### PR TITLE
test: Fix flaky active-executions test 

### DIFF
--- a/packages/cli/src/__tests__/active-executions.test.ts
+++ b/packages/cli/src/__tests__/active-executions.test.ts
@@ -14,7 +14,6 @@ import type {
 import {
 	createEmptyRunExecutionData,
 	ManualExecutionCancelledError,
-	randomInt,
 	sleep,
 	SystemShutdownExecutionCancelledError,
 } from 'n8n-workflow';

--- a/packages/cli/src/__tests__/active-executions.test.ts
+++ b/packages/cli/src/__tests__/active-executions.test.ts
@@ -322,9 +322,8 @@ describe('ActiveExecutions', () => {
 		let waitingExecutionId1: string, waitingExecutionId2: string;
 
 		beforeEach(async () => {
-			executionRepository.createNewExecution.mockImplementation(async () =>
-				randomInt(1000, 2000).toString(),
-			);
+			let i = 1000;
+			executionRepository.createNewExecution.mockImplementation(async () => `${i++}`);
 
 			(sleep as jest.Mock).mockImplementation(() => {
 				// @ts-expect-error private property


### PR DESCRIPTION
## Summary

I'm not positive this is the actual root cause, but I could see how the randomness occasionally causes a collision and a missing execution which would explain this seldom flaky test.

## Related Linear tickets, Github issues, and Community forum posts

n/a


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
