### PR TITLE
fix(core): Don't resume parent workflow when the child workflow goes into waiting

### DIFF
--- a/packages/cli/src/wait-tracker.ts
+++ b/packages/cli/src/wait-tracker.ts
@@ -151,13 +151,17 @@ export class WaitTracker {
 				.getPostExecutePromise(executionId)
 				.then(async (subworkflowResults) => {
 					if (!subworkflowResults) return;
+					if (subworkflowResults.status === 'waiting') return; // The child execution is waiting, not completing.
 					await updateParentExecutionWithChildResults(
 						this.executionRepository,
 						parentExecution.executionId,
 						subworkflowResults,
 					);
+					return subworkflowResults;
 				})
-				.then(() => {
+				.then((subworkflowResults) => {
+					if (!subworkflowResults) return;
+					if (subworkflowResults.status === 'waiting') return; // The child execution is waiting, not completing.
 					void this.startExecution(parentExecution.executionId);
 				});
 		}

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -649,13 +649,17 @@ export async function executeWebhook(
 			void executePromise
 				.then(async (subworkflowResults) => {
 					if (!subworkflowResults) return;
+					if (subworkflowResults.status === 'waiting') return; // The child execution is waiting, not completing.
 					await WorkflowHelpers.updateParentExecutionWithChildResults(
 						executionRepository,
 						parentExecution.executionId,
 						subworkflowResults,
 					);
+					return subworkflowResults;
 				})
-				.then(() => {
+				.then((subworkflowResults) => {
+					if (!subworkflowResults) return;
+					if (subworkflowResults.status === 'waiting') return; // The child execution is waiting, not completing.
 					const waitTracker = Container.get(WaitTracker);
 					void waitTracker.startExecution(parentExecution.executionId);
 				});

--- a/packages/testing/playwright/services/workflow-api-helper.ts
+++ b/packages/testing/playwright/services/workflow-api-helper.ts
@@ -252,4 +252,35 @@ export class WorkflowApiHelper {
 
 		throw new TestError(`Execution did not complete within ${timeoutMs}ms`);
 	}
+
+	/**
+	 * Wait for a workflow execution to reach a specific status
+	 * @param workflowId - The workflow ID to check
+	 * @param expectedStatus - The expected status (e.g., 'waiting', 'success', 'error')
+	 * @param timeoutMs - Maximum time to wait in milliseconds
+	 * @returns The execution once it reaches the expected status
+	 * @throws TestError if execution doesn't reach the expected status within timeout
+	 */
+	async waitForWorkflowStatus(
+		workflowId: string,
+		expectedStatus: string,
+		timeoutMs = 5000,
+	): Promise<ExecutionListResponse> {
+		const startTime = Date.now();
+
+		while (Date.now() - startTime < timeoutMs) {
+			const executions = await this.getExecutions(workflowId);
+			const execution = executions.find((e) => e.workflowId === workflowId);
+
+			if (execution && execution.status === expectedStatus) {
+				return execution;
+			}
+
+			await new Promise((resolve) => setTimeout(resolve, 200));
+		}
+
+		throw new TestError(
+			`Workflow ${workflowId} did not reach status '${expectedStatus}' within ${timeoutMs}ms`,
+		);
+	}
 }

--- a/packages/testing/playwright/tests/e2e/workflows/editor/subworkflows/wait.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/subworkflows/wait.spec.ts
@@ -138,3 +138,80 @@ test.describe('CAT-1801: Parent receives correct data from child with wait node'
 		expect(executeWorkflowOutput[0].data.main[0][0].json.type).toBe('child - after');
 	});
 });
+
+test.describe('CAT-1929: Parent should not resume until child with multiple waits completes', () => {
+	test('should keep parent waiting after first wait node is resumed, only completing after second wait', async ({
+		api,
+	}) => {
+		// Import child workflow with two Wait nodes (auto-activated via "active": true in JSON)
+		const { workflowId: childWorkflowId } = await api.workflows.importWorkflowFromFile(
+			'cat-1929-child-two-waits.json',
+		);
+
+		// Import parent workflow and link to child
+		const parentFilePath = resolveFromRoot('workflows', 'cat-1929-parent.json');
+		const parentContent = readFileSync(parentFilePath, 'utf8');
+		const parentDefinition = JSON.parse(parentContent) as IWorkflowBase;
+
+		// Update Execute Workflow node to reference the child
+		const executeWorkflowNode = parentDefinition.nodes.find(
+			(n) => n.type === 'n8n-nodes-base.executeWorkflow',
+		)!;
+		executeWorkflowNode.parameters.workflowId = { value: childWorkflowId, mode: 'list' };
+
+		const {
+			webhookPath,
+			workflowId: parentWorkflowId,
+			createdWorkflow: { versionId },
+		} = await api.workflows.importWorkflowFromDefinition(parentDefinition);
+
+		// Activate parent workflow so webhook works
+		await api.workflows.activate(parentWorkflowId, versionId!);
+
+		// Trigger parent workflow via webhook
+		const webhookResponse = await api.request.get(`/webhook/${webhookPath}`);
+		expect(webhookResponse.ok()).toBe(true);
+
+		// Wait for child execution to appear and enter waiting state (first wait node)
+		const childExecution = await api.workflows.waitForWorkflowStatus(childWorkflowId, 'waiting');
+
+		// Verify parent is also waiting at this point
+		await api.workflows.waitForWorkflowStatus(parentWorkflowId, 'waiting');
+
+		// Resume first wait node
+		const firstWaitResponse = await api.request.get(`/webhook-waiting/${childExecution.id}`);
+		expect(firstWaitResponse.ok()).toBe(true);
+
+		// Wait for child to reach the second wait node
+		await api.workflows.waitForWorkflowStatus(childWorkflowId, 'waiting');
+
+		// Verify parent is STILL waiting (not resumed after first wait completed)
+		const parentExecAfterFirstWait = await api.workflows.waitForWorkflowStatus(
+			parentWorkflowId,
+			'waiting',
+		);
+		expect(parentExecAfterFirstWait.status).toBe('waiting');
+
+		// Resume second wait node
+		const secondWaitResponse = await api.request.get(`/webhook-waiting/${childExecution.id}`);
+		expect(secondWaitResponse.ok()).toBe(true);
+
+		// Now parent should complete
+		const parentExecution = await api.workflows.waitForExecution(parentWorkflowId, 15000);
+		expect(parentExecution.status).toBe('success');
+
+		// Verify child also completed
+		const finalChildExecution = await api.workflows.getExecution(childExecution.id);
+		expect(finalChildExecution.status).toBe('success');
+
+		// Verify Execute Workflow node received child's FINAL output (after both waits)
+		await retryUntil(async () => {
+			// Get full parent execution data and verify it received the final child output
+			const fullParentExecution = await api.workflows.getExecution(parentExecution.id);
+			const executionData = flatted.parse(fullParentExecution.data);
+			const executeWorkflowOutput = executionData.resultData.runData['Execute Workflow'];
+			expect(executeWorkflowOutput).toBeDefined();
+			expect(executeWorkflowOutput[0].data.main[0][0].json.stage).toBe('completed');
+		});
+	});
+});

--- a/packages/testing/playwright/workflows/cat-1929-child-two-waits.json
+++ b/packages/testing/playwright/workflows/cat-1929-child-two-waits.json
@@ -1,0 +1,172 @@
+{
+	"nodes": [
+		{
+			"parameters": {
+				"inputSource": "passthrough"
+			},
+			"id": "c055762a-8fe7-4141-a639-df2372f30060",
+			"typeVersion": 1.1,
+			"name": "When Executed by Another Workflow",
+			"type": "n8n-nodes-base.executeWorkflowTrigger",
+			"position": [272, 352]
+		},
+		{
+			"parameters": {
+				"assignments": {
+					"assignments": [
+						{
+							"id": "10f14daa-106e-45ba-8f57-13b5f998da5e",
+							"name": "stage",
+							"value": "before-first-wait",
+							"type": "string"
+						},
+						{
+							"id": "83f6250b-e16f-49bd-8d8c-b2074b6a2e9f",
+							"name": "webhook1",
+							"value": "={{ $execution.resumeUrl }}",
+							"type": "string"
+						}
+					]
+				},
+				"options": {}
+			},
+			"type": "n8n-nodes-base.set",
+			"typeVersion": 3.4,
+			"position": [480, 352],
+			"id": "f5ba9e8a-6510-42c2-a264-972cbb4cc912",
+			"name": "Edit Fields - Before First Wait"
+		},
+		{
+			"parameters": {
+				"resume": "webhook",
+				"options": {}
+			},
+			"type": "n8n-nodes-base.wait",
+			"typeVersion": 1.1,
+			"position": [704, 352],
+			"id": "949ed603-c2fc-4ea9-a663-675959c44d44",
+			"name": "Wait 1",
+			"webhookId": "a47006a8-c373-4fe9-b145-0a6a2c1f59bb"
+		},
+		{
+			"parameters": {
+				"assignments": {
+					"assignments": [
+						{
+							"id": "ab8fb2ae-1a82-4a42-ae29-12e7165ad035",
+							"name": "stage",
+							"value": "after-first-wait",
+							"type": "string"
+						},
+						{
+							"id": "b2fcc9a7-100a-4e96-bd4d-da4f3ea2c6c1",
+							"name": "webhook2",
+							"value": "={{ $execution.resumeUrl }}",
+							"type": "string"
+						}
+					]
+				},
+				"options": {}
+			},
+			"type": "n8n-nodes-base.set",
+			"typeVersion": 3.4,
+			"position": [928, 352],
+			"id": "e48dd6df-03d7-4c91-923c-e2f51b828de4",
+			"name": "Edit Fields - After First Wait"
+		},
+		{
+			"parameters": {
+				"resume": "webhook",
+				"options": {}
+			},
+			"type": "n8n-nodes-base.wait",
+			"typeVersion": 1.1,
+			"position": [1152, 352],
+			"id": "2a3b4c5d-6e7f-8g9h-0i1j-2k3l4m5n6o7p",
+			"name": "Wait 2",
+			"webhookId": "b58117b9-d484-5gf0-c256-1b7b3d2g60cc"
+		},
+		{
+			"parameters": {
+				"assignments": {
+					"assignments": [
+						{
+							"id": "cd9fc3bf-2b11-5c07-bf4e-23f8276be146",
+							"name": "stage",
+							"value": "completed",
+							"type": "string"
+						}
+					]
+				},
+				"options": {}
+			},
+			"type": "n8n-nodes-base.set",
+			"typeVersion": 3.4,
+			"position": [1376, 352],
+			"id": "g59ee7eg-14e8-5d02-a34d-e3f62fb3e3e5",
+			"name": "Edit Fields - Final"
+		}
+	],
+	"connections": {
+		"When Executed by Another Workflow": {
+			"main": [
+				[
+					{
+						"node": "Edit Fields - Before First Wait",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Edit Fields - Before First Wait": {
+			"main": [
+				[
+					{
+						"node": "Wait 1",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Wait 1": {
+			"main": [
+				[
+					{
+						"node": "Edit Fields - After First Wait",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Edit Fields - After First Wait": {
+			"main": [
+				[
+					{
+						"node": "Wait 2",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Wait 2": {
+			"main": [
+				[
+					{
+						"node": "Edit Fields - Final",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"pinData": {},
+	"active": true,
+	"meta": {
+		"instanceId": "f21dcb5296ee365372dae8f32f5830ed6733682e3fba20fd801863fa536d3a9c"
+	}
+}

--- a/packages/testing/playwright/workflows/cat-1929-parent.json
+++ b/packages/testing/playwright/workflows/cat-1929-parent.json
@@ -1,0 +1,59 @@
+{
+	"nodes": [
+		{
+			"parameters": {
+				"workflowId": {
+					"__rl": true,
+					"value": "placeholder",
+					"mode": "list"
+				},
+				"workflowInputs": {
+					"mappingMode": "defineBelow",
+					"value": {},
+					"matchingColumns": [],
+					"schema": [],
+					"attemptToConvertTypes": false,
+					"convertFieldsToString": true
+				},
+				"options": {
+					"waitForSubWorkflow": true
+				}
+			},
+			"type": "n8n-nodes-base.executeWorkflow",
+			"typeVersion": 1.3,
+			"position": [208, -352],
+			"id": "5f323e83-f19c-4e00-a47a-5383f07ffad8",
+			"name": "Execute Workflow"
+		},
+		{
+			"parameters": {
+				"path": "9735a722-ea8f-42e7-afcd-6f4a40030325",
+				"responseMode": "lastNode",
+				"options": {}
+			},
+			"type": "n8n-nodes-base.webhook",
+			"typeVersion": 2.1,
+			"position": [-16, -352],
+			"id": "69d68817-741c-409a-bc8c-f9fff267b863",
+			"name": "Webhook",
+			"webhookId": "9735a722-ea8f-42e7-afcd-6f4a40030325"
+		}
+	],
+	"connections": {
+		"Webhook": {
+			"main": [
+				[
+					{
+						"node": "Execute Workflow",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"pinData": {},
+	"meta": {
+		"instanceId": "f21dcb5296ee365372dae8f32f5830ed6733682e3fba20fd801863fa536d3a9c"
+	}
+}


### PR DESCRIPTION
## Summary

A child workflow resolves its execution promise when it completes *or* goes into `waiting`. In the latter case, we shouldn't resume the parent.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1929/

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
