### PR TITLE
fix(auth): add configurable TTL for task runner grant tokens

### DIFF
--- a/packages/@n8n/config/src/configs/runners.config.ts
+++ b/packages/@n8n/config/src/configs/runners.config.ts
@@ -24,6 +24,14 @@ export class TaskRunnersConfig {
 	@Env('N8N_RUNNERS_AUTH_TOKEN')
 	authToken: string = '';
 
+	/**
+	 * TTL (in seconds) for grant tokens used to authenticate runner WebSocket connections.
+	 * Increase this if task runners take longer to start up in container environments
+	 * (e.g., set to 60 for slow container environments).
+	 */
+	@Env('N8N_RUNNERS_GRANT_TOKEN_TTL')
+	grantTokenTtl: number = 15;
+
 	/** Port task runners broker should listen on */
 	@Env('N8N_RUNNERS_BROKER_PORT')
 	port: number = 5679;

--- a/packages/cli/src/task-runners/task-broker/auth/task-broker-auth.service.ts
+++ b/packages/cli/src/task-runners/task-broker/auth/task-broker-auth.service.ts
@@ -5,7 +5,7 @@ import { randomBytes, timingSafeEqual } from 'crypto';
 
 import { CacheService } from '@/services/cache/cache.service';
 
-const GRANT_TOKEN_TTL = 15 * Time.seconds.toMilliseconds;
+const DEFAULT_GRANT_TOKEN_TTL = 15 * Time.seconds.toMilliseconds;
 
 @Service()
 export class TaskBrokerAuthService {
@@ -15,8 +15,18 @@ export class TaskBrokerAuthService {
 		private readonly globalConfig: GlobalConfig,
 		private readonly cacheService: CacheService,
 		// For unit testing purposes
-		private readonly grantTokenTtl = GRANT_TOKEN_TTL,
+		private readonly grantTokenTtl = globalConfig.taskRunners.grantTokenTtl
+			? globalConfig.taskRunners.grantTokenTtl * Time.seconds.toMilliseconds
+			: DEFAULT_GRANT_TOKEN_TTL,
 	) {}
+
+	/**
+	 * Returns the grant token TTL in milliseconds.
+	 * Useful for logging and debugging.
+	 */
+	getGrantTokenTtl() {
+		return this.grantTokenTtl;
+	}
 
 	isValidAuthToken(token: string) {
 		const tokenBuffer = Buffer.from(token);


### PR DESCRIPTION
## Summary

The initialization step in the external task runner mechanism has 15sec fixed timeout. Its not so natural, unclear, and some runtimes will exceed the limit. So I want
- Configurable TTL can extend the fixed limit
- More informative logs

## Related Linear tickets, Github issues, and Community forum posts

https://community.n8n.io/t/code-nodes-are-broken-by-task-runner-connection-attempt-failed-with-status-code-403/236238/7

I and some users have the same issue.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
