### PR TITLE
refactor(core): Make Chat db queries faster

### DIFF
--- a/packages/@n8n/db/src/migrations/common/1766068346315-AddChatMessageIndices.ts
+++ b/packages/@n8n/db/src/migrations/common/1766068346315-AddChatMessageIndices.ts
@@ -1,0 +1,49 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+export class AddChatMessageIndices1766068346315 implements ReversibleMigration {
+	async up({ schemaBuilder: { addNotNull }, runQuery, escape, tablePrefix }: MigrationContext) {
+		const sessionsTable = escape.tableName('chat_hub_sessions');
+		const idColumn = escape.columnName('id');
+		const createdAtColumn = escape.columnName('createdAt');
+		const ownerIdColumn = escape.columnName('ownerId');
+		const lastMessageAtColumn = escape.columnName('lastMessageAt');
+
+		const messagesTable = escape.tableName('chat_hub_messages');
+		const sessionIdColumn = escape.columnName('sessionId');
+
+		// Backfill lastMessageAt for existing rows to allow adding a NOT NULL constraint
+		await runQuery(
+			`UPDATE ${sessionsTable}
+			SET ${lastMessageAtColumn} = ${createdAtColumn}
+			WHERE ${lastMessageAtColumn} IS NULL`,
+		);
+
+		await addNotNull('chat_hub_sessions', 'lastMessageAt');
+
+		// Index intended for faster sessionRepository.getManyByUserId queries
+		await runQuery(
+			'CREATE INDEX IF NOT EXISTS ' +
+				escape.tableName(`idx_${tablePrefix}chat_hub_sessions_owner_lastmsg_id`) +
+				` ON ${sessionsTable}(${ownerIdColumn}, ${lastMessageAtColumn} DESC, ${idColumn})`,
+		);
+
+		// Index intended for faster sessionRepository.getOneByIdAndUserId queries and joins
+		await runQuery(
+			'CREATE INDEX IF NOT EXISTS ' +
+				escape.tableName(`idx_${tablePrefix}chat_hub_messages_sessionId`) +
+				` ON ${messagesTable}(${sessionIdColumn})`,
+		);
+	}
+
+	async down({ schemaBuilder: { dropNotNull }, runQuery, escape, tablePrefix }: MigrationContext) {
+		await runQuery(
+			'DROP INDEX IF EXISTS ' +
+				escape.tableName(`idx_${tablePrefix}chat_hub_sessions_owner_lastmsg_id`),
+		);
+		await runQuery(
+			'DROP INDEX IF EXISTS ' + escape.tableName(`idx_${tablePrefix}chat_hub_messages_sessionId`),
+		);
+
+		await dropNotNull('chat_hub_sessions', 'lastMessageAt');
+	}
+}

