### PR TITLE
feat(Pipedrive Node): Allow setting custom properties when creating and updating leads

### DIFF
--- a/packages/nodes-base/nodes/Pipedrive/Pipedrive.node.ts
+++ b/packages/nodes-base/nodes/Pipedrive/Pipedrive.node.ts
@@ -11,7 +11,7 @@ export class Pipedrive extends VersionedNodeType {
 			name: 'pipedrive',
 			icon: 'file:pipedrive.svg',
 			group: ['transform'],
-			defaultVersion: 2,
+			defaultVersion: 2.1,
 			subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
 			description: 'Create and edit data in Pipedrive',
 		};
@@ -19,6 +19,7 @@ export class Pipedrive extends VersionedNodeType {
 		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
 			1: new PipedriveV1(baseDescription),
 			2: new PipedriveV2(baseDescription),
+			2.1: new PipedriveV2(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/packages/nodes-base/nodes/Pipedrive/test/v1/node/credentials.ts
+++ b/packages/nodes-base/nodes/Pipedrive/test/v1/node/credentials.ts
@@ -1,0 +1,5 @@
+export const credentials = {
+	pipedriveApi: {
+		apiToken: 'test-api-token',
+	},
+};

--- a/packages/nodes-base/nodes/Pipedrive/test/v1/node/lead/createWithCustomFields.test.ts
+++ b/packages/nodes-base/nodes/Pipedrive/test/v1/node/lead/createWithCustomFields.test.ts
@@ -2,28 +2,30 @@ import { NodeTestHarness } from '@nodes-testing/node-test-harness';
 import nock from 'nock';
 
 import { credentials } from '../credentials';
-import { mockFieldsApi } from '../fieldsApiMock';
 
-describe('Test PipedriveV2, lead => create', () => {
-	mockFieldsApi('lead');
-
+describe('Test PipedriveV1, lead => create with custom fields', () => {
+	// V1 sets custom fields directly on the request body keyed by field key, and
+	// relies on addAdditionalFields to flatten the customProperties collection
+	// while leaving other additional fields (e.g. owner_id) untouched.
 	nock('https://api.pipedrive.com/v1')
 		.post('/leads', {
-			title: 'Promising Lead',
+			title: 'Lead With Custom Fields',
 			organization_id: 7,
-			person_id: 10,
+			owner_id: 25455458,
+			'48f483ac81a7b619c59322931ea839310e987725': 'option_a',
+			'7095cf9bf6bdeb457b12a76fdbb0fe06c0ad5151': 'option_b',
 		})
 		.reply(200, {
 			success: true,
 			data: {
-				id: '9ce77a10-2e16-11f1-91c1-d76c55e1594b',
-				title: 'Promising Lead',
+				id: 'aaa11111-bb22-cc33-dd44-ee5555555555',
+				title: 'Lead With Custom Fields',
 				owner_id: 25455458,
 				creator_id: 25455458,
 				label_ids: [],
 				value: null,
 				expected_close_date: null,
-				person_id: 10,
+				person_id: null,
 				organization_id: 7,
 				is_archived: false,
 				archive_time: null,
@@ -38,12 +40,14 @@ describe('Test PipedriveV2, lead => create', () => {
 				add_time: '2026-04-01T22:03:28.177Z',
 				update_time: '2026-04-01T22:03:28.177Z',
 				visible_to: '3',
-				cc_email: 'added-cauliflower+14712380+lead9aeonoweeh1wbg0z8godmoua3@pipedrivemail.com',
+				cc_email: 'test+lead@pipedrivemail.com',
+				'48f483ac81a7b619c59322931ea839310e987725': 'option_a',
+				'7095cf9bf6bdeb457b12a76fdbb0fe06c0ad5151': 'option_b',
 			},
 		});
 
 	new NodeTestHarness().setupTests({
 		credentials,
-		workflowFiles: ['create.workflow.json'],
+		workflowFiles: ['createWithCustomFields.workflow.json'],
 	});
 });

--- a/packages/nodes-base/nodes/Pipedrive/test/v1/node/lead/createWithCustomFields.workflow.json
+++ b/packages/nodes-base/nodes/Pipedrive/test/v1/node/lead/createWithCustomFields.workflow.json
@@ -1,0 +1,98 @@
+{
+	"name": "Pipedrive v1 lead create with custom fields test",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "d1e2f3a4-b5c6-7890-abcd-ef1234567890",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0]
+		},
+		{
+			"parameters": {
+				"authentication": "apiToken",
+				"resource": "lead",
+				"operation": "create",
+				"title": "Lead With Custom Fields",
+				"associateWith": "organization",
+				"organization_id": 7,
+				"additionalFields": {
+					"owner_id": 25455458,
+					"customProperties": {
+						"property": [
+							{
+								"name": "48f483ac81a7b619c59322931ea839310e987725",
+								"value": "option_a"
+							},
+							{
+								"name": "7095cf9bf6bdeb457b12a76fdbb0fe06c0ad5151",
+								"value": "option_b"
+							}
+						]
+					}
+				}
+			},
+			"id": "e2f3a4b5-c6d7-8901-bcde-f12345678901",
+			"name": "Pipedrive",
+			"type": "n8n-nodes-base.pipedrive",
+			"typeVersion": 1,
+			"position": [200, 0],
+			"credentials": {
+				"pipedriveApi": {
+					"id": "cred-1",
+					"name": "Pipedrive API"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "f3a4b5c6-d7e8-9012-cdef-123456789012",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [400, 0]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"id": "aaa11111-bb22-cc33-dd44-ee5555555555",
+					"title": "Lead With Custom Fields",
+					"owner_id": 25455458,
+					"creator_id": 25455458,
+					"label_ids": [],
+					"value": null,
+					"expected_close_date": null,
+					"person_id": null,
+					"organization_id": 7,
+					"is_archived": false,
+					"archive_time": null,
+					"source_name": "API",
+					"source_deal_id": null,
+					"origin": "API",
+					"origin_id": null,
+					"channel": null,
+					"channel_id": null,
+					"was_seen": false,
+					"next_activity_id": null,
+					"add_time": "2026-04-01T22:03:28.177Z",
+					"update_time": "2026-04-01T22:03:28.177Z",
+					"visible_to": "3",
+					"cc_email": "test+lead@pipedrivemail.com",
+					"48f483ac81a7b619c59322931ea839310e987725": "option_a",
+					"7095cf9bf6bdeb457b12a76fdbb0fe06c0ad5151": "option_b"
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [[{ "node": "Pipedrive", "type": "main", "index": 0 }]]
+		},
+		"Pipedrive": {
+			"main": [[{ "node": "No Operation, do nothing", "type": "main", "index": 0 }]]
+		}
+	}
+}

--- a/packages/nodes-base/nodes/Pipedrive/test/v1/node/lead/updateWithCustomFields.test.ts
+++ b/packages/nodes-base/nodes/Pipedrive/test/v1/node/lead/updateWithCustomFields.test.ts
@@ -2,26 +2,26 @@ import { NodeTestHarness } from '@nodes-testing/node-test-harness';
 import nock from 'nock';
 
 import { credentials } from '../credentials';
-import { mockFieldsApi } from '../fieldsApiMock';
 
-describe('Test PipedriveV2, lead => update', () => {
-	mockFieldsApi('lead');
-
+describe('Test PipedriveV1, lead => update with custom fields', () => {
+	// V1 sends both the custom field (keyed by field key) and the other update
+	// fields (e.g. owner_id) in a single PATCH body via addAdditionalFields.
 	nock('https://api.pipedrive.com/v1')
-		.put('/leads/9ce77a10-2e16-11f1-91c1-d76c55e1594b', {
-			title: 'Updated Lead',
+		.patch('/leads/aaa11111-bb22-cc33-dd44-ee5555555555', {
+			owner_id: 25455458,
+			'48f483ac81a7b619c59322931ea839310e987725': 'option_c',
 		})
 		.reply(200, {
 			success: true,
 			data: {
-				id: '9ce77a10-2e16-11f1-91c1-d76c55e1594b',
-				title: 'Updated Lead',
+				id: 'aaa11111-bb22-cc33-dd44-ee5555555555',
+				title: 'Existing Lead',
 				owner_id: 25455458,
 				creator_id: 25455458,
 				label_ids: [],
 				value: null,
 				expected_close_date: null,
-				person_id: 10,
+				person_id: null,
 				organization_id: 7,
 				is_archived: false,
 				archive_time: null,
@@ -36,12 +36,13 @@ describe('Test PipedriveV2, lead => update', () => {
 				add_time: '2026-04-01T22:03:28.177Z',
 				update_time: '2026-04-01T22:03:32.984Z',
 				visible_to: '3',
-				cc_email: 'added-cauliflower+14712380+lead9aeonoweeh1wbg0z8godmoua3@pipedrivemail.com',
+				cc_email: 'test+lead@pipedrivemail.com',
+				'48f483ac81a7b619c59322931ea839310e987725': 'option_c',
 			},
 		});
 
 	new NodeTestHarness().setupTests({
 		credentials,
-		workflowFiles: ['update.workflow.json'],
+		workflowFiles: ['updateWithCustomFields.workflow.json'],
 	});
 });

--- a/packages/nodes-base/nodes/Pipedrive/test/v1/node/lead/updateWithCustomFields.workflow.json
+++ b/packages/nodes-base/nodes/Pipedrive/test/v1/node/lead/updateWithCustomFields.workflow.json
@@ -1,0 +1,91 @@
+{
+	"name": "Pipedrive v1 lead update with custom fields test",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "d1e2f3a4-b5c6-7890-abcd-ef1234567890",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0]
+		},
+		{
+			"parameters": {
+				"authentication": "apiToken",
+				"resource": "lead",
+				"operation": "update",
+				"leadId": "aaa11111-bb22-cc33-dd44-ee5555555555",
+				"updateFields": {
+					"owner_id": 25455458,
+					"customProperties": {
+						"property": [
+							{
+								"name": "48f483ac81a7b619c59322931ea839310e987725",
+								"value": "option_c"
+							}
+						]
+					}
+				}
+			},
+			"id": "e2f3a4b5-c6d7-8901-bcde-f12345678901",
+			"name": "Pipedrive",
+			"type": "n8n-nodes-base.pipedrive",
+			"typeVersion": 1,
+			"position": [200, 0],
+			"credentials": {
+				"pipedriveApi": {
+					"id": "cred-1",
+					"name": "Pipedrive API"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "f3a4b5c6-d7e8-9012-cdef-123456789012",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [400, 0]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"id": "aaa11111-bb22-cc33-dd44-ee5555555555",
+					"title": "Existing Lead",
+					"owner_id": 25455458,
+					"creator_id": 25455458,
+					"label_ids": [],
+					"value": null,
+					"expected_close_date": null,
+					"person_id": null,
+					"organization_id": 7,
+					"is_archived": false,
+					"archive_time": null,
+					"source_name": "API",
+					"source_deal_id": null,
+					"origin": "API",
+					"origin_id": null,
+					"channel": null,
+					"channel_id": null,
+					"was_seen": false,
+					"next_activity_id": null,
+					"add_time": "2026-04-01T22:03:28.177Z",
+					"update_time": "2026-04-01T22:03:32.984Z",
+					"visible_to": "3",
+					"cc_email": "test+lead@pipedrivemail.com",
+					"48f483ac81a7b619c59322931ea839310e987725": "option_c"
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [[{ "node": "Pipedrive", "type": "main", "index": 0 }]]
+		},
+		"Pipedrive": {
+			"main": [[{ "node": "No Operation, do nothing", "type": "main", "index": 0 }]]
+		}
+	}
+}

--- a/packages/nodes-base/nodes/Pipedrive/test/v2/node/fieldsApiMock.ts
+++ b/packages/nodes-base/nodes/Pipedrive/test/v2/node/fieldsApiMock.ts
@@ -2,9 +2,11 @@ import nock from 'nock';
 
 import mockData from '../mock-data.json';
 
-type ResourceType = 'activity' | 'deal' | 'organization' | 'person' | 'product';
+type V2ResourceType = 'activity' | 'deal' | 'organization' | 'person' | 'product';
+type V1ResourceType = 'lead';
+type ResourceType = V2ResourceType | V1ResourceType;
 
-const fieldEndpoints: Record<ResourceType, string> = {
+const v2FieldEndpoints: Record<V2ResourceType, string> = {
 	activity: '/activityFields',
 	deal: '/dealFields',
 	organization: '/organizationFields',
@@ -12,8 +14,12 @@ const fieldEndpoints: Record<ResourceType, string> = {
 	product: '/productFields',
 };
 
+const v1FieldEndpoints: Record<V1ResourceType, string> = {
+	lead: '/leadFields',
+};
+
 /**
- * Registers a nock mock for the v2 Fields API endpoint so that
+ * Registers a nock mock for the Fields API endpoint so that
  * custom field resolution/encoding works in workflow tests.
  */
 export function mockFieldsApi(resource: ResourceType): void {
@@ -21,21 +27,43 @@ export function mockFieldsApi(resource: ResourceType): void {
 		resource
 	];
 
-	const fields = Object.entries(customFieldKeys ?? {}).map(([name, code]) => ({
-		field_name: name,
-		field_code: code,
-		field_type: 'text',
-		options: null,
-		is_custom_field: true,
-	}));
+	if (resource in v2FieldEndpoints) {
+		const fields = Object.entries(customFieldKeys ?? {}).map(([name, code]) => ({
+			field_name: name,
+			field_code: code,
+			field_type: 'text',
+			options: null,
+			is_custom_field: true,
+		}));
 
-	nock('https://api.pipedrive.com/api/v2')
-		.get(fieldEndpoints[resource])
-		.query(true)
-		.reply(200, {
-			success: true,
-			data: fields,
-			additional_data: {},
-		})
-		.persist();
+		nock('https://api.pipedrive.com/api/v2')
+			.get(v2FieldEndpoints[resource as V2ResourceType])
+			.query(true)
+			.reply(200, {
+				success: true,
+				data: fields,
+				additional_data: {},
+			})
+			.persist();
+	} else {
+		// v1 Fields API uses key/name instead of field_code/field_name
+		const fields = Object.entries(customFieldKeys ?? {}).map(([name, key]) => ({
+			name,
+			key,
+			field_type: 'text',
+			options: null,
+		}));
+
+		nock('https://api.pipedrive.com/v1')
+			.get(v1FieldEndpoints[resource as V1ResourceType])
+			.query(true)
+			.reply(200, {
+				success: true,
+				data: fields,
+				additional_data: {
+					pagination: { more_items_in_collection: false },
+				},
+			})
+			.persist();
+	}
 }

--- a/packages/nodes-base/nodes/Pipedrive/test/v2/node/lead/create.test.ts
+++ b/packages/nodes-base/nodes/Pipedrive/test/v2/node/lead/create.test.ts
@@ -2,8 +2,11 @@ import { NodeTestHarness } from '@nodes-testing/node-test-harness';
 import nock from 'nock';
 
 import { credentials } from '../credentials';
+import { mockFieldsApi } from '../fieldsApiMock';
 
 describe('Test PipedriveV2, lead => create', () => {
+	mockFieldsApi('lead');
+
 	nock('https://api.pipedrive.com/v1')
 		.post('/leads', {
 			title: 'Promising Lead',

--- a/packages/nodes-base/nodes/Pipedrive/test/v2/node/lead/createWithCustomFields.test.ts
+++ b/packages/nodes-base/nodes/Pipedrive/test/v2/node/lead/createWithCustomFields.test.ts
@@ -4,24 +4,29 @@ import nock from 'nock';
 import { credentials } from '../credentials';
 import { mockFieldsApi } from '../fieldsApiMock';
 
-describe('Test PipedriveV2, lead => update', () => {
+describe('Test PipedriveV2, lead => create with custom fields', () => {
 	mockFieldsApi('lead');
 
 	nock('https://api.pipedrive.com/v1')
-		.put('/leads/9ce77a10-2e16-11f1-91c1-d76c55e1594b', {
-			title: 'Updated Lead',
+		.post('/leads', {
+			title: 'Lead With Custom Fields',
+			organization_id: 7,
+			custom_fields: {
+				'48f483ac81a7b619c59322931ea839310e987725': 'option_a',
+				'7095cf9bf6bdeb457b12a76fdbb0fe06c0ad5151': 'option_b',
+			},
 		})
 		.reply(200, {
 			success: true,
 			data: {
-				id: '9ce77a10-2e16-11f1-91c1-d76c55e1594b',
-				title: 'Updated Lead',
+				id: 'aaa11111-bb22-cc33-dd44-ee5555555555',
+				title: 'Lead With Custom Fields',
 				owner_id: 25455458,
 				creator_id: 25455458,
 				label_ids: [],
 				value: null,
 				expected_close_date: null,
-				person_id: 10,
+				person_id: null,
 				organization_id: 7,
 				is_archived: false,
 				archive_time: null,
@@ -34,14 +39,18 @@ describe('Test PipedriveV2, lead => update', () => {
 				was_seen: false,
 				next_activity_id: null,
 				add_time: '2026-04-01T22:03:28.177Z',
-				update_time: '2026-04-01T22:03:32.984Z',
+				update_time: '2026-04-01T22:03:28.177Z',
 				visible_to: '3',
-				cc_email: 'added-cauliflower+14712380+lead9aeonoweeh1wbg0z8godmoua3@pipedrivemail.com',
+				cc_email: 'test+lead@pipedrivemail.com',
+				custom_fields: {
+					'48f483ac81a7b619c59322931ea839310e987725': 'option_a',
+					'7095cf9bf6bdeb457b12a76fdbb0fe06c0ad5151': 'option_b',
+				},
 			},
 		});
 
 	new NodeTestHarness().setupTests({
 		credentials,
-		workflowFiles: ['update.workflow.json'],
+		workflowFiles: ['createWithCustomFields.workflow.json'],
 	});
 });

--- a/packages/nodes-base/nodes/Pipedrive/test/v2/node/lead/createWithCustomFields.test.ts
+++ b/packages/nodes-base/nodes/Pipedrive/test/v2/node/lead/createWithCustomFields.test.ts
@@ -4,24 +4,29 @@ import nock from 'nock';
 import { credentials } from '../credentials';
 import { mockFieldsApi } from '../fieldsApiMock';
 
-describe('Test PipedriveV2, lead => update', () => {
+describe('Test PipedriveV2, lead => create with custom fields', () => {
 	mockFieldsApi('lead');
 
+	// The v1 Leads endpoint takes and returns custom fields as top-level 40-char
+	// keys, not nested under `custom_fields`.
 	nock('https://api.pipedrive.com/v1')
-		.put('/leads/9ce77a10-2e16-11f1-91c1-d76c55e1594b', {
-			title: 'Updated Lead',
+		.post('/leads', {
+			title: 'Lead With Custom Fields',
+			organization_id: 7,
+			'48f483ac81a7b619c59322931ea839310e987725': 'option_a',
+			'7095cf9bf6bdeb457b12a76fdbb0fe06c0ad5151': 'option_b',
 		})
 		.reply(200, {
 			success: true,
 			data: {
-				id: '9ce77a10-2e16-11f1-91c1-d76c55e1594b',
-				title: 'Updated Lead',
+				id: 'aaa11111-bb22-cc33-dd44-ee5555555555',
+				title: 'Lead With Custom Fields',
 				owner_id: 25455458,
 				creator_id: 25455458,
 				label_ids: [],
 				value: null,
 				expected_close_date: null,
-				person_id: 10,
+				person_id: null,
 				organization_id: 7,
 				is_archived: false,
 				archive_time: null,
@@ -34,14 +39,16 @@ describe('Test PipedriveV2, lead => update', () => {
 				was_seen: false,
 				next_activity_id: null,
 				add_time: '2026-04-01T22:03:28.177Z',
-				update_time: '2026-04-01T22:03:32.984Z',
+				update_time: '2026-04-01T22:03:28.177Z',
 				visible_to: '3',
-				cc_email: 'added-cauliflower+14712380+lead9aeonoweeh1wbg0z8godmoua3@pipedrivemail.com',
+				cc_email: 'test+lead@pipedrivemail.com',
+				'48f483ac81a7b619c59322931ea839310e987725': 'option_a',
+				'7095cf9bf6bdeb457b12a76fdbb0fe06c0ad5151': 'option_b',
 			},
 		});
 
 	new NodeTestHarness().setupTests({
 		credentials,
-		workflowFiles: ['update.workflow.json'],
+		workflowFiles: ['createWithCustomFields.workflow.json'],
 	});
 });

--- a/packages/nodes-base/nodes/Pipedrive/test/v2/node/lead/createWithCustomFields.workflow.json
+++ b/packages/nodes-base/nodes/Pipedrive/test/v2/node/lead/createWithCustomFields.workflow.json
@@ -1,0 +1,99 @@
+{
+	"name": "Pipedrive v2 lead create with custom fields test",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "d1e2f3a4-b5c6-7890-abcd-ef1234567890",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0]
+		},
+		{
+			"parameters": {
+				"authentication": "apiToken",
+				"resource": "lead",
+				"operation": "create",
+				"title": "Lead With Custom Fields",
+				"associateWith": "organization",
+				"organization_id": 7,
+				"additionalFields": {
+					"customFields": {
+						"property": [
+							{
+								"name": "test_enum",
+								"value": "option_a"
+							},
+							{
+								"name": "test_multi",
+								"value": "option_b"
+							}
+						]
+					}
+				}
+			},
+			"id": "e2f3a4b5-c6d7-8901-bcde-f12345678901",
+			"name": "Pipedrive",
+			"type": "n8n-nodes-base.pipedrive",
+			"typeVersion": 2,
+			"position": [200, 0],
+			"credentials": {
+				"pipedriveApi": {
+					"id": "cred-1",
+					"name": "Pipedrive API"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "f3a4b5c6-d7e8-9012-cdef-123456789012",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [400, 0]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"id": "aaa11111-bb22-cc33-dd44-ee5555555555",
+					"title": "Lead With Custom Fields",
+					"owner_id": 25455458,
+					"creator_id": 25455458,
+					"label_ids": [],
+					"value": null,
+					"expected_close_date": null,
+					"person_id": null,
+					"organization_id": 7,
+					"is_archived": false,
+					"archive_time": null,
+					"source_name": "API",
+					"source_deal_id": null,
+					"origin": "API",
+					"origin_id": null,
+					"channel": null,
+					"channel_id": null,
+					"was_seen": false,
+					"next_activity_id": null,
+					"add_time": "2026-04-01T22:03:28.177Z",
+					"update_time": "2026-04-01T22:03:28.177Z",
+					"visible_to": "3",
+					"cc_email": "test+lead@pipedrivemail.com",
+					"custom_fields": {
+						"test_enum": "option_a",
+						"test_multi": "option_b"
+					}
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [[{ "node": "Pipedrive", "type": "main", "index": 0 }]]
+		},
+		"Pipedrive": {
+			"main": [[{ "node": "No Operation, do nothing", "type": "main", "index": 0 }]]
+		}
+	}
+}

--- a/packages/nodes-base/nodes/Pipedrive/test/v2/node/lead/createWithCustomFields.workflow.json
+++ b/packages/nodes-base/nodes/Pipedrive/test/v2/node/lead/createWithCustomFields.workflow.json
@@ -1,0 +1,99 @@
+{
+	"name": "Pipedrive v2 lead create with custom fields test",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "d1e2f3a4-b5c6-7890-abcd-ef1234567890",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0]
+		},
+		{
+			"parameters": {
+				"authentication": "apiToken",
+				"resource": "lead",
+				"operation": "create",
+				"title": "Lead With Custom Fields",
+				"associateWith": "organization",
+				"organization_id": 7,
+				"additionalFields": {
+					"customFields": {
+						"property": [
+							{
+								"name": "test_enum",
+								"value": "option_a"
+							},
+							{
+								"name": "test_multi",
+								"value": "option_b"
+							}
+						]
+					}
+				}
+			},
+			"id": "e2f3a4b5-c6d7-8901-bcde-f12345678901",
+			"name": "Pipedrive",
+			"type": "n8n-nodes-base.pipedrive",
+			"typeVersion": 2.1,
+			"position": [200, 0],
+			"credentials": {
+				"pipedriveApi": {
+					"id": "cred-1",
+					"name": "Pipedrive API"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "f3a4b5c6-d7e8-9012-cdef-123456789012",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [400, 0]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"id": "aaa11111-bb22-cc33-dd44-ee5555555555",
+					"title": "Lead With Custom Fields",
+					"owner_id": 25455458,
+					"creator_id": 25455458,
+					"label_ids": [],
+					"value": null,
+					"expected_close_date": null,
+					"person_id": null,
+					"organization_id": 7,
+					"is_archived": false,
+					"archive_time": null,
+					"source_name": "API",
+					"source_deal_id": null,
+					"origin": "API",
+					"origin_id": null,
+					"channel": null,
+					"channel_id": null,
+					"was_seen": false,
+					"next_activity_id": null,
+					"add_time": "2026-04-01T22:03:28.177Z",
+					"update_time": "2026-04-01T22:03:28.177Z",
+					"visible_to": "3",
+					"cc_email": "test+lead@pipedrivemail.com",
+					"custom_fields": {
+						"test_enum": "option_a",
+						"test_multi": "option_b"
+					}
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [[{ "node": "Pipedrive", "type": "main", "index": 0 }]]
+		},
+		"Pipedrive": {
+			"main": [[{ "node": "No Operation, do nothing", "type": "main", "index": 0 }]]
+		}
+	}
+}

--- a/packages/nodes-base/nodes/Pipedrive/test/v2/node/lead/updateWithCustomFields.test.ts
+++ b/packages/nodes-base/nodes/Pipedrive/test/v2/node/lead/updateWithCustomFields.test.ts
@@ -4,24 +4,27 @@ import nock from 'nock';
 import { credentials } from '../credentials';
 import { mockFieldsApi } from '../fieldsApiMock';
 
-describe('Test PipedriveV2, lead => update', () => {
+describe('Test PipedriveV2, lead => update with custom fields', () => {
 	mockFieldsApi('lead');
 
 	nock('https://api.pipedrive.com/v1')
-		.put('/leads/9ce77a10-2e16-11f1-91c1-d76c55e1594b', {
-			title: 'Updated Lead',
+		.put('/leads/aaa11111-bb22-cc33-dd44-ee5555555555', {
+			title: 'Updated Lead With Custom Fields',
+			custom_fields: {
+				'48f483ac81a7b619c59322931ea839310e987725': 'option_c',
+			},
 		})
 		.reply(200, {
 			success: true,
 			data: {
-				id: '9ce77a10-2e16-11f1-91c1-d76c55e1594b',
-				title: 'Updated Lead',
+				id: 'aaa11111-bb22-cc33-dd44-ee5555555555',
+				title: 'Updated Lead With Custom Fields',
 				owner_id: 25455458,
 				creator_id: 25455458,
 				label_ids: [],
 				value: null,
 				expected_close_date: null,
-				person_id: 10,
+				person_id: null,
 				organization_id: 7,
 				is_archived: false,
 				archive_time: null,
@@ -36,12 +39,15 @@ describe('Test PipedriveV2, lead => update', () => {
 				add_time: '2026-04-01T22:03:28.177Z',
 				update_time: '2026-04-01T22:03:32.984Z',
 				visible_to: '3',
-				cc_email: 'added-cauliflower+14712380+lead9aeonoweeh1wbg0z8godmoua3@pipedrivemail.com',
+				cc_email: 'test+lead@pipedrivemail.com',
+				custom_fields: {
+					'48f483ac81a7b619c59322931ea839310e987725': 'option_c',
+				},
 			},
 		});
 
 	new NodeTestHarness().setupTests({
 		credentials,
-		workflowFiles: ['update.workflow.json'],
+		workflowFiles: ['updateWithCustomFields.workflow.json'],
 	});
 });

--- a/packages/nodes-base/nodes/Pipedrive/test/v2/node/lead/updateWithCustomFields.test.ts
+++ b/packages/nodes-base/nodes/Pipedrive/test/v2/node/lead/updateWithCustomFields.test.ts
@@ -4,24 +4,27 @@ import nock from 'nock';
 import { credentials } from '../credentials';
 import { mockFieldsApi } from '../fieldsApiMock';
 
-describe('Test PipedriveV2, lead => update', () => {
+describe('Test PipedriveV2, lead => update with custom fields', () => {
 	mockFieldsApi('lead');
 
+	// The v1 Leads endpoint takes and returns custom fields as top-level 40-char
+	// keys, not nested under `custom_fields`.
 	nock('https://api.pipedrive.com/v1')
-		.put('/leads/9ce77a10-2e16-11f1-91c1-d76c55e1594b', {
-			title: 'Updated Lead',
+		.put('/leads/aaa11111-bb22-cc33-dd44-ee5555555555', {
+			title: 'Updated Lead With Custom Fields',
+			'48f483ac81a7b619c59322931ea839310e987725': 'option_c',
 		})
 		.reply(200, {
 			success: true,
 			data: {
-				id: '9ce77a10-2e16-11f1-91c1-d76c55e1594b',
-				title: 'Updated Lead',
+				id: 'aaa11111-bb22-cc33-dd44-ee5555555555',
+				title: 'Updated Lead With Custom Fields',
 				owner_id: 25455458,
 				creator_id: 25455458,
 				label_ids: [],
 				value: null,
 				expected_close_date: null,
-				person_id: 10,
+				person_id: null,
 				organization_id: 7,
 				is_archived: false,
 				archive_time: null,
@@ -36,12 +39,13 @@ describe('Test PipedriveV2, lead => update', () => {
 				add_time: '2026-04-01T22:03:28.177Z',
 				update_time: '2026-04-01T22:03:32.984Z',
 				visible_to: '3',
-				cc_email: 'added-cauliflower+14712380+lead9aeonoweeh1wbg0z8godmoua3@pipedrivemail.com',
+				cc_email: 'test+lead@pipedrivemail.com',
+				'48f483ac81a7b619c59322931ea839310e987725': 'option_c',
 			},
 		});
 
 	new NodeTestHarness().setupTests({
 		credentials,
-		workflowFiles: ['update.workflow.json'],
+		workflowFiles: ['updateWithCustomFields.workflow.json'],
 	});
 });

--- a/packages/nodes-base/nodes/Pipedrive/test/v2/node/lead/updateWithCustomFields.workflow.json
+++ b/packages/nodes-base/nodes/Pipedrive/test/v2/node/lead/updateWithCustomFields.workflow.json
@@ -1,0 +1,93 @@
+{
+	"name": "Pipedrive v2 lead update with custom fields test",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "d1e2f3a4-b5c6-7890-abcd-ef1234567890",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0]
+		},
+		{
+			"parameters": {
+				"authentication": "apiToken",
+				"resource": "lead",
+				"operation": "update",
+				"leadId": "aaa11111-bb22-cc33-dd44-ee5555555555",
+				"updateFields": {
+					"title": "Updated Lead With Custom Fields",
+					"customFields": {
+						"property": [
+							{
+								"name": "test_enum",
+								"value": "option_c"
+							}
+						]
+					}
+				}
+			},
+			"id": "e2f3a4b5-c6d7-8901-bcde-f12345678901",
+			"name": "Pipedrive",
+			"type": "n8n-nodes-base.pipedrive",
+			"typeVersion": 2,
+			"position": [200, 0],
+			"credentials": {
+				"pipedriveApi": {
+					"id": "cred-1",
+					"name": "Pipedrive API"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "f3a4b5c6-d7e8-9012-cdef-123456789012",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [400, 0]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"id": "aaa11111-bb22-cc33-dd44-ee5555555555",
+					"title": "Updated Lead With Custom Fields",
+					"owner_id": 25455458,
+					"creator_id": 25455458,
+					"label_ids": [],
+					"value": null,
+					"expected_close_date": null,
+					"person_id": null,
+					"organization_id": 7,
+					"is_archived": false,
+					"archive_time": null,
+					"source_name": "API",
+					"source_deal_id": null,
+					"origin": "API",
+					"origin_id": null,
+					"channel": null,
+					"channel_id": null,
+					"was_seen": false,
+					"next_activity_id": null,
+					"add_time": "2026-04-01T22:03:28.177Z",
+					"update_time": "2026-04-01T22:03:32.984Z",
+					"visible_to": "3",
+					"cc_email": "test+lead@pipedrivemail.com",
+					"custom_fields": {
+						"test_enum": "option_c"
+					}
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [[{ "node": "Pipedrive", "type": "main", "index": 0 }]]
+		},
+		"Pipedrive": {
+			"main": [[{ "node": "No Operation, do nothing", "type": "main", "index": 0 }]]
+		}
+	}
+}

--- a/packages/nodes-base/nodes/Pipedrive/test/v2/node/lead/updateWithCustomFields.workflow.json
+++ b/packages/nodes-base/nodes/Pipedrive/test/v2/node/lead/updateWithCustomFields.workflow.json
@@ -1,0 +1,93 @@
+{
+	"name": "Pipedrive v2 lead update with custom fields test",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "d1e2f3a4-b5c6-7890-abcd-ef1234567890",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0]
+		},
+		{
+			"parameters": {
+				"authentication": "apiToken",
+				"resource": "lead",
+				"operation": "update",
+				"leadId": "aaa11111-bb22-cc33-dd44-ee5555555555",
+				"updateFields": {
+					"title": "Updated Lead With Custom Fields",
+					"customFields": {
+						"property": [
+							{
+								"name": "test_enum",
+								"value": "option_c"
+							}
+						]
+					}
+				}
+			},
+			"id": "e2f3a4b5-c6d7-8901-bcde-f12345678901",
+			"name": "Pipedrive",
+			"type": "n8n-nodes-base.pipedrive",
+			"typeVersion": 2.1,
+			"position": [200, 0],
+			"credentials": {
+				"pipedriveApi": {
+					"id": "cred-1",
+					"name": "Pipedrive API"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "f3a4b5c6-d7e8-9012-cdef-123456789012",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [400, 0]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"id": "aaa11111-bb22-cc33-dd44-ee5555555555",
+					"title": "Updated Lead With Custom Fields",
+					"owner_id": 25455458,
+					"creator_id": 25455458,
+					"label_ids": [],
+					"value": null,
+					"expected_close_date": null,
+					"person_id": null,
+					"organization_id": 7,
+					"is_archived": false,
+					"archive_time": null,
+					"source_name": "API",
+					"source_deal_id": null,
+					"origin": "API",
+					"origin_id": null,
+					"channel": null,
+					"channel_id": null,
+					"was_seen": false,
+					"next_activity_id": null,
+					"add_time": "2026-04-01T22:03:28.177Z",
+					"update_time": "2026-04-01T22:03:32.984Z",
+					"visible_to": "3",
+					"cc_email": "test+lead@pipedrivemail.com",
+					"custom_fields": {
+						"test_enum": "option_c"
+					}
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [[{ "node": "Pipedrive", "type": "main", "index": 0 }]]
+		},
+		"Pipedrive": {
+			"main": [[{ "node": "No Operation, do nothing", "type": "main", "index": 0 }]]
+		}
+	}
+}

--- a/packages/nodes-base/nodes/Pipedrive/v1/PipedriveV1.node.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v1/PipedriveV1.node.ts
@@ -2179,11 +2179,48 @@ const versionDescription: INodeTypeDescription = {
 			},
 			options: [
 				{
+					displayName: 'Custom Properties',
+					name: 'customProperties',
+					placeholder: 'Add Custom Property',
+					description: 'Adds a custom property to set also values which have not been predefined',
+					type: 'fixedCollection',
+					typeOptions: {
+						multipleValues: true,
+					},
+					default: {},
+					options: [
+						{
+							name: 'property',
+							displayName: 'Property',
+							values: [
+								{
+									displayName: 'Property Name or ID',
+									name: 'name',
+									type: 'options',
+									typeOptions: {
+										loadOptionsMethod: 'getLeadCustomFields',
+									},
+									default: '',
+									description:
+										'Name of the property to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+								},
+								{
+									displayName: 'Property Value',
+									name: 'value',
+									type: 'string',
+									default: '',
+									description: 'Value of the property to set',
+								},
+							],
+						},
+					],
+				},
+				{
 					displayName: 'Expected Close Date',
 					name: 'expected_close_date',
 					type: 'dateTime',
 					default: '',
-					description: 'Date when the lead’s deal is expected to be closed, in ISO-8601 format',
+					description: "Date when the lead's deal is expected to be closed, in ISO-8601 format",
 				},
 				{
 					displayName: 'Label Names or IDs',
@@ -2397,11 +2434,48 @@ const versionDescription: INodeTypeDescription = {
 					],
 				},
 				{
+					displayName: 'Custom Properties',
+					name: 'customProperties',
+					placeholder: 'Add Custom Property',
+					description: 'Adds a custom property to set also values which have not been predefined',
+					type: 'fixedCollection',
+					typeOptions: {
+						multipleValues: true,
+					},
+					default: {},
+					options: [
+						{
+							name: 'property',
+							displayName: 'Property',
+							values: [
+								{
+									displayName: 'Property Name or ID',
+									name: 'name',
+									type: 'options',
+									typeOptions: {
+										loadOptionsMethod: 'getLeadCustomFields',
+									},
+									default: '',
+									description:
+										'Name of the property to set. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+								},
+								{
+									displayName: 'Property Value',
+									name: 'value',
+									type: 'string',
+									default: '',
+									description: 'Value of the property to set',
+								},
+							],
+						},
+					],
+				},
+				{
 					displayName: 'Expected Close Date',
 					name: 'expected_close_date',
 					type: 'dateTime',
 					default: '',
-					description: 'Date when the lead’s deal is expected to be closed, in ISO-8601 format',
+					description: "Date when the lead's deal is expected to be closed, in ISO-8601 format",
 				},
 			],
 		},
@@ -3973,6 +4047,22 @@ export class PipedriveV1 implements INodeType {
 
 				return sortOptionParameters(returnData);
 			},
+			// Get all the Lead Custom Fields to display them to user so that they can
+			// select them easily
+			async getLeadCustomFields(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+				const returnData: INodePropertyOptions[] = [];
+				const { data } = await pipedriveApiRequest.call(this, 'GET', '/leadFields', {});
+				for (const field of data) {
+					if (field.key.length === 40) {
+						returnData.push({
+							name: field.name,
+							value: field.key,
+						});
+					}
+				}
+
+				return sortOptionParameters(returnData);
+			},
 			// Get all the Person Custom Fields to display them to user so that they can
 			// select them easily
 			async getPersonCustomFields(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
@@ -4570,7 +4660,7 @@ export class PipedriveV1 implements INodeType {
 						};
 
 						if (Object.keys(rest).length) {
-							Object.assign(body, rest);
+							addAdditionalFields(body, rest);
 						}
 
 						if (value) {
@@ -4646,7 +4736,7 @@ export class PipedriveV1 implements INodeType {
 						};
 
 						if (Object.keys(rest).length) {
-							Object.assign(body, rest);
+							addAdditionalFields(body, rest);
 						}
 
 						if (value) {
@@ -4655,10 +4745,6 @@ export class PipedriveV1 implements INodeType {
 
 						if (expected_close_date) {
 							body.expected_close_date = expected_close_date.split('T')[0];
-						}
-
-						if (Object.keys(rest).length) {
-							Object.assign(body, rest);
 						}
 
 						const leadId = this.getNodeParameter('leadId', i);

--- a/packages/nodes-base/nodes/Pipedrive/v2/actions/lead/create.operation.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/actions/lead/create.operation.ts
@@ -6,8 +6,13 @@ import type {
 } from 'n8n-workflow';
 
 import { updateDisplayOptions } from '../../../../../utils/utilities';
-import { pipedriveApiRequest } from '../../transport';
-import { visibleToOption } from '../common.description';
+import { pipedriveApiRequest, pipedriveGetCustomProperties } from '../../transport';
+import { encodeCustomFieldsV2, resolveCustomFieldsV2, addFieldsToBody } from '../../helpers';
+import {
+	customFieldsCollection,
+	rawCustomFieldKeysOption,
+	visibleToOption,
+} from '../common.description';
 import { currencies } from '../../../utils';
 
 const properties: INodeProperties[] = [
@@ -159,8 +164,10 @@ const properties: INodeProperties[] = [
 				default: false,
 				description: 'Whether the lead was seen by someone in the Pipedrive UI',
 			},
+			customFieldsCollection,
 		],
 	},
+	rawCustomFieldKeysOption,
 ];
 
 const displayOptions = {
@@ -176,6 +183,12 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 	const items = this.getInputData();
 	const returnData: INodeExecutionData[] = [];
 
+	const rawKeys = this.getNodeParameter('rawCustomFieldKeys', 0, false) as boolean;
+	let customProperties;
+	if (!rawKeys) {
+		customProperties = await pipedriveGetCustomProperties.call(this, 'lead');
+	}
+
 	for (let i = 0; i < items.length; i++) {
 		try {
 			const body: IDataObject = {
@@ -190,10 +203,8 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 				body.person_id = this.getNodeParameter('person_id', i) as number;
 			}
 
-			const { value, expected_close_date, ...rest } = this.getNodeParameter(
-				'additionalFields',
-				i,
-			) as {
+			const additionalFields = this.getNodeParameter('additionalFields', i);
+			const { value, expected_close_date, ...rest } = additionalFields as {
 				value?: {
 					valueProperties: {
 						amount: number;
@@ -205,7 +216,7 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 			};
 
 			if (Object.keys(rest).length) {
-				Object.assign(body, rest);
+				addFieldsToBody(body, rest as IDataObject);
 			}
 
 			if (value) {
@@ -214,6 +225,10 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 
 			if (expected_close_date) {
 				body.expected_close_date = expected_close_date.split('T')[0];
+			}
+
+			if (customProperties) {
+				encodeCustomFieldsV2(customProperties, body);
 			}
 
 			const responseData = await pipedriveApiRequest.call(
@@ -229,6 +244,13 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 				this.helpers.returnJsonArray(responseData.data as IDataObject),
 				{ itemData: { item: i } },
 			);
+
+			if (customProperties) {
+				for (const item of executionData) {
+					resolveCustomFieldsV2(customProperties, item);
+				}
+			}
+
 			returnData.push(...executionData);
 		} catch (error) {
 			if (this.continueOnFail()) {

--- a/packages/nodes-base/nodes/Pipedrive/v2/actions/lead/create.operation.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/actions/lead/create.operation.ts
@@ -6,8 +6,20 @@ import type {
 } from 'n8n-workflow';
 
 import { updateDisplayOptions } from '../../../../../utils/utilities';
-import { pipedriveApiRequest } from '../../transport';
-import { visibleToOption } from '../common.description';
+import type { ICustomProperties } from '../../transport';
+import { pipedriveApiRequest, pipedriveGetCustomProperties } from '../../transport';
+import {
+	encodeCustomFieldsV2,
+	resolveCustomFieldsV2,
+	addFieldsToBody,
+	flattenCustomFieldsToRoot,
+	nestRootCustomFields,
+} from '../../helpers';
+import {
+	customFieldsCollection,
+	rawCustomFieldKeysOption,
+	visibleToOption,
+} from '../common.description';
 import { currencies } from '../../../utils';
 
 const properties: INodeProperties[] = [
@@ -159,8 +171,10 @@ const properties: INodeProperties[] = [
 				default: false,
 				description: 'Whether the lead was seen by someone in the Pipedrive UI',
 			},
+			customFieldsCollection,
 		],
 	},
+	rawCustomFieldKeysOption,
 ];
 
 const displayOptions = {
@@ -176,8 +190,29 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 	const items = this.getInputData();
 	const returnData: INodeExecutionData[] = [];
 
+	// Resolving custom field keys/IDs to human-readable names on output was added
+	// after v2 shipped without lead custom field support. Gate it to v2.1+ so leads
+	// created on v2 keep the raw Pipedrive keys they returned before.
+	const resolveOutput = this.getNode().typeVersion >= 2.1;
+
+	const rawKeys = this.getNodeParameter('rawCustomFieldKeys', 0, false) as boolean;
+	// Fetch the lead field metadata once, but surface a failure through the
+	// per-item error path below so `continueOnFail` keeps working.
+	let customProperties: ICustomProperties | undefined;
+	let customPropertiesError: Error | undefined;
+	if (!rawKeys) {
+		try {
+			customProperties = await pipedriveGetCustomProperties.call(this, 'lead');
+		} catch (error) {
+			if (!this.continueOnFail()) throw error;
+			customPropertiesError = error as Error;
+		}
+	}
+
 	for (let i = 0; i < items.length; i++) {
 		try {
+			if (customPropertiesError) throw customPropertiesError;
+
 			const body: IDataObject = {
 				title: this.getNodeParameter('title', i) as string,
 			};
@@ -190,10 +225,8 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 				body.person_id = this.getNodeParameter('person_id', i) as number;
 			}
 
-			const { value, expected_close_date, ...rest } = this.getNodeParameter(
-				'additionalFields',
-				i,
-			) as {
+			const additionalFields = this.getNodeParameter('additionalFields', i);
+			const { value, expected_close_date, ...rest } = additionalFields as {
 				value?: {
 					valueProperties: {
 						amount: number;
@@ -205,7 +238,7 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 			};
 
 			if (Object.keys(rest).length) {
-				Object.assign(body, rest);
+				addFieldsToBody(body, rest as IDataObject);
 			}
 
 			if (value) {
@@ -215,6 +248,12 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 			if (expected_close_date) {
 				body.expected_close_date = expected_close_date.split('T')[0];
 			}
+
+			if (customProperties) {
+				encodeCustomFieldsV2(customProperties, body);
+			}
+			// The v1 Leads endpoint takes custom fields as top-level keys, not nested.
+			flattenCustomFieldsToRoot(body);
 
 			const responseData = await pipedriveApiRequest.call(
 				this,
@@ -229,6 +268,16 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 				this.helpers.returnJsonArray(responseData.data as IDataObject),
 				{ itemData: { item: i } },
 			);
+
+			if (customProperties && resolveOutput) {
+				for (const item of executionData) {
+					// v1 returns custom fields at the root; nest them so the shared
+					// resolver can map keys/IDs to human-readable names.
+					nestRootCustomFields(customProperties, item);
+					resolveCustomFieldsV2(customProperties, item);
+				}
+			}
+
 			returnData.push(...executionData);
 		} catch (error) {
 			if (this.continueOnFail()) {

--- a/packages/nodes-base/nodes/Pipedrive/v2/actions/lead/update.operation.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/actions/lead/update.operation.ts
@@ -6,8 +6,13 @@ import type {
 } from 'n8n-workflow';
 
 import { updateDisplayOptions } from '../../../../../utils/utilities';
-import { pipedriveApiRequest } from '../../transport';
-import { visibleToOption } from '../common.description';
+import { pipedriveApiRequest, pipedriveGetCustomProperties } from '../../transport';
+import { encodeCustomFieldsV2, resolveCustomFieldsV2, addFieldsToBody } from '../../helpers';
+import {
+	customFieldsCollection,
+	rawCustomFieldKeysOption,
+	visibleToOption,
+} from '../common.description';
 import { currencies } from '../../../utils';
 
 const properties: INodeProperties[] = [
@@ -116,8 +121,10 @@ const properties: INodeProperties[] = [
 				default: false,
 				description: 'Whether the lead was seen by someone in the Pipedrive UI',
 			},
+			customFieldsCollection,
 		],
 	},
+	rawCustomFieldKeysOption,
 ];
 
 const displayOptions = {
@@ -133,11 +140,18 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 	const items = this.getInputData();
 	const returnData: INodeExecutionData[] = [];
 
+	const rawKeys = this.getNodeParameter('rawCustomFieldKeys', 0, false) as boolean;
+	let customProperties;
+	if (!rawKeys) {
+		customProperties = await pipedriveGetCustomProperties.call(this, 'lead');
+	}
+
 	for (let i = 0; i < items.length; i++) {
 		try {
 			const leadId = this.getNodeParameter('leadId', i) as string;
 
-			const { value, expected_close_date, ...rest } = this.getNodeParameter('updateFields', i) as {
+			const updateFields = this.getNodeParameter('updateFields', i);
+			const { value, expected_close_date, ...rest } = updateFields as {
 				value?: {
 					valueProperties: {
 						amount: number;
@@ -151,7 +165,7 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 			const body: IDataObject = {};
 
 			if (Object.keys(rest).length) {
-				Object.assign(body, rest);
+				addFieldsToBody(body, rest as IDataObject);
 			}
 
 			if (value) {
@@ -160,6 +174,10 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 
 			if (expected_close_date) {
 				body.expected_close_date = expected_close_date.split('T')[0];
+			}
+
+			if (customProperties) {
+				encodeCustomFieldsV2(customProperties, body);
 			}
 
 			const responseData = await pipedriveApiRequest.call(
@@ -175,6 +193,13 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 				this.helpers.returnJsonArray(responseData.data as IDataObject),
 				{ itemData: { item: i } },
 			);
+
+			if (customProperties) {
+				for (const item of executionData) {
+					resolveCustomFieldsV2(customProperties, item);
+				}
+			}
+
 			returnData.push(...executionData);
 		} catch (error) {
 			if (this.continueOnFail()) {

--- a/packages/nodes-base/nodes/Pipedrive/v2/actions/lead/update.operation.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/actions/lead/update.operation.ts
@@ -6,8 +6,20 @@ import type {
 } from 'n8n-workflow';
 
 import { updateDisplayOptions } from '../../../../../utils/utilities';
-import { pipedriveApiRequest } from '../../transport';
-import { visibleToOption } from '../common.description';
+import type { ICustomProperties } from '../../transport';
+import { pipedriveApiRequest, pipedriveGetCustomProperties } from '../../transport';
+import {
+	encodeCustomFieldsV2,
+	resolveCustomFieldsV2,
+	addFieldsToBody,
+	flattenCustomFieldsToRoot,
+	nestRootCustomFields,
+} from '../../helpers';
+import {
+	customFieldsCollection,
+	rawCustomFieldKeysOption,
+	visibleToOption,
+} from '../common.description';
 import { currencies } from '../../../utils';
 
 const properties: INodeProperties[] = [
@@ -116,8 +128,10 @@ const properties: INodeProperties[] = [
 				default: false,
 				description: 'Whether the lead was seen by someone in the Pipedrive UI',
 			},
+			customFieldsCollection,
 		],
 	},
+	rawCustomFieldKeysOption,
 ];
 
 const displayOptions = {
@@ -133,11 +147,33 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 	const items = this.getInputData();
 	const returnData: INodeExecutionData[] = [];
 
+	// Resolving custom field keys/IDs to human-readable names on output was added
+	// after v2 shipped without lead custom field support. Gate it to v2.1+ so leads
+	// created on v2 keep the raw Pipedrive keys they returned before.
+	const resolveOutput = this.getNode().typeVersion >= 2.1;
+
+	const rawKeys = this.getNodeParameter('rawCustomFieldKeys', 0, false) as boolean;
+	// Fetch the lead field metadata once, but surface a failure through the
+	// per-item error path below so `continueOnFail` keeps working.
+	let customProperties: ICustomProperties | undefined;
+	let customPropertiesError: Error | undefined;
+	if (!rawKeys) {
+		try {
+			customProperties = await pipedriveGetCustomProperties.call(this, 'lead');
+		} catch (error) {
+			if (!this.continueOnFail()) throw error;
+			customPropertiesError = error as Error;
+		}
+	}
+
 	for (let i = 0; i < items.length; i++) {
 		try {
+			if (customPropertiesError) throw customPropertiesError;
+
 			const leadId = this.getNodeParameter('leadId', i) as string;
 
-			const { value, expected_close_date, ...rest } = this.getNodeParameter('updateFields', i) as {
+			const updateFields = this.getNodeParameter('updateFields', i);
+			const { value, expected_close_date, ...rest } = updateFields as {
 				value?: {
 					valueProperties: {
 						amount: number;
@@ -151,7 +187,7 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 			const body: IDataObject = {};
 
 			if (Object.keys(rest).length) {
-				Object.assign(body, rest);
+				addFieldsToBody(body, rest as IDataObject);
 			}
 
 			if (value) {
@@ -161,6 +197,12 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 			if (expected_close_date) {
 				body.expected_close_date = expected_close_date.split('T')[0];
 			}
+
+			if (customProperties) {
+				encodeCustomFieldsV2(customProperties, body);
+			}
+			// The v1 Leads endpoint takes custom fields as top-level keys, not nested.
+			flattenCustomFieldsToRoot(body);
 
 			const responseData = await pipedriveApiRequest.call(
 				this,
@@ -175,6 +217,16 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 				this.helpers.returnJsonArray(responseData.data as IDataObject),
 				{ itemData: { item: i } },
 			);
+
+			if (customProperties && resolveOutput) {
+				for (const item of executionData) {
+					// v1 returns custom fields at the root; nest them so the shared
+					// resolver can map keys/IDs to human-readable names.
+					nestRootCustomFields(customProperties, item);
+					resolveCustomFieldsV2(customProperties, item);
+				}
+			}
+
 			returnData.push(...executionData);
 		} catch (error) {
 			if (this.continueOnFail()) {

--- a/packages/nodes-base/nodes/Pipedrive/v2/actions/versionDescription.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/actions/versionDescription.ts
@@ -16,7 +16,7 @@ export const versionDescription: INodeTypeDescription = {
 	name: 'pipedrive',
 	icon: 'file:pipedrive.svg',
 	group: ['transform'],
-	version: 2,
+	version: [2, 2.1],
 	subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
 	description: 'Create and edit data in Pipedrive',
 	defaults: {

--- a/packages/nodes-base/nodes/Pipedrive/v2/helpers/customFields.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/helpers/customFields.ts
@@ -1,4 +1,5 @@
 import type { IDataObject, INodeExecutionData } from 'n8n-workflow';
+import { setSafeObjectProperty } from 'n8n-workflow';
 
 import type { ICustomProperties, ICustomInterface } from '../transport';
 
@@ -148,5 +149,49 @@ export function resolveCustomFieldsV2(
 	}
 
 	json.custom_fields = resolved;
+	item.json = json;
+}
+
+/**
+ * The v1 Leads endpoint (used for lead create/update) expects custom fields as
+ * top-level 40-char keys, not nested under a `custom_fields` object. Moves the
+ * encoded custom fields from `body.custom_fields` to the root of the body.
+ */
+export function flattenCustomFieldsToRoot(body: IDataObject): void {
+	const customFields = body.custom_fields;
+	if (!customFields || typeof customFields !== 'object') {
+		return;
+	}
+
+	for (const [key, value] of Object.entries(customFields as IDataObject)) {
+		setSafeObjectProperty(body, key, value);
+	}
+	delete body.custom_fields;
+}
+
+/**
+ * The v1 Leads endpoint returns custom fields as top-level 40-char keys. Moves
+ * the known custom field keys under `custom_fields` so the shared resolver can
+ * map them to human-readable names, keeping lead output consistent with other
+ * v2 resources.
+ */
+export function nestRootCustomFields(
+	customProperties: ICustomProperties,
+	item: INodeExecutionData,
+): void {
+	const json = item.json as IDataObject;
+	const customFields = (json.custom_fields as IDataObject) ?? {};
+
+	for (const key of Object.keys(json)) {
+		// Only 40-char keys defined in the account's lead fields are custom fields.
+		if (customProperties[key] !== undefined) {
+			customFields[key] = json[key];
+			delete json[key];
+		}
+	}
+
+	if (Object.keys(customFields).length > 0) {
+		json.custom_fields = customFields;
+	}
 	item.json = json;
 }

--- a/packages/nodes-base/nodes/Pipedrive/v2/helpers/index.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/helpers/index.ts
@@ -1,4 +1,9 @@
-export { encodeCustomFieldsV2, resolveCustomFieldsV2 } from './customFields';
+export {
+	encodeCustomFieldsV2,
+	resolveCustomFieldsV2,
+	flattenCustomFieldsToRoot,
+	nestRootCustomFields,
+} from './customFields';
 
 export { coerceToBoolean, coerceToNumber, toDateOnly, toRfc3339 } from './typeCoercion';
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Allow setting Pipedrive custom properties during lead creation and update.
Converting a lead to a deal in Pipedrive retains the custom properties but before this only deals could be created directly with them.
With this PR, leads can also be created with custom properties.

Selecting custom properties (those are created in Pipedrive):
<img width="473" height="902" alt="grafik" src="https://github.com/user-attachments/assets/b6a4c321-6b8b-4ab5-9be8-1b45f71dee06" />

A successfull request
<img width="1091" height="620" alt="grafik" src="https://github.com/user-attachments/assets/86c45091-7316-4eac-9d45-9d01e0368060" />

Lead in pipedrive with custom property set
<img width="1345" height="505" alt="grafik" src="https://github.com/user-attachments/assets/b1c66a25-8942-45a6-9226-e9d4163598ff" />

## Related Linear tickets, Github issues, and Community forum posts

https://community.n8n.io/t/pipedrive-update-leads-custom-properties/53194/1

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
