### PR TITLE
test: Revert the orchestration due to limitations with re-running the suites

### DIFF
--- a/.github/workflows/playwright-test-ci.yml
+++ b/.github/workflows/playwright-test-ci.yml
@@ -12,7 +12,7 @@ jobs:
     uses: ./.github/workflows/playwright-test-reusable.yml
     with:
       test-mode: docker-build
-      test-command: pnpm --filter=n8n-playwright exec npx pwc-p -- --project=multi-main:ui
+      test-command: pnpm --filter=n8n-playwright test:container:multi-main:ui
       shards: '[1, 2, 3, 4, 5, 6, 7, 8]'
       runner: blacksmith-4vcpu-ubuntu-2204
       workers: '1'
@@ -24,7 +24,7 @@ jobs:
     uses: ./.github/workflows/playwright-test-reusable.yml
     with:
       test-mode: docker-build
-      test-command: pnpm --filter=n8n-playwright exec npx pwc-p -- --project=multi-main:ui:isolated
+      test-command: pnpm --filter=n8n-playwright test:container:multi-main:isolated
       shards: '[1]'
       runner: blacksmith-4vcpu-ubuntu-2204
       workers: '1'

--- a/.github/workflows/playwright-test-reusable.yml
+++ b/.github/workflows/playwright-test-reusable.yml
@@ -53,11 +53,11 @@ on:
         required: false
 
 env:
-  PLAYWRIGHT_BROWSERS_PATH: ms-playwright-cache
+  PLAYWRIGHT_BROWSERS_PATH: packages/testing/playwright/ms-playwright-cache
   NODE_OPTIONS: --max-old-space-size=3072
   # Disable Ryuk to avoid issues with Docker since it needs privileged access, containers are cleaned on teardown anyway
   TESTCONTAINERS_RYUK_DISABLED: true
-  PLAYWRIGHT_WORKERS: ${{ inputs.workers || '2' }}
+  PLAYWRIGHT_WORKERS: ${{ inputs.workers || '2' }} # Configurable workers, defaults to 2 to reduce resource contention
   # Must match CI's COVERAGE_ENABLED to ensure Turbo cache hits (it's a globalEnv in turbo.json)
   COVERAGE_ENABLED: 'true'
 
@@ -69,7 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         shard: ${{ fromJSON(inputs.shards || '[1, 2, 3, 4, 5, 6, 7, 8]') }}
-    name: Test (Machine ${{ matrix.shard }})
+    name: Test (Shard ${{ matrix.shard }}/${{ strategy.job-total }})
 
     steps:
       - name: Checkout
@@ -87,6 +87,7 @@ jobs:
           INCLUDE_TEST_CONTROLLER: ${{ inputs.test-mode == 'docker-build' && 'true' || '' }}
 
       - name: Install Browsers
+        if: inputs.test-mode == 'docker-build'
         run: pnpm turbo install-browsers:ci
 
       - name: Pre-pull Test Container Images
@@ -103,15 +104,12 @@ jobs:
 
       - name: Run Tests
         run: |
-          if echo "${{ inputs.test-command }}" | grep -q "pwc-p"; then
-            ${{ inputs.test-command }} --workers=${{ env.PLAYWRIGHT_WORKERS }}
-          else
-            ${{ inputs.test-command }} --shard=${{ matrix.shard }}/${{ strategy.job-total }} --workers=${{ env.PLAYWRIGHT_WORKERS }}
-          fi
+          ${{ inputs.test-command }} \
+            --shard=${{ matrix.shard }}/${{ strategy.job-total }} \
+            --workers=${{ env.PLAYWRIGHT_WORKERS }}
         env:
           N8N_DOCKER_IMAGE: ${{ inputs.test-mode == 'docker-build' && 'n8nio/n8n:local' || inputs.docker-image }}
           CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}
-          PLAYWRIGHT_WORKERS: ${{ env.PLAYWRIGHT_WORKERS }}
           QA_PERFORMANCE_METRICS_WEBHOOK_URL: ${{ secrets.QA_PERFORMANCE_METRICS_WEBHOOK_URL }}
           QA_PERFORMANCE_METRICS_WEBHOOK_USER: ${{ secrets.QA_PERFORMANCE_METRICS_WEBHOOK_USER }}
           QA_PERFORMANCE_METRICS_WEBHOOK_PASSWORD: ${{ secrets.QA_PERFORMANCE_METRICS_WEBHOOK_PASSWORD }}

--- a/.github/workflows/playwright-test-reusable.yml
+++ b/.github/workflows/playwright-test-reusable.yml
@@ -41,8 +41,6 @@ on:
     secrets:
       CURRENTS_RECORD_KEY:
         required: false
-      CURRENTS_API_KEY:
-        required: false
       QA_PERFORMANCE_METRICS_WEBHOOK_URL:
         required: false
       QA_PERFORMANCE_METRICS_WEBHOOK_USER:
