### PR TITLE
fix(core): Preserve AI tool input/output data on execution error

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.node.ts
@@ -9,7 +9,7 @@ import type {
 	IExecuteFunctions,
 	INodeExecutionData,
 } from 'n8n-workflow';
-import { nodeNameToToolName } from 'n8n-workflow';
+import { nodeNameToToolName, NodeOperationError } from 'n8n-workflow';
 
 import { localResourceMapping } from './methods';
 import { WorkflowToolService } from './utils/WorkflowToolService';
@@ -67,18 +67,26 @@ export class ToolWorkflowV2 implements INodeType {
 			if (item === undefined) {
 				continue;
 			}
-			const result = await tool.invoke(item.json);
 
-			// When manualLogging is false, tool.invoke returns INodeExecutionData[]
-			// We need to spread these into the response array
-			if (Array.isArray(result)) {
-				response.push(...result);
-			} else {
-				// Fallback for unexpected types (shouldn't happen with manualLogging=false)
-				response.push({
-					json: { response: result },
-					pairedItem: { item: itemIndex },
-				});
+			try {
+				const result = await tool.invoke(item.json);
+
+				// When manualLogging is false, tool.invoke returns INodeExecutionData[]
+				// We need to spread these into the response array
+				if (Array.isArray(result)) {
+					response.push(...result);
+				} else {
+					// Fallback for unexpected types (shouldn't happen with manualLogging=false)
+					response.push({
+						json: { response: result },
+						pairedItem: { item: itemIndex },
+					});
+				}
+			} catch (error) {
+				// Catch schema validation errors (ToolInputParsingException) and other errors
+				// Re-throw as NodeOperationError with itemIndex for better error context
+				const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+				throw new NodeOperationError(this.getNode(), errorMessage, { itemIndex });
 			}
 		}
 

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.test.ts
@@ -381,6 +381,172 @@ describe('WorkflowTool::WorkflowToolService', () => {
 		});
 	});
 
