### PR TITLE
chore: Clean up command bar feature flag (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/App.vue
+++ b/packages/frontend/editor-ui/src/app/App.vue
@@ -45,7 +45,6 @@ const { APP_Z_INDEXES } = useStyles();
 
 const {
 	initialize: initializeCommandBar,
-	isEnabled: isCommandBarEnabled,
 	items,
 	placeholder,
 	context,
@@ -71,9 +70,7 @@ const isDemoMode = computed(() => route.name === VIEWS.DEMO);
 const hasContentFooter = ref(false);
 const appGrid = ref<Element | null>(null);
 
-const showCommandBar = computed(
-	() => isCommandBarEnabled.value && hasPermission(['authenticated']) && !isDemoMode.value,
-);
+const showCommandBar = computed(() => hasPermission(['authenticated']) && !isDemoMode.value);
 
 const chatPanelWidth = computed(() => chatPanelStore.width);
 

--- a/packages/frontend/editor-ui/src/app/components/MainSidebarHeader.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainSidebarHeader.test.ts
@@ -7,7 +7,6 @@ import { defaultSettings } from '@/__tests__/defaults';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
 import MainSidebarHeader from './MainSidebarHeader.vue';
-import { COMMAND_BAR_EXPERIMENT } from '../constants';
 
 vi.mock('vue-router', () => ({
 	useRouter: () => ({
@@ -20,9 +19,7 @@ vi.mock('vue-router', () => ({
 }));
 
 vi.mock('@/app/stores/posthog.store', () => ({
-	usePostHog: () => ({
-		isVariantEnabled: vi.fn().mockImplementation((name) => name === COMMAND_BAR_EXPERIMENT.name),
-	}),
+	usePostHog: () => ({}),
 }));
 
 let settingsStore: MockedStore<typeof useSettingsStore>;

--- a/packages/frontend/editor-ui/src/app/components/MainSidebarHeader.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainSidebarHeader.vue
@@ -14,7 +14,6 @@ import {
 } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
 import { VIEWS } from '@/app/constants';
-import { useCommandBar } from '@/features/shared/commandBar/composables/useCommandBar';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
 import KeyboardShortcutTooltip from '@/app/components/KeyboardShortcutTooltip.vue';
 import { useSettingsStore } from '@/app/stores/settings.store';
@@ -31,8 +30,6 @@ const emit = defineEmits<{
 	collapse: [];
 	openCommandBar: [event: MouseEvent];
 }>();
-
-const { isEnabled: isCommandBarEnabled } = useCommandBar();
 
 const i18n = useI18n();
 const sourceControlStore = useSourceControlStore();
@@ -166,7 +163,6 @@ const {
 			</template>
 		</N8nNavigationDropdown>
 		<KeyboardShortcutTooltip
-			v-if="isCommandBarEnabled"
 			:placement="isCollapsed ? 'right' : 'bottom'"
 			:show-after="500"
 			:label="i18n.baseText('nodeView.openCommandBar')"

--- a/packages/frontend/editor-ui/src/app/constants/experiments.ts
+++ b/packages/frontend/editor-ui/src/app/constants/experiments.ts
@@ -10,12 +10,6 @@ export const NDV_IN_FOCUS_PANEL_EXPERIMENT = {
 	variant: 'variant',
 };
 
-export const COMMAND_BAR_EXPERIMENT = {
-	name: 'command_bar',
-	control: 'control',
-	variant: 'variant',
-};
-
 export const EXTRA_TEMPLATE_LINKS_EXPERIMENT = {
 	name: '034_extra_template_links',
 	control: 'control',

--- a/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useCommandBar.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useCommandBar.ts
@@ -2,7 +2,7 @@ import { computed, ref } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
-import { COMMAND_BAR_EXPERIMENT, VIEWS } from '@/app/constants';
+import { VIEWS } from '@/app/constants';
 import { type CommandBarItem } from '@n8n/design-system/components/N8nCommandBar/types';
 import { useNodeCommands } from './useNodeCommands';
 import { useWorkflowCommands } from './useWorkflowCommands';
@@ -16,7 +16,6 @@ import { useGenericCommands } from './useGenericCommands';
 import { useRecentResources } from './useRecentResources';
 import { useChatHubCommands } from './useChatHubCommands';
 import type { CommandGroup } from '../types';
-import { usePostHog } from '@/app/stores/posthog.store';
 import { useI18n } from '@n8n/i18n';
 import { PROJECT_DATA_TABLES, DATA_TABLE_VIEW } from '@/features/core/dataTable/constants';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
@@ -34,15 +33,10 @@ export function useCommandBar() {
 	const workflowStore = useWorkflowsStore();
 	const router = useRouter();
 	const route = useRoute();
-	const postHog = usePostHog();
 	const i18n = useI18n();
 	const telemetry = useTelemetry();
 
 	const placeholder = i18n.baseText('commandBar.placeholder');
-
-	const isEnabled = computed(() =>
-		postHog.isVariantEnabled(COMMAND_BAR_EXPERIMENT.name, COMMAND_BAR_EXPERIMENT.variant),
-	);
 
 	const activeNodeId = ref<string | null>(null);
 	const lastQuery = ref('');
@@ -313,7 +307,6 @@ export function useCommandBar() {
 	}
 
 	return {
-		isEnabled,
 		items,
 		initialize,
 		onCommandBarChange,

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/NodeCreation.vue
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/NodeCreation.vue
@@ -22,7 +22,6 @@ import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useAssistantStore } from '@/features/ai/assistant/assistant.store';
 import { useBuilderStore } from '@/features/ai/assistant/builder.store';
 import { useChatPanelStore } from '@/features/ai/assistant/chatPanel.store';
-import { useCommandBar } from '@/features/shared/commandBar/composables/useCommandBar';
 
 import { N8nAssistantIcon, N8nButton, N8nIconButton, N8nTooltip } from '@n8n/design-system';
 
@@ -54,7 +53,6 @@ const telemetry = useTelemetry();
 const assistantStore = useAssistantStore();
 const builderStore = useBuilderStore();
 const chatPanelStore = useChatPanelStore();
-const { isEnabled: isCommandBarEnabled } = useCommandBar();
 
 const { getAddedNodesAndConnections } = useActions();
 
@@ -150,7 +148,6 @@ function openCommandBar(event: MouseEvent) {
 			/>
 		</KeyboardShortcutTooltip>
 		<KeyboardShortcutTooltip
-			v-if="isCommandBarEnabled"
 			:label="i18n.baseText('nodeView.openCommandBar')"
 			:shortcut="{ keys: ['k'], metaKey: true }"
 			placement="left"


### PR DESCRIPTION
## Summary

Title self explanatory

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4362/tech-debt-cleanup-command-bar-feature-flag

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
