### PR TITLE
fix(python-runner): Include stack trace in error responses

### DIFF
--- a/packages/@n8n/task-runner-python/src/task_runner.py
+++ b/packages/@n8n/task-runner-python/src/task_runner.py
@@ -363,6 +363,7 @@ class TaskRunner:
             error = {
                 "message": getattr(e, "message", str(e)),
                 "description": getattr(e, "description", ""),
+                "stack": getattr(e, "stack_trace", ""),
             }
             response = RunnerTaskError(task_id=task_id, error=error)
             await self._send_message(response)

--- a/packages/@n8n/task-runner-python/tests/integration/test_execution.py
+++ b/packages/@n8n/task-runner-python/tests/integration/test_execution.py
@@ -57,6 +57,8 @@ async def test_all_items_with_error(broker, manager):
 
     assert error_msg["taskId"] == task_id
     assert "Intentional error" in str(error_msg["error"]["message"])
+    assert "stack" in error_msg["error"]
+    assert "ValueError" in error_msg["error"]["stack"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Include stack trace in Python task runner error responses.

Previously, when a Python code node execution failed with a runtime error, only `message` and `description` were sent back to the frontend. The `TaskRuntimeError` class stores the full stack trace in `stack_trace`, but this wasn't being forwarded in the error response.

This fix adds the `stack` field to error responses, making it easier to debug Python code node failures by showing the full traceback.

**Change:**

```python
error = {
    "message": getattr(e, "message", str(e)),
    "description": getattr(e, "description", ""),
    "stack": getattr(e, "stack_trace", ""),  # Added
}
```

**Test:** Added assertions to `test_all_items_with_error` to verify the `stack` field is populated with the traceback.

Example Code used in Code Node (run mode was set to "Run Once for Each Item" so _items didn't exist):
```python
# Single item: increase "num" by +2
item = _items[0]
item["json"]["num"] = item["json"].get("num", 0) + 2
return _items
```

Before:
![before](https://github.com/user-attachments/assets/49998bdc-0a0c-43a7-a4fc-99f7114bd880)

After:
![after](https://github.com/user-attachments/assets/938406f3-08d9-42a3-9b72-733014454da2)

## Related Linear tickets, Github issues, and Community forum posts

No related ticket were found with a search - this was discovered during development

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
