### PR TITLE
fix(editor): Fix input type switch when pasting expression

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.test.ts
@@ -582,10 +582,24 @@ describe('ParameterInput.vue', () => {
 	});
 
 	test('should reset string on eventBus:removeExpression', async () => {
+		mockNdvState = {
+			...getNdvStateMock(),
+			activeNode: {
+				id: faker.string.uuid(),
+				name: 'Test Node',
+				parameters: {
+					aStr: 'test',
+				},
+				position: [0, 0],
+				type: 'n8n-nodes-base.httpRequest',
+				typeVersion: 1,
+			},
+		};
+
 		const eventBus = createEventBus();
 		const { emitted } = renderComponent({
 			props: {
-				path: 'aStr',
+				path: 'parameters.aStr',
 				parameter: {
 					displayName: 'A Str',
 					name: 'aStr',

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
@@ -914,11 +914,7 @@ function valueChanged(untypedValue: unknown) {
 
 	const isSpecializedEditor = props.parameter.typeOptions?.editor !== undefined;
 
-	if (
-		!oldValue &&
-		oldValue !== undefined &&
-		shouldConvertToExpression(value, isSpecializedEditor)
-	) {
+	if (!oldValue && shouldConvertToExpression(value, isSpecializedEditor)) {
 		// if empty old value and updated value has an expression, add '=' prefix to switch to expression mode
 		value = '=' + value;
 	}


### PR DESCRIPTION
## Summary

For some of the inputs the old value was undefined which was preventing the switch logic to kick in. I couldn't think of a case where old value of undefined would break this flow.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4555/bug-pasting-an-expression-into-a-param-doesnt-automatically-turn-it

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
