### PR TITLE
chore(ai-builder): Add telemetry event on build with ai button

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.test.ts
@@ -429,6 +429,69 @@ describe('AI Assistant store', () => {
 			source: 'error',
 			task: 'error',
 			workflow_id: '',
+			instance_id: '',
+			canvas_status: 'empty',
+		});
+	});
+
+	it('should call telemetry for opening assistant with build_with_ai source on empty canvas', () => {
+		const assistantStore = useAssistantStore();
+		const workflowsStore = useWorkflowsStore();
+
+		// Ensure canvas is empty
+		workflowsStore.workflow.nodes = [];
+
+		assistantStore.trackUserOpenedAssistant({
+			task: 'placeholder',
+			source: 'build_with_ai',
+			has_existing_session: false,
+		});
+
+		expect(track).toHaveBeenCalledWith('User opened assistant', {
+			source: 'build_with_ai',
+			task: 'placeholder',
+			has_existing_session: false,
+			instance_id: '',
+			workflow_id: '',
+			canvas_status: 'empty',
+			node_type: undefined,
+			error: undefined,
+			chat_session_id: undefined,
+		});
+	});
+
+	it('should call telemetry for opening assistant with build_with_ai source on existing workflow', () => {
+		const assistantStore = useAssistantStore();
+		const workflowsStore = useWorkflowsStore();
+
+		// Add a node to the workflow
+		workflowsStore.workflow.nodes = [
+			{
+				id: '1',
+				type: 'n8n-nodes-base.start',
+				typeVersion: 1,
+				name: 'Start',
+				position: [250, 250],
+				parameters: {},
+			},
+		];
+
+		assistantStore.trackUserOpenedAssistant({
+			task: 'placeholder',
+			source: 'build_with_ai',
+			has_existing_session: false,
+		});
+
+		expect(track).toHaveBeenCalledWith('User opened assistant', {
+			source: 'build_with_ai',
+			task: 'placeholder',
+			has_existing_session: false,
+			instance_id: '',
+			workflow_id: '',
+			canvas_status: 'existing_workflow',
+			node_type: undefined,
+			error: undefined,
+			chat_session_id: undefined,
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.test.ts
@@ -460,7 +460,7 @@ describe('AI Assistant store', () => {
 		});
 	});
 
-	it('should call telemetry for opening assistant with build_with_ai source on existing workflow', () => {
+	it('should call telemetry for opening assistant on existing workflow', () => {
 		const assistantStore = useAssistantStore();
 		const workflowsStore = useWorkflowsStore();
 
@@ -478,12 +478,12 @@ describe('AI Assistant store', () => {
 
 		assistantStore.trackUserOpenedAssistant({
 			task: 'placeholder',
-			source: 'build_with_ai',
+			source: 'canvas',
 			has_existing_session: false,
 		});
 
 		expect(track).toHaveBeenCalledWith('User opened assistant', {
-			source: 'build_with_ai',
+			source: 'canvas',
 			task: 'placeholder',
 			has_existing_session: false,
 			instance_id: '',

--- a/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.ts
@@ -603,15 +603,22 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 				task: 'placeholder';
 		  }
 		| {
+				source: 'build_with_ai';
+				task: 'placeholder';
+		  }
+		| {
 				source: 'credential';
 				task: 'credentials';
 		  }
 	)) {
+		const canvasStatus = workflowsStore.allNodes.length === 0 ? 'empty' : 'existing_workflow';
 		telemetry.track('User opened assistant', {
 			source,
 			task,
 			has_existing_session,
+			instance_id: rootStore.instanceId,
 			workflow_id: workflowsStore.workflowId,
+			canvas_status: canvasStatus,
 			node_type: chatSessionError.value?.node?.type,
 			error: chatSessionError.value?.error,
 			chat_session_id: currentSessionId.value,

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeChoicePrompt.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeChoicePrompt.vue
@@ -19,6 +19,7 @@ import { useRouter } from 'vue-router';
 import { N8nIcon, N8nLink } from '@n8n/design-system';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useTemplatesDataQualityStore } from '@/experiments/templatesDataQuality/stores/templatesDataQuality.store';
+import { useAssistantStore } from '@/features/ai/assistant/assistant.store';
 
 const nodeCreatorStore = useNodeCreatorStore();
 const chatPanelStore = useChatPanelStore();
@@ -28,6 +29,7 @@ const templatesStore = useTemplatesStore();
 const router = useRouter();
 const uiStore = useUIStore();
 const templatesDataQualityStore = useTemplatesDataQualityStore();
+const assistantStore = useAssistantStore();
 
 const isChatWindowOpen = computed(
 	() => chatPanelStore.isOpen && chatPanelStore.isBuilderModeActive,
@@ -48,6 +50,11 @@ const onAddFirstStepClick = () => {
 };
 
 async function onBuildWithAIClick() {
+	assistantStore.trackUserOpenedAssistant({
+		source: 'build_with_ai',
+		task: 'placeholder',
+		has_existing_session: !assistantStore.isSessionEnded,
+	});
 	await chatPanelStore.toggle({ mode: 'builder' });
 }
 


### PR DESCRIPTION
## Summary

  This PR adds telemetry tracking for the "Build with AI" button in the canvas choice prompt. When users click the "Build with AI" button, we now track this interaction with the existing "User opened assistant" event.

  **What's included:**
  - Telemetry event triggered when clicking "Build with AI" button with `source: "build_with_ai"`
  - Added `instance_id` to the telemetry event
  - Added `canvas_status` field that shows whether the canvas is `empty` or has an `existing_workflow`

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-1848/telemetry-track-clicks-of-build-with-ai-button


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
