### PR TITLE
fix(core): Inserts into execution metadata table fail due to fk

### DIFF
--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -26,6 +26,7 @@ import type {
 import { EventService } from '@/events/event.service';
 import { ExternalHooks } from '@/external-hooks';
 import { Push } from '@/push';
+import { ExecutionMetadataService } from '@/services/execution-metadata.service';
 import { OwnershipService } from '@/services/ownership.service';
 import { WorkflowStatisticsService } from '@/services/workflow-statistics.service';
 import { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
@@ -44,6 +45,7 @@ describe('Execution Lifecycle Hooks', () => {
 	const errorReporter = mockInstance(ErrorReporter);
 	const eventService = mockInstance(EventService);
 	const executionRepository = mockInstance(ExecutionRepository);
+	const executionMetadataService = mockInstance(ExecutionMetadataService);
 	const externalHooks = mockInstance(ExternalHooks);
 	const push = mockInstance(Push);
 	const workflowStaticDataService = mockInstance(WorkflowStaticDataService);
@@ -105,6 +107,19 @@ describe('Execution Lifecycle Hooks', () => {
 		status: 'waiting',
 		waitTill: new Date(),
 	});
+	const successfulRunWithMetadata = mock<IRun>({
+		status: 'success',
+		finished: true,
+		waitTill: undefined,
+		data: {
+			resultData: {
+				metadata: {
+					testKey1: 'testValue1',
+					testKey2: 'testValue2',
+				},
+			},
+		},
+	});
 	const expressionError = new ExpressionError('Error');
 	const pushRef = 'test-push-ref';
 	const retryOf = 'test-retry-of';
@@ -136,6 +151,15 @@ describe('Execution Lifecycle Hooks', () => {
 			},
 			resultData: {
 				runData: {},
+			},
+		});
+		successfulRunWithMetadata.data = createRunExecutionData({
+			resultData: {
+				runData: {},
+				metadata: {
+					testKey1: 'testValue1',
+					testKey2: 'testValue2',
+				},
 			},
 		});
 	});
@@ -536,6 +560,38 @@ describe('Execution Lifecycle Hooks', () => {
 				});
 			});
 
+			describe('saving metadata', () => {
+				it('should save metadata in regular main mode', async () => {
+					await lifecycleHooks.runHook('workflowExecuteAfter', [successfulRunWithMetadata, {}]);
+
+					expect(executionMetadataService.save).toHaveBeenCalledWith(executionId, {
+						testKey1: 'testValue1',
+						testKey2: 'testValue2',
+					});
+				});
+
+				it('should not save metadata if execution has none', async () => {
+					await lifecycleHooks.runHook('workflowExecuteAfter', [successfulRun, {}]);
+
+					expect(executionMetadataService.save).not.toHaveBeenCalled();
+				});
+
+				it('should save metadata even if execution will be kept (not deleted)', async () => {
+					lifecycleHooks = createHooks('trigger');
+					workflowData.settings = {
+						saveDataSuccessExecution: 'all',
+					};
+
+					await lifecycleHooks.runHook('workflowExecuteAfter', [successfulRunWithMetadata, {}]);
+
+					expect(executionMetadataService.save).toHaveBeenCalledWith(executionId, {
+						testKey1: 'testValue1',
+						testKey2: 'testValue2',
+					});
+					expect(executionRepository.hardDelete).not.toHaveBeenCalled();
+				});
+			});
+
 			describe('error workflow', () => {
 				it('should not execute error workflow for manual executions', async () => {
 					await lifecycleHooks.runHook('workflowExecuteAfter', [failedRun, {}]);
@@ -727,6 +783,50 @@ describe('Execution Lifecycle Hooks', () => {
 					executionId,
 				});
 			});
+
+			describe('metadata handling', () => {
+				it('should save metadata in scaling main mode when execution is kept', async () => {
+					// Test that scaling main saves metadata when execution is not deleted
+					await lifecycleHooks.runHook('workflowExecuteAfter', [successfulRunWithMetadata, {}]);
+
+					expect(executionMetadataService.save).toHaveBeenCalledWith(executionId, {
+						testKey1: 'testValue1',
+						testKey2: 'testValue2',
+					});
+				});
+
+				it('should NOT save metadata in scaling main mode when execution is deleted', async () => {
+					workflowData.settings = {
+						saveDataSuccessExecution: 'none' as const,
+						saveDataErrorExecution: 'all' as const,
+					};
+					const testLifecycleHooks = getLifecycleHooksForScalingMain(
+						{
+							executionMode: 'webhook',
+							workflowData,
+							pushRef,
+							retryOf,
+						},
+						executionId,
+					);
+
+					await testLifecycleHooks.runHook('workflowExecuteAfter', [successfulRunWithMetadata, {}]);
+
+					// Metadata should not be saved before deletion
+					expect(executionMetadataService.save).not.toHaveBeenCalled();
+					// Execution should be deleted
+					expect(executionRepository.hardDelete).toHaveBeenCalledWith({
+						workflowId,
+						executionId,
+					});
+				});
+
+				it('should NOT save metadata when execution has none', async () => {
+					await lifecycleHooks.runHook('workflowExecuteAfter', [successfulRun, {}]);
+
+					expect(executionMetadataService.save).not.toHaveBeenCalled();
+				});
+			});
 		});
 	});
 
