### PR TITLE
fix : AI Agent Node- "Max Iterations" limit triggers Success output instead of Error output 

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/execute.ts
@@ -7,7 +7,7 @@ import type {
 	EngineResponse,
 } from 'n8n-workflow';
 
-import { buildExecutionContext, executeBatch, checkMaxIterations } from './helpers';
+import { buildExecutionContext, executeBatch } from './helpers';
 import type { RequestResponseMetadata } from './types';
 
 /* -----------------------------------------------------------
@@ -30,10 +30,6 @@ export async function toolsAgentExecute(
 	response?: EngineResponse<RequestResponseMetadata>,
 ): Promise<INodeExecutionData[][] | EngineRequest<RequestResponseMetadata>> {
 	this.logger.debug('Executing Tools Agent V3');
-
-	// Check max iterations if this is a continuation of a previous execution
-	const maxIterations = this.getNodeParameter('options.maxIterations', 0, 10) as number;
-	checkMaxIterations(response, maxIterations, this.getNode());
 
 	const returnData: INodeExecutionData[] = [];
 	let request: EngineRequest<RequestResponseMetadata> | undefined = undefined;

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/runAgent.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/runAgent.ts
@@ -16,6 +16,7 @@ import {
 } from '@utils/agent-execution';
 
 import { SYSTEM_MESSAGE } from '../../prompt';
+import { checkMaxIterations } from './checkMaxIterations';
 import type { AgentResult, RequestResponseMetadata } from '../types';
 import { buildResponseMetadata } from './buildResponseMetadata';
 import type { ItemContext } from './prepareItemContext';
@@ -41,6 +42,10 @@ export async function runAgent(
 	memory: BaseChatMemory | undefined,
 	response?: EngineResponse<RequestResponseMetadata>,
 ): Promise<RunAgentResult> {
+	// Check max iterations if this is a continuation of a previous execution
+	const maxIterations = ctx.getNodeParameter('options.maxIterations', 0, 10) as number;
+	checkMaxIterations(response, maxIterations, ctx.getNode());
+
 	const { itemIndex, input, steps, tools, options } = itemContext;
 
 	const invokeParams = {


### PR DESCRIPTION

## Summary

This PR solves the routing of maxiteration error to the error branch if continue on fail is enabled. 
Working Screenshot:
<img width="1227" height="550" alt="image" src="https://github.com/user-attachments/assets/c9f20a83-93d0-4772-8f99-aa7f247dbb20" />

## Related Linear tickets, Github issues, and Community forum posts

fixes #22771 


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