--- a/packages/@n8n/db/src/migrations/common/1766068346315-AddChatMessageIndices.ts
+++ b/packages/@n8n/db/src/migrations/common/1766068346315-AddChatMessageIndices.ts
@@ -1,7 +1,7 @@
 import type { MigrationContext, ReversibleMigration } from '../migration-types';
 
 export class AddChatMessageIndices1766068346315 implements ReversibleMigration {
-	async up({ schemaBuilder: { addNotNull }, runQuery, escape, tablePrefix }: MigrationContext) {
+	async up({ schemaBuilder: { addNotNull }, runQuery, escape }: MigrationContext) {
 		const sessionsTable = escape.tableName('chat_hub_sessions');
 		const idColumn = escape.columnName('id');
 		const createdAtColumn = escape.columnName('createdAt');
@@ -23,26 +23,23 @@ export class AddChatMessageIndices1766068346315 implements ReversibleMigration {
 		// Index intended for faster sessionRepository.getManyByUserId queries
 		await runQuery(
 			'CREATE INDEX IF NOT EXISTS ' +
-				escape.tableName(`idx_${tablePrefix}chat_hub_sessions_owner_lastmsg_id`) +
+				escape.indexName('chat_hub_sessions_owner_lastmsg_id') +
 				` ON ${sessionsTable}(${ownerIdColumn}, ${lastMessageAtColumn} DESC, ${idColumn})`,
 		);
 
 		// Index intended for faster sessionRepository.getOneByIdAndUserId queries and joins
 		await runQuery(
 			'CREATE INDEX IF NOT EXISTS ' +
-				escape.tableName(`idx_${tablePrefix}chat_hub_messages_sessionId`) +
+				escape.indexName('chat_hub_messages_sessionId') +
 				` ON ${messagesTable}(${sessionIdColumn})`,
 		);
 	}
 
-	async down({ schemaBuilder: { dropNotNull }, runQuery, escape, tablePrefix }: MigrationContext) {
+	async down({ schemaBuilder: { dropNotNull }, runQuery, escape }: MigrationContext) {
 		await runQuery(
-			'DROP INDEX IF EXISTS ' +
-				escape.tableName(`idx_${tablePrefix}chat_hub_sessions_owner_lastmsg_id`),
+			'DROP INDEX IF EXISTS ' + escape.indexName('chat_hub_sessions_owner_lastmsg_id'),
 		);
-		await runQuery(
-			'DROP INDEX IF EXISTS ' + escape.tableName(`idx_${tablePrefix}chat_hub_messages_sessionId`),
-		);
+		await runQuery('DROP INDEX IF EXISTS ' + escape.indexName('chat_hub_messages_sessionId'));
 
 		await dropNotNull('chat_hub_sessions', 'lastMessageAt');
 	}

--- a/packages/@n8n/db/src/migrations/common/1766068346315-AddChatMessageIndices.ts
+++ b/packages/@n8n/db/src/migrations/common/1766068346315-AddChatMessageIndices.ts
@@ -22,24 +22,22 @@ export class AddChatMessageIndices1766068346315 implements ReversibleMigration {
 
 		// Index intended for faster sessionRepository.getManyByUserId queries
 		await runQuery(
-			'CREATE INDEX IF NOT EXISTS ' +
-				escape.indexName('chat_hub_sessions_owner_lastmsg_id') +
-				` ON ${sessionsTable}(${ownerIdColumn}, ${lastMessageAtColumn} DESC, ${idColumn})`,
+			`CREATE INDEX IF NOT EXISTS ${escape.indexName('chat_hub_sessions_owner_lastmsg_id')}
+			ON ${sessionsTable}(${ownerIdColumn}, ${lastMessageAtColumn} DESC, ${idColumn})`,
 		);
 
 		// Index intended for faster sessionRepository.getOneByIdAndUserId queries and joins
 		await runQuery(
-			'CREATE INDEX IF NOT EXISTS ' +
-				escape.indexName('chat_hub_messages_sessionId') +
-				` ON ${messagesTable}(${sessionIdColumn})`,
+			`CREATE INDEX IF NOT EXISTS ${escape.indexName('chat_hub_messages_sessionId')}
+			ON ${messagesTable}(${sessionIdColumn})`,
 		);
 	}
 
 	async down({ schemaBuilder: { dropNotNull }, runQuery, escape }: MigrationContext) {
 		await runQuery(
-			'DROP INDEX IF EXISTS ' + escape.indexName('chat_hub_sessions_owner_lastmsg_id'),
+			`DROP INDEX IF EXISTS ${escape.indexName('chat_hub_sessions_owner_lastmsg_id')}`,
 		);
-		await runQuery('DROP INDEX IF EXISTS ' + escape.indexName('chat_hub_messages_sessionId'));
+		await runQuery(`DROP INDEX IF EXISTS ${escape.indexName('chat_hub_messages_sessionId')}`);
 
 		await dropNotNull('chat_hub_sessions', 'lastMessageAt');
 	}

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -130,6 +130,7 @@ import { AddIconToAgentTable1765788427674 } from '../common/1765788427674-AddIco
 import { AddAgentIdForeignKeys1765886667897 } from '../common/1765886667897-AddAgentIdForeignKeys';
 import { AddWorkflowVersionIdToExecutionData1765892199653 } from '../common/1765892199653-AddVersionIdToExecutionData';
 import { AddWorkflowPublishScopeToProjectRoles1766064542000 } from '../common/1766064542000-AddWorkflowPublishScopeToProjectRoles';
+import { AddChatMessageIndices1766068346315 } from '../common/1766068346315-AddChatMessageIndices';
 import type { Migration } from '../migration-types';
 
 export const postgresMigrations: Migration[] = [
@@ -265,4 +266,5 @@ export const postgresMigrations: Migration[] = [
 	AddAgentIdForeignKeys1765886667897,
 	AddWorkflowVersionIdToExecutionData1765892199653,
 	AddWorkflowPublishScopeToProjectRoles1766064542000,
+	AddChatMessageIndices1766068346315,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/1766068346315-AddChatMessageIndices.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1766068346315-AddChatMessageIndices.ts
@@ -1,0 +1,5 @@
+import { AddChatMessageIndices1766068346315 as BaseMigration } from '../common/1766068346315-AddChatMessageIndices';
+
+export class AddChatMessageIndices1766068346315 extends BaseMigration {
+	transaction = false as const;
+}

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -49,6 +49,7 @@ import { ChangeDependencyInfoToJson1761655473000 } from './1761655473000-ChangeD
 import { AddCreatorIdToProjectTable1764276827837 } from './1764276827837-AddCreatorIdToProjectTable';
 import { AddResolvableFieldsToCredentials1764689448000 } from './1764689448000-AddResolvableFieldsToCredentials';
 import { AddAgentIdForeignKeys1765886667897 } from './1765886667897-AddAgentIdForeignKeys';
+import { AddChatMessageIndices1766068346315 } from './1766068346315-AddChatMessageIndices';
 import { UniqueWorkflowNames1620821879465 } from '../common/1620821879465-UniqueWorkflowNames';
 import { UpdateWorkflowCredentials1630330987096 } from '../common/1630330987096-UpdateWorkflowCredentials';
 import { AddNodeIds1658930531669 } from '../common/1658930531669-AddNodeIds';
@@ -255,6 +256,7 @@ const sqliteMigrations: Migration[] = [
 	AddAgentIdForeignKeys1765886667897,
 	AddWorkflowVersionIdToExecutionData1765892199653,
 	AddWorkflowPublishScopeToProjectRoles1766064542000,
+	AddChatMessageIndices1766068346315,
 ];
 
 export { sqliteMigrations };

--- a/packages/cli/src/modules/chat-hub/chat-hub-agent.repository.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-agent.repository.ts
@@ -11,12 +11,17 @@ export class ChatHubAgentRepository extends Repository<ChatHubAgent> {
 	}
 
 	async createAgent(agent: Partial<ChatHubAgent>, trx?: EntityManager) {
-		return await withTransaction(this.manager, trx, async (em) => {
-			await em.insert(ChatHubAgent, agent);
-			return await em.findOneOrFail(ChatHubAgent, {
-				where: { id: agent.id },
-			});
-		});
+		return await withTransaction(
+			this.manager,
+			trx,
+			async (em) => {
+				await em.insert(ChatHubAgent, agent);
+				return await em.findOneOrFail(ChatHubAgent, {
+					where: { id: agent.id },
+				});
+			},
+			false,
+		);
 	}
 
 	async updateAgent(
@@ -29,18 +34,28 @@ export class ChatHubAgentRepository extends Repository<ChatHubAgent> {
 		>,
 		trx?: EntityManager,
 	) {
-		return await withTransaction(this.manager, trx, async (em) => {
-			await em.update(ChatHubAgent, { id }, updates);
-			return await em.findOneOrFail(ChatHubAgent, {
-				where: { id },
-			});
-		});
+		return await withTransaction(
+			this.manager,
+			trx,
+			async (em) => {
+				await em.update(ChatHubAgent, { id }, updates);
+				return await em.findOneOrFail(ChatHubAgent, {
+					where: { id },
+				});
+			},
+			false,
+		);
 	}
 
 	async deleteAgent(id: string, trx?: EntityManager) {
-		return await withTransaction(this.manager, trx, async (em) => {
-			return await em.delete(ChatHubAgent, { id });
-		});
+		return await withTransaction(
+			this.manager,
+			trx,
+			async (em) => {
+				return await em.delete(ChatHubAgent, { id });
+			},
+			false,
+		);
 	}
 
 	async getManyByUserId(userId: string) {

--- a/packages/cli/src/modules/chat-hub/chat-hub-session.entity.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-session.entity.ts
@@ -50,8 +50,8 @@ export class ChatHubSession extends WithTimestamps {
 	 * Timestamp of the last active message in the session.
 	 * Used to sort chat sessions by recent activity.
 	 */
-	@DateTimeColumn({ nullable: true })
-	lastMessageAt: Date | null;
+	@DateTimeColumn()
+	lastMessageAt: Date;
 
 	/*
 	 * ID of the selected credential to use by default with the selected LLM provider (if applicable).

--- a/packages/cli/src/modules/chat-hub/chat-hub.controller.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.controller.ts
@@ -96,7 +96,7 @@ export class ChatHubController {
 		}
 
 		// Verify user has access to this session
-		await this.chatService.getConversation(req.user.id, sessionId);
+		await this.chatService.ensureConversation(req.user.id, sessionId);
 
 		const [{ mimeType, fileName }, attachmentAsStreamOrBuffer] =
 			await this.chatAttachmentService.getAttachment(sessionId, messageId, attachmentIndex);

--- a/packages/cli/src/modules/chat-hub/chat-hub.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.service.ts
@@ -1392,19 +1392,6 @@ export class ChatHubService {
 	}
 
 	/**
-	 * Updates the title of a session
-	 */
-	async updateSessionTitle(userId: string, sessionId: ChatSessionId, title: string) {
-		const session = await this.sessionRepository.getOneById(sessionId, userId);
-
-		if (!session) {
-			throw new NotFoundError('Session not found');
-		}
-
-		return await this.sessionRepository.updateChatTitle(sessionId, title);
-	}
-
-	/**
 	 * Updates a session with the provided fields
 	 */
 	async updateSession(

--- a/packages/cli/src/modules/chat-hub/chat-message.repository.ts
+++ b/packages/cli/src/modules/chat-hub/chat-message.repository.ts
@@ -5,6 +5,7 @@ import { DataSource, EntityManager, Repository } from '@n8n/typeorm';
 
 import { ChatHubMessage } from './chat-hub-message.entity';
 import { ChatHubSessionRepository } from './chat-session.repository';
+
 import { UnexpectedError, type IBinaryData } from 'n8n-workflow';
 import { QueryDeepPartialEntity } from '@n8n/typeorm/query-builder/QueryPartialEntity';
 
@@ -19,23 +20,20 @@ export class ChatHubMessageRepository extends Repository<ChatHubMessage> {
 
 	async createChatMessage(message: QueryDeepPartialEntity<ChatHubMessage>, trx?: EntityManager) {
 		const messageId = message.id;
-		if (typeof messageId === 'function') {
+		const sessionId = message.sessionId;
+
+		if (typeof messageId === 'function' || !messageId) {
 			throw new UnexpectedError('Message ID is required and must be a string value');
 		}
 
-		return await withTransaction(
-			this.manager,
-			trx,
-			async (em) => {
-				await em.insert(ChatHubMessage, message);
-				const saved = await em.findOneOrFail(ChatHubMessage, {
-					where: { id: messageId },
-				});
-				await this.chatSessionRepository.updateLastMessageAt(saved.sessionId, saved.createdAt, em);
-				return saved;
-			},
-			false,
-		);
+		if (typeof sessionId === 'function' || !sessionId) {
+			throw new UnexpectedError('Session ID is required and must be a string value');
+		}
+
+		return await withTransaction(this.manager, trx, async (em) => {
+			await em.insert(ChatHubMessage, message);
+			await this.chatSessionRepository.updateLastMessageAt(sessionId, em);
+		});
 	}
 
 	async updateChatMessage(

--- a/packages/cli/src/modules/chat-hub/chat-message.repository.ts
+++ b/packages/cli/src/modules/chat-hub/chat-message.repository.ts
@@ -2,12 +2,11 @@ import type { ChatHubMessageStatus, ChatMessageId, ChatSessionId } from '@n8n/ap
 import { withTransaction } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { DataSource, EntityManager, Repository } from '@n8n/typeorm';
+import { QueryDeepPartialEntity } from '@n8n/typeorm/query-builder/QueryPartialEntity';
+import { UnexpectedError, type IBinaryData } from 'n8n-workflow';
 
 import { ChatHubMessage } from './chat-hub-message.entity';
 import { ChatHubSessionRepository } from './chat-session.repository';
-
-import { UnexpectedError, type IBinaryData } from 'n8n-workflow';
-import { QueryDeepPartialEntity } from '@n8n/typeorm/query-builder/QueryPartialEntity';
 
 @Service()
 export class ChatHubMessageRepository extends Repository<ChatHubMessage> {

--- a/packages/cli/src/modules/chat-hub/chat-session.repository.ts
+++ b/packages/cli/src/modules/chat-hub/chat-session.repository.ts
@@ -83,8 +83,7 @@ export class ChatHubSessionRepository extends Repository<ChatHubSession> {
 			.leftJoinAndSelect('shared.project', 'project')
 			.leftJoinAndSelect('workflow.activeVersion', 'activeVersion')
 			.where('session.ownerId = :userId', { userId })
-			.addSelect("COALESCE(session.lastMessageAt, '1970-01-01')", 'sortdate')
-			.orderBy('sortdate', 'DESC')
+			.orderBy('session.lastMessageAt', 'DESC')
 			.addOrderBy('session.id', 'ASC');
 
 		if (cursor) {
@@ -108,6 +107,17 @@ export class ChatHubSessionRepository extends Repository<ChatHubSession> {
 		queryBuilder.take(limit);
 
 		return await queryBuilder.getMany();
+	}
+
+	async existsById(id: string, userId: string, trx?: EntityManager): Promise<boolean> {
+		return await withTransaction(
+			this.manager,
+			trx,
+			async (em) => {
+				return await em.exists(ChatHubSession, { where: { id, ownerId: userId } });
+			},
+			false,
+		);
 	}
 
 	async getOneById(id: string, userId: string, trx?: EntityManager) {

--- a/packages/cli/src/modules/chat-hub/chat-session.repository.ts
+++ b/packages/cli/src/modules/chat-hub/chat-session.repository.ts
@@ -13,49 +13,66 @@ export class ChatHubSessionRepository extends Repository<ChatHubSession> {
 	}
 
 	async createChatSession(session: Partial<ChatHubSession>, trx?: EntityManager) {
-		return await withTransaction(this.manager, trx, async (em) => {
-			await em.insert(ChatHubSession, session);
-			return await em.findOneOrFail(ChatHubSession, {
-				where: { id: session.id },
-				relations: ['messages'],
-			});
-		});
+		return await withTransaction(
+			this.manager,
+			trx,
+			async (em) => {
+				await em.insert(ChatHubSession, session);
+				return await em.findOneOrFail(ChatHubSession, {
+					where: { id: session.id },
+					relations: ['messages'],
+				});
+			},
+			false,
+		);
 	}
 
-	async updateLastMessageAt(id: string, lastMessageAt: Date, trx?: EntityManager) {
-		return await withTransaction(this.manager, trx, async (em) => {
-			await em.update(ChatHubSession, { id }, { lastMessageAt });
-			return await em.findOneOrFail(ChatHubSession, {
-				where: { id },
-				relations: ['messages'],
-			});
-		});
+	async updateLastMessageAt(id: string, trx?: EntityManager) {
+		return await withTransaction(
+			this.manager,
+			trx,
+			async (em) => {
+				await em.update(ChatHubSession, { id }, { lastMessageAt: new Date() });
+			},
+			false,
+		);
 	}
 
 	async updateChatTitle(id: string, title: string, trx?: EntityManager) {
-		return await withTransaction(this.manager, trx, async (em) => {
-			await em.update(ChatHubSession, { id }, { title });
-			return await em.findOneOrFail(ChatHubSession, {
-				where: { id },
-				relations: ['messages'],
-			});
-		});
+		return await withTransaction(
+			this.manager,
+			trx,
+			async (em) => {
+				await em.update(ChatHubSession, { id }, { title });
+			},
+			false,
+		);
 	}
 
 	async updateChatSession(id: string, updates: Partial<ChatHubSession>, trx?: EntityManager) {
-		return await withTransaction(this.manager, trx, async (em) => {
-			await em.update(ChatHubSession, { id }, updates);
-			return await em.findOneOrFail(ChatHubSession, {
-				where: { id },
-				relations: ['messages'],
-			});
-		});
+		return await withTransaction(
+			this.manager,
+			trx,
+			async (em) => {
+				await em.update(ChatHubSession, { id }, updates);
+				return await em.findOneOrFail(ChatHubSession, {
+					where: { id },
+					relations: ['messages'],
+				});
+			},
+			false,
+		);
 	}
 
 	async deleteChatHubSession(id: string, trx?: EntityManager) {
-		return await withTransaction(this.manager, trx, async (em) => {
-			return await em.delete(ChatHubSession, { id });
-		});
+		return await withTransaction(
+			this.manager,
+			trx,
+			async (em) => {
+				return await em.delete(ChatHubSession, { id });
+			},
+			false,
+		);
 	}
 
 	async getManyByUserId(userId: string, limit: number, cursor?: string) {
@@ -117,8 +134,13 @@ export class ChatHubSessionRepository extends Repository<ChatHubSession> {
 	}
 
 	async deleteAll(trx?: EntityManager) {
-		return await withTransaction(this.manager, trx, async (em) => {
-			return await em.createQueryBuilder().delete().from(ChatHubSession).execute();
-		});
+		return await withTransaction(
+			this.manager,
+			trx,
+			async (em) => {
+				return await em.createQueryBuilder().delete().from(ChatHubSession).execute();
+			},
+			false,
+		);
 	}
 }


### PR DESCRIPTION
## Summary

Making Chat hub DB queries faster:
1) Removing unnecessary selects / skip loading unused relations / and otherwise simplifying the queries
2) Not making things run in transactions unnecessarily (`withTransaction` helper's optional parameter `false` skips creating transaction if one isn't passed, but still allows the function to be used within a transaction if we want to)
3) DB indices, turning `lastMessageAt` into a required column to avoid COALESCE & enabling index use

With this, the main query that happens when loading conversations drops on my local postgres with 100k sessions (only 10 users) DB from ~25ms to 1ms and it only does index scans. Same on sqlite.

Other big win would be on credential access checks and at finding Chat workflows (with enabled chat triggers), but both of those turned out to be nontrivial so saving those for a followup.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-81/make-chat-queries-faster

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
