### PR TITLE
fix(docker): preserve apk package manager in Alpine image

### DIFF
--- a/docker/images/n8n-base/Dockerfile
+++ b/docker/images/n8n-base/Dockerfile
@@ -42,7 +42,7 @@ FROM node:${NODE_VERSION}-alpine
 
 COPY --from=builder / /
 
-RUN rm -rf /opt/yarn* && apk del apk-tools
+RUN rm -rf /opt/yarn*
 
 WORKDIR /home/node
 ENV NODE_ICU_DATA=/usr/local/lib/node_modules/full-icu


### PR DESCRIPTION
## Summary

This PR preserves the `apk` package manager in the Alpine-based n8n Docker image by removing the `apk del apk-tools` command from the final build stage.

### The Issue

Since n8n 2.1.0, users who extend the official n8n Docker image cannot install additional packages because `apk-tools` was removed as part of optimization efforts (#23149). This breaks common use cases like adding `ffmpeg`, `pipx`, or other utilities.

### The Solution

Rather than requiring users to employ complex workarounds involving `apk-tools-static` (as suggested in the issue comments), this change simply preserves `apk-tools` in the final image.

### Trade-offs

- **Image size**: Minimal increase (~1-2 MB for apk-tools)
- **User experience**: Significant improvement for users who need to extend the base image
- **Backward compatibility**: Restores expected behavior from versions prior to 2.1.0

I understand if this doesn't align with the project's direction for official image optimization. However, I wanted to offer this option as a potential middle ground that benefits the community while keeping the change minimal.

Fixes #23246

## Test Plan

- [ ] Build the Docker image successfully
- [ ] Verify `apk` command is available in the final image
- [ ] Verify additional packages can be installed (e.g., `apk add --no-cache ffmpeg`)