### PR TITLE
fix(editor): Data table resource list icon (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/core/dataTable/components/DataTableCard.vue
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/components/DataTableCard.vue
@@ -46,9 +46,9 @@ const getDataTableSize = computed(() => {
 					<N8nIcon
 						data-test-id="data-table-card-icon"
 						:class="$style['card-icon']"
-						icon="database"
+						icon="table"
 						size="xlarge"
-						:stroke-width="1"
+						:stroke-width="1.5"
 					/>
 				</template>
 				<template #header>


### PR DESCRIPTION
## Summary

Fixes the stroke width issue on the data table icon in the resource list, changed the icon to be consistent with the data table node.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/ADO-4581/bug-data-table-icon-in-resource-list


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
