### PR TITLE
chore(core): Update workflow status endpoint to use absolute URL

### DIFF
--- a/packages/cli/src/modules/dynamic-credentials.ee/__tests__/workflow-status.controller.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/__tests__/workflow-status.controller.test.ts
@@ -6,11 +6,13 @@ import { WorkflowStatusController } from '../workflow-status.controller';
 import type { CredentialResolverWorkflowService } from '../services/credential-resolver-workflow.service';
 import { UnauthenticatedError } from '@/errors/response-errors/unauthenticated.error';
 import type { UrlService } from '@/services/url.service';
+import type { GlobalConfig } from '@n8n/config';
 
 describe('WorkflowStatusController', () => {
 	let controller: WorkflowStatusController;
 	let mockService: jest.Mocked<CredentialResolverWorkflowService>;
 	let mockUrlService: jest.Mocked<UrlService>;
+	let mockGlobalConfig: jest.Mocked<GlobalConfig>;
 
 	beforeEach(() => {
 		jest.clearAllMocks();
@@ -23,7 +25,13 @@ describe('WorkflowStatusController', () => {
 			getInstanceBaseUrl: jest.fn().mockReturnValue('https://n8n.example.com'),
 		} as unknown as jest.Mocked<UrlService>;
 
-		controller = new WorkflowStatusController(mockService, mockUrlService);
+		mockGlobalConfig = {
+			endpoints: {
+				rest: 'rest',
+			},
+		} as unknown as jest.Mocked<GlobalConfig>;
+
+		controller = new WorkflowStatusController(mockService, mockUrlService, mockGlobalConfig);
 	});
 
 	describe('checkWorkflowForExecution', () => {

--- a/packages/cli/src/modules/dynamic-credentials.ee/workflow-status.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/workflow-status.controller.ts
@@ -6,12 +6,14 @@ import { CredentialResolverWorkflowService } from './services/credential-resolve
 import { WorkflowExecutionStatus } from '@n8n/api-types';
 import { getBearerToken } from './utils';
 import { UrlService } from '@/services/url.service';
+import { GlobalConfig } from '@n8n/config';
 
 @RestController('/workflows')
 export class WorkflowStatusController {
 	constructor(
 		private readonly credentialResolverWorkflowService: CredentialResolverWorkflowService,
 		private readonly urlService: UrlService,
+		private readonly globalConfig: GlobalConfig,
 	) {}
 
 	/**
@@ -40,6 +42,7 @@ export class WorkflowStatusController {
 		const isReady = status.every((s) => s.status === 'configured');
 
 		const basePath = this.urlService.getInstanceBaseUrl();
+		const restPath = this.globalConfig.endpoints.rest;
 
 		const executionStatus: WorkflowExecutionStatus = {
 			workflowId,
@@ -48,7 +51,7 @@ export class WorkflowStatusController {
 				credentialId: s.credentialId,
 				credentialStatus: s.status,
 				credentialType: s.credentialType,
-				authorizationUrl: `${basePath}/rest/credentials/${s.credentialId}/authorize?resolverId=${encodeURIComponent(s.resolverId)}`,
+				authorizationUrl: `${basePath}/${restPath}/credentials/${s.credentialId}/authorize?resolverId=${encodeURIComponent(s.resolverId)}`,
 			})),
 		};
 		return executionStatus;

--- a/packages/cli/src/modules/dynamic-credentials.ee/workflow-status.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/workflow-status.controller.ts
@@ -5,11 +5,13 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { CredentialResolverWorkflowService } from './services/credential-resolver-workflow.service';
 import { WorkflowExecutionStatus } from '@n8n/api-types';
 import { getBearerToken } from './utils';
+import { UrlService } from '@/services/url.service';
 
 @RestController('/workflows')
 export class WorkflowStatusController {
 	constructor(
 		private readonly credentialResolverWorkflowService: CredentialResolverWorkflowService,
+		private readonly urlService: UrlService,
 	) {}
 
 	/**
@@ -37,6 +39,8 @@ export class WorkflowStatusController {
 
 		const isReady = status.every((s) => s.status === 'configured');
 
+		const basePath = this.urlService.getInstanceBaseUrl();
+
 		const executionStatus: WorkflowExecutionStatus = {
 			workflowId,
 			readyToExecute: isReady,
@@ -44,7 +48,7 @@ export class WorkflowStatusController {
 				credentialId: s.credentialId,
 				credentialStatus: s.status,
 				credentialType: s.credentialType,
-				authorizationUrl: `/credentials/${s.credentialId}/authorize?resolverId=${encodeURIComponent(s.resolverId)}`,
+				authorizationUrl: `${basePath}/rest/credentials/${s.credentialId}/authorize?resolverId=${encodeURIComponent(s.resolverId)}`,
 			})),
 		};
 		return executionStatus;


### PR DESCRIPTION
## Summary

Updates the workflow status endpoint to return absolute authorization URLs instead of relative paths. The controller now injects `UrlService` to retrieve the instance base URL and constructs fully qualified URLs (e.g., `https://n8n.example.com/rest/credentials/{id}/authorize?resolverId=...`) for credential authorization endpoints. This ensures clients receive complete URLs that can be used directly without requiring additional context about the server's base path.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-4334/update-workflow-status-endpoint-to-include-full-url

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
