### PR TITLE
fix(docker): restore apk package manager in Alpine image

### DIFF
--- a/docker/images/n8n-base/Dockerfile
+++ b/docker/images/n8n-base/Dockerfile
@@ -42,7 +42,7 @@ FROM node:${NODE_VERSION}-alpine
 
 COPY --from=builder / /
 
-RUN rm -rf /opt/yarn* && apk del apk-tools
+RUN rm -rf /opt/yarn*
 
 WORKDIR /home/node
 ENV NODE_ICU_DATA=/usr/local/lib/node_modules/full-icu


### PR DESCRIPTION
## Summary

- Restore the ability for users to extend the n8n Docker image with additional Alpine packages via `apk add`
- Fixes a regression introduced in #23149 where `apk del apk-tools` was moved to the final image stage

## Problem

In n8n 2.1.0, custom Docker builds extending from `n8nio/n8n:2.1.0` fail with:

```
/bin/sh: apk: not found
ERROR: process "/bin/sh -c apk add --no-cache ffmpeg" did not complete successfully: exit code: 127
```

This breaks a common use case where users install additional packages like `ffmpeg`, `chromium`, or `python` for various nodes.

## Solution

Remove `apk del apk-tools` from `docker/images/n8n-base/Dockerfile` to preserve the Alpine package manager in the final image.

## Related Issue

Fixes #23246

## Testing

After this fix, the following Dockerfile should build successfully:

```dockerfile
FROM n8nio/n8n:latest
USER root
RUN apk add --no-cache ffmpeg
USER node
```

## Checklist

- [x] I have read the [n8n Contributing Guide](https://github.com/n8n-io/n8n/blob/master/CONTRIBUTING.md)
- [x] I have linked the related issue (#23246)
- [x] My changes follow the existing code style