### PR TITLE
fix(editor): Track changes from iframe and adjust history actions

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/FocusPanel.vue
+++ b/packages/frontend/editor-ui/src/app/components/FocusPanel.vue
@@ -437,6 +437,27 @@ function onResize(event: ResizeData) {
 
 const onResizeThrottle = useThrottleFn(onResize, 10);
 
+const postFocusPanelState = () => {
+	if (window.parent !== window) {
+		window.parent.postMessage(
+			JSON.stringify({
+				command: 'focusPanelStateChanged',
+				width: focusPanelStore.focusPanelWidth,
+				active: focusPanelStore.focusPanelActive,
+			}),
+			'*',
+		);
+	}
+};
+
+watch(
+	[() => focusPanelStore.focusPanelWidth, () => focusPanelStore.focusPanelActive],
+	() => {
+		postFocusPanelState();
+	},
+	{ immediate: true },
+);
+
 function onOpenNdv() {
 	if (node.value) {
 		ndvStore.setActiveNodeName(node.value.name, 'focus_panel');

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -1902,11 +1902,6 @@ watch(
 );
 
 onBeforeRouteLeave(async (to, from, next) => {
-	// Close the focus panel when leaving the workflow view
-	if (focusPanelStore.focusPanelActive) {
-		focusPanelStore.closeFocusPanel();
-	}
-
 	const toNodeViewTab = getNodeViewTab(to);
 
 	if (

--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryActions.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryActions.vue
@@ -1,0 +1,241 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import type { UserAction } from '@/Interface';
+import type {
+	WorkflowVersion,
+	WorkflowHistoryActionTypes,
+} from '@n8n/rest-api-client/api/workflowHistory';
+import type { IUser } from 'n8n-workflow';
+import { useI18n } from '@n8n/i18n';
+
+import {
+	N8nActionToggle,
+	N8nButton,
+	N8nIcon,
+	N8nLink,
+	N8nText,
+	N8nTooltip,
+} from '@n8n/design-system';
+import { IS_DRAFT_PUBLISH_ENABLED } from '@/app/constants';
+import type { WorkflowHistoryAction } from '@/features/workflows/workflowHistory/types';
+
+const i18n = useI18n();
+
+const props = withDefaults(
+	defineProps<{
+		workflowVersion: WorkflowVersion;
+		actions: Array<UserAction<IUser>>;
+		isVersionActive?: boolean;
+		isFirstItemShown?: boolean;
+		formattedCreatedAt: string;
+		versionNameDisplay: string;
+		description: string;
+		focusPanelWidth?: number;
+		isFocusPanelActive?: boolean;
+	}>(),
+	{
+		focusPanelWidth: 0,
+		isFocusPanelActive: false,
+	},
+);
+
+const emit = defineEmits<{
+	action: [value: WorkflowHistoryAction];
+}>();
+
+const isDraftPublishEnabled = IS_DRAFT_PUBLISH_ENABLED;
+
+const MAX_DESCRIPTION_LENGTH = 200;
+const isDescriptionExpanded = ref(false);
+
+const containerStyle = computed(() => {
+	if (props.isFocusPanelActive && props.focusPanelWidth > 0) {
+		return { width: `calc(100% - ${props.focusPanelWidth}px)` };
+	}
+	return {};
+});
+
+const isDescriptionLong = computed(() => props.description.length > MAX_DESCRIPTION_LENGTH);
+
+const displayDescription = computed(() => {
+	if (!isDescriptionLong.value || isDescriptionExpanded.value) {
+		return props.description;
+	}
+	return props.description.substring(0, MAX_DESCRIPTION_LENGTH) + '... ';
+});
+
+const filteredActions = computed(() => {
+	const excludedActions = new Set<string>();
+
+	if (props.isFirstItemShown) {
+		excludedActions.add('restore');
+	}
+
+	if (IS_DRAFT_PUBLISH_ENABLED) {
+		excludedActions.add(props.isVersionActive ? 'publish' : 'unpublish');
+	} else {
+		excludedActions.add('publish');
+		excludedActions.add('unpublish');
+	}
+
+	return props.actions.filter((action) => !excludedActions.has(action.value));
+});
+
+const toggleDescription = () => {
+	isDescriptionExpanded.value = !isDescriptionExpanded.value;
+};
+
+const onAction = (value: string) => {
+	emit('action', {
+		action: value as WorkflowHistoryActionTypes[number],
+		id: props.workflowVersion.versionId,
+		data: {
+			formattedCreatedAt: props.formattedCreatedAt,
+			versionName: props.versionNameDisplay,
+			description: props.description,
+		},
+	});
+};
+</script>
+
+<template>
+	<div :class="$style.info" :style="containerStyle">
+		<div :class="$style.card">
+			<div v-if="isDraftPublishEnabled" :class="$style.descriptionBox">
+				<N8nTooltip v-if="versionNameDisplay" :content="versionNameDisplay">
+					<N8nText :class="$style.mainLine" bold color="text-dark">{{
+						versionNameDisplay
+					}}</N8nText>
+				</N8nTooltip>
+				<N8nText v-if="description" size="small" color="text-base">
+					{{ displayDescription }}
+					<N8nLink v-if="isDescriptionLong" size="small" @click="toggleDescription">
+						{{
+							isDescriptionExpanded
+								? i18n.baseText('generic.showLess')
+								: i18n.baseText('generic.showMore')
+						}}
+					</N8nLink>
+				</N8nText>
+			</div>
+			<section v-else :class="$style.textOld">
+				<p>
+					<span :class="$style.label"> {{ i18n.baseText('workflowHistory.content.title') }}: </span>
+					<time :datetime="props.workflowVersion.createdAt">{{ formattedCreatedAt }}</time>
+				</p>
+				<p>
+					<span :class="$style.label">
+						{{ i18n.baseText('workflowHistory.content.editedBy') }}:
+					</span>
+					<span>{{ props.workflowVersion.authors }}</span>
+				</p>
+				<p>
+					<span :class="$style.label">
+						{{ i18n.baseText('workflowHistory.content.versionId') }}:
+					</span>
+					<data :value="props.workflowVersion.versionId">{{
+						props.workflowVersion.versionId
+					}}</data>
+				</p>
+			</section>
+			<N8nActionToggle
+				:class="$style.actions"
+				:actions="filteredActions"
+				placement="bottom-end"
+				data-test-id="workflow-history-content-actions"
+				@action="onAction"
+			>
+				<N8nButton type="tertiary" size="large" data-test-id="action-toggle-button">
+					{{ i18n.baseText('workflowHistory.content.actions') }}
+					<N8nIcon class="ml-3xs" icon="chevron-down" size="small" />
+				</N8nButton>
+			</N8nActionToggle>
+		</div>
+	</div>
+</template>
+
+<style module lang="scss">
+.info {
+	position: absolute;
+	z-index: 1;
+	top: 0;
+	left: 0;
+	width: 100%;
+}
+
+$descriptionBoxMaxWidth: 330px;
+
+.card {
+	display: flex;
+	align-items: start;
+	justify-content: space-between;
+	padding: var(--spacing--sm) var(--spacing--lg) 0;
+}
+
+.descriptionBox {
+	display: flex;
+	flex-direction: column;
+	max-width: $descriptionBoxMaxWidth;
+	gap: var(--spacing--3xs);
+	margin-top: var(--spacing--3xs);
+	padding: var(--spacing--xs);
+	border: var(--border-width) var(--border-style) var(--color--foreground);
+	border-radius: var(--radius);
+	background-color: var(--color--background--light-3);
+}
+
+.mainLine {
+	@include mixins.utils-ellipsis;
+	cursor: default;
+}
+
+.textOld {
+	display: flex;
+	flex-direction: column;
+	flex: 1 1 auto;
+
+	p {
+		display: flex;
+		align-items: center;
+		padding: 0;
+		cursor: default;
+
+		&:first-child {
+			padding-top: var(--spacing--3xs);
+			padding-bottom: var(--spacing--4xs);
+			* {
+				margin-top: auto;
+				font-size: var(--font-size--md);
+			}
+		}
+
+		&:last-child {
+			padding-top: var(--spacing--3xs);
+
+			* {
+				font-size: var(--font-size--2xs);
+			}
+		}
+
+		* {
+			max-width: unset;
+			justify-self: unset;
+			white-space: unset;
+			overflow: hidden;
+			text-overflow: unset;
+			padding: 0;
+			font-size: var(--font-size--sm);
+		}
+	}
+}
+
+.label {
+	color: var(--color--text--tint-1);
+	padding-right: var(--spacing--4xs);
+}
+
+.actions {
+	display: block;
+	padding: var(--spacing--3xs);
+}
+</style>

--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryContent.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryContent.vue
@@ -1,27 +1,22 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue';
+import { computed, ref } from 'vue';
 import type { IWorkflowDb, UserAction } from '@/Interface';
-import type {
-	WorkflowVersion,
-	WorkflowHistoryActionTypes,
-} from '@n8n/rest-api-client/api/workflowHistory';
+import type { WorkflowVersion } from '@n8n/rest-api-client/api/workflowHistory';
 import WorkflowPreview from '@/app/components/WorkflowPreview.vue';
+import WorkflowHistoryActions from '@/features/workflows/workflowHistory/components/WorkflowHistoryActions.vue';
 import { useI18n } from '@n8n/i18n';
 import type { IUser } from 'n8n-workflow';
 
-import {
-	N8nActionToggle,
-	N8nButton,
-	N8nIcon,
-	N8nLink,
-	N8nText,
-	N8nTooltip,
-} from '@n8n/design-system';
-import { IS_DRAFT_PUBLISH_ENABLED } from '@/app/constants';
 import { formatTimestamp, generateVersionName } from '@/features/workflows/workflowHistory/utils';
 import type { WorkflowHistoryAction } from '@/features/workflows/workflowHistory/types';
 
 const i18n = useI18n();
+
+const focusPanelState = ref<{ width: number; active: boolean }>({ width: 0, active: false });
+
+const onFocusPanelStateChanged = (state: { width: number; active: boolean }) => {
+	focusPanelState.value = state;
+};
 
 const props = defineProps<{
 	workflow: IWorkflowDb | null;
@@ -35,8 +30,6 @@ const props = defineProps<{
 const emit = defineEmits<{
 	action: [value: WorkflowHistoryAction];
 }>();
-
-const isDraftPublishEnabled = IS_DRAFT_PUBLISH_ENABLED;
 
 const workflowVersionPreview = computed<IWorkflowDb | undefined>(() => {
 	if (!props.workflowVersion || !props.workflow) {
@@ -67,66 +60,11 @@ const versionNameDisplay = computed(() => {
 		: formattedCreatedAt.value;
 });
 
-const MAX_DESCRIPTION_LENGTH = 200;
-const isDescriptionExpanded = ref(false);
-
 const description = computed(() => props.workflowVersion?.description ?? '');
-const isDescriptionLong = computed(() => description.value.length > MAX_DESCRIPTION_LENGTH);
-const displayDescription = computed(() => {
-	if (!isDescriptionLong.value || isDescriptionExpanded.value) {
-		return description.value;
-	}
-	return description.value.substring(0, MAX_DESCRIPTION_LENGTH) + '... ';
-});
 
-const toggleDescription = () => {
-	isDescriptionExpanded.value = !isDescriptionExpanded.value;
+const onAction = (value: WorkflowHistoryAction) => {
+	emit('action', value);
 };
-
-const actions = computed(() => {
-	let filteredActions = props.actions;
-
-	if (props.isFirstItemShown) {
-		filteredActions = filteredActions.filter((action) => action.value !== 'restore');
-	}
-
-	if (isDraftPublishEnabled) {
-		if (props.isVersionActive) {
-			filteredActions = filteredActions.filter((action) => action.value !== 'publish');
-		} else {
-			filteredActions = filteredActions.filter((action) => action.value !== 'unpublish');
-		}
-	} else {
-		filteredActions = filteredActions.filter(
-			(action) => action.value !== 'publish' && action.value !== 'unpublish',
-		);
-	}
-
-	return filteredActions;
-});
-
-const onAction = (value: string) => {
-	if (!props.workflowVersion) {
-		return;
-	}
-	const action = value as WorkflowHistoryActionTypes[number];
-	emit('action', {
-		action,
-		id: props.workflowVersion.versionId,
-		data: {
-			formattedCreatedAt: formattedCreatedAt.value,
-			versionName: versionNameDisplay.value,
-			description: description.value,
-		},
-	});
-};
-
-watch(
-	() => props.workflowVersion,
-	() => {
-		isDescriptionExpanded.value = false;
-	},
-);
 </script>
 
 <template>
@@ -136,62 +74,21 @@ watch(
 			:workflow="workflowVersionPreview"
 			:loading="props.isListLoading"
 			loader-type="spinner"
+			@focus-panel-state-changed="onFocusPanelStateChanged"
 		/>
-		<div v-if="props.workflowVersion" :class="$style.info">
-			<div :class="$style.card">
-				<div v-if="isDraftPublishEnabled" :class="$style.descriptionBox">
-					<N8nTooltip v-if="versionNameDisplay" :content="versionNameDisplay">
-						<N8nText :class="$style.mainLine" bold color="text-dark">{{
-							versionNameDisplay
-						}}</N8nText>
-					</N8nTooltip>
-					<N8nText v-if="description" size="small" color="text-base">
-						{{ displayDescription }}
-						<N8nLink v-if="isDescriptionLong" size="small" @click="toggleDescription">
-							{{
-								isDescriptionExpanded
-									? i18n.baseText('generic.showLess')
-									: i18n.baseText('generic.showMore')
-							}}
-						</N8nLink>
-					</N8nText>
-				</div>
-				<section v-else :class="$style.textOld">
-					<p>
-						<span :class="$style.label">
-							{{ i18n.baseText('workflowHistory.content.title') }}:
-						</span>
-						<time :datetime="props.workflowVersion.createdAt">{{ formattedCreatedAt }}</time>
-					</p>
-					<p>
-						<span :class="$style.label">
-							{{ i18n.baseText('workflowHistory.content.editedBy') }}:
-						</span>
-						<span>{{ props.workflowVersion.authors }}</span>
-					</p>
-					<p>
-						<span :class="$style.label">
-							{{ i18n.baseText('workflowHistory.content.versionId') }}:
-						</span>
-						<data :value="props.workflowVersion.versionId">{{
-							props.workflowVersion.versionId
-						}}</data>
-					</p>
-				</section>
-				<N8nActionToggle
-					:class="$style.actions"
-					:actions="actions"
-					placement="bottom-end"
-					data-test-id="workflow-history-content-actions"
-					@action="onAction"
-				>
-					<N8nButton type="tertiary" size="large" data-test-id="action-toggle-button">
-						{{ i18n.baseText('workflowHistory.content.actions') }}
-						<N8nIcon class="ml-3xs" icon="chevron-down" size="small" />
-					</N8nButton>
-				</N8nActionToggle>
-			</div>
-		</div>
+		<WorkflowHistoryActions
+			v-if="props.workflowVersion"
+			:workflow-version="props.workflowVersion"
+			:actions="props.actions"
+			:is-version-active="props.isVersionActive"
+			:is-first-item-shown="props.isFirstItemShown"
+			:formatted-created-at="formattedCreatedAt"
+			:version-name-display="versionNameDisplay"
+			:description="description"
+			:focus-panel-width="focusPanelState.width"
+			:is-focus-panel-active="focusPanelState.active"
+			@action="onAction"
+		/>
 	</div>
 </template>
 
@@ -204,89 +101,5 @@ watch(
 	width: 100%;
 	height: 100%;
 	overflow: auto;
-}
-
-.info {
-	position: absolute;
-	z-index: 1;
-	top: 0;
-	left: 0;
-	width: 100%;
-}
-
-$descriptionBoxMaxWidth: 330px;
-
-.card {
-	display: flex;
-	align-items: start;
-	justify-content: space-between;
-	padding: var(--spacing--sm) var(--spacing--lg) 0;
-}
-
-.descriptionBox {
-	display: flex;
-	flex-direction: column;
-	max-width: $descriptionBoxMaxWidth;
-	gap: var(--spacing--3xs);
-	margin-top: var(--spacing--3xs);
-	padding: var(--spacing--xs);
-	border: var(--border-width) var(--border-style) var(--color--foreground);
-	border-radius: var(--radius);
-	background-color: var(--color--background--light-3);
-}
-
-.mainLine {
-	@include mixins.utils-ellipsis;
-	cursor: default;
-}
-
-.textOld {
-	display: flex;
-	flex-direction: column;
-	flex: 1 1 auto;
-
-	p {
-		display: flex;
-		align-items: center;
-		padding: 0;
-		cursor: default;
-
-		&:first-child {
-			padding-top: var(--spacing--3xs);
-			padding-bottom: var(--spacing--4xs);
-			* {
-				margin-top: auto;
-				font-size: var(--font-size--md);
-			}
-		}
-
-		&:last-child {
-			padding-top: var(--spacing--3xs);
-
-			* {
-				font-size: var(--font-size--2xs);
-			}
-		}
-
-		* {
-			max-width: unset;
-			justify-self: unset;
-			white-space: unset;
-			overflow: hidden;
-			text-overflow: unset;
-			padding: 0;
-			font-size: var(--font-size--sm);
-		}
-	}
-}
-
-.label {
-	color: var(--color--text--tint-1);
-	padding-right: var(--spacing--4xs);
-}
-
-.actions {
-	display: block;
-	padding: var(--spacing--3xs);
 }
 </style>


### PR DESCRIPTION
## Summary
The workflow history actions render changes based on the focus panel. This enables users to view the focus panel and close it if not needed. 

- Created new WorkflowHistoryActions component - Extracted action-related UI (version info display, action toggle button) from WorkflowHistoryContent.vue into a dedicated component for better separation of concerns
- Uses cross-iframe communication for FocusPanel width - Added postMessage-based communication between the iframe (containing FocusPanel) and the parent window to dynamically adjust WorkflowHistoryActions width when FocusPanel is active

https://www.loom.com/share/656d82235546495986ef268da0dfb382

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/ADO-4557/bug-focus-tab-not-showing-up-in-workflow-history
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
