### PR TITLE
fix(ai-builder): Fix error message for large context windows

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/workflow-builder-agent.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/workflow-builder-agent.ts
@@ -632,6 +632,7 @@ export class WorkflowBuilderAgent {
 					'message' in errorDetails &&
 					typeof errorDetails.message === 'string'
 				) {
+					// Override original error message from model provider for prompt size issues
 					if (errorDetails.message.toLocaleLowerCase().includes('prompt is too long')) {
 						return PROMPT_IS_TOO_LARGE_ERROR;
 					}


### PR DESCRIPTION
## Summary


There might be cases when our estimate of input length in tokens falls bellow the threshold, but after sending it to LLM the real token length is more than allowed. We want to show more user-friendly message in such cases, so we override the original error message from model provider.

<img width="1920" height="933" alt="image" src="https://github.com/user-attachments/assets/0de8b6a2-ede0-46d2-94bc-d67ee3606511" />


## Related Linear tickets, Github issues, and Community forum posts
[AI-1805](https://linear.app/n8n/issue/AI-1805/bug-prompt-is-too-long-error-from-builder)



## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
