### PR TITLE
chore(ai-builder): Add evaluation run type metadata

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/pairwise/runner.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/pairwise/runner.ts
@@ -313,6 +313,19 @@ export async function runPairwiseLangsmithEvaluation(
 
 		const evalStartTime = Date.now();
 
+		// Determine run type for metadata
+		let runType: 'full' | 'by-category' | 'by-id';
+		let filterValue: string | undefined;
+		if (notionId) {
+			runType = 'by-id';
+			filterValue = notionId;
+		} else if (technique) {
+			runType = 'by-category';
+			filterValue = technique;
+		} else {
+			runType = 'full';
+		}
+
 		// Run evaluation using LangSmith's built-in features
 		await evaluate(target, {
 			data,
@@ -326,6 +339,8 @@ export async function runPairwiseLangsmithEvaluation(
 				repetitions,
 				concurrency,
 				scoringMethod: numGenerations > 1 ? 'hierarchical-multi-generation' : 'hierarchical',
+				runType,
+				...(filterValue && { filterValue }),
 			},
 		});
 


### PR DESCRIPTION
## Summary

Adds metadata property when spec evals are run with technique or id filter.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-1754/create-data-pipeline-from-langsmith-to-bigquery

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
