### PR TITLE
fix(Embeddings OpenAI Node): Validate embedding inputs to prevent undefined errors

### DIFF
--- a/packages/@n8n/nodes-langchain/utils/embeddings/embeddingInputValidation.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/embeddings/embeddingInputValidation.test.ts
@@ -1,0 +1,130 @@
+import type { INode } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+
+import { validateEmbedQueryInput, validateEmbedDocumentsInput } from './embeddingInputValidation';
+
+const createMockNode = (): INode => ({
+	id: 'test-node',
+	name: 'Test Embeddings Node',
+	type: 'test',
+	typeVersion: 1,
+	position: [0, 0],
+	parameters: {},
+});
+
+describe('embeddingInputValidation', () => {
+	describe('validateEmbedQueryInput', () => {
+		const mockNode = createMockNode();
+
+		it('should throw NodeOperationError when query is undefined', () => {
+			expect(() => validateEmbedQueryInput(undefined, mockNode)).toThrow(NodeOperationError);
+		});
+
+		it('should throw NodeOperationError when query is null', () => {
+			expect(() => validateEmbedQueryInput(null, mockNode)).toThrow(NodeOperationError);
+		});
+
+		it('should throw NodeOperationError when query is empty string', () => {
+			expect(() => validateEmbedQueryInput('', mockNode)).toThrow(NodeOperationError);
+		});
+
+		it('should return query when valid string', () => {
+			const query = 'valid search query';
+			expect(validateEmbedQueryInput(query, mockNode)).toBe(query);
+		});
+
+		it('should return query with whitespace (not trimmed)', () => {
+			const query = '  query with spaces  ';
+			expect(validateEmbedQueryInput(query, mockNode)).toBe(query);
+		});
+
+		it('should include helpful error message', () => {
+			try {
+				validateEmbedQueryInput(undefined, mockNode);
+				fail('Expected error to be thrown');
+			} catch (e) {
+				expect(e).toBeInstanceOf(NodeOperationError);
+				expect((e as NodeOperationError).message).toContain('empty or undefined text');
+			}
+		});
+
+		it('should include description with possible causes', () => {
+			try {
+				validateEmbedQueryInput(undefined, mockNode);
+				fail('Expected error to be thrown');
+			} catch (e) {
+				expect(e).toBeInstanceOf(NodeOperationError);
+				const description = (e as NodeOperationError).description as string;
+				expect(description).toContain('expression evaluates to undefined');
+				expect(description).toContain('AI agent');
+				expect(description).toContain('required field is missing');
+			}
+		});
+	});
+
+	describe('validateEmbedDocumentsInput', () => {
+		const mockNode = createMockNode();
+
+		it('should throw NodeOperationError when documents is undefined', () => {
+			expect(() => validateEmbedDocumentsInput(undefined, mockNode)).toThrow(NodeOperationError);
+		});
+
+		it('should throw NodeOperationError when documents is null', () => {
+			expect(() => validateEmbedDocumentsInput(null, mockNode)).toThrow(NodeOperationError);
+		});
+
+		it('should throw NodeOperationError when documents is not an array', () => {
+			expect(() => validateEmbedDocumentsInput('not an array', mockNode)).toThrow(
+				NodeOperationError,
+			);
+		});
+
+		it('should throw NodeOperationError when any document is undefined', () => {
+			expect(() =>
+				validateEmbedDocumentsInput(['valid', undefined, 'also valid'], mockNode),
+			).toThrow(NodeOperationError);
+		});
+
+		it('should throw NodeOperationError when any document is null', () => {
+			expect(() => validateEmbedDocumentsInput(['valid', null], mockNode)).toThrow(
+				NodeOperationError,
+			);
+		});
+
+		it('should throw NodeOperationError when any document is empty string', () => {
+			expect(() => validateEmbedDocumentsInput(['valid', ''], mockNode)).toThrow(
+				NodeOperationError,
+			);
+		});
+
+		it('should return documents when all are valid strings', () => {
+			const docs = ['document 1', 'document 2', 'document 3'];
+			expect(validateEmbedDocumentsInput(docs, mockNode)).toBe(docs);
+		});
+
+		it('should return empty array when given empty array', () => {
+			const docs: string[] = [];
+			expect(validateEmbedDocumentsInput(docs, mockNode)).toBe(docs);
+		});
+
+		it('should include index of invalid document in error message', () => {
+			try {
+				validateEmbedDocumentsInput(['valid', 'also valid', undefined], mockNode);
+				fail('Expected error to be thrown');
+			} catch (e) {
+				expect(e).toBeInstanceOf(NodeOperationError);
+				expect((e as NodeOperationError).message).toContain('index 2');
+			}
+		});
+
+		it('should include helpful description in error', () => {
+			try {
+				validateEmbedDocumentsInput(['valid', null], mockNode);
+				fail('Expected error to be thrown');
+			} catch (e) {
+				expect(e).toBeInstanceOf(NodeOperationError);
+				expect((e as NodeOperationError).description).toContain('non-empty strings');
+			}
+		});
+	});
+});

