### PR TITLE
chore(core): Skip dynamic credentials for manual executions

### DIFF
--- a/packages/cli/src/credentials-helper.ts
+++ b/packages/cli/src/credentials-helper.ts
@@ -358,20 +358,26 @@ export class CredentialsHelper extends ICredentialsHelper {
 		);
 		let decryptedDataOriginal = credentials.getData();
 
-		// Resolve dynamic credentials if configured (EE feature)
-		decryptedDataOriginal = await this.dynamicCredentialsProxy.resolveIfNeeded(
-			{
-				id: credentialsEntity.id,
-				name: credentialsEntity.name,
-				type: credentialsEntity.type,
-				isResolvable: credentialsEntity.isResolvable,
-				resolverId: credentialsEntity.resolverId ?? undefined,
-				resolvableAllowFallback: credentialsEntity.resolvableAllowFallback,
-			},
-			decryptedDataOriginal,
-			additionalData.executionContext,
-			additionalData.workflowSettings,
-		);
+		/**
+		 * We skip dynamic credentials resolution for manual triggers,
+		 * this helps workflow developers to run workflows with static credentials.
+		 */
+		if (additionalData.executionContext?.triggerNode?.type !== 'n8n-nodes-base.manualTrigger') {
+			// Resolve dynamic credentials if configured (EE feature)
+			decryptedDataOriginal = await this.dynamicCredentialsProxy.resolveIfNeeded(
+				{
+					id: credentialsEntity.id,
+					name: credentialsEntity.name,
+					type: credentialsEntity.type,
+					isResolvable: credentialsEntity.isResolvable,
+					resolverId: credentialsEntity.resolverId ?? undefined,
+					resolvableAllowFallback: credentialsEntity.resolvableAllowFallback,
+				},
+				decryptedDataOriginal,
+				additionalData.executionContext,
+				additionalData.workflowSettings,
+			);
+		}
 
 		if (raw === true) {
 			return decryptedDataOriginal;

--- a/packages/core/src/execution-engine/__tests__/execution-context.test.ts
+++ b/packages/core/src/execution-engine/__tests__/execution-context.test.ts
@@ -238,7 +238,7 @@ describe('establishExecutionContext', () => {
 			const context = runExecutionData.executionData!.runtimeData;
 
 			// Verify context has only expected properties
-			expect(Object.keys(context!)).toEqual(['version', 'establishedAt', 'source']);
+			expect(Object.keys(context!)).toEqual(['version', 'establishedAt', 'source', 'triggerNode']);
 			expect(typeof context!.version).toBe('number');
 			expect(typeof context!.establishedAt).toBe('number');
 			expect(context!.source).toBe('manual');

--- a/packages/core/src/execution-engine/execution-context.ts
+++ b/packages/core/src/execution-engine/execution-context.ts
@@ -162,6 +162,12 @@ export const establishExecutionContext = async (
 		return;
 	}
 
+	// Store basic trigger node info in the context for reference
+	executionData.runtimeData.triggerNode = {
+		name: startItem.node.name,
+		type: startItem.node.type,
+	};
+
 	// We were triggered from a parent execution
 	// and can inherit context from there
 	if (startItem.metadata?.parentExecution?.executionContext) {

--- a/packages/workflow/src/execution-context.ts
+++ b/packages/workflow/src/execution-context.ts
@@ -58,6 +58,16 @@ const ExecutionContextSchemaV1 = z.object({
 	source: WorkflowExecuteModeSchema,
 
 	/**
+	 * Optional node where execution started
+	 */
+	triggerNode: z
+		.object({
+			name: z.string(),
+			type: z.string(),
+		})
+		.optional(),
+
+	/**
 	 * Optional ID of the parent execution, if this is set this
 	 * execution context inherited from the mentioned parent execution context.
 	 */


### PR DESCRIPTION
## Summary

Skip dynamic credential resolution for manual trigger executions. Adds trigger node information (name and type) to the execution context, and uses this to conditionally bypass dynamic credential resolution when the workflow is started by a manual trigger (`n8n-nodes-base.manualTrigger`). This prevents unnecessary credential resolution overhead for manually triggered workflow executions.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-4307/use-static-data-for-manual-execution

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
