### PR TITLE
fix(editor): Remove running tool messages when AI builder task fails

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
@@ -737,6 +737,68 @@ describe('AI Builder store', () => {
 			expect(abortedMessage.aborted).toBe(true);
 		});
 
+		it('should remove running tool messages when service error occurs', async () => {
+			const builderStore = useBuilderStore();
+
+			apiSpy.mockImplementationOnce((_ctx, _payload, onMessage, _onDone, onError) => {
+				// First send some tool messages - one completed, one running
+				onMessage({
+					messages: [
+						{
+							type: 'tool',
+							role: 'assistant',
+							toolName: 'add_nodes',
+							toolCallId: 'call-1',
+							status: 'completed',
+							updates: [{ type: 'output', data: { success: true } }],
+						},
+					],
+				});
+				onMessage({
+					messages: [
+						{
+							type: 'tool',
+							role: 'assistant',
+							toolName: 'connect_nodes',
+							toolCallId: 'call-2',
+							status: 'running',
+							updates: [{ type: 'input', data: {} }],
+						},
+					],
+				});
+				// Then simulate a service error
+				onError(new Error('Network error'));
+			});
+
+			builderStore.sendChatMessage({ text: 'test message' });
+
+			// Wait for error message to be processed
+			await vi.waitFor(() => {
+				const errorMsg = builderStore.chatMessages.find((msg) => msg.type === 'error');
+				return expect(errorMsg).toBeDefined();
+			});
+
+			// Should have: user message, completed tool, error message
+			// Running tool should be removed
+			const toolMessages = builderStore.chatMessages.filter((msg) => msg.type === 'tool');
+			expect(toolMessages).toHaveLength(1);
+			expect((toolMessages[0] as ChatUI.ToolMessage).toolName).toBe('add_nodes');
+			expect((toolMessages[0] as ChatUI.ToolMessage).status).toBe('completed');
+
+			// Verify no running tools remain
+			const runningTools = toolMessages.filter(
+				(msg) => (msg as ChatUI.ToolMessage).status === 'running',
+			);
+			expect(runningTools).toHaveLength(0);
+
+			// Verify error message is present
+			const errorMessage = builderStore.chatMessages.find(
+				(msg) => msg.type === 'error',
+			) as ChatUI.ErrorMessage;
+			expect(errorMessage).toBeDefined();
+			expect(errorMessage.retry).toBeDefined();
+		});
+
 		it('should abort previous request when sending new message', () => {
 			const builderStore = useBuilderStore();
 

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
@@ -670,6 +670,73 @@ describe('AI Builder store', () => {
 			expect(builderStore.builderThinkingMessage).toBeUndefined();
 		});
 
+		it('should remove running tool messages when AbortError occurs', async () => {
+			const builderStore = useBuilderStore();
+
+			const abortError = new Error('AbortError');
+			abortError.name = 'AbortError';
+
+			apiSpy.mockImplementationOnce((_ctx, _payload, onMessage, _onDone, onError) => {
+				// First send some tool messages - one completed, one running
+				onMessage({
+					messages: [
+						{
+							type: 'tool',
+							role: 'assistant',
+							toolName: 'add_nodes',
+							toolCallId: 'call-1',
+							status: 'completed',
+							updates: [{ type: 'output', data: { success: true } }],
+						},
+					],
+				});
+				onMessage({
+					messages: [
+						{
+							type: 'tool',
+							role: 'assistant',
+							toolName: 'connect_nodes',
+							toolCallId: 'call-2',
+							status: 'running',
+							updates: [{ type: 'input', data: {} }],
+						},
+					],
+				});
+				// Then simulate abort
+				onError(abortError);
+			});
+
+			builderStore.sendChatMessage({ text: 'test message' });
+
+			// Wait for messages to be processed
+			await vi.waitFor(() => {
+				const abortedMsg = builderStore.chatMessages.find(
+					(msg) => msg.type === 'text' && 'aborted' in msg,
+				);
+				return expect(abortedMsg).toBeDefined();
+			});
+
+			// Should have: user message, completed tool, aborted message
+			// Running tool should be removed
+			const toolMessages = builderStore.chatMessages.filter((msg) => msg.type === 'tool');
+			expect(toolMessages).toHaveLength(1);
+			expect((toolMessages[0] as ChatUI.ToolMessage).toolName).toBe('add_nodes');
+			expect((toolMessages[0] as ChatUI.ToolMessage).status).toBe('completed');
+
+			// Verify no running tools remain
+			const runningTools = toolMessages.filter(
+				(msg) => (msg as ChatUI.ToolMessage).status === 'running',
+			);
+			expect(runningTools).toHaveLength(0);
+
+			// Verify aborted message is present
+			const abortedMessage = builderStore.chatMessages.find(
+				(msg) => msg.type === 'text' && 'aborted' in msg,
+			) as ChatUI.TaskAbortedMessage;
+			expect(abortedMessage).toBeDefined();
+			expect(abortedMessage.aborted).toBe(true);
+		});
+
 		it('should abort previous request when sending new message', () => {
 			const builderStore = useBuilderStore();
 

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
@@ -272,12 +272,17 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 
 		if (e.name === 'AbortError') {
 			// Handle abort errors as they are expected when stopping streaming
+			// Remove tools that were still running when aborted
+			const messagesWithoutRunningTools = chatMessages.value.filter(
+				(msg) => !(msg.type === 'tool' && msg.status === 'running'),
+			);
+
 			const userMsg = createAssistantMessage(
 				locale.baseText('aiAssistant.builder.streamAbortedMessage'),
 				'aborted-streaming',
 				{ aborted: true },
 			);
-			chatMessages.value = [...chatMessages.value, userMsg];
+			chatMessages.value = [...messagesWithoutRunningTools, userMsg];
 			return;
 		}
 

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
@@ -270,13 +270,13 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 		});
 		builderThinkingMessage.value = undefined;
 
+		// Remove tools that were still running when error occurred
+		const messagesWithoutRunningTools = chatMessages.value.filter(
+			(msg) => !(msg.type === 'tool' && msg.status === 'running'),
+		);
+
 		if (e.name === 'AbortError') {
 			// Handle abort errors as they are expected when stopping streaming
-			// Remove tools that were still running when aborted
-			const messagesWithoutRunningTools = chatMessages.value.filter(
-				(msg) => !(msg.type === 'tool' && msg.status === 'running'),
-			);
-
 			const userMsg = createAssistantMessage(
 				locale.baseText('aiAssistant.builder.streamAbortedMessage'),
 				'aborted-streaming',
@@ -292,7 +292,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 			retry,
 		);
 
-		chatMessages.value = [...chatMessages.value, errorMessage];
+		chatMessages.value = [...messagesWithoutRunningTools, errorMessage];
 	}
 
 	// Helper functions


### PR DESCRIPTION
## Summary
Fixes a bug in the AI Workflow Builder where the thinking container continued showing loading spinners after aborting a task or when an error occurred. Running tool messages are now filtered out for all error scenarios (abort and service errors), so only completed tools remain visible.

## Changes
- Filter out tool messages with `status: 'running'` in `handleServiceError` before adding error/abort messages
- The filtering now applies to both AbortError (user-initiated stop) and other service errors (network failures, etc.)
- Added two test cases to verify running tools are removed for both abort and service error scenarios

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
