### PR TITLE
ci: Resolve Poutine security scanner findings

### DIFF
--- a/.github/workflows/ci-evals.yml
+++ b/.github/workflows/ci-evals.yml
@@ -35,12 +35,15 @@ jobs:
           ref: ${{ github.event.inputs.branch || github.ref }}
 
       - name: Select dataset
+        env:
+          DATASET_INPUT: ${{ github.event.inputs.dataset }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           DATASET="workflow-builder-canvas-prompts"
-          if [ "${{ github.event_name }}" = "schedule" ]; then
+          if [ "$EVENT_NAME" = "schedule" ]; then
             DATASET="prompts-v2"
-          elif [ -n "${{ github.event.inputs.dataset }}" ]; then
-            DATASET="${{ github.event.inputs.dataset }}"
+          elif [ -n "$DATASET_INPUT" ]; then
+            DATASET="$DATASET_INPUT"
           fi
           echo "LANGSMITH_DATASET_NAME=$DATASET" >> "$GITHUB_ENV"
 

--- a/.poutine.yml
+++ b/.poutine.yml
@@ -33,22 +33,21 @@ skip:
       - pkg:githubactions/tomi/paths-filter-action
       - pkg:githubactions/useblacksmith/setup-docker-builder
 
-  # === TEMPORARY SKIPS ===
-  # These findings need to be addressed in a follow-up ticket.
-  # Do not add new entries to this section.
-
-  # TODO: Fix injection vulnerability - use environment variable instead of
-  # direct interpolation of github.event.inputs.dataset
-  - rule: injection
-    path:
-      - .github/workflows/ci-evals.yml
-
-  # TODO: Review untrusted checkout execution patterns.
-  # These workflows run local actions or package managers after checking out
-  # untrusted PR code, which is a potential security risk.
+  # === UNTRUSTED CHECKOUT EXECUTION (DOCUMENTED FALSE POSITIVES) ===
+  # These workflows check out code and run local actions/package managers.
+  # Poutine flags them as potential risks, but they are safe due to their
+  # invocation context.
   - rule: untrusted_checkout_exec
     path:
+      # Only called from release-publish.yml with release tag refs (e.g., n8n@1.2.3),
+      # never PR code. The checked out code is already-released, trusted code.
       - .github/workflows/sbom-generation-callable.yml
+      # Uses merge commit SHA from GitHub - the code has already been reviewed
+      # and merged, not arbitrary PR code.
       - .github/workflows/linting-reusable.yml
-      - .github/workflows/test-workflows-callable.yml
+      # Uses merge commit SHA from GitHub - the code has already been reviewed
+      # and merged, not arbitrary PR code.
       - .github/workflows/units-tests-reusable.yml
+      # Permission-gated: only maintainers (admin/write/maintain) can trigger
+      # via /test-workflows comment. Verified in test-workflows-pr-comment.yml.
+      - .github/workflows/test-workflows-callable.yml


### PR DESCRIPTION
## Summary

  - Fix command injection vulnerability in `ci-evals.yml` by using environment variables instead of direct GitHub expression interpolation
  - Convert temporary Poutine skips to documented permanent skips with security justifications
  - Remove TODO comments from `.poutine.yml`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2063


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
