### PR TITLE
fix(gitlab Node): Fix GitLab API path and unifies node behavior

### DIFF
--- a/packages/nodes-base/nodes/Gitlab/Gitlab.node.ts
+++ b/packages/nodes-base/nodes/Gitlab/Gitlab.node.ts
@@ -1349,7 +1349,7 @@ export class Gitlab implements INodeType {
 				responseData = await gitlabApiRequest.call(this, 'GET', '/projects', {}, qs);
 
 				if (Array.isArray(responseData) && responseData.length === 0) {
-					throw new NodeOperationError(this.getNode(), 'Project does not exists.', {
+					throw new NodeOperationError(this.getNode(), 'Project does not exist.', {
 						itemIndex: i,
 					});
 				}


### PR DESCRIPTION
## Summary

This PR aim to fix the GitLab nodes using `projectName` and `projectOwner` fields (~ 90% of the nodes). In current n8n version + up-to-date GitLab (18.7.0), the nodes are not working anymore because the API base path is not valid anymore: the GitLab API **needs** an ID, not a project path.

This PR also unifies the GitLab nodes: some of them required a projectID, some doesn't. The `projectId` argument have been completely removed in favor of `projectName` and `ownerName`. This is **not supposed to be a breaking change**, as all GitLab nodes already required `projectName` and `ownerName` (and only a few subset required `projectId`, which is now useless as we deduct it using GitLab API).

Here is the current (non-working) behavior of the GitLab node:


https://github.com/user-attachments/assets/7ed3bd01-d23f-40fe-b5ba-6e7e9026572a

And the fixed behavior:


https://github.com/user-attachments/assets/96c8d2d6-22a3-47f2-8d4e-62e4ed77e4bb




## Related Linear tickets, Github issues, and Community forum posts

fixes #23682 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. - *I don't know how to add this kind of test, regarding the modification made. Help wanted/required!* 
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
