### PR TITLE
ci: Optimize Docker image build process

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,21 +1,27 @@
-# We want to include the THIRD_PARTY_LICENSES.md file in the Docker image,
-# but not other .md files
-**/*.md
-!**/THIRD_PARTY_LICENSES.md
-**/.env
-.cache
-assets
-node_modules
-packages/node-dev
-packages/**/node_modules
-packages/**/dist
-packages/**/.turbo
-packages/**/*.test.*
-.git
-.github
-!.github/scripts
-*.tsbuildinfo
-docker/compose
-docker/**/Dockerfile
-.vscode
-packages/testing
+# Whitelist approach: ignore everything, then allow only what Docker builds need
+# This reduces build context from ~900MB to just what's required
+
+# Ignore everything first
+*
+
+# === n8n main image (docker/images/n8n/Dockerfile) ===
+!compiled
+!compiled/**
+!THIRD_PARTY_LICENSES.md
+
+# === runners image (docker/images/runners/Dockerfile + Dockerfile.distroless) ===
+!dist
+!dist/task-runner-javascript
+!dist/task-runner-javascript/**
+!packages
+!packages/@n8n
+!packages/@n8n/task-runner-python
+!packages/@n8n/task-runner-python/**
+
+# === Docker build files (entrypoints, configs) ===
+!docker
+!docker/images
+!docker/images/n8n
+!docker/images/n8n/docker-entrypoint.sh
+!docker/images/runners
+!docker/images/runners/n8n-task-runners.json

--- a/docker/images/n8n-base/Dockerfile
+++ b/docker/images/n8n-base/Dockerfile
@@ -33,8 +33,7 @@ RUN echo "https://dl-cdn.alpinelinux.org/alpine/v3.22/main" >> /etc/apk/reposito
 # Install full-icu
 RUN npm install -g full-icu@1.5.0
 
-RUN rm -rf /tmp/* /root/.npm /root/.cache/node /opt/yarn* && \
-  apk del apk-tools
+RUN rm -rf /tmp/* /root/.npm /root/.cache/node
 
 # ==============================================================================
 # STAGE 2: Final Base Runtime Image
@@ -42,6 +41,8 @@ RUN rm -rf /tmp/* /root/.npm /root/.cache/node /opt/yarn* && \
 FROM node:${NODE_VERSION}-alpine
 
 COPY --from=builder / /
+
+RUN rm -rf /opt/yarn* && apk del apk-tools
 
 WORKDIR /home/node
 ENV NODE_ICU_DATA=/usr/local/lib/node_modules/full-icu


### PR DESCRIPTION


## Summary

Improves the efficiency of Docker image builds by implementing a whitelist approach in `.dockerignore`. This reduces the build context size significantly, resulting in faster build times.

Removes yarn specific configuration from the base Dockerfile.

## Related Linear tickets, Github issues, and Community forum posts

Addresses Fortify scan that detects Yarn in image and reports vulnerability. Also Yarn isn't needed so it's safe to remove.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
