### PR TITLE
feat(ai-builder): LangSmith evaluation improvements

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/README.md
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/README.md
@@ -308,7 +308,20 @@ pnpm eval:langsmith --name "my-experiment"
 
 # With feature flags enabled
 pnpm eval:langsmith --multi-agent
+
+# Enable verbose logging
+pnpm eval:langsmith --verbose
 ```
+
+#### CLI Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--name <name>` | Custom experiment name in LangSmith | `workflow-builder-evaluation` |
+| `--repetitions <n>` | Number of times to repeat each example | 1 |
+| `--verbose`, `-v` | Enable verbose logging | false |
+| `--multi-agent` | Enable multi-agent architecture | false |
+| `--template-examples` | Enable template-based examples | false |
 
 ### Pairwise Evaluation
 

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/README.md
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/README.md
@@ -303,6 +303,9 @@ export LANGSMITH_DATASET_NAME=your_dataset_name
 # Run evaluation
 pnpm eval:langsmith
 
+# With custom experiment name
+pnpm eval:langsmith --name "my-experiment"
+
 # With feature flags enabled
 pnpm eval:langsmith --multi-agent
 ```

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/README.md
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/README.md
@@ -506,6 +506,7 @@ The evaluation will fail with a clear error message if `nodes.json` is missing.
 - `EVAL_FEATURE_MULTI_AGENT` - Set to "true" to enable multi-agent mode
 - `EVAL_FEATURE_TEMPLATE_EXAMPLES` - Set to "true" to enable template examples
 - `N8N_EVALS_DISABLED_NODES` - Comma-separated list of node types to disable (e.g., `n8n-nodes-base.slack,@n8n/n8n-nodes-langchain.agent`)
+- `LANGSMITH_MINIMAL_TRACING` - Controls trace payload filtering (default: `true`). Set to `false` to get full unfiltered traces. When enabled, large fields like `cachedTemplates`, `parsedNodeTypes`, and `workflowContext` are summarized to reduce payload size and avoid 403 errors.
 
 ### Feature Flags
 

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/constants.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/constants.ts
@@ -48,6 +48,7 @@ export const DEFAULTS = {
 	NUM_JUDGES: 3,
 	NUM_GENERATIONS: 1,
 	EXPERIMENT_NAME: 'pairwise-evals',
+	LLM_JUDGE_EXPERIMENT_NAME: 'workflow-builder-evaluation',
 	CONCURRENCY: 5,
 	REPETITIONS: 1,
 	DATASET_NAME: 'notion-pairwise-workflows',

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/core/environment.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/core/environment.ts
@@ -8,6 +8,13 @@ import { anthropicClaudeSonnet45 } from '../../src/llm-config.js';
 import type { BuilderFeatureFlags } from '../../src/workflow-builder-agent.js';
 import { WorkflowBuilderAgent } from '../../src/workflow-builder-agent.js';
 import { loadNodesFromFile } from '../load-nodes.js';
+import { filterTraceInputs, filterTraceOutputs, isMinimalTracingEnabled } from './trace-filters.js';
+
+/** Maximum batch size in bytes for trace uploads (10MB) */
+const TRACE_BATCH_SIZE_LIMIT = 10_000_000;
+
+/** Number of concurrent trace batch uploads */
+const TRACE_BATCH_CONCURRENCY = 2;
 
 export interface TestEnvironment {
 	parsedNodeTypes: INodeTypeDescription[];
@@ -42,7 +49,9 @@ export function createTracer(client: Client, projectName: string): LangChainTrac
 }
 
 /**
- * Creates a Langsmith client if API key is available
+ * Creates a Langsmith client if API key is available.
+ * By default, minimal tracing is enabled to reduce payload sizes and avoid 403 errors.
+ * Set LANGSMITH_MINIMAL_TRACING=false to disable filtering and get full traces.
  * @returns Langsmith client or undefined
  */
 export function createLangsmithClient(): Client | undefined {
@@ -50,7 +59,18 @@ export function createLangsmithClient(): Client | undefined {
 	if (!apiKey) {
 		return undefined;
 	}
-	return new Client({ apiKey });
+
+	const minimalTracing = isMinimalTracingEnabled();
+
+	return new Client({
+		apiKey,
+		// Filter large fields from traces to avoid 403 payload errors
+		hideInputs: minimalTracing ? filterTraceInputs : undefined,
+		hideOutputs: minimalTracing ? filterTraceOutputs : undefined,
+		// Reduce batch size and concurrency for high-volume scenarios
+		batchSizeBytesLimit: minimalTracing ? TRACE_BATCH_SIZE_LIMIT : undefined,
+		traceBatchConcurrency: minimalTracing ? TRACE_BATCH_CONCURRENCY : undefined,
+	});
 }
 
 /**

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/core/trace-filters.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/core/trace-filters.ts
@@ -1,0 +1,311 @@
+import type { KVMap } from 'langsmith/schemas';
+
+/**
+ * Large state fields that should be filtered from traces.
+ * These contribute most to payload bloat.
+ */
+const LARGE_STATE_FIELDS = ['cachedTemplates', 'parsedNodeTypes'] as const;
+
+/**
+ * Keys that indicate a LangChain serializable object.
+ * These should be passed through unchanged - copying them causes size inflation.
+ */
+const LANGCHAIN_SERIALIZABLE_KEYS = ['lc_serializable', 'lc_kwargs', 'lc_namespace'] as const;
+
+/**
+ * Check if an object is a LangChain serializable object.
+ * These objects should not be filtered as copying them causes size inflation.
+ */
+function isLangChainSerializable(obj: KVMap): boolean {
+	return LANGCHAIN_SERIALIZABLE_KEYS.some((key) => key in obj);
+}
+
+/**
+ * Check if an object has any fields worth filtering.
+ */
+function hasFilterableFields(obj: KVMap): boolean {
+	return (
+		LARGE_STATE_FIELDS.some((field) => field in obj) ||
+		'workflowContext' in obj ||
+		'workflowJSON' in obj ||
+		'workflow' in obj
+	);
+}
+
+// Track if we've logged the filtering status
+let hasLoggedFilteringActive = false;
+
+// Track cumulative stats for final summary
+let totalInputBefore = 0;
+let totalInputAfter = 0;
+let totalOutputBefore = 0;
+let totalOutputAfter = 0;
+let inputCallCount = 0;
+let outputCallCount = 0;
+
+/**
+ * Reset filtering statistics.
+ * Call this at the start of each evaluation run to ensure accurate stats.
+ */
+export function resetFilteringStats(): void {
+	hasLoggedFilteringActive = false;
+	totalInputBefore = 0;
+	totalInputAfter = 0;
+	totalOutputBefore = 0;
+	totalOutputAfter = 0;
+	inputCallCount = 0;
+	outputCallCount = 0;
+}
+
+/**
+ * Get approximate size of an object in characters (JSON string length).
+ * For ASCII content this approximates byte size.
+ */
+function getApproxSize(obj: unknown): number {
+	try {
+		return JSON.stringify(obj).length;
+	} catch {
+		return 0;
+	}
+}
+
+/**
+ * Format bytes to human readable string.
+ */
+function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes}B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(2)}MB`;
+}
+
+/**
+ * Large context fields within workflowContext that should be filtered.
+ */
+const LARGE_CONTEXT_FIELDS = ['executionData', 'executionSchema', 'expressionValues'] as const;
+
+/**
+ * Threshold for summarizing workflows instead of including full definition.
+ */
+const WORKFLOW_SUMMARY_THRESHOLD = 20;
+
+/**
+ * Summarize a workflow for minimal trace output.
+ * Preserves node counts and names without full definitions.
+ */
+function summarizeWorkflow(workflow: unknown): Record<string, unknown> {
+	if (!workflow || typeof workflow !== 'object') {
+		return { unknown: true };
+	}
+
+	const wf = workflow as Record<string, unknown>;
+	const nodes = wf.nodes as Array<{ name?: string }> | undefined;
+	const connections = wf.connections as Record<string, unknown> | undefined;
+
+	return {
+		nodeCount: Array.isArray(nodes) ? nodes.length : 0,
+		nodeNames: Array.isArray(nodes) ? nodes.map((n) => n.name).filter(Boolean) : [],
+		connectionCount: connections ? Object.keys(connections).length : 0,
+		name: wf.name,
+	};
+}
+
+/**
+ * Summarize cached templates - just IDs and names, not full workflows.
+ */
+function summarizeCachedTemplates(templates: unknown[]): Array<Record<string, unknown>> {
+	return templates.map((t) => {
+		if (!t || typeof t !== 'object') return { unknown: true };
+		const template = t as Record<string, unknown>;
+		return {
+			templateId: template.templateId,
+			name: template.name,
+		};
+	});
+}
+
+/**
+ * Filter large state fields in-place (mutates the object).
+ * Shared logic for both input and output filtering.
+ */
+function filterLargeStateFields(obj: KVMap): void {
+	for (const field of LARGE_STATE_FIELDS) {
+		if (field in obj) {
+			if (field === 'cachedTemplates' && Array.isArray(obj[field])) {
+				obj[field] = summarizeCachedTemplates(obj[field] as unknown[]);
+			} else if (field === 'parsedNodeTypes' && Array.isArray(obj[field])) {
+				obj[field] = `[${(obj[field] as unknown[]).length} node types]`;
+			}
+		}
+	}
+}
+
+/**
+ * Filter inputs for minimal trace mode.
+ * Removes large fields, keeps essential metadata for debugging.
+ */
+export function filterTraceInputs(inputs: KVMap): KVMap {
+	// Log once per process to confirm filtering is active
+	if (!hasLoggedFilteringActive) {
+		hasLoggedFilteringActive = true;
+		console.log(
+			'➔ LangSmith trace filtering: ACTIVE (set LANGSMITH_MINIMAL_TRACING=false to disable)',
+		);
+	}
+
+	// Skip LangChain serializable objects - copying them causes size inflation
+	if (isLangChainSerializable(inputs)) {
+		const size = getApproxSize(inputs);
+		inputCallCount++;
+		totalInputBefore += size;
+		totalInputAfter += size;
+		return inputs;
+	}
+
+	// Skip if no filterable fields - avoid unnecessary copy overhead
+	if (!hasFilterableFields(inputs)) {
+		const size = getApproxSize(inputs);
+		inputCallCount++;
+		totalInputBefore += size;
+		totalInputAfter += size;
+		return inputs;
+	}
+
+	const beforeSize = getApproxSize(inputs);
+	const filtered = { ...inputs };
+
+	// Handle large top-level fields
+	filterLargeStateFields(filtered);
+
+	// Handle workflowContext if present
+	if (filtered.workflowContext && typeof filtered.workflowContext === 'object') {
+		const ctx = filtered.workflowContext as Record<string, unknown>;
+		const filteredCtx: Record<string, unknown> = {};
+
+		for (const [key, value] of Object.entries(ctx)) {
+			if ((LARGE_CONTEXT_FIELDS as readonly string[]).includes(key)) {
+				if (key === 'executionData') {
+					filteredCtx[key] = '[execution data omitted]';
+				} else if (key === 'executionSchema') {
+					filteredCtx[key] = `[${Array.isArray(value) ? value.length : 0} schemas]`;
+				} else if (key === 'expressionValues') {
+					filteredCtx[key] =
+						`[${typeof value === 'object' && value ? Object.keys(value).length : 0} expressions]`;
+				}
+			} else if (key === 'currentWorkflow' && value) {
+				// Summarize currentWorkflow
+				filteredCtx[key] = summarizeWorkflow(value);
+			} else {
+				filteredCtx[key] = value;
+			}
+		}
+
+		filtered.workflowContext = filteredCtx;
+	}
+
+	// Handle workflowJSON if present at top level
+	if (filtered.workflowJSON && typeof filtered.workflowJSON === 'object') {
+		const wf = filtered.workflowJSON as { nodes?: unknown[] };
+		if (wf.nodes && wf.nodes.length > WORKFLOW_SUMMARY_THRESHOLD) {
+			filtered.workflowJSON = summarizeWorkflow(filtered.workflowJSON);
+		}
+	}
+
+	// Track stats for final summary
+	const afterSize = getApproxSize(filtered);
+	inputCallCount++;
+	totalInputBefore += beforeSize;
+	totalInputAfter += afterSize;
+
+	return filtered;
+}
+
+/**
+ * Filter outputs for minimal trace mode.
+ */
+export function filterTraceOutputs(outputs: KVMap): KVMap {
+	// Skip LangChain serializable objects - copying them causes size inflation
+	if (isLangChainSerializable(outputs)) {
+		const size = getApproxSize(outputs);
+		outputCallCount++;
+		totalOutputBefore += size;
+		totalOutputAfter += size;
+		return outputs;
+	}
+
+	const beforeSize = getApproxSize(outputs);
+	outputCallCount++;
+
+	// Check if there are any filterable fields in outputs
+	const hasFilterableOutputFields =
+		'workflow' in outputs || LARGE_STATE_FIELDS.some((field) => field in outputs);
+
+	// Skip if no filterable fields
+	if (!hasFilterableOutputFields) {
+		totalOutputBefore += beforeSize;
+		totalOutputAfter += beforeSize;
+		return outputs;
+	}
+
+	const filtered = { ...outputs };
+
+	// Handle large state fields in outputs
+	filterLargeStateFields(filtered);
+
+	// Summarize workflow outputs if present and large
+	if (filtered.workflow && typeof filtered.workflow === 'object') {
+		const wf = filtered.workflow as { nodes?: unknown[] };
+		if (wf.nodes && wf.nodes.length > WORKFLOW_SUMMARY_THRESHOLD) {
+			filtered.workflow = summarizeWorkflow(filtered.workflow);
+		}
+	}
+
+	// Keep feedback array as-is - it's essential for evaluation results
+
+	// Track stats for final summary
+	const afterSize = getApproxSize(filtered);
+	totalOutputBefore += beforeSize;
+	totalOutputAfter += afterSize;
+
+	return filtered;
+}
+
+/**
+ * Check if minimal tracing is enabled.
+ * Default: true (enabled by default for evaluations)
+ * Set LANGSMITH_MINIMAL_TRACING=false to disable.
+ */
+export function isMinimalTracingEnabled(): boolean {
+	const envValue = process.env.LANGSMITH_MINIMAL_TRACING;
+	// Default to true if not set, only disable if explicitly set to 'false'
+	return envValue !== 'false';
+}
+
+/**
+ * Log final filtering statistics.
+ * Call this at the end of evaluation runs to see total impact.
+ */
+export function logFilteringStats(): void {
+	if (inputCallCount === 0 && outputCallCount === 0) {
+		return;
+	}
+
+	const inputReduction =
+		totalInputBefore > 0 ? ((1 - totalInputAfter / totalInputBefore) * 100).toFixed(1) : '0';
+	const outputReduction =
+		totalOutputBefore > 0 ? ((1 - totalOutputAfter / totalOutputBefore) * 100).toFixed(1) : '0';
+	const totalBefore = totalInputBefore + totalOutputBefore;
+	const totalAfter = totalInputAfter + totalOutputAfter;
+	const totalReduction = totalBefore > 0 ? ((1 - totalAfter / totalBefore) * 100).toFixed(1) : '0';
+
+	console.log('\n📊 ═══════════════ TRACE FILTERING SUMMARY ═══════════════');
+	console.log(
+		`   INPUTS:  ${formatBytes(totalInputBefore)} → ${formatBytes(totalInputAfter)} (${inputReduction}% reduction, ${inputCallCount} traces)`,
+	);
+	console.log(
+		`   OUTPUTS: ${formatBytes(totalOutputBefore)} → ${formatBytes(totalOutputAfter)} (${outputReduction}% reduction, ${outputCallCount} traces)`,
+	);
+	console.log(
+		`   TOTAL:   ${formatBytes(totalBefore)} → ${formatBytes(totalAfter)} (${totalReduction}% reduction)`,
+	);
+	console.log('═══════════════════════════════════════════════════════════\n');
+}

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/core/trace-filters.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/core/trace-filters.ts
@@ -32,31 +32,6 @@ function hasFilterableFields(obj: KVMap): boolean {
 	);
 }
 
