### PR TITLE
fix(ai-builder): Hide execute and refine button when there's no trigger

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/ExecuteMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/ExecuteMessage.vue
@@ -225,14 +225,19 @@ onBeforeUnmount(() => {
 		</template>
 
 		<!-- No Issues Section -->
-		<template v-else>
+		<template v-else-if="availableTriggerNodes.length > 0">
 			<p :class="$style.noIssuesMessage">
 				{{ i18n.baseText('aiAssistant.builder.executeMessage.noIssues') }}
 			</p>
 		</template>
 
 		<!-- Execution Button -->
-		<N8nTooltip :disabled="!hasValidationIssues" :content="executeButtonTooltip" placement="left">
+		<N8nTooltip
+			v-if="availableTriggerNodes.length > 0"
+			:disabled="!hasValidationIssues"
+			:content="executeButtonTooltip"
+			placement="left"
+		>
 			<CanvasRunWorkflowButton
 				:class="$style.runButton"
 				:disabled="hasValidationIssues || builderStore.hasNoCreditsRemaining"

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/ExecuteMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/ExecuteMessage.vue
@@ -225,7 +225,7 @@ onBeforeUnmount(() => {
 		</template>
 
 		<!-- No Issues Section -->
-		<template v-else-if="availableTriggerNodes.length > 0">
+		<template v-else-if="triggerNodes.length > 0">
 			<p :class="$style.noIssuesMessage">
 				{{ i18n.baseText('aiAssistant.builder.executeMessage.noIssues') }}
 			</p>
@@ -233,7 +233,7 @@ onBeforeUnmount(() => {
 
 		<!-- Execution Button -->
 		<N8nTooltip
-			v-if="availableTriggerNodes.length > 0"
+			v-if="triggerNodes.length > 0"
 			:disabled="!hasValidationIssues"
 			:content="executeButtonTooltip"
 			placement="left"


### PR DESCRIPTION
## Summary

Hide execute workflow button inside AI builder chat when workflow does not have any trigger.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-1772/bug-should-not-be-able-to-execute-workflow-without-a-trigger

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
