### PR TITLE
refactor(core): Remove 'beginTransaction' parameter from withTransaction

### DIFF
--- a/packages/@n8n/db/src/utils/transaction.ts
+++ b/packages/@n8n/db/src/utils/transaction.ts
@@ -9,10 +9,8 @@ export async function withTransaction<T>(
 	manager: EntityManager,
 	trx: Tx,
 	run: (em: EntityManager) => Promise<T>,
-	beginTransaction: boolean = true,
 ): Promise<T> {
 	if (trx) return await run(trx);
-	if (beginTransaction) return await manager.transaction(run);
 
-	return await run(manager);
+	return await manager.transaction(run);
 }

--- a/packages/cli/src/modules/chat-hub/chat-hub-agent.repository.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-agent.repository.ts
@@ -1,4 +1,3 @@
-import { withTransaction } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { DataSource, EntityManager, Repository } from '@n8n/typeorm';
 
@@ -14,42 +13,24 @@ export class ChatHubAgentRepository extends Repository<ChatHubAgent> {
 		agent: Partial<IChatHubAgent> & Pick<IChatHubAgent, 'id'>,
 		trx?: EntityManager,
 	) {
-		return await withTransaction(
-			this.manager,
-			trx,
-			async (em) => {
-				await em.insert(ChatHubAgent, agent);
-				return await em.findOneOrFail(ChatHubAgent, {
-					where: { id: agent.id },
-				});
-			},
-			false,
-		);
+		const em = trx ?? this.manager;
+		await em.insert(ChatHubAgent, agent);
+		return await em.findOneOrFail(ChatHubAgent, {
+			where: { id: agent.id },
+		});
 	}
 
 	async updateAgent(id: string, updates: Partial<IChatHubAgent>, trx?: EntityManager) {
-		return await withTransaction(
-			this.manager,
-			trx,
-			async (em) => {
-				await em.update(ChatHubAgent, { id }, updates);
-				return await em.findOneOrFail(ChatHubAgent, {
-					where: { id },
-				});
-			},
-			false,
-		);
+		const em = trx ?? this.manager;
+		await em.update(ChatHubAgent, { id }, updates);
+		return await em.findOneOrFail(ChatHubAgent, {
+			where: { id },
+		});
 	}
 
 	async deleteAgent(id: string, trx?: EntityManager) {
-		return await withTransaction(
-			this.manager,
-			trx,
-			async (em) => {
-				return await em.delete(ChatHubAgent, { id });
-			},
-			false,
-		);
+		const em = trx ?? this.manager;
+		return await em.delete(ChatHubAgent, { id });
 	}
 
 	async getManyByUserId(userId: string) {
@@ -60,15 +41,9 @@ export class ChatHubAgentRepository extends Repository<ChatHubAgent> {
 	}
 
 	async getOneById(id: string, userId: string, trx?: EntityManager) {
-		return await withTransaction(
-			this.manager,
-			trx,
-			async (em) => {
-				return await em.findOne(ChatHubAgent, {
-					where: { id, ownerId: userId },
-				});
-			},
-			false,
-		);
+		const em = trx ?? this.manager;
+		return await em.findOne(ChatHubAgent, {
+			where: { id, ownerId: userId },
+		});
 	}
 }

--- a/packages/cli/src/modules/chat-hub/chat-message.repository.ts
+++ b/packages/cli/src/modules/chat-hub/chat-message.repository.ts
@@ -44,39 +44,21 @@ export class ChatHubMessageRepository extends Repository<ChatHubMessage> {
 		fields: { status?: ChatHubMessageStatus; content?: string; attachments?: IBinaryData[] },
 		trx?: EntityManager,
 	) {
-		return await withTransaction(
-			this.manager,
-			trx,
-			async (em) => {
-				return await em.update(ChatHubMessage, { id }, fields);
-			},
-			false,
-		);
+		const em = trx ?? this.manager;
+		return await em.update(ChatHubMessage, { id }, fields);
 	}
 
 	async deleteChatMessage(id: ChatMessageId, trx?: EntityManager) {
-		return await withTransaction(
-			this.manager,
-			trx,
-			async (em) => {
-				return await em.delete(ChatHubMessage, { id });
-			},
-			false,
-		);
+		const em = trx ?? this.manager;
+		return await em.delete(ChatHubMessage, { id });
 	}
 
 	async getManyBySessionId(sessionId: string, trx?: EntityManager) {
-		return await withTransaction(
-			this.manager,
-			trx,
-			async (em) => {
-				return await em.find(ChatHubMessage, {
-					where: { sessionId },
-					order: { createdAt: 'ASC', id: 'DESC' },
-				});
-			},
-			false,
-		);
+		const em = trx ?? this.manager;
+		return await em.find(ChatHubMessage, {
+			where: { sessionId },
+			order: { createdAt: 'ASC', id: 'DESC' },
+		});
 	}
 
 	async getOneById(
@@ -85,16 +67,10 @@ export class ChatHubMessageRepository extends Repository<ChatHubMessage> {
 		relations: string[] = [],
 		trx?: EntityManager,
 	) {
-		return await withTransaction(
-			this.manager,
-			trx,
-			async (em) => {
-				return await em.findOne(ChatHubMessage, {
-					where: { id, sessionId },
-					relations,
-				});
-			},
-			false,
-		);
+		const em = trx ?? this.manager;
+		return await em.findOne(ChatHubMessage, {
+			where: { id, sessionId },
+			relations,
+		});
 	}
 }

