### PR TITLE
test: Target correct canvas handle wrapper

### DIFF
--- a/packages/testing/playwright/pages/CanvasPage.ts
+++ b/packages/testing/playwright/pages/CanvasPage.ts
@@ -965,6 +965,14 @@ export class CanvasPage extends BasePage {
 		return this.page.getByTestId('canvas-handle-plus');
 	}
 
+	getCanvasHandlePlusWrapperByName(nodeName: string): Locator {
+		return this.page
+			.locator(
+				`[data-test-id="canvas-node-output-handle"][data-node-name="${nodeName}"] [data-test-id="canvas-handle-plus-wrapper"]`,
+			)
+			.first();
+	}
+
 	stopExecutionWaitingForWebhookButton(): Locator {
 		return this.page.getByTestId('stop-execution-waiting-for-webhook-button');
 	}

--- a/packages/testing/playwright/tests/e2e/workflows/editor/canvas/canvas-nodes.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/canvas/canvas-nodes.spec.ts
@@ -143,15 +143,16 @@ test.describe('Canvas Node Manipulation and Navigation', () => {
 
 		await expect(n8n.canvas.getSuccessEdges()).toHaveCount(nodeCount);
 		await expect(n8n.canvas.getAllNodeSuccessIndicators()).toHaveCount(nodeCount + 1);
-		await expect(n8n.canvas.getCanvasHandlePlusWrapper()).toHaveAttribute(
-			'data-plus-type',
-			'success',
-		);
+		await expect(
+			n8n.canvas.getCanvasHandlePlusWrapperByName('Code in JavaScript2'),
+		).toHaveAttribute('data-plus-type', 'success');
 
 		await n8n.canvas.addNode(CODE_NODE_NAME, { action: 'Code in JavaScript', closeNDV: true });
 		await n8n.canvas.clickZoomToFitButton();
 
-		await expect(n8n.canvas.getCanvasHandlePlus()).not.toHaveAttribute('data-plus-type', 'success');
+		await expect(
+			n8n.canvas.getCanvasHandlePlusWrapperByName('Code in JavaScript3'),
+		).not.toHaveAttribute('data-plus-type', 'success');
 
 		await expect(n8n.canvas.getSuccessEdges()).toHaveCount(nodeCount + 1);
 		await expect(n8n.canvas.getAllNodeSuccessIndicators()).toHaveCount(nodeCount + 1);


### PR DESCRIPTION
## Summary

Updates the canvas node test to correctly target
the correct `data-plus-type` attribute
on the canvas handle plus wrapper by using
`nodeName`.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
