### PR TITLE
fix(editor): Fix typo in source control push modal message

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2827,7 +2827,7 @@
 	"settings.sourceControl.modals.push.buttons.save": "Commit and push",
 	"settings.sourceControl.modals.push.success.title": "Pushed successfully",
 	"settings.sourceControl.modals.push.success.description": "were committed and pushed to your remote repository",
-	"settings.sourceControl.modals.push.projectAdmin.callout": "If you want to push workflows from your personal space, move then to a project first.",
+	"settings.sourceControl.modals.push.projectAdmin.callout": "If you want to push workflows from your personal space, move them to a project first.",
 	"settings.sourceControl.status.modified": "Modified",
 	"settings.sourceControl.status.deleted": "Deleted",
 	"settings.sourceControl.status.created": "New",


### PR DESCRIPTION
Changed "move then to" to "move them to" in the source control push modal callout message for project admins.

