### PR TITLE
  fix(core): Allow workflows with deprecated Start nodes to activate at startup

### DIFF
--- a/packages/cli/test/integration/active-workflow-manager.test.ts
+++ b/packages/cli/test/integration/active-workflow-manager.test.ts
@@ -277,8 +277,8 @@ describe('add()', () => {
 				expect(addWebhooksSpy).toHaveBeenCalledTimes(1);
 				expect(addTriggersAndPollersSpy).toHaveBeenCalledTimes(1);
 
-				if (!(argWorkflow instanceof Workflow)) fail();
-				if (!(_argWorkflow instanceof Workflow)) fail();
+				expect(argWorkflow).toBeInstanceOf(Workflow);
+				expect(_argWorkflow).toBeInstanceOf(Workflow);
 
 				expect(argWorkflow.id).toBe(dbWorkflow.id);
 				expect(_argWorkflow.id).toBe(dbWorkflow.id);

--- a/packages/cli/test/integration/active-workflow-manager.test.ts
+++ b/packages/cli/test/integration/active-workflow-manager.test.ts
@@ -140,6 +140,36 @@ describe('init()', () => {
 
 		expect(validateWorkflowHasTriggerLikeNodeSpy).toHaveBeenCalledTimes(2);
 	});
+
+	it('should activate workflow with deprecated Start node during init', async () => {
+		// Create a workflow with a deprecated Start node and a trigger
+		const dbWorkflow = await createActiveWorkflow({
+			nodes: [
+				{
+					id: 'uuid-start',
+					parameters: {},
+					name: 'Start',
+					type: 'n8n-nodes-base.start',
+					typeVersion: 1,
+					position: [250, 300],
+				},
+				{
+					id: 'uuid-trigger',
+					parameters: {},
+					name: 'Schedule Trigger',
+					type: 'n8n-nodes-base.scheduleTrigger',
+					typeVersion: 1,
+					position: [500, 300],
+				},
+			],
+		});
+
+		await activeWorkflowManager.init();
+
+		// Workflow should be activated despite having a Start node
+		expect(activeWorkflowManager.allActiveInMemory()).toHaveLength(1);
+		expect(activeWorkflowManager.allActiveInMemory()).toContain(dbWorkflow.id);
+	});
 });
 
 describe('add()', () => {

--- a/packages/cli/test/integration/active-workflow-manager.test.ts
+++ b/packages/cli/test/integration/active-workflow-manager.test.ts
@@ -143,7 +143,7 @@ describe('init()', () => {
 
 	it('should activate workflow with deprecated Start node during init', async () => {
 		// Create a workflow with a deprecated Start node and a trigger
-		const dbWorkflow = await createActiveWorkflow({
+		await createActiveWorkflow({
 			nodes: [
 				{
 					id: 'uuid-start',
@@ -222,7 +222,7 @@ describe('init()', () => {
 	});
 
 	it('should not filter disabled Start nodes from nodes array', async () => {
-		const dbWorkflow = await createActiveWorkflow({
+		await createActiveWorkflow({
 			nodes: [
 				{
 					id: 'uuid-start',

--- a/packages/cli/test/integration/active-workflow-manager.test.ts
+++ b/packages/cli/test/integration/active-workflow-manager.test.ts
@@ -142,7 +142,6 @@ describe('init()', () => {
 	});
 
 	it('should activate workflow with deprecated Start node during init', async () => {
-		// Create a workflow with a deprecated Start node and a trigger
 		const dbWorkflow = await createActiveWorkflow({
 			nodes: [
 				{
@@ -166,7 +165,6 @@ describe('init()', () => {
 
 		await activeWorkflowManager.init();
 
-		// Workflow should be activated despite having a Start node
 		expect(activeWorkflowManager.allActiveInMemory()).toHaveLength(1);
 		expect(activeWorkflowManager.allActiveInMemory()).toContain(dbWorkflow.id);
 	});
@@ -204,19 +202,15 @@ describe('init()', () => {
 
 		expect(addSpy).toHaveBeenCalled();
 
-		// Verify the workflow was modified and activated
 		const [workflowId, activationMode, existingWorkflow] = addSpy.mock.calls[0];
 		expect(workflowId).toBe(dbWorkflow.id);
 		expect(activationMode).toBe('init');
 
-		// After filtering, the workflow should only have the Schedule Trigger (Start was removed)
 		expect(existingWorkflow).toBeDefined();
 		expect(existingWorkflow!.nodes).toHaveLength(1);
 		expect(existingWorkflow!.nodes[0].type).toBe('n8n-nodes-base.scheduleTrigger');
-		// Connections from Start should also be removed
 		expect(existingWorkflow!.connections.Start).toBeUndefined();
 
-		// Workflow should be active in memory
 		expect(activeWorkflowManager.allActiveInMemory()).toContain(dbWorkflow.id);
 	});
 
@@ -230,7 +224,7 @@ describe('init()', () => {
 					type: 'n8n-nodes-base.start',
 					typeVersion: 1,
 					position: [250, 300],
-					disabled: true, // Disabled Start node
+					disabled: true,
 				},
 				{
 					id: 'uuid-trigger',
@@ -247,10 +241,8 @@ describe('init()', () => {
 
 		await activeWorkflowManager.init();
 
-		// Verify disabled Start node was NOT filtered out
 		const [, , existingWorkflow] = addSpy.mock.calls[0];
 		expect(existingWorkflow).toBeDefined();
-		// Both nodes should still be in the array (disabled Start is not filtered)
 		expect(existingWorkflow!.nodes).toHaveLength(2);
 		const startNode = existingWorkflow!.nodes.find((n) => n.name === 'Start');
 		expect(startNode).toBeDefined();

--- a/packages/cli/test/integration/active-workflow-manager.test.ts
+++ b/packages/cli/test/integration/active-workflow-manager.test.ts
@@ -210,12 +210,11 @@ describe('init()', () => {
 		expect(activationMode).toBe('init');
 
 		// After filtering, the workflow should only have the Schedule Trigger (Start was removed)
-		if (existingWorkflow) {
-			expect(existingWorkflow.nodes).toHaveLength(1);
-			expect(existingWorkflow.nodes[0].type).toBe('n8n-nodes-base.scheduleTrigger');
-			// Connections from Start should also be removed
-			expect(existingWorkflow.connections.Start).toBeUndefined();
-		}
+		expect(existingWorkflow).toBeDefined();
+		expect(existingWorkflow!.nodes).toHaveLength(1);
+		expect(existingWorkflow!.nodes[0].type).toBe('n8n-nodes-base.scheduleTrigger');
+		// Connections from Start should also be removed
+		expect(existingWorkflow!.connections.Start).toBeUndefined();
 
 		// Workflow should be active in memory
 		expect(activeWorkflowManager.allActiveInMemory()).toContain(dbWorkflow.id);
@@ -250,13 +249,12 @@ describe('init()', () => {
 
 		// Verify disabled Start node was NOT filtered out
 		const [, , existingWorkflow] = addSpy.mock.calls[0];
-		if (existingWorkflow) {
-			// Both nodes should still be in the array (disabled Start is not filtered)
-			expect(existingWorkflow.nodes).toHaveLength(2);
-			const startNode = existingWorkflow.nodes.find((n) => n.name === 'Start');
-			expect(startNode).toBeDefined();
-			expect(startNode?.disabled).toBe(true);
-		}
+		expect(existingWorkflow).toBeDefined();
+		// Both nodes should still be in the array (disabled Start is not filtered)
+		expect(existingWorkflow!.nodes).toHaveLength(2);
+		const startNode = existingWorkflow!.nodes.find((n) => n.name === 'Start');
+		expect(startNode).toBeDefined();
+		expect(startNode!.disabled).toBe(true);
 	});
 });
 

--- a/packages/cli/test/integration/active-workflow-manager.test.ts
+++ b/packages/cli/test/integration/active-workflow-manager.test.ts
@@ -143,7 +143,7 @@ describe('init()', () => {
 
 	it('should activate workflow with deprecated Start node during init', async () => {
 		// Create a workflow with a deprecated Start node and a trigger
-		await createActiveWorkflow({
+		const dbWorkflow = await createActiveWorkflow({
 			nodes: [
 				{
 					id: 'uuid-start',


### PR DESCRIPTION
## Summary

  Fixes workflow activation failures caused by deprecated Start nodes. Workflows that contain both a Start node and another trigger (Cron, Schedule, Webhook, etc.) can now activate successfully via their other triggers, preventing unnecessary workflow breakage during the Start node deprecation transition.

  ## Problem

  After PR #23183 removed the Start node from `package.json`, workflows containing Start nodes fail to activate with "Unrecognized node type: n8n-nodes-base.start" errors.

  This affects workflows that have:
  - A deprecated Start node (used for manual execution)
  - **AND** another valid trigger (Cron, Schedule, Webhook, etc.)

  Without this fix, these workflows fail to activate entirely, even though they have a valid trigger and could work perfectly fine. This creates a poor user experience and breaks functioning workflows unnecessarily.

## Related Linear tickets, Github issues, and Community forum posts

See context here -> https://n8nio.slack.com/archives/C069KJBJ8HE/p1766778124751229

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
