### PR TITLE
fix: Handle nodes with missing type field in ActivateExecuteWorkflowTriggerWorkflows migration

### DIFF
--- a/packages/@n8n/db/src/migrations/common/1763048000000-ActivateExecuteWorkflowTriggerWorkflows.ts
+++ b/packages/@n8n/db/src/migrations/common/1763048000000-ActivateExecuteWorkflowTriggerWorkflows.ts
@@ -124,7 +124,7 @@ export class ActivateExecuteWorkflowTriggerWorkflows1763048000000 implements Irr
 				// Disable other trigger nodes (keep valid executeWorkflowTrigger and errorTrigger enabled)
 				let nodesModified = false;
 				nodes.forEach((node: Node) => {
-					if (this.isTriggerNode(node.type)) {
+					if (node.type && this.isTriggerNode(node.type)) {
 						// Keep valid Execute Workflow Trigger active
 						if (
 							node.type === EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE &&


### PR DESCRIPTION
## Summary
The ActivateExecuteWorkflowTriggerWorkflows1763048000000 migration crashes when encountering workflows with malformed nodes that are missing the type field.

Root cause: The migration iterates over workflow nodes and calls this.isTriggerNode(node.type) without checking if node.type exists. When a node has no type field, this results in:

Migration "ActivateExecuteWorkflowTriggerWorkflows1763048000000" failed, error: Cannot read properties of undefined (reading 'includes')

Fix: Add a defensive check node.type && before calling isTriggerNode() to skip malformed nodes gracefully.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
