### PR TITLE
chore(core): Expose credential name in workflow status

### DIFF
--- a/packages/@n8n/api-types/src/schemas/workflow-execution-status.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/workflow-execution-status.schema.ts
@@ -6,6 +6,7 @@ export const WorkflowExecutionStatusSchema = z.object({
 		.array(
 			z.object({
 				credentialId: z.string(),
+				credentialName: z.string(),
 				credentialType: z.string(),
 				credentialStatus: z.enum(['missing', 'configured']),
 				authorizationUrl: z.string().optional(),

--- a/packages/cli/src/modules/dynamic-credentials.ee/__tests__/workflow-status.controller.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/__tests__/workflow-status.controller.test.ts
@@ -263,6 +263,7 @@ describe('WorkflowStatusController', () => {
 					{
 						credentialId: 'cred-1',
 						credentialStatus: 'missing',
+						credentialName: 'My OAuth2 Credential',
 						credentialType: 'oauth2Api',
 						authorizationUrl:
 							'https://n8n.example.com/rest/credentials/cred-1/authorize?resolverId=resolver-1',

--- a/packages/cli/src/modules/dynamic-credentials.ee/__tests__/workflow-status.controller.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/__tests__/workflow-status.controller.test.ts
@@ -113,12 +113,14 @@ describe('WorkflowStatusController', () => {
 				{
 					credentialId: 'cred-1',
 					resolverId: 'resolver-1',
+					credentialName: 'My OAuth2 Credential',
 					status: 'configured',
 					credentialType: 'oauth2Api',
 				},
 				{
 					credentialId: 'cred-2',
 					resolverId: 'resolver-1',
+					credentialName: 'My OAuth2 Credential',
 					status: 'configured',
 					credentialType: 'httpBasicAuth',
 				},
@@ -142,12 +144,14 @@ describe('WorkflowStatusController', () => {
 				{
 					credentialId: 'cred-1',
 					resolverId: 'resolver-1',
+					credentialName: 'My OAuth2 Credential',
 					status: 'configured',
 					credentialType: 'oauth2Api',
 				},
 				{
 					credentialId: 'cred-2',
 					resolverId: 'resolver-1',
+					credentialName: 'My OAuth2 Credential',
 					status: 'missing',
 					credentialType: 'httpBasicAuth',
 				},
@@ -171,6 +175,7 @@ describe('WorkflowStatusController', () => {
 				{
 					credentialId: 'cred-1',
 					resolverId: 'resolver-1',
+					credentialName: 'My OAuth2 Credential',
 					status: 'configured',
 					credentialType: 'oauth2Api',
 				},
@@ -194,6 +199,7 @@ describe('WorkflowStatusController', () => {
 				{
 					credentialId: 'cred-1',
 					resolverId: 'resolver/with/special chars',
+					credentialName: 'My OAuth2 Credential',
 					status: 'configured',
 					credentialType: 'oauth2Api',
 				},
@@ -217,6 +223,7 @@ describe('WorkflowStatusController', () => {
 				{
 					credentialId: 'cred-1',
 					resolverId: 'resolver-1',
+					credentialName: 'My OAuth2 Credential',
 					status: 'configured',
 					credentialType: 'oauth2Api',
 				},
@@ -241,6 +248,7 @@ describe('WorkflowStatusController', () => {
 				{
 					credentialId: 'cred-1',
 					resolverId: 'resolver-1',
+					credentialName: 'My OAuth2 Credential',
 					status: 'missing',
 					credentialType: 'oauth2Api',
 				},

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-resolver-workflow.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-resolver-workflow.service.test.ts
@@ -167,6 +167,7 @@ describe('CredentialResolverWorkflowService', () => {
 			const mockCredential = createMockCredential({
 				id: 'cred-1',
 				type: 'oauth2Api',
+				name: 'OAuth2 API',
 				isResolvable: true,
 				resolverId: null,
 			});
@@ -190,6 +191,7 @@ describe('CredentialResolverWorkflowService', () => {
 			expect(result[0]).toEqual({
 				credentialId: 'cred-1',
 				resolverId: 'resolver-1',
+				credentialName: 'OAuth2 API',
 				status: 'configured',
 				credentialType: 'oauth2Api',
 			});
@@ -219,6 +221,7 @@ describe('CredentialResolverWorkflowService', () => {
 			const mockCredential = createMockCredential({
 				id: 'cred-1',
 				type: 'oauth2Api',
+				name: 'OAuth2 API',
 				isResolvable: true,
 				resolverId: null,
 			});
@@ -242,6 +245,7 @@ describe('CredentialResolverWorkflowService', () => {
 			expect(result[0]).toEqual({
 				credentialId: 'cred-1',
 				resolverId: 'resolver-1',
+				credentialName: 'OAuth2 API',
 				status: 'missing',
 				credentialType: 'oauth2Api',
 			});

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/credential-resolver-workflow.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/credential-resolver-workflow.service.ts
@@ -8,6 +8,7 @@ import { Service } from '@n8n/di';
 
 type CredentialStatus = {
 	credentialId: string;
+	credentialName: string;
 	resolverId: string;
 	credentialType: string;
 	status: 'missing' | 'configured';
@@ -167,6 +168,7 @@ export class CredentialResolverWorkflowService {
 				return {
 					credentialId: credential.id,
 					resolverId: credentialResolverId,
+					credentialName: credential.name,
 					status: 'configured',
 					credentialType: credential.type,
 				};
@@ -175,6 +177,7 @@ export class CredentialResolverWorkflowService {
 				return {
 					credentialId: credential.id,
 					resolverId: credentialResolverId,
+					credentialName: credential.name,
 					status: 'missing',
 					credentialType: credential.type,
 				};

--- a/packages/cli/src/modules/dynamic-credentials.ee/workflow-status.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/workflow-status.controller.ts
@@ -49,6 +49,7 @@ export class WorkflowStatusController {
 			readyToExecute: isReady,
 			credentials: status.map((s) => ({
 				credentialId: s.credentialId,
+				credentialName: s.credentialName,
 				credentialStatus: s.status,
 				credentialType: s.credentialType,
 				authorizationUrl: `${basePath}/${restPath}/credentials/${s.credentialId}/authorize?resolverId=${encodeURIComponent(s.resolverId)}`,


### PR DESCRIPTION
## Summary

Expose the credential name in the workflow status endpoint.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/PAY-4338/include-credential-name-in-workflow-status-endpoint

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
