### PR TITLE
Make Shopify OAuth2 scope configurable in credentials

### DIFF
--- a/packages/nodes-base/credentials/ShopifyOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/ShopifyOAuth2Api.credentials.ts
@@ -66,7 +66,7 @@ export class ShopifyOAuth2Api implements ICredentialType {
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden',
+			type: 'string',
 			default: 'write_orders read_orders write_products read_products',
 		},
 		{


### PR DESCRIPTION
## Summary

This change makes the Scope credential field editable instead of hidden. Users can now view and adjust the Shopify permission scopes directly when configuring credentials. This helps with debugging access issues and allows customization for stores that require different permissions.

How to test  
Create or edit a Shopify OAuth2 credential.  
Confirm the Scope field is visible and prefilled with the default value.  
Modify the scope value and complete authentication.  
Verify the resulting access token respects the updated scopes.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

No existing ticket or issue. Change is based on usability improvement observed during credential setup.

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` if the PR is an urgent fix that needs to be backported
