### PR TITLE
fix(AI Agent Node): Fix toolInput field in intermediateSteps output

### DIFF
--- a/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
@@ -230,7 +230,15 @@ export function buildSteps(
 				...(typeof messageContent === 'string' && { tool_calls: [toolCall] }),
 			});
 
-			const toolInputForResult = toolInput.input;
+			// Extract tool input arguments for the result
+			let toolInputForResult: IDataObject | string;
+			if (toolInput.input && typeof toolInput.input === 'string') {
+				toolInputForResult = toolInput.input;
+			} else {
+				// Exclude metadata fields: id, log, type
+				const { id, log, type, ...actualInput } = toolInput;
+				toolInputForResult = actualInput;
+			}
 
 			// Build observation from tool result data or error information
 			// When tool execution fails, ai_tool may be missing but error info should be preserved
@@ -253,10 +261,7 @@ export function buildSteps(
 			const toolResult = {
 				action: {
 					tool: nodeNameToToolName(tool.action.nodeName),
-					toolInput:
-						toolInputForResult && typeof toolInputForResult === 'object'
-							? (toolInputForResult as IDataObject)
-							: {},
+					toolInput: toolInputForResult,
 					log: toolInput.log || syntheticAIMessage.content,
 					messageLog: [syntheticAIMessage],
 					toolCallId: toolInput?.id,

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/types.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/types.ts
@@ -27,7 +27,7 @@ export type ToolCallRequest = {
 export type ToolCallData = {
 	action: {
 		tool: string;
-		toolInput: Record<string, unknown>;
+		toolInput: Record<string, unknown> | string;
 		log: string | number | true | object;
 		messageLog?: AIMessage[];
 		toolCallId: IDataObject | GenericValue | GenericValue[] | IDataObject[];


### PR DESCRIPTION
## Summary

  Fixes a bug where the `toolInput` field in `intermediateSteps` output was always empty despite the `log` field showing the input arguments.

  **Changes:**
  - Modified `buildSteps.ts` to properly extract tool input arguments from the action response
  - Updated `toolInput` type to allow both `Record<string, unknown>` and `string` to support both legacy and new formats
  - Added logic to distinguish between:
    - When `input.input` is a string (e.g., Calculator with single `input` parameter)
    - New format: when multiple arguments are present, exclude metadata fields passed in input for rebuilding steps (`id`, `log`, `type`) and return actual input arguments

  **Before:**
  ```json
  {
    "toolInput": {},
  }
```

  After (for single input tools):
  ```json
  {
    "toolInput": "5*343"
  }
```

  After (for multiple args):
  ```json
  {
    "toolInput": {
      "url": "https://examle.org",
      "limit": 1
    }
  }
```

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-1861


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
