### PR TITLE
chore(ai-builder): Consolidate structured output parser recommendation and guidance prompts

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/builder.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/builder.prompt.ts
@@ -6,11 +6,7 @@
  */
 
 import { prompt } from '../builder';
-import {
-	AI_AGENT_PARSER_CONFIG,
-	DATA_PARSING_STRATEGY,
-	PARSER_CONNECTION_PATTERN,
-} from '../shared/node-guidance/structured-output-parser';
+import { structuredOutputParser } from '../shared/node-guidance';
 
 const BUILDER_ROLE = 'You are a Builder Agent specialized in constructing n8n workflows.';
 
@@ -53,11 +49,11 @@ Placement rules:
 
 const DATA_PARSING = `Code nodes are slower than core n8n nodes (like Edit Fields, If, Switch, etc.) as they run in a sandboxed environment. Use Code nodes as a last resort for custom business logic.
 
-${DATA_PARSING_STRATEGY}
+${structuredOutputParser.recommendation}
 
 For AI-generated structured data, use a Structured Output Parser node. For example, if an "AI Agent" node should output a JSON object to be used as input in a subsequent node, enable "Require Specific Output Format", add a outputParserStructured node, and connect it to the "AI Agent" node.
 
-${PARSER_CONNECTION_PATTERN}`;
+${structuredOutputParser.connections}`;
 
 const PROACTIVE_DESIGN = `Anticipate workflow needs:
 - Switch or If nodes for conditional logic when multiple outcomes exist
@@ -84,7 +80,7 @@ const CONNECTION_PARAMETERS = `- Static nodes (HTTP Request, Set, Code): reasoni
 - Document Loader custom: reasoning="Custom mode enables text splitter input", parameters={{ textSplittingMode: "custom" }}
 - Switch with routing rules: reasoning="Switch needs N outputs, creating N rules.values entries with outputKeys", parameters={{ mode: "rules", rules: {{ values: [...] }} }} - see <switch_node_pattern> for full structure`;
 
-const STRUCTURED_OUTPUT_PARSER = AI_AGENT_PARSER_CONFIG;
+const STRUCTURED_OUTPUT_PARSER = structuredOutputParser.configuration;
 
 const AI_CONNECTIONS = `n8n connections flow from SOURCE (output) to TARGET (input).
 

--- a/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/builder.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/builder.prompt.ts
@@ -6,6 +6,11 @@
  */
 
 import { prompt } from '../builder';
+import {
+	AI_AGENT_PARSER_CONFIG,
+	DATA_PARSING_STRATEGY,
+	PARSER_CONNECTION_PATTERN,
+} from '../shared/node-guidance/structured-output-parser';
 
 const BUILDER_ROLE = 'You are a Builder Agent specialized in constructing n8n workflows.';
 
@@ -47,14 +52,12 @@ Placement rules:
 - Name it "Workflow Configuration"`;
 
 const DATA_PARSING = `Code nodes are slower than core n8n nodes (like Edit Fields, If, Switch, etc.) as they run in a sandboxed environment. Use Code nodes as a last resort for custom business logic.
-For binary file data, use Extract From File node to extract content from files before processing.
+
+${DATA_PARSING_STRATEGY}
 
 For AI-generated structured data, use a Structured Output Parser node. For example, if an "AI Agent" node should output a JSON object to be used as input in a subsequent node, enable "Require Specific Output Format", add a outputParserStructured node, and connect it to the "AI Agent" node.
 
-When Discovery results include AI Agent or Structured Output Parser:
-1. Create the Structured Output Parser node
-2. Set AI Agent's hasOutputParser: true in connectionParameters
-3. Connect: Structured Output Parser → AI Agent (ai_outputParser connection)`;
+${PARSER_CONNECTION_PATTERN}`;
 
 const PROACTIVE_DESIGN = `Anticipate workflow needs:
 - Switch or If nodes for conditional logic when multiple outcomes exist
@@ -81,12 +84,7 @@ const CONNECTION_PARAMETERS = `- Static nodes (HTTP Request, Set, Code): reasoni
 - Document Loader custom: reasoning="Custom mode enables text splitter input", parameters={{ textSplittingMode: "custom" }}
 - Switch with routing rules: reasoning="Switch needs N outputs, creating N rules.values entries with outputKeys", parameters={{ mode: "rules", rules: {{ values: [...] }} }} - see <switch_node_pattern> for full structure`;
 
