### PR TITLE
ci: Backport GH workflow renames to 1.x branch

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -1,4 +1,4 @@
-name: Docker Base Image CI
+name: 'Build: Base Image'
 
 on:
   push:

--- a/.github/workflows/build-benchmark-image.yml
+++ b/.github/workflows/build-benchmark-image.yml
@@ -1,4 +1,4 @@
-name: Benchmark Docker Image CI
+name: 'Build: Benchmark Image'
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build-unit-test-pr-comment.yml
+++ b/.github/workflows/build-unit-test-pr-comment.yml
@@ -1,4 +1,4 @@
-name: Trigger build/unit tests on PR comment
+name: 'Build: Unit Test PR Comment'
 
 on:
   issue_comment:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,4 +1,4 @@
-name: Windows CI
+name: 'Build: Windows'
 
 on:
   workflow_dispatch:

--- a/.github/workflows/ci-check-eligibility-reusable.yml
+++ b/.github/workflows/ci-check-eligibility-reusable.yml
@@ -13,7 +13,7 @@
 #
 # It outputs `should_run` as 'true' if ALL conditions pass, 'false' otherwise.
 
-name: PR Eligibility Check
+name: 'CI: Check Eligibility'
 
 on:
   workflow_call:

--- a/.github/workflows/ci-check-pr-title.yml
+++ b/.github/workflows/ci-check-pr-title.yml
@@ -1,4 +1,4 @@
-name: Check PR title
+name: 'CI: Check PR Title'
 
 on:
   pull_request:

--- a/.github/workflows/ci-manual-unit-tests.yml
+++ b/.github/workflows/ci-manual-unit-tests.yml
@@ -1,4 +1,4 @@
-name: Build, unit test and lint (manual trigger)
+name: 'CI: Manual Unit Tests'
 
 on:
   workflow_dispatch:
@@ -66,7 +66,7 @@ jobs:
   unit-tests:
     name: Unit tests
     needs: install-and-build
-    uses: ./.github/workflows/units-tests-reusable.yml
+    uses: ./.github/workflows/test-unit-reusable.yml
     with:
       ref: ${{ inputs.ref }}
       collectCoverage: true
@@ -76,7 +76,7 @@ jobs:
   lint:
     name: Lint
     needs: install-and-build
-    uses: ./.github/workflows/linting-reusable.yml
+    uses: ./.github/workflows/test-linting-reusable.yml
     with:
       ref: ${{ inputs.ref }}
 

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -1,4 +1,4 @@
-name: Test Master
+name: 'CI: Master (Build, Test, Lint)'
 
 on:
   push:
@@ -20,7 +20,7 @@ jobs:
 
   unit-test:
     name: Unit tests
-    uses: ./.github/workflows/units-tests-reusable.yml
+    uses: ./.github/workflows/test-unit-reusable.yml
     strategy:
       matrix:
         node-version: [20.x, 22.x, 24.3.x]
@@ -33,7 +33,7 @@ jobs:
 
   lint:
     name: Lint
-    uses: ./.github/workflows/linting-reusable.yml
+    uses: ./.github/workflows/test-linting-reusable.yml
     with:
       ref: ${{ github.sha }}
 

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -1,4 +1,4 @@
-name: Build, unit test and lint branch
+name: 'CI: Pull Requests (Build, Test, Lint)'
 
 on:
   pull_request:
@@ -89,7 +89,7 @@ jobs:
   unit-test:
     name: Unit tests
     if: needs.install-and-build.outputs.non_python_changed == 'true'
-    uses: ./.github/workflows/units-tests-reusable.yml
+    uses: ./.github/workflows/test-unit-reusable.yml
     needs: install-and-build
     with:
       ref: refs/pull/${{ github.event.pull_request.number }}/merge
@@ -115,7 +115,7 @@ jobs:
   lint:
     name: Lint
     if: needs.install-and-build.outputs.non_python_changed == 'true'
-    uses: ./.github/workflows/linting-reusable.yml
+    uses: ./.github/workflows/test-linting-reusable.yml
     needs: install-and-build
     with:
       ref: refs/pull/${{ github.event.pull_request.number }}/merge
@@ -129,7 +129,7 @@ jobs:
       needs.unit-test.result != 'failure' &&
       needs.typecheck.result != 'failure' &&
       needs.lint.result != 'failure'
-    uses: ./.github/workflows/playwright-test-reusable.yml
+    uses: ./.github/workflows/test-e2e-reusable.yml
     secrets: inherit
 
   e2e-checks:

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -1,4 +1,4 @@
-name: Python CI
+name: 'CI: Python'
 
 on:
   pull_request:

--- a/.github/workflows/playwright-nightly.yml
+++ b/.github/workflows/playwright-nightly.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         config: [standard, postgres]
     name: Test ${{ matrix.config }}