--- a/packages/cli/src/modules/chat-hub/chat-session.repository.ts
+++ b/packages/cli/src/modules/chat-hub/chat-session.repository.ts
@@ -1,4 +1,3 @@
-import { withTransaction } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { DataSource, EntityManager, Repository } from '@n8n/typeorm';
 
@@ -16,40 +15,22 @@ export class ChatHubSessionRepository extends Repository<ChatHubSession> {
 		session: Partial<IChatHubSession> & Pick<IChatHubSession, 'id'>,
 		trx?: EntityManager,
 	) {
-		return await withTransaction(
-			this.manager,
-			trx,
-			async (em) => {
-				await em.insert(ChatHubSession, session);
-				return await em.findOneOrFail(ChatHubSession, {
-					where: { id: session.id },
-					relations: ['messages'],
-				});
-			},
-			false,
-		);
+		const em = trx ?? this.manager;
+		await em.insert(ChatHubSession, session);
+		return await em.findOneOrFail(ChatHubSession, {
+			where: { id: session.id },
+			relations: ['messages'],
+		});
 	}
 
 	async updateChatSession(id: string, updates: Partial<IChatHubSession>, trx?: EntityManager) {
-		return await withTransaction(
-			this.manager,
-			trx,
-			async (em) => {
-				await em.update(ChatHubSession, { id }, updates);
-			},
-			false,
-		);
+		const em = trx ?? this.manager;
+		await em.update(ChatHubSession, { id }, updates);
 	}
 
 	async deleteChatHubSession(id: string, trx?: EntityManager) {
-		return await withTransaction(
-			this.manager,
-			trx,
-			async (em) => {
-				return await em.delete(ChatHubSession, { id });
-			},
-			false,
-		);
+		const em = trx ?? this.manager;
+		return await em.delete(ChatHubSession, { id });
 	}
 
 	async getManyByUserId(userId: string, limit: number, cursor?: string) {
@@ -87,47 +68,29 @@ export class ChatHubSessionRepository extends Repository<ChatHubSession> {
 	}
 
 	async existsById(id: string, userId: string, trx?: EntityManager): Promise<boolean> {
-		return await withTransaction(
-			this.manager,
-			trx,
-			async (em) => {
-				return await em.exists(ChatHubSession, { where: { id, ownerId: userId } });
-			},
-			false,
-		);
+		const em = trx ?? this.manager;
+		return await em.exists(ChatHubSession, { where: { id, ownerId: userId } });
 	}
 
 	async getOneById(id: string, userId: string, trx?: EntityManager) {
-		return await withTransaction(
-			this.manager,
-			trx,
-			async (em) => {
-				return await em.findOne(ChatHubSession, {
-					where: { id, ownerId: userId },
-					relations: {
-						messages: true,
-						agent: true,
-						workflow: {
-							shared: {
-								project: true,
-							},
-							activeVersion: true,
-						},
+		const em = trx ?? this.manager;
+		return await em.findOne(ChatHubSession, {
+			where: { id, ownerId: userId },
+			relations: {
+				messages: true,
+				agent: true,
+				workflow: {
+					shared: {
+						project: true,
 					},
-				});
+					activeVersion: true,
+				},
 			},
-			false,
-		);
+		});
 	}
 
 	async deleteAll(trx?: EntityManager) {
-		return await withTransaction(
-			this.manager,
-			trx,
-			async (em) => {
-				return await em.createQueryBuilder().delete().from(ChatHubSession).execute();
-			},
-			false,
-		);
+		const em = trx ?? this.manager;
+		return await em.createQueryBuilder().delete().from(ChatHubSession).execute();
 	}
 }

--- a/packages/cli/src/modules/data-table/data-table-column.repository.ts
+++ b/packages/cli/src/modules/data-table/data-table-column.repository.ts
@@ -59,23 +59,17 @@ export class DataTableColumnRepository extends Repository<DataTableColumn> {
 	}
 
 	async getColumns(dataTableId: string, trx?: EntityManager) {
-		return await withTransaction(
-			this.manager,
-			trx,
-			async (em) => {
-				const columns = await em
-					.createQueryBuilder(DataTableColumn, 'dsc')
-					.where('dsc.dataTableId = :dataTableId', { dataTableId })
-					.getMany();
+		const em = trx ?? this.manager;
+		const columns = await em
+			.createQueryBuilder(DataTableColumn, 'dsc')
+			.where('dsc.dataTableId = :dataTableId', { dataTableId })
+			.getMany();
 
-				// Ensure columns are always returned in the correct order by index,
-				// since the database does not guarantee ordering and TypeORM does not preserve
-				// join order in @OneToMany relations.
-				columns.sort((a, b) => a.index - b.index);
-				return columns;
-			},
-			false,
-		);
+		// Ensure columns are always returned in the correct order by index,
+		// since the database does not guarantee ordering and TypeORM does not preserve
+		// join order in @OneToMany relations.
+		columns.sort((a, b) => a.index - b.index);
+		return columns;
 	}
 
 	async addColumn(dataTableId: string, schema: DataTableCreateColumnSchema, trx?: EntityManager) {


### PR DESCRIPTION
## Summary

Followup to https://github.com/n8n-io/n8n/pull/23397#discussion_r2634258652

The optional `beginTransaction` argument on withTransaction brought unnecessary noise to code that didn't want automatic transactions to be started. Prefer using nullish coalescing operators instead, as that's all the function did in `beginTransaction=false`mode.

The helper is still somewhat handy for actually wrapping blocks of code with "start a transaction if there isn't already one" logic, so not getting rid of it fully.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
