### PR TITLE
test: Removes Github reporter from Playwright tests

### DIFF
--- a/packages/testing/playwright/fixtures/base.ts
+++ b/packages/testing/playwright/fixtures/base.ts
@@ -117,10 +117,6 @@ export const test = base.extend<
 				`[${new Date().toISOString()}] Container created in ${duration}s - URL: ${container.baseUrl}`,
 			);
 
-			console.log(
-				`[${new Date().toISOString()}] Container created in ${duration}s - URL: ${container.baseUrl}`,
-			);
-
 			await use(container);
 			await container.stop();
 		},

--- a/packages/testing/playwright/playwright.config.ts
+++ b/packages/testing/playwright/playwright.config.ts
@@ -91,7 +91,6 @@ export default defineConfig<CurrentsFixtures, CurrentsWorkerFixtures>({
 	reporter: IS_CI
 		? [
 				['list'],
-				['github'],
 				['junit', { outputFile: process.env.PLAYWRIGHT_JUNIT_OUTPUT_NAME ?? 'results.xml' }],
 				['html', { open: 'never' }],
 				['json', { outputFile: 'test-results.json' }],


### PR DESCRIPTION
## Summary

The flaky test annotations were too noisy on unrelated changes


## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
