### PR TITLE
feat(core): Add log streaming events for variables

### DIFF
--- a/packages/cli/src/environments.ee/variables/variables.service.ee.ts
+++ b/packages/cli/src/environments.ee/variables/variables.service.ee.ts
@@ -150,6 +150,8 @@ export class VariablesService {
 			throw new ForbiddenError('You are not allowed to delete this variable');
 		}
 
+		await this.delete(id);
+
 		this.eventService.emit('variable-deleted', {
 			user: {
 				id: user.id,
@@ -162,8 +164,6 @@ export class VariablesService {
 			variableKey: existingVariable?.key ?? '',
 			projectId: existingVariable?.project?.id,
 		});
-
-		await this.delete(id);
 	}
 
 	async delete(id: string): Promise<void> {

--- a/packages/cli/src/environments.ee/variables/variables.service.ee.ts
+++ b/packages/cli/src/environments.ee/variables/variables.service.ee.ts
@@ -162,7 +162,7 @@ export class VariablesService {
 			},
 			variableId: id,
 			variableKey: existingVariable?.key ?? '',
-			projectId: existingVariable?.project?.id,
+			...(existingVariable?.project?.id && { projectId: existingVariable.project.id }),
 		});
 	}
 
@@ -249,7 +249,7 @@ export class VariablesService {
 			},
 			variableId: saveResult.id,
 			variableKey: saveResult.key,
-			projectId: variable.projectId,
+			...(variable.projectId && { projectId: variable.projectId }),
 		});
 		await this.updateCache();
 		return saveResult;
@@ -315,7 +315,7 @@ export class VariablesService {
 			},
 			variableId: id,
 			variableKey: variable.key ?? existingVariable.key,
-			projectId: newProjectId,
+			...(newProjectId && { projectId: newProjectId }),
 		});
 		await this.updateCache();
 		return (await this.getCached(id))!;

--- a/packages/cli/src/environments.ee/variables/variables.service.ee.ts
+++ b/packages/cli/src/environments.ee/variables/variables.service.ee.ts
@@ -150,6 +150,19 @@ export class VariablesService {
 			throw new ForbiddenError('You are not allowed to delete this variable');
 		}
 
+		this.eventService.emit('variable-deleted', {
+			user: {
+				id: user.id,
+				email: user.email,
+				firstName: user.firstName,
+				lastName: user.lastName,
+				role: user.role,
+			},
+			variableId: id,
+			variableKey: existingVariable?.key ?? '',
+			projectId: existingVariable?.project?.id,
+		});
+
 		await this.delete(id);
 	}
 
@@ -227,6 +240,15 @@ export class VariablesService {
 			{ transaction: false },
 		);
 		this.eventService.emit('variable-created', {
+			user: {
+				id: user.id,
+				email: user.email,
+				firstName: user.firstName,
+				lastName: user.lastName,
+				role: user.role,
+			},
+			variableId: saveResult.id,
+			variableKey: saveResult.key,
 			projectId: variable.projectId,
 		});
 		await this.updateCache();
@@ -284,6 +306,15 @@ export class VariablesService {
 				: {}),
 		});
 		this.eventService.emit('variable-updated', {
+			user: {
+				id: user.id,
+				email: user.email,
+				firstName: user.firstName,
+				lastName: user.lastName,
+				role: user.role,
+			},
+			variableId: id,
+			variableKey: variable.key ?? existingVariable.key,
 			projectId: newProjectId,
 		});
 		await this.updateCache();

