### PR TITLE
fix(editor): Fix wf nodes not updated correctly on workflow activated/deactivated events

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -130,6 +130,7 @@ import { useRoute, useRouter } from 'vue-router';
 import { useTemplatesStore } from '@/features/workflows/templates/templates.store';
 import { isValidNodeConnectionType } from '@/app/utils/typeGuards';
 import { useParentFolder } from '@/features/core/folders/composables/useParentFolder';
+import { useWorkflowState } from '@/app/composables/useWorkflowState';
 
 type AddNodeData = Partial<INodeUi> & {
 	type: string;
@@ -1756,7 +1757,7 @@ export function useCanvasOperations() {
 	}
 
 	async function initializeWorkspace(data: IWorkflowDb) {
-		await workflowHelpers.initState(data);
+		await workflowHelpers.initState(data, useWorkflowState());
 		data.nodes.forEach((node) => {
 			const nodeTypeDescription = requireNodeTypeDescription(node.type, node.typeVersion);
 			const isUnknownNode =

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowActivated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowActivated.ts
@@ -2,8 +2,10 @@ import type { WorkflowActivated } from '@n8n/api-types/push/workflow';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useBannersStore } from '@/features/shared/banners/banners.store';
 import { useUIStore } from '@/app/stores/ui.store';
+import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
 
 export async function workflowActivated({ data }: WorkflowActivated) {
+	const { initializeWorkspace } = useCanvasOperations();
 	const workflowsStore = useWorkflowsStore();
 	const bannersStore = useBannersStore();
 	const uiStore = useUIStore();
@@ -19,7 +21,7 @@ export async function workflowActivated({ data }: WorkflowActivated) {
 			if (!updatedWorkflow.checksum) {
 				throw new Error('Failed to fetch workflow');
 			}
-			workflowsStore.setWorkflow(updatedWorkflow);
+			await initializeWorkspace(updatedWorkflow);
 		}
 	}
 

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowAutoDeactivated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowAutoDeactivated.ts
@@ -2,9 +2,11 @@ import type { WorkflowAutoDeactivated } from '@n8n/api-types/push/workflow';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useBannersStore } from '@/features/shared/banners/banners.store';
 import { useUIStore } from '@/app/stores/ui.store';
+import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
 
 export async function workflowAutoDeactivated({ data }: WorkflowAutoDeactivated) {
 	const workflowsStore = useWorkflowsStore();
+	const { initializeWorkspace } = useCanvasOperations();
 	const bannersStore = useBannersStore();
 	const uiStore = useUIStore();
 
@@ -17,7 +19,7 @@ export async function workflowAutoDeactivated({ data }: WorkflowAutoDeactivated)
 			if (!updatedWorkflow.checksum) {
 				throw new Error('Failed to fetch workflow');
 			}
-			workflowsStore.setWorkflow(updatedWorkflow);
+			await initializeWorkspace(updatedWorkflow);
 		}
 
 		bannersStore.pushBannerToStack('WORKFLOW_AUTO_DEACTIVATED');

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowDeactivated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowDeactivated.ts
@@ -1,8 +1,10 @@
 import type { WorkflowDeactivated } from '@n8n/api-types/push/workflow';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useUIStore } from '@/app/stores/ui.store';
+import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
 
 export async function workflowDeactivated({ data }: WorkflowDeactivated) {
+	const { initializeWorkspace } = useCanvasOperations();
 	const workflowsStore = useWorkflowsStore();
 	const uiStore = useUIStore();
 
@@ -13,7 +15,7 @@ export async function workflowDeactivated({ data }: WorkflowDeactivated) {
 			if (!updatedWorkflow.checksum) {
 				throw new Error('Failed to fetch workflow');
 			}
-			workflowsStore.setWorkflow(updatedWorkflow);
+			await initializeWorkspace(updatedWorkflow);
 		}
 	}
 }

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -755,7 +755,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		}
 	}
 
-	function setWorkflowActiveVersion(version: WorkflowHistory) {
+	function setWorkflowActiveVersion(version: WorkflowHistory | null) {
 		workflow.value.activeVersion = deepCopy(version);
 	}
 


### PR DESCRIPTION
## Summary

When n8n is running in multi main mode there are socket messages being sent when workflow is activated/deactivated. That is also the the case when settings are being changed which is triggering deactivated and then activate messages. The way we were updating the local state of the workflow in the handlers of those messages were not correct as they were not setting the node parameter defaults.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4553/bug-setting-workflow-settings-breaks-node-configuration

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
