### PR TITLE
fix(McpClientTool Node): Sanitize MCP tool arguments based on schema

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
@@ -26,6 +26,8 @@ import {
 	mapToNodeOperationError,
 	tryRefreshOAuth2Token,
 } from '../shared/utils';
+import type { JSONSchema7 } from 'json-schema';
+import pick from 'lodash/pick';
 
 /**
  * Get node parameters for MCP client configuration
@@ -424,12 +426,20 @@ export class McpClientTool implements INodeType {
 				if (toolName === tool.name) {
 					// Extract the tool name from arguments before passing to MCP
 					const { tool: _, ...toolArguments } = item.json;
+					const schema: JSONSchema7 = tool.inputSchema;
+					// When additionalProperties is explicitly false, filter to schema-defined properties.
+					// Otherwise (true or omitted), pass all arguments through
+					const sanitizedToolArguments: IDataObject =
+						schema.additionalProperties === false
+							? pick(toolArguments, Object.keys(schema.properties ?? {}))
+							: toolArguments;
+
 					const params: {
 						name: string;
 						arguments: IDataObject;
 					} = {
 						name: tool.name,
-						arguments: toolArguments,
+						arguments: sanitizedToolArguments,
 					};
 					const result = await client.callTool(params, CallToolResultSchema, {
 						timeout: config.timeout,

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/__test__/McpClientTool.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/__test__/McpClientTool.node.test.ts
@@ -424,7 +424,11 @@ describe('McpClientTool', () => {
 					{
 						name: 'get_weather',
 						description: 'Gets the weather',
-						inputSchema: { type: 'object', properties: { location: { type: 'string' } } },
+						inputSchema: {
+							type: 'object',
+							properties: { location: { type: 'string' } },
+							additionalProperties: false,
+						},
 					},
 				],
 			});
@@ -437,6 +441,7 @@ describe('McpClientTool', () => {
 						json: {
 							tool: 'get_weather',
 							location: 'Berlin',
+							foo: 'bar', // arbitrary field to be filtered out
 						},
 					},
 				]),
@@ -470,6 +475,58 @@ describe('McpClientTool', () => {
 				{
 					name: 'get_weather',
 					arguments: { location: 'Berlin' },
+				},
+				expect.anything(),
+				expect.anything(),
+			);
+		});
+
+		it('should pass all arguments when schema has additionalProperties: true', async () => {
+			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({
+				content: [{ type: 'text', text: 'Success' }],
+			});
+			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({
+				tools: [
+					{
+						name: 'flexible_tool',
+						description: 'Accepts any arguments',
+						inputSchema: { type: 'object', additionalProperties: true },
+					},
+				],
+			});
+
+			const mockNode = mock<INode>({ typeVersion: 1, type: 'mcpClientTool' });
+			const mockExecuteFunctions = mock<any>({
+				getNode: jest.fn(() => mockNode),
+				getInputData: jest.fn(() => [
+					{
+						json: {
+							tool: 'flexible_tool',
+							foo: 'bar',
+							extra: 'data',
+						},
+					},
+				]),
+				getNodeParameter: jest.fn((key) => {
+					const params: Record<string, any> = {
+						include: 'all',
+						includeTools: [],
+						excludeTools: [],
+						authentication: 'none',
+						sseEndpoint: 'https://test.com/sse',
+						'options.timeout': 60000,
+					};
+					return params[key];
+				}),
+			});
+
+			await new McpClientTool().execute.call(mockExecuteFunctions);
+
+			expect(Client.prototype.callTool).toHaveBeenCalledWith(
+				{
+					name: 'flexible_tool',
+					arguments: { foo: 'bar', extra: 'data' },
 				},
 				expect.anything(),
 				expect.anything(),


### PR DESCRIPTION
## Summary

Backport of https://github.com/n8n-io/n8n/pull/23167 into 1.x

## Related Linear tickets, Github issues, and Community forum posts

- https://github.com/n8n-io/n8n/issues/21716
- https://linear.app/n8n/issue/NODE-4047/community-issue-mcp-tool-calls-are-failing-due-to-new-toolcallid


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
