### PR TITLE
feat(core): Use credential entity resolver fields on resolving and storing process

### DIFF
--- a/packages/cli/src/__tests__/credentials-helper.test.ts
+++ b/packages/cli/src/__tests__/credentials-helper.test.ts
@@ -417,6 +417,8 @@ describe('CredentialsHelper', () => {
 			name: 'Test Credentials',
 			type: credentialType,
 			data: cipher.encrypt({ apiKey: 'static-key' }),
+			isResolvable: false,
+			resolvableAllowFallback: false,
 		} as CredentialsEntity;
 
 		beforeEach(() => {
@@ -431,6 +433,7 @@ describe('CredentialsHelper', () => {
 
 			const resolvedData = { apiKey: 'dynamic-key' };
 			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue(resolvedData);
+			credentialsRepository.findOneByOrFail.mockResolvedValue(mockCredentialEntity);
 
 			const result = await credentialsHelper.getDecrypted(
 				mockAdditionalData,
@@ -447,6 +450,8 @@ describe('CredentialsHelper', () => {
 					name: mockCredentialEntity.name,
 					isResolvable: false,
 					type: 'testApi',
+					resolverId: undefined,
+					resolvableAllowFallback: false,
 				},
 				{ apiKey: 'static-key' },
 				mockAdditionalData.executionContext,

--- a/packages/cli/src/credentials-helper.ts
+++ b/packages/cli/src/credentials-helper.ts
@@ -363,12 +363,10 @@ export class CredentialsHelper extends ICredentialsHelper {
 			{
 				id: credentialsEntity.id,
 				name: credentialsEntity.name,
-				isResolvable: false,
 				type: credentialsEntity.type,
-				// TODO: use the actual values from the entity once they are added
-				// isResolvable: credentialsEntity.isResolvable,
-				// resolverId: (credentialsEntity as any).resolverId,
-				// resolvableAllowFallback: (credentialsEntity as any).resolvableAllowFallback,
+				isResolvable: credentialsEntity.isResolvable,
+				resolverId: credentialsEntity.resolverId ?? undefined,
+				resolvableAllowFallback: credentialsEntity.resolvableAllowFallback,
 			},
 			decryptedDataOriginal,
 			additionalData.executionContext,

--- a/packages/cli/src/oauth/__tests__/oauth.service.test.ts
+++ b/packages/cli/src/oauth/__tests__/oauth.service.test.ts
@@ -835,6 +835,8 @@ describe('OauthService', () => {
 				name: 'Test Credential',
 				type: 'googleOAuth2Api',
 				data: 'encrypted-data',
+				isResolvable: true,
+				resolverId: 'resolver-id',
 			});
 			const oauthTokenData = {
 				access_token: 'access-token',
@@ -858,6 +860,7 @@ describe('OauthService', () => {
 					name: 'Test Credential',
 					type: 'googleOAuth2Api',
 					isResolvable: true,
+					resolverId: 'resolver-id',
 				},
 				oauthTokenData,
 				{ version: 1, identity: authToken },

--- a/packages/cli/src/oauth/oauth.service.ts
+++ b/packages/cli/src/oauth/oauth.service.ts
@@ -582,14 +582,12 @@ export class OauthService {
 			id: credential.id,
 			name: credential.name,
 			type: credential.type,
-			isResolvable: true,
+			isResolvable: credential.isResolvable,
+			resolverId: credentialResolverId,
 		};
 
 		await this.dynamicCredentialsProxy.storeIfNeeded(
-			{
-				...credentialStoreMetadata,
-				isResolvable: true,
-			},
+			credentialStoreMetadata,
 			oauthTokenData,
 			//  todo parse this
 			{ version: 1, identity: authHeader },


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR uses the actual credential entity resolver related fields (isResolvable, resolverId and resolvableAllowFallback) to call the credential resolving and dynamic credential entry saving processes

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-4219/audit-credential-access-points


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
