### PR TITLE
chore(core): Implement oauth introspection resolver and bearer token extractor

### DIFF
--- a/packages/@n8n/decorators/src/credential-resolver/credential-resolver.ts
+++ b/packages/@n8n/decorators/src/credential-resolver/credential-resolver.ts
@@ -10,6 +10,12 @@ import type {
  */
 export type CredentialResolverConfiguration = Record<string, unknown>;
 
+export type CredentialResolverHandle = {
+	configuration: CredentialResolverConfiguration;
+	resolverName: string;
+	resolverId: string;
+};
+
 /**
  * Metadata describing a credential resolver type for UI integration and discovery.
  */
@@ -43,7 +49,7 @@ export interface ICredentialResolver {
 	getSecret(
 		credentialId: string,
 		context: ICredentialContext,
-		options: CredentialResolverConfiguration,
+		handle: CredentialResolverHandle,
 	): Promise<ICredentialDataDecryptedObject>;
 
 	/**
@@ -54,7 +60,7 @@ export interface ICredentialResolver {
 		credentialId: string,
 		context: ICredentialContext,
 		data: ICredentialDataDecryptedObject,
-		options: CredentialResolverConfiguration,
+		handle: CredentialResolverHandle,
 	): Promise<void>;
 
 	/**
@@ -65,7 +71,7 @@ export interface ICredentialResolver {
 	deleteSecret?(
 		credentialId: string,
 		context: ICredentialContext,
-		options: CredentialResolverConfiguration,
+		handle: CredentialResolverHandle,
 	): Promise<void>;
 
 	/**

--- a/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/__tests__/bearer-token-extractor.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/__tests__/bearer-token-extractor.test.ts
@@ -1,0 +1,188 @@
+import type { ContextEstablishmentOptions, ContextEstablishmentResult } from '@n8n/decorators';
+
+import { BearerTokenExtractor } from '../bearer-token-extractor';
+import type { HttpHeaderExtractor } from '../http-header-extractor';
+
+describe('BearerTokenExtractor', () => {
+	let bearerTokenExtractor: BearerTokenExtractor;
+	let mockHttpHeaderExtractor: jest.Mocked<HttpHeaderExtractor>;
+
+	beforeEach(() => {
+		mockHttpHeaderExtractor = {
+			isApplicableToTriggerNode: jest.fn(),
+			execute: jest.fn(),
+		} as unknown as jest.Mocked<HttpHeaderExtractor>;
+
+		bearerTokenExtractor = new BearerTokenExtractor(mockHttpHeaderExtractor);
+	});
+
+	describe('hookDescription', () => {
+		it('should have correct metadata', () => {
+			expect(bearerTokenExtractor.hookDescription).toEqual({
+				name: 'BearerTokenExtractor',
+				displayName: 'Bearer Token Extractor',
+				options: [],
+			});
+		});
+	});
+
+	describe('isApplicableToTriggerNode', () => {
+		it('should delegate to HttpHeaderExtractor', () => {
+			mockHttpHeaderExtractor.isApplicableToTriggerNode.mockReturnValue(true);
+
+			const result = bearerTokenExtractor.isApplicableToTriggerNode('n8n-nodes-base.webhook');
+
+			expect(mockHttpHeaderExtractor.isApplicableToTriggerNode).toHaveBeenCalledWith(
+				'n8n-nodes-base.webhook',
+			);
+			expect(result).toBe(true);
+		});
+
+		it('should return false for non-webhook nodes', () => {
+			mockHttpHeaderExtractor.isApplicableToTriggerNode.mockReturnValue(false);
+
+			const result = bearerTokenExtractor.isApplicableToTriggerNode('n8n-nodes-base.httpRequest');
+
+			expect(result).toBe(false);
+		});
+	});
+
+	describe('execute', () => {
+		it('should extract bearer token from Authorization header', async () => {
+			const options: ContextEstablishmentOptions = {
+				triggerItems: [
+					{
+						json: {
+							headers: {
+								authorization: 'Bearer test-token-123',
+							},
+						},
+					},
+				],
+			};
+
+			const expectedResult: ContextEstablishmentResult = {
+				triggerItems: options.triggerItems,
+				contextUpdate: {
+					credentials: {
+						version: 1,
+						identity: 'test-token-123',
+						metadata: { source: 'http-header', headerName: 'authorization' },
+					},
+				},
+			};
+
+			mockHttpHeaderExtractor.execute.mockResolvedValue(expectedResult);
+
+			const result = await bearerTokenExtractor.execute(options);
+
+			expect(mockHttpHeaderExtractor.execute).toHaveBeenCalledWith({
+				...options,
+				options: {
+					headerName: 'authorization',
+					headerValue: '[Bb][Ee][Aa][Rr][Ee][Rr]\\s+(.+)',
+				},
+			});
+			expect(result).toEqual(expectedResult);
+		});
+
+		it('should pass through all options to HttpHeaderExtractor', async () => {
+			const options: ContextEstablishmentOptions = {
+				triggerItems: [
+					{
+						json: {
+							headers: {
+								authorization: 'Bearer token',
+							},
+						},
+					},
+				],
+				customField: 'custom-value',
+			};
+
+			mockHttpHeaderExtractor.execute.mockResolvedValue({});
+
+			await bearerTokenExtractor.execute(options);
+
+			expect(mockHttpHeaderExtractor.execute).toHaveBeenCalledWith({
+				triggerItems: options.triggerItems,
+				customField: 'custom-value',
+				options: {
+					headerName: 'authorization',
+					headerValue: '[Bb][Ee][Aa][Rr][Ee][Rr]\\s+(.+)',
+				},
+			});
+		});
+
+		it('should handle case-insensitive bearer prefix', async () => {
+			const testCases = [
+				'Bearer token123',
+				'bearer token456',
+				'BEARER token789',
+				'BeArEr tokenABC',
+			];
+
+			for (const authHeader of testCases) {
+				const options: ContextEstablishmentOptions = {
+					triggerItems: [{ json: { headers: { authorization: authHeader } } }],
+				};
+
+				mockHttpHeaderExtractor.execute.mockResolvedValue({
+					contextUpdate: {
+						credentials: {
+							version: 1,
+							identity: authHeader.split(' ')[1],
+							metadata: { source: 'http-header', headerName: 'authorization' },
+						},
+					},
+				});
+
+				await bearerTokenExtractor.execute(options);
+
+				expect(mockHttpHeaderExtractor.execute).toHaveBeenCalledWith({
+					...options,
+					options: {
+						headerName: 'authorization',
+						headerValue: '[Bb][Ee][Aa][Rr][Ee][Rr]\\s+(.+)',
+					},
+				});
+			}
+		});
+
+		it('should return empty result when no Authorization header present', async () => {
+			const options: ContextEstablishmentOptions = {
+				triggerItems: [{ json: { headers: {} } }],
+			};
+
+			mockHttpHeaderExtractor.execute.mockResolvedValue({
+				triggerItems: options.triggerItems,
+			});
+
+			const result = await bearerTokenExtractor.execute(options);
+
+			expect(result).toEqual({ triggerItems: options.triggerItems });
+		});
+
+		it('should return empty result for malformed bearer token', async () => {
+			const options: ContextEstablishmentOptions = {
+				triggerItems: [
+					{
+						json: {
+							headers: {
+								authorization: 'NotBearer token123',
+							},
+						},
+					},
+				],
+			};
+
+			mockHttpHeaderExtractor.execute.mockResolvedValue({
+				triggerItems: options.triggerItems,
+			});
+
+			const result = await bearerTokenExtractor.execute(options);
+
+			expect(result).toEqual({ triggerItems: options.triggerItems });
+		});
+	});
+});

--- a/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/__tests__/http-header-extractor.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/__tests__/http-header-extractor.test.ts
@@ -1,27 +1,11 @@
 import type { Logger } from '@n8n/backend-common';
-import type { ContextEstablishmentOptions } from '@n8n/decorators';
-import type { INodeExecutionData } from 'n8n-workflow';
 
 import { HttpHeaderExtractor } from '../http-header-extractor';
+import { createOptions, createTriggerItem } from './utils';
 
 describe('HttpHeaderExtractor', () => {
 	let extractor: HttpHeaderExtractor;
 	let mockLogger: jest.Mocked<Logger>;
-
-	// Factory functions for test data
-	const createTriggerItem = (headers?: Record<string, unknown>): INodeExecutionData => ({
-		json: { headers },
-		pairedItem: { item: 0 },
-	});
-
-	const createOptions = (
-		overrides?: Partial<ContextEstablishmentOptions>,
-	): ContextEstablishmentOptions =>
-		({
-			triggerItems: [createTriggerItem({ authorization: 'Bearer test-token-123' })],
-			options: {},
-			...overrides,
-		}) as ContextEstablishmentOptions;
 
 	beforeAll(() => {
 		mockLogger = {

--- a/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/__tests__/utils.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/__tests__/utils.ts
@@ -1,0 +1,17 @@
+import type { ContextEstablishmentOptions } from '@n8n/decorators';
+import type { INodeExecutionData } from 'n8n-workflow';
+
+// Factory functions for test data
+export const createTriggerItem = (headers?: Record<string, unknown>): INodeExecutionData => ({
+	json: { headers },
+	pairedItem: { item: 0 },
+});
+
+export const createOptions = (
+	overrides?: Partial<ContextEstablishmentOptions>,
+): ContextEstablishmentOptions =>
+	({
+		triggerItems: [createTriggerItem({ authorization: 'Bearer test-token-123' })],
+		options: {},
+		...overrides,
+	}) as ContextEstablishmentOptions;

--- a/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/bearer-token-extractor.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/bearer-token-extractor.ts
@@ -1,0 +1,50 @@
+import {
+	ContextEstablishmentHook,
+	ContextEstablishmentOptions,
+	ContextEstablishmentResult,
+	HookDescription,
+	IContextEstablishmentHook,
+} from '@n8n/decorators';
+
+import { HttpHeaderExtractor } from './http-header-extractor';
+
+/**
+ * Extracts bearer tokens from the Authorization HTTP header.
+ *
+ * Automatically extracts tokens from headers in the format:
+ * - `Authorization: Bearer <token>`
+ * - Case-insensitive "Bearer" prefix
+ *
+ * The extracted token becomes the credential identity for OAuth2 introspection.
+ *
+ * @example
+ * // Request header:
+ * // Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+ *
+ * // Result:
+ * // context.credentials.identity = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+ */
+@ContextEstablishmentHook()
+export class BearerTokenExtractor implements IContextEstablishmentHook {
+	constructor(private readonly httpHeaderExtractor: HttpHeaderExtractor) {}
+
+	hookDescription: HookDescription = {
+		name: 'BearerTokenExtractor',
+		displayName: 'Bearer Token Extractor',
+		options: [],
+	};
+
+	isApplicableToTriggerNode(nodeType: string): boolean {
+		return this.httpHeaderExtractor.isApplicableToTriggerNode(nodeType);
+	}
+
+	async execute(options: ContextEstablishmentOptions): Promise<ContextEstablishmentResult> {
+		return await this.httpHeaderExtractor.execute({
+			...options,
+			options: {
+				headerName: 'authorization',
+				headerValue: '[Bb][Ee][Aa][Rr][Ee][Rr]\\s+(.+)',
+			},
+		});
+	}
+}

--- a/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/index.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/index.ts
@@ -1,1 +1,2 @@
 import './http-header-extractor';
+import './bearer-token-extractor';

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/__tests__/oauth-credential-resolver.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/__tests__/oauth-credential-resolver.test.ts
@@ -1,0 +1,281 @@
+import type { Logger } from '@n8n/backend-common';
+import type { Cipher } from 'n8n-core';
+
+import { testCredentialResolverContract, testHelpers } from './resolver-contract-tests';
+import { OAuth2TokenIntrospectionIdentifier } from '../identifiers/oauth2-introspection-identifier';
+import { OAuthCredentialResolver } from '../oauth-credential-resolver';
+import type { DynamicCredentialEntryStorage } from '../storage/dynamic-credential-entry-storage';
+
+describe('OAuthCredentialResolver', () => {
+	let mockLogger: jest.Mocked<Logger>;
+	let mockIdentifier: jest.Mocked<OAuth2TokenIntrospectionIdentifier>;
+	let mockStorage: jest.Mocked<DynamicCredentialEntryStorage>;
+	let mockCipher: jest.Mocked<Cipher>;
+
+	const validOptions = {
+		metadataUri: 'https://auth.example.com/.well-known/openid-configuration',
+		clientId: 'test-client-id',
+		clientSecret: 'test-client-secret',
+		subjectClaim: 'sub',
+	};
+
+	beforeEach(() => {
+		mockLogger = {
+			debug: jest.fn(),
+			info: jest.fn(),
+			warn: jest.fn(),
+			error: jest.fn(),
+		} as unknown as jest.Mocked<Logger>;
+
+		mockIdentifier = {
+			resolve: jest.fn(),
+			validateOptions: jest.fn(),
+		} as unknown as jest.Mocked<OAuth2TokenIntrospectionIdentifier>;
+
+		mockStorage = {
+			getCredentialData: jest.fn(),
+			setCredentialData: jest.fn(),
+			deleteCredentialData: jest.fn(),
+		} as unknown as jest.Mocked<DynamicCredentialEntryStorage>;
+
+		mockCipher = {
+			encrypt: jest.fn(),
+			decrypt: jest.fn(),
+		} as unknown as jest.Mocked<Cipher>;
+	});
+
+	// Run the standard contract tests
+	testCredentialResolverContract({
+		createResolver: () => {
+			// Create an in-memory storage for contract tests
+			const storage = new Map<string, string>();
+
+			// Reset mocks with stateful implementations
+			// Make identifier return different subjects for different identities
+			mockIdentifier.resolve.mockImplementation(async (context) => {
+				return `subject-${context.identity}`;
+			});
+			mockIdentifier.validateOptions.mockResolvedValue(undefined);
+
+			mockStorage.getCredentialData.mockImplementation(
+				async (credentialId, subjectId, resolverId) => {
+					const key = `${credentialId}:${subjectId}:${resolverId}`;
+					return storage.get(key) ?? null;
+				},
+			);
+
+			mockStorage.setCredentialData.mockImplementation(
+				async (credentialId, subjectId, resolverId, data) => {
+					const key = `${credentialId}:${subjectId}:${resolverId}`;
+					storage.set(key, data);
+				},
+			);
+
+			mockStorage.deleteCredentialData.mockImplementation(
+				async (credentialId, subjectId, resolverId) => {
+					const key = `${credentialId}:${subjectId}:${resolverId}`;
+					storage.delete(key);
+				},
+			);
+
+			mockCipher.encrypt.mockImplementation((data) => JSON.stringify(data));
+			mockCipher.decrypt.mockImplementation((data) => data);
+
+			return new OAuthCredentialResolver(mockLogger, mockIdentifier, mockStorage, mockCipher);
+		},
+		validationTests: {
+			validOptions: [
+				['complete OAuth config', validOptions],
+				['with custom subject claim', { ...validOptions, subjectClaim: 'email' }],
+				[
+					'minimal config (subjectClaim defaults to "sub")',
+					{
+						metadataUri: validOptions.metadataUri,
+						clientId: validOptions.clientId,
+						clientSecret: validOptions.clientSecret,
+					},
+				],
+			],
+			invalidOptions: [
+				['missing metadataUri', { clientId: 'x', clientSecret: 'y' }],
+				['missing clientId', { metadataUri: validOptions.metadataUri, clientSecret: 'y' }],
+				['missing clientSecret', { metadataUri: validOptions.metadataUri, clientId: 'x' }],
+				[
+					'invalid metadataUri (not a URL)',
+					{ metadataUri: 'not-a-url', clientId: 'x', clientSecret: 'y' },
+				],
+			],
+		},
+	});
+
+	// OAuth-specific behavior tests
+	describe('OAuth-specific behavior', () => {
+		let resolver: OAuthCredentialResolver;
+
+		beforeEach(() => {
+			mockIdentifier.resolve.mockResolvedValue('oauth-subject-123');
+			mockIdentifier.validateOptions.mockResolvedValue(undefined);
+			resolver = new OAuthCredentialResolver(mockLogger, mockIdentifier, mockStorage, mockCipher);
+		});
+
+		describe('getSecret', () => {
+			it('should use identifier to resolve subject from token', async () => {
+				const credentialId = 'cred-123';
+				const context = testHelpers.createContext('access-token-xyz');
+				const handle = testHelpers.createHandle(validOptions);
+
+				mockStorage.getCredentialData.mockResolvedValue('encrypted-credential-data');
+				mockCipher.decrypt.mockReturnValue('{"apiKey":"decrypted-key"}');
+
+				await resolver.getSecret(credentialId, context, handle);
+
+				expect(mockIdentifier.resolve).toHaveBeenCalledWith(context, validOptions);
+			});
+
+			it('should decrypt data retrieved from storage', async () => {
+				const credentialId = 'cred-123';
+				const context = testHelpers.createContext('access-token-xyz');
+				const handle = testHelpers.createHandle(validOptions);
+
+				mockStorage.getCredentialData.mockResolvedValue('encrypted-data-from-db');
+				mockCipher.decrypt.mockReturnValue('{"apiKey":"secret-key-123"}');
+
+				const result = await resolver.getSecret(credentialId, context, handle);
+
+				expect(mockCipher.decrypt).toHaveBeenCalledWith('encrypted-data-from-db');
+				expect(result).toEqual({ apiKey: 'secret-key-123' });
+			});
+
+			it('should throw when decrypted data is not valid JSON', async () => {
+				const credentialId = 'cred-123';
+				const context = testHelpers.createContext('access-token-xyz');
+				const handle = testHelpers.createHandle(validOptions);
+
+				mockStorage.getCredentialData.mockResolvedValue('encrypted-data');
+				mockCipher.decrypt.mockReturnValue('invalid-json{{{');
+
+				await expect(resolver.getSecret(credentialId, context, handle)).rejects.toThrow();
+				expect(mockLogger.error).toHaveBeenCalledWith(
+					'Failed to parse decrypted credential data',
+					expect.any(Object),
+				);
+			});
+		});
+
+		describe('setSecret', () => {
+			it('should encrypt data before storing', async () => {
+				const credentialId = 'cred-123';
+				const context = testHelpers.createContext('access-token-xyz');
+				const data = testHelpers.createCredentialData({ apiKey: 'new-key' });
+				const handle = testHelpers.createHandle(validOptions);
+
+				mockCipher.encrypt.mockReturnValue('encrypted-new-data');
+
+				await resolver.setSecret(credentialId, context, data, handle);
+
+				expect(mockCipher.encrypt).toHaveBeenCalledWith(data);
+				expect(mockStorage.setCredentialData).toHaveBeenCalledWith(
+					credentialId,
+					'oauth-subject-123',
+					handle.resolverId,
+					'encrypted-new-data',
+					validOptions,
+				);
+			});
+
+			it('should use resolved subject as storage key', async () => {
+				const credentialId = 'cred-123';
+				const context = testHelpers.createContext('access-token-xyz');
+				const data = testHelpers.createCredentialData();
+				const handle = testHelpers.createHandle(validOptions);
+
+				mockIdentifier.resolve.mockResolvedValue('resolved-subject-456');
+				mockCipher.encrypt.mockReturnValue('encrypted-data');
+
+				await resolver.setSecret(credentialId, context, data, handle);
+
+				expect(mockStorage.setCredentialData).toHaveBeenCalledWith(
+					credentialId,
+					'resolved-subject-456',
+					handle.resolverId,
+					'encrypted-data',
+					validOptions,
+				);
+			});
+		});
+
+		describe('deleteSecret', () => {
+			it('should use resolved subject for deletion', async () => {
+				const credentialId = 'cred-123';
+				const context = testHelpers.createContext('access-token-xyz');
+				const handle = testHelpers.createHandle(validOptions);
+
+				mockIdentifier.resolve.mockResolvedValue('subject-to-delete');
+
+				await resolver.deleteSecret(credentialId, context, handle);
+
+				expect(mockIdentifier.resolve).toHaveBeenCalledWith(context, validOptions);
+				expect(mockStorage.deleteCredentialData).toHaveBeenCalledWith(
+					credentialId,
+					'subject-to-delete',
+					handle.resolverId,
+					validOptions,
+				);
+			});
+		});
+
+		describe('validateOptions', () => {
+			it('should delegate validation to identifier', async () => {
+				await resolver.validateOptions(validOptions);
+
+				expect(mockIdentifier.validateOptions).toHaveBeenCalledWith(validOptions);
+			});
+
+			it('should throw when identifier validation fails', async () => {
+				mockIdentifier.validateOptions.mockRejectedValue(new Error('Invalid metadata'));
+
+				await expect(resolver.validateOptions(validOptions)).rejects.toThrow('Invalid metadata');
+			});
+		});
+
+		describe('isolation with different tokens', () => {
+			it('should store credentials for different tokens separately', async () => {
+				const credentialId = 'cred-123';
+				const token1 = 'token-user-1';
+				const token2 = 'token-user-2';
+				const handle = testHelpers.createHandle(validOptions);
+
+				// Mock identifier to return different subjects for different tokens
+				mockIdentifier.resolve.mockImplementation(async (context) => {
+					if (context.identity === token1) return 'subject-1';
+					if (context.identity === token2) return 'subject-2';
+					return 'unknown';
+				});
+
+				const data1 = testHelpers.createCredentialData({ apiKey: 'key-1' });
+				const data2 = testHelpers.createCredentialData({ apiKey: 'key-2' });
+
+				mockCipher.encrypt.mockReturnValue('encrypted');
+
+				await resolver.setSecret(credentialId, testHelpers.createContext(token1), data1, handle);
+				await resolver.setSecret(credentialId, testHelpers.createContext(token2), data2, handle);
+
+				// Verify both were stored with different subjects
+				expect(mockStorage.setCredentialData).toHaveBeenCalledWith(
+					credentialId,
+					'subject-1',
+					handle.resolverId,
+					'encrypted',
+					validOptions,
+				);
+				expect(mockStorage.setCredentialData).toHaveBeenCalledWith(
+					credentialId,
+					'subject-2',
+					handle.resolverId,
+					'encrypted',
+					validOptions,
+				);
+			});
+		});
+	});
+});

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/__tests__/oauth-credential-resolver.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/__tests__/oauth-credential-resolver.test.ts
@@ -2,7 +2,7 @@ import type { Logger } from '@n8n/backend-common';
 import type { Cipher } from 'n8n-core';
 
 import { testCredentialResolverContract, testHelpers } from './resolver-contract-tests';
-import { OAuth2TokenIntrospectionIdentifier } from '../identifiers/oauth2-introspection-identifier';
+import type { OAuth2TokenIntrospectionIdentifier } from '../identifiers/oauth2-introspection-identifier';
 import { OAuthCredentialResolver } from '../oauth-credential-resolver';
 import type { DynamicCredentialEntryStorage } from '../storage/dynamic-credential-entry-storage';
 

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/__tests__/resolver-contract-tests.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/__tests__/resolver-contract-tests.ts
@@ -1,4 +1,8 @@
-import type { CredentialResolverConfiguration, ICredentialResolver } from '@n8n/decorators';
+import type {
+	CredentialResolverConfiguration,
+	CredentialResolverHandle,
+	ICredentialResolver,
+} from '@n8n/decorators';
 import {
 	CredentialResolverDataNotFoundError,
 	CredentialResolverValidationError,
@@ -45,6 +49,13 @@ export const testHelpers = {
 		apiKey: 'test-key-123',
 		apiSecret: 'test-secret-456',
 		...data,
+	}),
+
+	/** Creates a credential resolver handle with the given configuration */
+	createHandle: (configuration: CredentialResolverConfiguration): CredentialResolverHandle => ({
+		configuration,
+		resolverName: 'test-resolver',
+		resolverId: 'test-resolver-id',
 	}),
 
 	/** Generates a random credential ID for isolation */
@@ -120,8 +131,9 @@ export function testCredentialResolverContract(config: ResolverContractTestConfi
 				const credentialId = testHelpers.randomCredentialId();
 				const context = testHelpers.createContext(testHelpers.randomIdentity());
 				const options = validationTests.validOptions[0][1];
+				const handle = testHelpers.createHandle(options);
 
-				await expect(resolver.getSecret(credentialId, context, options)).rejects.toThrow(
+				await expect(resolver.getSecret(credentialId, context, handle)).rejects.toThrow(
 					CredentialResolverDataNotFoundError,
 				);
 			});
@@ -131,9 +143,10 @@ export function testCredentialResolverContract(config: ResolverContractTestConfi
 				const context = testHelpers.createContext(testHelpers.randomIdentity());
 				const data = testHelpers.createCredentialData();
 				const options = validationTests.validOptions[0][1];
+				const handle = testHelpers.createHandle(options);
 
-				await resolver.setSecret(credentialId, context, data, options);
-				const retrieved = await resolver.getSecret(credentialId, context, options);
+				await resolver.setSecret(credentialId, context, data, handle);
+				const retrieved = await resolver.getSecret(credentialId, context, handle);
 
 				expect(retrieved).toEqual(data);
 			});
@@ -147,11 +160,12 @@ export function testCredentialResolverContract(config: ResolverContractTestConfi
 				const context = testHelpers.createContext(testHelpers.randomIdentity());
 				const data = testHelpers.createCredentialData();
 				const options = validationTests.validOptions[0][1];
+				const handle = testHelpers.createHandle(options);
 
-				await resolver.setSecret(credentialId, context, data, options);
-				await resolver.deleteSecret(credentialId, context, options);
+				await resolver.setSecret(credentialId, context, data, handle);
+				await resolver.deleteSecret(credentialId, context, handle);
 
-				await expect(resolver.getSecret(credentialId, context, options)).rejects.toThrow(
+				await expect(resolver.getSecret(credentialId, context, handle)).rejects.toThrow(
 					CredentialResolverDataNotFoundError,
 				);
 			});
@@ -163,9 +177,10 @@ export function testCredentialResolverContract(config: ResolverContractTestConfi
 				const context = testHelpers.createContext(testHelpers.randomIdentity());
 				const data = testHelpers.createCredentialData();
 				const options = validationTests.validOptions[0][1];
+				const handle = testHelpers.createHandle(options);
 
-				await resolver.setSecret(credentialId, context, data, options);
-				const retrieved = await resolver.getSecret(credentialId, context, options);
+				await resolver.setSecret(credentialId, context, data, handle);
+				const retrieved = await resolver.getSecret(credentialId, context, handle);
 
 				expect(retrieved).toEqual(data);
 			});
