### PR TITLE
feat(nodes): Add thread ID and parse mode options to Telegram Send and Wait

### DIFF
--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -1817,7 +1817,45 @@ export class Telegram implements INodeType {
 					},
 				],
 				'message',
-				undefined,
+				[
+					{
+						displayName: 'Telegram Options',
+						name: 'telegramOptions',
+						type: 'collection',
+						placeholder: 'Add option',
+						default: {},
+						options: [
+							{
+								displayName: 'Message Thread ID',
+								name: 'message_thread_id',
+								type: 'number',
+								default: 0,
+								description: 'Unique identifier for the target message thread (topic) of the forum',
+							},
+							{
+								displayName: 'Parse Mode',
+								name: 'parse_mode',
+								type: 'options',
+								options: [
+									{
+										name: 'Markdown (Legacy)',
+										value: 'Markdown',
+									},
+									{
+										name: 'MarkdownV2',
+										value: 'MarkdownV2',
+									},
+									{
+										name: 'HTML',
+										value: 'HTML',
+									},
+								],
+								default: 'Markdown',
+								description: 'How to parse the text',
+							},
+						],
+					},
+				],
 				{
 					noButtonStyle: true,
 					defaultApproveLabel: '✅ Approve',

--- a/packages/nodes-base/nodes/Telegram/tests/node/sendAndWait.operation.test.ts
+++ b/packages/nodes-base/nodes/Telegram/tests/node/sendAndWait.operation.test.ts
@@ -38,6 +38,7 @@ describe('Test Telegram, message => sendAndWait', () => {
 
 		//createSendAndWaitMessageBody
 		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('chatID');
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({}); // telegramOptions
 
 		//getSendAndWaitConfig
 		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('my message');
@@ -73,6 +74,61 @@ describe('Test Telegram, message => sendAndWait', () => {
 				],
 			},
 			text: 'my message\n\n_This message was sent automatically with _[n8n](https://n8n.io/?utm_source=n8n-internal&utm_medium=powered_by&utm_campaign=n8n-nodes-base.telegram_instanceId)',
+		});
+	});
+
+	it('should send message with message_thread_id and HTML parse_mode', async () => {
+		const items = [{ json: { data: 'test' } }];
+		//node
+		mockExecuteFunctions.getInputData.mockReturnValue(items);
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce(SEND_AND_WAIT_OPERATION);
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('message');
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce(false);
+		mockExecuteFunctions.getNode.mockReturnValue(mock<INode>());
+		mockExecuteFunctions.getInstanceId.mockReturnValue('instanceId');
+
+		//createSendAndWaitMessageBody
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('chatID');
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({
+			message_thread_id: 123,
+			parse_mode: 'HTML',
+		}); // telegramOptions
+
+		//getSendAndWaitConfig
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('my message');
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('my subject');
+		mockExecuteFunctions.getSignedResumeUrl.mockReturnValue(
+			'http://localhost/waiting-webhook/nodeID?approved=true&signature=abc',
+		);
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({}); // approvalOptions
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({}); // options
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('approval');
+
+		// configureWaitTillDate
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({}); //options.limitWaitTime.values
+
+		const result = await telegram.execute.call(mockExecuteFunctions);
+
+		expect(result).toEqual([items]);
+		expect(genericFunctions.apiRequest).toHaveBeenCalledTimes(1);
+		expect(mockExecuteFunctions.putExecutionToWait).toHaveBeenCalledTimes(1);
+
+		expect(genericFunctions.apiRequest).toHaveBeenCalledWith('POST', 'sendMessage', {
+			chat_id: 'chatID',
+			disable_web_page_preview: true,
+			parse_mode: 'HTML',
+			message_thread_id: 123,
+			reply_markup: {
+				inline_keyboard: [
+					[
+						{
+							text: 'Approve',
+							url: 'http://localhost/waiting-webhook/nodeID?approved=true&signature=abc',
+						},
+					],
+				],
+			},
+			text: 'my message\n\n<em>This message was sent automatically with </em><a href="https://n8n.io/?utm_source=n8n-internal&utm_medium=powered_by&utm_campaign=n8n-nodes-base.telegram_instanceId" target="_blank">n8n</a>',
 		});
 	});
 });


### PR DESCRIPTION
## Changes

- Added `telegramOptions` to allow configuration of `message_thread_id` and `parse_mode` (Markdown, MarkdownV2, HTML) when sending messages.
- Updated `createSendAndWaitMessageBody` to handle different parse modes for message formatting.
- Enhanced tests to cover new functionality for sending messages with specified thread ID and HTML parse mode.

## Summary

This PR enhances the Telegram "Send and Wait for Response" operation by adding options that were previously only available in other Telegram message operations:

1. **Message Thread ID**: Allows the bot to reply to a specific forum topic/thread in supergroups with topics enabled
2. **Parse Mode**: Allows choosing between Markdown (Legacy), MarkdownV2, or HTML formatting for the message

These options are consistent with the existing Telegram node operations and provide more flexibility when using the Send and Wait feature.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Include links to Linear ticket or Github issue or Community forum post -->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)