### PR TITLE
fix(core): Check if user data changed before calling save on ldap sync

### DIFF
--- a/packages/cli/src/ldap.ee/__tests__/helpers.test.ts
+++ b/packages/cli/src/ldap.ee/__tests__/helpers.test.ts
@@ -1,5 +1,7 @@
 import { mockInstance } from '@n8n/backend-test-utils';
 import { generateNanoId, AuthIdentity, User, UserRepository } from '@n8n/db';
+import type { EntityManager } from '@n8n/typeorm';
+import { mock } from 'jest-mock-extended';
 
 import * as helpers from '@/ldap.ee/helpers.ee';
 
@@ -33,6 +35,117 @@ describe('Ldap/helpers', () => {
 			//
 			expect(userRepository.save).toHaveBeenCalledWith({ ...user, ...data }, { transaction: true });
 			expect(userRepository.update).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('processUsers', () => {
+		let transactionManager: EntityManager;
+		let mockManagerTransaction: jest.Mock;
+
+		beforeEach(() => {
+			transactionManager = mock<EntityManager>({
+				findOneBy: jest.fn(),
+				save: jest.fn(),
+				update: jest.fn(),
+			});
+
+			mockManagerTransaction = jest.fn();
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			(userRepository as any).manager = { transaction: mockManagerTransaction };
+		});
+
+		test('does not update user when data has not changed', async () => {
+			//
+			// ARRANGE
+			//
+			const userId = generateNanoId();
+			const ldapId = 'ldap123';
+			const existingUser = Object.assign(new User(), {
+				id: userId,
+				email: 'same@example.com',
+				firstName: 'Same',
+				lastName: 'Name',
+			} as User);
+
+			// User data from LDAP is identical to existing user
+			const ldapUser = Object.assign(new User(), {
+				email: 'same@example.com',
+				firstName: 'Same',
+				lastName: 'Name',
+			} as User);
+
+			const authIdentity = Object.assign(new AuthIdentity(), {
+				providerId: ldapId,
+				userId,
+			} as AuthIdentity);
+
+			// Mock the transaction to capture and execute the function
+			mockManagerTransaction.mockImplementation(
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				async (fn: (manager: EntityManager) => Promise<any>) => await fn(transactionManager),
+			);
+
+			(transactionManager.findOneBy as jest.Mock)
+				.mockResolvedValueOnce(authIdentity) // First call for AuthIdentity
+				.mockResolvedValueOnce(existingUser); // Second call for User
+
+			//
+			// ACT
+			//
+			await helpers.processUsers([], [[ldapId, ldapUser]], []);
+
+			//
+			// ASSERT
+			//
+			// Should not call save when data hasn't changed
+			expect(transactionManager.save).not.toHaveBeenCalled();
+			expect(transactionManager.update).not.toHaveBeenCalled();
+		});
+
+		test('updates user when email has changed', async () => {
+			//
+			// ARRANGE
+			//
+			const userId = generateNanoId();
+			const ldapId = 'ldap123';
+			const existingUser = Object.assign(new User(), {
+				id: userId,
+				email: 'old@example.com',
+				firstName: 'Same',
+				lastName: 'Name',
+			} as User);
+
+			const updatedUser = Object.assign(new User(), {
+				email: 'new@example.com',
+				firstName: 'Same',
+				lastName: 'Name',
+			} as User);
+
+			const authIdentity = Object.assign(new AuthIdentity(), {
+				providerId: ldapId,
+				userId,
+			} as AuthIdentity);
+
+			// Mock the transaction to capture and execute the function
+			mockManagerTransaction.mockImplementation(
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				async (fn: (manager: EntityManager) => Promise<any>) => await fn(transactionManager),
+			);
+
+			(transactionManager.findOneBy as jest.Mock)
+				.mockResolvedValueOnce(authIdentity) // First call for AuthIdentity
+				.mockResolvedValueOnce(existingUser); // Second call for User
+
+			//
+			// ACT
+			//
+			await helpers.processUsers([], [[ldapId, updatedUser]], []);
+
+			//
+			// ASSERT
+			//
+			expect(transactionManager.save).toHaveBeenCalledWith(User, existingUser);
+			expect(existingUser.email).toBe('new@example.com');
 		});
 	});
 });


### PR DESCRIPTION

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR fixes the issue that a 'Could not update the personal project's name' log is displayed on each ldap sync, because .update is called in the LDAP sync mechanism, which triggers a log in the UserSubscriber EntitySubscriberInterface.
What was done:
- Use .save instead of .update on LDAP user update, so that the subscriber knows about the changed entity and can update project name accordingly
- Check if user firstname, lastname and email actually changed before saving, to prevent triggering the event subscriber if not

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-4105/could-not-update-the-personal-projects-name-in-self-hosted-enterprise


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
