### PR TITLE
fix(editor): Keep structured output parser error icon in correct position when running

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeDefault.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeDefault.vue
@@ -286,11 +286,9 @@ function onActivate(event: MouseEvent) {
 				margin-left: calc((var(--canvas-node--height) - var(--node--icon--size) - 4px) / 2);
 			}
 
-			&:not(.running) {
-				.statusIcons {
-					position: static;
-					margin-right: var(--spacing--2xs);
-				}
+			.statusIcons {
+				position: static;
+				margin-right: var(--spacing--2xs);
 			}
 
 			.description {


### PR DESCRIPTION
## Summary

This PR fixes an issue with the structured output parser (and likely other similarly styled nodes) where the error icon would move around while the running animation was active. I've made the location of the icon static consistently now, rather than excluding it while it is running.

![structured-output-animation](https://github.com/user-attachments/assets/5733ed39-701c-4ed7-8fb1-754d11c9cf80)

Addresses: https://linear.app/n8n/issue/AI-1807/bug-structured-output-parser-animation-causes-state-icon-to-move

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
