### PR TITLE
refactor(core): Drop self-referencing entity fields from ChatHubMessage entity to solve deep type instantiation issues

### DIFF
--- a/packages/cli/src/modules/chat-hub/chat-hub-message.entity.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-message.entity.ts
@@ -5,7 +5,6 @@ import {
 	Entity,
 	ManyToOne,
 	JoinColumn,
-	OneToMany,
 	type Relation,
 	PrimaryGeneratedColumn,
 } from '@n8n/typeorm';
@@ -104,64 +103,15 @@ export class ChatHubMessage extends WithTimestamps {
 	previousMessageId: string | null;
 
 	/**
-	 * The previous message this message is a response to, NULL on the initial message.
-	 */
-	@ManyToOne('ChatHubMessage', (m: ChatHubMessage) => m.responses, {
-		onDelete: 'CASCADE',
-		nullable: true,
-	})
-	@JoinColumn({ name: 'previousMessageId' })
-	previousMessage?: Relation<ChatHubMessage> | null;
-
-	/**
-	 * Messages that are responses to this message. This could branch out to multiple threads.
-	 */
-	@OneToMany('ChatHubMessage', (m: ChatHubMessage) => m.previousMessage)
-	responses?: Array<Relation<ChatHubMessage>>;
-
-	/**
 	 * ID of the message that this message is a retry of (if applicable).
 	 */
 	@Column({ type: String, nullable: true })
 	retryOfMessageId: string | null;
-
-	/**
-	 * The message that this message is a retry of (if applicable).
-	 */
-	@ManyToOne('ChatHubMessage', (m: ChatHubMessage) => m.retries, {
-		onDelete: 'CASCADE',
-		nullable: true,
-	})
-	@JoinColumn({ name: 'retryOfMessageId' })
-	retryOfMessage?: Relation<ChatHubMessage> | null;
-
-	/**
-	 * All messages that are retries of this message (if applicable).
-	 */
-	@OneToMany('ChatHubMessage', (m: ChatHubMessage) => m.retryOfMessage)
-	retries?: Array<Relation<ChatHubMessage>>;
-
 	/**
 	 * ID of the message that this message is a revision/edit of (if applicable).
 	 */
 	@Column({ type: String, nullable: true })
 	revisionOfMessageId: string | null;
-
-	/**
-	 * The message that this message is a revision/edit of (if applicable).
-	 */
-	@ManyToOne('ChatHubMessage', (m: ChatHubMessage) => m.revisions, {
-		onDelete: 'CASCADE',
-		nullable: true,
-	})
-	@JoinColumn({ name: 'revisionOfMessageId' })
-	revisionOfMessage?: Relation<ChatHubMessage> | null;
-
-	/**
-	 * All messages that are revisions/edits of this message (if applicable).
-	 */
-	@OneToMany('ChatHubMessage', (m: ChatHubMessage) => m.revisionOfMessage)
-	revisions?: Array<Relation<ChatHubMessage>>;
 
 	/**
 	 * Status of the message, e.g. 'running', 'success', 'error', 'cancelled'.


### PR DESCRIPTION
## Summary

`chat_hub_message` table represents a graph / tree structure, and it references to itself to keep track of previous messages of each message & retries / revisions. This works, but sometimes appears to lead into

<img width="1315" height="256" alt="image" src="https://github.com/user-attachments/assets/06e0e2ad-42d5-4192-b819-c5aec12f7691" />

```
Type instantiation is excessively deep and possibly infinite
```

issues at unrelated code changes. Sometimes these go away with `pnpm reset`, but now they're blocking unrelated PRs from building on CI.

Since we never load these entity relations on the backend and instead just construct the message graph at FE based no the IDs (and trust on the foreign keys to keep the data structure sane) dropping these entity relations until we have a real use for them could hopefully help with these random build issues.

Lets add these back later if we need them.

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C03MZF137FV/p1763993338525809

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
