### PR TITLE
fix(editor): Fix sticky note color selector padding and toolbar visibility

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNodeToolbar.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNodeToolbar.vue
@@ -221,8 +221,8 @@ function onFocusNode() {
 	}
 }
 
-.forceVisible {
-	opacity: 1 !important;
+.canvasNodeToolbar.forceVisible .canvasNodeToolbarItems {
+	opacity: 1;
 }
 
 .statusIcons {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/toolbar/CanvasNodeStickyColorSelector.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/toolbar/CanvasNodeStickyColorSelector.vue
@@ -95,8 +95,6 @@ onBeforeUnmount(() => {
 <style lang="scss" module>
 .popover {
 	min-width: 208px;
-	margin-bottom: -8px;
-	margin-left: -2px;
 }
 
 .content {
@@ -104,6 +102,7 @@ onBeforeUnmount(() => {
 	flex-direction: row;
 	width: fit-content;
 	gap: var(--spacing--2xs);
+	padding: var(--spacing--2xs);
 }
 
 .color {


### PR DESCRIPTION
##   Summary

Fixes two visual issues with the sticky note color selector:

1. Padding issue: The color circles in the popover had inconsistent padding - only the right side had spacing while top, left, and bottom had none.

Fix: Added padding: var(--spacing--2xs) to the content container and removed unnecessary negative margins.

2. Toolbar disappearing on hover: When opening the color selector and hovering over the popover to select a color, the entire toolbar would disappear. This occurred because the popover is teleported to <body>, causing the mouse to leave the canvas node and losing the CSS hover state.

Fix: Added a CSS rule with proper specificity (3 classes) to keep toolbar items visible when the color selector is open, avoiding the use of !important.

How to test:
1. Create a sticky note on the canvas
2. Hover over it to reveal the toolbar
3. Click the color palette icon
4. Verify padding is consistent around all color circles
5. Hover over the color circles to select a color
6. Verify the toolbar remains visible while selecting

Before:

<img width="347" height="262" alt="image" src="https://github.com/user-attachments/assets/2786ce87-1cea-4fda-bbc1-a92da2343493" />

After:

<img width="388" height="315" alt="image" src="https://github.com/user-attachments/assets/f545cfc7-3470-42a4-b10a-5a75fa3d3088" />

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/ADO-4580/bug-sticky-notes-color-selector-padding-issues
- closes #ADO-4580

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
