### PR TITLE
fix(editor): Select default Chat hub model to use from models allowed by settings

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
@@ -50,11 +50,13 @@ import {
 } from '@/features/ai/chatHub/chat.types';
 import { useI18n } from '@n8n/i18n';
 import { useCustomAgent } from '@/features/ai/chatHub/composables/useCustomAgent';
+import { useSettingsStore } from '@/app/stores/settings.store';
 
 const router = useRouter();
 const route = useRoute();
 const usersStore = useUsersStore();
 const chatStore = useChatStore();
+const settingsStore = useSettingsStore();
 const toast = useToast();
 const isMobileDevice = useMediaQuery(MOBILE_MEDIA_QUERY);
 const documentTitle = useDocumentTitle();
@@ -320,12 +322,13 @@ watch(
 watch(
 	() => chatStore.agents,
 	(models) => {
-		if (!models || !!selectedModel.value || !isNewSession.value) {
+		const settings = settingsStore.moduleSettings?.['chat-hub'];
+
+		if (!models || !!selectedModel.value || !isNewSession.value || !settings) {
 			return;
 		}
 
-		const model = findOneFromModelsResponse(models) ?? null;
-
+		const model = findOneFromModelsResponse(models, settings.providers);
 		if (model) {
 			void handleSelectAgent(model);
 		}

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chat.utils.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chat.utils.ts
@@ -10,6 +10,7 @@ import {
 	type ChatHubLLMProvider,
 	type ChatHubInputModality,
 	type AgentIconOrEmoji,
+	ChatProviderSettingsDto,
 } from '@n8n/api-types';
 import type {
 	ChatMessage,
@@ -22,16 +23,6 @@ import type {
 import { CHAT_VIEW } from './constants';
 import { v4 as uuidv4 } from 'uuid';
 import type { IconName } from '@n8n/design-system/components/N8nIcon/icons';
-
-export function findOneFromModelsResponse(response: ChatModelsResponse): ChatModelDto | undefined {
-	for (const provider of chatHubProviderSchema.options) {
-		if (response[provider].models.length > 0) {
-			return response[provider].models[0];
-		}
-	}
-
-	return undefined;
-}
 
 export function getRelativeDate(now: Date, dateString: string): string {
 	const date = new Date(dateString);
@@ -333,6 +324,36 @@ export function isLlmProviderModel(
 	model?: ChatHubConversationModel,
 ): model is ChatHubConversationModel & { provider: ChatHubLLMProvider } {
 	return isLlmProvider(model?.provider);
+}
+
+export function findOneFromModelsResponse(
+	response: ChatModelsResponse,
+	providerSettings: Record<ChatHubLLMProvider, ChatProviderSettingsDto>,
+): ChatModelDto | undefined {
+	for (const provider of chatHubProviderSchema.options) {
+		const settings: ChatProviderSettingsDto | undefined = isLlmProvider(provider)
+			? providerSettings[provider]
+			: undefined;
+
+		if (!settings?.enabled) {
+			continue;
+		}
+
+		const availableModels = response[provider].models.filter((providerModel) => {
+			const { model } = providerModel;
+			if (isLlmProviderModel(model) && settings.allowedModels.length > 0) {
+				return settings.allowedModels.some((allowed) => allowed.model === model.model);
+			}
+
+			return true;
+		});
+
+		if (availableModels.length > 0) {
+			return availableModels[0];
+		}
+	}
+
+	return undefined;
 }
 
 export function createSessionFromStreamingState(streaming: ChatStreamingState): ChatHubSessionDto {

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chat.utils.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chat.utils.ts
@@ -10,7 +10,7 @@ import {
 	type ChatHubLLMProvider,
 	type ChatHubInputModality,
 	type AgentIconOrEmoji,
-	ChatProviderSettingsDto,
+	type ChatProviderSettingsDto,
 } from '@n8n/api-types';
 import type {
 	ChatMessage,

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatProvidersTable.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatProvidersTable.vue
@@ -42,7 +42,7 @@ const tableHeaders = ref<Array<TableHeader<ChatProviderSettingsDto>>>([
 	{
 		title: i18n.baseText('settings.chatHub.providers.table.provider'),
 		key: 'provider',
-		width: 80,
+		width: 120,
 		disableSort: true,
 		value() {
 			return;


### PR DESCRIPTION
## Summary

The default chat model to use was being picked from the full list of models regardless of which ones are allowed by chat settings. This was inconvenient if one set up a restricted list of chat providers / models without the first item on the list, as it would become preselected (and not work) anyways.

Now if admins configure something like
<img width="429" height="260" alt="image" src="https://github.com/user-attachments/assets/faffe18c-7927-4a97-97fb-941c10df843c" />

the expected Anthropic Opus 4.1 model would be the default selection users get when first landing on the page.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-67/bug-if-available-openai-models-are-restricted-model-selector-still

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