-    uses: ./.github/workflows/playwright-test-reusable.yml
+    uses: ./.github/workflows/test-e2e-reusable.yml
     with:
       test-mode: docker-pull
       docker-image: ${{ github.event.inputs.image || 'n8nio/n8n:nightly' }}

--- a/.github/workflows/playwright-test-docker-build.yml
+++ b/.github/workflows/playwright-test-docker-build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-and-test:
-    uses: ./.github/workflows/playwright-test-reusable.yml
+    uses: ./.github/workflows/test-e2e-reusable.yml
     with:
       test-mode: docker-build
       test-command: pnpm --filter=n8n-playwright test:container:standard

--- a/.github/workflows/test-benchmark-destroy-nightly.yml
+++ b/.github/workflows/test-benchmark-destroy-nightly.yml
@@ -1,4 +1,4 @@
-name: Destroy Benchmark Env
+name: 'Test: Benchmark Destroy Env'
 
 on:
   schedule:

--- a/.github/workflows/test-benchmark-nightly.yml
+++ b/.github/workflows/test-benchmark-nightly.yml
@@ -1,4 +1,4 @@
-name: Run Nightly Benchmark
+name: 'Test: Benchmark Nightly'
 run-name: Benchmark ${{ inputs.n8n_tag || 'nightly' }}
 
 on:

--- a/.github/workflows/test-db-postgres-mysql.yml
+++ b/.github/workflows/test-db-postgres-mysql.yml
@@ -1,4 +1,4 @@
-name: Test Postgres and MySQL schemas
+name: 'Test: DB Postgres MySQL'
 
 on:
   schedule:

--- a/.github/workflows/test-e2e-coverage-weekly.yml
+++ b/.github/workflows/test-e2e-coverage-weekly.yml
@@ -1,4 +1,4 @@
-name: Weekly Coverage Tests
+name: 'Test: E2E Coverage Weekly'
 
 on:
   schedule:

--- a/.github/workflows/test-e2e-docker-pull-reusable.yml
+++ b/.github/workflows/test-e2e-docker-pull-reusable.yml
@@ -1,4 +1,4 @@
-name: Run Playwright Tests (Docker Pull)
+name: 'Test: E2E Docker Pull'
 # This workflow is used to run Playwright tests in a Docker container pulled from the registry
 
 on:
@@ -29,7 +29,7 @@ on:
 
 jobs:
   build-and-test:
-    uses: ./.github/workflows/playwright-test-reusable.yml
+    uses: ./.github/workflows/test-e2e-reusable.yml
     with:
       test-mode: docker-pull
       shards: ${{ inputs.shards }}

--- a/.github/workflows/test-e2e-performance-reusable.yml
+++ b/.github/workflows/test-e2e-performance-reusable.yml
@@ -1,4 +1,4 @@
-name: Run Playwright Performance Tests
+name: 'Test: E2E Performance'
 
 on:
   workflow_call:
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build-and-test-performance:
-    uses: ./.github/workflows/playwright-test-reusable.yml
+    uses: ./.github/workflows/test-e2e-reusable.yml
     with:
       test-mode: docker-build
       test-command: pnpm --filter=n8n-playwright test:performance

--- a/.github/workflows/test-e2e-reusable.yml
+++ b/.github/workflows/test-e2e-reusable.yml
@@ -1,4 +1,4 @@
-name: Playwright Tests - Reusable
+name: 'Test: E2E'
 
 on:
   workflow_call:

--- a/.github/workflows/test-evals-ai.yml
+++ b/.github/workflows/test-evals-ai.yml
@@ -1,4 +1,4 @@
-name: Run Workflow Builder Evals
+name: 'Test: Evals AI'
 
 on:
   push:

--- a/.github/workflows/test-evals-python.yml
+++ b/.github/workflows/test-evals-python.yml
@@ -1,4 +1,4 @@
-name: Python CI
+name: 'Test: Evals Python'
 
 on:
   pull_request:

--- a/.github/workflows/test-linting-reusable.yml
+++ b/.github/workflows/test-linting-reusable.yml
@@ -1,4 +1,4 @@
-name: Reusable linting workflow
+name: 'Test: Linting'
 
 on:
   workflow_call:

--- a/.github/workflows/test-unit-reusable.yml
+++ b/.github/workflows/test-unit-reusable.yml
@@ -1,4 +1,4 @@
-name: Reusable units test workflow
+name: 'Test: Unit'
 
 on:
   workflow_call:

--- a/.github/workflows/test-visual-chromatic.yml
+++ b/.github/workflows/test-visual-chromatic.yml
@@ -1,4 +1,4 @@
-name: Chromatic
+name: 'Test: Visual Chromatic'
 
 on:
   schedule:

--- a/.github/workflows/test-visual-storybook.yml
+++ b/.github/workflows/test-visual-storybook.yml
@@ -1,4 +1,4 @@
-name: Storybook
+name: 'Test: Visual Storybook'
 
 on:
   schedule:

