### PR TITLE
test: Skip source control flakey tests

### DIFF
--- a/packages/testing/playwright/tests/e2e/settings/environments/source-control.spec.ts
+++ b/packages/testing/playwright/tests/e2e/settings/environments/source-control.spec.ts
@@ -17,7 +17,9 @@ async function saveSettings(n8n: n8nPage) {
 	);
 }
 
-test.describe('Source Control Settings @capability:source-control', () => {
+// Skipped: These tests are flaky. Re-enable when PAY-4365 is resolved.
+// https://linear.app/n8n/issue/PAY-4365/bug-source-control-operations-fail-in-multi-main-deployment
+test.describe.skip('Source Control Settings @capability:source-control', () => {
 	let repoUrl: string;
 	let repoName: string;
 

--- a/packages/testing/playwright/tests/e2e/source-control/pull.spec.ts
+++ b/packages/testing/playwright/tests/e2e/source-control/pull.spec.ts
@@ -11,7 +11,7 @@ async function expectPullSuccess(n8n: n8nPage) {
 	).toBe(true);
 }
 
-test.describe('Pull resources from Git @capability:source-control', () => {
+test.describe.skip('Pull resources from Git @capability:source-control', () => {
 	let repoUrl: string;
 
 	test.beforeEach(async ({ n8n, n8nContainer }) => {

--- a/packages/testing/playwright/tests/e2e/source-control/pull.spec.ts
+++ b/packages/testing/playwright/tests/e2e/source-control/pull.spec.ts
@@ -11,6 +11,8 @@ async function expectPullSuccess(n8n: n8nPage) {
 	).toBe(true);
 }
 
+// Skipped: These tests are flaky. Re-enable when PAY-4365 is resolved.
+// https://linear.app/n8n/issue/PAY-4365/bug-source-control-operations-fail-in-multi-main-deployment
 test.describe.skip('Pull resources from Git @capability:source-control', () => {
 	let repoUrl: string;
 

--- a/packages/testing/playwright/tests/e2e/source-control/push.spec.ts
+++ b/packages/testing/playwright/tests/e2e/source-control/push.spec.ts
@@ -17,7 +17,9 @@ async function expectNoChangesToCommit(n8n: n8nPage) {
 	).toBe(true);
 }
 
-test.describe('Push resources to Git @capability:source-control', () => {
+// Skipped: These tests are flaky. Re-enable when PAY-4365 is resolved.
+// https://linear.app/n8n/issue/PAY-4365/bug-source-control-operations-fail-in-multi-main-deployment
+test.describe.skip('Push resources to Git @capability:source-control', () => {
 	test.beforeEach(async ({ n8n, n8nContainer }) => {
 		await n8n.api.enableFeature('sourceControl');
 		await n8n.api.enableFeature('variables');


### PR DESCRIPTION
## Summary

Skipping the source-control tests because they are flakey. This is most likely due to the fact that in multi-main only the node used to connect works.

There is a follow-up [ticket](https://linear.app/n8n/issue/PAY-4395/restore-sourcecontrol-playwright-tests) to restore those tests: 

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
