### PR TITLE
chore(core): Add userinfo identifier to auth2 resolver

### DIFF
--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/oauth2-introspection-identifier.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/oauth2-introspection-identifier.test.ts
@@ -21,6 +21,7 @@ describe('OAuth2TokenIntrospectionIdentifier', () => {
 		clientId: 'test-client',
 		clientSecret: 'test-secret',
 		subjectClaim: 'sub',
+		validation: 'oauth2-introspection',
 	};
 
 	const validMetadata = {

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/oauth2-userinfo-identifier.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/oauth2-userinfo-identifier.test.ts
@@ -1,0 +1,292 @@
+import { mockLogger } from '@n8n/backend-test-utils';
+import { Time } from '@n8n/constants';
+import axios from 'axios';
+import { mock } from 'jest-mock-extended';
+
+import type { CacheService } from '@/services/cache/cache.service';
+
+import { IdentifierValidationError } from '../identifier-interface';
+import { OAuth2UserInfoIdentifier } from '../oauth2-userinfo-identifier';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('OAuth2UserInfoIdentifier', () => {
+	const logger = mockLogger();
+	const cache = mock<CacheService>();
+	let identifier: OAuth2UserInfoIdentifier;
+
+	const validOptions = {
+		metadataUri: 'https://auth.example.com/.well-known/openid-configuration',
+		subjectClaim: 'sub',
+		validation: 'oauth2-userinfo' as const,
+	};
+
+	const validMetadata = {
+		issuer: 'https://auth.example.com',
+		userinfo_endpoint: 'https://auth.example.com/oauth/userinfo',
+	};
+
+	const validUserInfoResponse = {
+		sub: 'user-123',
+		email: 'user@example.com',
+		name: 'Test User',
+	};
+
+	const mockContext = {
+		identity: 'mock-access-token',
+		version: 1 as const,
+	};
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		identifier = new OAuth2UserInfoIdentifier(logger, cache);
+		cache.get.mockResolvedValue(undefined);
+		cache.set.mockResolvedValue();
+	});
+
+	describe('Happy Path', () => {
+		test('should resolve subject successfully', async () => {
+			mockedAxios.get
+				.mockResolvedValueOnce({
+					status: 200,
+					data: validMetadata,
+				})
+				.mockResolvedValueOnce({
+					status: 200,
+					data: validUserInfoResponse,
+				});
+
+			const result = await identifier.resolve(mockContext, validOptions);
+
+			expect(result).toBe('user-123');
+			expect(cache.set).toHaveBeenCalledWith(
+				expect.stringContaining('oauth2-userinfo-identifier:subject'),
+				'user-123',
+				expect.any(Number),
+			);
+			expect(mockedAxios.get).toHaveBeenCalledWith(
+				'https://auth.example.com/oauth/userinfo',
+				expect.objectContaining({
+					headers: { authorization: 'Bearer mock-access-token' },
+				}),
+			);
+		});
+
+		test('should return cached result on subsequent calls', async () => {
+			cache.get.mockResolvedValueOnce(undefined).mockResolvedValueOnce('cached-user-123');
+
+			mockedAxios.get.mockResolvedValueOnce({
+				status: 200,
+				data: validMetadata,
+			});
+
+			const result = await identifier.resolve(mockContext, validOptions);
+
+			expect(result).toBe('cached-user-123');
+			expect(mockedAxios.get).toHaveBeenCalledTimes(1); // Only metadata call, no userinfo call
+		});
+
+		test('should extract subject from custom claim', async () => {
+			const customOptions = { ...validOptions, subjectClaim: 'email' };
+			const customResponse = { ...validUserInfoResponse, email: 'john.doe@example.com' };
+
+			mockedAxios.get
+				.mockResolvedValueOnce({
+					status: 200,
+					data: validMetadata,
+				})
+				.mockResolvedValueOnce({
+					status: 200,
+					data: customResponse,
+				});
+
+			const result = await identifier.resolve(mockContext, customOptions);
+
+			expect(result).toBe('john.doe@example.com');
+		});
+	});
+
+	describe('Validation', () => {
+		test('should validate successfully with valid options', async () => {
+			mockedAxios.get.mockResolvedValue({
+				status: 200,
+				data: validMetadata,
+			});
+
+			await expect(identifier.validateOptions(validOptions)).resolves.toBeUndefined();
+		});
+
+		test('should throw IdentifierValidationError when metadata missing userinfo_endpoint', async () => {
+			const metadataWithoutUserInfo = {
+				issuer: 'https://auth.example.com',
+			};
+
+			mockedAxios.get.mockResolvedValue({
+				status: 200,
+				data: metadataWithoutUserInfo,
+			});
+
+			await expect(identifier.validateOptions(validOptions)).rejects.toThrow(
+				IdentifierValidationError,
+			);
+			await expect(identifier.validateOptions(validOptions)).rejects.toThrow(
+				'Invalid OAuth2 metadata format',
+			);
+		});
+	});
+
+	describe('Critical Errors', () => {
+		test('should throw IdentifierValidationError for invalid options', async () => {
+			const invalidOptions = { metadataUri: 'not-a-url' };
+
+			await expect(identifier.resolve(mockContext, invalidOptions)).rejects.toThrow(
+				IdentifierValidationError,
+			);
+		});
+
+		test('should throw IdentifierValidationError when metadata fetch fails', async () => {
+			mockedAxios.get.mockResolvedValue({
+				status: 404,
+				data: {},
+			});
+
+			await expect(identifier.resolve(mockContext, validOptions)).rejects.toThrow(
+				IdentifierValidationError,
+			);
+			expect(logger.error).toHaveBeenCalledWith(
+				expect.stringContaining('Failed to fetch OAuth2 metadata'),
+			);
+		});
+
+		test('should throw IdentifierValidationError when userinfo call fails', async () => {
+			mockedAxios.get
+				.mockResolvedValueOnce({
+					status: 200,
+					data: validMetadata,
+				})
+				.mockResolvedValueOnce({
+					status: 401,
+					data: { error: 'invalid_token' },
+				});
+
+			await expect(identifier.resolve(mockContext, validOptions)).rejects.toThrow(
+				IdentifierValidationError,
+			);
+			expect(logger.error).toHaveBeenCalledWith('UserInfo failed', expect.any(Object));
+		});
+
+		test('should throw IdentifierValidationError when subject claim is missing', async () => {
+			const responseWithoutSub = {
+				email: 'user@example.com',
+				name: 'Test User',
+			};
+
+			mockedAxios.get
+				.mockResolvedValueOnce({
+					status: 200,
+					data: validMetadata,
+				})
+				.mockResolvedValueOnce({
+					status: 200,
+					data: responseWithoutSub,
+				});
+
+			await expect(identifier.resolve(mockContext, validOptions)).rejects.toThrow(
+				IdentifierValidationError,
+			);
+			expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('missing subject claim'));
+		});
+	});
+
+	describe('TTL Handling', () => {
+		test('should use default TTL when exp not provided', async () => {
+			mockedAxios.get
+				.mockResolvedValueOnce({
+					status: 200,
+					data: validMetadata,
+				})
+				.mockResolvedValueOnce({
+					status: 200,
+					data: validUserInfoResponse,
+				});
+
+			await identifier.resolve(mockContext, validOptions);
+
+			const subjectCacheCall = cache.set.mock.calls.find((call) => call[0].includes(':subject:'));
+			expect(subjectCacheCall).toBeDefined();
+			expect(subjectCacheCall![2]).toBe(60 * Time.seconds.toMilliseconds);
+		});
+
+		test('should cap TTL at MAX_TOKEN_CACHE_TIMEOUT for long-lived token', async () => {
+			const longLivedResponse = {
+				...validUserInfoResponse,
+				exp: Math.floor(Date.now() / 1000) + 7200, // 2 hours from now
+			};
+
+			mockedAxios.get
+				.mockResolvedValueOnce({
+					status: 200,
+					data: validMetadata,
+				})
+				.mockResolvedValueOnce({
+					status: 200,
+					data: longLivedResponse,
+				});
+
+			await identifier.resolve(mockContext, validOptions);
+
+			const subjectCacheCall = cache.set.mock.calls.find((call) => call[0].includes(':subject:'));
+			expect(subjectCacheCall).toBeDefined();
+			expect(subjectCacheCall![2]).toBe(5 * Time.minutes.toMilliseconds);
+		});
+
+		test('should use MIN_TOKEN_CACHE_TIMEOUT for expired token', async () => {
+			const expiredResponse = {
+				...validUserInfoResponse,
+				exp: Math.floor(Date.now() / 1000) - 3600, // 1 hour ago
+			};
+
+			mockedAxios.get
+				.mockResolvedValueOnce({
+					status: 200,
+					data: validMetadata,
+				})
+				.mockResolvedValueOnce({
+					status: 200,
+					data: expiredResponse,
+				});
+
+			await identifier.resolve(mockContext, validOptions);
+
+			const subjectCacheCall = cache.set.mock.calls.find((call) => call[0].includes(':subject:'));
+			expect(subjectCacheCall).toBeDefined();
+			expect(subjectCacheCall![2]).toBe(30 * Time.seconds.toMilliseconds);
+		});
+
+		test('should calculate correct TTL for token expiring in 2 minutes', async () => {
+			const expiringResponse = {
+				...validUserInfoResponse,
+				exp: Math.floor(Date.now() / 1000) + 120, // 2 minutes from now
+			};
+
+			mockedAxios.get
+				.mockResolvedValueOnce({
+					status: 200,
+					data: validMetadata,
+				})
+				.mockResolvedValueOnce({
+					status: 200,
+					data: expiringResponse,
+				});
+
+			await identifier.resolve(mockContext, validOptions);
+
+			const subjectCacheCall = cache.set.mock.calls.find((call) => call[0].includes(':subject:'));
+			expect(subjectCacheCall).toBeDefined();
+			// Should be ~120 seconds, but at least MIN_TOKEN_CACHE_TIMEOUT
+			expect(subjectCacheCall![2]).toBeGreaterThanOrEqual(30 * Time.seconds.toMilliseconds);
+			expect(subjectCacheCall![2]).toBeLessThanOrEqual(120 * Time.seconds.toMilliseconds);
+		});
+	});
+});

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-introspection-identifier.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-introspection-identifier.ts
@@ -19,6 +19,7 @@ const METADATA_CACHE_TIMEOUT = 1 * Time.hours.toMilliseconds; // 1 hour
 
 export const OAuth2IntrospectionOptionsSchema = z.object({
 	...OAuth2OptionsSchema.shape,
+	validation: z.literal('oauth2-introspection'),
 	clientId: z.string(),
 	clientSecret: z.string(),
 });

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-userinfo-identifier.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-userinfo-identifier.ts
@@ -1,0 +1,195 @@
+import { Logger } from '@n8n/backend-common';
+import { Time } from '@n8n/constants';
+import { Service } from '@n8n/di';
+import axios from 'axios';
+import type { ICredentialContext } from 'n8n-workflow';
+import { z } from 'zod';
+
+import { CacheService } from '@/services/cache/cache.service';
+
+import { IdentifierValidationError, ITokenIdentifier } from './identifier-interface';
+import { OAuth2OptionsSchema, sha256 } from './oauth2-utils';
+
+// Use minimum of 30 seconds to avoid cache thrashing
+// Cap at 5 minutes to ensure periodic revalidation
+const MIN_TOKEN_CACHE_TIMEOUT = 30 * Time.seconds.toMilliseconds;
+const MAX_TOKEN_CACHE_TIMEOUT = 5 * Time.minutes.toMilliseconds;
+const DEFAULT_CACHE_TIMEOUT = 60 * Time.seconds.toMilliseconds; // 60 seconds
+const METADATA_CACHE_TIMEOUT = 1 * Time.hours.toMilliseconds; // 1 hour
+
+export const OAuth2UserInfoOptionsSchema = z.object({
+	...OAuth2OptionsSchema.shape,
+	validation: z.literal('oauth2-userinfo'),
+});
+
+type OAuth2UserInfoOptions = z.infer<typeof OAuth2UserInfoOptionsSchema>;
+
+const OAuth2MetadataSchema = z.object({
+	issuer: z.string().url(),
+	userinfo_endpoint: z.string().url(),
+});
+
+type OAuth2Metadata = z.infer<typeof OAuth2MetadataSchema>;
+
+export const UserInfoResponseSchema = z
+	.object({
+		// Standard optional fields
+		sub: z.string().optional(),
+	})
+	.passthrough();
+
+export type UserInfoResponse = z.infer<typeof UserInfoResponseSchema>;
+
+const CACHE_PREFIX = 'oauth2-userinfo-identifier';
+
+@Service()
+export class OAuth2UserInfoIdentifier implements ITokenIdentifier {
+	constructor(
+		private readonly logger: Logger,
+		private readonly cache: CacheService,
+	) {}
+
+	async validateOptions(identifierOptions: Record<string, unknown>): Promise<void> {
+		const options = this.parseOptions(identifierOptions);
+		const metadata = await this.fetchMetadata(options, true);
+		if (!metadata.userinfo_endpoint) {
+			this.logger.error('Metadata does not contain an userinfo endpoint');
+			throw new IdentifierValidationError('Metadata does not contain an userinfo endpoint');
+		}
+	}
+
+	async resolve(
+		context: ICredentialContext,
+		identifierOptions: Record<string, unknown>,
+	): Promise<string> {
+		const options = this.parseOptions(identifierOptions);
+		const metadata = await this.fetchMetadata(options);
+
+		const hashedToken = sha256(context.identity);
+
+		const identifierCacheKey = `${CACHE_PREFIX}:subject:${metadata.issuer}:${hashedToken}`;
+		const cached = await this.cache.get<string>(identifierCacheKey);
+		if (cached) {
+			return cached;
+		}
+
+		let ttl = DEFAULT_CACHE_TIMEOUT;
+		const { subject, ttl: ttlOverwrite } = await this.resolveBasedOnUserInfo(
+			metadata,
+			options,
+			context,
+		);
+		if (ttlOverwrite) {
+			ttl = ttlOverwrite;
+		}
+
+		await this.cache.set(identifierCacheKey, subject, ttl);
+		return subject;
+	}
+
+	// ------------------------ Private Methods ----------------------- //
+
+	private parseOptions(options: Record<string, unknown>): OAuth2UserInfoOptions {
+		try {
+			return OAuth2UserInfoOptionsSchema.parse(options);
+		} catch (error) {
+			this.logger.error('Invalid OAuth2 identifier options', { error });
+			throw new IdentifierValidationError('Invalid OAuth2 identifier options', {
+				cause: error,
+			});
+		}
+	}
+
+	private async fetchMetadata(
+		options: OAuth2UserInfoOptions,
+		skipCache: boolean = false,
+	): Promise<OAuth2Metadata> {
+		const cacheKey = `${CACHE_PREFIX}:metadata:${options.metadataUri}`;
+		if (!skipCache) {
+			const cached = await this.cache.get<OAuth2Metadata>(cacheKey);
+			if (cached) {
+				return cached;
+			}
+		}
+
+		const response = await axios.get(options.metadataUri, {
+			validateStatus: () => true,
+			timeout: 10 * Time.seconds.toMilliseconds,
+		});
+
+		if (response.status !== 200) {
+			this.logger.error(
+				`Failed to fetch OAuth2 metadata from ${options.metadataUri}, status code: ${response.status}`,
+			);
+			throw new IdentifierValidationError(
+				`Failed to fetch OAuth2 metadata, status code: ${response.status}`,
+			);
+		}
+
+		try {
+			const metadata = OAuth2MetadataSchema.parse(response.data);
+			if (!skipCache) {
+				await this.cache.set(cacheKey, metadata, METADATA_CACHE_TIMEOUT);
+			}
+			return metadata;
+		} catch (error) {
+			this.logger.error('Invalid OAuth2 metadata format', { error });
+			throw new IdentifierValidationError('Invalid OAuth2 metadata format', { cause: error });
+		}
+	}
+
+	private parseUserInfoResponse(data: unknown): UserInfoResponse {
+		try {
+			return UserInfoResponseSchema.parse(data);
+		} catch (error) {
+			this.logger.error('Invalid userinfo response format', { error });
+			throw new IdentifierValidationError('Invalid token introspection response format');
+		}
+	}
+
+	private async resolveBasedOnUserInfo(
+		metadata: OAuth2Metadata,
+		options: OAuth2UserInfoOptions,
+		context: ICredentialContext,
+	): Promise<{ subject: string; ttl?: number }> {
+		const response = await axios.get(metadata.userinfo_endpoint, {
+			headers: { authorization: `Bearer ${context.identity}` },
+			validateStatus: () => true,
+			timeout: 10 * Time.seconds.toMilliseconds,
+		});
+
+		if (response.status !== 200) {
+			this.logger.error('UserInfo failed', {
+				status: response.status,
+				data: response.data,
+			});
+			throw new IdentifierValidationError('Token introspection failed');
+		}
+
+		// TODO: Add support for JWT responses in addition to JSON
+		const userData = this.parseUserInfoResponse(response.data);
+		const subject = userData[options.subjectClaim];
+		if (!subject) {
+			this.logger.error(`UserInfo response missing subject claim (${options.subjectClaim})`);
+			throw new IdentifierValidationError(
+				`UserInfo response missing subject claim (${options.subjectClaim})`,
+			);
+		}
+
+		const subjectStr = String(subject);
+
+		this.logger.debug('UserInfo successfully', { subject: subjectStr });
+
+		let ttl: number | undefined = undefined;
+		if (userData.exp && typeof userData.exp === 'number') {
+			const expiresIn = userData.exp * 1000 - Date.now();
+			if (expiresIn > 0) {
+				ttl = Math.max(MIN_TOKEN_CACHE_TIMEOUT, Math.min(expiresIn, MAX_TOKEN_CACHE_TIMEOUT));
+			} else {
+				ttl = MIN_TOKEN_CACHE_TIMEOUT;
+			}
+		}
+
+		return { subject: subjectStr, ttl };
+	}
+}

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-userinfo-identifier.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-userinfo-identifier.ts
@@ -143,7 +143,7 @@ export class OAuth2UserInfoIdentifier implements ITokenIdentifier {
 			return UserInfoResponseSchema.parse(data);
 		} catch (error) {
 			this.logger.error('Invalid userinfo response format', { error });
-			throw new IdentifierValidationError('Invalid token introspection response format');
+			throw new IdentifierValidationError('Invalid userinfo response format');
 		}
 	}
 
