### PR TITLE
feat(API): Add timeSavedMode property to workflow settings schema

### DIFF
--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflowSettings.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflowSettings.yml
@@ -46,6 +46,10 @@ properties:
     type: string
     description: Comma-separated list of workflow IDs allowed to call this workflow (only used with workflowsFromAList policy)
     example: '14, 18, 23'
+  timeSavedMode:
+    type: string
+    enum: ['fixed', 'dynamic']
+    description: Controls the mode for calculating the time saved per execution
   timeSavedPerExecution:
     type: number
     description: Estimated time saved per execution in minutes

--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflowSettings.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflowSettings.yml
@@ -49,7 +49,15 @@ properties:
   timeSavedMode:
     type: string
     enum: ['fixed', 'dynamic']
-    description: Controls the mode for calculating the time saved per execution
+    description: |
+      Controls how the time saved per execution is calculated.
+      Available options:
+      - `fixed`: Uses a predetermined time value specified in the `timeSavedPerExecution` field.
+        * Requires the `timeSavedPerExecution` field to be set
+        * Use when the time saved is consistent across all executions
+      - `dynamic`: Automatically calculates time saved based on actual execution metrics
+        * The `timeSavedPerExecution` field is ignored when this mode is active
+        * Use when time saved varies between executions
   timeSavedPerExecution:
     type: number
     description: Estimated time saved per execution in minutes


### PR DESCRIPTION
## Summary

This PR adds the `timeSavedMode` property to the workflow settings OpenAPI schema for the public API v1.
### Changes

- Added `timeSavedMode` field to `workflowSettings.yml` schema
- The property accepts two values: `'fixed'` or `'dynamic'`
- This allows API consumers to control how time saved per execution is calculated

### How to test

1. Access the public API documentation at `/api/v1/docs`
2. Verify the `timeSavedMode` property appears in the workflow settings schema
3. Create/update a workflow via API with `timeSavedMode` set to `'fixed'` or `'dynamic'`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/GHC-5917
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
FIxes #23196

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)