### PR TITLE
fix(core): Skip saving workflow statistics on 'chat' executions

### DIFF
--- a/packages/cli/src/services/__tests__/workflow-statistics.service.integration.test.ts
+++ b/packages/cli/src/services/__tests__/workflow-statistics.service.integration.test.ts
@@ -119,6 +119,25 @@ describe('WorkflowStatisticsService', () => {
 			},
 		);
 
+		it('should not upsert statistics for execution mode chat', async () => {
+			// ARRANGE
+			const runData: IRun = {
+				finished: true,
+				status: 'success',
+				data: createEmptyRunExecutionData(),
+				mode: 'chat',
+				startedAt: new Date(),
+			};
+
+			// ACT
+			await workflowStatisticsService.workflowExecutionCompleted(workflow, runData);
+			await workflowStatisticsService.workflowExecutionCompleted(workflow, runData);
+
+			// ASSERT
+			const statistics = await workflowStatisticsRepository.find();
+			expect(statistics).toHaveLength(0);
+		});
+
 		test.each<ExecutionStatus>(['success', 'crashed', 'error'])(
 			'should upsert `count` and `rootCount` for execution status %s',
 			async (status) => {

--- a/packages/cli/src/services/workflow-statistics.service.ts
+++ b/packages/cli/src/services/workflow-statistics.service.ts
@@ -90,16 +90,24 @@ export class WorkflowStatisticsService extends TypedEmitter<WorkflowStatisticsEv
 	async workflowExecutionCompleted(workflowData: IWorkflowBase, runData: IRun): Promise<void> {
 		// Determine the name of the statistic
 		const isSuccess = runData.status === 'success';
-		const manual = runData.mode === 'manual';
+		const manualExecution = runData.mode === 'manual';
+		const chatExecution = runData.mode === 'chat';
+
+		if (chatExecution) {
+			// Chat workflows are short lived and deleted immediately after execution, so we skip statistics for them.
+			// They are also not counted towards execution limits.
+			return;
+		}
+
 		let name: StatisticsNames;
 		const isRootExecution =
 			isModeRootExecution[runData.mode] && isStatusRootExecution[runData.status];
 
 		if (isSuccess) {
-			if (manual) name = StatisticsNames.manualSuccess;
+			if (manualExecution) name = StatisticsNames.manualSuccess;
 			else name = StatisticsNames.productionSuccess;
 		} else {
-			if (manual) name = StatisticsNames.manualError;
+			if (manualExecution) name = StatisticsNames.manualError;
 			else name = StatisticsNames.productionError;
 		}
 


### PR DESCRIPTION
## Summary

When chatting with base LLM models on Chat hub errors from workflow statistics are loccassionally logged especially on postgres, as the chat workflow that gets executed is short lived and gets deleted immediately after finishing, so inserting workflow statistics that has foreign key reference to the workflow fails. This error is mostly cosmetic, as we don't really care for it failing.

```
error QueryFailedError: insert or update on table "workflow_statistics" violates foreign key constraint "fk_workflow_statistics_workflow_id"
    at PostgresQueryRunner.query (/Users/jaakko/work/n8n/node_modules/.pnpm/@n8n+typeorm@0.3.20-15_@sentry+node@9.42.1_mysql2@3.15.0_pg@8.12.0_sqlite3@5.1.7/node_modules/src/driver/postgres/PostgresQueryRunner.ts:331:19)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
    at DataSource.query (/Users/jaakko/work/n8n/node_modules/.pnpm/@n8n+typeorm@0.3.20-15_@sentry+node@9.42.1_mysql2@3.15.0_pg@8.12.0_sqlite3@5.1.7/node_modules/src/data-source/DataSource.ts:487:20)
    at WorkflowStatisticsRepository.upsertWorkflowStatistics (/Users/jaakko/work/n8n/packages/@n8n/db/src/repositories/workflow-statistics.repository.ts:92:26)
    at WorkflowStatisticsService.workflowExecutionCompleted (/Users/jaakko/work/n8n/packages/cli/src/services/workflow-statistics.service.ts:111:25)
    at WorkflowStatisticsService.<anonymous> (/Users/jaakko/work/n8n/packages/cli/src/services/workflow-statistics.service.ts:86:5) {
  query: 'INSERT INTO "workflow_statistics" ("count", "rootCount", "name", "workflowId", "latestEvent")\n' +
    '\t\t\t\t\tVALUES (1, $1, $2, $3, CURRENT_TIMESTAMP)\n' +
    '\t\t\t\t\tON CONFLICT ("name", "workflowId")\n' +
    '\t\t\t\t\tDO UPDATE SET\n' +
    '\t\t\t\t\t\t"count" = "workflow_statistics"."count" + 1,\n' +
    '\t\t\t\t\t\t"rootCount" = "workflow_statistics"."rootCount" + $4,\n' +
    '\t\t\t\t\t\t"latestEvent" = CURRENT_TIMESTAMP\n' +
    '\t\t\t\t\tRETURNING *;',
  parameters: [ 0, 'production_success', 'tYylfFFH5FJ9P95q', 0 ],
  driverError: error: insert or update on table "workflow_statistics" violates foreign key constraint "fk_workflow_statistics_workflow_id"
      at /Users/jaakko/work/n8n/node_modules/.pnpm/pg@8.12.0/node_modules/pg/lib/client.js:526:17
      at processTicksAndRejections (node:internal/process/task_queues:105:5)
      at PostgresQueryRunner.query (/Users/jaakko/work/n8n/node_modules/.pnpm/@n8n+typeorm@0.3.20-15_@sentry+node@9.42.1_mysql2@3.15.0_pg@8.12.0_sqlite3@5.1.7/node_modules/src/driver/postgres/PostgresQueryRunner.ts:260:25)
      at DataSource.query (/Users/jaakko/work/n8n/node_modules/.pnpm/@n8n+typeorm@0.3.20-15_@sentry+node@9.42.1_mysql2@3.15.0_pg@8.12.0_sqlite3@5.1.7/node_modules/src/data-source/DataSource.ts:487:20)
      at WorkflowStatisticsRepository.upsertWorkflowStatistics (/Users/jaakko/work/n8n/packages/@n8n/db/src/repositories/workflow-statistics.repository.ts:92:26)
      at WorkflowStatisticsService.workflowExecutionCompleted (/Users/jaakko/work/n8n/packages/cli/src/services/workflow-statistics.service.ts:111:25)
      at WorkflowStatisticsService.<anonymous> (/Users/jaakko/work/n8n/packages/cli/src/services/workflow-statistics.service.ts:86:5) {
    length: 330,
    severity: 'ERROR',
    code: '23503',
    detail: 'Key (workflowId)=(tYylfFFH5FJ9P95q) is not present in table "workflow_entity".',
    hint: undefined,
    position: undefined,
    internalPosition: undefined,
    internalQuery: undefined,
    where: undefined,
    schema: 'public',
    table: 'workflow_statistics',
    column: undefined,
    dataType: undefined,
    constraint: 'fk_workflow_statistics_workflow_id',
    file: 'ri_triggers.c',
    line: '2608',
    routine: 'ri_ReportViolation'
  },
  length: 330,
  severity: 'ERROR',
  code: '23503',
  detail: 'Key (workflowId)=(tYylfFFH5FJ9P95q) is not present in table "workflow_entity".',
  hint: undefined,
  position: undefined,
  internalPosition: undefined,
  internalQuery: undefined,
  where: undefined,
  schema: 'public',
  table: 'workflow_statistics',
  column: undefined,
  dataType: undefined,
  constraint: 'fk_workflow_statistics_workflow_id',
  file: 'ri_triggers.c',
  line: '2608',
  routine: 'ri_ReportViolation'
}
```

There appears to be `CASCADE ON DELETE` trigger on the workflow statistics to anyways delete the rows when WF is deleted, so simply not saving `chat` executions should be a good idea.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-91/bug-chat-removing-the-wfs-after-running-causes-errors-at-wf-statistics

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