-const STRUCTURED_OUTPUT_PARSER = `WHEN TO SET hasOutputParser: true on AI Agent:
-- Discovery found Structured Output Parser node → MUST set hasOutputParser: true
-- AI output will be used in conditions (IF/Switch nodes checking $json.field)
-- AI output will be formatted/displayed (HTML emails, reports with specific sections)
-- AI output will be stored in database/data tables with specific fields
-- AI is classifying, scoring, or extracting specific data fields`;
+const STRUCTURED_OUTPUT_PARSER = AI_AGENT_PARSER_CONFIG;
 
 const AI_CONNECTIONS = `n8n connections flow from SOURCE (output) to TARGET (input).
 

--- a/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/discovery.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/discovery.prompt.ts
@@ -12,6 +12,7 @@ import {
 } from '@/types/categorization';
 
 import { prompt } from '../builder';
+import { WHEN_TO_USE_STRUCTURED_OUTPUT } from '../shared/node-guidance/structured-output-parser';
 
 /** Few-shot examples for technique classification */
 export const exampleCategorizations: Array<{
@@ -215,15 +216,7 @@ const SUB_NODES_SEARCHES = `When searching for AI nodes, ALSO search for their r
 - "Basic LLM Chain" → also search for "Chat Model", "Output Parser"
 - "Vector Store" → also search for "Embeddings", "Document Loader"`;
 
-const STRUCTURED_OUTPUT_PARSER = `Search for "Structured Output Parser" (@n8n/n8n-nodes-langchain.outputParserStructured) when:
-- AI output will be used programmatically (conditions, formatting, database storage, API calls)
-- AI needs to extract specific fields (e.g., score, category, priority, action items)
-- AI needs to classify/categorize data into defined categories
-- Downstream nodes need to access specific fields from AI response (e.g., $json.score, $json.category)
-- Output will be displayed in a formatted way (e.g., HTML email with specific sections)
-- Data needs validation against a schema before processing
-
-- Always use search_nodes to find the exact node names and versions - NEVER guess versions`;
+const STRUCTURED_OUTPUT_PARSER = WHEN_TO_USE_STRUCTURED_OUTPUT;
 
 const CRITICAL_RULES = `- NEVER ask clarifying questions
 - ALWAYS call get_best_practices first

--- a/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/discovery.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/discovery.prompt.ts
@@ -12,7 +12,7 @@ import {
 } from '@/types/categorization';
 
 import { prompt } from '../builder';
