### PR TITLE
fix(editor): Fix operator selection in NDV (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nPopover/Popover.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nPopover/Popover.vue
@@ -25,6 +25,10 @@ interface Props
 	 */
 	enableScrolling?: boolean;
 	/**
+	 * Whether to force mount the content even when closed
+	 */
+	forceMount?: boolean;
+	/**
 	 * Whether to enable slide-in animation
 	 */
 	enableSlideIn?: boolean;
@@ -73,6 +77,7 @@ const props = withDefaults(defineProps<Props>(), {
 	maxHeight: undefined,
 	width: undefined,
 	enableScrolling: true,
+	forceMount: false,
 	enableSlideIn: true,
 	scrollType: 'hover',
 	sideOffset: 5,
@@ -134,6 +139,7 @@ watch(
 				:class="[$style.popoverContent, contentClass, { [$style.enableSlideIn]: enableSlideIn }]"
 				:style="{ width, zIndex }"
 				:reference="reference"
+				:force-mount="forceMount"
 				@open-auto-focus="handleOpenAutoFocus"
 				@pointer-down-outside="handleOutsideInteraction"
 				@interact-outside="handleOutsideInteraction"
@@ -169,6 +175,10 @@ watch(
 	&.enableSlideIn {
 		animation-duration: 400ms;
 		animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+	}
+
+	&[data-state='closed'] {
+		display: none;
 	}
 }
 

--- a/packages/frontend/@n8n/design-system/src/components/N8nPopover/Popover.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nPopover/Popover.vue
@@ -18,7 +18,10 @@ defineOptions({ name: 'N8nPopover' });
 import N8nScrollArea from '../N8nScrollArea/N8nScrollArea.vue';
 
 interface Props
-	extends Pick<PopoverContentProps, 'side' | 'align' | 'sideFlip' | 'sideOffset' | 'reference'>,
+	extends Pick<
+			PopoverContentProps,
+			'side' | 'align' | 'sideFlip' | 'sideOffset' | 'reference' | 'positionStrategy'
+		>,
 		Pick<PopoverRootProps, 'open'> {
 	/**
 	 * Whether to enable scrolling in the popover content
@@ -86,6 +89,7 @@ const props = withDefaults(defineProps<Props>(), {
 	zIndex: 999,
 	showArrow: false,
 	teleported: true,
+	positionStrategy: undefined,
 });
 
 const emit = defineEmits<Emits>();
@@ -140,6 +144,7 @@ watch(
 				:style="{ width, zIndex }"
 				:reference="reference"
 				:force-mount="forceMount"
+				:position-strategy="positionStrategy"
 				@open-auto-focus="handleOpenAutoFocus"
 				@pointer-down-outside="handleOutsideInteraction"
 				@interact-outside="handleOutsideInteraction"

--- a/packages/frontend/@n8n/design-system/src/components/N8nPopover/__snapshots__/Popover.test.ts.snap
+++ b/packages/frontend/@n8n/design-system/src/components/N8nPopover/__snapshots__/Popover.test.ts.snap
@@ -4,7 +4,7 @@ exports[`N8nPopover > should render correctly with default props 1`] = `
 "<mock-popover-root>
   <mock-popover-trigger><button></button></mock-popover-trigger>
   <mock-popover-portal disabled="false">
-    <mock-popover-content role="dialog">
+    <mock-popover-content role="dialog" force-mount="false">
       <div dir="ltr" style="position: relative; --reka-scroll-area-corner-width: 0px; --reka-scroll-area-corner-height: 0px;" class="scrollAreaRoot">
         <div data-reka-scroll-area-viewport="" style="overflow-x: hidden; overflow-y: hidden;" class="viewport" tabindex="0">
           <div>

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/ExecutionsFilter.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/ExecutionsFilter.vue
@@ -174,6 +174,7 @@ onBeforeMount(() => {
 	<N8nPopover
 		:side="props.popoverSide"
 		:align="props.popoverAlign"
+		position-strategy="absolute"
 		width="440px"
 		:content-class="$style['popover-content']"
 		show-arrow

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/FilterConditions/OperatorSelect.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/FilterConditions/OperatorSelect.vue
@@ -46,9 +46,7 @@ const getOperatorId = (operator: FilterOperator): string =>
 
 function onSelectVisibleChange(open: boolean) {
 	menuOpen.value = open;
-	if (!open) {
-		submenu.value = 'none';
-	}
+	submenu.value = 'none';
 }
 
 function onGroupSelect(group: string) {
@@ -90,6 +88,8 @@ watch(
 					width="auto"
 					:content-class="$style.submenuContent"
 					:enable-scrolling="false"
+					:teleported="false"
+					:force-mount="true"
 				>
 					<template #trigger>
 						<div


### PR DESCRIPTION
## Summary

<img width="3024" height="1808" alt="image" src="https://github.com/user-attachments/assets/0e5b395e-f870-40e7-aa70-e437807fa3e0" />
<img width="1512" height="842" alt="image" src="https://github.com/user-attachments/assets/d9c20e89-59ad-4e23-a273-8bebd4f7d860" />


The N8nPopover migration to Reka UI (#22766) broke the operator selector because:
  1. Reka UI's PopoverContent only mounts when open=true, unlike Element Plus which kept content in DOM
  2. Since submenus start closed, no N8nOption elements were in the DOM for ElSelect to find
  
Also fixed the executions filter poover not being accessible as there's no scroll.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4570/operator-selector-in-ndv-is-broken

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
