### PR TITLE
fix(editor): Logs not showing tool usage correctly for sub-agents

### DIFF
--- a/packages/frontend/editor-ui/src/features/execution/logs/logs.utils.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/logs.utils.ts
@@ -111,7 +111,7 @@ function getChildNodes(
 		return (
 			(source?.previousNode === node.name ||
 				(isPlaceholderLog(treeNode) && source?.previousNode === TOOL_EXECUTOR_NODE_NAME)) &&
-			(runIndex === undefined || source.previousNodeRun === runIndex)
+			(runIndex === undefined || (source.previousNodeRun ?? 0) === runIndex)
 		);
 	}
 


### PR DESCRIPTION
## Summary

This PR fixes the bug in log view where tool usage logs by sub agents are not always shown.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1906/logs-dont-seem-to-show-tool-usage-correctly-for-sub-agents


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
