### PR TITLE
fix(DataTable Node): Use extractValue to properly resolve data table ID

### DIFF
--- a/packages/nodes-base/nodes/DataTable/common/utils.ts
+++ b/packages/nodes-base/nodes/DataTable/common/utils.ts
@@ -28,7 +28,6 @@ function isDateLike(v: unknown): v is DateLike {
 async function resolveDataTableId(
 	ctx: IExecuteFunctions | ILoadOptionsFunctions,
 	resourceLocator: { mode: 'list' | 'id' | 'name'; value: string },
-	index?: number,
 ): Promise<string> {
 	if (resourceLocator.mode === 'name') {
 		// Look up table by name
@@ -47,10 +46,8 @@ async function resolveDataTableId(
 
 		return response.data[0].id;
 	} else {
-		// For 'list' and 'id' modes, extract the value directly
-		return ctx.getNodeParameter(DATA_TABLE_ID_FIELD, index, undefined, {
-			extractValue: true,
-		}) as string;
+		// For 'list' and 'id' modes, the value is already the ID
+		return resourceLocator.value;
 	}
 }
 
@@ -71,7 +68,7 @@ export async function getDataTableProxyExecute(
 		value: string;
 	};
 
-	const dataTableId = await resolveDataTableId(ctx, resourceLocator, index);
+	const dataTableId = await resolveDataTableId(ctx, resourceLocator);
 
 	return await ctx.helpers.getDataTableProxy(dataTableId);
 }


### PR DESCRIPTION

## Summary
Fixes the `resolveDataTableId` function in the DataTable node to properly extract the data table ID when using 'list' or 'id' modes in the resource locator.

The function now uses `ctx.getNodeParameter` with the `extractValue: true` option instead of directly returning `resourceLocator.value`. This ensures the ID is correctly extracted from the resource locator regardless of the internal structure.

### Changes
- Added `index` parameter to `resolveDataTableId` function
- For 'list' and 'id' modes, use `ctx.getNodeParameter` with `extractValue: true` to properly resolve the data table ID
- Updated `getDataTableProxyExecute` to pass the index parameter

### Screenshots
#### Before
<img width="1415" height="1009" alt="image" src="https://github.com/user-attachments/assets/c738f85e-2f59-43ba-9c59-389550633826" />

#### After
<img width="1031" height="600" alt="image" src="https://github.com/user-attachments/assets/53dded31-4fc2-4039-80fa-3c62ef952413" />

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/GHC-6167
Fixes #23884
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
