### PR TITLE
fix(core): Fix race condition in executions pruning on leadership change

### DIFF
--- a/packages/cli/src/services/pruning/__tests__/executions-pruning.service.test.ts
+++ b/packages/cli/src/services/pruning/__tests__/executions-pruning.service.test.ts
@@ -171,6 +171,7 @@ describe('PruningService', () => {
 				instanceType: 'main',
 				isMultiMain: true,
 			});
+			Object.defineProperty(instanceSettings, 'isLeader', { get: () => isLeader });
 			instanceSettings.markAsFollower.mockImplementation(() => {
 				isLeader = false;
 			});

--- a/packages/cli/src/services/pruning/__tests__/executions-pruning.service.test.ts
+++ b/packages/cli/src/services/pruning/__tests__/executions-pruning.service.test.ts
@@ -156,4 +156,49 @@ describe('PruningService', () => {
 			expect(scheduleNextHardDeletionSpy).toHaveBeenCalled();
 		});
 	});
+
+	describe('stopPruning', () => {
+		afterEach(() => jest.restoreAllMocks());
+
+		it('should stop pruning when instance loses leadership', () => {
+			// arrange
+
+			const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+			const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+
+			let isLeader = true;
+			const instanceSettings = mock<InstanceSettings>({
+				instanceType: 'main',
+				isMultiMain: true,
+			});
+			instanceSettings.markAsFollower.mockImplementation(() => {
+				isLeader = false;
+			});
+
+			const pruningService = new ExecutionsPruningService(
+				mockLogger(),
+				instanceSettings,
+				dbConnection,
+				mock(),
+				mock(),
+				mock<ExecutionsConfig>({
+					pruneData: true,
+					pruneDataIntervals: { softDelete: 60, hardDelete: 15 },
+				}),
+			);
+
+			pruningService.startPruning();
+
+			// act
+
+			instanceSettings.markAsFollower();
+			pruningService.stopPruning();
+
+			// assert
+
+			expect(isLeader).toBe(false);
+			expect(clearIntervalSpy).toHaveBeenCalled();
+			expect(clearTimeoutSpy).toHaveBeenCalled();
+		});
+	});
 });

--- a/packages/cli/src/services/pruning/executions-pruning.service.ts
+++ b/packages/cli/src/services/pruning/executions-pruning.service.ts
@@ -77,8 +77,6 @@ export class ExecutionsPruningService {
 
 	@OnLeaderStepdown()
 	stopPruning() {
-		if (!this.isEnabled) return;
-
 		clearInterval(this.softDeletionInterval);
 		clearTimeout(this.hardDeletionTimeout);
 

--- a/packages/cli/src/services/pruning/executions-pruning.service.ts
+++ b/packages/cli/src/services/pruning/executions-pruning.service.ts
@@ -77,10 +77,12 @@ export class ExecutionsPruningService {
 
 	@OnLeaderStepdown()
 	stopPruning() {
+		const hadTimers = this.softDeletionInterval ?? this.hardDeletionTimeout;
+
 		clearInterval(this.softDeletionInterval);
 		clearTimeout(this.hardDeletionTimeout);
 
-		this.logger.debug('Stopped pruning timers');
+		if (hadTimers) this.logger.debug('Stopped pruning timers');
 	}
 
 	private scheduleRollingSoftDeletions(rateMs = this.rates.softDeletion) {


### PR DESCRIPTION
## Summary

On leader stepdown, `stopPruning` was not actually stopping the pruning timers. This method checks `isEnabled` which depends on `isLeader`, but `markAsFollower` is called _before_ the `@OnLeaderStepdown` event fires, so `isLeader` was already `false` leading `stopPruning` to bail early, resulting in redundant work.

This bug manifests only in executions pruning. Checked all other decorated services and cleanup there is either unconditional or relies on whether a timer or resource exists, not leadership state.

Longer term, we should:

- Ensure cleanup methods don't guard on state, i.e. keep them idempotent.
- Ensure consumers only rely on the takeover or stepdown event, not on leadership state.

I'll add a follow-up for this.

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C069HS026UF/p1766493370062609

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
