### PR TITLE
fix(Evaluation Node): Docs link falls back to default

### DIFF
--- a/packages/nodes-base/nodes/Evaluation/Evaluation/Evaluation.node.ee.ts
+++ b/packages/nodes-base/nodes/Evaluation/Evaluation/Evaluation.node.ee.ts
@@ -42,9 +42,6 @@ export class Evaluation implements INodeType {
 		// Pass function explicitly since expression context doesn't allow imports in getInputConnectionTypes
 		inputs: `={{(${getInputConnectionTypes})($parameter, ${metricRequiresModelConnection})}}`,
 		outputs: `={{(${getOutputConnectionTypes})($parameter)}}`,
-		codex: {
-			alias: ['Test', 'Metrics', 'Evals', 'Set Output', 'Set Metrics'],
-		},
 		credentials: [
 			{
 				name: 'googleApi',

--- a/packages/nodes-base/scripts/copy-nodes-json.js
+++ b/packages/nodes-base/scripts/copy-nodes-json.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 
 function copyJsonFiles(baseDir) {
-	const files = glob.sync('nodes/**/*.node.json', { cwd: baseDir });
+	const files = glob.sync('nodes/**/*.node{,.ee}.json', { cwd: baseDir });
 	for (const file of files) {
 		fs.copyFileSync(path.resolve(baseDir, file), path.resolve(baseDir, 'dist', file));
 	}


### PR DESCRIPTION
## Summary

Fix the Docs link of the Evaluation Node.

## Related Linear tickets, Github issues, and Community forum posts

fixes #NODE-4079

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
