### PR TITLE
fix: Don't encrypt state for hooks calls

### DIFF
--- a/packages/cli/src/oauth/oauth.service.ts
+++ b/packages/cli/src/oauth/oauth.service.ts
@@ -181,7 +181,7 @@ export class OauthService {
 		return await this.credentialsRepository.findOneBy({ id: credentialId });
 	}
 
-	createCsrfState(data: CreateCsrfStateData): [string, string] {
+	createCsrfState(data: CreateCsrfStateData): [string, string, string] {
 		const token = new Csrf();
 		const csrfSecret = token.secretSync();
 		const state: CsrfState = {
@@ -189,8 +189,10 @@ export class OauthService {
 			createdAt: Date.now(),
 			...data,
 		};
+
+		const base64State = Buffer.from(JSON.stringify(state)).toString('base64');
 		const encryptedState = this.cipher.encrypt(JSON.stringify(state));
-		return [csrfSecret, encryptedState];
+		return [csrfSecret, encryptedState, base64State];
 	}
 
 	protected decodeCsrfState(encodedState: string, req: AuthenticatedRequest): CsrfState {
@@ -369,7 +371,7 @@ export class OauthService {
 		}
 
 		// Generate a CSRF prevention token and send it as an OAuth2 state string
-		const [csrfSecret, state] = this.createCsrfState(csrfData);
+		const [csrfSecret, state, base64State] = this.createCsrfState(csrfData);
 
 		const oAuthOptions = {
 			...this.convertCredentialToOptions(oauthCredentials),
@@ -380,7 +382,7 @@ export class OauthService {
 			oAuthOptions.query = qs.parse(oauthCredentials.authQueryParameters);
 		}
 
-		await this.externalHooks.run('oauth2.authenticate', [oAuthOptions]);
+		await this.externalHooks.run('oauth2.authenticate', [{ ...oAuthOptions, state: base64State }]);
 
 		toUpdate.csrfSecret = csrfSecret;
 		if (oauthCredentials.grantType === 'pkce') {
@@ -576,6 +578,7 @@ export class OauthService {
 		credentialResolverId: string,
 	) {
 		const credentials = new Credentials(credential, credential.type, credential.data);
+		credentials.updateData(oauthTokenData, ['csrfSecret']);
 
 		const credentialStoreMetadata: CredentialStoreMetadata = {
 			id: credential.id,


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR fixes an issue with n8n cloud hooks expecting a base64 string for hooks calls, when we actually have an encrypted state, fixed by allowing hooks to use the base64 state

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
