### PR TITLE
fix(DataTable): add generic boolean filter options (eq/neq)

### DIFF
--- a/packages/nodes-base/nodes/DataTable/common/methods.ts
+++ b/packages/nodes-base/nodes/DataTable/common/methods.ts
@@ -126,19 +126,17 @@ export async function getConditionsForColumn(this: ILoadOptionsFunctions) {
 	const conditions: INodePropertyOptions[] = [];
 
 	if (type === 'boolean') {
-		conditions.push.apply(conditions, booleanConditions);
+		conditions.push(...equalsConditions, ...booleanConditions, ...nullConditions);
+		return conditions;
 	}
 
 	// String columns get LIKE operators
 	if (type === 'string') {
-		conditions.push.apply(conditions, equalsConditions);
-		conditions.push.apply(conditions, stringConditions);
-		conditions.push.apply(conditions, comparableConditions);
+		conditions.push(...equalsConditions, ...stringConditions, ...comparableConditions);
 	}
 
 	if (['number', 'date'].includes(type)) {
-		conditions.push.apply(conditions, equalsConditions);
-		conditions.push.apply(conditions, comparableConditions);
+		conditions.push(...equalsConditions, ...comparableConditions);
 	}
 
 	conditions.push.apply(conditions, nullConditions);


### PR DESCRIPTION
This PR adds the missing "Equal" and "Not Equal" filter options for Boolean columns in the Data Table node.

Why: Previously, when filtering a Boolean column, the only available options were Is True, Is False, Is Empty, and Is Not Empty. This prevented users from filtering based on variable input (e.g., matching a boolean value from a previous node using "Equal").

Fixes #23371