### PR TITLE
feat: Assign default project admin on pull

### DIFF
--- a/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
@@ -12,6 +12,7 @@ import type {
 import {
 	CredentialsRepository,
 	FolderRepository,
+	ProjectRelationRepository,
 	ProjectRepository,
 	SharedCredentialsRepository,
 	SharedWorkflowRepository,
@@ -23,7 +24,7 @@ import {
 	WorkflowPublishHistoryRepository,
 } from '@n8n/db';
 import { Service } from '@n8n/di';
-import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
+import { PROJECT_ADMIN_ROLE_SLUG, PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In } from '@n8n/typeorm';
 import { QueryDeepPartialEntity } from '@n8n/typeorm/query-builder/QueryPartialEntity';
@@ -144,6 +145,7 @@ export class SourceControlImportService {
 		private readonly activeWorkflowManager: ActiveWorkflowManager,
 		private readonly credentialsRepository: CredentialsRepository,
 		private readonly projectRepository: ProjectRepository,
+		private readonly projectRelationRepository: ProjectRelationRepository,
 		private readonly tagRepository: TagRepository,
 		private readonly sharedWorkflowRepository: SharedWorkflowRepository,
 		private readonly sharedCredentialsRepository: SharedCredentialsRepository,
@@ -1067,8 +1069,14 @@ export class SourceControlImportService {
 	 * Only team projects are supported.
 	 * Personal project are not supported because they are not stable across instances
 	 * (different ids across instances).
+	 *
+	 * @param candidates - The project files to import
+	 * @param pullingUserId - The ID of the user pulling the changes (will be assigned as project admin for new projects)
 	 */
-	async importTeamProjectsFromWorkFolder(candidates: SourceControlledFile[]) {
+	async importTeamProjectsFromWorkFolder(
+		candidates: SourceControlledFile[],
+		pullingUserId: string,
+	) {
 		const importResults = [];
 		const existingProjectVariables = (await this.variablesService.getAllCached()).filter(
 			(v) => v.project,
@@ -1103,6 +1111,27 @@ export class SourceControlImportService {
 					},
 					['id'],
 				);
+
+				const existingProject = await this.projectRepository.findOne({
+					where: { id: project.id },
+				});
+
+				// For newly created projects OR existing projects without an admin,
+				// assign the pulling user as project admin
+				const hasExistingAdmin =
+					existingProject &&
+					(await this.projectRelationRepository.findOne({
+						where: { projectId: project.id, role: { slug: PROJECT_ADMIN_ROLE_SLUG } },
+					}));
+
+				if (!hasExistingAdmin) {
+					await this.projectRelationRepository.save({
+						projectId: project.id,
+						userId: pullingUserId,
+						role: { slug: PROJECT_ADMIN_ROLE_SLUG },
+					});
+					this.logger.debug(`Assigned user ${pullingUserId} as admin for project ${project.name}`);
+				}
 
 				await this.importVariables(
 					project.variableStubs?.map((v) => ({ ...v, projectId: project.id })) ?? [],

--- a/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-import.service.ee.ts
@@ -661,7 +661,7 @@ export class SourceControlImportService {
 		// as project creation might cause constraint issues.
 		// We must iterate over the array and run the whole process workflow by workflow
 		for (const candidate of candidates) {
-			this.logger.debug(`Parsing workflow file ${candidate.file}`);
+			this.logger.debug(`Importing workflow file ${candidate.file}`);
 
 			const importedWorkflow = await this.parseWorkflowFromFile(candidate.file);
 

--- a/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
@@ -420,7 +420,10 @@ export class SourceControlService {
 
 		// IMPORTANT: Make sure the projects and folders get processed first as the workflows depend on them
 		const projectsToBeImported = getNonDeletedResources(statusResult, 'project');
-		await this.sourceControlImportService.importTeamProjectsFromWorkFolder(projectsToBeImported);
+		await this.sourceControlImportService.importTeamProjectsFromWorkFolder(
+			projectsToBeImported,
+			user.id,
+		);
 
 		const foldersToBeImported = getNonDeletedResources(statusResult, 'folders')[0];
 		if (foldersToBeImported) {

--- a/packages/cli/test/integration/environments/source-control-import.service.test.ts
+++ b/packages/cli/test/integration/environments/source-control-import.service.test.ts
@@ -91,6 +91,7 @@ describe('SourceControlImportService', () => {
 			mock(),
 			credentialsRepository,
 			projectRepository,
+			mock(),
 			tagRepository,
 			sharedWorkflowRepository,
 			sharedCredentialsRepository,


### PR DESCRIPTION
## Summary

When pulling a new project, the user who pulled is made project admin. 
For existing project the user who pulls is made admin only if the project doesn't already have an admin user


<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
