### PR TITLE
chore(core): Streamline runner debugging

### DIFF
--- a/packages/@n8n/task-runner-python/justfile
+++ b/packages/@n8n/task-runner-python/justfile
@@ -3,9 +3,6 @@ check:
     just format-check
     just typecheck
 
-run:
-    uv run python -m src.main
-
 sync:
     uv sync --group dev
 
@@ -42,7 +39,7 @@ debug:
     for i in {1..30}; do
         GRANT_TOKEN=$(curl -s -X POST http://127.0.0.1:5679/runners/auth -H "Content-Type: application/json" -d '{"token":"test"}' | jq -r '.data.token')
         if [ -n "$GRANT_TOKEN" ] && [ "$GRANT_TOKEN" != "null" ]; then
-            N8N_RUNNERS_GRANT_TOKEN="$GRANT_TOKEN" just run
+            PYTHONPATH="{{justfile_directory()}}" N8N_RUNNERS_GRANT_TOKEN="$GRANT_TOKEN" uv run python src/main.py
             exit 0
         fi
         [ $i -eq 1 ] && echo "Waiting for n8n task broker server at http://127.0.0.1:5679..."

--- a/packages/@n8n/task-runner/package.json
+++ b/packages/@n8n/task-runner/package.json
@@ -5,6 +5,7 @@
     "clean": "rimraf dist .turbo",
     "start": "node dist/start.js",
     "dev": "pnpm build && pnpm start",
+    "debug": "./scripts/debug.sh",
     "typecheck": "tsc --noEmit",
     "build": "tsc -p ./tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "format": "biome format --write src",

--- a/packages/@n8n/task-runner/scripts/debug.sh
+++ b/packages/@n8n/task-runner/scripts/debug.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# For debugging only, start the runner with a manually fetched grant token. If no broker, wait until available.
+
+for i in {1..30}; do
+    GRANT_TOKEN=$(curl -s -X POST http://127.0.0.1:5679/runners/auth -H "Content-Type: application/json" -d '{"token":"test"}' | jq -r '.data.token')
+    if [ -n "$GRANT_TOKEN" ] && [ "$GRANT_TOKEN" != "null" ]; then
+        N8N_RUNNERS_GRANT_TOKEN="$GRANT_TOKEN" pnpm start
+        exit 0
+    fi
+    [ $i -eq 1 ] && echo "Waiting for n8n task broker server at http://127.0.0.1:5679..."
+    sleep 1
+done
+echo "Error: Could not connect to n8n task broker server after 30 seconds"
+exit 1


### PR DESCRIPTION
## Summary

- Remove `run` recipe from Python runner justfile (pointless without auth)
- Update `debug` recipe to start the Python runner just like in prod
- Add `debug` script for JS runner

## Related Linear tickets, Github issues, and Community forum posts

n/a

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
