### PR TITLE
fix(core): Stronger allowed path enforcement for read/write Node

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
@@ -1,7 +1,7 @@
 import { SecurityConfig } from '@n8n/config';
 import { Container } from '@n8n/di';
 import type { INode } from 'n8n-workflow';
-import { constants } from 'node:fs';
+import { close, constants } from 'node:fs';
 import {
 	access as fsAccess,
 	realpath as fsRealpath,
@@ -358,12 +358,13 @@ describe('getFileSystemHelperFunctions', () => {
 			).rejects.toThrow('Symlinks are not allowed.');
 		});
 
-		it('should reject when file identity changes (TOCTOU prevention)', async () => {
+		it('should reject when file identity changes', async () => {
 			const filePath = '/allowed/path/file';
 			const differentStats = { dev: 999, ino: 888 };
 			const mockFileHandle = {
 				stat: jest.fn().mockResolvedValue(differentStats),
 				createReadStream: jest.fn(),
+				close: jest.fn(),
 			};
 
 			(fsStat as jest.Mock).mockResolvedValueOnce(mockFileStats);

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
@@ -1,7 +1,7 @@
 import { SecurityConfig } from '@n8n/config';
 import { Container } from '@n8n/di';
 import type { INode } from 'n8n-workflow';
-import { close, constants } from 'node:fs';
+import { constants } from 'node:fs';
 import {
 	access as fsAccess,
 	realpath as fsRealpath,
@@ -374,6 +374,7 @@ describe('getFileSystemHelperFunctions', () => {
 			await expect(
 				helperFunctions.createReadStream(await helperFunctions.resolvePath(filePath)),
 			).rejects.toThrow('The file has changed and cannot be accessed.');
+			expect(mockFileHandle.close).toHaveBeenCalled();
 		});
 	});
 
@@ -409,7 +410,7 @@ describe('getFileSystemHelperFunctions', () => {
 			).rejects.toThrow('Symlinks are not allowed.');
 		});
 
-		it('should reject when file identity changes (TOCTOU prevention)', async () => {
+		it('should reject when file identity changes', async () => {
 			const filePath = '/allowed/path/file';
 			const differentStats = { dev: 999, ino: 888, isFile: () => true };
 			const mockFileHandle = {

--- a/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
@@ -120,8 +120,8 @@ export const getFileSystemHelperFunctions = (node: INode): FileSystemHelperFunct
 		try {
 			fileHandle = await fsOpen(resolvedFilePath, constants.O_RDONLY | constants.O_NOFOLLOW);
 		} catch (error) {
-			if (error instanceof Error && 'code' in error && error.code === 'ELOOP') {
-				throw new NodeOperationError(node, error, {
+			if ('code' in error && (error as unknown as { code: string }).code === 'ELOOP') {
+				throw new NodeOperationError(node, error instanceof Error ? error : '', {
 					message: 'Symlinks are not allowed.',
 					level: 'warning',
 				});
@@ -159,7 +159,9 @@ export const getFileSystemHelperFunctions = (node: INode): FileSystemHelperFunct
 		try {
 			pathIdentity = await fsStat(resolvedFilePath);
 		} catch (error) {
-			if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+			// NOTE: for some reason instanceof Error does not work here in tests,
+			// so we just look for the code to catch ENOENT.
+			if ('code' in error && (error as unknown as { code: string }).code === 'ENOENT') {
 				// It's possible the file does not exist yet. In this case we'll create it later.
 				fileExists = false;
 			} else {
@@ -192,8 +194,8 @@ export const getFileSystemHelperFunctions = (node: INode): FileSystemHelperFunct
 		try {
 			fileHandle = await fsOpen(resolvedFilePath, openFlags);
 		} catch (error) {
-			if (error instanceof Error && 'code' in error && error.code === 'ELOOP') {
-				throw new NodeOperationError(node, error, {
+			if ('code' in error && (error as unknown as { code: string }).code === 'ELOOP') {
+				throw new NodeOperationError(node, error instanceof Error ? error : '', {
 					message: 'Symlinks are not allowed.',
 					level: 'warning',
 				});

--- a/packages/nodes-base/nodes/Crypto/test/Crypto.test.ts
+++ b/packages/nodes-base/nodes/Crypto/test/Crypto.test.ts
@@ -1,5 +1,5 @@
 import { NodeTestHarness } from '@nodes-testing/node-test-harness';
-import fs from 'fs';
+import type fs from 'fs';
 import fsPromises, { type FileHandle } from 'fs/promises';
 import { Readable } from 'stream';
 

--- a/packages/nodes-base/nodes/Crypto/test/Crypto.test.ts
+++ b/packages/nodes-base/nodes/Crypto/test/Crypto.test.ts
@@ -1,21 +1,45 @@
 import { NodeTestHarness } from '@nodes-testing/node-test-harness';
 import fs from 'fs';
-import fsPromises from 'fs/promises';
+import fsPromises, { type FileHandle } from 'fs/promises';
 import { Readable } from 'stream';
 
 describe('Test Crypto Node', () => {
 	jest.mock('fast-glob', () => async () => ['/test/binary.data']);
 	jest.mock('fs/promises');
 	fsPromises.access = async () => {};
+	fsPromises.stat = jest.fn(async (path: fs.PathLike) => {
+		if (path === '/test/binary.data') {
+			return {
+				isFile: () => true,
+				dev: 123456,
+				ino: 654321,
+			} as fs.Stats;
+		}
+		throw Object.assign(new Error('File not found'), { code: 'ENOENT' });
+	}) as unknown as typeof fsPromises.stat;
+	fsPromises.open = jest.fn(async (path: fs.PathLike) => {
+		if (path === '/test/binary.data') {
+			return {
+				close: async () => {},
+				// eslint-disable-next-line @typescript-eslint/require-await
+				stat: async () =>
+					({
+						isFile: () => true,
+						dev: 123456,
+						ino: 654321,
+					}) as fs.Stats,
+				createReadStream: () => {
+					const stream = Readable.from(Buffer.from('test')) as fs.ReadStream;
+					// Emit 'open' event asynchronously to match real fs.ReadStream behavior
+					setImmediate(() => stream.emit('open'));
+					return stream;
+				},
+			} as FileHandle;
+		}
+		throw Object.assign(new Error('File not found'), { code: 'ENOENT' });
+	}) as unknown as typeof fsPromises.open;
 	const realpathSpy = jest.spyOn(fsPromises, 'realpath');
 	realpathSpy.mockImplementation(async (path) => path as string);
-	jest.mock('fs');
-	fs.createReadStream = () => {
-		const stream = Readable.from(Buffer.from('test')) as fs.ReadStream;
-		// Emit 'open' event asynchronously to match real fs.ReadStream behavior
-		setImmediate(() => stream.emit('open'));
-		return stream;
-	};
 
 	new NodeTestHarness().setupTests();
 });


### PR DESCRIPTION
## Summary

Fix allowed path enforcement when reading/writing files.

This change ensures that the path we check for safety _actually_ matches the file we read/write.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1852

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
