### PR TITLE
feat: All requests to OpenAI include a platform header

### DIFF
--- a/packages/@n8n/config/src/configs/__tests__/ai.config.test.ts
+++ b/packages/@n8n/config/src/configs/__tests__/ai.config.test.ts
@@ -1,0 +1,17 @@
+import { Container } from '@n8n/di';
+
+import { AiConfig } from '../ai.config';
+
+describe('AiConfig', () => {
+	beforeEach(() => {
+		Container.reset();
+		jest.clearAllMocks();
+	});
+
+	it('should not poison openAiDefaultHeaders object globally when modified', () => {
+		const { openAiDefaultHeaders } = Container.get(AiConfig);
+		openAiDefaultHeaders.test = 'ok';
+		expect(openAiDefaultHeaders.test).toBe('ok');
+		expect(Container.get(AiConfig).openAiDefaultHeaders.test).toBeFalsy();
+	});
+});

--- a/packages/@n8n/config/src/configs/ai.config.ts
+++ b/packages/@n8n/config/src/configs/ai.config.ts
@@ -1,6 +1,6 @@
 import { Config, Env } from '../decorators';
 
-class HeadersRecord {
+class RequestHeaders {
 	[key: string]: string;
 
 	constructor(headers: string) {
@@ -28,5 +28,5 @@ export class AiConfig {
 	/** Default headers sent with each request to OpenAI. Separate multiple headers with "\n" */
 	@Env('N8N_AI_OPENAI_DEFAULT_HEADERS')
 	// eslint-disable-next-line @typescript-eslint/naming-convention
-	openAiDefaultHeaders: HeadersRecord = { 'OPENAI-PLATFORM': 'org-qkmJQuJ2WnvoIKMr2UJwIJkZ' };
+	openAiDefaultHeaders: RequestHeaders = { 'openai-platform': 'org-qkmJQuJ2WnvoIKMr2UJwIJkZ' };
 }

--- a/packages/@n8n/config/src/configs/ai.config.ts
+++ b/packages/@n8n/config/src/configs/ai.config.ts
@@ -1,32 +1,13 @@
 import { Config, Env } from '../decorators';
 
-class RequestHeaders {
-	[key: string]: string;
-
-	constructor(headers: string) {
-		const headersMap = headers
-			.split('\\n')
-			.map((entry) => entry.trim())
-			.filter((entry) => entry)
-			.reduce<Record<string, string>>((result, current) => {
-				const [key, ...values] = current.split(':');
-				result[key.trim()] = values.join(':').trim();
-
-				return result;
-			}, {});
-
-		return headersMap;
-	}
-}
-
 @Config
 export class AiConfig {
 	/** Whether AI features are enabled. */
 	@Env('N8N_AI_ENABLED')
 	enabled: boolean = false;
 
-	/** Default headers sent with each request to OpenAI. Separate multiple headers with "\n" */
-	@Env('N8N_AI_OPENAI_DEFAULT_HEADERS')
-	// eslint-disable-next-line @typescript-eslint/naming-convention
-	openAiDefaultHeaders: RequestHeaders = { 'openai-platform': 'org-qkmJQuJ2WnvoIKMr2UJwIJkZ' };
+	get openAiDefaultHeaders(): Record<string, string> {
+		// eslint-disable-next-line @typescript-eslint/naming-convention
+		return { 'openai-platform': 'org-qkmJQuJ2WnvoIKMr2UJwIJkZ' };
+	}
 }

--- a/packages/@n8n/config/src/configs/ai.config.ts
+++ b/packages/@n8n/config/src/configs/ai.config.ts
@@ -1,8 +1,32 @@
 import { Config, Env } from '../decorators';
 
+class HeadersRecord {
+	[key: string]: string;
+
+	constructor(headers: string) {
+		const headersMap = headers
+			.split('\\n')
+			.map((entry) => entry.trim())
+			.filter((entry) => entry)
+			.reduce<Record<string, string>>((result, current) => {
+				const [key, ...values] = current.split(':');
+				result[key.trim()] = values.join(':').trim();
+
+				return result;
+			}, {});
+
+		return headersMap;
+	}
+}
+
 @Config
 export class AiConfig {
 	/** Whether AI features are enabled. */
 	@Env('N8N_AI_ENABLED')
 	enabled: boolean = false;
+
+	/** Default headers sent with each request to OpenAI. Separate multiple headers with "\n" */
+	@Env('N8N_AI_OPENAI_DEFAULT_HEADERS')
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	openAiDefaultHeaders: HeadersRecord = { 'OPENAI-PLATFORM': 'org-qkmJQuJ2WnvoIKMr2UJwIJkZ' };
 }

--- a/packages/@n8n/config/src/index.ts
+++ b/packages/@n8n/config/src/index.ts
@@ -39,6 +39,7 @@ import { WorkflowsConfig } from './configs/workflows.config';
 import { Config, Env, Nested } from './decorators';
 
 export { Config, Env, Nested } from './decorators';
+export { AiConfig } from './configs/ai.config';
 export { DatabaseConfig, SqliteConfig } from './configs/database.config';
 export { InstanceSettingsConfig } from './configs/instance-settings-config';
 export type { TaskRunnerMode } from './configs/runners.config';

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -409,6 +409,7 @@ describe('GlobalConfig', () => {
 		externalFrontendHooksUrls: '',
 		ai: {
 			enabled: false,
+			openAiDefaultHeaders: {},
 		},
 	};
 

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -407,9 +407,9 @@ describe('GlobalConfig', () => {
 			prefix: 'n8n',
 		},
 		externalFrontendHooksUrls: '',
+		// @ts-expect-error structuredClone ignores properties defined as a getter
 		ai: {
 			enabled: false,
-			openAiDefaultHeaders: {},
 		},
 	};
 
@@ -438,6 +438,7 @@ describe('GlobalConfig', () => {
 			N8N_DYNAMIC_BANNERS_ENABLED: 'false',
 		};
 		const config = Container.get(GlobalConfig);
+
 		expect(structuredClone(config)).toEqual({
 			...defaultConfig,
 			database: {

--- a/packages/@n8n/nodes-langchain/nodes/agents/OpenAiAssistant/OpenAiAssistant.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/OpenAiAssistant/OpenAiAssistant.node.ts
@@ -14,6 +14,8 @@ import { getConnectedTools } from '@utils/helpers';
 import { getTracingConfig } from '@utils/tracing';
 
 import { formatToOpenAIAssistantTool } from './utils';
+import { Container } from '@n8n/di';
+import { AiConfig } from '@n8n/config';
 
 export class OpenAiAssistant implements INodeType {
 	description: INodeTypeDescription = {
@@ -339,11 +341,14 @@ export class OpenAiAssistant implements INodeType {
 					throw new NodeOperationError(this.getNode(), 'The ‘text‘ parameter is empty.');
 				}
 
+				const { openAiDefaultHeaders: defaultHeaders } = Container.get(AiConfig);
+
 				const client = new OpenAIClient({
 					apiKey: credentials.apiKey as string,
 					maxRetries: options.maxRetries ?? 2,
 					timeout: options.timeout ?? 10000,
 					baseURL: options.baseURL,
+					defaultHeaders,
 				});
 				let agent;
 				const nativeToolsParsed: OpenAIToolType = nativeTools.map((tool) => ({ type: tool }));

--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsOpenAI/EmbeddingsOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsOpenAI/EmbeddingsOpenAi.node.ts
@@ -13,6 +13,8 @@ import { logWrapper } from '@utils/logWrapper';
 
 import { getProxyAgent } from '@utils/httpProxyAgent';
 import { getConnectionHintNoticeField } from '@utils/sharedFields';
+import { Container } from '@n8n/di';
+import { AiConfig } from '@n8n/config';
 
 const modelParameter: INodeProperties = {
 	displayName: 'Model',
@@ -245,7 +247,11 @@ export class EmbeddingsOpenAi implements INodeType {
 			options.timeout = undefined;
 		}
 
-		const configuration: ClientOptions = {};
+		const { openAiDefaultHeaders: defaultHeaders } = Container.get(AiConfig);
+
+		const configuration: ClientOptions = {
+			defaultHeaders,
+		};
 		if (options.baseURL) {
 			configuration.baseURL = options.baseURL;
 		} else if (credentials.url) {

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
@@ -764,7 +764,10 @@ export class LmChatOpenAi implements INodeType {
 			credentials.headerName &&
 			typeof credentials.headerValue === 'string'
 		) {
-			configuration.defaultHeaders[credentials.headerName] = credentials.headerValue;
+			configuration.defaultHeaders = {
+				...configuration.defaultHeaders,
+				[credentials.headerName]: credentials.headerValue,
+			};
 		}
 
 		// Extra options to send to OpenAI, that are not directly supported by LangChain

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
@@ -19,6 +19,8 @@ import { N8nLlmTracing } from '../N8nLlmTracing';
 import { formatBuiltInTools, prepareAdditionalResponsesParams } from './common';
 import { searchModels } from './methods/loadModels';
 import type { ModelOptions } from './types';
+import { Container } from '@n8n/di';
+import { AiConfig } from '@n8n/config';
 
 const INCLUDE_JSON_WARNING: INodeProperties = {
 	displayName:
@@ -739,7 +741,11 @@ export class LmChatOpenAi implements INodeType {
 
 		const options = this.getNodeParameter('options', itemIndex, {}) as ModelOptions;
 
-		const configuration: ClientOptions = {};
+		const { openAiDefaultHeaders: defaultHeaders } = Container.get(AiConfig);
+
+		const configuration: ClientOptions = {
+			defaultHeaders,
+		};
 
 		if (options.baseURL) {
 			configuration.baseURL = options.baseURL;
@@ -758,9 +764,7 @@ export class LmChatOpenAi implements INodeType {
 			credentials.headerName &&
 			typeof credentials.headerValue === 'string'
 		) {
-			configuration.defaultHeaders = {
-				[credentials.headerName]: credentials.headerValue,
-			};
+			configuration.defaultHeaders[credentials.headerName] = credentials.headerValue;
 		}
 
 		// Extra options to send to OpenAI, that are not directly supported by LangChain

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/methods/loadModels.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/methods/loadModels.ts
@@ -3,6 +3,8 @@ import OpenAI from 'openai';
 
 import { shouldIncludeModel } from '../../../vendors/OpenAi/helpers/modelFiltering';
 import { getProxyAgent } from '@utils/httpProxyAgent';
+import { Container } from '@n8n/di';
+import { AiConfig } from '@n8n/config';
 
 export async function searchModels(
 	this: ILoadOptionsFunctions,
@@ -13,6 +15,7 @@ export async function searchModels(
 		(this.getNodeParameter('options.baseURL', '') as string) ||
 		(credentials.url as string) ||
 		'https://api.openai.com/v1';
+	const { openAiDefaultHeaders: defaultHeaders } = Container.get(AiConfig);
 
 	const openai = new OpenAI({
 		baseURL,
@@ -20,6 +23,7 @@ export async function searchModels(
 		fetchOptions: {
 			dispatcher: getProxyAgent(baseURL),
 		},
+		defaultHeaders,
 	});
 	const { data: models = [] } = await openai.models.list();
 

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMOpenAi/LmOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMOpenAi/LmOpenAi.node.ts
@@ -9,6 +9,8 @@ import type {
 } from 'n8n-workflow';
 
 import { getProxyAgent } from '@utils/httpProxyAgent';
+import { Container } from '@n8n/di';
+import { AiConfig } from '@n8n/config';
 
 import { makeN8nLlmFailedAttemptHandler } from '../n8nLlmFailedAttemptHandler';
 import { N8nLlmTracing } from '../N8nLlmTracing';
@@ -249,10 +251,12 @@ export class LmOpenAi implements INodeType {
 			topP?: number;
 		};
 
+		const { openAiDefaultHeaders: defaultHeaders } = Container.get(AiConfig);
 		const configuration: ClientOptions = {
 			fetchOptions: {
 				dispatcher: getProxyAgent(options.baseURL ?? 'https://api.openai.com/v1'),
 			},
+			defaultHeaders,
 		};
 
 		if (options.baseURL) {

--- a/packages/@n8n/nodes-langchain/nodes/llms/test/LmChatOpenAi.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/test/LmChatOpenAi.test.ts
@@ -116,7 +116,9 @@ describe('LmChatOpenAi', () => {
 					model: 'gpt-4o-mini',
 					timeout: 60000,
 					maxRetries: 2,
-					configuration: {},
+					configuration: {
+						defaultHeaders,
+					},
 					callbacks: expect.arrayContaining([expect.any(Object)]),
 					modelKwargs: {},
 					onFailedAttempt: expect.any(Function),

--- a/packages/@n8n/nodes-langchain/nodes/llms/test/LmChatOpenAi.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/test/LmChatOpenAi.test.ts
@@ -1,6 +1,8 @@
 /* eslint-disable n8n-nodes-base/node-filename-against-convention */
 /* eslint-disable @typescript-eslint/unbound-method */
 import { ChatOpenAI } from '@langchain/openai';
+import { AiConfig } from '@n8n/config';
+import { Container } from '@n8n/di';
 import { createMockExecuteFunction } from 'n8n-nodes-base/test/nodes/Helpers';
 import type { IDataObject, INode, ISupplyDataFunctions } from 'n8n-workflow';
 
@@ -21,6 +23,7 @@ const MockedChatOpenAI = jest.mocked(ChatOpenAI);
 const MockedN8nLlmTracing = jest.mocked(N8nLlmTracing);
 const mockedMakeN8nLlmFailedAttemptHandler = jest.mocked(makeN8nLlmFailedAttemptHandler);
 const mockedCommon = jest.mocked(common);
+const { openAiDefaultHeaders: defaultHeaders } = Container.get(AiConfig);
 
 describe('LmChatOpenAi', () => {
 	let lmChatOpenAi: LmChatOpenAi;
@@ -145,7 +148,9 @@ describe('LmChatOpenAi', () => {
 					model: 'gpt-4o-mini',
 					timeout: 60000,
 					maxRetries: 2,
-					configuration: {},
+					configuration: {
+						defaultHeaders,
+					},
 					callbacks: expect.arrayContaining([expect.any(Object)]),
 					modelKwargs: {},
 					onFailedAttempt: expect.any(Function),
@@ -182,6 +187,7 @@ describe('LmChatOpenAi', () => {
 						fetchOptions: {
 							dispatcher: {},
 						},
+						defaultHeaders,
 					},
 					callbacks: expect.arrayContaining([expect.any(Object)]),
 					modelKwargs: {},
@@ -218,6 +224,7 @@ describe('LmChatOpenAi', () => {
 						fetchOptions: {
 							dispatcher: {},
 						},
+						defaultHeaders,
 					},
 					callbacks: expect.arrayContaining([expect.any(Object)]),
 					modelKwargs: {},
@@ -252,6 +259,7 @@ describe('LmChatOpenAi', () => {
 					maxRetries: 2,
 					configuration: {
 						defaultHeaders: {
+							...defaultHeaders,
 							'X-Custom-Header': 'custom-value',
 						},
 					},
@@ -295,7 +303,9 @@ describe('LmChatOpenAi', () => {
 					topP: 0.9,
 					timeout: 45000,
 					maxRetries: 3,
-					configuration: {},
+					configuration: {
+						defaultHeaders,
+					},
 					callbacks: expect.arrayContaining([expect.any(Object)]),
 					modelKwargs: {
 						response_format: { type: 'json_object' },
@@ -406,6 +416,7 @@ describe('LmChatOpenAi', () => {
 						fetchOptions: {
 							dispatcher: {},
 						},
+						defaultHeaders,
 					},
 				}),
 			);

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v1/actions/assistant/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v1/actions/assistant/message.operation.ts
@@ -25,6 +25,8 @@ import { getTracingConfig } from '@utils/tracing';
 import { formatToOpenAIAssistantTool, getChatMessages } from '../../../helpers/utils';
 import { assistantRLC } from '../descriptions';
 import { getProxyAgent } from '@utils/httpProxyAgent';
+import { Container } from '@n8n/di';
+import { AiConfig } from '@n8n/config';
 
 const properties: INodeProperties[] = [
 	assistantRLC,
@@ -179,6 +181,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 	};
 
 	const baseURL = (options.baseURL ?? credentials.url) as string;
+	const { openAiDefaultHeaders: defaultHeaders } = Container.get(AiConfig);
 
 	const client = new OpenAIClient({
 		apiKey: credentials.apiKey as string,
@@ -188,6 +191,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 		fetchOptions: {
 			dispatcher: getProxyAgent(baseURL),
 		},
+		defaultHeaders,
 	});
 
 	const agent = new OpenAIAssistantRunnable({ assistantId, client, asAgent: true });

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/request-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/request-helper-functions.test.ts
@@ -1,3 +1,5 @@
+import { AiConfig } from '@n8n/config';
+import { Container } from '@n8n/di';
 import FormData from 'form-data';
 import type { Agent as HttpsAgent } from 'https';
 import { mock, mockDeep } from 'jest-mock-extended';
@@ -231,6 +233,22 @@ describe('Request Helper Functions', () => {
 				},
 				{ sendImmediately: false },
 			);
+
+			expect(response.status).toBe(200);
+			expect(response.data).toEqual({ success: true });
+		});
+
+		it('should include vendor headers in requests to OpenAi', async () => {
+			const { openAiDefaultHeaders } = Container.get(AiConfig);
+			nock('https://api.openai.com', {
+				reqheaders: openAiDefaultHeaders,
+			})
+				.get('/chat')
+				.reply(200, { success: true });
+
+			const response = await invokeAxios({
+				url: 'https://api.openai.com/chat',
+			});
 
 			expect(response.status).toBe(200);
 			expect(response.data).toEqual({ success: true });
@@ -866,6 +884,22 @@ describe('Request Helper Functions', () => {
 
 			expect(response).toEqual({ success: true });
 			scope.done();
+		});
+
+		it('should include vendor headers in requests to OpenAi', async () => {
+			const { openAiDefaultHeaders } = Container.get(AiConfig);
+			nock('https://api.openai.com', {
+				reqheaders: openAiDefaultHeaders,
+			})
+				.get('/chat')
+				.reply(200, { success: true });
+
+			const response = await invokeAxios({
+				url: 'https://api.openai.com/chat',
+			});
+
+			expect(response.status).toBe(200);
+			expect(response.data).toEqual({ success: true });
 		});
 	});
 

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/request-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/request-helper-functions.test.ts
@@ -888,18 +888,19 @@ describe('Request Helper Functions', () => {
 
 		it('should include vendor headers in requests to OpenAi', async () => {
 			const { openAiDefaultHeaders } = Container.get(AiConfig);
-			nock('https://api.openai.com', {
+			const scope = nock('https://api.openai.com', {
 				reqheaders: openAiDefaultHeaders,
 			})
 				.get('/chat')
 				.reply(200, { success: true });
 
-			const response = await invokeAxios({
+			const response = await httpRequest({
+				method: 'GET',
 				url: 'https://api.openai.com/chat',
+				headers: { 'X-Custom-Header': 'custom-value' },
 			});
-
-			expect(response.status).toBe(200);
-			expect(response.data).toEqual({ success: true });
+			expect(response).toEqual({ success: true });
+			scope.done();
 		});
 	});
 

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
@@ -14,6 +14,7 @@ import type {
 	OAuth2CredentialData,
 } from '@n8n/client-oauth2';
 import { ClientOAuth2 } from '@n8n/client-oauth2';
+import { AiConfig } from '@n8n/config';
 import { Container } from '@n8n/di';
 import type { AxiosError, AxiosHeaders, AxiosRequestConfig, AxiosResponse } from 'axios';
 import axios from 'axios';
@@ -69,7 +70,6 @@ import type { IResponseError } from '@/interfaces';
 
 import { binaryToString } from './binary-helper-functions';
 import { parseIncomingMessage } from './parse-incoming-message';
-import { AiConfig } from '@n8n/config';
 
 axios.defaults.timeout = 300000;
 // Prevent axios from adding x-form-www-urlencoded headers by default


### PR DESCRIPTION
## Summary

Adds configurable default headers for OpenAI vendor requests. To test the changes run the environment with `NODE_DEBUG=http,http2,https DEBUG=openai-agents:* OPENAI_LOG=debug` and observe in application logs that requests to OpenAI api include the new platform header.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4120/all-requests-to-openai-should-include-a-platform-header

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
