### PR TITLE
fix: Limit access to files based on regex pattern

### DIFF
--- a/packages/@n8n/config/src/configs/security.config.ts
+++ b/packages/@n8n/config/src/configs/security.config.ts
@@ -21,6 +21,14 @@ export class SecurityConfig {
 	blockFileAccessToN8nFiles: boolean = true;
 
 	/**
+	 * Blocked file and folder regular expression patterns that `ReadWriteFile` and `ReadBinaryFiles` nodes cant access. Separate multiple patterns with with semicolon `;`.
+	 * - `^(.*\/)*\.git(\/.*)*$`
+	 * Set to empty to not block based on file patterns.
+	 */
+	@Env('N8N_BLOCK_FILE_PATTERNS')
+	blockFilePatterns: string = '^(.*\\/)*\\.git(\\/.*)*$';
+
+	/**
 	 * In a [security audit](https://docs.n8n.io/hosting/securing/security-audit/), how many days for a workflow to be considered abandoned if not executed.
 	 */
 	@Env('N8N_SECURITY_AUDIT_DAYS_ABANDONED_WORKFLOW')

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -319,6 +319,7 @@ describe('GlobalConfig', () => {
 		security: {
 			restrictFileAccessTo: '~/.n8n-files',
 			blockFileAccessToN8nFiles: true,
+			blockFilePatterns: '^(.*\\/)*\\.git(\\/.*)*$',
 			daysAbandonedWorkflow: 90,
 			contentSecurityPolicy: '{}',
 			contentSecurityPolicyReportOnly: false,

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
@@ -201,7 +201,7 @@ describe('isFilePathBlocked', () => {
 
 	it('should allow access when pattern matching is disabled', async () => {
 		securityConfig.blockFilePatterns = '';
-		expect(isFilePathBlocked(await resolvePath("'/tmp/.git'"))).toBe(false);
+		expect(isFilePathBlocked(await resolvePath('/tmp/.git'))).toBe(false);
 	});
 
 	describe('when multiple file patterns are configured', () => {

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
@@ -204,6 +204,11 @@ describe('isFilePathBlocked', () => {
 		expect(isFilePathBlocked(await resolvePath('/tmp/.git'))).toBe(false);
 	});
 
+	it('should block all access when using invalid pattern', async () => {
+		securityConfig.blockFilePatterns = '(';
+		expect(isFilePathBlocked(await resolvePath('/tmp/xo'))).toBe(true);
+	});
+
 	describe('when multiple file patterns are configured', () => {
 		beforeEach(() => {
 			securityConfig.blockFilePatterns = 'hello; \\/there$; ^where';

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
@@ -193,11 +193,12 @@ describe('isFilePathBlocked', () => {
 		expect(isFilePathBlocked(await resolvePath(filePath))).toBe(true);
 	});
 
-	['.git', '/.git', '/tmp/.git', '/tmp/.git/config'].forEach((path) => {
-		it(`should per default block access to ${path}`, async () => {
+	it.each(['.git', '/.git', '/tmp/.git', '/tmp/.git/config'])(
+		'should per default block access to %s',
+		async (path) => {
 			expect(isFilePathBlocked(await resolvePath(path))).toBe(true);
-		});
-	});
+		},
+	);
 
 	it('should allow access when pattern matching is disabled', async () => {
 		securityConfig.blockFilePatterns = '';
@@ -214,7 +215,7 @@ describe('isFilePathBlocked', () => {
 			securityConfig.blockFilePatterns = 'hello; \\/there$; ^where';
 		});
 
-		[
+		it.each([
 			'hello',
 			'xhellox',
 			'subpath/hello/',
@@ -222,16 +223,12 @@ describe('isFilePathBlocked', () => {
 			'/subpath/there',
 			'where',
 			'where-is/it',
-		].forEach((path) => {
-			it(`should block access to ${path}`, async () => {
-				expect(isFilePathBlocked(await resolvePath(path))).toBe(true);
-			});
+		])('should block access to %s', async (path) => {
+			expect(isFilePathBlocked(await resolvePath(path))).toBe(true);
 		});
 
-		['/there/is', '/where'].forEach((path) => {
-			it(`should not block access to ${path}`, async () => {
-				expect(isFilePathBlocked(await resolvePath(path))).toBe(false);
-			});
+		it.each(['/there/is', '/where'])('should not block access to %s', async (path) => {
+			expect(isFilePathBlocked(await resolvePath(path))).toBe(false);
 		});
 	});
 });

--- a/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
@@ -47,6 +47,16 @@ async function resolvePath(path: PathLike): Promise<ResolvedFilePath> {
 	}
 }
 
+function isFilePatternBlocked(resolvedFilePath: ResolvedFilePath): boolean {
+	const { blockFilePatterns } = Container.get(SecurityConfig);
+
+	return blockFilePatterns
+		.split(';')
+		.map((pattern) => pattern.trim())
+		.filter((pattern) => pattern)
+		.some((pattern) => new RegExp(pattern, 'mi').test(resolvedFilePath));
+}
+
 function isFilePathBlocked(resolvedFilePath: ResolvedFilePath): boolean {
 	const allowedPaths = getAllowedPaths();
 	const blockFileAccessToN8nFiles = process.env[BLOCK_FILE_ACCESS_TO_N8N_FILES] !== 'false';
@@ -55,6 +65,10 @@ function isFilePathBlocked(resolvedFilePath: ResolvedFilePath): boolean {
 	if (
 		restrictedPaths.some((restrictedPath) => isContainedWithin(restrictedPath, resolvedFilePath))
 	) {
+		return true;
+	}
+
+	if (isFilePatternBlocked(resolvedFilePath)) {
 		return true;
 	}
 

--- a/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
@@ -54,7 +54,13 @@ function isFilePatternBlocked(resolvedFilePath: ResolvedFilePath): boolean {
 		.split(';')
 		.map((pattern) => pattern.trim())
 		.filter((pattern) => pattern)
-		.some((pattern) => new RegExp(pattern, 'mi').test(resolvedFilePath));
+		.some((pattern) => {
+			try {
+				return new RegExp(pattern, 'mi').test(resolvedFilePath);
+			} catch {
+				return true;
+			}
+		});
 }
 
 function isFilePathBlocked(resolvedFilePath: ResolvedFilePath): boolean {


### PR DESCRIPTION
## Summary

Limit read/write access based on (configurable) file pattern

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4106


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
