### PR TITLE
fix(editor): Model selector dropdown menu in chat closes too eagerly

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ModelSelector.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ModelSelector.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, useTemplateRef, watch } from 'vue';
+import { computed, ref, useCssModule, useTemplateRef, watch } from 'vue';
 import { N8nNavigationDropdown, N8nIcon, N8nButton, N8nText, N8nAvatar } from '@n8n/design-system';
 import { type ComponentProps } from 'vue-component-type-helpers';
 import {
@@ -82,6 +82,7 @@ const settingStore = useSettingsStore();
 const credentialsStore = useCredentialsStore();
 const projectStore = useProjectsStore();
 const telemetry = useTelemetry();
+const styles = useCssModule();
 
 const credentialsName = computed(() =>
 	selectedAgent
@@ -324,6 +325,9 @@ function onSelect(id: string) {
 onClickOutside(
 	computed(() => dropdownRef.value?.$el),
 	() => dropdownRef.value?.close(),
+	{
+		ignore: [`.${styles.component} [role=menuitem]`],
+	},
 );
 
 // Update agents when credentials are updated


### PR DESCRIPTION
## Summary

This PR fixes the bug in model selector dropdown in chat where it closes when a top-level menu item is clicked.

I initially thought that the behavior comes from ElementPlus, but it turned out that the culprit was `onClickOutside` which I added to ensure closing the menu when it's opened programmatically.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
