### PR TITLE
fix: Fix broken route for variables notification toast on pull

### DIFF
--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/sourceControl.utils.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/sourceControl.utils.ts
@@ -47,7 +47,7 @@ export const getPushPriorityByStatus = (status: SourceControlledFileStatus) =>
 	pushStatusPriority[status] ?? 0;
 
 const createVariablesToast = (router: Router) => {
-	const route = { name: VIEWS.PROJECTS_VARIABLES, query: { incomplete: 'true' } };
+	const route = { name: VIEWS.HOME_VARIABLES, query: { incomplete: 'true' } };
 	const { href } = router.resolve(route);
 
 	return {


### PR DESCRIPTION
## Summary

Fixed broken route in the variables notification toast that appears when pulling changes via source control. 

The toast was using `VIEWS.PROJECTS_VARIABLES` which requires a `projectId` parameter that wasn't provided, causing `router.resolve()` to fail. Now correctly uses `VIEWS.HOME_VARIABLES` which maps to `/home/variables`.
<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

fixes PAY-4337

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)