### PR TITLE
chore(core): OAuth2 data storage for dynamic credentials

### DIFF
--- a/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
+++ b/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
@@ -161,8 +161,9 @@ describe('OAuth2CredentialController', () => {
 
 		it('should handle dynamic credential callback successfully', async () => {
 			const { ClientOAuth2 } = await import('@n8n/client-oauth2');
+			const oauthTokenData = { access_token: 'new_token', refresh_token: 'refresh_token' };
 			const mockGetToken = jest.fn().mockResolvedValue({
-				data: { access_token: 'new_token', refresh_token: 'refresh_token' },
+				data: oauthTokenData,
 			});
 			jest.mocked(ClientOAuth2).mockImplementation(
 				() =>
@@ -216,7 +217,9 @@ describe('OAuth2CredentialController', () => {
 			// The controller passes decryptedDataOriginal directly, not the merged oauthTokenData
 			expect(oauthService.saveDynamicCredential).toHaveBeenCalledWith(
 				mockResolvedCredential,
-				mockDecryptedData,
+				{
+					oauthTokenData,
+				},
 				'token123',
 				'resolver-id',
 			);

--- a/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
+++ b/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
@@ -86,9 +86,9 @@ export class OAuth2CredentialController {
 
 			// Only overwrite supplied data as some providers do for example just return the
 			// refresh_token on the very first request and not on subsequent ones.
-			let { oauthTokenData } = decryptedDataOriginal;
-			oauthTokenData = {
-				...(typeof oauthTokenData === 'object' ? oauthTokenData : {}),
+			const { oauthTokenData: tokenData } = decryptedDataOriginal;
+			const oauthTokenData: ICredentialDataDecryptedObject = {
+				...(typeof tokenData === 'object' ? tokenData : {}),
 				...oauthToken.data,
 			} as ICredentialDataDecryptedObject;
 
@@ -117,7 +117,7 @@ export class OAuth2CredentialController {
 
 				await this.oauthService.saveDynamicCredential(
 					credential,
-					decryptedDataOriginal,
+					{ oauthTokenData },
 					state.authorizationHeader.split('Bearer ')[1],
 					state.credentialResolverId,
 				);

--- a/packages/cli/src/modules/dynamic-credentials.ee/__tests__/dynamic-credentials.controller.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/__tests__/dynamic-credentials.controller.test.ts
@@ -4,15 +4,22 @@ import { type CredentialsEntity } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
 import type { Request, Response } from 'express';
+import { Cipher } from 'n8n-core';
 import { DynamicCredentialsController } from '@/modules/dynamic-credentials.ee/dynamic-credentials.controller';
 import { EnterpriseCredentialsService } from '@/credentials/credentials.service.ee';
 import { OauthService } from '@/oauth/oauth.service';
+import { DynamicCredentialResolverRepository } from '@/modules/dynamic-credentials.ee/database/repositories/credential-resolver.repository';
+import { DynamicCredentialResolverRegistry } from '@/modules/dynamic-credentials.ee/services';
+import type { DynamicCredentialResolver } from '@/modules/dynamic-credentials.ee/database/entities/credential-resolver';
 
 jest.mock('axios');
 
 describe('DynamicCredentialsController', () => {
 	const enterpriseCredentialsService = mockInstance(EnterpriseCredentialsService);
 	const oauthService = mockInstance(OauthService);
+	const resolverRepository = mockInstance(DynamicCredentialResolverRepository);
+	const resolverRegistry = mockInstance(DynamicCredentialResolverRegistry);
+	const cipher = mockInstance(Cipher);
 
 	mockInstance(Logger);
 
@@ -27,9 +34,29 @@ describe('DynamicCredentialsController', () => {
 	});
 
 	describe('authorizeCredential', () => {
+		const mockResolverEntity: DynamicCredentialResolver = {
+			id: 'resolver-123',
+			type: 'oauth2-introspection-identifier',
+			config: 'encrypted-config',
+			createdAt: new Date(),
+			updatedAt: new Date(),
+		};
+
+		const mockResolver = {
+			metadata: {
+				name: 'oauth2-introspection-identifier',
+				description: 'OAuth2 Introspection Identifier',
+			},
+			getSecret: jest.fn(),
+			setSecret: jest.fn(),
+			validateOptions: jest.fn(),
+		};
+
 		it('should throw NotFoundError when credential is not found', async () => {
 			const req = mock<Request>({
 				params: { id: 'non-existent-id' },
+				query: { resolverId: 'resolver-123' },
+				headers: { authorization: 'Bearer token123' },
 			});
 			const res = mock<Response>();
 
@@ -41,6 +68,25 @@ describe('DynamicCredentialsController', () => {
 			expect(enterpriseCredentialsService.getOne).toHaveBeenCalledWith('non-existent-id');
 		});
 
+		it('should throw BadRequestError when resolverId is missing', async () => {
+			const mockCredential = mock<CredentialsEntity>({
+				id: '1',
+				type: 'googleOAuth2Api',
+			});
+			const req = {
+				params: { id: '1' },
+				query: {} as any,
+				headers: { authorization: 'Bearer token123' },
+			} as Request;
+			const res = mock<Response>();
+
+			enterpriseCredentialsService.getOne.mockResolvedValue(mockCredential);
+
+			await expect(controller.authorizeCredential(req, res)).rejects.toThrow(
+				'Missing resolverId query parameter',
+			);
+		});
+
 		it('should throw BadRequestError when credential type is not OAuth2 or OAuth1', async () => {
 			const mockCredential = mock<CredentialsEntity>({
 				id: '1',
@@ -48,6 +94,8 @@ describe('DynamicCredentialsController', () => {
 			});
 			const req = mock<Request>({
 				params: { id: '1' },
+				query: { resolverId: 'resolver-123' },
+				headers: { authorization: 'Bearer token123' },
 			});
 			const res = mock<Response>();
 
@@ -59,6 +107,51 @@ describe('DynamicCredentialsController', () => {
 			expect(enterpriseCredentialsService.getOne).toHaveBeenCalledWith('1');
 		});
 
+		it('should throw NotFoundError when resolver is not found', async () => {
+			const mockCredential = mock<CredentialsEntity>({
+				id: '1',
+				type: 'googleOAuth2Api',
+			});
+			const req = mock<Request>({
+				params: { id: '1' },
+				query: { resolverId: 'non-existent-resolver' },
+				headers: { authorization: 'Bearer token123' },
+			});
+			const res = mock<Response>();
+
+			enterpriseCredentialsService.getOne.mockResolvedValue(mockCredential);
+			resolverRepository.findOneBy.mockResolvedValue(null);
+
+			await expect(controller.authorizeCredential(req, res)).rejects.toThrow('Resolver not found');
+			expect(resolverRepository.findOneBy).toHaveBeenCalledWith({
+				id: 'non-existent-resolver',
+			});
+		});
+
+		it('should throw NotFoundError when resolver type is not registered', async () => {
+			const mockCredential = mock<CredentialsEntity>({
+				id: '1',
+				type: 'googleOAuth2Api',
+			});
+			const req = mock<Request>({
+				params: { id: '1' },
+				query: { resolverId: 'resolver-123' },
+				headers: { authorization: 'Bearer token123' },
+			});
+			const res = mock<Response>();
+
+			enterpriseCredentialsService.getOne.mockResolvedValue(mockCredential);
+			resolverRepository.findOneBy.mockResolvedValue(mockResolverEntity);
+			resolverRegistry.getResolverByTypename.mockReturnValue(undefined);
+
+			await expect(controller.authorizeCredential(req, res)).rejects.toThrow(
+				'Resolver type not found',
+			);
+			expect(resolverRegistry.getResolverByTypename).toHaveBeenCalledWith(
+				'oauth2-introspection-identifier',
+			);
+		});
+
 		it('should return auth URI for OAuth2 credential', async () => {
 			const mockCredential = mock<CredentialsEntity>({
 				id: '1',
@@ -66,11 +159,14 @@ describe('DynamicCredentialsController', () => {
 			});
 			const req = mock<Request>({
 				params: { id: '1' },
+				query: { resolverId: 'resolver-123' },
 				headers: { authorization: 'Bearer token123' },
 			});
 			const res = mock<Response>();
 
 			enterpriseCredentialsService.getOne.mockResolvedValue(mockCredential);
+			resolverRepository.findOneBy.mockResolvedValue(mockResolverEntity);
+			resolverRegistry.getResolverByTypename.mockReturnValue(mockResolver);
 			oauthService.generateAOauth2AuthUri.mockResolvedValueOnce(
 				'https://example.domain/oauth2/auth?client_id=client_id&redirect_uri=http://localhost:5678/rest/oauth2-credential/callback&response_type=code&state=state&scope=openid',
 			);
@@ -79,10 +175,15 @@ describe('DynamicCredentialsController', () => {
 
 			expect(authUri).toContain('https://example.domain/oauth2/auth');
 			expect(enterpriseCredentialsService.getOne).toHaveBeenCalledWith('1');
+			expect(resolverRepository.findOneBy).toHaveBeenCalledWith({ id: 'resolver-123' });
+			expect(resolverRegistry.getResolverByTypename).toHaveBeenCalledWith(
+				'oauth2-introspection-identifier',
+			);
 			expect(oauthService.generateAOauth2AuthUri).toHaveBeenCalledWith(mockCredential, {
 				cid: '1',
 				origin: 'dynamic-credential',
 				authorizationHeader: 'Bearer token123',
+				credentialResolverId: 'resolver-123',
 			});
 		});
 
@@ -93,11 +194,14 @@ describe('DynamicCredentialsController', () => {
 			});
 			const req = mock<Request>({
 				params: { id: '1' },
+				query: { resolverId: 'resolver-123' },
 				headers: { authorization: 'Bearer token123' },
 			});
 			const res = mock<Response>();
 
 			enterpriseCredentialsService.getOne.mockResolvedValue(mockCredential);
+			resolverRepository.findOneBy.mockResolvedValue(mockResolverEntity);
+			resolverRegistry.getResolverByTypename.mockReturnValue(mockResolver);
 			oauthService.generateAOauth1AuthUri.mockResolvedValueOnce(
 				'https://example.domain/oauth/authorize?oauth_token=random-token',
 			);
@@ -106,37 +210,99 @@ describe('DynamicCredentialsController', () => {
 
 			expect(authUri).toContain('https://example.domain/oauth/authorize?oauth_token=random-token');
 			expect(enterpriseCredentialsService.getOne).toHaveBeenCalledWith('1');
+			expect(resolverRepository.findOneBy).toHaveBeenCalledWith({ id: 'resolver-123' });
+			expect(resolverRegistry.getResolverByTypename).toHaveBeenCalledWith(
+				'oauth2-introspection-identifier',
+			);
 			expect(oauthService.generateAOauth1AuthUri).toHaveBeenCalledWith(mockCredential, {
 				cid: '1',
 				origin: 'dynamic-credential',
 				authorizationHeader: 'Bearer token123',
+				credentialResolverId: 'resolver-123',
 			});
 		});
 
-		it('should handle request without authorization header', async () => {
+		it('should throw UnauthenticatedError when authorization header is missing', async () => {
+			const req = mock<Request>({
+				params: { id: '1' },
+				query: { resolverId: 'resolver-123' },
+				headers: { authorization: undefined },
+			});
+			const res = mock<Response>();
+
+			await expect(controller.authorizeCredential(req, res)).rejects.toThrow('Unauthenticated');
+		});
+
+		it('should throw BadRequestError when authorization header is malformed', async () => {
+			const req = mock<Request>({
+				params: { id: '1' },
+				query: { resolverId: 'resolver-123' },
+				headers: { authorization: 'InvalidFormat' },
+			});
+			const res = mock<Response>();
+
+			await expect(controller.authorizeCredential(req, res)).rejects.toThrow(
+				'Authorization header is malformed',
+			);
+		});
+
+		it('should call validateIdentity when resolver has validateIdentity method', async () => {
+			const mockCredential = mock<CredentialsEntity>({
+				id: '1',
+				type: 'googleOAuth2Api',
+			});
+			const mockResolverWithValidation = {
+				...mockResolver,
+				validateIdentity: jest.fn().mockResolvedValue(undefined),
+			};
+			const req = mock<Request>({
+				params: { id: '1' },
+				query: { resolverId: 'resolver-123' },
+				headers: { authorization: 'Bearer token123' },
+			});
+			const res = mock<Response>();
+
+			// Set up all mocks before calling the controller
+			enterpriseCredentialsService.getOne.mockResolvedValue(mockCredential);
+			resolverRepository.findOneBy.mockResolvedValue(mockResolverEntity);
+			resolverRegistry.getResolverByTypename.mockReturnValue(mockResolverWithValidation);
+			cipher.decrypt.mockReturnValueOnce('{"introspectionUrl":"https://example.com/introspect"}');
+			oauthService.generateAOauth2AuthUri.mockResolvedValueOnce(
+				'https://example.domain/oauth2/auth',
+			);
+
+			await controller.authorizeCredential(req, res);
+
+			expect(cipher.decrypt).toHaveBeenCalledWith('encrypted-config');
+			expect(mockResolverWithValidation.validateIdentity).toHaveBeenCalledWith('token123', {
+				resolverId: 'resolver-123',
+				resolverName: 'oauth2-introspection-identifier',
+				configuration: { introspectionUrl: 'https://example.com/introspect' },
+			});
+		});
+
+		it('should not call validateIdentity when resolver lacks validateIdentity method', async () => {
 			const mockCredential = mock<CredentialsEntity>({
 				id: '1',
 				type: 'googleOAuth2Api',
 			});
 			const req = mock<Request>({
 				params: { id: '1' },
-				headers: { authorization: undefined },
+				query: { resolverId: 'resolver-123' },
+				headers: { authorization: 'Bearer token123' },
 			});
 			const res = mock<Response>();
 
 			enterpriseCredentialsService.getOne.mockResolvedValue(mockCredential);
+			resolverRepository.findOneBy.mockResolvedValue(mockResolverEntity);
+			resolverRegistry.getResolverByTypename.mockReturnValue(mockResolver); // No validateIdentity
 			oauthService.generateAOauth2AuthUri.mockResolvedValueOnce(
-				'https://example.domain/oauth2/auth?client_id=client_id&redirect_uri=http://localhost:5678/rest/oauth2-credential/callback&response_type=code&state=state&scope=openid',
+				'https://example.domain/oauth2/auth',
 			);
 
-			const authUri = await controller.authorizeCredential(req, res);
+			await controller.authorizeCredential(req, res);
 
-			expect(authUri).toContain('https://example.domain/oauth2/auth');
-			expect(oauthService.generateAOauth2AuthUri).toHaveBeenCalledWith(mockCredential, {
-				cid: '1',
-				origin: 'dynamic-credential',
-				authorizationHeader: '',
-			});
+			expect(cipher.decrypt).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/cli/src/modules/dynamic-credentials.ee/__tests__/dynamic-credentials.controller.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/__tests__/dynamic-credentials.controller.test.ts
@@ -85,9 +85,7 @@ describe('DynamicCredentialsController', () => {
 
 			enterpriseCredentialsService.getOne.mockResolvedValue(mockCredential);
 
-			await expect(controller.authorizeCredential(req, res)).rejects.toThrow(
-				'Missing resolverId query parameter',
-			);
+			await expect(controller.authorizeCredential(req, res)).rejects.toThrow('Resolver not found');
 		});
 
 		it('should throw BadRequestError when credential type is not OAuth2 or OAuth1', async () => {

--- a/packages/cli/src/modules/dynamic-credentials.ee/__tests__/dynamic-credentials.controller.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/__tests__/dynamic-credentials.controller.test.ts
@@ -36,10 +36,13 @@ describe('DynamicCredentialsController', () => {
 	describe('authorizeCredential', () => {
 		const mockResolverEntity: DynamicCredentialResolver = {
 			id: 'resolver-123',
+			name: 'Test Resolver',
 			type: 'oauth2-introspection-identifier',
 			config: 'encrypted-config',
 			createdAt: new Date(),
 			updatedAt: new Date(),
+			generateId: jest.fn(),
+			setUpdateDate: jest.fn(),
 		};
 
 		const mockResolver = {
@@ -73,11 +76,11 @@ describe('DynamicCredentialsController', () => {
 				id: '1',
 				type: 'googleOAuth2Api',
 			});
-			const req = {
+			const req = mock<Request>({
 				params: { id: '1' },
-				query: {} as any,
+				query: {},
 				headers: { authorization: 'Bearer token123' },
-			} as Request;
+			});
 			const res = mock<Response>();
 
 			enterpriseCredentialsService.getOne.mockResolvedValue(mockCredential);

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/oauth-credential-resolver.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/oauth-credential-resolver.ts
@@ -218,4 +218,16 @@ export class OAuthCredentialResolver implements ICredentialResolver {
 		const [identifier, parsedOptions] = await this.getIdentifier(options);
 		return await identifier.resolve(context, parsedOptions);
 	}
+
+	async validateIdentity(identity: string, handle: CredentialResolverHandle): Promise<void> {
+		const parsedOptions = await this.parseOptions(handle.configuration);
+		await this.resolveIdentifier(
+			{
+				identity,
+				version: 1,
+				metadata: {},
+			},
+			parsedOptions,
+		);
+	}
 }

--- a/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.controller.ts
@@ -6,17 +6,26 @@ import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { CreateCsrfStateData, OauthService } from '@/oauth/oauth.service';
 import { CredentialsEntity } from '@n8n/db';
+import { DynamicCredentialResolverRepository } from './database/repositories/credential-resolver.repository';
+import { DynamicCredentialResolverRegistry } from './services';
+import { getBearerToken } from './utils';
+import { Cipher } from 'n8n-core';
+import { jsonParse } from 'n8n-workflow';
 
 @RestController('/credentials')
 export class DynamicCredentialsController {
 	constructor(
 		private readonly enterpriseCredentialsService: EnterpriseCredentialsService,
 		private readonly oauthService: OauthService,
+		private readonly resolverRepository: DynamicCredentialResolverRepository,
+		private readonly resolverRegistry: DynamicCredentialResolverRegistry,
+		private readonly cipher: Cipher,
 	) {}
 
 	@Post('/:id/authorize', { skipAuth: true })
 	async authorizeCredential(req: Request, _res: Response): Promise<string> {
 		const credential = await this.enterpriseCredentialsService.getOne(req.params.id);
+		const token = getBearerToken(req);
 
 		if (!credential) {
 			throw new NotFoundError('Credential not found');
@@ -24,6 +33,38 @@ export class DynamicCredentialsController {
 
 		if (!credential.type.includes('OAuth2') && !credential.type.includes('OAuth1')) {
 			throw new BadRequestError('Credential type not supported');
+		}
+
+		const resolverId = req.query.resolverId as string | undefined;
+		if (!resolverId) {
+			throw new BadRequestError('Missing resolverId query parameter');
+		}
+
+		const resolverEntity = await this.resolverRepository.findOneBy({
+			id: resolverId,
+		});
+
+		if (!resolverEntity) {
+			throw new NotFoundError('Resolver not found');
+		}
+
+		// Get resolver instance from registry
+		const resolver = this.resolverRegistry.getResolverByTypename(resolverEntity.type);
+
+		if (!resolver) {
+			throw new NotFoundError('Resolver type not found');
+		}
+
+		if (resolver.validateIdentity) {
+			// Decrypt and parse resolver configuration
+			const decryptedConfig = this.cipher.decrypt(resolverEntity.config);
+			const resolverConfig = jsonParse<Record<string, unknown>>(decryptedConfig);
+
+			await resolver.validateIdentity(token, {
+				resolverId,
+				resolverName: resolverEntity.type,
+				configuration: resolverConfig,
+			});
 		}
 
 		const callerData: [CredentialsEntity, CreateCsrfStateData] = [

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/credential-resolver-workflow.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/credential-resolver-workflow.service.ts
@@ -141,42 +141,43 @@ export class CredentialResolverWorkflowService {
 		let resolverInstance: ICredentialResolver | null = options.workflowResolverInstance;
 		let resolverConfig: Record<string, unknown> | null = options.workflowResolverConfig;
 		const credentialResolverId = credential.resolverId ?? options.resolverId;
-		if (credentialResolverId) {
-			if (credentialResolverId !== options.resolverId) {
-				const {
-					resolverInstance: credentialResolverInstance,
-					resolverConfig: credentialResolverConfig,
-				} = await this.getResolver(credentialResolverId);
-				resolverInstance = credentialResolverInstance;
-				resolverConfig = credentialResolverConfig;
-			}
+		if (!credentialResolverId) {
+			return null;
+		}
+		if (credentialResolverId !== options.resolverId) {
+			const {
+				resolverInstance: credentialResolverInstance,
+				resolverConfig: credentialResolverConfig,
+			} = await this.getResolver(credentialResolverId);
+			resolverInstance = credentialResolverInstance;
+			resolverConfig = credentialResolverConfig;
+		}
 
-			if (resolverConfig && resolverInstance) {
-				try {
-					await resolverInstance.getSecret(
-						credential.id,
-						{ identity: options.identityToken, version: 1 },
-						{
-							configuration: resolverConfig,
-							resolverName: resolverInstance.metadata.name,
-							resolverId: credentialResolverId,
-						},
-					);
-					return {
-						credentialId: credential.id,
+		if (resolverConfig && resolverInstance) {
+			try {
+				await resolverInstance.getSecret(
+					credential.id,
+					{ identity: options.identityToken, version: 1 },
+					{
+						configuration: resolverConfig,
+						resolverName: resolverInstance.metadata.name,
 						resolverId: credentialResolverId,
-						status: 'configured',
-						credentialType: credential.type,
-					};
-				} catch (error) {
-					// Handle error (e.g., log it, collect status, etc.
-					return {
-						credentialId: credential.id,
-						resolverId: credentialResolverId,
-						status: 'missing',
-						credentialType: credential.type,
-					};
-				}
+					},
+				);
+				return {
+					credentialId: credential.id,
+					resolverId: credentialResolverId,
+					status: 'configured',
+					credentialType: credential.type,
+				};
+			} catch (error) {
+				// Handle error (e.g., log it, collect status, etc.
+				return {
+					credentialId: credential.id,
+					resolverId: credentialResolverId,
+					status: 'missing',
+					credentialType: credential.type,
+				};
 			}
 		}
 		return null;

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/shared-fields.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/shared-fields.ts
@@ -3,12 +3,39 @@
  * If a field is not defined in the schema, it is considered dynamic.
  * If a field is marked as dynamic in the schema it is considered dynamic.
  */
-import type { ICredentialType } from 'n8n-workflow';
+import { Container } from '@n8n/di';
+import { NodeHelpers, type ICredentialType, type INodeProperties } from 'n8n-workflow';
+
+import { CredentialTypes } from '@/credential-types';
+
+// Build merged properties from credential hierarchy
+function getExtendedProps(
+	type: ICredentialType,
+	credentialTypes: CredentialTypes,
+): INodeProperties[] {
+	const props: INodeProperties[] = [];
+
+	// Recursively get parent properties first (bottom-up)
+	for (const parentTypeName of type.extends ?? []) {
+		const parentType = credentialTypes.getByName(parentTypeName);
+		const parentProps = getExtendedProps(parentType, credentialTypes);
+		NodeHelpers.mergeNodeProperties(props, parentProps);
+	}
+
+	// Merge current type's properties (child properties override parent)
+	NodeHelpers.mergeNodeProperties(props, type.properties);
+
+	return props;
+}
 
 export function extractSharedFields(credentialType: ICredentialType): string[] {
+	const credentialTypes = Container.get(CredentialTypes);
+
+	const mergedProperties = getExtendedProps(credentialType, credentialTypes);
+
 	const sharedFields: string[] = [];
 
-	for (const property of credentialType.properties) {
+	for (const property of mergedProperties) {
 		// If a field is not marked as resolvable, consider it static
 		if (property.resolvableField !== true) {
 			sharedFields.push(property.name);

--- a/packages/cli/src/modules/dynamic-credentials.ee/utils.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/utils.ts
@@ -1,0 +1,22 @@
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { UnauthenticatedError } from '@/errors/response-errors/unauthenticated.error';
+import type { Request } from 'express';
+
+const BEARER_TOKEN_REGEX = /^[Bb][Ee][Aa][Rr][Ee][Rr]\s+(.+)$/;
+
+export function getBearerToken(req: Request): string {
+	const headerValue = req.headers['authorization']?.toString();
+
+	if (!headerValue) {
+		throw new UnauthenticatedError();
+	}
+
+	const result = BEARER_TOKEN_REGEX.exec(headerValue);
+	const token = result ? result[1] : null;
+
+	if (!token) {
+		throw new BadRequestError('Authorization header is malformed');
+	}
+
+	return token;
+}

--- a/packages/cli/src/modules/dynamic-credentials.ee/workflow-status.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/workflow-status.controller.ts
@@ -4,9 +4,7 @@ import { Request, Response } from 'express';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { CredentialResolverWorkflowService } from './services/credential-resolver-workflow.service';
 import { WorkflowExecutionStatus } from '@n8n/api-types';
-import { UnauthenticatedError } from '@/errors/response-errors/unauthenticated.error';
-
-const BEARER_TOKEN_REGEX = /^[Bb][Ee][Aa][Rr][Ee][Rr]\s+(.+)$/;
+import { getBearerToken } from './utils';
 
 @RestController('/workflows')
 export class WorkflowStatusController {
@@ -26,18 +24,7 @@ export class WorkflowStatusController {
 	@Get('/:workflowId/execution-status', { skipAuth: true })
 	async checkWorkflowForExecution(req: Request, _res: Response): Promise<WorkflowExecutionStatus> {
 		const workflowId = req.params['workflowId'];
-		const headerValue = req.headers['authorization']?.toString();
-
-		if (!headerValue) {
-			throw new UnauthenticatedError();
-		}
-
-		const result = BEARER_TOKEN_REGEX.exec(headerValue);
-		const token = result ? result[1] : null;
-
-		if (!token) {
-			throw new BadRequestError('Authorization header is malformed');
-		}
+		const token = getBearerToken(req);
 
 		if (!workflowId) {
 			throw new BadRequestError('Workflow ID is missing');

--- a/packages/cli/src/oauth/oauth.service.ts
+++ b/packages/cli/src/oauth/oauth.service.ts
@@ -576,7 +576,6 @@ export class OauthService {
 		credentialResolverId: string,
 	) {
 		const credentials = new Credentials(credential, credential.type, credential.data);
-		credentials.updateData(oauthTokenData, ['csrfSecret']);
 
 		const credentialStoreMetadata: CredentialStoreMetadata = {
 			id: credential.id,


### PR DESCRIPTION
## Summary

Store correct data object for dynamic credentials.

## Related Linear tickets, Github issues, and Community forum posts

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
