### PR TITLE
chore(core): Add DTOs for workflow create / update validation

### DIFF
--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -61,6 +61,8 @@ export { CredentialsGetOneRequestQuery } from './credentials/credentials-get-one
 export { CredentialsGetManyRequestQuery } from './credentials/credentials-get-many-request.dto';
 export { GenerateCredentialNameRequestQuery } from './credentials/generate-credential-name.dto';
 
+export { CreateWorkflowDto } from './workflows/create-workflow.dto';
+export { UpdateWorkflowDto } from './workflows/update-workflow.dto';
 export { ImportWorkflowFromUrlDto } from './workflows/import-workflow-from-url.dto';
 export { TransferWorkflowBodyDto } from './workflows/transfer.dto';
 export { ActivateWorkflowDto } from './workflows/activate-workflow.dto';

--- a/packages/@n8n/api-types/src/dto/workflows/__tests__/create-workflow.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/__tests__/create-workflow.dto.test.ts
@@ -1,0 +1,308 @@
+import { CreateWorkflowDto } from '../create-workflow.dto';
+
+describe('CreateWorkflowDto', () => {
+	describe('Valid requests', () => {
+		test.each([
+			{
+				name: 'minimal workflow',
+				request: {
+					name: 'My Workflow',
+					nodes: [],
+					connections: {},
+				},
+			},
+			{
+				name: 'with all optional fields',
+				request: {
+					name: 'Complete Workflow',
+					nodes: [],
+					connections: {},
+					description: 'A test workflow',
+					settings: { saveExecutionProgress: true },
+					staticData: { key: 'value' },
+					meta: { version: '1.0' },
+					pinData: {},
+					hash: 'abc123',
+					tags: ['tag1', 'tag2'],
+					projectId: 'proj123',
+					parentFolderId: 'folder123',
+					uiContext: 'workflow_list',
+					aiBuilderAssisted: true,
+					autosaved: false,
+				},
+			},
+			{
+				name: 'with tags as objects (backward compatibility)',
+				request: {
+					name: 'Tagged Workflow',
+					nodes: [],
+					connections: {},
+					tags: [
+						{ id: 'tag1', name: 'Tag 1' },
+						{ id: 'tag2', name: 'Tag 2' },
+					],
+				},
+			},
+		])('should validate $name', ({ request }) => {
+			const result = CreateWorkflowDto.safeParse(request);
+			expect(result.success).toBe(true);
+		});
+
+		test('should transform tags from objects to string array', () => {
+			const result = CreateWorkflowDto.safeParse({
+				name: 'Test',
+				nodes: [],
+				connections: {},
+				tags: [
+					{ id: 'tag1', name: 'Tag 1' },
+					{ id: 'tag2', name: 'Tag 2' },
+				],
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.data?.tags).toEqual(['tag1', 'tag2']);
+		});
+	});
+
+	describe('Invalid requests', () => {
+		test.each([
+			{
+				name: 'missing name',
+				request: { nodes: [], connections: {} },
+				expectedErrorPath: ['name'],
+			},
+			{
+				name: 'empty name',
+				request: { name: '', nodes: [], connections: {} },
+				expectedErrorPath: ['name'],
+			},
+			{
+				name: 'name too long',
+				request: { name: 'a'.repeat(129), nodes: [], connections: {} },
+				expectedErrorPath: ['name'],
+			},
+			{
+				name: 'missing nodes',
+				request: { name: 'Test', connections: {} },
+				expectedErrorPath: ['nodes'],
+			},
+			{
+				name: 'missing connections',
+				request: { name: 'Test', nodes: [] },
+				expectedErrorPath: ['connections'],
+			},
+			{
+				name: 'connections as array',
+				request: { name: 'Test', nodes: [], connections: [] },
+				expectedErrorPath: ['connections'],
+			},
+			{
+				name: 'settings as array',
+				request: { name: 'Test', nodes: [], connections: {}, settings: [] },
+				expectedErrorPath: ['settings'],
+			},
+			{
+				name: 'staticData as array',
+				request: { name: 'Test', nodes: [], connections: {}, staticData: [] },
+				expectedErrorPath: ['staticData'],
+			},
+			{
+				name: 'pinData as array',
+				request: { name: 'Test', nodes: [], connections: {}, pinData: [] },
+				expectedErrorPath: ['pinData'],
+			},
+		])('should fail validation for $name', ({ request, expectedErrorPath }) => {
+			const result = CreateWorkflowDto.safeParse(request);
+			expect(result.success).toBe(false);
+			if (expectedErrorPath) {
+				expect(result.error?.issues[0].path).toEqual(expectedErrorPath);
+			}
+		});
+	});
+
+	describe('Security: Mass assignment protection', () => {
+		describe('Activation fields', () => {
+			test('should not accept active field', () => {
+				const result = CreateWorkflowDto.safeParse({
+					name: 'Test',
+					nodes: [],
+					connections: {},
+					active: true,
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.data).not.toHaveProperty('active');
+			});
+
+			test('should not accept activeVersionId field', () => {
+				const result = CreateWorkflowDto.safeParse({
+					name: 'Test',
+					nodes: [],
+					connections: {},
+					activeVersionId: 'version123',
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.data).not.toHaveProperty('activeVersionId');
+			});
+
+			test('should not accept activeVersion field', () => {
+				const result = CreateWorkflowDto.safeParse({
+					name: 'Test',
+					nodes: [],
+					connections: {},
+					activeVersion: { versionId: 'v1', workflowId: 'w1' },
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.data).not.toHaveProperty('activeVersion');
+			});
+		});
+
+		describe('Sharing and permissions', () => {
+			test('should not accept shared field', () => {
+				const result = CreateWorkflowDto.safeParse({
+					name: 'Test',
+					nodes: [],
+					connections: {},
+					shared: [{ role: 'owner' }],
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.data).not.toHaveProperty('shared');
+			});
+
+			test('should not accept sharedWithProjects field', () => {
+				const result = CreateWorkflowDto.safeParse({
+					name: 'Test',
+					nodes: [],
+					connections: {},
+					sharedWithProjects: [{ id: 'proj1', name: 'Project' }],
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.data).not.toHaveProperty('sharedWithProjects');
+			});
+
+			test('should not accept homeProject field', () => {
+				const result = CreateWorkflowDto.safeParse({
+					name: 'Test',
+					nodes: [],
+					connections: {},
+					homeProject: { id: 'proj1', name: 'Project' },
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.data).not.toHaveProperty('homeProject');
+			});
+		});
+
+		describe('Internal counters and metadata', () => {
+			test('should not accept triggerCount field (billing bypass)', () => {
+				const result = CreateWorkflowDto.safeParse({
+					name: 'Test',
+					nodes: [],
+					connections: {},
+					triggerCount: 999,
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.data).not.toHaveProperty('triggerCount');
+			});
+
+			test('should not accept versionCounter field', () => {
+				const result = CreateWorkflowDto.safeParse({
+					name: 'Test',
+					nodes: [],
+					connections: {},
+					versionCounter: 100,
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.data).not.toHaveProperty('versionCounter');
+			});
+
+			test('should not accept versionId field', () => {
+				const result = CreateWorkflowDto.safeParse({
+					name: 'Test',
+					nodes: [],
+					connections: {},
+					versionId: 'custom-version-id',
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.data).not.toHaveProperty('versionId');
+			});
+
+			test('should not accept isArchived field', () => {
+				const result = CreateWorkflowDto.safeParse({
+					name: 'Test',
+					nodes: [],
+					connections: {},
+					isArchived: true,
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.data).not.toHaveProperty('isArchived');
+			});
+		});
+
+		describe('Timestamps', () => {
+			test('should not accept createdAt field', () => {
+				const result = CreateWorkflowDto.safeParse({
+					name: 'Test',
+					nodes: [],
+					connections: {},
+					createdAt: new Date().toISOString(),
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.data).not.toHaveProperty('createdAt');
+			});
+
+			test('should not accept updatedAt field', () => {
+				const result = CreateWorkflowDto.safeParse({
+					name: 'Test',
+					nodes: [],
+					connections: {},
+					updatedAt: new Date().toISOString(),
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.data).not.toHaveProperty('updatedAt');
+			});
+		});
+
+		describe('Multiple malicious fields at once', () => {
+			test('should strip all internal fields when multiple are provided', () => {
+				const result = CreateWorkflowDto.safeParse({
+					name: 'Test',
+					nodes: [],
+					connections: {},
+					active: true,
+					activeVersionId: 'v1',
+					triggerCount: 999,
+					versionCounter: 100,
+					isArchived: true,
+					shared: [{ role: 'owner' }],
+					createdAt: new Date().toISOString(),
+					updatedAt: new Date().toISOString(),
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.data).not.toHaveProperty('active');
+				expect(result.data).not.toHaveProperty('activeVersionId');
+				expect(result.data).not.toHaveProperty('triggerCount');
+				expect(result.data).not.toHaveProperty('versionCounter');
+				expect(result.data).not.toHaveProperty('isArchived');
+				expect(result.data).not.toHaveProperty('shared');
+				expect(result.data).not.toHaveProperty('createdAt');
+				expect(result.data).not.toHaveProperty('updatedAt');
+				// Valid fields should remain
+				expect(result.data?.name).toBe('Test');
+				expect(result.data?.nodes).toEqual([]);
+				expect(result.data?.connections).toEqual({});
+			});
+		});
+	});
+});

--- a/packages/@n8n/api-types/src/dto/workflows/__tests__/update-workflow.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/__tests__/update-workflow.dto.test.ts
@@ -1,0 +1,273 @@
+import { UpdateWorkflowDto } from '../update-workflow.dto';
+
+describe('UpdateWorkflowDto', () => {
+	describe('Valid requests', () => {
+		test.each([
+			{
+				name: 'empty update',
+				request: {},
+			},
+			{
+				name: 'update name only',
+				request: { name: 'Updated Name' },
+			},
+			{
+				name: 'update nodes and connections',
+				request: {
+					nodes: [{ id: 'node1', name: 'Node', type: 'test', position: [0, 0], parameters: {} }],
+					connections: { node1: { main: [[]] } },
+				},
+			},
+			{
+				name: 'update tags as strings',
+				request: { tags: ['tag1', 'tag2'] },
+			},
+			{
+				name: 'update tags as objects',
+				request: {
+					tags: [
+						{ id: 'tag1', name: 'Tag 1' },
+						{ id: 'tag2', name: 'Tag 2' },
+					],
+				},
+			},
+			{
+				name: 'update multiple fields',
+				request: {
+					name: 'Updated Workflow',
+					description: 'Updated description',
+					settings: { saveExecutionProgress: false },
+					meta: { version: '2.0' },
+				},
+			},
+		])('should validate $name', ({ request }) => {
+			const result = UpdateWorkflowDto.safeParse(request);
+			expect(result.success).toBe(true);
+		});
+
+		test('should transform tags from objects to string array', () => {
+			const result = UpdateWorkflowDto.safeParse({
+				tags: [
+					{ id: 'tag1', name: 'Tag 1' },
+					{ id: 'tag2', name: 'Tag 2' },
+				],
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.data?.tags).toEqual(['tag1', 'tag2']);
+		});
+	});
+
+	describe('Invalid requests', () => {
+		test.each([
+			{
+				name: 'empty name',
+				request: { name: '' },
+				expectedErrorPath: ['name'],
+			},
+			{
+				name: 'name too long',
+				request: { name: 'a'.repeat(129) },
+				expectedErrorPath: ['name'],
+			},
+			{
+				name: 'invalid nodes type',
+				request: { nodes: 'not-an-array' },
+				expectedErrorPath: ['nodes'],
+			},
+			{
+				name: 'invalid connections type',
+				request: { connections: 'not-an-object' },
+				expectedErrorPath: ['connections'],
+			},
+			{
+				name: 'connections as array',
+				request: { connections: [] },
+				expectedErrorPath: ['connections'],
+			},
+			{
+				name: 'settings as array',
+				request: { settings: [] },
+				expectedErrorPath: ['settings'],
+			},
+			{
+				name: 'staticData as array',
+				request: { staticData: [] },
+				expectedErrorPath: ['staticData'],
+			},
+			{
+				name: 'pinData as array',
+				request: { pinData: [] },
+				expectedErrorPath: ['pinData'],
+			},
+		])('should fail validation for $name', ({ request, expectedErrorPath }) => {
+			const result = UpdateWorkflowDto.safeParse(request);
+			expect(result.success).toBe(false);
+			if (expectedErrorPath) {
+				expect(result.error?.issues[0].path).toEqual(expectedErrorPath);
+			}
+		});
+	});
+
+	describe('Security: Mass assignment protection', () => {
+		describe('Internal counters and metadata', () => {
+			test('should not accept triggerCount field (billing bypass)', () => {
+				const result = UpdateWorkflowDto.safeParse({
+					name: 'Updated',
+					triggerCount: 999,
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.data).not.toHaveProperty('triggerCount');
+			});
+
+			test('should not accept versionCounter field', () => {
+				const result = UpdateWorkflowDto.safeParse({
+					name: 'Updated',
+					versionCounter: 100,
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.data).not.toHaveProperty('versionCounter');
+			});
+
+			test('should not accept versionId field', () => {
+				const result = UpdateWorkflowDto.safeParse({
+					name: 'Updated',
+					versionId: 'custom-version-id',
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.data).not.toHaveProperty('versionId');
+			});
+
+			test('should not accept isArchived field', () => {
+				const result = UpdateWorkflowDto.safeParse({
+					name: 'Updated',
+					isArchived: true,
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.data).not.toHaveProperty('isArchived');
+			});
+		});
+
+		describe('Activation fields', () => {
+			test('should not accept active field', () => {
+				const result = UpdateWorkflowDto.safeParse({
+					name: 'Updated',
+					active: true,
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.data).not.toHaveProperty('active');
+			});
+
+			test('should not accept activeVersionId field', () => {
+				const result = UpdateWorkflowDto.safeParse({
+					name: 'Updated',
+					activeVersionId: 'version123',
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.data).not.toHaveProperty('activeVersionId');
+			});
+
+			test('should not accept activeVersion field', () => {
+				const result = UpdateWorkflowDto.safeParse({
+					name: 'Updated',
+					activeVersion: { versionId: 'v1', workflowId: 'w1' },
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.data).not.toHaveProperty('activeVersion');
+			});
+		});
+
+		describe('Sharing and permissions', () => {
+			test('should not accept shared field', () => {
+				const result = UpdateWorkflowDto.safeParse({
+					name: 'Updated',
+					shared: [{ role: 'owner' }],
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.data).not.toHaveProperty('shared');
+			});
+
+			test('should not accept projectId field', () => {
+				const result = UpdateWorkflowDto.safeParse({
+					name: 'Updated',
+					projectId: 'malicious-project-id',
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.data).not.toHaveProperty('projectId');
+			});
+
+			test('should not accept id field', () => {
+				const result = UpdateWorkflowDto.safeParse({
+					name: 'Updated',
+					id: 'malicious-id',
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.data).not.toHaveProperty('id');
+			});
+		});
+
+		describe('Timestamps', () => {
+			test('should not accept createdAt field', () => {
+				const result = UpdateWorkflowDto.safeParse({
+					name: 'Updated',
+					createdAt: new Date().toISOString(),
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.data).not.toHaveProperty('createdAt');
+			});
+
+			test('should not accept updatedAt field', () => {
+				const result = UpdateWorkflowDto.safeParse({
+					name: 'Updated',
+					updatedAt: new Date().toISOString(),
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.data).not.toHaveProperty('updatedAt');
+			});
+		});
+
+		describe('Multiple malicious fields at once', () => {
+			test('should strip all internal fields when multiple are provided', () => {
+				const result = UpdateWorkflowDto.safeParse({
+					name: 'Updated',
+					active: true,
+					activeVersionId: 'v1',
+					triggerCount: 999,
+					versionCounter: 100,
+					isArchived: true,
+					shared: [{ role: 'owner' }],
+					projectId: 'malicious-project',
+					id: 'malicious-id',
+					createdAt: new Date().toISOString(),
+					updatedAt: new Date().toISOString(),
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.data).not.toHaveProperty('active');
+				expect(result.data).not.toHaveProperty('activeVersionId');
+				expect(result.data).not.toHaveProperty('triggerCount');
+				expect(result.data).not.toHaveProperty('versionCounter');
+				expect(result.data).not.toHaveProperty('isArchived');
+				expect(result.data).not.toHaveProperty('shared');
+				expect(result.data).not.toHaveProperty('projectId');
+				expect(result.data).not.toHaveProperty('id');
+				expect(result.data).not.toHaveProperty('createdAt');
+				expect(result.data).not.toHaveProperty('updatedAt');
+				// Valid fields should remain
+				expect(result.data?.name).toBe('Updated');
+			});
+		});
+	});
+});

--- a/packages/@n8n/api-types/src/dto/workflows/base-workflow.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/base-workflow.dto.ts
@@ -77,7 +77,7 @@ export const baseWorkflowShape = {
 
 	// Folder organization
 	parentFolderId: z.string().optional(),
-	parentFolder: z.object({ id: z.string(), name: z.string() }).optional(),
+	parentFolder: z.object({ id: z.string(), name: z.string() }).nullable().optional(),
 
 	// Tags
 	tags: z

--- a/packages/@n8n/api-types/src/dto/workflows/base-workflow.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/base-workflow.dto.ts
@@ -79,7 +79,17 @@ export const baseWorkflowShape = {
 	parentFolderId: z.string().optional(),
 
 	// Tags
-	tags: z.array(z.string()).optional(),
+	tags: z
+		// Accept either array of tag IDs (strings) or array of tag objects ({ id, name }) for backwards compatibility
+		.union([z.array(z.string()), z.array(z.object({ id: z.string(), name: z.string() }))])
+		.transform((val): string[] => {
+			// If array of objects, extract just the ids
+			if (val.length > 0 && typeof val[0] === 'object' && 'id' in val[0]) {
+				return (val as Array<{ id: string; name: string }>).map((tag) => tag.id);
+			}
+			return val as string[];
+		})
+		.optional(),
 
 	// UI context and builder metadata
 	uiContext: z.string().optional(),

--- a/packages/@n8n/api-types/src/dto/workflows/base-workflow.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/base-workflow.dto.ts
@@ -77,6 +77,7 @@ export const baseWorkflowShape = {
 
 	// Folder organization
 	parentFolderId: z.string().optional(),
+	parentFolder: z.object({ id: z.string(), name: z.string() }).optional(),
 
 	// Tags
 	tags: z

--- a/packages/@n8n/api-types/src/dto/workflows/base-workflow.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/base-workflow.dto.ts
@@ -1,0 +1,91 @@
+import type { IPinData, IConnections, IDataObject, INode, IWorkflowSettings } from 'n8n-workflow';
+import { z } from 'zod';
+
+export const WORKFLOW_NAME_MAX_LENGTH = 128;
+
+export const workflowNameSchema = z
+	.string()
+	.min(1, { message: 'Workflow name is required' })
+	.max(WORKFLOW_NAME_MAX_LENGTH, {
+		message: `Workflow name must be ${WORKFLOW_NAME_MAX_LENGTH} characters or less`,
+	});
+
+export const workflowDescriptionSchema = z.string().nullable();
+
+// Use z.custom() with type predicates for better type safety
+export const workflowNodesSchema = z.custom<INode[]>((val) => Array.isArray(val), {
+	message: 'Nodes must be an array',
+});
+
+export const workflowConnectionsSchema = z.custom<IConnections>(
+	(val) => typeof val === 'object' && val !== null,
+	{
+		message: 'Connections must be an object',
+	},
+);
+
+export const workflowSettingsSchema = z.custom<IWorkflowSettings>(
+	(val) => val === null || (typeof val === 'object' && val !== null),
+	{
+		message: 'Settings must be an object or null',
+	},
+);
+
+export const workflowStaticDataSchema = z.preprocess(
+	(val) => {
+		// If it's a string, try to parse it as JSON
+		if (typeof val === 'string') {
+			try {
+				return JSON.parse(val);
+			} catch {
+				throw new Error('Static data string must be valid JSON');
+			}
+		}
+		return val;
+	},
+	z.custom<IDataObject | null>((val) => val === null || (typeof val === 'object' && val !== null), {
+		message: 'Static data must be an object or null',
+	}),
+);
+
+// Pin data is a record of node names to their pinned execution data
+export const workflowPinDataSchema = z.custom<IPinData | null>(
+	(val) => val === null || (typeof val === 'object' && val !== null),
+	{
+		message: 'Pin data must be an object or null',
+	},
+);
+
+export const workflowMetaSchema = z.record(z.string(), z.unknown()).nullable();
+
+/**
+ * Base workflow shape containing fields shared between Create and Update DTOs.
+ */
+export const baseWorkflowShape = {
+	// Core workflow data
+	name: workflowNameSchema,
+	description: workflowDescriptionSchema.optional(),
+	nodes: workflowNodesSchema,
+	connections: workflowConnectionsSchema,
+
+	// Optional workflow configuration
+	settings: workflowSettingsSchema.optional(),
+	staticData: workflowStaticDataSchema.optional(),
+	meta: workflowMetaSchema.optional(),
+	pinData: workflowPinDataSchema.optional(),
+	hash: z.string().optional(),
+
+	// Folder organization
+	parentFolderId: z.string().optional(),
+
+	// Tags
+	tags: z.array(z.string()).optional(),
+
+	// UI context and builder metadata
+	uiContext: z.string().optional(),
+	aiBuilderAssisted: z.boolean().optional(),
+
+	// Version control
+	expectedChecksum: z.string().optional(),
+	autosaved: z.boolean().optional(),
+} as const;

--- a/packages/@n8n/api-types/src/dto/workflows/base-workflow.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/base-workflow.dto.ts
@@ -18,14 +18,14 @@ export const workflowNodesSchema = z.custom<INode[]>((val) => Array.isArray(val)
 });
 
 export const workflowConnectionsSchema = z.custom<IConnections>(
-	(val) => typeof val === 'object' && val !== null,
+	(val) => typeof val === 'object' && val !== null && !Array.isArray(val),
 	{
 		message: 'Connections must be an object',
 	},
 );
 
 export const workflowSettingsSchema = z.custom<IWorkflowSettings>(
-	(val) => val === null || (typeof val === 'object' && val !== null),
+	(val) => val === null || (typeof val === 'object' && val !== null && !Array.isArray(val)),
 	{
 		message: 'Settings must be an object or null',
 	},
@@ -43,14 +43,17 @@ export const workflowStaticDataSchema = z.preprocess(
 		}
 		return val;
 	},
-	z.custom<IDataObject | null>((val) => val === null || (typeof val === 'object' && val !== null), {
-		message: 'Static data must be an object or null',
-	}),
+	z.custom<IDataObject | null>(
+		(val) => val === null || (typeof val === 'object' && val !== null && !Array.isArray(val)),
+		{
+			message: 'Static data must be an object or null',
+		},
+	),
 );
 
 // Pin data is a record of node names to their pinned execution data
 export const workflowPinDataSchema = z.custom<IPinData | null>(
-	(val) => val === null || (typeof val === 'object' && val !== null),
+	(val) => val === null || (typeof val === 'object' && val !== null && !Array.isArray(val)),
 	{
 		message: 'Pin data must be an object or null',
 	},

--- a/packages/@n8n/api-types/src/dto/workflows/create-workflow.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/create-workflow.dto.ts
@@ -16,16 +16,4 @@ export class CreateWorkflowDto extends Z.class({
 
 	// Project assignment (only on creation)
 	projectId: z.string().optional(),
-
-	// SECURITY: These fields are included to accept them from the request body but are
-	// always overridden in the controller to enforce security policies:
-	// - active is always set to false (workflows must be activated via separate endpoint)
-	// - activeVersionId is always set to null (managed by the system)
-	active: z.boolean().optional(),
-	activeVersionId: z.string().nullable().optional(),
-	activeVersion: z.unknown().optional(),
-
-	// Shared property for backward compatibility in case UI sends it
-	// but it is discarded creation
-	shared: z.unknown().optional(),
 }) {}

--- a/packages/@n8n/api-types/src/dto/workflows/create-workflow.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/create-workflow.dto.ts
@@ -21,7 +21,7 @@ export class CreateWorkflowDto extends Z.class({
 	// always overridden in the controller to enforce security policies:
 	// - active is always set to false (workflows must be activated via separate endpoint)
 	// - activeVersionId is always set to null (managed by the system)
-	active: z.boolean().optional().default(false),
+	active: z.boolean().optional(),
 	activeVersionId: z.string().nullable().optional(),
 	activeVersion: z.unknown().optional(),
 

--- a/packages/@n8n/api-types/src/dto/workflows/create-workflow.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/create-workflow.dto.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+import { Z } from 'zod-class';
+
+import { baseWorkflowShape } from './base-workflow.dto';
+
+export const workflowIdSchema = z.string();
+
+export class CreateWorkflowDto extends Z.class({
+	// Spread base fields (name, nodes, connections, settings, etc.)
+	...baseWorkflowShape,
+
+	// Create-specific fields:
+
+	// Optional ID - if provided, must not already exist (validated in controller)
+	id: workflowIdSchema.optional(),
+
+	// Project assignment (only on creation)
+	projectId: z.string().optional(),
+
+	// SECURITY: These fields are included to accept them from the request body but are
+	// always overridden in the controller to enforce security policies:
+	// - active is always set to false (workflows must be activated via separate endpoint)
+	// - activeVersionId is always set to null (managed by the system)
+	active: z.boolean().optional().default(false),
+	activeVersionId: z.string().nullable().optional(),
+	activeVersion: z.unknown().optional(),
+
+	// Shared property for backward compatibility in case UI sends it
+	// but it is discarded creation
+	shared: z.unknown().optional(),
+}) {}

--- a/packages/@n8n/api-types/src/dto/workflows/update-workflow.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/update-workflow.dto.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+import { Z } from 'zod-class';
+
+import { baseWorkflowShape } from './base-workflow.dto';
+
+export class UpdateWorkflowDto extends Z.class(
+	// Make all base fields optional for partial updates
+	z.object(baseWorkflowShape).partial().shape,
+) {}

--- a/packages/cli/src/workflows/__tests__/workflows.controller.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflows.controller.test.ts
@@ -1,22 +1,26 @@
-import type { ImportWorkflowFromUrlDto } from '@n8n/api-types';
+import type { CreateWorkflowDto, ImportWorkflowFromUrlDto } from '@n8n/api-types';
 import type { Logger } from '@n8n/backend-common';
-import type { AuthenticatedRequest, IExecutionResponse, CredentialsEntity, User } from '@n8n/db';
 import { WorkflowEntity } from '@n8n/db';
-import type { WorkflowRepository } from '@n8n/db';
+import type {
+	AuthenticatedRequest,
+	IExecutionResponse,
+	CredentialsEntity,
+	User,
+	WorkflowRepository,
+} from '@n8n/db';
 import axios from 'axios';
 import type { Response } from 'express';
 import { mock } from 'jest-mock-extended';
 
+import { WorkflowsController } from '../workflows.controller';
+
+import type { CredentialsService } from '@/credentials/credentials.service';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import type { ExecutionService } from '@/executions/execution.service';
-import type { CredentialsService } from '@/credentials/credentials.service';
-import type { EnterpriseWorkflowService } from '@/workflows/workflow.service.ee';
 import type { License } from '@/license';
-import type { WorkflowRequest } from '../workflow.request';
 import type { ProjectService } from '@/services/project.service.ee';
-
-import { WorkflowsController } from '../workflows.controller';
+import type { EnterpriseWorkflowService } from '@/workflows/workflow.service.ee';
 
 jest.mock('axios');
 
@@ -190,13 +194,13 @@ describe('WorkflowsController', () => {
 				 * Arrange
 				 */
 				const mockUser = mock<User>({ id: 'user-123' });
-				const mockRequest = mock<WorkflowRequest.Create>({
+				const mockBody: CreateWorkflowDto = {
+					name: 'Test Workflow',
+					nodes: [],
+					connections: {},
+				};
+				const mockRequest = mock<AuthenticatedRequest>({
 					user: mockUser,
-					body: {
-						name: 'Test Workflow',
-						nodes: [],
-						connections: {},
-					},
 				});
 
 				const mockGlobalCredential = mock<CredentialsEntity>({
@@ -243,7 +247,9 @@ describe('WorkflowsController', () => {
 				/**
 				 * Act & Assert
 				 */
-				await expect(controller.create(mockRequest)).rejects.toThrow(BadRequestError);
+				await expect(controller.create(mockRequest, res, mockBody)).rejects.toThrow(
+					BadRequestError,
+				);
 
 				/**
 				 * Assert - Verify credentials were fetched with includeGlobal: true
@@ -262,13 +268,13 @@ describe('WorkflowsController', () => {
 				 * Arrange
 				 */
 				const mockUser = mock<User>({ id: 'user-123' });
-				const mockRequest = mock<WorkflowRequest.Create>({
+				const mockBody: CreateWorkflowDto = {
+					name: 'Test Workflow',
+					nodes: [],
+					connections: {},
+				};
+				const mockRequest = mock<AuthenticatedRequest>({
 					user: mockUser,
-					body: {
-						name: 'Test Workflow',
-						nodes: [],
-						connections: {},
-					},
 				});
 
 				const mockGlobalCredential = mock<CredentialsEntity>({
@@ -303,8 +309,10 @@ describe('WorkflowsController', () => {
 				/**
 				 * Act & Assert
 				 */
-				await expect(controller.create(mockRequest)).rejects.toThrow(BadRequestError);
-				await expect(controller.create(mockRequest)).rejects.toThrow(
+				await expect(controller.create(mockRequest, res, mockBody)).rejects.toThrow(
+					BadRequestError,
+				);
+				await expect(controller.create(mockRequest, res, mockBody)).rejects.toThrow(
 					'The workflow you are trying to save contains credentials that are not shared with you',
 				);
 

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -104,21 +104,6 @@ export class WorkflowsController {
 				throw new BadRequestError(`Workflow with id ${body.id} exists already.`);
 			}
 		}
-		// We shouldn't accept this because it can
-		// mess with relations of other workflows
-		delete body.shared;
-
-		// Warn if user attempts to create an active workflow
-		if (body.activeVersionId || body.active) {
-			this.logger.warn(
-				'Creating a workflow as active is not supported. The workflow will be created as inactive.',
-				{ userId: req.user.id },
-			);
-
-			// Discard active fields
-			delete body.activeVersionId;
-			delete body.activeVersion;
-		}
 
 		const { autosaved = false } = body;
 

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -1,8 +1,10 @@
 import {
 	ActivateWorkflowDto,
+	CreateWorkflowDto,
 	ImportWorkflowFromUrlDto,
 	ROLE,
 	TransferWorkflowBodyDto,
+	UpdateWorkflowDto,
 } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
@@ -38,6 +40,14 @@ import express from 'express';
 import { UnexpectedError, calculateWorkflowChecksum } from 'n8n-workflow';
 import { v4 as uuid } from 'uuid';
 
+import { WorkflowExecutionService } from './workflow-execution.service';
+import { WorkflowFinderService } from './workflow-finder.service';
+import { WorkflowHistoryService } from './workflow-history/workflow-history.service';
+import { WorkflowRequest } from './workflow.request';
+import { WorkflowService } from './workflow.service';
+import { EnterpriseWorkflowService } from './workflow.service.ee';
+import { CredentialsService } from '../credentials/credentials.service';
+
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { InternalServerError } from '@/errors/response-errors/internal-server.error';
@@ -49,6 +59,7 @@ import { validateEntity } from '@/generic-helpers';
 import type { IWorkflowResponse } from '@/interfaces';
 import { License } from '@/license';
 import { listQueryMiddleware } from '@/middlewares';
+import { userHasScopes } from '@/permissions.ee/check-access';
 import * as ResponseHelper from '@/response-helper';
 import { FolderService } from '@/services/folder.service';
 import { NamingService } from '@/services/naming.service';
@@ -57,15 +68,6 @@ import { TagService } from '@/services/tag.service';
 import { UserManagementMailer } from '@/user-management/email';
 import * as utils from '@/utils';
 import * as WorkflowHelpers from '@/workflow-helpers';
-import { userHasScopes } from '@/permissions.ee/check-access';
-
-import { WorkflowExecutionService } from './workflow-execution.service';
-import { WorkflowFinderService } from './workflow-finder.service';
-import { WorkflowHistoryService } from './workflow-history/workflow-history.service';
-import { WorkflowRequest } from './workflow.request';
-import { WorkflowService } from './workflow.service';
-import { EnterpriseWorkflowService } from './workflow.service.ee';
-import { CredentialsService } from '../credentials/credentials.service';
 
 @RestController('/workflows')
 export class WorkflowsController {
@@ -95,36 +97,38 @@ export class WorkflowsController {
 	) {}
 
 	@Post('/')
-	async create(req: WorkflowRequest.Create) {
-		if (req.body.id) {
-			const workflowExists = await this.workflowRepository.existsBy({ id: req.body.id });
+	async create(req: AuthenticatedRequest, _res: unknown, @Body body: CreateWorkflowDto) {
+		if (body.id) {
+			const workflowExists = await this.workflowRepository.existsBy({ id: body.id });
 			if (workflowExists) {
-				throw new BadRequestError(`Workflow with id ${req.body.id} exists already.`);
+				throw new BadRequestError(`Workflow with id ${body.id} exists already.`);
 			}
 		}
-		// @ts-expect-error: We shouldn't accept this because it can
+		// We shouldn't accept this because it can
 		// mess with relations of other workflows
-		delete req.body.shared;
+		delete body.shared;
 
-		// @ts-expect-error: We shouldn't accept this, this will be set when activating
-		if (req.body.activeVersionId || req.body.active) {
+		// Warn if user attempts to create an active workflow
+		if (body.activeVersionId || body.active) {
 			this.logger.warn(
 				'Creating a workflow as active is not supported. The workflow will be created as inactive.',
 				{ userId: req.user.id },
 			);
 
-			// @ts-expect-error: We shouldn't accept this
-			delete req.body.activeVersionId;
-			// @ts-expect-error: We shouldn't accept this
-			delete req.body.activeVersion;
-			req.body.active = false;
+			// Discard active fields
+			delete body.activeVersionId;
+			delete body.activeVersion;
+			body.active = false;
 		}
 
-		const { autosaved = false } = req.body;
+		const { autosaved = false } = body;
 
 		const newWorkflow = new WorkflowEntity();
 
-		Object.assign(newWorkflow, req.body);
+		// Security: Object.assign is now safe because the DTO validates and filters all input
+		// Only fields defined in CreateWorkflowDto are assigned; internal fields like
+		// triggerCount, versionCounter, isArchived, etc. are never set from user input
+		Object.assign(newWorkflow, body);
 
 		newWorkflow.versionId = uuid();
 
@@ -132,7 +136,7 @@ export class WorkflowsController {
 
 		await this.externalHooks.run('workflow.create', [newWorkflow]);
 
-		const { tags: tagIds } = req.body;
+		const { tags: tagIds } = body;
 
 		if (tagIds?.length && !this.globalConfig.tags.disabled) {
 			newWorkflow.tags = await this.tagRepository.findMany(tagIds);
@@ -166,8 +170,8 @@ export class WorkflowsController {
 
 		let project: Project | null = null;
 		const savedWorkflow = await dbManager.transaction(async (transactionManager) => {
-			const { parentFolderId } = req.body;
-			let { projectId } = req.body;
+			const { parentFolderId } = body;
+			let { projectId } = body;
 
 			if (projectId === undefined) {
 				const personalProject = await this.projectRepository.getPersonalProjectForUserOrFail(
@@ -259,7 +263,7 @@ export class WorkflowsController {
 			publicApi: false,
 			projectId: project!.id,
 			projectType: project!.type,
-			uiContext: req.body.uiContext,
+			uiContext: body.uiContext,
 		});
 
 		const scopes = await this.workflowService.getWorkflowScopes(req.user, savedWorkflow.id);
@@ -440,22 +444,28 @@ export class WorkflowsController {
 
 	@Patch('/:workflowId')
 	@ProjectScope('workflow:update')
-	async update(req: WorkflowRequest.Update) {
-		const { workflowId } = req.params;
+	async update(
+		req: WorkflowRequest.Update,
+		_res: unknown,
+		@Param('workflowId') workflowId: string,
+		@Body body: UpdateWorkflowDto,
+	) {
 		const forceSave = req.query.forceSave === 'true';
 
 		let updateData = new WorkflowEntity();
-		const { tags, parentFolderId, aiBuilderAssisted, expectedChecksum, autosaved, ...rest } =
-			req.body;
+		const { tags, parentFolderId, aiBuilderAssisted, expectedChecksum, autosaved, ...rest } = body;
 
-		// TODO: Add zod validation for entire `rest` object before assigning to `updateData`
+		// Validate timeSavedMode if present
 		if (
-			rest.settings?.timeSavedMode !== undefined &&
-			!['fixed', 'dynamic'].includes(rest.settings.timeSavedMode)
+			body.settings?.timeSavedMode !== undefined &&
+			!['fixed', 'dynamic'].includes(body.settings.timeSavedMode)
 		) {
 			throw new BadRequestError('Invalid timeSavedMode');
 		}
 
+		// Security: Object.assign is now safe because the DTO validates and filters all input
+		// Only fields defined in UpdateWorkflowDto are assigned; internal fields like
+		// triggerCount, versionCounter, isArchived, active, activeVersionId, etc. are never set from user input
 		Object.assign(updateData, rest);
 
 		const isSharingEnabled = this.license.isSharingEnabled();

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -118,7 +118,6 @@ export class WorkflowsController {
 			// Discard active fields
 			delete body.activeVersionId;
 			delete body.activeVersion;
-			body.active = false;
 		}
 
 		const { autosaved = false } = body;
@@ -130,6 +129,8 @@ export class WorkflowsController {
 		// triggerCount, versionCounter, isArchived, etc. are never set from user input
 		Object.assign(newWorkflow, body);
 
+		// Ensure workflow is created as inactive
+		newWorkflow.active = false;
 		newWorkflow.versionId = uuid();
 
 		await validateEntity(newWorkflow);


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR implements new DTOs for workflow creation and update, to make sure that user cannot forge a request containing fields that should be updated only internally (like triggerCount, versionCounter, or shared fields)

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-4382/mass-assignment-in-workflow-creation-allows-tampering-with-internal

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