--- a/packages/@n8n/nodes-langchain/utils/embeddings/embeddingInputValidation.ts
+++ b/packages/@n8n/nodes-langchain/utils/embeddings/embeddingInputValidation.ts
@@ -1,0 +1,53 @@
+import type { INode } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+
+/**
+ * Validates query input for embedQuery operations.
+ * Throws NodeOperationError if query is invalid (undefined, null, or empty string).
+ *
+ * @param query - The query to validate
+ * @param node - The node for error context
+ * @returns The validated query string
+ * @throws NodeOperationError if query is invalid
+ */
+export function validateEmbedQueryInput(query: unknown, node: INode): string {
+	if (query === undefined || query === null || query === '') {
+		throw new NodeOperationError(node, 'Cannot embed empty or undefined text', {
+			description:
+				'The text provided for embedding is empty or undefined. ' +
+				'This can happen when: the input expression evaluates to undefined, ' +
+				'the AI agent calls a tool without proper arguments, ' +
+				'or a required field is missing.',
+		});
+	}
+	return query as string;
+}
+
+/**
+ * Validates documents input for embedDocuments operations.
+ * Throws NodeOperationError if documents array is invalid or contains invalid entries.
+ *
+ * @param documents - The documents array to validate
+ * @param node - The node for error context
+ * @returns The validated documents array
+ * @throws NodeOperationError if documents is not an array or contains invalid entries
+ */
+export function validateEmbedDocumentsInput(documents: unknown, node: INode): string[] {
+	if (!Array.isArray(documents)) {
+		throw new NodeOperationError(node, 'Documents must be an array', {
+			description: 'Expected an array of strings to embed.',
+		});
+	}
+
+	const invalidIndex = documents.findIndex(
+		(doc) => doc === undefined || doc === null || doc === '',
+	);
+
+	if (invalidIndex !== -1) {
+		throw new NodeOperationError(node, `Invalid document at index ${invalidIndex}`, {
+			description: `Document at index ${invalidIndex} is empty or undefined. All documents must be non-empty strings.`,
+		});
+	}
+
+	return documents;
+}

--- a/packages/@n8n/nodes-langchain/utils/embeddings/embeddingInputValidation.ts
+++ b/packages/@n8n/nodes-langchain/utils/embeddings/embeddingInputValidation.ts
@@ -11,7 +11,7 @@ import { NodeOperationError } from 'n8n-workflow';
  * @throws NodeOperationError if query is invalid
  */
 export function validateEmbedQueryInput(query: unknown, node: INode): string {
-	if (query === undefined || query === null || query === '') {
+	if (typeof query !== 'string' || query === '') {
 		throw new NodeOperationError(node, 'Cannot embed empty or undefined text', {
 			description:
 				'The text provided for embedding is empty or undefined. ' +
@@ -20,7 +20,7 @@ export function validateEmbedQueryInput(query: unknown, node: INode): string {
 				'or a required field is missing.',
 		});
 	}
-	return query as string;
+	return query;
 }
 
 /**

--- a/packages/@n8n/nodes-langchain/utils/embeddings/embeddingInputValidation.ts
+++ b/packages/@n8n/nodes-langchain/utils/embeddings/embeddingInputValidation.ts
@@ -14,10 +14,7 @@ export function validateEmbedQueryInput(query: unknown, node: INode): string {
 	if (typeof query !== 'string' || query === '') {
 		throw new NodeOperationError(node, 'Cannot embed empty or undefined text', {
 			description:
-				'The text provided for embedding is empty or undefined. ' +
-				'This can happen when: the input expression evaluates to undefined, ' +
-				'the AI agent calls a tool without proper arguments, ' +
-				'or a required field is missing.',
+				'The text provided for embedding is empty or undefined. This can happen when: the input expression evaluates to undefined, the AI agent calls a tool without proper arguments, or a required field is missing.',
 		});
 	}
 	return query;


### PR DESCRIPTION
## Summary 
Fixes intermittent error "Cannot read properties of undefined (reading 'replace')" that occurs in Agentic RAG flows when AI Agent generates malformed tool calls (empty/missing args) or expressions evaluate to undefined, causing invalid input to flow through to embedQuery() and crash inside LangChain's embedding providers.

## Fix

Add input validation in logWrapper to catch undefined/null/empty inputs before they reach LangChain's embedding providers:

- Clear, actionable error messages explaining possible causes
- Central validation that protects ALL embedding calls (including custom nodes)
<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
