### PR TITLE
chore(core): Set foreign key constraint on ChatHub agentId

### DIFF
--- a/packages/@n8n/db/src/migrations/common/1765801023649-AddAgentIdForeignKeys.ts
+++ b/packages/@n8n/db/src/migrations/common/1765801023649-AddAgentIdForeignKeys.ts
@@ -1,0 +1,50 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+const table = {
+	agents: 'chat_hub_agents',
+	sessions: 'chat_hub_sessions',
+	messages: 'chat_hub_messages',
+} as const;
+
+export class AddAgentIdForeignKeys1765801023649 implements ReversibleMigration {
+	async up({ schemaBuilder: { addForeignKey }, runQuery, escape }: MigrationContext) {
+		// Clean up orphaned agentId references before adding foreign key constraint
+		await runQuery(
+			`UPDATE ${escape.tableName(table.sessions)} SET "agentId" = NULL WHERE "agentId" IS NOT NULL AND "agentId" NOT IN (SELECT id FROM ${escape.tableName(table.agents)})`,
+		);
+		await runQuery(
+			`UPDATE ${escape.tableName(table.messages)} SET "agentId" = NULL WHERE "agentId" IS NOT NULL AND "agentId" NOT IN (SELECT id FROM ${escape.tableName(table.agents)})`,
+		);
+
+		// Add foreign key constraint for agentId in sessions table
+		await addForeignKey(
+			table.sessions,
+			'agentId',
+			[table.agents, 'id'],
+			'FK_chat_hub_sessions_agentId',
+			'SET NULL',
+		);
+		await addForeignKey(
+			table.messages,
+			'agentId',
+			[table.agents, 'id'],
+			'FK_chat_hub_messages_agentId',
+			'SET NULL',
+		);
+	}
+
+	async down({ schemaBuilder: { dropForeignKey } }: MigrationContext) {
+		await dropForeignKey(
+			table.messages,
+			'agentId',
+			[table.agents, 'id'],
+			'FK_chat_hub_messages_agentId',
+		);
+		await dropForeignKey(
+			table.sessions,
+			'agentId',
+			[table.agents, 'id'],
+			'FK_chat_hub_sessions_agentId',
+		);
+	}
+}

