### PR TITLE
fix: Make sure duplicating workflows creates them as unpublished (no-changelog)

### DIFF
--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -109,7 +109,9 @@ export class WorkflowsController {
 			);
 
 			// @ts-expect-error: We shouldn't accept this
-			req.body.activeVersionId = undefined;
+			delete req.body.activeVersionId;
+			// @ts-expect-error: We shouldn't accept this
+			delete req.body.activeVersion;
 			req.body.active = false;
 		}
 
@@ -213,12 +215,6 @@ export class WorkflowsController {
 				autosaved,
 				transactionManager,
 			);
-
-			const shouldActivate = req.body.active === true;
-			if (shouldActivate) {
-				workflow.activeVersionId = workflow.versionId;
-				await transactionManager.save(workflow);
-			}
 
 			return await this.workflowFinderService.findWorkflowForUser(
 				workflow.id,

--- a/packages/frontend/editor-ui/src/app/components/DuplicateWorkflowDialog.vue
+++ b/packages/frontend/editor-ui/src/app/components/DuplicateWorkflowDialog.vue
@@ -96,6 +96,9 @@ const save = async (): Promise<void> => {
 				id,
 				homeProject,
 				sharedWithProjects,
+				activeVersionId,
+				activeVersion,
+				active,
 				...workflow
 			} = await workflowsStore.fetchWorkflow(props.data.id);
 			workflowToUpdate = workflow;


### PR DESCRIPTION
## Summary

When duplicating a published workflow, 2 problems were happening:
1. Frontend was sending a create payload with all the active fields set,
2. Backend was ignoring `active` and `activeVersionId` fields, but not `activeVersion`, so if `activeVersion` was set in the payload, workflow was created as published.

This PR fixes both problems.

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-4533](https://linear.app/n8n/issue/ADO-4533/bug-duplicating-workflows-doesnt-properly-update-active-version)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