@@ -174,14 +189,15 @@ export function testCredentialResolverContract(config: ResolverContractTestConfi
 				const credentialId = testHelpers.randomCredentialId();
 				const context = testHelpers.createContext(testHelpers.randomIdentity());
 				const options = validationTests.validOptions[0][1];
+				const handle = testHelpers.createHandle(options);
 
 				const data1 = testHelpers.createCredentialData({ apiKey: 'key-1' });
 				const data2 = testHelpers.createCredentialData({ apiKey: 'key-2' });
 
-				await resolver.setSecret(credentialId, context, data1, options);
-				await resolver.setSecret(credentialId, context, data2, options);
+				await resolver.setSecret(credentialId, context, data1, handle);
+				await resolver.setSecret(credentialId, context, data2, handle);
 
-				const retrieved = await resolver.getSecret(credentialId, context, options);
+				const retrieved = await resolver.getSecret(credentialId, context, handle);
 				expect(retrieved).toEqual(data2);
 			});
 		});
@@ -196,11 +212,12 @@ export function testCredentialResolverContract(config: ResolverContractTestConfi
 				const context = testHelpers.createContext(testHelpers.randomIdentity());
 				const data = testHelpers.createCredentialData();
 				const options = validationTests.validOptions[0][1];
+				const handle = testHelpers.createHandle(options);
 
-				await resolver.setSecret(credentialId, context, data, options);
-				await resolver.deleteSecret(credentialId, context, options);
+				await resolver.setSecret(credentialId, context, data, handle);
+				await resolver.deleteSecret(credentialId, context, handle);
 
-				await expect(resolver.getSecret(credentialId, context, options)).rejects.toThrow(
+				await expect(resolver.getSecret(credentialId, context, handle)).rejects.toThrow(
 					CredentialResolverDataNotFoundError,
 				);
 			});
