### PR TITLE
fix: Add version history records when importing workflows

### DIFF
--- a/packages/@n8n/backend-test-utils/src/db/workflows.ts
+++ b/packages/@n8n/backend-test-utils/src/db/workflows.ts
@@ -202,8 +202,7 @@ export async function createWorkflowWithHistory(
 	const workflow = await createWorkflow(attributes, userOrProject);
 
 	// Create workflow history for the initial version
-	const user = userOrProject instanceof User ? userOrProject : undefined;
-	await createWorkflowHistory(workflow, user, withPublishHistory);
+	await createWorkflowHistory(workflow, userOrProject, withPublishHistory);
 
 	return workflow;
 }
@@ -247,12 +246,19 @@ export async function createWorkflowHistory(
 	userOrProject?: User | Project,
 	withPublishHistory?: Partial<WorkflowPublishHistory>,
 ): Promise<void> {
+	const authors =
+		userOrProject instanceof User
+			? userOrProject.firstName && userOrProject.lastName
+				? `${userOrProject.firstName} ${userOrProject.lastName}`
+				: 'Test User'
+			: 'Test User';
+
 	await Container.get(WorkflowHistoryRepository).insert({
 		workflowId: workflow.id,
 		versionId: workflow.versionId,
 		nodes: workflow.nodes,
 		connections: workflow.connections,
-		authors: userOrProject instanceof User ? userOrProject.email : 'test@example.com',
+		authors,
 	});
 
 	if (withPublishHistory) {

--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control-import.service.ee.test.ts
@@ -75,7 +75,6 @@ describe('SourceControlImportService', () => {
 		sourceControlScopedService,
 		mock(),
 		mock(),
-		mock(),
 	);
 
 	const globMock = fastGlob.default as unknown as jest.Mock<Promise<string[]>, string[]>;

--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control-import.service.ee.test.ts
@@ -74,6 +74,8 @@ describe('SourceControlImportService', () => {
 		mock<InstanceSettings>({ n8nFolder: '/mock/n8n' }),
 		sourceControlScopedService,
 		mock(),
+		mock(),
+		mock(),
 	);
 
 	const globMock = fastGlob.default as unknown as jest.Mock<Promise<string[]>, string[]>;

--- a/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
@@ -35,6 +35,7 @@ import type { IWorkflowBase } from 'n8n-workflow';
 import { ensureError, jsonParse, UnexpectedError, UserError } from 'n8n-workflow';
 import { readFile as fsReadFile } from 'node:fs/promises';
 import path from 'path';
+import { v4 as uuid } from 'uuid';
 
 import { ActiveWorkflowManager } from '@/active-workflow-manager';
 import { CredentialsService } from '@/credentials/credentials.service';
@@ -684,6 +685,7 @@ export class SourceControlImportService {
 			} else {
 				importedWorkflow.active = false;
 				importedWorkflow.activeVersionId = null;
+				importedWorkflow.versionId = importedWorkflow.versionId ?? uuid();
 			}
 
 			const parentFolderId = importedWorkflow.parentFolderId ?? '';

--- a/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
@@ -1287,6 +1287,10 @@ export class SourceControlImportService {
 			return;
 		}
 
+		// Fetch user for author info
+		const user = await this.userRepository.findOne({ where: { id: userId } });
+		const authors = user ? `${user.firstName} ${user.lastName}` : 'Unknown';
+
 		try {
 			const existingVersion = await this.workflowHistoryService.findVersion(
 				importedWorkflow.id,
@@ -1306,16 +1310,13 @@ export class SourceControlImportService {
 						`Updating workflow history for versionId ${importedWorkflow.versionId}`,
 					);
 
-					// Fetch user for author info
-					const user = await this.userRepository.findOne({ where: { id: userId } });
-
 					await this.workflowHistoryService.updateVersion(
 						importedWorkflow.versionId,
 						importedWorkflow.id,
 						{
 							nodes: importedWorkflow.nodes,
 							connections: importedWorkflow.connections,
-							authors: user ? `${user.firstName} ${user.lastName}` : 'Unknown',
+							authors,
 						},
 					);
 				} else {
@@ -1329,10 +1330,8 @@ export class SourceControlImportService {
 					`Creating new workflow history for versionId ${importedWorkflow.versionId}`,
 				);
 
-				const user = await this.userRepository.findOneOrFail({ where: { id: userId } });
-
 				await this.workflowHistoryService.saveVersion(
-					user,
+					authors,
 					importedWorkflow as unknown as IWorkflowBase,
 					importedWorkflow.id,
 				);

--- a/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
@@ -21,7 +21,6 @@ import {
 	WorkflowRepository,
 	WorkflowTagMappingRepository,
 	WorkflowPublishHistoryRepository,
-	WorkflowHistoryRepository,
 } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
@@ -160,7 +159,6 @@ export class SourceControlImportService {
 		private readonly sourceControlScopedService: SourceControlScopedService,
 		private readonly workflowPublishHistoryRepository: WorkflowPublishHistoryRepository,
 		private readonly workflowHistoryService: WorkflowHistoryService,
-		private readonly workflowHistoryRepository: WorkflowHistoryRepository,
 	) {
 		this.gitFolder = path.join(instanceSettings.n8nFolder, SOURCE_CONTROL_GIT_FOLDER);
 		this.workflowExportFolder = path.join(this.gitFolder, SOURCE_CONTROL_WORKFLOW_EXPORT_FOLDER);
@@ -1290,13 +1288,10 @@ export class SourceControlImportService {
 		}
 
 		try {
-			const existingVersion = await this.workflowHistoryRepository.findOne({
-				where: {
-					versionId: importedWorkflow.versionId,
-					workflowId: importedWorkflow.id,
-				},
-				select: ['versionId', 'nodes', 'connections'],
-			});
+			const existingVersion = await this.workflowHistoryService.findVersion(
+				importedWorkflow.id,
+				importedWorkflow.versionId,
+			);
 
 			if (existingVersion) {
 				// Check if nodes or connections changed

--- a/packages/cli/src/workflows/workflow-history/workflow-history.service.ts
+++ b/packages/cli/src/workflows/workflow-history/workflow-history.service.ts
@@ -97,7 +97,7 @@ export class WorkflowHistoryService {
 	}
 
 	async saveVersion(
-		user: User,
+		user: User | string,
 		workflow: IWorkflowBase,
 		workflowId: string,
 		transactionManager?: EntityManager,
@@ -108,13 +108,15 @@ export class WorkflowHistoryService {
 			);
 		}
 
+		const authors = typeof user === 'string' ? user : `${user.firstName} ${user.lastName}`;
+
 		const repository = transactionManager
 			? transactionManager.getRepository(WorkflowHistory)
 			: this.workflowHistoryRepository;
 
 		try {
 			await repository.insert({
-				authors: user.firstName + ' ' + user.lastName,
+				authors,
 				connections: workflow.connections,
 				nodes: workflow.nodes,
 				versionId: workflow.versionId,

--- a/packages/cli/src/workflows/workflow-history/workflow-history.service.ts
+++ b/packages/cli/src/workflows/workflow-history/workflow-history.service.ts
@@ -84,6 +84,18 @@ export class WorkflowHistoryService {
 		return hist;
 	}
 
+	/**
+	 * Find a workflow history version without permission checks.
+	 */
+	async findVersion(workflowId: string, versionId: string): Promise<WorkflowHistory | null> {
+		return await this.workflowHistoryRepository.findOne({
+			where: {
+				workflowId,
+				versionId,
+			},
+		});
+	}
+
 	async saveVersion(
 		user: User,
 		workflow: IWorkflowBase,

--- a/packages/cli/test/integration/environments/source-control-import.service.test.ts
+++ b/packages/cli/test/integration/environments/source-control-import.service.test.ts
@@ -106,7 +106,6 @@ describe('SourceControlImportService', () => {
 			sourceControlScopedService,
 			mock(),
 			workflowHistoryService,
-			workflowHistoryRepository,
 		);
 	});
 

--- a/packages/cli/test/integration/environments/source-control-import.service.test.ts
+++ b/packages/cli/test/integration/environments/source-control-import.service.test.ts
@@ -95,6 +95,8 @@ describe('SourceControlImportService', () => {
 			mock<InstanceSettings>({ n8nFolder: '/some-path' }),
 			sourceControlScopedService,
 			mock(),
+			mock(),
+			mock(),
 		);
 	});
 


### PR DESCRIPTION
## Summary

This PR adds workflow history records during workflow import. If it's an existing workflow with an existing record, it updates it.

This was causing migration problems for users when adding `activeVersionId`, so I also updated the migration to backfill workflow history again (same way we did it in `BackfillMissingWorkflowHistoryRecords1762763704614`).

To test it, I had to temporarily enable `PRAGMA foreign_keys = ON` in the migration runner to catch the FK constraint violation during testing.

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-4517](https://linear.app/n8n/issue/ADO-4517/db-migration-on-update-to-11225-fails-when-using-source-control) and [ADO-4520](https://linear.app/n8n/issue/ADO-4520/workflow-cannot-be-activated-in-prod-when-pushed-from-dev-env-via-git)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
