### PR TITLE
refactor: Add list method to LLM nodes

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOllama/LmChatOllama.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOllama/LmChatOllama.node.ts
@@ -13,8 +13,15 @@ import { getConnectionHintNoticeField } from '@utils/sharedFields';
 import { ollamaModel, ollamaOptions, ollamaDescription } from '../LMOllama/description';
 import { makeN8nLlmFailedAttemptHandler } from '../n8nLlmFailedAttemptHandler';
 import { N8nLlmTracing } from '../N8nLlmTracing';
+import { getModels } from '../LMOllama/methods/loadOptions';
 
 export class LmChatOllama implements INodeType {
+	methods = {
+		loadOptions: {
+			getModels,
+		},
+	};
+
 	description: INodeTypeDescription = {
 		displayName: 'Ollama Chat Model',
 

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMOllama/LmOllama.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMOllama/LmOllama.node.ts
@@ -12,8 +12,15 @@ import { getConnectionHintNoticeField } from '@utils/sharedFields';
 import { ollamaDescription, ollamaModel, ollamaOptions } from './description';
 import { makeN8nLlmFailedAttemptHandler } from '../n8nLlmFailedAttemptHandler';
 import { N8nLlmTracing } from '../N8nLlmTracing';
+import { getModels } from './methods/loadOptions';
 
 export class LmOllama implements INodeType {
+	methods = {
+		loadOptions: {
+			getModels,
+		},
+	};
+
 	description: INodeTypeDescription = {
 		displayName: 'Ollama Model',
 

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMOllama/description.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMOllama/description.ts
@@ -14,44 +14,16 @@ export const ollamaDescription: Partial<INodeTypeDescription> = {
 };
 
 export const ollamaModel: INodeProperties = {
+	// eslint-disable-next-line n8n-nodes-base/node-param-display-name-wrong-for-dynamic-options
 	displayName: 'Model',
 	name: 'model',
 	type: 'options',
 	default: 'llama3.2',
+	// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 	description:
 		'The model which will generate the completion. To download models, visit <a href="https://ollama.ai/library">Ollama Models Library</a>.',
 	typeOptions: {
-		loadOptions: {
-			routing: {
-				request: {
-					method: 'GET',
-					url: '/api/tags',
-				},
-				output: {
-					postReceive: [
-						{
-							type: 'rootProperty',
-							properties: {
-								property: 'models',
-							},
-						},
-						{
-							type: 'setKeyValue',
-							properties: {
-								name: '={{$responseItem.name}}',
-								value: '={{$responseItem.name}}',
-							},
-						},
-						{
-							type: 'sort',
-							properties: {
-								key: 'name',
-							},
-						},
-					],
-				},
-			},
-		},
+		loadOptionsMethod: 'getModels',
 	},
 	routing: {
 		send: {

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMOllama/methods/loadOptions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMOllama/methods/loadOptions.ts
@@ -22,8 +22,8 @@ export async function getModels(this: ILoadOptionsFunctions): Promise<INodePrope
 
 	// Sort models by name
 	options.sort((a, b) => {
-		const nameA = (a.name as string).toLowerCase();
-		const nameB = (b.name as string).toLowerCase();
+		const nameA = String(a.name).toLowerCase();
+		const nameB = String(b.name).toLowerCase();
 		return nameA.localeCompare(nameB);
 	});
 

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMOllama/methods/loadOptions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMOllama/methods/loadOptions.ts
@@ -1,0 +1,31 @@
+import type { ILoadOptionsFunctions, INodePropertyOptions } from 'n8n-workflow';
+
+export interface OllamaModel {
+	name: string;
+}
+
+export async function getModels(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+	const credentials = await this.getCredentials<{ baseUrl?: string }>('ollamaApi');
+
+	const baseURL = credentials.baseUrl ?? 'http://localhost:11434';
+	const response = (await this.helpers.httpRequestWithAuthentication.call(this, 'ollamaApi', {
+		url: `${baseURL}/api/tags`,
+		method: 'GET',
+	})) as { models: OllamaModel[] };
+
+	const models = response.models || [];
+
+	const options: INodePropertyOptions[] = models.map((model) => ({
+		name: model.name,
+		value: model.name,
+	}));
+
+	// Sort models by name
+	options.sort((a, b) => {
+		const nameA = (a.name as string).toLowerCase();
+		const nameB = (b.name as string).toLowerCase();
+		return nameA.localeCompare(nameB);
+	});
+
+	return options;
+}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts
@@ -14,8 +14,16 @@ import {
 
 import { makeN8nLlmFailedAttemptHandler } from '../n8nLlmFailedAttemptHandler';
 import { N8nLlmTracing } from '../N8nLlmTracing';
+import { getFoundationModels, getInferenceProfiles } from './methods/loadOptions';
 
 export class LmChatAwsBedrock implements INodeType {
+	methods = {
+		loadOptions: {
+			getFoundationModels,
+			getInferenceProfiles,
+		},
+	};
+
 	description: INodeTypeDescription = {
 		displayName: 'AWS Bedrock Chat Model',
 
@@ -84,10 +92,12 @@ export class LmChatAwsBedrock implements INodeType {
 				description: 'Choose between on-demand foundation models or inference profiles',
 			},
 			{
+				// eslint-disable-next-line n8n-nodes-base/node-param-display-name-wrong-for-dynamic-options
 				displayName: 'Model',
 				name: 'model',
 				type: 'options',
 				allowArbitraryValues: true, // Hide issues when model name is specified in the expression and does not match any of the options
+				// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 				description:
 					'The model which will generate the completion. <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/foundation-models.html">Learn more</a>.',
 				displayOptions: {
@@ -97,38 +107,7 @@ export class LmChatAwsBedrock implements INodeType {
 				},
 				typeOptions: {
 					loadOptionsDependsOn: ['modelSource'],
-					loadOptions: {
-						routing: {
-							request: {
-								method: 'GET',
-								url: '/foundation-models?&byOutputModality=TEXT&byInferenceType=ON_DEMAND',
-							},
-							output: {
-								postReceive: [
-									{
-										type: 'rootProperty',
-										properties: {
-											property: 'modelSummaries',
-										},
-									},
-									{
-										type: 'setKeyValue',
-										properties: {
-											name: '={{$responseItem.modelName}}',
-											description: '={{$responseItem.modelArn}}',
-											value: '={{$responseItem.modelId}}',
-										},
-									},
-									{
-										type: 'sort',
-										properties: {
-											key: 'name',
-										},
-									},
-								],
-							},
-						},
-					},
+					loadOptionsMethod: 'getFoundationModels',
 				},
 				routing: {
 					send: {
@@ -139,10 +118,12 @@ export class LmChatAwsBedrock implements INodeType {
 				default: '',
 			},
 			{
+				// eslint-disable-next-line n8n-nodes-base/node-param-display-name-wrong-for-dynamic-options
 				displayName: 'Model',
 				name: 'model',
 				type: 'options',
 				allowArbitraryValues: true,
+				// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 				description:
 					'The inference profile which will generate the completion. <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-use.html">Learn more</a>.',
 				displayOptions: {
@@ -152,39 +133,7 @@ export class LmChatAwsBedrock implements INodeType {
 				},
 				typeOptions: {
 					loadOptionsDependsOn: ['modelSource'],
-					loadOptions: {
-						routing: {
-							request: {
-								method: 'GET',
-								url: '/inference-profiles?maxResults=1000',
-							},
-							output: {
-								postReceive: [
-									{
-										type: 'rootProperty',
-										properties: {
-											property: 'inferenceProfileSummaries',
-										},
-									},
-									{
-										type: 'setKeyValue',
-										properties: {
-											name: '={{$responseItem.inferenceProfileName}}',
-											description:
-												'={{$responseItem.description || $responseItem.inferenceProfileArn}}',
-											value: '={{$responseItem.inferenceProfileId}}',
-										},
-									},
-									{
-										type: 'sort',
-										properties: {
-											key: 'name',
-										},
-									},
-								],
-							},
-						},
-					},
+					loadOptionsMethod: 'getInferenceProfiles',
 				},
 				routing: {
 					send: {

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/methods/loadOptions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/methods/loadOptions.ts
@@ -1,0 +1,74 @@
+import type { ILoadOptionsFunctions, INodePropertyOptions } from 'n8n-workflow';
+
+export interface FoundationModel {
+	modelName: string;
+	modelId: string;
+	modelArn: string;
+}
+
+export interface InferenceProfile {
+	inferenceProfileName: string;
+	inferenceProfileId: string;
+	inferenceProfileArn: string;
+	description?: string;
+}
+
+export async function getFoundationModels(
+	this: ILoadOptionsFunctions,
+): Promise<INodePropertyOptions[]> {
+	const credentials = await this.getCredentials<{ region?: string }>('aws');
+
+	const region = credentials.region ?? 'eu-central-1';
+	const baseURL = `https://bedrock.${region}.amazonaws.com`;
+	const response = (await this.helpers.httpRequestWithAuthentication.call(this, 'aws', {
+		url: `${baseURL}/foundation-models?&byOutputModality=TEXT&byInferenceType=ON_DEMAND`,
+		method: 'GET',
+	})) as { modelSummaries: FoundationModel[] };
+
+	const models = response.modelSummaries || [];
+
+	const options: INodePropertyOptions[] = models.map((model) => ({
+		name: model.modelName,
+		value: model.modelId,
+		description: model.modelArn,
+	}));
+
+	// Sort models by name
+	options.sort((a, b) => {
+		const nameA = (a.name as string).toLowerCase();
+		const nameB = (b.name as string).toLowerCase();
+		return nameA.localeCompare(nameB);
+	});
+
+	return options;
+}
+
+export async function getInferenceProfiles(
+	this: ILoadOptionsFunctions,
+): Promise<INodePropertyOptions[]> {
+	const credentials = await this.getCredentials<{ region?: string }>('aws');
+
+	const region = credentials.region ?? 'eu-central-1';
+	const baseURL = `https://bedrock.${region}.amazonaws.com`;
+	const response = (await this.helpers.httpRequestWithAuthentication.call(this, 'aws', {
+		url: `${baseURL}/inference-profiles?maxResults=1000`,
+		method: 'GET',
+	})) as { inferenceProfileSummaries: InferenceProfile[] };
+
+	const profiles = response.inferenceProfileSummaries || [];
+
+	const options: INodePropertyOptions[] = profiles.map((profile) => ({
+		name: profile.inferenceProfileName,
+		value: profile.inferenceProfileId,
+		description: profile.description || profile.inferenceProfileArn,
+	}));
+
+	// Sort profiles by name
+	options.sort((a, b) => {
+		const nameA = (a.name as string).toLowerCase();
+		const nameB = (b.name as string).toLowerCase();
+		return nameA.localeCompare(nameB);
+	});
+
+	return options;
+}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/methods/loadOptions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/methods/loadOptions.ts
@@ -35,8 +35,8 @@ export async function getFoundationModels(
 
 	// Sort models by name
 	options.sort((a, b) => {
-		const nameA = (a.name as string).toLowerCase();
-		const nameB = (b.name as string).toLowerCase();
+		const nameA = String(a.name).toLowerCase();
+		const nameB = String(b.name).toLowerCase();
 		return nameA.localeCompare(nameB);
 	});
 
@@ -65,8 +65,8 @@ export async function getInferenceProfiles(
 
 	// Sort profiles by name
 	options.sort((a, b) => {
-		const nameA = (a.name as string).toLowerCase();
-		const nameB = (b.name as string).toLowerCase();
+		const nameA = String(a.name).toLowerCase();
+		const nameB = String(b.name).toLowerCase();
 		return nameA.localeCompare(nameB);
 	});
 

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatCohere/LmChatCohere.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatCohere/LmChatCohere.node.ts
@@ -11,6 +11,7 @@ import { getConnectionHintNoticeField } from '@utils/sharedFields';
 
 import { makeN8nLlmFailedAttemptHandler } from '../n8nLlmFailedAttemptHandler';
 import { N8nLlmTracing } from '../N8nLlmTracing';
+import { getModels } from './methods/loadOptions';
 
 export function tokensUsageParser(result: LLMResult): {
 	completionTokens: number;
@@ -38,6 +39,12 @@ export function tokensUsageParser(result: LLMResult): {
 }
 
 export class LmChatCohere implements INodeType {
+	methods = {
+		loadOptions: {
+			getModels,
+		},
+	};
+
 	description: INodeTypeDescription = {
 		displayName: 'Cohere Chat Model',
 		name: 'lmChatCohere',
@@ -81,44 +88,15 @@ export class LmChatCohere implements INodeType {
 		properties: [
 			getConnectionHintNoticeField(['ai_chain', 'ai_agent']),
 			{
+				// eslint-disable-next-line n8n-nodes-base/node-param-display-name-wrong-for-dynamic-options
 				displayName: 'Model',
 				name: 'model',
 				type: 'options',
+				// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 				description:
 					'The model which will generate the completion. <a href="https://docs.cohere.com/docs/models">Learn more</a>.',
 				typeOptions: {
-					loadOptions: {
-						routing: {
-							request: {
-								method: 'GET',
-								url: '/v1/models?page_size=100&endpoint=chat',
-							},
-							output: {
-								postReceive: [
-									{
-										type: 'rootProperty',
-										properties: {
-											property: 'models',
-										},
-									},
-									{
-										type: 'setKeyValue',
-										properties: {
-											name: '={{$responseItem.name}}',
-											value: '={{$responseItem.name}}',
-											description: '={{$responseItem.description}}',
-										},
-									},
-									{
-										type: 'sort',
-										properties: {
-											key: 'name',
-										},
-									},
-								],
-							},
-						},
-					},
+					loadOptionsMethod: 'getModels',
 				},
 				default: 'command-a-03-2025',
 			},

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatCohere/methods/loadOptions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatCohere/methods/loadOptions.ts
@@ -24,8 +24,8 @@ export async function getModels(this: ILoadOptionsFunctions): Promise<INodePrope
 
 	// Sort models by name
 	options.sort((a, b) => {
-		const nameA = (a.name as string).toLowerCase();
-		const nameB = (b.name as string).toLowerCase();
+		const nameA = String(a.name).toLowerCase();
+		const nameB = String(b.name).toLowerCase();
 		return nameA.localeCompare(nameB);
 	});
 

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatCohere/methods/loadOptions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatCohere/methods/loadOptions.ts
@@ -1,0 +1,33 @@
+import type { ILoadOptionsFunctions, INodePropertyOptions } from 'n8n-workflow';
+
+export interface CohereModel {
+	name: string;
+	description?: string;
+}
+
+export async function getModels(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+	const credentials = await this.getCredentials<{ url?: string }>('cohereApi');
+
+	const baseURL = credentials.url ?? 'https://api.cohere.ai';
+	const response = (await this.helpers.httpRequestWithAuthentication.call(this, 'cohereApi', {
+		url: `${baseURL}/v1/models?page_size=100&endpoint=chat`,
+		method: 'GET',
+	})) as { models: CohereModel[] };
+
+	const models = response.models || [];
+
+	const options: INodePropertyOptions[] = models.map((model) => ({
+		name: model.name,
+		value: model.name,
+		description: model.description,
+	}));
+
+	// Sort models by name
+	options.sort((a, b) => {
+		const nameA = (a.name as string).toLowerCase();
+		const nameB = (b.name as string).toLowerCase();
+		return nameA.localeCompare(nameB);
+	});
+
+	return options;
+}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatDeepSeek/LmChatDeepSeek.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatDeepSeek/LmChatDeepSeek.node.ts
@@ -14,8 +14,15 @@ import type { OpenAICompatibleCredential } from '../../../types/types';
 import { openAiFailedAttemptHandler } from '../../vendors/OpenAi/helpers/error-handling';
 import { makeN8nLlmFailedAttemptHandler } from '../n8nLlmFailedAttemptHandler';
 import { N8nLlmTracing } from '../N8nLlmTracing';
+import { getModels } from './methods/loadOptions';
 
 export class LmChatDeepSeek implements INodeType {
+	methods = {
+		loadOptions: {
+			getModels,
+		},
+	};
+
 	description: INodeTypeDescription = {
 		displayName: 'DeepSeek Chat Model',
 
@@ -71,43 +78,15 @@ export class LmChatDeepSeek implements INodeType {
 				},
 			},
 			{
+				// eslint-disable-next-line n8n-nodes-base/node-param-display-name-wrong-for-dynamic-options
 				displayName: 'Model',
 				name: 'model',
 				type: 'options',
+				// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 				description:
 					'The model which will generate the completion. <a href="https://api-docs.deepseek.com/quick_start/pricing">Learn more</a>.',
 				typeOptions: {
-					loadOptions: {
-						routing: {
-							request: {
-								method: 'GET',
-								url: '/models',
-							},
-							output: {
-								postReceive: [
-									{
-										type: 'rootProperty',
-										properties: {
-											property: 'data',
-										},
-									},
-									{
-										type: 'setKeyValue',
-										properties: {
-											name: '={{$responseItem.id}}',
-											value: '={{$responseItem.id}}',
-										},
-									},
-									{
-										type: 'sort',
-										properties: {
-											key: 'name',
-										},
-									},
-								],
-							},
-						},
-					},
+					loadOptionsMethod: 'getModels',
 				},
 				routing: {
 					send: {

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatDeepSeek/methods/loadOptions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatDeepSeek/methods/loadOptions.ts
@@ -22,8 +22,8 @@ export async function getModels(this: ILoadOptionsFunctions): Promise<INodePrope
 
 	// Sort models by name
 	options.sort((a, b) => {
-		const nameA = (a.name as string).toLowerCase();
-		const nameB = (b.name as string).toLowerCase();
+		const nameA = String(a.name).toLowerCase();
+		const nameB = String(b.name).toLowerCase();
 		return nameA.localeCompare(nameB);
 	});
 

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatDeepSeek/methods/loadOptions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatDeepSeek/methods/loadOptions.ts
@@ -1,0 +1,31 @@
+import type { ILoadOptionsFunctions, INodePropertyOptions } from 'n8n-workflow';
+
+export interface DeepSeekModel {
+	id: string;
+}
+
+export async function getModels(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+	const credentials = await this.getCredentials<{ url?: string }>('deepSeekApi');
+
+	const baseURL = credentials.url ?? 'https://api.deepseek.com';
+	const response = (await this.helpers.httpRequestWithAuthentication.call(this, 'deepSeekApi', {
+		url: `${baseURL}/models`,
+		method: 'GET',
+	})) as { data: DeepSeekModel[] };
+
+	const models = response.data || [];
+
+	const options: INodePropertyOptions[] = models.map((model) => ({
+		name: model.id,
+		value: model.id,
+	}));
+
+	// Sort models by name
+	options.sort((a, b) => {
+		const nameA = (a.name as string).toLowerCase();
+		const nameB = (b.name as string).toLowerCase();
+		return nameA.localeCompare(nameB);
+	});
+
+	return options;
+}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleGemini/LmChatGoogleGemini.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleGemini/LmChatGoogleGemini.node.ts
@@ -14,6 +14,7 @@ import { getConnectionHintNoticeField } from '@utils/sharedFields';
 import { getAdditionalOptions } from '../gemini-common/additional-options';
 import { makeN8nLlmFailedAttemptHandler } from '../n8nLlmFailedAttemptHandler';
 import { N8nLlmTracing } from '../N8nLlmTracing';
+import { getModels } from './methods/loadOptions';
 
 function errorDescriptionMapper(error: NodeError) {
 	if (error.description?.includes('properties: should be non-empty for OBJECT type')) {
@@ -23,6 +24,12 @@ function errorDescriptionMapper(error: NodeError) {
 	return error.description ?? 'Unknown error';
 }
 export class LmChatGoogleGemini implements INodeType {
+	methods = {
+		loadOptions: {
+			getModels,
+		},
+	};
+
 	description: INodeTypeDescription = {
 		displayName: 'Google Gemini Chat Model',
 
@@ -66,50 +73,15 @@ export class LmChatGoogleGemini implements INodeType {
 		properties: [
 			getConnectionHintNoticeField([NodeConnectionTypes.AiChain, NodeConnectionTypes.AiAgent]),
 			{
+				// eslint-disable-next-line n8n-nodes-base/node-param-display-name-wrong-for-dynamic-options
 				displayName: 'Model',
 				name: 'modelName',
 				type: 'options',
+				// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 				description:
 					'The model which will generate the completion. <a href="https://developers.generativeai.google/api/rest/generativelanguage/models/list">Learn more</a>.',
 				typeOptions: {
-					loadOptions: {
-						routing: {
-							request: {
-								method: 'GET',
-								url: '/v1beta/models',
-							},
-							output: {
-								postReceive: [
-									{
-										type: 'rootProperty',
-										properties: {
-											property: 'models',
-										},
-									},
-									{
-										type: 'filter',
-										properties: {
-											pass: "={{ !$responseItem.name.includes('embedding') }}",
-										},
-									},
-									{
-										type: 'setKeyValue',
-										properties: {
-											name: '={{$responseItem.name}}',
-											value: '={{$responseItem.name}}',
-											description: '={{$responseItem.description}}',
-										},
-									},
-									{
-										type: 'sort',
-										properties: {
-											key: 'name',
-										},
-									},
-								],
-							},
-						},
-					},
+					loadOptionsMethod: 'getModels',
 				},
 				routing: {
 					send: {

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleGemini/methods/loadOptions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleGemini/methods/loadOptions.ts
@@ -1,0 +1,37 @@
+import type { ILoadOptionsFunctions, INodePropertyOptions } from 'n8n-workflow';
+
+export interface GoogleModel {
+	name: string;
+	description: string;
+	displayName?: string;
+}
+
+export async function getModels(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+	const credentials = await this.getCredentials<{ host?: string }>('googlePalmApi');
+
+	const baseURL = credentials.host ?? 'https://generativelanguage.googleapis.com';
+	const response = (await this.helpers.httpRequestWithAuthentication.call(this, 'googlePalmApi', {
+		url: `${baseURL}/v1beta/models`,
+		method: 'GET',
+	})) as { models: GoogleModel[] };
+
+	const models = response.models || [];
+
+	// Filter out embedding models
+	const chatModels = models.filter((model) => !model.name.includes('embedding'));
+
+	const options: INodePropertyOptions[] = chatModels.map((model) => ({
+		name: model.name,
+		value: model.name,
+		description: model.description,
+	}));
+
+	// Sort models by name
+	options.sort((a, b) => {
+		const nameA = (a.name as string).toLowerCase();
+		const nameB = (b.name as string).toLowerCase();
+		return nameA.localeCompare(nameB);
+	});
+
+	return options;
+}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleGemini/methods/loadOptions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleGemini/methods/loadOptions.ts
@@ -28,8 +28,8 @@ export async function getModels(this: ILoadOptionsFunctions): Promise<INodePrope
 
 	// Sort models by name
 	options.sort((a, b) => {
-		const nameA = (a.name as string).toLowerCase();
-		const nameB = (b.name as string).toLowerCase();
+		const nameA = String(a.name).toLowerCase();
+		const nameB = String(b.name).toLowerCase();
 		return nameA.localeCompare(nameB);
 	});
 

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatGroq/LmChatGroq.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatGroq/LmChatGroq.node.ts
@@ -12,8 +12,15 @@ import { getConnectionHintNoticeField } from '@utils/sharedFields';
 
 import { makeN8nLlmFailedAttemptHandler } from '../n8nLlmFailedAttemptHandler';
 import { N8nLlmTracing } from '../N8nLlmTracing';
+import { getModels } from './methods/loadOptions';
 
 export class LmChatGroq implements INodeType {
+	methods = {
+		loadOptions: {
+			getModels,
+		},
+	};
+
 	description: INodeTypeDescription = {
 		displayName: 'Groq Chat Model',
 
@@ -56,41 +63,12 @@ export class LmChatGroq implements INodeType {
 		properties: [
 			getConnectionHintNoticeField([NodeConnectionTypes.AiChain, NodeConnectionTypes.AiChain]),
 			{
+				// eslint-disable-next-line n8n-nodes-base/node-param-display-name-wrong-for-dynamic-options
 				displayName: 'Model',
 				name: 'model',
 				type: 'options',
 				typeOptions: {
-					loadOptions: {
-						routing: {
-							request: {
-								method: 'GET',
-								url: '/models',
-							},
-							output: {
-								postReceive: [
-									{
-										type: 'rootProperty',
-										properties: {
-											property: 'data',
-										},
-									},
-									{
-										type: 'filter',
-										properties: {
-											pass: '={{ $responseItem.active === true && $responseItem.object === "model" }}',
-										},
-									},
-									{
-										type: 'setKeyValue',
-										properties: {
-											name: '={{$responseItem.id}}',
-											value: '={{$responseItem.id}}',
-										},
-									},
-								],
-							},
-						},
-					},
+					loadOptionsMethod: 'getModels',
 				},
 				routing: {
 					send: {
@@ -98,6 +76,7 @@ export class LmChatGroq implements INodeType {
 						property: 'model',
 					},
 				},
+				// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 				description:
 					'The model which will generate the completion. <a href="https://console.groq.com/docs/models">Learn more</a>.',
 				default: 'llama3-8b-8192',

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatGroq/methods/loadOptions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatGroq/methods/loadOptions.ts
@@ -1,0 +1,27 @@
+import type { ILoadOptionsFunctions, INodePropertyOptions } from 'n8n-workflow';
+
+export interface GroqModel {
+	id: string;
+	active?: boolean;
+	object?: string;
+}
+
+export async function getModels(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+	const baseURL = 'https://api.groq.com/openai/v1';
+	const response = (await this.helpers.httpRequestWithAuthentication.call(this, 'groqApi', {
+		url: `${baseURL}/models`,
+		method: 'GET',
+	})) as { data: GroqModel[] };
+
+	const models = response.data || [];
+
+	// Filter for active chat models only
+	const activeModels = models.filter((model) => model.active === true && model.object === 'model');
+
+	const options: INodePropertyOptions[] = activeModels.map((model) => ({
+		name: model.id,
+		value: model.id,
+	}));
+
+	return options;
+}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatMistralCloud/LmChatMistralCloud.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatMistralCloud/LmChatMistralCloud.node.ts
@@ -12,10 +12,17 @@ import { getConnectionHintNoticeField } from '@utils/sharedFields';
 
 import { makeN8nLlmFailedAttemptHandler } from '../n8nLlmFailedAttemptHandler';
 import { N8nLlmTracing } from '../N8nLlmTracing';
+import { getModels } from './methods/loadOptions';
 
 const deprecatedMagistralModelsWithTextOutput = ['magistral-small-2506', 'magistral-medium-2506'];
 
 export class LmChatMistralCloud implements INodeType {
+	methods = {
+		loadOptions: {
+			getModels,
+		},
+	};
+
 	description: INodeTypeDescription = {
 		displayName: 'Mistral Cloud Chat Model',
 
@@ -59,49 +66,15 @@ export class LmChatMistralCloud implements INodeType {
 		properties: [
 			getConnectionHintNoticeField([NodeConnectionTypes.AiChain, NodeConnectionTypes.AiAgent]),
 			{
+				// eslint-disable-next-line n8n-nodes-base/node-param-display-name-wrong-for-dynamic-options
 				displayName: 'Model',
 				name: 'model',
 				type: 'options',
+				// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 				description:
 					'The model which will generate the completion. <a href="https://docs.mistral.ai/platform/endpoints/">Learn more</a>.',
 				typeOptions: {
-					loadOptions: {
-						routing: {
-							request: {
-								method: 'GET',
-								url: '/models',
-							},
-							output: {
-								postReceive: [
-									{
-										type: 'rootProperty',
-										properties: {
-											property: 'data',
-										},
-									},
-									{
-										type: 'filter',
-										properties: {
-											pass: "={{ !$responseItem.id.includes('embed') }}",
-										},
-									},
-									{
-										type: 'setKeyValue',
-										properties: {
-											name: '={{ $responseItem.id }}',
-											value: '={{ $responseItem.id }}',
-										},
-									},
-									{
-										type: 'sort',
-										properties: {
-											key: 'name',
-										},
-									},
-								],
-							},
-						},
-					},
+					loadOptionsMethod: 'getModels',
 				},
 				routing: {
 					send: {

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatMistralCloud/methods/loadOptions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatMistralCloud/methods/loadOptions.ts
@@ -23,8 +23,8 @@ export async function getModels(this: ILoadOptionsFunctions): Promise<INodePrope
 
 	// Sort models by name
 	options.sort((a, b) => {
-		const nameA = (a.name as string).toLowerCase();
-		const nameB = (b.name as string).toLowerCase();
+		const nameA = String(a.name).toLowerCase();
+		const nameB = String(b.name).toLowerCase();
 		return nameA.localeCompare(nameB);
 	});
 

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatMistralCloud/methods/loadOptions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatMistralCloud/methods/loadOptions.ts
@@ -1,0 +1,32 @@
+import type { ILoadOptionsFunctions, INodePropertyOptions } from 'n8n-workflow';
+
+export interface MistralModel {
+	id: string;
+}
+
+export async function getModels(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+	const baseURL = 'https://api.mistral.ai/v1';
+	const response = (await this.helpers.httpRequestWithAuthentication.call(this, 'mistralCloudApi', {
+		url: `${baseURL}/models`,
+		method: 'GET',
+	})) as { data: MistralModel[] };
+
+	const models = response.data || [];
+
+	// Filter out embedding models
+	const chatModels = models.filter((model) => !model.id.includes('embed'));
+
+	const options: INodePropertyOptions[] = chatModels.map((model) => ({
+		name: model.id,
+		value: model.id,
+	}));
+
+	// Sort models by name
+	options.sort((a, b) => {
+		const nameA = (a.name as string).toLowerCase();
+		const nameB = (b.name as string).toLowerCase();
+		return nameA.localeCompare(nameB);
+	});
+
+	return options;
+}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.ts
@@ -14,8 +14,15 @@ import type { OpenAICompatibleCredential } from '../../../types/types';
 import { openAiFailedAttemptHandler } from '../../vendors/OpenAi/helpers/error-handling';
 import { makeN8nLlmFailedAttemptHandler } from '../n8nLlmFailedAttemptHandler';
 import { N8nLlmTracing } from '../N8nLlmTracing';
+import { getModels } from './methods/loadOptions';
 
 export class LmChatOpenRouter implements INodeType {
+	methods = {
+		loadOptions: {
+			getModels,
+		},
+	};
+
 	description: INodeTypeDescription = {
 		displayName: 'OpenRouter Chat Model',
 		name: 'lmChatOpenRouter',
@@ -70,43 +77,15 @@ export class LmChatOpenRouter implements INodeType {
 				},
 			},
 			{
+				// eslint-disable-next-line n8n-nodes-base/node-param-display-name-wrong-for-dynamic-options
 				displayName: 'Model',
 				name: 'model',
 				type: 'options',
+				// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 				description:
 					'The model which will generate the completion. <a href="https://openrouter.ai/docs/models">Learn more</a>.',
 				typeOptions: {
-					loadOptions: {
-						routing: {
-							request: {
-								method: 'GET',
-								url: '/models',
-							},
-							output: {
-								postReceive: [
-									{
-										type: 'rootProperty',
-										properties: {
-											property: 'data',
-										},
-									},
-									{
-										type: 'setKeyValue',
-										properties: {
-											name: '={{$responseItem.id}}',
-											value: '={{$responseItem.id}}',
-										},
-									},
-									{
-										type: 'sort',
-										properties: {
-											key: 'name',
-										},
-									},
-								],
-							},
-						},
-					},
+					loadOptionsMethod: 'getModels',
 				},
 				routing: {
 					send: {

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/methods/loadOptions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/methods/loadOptions.ts
@@ -22,8 +22,8 @@ export async function getModels(this: ILoadOptionsFunctions): Promise<INodePrope
 
 	// Sort models by name
 	options.sort((a, b) => {
-		const nameA = (a.name as string).toLowerCase();
-		const nameB = (b.name as string).toLowerCase();
+		const nameA = String(a.name).toLowerCase();
+		const nameB = String(b.name).toLowerCase();
 		return nameA.localeCompare(nameB);
 	});
 

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/methods/loadOptions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/methods/loadOptions.ts
@@ -1,0 +1,31 @@
+import type { ILoadOptionsFunctions, INodePropertyOptions } from 'n8n-workflow';
+
+export interface OpenRouterModel {
+	id: string;
+}
+
+export async function getModels(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+	const credentials = await this.getCredentials<{ url?: string }>('openRouterApi');
+
+	const baseURL = credentials.url ?? 'https://openrouter.ai/api/v1';
+	const response = (await this.helpers.httpRequestWithAuthentication.call(this, 'openRouterApi', {
+		url: `${baseURL}/models`,
+		method: 'GET',
+	})) as { data: OpenRouterModel[] };
+
+	const models = response.data || [];
+
+	const options: INodePropertyOptions[] = models.map((model) => ({
+		name: model.id,
+		value: model.id,
+	}));
+
+	// Sort models by name
+	options.sort((a, b) => {
+		const nameA = (a.name as string).toLowerCase();
+		const nameB = (b.name as string).toLowerCase();
+		return nameA.localeCompare(nameB);
+	});
+
+	return options;
+}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatVercelAiGateway/LmChatVercelAiGateway.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatVercelAiGateway/LmChatVercelAiGateway.node.ts
@@ -14,8 +14,15 @@ import type { OpenAICompatibleCredential } from '../../../types/types';
 import { openAiFailedAttemptHandler } from '../../vendors/OpenAi/helpers/error-handling';
 import { makeN8nLlmFailedAttemptHandler } from '../n8nLlmFailedAttemptHandler';
 import { N8nLlmTracing } from '../N8nLlmTracing';
+import { getModels } from './methods/loadOptions';
 
 export class LmChatVercelAiGateway implements INodeType {
+	methods = {
+		loadOptions: {
+			getModels,
+		},
+	};
+
 	description: INodeTypeDescription = {
 		displayName: 'Vercel AI Gateway Chat Model',
 		name: 'lmChatVercelAiGateway',
@@ -70,42 +77,14 @@ export class LmChatVercelAiGateway implements INodeType {
 				},
 			},
 			{
+				// eslint-disable-next-line n8n-nodes-base/node-param-display-name-wrong-for-dynamic-options
 				displayName: 'Model',
 				name: 'model',
 				type: 'options',
+				// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 				description: 'The model which will generate the completion',
 				typeOptions: {
-					loadOptions: {
-						routing: {
-							request: {
-								method: 'GET',
-								url: '/models',
-							},
-							output: {
-								postReceive: [
-									{
-										type: 'rootProperty',
-										properties: {
-											property: 'data',
-										},
-									},
-									{
-										type: 'setKeyValue',
-										properties: {
-											name: '={{$responseItem.id}}',
-											value: '={{$responseItem.id}}',
-										},
-									},
-									{
-										type: 'sort',
-										properties: {
-											key: 'name',
-										},
-									},
-								],
-							},
-						},
-					},
+					loadOptionsMethod: 'getModels',
 				},
 				routing: {
 					send: {

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatVercelAiGateway/methods/loadOptions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatVercelAiGateway/methods/loadOptions.ts
@@ -26,8 +26,8 @@ export async function getModels(this: ILoadOptionsFunctions): Promise<INodePrope
 
 	// Sort models by name
 	options.sort((a, b) => {
-		const nameA = (a.name as string).toLowerCase();
-		const nameB = (b.name as string).toLowerCase();
+		const nameA = String(a.name).toLowerCase();
+		const nameB = String(b.name).toLowerCase();
 		return nameA.localeCompare(nameB);
 	});
 

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatVercelAiGateway/methods/loadOptions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatVercelAiGateway/methods/loadOptions.ts
@@ -1,0 +1,35 @@
+import type { ILoadOptionsFunctions, INodePropertyOptions } from 'n8n-workflow';
+
+export interface VercelAiGatewayModel {
+	id: string;
+}
+
+export async function getModels(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+	const credentials = await this.getCredentials<{ url?: string }>('vercelAiGatewayApi');
+
+	const baseURL = credentials.url ?? 'https://ai-gateway.vercel.sh/v1';
+	const response = (await this.helpers.httpRequestWithAuthentication.call(
+		this,
+		'vercelAiGatewayApi',
+		{
+			url: `${baseURL}/models`,
+			method: 'GET',
+		},
+	)) as { data: VercelAiGatewayModel[] };
+
+	const models = response.data || [];
+
+	const options: INodePropertyOptions[] = models.map((model) => ({
+		name: model.id,
+		value: model.id,
+	}));
+
+	// Sort models by name
+	options.sort((a, b) => {
+		const nameA = (a.name as string).toLowerCase();
+		const nameB = (b.name as string).toLowerCase();
+		return nameA.localeCompare(nameB);
+	});
+
+	return options;
+}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatXAiGrok/LmChatXAiGrok.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatXAiGrok/LmChatXAiGrok.node.ts
@@ -14,8 +14,15 @@ import type { OpenAICompatibleCredential } from '../../../types/types';
 import { openAiFailedAttemptHandler } from '../../vendors/OpenAi/helpers/error-handling';
 import { makeN8nLlmFailedAttemptHandler } from '../n8nLlmFailedAttemptHandler';
 import { N8nLlmTracing } from '../N8nLlmTracing';
+import { getModels } from './methods/loadOptions';
 
 export class LmChatXAiGrok implements INodeType {
+	methods = {
+		loadOptions: {
+			getModels,
+		},
+	};
+
 	description: INodeTypeDescription = {
 		displayName: 'xAI Grok Chat Model',
 
@@ -71,43 +78,15 @@ export class LmChatXAiGrok implements INodeType {
 				},
 			},
 			{
+				// eslint-disable-next-line n8n-nodes-base/node-param-display-name-wrong-for-dynamic-options
 				displayName: 'Model',
 				name: 'model',
 				type: 'options',
+				// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-options
 				description:
 					'The model which will generate the completion. <a href="https://docs.x.ai/docs/models">Learn more</a>.',
 				typeOptions: {
-					loadOptions: {
-						routing: {
-							request: {
-								method: 'GET',
-								url: '/models',
-							},
-							output: {
-								postReceive: [
-									{
-										type: 'rootProperty',
-										properties: {
-											property: 'data',
-										},
-									},
-									{
-										type: 'setKeyValue',
-										properties: {
-											name: '={{$responseItem.id}}',
-											value: '={{$responseItem.id}}',
-										},
-									},
-									{
-										type: 'sort',
-										properties: {
-											key: 'name',
-										},
-									},
-								],
-							},
-						},
-					},
+					loadOptionsMethod: 'getModels',
 				},
 				routing: {
 					send: {

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatXAiGrok/methods/loadOptions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatXAiGrok/methods/loadOptions.ts
@@ -22,8 +22,8 @@ export async function getModels(this: ILoadOptionsFunctions): Promise<INodePrope
 
 	// Sort models by name
 	options.sort((a, b) => {
-		const nameA = (a.name as string).toLowerCase();
-		const nameB = (b.name as string).toLowerCase();
+		const nameA = String(a.name).toLowerCase();
+		const nameB = String(b.name).toLowerCase();
 		return nameA.localeCompare(nameB);
 	});
 

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatXAiGrok/methods/loadOptions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatXAiGrok/methods/loadOptions.ts
@@ -1,0 +1,31 @@
+import type { ILoadOptionsFunctions, INodePropertyOptions } from 'n8n-workflow';
+
+export interface XAiModel {
+	id: string;
+}
+
+export async function getModels(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+	const credentials = await this.getCredentials<{ url?: string }>('xAiApi');
+
+	const baseURL = credentials.url ?? 'https://api.x.ai/v1';
+	const response = (await this.helpers.httpRequestWithAuthentication.call(this, 'xAiApi', {
+		url: `${baseURL}/models`,
+		method: 'GET',
+	})) as { data: XAiModel[] };
+
+	const models = response.data || [];
+
+	const options: INodePropertyOptions[] = models.map((model) => ({
+		name: model.id,
+		value: model.id,
+	}));
+
+	// Sort models by name
+	options.sort((a, b) => {
+		const nameA = (a.name as string).toLowerCase();
+		const nameB = (b.name as string).toLowerCase();
+		return nameA.localeCompare(nameB);
+	});
+
+	return options;
+}

--- a/packages/cli/src/modules/chat-hub/chat-hub.models.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.models.service.ts
@@ -8,7 +8,7 @@ import {
 	type ChatModelsResponse,
 } from '@n8n/api-types';
 import { In, WorkflowRepository, type User, type WorkflowEntity } from '@n8n/db';
-import { Service } from '@n8n/di';
+import { Container, Service } from '@n8n/di';
 import {
 	CHAT_TRIGGER_NODE_TYPE,
 	type INodeCredentials,
@@ -26,6 +26,7 @@ import { DynamicNodeParametersService } from '@/services/dynamic-node-parameters
 import { getBase } from '@/workflow-execute-additional-data';
 import { WorkflowService } from '@/workflows/workflow.service';
 import { Scope } from '@n8n/permissions';
+import { Logger } from '@n8n/backend-common';
 
 @Service()
 export class ChatHubModelsService {
@@ -76,7 +77,7 @@ export class ChatHubModelsService {
 							provider,
 							await this.fetchModelsForProvider(user, provider, credentials, additionalData),
 						];
-					} catch {
+					} catch (e) {
 						return [
 							provider,
 							{ models: [], error: 'Could not retrieve models. Verify credentials.' },
@@ -201,47 +202,9 @@ export class ChatHubModelsService {
 		credentials: INodeCredentials,
 		additionalData: IWorkflowExecuteAdditionalData,
 	): Promise<INodePropertyOptions[]> {
-		return await this.nodeParametersService.getOptionsViaLoadOptions(
-			{
-				// From Gemini node
-				// https://github.com/n8n-io/n8n/blob/master/packages/%40n8n/nodes-langchain/nodes/llms/LmChatGoogleGemini/LmChatGoogleGemini.node.ts#L75
-				routing: {
-					request: {
-						method: 'GET',
-						url: '/v1beta/models',
-					},
-					output: {
-						postReceive: [
-							{
-								type: 'rootProperty',
-								properties: {
-									property: 'models',
-								},
-							},
-							{
-								type: 'filter',
-								properties: {
-									pass: "={{ !$responseItem.name.includes('embedding') }}",
-								},
-							},
-							{
-								type: 'setKeyValue',
-								properties: {
-									name: '={{$responseItem.name}}',
-									value: '={{$responseItem.name}}',
-									description: '={{$responseItem.description}}',
-								},
-							},
-							{
-								type: 'sort',
-								properties: {
-									key: 'name',
-								},
-							},
-						],
-					},
-				},
-			},
+		return await this.nodeParametersService.getOptionsViaMethodName(
+			'getModels',
+			'parameters.modelName',
 			additionalData,
 			PROVIDER_NODE_TYPE_MAP.google,
 			{},
@@ -253,40 +216,9 @@ export class ChatHubModelsService {
 		credentials: INodeCredentials,
 		additionalData: IWorkflowExecuteAdditionalData,
 	): Promise<INodePropertyOptions[]> {
-		return await this.nodeParametersService.getOptionsViaLoadOptions(
-			{
-				// From Ollama Model node
-				// https://github.com/n8n-io/n8n/blob/master/packages/%40n8n/nodes-langchain/nodes/llms/LMOllama/description.ts#L24
-				routing: {
-					request: {
-						method: 'GET',
-						url: '/api/tags',
-					},
-					output: {
-						postReceive: [
-							{
-								type: 'rootProperty',
-								properties: {
-									property: 'models',
-								},
-							},
-							{
-								type: 'setKeyValue',
-								properties: {
-									name: '={{$responseItem.name}}',
-									value: '={{$responseItem.name}}',
-								},
-							},
-							{
-								type: 'sort',
-								properties: {
-									key: 'name',
-								},
-							},
-						],
-					},
-				},
-			},
+		return await this.nodeParametersService.getOptionsViaMethodName(
+			'getModels',
+			'parameters.model',
 			additionalData,
 			PROVIDER_NODE_TYPE_MAP.ollama,
 			{},
@@ -315,82 +247,18 @@ export class ChatHubModelsService {
 		credentials: INodeCredentials,
 		additionalData: IWorkflowExecuteAdditionalData,
 	): Promise<INodePropertyOptions[]> {
-		// From AWS Bedrock node
-		// https://github.com/n8n-io/n8n/blob/master/packages/%40n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts#L100
-		// https://github.com/n8n-io/n8n/blob/master/packages/%40n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts#L155
-		const foundationModelsRequest = this.nodeParametersService.getOptionsViaLoadOptions(
-			{
-				routing: {
-					request: {
-						method: 'GET',
-						url: '/foundation-models?&byOutputModality=TEXT&byInferenceType=ON_DEMAND',
-					},
-					output: {
-						postReceive: [
-							{
-								type: 'rootProperty',
-								properties: {
-									property: 'modelSummaries',
-								},
-							},
-							{
-								type: 'setKeyValue',
-								properties: {
-									name: '={{$responseItem.modelName}}',
-									description: '={{$responseItem.modelArn}}',
-									value: '={{$responseItem.modelId}}',
-								},
-							},
-							{
-								type: 'sort',
-								properties: {
-									key: 'name',
-								},
-							},
-						],
-					},
-				},
-			},
+		const foundationModelsRequest = this.nodeParametersService.getOptionsViaMethodName(
+			'getFoundationModels',
+			'parameters.model',
 			additionalData,
 			PROVIDER_NODE_TYPE_MAP.awsBedrock,
 			{},
 			credentials,
 		);
 
-		const inferenceProfileModelsRequest = this.nodeParametersService.getOptionsViaLoadOptions(
-			{
-				routing: {
-					request: {
-						method: 'GET',
-						url: '/inference-profiles?maxResults=1000',
-					},
-					output: {
-						postReceive: [
-							{
-								type: 'rootProperty',
-								properties: {
-									property: 'inferenceProfileSummaries',
-								},
-							},
-							{
-								type: 'setKeyValue',
-								properties: {
-									name: '={{$responseItem.inferenceProfileName}}',
-									description:
-										'={{$responseItem.description || $responseItem.inferenceProfileArn}}',
-									value: '={{$responseItem.inferenceProfileId}}',
-								},
-							},
-							{
-								type: 'sort',
-								properties: {
-									key: 'name',
-								},
-							},
-						],
-					},
-				},
-			},
+		const inferenceProfileModelsRequest = this.nodeParametersService.getOptionsViaMethodName(
+			'getInferenceProfiles',
+			'parameters.model',
 			additionalData,
 			PROVIDER_NODE_TYPE_MAP.awsBedrock,
 			{},
@@ -409,44 +277,9 @@ export class ChatHubModelsService {
 		credentials: INodeCredentials,
 		additionalData: IWorkflowExecuteAdditionalData,
 	): Promise<INodePropertyOptions[]> {
-		return await this.nodeParametersService.getOptionsViaLoadOptions(
-			{
-				routing: {
-					request: {
-						method: 'GET',
-						url: '/models',
-					},
-					output: {
-						postReceive: [
-							{
-								type: 'rootProperty',
-								properties: {
-									property: 'data',
-								},
-							},
-							{
-								type: 'filter',
-								properties: {
-									pass: "={{ !$responseItem.id.includes('embed') }}",
-								},
-							},
-							{
-								type: 'setKeyValue',
-								properties: {
-									name: '={{ $responseItem.id }}',
-									value: '={{ $responseItem.id }}',
-								},
-							},
-							{
-								type: 'sort',
-								properties: {
-									key: 'name',
-								},
-							},
-						],
-					},
-				},
-			},
+		return await this.nodeParametersService.getOptionsViaMethodName(
+			'getModels',
+			'parameters.model',
 			additionalData,
 			PROVIDER_NODE_TYPE_MAP.mistralCloud,
 			{},
@@ -458,39 +291,9 @@ export class ChatHubModelsService {
 		credentials: INodeCredentials,
 		additionalData: IWorkflowExecuteAdditionalData,
 	): Promise<INodePropertyOptions[]> {
-		return await this.nodeParametersService.getOptionsViaLoadOptions(
-			{
-				routing: {
-					request: {
-						method: 'GET',
-						url: '/v1/models?page_size=100&endpoint=chat',
-					},
-					output: {
-						postReceive: [
-							{
-								type: 'rootProperty',
-								properties: {
-									property: 'models',
-								},
-							},
-							{
-								type: 'setKeyValue',
-								properties: {
-									name: '={{$responseItem.name}}',
-									value: '={{$responseItem.name}}',
-									description: '={{$responseItem.description}}',
-								},
-							},
-							{
-								type: 'sort',
-								properties: {
-									key: 'name',
-								},
-							},
-						],
-					},
-				},
-			},
+		return await this.nodeParametersService.getOptionsViaMethodName(
+			'getModels',
+			'parameters.model',
 			additionalData,
 			PROVIDER_NODE_TYPE_MAP.cohere,
 			{},
@@ -502,38 +305,9 @@ export class ChatHubModelsService {
 		credentials: INodeCredentials,
 		additionalData: IWorkflowExecuteAdditionalData,
 	): Promise<INodePropertyOptions[]> {
-		return await this.nodeParametersService.getOptionsViaLoadOptions(
-			{
-				routing: {
-					request: {
-						method: 'GET',
-						url: '/models',
-					},
-					output: {
-						postReceive: [
-							{
-								type: 'rootProperty',
-								properties: {
-									property: 'data',
-								},
-							},
-							{
-								type: 'setKeyValue',
-								properties: {
-									name: '={{$responseItem.id}}',
-									value: '={{$responseItem.id}}',
-								},
-							},
-							{
-								type: 'sort',
-								properties: {
-									key: 'name',
-								},
-							},
-						],
-					},
-				},
-			},
+		return await this.nodeParametersService.getOptionsViaMethodName(
+			'getModels',
+			'parameters.model',
 			additionalData,
 			PROVIDER_NODE_TYPE_MAP.deepSeek,
 			{},
@@ -545,38 +319,9 @@ export class ChatHubModelsService {
 		credentials: INodeCredentials,
 		additionalData: IWorkflowExecuteAdditionalData,
 	): Promise<INodePropertyOptions[]> {
-		return await this.nodeParametersService.getOptionsViaLoadOptions(
-			{
-				routing: {
-					request: {
-						method: 'GET',
-						url: '/models',
-					},
-					output: {
-						postReceive: [
-							{
-								type: 'rootProperty',
-								properties: {
-									property: 'data',
-								},
-							},
-							{
-								type: 'setKeyValue',
-								properties: {
-									name: '={{$responseItem.id}}',
-									value: '={{$responseItem.id}}',
-								},
-							},
-							{
-								type: 'sort',
-								properties: {
-									key: 'name',
-								},
-							},
-						],
-					},
-				},
-			},
+		return await this.nodeParametersService.getOptionsViaMethodName(
+			'getModels',
+			'parameters.model',
 			additionalData,
 			PROVIDER_NODE_TYPE_MAP.openRouter,
 			{},
@@ -588,38 +333,9 @@ export class ChatHubModelsService {
 		credentials: INodeCredentials,
 		additionalData: IWorkflowExecuteAdditionalData,
 	): Promise<INodePropertyOptions[]> {
-		return await this.nodeParametersService.getOptionsViaLoadOptions(
-			{
-				routing: {
-					request: {
-						method: 'GET',
-						url: '/models',
-					},
-					output: {
-						postReceive: [
-							{
-								type: 'rootProperty',
-								properties: {
-									property: 'data',
-								},
-							},
-							{
-								type: 'filter',
-								properties: {
-									pass: '={{ $responseItem.active === true && $responseItem.object === "model" }}',
-								},
-							},
-							{
-								type: 'setKeyValue',
-								properties: {
-									name: '={{$responseItem.id}}',
-									value: '={{$responseItem.id}}',
-								},
-							},
-						],
-					},
-				},
-			},
+		return await this.nodeParametersService.getOptionsViaMethodName(
+			'getModels',
+			'parameters.model',
 			additionalData,
 			PROVIDER_NODE_TYPE_MAP.groq,
 			{},
@@ -631,38 +347,9 @@ export class ChatHubModelsService {
 		credentials: INodeCredentials,
 		additionalData: IWorkflowExecuteAdditionalData,
 	): Promise<INodePropertyOptions[]> {
-		return await this.nodeParametersService.getOptionsViaLoadOptions(
-			{
-				routing: {
-					request: {
-						method: 'GET',
-						url: '/models',
-					},
-					output: {
-						postReceive: [
-							{
-								type: 'rootProperty',
-								properties: {
-									property: 'data',
-								},
-							},
-							{
-								type: 'setKeyValue',
-								properties: {
-									name: '={{$responseItem.id}}',
-									value: '={{$responseItem.id}}',
-								},
-							},
-							{
-								type: 'sort',
-								properties: {
-									key: 'name',
-								},
-							},
-						],
-					},
-				},
-			},
+		return await this.nodeParametersService.getOptionsViaMethodName(
+			'getModels',
+			'parameters.model',
 			additionalData,
 			PROVIDER_NODE_TYPE_MAP.xAiGrok,
 			{},
@@ -674,38 +361,9 @@ export class ChatHubModelsService {
 		credentials: INodeCredentials,
 		additionalData: IWorkflowExecuteAdditionalData,
 	): Promise<INodePropertyOptions[]> {
-		return await this.nodeParametersService.getOptionsViaLoadOptions(
-			{
-				routing: {
-					request: {
-						method: 'GET',
-						url: '/models',
-					},
-					output: {
-						postReceive: [
-							{
-								type: 'rootProperty',
-								properties: {
-									property: 'data',
-								},
-							},
-							{
-								type: 'setKeyValue',
-								properties: {
-									name: '={{$responseItem.id}}',
-									value: '={{$responseItem.id}}',
-								},
-							},
-							{
-								type: 'sort',
-								properties: {
-									key: 'name',
-								},
-							},
-						],
-					},
-				},
-			},
+		return await this.nodeParametersService.getOptionsViaMethodName(
+			'getModels',
+			'parameters.model',
 			additionalData,
 			PROVIDER_NODE_TYPE_MAP.vercelAiGateway,
 			{},

--- a/packages/cli/src/modules/chat-hub/chat-hub.models.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.models.service.ts
@@ -8,7 +8,7 @@ import {
 	type ChatModelsResponse,
 } from '@n8n/api-types';
 import { In, WorkflowRepository, type User, type WorkflowEntity } from '@n8n/db';
-import { Container, Service } from '@n8n/di';
+import { Service } from '@n8n/di';
 import {
 	CHAT_TRIGGER_NODE_TYPE,
 	type INodeCredentials,
@@ -26,7 +26,6 @@ import { DynamicNodeParametersService } from '@/services/dynamic-node-parameters
 import { getBase } from '@/workflow-execute-additional-data';
 import { WorkflowService } from '@/workflows/workflow.service';
 import { Scope } from '@n8n/permissions';
-import { Logger } from '@n8n/backend-common';
 
 @Service()
 export class ChatHubModelsService {


### PR DESCRIPTION
## Summary

This PR implements the method to list available models in langchain nodes to replace the current approach based on API endpoint details specified in the node parameter's `typeOptions.loadOptions.routing` property.

This makes it possible for ChatHub module in CLI package to list models without repeating the same endpoint details specified in the langchain node itself, without introducing CLI → @n8n/nodes-langchain dependency.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
