### PR TITLE
fix: Limit access to files based on regex pattern

### DIFF
--- a/packages/@n8n/config/src/configs/security.config.ts
+++ b/packages/@n8n/config/src/configs/security.config.ts
@@ -20,6 +20,14 @@ export class SecurityConfig {
 	blockFileAccessToN8nFiles: boolean = true;
 
 	/**
+	 * Blocked file and folder regular expression patterns that `ReadWriteFile` and `ReadBinaryFiles` nodes cant access. Separate multiple patterns with with semicolon `;`.
+	 * - `^(.*\/)*\.git(\/.*)*$`
+	 * Set to empty to not block based on file patterns.
+	 */
+	@Env('N8N_BLOCK_FILE_PATTERNS')
+	blockFilePatterns: string = '^(.*\\/)*\\.git(\\/.*)*$';
+
+	/**
 	 * In a [security audit](https://docs.n8n.io/hosting/securing/security-audit/), how many days for a workflow to be considered abandoned if not executed.
 	 */
 	@Env('N8N_SECURITY_AUDIT_DAYS_ABANDONED_WORKFLOW')

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -320,6 +320,7 @@ describe('GlobalConfig', () => {
 		security: {
 			restrictFileAccessTo: '',
 			blockFileAccessToN8nFiles: true,
+			blockFilePatterns: '^(.*\\/)*\\.git(\\/.*)*$',
 			daysAbandonedWorkflow: 90,
 			contentSecurityPolicy: '{}',
 			contentSecurityPolicyReportOnly: false,

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
@@ -1,3 +1,4 @@
+import { SecurityConfig } from '@n8n/config';
 import { Container } from '@n8n/di';
 import type { INode } from 'n8n-workflow';
 import { constants, createReadStream } from 'node:fs';
@@ -23,6 +24,9 @@ jest.mock('node:fs/promises');
 const originalProcessEnv = { ...process.env };
 
 let instanceSettings: InstanceSettings;
+let securityConfig: SecurityConfig;
+let originalBlockedFilePatterns: string;
+
 beforeEach(() => {
 	process.env = { ...originalProcessEnv };
 
@@ -33,6 +37,13 @@ beforeEach(() => {
 	(fsRealpath as jest.Mock).mockImplementation((path: string) => path);
 
 	instanceSettings = Container.get(InstanceSettings);
+	securityConfig = Container.get(SecurityConfig);
+	securityConfig.restrictFileAccessTo = '';
+	originalBlockedFilePatterns = securityConfig.blockFilePatterns;
+});
+
+afterEach(() => {
+	securityConfig.blockFilePatterns = originalBlockedFilePatterns;
 });
 
 describe('isFilePathBlocked', () => {
@@ -181,6 +192,45 @@ describe('isFilePathBlocked', () => {
 		error.code = 'ENOENT';
 		(fsRealpath as jest.Mock).mockRejectedValueOnce(error);
 		expect(isFilePathBlocked(await resolvePath(filePath))).toBe(true);
+	});
+
+	it.each(['.git', '/.git', '/tmp/.git', '/tmp/.git/config'])(
+		'should per default block access to %s',
+		async (path) => {
+			expect(isFilePathBlocked(await resolvePath(path))).toBe(true);
+		},
+	);
+
+	it('should allow access when pattern matching is disabled', async () => {
+		securityConfig.blockFilePatterns = '';
+		expect(isFilePathBlocked(await resolvePath('/tmp/.git'))).toBe(false);
+	});
+
+	it('should block all access when using invalid pattern', async () => {
+		securityConfig.blockFilePatterns = '(';
+		expect(isFilePathBlocked(await resolvePath('/tmp/xo'))).toBe(true);
+	});
+
+	describe('when multiple file patterns are configured', () => {
+		beforeEach(() => {
+			securityConfig.blockFilePatterns = 'hello; \\/there$; ^where';
+		});
+
+		it.each([
+			'hello',
+			'xhellox',
+			'subpath/hello/',
+			'/there',
+			'/subpath/there',
+			'where',
+			'where-is/it',
+		])('should block access to %s', async (path) => {
+			expect(isFilePathBlocked(await resolvePath(path))).toBe(true);
+		});
+
+		it.each(['/there/is', '/where'])('should not block access to %s', async (path) => {
+			expect(isFilePathBlocked(await resolvePath(path))).toBe(false);
+		});
 	});
 });
 


### PR DESCRIPTION
## Summary

Limit read/write access based on (configurable) file pattern

Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-4106

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