-import { WHEN_TO_USE_STRUCTURED_OUTPUT } from '../shared/node-guidance/structured-output-parser';
+import { structuredOutputParser } from '../shared/node-guidance';
 
 /** Few-shot examples for technique classification */
 export const exampleCategorizations: Array<{
@@ -216,7 +216,7 @@ const SUB_NODES_SEARCHES = `When searching for AI nodes, ALSO search for their r
 - "Basic LLM Chain" → also search for "Chat Model", "Output Parser"
 - "Vector Store" → also search for "Embeddings", "Document Loader"`;
 
-const STRUCTURED_OUTPUT_PARSER = WHEN_TO_USE_STRUCTURED_OUTPUT;
+const STRUCTURED_OUTPUT_PARSER = structuredOutputParser.usage;
 
 const CRITICAL_RULES = `- NEVER ask clarifying questions
 - ALWAYS call get_best_practices first

--- a/packages/@n8n/ai-workflow-builder.ee/src/prompts/legacy-agent.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/prompts/legacy-agent.prompt.ts
@@ -1,6 +1,7 @@
 import { ChatPromptTemplate } from '@langchain/core/prompts';
 
 import { instanceUrlPrompt } from './chains/parameter-updater/instance-url';
+import { DATA_PARSING_STRATEGY } from './shared/node-guidance/structured-output-parser';
 
 /**
  * Phase configuration for the workflow creation sequence
@@ -437,15 +438,7 @@ update_node_parameters({{
 </configuration_requirements>
 
 <data_parsing_strategy>
-For AI-generated structured data, prefer Structured Output Parser nodes over Code nodes.
-Why: Purpose-built parsers are more reliable and handle edge cases better than custom code.
-
-For binary file data, use Extract From File node to extract content from files before processing.
-
-Use Code nodes only for:
-- Simple string manipulations
-- Already structured data (JSON, CSV)
-- Custom business logic beyond parsing
+${DATA_PARSING_STRATEGY}
 </data_parsing_strategy>
 
 <fromAI_expressions>

--- a/packages/@n8n/ai-workflow-builder.ee/src/prompts/legacy-agent.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/prompts/legacy-agent.prompt.ts
@@ -1,7 +1,7 @@
 import { ChatPromptTemplate } from '@langchain/core/prompts';
 
 import { instanceUrlPrompt } from './chains/parameter-updater/instance-url';
-import { DATA_PARSING_STRATEGY } from './shared/node-guidance/structured-output-parser';
+import { structuredOutputParser } from './shared/node-guidance';
 
 /**
  * Phase configuration for the workflow creation sequence
@@ -438,7 +438,7 @@ update_node_parameters({{
 </configuration_requirements>
 
 <data_parsing_strategy>
-${DATA_PARSING_STRATEGY}
+${structuredOutputParser.recommendation}
 </data_parsing_strategy>
 
 <fromAI_expressions>

--- a/packages/@n8n/ai-workflow-builder.ee/src/prompts/shared/node-guidance/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/prompts/shared/node-guidance/index.ts
@@ -1,0 +1,1 @@
+export { structuredOutputParser } from './structured-output-parser';

--- a/packages/@n8n/ai-workflow-builder.ee/src/prompts/shared/node-guidance/structured-output-parser.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/prompts/shared/node-guidance/structured-output-parser.ts
@@ -1,0 +1,31 @@
+export const WHEN_TO_USE_STRUCTURED_OUTPUT = `Search for "Structured Output Parser" (@n8n/n8n-nodes-langchain.outputParserStructured) when:
+- AI output will be used programmatically (conditions, formatting, database storage, API calls)
+- AI needs to extract specific fields (e.g., score, category, priority, action items)
+- AI needs to classify/categorize data into defined categories
+- Downstream nodes need to access specific fields from AI response (e.g., $json.score, $json.category)
+- Output will be displayed in a formatted way (e.g., HTML email with specific sections)
+- Data needs validation against a schema before processing
+
+- Always use search_nodes to find the exact node names and versions - NEVER guess versions`;
+
+export const AI_AGENT_PARSER_CONFIG = `WHEN TO SET hasOutputParser: true on AI Agent:
+- Discovery found Structured Output Parser node → MUST set hasOutputParser: true
+- AI output will be used in conditions (IF/Switch nodes checking $json.field)
+- AI output will be formatted/displayed (HTML emails, reports with specific sections)
+- AI output will be stored in database/data tables with specific fields
+- AI is classifying, scoring, or extracting specific data fields`;
+
+export const PARSER_CONNECTION_PATTERN = `When Discovery results include AI Agent or Structured Output Parser:
+1. Create the Structured Output Parser node
+2. Set AI Agent's hasOutputParser: true in connectionParameters
+3. Connect: Structured Output Parser → AI Agent (ai_outputParser connection)`;
+
+export const DATA_PARSING_STRATEGY = `For AI-generated structured data, prefer Structured Output Parser nodes over Code nodes.
+Why: Purpose-built parsers are more reliable and handle edge cases better than custom code.
+
+For binary file data, use Extract From File node to extract content from files before processing.
+
+Use Code nodes only for:
+- Simple string manipulations
+- Already structured data (JSON, CSV)
+- Custom business logic beyond parsing`;

--- a/packages/@n8n/ai-workflow-builder.ee/src/prompts/shared/node-guidance/structured-output-parser.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/prompts/shared/node-guidance/structured-output-parser.ts
@@ -1,4 +1,9 @@
-export const WHEN_TO_USE_STRUCTURED_OUTPUT = `Search for "Structured Output Parser" (@n8n/n8n-nodes-langchain.outputParserStructured) when:
+import type { NodeGuidance } from '@/types';
+
+export const structuredOutputParser: NodeGuidance = {
+	nodeType: '@n8n/n8n-nodes-langchain.outputParserStructured',
+
+	usage: `Search for "Structured Output Parser" (@n8n/n8n-nodes-langchain.outputParserStructured) when:
 - AI output will be used programmatically (conditions, formatting, database storage, API calls)
 - AI needs to extract specific fields (e.g., score, category, priority, action items)
 - AI needs to classify/categorize data into defined categories
@@ -6,21 +11,21 @@ export const WHEN_TO_USE_STRUCTURED_OUTPUT = `Search for "Structured Output Pars
 - Output will be displayed in a formatted way (e.g., HTML email with specific sections)
 - Data needs validation against a schema before processing
 
-- Always use search_nodes to find the exact node names and versions - NEVER guess versions`;
+- Always use search_nodes to find the exact node names and versions - NEVER guess versions`,
 
-export const AI_AGENT_PARSER_CONFIG = `WHEN TO SET hasOutputParser: true on AI Agent:
+	connections: `When Discovery results include AI Agent or Structured Output Parser:
+1. Create the Structured Output Parser node
+2. Set AI Agent's hasOutputParser: true in connectionParameters
+3. Connect: Structured Output Parser → AI Agent (ai_outputParser connection)`,
+
+	configuration: `WHEN TO SET hasOutputParser: true on AI Agent:
 - Discovery found Structured Output Parser node → MUST set hasOutputParser: true
 - AI output will be used in conditions (IF/Switch nodes checking $json.field)
 - AI output will be formatted/displayed (HTML emails, reports with specific sections)
 - AI output will be stored in database/data tables with specific fields
-- AI is classifying, scoring, or extracting specific data fields`;
+- AI is classifying, scoring, or extracting specific data fields`,
 
-export const PARSER_CONNECTION_PATTERN = `When Discovery results include AI Agent or Structured Output Parser:
-1. Create the Structured Output Parser node
-2. Set AI Agent's hasOutputParser: true in connectionParameters
-3. Connect: Structured Output Parser → AI Agent (ai_outputParser connection)`;
-
-export const DATA_PARSING_STRATEGY = `For AI-generated structured data, prefer Structured Output Parser nodes over Code nodes.
+	recommendation: `For AI-generated structured data, prefer Structured Output Parser nodes over Code nodes.
 Why: Purpose-built parsers are more reliable and handle edge cases better than custom code.
 
 For binary file data, use Extract From File node to extract content from files before processing.
@@ -28,4 +33,5 @@ For binary file data, use Extract From File node to extract content from files b
 Use Code nodes only for:
 - Simple string manipulations
 - Already structured data (JSON, CSV)
-- Custom business logic beyond parsing`;
+- Custom business logic beyond parsing`,
+};

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/best-practices/document-processing.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/best-practices/document-processing.ts
@@ -103,14 +103,12 @@ For varied or complex documents:
 Option 1 - Using Document Loader (Recommended for binary files):
 1. Pass binary data directly to Document Loader node (set Data Source to "Binary")
 2. Connect to AI Agent or LLM Chain for processing
-3. Use Structured Output Parser to ensure consistent JSON
-4. Validate extracted fields before processing
+3. Validate extracted fields before processing
 
 Option 2 - Using text extraction:
 1. Extract raw text using Extract from File or OCR
 2. Pass to AI Agent or LLM Chain with structured prompt
-3. Use Structured Output Parser to ensure consistent JSON
-4. Validate extracted fields before processing
+3. Validate extracted fields before processing
 
 Example system prompt structure:
 "Extract the following fields from the document: [field list]. Return as JSON with this schema: [schema example]"
@@ -198,7 +196,6 @@ Configuration: Include structured output tools for consistent results
 
 **LLM Chain (@n8n/n8n-nodes-langchain.chainLlm)**
 Purpose: Document classification and data extraction
-Use with: Structured Output Parser for JSON consistency
 
 **Document Loader (@n8n/n8n-nodes-langchain.documentLoader)**
 Purpose: Load and process documents directly from binary data for AI processing

--- a/packages/@n8n/ai-workflow-builder.ee/src/types/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/types/index.ts
@@ -10,6 +10,7 @@ export type * from './config';
 export type * from './utils';
 export type * from './categorization';
 export type * from './best-practices';
+export type * from './node-guidance';
 
 // Re-export web/templates (includes both types and runtime values)
 export * from './web/templates';

--- a/packages/@n8n/ai-workflow-builder.ee/src/types/node-guidance.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/types/node-guidance.ts
@@ -1,0 +1,32 @@
+/**
+ * Structured guidance for node usage across different agents.
+ * Each property maps to a specific agent's needs.
+ */
+export interface NodeGuidance {
+	/** Node identifier (e.g., "@n8n/n8n-nodes-langchain.outputParserStructured") */
+	nodeType: string;
+
+	/**
+	 * When to use this node - used by Discovery Agent
+	 * Describes scenarios/conditions that warrant searching for this node
+	 */
+	usage: string;
+
+	/**
+	 * How to connect this node - used by Builder Agent
+	 * Describes connection patterns, source/target relationships
+	 */
+	connections: string;
+
+	/**
+	 * How to configure parameters - used by Builder Agent
+	 * Describes parameter settings that affect the node or related nodes
+	 */
+	configuration: string;
+
+	/**
+	 * General recommendations - used by Legacy Agent
+	 * High-level guidance about when to prefer this node over alternatives
+	 */
+	recommendation?: string;
+}


### PR DESCRIPTION
## Summary
The structured output parser (s.o.p) is a relatively complex sub-node that requires some specific configuration and recommendations for when to use. I've reduced the recommendations we make for this in the best practices (as it shouldn't be necessary) and centralised all the explanations from the multi-agent prompts into one location.

I've re-ran the pairwise evals and haven't seen a difference in performance when it comes to usage of the structured output parser.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
