### PR TITLE
fix: Remove eval() usage for resolving CSS color (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/styleguide/ColorCircles.utils.ts
+++ b/packages/frontend/@n8n/design-system/src/styleguide/ColorCircles.utils.ts
@@ -15,25 +15,9 @@ export function hslToHex(h: number, s: number, l: number): string {
 }
 
 /**
- * Resolve calc() expressions in HSL strings
- */
-export function resolveHSLCalc(hslString: string): string {
-	const calcRegex = /calc\(([^)]+)\)/;
-	const matchCalc = hslString.match(calcRegex);
-	if (!matchCalc) {
-		return hslString;
-	}
-	const expression = matchCalc[1].replace(/%/g, '');
-	const evaluation: number = eval(expression);
-	const finalPercentage = `${evaluation}%`;
-	return hslString.replace(calcRegex, finalPercentage);
-}
-
-/**
  * Get the Hex color from an HSL color string
  */
 export function getHex(hsl: string): string {
-	hsl = resolveHSLCalc(hsl);
 	const colors = hsl
 		.replace('hsl(', '')
 		.replace(')', '')

--- a/packages/frontend/@n8n/design-system/src/styleguide/ColorCircles.vue
+++ b/packages/frontend/@n8n/design-system/src/styleguide/ColorCircles.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue';
 
-import { getHex, resolveHSLCalc } from './ColorCircles.utils';
+import { getHex } from './ColorCircles.utils';
 
 const props = defineProps<{ colors: string[] }>();
 
@@ -43,7 +43,6 @@ onUnmounted(() => {
 
 // Expose functions for template usage
 const getHexValue = (color: string) => getHex(hsl.value[color]);
-const getHSLValue = (color: string) => resolveHSLCalc(hsl.value[color]);
 </script>
 
 <template>
@@ -51,7 +50,7 @@ const getHSLValue = (color: string) => resolveHSLCalc(hsl.value[color]);
 		<div v-for="color in colors" :key="color" :class="$style.container">
 			<div :class="$style.circle" :style="{ backgroundColor: `var(${color})` }"></div>
 			<span>{{ color }}</span>
-			<span :class="$style.hsl">{{ getHSLValue(color) }}</span>
+			<span :class="$style.hsl">{{ hsl[color] }}</span>
 			<span :class="$style.color">{{ getHexValue(color) }}</span>
 		</div>
 	</div>


### PR DESCRIPTION
## Summary

This PR removes insecure JavaScript eval() function usage for resolving CSS color in a design system component used for illustrating color tokens in Storybook. As of now it appears there's no token that needs the logic, so I'm simply removing it.

## Related Linear tickets, Github issues, and Community forum posts

Resolves https://app.aikido.dev/queue?sidebarIssue=16723822&sidebarIssueTask=2267670&sidebarTab=tasks


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
