### PR TITLE
fix(AI Agent Node): Normalize toolInput to object for LangChain ToolCall compatibility (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
@@ -231,14 +231,8 @@ export function buildSteps(
 			});
 
 			// Extract tool input arguments for the result
-			let toolInputForResult: IDataObject | string;
-			if (toolInput.input && typeof toolInput.input === 'string') {
-				toolInputForResult = toolInput.input;
-			} else {
-				// Exclude metadata fields: id, log, type
-				const { id, log, type, ...actualInput } = toolInput;
-				toolInputForResult = actualInput;
-			}
+			// Exclude metadata fields: id, log, type - always keep as object for type consistency
+			const { id, log, type, ...toolInputForResult } = toolInput;
 
 			// Build observation from tool result data or error information
 			// When tool execution fails, ai_tool may be missing but error info should be preserved

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/buildSteps.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/buildSteps.test.ts
@@ -51,7 +51,7 @@ describe('buildSteps', () => {
 			expect(result[0]).toMatchObject({
 				action: {
 					tool: 'Calculator',
-					toolInput: '2+2',
+					toolInput: { input: '2+2' },
 					toolCallId: 'call_123',
 					type: 'tool_call',
 				},
@@ -986,7 +986,7 @@ describe('buildSteps', () => {
 	});
 
 	describe('Tool input extraction', () => {
-		it('should extract toolInput as string from nested input property (legacy format)', () => {
+		it('should extract toolInput as object with string input property', () => {
 			const response: EngineResponse<RequestResponseMetadata> = {
 				actionResponses: [
 					{
@@ -1020,8 +1020,8 @@ describe('buildSteps', () => {
 			const result = buildSteps(response, itemIndex);
 
 			expect(result).toHaveLength(1);
-			// Should be a string to mimic old behavior
-			expect(result[0].action.toolInput).toBe('5*343');
+			// toolInput is always an object for type consistency with LangChain ToolCall
+			expect(result[0].action.toolInput).toEqual({ input: '5*343' });
 		});
 
 		it('should extract toolInput with multiple arguments (new format)', () => {

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/types.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/types.ts
@@ -27,7 +27,7 @@ export type ToolCallRequest = {
 export type ToolCallData = {
 	action: {
 		tool: string;
-		toolInput: Record<string, unknown> | string;
+		toolInput: Record<string, unknown>;
 		log: string | number | true | object;
 		messageLog?: AIMessage[];
 		toolCallId: IDataObject | GenericValue | GenericValue[] | IDataObject[];


### PR DESCRIPTION
## Summary
Fixes TypeScript error in `memoryManagement.ts` where `toolInput` type was incompatible with LangChain's `ToolCall` which requires `args` to be `Record<string, any>`.

The fix ensures `toolInput` is always an object by removing the string unwrapping logic in `buildSteps.ts` that was extracting string values from `{ input: "string" }` format.

## Changes
- Simplified `buildSteps.ts` to always keep `toolInput` as object
- Updated `ToolCallData.toolInput` type from `Record<string, unknown> | string` to `Record<string, unknown>`
- Updated tests to expect object format
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
