### PR TITLE
fix: Return null if no last successful execution exists instead of 404

### DIFF
--- a/packages/cli/src/workflows/__tests__/workflows.controller.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflows.controller.test.ts
@@ -9,7 +9,6 @@ import { mock } from 'jest-mock-extended';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
-import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import type { ExecutionService } from '@/executions/execution.service';
 import type { CredentialsService } from '@/credentials/credentials.service';
 import type { EnterpriseWorkflowService } from '@/workflows/workflow.service.ee';
@@ -162,7 +161,7 @@ describe('WorkflowsController', () => {
 			expect(executionService.getLastSuccessfulExecution).toHaveBeenCalledWith(workflowId);
 		});
 
-		it('should throw NotFoundError when no successful execution exists', async () => {
+		it('should return null when no successful execution exists', async () => {
 			/**
 			 * Arrange
 			 */
@@ -172,11 +171,14 @@ describe('WorkflowsController', () => {
 			controller.executionService = executionService;
 
 			/**
-			 * Act & Assert
+			 * Act
 			 */
-			await expect(controller.getLastSuccessfulExecution(req, res, workflowId)).rejects.toThrow(
-				NotFoundError,
-			);
+			const result = await controller.getLastSuccessfulExecution(req, res, workflowId);
+
+			/**
+			 * Assert
+			 */
+			expect(result).toBeNull();
 			expect(executionService.getLastSuccessfulExecution).toHaveBeenCalledWith(workflowId);
 		});
 	});

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -704,11 +704,7 @@ export class WorkflowsController {
 	) {
 		const lastExecution = await this.executionService.getLastSuccessfulExecution(workflowId);
 
-		if (lastExecution === undefined) {
-			throw new NotFoundError('No successful execution found for the workflow');
-		}
-
-		return lastExecution;
+		return lastExecution ?? null;
 	}
 
 	@Post('/with-node-types')

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -4009,13 +4009,13 @@ describe('GET /workflows/:workflowId/executions/last-successful', () => {
 		});
 	});
 
-	test('should return 404 when no successful execution exists', async () => {
+	test('should return 200 with null when no successful execution exists', async () => {
 		const workflow = await createWorkflow({}, owner);
 
 		const response = await authOwnerAgent
 			.get(`/workflows/${workflow.id}/executions/last-successful`)
-			.expect(404);
+			.expect(200);
 
-		expect(response.body.message).toBe('No successful execution found for the workflow');
+		expect(response.body.data).toBeNull();
 	});
 });

--- a/packages/frontend/editor-ui/src/app/api/workflows.test.ts
+++ b/packages/frontend/editor-ui/src/app/api/workflows.test.ts
@@ -49,21 +49,18 @@ describe('API: workflows', () => {
 			expect(result).toEqual(mockResponse);
 		});
 
-		it('should handle 404 error when no successful execution exists', async () => {
+		it('should return null when no successful execution exists', async () => {
 			const workflowId = 'workflow-no-success';
-			const error = {
-				httpStatusCode: 404,
-				message: 'No successful execution found for the workflow',
-			};
-			makeRestApiRequestSpy.mockRejectedValue(error);
+			makeRestApiRequestSpy.mockResolvedValue(null);
 
-			await expect(getLastSuccessfulExecution(mockContext, workflowId)).rejects.toEqual(error);
+			const result = await getLastSuccessfulExecution(mockContext, workflowId);
 
 			expect(makeRestApiRequestSpy).toHaveBeenCalledWith(
 				mockContext,
 				'GET',
 				`/workflows/${workflowId}/executions/last-successful`,
 			);
+			expect(result).toBeNull();
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Changes the last successful execution endpoint to return null instead of a 404 error when no successful execution is found for a workflow.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1996/return-null-instead-of-404-for-last-successful-endpoint-when-no#comment-cadcf790


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
