### PR TITLE
fix(editor): Correct hosted chat font family defaults

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/constants.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/constants.ts
@@ -20,17 +20,7 @@ export const cssVariables = `
   --chat--spacing: 1rem;
   --chat--border-radius: 0.25rem;
   --chat--transition-duration: 0.15s;
-  --chat--font-family: (
-    -apple-system,
-    BlinkMacSystemFont,
-    'Segoe UI',
-    Roboto,
-    Oxygen-Sans,
-    Ubuntu,
-    Cantarell,
-    'Helvetica Neue',
-    sans-serif
-  );
+  --chat--font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
 
   /* Window Dimensions */
   --chat--window--width: 400px;

--- a/packages/frontend/@n8n/chat/src/css/_tokens.scss
+++ b/packages/frontend/@n8n/chat/src/css/_tokens.scss
@@ -18,17 +18,9 @@
 	--chat--spacing: 1rem;
 	--chat--border-radius: 0.25rem;
 	--chat--transition-duration: 0.15s;
-	--chat--font-family: (
-		-apple-system,
-		BlinkMacSystemFont,
-		'Segoe UI',
-		Roboto,
-		Oxygen-Sans,
-		Ubuntu,
-		Cantarell,
-		'Helvetica Neue',
-		sans-serif
-	);
+	--chat--font-family:
+		-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell,
+		'Helvetica Neue', sans-serif;
 
 	/* Window Dimensions */
 	--chat--window--width: 400px;


### PR DESCRIPTION
## Summary
Fixes a CSS error with the default value of `--chat--font-family` variable that made the hosted chat to fallback to a wrong font.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-1840/community-issue-bug-invalid-css-syntax-in-chat-nodewidget-causes-font


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
