### PR TITLE
fix(Structured Output Parser Node): Fix parsing of JSON with markdown code segments

### DIFF
--- a/packages/@n8n/nodes-langchain/utils/output_parsers/N8nStructuredOutputParser.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/output_parsers/N8nStructuredOutputParser.test.ts
@@ -1,0 +1,356 @@
+import { mock } from 'jest-mock-extended';
+import type { INode, ISupplyDataFunctions } from 'n8n-workflow';
+import { NodeConnectionTypes } from 'n8n-workflow';
+import { z } from 'zod';
+
+import { N8nStructuredOutputParser } from './N8nStructuredOutputParser';
+
+describe('N8nStructuredOutputParser', () => {
+	let mockContext: jest.Mocked<ISupplyDataFunctions>;
+
+	beforeEach(() => {
+		mockContext = mock<ISupplyDataFunctions>();
+		mockContext.addInputData.mockReturnValue({ index: 0 });
+		mockContext.addOutputData.mockReturnValue(undefined);
+		mockContext.getNode.mockReturnValue({
+			name: 'Test Node',
+			type: 'n8n-nodes-langchain.outputParserStructured',
+			typeVersion: 1.3,
+			position: [0, 0],
+		} as INode);
+	});
+
+	// Bug AI-1852
+	describe('Backticks in JSON string values', () => {
+		it('should parse JSON containing markdown code blocks in string values', async () => {
+			const schema = z.object({
+				output: z.object({
+					message: z.string(),
+					status: z.string(),
+				}),
+			});
+
+			const parser = new N8nStructuredOutputParser(mockContext, schema);
+
+			// This is the exact problematic output from the bug report
+			// Valid JSON wrapped in code fence, but contains backticks INSIDE the message field
+			const problematicOutput = `\`\`\`json
+{
+  "output": {
+    "message": "## Example\\n\`\`\`bash\\n--set globals.enable=false\\n\`\`\`\\n",
+    "status": "completed"
+  }
+}
+\`\`\``;
+
+			const result = await parser.parse(problematicOutput);
+
+			expect(result).toEqual({
+				output: {
+					message: '## Example\n```bash\n--set globals.enable=false\n```\n',
+					status: 'completed',
+				},
+			});
+		});
+
+		it('should parse JSON containing multiple code blocks in string values', async () => {
+			const schema = z.object({
+				output: z.object({
+					content: z.string(),
+				}),
+			});
+
+			const parser = new N8nStructuredOutputParser(mockContext, schema);
+
+			const multipleCodeBlocksOutput = `\`\`\`json
+{
+  "output": {
+    "content": "First example:\\n\`\`\`javascript\\nconst x = 1;\\n\`\`\`\\n\\nSecond example:\\n\`\`\`python\\nprint('hello')\\n\`\`\`"
+  }
+}
+\`\`\``;
+
+			const result = await parser.parse(multipleCodeBlocksOutput);
+
+			expect(result).toEqual({
+				output: {
+					content:
+						"First example:\n```javascript\nconst x = 1;\n```\n\nSecond example:\n```python\nprint('hello')\n```",
+				},
+			});
+		});
+
+		it('should parse nested markdown in complex JSON structures', async () => {
+			const schema = z.object({
+				output: z.object({
+					steps: z.array(
+						z.object({
+							title: z.string(),
+							description: z.string(),
+							code: z.string(),
+						}),
+					),
+				}),
+			});
+
+			const parser = new N8nStructuredOutputParser(mockContext, schema);
+
+			const complexOutput = `\`\`\`json
+{
+  "output": {
+    "steps": [
+      {
+        "title": "Step 1",
+        "description": "Run this command:\\n\`\`\`bash\\nnpm install\\n\`\`\`",
+        "code": "npm install"
+      }
+    ]
+  }
+}
+\`\`\``;
+
+			const result = await parser.parse(complexOutput);
+
+			expect(result).toEqual({
+				output: {
+					steps: [
+						{
+							title: 'Step 1',
+							description: 'Run this command:\n```bash\nnpm install\n```',
+							code: 'npm install',
+						},
+					],
+				},
+			});
+		});
+	});
+
+	describe('Valid JSON parsing', () => {
+		it('should parse valid JSON without code fence', async () => {
+			const schema = z.object({
+				output: z.object({
+					message: z.string(),
+					status: z.string(),
+				}),
+			});
+
+			const parser = new N8nStructuredOutputParser(mockContext, schema);
+
+			const validOutput = `{
+  "output": {
+    "message": "Simple message",
+    "status": "completed"
+  }
+}`;
+
+			const result = await parser.parse(validOutput);
+
+			expect(result).toEqual({
+				output: {
+					message: 'Simple message',
+					status: 'completed',
+				},
+			});
+		});
+
+		it('should parse valid JSON wrapped in code fence without internal backticks', async () => {
+			const schema = z.object({
+				output: z.object({
+					message: z.string(),
+					status: z.string(),
+				}),
+			});
+
+			const parser = new N8nStructuredOutputParser(mockContext, schema);
+
+			const validOutput = `\`\`\`json
+{
+  "output": {
+    "message": "Simple message",
+    "status": "completed"
+  }
+}
+\`\`\``;
+
+			const result = await parser.parse(validOutput);
+
+			expect(result).toEqual({
+				output: {
+					message: 'Simple message',
+					status: 'completed',
+				},
+			});
+		});
+
+		it('should parse JSON with escaped quotes and newlines', async () => {
+			const schema = z.object({
+				output: z.object({
+					message: z.string(),
+				}),
+			});
+
+			const parser = new N8nStructuredOutputParser(mockContext, schema);
+
+			const validOutput = `{
+  "output": {
+    "message": "Line 1\\nLine 2\\n\\"quoted\\""
+  }
+}`;
+
+			const result = await parser.parse(validOutput);
+
+			expect(result).toEqual({
+				output: {
+					message: 'Line 1\nLine 2\n"quoted"',
+				},
+			});
+		});
+
+		it('should handle code fence with json language marker', async () => {
+			const schema = z.object({
+				output: z.object({
+					data: z.string(),
+				}),
+			});
+
+			const parser = new N8nStructuredOutputParser(mockContext, schema);
+
+			const validOutput = `\`\`\`json
+{
+  "output": {
+    "data": "test"
+  }
+}
+\`\`\``;
+
+			const result = await parser.parse(validOutput);
+
+			expect(result).toEqual({
+				output: {
+					data: 'test',
+				},
+			});
+		});
+
+		it('should handle code fence without language marker', async () => {
+			const schema = z.object({
+				output: z.object({
+					data: z.string(),
+				}),
+			});
+
+			const parser = new N8nStructuredOutputParser(mockContext, schema);
+
+			const validOutput = `\`\`\`
+{
+  "output": {
+    "data": "test"
+  }
+}
+\`\`\``;
+
+			const result = await parser.parse(validOutput);
+
+			expect(result).toEqual({
+				output: {
+					data: 'test',
+				},
+			});
+		});
+	});
+
+	describe('Error handling', () => {
+		it('should handle invalid JSON gracefully', async () => {
+			const schema = z.object({
+				output: z.object({
+					message: z.string(),
+				}),
+			});
+
+			const parser = new N8nStructuredOutputParser(mockContext, schema);
+
+			const invalidOutput = 'not valid json';
+
+			await expect(parser.parse(invalidOutput)).rejects.toThrow(
+				"Model output doesn't fit required format",
+			);
+		});
+
+		it('should handle empty output', async () => {
+			const schema = z.object({
+				output: z.object({
+					message: z.string(),
+				}),
+			});
+
+			const parser = new N8nStructuredOutputParser(mockContext, schema);
+
+			const emptyOutput = '{}';
+
+			await expect(parser.parse(emptyOutput)).rejects.toThrow(
+				"Model output doesn't fit required format",
+			);
+		});
+
+		it('should handle schema mismatch', async () => {
+			const schema = z.object({
+				output: z.object({
+					message: z.string(),
+					requiredField: z.string(),
+				}),
+			});
+
+			const parser = new N8nStructuredOutputParser(mockContext, schema);
+
+			const mismatchOutput = `{
+  "output": {
+    "message": "Test"
+  }
+}`;
+
+			await expect(parser.parse(mismatchOutput)).rejects.toThrow(
+				"Model output doesn't fit required format",
+			);
+		});
+	});
+
+	describe('Context integration', () => {
+		it('should call addInputData with correct parameters', async () => {
+			const schema = z.object({
+				output: z.object({
+					message: z.string(),
+				}),
+			});
+
+			const parser = new N8nStructuredOutputParser(mockContext, schema);
+
+			const validOutput = '{"output": {"message": "test"}}';
+
+			await parser.parse(validOutput);
+
+			expect(mockContext.addInputData).toHaveBeenCalledWith(NodeConnectionTypes.AiOutputParser, [
+				[{ json: { action: 'parse', text: validOutput } }],
+			]);
+		});
+
+		it('should call addOutputData with parsed result', async () => {
+			const schema = z.object({
+				output: z.object({
+					message: z.string(),
+				}),
+			});
+
+			const parser = new N8nStructuredOutputParser(mockContext, schema);
+
+			const validOutput = '{"output": {"message": "test"}}';
+
+			await parser.parse(validOutput);
+
+			expect(mockContext.addOutputData).toHaveBeenCalledWith(
+				NodeConnectionTypes.AiOutputParser,
+				0,
+				[[{ json: { action: 'parse', response: { output: { message: 'test' } } } }]],
+			);
+		});
+	});
+});


### PR DESCRIPTION
## Summary
This PR fixes a bug in the AI Agent's structured output parser where it would fail to parse valid JSON responses containing markdown code blocks (triple backticks) inside string values.

The parser used naive string splitting (text.split(/```(?:json)?/)[1]) which would incorrectly trigger on ANY occurrence of triple backticks, including those inside JSON string values. When an AI response contained markdown with code examples in the message field, the parser would split at the first backtick occurrence, producing invalid JSON.

Instead this replaces the string splitting with a regex pattern using anchors. The anchors ensure the regex only matches when the entire text is wrapped in a code fence, preventing false matches on backticks inside the JSON content.

  ## Related Linear tickets, Github issues, and Community forum posts

  - Linear: https://linear.app/n8n/issue/AI-1852/community-issue-ai-agent-structured-output-parser
  - Closes https://github.com/n8n-io/n8n/issues/21174

  ## Review / Merge checklist

  - [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
  - [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
  - [x] Tests included.
  - [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
