### PR TITLE
fix(task-runner-python): add Windows support for Python Task Runner

### DIFF
--- a/packages/@n8n/task-runner-python/src/task_state.py
+++ b/packages/@n8n/task-runner-python/src/task_state.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from dataclasses import dataclass
-from multiprocessing.context import ForkServerProcess
+from multiprocessing.process import BaseProcess
 
 
 class TaskStatus(Enum):
@@ -13,7 +13,7 @@ class TaskStatus(Enum):
 class TaskState:
     task_id: str
     status: TaskStatus
-    process: ForkServerProcess | None = None
+    process: BaseProcess | None = None
     workflow_name: str | None = None
     workflow_id: str | None = None
     node_name: str | None = None


### PR DESCRIPTION
## Summary
The Python Task Runner fails to start on Windows because it imports `ForkServerProcess` from `multiprocessing.context`, which is Unix-specific and not available on Windows.

**Changes:**
1. Replaced `ForkServerProcess` with platform-agnostic `BaseProcess` from `multiprocessing.process`
2. Changed multiprocessing context to use `forkserver` on Unix (faster process creation) and `spawn` on Windows (only supported option)
3. Updated all type hints from `ForkServerProcess` to `BaseProcess`

## Related Issue
Fixes #23384

## Test plan
- [x] Code compiles without import errors
- [x] Type hints use platform-agnostic `BaseProcess`
- [x] Multiprocessing context selection based on platform