--- a/packages/cli/src/eventbus/event-message-classes/event-message-audit.ts
+++ b/packages/cli/src/eventbus/event-message-classes/event-message-audit.ts
@@ -22,6 +22,8 @@ export interface EventPayloadAudit extends AbstractEventPayload {
 	workflowName?: string;
 	activeVersionId?: string | null;
 	settingsChanged?: Record<string, { from: JsonValue; to: JsonValue }>;
+	variableId?: string;
+	variableKey?: string;
 }
 
 export interface EventMessageAuditOptions extends AbstractEventMessageOptions {

--- a/packages/cli/src/eventbus/event-message-classes/index.ts
+++ b/packages/cli/src/eventbus/event-message-classes/index.ts
@@ -85,6 +85,9 @@ export const eventNamesAudit = [
 	'n8n.audit.workflow.unarchived',
 	'n8n.audit.workflow.activated',
 	'n8n.audit.workflow.deactivated',
+	'n8n.audit.variable.created',
+	'n8n.audit.variable.updated',
+	'n8n.audit.variable.deleted',
 ] as const;
 
 export type EventNamesWorkflowType = (typeof eventNamesWorkflow)[number];

--- a/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
@@ -1062,7 +1062,7 @@ describe('LogStreamingEventRelay', () => {
 	});
 
 	describe('variable events', () => {
-		it('should log on `variable-created` event', () => {
+		it('should log on `variable-created` event with projectId', () => {
 			const event: RelayEventMap['variable-created'] = {
 				user: {
 					id: 'user123',
@@ -1093,7 +1093,36 @@ describe('LogStreamingEventRelay', () => {
 			});
 		});
 
-		it('should log on `variable-updated` event', () => {
+		it('should log on `variable-created` event without projectId', () => {
+			const event: RelayEventMap['variable-created'] = {
+				user: {
+					id: 'user123',
+					email: 'user@example.com',
+					firstName: 'Test',
+					lastName: 'User',
+					role: { slug: GLOBAL_OWNER_ROLE.slug },
+				},
+				variableId: 'var456',
+				variableKey: 'MY_GLOBAL_VARIABLE',
+			};
+
+			eventService.emit('variable-created', event);
+
+			expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
+				eventName: 'n8n.audit.variable.created',
+				payload: {
+					userId: 'user123',
+					_email: 'user@example.com',
+					_firstName: 'Test',
+					_lastName: 'User',
+					globalRole: 'global:owner',
+					variableId: 'var456',
+					variableKey: 'MY_GLOBAL_VARIABLE',
+				},
+			});
+		});
+
+		it('should log on `variable-updated` event with projectId', () => {
 			const event: RelayEventMap['variable-updated'] = {
 				user: {
 					id: 'user123',
@@ -1124,7 +1153,36 @@ describe('LogStreamingEventRelay', () => {
 			});
 		});
 
-		it('should log on `variable-deleted` event', () => {
+		it('should log on `variable-updated` event without projectId', () => {
+			const event: RelayEventMap['variable-updated'] = {
+				user: {
+					id: 'user123',
+					email: 'user@example.com',
+					firstName: 'Test',
+					lastName: 'User',
+					role: { slug: 'global:member' },
+				},
+				variableId: 'var456',
+				variableKey: 'MY_UPDATED_GLOBAL_VARIABLE',
+			};
+
+			eventService.emit('variable-updated', event);
+
+			expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
+				eventName: 'n8n.audit.variable.updated',
+				payload: {
+					userId: 'user123',
+					_email: 'user@example.com',
+					_firstName: 'Test',
+					_lastName: 'User',
+					globalRole: 'global:member',
+					variableId: 'var456',
+					variableKey: 'MY_UPDATED_GLOBAL_VARIABLE',
+				},
+			});
+		});
+
+		it('should log on `variable-deleted` event with projectId', () => {
 			const event: RelayEventMap['variable-deleted'] = {
 				user: {
 					id: 'user123',
@@ -1135,6 +1193,7 @@ describe('LogStreamingEventRelay', () => {
 				},
 				variableId: 'var456',
 				variableKey: 'MY_DELETED_VARIABLE',
+				projectId: 'proj789',
 			};
 
 			eventService.emit('variable-deleted', event);
@@ -1149,6 +1208,36 @@ describe('LogStreamingEventRelay', () => {
 					globalRole: 'global:owner',
 					variableId: 'var456',
 					variableKey: 'MY_DELETED_VARIABLE',
+					projectId: 'proj789',
+				},
+			});
+		});
+
+		it('should log on `variable-deleted` event without projectId', () => {
+			const event: RelayEventMap['variable-deleted'] = {
+				user: {
+					id: 'user123',
+					email: 'user@example.com',
+					firstName: 'Test',
+					lastName: 'User',
+					role: { slug: GLOBAL_OWNER_ROLE.slug },
+				},
+				variableId: 'var456',
+				variableKey: 'MY_DELETED_GLOBAL_VARIABLE',
+			};
+
+			eventService.emit('variable-deleted', event);
+
+			expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
+				eventName: 'n8n.audit.variable.deleted',
+				payload: {
+					userId: 'user123',
+					_email: 'user@example.com',
+					_firstName: 'Test',
+					_lastName: 'User',
+					globalRole: 'global:owner',
+					variableId: 'var456',
+					variableKey: 'MY_DELETED_GLOBAL_VARIABLE',
 				},
 			});
 		});

--- a/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
@@ -1135,7 +1135,6 @@ describe('LogStreamingEventRelay', () => {
 				},
 				variableId: 'var456',
 				variableKey: 'MY_DELETED_VARIABLE',
-				projectId: undefined,
 			};
 
 			eventService.emit('variable-deleted', event);
@@ -1150,7 +1149,6 @@ describe('LogStreamingEventRelay', () => {
 					globalRole: 'global:owner',
 					variableId: 'var456',
 					variableKey: 'MY_DELETED_VARIABLE',
-					projectId: undefined,
 				},
 			});
 		});

--- a/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
@@ -1061,6 +1061,101 @@ describe('LogStreamingEventRelay', () => {
 		});
 	});
 
+	describe('variable events', () => {
+		it('should log on `variable-created` event', () => {
+			const event: RelayEventMap['variable-created'] = {
+				user: {
+					id: 'user123',
+					email: 'user@example.com',
+					firstName: 'Test',
+					lastName: 'User',
+					role: { slug: GLOBAL_OWNER_ROLE.slug },
+				},
+				variableId: 'var456',
+				variableKey: 'MY_VARIABLE',
+				projectId: 'proj789',
+			};
+
+			eventService.emit('variable-created', event);
+
+			expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
+				eventName: 'n8n.audit.variable.created',
+				payload: {
+					userId: 'user123',
+					_email: 'user@example.com',
+					_firstName: 'Test',
+					_lastName: 'User',
+					globalRole: 'global:owner',
+					variableId: 'var456',
+					variableKey: 'MY_VARIABLE',
+					projectId: 'proj789',
+				},
+			});
+		});
+
+		it('should log on `variable-updated` event', () => {
+			const event: RelayEventMap['variable-updated'] = {
+				user: {
+					id: 'user123',
+					email: 'user@example.com',
+					firstName: 'Test',
+					lastName: 'User',
+					role: { slug: 'global:member' },
+				},
+				variableId: 'var456',
+				variableKey: 'MY_UPDATED_VARIABLE',
+				projectId: 'proj789',
+			};
+
+			eventService.emit('variable-updated', event);
+
+			expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
+				eventName: 'n8n.audit.variable.updated',
+				payload: {
+					userId: 'user123',
+					_email: 'user@example.com',
+					_firstName: 'Test',
+					_lastName: 'User',
+					globalRole: 'global:member',
+					variableId: 'var456',
+					variableKey: 'MY_UPDATED_VARIABLE',
+					projectId: 'proj789',
+				},
+			});
+		});
+
+		it('should log on `variable-deleted` event', () => {
+			const event: RelayEventMap['variable-deleted'] = {
+				user: {
+					id: 'user123',
+					email: 'user@example.com',
+					firstName: 'Test',
+					lastName: 'User',
+					role: { slug: GLOBAL_OWNER_ROLE.slug },
+				},
+				variableId: 'var456',
+				variableKey: 'MY_DELETED_VARIABLE',
+				projectId: undefined,
+			};
+
+			eventService.emit('variable-deleted', event);
+
+			expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
+				eventName: 'n8n.audit.variable.deleted',
+				payload: {
+					userId: 'user123',
+					_email: 'user@example.com',
+					_firstName: 'Test',
+					_lastName: 'User',
+					globalRole: 'global:owner',
+					variableId: 'var456',
+					variableKey: 'MY_DELETED_VARIABLE',
+					projectId: undefined,
+				},
+			});
+		});
+	});
+
 	describe('auth events', () => {
 		it('should log on `user-login-failed` event', () => {
 			const event: RelayEventMap['user-login-failed'] = {

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -331,26 +331,131 @@ describe('TelemetryEventRelay', () => {
 	});
 
 	describe('variable events', () => {
-		it('should track on `variable-created` event', () => {
-			eventService.emit('variable-created', {});
+		it('should track on `variable-created` event without projectId', () => {
+			const event: RelayEventMap['variable-created'] = {
+				user: {
+					id: 'user123',
+					email: 'test@example.com',
+					firstName: 'Test',
+					lastName: 'User',
+					role: { slug: 'global:owner' },
+				},
+				variableId: 'var456',
+				variableKey: 'MY_VARIABLE',
+			};
 
-			expect(telemetry.track).toHaveBeenCalledWith('User created variable', {});
-
-			eventService.emit('variable-created', { projectId: 'projectId' });
+			eventService.emit('variable-created', event);
 
 			expect(telemetry.track).toHaveBeenCalledWith('User created variable', {
+				user_id: 'user123',
+				project_id: undefined,
+			});
+		});
+
+		it('should track on `variable-created` event with projectId', () => {
+			const event: RelayEventMap['variable-created'] = {
+				user: {
+					id: 'user123',
+					email: 'test@example.com',
+					firstName: 'Test',
+					lastName: 'User',
+					role: { slug: 'global:owner' },
+				},
+				variableId: 'var456',
+				variableKey: 'MY_VARIABLE',
+				projectId: 'projectId',
+			};
+
+			eventService.emit('variable-created', event);
+
+			expect(telemetry.track).toHaveBeenCalledWith('User created variable', {
+				user_id: 'user123',
 				project_id: 'projectId',
 			});
 		});
 
-		it('should track on `variable-updated` event', () => {
-			eventService.emit('variable-updated', {});
+		it('should track on `variable-updated` event without projectId', () => {
+			const event: RelayEventMap['variable-updated'] = {
+				user: {
+					id: 'user123',
+					email: 'test@example.com',
+					firstName: 'Test',
+					lastName: 'User',
+					role: { slug: 'global:owner' },
+				},
+				variableId: 'var456',
+				variableKey: 'MY_VARIABLE',
+			};
 
-			expect(telemetry.track).toHaveBeenCalledWith('User updated variable', {});
-
-			eventService.emit('variable-updated', { projectId: 'projectId' });
+			eventService.emit('variable-updated', event);
 
 			expect(telemetry.track).toHaveBeenCalledWith('User updated variable', {
+				user_id: 'user123',
+				project_id: undefined,
+			});
+		});
+
+		it('should track on `variable-updated` event with projectId', () => {
+			const event: RelayEventMap['variable-updated'] = {
+				user: {
+					id: 'user123',
+					email: 'test@example.com',
+					firstName: 'Test',
+					lastName: 'User',
+					role: { slug: 'global:owner' },
+				},
+				variableId: 'var456',
+				variableKey: 'MY_VARIABLE',
+				projectId: 'projectId',
+			};
+
+			eventService.emit('variable-updated', event);
+
+			expect(telemetry.track).toHaveBeenCalledWith('User updated variable', {
+				user_id: 'user123',
+				project_id: 'projectId',
+			});
+		});
+
+		it('should track on `variable-deleted` event without projectId', () => {
+			const event: RelayEventMap['variable-deleted'] = {
+				user: {
+					id: 'user123',
+					email: 'test@example.com',
+					firstName: 'Test',
+					lastName: 'User',
+					role: { slug: 'global:owner' },
+				},
+				variableId: 'var456',
+				variableKey: 'MY_VARIABLE',
+			};
+
+			eventService.emit('variable-deleted', event);
+
+			expect(telemetry.track).toHaveBeenCalledWith('User deleted variable', {
+				user_id: 'user123',
+				project_id: undefined,
+			});
+		});
+
+		it('should track on `variable-deleted` event with projectId', () => {
+			const event: RelayEventMap['variable-deleted'] = {
+				user: {
+					id: 'user123',
+					email: 'test@example.com',
+					firstName: 'Test',
+					lastName: 'User',
+					role: { slug: 'global:owner' },
+				},
+				variableId: 'var456',
+				variableKey: 'MY_VARIABLE',
+				projectId: 'projectId',
+			};
+
+			eventService.emit('variable-deleted', event);
+
+			expect(telemetry.track).toHaveBeenCalledWith('User deleted variable', {
+				user_id: 'user123',
 				project_id: 'projectId',
 			});
 		});

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -348,7 +348,6 @@ describe('TelemetryEventRelay', () => {
 
 			expect(telemetry.track).toHaveBeenCalledWith('User created variable', {
 				user_id: 'user123',
-				project_id: undefined,
 			});
 		});
 
@@ -391,7 +390,6 @@ describe('TelemetryEventRelay', () => {
 
 			expect(telemetry.track).toHaveBeenCalledWith('User updated variable', {
 				user_id: 'user123',
-				project_id: undefined,
 			});
 		});
 
@@ -434,7 +432,6 @@ describe('TelemetryEventRelay', () => {
 
 			expect(telemetry.track).toHaveBeenCalledWith('User deleted variable', {
 				user_id: 'user123',
-				project_id: undefined,
 			});
 		});
 

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -502,10 +502,23 @@ export type RelayEventMap = {
 	// #region Variable
 
 	'variable-created': {
+		user: UserLike;
+		variableId: string;
+		variableKey: string;
 		projectId?: string;
 	};
 
 	'variable-updated': {
+		user: UserLike;
+		variableId: string;
+		variableKey: string;
+		projectId?: string;
+	};
+
+	'variable-deleted': {
+		user: UserLike;
+		variableId: string;
+		variableKey: string;
 		projectId?: string;
 	};
 

--- a/packages/cli/src/events/relays/log-streaming.event-relay.ts
+++ b/packages/cli/src/events/relays/log-streaming.event-relay.ts
@@ -50,6 +50,9 @@ export class LogStreamingEventRelay extends EventRelay {
 			'credentials-deleted': (event) => this.credentialsDeleted(event),
 			'credentials-shared': (event) => this.credentialsShared(event),
 			'credentials-updated': (event) => this.credentialsUpdated(event),
+			'variable-created': (event) => this.variableCreated(event),
+			'variable-updated': (event) => this.variableUpdated(event),
+			'variable-deleted': (event) => this.variableDeleted(event),
 			'community-package-installed': (event) => this.communityPackageInstalled(event),
 			'community-package-updated': (event) => this.communityPackageUpdated(event),
 			'community-package-deleted': (event) => this.communityPackageDeleted(event),
@@ -462,6 +465,34 @@ export class LogStreamingEventRelay extends EventRelay {
 	private credentialsUpdated({ user, ...rest }: RelayEventMap['credentials-updated']) {
 		void this.eventBus.sendAuditEvent({
 			eventName: 'n8n.audit.user.credentials.updated',
+			payload: { ...user, ...rest },
+		});
+	}
+
+	// #endregion
+
+	// #region Variable
+
+	@Redactable()
+	private variableCreated({ user, ...rest }: RelayEventMap['variable-created']) {
+		void this.eventBus.sendAuditEvent({
+			eventName: 'n8n.audit.variable.created',
+			payload: { ...user, ...rest },
+		});
+	}
+
+	@Redactable()
+	private variableUpdated({ user, ...rest }: RelayEventMap['variable-updated']) {
+		void this.eventBus.sendAuditEvent({
+			eventName: 'n8n.audit.variable.updated',
+			payload: { ...user, ...rest },
+		});
+	}
+
+	@Redactable()
+	private variableDeleted({ user, ...rest }: RelayEventMap['variable-deleted']) {
+		void this.eventBus.sendAuditEvent({
+			eventName: 'n8n.audit.variable.deleted',
 			payload: { ...user, ...rest },
 		});
 	}

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -280,21 +280,21 @@ export class TelemetryEventRelay extends EventRelay {
 	private variableCreated({ user, projectId }: RelayEventMap['variable-created']) {
 		this.telemetry.track('User created variable', {
 			user_id: user.id,
-			project_id: projectId,
+			...(projectId && { project_id: projectId }),
 		});
 	}
 
 	private variableUpdated({ user, projectId }: RelayEventMap['variable-updated']) {
 		this.telemetry.track('User updated variable', {
 			user_id: user.id,
-			project_id: projectId,
+			...(projectId && { project_id: projectId }),
 		});
 	}
 
 	private variableDeleted({ user, projectId }: RelayEventMap['variable-deleted']) {
 		this.telemetry.track('User deleted variable', {
 			user_id: user.id,
-			project_id: projectId,
+			...(projectId && { project_id: projectId }),
 		});
 	}
 

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -65,6 +65,7 @@ export class TelemetryEventRelay extends EventRelay {
 			'license-community-plus-registered': (event) => this.licenseCommunityPlusRegistered(event),
 			'variable-created': (event) => this.variableCreated(event),
 			'variable-updated': (event) => this.variableUpdated(event),
+			'variable-deleted': (event) => this.variableDeleted(event),
 			'external-secrets-provider-settings-saved': (event) =>
 				this.externalSecretsProviderSettingsSaved(event),
 			'public-api-invoked': (event) => this.publicApiInvoked(event),
@@ -276,15 +277,24 @@ export class TelemetryEventRelay extends EventRelay {
 
 	// #region Variable
 
-	private variableCreated(event: RelayEventMap['variable-created']) {
+	private variableCreated({ user, projectId }: RelayEventMap['variable-created']) {
 		this.telemetry.track('User created variable', {
-			project_id: event.projectId,
+			user_id: user.id,
+			project_id: projectId,
 		});
 	}
 
-	private variableUpdated(event: RelayEventMap['variable-updated']) {
+	private variableUpdated({ user, projectId }: RelayEventMap['variable-updated']) {
 		this.telemetry.track('User updated variable', {
-			project_id: event.projectId,
+			user_id: user.id,
+			project_id: projectId,
+		});
+	}
+
+	private variableDeleted({ user, projectId }: RelayEventMap['variable-deleted']) {
+		this.telemetry.track('User deleted variable', {
+			user_id: user.id,
+			project_id: projectId,
 		});
 	}
 


### PR DESCRIPTION
## Summary

Add missing log streaming audit events for variable CRUD operations:
- `n8n.audit.variable.created` - emitted when a variable is created
- `n8n.audit.variable.updated` - emitted when a variable is updated
- `n8n.audit.variable.deleted` - emitted when a variable is deleted

Event payloads include user info (id, email, firstName, lastName, role), variableId, variableKey, and projectId to maintain consistency with credential and workflow audit events. Variable values are intentionally excluded for security purposes.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-2935/log-streaming-add-variables

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)