### PR TITLE
fix(core): Fix AddWorkflowVersionIdToExecutionData migration copying the table

### DIFF
--- a/packages/@n8n/db/src/migrations/common/1765892199653-AddVersionIdToExecutionData.ts
+++ b/packages/@n8n/db/src/migrations/common/1765892199653-AddVersionIdToExecutionData.ts
@@ -1,11 +1,15 @@
 import type { MigrationContext, ReversibleMigration } from '../migration-types';
 
 export class AddWorkflowVersionIdToExecutionData1765892199653 implements ReversibleMigration {
-	async up({ schemaBuilder: { addColumns, column } }: MigrationContext) {
-		await addColumns('execution_data', [column('workflowVersionId').varchar(36)]);
+	async up({ runQuery, escape }: MigrationContext) {
+		const tableName = escape.tableName('execution_data');
+		const workflowVersionId = escape.columnName('workflowVersionId');
+		await runQuery(`ALTER TABLE ${tableName} ADD COLUMN ${workflowVersionId} VARCHAR(36)`);
 	}
 
-	async down({ schemaBuilder: { dropColumns } }: MigrationContext) {
-		await dropColumns('execution_data', ['workflowVersionId']);
+	async down({ runQuery, escape }: MigrationContext) {
+		const tableName = escape.tableName('execution_data');
+		const workflowVersionId = escape.columnName('workflowVersionId');
+		await runQuery(`ALTER TABLE ${tableName} DROP COLUMN ${workflowVersionId}`);
 	}
 }


### PR DESCRIPTION
## Summary

Typeorm's `addColumns` copies the underlying table rather than using a native ALTER TABLE command in sqlite.

Tested by checking out 2.1.0 locally, deleting my DB, adding some large execution data and then running this branch.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4588


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
