### PR TITLE
refactor(core): Remove oversized payloads from logs

### DIFF
--- a/packages/cli/src/webhooks/webhook-request-handler.ts
+++ b/packages/cli/src/webhooks/webhook-request-handler.ts
@@ -23,7 +23,6 @@ import {
 	isWebhookResponse,
 	isWebhookStreamResponse,
 } from '@/webhooks/webhook-response';
-import { WebhookService } from '@/webhooks/webhook.service';
 import type {
 	IWebhookManager,
 	WebhookOptionsRequest,
@@ -81,10 +80,7 @@ class WebhookRequestHandler {
 			const logger = Container.get(Logger);
 
 			if (e instanceof WebhookNotFoundError) {
-				const currentlyRegistered = await Container.get(WebhookService).findAll();
-				logger.error(`Received request for unknown webhook: ${e.message}`, {
-					currentlyRegistered: currentlyRegistered.map((w) => w.display()),
-				});
+				logger.error(`Received request for unknown webhook: ${e.message}`);
 			} else {
 				logger.error(
 					`Error in handling webhook request ${req.method} ${req.path}: ${error.message}`,

--- a/packages/core/src/binary-data/object-store/object-store.service.ee.ts
+++ b/packages/core/src/binary-data/object-store/object-store.service.ee.ts
@@ -114,7 +114,8 @@ export class ObjectStoreService {
 				params.ContentType = metadata.mimeType;
 			}
 
-			this.logger.debug('Sending PUT request to S3', { params });
+			const { Body: _body, ...logParams } = params;
+			this.logger.debug('Sending PUT request to S3', { params: logParams });
 			const command = new PutObjectCommand(params);
 			return await this.s3Client.send(command);
 		} catch (e) {


### PR DESCRIPTION
While debugging internal this week, I found logs getting flooded by binary buffers and registered webhooks.