### PR TITLE
fix(Chat Trigger Node): Fix file upload with streaming in public chat

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/templates.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/templates.ts
@@ -151,7 +151,6 @@ export function createPage({
 						metadata: metadata,
 						webhookConfig: {
 							headers: {
-								'Content-Type': 'application/json',
 								'X-Instance-Id': '${instanceId}',
 							}
 						},

--- a/packages/frontend/@n8n/chat/src/api/message.ts
+++ b/packages/frontend/@n8n/chat/src/api/message.ts
@@ -188,12 +188,16 @@ async function sendWithFiles(
 		formData.append('files', file);
 	}
 
+	// Exclude Content-Type to let the browser set it with the multipart boundary
+	const headers: Record<string, string> = {
+		Accept: 'text/plain',
+		...options.webhookConfig?.headers,
+	};
+	delete headers['Content-Type'];
+
 	return await fetch(options.webhookUrl, {
 		method: 'POST',
-		headers: {
-			Accept: 'text/plain',
-			...options.webhookConfig?.headers,
-		},
+		headers,
 		body: formData,
 	});
 }


### PR DESCRIPTION
## Summary
Fixes file uploads failing with "Failed to parse request body" error when streaming is enabled in public/hosted chat mode. The hosted chat template was setting `Content-Type: application/json` in webhookConfig headers, which overwrote the browser's automatic `multipart/form-data` Content-Type when uploading files via FormData.

https://github.com/user-attachments/assets/5d43d3fe-e828-41cb-bd04-4cb6a2dcb0b1


## Changes

- Remove hardcoded `Content-Type: application/json` from hosted chat webhookConfig in `templates.ts`
- Strip Content-Type header in `sendWithFiles` when sending FormData, allowing the browser to set the correct multipart boundary
- Add regression test to verify Content-Type is excluded for file uploads while preserving other custom headers

## Testing

- Added unit test that sets Content-Type in webhookConfig, uploads a file, and verifies Content-Type is stripped from the request
- Manually tested file upload with streaming enabled in hosted chat mode

## Related Issues

- Closes https://github.com/n8n-io/n8n/issues/22934


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
