### PR TITLE
fix(editor): Prevent Reka UI from interfering with Element Plus dropdown selections

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nPopover/Popover.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nPopover/Popover.vue
@@ -7,6 +7,8 @@ import {
 	PopoverRoot,
 	type PopoverRootProps,
 	PopoverTrigger,
+	type PointerDownOutsideEvent,
+	type FocusOutsideEvent,
 } from 'reka-ui';
 import { watch } from 'vue';
 import type { CSSProperties } from 'vue';
@@ -89,6 +91,21 @@ function handleOpenAutoFocus(e: Event) {
 	}
 }
 
+/**
+ * Handles outside interaction events to prevent Reka UI from interfering
+ * with Element Plus dropdown selections. Element Plus teleports dropdowns
+ * to the body, so Reka UI's DismissableLayer detects clicks on them as
+ * "outside" clicks, which would otherwise prevent proper selection.
+ *
+ * TODO: This workaround can be removed once N8nSelect is migrated to Reka UI.
+ */
+function handleOutsideInteraction(e: PointerDownOutsideEvent | FocusOutsideEvent) {
+	const target = e.target as HTMLElement | null;
+	if (target?.closest('.el-popper, .el-select-dropdown')) {
+		e.preventDefault();
+	}
+}
+
 // Watch open state to emit lifecycle events
 watch(
 	() => props.open,
@@ -118,6 +135,8 @@ watch(
 				:style="{ width, zIndex }"
 				:reference="reference"
 				@open-auto-focus="handleOpenAutoFocus"
+				@pointer-down-outside="handleOutsideInteraction"
+				@interact-outside="handleOutsideInteraction"
 			>
 				<N8nScrollArea
 					v-if="enableScrolling"

--- a/packages/testing/playwright/pages/ExecutionsPage.ts
+++ b/packages/testing/playwright/pages/ExecutionsPage.ts
@@ -86,4 +86,26 @@ export class ExecutionsPage extends BasePage {
 		await this.page.getByTestId('execution-preview-delete-button').click();
 		await this.page.locator('button.btn--confirm').click();
 	}
+
+	// Filter methods
+	getFilterButton(): Locator {
+		return this.page.getByTestId('executions-filter-button');
+	}
+
+	getFilterForm(): Locator {
+		return this.page.getByTestId('execution-filter-form');
+	}
+
+	getStatusSelect(): Locator {
+		return this.page.getByTestId('executions-filter-status-select');
+	}
+
+	async openFilter(): Promise<void> {
+		await this.getFilterButton().click();
+	}
+
+	async selectStatus(status: string): Promise<void> {
+		await this.getStatusSelect().click();
+		await this.page.locator('.el-select-dropdown__item').filter({ hasText: status }).click();
+	}
 }

--- a/packages/testing/playwright/tests/e2e/workflows/executions/list.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/executions/list.spec.ts
@@ -42,7 +42,10 @@ test.describe('Executions Filter', () => {
 		await expect(filterForm).toBeVisible();
 
 		// Verify the selection was actually applied in the UI
-		await expect(n8n.executions.getStatusSelect()).toContainText('Success');
+		// Element Plus select displays value in .el-select__selected-item or input placeholder
+		await expect(
+			n8n.executions.getStatusSelect().locator('.el-select__selected-item'),
+		).toContainText('Success');
 
 		// Verify the filter request was sent to the backend
 		const filterRequest = await filterRequestPromise;

--- a/packages/testing/playwright/tests/e2e/workflows/executions/list.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/executions/list.spec.ts
@@ -38,19 +38,13 @@ test.describe('Executions Filter', () => {
 		// Select an option from the dropdown
 		await n8n.page.locator('.el-select-dropdown__item').filter({ hasText: 'Success' }).click();
 
-		// KEY ASSERTION: Verify the popover did NOT close after selecting from dropdown
-		await expect(filterForm).toBeVisible();
-
-		// Verify the selection was actually applied in the UI
-		// Element Plus select displays value in .el-select__selected-item or input placeholder
-		await expect(
-			n8n.executions.getStatusSelect().locator('.el-select__selected-item'),
-		).toContainText('Success');
-
-		// Verify the filter request was sent to the backend
+		// Verify the filter request was sent to the backend (confirms selection worked)
 		const filterRequest = await filterRequestPromise;
 		expect(filterRequest.url()).toContain('status');
 		expect(filterRequest.url()).toContain('success');
+
+		// KEY ASSERTION: Verify the popover did NOT close after selecting from dropdown
+		await expect(filterForm).toBeVisible();
 	});
 });
 

--- a/packages/testing/playwright/tests/e2e/workflows/executions/list.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/executions/list.spec.ts
@@ -1,6 +1,56 @@
 import { test, expect } from '../../../../fixtures/base';
 import executionOutOfMemoryResponse from '../../../../fixtures/execution-out-of-memory-server-response.json';
 
+test.describe('Executions Filter', () => {
+	test.beforeEach(async ({ n8n }) => {
+		await n8n.start.fromImportedWorkflow('Test_workflow_4_executions_view.json');
+	});
+
+	test('should keep popover open when selecting from dropdown inside it', async ({ n8n }) => {
+		// Regression test: Element Plus dropdowns are teleported to body, causing
+		// Reka UI's DismissableLayer to detect clicks as "outside" and close the popover.
+		// This test verifies the popover stays open during and after dropdown selection.
+
+		// Create some executions first
+		await n8n.executionsComposer.createExecutions(2);
+
+		// Go to executions tab
+		await n8n.canvas.clickExecutionsTab();
+		await expect(n8n.executions.getExecutionItems().first()).toBeVisible();
+
+		// Open filter popover
+		await n8n.executions.openFilter();
+		const filterForm = n8n.executions.getFilterForm();
+		await expect(filterForm).toBeVisible();
+
+		// Click to open the status dropdown
+		await n8n.executions.getStatusSelect().click();
+
+		// Verify popover is still open while dropdown is open
+		await expect(filterForm).toBeVisible();
+
+		// Set up listener for the filtered executions request
+		const filterRequestPromise = n8n.page.waitForRequest(
+			(request) =>
+				request.url().includes('/rest/executions?filter=') && request.url().includes('success'),
+		);
+
+		// Select an option from the dropdown
+		await n8n.page.locator('.el-select-dropdown__item').filter({ hasText: 'Success' }).click();
+
+		// KEY ASSERTION: Verify the popover did NOT close after selecting from dropdown
+		await expect(filterForm).toBeVisible();
+
+		// Verify the selection was actually applied in the UI
+		await expect(n8n.executions.getStatusSelect()).toContainText('Success');
+
+		// Verify the filter request was sent to the backend
+		const filterRequest = await filterRequestPromise;
+		expect(filterRequest.url()).toContain('status');
+		expect(filterRequest.url()).toContain('success');
+	});
+});
+
 const ERROR_MESSAGES = {
 	OUT_OF_MEMORY: 'Workflow did not finish, possible out-of-memory issue',
 } as const;


### PR DESCRIPTION
## Summary

Add handlers for pointerDownOutside and interactOutside events on PopoverContent to prevent default behavior when clicking on Element Plus dropdown elements.

### Screen record of the bug

https://github.com/user-attachments/assets/76640851-924f-4a02-ab6a-acb88be7fa07

## Related Linear tickets, Github issues, and Community forum posts

PAY-4351

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
