### PR TITLE
feat(core): Add array expansion support for fixedCollection parameters

### DIFF
--- a/packages/workflow/src/expression-array-expander.ts
+++ b/packages/workflow/src/expression-array-expander.ts
@@ -1,0 +1,87 @@
+import type { INodeParameters, NodeParameterValueType } from './interfaces';
+
+/**
+ * Checks if an object has array properties that should be expanded.
+ * Returns true if at least one property value is an array.
+ */
+export function hasExpandableArrays(obj: INodeParameters): boolean {
+	const values = Object.values(obj);
+	return values.some((v) => Array.isArray(v));
+}
+
+/**
+ * Expands an object with array properties into multiple objects by "zipping" them together.
+ * Uses the longest array length, filling shorter arrays with undefined.
+ *
+ * Example:
+ *   Input:  { name: ['A', 'B', 'C'], price: [10, 20, 30], currency: 'USD' }
+ *   Output: [
+ *     { name: 'A', price: 10, currency: 'USD' },
+ *     { name: 'B', price: 20, currency: 'USD' },
+ *     { name: 'C', price: 30, currency: 'USD' }
+ *   ]
+ */
+export function expandArraysToObjects(obj: INodeParameters): INodeParameters[] {
+	const entries = Object.entries(obj);
+	const arrayEntries = entries.filter(([_, v]) => Array.isArray(v));
+	const scalarEntries = entries.filter(([_, v]) => !Array.isArray(v));
+
+	if (arrayEntries.length === 0) {
+		return [obj];
+	}
+
+	const maxLength = Math.max(...arrayEntries.map(([_, arr]) => (arr as unknown[]).length));
+	if (maxLength === 0) {
+		return [];
+	}
+
+	const result: INodeParameters[] = [];
+	for (let i = 0; i < maxLength; i++) {
+		const newObj: INodeParameters = {};
+
+		// Add scalar values to each expanded object
+		for (const [key, value] of scalarEntries) {
+			newObj[key] = value;
+		}
+
+		// Add array values by index (undefined if array is shorter)
+		for (const [key, arr] of arrayEntries) {
+			newObj[key] = (arr as NodeParameterValueType[])[i];
+		}
+
+		result.push(newObj);
+	}
+
+	return result;
+}
+
+/**
+ * Flattens an array where some items may have been expanded into sub-arrays.
+ * This is used to flatten the parent array when child items were expanded.
+ *
+ * Example:
+ *   Input:  [ [{ a: 1 }, { a: 2 }], { b: 3 } ]
+ *   Output: [ { a: 1 }, { a: 2 }, { b: 3 } ]
+ *
+ *   Input:  [ [] ]  (empty expansion)
+ *   Output: []
+ */
+export function flattenExpandedArray<T>(arr: T[]): T[] {
+	const result: T[] = [];
+	for (const item of arr) {
+		if (Array.isArray(item)) {
+			// Flatten arrays from expansion:
+			// - Empty arrays (no items expanded) contribute nothing
+			// - Arrays of objects are flattened
+			// - Arrays of primitives are kept as-is (not from expansion)
+			if (item.length === 0 || (typeof item[0] === 'object' && item[0] !== null)) {
+				result.push(...(item as T[]));
+			} else {
+				result.push(item as T);
+			}
+		} else {
+			result.push(item);
+		}
+	}
+	return result;
+}

--- a/packages/workflow/src/extensions/expression-extension.ts
+++ b/packages/workflow/src/extensions/expression-extension.ts
@@ -60,10 +60,18 @@ const EXPRESSION_EXTENSION_REGEX = new RegExp(
 	`(\\$if|\\.(${EXPRESSION_EXTENSION_METHODS.join('|')})\\s*(\\?\\.)?)\\s*\\(`,
 );
 
+// Regex to detect [*] array mapping syntax (e.g., items[*].field)
+const ARRAY_WILDCARD_REGEX = /\[\s*\*\s*\]/;
+
+// Placeholder used to make [*] parseable by esprima
+const ARRAY_WILDCARD_PLACEHOLDER = '__n8n_array_wildcard__';
+
 const isExpressionExtension = (str: string) => EXPRESSION_EXTENSION_METHODS.some((m) => m === str);
 
 export const hasExpressionExtension = (str: string): boolean =>
 	EXPRESSION_EXTENSION_REGEX.test(str);
