### PR TITLE
ci: Rename GH workflows for consistent naming

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -1,4 +1,4 @@
-name: Docker Base Image CI
+name: 'Build: Base Image'
 
 on:
   push:

--- a/.github/workflows/build-benchmark-image.yml
+++ b/.github/workflows/build-benchmark-image.yml
@@ -1,4 +1,4 @@
-name: Benchmark Docker Image CI
+name: 'Build: Benchmark Image'
 
 on:
   workflow_dispatch:
@@ -9,7 +9,7 @@ on:
       - 'packages/@n8n/benchmark/**'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
-      - '.github/workflows/docker-images-benchmark.yml'
+      - '.github/workflows/build-benchmark-image.yml'
 
 jobs:
   build:

--- a/.github/workflows/build-unit-test-pr-comment.yml
+++ b/.github/workflows/build-unit-test-pr-comment.yml
@@ -94,7 +94,7 @@ jobs:
           HEAD_SHA: ${{ steps.check_permissions.outputs.headSha }}
           PR_NUMBER: ${{ steps.check_permissions.outputs.prNumber }}
         run: |
-          gh workflow run ci-manual-build-unit-tests.yml \
+          gh workflow run ci-manual-unit-tests.yml \
             --repo "${{ github.repository }}" \
             -f ref="${HEAD_SHA}" \
             -f pr_number="${PR_NUMBER}"

--- a/.github/workflows/build-unit-test-pr-comment.yml
+++ b/.github/workflows/build-unit-test-pr-comment.yml
@@ -1,4 +1,4 @@
-name: Trigger build/unit tests on PR comment
+name: 'Build: Unit Test PR Comment'
 
 on:
   issue_comment:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,4 +1,4 @@
-name: Windows CI
+name: 'Build: Windows'
 
 on:
   workflow_dispatch:

--- a/.github/workflows/ci-check-eligibility-reusable.yml
+++ b/.github/workflows/ci-check-eligibility-reusable.yml
@@ -13,7 +13,7 @@
 #
 # It outputs `should_run` as 'true' if ALL conditions pass, 'false' otherwise.
 
-name: PR Eligibility Check
+name: 'CI: Check Eligibility'
 
 on:
   workflow_call:

--- a/.github/workflows/ci-check-pr-title.yml
+++ b/.github/workflows/ci-check-pr-title.yml
@@ -1,4 +1,4 @@
-name: Check PR title
+name: 'CI: Check PR Title'
 
 on:
   pull_request:

--- a/.github/workflows/ci-manual-unit-tests.yml
+++ b/.github/workflows/ci-manual-unit-tests.yml
@@ -1,4 +1,4 @@
-name: Build, unit test and lint (manual trigger)
+name: 'CI: Manual Unit Tests'
 
 on:
   workflow_dispatch:
@@ -66,7 +66,7 @@ jobs:
   unit-tests:
     name: Unit tests
     needs: install-and-build
-    uses: ./.github/workflows/units-tests-reusable.yml
+    uses: ./.github/workflows/test-unit-reusable.yml
     with:
       ref: ${{ inputs.ref }}
       collectCoverage: true
@@ -76,7 +76,7 @@ jobs:
   lint:
     name: Lint
     needs: install-and-build
-    uses: ./.github/workflows/linting-reusable.yml
+    uses: ./.github/workflows/test-linting-reusable.yml
     with:
       ref: ${{ inputs.ref }}
 

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -20,7 +20,7 @@ jobs:
 
   unit-test:
     name: Unit tests
-    uses: ./.github/workflows/units-tests-reusable.yml
+    uses: ./.github/workflows/test-unit-reusable.yml
     strategy:
       matrix:
         node-version: [20.x, 22.x, 24.3.x]
@@ -33,7 +33,7 @@ jobs:
 
   lint:
     name: Lint
-    uses: ./.github/workflows/linting-reusable.yml
+    uses: ./.github/workflows/test-linting-reusable.yml
     with:
       ref: ${{ github.sha }}
 

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -1,4 +1,4 @@
-name: Test Master
+name: 'CI: Master (Build, Test, Lint)'
 
 on:
   push:

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -53,7 +53,7 @@ jobs:
   unit-test:
     name: Unit tests
     if: needs.install-and-build.outputs.non_python_changed == 'true'
