### PR TITLE
fix(core): Fix redirection of user missing MFA to personal settings

### DIFF
--- a/packages/@n8n/db/src/entities/types-db.ts
+++ b/packages/@n8n/db/src/entities/types-db.ts
@@ -391,6 +391,8 @@ export type APIRequest<
 
 export type AuthenticationInformation = {
 	usedMfa: boolean;
+	// Indicates the user is logged in but hasn't completed required MFA enrollment
+	mfaEnrollmentRequired?: boolean;
 };
 
 export type AuthenticatedRequest<

--- a/packages/cli/src/auth/auth.service.ts
+++ b/packages/cli/src/auth/auth.service.ts
@@ -114,7 +114,16 @@ export class AuthService {
 							// If the user has MFA enforced, but did not use it during authentication, we need to throw an error
 							throw new AuthError('MFA not used during authentication');
 						} else {
+							// User doesn't have MFA enabled, but MFA is enforced
+							// They need to set up MFA before accessing most endpoints
 							if (allowUnauthenticated) {
+								// Don't set req.user to avoid giving full access to semi-authenticated users
+								// Instead, set a flag in authInfo to indicate MFA enrollment is required
+								// This allows endpoints to handle this state appropriately (e.g., return public settings)
+								req.authInfo = {
+									usedMfa,
+									mfaEnrollmentRequired: true,
+								};
 								return next();
 							}
 

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -489,7 +489,7 @@ export class Server extends AbstractServer {
 				ResponseHelper.send(async (req: AuthenticatedRequest) => {
 					return req.user
 						? await frontendService.getSettings()
-						: await frontendService.getPublicSettings();
+						: await frontendService.getPublicSettings(!!req.authInfo?.mfaEnrollmentRequired);
 				}),
 			);
 		}

--- a/packages/cli/src/services/__tests__/frontend.service.test.ts
+++ b/packages/cli/src/services/__tests__/frontend.service.test.ts
@@ -230,7 +230,39 @@ describe('FrontendService', () => {
 			};
 
 			const { service } = createMockService();
-			const settings = await service.getPublicSettings();
+			const settings = await service.getPublicSettings(false);
+
+			expect(settings).toEqual(expectedPublicSettings);
+		});
+
+		it('should return public settings with mfa', async () => {
+			const expectedPublicSettings = {
+				settingsMode: 'public',
+				defaultLocale: 'en',
+				userManagement: {
+					smtpSetup: false,
+					showSetupOnFirstLoad: true,
+					authenticationMethod: 'email',
+				},
+				sso: {
+					saml: { loginEnabled: false },
+					ldap: { loginEnabled: false, loginLabel: '' },
+					oidc: {
+						loginEnabled: false,
+						loginUrl: 'http://localhost:5678/rest/sso/oidc/login',
+					},
+				},
+				authCookie: { secure: false },
+				previewMode: false,
+				enterprise: { saml: false, ldap: false, oidc: false },
+				mfa: {
+					enabled: false,
+					enforced: false,
+				},
+			};
+
+			const { service } = createMockService();
+			const settings = await service.getPublicSettings(true);
 
 			expect(settings).toEqual(expectedPublicSettings);
 		});

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -20,11 +20,11 @@ import { getLdapLoginLabel } from '@/ldap.ee/helpers.ee';
 import { License } from '@/license';
 import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 import { MfaService } from '@/mfa/mfa.service';
-import { OwnershipService } from '@/services/ownership.service';
 import { CommunityPackagesConfig } from '@/modules/community-packages/community-packages.config';
 import type { CommunityPackagesService } from '@/modules/community-packages/community-packages.service';
 import { isApiEnabled } from '@/public-api';
 import { PushConfig } from '@/push/push.config';
+import { OwnershipService } from '@/services/ownership.service';
 import { getSamlLoginLabel } from '@/sso.ee/saml/saml-helpers';
 import { getCurrentAuthenticationMethod } from '@/sso.ee/sso-helpers';
 import { UserManagementMailer } from '@/user-management/email';
@@ -92,6 +92,11 @@ export type PublicFrontendSettings = {
 			/** Required for OIDC authentication redirect URL */
 			loginUrl: FrontendSettings['sso']['oidc']['loginUrl'];
 		};
+	};
+
+	mfa?: {
+		enabled: boolean;
+		enforced: boolean;
 	};
 };
 
@@ -519,7 +524,7 @@ export class FrontendService {
 	 * Only add settings that are absolutely necessary for non-authenticated pages
 	 * @returns Public settings for unauthenticated users
 	 */
-	async getPublicSettings(): Promise<PublicFrontendSettings> {
+	async getPublicSettings(displayMfaSettings: boolean): Promise<PublicFrontendSettings> {
 		// Get full settings to ensure all required properties are initialized
 		const {
 			defaultLocale,
@@ -528,6 +533,7 @@ export class FrontendService {
 			authCookie,
 			previewMode,
 			enterprise: { saml, ldap, oidc },
+			mfa,
 		} = await this.getSettings();
 
 		const publicSettings: PublicFrontendSettings = {
@@ -548,6 +554,9 @@ export class FrontendService {
 			previewMode,
 			enterprise: { saml, ldap, oidc },
 		};
+		if (displayMfaSettings) {
+			publicSettings.mfa = mfa;
+		}
 		return publicSettings;
 	}
 

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -524,7 +524,7 @@ export class FrontendService {
 	 * Only add settings that are absolutely necessary for non-authenticated pages
 	 * @returns Public settings for unauthenticated users
 	 */
-	async getPublicSettings(displayMfaSettings: boolean): Promise<PublicFrontendSettings> {
+	async getPublicSettings(includeMfaSettings: boolean): Promise<PublicFrontendSettings> {
 		// Get full settings to ensure all required properties are initialized
 		const {
 			defaultLocale,
@@ -554,7 +554,7 @@ export class FrontendService {
 			previewMode,
 			enterprise: { saml, ldap, oidc },
 		};
-		if (displayMfaSettings) {
+		if (includeMfaSettings) {
 			publicSettings.mfa = mfa;
 		}
 		return publicSettings;

--- a/packages/frontend/editor-ui/src/app/stores/settings.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/settings.store.ts
@@ -239,6 +239,10 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 		setSettings(fetchedSettings);
 		rootStore.setDefaultLocale(fetchedSettings.defaultLocale);
 
+		// Set MFA enforced state even for public settings mode
+		// as it is needed to determine if the MFA setup page should be shown
+		isMFAEnforced.value = settings.value.mfa?.enforced ?? false;
+
 		if (fetchedSettings.settingsMode === 'public') {
 			// public settings mode is typically used for unauthenticated users
 			// when public settings are returned we can skip the rest of the setup
@@ -254,8 +258,6 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 		setSaveDataSuccessExecution(fetchedSettings.saveDataSuccessExecution);
 		setSaveDataProgressExecution(fetchedSettings.saveExecutionProgress);
 		setSaveManualExecutions(fetchedSettings.saveManualExecutions);
-
-		isMFAEnforced.value = settings.value.mfa?.enforced ?? false;
 
 		rootStore.setUrlBaseWebhook(fetchedSettings.urlBaseWebhook);
 		rootStore.setUrlBaseEditor(fetchedSettings.urlBaseEditor);


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR fixes the issue that users missing enforced MFA are blocked from the instance.
This issue was caused by the public settings not returning mfa settings for user authenticated without mandatory MFA. 
We fixed it by returning the MFA settings for user authenticated but missing MFA, so that the front can redirect to personal settings for the user to setup their MFA.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-4385/enforcing-mfa-blocks-all-users-without-mfa-setup-from-the-instance

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
