### PR TITLE
fix: Add support for DeepSeek reasoning_content in tool calling

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/interfaces.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/interfaces.ts
@@ -53,22 +53,23 @@ export type ChatCompletion = {
 	object: string;
 	created: number;
 	model: string;
-	choices: Array<{
-		index: number;
-		message: {
-			role: string;
-			content: string;
-			tool_calls?: Array<{
-				id: string;
-				type: 'function';
-				function: {
-					name: string;
-					arguments: string;
-				};
-			}>;
-		};
-		finish_reason?: 'tool_calls';
-	}>;
+		choices: Array<{
+			index: number;
+			message: {
+				role: string;
+				content: string;
+				reasoning_content?: string;
+				tool_calls?: Array<{
+					id: string;
+					type: 'function';
+					function: {
+						name: string;
+						arguments: string;
+					};
+				}>;
+			};
+			finish_reason?: 'tool_calls';
+		}>;
 	usage: {
 		prompt_tokens: number;
 		completion_tokens: number;

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
@@ -22,6 +22,8 @@ interface ProviderMetadata {
 	thinkingType?: 'thinking' | 'redacted_thinking';
 	/** Anthropic thinking signature */
 	thinkingSignature?: string;
+	/** DeepSeek reasoning_content */
+	reasoningContent?: string;
 }
 
 /**
@@ -57,11 +59,17 @@ function extractProviderMetadata(metadata?: RequestResponseMetadata): ProviderMe
 			? metadata.anthropic.thinkingSignature
 			: undefined;
 
+	const reasoningContent =
+		typeof metadata.deepseek?.reasoningContent === 'string'
+			? metadata.deepseek.reasoningContent
+			: undefined;
+
 	return {
 		thoughtSignature,
 		thinkingContent,
 		thinkingType,
 		thinkingSignature,
+		reasoningContent,
 	};
 }
 
@@ -197,11 +205,11 @@ export function buildSteps(
 			// Extract provider-specific metadata (Gemini, Anthropic, etc.)
 			const providerMetadata = extractProviderMetadata(tool.action.metadata);
 
-			// Build tool ID and name for reuse
+		// Build tool ID and name for reuse
 			const toolId = typeof toolInput?.id === 'string' ? toolInput.id : 'reconstructed_call';
 			const toolName = nodeNameToToolName(tool.action.nodeName);
 
-			// Build the tool call object with thought_signature if present (for Gemini)
+		// Build tool call object with thought_signature (for Gemini) and reasoning_content (for DeepSeek)
 			const toolCall = {
 				id: toolId,
 				name: toolName,
@@ -210,6 +218,9 @@ export function buildSteps(
 				additional_kwargs: {
 					...(providerMetadata.thoughtSignature && {
 						thought_signature: providerMetadata.thoughtSignature,
+					}),
+					...(providerMetadata.reasoningContent && {
+						reasoning_content: providerMetadata.reasoningContent,
 					}),
 				},
 			};

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/createEngineRequests.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/createEngineRequests.ts
@@ -74,9 +74,9 @@ export async function createEngineRequests(
 									thinkingType = 'redacted_thinking';
 								}
 							}
-						} else if (message && 'reasoning_content' in message) {
+						} else if (message && 'reasoning_content' in message && typeof message.reasoning_content === 'string') {
 							// DeepSeek reasoning_content field
-							reasoningContent = message.reasoning_content as string;
+							reasoningContent = message.reasoning_content;
 						}
 						if (thoughtSignature || thinkingContent || reasoningContent) break;
 					}

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/createEngineRequests.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/createEngineRequests.ts
@@ -46,10 +46,12 @@ export async function createEngineRequests(
 			let thinkingContent: string | undefined;
 			let thinkingType: 'thinking' | 'redacted_thinking' | undefined;
 			let thinkingSignature: string | undefined;
+		// Extract reasoning_content from AIMessage (for DeepSeek)
+			let reasoningContent: string | undefined;
 
 			if (toolCall.messageLog && Array.isArray(toolCall.messageLog)) {
 				for (const message of toolCall.messageLog) {
-					// Check if message has content that could contain thought_signature or thinking blocks
+					// Check if message has content that could contain thought_signature, thinking blocks, or reasoning_content
 					if (message && typeof message === 'object' && 'content' in message) {
 						const content = message.content;
 						// Content can be string or array of content blocks
@@ -72,8 +74,11 @@ export async function createEngineRequests(
 									thinkingType = 'redacted_thinking';
 								}
 							}
+						} else if (message && 'reasoning_content' in message) {
+							// DeepSeek reasoning_content field
+							reasoningContent = message.reasoning_content as string;
 						}
-						if (thoughtSignature || thinkingContent) break;
+						if (thoughtSignature || thinkingContent || reasoningContent) break;
 					}
 				}
 			}
@@ -96,6 +101,11 @@ export async function createEngineRequests(
 							thinkingContent,
 							thinkingType,
 							thinkingSignature,
+						},
+					}),
+					...(reasoningContent && {
+						deepseek: {
+							reasoningContent,
 						},
 					}),
 				},


### PR DESCRIPTION
## Summary
Fixes #22579 - DeepSeek Reasoner tool-use now works with n8n

DeepSeek's thinking mode (introduced in V3.2 on Dec 1, 2025) requires the `reasoning_content` field to be preserved and sent back when resuming tool calls. Previously, n8n was dropping this field during tool execution, causing HTTP 400 errors with "Missing reasoning_content" message.

## Changes
- **interfaces.ts**: Added `reasoning_content?: string` field to ChatCompletion message type
- **createEngineRequests.ts**: Extract and preserve `reasoning_content` from DeepSeek messages, pass through metadata
- **buildSteps.ts**: Include `reasoning_content` in provider metadata and tool call additional_kwargs

## Technical Details
When DeepSeek's reasoning model makes tool calls, it outputs:
- `reasoning_content`: The chain-of-thought reasoning 
- `content`: The final answer (empty during tool calls)
- `tool_calls`: The tool invocations

During multi-turn tool execution, the assistant message (with tool_calls) must be re-sent with its original `reasoning_content` so the model can continue reasoning. Without this, DeepSeek returns HTTP 400.

## Testing
This fix ensures n8n correctly handles DeepSeek's thinking mode tool calling by:
1. Accepting `reasoning_content` in API responses
2. Preserving it through the tool execution flow
3. Re-sending it on subsequent requests to continue the reasoning chain

Fixes #22579