### PR TITLE
chore(core): Prevent prototype pollution in deep merge

### DIFF
--- a/packages/core/src/utils/deep-merge.ts
+++ b/packages/core/src/utils/deep-merge.ts
@@ -35,6 +35,9 @@ export function deepMerge<T>(target: T, source: Partial<T>): T {
 	const sourceRecord = source as Record<string, unknown>;
 
 	for (const key of Object.keys(sourceRecord)) {
+		// Prevent prototype pollution
+		if (['__proto__', 'constructor', 'prototype'].includes(key)) continue;
+
 		const sourceValue = sourceRecord[key];
 		const targetValue = result[key];
 


### PR DESCRIPTION
## Summary

Prevent prototype solution in recursive deep merge.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-4296/prototype-pollution-vulnerability-detected

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
