### PR TITLE
fix(core): handle }} inside strings in expression parser

### DIFF
--- a/packages/workflow/src/extensions/expression-parser.ts
+++ b/packages/workflow/src/extensions/expression-parser.ts
@@ -21,6 +21,36 @@ export const escapeCode = (text: string): string => {
 	return text.replace('\\}}', '}}');
 };
 
+/**
+ * Checks if a position in a string is inside a quoted string.
+ * Handles single quotes, double quotes, and backticks, with escape sequence support.
+ */
+const isInsideString = (text: string, position: number): boolean => {
+	let inSingleQuote = false;
+	let inDoubleQuote = false;
+	let inBacktick = false;
+
+	for (let i = 0; i < position; i++) {
+		const char = text[i];
+		const prevChar = i > 0 ? text[i - 1] : '';
+
+		// Skip escaped characters
+		if (prevChar === '\\') {
+			continue;
+		}
+
+		if (char === "'" && !inDoubleQuote && !inBacktick) {
+			inSingleQuote = !inSingleQuote;
+		} else if (char === '"' && !inSingleQuote && !inBacktick) {
+			inDoubleQuote = !inDoubleQuote;
+		} else if (char === '`' && !inSingleQuote && !inDoubleQuote) {
+			inBacktick = !inBacktick;
+		}
+	}
+
+	return inSingleQuote || inDoubleQuote || inBacktick;
+};
+
 export const splitExpression = (expression: string): ExpressionChunk[] => {
 	// Mirror @n8n/tournament's splitExpression: always emit an initial text
 	// chunk so downstream consumers can rely on chunks[0] being defined.
@@ -62,6 +92,17 @@ export const splitExpression = (expression: string): ExpressionChunk[] => {
 			buffer += expr.slice(0, res.index + 3);
 			index += res.index + 3;
 		} else {
+			// When searching for close bracket, check if it's inside a string
+			if (
+				searchingFor === 'close' &&
+				isInsideString(buffer + expr.slice(0, res.index), res.index + buffer.length)
+			) {
+				// The }} is inside a string, skip it and continue searching
+				buffer += expr.slice(0, res.index + 2);
+				index += res.index + 2;
+				continue;
+			}
+
 			buffer += expr.slice(0, res.index);
 
 			if (searchingFor === 'open') {
@@ -89,9 +130,26 @@ export const splitExpression = (expression: string): ExpressionChunk[] => {
 	return chunks;
 };
 
-// Expressions only have closing brackets escaped
+// Expressions only have closing brackets escaped, but not those inside strings
 const escapeTmplExpression = (part: string) => {
-	return part.replace('}}', '\\}}');
+	let result = '';
+	let i = 0;
+
+	while (i < part.length) {
+		// Check for }}
+		if (part[i] === '}' && part[i + 1] === '}') {
+			// Only escape if not inside a string
+			if (!isInsideString(part, i)) {
+				result += '\\}}';
+				i += 2;
+				continue;
+			}
+		}
+		result += part[i];
+		i++;
+	}
+
+	return result;
 };
 
 export const joinExpression = (parts: ExpressionChunk[]): string => {

--- a/packages/workflow/src/extensions/expression-parser.ts
+++ b/packages/workflow/src/extensions/expression-parser.ts
@@ -29,13 +29,22 @@ const isInsideString = (text: string, position: number): boolean => {
 	let inSingleQuote = false;
 	let inDoubleQuote = false;
 	let inBacktick = false;
+	let escaped = false;
 
 	for (let i = 0; i < position; i++) {
 		const char = text[i];
-		const prevChar = i > 0 ? text[i - 1] : '';
 
-		// Skip escaped characters
-		if (prevChar === '\\') {
+		// Skip the character following a backslash
+		if (escaped) {
+			escaped = false;
+			continue;
+		}
+
+		// A backslash escapes the next character; consecutive backslashes
+		// toggle the escape state (e.g. `\\` is an escaped backslash, so a
+		// quote right after it still closes the string)
+		if (char === '\\') {
+			escaped = true;
 			continue;
 		}
 

--- a/packages/workflow/test/expressions/expression-parser.test.ts
+++ b/packages/workflow/test/expressions/expression-parser.test.ts
@@ -1,0 +1,146 @@
+import { splitExpression, joinExpression } from '../../src/extensions/expression-parser';
+
+describe('expression-parser', () => {
+	describe('splitExpression', () => {
+		it('should parse simple expression', () => {
+			const result = splitExpression('hello {{ $json.name }} world');
+			expect(result).toEqual([
+				{ type: 'text', text: 'hello ' },
+				{ type: 'code', text: ' $json.name ', hasClosingBrackets: true },
+				{ type: 'text', text: ' world' },
+			]);
+		});
+
+		it('should handle expression with single quotes containing }}', () => {
+			const result = splitExpression("{{ $jmespath($json, '{a: b}') }}");
+			expect(result).toEqual([
+				{ type: 'text', text: '' },
+				{ type: 'code', text: " $jmespath($json, '{a: b}') ", hasClosingBrackets: true },
+			]);
+		});
+
+		it('should handle JMESPath with nested braces (issue #22264)', () => {
+			const result = splitExpression(
+				"{{ $jmespath($json, '{reviewers: values[*].{uuid: user.uuid}}') }}",
+			);
+			expect(result).toEqual([
+				{ type: 'text', text: '' },
+				{
+					type: 'code',
+					text: " $jmespath($json, '{reviewers: values[*].{uuid: user.uuid}}') ",
+					hasClosingBrackets: true,
+				},
+			]);
+		});
+
+		it('should handle double quotes containing }}', () => {
+			const result = splitExpression('{{ "test}}value" }}');
+			expect(result).toEqual([
+				{ type: 'text', text: '' },
+				{ type: 'code', text: ' "test}}value" ', hasClosingBrackets: true },
+			]);
+		});
+
+		it('should handle backticks containing }}', () => {
+			const result = splitExpression('{{ `template}}string` }}');
+			expect(result).toEqual([
+				{ type: 'text', text: '' },
+				{ type: 'code', text: ' `template}}string` ', hasClosingBrackets: true },
+			]);
+		});
+
+		it('should handle escaped quotes inside strings', () => {
+			const result = splitExpression("{{ 'test\\'s}}value' }}");
+			expect(result).toEqual([
+				{ type: 'text', text: '' },
+				{ type: 'code', text: " 'test\\'s}}value' ", hasClosingBrackets: true },
+			]);
+		});
+
+		it('should handle multiple expressions with strings containing }}', () => {
+			const result = splitExpression("prefix {{ '{a}}' }} middle {{ '{b}}' }} suffix");
+			expect(result).toEqual([
+				{ type: 'text', text: 'prefix ' },
+				{ type: 'code', text: " '{a}}' ", hasClosingBrackets: true },
+				{ type: 'text', text: ' middle ' },
+				{ type: 'code', text: " '{b}}' ", hasClosingBrackets: true },
+				{ type: 'text', text: ' suffix' },
+			]);
+		});
+
+		it('should handle }} outside of strings correctly', () => {
+			const result = splitExpression('{{ $json.a }} }} extra');
+			expect(result).toEqual([
+				{ type: 'text', text: '' },
+				{ type: 'code', text: ' $json.a ', hasClosingBrackets: true },
+				{ type: 'text', text: ' }} extra' },
+			]);
+		});
+
+		it('should handle expression without closing brackets', () => {
+			const result = splitExpression('{{ $json.name');
+			expect(result).toEqual([
+				{ type: 'text', text: '' },
+				{ type: 'code', text: ' $json.name', hasClosingBrackets: false },
+			]);
+		});
+
+		it('should handle escaped closing brackets', () => {
+			const result = splitExpression('{{ $json.name \\}} }}');
+			expect(result).toEqual([
+				{ type: 'text', text: '' },
+				{ type: 'code', text: ' $json.name }} ', hasClosingBrackets: true },
+			]);
+		});
+	});
+
+	describe('joinExpression', () => {
+		it('should join simple expression', () => {
+			const result = joinExpression([
+				{ type: 'text', text: 'hello ' },
+				{ type: 'code', text: ' $json.name ', hasClosingBrackets: true },
+				{ type: 'text', text: ' world' },
+			]);
+			expect(result).toBe('hello {{ $json.name }} world');
+		});
+
+		it('should handle strings containing }} without escaping them', () => {
+			const result = joinExpression([
+				{ type: 'text', text: '' },
+				{ type: 'code', text: " '{a}}' ", hasClosingBrackets: true },
+				{ type: 'text', text: '' },
+			]);
+			// }} inside the string should NOT be escaped
+			expect(result).toBe("{{ '{a}}' }}");
+		});
+
+		it('should handle code without closing brackets', () => {
+			const result = joinExpression([
+				{ type: 'text', text: '' },
+				{ type: 'code', text: ' $json.name', hasClosingBrackets: false },
+			]);
+			expect(result).toBe('{{ $json.name');
+		});
+	});
+
+	describe('roundtrip', () => {
+		const testCases = [
+			'hello {{ $json.name }} world',
+			"{{ $jmespath($json, '{a: b}') }}",
+			"{{ $jmespath($json, '{reviewers: values[*].{uuid: user.uuid}}') }}",
+			'{{ "test}}value" }}',
+			'{{ `template}}string` }}',
+			"prefix {{ '{a}}' }} middle {{ '{b}}' }} suffix",
+		];
+
+		for (const testCase of testCases) {
+			it(`should roundtrip: ${testCase}`, () => {
+				const parsed = splitExpression(testCase);
+				const rejoined = joinExpression(parsed);
+				// The rejoined expression may have extra spaces, but parsing it again should be equivalent
+				const reparsed = splitExpression(rejoined);
+				expect(reparsed).toEqual(parsed);
+			});
+		}
+	});
+});

--- a/packages/workflow/test/expressions/expression-parser.test.ts
+++ b/packages/workflow/test/expressions/expression-parser.test.ts
@@ -57,6 +57,37 @@ describe('expression-parser', () => {
 			]);
 		});
 
+		it('should close a string that ends with an escaped backslash', () => {
+			// Literal expression: {{ 'a\\' }}
+			// The `\\` is an escaped backslash, so the following quote closes the string
+			// and the `}}` is outside of it.
+			const result = splitExpression("{{ 'a\\\\' }}");
+			expect(result).toEqual([
+				{ type: 'text', text: '' },
+				{ type: 'code', text: " 'a\\\\' ", hasClosingBrackets: true },
+			]);
+		});
+
+		it('should not close a string on an escaped quote', () => {
+			// Literal expression: {{ 'a\'}}b' }}
+			// The `\'` is escaped, so the string only closes after `b`, which means the
+			// first `}}` is inside the string.
+			const result = splitExpression("{{ 'a\\'}}b' }}");
+			expect(result).toEqual([
+				{ type: 'text', text: '' },
+				{ type: 'code', text: " 'a\\'}}b' ", hasClosingBrackets: true },
+			]);
+		});
+
+		it('should still detect }} inside a string that contains an escaped backslash', () => {
+			// Literal expression: {{ 'a\\b}}c' }}
+			const result = splitExpression("{{ 'a\\\\b}}c' }}");
+			expect(result).toEqual([
+				{ type: 'text', text: '' },
+				{ type: 'code', text: " 'a\\\\b}}c' ", hasClosingBrackets: true },
+			]);
+		});
+
 		it('should handle multiple expressions with strings containing }}', () => {
 			const result = splitExpression("prefix {{ '{a}}' }} middle {{ '{b}}' }} suffix");
 			expect(result).toEqual([


### PR DESCRIPTION
## Summary

- Fixes expression parser incorrectly identifying `}}` inside quoted strings as expression closing marker
- Adds string context tracking (single quotes, double quotes, backticks)
- Properly handles escape sequences inside strings

## Test plan

- [x] Added comprehensive unit tests for `splitExpression` and `joinExpression`
- [x] Tests cover JMESPath expressions with nested braces
- [x] Tests cover all quote types (single, double, backtick)
- [x] Tests cover escaped quotes inside strings
- [x] All existing expression tests pass
- [x] TypeScript checks pass

## Example

Before this fix, the expression:
```js
{{ $jmespath($json, '{reviewers: values[*].{uuid: user.uuid}}') }}
```
Would fail with "invalid syntax" because `}}` inside the JMESPath string was interpreted as the expression end marker.

After this fix, the expression is correctly parsed and executed.

Fixes #22264