### PR TITLE
fix(editor): Show node settings in protected view for read-only review

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
@@ -457,7 +457,7 @@ const populateHiddenIssuesSet = () => {
 };
 
 const nodeSettings = computed(() =>
-	createCommonNodeSettings(isExecutable.value, isToolNode.value, i18n.baseText.bind(i18n)),
+	createCommonNodeSettings(isToolNode.value, i18n.baseText.bind(i18n)),
 );
 
 const iconSource = computed(() =>

--- a/packages/frontend/editor-ui/src/features/ndv/shared/ndv.utils.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/ndv.utils.ts
@@ -443,14 +443,10 @@ export function shouldSkipParamValidation(
 	);
 }
 
-export function createCommonNodeSettings(
-	isExecutable: boolean,
-	isTriggerNode: boolean,
-	t: (key: BaseTextKey) => string,
-) {
+export function createCommonNodeSettings(isToolNode: boolean, t: (key: BaseTextKey) => string) {
 	const ret: INodeProperties[] = [];
 
-	if (isExecutable && !isTriggerNode) {
+	if (!isToolNode) {
 		ret.push(
 			{
 				displayName: t('nodeSettings.alwaysOutputData.displayName'),


### PR DESCRIPTION
## Summary

Previously, the `createCommonNodeSettings` function took an `isExecutable` parameter.
In protected view (source control environment), `isExecutable` is false, which caused the node settings (like "Always Output Data", "Execute Once", "Retry on Fail", etc.) to be hidden entirely.

Node settings will now be visible in protected view (read-only state). The settings themselves will still be read-only because other parts of the UI handle the disabled/read-only state - this change just ensures the settings are displayed so users can review what's configured.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
[PAY-2519](https://linear.app/n8n/issue/PAY-2519/node-settings-missing-in-protected-view)


<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
