### PR TITLE
feat: Add PostgreSQL advisory lock for migrations

### DIFF
--- a/packages/@n8n/db/src/connection/__tests__/db-connection.test.ts
+++ b/packages/@n8n/db/src/connection/__tests__/db-connection.test.ts
@@ -4,7 +4,7 @@ import type { DatabaseConfig } from '@n8n/config';
 import { DataSource, type DataSourceOptions } from '@n8n/typeorm';
 import { mock, mockDeep } from 'jest-mock-extended';
 import type { BinaryDataConfig, ErrorReporter } from 'n8n-core';
-import { DbConnectionTimeoutError } from 'n8n-workflow';
+import { DbConnectionTimeoutError, OperationalError } from 'n8n-workflow';
 
 import * as migrationHelper from '../../migrations/migration-helpers';
 import type { Migration } from '../../migrations/migration-types';
@@ -40,11 +40,29 @@ describe('DbConnection', () => {
 		migrations,
 	};
 
+	// Mock entity manager for transaction-level advisory lock
+	const mockEntityManager = {
+		query: jest.fn(),
+	};
+
 	beforeEach(() => {
 		jest.resetAllMocks();
 
 		connectionOptions.getOptions.mockReturnValue(postgresOptions);
 		(DataSource as jest.Mock) = jest.fn().mockImplementation(() => dataSource);
+
+		// Default mock for transaction - executes callback with mock entity manager
+		dataSource.transaction.mockImplementation(
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			async (callbackOrIsolationLevel: any) => {
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
+				return await callbackOrIsolationLevel(mockEntityManager);
+			},
+		);
+
+		// Default mock for advisory lock - returns true (lock acquired)
+		// eslint-disable-next-line @typescript-eslint/naming-convention
+		mockEntityManager.query.mockResolvedValue([{ pg_try_advisory_xact_lock: true }]);
 
 		dbConnection = new DbConnection(
 			errorReporter,
@@ -93,6 +111,84 @@ describe('DbConnection', () => {
 			// Act & Assert
 			await expect(dbConnection.init()).rejects.toThrow('Some other error');
 		});
+
+		it('should set max_allowed_packet for mysql with database binary mode', async () => {
+			const mysqlOptions: DataSourceOptions = {
+				type: 'mysql',
+				host: 'localhost',
+				port: 3306,
+				username: 'user',
+				password: 'password',
+				database: 'n8n',
+				migrations,
+			};
+			connectionOptions.getOptions.mockReturnValue(mysqlOptions);
+
+			const mysqlBinaryDataConfig = mock<BinaryDataConfig>({
+				availableModes: ['database'],
+				dbMaxFileSize: 512,
+			});
+
+			const mysqlDbConnection = new DbConnection(
+				errorReporter,
+				connectionOptions,
+				databaseConfig,
+				logger,
+				mysqlBinaryDataConfig,
+			);
+
+			// @ts-expect-error accessing private property for testing
+			const mysqlDataSource = mysqlDbConnection.dataSource as jest.Mocked<DataSource>;
+			mysqlDataSource.initialize = jest.fn().mockResolvedValue(mysqlDataSource);
+			mysqlDataSource.query = jest.fn().mockResolvedValue(undefined);
+			// @ts-expect-error mock options
+			mysqlDataSource.options = { migrations, type: 'mysql' };
+
+			await mysqlDbConnection.init();
+
+			expect(mysqlDataSource.query).toHaveBeenCalledWith(
+				'SET GLOBAL max_allowed_packet = 536870912',
+			);
+		});
+
+		it('should log warning when setting max_allowed_packet fails for mysql', async () => {
+			const mysqlOptions: DataSourceOptions = {
+				type: 'mysql',
+				host: 'localhost',
+				port: 3306,
+				username: 'user',
+				password: 'password',
+				database: 'n8n',
+				migrations,
+			};
+			connectionOptions.getOptions.mockReturnValue(mysqlOptions);
+
+			const mysqlBinaryDataConfig = mock<BinaryDataConfig>({
+				availableModes: ['database'],
+				dbMaxFileSize: 512,
+			});
+
+			const mysqlDbConnection = new DbConnection(
+				errorReporter,
+				connectionOptions,
+				databaseConfig,
+				logger,
+				mysqlBinaryDataConfig,
+			);
+
+			// @ts-expect-error accessing private property for testing
+			const mysqlDataSource = mysqlDbConnection.dataSource as jest.Mocked<DataSource>;
+			mysqlDataSource.initialize = jest.fn().mockResolvedValue(mysqlDataSource);
+			mysqlDataSource.query = jest.fn().mockRejectedValue(new Error('Permission denied'));
+			// @ts-expect-error mock options
+			mysqlDataSource.options = { migrations, type: 'mysql' };
+
+			await mysqlDbConnection.init();
+
+			expect(logger.warn).toHaveBeenCalledWith(
+				expect.stringContaining('Failed to set `max_allowed_packet`'),
+			);
+		});
 	});
 
 	describe('migrate', () => {
@@ -109,6 +205,211 @@ describe('DbConnection', () => {
 			expect(wrapMigrationSpy).toHaveBeenCalledTimes(2);
 			expect(dataSource.runMigrations).toHaveBeenCalledWith({ transaction: 'each' });
 			expect(dbConnection.connectionState.migrated).toBe(true);
+		});
+
+		it('should acquire transaction-level advisory lock for postgres', async () => {
+			dataSource.runMigrations.mockResolvedValue([]);
+			jest.spyOn(migrationHelper, 'wrapMigration').mockImplementation();
+
+			await dbConnection.migrate();
+
+			// Should use transaction for lock
+			expect(dataSource.transaction).toHaveBeenCalled();
+			expect(mockEntityManager.query).toHaveBeenCalledWith(
+				'SELECT pg_try_advisory_xact_lock(1850)',
+			);
+			// No explicit unlock needed - transaction-level locks auto-release
+		});
+
+		it('should auto-release advisory lock when migrations fail (via transaction rollback)', async () => {
+			const migrationError = new Error('Migration failed');
+			dataSource.runMigrations.mockRejectedValue(migrationError);
+			jest.spyOn(migrationHelper, 'wrapMigration').mockImplementation();
+
+			await expect(dbConnection.migrate()).rejects.toThrow('Migration failed');
+
+			// Lock should have been acquired via transaction
+			expect(dataSource.transaction).toHaveBeenCalled();
+			expect(mockEntityManager.query).toHaveBeenCalledWith(
+				'SELECT pg_try_advisory_xact_lock(1850)',
+			);
+			// No explicit unlock needed - transaction rollback auto-releases the lock
+		});
+
+		it('should not use advisory lock for sqlite', async () => {
+			const sqliteOptions: DataSourceOptions = {
+				type: 'sqlite',
+				database: ':memory:',
+				migrations,
+			};
+			connectionOptions.getOptions.mockReturnValue(sqliteOptions);
+
+			// Create a new instance with sqlite options
+			const sqliteDbConnection = new DbConnection(
+				errorReporter,
+				connectionOptions,
+				databaseConfig,
+				logger,
+				binaryDataConfig,
+			);
+
+			// Get the dataSource from the new instance and mock it
+			// @ts-expect-error accessing private property for testing
+			const sqliteDataSource = sqliteDbConnection.dataSource as jest.Mocked<DataSource>;
+			sqliteDataSource.runMigrations = jest.fn().mockResolvedValue([]);
+			sqliteDataSource.query = jest.fn();
+			sqliteDataSource.transaction = jest.fn();
+			// @ts-expect-error mock options
+			sqliteDataSource.options = { migrations, type: 'sqlite' };
+
+			jest.spyOn(migrationHelper, 'wrapMigration').mockImplementation();
+
+			await sqliteDbConnection.migrate();
+
+			// Should not use transaction for SQLite (no advisory lock support)
+			expect(sqliteDataSource.transaction).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('withAdvisoryLock', () => {
+		it('should acquire transaction-level advisory lock for postgres', async () => {
+			const mockFn = jest.fn().mockResolvedValue('result');
+
+			await dbConnection.withAdvisoryLock(mockFn);
+
+			// Should use transaction for lock
+			expect(dataSource.transaction).toHaveBeenCalled();
+			expect(mockEntityManager.query).toHaveBeenCalledWith(
+				'SELECT pg_try_advisory_xact_lock(1850)',
+			);
+			// No explicit unlock needed - transaction-level locks auto-release on commit
+		});
+
+		it('should return the result from the callback function', async () => {
+			const expectedResult = { data: 'test' };
+			const mockFn = jest.fn().mockResolvedValue(expectedResult);
+
+			const result = await dbConnection.withAdvisoryLock(mockFn);
+
+			expect(result).toEqual(expectedResult);
+		});
+
+		it('should auto-release advisory lock when callback fails (via transaction rollback)', async () => {
+			const mockError = new Error('Callback failed');
+			const mockFn = jest.fn().mockRejectedValue(mockError);
+
+			await expect(dbConnection.withAdvisoryLock(mockFn)).rejects.toThrow('Callback failed');
+
+			// Lock should have been acquired via transaction
+			expect(dataSource.transaction).toHaveBeenCalled();
+			expect(mockEntityManager.query).toHaveBeenCalledWith(
+				'SELECT pg_try_advisory_xact_lock(1850)',
+			);
+			// No explicit unlock needed - transaction rollback auto-releases the lock
+		});
+
+		it('should retry acquiring lock and timeout with clear error message', async () => {
+			jest.useFakeTimers();
+
+			// Mock lock always returning false (lock not acquired)
+			// eslint-disable-next-line @typescript-eslint/naming-convention
+			mockEntityManager.query.mockResolvedValue([{ pg_try_advisory_xact_lock: false }]);
+
+			const mockFn = jest.fn().mockResolvedValue('result');
+			const lockPromise = dbConnection.withAdvisoryLock(mockFn);
+
+			// Advance time past the timeout (30 seconds)
+			await jest.advanceTimersByTimeAsync(31_000);
+
+			await expect(lockPromise).rejects.toThrow(OperationalError);
+			await expect(lockPromise).rejects.toThrow(/Failed to acquire database advisory lock/);
+			await expect(lockPromise).rejects.toThrow(/auto-release/);
+			await expect(lockPromise).rejects.toThrow(/pg_terminate_backend/);
+
+			// Function should never have been called
+			expect(mockFn).not.toHaveBeenCalled();
+
+			jest.useRealTimers();
+		});
+
+		it('should retry and succeed when lock becomes available', async () => {
+			jest.useFakeTimers();
+
+			// First call returns false, second returns true
+			mockEntityManager.query
+				// eslint-disable-next-line @typescript-eslint/naming-convention
+				.mockResolvedValueOnce([{ pg_try_advisory_xact_lock: false }])
+				// eslint-disable-next-line @typescript-eslint/naming-convention
+				.mockResolvedValueOnce([{ pg_try_advisory_xact_lock: true }]);
+
+			const mockFn = jest.fn().mockResolvedValue('result');
+			const lockPromise = dbConnection.withAdvisoryLock(mockFn);
+
+			// Advance time to trigger retry
+			await jest.advanceTimersByTimeAsync(600);
+
+			const result = await lockPromise;
+
+			expect(result).toBe('result');
+			expect(mockFn).toHaveBeenCalled();
+			// No explicit unlock call - transaction commit auto-releases
+
+			jest.useRealTimers();
+		});
+
+		it('should treat empty query result as lock not acquired', async () => {
+			jest.useFakeTimers();
+
+			// First call returns empty array (edge case), second returns true
+			mockEntityManager.query
+				.mockResolvedValueOnce([]) // Empty result - should default to false
+				// eslint-disable-next-line @typescript-eslint/naming-convention
+				.mockResolvedValueOnce([{ pg_try_advisory_xact_lock: true }]);
+
+			const mockFn = jest.fn().mockResolvedValue('result');
+			const lockPromise = dbConnection.withAdvisoryLock(mockFn);
+
+			// Advance time to trigger retry
+			await jest.advanceTimersByTimeAsync(600);
+
+			const result = await lockPromise;
+
+			expect(result).toBe('result');
+			expect(mockEntityManager.query).toHaveBeenCalledTimes(2);
+
+			jest.useRealTimers();
+		});
+
+		it('should not use advisory lock for sqlite', async () => {
+			const sqliteOptions: DataSourceOptions = {
+				type: 'sqlite',
+				database: ':memory:',
+				migrations,
+			};
+			connectionOptions.getOptions.mockReturnValue(sqliteOptions);
+
+			const sqliteDbConnection = new DbConnection(
+				errorReporter,
+				connectionOptions,
+				databaseConfig,
+				logger,
+				binaryDataConfig,
+			);
+
+			// @ts-expect-error accessing private property for testing
+			const sqliteDataSource = sqliteDbConnection.dataSource as jest.Mocked<DataSource>;
+			sqliteDataSource.query = jest.fn();
+			sqliteDataSource.transaction = jest.fn();
+			// @ts-expect-error mock options
+			sqliteDataSource.options = { migrations, type: 'sqlite' };
+
+			const mockFn = jest.fn().mockResolvedValue('result');
+
+			await sqliteDbConnection.withAdvisoryLock(mockFn);
+
+			expect(mockFn).toHaveBeenCalled();
+			// Should not use transaction for SQLite (no advisory lock support)
+			expect(sqliteDataSource.transaction).not.toHaveBeenCalled();
 		});
 	});
 
@@ -170,6 +471,47 @@ describe('DbConnection', () => {
 
 			expect(errorReporter.error).toHaveBeenCalledWith(error);
 		});
+
+		it('should log warning for OperationalError on ping failure', async () => {
+			// @ts-expect-error readonly property
+			dataSource.isInitialized = true;
+			const error = new OperationalError('Database connection timed out');
+			dataSource.query.mockRejectedValue(error);
+
+			// @ts-expect-error private property
+			await dbConnection.ping();
+
+			expect(logger.warn).toHaveBeenCalledWith('Database connection timed out');
+			expect(errorReporter.error).not.toHaveBeenCalled();
+		});
+
+		it('should timeout and throw OperationalError if ping takes too long', async () => {
+			jest.useFakeTimers();
+			// @ts-expect-error readonly property
+			dataSource.isInitialized = true;
+			// Make the query hang indefinitely until aborted
+			dataSource.query.mockImplementation(
+				async () =>
+					await new Promise((_, reject) => {
+						// This promise will be rejected when the AbortController aborts
+						setTimeout(() => reject(new Error('Query was aborted')), 10000);
+					}),
+			);
+
+			// @ts-expect-error private property
+			const pingPromise = dbConnection.ping();
+
+			// Advance time past the 5 second timeout
+			await jest.advanceTimersByTimeAsync(5001);
+
+			await pingPromise;
+
+			// After timeout, connection state should be false and warning logged
+			expect(dbConnection.connectionState.connected).toBe(false);
+			expect(logger.warn).toHaveBeenCalledWith('Database connection timed out');
+
+			jest.useRealTimers();
+		}, 10000);
 
 		it('should schedule next ping after execution', async () => {
 			// @ts-expect-error readonly property

--- a/packages/cli/src/commands/base-command.ts
+++ b/packages/cli/src/commands/base-command.ts
@@ -123,8 +123,11 @@ export abstract class BaseCommand<F = never> {
 					await this.exitWithCrash('There was an error running database migrations', error),
 			);
 
-		// Initialize the auth roles service to make sure that roles are correctly setup for the instance
-		await Container.get(AuthRolesService).init();
+		// Initialize the auth roles service to make sure that roles are correctly setup for the instance.
+		// Uses advisory lock to prevent race conditions when multiple instances start simultaneously.
+		await this.dbConnection.withAdvisoryLock(async () => {
+			await Container.get(AuthRolesService).init();
+		});
 
 		if (process.env.EXECUTIONS_PROCESS === 'own') process.exit(-1);
 


### PR DESCRIPTION
## Summary

Ensures only one n8n instance runs database migrations and initializes auth roles service in multi-main setups to prevent race conditions.
Implements transaction-level advisory locks for PostgreSQL to avoid orphaned locks and improve reliability.
Retries lock acquisition with timeout and provides detailed error message with instructions for manual intervention.
Disables advisory lock for SQLite databases.
Runs main instances in parallel during testing to improve efficiency.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
