### PR TITLE
feat: Set `autosave` for history versions (no-changelog)

### DIFF
--- a/packages/@n8n/backend-test-utils/src/db/workflows.ts
+++ b/packages/@n8n/backend-test-utils/src/db/workflows.ts
@@ -240,11 +240,14 @@ export const getWorkflowById = async (id: string) =>
  * Create a workflow history record for a workflow
  * @param workflow workflow to create history for
  * @param user user who created the version (optional)
+ * @param withPublishHistory publish history to create (optional)
+ * @param autosaved whether this is an autosave (optional)
  */
 export async function createWorkflowHistory(
 	workflow: IWorkflowDb,
 	userOrProject?: User | Project,
 	withPublishHistory?: Partial<WorkflowPublishHistory>,
+	autosaved = false,
 ): Promise<void> {
 	const authors =
 		userOrProject instanceof User
@@ -259,6 +262,7 @@ export async function createWorkflowHistory(
 		nodes: workflow.nodes,
 		connections: workflow.connections,
 		authors,
+		autosaved,
 	});
 
 	if (withPublishHistory) {

--- a/packages/@n8n/db/src/entities/workflow-history.ts
+++ b/packages/@n8n/db/src/entities/workflow-history.ts
@@ -29,6 +29,9 @@ export class WorkflowHistory extends WithTimestamps {
 	@Column({ type: 'text', nullable: true })
 	description: string | null;
 
+	@Column({ default: false })
+	autosaved: boolean;
+
 	@ManyToOne('WorkflowEntity', {
 		onDelete: 'CASCADE',
 	})

--- a/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
@@ -151,7 +151,9 @@ export = {
 					publicApi: true,
 				});
 
-				return res.json(version);
+				const { autosaved, ...versionWithoutInternalFields } = version;
+
+				return res.json(versionWithoutInternalFields);
 			} catch (error) {
 				return res.status(404).json({ message: 'Version not found' });
 			}

--- a/packages/cli/src/workflows/workflow-history/__tests__/workflow-history.service.test.ts
+++ b/packages/cli/src/workflows/workflow-history/__tests__/workflow-history.service.test.ts
@@ -46,6 +46,51 @@ describe('WorkflowHistoryService', () => {
 				nodes: workflow.nodes,
 				versionId: workflow.versionId,
 				workflowId,
+				autosaved: false,
+			});
+		});
+
+		it('should save a new version with autosaved: true when autosaved parameter is true', async () => {
+			// Arrange
+			const workflow = getWorkflow({ addNodeWithoutCreds: true });
+			const workflowId = '123';
+			workflow.connections = {};
+			workflow.id = workflowId;
+			workflow.versionId = '456';
+
+			// Act
+			await workflowHistoryService.saveVersion(testUser, workflow, workflowId, true);
+
+			// Assert
+			expect(workflowHistoryRepository.insert).toHaveBeenCalledWith({
+				authors: 'John Doe',
+				connections: {},
+				nodes: workflow.nodes,
+				versionId: workflow.versionId,
+				workflowId,
+				autosaved: true,
+			});
+		});
+
+		it('should save a new version with autosaved: false when autosaved parameter is false', async () => {
+			// Arrange
+			const workflow = getWorkflow({ addNodeWithoutCreds: true });
+			const workflowId = '123';
+			workflow.connections = {};
+			workflow.id = workflowId;
+			workflow.versionId = '456';
+
+			// Act
+			await workflowHistoryService.saveVersion(testUser, workflow, workflowId, false);
+
+			// Assert
+			expect(workflowHistoryRepository.insert).toHaveBeenCalledWith({
+				authors: 'John Doe',
+				connections: {},
+				nodes: workflow.nodes,
+				versionId: workflow.versionId,
+				workflowId,
+				autosaved: false,
 			});
 		});
 

