### PR TITLE
fix(editor): dropdown scroll jitter in Chat Hub at 100%+ browser zoom (Windows / Linux / Chrome)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nNavigationDropdown/NavigationDropdown.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nNavigationDropdown/NavigationDropdown.vue
@@ -108,6 +108,8 @@ defineExpose({
 					<ElSubMenu
 						:popper-class="$style.nestedSubmenu"
 						:index="item.id"
+						trigger="click"
+						:teleported="true"
 						:popper-offset="-10"
 						data-test-id="navigation-submenu"
 					>
@@ -223,6 +225,7 @@ defineExpose({
 
 .submenu {
 	padding: 5px 0 !important;
+	margin-left: 10%;
 
 	:global(.el-menu--horizontal .el-menu .el-menu-item),
 	:global(.el-menu--horizontal .el-menu .el-sub-menu__title) {

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ModelSelector.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ModelSelector.vue
@@ -444,6 +444,17 @@ defineExpose({
 	& :global(.el-popper) {
 		/* Enforce via text truncation instead */
 		max-width: unset !important;
+		/* Prevent dropdown from affecting parent layout */
+		contain: layout style paint;
+	}
+
+	& :global(.el-menu--popup) {
+		/* Prevent dropdown from extending past viewport and causing layout shifts */
+		max-height: calc(100vh - 200px);
+		overflow-y: auto;
+		overflow-x: hidden;
+		/* Ensure smooth scrolling without layout shifts */
+		overscroll-behavior: contain;
 	}
 }
 


### PR DESCRIPTION
This PR resolves a UI issue #23514  in the Chat Hub dropdown (Workflow Agents / AI Provider selector) where scrolling caused the entire interface to shake horizontally when the browser zoom level was 100% or higher.

<img width="1339" height="698" alt="image" src="https://github.com/user-attachments/assets/a63e6e85-5fcd-42b1-bd2d-ed248faa583d" />


<img width="1339" height="698" alt="image" src="https://github.com/user-attachments/assets/fdada389-ce52-447c-99a5-62ae8e75f4dd" />
