### PR TITLE
chore(editor): Address Vue warnings

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nActionBox/ActionBox.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nActionBox/ActionBox.vue
@@ -53,12 +53,11 @@ withDefaults(defineProps<ActionBoxProps>(), {
 				</slot>
 			</N8nText>
 		</div>
-		<N8nTooltip :disabled="!buttonDisabled">
+		<N8nTooltip v-if="buttonText" :disabled="!buttonDisabled">
 			<template #content>
 				<slot name="disabledButtonTooltip"></slot>
 			</template>
 			<N8nButton
-				v-if="buttonText"
 				:label="buttonText"
 				:type="buttonType"
 				:disabled="buttonDisabled"

--- a/packages/frontend/@n8n/design-system/src/v2/components/DropdownMenu/DropdownMenu.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/v2/components/DropdownMenu/DropdownMenu.stories.ts
@@ -29,7 +29,6 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Basic: Story = {
-	// @ts-expect-error generic typed components https://github.com/storybookjs/storybook/issues/24238
 	render: (args) => ({
 		components: { DropdownMenu },
 		setup() {
@@ -60,7 +59,6 @@ export const Basic: Story = {
 };
 
 export const WithCustomTrigger: Story = {
-	// @ts-expect-error generic typed components https://github.com/storybookjs/storybook/issues/24238
 	render: (args) => ({
 		components: { DropdownMenu, N8nButton },
 		setup() {
@@ -102,7 +100,6 @@ export const WithCustomTrigger: Story = {
 };
 
 export const EmojiActivator: Story = {
-	// @ts-expect-error generic typed components https://github.com/storybookjs/storybook/issues/24238
 	render: (args) => ({
 		components: { DropdownMenu },
 		setup() {
@@ -130,7 +127,6 @@ export const EmojiActivator: Story = {
 };
 
 export const WithCheckedItems: Story = {
-	// @ts-expect-error generic typed components https://github.com/storybookjs/storybook/issues/24238
 	render: (args) => ({
 		components: { DropdownMenu },
 		setup() {
@@ -155,7 +151,6 @@ export const WithCheckedItems: Story = {
 };
 
 export const WithDisabledItems: Story = {
-	// @ts-expect-error generic typed components https://github.com/storybookjs/storybook/issues/24238
 	render: (args) => ({
 		components: { DropdownMenu },
 		setup() {
@@ -185,7 +180,6 @@ export const WithDisabledItems: Story = {
 };
 
 export const WithBadgesAndShortcuts: Story = {
-	// @ts-expect-error generic typed components https://github.com/storybookjs/storybook/issues/24238
 	render: (args) => ({
 		components: { DropdownMenu, N8nBadge, N8nKeyboardShortcut },
 		setup() {
@@ -235,7 +229,6 @@ export const WithBadgesAndShortcuts: Story = {
 };
 
 export const WithCustomLeadingSlot: Story = {
-	// @ts-expect-error generic typed components https://github.com/storybookjs/storybook/issues/24238
 	render: (args) => ({
 		components: { DropdownMenu, N8nCheckbox },
 		setup() {
@@ -287,7 +280,6 @@ export const WithCustomLeadingSlot: Story = {
 };
 
 export const LoadingState: Story = {
-	// @ts-expect-error generic typed components https://github.com/storybookjs/storybook/issues/24238
 	render: (args) => ({
 		components: { DropdownMenu },
 		setup() {
@@ -311,7 +303,6 @@ export const LoadingState: Story = {
 };
 
 export const Placements: Story = {
-	// @ts-expect-error generic typed components https://github.com/storybookjs/storybook/issues/24238
 	render: (args) => ({
 		components: { DropdownMenu, N8nButton },
 		setup() {
@@ -354,7 +345,6 @@ export const Placements: Story = {
 };
 
 export const ControlledState: Story = {
-	// @ts-expect-error generic typed components https://github.com/storybookjs/storybook/issues/24238
 	render: (args) => ({
 		components: { DropdownMenu, N8nButton },
 		setup() {
@@ -394,7 +384,6 @@ export const ControlledState: Story = {
 };
 
 export const NestedMenu: Story = {
-	// @ts-expect-error generic typed components https://github.com/storybookjs/storybook/issues/24238
 	render: (args) => ({
 		components: { DropdownMenu },
 		setup() {
@@ -445,7 +434,6 @@ export const NestedMenu: Story = {
 };
 
 export const MoreLevels: Story = {
-	// @ts-expect-error generic typed components https://github.com/storybookjs/storybook/issues/24238
 	render: (args) => ({
 		components: { DropdownMenu },
 		setup() {
@@ -499,7 +487,6 @@ export const MoreLevels: Story = {
 };
 
 export const SubMenuLoading: Story = {
-	// @ts-expect-error generic typed components https://github.com/storybookjs/storybook/issues/24238
 	render: (args) => ({
 		components: { DropdownMenu },
 		setup() {
@@ -544,7 +531,6 @@ export const SubMenuLoading: Story = {
 };
 
 export const SearchableRoot: Story = {
-	// @ts-expect-error generic typed components https://github.com/storybookjs/storybook/issues/24238
 	render: (args) => ({
 		components: { DropdownMenu },
 		setup() {
@@ -600,7 +586,6 @@ export const SearchableRoot: Story = {
 };
 
 export const SearchableRootWithSubmenus: Story = {
-	// @ts-expect-error generic typed components https://github.com/storybookjs/storybook/issues/24238
 	render: (args) => ({
 		components: { DropdownMenu },
 		setup() {
@@ -699,8 +684,7 @@ export const SearchableRootWithSubmenus: Story = {
 };
 
 export const SearchableSubmenu: Story = {
-	// @ts-expect-error generic typed components https://github.com/storybookjs/storybook/issues/24238
-	render: (args) => ({
+	render: () => ({
 		components: { DropdownMenu },
 		setup() {
 			const allProjects = [
@@ -774,8 +758,7 @@ export const SearchableSubmenu: Story = {
 };
 
 export const LazyLoadingSubmenu: Story = {
-	// @ts-expect-error generic typed components https://github.com/storybookjs/storybook/issues/24238
-	render: (args) => ({
+	render: () => ({
 		components: { DropdownMenu },
 		setup() {
 			// Define all possible children upfront (simulates API response)
@@ -889,7 +872,6 @@ export const LazyLoadingSubmenu: Story = {
 };
 
 export const EmptyState: Story = {
-	// @ts-expect-error generic typed components https://github.com/storybookjs/storybook/issues/24238
 	render: (args) => ({
 		components: { DropdownMenu },
 		setup() {
@@ -907,7 +889,6 @@ export const EmptyState: Story = {
 };
 
 export const CustomEmptyState: Story = {
-	// @ts-expect-error generic typed components https://github.com/storybookjs/storybook/issues/24238
 	render: (args) => ({
 		components: { DropdownMenu },
 		setup() {

--- a/packages/frontend/@n8n/design-system/src/v2/components/DropdownMenu/DropdownMenu.types.ts
+++ b/packages/frontend/@n8n/design-system/src/v2/components/DropdownMenu/DropdownMenu.types.ts
@@ -102,24 +102,24 @@ type SlotUiProps = { class: string };
 
 export interface DropdownMenuSlots<T = string> {
 	/** Custom trigger element (replaces default button) */
-	trigger: () => void;
+	trigger?: () => void;
 	/** Complete custom dropdown content (replaces item list) */
-	content: () => void;
+	content?: () => void;
 	/** Custom item rendering (replaces default N8nDropdownMenuItem) */
-	item: (props: { item: DropdownMenuItemProps<T> }) => void;
+	item?: (props: { item: DropdownMenuItemProps<T> }) => void;
 	/** Pass-through to N8nDropdownMenuItem */
-	'item-leading': (props: { item: DropdownMenuItemProps<T>; ui: SlotUiProps }) => void;
+	'item-leading'?: (props: { item: DropdownMenuItemProps<T>; ui: SlotUiProps }) => void;
 	/** Pass-through to N8nDropdownMenuItem */
-	'item-trailing': (props: { item: DropdownMenuItemProps<T>; ui: SlotUiProps }) => void;
+	'item-trailing'?: (props: { item: DropdownMenuItemProps<T>; ui: SlotUiProps }) => void;
 	/** Custom loading state */
-	loading: () => void;
+	loading?: () => void;
 	/** Custom empty state when no items */
-	empty: () => void;
+	empty?: () => void;
 }
 
 export interface DropdownMenuItemSlots<T = string> {
 	/** Content before the label (default: icon if provided) */
-	'item-leading': (props: { item: DropdownMenuItemProps<T>; ui: SlotUiProps }) => void;
+	'item-leading'?: (props: { item: DropdownMenuItemProps<T>; ui: SlotUiProps }) => void;
 	/** Content after the label (badges, shortcuts, etc.) */
-	'item-trailing': (props: { item: DropdownMenuItemProps<T>; ui: SlotUiProps }) => void;
+	'item-trailing'?: (props: { item: DropdownMenuItemProps<T>; ui: SlotUiProps }) => void;
 }

--- a/packages/frontend/editor-ui/src/app/components/DynamicModalLoader.vue
+++ b/packages/frontend/editor-ui/src/app/components/DynamicModalLoader.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, defineAsyncComponent } from 'vue';
+import { onMounted, onUnmounted, defineAsyncComponent, shallowRef } from 'vue';
 import type { Component } from 'vue';
 import * as modalRegistry from '@/app/moduleInitializer/modalRegistry';
 import ModalRoot from '@/app/components/ModalRoot.vue';
 
 // Keep track of registered modals
-const registeredModals = ref<
+// Using shallowRef() to fix "Vue received a Component that was made a reactive object. This can lead to unnecessary performance overhead..."
+const registeredModals = shallowRef<
 	Array<{
 		key: string;
 		component: Component;

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -47,7 +47,7 @@ import {
 } from '@/app/constants';
 import { STORES } from '@n8n/stores';
 import type { Connection } from '@vue-flow/core';
-import { useClipboard } from '@/app/composables/useClipboard';
+import { useClipboard } from '@vueuse/core';
 import { createCanvasConnectionHandleString } from '@/features/workflows/canvas/canvas.utils';
 import { nextTick, reactive, ref } from 'vue';
 import type { CanvasLayoutEvent } from '@/features/workflows/canvas/composables/useCanvasLayout';
@@ -97,9 +97,14 @@ vi.mock('n8n-workflow', async (importOriginal) => {
 	};
 });
 
-vi.mock('@/app/composables/useClipboard', async () => {
+vi.mock('@vueuse/core', async (importOriginal) => {
+	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+	const original = await importOriginal<typeof import('@vueuse/core')>();
 	const copySpy = vi.fn();
-	return { useClipboard: vi.fn(() => ({ copy: copySpy })) };
+	return {
+		...original,
+		useClipboard: vi.fn(() => ({ copy: copySpy })),
+	};
 });
 
 vi.mock('@/app/composables/useTelemetry', () => {

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -112,7 +112,6 @@ import {
 	isCommunityPackageName,
 } from 'n8n-workflow';
 import { computed, nextTick, ref } from 'vue';
-import { useClipboard } from '@/app/composables/useClipboard';
 import { useUniqueNodeName } from '@/app/composables/useUniqueNodeName';
 import { injectWorkflowState } from '@/app/composables/useWorkflowState';
 import { isPresent, tryToParseNumber } from '@/app/utils/typesUtils';
@@ -132,6 +131,7 @@ import { useTemplatesStore } from '@/features/workflows/templates/templates.stor
 import { isValidNodeConnectionType } from '@/app/utils/typeGuards';
 import { useParentFolder } from '@/features/core/folders/composables/useParentFolder';
 import { useWorkflowState } from '@/app/composables/useWorkflowState';
+import { useClipboard } from '@vueuse/core';
 
 type AddNodeData = Partial<INodeUi> & {
 	type: string;

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/CollectionParameter.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/CollectionParameter.vue
@@ -17,15 +17,16 @@ import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { useI18n } from '@n8n/i18n';
 import { storeToRefs } from 'pinia';
-
 import { N8nButton, N8nOption, N8nSelect, N8nText } from '@n8n/design-system';
+
 const selectedOption = ref<string | undefined>(undefined);
+
 export interface Props {
 	hideDelete?: boolean;
 	nodeValues: INodeParameters;
 	parameter: INodeProperties;
 	path: string;
-	values: INodeParameters;
+	values?: INodeParameters;
 	isReadOnly?: boolean;
 }
 const emit = defineEmits<{

--- a/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsViewV2.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsViewV2.vue
@@ -321,7 +321,6 @@ const nodeSettingsProps = computed(() => ({
 	eventBus: settingsEventBus,
 	dragging: isDragging.value,
 	pushRef: pushRef.value,
-	nodeType: activeNodeType.value,
 	foreignCredentials: foreignCredentials.value,
 	readOnly: props.readOnly,
 	blockUI: blockUi.value && showTriggerPanel.value,


### PR DESCRIPTION
## Summary

This PR cleans up following warnings on the browser's console.

When navigating
```
[Vue warn]: onMounted is called when there is no active component instance to be associated with. Lifecycle injection APIs can only be used during execution of setup(). If you are using async setup(), make sure to register lifecycle hooks before the first await statement.
[Vue warn]: onBeforeUnmount is called when there is no active component instance to be associated with. Lifecycle injection APIs can only be used during execution of setup(). If you are using async setup(), make sure to register lifecycle hooks before the first await statement.
```

When opening a dynamic modal
```
[Vue warn]: Vue received a Component that was made a reactive object. This can lead to unnecessary performance overhead and should be avoided by marking the component with `markRaw` or using `shallowRef` instead of `ref`. 
```

When opening NDV (with specific parameter)
```
[Vue warn]: Invalid prop: type check failed for prop "values". Expected Object, got Undefined
```
```
[Vue warn]: Failed setting prop "nodeType" on <div>: value [object Object] is invalid. TypeError: Cannot set property nodeType of #<Node> which has only a getter
```

When building `@n8n/chat` package
```
../design-system/src/v2/components/DropdownMenu/DropdownMenu.vue:216:30 - error TS2774: This condition will always return true since this function is always defined. Did you mean to call it instead?

216   <DropdownMenuTrigger v-if="slots.trigger" as-child :disabled="disabled">
                                 ~~~~~~~~~~~~~
../design-system/src/v2/components/DropdownMenu/DropdownMenu.vue:241:17 - error TS2774: This condition will always return true since this function is always defined. Did you mean to call it instead?

241     <slot v-if="$slots.content" name="content" />
```

When ChatHub settings page is opened
```
ElementPlusError: [ElOnlyChild] no valid child node found
```

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
