### PR TITLE
fix(nodes-langchain): handle primitive toolInput in intermediateSteps

### DIFF
--- a/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
@@ -250,13 +250,24 @@ export function buildSteps(
 				observation = JSON.stringify('');
 			}
 
+			// Build toolInput for the result:
+			// - If toolInputForResult is an object, use it directly (e.g., { expression: '2+2' })
+			// - If toolInputForResult is a primitive (string, number), wrap it as { input: value }
+			// - Otherwise, return empty object
+			let resultToolInput: IDataObject;
+			if (toolInputForResult && typeof toolInputForResult === 'object') {
+				resultToolInput = toolInputForResult as IDataObject;
+			} else if (toolInputForResult !== undefined && toolInputForResult !== null) {
+				// Handle primitive values like strings or numbers
+				resultToolInput = { input: toolInputForResult };
+			} else {
+				resultToolInput = {};
+			}
+
 			const toolResult = {
 				action: {
 					tool: nodeNameToToolName(tool.action.nodeName),
-					toolInput:
-						toolInputForResult && typeof toolInputForResult === 'object'
-							? (toolInputForResult as IDataObject)
-							: {},
+					toolInput: resultToolInput,
 					log: toolInput.log || syntheticAIMessage.content,
 					messageLog: [syntheticAIMessage],
 					toolCallId: toolInput?.id,

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/buildSteps.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/buildSteps.test.ts
@@ -220,6 +220,85 @@ describe('buildSteps', () => {
 			expect(result[0].action.toolInput).toEqual({});
 		});
 
+		it('should handle primitive string input by wrapping it in an object (issue #23501)', () => {
+			// When tools like Calculator receive a simple string input like "5*343",
+			// the input structure is { id: 'call_123', input: '5*343' } where input is a string
+			const response: EngineResponse<RequestResponseMetadata> = {
+				actionResponses: [
+					{
+						action: {
+							actionType: 'ExecutionNodeAction',
+							nodeName: 'Calculator1',
+							input: {
+								id: 'call_9yHJCyXEEWxsRmU7xM56JX2m',
+								input: '5*343', // String primitive, not an object
+							},
+							type: NodeConnectionTypes.AiTool,
+							id: 'call_9yHJCyXEEWxsRmU7xM56JX2m',
+							metadata: {
+								itemIndex: 0,
+							},
+						},
+						data: {
+							data: {
+								ai_tool: [[{ json: { result: '1715' } }]],
+							},
+							executionTime: 0,
+							startTime: 0,
+							executionIndex: 0,
+							source: [],
+						},
+					},
+				],
+				metadata: {},
+			};
+
+			const result = buildSteps(response, itemIndex);
+
+			expect(result).toHaveLength(1);
+			// String input should be wrapped as { input: '5*343' }
+			expect(result[0].action.toolInput).toEqual({ input: '5*343' });
+			expect(result[0].action.toolCallId).toBe('call_9yHJCyXEEWxsRmU7xM56JX2m');
+		});
+
+		it('should handle primitive number input by wrapping it in an object', () => {
+			const response: EngineResponse<RequestResponseMetadata> = {
+				actionResponses: [
+					{
+						action: {
+							actionType: 'ExecutionNodeAction',
+							nodeName: 'NumberTool',
+							input: {
+								id: 'call_456',
+								input: 42, // Number primitive
+							},
+							type: NodeConnectionTypes.AiTool,
+							id: 'call_456',
+							metadata: {
+								itemIndex: 0,
+							},
+						},
+						data: {
+							data: {
+								ai_tool: [[{ json: { result: 'processed' } }]],
+							},
+							executionTime: 0,
+							startTime: 0,
+							executionIndex: 0,
+							source: [],
+						},
+					},
+				],
+				metadata: {},
+			};
+
+			const result = buildSteps(response, itemIndex);
+
+			expect(result).toHaveLength(1);
+			// Number input should be wrapped as { input: 42 }
+			expect(result[0].action.toolInput).toEqual({ input: 42 });
+		});
+
 		describe('Previous requests handling', () => {
 			it('should include previous requests from metadata', () => {
 				const previousRequests = [


### PR DESCRIPTION
## Summary
When tools receive primitive values (strings, numbers) as input, the `toolInput` field in `intermediateSteps` was incorrectly set to an empty object `{}`. This fix wraps primitive values in an object with an `input` key, ensuring the tool input is properly exposed.

**The issue:** In `buildSteps.ts`, when `toolInput.input` is a primitive value (like a string `"5*343"`), the condition `typeof toolInputForResult === 'object'` fails, resulting in an empty `{}` being returned instead of the actual input.

**The fix:** Added logic to wrap primitive values in `{ input: value }` format, making the input accessible in `intermediateSteps`.

## Related Issue
Fixes #23501

## Test plan
- [x] Added test case for primitive string input (`"5*343"`)
- [x] Added test case for primitive number input (`42`)
- [x] All existing tests pass
- [x] TypeScript type check passes