-    uses: ./.github/workflows/units-tests-reusable.yml
+    uses: ./.github/workflows/test-unit-reusable.yml
     needs: install-and-build
     with:
       ref: ${{ needs.install-and-build.outputs.commit_sha }}
@@ -79,7 +79,7 @@ jobs:
   lint:
     name: Lint
     if: needs.install-and-build.outputs.non_python_changed == 'true'
-    uses: ./.github/workflows/linting-reusable.yml
+    uses: ./.github/workflows/test-linting-reusable.yml
     needs: install-and-build
     with:
       ref: ${{ needs.install-and-build.outputs.commit_sha }}
@@ -88,7 +88,7 @@ jobs:
     name: E2E Tests
     needs: install-and-build
     if: needs.install-and-build.outputs.non_python_changed == 'true'
-    uses: ./.github/workflows/playwright-test-ci.yml
+    uses: ./.github/workflows/test-e2e-ci-reusable.yml
     with:
       branch: ${{ needs.install-and-build.outputs.commit_sha }}
     secrets: inherit
@@ -97,7 +97,7 @@ jobs:
     name: Security Checks
     needs: install-and-build
     if: needs.install-and-build.outputs.workflows_changed == 'true'
-    uses: ./.github/workflows/ci-security.yml
+    uses: ./.github/workflows/sec-ci-reusable.yml
     with:
       ref: ${{ needs.install-and-build.outputs.commit_sha }}
     secrets: inherit

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -1,4 +1,4 @@
-name: Build, unit test and lint branch
+name: 'CI: Pull Requests (Build, Test, Lint)'
 
 on:
   pull_request:

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -1,4 +1,4 @@
-name: Python CI
+name: 'CI: Python'
 
 on:
   pull_request:

--- a/.github/workflows/sec-ci-reusable.yml
+++ b/.github/workflows/sec-ci-reusable.yml
@@ -1,4 +1,4 @@
-name: Security Checks
+name: 'Sec: CI Checks'
 
 on:
   workflow_call:
@@ -12,7 +12,7 @@ on:
 jobs:
   poutine-scan:
     name: Poutine Security Scan
-    uses: ./.github/workflows/security-poutine-scan-callable.yml
+    uses: ./.github/workflows/sec-poutine-reusable.yml
     with:
       ref: ${{ inputs.ref }}
     secrets: inherit

--- a/.github/workflows/sec-poutine-reusable.yml
+++ b/.github/workflows/sec-poutine-reusable.yml
@@ -1,4 +1,4 @@
-name: Security - Scan GitHub Actions with Poutine
+name: 'Sec: Poutine Scan'
 
 on:
   workflow_dispatch:

--- a/.github/workflows/test-benchmark-destroy-nightly.yml
+++ b/.github/workflows/test-benchmark-destroy-nightly.yml
@@ -1,4 +1,4 @@
-name: Destroy Benchmark Env
+name: 'Test: Benchmark Destroy Env'
 
 on:
   schedule:

--- a/.github/workflows/test-benchmark-nightly.yml
+++ b/.github/workflows/test-benchmark-nightly.yml
@@ -1,4 +1,4 @@
-name: Run Nightly Benchmark
+name: 'Test: Benchmark Nightly'
 run-name: Benchmark ${{ inputs.n8n_tag || 'nightly' }}
 
 on:

--- a/.github/workflows/test-db-postgres-mysql.yml
+++ b/.github/workflows/test-db-postgres-mysql.yml
@@ -1,4 +1,4 @@
-name: Test Postgres and MySQL schemas
+name: 'Test: DB Postgres MySQL'
 
 on:
   schedule:
