### PR TITLE
feat(core): First shot in resolving the credential resolver config expressions

### DIFF
--- a/packages/@n8n/decorators/src/credential-resolver/credential-resolver.ts
+++ b/packages/@n8n/decorators/src/credential-resolver/credential-resolver.ts
@@ -2,13 +2,14 @@ import type { Constructable } from '@n8n/di';
 import type {
 	ICredentialContext,
 	ICredentialDataDecryptedObject,
+	INodeParameters,
 	INodeProperties,
 } from 'n8n-workflow';
 
 /**
  * Configuration object passed to resolver methods. Structure is defined by resolver type's metadata.options.
  */
-export type CredentialResolverConfiguration = Record<string, unknown>;
+export type CredentialResolverConfiguration = INodeParameters;
 
 export type CredentialResolverHandle = {
 	configuration: CredentialResolverConfiguration;

--- a/packages/@n8n/decorators/src/credential-resolver/credential-resolver.ts
+++ b/packages/@n8n/decorators/src/credential-resolver/credential-resolver.ts
@@ -2,14 +2,13 @@ import type { Constructable } from '@n8n/di';
 import type {
 	ICredentialContext,
 	ICredentialDataDecryptedObject,
-	INodeParameters,
 	INodeProperties,
 } from 'n8n-workflow';
 
 /**
  * Configuration object passed to resolver methods. Structure is defined by resolver type's metadata.options.
  */
-export type CredentialResolverConfiguration = INodeParameters;
+export type CredentialResolverConfiguration = Record<string, unknown>;
 
 export type CredentialResolverHandle = {
 	configuration: CredentialResolverConfiguration;

--- a/packages/cli/src/__tests__/credentials-helper.test.ts
+++ b/packages/cli/src/__tests__/credentials-helper.test.ts
@@ -565,11 +565,8 @@ describe('CredentialsHelper', () => {
 				true,
 			);
 
-			const call = mockCredentialResolutionProvider.resolveIfNeeded.mock.calls[0];
-			expect(call[2]).toBe(additionalDataWithoutContext);
-			expect(call[2].executionContext).toBeUndefined();
-			expect(call[3]).toBe('manual');
-			expect(call[4]).toBe(false); // canUseExternalSecrets
+			expect(mockCredentialResolutionProvider.resolveIfNeeded).not.toHaveBeenCalled();
+			expect(result).toEqual({ apiKey: 'static-key' });
 		});
 
 		test('should skip resolution when credentials context is missing', async () => {

--- a/packages/cli/src/__tests__/credentials-helper.test.ts
+++ b/packages/cli/src/__tests__/credentials-helper.test.ts
@@ -456,8 +456,6 @@ describe('CredentialsHelper', () => {
 					resolvableAllowFallback: false,
 				},
 				{ apiKey: 'static-key' },
-				mockAdditionalData.executionContext,
-				mockAdditionalData.workflowSettings,
 				mockAdditionalData,
 				'manual',
 				false, // canUseExternalSecrets
@@ -479,10 +477,10 @@ describe('CredentialsHelper', () => {
 			);
 
 			const call = mockCredentialResolutionProvider.resolveIfNeeded.mock.calls[0];
-			expect(call[2]).toBe(mockAdditionalData.executionContext);
-			expect(call[4]).toBe(mockAdditionalData);
-			expect(call[5]).toBe('manual');
-			expect(call[6]).toBe(false); // canUseExternalSecrets
+			expect(call[2]).toBe(mockAdditionalData);
+			expect(call[2].executionContext).toBe(mockAdditionalData.executionContext);
+			expect(call[3]).toBe('manual');
+			expect(call[4]).toBe(false); // canUseExternalSecrets
 		});
 
 		test('should pass workflowSettings from additionalData to resolver', async () => {
@@ -499,10 +497,10 @@ describe('CredentialsHelper', () => {
 			);
 
 			const call = mockCredentialResolutionProvider.resolveIfNeeded.mock.calls[0];
-			expect(call[3]).toBe(mockAdditionalData.workflowSettings);
-			expect(call[4]).toBe(mockAdditionalData);
-			expect(call[5]).toBe('manual');
-			expect(call[6]).toBe(false); // canUseExternalSecrets
+			expect(call[2]).toBe(mockAdditionalData);
+			expect(call[2].workflowSettings).toBe(mockAdditionalData.workflowSettings);
+			expect(call[3]).toBe('manual');
+			expect(call[4]).toBe(false); // canUseExternalSecrets
 		});
 
 		test('should skip resolution when credentialResolutionProvider is not set', async () => {
@@ -568,10 +566,10 @@ describe('CredentialsHelper', () => {
 			);
 
 			const call = mockCredentialResolutionProvider.resolveIfNeeded.mock.calls[0];
-			expect(call[2]).toBeUndefined();
-			expect(call[4]).toBe(additionalDataWithoutContext);
-			expect(call[5]).toBe('manual');
-			expect(call[6]).toBe(false); // canUseExternalSecrets
+			expect(call[2]).toBe(additionalDataWithoutContext);
+			expect(call[2].executionContext).toBeUndefined();
+			expect(call[3]).toBe('manual');
+			expect(call[4]).toBe(false); // canUseExternalSecrets
 		});
 
 		test('should skip resolution when credentials context is missing', async () => {
@@ -622,10 +620,10 @@ describe('CredentialsHelper', () => {
 			);
 
 			const call = mockCredentialResolutionProvider.resolveIfNeeded.mock.calls[0];
-			expect(call[3]).toBeUndefined();
-			expect(call[4]).toBe(additionalDataWithoutSettings);
-			expect(call[5]).toBe('manual');
-			expect(call[6]).toBe(false); // canUseExternalSecrets
+			expect(call[2]).toBe(additionalDataWithoutSettings);
+			expect(call[2].workflowSettings).toBeUndefined();
+			expect(call[3]).toBe('manual');
+			expect(call[4]).toBe(false); // canUseExternalSecrets
 		});
 	});
 });

--- a/packages/cli/src/__tests__/credentials-helper.test.ts
+++ b/packages/cli/src/__tests__/credentials-helper.test.ts
@@ -457,7 +457,6 @@ describe('CredentialsHelper', () => {
 				},
 				{ apiKey: 'static-key' },
 				mockAdditionalData,
-				'manual',
 				false, // canUseExternalSecrets
 			);
 			expect(result).toEqual(resolvedData);

--- a/packages/cli/src/__tests__/credentials-helper.test.ts
+++ b/packages/cli/src/__tests__/credentials-helper.test.ts
@@ -478,8 +478,7 @@ describe('CredentialsHelper', () => {
 			const call = mockCredentialResolutionProvider.resolveIfNeeded.mock.calls[0];
 			expect(call[2]).toBe(mockAdditionalData);
 			expect(call[2].executionContext).toBe(mockAdditionalData.executionContext);
-			expect(call[3]).toBe('manual');
-			expect(call[4]).toBe(false); // canUseExternalSecrets
+			expect(call[3]).toBe(false); // canUseExternalSecrets
 		});
 
 		test('should pass workflowSettings from additionalData to resolver', async () => {
@@ -498,8 +497,7 @@ describe('CredentialsHelper', () => {
 			const call = mockCredentialResolutionProvider.resolveIfNeeded.mock.calls[0];
 			expect(call[2]).toBe(mockAdditionalData);
 			expect(call[2].workflowSettings).toBe(mockAdditionalData.workflowSettings);
-			expect(call[3]).toBe('manual');
-			expect(call[4]).toBe(false); // canUseExternalSecrets
+			expect(call[3]).toBe(false); // canUseExternalSecrets
 		});
 
 		test('should skip resolution when credentialResolutionProvider is not set', async () => {
@@ -618,8 +616,7 @@ describe('CredentialsHelper', () => {
 			const call = mockCredentialResolutionProvider.resolveIfNeeded.mock.calls[0];
 			expect(call[2]).toBe(additionalDataWithoutSettings);
 			expect(call[2].workflowSettings).toBeUndefined();
-			expect(call[3]).toBe('manual');
-			expect(call[4]).toBe(false); // canUseExternalSecrets
+			expect(call[3]).toBe(false); // canUseExternalSecrets
 		});
 	});
 });

--- a/packages/cli/src/__tests__/credentials-helper.test.ts
+++ b/packages/cli/src/__tests__/credentials-helper.test.ts
@@ -17,10 +17,10 @@ import type {
 import { deepCopy, Workflow } from 'n8n-workflow';
 
 import { CredentialTypes } from '@/credential-types';
+import { DynamicCredentialsProxy } from '@/credentials/dynamic-credentials-proxy';
 import { CredentialsHelper } from '@/credentials-helper';
 import { CredentialNotFoundError } from '@/errors/credential-not-found.error';
 import type { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
-import { DynamicCredentialsProxy } from '@/credentials/dynamic-credentials-proxy';
 
 describe('CredentialsHelper', () => {
 	const nodeTypes = mock<INodeTypes>();
@@ -458,6 +458,9 @@ describe('CredentialsHelper', () => {
 				{ apiKey: 'static-key' },
 				mockAdditionalData.executionContext,
 				mockAdditionalData.workflowSettings,
+				mockAdditionalData,
+				'manual',
+				false, // canUseExternalSecrets
 			);
 			expect(result).toEqual(resolvedData);
 		});
@@ -477,6 +480,9 @@ describe('CredentialsHelper', () => {
 
 			const call = mockCredentialResolutionProvider.resolveIfNeeded.mock.calls[0];
 			expect(call[2]).toBe(mockAdditionalData.executionContext);
+			expect(call[4]).toBe(mockAdditionalData);
+			expect(call[5]).toBe('manual');
+			expect(call[6]).toBe(false); // canUseExternalSecrets
 		});
 
 		test('should pass workflowSettings from additionalData to resolver', async () => {
@@ -494,6 +500,9 @@ describe('CredentialsHelper', () => {
 
 			const call = mockCredentialResolutionProvider.resolveIfNeeded.mock.calls[0];
 			expect(call[3]).toBe(mockAdditionalData.workflowSettings);
+			expect(call[4]).toBe(mockAdditionalData);
+			expect(call[5]).toBe('manual');
+			expect(call[6]).toBe(false); // canUseExternalSecrets
 		});
 
 		test('should skip resolution when credentialResolutionProvider is not set', async () => {
@@ -558,10 +567,11 @@ describe('CredentialsHelper', () => {
 				true,
 			);
 
-			// Resolution should not happen when executionContext is missing
-			expect(mockCredentialResolutionProvider.resolveIfNeeded).not.toHaveBeenCalled();
-			// Should return static decrypted data
-			expect(result).toEqual({ apiKey: 'static-key' });
+			const call = mockCredentialResolutionProvider.resolveIfNeeded.mock.calls[0];
+			expect(call[2]).toBeUndefined();
+			expect(call[4]).toBe(additionalDataWithoutContext);
+			expect(call[5]).toBe('manual');
+			expect(call[6]).toBe(false); // canUseExternalSecrets
 		});
 
 		test('should skip resolution when credentials context is missing', async () => {
@@ -613,6 +623,9 @@ describe('CredentialsHelper', () => {
 
 			const call = mockCredentialResolutionProvider.resolveIfNeeded.mock.calls[0];
 			expect(call[3]).toBeUndefined();
+			expect(call[4]).toBe(additionalDataWithoutSettings);
+			expect(call[5]).toBe('manual');
+			expect(call[6]).toBe(false); // canUseExternalSecrets
 		});
 	});
 });

--- a/packages/cli/src/__tests__/credentials-helper.test.ts
+++ b/packages/cli/src/__tests__/credentials-helper.test.ts
@@ -456,7 +456,8 @@ describe('CredentialsHelper', () => {
 					resolvableAllowFallback: false,
 				},
 				{ apiKey: 'static-key' },
-				mockAdditionalData,
+				mockAdditionalData.executionContext,
+				mockAdditionalData.workflowSettings,
 				false, // canUseExternalSecrets
 			);
 			expect(result).toEqual(resolvedData);
@@ -476,9 +477,8 @@ describe('CredentialsHelper', () => {
 			);
 
 			const call = mockCredentialResolutionProvider.resolveIfNeeded.mock.calls[0];
-			expect(call[2]).toBe(mockAdditionalData);
-			expect(call[2].executionContext).toBe(mockAdditionalData.executionContext);
-			expect(call[3]).toBe(false); // canUseExternalSecrets
+			expect(call[2]).toBe(mockAdditionalData.executionContext);
+			expect(call[4]).toBe(false); // canUseExternalSecrets
 		});
 
 		test('should pass workflowSettings from additionalData to resolver', async () => {
@@ -495,9 +495,8 @@ describe('CredentialsHelper', () => {
 			);
 
 			const call = mockCredentialResolutionProvider.resolveIfNeeded.mock.calls[0];
-			expect(call[2]).toBe(mockAdditionalData);
-			expect(call[2].workflowSettings).toBe(mockAdditionalData.workflowSettings);
-			expect(call[3]).toBe(false); // canUseExternalSecrets
+			expect(call[3]).toBe(mockAdditionalData.workflowSettings);
+			expect(call[4]).toBe(false); // canUseExternalSecrets
 		});
 
 		test('should skip resolution when credentialResolutionProvider is not set', async () => {
@@ -614,9 +613,9 @@ describe('CredentialsHelper', () => {
 			);
 
 			const call = mockCredentialResolutionProvider.resolveIfNeeded.mock.calls[0];
-			expect(call[2]).toBe(additionalDataWithoutSettings);
-			expect(call[2].workflowSettings).toBeUndefined();
-			expect(call[3]).toBe(false); // canUseExternalSecrets
+			expect(call[2]).toBe(additionalDataWithoutSettings.executionContext);
+			expect(call[3]).toBeUndefined(); // workflowSettings
+			expect(call[4]).toBe(false); // canUseExternalSecrets
 		});
 	});
 });

--- a/packages/cli/src/credentials-helper.ts
+++ b/packages/cli/src/credentials-helper.ts
@@ -43,12 +43,12 @@ import {
 } from 'n8n-workflow';
 
 import { RESPONSE_ERROR_MESSAGES } from './constants';
+import { DynamicCredentialsProxy } from './credentials/dynamic-credentials-proxy';
 import { CredentialNotFoundError } from './errors/credential-not-found.error';
 import { CacheService } from './services/cache/cache.service';
 
 import { CredentialTypes } from '@/credential-types';
 import { CredentialsOverwrites } from '@/credentials-overwrites';
-import { DynamicCredentialsProxy } from './credentials/dynamic-credentials-proxy';
 
 const mockNode = {
 	name: '',
@@ -377,8 +377,6 @@ export class CredentialsHelper extends ICredentialsHelper {
 					resolvableAllowFallback: credentialsEntity.resolvableAllowFallback,
 				},
 				decryptedDataOriginal,
-				additionalData.executionContext,
-				additionalData.workflowSettings,
 				additionalData,
 				mode,
 				canUseExternalSecrets,

--- a/packages/cli/src/credentials-helper.ts
+++ b/packages/cli/src/credentials-helper.ts
@@ -358,6 +358,9 @@ export class CredentialsHelper extends ICredentialsHelper {
 		);
 		let decryptedDataOriginal = credentials.getData();
 
+		// Check if credential can use external secrets for expression resolution
+		const canUseExternalSecrets = await this.credentialCanUseExternalSecrets(nodeCredentials);
+
 		/**
 		 * We skip dynamic credentials resolution when no credentials context is present.
 		 * This helps workflow developers to run workflows with static credentials.
@@ -376,6 +379,9 @@ export class CredentialsHelper extends ICredentialsHelper {
 				decryptedDataOriginal,
 				additionalData.executionContext,
 				additionalData.workflowSettings,
+				additionalData,
+				mode,
+				canUseExternalSecrets,
 			);
 		}
 
@@ -386,9 +392,9 @@ export class CredentialsHelper extends ICredentialsHelper {
 		return await this.applyDefaultsAndOverwrites(
 			additionalData,
 			decryptedDataOriginal,
-			nodeCredentials,
 			type,
 			mode,
+			canUseExternalSecrets,
 			executeData,
 			expressionResolveValues,
 		);
@@ -400,9 +406,9 @@ export class CredentialsHelper extends ICredentialsHelper {
 	async applyDefaultsAndOverwrites(
 		additionalData: IWorkflowExecuteAdditionalData,
 		decryptedDataOriginal: ICredentialDataDecryptedObject,
-		credential: INodeCredentialsDetails,
 		type: string,
 		mode: WorkflowExecuteMode,
+		canUseExternalSecrets: boolean,
 		executeData?: IExecuteData,
 		expressionResolveValues?: ICredentialsExpressionResolveValues,
 	): Promise<ICredentialDataDecryptedObject> {
@@ -455,7 +461,6 @@ export class CredentialsHelper extends ICredentialsHelper {
 			decryptedData.authentication = decryptedDataOriginal.authentication;
 		}
 
-		const canUseExternalSecrets = await this.credentialCanUseExternalSecrets(credential);
 		const additionalKeys = getAdditionalKeys(additionalData, mode, null, {
 			secretsEnabled: canUseExternalSecrets,
 		});

--- a/packages/cli/src/credentials-helper.ts
+++ b/packages/cli/src/credentials-helper.ts
@@ -378,7 +378,6 @@ export class CredentialsHelper extends ICredentialsHelper {
 				},
 				decryptedDataOriginal,
 				additionalData,
-				mode,
 				canUseExternalSecrets,
 			);
 		}

--- a/packages/cli/src/credentials-helper.ts
+++ b/packages/cli/src/credentials-helper.ts
@@ -377,7 +377,8 @@ export class CredentialsHelper extends ICredentialsHelper {
 					resolvableAllowFallback: credentialsEntity.resolvableAllowFallback,
 				},
 				decryptedDataOriginal,
-				additionalData,
+				additionalData.executionContext,
+				additionalData.workflowSettings,
 				canUseExternalSecrets,
 			);
 		}

--- a/packages/cli/src/credentials/__tests__/dynamic-credentials-proxy.test.ts
+++ b/packages/cli/src/credentials/__tests__/dynamic-credentials-proxy.test.ts
@@ -2,8 +2,9 @@ import type { Logger } from '@n8n/backend-common';
 import type {
 	ICredentialContext,
 	ICredentialDataDecryptedObject,
-	IExecutionContext,
+	IWorkflowExecuteAdditionalData,
 	IWorkflowSettings,
+	WorkflowExecuteMode,
 } from 'n8n-workflow';
 
 import type {
@@ -84,18 +85,15 @@ describe('DynamicCredentialsProxy', () => {
 				undefined,
 				undefined,
 				undefined,
-				undefined,
-				undefined,
 			);
 		});
 
 		it('should pass through all parameters to provider', async () => {
-			const executionContext: IExecutionContext = {
-				version: 1,
-				establishedAt: Date.now(),
-				source: 'manual',
+			const additionalData: Partial<IWorkflowExecuteAdditionalData> = {
+				executionId: 'exec-123',
 			};
-			const workflowSettings: IWorkflowSettings = { executionTimeout: 300 };
+			const mode: WorkflowExecuteMode = 'manual';
+			const canUseExternalSecrets = true;
 
 			mockResolverProvider.resolveIfNeeded.mockResolvedValue(staticData);
 			proxy.setResolverProvider(mockResolverProvider);
@@ -103,18 +101,17 @@ describe('DynamicCredentialsProxy', () => {
 			await proxy.resolveIfNeeded(
 				credentialMetadata,
 				staticData,
-				executionContext,
-				workflowSettings,
+				additionalData as IWorkflowExecuteAdditionalData,
+				mode,
+				canUseExternalSecrets,
 			);
 
 			expect(mockResolverProvider.resolveIfNeeded).toHaveBeenCalledWith(
 				credentialMetadata,
 				staticData,
-				executionContext,
-				workflowSettings,
-				undefined,
-				undefined,
-				undefined,
+				additionalData,
+				mode,
+				canUseExternalSecrets,
 			);
 		});
 	});

--- a/packages/cli/src/credentials/__tests__/dynamic-credentials-proxy.test.ts
+++ b/packages/cli/src/credentials/__tests__/dynamic-credentials-proxy.test.ts
@@ -2,7 +2,7 @@ import type { Logger } from '@n8n/backend-common';
 import type {
 	ICredentialContext,
 	ICredentialDataDecryptedObject,
-	IWorkflowExecuteAdditionalData,
+	IExecutionContext,
 	IWorkflowSettings,
 } from 'n8n-workflow';
 
@@ -83,12 +83,18 @@ describe('DynamicCredentialsProxy', () => {
 				staticData,
 				undefined,
 				undefined,
+				undefined,
 			);
 		});
 
 		it('should pass through all parameters to provider', async () => {
-			const additionalData: Partial<IWorkflowExecuteAdditionalData> = {
-				executionId: 'exec-123',
+			const executionContext: IExecutionContext = {
+				version: 1,
+				establishedAt: Date.now(),
+				source: 'manual',
+			};
+			const workflowSettings: IWorkflowSettings = {
+				executionTimeout: 300,
 			};
 			const canUseExternalSecrets = true;
 
@@ -98,14 +104,16 @@ describe('DynamicCredentialsProxy', () => {
 			await proxy.resolveIfNeeded(
 				credentialMetadata,
 				staticData,
-				additionalData as IWorkflowExecuteAdditionalData,
+				executionContext,
+				workflowSettings,
 				canUseExternalSecrets,
 			);
 
 			expect(mockResolverProvider.resolveIfNeeded).toHaveBeenCalledWith(
 				credentialMetadata,
 				staticData,
-				additionalData,
+				executionContext,
+				workflowSettings,
 				canUseExternalSecrets,
 			);
 		});

--- a/packages/cli/src/credentials/__tests__/dynamic-credentials-proxy.test.ts
+++ b/packages/cli/src/credentials/__tests__/dynamic-credentials-proxy.test.ts
@@ -83,6 +83,9 @@ describe('DynamicCredentialsProxy', () => {
 				staticData,
 				undefined,
 				undefined,
+				undefined,
+				undefined,
+				undefined,
 			);
 		});
 
@@ -109,6 +112,9 @@ describe('DynamicCredentialsProxy', () => {
 				staticData,
 				executionContext,
 				workflowSettings,
+				undefined,
+				undefined,
+				undefined,
 			);
 		});
 	});

--- a/packages/cli/src/credentials/__tests__/dynamic-credentials-proxy.test.ts
+++ b/packages/cli/src/credentials/__tests__/dynamic-credentials-proxy.test.ts
@@ -4,7 +4,6 @@ import type {
 	ICredentialDataDecryptedObject,
 	IWorkflowExecuteAdditionalData,
 	IWorkflowSettings,
-	WorkflowExecuteMode,
 } from 'n8n-workflow';
 
 import type {
@@ -84,7 +83,6 @@ describe('DynamicCredentialsProxy', () => {
 				staticData,
 				undefined,
 				undefined,
-				undefined,
 			);
 		});
 
@@ -92,7 +90,6 @@ describe('DynamicCredentialsProxy', () => {
 			const additionalData: Partial<IWorkflowExecuteAdditionalData> = {
 				executionId: 'exec-123',
 			};
-			const mode: WorkflowExecuteMode = 'manual';
 			const canUseExternalSecrets = true;
 
 			mockResolverProvider.resolveIfNeeded.mockResolvedValue(staticData);
@@ -102,7 +99,6 @@ describe('DynamicCredentialsProxy', () => {
 				credentialMetadata,
 				staticData,
 				additionalData as IWorkflowExecuteAdditionalData,
-				mode,
 				canUseExternalSecrets,
 			);
 
@@ -110,7 +106,6 @@ describe('DynamicCredentialsProxy', () => {
 				credentialMetadata,
 				staticData,
 				additionalData,
-				mode,
 				canUseExternalSecrets,
 			);
 		});

--- a/packages/cli/src/credentials/credential-resolution-provider.interface.ts
+++ b/packages/cli/src/credentials/credential-resolution-provider.interface.ts
@@ -1,8 +1,6 @@
 import type {
 	ICredentialDataDecryptedObject,
-	IExecutionContext,
 	IWorkflowExecuteAdditionalData,
-	IWorkflowSettings,
 	WorkflowExecuteMode,
 } from 'n8n-workflow';
 
@@ -27,9 +25,7 @@ export interface ICredentialResolutionProvider {
 	 *
 	 * @param credentialsResolveMetadata The credential resolve metadata
 	 * @param staticData The decrypted static credential data
-	 * @param executionContext Optional execution context containing credential context
-	 * @param workflowSettings Optional workflow settings containing resolver ID fallback
-	 * @param additionalData Additional workflow execution data for expression resolution
+	 * @param additionalData Additional workflow execution data for expression resolution and context and settings
 	 * @param mode Workflow execution mode
 	 * @param canUseExternalSecrets Whether the credential can use external secrets for expression resolution
 	 * @returns Resolved credential data (either dynamic or static)
@@ -37,8 +33,6 @@ export interface ICredentialResolutionProvider {
 	resolveIfNeeded(
 		credentialsResolveMetadata: CredentialResolveMetadata,
 		staticData: ICredentialDataDecryptedObject,
-		executionContext?: IExecutionContext,
-		workflowSettings?: IWorkflowSettings,
 		additionalData?: IWorkflowExecuteAdditionalData,
 		mode?: WorkflowExecuteMode,
 		canUseExternalSecrets?: boolean,

--- a/packages/cli/src/credentials/credential-resolution-provider.interface.ts
+++ b/packages/cli/src/credentials/credential-resolution-provider.interface.ts
@@ -1,4 +1,8 @@
-import type { ICredentialDataDecryptedObject, IWorkflowExecuteAdditionalData } from 'n8n-workflow';
+import type {
+	ICredentialDataDecryptedObject,
+	IExecutionContext,
+	IWorkflowSettings,
+} from 'n8n-workflow';
 
 export type CredentialResolveMetadata = {
 	id: string;
@@ -28,7 +32,8 @@ export interface ICredentialResolutionProvider {
 	resolveIfNeeded(
 		credentialsResolveMetadata: CredentialResolveMetadata,
 		staticData: ICredentialDataDecryptedObject,
-		additionalData?: IWorkflowExecuteAdditionalData,
+		executionContext?: IExecutionContext,
+		workflowSettings?: IWorkflowSettings,
 		canUseExternalSecrets?: boolean,
 	): Promise<ICredentialDataDecryptedObject>;
 }

--- a/packages/cli/src/credentials/credential-resolution-provider.interface.ts
+++ b/packages/cli/src/credentials/credential-resolution-provider.interface.ts
@@ -1,7 +1,9 @@
 import type {
 	ICredentialDataDecryptedObject,
 	IExecutionContext,
+	IWorkflowExecuteAdditionalData,
 	IWorkflowSettings,
+	WorkflowExecuteMode,
 } from 'n8n-workflow';
 
 export type CredentialResolveMetadata = {
@@ -27,6 +29,9 @@ export interface ICredentialResolutionProvider {
 	 * @param staticData The decrypted static credential data
 	 * @param executionContext Optional execution context containing credential context
 	 * @param workflowSettings Optional workflow settings containing resolver ID fallback
+	 * @param additionalData Additional workflow execution data for expression resolution
+	 * @param mode Workflow execution mode
+	 * @param canUseExternalSecrets Whether the credential can use external secrets for expression resolution
 	 * @returns Resolved credential data (either dynamic or static)
 	 */
 	resolveIfNeeded(
@@ -34,5 +39,8 @@ export interface ICredentialResolutionProvider {
 		staticData: ICredentialDataDecryptedObject,
 		executionContext?: IExecutionContext,
 		workflowSettings?: IWorkflowSettings,
+		additionalData?: IWorkflowExecuteAdditionalData,
+		mode?: WorkflowExecuteMode,
+		canUseExternalSecrets?: boolean,
 	): Promise<ICredentialDataDecryptedObject>;
 }

--- a/packages/cli/src/credentials/credential-resolution-provider.interface.ts
+++ b/packages/cli/src/credentials/credential-resolution-provider.interface.ts
@@ -1,8 +1,4 @@
-import type {
-	ICredentialDataDecryptedObject,
-	IWorkflowExecuteAdditionalData,
-	WorkflowExecuteMode,
-} from 'n8n-workflow';
+import type { ICredentialDataDecryptedObject, IWorkflowExecuteAdditionalData } from 'n8n-workflow';
 
 export type CredentialResolveMetadata = {
 	id: string;
@@ -25,8 +21,7 @@ export interface ICredentialResolutionProvider {
 	 *
 	 * @param credentialsResolveMetadata The credential resolve metadata
 	 * @param staticData The decrypted static credential data
-	 * @param additionalData Additional workflow execution data for expression resolution and context and settings
-	 * @param mode Workflow execution mode
+	 * @param additionalData Additional workflow execution data for context and settings
 	 * @param canUseExternalSecrets Whether the credential can use external secrets for expression resolution
 	 * @returns Resolved credential data (either dynamic or static)
 	 */
@@ -34,7 +29,6 @@ export interface ICredentialResolutionProvider {
 		credentialsResolveMetadata: CredentialResolveMetadata,
 		staticData: ICredentialDataDecryptedObject,
 		additionalData?: IWorkflowExecuteAdditionalData,
-		mode?: WorkflowExecuteMode,
 		canUseExternalSecrets?: boolean,
 	): Promise<ICredentialDataDecryptedObject>;
 }

--- a/packages/cli/src/credentials/dynamic-credentials-proxy.ts
+++ b/packages/cli/src/credentials/dynamic-credentials-proxy.ts
@@ -42,8 +42,6 @@ export class DynamicCredentialsProxy
 	async resolveIfNeeded(
 		credentialsResolveMetadata: CredentialResolveMetadata,
 		staticData: ICredentialDataDecryptedObject,
-		executionContext?: IExecutionContext,
-		workflowSettings?: IWorkflowSettings,
 		additionalData?: IWorkflowExecuteAdditionalData,
 		mode?: WorkflowExecuteMode,
 		canUseExternalSecrets?: boolean,
@@ -60,8 +58,6 @@ export class DynamicCredentialsProxy
 		return await this.resolvingProvider.resolveIfNeeded(
 			credentialsResolveMetadata,
 			staticData,
-			executionContext,
-			workflowSettings,
 			additionalData,
 			mode,
 			canUseExternalSecrets,

--- a/packages/cli/src/credentials/dynamic-credentials-proxy.ts
+++ b/packages/cli/src/credentials/dynamic-credentials-proxy.ts
@@ -2,21 +2,25 @@ import { Logger } from '@n8n/backend-common';
 import { Container, Service } from '@n8n/di';
 import { Cipher } from 'n8n-core';
 import type {
-	CredentialStoreMetadata,
-	IDynamicCredentialStorageProvider,
-} from './dynamic-credential-storage.interface';
-import type {
 	ICredentialContext,
 	ICredentialDataDecryptedObject,
 	IDataObject,
 	IExecutionContext,
+	IWorkflowExecuteAdditionalData,
 	IWorkflowSettings,
+	WorkflowExecuteMode,
+	toCredentialContext,
+	UnexpectedError,
 } from 'n8n-workflow';
-import { toCredentialContext, UnexpectedError } from 'n8n-workflow';
+
 import type {
 	CredentialResolveMetadata,
 	ICredentialResolutionProvider,
 } from './credential-resolution-provider.interface';
+import type {
+	CredentialStoreMetadata,
+	IDynamicCredentialStorageProvider,
+} from './dynamic-credential-storage.interface';
 
 @Service()
 export class DynamicCredentialsProxy
@@ -40,6 +44,9 @@ export class DynamicCredentialsProxy
 		staticData: ICredentialDataDecryptedObject,
 		executionContext?: IExecutionContext,
 		workflowSettings?: IWorkflowSettings,
+		additionalData?: IWorkflowExecuteAdditionalData,
+		mode?: WorkflowExecuteMode,
+		canUseExternalSecrets?: boolean,
 	): Promise<ICredentialDataDecryptedObject> {
 		if (!this.resolvingProvider) {
 			if (credentialsResolveMetadata.isResolvable) {
@@ -55,6 +62,9 @@ export class DynamicCredentialsProxy
 			staticData,
 			executionContext,
 			workflowSettings,
+			additionalData,
+			mode,
+			canUseExternalSecrets,
 		);
 	}
 

--- a/packages/cli/src/credentials/dynamic-credentials-proxy.ts
+++ b/packages/cli/src/credentials/dynamic-credentials-proxy.ts
@@ -6,10 +6,8 @@ import type {
 	ICredentialDataDecryptedObject,
 	IDataObject,
 	IExecutionContext,
-	IWorkflowExecuteAdditionalData,
 	IWorkflowSettings,
 } from 'n8n-workflow';
-
 import { toCredentialContext, UnexpectedError } from 'n8n-workflow';
 
 import type {
@@ -41,7 +39,8 @@ export class DynamicCredentialsProxy
 	async resolveIfNeeded(
 		credentialsResolveMetadata: CredentialResolveMetadata,
 		staticData: ICredentialDataDecryptedObject,
-		additionalData?: IWorkflowExecuteAdditionalData,
+		executionContext?: IExecutionContext,
+		workflowSettings?: IWorkflowSettings,
 		canUseExternalSecrets?: boolean,
 	): Promise<ICredentialDataDecryptedObject> {
 		if (!this.resolvingProvider) {
@@ -56,7 +55,8 @@ export class DynamicCredentialsProxy
 		return await this.resolvingProvider.resolveIfNeeded(
 			credentialsResolveMetadata,
 			staticData,
-			additionalData,
+			executionContext,
+			workflowSettings,
 			canUseExternalSecrets,
 		);
 	}

--- a/packages/cli/src/credentials/dynamic-credentials-proxy.ts
+++ b/packages/cli/src/credentials/dynamic-credentials-proxy.ts
@@ -9,9 +9,9 @@ import type {
 	IWorkflowExecuteAdditionalData,
 	IWorkflowSettings,
 	WorkflowExecuteMode,
-	toCredentialContext,
-	UnexpectedError,
 } from 'n8n-workflow';
+
+import { toCredentialContext, UnexpectedError } from 'n8n-workflow';
 
 import type {
 	CredentialResolveMetadata,

--- a/packages/cli/src/credentials/dynamic-credentials-proxy.ts
+++ b/packages/cli/src/credentials/dynamic-credentials-proxy.ts
@@ -8,7 +8,6 @@ import type {
 	IExecutionContext,
 	IWorkflowExecuteAdditionalData,
 	IWorkflowSettings,
-	WorkflowExecuteMode,
 } from 'n8n-workflow';
 
 import { toCredentialContext, UnexpectedError } from 'n8n-workflow';
@@ -43,7 +42,6 @@ export class DynamicCredentialsProxy
 		credentialsResolveMetadata: CredentialResolveMetadata,
 		staticData: ICredentialDataDecryptedObject,
 		additionalData?: IWorkflowExecuteAdditionalData,
-		mode?: WorkflowExecuteMode,
 		canUseExternalSecrets?: boolean,
 	): Promise<ICredentialDataDecryptedObject> {
 		if (!this.resolvingProvider) {
@@ -59,7 +57,6 @@ export class DynamicCredentialsProxy
 			credentialsResolveMetadata,
 			staticData,
 			additionalData,
-			mode,
 			canUseExternalSecrets,
 		);
 	}

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers.controller.ts
@@ -67,7 +67,7 @@ export class CredentialResolversController {
 		_res: Response,
 		@Body dto: CreateCredentialResolverDto,
 	): Promise<CredentialResolver> {
-		if (!isNodeParameters(dto.config)) {
+		if (dto.config && !isNodeParameters(dto.config)) {
 			throw new BadRequestError('Invalid config format');
 		}
 
@@ -117,7 +117,7 @@ export class CredentialResolversController {
 		@Param('id') id: string,
 		@Body dto: UpdateCredentialResolverDto,
 	): Promise<CredentialResolver> {
-		if (!isNodeParameters(dto.config)) {
+		if (dto.config && !isNodeParameters(dto.config)) {
 			throw new BadRequestError('Invalid config format');
 		}
 		try {

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers.controller.ts
@@ -20,6 +20,7 @@ import {
 	CredentialResolverValidationError,
 } from '@n8n/decorators';
 import { Response } from 'express';
+import { isNodeParameters } from 'n8n-workflow';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { InternalServerError } from '@/errors/response-errors/internal-server.error';
@@ -66,6 +67,10 @@ export class CredentialResolversController {
 		_res: Response,
 		@Body dto: CreateCredentialResolverDto,
 	): Promise<CredentialResolver> {
+		if (!isNodeParameters(dto.config)) {
+			throw new BadRequestError('Invalid config format');
+		}
+
 		try {
 			const createdResolver = await this.service.create({
 				name: dto.name,
@@ -112,6 +117,9 @@ export class CredentialResolversController {
 		@Param('id') id: string,
 		@Body dto: UpdateCredentialResolverDto,
 	): Promise<CredentialResolver> {
+		if (!isNodeParameters(dto.config)) {
+			throw new BadRequestError('Invalid config format');
+		}
 		try {
 			return credentialResolverSchema.parse(
 				await this.service.update(id, {

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers.controller.ts
@@ -62,7 +62,7 @@ export class CredentialResolversController {
 	@Post('/')
 	@GlobalScope('credentialResolver:create')
 	async createResolver(
-		_req: AuthenticatedRequest,
+		req: AuthenticatedRequest,
 		_res: Response,
 		@Body dto: CreateCredentialResolverDto,
 	): Promise<CredentialResolver> {
@@ -71,6 +71,7 @@ export class CredentialResolversController {
 				name: dto.name,
 				type: dto.type,
 				config: dto.config,
+				user: req.user,
 			});
 			return credentialResolverSchema.parse(createdResolver);
 		} catch (e: unknown) {
@@ -107,7 +108,7 @@ export class CredentialResolversController {
 	@Patch('/:id')
 	@GlobalScope('credentialResolver:update')
 	async updateResolver(
-		_req: AuthenticatedRequest,
+		req: AuthenticatedRequest,
 		_res: Response,
 		@Param('id') id: string,
 		@Body dto: UpdateCredentialResolverDto,
@@ -118,6 +119,7 @@ export class CredentialResolversController {
 					type: dto.type,
 					name: dto.name,
 					config: dto.config,
+					user: req.user,
 				}),
 			);
 		} catch (e: unknown) {

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers.controller.ts
@@ -20,14 +20,13 @@ import {
 	CredentialResolverValidationError,
 } from '@n8n/decorators';
 import { Response } from 'express';
-import { isNodeParameters } from 'n8n-workflow';
+
+import { DynamicCredentialResolverNotFoundError } from './errors/credential-resolver-not-found.error';
+import { DynamicCredentialResolverService } from './services/credential-resolver.service';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { InternalServerError } from '@/errors/response-errors/internal-server.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
-
-import { DynamicCredentialResolverNotFoundError } from './errors/credential-resolver-not-found.error';
-import { DynamicCredentialResolverService } from './services/credential-resolver.service';
 
 @RestController('/credential-resolvers')
 export class CredentialResolversController {
@@ -67,10 +66,6 @@ export class CredentialResolversController {
 		_res: Response,
 		@Body dto: CreateCredentialResolverDto,
 	): Promise<CredentialResolver> {
-		if (dto.config && !isNodeParameters(dto.config)) {
-			throw new BadRequestError('Invalid config format');
-		}
-
 		try {
 			const createdResolver = await this.service.create({
 				name: dto.name,
@@ -117,9 +112,6 @@ export class CredentialResolversController {
 		@Param('id') id: string,
 		@Body dto: UpdateCredentialResolverDto,
 	): Promise<CredentialResolver> {
-		if (dto.config && !isNodeParameters(dto.config)) {
-			throw new BadRequestError('Invalid config format');
-		}
 		try {
 			return credentialResolverSchema.parse(
 				await this.service.update(id, {

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-resolver.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-resolver.service.test.ts
@@ -75,8 +75,7 @@ describe('DynamicCredentialResolverService', () => {
 		} as unknown as jest.Mocked<Cipher>;
 
 		mockExpressionService = {
-			resolveForRuntime: jest.fn((config) => config),
-			resolveForValidation: jest.fn(async (config) => await Promise.resolve(config)),
+			resolve: jest.fn(async (config) => await Promise.resolve(config)),
 		} as unknown as jest.Mocked<ResolverConfigExpressionService>;
 
 		service = new DynamicCredentialResolverService(

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-resolver.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-resolver.service.test.ts
@@ -1,4 +1,5 @@
 import type { Logger } from '@n8n/backend-common';
+import { GLOBAL_MEMBER_ROLE, GLOBAL_OWNER_ROLE, type User } from '@n8n/db';
 import {
 	CredentialResolverValidationError,
 	type CredentialResolverConfiguration,
@@ -46,6 +47,13 @@ describe('DynamicCredentialResolverService', () => {
 		return entity;
 	};
 
+	const createMockUser = (role = GLOBAL_OWNER_ROLE): User => {
+		return {
+			id: 'user-123',
+			role,
+		} as User;
+	};
+
 	beforeEach(() => {
 		jest.clearAllMocks();
 
@@ -91,6 +99,7 @@ describe('DynamicCredentialResolverService', () => {
 		it('should create a resolver with encrypted config', async () => {
 			const config: CredentialResolverConfiguration = { prefix: 'test-prefix' };
 			const savedEntity = createMockEntity();
+			const mockUser = createMockUser();
 
 			mockRegistry.getResolverByTypename.mockReturnValue(mockResolverImplementation);
 			mockResolverImplementation.validateOptions.mockResolvedValue(undefined);
@@ -103,6 +112,7 @@ describe('DynamicCredentialResolverService', () => {
 				name: 'Test Resolver',
 				type: 'test.resolver',
 				config,
+				user: mockUser,
 			});
 
 			expect(mockRegistry.getResolverByTypename).toHaveBeenCalledWith('test.resolver');
@@ -121,6 +131,7 @@ describe('DynamicCredentialResolverService', () => {
 		});
 
 		it('should throw CredentialResolverValidationError for unknown resolver type', async () => {
+			const mockUser = createMockUser();
 			mockRegistry.getResolverByTypename.mockReturnValue(undefined);
 
 			await expect(
@@ -128,6 +139,7 @@ describe('DynamicCredentialResolverService', () => {
 					name: 'Test Resolver',
 					type: 'unknown.resolver',
 					config: {},
+					user: mockUser,
 				}),
 			).rejects.toThrow(CredentialResolverValidationError);
 
@@ -137,6 +149,7 @@ describe('DynamicCredentialResolverService', () => {
 
 		it('should throw CredentialResolverValidationError when config validation fails', async () => {
 			const config: CredentialResolverConfiguration = { invalidOption: 'value' };
+			const mockUser = createMockUser();
 
 			mockRegistry.getResolverByTypename.mockReturnValue(mockResolverImplementation);
 			mockResolverImplementation.validateOptions.mockRejectedValue(
@@ -148,11 +161,58 @@ describe('DynamicCredentialResolverService', () => {
 					name: 'Test Resolver',
 					type: 'test.resolver',
 					config,
+					user: mockUser,
 				}),
 			).rejects.toThrow(CredentialResolverValidationError);
 
 			expect(mockRepository.create).not.toHaveBeenCalled();
 			expect(mockRepository.save).not.toHaveBeenCalled();
+		});
+
+		it('should pass canUseExternalSecrets=true to validation for users with externalSecret:list permission', async () => {
+			const config: CredentialResolverConfiguration = { prefix: 'test-prefix' };
+			const savedEntity = createMockEntity();
+			const mockUser = createMockUser(GLOBAL_OWNER_ROLE); // Owner has externalSecret:list
+
+			mockRegistry.getResolverByTypename.mockReturnValue(mockResolverImplementation);
+			mockResolverImplementation.validateOptions.mockResolvedValue(undefined);
+			mockCipher.encrypt.mockReturnValue('encrypted-config-data');
+			mockRepository.create.mockReturnValue(savedEntity);
+			mockRepository.save.mockResolvedValue(savedEntity);
+			mockCipher.decrypt.mockReturnValue(JSON.stringify(config));
+
+			await service.create({
+				name: 'Test Resolver',
+				type: 'test.resolver',
+				config,
+				user: mockUser,
+			});
+
+			// Verify expression service was called with canUseExternalSecrets=true
+			expect(mockExpressionService.resolve).toHaveBeenCalledWith(config, true);
+		});
+
+		it('should pass canUseExternalSecrets=false to validation for users without externalSecret:list permission', async () => {
+			const config: CredentialResolverConfiguration = { prefix: 'test-prefix' };
+			const savedEntity = createMockEntity();
+			const mockUser = createMockUser(GLOBAL_MEMBER_ROLE); // Member doesn't have externalSecret:list
+
+			mockRegistry.getResolverByTypename.mockReturnValue(mockResolverImplementation);
+			mockResolverImplementation.validateOptions.mockResolvedValue(undefined);
+			mockCipher.encrypt.mockReturnValue('encrypted-config-data');
+			mockRepository.create.mockReturnValue(savedEntity);
+			mockRepository.save.mockResolvedValue(savedEntity);
+			mockCipher.decrypt.mockReturnValue(JSON.stringify(config));
+
+			await service.create({
+				name: 'Test Resolver',
+				type: 'test.resolver',
+				config,
+				user: mockUser,
+			});
+
+			// Verify expression service was called with canUseExternalSecrets=false
+			expect(mockExpressionService.resolve).toHaveBeenCalledWith(config, false);
 		});
 	});
 
@@ -223,12 +283,16 @@ describe('DynamicCredentialResolverService', () => {
 			const entity = createMockEntity();
 			const updatedEntity = createMockEntity({ name: 'Updated Name' });
 			const decryptedConfig = { prefix: 'test' };
+			const mockUser = createMockUser();
 
 			mockRepository.findOneBy.mockResolvedValue(entity);
 			mockRepository.save.mockResolvedValue(updatedEntity);
 			mockCipher.decrypt.mockReturnValue(JSON.stringify(decryptedConfig));
 
-			const result = await service.update('resolver-id-123', { name: 'Updated Name' });
+			const result = await service.update('resolver-id-123', {
+				name: 'Updated Name',
+				user: mockUser,
+			});
 
 			expect(mockRepository.findOneBy).toHaveBeenCalledWith({ id: 'resolver-id-123' });
 			expect(mockRepository.save).toHaveBeenCalled();
@@ -242,6 +306,7 @@ describe('DynamicCredentialResolverService', () => {
 			const entity = createMockEntity();
 			const newConfig: CredentialResolverConfiguration = { prefix: 'new-prefix' };
 			const updatedEntity = createMockEntity({ config: 'new-encrypted-config' });
+			const mockUser = createMockUser();
 
 			mockRepository.findOneBy.mockResolvedValue(entity);
 			mockRegistry.getResolverByTypename.mockReturnValue(mockResolverImplementation);
@@ -250,7 +315,7 @@ describe('DynamicCredentialResolverService', () => {
 			mockRepository.save.mockResolvedValue(updatedEntity);
 			mockCipher.decrypt.mockReturnValue(JSON.stringify(newConfig));
 
-			await service.update('resolver-id-123', { config: newConfig });
+			await service.update('resolver-id-123', { config: newConfig, user: mockUser });
 
 			expect(mockRegistry.getResolverByTypename).toHaveBeenCalledWith('test.resolver');
 			expect(mockResolverImplementation.validateOptions).toHaveBeenCalledWith(newConfig);
@@ -259,11 +324,12 @@ describe('DynamicCredentialResolverService', () => {
 		});
 
 		it('should throw DynamicCredentialResolverNotFoundError when resolver not found', async () => {
+			const mockUser = createMockUser();
 			mockRepository.findOneBy.mockResolvedValue(null);
 
-			await expect(service.update('non-existent-id', { name: 'New Name' })).rejects.toThrow(
-				DynamicCredentialResolverNotFoundError,
-			);
+			await expect(
+				service.update('non-existent-id', { name: 'New Name', user: mockUser }),
+			).rejects.toThrow(DynamicCredentialResolverNotFoundError);
 
 			expect(mockRepository.save).not.toHaveBeenCalled();
 		});
@@ -271,6 +337,7 @@ describe('DynamicCredentialResolverService', () => {
 		it('should throw CredentialResolverValidationError when config validation fails on update', async () => {
 			const entity = createMockEntity();
 			const invalidConfig: CredentialResolverConfiguration = { badOption: 'value' };
+			const mockUser = createMockUser();
 
 			mockRepository.findOneBy.mockResolvedValue(entity);
 			mockRegistry.getResolverByTypename.mockReturnValue(mockResolverImplementation);
@@ -278,9 +345,9 @@ describe('DynamicCredentialResolverService', () => {
 				new CredentialResolverValidationError('Invalid config'),
 			);
 
-			await expect(service.update('resolver-id-123', { config: invalidConfig })).rejects.toThrow(
-				CredentialResolverValidationError,
-			);
+			await expect(
+				service.update('resolver-id-123', { config: invalidConfig, user: mockUser }),
+			).rejects.toThrow(CredentialResolverValidationError);
 
 			expect(mockRepository.save).not.toHaveBeenCalled();
 		});
@@ -289,6 +356,7 @@ describe('DynamicCredentialResolverService', () => {
 			const entity = createMockEntity({ type: 'old.resolver' });
 			const existingConfig: CredentialResolverConfiguration = { prefix: 'test' };
 			const updatedEntity = createMockEntity({ type: 'new.resolver' });
+			const mockUser = createMockUser();
 
 			mockRepository.findOneBy.mockResolvedValue(entity);
 			mockCipher.decrypt.mockReturnValue(JSON.stringify(existingConfig));
@@ -296,7 +364,7 @@ describe('DynamicCredentialResolverService', () => {
 			mockResolverImplementation.validateOptions.mockResolvedValue(undefined);
 			mockRepository.save.mockResolvedValue(updatedEntity);
 
-			await service.update('resolver-id-123', { type: 'new.resolver' });
+			await service.update('resolver-id-123', { type: 'new.resolver', user: mockUser });
 
 			expect(mockCipher.decrypt).toHaveBeenCalledWith('encrypted-config-data');
 			expect(mockRegistry.getResolverByTypename).toHaveBeenCalledWith('new.resolver');
@@ -307,6 +375,7 @@ describe('DynamicCredentialResolverService', () => {
 		it('should throw CredentialResolverValidationError when existing config is incompatible with new type', async () => {
 			const entity = createMockEntity({ type: 'old.resolver' });
 			const existingConfig: CredentialResolverConfiguration = { prefix: 'test' };
+			const mockUser = createMockUser();
 
 			mockRepository.findOneBy.mockResolvedValue(entity);
 			mockCipher.decrypt.mockReturnValue(JSON.stringify(existingConfig));
@@ -315,11 +384,49 @@ describe('DynamicCredentialResolverService', () => {
 				new CredentialResolverValidationError('Config incompatible with new resolver type'),
 			);
 
-			await expect(service.update('resolver-id-123', { type: 'new.resolver' })).rejects.toThrow(
-				CredentialResolverValidationError,
-			);
+			await expect(
+				service.update('resolver-id-123', { type: 'new.resolver', user: mockUser }),
+			).rejects.toThrow(CredentialResolverValidationError);
 
 			expect(mockRepository.save).not.toHaveBeenCalled();
+		});
+
+		it('should pass canUseExternalSecrets=true to validation for users with externalSecret:list permission on update', async () => {
+			const entity = createMockEntity();
+			const newConfig: CredentialResolverConfiguration = { prefix: 'new-prefix' };
+			const updatedEntity = createMockEntity({ config: 'new-encrypted-config' });
+			const mockUser = createMockUser(GLOBAL_OWNER_ROLE); // Owner has externalSecret:list
+
+			mockRepository.findOneBy.mockResolvedValue(entity);
+			mockRegistry.getResolverByTypename.mockReturnValue(mockResolverImplementation);
+			mockResolverImplementation.validateOptions.mockResolvedValue(undefined);
+			mockCipher.encrypt.mockReturnValue('new-encrypted-config');
+			mockRepository.save.mockResolvedValue(updatedEntity);
+			mockCipher.decrypt.mockReturnValue(JSON.stringify(newConfig));
+
+			await service.update('resolver-id-123', { config: newConfig, user: mockUser });
+
+			// Verify expression service was called with canUseExternalSecrets=true
+			expect(mockExpressionService.resolve).toHaveBeenCalledWith(newConfig, true);
+		});
+
+		it('should pass canUseExternalSecrets=false to validation for users without externalSecret:list permission on update', async () => {
+			const entity = createMockEntity();
+			const newConfig: CredentialResolverConfiguration = { prefix: 'new-prefix' };
+			const updatedEntity = createMockEntity({ config: 'new-encrypted-config' });
+			const mockUser = createMockUser(GLOBAL_MEMBER_ROLE); // Member doesn't have externalSecret:list
+
+			mockRepository.findOneBy.mockResolvedValue(entity);
+			mockRegistry.getResolverByTypename.mockReturnValue(mockResolverImplementation);
+			mockResolverImplementation.validateOptions.mockResolvedValue(undefined);
+			mockCipher.encrypt.mockReturnValue('new-encrypted-config');
+			mockRepository.save.mockResolvedValue(updatedEntity);
+			mockCipher.decrypt.mockReturnValue(JSON.stringify(newConfig));
+
+			await service.update('resolver-id-123', { config: newConfig, user: mockUser });
+
+			// Verify expression service was called with canUseExternalSecrets=false
+			expect(mockExpressionService.resolve).toHaveBeenCalledWith(newConfig, false);
 		});
 	});
 

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-resolver.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-resolver.service.test.ts
@@ -12,6 +12,7 @@ import type { DynamicCredentialResolverRepository } from '../../database/reposit
 import { DynamicCredentialResolverNotFoundError } from '../../errors/credential-resolver-not-found.error';
 import type { DynamicCredentialResolverRegistry } from '../credential-resolver-registry.service';
 import { DynamicCredentialResolverService } from '../credential-resolver.service';
+import type { ResolverConfigExpressionService } from '../resolver-config-expression.service';
 
 describe('DynamicCredentialResolverService', () => {
 	let service: DynamicCredentialResolverService;
@@ -19,6 +20,7 @@ describe('DynamicCredentialResolverService', () => {
 	let mockRepository: jest.Mocked<DynamicCredentialResolverRepository>;
 	let mockRegistry: jest.Mocked<DynamicCredentialResolverRegistry>;
 	let mockCipher: jest.Mocked<Cipher>;
+	let mockExpressionService: jest.Mocked<ResolverConfigExpressionService>;
 
 	const mockResolverImplementation: jest.Mocked<ICredentialResolver> = {
 		metadata: {
@@ -72,11 +74,17 @@ describe('DynamicCredentialResolverService', () => {
 			decrypt: jest.fn(),
 		} as unknown as jest.Mocked<Cipher>;
 
+		mockExpressionService = {
+			resolveForRuntime: jest.fn((config) => config),
+			resolveForValidation: jest.fn(async (config) => await Promise.resolve(config)),
+		} as unknown as jest.Mocked<ResolverConfigExpressionService>;
+
 		service = new DynamicCredentialResolverService(
 			mockLogger,
 			mockRepository,
 			mockRegistry,
 			mockCipher,
+			mockExpressionService,
 		);
 	});
 

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential.service.test.ts
@@ -847,7 +847,7 @@ describe('DynamicCredentialService', () => {
 
 				const mockResolver = createMockResolver();
 				mockResolverRepository.findOneBy.mockResolvedValue(resolverEntity);
-				mockResolverRegistry.getResolverByName.mockReturnValue(mockResolver);
+				mockResolverRegistry.getResolverByTypename.mockReturnValue(mockResolver);
 				mockCipher.decrypt
 					.mockReturnValueOnce(JSON.stringify(credentialContext))
 					.mockReturnValueOnce(JSON.stringify(resolverConfigWithExpression));
@@ -894,7 +894,7 @@ describe('DynamicCredentialService', () => {
 
 				const mockResolver = createMockResolver();
 				mockResolverRepository.findOneBy.mockResolvedValue(resolverEntity);
-				mockResolverRegistry.getResolverByName.mockReturnValue(mockResolver);
+				mockResolverRegistry.getResolverByTypename.mockReturnValue(mockResolver);
 				mockCipher.decrypt
 					.mockReturnValueOnce(JSON.stringify(credentialContext))
 					.mockReturnValueOnce(JSON.stringify(resolverConfigWithVars));
@@ -959,7 +959,7 @@ describe('DynamicCredentialService', () => {
 
 				const mockResolver = createMockResolver();
 				mockResolverRepository.findOneBy.mockResolvedValue(resolverEntity);
-				mockResolverRegistry.getResolverByName.mockReturnValue(mockResolver);
+				mockResolverRegistry.getResolverByTypename.mockReturnValue(mockResolver);
 				mockCipher.decrypt
 					.mockReturnValueOnce(JSON.stringify(credentialContext))
 					.mockReturnValueOnce(JSON.stringify(resolverConfig));
@@ -1020,7 +1020,7 @@ describe('DynamicCredentialService', () => {
 
 				const mockResolver = createMockResolver();
 				mockResolverRepository.findOneBy.mockResolvedValue(resolverEntity);
-				mockResolverRegistry.getResolverByName.mockReturnValue(mockResolver);
+				mockResolverRegistry.getResolverByTypename.mockReturnValue(mockResolver);
 				mockCipher.decrypt
 					.mockReturnValueOnce(JSON.stringify(credentialContext))
 					.mockReturnValueOnce(JSON.stringify(resolverConfig));
@@ -1067,7 +1067,7 @@ describe('DynamicCredentialService', () => {
 
 				const mockResolver = createMockResolver();
 				mockResolverRepository.findOneBy.mockResolvedValue(resolverEntity);
-				mockResolverRegistry.getResolverByName.mockReturnValue(mockResolver);
+				mockResolverRegistry.getResolverByTypename.mockReturnValue(mockResolver);
 				mockCipher.decrypt
 					.mockReturnValueOnce(JSON.stringify(credentialContext))
 					.mockReturnValueOnce(JSON.stringify(resolverConfigWithExpressions));
@@ -1108,7 +1108,7 @@ describe('DynamicCredentialService', () => {
 
 				const mockResolver = createMockResolver();
 				mockResolverRepository.findOneBy.mockResolvedValue(resolverEntity);
-				mockResolverRegistry.getResolverByName.mockReturnValue(mockResolver);
+				mockResolverRegistry.getResolverByTypename.mockReturnValue(mockResolver);
 				mockCipher.decrypt
 					.mockReturnValueOnce(JSON.stringify(credentialContext))
 					.mockReturnValueOnce(JSON.stringify(resolverConfigWithExpression));
@@ -1146,7 +1146,7 @@ describe('DynamicCredentialService', () => {
 
 				const mockResolver = createMockResolver();
 				mockResolverRepository.findOneBy.mockResolvedValue(resolverEntity);
-				mockResolverRegistry.getResolverByName.mockReturnValue(mockResolver);
+				mockResolverRegistry.getResolverByTypename.mockReturnValue(mockResolver);
 				mockCipher.decrypt
 					.mockReturnValueOnce(JSON.stringify(credentialContext))
 					.mockReturnValueOnce(JSON.stringify(resolverConfigWithExpression));

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential.service.test.ts
@@ -784,7 +784,7 @@ describe('DynamicCredentialService', () => {
 					credentialsEntity,
 					staticData,
 					additionalData.executionContext,
-					undefined,
+					additionalData.workflowSettings,
 				);
 
 				expect(mockResolverRepository.findOneBy).toHaveBeenCalledWith({

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential.service.test.ts
@@ -5,7 +5,6 @@ import type {
 	ICredentialContext,
 	ICredentialDataDecryptedObject,
 	IExecutionContext,
-	IWorkflowExecuteAdditionalData,
 } from 'n8n-workflow';
 
 import type { CredentialResolveMetadata } from '@/credentials/credential-resolution-provider.interface';
@@ -87,7 +86,7 @@ describe('DynamicCredentialService', () => {
 		executionId: string = 'exec-123',
 		secrets: Record<string, string> = {},
 		executionContext?: IExecutionContext,
-	): Partial<IWorkflowExecuteAdditionalData> => ({
+	) => ({
 		executionId,
 		restartExecutionId: undefined,
 		restApiUrl: '',
@@ -301,7 +300,8 @@ describe('DynamicCredentialService', () => {
 				const result = await service.resolveIfNeeded(
 					credentialsEntity,
 					staticData,
-					additionalData as IWorkflowExecuteAdditionalData,
+					additionalData.executionContext,
+					undefined,
 				);
 
 				expect(result).toBe(staticData);
@@ -330,7 +330,8 @@ describe('DynamicCredentialService', () => {
 				const result = await service.resolveIfNeeded(
 					credentialsEntity,
 					staticData,
-					additionalData as IWorkflowExecuteAdditionalData,
+					additionalData.executionContext,
+					undefined,
 				);
 
 				expect(result).toBe(staticData);
@@ -363,7 +364,8 @@ describe('DynamicCredentialService', () => {
 				const result = await service.resolveIfNeeded(
 					credentialsEntity,
 					staticData,
-					additionalData as IWorkflowExecuteAdditionalData,
+					additionalData.executionContext,
+					undefined,
 				);
 
 				expect(result).toBe(staticData);
@@ -388,7 +390,8 @@ describe('DynamicCredentialService', () => {
 				const result = await service.resolveIfNeeded(
 					credentialsEntity,
 					staticData,
-					additionalData as IWorkflowExecuteAdditionalData,
+					additionalData.executionContext,
+					undefined,
 				);
 
 				expect(result).toBe(staticData);
@@ -470,7 +473,8 @@ describe('DynamicCredentialService', () => {
 					service.resolveIfNeeded(
 						credentialsEntity,
 						staticData,
-						additionalData as IWorkflowExecuteAdditionalData,
+						additionalData.executionContext,
+						undefined,
 					),
 				).rejects.toThrow(CredentialResolutionError);
 
@@ -478,7 +482,8 @@ describe('DynamicCredentialService', () => {
 					service.resolveIfNeeded(
 						credentialsEntity,
 						staticData,
-						additionalData as IWorkflowExecuteAdditionalData,
+						additionalData.executionContext,
+						undefined,
 					),
 				).rejects.toThrow('Failed to resolve dynamic credentials for "Test Credential"');
 
@@ -523,7 +528,8 @@ describe('DynamicCredentialService', () => {
 				const result = await service.resolveIfNeeded(
 					credentialsEntity,
 					staticOAuthData,
-					additionalData as IWorkflowExecuteAdditionalData,
+					additionalData.executionContext,
+					undefined,
 				);
 
 				// Verify merge: static fields preserved, dynamic fields added/overridden
@@ -575,7 +581,8 @@ describe('DynamicCredentialService', () => {
 				await service.resolveIfNeeded(
 					credentialsEntity,
 					staticData,
-					additionalData as IWorkflowExecuteAdditionalData,
+					additionalData.executionContext,
+					undefined,
 				);
 
 				expect(mockResolver.getSecret).toHaveBeenCalledWith('cred-123', credentialContext, {
@@ -609,7 +616,8 @@ describe('DynamicCredentialService', () => {
 				await service.resolveIfNeeded(
 					credentialsEntity,
 					staticData,
-					additionalData as IWorkflowExecuteAdditionalData,
+					additionalData.executionContext,
+					undefined,
 				);
 
 				expect(mockResolver.getSecret).toHaveBeenCalledWith(
@@ -642,7 +650,8 @@ describe('DynamicCredentialService', () => {
 				const result = await service.resolveIfNeeded(
 					credentialsEntity,
 					staticData,
-					additionalData as IWorkflowExecuteAdditionalData,
+					additionalData.executionContext,
+					undefined,
 				);
 
 				expect(result).toBe(staticData);
@@ -665,7 +674,8 @@ describe('DynamicCredentialService', () => {
 				const result = await service.resolveIfNeeded(
 					credentialsEntity,
 					staticData,
-					additionalData as IWorkflowExecuteAdditionalData,
+					additionalData.executionContext,
+					undefined,
 				);
 
 				expect(result).toBe(staticData);
@@ -691,7 +701,8 @@ describe('DynamicCredentialService', () => {
 				await service.resolveIfNeeded(
 					credentialsEntity,
 					staticData,
-					additionalData as IWorkflowExecuteAdditionalData,
+					additionalData.executionContext,
+					undefined,
 				);
 
 				expect(mockResolver.getSecret).toHaveBeenCalledWith('cred-123', credentialContext, {
@@ -729,7 +740,8 @@ describe('DynamicCredentialService', () => {
 				const result = await service.resolveIfNeeded(
 					credentialsEntity,
 					staticData,
-					additionalData as IWorkflowExecuteAdditionalData,
+					additionalData.executionContext,
+					additionalData.workflowSettings,
 				);
 
 				expect(mockResolverRepository.findOneBy).toHaveBeenCalledWith({
@@ -771,7 +783,8 @@ describe('DynamicCredentialService', () => {
 				const result = await service.resolveIfNeeded(
 					credentialsEntity,
 					staticData,
-					additionalData as IWorkflowExecuteAdditionalData,
+					additionalData.executionContext,
+					undefined,
 				);
 
 				expect(mockResolverRepository.findOneBy).toHaveBeenCalledWith({
@@ -805,7 +818,8 @@ describe('DynamicCredentialService', () => {
 				const result = await service.resolveIfNeeded(
 					credentialsEntity,
 					staticData,
-					additionalData as IWorkflowExecuteAdditionalData,
+					additionalData.executionContext,
+					additionalData.workflowSettings,
 				);
 
 				expect(result).toBe(staticData);
@@ -852,7 +866,8 @@ describe('DynamicCredentialService', () => {
 				await service.resolveIfNeeded(
 					credentialsEntity,
 					staticData,
-					additionalData as IWorkflowExecuteAdditionalData,
+					additionalData.executionContext,
+					undefined,
 					false,
 				);
 
@@ -899,7 +914,8 @@ describe('DynamicCredentialService', () => {
 				await service.resolveIfNeeded(
 					credentialsEntity,
 					staticData,
-					additionalData as IWorkflowExecuteAdditionalData,
+					additionalData.executionContext,
+					undefined,
 					true, // canUseExternalSecrets = true (enables $secrets support)
 				);
 
@@ -941,7 +957,8 @@ describe('DynamicCredentialService', () => {
 				await service.resolveIfNeeded(
 					credentialsEntity,
 					staticData,
-					additionalData as IWorkflowExecuteAdditionalData,
+					additionalData.executionContext,
+					undefined,
 					false, // canUseExternalSecrets = false (disables $secrets support)
 				);
 
@@ -988,7 +1005,8 @@ describe('DynamicCredentialService', () => {
 				await service.resolveIfNeeded(
 					credentialsEntity,
 					staticData,
-					additionalData as IWorkflowExecuteAdditionalData,
+					additionalData.executionContext,
+					undefined,
 					false,
 				);
 
@@ -1032,7 +1050,8 @@ describe('DynamicCredentialService', () => {
 				await service.resolveIfNeeded(
 					credentialsEntity,
 					staticData,
-					additionalData as IWorkflowExecuteAdditionalData,
+					additionalData.executionContext,
+					undefined,
 				);
 
 				// Verify config passed as-is (expression not resolved)

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/credential-resolver.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/credential-resolver.service.ts
@@ -159,13 +159,10 @@ export class DynamicCredentialResolverService {
 			throw new CredentialResolverValidationError(`Unknown resolver type: ${type}`);
 		}
 
-		// Resolve expressions in the config with mock/empty values to validate syntax
+		// Resolve expressions in the config to validate syntax
 		let resolvedConfig = config;
 		try {
-			resolvedConfig = await this.expressionService.resolveForValidation(
-				config,
-				canUseExternalSecrets ?? false,
-			);
+			resolvedConfig = await this.expressionService.resolve(config, canUseExternalSecrets ?? false);
 		} catch (error) {
 			// If expression resolution fails, it means there's a syntax error
 			throw new CredentialResolverValidationError(

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential-storage.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential-storage.service.ts
@@ -4,21 +4,20 @@ import { Cipher } from 'n8n-core';
 import {
 	type ICredentialContext,
 	type ICredentialDataDecryptedObject,
-	isNodeParameters,
 	type IWorkflowSettings,
 	jsonParse,
 } from 'n8n-workflow';
+
+import { DynamicCredentialResolverRegistry } from './credential-resolver-registry.service';
+import { extractSharedFields } from './shared-fields';
+import { DynamicCredentialResolverRepository } from '../database/repositories/credential-resolver.repository';
+import { CredentialStorageError } from '../errors/credential-storage.error';
 
 import type {
 	CredentialStoreMetadata,
 	IDynamicCredentialStorageProvider,
 } from '@/credentials/dynamic-credential-storage.interface';
 import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
-
-import { DynamicCredentialResolverRegistry } from './credential-resolver-registry.service';
-import { extractSharedFields } from './shared-fields';
-import { DynamicCredentialResolverRepository } from '../database/repositories/credential-resolver.repository';
-import { CredentialStorageError } from '../errors/credential-storage.error';
 
 @Service()
 export class DynamicCredentialStorageService implements IDynamicCredentialStorageProvider {
@@ -70,11 +69,6 @@ export class DynamicCredentialStorageService implements IDynamicCredentialStorag
 
 			const decryptedConfig = this.cipher.decrypt(resolverEntity.config);
 			const resolverConfig = jsonParse<Record<string, unknown>>(decryptedConfig);
-			if (!isNodeParameters(resolverConfig)) {
-				throw new CredentialStorageError(
-					`Invalid resolver config format for resolver "${resolverEntity.name}" (${resolverEntity.id})`,
-				);
-			}
 
 			const credentialType = this.loadNodesAndCredentials.getCredential(
 				credentialStoreMetadata.type,

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential.service.ts
@@ -5,11 +5,10 @@ import { Cipher } from 'n8n-core';
 import type {
 	ICredentialDataDecryptedObject,
 	IExecutionContext,
-	INodeParameters,
 	IWorkflowExecuteAdditionalData,
 	WorkflowExecuteMode,
 } from 'n8n-workflow';
-import { isNodeParameters, jsonParse, toCredentialContext } from 'n8n-workflow';
+import { jsonParse, toCredentialContext } from 'n8n-workflow';
 
 import { DynamicCredentialResolverRegistry } from './credential-resolver-registry.service';
 import { ResolverConfigExpressionService } from './resolver-config-expression.service';
@@ -100,14 +99,9 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 			// Decrypt and parse resolver configuration
 			const decryptedConfig = this.cipher.decrypt(resolverEntity.config);
 			const parsedConfig = jsonParse<Record<string, unknown>>(decryptedConfig);
-			if (!isNodeParameters(parsedConfig)) {
-				throw new CredentialResolutionError(
-					`Invalid resolver config format for resolver "${resolverEntity.name}" (${resolverEntity.id})`,
-				);
-			}
 
 			// Type assertion after validation to preserve INodeParameters type
-			let resolverConfig: INodeParameters = parsedConfig;
+			let resolverConfig: Record<string, unknown> = parsedConfig;
 
 			// Resolve expressions in resolver configuration if context is available
 			if (additionalData && mode) {

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/resolver-config-expression.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/resolver-config-expression.service.ts
@@ -85,13 +85,13 @@ export class ResolverConfigExpressionService {
 
 		return workflow.expression.getComplexParameterValue(
 			this.mockNode,
-			config as unknown as INodeParameters,
+			config,
 			'manual',
 			additionalKeys,
 			undefined,
 			undefined,
 			config,
-		) as CredentialResolverConfiguration;
+		) as INodeParameters;
 	}
 
 	/**
@@ -99,11 +99,11 @@ export class ResolverConfigExpressionService {
 	 * Uses actual execution context to resolve expressions to real values.
 	 */
 	resolveForRuntime(
-		config: Record<string, unknown>,
+		config: CredentialResolverConfiguration,
 		additionalData: IWorkflowExecuteAdditionalData,
 		mode: WorkflowExecuteMode,
 		canUseExternalSecrets: boolean,
-	): Record<string, unknown> {
+	): CredentialResolverConfiguration {
 		const workflow = new Workflow({
 			nodes: [this.mockNode],
 			connections: {},
@@ -117,12 +117,12 @@ export class ResolverConfigExpressionService {
 
 		return workflow.expression.getComplexParameterValue(
 			this.mockNode,
-			config as INodeParameters,
+			config,
 			mode,
 			additionalKeys,
 			undefined,
 			undefined,
 			config,
-		) as Record<string, unknown>;
+		) as INodeParameters;
 	}
 }

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/resolver-config-expression.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/resolver-config-expression.service.ts
@@ -13,14 +13,7 @@ import { getBase } from '@/workflow-execute-additional-data';
  */
 @Service()
 export class ResolverConfigExpressionService {
-	private readonly mockNode: INode;
-
-	constructor(private readonly nodeTypes: NodeTypes) {
-		this.mockNode = {
-			id: '1',
-			name: 'Mock Node',
-		} as INode;
-	}
+	constructor(private readonly nodeTypes: NodeTypes) {}
 
 	/**
 	 * Resolves expressions in config using global data only (secrets, variables).
@@ -31,6 +24,11 @@ export class ResolverConfigExpressionService {
 		config: CredentialResolverConfiguration,
 		canUseExternalSecrets = false,
 	): Promise<CredentialResolverConfiguration> {
+		// If config is not INodeParameters, return as is
+		if (!isNodeParameters(config)) {
+			return config;
+		}
+
 		// Create a minimal workflow with the mock node to leverage the expression resolver
 		const workflow = new Workflow({
 			nodes: [],
@@ -44,13 +42,12 @@ export class ResolverConfigExpressionService {
 			secretsEnabled: canUseExternalSecrets,
 		});
 
-		// If config is not INodeParameters, return as is
-		if (!isNodeParameters(config)) {
-			return config;
-		}
-
 		return workflow.expression.getComplexParameterValue(
-			this.mockNode,
+			// Use a mock node (mandatory) to resolve expressions in the config
+			{
+				id: '1',
+				name: 'Mock Node',
+			} as INode,
 			config,
 			'manual',
 			additionalKeys,

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/resolver-config-expression.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/resolver-config-expression.service.ts
@@ -1,0 +1,128 @@
+import { CredentialResolverConfiguration } from '@n8n/decorators';
+import { Service } from '@n8n/di';
+import { getAdditionalKeys } from 'n8n-core';
+import type {
+	INode,
+	INodeParameters,
+	INodeProperties,
+	INodeType,
+	INodeTypeData,
+	INodeTypes,
+	IVersionedNodeType,
+	IWorkflowExecuteAdditionalData,
+	WorkflowExecuteMode,
+} from 'n8n-workflow';
+import { NodeHelpers, UnexpectedError, Workflow } from 'n8n-workflow';
+
+import { getBase } from '@/workflow-execute-additional-data';
+
+/**
+ * Service for resolving expressions in credential resolver configurations.
+ * Provides both validation-time resolution (with mock values) and runtime resolution (with actual execution context).
+ */
+@Service()
+export class ResolverConfigExpressionService {
+	private readonly mockNode: INode;
+
+	private readonly mockNodeTypes: INodeTypes;
+
+	constructor() {
+		// Mock node setup for expression resolution
+		this.mockNode = {
+			id: 'mock',
+			name: '',
+			typeVersion: 1,
+			type: 'mock',
+			position: [0, 0],
+			parameters: {} as INodeParameters,
+		};
+
+		const mockNodesData: INodeTypeData = {
+			mock: {
+				sourcePath: '',
+				type: {
+					description: { properties: [] as INodeProperties[] },
+				} as INodeType,
+			},
+		};
+
+		this.mockNodeTypes = {
+			getKnownTypes(): { [key: string]: { className: string; sourcePath: string } } {
+				return {};
+			},
+			getByName(nodeType: string): INodeType | IVersionedNodeType {
+				return mockNodesData[nodeType]?.type;
+			},
+			getByNameAndVersion(nodeType: string, version?: number): INodeType {
+				if (!mockNodesData[nodeType]) {
+					throw new UnexpectedError(`Node type "${nodeType}" not found`);
+				}
+				return NodeHelpers.getVersionedNodeType(mockNodesData[nodeType].type, version);
+			},
+		};
+	}
+
+	/**
+	 * Resolves expressions in config for validation purposes.
+	 * Uses mock/empty values to validate expression syntax during resolver creation/update.
+	 * @throws Error if expression syntax is invalid
+	 */
+	async resolveForValidation(
+		config: CredentialResolverConfiguration,
+		canUseExternalSecrets = false,
+	): Promise<CredentialResolverConfiguration> {
+		const workflow = new Workflow({
+			nodes: [this.mockNode],
+			connections: {},
+			active: false,
+			nodeTypes: this.mockNodeTypes,
+		});
+
+		const additionalData = await getBase();
+		const additionalKeys = getAdditionalKeys(additionalData, 'manual', null, {
+			secretsEnabled: canUseExternalSecrets,
+		});
+
+		return workflow.expression.getComplexParameterValue(
+			this.mockNode,
+			config as unknown as INodeParameters,
+			'manual',
+			additionalKeys,
+			undefined,
+			undefined,
+			config,
+		) as CredentialResolverConfiguration;
+	}
+
+	/**
+	 * Resolves expressions in config for runtime execution.
+	 * Uses actual execution context to resolve expressions to real values.
+	 */
+	resolveForRuntime(
+		config: Record<string, unknown>,
+		additionalData: IWorkflowExecuteAdditionalData,
+		mode: WorkflowExecuteMode,
+		canUseExternalSecrets: boolean,
+	): Record<string, unknown> {
+		const workflow = new Workflow({
+			nodes: [this.mockNode],
+			connections: {},
+			active: false,
+			nodeTypes: this.mockNodeTypes,
+		});
+
+		const additionalKeys = getAdditionalKeys(additionalData, mode, null, {
+			secretsEnabled: canUseExternalSecrets,
+		});
+
+		return workflow.expression.getComplexParameterValue(
+			this.mockNode,
+			config as INodeParameters,
+			mode,
+			additionalKeys,
+			undefined,
+			undefined,
+			config,
+		) as Record<string, unknown>;
+	}
+}

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/resolver-config-expression.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/resolver-config-expression.service.ts
@@ -12,7 +12,7 @@ import type {
 	IWorkflowExecuteAdditionalData,
 	WorkflowExecuteMode,
 } from 'n8n-workflow';
-import { NodeHelpers, UnexpectedError, Workflow } from 'n8n-workflow';
+import { isNodeParameters, NodeHelpers, UnexpectedError, Workflow } from 'n8n-workflow';
 
 import { getBase } from '@/workflow-execute-additional-data';
 
@@ -67,6 +67,7 @@ export class ResolverConfigExpressionService {
 	 * Uses mock/empty values to validate expression syntax during resolver creation/update.
 	 * @throws Error if expression syntax is invalid
 	 */
+
 	async resolveForValidation(
 		config: CredentialResolverConfiguration,
 		canUseExternalSecrets = false,
@@ -82,6 +83,11 @@ export class ResolverConfigExpressionService {
 		const additionalKeys = getAdditionalKeys(additionalData, 'manual', null, {
 			secretsEnabled: canUseExternalSecrets,
 		});
+
+		// If config is not INodeParameters, return as is
+		if (!isNodeParameters(config)) {
+			return config;
+		}
 
 		return workflow.expression.getComplexParameterValue(
 			this.mockNode,
@@ -114,6 +120,11 @@ export class ResolverConfigExpressionService {
 		const additionalKeys = getAdditionalKeys(additionalData, mode, null, {
 			secretsEnabled: canUseExternalSecrets,
 		});
+
+		// If config is not INodeParameters, return as is
+		if (!isNodeParameters(config)) {
+			return config;
+		}
 
 		return workflow.expression.getComplexParameterValue(
 			this.mockNode,

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/resolver-config-expression.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/resolver-config-expression.service.ts
@@ -1,6 +1,6 @@
 import { CredentialResolverConfiguration } from '@n8n/decorators';
 import { Service } from '@n8n/di';
-import { getNonWorkflowAdditionalKeys } from 'n8n-core/src/execution-engine/node-execution-context/utils/get-additional-keys';
+import { getNonWorkflowAdditionalKeys } from 'n8n-core';
 import type { INode, INodeParameters } from 'n8n-workflow';
 import { isNodeParameters, Workflow } from 'n8n-workflow';
 
@@ -16,16 +16,10 @@ export class ResolverConfigExpressionService {
 	private readonly mockNode: INode;
 
 	constructor(private readonly nodeTypes: NodeTypes) {
-		// Mock node setup for expression resolution
-		// We won't use any of its properties, but it's required by the workflow expression resolver
 		this.mockNode = {
-			id: 'mock',
-			name: '',
-			typeVersion: 1,
-			type: 'mock',
-			position: [0, 0],
-			parameters: {} as INodeParameters,
-		};
+			id: '1',
+			name: 'Mock Node',
+		} as INode;
 	}
 
 	/**
@@ -39,7 +33,7 @@ export class ResolverConfigExpressionService {
 	): Promise<CredentialResolverConfiguration> {
 		// Create a minimal workflow with the mock node to leverage the expression resolver
 		const workflow = new Workflow({
-			nodes: [this.mockNode],
+			nodes: [],
 			connections: {},
 			active: false,
 			nodeTypes: this.nodeTypes,

--- a/packages/cli/src/oauth/__tests__/oauth.service.test.ts
+++ b/packages/cli/src/oauth/__tests__/oauth.service.test.ts
@@ -254,9 +254,9 @@ describe('OauthService', () => {
 			expect(credentialsHelper.applyDefaultsAndOverwrites).toHaveBeenCalledWith(
 				additionalData,
 				decryptedData,
-				credential,
 				credential.type,
 				'internal',
+				undefined,
 				undefined,
 				undefined,
 			);
@@ -1094,9 +1094,9 @@ describe('OauthService', () => {
 			expect(credentialsHelper.applyDefaultsAndOverwrites).toHaveBeenCalledWith(
 				mockAdditionalData,
 				{ clientId: 'client-id' },
-				credential,
 				credential.type,
 				'internal',
+				undefined,
 				undefined,
 				undefined,
 			);
@@ -1120,9 +1120,9 @@ describe('OauthService', () => {
 			expect(credentialsHelper.applyDefaultsAndOverwrites).toHaveBeenCalledWith(
 				mockAdditionalData,
 				{ clientId: 'client-id', scope: 'old-scope' },
-				credential,
 				credential.type,
 				'internal',
+				undefined,
 				undefined,
 				undefined,
 			);
@@ -1146,9 +1146,9 @@ describe('OauthService', () => {
 			expect(credentialsHelper.applyDefaultsAndOverwrites).toHaveBeenCalledWith(
 				mockAdditionalData,
 				{ clientId: 'client-id', scope: 'old-scope' },
-				credential,
 				credential.type,
 				'internal',
+				undefined,
 				undefined,
 				undefined,
 			);

--- a/packages/cli/src/oauth/oauth.service.ts
+++ b/packages/cli/src/oauth/oauth.service.ts
@@ -150,12 +150,14 @@ export class OauthService {
 		decryptedData: ICredentialDataDecryptedObject,
 		additionalData: IWorkflowExecuteAdditionalData,
 	) {
+		const canUseExternalSecrets =
+			await this.credentialsHelper.credentialCanUseExternalSecrets(credential);
 		return (await this.credentialsHelper.applyDefaultsAndOverwrites(
 			additionalData,
 			decryptedData,
-			credential,
 			credential.type,
 			'internal',
+			canUseExternalSecrets,
 			undefined,
 			undefined,
 		)) as unknown as T;

--- a/packages/cli/src/services/credentials-tester.service.ts
+++ b/packages/cli/src/services/credentials-tester.service.ts
@@ -214,12 +214,14 @@ export class CredentialsTester {
 				credentialsDataSecretKeys = getAllKeyPaths(credentialsDecrypted.data, '', [], (value) =>
 					value.includes('$secrets.'),
 				);
+				const canUseExternalSecrets =
+					await this.credentialsHelper.credentialCanUseExternalSecrets(credentialsDecrypted);
 				credentialsDecrypted.data = await this.credentialsHelper.applyDefaultsAndOverwrites(
 					additionalData,
 					credentialsDecrypted.data,
-					credentialsDecrypted,
 					credentialType,
 					'internal' as WorkflowExecuteMode,
+					canUseExternalSecrets,
 					undefined,
 					undefined,
 				);

--- a/packages/cli/test/integration/dynamic-credentials.ee/credential-resolvers.api.test.ts
+++ b/packages/cli/test/integration/dynamic-credentials.ee/credential-resolvers.api.test.ts
@@ -62,11 +62,13 @@ describe('Credential Resolvers API', () => {
 				name: 'Resolver 1',
 				type: 'credential-resolver.stub-1.0',
 				config: { prefix: 'test1-' },
+				user: owner,
 			});
 			await service.create({
 				name: 'Resolver 2',
 				type: 'credential-resolver.stub-1.0',
 				config: { prefix: 'test2-' },
+				user: owner,
 			});
 
 			const response = await ownerAgent.get('/credential-resolvers').expect(200);
@@ -159,6 +161,7 @@ describe('Credential Resolvers API', () => {
 				name: 'Test Resolver',
 				type: 'credential-resolver.stub-1.0',
 				config: { prefix: 'test-' },
+				user: owner,
 			});
 
 			const response = await ownerAgent.get(`/credential-resolvers/${resolver.id}`).expect(200);
@@ -181,6 +184,7 @@ describe('Credential Resolvers API', () => {
 				name: 'Original Name',
 				type: 'credential-resolver.stub-1.0',
 				config: { prefix: 'test-' },
+				user: owner,
 			});
 
 			const response = await ownerAgent
@@ -205,6 +209,7 @@ describe('Credential Resolvers API', () => {
 				name: 'Test Resolver',
 				type: 'credential-resolver.stub-1.0',
 				config: { prefix: 'test-' },
+				user: owner,
 			});
 
 			const response = await ownerAgent.delete(`/credential-resolvers/${resolver.id}`).expect(200);

--- a/packages/core/src/execution-engine/node-execution-context/index.ts
+++ b/packages/core/src/execution-engine/node-execution-context/index.ts
@@ -10,7 +10,7 @@ export { TriggerContext } from './trigger-context';
 export { WebhookContext } from './webhook-context';
 
 export { constructExecutionMetaData } from './utils/construct-execution-metadata';
-export { getAdditionalKeys } from './utils/get-additional-keys';
+export { getAdditionalKeys, getNonWorkflowAdditionalKeys } from './utils/get-additional-keys';
 export { normalizeItems } from './utils/normalize-items';
 export { parseIncomingMessage } from './utils/parse-incoming-message';
 export { parseRequestObject } from './utils/request-helper-functions';

--- a/packages/core/src/execution-engine/node-execution-context/utils/get-additional-keys.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/get-additional-keys.ts
@@ -73,3 +73,17 @@ export function getAdditionalKeys(
 		$resumeWebhookUrl: resumeUrl,
 	};
 }
+
+/**
+ * Returns the global additional keys for Expressions
+ * without workflow execution context
+ * */
+export function getNonWorkflowAdditionalKeys(
+	additionalData: IWorkflowExecuteAdditionalData,
+	options?: { secretsEnabled?: boolean },
+): IWorkflowDataProxyAdditionalKeys {
+	return {
+		$vars: additionalData.variables,
+		$secrets: options?.secretsEnabled ? getSecretsProxy(additionalData) : undefined,
+	};
+}

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -80,6 +80,7 @@ export * as ExpressionParser from './extensions/expression-parser';
 export { NativeMethods } from './native-methods';
 export * from './node-parameters/filter-parameter';
 export * from './node-parameters/parameter-type-validation';
+export * from './node-parameters/node-parameter-value-type-guard';
 export * from './node-parameters/path-utils';
 export * from './evaluation-helpers';
 export * from './workflow-diff';

--- a/packages/workflow/src/node-parameters/node-parameter-value-type-guard.ts
+++ b/packages/workflow/src/node-parameters/node-parameter-value-type-guard.ts
@@ -58,8 +58,7 @@ export function isNodeParameters(value: unknown): value is INodeParameters {
 
 	// Reject built-in class instances (Date, RegExp, etc.)
 	// Only accept plain objects created with {} or Object.create(null)
-	const proto = Object.getPrototypeOf(value);
-	if (proto !== null && proto !== Object.prototype) {
+	if (Object.prototype.toString.call(value) !== '[object Object]') {
 		return false;
 	}
 

--- a/packages/workflow/src/node-parameters/node-parameter-value-type-guard.ts
+++ b/packages/workflow/src/node-parameters/node-parameter-value-type-guard.ts
@@ -56,6 +56,13 @@ export function isNodeParameters(value: unknown): value is INodeParameters {
 		return false;
 	}
 
+	// Reject built-in class instances (Date, RegExp, etc.)
+	// Only accept plain objects created with {} or Object.create(null)
+	const proto = Object.getPrototypeOf(value);
+	if (proto !== null && proto !== Object.prototype) {
+		return false;
+	}
+
 	// Recursively validate all values
 	return Object.values(value).every((val) => isValidNodeParameterValueType(val));
 }

--- a/packages/workflow/src/node-parameters/node-parameter-value-type-guard.ts
+++ b/packages/workflow/src/node-parameters/node-parameter-value-type-guard.ts
@@ -1,0 +1,161 @@
+import type {
+	AssignmentCollectionValue,
+	INodeParameters,
+	NodeParameterValue,
+	NodeParameterValueType,
+} from '../interfaces';
+import { isResourceLocatorValue, isResourceMapperValue, isFilterValue } from '../type-guards';
+
+/**
+ * Type guard for primitive NodeParameterValue types.
+ * Checks if a value is string, number, boolean, undefined, or null.
+ */
+export function isNodeParameterValue(value: unknown): value is NodeParameterValue {
+	return (
+		typeof value === 'string' ||
+		typeof value === 'number' ||
+		typeof value === 'boolean' ||
+		value === undefined ||
+		value === null
+	);
+}
+
+/**
+ * Type guard for AssignmentCollectionValue.
+ * Checks if a value has the structure of an assignment collection.
+ */
+export function isAssignmentCollectionValue(value: unknown): value is AssignmentCollectionValue {
+	if (typeof value !== 'object' || value === null || !('assignments' in value)) {
+		return false;
+	}
+
+	const assignments = (value as AssignmentCollectionValue).assignments;
+	if (!Array.isArray(assignments)) {
+		return false;
+	}
+
+	return assignments.every(
+		(assignment) =>
+			typeof assignment === 'object' &&
+			assignment !== null &&
+			'id' in assignment &&
+			'name' in assignment &&
+			'value' in assignment &&
+			typeof assignment.id === 'string' &&
+			typeof assignment.name === 'string' &&
+			isNodeParameterValue(assignment.value),
+	);
+}
+
+/**
+ * Type guard for INodeParameters.
+ * Recursively validates that all values in the object are valid NodeParameterValueType.
+ */
+export function isNodeParameters(value: unknown): value is INodeParameters {
+	if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+		return false;
+	}
+
+	// Recursively validate all values
+	return Object.values(value).every((val) => isValidNodeParameterValueType(val));
+}
+
+/**
+ * Comprehensive type guard for NodeParameterValueType.
+ * Validates that a value matches any of the valid node parameter value types.
+ *
+ * @param value - The value to check
+ * @returns true if the value is a valid NodeParameterValueType
+ *
+ * @example
+ * ```typescript
+ * const value: unknown = { foo: 'bar' };
+ * if (isValidNodeParameterValueType(value)) {
+ *   // value is now typed as NodeParameterValueType
+ * }
+ * ```
+ */
+export function isValidNodeParameterValueType(value: unknown): value is NodeParameterValueType {
+	// Check primitives first (most common case)
+	if (isNodeParameterValue(value)) {
+		return true;
+	}
+
+	// Check special object types
+	if (isResourceLocatorValue(value)) {
+		return true;
+	}
+
+	if (isResourceMapperValue(value)) {
+		return true;
+	}
+
+	if (isFilterValue(value)) {
+		return true;
+	}
+
+	if (isAssignmentCollectionValue(value)) {
+		return true;
+	}
+
+	// Check arrays
+	if (Array.isArray(value)) {
+		// Empty arrays are valid
+		if (value.length === 0) {
+			return true;
+		}
+
+		// Check if it's an array of primitives
+		if (value.every(isNodeParameterValue)) {
+			return true;
+		}
+
+		// Check if it's an array of INodeParameters
+		if (value.every(isNodeParameters)) {
+			return true;
+		}
+
+		// Check if it's an array of resource locators
+		if (value.every(isResourceLocatorValue)) {
+			return true;
+		}
+
+		// Check if it's an array of resource mapper values
+		if (value.every(isResourceMapperValue)) {
+			return true;
+		}
+
+		return false;
+	}
+
+	// Check if it's INodeParameters (must be last to avoid infinite recursion on first check)
+	if (isNodeParameters(value)) {
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * Assertion function that throws if the value is not a valid NodeParameterValueType.
+ * Useful for runtime validation with TypeScript type narrowing.
+ *
+ * @param value - The value to validate
+ * @param errorMessage - Optional custom error message
+ * @throws Error if the value is not a valid NodeParameterValueType
+ *
+ * @example
+ * ```typescript
+ * const value: unknown = getData();
+ * assertIsValidNodeParameterValueType(value);
+ * // value is now typed as NodeParameterValueType
+ * ```
+ */
+export function assertIsValidNodeParameterValueType(
+	value: unknown,
+	errorMessage = 'Value is not a valid NodeParameterValueType',
+): asserts value is NodeParameterValueType {
+	if (!isValidNodeParameterValueType(value)) {
+		throw new Error(errorMessage);
+	}
+}

--- a/packages/workflow/src/node-parameters/node-parameter-value-type-guard.ts
+++ b/packages/workflow/src/node-parameters/node-parameter-value-type-guard.ts
@@ -82,64 +82,24 @@ export function isNodeParameters(value: unknown): value is INodeParameters {
  * ```
  */
 export function isValidNodeParameterValueType(value: unknown): value is NodeParameterValueType {
-	// Check primitives first (most common case)
-	if (isNodeParameterValue(value)) {
-		return true;
-	}
-
-	// Check special object types
-	if (isResourceLocatorValue(value)) {
-		return true;
-	}
-
-	if (isResourceMapperValue(value)) {
-		return true;
-	}
-
-	if (isFilterValue(value)) {
-		return true;
-	}
-
-	if (isAssignmentCollectionValue(value)) {
-		return true;
-	}
-
-	// Check arrays
-	if (Array.isArray(value)) {
-		// Empty arrays are valid
-		if (value.length === 0) {
-			return true;
-		}
-
-		// Check if it's an array of primitives
-		if (value.every(isNodeParameterValue)) {
-			return true;
-		}
-
-		// Check if it's an array of INodeParameters
-		if (value.every(isNodeParameters)) {
-			return true;
-		}
-
-		// Check if it's an array of resource locators
-		if (value.every(isResourceLocatorValue)) {
-			return true;
-		}
-
-		// Check if it's an array of resource mapper values
-		if (value.every(isResourceMapperValue)) {
-			return true;
-		}
-
-		return false;
-	}
-
-	// Check if it's INodeParameters (must be last to avoid infinite recursion on first check)
-	if (isNodeParameters(value)) {
-		return true;
-	}
-
-	return false;
+	return (
+		// Primitives (most common case)
+		isNodeParameterValue(value) ||
+		// Special object types
+		isResourceLocatorValue(value) ||
+		isResourceMapperValue(value) ||
+		isFilterValue(value) ||
+		isAssignmentCollectionValue(value) ||
+		// Arrays - all items should be valid NodeParameterValueType
+		(Array.isArray(value) &&
+			(value.length === 0 ||
+				value.every(isNodeParameterValue) ||
+				value.every(isNodeParameters) ||
+				value.every(isResourceLocatorValue) ||
+				value.every(isResourceMapperValue))) ||
+		// INodeParameters (must be last to avoid infinite recursion on first check)
+		isNodeParameters(value)
+	);
 }
 
 /**

--- a/packages/workflow/test/node-parameters/node-parameter-value-type-guard.test.ts
+++ b/packages/workflow/test/node-parameters/node-parameter-value-type-guard.test.ts
@@ -1,0 +1,190 @@
+import {
+	isNodeParameterValue,
+	isNodeParameters,
+	isValidNodeParameterValueType,
+	assertIsValidNodeParameterValueType,
+	isAssignmentCollectionValue,
+} from '../../src/node-parameters/node-parameter-value-type-guard';
+
+describe('node-parameter-value-type-guard', () => {
+	describe('isNodeParameterValue', () => {
+		it('should return true for primitives', () => {
+			expect(isNodeParameterValue('string')).toBe(true);
+			expect(isNodeParameterValue(42)).toBe(true);
+			expect(isNodeParameterValue(true)).toBe(true);
+			expect(isNodeParameterValue(false)).toBe(true);
+			expect(isNodeParameterValue(null)).toBe(true);
+			expect(isNodeParameterValue(undefined)).toBe(true);
+		});
+
+		it('should return false for non-primitives', () => {
+			expect(isNodeParameterValue({})).toBe(false);
+			expect(isNodeParameterValue([])).toBe(false);
+			expect(isNodeParameterValue(() => {})).toBe(false);
+			expect(isNodeParameterValue(Symbol('test'))).toBe(false);
+		});
+	});
+
+	describe('isNodeParameters', () => {
+		it('should return true for valid INodeParameters objects', () => {
+			expect(isNodeParameters({})).toBe(true);
+			expect(isNodeParameters({ key: 'value' })).toBe(true);
+			expect(isNodeParameters({ key: 123 })).toBe(true);
+			expect(isNodeParameters({ key: true })).toBe(true);
+			expect(isNodeParameters({ nested: { key: 'value' } })).toBe(true);
+		});
+
+		it('should return false for non-objects', () => {
+			expect(isNodeParameters('string')).toBe(false);
+			expect(isNodeParameters(123)).toBe(false);
+			expect(isNodeParameters(null)).toBe(false);
+			expect(isNodeParameters(undefined)).toBe(false);
+			expect(isNodeParameters([])).toBe(false);
+		});
+
+		it('should return false for objects with invalid values', () => {
+			expect(isNodeParameters({ key: () => {} })).toBe(false);
+			expect(isNodeParameters({ key: Symbol('test') })).toBe(false);
+			expect(isNodeParameters({ key: new Date() })).toBe(false);
+		});
+
+		it('should handle nested objects', () => {
+			expect(
+				isNodeParameters({
+					level1: {
+						level2: {
+							level3: 'value',
+						},
+					},
+				}),
+			).toBe(true);
+
+			expect(
+				isNodeParameters({
+					level1: {
+						level2: {
+							level3: () => {},
+						},
+					},
+				}),
+			).toBe(false);
+		});
+	});
+
+	describe('isAssignmentCollectionValue', () => {
+		it('should return true for valid assignment collections', () => {
+			expect(
+				isAssignmentCollectionValue({
+					assignments: [
+						{
+							id: '1',
+							name: 'test',
+							value: 'value',
+						},
+					],
+				}),
+			).toBe(true);
+
+			expect(isAssignmentCollectionValue({ assignments: [] })).toBe(true);
+		});
+
+		it('should return false for invalid assignment collections', () => {
+			expect(isAssignmentCollectionValue({})).toBe(false);
+			expect(isAssignmentCollectionValue({ assignments: 'not-array' })).toBe(false);
+			expect(
+				isAssignmentCollectionValue({
+					assignments: [
+						{
+							id: '1',
+							// missing name and value
+						},
+					],
+				}),
+			).toBe(false);
+		});
+	});
+
+	describe('isValidNodeParameterValueType', () => {
+		it('should return true for all valid types', () => {
+			// Primitives
+			expect(isValidNodeParameterValueType('string')).toBe(true);
+			expect(isValidNodeParameterValueType(123)).toBe(true);
+			expect(isValidNodeParameterValueType(true)).toBe(true);
+			expect(isValidNodeParameterValueType(null)).toBe(true);
+			expect(isValidNodeParameterValueType(undefined)).toBe(true);
+
+			// Objects
+			expect(isValidNodeParameterValueType({})).toBe(true);
+			expect(isValidNodeParameterValueType({ key: 'value' })).toBe(true);
+
+			// Arrays
+			expect(isValidNodeParameterValueType([])).toBe(true);
+			expect(isValidNodeParameterValueType(['string'])).toBe(true);
+			expect(isValidNodeParameterValueType([1, 2, 3])).toBe(true);
+			expect(isValidNodeParameterValueType([{ key: 'value' }])).toBe(true);
+
+			// Resource locator
+			expect(
+				isValidNodeParameterValueType({
+					__rl: true,
+					mode: 'id',
+					value: '123',
+				}),
+			).toBe(true);
+
+			// Resource mapper
+			expect(
+				isValidNodeParameterValueType({
+					mappingMode: 'defineBelow',
+					schema: [],
+					value: {},
+				}),
+			).toBe(true);
+
+			// Filter value
+			expect(
+				isValidNodeParameterValueType({
+					conditions: [],
+					combinator: 'and',
+				}),
+			).toBe(true);
+
+			// Assignment collection
+			expect(
+				isValidNodeParameterValueType({
+					assignments: [{ id: '1', name: 'test', value: 'value' }],
+				}),
+			).toBe(true);
+		});
+
+		it('should return false for invalid types', () => {
+			expect(isValidNodeParameterValueType(() => {})).toBe(false);
+			expect(isValidNodeParameterValueType(Symbol('test'))).toBe(false);
+			expect(isValidNodeParameterValueType(new Date())).toBe(false);
+			expect(isValidNodeParameterValueType({ key: () => {} })).toBe(false);
+			expect(isValidNodeParameterValueType([() => {}])).toBe(false);
+		});
+	});
+
+	describe('assertIsValidNodeParameterValueType', () => {
+		it('should not throw for valid values', () => {
+			expect(() => assertIsValidNodeParameterValueType('string')).not.toThrow();
+			expect(() => assertIsValidNodeParameterValueType(123)).not.toThrow();
+			expect(() => assertIsValidNodeParameterValueType({})).not.toThrow();
+		});
+
+		it('should throw for invalid values', () => {
+			expect(() => assertIsValidNodeParameterValueType(() => {})).toThrow(
+				'Value is not a valid NodeParameterValueType',
+			);
+			expect(() => assertIsValidNodeParameterValueType(Symbol('test'))).toThrow();
+			expect(() => assertIsValidNodeParameterValueType(new Date())).toThrow();
+		});
+
+		it('should support custom error messages', () => {
+			expect(() => assertIsValidNodeParameterValueType(() => {}, 'Custom error')).toThrow(
+				'Custom error',
+			);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR adds expression resolution support for credential resolver configurations in the dynamic credentials system. It allows users to use n8n expressions (like $execution.id, $vars.*, $secrets.*) within credential resolver configs.

 ### Key Changes

New **ResolverConfigExpressionService** (packages/cli/src/modules/dynamic-credentials.ee/services/resolver-config-expression.service.ts)
  - Handles resolving expressions in resolver configs at runtime and validation time
  - Supports $execution, $vars, and $secrets expressions

Type-safe resolver configuration
  - Changed CredentialResolverConfiguration from Record<string, unknown> to INodeParameters for proper type checking when executing expression resolutions
  - Added isNodeParameters type guard in packages/workflow for validating config format

Updated credential resolution flow
  - resolveIfNeeded now receives additionalData, mode, and canUseExternalSecrets instead of separate executionContext and workflowSettings
  - This provides full context needed for expression resolution

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-4302/support-expressions-in-resolver-config

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
