### PR TITLE
fix(core): Error running evaluations in queue mode

### DIFF
--- a/packages/cli/src/evaluation.ee/test-runner/__tests__/test-runner.service.ee.test.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/__tests__/test-runner.service.ee.test.ts
@@ -871,6 +871,7 @@ describe('TestRunnerService', () => {
 							name: triggerNodeName,
 						},
 						executionData: createRunExecutionData({
+							executionData: null,
 							resultData: {
 								pinData: {
 									[triggerNodeName]: [testCase],

--- a/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
@@ -263,9 +263,9 @@ export class TestRunnerService {
 		// the same way as it would be passed in manual mode
 		if (this.executionsConfig.mode === 'queue') {
 			data.executionData = createRunExecutionData({
+				executionData: null,
 				resultData: {
 					pinData,
-					runData: {},
 				},
 				manualData: {
 					userId: metadata.userId,


### PR DESCRIPTION
## Summary

Fix evaluation runs in queue mode. The issue was in default `executionData` property provided to the workflow runner, while it should be undefined or null in queue mode.

## Related Linear tickets, Github issues, and Community forum posts

- https://github.com/n8n-io/n8n/issues/22901
- https://linear.app/n8n/issue/AI-1788/community-issue-workflow-not-run-during-evaluation-in-self-hosted

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
