### PR TITLE
fix(code-editor): add $node global typing

### DIFF
--- a/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/typescript/worker/type-declarations/n8n.d.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/typescript/worker/type-declarations/n8n.d.ts
@@ -84,6 +84,28 @@ declare global {
 	const $vars: N8nVars;
 	const $nodeVersion: number;
 
+	interface N8nNodeData<J extends N8nJson = N8nJson, B extends string = string> {
+		json: J & N8nJson;
+		binary: Record<B, N8nBinary>;
+	}
+
+	type SomeOtherString = string & NonNullable<unknown>;
+
+	// @ts-expect-error NodeName is created dynamically
+	function $<K extends NodeName>(
+		nodeName: K | SomeOtherString,
+		// @ts-expect-error NodeDataMap is created dynamically
+	): K extends keyof NodeDataMap ? NodeDataMap[K] : N8nNodeData;
+
+	// @ts-expect-error NodeName is created dynamically
+	const $node: {
+		<K extends NodeName>(
+			nodeName: K | SomeOtherString,
+			// @ts-expect-error NodeDataMap is created dynamically
+		): K extends keyof NodeDataMap ? NodeDataMap[K] : N8nNodeData;
+		[nodeName: string]: N8nNodeData;
+	};
+
 	function $jmespath(object: Object | Array<any>, expression: string): any;
 	function $if<B extends boolean, T, F>(
 		condition: B,


### PR DESCRIPTION
## Summary

The Code node editor currently shows a TypeScript error when using the built‑in `$node` helper (e.g. `Cannot find name '$node'`).
This PR adds a global TypeScript declaration for $node in the code editor worker so that `$node["Some Node"].json` is recognized by the editor and no longer reported as an error.
​

## Changes

- Define a `N8nNodeData` type (`json` + `binary`) for node output data.

- Update the global `$` helper signature to return `N8nNodeData` when `NodeDataMap` does not provide a more specific type.

- Add a new `$node` global with the same generic signature as `$`, including an index signature, so $node["Some Node"].json is properly typed.
​

## Motivation / Context

Docs and examples recommend $node["Node Name"].json to access data from other nodes, but the editor previously flagged $node as unknown, and `$node["..."].json` lacked typings.

## Testing

Started the editor in dev mode.

In a Code node (JavaScript mode), used:

```js
const items = $input.all();
const prev = $node["Extract Video ID"].json;
return items;
```

Confirmed that the editor no longer reports `Cannot find name '$node'` and that `prev` has `json`/`binary` fields without type errors.

<img width="677" height="331" alt="image" src="https://github.com/user-attachments/assets/31652868-70de-405c-b840-cd5cd2007d83" />
​

Fixes n8n-io/n8n#23909