### PR TITLE
fix(editor): Fix navigation menu layout

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nNavigationDropdown/NavigationDropdown.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nNavigationDropdown/NavigationDropdown.vue
@@ -140,7 +140,6 @@ defineExpose({
 									data-test-id="navigation-submenu-item"
 									:index="subitem.id"
 									:disabled="subitem.disabled"
-									:class="{ [$style.menuItemWithTooltip]: subitem.description }"
 									@click="emit('itemClick', $event)"
 								>
 									<slot name="item-icon" v-bind="{ item: subitem }">
@@ -251,12 +250,6 @@ defineExpose({
 		color: var(--color--text--tint-1);
 	}
 
-	:global(.el-menu--horizontal .el-menu .el-menu-item) {
-		display: flex;
-		align-items: center;
-		gap: var(--spacing--2xs);
-	}
-
 	:global(.el-sub-menu__icon-arrow svg) {
 		margin-top: auto;
 	}
@@ -279,10 +272,6 @@ defineExpose({
 	color: var(--color--text);
 }
 
-.menuItemWithTooltip {
-	position: relative;
-}
-
 .menuItemTitle {
 	flex: 1;
 	overflow: hidden;
@@ -300,10 +289,7 @@ defineExpose({
 
 .infoIcon {
 	color: var(--color--text--tint-1);
-	cursor: pointer;
-
-	&:hover {
-		color: var(--color--text);
-	}
+	outline: none;
+	margin-left: var(--spacing--2xs);
 }
 </style>


### PR DESCRIPTION
## Summary

Changes to NavigationDropdown component to add info icon in #23032 broke the menu item layout, increasing the gap between the icon on the left and text. This PR fixes it.

<img width="460" height="165" alt="Screenshot 2025-12-16 at 11 09 16" src="https://github.com/user-attachments/assets/fb1caa4f-4969-4cf9-b3fd-7cf90788daa1" />


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
