### PR TITLE
feat(Pipedrive Node): Allow setting source channel and source channel ID when creating and updating leads

### DIFF
--- a/packages/nodes-base/nodes/Pipedrive/v1/PipedriveV1.node.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v1/PipedriveV1.node.ts
@@ -2232,6 +2232,24 @@ const versionDescription: INodeTypeDescription = {
 					},
 				},
 				{
+					displayName: 'Source Channel Name or ID',
+					name: 'channel',
+					type: 'options',
+					typeOptions: {
+						loadOptionsMethod: 'getLeadChannels',
+					},
+					default: '',
+					description:
+						'ID of the marketing channel this lead was created from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+				},
+				{
+					displayName: 'Source Channel ID',
+					name: 'channel_id',
+					type: 'string',
+					default: '',
+					description: 'Optional ID to further distinguish the marketing channel',
+				},
+				{
 					displayName: 'Value',
 					name: 'value',
 					type: 'fixedCollection',
@@ -2367,6 +2385,24 @@ const versionDescription: INodeTypeDescription = {
 					default: '',
 					description:
 						'ID of the person to link to this lead. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+				},
+				{
+					displayName: 'Source Channel Name or ID',
+					name: 'channel',
+					type: 'options',
+					typeOptions: {
+						loadOptionsMethod: 'getLeadChannels',
+					},
+					default: '',
+					description:
+						'ID of the marketing channel this lead was created from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+				},
+				{
+					displayName: 'Source Channel ID',
+					name: 'channel_id',
+					type: 'string',
+					default: '',
+					description: 'Optional ID to further distinguish the marketing channel',
 				},
 				{
 					displayName: 'Value',
@@ -4066,6 +4102,27 @@ export class PipedriveV1 implements INodeType {
 				};
 
 				return sortOptionParameters(data.map(({ id, name }) => ({ value: id, name })));
+			},
+
+			// Get all the lead channels to display them to user so that they can
+			// select them easily
+			async getLeadChannels(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+				const returnData: INodePropertyOptions[] = [];
+				const { data } = await pipedriveApiRequest.call(this, 'GET', '/leadFields', {});
+				for (const field of data) {
+					if (field.key === 'channel') {
+						if (field.options) {
+							for (const option of field.options) {
+								returnData.push({
+									name: option.label,
+									value: option.id,
+								});
+							}
+						}
+					}
+				}
+
+				return sortOptionParameters(returnData);
 			},
 
 			// Get all the labels to display them to user so that they can

--- a/packages/nodes-base/nodes/Pipedrive/v2/actions/lead/create.operation.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/actions/lead/create.operation.ts
@@ -124,6 +124,24 @@ const properties: INodeProperties[] = [
 				},
 			},
 			{
+				displayName: 'Source Channel Name or ID',
+				name: 'channel',
+				type: 'options',
+				typeOptions: {
+					loadOptionsMethod: 'getLeadChannels',
+				},
+				default: '',
+				description:
+					'ID of the marketing channel this lead was created from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			},
+			{
+				displayName: 'Source Channel ID',
+				name: 'channel_id',
+				type: 'string',
+				default: '',
+				description: 'Optional ID to further distinguish the marketing channel',
+			},
+			{
 				displayName: 'Value',
 				name: 'value',
 				type: 'fixedCollection',

--- a/packages/nodes-base/nodes/Pipedrive/v2/actions/lead/update.operation.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/actions/lead/update.operation.ts
@@ -74,6 +74,24 @@ const properties: INodeProperties[] = [
 					'ID of the person to link to this lead. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 			},
 			{
+				displayName: 'Source Channel Name or ID',
+				name: 'channel',
+				type: 'options',
+				typeOptions: {
+					loadOptionsMethod: 'getLeadChannels',
+				},
+				default: '',
+				description:
+					'ID of the marketing channel this lead was created from. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			},
+			{
+				displayName: 'Source Channel ID',
+				name: 'channel_id',
+				type: 'string',
+				default: '',
+				description: 'Optional ID to further distinguish the marketing channel',
+			},
+			{
 				displayName: 'Title',
 				name: 'title',
 				type: 'string',

--- a/packages/nodes-base/nodes/Pipedrive/v2/methods/loadOptions.ts
+++ b/packages/nodes-base/nodes/Pipedrive/v2/methods/loadOptions.ts
@@ -223,6 +223,39 @@ export async function getLeadLabels(this: ILoadOptionsFunctions): Promise<INodeP
 	return sortOptionParameters(labels.map(({ id, name }) => ({ value: id, name })));
 }
 
+/**
+ * Get all lead channels
+ * Uses v1 endpoint: /leadFields
+ */
+export async function getLeadChannels(
+	this: ILoadOptionsFunctions,
+): Promise<INodePropertyOptions[]> {
+	const returnData: INodePropertyOptions[] = [];
+	const { data } = await pipedriveApiRequest.call(
+		this,
+		'GET',
+		'/leadFields',
+		{},
+		{},
+		{ apiVersion: 'v1' },
+	);
+	for (const field of data as Array<{
+		key: string;
+		options?: Array<{ id: number; label: string }>;
+	}>) {
+		if (field.key === 'channel' && field.options) {
+			for (const option of field.options) {
+				returnData.push({
+					name: option.label,
+					value: option.id,
+				});
+			}
+		}
+	}
+
+	return sortOptionParameters(returnData);
+}
+
 export async function getDealLabels(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 	return await getLabelsForResource.call(this, '/dealFields');
 }


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Allow setting source channel and source channel ID for Pipedrive leads during creation and update.
This functionality is currently missing from n8n.

<img width="448" height="833" alt="grafik" src="https://github.com/user-attachments/assets/f0462f2c-ca54-478c-bbe0-1f9c1785473a" />

<img width="457" height="822" alt="grafik" src="https://github.com/user-attachments/assets/a63cd9a7-4f61-4538-b8eb-0c57a48e69ef" />

In Pipedrive
<img width="535" height="409" alt="grafik" src="https://github.com/user-attachments/assets/e2e032ad-2c44-4128-84d6-1474d40e9bab" />



## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

None.


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
