### PR TITLE
fix(editor-ui): keep filter edits scoped to current node

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/FilterConditions/FilterConditions.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/FilterConditions/FilterConditions.vue
@@ -10,7 +10,7 @@ import {
 	type NodeParameterValue,
 	type FilterOptionsValue,
 } from 'n8n-workflow';
-import { computed, reactive, watch } from 'vue';
+import { computed, reactive, watch, onBeforeUnmount } from 'vue';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import {
 	DEFAULT_FILTER_OPTIONS,
@@ -113,7 +113,7 @@ watch(
 
 		if (!isEqual(state.paramValue.options, newOptions)) {
 			state.paramValue.options = newOptions;
-			debouncedEmitChange();
+			scheduleEmitChange();
 		}
 	},
 	{ immediate: true },
@@ -132,17 +132,39 @@ watch(
 watch(
 	() => state.paramValue,
 	() => {
-		debouncedEmitChange();
+		scheduleEmitChange();
 	},
 	{ deep: true },
 );
 
-function emitChange() {
+watch(
+	() => props.node?.name,
+	(_, previousNodeName) => {
+		if (previousNodeName) {
+			debouncedEmitChange.flush();
+		}
+	},
+);
+
+onBeforeUnmount(() => {
+	debouncedEmitChange.flush();
+});
+
+function emitChange(nodeName?: string) {
+	if (!nodeName) return;
 	emit('valueChanged', {
 		name: props.path,
 		value: state.paramValue,
-		node: props.node?.name as string,
+		node: nodeName,
 	});
+}
+
+function scheduleEmitChange() {
+	const nodeName = props.node?.name;
+	if (!nodeName) {
+		return;
+	}
+	debouncedEmitChange(nodeName);
 }
 
 function addCondition(): void {


### PR DESCRIPTION
## Summary

- prevent `FilterConditions` from emitting stale debounced updates after switching nodes by capturing the node name, flushing on node change/unmount, and skipping emits when no node is active
- reuse the same scheduling helper for async option updates so delayed loads can’t overwrite other nodes’ parameters
- verified manually (editing adjacent If nodes) and via `pnpm exec vitest run src/features/ndv/parameters/components/FilterConditions/FilterConditions.test.ts`

## Related Linear tickets, Github issues, and Community forum posts

- _N/A_

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR labeled with `release/backport` if needed.
