### PR TITLE
fix(Stripe Node): Prevent duplicate webhook creation on Stripe

### DIFF
--- a/packages/nodes-base/nodes/Stripe/StripeTrigger.node.ts
+++ b/packages/nodes-base/nodes/Stripe/StripeTrigger.node.ts
@@ -922,6 +922,14 @@ export class StripeTrigger implements INodeType {
 				return true;
 			},
 			async delete(this: IHookFunctions): Promise<boolean> {
+				const activationMode = this.getActivationMode();
+
+				// When the workflow is being updated (re-published), keep the existing
+				// Stripe webhook to avoid creating duplicates
+				if (activationMode === 'update') {
+					return true;
+				}
+
 				const webhookData = this.getWorkflowStaticData('node');
 
 				if (webhookData.webhookId !== undefined) {


### PR DESCRIPTION
When a workflow with a Stripe trigger is republished, the webhook was being deleted and recreated, causing duplicate webhooks in Stripe. This fix checks the activation mode and skips webhook deletion when the mode is 'update', preserving the existing webhook.

## Summary
  - Fix duplicate Stripe webhooks being created when republishing an active workflow
  - Skip webhook deletion when activation mode is `update` to preserve existing webhook
 
Fixes https://github.com/n8n-io/n8n/issues/23893

  ## Test plan
  - [x] Added unit tests for the delete method behavior
  - [ ] Manual test: Republish a workflow with Stripe trigger and verify no duplicate webhook is created in Stripe dashboard

  Une fois la PR créée, l'équipe n8n la reviewera. Ils peuvent te demander des modifications - c'est normal pour une première contribution !