### PR TITLE
fix(Stripe Trigger Node): Add Stripe signature verification

### DIFF
--- a/packages/nodes-base/credentials/StripeApi.credentials.ts
+++ b/packages/nodes-base/credentials/StripeApi.credentials.ts
@@ -20,6 +20,27 @@ export class StripeApi implements ICredentialType {
 			typeOptions: { password: true },
 			default: '',
 		},
+		{
+			displayName: 'Signature Secret',
+			name: 'signatureSecret',
+			type: 'string',
+			typeOptions: { password: true },
+			default: '',
+			description:
+				'The signature secret is used to verify the authenticity of requests sent by Stripe.',
+		},
+		{
+			displayName:
+				'We strongly recommend setting up a <a href="https://stripe.com/docs/webhooks" target="_blank">signing secret</a> to ensure the authenticity of requests.',
+			name: 'notice',
+			type: 'notice',
+			default: '',
+			displayOptions: {
+				show: {
+					signatureSecret: [''],
+				},
+			},
+		},
 	];
 
 	authenticate: IAuthenticateGeneric = {

--- a/packages/nodes-base/nodes/Stripe/StripeTriggerHelpers.ts
+++ b/packages/nodes-base/nodes/Stripe/StripeTriggerHelpers.ts
@@ -1,0 +1,74 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+import type { IWebhookFunctions } from 'n8n-workflow';
+
+export async function verifySignature(this: IWebhookFunctions): Promise<boolean> {
+	const credential = await this.getCredentials('stripeApi');
+	if (!credential?.signatureSecret) {
+		return true; // No signature secret provided, skip verification
+	}
+
+	const req = this.getRequestObject();
+
+	const signature = req.header('stripe-signature');
+	if (!signature) {
+		return false;
+	}
+
+	// Parse the Stripe signature header
+	const elements = signature.split(',');
+	let timestamp: string | undefined;
+	let signatureValue: string | undefined;
+
+	for (const element of elements) {
+		if (element.startsWith('t=')) {
+			timestamp = element.substring(2);
+		} else if (element.startsWith('v1=')) {
+			signatureValue = element.substring(3);
+		}
+	}
+
+	if (!timestamp || !signatureValue) {
+		return false;
+	}
+
+	// Verify timestamp
+	const currentTimestamp = Math.floor(Date.now() / 1000);
+	const webhookTimestamp = parseInt(timestamp, 10);
+	const TIMESTAMP_TOLERANCE_SECONDS = 300; // 5 minutes
+
+	if (Math.abs(currentTimestamp - webhookTimestamp) > TIMESTAMP_TOLERANCE_SECONDS) {
+		return false;
+	}
+
+	try {
+		if (typeof credential.signatureSecret !== 'string') {
+			return false;
+		}
+
+		if (!req.rawBody) {
+			return false;
+		}
+
+		let rawBodyString: string;
+		if (Buffer.isBuffer(req.rawBody)) {
+			rawBodyString = req.rawBody.toString();
+		} else {
+			rawBodyString = typeof req.rawBody === 'string' ? req.rawBody : JSON.stringify(req.rawBody);
+		}
+
+		const signedPayload = `${timestamp}.${rawBodyString}`;
+		const hmac = createHmac('sha256', credential.signatureSecret);
+		hmac.update(signedPayload);
+		const computedSignature = hmac.digest('hex');
+
+		const computedBuffer = Buffer.from(computedSignature);
+		const providedBuffer = Buffer.from(signatureValue);
+
+		return (
+			computedBuffer.length === providedBuffer.length &&
+			timingSafeEqual(computedBuffer, providedBuffer)
+		);
+	} catch (error) {
+		return false;
+	}
+}

--- a/packages/nodes-base/nodes/Stripe/__tests__/StripeTriggerHelpers.test.ts
+++ b/packages/nodes-base/nodes/Stripe/__tests__/StripeTriggerHelpers.test.ts
@@ -1,0 +1,234 @@
+import { createHmac } from 'crypto';
+import type { IWebhookFunctions } from 'n8n-workflow';
+
+import { verifySignature } from '../StripeTriggerHelpers';
+
+describe('StripeTriggerHelpers', () => {
+	describe('verifySignature', () => {
+		let mockWebhookFunctions: IWebhookFunctions;
+		const webhookSecret = 'whsec_test123456789';
+		const getCurrentTimestamp = () => Math.floor(Date.now() / 1000).toString();
+		const testBody = { type: 'charge.succeeded', id: 'ch_123' };
+		const rawBody = JSON.stringify(testBody);
+
+		function generateValidSignature(timestamp: string, body: string, secret: string): string {
+			const signedPayload = `${timestamp}.${body}`;
+			const signature = createHmac('sha256', secret).update(signedPayload).digest('hex');
+			return `t=${timestamp},v1=${signature}`;
+		}
+
+		beforeEach(() => {
+			mockWebhookFunctions = {
+				getCredentials: jest.fn().mockResolvedValue({
+					secretKey: 'sk_test_123',
+					signatureSecret: webhookSecret,
+				}),
+				getRequestObject: jest.fn().mockReturnValue({
+					header: jest.fn(),
+					rawBody: Buffer.from(rawBody),
+				}),
+			} as unknown as IWebhookFunctions;
+		});
+
+		it('should return true when no signature secret is provided', async () => {
+			(mockWebhookFunctions.getCredentials as jest.Mock).mockResolvedValue({
+				secretKey: 'sk_test_123',
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false when stripe-signature header is missing', async () => {
+			const mockHeader = jest.fn().mockReturnValue(undefined);
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				header: mockHeader,
+				rawBody: Buffer.from(rawBody),
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+			expect(mockHeader).toHaveBeenCalledWith('stripe-signature');
+		});
+
+		it('should return false when signature format is invalid', async () => {
+			const mockHeader = jest.fn().mockReturnValue('invalid-format');
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				header: mockHeader,
+				rawBody: Buffer.from(rawBody),
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false when timestamp is missing', async () => {
+			const timestamp = getCurrentTimestamp();
+			const signature = createHmac('sha256', webhookSecret)
+				.update(`${timestamp}.${rawBody}`)
+				.digest('hex');
+			const mockHeader = jest.fn().mockReturnValue(`v1=${signature}`);
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				header: mockHeader,
+				rawBody: Buffer.from(rawBody),
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false when v1 signature is missing', async () => {
+			const timestamp = getCurrentTimestamp();
+			const mockHeader = jest.fn().mockReturnValue(`t=${timestamp}`);
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				header: mockHeader,
+				rawBody: Buffer.from(rawBody),
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return true when signature is valid', async () => {
+			const timestamp = getCurrentTimestamp();
+			const validSignature = generateValidSignature(timestamp, rawBody, webhookSecret);
+			const mockHeader = jest.fn().mockReturnValue(validSignature);
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				header: mockHeader,
+				rawBody: Buffer.from(rawBody),
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false when signature is invalid', async () => {
+			const timestamp = getCurrentTimestamp();
+			const wrongSecret = 'wrong_secret';
+			const invalidSignature = generateValidSignature(timestamp, rawBody, wrongSecret);
+			const mockHeader = jest.fn().mockReturnValue(invalidSignature);
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				header: mockHeader,
+				rawBody: Buffer.from(rawBody),
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should handle complex signature header with multiple elements', async () => {
+			const timestamp = getCurrentTimestamp();
+			const signature = createHmac('sha256', webhookSecret)
+				.update(`${timestamp}.${rawBody}`)
+				.digest('hex');
+			const complexHeader = `t=${timestamp},v1=${signature},v0=old_signature`;
+			const mockHeader = jest.fn().mockReturnValue(complexHeader);
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				header: mockHeader,
+				rawBody: Buffer.from(rawBody),
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should handle string rawBody', async () => {
+			const timestamp = getCurrentTimestamp();
+			const validSignature = generateValidSignature(timestamp, rawBody, webhookSecret);
+			const mockHeader = jest.fn().mockReturnValue(validSignature);
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				header: mockHeader,
+				rawBody, // String instead of Buffer
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false when rawBody is missing', async () => {
+			const timestamp = getCurrentTimestamp();
+			const validSignature = generateValidSignature(timestamp, rawBody, webhookSecret);
+			const mockHeader = jest.fn().mockReturnValue(validSignature);
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				header: mockHeader,
+				rawBody: null,
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false when signatureSecret is not a string', async () => {
+			const timestamp = getCurrentTimestamp();
+			const validSignature = generateValidSignature(timestamp, rawBody, webhookSecret);
+			const mockHeader = jest.fn().mockReturnValue(validSignature);
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				header: mockHeader,
+				rawBody: Buffer.from(rawBody),
+			});
+			(mockWebhookFunctions.getCredentials as jest.Mock).mockResolvedValue({
+				secretKey: 'sk_test_123',
+				signatureSecret: 123, // Not a string
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false when timestamp is older than 5 minutes', async () => {
+			// Create timestamp that's 6 minutes (360 seconds) old
+			const oldTimestamp = (Math.floor(Date.now() / 1000) - 360).toString();
+			const validSignature = generateValidSignature(oldTimestamp, rawBody, webhookSecret);
+			const mockHeader = jest.fn().mockReturnValue(validSignature);
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				header: mockHeader,
+				rawBody: Buffer.from(rawBody),
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false when timestamp is from the future beyond tolerance', async () => {
+			// Create timestamp that's 6 minutes (360 seconds) in the future
+			const futureTimestamp = (Math.floor(Date.now() / 1000) + 360).toString();
+			const validSignature = generateValidSignature(futureTimestamp, rawBody, webhookSecret);
+			const mockHeader = jest.fn().mockReturnValue(validSignature);
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				header: mockHeader,
+				rawBody: Buffer.from(rawBody),
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return true when timestamp is within tolerance', async () => {
+			// Create timestamp that's 4 minutes (240 seconds) old - within 5 minute tolerance
+			const recentTimestamp = (Math.floor(Date.now() / 1000) - 240).toString();
+			const validSignature = generateValidSignature(recentTimestamp, rawBody, webhookSecret);
+			const mockHeader = jest.fn().mockReturnValue(validSignature);
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				header: mockHeader,
+				rawBody: Buffer.from(rawBody),
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

This PR implements proper Stripe webhook signature verification by validating the Stripe-Signature
header against the webhook secret using HMAC-SHA256. This ensures webhook authenticity and follows
Stripe's recommended verification process for incoming webhook events.
Similar to https://github.com/n8n-io/n8n/pull/17838

Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-4018/missing-stripe-signature-verification


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
