### PR TITLE
fix(editor): Fix wf history item display issue (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryListItem.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryListItem.vue
@@ -358,6 +358,7 @@ $hoverBackground: var(--color--background--light-1);
 
 .unnamedTime {
 	margin-left: var(--spacing--5xs);
+	white-space: nowrap;
 }
 
 .actions {


### PR DESCRIPTION
## Summary

<img width="436" height="1029" alt="image" src="https://github.com/user-attachments/assets/70aeb4af-88d5-44f9-b947-e8f3eeeb1227" />
<img width="405" height="938" alt="image" src="https://github.com/user-attachments/assets/6b149bb7-c999-4b22-8fc2-9d47dc4c2b7b" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4586/version-titles-in-history-list-are-not-displayed-properly

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
