### PR TITLE
feat(core): Introduce WorkflowHistory compaction service

### DIFF
--- a/packages/@n8n/backend-test-utils/src/db/workflows.ts
+++ b/packages/@n8n/backend-test-utils/src/db/workflows.ts
@@ -1,4 +1,4 @@
-import type { SharedWorkflow, IWorkflowDb, WorkflowPublishHistory } from '@n8n/db';
+import type { SharedWorkflow, IWorkflowDb, WorkflowPublishHistory, WorkflowHistory } from '@n8n/db';
 import {
 	Project,
 	User,
@@ -247,7 +247,7 @@ export async function createWorkflowHistory(
 	workflow: IWorkflowDb,
 	userOrProject?: User | Project,
 	withPublishHistory?: Partial<WorkflowPublishHistory>,
-	autosaved = false,
+	overrides: Partial<WorkflowHistory> = {},
 ): Promise<void> {
 	const authors =
 		userOrProject instanceof User
@@ -262,7 +262,8 @@ export async function createWorkflowHistory(
 		nodes: workflow.nodes,
 		connections: workflow.connections,
 		authors,
-		autosaved,
+		autosaved: false,
+		...overrides,
 	});
 
 	if (withPublishHistory) {

--- a/packages/@n8n/config/src/configs/logging.config.ts
+++ b/packages/@n8n/config/src/configs/logging.config.ts
@@ -29,7 +29,7 @@ export const LOG_SCOPES = [
 	'breaking-changes',
 	'circuit-breaker',
 	'dynamic-credentials',
-	'history-compaction',
+	'workflow-history-compaction',
 ] as const;
 
 export type LogScope = (typeof LOG_SCOPES)[number];

--- a/packages/@n8n/config/src/configs/logging.config.ts
+++ b/packages/@n8n/config/src/configs/logging.config.ts
@@ -29,6 +29,7 @@ export const LOG_SCOPES = [
 	'breaking-changes',
 	'circuit-breaker',
 	'dynamic-credentials',
+	'history-compaction',
 ] as const;
 
 export type LogScope = (typeof LOG_SCOPES)[number];

--- a/packages/@n8n/config/src/configs/workflow-history-compaction.config.ts
+++ b/packages/@n8n/config/src/configs/workflow-history-compaction.config.ts
@@ -1,0 +1,54 @@
+import { Config, Env } from '../decorators';
+
+@Config
+export class WorkflowHistoryCompactionConfig {
+	@Env('N8N_WORKFLOW_HISTORY_COMPACTION_MINIMUM_AGE_HOURS')
+	/**
+	 * The minimum time we leave workflows in the history untouched
+	 * before we start compacting them.
+	 *
+	 * The workflow versions we compare and compact are those with
+	 * a `createdAt` value between `compactingMinimumAgeHours - compactingTimeWindowHours`
+	 * and `compactingMinimumAgeHours`
+
+	 */
+	compactingMinimumAgeHours: number = 24;
+
+	/**
+	 * The time window we consider when compacting versions.
+	 *
+	 * The workflow versions we compare and compact are those with
+	 * a `createdAt` value between `compactingMinimumAgeHours - compactingTimeWindowHours`
+	 * and `compactingMinimumAgeHours`.
+	 *
+	 * Compaction will happen every `compactingTimeWindowHours/2` hours to
+	 * account for small gaps and downtime.
+	 */
+	@Env('N8N_WORKFLOW_HISTORY_COMPACTION_TIME_WINDOW_HOURS')
+	compactingTimeWindowHours: number = 2;
+
+	/**
+	 * The maximum number of compared workflow versions before waiting `batchDelayMs`
+	 * before continuing with the next workflowId
+	 */
+	@Env('N8N_WORKFLOW_HISTORY_COMPACTION_BATCH_SIZE')
+	batchSize: number = 1_000;
+
+	/**
+	 * Delay in milliseconds before continuing with the next workflowId to compact
+	 * after having compared at least `batchSize` workflow versions
+	 */
+	@Env('N8N_WORKFLOW_HISTORY_COMPACTION_BATCH_DELAY_MS')
+	batchDelayMs: number = 1_000;
+
+	/**
+	 * Whether to run compaction on instance start up.
+	 *
+	 * Useful to apply a larger compaction value to cover existing
+	 * histories if something went wrong previously, and for development.
+	 *
+	 * @warning Long-running blocking operation that will increase startup time.
+	 */
+	@Env('N8N_WORKFLOW_HISTORY_COMPACTION_RUN_ON_START_UP')
+	compactOnStartUp: boolean = false;
+}

--- a/packages/@n8n/config/src/index.ts
+++ b/packages/@n8n/config/src/index.ts
@@ -34,6 +34,7 @@ import { TagsConfig } from './configs/tags.config';
 import { TemplatesConfig } from './configs/templates.config';
 import { UserManagementConfig } from './configs/user-management.config';
 import { VersionNotificationsConfig } from './configs/version-notifications.config';
+import { WorkflowHistoryCompactionConfig } from './configs/workflow-history-compaction.config';
 import { WorkflowHistoryConfig } from './configs/workflow-history.config';
 import { WorkflowsConfig } from './configs/workflows.config';
 import { Config, Env, Nested } from './decorators';
@@ -55,6 +56,7 @@ export { HiringBannerConfig } from './configs/hiring-banner.config';
 export { PersonalizationConfig } from './configs/personalization.config';
 export { NodesConfig } from './configs/nodes.config';
 export { CronLoggingConfig } from './configs/logging.config';
+export { WorkflowHistoryCompactionConfig } from './configs/workflow-history-compaction.config';
 
 const protocolSchema = z.enum(['http', 'https']);
 
@@ -217,4 +219,7 @@ export class GlobalConfig {
 
 	@Nested
 	dataTable: DataTableConfig;
+
+	@Nested
+	workflowHistoryCompaction: WorkflowHistoryCompactionConfig;
 }

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -410,6 +410,13 @@ describe('GlobalConfig', () => {
 		ai: {
 			enabled: false,
 		},
+		workflowHistoryCompaction: {
+			batchDelayMs: 1_000,
+			batchSize: 1_000,
+			compactingMinimumAgeHours: 24,
+			compactingTimeWindowHours: 2,
+			compactOnStartUp: false,
+		},
 	};
 
 	it('should use all default values when no env variables are defined', () => {

--- a/packages/@n8n/constants/src/time.ts
+++ b/packages/@n8n/constants/src/time.ts
@@ -3,6 +3,7 @@
  */
 export const Time = {
 	milliseconds: {
+		toHours: 1 / (60 * 60 * 1000),
 		toMinutes: 1 / (60 * 1000),
 		toSeconds: 1 / 1000,
 	},

--- a/packages/@n8n/db/src/repositories/workflow-history.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-history.repository.ts
@@ -69,7 +69,7 @@ export class WorkflowHistoryRepository extends Repository<WorkflowHistory> {
 				startDate,
 			})
 			.groupBy('wh.workflowId')
-			.getRawMany<WorkflowHistory>(); // need raw due to `distinct(true)`
+			.getRawMany<{ workflowId: string }>();
 
 		return result.map((x) => x.workflowId);
 	}

--- a/packages/@n8n/db/src/repositories/workflow-history.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-history.repository.ts
@@ -1,11 +1,16 @@
 import { Service } from '@n8n/di';
-import { DataSource, LessThan, Repository } from '@n8n/typeorm';
+import { DataSource, In, LessThan, Repository } from '@n8n/typeorm';
+import { GroupedWorkflowHistory, groupWorkflows, RULES } from 'n8n-workflow';
 
 import { WorkflowHistory, WorkflowEntity } from '../entities';
+import { WorkflowPublishHistoryRepository } from './workflow-publish-history.repository';
 
 @Service()
 export class WorkflowHistoryRepository extends Repository<WorkflowHistory> {
-	constructor(dataSource: DataSource) {
+	constructor(
+		dataSource: DataSource,
+		private readonly workflowPublishHistoryRepository: WorkflowPublishHistoryRepository,
+	) {
 		super(WorkflowHistory, dataSource.manager);
 	}
 
@@ -40,5 +45,71 @@ export class WorkflowHistoryRepository extends Repository<WorkflowHistory> {
 			.andWhere(`versionId NOT IN (${currentVersionIdsSubquery})`)
 			.andWhere(`versionId NOT IN (${activeVersionIdsSubquery})`)
 			.execute();
+	}
+
+	private makeSkipActiveAndNamedVersionsRule(activeVersions: string[]) {
+		return (
+			prev: GroupedWorkflowHistory<WorkflowHistory>,
+			_next: GroupedWorkflowHistory<WorkflowHistory>,
+		): boolean =>
+			prev.to.name !== null ||
+			prev.to.description !== null ||
+			activeVersions.includes(prev.to.versionId);
+	}
+
+	async getWorkflowIdsInRange(startDate: Date, endDate: Date) {
+		const result = await this.manager
+			.createQueryBuilder(WorkflowHistory, 'wh')
+			.select('wh.workflowId', 'workflowId')
+			.distinct(true)
+			.where('wh.createdAt <= :endDate', {
+				endDate,
+			})
+			.andWhere('wh.createdAt >= :startDate', {
+				startDate,
+			})
+			.groupBy('wh.workflowId')
+			.getRawMany<WorkflowHistory>(); // need raw due to `distinct(true)`
+
+		return result.map((x) => x.workflowId);
+	}
+
+	/**
+	 * @returns The amount of seen and deleted versions
+	 */
+	async pruneHistory(
+		workflowId: string,
+		startDate: Date,
+		endDate: Date,
+	): Promise<{ seen: number; deleted: number }> {
+		const workflows = await this.manager
+			.createQueryBuilder(WorkflowHistory, 'wh')
+			.where('wh.workflowId = :workflowId', { workflowId })
+			.andWhere('wh.createdAt <= :endDate', {
+				endDate,
+			})
+			.andWhere('wh.createdAt >= :startDate', {
+				startDate,
+			})
+			.orderBy('wh.createdAt', 'ASC')
+			.getMany();
+
+		// Group by workflowId
+
+		const versionsToDelete = [];
+		const publishedVersions =
+			await this.workflowPublishHistoryRepository.getPublishedVersions(workflowId);
+		const grouped = groupWorkflows<WorkflowHistory>(
+			workflows,
+			[RULES.mergeAdditiveChanges],
+			[this.makeSkipActiveAndNamedVersionsRule(publishedVersions.map((x) => x.versionId))],
+		);
+		for (const group of grouped) {
+			for (const wf of group.groupedWorkflows) {
+				versionsToDelete.push(wf.versionId);
+			}
+		}
+		await this.delete({ versionId: In(versionsToDelete) });
+		return { seen: workflows.length, deleted: versionsToDelete.length };
 	}
 }

--- a/packages/@n8n/db/src/repositories/workflow-publish-history.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-publish-history.repository.ts
@@ -22,4 +22,15 @@ export class WorkflowPublishHistoryRepository extends Repository<WorkflowPublish
 			userId,
 		});
 	}
+
+	async getPublishedVersions(
+		workflowId: string,
+	): Promise<Array<Pick<WorkflowPublishHistory, 'versionId'>>> {
+		return await this.manager
+			.createQueryBuilder(WorkflowPublishHistory, 'wph')
+			.select('wph.versionId')
+			.distinct(true)
+			.where('wph.workflowId = :workflowId', { workflowId })
+			.getMany();
+	}
 }

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -36,6 +36,7 @@ import { BaseCommand } from './base-command';
 import { CredentialsOverwrites } from '@/credentials-overwrites';
 import { DeprecationService } from '@/deprecation/deprecation.service';
 import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
+import { WorkflowHistoryCompactionService } from '@/services/pruning/workflow-history-compaction.service';
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const open = require('open');
@@ -315,6 +316,7 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 		await this.server.start();
 
 		Container.get(ExecutionsPruningService).init();
+		Container.get(WorkflowHistoryCompactionService).init();
 
 		if (this.globalConfig.executions.mode === 'regular') {
 			await this.runEnqueuedExecutions();

--- a/packages/cli/src/executions/__tests__/execution-recovery.service.integration.test.ts
+++ b/packages/cli/src/executions/__tests__/execution-recovery.service.integration.test.ts
@@ -66,7 +66,13 @@ describe('ExecutionRecoveryService', () => {
 	afterEach(async () => {
 		jest.restoreAllMocks();
 		globalConfig.executions.recovery.workflowDeactivationEnabled = false;
-		await testDb.truncate(['ExecutionEntity', 'ExecutionData', 'WorkflowEntity']);
+		await testDb.truncate([
+			'ExecutionEntity',
+			'ExecutionData',
+			'WorkflowEntity',
+			'WorkflowHistory',
+			'WorkflowPublishHistory',
+		]);
 	});
 
 	afterAll(async () => {

--- a/packages/cli/src/services/pruning/__tests__/workflow-history-compaction.service.test.ts
+++ b/packages/cli/src/services/pruning/__tests__/workflow-history-compaction.service.test.ts
@@ -1,0 +1,92 @@
+import { mockLogger } from '@n8n/backend-test-utils';
+import type { WorkflowHistoryCompactionConfig } from '@n8n/config';
+import type { DbConnection } from '@n8n/db';
+import { mock } from 'jest-mock-extended';
+import type { InstanceSettings } from 'n8n-core';
+
+import { WorkflowHistoryCompactionService } from '../workflow-history-compaction.service';
+
+describe('WorkflowHistoryCompactionService', () => {
+	const dbConnection = mock<DbConnection>({
+		connectionState: { migrated: true },
+	});
+	const config = mock<WorkflowHistoryCompactionConfig>({
+		batchDelayMs: 1000,
+		batchSize: 1000,
+		compactingMinimumAgeHours: 24,
+		compactingTimeWindowHours: 2,
+		compactOnStartUp: false,
+	});
+
+	describe('init', () => {
+		it('should start compacting on main instance that is the leader', () => {
+			const compactingService = new WorkflowHistoryCompactionService(
+				config,
+				mockLogger(),
+				mock<InstanceSettings>({ isLeader: true, isMultiMain: true }),
+				dbConnection,
+				mock(),
+			);
+			const startCompacting = jest.spyOn(compactingService, 'startCompacting');
+
+			compactingService.init();
+
+			expect(startCompacting).toHaveBeenCalled();
+		});
+
+		it('should not start pruning on main instance that is a follower', () => {
+			const compactingService = new WorkflowHistoryCompactionService(
+				config,
+				mockLogger(),
+				mock<InstanceSettings>({ isLeader: false, isMultiMain: true }),
+				dbConnection,
+				mock(),
+			);
+			const startCompacting = jest.spyOn(compactingService, 'startCompacting');
+
+			compactingService.init();
+
+			expect(startCompacting).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('startCompacting', () => {
+		it('should start compacting if service is enabled and DB is migrated', () => {
+			const compactingService = new WorkflowHistoryCompactionService(
+				config,
+				mockLogger(),
+				mock<InstanceSettings>({ isLeader: true, instanceType: 'main', isMultiMain: true }),
+				dbConnection,
+				mock(),
+			);
+
+			const scheduleRollingCompactingSpy = jest
+				// @ts-expect-error Private method
+				.spyOn(compactingService, 'scheduleRollingCompacting')
+				.mockImplementation();
+
+			compactingService.startCompacting();
+
+			expect(scheduleRollingCompactingSpy).toHaveBeenCalled();
+		});
+	});
+
+	it('should compact on start up if config says so', () => {
+		const compactingService = new WorkflowHistoryCompactionService(
+			{ ...config, compactOnStartUp: true },
+			mockLogger(),
+			mock<InstanceSettings>({ isLeader: true, instanceType: 'main', isMultiMain: true }),
+			dbConnection,
+			mock(),
+		);
+
+		const scheduleRollingCompactingSpy = jest
+			// @ts-expect-error Private method
+			.spyOn(compactingService, 'compactHistories')
+			.mockImplementation();
+
+		compactingService.startCompacting();
+
+		expect(scheduleRollingCompactingSpy).toHaveBeenCalled();
+	});
+});

--- a/packages/cli/src/services/pruning/workflow-history-compaction.service.ts
+++ b/packages/cli/src/services/pruning/workflow-history-compaction.service.ts
@@ -1,0 +1,176 @@
+import { Logger } from '@n8n/backend-common';
+import { WorkflowHistoryCompactionConfig } from '@n8n/config';
+import { Time } from '@n8n/constants';
+import { DbConnection, WorkflowHistoryRepository } from '@n8n/db';
+import { OnLeaderStepdown, OnLeaderTakeover, OnShutdown } from '@n8n/decorators';
+import { Service } from '@n8n/di';
+import { InstanceSettings } from 'n8n-core';
+import { ensureError, sleep } from 'n8n-workflow';
+import { strict } from 'node:assert';
+
+/**
+ * Responsible for compacting auto saved workflow history entries in the database.
+ *
+ * Every hour (`compactingTimeWindowHours` / 2):
+ *
+ * 1. Find workflows with new versions in the time window determined
+ *    by `compactingMinimumAgeHours` and `compactingTimeWindowHours`
+ *
+ * 2. For each workflow, fetch all versions in that window and remove
+ *    versions based on workflowHistoryRepo.pruneHistory.
+ *
+ * This currently removes any *redundant* versions, i.e. versions
+ * which hold no meaningful data compared to the next iteration
+ * e.g. only change is node parameter { a: 'the quick' } to { a: 'the quick brown fox' }
+ *
+ * We may introduce more stricter rules in the future, likely with
+ * a mechanism to run this pruning on demand.
+ */
+@Service()
+export class WorkflowHistoryCompactionService {
+	private compactingInterval: NodeJS.Timeout | undefined;
+
+	private isShuttingDown = false;
+
+	constructor(
+		private readonly config: WorkflowHistoryCompactionConfig,
+		private readonly logger: Logger,
+		private readonly instanceSettings: InstanceSettings,
+		private readonly dbConnection: DbConnection,
+		private readonly workflowHistoryRepository: WorkflowHistoryRepository,
+	) {
+		this.logger = this.logger.scoped('history-compaction');
+	}
+
+	init() {
+		strict(this.instanceSettings.instanceRole !== 'unset', 'Instance role is not set');
+
+		if (this.instanceSettings.isLeader) this.startCompacting();
+	}
+
+	get isEnabled() {
+		return this.instanceSettings.instanceType === 'main' && this.instanceSettings.isLeader;
+	}
+
+	@OnLeaderTakeover()
+	startCompacting() {
+		const { connectionState } = this.dbConnection;
+		if (!this.isEnabled || !connectionState.migrated || this.isShuttingDown) return;
+
+		this.logger.debug('Started workflow histories compaction');
+
+		this.scheduleRollingCompacting();
+
+		if (this.config.compactOnStartUp) {
+			void this.compactHistories();
+		}
+	}
+
+	@OnLeaderStepdown()
+	stopCompacting() {
+		if (!this.isEnabled) return;
+
+		clearInterval(this.compactingInterval);
+
+		this.logger.debug('Stopped workflow histories compaction');
+	}
+
+	private scheduleRollingCompacting() {
+		// We run compaction twice as often as the window for which we compact workflows
+		// This allows redundancy for covering first and last versions in the window, accounts
+		// for restarts and other small gaps, e.g. caused by the next internal needing to wait
+		// for computing resources if the instance is busy
+		const rateMs = (this.config.compactingTimeWindowHours / 2) * Time.hours.toMilliseconds;
+		this.compactingInterval = setInterval(async () => await this.compactHistories(), rateMs);
+
+		this.logger.debug(
+			`Compacting histories every ${this.config.compactingTimeWindowHours / 2.0} hour(s)`,
+		);
+	}
+
+	@OnShutdown()
+	shutdown(): void {
+		this.isShuttingDown = true;
+		this.stopCompacting();
+	}
+
+	private async compactHistories(): Promise<void> {
+		const compactionStartTime = Date.now();
+
+		const startDate = new Date(
+			compactionStartTime -
+				(this.config.compactingMinimumAgeHours + this.config.compactingTimeWindowHours) *
+					Time.hours.toMilliseconds,
+		);
+		const endDate = new Date(
+			compactionStartTime - this.config.compactingMinimumAgeHours * Time.hours.toMilliseconds,
+		);
+
+		const startIso = startDate.toISOString();
+		const endIso = endDate.toISOString();
+
+		this.logger.info('Starting workflow history compaction', {
+			dateRange: { start: startIso, end: endIso },
+			config: this.config,
+		});
+
+		const workflowIds = await this.workflowHistoryRepository.getWorkflowIdsInRange(
+			startDate,
+			endDate,
+		);
+
+		this.logger.debug(
+			`Found ${workflowIds.length} workflows with versions between ${startDate.toISOString()} and ${endDate.toISOString()}`,
+		);
+
+		let batchSum = 0;
+		let totalSum = 0;
+		let totalDeleted = 0;
+		let errorCount = 0;
+		for (const [index, workflowId] of workflowIds.entries()) {
+			try {
+				const { seen, deleted } = await this.workflowHistoryRepository.pruneHistory(
+					workflowId,
+					startDate,
+					endDate,
+				);
+				batchSum += seen;
+				totalSum += seen;
+				totalDeleted += deleted;
+
+				this.logger.debug(
+					`Deleted ${deleted} of ${seen} versions of workflow ${workflowId} between ${startIso} and ${endIso}`,
+				);
+			} catch (error) {
+				errorCount += 1;
+				this.logger.error(`Failed to prune version history of workflow ${workflowId}`, {
+					error: ensureError(error),
+				});
+
+				// Sleep after error to back off
+				await sleep(this.config.batchDelayMs);
+			}
+
+			if (batchSum > this.config.batchSize) {
+				this.logger.warn(
+					`Encountered more than ${this.config.batchSize} workflow versions, waiting ${this.config.batchDelayMs * Time.milliseconds.toSeconds} second(s) before continuing.`,
+				);
+				this.logger.warn(
+					`Compacted ${index} of ${workflowIds.length} workflows with versions between ${startIso} and ${endIso}`,
+				);
+				await sleep(this.config.batchDelayMs);
+				batchSum = 0;
+			}
+		}
+
+		const compactionDuration = Date.now() - compactionStartTime;
+		this.logger.info('Workflow history compaction complete', {
+			workflowsProcessed: workflowIds.length,
+			totalVersionsSeen: totalSum,
+			totalVersionsDeleted: totalDeleted,
+			errorCount,
+			durationMs: compactionDuration,
+			dateRange: { start: startIso, end: endIso },
+		});
+	}
+}

--- a/packages/cli/src/services/pruning/workflow-history-compaction.service.ts
+++ b/packages/cli/src/services/pruning/workflow-history-compaction.service.ts
@@ -39,7 +39,7 @@ export class WorkflowHistoryCompactionService {
 		private readonly dbConnection: DbConnection,
 		private readonly workflowHistoryRepository: WorkflowHistoryRepository,
 	) {
-		this.logger = this.logger.scoped('history-compaction');
+		this.logger = this.logger.scoped('workflow-history-compaction');
 	}
 
 	init() {
@@ -57,18 +57,19 @@ export class WorkflowHistoryCompactionService {
 		const { connectionState } = this.dbConnection;
 		if (!this.isEnabled || !connectionState.migrated || this.isShuttingDown) return;
 
-		this.logger.debug('Started workflow histories compaction');
+		this.logger.debug('Started workflow histories compaction', { ...this.config });
 
 		this.scheduleRollingCompacting();
 
 		if (this.config.compactOnStartUp) {
+			this.logger.debug('Compacting on start up');
 			void this.compactHistories();
 		}
 	}
 
 	@OnLeaderStepdown()
 	stopCompacting() {
-		if (!this.isEnabled) return;
+		if (!this.compactingInterval) return;
 
 		clearInterval(this.compactingInterval);
 
@@ -120,12 +121,12 @@ export class WorkflowHistoryCompactionService {
 		);
 
 		this.logger.debug(
-			`Found ${workflowIds.length} workflows with versions between ${startDate.toISOString()} and ${endDate.toISOString()}`,
+			`Found ${workflowIds.length} workflows with versions between ${startIso} and ${endIso}`,
 		);
 
 		let batchSum = 0;
-		let totalSum = 0;
-		let totalDeleted = 0;
+		let totalVersionsSeen = 0;
+		let totalVersionsDeleted = 0;
 		let errorCount = 0;
 		for (const [index, workflowId] of workflowIds.entries()) {
 			try {
@@ -135,8 +136,8 @@ export class WorkflowHistoryCompactionService {
 					endDate,
 				);
 				batchSum += seen;
-				totalSum += seen;
-				totalDeleted += deleted;
+				totalVersionsSeen += seen;
+				totalVersionsDeleted += deleted;
 
 				this.logger.debug(
 					`Deleted ${deleted} of ${seen} versions of workflow ${workflowId} between ${startIso} and ${endIso}`,
@@ -163,13 +164,13 @@ export class WorkflowHistoryCompactionService {
 			}
 		}
 
-		const compactionDuration = Date.now() - compactionStartTime;
+		const durationMs = Date.now() - compactionStartTime;
 		this.logger.info('Workflow history compaction complete', {
 			workflowsProcessed: workflowIds.length,
-			totalVersionsSeen: totalSum,
-			totalVersionsDeleted: totalDeleted,
+			totalVersionsSeen,
+			totalVersionsDeleted,
 			errorCount,
-			durationMs: compactionDuration,
+			durationMs,
 			dateRange: { start: startIso, end: endIso },
 		});
 	}

--- a/packages/cli/test/integration/database/repositories/workflow-history.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/workflow-history.repository.test.ts
@@ -1,0 +1,229 @@
+import {
+	createWorkflow,
+	createWorkflowHistory,
+	createWorkflowWithHistory,
+	testDb,
+} from '@n8n/backend-test-utils';
+import { WorkflowHistoryRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+import { type INode } from 'n8n-workflow';
+import { v4 as uuid } from 'uuid';
+
+describe('WorkflowHistoryRepository', () => {
+	const testNode1 = {
+		id: uuid(),
+		name: 'testNode1',
+		parameters: {},
+		type: 'aNodeType',
+		typeVersion: 1,
+		position: [0, 0],
+	} satisfies INode;
+
+	beforeAll(async () => {
+		await testDb.init();
+	});
+
+	beforeEach(async () => {
+		await testDb.truncate(['WorkflowPublishHistory', 'WorkflowHistory', 'WorkflowEntity', 'User']);
+	});
+
+	afterAll(async () => {
+		await testDb.terminate();
+	});
+
+	describe('pruneHistory', () => {
+		it('should prune superseded version', async () => {
+			const id1 = uuid();
+			const id2 = uuid();
+
+			const workflow = await createWorkflowWithHistory({
+				versionId: id1,
+				nodes: [{ ...testNode1, parameters: { a: 'a' } }],
+			});
+			await createWorkflowHistory({
+				...workflow,
+				versionId: uuid(),
+				nodes: [{ ...testNode1, parameters: { a: 'ab' } }],
+			});
+			await createWorkflowHistory({
+				...workflow,
+				versionId: uuid(),
+				nodes: [{ ...testNode1, parameters: { a: 'abc' } }],
+			});
+			await createWorkflowHistory({
+				...workflow,
+				versionId: id2,
+				nodes: [{ ...testNode1, parameters: { a: 'abcd' } }],
+			});
+
+			// ACT
+			const repository = Container.get(WorkflowHistoryRepository);
+
+			const tenDaysAgo = new Date();
+			tenDaysAgo.setDate(tenDaysAgo.getDate() - 10);
+
+			const aDayAgo = new Date();
+			aDayAgo.setDate(aDayAgo.getDate() - 1);
+
+			const nextDay = new Date();
+			nextDay.setDate(nextDay.getDate() + 1);
+
+			const inTenDays = new Date();
+			inTenDays.setDate(inTenDays.getDate() + 10);
+
+			{
+				// Don't touch workflows younger than range
+				const { deleted, seen } = await repository.pruneHistory(workflow.id, tenDaysAgo, aDayAgo);
+				expect(deleted).toBe(0);
+				expect(seen).toBe(0);
+
+				const history = await repository.find();
+				expect(history.length).toBe(4);
+			}
+
+			{
+				// Don't touch workflows older
+				const { deleted, seen } = await repository.pruneHistory(workflow.id, nextDay, inTenDays);
+				expect(deleted).toBe(0);
+				expect(seen).toBe(0);
+
+				const history = await repository.find();
+				expect(history.length).toBe(4);
+			}
+
+			{
+				const { deleted, seen } = await repository.pruneHistory(workflow.id, aDayAgo, nextDay);
+				expect(deleted).toBe(2);
+				expect(seen).toBe(4);
+
+				const history = await repository.find();
+				expect(history.length).toBe(2);
+				expect(history).toEqual([
+					expect.objectContaining({ versionId: id1 }),
+					expect.objectContaining({ versionId: id2 }),
+				]);
+			}
+		});
+
+		it('should never prune previously active or named versions', async () => {
+			// ARRANGE
+			const id1 = uuid();
+			const id2 = uuid();
+			const id3 = uuid();
+			const id4 = uuid();
+			const id5 = uuid();
+
+			const workflow = await createWorkflowWithHistory({
+				versionId: id1,
+				nodes: [{ ...testNode1, parameters: { a: 'a' } }],
+			});
+			await createWorkflowHistory(
+				{
+					...workflow,
+					versionId: id2,
+					nodes: [{ ...testNode1, parameters: { a: 'ab' } }],
+				},
+				undefined,
+				undefined,
+				{ name: 'aVersionName' },
+			);
+			await createWorkflowHistory({
+				...workflow,
+				versionId: id3,
+				nodes: [{ ...testNode1, parameters: { a: 'abc' } }],
+			});
+			await createWorkflowHistory(
+				{
+					...workflow,
+					versionId: id4,
+					nodes: [{ ...testNode1, parameters: { a: 'abcd' } }],
+				},
+				undefined,
+				{ event: 'activated' },
+			);
+			await createWorkflowHistory({
+				...workflow,
+				versionId: id5,
+				nodes: [{ ...testNode1, parameters: { a: 'abcde' } }],
+			});
+
+			// ACT
+			const repository = Container.get(WorkflowHistoryRepository);
+
+			const aDayAgo = new Date();
+			aDayAgo.setDate(aDayAgo.getDate() - 1);
+
+			const nextDay = new Date();
+			nextDay.setDate(nextDay.getDate() + 1);
+
+			const { deleted, seen } = await repository.pruneHistory(workflow.id, aDayAgo, nextDay);
+
+			// ASSERT
+			expect(deleted).toBe(1);
+			expect(seen).toBe(5);
+
+			const history = await repository.find();
+			expect(history.length).toBe(4);
+			expect(history).toEqual([
+				expect.objectContaining({ versionId: id1 }),
+				expect.objectContaining({ versionId: id2 }),
+				expect.objectContaining({ versionId: id4 }),
+				expect.objectContaining({ versionId: id5 }),
+			]);
+
+			const redo = await repository.pruneHistory(workflow.id, aDayAgo, nextDay);
+
+			// ASSERT
+			expect(redo.deleted).toBe(0);
+			expect(redo.seen).toBe(4);
+		});
+	});
+	describe('getWorkflowIdsInRange', () => {
+		it('should return versions in range', async () => {
+			const now = Date.now();
+			const twoSecondsAhead = new Date(now + 2 * 1000);
+			const fourSecondsAhead = new Date(now + 4 * 1000);
+			const sixSecondsAhead = new Date(now + 6 * 1000);
+
+			const workflowA = await createWorkflow({
+				versionId: uuid(),
+				nodes: [{ ...testNode1, parameters: { a: 'a' } }],
+			});
+
+			// Create workflow history for the initial version
+			await createWorkflowHistory(workflowA, undefined, undefined, { createdAt: new Date(now) });
+
+			await createWorkflowHistory(
+				{
+					...workflowA,
+					versionId: uuid(),
+					nodes: [{ ...testNode1, parameters: { a: 'abcd' } }],
+				},
+				undefined,
+				undefined,
+				{ createdAt: twoSecondsAhead },
+			);
+
+			const workflowB = await createWorkflow({
+				versionId: uuid(),
+				nodes: [{ ...testNode1, parameters: { a: 'a' } }],
+			});
+			await createWorkflowHistory(workflowB, undefined, undefined, { createdAt: fourSecondsAhead });
+
+			// ACT
+			const repository = Container.get(WorkflowHistoryRepository);
+			{
+				const ids = await repository.getWorkflowIdsInRange(sixSecondsAhead, sixSecondsAhead);
+				expect(ids).toEqual([]);
+			}
+			{
+				const ids = await repository.getWorkflowIdsInRange(fourSecondsAhead, sixSecondsAhead);
+				expect(ids).toEqual([workflowB.id]);
+			}
+			{
+				const ids = await repository.getWorkflowIdsInRange(twoSecondsAhead, sixSecondsAhead);
+				expect(ids).toEqual(expect.arrayContaining([workflowA.id, workflowB.id]));
+			}
+		});
+	});
+});

--- a/packages/cli/test/integration/workflow-history-compaction.service.test.ts
+++ b/packages/cli/test/integration/workflow-history-compaction.service.test.ts
@@ -1,0 +1,224 @@
+import { mockLogger, createWorkflow, testDb, createWorkflowHistory } from '@n8n/backend-test-utils';
+import { GlobalConfig } from '@n8n/config';
+import { Time } from '@n8n/constants';
+import { DbConnection, WorkflowHistoryRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+import repeat from 'lodash/repeat';
+import { InstanceSettings } from 'n8n-core';
+import { sleep, type INode } from 'n8n-workflow';
+import { v4 as uuid } from 'uuid';
+
+import { WorkflowHistoryCompactionService } from '@/services/pruning/workflow-history-compaction.service';
+
+describe('compacting cycle', () => {
+	let compactionService: WorkflowHistoryCompactionService;
+	const instanceSettings = Container.get(InstanceSettings);
+	instanceSettings.markAsLeader();
+
+	const now = Date.now();
+	// before minimum compacting age
+	const todayA = new Date(now - 0.3 * Time.days.toMilliseconds);
+	const todayB = new Date(now - 0.5 * Time.days.toMilliseconds);
+	// within first hour
+	const yesterdayA = new Date(now - 1.005 * Time.days.toMilliseconds);
+	const yesterdayB = new Date(now - 1.004 * Time.days.toMilliseconds);
+	const yesterdayC = new Date(now - 1.003 * Time.days.toMilliseconds);
+	const yesterdayD = new Date(now - 1.002 * Time.days.toMilliseconds);
+	const yesterdayE = new Date(now - 1.001 * Time.days.toMilliseconds);
+	const lastWeekA = new Date(now - 7.5 * Time.days.toMilliseconds);
+	const lastWeekB = new Date(now - 7.3 * Time.days.toMilliseconds);
+
+	const wf1_versions = Array<string>(10)
+		.fill('')
+		.map(() => uuid());
+	const wf2_versions = Array<string>(10)
+		.fill('')
+		.map(() => uuid());
+	const wf3_versions = Array<string>(10)
+		.fill('')
+		.map(() => uuid());
+
+	const testNode1 = {
+		id: uuid(),
+		name: 'testNode1',
+		parameters: {},
+		type: 'aNodeType',
+		typeVersion: 1,
+		position: [0, 0],
+	} satisfies INode;
+
+	beforeAll(async () => {
+		await testDb.init();
+	});
+
+	beforeEach(async () => {
+		await testDb.truncate(['WorkflowEntity', 'WorkflowHistory', 'WorkflowPublishHistory']);
+
+		compactionService = new WorkflowHistoryCompactionService(
+			Container.get(GlobalConfig).workflowHistoryCompaction,
+			mockLogger(),
+			instanceSettings,
+			Container.get(DbConnection),
+			Container.get(WorkflowHistoryRepository),
+		);
+	});
+
+	afterAll(async () => {
+		await testDb.terminate();
+	});
+
+	it('compacts select workflow versions', async () => {
+		// ARRANGE
+		const wf1 = await createWorkflow({ versionId: wf1_versions[0] });
+
+		const wf1_history: Array<[Date, string]> = [
+			lastWeekA,
+			lastWeekB,
+			yesterdayA,
+			yesterdayB,
+			yesterdayC,
+			yesterdayD,
+			yesterdayE,
+			todayA,
+			todayB,
+		].map((x) => [x, uuid()]);
+
+		for (const [i, [createdAt, versionId]] of wf1_history.entries()) {
+			await createWorkflowHistory(
+				{ ...wf1, versionId, nodes: [{ ...testNode1, parameters: { a: repeat('1', i + 1) } }] },
+				undefined,
+				undefined,
+				{
+					createdAt,
+				},
+			);
+		}
+
+		const wf2_history: Array<[Date, string]> = [
+			yesterdayA,
+			yesterdayB,
+			yesterdayC,
+			yesterdayD,
+			yesterdayE,
+		].map((x) => [x, uuid()]);
+		const wf2 = await createWorkflow({ versionId: wf2_versions[0] });
+
+		for (const [i, [createdAt, versionId]] of wf2_history.entries()) {
+			await createWorkflowHistory(
+				{ ...wf2, versionId, nodes: [{ ...testNode1, parameters: { a: repeat('1', i + 1) } }] },
+				undefined,
+				undefined,
+				{
+					createdAt,
+				},
+			);
+		}
+
+		// ACT
+		await compactionService['compactHistories']();
+
+		// ASSERT
+		const allHistories = await Container.get(WorkflowHistoryRepository).find({});
+		const expectedVersions = [
+			wf1_history[0],
+			wf1_history[1],
+			wf1_history[2],
+			wf1_history[6],
+			wf1_history[7],
+			wf1_history[8],
+			wf2_history[0],
+			wf2_history[4],
+		].map((x) => x[1]);
+		expect(allHistories.map((x) => x.versionId)).toEqual(expect.arrayContaining(expectedVersions));
+	});
+
+	it('should honor batching', async () => {
+		// ARRANGE
+		const wf1 = await createWorkflow({ versionId: wf1_versions[0] });
+		const wf1_history: Array<[Date, string]> = [lastWeekB, yesterdayA, yesterdayB, yesterdayC].map(
+			(x) => [x, uuid()],
+		);
+		for (const [i, [createdAt, versionId]] of wf1_history.entries()) {
+			await createWorkflowHistory(
+				{ ...wf1, versionId, nodes: [{ ...testNode1, parameters: { a: repeat('1', i + 1) } }] },
+				undefined,
+				undefined,
+				{
+					createdAt,
+				},
+			);
+		}
+
+		const wf2_history: Array<[Date, string]> = [yesterdayA, yesterdayB, yesterdayC].map((x) => [
+			x,
+			uuid(),
+		]);
+		const wf2 = await createWorkflow({ versionId: wf2_versions[0] });
+		for (const [i, [createdAt, versionId]] of wf2_history.entries()) {
+			await createWorkflowHistory(
+				{ ...wf2, versionId, nodes: [{ ...testNode1, parameters: { a: repeat('1', i + 1) } }] },
+				undefined,
+				undefined,
+				{
+					createdAt,
+				},
+			);
+		}
+
+		const wf3_history: Array<[Date, string]> = [yesterdayA, yesterdayB, yesterdayC].map((x) => [
+			x,
+			uuid(),
+		]);
+		const wf3 = await createWorkflow({ versionId: wf3_versions[0] });
+		for (const [i, [createdAt, versionId]] of wf3_history.entries()) {
+			await createWorkflowHistory(
+				{ ...wf3, versionId, nodes: [{ ...testNode1, parameters: { a: repeat('1', i + 1) } }] },
+				undefined,
+				undefined,
+				{
+					createdAt,
+				},
+			);
+		}
+
+		// ACT
+		compactionService = new WorkflowHistoryCompactionService(
+			{
+				...Container.get(GlobalConfig).workflowHistoryCompaction,
+				batchDelayMs: 10_000,
+				batchSize: 5,
+			},
+			mockLogger(),
+			instanceSettings,
+			Container.get(DbConnection),
+			Container.get(WorkflowHistoryRepository),
+		);
+
+		// Expect wf1 and wf2 to be handled in the first batch, with wf3 untouched due to the long delay after batching
+		void compactionService['compactHistories']();
+		await sleep(500);
+
+		// ASSERT
+		const allHistories = await Container.get(WorkflowHistoryRepository).find({});
+		const allVersions = allHistories.map((x) => x.versionId);
+
+		const expectedVersions = [
+			wf1_history[0],
+			wf1_history[1],
+			wf1_history[3],
+			wf2_history[0],
+			wf2_history[2],
+			wf3_history[0],
+			wf3_history[2],
+		].map((x) => x[1]);
+		expect(allVersions).toEqual(expect.arrayContaining(expectedVersions));
+
+		const includesWf1 = allVersions.includes(wf1_history[2][1]);
+		const includesWf2 = allVersions.includes(wf2_history[1][1]);
+		const includesWf3 = allVersions.includes(wf3_history[1][1]);
+
+		// Batching should cause the compaction to stop before one of the three workflows
+		// Is handled.
+		expect(0 + +includesWf1 + +includesWf2 + +includesWf3).toBe(1);
+	});
+});

--- a/packages/workflow/src/connections-diff.ts
+++ b/packages/workflow/src/connections-diff.ts
@@ -1,0 +1,87 @@
+import type { IConnection, IConnections } from '.';
+
+type ConnectionEntry = {
+	sourceIndex: number;
+	value: { index: number; connection: IConnection } | null;
+};
+
+export type INodeConnectionsDiff = Record<string, ConnectionEntry[]>;
+
+export type ConnectionsDiff = {
+	added: Record<string, INodeConnectionsDiff>;
+	removed: Record<string, INodeConnectionsDiff>;
+};
+
+export function compareConnections(prev: IConnections, next: IConnections): ConnectionsDiff {
+	const added: Record<string, INodeConnectionsDiff> = {};
+	const removed: Record<string, INodeConnectionsDiff> = {};
+
+	// Get all unique node names from both connection objects
+	const allNodeNames = new Set([...Object.keys(prev), ...Object.keys(next)]);
+
+	for (const nodeName of allNodeNames) {
+		const prevNodeConnections = prev[nodeName] ?? {};
+		const nextNodeConnections = next[nodeName] ?? {};
+
+		// Get all unique input names for this node
+		const allInputNames = new Set([
+			...Object.keys(prevNodeConnections),
+			...Object.keys(nextNodeConnections),
+		]);
+
+		for (const inputName of allInputNames) {
+			const prevInputConnections = prevNodeConnections[inputName] ?? [];
+			const nextInputConnections = nextNodeConnections[inputName] ?? [];
+
+			// Compare each source index
+			const maxLength = Math.max(prevInputConnections.length, nextInputConnections.length);
+
+			for (let sourceIndex = 0; sourceIndex < maxLength; sourceIndex++) {
+				const prevConnections = prevInputConnections[sourceIndex] ?? [];
+				const nextConnections = nextInputConnections[sourceIndex] ?? [];
+
+				// Build maps for easier comparison
+				const prevMap = new Map(
+					prevConnections.map((conn, idx) => [
+						JSON.stringify(conn),
+						{ index: idx, connection: conn },
+					]),
+				);
+				const nextMap = new Map(
+					nextConnections.map((conn, idx) => [
+						JSON.stringify(conn),
+						{ index: idx, connection: conn },
+					]),
+				);
+
+				// Find added connections
+				for (const [key, value] of nextMap) {
+					if (!prevMap.has(key)) {
+						if (!added[nodeName]) added[nodeName] = {};
+						if (!added[nodeName][inputName]) added[nodeName][inputName] = [];
+
+						added[nodeName][inputName].push({
+							sourceIndex,
+							value,
+						});
+					}
+				}
+
+				// Find removed connections
+				for (const [key, value] of prevMap) {
+					if (!nextMap.has(key)) {
+						if (!removed[nodeName]) removed[nodeName] = {};
+						if (!removed[nodeName][inputName]) removed[nodeName][inputName] = [];
+
+						removed[nodeName][inputName].push({
+							sourceIndex,
+							value,
+						});
+					}
+				}
+			}
+		}
+	}
+
+	return { added, removed };
+}

--- a/packages/workflow/src/workflow-diff.ts
+++ b/packages/workflow/src/workflow-diff.ts
@@ -2,10 +2,17 @@ import isEqual from 'lodash/isEqual';
 import pick from 'lodash/pick';
 
 import type { IConnections, INode, IWorkflowBase } from '.';
+import { compareConnections, type ConnectionsDiff } from './connections-diff';
+
+export type WorkflowDiffBase = Omit<
+	IWorkflowBase,
+	'id' | 'active' | 'activeVersionId' | 'isArchived' | 'name'
+> & { name: string | null };
 
 export type DiffableNode = Pick<INode, 'id' | 'parameters' | 'name'>;
 export type DiffableWorkflow<N extends DiffableNode = DiffableNode> = {
 	nodes: N[];
+	connections: IConnections;
 };
 
 export const enum NodeDiffStatus {
@@ -111,32 +118,20 @@ function mergeNodeDiff(
 }
 
 export class WorkflowChangeSet<T extends DiffableNode> {
-	constructor(public nodes: WorkflowDiff<T> = new Map()) {}
+	readonly nodes: WorkflowDiff<T>;
+	readonly connections: ConnectionsDiff;
+	constructor(from: DiffableWorkflow<T>, to: DiffableWorkflow<T>) {
+		this.nodes = compareWorkflowsNodes(from.nodes, to.nodes);
+		this.connections = compareConnections(from.connections, to.connections);
+	}
 
 	hasChanges() {
 		for (const nodeDiff of this.nodes.values()) {
 			if (nodeDiff.status !== NodeDiffStatus.Eq) return true;
 		}
+		if (Object.keys(this.connections.added).length || Object.keys(this.connections.removed).length)
+			return true;
 		return false;
-	}
-
-	mergeNext(wcs: WorkflowChangeSet<T>) {
-		for (const [key, diff] of wcs.nodes) {
-			const existing = this.nodes.get(key);
-			if (existing) {
-				const diffStatus = mergeNodeDiff(existing.status, diff.status);
-				if (diffStatus === 'invariant broken') {
-					throw new Error('invariant broken');
-				}
-				if (diffStatus === 'undone') {
-					this.nodes.delete(key);
-				} else {
-					this.nodes.set(key, { ...diff, status: diffStatus });
-				}
-			} else {
-				this.nodes.set(key, { ...diff, status: NodeDiffStatus.Added });
-			}
-		}
 	}
 }
 
@@ -169,15 +164,18 @@ function nodeIsAdditive<T extends DiffableNode>(prevNode: T, nextNode: T) {
 function mergeAdditiveChanges<N extends DiffableNode = DiffableNode>(
 	_prev: GroupedWorkflowHistory<DiffableWorkflow<N>>,
 	next: GroupedWorkflowHistory<DiffableWorkflow<N>>,
-	diff: WorkflowDiff<N>,
+	diff: WorkflowChangeSet<N>,
 ) {
-	for (const d of diff.values()) {
+	for (const d of diff.nodes.values()) {
 		if (d.status === NodeDiffStatus.Deleted) return false;
 		if (d.status === NodeDiffStatus.Added) continue;
-		const nextNode = next.from.nodes.find((x) => x.name === d.node.name);
+		const nextNode = next.from.nodes.find((x) => x.id === d.node.id);
 		if (!nextNode) throw new Error('invariant broken');
 		if (d.status === NodeDiffStatus.Modified && !nodeIsAdditive(d.node, nextNode)) return false;
 	}
+
+	if (Object.keys(diff.connections.removed).length > 0) return false;
+
 	return true;
 }
 
@@ -185,19 +183,18 @@ export const RULES = {
 	mergeAdditiveChanges,
 };
 
-type GroupedWorkflowHistory<W extends DiffableWorkflow<DiffableNode>> = {
+export type GroupedWorkflowHistory<W extends DiffableWorkflow<DiffableNode>> = {
 	workflowChangeSet: WorkflowChangeSet<W['nodes'][number]>;
 	groupedWorkflows: W[];
 	from: W;
 	to: W;
 };
 
-function compareWorkflows<W extends IWorkflowBase = IWorkflowBase>(
+function compareWorkflows<W extends WorkflowDiffBase = WorkflowDiffBase>(
 	previous: W,
 	next: W,
 ): GroupedWorkflowHistory<W> {
-	const nodesDiff = compareWorkflowsNodes(previous.nodes, next.nodes);
-	const workflowChangeSet = new WorkflowChangeSet(nodesDiff);
+	const workflowChangeSet = new WorkflowChangeSet(previous, next);
 	return {
 		workflowChangeSet,
 		groupedWorkflows: [],
@@ -207,23 +204,24 @@ function compareWorkflows<W extends IWorkflowBase = IWorkflowBase>(
 }
 
 export type DiffRule<
-	W extends IWorkflowBase = IWorkflowBase,
+	W extends WorkflowDiffBase = WorkflowDiffBase,
 	N extends W['nodes'][number] = W['nodes'][number],
 > = (
 	prev: GroupedWorkflowHistory<W>,
 	next: GroupedWorkflowHistory<W>,
-	diff: WorkflowDiff<N>,
+	diff: WorkflowChangeSet<N>,
 ) => boolean;
 
-export function groupWorkflows<W extends IWorkflowBase = IWorkflowBase>(
+export function groupWorkflows<W extends WorkflowDiffBase = WorkflowDiffBase>(
 	workflows: W[],
 	rules: Array<DiffRule<W>>,
+	skipRules: Array<DiffRule<W>> = [],
 ): Array<GroupedWorkflowHistory<W>> {
 	if (workflows.length === 0) return [];
 	if (workflows.length === 1) {
 		return [
 			{
-				workflowChangeSet: new WorkflowChangeSet(),
+				workflowChangeSet: new WorkflowChangeSet(workflows[0], workflows[0]),
 				groupedWorkflows: [],
 				from: workflows[0],
 				to: workflows[0],
@@ -240,16 +238,19 @@ export function groupWorkflows<W extends IWorkflowBase = IWorkflowBase>(
 	do {
 		prevDiffsLength = diffs.length;
 		const n = diffs.length;
-		for (let i = n - 1; i > 0; --i) {
-			const diff = compareWorkflowsNodes(diffs[i - 1].from.nodes, diffs[i].to.nodes);
+		diffLoop: for (let i = n - 1; i > 0; --i) {
+			const wcs = new WorkflowChangeSet(diffs[i - 1].from, diffs[i].to);
+			for (const shouldSkip of skipRules) {
+				if (shouldSkip(diffs[i - 1], diffs[i], wcs)) continue diffLoop;
+			}
 			for (const rule of rules) {
-				const shouldMerge = rule(diffs[i - 1], diffs[i], diff);
+				const shouldMerge = rule(diffs[i - 1], diffs[i], wcs);
 				if (shouldMerge) {
-					const right = diffs.pop();
+					const right = diffs.splice(i, 1)[0];
 					if (!right) throw new Error('invariant broken');
 
 					// merge diffs
-					diffs[i - 1].workflowChangeSet.mergeNext(right.workflowChangeSet);
+					diffs[i - 1].workflowChangeSet = wcs;
 					diffs[i - 1].groupedWorkflows.push(diffs[i - 1].to);
 					diffs[i - 1].groupedWorkflows.push(...right.groupedWorkflows);
 					diffs[i - 1].to = right.to;

--- a/packages/workflow/test/connections-diff.test.ts
+++ b/packages/workflow/test/connections-diff.test.ts
@@ -1,0 +1,549 @@
+import { mocked } from 'vitest-mock-extended';
+
+import { type IConnection, type IConnections } from '../src';
+import { compareConnections } from '../src/connections-diff';
+
+// Mock IConnection for testing
+const createConnection = (node: string, type: IConnection['type'], index: number): IConnection =>
+	mocked<IConnection>({
+		node,
+		type,
+		index,
+	});
+
+describe('compareConnections', () => {
+	describe('empty states', () => {
+		it('should return empty diff when both prev and next are empty', () => {
+			const prev: IConnections = {};
+			const next: IConnections = {};
+
+			const result = compareConnections(prev, next);
+
+			expect(result.added).toEqual({});
+			expect(result.removed).toEqual({});
+		});
+
+		it('should detect all connections as added when prev is empty', () => {
+			const prev: IConnections = {};
+			const next: IConnections = {
+				node1: {
+					main: [[createConnection('node0', 'main', 0)]],
+				},
+			};
+
+			const result = compareConnections(prev, next);
+
+			expect(result.added).toEqual({
+				node1: {
+					main: [
+						{
+							sourceIndex: 0,
+							value: { index: 0, connection: createConnection('node0', 'main', 0) },
+						},
+					],
+				},
+			});
+			expect(result.removed).toEqual({});
+		});
+
+		it('should detect all connections as removed when next is empty', () => {
+			const prev: IConnections = {
+				node1: {
+					main: [[createConnection('node0', 'main', 0)]],
+				},
+			};
+			const next: IConnections = {};
+
+			const result = compareConnections(prev, next);
+
+			expect(result.added).toEqual({});
+			expect(result.removed).toEqual({
+				node1: {
+					main: [
+						{
+							sourceIndex: 0,
+							value: { index: 0, connection: createConnection('node0', 'main', 0) },
+						},
+					],
+				},
+			});
+		});
+	});
+
+	describe('no changes', () => {
+		it('should return empty diff when connections are identical', () => {
+			const connections: IConnections = {
+				node1: {
+					main: [[createConnection('node0', 'main', 0)]],
+				},
+			};
+
+			const result = compareConnections(connections, connections);
+
+			expect(result.added).toEqual({});
+			expect(result.removed).toEqual({});
+		});
+
+		it('should handle identical complex structures', () => {
+			const connections: IConnections = {
+				node1: {
+					main: [[createConnection('node0', 'main', 0), createConnection('node2', 'main', 0)]],
+				},
+				node2: {
+					main: [[createConnection('node1', 'main', 0)]],
+				},
+			};
+
+			const result = compareConnections(connections, connections);
+
+			expect(result.added).toEqual({});
+			expect(result.removed).toEqual({});
+		});
+	});
+
+	describe('simple additions and removals', () => {
+		it('should detect a single added connection', () => {
+			const prev: IConnections = {
+				node1: {
+					main: [[createConnection('node0', 'main', 0)]],
+				},
+			};
+			const next: IConnections = {
+				node1: {
+					main: [[createConnection('node0', 'main', 0), createConnection('node2', 'main', 0)]],
+				},
+			};
+
+			const result = compareConnections(prev, next);
+
+			expect(result.added).toEqual({
+				node1: {
+					main: [
+						{
+							sourceIndex: 0,
+							value: { index: 1, connection: createConnection('node2', 'main', 0) },
+						},
+					],
+				},
+			});
+			expect(result.removed).toEqual({});
+		});
+
+		it('should detect a single removed connection', () => {
+			const prev: IConnections = {
+				node1: {
+					main: [[createConnection('node0', 'main', 0), createConnection('node2', 'main', 0)]],
+				},
+			};
+			const next: IConnections = {
+				node1: {
+					main: [[createConnection('node0', 'main', 0)]],
+				},
+			};
+
+			const result = compareConnections(prev, next);
+
+			expect(result.added).toEqual({});
+			expect(result.removed).toEqual({
+				node1: {
+					main: [
+						{
+							sourceIndex: 0,
+							value: { index: 1, connection: createConnection('node2', 'main', 0) },
+						},
+					],
+				},
+			});
+		});
+
+		it('should detect connection replacement', () => {
+			const prev: IConnections = {
+				node1: {
+					main: [[createConnection('node0', 'main', 0)]],
+				},
+			};
+			const next: IConnections = {
+				node1: {
+					main: [[createConnection('node2', 'main', 0)]],
+				},
+			};
+
+			const result = compareConnections(prev, next);
+
+			expect(result.added).toEqual({
+				node1: {
+					main: [
+						{
+							sourceIndex: 0,
+							value: { index: 0, connection: createConnection('node2', 'main', 0) },
+						},
+					],
+				},
+			});
+			expect(result.removed).toEqual({
+				node1: {
+					main: [
+						{
+							sourceIndex: 0,
+							value: { index: 0, connection: createConnection('node0', 'main', 0) },
+						},
+					],
+				},
+			});
+		});
+	});
+
+	describe('multiple nodes', () => {
+		it('should handle changes across multiple nodes', () => {
+			const prev: IConnections = {
+				node1: {
+					main: [[createConnection('node0', 'main', 0)]],
+				},
+				node2: {
+					main: [[createConnection('node1', 'main', 0)]],
+				},
+			};
+			const next: IConnections = {
+				node1: {
+					main: [[createConnection('node0', 'main', 0)]],
+				},
+				node2: {
+					main: [[createConnection('node3', 'main', 0)]],
+				},
+			};
+
+			const result = compareConnections(prev, next);
+
+			expect(result.added).toEqual({
+				node2: {
+					main: [
+						{
+							sourceIndex: 0,
+							value: { index: 0, connection: createConnection('node3', 'main', 0) },
+						},
+					],
+				},
+			});
+			expect(result.removed).toEqual({
+				node2: {
+					main: [
+						{
+							sourceIndex: 0,
+							value: { index: 0, connection: createConnection('node1', 'main', 0) },
+						},
+					],
+				},
+			});
+		});
+
+		it('should detect new node with connections', () => {
+			const prev: IConnections = {
+				node1: {
+					main: [[createConnection('node0', 'main', 0)]],
+				},
+			};
+			const next: IConnections = {
+				node1: {
+					main: [[createConnection('node0', 'main', 0)]],
+				},
+				node2: {
+					main: [[createConnection('node1', 'main', 0)]],
+				},
+			};
+
+			const result = compareConnections(prev, next);
+
+			expect(result.added).toEqual({
+				node2: {
+					main: [
+						{
+							sourceIndex: 0,
+							value: { index: 0, connection: createConnection('node1', 'main', 0) },
+						},
+					],
+				},
+			});
+			expect(result.removed).toEqual({});
+		});
+
+		it('should detect removed node with connections', () => {
+			const prev: IConnections = {
+				node1: {
+					main: [[createConnection('node0', 'main', 0)]],
+				},
+				node2: {
+					main: [[createConnection('node1', 'main', 0)]],
+				},
+			};
+			const next: IConnections = {
+				node1: {
+					main: [[createConnection('node0', 'main', 0)]],
+				},
+			};
+
+			const result = compareConnections(prev, next);
+
+			expect(result.added).toEqual({});
+			expect(result.removed).toEqual({
+				node2: {
+					main: [
+						{
+							sourceIndex: 0,
+							value: { index: 0, connection: createConnection('node1', 'main', 0) },
+						},
+					],
+				},
+			});
+		});
+	});
+
+	describe('multiple inputs', () => {
+		it('should handle multiple input types on same node', () => {
+			const prev: IConnections = {
+				node1: {
+					main: [[createConnection('node0', 'main', 0)]],
+					aux: [[createConnection('node2', 'main', 0)]],
+				},
+			};
+			const next: IConnections = {
+				node1: {
+					main: [[createConnection('node0', 'main', 0)]],
+					aux: [[createConnection('node3', 'main', 0)]],
+				},
+			};
+
+			const result = compareConnections(prev, next);
+
+			expect(result.added).toEqual({
+				node1: {
+					aux: [
+						{
+							sourceIndex: 0,
+							value: { index: 0, connection: createConnection('node3', 'main', 0) },
+						},
+					],
+				},
+			});
+			expect(result.removed).toEqual({
+				node1: {
+					aux: [
+						{
+							sourceIndex: 0,
+							value: { index: 0, connection: createConnection('node2', 'main', 0) },
+						},
+					],
+				},
+			});
+		});
+
+		it('should detect new input type', () => {
+			const prev: IConnections = {
+				node1: {
+					main: [[createConnection('node0', 'main', 0)]],
+				},
+			};
+			const next: IConnections = {
+				node1: {
+					main: [[createConnection('node0', 'main', 0)]],
+					aux: [[createConnection('node2', 'main', 0)]],
+				},
+			};
+
+			const result = compareConnections(prev, next);
+
+			expect(result.added).toEqual({
+				node1: {
+					aux: [
+						{
+							sourceIndex: 0,
+							value: { index: 0, connection: createConnection('node2', 'main', 0) },
+						},
+					],
+				},
+			});
+			expect(result.removed).toEqual({});
+		});
+	});
+
+	describe('multiple source indices', () => {
+		it('should handle multiple source indices (switch-like nodes)', () => {
+			const prev: IConnections = {
+				node1: {
+					main: [
+						[createConnection('node0', 'main', 0)],
+						null,
+						[createConnection('node2', 'main', 0)],
+					],
+				},
+			};
+			const next: IConnections = {
+				node1: {
+					main: [
+						[createConnection('node0', 'main', 0)],
+						[createConnection('node3', 'main', 0)],
+						[createConnection('node2', 'main', 0)],
+					],
+				},
+			};
+
+			const result = compareConnections(prev, next);
+
+			expect(result.added).toEqual({
+				node1: {
+					main: [
+						{
+							sourceIndex: 1,
+							value: { index: 0, connection: createConnection('node3', 'main', 0) },
+						},
+					],
+				},
+			});
+			expect(result.removed).toEqual({});
+		});
+
+		it('should detect removed connection at specific source index', () => {
+			const prev: IConnections = {
+				node1: {
+					main: [
+						[createConnection('node0', 'main', 0)],
+						[createConnection('node3', 'main', 0)],
+						[createConnection('node2', 'main', 0)],
+					],
+				},
+			};
+			const next: IConnections = {
+				node1: {
+					main: [
+						[createConnection('node0', 'main', 0)],
+						null,
+						[createConnection('node2', 'main', 0)],
+					],
+				},
+			};
+
+			const result = compareConnections(prev, next);
+
+			expect(result.added).toEqual({});
+			expect(result.removed).toEqual({
+				node1: {
+					main: [
+						{
+							sourceIndex: 1,
+							value: { index: 0, connection: createConnection('node3', 'main', 0) },
+						},
+					],
+				},
+			});
+		});
+	});
+
+	describe('complex scenarios', () => {
+		it('should handle multiple changes simultaneously', () => {
+			const prev: IConnections = {
+				node1: {
+					main: [[createConnection('node0', 'main', 0)]],
+				},
+				node2: {
+					main: [[createConnection('node1', 'main', 0)], [createConnection('node3', 'main', 0)]],
+				},
+			};
+			const next: IConnections = {
+				node1: {
+					main: [[createConnection('node0', 'main', 0), createConnection('node4', 'main', 0)]],
+				},
+				node2: {
+					main: [[createConnection('node1', 'main', 0)]],
+				},
+				node3: {
+					main: [[createConnection('node2', 'main', 0)]],
+				},
+			};
+
+			const result = compareConnections(prev, next);
+
+			expect(result.added).toEqual({
+				node1: {
+					main: [
+						{
+							sourceIndex: 0,
+							value: { index: 1, connection: createConnection('node4', 'main', 0) },
+						},
+					],
+				},
+				node3: {
+					main: [
+						{
+							sourceIndex: 0,
+							value: { index: 0, connection: createConnection('node2', 'main', 0) },
+						},
+					],
+				},
+			});
+			expect(result.removed).toEqual({
+				node2: {
+					main: [
+						{
+							sourceIndex: 1,
+							value: { index: 0, connection: createConnection('node3', 'main', 0) },
+						},
+					],
+				},
+			});
+		});
+
+		it('should handle connections with different indices but same node', () => {
+			const prev: IConnections = {
+				node1: {
+					main: [[createConnection('node0', 'main', 0)]],
+				},
+			};
+			const next: IConnections = {
+				node1: {
+					main: [[createConnection('node0', 'main', 1)]],
+				},
+			};
+
+			const result = compareConnections(prev, next);
+
+			// These should be considered different connections
+			expect(result.added).toEqual({
+				node1: {
+					main: [
+						{
+							sourceIndex: 0,
+							value: { index: 0, connection: createConnection('node0', 'main', 1) },
+						},
+					],
+				},
+			});
+			expect(result.removed).toEqual({
+				node1: {
+					main: [
+						{
+							sourceIndex: 0,
+							value: { index: 0, connection: createConnection('node0', 'main', 0) },
+						},
+					],
+				},
+			});
+		});
+
+		it('should handle empty arrays vs null', () => {
+			const prev: IConnections = {
+				node1: {
+					main: [[]],
+				},
+			};
+			const next: IConnections = {
+				node1: {
+					main: [null],
+				},
+			};
+
+			const result = compareConnections(prev, next);
+
+			expect(result.added).toEqual({});
+			expect(result.removed).toEqual({});
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Introduce a compaction service to remove older (auto-saved) versions of workflows.

Currently only ever removes versions with redundant information, e.g. if a workflow history goes from changing a parameter of the same node from `'the quick'` to `'the quick brown'` to `'the quick brown fox'`, then we can remove the first two versions without losing any data. If a version was ever published or named we will never delete it currently.

Also includes https://github.com/n8n-io/n8n/pull/23282

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4327


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