--- a/packages/cli/src/workflows/workflow-history/workflow-history.service.ts
+++ b/packages/cli/src/workflows/workflow-history/workflow-history.service.ts
@@ -100,6 +100,7 @@ export class WorkflowHistoryService {
 		user: User | string,
 		workflow: IWorkflowBase,
 		workflowId: string,
+		autosaved = false,
 		transactionManager?: EntityManager,
 	) {
 		if (!workflow.nodes || !workflow.connections) {
@@ -121,6 +122,7 @@ export class WorkflowHistoryService {
 				nodes: workflow.nodes,
 				versionId: workflow.versionId,
 				workflowId,
+				autosaved,
 			});
 		} catch (e) {
 			const error = ensureError(e);

--- a/packages/cli/src/workflows/workflow.request.ts
+++ b/packages/cli/src/workflows/workflow.request.ts
@@ -29,6 +29,7 @@ export declare namespace WorkflowRequest {
 		uiContext?: string;
 		expectedChecksum?: string;
 		aiBuilderAssisted?: boolean;
+		autosaved?: boolean;
 	}>;
 
 	// TODO: Use a discriminator when CAT-1809 lands

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -234,6 +234,7 @@ export class WorkflowService {
 			publishIfActive?: boolean;
 			aiBuilderAssisted?: boolean;
 			expectedChecksum?: string;
+			autosaved?: boolean;
 		} = {},
 	): Promise<WorkflowEntity> {
 		const {
@@ -244,6 +245,7 @@ export class WorkflowService {
 			publicApi = false,
 			publishIfActive = false,
 			aiBuilderAssisted = false,
+			autosaved = false,
 		} = options;
 		const workflow = await this.workflowFinderService.findWorkflowForUser(
 			workflowId,
@@ -358,7 +360,12 @@ export class WorkflowService {
 
 		// Save the workflow to history first, so we can retrieve the complete version object for the update
 		if (saveNewVersion) {
-			await this.workflowHistoryService.saveVersion(user, workflowUpdateData, workflowId);
+			await this.workflowHistoryService.saveVersion(
+				user,
+				workflowUpdateData,
+				workflowId,
+				autosaved,
+			);
 		}
 
 		const publishCurrent = workflow.activeVersionId && publishIfActive;

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -113,6 +113,8 @@ export class WorkflowsController {
 			req.body.active = false;
 		}
 
+		const { autosaved = false } = req.body;
+
 		const newWorkflow = new WorkflowEntity();
 
 		Object.assign(newWorkflow, req.body);
@@ -208,6 +210,7 @@ export class WorkflowsController {
 				req.user,
 				workflow,
 				workflow.id,
+				autosaved,
 				transactionManager,
 			);
 
@@ -429,7 +432,8 @@ export class WorkflowsController {
 		const forceSave = req.query.forceSave === 'true';
 
 		let updateData = new WorkflowEntity();
-		const { tags, parentFolderId, aiBuilderAssisted, expectedChecksum, ...rest } = req.body;
+		const { tags, parentFolderId, aiBuilderAssisted, expectedChecksum, autosaved, ...rest } =
+			req.body;
 
 		// TODO: Add zod validation for entire `rest` object before assigning to `updateData`
 		if (
@@ -456,6 +460,7 @@ export class WorkflowsController {
 			forceSave: isSharingEnabled ? forceSave : true,
 			expectedChecksum,
 			aiBuilderAssisted,
+			autosaved,
 		});
 
 		const scopes = await this.workflowService.getWorkflowScopes(req.user, workflowId);

--- a/packages/cli/test/integration/shared/db/workflow-history.ts
+++ b/packages/cli/test/integration/shared/db/workflow-history.ts
@@ -22,6 +22,7 @@ export async function createWorkflowHistoryItem(
 		],
 		versionId: uuid(),
 		workflowPublishHistory: [],
+		autosaved: false,
 		...(data ?? {}),
 		workflowId,
 	});

--- a/packages/cli/test/integration/workflow-history.api.test.ts
+++ b/packages/cli/test/integration/workflow-history.api.test.ts
@@ -58,17 +58,23 @@ describe('GET /workflow-history/:workflowId', () => {
 				),
 		);
 
-		const last = versions.sort((a, b) => b.createdAt.valueOf() - a.createdAt.valueOf())[0] as any;
-		delete last.nodes;
-		delete last.connections;
+		const last = versions.sort((a, b) => b.createdAt.valueOf() - a.createdAt.valueOf())[0];
 
-		last.createdAt = last.createdAt.toISOString();
-		last.updatedAt = last.updatedAt.toISOString();
+		const expected = {
+			versionId: last.versionId,
+			workflowId: last.workflowId,
+			authors: last.authors,
+			name: last.name,
+			description: last.description,
+			createdAt: last.createdAt.toISOString(),
+			updatedAt: last.updatedAt.toISOString(),
+			workflowPublishHistory: last.workflowPublishHistory,
+		};
 
 		const resp = await authOwnerAgent.get('/workflow-history/workflow/' + workflow.id);
 		expect(resp.status).toBe(200);
 		expect(resp.body.data).toHaveLength(10);
-		expect(resp.body.data[0]).toEqual(last);
+		expect(resp.body.data[0]).toEqual(expected);
 	});
 
 	test('should return versions only for workflow id provided', async () => {
@@ -87,17 +93,23 @@ describe('GET /workflow-history/:workflowId', () => {
 			new Array(10).fill(undefined).map(async (_) => await createWorkflowHistoryItem(workflow2.id)),
 		);
 
-		const last = versions.sort((a, b) => b.createdAt.valueOf() - a.createdAt.valueOf())[0] as any;
-		delete last.nodes;
-		delete last.connections;
+		const last = versions.sort((a, b) => b.createdAt.valueOf() - a.createdAt.valueOf())[0];
 
-		last.createdAt = last.createdAt.toISOString();
-		last.updatedAt = last.updatedAt.toISOString();
+		const expected = {
+			versionId: last.versionId,
+			workflowId: last.workflowId,
+			authors: last.authors,
+			name: last.name,
+			description: last.description,
+			createdAt: last.createdAt.toISOString(),
+			updatedAt: last.updatedAt.toISOString(),
+			workflowPublishHistory: last.workflowPublishHistory,
+		};
 
 		const resp = await authOwnerAgent.get('/workflow-history/workflow/' + workflow.id);
 		expect(resp.status).toBe(200);
 		expect(resp.body.data).toHaveLength(10);
-		expect(resp.body.data[0]).toEqual(last);
+		expect(resp.body.data[0]).toEqual(expected);
 	});
 
 	test('should work with take parameter', async () => {
@@ -111,17 +123,23 @@ describe('GET /workflow-history/:workflowId', () => {
 				),
 		);
 
-		const last = versions.sort((a, b) => b.createdAt.valueOf() - a.createdAt.valueOf())[0] as any;
-		delete last.nodes;
-		delete last.connections;
+		const last = versions.sort((a, b) => b.createdAt.valueOf() - a.createdAt.valueOf())[0];
 
-		last.createdAt = last.createdAt.toISOString();
-		last.updatedAt = last.updatedAt.toISOString();
+		const expected = {
+			versionId: last.versionId,
+			workflowId: last.workflowId,
+			authors: last.authors,
+			name: last.name,
+			description: last.description,
+			createdAt: last.createdAt.toISOString(),
+			updatedAt: last.updatedAt.toISOString(),
+			workflowPublishHistory: last.workflowPublishHistory,
+		};
 
 		const resp = await authOwnerAgent.get(`/workflow-history/workflow/${workflow.id}?take=5`);
 		expect(resp.status).toBe(200);
 		expect(resp.body.data).toHaveLength(5);
-		expect(resp.body.data[0]).toEqual(last);
+		expect(resp.body.data[0]).toEqual(expected);
 	});
 
 	test('should work with skip parameter', async () => {
@@ -135,19 +153,25 @@ describe('GET /workflow-history/:workflowId', () => {
 				),
 		);
 
-		const last = versions.sort((a, b) => b.createdAt.valueOf() - a.createdAt.valueOf())[5] as any;
-		delete last.nodes;
-		delete last.connections;
+		const last = versions.sort((a, b) => b.createdAt.valueOf() - a.createdAt.valueOf())[5];
 
-		last.createdAt = last.createdAt.toISOString();
-		last.updatedAt = last.updatedAt.toISOString();
+		const expected = {
+			versionId: last.versionId,
+			workflowId: last.workflowId,
+			authors: last.authors,
+			name: last.name,
+			description: last.description,
+			createdAt: last.createdAt.toISOString(),
+			updatedAt: last.updatedAt.toISOString(),
+			workflowPublishHistory: last.workflowPublishHistory,
+		};
 
 		const resp = await authOwnerAgent.get(
 			`/workflow-history/workflow/${workflow.id}?skip=5&take=20`,
 		);
 		expect(resp.status).toBe(200);
 		expect(resp.body.data).toHaveLength(5);
-		expect(resp.body.data[0]).toEqual(last);
+		expect(resp.body.data[0]).toEqual(expected);
 	});
 
 	test('should include workflowPublishHistory records related to each history item', async () => {

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -260,6 +260,83 @@ describe('POST /workflows', () => {
 		expect(historyVersion!.nodes).toEqual(payload.nodes);
 	});
 
+	test('should set autosaved: true in workflow history when autosaved parameter is sent', async () => {
+		const payload = {
+			name: 'testing autosave',
+			nodes: [
+				{
+					id: 'uuid-1234',
+					parameters: {},
+					name: 'Start',
+					type: 'n8n-nodes-base.start',
+					typeVersion: 1,
+					position: [240, 300],
+				},
+			],
+			connections: {},
+			staticData: null,
+			settings: {},
+			active: false,
+			activeVersionId: null,
+			autosaved: true,
+		};
+
+		const response = await authOwnerAgent.post('/workflows').send(payload);
+
+		expect(response.statusCode).toBe(200);
+
+		const {
+			data: { id },
+		} = response.body as { data: WorkflowEntity };
+
+		expect(id).toBeDefined();
+		const historyVersion = await workflowHistoryRepository.findOne({
+			where: {
+				workflowId: id,
+			},
+		});
+		expect(historyVersion).not.toBeNull();
+		expect(historyVersion!.autosaved).toBe(true);
+	});
+
+	test('should set autosaved: false in workflow history when autosaved is not sent', async () => {
+		const payload = {
+			name: 'testing manual save',
+			nodes: [
+				{
+					id: 'uuid-1234',
+					parameters: {},
+					name: 'Start',
+					type: 'n8n-nodes-base.start',
+					typeVersion: 1,
+					position: [240, 300],
+				},
+			],
+			connections: {},
+			staticData: null,
+			settings: {},
+			active: false,
+			activeVersionId: null,
+		};
+
+		const response = await authOwnerAgent.post('/workflows').send(payload);
+
+		expect(response.statusCode).toBe(200);
+
+		const {
+			data: { id },
+		} = response.body as { data: WorkflowEntity };
+
+		expect(id).toBeDefined();
+		const historyVersion = await workflowHistoryRepository.findOne({
+			where: {
+				workflowId: id,
+			},
+		});
+		expect(historyVersion).not.toBeNull();
+		expect(historyVersion!.autosaved).toBe(false);
+	});
+
 	test('should create workflow as inactive even when active: true is provided in POST body', async () => {
 		const payload = {
 			name: 'active workflow',
@@ -2649,6 +2726,69 @@ describe('PATCH /workflows/:workflowId', () => {
 		const versions = await workflowHistoryRepository.find({ where: { workflowId: id } });
 		expect(versions).toHaveLength(1);
 		expect(versions[0].versionId).toBe(workflow.versionId);
+	});
+
+	test('should set autosaved: true in workflow history when autosaved parameter is sent on update', async () => {
+		const workflow = await createWorkflowWithHistory({}, owner);
+		const payload = {
+			nodes: [
+				{
+					id: 'uuid-5678',
+					parameters: {},
+					name: 'Cron',
+					type: 'n8n-nodes-base.cron',
+					typeVersion: 1,
+					position: [400, 300],
+				},
+			],
+			connections: {},
+			autosaved: true,
+		};
+
+		const response = await authOwnerAgent.patch(`/workflows/${workflow.id}`).send(payload);
+
+		expect(response.statusCode).toBe(200);
+
+		const {
+			data: { id, versionId: updatedVersionId },
+		} = response.body as { data: WorkflowEntity };
+
+		const versions = await workflowHistoryRepository.find({ where: { workflowId: id } });
+		expect(versions).toHaveLength(2);
+		const newVersion = versions.find((v) => v.versionId === updatedVersionId);
+		expect(newVersion).not.toBeNull();
+		expect(newVersion!.autosaved).toBe(true);
+	});
+
+	test('should set autosaved: false in workflow history when autosaved is not sent on update', async () => {
+		const workflow = await createWorkflowWithHistory({}, owner);
+		const payload = {
+			nodes: [
+				{
+					id: 'uuid-5678',
+					parameters: {},
+					name: 'Cron',
+					type: 'n8n-nodes-base.cron',
+					typeVersion: 1,
+					position: [400, 300],
+				},
+			],
+			connections: {},
+		};
+
+		const response = await authOwnerAgent.patch(`/workflows/${workflow.id}`).send(payload);
+
+		expect(response.statusCode).toBe(200);
+
+		const {
+			data: { id, versionId: updatedVersionId },
+		} = response.body as { data: WorkflowEntity };
+
+		const versions = await workflowHistoryRepository.find({ where: { workflowId: id } });
+		expect(versions).toHaveLength(2);
+		const newVersion = versions.find((v) => v.versionId === updatedVersionId);
+		expect(newVersion).not.toBeNull();
+		expect(newVersion!.autosaved).toBe(false);
 	});
 
 	test('should ignore provided version id', async () => {

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -1730,7 +1730,7 @@ describe('GET /workflows', () => {
 
 			const response = await authOwnerAgent
 				.get('/workflows')
-				.query('take=2&skip=1')
+				.query('sortBy=name:asc&take=2&skip=1')
 				.query('filter={"query":"Special"}')
 				.expect(200);
 
@@ -2599,7 +2599,7 @@ describe('GET /workflows?includeFolders=true', () => {
 
 			const response = await authOwnerAgent
 				.get('/workflows')
-				.query('take=2&skip=1')
+				.query('sortBy=name:asc&take=2&skip=1')
 				.query('filter={"query":"Special"}&includeFolders=true')
 				.expect(200);
 

--- a/packages/frontend/@n8n/rest-api-client/src/api/workflows.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/api/workflows.ts
@@ -41,6 +41,7 @@ export interface WorkflowDataUpdate {
 	// checksum of workflow snapshot for conflict detection
 	expectedChecksum?: string;
 	aiBuilderAssisted?: boolean;
+	autosaved?: boolean;
 }
 
 export interface WorkflowDataCreate extends WorkflowDataUpdate {

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
@@ -81,6 +81,7 @@ describe('useWorkflowSaving', () => {
 	afterEach(() => {
 		vi.clearAllMocks();
 	});
+
 	beforeEach(() => {
 		setActivePinia(createTestingPinia({ stubActions: false }));
 
@@ -304,6 +305,7 @@ describe('useWorkflowSaving', () => {
 			expect(next).toHaveBeenCalledWith(resolveMarker);
 		});
 	});
+
 	describe('saveAsNewWorkflow', () => {
 		it('should respect `resetWebhookUrls: false` when duplicating workflows', async () => {
 			const workflow = getDuplicateTestWorkflow();
@@ -349,6 +351,7 @@ describe('useWorkflowSaving', () => {
 			expect(pathsPreSave).not.toEqual(pathsPostSave);
 		});
 	});
+
 	describe('saveCurrentWorkflow', () => {
 		it('should save the current workflow', async () => {
 			const workflow = createTestWorkflow({
@@ -388,6 +391,48 @@ describe('useWorkflowSaving', () => {
 			expect(workflowsStore.updateWorkflow).toHaveBeenCalledWith(
 				'w1',
 				expect.objectContaining({ id: 'w1' }),
+				false,
+			);
+		});
+
+		it('should send autosaved: true when autosaved parameter is true', async () => {
+			const workflow = createTestWorkflow({
+				id: 'w2',
+				nodes: [createTestNode({ type: CHAT_TRIGGER_NODE_TYPE, disabled: false })],
+				active: true,
+			});
+
+			vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue(workflow);
+			vi.spyOn(workflowsStore, 'updateWorkflow').mockResolvedValue(workflow);
+
+			workflowsStore.setWorkflow(workflow);
+
+			const { saveCurrentWorkflow } = useWorkflowSaving({ router });
+			await saveCurrentWorkflow({ id: 'w2' }, true, false, true);
+			expect(workflowsStore.updateWorkflow).toHaveBeenCalledWith(
+				'w2',
+				expect.objectContaining({ id: 'w2', active: true, autosaved: true }),
+				false,
+			);
+		});
+
+		it('should send autosaved: false when autosaved parameter is false', async () => {
+			const workflow = createTestWorkflow({
+				id: 'w3',
+				nodes: [createTestNode({ type: CHAT_TRIGGER_NODE_TYPE, disabled: false })],
+				active: true,
+			});
+
+			vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue(workflow);
+			vi.spyOn(workflowsStore, 'updateWorkflow').mockResolvedValue(workflow);
+
+			workflowsStore.setWorkflow(workflow);
+
+			const { saveCurrentWorkflow } = useWorkflowSaving({ router });
+			await saveCurrentWorkflow({ id: 'w3' }, true, false, false);
+			expect(workflowsStore.updateWorkflow).toHaveBeenCalledWith(
+				'w3',
+				expect.objectContaining({ id: 'w3', active: true, autosaved: false }),
 				false,
 			);
 		});


### PR DESCRIPTION
## Summary

This PR adds a possibility to send `autosave` for create and update workflow endpoints and updates frontend to send it as well, with `false` by default (we will start sending "autosave=true" when autosave will be implemented).
I also updated two flaky unrelated tests.

One important reason to distinguish between autosaves and other saves is saving from AI Workflow Builder which might be using another field or just rely on `autosave=false`.

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-4531](https://linear.app/n8n/issue/ADO-4531/refactor-add-a-possibility-to-set-autosave-on-workflow-history)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
