### PR TITLE
feat(core): Add new Chat hub feature for chatting with LLMs and your n8n agent workflows

### DIFF
--- a/packages/@n8n/backend-common/src/modules/__tests__/module-registry.test.ts
+++ b/packages/@n8n/backend-common/src/modules/__tests__/module-registry.test.ts
@@ -15,10 +15,7 @@ beforeEach(() => {
 
 describe('eligibleModules', () => {
 	it('should consider all default modules eligible', () => {
-		// 'chat-hub' isn't (yet) an eligible module by default
-		const NON_DEFAULT_MODULES = ['chat-hub'];
-		const expectedModules = MODULE_NAMES.filter((name) => !NON_DEFAULT_MODULES.includes(name));
-		expect(Container.get(ModuleRegistry).eligibleModules).toEqual(expectedModules);
+		expect(Container.get(ModuleRegistry).eligibleModules).toEqual(MODULE_NAMES);
 	});
 
 	it('should consider a module ineligible if it was disabled via env var', () => {
@@ -31,6 +28,7 @@ describe('eligibleModules', () => {
 			'provisioning',
 			'breaking-changes',
 			'dynamic-credentials',
+			'chat-hub',
 		]);
 	});
 
@@ -45,6 +43,7 @@ describe('eligibleModules', () => {
 			'provisioning',
 			'breaking-changes',
 			'dynamic-credentials',
+			'chat-hub',
 		]);
 	});
 

--- a/packages/@n8n/backend-common/src/modules/module-registry.ts
+++ b/packages/@n8n/backend-common/src/modules/module-registry.ts
@@ -38,6 +38,7 @@ export class ModuleRegistry {
 		'provisioning',
 		'breaking-changes',
 		'dynamic-credentials',
+		'chat-hub',
 	];
 
 	private readonly activeModules: string[] = [];

--- a/packages/@n8n/backend-common/src/modules/modules.config.ts
+++ b/packages/@n8n/backend-common/src/modules/modules.config.ts
@@ -8,10 +8,10 @@ export const MODULE_NAMES = [
 	'community-packages',
 	'data-table',
 	'mcp',
-	'chat-hub',
 	'provisioning',
 	'breaking-changes',
 	'dynamic-credentials',
+	'chat-hub',
 ] as const;
 
 export type ModuleName = (typeof MODULE_NAMES)[number];

--- a/packages/cli/src/modules/chat-hub/chat-hub.module.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.module.ts
@@ -1,21 +1,10 @@
-import { Logger } from '@n8n/backend-common';
 import type { ModuleInterface } from '@n8n/decorators';
 import { BackendModule, OnShutdown } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 
-const YELLOW = '\x1b[33m';
-const CLEAR = '\x1b[0m';
-const WARNING_MESSAGE =
-	"[Chat] 'chat-hub' module is experimental, undocumented and subject to change. " +
-	'Before its official release any features may become inaccessible at any point, ' +
-	'and using the module could compromise the stability of your system. Use at your own risk!';
-
 @BackendModule({ name: 'chat-hub' })
 export class ChatHubModule implements ModuleInterface {
 	async init() {
-		const logger = Container.get(Logger).scoped('chat-hub');
-		logger.warn(`${YELLOW}${WARNING_MESSAGE}${CLEAR}`);
-
 		await import('./chat-hub.controller');
 		await import('./chat-hub.settings.controller');
 	}

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/module.descriptor.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/module.descriptor.ts
@@ -22,7 +22,7 @@ const SettingsChatHubView = async () =>
 export const ChatModule: FrontendModuleDescription = {
 	id: 'chat-hub',
 	name: 'Chat',
-	description: 'Interact with various LLM models or your n8n AI agents.',
+	description: 'Chat with LLM models or your n8n AI agents.',
 	icon: 'chat',
 	modals: [
 		{


### PR DESCRIPTION
## Summary

This PR enables the new Chat hub feature by default. This feature allows n8n users to chat with various LLM providers using their API credentials, or to chat with their own n8n agent workflows that have enabled a new `Make Available in n8n Chat` toggle on their Chat Trigger and published the workflow.

<img width="519" height="627" alt="image" src="https://github.com/user-attachments/assets/844bbb11-646c-448a-bc51-44624fd4135f" />

The chat can be accessed on /home/chat, and enabling the module should bring a link on the main sidebar.

<img width="300" height="458" alt="image" src="https://github.com/user-attachments/assets/32d1eb2b-ecab-461e-871d-2c638fd2a543" />

<img width="1693" height="957" alt="image" src="https://github.com/user-attachments/assets/4d6c87ea-e88c-4a0a-8a04-3420f806fc34" />

Note:
This feature can be disabled by setting `N8N_DISABLED_MODULES=chat-hub`, but it being enabled is the new default starting version 2.1.0.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
