### PR TITLE
fix(Loop Over Items Node): Reset state when loop is re-entered in nested loopsFix Loop Over Items node skipping iterations in nested loops

### DIFF
--- a/packages/nodes-base/nodes/SplitInBatches/v3/SplitInBatchesV3.node.ts
+++ b/packages/nodes-base/nodes/SplitInBatches/v3/SplitInBatchesV3.node.ts
@@ -75,7 +75,7 @@ export class SplitInBatchesV3 implements INodeType {
 
 		const options = this.getNodeParameter('options', 0, {});
 
-		if (nodeContext.items === undefined || options.reset === true) {
+		if (nodeContext.items === undefined || options.reset === true || nodeContext.done === true) {
 			// Is the first time the node runs
 
 			const sourceData = this.getInputSourceData();


### PR DESCRIPTION
## Important notes

1. This was fixed using Claude Code, so it needs some attention. It was tested on n8n and worked correctly.
2. Only the V3 of the node, not V2. I don't know what our policy if we fix also older versions of the nodes.
3. **Before merging**: we should understand whether this is an expected behaviour (as Jon mentioned) or not.
4. **Create a new version** as this will be a breaking change.

## Summary

- Fix for Loop Over Items node skipping iterations when used in nested loop configurations.
- The problem: When a Loop Over Items node (inner loop) was nested inside another loop (parent loop), after the first complete cycle of the parent loop, the inner loop would incorrectly skip directly to the "done" branch instead of processing items in subsequent parent iterations.
- Root cause: The node context retained done === true from the previous completion, but the reset condition only checked for undefined items or explicit reset option.
- The fix: Add nodeContext.done === true to the reset condition, ensuring the loop properly resets when re-entered after completion.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2059/bug-loop-node-nested-loop-node-skips-loop-branch-after-first-parent


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
