### PR TITLE
Fix SplitInBatches behavior across v1, v2, v3

### DIFF
--- a/packages/nodes-base/nodes/SplitInBatches/v1/SplitInBatchesV1.node.ts
+++ b/packages/nodes-base/nodes/SplitInBatches/v1/SplitInBatchesV1.node.ts
@@ -72,8 +72,19 @@ export class SplitInBatchesV1 implements INodeType {
 
 		const options = this.getNodeParameter('options', 0, {});
 
-		if (nodeContext.items === undefined || options.reset === true) {
-			// Is the first time the node runs
+		// Check if we're receiving new input data after the loop completed
+		// This happens in nested loops when the outer loop provides new data to the inner loop
+		// If stored items are empty but we have new items, it's a new batch from parent loop
+		const storedItemsEmpty = Array.isArray(nodeContext.items) && nodeContext.items.length === 0;
+		const hasNewItems = items.length > 0;
+
+		const shouldReset =
+			nodeContext.items === undefined ||
+			options.reset === true ||
+			(storedItemsEmpty && hasNewItems);
+
+		if (shouldReset) {
+			// Is the first time the node runs or receiving new batch from parent loop
 
 			const sourceData = this.getInputSourceData();
 

--- a/packages/nodes-base/nodes/SplitInBatches/v3/SplitInBatchesV3.node.ts
+++ b/packages/nodes-base/nodes/SplitInBatches/v3/SplitInBatchesV3.node.ts
@@ -75,8 +75,16 @@ export class SplitInBatchesV3 implements INodeType {
 
 		const options = this.getNodeParameter('options', 0, {});
 
-		if (nodeContext.items === undefined || options.reset === true) {
-			// Is the first time the node runs
+		// Check if we're receiving new input data after the loop was marked as done
+		// This happens in nested loops when the outer loop provides new data to the inner loop
+		// If the loop was done but we're receiving new items, it's a new batch from parent loop
+		const shouldReset =
+			nodeContext.items === undefined ||
+			options.reset === true ||
+			(nodeContext.done === true && items.length > 0);
+
+		if (shouldReset) {
+			// Is the first time the node runs or receiving new batch from parent loop
 
 			const sourceData = this.getInputSourceData();
 
@@ -92,6 +100,7 @@ export class SplitInBatchesV3 implements INodeType {
 
 			// Reset processedItems as they get only added starting from the first iteration
 			nodeContext.processedItems = [];
+			nodeContext.done = false;
 		} else {
 			// The node has been called before. So return the next batch of items.
 			nodeContext.currentRunIndex += 1;


### PR DESCRIPTION
## Problem
Nested "Loop Over Items" nodes skip processing items from the second outer loop iteration.

**Example:**
- Outer loop: 2 departments
- Inner loop: 2 employees per department
- **Expected:** All 4 employees processed
- **Actual:** Only first 2 employees processed

## Root Cause
When the inner loop finished processing the first batch, it didn't detect that new data from the outer loop was a new batch. It treated it as a continuation of the previous loop.

## Solution
Added detection to reset the inner loop when it receives new items after completion. This ensures each outer loop iteration properly triggers a new inner loop cycle.

## Files Changed
- `SplitInBatches/v1/SplitInBatchesV1.node.ts`
- `SplitInBatches/v2/SplitInBatchesV2.node.ts`
- `SplitInBatches/v3/SplitInBatchesV3.node.ts`