### PR TITLE
fix: Resolve expressions in custom form HTML fields for HITL nodes

### DIFF
--- a/packages/nodes-base/utils/sendAndWait/test/util.test.ts
+++ b/packages/nodes-base/utils/sendAndWait/test/util.test.ts
@@ -341,6 +341,59 @@ describe('Send and Wait utils tests', () => {
 			});
 		});
 
+		it('should resolve expressions in HTML fields for customForm GET webhook', async () => {
+			const mockRender = jest.fn();
+			const mockSetHeader = jest.fn();
+
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				method: 'GET',
+			} as any);
+
+			mockWebhookFunctions.getResponseObject.mockReturnValue({
+				render: mockRender,
+				setHeader: mockSetHeader,
+			} as any);
+
+			// Mock evaluateExpression to resolve the expression
+			mockWebhookFunctions.evaluateExpression.mockImplementation((expression) => {
+				if (expression === '{{ $json.videoUrl }}') {
+					return 'https://example.com/video.mp4';
+				}
+				return expression;
+			});
+
+			mockWebhookFunctions.getNodeParameter.mockImplementation((parameterName: string) => {
+				const params: { [key: string]: any } = {
+					responseType: 'customForm',
+					message: 'Test message',
+					defineForm: 'fields',
+					'formFields.values': [
+						{
+							fieldLabel: 'Custom HTML',
+							fieldType: 'html',
+							// Use <source> tag inside <video> since sanitizeHtml allows src on source, not video
+							html: '<video controls><source src="{{ $json.videoUrl }}" type="video/mp4" /></video>',
+						},
+					],
+					options: {},
+				};
+				return params[parameterName];
+			});
+
+			await sendAndWaitWebhook.call(mockWebhookFunctions);
+
+			expect(mockRender).toHaveBeenCalledWith(
+				'form-trigger',
+				expect.objectContaining({
+					formFields: expect.arrayContaining([
+						expect.objectContaining({
+							html: '<video controls><source src="https://example.com/video.mp4" type="video/mp4"></source></video>',
+						}),
+					]),
+				}),
+			);
+		});
+
 		it('should handle customForm POST webhook', async () => {
 			mockWebhookFunctions.getRequestObject.mockReturnValue({
 				method: 'POST',

--- a/packages/nodes-base/utils/sendAndWait/utils.ts
+++ b/packages/nodes-base/utils/sendAndWait/utils.ts
@@ -27,6 +27,7 @@ import { cssVariables } from '../../nodes/Form/cssVariables';
 import { formFieldsProperties } from '../../nodes/Form/Form.node';
 import {
 	prepareFormData,
+	prepareFormFields,
 	prepareFormReturnItem,
 	resolveRawData,
 } from '../../nodes/Form/utils/utils';
@@ -431,6 +432,8 @@ export async function sendAndWaitWebhook(this: IWebhookFunctions) {
 		if (method === 'GET') {
 			const { formTitle, formDescription, buttonLabel, customCss } =
 				getFormResponseCustomizations(this);
+
+			fields = prepareFormFields(this, fields);
 
 			const data = prepareFormData({
 				formTitle,


### PR DESCRIPTION
## Summary

Expressions in custom HTML form fields are now resolved when rendering Send and Wait forms. Previously, expressions like `{{ $json.videoUrl }}` in HTML fields were rendered as-is instead of being evaluated to their actual values.

Frontend expression highlighting in the editor will be addressed in a separate PR: https://github.com/n8n-io/codemirror-lang-n8n-html/pull/2 / https://github.com/n8n-io/n8n/pull/23928


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4152

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
