### PR TITLE
fix(editor): Save only once on publish

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
@@ -9,6 +9,7 @@ import {
 	MODAL_CONFIRM,
 	PLACEHOLDER_EMPTY_WORKFLOW_ID,
 	VIEWS,
+	AutoSaveState,
 } from '@/app/constants';
 import { useWorkflowHelpers } from '@/app/composables/useWorkflowHelpers';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
@@ -29,6 +30,8 @@ import { injectWorkflowState, type WorkflowState } from '@/app/composables/useWo
 import { getResourcePermissions } from '@n8n/permissions';
 import { useDebounceFn } from '@vueuse/core';
 import { useBuilderStore } from '@/features/ai/assistant/builder.store';
+import { useWorkflowAutosaveStore } from '@/app/stores/workflowAutosave.store';
+import { storeToRefs } from 'pinia';
 
 export function useWorkflowSaving({
 	router,
@@ -53,6 +56,9 @@ export function useWorkflowSaving({
 	const builderStore = useBuilderStore();
 	const { getWorkflowDataToSave, checkConflictingWebhooks, getWorkflowProjectRole } =
 		useWorkflowHelpers();
+
+	const autosaveStore = useWorkflowAutosaveStore();
+	const { autoSaveState, pendingAutoSave } = storeToRefs(autosaveStore);
 
 	async function promptSaveUnsavedWorkflowChanges(
 		next: NavigationGuardNext,
@@ -425,21 +431,51 @@ export function useWorkflowSaving({
 		}
 	}
 
-	const autoSaveWorkflow = useDebounceFn(
-		async () => {
-			const saved = await saveCurrentWorkflow({}, true, false, true);
-			if (saved) {
-				console.log('[AutoSave] ✅ Workflow saved successfully');
+	const autoSaveWorkflowDebounced = useDebounceFn(
+		() => {
+			// Check if cancelled during debounce period
+			if (autoSaveState.value === AutoSaveState.Idle) {
+				console.log('[AutoSave] Cancelled during debounce');
+				return;
 			}
+
+			autosaveStore.setAutoSaveState(AutoSaveState.InProgress);
+
+			const savePromise = (async () => {
+				try {
+					const saved = await saveCurrentWorkflow({}, true, false, true);
+					if (saved) {
+						console.log('[AutoSave] ✅ Workflow saved successfully');
+					}
+				} finally {
+					autosaveStore.setAutoSaveState(AutoSaveState.Idle);
+					autosaveStore.setPendingAutoSave(null);
+				}
+			})();
+
+			autosaveStore.setPendingAutoSave(savePromise);
 		},
 		1500,
 		{ maxWait: 5000 },
 	);
 
+	const scheduleAutoSave = () => {
+		autosaveStore.setAutoSaveState(AutoSaveState.Scheduled);
+		void autoSaveWorkflowDebounced();
+	};
+
+	const cancelAutoSave = () => {
+		(autoSaveWorkflowDebounced as { cancel?: () => void }).cancel?.();
+		autosaveStore.setAutoSaveState(AutoSaveState.Idle);
+	};
+
 	return {
 		promptSaveUnsavedWorkflowChanges,
 		saveCurrentWorkflow,
 		saveAsNewWorkflow,
-		autoSaveWorkflow,
+		autoSaveWorkflow: scheduleAutoSave,
+		autoSaveState,
+		cancelAutoSave,
+		pendingAutoSave,
 	};
 }

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
@@ -24,6 +24,7 @@ import { useExternalHooks } from './useExternalHooks';
 import { useTelemetry } from './useTelemetry';
 import { useNodeHelpers } from './useNodeHelpers';
 import { tryToParseNumber } from '@/app/utils/typesUtils';
+import { isDebouncedFunction } from '@/app/utils/typeGuards';
 import { useTemplatesStore } from '@/features/workflows/templates/templates.store';
 import { useFocusPanelStore } from '@/app/stores/focusPanel.store';
 import { injectWorkflowState, type WorkflowState } from '@/app/composables/useWorkflowState';
@@ -465,7 +466,9 @@ export function useWorkflowSaving({
 	};
 
 	const cancelAutoSave = () => {
-		(autoSaveWorkflowDebounced as { cancel?: () => void }).cancel?.();
+		if (isDebouncedFunction(autoSaveWorkflowDebounced)) {
+			autoSaveWorkflowDebounced.cancel();
+		}
 		autosaveStore.setAutoSaveState(AutoSaveState.Idle);
 	};
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
@@ -32,7 +32,6 @@ import { getResourcePermissions } from '@n8n/permissions';
 import { useDebounceFn } from '@vueuse/core';
 import { useBuilderStore } from '@/features/ai/assistant/builder.store';
 import { useWorkflowAutosaveStore } from '@/app/stores/workflowAutosave.store';
-import { storeToRefs } from 'pinia';
 
 export function useWorkflowSaving({
 	router,
@@ -59,7 +58,6 @@ export function useWorkflowSaving({
 		useWorkflowHelpers();
 
 	const autosaveStore = useWorkflowAutosaveStore();
-	const { autoSaveState, pendingAutoSave } = storeToRefs(autosaveStore);
 
 	async function promptSaveUnsavedWorkflowChanges(
 		next: NavigationGuardNext,
@@ -435,7 +433,7 @@ export function useWorkflowSaving({
 	const autoSaveWorkflowDebounced = useDebounceFn(
 		() => {
 			// Check if cancelled during debounce period
-			if (autoSaveState.value === AutoSaveState.Idle) {
+			if (autosaveStore.autoSaveState === AutoSaveState.Idle) {
 				console.log('[AutoSave] Cancelled during debounce');
 				return;
 			}
@@ -477,8 +475,6 @@ export function useWorkflowSaving({
 		saveCurrentWorkflow,
 		saveAsNewWorkflow,
 		autoSaveWorkflow: scheduleAutoSave,
-		autoSaveState,
 		cancelAutoSave,
-		pendingAutoSave,
 	};
 }

--- a/packages/frontend/editor-ui/src/app/constants/workflows.ts
+++ b/packages/frontend/editor-ui/src/app/constants/workflows.ts
@@ -14,3 +14,9 @@ export const WORKFLOWS_DRAFT_PUBLISH_ENABLED_FLAG = 'WORKFLOWS_DRAFT_PUBLISH_ENA
 // make sure to drop the activeChange and activeChangeCurrent external hooks
 // double check that onWorkflowActivate is never called in NodeDetailsViewV2.vue and NodeDetailsView.vue and clean it up
 export const IS_DRAFT_PUBLISH_ENABLED = true;
+
+export const enum AutoSaveState {
+	Idle = 'idle',
+	Scheduled = 'scheduled',
+	InProgress = 'in-progress',
+}

--- a/packages/frontend/editor-ui/src/app/stores/workflowAutosave.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowAutosave.store.ts
@@ -1,0 +1,38 @@
+import { defineStore } from 'pinia';
+import { ref, watch } from 'vue';
+import { AutoSaveState } from '@/app/constants';
+
+/**
+ * Store for managing workflow autosave state.
+ * This ensures all components share the same autosave state across the app.
+ */
+export const useWorkflowAutosaveStore = defineStore('workflowAutosave', () => {
+	const autoSaveState = ref<AutoSaveState>(AutoSaveState.Idle);
+	const pendingAutoSave = ref<Promise<void> | null>(null);
+
+	// Log state changes for debugging
+	watch(autoSaveState, (newState, oldState) => {
+		console.log('[AutoSave] State changed:', oldState, '→', newState);
+	});
+
+	function setAutoSaveState(state: AutoSaveState) {
+		autoSaveState.value = state;
+	}
+
+	function setPendingAutoSave(promise: Promise<void> | null) {
+		pendingAutoSave.value = promise;
+	}
+
+	function reset() {
+		autoSaveState.value = AutoSaveState.Idle;
+		pendingAutoSave.value = null;
+	}
+
+	return {
+		autoSaveState,
+		pendingAutoSave,
+		setAutoSaveState,
+		setPendingAutoSave,
+		reset,
+	};
+});

--- a/packages/frontend/editor-ui/src/app/utils/typeGuards.ts
+++ b/packages/frontend/editor-ui/src/app/utils/typeGuards.ts
@@ -160,3 +160,11 @@ export function isTeamProjectRole(role: string): role is TeamProjectRole {
 
 export const isWorkflowListItem = (resource: WorkflowListResource): resource is WorkflowListItem =>
 	'resource' in resource ? resource.resource !== 'folder' : true;
+
+export function isDebouncedFunction(fn: unknown): fn is { cancel: () => void } {
+	return (
+		typeof fn === 'function' &&
+		'cancel' in fn &&
+		typeof (fn as Record<string, unknown>).cancel === 'function'
+	);
+}


### PR DESCRIPTION
## Summary

This PR introduces a separate store for autosave to be able to track its state in different components. During publish we check whether autosave is already running or not, and save the workflow immediately only if needed.

Console logs will be removed later.

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-4558](https://linear.app/n8n/issue/ADO-4558/bug-save-on-publishing-does-not-cancel-scheduled-autosave)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
