### PR TITLE
fix/feat(editor): Enhance mapping functions to support JSON/Table drag-and-drop supports explicit item indexing

### DIFF
--- a/packages/frontend/editor-ui/src/app/utils/mappingUtils.ts
+++ b/packages/frontend/editor-ui/src/app/utils/mappingUtils.ts
@@ -30,12 +30,14 @@ export function getMappedExpression({
 	nodeName,
 	distanceFromActive,
 	path,
+	itemIndex,
 }: {
 	nodeName: string;
 	distanceFromActive: number;
 	path: Array<string | number> | string;
+	itemIndex?: number;
 }) {
-	const root = getNodeParentExpression({ nodeName, distanceFromActive });
+	const root = getNodeParentExpression({ nodeName, distanceFromActive, itemIndex });
 
 	if (typeof path === 'string') {
 		return `{{ ${root}${path} }}`;
@@ -47,10 +49,16 @@ export function getMappedExpression({
 export function getNodeParentExpression({
 	nodeName,
 	distanceFromActive,
+	itemIndex,
 }: {
 	nodeName: string;
 	distanceFromActive: number;
+	itemIndex?: number;
 }) {
+	if (itemIndex !== undefined && itemIndex > 0) {
+		return generatePath(`$('${escapeMappingString(nodeName)}').all()`, [itemIndex, 'json']);
+	}
+
 	return distanceFromActive === 1
 		? '$json'
 		: generatePath(`$('${escapeMappingString(nodeName)}')`, ['item', 'json']);

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataJson.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataJson.vue
@@ -67,12 +67,20 @@ const getShortKey = (el: HTMLElement) => {
 };
 
 const getJsonParameterPath = (path: string) => {
-	const subPath = path.replace(/^(\["?\d"?])/, ''); // remove item position
+	const match = path.match(/^\["?(\d+)"?]/);
+	let itemIndex: number | undefined;
+	let subPath = path;
+
+	if (match) {
+		itemIndex = parseInt(match[1], 10);
+		subPath = path.replace(/^(\["?\d"?])/, '');
+	}
 
 	return getMappedExpression({
 		nodeName: props.node.name,
 		distanceFromActive: props.distanceFromActive,
 		path: subPath,
+		itemIndex,
 	});
 };
 

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataTable.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataTable.vue
@@ -189,16 +189,16 @@ function onMouseLeaveCell() {
 	hoveringColumnIndex.value = -1;
 }
 
-function onMouseEnterKey(path: Array<string | number>, colIndex: number) {
-	hoveringPath.value = getCellExpression(path, colIndex);
+function onMouseEnterKey(path: Array<string | number>, colIndex: number, rowIndex?: number) {
+	hoveringPath.value = getCellExpression(path, colIndex, rowIndex);
 }
 
 function onMouseLeaveKey() {
 	hoveringPath.value = null;
 }
 
-function isHovering(path: Array<string | number>, colIndex: number) {
-	const expr = getCellExpression(path, colIndex);
+function isHovering(path: Array<string | number>, colIndex: number, rowIndex?: number) {
+	const expr = getCellExpression(path, colIndex, rowIndex);
 
 	return hoveringPath.value === expr;
 }
@@ -235,7 +235,7 @@ function getCellPathName(path: Array<string | number>, colIndex: number) {
 	return `${column}[${lastKey}]`;
 }
 
-function getCellExpression(path: Array<string | number>, colIndex: number) {
+function getCellExpression(path: Array<string | number>, colIndex: number, rowIndex?: number) {
 	if (!props.node) {
 		return '';
 	}
@@ -244,6 +244,7 @@ function getCellExpression(path: Array<string | number>, colIndex: number) {
 		nodeName: props.node.name,
 		distanceFromActive: props.distanceFromActive,
 		path: [column, ...path],
+		itemIndex: rowIndex,
 	});
 }
 
@@ -303,12 +304,12 @@ function onCellDragEnd(el: HTMLElement) {
 	onDragEnd(el.dataset.name ?? '', 'tree', el.dataset.depth ?? '0');
 }
 
-function isDraggingKey(path: Array<string | number>, colIndex: number) {
+function isDraggingKey(path: Array<string | number>, colIndex: number, rowIndex?: number) {
 	if (!draggingPath.value) {
 		return;
 	}
 
-	return draggingPath.value === getCellExpression(path, colIndex);
+	return draggingPath.value === getCellExpression(path, colIndex, rowIndex);
 }
 
 function onDragEnd(column: string, src: string, depth = '0') {
@@ -731,17 +732,17 @@ watch(
 								<TextWithHighlights
 									data-target="mappable"
 									:class="{
-										[$style.hoveringKey]: mappingEnabled && isHovering(path, index2),
-										[$style.draggingKey]: isDraggingKey(path, index2),
+										[$style.hoveringKey]: mappingEnabled && isHovering(path, index2, index1),
+										[$style.draggingKey]: isDraggingKey(path, index2, index1),
 										[$style.dataKey]: true,
 										[$style.mappable]: mappingEnabled,
 									}"
 									:content="label || i18n.baseText('runData.unnamedField')"
 									:search="search"
 									:data-name="getCellPathName(path, index2)"
-									:data-value="getCellExpression(path, index2)"
+									:data-value="getCellExpression(path, index2, index1)"
 									:data-depth="path.length"
-									@mouseenter="() => onMouseEnterKey(path, index2)"
+									@mouseenter="() => onMouseEnterKey(path, index2, index1)"
 									@mouseleave="onMouseLeaveKey"
 								/>
 							</template>


### PR DESCRIPTION
Summary

Fix drag-and-drop mapping in the NDV to work reliably with multi-item inputs (appends/merges).
Keep Schema view behavior unchanged (maps to “current item” with $json).
In JSON/Table views, when dragging from item index > 0, generate explicit item references using $('Node').all()[index].json.field.
Problem

Current drag generates {{ $json.field }}, which assumes a single “current item.” In workflows that append/merge items, this is ambiguous and can resolve to the wrong item.
Solution

Use $('NodeName').all()[index].json.field for drags from non-zero item rows in JSON/Table views.
Heuristics:
Schema view: {{ $json... }} (unchanged).
JSON/Table:
Item 0 → {{ $json... }}.
Item > 0 → {{ $('NodeName').all()[index].json... }}.
Prefer $('Node').all() over legacy $items() for clarity and support.
UX Behavior

Schema: drag account.name → {{ $json.account.name }}.
JSON: drag name from Item 0 → {{ $json.name }}; from Item 1 (node “Code”) → {{ $('Code').all()[1].json.name }}.
Table: drag nested.val from second row (node “Code”) → {{ $('Code').all()[1].json.nested.val }}.
Implementation

Expression builder now accepts optional itemIndex and emits explicit roots when itemIndex > 0:
packages/frontend/editor-ui/src/app/utils/mappingUtils.ts
JSON view extracts the leading “[N]” from the path and passes itemIndex:
packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataJson.vue
Table view passes row index as itemIndex when generating cell expressions:
packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataTable.vue
Backward Compatibility

Existing mappings with {{ $json... }} remain unchanged.
Dragging from Item 0 continues to produce {{ $json... }}.
Only drags from items with index > 0 generate explicit item references.
How To Test

Build/run:
Backend:
pnpm --filter @n8n/db build
pnpm --filter n8n-core build
pnpm --filter @n8n/task-runner build
pnpm --filter n8n build && pnpm --filter n8n exec tsc-alias -p tsconfig.build.json && pnpm --filter n8n run build:data
pnpm --filter n8n start
Editor: pnpm --filter n8n-editor-ui dev (open http://localhost:8080)
Workflow:
Code node → returns two items:
{ id: 1, name: 'A', nested: { val: 10 } }
{ id: 2, name: 'B', nested: { val: 20 } }
Connect to Set node and map fields by drag-and-drop:
Schema: drag name → {{ $json.name }}.
JSON: drag name from Item 0 → {{ $json.name }}; from Item 1 → {{ $('Code').all()[1].json.name }}.
Table: drag nested.val from row 2 → {{ $('Code').all()[1].json.nested.val }}.
Execute and verify values resolve as expected.
Tests

Frontend unit (fast iteration):
pnpm --filter n8n-editor-ui test:dev -- --bail=1
Focus on NDV/mapping specs; update snapshots if needed (-u).
Playwright (targeted):
pnpm --filter @n8n/testing test:playwright -- packages/testing/playwright/tests/ndv --max-failures=1
Exclude performance specs when iterating.
Docs

Add a short section explaining Schema vs JSON/Table drag behavior and explicit indexing recommendation when dealing with merges/appends.
Related Linear / Issues

closes #<issue-number>
https://linear.app/n8n/issue/<id> (if any)
Review / Merge checklist

 Title follows conventions; include (no-changelog) if not user-facing.
 Docs PR linked or follow-up ticket created.
 Tests included/updated for mapping behavior (JSON/Table drags).
 Labeled for backport if urgent.
If you want, I can drop this into your PR description and push minor test updates to cover the new expression outputs.