### PR TITLE
fix(Microsoft OneDrive Node): Don't overwrite filename from node parameters when uploading binary file

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDrive.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDrive.node.ts
@@ -218,15 +218,18 @@ export class MicrosoftOneDrive implements INodeType {
 							const body = await this.helpers.getBinaryDataBuffer(i, binaryPropertyName);
 							let encodedFilename;
 
-							if (nodeVersion == 1 && binaryData.fileName !== undefined) {
-								// pre-fix behavior, filename provided in node parameters is always ignored
-								encodedFilename = encodeURIComponent(binaryData.fileName);
+							if (nodeVersion >= 1.1) {
+								if (fileName !== '') {
+									encodedFilename = encodeURIComponent(fileName);
+								} else if (binaryData.fileName !== undefined) {
+									encodedFilename = encodeURIComponent(binaryData.fileName);
+								}
 							} else {
 								if (fileName !== '') {
 									encodedFilename = encodeURIComponent(fileName);
 								}
 
-								if (fileName == '' && binaryData.fileName !== undefined) {
+								if (binaryData.fileName !== undefined) {
 									encodedFilename = encodeURIComponent(binaryData.fileName);
 								}
 							}

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDrive.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDrive.node.ts
@@ -19,7 +19,7 @@ export class MicrosoftOneDrive implements INodeType {
 		name: 'microsoftOneDrive',
 		icon: 'file:oneDrive.svg',
 		group: ['input'],
-		version: 1,
+		version: [1, 1.1],
 		subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
 		description: 'Consume Microsoft OneDrive API',
 		defaults: {
@@ -63,6 +63,7 @@ export class MicrosoftOneDrive implements INodeType {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
 		const length = items.length;
+		const nodeVersion = this.getNode().typeVersion;
 		let responseData;
 		const resource = this.getNodeParameter('resource', 0);
 		const operation = this.getNodeParameter('operation', 0);
@@ -217,12 +218,17 @@ export class MicrosoftOneDrive implements INodeType {
 							const body = await this.helpers.getBinaryDataBuffer(i, binaryPropertyName);
 							let encodedFilename;
 
-							if (fileName !== '') {
-								encodedFilename = encodeURIComponent(fileName);
-							}
-
-							if (fileName == '' && binaryData.fileName !== undefined) {
+							if (nodeVersion == 1 && binaryData.fileName !== undefined) {
+								// pre-fix behavior, filename provided in node parameters is always ignored
 								encodedFilename = encodeURIComponent(binaryData.fileName);
+							} else {
+								if (fileName !== '') {
+									encodedFilename = encodeURIComponent(fileName);
+								}
+
+								if (fileName == '' && binaryData.fileName !== undefined) {
+									encodedFilename = encodeURIComponent(binaryData.fileName);
+								}
 							}
 
 							responseData = await microsoftApiRequest.call(

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDrive.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDrive.node.ts
@@ -221,7 +221,7 @@ export class MicrosoftOneDrive implements INodeType {
 								encodedFilename = encodeURIComponent(fileName);
 							}
 
-							if (binaryData.fileName !== undefined) {
+							if (fileName == '' && binaryData.fileName !== undefined) {
 								encodedFilename = encodeURIComponent(binaryData.fileName);
 							}
 

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/test/node/file.download.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/test/node/file.download.test.ts
@@ -30,6 +30,15 @@ describe('Test MicrosoftOneDrive, file > download', () => {
 	const httpRequest = jest.fn(async () => ({ body: mock<IncomingMessage>() }));
 	const prepareBinaryData = jest.fn(async () => ({ data: 'testBinary' }));
 
+	const mockNode = {
+		id: 'test-node-id',
+		name: 'Microsoft OneDrive Test',
+		type: 'n8n-nodes-base.microsoftOneDrive',
+		typeVersion: 1.1,
+		position: [0, 0] as [number, number],
+		parameters: {},
+	};
+
 	beforeEach(() => {
 		mockExecuteFunctions = mock<IExecuteFunctions>();
 		microsoftOneDrive = new MicrosoftOneDrive();
@@ -40,6 +49,8 @@ describe('Test MicrosoftOneDrive, file > download', () => {
 			returnJsonArray: jest.fn((data) => [data]),
 			constructExecutionMetaData: jest.fn((data) => data),
 		} as any;
+
+		mockExecuteFunctions.getNode.mockReturnValue(mockNode);
 	});
 
 	afterEach(() => {

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/test/node/file.upload.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/test/node/file.upload.test.ts
@@ -20,6 +20,15 @@ describe('Test MicrosoftOneDrive, file > upload', () => {
 	let microsoftOneDrive: MicrosoftOneDrive;
 	const getBinaryDataBuffer = jest.fn(async () => Buffer.from('test content'));
 
+	const mockNode = {
+		id: 'test-node-id',
+		name: 'Microsoft OneDrive Test',
+		type: 'n8n-nodes-base.microsoftOneDrive',
+		typeVersion: 1.1,
+		position: [0, 0] as [number, number],
+		parameters: {},
+	};
+
 	beforeEach(() => {
 		mockExecuteFunctions = mock<IExecuteFunctions>();
 		microsoftOneDrive = new MicrosoftOneDrive();
@@ -36,13 +45,15 @@ describe('Test MicrosoftOneDrive, file > upload', () => {
 			returnJsonArray: jest.fn((data) => [data]),
 			constructExecutionMetaData: jest.fn((data) => data),
 		} as any;
+
+		mockExecuteFunctions.getNode.mockReturnValue(mockNode);
 	});
 
 	afterEach(() => {
 		jest.clearAllMocks();
 	});
 
-	it('should use filename from node parameters even when binary has a filename', async () => {
+	it('should use filename from node parameters even when binary has a filename (version 1.1+)', async () => {
 		const items = [{ json: { data: 'test' }, binary: { data: {} as IBinaryData } }];
 		mockExecuteFunctions.getInputData.mockReturnValue(items);
 		mockExecuteFunctions.getNodeParameter.mockImplementation((key: string) => {
@@ -63,7 +74,7 @@ describe('Test MicrosoftOneDrive, file > upload', () => {
 			expect.any(Buffer),
 			{},
 			undefined,
-			{ 'Content-Type': 'text/plain', 'Content-Length': expect.any(Number) },
+			{ 'Content-Type': 'text/plain', 'Content-length': expect.any(Number) },
 			{},
 		);
 	});
@@ -94,7 +105,7 @@ describe('Test MicrosoftOneDrive, file > upload', () => {
 		);
 	});
 
-	it('should properly encode special characters in filename from node parameters', async () => {
+	it('should properly encode special characters in filename from node parameters (version 1.1+)', async () => {
 		const items = [{ json: { data: 'test' }, binary: { data: {} as IBinaryData } }];
 		mockExecuteFunctions.getInputData.mockReturnValue(items);
 		mockExecuteFunctions.getNodeParameter.mockImplementation((key: string) => {
@@ -112,6 +123,38 @@ describe('Test MicrosoftOneDrive, file > upload', () => {
 		expect(genericFunctions.microsoftApiRequest).toHaveBeenCalledWith(
 			'PUT',
 			'/drive/items/parentFolderId:/file%20with%20spaces%20%26%20special.txt:/content',
+			expect.any(Buffer),
+			{},
+			undefined,
+			{ 'Content-Type': 'text/plain', 'Content-length': expect.any(Number) },
+			{},
+		);
+	});
+
+	it('should always use binary filename even when node parameter has a filename (version 1 - legacy bug)', async () => {
+		mockExecuteFunctions.getNode.mockReturnValue({
+			...mockNode,
+			typeVersion: 1,
+		});
+
+		const items = [{ json: { data: 'test' }, binary: { data: {} as IBinaryData } }];
+		mockExecuteFunctions.getInputData.mockReturnValue(items);
+		mockExecuteFunctions.getNodeParameter.mockImplementation((key: string) => {
+			if (key === 'resource') return 'file';
+			if (key === 'operation') return 'upload';
+			if (key === 'parentId') return 'parentFolderId';
+			if (key === 'fileName') return 'customFileName.txt';
+			if (key === 'binaryData') return true;
+			if (key === 'binaryPropertyName') return 'data';
+		});
+
+		await microsoftOneDrive.execute.call(mockExecuteFunctions);
+
+		expect(genericFunctions.microsoftApiRequest).toHaveBeenCalledTimes(1);
+		// In version 1, binary filename always overwrites the parameter filename
+		expect(genericFunctions.microsoftApiRequest).toHaveBeenCalledWith(
+			'PUT',
+			'/drive/items/parentFolderId:/binaryFileName.txt:/content',
 			expect.any(Buffer),
 			{},
 			undefined,

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/test/node/file.upload.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/test/node/file.upload.test.ts
@@ -1,6 +1,6 @@
 import type { MockProxy } from 'jest-mock-extended';
 import { mock } from 'jest-mock-extended';
-import type { IHttpRequestMethods, IExecuteFunctions, IBinaryData } from 'n8n-workflow';
+import type { IExecuteFunctions, IBinaryData } from 'n8n-workflow';
 
 import * as genericFunctions from '../../GenericFunctions';
 import { MicrosoftOneDrive } from '../../MicrosoftOneDrive.node';

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/test/node/file.upload.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/test/node/file.upload.test.ts
@@ -1,0 +1,122 @@
+import type { MockProxy } from 'jest-mock-extended';
+import { mock } from 'jest-mock-extended';
+import type { IHttpRequestMethods, IExecuteFunctions, IBinaryData } from 'n8n-workflow';
+
+import * as genericFunctions from '../../GenericFunctions';
+import { MicrosoftOneDrive } from '../../MicrosoftOneDrive.node';
+
+jest.mock('../../GenericFunctions', () => ({
+	...jest.requireActual('../../GenericFunctions'),
+	microsoftApiRequest: jest.fn(async function () {
+		return JSON.stringify({
+			id: 'uploadedFileId',
+			name: 'uploadedFile.txt',
+		});
+	}),
+}));
+
+describe('Test MicrosoftOneDrive, file > upload', () => {
+	let mockExecuteFunctions: MockProxy<IExecuteFunctions>;
+	let microsoftOneDrive: MicrosoftOneDrive;
+	const getBinaryDataBuffer = jest.fn(async () => Buffer.from('test content'));
+
+	beforeEach(() => {
+		mockExecuteFunctions = mock<IExecuteFunctions>();
+		microsoftOneDrive = new MicrosoftOneDrive();
+
+		mockExecuteFunctions.helpers = {
+			assertBinaryData: jest.fn((itemIndex: number, propertyName: string) => {
+				return {
+					data: 'base64data',
+					mimeType: 'text/plain',
+					fileName: 'binaryFileName.txt',
+				} as IBinaryData;
+			}),
+			getBinaryDataBuffer,
+			returnJsonArray: jest.fn((data) => [data]),
+			constructExecutionMetaData: jest.fn((data) => data),
+		} as any;
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should use filename from node parameters even when binary has a filename', async () => {
+		const items = [{ json: { data: 'test' }, binary: { data: {} as IBinaryData } }];
+		mockExecuteFunctions.getInputData.mockReturnValue(items);
+		mockExecuteFunctions.getNodeParameter.mockImplementation((key: string, index: number) => {
+			if (key === 'resource') return 'file';
+			if (key === 'operation') return 'upload';
+			if (key === 'parentId') return 'parentFolderId';
+			if (key === 'fileName') return 'customFileName.txt';
+			if (key === 'binaryData') return true;
+			if (key === 'binaryPropertyName') return 'data';
+		});
+
+		await microsoftOneDrive.execute.call(mockExecuteFunctions);
+
+		expect(genericFunctions.microsoftApiRequest).toHaveBeenCalledTimes(1);
+		expect(genericFunctions.microsoftApiRequest).toHaveBeenCalledWith(
+			'PUT',
+			'/drive/items/parentFolderId:/customFileName.txt:/content',
+			expect.any(Buffer),
+			{},
+			undefined,
+			{ 'Content-Type': 'text/plain', 'Content-length': expect.any(Number) },
+			{},
+		);
+	});
+
+	it('should use binary filename when node parameter filename is empty', async () => {
+		const items = [{ json: { data: 'test' }, binary: { data: {} as IBinaryData } }];
+		mockExecuteFunctions.getInputData.mockReturnValue(items);
+		mockExecuteFunctions.getNodeParameter.mockImplementation((key: string, index: number) => {
+			if (key === 'resource') return 'file';
+			if (key === 'operation') return 'upload';
+			if (key === 'parentId') return 'parentFolderId';
+			if (key === 'fileName') return '';
+			if (key === 'binaryData') return true;
+			if (key === 'binaryPropertyName') return 'data';
+		});
+
+		await microsoftOneDrive.execute.call(mockExecuteFunctions);
+
+		expect(genericFunctions.microsoftApiRequest).toHaveBeenCalledTimes(1);
+		expect(genericFunctions.microsoftApiRequest).toHaveBeenCalledWith(
+			'PUT',
+			'/drive/items/parentFolderId:/binaryFileName.txt:/content',
+			expect.any(Buffer),
+			{},
+			undefined,
+			{ 'Content-Type': 'text/plain', 'Content-length': expect.any(Number) },
+			{},
+		);
+	});
+
+	it('should properly encode special characters in filename from node parameters', async () => {
+		const items = [{ json: { data: 'test' }, binary: { data: {} as IBinaryData } }];
+		mockExecuteFunctions.getInputData.mockReturnValue(items);
+		mockExecuteFunctions.getNodeParameter.mockImplementation((key: string, index: number) => {
+			if (key === 'resource') return 'file';
+			if (key === 'operation') return 'upload';
+			if (key === 'parentId') return 'parentFolderId';
+			if (key === 'fileName') return 'file with spaces & special.txt';
+			if (key === 'binaryData') return true;
+			if (key === 'binaryPropertyName') return 'data';
+		});
+
+		await microsoftOneDrive.execute.call(mockExecuteFunctions);
+
+		expect(genericFunctions.microsoftApiRequest).toHaveBeenCalledTimes(1);
+		expect(genericFunctions.microsoftApiRequest).toHaveBeenCalledWith(
+			'PUT',
+			'/drive/items/parentFolderId:/file%20with%20spaces%20%26%20special.txt:/content',
+			expect.any(Buffer),
+			{},
+			undefined,
+			{ 'Content-Type': 'text/plain', 'Content-length': expect.any(Number) },
+			{},
+		);
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/test/node/file.upload.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/test/node/file.upload.test.ts
@@ -25,7 +25,7 @@ describe('Test MicrosoftOneDrive, file > upload', () => {
 		microsoftOneDrive = new MicrosoftOneDrive();
 
 		mockExecuteFunctions.helpers = {
-			assertBinaryData: jest.fn((itemIndex: number, propertyName: string) => {
+			assertBinaryData: jest.fn(() => {
 				return {
 					data: 'base64data',
 					mimeType: 'text/plain',
@@ -45,7 +45,7 @@ describe('Test MicrosoftOneDrive, file > upload', () => {
 	it('should use filename from node parameters even when binary has a filename', async () => {
 		const items = [{ json: { data: 'test' }, binary: { data: {} as IBinaryData } }];
 		mockExecuteFunctions.getInputData.mockReturnValue(items);
-		mockExecuteFunctions.getNodeParameter.mockImplementation((key: string, index: number) => {
+		mockExecuteFunctions.getNodeParameter.mockImplementation((key: string) => {
 			if (key === 'resource') return 'file';
 			if (key === 'operation') return 'upload';
 			if (key === 'parentId') return 'parentFolderId';
@@ -63,7 +63,7 @@ describe('Test MicrosoftOneDrive, file > upload', () => {
 			expect.any(Buffer),
 			{},
 			undefined,
-			{ 'Content-Type': 'text/plain', 'Content-length': expect.any(Number) },
+			{ 'Content-Type': 'text/plain', 'Content-Length': expect.any(Number) },
 			{},
 		);
 	});
@@ -71,7 +71,7 @@ describe('Test MicrosoftOneDrive, file > upload', () => {
 	it('should use binary filename when node parameter filename is empty', async () => {
 		const items = [{ json: { data: 'test' }, binary: { data: {} as IBinaryData } }];
 		mockExecuteFunctions.getInputData.mockReturnValue(items);
-		mockExecuteFunctions.getNodeParameter.mockImplementation((key: string, index: number) => {
+		mockExecuteFunctions.getNodeParameter.mockImplementation((key: string) => {
 			if (key === 'resource') return 'file';
 			if (key === 'operation') return 'upload';
 			if (key === 'parentId') return 'parentFolderId';
@@ -97,7 +97,7 @@ describe('Test MicrosoftOneDrive, file > upload', () => {
 	it('should properly encode special characters in filename from node parameters', async () => {
 		const items = [{ json: { data: 'test' }, binary: { data: {} as IBinaryData } }];
 		mockExecuteFunctions.getInputData.mockReturnValue(items);
-		mockExecuteFunctions.getNodeParameter.mockImplementation((key: string, index: number) => {
+		mockExecuteFunctions.getNodeParameter.mockImplementation((key: string) => {
 			if (key === 'resource') return 'file';
 			if (key === 'operation') return 'upload';
 			if (key === 'parentId') return 'parentFolderId';

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/test/node/file.upload.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/test/node/file.upload.test.ts
@@ -105,7 +105,7 @@ describe('Test MicrosoftOneDrive, file > upload', () => {
 		);
 	});
 
-	it('should properly encode special characters in filename from node parameters (version 1.1+)', async () => {
+	it('should properly encode special characters in filename from node parameters', async () => {
 		const items = [{ json: { data: 'test' }, binary: { data: {} as IBinaryData } }];
 		mockExecuteFunctions.getInputData.mockReturnValue(items);
 		mockExecuteFunctions.getNodeParameter.mockImplementation((key: string) => {


### PR DESCRIPTION
The node always used the binary.fileName even when there was a file name provided in the node parameters. 
This adds v1.1 of the node and fixes the IF statements flow, so the file name from the node parameters is prioritised.

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/GHC-5780/community-issue-microsoft-onedrive-fileupload-ignore-settings-filename
fixes #22758


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