@@ -214,10 +231,11 @@ export function testCredentialResolverContract(config: ResolverContractTestConfi
 				const context = testHelpers.createContext(testHelpers.randomIdentity());
 				const data = testHelpers.createCredentialData();
 				const options = validationTests.validOptions[0][1];
+				const handle = testHelpers.createHandle(options);
 
-				await resolver.setSecret(credentialId, context, data, options);
-				await resolver.deleteSecret(credentialId, context, options);
-				await expect(resolver.deleteSecret(credentialId, context, options)).resolves.not.toThrow();
+				await resolver.setSecret(credentialId, context, data, handle);
+				await resolver.deleteSecret(credentialId, context, handle);
+				await expect(resolver.deleteSecret(credentialId, context, handle)).resolves.not.toThrow();
 			});
 
 			it('should not error when deleting non-existent data', async () => {
@@ -228,8 +246,9 @@ export function testCredentialResolverContract(config: ResolverContractTestConfi
 				const credentialId = testHelpers.randomCredentialId();
 				const context = testHelpers.createContext(testHelpers.randomIdentity());
 				const options = validationTests.validOptions[0][1];
+				const handle = testHelpers.createHandle(options);
 
-				await expect(resolver.deleteSecret(credentialId, context, options)).resolves.not.toThrow();
+				await expect(resolver.deleteSecret(credentialId, context, handle)).resolves.not.toThrow();
 			});
 		});
 