@@ -163,7 +163,7 @@ export class OAuth2UserInfoIdentifier implements ITokenIdentifier {
 				status: response.status,
 				data: response.data,
 			});
-			throw new IdentifierValidationError('Token introspection failed');
+			throw new IdentifierValidationError('UserInfo query failed');
 		}
 
 		// TODO: Add support for JWT responses in addition to JSON

--- a/packages/frontend/editor-ui/src/app/components/CredentialResolverEditModal.vue
+++ b/packages/frontend/editor-ui/src/app/components/CredentialResolverEditModal.vue
@@ -111,6 +111,7 @@ const selectedType = computed(() => {
 // The explicit return type provides type narrowing from unknown to INodeProperties
 const toNodeProperty = (option: Record<string, unknown>): INodeProperties => {
 	return {
+		...option,
 		name: typeof option.name === 'string' ? option.name : '',
 		type: (typeof option.type === 'string' ? option.type : 'string') as INodeProperties['type'],
 		displayName: typeof option.displayName === 'string' ? option.displayName : '',


### PR DESCRIPTION
## Summary

Added OAuth2 UserInfo endpoint support as an alternative validation method to the existing token introspection approach. The OAuthCredentialResolver now uses a discriminated union to route between OAuth2TokenIntrospectionIdentifier and OAuth2UserInfoIdentifier based on the validation configuration option.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-4304/implement-oauth-userinfo-identifier

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
