### PR TITLE
feat(core): Add log streaming events for executions

### DIFF
--- a/packages/cli/src/eventbus/event-message-classes/index.ts
+++ b/packages/cli/src/eventbus/event-message-classes/index.ts
@@ -76,7 +76,7 @@ export const eventNamesAudit = [
 	'n8n.audit.user.mfa.enabled',
 	'n8n.audit.user.mfa.disabled',
 	'n8n.audit.user.execution.deleted',
-	'n8n.audit.user.workflow.executed',
+	'n8n.audit.workflow.executed',
 	'n8n.audit.package.installed',
 	'n8n.audit.package.updated',
 	'n8n.audit.package.deleted',

--- a/packages/cli/src/eventbus/event-message-classes/index.ts
+++ b/packages/cli/src/eventbus/event-message-classes/index.ts
@@ -75,6 +75,8 @@ export const eventNamesAudit = [
 	'n8n.audit.user.api.deleted',
 	'n8n.audit.user.mfa.enabled',
 	'n8n.audit.user.mfa.disabled',
+	'n8n.audit.user.execution.deleted',
+	'n8n.audit.user.workflow.executed',
 	'n8n.audit.package.installed',
 	'n8n.audit.package.updated',
 	'n8n.audit.package.deleted',

--- a/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
@@ -1447,8 +1447,8 @@ describe('LogStreamingEventRelay', () => {
 			});
 		});
 
