### PR TITLE
Youtube node mime type fix

### DIFF
--- a/packages/nodes-base/nodes/Google/YouTube/YouTube.node.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/YouTube.node.ts
@@ -854,6 +854,8 @@ export class YouTube implements INodeType {
 							mimeType = binaryData.mimeType;
 						}
 
+						mimeType = mimeType == 'application/mp4' ? 'video/mp4' : mimeType; //Youtube API accepts video/mp4
+
 						const payload = {
 							snippet: {
 								title,


### PR DESCRIPTION
## Summary

Added a safeguard to normalize application/mp4 uploads to video/mp4 so YouTube’s API accepts the upload content type.

How to check:
Upload a video with mimeType = application/mp4 and confirm it succeeds.