### PR TITLE
feat(GoogleApi.credentials): add global region to Google API credentials

### DIFF
--- a/packages/nodes-base/credentials/GoogleApi.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleApi.credentials.ts
@@ -12,6 +12,11 @@ import type {
 
 const regions = [
 	{
+		name: 'global',
+		displayName: 'Global',
+		location: 'Global',
+	},
+	{
 		name: 'africa-south1',
 		displayName: 'Africa',
 		location: 'Johannesburg',


### PR DESCRIPTION
## Summary

It allows to use `gemini-3-flash-preview` and `gemini-3-pro-preview` on Google Cloud VertexAI.

<img width="513" height="355" alt="image" src="https://github.com/user-attachments/assets/a9c4f536-b2ff-44d0-a4a3-b04195db022c" />

<img width="628" height="331" alt="image" src="https://github.com/user-attachments/assets/efd16fdd-b834-4e8b-a83f-08e176142129" />

It works in my local env.

## Related Linear tickets, Github issues, and Community forum posts

https://community.n8n.io/t/global-region-support-for-google-service-account-api-credentials/239056

(and a similar topic) https://community.n8n.io/t/vertex-model-chat-model-not-found/129691

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
