### PR TITLE
fix(editor): Preserve AI Builder chat state when switching routes during streaming

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/assistant/chatPanel.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/chatPanel.store.ts
@@ -68,10 +68,10 @@ export const useChatPanelStore = defineStore(STORES.CHAT_PANEL, () => {
 
 		if (chatPanelStateStore.activeMode === 'builder') {
 			const builderStore = useBuilderStore();
-			builderStore.chatMessages = [];
-			// Load credits and sessions in the background without blocking panel opening
-			void builderStore.fetchBuilderCredits();
-			void builderStore.loadSessions();
+			if (!builderStore.streaming && builderStore.chatMessages.length === 0) {
+				void builderStore.fetchBuilderCredits();
+				void builderStore.loadSessions();
+			}
 		} else if (chatPanelStateStore.activeMode === 'assistant') {
 			const assistantStore = useAssistantStore();
 			assistantStore.chatMessages = assistantStore.chatMessages.map((msg) => ({
@@ -103,8 +103,9 @@ export const useChatPanelStore = defineStore(STORES.CHAT_PANEL, () => {
 				assistantStore.resetAssistantChat();
 			}
 
-			// Always reset builder
-			builderStore.resetBuilderChat();
+			if (!builderStore.streaming) {
+				builderStore.resetBuilderChat();
+			}
 		}, ASK_AI_SLIDE_OUT_DURATION_MS + 50);
 	}
 
@@ -164,10 +165,25 @@ export const useChatPanelStore = defineStore(STORES.CHAT_PANEL, () => {
 	watch(
 		() => route?.name,
 		(newRoute) => {
-			if (!chatPanelStateStore.isOpen || !newRoute) {
+			if (!newRoute) {
 				return;
 			}
+
 			const builderStore = useBuilderStore();
+
+			// Re-open panel if streaming and entering a builder view
+			if (
+				!chatPanelStateStore.isOpen &&
+				builderStore.streaming &&
+				isEnabledView(newRoute, BUILDER_ENABLED_VIEWS)
+			) {
+				void open({ mode: 'builder' });
+				return;
+			}
+
+			if (!chatPanelStateStore.isOpen) {
+				return;
+			}
 
 			const enabledViews =
 				chatPanelStateStore.activeMode === 'assistant'
@@ -176,8 +192,7 @@ export const useChatPanelStore = defineStore(STORES.CHAT_PANEL, () => {
 
 			if (!isEnabledView(newRoute, enabledViews)) {
 				close();
-			} else if (isEnabledView(newRoute, BUILDER_ENABLED_VIEWS)) {
-				// If entering an editable canvas view with builder mode active, refresh state
+			} else if (isEnabledView(newRoute, BUILDER_ENABLED_VIEWS) && !builderStore.streaming) {
 				builderStore.resetBuilderChat();
 			}
 		},

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/AskAssistantBuild.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/AskAssistantBuild.vue
@@ -233,9 +233,11 @@ watch(
 	},
 );
 
-// Reset on route change
+// Reset on route change, but not if streaming is in progress
 watch(currentRoute, () => {
-	onNewWorkflow();
+	if (!builderStore.streaming) {
+		onNewWorkflow();
+	}
 });
 
 defineExpose({


### PR DESCRIPTION
## Summary

When switching from Editor to Executions tab and back during AI workflow generation, the chat panel would close, messages would be lost, and streaming state was not preserved. This fix ensures the chat panel auto-reopens and retains accumulated messages when returning to the Editor during active streaming.

## Changes

- `chatPanel.store.ts`: Skip fetching credits/sessions in `open()` if streaming or messages exist; skip `resetBuilderChat()` in `close()` if streaming; auto-reopen panel via route watcher when returning to builder view during streaming
- `AskAssistantBuild.vue`: Skip `onNewWorkflow()` on route change if streaming
- Added tests covering streaming state preservation and grid width restoration

https://github.com/user-attachments/assets/98a62dcd-3fcf-4a87-94f7-c8214fce03a4


## Related Linear tickets, Github issues, and Community forum posts


<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
