### PR TITLE
feat(editor): Group sub-node execution errors with same messages inside a tooltip

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeStatusIcons.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeStatusIcons.vue
@@ -49,6 +49,20 @@ const commonClasses = computed(() => [
 	spinnerScrim ? $style.spinnerScrim : '',
 	spinnerLayout === 'absolute' ? $style.absoluteSpinner : '',
 ]);
+
+const groupedExecutionErrors = computed(() => {
+	const errorCounts = executionErrors.value.reduce(
+		(acc, error) => {
+			acc[error] = (acc[error] || 0) + 1;
+			return acc;
+		},
+		{} as Record<string, number>,
+	);
+
+	return Object.entries(errorCounts).map(([error, count]) =>
+		count > 1 ? `${error} (x${count})` : error,
+	);
+});
 </script>
 
 <template>
@@ -72,7 +86,7 @@ const commonClasses = computed(() => [
 	>
 		<N8nTooltip :show-after="500" placement="bottom">
 			<template #content>
-				<TitledList :title="`${i18n.baseText('node.issues')}:`" :items="executionErrors" />
+				<TitledList :title="`${i18n.baseText('node.issues')}:`" :items="groupedExecutionErrors" />
 			</template>
 			<N8nIcon icon="node-execution-error" :size="size" />
 		</N8nTooltip>


### PR DESCRIPTION
## Summary

Instead of showing N identical error messages per each execution of a sub-node in its tooltip, same errors are grouped now.
<img width="741" height="511" alt="image" src="https://github.com/user-attachments/assets/67b8b096-f0be-4018-bfa5-b18e5bd3df39" />

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-1814/structured-output-parser-error-tooltip-overflows-canvasviewport


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
