### PR TITLE
ci: Remove release exclusion from PR's

### DIFF
--- a/.github/workflows/ci-postgres-mysql.yml
+++ b/.github/workflows/ci-postgres-mysql.yml
@@ -16,8 +16,6 @@ on:
       - packages/cli/**/__tests__/**
       - .github/workflows/ci-postgres-mysql.yml
       - .github/docker-compose.yml
-  pull_request_review:
-    types: [submitted]
 
 concurrency:
   group: db-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -2,9 +2,6 @@ name: Build, unit test and lint branch
 
 on:
   pull_request:
-    branches:
-      - '**'
-      - '!release/*'
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary

CI was not being run on release PR's
postgres/integration was running twice, once on PR opened, once on approval.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
