### PR TITLE
fix: Add script for running e2e with dev server and cleanup after

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dev:fe": "run-p start \"dev:fe:editor --filter=@n8n/design-system\"",
     "dev:fe:e2e": "run-p start dev:fe:editor",
     "dev:fe:editor": "turbo run dev --parallel --env-mode=loose --filter=n8n-editor-ui",
-    "dev:e2e": "pnpm --filter=n8n-playwright dev --ui",
+    "dev:e2e": "pnpm --filter=n8n-playwright dev",
     "clean": "turbo run clean",
     "reset": "node scripts/ensure-zx.mjs && zx scripts/reset.mjs",
     "format": "turbo run format && node scripts/format.mjs",

--- a/packages/testing/playwright/package.json
+++ b/packages/testing/playwright/package.json
@@ -2,7 +2,7 @@
   "name": "n8n-playwright",
   "private": true,
   "scripts": {
-    "dev": "N8N_BASE_URL=http://localhost:5678 N8N_EDITOR_URL=http://localhost:8080 RESET_E2E_DB=true playwright test --project=ui --project=ui:isolated",
+    "dev": "node scripts/dev.mjs",
     "test:all": "playwright test",
     "test:local": "N8N_BASE_URL=http://localhost:5680 RESET_E2E_DB=true playwright test --project=ui --project=ui:isolated",
     "test:local:ui-only": "N8N_BASE_URL=http://localhost:5680 RESET_E2E_DB=true playwright test --project=ui",

--- a/packages/testing/playwright/scripts/dev.mjs
+++ b/packages/testing/playwright/scripts/dev.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * Run Playwright dev tests with automatic port cleanup on exit
+ *
+ * This script runs Playwright tests and ensures ports 5678 and 8080
+ * are properly cleaned up when the script exits, even on Ctrl+C.
+ */
+
+import { $, echo, chalk } from 'zx';
+import process from 'node:process';
+
+// Disable verbose mode for cleaner output
+$.verbose = false;
+process.env.FORCE_COLOR = '1';
+
+// #region ===== Configuration =====
+
+const PORTS = [5678, 8080];
+const PORT_NAMES = {
+	5678: 'n8n backend',
+	8080: 'frontend dev server',
+};
+
+const config = {
+	env: {
+		N8N_BASE_URL: 'http://localhost:5678',
+		N8N_EDITOR_URL: 'http://localhost:8080',
+		RESET_E2E_DB: 'true',
+	},
+	projects: ['ui', 'ui:isolated'],
+};
+
+// #endregion ===== Configuration =====
+
+// #region ===== Helper Functions =====
+
+/**
+ * Find PIDs of processes using the specified port
+ * @param {number} port - Port number to check
+ * @returns {Promise<string[]>} Array of PIDs
+ */
+async function findPidsOnPort(port) {
+	try {
+		const { stdout } = await $`lsof -ti:${port}`;
+		return stdout.trim().split('\n').filter(Boolean);
+	} catch {
+		// No process found on this port
+		return [];
+	}
+}
+
+/**
+ * Kill a process by PID
+ * @param {string} pid - Process ID to kill
+ * @returns {Promise<boolean>} True if successful
+ */
+async function killProcess(pid) {
+	try {
+		await $`kill -9 ${pid}`;
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Clean up processes on specified ports
+ * @returns {Promise<void>}
+ */
+async function cleanupPorts() {
+	echo('');
+	echo(chalk.blue('🧹 Cleaning up ports 5678 and 8080...'));
+
+	for (const port of PORTS) {
+		const pids = await findPidsOnPort(port);
+		const portName = PORT_NAMES[port];
+
+		if (pids.length > 0) {
+			for (const pid of pids) {
+				const success = await killProcess(pid);
+				if (success) {
+					echo(chalk.gray(`  Killed ${portName} process (PID: ${pid})`));
+				}
+			}
+			echo(chalk.green(`  ✓ Port ${port} cleared`));
+		} else {
+			echo(chalk.gray(`  ✓ Port ${port} is already free`));
+		}
+	}
+
+	echo(chalk.green('✨ Cleanup completed'));
+}
+
+// #endregion ===== Helper Functions =====
+
+// #region ===== Main Process =====
+
+let isCleaningUp = false;
+
+/**
+ * Handle cleanup on exit
+ */
+async function handleExit(exitCode = 0) {
+	if (isCleaningUp) return;
+	isCleaningUp = true;
+
+	await cleanupPorts();
+	process.exit(exitCode);
+}
+
+/**
+ * Run Playwright tests with cleanup handlers
+ */
+async function main() {
+	echo(chalk.blue.bold('🚀 Starting Playwright dev tests...'));
+	echo(chalk.gray('-'.repeat(47)));
+
+	// Set up signal handlers for graceful shutdown
+	process.on('SIGINT', async () => {
+		echo(chalk.yellow('\n⚠️  Received SIGINT (Ctrl+C)'));
+		await handleExit(130);
+	});
+
+	process.on('SIGTERM', async () => {
+		echo(chalk.yellow('\n⚠️  Received SIGTERM'));
+		await handleExit(143);
+	});
+
+	try {
+		// Run Playwright with environment variables
+		const projectArgs = config.projects.flatMap((p) => ['--project', p]);
+
+		await $({
+			env: {
+				...process.env,
+				...config.env,
+			},
+			stdio: 'inherit',
+		})`playwright test ${projectArgs} --ui`;
+
+		// Tests completed successfully
+		await handleExit(0);
+	} catch (error) {
+		// Tests failed or were interrupted
+		const exitCode = error.exitCode ?? 1;
+		await handleExit(exitCode);
+	}
+}
+
+// #endregion ===== Main Process =====
+
+main().catch(async (error) => {
+	echo(chalk.red(`Unexpected error: ${error.message}`));
+	await handleExit(1);
+});


### PR DESCRIPTION
## Summary

This pull request updates the Playwright end-to-end (E2E) testing workflow to improve developer experience and ensure ports are properly cleaned up after running tests. The main change is replacing the previous Playwright dev script with a new Node.js script that manages environment setup and automatic port cleanup, especially on exit or interruption.

Key improvements to Playwright E2E workflow:

* Added a new `scripts/dev.mjs` script in `n8n-playwright` that runs Playwright dev tests and ensures ports 5678 and 8080 are cleaned up on exit, even if interrupted (e.g., Ctrl+C). This prevents port conflicts in future runs.
* Updated the `dev` script in `packages/testing/playwright/package.json` to use the new `dev.mjs` script instead of directly invoking Playwright with environment variables.
* Modified the root `package.json` so that the `dev:e2e` script no longer passes the `--ui` flag directly, delegating all configuration to the new script.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1890/allow-running-playwright-e2e-in-dev-mode-using-vite-devserver

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
