### PR TITLE
fix(editor): Fix style of concurrent execution header

### DIFF
--- a/packages/frontend/editor-ui/src/features/execution/executions/components/ConcurrentExecutionsHeader.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/ConcurrentExecutionsHeader.vue
@@ -42,7 +42,7 @@ const headerText = computed(() => {
 </script>
 
 <template>
-	<div data-test-id="concurrent-executions-header">
+	<div data-test-id="concurrent-executions-header" :class="$style.concurrentExecutionHeader">
 		<N8nText>{{ headerText }}</N8nText>
 		<N8nTooltip>
 			<template #content>
@@ -78,5 +78,9 @@ const headerText = computed(() => {
 }
 .link {
 	margin-top: var(--spacing--xs);
+}
+.concurrentExecutionHeader {
+	display: flex;
+	align-items: center;
 }
 </style>


### PR DESCRIPTION
## Summary

Minor style fix

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/PAY-4145/no-active-executions-indicator-not-aligned-on-executions-list


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