-		it('should log on `workflow-executed-by-user` event for manual execution', () => {
-			const event: RelayEventMap['workflow-executed-by-user'] = {
+		it('should log on `workflow-executed` event for manual user execution', () => {
+			const event: RelayEventMap['workflow-executed'] = {
 				user: {
 					id: 'user789',
 					email: 'executor@example.com',
@@ -1459,13 +1459,13 @@ describe('LogStreamingEventRelay', () => {
 				workflowId: 'wf-manual',
 				workflowName: 'Manual Test Workflow',
 				executionId: 'exec-manual-123',
-				executionMode: 'manual',
+				source: 'user-manual',
 			};
 
-			eventService.emit('workflow-executed-by-user', event);
+			eventService.emit('workflow-executed', event);
 
 			expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
-				eventName: 'n8n.audit.user.workflow.executed',
+				eventName: 'n8n.audit.workflow.executed',
 				payload: {
 					userId: 'user789',
 					_email: 'executor@example.com',
@@ -1475,13 +1475,13 @@ describe('LogStreamingEventRelay', () => {
 					workflowId: 'wf-manual',
 					workflowName: 'Manual Test Workflow',
 					executionId: 'exec-manual-123',
-					executionMode: 'manual',
+					source: 'user-manual',
 				},
 			});
 		});
 
-		it('should log on `workflow-executed-by-user` event for retry execution', () => {
-			const event: RelayEventMap['workflow-executed-by-user'] = {
+		it('should log on `workflow-executed` event for retry user execution', () => {
+			const event: RelayEventMap['workflow-executed'] = {
 				user: {
 					id: 'user101',
 					email: 'retrier@example.com',
@@ -1492,13 +1492,13 @@ describe('LogStreamingEventRelay', () => {
 				workflowId: 'wf-retry',
 				workflowName: 'Retry Test Workflow',
 				executionId: 'exec-retry-456',
-				executionMode: 'retry',
+				source: 'user-retry',
 			};
 
-			eventService.emit('workflow-executed-by-user', event);
+			eventService.emit('workflow-executed', event);
 
 			expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
-				eventName: 'n8n.audit.user.workflow.executed',
+				eventName: 'n8n.audit.workflow.executed',
 				payload: {
 					userId: 'user101',
 					_email: 'retrier@example.com',
@@ -1508,7 +1508,7 @@ describe('LogStreamingEventRelay', () => {
 					workflowId: 'wf-retry',
 					workflowName: 'Retry Test Workflow',
 					executionId: 'exec-retry-456',
-					executionMode: 'retry',
+					source: 'user-retry',
 				},
 			});
 		});

--- a/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
@@ -1447,8 +1447,8 @@ describe('LogStreamingEventRelay', () => {
 			});
 		});
 
-		it('should log on `workflow-executed` event for manual execution', () => {
-			const event: RelayEventMap['workflow-executed'] = {
+		it('should log on `workflow-executed-by-user` event for manual execution', () => {
+			const event: RelayEventMap['workflow-executed-by-user'] = {
 				user: {
 					id: 'user789',
 					email: 'executor@example.com',
@@ -1462,7 +1462,7 @@ describe('LogStreamingEventRelay', () => {
 				executionMode: 'manual',
 			};
 
-			eventService.emit('workflow-executed', event);
+			eventService.emit('workflow-executed-by-user', event);
 
 			expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
 				eventName: 'n8n.audit.user.workflow.executed',
@@ -1480,8 +1480,8 @@ describe('LogStreamingEventRelay', () => {
 			});
 		});
 
-		it('should log on `workflow-executed` event for retry execution', () => {
-			const event: RelayEventMap['workflow-executed'] = {
+		it('should log on `workflow-executed-by-user` event for retry execution', () => {
+			const event: RelayEventMap['workflow-executed-by-user'] = {
 				user: {
 					id: 'user101',
 					email: 'retrier@example.com',
@@ -1495,7 +1495,7 @@ describe('LogStreamingEventRelay', () => {
 				executionMode: 'retry',
 			};
 
-			eventService.emit('workflow-executed', event);
+			eventService.emit('workflow-executed-by-user', event);
 
 			expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
 				eventName: 'n8n.audit.user.workflow.executed',

--- a/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
@@ -1359,6 +1359,7 @@ describe('LogStreamingEventRelay', () => {
 					_lastName: 'User',
 					globalRole: 'global:owner',
 					executionIds: ['exec1', 'exec2'],
+					deleteBefore: undefined,
 				},
 			});
 		});
@@ -1386,6 +1387,7 @@ describe('LogStreamingEventRelay', () => {
 					_lastName: 'Deleter',
 					globalRole: 'global:member',
 					executionIds: ['exec-single'],
+					deleteBefore: undefined,
 				},
 			});
 		});
@@ -1413,6 +1415,37 @@ describe('LogStreamingEventRelay', () => {
 					_lastName: 'Deleter',
 					globalRole: 'global:owner',
 					executionIds: [],
+					deleteBefore: undefined,
+				},
+			});
+		});
+
+		it('should log on `execution-deleted` event with deleteBefore date filter', () => {
+			const deleteBefore = new Date('2024-01-01T00:00:00.000Z');
+			const event: RelayEventMap['execution-deleted'] = {
+				user: {
+					id: 'user999',
+					email: 'datefilter@example.com',
+					firstName: 'Date',
+					lastName: 'Filter',
+					role: { slug: 'global:owner' },
+				},
+				executionIds: [],
+				deleteBefore,
+			};
+
+			eventService.emit('execution-deleted', event);
+
+			expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
+				eventName: 'n8n.audit.user.execution.deleted',
+				payload: {
+					userId: 'user999',
+					_email: 'datefilter@example.com',
+					_firstName: 'Date',
+					_lastName: 'Filter',
+					globalRole: 'global:owner',
+					executionIds: [],
+					deleteBefore: '2024-01-01T00:00:00.000Z',
 				},
 			});
 		});

--- a/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
@@ -1359,7 +1359,6 @@ describe('LogStreamingEventRelay', () => {
 					_lastName: 'User',
 					globalRole: 'global:owner',
 					executionIds: ['exec1', 'exec2'],
-					deleteBefore: undefined,
 				},
 			});
 		});
@@ -1387,7 +1386,6 @@ describe('LogStreamingEventRelay', () => {
 					_lastName: 'Deleter',
 					globalRole: 'global:member',
 					executionIds: ['exec-single'],
-					deleteBefore: undefined,
 				},
 			});
 		});
@@ -1415,7 +1413,6 @@ describe('LogStreamingEventRelay', () => {
 					_lastName: 'Deleter',
 					globalRole: 'global:owner',
 					executionIds: [],
-					deleteBefore: undefined,
 				},
 			});
 		});

--- a/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
@@ -1335,6 +1335,153 @@ describe('LogStreamingEventRelay', () => {
 				});
 			},
 		);
+
+		it('should log on `execution-deleted` event with multiple execution ids', () => {
+			const event: RelayEventMap['execution-deleted'] = {
+				user: {
+					id: 'user123',
+					email: 'user@example.com',
+					firstName: 'Test',
+					lastName: 'User',
+					role: { slug: 'global:owner' },
+				},
+				executionIds: ['exec1', 'exec2'],
+			};
+
+			eventService.emit('execution-deleted', event);
+
+			expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
+				eventName: 'n8n.audit.user.execution.deleted',
+				payload: {
+					userId: 'user123',
+					_email: 'user@example.com',
+					_firstName: 'Test',
+					_lastName: 'User',
+					globalRole: 'global:owner',
+					executionIds: ['exec1', 'exec2'],
+				},
+			});
+		});
+
+		it('should log on `execution-deleted` event with single execution id', () => {
+			const event: RelayEventMap['execution-deleted'] = {
+				user: {
+					id: 'user789',
+					email: 'singledelete@example.com',
+					firstName: 'Single',
+					lastName: 'Deleter',
+					role: { slug: 'global:member' },
+				},
+				executionIds: ['exec-single'],
+			};
+
+			eventService.emit('execution-deleted', event);
+
+			expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
+				eventName: 'n8n.audit.user.execution.deleted',
+				payload: {
+					userId: 'user789',
+					_email: 'singledelete@example.com',
+					_firstName: 'Single',
+					_lastName: 'Deleter',
+					globalRole: 'global:member',
+					executionIds: ['exec-single'],
+				},
+			});
+		});
+
+		it('should log on `execution-deleted` event with empty execution ids array', () => {
+			const event: RelayEventMap['execution-deleted'] = {
+				user: {
+					id: 'user456',
+					email: 'bulkdelete@example.com',
+					firstName: 'Bulk',
+					lastName: 'Deleter',
+					role: { slug: 'global:owner' },
+				},
+				executionIds: [],
+			};
+
+			eventService.emit('execution-deleted', event);
+
+			expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
+				eventName: 'n8n.audit.user.execution.deleted',
+				payload: {
+					userId: 'user456',
+					_email: 'bulkdelete@example.com',
+					_firstName: 'Bulk',
+					_lastName: 'Deleter',
+					globalRole: 'global:owner',
+					executionIds: [],
+				},
+			});
+		});
+
+		it('should log on `workflow-executed` event for manual execution', () => {
+			const event: RelayEventMap['workflow-executed'] = {
+				user: {
+					id: 'user789',
+					email: 'executor@example.com',
+					firstName: 'Manual',
+					lastName: 'Executor',
+					role: { slug: 'global:member' },
+				},
+				workflowId: 'wf-manual',
+				workflowName: 'Manual Test Workflow',
+				executionId: 'exec-manual-123',
+				executionMode: 'manual',
+			};
+
+			eventService.emit('workflow-executed', event);
+
+			expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
+				eventName: 'n8n.audit.user.workflow.executed',
+				payload: {
+					userId: 'user789',
+					_email: 'executor@example.com',
+					_firstName: 'Manual',
+					_lastName: 'Executor',
+					globalRole: 'global:member',
+					workflowId: 'wf-manual',
+					workflowName: 'Manual Test Workflow',
+					executionId: 'exec-manual-123',
+					executionMode: 'manual',
+				},
+			});
+		});
+
+		it('should log on `workflow-executed` event for retry execution', () => {
+			const event: RelayEventMap['workflow-executed'] = {
+				user: {
+					id: 'user101',
+					email: 'retrier@example.com',
+					firstName: 'Retry',
+					lastName: 'User',
+					role: { slug: GLOBAL_OWNER_ROLE.slug },
+				},
+				workflowId: 'wf-retry',
+				workflowName: 'Retry Test Workflow',
+				executionId: 'exec-retry-456',
+				executionMode: 'retry',
+			};
+
+			eventService.emit('workflow-executed', event);
+
+			expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
+				eventName: 'n8n.audit.user.workflow.executed',
+				payload: {
+					userId: 'user101',
+					_email: 'retrier@example.com',
+					_firstName: 'Retry',
+					_lastName: 'User',
+					globalRole: 'global:owner',
+					workflowId: 'wf-retry',
+					workflowName: 'Retry Test Workflow',
+					executionId: 'exec-retry-456',
+					executionMode: 'retry',
+				},
+			});
+		});
 	});
 
 	describe('AI events', () => {

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -125,12 +125,22 @@ export type RelayEventMap = {
 		userIdList: string[];
 	};
 
-	'workflow-executed-by-user': {
-		user: UserLike;
+	'workflow-executed': {
+		user?: UserLike;
 		workflowId: string;
 		workflowName: string;
 		executionId: string;
-		executionMode: 'manual' | 'retry';
+		source:
+			| 'user-manual'
+			| 'user-retry'
+			| 'webhook'
+			| 'trigger'
+			| 'error'
+			| 'cli'
+			| 'integrated'
+			| 'internal'
+			| 'evaluation'
+			| 'chat';
 	};
 
 	// #endregion

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -125,7 +125,7 @@ export type RelayEventMap = {
 		userIdList: string[];
 	};
 
-	'workflow-executed': {
+	'workflow-executed-by-user': {
 		user: UserLike;
 		workflowId: string;
 		workflowName: string;

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -130,17 +130,16 @@ export type RelayEventMap = {
 		workflowId: string;
 		workflowName: string;
 		executionId: string;
-		source:
-			| 'user-manual'
-			| 'user-retry'
-			| 'webhook'
-			| 'trigger'
-			| 'error'
-			| 'cli'
-			| 'integrated'
-			| 'internal'
-			| 'evaluation'
-			| 'chat';
+		source: 'user-manual' | 'user-retry';
+		// TODO: To be added in future PR
+		// | 'webhook'
+		// | 'trigger'
+		// | 'error'
+		// | 'cli'
+		// | 'integrated'
+		// | 'internal'
+		// | 'evaluation'
+		// | 'chat';
 	};
 
 	// #endregion

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -125,6 +125,14 @@ export type RelayEventMap = {
 		userIdList: string[];
 	};
 
+	'workflow-executed': {
+		user: UserLike;
+		workflowId: string;
+		workflowName: string;
+		executionId: string;
+		executionMode: 'manual' | 'retry';
+	};
+
 	// #endregion
 
 	// #region Node
@@ -416,14 +424,6 @@ export type RelayEventMap = {
 		user: UserLike;
 		executionIds: string[];
 		deleteBefore?: Date;
-	};
-
-	'workflow-executed': {
-		user: UserLike;
-		workflowId: string;
-		workflowName: string;
-		executionId: string;
-		executionMode: 'manual' | 'retry';
 	};
 
 	// #endregion

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -412,6 +412,19 @@ export type RelayEventMap = {
 		reason: CancellationReason;
 	};
 
+	'execution-deleted': {
+		user: UserLike;
+		executionIds: string[];
+	};
+
+	'workflow-executed': {
+		user: UserLike;
+		workflowId: string;
+		workflowName: string;
+		executionId: string;
+		executionMode: 'manual' | 'retry';
+	};
+
 	// #endregion
 
 	// #region Project

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -415,6 +415,7 @@ export type RelayEventMap = {
 	'execution-deleted': {
 		user: UserLike;
 		executionIds: string[];
+		deleteBefore?: Date;
 	};
 
 	'workflow-executed': {

--- a/packages/cli/src/events/relays/log-streaming.event-relay.ts
+++ b/packages/cli/src/events/relays/log-streaming.event-relay.ts
@@ -29,7 +29,7 @@ export class LogStreamingEventRelay extends EventRelay {
 			'workflow-saved': (event) => this.workflowSaved(event),
 			'workflow-pre-execute': (event) => this.workflowPreExecute(event),
 			'workflow-post-execute': (event) => this.workflowPostExecute(event),
-			'workflow-executed': (event) => this.workflowExecuted(event),
+			'workflow-executed-by-user': (event) => this.workflowExecutedByUser(event),
 			'node-pre-execute': (event) => this.nodePreExecute(event),
 			'node-post-execute': (event) => this.nodePostExecute(event),
 			'user-deleted': (event) => this.userDeleted(event),
@@ -245,13 +245,13 @@ export class LogStreamingEventRelay extends EventRelay {
 	}
 
 	@Redactable()
-	private workflowExecuted({
+	private workflowExecutedByUser({
 		user,
 		workflowId,
 		workflowName,
 		executionId,
 		executionMode,
-	}: RelayEventMap['workflow-executed']) {
+	}: RelayEventMap['workflow-executed-by-user']) {
 		void this.eventBus.sendAuditEvent({
 			eventName: 'n8n.audit.user.workflow.executed',
 			payload: { ...user, workflowId, workflowName, executionId, executionMode },

--- a/packages/cli/src/events/relays/log-streaming.event-relay.ts
+++ b/packages/cli/src/events/relays/log-streaming.event-relay.ts
@@ -29,7 +29,7 @@ export class LogStreamingEventRelay extends EventRelay {
 			'workflow-saved': (event) => this.workflowSaved(event),
 			'workflow-pre-execute': (event) => this.workflowPreExecute(event),
 			'workflow-post-execute': (event) => this.workflowPostExecute(event),
-			'workflow-executed-by-user': (event) => this.workflowExecutedByUser(event),
+			'workflow-executed': (event) => this.workflowExecuted(event),
 			'node-pre-execute': (event) => this.nodePreExecute(event),
 			'node-post-execute': (event) => this.nodePostExecute(event),
 			'user-deleted': (event) => this.userDeleted(event),
@@ -245,16 +245,22 @@ export class LogStreamingEventRelay extends EventRelay {
 	}
 
 	@Redactable()
-	private workflowExecutedByUser({
+	private workflowExecuted({
 		user,
 		workflowId,
 		workflowName,
 		executionId,
-		executionMode,
-	}: RelayEventMap['workflow-executed-by-user']) {
+		source,
+	}: RelayEventMap['workflow-executed']) {
 		void this.eventBus.sendAuditEvent({
-			eventName: 'n8n.audit.user.workflow.executed',
-			payload: { ...user, workflowId, workflowName, executionId, executionMode },
+			eventName: 'n8n.audit.workflow.executed',
+			payload: {
+				...(user && { ...user }),
+				workflowId,
+				workflowName,
+				executionId,
+				source,
+			},
 		});
 	}
 

--- a/packages/cli/src/events/relays/log-streaming.event-relay.ts
+++ b/packages/cli/src/events/relays/log-streaming.event-relay.ts
@@ -29,6 +29,7 @@ export class LogStreamingEventRelay extends EventRelay {
 			'workflow-saved': (event) => this.workflowSaved(event),
 			'workflow-pre-execute': (event) => this.workflowPreExecute(event),
 			'workflow-post-execute': (event) => this.workflowPostExecute(event),
+			'workflow-executed': (event) => this.workflowExecuted(event),
 			'node-pre-execute': (event) => this.nodePreExecute(event),
 			'node-post-execute': (event) => this.nodePostExecute(event),
 			'user-deleted': (event) => this.userDeleted(event),
@@ -57,7 +58,6 @@ export class LogStreamingEventRelay extends EventRelay {
 			'execution-started-during-bootup': (event) => this.executionStartedDuringBootup(event),
 			'execution-cancelled': (event) => this.executionCancelled(event),
 			'execution-deleted': (event) => this.executionDeleted(event),
-			'workflow-executed': (event) => this.workflowExecuted(event),
 			'ai-messages-retrieved-from-memory': (event) => this.aiMessagesRetrievedFromMemory(event),
 			'ai-message-added-to-memory': (event) => this.aiMessageAddedToMemory(event),
 			'ai-output-parsed': (event) => this.aiOutputParsed(event),
@@ -242,6 +242,20 @@ export class LogStreamingEventRelay extends EventRelay {
 				},
 			});
 		}
+	}
+
+	@Redactable()
+	private workflowExecuted({
+		user,
+		workflowId,
+		workflowName,
+		executionId,
+		executionMode,
+	}: RelayEventMap['workflow-executed']) {
+		void this.eventBus.sendAuditEvent({
+			eventName: 'n8n.audit.user.workflow.executed',
+			payload: { ...user, workflowId, workflowName, executionId, executionMode },
+		});
 	}
 
 	// #endregion
@@ -549,20 +563,6 @@ export class LogStreamingEventRelay extends EventRelay {
 				executionIds,
 				...(deleteBefore && { deleteBefore: deleteBefore.toISOString() }),
 			},
-		});
-	}
-
-	@Redactable()
-	private workflowExecuted({
-		user,
-		workflowId,
-		workflowName,
-		executionId,
-		executionMode,
-	}: RelayEventMap['workflow-executed']) {
-		void this.eventBus.sendAuditEvent({
-			eventName: 'n8n.audit.user.workflow.executed',
-			payload: { ...user, workflowId, workflowName, executionId, executionMode },
 		});
 	}
 

--- a/packages/cli/src/events/relays/log-streaming.event-relay.ts
+++ b/packages/cli/src/events/relays/log-streaming.event-relay.ts
@@ -56,6 +56,8 @@ export class LogStreamingEventRelay extends EventRelay {
 			'execution-throttled': (event) => this.executionThrottled(event),
 			'execution-started-during-bootup': (event) => this.executionStartedDuringBootup(event),
 			'execution-cancelled': (event) => this.executionCancelled(event),
+			'execution-deleted': (event) => this.executionDeleted(event),
+			'workflow-executed': (event) => this.workflowExecuted(event),
 			'ai-messages-retrieved-from-memory': (event) => this.aiMessagesRetrievedFromMemory(event),
 			'ai-message-added-to-memory': (event) => this.aiMessageAddedToMemory(event),
 			'ai-output-parsed': (event) => this.aiOutputParsed(event),
@@ -531,6 +533,28 @@ export class LogStreamingEventRelay extends EventRelay {
 				workflowName,
 				reason,
 			},
+		});
+	}
+
+	@Redactable()
+	private executionDeleted({ user, executionIds }: RelayEventMap['execution-deleted']) {
+		void this.eventBus.sendAuditEvent({
+			eventName: 'n8n.audit.user.execution.deleted',
+			payload: { ...user, executionIds },
+		});
+	}
+
+	@Redactable()
+	private workflowExecuted({
+		user,
+		workflowId,
+		workflowName,
+		executionId,
+		executionMode,
+	}: RelayEventMap['workflow-executed']) {
+		void this.eventBus.sendAuditEvent({
+			eventName: 'n8n.audit.user.workflow.executed',
+			payload: { ...user, workflowId, workflowName, executionId, executionMode },
 		});
 	}
 

--- a/packages/cli/src/events/relays/log-streaming.event-relay.ts
+++ b/packages/cli/src/events/relays/log-streaming.event-relay.ts
@@ -544,7 +544,11 @@ export class LogStreamingEventRelay extends EventRelay {
 	}: RelayEventMap['execution-deleted']) {
 		void this.eventBus.sendAuditEvent({
 			eventName: 'n8n.audit.user.execution.deleted',
-			payload: { ...user, executionIds, deleteBefore: deleteBefore?.toISOString() },
+			payload: {
+				...user,
+				executionIds,
+				...(deleteBefore && { deleteBefore: deleteBefore.toISOString() }),
+			},
 		});
 	}
 

--- a/packages/cli/src/events/relays/log-streaming.event-relay.ts
+++ b/packages/cli/src/events/relays/log-streaming.event-relay.ts
@@ -537,10 +537,14 @@ export class LogStreamingEventRelay extends EventRelay {
 	}
 
 	@Redactable()
-	private executionDeleted({ user, executionIds }: RelayEventMap['execution-deleted']) {
+	private executionDeleted({
+		user,
+		executionIds,
+		deleteBefore,
+	}: RelayEventMap['execution-deleted']) {
 		void this.eventBus.sendAuditEvent({
 			eventName: 'n8n.audit.user.execution.deleted',
-			payload: { ...user, executionIds },
+			payload: { ...user, executionIds, deleteBefore: deleteBefore?.toISOString() },
 		});
 	}
 

--- a/packages/cli/src/executions/__tests__/execution.service.test.ts
+++ b/packages/cli/src/executions/__tests__/execution.service.test.ts
@@ -37,6 +37,7 @@ describe('ExecutionService', () => {
 		concurrencyControl,
 		mock(),
 		mock(),
+		mock(),
 	);
 
 	beforeEach(() => {

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -269,7 +269,7 @@ export class ExecutionService {
 			throw new UnexpectedError('The retry did not start for an unknown reason.');
 		}
 
-		this.eventService.emit('workflow-executed-by-user', {
+		this.eventService.emit('workflow-executed', {
 			user: {
 				id: req.user.id,
 				email: req.user.email,
@@ -280,7 +280,7 @@ export class ExecutionService {
 			workflowId: execution.workflowId,
 			workflowName: execution.workflowData.name,
 			executionId: retriedExecutionId,
-			executionMode: 'retry',
+			source: 'user-retry',
 		});
 
 		return {

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -269,7 +269,7 @@ export class ExecutionService {
 			throw new UnexpectedError('The retry did not start for an unknown reason.');
 		}
 
-		this.eventService.emit('workflow-executed', {
+		this.eventService.emit('workflow-executed-by-user', {
 			user: {
 				id: req.user.id,
 				email: req.user.email,

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -333,6 +333,7 @@ export class ExecutionService {
 				role: req.user.role,
 			},
 			executionIds: ids ?? [],
+			deleteBefore,
 		});
 	}
 

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -593,7 +593,7 @@ export class WorkflowsController {
 		);
 
 		if ('executionId' in result) {
-			this.eventService.emit('workflow-executed-by-user', {
+			this.eventService.emit('workflow-executed', {
 				user: {
 					id: req.user.id,
 					email: req.user.email,
@@ -604,7 +604,7 @@ export class WorkflowsController {
 				workflowId: req.body.workflowData.id,
 				workflowName: req.body.workflowData.name,
 				executionId: result.executionId,
-				executionMode: 'manual',
+				source: 'user-manual',
 			});
 		}
 

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -593,7 +593,7 @@ export class WorkflowsController {
 		);
 
 		if ('executionId' in result) {
-			this.eventService.emit('workflow-executed', {
+			this.eventService.emit('workflow-executed-by-user', {
 				user: {
 					id: req.user.id,
 					email: req.user.email,

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -586,11 +586,29 @@ export class WorkflowsController {
 			req.body.workflowData.nodes = safeWorkflow.nodes;
 		}
 
-		return await this.workflowExecutionService.executeManually(
+		const result = await this.workflowExecutionService.executeManually(
 			req.body,
 			req.user,
 			req.headers['push-ref'],
 		);
+
+		if ('executionId' in result) {
+			this.eventService.emit('workflow-executed', {
+				user: {
+					id: req.user.id,
+					email: req.user.email,
+					firstName: req.user.firstName,
+					lastName: req.user.lastName,
+					role: req.user.role,
+				},
+				workflowId: req.body.workflowData.id,
+				workflowName: req.body.workflowData.name,
+				executionId: result.executionId,
+				executionMode: 'manual',
+			});
+		}
+
+		return result;
 	}
 
 	@Licensed('feat:sharing')

--- a/packages/cli/test/integration/execution.service.integration.test.ts
+++ b/packages/cli/test/integration/execution.service.integration.test.ts
@@ -33,6 +33,7 @@ describe('ExecutionService', () => {
 			mock(),
 			mock(),
 			mock(),
+			mock(),
 		);
 	});
 


### PR DESCRIPTION
## Summary

Adds two new log streaming events for audit logging:
- `n8n.audit.user.execution.deleted`: Emitted when user deletes executions
- `n8n.audit.user.workflow.executed`: Emitted when user manually runs or retries a workflow

Both events include user context for audit tracking.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-2936


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