+
+export const hasArrayWildcardSyntax = (str: string): boolean => ARRAY_WILDCARD_REGEX.test(str);
 
 export const hasNativeMethod = (method: string): boolean => {
 	if (hasExpressionExtension(method)) {
@@ -107,6 +115,93 @@ function parseWithEsprimaNext(source: string, options?: any): any {
 }
 
 /**
+ * Checks if a MemberExpression node represents array wildcard access [*]
+ * After preprocessing, [*] becomes ["__n8n_array_wildcard__"]
+ */
+function isArrayWildcardAccess(node: types.namedTypes.MemberExpression): boolean {
+	return (
+		node.computed === true &&
+		node.property.type === 'Literal' &&
+		node.property.value === ARRAY_WILDCARD_PLACEHOLDER
+	);
+}
+
+/**
+ * Checks if a node contains an array wildcard [*] access anywhere in its chain
+ */
+function containsArrayWildcard(node: ExpressionKind): boolean {
+	if (node.type === 'MemberExpression') {
+		if (isArrayWildcardAccess(node)) {
+			return true;
+		}
+		return containsArrayWildcard(node.object);
+	}
+	return false;
+}
+
+/**
+ * Collects the JMESPath query string from member expressions following [*]
+ * Returns the path string like ".field" or ".address.city"
+ *
+ * For expression like: $json.orders[*].customer.name
+ * - baseObject = $json.orders
+ * - jmesPath = "[*].customer.name"
+ */
+function collectJmesPathFromChain(
+	node: types.namedTypes.MemberExpression,
+): { baseObject: ExpressionKind; jmesPath: string } | null {
+	// First, check if this is the topmost expression containing [*]
+	// by verifying that node contains [*] but is not itself inside another [*] chain
+	if (!containsArrayWildcard(node)) {
+		return null;
+	}
+
+	const pathParts: string[] = [];
+	let baseObject: ExpressionKind | null = null;
+
+	// Walk down the member expression chain to find [*] and collect all paths after it
+	const collectPath = (n: ExpressionKind): 'before_wildcard' | 'after_wildcard' => {
+		if (n.type === 'MemberExpression') {
+			const memberNode = n;
+
+			// Check if this is the [*] node
+			if (isArrayWildcardAccess(memberNode)) {
+				baseObject = memberNode.object;
+				return 'after_wildcard';
+			}
+
+			// Recurse into the object (go deeper first)
+			const result = collectPath(memberNode.object);
+
+			if (result === 'after_wildcard') {
+				// We're past the [*], collect this property
+				if (memberNode.property.type === 'Identifier') {
+					pathParts.push(memberNode.property.name);
+				} else if (memberNode.property.type === 'Literal') {
+					// Handle computed properties like ['field']
+					pathParts.push(String(memberNode.property.value));
+				}
+				return 'after_wildcard';
+			}
+
+			return 'before_wildcard';
+		}
+		return 'before_wildcard';
+	};
+
+	collectPath(node);
+
+	if (!baseObject || pathParts.length === 0) {
+		return null;
+	}
+
+	// Build JMESPath query: [*].field1.field2
+	const jmesPath = '[*].' + pathParts.join('.');
+
+	return { baseObject, jmesPath };
+}
+
+/**
  * A function to inject an extender function call into the AST of an expression.
  * This uses recast to do the transform.
  *
@@ -118,13 +213,63 @@ function parseWithEsprimaNext(source: string, options?: any): any {
  *
  * 'a'.first('x').second('y') // becomes
  * extend(extend('a', 'first', ['x']), 'second', ['y']));
+ *
+ * // Array wildcard syntax:
+ * items[*].field // becomes
+ * $jmesPath(items, '[*].field')
  * ```
  */
 export const extendTransform = (expression: string): { code: string } | undefined => {
 	try {
-		const ast = parse(expression, { parser: { parse: parseWithEsprimaNext } }) as types.ASTNode;
+		// Preprocess: Replace [*] with ["__n8n_array_wildcard__"] to make it parseable
+		// JavaScript doesn't allow [*] as it interprets * as multiplication operator
+		const preprocessedExpression = expression.replace(
+			ARRAY_WILDCARD_REGEX,
+			`["${ARRAY_WILDCARD_PLACEHOLDER}"]`,
+		);
+
+		const ast = parse(preprocessedExpression, {
+			parser: { parse: parseWithEsprimaNext },
+		}) as types.ASTNode;
 
 		let currentChain = 1;
+
+		// Transform array wildcard [*] syntax to $jmesPath calls
+		// e.g., $json.items[*].title -> $jmesPath($json.items, '[*].title')
+		visit(ast, {
+			visitMemberExpression(path) {
+				// First traverse children to handle nested expressions
+				this.traverse(path);
+
+				const node = path.node;
+
+				// Skip if this node is part of a larger MemberExpression chain
+				// We only want to process the topmost expression containing [*]
+				const parentNode = path.parent?.node as types.namedTypes.Node | undefined;
+				if (
+					parentNode &&
+					parentNode.type === 'MemberExpression' &&
+					(parentNode as types.namedTypes.MemberExpression).object === node
+				) {
+					// This node is the `object` of a parent MemberExpression,
+					// so we should skip it and let the parent handle the full chain
+					return;
+				}
+
+				// Check if this expression contains [*]
+				const result = collectJmesPathFromChain(node);
+
+				if (result) {
+					// Create $jmesPath(baseObject, '[*].path')
+					const jmesPathCall = types.builders.callExpression(
+						types.builders.identifier('$jmesPath'),
+						[result.baseObject, types.builders.literal(result.jmesPath)],
+					);
+
+					path.replace(jmesPathCall);
+				}
+			},
+		});
 
 		// Polyfill optional chaining
 		visit(ast, {
@@ -572,10 +717,13 @@ export function extendSyntax(bracketedExpression: string, forceExtend = false): 
 		.filter((c) => c.type === 'code')
 		.map((c) => c.text.replace(/("|').*?("|')/, '').trim());
 
-	if (
-		(!codeChunks.some(hasExpressionExtension) || hasNativeMethod(bracketedExpression)) &&
-		!forceExtend
-	) {
+	// Check if expression needs transformation:
+	// - Has extension methods (e.g., .isEmpty())
+	// - Has array wildcard syntax (e.g., [*])
+	const needsExtension =
+		codeChunks.some(hasExpressionExtension) || codeChunks.some(hasArrayWildcardSyntax);
+
+	if ((!needsExtension || hasNativeMethod(bracketedExpression)) && !forceExtend) {
 		return bracketedExpression;
 	}
 

--- a/packages/workflow/src/extensions/index.ts
+++ b/packages/workflow/src/extensions/index.ts
@@ -2,6 +2,7 @@ export {
 	extend,
 	extendOptional,
 	hasExpressionExtension,
+	hasArrayWildcardSyntax,
 	hasNativeMethod,
 	extendTransform,
 	EXTENSION_OBJECTS as ExpressionExtensions,

--- a/packages/workflow/test/ExpressionExtensions/helpers.ts
+++ b/packages/workflow/test/ExpressionExtensions/helpers.ts
@@ -1,4 +1,4 @@
-import type { IDataObject } from '../../src/interfaces';
+import type { IDataObject, NodeParameterValueType } from '../../src/interfaces';
 import { Workflow } from '../../src/workflow';
 import * as Helpers from '../helpers';
 
@@ -21,6 +21,18 @@ export const workflow = new Workflow({
 export const expression = workflow.expression;
 
 export const evaluate = (value: string, values?: IDataObject[]) =>
+	expression.getParameterValue(
+		value,
+		null,
+		0,
+		0,
+		'node',
+		values?.map((v) => ({ json: v })) ?? [],
+		'manual',
+		{},
+	);
+
+export const evaluateParam = (value: NodeParameterValueType, values?: IDataObject[]) =>
 	expression.getParameterValue(
 		value,
 		null,

--- a/packages/workflow/test/expression-array-expander.test.ts
+++ b/packages/workflow/test/expression-array-expander.test.ts
@@ -1,0 +1,150 @@
+import {
+	hasExpandableArrays,
+	expandArraysToObjects,
+	flattenExpandedArray,
+} from '../src/expression-array-expander';
+
+describe('Expression Array Expander', () => {
+	describe('hasExpandableArrays', () => {
+		test('returns true for object with array properties', () => {
+			expect(hasExpandableArrays({ name: ['A', 'B', 'C'], price: [10, 20, 30] })).toBe(true);
+		});
+
+		test('returns true for object with single array property', () => {
+			expect(hasExpandableArrays({ name: ['A', 'B', 'C'], price: 100 })).toBe(true);
+		});
+
+		test('returns false for object with no arrays', () => {
+			expect(hasExpandableArrays({ name: 'A', price: 10 })).toBe(false);
+		});
+
+		test('returns false for empty object', () => {
+			expect(hasExpandableArrays({})).toBe(false);
+		});
+	});
+
+	describe('expandArraysToObjects', () => {
+		test('zips arrays into multiple objects', () => {
+			expect(
+				expandArraysToObjects({
+					name: ['A', 'B', 'C'],
+					price: [10, 20, 30],
+				}),
+			).toEqual([
+				{ name: 'A', price: 10 },
+				{ name: 'B', price: 20 },
+				{ name: 'C', price: 30 },
+			]);
+		});
+
+		test('preserves scalar values in all expanded objects', () => {
+			expect(
+				expandArraysToObjects({
+					name: ['A', 'B'],
+					price: [10, 20],
+					currency: 'USD',
+				}),
+			).toEqual([
+				{ name: 'A', price: 10, currency: 'USD' },
+				{ name: 'B', price: 20, currency: 'USD' },
+			]);
+		});
+
+		test('handles mismatched array lengths by using longest array', () => {
+			expect(
+				expandArraysToObjects({
+					name: ['A', 'B', 'C'],
+					price: [10, 20],
+				}),
+			).toEqual([
+				{ name: 'A', price: 10 },
+				{ name: 'B', price: 20 },
+				{ name: 'C', price: undefined },
+			]);
+		});
+
+		test('handles empty arrays', () => {
+			expect(
+				expandArraysToObjects({
+					name: [],
+					price: [],
+				}),
+			).toEqual([]);
+		});
+
+		test('returns original object wrapped in array when no arrays present', () => {
+			expect(expandArraysToObjects({ name: 'A', price: 10 })).toEqual([{ name: 'A', price: 10 }]);
+		});
+
+		test('handles single array with multiple scalar values', () => {
+			expect(
+				expandArraysToObjects({
+					name: ['A', 'B', 'C'],
+					type: 'product',
+					active: true,
+				}),
+			).toEqual([
+				{ name: 'A', type: 'product', active: true },
+				{ name: 'B', type: 'product', active: true },
+				{ name: 'C', type: 'product', active: true },
+			]);
+		});
+
+		test('handles arrays with nested objects', () => {
+			expect(
+				expandArraysToObjects({
+					item: [{ id: 1 }, { id: 2 }],
+					qty: [5, 10],
+				}),
+			).toEqual([
+				{ item: { id: 1 }, qty: 5 },
+				{ item: { id: 2 }, qty: 10 },
+			]);
+		});
+	});
+
+	describe('flattenExpandedArray', () => {
+		test('flattens expanded objects into parent array', () => {
+			const input = [
+				[
+					{ name: 'A', price: 10 },
+					{ name: 'B', price: 20 },
+				],
+				{ name: 'C', price: 30 },
+			];
+			expect(flattenExpandedArray(input)).toEqual([
+				{ name: 'A', price: 10 },
+				{ name: 'B', price: 20 },
+				{ name: 'C', price: 30 },
+			]);
+		});
+
+		test('preserves non-array items', () => {
+			const input = [
+				{ name: 'A', price: 10 },
+				{ name: 'B', price: 20 },
+			];
+			expect(flattenExpandedArray(input)).toEqual([
+				{ name: 'A', price: 10 },
+				{ name: 'B', price: 20 },
+			]);
+		});
+
+		test('does not flatten nested arrays of primitives', () => {
+			// Arrays of primitives should not be flattened (they're likely intentional data)
+			const input = [[1, 2, 3], 'hello', { data: 'value' }];
+			// [1, 2, 3] is not an array of objects, so it should not be flattened
+			expect(flattenExpandedArray(input)).toEqual([[1, 2, 3], 'hello', { data: 'value' }]);
+		});
+
+		test('handles empty arrays in input (from empty expansion)', () => {
+			// Empty arrays represent "no items expanded" and should contribute nothing
+			const input = [[], { name: 'A' }];
+			expect(flattenExpandedArray(input)).toEqual([{ name: 'A' }]);
+		});
+
+		test('handles completely empty input', () => {
+			expect(flattenExpandedArray([])).toEqual([]);
+		});
+	});
+});


### PR DESCRIPTION
 ## Summary

  - Add automatic expansion of `[*]` array wildcard expressions in fixedCollection parameters
  - When multiple fields contain array expressions, they are "zipped" together to create multiple items
  - Scalar values are preserved across all expanded items

  ## Example

  **Input data:**
  ```json
  { "items": [{ "name": "A", "price": 10 }, { "name": "B", "price": 20 }] }
```
  fixedCollection config (1 template):
  ```
  { lineItemValues: [{ title: '={{ $json.items[*].name }}', price: '={{ $json.items[*].price }}', qty: 1 }] }
```
  Result (2 expanded items):
  ```
  { lineItemValues: [
    { title: 'A', price: 10, qty: 1 },
    { title: 'B', price: 20, qty: 1 }
  ]}
```

  Test plan

  - Unit tests for expression-array-expander.ts utility functions
  - Integration tests for fixedCollection array expansion
  - Manual testing with Shopify node lineItems