### PR TITLE
refactor: Lazy-load binary other than defined binary data modes (no-changelog)

### DIFF
--- a/packages/cli/src/commands/base-command.ts
+++ b/packages/cli/src/commands/base-command.ts
@@ -201,9 +201,34 @@ export abstract class BaseCommand<F = never> {
 		const binaryDataService = Container.get(BinaryDataService);
 		const isS3WriteMode = binaryDataConfig.mode === 's3';
 
-		const { DatabaseManager } = await import('@/binary-data/database.manager');
-		binaryDataService.setManager('database', Container.get(DatabaseManager));
+		// Register database loader (lazy)
+		binaryDataService.registerLoader('database', async () => {
+			const { DatabaseManager } = await import('@/binary-data/database.manager');
+			return Container.get(DatabaseManager);
+		});
 
+		// Register S3 loader (lazy)
+		binaryDataService.registerLoader('s3', async () => {
+			const objectStoreService = Container.get(ObjectStoreService);
+			await objectStoreService.init();
+			const { ObjectStoreManager } = await import('n8n-core/dist/binary-data/object-store.manager');
+			return new ObjectStoreManager(objectStoreService);
+		});
+
+		// Initialize the service (will eagerly load filesystem or database based on config)
+		await binaryDataService.init();
+
+		// If database is write mode, eagerly load it
+		if (binaryDataConfig.mode === 'database') {
+			try {
+				await binaryDataService.getManager('database');
+			} catch (error) {
+				this.logger.error('Failed to initialize database binary data manager');
+				throw error;
+			}
+		}
+
+		// If S3 is the write mode, verify license and eagerly load it
 		if (isS3WriteMode) {
 			const isLicensed = Container.get(License).isLicensed(LICENSE_FEATURES.BINARY_DATA_S3);
 			if (!isLicensed) {
@@ -212,25 +237,17 @@ export abstract class BaseCommand<F = never> {
 				);
 				process.exit(1);
 			}
-		}
 
-		// we always try to init S3 for reading - silently fail if not configured
-		try {
-			const objectStoreService = Container.get(ObjectStoreService);
-			await objectStoreService.init();
-			const { ObjectStoreManager } = await import('n8n-core/dist/binary-data/object-store.manager');
-			binaryDataService.setManager('s3', new ObjectStoreManager(objectStoreService));
-		} catch {
-			if (isS3WriteMode) {
+			// Eagerly load and verify S3 connection for write mode
+			try {
+				await binaryDataService.getManager('s3');
+			} catch (error) {
 				this.logger.error(
 					'Failed to connect to S3 for binary data storage. Please check your S3 configuration.',
 				);
 				process.exit(1);
 			}
-			// S3 not configured - users without S3 data are unaffected; users with S3 data will fail at runtime when reading
 		}
-
-		await binaryDataService.init();
 	}
 
 	protected async initDataDeduplicationService() {

--- a/packages/cli/test/integration/binary-data.api.test.ts
+++ b/packages/cli/test/integration/binary-data.api.test.ts
@@ -40,7 +40,7 @@ describe('GET /binary-data', () => {
 
 	describe('should reject on missing or invalid binary data ID', () => {
 		test.each([['view'], ['download']])('on request to %s', async (action) => {
-			binaryDataService.getPath.mockReturnValue(binaryFilePath);
+			binaryDataService.getPath.mockResolvedValue(binaryFilePath);
 			fsp.readFile = jest.fn().mockResolvedValue(buffer);
 
 			await authOwnerAgent

--- a/packages/core/src/binary-data/__tests__/lazy-loading.test.ts
+++ b/packages/core/src/binary-data/__tests__/lazy-loading.test.ts
@@ -255,12 +255,13 @@ describe('BinaryDataService - Lazy Loading', () => {
 
 			await binaryDataService.init();
 
-			// Try to access unregistered mode
+			await expect(binaryDataService.getManager('unknown-mode')).rejects.toThrow(
+				InvalidManagerError,
+			);
+
 			try {
 				await binaryDataService.getManager('unknown-mode');
-				fail('Should have thrown InvalidManagerError');
 			} catch (error) {
-				expect(error).toBeInstanceOf(InvalidManagerError);
 				expect((error as InvalidManagerError).message).toContain('unknown-mode');
 			}
 		});

--- a/packages/core/src/binary-data/__tests__/lazy-loading.test.ts
+++ b/packages/core/src/binary-data/__tests__/lazy-loading.test.ts
@@ -1,11 +1,12 @@
-import { mock } from 'jest-mock-extended';
 import type { Logger } from '@n8n/backend-common';
+import { mock } from 'jest-mock-extended';
 
-import { BinaryDataService } from '../binary-data.service';
-import { BinaryDataConfig } from '../binary-data.config';
-import { ErrorReporter } from '@/errors';
+import type { ErrorReporter } from '@/errors';
 import type { BinaryData } from '../types';
 import { InvalidManagerError } from '../../errors/invalid-manager.error';
+
+import { BinaryDataConfig } from '../binary-data.config';
+import { BinaryDataService } from '../binary-data.service';
 
 describe('BinaryDataService - Lazy Loading', () => {
 	let binaryDataService: BinaryDataService;
@@ -22,7 +23,7 @@ describe('BinaryDataService - Lazy Loading', () => {
 		const executionsConfig = {
 			mode: 'regular',
 		};
-		config = new BinaryDataConfig(instanceSettings as any, executionsConfig as any);
+		config = new BinaryDataConfig(instanceSettings, executionsConfig);
 		config.mode = 'filesystem';
 
 		errorReporter = mock<ErrorReporter>();

--- a/packages/core/src/binary-data/__tests__/lazy-loading.test.ts
+++ b/packages/core/src/binary-data/__tests__/lazy-loading.test.ts
@@ -1,4 +1,3 @@
-import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
 import type { Logger } from '@n8n/backend-common';
 

--- a/packages/core/src/binary-data/__tests__/lazy-loading.test.ts
+++ b/packages/core/src/binary-data/__tests__/lazy-loading.test.ts
@@ -1,0 +1,349 @@
+import { Container } from '@n8n/di';
+import { mock } from 'jest-mock-extended';
+import type { Logger } from '@n8n/backend-common';
+
+import { BinaryDataService } from '../binary-data.service';
+import { BinaryDataConfig } from '../binary-data.config';
+import { ErrorReporter } from '@/errors';
+import type { BinaryData } from '../types';
+import { InvalidManagerError } from '../../errors/invalid-manager.error';
+
+describe('BinaryDataService - Lazy Loading', () => {
+	let binaryDataService: BinaryDataService;
+	let config: BinaryDataConfig;
+	let errorReporter: ErrorReporter;
+	let logger: Logger;
+	let mockManager: BinaryData.Manager;
+
+	beforeEach(() => {
+		const instanceSettings = {
+			encryptionKey: 'test-key',
+			n8nFolder: '/tmp/n8n',
+		};
+		const executionsConfig = {
+			mode: 'regular',
+		};
+		config = new BinaryDataConfig(instanceSettings as any, executionsConfig as any);
+		config.mode = 'filesystem';
+
+		errorReporter = mock<ErrorReporter>();
+		logger = mock<Logger>();
+
+		// Create a mock manager
+		mockManager = {
+			init: jest.fn().mockResolvedValue(undefined),
+			store: jest.fn(),
+			getPath: jest.fn().mockReturnValue('/fake/path'),
+			getAsBuffer: jest.fn().mockResolvedValue(Buffer.from('test')),
+			getAsStream: jest.fn(),
+			getMetadata: jest.fn().mockResolvedValue({ fileSize: 100 }),
+			copyByFileId: jest.fn(),
+			copyByFilePath: jest.fn(),
+			rename: jest.fn(),
+		};
+
+		binaryDataService = new BinaryDataService(config, errorReporter, logger);
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('Configured mode is eagerly loaded', () => {
+		it('should eagerly load filesystem manager when mode is filesystem', async () => {
+			config.mode = 'filesystem';
+
+			await binaryDataService.init();
+
+			// Manager should be loaded immediately
+			const manager = await binaryDataService.getManager('filesystem-v2');
+			expect(manager).toBeDefined();
+		});
+
+		it('should not load database manager when mode is filesystem', async () => {
+			config.mode = 'filesystem';
+
+			const databaseLoader = jest.fn().mockResolvedValue(mockManager);
+			binaryDataService.registerLoader('database', databaseLoader);
+
+			await binaryDataService.init();
+
+			// Database loader should not be called
+			expect(databaseLoader).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('Non-configured modes are lazy loaded', () => {
+		it('should lazy-load database manager on first access', async () => {
+			config.mode = 'filesystem';
+
+			const databaseLoader = jest.fn().mockResolvedValue(mockManager);
+			binaryDataService.registerLoader('database', databaseLoader);
+
+			await binaryDataService.init();
+
+			// Database loader should not be called yet
+			expect(databaseLoader).not.toHaveBeenCalled();
+
+			// Access database manager
+			const manager = await binaryDataService.getManager('database');
+
+			// Now loader should be called
+			expect(databaseLoader).toHaveBeenCalledTimes(1);
+			expect(manager).toBe(mockManager);
+			expect(mockManager.init).toHaveBeenCalledTimes(1);
+		});
+
+		it('should cache loaded managers for subsequent accesses', async () => {
+			config.mode = 'filesystem';
+
+			const databaseLoader = jest.fn().mockResolvedValue(mockManager);
+			binaryDataService.registerLoader('database', databaseLoader);
+
+			await binaryDataService.init();
+
+			// Access database manager multiple times
+			const manager1 = await binaryDataService.getManager('database');
+			const manager2 = await binaryDataService.getManager('database');
+			const manager3 = await binaryDataService.getManager('database');
+
+			// Loader should only be called once
+			expect(databaseLoader).toHaveBeenCalledTimes(1);
+			expect(manager1).toBe(manager2);
+			expect(manager2).toBe(manager3);
+		});
+
+		it('should lazy-load S3 manager on first access', async () => {
+			config.mode = 'filesystem';
+
+			const s3Loader = jest.fn().mockResolvedValue(mockManager);
+			binaryDataService.registerLoader('s3', s3Loader);
+
+			await binaryDataService.init();
+
+			// S3 loader should not be called yet
+			expect(s3Loader).not.toHaveBeenCalled();
+
+			// Access S3 manager
+			const manager = await binaryDataService.getManager('s3');
+
+			// Now loader should be called
+			expect(s3Loader).toHaveBeenCalledTimes(1);
+			expect(manager).toBe(mockManager);
+		});
+	});
+
+	describe('Race condition handling', () => {
+		it('should only load manager once when accessed simultaneously', async () => {
+			config.mode = 'filesystem';
+
+			let loaderCallCount = 0;
+			const databaseLoader = jest.fn().mockImplementation(async () => {
+				loaderCallCount++;
+				// Simulate async loading delay
+				await new Promise((resolve) => setTimeout(resolve, 50));
+				return mockManager;
+			});
+
+			binaryDataService.registerLoader('database', databaseLoader);
+
+			await binaryDataService.init();
+
+			// Access database manager simultaneously
+			const promises = [
+				binaryDataService.getManager('database'),
+				binaryDataService.getManager('database'),
+				binaryDataService.getManager('database'),
+			];
+
+			const managers = await Promise.all(promises);
+
+			// Loader should only be called once despite multiple simultaneous accesses
+			expect(databaseLoader).toHaveBeenCalledTimes(1);
+			expect(loaderCallCount).toBe(1);
+
+			// All should return the same manager instance
+			expect(managers[0]).toBe(managers[1]);
+			expect(managers[1]).toBe(managers[2]);
+		});
+	});
+
+	describe('Failed loads are not cached', () => {
+		it('should retry loading on subsequent access after failure', async () => {
+			config.mode = 'filesystem';
+
+			let callCount = 0;
+			const flakyLoader = jest.fn().mockImplementation(async () => {
+				callCount++;
+				if (callCount === 1) {
+					throw new Error('Simulated loader failure');
+				}
+				return mockManager;
+			});
+
+			binaryDataService.registerLoader('database', flakyLoader);
+
+			await binaryDataService.init();
+
+			// First access should fail
+			await expect(binaryDataService.getManager('database')).rejects.toThrow(
+				'Simulated loader failure',
+			);
+
+			// Second access should succeed
+			const manager = await binaryDataService.getManager('database');
+
+			expect(flakyLoader).toHaveBeenCalledTimes(2);
+			expect(manager).toBe(mockManager);
+		});
+
+		it('should log warning on loader failure', async () => {
+			config.mode = 'filesystem';
+
+			const failingLoader = jest.fn().mockRejectedValue(new Error('Load failed'));
+			binaryDataService.registerLoader('database', failingLoader);
+
+			await binaryDataService.init();
+
+			// Try to access failing manager
+			await expect(binaryDataService.getManager('database')).rejects.toThrow('Load failed');
+
+			// Should log warning
+			expect(logger.warn).toHaveBeenCalledWith(
+				'Failed to load binary data manager for mode database',
+				expect.objectContaining({
+					error: expect.any(Error),
+				}),
+			);
+		});
+
+		it('should log debug messages during successful loading', async () => {
+			config.mode = 'filesystem';
+
+			const databaseLoader = jest.fn().mockResolvedValue(mockManager);
+			binaryDataService.registerLoader('database', databaseLoader);
+
+			await binaryDataService.init();
+
+			// Access database manager
+			await binaryDataService.getManager('database');
+
+			// Should log debug messages
+			expect(logger.debug).toHaveBeenCalledWith(
+				'Lazy-loading binary data manager for mode: database',
+			);
+			expect(logger.debug).toHaveBeenCalledWith(
+				'Successfully loaded binary data manager for mode: database',
+			);
+		});
+	});
+
+	describe('Invalid mode throws error', () => {
+		it('should throw InvalidManagerError for unregistered mode', async () => {
+			config.mode = 'filesystem';
+
+			await binaryDataService.init();
+
+			// Try to access unregistered mode
+			await expect(binaryDataService.getManager('nonexistent')).rejects.toThrow(
+				InvalidManagerError,
+			);
+		});
+
+		it('should throw InvalidManagerError with mode information', async () => {
+			config.mode = 'filesystem';
+
+			await binaryDataService.init();
+
+			// Try to access unregistered mode
+			try {
+				await binaryDataService.getManager('unknown-mode');
+				fail('Should have thrown InvalidManagerError');
+			} catch (error) {
+				expect(error).toBeInstanceOf(InvalidManagerError);
+				expect((error as InvalidManagerError).message).toContain('unknown-mode');
+			}
+		});
+	});
+
+	describe('Filesystem-v2 alias works correctly', () => {
+		it('should set both filesystem and filesystem-v2 managers when loading filesystem', async () => {
+			config.mode = 'filesystem';
+
+			await binaryDataService.init();
+
+			// Both keys should exist and point to same manager
+			const fsManager = await binaryDataService.getManager('filesystem');
+			const fsV2Manager = await binaryDataService.getManager('filesystem-v2');
+
+			expect(fsManager).toBe(fsV2Manager);
+		});
+	});
+
+	describe('Integration with binary data operations', () => {
+		it('should lazy-load manager when reading binary data with non-configured mode', async () => {
+			config.mode = 'filesystem';
+
+			const databaseLoader = jest.fn().mockResolvedValue(mockManager);
+			binaryDataService.registerLoader('database', databaseLoader);
+
+			await binaryDataService.init();
+
+			// Access via getAsBuffer (which calls getManager internally)
+			const binaryData = { id: 'database:file123', data: '', mimeType: 'text/plain' };
+			await binaryDataService.getAsBuffer(binaryData);
+
+			// Database loader should have been called
+			expect(databaseLoader).toHaveBeenCalledTimes(1);
+			expect(mockManager.getAsBuffer).toHaveBeenCalledWith('file123');
+		});
+
+		it('should lazy-load manager when calling getPath', async () => {
+			config.mode = 'filesystem';
+
+			const s3Loader = jest.fn().mockResolvedValue(mockManager);
+			binaryDataService.registerLoader('s3', s3Loader);
+
+			await binaryDataService.init();
+
+			// Access via getPath
+			await binaryDataService.getPath('s3:file456');
+
+			// S3 loader should have been called
+			expect(s3Loader).toHaveBeenCalledTimes(1);
+			expect(mockManager.getPath).toHaveBeenCalledWith('file456');
+		});
+
+		it('should lazy-load manager when calling getAsStream', async () => {
+			config.mode = 'filesystem';
+
+			const databaseLoader = jest.fn().mockResolvedValue(mockManager);
+			binaryDataService.registerLoader('database', databaseLoader);
+
+			await binaryDataService.init();
+
+			// Access via getAsStream
+			await binaryDataService.getAsStream('database:file789');
+
+			// Database loader should have been called
+			expect(databaseLoader).toHaveBeenCalledTimes(1);
+			expect(mockManager.getAsStream).toHaveBeenCalledWith('file789', undefined);
+		});
+
+		it('should lazy-load manager when calling getMetadata', async () => {
+			config.mode = 'filesystem';
+
+			const s3Loader = jest.fn().mockResolvedValue(mockManager);
+			binaryDataService.registerLoader('s3', s3Loader);
+
+			await binaryDataService.init();
+
+			// Access via getMetadata
+			await binaryDataService.getMetadata('s3:metadata123');
+
+			// S3 loader should have been called
+			expect(s3Loader).toHaveBeenCalledTimes(1);
+			expect(mockManager.getMetadata).toHaveBeenCalledWith('metadata123');
+		});
+	});
+});

--- a/packages/core/src/binary-data/__tests__/lazy-loading.test.ts
+++ b/packages/core/src/binary-data/__tests__/lazy-loading.test.ts
@@ -278,6 +278,29 @@ describe('BinaryDataService - Lazy Loading', () => {
 
 			expect(fsManager).toBe(fsV2Manager);
 		});
+
+		it('should lazy-load filesystem manager when accessing filesystem-v2 with different configured mode', async () => {
+			config.mode = 's3';
+
+			const s3Loader = jest.fn().mockResolvedValue(mockManager);
+			binaryDataService.registerLoader('s3', s3Loader);
+
+			await binaryDataService.init();
+
+			// Filesystem should not be eagerly loaded when mode is s3
+			expect(s3Loader).not.toHaveBeenCalled();
+
+			// Access filesystem-v2 manager (should lazy-load filesystem)
+			const fsV2Manager = await binaryDataService.getManager('filesystem-v2');
+
+			// Should successfully return a manager
+			expect(fsV2Manager).toBeDefined();
+			expect(fsV2Manager.init).toBeDefined();
+
+			// Both filesystem and filesystem-v2 should point to the same instance
+			const fsManager = await binaryDataService.getManager('filesystem');
+			expect(fsManager).toBe(fsV2Manager);
+		});
 	});
 
 	describe('Integration with binary data operations', () => {

--- a/packages/core/src/binary-data/__tests__/lazy-loading.test.ts
+++ b/packages/core/src/binary-data/__tests__/lazy-loading.test.ts
@@ -2,11 +2,11 @@ import type { Logger } from '@n8n/backend-common';
 import { mock } from 'jest-mock-extended';
 
 import type { ErrorReporter } from '@/errors';
-import type { BinaryData } from '../types';
-import { InvalidManagerError } from '../../errors/invalid-manager.error';
+import { InvalidManagerError } from '@/errors/invalid-manager.error';
 
 import { BinaryDataConfig } from '../binary-data.config';
 import { BinaryDataService } from '../binary-data.service';
+import type { BinaryData } from '../types';
 
 describe('BinaryDataService - Lazy Loading', () => {
 	let binaryDataService: BinaryDataService;
@@ -19,11 +19,11 @@ describe('BinaryDataService - Lazy Loading', () => {
 		const instanceSettings = {
 			encryptionKey: 'test-key',
 			n8nFolder: '/tmp/n8n',
-		};
+		} as const;
 		const executionsConfig = {
 			mode: 'regular',
-		};
-		config = new BinaryDataConfig(instanceSettings, executionsConfig);
+		} as const;
+		config = new BinaryDataConfig(instanceSettings as never, executionsConfig as never);
 		config.mode = 'filesystem';
 
 		errorReporter = mock<ErrorReporter>();

--- a/packages/core/src/binary-data/binary-data.service.ts
+++ b/packages/core/src/binary-data/binary-data.service.ts
@@ -297,12 +297,13 @@ export class BinaryDataService {
 		const loadingPromise = this.loadingPromises.get(mode);
 		if (loadingPromise) return await loadingPromise;
 
-		const loader = this.managerLoaders[mode];
+		const loaderMode = mode === 'filesystem-v2' ? 'filesystem' : mode;
+		const loader = this.managerLoaders[loaderMode];
 		if (!loader) {
 			throw new InvalidManagerError(mode);
 		}
 
-		const promise = this.loadManager(mode, loader);
+		const promise = this.loadManager(loaderMode, loader);
 		this.loadingPromises.set(mode, promise);
 
 		try {

--- a/packages/core/src/binary-data/binary-data.service.ts
+++ b/packages/core/src/binary-data/binary-data.service.ts
@@ -44,7 +44,6 @@ export class BinaryDataService {
 
 		this.mode = config.mode === 'filesystem' ? 'filesystem-v2' : config.mode;
 
-		// Register filesystem loader
 		this.registerLoader('filesystem', async () => {
 			const { FileSystemManager } = await import('./file-system.manager');
 			return new FileSystemManager(config.localStoragePath, this.errorReporter);
@@ -293,20 +292,16 @@ export class BinaryDataService {
 	}
 
 	async getManager(mode: string): Promise<BinaryData.Manager> {
-		// If manager already exists, return it
 		if (this.managers[mode]) return this.managers[mode];
 
-		// If currently loading, wait for that promise
 		const loadingPromise = this.loadingPromises.get(mode);
 		if (loadingPromise) return await loadingPromise;
 
-		// If no loader registered, throw error
 		const loader = this.managerLoaders[mode];
 		if (!loader) {
 			throw new InvalidManagerError(mode);
 		}
 
-		// Start loading the manager
 		const promise = this.loadManager(mode, loader);
 		this.loadingPromises.set(mode, promise);
 

--- a/packages/core/src/binary-data/binary-data.service.ts
+++ b/packages/core/src/binary-data/binary-data.service.ts
@@ -21,6 +21,10 @@ export class BinaryDataService {
 
 	private managers: Record<string, BinaryData.Manager> = {};
 
+	private managerLoaders: Record<string, BinaryData.ManagerLoader> = {};
+
+	private loadingPromises: Map<string, Promise<BinaryData.Manager>> = new Map();
+
 	constructor(
 		private readonly config: BinaryDataConfig,
 		private readonly errorReporter: ErrorReporter,
@@ -31,17 +35,30 @@ export class BinaryDataService {
 		this.managers[mode] = manager;
 	}
 
+	registerLoader(mode: string, loader: BinaryData.ManagerLoader) {
+		this.managerLoaders[mode] = loader;
+	}
+
 	async init() {
 		const { config } = this;
 
 		this.mode = config.mode === 'filesystem' ? 'filesystem-v2' : config.mode;
 
-		const { FileSystemManager } = await import('./file-system.manager');
-		this.managers.filesystem = new FileSystemManager(config.localStoragePath, this.errorReporter);
-		this.managers['filesystem-v2'] = this.managers.filesystem;
-		await this.managers.filesystem.init();
+		// Register filesystem loader
+		this.registerLoader('filesystem', async () => {
+			const { FileSystemManager } = await import('./file-system.manager');
+			return new FileSystemManager(config.localStoragePath, this.errorReporter);
+		});
 
-		// DB and S3 managers are set via `setManager()` from `cli`
+		// Eagerly load only the configured write mode (filesystem-v2)
+		if (this.mode === 'filesystem-v2') {
+			const loader = this.managerLoaders['filesystem'];
+			if (loader) {
+				await this.loadManager('filesystem', loader);
+			}
+		}
+
+		// DB and S3 loaders will be registered from cli package
 	}
 
 	createSignedToken(binaryData: IBinaryData, expiresIn: TimeUnitValue = '1 day') {
@@ -123,30 +140,34 @@ export class BinaryDataService {
 
 	async getAsStream(binaryDataId: string, chunkSize?: number) {
 		const [mode, fileId] = binaryDataId.split(':');
+		const manager = await this.getManager(mode);
 
-		return await this.getManager(mode).getAsStream(fileId, chunkSize);
+		return await manager.getAsStream(fileId, chunkSize);
 	}
 
 	async getAsBuffer(binaryData: IBinaryData) {
 		if (binaryData.id) {
 			const [mode, fileId] = binaryData.id.split(':');
+			const manager = await this.getManager(mode);
 
-			return await this.getManager(mode).getAsBuffer(fileId);
+			return await manager.getAsBuffer(fileId);
 		}
 
 		return Buffer.from(binaryData.data, BINARY_ENCODING);
 	}
 
-	getPath(binaryDataId: string) {
+	async getPath(binaryDataId: string): Promise<string> {
 		const [mode, fileId] = binaryDataId.split(':');
+		const manager = await this.getManager(mode);
 
-		return this.getManager(mode).getPath(fileId);
+		return manager.getPath(fileId);
 	}
 
 	async getMetadata(binaryDataId: string) {
 		const [mode, fileId] = binaryDataId.split(':');
+		const manager = await this.getManager(mode);
 
-		return await this.getManager(mode).getMetadata(fileId);
+		return await manager.getMetadata(fileId);
 	}
 
 	async deleteMany(locations: BinaryData.FileLocation[]) {
@@ -216,7 +237,7 @@ export class BinaryDataService {
 	}
 
 	async rename(oldFileId: string, newFileId: string) {
-		const manager = this.getManager(this.mode);
+		const manager = await this.getManager(this.mode);
 
 		if (!manager) return;
 
@@ -271,11 +292,52 @@ export class BinaryDataService {
 		return executionData;
 	}
 
-	private getManager(mode: string) {
-		const manager = this.managers[mode];
+	async getManager(mode: string): Promise<BinaryData.Manager> {
+		// If manager already exists, return it
+		if (this.managers[mode]) return this.managers[mode];
 
-		if (manager) return manager;
+		// If currently loading, wait for that promise
+		const loadingPromise = this.loadingPromises.get(mode);
+		if (loadingPromise) return await loadingPromise;
 
-		throw new InvalidManagerError(mode);
+		// If no loader registered, throw error
+		const loader = this.managerLoaders[mode];
+		if (!loader) {
+			throw new InvalidManagerError(mode);
+		}
+
+		// Start loading the manager
+		const promise = this.loadManager(mode, loader);
+		this.loadingPromises.set(mode, promise);
+
+		try {
+			const manager = await promise;
+			return manager;
+		} finally {
+			this.loadingPromises.delete(mode);
+		}
+	}
+
+	private async loadManager(
+		mode: string,
+		loader: BinaryData.ManagerLoader,
+	): Promise<BinaryData.Manager> {
+		try {
+			this.logger.debug(`Lazy-loading binary data manager for mode: ${mode}`);
+			const manager = await loader();
+			await manager.init();
+			this.managers[mode] = manager;
+
+			// Handle filesystem-v2 alias
+			if (mode === 'filesystem') {
+				this.managers['filesystem-v2'] = manager;
+			}
+
+			this.logger.debug(`Successfully loaded binary data manager for mode: ${mode}`);
+			return manager;
+		} catch (error) {
+			this.logger.warn(`Failed to load binary data manager for mode ${mode}`, { error });
+			throw error;
+		}
 	}
 }

--- a/packages/core/src/binary-data/types.ts
+++ b/packages/core/src/binary-data/types.ts
@@ -68,6 +68,12 @@ export namespace BinaryData {
 		rename(oldFileId: string, newFileId: string): Promise<void>;
 	}
 
+	/**
+	 * Function that creates and returns a binary data manager instance.
+	 * Used for lazy-loading managers on demand.
+	 */
+	export type ManagerLoader = () => Promise<Manager>;
+
 	export type SigningPayload = {
 		id: string;
 	};

--- a/packages/core/src/binary-data/types.ts
+++ b/packages/core/src/binary-data/types.ts
@@ -68,10 +68,6 @@ export namespace BinaryData {
 		rename(oldFileId: string, newFileId: string): Promise<void>;
 	}
 
-	/**
-	 * Function that creates and returns a binary data manager instance.
-	 * Used for lazy-loading managers on demand.
-	 */
 	export type ManagerLoader = () => Promise<Manager>;
 
 	export type SigningPayload = {

--- a/packages/core/src/execution-engine/node-execution-context/utils/binary-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/binary-helper-functions.ts
@@ -37,8 +37,8 @@ export async function binaryToString(body: Buffer | Readable, encoding?: string)
 	return iconv.decode(buffer, encoding ?? 'utf-8');
 }
 
-function getBinaryPath(binaryDataId: string): string {
-	return Container.get(BinaryDataService).getPath(binaryDataId);
+async function getBinaryPath(binaryDataId: string): Promise<string> {
+	return await Container.get(BinaryDataService).getPath(binaryDataId);
 }
 
 /**

--- a/packages/nodes-base/nodes/SpreadsheetFile/v1/SpreadsheetFileV1.node.ts
+++ b/packages/nodes-base/nodes/SpreadsheetFile/v1/SpreadsheetFileV1.node.ts
@@ -78,7 +78,7 @@ export class SpreadsheetFileV1 implements INodeType {
 					if (options.readAsString) xlsxOptions.type = 'string';
 
 					if (binaryData.id) {
-						const binaryPath = this.helpers.getBinaryPath(binaryData.id);
+						const binaryPath = await this.helpers.getBinaryPath(binaryData.id);
 						xlsxOptions.codepage = 65001; // utf8 codepage
 						workbook = xlsxReadFile(binaryPath, xlsxOptions);
 					} else {

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -734,7 +734,7 @@ export interface BinaryHelperFunctions {
 	copyBinaryFile(): Promise<never>;
 	binaryToBuffer(body: Buffer | Readable): Promise<Buffer>;
 	binaryToString(body: Buffer | Readable, encoding?: BufferEncoding): Promise<string>;
-	getBinaryPath(binaryDataId: string): string;
+	getBinaryPath(binaryDataId: string): Promise<string>;
 	getBinaryStream(binaryDataId: string, chunkSize?: number): Promise<Readable>;
 	createBinarySignedUrl(binaryData: IBinaryData, expiresIn?: string): string;
 	getBinaryMetadata(binaryDataId: string): Promise<{


### PR DESCRIPTION
## Summary

Title self explanatory

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2008/lazy-load-binary-other-than-defined-binary-data-modes

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
