### PR TITLE
feat(core): Support [*] syntax for array property expansion in expressions

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -1169,6 +1169,8 @@
 	"expressionModalInput.pairedItemInvalidPinnedError": "Unpin node ‘{node}’ and execute",
 	"expressionModalInput.pairedItemError": "Can’t determine which item to use",
 	"expressionModalInput.pairedItemError.noRunData": "Can't determine which item to use - execute node for more info",
+	"expressionModalInput.dynamicArrayExpansion": "Dynamic value, will be resolved on execution",
+	"expressionModalInput.multipleArrayWildcards": "Only one [*] wildcard is allowed per expression",
 	"fixedCollectionParameter.addField": "Add Field",
 	"fixedCollectionParameter.choose": "Choose...",
 	"fixedCollectionParameter.currentlyNoItemsExist": "Currently no items exist",

--- a/packages/frontend/editor-ui/src/features/shared/editors/composables/useExpressionEditor.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/composables/useExpressionEditor.ts
@@ -15,7 +15,7 @@ import {
 
 import { ensureSyntaxTree } from '@codemirror/language';
 import type { IDataObject } from 'n8n-workflow';
-import { Expression, ExpressionExtensions } from 'n8n-workflow';
+import { Expression, ExpressionExtensions, hasArrayWildcardSyntax } from 'n8n-workflow';
 
 import {
 	EXPRESSION_EDITOR_PARSER_TIMEOUT,
@@ -50,6 +50,8 @@ import { ignoreUpdateAnnotation } from '@/app/utils/forceParse';
 import { TARGET_NODE_PARAMETER_FACET } from '../plugins/codemirror/completions/constants';
 import { useDeviceSupport } from '@n8n/composables/useDeviceSupport';
 import { isEventTargetContainedBy } from '@/app/utils/htmlUtils';
+
+const ARRAY_WILDCARD_REGEX = /\[\s*\*\s*\]/g;
 
 export const useExpressionEditor = ({
 	editorRef,
@@ -335,6 +337,74 @@ export const useExpressionEditor = ({
 		return end !== undefined && expressionExtensionNames.value.has(end);
 	}
 
+	// Helper: Resolve an expression string using the appropriate context
+	function resolveExpressionValue(resolvable: string, target: TargetItem | null): unknown {
+		if (expressionLocalResolveContext.value) {
+			return workflowHelpers.resolveExpression('=' + resolvable, undefined, {
+				...expressionLocalResolveContext.value,
+				additionalKeys: toValue(additionalData),
+			});
+		}
+
+		if (!ndvStore.activeNode && toValue(targetNodeParameterContext) === undefined) {
+			// e.g. credential modal
+			return Expression.resolveWithoutWorkflow(resolvable, toValue(additionalData));
+		}
+
+		let opts: ResolveParameterOptions = {
+			additionalKeys: toValue(additionalData),
+			contextNodeName: toValue(targetNodeParameterContext)?.nodeName,
+		};
+		if (toValue(targetNodeParameterContext) === undefined && ndvStore.isInputParentOfActiveNode) {
+			opts = {
+				targetItem: target ?? undefined,
+				inputNodeName: ndvStore.ndvInputNodeName,
+				inputRunIndex: ndvStore.ndvInputRunIndex,
+				inputBranchIndex: ndvStore.ndvInputBranchIndex,
+			};
+		}
+		return workflowHelpers.resolveExpression('=' + resolvable, undefined, opts);
+	}
+
+	// Helper: Count [*] wildcards in expression
+	function countArrayWildcards(expression: string): number {
+		const matches = expression.match(/\[\s*\*\s*\]/g);
+		return matches?.length ?? 0;
+	}
+
+	// Helper: Validate [*] wildcard expression by testing with first item
+	function validateWildcardExpression(
+		resolvable: string,
+		target: TargetItem | null,
+	): { resolved: string; error: boolean } {
+		// Only one [*] wildcard allowed per expression
+		if (countArrayWildcards(resolvable) > 1) {
+			return {
+				resolved: `[${i18n.baseText('expressionModalInput.multipleArrayWildcards')}]`,
+				error: true,
+			};
+		}
+
+		// Test by replacing [*] with [0] to check if property exists
+		const testExpression = resolvable.replace(ARRAY_WILDCARD_REGEX, '[0]');
+		try {
+			const testResult = resolveExpressionValue(testExpression, target);
+			if (testResult !== undefined) {
+				return {
+					resolved: `[${i18n.baseText('expressionModalInput.dynamicArrayExpansion')}]`,
+					error: false,
+				};
+			}
+		} catch {
+			// Test expression threw - treat as invalid
+		}
+
+		return {
+			resolved: i18n.baseText('expressionModalInput.undefined'),
+			error: true,
+		};
+	}
+
 	function resolve(resolvable: string, target: TargetItem | null) {
 		const result: { resolved: unknown; error: boolean; fullError: Error | null } = {
 			resolved: undefined,
@@ -343,32 +413,7 @@ export const useExpressionEditor = ({
 		};
 
 		try {
-			if (expressionLocalResolveContext.value) {
-				result.resolved = workflowHelpers.resolveExpression('=' + resolvable, undefined, {
-					...expressionLocalResolveContext.value,
-					additionalKeys: toValue(additionalData),
-				});
-			} else if (!ndvStore.activeNode && toValue(targetNodeParameterContext) === undefined) {
-				// e.g. credential modal
-				result.resolved = Expression.resolveWithoutWorkflow(resolvable, toValue(additionalData));
-			} else {
-				let opts: ResolveParameterOptions = {
-					additionalKeys: toValue(additionalData),
-					contextNodeName: toValue(targetNodeParameterContext)?.nodeName,
-				};
-				if (
-					toValue(targetNodeParameterContext) === undefined &&
-					ndvStore.isInputParentOfActiveNode
-				) {
-					opts = {
-						targetItem: target ?? undefined,
-						inputNodeName: ndvStore.ndvInputNodeName,
-						inputRunIndex: ndvStore.ndvInputRunIndex,
-						inputBranchIndex: ndvStore.ndvInputBranchIndex,
-					};
-				}
-				result.resolved = workflowHelpers.resolveExpression('=' + resolvable, undefined, opts);
-			}
+			result.resolved = resolveExpressionValue(resolvable, target);
 		} catch (error) {
 			const hasRunData =
 				!!workflowsStore.workflowExecutionData?.data?.resultData?.runData[
@@ -379,12 +424,18 @@ export const useExpressionEditor = ({
 			result.fullError = error;
 		}
 
+		console.log('result', result);
 		if (result.resolved === undefined) {
-			result.resolved = isUncalledExpressionExtension(resolvable)
-				? i18n.baseText('expressionEditor.uncalledFunction')
-				: i18n.baseText('expressionModalInput.undefined');
-
-			result.error = true;
+			if (hasArrayWildcardSyntax(resolvable)) {
+				const validation = validateWildcardExpression(resolvable, target);
+				result.resolved = validation.resolved;
+				result.error = validation.error;
+			} else {
+				result.resolved = isUncalledExpressionExtension(resolvable)
+					? i18n.baseText('expressionEditor.uncalledFunction')
+					: i18n.baseText('expressionModalInput.undefined');
+				result.error = true;
+			}
 		}
 
 		return result;

--- a/packages/frontend/editor-ui/src/features/shared/editors/composables/useExpressionEditor.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/composables/useExpressionEditor.ts
@@ -368,7 +368,7 @@ export const useExpressionEditor = ({
 
 	// Helper: Count [*] wildcards in expression
 	function countArrayWildcards(expression: string): number {
-		const matches = expression.match(/\[\s*\*\s*\]/g);
+		const matches = expression.match(ARRAY_WILDCARD_REGEX);
 		return matches?.length ?? 0;
 	}
 

--- a/packages/workflow/src/expression-array-expander.ts
+++ b/packages/workflow/src/expression-array-expander.ts
@@ -1,0 +1,56 @@
+import type { INodeParameters, NodeParameterValueType } from './interfaces';
+
+/**
+ * Checks if an object has array properties that should be expanded.
+ * Returns true if at least one property value is an array.
+ */
+export function hasExpandableArrays(obj: INodeParameters): boolean {
+	const values = Object.values(obj);
+	return values.some((v) => Array.isArray(v));
+}
+
+/**
+ * Expands an object with array properties into multiple objects by "zipping" them together.
+ * Uses the longest array length, filling shorter arrays with undefined.
+ *
+ * Example:
+ *   Input:  { name: ['A', 'B', 'C'], price: [10, 20, 30], currency: 'USD' }
+ *   Output: [
+ *     { name: 'A', price: 10, currency: 'USD' },
+ *     { name: 'B', price: 20, currency: 'USD' },
+ *     { name: 'C', price: 30, currency: 'USD' }
+ *   ]
+ */
+export function expandArraysToObjects(obj: INodeParameters): INodeParameters[] {
+	const entries = Object.entries(obj);
+	const arrayEntries = entries.filter(([_, v]) => Array.isArray(v));
+	const scalarEntries = entries.filter(([_, v]) => !Array.isArray(v));
+
+	if (arrayEntries.length === 0) {
+		return [obj];
+	}
+
+	const maxLength = Math.max(...arrayEntries.map(([_, arr]) => (arr as unknown[]).length));
+	if (maxLength === 0) {
+		return [];
+	}
+
+	const result: INodeParameters[] = [];
+	for (let i = 0; i < maxLength; i++) {
+		const newObj: INodeParameters = {};
+
+		// Add scalar values to each expanded object
+		for (const [key, value] of scalarEntries) {
+			newObj[key] = value;
+		}
+
+		// Add array values by index (undefined if array is shorter)
+		for (const [key, arr] of arrayEntries) {
+			newObj[key] = (arr as NodeParameterValueType[])[i];
+		}
+
+		result.push(newObj);
+	}
+
+	return result;
+}

--- a/packages/workflow/src/expression.ts
+++ b/packages/workflow/src/expression.ts
@@ -1,16 +1,16 @@
+import { ApplicationError } from '@n8n/errors';
 import { DateTime, Duration, Interval } from 'luxon';
 
-import { ApplicationError } from '@n8n/errors';
 import { ExpressionExtensionError } from './errors/expression-extension.error';
 import { ExpressionError } from './errors/expression.error';
+import { hasExpandableArrays, expandArraysToObjects } from './expression-array-expander';
 import { evaluateExpression, setErrorHandler } from './expression-evaluator-proxy';
 import { sanitizer, sanitizerName } from './expression-sandboxing';
 import { isExpression } from './expressions/expression-helpers';
-import { extend, extendOptional } from './extensions';
+import { extend, extendOptional, hasArrayWildcardSyntax } from './extensions';
 import { extendSyntax } from './extensions/expression-extension';
 import { extendedFunctions } from './extensions/extended-functions';
 import { getGlobalState } from './global-state';
-import { createEmptyRunExecutionData } from './run-execution-data-factory';
 import type {
 	IDataObject,
 	IExecuteData,
@@ -24,9 +24,10 @@ import type {
 	NodeParameterValueType,
 	WorkflowExecuteMode,
 } from './interfaces';
+import type { IRunExecutionData } from './run-execution-data/run-execution-data';
+import { createEmptyRunExecutionData } from './run-execution-data-factory';
 import type { Workflow } from './workflow';
 import { WorkflowDataProxy } from './workflow-data-proxy';
-import type { IRunExecutionData } from './run-execution-data/run-execution-data';
 
 const IS_FRONTEND_IN_DEV_MODE =
 	typeof process === 'object' &&
@@ -550,12 +551,31 @@ export class Expression {
 
 		// Data is an object
 		const returnData: INodeParameters = {};
+		let hasWildcardArrayExpansion = false;
 
 		for (const [key, value] of Object.entries(parameterValue)) {
-			returnData[key] = resolveParameterValue(
+			// Only trigger array expansion when [*] wildcard syntax is explicitly used
+			// This ensures backward compatibility - expressions returning arrays without [*]
+			// will not be expanded into multiple objects
+			const usesWildcardSyntax =
+				typeof value === 'string' && isExpression(value) && hasArrayWildcardSyntax(value);
+
+			const resolved = resolveParameterValue(
 				value as NodeParameterValueType,
 				parameterValue as INodeParameters,
 			);
+			returnData[key] = resolved;
+
+			// Track if [*] wildcard was used and resolved to an array
+			if (usesWildcardSyntax && Array.isArray(resolved)) {
+				hasWildcardArrayExpansion = true;
+			}
+		}
+
+		// If object has array values from [*] wildcard expressions, expand into multiple objects
+		// Only expand when [*] syntax was explicitly used (backward compatibility)
+		if (hasWildcardArrayExpansion && hasExpandableArrays(returnData)) {
+			return expandArraysToObjects(returnData);
 		}
 
 		if (returnObjectAsString && typeof returnData === 'object') {

--- a/packages/workflow/src/extensions/expression-extension.ts
+++ b/packages/workflow/src/extensions/expression-extension.ts
@@ -61,6 +61,7 @@ const EXPRESSION_EXTENSION_REGEX = new RegExp(
 );
 
 // Regex to detect [*] array mapping syntax (e.g., items[*].field)
+// Note: No 'g' flag here - used with .test() which has stateful behavior with global regexes
 const ARRAY_WILDCARD_REGEX = /\[\s*\*\s*\]/;
 
 // Placeholder used to make [*] parseable by esprima
@@ -72,6 +73,12 @@ export const hasExpressionExtension = (str: string): boolean =>
 	EXPRESSION_EXTENSION_REGEX.test(str);
 
 export const hasArrayWildcardSyntax = (str: string): boolean => ARRAY_WILDCARD_REGEX.test(str);
+
+/**
+ * Replaces all [*] occurrences with the placeholder for parsing
+ */
+const replaceArrayWildcards = (str: string): string =>
+	str.replace(/\[\s*\*\s*\]/g, `["${ARRAY_WILDCARD_PLACEHOLDER}"]`);
 
 export const hasNativeMethod = (method: string): boolean => {
 	if (hasExpressionExtension(method)) {
@@ -223,10 +230,7 @@ export const extendTransform = (expression: string): { code: string } | undefine
 	try {
 		// Preprocess: Replace [*] with ["__n8n_array_wildcard__"] to make it parseable
 		// JavaScript doesn't allow [*] as it interprets * as multiplication operator
-		const preprocessedExpression = expression.replace(
-			ARRAY_WILDCARD_REGEX,
-			`["${ARRAY_WILDCARD_PLACEHOLDER}"]`,
-		);
+		const preprocessedExpression = replaceArrayWildcards(expression);
 
 		const ast = parse(preprocessedExpression, {
 			parser: { parse: parseWithEsprimaNext },

--- a/packages/workflow/src/extensions/expression-extension.ts
+++ b/packages/workflow/src/extensions/expression-extension.ts
@@ -60,10 +60,18 @@ const EXPRESSION_EXTENSION_REGEX = new RegExp(
 	`(\\$if|\\.(${EXPRESSION_EXTENSION_METHODS.join('|')})\\s*(\\?\\.)?)\\s*\\(`,
 );
 
+// Regex to detect [*] array mapping syntax (e.g., items[*].field)
+const ARRAY_WILDCARD_REGEX = /\[\s*\*\s*\]/;
+
+// Placeholder used to make [*] parseable by esprima
+const ARRAY_WILDCARD_PLACEHOLDER = '__n8n_array_wildcard__';
+
 const isExpressionExtension = (str: string) => EXPRESSION_EXTENSION_METHODS.some((m) => m === str);
 
 export const hasExpressionExtension = (str: string): boolean =>
 	EXPRESSION_EXTENSION_REGEX.test(str);
+
+export const hasArrayWildcardSyntax = (str: string): boolean => ARRAY_WILDCARD_REGEX.test(str);
 
 export const hasNativeMethod = (method: string): boolean => {
 	if (hasExpressionExtension(method)) {
@@ -107,6 +115,93 @@ function parseWithEsprimaNext(source: string, options?: any): any {
 }
 
 /**
+ * Checks if a MemberExpression node represents array wildcard access [*]
+ * After preprocessing, [*] becomes ["__n8n_array_wildcard__"]
+ */
+function isArrayWildcardAccess(node: types.namedTypes.MemberExpression): boolean {
+	return (
+		node.computed === true &&
+		node.property.type === 'Literal' &&
+		node.property.value === ARRAY_WILDCARD_PLACEHOLDER
+	);
+}
+
+/**
+ * Checks if a node contains an array wildcard [*] access anywhere in its chain
+ */
+function containsArrayWildcard(node: ExpressionKind): boolean {
+	if (node.type === 'MemberExpression') {
+		if (isArrayWildcardAccess(node)) {
+			return true;
+		}
+		return containsArrayWildcard(node.object);
+	}
+	return false;
+}
+
+/**
+ * Collects the JMESPath query string from member expressions following [*]
+ * Returns the path string like ".field" or ".address.city"
+ *
+ * For expression like: $json.orders[*].customer.name
+ * - baseObject = $json.orders
+ * - jmesPath = "[*].customer.name"
+ */
+function collectJmesPathFromChain(
+	node: types.namedTypes.MemberExpression,
+): { baseObject: ExpressionKind; jmesPath: string } | null {
+	// First, check if this is the topmost expression containing [*]
+	// by verifying that node contains [*] but is not itself inside another [*] chain
+	if (!containsArrayWildcard(node)) {
+		return null;
+	}
+
+	const pathParts: string[] = [];
+	let baseObject: ExpressionKind | null = null;
+
+	// Walk down the member expression chain to find [*] and collect all paths after it
+	const collectPath = (n: ExpressionKind): 'before_wildcard' | 'after_wildcard' => {
+		if (n.type === 'MemberExpression') {
+			const memberNode = n;
+
+			// Check if this is the [*] node
+			if (isArrayWildcardAccess(memberNode)) {
+				baseObject = memberNode.object;
+				return 'after_wildcard';
+			}
+
+			// Recurse into the object (go deeper first)
+			const result = collectPath(memberNode.object);
+
+			if (result === 'after_wildcard') {
+				// We're past the [*], collect this property
+				if (memberNode.property.type === 'Identifier') {
+					pathParts.push(memberNode.property.name);
+				} else if (memberNode.property.type === 'Literal') {
+					// Handle computed properties like ['field']
+					pathParts.push(String(memberNode.property.value));
+				}
+				return 'after_wildcard';
+			}
+
+			return 'before_wildcard';
+		}
+		return 'before_wildcard';
+	};
+
+	collectPath(node);
+
+	if (!baseObject || pathParts.length === 0) {
+		return null;
+	}
+
+	// Build JMESPath query: [*].field1.field2
+	const jmesPath = '[*].' + pathParts.join('.');
+
+	return { baseObject, jmesPath };
+}
+
+/**
  * A function to inject an extender function call into the AST of an expression.
  * This uses recast to do the transform.
  *
@@ -118,13 +213,63 @@ function parseWithEsprimaNext(source: string, options?: any): any {
  *
  * 'a'.first('x').second('y') // becomes
  * extend(extend('a', 'first', ['x']), 'second', ['y']));
+ *
+ * // Array wildcard syntax:
+ * items[*].field // becomes
+ * $jmesPath(items, '[*].field')
  * ```
  */
 export const extendTransform = (expression: string): { code: string } | undefined => {
 	try {
-		const ast = parse(expression, { parser: { parse: parseWithEsprimaNext } }) as types.ASTNode;
+		// Preprocess: Replace [*] with ["__n8n_array_wildcard__"] to make it parseable
+		// JavaScript doesn't allow [*] as it interprets * as multiplication operator
+		const preprocessedExpression = expression.replace(
+			ARRAY_WILDCARD_REGEX,
+			`["${ARRAY_WILDCARD_PLACEHOLDER}"]`,
+		);
+
+		const ast = parse(preprocessedExpression, {
+			parser: { parse: parseWithEsprimaNext },
+		}) as types.ASTNode;
 
 		let currentChain = 1;
+
+		// Transform array wildcard [*] syntax to $jmesPath calls
+		// e.g., $json.items[*].title -> $jmesPath($json.items, '[*].title')
+		visit(ast, {
+			visitMemberExpression(path) {
+				// First traverse children to handle nested expressions
+				this.traverse(path);
+
+				const node = path.node;
+
+				// Skip if this node is part of a larger MemberExpression chain
+				// We only want to process the topmost expression containing [*]
+				const parentNode = path.parent?.node as types.namedTypes.Node | undefined;
+				if (
+					parentNode &&
+					parentNode.type === 'MemberExpression' &&
+					(parentNode as types.namedTypes.MemberExpression).object === node
+				) {
+					// This node is the `object` of a parent MemberExpression,
+					// so we should skip it and let the parent handle the full chain
+					return;
+				}
+
+				// Check if this expression contains [*]
+				const result = collectJmesPathFromChain(node);
+
+				if (result) {
+					// Create $jmesPath(baseObject, '[*].path')
+					const jmesPathCall = types.builders.callExpression(
+						types.builders.identifier('$jmesPath'),
+						[result.baseObject, types.builders.literal(result.jmesPath)],
+					);
+
+					path.replace(jmesPathCall);
+				}
+			},
+		});
 
 		// Polyfill optional chaining
 		visit(ast, {
@@ -572,10 +717,13 @@ export function extendSyntax(bracketedExpression: string, forceExtend = false): 
 		.filter((c) => c.type === 'code')
 		.map((c) => c.text.replace(/("|').*?("|')/, '').trim());
 
-	if (
-		(!codeChunks.some(hasExpressionExtension) || hasNativeMethod(bracketedExpression)) &&
-		!forceExtend
-	) {
+	// Check if expression needs transformation:
+	// - Has extension methods (e.g., .isEmpty())
+	// - Has array wildcard syntax (e.g., [*])
+	const needsExtension =
+		codeChunks.some(hasExpressionExtension) || codeChunks.some(hasArrayWildcardSyntax);
+
+	if ((!needsExtension || hasNativeMethod(bracketedExpression)) && !forceExtend) {
 		return bracketedExpression;
 	}
 

--- a/packages/workflow/src/extensions/index.ts
+++ b/packages/workflow/src/extensions/index.ts
@@ -2,6 +2,7 @@ export {
 	extend,
 	extendOptional,
 	hasExpressionExtension,
+	hasArrayWildcardSyntax,
 	hasNativeMethod,
 	extendTransform,
 	EXTENSION_OBJECTS as ExpressionExtensions,

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -75,7 +75,7 @@ export {
 	type ExtractableSubgraphData,
 	type IConnectionAdjacencyList as AdjacencyList,
 } from './graph/graph-utils';
-export { ExpressionExtensions, type Alias, type AliasCompletion } from './extensions';
+export { ExpressionExtensions, hasArrayWildcardSyntax, type Alias, type AliasCompletion } from './extensions';
 export * as ExpressionParser from './extensions/expression-parser';
 export { NativeMethods } from './native-methods';
 export * from './node-parameters/filter-parameter';

--- a/packages/workflow/test/ExpressionExtensions/helpers.ts
+++ b/packages/workflow/test/ExpressionExtensions/helpers.ts
@@ -1,4 +1,4 @@
-import type { IDataObject } from '../../src/interfaces';
+import type { IDataObject, NodeParameterValueType } from '../../src/interfaces';
 import { Workflow } from '../../src/workflow';
 import * as Helpers from '../helpers';
 
@@ -21,6 +21,18 @@ export const workflow = new Workflow({
 export const expression = workflow.expression;
 
 export const evaluate = (value: string, values?: IDataObject[]) =>
+	expression.getParameterValue(
+		value,
+		null,
+		0,
+		0,
+		'node',
+		values?.map((v) => ({ json: v })) ?? [],
+		'manual',
+		{},
+	);
+
+export const evaluateParam = (value: NodeParameterValueType, values?: IDataObject[]) =>
 	expression.getParameterValue(
 		value,
 		null,

--- a/packages/workflow/test/expression-array-expander.test.ts
+++ b/packages/workflow/test/expression-array-expander.test.ts
@@ -1,0 +1,101 @@
+import { hasExpandableArrays, expandArraysToObjects } from '../src/expression-array-expander';
+
+describe('Expression Array Expander', () => {
+	describe('hasExpandableArrays', () => {
+		test('returns true for object with array properties', () => {
+			expect(hasExpandableArrays({ name: ['A', 'B', 'C'], price: [10, 20, 30] })).toBe(true);
+		});
+
+		test('returns true for object with single array property', () => {
+			expect(hasExpandableArrays({ name: ['A', 'B', 'C'], price: 100 })).toBe(true);
+		});
+
+		test('returns false for object with no arrays', () => {
+			expect(hasExpandableArrays({ name: 'A', price: 10 })).toBe(false);
+		});
+
+		test('returns false for empty object', () => {
+			expect(hasExpandableArrays({})).toBe(false);
+		});
+	});
+
+	describe('expandArraysToObjects', () => {
+		test('zips arrays into multiple objects', () => {
+			expect(
+				expandArraysToObjects({
+					name: ['A', 'B', 'C'],
+					price: [10, 20, 30],
+				}),
+			).toEqual([
+				{ name: 'A', price: 10 },
+				{ name: 'B', price: 20 },
+				{ name: 'C', price: 30 },
+			]);
+		});
+
+		test('preserves scalar values in all expanded objects', () => {
+			expect(
+				expandArraysToObjects({
+					name: ['A', 'B'],
+					price: [10, 20],
+					currency: 'USD',
+				}),
+			).toEqual([
+				{ name: 'A', price: 10, currency: 'USD' },
+				{ name: 'B', price: 20, currency: 'USD' },
+			]);
+		});
+
+		test('handles mismatched array lengths by using longest array', () => {
+			expect(
+				expandArraysToObjects({
+					name: ['A', 'B', 'C'],
+					price: [10, 20],
+				}),
+			).toEqual([
+				{ name: 'A', price: 10 },
+				{ name: 'B', price: 20 },
+				{ name: 'C', price: undefined },
+			]);
+		});
+
+		test('handles empty arrays', () => {
+			expect(
+				expandArraysToObjects({
+					name: [],
+					price: [],
+				}),
+			).toEqual([]);
+		});
+
+		test('returns original object wrapped in array when no arrays present', () => {
+			expect(expandArraysToObjects({ name: 'A', price: 10 })).toEqual([{ name: 'A', price: 10 }]);
+		});
+
+		test('handles single array with multiple scalar values', () => {
+			expect(
+				expandArraysToObjects({
+					name: ['A', 'B', 'C'],
+					type: 'product',
+					active: true,
+				}),
+			).toEqual([
+				{ name: 'A', type: 'product', active: true },
+				{ name: 'B', type: 'product', active: true },
+				{ name: 'C', type: 'product', active: true },
+			]);
+		});
+
+		test('handles arrays with nested objects', () => {
+			expect(
+				expandArraysToObjects({
+					item: [{ id: 1 }, { id: 2 }],
+					qty: [5, 10],
+				}),
+			).toEqual([
+				{ item: { id: 1 }, qty: 5 },
+				{ item: { id: 2 }, qty: 10 },
+			]);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds support for [*] array wildcard syntax in expressions, enabling users to map over array properties and extract values from nested items.

## Examples

#### Extract array property values
```js
  // Input data
  $json.orders = [
    { name: 'Order A', price: 10 },
    { name: 'Order B', price: 20 },
    { name: 'Order C', price: 30 }
  ]

  // Expression with [*] syntax
  {{ $json.orders[*].name }}

  // Result: ['Order A', 'Order B', 'Order C']
```
<img width="200" height="338" alt="image" src="https://github.com/user-attachments/assets/24143772-bc04-4ab7-a4b7-fd220114fc7d" />


#### Parameter expansion
When multiple fields in a node parameter use [*] syntax, the results are "zipped" together:

```js
  // Parameters
  {
    name: "{{ $json.orders[*].name }}",    // ['A', 'B', 'C']
    price: "{{ $json.orders[*].price }}",  // [10, 20, 30]
    currency: "USD"
  }

  // Expands to
  [
    { name: 'A', price: 10, currency: 'USD' },
    { name: 'B', price: 20, currency: 'USD' },
    { name: 'C', price: 30, currency: 'USD' }
  ]
```
<img height="300" alt="image" src="https://github.com/user-attachments/assets/46ace879-5ee4-4046-af29-12e39e7a57be" />


##  Key implementation details:
- [*] is converted to a .map() call using JMESPath-style traversal
- Backward compatible: existing expressions returning arrays without [*] are not affected
- Array expansion only triggers when [*] syntax is explicitly used

## Related Linear tickets, Github issues, and Community forum posts
n/a

## Review / Merge checklist
- [x] PR title and summary are descriptive. ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with release/backport (if the PR is an urgent fix that needs to be backported)