### PR TITLE
chore(core): Add test to compare insights and workflow statistics

### DIFF
--- a/packages/cli/src/modules/insights/insights-compaction.service.ts
+++ b/packages/cli/src/modules/insights/insights-compaction.service.ts
@@ -4,6 +4,7 @@ import { Service } from '@n8n/di';
 import { InsightsByPeriodRepository } from './database/repositories/insights-by-period.repository';
 import { InsightsRawRepository } from './database/repositories/insights-raw.repository';
 import { InsightsConfig } from './insights.config';
+import { Time } from '@n8n/constants';
 
 /**
  * This service is responsible for compacting lower granularity insights data
@@ -26,7 +27,7 @@ export class InsightsCompactionService {
 		this.stopCompactionTimer();
 		this.compactInsightsTimer = setInterval(
 			async () => await this.compactInsights(),
-			this.insightsConfig.compactionIntervalMinutes * 60 * 1000,
+			this.insightsConfig.compactionIntervalMinutes * Time.minutes.toMilliseconds,
 		);
 		this.logger.debug('Started compaction timer');
 	}

--- a/packages/cli/test/integration/insights/insights-vs-workflow-statistics.integration.test.ts
+++ b/packages/cli/test/integration/insights/insights-vs-workflow-statistics.integration.test.ts
@@ -211,7 +211,7 @@ describe('Insights vs Workflow Statistics Integration', () => {
 	async function waitForStatistics(
 		workflowId: string,
 		expectedCount: number,
-		timeout = 10000,
+		timeout = 30000,
 	): Promise<void> {
 		const start = Date.now();
 		while (Date.now() - start < timeout) {

--- a/packages/cli/test/integration/insights/insights-vs-workflow-statistics.integration.test.ts
+++ b/packages/cli/test/integration/insights/insights-vs-workflow-statistics.integration.test.ts
@@ -1,0 +1,441 @@
+/**
+ * Integration test to compare workflow statistics with insights data.
+ * This test verifies that both systems report consistent execution counts,
+ * properly distinguishing between root executions and subworkflow executions.
+ *
+ * This test actually executes workflows (not just mocking) to ensure end-to-end correctness.
+ * It configures the system for fast compaction and waits for automatic processing.
+ */
+
+import { createTeamProject, createWorkflow, testDb, testModules } from '@n8n/backend-test-utils';
+import type { Project, WorkflowEntity } from '@n8n/db';
+import { ExecutionRepository, StatisticsNames, WorkflowStatisticsRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+import { readFileSync } from 'fs';
+import { InstanceSettings, UnrecognizedNodeTypeError } from 'n8n-core';
+import type { INodeType, INodeTypeData, NodeLoadingDetails } from 'n8n-workflow';
+import { createRunExecutionData } from 'n8n-workflow';
+import path from 'path';
+
+import { InsightsByPeriodRepository } from '@/modules/insights/database/repositories/insights-by-period.repository';
+import { InsightsRawRepository } from '@/modules/insights/database/repositories/insights-raw.repository';
+import { InsightsCompactionService } from '@/modules/insights/insights-compaction.service';
+import { InsightsCollectionService } from '@/modules/insights/insights-collection.service';
+import { WorkflowStatisticsService } from '@/services/workflow-statistics.service';
+import { WorkflowRunner } from '@/workflow-runner';
+
+import * as utils from '../shared/utils';
+import {
+	createParentWorkflowFixture,
+	createSimpleWorkflowFixture,
+	createSubWorkflowFixture,
+} from '../shared/workflow-fixtures';
+
+// ============================================================
+// Helper to load nodes from dist folder
+// ============================================================
+
+const BASE_DIR = path.resolve(__dirname, '../../../..');
+
+function loadNodesFromDist(nodeNames: string[]): INodeTypeData {
+	const nodeTypes: INodeTypeData = {};
+
+	const knownNodes = JSON.parse(
+		readFileSync(path.join(BASE_DIR, 'nodes-base/dist/known/nodes.json'), 'utf-8'),
+	) as Record<string, NodeLoadingDetails>;
+
+	for (const nodeName of nodeNames) {
+		const loadInfo = knownNodes[nodeName.replace('n8n-nodes-base.', '')];
+		if (!loadInfo) {
+			throw new UnrecognizedNodeTypeError('n8n-nodes-base', nodeName);
+		}
+		// Load from dist .js files (sourcePath already includes 'dist/')
+		const nodeDistPath = path.join(BASE_DIR, 'nodes-base', loadInfo.sourcePath);
+		const node = new (require(nodeDistPath)[loadInfo.className])() as INodeType;
+		nodeTypes[nodeName] = {
+			sourcePath: '',
+			type: node,
+		};
+	}
+
+	return nodeTypes;
+}
+
+beforeAll(async () => {
+	// Configure insights for fast flushing and compaction BEFORE loading modules
+	process.env.N8N_INSIGHTS_FLUSH_BATCH_SIZE = '10'; // Flush after 10 events
+	process.env.N8N_INSIGHTS_FLUSH_INTERVAL_SECONDS = '1'; // Flush every 1 second
+	process.env.N8N_INSIGHTS_COMPACTION_INTERVAL_MINUTES = '0.05'; // Compact every ~3 seconds
+	process.env.N8N_INSIGHTS_COMPACTION_BATCH_SIZE = '100'; // Process up to 100 items per batch
+
+	await testModules.loadModules(['insights']);
+	await testDb.init();
+
+	// Load required node types from dist folder
+	const nodeTypes = loadNodesFromDist([
+		'n8n-nodes-base.manualTrigger',
+		'n8n-nodes-base.executeWorkflow',
+		'n8n-nodes-base.executeWorkflowTrigger',
+	]);
+
+	await utils.initNodeTypes(nodeTypes);
+	await utils.initBinaryDataService();
+
+	// Mark instance as leader to enable compaction
+	Container.get(InstanceSettings).markAsLeader();
+});
+
+beforeEach(async () => {
+	await testDb.truncate([
+		'InsightsRaw',
+		'InsightsByPeriod',
+		'InsightsMetadata',
+		'WorkflowEntity',
+		'WorkflowStatistics',
+		'ExecutionEntity',
+		'Project',
+	]);
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+describe('Insights vs Workflow Statistics Integration', () => {
+	let insightsCollectionService: InsightsCollectionService;
+	let insightsCompactionService: InsightsCompactionService;
+	let insightsByPeriodRepository: InsightsByPeriodRepository;
+	let insightsRawRepository: InsightsRawRepository;
+	let workflowStatisticsRepository: WorkflowStatisticsRepository;
+	let workflowRunner: WorkflowRunner;
+	let executionRepository: ExecutionRepository;
+
+	let project: Project;
+	let workflow1: WorkflowEntity;
+	let workflow2: WorkflowEntity;
+	let workflow3Subworkflow: WorkflowEntity;
+
+	beforeAll(() => {
+		// CRITICAL: Ensure SKIP_STATISTICS_EVENTS is not set
+		// The WorkflowStatisticsService checks this in its constructor
+		delete process.env.SKIP_STATISTICS_EVENTS;
+
+		// IMPORTANT: Get WorkflowStatisticsService early to ensure its event listeners are set up
+		// This must be done BEFORE any workflows are executed
+		const workflowStatisticsService = Container.get(WorkflowStatisticsService);
+		// Just getting it from the container initializes it and sets up its event listeners
+		console.log('WorkflowStatisticsService initialized:', !!workflowStatisticsService);
+
+		insightsCollectionService = Container.get(InsightsCollectionService);
+		insightsCompactionService = Container.get(InsightsCompactionService);
+		insightsByPeriodRepository = Container.get(InsightsByPeriodRepository);
+		insightsRawRepository = Container.get(InsightsRawRepository);
+		workflowStatisticsRepository = Container.get(WorkflowStatisticsRepository);
+		workflowRunner = Container.get(WorkflowRunner);
+		executionRepository = Container.get(ExecutionRepository);
+
+		// Initialize insights collection service (config already set via env vars)
+		insightsCollectionService.init();
+
+		// Start automatic compaction timer
+		insightsCompactionService.startCompactionTimer();
+	});
+
+	afterAll(() => {
+		// Stop compaction timer
+		insightsCompactionService.stopCompactionTimer();
+	});
+
+	beforeEach(async () => {
+		project = await createTeamProject('Test Project');
+
+		// Create workflow 1 - standalone workflow with manual trigger
+		workflow1 = await createWorkflow(
+			{
+				name: 'Workflow 1 - Standalone',
+				...createSimpleWorkflowFixture(),
+				settings: {
+					timeSavedPerExecution: 5,
+				},
+			},
+			project,
+		);
+
+		// Create workflow 3 (subworkflow) first so we can reference it in workflow 2
+		workflow3Subworkflow = await createWorkflow(
+			{
+				name: 'Workflow 3 - Subworkflow',
+				...createSubWorkflowFixture(),
+				settings: {
+					timeSavedPerExecution: 2,
+				},
+			},
+			project,
+		);
+
+		// Create workflow 2 - parent workflow that calls workflow 3
+		workflow2 = await createWorkflow(
+			{
+				name: 'Workflow 2 - Parent',
+				...createParentWorkflowFixture(workflow3Subworkflow.id),
+				settings: {
+					timeSavedPerExecution: 3,
+				},
+			},
+			project,
+		);
+	});
+
+	/**
+	 * Helper to wait for an execution to complete by polling the database
+	 */
+	async function waitForExecution(executionId: string, timeout = 10000): Promise<void> {
+		const start = Date.now();
+		while (Date.now() - start < timeout) {
+			const execution = await executionRepository.findOneBy({ id: executionId });
+			if (execution?.finished) {
+				// Log execution status for debugging
+				if (execution.status !== 'success') {
+					console.log(`Execution ${executionId} finished with status: ${execution.status}`);
+				}
+				return;
+			}
+			await new Promise((resolve) => setTimeout(resolve, 100));
+		}
+		throw new Error(`Execution ${executionId} did not complete within ${timeout}ms`);
+	}
+
+	/**
+	 * Helper to wait for workflow statistics to be recorded
+	 */
+	async function waitForStatistics(
+		workflowId: string,
+		expectedCount: number,
+		timeout = 10000,
+	): Promise<void> {
+		const start = Date.now();
+		while (Date.now() - start < timeout) {
+			const stats = await workflowStatisticsRepository.findOne({
+				where: {
+					workflowId,
+					name: StatisticsNames.productionSuccess,
+				},
+			});
+			if (stats && stats.count >= expectedCount) {
+				return;
+			}
+			await new Promise((resolve) => setTimeout(resolve, 100));
+		}
+		throw new Error(
+			`Workflow statistics did not reach expected count ${expectedCount} within ${timeout}ms`,
+		);
+	}
+
+	/**
+	 * Helper to wait for insights to be compacted (raw insights cleared and compacted data available)
+	 */
+	async function waitForCompaction(workflowId: string, timeout = 30000): Promise<void> {
+		const start = Date.now();
+		while (Date.now() - start < timeout) {
+			// Check if raw insights have been compacted (should be low or zero)
+			const rawInsights = await insightsRawRepository.find();
+			// Check if compacted insights exist for this workflow
+			const compactedInsights = await insightsByPeriodRepository.find({
+				where: {
+					metadata: { workflowId },
+				},
+				relations: ['metadata'],
+			});
+
+			// Compaction is done if we have compacted data and few/no raw insights
+			if (compactedInsights.length > 0 && rawInsights.length < 10) {
+				return;
+			}
+			await new Promise((resolve) => setTimeout(resolve, 500));
+		}
+		throw new Error(`Insights compaction did not complete within ${timeout}ms`);
+	}
+
+	/**
+	 * Helper to execute a workflow in webhook/trigger mode
+	 */
+	async function executeWorkflow(
+		workflow: WorkflowEntity,
+		mode: 'webhook' | 'trigger' = 'webhook',
+	): Promise<string> {
+		const executionData = createRunExecutionData({});
+
+		const executionId = await workflowRunner.run(
+			{
+				workflowData: workflow,
+				userId: project.id,
+				executionMode: mode,
+				executionData,
+			},
+			true,
+		);
+
+		return executionId;
+	}
+
+	test('should match execution counts between insights and workflow statistics for standalone workflow', async () => {
+		// ============================================================
+		// ACT: Execute workflow 1 (standalone) ten times in webhook mode
+		// ============================================================
+		const execution1Ids: string[] = [];
+		for (let i = 0; i < 10; i++) {
+			const executionId = await executeWorkflow(workflow1, 'webhook');
+			execution1Ids.push(executionId);
+		}
+
+		// Wait for all executions to complete
+		await Promise.all(execution1Ids.map(async (id) => await waitForExecution(id)));
+
+		// Wait for workflow statistics to be recorded
+		await waitForStatistics(workflow1.id, 10);
+
+		// Wait for automatic compaction to complete
+		await waitForCompaction(workflow1.id);
+
+		// ============================================================
+		// ASSERT: Query workflow statistics
+		// ============================================================
+		const stats1 = await workflowStatisticsRepository.findOne({
+			where: {
+				workflowId: workflow1.id,
+				name: StatisticsNames.productionSuccess,
+			},
+		});
+
+		// Verify workflow statistics counts
+		expect(stats1).toBeDefined();
+		expect(stats1?.count).toBe(10); // Total executions
+		expect(stats1?.rootCount).toBe(10); // All are root executions
+
+		// ============================================================
+		// ASSERT: Query insights data (compacted)
+		// ============================================================
+		const allInsights1 = await insightsByPeriodRepository.find({
+			where: {
+				metadata: { workflowId: workflow1.id },
+			},
+			relations: ['metadata'],
+		});
+
+		// Filter by type 'success'
+		const insights1 = allInsights1.filter((insight) => insight.type === 'success');
+		const insights1SuccessCount = insights1.reduce((sum, insight) => sum + insight.value, 0);
+
+		// Insights should match root execution counts
+		expect(insights1SuccessCount).toBe(10);
+		expect(insights1SuccessCount).toBe(stats1?.rootCount);
+
+		// Verify runtime metrics
+		const insights1Runtime = allInsights1.filter((insight) => insight.type === 'runtime_ms');
+		const totalRuntime1 = insights1Runtime.reduce((sum, insight) => sum + insight.value, 0);
+		expect(totalRuntime1).toBeGreaterThan(0);
+
+		// Verify time saved metrics
+		const insights1TimeSaved = allInsights1.filter((insight) => insight.type === 'time_saved_min');
+		const totalTimeSaved1 = insights1TimeSaved.reduce((sum, insight) => sum + insight.value, 0);
+		expect(totalTimeSaved1).toBe(10 * 5); // 10 executions * 5 minutes saved per execution
+	}, 60000);
+
+	test('should match execution counts for parent workflow calling subworkflow', async () => {
+		// ============================================================
+		// ACT: Execute workflow 2 (parent) ten times in webhook mode
+		// This will trigger workflow 3 (subworkflow) as well
+		// ============================================================
+		const execution2Ids: string[] = [];
+		for (let i = 0; i < 10; i++) {
+			const executionId = await executeWorkflow(workflow2, 'webhook');
+			execution2Ids.push(executionId);
+		}
+
+		// Wait for all parent executions to complete
+		await Promise.all(execution2Ids.map(async (id) => await waitForExecution(id)));
+
+		// Wait for workflow statistics to be recorded for both workflows
+		await waitForStatistics(workflow2.id, 10); // Parent: 10 root executions
+		await waitForStatistics(workflow3Subworkflow.id, 10); // Subworkflow: 10 non-root executions
+
+		// Wait for automatic compaction
+		await waitForCompaction(workflow2.id);
+		await waitForCompaction(workflow3Subworkflow.id);
+
+		// Debug: Check all executions
+		const allExecutions = await executionRepository.find();
+		const wf2Execs = allExecutions.filter((e) => e.workflowId === workflow2.id);
+		const wf3Execs = allExecutions.filter((e) => e.workflowId === workflow3Subworkflow.id);
+		console.log(
+			`Executions: Parent=${wf2Execs.length}, Subworkflow=${wf3Execs.length}, Total=${allExecutions.length}`,
+		);
+
+		// ============================================================
+		// ASSERT: Workflow 2 (Parent) Statistics
+		// ============================================================
+		const stats2 = await workflowStatisticsRepository.findOne({
+			where: {
+				workflowId: workflow2.id,
+				name: StatisticsNames.productionSuccess,
+			},
+		});
+
+		expect(stats2).toBeDefined();
+		expect(stats2?.count).toBe(10); // 10 parent executions
+		expect(stats2?.rootCount).toBe(10); // All parent executions are root
+
+		// ============================================================
+		// ASSERT: Workflow 3 (Subworkflow) Statistics
+		// ============================================================
+		const stats3 = await workflowStatisticsRepository.findOne({
+			where: {
+				workflowId: workflow3Subworkflow.id,
+				name: StatisticsNames.productionSuccess,
+			},
+		});
+
+		expect(stats3).toBeDefined();
+		expect(stats3?.count).toBe(10); // 10 subworkflow executions
+		expect(stats3?.rootCount).toBe(0); // None are root (all called by parent)
+
+		// ============================================================
+		// ASSERT: Workflow 2 (Parent) Insights - Should track root executions
+		// ============================================================
+		const allInsights2 = await insightsByPeriodRepository.find({
+			where: {
+				metadata: { workflowId: workflow2.id },
+			},
+			relations: ['metadata'],
+		});
+
+		const insights2Success = allInsights2.filter((insight) => insight.type === 'success');
+		const insights2SuccessCount = insights2Success.reduce((sum, insight) => sum + insight.value, 0);
+
+		// Insights should match root execution counts only
+		expect(insights2SuccessCount).toBe(10);
+		expect(insights2SuccessCount).toBe(stats2?.rootCount);
+
+		// Verify time saved for parent
+		const insights2TimeSaved = allInsights2.filter((insight) => insight.type === 'time_saved_min');
+		const totalTimeSaved2 = insights2TimeSaved.reduce((sum, insight) => sum + insight.value, 0);
+		expect(totalTimeSaved2).toBe(10 * 3); // 10 executions * 3 minutes
+
+		// ============================================================
+		// ASSERT: Workflow 3 (Subworkflow) Insights - Should NOT track (rootCount = 0)
+		// ============================================================
+		const allInsights3 = await insightsByPeriodRepository.find({
+			where: {
+				metadata: { workflowId: workflow3Subworkflow.id },
+			},
+			relations: ['metadata'],
+		});
+
+		const insights3Success = allInsights3.filter((insight) => insight.type === 'success');
+		const insights3SuccessCount = insights3Success.reduce((sum, insight) => sum + insight.value, 0);
+
+		// Insights should be 0 for subworkflow (not root executions)
+		expect(insights3SuccessCount).toBe(0);
+		expect(insights3SuccessCount).toBe(stats3?.rootCount);
+	}, 60000);
+});

--- a/packages/cli/test/integration/insights/insights-vs-workflow-statistics.integration.test.ts
+++ b/packages/cli/test/integration/insights/insights-vs-workflow-statistics.integration.test.ts
@@ -181,7 +181,7 @@ describe('Insights vs Workflow Statistics Integration', () => {
 	async function waitForStatistics(
 		workflowId: string,
 		expectedCount: number,
-		timeout = 30000,
+		timeout = 10000,
 	): Promise<void> {
 		const start = Date.now();
 		while (Date.now() - start < timeout) {
@@ -204,7 +204,7 @@ describe('Insights vs Workflow Statistics Integration', () => {
 	/**
 	 * Helper to wait for insights to be compacted (raw insights cleared and compacted data available)
 	 */
-	async function waitForCompaction(workflowId: string, timeout = 30000): Promise<void> {
+	async function waitForCompaction(workflowId: string, timeout = 10000): Promise<void> {
 		const start = Date.now();
 		while (Date.now() - start < timeout) {
 			// Check if raw insights have been compacted (should be low or zero)

--- a/packages/cli/test/integration/shared/workflow-fixtures.ts
+++ b/packages/cli/test/integration/shared/workflow-fixtures.ts
@@ -3,6 +3,7 @@
  * These fixtures create minimal workflow structures needed for testing.
  */
 
+import { NodeConnectionTypes } from 'n8n-workflow';
 import { v4 as uuid } from 'uuid';
 
 /**
@@ -88,7 +89,7 @@ export function createParentWorkflowFixture(childWorkflowId: string) {
 					[
 						{
 							node: 'Execute Workflow',
-							type: 'main',
+							type: NodeConnectionTypes.Main,
 							index: 0,
 						},
 					],
@@ -161,7 +162,7 @@ export function createMiddleWorkflowFixture(childWorkflowId: string) {
 					[
 						{
 							node: 'Execute Workflow',
-							type: 'main',
+							type: NodeConnectionTypes.Main,
 							index: 0,
 						},
 					],
@@ -247,7 +248,7 @@ export function createFailingWorkflowFixture() {
 					[
 						{
 							node: 'DebugHelper',
-							type: 'main',
+							type: NodeConnectionTypes.Main,
 							index: 0,
 						},
 					],
@@ -291,7 +292,7 @@ export function createWorkflowWithErrorHandlerFixture(errorWorkflowId: string) {
 					[
 						{
 							node: 'DebugHelper',
-							type: 'main',
+							type: NodeConnectionTypes.Main,
 							index: 0,
 						},
 					],


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
This PR adds integration tests to compare workflow statistics and insights computed numbers after workflow executions, to make sure that root production execution matches with insights execution count
The test is minimal for now, and should be augmented at some point. But I encountered test environment issues with sqlite locking when running workflows and subworkflows

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-4144/create-integration-tests-to-compare-insights-and-workflow-statistics

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
