### PR TITLE
chore: Make workflow comparison run in CI

### DIFF
--- a/.github/workflows/ci-evals.yml
+++ b/.github/workflows/ci-evals.yml
@@ -47,6 +47,21 @@ jobs:
       - name: Setup and Build
         uses: ./.github/actions/setup-nodejs-blacksmith
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1 # 6.5.0
+        with:
+          enable-cache: true
+
+      - name: Install just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
+
+      - name: Install Python
+        run: uv python install 3.11
+
+      - name: Install workflow comparison dependencies
+        working-directory: packages/@n8n/ai-workflow-builder.ee/evaluations/programmatic/python
+        run: just sync-all
+
       - name: Export Node Types
         run: |
           ./packages/cli/bin/n8n export:nodes --output ./packages/@n8n/ai-workflow-builder.ee/evaluations/nodes.json

--- a/.github/workflows/ci-evals.yml
+++ b/.github/workflows/ci-evals.yml
@@ -56,6 +56,7 @@ jobs:
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
 
       - name: Install Python
+        working-directory: packages/@n8n/ai-workflow-builder.ee/evaluations/programmatic/python
         run: uv python install 3.11
 
       - name: Install workflow comparison dependencies

--- a/.github/workflows/ci-python-workflow-builder-evals.yml
+++ b/.github/workflows/ci-python-workflow-builder-evals.yml
@@ -1,4 +1,4 @@
-name: Python CI
+name: AI Workflow Builder Evals Python CI
 
 on:
   pull_request:

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/langsmith/evaluator.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/langsmith/evaluator.ts
@@ -113,7 +113,8 @@ export function createLangsmithEvaluator(
 
 		let referenceWorkflow: SimpleWorkflow | SimpleWorkflow[] | undefined = undefined;
 		let referenceWorkflows: SimpleWorkflow[] | undefined = undefined;
-		// Extract reference workflow from example outputs if available
+		let preset: 'strict' | 'standard' | 'lenient' | undefined = undefined;
+		// Extract reference workflow and preset from example outputs if available
 		if (example?.outputs) {
 			const exampleOutputs = example.outputs as Record<string, unknown>;
 			if (Array.isArray(exampleOutputs.workflowJSON)) {
@@ -127,6 +128,13 @@ export function createLangsmithEvaluator(
 			if (isSimpleWorkflow(exampleOutputs.workflowJSON)) {
 				referenceWorkflow = exampleOutputs.workflowJSON;
 			}
+			// Extract preset if available
+			if (
+				typeof exampleOutputs.preset === 'string' &&
+				['strict', 'standard', 'lenient'].includes(exampleOutputs.preset)
+			) {
+				preset = exampleOutputs.preset as 'strict' | 'standard' | 'lenient';
+			}
 		}
 
 		const evaluationInput: EvaluationInput = {
@@ -134,6 +142,7 @@ export function createLangsmithEvaluator(
 			generatedWorkflow: validation.workflow!,
 			referenceWorkflow,
 			referenceWorkflows,
+			preset,
 		};
 
 		try {

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/programmatic/evaluators/workflow-similarity.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/programmatic/evaluators/workflow-similarity.test.ts
@@ -178,6 +178,31 @@ describe('evaluateWorkflowSimilarity', () => {
 
 			expect(result.violations[0].pointsDeducted).toBe(16);
 		});
+
+		it('should pass custom preset to Python script', async () => {
+			const mockPythonOutput = JSON.stringify({
+				similarity_score: 0.9,
+				edit_cost: 10,
+				max_possible_cost: 100,
+				top_edits: [],
+				metadata: {
+					generated_nodes: 1,
+					ground_truth_nodes: 1,
+					config_name: 'lenient',
+				},
+			});
+
+			mockExecFileAsync.mockResolvedValue({ stdout: mockPythonOutput, stderr: '' });
+
+			await evaluateWorkflowSimilarity(generatedWorkflow, groundTruthWorkflow, 'lenient');
+
+			// Verify the preset was passed to the Python script
+			expect(mockExecFileAsync).toHaveBeenCalledWith(
+				'uvx',
+				expect.arrayContaining(['--preset', 'lenient']),
+				expect.any(Object),
+			);
+		});
 	});
 
 	describe('error handling', () => {

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/programmatic/programmatic-evaluation.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/programmatic/programmatic-evaluation.ts
@@ -20,7 +20,7 @@ export async function programmaticEvaluation(
 	input: ProgrammaticEvaluationInput,
 	nodeTypes: INodeTypeDescription[],
 ) {
-	const { generatedWorkflow, referenceWorkflow, referenceWorkflows } = input;
+	const { generatedWorkflow, referenceWorkflow, referenceWorkflows, preset = 'standard' } = input;
 
 	const connectionsEvaluationResult = evaluateConnections(generatedWorkflow, nodeTypes);
 	const nodesEvaluationResult = evaluateNodes(generatedWorkflow, nodeTypes);
@@ -38,6 +38,7 @@ export async function programmaticEvaluation(
 			similarityEvaluationResult = await evaluateWorkflowSimilarityMultiple(
 				generatedWorkflow,
 				referenceWorkflows,
+				preset,
 			);
 		} catch (error) {
 			console.warn('Multiple workflow similarity evaluation failed:', error);
@@ -58,6 +59,7 @@ export async function programmaticEvaluation(
 			similarityEvaluationResult = await evaluateWorkflowSimilarity(
 				generatedWorkflow,
 				referenceWorkflow,
+				preset,
 			);
 		} catch (error) {
 			console.warn('Workflow similarity evaluation failed:', error);

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/programmatic/python/src/configs/presets/lenient.yaml
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/programmatic/python/src/configs/presets/lenient.yaml
@@ -19,7 +19,7 @@ costs:
     substitution: 2.0
 
   parameters:
-    mismatch_weight: 0.2  # Low weight for parameter differences
+    mismatch_weight: 0.3
     nested_weight: 0.1
 
 # Node type similarity groups (same as standard)
@@ -77,7 +77,7 @@ parameter_comparison:
 
 # Output configuration
 output:
-  max_edits: 10  # Show fewer edits since many are ignored
+  max_edits: 20
   group_by: "priority"
   include_explanations: true
   include_suggestions: true

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/types/evaluation.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/types/evaluation.ts
@@ -93,6 +93,7 @@ export const evaluationInputSchema = z.object({
 	generatedWorkflow: z.custom<SimpleWorkflow>(),
 	referenceWorkflow: z.custom<SimpleWorkflow>().optional(),
 	referenceWorkflows: z.array(z.custom<SimpleWorkflow>()).optional(),
+	preset: z.enum(['strict', 'standard', 'lenient']).optional(),
 });
 
 export type EvaluationInput = z.infer<typeof evaluationInputSchema>;

--- a/packages/@n8n/ai-workflow-builder.ee/src/validation/types.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/validation/types.ts
@@ -71,6 +71,7 @@ export interface ProgrammaticEvaluationInput {
 	userPrompt?: string;
 	referenceWorkflow?: SimpleWorkflow;
 	referenceWorkflows?: SimpleWorkflow[];
+	preset?: 'strict' | 'standard' | 'lenient';
 }
 
 export interface NodeResolvedConnectionTypesInfo {


### PR DESCRIPTION
## Summary
Fixes some issues when running workflow comparison with langsmith dataset and updates CI to install the necessary python requirements to be able to execute that step. 
- Fixed reading of reference workflows from dataset
- Added reading used preset from dataset
- Adjusted weights in lenient preset
- Added uv/just/python installation steps to ci-evals

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-1758/run-workflow-diffs-in-ci


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
