### PR TITLE
ci: Auto-tag Dockerhub releases with 1 docker tag

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -240,6 +240,22 @@ jobs:
           create_manifest "runners" "${{ needs.build-and-push-docker.outputs.runners_primary_ghcr_manifest_tag }}"
           create_manifest "runners-distroless" "${{ needs.build-and-push-docker.outputs.runners_distroless_primary_ghcr_manifest_tag }}"
 
+      - name: Tag v1 Docker image on GHCR
+        run: |
+          VERSION="${{ needs.determine-build-context.outputs.n8n_version }}"
+
+          if [[ "$VERSION" == 1.* ]]; then
+            echo "Creating GHCR '1' tag for v1 release ${VERSION}"
+
+            docker buildx imagetools create \
+              -t "ghcr.io/${{ github.repository_owner }}/n8n:1" \
+              "ghcr.io/${{ github.repository_owner }}/n8n:${VERSION}"
+
+            docker buildx imagetools create \
+              -t "ghcr.io/${{ github.repository_owner }}/runners:1" \
+              "ghcr.io/${{ github.repository_owner }}/runners:${VERSION}"
+          fi
+
       - name: Create Docker Hub manifests
         if: needs.determine-build-context.outputs.push_to_docker == 'true'
         run: |
@@ -263,6 +279,24 @@ jobs:
               "${DOCKER_BASE}/${IMAGE_NAME}:${TAG_SUFFIX}-amd64" \
               "${DOCKER_BASE}/${IMAGE_NAME}:${TAG_SUFFIX}-arm64"
           done
+
+      - name: Tag v1 Docker image on Docker Hub
+        if: needs.determine-build-context.outputs.push_to_docker == 'true'
+        run: |
+          VERSION="${{ needs.determine-build-context.outputs.n8n_version }}"
+
+          if [[ "$VERSION" == 1.* ]]; then
+            DOCKER_BASE="${{ secrets.DOCKER_USERNAME }}"
+            echo "Creating Docker Hub '1' tag for v1 release ${VERSION}"
+
+            docker buildx imagetools create \
+              -t "${DOCKER_BASE}/n8n:1" \
+              "${DOCKER_BASE}/n8n:${VERSION}"
+
+            docker buildx imagetools create \
+              -t "${DOCKER_BASE}/runners:1" \
+              "${DOCKER_BASE}/runners:${VERSION}"
+          fi
 
   call-success-url:
     name: Call Success URL

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -249,11 +249,15 @@ jobs:
 
             docker buildx imagetools create \
               -t "ghcr.io/${{ github.repository_owner }}/n8n:1" \
-              "ghcr.io/${{ github.repository_owner }}/n8n:${VERSION}"
+              "${{ needs.build-and-push-docker.outputs.primary_ghcr_manifest_tag }}"
 
             docker buildx imagetools create \
               -t "ghcr.io/${{ github.repository_owner }}/runners:1" \
-              "ghcr.io/${{ github.repository_owner }}/runners:${VERSION}"
+              "${{ needs.build-and-push-docker.outputs.runners_primary_ghcr_manifest_tag }}"
+
+            docker buildx imagetools create \
+              -t "ghcr.io/${{ github.repository_owner }}/runners:1-distroless" \
+              "${{ needs.build-and-push-docker.outputs.runners_distroless_primary_ghcr_manifest_tag }}"
           fi
 
       - name: Create Docker Hub manifests
@@ -296,6 +300,10 @@ jobs:
             docker buildx imagetools create \
               -t "${DOCKER_BASE}/runners:1" \
               "${DOCKER_BASE}/runners:${VERSION}"
+
+            docker buildx imagetools create \
+              -t "${DOCKER_BASE}/runners:1-distroless" \
+              "${DOCKER_BASE}/runners:${VERSION}-distroless"
           fi
 
   call-success-url:


### PR DESCRIPTION
## Summary
  - Automatically creates `n8nio/n8n:1`, `n8nio/runners:1` and `n8nio/runners:1-distroless` Docker tags when releasing v1.x.x versions
  - Also tags on GHCR (`ghcr.io/n8n-io/n8n:1`, `ghcr.io/n8n-io/runners:1`, `ghcr.io/n8n-io/runners:1-distroless`)
  - Allows users to stay on latest v1 with `docker pull n8nio/n8n:1`

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/CAT-1974
https://community.n8n.io/t/please-add-a-v1-docker-tag/231583


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
