### PR TITLE
fix(nodes-langchain): fix AI Agent strict=null issue with Responses API

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
@@ -806,6 +806,10 @@ export class LmChatOpenAi implements INodeType {
 		// by default ChatOpenAI can switch to responses API automatically, so force it only on 1.3 and above to keep backwards compatibility
 		if (responsesApiEnabled) {
 			fields.useResponsesApi = true;
+			// Set supportsStrictToolCalling to false to prevent sending null for the strict field
+			// in tool definitions. OpenAI-compatible backends (like LM Studio) expect strict to be
+			// a boolean or omitted entirely, not null.
+			fields.supportsStrictToolCalling = false;
 		}
 
 		const model = new ChatOpenAI(fields);


### PR DESCRIPTION
## Summary
- Set `supportsStrictToolCalling` to `false` when using the Responses API
- This prevents LangChain from sending `null` for the `strict` field in tool definitions
- OpenAI-compatible backends (like LM Studio, vLLM, Ollama with OpenAI proxy) expect the `strict` field to be a boolean (`true`/`false`) or omitted entirely, not `null`

## Root Cause
The `@langchain/openai` library sets `strict: fields?.strict ?? null` in tool definitions when using the Responses API. When `supportsStrictToolCalling` is `undefined`, this results in `strict: null` being sent to the API, causing validation errors on OpenAI-compatible backends.

## Test plan
- [x] Build passes
- [x] TypeCheck passes  
- [x] Lint passes
- [x] Existing tests pass

Fixes #23656