### PR TITLE
chore(core): Only encrypt partial oauth state

### DIFF
--- a/packages/cli/src/controllers/oauth/__tests__/oauth1-credential.controller.test.ts
+++ b/packages/cli/src/controllers/oauth/__tests__/oauth1-credential.controller.test.ts
@@ -56,6 +56,7 @@ describe('OAuth1CredentialController', () => {
 				cid: '1',
 				origin: 'static-credential',
 				createdAt: timestamp,
+				data: 'encrypted-data',
 			}),
 		).toString('base64');
 
@@ -87,6 +88,7 @@ describe('OAuth1CredentialController', () => {
 				cid: '1',
 				origin: 'static-credential' as const,
 				createdAt: timestamp,
+				data: 'encrypted-data',
 			};
 			oauthService.getCredential.mockResolvedValueOnce(mockResolvedCredential);
 			// @ts-ignore
@@ -130,6 +132,7 @@ describe('OAuth1CredentialController', () => {
 				credentialResolverId: 'resolver-id',
 				authorizationHeader: 'Bearer token123',
 				createdAt: timestamp,
+				data: 'encrypted-data',
 			};
 			const dynamicState = Buffer.from(JSON.stringify(mockState)).toString('base64');
 			const dynamicReq = mock<OAuthRequest.OAuth1Credential.Callback>({
@@ -174,6 +177,7 @@ describe('OAuth1CredentialController', () => {
 				origin: 'dynamic-credential' as const,
 				authorizationHeader: 'Bearer token123',
 				createdAt: timestamp,
+				data: 'encrypted-data',
 			};
 			const dynamicState = Buffer.from(JSON.stringify(mockState)).toString('base64');
 			const dynamicReq = mock<OAuthRequest.OAuth1Credential.Callback>({
@@ -211,6 +215,7 @@ describe('OAuth1CredentialController', () => {
 				origin: 'dynamic-credential' as const,
 				credentialResolverId: 'resolver-id',
 				createdAt: timestamp,
+				data: 'encrypted-data',
 			};
 			const dynamicState = Buffer.from(JSON.stringify(mockState)).toString('base64');
 			const dynamicReq = mock<OAuthRequest.OAuth1Credential.Callback>({
@@ -249,6 +254,7 @@ describe('OAuth1CredentialController', () => {
 				credentialResolverId: 'resolver-id',
 				authorizationHeader: 'Invalid token123',
 				createdAt: timestamp,
+				data: 'encrypted-data',
 			};
 			const dynamicState = Buffer.from(JSON.stringify(mockState)).toString('base64');
 			const dynamicReq = mock<OAuthRequest.OAuth1Credential.Callback>({
@@ -285,6 +291,7 @@ describe('OAuth1CredentialController', () => {
 				cid: '1',
 				origin: 'static-credential' as const,
 				createdAt: timestamp,
+				data: 'encrypted-data',
 			};
 			const undefinedOriginState = Buffer.from(JSON.stringify(mockState)).toString('base64');
 			const undefinedOriginReq = mock<OAuthRequest.OAuth1Credential.Callback>({

--- a/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
+++ b/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
@@ -82,6 +82,7 @@ describe('OAuth2CredentialController', () => {
 				userId: '123',
 				origin: 'static-credential',
 				createdAt: timestamp,
+				data: 'encrypted-data',
 			}),
 		).toString('base64');
 
@@ -120,6 +121,7 @@ describe('OAuth2CredentialController', () => {
 				userId: '123',
 				origin: 'static-credential' as const,
 				createdAt: timestamp,
+				data: 'encrypted-data',
 			};
 			oauthService.resolveCredential.mockResolvedValueOnce([
 				mockResolvedCredential,
@@ -184,6 +186,7 @@ describe('OAuth2CredentialController', () => {
 				credentialResolverId: 'resolver-id',
 				authorizationHeader: 'Bearer token123',
 				createdAt: timestamp,
+				data: 'encrypted-data',
 			};
 			const dynamicState = Buffer.from(JSON.stringify(mockState)).toString('base64');
 			oauthService.resolveCredential.mockResolvedValueOnce([
@@ -249,6 +252,7 @@ describe('OAuth2CredentialController', () => {
 				origin: 'dynamic-credential' as const,
 				authorizationHeader: 'Bearer token123',
 				createdAt: timestamp,
+				data: 'encrypted-data',
 			};
 			const dynamicState = Buffer.from(JSON.stringify(mockState)).toString('base64');
 			oauthService.resolveCredential.mockResolvedValueOnce([
@@ -307,6 +311,7 @@ describe('OAuth2CredentialController', () => {
 				origin: 'dynamic-credential' as const,
 				credentialResolverId: 'resolver-id',
 				createdAt: timestamp,
+				data: 'encrypted-data',
 			};
 			const dynamicState = Buffer.from(JSON.stringify(mockState)).toString('base64');
 			oauthService.resolveCredential.mockResolvedValueOnce([
@@ -366,6 +371,7 @@ describe('OAuth2CredentialController', () => {
 				credentialResolverId: 'resolver-id',
 				authorizationHeader: 'Invalid token123',
 				createdAt: timestamp,
+				data: 'encrypted-data',
 			};
 			const dynamicState = Buffer.from(JSON.stringify(mockState)).toString('base64');
 			oauthService.resolveCredential.mockResolvedValueOnce([
@@ -423,6 +429,7 @@ describe('OAuth2CredentialController', () => {
 				userId: '123',
 				origin: 'static-credential' as const,
 				createdAt: timestamp,
+				data: 'encrypted-data',
 			};
 			const undefinedOriginState = Buffer.from(JSON.stringify(mockState)).toString('base64');
 			oauthService.resolveCredential.mockResolvedValueOnce([
@@ -483,6 +490,7 @@ describe('OAuth2CredentialController', () => {
 				userId: '123',
 				origin: 'static-credential' as const,
 				createdAt: timestamp,
+				data: 'encrypted-data',
 			};
 			oauthService.resolveCredential.mockResolvedValueOnce([
 				mockResolvedCredential,
@@ -541,6 +549,7 @@ describe('OAuth2CredentialController', () => {
 				userId: '123',
 				origin: 'static-credential' as const,
 				createdAt: timestamp,
+				data: 'encrypted-data',
 			};
 			oauthService.resolveCredential.mockResolvedValueOnce([
 				mockResolvedCredential,
@@ -601,6 +610,7 @@ describe('OAuth2CredentialController', () => {
 				userId: '123',
 				origin: 'static-credential' as const,
 				createdAt: timestamp,
+				data: 'encrypted-data',
 			};
 			oauthService.resolveCredential.mockResolvedValueOnce([
 				mockResolvedCredential,
@@ -664,6 +674,7 @@ describe('OAuth2CredentialController', () => {
 				userId: '123',
 				origin: 'static-credential' as const,
 				createdAt: timestamp,
+				data: 'encrypted-data',
 			};
 			oauthService.resolveCredential.mockResolvedValueOnce([
 				mockResolvedCredential,

--- a/packages/cli/src/oauth/types.ts
+++ b/packages/cli/src/oauth/types.ts
@@ -5,6 +5,8 @@ export type CsrfStateRequired = {
 	token: string;
 	/** Creation timestamp of the CSRF state. Used for expiration.  */
 	createdAt: number;
+	/** Encrypted stringified CSRF state data */
+	data: string;
 };
 
 export type CreateCsrfStateData = {
@@ -13,7 +15,7 @@ export type CreateCsrfStateData = {
 	[key: string]: unknown;
 };
 
-export type CsrfState = CsrfStateRequired & CreateCsrfStateData;
+export type CsrfState = CsrfStateRequired;
 
 export const MAX_CSRF_AGE = 5 * Time.minutes.toMilliseconds;
 


### PR DESCRIPTION
## Summary

We can only encrypt partial oauth state, because the cloud system, requires to decode the state to determine where to redirect for managed credentials.

We try to decode the state here: https://github.com/n8n-io/n8n-oauth-service/blob/5ac43fefde07a70a7efc4de61529995758fad79a/routes/oauth2/index.js#L35C15-L35C19 and this fails if the full state is encrypted.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
