### PR TITLE
fix(core): Ensure runner does not terminate pipe reader prematurely

### DIFF
--- a/packages/@n8n/task-runner-python/src/config/task_runner_config.py
+++ b/packages/@n8n/task-runner-python/src/config/task_runner_config.py
@@ -22,9 +22,6 @@ from src.constants import (
     ENV_AUTO_SHUTDOWN_TIMEOUT,
     ENV_GRACEFUL_SHUTDOWN_TIMEOUT,
     PIPE_MSG_MAX_SIZE,
-    TYPICAL_PAYLOAD_RATIO,
-    PARSE_THROUGHPUT_BYTES_PER_SEC,
-    PIPE_READER_JOIN_TIMEOUT_SAFETY_BUFFER,
 )
 
 
@@ -60,7 +57,6 @@ class TaskRunnerConfig:
     external_allow: set[str]
     builtins_deny: set[str]
     env_deny: bool
-    pipe_reader_timeout: float
 
     @property
     def is_auto_shutdown_enabled(self) -> bool:
@@ -102,12 +98,6 @@ class TaskRunnerConfig:
                 f"Max payload size of {max_payload_size} bytes exceeds pipe message limit of {PIPE_MSG_MAX_SIZE} bytes. Reduce {ENV_MAX_PAYLOAD_SIZE}."
             )
 
-        # Calculate pipe reader timeout based on configured max payload size (3s for default 1 GiB)
-        typical_payload = max_payload_size * TYPICAL_PAYLOAD_RATIO
-        pipe_reader_timeout = (
-            typical_payload / PARSE_THROUGHPUT_BYTES_PER_SEC
-        ) + PIPE_READER_JOIN_TIMEOUT_SAFETY_BUFFER
-
         return cls(
             grant_token=grant_token,
             task_broker_uri=read_str_env(ENV_TASK_BROKER_URI, DEFAULT_TASK_BROKER_URI),
@@ -129,5 +119,4 @@ class TaskRunnerConfig:
                 ).split(",")
             ),
             env_deny=read_bool_env(ENV_BLOCK_RUNNER_ENV_ACCESS, True),
-            pipe_reader_timeout=pipe_reader_timeout,
         )

--- a/packages/@n8n/task-runner-python/src/constants.py
+++ b/packages/@n8n/task-runner-python/src/constants.py
@@ -49,11 +49,6 @@ PIPE_MSG_MAX_SIZE = (
     2 ** (PIPE_MSG_PREFIX_LENGTH * 8) - 1
 )  # bytes (~4 GiB with 4-byte prefix)
 
-# Pipe reader join timeout
-TYPICAL_PAYLOAD_RATIO = 0.1  # assume typical size is 10% of max payload
-PARSE_THROUGHPUT_BYTES_PER_SEC = 100_000_000  # 100 MB/s
-PIPE_READER_JOIN_TIMEOUT_SAFETY_BUFFER = 2.0  # seconds
-
 # Broker
 DEFAULT_TASK_BROKER_URI = "http://127.0.0.1:5679"
 TASK_BROKER_WS_PATH = "/runners/_ws"
@@ -106,11 +101,6 @@ LOG_TASK_CANCEL_UNKNOWN = (
 )
 LOG_TASK_CANCEL_WAITING = "Cancelled task {task_id} (waiting for settings)"
 LOG_SENTRY_MISSING = "Sentry is enabled but sentry-sdk is not installed. Install with: uv sync --all-extras"
-LOG_PIPE_READER_TIMEOUT_TRIGGERED = (
-    "Pipe reader thread did not finish reading within {timeout}s. "
-    "Closing pipe to unblock. Task may fail if data was not fully read. "
-    "For large payloads, increase N8N_RUNNERS_MAX_PAYLOAD to scale timeout."
-)
 
 # RPC
 RPC_BROWSER_CONSOLE_LOG_METHOD = "logNodeOutput"

--- a/packages/@n8n/task-runner-python/src/task_runner.py
+++ b/packages/@n8n/task-runner-python/src/task_runner.py
@@ -326,7 +326,6 @@ class TaskRunner:
                 read_conn=read_conn,
                 write_conn=write_conn,
                 task_timeout=self.config.task_timeout,
-                pipe_reader_timeout=self.config.pipe_reader_timeout,
                 continue_on_fail=task_settings.continue_on_fail,
             )
 

--- a/packages/@n8n/task-runner-python/tests/unit/test_task_executor.py
+++ b/packages/@n8n/task-runner-python/tests/unit/test_task_executor.py
@@ -29,7 +29,6 @@ class TestTaskExecutorProcessExitHandling:
                 read_conn=read_conn,
                 write_conn=write_conn,
                 task_timeout=60,
-                pipe_reader_timeout=3.0,
                 continue_on_fail=False,
             )
 
@@ -48,7 +47,6 @@ class TestTaskExecutorProcessExitHandling:
                 read_conn=read_conn,
                 write_conn=write_conn,
                 task_timeout=60,
-                pipe_reader_timeout=3.0,
                 continue_on_fail=False,
             )
 
@@ -67,7 +65,6 @@ class TestTaskExecutorProcessExitHandling:
                 read_conn=read_conn,
                 write_conn=write_conn,
                 task_timeout=60,
-                pipe_reader_timeout=3.0,
                 continue_on_fail=False,
             )
 
@@ -90,7 +87,6 @@ class TestTaskExecutorProcessExitHandling:
                 read_conn=read_conn,
                 write_conn=write_conn,
                 task_timeout=60,
-                pipe_reader_timeout=3.0,
                 continue_on_fail=False,
             )
 
@@ -120,7 +116,6 @@ class TestTaskExecutorPipeCommunication:
             read_conn=read_conn,
             write_conn=write_conn,
             task_timeout=60,
-            pipe_reader_timeout=3.0,
             continue_on_fail=False,
         )
 
@@ -161,7 +156,6 @@ class TestTaskExecutorPipeCommunication:
                 read_conn=read_conn,
                 write_conn=write_conn,
                 task_timeout=60,
-                pipe_reader_timeout=3.0,
                 continue_on_fail=False,
             )
 

--- a/packages/@n8n/task-runner-python/tests/unit/test_task_runner.py
+++ b/packages/@n8n/task-runner-python/tests/unit/test_task_runner.py
@@ -21,7 +21,6 @@ class TestTaskRunnerConnectionRetry:
             external_allow={"*"},
             builtins_deny=set(),
             env_deny=False,
-            pipe_reader_timeout=3.0,
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

We have a subprocess running Python code and writing to a pipe, and a parent process with a pipe reader background thread for pulling data from the pipe. We are currently force-closing the pipe reader's read connection after ~3s, which is based on a napkin estimation about typical payload size and throughput. But [Sentry shows](https://n8nio.sentry.io/issues/6997406518/?project=4508342481780736) that large results are blowing past that, so we're prematurely closing even though the subprocess exited 0 and the data is sitting in the pipe buffer, i.e the overly tight timeout is discarding good results.

Hence this PR gives the pipe reader a fair chance to finish reading by reusing `task_timeout` (if the subprocess finished within it, reading the result shouldn't take longer) and if that's not enough only then raise an appropriate error. 

Technically this means we're redefining "task timeout" to mean task processing as a whole (execute + read). We could also track elapsed time and give the read only the time that was not consumed by execution, but looking at the number of Sentry reports I lean towards redefining timeout instead. Let me know if you disagree. I also considered calculating a dynamic timeout based on each result size, but it struck me as over-engineering.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1710

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
