### PR TITLE
ci: Change community PR's to single worker

### DIFF
--- a/.github/workflows/playwright-test-ci.yml
+++ b/.github/workflows/playwright-test-ci.yml
@@ -52,7 +52,8 @@ jobs:
       test-command: pnpm --filter=n8n-playwright test:local:e2e-only
       shards: 6
       runner: ubuntu-latest
-      workers: '2'
+      workers: '1'
+      upload-failure-artifacts: true
 
   community-isolated:
     name: 'Community: Isolated'
@@ -65,3 +66,4 @@ jobs:
       shards: 2
       runner: ubuntu-latest
       workers: '1'
+      upload-failure-artifacts: true

--- a/.github/workflows/playwright-test-reusable.yml
+++ b/.github/workflows/playwright-test-reusable.yml
@@ -42,6 +42,11 @@ on:
         required: false
         default: false
         type: boolean
+      upload-failure-artifacts:
+        description: 'Upload test failure artifacts (screenshots, traces, videos). Enable for community PRs without Currents access.'
+        required: false
+        default: false
+        type: boolean
 
     secrets:
       CURRENTS_RECORD_KEY:
@@ -133,3 +138,13 @@ jobs:
           QA_PERFORMANCE_METRICS_WEBHOOK_USER: ${{ secrets.QA_PERFORMANCE_METRICS_WEBHOOK_USER }}
           QA_PERFORMANCE_METRICS_WEBHOOK_PASSWORD: ${{ secrets.QA_PERFORMANCE_METRICS_WEBHOOK_PASSWORD }}
           N8N_LICENSE_ACTIVATION_KEY: ${{ secrets.N8N_LICENSE_ACTIVATION_KEY }}
+
+      - name: Upload Failure Artifacts
+        if: ${{ failure() && inputs.upload-failure-artifacts }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: playwright-report-shard-${{ matrix.shard }}
+          path: |
+            packages/testing/playwright/test-results/
+            packages/testing/playwright/playwright-report/
+          retention-days: 7


### PR DESCRIPTION
## Summary

Change e2e tests to run sequentially for stability
Added artifacts to help debugging

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
