### PR TITLE
chore(core): Debug configuration for remote n8n process

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -59,6 +59,30 @@
 			],
 			"type": "node",
 			"request": "launch"
+		},
+		{
+			"name": "Attach to remote n8n (K8s)",
+			"type": "node",
+			"request": "attach",
+			"port": 9229,
+			"address": "localhost",
+			"localRoot": "${workspaceFolder}/packages/cli",
+			"remoteRoot": "/usr/local/lib/node_modules/n8n",
+			"skipFiles": ["<node_internals>/**"],
+			"restart": true,
+			"sourceMaps": true,
+			"resolveSourceMapLocations": [
+				"${workspaceFolder}/**",
+				"!**/node_modules/**"
+			],
+			"outFiles": [
+				"${workspaceFolder}/**/dist/**/*.js"
+			],
+			"sourceMapPathOverrides": {
+				"/usr/local/lib/node_modules/n8n/node_modules/.pnpm/@n8n+*@*/node_modules/@n8n/*": "${workspaceFolder}/packages/@n8n/*/dist",
+				"/usr/local/lib/node_modules/n8n/packages/*": "${workspaceFolder}/packages/*",
+				"/usr/local/lib/node_modules/n8n/*": "${workspaceFolder}/packages/cli/*"
+			}
 		}
 	]
 


### PR DESCRIPTION
## Summary

This new launch task allows debugging of a cloud instance in k8s. The cloud instance need to be started using `--inspect` and kubectl needs to be used to portforward port 9229 to localhost.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
