### PR TITLE
fix(nodes-base): fix Nextcloud file operations with spaces in path

### DIFF
--- a/packages/nodes-base/nodes/NextCloud/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/NextCloud/GenericFunctions.test.ts
@@ -1,0 +1,53 @@
+import { encodeWebDavPath } from './GenericFunctions';
+
+describe('encodeWebDavPath', () => {
+	it('should encode spaces in filename', () => {
+		expect(encodeWebDavPath('/Photos/test photo.jpg')).toBe('/Photos/test%20photo.jpg');
+	});
+
+	it('should encode spaces in folder name', () => {
+		expect(encodeWebDavPath('/My Documents/file.pdf')).toBe('/My%20Documents/file.pdf');
+	});
+
+	it('should encode multiple spaces', () => {
+		expect(encodeWebDavPath('/My Files/my document 2024.pdf')).toBe(
+			'/My%20Files/my%20document%202024.pdf',
+		);
+	});
+
+	it('should handle path without spaces', () => {
+		expect(encodeWebDavPath('/Documents/file.pdf')).toBe('/Documents/file.pdf');
+	});
+
+	it('should handle empty path', () => {
+		expect(encodeWebDavPath('')).toBe('');
+	});
+
+	it('should handle root path', () => {
+		expect(encodeWebDavPath('/')).toBe('/');
+	});
+
+	it('should encode special characters', () => {
+		expect(encodeWebDavPath('/Files/report#2024.pdf')).toBe('/Files/report%232024.pdf');
+	});
+
+	it('should encode ampersand', () => {
+		expect(encodeWebDavPath('/Files/Tom & Jerry.pdf')).toBe('/Files/Tom%20%26%20Jerry.pdf');
+	});
+
+	it('should preserve leading slash', () => {
+		expect(encodeWebDavPath('/folder/file.txt')).toBe('/folder/file.txt');
+	});
+
+	it('should handle multiple consecutive slashes', () => {
+		expect(encodeWebDavPath('//folder//file.txt')).toBe('//folder//file.txt');
+	});
+
+	it('should encode parentheses', () => {
+		expect(encodeWebDavPath('/Files/document (1).pdf')).toBe('/Files/document%20(1).pdf');
+	});
+
+	it('should encode plus sign', () => {
+		expect(encodeWebDavPath('/Files/file+name.pdf')).toBe('/Files/file%2Bname.pdf');
+	});
+});

--- a/packages/nodes-base/nodes/NextCloud/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/NextCloud/GenericFunctions.ts
@@ -8,6 +8,19 @@ import {
 } from 'n8n-workflow';
 
 /**
+ * Encodes a path for use in NextCloud WebDAV URLs.
+ * Encodes each path segment individually while preserving path separators.
+ * This ensures proper handling of special characters including spaces.
+ */
+export function encodeWebDavPath(path: string): string {
+	// Split path by '/', encode each segment, then rejoin
+	return path
+		.split('/')
+		.map((segment) => encodeURIComponent(segment))
+		.join('/');
+}
+
+/**
  * Make an API request to NextCloud
  *
  */
@@ -45,7 +58,7 @@ export async function nextCloudApiRequest(
 		options.encoding = null;
 	}
 
-	options.uri = `${credentials.webDavUrl}/${encodeURI(endpoint)}`;
+	options.uri = `${credentials.webDavUrl}/${encodeWebDavPath(endpoint)}`;
 
 	if (resource === 'user' && operation === 'create') {
 		options.uri = options.uri.replace('/remote.php/webdav', '');

--- a/packages/nodes-base/nodes/NextCloud/NextCloud.node.ts
+++ b/packages/nodes-base/nodes/NextCloud/NextCloud.node.ts
@@ -12,7 +12,7 @@ import { NodeApiError, NodeConnectionTypes, NodeOperationError } from 'n8n-workf
 import { URLSearchParams } from 'url';
 import { parseString } from 'xml2js';
 
-import { nextCloudApiRequest } from './GenericFunctions';
+import { encodeWebDavPath, nextCloudApiRequest } from './GenericFunctions';
 import { wrapData } from '../../utils/utilities';
 
 export class NextCloud implements INodeType {
@@ -936,7 +936,7 @@ export class NextCloud implements INodeType {
 						requestMethod = 'COPY' as IHttpRequestMethods;
 						endpoint = this.getNodeParameter('path', i) as string;
 						const toPath = this.getNodeParameter('toPath', i) as string;
-						headers.Destination = `${credentials.webDavUrl}/${encodeURI(toPath)}`;
+						headers.Destination = `${credentials.webDavUrl}/${encodeWebDavPath(toPath)}`;
 					} else if (operation === 'delete') {
 						// ----------------------------------
 						//         delete
@@ -952,7 +952,7 @@ export class NextCloud implements INodeType {
 						requestMethod = 'MOVE' as IHttpRequestMethods;
 						endpoint = this.getNodeParameter('path', i) as string;
 						const toPath = this.getNodeParameter('toPath', i) as string;
-						headers.Destination = `${credentials.webDavUrl}/${encodeURI(toPath)}`;
+						headers.Destination = `${credentials.webDavUrl}/${encodeWebDavPath(toPath)}`;
 					} else if (operation === 'share') {
 						// ----------------------------------
 						//         share


### PR DESCRIPTION
## Summary
- Replace `encodeURI()` with a custom `encodeWebDavPath()` function for proper WebDAV path encoding
- The new function encodes each path segment individually using `encodeURIComponent()` while preserving path separators
- This fixes issues with downloading, copying, and moving files that have spaces or special characters in their names

## Test plan
- [x] Added unit tests for `encodeWebDavPath()` function
- [x] All existing tests pass
- [x] TypeCheck passes
- [x] Lint passes

Fixes #23818