### PR TITLE
fix(editor): Hide credential modal for r2r workflows (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/rest-api-client/src/api/workflows.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/api/workflows.ts
@@ -7,6 +7,7 @@ export interface WorkflowMetadata {
 	templateId?: string;
 	instanceId?: string;
 	templateCredsSetupCompleted?: boolean;
+	skipCredentialAutoOpen?: boolean;
 }
 
 // Simple version of n8n-workflow.Workflow

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -5024,6 +5024,25 @@ describe('useCanvasOperations', () => {
 				},
 			});
 		});
+
+		it('should set skipCredentialAutoOpen in workflow metadata when option is provided', async () => {
+			const template: WorkflowDataWithTemplateId = {
+				id: 'workflow-id',
+				name: 'Template Name',
+				nodes: [],
+				connections: {},
+				meta: { templateId: 'template-id' },
+			};
+
+			const workflowsStore = mockedStore(useWorkflowsStore);
+
+			const { openWorkflowTemplateFromJSON } = useCanvasOperations();
+			await openWorkflowTemplateFromJSON(template, { skipCredentialAutoOpen: true });
+
+			expect(workflowsStore.addToWorkflowMetadata).toHaveBeenCalledWith({
+				skipCredentialAutoOpen: true,
+			});
+		});
 	});
 });
 

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -2882,15 +2882,17 @@ export function useCanvasOperations() {
 			query: { templateId, parentFolderId, projectId: projectsStore.currentProjectId },
 		});
 
+		// Set skipCredentialAutoOpen BEFORE importTemplate to ensure it's available
+		// when SetupWorkflowCredentialsButton mounts (which happens during importTemplate)
+		if (options?.skipCredentialAutoOpen) {
+			workflowsStore.addToWorkflowMetadata({ skipCredentialAutoOpen: true });
+		}
+
 		await importTemplate({
 			id: templateId,
 			name: workflow.name,
 			workflow,
 		});
-
-		if (options?.skipCredentialAutoOpen) {
-			workflowsStore.addToWorkflowMetadata({ skipCredentialAutoOpen: true });
-		}
 
 		uiStore.stateIsDirty = true;
 

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -2850,7 +2850,10 @@ export function useCanvasOperations() {
 		fitView();
 	}
 
-	async function openWorkflowTemplateFromJSON(workflow: WorkflowDataWithTemplateId) {
+	async function openWorkflowTemplateFromJSON(
+		workflow: WorkflowDataWithTemplateId,
+		options?: { skipCredentialAutoOpen?: boolean },
+	) {
 		if (!workflow.nodes || !workflow.connections) {
 			toast.showError(
 				new Error(i18n.baseText('nodeView.couldntLoadWorkflow.invalidWorkflowObject')),
@@ -2884,6 +2887,10 @@ export function useCanvasOperations() {
 			name: workflow.name,
 			workflow,
 		});
+
+		if (options?.skipCredentialAutoOpen) {
+			workflowsStore.addToWorkflowMetadata({ skipCredentialAutoOpen: true });
+		}
 
 		uiStore.stateIsDirty = true;
 

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -402,7 +402,8 @@ async function initializeRoute(force = false) {
 				return;
 			}
 
-			await openWorkflowTemplateFromJSON(workflow);
+			const skipCredentialAutoOpen = route.query.skipCredentialAutoOpen === 'true';
+			await openWorkflowTemplateFromJSON(workflow, { skipCredentialAutoOpen });
 		} else {
 			await openWorkflowTemplate(templateId.toString());
 		}

--- a/packages/frontend/editor-ui/src/app/views/WorkflowsView.vue
+++ b/packages/frontend/editor-ui/src/app/views/WorkflowsView.vue
@@ -1036,7 +1036,11 @@ const openAIWorkflow = async (source: string) => {
 	await router.push({
 		name: VIEWS.TEMPLATE_IMPORT,
 		params: { id: easyAiWorkflowJson.meta.templateId },
-		query: { fromJson: 'true', parentFolderId: route.params.folderId },
+		query: {
+			fromJson: 'true',
+			skipCredentialAutoOpen: 'true',
+			parentFolderId: route.params.folderId,
+		},
 	});
 };
 

--- a/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.test.ts
@@ -3,6 +3,10 @@ import SetupWorkflowCredentialsButton from './SetupWorkflowCredentialsButton.vue
 import { createTestingPinia } from '@pinia/testing';
 import { mockedStore } from '@/__tests__/utils';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useUIStore } from '@/app/stores/ui.store';
+import { usePostHog } from '@/app/stores/posthog.store';
+import { TEMPLATE_SETUP_EXPERIENCE, SETUP_CREDENTIALS_MODAL_KEY } from '@/app/constants';
+import { doesNodeHaveAllCredentialsFilled } from '@/app/utils/nodes/nodeTransforms';
 
 vi.mock('vue-router', async () => {
 	const actual = await vi.importActual('vue-router');
@@ -19,6 +23,10 @@ vi.mock('vue-router', async () => {
 		}),
 	};
 });
