### PR TITLE
fix(editor): Fix NDV state getting stale when navigating using the floating buttons

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/AssignmentCollection/AssignmentCollection.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/AssignmentCollection/AssignmentCollection.vue
@@ -2,6 +2,7 @@
 import { useDebounce } from '@/app/composables/useDebounce';
 import { useI18n } from '@n8n/i18n';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import isEqual from 'lodash/isEqual';
 import type {
 	AssignmentCollectionValue,
 	AssignmentValue,
@@ -87,9 +88,11 @@ const actions = computed(() => {
 });
 
 watch(
-	() => props.node?.name,
+	() => props.node,
 	() => {
-		state.paramValue = createParamValue(props.value);
+		const newParamValue = createParamValue(props.value);
+		if (isEqual(state.paramValue, newParamValue)) return;
+		state.paramValue = newParamValue;
 	},
 );
 


### PR DESCRIPTION
## Summary

There was a similar issue in the FilterCondition component used in the If node where local component state was not being updated when switching to an empty node.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4573/set-node-detail-panel-doesnt-change-when-navigating-using-buttons-on

https://www.loom.com/share/0a6a2c1c0a8249f98a89a57e0872412e


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
