### PR TITLE
fix(editor): Keep focus in canvas chat after sending a message

### DIFF
--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsOverviewRow.vue
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsOverviewRow.vue
@@ -100,7 +100,15 @@ watch(
 	(isSelected) => {
 		void nextTick(() => {
 			if (isSelected) {
-				container.value?.focus();
+				// Don't steal focus if the chat input is currently focused
+				const activeElement = document.activeElement;
+				const isChatInputFocused =
+					activeElement?.getAttribute('data-test-id') === 'chat-input' ||
+					activeElement?.closest('[data-test-id="canvas-chat"]') !== null;
+
+				if (!isChatInputFocused) {
+					container.value?.focus();
+				}
 			}
 		});
 	},


### PR DESCRIPTION
## Summary
This PR fixes an issue where the logs panel steals the focus from the canvas chat input field after an execution completes.  


## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-1846/community-issue-chatgpt-说：-the-text-insertion-cursor-loses-focus-after


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
