### PR TITLE
fix: Only support specified git config keys in Git node

### DIFF
--- a/packages/@n8n/config/src/configs/security.config.ts
+++ b/packages/@n8n/config/src/configs/security.config.ts
@@ -61,4 +61,10 @@ export class SecurityConfig {
 	 */
 	@Env('N8N_GIT_NODE_ENABLE_HOOKS')
 	enableGitNodeHooks: boolean = false;
+
+	/**
+	 * Whether to enable arbitrary git config keys.
+	 */
+	@Env('N8N_GIT_NODE_ENABLE_ALL_CONFIG_KEYS')
+	enableGitNodeAllConfigKeys: boolean = false;
 }

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -327,6 +327,7 @@ describe('GlobalConfig', () => {
 			disableBareRepos: false,
 			awsSystemCredentialsAccess: false,
 			enableGitNodeHooks: false,
+			enableGitNodeAllConfigKeys: false,
 		},
 		executions: {
 			mode: 'regular',

--- a/packages/nodes-base/nodes/Git/Git.node.ts
+++ b/packages/nodes-base/nodes/Git/Git.node.ts
@@ -18,6 +18,7 @@ import { URL } from 'url';
 import {
 	addConfigFields,
 	addFields,
+	ALLOWED_CONFIG_KEYS,
 	cloneFields,
 	commitFields,
 	logFields,
@@ -34,7 +35,7 @@ export class Git implements INodeType {
 		name: 'git',
 		icon: 'file:git.svg',
 		group: ['transform'],
-		version: 1,
+		version: [1, 1.1],
 		description: 'Control git.',
 		defaults: {
 			name: 'Git',
@@ -355,7 +356,15 @@ export class Git implements INodeType {
 
 					const key = this.getNodeParameter('key', itemIndex, '') as string;
 					const value = this.getNodeParameter('value', itemIndex, '') as string;
+					const securityConfig = Container.get(SecurityConfig);
+					const enableGitNodeAllConfigKeys = securityConfig.enableGitNodeAllConfigKeys;
 					let append = false;
+					if (!enableGitNodeAllConfigKeys && !ALLOWED_CONFIG_KEYS.includes(key)) {
+						throw new NodeOperationError(
+							this.getNode(),
+							`The provided git config key '${key}' is not allowed`,
+						);
+					}
 
 					if (options.mode === 'append') {
 						append = true;

--- a/packages/nodes-base/nodes/Git/descriptions/AddConfigDescription.ts
+++ b/packages/nodes-base/nodes/Git/descriptions/AddConfigDescription.ts
@@ -1,6 +1,26 @@
 import type { INodeProperties } from 'n8n-workflow';
 
+export const ALLOWED_CONFIG_KEYS = ['user.email', 'user.name', 'remote.origin.url'];
+
 export const addConfigFields: INodeProperties[] = [
+	{
+		displayName: 'Key',
+		name: 'key',
+		type: 'options',
+		displayOptions: {
+			show: {
+				operation: ['addConfig'],
+				'@version': [{ _cnd: { gte: 1.1 } }],
+			},
+		},
+		options: ALLOWED_CONFIG_KEYS.map((key) => ({
+			name: key,
+			value: key,
+		})),
+		default: '',
+		description: 'Name of the key to set',
+		required: true,
+	},
 	{
 		displayName: 'Key',
 		name: 'key',
@@ -8,6 +28,7 @@ export const addConfigFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				operation: ['addConfig'],
+				'@version': [{ _cnd: { lt: 1.1 } }],
 			},
 		},
 		default: '',

--- a/packages/nodes-base/nodes/Git/test/Git.node.test.ts
+++ b/packages/nodes-base/nodes/Git/test/Git.node.test.ts
@@ -2,8 +2,11 @@ import * as fsPromises from 'fs/promises';
 import { mock } from 'jest-mock-extended';
 import type { IExecuteFunctions } from 'n8n-workflow';
 import type { SimpleGit } from 'simple-git';
+import { Container } from '@n8n/di';
+import { SecurityConfig } from '@n8n/config';
 
 import { Git } from '../Git.node';
+import { ALLOWED_CONFIG_KEYS } from '../descriptions';
 
 // Mock simple-git
 const mockGit = {
@@ -370,6 +373,78 @@ describe('Git Node', () => {
 
 			expect(mockGit.add).toHaveBeenCalledWith(['file.txt']);
 			expect(result[0]).toEqual([{ json: { success: true }, pairedItem: { item: 0 } }]);
+		});
+
+		ALLOWED_CONFIG_KEYS.forEach((key) => {
+			it(`should handle addConfig with key '${key}' operation`, async () => {
+				mockExecuteFunctions.getNodeParameter
+					.mockReturnValueOnce('addConfig')
+					.mockReturnValueOnce('/repo')
+					.mockReturnValueOnce({})
+					.mockReturnValueOnce(key)
+					.mockReturnValueOnce('test value');
+
+				await gitNode.execute.call(mockExecuteFunctions);
+
+				expect(mockGit.addConfig).toHaveBeenCalledWith(key, 'test value', false);
+			});
+		});
+
+		describe('enableGitNodeAllConfigKeys is false (default value)', () => {
+			[
+				'core.sshCommand',
+				'core.hooksPath',
+				'credential.helper',
+				'remote.origin.uploadpack',
+				'remote.origin.receivepack',
+				'url.xxx.insteadOf',
+				'user.name,core.sshCommand',
+			].forEach((key) => {
+				it(`should reject addConfig with key '${key}'`, async () => {
+					mockExecuteFunctions.getNodeParameter
+						.mockReturnValueOnce('addConfig')
+						.mockReturnValueOnce('/repo')
+						.mockReturnValueOnce({})
+						.mockReturnValueOnce(key)
+						.mockReturnValueOnce('test value');
+
+					await expect(gitNode.execute.call(mockExecuteFunctions)).rejects.toThrow(
+						`The provided git config key '${key}' is not allowed`,
+					);
+				});
+			});
+		});
+
+		describe('enableGitNodeAllConfigKeys is true', () => {
+			beforeEach(() => {
+				const securityConfig = mock<SecurityConfig>({
+					enableGitNodeAllConfigKeys: true,
+				});
+				Container.set(SecurityConfig, securityConfig);
+			});
+
+			[
+				'core.sshCommand',
+				'core.hooksPath',
+				'credential.helper',
+				'remote.origin.uploadpack',
+				'remote.origin.receivepack',
+				'url.xxx.insteadOf',
+				'user.name,core.sshCommand',
+			].forEach((key) => {
+				it(`should handle addConfig with key '${key}'`, async () => {
+					mockExecuteFunctions.getNodeParameter
+						.mockReturnValueOnce('addConfig')
+						.mockReturnValueOnce('/repo')
+						.mockReturnValueOnce({})
+						.mockReturnValueOnce(key)
+						.mockReturnValueOnce('test value');
+
+					await gitNode.execute.call(mockExecuteFunctions);
+
+					expect(mockGit.addConfig).toHaveBeenCalledWith(key, 'test value', false);
+				});
+			});
 		});
 
 		it('should handle addConfig operation', async () => {


### PR DESCRIPTION
## Summary
Only support specified configuration keys in Git node

Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-4089


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
