### PR TITLE
feat(editor): Showing wf saving indication on canvas (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/constants/durations.ts
+++ b/packages/frontend/editor-ui/src/app/constants/durations.ts
@@ -23,3 +23,5 @@ export const TIME = {
 export const THREE_DAYS_IN_MILLIS = 3 * TIME.DAY;
 export const SEVEN_DAYS_IN_MILLIS = 7 * TIME.DAY;
 export const SIX_MONTHS_IN_MILLIS = 6 * 30 * TIME.DAY;
+
+export const LOADING_ANIMATION_MIN_DURATION = 500;

--- a/packages/frontend/editor-ui/src/features/core/dataTable/DataTableDetailsView.vue
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/DataTableDetailsView.vue
@@ -9,7 +9,8 @@ import { useDataTableStore } from '@/features/core/dataTable/dataTable.store';
 import { useToast } from '@/app/composables/useToast';
 import { useI18n } from '@n8n/i18n';
 import { useRouter } from 'vue-router';
-import { DATA_TABLE_VIEW, MIN_LOADING_TIME } from '@/features/core/dataTable/constants';
+import { DATA_TABLE_VIEW } from '@/features/core/dataTable/constants';
+import { LOADING_ANIMATION_MIN_DURATION } from '@/app/constants/durations';
 import DataTableBreadcrumbs from '@/features/core/dataTable/components/DataTableBreadcrumbs.vue';
 import { useDocumentTitle } from '@/app/composables/useDocumentTitle';
 import DataTableTable from './components/dataGrid/DataTableTable.vue';
@@ -85,7 +86,7 @@ const debouncedHideSaving = debounce(
 	() => {
 		saving.value = false;
 	},
-	{ debounceTime: MIN_LOADING_TIME, trailing: true },
+	{ debounceTime: LOADING_ANIMATION_MIN_DURATION, trailing: true },
 );
 
 const onToggleSave = (value: boolean) => {

--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryButton.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryButton.vue
@@ -1,15 +1,39 @@
 <script lang="ts" setup>
-import { computed } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { VIEWS } from '@/app/constants';
 import { useI18n } from '@n8n/i18n';
-
+import { useUIStore } from '@/app/stores/ui.store';
 import { N8nIconButton, N8nTooltip } from '@n8n/design-system';
+import { useDebounce } from '@/app/composables/useDebounce';
+import { LOADING_ANIMATION_MIN_DURATION } from '@/app/constants/durations';
 const locale = useI18n();
 
 const props = defineProps<{
 	workflowId: string;
 	isNewWorkflow: boolean;
 }>();
+
+const uiStore = useUIStore();
+const isWorkflowSaving = ref(false);
+const { debounce } = useDebounce();
+
+const debouncedRemoveSaveIndicator = debounce(
+	() => {
+		isWorkflowSaving.value = false;
+	},
+	{ debounceTime: LOADING_ANIMATION_MIN_DURATION, trailing: true },
+);
+
+watch(
+	() => uiStore.isActionActive.workflowSaving,
+	(value) => {
+		if (value) {
+			isWorkflowSaving.value = true;
+		} else {
+			debouncedRemoveSaveIndicator();
+		}
+	},
+);
 
 const workflowHistoryRoute = computed<{ name: string; params: { workflowId: string } }>(() => ({
 	name: VIEWS.WORKFLOW_HISTORY,
@@ -23,6 +47,7 @@ const workflowHistoryRoute = computed<{ name: string; params: { workflowId: stri
 	<N8nTooltip placement="bottom">
 		<RouterLink :to="workflowHistoryRoute">
 			<N8nIconButton
+				:class="{ [$style.saving]: isWorkflowSaving }"
 				:disabled="isNewWorkflow"
 				data-test-id="workflow-history-button"
 				type="highlight"
@@ -38,3 +63,15 @@ const workflowHistoryRoute = computed<{ name: string; params: { workflowId: stri
 		</template>
 	</N8nTooltip>
 </template>
+
+<style lang="scss" module>
+.saving {
+	animation: loading-rotate 1s linear infinite;
+}
+
+@keyframes loading-rotate {
+	100% {
+		transform: rotate(-360deg);
+	}
+}
+</style>


### PR DESCRIPTION
## Summary

Hide save button and add indicator of when autosave is triggered

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4290/feature-fe-remove-save-button-and-introduce-save-state


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