@@ -72,9 +70,6 @@ jobs:
       matrix:
         shard: ${{ fromJSON(inputs.shards || '[1, 2, 3, 4, 5, 6, 7, 8]') }}
     name: Test (Machine ${{ matrix.shard }})
-    env:
-      CURRENTS_API_KEY: ${{ secrets.CURRENTS_API_KEY }}
-      CURRENTS_CI_BUILD_ID: ${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
       - name: Checkout
@@ -94,16 +89,6 @@ jobs:
       - name: Install Browsers
         run: pnpm turbo install-browsers:ci
 
-      - name: Playwright Last Failed action
-        id: last-failed-action
-        if: ${{ env.CURRENTS_API_KEY != '' }}
-        uses: currents-dev/playwright-last-failed@v1
-        with:
-          or8n: true
-          pw-output-dir: packages/testing/playwright/test-results
-          api-key: ${{ secrets.CURRENTS_API_KEY }}
-          project-id: I0yzoc
-
       - name: Pre-pull Test Container Images
         if: ${{ !contains(inputs.test-command, 'test:local') }}
         run: |
@@ -119,7 +104,7 @@ jobs:
       - name: Run Tests
         run: |
           if echo "${{ inputs.test-command }}" | grep -q "pwc-p"; then
-            ${{ inputs.test-command }} --workers=${{ env.PLAYWRIGHT_WORKERS }} ${{ steps.last-failed-action.outputs.extra-pw-flags }}
+            ${{ inputs.test-command }} --workers=${{ env.PLAYWRIGHT_WORKERS }}
           else
             ${{ inputs.test-command }} --shard=${{ matrix.shard }}/${{ strategy.job-total }} --workers=${{ env.PLAYWRIGHT_WORKERS }}
           fi

--- a/packages/testing/playwright/currents.config.ts
+++ b/packages/testing/playwright/currents.config.ts
@@ -3,10 +3,6 @@ import type { CurrentsConfig } from '@currents/playwright';
 const config: CurrentsConfig = {
 	recordKey: process.env.CURRENTS_RECORD_KEY ?? '',
 	projectId: process.env.CURRENTS_PROJECT_ID ?? 'I0yzoc',
-	ciBuildId: `${process.env.GITHUB_REPOSITORY}-${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT}`,
-	orchestration: {
-		batchSize: Number(process.env.CURRENTS_BATCH_SIZE) || 5,
-	},
 	...(process.env.BUILD_WITH_COVERAGE === 'true' && {
 		coverage: {
 			projects: true,

--- a/packages/testing/playwright/playwright-projects.ts
+++ b/packages/testing/playwright/playwright-projects.ts
@@ -32,9 +32,6 @@ const CONTAINER_CONFIGS: Array<{ name: string; config: N8NConfig }> = [
 	{ name: 'multi-main', config: { queueMode: { mains: 2, workers: 1 } } },
 ];
 
-// Disable fullyParallel when running with single worker (no benefit, used by Currents orchestration)
-const enableParallelism = process.env.PLAYWRIGHT_WORKERS !== '1';
-
 export function getProjects(): Project[] {
 	const isLocal = !!getBackendUrl();
 	const projects: Project[] = [];
@@ -67,7 +64,7 @@ export function getProjects(): Project[] {
 					testDir: './tests/e2e',
 					grepInvert: new RegExp(grepInvertPatterns.join('|')),
 					timeout: name === 'standard' ? 60000 : 180000, // 60 seconds for standard container test, 180 for containers to allow startup etc
-					fullyParallel: enableParallelism,
+					fullyParallel: true,
 					use: { containerConfig: config },
 				},
 				{

--- a/packages/testing/playwright/playwright.config.ts
+++ b/packages/testing/playwright/playwright.config.ts
@@ -86,7 +86,6 @@ export default defineConfig<CurrentsFixtures, CurrentsWorkerFixtures>({
 		actionTimeout: 20000, // TODO: We might need to make this dynamic for container tests if we have low resource containers etc
 		navigationTimeout: 10000,
 		currentsFixturesEnabled: !!process.env.CI,
-		currentsBatchSize: 5,
 	},
 
 	reporter: IS_CI


### PR DESCRIPTION
## Summary

When using Currents orchestration (pwc-p), rerunning a single failed machine (e.g., clicking "Rerun failed jobs" on machine 7) causes all tests to be rerun instead of just the tests that failed on that machine.

Root cause: With orchestration, tests are dynamically assigned by Currents rather than deterministically sharded. When a single machine restarts, Currents treats it as part of a new orchestration run.

Revert PRs [#22747](https://github.com/n8n-io/n8n/pull/22747) and [#23139](https://github.com/n8n-io/n8n/pull/23139) to restore deterministic sharding behavior until orchestration rerun logic is properly fixed.


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1959/revert-the-orchestration-due-to-bug-with-re-running-the-specs


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