+	describe('error data format for addOutputData', () => {
+		beforeEach(() => {
+			jest.clearAllMocks();
+		});
+
+		it('should pass error data in INodeExecutionData format to addOutputData', async () => {
+			// This test ensures that when tool execution fails, the error is wrapped
+			// in the correct format for addOutputData, not passed as raw ExecutionError
+			const executeWorkflowMock = jest
+				.fn()
+				.mockRejectedValue(new Error('Workflow execution failed'));
+			const addOutputDataMock = jest.fn();
+
+			const contextWithError = createMockContext({
+				getNode: jest.fn().mockReturnValue({
+					name: 'Test Tool',
+					parameters: { workflowInputs: { schema: [] } },
+					retryOnFail: false,
+				}),
+				getNodeParameter: jest.fn().mockImplementation((name) => {
+					if (name === 'source') return 'database';
+					if (name === 'workflowId') return { value: 'test-workflow-id' };
+					if (name === 'fields.values') return [];
+					return {};
+				}),
+				executeWorkflow: executeWorkflowMock,
+				addOutputData: addOutputDataMock,
+			});
+			contextWithError.cloneWith = jest.fn().mockImplementation((cloneOverrides) => ({
+				...createMockClonedContext(contextWithError, executeWorkflowMock),
+				getWorkflowDataProxy: jest.fn().mockReturnValue({
+					$execution: { id: 'exec-id' },
+					$workflow: { id: 'workflow-id' },
+				}),
+				getNodeParameter: contextWithError.getNodeParameter,
+				addOutputData: addOutputDataMock,
+				...cloneOverrides,
+			}));
+
+			service = new WorkflowToolService(contextWithError);
+			const tool = await service.createTool({
+				ctx: contextWithError,
+				name: 'Test Tool',
+				description: 'Test Description',
+				itemIndex: 0,
+			});
+
+			await tool.func('test query');
+
+			expect(addOutputDataMock).toHaveBeenCalled();
+			const [connectionType, _runIndex, outputData] = addOutputDataMock.mock.calls[0];
+
+			// The output data should be in INodeExecutionData[][] format, not raw Error
+			// This is critical for the agent to receive proper execution data
+			expect(connectionType).toBe('ai_tool');
+			expect(Array.isArray(outputData)).toBe(true);
+			// Structure is [[{json: {error: ...}}]] - outer array for runs, inner for items
+			expect(Array.isArray(outputData[0])).toBe(true);
+			expect(outputData[0][0]).toHaveProperty('json');
+			expect(outputData[0][0].json).toHaveProperty('error');
+		});
+
+		it('should include error message in the wrapped output data', async () => {
+			const errorMessage = 'Sub-workflow failed with validation error';
+			const executeWorkflowMock = jest.fn().mockRejectedValue(new Error(errorMessage));
+			const addOutputDataMock = jest.fn();
+
+			const contextWithError = createMockContext({
+				getNode: jest.fn().mockReturnValue({
+					name: 'Test Tool',
+					parameters: { workflowInputs: { schema: [] } },
+					retryOnFail: false,
+				}),
+				getNodeParameter: jest.fn().mockImplementation((name) => {
+					if (name === 'source') return 'database';
+					if (name === 'workflowId') return { value: 'test-workflow-id' };
+					if (name === 'fields.values') return [];
+					return {};
+				}),
+				executeWorkflow: executeWorkflowMock,
+				addOutputData: addOutputDataMock,
+			});
+			contextWithError.cloneWith = jest.fn().mockImplementation((cloneOverrides) => ({
+				...createMockClonedContext(contextWithError, executeWorkflowMock),
+				getWorkflowDataProxy: jest.fn().mockReturnValue({
+					$execution: { id: 'exec-id' },
+					$workflow: { id: 'workflow-id' },
+				}),
+				getNodeParameter: contextWithError.getNodeParameter,
+				addOutputData: addOutputDataMock,
+				...cloneOverrides,
+			}));
+
+			service = new WorkflowToolService(contextWithError);
+			const tool = await service.createTool({
+				ctx: contextWithError,
+				name: 'Test Tool',
+				description: 'Test Description',
+				itemIndex: 0,
+			});
+
+			await tool.func('test query');
+
+			expect(addOutputDataMock).toHaveBeenCalled();
+			const [, , outputData] = addOutputDataMock.mock.calls[0];
+
+			// The error message should be preserved in the output data
+			// Structure is [[{json: {error: ...}}]]
+			expect(Array.isArray(outputData)).toBe(true);
+			expect(Array.isArray(outputData[0])).toBe(true);
+			const errorJson = outputData[0][0]?.json?.error;
+			expect(errorJson).toContain(errorMessage);
+		});
+
+		it('should call addOutputData with correct arguments on error', async () => {
+			// Test that addOutputData is called with all expected arguments
+			const executeWorkflowMock = jest.fn().mockRejectedValue(new Error('Execution failed'));
+			const addOutputDataMock = jest.fn();
+
+			const contextWithError = createMockContext({
+				getNode: jest.fn().mockReturnValue({
+					name: 'Test Tool',
+					parameters: { workflowInputs: { schema: [] } },
+					retryOnFail: false,
+				}),
+				getNodeParameter: jest.fn().mockImplementation((name) => {
+					if (name === 'source') return 'database';
+					if (name === 'workflowId') return { value: 'test-workflow-id' };
+					if (name === 'fields.values') return [];
+					return {};
+				}),
+				executeWorkflow: executeWorkflowMock,
+				addOutputData: addOutputDataMock,
+			});
+			contextWithError.cloneWith = jest.fn().mockImplementation((cloneOverrides) => ({
+				...createMockClonedContext(contextWithError, executeWorkflowMock),
+				getWorkflowDataProxy: jest.fn().mockReturnValue({
+					$execution: { id: 'exec-id' },
+					$workflow: { id: 'workflow-id' },
+				}),
+				getNodeParameter: contextWithError.getNodeParameter,
+				addOutputData: addOutputDataMock,
+				...cloneOverrides,
+			}));
+
+			service = new WorkflowToolService(contextWithError);
+			const tool = await service.createTool({
+				ctx: contextWithError,
+				name: 'Test Tool',
+				description: 'Test Description',
+				itemIndex: 0,
+			});
+
+			await tool.func('test query');
+
+			expect(addOutputDataMock).toHaveBeenCalled();
+			// Should be called with 4 arguments: connectionType, runIndex, data, metadata
+			expect(addOutputDataMock.mock.calls[0]).toHaveLength(4);
+			const [connectionType, runIndex, outputData, _metadata] = addOutputDataMock.mock.calls[0];
+			expect(connectionType).toBe('ai_tool');
+			expect(typeof runIndex).toBe('number');
+			expect(Array.isArray(outputData)).toBe(true);
+			// metadata may be undefined if parseErrorMetadata returns nothing, that's ok
+		});
+	});
+
 	describe('retry functionality', () => {
 		beforeEach(() => {
 			jest.clearAllMocks();

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/utils/WorkflowToolService.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/utils/WorkflowToolService.ts
@@ -193,10 +193,13 @@ export class WorkflowToolService {
 
 					if (manualLogging) {
 						const metadata = parseErrorMetadata(error);
+						// Wrap error in INodeExecutionData format so it can be properly processed
+						// by buildSteps and displayed in the UI execution data
+						const errorData: INodeExecutionData[] = [{ json: { error: errorResponse } }];
 						void context.addOutputData(
 							NodeConnectionTypes.AiTool,
 							localRunIndex,
-							executionError,
+							[errorData],
 							metadata,
 						);
 					}
@@ -424,8 +427,9 @@ export class WorkflowToolService {
 			return new DynamicTool({ name, description, func });
 		}
 
-		// Otherwise, prepare Zod schema and create a structured tool
+		// Prepare Zod schema for the structured tool
 		const schema = createZodSchemaFromArgs(collectedArguments);
+
 		return new DynamicStructuredTool({ schema, name, description, func });
 	}
 }


### PR DESCRIPTION
## Summary
Fixes an issue where AI Agent nodes showed no execution data when a sub-workflow tool call failed. The bug was caused by the engine's error handling path creating duplicate runData entries instead of merging with existing ones that contained input data.

## Changes
- Modified error handling in `workflow-execute.ts` to preserve `inputOverride` and set error output under the correct connection type (`ai_tool`) when AI tool nodes fail
- Fixed `WorkflowToolService.ts` to wrap errors in `INodeExecutionData` format instead of passing raw `ExecutionError` to `addOutputData`
- Updated `buildSteps.ts` to extract error information when `ai_tool` data is missing but error info is present
- Added try/catch in `ToolWorkflowV2.node.ts` to provide better error context with `itemIndex`

Before:
On error run with input but empty output and error output with empty input:
<img width="1686" height="1248" alt="CleanShot 2025-12-16 at 15 39 37" src="https://github.com/user-attachments/assets/53e39b93-e290-41af-a814-41e9732e5210" />
After:
Consolidated input/output:
<img width="1266" height="1272" alt="CleanShot 2025-12-16 at 15 31 36" src="https://github.com/user-attachments/assets/07085971-8ec2-4c0f-96f3-acd1471e298f" />

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
