### PR TITLE
ci: Extract docker-registry-login composite action

### DIFF
--- a/.github/actions/docker-registry-login/action.yml
+++ b/.github/actions/docker-registry-login/action.yml
@@ -1,0 +1,39 @@
+# Composite action for logging into Docker registries (GHCR and/or DockerHub).
+# Centralizes the login pattern used across multiple Docker workflows.
+
+name: 'Docker Registry Login'
+description: 'Login to GitHub Container Registry and/or DockerHub'
+
+inputs:
+  login-ghcr:
+    description: 'Login to GitHub Container Registry'
+    required: false
+    default: 'true'
+  login-dockerhub:
+    description: 'Login to DockerHub'
+    required: false
+    default: 'false'
+  dockerhub-username:
+    description: 'DockerHub username (required if login-dockerhub is true)'
+    required: false
+  dockerhub-password:
+    description: 'DockerHub password (required if login-dockerhub is true)'
+    required: false
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Login to GitHub Container Registry
+      if: inputs.login-ghcr == 'true'
+      uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+
+    - name: Login to DockerHub
+      if: inputs.login-dockerhub == 'true'
+      uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+      with:
+        username: ${{ inputs.dockerhub-username }}
+        password: ${{ inputs.dockerhub-password }}

--- a/.github/workflows/docker-base-image.yml
+++ b/.github/workflows/docker-base-image.yml
@@ -32,20 +32,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
-      - name: Login to GitHub Container Registry
+      - name: Login to Docker registries
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push == true)
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: ./.github/actions/docker-registry-login
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Login to DockerHub
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push == true)
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          login-ghcr: true
+          login-dockerhub: true
+          dockerhub-username: ${{ secrets.DOCKER_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -105,22 +105,14 @@ jobs:
             echo "${key}: ${value%%,*}..."  # Show first tag for brevity
           done
 
-      - name: Login to GitHub Container Registry
+      - name: Login to Docker registries
         if: needs.determine-build-context.outputs.push_enabled == 'true'
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: ./.github/actions/docker-registry-login
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Login to Docker Hub
-        if: |
-          needs.determine-build-context.outputs.push_enabled == 'true' &&
-          needs.determine-build-context.outputs.push_to_docker == 'true'
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          login-ghcr: true
+          login-dockerhub: ${{ needs.determine-build-context.outputs.push_to_docker == 'true' }}
+          dockerhub-username: ${{ secrets.DOCKER_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push n8n Docker image
         uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
@@ -175,22 +167,19 @@ jobs:
       needs.build-and-push-docker.result == 'success' &&
       needs.determine-build-context.outputs.push_enabled == 'true'
     steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+      - name: Login to Docker registries
+        uses: ./.github/actions/docker-registry-login
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Login to Docker Hub
-        if: needs.determine-build-context.outputs.push_to_docker == 'true'
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          login-ghcr: true
+          login-dockerhub: ${{ needs.determine-build-context.outputs.push_to_docker == 'true' }}
+          dockerhub-username: ${{ secrets.DOCKER_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Create GHCR multi-arch manifests
         run: |

--- a/.github/workflows/docker-images-benchmark.yml
+++ b/.github/workflows/docker-images-benchmark.yml
@@ -25,11 +25,9 @@ jobs:
         uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        uses: ./.github/actions/docker-registry-login
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          login-ghcr: true
 
       - name: Build
         uses: docker/build-push-action@b32b51a8eda65d6793cd0494a773d4f6bcef32dc # v6.11.0

--- a/.github/workflows/docker-images-benchmark.yml
+++ b/.github/workflows/docker-images-benchmark.yml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: ./.github/actions/docker-registry-login
-        with:
-          login-ghcr: true
 
       - name: Build
         uses: docker/build-push-action@b32b51a8eda65d6793cd0494a773d4f6bcef32dc # v6.11.0

--- a/.github/workflows/release-push-to-channel.yml
+++ b/.github/workflows/release-push-to-channel.yml
@@ -120,8 +120,6 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: ./.github/actions/docker-registry-login
-        with:
-          login-ghcr: true
 
       - name: Tag stable/latest GHCR image
         if: needs.validate-inputs.outputs.release_channel == 'stable'

--- a/.github/workflows/release-push-to-channel.yml
+++ b/.github/workflows/release-push-to-channel.yml
@@ -82,10 +82,16 @@ jobs:
     needs: validate-inputs
     timeout-minutes: 5
     steps:
-      - uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Login to DockerHub
+        uses: ./.github/actions/docker-registry-login
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          login-ghcr: false
+          login-dockerhub: true
+          dockerhub-username: ${{ secrets.DOCKER_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Tag stable/latest Docker image
         if: needs.validate-inputs.outputs.release_channel == 'stable'
@@ -109,11 +115,13 @@ jobs:
     needs: validate-inputs
     timeout-minutes: 5
     steps:
-      - uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Login to GitHub Container Registry
+        uses: ./.github/actions/docker-registry-login
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          login-ghcr: true
 
       - name: Tag stable/latest GHCR image
         if: needs.validate-inputs.outputs.release_channel == 'stable'


### PR DESCRIPTION
## Summary

  - Create `.github/actions/docker-registry-login` composite action to centralize GHCR and DockerHub login patterns
  - Replace 9 duplicate login steps across 4 workflow files with 6 action calls
  - Upgrade `docker/login-action` from v3.3.0/v3.4.0 to v3.6.0
  - Supports logging into GHCR only, DockerHub only, or both

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1936

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
