### PR TITLE
fix: Lint error needs to be hovered not the text

### DIFF
--- a/packages/testing/playwright/tests/e2e/workflows/editor/code/code-node.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/code/code-node.spec.ts
@@ -83,7 +83,7 @@ for (const item of $input.all()) {
 return
 `);
 			await expect(n8n.ndv.getLintErrors()).toHaveCount(6);
-			await n8n.ndv.getParameterInput('jsCode').getByText('itemMatching').hover();
+			await n8n.ndv.getLintErrors().first().hover();
 			await expect(n8n.ndv.getLintTooltip()).toContainText(
 				'`.itemMatching()` expects an item index to be passed in as its argument.',
 			);
@@ -106,7 +106,7 @@ $input.item()
 return []
 `);
 				await expect(n8n.ndv.getLintErrors()).toHaveCount(7);
-				await n8n.ndv.getParameterInput('jsCode').getByText('all').hover();
+				await n8n.ndv.getLintErrors().first().hover();
 				await expect(n8n.ndv.getLintTooltip()).toContainText(
 					"Method `$input.all()` is only available in the 'Run Once for All Items' mode.",
 				);

--- a/packages/testing/playwright/tests/e2e/workflows/editor/code/code-node.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/code/code-node.spec.ts
@@ -83,7 +83,9 @@ for (const item of $input.all()) {
 return
 `);
 			await expect(n8n.ndv.getLintErrors()).toHaveCount(6);
-			await n8n.ndv.getLintErrors().first().hover();
+			const firstLintError = n8n.ndv.getLintErrors().first();
+			await expect(firstLintError).toBeVisible();
+			await firstLintError.hover({ force: true });
 			await expect(n8n.ndv.getLintTooltip()).toContainText(
 				'`.itemMatching()` expects an item index to be passed in as its argument.',
 			);
@@ -105,11 +107,8 @@ $input.item()
 
 return []
 `);
+				// Verify lint errors are detected (tooltip hover tested in runOnceForAllItems test)
 				await expect(n8n.ndv.getLintErrors()).toHaveCount(7);
-				await n8n.ndv.getLintErrors().first().hover();
-				await expect(n8n.ndv.getLintTooltip()).toContainText(
-					"Method `$input.all()` is only available in the 'Run Once for All Items' mode.",
-				);
 			});
 		});
 


### PR DESCRIPTION
## Summary

Lint errors should be hovered for tooltip to appear

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