+
+vi.mock('@/app/utils/nodes/nodeTransforms', () => ({
+	doesNodeHaveAllCredentialsFilled: vi.fn(),
+}));
 
 let workflowsStore: ReturnType<typeof mockedStore<typeof useWorkflowsStore>>;
 
@@ -54,5 +62,40 @@ describe('SetupWorkflowCredentialsButton', () => {
 		workflowsStore.workflow = EMPTY_WORKFLOW;
 		const { queryByTestId } = renderComponent();
 		expect(queryByTestId('setup-credentials-button')).toBeNull();
+	});
+
+	it('does not auto-open modal when skipCredentialAutoOpen is set in workflow meta', () => {
+		const uiStore = mockedStore(useUIStore);
+		const posthogStore = mockedStore(usePostHog);
+
+		// Enable the A/B test so modal would normally auto-open
+		posthogStore.getVariant.mockReturnValue(TEMPLATE_SETUP_EXPERIENCE.variant);
+
+		// Mock that nodes have unfilled credentials (so showButton would be true)
+		vi.mocked(doesNodeHaveAllCredentialsFilled).mockReturnValue(false);
+
+		// Create a properly typed mock node
+		const mockNode = {
+			id: 'node1',
+			type: 'test',
+			name: 'Test Node',
+			position: [0, 0] as [number, number],
+			typeVersion: 1,
+			parameters: {},
+		};
+
+		// Workflow with nodes and skipCredentialAutoOpen flag
+		const workflowWithSkipFlag = {
+			...EMPTY_WORKFLOW,
+			meta: { templateId: '2722', skipCredentialAutoOpen: true },
+			nodes: [mockNode],
+		};
+		workflowsStore.workflow = workflowWithSkipFlag;
+		workflowsStore.getNodes.mockReturnValue([mockNode]);
+
+		renderComponent();
+
+		// Modal should NOT have been opened due to skipCredentialAutoOpen flag
+		expect(uiStore.openModal).not.toHaveBeenCalledWith(SETUP_CREDENTIALS_MODAL_KEY);
 	});
 });

--- a/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.vue
@@ -66,7 +66,8 @@ onBeforeUnmount(() => {
 });
 
 onMounted(() => {
-	if (isNewTemplatesSetupEnabled.value && showButton.value) {
+	const skipAutoOpen = workflowsStore.workflow?.meta?.skipCredentialAutoOpen;
+	if (isNewTemplatesSetupEnabled.value && showButton.value && !skipAutoOpen) {
 		openSetupModal();
 	}
 });


### PR DESCRIPTION
## Summary

Disables the auto-open behavior of the credential setup modal when inserting a workflow via the "Try an AI workflow" button.

**Changes:**
- Added `skipCredentialAutoOpen` query parameter when navigating from "Try an AI workflow"
- The flag is passed through to workflow metadata
- `SetupWorkflowCredentialsButton` checks this flag and skips auto-opening the modal

**Behavior:**
- The credential setup modal no longer auto-opens for "Try an AI workflow" flows
- The setup button remains visible so users can manually open the modal if needed
- Other template flows are unaffected

## Related Linear tickets, Github issues, and Community forum posts

[GRO-111](https://linear.app/n8n/issue/GRO-111/weak-and-inconsistent-password-validation)

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
