### PR TITLE
fix: Reset git files when push fails 

### DIFF
--- a/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
@@ -347,7 +347,14 @@ export class SourceControlService {
 
 			await this.gitService.commit(options.commitMessage ?? 'Updated Workfolder');
 		} catch (error) {
-			this.gitService.resetBranch();
+			this.logger.error('Failed to export or commit changes', { error });
+			try {
+				await this.gitService.resetBranch({ hard: true, target: 'HEAD' });
+			} catch (resetError) {
+				this.logger.error('Failed to reset branch after export/commit error', {
+					error: resetError,
+				});
+			}
 			throw error;
 		}
 

--- a/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
@@ -287,70 +287,82 @@ export class SourceControlService {
 			}
 		}
 
-		const filesToBePushed = new Set<string>();
-		const filesToBeDeleted = new Set<string>();
+		try {
+			const filesToBePushed = new Set<string>();
+			const filesToBeDeleted = new Set<string>();
 
-		/*
+			/*
 			Exclude tags, variables and folders JSON file from being deleted as
 			we keep track of them in a single file unlike workflows and credentials
 		*/
-		filesToPush
-			.filter((f) => ['workflow', 'credential', 'project'].includes(f.type))
-			.forEach((e) => {
-				if (e.status !== 'deleted') {
-					filesToBePushed.add(e.file);
-				} else {
-					filesToBeDeleted.add(e.file);
-				}
-			});
+			filesToPush
+				.filter((f) => ['workflow', 'credential', 'project'].includes(f.type))
+				.forEach((e) => {
+					if (e.status !== 'deleted') {
+						filesToBePushed.add(e.file);
+					} else {
+						filesToBeDeleted.add(e.file);
+					}
+				});
 
-		this.sourceControlExportService.rmFilesFromExportFolder(filesToBeDeleted);
+			this.sourceControlExportService.rmFilesFromExportFolder(filesToBeDeleted);
 
-		const workflowsToBeExported = getNonDeletedResources(filesToPush, 'workflow');
-		await this.sourceControlExportService.exportWorkflowsToWorkFolder(workflowsToBeExported);
+			const workflowsToBeExported = getNonDeletedResources(filesToPush, 'workflow');
+			await this.sourceControlExportService.exportWorkflowsToWorkFolder(workflowsToBeExported);
 
-		const credentialsToBeExported = getNonDeletedResources(filesToPush, 'credential');
-		const credentialExportResult =
-			await this.sourceControlExportService.exportCredentialsToWorkFolder(credentialsToBeExported);
-		if (credentialExportResult.missingIds && credentialExportResult.missingIds.length > 0) {
-			credentialExportResult.missingIds.forEach((id) => {
-				filesToBePushed.delete(this.sourceControlExportService.getCredentialsPath(id));
-				statusResult = statusResult.filter(
-					(e) => e.file !== this.sourceControlExportService.getCredentialsPath(id),
+			const credentialsToBeExported = getNonDeletedResources(filesToPush, 'credential');
+			const credentialExportResult =
+				await this.sourceControlExportService.exportCredentialsToWorkFolder(
+					credentialsToBeExported,
 				);
+			if (credentialExportResult.missingIds && credentialExportResult.missingIds.length > 0) {
+				credentialExportResult.missingIds.forEach((id) => {
+					filesToBePushed.delete(this.sourceControlExportService.getCredentialsPath(id));
+					statusResult = statusResult.filter(
+						(e) => e.file !== this.sourceControlExportService.getCredentialsPath(id),
+					);
+				});
+			}
+
+			const projectsToBeExported = getNonDeletedResources(filesToPush, 'project');
+			await this.sourceControlExportService.exportTeamProjectsToWorkFolder(projectsToBeExported);
+
+			// The tags file is always re-generated and exported to make sure the workflow-tag mappings are up to date
+			filesToBePushed.add(getTagsPath(this.gitFolder));
+			await this.sourceControlExportService.exportTagsToWorkFolder(context);
+
+			const folderChanges = filterByType(filesToPush, 'folders')[0];
+			if (folderChanges) {
+				filesToBePushed.add(folderChanges.file);
+				await this.sourceControlExportService.exportFoldersToWorkFolder(context);
+			}
+
+			const variablesChanges = filterByType(filesToPush, 'variables')[0];
+			if (variablesChanges) {
+				filesToBePushed.add(variablesChanges.file);
+				await this.sourceControlExportService.exportGlobalVariablesToWorkFolder();
+			}
+
+			await this.gitService.stage(filesToBePushed, filesToBeDeleted);
+
+			await this.gitService.commit(options.commitMessage ?? 'Updated Workfolder');
+		} catch (error) {
+			this.gitService.resetBranch();
+			throw error;
+		}
+
+		let pushResult: PushResult | undefined;
+		try {
+			pushResult = await this.gitService.push({
+				branch: this.sourceControlPreferencesService.getBranchName(),
+				force: options.force ?? false,
 			});
+
+			statusResult.forEach((result) => (result.pushed = true));
+		} catch (error) {
+			this.gitService.resetBranch({ hard: true, target: 'HEAD~1' });
+			throw error;
 		}
-
-		const projectsToBeExported = getNonDeletedResources(filesToPush, 'project');
-		await this.sourceControlExportService.exportTeamProjectsToWorkFolder(projectsToBeExported);
-
-		// The tags file is always re-generated and exported to make sure the workflow-tag mappings are up to date
-		filesToBePushed.add(getTagsPath(this.gitFolder));
-		await this.sourceControlExportService.exportTagsToWorkFolder(context);
-
-		const folderChanges = filterByType(filesToPush, 'folders')[0];
-		if (folderChanges) {
-			filesToBePushed.add(folderChanges.file);
-			await this.sourceControlExportService.exportFoldersToWorkFolder(context);
-		}
-
-		const variablesChanges = filterByType(filesToPush, 'variables')[0];
-		if (variablesChanges) {
-			filesToBePushed.add(variablesChanges.file);
-			await this.sourceControlExportService.exportGlobalVariablesToWorkFolder();
-		}
-
-		await this.gitService.stage(filesToBePushed, filesToBeDeleted);
-
-		// Set all results as pushed
-		statusResult.forEach((result) => (result.pushed = true));
-
-		await this.gitService.commit(options.commitMessage ?? 'Updated Workfolder');
-
-		const pushResult = await this.gitService.push({
-			branch: this.sourceControlPreferencesService.getBranchName(),
-			force: options.force ?? false,
-		});
 
 		// #region Tracking Information
 		this.eventService.emit(


### PR DESCRIPTION
## Summary

When the push operation fails, the files in the git folder are nor restored to the previous state.
This keeps the files in the git folder in a clean state and guaranties that the comparison with the database data to be valid
<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

fixes PAY-4055

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
