### PR TITLE
fix(core): Add missing env vars to internal mode

### DIFF
--- a/packages/cli/src/task-runners/task-runner-process-py.ts
+++ b/packages/cli/src/task-runners/task-runner-process-py.ts
@@ -49,6 +49,12 @@ export class PyTaskRunnerProcess extends TaskRunnerProcessBase {
 				N8N_RUNNERS_MAX_CONCURRENCY: this.runnerConfig.maxConcurrency.toString(),
 				N8N_RUNNERS_TASK_TIMEOUT: this.runnerConfig.taskTimeout.toString(),
 				N8N_RUNNERS_HEARTBEAT_INTERVAL: this.runnerConfig.heartbeatInterval.toString(),
+
+				// n8n
+				N8N_RUNNERS_STDLIB_ALLOW: process.env.N8N_RUNNERS_STDLIB_ALLOW,
+				N8N_RUNNERS_EXTERNAL_ALLOW: process.env.N8N_RUNNERS_EXTERNAL_ALLOW,
+				N8N_RUNNERS_BUILTINS_DENY: process.env.N8N_RUNNERS_BUILTINS_DENY,
+				N8N_BLOCK_RUNNER_ENV_ACCESS: process.env.N8N_BLOCK_RUNNER_ENV_ACCESS,
 			},
 		});
 	}


### PR DESCRIPTION
## Summary

Internal mode for Python is missing support for env vars relating to allow- and deny-lists.

## Related Linear tickets, Github issues, and Community forum posts

Fixes https://github.com/n8n-io/n8n/issues/22958
https://linear.app/n8n/issue/GHC-5831

## Testing

To test:

```
N8N_RUNNERS_ENABLED=true \
N8N_RUNNERS_MODE=internal \
N8N_RUNNERS_STDLIB_ALLOW=* \
N8N_LOG_LEVEL=debug \
N8N_NATIVE_PYTHON_RUNNER=true \
pnpm start
```

And run a Code node with this, which should succeed.

```
import re

text = "Contact us at hello@example.com"
emails = re.findall(r'\b[\w.-]+@[\w.-]+\.\w+\b', text)
print(emails)

return []
```


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
