### PR TITLE
fix(editor): Fix ChatHub UI bugs in tool use

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
@@ -134,8 +134,6 @@ const defaultTools = useLocalStorage<INode[] | null>(
 	},
 );
 
-const shouldSkipNextScrollTrigger = ref(false);
-
 const modelFromQuery = computed<ChatModelDto | null>(() => {
 	const agentId = route.query.agentId;
 	const workflowId = route.query.workflowId;
@@ -269,7 +267,12 @@ const messagingState = computed<MessagingState>(() => {
 
 const editingMessageId = ref<string>();
 const messageElementsRef = useTemplateRef('messages');
-const didSubmitInCurrentSession = ref(false);
+const sessionOpenedAt = ref(Date.now());
+const didSubmitInCurrentSession = computed(() => {
+	const lastCreatedAt = chatMessages.value[chatMessages.value.length - 1]?.createdAt;
+
+	return +new Date(lastCreatedAt ?? 0) > sessionOpenedAt.value;
+});
 
 const canAcceptFiles = computed(() => {
 	const baseCondition =
@@ -302,29 +305,11 @@ function scrollToMessage(messageId: ChatMessageId) {
 	});
 }
 
-// Scroll to the bottom when a new message is added
+// Prevent "scroll to bottom" button from appearing when not necessary
 watch(
 	() => chatMessages.value[chatMessages.value.length - 1]?.id,
-	(lastMessageId) => {
-		if (!lastMessageId) {
-			return;
-		}
-
-		if (shouldSkipNextScrollTrigger.value) {
-			shouldSkipNextScrollTrigger.value = false;
-			return;
-		}
-
-		// Prevent "scroll to bottom" button from appearing when not necessary
+	() => {
 		void nextTick(measure);
-
-		if (chatStore.streaming?.sessionId === sessionId.value) {
-			// Scroll to user's prompt when the message is being generated
-			scrollToMessage(chatStore.streaming.promptId);
-			return;
-		}
-
-		scrollToBottom(false);
 	},
 	{ immediate: true, flush: 'post' },
 );
@@ -350,7 +335,7 @@ watch(
 watch(
 	[sessionId, isNewSession],
 	async ([id, isNew]) => {
-		didSubmitInCurrentSession.value = false;
+		sessionOpenedAt.value = Date.now();
 		editingMessageId.value = undefined;
 
 		if (!isNew && !chatStore.getConversation(id)) {
@@ -359,7 +344,10 @@ watch(
 			} catch (error) {
 				toast.showError(error, i18n.baseText('chatHub.error.fetchConversationFailed'));
 				await router.push({ name: CHAT_VIEW });
+				return;
 			}
+
+			scrollToBottom(false);
 		}
 	},
 	{ immediate: true },
@@ -430,10 +418,9 @@ async function onSubmit(message: string, attachments: File[]) {
 		return;
 	}
 
-	didSubmitInCurrentSession.value = true;
 	editingMessageId.value = undefined;
 
-	await chatStore.sendMessage(
+	const streaming = await chatStore.sendMessage(
 		sessionId.value,
 		message,
 		selectedModel.value,
@@ -443,6 +430,7 @@ async function onSubmit(message: string, attachments: File[]) {
 	);
 
 	inputRef.value?.reset();
+	scrollToMessage(streaming.promptId);
 
 	if (isNewSession.value) {
 		// TODO: this should not happen when submit fails
@@ -540,7 +528,6 @@ async function handleSelectAgent(selection: ChatModelDto) {
 }
 
 function handleSwitchAlternative(messageId: string) {
-	shouldSkipNextScrollTrigger.value = true;
 	chatStore.switchAlternative(sessionId.value, messageId);
 }
 

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
@@ -362,6 +362,17 @@ watch(
 	{ immediate: true },
 );
 
+// Focus prompt when streaming is completed
+watch(
+	isResponding,
+	(responding, wasResponding) => {
+		if (!responding && wasResponding) {
+			inputRef.value?.focus();
+		}
+	},
+	{ immediate: true },
+);
+
 watch(
 	currentConversationTitle,
 	(title) => {

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/__test__/data.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/__test__/data.ts
@@ -269,3 +269,121 @@ export function createChatHubModuleSettings(
 		...overrides,
 	};
 }
+
+/**
+ * Simple conversation with one user prompt and one AI response
+ */
+export const SIMPLE_CONVERSATION: ChatHubConversationResponse = {
+	session: createMockSession({
+		id: 'existing-session-123',
+		title: 'Test Conversation',
+		lastMessageAt: new Date().toISOString(),
+		provider: 'custom-agent',
+		agentId: 'agent-123',
+	}),
+	conversation: {
+		messages: {
+			'msg-1': createMockMessageDto({
+				id: 'msg-1',
+				sessionId: 'existing-session-123',
+				content: 'What is the weather today?',
+			}),
+			'msg-2': createMockMessageDto({
+				id: 'msg-2',
+				sessionId: 'existing-session-123',
+				type: 'ai',
+				name: 'Assistant',
+				content: 'The weather is sunny today.',
+				provider: 'custom-agent',
+				agentId: 'agent-123',
+				previousMessageId: 'msg-1',
+			}),
+		},
+	},
+};
+
+/**
+ * Conversation with file attachments for testing editing
+ */
+export const CONVERSATION_WITH_ATTACHMENTS: ChatHubConversationResponse = {
+	session: createMockSession({
+		id: 'existing-session-123',
+		provider: 'custom-agent',
+		agentId: 'agent-123',
+	}),
+	conversation: {
+		messages: {
+			'msg-1': createMockMessageDto({
+				id: 'msg-1',
+				sessionId: 'existing-session-123',
+				content: 'Please analyze these files',
+				attachments: [
+					{ fileName: 'file1.txt', mimeType: 'text/plain' },
+					{ fileName: 'file2.pdf', mimeType: 'application/pdf' },
+					{ fileName: 'file3.jpg', mimeType: 'image/jpeg' },
+				],
+			}),
+			'msg-2': createMockMessageDto({
+				id: 'msg-2',
+				sessionId: 'existing-session-123',
+				type: 'ai',
+				name: 'Assistant',
+				content: 'Analysis complete',
+				provider: 'custom-agent',
+				agentId: 'agent-123',
+				previousMessageId: 'msg-1',
+			}),
+		},
+	},
+};
+
+/**
+ * Multi-step AI conversation where AI sends multiple sequential responses
+ * (e.g., when using tools). This simulates an AI agent performing a multi-step task.
+ */
+export const MULTI_STEP_AI_CONVERSATION: ChatHubConversationResponse = {
+	session: createMockSession({
+		id: 'existing-session-123',
+		provider: 'custom-agent',
+		agentId: 'agent-123',
+	}),
+	conversation: {
+		messages: {
+			'msg-1': createMockMessageDto({
+				id: 'msg-1',
+				sessionId: 'existing-session-123',
+				content: 'Check latest news on the web',
+			}),
+			'msg-2': createMockMessageDto({
+				id: 'msg-2',
+				sessionId: 'existing-session-123',
+				type: 'ai',
+				name: 'Assistant',
+				content: 'I will help you find latest news',
+				provider: 'custom-agent',
+				agentId: 'agent-123',
+				previousMessageId: 'msg-1',
+			}),
+			'msg-3': createMockMessageDto({
+				id: 'msg-3',
+				sessionId: 'existing-session-123',
+				type: 'ai',
+				name: 'Assistant',
+				content: 'Let me use web search tool',
+				provider: 'custom-agent',
+				agentId: 'agent-123',
+				previousMessageId: 'msg-2',
+			}),
+			'msg-4': createMockMessageDto({
+				id: 'msg-4',
+				sessionId: 'existing-session-123',
+				type: 'ai',
+				name: 'Assistant',
+				content: 'Here are latest news: Breaking news today...',
+				provider: 'custom-agent',
+				agentId: 'agent-123',
+				previousMessageId: 'msg-3',
+			}),
+		},
+	},
+};

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chat.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chat.store.ts
@@ -573,6 +573,8 @@ export const useChatStore = defineStore(CHAT_STORE, () => {
 			onStreamDone,
 			onStreamError,
 		);
+
+		return streaming.value;
 	}
 
 	async function editMessage(

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chat.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chat.store.ts
@@ -655,22 +655,35 @@ export const useChatStore = defineStore(CHAT_STORE, () => {
 		agent: ChatModelDto,
 		credentials: ChatHubSendMessageRequest['credentials'],
 	) {
-		const conversation = ensureConversation(sessionId);
-		const previousMessageId = conversation.messages[retryId]?.previousMessageId ?? null;
+		let prompt: ChatMessage | undefined = undefined;
+		let isRetryIdSeen = false;
+
+		for (const m of getActiveMessages(sessionId).toReversed()) {
+			if (m.id === retryId) {
+				isRetryIdSeen = true;
+				continue;
+			}
+
+			if (isRetryIdSeen && m.type === 'human') {
+				prompt = m;
+				break;
+			}
+		}
+
 		const payload: ChatHubRegenerateMessageRequest = {
 			model: agent.model,
 			credentials,
 			timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
 		};
 
-		if (!previousMessageId) {
+		if (!prompt) {
 			throw new Error('No previous message to base regeneration on');
 		}
 
 		streaming.value = {
-			promptPreviousMessageId: previousMessageId,
-			promptId: retryId,
-			promptText: '',
+			promptPreviousMessageId: prompt.previousMessageId,
+			promptId: prompt.id,
+			promptText: prompt.content,
 			sessionId,
 			agent,
 			retryOfMessageId: retryId,


### PR DESCRIPTION
## Summary

This PR fixes ChatHub conversation UI bugs found while testing MCP.

- When agent sends multiple messages, each new message forces unwanted scroll
- Typing indicator is shown on a wrong message while waiting for the first chunk
- Incorrect alternatives are shown after regenerating agent's response that spans multiple messages
- After agent's response is complete, chat input doesn't become focused

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
