### PR TITLE
fix(core): Fix CORS issue in waiting webhook responses

### DIFF
--- a/packages/cli/src/utils/__tests__/cors.util.test.ts
+++ b/packages/cli/src/utils/__tests__/cors.util.test.ts
@@ -1,0 +1,135 @@
+import type { Request, Response } from 'express';
+
+import { applyCors } from '../cors.util';
+
+describe('applyCors', () => {
+	let mockReq: Partial<Request>;
+	let mockRes: Partial<Response>;
+	let setHeaderSpy: jest.Mock;
+	let getHeaderSpy: jest.Mock;
+
+	beforeEach(() => {
+		setHeaderSpy = jest.fn();
+		getHeaderSpy = jest.fn();
+
+		mockReq = {
+			headers: {},
+		};
+
+		mockRes = {
+			setHeader: setHeaderSpy,
+			getHeader: getHeaderSpy,
+		};
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should not modify headers if Access-Control-Allow-Origin is already set', () => {
+		getHeaderSpy.mockReturnValue('https://example.com');
+		mockReq.headers = { origin: 'https://test.com' };
+
+		applyCors(mockReq as Request, mockRes as Response);
+
+		expect(getHeaderSpy).toHaveBeenCalledWith('Access-Control-Allow-Origin');
+		expect(setHeaderSpy).not.toHaveBeenCalled();
+	});
+
+	it('should set Access-Control-Allow-Origin to * when origin is undefined', () => {
+		getHeaderSpy.mockReturnValue(undefined);
+		mockReq.headers = {};
+
+		applyCors(mockReq as Request, mockRes as Response);
+
+		expect(setHeaderSpy).toHaveBeenCalledWith('Access-Control-Allow-Origin', '*');
+		expect(setHeaderSpy).toHaveBeenCalledWith('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
+		expect(setHeaderSpy).toHaveBeenCalledWith('Access-Control-Allow-Headers', 'Content-Type');
+		expect(setHeaderSpy).toHaveBeenCalledTimes(3);
+	});
+
+	it('should set Access-Control-Allow-Origin to * when origin is "null"', () => {
+		getHeaderSpy.mockReturnValue(undefined);
+		mockReq.headers = { origin: 'null' };
+
+		applyCors(mockReq as Request, mockRes as Response);
+
+		expect(setHeaderSpy).toHaveBeenCalledWith('Access-Control-Allow-Origin', '*');
+		expect(setHeaderSpy).toHaveBeenCalledWith('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
+		expect(setHeaderSpy).toHaveBeenCalledWith('Access-Control-Allow-Headers', 'Content-Type');
+		expect(setHeaderSpy).toHaveBeenCalledTimes(3);
+	});
+
+	it('should set Access-Control-Allow-Origin to the request origin when origin is provided', () => {
+		getHeaderSpy.mockReturnValue(undefined);
+		const origin = 'https://example.com';
+		mockReq.headers = { origin };
+
+		applyCors(mockReq as Request, mockRes as Response);
+
+		expect(setHeaderSpy).toHaveBeenCalledWith('Access-Control-Allow-Origin', origin);
+		expect(setHeaderSpy).toHaveBeenCalledWith('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
+		expect(setHeaderSpy).toHaveBeenCalledWith('Access-Control-Allow-Headers', 'Content-Type');
+		expect(setHeaderSpy).toHaveBeenCalledTimes(3);
+	});
+
+	it('should set Access-Control-Allow-Origin to the request origin with localhost', () => {
+		getHeaderSpy.mockReturnValue(undefined);
+		const origin = 'http://localhost:3000';
+		mockReq.headers = { origin };
+
+		applyCors(mockReq as Request, mockRes as Response);
+
+		expect(setHeaderSpy).toHaveBeenCalledWith('Access-Control-Allow-Origin', origin);
+		expect(setHeaderSpy).toHaveBeenCalledWith('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
+		expect(setHeaderSpy).toHaveBeenCalledWith('Access-Control-Allow-Headers', 'Content-Type');
+		expect(setHeaderSpy).toHaveBeenCalledTimes(3);
+	});
+
+	it('should set Access-Control-Allow-Origin to the request origin with custom port', () => {
+		getHeaderSpy.mockReturnValue(undefined);
+		const origin = 'https://app.example.com:8080';
+		mockReq.headers = { origin };
+
+		applyCors(mockReq as Request, mockRes as Response);
+
+		expect(setHeaderSpy).toHaveBeenCalledWith('Access-Control-Allow-Origin', origin);
+		expect(setHeaderSpy).toHaveBeenCalledWith('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
+		expect(setHeaderSpy).toHaveBeenCalledWith('Access-Control-Allow-Headers', 'Content-Type');
+		expect(setHeaderSpy).toHaveBeenCalledTimes(3);
+	});
+
+	it('should handle IP address as origin', () => {
+		getHeaderSpy.mockReturnValue(undefined);
+		const origin = 'http://192.168.1.1:5000';
+		mockReq.headers = { origin };
+
+		applyCors(mockReq as Request, mockRes as Response);
+
+		expect(setHeaderSpy).toHaveBeenCalledWith('Access-Control-Allow-Origin', origin);
+		expect(setHeaderSpy).toHaveBeenCalledWith('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
+		expect(setHeaderSpy).toHaveBeenCalledWith('Access-Control-Allow-Headers', 'Content-Type');
+		expect(setHeaderSpy).toHaveBeenCalledTimes(3);
+	});
+
+	it('should always set Allow-Methods and Allow-Headers when origin is present', () => {
+		getHeaderSpy.mockReturnValue(undefined);
+		const origin = 'https://trusted-domain.com';
+		mockReq.headers = { origin };
+
+		applyCors(mockReq as Request, mockRes as Response);
+
+		expect(setHeaderSpy).toHaveBeenCalledWith('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
+		expect(setHeaderSpy).toHaveBeenCalledWith('Access-Control-Allow-Headers', 'Content-Type');
+	});
+
+	it('should always set Allow-Methods and Allow-Headers when origin is not present', () => {
+		getHeaderSpy.mockReturnValue(undefined);
+		mockReq.headers = {};
+
+		applyCors(mockReq as Request, mockRes as Response);
+
+		expect(setHeaderSpy).toHaveBeenCalledWith('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
+		expect(setHeaderSpy).toHaveBeenCalledWith('Access-Control-Allow-Headers', 'Content-Type');
+	});
+});

--- a/packages/cli/src/utils/cors.util.ts
+++ b/packages/cli/src/utils/cors.util.ts
@@ -1,0 +1,18 @@
+import type { Request, Response } from 'express';
+
+export function applyCors(req: Request, res: Response) {
+	if (res.getHeader('Access-Control-Allow-Origin')) {
+		return;
+	}
+
+	const origin = req.headers.origin;
+
+	if (!origin || origin === 'null') {
+		res.setHeader('Access-Control-Allow-Origin', '*');
+	} else {
+		res.setHeader('Access-Control-Allow-Origin', origin);
+	}
+
+	res.setHeader('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
+	res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}

--- a/packages/cli/src/webhooks/waiting-forms.ts
+++ b/packages/cli/src/webhooks/waiting-forms.ts
@@ -17,6 +17,7 @@ import { WaitingWebhooks } from '@/webhooks/waiting-webhooks';
 
 import { sanitizeWebhookRequest } from './webhook-request-sanitizer';
 import type { IWebhookResponseCallbackData, WaitingWebhookRequest } from './webhook.types';
+import { applyCors } from '@/utils/cors.util';
 
 @Service()
 export class WaitingForms extends WaitingWebhooks {
@@ -97,9 +98,7 @@ export class WaitingForms extends WaitingWebhooks {
 				}
 			}
 
-			if (req.headers.origin) {
-				res.header('Access-Control-Allow-Origin', req.headers.origin);
-			}
+			applyCors(req, res);
 
 			res.send(status);
 			return { noWebhookResponse: true };
@@ -147,6 +146,8 @@ export class WaitingForms extends WaitingWebhooks {
 				lastNodeExecuted = completionPage;
 			}
 		}
+
+		applyCors(req, res);
 
 		return await this.getWebhookExecutionData({
 			execution,

--- a/packages/cli/src/webhooks/waiting-webhooks.ts
+++ b/packages/cli/src/webhooks/waiting-webhooks.ts
@@ -33,6 +33,7 @@ import { getWorkflowActiveStatusFromWorkflowData } from '@/executions/execution.
 import { NodeTypes } from '@/node-types';
 import * as WebhookHelpers from '@/webhooks/webhook-helpers';
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
+import { applyCors } from '@/utils/cors.util';
 
 /**
  * Service for handling the execution of webhooks of Wait nodes that use the
@@ -169,6 +170,8 @@ export class WaitingWebhooks implements IWebhookManager {
 		}
 
 		const lastNodeExecuted = execution.data.resultData.lastNodeExecuted as string;
+
+		applyCors(req, res);
 
 		return await this.getWebhookExecutionData({
 			execution,


### PR DESCRIPTION
## Summary

Fixes an issue where Telegram “Send message and wait for response” custom forms remain stuck in a loading state after submission.

The backend correctly receives and processes the form data, but the frontend fails due to missing CORS headers on waiting webhook responses (especially when the request origin is "null").

This change ensures proper CORS headers are always sent for waiting webhooks, allowing the form to complete and render the submission confirmation page.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4141/community-issue-telegram-node-custom-form-passes-data-but-still-loads


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