@@ -239,15 +258,16 @@ export function testCredentialResolverContract(config: ResolverContractTestConfi
 				const credentialId2 = testHelpers.randomCredentialId();
 				const context = testHelpers.createContext(testHelpers.randomIdentity());
 				const options = validationTests.validOptions[0][1];
+				const handle = testHelpers.createHandle(options);
 
 				const data1 = testHelpers.createCredentialData({ apiKey: 'key-1' });
 				const data2 = testHelpers.createCredentialData({ apiKey: 'key-2' });
 
-				await resolver.setSecret(credentialId1, context, data1, options);
-				await resolver.setSecret(credentialId2, context, data2, options);
+				await resolver.setSecret(credentialId1, context, data1, handle);
+				await resolver.setSecret(credentialId2, context, data2, handle);
 
-				const retrieved1 = await resolver.getSecret(credentialId1, context, options);
-				const retrieved2 = await resolver.getSecret(credentialId2, context, options);
+				const retrieved1 = await resolver.getSecret(credentialId1, context, handle);
+				const retrieved2 = await resolver.getSecret(credentialId2, context, handle);
 
 				expect(retrieved1).toEqual(data1);
 				expect(retrieved2).toEqual(data2);
@@ -258,6 +278,7 @@ export function testCredentialResolverContract(config: ResolverContractTestConfi
 				const identity1 = testHelpers.randomIdentity();
 				const identity2 = testHelpers.randomIdentity();
 				const options = validationTests.validOptions[0][1];
+				const handle = testHelpers.createHandle(options);
 
 				const context1 = testHelpers.createContext(identity1);
 				const context2 = testHelpers.createContext(identity2);
@@ -265,11 +286,11 @@ export function testCredentialResolverContract(config: ResolverContractTestConfi
 				const data1 = testHelpers.createCredentialData({ apiKey: 'key-1' });
 				const data2 = testHelpers.createCredentialData({ apiKey: 'key-2' });
 
-				await resolver.setSecret(credentialId, context1, data1, options);
-				await resolver.setSecret(credentialId, context2, data2, options);
+				await resolver.setSecret(credentialId, context1, data1, handle);
+				await resolver.setSecret(credentialId, context2, data2, handle);
 
-				const retrieved1 = await resolver.getSecret(credentialId, context1, options);
-				const retrieved2 = await resolver.getSecret(credentialId, context2, options);
+				const retrieved1 = await resolver.getSecret(credentialId, context1, handle);
+				const retrieved2 = await resolver.getSecret(credentialId, context2, handle);
 
 				expect(retrieved1).toEqual(data1);
 				expect(retrieved2).toEqual(data2);
@@ -280,14 +301,15 @@ export function testCredentialResolverContract(config: ResolverContractTestConfi
 				const identity = testHelpers.randomIdentity();
 				const context = testHelpers.createContext(identity);
 				const options = validationTests.validOptions[0][1];
+				const handle = testHelpers.createHandle(options);
 
 				const data = testHelpers.createCredentialData();
 
-				await resolver.setSecret(credentialId, context, data, options);
+				await resolver.setSecret(credentialId, context, data, handle);
 
 				// Create a new context with same identity
 				const sameContext = testHelpers.createContext(identity);
-				const retrieved = await resolver.getSecret(credentialId, sameContext, options);
+				const retrieved = await resolver.getSecret(credentialId, sameContext, handle);
 
 				expect(retrieved).toEqual(data);
 			});
@@ -301,6 +323,7 @@ export function testCredentialResolverContract(config: ResolverContractTestConfi
 				const identity1 = testHelpers.randomIdentity();
 				const identity2 = testHelpers.randomIdentity();
 				const options = validationTests.validOptions[0][1];
+				const handle = testHelpers.createHandle(options);
 
 				const context1 = testHelpers.createContext(identity1);
 				const context2 = testHelpers.createContext(identity2);
@@ -308,18 +331,18 @@ export function testCredentialResolverContract(config: ResolverContractTestConfi
 				const data1 = testHelpers.createCredentialData({ apiKey: 'key-1' });
 				const data2 = testHelpers.createCredentialData({ apiKey: 'key-2' });
 
-				await resolver.setSecret(credentialId, context1, data1, options);
-				await resolver.setSecret(credentialId, context2, data2, options);
+				await resolver.setSecret(credentialId, context1, data1, handle);
+				await resolver.setSecret(credentialId, context2, data2, handle);
 
-				await resolver.deleteSecret(credentialId, context1, options);
+				await resolver.deleteSecret(credentialId, context1, handle);
 
 				// Identity1 should be deleted
-				await expect(resolver.getSecret(credentialId, context1, options)).rejects.toThrow(
+				await expect(resolver.getSecret(credentialId, context1, handle)).rejects.toThrow(
 					CredentialResolverDataNotFoundError,
 				);
 
 				// Identity2 should still exist
-				const retrieved2 = await resolver.getSecret(credentialId, context2, options);
+				const retrieved2 = await resolver.getSecret(credentialId, context2, handle);
 				expect(retrieved2).toEqual(data2);
 			});
 		});

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/__tests__/stub-credential-resolver.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/__tests__/stub-credential-resolver.test.ts
@@ -40,20 +40,26 @@ describe('StubCredentialResolver', () => {
 			const context = testHelpers.createContext('user-1');
 			const data = { apiKey: 'test-key' };
 
+			const handleWithPrefix = testHelpers.createHandle({ prefix: 'test' });
+			const handleWithOtherPrefix = testHelpers.createHandle({ prefix: 'other' });
+			const handleWithoutPrefix = testHelpers.createHandle({});
+
 			// Store with prefix
-			await resolver.setSecret(credentialId, context, data, { prefix: 'test' });
+			await resolver.setSecret(credentialId, context, data, handleWithPrefix);
 
 			// Should retrieve with same prefix
-			const retrieved = await resolver.getSecret(credentialId, context, { prefix: 'test' });
+			const retrieved = await resolver.getSecret(credentialId, context, handleWithPrefix);
 			expect(retrieved).toEqual(data);
 
 			// Should NOT retrieve with different prefix
 			await expect(
-				resolver.getSecret(credentialId, context, { prefix: 'other' }),
+				resolver.getSecret(credentialId, context, handleWithOtherPrefix),
 			).rejects.toThrow();
 
 			// Should NOT retrieve without prefix
-			await expect(resolver.getSecret(credentialId, context, {})).rejects.toThrow();
+			await expect(
+				resolver.getSecret(credentialId, context, handleWithoutPrefix),
+			).rejects.toThrow();
 		});
 
 		it('should store data in memory (lost on restart)', async () => {
@@ -63,12 +69,13 @@ describe('StubCredentialResolver', () => {
 			const credentialId = 'cred-123';
 			const context = testHelpers.createContext('user-1');
 			const data = { apiKey: 'test-key' };
+			const handle = testHelpers.createHandle({});
 
 			// Store in first instance
-			await resolver1.setSecret(credentialId, context, data, {});
+			await resolver1.setSecret(credentialId, context, data, handle);
 
 			// Should not be available in second instance (different memory)
-			await expect(resolver2.getSecret(credentialId, context, {})).rejects.toThrow();
+			await expect(resolver2.getSecret(credentialId, context, handle)).rejects.toThrow();
 		});
 	});
 });

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-introspection-identifier.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-introspection-identifier.ts
@@ -246,7 +246,7 @@ export class OAuth2TokenIntrospectionIdentifier implements ITokenIdentifier {
 		});
 
 		if (response.status !== 200) {
-			this.logger.debug('Token introspection failed', {
+			this.logger.error('Token introspection failed', {
 				status: response.status,
 				data: response.data,
 			});

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/index.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/index.ts
@@ -1,1 +1,2 @@
 import './stub-credential-resolver';
+import './oauth-credential-resolver';

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/oauth-credential-resolver.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/oauth-credential-resolver.ts
@@ -1,0 +1,160 @@
+import { Logger } from '@n8n/backend-common';
+import {
+	CredentialResolver,
+	CredentialResolverConfiguration,
+	CredentialResolverDataNotFoundError,
+	CredentialResolverHandle,
+	CredentialResolverValidationError,
+	ICredentialResolver,
+} from '@n8n/decorators';
+import { Cipher } from 'n8n-core';
+import { ICredentialContext, ICredentialDataDecryptedObject, jsonParse } from 'n8n-workflow';
+import z from 'zod';
+
+import {
+	OAuth2IntrospectionOptionsSchema,
+	OAuth2TokenIntrospectionIdentifier,
+} from './identifiers/oauth2-introspection-identifier';
+import { DynamicCredentialEntryStorage } from './storage/dynamic-credential-entry-storage';
+
+const OAuthCredentialResolverOptionsSchema = z.object({
+	...OAuth2IntrospectionOptionsSchema.shape,
+});
+
+/**
+ * OAuth2 token introspection-based credential resolver.
+ * Resolves user identity via OAuth2 token introspection and stores credentials
+ * encrypted in the database, keyed by the introspected subject.
+ */
+@CredentialResolver()
+export class OAuthCredentialResolver implements ICredentialResolver {
+	constructor(
+		private readonly logger: Logger,
+		private readonly oAuth2TokenIntrospectionIdentifier: OAuth2TokenIntrospectionIdentifier,
+		private readonly storage: DynamicCredentialEntryStorage,
+		private readonly cipher: Cipher,
+	) {}
+
+	metadata = {
+		name: 'credential-resolver.oauth2-1.0',
+		description: 'OAuth2 token introspection-based credential resolver',
+		displayName: 'OAuth2 Introspection',
+		options: [
+			{
+				displayName: 'Metadata URL',
+				name: 'metadataUri',
+				type: 'string' as const,
+				required: true,
+				default: '',
+				placeholder: 'https://auth.example.com/.well-known/openid-configuration',
+				description: 'OAuth2 server metadata endpoint URL',
+			},
+			{
+				displayName: 'Client ID',
+				name: 'clientId',
+				type: 'string' as const,
+				default: '',
+				required: true,
+				description: 'OAuth2 client ID for introspection',
+			},
+			{
+				displayName: 'Client Secret',
+				name: 'clientSecret',
+				type: 'string' as const,
+				default: '',
+				required: true,
+				typeOptions: { password: true },
+				description: 'OAuth2 client secret for introspection',
+			},
+			{
+				displayName: 'Subject Claim',
+				name: 'subjectClaim',
+				type: 'string' as const,
+				default: 'sub',
+				description: 'Token claim to use as subject identifier',
+			},
+		],
+	};
+
+	/**
+	 * Retrieves stored credential data for the given identity.
+	 * @throws {CredentialResolverDataNotFoundError} When no data exists for the key
+	 */
+	async getSecret(
+		credentialId: string,
+		context: ICredentialContext,
+		handle: CredentialResolverHandle,
+	): Promise<ICredentialDataDecryptedObject> {
+		const parsedOptions = await this.parseOptions(handle.configuration);
+		const key = await this.oAuth2TokenIntrospectionIdentifier.resolve(context, parsedOptions);
+
+		const data = await this.storage.getCredentialData(
+			credentialId,
+			key,
+			handle.resolverId,
+			parsedOptions,
+		);
+
+		if (!data) {
+			throw new CredentialResolverDataNotFoundError();
+		}
+		const plaintext = this.cipher.decrypt(data);
+		try {
+			const secret = jsonParse<ICredentialDataDecryptedObject>(plaintext);
+			return secret;
+		} catch (error) {
+			this.logger.error('Failed to parse decrypted credential data', { error });
+			throw new CredentialResolverDataNotFoundError();
+		}
+	}
+
+	/** Stores credential data for the given identity */
+	async setSecret(
+		credentialId: string,
+		context: ICredentialContext,
+		data: ICredentialDataDecryptedObject,
+		handle: CredentialResolverHandle,
+	): Promise<void> {
+		const parsedOptions = await this.parseOptions(handle.configuration);
+		const key = await this.oAuth2TokenIntrospectionIdentifier.resolve(context, parsedOptions);
+
+		const encryptedData = this.cipher.encrypt(data);
+
+		await this.storage.setCredentialData(
+			credentialId,
+			key,
+			handle.resolverId,
+			encryptedData,
+			parsedOptions,
+		);
+	}
+
+	/** Deletes credential data for the given identity. Succeeds silently if not found. */
+	async deleteSecret(
+		credentialId: string,
+		context: ICredentialContext,
+		handle: CredentialResolverHandle,
+	): Promise<void> {
+		const parsedOptions = await this.parseOptions(handle.configuration);
+		const key = await this.oAuth2TokenIntrospectionIdentifier.resolve(context, parsedOptions);
+		await this.storage.deleteCredentialData(credentialId, key, handle.resolverId, parsedOptions);
+	}
+
+	private async parseOptions(options: CredentialResolverConfiguration) {
+		const result = await OAuthCredentialResolverOptionsSchema.safeParseAsync(options);
+		if (result.error) {
+			this.logger.error('Invalid options provided to OAuthCredentialResolver', {
+				error: result.error,
+			});
+			throw new CredentialResolverValidationError(
+				`Invalid options for OAuthCredentialResolver: ${result.error.message}`,
+			);
+		}
+		return result.data;
+	}
+
+	async validateOptions(options: CredentialResolverConfiguration): Promise<void> {
+		const parsedOptions = await this.parseOptions(options);
+		await this.oAuth2TokenIntrospectionIdentifier.validateOptions(parsedOptions);
+	}
+}

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/stub-credential-resolver.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/stub-credential-resolver.ts
@@ -3,11 +3,12 @@ import {
 	CredentialResolver,
 	CredentialResolverConfiguration,
 	CredentialResolverDataNotFoundError,
+	CredentialResolverHandle,
 	CredentialResolverValidationError,
 	ICredentialResolver,
 } from '@n8n/decorators';
 import { ICredentialContext, ICredentialDataDecryptedObject } from 'n8n-workflow';
-import z from 'zod/v4';
+import z from 'zod';
 
 const StubOptionsSchema = z.object({
 	prefix: z.string().default(''),
@@ -57,9 +58,9 @@ export class StubCredentialResolver implements ICredentialResolver {
 	async getSecret(
 		credentialId: string,
 		context: ICredentialContext,
-		options: CredentialResolverConfiguration,
+		handle: CredentialResolverHandle,
 	): Promise<ICredentialDataDecryptedObject> {
-		const parsedOptions = await this.parseOptions(options);
+		const parsedOptions = await this.parseOptions(handle.configuration);
 		const key = this.generateKey(credentialId, context, parsedOptions);
 		const secret = this.secretsStore.get(key);
 		if (!secret) {
@@ -73,9 +74,9 @@ export class StubCredentialResolver implements ICredentialResolver {
 		credentialId: string,
 		context: ICredentialContext,
 		data: ICredentialDataDecryptedObject,
-		options: CredentialResolverConfiguration,
+		handle: CredentialResolverHandle,
 	): Promise<void> {
-		const parsedOptions = await this.parseOptions(options);
+		const parsedOptions = await this.parseOptions(handle.configuration);
 		const key = this.generateKey(credentialId, context, parsedOptions);
 		this.secretsStore.set(key, data);
 	}
@@ -84,9 +85,9 @@ export class StubCredentialResolver implements ICredentialResolver {
 	async deleteSecret(
 		credentialId: string,
 		context: ICredentialContext,
-		options: CredentialResolverConfiguration,
+		handle: CredentialResolverHandle,
 	): Promise<void> {
-		const parsedOptions = await this.parseOptions(options);
+		const parsedOptions = await this.parseOptions(handle.configuration);
 		const key = this.generateKey(credentialId, context, parsedOptions);
 		this.secretsStore.delete(key);
 	}


### PR DESCRIPTION
## Summary

Implements OAuth2 token introspection-based credential resolution (RFC 7662) for multi-tenant workflows. The OAuthCredentialResolver introspects bearer tokens via OAuth2 metadata endpoints, extracts user identity (subject claim), and stores encrypted credentials per-user in the database. Includes BearerTokenExtractor hook for automatic token extraction from webhook requests.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-4227/implement-oauth-introspection-resolver

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
