### PR TITLE
feat(GitHub Node): Introduce get members operation on organization resource

### DIFF
--- a/packages/nodes-base/nodes/Github/Github.node.ts
+++ b/packages/nodes-base/nodes/Github/Github.node.ts
@@ -164,6 +164,12 @@ export class Github implements INodeType {
 						description: 'Returns all repositories of an organization',
 						action: 'Get repositories for an organization',
 					},
+					{
+						name: 'Get Members',
+						value: 'getMembers',
+						description: 'Returns all members of an organization',
+						action: 'Get members for an organization',
+					},
 				],
 				default: 'getRepositories',
 			},
@@ -2076,7 +2082,7 @@ export class Github implements INodeType {
 			},
 
 			// ----------------------------------
-			//    organization:getRepositories
+			//         organization:getRepositories
 			// ----------------------------------
 			{
 				displayName: 'Return All',
@@ -2099,6 +2105,41 @@ export class Github implements INodeType {
 					show: {
 						resource: ['organization'],
 						operation: ['getRepositories'],
+						returnAll: [false],
+					},
+				},
+				typeOptions: {
+					minValue: 1,
+					maxValue: 100,
+				},
+				default: 50,
+				description: 'Max number of results to return',
+			},
+
+			// ----------------------------------
+			//         organization:getMembers
+			// ----------------------------------
+			{
+				displayName: 'Return All',
+				name: 'returnAll',
+				type: 'boolean',
+				displayOptions: {
+					show: {
+						resource: ['organization'],
+						operation: ['getMembers'],
+					},
+				},
+				default: false,
+				description: 'Whether to return all results or only up to a given limit',
+			},
+			{
+				displayName: 'Limit',
+				name: 'limit',
+				type: 'number',
+				displayOptions: {
+					show: {
+						resource: ['organization'],
+						operation: ['getMembers'],
 						returnAll: [false],
 					},
 				},
@@ -2316,6 +2357,7 @@ export class Github implements INodeType {
 			'release:getAll',
 			'review:getAll',
 			'organization:getRepositories',
+			'organization:getMembers',
 		];
 
 		// For Post
@@ -2399,7 +2441,8 @@ export class Github implements INodeType {
 					fullOperation !== 'user:getRepositories' &&
 					fullOperation !== 'user:getUserIssues' &&
 					fullOperation !== 'user:invite' &&
-					fullOperation !== 'organization:getRepositories'
+					fullOperation !== 'organization:getRepositories' &&
+					fullOperation !== 'organization:getMembers'
 				) {
 					repository = this.getNodeParameter('repository', i, '', { extractValue: true }) as string;
 				}
@@ -2824,6 +2867,20 @@ export class Github implements INodeType {
 						requestMethod = 'GET';
 
 						endpoint = `/orgs/${owner}/repos`;
+						returnAll = this.getNodeParameter('returnAll', 0);
+
+						if (!returnAll) {
+							qs.per_page = this.getNodeParameter('limit', 0);
+						}
+					}
+					if (operation === 'getMembers') {
+						// ----------------------------------
+						//         getMembers
+						// ----------------------------------
+
+						requestMethod = 'GET';
+
+						endpoint = `/orgs/${owner}/members`;
 						returnAll = this.getNodeParameter('returnAll', 0);
 
 						if (!returnAll) {

--- a/packages/nodes-base/nodes/Github/__schema__/v1.0.0/organization/getMembers.json
+++ b/packages/nodes-base/nodes/Github/__schema__/v1.0.0/organization/getMembers.json
@@ -1,0 +1,60 @@
+{
+	"type": "object",
+	"properties": {
+		"login": {
+			"type": "string"
+		},
+		"id": {
+			"type": "integer"
+		},
+		"node_id": {
+			"type": "string"
+		},
+		"avatar_url": {
+			"type": "string"
+		},
+		"gravatar_id": {
+			"type": "string"
+		},
+		"url": {
+			"type": "string"
+		},
+		"html_url": {
+			"type": "string"
+		},
+		"followers_url": {
+			"type": "string"
+		},
+		"following_url": {
+			"type": "string"
+		},
+		"gists_url": {
+			"type": "string"
+		},
+		"starred_url": {
+			"type": "string"
+		},
+		"subscriptions_url": {
+			"type": "string"
+		},
+		"organizations_url": {
+			"type": "string"
+		},
+		"repos_url": {
+			"type": "string"
+		},
+		"events_url": {
+			"type": "string"
+		},
+		"received_events_url": {
+			"type": "string"
+		},
+		"type": {
+			"type": "string"
+		},
+		"site_admin": {
+			"type": "boolean"
+		}
+	},
+	"version": 1
+}

--- a/packages/nodes-base/nodes/Github/__tests__/Github.organization.getMembers.test.ts
+++ b/packages/nodes-base/nodes/Github/__tests__/Github.organization.getMembers.test.ts
@@ -10,7 +10,7 @@ describe('Github Node - Organization getMembers', () => {
 		},
 	};
 
-	describe('Basic getUsers Operation', () => {
+	describe('Basic getMembers Operation', () => {
 		beforeAll(() => {
 			const mock = nock('https://api.github.com');
 
@@ -67,7 +67,7 @@ describe('Github Node - Organization getMembers', () => {
 		});
 	});
 
-	describe('Paginated getUsers Operation', () => {
+	describe('Paginated getMembers Operation', () => {
 		beforeAll(() => {
 			const mock = nock('https://api.github.com');
 

--- a/packages/nodes-base/nodes/Github/__tests__/Github.organization.getMembers.test.ts
+++ b/packages/nodes-base/nodes/Github/__tests__/Github.organization.getMembers.test.ts
@@ -1,0 +1,106 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+describe('Github Node - Organization getMembers', () => {
+	const credentials = {
+		githubApi: {
+			accessToken: 'test-token',
+			server: 'https://api.github.com',
+			user: 'testuser',
+		},
+	};
+
+	describe('Basic getUsers Operation', () => {
+		beforeAll(() => {
+			const mock = nock('https://api.github.com');
+
+			mock
+				.get('/orgs/testorg/members')
+				.query(true)
+				.reply(200, [
+					{
+						login: 'octocat',
+						id: 1,
+						node_id: 'MDQ6VXNlcjE=',
+						avatar_url: 'https://github.com/images/error/octocat_happy.gif',
+						gravatar_id: '',
+						url: 'https://api.github.com/users/octocat',
+						html_url: 'https://github.com/octocat',
+						followers_url: 'https://api.github.com/users/octocat/followers',
+						following_url: 'https://api.github.com/users/octocat/following',
+						gists_url: 'https://api.github.com/users/octocat/gists',
+						starred_url: 'https://api.github.com/users/octocat/starred',
+						subscriptions_url: 'https://api.github.com/users/octocat/subscriptions',
+						organizations_url: 'https://api.github.com/users/octocat/orgs',
+						repos_url: 'https://api.github.com/users/octocat/repos',
+						events_url: 'https://api.github.com/users/octocat/events',
+						received_events_url: 'https://api.github.com/users/octocat/received_events',
+						type: 'User',
+						site_admin: false,
+					},
+					{
+						login: 'testuser',
+						id: 2,
+						node_id: 'MDQ6VXNlcjI=',
+						avatar_url: 'https://github.com/images/error/testuser.gif',
+						gravatar_id: '',
+						url: 'https://api.github.com/users/testuser',
+						html_url: 'https://github.com/testuser',
+						followers_url: 'https://api.github.com/users/testuser/followers',
+						following_url: 'https://api.github.com/users/testuser/following',
+						gists_url: 'https://api.github.com/users/testuser/gists',
+						starred_url: 'https://api.github.com/users/testuser/starred',
+						subscriptions_url: 'https://api.github.com/users/testuser/subscriptions',
+						organizations_url: 'https://api.github.com/users/testuser/orgs',
+						repos_url: 'https://api.github.com/users/testuser/repos',
+						events_url: 'https://api.github.com/users/testuser/events',
+						received_events_url: 'https://api.github.com/users/testuser/received_events',
+						type: 'User',
+						site_admin: false,
+					},
+				]);
+		});
+
+		new NodeTestHarness().setupTests({
+			credentials,
+			workflowFiles: ['getMembers.workflow.json'],
+		});
+	});
+
+	describe('Paginated getUsers Operation', () => {
+		beforeAll(() => {
+			const mock = nock('https://api.github.com');
+
+			mock
+				.get('/orgs/testorg/members')
+				.query({ per_page: 1 })
+				.reply(200, [
+					{
+						login: 'octocat',
+						id: 1,
+						node_id: 'MDQ6VXNlcjE=',
+						avatar_url: 'https://github.com/images/error/octocat_happy.gif',
+						gravatar_id: '',
+						url: 'https://api.github.com/users/octocat',
+						html_url: 'https://github.com/octocat',
+						followers_url: 'https://api.github.com/users/octocat/followers',
+						following_url: 'https://api.github.com/users/octocat/following',
+						gists_url: 'https://api.github.com/users/octocat/gists',
+						starred_url: 'https://api.github.com/users/octocat/starred',
+						subscriptions_url: 'https://api.github.com/users/octocat/subscriptions',
+						organizations_url: 'https://api.github.com/users/octocat/orgs',
+						repos_url: 'https://api.github.com/users/octocat/repos',
+						events_url: 'https://api.github.com/users/octocat/events',
+						received_events_url: 'https://api.github.com/users/octocat/received_events',
+						type: 'User',
+						site_admin: false,
+					},
+				]);
+		});
+
+		new NodeTestHarness().setupTests({
+			credentials,
+			workflowFiles: ['getMembersLimit.workflow.json'],
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Github/__tests__/getMembers.workflow.json
+++ b/packages/nodes-base/nodes/Github/__tests__/getMembers.workflow.json
@@ -1,0 +1,120 @@
+{
+	"name": "Github Organization getMembers Test Workflow",
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0],
+			"id": "trigger-id",
+			"name": "When clicking 'Execute Workflow'"
+		},
+		{
+			"parameters": {
+				"resource": "organization",
+				"operation": "getMembers",
+				"owner": {
+					"__rl": true,
+					"value": "testorg",
+					"mode": "name"
+				},
+				"returnAll": true
+			},
+			"type": "n8n-nodes-base.github",
+			"typeVersion": 1,
+			"position": [200, 0],
+			"id": "github-node-id",
+			"name": "Get Organization Members",
+			"credentials": {
+				"githubApi": {
+					"id": "credential-id",
+					"name": "Test Credentials"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [400, 0],
+			"id": "noop-id",
+			"name": "Members Response"
+		}
+	],
+	"pinData": {
+		"Members Response": [
+			{
+				"json": {
+					"login": "octocat",
+					"id": 1,
+					"node_id": "MDQ6VXNlcjE=",
+					"avatar_url": "https://github.com/images/error/octocat_happy.gif",
+					"gravatar_id": "",
+					"url": "https://api.github.com/users/octocat",
+					"html_url": "https://github.com/octocat",
+					"followers_url": "https://api.github.com/users/octocat/followers",
+					"following_url": "https://api.github.com/users/octocat/following",
+					"gists_url": "https://api.github.com/users/octocat/gists",
+					"starred_url": "https://api.github.com/users/octocat/starred",
+					"subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+					"organizations_url": "https://api.github.com/users/octocat/orgs",
+					"repos_url": "https://api.github.com/users/octocat/repos",
+					"events_url": "https://api.github.com/users/octocat/events",
+					"received_events_url": "https://api.github.com/users/octocat/received_events",
+					"type": "User",
+					"site_admin": false
+				}
+			},
+			{
+				"json": {
+					"login": "testuser",
+					"id": 2,
+					"node_id": "MDQ6VXNlcjI=",
+					"avatar_url": "https://github.com/images/error/testuser.gif",
+					"gravatar_id": "",
+					"url": "https://api.github.com/users/testuser",
+					"html_url": "https://github.com/testuser",
+					"followers_url": "https://api.github.com/users/testuser/followers",
+					"following_url": "https://api.github.com/users/testuser/following",
+					"gists_url": "https://api.github.com/users/testuser/gists",
+					"starred_url": "https://api.github.com/users/testuser/starred",
+					"subscriptions_url": "https://api.github.com/users/testuser/subscriptions",
+					"organizations_url": "https://api.github.com/users/testuser/orgs",
+					"repos_url": "https://api.github.com/users/testuser/repos",
+					"events_url": "https://api.github.com/users/testuser/events",
+					"received_events_url": "https://api.github.com/users/testuser/received_events",
+					"type": "User",
+					"site_admin": false
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking 'Execute Workflow'": {
+			"main": [
+				[
+					{
+						"node": "Get Organization Members",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Get Organization Members": {
+			"main": [
+				[
+					{
+						"node": "Members Response",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	}
+}

--- a/packages/nodes-base/nodes/Github/__tests__/getMembersLimit.workflow.json
+++ b/packages/nodes-base/nodes/Github/__tests__/getMembersLimit.workflow.json
@@ -1,0 +1,99 @@
+{
+	"name": "Github Organization getMembers Limit Test Workflow",
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0],
+			"id": "trigger-id",
+			"name": "When clicking 'Execute Workflow'"
+		},
+		{
+			"parameters": {
+				"resource": "organization",
+				"operation": "getMembers",
+				"owner": {
+					"__rl": true,
+					"value": "testorg",
+					"mode": "name"
+				},
+				"returnAll": false,
+				"limit": 1
+			},
+			"type": "n8n-nodes-base.github",
+			"typeVersion": 1,
+			"position": [200, 0],
+			"id": "github-node-id",
+			"name": "Get Organization Members Limited",
+			"credentials": {
+				"githubApi": {
+					"id": "credential-id",
+					"name": "Test Credentials"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [400, 0],
+			"id": "noop-id",
+			"name": "Members Response"
+		}
+	],
+	"pinData": {
+		"Members Response": [
+			{
+				"json": {
+					"login": "octocat",
+					"id": 1,
+					"node_id": "MDQ6VXNlcjE=",
+					"avatar_url": "https://github.com/images/error/octocat_happy.gif",
+					"gravatar_id": "",
+					"url": "https://api.github.com/users/octocat",
+					"html_url": "https://github.com/octocat",
+					"followers_url": "https://api.github.com/users/octocat/followers",
+					"following_url": "https://api.github.com/users/octocat/following",
+					"gists_url": "https://api.github.com/users/octocat/gists",
+					"starred_url": "https://api.github.com/users/octocat/starred",
+					"subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+					"organizations_url": "https://api.github.com/users/octocat/orgs",
+					"repos_url": "https://api.github.com/users/octocat/repos",
+					"events_url": "https://api.github.com/users/octocat/events",
+					"received_events_url": "https://api.github.com/users/octocat/received_events",
+					"type": "User",
+					"site_admin": false
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking 'Execute Workflow'": {
+			"main": [
+				[
+					{
+						"node": "Get Organization Members Limited",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Get Organization Members Limited": {
+			"main": [
+				[
+					{
+						"node": "Members Response",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds a `organization:getMembers` operation to the GitHub node, allowing users to retrieve all members of a specified GitHub organization.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
