### PR TITLE
fix(core): Validate missing `code` param in Code node

### DIFF
--- a/packages/cli/test/integration/database/repositories/execution.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/execution.repository.test.ts
@@ -1,9 +1,10 @@
 import { createWorkflow, testDb } from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
+import type { ExecutionData } from '@n8n/db';
 import { ExecutionDataRepository, ExecutionRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
-import type { IRunExecutionData, IRunExecutionDataAll } from 'n8n-workflow';
 import { stringify } from 'flatted';
+import type { IRunExecutionData, IRunExecutionDataAll } from 'n8n-workflow';
 
 describe('ExecutionRepository', () => {
 	beforeAll(async () => {
@@ -115,7 +116,7 @@ describe('ExecutionRepository', () => {
 				executionId,
 				workflowData: { id: workflow.id, connections: {}, nodes: [], name: workflow.name },
 				data: stringify(v0Data),
-			});
+			} as unknown as Partial<ExecutionData>);
 
 			// Read the execution back
 			const execution = await executionRepo.findSingleExecution(executionId, {

--- a/packages/cli/test/integration/database/repositories/execution.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/execution.repository.test.ts
@@ -1,6 +1,5 @@
 import { createWorkflow, testDb } from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
-import type { ExecutionData } from '@n8n/db';
 import { ExecutionDataRepository, ExecutionRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { stringify } from 'flatted';

--- a/packages/cli/test/integration/database/repositories/execution.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/execution.repository.test.ts
@@ -116,7 +116,7 @@ describe('ExecutionRepository', () => {
 				executionId,
 				workflowData: { id: workflow.id, connections: {}, nodes: [], name: workflow.name },
 				data: stringify(v0Data),
-			} as unknown as Partial<ExecutionData>);
+			});
 
 			// Read the execution back
 			const execution = await executionRepo.findSingleExecution(executionId, {

--- a/packages/nodes-base/nodes/Code/PythonTaskRunnerSandbox.ts
+++ b/packages/nodes-base/nodes/Code/PythonTaskRunnerSandbox.ts
@@ -3,6 +3,7 @@ import {
 	type IExecuteFunctions,
 	type INodeExecutionData,
 	type WorkflowExecuteMode,
+	NodeOperationError,
 } from 'n8n-workflow';
 
 import type { TextKeys } from './result-validation';
@@ -22,6 +23,15 @@ export class PythonTaskRunnerSandbox {
 		private readonly additionalProperties: Record<string, unknown> = {},
 	) {}
 
+	private validateCode(): void {
+		if (typeof this.pythonCode !== 'string') {
+			throw new NodeOperationError(
+				this.executeFunctions.getNode(),
+				'No Python code found to execute. Please add code to the Code node.',
+			);
+		}
+	}
+
 	/**
 	 * Run a script by forwarding it to a Python task runner, together with input items.
 	 *
@@ -30,6 +40,8 @@ export class PythonTaskRunnerSandbox {
 	 * instead retrieves them later, only if needed, via an RPC request.
 	 */
 	async runUsingIncomingItems() {
+		this.validateCode();
+
 		const itemIndex = 0;
 
 		const node = this.executeFunctions.getNode();
@@ -84,6 +96,8 @@ export class PythonTaskRunnerSandbox {
 	 * - Does not validate the result from the runner (tools can return any type)
 	 */
 	async runCodeForTool(): Promise<unknown> {
+		this.validateCode();
+
 		const itemIndex = 0;
 
 		const node = this.executeFunctions.getNode();

--- a/packages/nodes-base/nodes/Code/test/PythonTaskRunnerSandbox.test.ts
+++ b/packages/nodes-base/nodes/Code/test/PythonTaskRunnerSandbox.test.ts
@@ -1,6 +1,6 @@
 import { mock } from 'jest-mock-extended';
 import type { IExecuteFunctions } from 'n8n-workflow';
-import { createResultOk, createResultError } from 'n8n-workflow';
+import { createResultOk, createResultError, NodeOperationError } from 'n8n-workflow';
 
 import { PythonTaskRunnerSandbox } from '../PythonTaskRunnerSandbox';
 
@@ -135,6 +135,25 @@ describe('PythonTaskRunnerSandbox', () => {
 			await expect(sandbox.runUsingIncomingItems()).rejects.toThrow('Execution failed');
 			expect(throwExecutionErrorSpy).toHaveBeenCalledWith(executionError);
 		});
+
+		it('should throw NodeOperationError when pythonCode is undefined', async () => {
+			const nodeMode = 'runOnceForAllItems';
+			const workflowMode = 'manual';
+			const executeFunctions = createMockExecuteFunctions([]);
+
+			const sandbox = new PythonTaskRunnerSandbox(
+				undefined as unknown as string,
+				nodeMode,
+				workflowMode,
+				executeFunctions,
+			);
+
+			await expect(sandbox.runUsingIncomingItems()).rejects.toThrow(NodeOperationError);
+			await expect(sandbox.runUsingIncomingItems()).rejects.toThrow(
+				'No Python code found to execute',
+			);
+			expect(executeFunctions.startJob).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('runCodeForTool', () => {
@@ -253,6 +272,24 @@ describe('PythonTaskRunnerSandbox', () => {
 
 			await expect(sandbox.runCodeForTool()).rejects.toThrow('Tool execution failed');
 			expect(throwExecutionErrorSpy).toHaveBeenCalledWith(executionError);
+		});
+
+		it('should throw NodeOperationError when pythonCode is undefined', async () => {
+			const nodeMode = 'runOnceForAllItems';
+			const workflowMode = 'manual';
+			const executeFunctions = createMockExecuteFunctions([]);
+
+			const sandbox = new PythonTaskRunnerSandbox(
+				undefined as unknown as string,
+				nodeMode,
+				workflowMode,
+				executeFunctions,
+				{ query: 'test' },
+			);
+
+			await expect(sandbox.runCodeForTool()).rejects.toThrow(NodeOperationError);
+			await expect(sandbox.runCodeForTool()).rejects.toThrow('No Python code found to execute');
+			expect(executeFunctions.startJob).not.toHaveBeenCalled();
 		});
 	});
 });


### PR DESCRIPTION
Noticed this issue in passing - the current typing of node params is best-effort so it's not guaranteed that a Code node task always has a populated `code` param.

https://n8nio.sentry.io/issues/6913452586/?project=4508342481780736