### PR TITLE
fix(editor): Add `defaultLocale` to public settings

### DIFF
--- a/packages/cli/src/services/__tests__/frontend.service.test.ts
+++ b/packages/cli/src/services/__tests__/frontend.service.test.ts
@@ -210,6 +210,7 @@ describe('FrontendService', () => {
 		it('should return public settings', async () => {
 			const expectedPublicSettings: PublicFrontendSettings = {
 				settingsMode: 'public',
+				defaultLocale: 'en',
 				userManagement: {
 					smtpSetup: false,
 					showSetupOnFirstLoad: true,

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -40,6 +40,9 @@ export type PublicFrontendSettings = {
 	/** Controls initialization flow in settings store */
 	settingsMode: FrontendSettings['settingsMode'];
 
+	/** Used to localize login page UI */
+	defaultLocale: FrontendSettings['defaultLocale'];
+
 	/** Used to bypass authentication on the workflows/demo page */
 	previewMode: FrontendSettings['previewMode'];
 
@@ -522,6 +525,7 @@ export class FrontendService {
 	async getPublicSettings(): Promise<PublicFrontendSettings> {
 		// Get full settings to ensure all required properties are initialized
 		const {
+			defaultLocale,
 			userManagement: { authenticationMethod, showSetupOnFirstLoad, smtpSetup },
 			sso: { saml: ssoSaml, ldap: ssoLdap, oidc: ssoOidc },
 			authCookie,
@@ -531,6 +535,7 @@ export class FrontendService {
 
 		const publicSettings: PublicFrontendSettings = {
 			settingsMode: 'public',
+			defaultLocale,
 			userManagement: { authenticationMethod, showSetupOnFirstLoad, smtpSetup },
 			sso: {
 				saml: {

--- a/packages/frontend/editor-ui/src/app/stores/settings.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/settings.store.test.ts
@@ -138,7 +138,7 @@ describe('settings.store', () => {
 				expect(mockRootStore.setOauthCallbackUrls).not.toHaveBeenCalledWith(
 					mockSettings.oauthCallbackUrls,
 				);
-				expect(mockRootStore.setDefaultLocale).not.toHaveBeenCalledWith(mockSettings.defaultLocale);
+				expect(mockRootStore.setDefaultLocale).toHaveBeenCalledWith(mockSettings.defaultLocale);
 				expect(mockRootStore.setInstanceId).not.toHaveBeenCalledWith(mockSettings.instanceId);
 				expect(mockRootStore.setUrlBaseWebhook).not.toHaveBeenCalled();
 				expect(mockRootStore.setUrlBaseEditor).not.toHaveBeenCalled();

--- a/packages/frontend/editor-ui/src/app/stores/settings.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/settings.store.ts
@@ -245,7 +245,7 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 		if (fetchedSettings.settingsMode === 'public') {
 			// public settings mode is typically used for unauthenticated users
 			// when public settings are returned we can skip the rest of the setup
-			// that need the full set of auntenticated settings
+			// that need the full set of authenticated settings
 			return;
 		}
 

--- a/packages/frontend/editor-ui/src/app/stores/settings.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/settings.store.ts
@@ -185,6 +185,8 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 	const setSettings = (newSettings: FrontendSettings) => {
 		settings.value = newSettings;
 
+		useRootStore().setDefaultLocale(settings.value.defaultLocale);
+
 		userManagement.value = newSettings.userManagement;
 		if (userManagement.value) {
 			userManagement.value.showSetupOnFirstLoad =

--- a/packages/frontend/editor-ui/src/app/stores/settings.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/settings.store.ts
@@ -185,8 +185,6 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 	const setSettings = (newSettings: FrontendSettings) => {
 		settings.value = newSettings;
 
-		useRootStore().setDefaultLocale(settings.value.defaultLocale);
-
 		userManagement.value = newSettings.userManagement;
 		if (userManagement.value) {
 			userManagement.value.showSetupOnFirstLoad =
@@ -241,6 +239,7 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 		const fetchedSettings = await settingsApi.getSettings(rootStore.restApiContext);
 
 		setSettings(fetchedSettings);
+		rootStore.setDefaultLocale(fetchedSettings.defaultLocale);
 
 		if (fetchedSettings.settingsMode === 'public') {
 			// public settings mode is typically used for unauthenticated users
@@ -276,7 +275,6 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 		rootStore.setInstanceId(fetchedSettings.instanceId);
 		rootStore.setOauthCallbackUrls(fetchedSettings.oauthCallbackUrls);
 		rootStore.setN8nMetadata(fetchedSettings.n8nMetadata || {});
-		rootStore.setDefaultLocale(fetchedSettings.defaultLocale);
 		rootStore.setBinaryDataMode(fetchedSettings.binaryDataMode);
 
 		if (fetchedSettings.telemetry.enabled) {


### PR DESCRIPTION
## Summary

Since PR #22106, the login UI isn't being localized, as locale availability was removed from public API settings, along its setter calls.

This PR reintroduces **defaultLocale** in the public interface and calls `setDefaultLocale`  with its value before the early-return.

These side effects started at [n8n@1.123.0](https://github.com/n8n-io/n8n/releases/tag/n8n%401.123.0), the first release including the mentioned PR.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
