### PR TITLE
ci: Add formatting check to CI (no-changelog)

### DIFF
--- a/.github/workflows/ci-manual-build-unit-tests.yml
+++ b/.github/workflows/ci-manual-build-unit-tests.yml
@@ -74,7 +74,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
-    name: Lint
+    name: Lint and Format Check
     needs: install-and-build
     uses: ./.github/workflows/linting-reusable.yml
     with:

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -32,7 +32,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
-    name: Lint
+    name: Lint and Format Check
     uses: ./.github/workflows/linting-reusable.yml
     with:
       ref: ${{ github.sha }}

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -116,7 +116,7 @@ jobs:
           build-command: pnpm typecheck
 
   lint:
-    name: Lint
+    name: Lint and Format Check
     if: needs.install-and-build.outputs.non_python_changed == 'true'
     uses: ./.github/workflows/linting-reusable.yml
     needs: install-and-build

--- a/.github/workflows/linting-reusable.yml
+++ b/.github/workflows/linting-reusable.yml
@@ -1,4 +1,4 @@
-name: Reusable linting workflow
+name: Reusable linting and formatting check workflow
 
 on:
   workflow_call:
@@ -26,8 +26,8 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - name: Build and Test
+      - name: Lint and Format Check
         uses: n8n-io/n8n/.github/actions/setup-nodejs-blacksmith@f5fbbbe0a28a886451c886cac6b49192a39b0eea # v1.104.1
         with:
-          build-command: pnpm lint
+          build-command: pnpm lint && pnpm format:check
           node-version: ${{ inputs.nodeVersion }}


### PR DESCRIPTION
## Summary

This pull request updates the linting workflows to include formatting checks alongside linting, ensuring that code formatting standards are enforced during CI runs. The changes affect both the naming and the commands executed in the linting workflows.

**Linting and Formatting Workflow Updates:**

* Renamed the linting workflow in `.github/workflows/linting-reusable.yml` to "Reusable linting and formatting check workflow" to reflect the inclusion of formatting checks.
* Updated the linting job name in `.github/workflows/ci-manual-build-unit-tests.yml`, `.github/workflows/ci-master.yml`, and `.github/workflows/ci-pull-requests.yml` from "Lint" to "Lint and Format Check" for clarity. [[1]](diffhunk://#diff-56c6815bf9e487d89f21d7a73f9488fefbbab76f479bd9c1b24d9c8f689ac87cL77-R77) [[2]](diffhunk://#diff-e6f4a17ebab9d843e84f7492c50da580e9b3e20987b3a18d42dcfc050402ac97L35-R35) [[3]](diffhunk://#diff-4eb787923b5d10508f08732ecbbe5195a389acb35bb1d56c7b57ccaa747d9c7cL119-R119)
* Modified the build command in the linting job to run both `pnpm lint` and `pnpm format:check`, ensuring both linting and formatting are checked in CI.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1941/add-formatting-check-to-ci

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
