### PR TITLE
chore(core): Dynamic credential resolution depends on credential context

### DIFF
--- a/packages/cli/src/__tests__/credentials-helper.test.ts
+++ b/packages/cli/src/__tests__/credentials-helper.test.ts
@@ -540,7 +540,7 @@ describe('CredentialsHelper', () => {
 			expect(result).not.toEqual({ apiKey: 'static-key' });
 		});
 
-		test('should handle missing executionContext gracefully', async () => {
+		test('should skip resolution when executionContext is missing', async () => {
 			dynamicCredentialProxy.setResolverProvider(mockCredentialResolutionProvider);
 			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue({ apiKey: 'resolved' });
 
@@ -549,7 +549,7 @@ describe('CredentialsHelper', () => {
 				executionContext: undefined,
 			};
 
-			await credentialsHelper.getDecrypted(
+			const result = await credentialsHelper.getDecrypted(
 				additionalDataWithoutContext,
 				nodeCredentials,
 				credentialType,
@@ -558,8 +558,39 @@ describe('CredentialsHelper', () => {
 				true,
 			);
 
-			const call = mockCredentialResolutionProvider.resolveIfNeeded.mock.calls[0];
-			expect(call[2]).toBeUndefined();
+			// Resolution should not happen when executionContext is missing
+			expect(mockCredentialResolutionProvider.resolveIfNeeded).not.toHaveBeenCalled();
+			// Should return static decrypted data
+			expect(result).toEqual({ apiKey: 'static-key' });
+		});
+
+		test('should skip resolution when credentials context is missing', async () => {
+			dynamicCredentialProxy.setResolverProvider(mockCredentialResolutionProvider);
+			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue({ apiKey: 'resolved' });
+
+			const additionalDataWithoutCredentials = {
+				...mockAdditionalData,
+				executionContext: {
+					version: 1,
+					establishedAt: Date.now(),
+					source: 'manual' as const,
+					// credentials is undefined
+				},
+			};
+
+			const result = await credentialsHelper.getDecrypted(
+				additionalDataWithoutCredentials,
+				nodeCredentials,
+				credentialType,
+				'manual',
+				undefined,
+				true,
+			);
+
+			// Resolution should not happen when credentials context is missing
+			expect(mockCredentialResolutionProvider.resolveIfNeeded).not.toHaveBeenCalled();
+			// Should return static decrypted data
+			expect(result).toEqual({ apiKey: 'static-key' });
 		});
 
 		test('should handle missing workflowSettings gracefully', async () => {

--- a/packages/cli/src/credentials-helper.ts
+++ b/packages/cli/src/credentials-helper.ts
@@ -359,8 +359,8 @@ export class CredentialsHelper extends ICredentialsHelper {
 		let decryptedDataOriginal = credentials.getData();
 
 		/**
-		 * We skip dynamic credentials resolution for manual triggers,
-		 * this helps workflow developers to run workflows with static credentials.
+		 * We skip dynamic credentials resolution when no credentials context is present.
+		 * This helps workflow developers to run workflows with static credentials.
 		 */
 		if (additionalData.executionContext?.credentials !== undefined) {
 			// Resolve dynamic credentials if configured (EE feature)

--- a/packages/cli/src/credentials-helper.ts
+++ b/packages/cli/src/credentials-helper.ts
@@ -362,7 +362,7 @@ export class CredentialsHelper extends ICredentialsHelper {
 		 * We skip dynamic credentials resolution for manual triggers,
 		 * this helps workflow developers to run workflows with static credentials.
 		 */
-		if (additionalData.executionContext?.triggerNode?.type !== 'n8n-nodes-base.manualTrigger') {
+		if (additionalData.executionContext?.credentials !== undefined) {
 			// Resolve dynamic credentials if configured (EE feature)
 			decryptedDataOriginal = await this.dynamicCredentialsProxy.resolveIfNeeded(
 				{


### PR DESCRIPTION
## Summary

Dynamic credential resolution depends on the established credentials context, if no context exists, no dynamic resolution is attempted.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-4335/ignore-dynamic-resolution-for-partial-executions

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
