### PR TITLE
ci: Adjusts playwright test shards and command

### DIFF
--- a/.github/workflows/playwright-test-ci.yml
+++ b/.github/workflows/playwright-test-ci.yml
@@ -49,8 +49,8 @@ jobs:
     with:
       branch: ${{ inputs.branch }}
       test-mode: local
-      test-command: pnpm --filter=n8n-playwright test:local
-      shards: 5
+      test-command: pnpm --filter=n8n-playwright test:local:e2e-only
+      shards: 6
       runner: ubuntu-latest
       workers: '2'
 
@@ -62,6 +62,6 @@ jobs:
       branch: ${{ inputs.branch }}
       test-mode: local
       test-command: pnpm --filter=n8n-playwright test:local:isolated
-      shards: 1
+      shards: 2
       runner: ubuntu-latest
       workers: '1'


### PR DESCRIPTION

## Summary

Problem: The isolated tests were running at the same time, causing DB resets to trigger while other tests were still running. It always happened in the same test as it was the last in line.

Modifies the Playwright test CI workflow to use an e2e-only test command.
Increases the number of shards for local e2e tests to improve test execution time. Also, increases shards for isolated tests.

## Related Linear tickets, Github issues, and Community forum posts



## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
