### PR TITLE
ci: Add ui-e2e to codecov reports

### DIFF
--- a/.github/workflows/playwright-test-coverage.yml
+++ b/.github/workflows/playwright-test-coverage.yml
@@ -22,15 +22,21 @@ jobs:
 
       - name: Setup Environment
         uses: ./.github/actions/setup-nodejs-blacksmith
-        with:
-          build-command: pnpm turbo build:playwright
+        env:
+          INCLUDE_TEST_CONTROLLER: 'true'
 
-      - name: Build with Coverage
-        run: pnpm --filter n8n-editor-ui build:coverage
+      - name: Build Docker Image with Coverage
+        run: pnpm build:docker:coverage
+        env:
+          INCLUDE_TEST_CONTROLLER: 'true'
 
-      - name: Run Coverage Tests
+      - name: Install Browsers
+        run: pnpm turbo install-browsers:ci
+
+      - name: Run Container Coverage Tests
+        id: coverage-tests
         run: |
-          pnpm --filter n8n-playwright test:local \
+          pnpm --filter n8n-playwright test:container:standard \
             --workers=${{ env.PLAYWRIGHT_WORKERS }}
         env:
           BUILD_WITH_COVERAGE: 'true'
@@ -40,11 +46,23 @@ jobs:
           QA_PERFORMANCE_METRICS_WEBHOOK_PASSWORD: ${{ secrets.QA_PERFORMANCE_METRICS_WEBHOOK_PASSWORD }}
 
       - name: Generate Coverage Report
+        if: always() && steps.coverage-tests.outcome != 'skipped'
         run: pnpm --filter n8n-playwright coverage:report
 
-      - name: Upload Coverage Report
+      - name: Upload Coverage Report Artifact
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage-report
           path: packages/testing/playwright/coverage/
           retention-days: 14
+
+      - name: Upload E2E Coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: packages/testing/playwright/coverage/lcov.info
+          flags: frontend-e2e
+          name: playwright-e2e
+          fail_ci_if_error: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,9 +13,15 @@ github_checks:
   annotations: false
 
 flags:
-  tests:
-    paths:
-      - '**'
+  backend-unit:
+    carryforward: true
+  backend-integration:
+    carryforward: true
+  nodes-unit:
+    carryforward: true
+  frontend:
+    carryforward: true
+  frontend-e2e:
     carryforward: true
 
 component_management:

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:n8n": "node scripts/build-n8n.mjs",
     "build:deploy": "node scripts/build-n8n.mjs",
     "build:docker": "node scripts/build-n8n.mjs && node scripts/dockerize-n8n.mjs",
+    "build:docker:coverage": "BUILD_WITH_COVERAGE=true node scripts/build-n8n.mjs && node scripts/dockerize-n8n.mjs",
     "build:docker:scan": "node scripts/build-n8n.mjs && node scripts/dockerize-n8n.mjs && node scripts/scan-n8n-image.mjs",
     "build:docker:test": "node scripts/build-n8n.mjs && node scripts/dockerize-n8n.mjs && turbo run test:container:standard --filter=n8n-playwright",
     "typecheck": "turbo typecheck",

--- a/packages/testing/playwright/scripts/generate-coverage-report.js
+++ b/packages/testing/playwright/scripts/generate-coverage-report.js
@@ -34,18 +34,22 @@ function main() {
 		const mergedFile = path.join(NYC_OUTPUT_DIR, 'out.json');
 		execSync(`npx nyc merge ${UI_DIR} ${mergedFile}`, { stdio: 'inherit' });
 
-		// Generate HTML report
-		console.log('Generating HTML report...');
+		// Generate reports (HTML for viewing, LCOV for Codecov)
+		console.log('Generating coverage reports...');
 		execSync(
-			`npx nyc report --reporter=html --report-dir=${COVERAGE_DIR} --temp-dir=${NYC_OUTPUT_DIR} --config=${NYC_CONFIG} --exclude-after-remap=false`,
+			`npx nyc report --reporter=html --reporter=lcov --report-dir=${COVERAGE_DIR} --temp-dir=${NYC_OUTPUT_DIR} --config=${NYC_CONFIG} --exclude-after-remap=false`,
 			{ stdio: 'inherit' },
 		);
 
 		const htmlReportPath = path.join(COVERAGE_DIR, 'index.html');
+		const lcovPath = path.join(COVERAGE_DIR, 'lcov.info');
+
+		console.log(`\n✅ Coverage reports generated successfully!`);
 		if (fs.existsSync(htmlReportPath)) {
-			console.log(`\n✅ Coverage report generated successfully!`);
-			console.log(`📊 Report: ${htmlReportPath}`);
-			console.log(`🌐 Open: file://${htmlReportPath}`);
+			console.log(`📊 HTML Report: ${htmlReportPath}`);
+		}
+		if (fs.existsSync(lcovPath)) {
+			console.log(`📄 LCOV Report: ${lcovPath} (for Codecov)`);
 		}
 	} catch (error) {
 		console.error('❌ Failed to generate coverage report:', error.message);

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,5 @@
 {
-	"globalEnv": ["CI", "COVERAGE_ENABLED"],
+	"globalEnv": ["CI", "COVERAGE_ENABLED", "BUILD_WITH_COVERAGE"],
 	"tasks": {
 		"clean": { "cache": false },
 		"build": {


### PR DESCRIPTION
## Summary

Adds the ui-e2e weekly tests to Codecov, giving us a full picture of coverage.
The UI tests are running weekly with coverage with "carryforward" set this will ensure they the results available for regular CI runs.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1932/add-e2e-ui-coverage-to-codecov

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
