### PR TITLE
fix(editor): Sync sidebar state (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/stores/ui.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/ui.store.ts
@@ -263,8 +263,7 @@ export const useUIStore = defineStore(STORES.UI, () => {
 	});
 
 	const modalStack = ref<string[]>([]);
-	const sidebarMenuCollapsedPreference = useLocalStorage<boolean>('sidebar.collapsed', true);
-	const sidebarMenuCollapsed = ref<boolean>(sidebarMenuCollapsedPreference.value);
+	const sidebarMenuCollapsed = useLocalStorage<boolean>('sidebar.collapsed', true);
 	const currentView = ref<string>('');
 	const stateIsDirty = ref<boolean>(false);
 	const lastSelectedNode = ref<string | null>(null);
@@ -570,9 +569,7 @@ export const useUIStore = defineStore(STORES.UI, () => {
 	};
 
 	const toggleSidebarMenuCollapse = () => {
-		const newCollapsedState = !sidebarMenuCollapsed.value;
-		sidebarMenuCollapsedPreference.value = newCollapsedState;
-		sidebarMenuCollapsed.value = newCollapsedState;
+		sidebarMenuCollapsed.value = !sidebarMenuCollapsed.value;
 	};
 
 	const setNotificationsForView = (view: VIEWS, notifications: NotificationOptions[]) => {
@@ -680,7 +677,6 @@ export const useUIStore = defineStore(STORES.UI, () => {
 		nodeViewInitialized,
 		addFirstStepOnLoad,
 		sidebarMenuCollapsed,
-		sidebarMenuCollapsedPreference,
 		theme: computed(() => theme.value),
 		modalsById,
 		currentView,


### PR DESCRIPTION
## Summary
Fixes an issue with sidebar state not syncing correctly between browser windows.
<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DS-431/sidebar-state-not-syncing-in-different-windows

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