-// Track if we've logged the filtering status
-let hasLoggedFilteringActive = false;
-
-// Track cumulative stats for final summary
-let totalInputBefore = 0;
-let totalInputAfter = 0;
-let totalOutputBefore = 0;
-let totalOutputAfter = 0;
-let inputCallCount = 0;
-let outputCallCount = 0;
-
-/**
- * Reset filtering statistics.
- * Call this at the start of each evaluation run to ensure accurate stats.
- */
-export function resetFilteringStats(): void {
-	hasLoggedFilteringActive = false;
-	totalInputBefore = 0;
-	totalInputAfter = 0;
-	totalOutputBefore = 0;
-	totalOutputAfter = 0;
-	inputCallCount = 0;
-	outputCallCount = 0;
-}
-
 /**
  * Get approximate size of an object in characters (JSON string length).
  * For ASCII content this approximates byte size.
@@ -140,136 +115,6 @@ function filterLargeStateFields(obj: KVMap): void {
 }
 
 /**
- * Filter inputs for minimal trace mode.
- * Removes large fields, keeps essential metadata for debugging.
- */
-export function filterTraceInputs(inputs: KVMap): KVMap {
-	// Log once per process to confirm filtering is active
-	if (!hasLoggedFilteringActive) {
-		hasLoggedFilteringActive = true;
-		console.log(
-			'➔ LangSmith trace filtering: ACTIVE (set LANGSMITH_MINIMAL_TRACING=false to disable)',
-		);
-	}
-
-	// Skip LangChain serializable objects - copying them causes size inflation
-	if (isLangChainSerializable(inputs)) {
-		const size = getApproxSize(inputs);
-		inputCallCount++;
-		totalInputBefore += size;
-		totalInputAfter += size;
-		return inputs;
-	}
-
-	// Skip if no filterable fields - avoid unnecessary copy overhead
-	if (!hasFilterableFields(inputs)) {
-		const size = getApproxSize(inputs);
-		inputCallCount++;
-		totalInputBefore += size;
-		totalInputAfter += size;
-		return inputs;
-	}
-
-	const beforeSize = getApproxSize(inputs);
-	const filtered = { ...inputs };
-
-	// Handle large top-level fields
-	filterLargeStateFields(filtered);
-
-	// Handle workflowContext if present
-	if (filtered.workflowContext && typeof filtered.workflowContext === 'object') {
-		const ctx = filtered.workflowContext as Record<string, unknown>;
-		const filteredCtx: Record<string, unknown> = {};
-
-		for (const [key, value] of Object.entries(ctx)) {
-			if ((LARGE_CONTEXT_FIELDS as readonly string[]).includes(key)) {
-				if (key === 'executionData') {
-					filteredCtx[key] = '[execution data omitted]';
-				} else if (key === 'executionSchema') {
-					filteredCtx[key] = `[${Array.isArray(value) ? value.length : 0} schemas]`;
-				} else if (key === 'expressionValues') {
-					filteredCtx[key] =
-						`[${typeof value === 'object' && value ? Object.keys(value).length : 0} expressions]`;
-				}
-			} else if (key === 'currentWorkflow' && value) {
-				// Summarize currentWorkflow
-				filteredCtx[key] = summarizeWorkflow(value);
-			} else {
-				filteredCtx[key] = value;
-			}
-		}
-
-		filtered.workflowContext = filteredCtx;
-	}
-
-	// Handle workflowJSON if present at top level
-	if (filtered.workflowJSON && typeof filtered.workflowJSON === 'object') {
-		const wf = filtered.workflowJSON as { nodes?: unknown[] };
-		if (wf.nodes && wf.nodes.length > WORKFLOW_SUMMARY_THRESHOLD) {
-			filtered.workflowJSON = summarizeWorkflow(filtered.workflowJSON);
-		}
-	}
-
-	// Track stats for final summary
-	const afterSize = getApproxSize(filtered);
-	inputCallCount++;
-	totalInputBefore += beforeSize;
-	totalInputAfter += afterSize;
-
-	return filtered;
-}
-
-/**
- * Filter outputs for minimal trace mode.
- */
-export function filterTraceOutputs(outputs: KVMap): KVMap {
-	// Skip LangChain serializable objects - copying them causes size inflation
-	if (isLangChainSerializable(outputs)) {
-		const size = getApproxSize(outputs);
-		outputCallCount++;
-		totalOutputBefore += size;
-		totalOutputAfter += size;
-		return outputs;
-	}
-
-	const beforeSize = getApproxSize(outputs);
-	outputCallCount++;
-
-	// Check if there are any filterable fields in outputs
-	const hasFilterableOutputFields =
-		'workflow' in outputs || LARGE_STATE_FIELDS.some((field) => field in outputs);
-
-	// Skip if no filterable fields
-	if (!hasFilterableOutputFields) {
-		totalOutputBefore += beforeSize;
-		totalOutputAfter += beforeSize;
-		return outputs;
-	}
-
-	const filtered = { ...outputs };
-
-	// Handle large state fields in outputs
-	filterLargeStateFields(filtered);
-
-	// Summarize workflow outputs if present and large
-	if (filtered.workflow && typeof filtered.workflow === 'object') {
-		const wf = filtered.workflow as { nodes?: unknown[] };
-		if (wf.nodes && wf.nodes.length > WORKFLOW_SUMMARY_THRESHOLD) {
-			filtered.workflow = summarizeWorkflow(filtered.workflow);
-		}
-	}
-
-	// Keep feedback array as-is - it's essential for evaluation results
-
-	// Track stats for final summary
-	const afterSize = getApproxSize(filtered);
-	totalOutputBefore += beforeSize;
-	totalOutputAfter += afterSize;
-
-	return filtered;
-}
-
-/**
  * Check if minimal tracing is enabled.
  * Default: true (enabled by default for evaluations)
  * Set LANGSMITH_MINIMAL_TRACING=false to disable.
@@ -281,31 +126,193 @@ export function isMinimalTracingEnabled(): boolean {
 }
 
 /**
- * Log final filtering statistics.
- * Call this at the end of evaluation runs to see total impact.
+ * Trace filter functions with closure-scoped statistics.
  */
