### PR TITLE
fix(n8n Form Node): Restores executions status check for waiting forms

### DIFF
--- a/packages/cli/src/webhooks/waiting-forms.ts
+++ b/packages/cli/src/webhooks/waiting-forms.ts
@@ -96,6 +96,11 @@ export class WaitingForms extends WaitingWebhooks {
 					status = 'form-waiting';
 				}
 			}
+
+			if (req.headers.origin) {
+				res.header('Access-Control-Allow-Origin', req.headers.origin);
+			}
+
 			res.send(status);
 			return { noWebhookResponse: true };
 		}


### PR DESCRIPTION

## Summary

fixes regression introduced in https://github.com/n8n-io/n8n/pull/23061 that prevents waiting form to check execution status

Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-4119/form-trigger-not-redirecting-to-next-form-page-because-of-csp-header


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