@@ -14,7 +14,7 @@ on:
       - packages/cli/test/shared/db/**
       - packages/@n8n/db/**
       - packages/cli/**/__tests__/**
-      - .github/workflows/ci-postgres-mysql.yml
+      - .github/workflows/test-db-postgres-mysql.yml
       - .github/docker-compose.yml
 
 concurrency:

--- a/.github/workflows/test-e2e-ci-reusable.yml
+++ b/.github/workflows/test-e2e-ci-reusable.yml
@@ -1,4 +1,4 @@
-name: E2E Tests for CI
+name: 'Test: E2E CI'
 
 on:
   workflow_call:
@@ -16,7 +16,7 @@ jobs:
   multi-main-e2e:
     name: 'Multi-Main: E2E'
     if: ${{ !github.event.pull_request.head.repo.fork }}
-    uses: ./.github/workflows/playwright-test-reusable.yml
+    uses: ./.github/workflows/test-e2e-reusable.yml
     with:
       branch: ${{ inputs.branch }}
       test-mode: docker-build
@@ -30,7 +30,7 @@ jobs:
   multi-main-isolated:
     name: 'Multi-Main: Isolated'
     if: ${{ !github.event.pull_request.head.repo.fork }}
-    uses: ./.github/workflows/playwright-test-reusable.yml
+    uses: ./.github/workflows/test-e2e-reusable.yml
     with:
       branch: ${{ inputs.branch }}
       test-mode: docker-build
@@ -45,7 +45,7 @@ jobs:
   community-e2e:
     name: 'Community: E2E'
     if: ${{ github.event.pull_request.head.repo.fork }}
-    uses: ./.github/workflows/playwright-test-reusable.yml
+    uses: ./.github/workflows/test-e2e-reusable.yml
     with:
       branch: ${{ inputs.branch }}
       test-mode: local
@@ -58,7 +58,7 @@ jobs:
   community-isolated:
     name: 'Community: Isolated'
     if: ${{ github.event.pull_request.head.repo.fork }}
-    uses: ./.github/workflows/playwright-test-reusable.yml
+    uses: ./.github/workflows/test-e2e-reusable.yml
     with:
       branch: ${{ inputs.branch }}
       test-mode: local

--- a/.github/workflows/test-e2e-coverage-weekly.yml
+++ b/.github/workflows/test-e2e-coverage-weekly.yml
@@ -1,4 +1,4 @@
-name: Weekly Coverage Tests
+name: 'Test: E2E Coverage Weekly'
 
 on:
   schedule:

--- a/.github/workflows/test-e2e-docker-pull-reusable.yml
+++ b/.github/workflows/test-e2e-docker-pull-reusable.yml
@@ -1,4 +1,4 @@
-name: Run Playwright Tests (Docker Pull)
+name: 'Test: E2E Docker Pull'
 # This workflow is used to run Playwright tests in a Docker container pulled from the registry
 
 on:
@@ -7,8 +7,8 @@ on:
       shards:
         description: 'Shards for parallel execution'
         required: false
-        default: '[1]'
-        type: string
+        default: 1
+        type: number
       image:
         description: 'Image to use'
         required: false
@@ -19,8 +19,8 @@ on:
       shards:
         description: 'Shards for parallel execution'
         required: false
-        default: '[1]'
-        type: string
+        default: 1
+        type: number
       image:
         description: 'Image to use'
         required: false
@@ -29,7 +29,7 @@ on:
 
 jobs:
   build-and-test:
-    uses: ./.github/workflows/playwright-test-reusable.yml
+    uses: ./.github/workflows/test-e2e-reusable.yml
     with:
       test-mode: docker-pull
       shards: ${{ inputs.shards }}

--- a/.github/workflows/test-e2e-performance-reusable.yml
+++ b/.github/workflows/test-e2e-performance-reusable.yml
@@ -1,4 +1,4 @@
-name: Run Playwright Performance Tests
+name: 'Test: E2E Performance'
 
 on:
   workflow_call:
@@ -7,13 +7,13 @@ on:
     - cron: '0 0 * * *' # Runs daily at midnight
   pull_request:
     paths:
-      - '.github/workflows/playwright-test-performance.yml'
+      - '.github/workflows/test-e2e-performance-reusable.yml'
 
 jobs:
   build-and-test-performance:
-    uses: ./.github/workflows/playwright-test-reusable.yml
+    uses: ./.github/workflows/test-e2e-reusable.yml
     with:
       test-mode: docker-build
       test-command: pnpm --filter=n8n-playwright test:performance
-      shards: '[1]'
+      shards: 1
     secrets: inherit

--- a/.github/workflows/test-e2e-reusable.yml
+++ b/.github/workflows/test-e2e-reusable.yml
@@ -1,4 +1,4 @@
-name: Playwright Tests - Reusable
+name: 'Test: E2E'
 
 on:
   workflow_call:

--- a/.github/workflows/test-evals-ai.yml
+++ b/.github/workflows/test-evals-ai.yml
@@ -1,4 +1,4 @@
-name: Run Workflow Builder Evals
+name: 'Test: Evals AI'
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - master
     paths:
       - 'packages/@n8n/ai-workflow-builder.ee/**'
-      - '.github/workflows/ci-evals.yml'
+      - '.github/workflows/test-evals-ai.yml'
   schedule:
     - cron: '0 22 * * 6'
   workflow_dispatch:

--- a/.github/workflows/test-evals-python.yml
+++ b/.github/workflows/test-evals-python.yml
@@ -1,10 +1,10 @@
-name: AI Workflow Builder Evals Python CI
+name: 'Test: Evals Python'
 
 on:
   pull_request:
     paths:
       - packages/@n8n/ai-workflow-builder.ee/evaluations/programmatic/python/**
-      - .github/workflows/ci-python-workflow-builder-evals.yml
+      - .github/workflows/test-evals-python.yml
   push:
     paths:
       - packages/@n8n/ai-workflow-builder.ee/evaluations/programmatic/python/**

--- a/.github/workflows/test-linting-reusable.yml
+++ b/.github/workflows/test-linting-reusable.yml
@@ -1,4 +1,4 @@
-name: Reusable linting workflow
+name: 'Test: Linting'
 
 on:
   workflow_call:

--- a/.github/workflows/test-unit-reusable.yml
+++ b/.github/workflows/test-unit-reusable.yml
@@ -1,4 +1,4 @@
-name: Reusable units test workflow
+name: 'Test: Unit'
 
 on:
   workflow_call:

--- a/.github/workflows/test-visual-chromatic.yml
+++ b/.github/workflows/test-visual-chromatic.yml
@@ -1,4 +1,4 @@
-name: Chromatic
+name: 'Test: Visual Chromatic'
 
 on:
   schedule:
@@ -23,7 +23,7 @@ jobs:
           filters: |
             design_system:
               - 'packages/frontend/@n8n/design-system/**'
-              - '.github/workflows/storybook.yml'
+              - '.github/workflows/test-visual-storybook.yml'
     outputs:
       has_changes: ${{ steps.changed.outputs.design_system || 'false' }}
 

--- a/.github/workflows/test-visual-storybook.yml
+++ b/.github/workflows/test-visual-storybook.yml
@@ -1,4 +1,4 @@
-name: Storybook
+name: 'Test: Visual Storybook'
 
 on:
   schedule:
@@ -9,7 +9,7 @@ on:
       - master
     paths:
       - 'packages/frontend/@n8n/design-system/**'
-      - '.github/workflows/storybook.yml'
+      - '.github/workflows/test-visual-storybook.yml'
 concurrency:
   group: storybook-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test-workflows-callable.yml
+++ b/.github/workflows/test-workflows-callable.yml
@@ -1,4 +1,4 @@
-name: Test Workflows - Reusable
+name: 'Test: Workflows'
 
 on:
   workflow_call:

--- a/.github/workflows/test-workflows-nightly.yml
+++ b/.github/workflows/test-workflows-nightly.yml
@@ -1,4 +1,4 @@
-name: Test Workflows Nightly and Manual
+name: 'Test: Workflows Nightly'
 
 on:
   schedule:

--- a/.github/workflows/test-workflows-pr-comment.yml
+++ b/.github/workflows/test-workflows-pr-comment.yml
@@ -1,4 +1,4 @@
-name: Test Workflows on PR Comment
+name: 'Test: Workflows PR Comment'
 
 on:
   issue_comment:

--- a/.github/workflows/util-check-docs-urls.yml
+++ b/.github/workflows/util-check-docs-urls.yml
@@ -1,4 +1,4 @@
-name: Check Documentation URLs
+name: 'Util: Check Docs URLs'
 
 on:
   release:

--- a/.github/workflows/util-claude.yml
+++ b/.github/workflows/util-claude.yml
@@ -1,4 +1,4 @@
-name: Claude PR Assistant
+name: 'Util: Claude'
 
 on:
   issue_comment:

--- a/.github/workflows/util-data-tooling.yml
+++ b/.github/workflows/util-data-tooling.yml
@@ -1,4 +1,4 @@
-name: Data tooling, test exports and imports of data to various db types
+name: 'Util: Data Tooling'
 
 # TODO: Uncomment this after it works on a manual invocation
 # on:

--- a/.github/workflows/util-notify-pr-status.yml
+++ b/.github/workflows/util-notify-pr-status.yml
@@ -1,4 +1,4 @@
-name: Notify PR status changed
+name: 'Util: Notify PR Status'
 
 on:
   pull_request_review:

--- a/.github/workflows/util-sync-api-docs.yml
+++ b/.github/workflows/util-sync-api-docs.yml
@@ -1,4 +1,4 @@
-name: Sync Public API Schema to Docs Repo
+name: 'Util: Sync API Docs'
 
 on:
   # Triggers for the master branch if relevant Public API files have changed

--- a/.github/workflows/util-update-node-popularity.yml
+++ b/.github/workflows/util-update-node-popularity.yml
@@ -1,4 +1,4 @@
-name: Update Node Popularity Data
+name: 'Util: Update Node Popularity'
 
 on:
   schedule:

--- a/.poutine.yml
+++ b/.poutine.yml
@@ -44,10 +44,10 @@ skip:
       - .github/workflows/sbom-generation-callable.yml
       # Uses merge commit SHA from GitHub - the code has already been reviewed
       # and merged, not arbitrary PR code.
-      - .github/workflows/linting-reusable.yml
+      - .github/workflows/test-linting-reusable.yml
       # Uses merge commit SHA from GitHub - the code has already been reviewed
       # and merged, not arbitrary PR code.
-      - .github/workflows/units-tests-reusable.yml
+      - .github/workflows/test-unit-reusable.yml
       # Permission-gated: only maintainers (admin/write/maintain) can trigger
       # via /test-workflows comment. Verified in test-workflows-pr-comment.yml.
       - .github/workflows/test-workflows-callable.yml


### PR DESCRIPTION
## Summary

  Renames 27 GitHub workflow files and updates 8 additional `name:` fields to follow a consistent naming convention, improving discoverability and organization in the Actions UI.

  ### Domains
  | Prefix | Purpose | Files Renamed | Name Fields Updated |
  |--------|---------|---------------|---------------------|
  | `build-` | Builds (Docker images, binaries) | 2 | +2 |
  | `ci-` | Quality gates (build, lint, typecheck) | 3 | +3 |
  | `release-` | Release automation | 0 (preserved for 1.x) | 0 |
  | `sec-` | Security scanning | 2 | 0 |
  | `test-` | All tests (e2e, unit, visual, evals, benchmarks) | 14 | +3 |
  | `util-` | Utilities and triggers | 6 | 0 |

  ### Impact
  - **Files renamed:** 27 → now 39 of 43 (91%) follow filename convention
  - **Name fields standardized:** 35 → now 40 of 43 (93%) follow `'Domain: Description'` format
  - **Untouched for 1.x:** 4 files with non-standard filenames, 3 with non-standard name fields

  ### Key changes
  - **27 workflow files renamed** to follow `[domain]-[function]-[modifier].yml` pattern
  - **8 additional `name:` fields updated** for workflows that already had correct prefixes
  - **All caller references updated** in `ci-master.yml`, `ci-pull-requests.yml`, and dependent workflows
  - **Release workflows preserved**: `docker-build-push.yml`, `sbom-generation-callable.yml`, `security-trivy-scan-callable.yml`, and all `release-*.yml` files are NOT renamed to maintain 1.x branch compatibility

  ### Bug fix (pre-existing)
  Fixed `shards` input type mismatch in `test-e2e-docker-pull-reusable.yml` and `test-e2e-performance-reusable.yml` - was incorrectly typed as `string` with default `'[1]'`, now correctly typed as `number` with default `1` to match the reusable workflow's expected input type.

  ## Review notes
  - 1.x releases will continue working because release-critical workflows are unchanged
  - The `shards` type fix is a pre-existing bug that actionlint caught during the rename

  ## Related Linear tickets, Github issues, and Community forum posts
  - Linear: https://linear.app/n8n/issue/CAT-1938
  - Ghost workflow cleanup: [CAT-1991](https://linear.app/n8n/issue/CAT-1991) (post-merge)
  - Documentation: [CAT-1939](https://linear.app/n8n/issue/CAT-1939)


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
