### PR TITLE
feat(ClickUp): Add support for group assignees in task management

### DIFF
--- a/packages/nodes-base/nodes/ClickUp/ClickUp.node.ts
+++ b/packages/nodes-base/nodes/ClickUp/ClickUp.node.ts
@@ -297,10 +297,31 @@ export class ClickUp implements INodeType {
 				const { members } = await clickupApiRequest.call(this, 'GET', url);
 				for (const member of members) {
 					const memberName = member.username;
-					const menberId = member.id;
+					const memberId = member.id;
 					returnData.push({
 						name: memberName,
-						value: menberId,
+						value: memberId,
+					});
+				}
+				return returnData;
+			},
+			async getGroups(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+				const teamId = this.getCurrentNodeParameter('team') as string;
+				const returnData: INodePropertyOptions[] = [];
+				let url: string;
+				if (teamId) {
+					url = `/group?team_id=${teamId}`;
+				} else {
+					return returnData;
+				}
+
+				const { groups } = await clickupApiRequest.call(this, 'GET', url);
+				for (const g of groups) {
+					const groupName = g.name;
+					const groupId = g.id;
+					returnData.push({
+						name: groupName,
+						value: groupId,
 					});
 				}
 				return returnData;
@@ -894,6 +915,9 @@ export class ClickUp implements INodeType {
 						if (additionalFields.assignees) {
 							body.assignees = additionalFields.assignees as string[];
 						}
+						if (additionalFields.group_assignees) {
+							body.group_assignees = additionalFields.group_assignees as string[];
+						}
 						if (additionalFields.tags) {
 							body.tags = additionalFields.tags as string[];
 						}
@@ -935,6 +959,10 @@ export class ClickUp implements INodeType {
 						const updateFields = this.getNodeParameter('updateFields', i);
 						const body: ITask = {
 							assignees: {
+								add: [],
+								rem: [],
+							},
+							group_assignees: {
 								add: [],
 								rem: [],
 							},
@@ -980,6 +1008,14 @@ export class ClickUp implements INodeType {
 							body.assignees.rem = (updateFields.removeAssignees as string)
 								.split(',')
 								.map((e: string) => parseInt(e, 10));
+						}
+						if (updateFields.addGroupAssignees) {
+							//@ts-ignore
+							body.group_assignees.add = (updateFields.addGroupAssignees as string).split(',');
+						}
+						if (updateFields.removeGroupAssignees) {
+							//@ts-ignore
+							body.group_assignees.rem = (updateFields.removeGroupAssignees as string).split(',');
 						}
 						if (updateFields.status) {
 							body.status = updateFields.status as string;

--- a/packages/nodes-base/nodes/ClickUp/TaskDescription.ts
+++ b/packages/nodes-base/nodes/ClickUp/TaskDescription.ts
@@ -220,7 +220,7 @@ export const taskFields: INodeProperties[] = [
 					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'getGroups',
-					loadOptionsDependsOn: ['list'],
+					loadOptionsDependsOn: ['team'],
 				},
 				default: [],
 			},

--- a/packages/nodes-base/nodes/ClickUp/TaskDescription.ts
+++ b/packages/nodes-base/nodes/ClickUp/TaskDescription.ts
@@ -213,6 +213,18 @@ export const taskFields: INodeProperties[] = [
 				default: [],
 			},
 			{
+				displayName: 'User Groups Assignee Names or IDs',
+				name: 'group_assignees',
+				type: 'multiOptions',
+				description:
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: {
+					loadOptionsMethod: 'getGroups',
+					loadOptionsDependsOn: ['list'],
+				},
+				default: [],
+			},
+			{
 				displayName: 'Custom Fields JSON',
 				name: 'customFieldsJson',
 				type: 'json',
@@ -351,7 +363,14 @@ export const taskFields: INodeProperties[] = [
 				name: 'addAssignees',
 				type: 'string',
 				default: '',
-				description: 'Assignees IDs. Multiple ca be added separated by comma.',
+				description: 'Assignees IDs. Multiple can be added separated by comma.',
+			},
+			{
+				displayName: 'Add User Groups Assignees',
+				name: 'addGroupAssignees',
+				type: 'string',
+				default: '',
+				description: 'Group Assignees IDs. Multiple can be added separated by comma.',
 			},
 			{
 				displayName: 'Content',
@@ -411,7 +430,14 @@ export const taskFields: INodeProperties[] = [
 				name: 'removeAssignees',
 				type: 'string',
 				default: '',
-				description: 'Assignees IDs. Multiple ca be added separated by comma.',
+				description: 'Assignees IDs. Multiple can be added separated by comma.',
+			},
+			{
+				displayName: 'Remove Group Users Assignees',
+				name: 'removeGroupAssignees',
+				type: 'string',
+				default: '',
+				description: 'Group Assignees IDs. Multiple can be added separated by comma.',
 			},
 			{
 				displayName: 'Status',

--- a/packages/nodes-base/nodes/ClickUp/TaskInterface.ts
+++ b/packages/nodes-base/nodes/ClickUp/TaskInterface.ts
@@ -4,6 +4,7 @@ export interface ITask {
 	name?: string;
 	content?: string;
 	assignees?: string[] | IDataObject;
+	group_assignees?: string[] | IDataObject;
 	tags?: string[];
 	status?: string;
 	priority?: number;


### PR DESCRIPTION
## Summary

Current ClickUp implementation allows assigning tasks only to users. This PR is intended to add the possibility of tagging user groups defined in ClickUp. The implemented edits take inspiration from the code used to assign single users.

To test the functionality when creating a task:
- Add a "Create Task" clickup node
- Configure as usual (team name or team ID mandatory)
- In the "Additional Fields" section, select a group from the dropdown (to use expressions, add an array of group IDs as strings)
- Run the node

To test the functionality when updating a task:
- Add a "Update Task" clickup node
- Configure it as usual
- In the "Update Fields" section select Add Group Users Assignees (or Remove Group Users Assignees)
- Fill the textbox with group IDs separated by comma
- Run the node

## Side fixes
Fixed 2 typos in the implementation:
- Assignee memberId variable was "menberId"
- Assignee description contained "ca" instead of "can"

## Screenshots
<img width="447" height="975" alt="image" src="https://github.com/user-attachments/assets/1e91f4c1-0123-434b-b780-fa0496ed7123" />

_Create task dropdown_

<img width="415" height="410" alt="image" src="https://github.com/user-attachments/assets/be92d1a9-875b-4439-b8b8-a2ee2bf67cc1" />

_Update task textbox_

