### PR TITLE
fix: Escape all identifiers in MS Sql node

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Sql/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Sql/GenericFunctions.ts
@@ -118,7 +118,7 @@ export function configurePool(credentials: IDataObject) {
 const escapeTableName = (table: string) => {
 	table = table.trim();
 	if (table.startsWith('[') && table.endsWith(']')) {
-		table = table.substring(1, -1);
+		table = table.substring(1, table.length - 1);
 	}
 
 	return escapeIdentifier(table);


### PR DESCRIPTION
## Summary

Escape all identifiers (table and column names) in MS Sql node operations

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4135

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
