### PR TITLE
fix(core): Automatically re-publish workflow with new version on pull

### DIFF
--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control-import.service.ee.test.ts
@@ -400,6 +400,65 @@ describe('SourceControlImportService', () => {
 			expect(activeWorkflowManager.add).toHaveBeenCalledWith('workflow1', 'activate');
 		});
 
+		it('should call publishVersion with the new version when reactivating workflows', async () => {
+			const mockUserId = 'user-id-123';
+			const mockWorkflowFile = '/mock/workflow1.json';
+			const newVersionId = 'new-version-456';
+			const mockWorkflowData = {
+				id: 'workflow1',
+				name: 'Active Workflow',
+				nodes: [],
+				parentFolderId: null,
+				versionId: newVersionId,
+			};
+			const candidates = [mock<SourceControlledFile>({ file: mockWorkflowFile, id: 'workflow1' })];
+
+			projectRepository.getPersonalProjectForUserOrFail.mockResolvedValue(
+				Object.assign(new Project(), { id: 'project1', type: 'personal' }),
+			);
+			workflowRepository.findByIds.mockResolvedValue([
+				Object.assign(new WorkflowEntity(), {
+					id: 'workflow1',
+					name: 'Active Workflow',
+					active: true,
+					activeVersionId: 'old-version-123',
+				}),
+			]);
+			folderRepository.find.mockResolvedValue([]);
+			sharedWorkflowRepository.findWithFields.mockResolvedValue([]);
+			workflowRepository.upsert.mockResolvedValue({
+				identifiers: [{ id: 'workflow1' }],
+				generatedMaps: [],
+				raw: [],
+			});
+			workflowRepository.publishVersion.mockResolvedValue({
+				generatedMaps: [],
+				raw: [],
+				affected: 1,
+			});
+			workflowRepository.update.mockResolvedValue({
+				generatedMaps: [],
+				raw: [],
+				affected: 1,
+			});
+
+			fsReadFile.mockResolvedValue(JSON.stringify(mockWorkflowData));
+
+			await service.importWorkflowFromWorkFolder(candidates, mockUserId);
+
+			// Verify publishVersion is called with the new version
+			expect(workflowRepository.publishVersion).toHaveBeenCalledWith('workflow1', newVersionId);
+			// Verify the workflow is deactivated before reactivation
+			expect(activeWorkflowManager.remove).toHaveBeenCalledWith('workflow1');
+			// Verify the workflow is reactivated
+			expect(activeWorkflowManager.add).toHaveBeenCalledWith('workflow1', 'activate');
+			// Verify the versionId is updated
+			expect(workflowRepository.update).toHaveBeenCalledWith(
+				{ id: 'workflow1' },
+				{ versionId: newVersionId },
+			);
+		});
+
 		it('should deactivate archived workflows even if they were previously active', async () => {
 			const mockUserId = 'user-id-123';
 			const mockWorkflowFile = '/mock/workflow1.json';


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Fixes an issue where active workflows were not updated to run the new version after pulling changes from git. They continued running the old version instead of the newly pulled code.

## Problem
When pulling workflow changes from git:
- Already active workflows were deactivated and reactivated
- BUT they kept running the **old version** instead of the new pulled version
- The `activeVersionId` was not updated to the new `versionId`

## Solution
1. Use `workflowRepository.publishVersion()` to properly publish the new version
2. Update `activeVersionId` to the new version before reactivating
3. Ensure `versionId` is always updated in the `finally` block

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-4350/question-v203-git-environments-behaviour

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
