### PR TITLE
ci: Increase timer for e2e CI

### DIFF
--- a/.github/workflows/playwright-test-ci.yml
+++ b/.github/workflows/playwright-test-ci.yml
@@ -30,26 +30,26 @@ jobs:
       workers: '1'
     secrets: inherit
 
-  # Community PR tests: Standard mode with SQLite (no secrets required)
+  # Community PR tests: Local mode with SQLite (no container building, no secrets required)
   # Runs on GitHub-hosted runners without Currents reporting
-  community-standard-ui:
-    name: 'Community: Standard UI'
+  community-ui:
+    name: 'Community: UI'
     if: ${{ github.event.pull_request.head.repo.fork }}
     uses: ./.github/workflows/playwright-test-reusable.yml
     with:
-      test-mode: docker-build
-      test-command: pnpm --filter=n8n-playwright test:container:standard:ui
+      test-mode: local
+      test-command: pnpm --filter=n8n-playwright test:local
       shards: '[1, 2, 3, 4, 5]'
       runner: ubuntu-latest
       workers: '2'
 
-  community-standard-isolated:
-    name: 'Community: Standard Isolated'
+  community-isolated:
+    name: 'Community: Isolated'
     if: ${{ github.event.pull_request.head.repo.fork }}
     uses: ./.github/workflows/playwright-test-reusable.yml
     with:
-      test-mode: docker-build
-      test-command: pnpm --filter=n8n-playwright test:container:standard:isolated
+      test-mode: local
+      test-command: pnpm --filter=n8n-playwright test:local:isolated
       shards: '[1]'
       runner: ubuntu-latest
       workers: '1'

--- a/.github/workflows/playwright-test-reusable.yml
+++ b/.github/workflows/playwright-test-reusable.yml
@@ -64,7 +64,7 @@ env:
 jobs:
   test:
     runs-on: ${{ inputs.runner }}
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Increase timer for e2e jobs, for the community tests that run on GH without cache they are slower.
Also change them to local mode.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
