### PR TITLE
ci: Skip Docker base image builds for forks

### DIFF
--- a/.github/workflows/docker-base-image.yml
+++ b/.github/workflows/docker-base-image.yml
@@ -20,6 +20,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Skip Docker builds for forks (they don't have DOCKER_USERNAME secret)
+    # For pull_request events, github.repository is the target repo (n8n-io/n8n),
+    # so we must check github.event.pull_request.head.repo.full_name for the source
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && github.repository == 'n8n-io/n8n') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'n8n-io/n8n')
     strategy:
       matrix:
         node_version: ['20', '22.21.1', '24']


### PR DESCRIPTION
## Summary

Forks don't have the `DOCKER_USERNAME` secret configured, causing the Docker base image builds to fail with invalid tag format errors. This PR adds a condition to skip the build job for non-upstream repositories while preserving `workflow_dispatch` functionality for manual triggers.

## Changes

- Added `if` condition to `jobs.build` to only run for `n8n-io/n8n` or manual triggers
- Prevents fork builds from failing due to missing Docker credentials

## Test plan

- [x] Fork builds will skip the Docker job (no more failures)
- [x] Upstream `n8n-io/n8n` continues to build on push to master
- [x] `workflow_dispatch` manual triggers still work for testing

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)