### PR TITLE
fix(ai-builder): Connection validation respects node version and type

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/programmatic/evaluators/connections.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/programmatic/evaluators/connections.test.ts
@@ -122,30 +122,35 @@ describe('evaluateConnections', () => {
 			displayName: 'Manual Trigger',
 			group: ['trigger'],
 			description: 'Starts the workflow manually',
+			version: 1,
 			inputs: [],
 			outputs: [NodeConnectionTypes.Main],
 		},
 		{
 			name: 'n8n-nodes-test.code',
 			displayName: 'Code',
+			version: 1,
 			inputs: [NodeConnectionTypes.Main],
 			outputs: [NodeConnectionTypes.Main],
 		},
 		{
 			name: 'n8n-nodes-test.httpRequest',
 			displayName: 'HTTP Request',
+			version: 1,
 			inputs: [NodeConnectionTypes.Main],
 			outputs: [NodeConnectionTypes.Main],
 		},
 		{
 			name: 'n8n-nodes-test.openAi',
 			displayName: 'OpenAI',
+			version: 1,
 			inputs: `={{(() => { return [{ type: "${NodeConnectionTypes.Main}" }, { type: "${NodeConnectionTypes.AiTool}", displayName: "Tools" }]; })()}}`,
 			outputs: [NodeConnectionTypes.Main],
 		},
 		{
 			name: 'n8n-nodes-test.agent',
 			displayName: 'AI Agent',
+			version: [1, 2, 3],
 			inputs: [
 				{ type: NodeConnectionTypes.AiTool, required: true, maxConnections: -1 },
 				{ type: NodeConnectionTypes.Main },
@@ -155,12 +160,14 @@ describe('evaluateConnections', () => {
 		{
 			name: 'n8n-nodes-test.merge',
 			displayName: 'Merge',
+			version: 1,
 			inputs: `={{ Array.from({ length: $parameter.numberInputs || 2 }, (_, i) => ({ type: "${NodeConnectionTypes.Main}", displayName: \`Input $\{i + 1}\` })) }}`,
 			outputs: [NodeConnectionTypes.Main],
 		},
 		{
 			name: 'n8n-nodes-test.llmChain',
 			displayName: 'LLM Chain',
+			version: 1,
 			inputs: [
 				{ type: NodeConnectionTypes.Main },
 				{ type: NodeConnectionTypes.AiLanguageModel, required: true, maxConnections: 1 },
@@ -171,12 +178,14 @@ describe('evaluateConnections', () => {
 		{
 			name: 'n8n-nodes-test.chatOpenAi',
 			displayName: 'Chat OpenAI',
+			version: 1,
 			inputs: [],
 			outputs: [NodeConnectionTypes.AiLanguageModel],
 		},
 		{
 			name: 'n8n-nodes-test.vectorStore',
 			displayName: 'Vector Store',
+			version: [1, 1.1, 1.2, 1.3],
 			inputs: `={{
 			((parameters) => {
 				const mode = parameters?.mode;
@@ -201,6 +210,7 @@ describe('evaluateConnections', () => {
 		{
 			name: 'n8n-nodes-test.embeddingsOpenAi',
 			displayName: 'OpenAI Embeddings',
+			version: [1, 1.1, 1.2],
 			inputs: [],
 			outputs: [NodeConnectionTypes.AiEmbedding],
 		},
@@ -286,6 +296,31 @@ describe('evaluateConnections', () => {
 			expect(violations).toContainEqual(
 				expect.objectContaining({
 					description: 'Node type n8n-nodes-test.unknown not found for node Unknown Node',
+				}),
+			);
+		});
+
+		it('should detect node type with unregistered version', () => {
+			const workflow = mock<SimpleWorkflow>({
+				name: 'Test Workflow',
+				nodes: [
+					{
+						id: '1',
+						name: 'Code Node',
+						type: 'n8n-nodes-test.code',
+						parameters: {},
+						typeVersion: 99, // Version that doesn't exist
+						position: [0, 0],
+					},
+				],
+				connections: {},
+			});
+
+			const { violations } = evaluateConnections(workflow, mockNodeTypes);
+			expect(violations).toContainEqual(
+				expect.objectContaining({
+					name: 'node-type-not-found',
+					description: 'Node type n8n-nodes-test.code not found for node Code Node',
 				}),
 			);
 		});

--- a/packages/@n8n/ai-workflow-builder.ee/src/validation/checks/connections.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/validation/checks/connections.ts
@@ -3,6 +3,7 @@ import { mapConnectionsByDestination } from 'n8n-workflow';
 
 import type { SimpleWorkflow } from '@/types';
 import { isSubNode } from '@/utils/node-helpers';
+import { createNodeTypeMaps, getNodeTypeForNode } from '@/validation/utils/node-type-map';
 import { resolveNodeInputs, resolveNodeOutputs } from '@/validation/utils/resolve-connections';
 
 import type {
@@ -189,10 +190,10 @@ export function validateConnections(
 
 	const connectionsByDestination = mapConnectionsByDestination(workflow.connections);
 	const nodesByName = new Map(workflow.nodes.map((node) => [node.name, node]));
-	const nodeTypeMap = new Map(nodeTypes.map((type) => [type.name, type]));
+	const { nodeTypeMap, nodeTypesByName } = createNodeTypeMaps(nodeTypes);
 
 	for (const node of workflow.nodes) {
-		const nodeType = nodeTypeMap.get(node.type);
+		const nodeType = getNodeTypeForNode(node, nodeTypeMap, nodeTypesByName);
 		if (!nodeType) {
 			violations.push({
 				name: 'node-type-not-found',

--- a/packages/@n8n/ai-workflow-builder.ee/src/validation/utils/node-type-map.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/validation/utils/node-type-map.ts
@@ -1,0 +1,112 @@
+import type { INodeTypeDescription } from 'n8n-workflow';
+
+import type { SimpleWorkflow } from '@/types';
+
+/**
+ * Gets all versions supported by a node type.
+ * If version is a single number, returns [version].
+ * If version is an array, returns all versions.
+ * Falls back to [1] if version is not a valid number/array.
+ */
+function getNodeTypeVersions(nodeType: INodeTypeDescription): number[] {
+	const version = nodeType.version;
+
+	if (typeof version === 'number') {
+		return [version];
+	}
+
+	if (Array.isArray(version) && version.length > 0 && typeof version[0] === 'number') {
+		return version;
+	}
+
+	// Default to version 1 if version is undefined, null, or not a valid type
+	return [1];
+}
+
+/**
+ * Gets the default version for a node type.
+ * Uses defaultVersion if specified, otherwise the latest version in the array,
+ * or 1 if no version information exists.
+ */
+function getDefaultVersion(nodeType: INodeTypeDescription): number {
+	const defaultVersion = nodeType.defaultVersion;
+
+	if (typeof defaultVersion === 'number') {
+		return defaultVersion;
+	}
+
+	const versions = getNodeTypeVersions(nodeType);
+	return Math.max(...versions);
+}
+
+/**
+ * Creates a map for looking up node types by name and version.
+ * The key format is `${nodeTypeName}-${version}`.
+ *
+ * Each node type is registered for all its supported versions.
+ */
+export function createNodeTypeMap(
+	nodeTypes: INodeTypeDescription[],
+): Map<string, INodeTypeDescription> {
+	return new Map(
+		nodeTypes.flatMap((nodeType) => {
+			const versions = getNodeTypeVersions(nodeType);
+			return versions.map((version) => [`${nodeType.name}-${version}`, nodeType] as const);
+		}),
+	);
+}
+
+/**
+ * Resolves the version for a workflow node.
+ * If the node has a typeVersion, uses that.
+ * Otherwise, looks up the default version from the node type.
+ * Falls back to 1 if the node type is not found.
+ */
+function resolveNodeVersion(
+	node: SimpleWorkflow['nodes'][number],
+	nodeTypesByName: Map<string, INodeTypeDescription>,
+): number {
+	if (node.typeVersion !== undefined) {
+		return node.typeVersion;
+	}
+
+	const nodeType = nodeTypesByName.get(node.type);
+	if (nodeType) {
+		return getDefaultVersion(nodeType);
+	}
+
+	return 1;
+}
+
+/**
+ * Gets the node type for a workflow node, considering the node's version.
+ * Returns undefined if the exact version is not found.
+ */
+export function getNodeTypeForNode(
+	node: SimpleWorkflow['nodes'][number],
+	nodeTypeMap: Map<string, INodeTypeDescription>,
+	nodeTypesByName: Map<string, INodeTypeDescription>,
+): INodeTypeDescription | undefined {
+	const version = resolveNodeVersion(node, nodeTypesByName);
+	return nodeTypeMap.get(`${node.type}-${version}`);
+}
+
+/**
+ * Creates both lookup maps needed for version-aware node type resolution.
+ * Returns:
+ * - nodeTypeMap: For looking up by name and version
+ * - nodeTypesByName: For looking up by name only (used for default version resolution)
+ */
+export function createNodeTypeMaps(nodeTypes: INodeTypeDescription[]): {
+	nodeTypeMap: Map<string, INodeTypeDescription>;
+	nodeTypesByName: Map<string, INodeTypeDescription>;
+} {
+	// Convert to real array using Array.from (handles mock/proxy arrays in tests)
+	const nodeTypesArray = Array.from(nodeTypes);
+	const nodeTypeMap = createNodeTypeMap(nodeTypesArray);
+	const nodeTypesByName = new Map<string, INodeTypeDescription>(
+		nodeTypesArray.map((type) => [type.name, type] as const),
+	);
+
+	return { nodeTypeMap, nodeTypesByName };
+}


### PR DESCRIPTION
## Summary

Updating connection validation to make sure that we are checking the version as well as the node type. Nodes with multiple versions can have very different connection expectations.

Without this change the workflow builder can often get stuck on building agent nodes as the connections are all considered invalid.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