--- a/.github/workflows/test-workflows-callable.yml
+++ b/.github/workflows/test-workflows-callable.yml
@@ -1,4 +1,4 @@
-name: Test Workflows - Reusable
+name: 'Test: Workflows'
 
 on:
   workflow_call:

--- a/.github/workflows/test-workflows-nightly.yml
+++ b/.github/workflows/test-workflows-nightly.yml
@@ -1,4 +1,4 @@
-name: Test Workflows Nightly and Manual
+name: 'Test: Workflows Nightly'
 
 on:
   schedule:

--- a/.github/workflows/test-workflows-pr-comment.yml
+++ b/.github/workflows/test-workflows-pr-comment.yml
@@ -1,4 +1,4 @@
-name: Test Workflows on PR Comment
+name: 'Test: Workflows PR Comment'
 
 on:
   issue_comment:

--- a/.github/workflows/util-check-docs-urls.yml
+++ b/.github/workflows/util-check-docs-urls.yml
@@ -1,4 +1,4 @@
-name: Check Documentation URLs
+name: 'Util: Check Docs URLs'
 
 on:
   release:

--- a/.github/workflows/util-claude.yml
+++ b/.github/workflows/util-claude.yml
@@ -1,4 +1,4 @@
-name: Claude PR Assistant
+name: 'Util: Claude'
 
 on:
   issue_comment:

--- a/.github/workflows/util-data-tooling.yml
+++ b/.github/workflows/util-data-tooling.yml
@@ -1,4 +1,4 @@
-name: Data tooling, test exports and imports of data to various db types
+name: 'Util: Data Tooling'
 
 # TODO: Uncomment this after it works on a manual invocation
 # on:

--- a/.github/workflows/util-notify-pr-status.yml
+++ b/.github/workflows/util-notify-pr-status.yml
@@ -1,4 +1,4 @@
-name: Notify PR status changed
+name: 'Util: Notify PR Status'
 
 on:
   pull_request_review:

--- a/.github/workflows/util-sync-api-docs.yml
+++ b/.github/workflows/util-sync-api-docs.yml
@@ -1,4 +1,4 @@
-name: Sync Public API Schema to Docs Repo
+name: 'Util: Sync API Docs'
 
 on:
   # Triggers for the master branch if relevant Public API files have changed
@@ -107,7 +107,7 @@ jobs:
 
             # Find all commits between the last success and now that touched the relevant files
             # NOTE: The pathspecs here mirror the workflow's 'paths' trigger for precision
-            RELEVANT_COMMITS=$(git log --pretty=format:"- [%h](https://github.com/${{ github.repository }}/commit/%H) %s" $LAST_SUCCESS_SHA..${{ github.sha }} -- \
+            RELEVANT_COMMITS=$(git log --pretty=format:"- [%h](https://github.com/${{ github.repository }}/commit/%H) %s" "$LAST_SUCCESS_SHA..${{ github.sha }}" -- \
               'packages/cli/src/public-api/**/*.css' \
               'packages/cli/src/public-api/**/*.yaml' \
               'packages/cli/src/public-api/**/*.yml')
@@ -129,9 +129,11 @@ jobs:
             SOURCE_LINK="Source commit(s):"$'\n'"$RELEVANT_COMMITS"
           fi
 
-          echo "source_link<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$SOURCE_LINK" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          {
+            echo "source_link<<EOF"
+            echo "$SOURCE_LINK"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create PR in Docs Repo
         if: steps.verify_file.outputs.file_exists == 'true'

--- a/.github/workflows/util-update-node-popularity.yml
+++ b/.github/workflows/util-update-node-popularity.yml
@@ -1,4 +1,4 @@
-name: Update Node Popularity Data
+name: 'Util: Update Node Popularity'
 
 on:
   schedule:

--- a/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionHelpers.test.ts
@@ -62,7 +62,7 @@ describe('useExecutionHelpers()', () => {
 			const { getUIDetails } = useExecutionHelpers();
 			const uiDetails = getUIDetails(execution);
 
-			expect(uiDetails.startTime).toEqual('Jan 1, 00:00:00');
+			expect(uiDetails.startTime).toEqual('Jan 1, 2025, 00:00:00');
 		});
 	});
 


### PR DESCRIPTION
## Summary

  Backports workflow renames from master to 1.x branch to eliminate duplicate entries in GitHub Actions sidebar.

  - Rename 24 workflow files to follow `domain-description.yml` convention
  - Update `name:` fields in 32 files to match `'Domain: Description'` format
  - Update 11 internal `uses:` references to renamed workflows


## Related Linear tickets, Github issues, and Community forum posts

  - https://linear.app/n8n/issue/CAT-2067
  - https://linear.app/n8n/issue/CAT-1938
  - Parent PR: #23904


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
