### PR TITLE
test: Align MFA test assertion with 2.2.5 branch state

### DIFF
--- a/packages/cli/src/services/__tests__/frontend.service.test.ts
+++ b/packages/cli/src/services/__tests__/frontend.service.test.ts
@@ -237,7 +237,6 @@ describe('FrontendService', () => {
 		it('should return public settings with mfa', async () => {
 			const expectedPublicSettings = {
 				settingsMode: 'public',
-				defaultLocale: 'en',
 				userManagement: {
 					smtpSetup: false,
 					showSetupOnFirstLoad: true,


### PR DESCRIPTION
  ## Summary
  - Remove `defaultLocale` expectation from MFA test that doesn't exist on this branch

  ## Context
  The MFA test (#23881) was cherry-picked from master where `defaultLocale` exists in public settings (#23134).
  Since #23134 isn't in 2.2.5, the test assertion needs to match the actual branch behavior.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2076


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
