### PR TITLE
fix(editor): Clear sticky notifications when leaving workflow

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useToast.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useToast.test.ts
@@ -204,4 +204,52 @@ describe('useToast', () => {
 			expect(telemetryTrackSpy).not.toHaveBeenCalled();
 		});
 	});
+
+	describe('clearAllStickyNotifications', () => {
+		it('should close all sticky notifications (duration: 0)', async () => {
+			toast.showMessage({
+				message: 'Sticky notification 1',
+				title: 'Sticky 1',
+				duration: 0,
+			});
+
+			toast.showMessage({
+				message: 'Sticky notification 2',
+				title: 'Sticky 2',
+				duration: 0,
+			});
+
+			await waitFor(() => {
+				expect(screen.getAllByRole('alert')).toHaveLength(2);
+			});
+
+			toast.clearAllStickyNotifications();
+
+			await waitFor(() => {
+				expect(screen.queryAllByRole('alert')).toHaveLength(0);
+			});
+		});
+
+		it('should not affect non-sticky notifications', async () => {
+			toast.showMessage({
+				message: 'Non-sticky notification',
+				title: 'Non-sticky',
+				duration: 5000,
+			});
+
+			await waitFor(() => {
+				expect(screen.getByRole('alert')).toBeVisible();
+			});
+
+			toast.clearAllStickyNotifications();
+
+			await waitFor(() => {
+				expect(screen.getByRole('alert')).toBeVisible();
+			});
+		});
+
+		it('should handle being called when there are no sticky notifications', () => {
+			expect(() => toast.clearAllStickyNotifications()).not.toThrow();
+		});
+	});
 });

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -1931,8 +1931,6 @@ onBeforeRouteLeave(async (to, from, next) => {
 			return true;
 		},
 	});
-
-	toast.clearAllStickyNotifications();
 });
 
 /**
@@ -2003,6 +2001,7 @@ onActivated(() => {
 onDeactivated(() => {
 	uiStore.closeModal(WORKFLOW_SETTINGS_MODAL_KEY);
 	removeUndoRedoEventBindings();
+	toast.clearAllStickyNotifications();
 });
 
 onBeforeUnmount(() => {

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -1931,6 +1931,8 @@ onBeforeRouteLeave(async (to, from, next) => {
 			return true;
 		},
 	});
+
+	toast.clearAllStickyNotifications();
 });
 
 /**


### PR DESCRIPTION
## Summary

Clear all sticky notifications (like node execution errors) when navigating away from a workflow. This prevents error toasts from one workflow persisting and displaying on other pages like the homepage or new workflow canvas.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-3802

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)