### PR TITLE
fix(core): Add license check to DELETE variables endpoint

### DIFF
--- a/packages/cli/src/environments.ee/variables/variables.controller.ee.ts
+++ b/packages/cli/src/environments.ee/variables/variables.controller.ee.ts
@@ -72,6 +72,7 @@ export class VariablesController {
 	}
 
 	@Delete('/:id')
+	@Licensed('feat:variables')
 	async deleteVariable(req: AuthenticatedRequest<{ id: string }>) {
 		await this.variablesService.deleteForUser(req.user, req.params.id);
 

--- a/packages/cli/test/integration/variables.test.ts
+++ b/packages/cli/test/integration/variables.test.ts
@@ -324,6 +324,18 @@ describe('PATCH /variables/:id', () => {
 		expect(byId!.key).toBe(var1.key);
 		expect(byId!.value).toBe(var1.value);
 	});
+
+	test("should not modify a variable if the instance doesn't have a license", async () => {
+		const variable = await createVariable('test1', 'value1');
+		license.disable('feat:variables');
+		const response = await authOwnerAgent.patch(`/variables/${variable.id}`).send(toModify);
+		expect(response.statusCode).toBe(403);
+
+		const byId = await getVariableById(variable.id);
+		expect(byId).not.toBeNull();
+		expect(byId!.key).toBe('test1');
+		expect(byId!.value).toBe('value1');
+	});
 });
 
 // ----------------------------------------
@@ -362,5 +374,15 @@ describe('DELETE /variables/:id', () => {
 
 		const getResponse = await authMemberAgent.get('/variables');
 		expect(getResponse.body.data.length).toBe(3);
+	});
+
+	test("should not delete a variable if the instance doesn't have a license", async () => {
+		const variable = await createVariable('test1', 'value1');
+		license.disable('feat:variables');
+		const response = await authOwnerAgent.delete(`/variables/${variable.id}`);
+		expect(response.statusCode).toBe(403);
+
+		const byId = await getVariableById(variable.id);
+		expect(byId).not.toBeNull();
 	});
 });


### PR DESCRIPTION
## Summary

Add missing `@Licensed('feat:variables')` decorator to the DELETE endpoint in the variables controller to enforce license requirements consistently across all mutation endpoints (POST, PATCH, DELETE).

Also add license check tests for both `PATCH` and `DELETE` endpoints to ensure the feature check is properly enforced.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-4399/delete-variables-without-license-check

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- ~[ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- ~[ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~

