### PR TITLE
fix(core): Use correct entity manager in Data Table update transaction (no-changelog)

### DIFF
--- a/packages/cli/src/modules/data-table/data-table-rows.repository.ts
+++ b/packages/cli/src/modules/data-table/data-table-rows.repository.ts
@@ -330,7 +330,7 @@ export class DataTableRowsRepository {
 			if (!useReturning && returnData) {
 				// Only Postgres supports RETURNING statement on updates (with our typeorm),
 				// on other engines we must query the list of updates rows later by ID
-				affectedRows = await this.getAffectedRowsForUpdate(dataTableId, filter, columns, true, trx);
+				affectedRows = await this.getAffectedRowsForUpdate(dataTableId, filter, columns, true, em);
 			}
 
 			setData.updatedAt = normalizeValueForDatabase(new Date(), 'date', dbType);


### PR DESCRIPTION
## Summary

Use the provided em rather than the function argument. This specific part of the code cannot be reached with an undefined trx though, so I don't expect this to actually fix and latent issues as trx and em will always be the same object if trx is defined.

## Related Linear tickets, Github issues, and Community forum posts

n/a


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