--- a/packages/@n8n/db/src/migrations/common/1765801023649-AddAgentIdForeignKeys.ts
+++ b/packages/@n8n/db/src/migrations/common/1765801023649-AddAgentIdForeignKeys.ts
@@ -7,6 +7,8 @@ const table = {
 } as const;
 
 export class AddAgentIdForeignKeys1765801023649 implements ReversibleMigration {
+	transaction = false as const;
+
 	async up({ schemaBuilder: { addForeignKey }, runQuery, escape }: MigrationContext) {
 		// Clean up orphaned agentId references before adding foreign key constraint
 		await runQuery(

--- a/packages/@n8n/db/src/migrations/common/1765886667897-AddAgentIdForeignKeys.ts
+++ b/packages/@n8n/db/src/migrations/common/1765886667897-AddAgentIdForeignKeys.ts
@@ -7,8 +7,6 @@ const table = {
 } as const;
 
 export class AddAgentIdForeignKeys1765886667897 implements ReversibleMigration {
-	transaction = false as const;
-
 	async up({ schemaBuilder: { addForeignKey }, runQuery, escape }: MigrationContext) {
 		// Clean up orphaned agentId references before adding foreign key constraint
 		await runQuery(

--- a/packages/@n8n/db/src/migrations/common/1765886667897-AddAgentIdForeignKeys.ts
+++ b/packages/@n8n/db/src/migrations/common/1765886667897-AddAgentIdForeignKeys.ts
@@ -6,7 +6,7 @@ const table = {
 	messages: 'chat_hub_messages',
 } as const;
 
-export class AddAgentIdForeignKeys1765801023649 implements ReversibleMigration {
+export class AddAgentIdForeignKeys1765886667897 implements ReversibleMigration {
 	transaction = false as const;
 
 	async up({ schemaBuilder: { addForeignKey }, runQuery, escape }: MigrationContext) {

--- a/packages/@n8n/db/src/migrations/common/1765886667897-AddAgentIdForeignKeys.ts
+++ b/packages/@n8n/db/src/migrations/common/1765886667897-AddAgentIdForeignKeys.ts
@@ -8,12 +8,14 @@ const table = {
 
 export class AddAgentIdForeignKeys1765886667897 implements ReversibleMigration {
 	async up({ schemaBuilder: { addForeignKey }, runQuery, escape }: MigrationContext) {
+		const escapedAgentIdColumn = escape.columnName('agentId');
+
 		// Clean up orphaned agentId references before adding foreign key constraint
 		await runQuery(
-			`UPDATE ${escape.tableName(table.sessions)} SET "agentId" = NULL WHERE "agentId" IS NOT NULL AND "agentId" NOT IN (SELECT id FROM ${escape.tableName(table.agents)})`,
+			`UPDATE ${escape.tableName(table.sessions)} SET ${escapedAgentIdColumn} = NULL WHERE ${escapedAgentIdColumn} IS NOT NULL AND ${escapedAgentIdColumn} NOT IN (SELECT id FROM ${escape.tableName(table.agents)})`,
 		);
 		await runQuery(
-			`UPDATE ${escape.tableName(table.messages)} SET "agentId" = NULL WHERE "agentId" IS NOT NULL AND "agentId" NOT IN (SELECT id FROM ${escape.tableName(table.agents)})`,
+			`UPDATE ${escape.tableName(table.messages)} SET ${escapedAgentIdColumn} = NULL WHERE ${escapedAgentIdColumn} IS NOT NULL AND ${escapedAgentIdColumn} NOT IN (SELECT id FROM ${escape.tableName(table.agents)})`,
 		);
 
 		// Add foreign key constraint for agentId in sessions table

--- a/packages/@n8n/db/src/migrations/mysqldb/index.ts
+++ b/packages/@n8n/db/src/migrations/mysqldb/index.ts
@@ -126,7 +126,7 @@ import { AddDynamicCredentialEntryTable1764689388394 } from '../common/176468938
 import { BackfillMissingWorkflowHistoryRecords1765448186933 } from '../common/1765448186933-BackfillMissingWorkflowHistoryRecords';
 import { AddResolvableFieldsToCredentials1765459448000 } from '../common/1765459448000-AddResolvableFieldsToCredentials';
 import { AddIconToAgentTable1765788427674 } from '../common/1765788427674-AddIconToAgentTable';
-import { AddAgentIdForeignKeys1765801023649 } from '../common/1765801023649-AddAgentIdForeignKeys';
+import { AddAgentIdForeignKeys1765886667897 } from '../common/1765886667897-AddAgentIdForeignKeys';
 import type { Migration } from '../migration-types';
 
 export const mysqlMigrations: Migration[] = [
@@ -258,5 +258,5 @@ export const mysqlMigrations: Migration[] = [
 	BackfillMissingWorkflowHistoryRecords1765448186933,
 	AddResolvableFieldsToCredentials1765459448000,
 	AddIconToAgentTable1765788427674,
-	AddAgentIdForeignKeys1765801023649,
+	AddAgentIdForeignKeys1765886667897,
 ];

--- a/packages/@n8n/db/src/migrations/mysqldb/index.ts
+++ b/packages/@n8n/db/src/migrations/mysqldb/index.ts
@@ -126,6 +126,7 @@ import { AddDynamicCredentialEntryTable1764689388394 } from '../common/176468938
 import { BackfillMissingWorkflowHistoryRecords1765448186933 } from '../common/1765448186933-BackfillMissingWorkflowHistoryRecords';
 import { AddResolvableFieldsToCredentials1765459448000 } from '../common/1765459448000-AddResolvableFieldsToCredentials';
 import { AddIconToAgentTable1765788427674 } from '../common/1765788427674-AddIconToAgentTable';
+import { AddAgentIdForeignKeys1765801023649 } from '../common/1765801023649-AddAgentIdForeignKeys';
 import type { Migration } from '../migration-types';
 
 export const mysqlMigrations: Migration[] = [
@@ -257,4 +258,5 @@ export const mysqlMigrations: Migration[] = [
 	BackfillMissingWorkflowHistoryRecords1765448186933,
 	AddResolvableFieldsToCredentials1765459448000,
 	AddIconToAgentTable1765788427674,
+	AddAgentIdForeignKeys1765801023649,
 ];

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -127,7 +127,7 @@ import { AddDynamicCredentialEntryTable1764689388394 } from '../common/176468938
 import { BackfillMissingWorkflowHistoryRecords1765448186933 } from '../common/1765448186933-BackfillMissingWorkflowHistoryRecords';
 import { AddResolvableFieldsToCredentials1765459448000 } from '../common/1765459448000-AddResolvableFieldsToCredentials';
 import { AddIconToAgentTable1765788427674 } from '../common/1765788427674-AddIconToAgentTable';
-import { AddAgentIdForeignKeys1765801023649 } from '../common/1765801023649-AddAgentIdForeignKeys';
+import { AddAgentIdForeignKeys1765886667897 } from '../common/1765886667897-AddAgentIdForeignKeys';
 import type { Migration } from '../migration-types';
 
 export const postgresMigrations: Migration[] = [
@@ -260,5 +260,5 @@ export const postgresMigrations: Migration[] = [
 	AddResolvableFieldsToCredentials1765459448000,
 	AddIconToAgentTable1765788427674,
 	ConvertAgentIdToUuid1765804780000,
-	AddAgentIdForeignKeys1765801023649,
+	AddAgentIdForeignKeys1765886667897,
 ];

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -127,6 +127,7 @@ import { AddDynamicCredentialEntryTable1764689388394 } from '../common/176468938
 import { BackfillMissingWorkflowHistoryRecords1765448186933 } from '../common/1765448186933-BackfillMissingWorkflowHistoryRecords';
 import { AddResolvableFieldsToCredentials1765459448000 } from '../common/1765459448000-AddResolvableFieldsToCredentials';
 import { AddIconToAgentTable1765788427674 } from '../common/1765788427674-AddIconToAgentTable';
+import { AddAgentIdForeignKeys1765801023649 } from '../common/1765801023649-AddAgentIdForeignKeys';
 import type { Migration } from '../migration-types';
 
 export const postgresMigrations: Migration[] = [
@@ -259,4 +260,5 @@ export const postgresMigrations: Migration[] = [
 	AddResolvableFieldsToCredentials1765459448000,
 	AddIconToAgentTable1765788427674,
 	ConvertAgentIdToUuid1765804780000,
+	AddAgentIdForeignKeys1765801023649,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/1765886667897-AddAgentIdForeignKeys.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1765886667897-AddAgentIdForeignKeys.ts
@@ -1,0 +1,5 @@
+import { AddAgentIdForeignKeys1765886667897 as BaseMigration } from '../common/1765886667897-AddAgentIdForeignKeys';
+
+export class AddAgentIdForeignKeys1765886667897 extends BaseMigration {
+	transaction = false as const;
+}

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -122,7 +122,7 @@ import { CreateDynamicCredentialResolverTable1764682447000 } from '../common/176
 import { AddDynamicCredentialEntryTable1764689388394 } from '../common/1764689388394-AddDynamicCredentialEntryTable';
 import { BackfillMissingWorkflowHistoryRecords1765448186933 } from '../common/1765448186933-BackfillMissingWorkflowHistoryRecords';
 import { AddIconToAgentTable1765788427674 } from '../common/1765788427674-AddIconToAgentTable';
-import { AddAgentIdForeignKeys1765801023649 } from '../common/1765801023649-AddAgentIdForeignKeys';
+import { AddAgentIdForeignKeys1765886667897 } from '../common/1765886667897-AddAgentIdForeignKeys';
 import type { Migration } from '../migration-types';
 
 const sqliteMigrations: Migration[] = [
@@ -250,7 +250,7 @@ const sqliteMigrations: Migration[] = [
 	BackfillMissingWorkflowHistoryRecords1765448186933,
 	AddResolvableFieldsToCredentials1764689448000,
 	AddIconToAgentTable1765788427674,
-	AddAgentIdForeignKeys1765801023649,
+	AddAgentIdForeignKeys1765886667897,
 ];
 
 export { sqliteMigrations };

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -48,6 +48,7 @@ import { AddWorkflowVersionColumn1761047826451 } from './1761047826451-AddWorkfl
 import { ChangeDependencyInfoToJson1761655473000 } from './1761655473000-ChangeDependencyInfoToJson';
 import { AddCreatorIdToProjectTable1764276827837 } from './1764276827837-AddCreatorIdToProjectTable';
 import { AddResolvableFieldsToCredentials1764689448000 } from './1764689448000-AddResolvableFieldsToCredentials';
+import { AddAgentIdForeignKeys1765886667897 } from './1765886667897-AddAgentIdForeignKeys';
 import { UniqueWorkflowNames1620821879465 } from '../common/1620821879465-UniqueWorkflowNames';
 import { UpdateWorkflowCredentials1630330987096 } from '../common/1630330987096-UpdateWorkflowCredentials';
 import { AddNodeIds1658930531669 } from '../common/1658930531669-AddNodeIds';
@@ -122,7 +123,6 @@ import { CreateDynamicCredentialResolverTable1764682447000 } from '../common/176
 import { AddDynamicCredentialEntryTable1764689388394 } from '../common/1764689388394-AddDynamicCredentialEntryTable';
 import { BackfillMissingWorkflowHistoryRecords1765448186933 } from '../common/1765448186933-BackfillMissingWorkflowHistoryRecords';
 import { AddIconToAgentTable1765788427674 } from '../common/1765788427674-AddIconToAgentTable';
-import { AddAgentIdForeignKeys1765886667897 } from '../common/1765886667897-AddAgentIdForeignKeys';
 import type { Migration } from '../migration-types';
 
 const sqliteMigrations: Migration[] = [

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -122,6 +122,7 @@ import { CreateDynamicCredentialResolverTable1764682447000 } from '../common/176
 import { AddDynamicCredentialEntryTable1764689388394 } from '../common/1764689388394-AddDynamicCredentialEntryTable';
 import { BackfillMissingWorkflowHistoryRecords1765448186933 } from '../common/1765448186933-BackfillMissingWorkflowHistoryRecords';
 import { AddIconToAgentTable1765788427674 } from '../common/1765788427674-AddIconToAgentTable';
+import { AddAgentIdForeignKeys1765801023649 } from '../common/1765801023649-AddAgentIdForeignKeys';
 import type { Migration } from '../migration-types';
 
 const sqliteMigrations: Migration[] = [
@@ -249,6 +250,7 @@ const sqliteMigrations: Migration[] = [
 	BackfillMissingWorkflowHistoryRecords1765448186933,
 	AddResolvableFieldsToCredentials1764689448000,
 	AddIconToAgentTable1765788427674,
+	AddAgentIdForeignKeys1765801023649,
 ];
 
 export { sqliteMigrations };


### PR DESCRIPTION
## Summary

This PR follows up #23032 to introduce foreign key constraint on `agentId` column in the ChatHub session and message table.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