@@ -823,6 +923,32 @@ describe('Execution Lifecycle Hooks', () => {
 						},
 					},
 					project,
+				);
+			});
+		});
+
+		describe('metadata handling', () => {
+			it('should NOT save metadata in scaling worker mode', async () => {
+				const lifecycleHooks = createHooks('trigger');
+
+				await lifecycleHooks.runHook('workflowExecuteAfter', [successfulRunWithMetadata, {}]);
+
+				// Worker should never save metadata - that's main's responsibility
+				expect(executionMetadataService.save).not.toHaveBeenCalled();
+			});
+
+			it('should still update execution data in scaling worker mode', async () => {
+				const lifecycleHooks = createHooks('trigger');
+
+				await lifecycleHooks.runHook('workflowExecuteAfter', [successfulRunWithMetadata, {}]);
+
+				// Worker should save execution data but not metadata
+				expect(executionRepository.updateExistingExecution).toHaveBeenCalledWith(
+					executionId,
+					expect.objectContaining({
+						finished: true,
+						status: 'success',
+					}),
 				);
 			});
 		});

--- a/packages/cli/src/execution-lifecycle/shared/shared-hook-functions.ts
+++ b/packages/cli/src/execution-lifecycle/shared/shared-hook-functions.ts
@@ -73,6 +73,22 @@ export function prepareExecutionDataForDbUpdate(parameters: {
 	return fullExecutionData;
 }
 
+export async function updateExistingExecutionMetadata(
+	executionId: string,
+	metadata?: Record<string, string>,
+) {
+	const logger = Container.get(Logger);
+
+	try {
+		if (metadata && Object.keys(metadata).length > 0) {
+			await Container.get(ExecutionMetadataService).save(executionId, metadata);
+		}
+	} catch (e) {
+		const error = ensureError(e);
+		logger.error(`Failed to save metadata for execution ID ${executionId}`, { error });
+	}
+}
+
 export async function updateExistingExecution(parameters: {
 	executionId: string;
 	workflowId: string;
@@ -89,18 +105,6 @@ export async function updateExistingExecution(parameters: {
 	});
 
 	await Container.get(ExecutionRepository).updateExistingExecution(executionId, executionData);
-
-	try {
-		if (executionData.data?.resultData.metadata) {
-			await Container.get(ExecutionMetadataService).save(
-				executionId,
-				executionData.data.resultData.metadata,
-			);
-		}
-	} catch (e) {
-		const error = ensureError(e);
-		logger.error(`Failed to save metadata for execution ID ${executionId}`, { error });
-	}
 
 	if (executionData.finished === true && executionData.retryOf !== undefined) {
 		await Container.get(ExecutionRepository).updateExistingExecution(executionData.retryOf, {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR fixes a bug in scaling mode, when the workers asynchronously saves metadata for an execution that was asynchronously deleted by the main in parallel, which triggers a FK constraint error.
Fixed by having the main saves the metadata, only if the execution was not deleted

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-3329/inserts-into-execution-metadata-table-fail-due-to-fk-constraints


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
