### PR TITLE
feat: Workflows imported with separate option now validate before insertion

### DIFF
--- a/packages/cli/src/commands/import/workflow.ts
+++ b/packages/cli/src/commands/import/workflow.ts
@@ -205,13 +205,13 @@ export class ImportWorkflowsCommand extends BaseCommand<z.infer<typeof flagsSche
 			absolute: true,
 		});
 
+		const workflows = [];
+
 		for (const file of files) {
 			const workflow = jsonParse<IWorkflowToImport>(fs.readFileSync(file, { encoding: 'utf8' }));
 			if (!workflow.id) {
 				workflow.id = generateNanoId();
 			}
-
-			const workflows = [];
 
 			try {
 				assertHasWorkflowsToImport([workflow]);
@@ -221,9 +221,9 @@ export class ImportWorkflowsCommand extends BaseCommand<z.infer<typeof flagsSche
 				this.logger.warn(`Skipping invalid workflow file: ${file}`);
 				continue;
 			}
-
-			return workflows;
 		}
+
+		return workflows;
 	}
 
 	private async getProject(userId?: string, projectId?: string) {

--- a/packages/cli/src/commands/import/workflow.ts
+++ b/packages/cli/src/commands/import/workflow.ts
@@ -190,19 +190,7 @@ export class ImportWorkflowsCommand extends BaseCommand<z.infer<typeof flagsSche
 
 		const workflowRepository = Container.get(WorkflowRepository);
 
-		if (separate) {
-			const files = await glob('*.json', {
-				cwd: path,
-				absolute: true,
-			});
-			return files.map((file) => {
-				const workflow = jsonParse<IWorkflowToImport>(fs.readFileSync(file, { encoding: 'utf8' }));
-				if (!workflow.id) {
-					workflow.id = generateNanoId();
-				}
-				return workflowRepository.create(workflow);
-			});
-		} else {
+		if (!separate) {
 			const workflows = jsonParse<IWorkflowToImport | IWorkflowToImport[]>(
 				fs.readFileSync(path, { encoding: 'utf8' }),
 			);
@@ -210,6 +198,31 @@ export class ImportWorkflowsCommand extends BaseCommand<z.infer<typeof flagsSche
 			assertHasWorkflowsToImport(workflowsArray);
 
 			return workflowRepository.create(workflowsArray);
+		}
+
+		const files = await glob('*.json', {
+			cwd: path,
+			absolute: true,
+		});
+
+		for (const file of files) {
+			const workflow = jsonParse<IWorkflowToImport>(fs.readFileSync(file, { encoding: 'utf8' }));
+			if (!workflow.id) {
+				workflow.id = generateNanoId();
+			}
+
+			const workflows = [];
+
+			try {
+				assertHasWorkflowsToImport([workflow]);
+
+				workflows.push(workflowRepository.create(workflow));
+			} catch (error) {
+				this.logger.warn(`Skipping invalid workflow file: ${file}`);
+				continue;
+			}
+
+			return workflows;
 		}
 	}
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This ticket introduces missing validation per file for each workflow imported with a `--separate` flag, individual workflows were correctly validated, previously there were uncaught errors for invalid workflows with no nodes.

PAY-4073

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
