### PR TITLE
refactor(core): Rework how credential access is checked on Chat hub

### DIFF
--- a/packages/cli/src/modules/chat-hub/chat-hub-agent.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-agent.service.ts
@@ -8,12 +8,12 @@ import type { User } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { v4 as uuidv4 } from 'uuid';
 
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+
 import type { ChatHubAgent, IChatHubAgent } from './chat-hub-agent.entity';
 import { ChatHubAgentRepository } from './chat-hub-agent.repository';
 import { ChatHubCredentialsService } from './chat-hub-credentials.service';
 import { getModelMetadata } from './chat-hub.constants';
-
-import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
 @Service()
 export class ChatHubAgentService {
@@ -57,8 +57,8 @@ export class ChatHubAgentService {
 	}
 
 	async createAgent(user: User, data: ChatHubCreateAgentRequest): Promise<ChatHubAgent> {
-		// Ensure user has access to credentials if provided
-		await this.chatHubCredentialsService.ensureCredentialById(user, data.credentialId);
+		// Ensure user has access to the credential being saved
+		await this.chatHubCredentialsService.ensureCredentialAccess(user, data.credentialId);
 
 		const id = uuidv4();
 
@@ -90,9 +90,9 @@ export class ChatHubAgentService {
 			throw new NotFoundError('Chat agent not found');
 		}
 
-		// Ensure user has access to credentials if provided
+		// Ensure user has access to the credential if provided
 		if (updates.credentialId !== undefined && updates.credentialId !== null) {
-			await this.chatHubCredentialsService.ensureCredentialById(user, updates.credentialId);
+			await this.chatHubCredentialsService.ensureCredentialAccess(user, updates.credentialId);
 		}
 
 		const updateData: Partial<IChatHubAgent> = {};


### PR DESCRIPTION
## Summary

`ensureCredentialById` checks were rather slow on instances where the (admin?) user has access to thosuands of credentials. This check was loading all credentials the WF & user could access and doing an intersection on client side instead of doing that on the DB, requiring reading thousands of rows.

While that could've been changed to do it on DB side I realized this checkw as actually just unnecessary, an artifact from the development phase where we hadn't yet introduced the hard requirement for chat workflows to run in the current user's personal project. Now that we enforce that - every base LLM chat WF is created & runs under the current users personal project - we should be able to just trust on `CredentialsPermissionChecker` on https://github.com/n8n-io/n8n/blob/master/packages/cli/src/workflow-runner.ts#L147 to ensure that the WF that runs can access the credentials.

As such this PR removes those checks, and only checks for the presence of the credential in the credentials object now. We still check on saving agents that the user can access the credential being saved for a custom agent - if they try something malicious and bypass the UI and pick something not usable on their personal project that will then just fail at execution time, this check is mostly just for sanity.

These checks also weren't relevant on agent workflow executions.

This should make chats slightly faster on large instance, and I think this will also make saving agents faster as the new check used there is faster.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-81/make-chat-queries-faster

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
