### PR TITLE
fix(editor): Cannot copy JSON in log view for sub executions

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
@@ -1920,6 +1920,7 @@ defineExpose({ enterEditMode });
 					:total-runs="maxRunIndex"
 					:search="search"
 					:compact="props.compact"
+					:execution="workflowExecution"
 				/>
 			</Suspense>
 

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataJson.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataJson.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, defineAsyncComponent, ref } from 'vue';
 import VueJsonPretty from 'vue-json-pretty';
-import type { INodeExecutionData } from 'n8n-workflow';
+import type { INodeExecutionData, IRunExecutionData } from 'n8n-workflow';
 import Draggable from '@/app/components/Draggable.vue';
 import { executionDataToJson } from '@/app/utils/nodeTypesUtils';
 import { isString } from '@/app/utils/typeGuards';
@@ -35,6 +35,7 @@ const props = withDefaults(
 		totalRuns: number | undefined;
 		search: string | undefined;
 		compact?: boolean;
+		execution?: IRunExecutionData;
 	}>(),
 	{
 		editMode: () => ({}),
@@ -147,6 +148,7 @@ const getListItemName = (path: string) => {
 				:json-data="jsonData"
 				:output-index="outputIndex"
 				:run-index="runIndex"
+				:execution="execution"
 			/>
 		</Suspense>
 		<Draggable

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataJsonActions.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataJsonActions.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import jp from 'jsonpath';
 import type { INodeUi } from '@/Interface';
-import type { IDataObject } from 'n8n-workflow';
+import { NodeConnectionTypes, type IDataObject, type IRunExecutionData } from 'n8n-workflow';
 import { clearJsonKey, convertPath } from '@/app/utils/typesUtils';
 import { executionDataToJson } from '@/app/utils/nodeTypesUtils';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
@@ -32,6 +32,7 @@ const props = withDefaults(
 		jsonData: IDataObject[];
 		outputIndex: number | undefined;
 		runIndex: number | undefined;
+		execution?: IRunExecutionData;
 	}>(),
 	{
 		selectedJsonPath: nonExistingJsonPath,
@@ -76,7 +77,14 @@ function getJsonValue(): string {
 			selectedValue = clearJsonKey(pinnedData.data.value as object);
 		} else {
 			selectedValue = executionDataToJson(
-				nodeHelpers.getNodeInputData(props.node, props.runIndex, props.outputIndex),
+				nodeHelpers.getNodeInputData(
+					props.node,
+					props.runIndex,
+					props.outputIndex,
+					'output',
+					NodeConnectionTypes.Main,
+					props.execution,
+				),
 			);
 		}
 	} else {


### PR DESCRIPTION
## Summary

This PR fixes the bug in log view where the copy action in JSON mode does not work.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1908/copy-to-clipboard-in-logs-not-working


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
