### PR TITLE
fix(core):  Modify path validation to work cross platforms

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
@@ -211,6 +211,38 @@ describe('isFilePathBlocked', () => {
 		expect(isFilePathBlocked(await resolvePath('/tmp/xo'))).toBe(true);
 	});
 
+	describe('cross-platform path handling', () => {
+		beforeEach(() => {
+			// Use default .git blocking pattern
+			securityConfig.blockFilePatterns = '^(.*\\/)*\\.git(\\/.*)*$';
+		});
+
+		it('should handle Windows-style paths for .git directory', async () => {
+			const windowsGitPath = 'C:\\repo\\.git\\config';
+			expect(isFilePathBlocked(await resolvePath(windowsGitPath))).toBe(true);
+		});
+
+		it('should handle nested Windows paths for .git subdirectories', async () => {
+			const windowsGitPath = 'C:\\Users\\user\\project\\.git\\hooks\\pre-commit';
+			expect(isFilePathBlocked(await resolvePath(windowsGitPath))).toBe(true);
+		});
+
+		it('should handle mixed path separators', async () => {
+			const mixedPath = 'C:\\repo/.git\\objects\\abc123';
+			expect(isFilePathBlocked(await resolvePath(mixedPath))).toBe(true);
+		});
+
+		it('should allow legitimate files with git-related extensions', async () => {
+			const legitimatePath = 'C:\\repo\\somefile.txt';
+			expect(isFilePathBlocked(await resolvePath(legitimatePath))).toBe(false);
+		});
+
+		it('should handle Windows absolute paths to .git', async () => {
+			const windowsRootGit = 'C:\\.git';
+			expect(isFilePathBlocked(await resolvePath(windowsRootGit))).toBe(true);
+		});
+	});
+
 	describe('when multiple file patterns are configured', () => {
 		beforeEach(() => {
 			securityConfig.blockFilePatterns = 'hello; \\/there$; ^where';

--- a/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
@@ -10,7 +10,7 @@ import {
 	writeFile as fsWriteFile,
 	realpath as fsRealpath,
 } from 'node:fs/promises';
-import { resolve } from 'node:path';
+import { resolve, posix } from 'node:path';
 
 import {
 	BINARY_DATA_STORAGE_PATH,
@@ -49,13 +49,16 @@ async function resolvePath(path: PathLike): Promise<ResolvedFilePath> {
 function isFilePatternBlocked(resolvedFilePath: ResolvedFilePath): boolean {
 	const { blockFilePatterns } = Container.get(SecurityConfig);
 
+	// Normalize path separators for cross-platform compatibility
+	const normalizedPath = posix.normalize(resolvedFilePath.replace(/\\/g, '/'));
+
 	return blockFilePatterns
 		.split(';')
 		.map((pattern) => pattern.trim())
 		.filter((pattern) => pattern)
 		.some((pattern) => {
 			try {
-				return new RegExp(pattern, 'mi').test(resolvedFilePath);
+				return new RegExp(pattern, 'mi').test(normalizedPath);
 			} catch {
 				return true;
 			}


### PR DESCRIPTION
## Summary
This PR fixes an issue in path validation by normalising the path before validation to ensure the validation works cross platform. this is mainly to support the usage of backslashes in Windows file pathes

Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-4148


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
