### PR TITLE
fix(editor): Clear AI Agent output parser warning when parser is connected

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.test.ts
@@ -64,6 +64,17 @@ const testNodeTypes: INodeTypeData = {
 };
 const formWorkflowNodeTypes = createMockNodeTypes(testNodeTypes);
 
+const aiTestNodeTypes: INodeTypeData = {
+	'n8n-nodes-langchain.agent': mockLoadedNodeType('n8n-nodes-langchain.agent'),
+	'n8n-nodes-langchain.outputParserStructured': mockLoadedNodeType(
+		'n8n-nodes-langchain.outputParserStructured',
+	),
+};
+const aiWorkflowNodeTypes = createMockNodeTypes({
+	...testNodeTypes,
+	...aiTestNodeTypes,
+});
+
 vi.mock('vue-router', async () => {
 	const actual = await vi.importActual('vue-router');
 	return {
@@ -251,6 +262,95 @@ describe('ParameterInputList', () => {
 			const el = queryByText('TRIGGER NOTICE');
 
 			expect(el).not.toBeInTheDocument();
+		});
+	});
+
+	describe('updateAiConnectionNoticeParameters', () => {
+		const outputParserNoticeParameters: INodeProperties[] = [
+			{
+				displayName: 'Require Specific Output Format',
+				name: 'hasOutputParser',
+				type: 'boolean',
+				default: false,
+			},
+			{
+				displayName: `Connect an <a data-action='openSelectiveNodeCreator' data-action-parameter-connectiontype='${NodeConnectionTypes.AiOutputParser}'>output parser</a> on the canvas to specify the output format you require`,
+				name: 'notice',
+				type: 'notice',
+				default: '',
+				displayOptions: {
+					show: {
+						hasOutputParser: [true],
+					},
+				},
+			},
+		];
+
+		it('should show output parser notice if output parser is not connected', () => {
+			ndvStore.activeNode = createTestNode({
+				name: 'AI Agent',
+				type: 'n8n-nodes-langchain.agent',
+				parameters: { hasOutputParser: true },
+			}) as INodeUi;
+
+			const agentNode = createTestNode({
+				name: 'AI Agent',
+				type: 'n8n-nodes-langchain.agent',
+			});
+
+			workflowStore.workflowObject = createTestWorkflowObject({
+				nodes: [agentNode],
+				connections: {},
+				nodeTypes: aiWorkflowNodeTypes,
+			});
+
+			const { getByText } = renderComponent({
+				props: {
+					parameters: outputParserNoticeParameters,
+					nodeValues: { hasOutputParser: true },
+				},
+			});
+
+			expect(getByText(/specify the output format you require/i)).toBeInTheDocument();
+		});
+
+		it('should not show output parser notice if output parser is connected', () => {
+			ndvStore.activeNode = createTestNode({
+				name: 'AI Agent',
+				type: 'n8n-nodes-langchain.agent',
+				parameters: { hasOutputParser: true },
+			}) as INodeUi;
+
+			const agentNode = createTestNode({
+				name: 'AI Agent',
+				type: 'n8n-nodes-langchain.agent',
+			});
+
+			const outputParserNode = createTestNode({
+				name: 'Output Parser',
+				type: 'n8n-nodes-langchain.outputParserStructured',
+			});
+
+			workflowStore.workflowObject = createTestWorkflowObject({
+				nodes: [agentNode, outputParserNode],
+				connections: {
+					'Output Parser': {
+						[NodeConnectionTypes.AiOutputParser]: [
+							[{ node: 'AI Agent', type: NodeConnectionTypes.AiOutputParser, index: 0 }],
+						],
+					},
+				},
+				nodeTypes: aiWorkflowNodeTypes,
+			});
+
+			const { queryByText } = renderComponent({
+				props: {
+					parameters: outputParserNoticeParameters,
+					nodeValues: { hasOutputParser: true },
+				},
+			});
+
+			expect(queryByText(/specify the output format you require/i)).not.toBeInTheDocument();
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.vue
@@ -10,6 +10,7 @@ import type {
 import {
 	ADD_FORM_NOTICE,
 	getParameterValueByPath,
+	NodeConnectionTypes,
 	NodeHelpers,
 	resolveRelativePath,
 } from 'n8n-workflow';
@@ -196,6 +197,10 @@ throttledWatch(
 			filteredParameters = parameters;
 		}
 
+		if (node.value) {
+			filteredParameters = updateAiConnectionNoticeParameters(filteredParameters, node.value.name);
+		}
+
 		// Compute all parameter data for template usage
 		// Note: `value` is intentionally NOT included to prevent re-renders when values change
 		// Values are fetched via getParameterValue() in the template instead
@@ -357,6 +362,24 @@ function updateWaitParameters(parameters: INodeProperties[], nodeName: string) {
 	}
 
 	return parameters;
+}
+
+function updateAiConnectionNoticeParameters(parameters: INodeProperties[], nodeName: string) {
+	const workflowObject = workflowsStore.workflowObject;
+	if (!workflowObject) return parameters;
+
+	const hasOutputParserConnected =
+		workflowObject.getParentNodes(nodeName, NodeConnectionTypes.AiOutputParser, 1).length > 0;
+
+	if (!hasOutputParserConnected) return parameters;
+
+	const outputParserConnectionType = `data-action-parameter-connectiontype='${NodeConnectionTypes.AiOutputParser}'`;
+
+	return parameters.filter((parameter) => {
+		if (parameter.type !== 'notice') return true;
+		if (typeof parameter.displayName !== 'string') return true;
+		return !parameter.displayName.includes(outputParserConnectionType);
+	});
 }
 
 function updateFormParameters(parameters: INodeProperties[], nodeName: string) {


### PR DESCRIPTION
## Summary

Fixes an issue where the AI Agent node continues to display the
“Connect an output parser…” warning even when a valid output parser
is already connected.

This warning is misleading and can prompt users to create or disconnect
an otherwise correctly working parser.

### How to test
1. Create an AI Agent node
2. Enable "Require Specific Output Format"
3. See that the warning "Connect an output parser on the canvas to specify the output format you require" appears
3. Connect a valid output parser
4. Verify the warning is cleared once the parser is connected

---

## Related Linear tickets, Github issues, and Community forum posts

Fixes #20923

---

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] Docs updated (not required for this change).
- [x] Tests included.
- [ ] PR labeled with `release/backport` (not required).


