### PR TITLE
fix: Backfill missing workflow history records

### DIFF
--- a/packages/@n8n/db/src/migrations/common/1765448186933-BackfillMissingWorkflowHistoryRecords.ts
+++ b/packages/@n8n/db/src/migrations/common/1765448186933-BackfillMissingWorkflowHistoryRecords.ts
@@ -1,0 +1,48 @@
+import type { IrreversibleMigration, MigrationContext } from '../migration-types';
+
+// Some users still have missing workflow history records after pulling workflows using source control feature
+export class BackfillMissingWorkflowHistoryRecords1765448186933 implements IrreversibleMigration {
+	async up({ escape, runQuery }: MigrationContext) {
+		const workflowTable = escape.tableName('workflow_entity');
+		const historyTable = escape.tableName('workflow_history');
+		const versionIdColumn = escape.columnName('versionId');
+		const idColumn = escape.columnName('id');
+		const workflowIdColumn = escape.columnName('workflowId');
+		const nodesColumn = escape.columnName('nodes');
+		const connectionsColumn = escape.columnName('connections');
+		const authorsColumn = escape.columnName('authors');
+		const createdAtColumn = escape.columnName('createdAt');
+		const updatedAtColumn = escape.columnName('updatedAt');
+
+		await runQuery(
+			`
+            INSERT INTO ${historyTable} (
+                ${versionIdColumn},
+                ${workflowIdColumn},
+                ${authorsColumn},
+                ${nodesColumn},
+                ${connectionsColumn},
+                ${createdAtColumn},
+                ${updatedAtColumn}
+            )
+            SELECT
+                w.${versionIdColumn},
+                w.${idColumn},
+                :authors,
+                w.${nodesColumn},
+                w.${connectionsColumn},
+                :createdAt,
+                :updatedAt
+            FROM ${workflowTable} w
+            LEFT JOIN ${historyTable} wh
+                ON w.${versionIdColumn} = wh.${versionIdColumn}
+            WHERE wh.${versionIdColumn} IS NULL
+            `,
+			{
+				authors: 'system migration',
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		);
+	}
+}

--- a/packages/@n8n/db/src/migrations/mysqldb/index.ts
+++ b/packages/@n8n/db/src/migrations/mysqldb/index.ts
@@ -123,6 +123,7 @@ import { CreateWorkflowPublishHistoryTable1764167920585 } from '../common/176416
 import { AddCreatorIdToProjectTable1764276827837 } from '../common/1764276827837-AddCreatorIdToProjectTable';
 import { CreateDynamicCredentialResolverTable1764682447000 } from '../common/1764682447000-CreateCredentialResolverTable';
 import { AddDynamicCredentialEntryTable1764689388394 } from '../common/1764689388394-AddDynamicCredentialEntryTable';
+import { BackfillMissingWorkflowHistoryRecords1765448186933 } from '../common/1765448186933-BackfillMissingWorkflowHistoryRecords';
 import type { Migration } from '../migration-types';
 
 export const mysqlMigrations: Migration[] = [
@@ -251,4 +252,5 @@ export const mysqlMigrations: Migration[] = [
 	AddCreatorIdToProjectTable1764276827837,
 	CreateDynamicCredentialResolverTable1764682447000,
 	AddDynamicCredentialEntryTable1764689388394,
+	BackfillMissingWorkflowHistoryRecords1765448186933,
 ];

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -123,6 +123,7 @@ import { CreateWorkflowPublishHistoryTable1764167920585 } from '../common/176416
 import { AddCreatorIdToProjectTable1764276827837 } from '../common/1764276827837-AddCreatorIdToProjectTable';
 import { CreateDynamicCredentialResolverTable1764682447000 } from '../common/1764682447000-CreateCredentialResolverTable';
 import { AddDynamicCredentialEntryTable1764689388394 } from '../common/1764689388394-AddDynamicCredentialEntryTable';
+import { BackfillMissingWorkflowHistoryRecords1765448186933 } from '../common/1765448186933-BackfillMissingWorkflowHistoryRecords';
 import type { Migration } from '../migration-types';
 
 export const postgresMigrations: Migration[] = [
@@ -251,4 +252,5 @@ export const postgresMigrations: Migration[] = [
 	AddCreatorIdToProjectTable1764276827837,
 	CreateDynamicCredentialResolverTable1764682447000,
 	AddDynamicCredentialEntryTable1764689388394,
+	BackfillMissingWorkflowHistoryRecords1765448186933,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -119,6 +119,7 @@ import { CreateBinaryDataTable1763716655000 } from '../common/1763716655000-Crea
 import { CreateWorkflowPublishHistoryTable1764167920585 } from '../common/1764167920585-CreateWorkflowPublishHistoryTable';
 import { CreateDynamicCredentialResolverTable1764682447000 } from '../common/1764682447000-CreateCredentialResolverTable';
 import { AddDynamicCredentialEntryTable1764689388394 } from '../common/1764689388394-AddDynamicCredentialEntryTable';
+import { BackfillMissingWorkflowHistoryRecords1765448186933 } from '../common/1765448186933-BackfillMissingWorkflowHistoryRecords';
 import type { Migration } from '../migration-types';
 
 const sqliteMigrations: Migration[] = [
@@ -243,6 +244,7 @@ const sqliteMigrations: Migration[] = [
 	AddCreatorIdToProjectTable1764276827837,
 	CreateDynamicCredentialResolverTable1764682447000,
 	AddDynamicCredentialEntryTable1764689388394,
+	BackfillMissingWorkflowHistoryRecords1765448186933,
 ];
 
 export { sqliteMigrations };


### PR DESCRIPTION
## Summary

Those users, for whom the migration to add `activeVersionId` ran successfully after the [last fix](https://github.com/n8n-io/n8n/pull/22974), ended up with missing records in workflow history. I assumed that when pulling changes to their instance, their data will be fixed, but I didn't consider the fact that during pulling we don't have a mechanism to pull even unchanged workflows, so it's better to run the migration again to fix the corrupted data.

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-4530](https://linear.app/n8n/issue/ADO-4530/bug-source-control-users-have-workflow-versions-not-existing-in)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
