### PR TITLE
chore: Improve filtering of user errors from sentry

### DIFF
--- a/packages/@n8n/task-runner/src/task-runner-sentry.ts
+++ b/packages/@n8n/task-runner/src/task-runner-sentry.ts
@@ -56,8 +56,20 @@ export class TaskRunnerSentry {
 		const frames = error.stacktrace?.frames;
 		if (!frames) return false;
 
-		return frames.some(
-			(frame) => frame.filename === 'node:vm' && frame.function === 'runInContext',
-		);
+		return frames.some((frame) => {
+			if (frame.filename === 'node:vm' && frame.function === 'runInContext') {
+				return true;
+			}
+
+			if (frame.filename === 'evalmachine.<anonymous>') {
+				return true;
+			}
+
+			if (frame.function === 'VmCodeWrapper') {
+				return true;
+			}
+
+			return false;
+		});
 	}
 }


### PR DESCRIPTION
## Summary

To filter errors like [this](https://linear.app/n8n/issue/CAT-1944)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1557/fix-task-runner-error-filtering

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