-export function logFilteringStats(): void {
-	if (inputCallCount === 0 && outputCallCount === 0) {
-		return;
-	}
+export interface TraceFilters {
+	/** Filter function for hideInputs */
+	filterInputs: (inputs: KVMap) => KVMap;
+	/** Filter function for hideOutputs */
+	filterOutputs: (outputs: KVMap) => KVMap;
+	/** Log filtering statistics to console */
+	logStats: () => void;
+	/** Reset statistics (call at start of each evaluation run) */
+	resetStats: () => void;
+}
 
-	const inputReduction =
-		totalInputBefore > 0 ? ((1 - totalInputAfter / totalInputBefore) * 100).toFixed(1) : '0';
-	const outputReduction =
-		totalOutputBefore > 0 ? ((1 - totalOutputAfter / totalOutputBefore) * 100).toFixed(1) : '0';
-	const totalBefore = totalInputBefore + totalOutputBefore;
-	const totalAfter = totalInputAfter + totalOutputAfter;
-	const totalReduction = totalBefore > 0 ? ((1 - totalAfter / totalBefore) * 100).toFixed(1) : '0';
+/**
+ * Creates trace filter functions with closure-scoped state.
+ * Each call returns a new set of filters with independent statistics,
+ * avoiding global state issues with parallel evaluations.
+ */
+export function createTraceFilters(): TraceFilters {
+	// Closure-scoped state - isolated per client instance
+	let hasLoggedFilteringActive = false;
+	let totalInputBefore = 0;
+	let totalInputAfter = 0;
+	let totalOutputBefore = 0;
+	let totalOutputAfter = 0;
+	let inputCallCount = 0;
+	let outputCallCount = 0;
 
-	console.log('\n📊 ═══════════════ TRACE FILTERING SUMMARY ═══════════════');
-	console.log(
-		`   INPUTS:  ${formatBytes(totalInputBefore)} → ${formatBytes(totalInputAfter)} (${inputReduction}% reduction, ${inputCallCount} traces)`,
-	);
-	console.log(
-		`   OUTPUTS: ${formatBytes(totalOutputBefore)} → ${formatBytes(totalOutputAfter)} (${outputReduction}% reduction, ${outputCallCount} traces)`,
-	);
-	console.log(
-		`   TOTAL:   ${formatBytes(totalBefore)} → ${formatBytes(totalAfter)} (${totalReduction}% reduction)`,
-	);
-	console.log('═══════════════════════════════════════════════════════════\n');
+	const resetStats = (): void => {
+		hasLoggedFilteringActive = false;
+		totalInputBefore = 0;
+		totalInputAfter = 0;
+		totalOutputBefore = 0;
+		totalOutputAfter = 0;
+		inputCallCount = 0;
+		outputCallCount = 0;
+	};
+
+	const logStats = (): void => {
+		if (inputCallCount === 0 && outputCallCount === 0) {
+			return;
+		}
+
+		const inputReduction =
+			totalInputBefore > 0 ? ((1 - totalInputAfter / totalInputBefore) * 100).toFixed(1) : '0';
+		const outputReduction =
+			totalOutputBefore > 0 ? ((1 - totalOutputAfter / totalOutputBefore) * 100).toFixed(1) : '0';
+		const totalBefore = totalInputBefore + totalOutputBefore;
+		const totalAfter = totalInputAfter + totalOutputAfter;
+		const totalReduction =
+			totalBefore > 0 ? ((1 - totalAfter / totalBefore) * 100).toFixed(1) : '0';
+
+		console.log('\n📊 ═══════════════ TRACE FILTERING SUMMARY ═══════════════');
+		console.log(
+			`   INPUTS:  ${formatBytes(totalInputBefore)} → ${formatBytes(totalInputAfter)} (${inputReduction}% reduction, ${inputCallCount} traces)`,
+		);
+		console.log(
+			`   OUTPUTS: ${formatBytes(totalOutputBefore)} → ${formatBytes(totalOutputAfter)} (${outputReduction}% reduction, ${outputCallCount} traces)`,
+		);
+		console.log(
+			`   TOTAL:   ${formatBytes(totalBefore)} → ${formatBytes(totalAfter)} (${totalReduction}% reduction)`,
+		);
+		console.log('═══════════════════════════════════════════════════════════\n');
+	};
+
+	const filterInputs = (inputs: KVMap): KVMap => {
+		// Log once per client to confirm filtering is active
+		if (!hasLoggedFilteringActive) {
+			hasLoggedFilteringActive = true;
+			console.log(
+				'➔ LangSmith trace filtering: ACTIVE (set LANGSMITH_MINIMAL_TRACING=false to disable)',
+			);
+		}
+
+		// Skip LangChain serializable objects - copying them causes size inflation
+		if (isLangChainSerializable(inputs)) {
+			const size = getApproxSize(inputs);
+			inputCallCount++;
+			totalInputBefore += size;
+			totalInputAfter += size;
+			return inputs;
+		}
+
+		// Skip if no filterable fields - avoid unnecessary copy overhead
+		if (!hasFilterableFields(inputs)) {
+			const size = getApproxSize(inputs);
+			inputCallCount++;
+			totalInputBefore += size;
+			totalInputAfter += size;
+			return inputs;
+		}
+
+		const beforeSize = getApproxSize(inputs);
+		const filtered = { ...inputs };
+
+		// Handle large top-level fields
+		filterLargeStateFields(filtered);
+
+		// Handle workflowContext if present
+		if (filtered.workflowContext && typeof filtered.workflowContext === 'object') {
+			const ctx = filtered.workflowContext as Record<string, unknown>;
+			const filteredCtx: Record<string, unknown> = {};
+
+			for (const [key, value] of Object.entries(ctx)) {
+				if ((LARGE_CONTEXT_FIELDS as readonly string[]).includes(key)) {
+					if (key === 'executionData') {
+						filteredCtx[key] = '[execution data omitted]';
+					} else if (key === 'executionSchema') {
+						filteredCtx[key] = `[${Array.isArray(value) ? value.length : 0} schemas]`;
+					} else if (key === 'expressionValues') {
+						filteredCtx[key] =
+							`[${typeof value === 'object' && value ? Object.keys(value).length : 0} expressions]`;
+					}
+				} else if (key === 'currentWorkflow' && value) {
+					// Summarize currentWorkflow
+					filteredCtx[key] = summarizeWorkflow(value);
+				} else {
+					filteredCtx[key] = value;
+				}
+			}
+
+			filtered.workflowContext = filteredCtx;
+		}
+
+		// Handle workflowJSON if present at top level
+		if (filtered.workflowJSON && typeof filtered.workflowJSON === 'object') {
+			const wf = filtered.workflowJSON as { nodes?: unknown[] };
+			if (wf.nodes && wf.nodes.length > WORKFLOW_SUMMARY_THRESHOLD) {
+				filtered.workflowJSON = summarizeWorkflow(filtered.workflowJSON);
+			}
+		}
+
+		// Track stats for final summary
+		const afterSize = getApproxSize(filtered);
+		inputCallCount++;
+		totalInputBefore += beforeSize;
+		totalInputAfter += afterSize;
+
+		return filtered;
+	};
+
+	const filterOutputs = (outputs: KVMap): KVMap => {
+		// Skip LangChain serializable objects - copying them causes size inflation
+		if (isLangChainSerializable(outputs)) {
+			const size = getApproxSize(outputs);
+			outputCallCount++;
+			totalOutputBefore += size;
+			totalOutputAfter += size;
+			return outputs;
+		}
+
+		const beforeSize = getApproxSize(outputs);
+		outputCallCount++;
+
+		// Check if there are any filterable fields in outputs
+		const hasFilterableOutputFields =
+			'workflow' in outputs || LARGE_STATE_FIELDS.some((field) => field in outputs);
+
+		// Skip if no filterable fields
+		if (!hasFilterableOutputFields) {
+			totalOutputBefore += beforeSize;
+			totalOutputAfter += beforeSize;
+			return outputs;
+		}
+
+		const filtered = { ...outputs };
+
+		// Handle large state fields in outputs
+		filterLargeStateFields(filtered);
+
+		// Summarize workflow outputs if present and large
+		if (filtered.workflow && typeof filtered.workflow === 'object') {
+			const wf = filtered.workflow as { nodes?: unknown[] };
+			if (wf.nodes && wf.nodes.length > WORKFLOW_SUMMARY_THRESHOLD) {
+				filtered.workflow = summarizeWorkflow(filtered.workflow);
+			}
+		}
+
+		// Keep feedback array as-is - it's essential for evaluation results
+
+		// Track stats for final summary
+		const afterSize = getApproxSize(filtered);
+		totalOutputBefore += beforeSize;
+		totalOutputAfter += afterSize;
+
+		return filtered;
+	};
+
+	return { filterInputs, filterOutputs, logStats, resetStats };
 }

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/index.ts
@@ -133,7 +133,7 @@ async function main(): Promise<void> {
 			});
 		}
 	} else if (useLangsmith) {
-		await runLangsmithEvaluation(args.repetitions, featureFlags, args.experimentName);
+		await runLangsmithEvaluation(args.repetitions, featureFlags, args.experimentName, args.verbose);
 	} else {
 		const csvTestCases = args.promptsCsvPath
 			? loadTestCasesFromCsv(args.promptsCsvPath)

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/index.ts
@@ -133,7 +133,7 @@ async function main(): Promise<void> {
 			});
 		}
 	} else if (useLangsmith) {
-		await runLangsmithEvaluation(args.repetitions, featureFlags);
+		await runLangsmithEvaluation(args.repetitions, featureFlags, args.experimentName);
 	} else {
 		const csvTestCases = args.promptsCsvPath
 			? loadTestCasesFromCsv(args.promptsCsvPath)

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/langsmith/runner.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/langsmith/runner.ts
@@ -8,7 +8,7 @@ import pc from 'picocolors';
 import { createLangsmithEvaluator } from './evaluator';
 import type { BuilderFeatureFlags } from '../../src/workflow-builder-agent';
 import type { WorkflowState } from '../../src/workflow-state';
-import { EVAL_TYPES, EVAL_USERS, TRACEABLE_NAMES } from '../constants';
+import { DEFAULTS, EVAL_TYPES, EVAL_USERS, TRACEABLE_NAMES } from '../constants';
 import { setupTestEnvironment, createAgent } from '../core/environment';
 import {
 	generateRunId,
@@ -100,12 +100,17 @@ function createWorkflowGenerator(
  * Runs evaluation using Langsmith
  * @param repetitions - Number of times to run each example (default: 1)
  * @param featureFlags - Optional feature flags to pass to the agent
+ * @param experimentName - Optional custom experiment name (default: 'workflow-builder-evaluation')
  */
 export async function runLangsmithEvaluation(
 	repetitions: number = 1,
 	featureFlags?: BuilderFeatureFlags,
+	experimentName?: string,
 ): Promise<void> {
+	const finalExperimentName = experimentName ?? DEFAULTS.LLM_JUDGE_EXPERIMENT_NAME;
+
 	console.log(formatHeader('AI Workflow Builder Langsmith Evaluation', 70));
+	console.log(pc.blue(`➔ Experiment: ${finalExperimentName}`));
 	if (repetitions > 1) {
 		console.log(pc.yellow(`➔ Each example will be run ${repetitions} times`));
 	}
@@ -170,7 +175,7 @@ export async function runLangsmithEvaluation(
 			data: datasetName,
 			evaluators: [evaluator],
 			maxConcurrency: 7,
-			experimentPrefix: 'workflow-builder-evaluation',
+			experimentPrefix: finalExperimentName,
 			numRepetitions: repetitions,
 			metadata: {
 				evaluationType: 'llm-based',
@@ -184,7 +189,7 @@ export async function runLangsmithEvaluation(
 		// Display results information
 		console.log('\nView detailed results in Langsmith dashboard');
 		console.log(
-			`Experiment name: workflow-builder-evaluation-${new Date().toISOString().split('T')[0]}`,
+			`Experiment name: ${finalExperimentName}-${new Date().toISOString().split('T')[0]}`,
 		);
 
 		// Log summary of results if available

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/langsmith/runner.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/langsmith/runner.ts
@@ -10,7 +10,6 @@ import type { BuilderFeatureFlags } from '../../src/workflow-builder-agent';
 import type { WorkflowState } from '../../src/workflow-state';
 import { DEFAULTS, EVAL_TYPES, EVAL_USERS, TRACEABLE_NAMES } from '../constants';
 import { setupTestEnvironment, createAgent } from '../core/environment';
-import { logFilteringStats, resetFilteringStats } from '../core/trace-filters';
 import {
 	generateRunId,
 	safeExtractUsage,
@@ -132,7 +131,7 @@ export async function runLangsmithEvaluation(
 		}
 
 		// Setup test environment
-		const { parsedNodeTypes, llm, lsClient } = await setupTestEnvironment();
+		const { parsedNodeTypes, llm, lsClient, traceFilters } = await setupTestEnvironment();
 		// Note: Don't use the tracer from setupTestEnvironment() here.
 		// LangSmith's evaluate() manages its own tracing context - passing a separate
 		// tracer would create disconnected runs in a different project.
@@ -142,7 +141,7 @@ export async function runLangsmithEvaluation(
 		}
 
 		// Reset filtering stats for accurate per-run statistics
-		resetFilteringStats();
+		traceFilters?.resetStats();
 
 		// Get dataset name from env or use default
 		const datasetName = process.env.LANGSMITH_DATASET_NAME ?? 'workflow-builder-canvas-prompts';
@@ -192,7 +191,7 @@ export async function runLangsmithEvaluation(
 		console.log(pc.green(`✓ Evaluation completed in ${(totalTime / 1000).toFixed(1)}s`));
 
 		// Log filtering statistics
-		logFilteringStats();
+		traceFilters?.logStats();
 
 		// Display results information
 		console.log('\nView detailed results in Langsmith dashboard');

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/pairwise/runner.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/pairwise/runner.ts
@@ -271,7 +271,7 @@ export async function runPairwiseLangsmithEvaluation(
 			log.verbose('➔ Enabled LANGSMITH_TRACING=true');
 		}
 
-		const { parsedNodeTypes, llm, lsClient, traceFilters } = await setupTestEnvironment();
+		const { parsedNodeTypes, llm, lsClient, traceFilters } = await setupTestEnvironment(log);
 
 		if (!lsClient) {
 			throw new Error('Langsmith client not initialized');
@@ -397,7 +397,7 @@ export async function runLocalPairwiseEvaluation(options: LocalPairwiseOptions):
 	try {
 		validatePairwiseInputs(numJudges, numGenerations);
 
-		const { parsedNodeTypes, llm } = await setupTestEnvironment();
+		const { parsedNodeTypes, llm } = await setupTestEnvironment(log);
 
 		// Create artifact saver if output directory is configured
 		const artifactSaver = createArtifactSaver(outputDir, log);

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/pairwise/runner.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/pairwise/runner.ts
@@ -8,7 +8,6 @@ import { pairwiseLangsmithEvaluator } from './metrics-builder';
 import type { BuilderFeatureFlags } from '../../src/workflow-builder-agent';
 import { DEFAULTS } from '../constants';
 import { setupTestEnvironment } from '../core/environment';
-import { logFilteringStats, resetFilteringStats } from '../core/trace-filters';
 import { createArtifactSaver } from '../utils/artifact-saver';
 import { formatHeader } from '../utils/evaluation-helpers';
 import { createLogger, type EvalLogger } from '../utils/logger';
@@ -272,14 +271,14 @@ export async function runPairwiseLangsmithEvaluation(
 			log.verbose('➔ Enabled LANGSMITH_TRACING=true');
 		}
 
-		const { parsedNodeTypes, llm, lsClient } = await setupTestEnvironment();
+		const { parsedNodeTypes, llm, lsClient, traceFilters } = await setupTestEnvironment();
 
 		if (!lsClient) {
 			throw new Error('Langsmith client not initialized');
 		}
 
 		// Reset filtering stats for accurate per-run statistics
-		resetFilteringStats();
+		traceFilters?.resetStats();
 
 		const datasetName = process.env.LANGSMITH_DATASET_NAME ?? DEFAULTS.DATASET_NAME;
 		log.info(`➔ Dataset: ${datasetName}`);
@@ -337,7 +336,7 @@ export async function runPairwiseLangsmithEvaluation(
 		const totalEvalTime = Date.now() - evalStartTime;
 
 		// Log filtering statistics
-		logFilteringStats();
+		traceFilters?.logStats();
 
 		log.success('\n✓ Pairwise evaluation completed');
 		log.dim(`   Total time: ${(totalEvalTime / 1000).toFixed(1)}s`);


### PR DESCRIPTION
## Summary
- Add `--name` option to LLM-as-judge evaluations for custom experiment naming
- Add `--verbose` flag to LLM-as-judge evaluations for detailed logging
- Add LangSmith trace filtering to reduce payload sizes and avoid 403 errors

## Changes

### --name option
Adds support for specifying a custom experiment name when running LangSmith evaluations via `--name <name>` flag.

### --verbose flag
Adds `--verbose` / `-v` flag to `eval:langsmith` for consistent logging output using EvalLogger. This ensures trace filtering statistics are properly formatted.

### Trace filtering
Adds trace payload filtering to reduce the size of data sent to LangSmith during evaluations:
- Summarizes large fields like `cachedTemplates`, `parsedNodeTypes`, and `workflowContext`
- Uses closure-scoped state to avoid issues with parallel evaluations
- Adds `LANGSMITH_MINIMAL_TRACING` env var (default: `true`) to control filtering
- Logs filtering statistics at the end of evaluation runs

This prevents errors from oversized payloads during high-concurrency evaluations.