### PR TITLE
refactor(core): Clean up workflow history compaction service and related utils 

### DIFF
--- a/packages/@n8n/db/src/repositories/workflow-history.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-history.repository.ts
@@ -1,6 +1,6 @@
 import { Service } from '@n8n/di';
 import { DataSource, In, LessThan, Repository } from '@n8n/typeorm';
-import { GroupedWorkflowHistory, groupWorkflows, RULES, SKIP_RULES } from 'n8n-workflow';
+import { DiffRule, groupWorkflows, SKIP_RULES } from 'n8n-workflow';
 
 import { WorkflowHistory, WorkflowEntity } from '../entities';
 import { WorkflowPublishHistoryRepository } from './workflow-publish-history.repository';
@@ -48,13 +48,8 @@ export class WorkflowHistoryRepository extends Repository<WorkflowHistory> {
 	}
 
 	private makeSkipActiveAndNamedVersionsRule(activeVersions: string[]) {
-		return (
-			prev: GroupedWorkflowHistory<WorkflowHistory>,
-			_next: GroupedWorkflowHistory<WorkflowHistory>,
-		): boolean =>
-			prev.to.name !== null ||
-			prev.to.description !== null ||
-			activeVersions.includes(prev.to.versionId);
+		return (prev: WorkflowHistory, _next: WorkflowHistory): boolean =>
+			prev.name !== null || prev.description !== null || activeVersions.includes(prev.versionId);
 	}
 
 	async getWorkflowIdsInRange(startDate: Date, endDate: Date) {
@@ -81,7 +76,8 @@ export class WorkflowHistoryRepository extends Repository<WorkflowHistory> {
 		workflowId: string,
 		startDate: Date,
 		endDate: Date,
-		minimumTimeBetweenSessionsMs: number,
+		rules: DiffRule[] = [],
+		skipRules: DiffRule[] = [],
 	): Promise<{ seen: number; deleted: number }> {
 		const workflows = await this.manager
 			.createQueryBuilder(WorkflowHistory, 'wh')
@@ -100,14 +96,11 @@ export class WorkflowHistoryRepository extends Repository<WorkflowHistory> {
 		const versionsToDelete = [];
 		const publishedVersions =
 			await this.workflowPublishHistoryRepository.getPublishedVersions(workflowId);
-		const grouped = groupWorkflows<WorkflowHistory>(
-			workflows,
-			[RULES.mergeAdditiveChanges],
-			[
-				SKIP_RULES.makeSkipTimeDifference(minimumTimeBetweenSessionsMs),
-				this.makeSkipActiveAndNamedVersionsRule(publishedVersions.map((x) => x.versionId)),
-			],
-		);
+		const grouped = groupWorkflows<WorkflowHistory>(workflows, rules, [
+			this.makeSkipActiveAndNamedVersionsRule(publishedVersions.map((x) => x.versionId)),
+			SKIP_RULES.skipDifferentUsers,
+			...skipRules,
+		]);
 		for (const group of grouped) {
 			for (const wf of group.groupedWorkflows) {
 				versionsToDelete.push(wf.versionId);

--- a/packages/@n8n/db/src/repositories/workflow-history.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-history.repository.ts
@@ -100,7 +100,7 @@ export class WorkflowHistoryRepository extends Repository<WorkflowHistory> {
 			...skipRules,
 		]);
 
-		const result = await this.delete({ versionId: In(grouped.removed.map((x) => x.versionId)) });
+		await this.delete({ versionId: In(grouped.removed.map((x) => x.versionId)) });
 		return { seen: workflows.length, deleted: grouped.removed.length };
 	}
 }

--- a/packages/@n8n/db/src/repositories/workflow-history.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-history.repository.ts
@@ -47,9 +47,9 @@ export class WorkflowHistoryRepository extends Repository<WorkflowHistory> {
 			.execute();
 	}
 
-	private makeSkipActiveAndNamedVersionsRule(activeVersions: string[]) {
+	private makeSkipActiveAndNamedVersionsRule(activeVersions: Set<string>) {
 		return (prev: WorkflowHistory, _next: WorkflowHistory): boolean =>
-			prev.name !== null || prev.description !== null || activeVersions.includes(prev.versionId);
+			prev.name !== null || prev.description !== null || activeVersions.has(prev.versionId);
 	}
 
 	async getWorkflowIdsInRange(startDate: Date, endDate: Date) {
@@ -97,7 +97,7 @@ export class WorkflowHistoryRepository extends Repository<WorkflowHistory> {
 		const publishedVersions =
 			await this.workflowPublishHistoryRepository.getPublishedVersions(workflowId);
 		const grouped = groupWorkflows<WorkflowHistory>(workflows, rules, [
-			this.makeSkipActiveAndNamedVersionsRule(publishedVersions.map((x) => x.versionId)),
+			this.makeSkipActiveAndNamedVersionsRule(new Set(publishedVersions.map((x) => x.versionId))),
 			SKIP_RULES.skipDifferentUsers,
 			...skipRules,
 		]);

--- a/packages/@n8n/db/src/repositories/workflow-history.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-history.repository.ts
@@ -92,7 +92,6 @@ export class WorkflowHistoryRepository extends Repository<WorkflowHistory> {
 			.getMany();
 
 		// Group by workflowId
-
 		const versionsToDelete = [];
 		const publishedVersions =
 			await this.workflowPublishHistoryRepository.getPublishedVersions(workflowId);
@@ -101,12 +100,8 @@ export class WorkflowHistoryRepository extends Repository<WorkflowHistory> {
 			SKIP_RULES.skipDifferentUsers,
 			...skipRules,
 		]);
-		for (const group of grouped) {
-			for (const wf of group.groupedWorkflows) {
-				versionsToDelete.push(wf.versionId);
-			}
-		}
-		await this.delete({ versionId: In(versionsToDelete) });
+
+		await this.delete({ versionId: In(grouped.removed.map((x) => x.versionId)) });
 		return { seen: workflows.length, deleted: versionsToDelete.length };
 	}
 }

--- a/packages/@n8n/db/src/repositories/workflow-history.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-history.repository.ts
@@ -92,7 +92,6 @@ export class WorkflowHistoryRepository extends Repository<WorkflowHistory> {
 			.getMany();
 
 		// Group by workflowId
-		const versionsToDelete = [];
 		const publishedVersions =
 			await this.workflowPublishHistoryRepository.getPublishedVersions(workflowId);
 		const grouped = groupWorkflows<WorkflowHistory>(workflows, rules, [
@@ -101,7 +100,7 @@ export class WorkflowHistoryRepository extends Repository<WorkflowHistory> {
 			...skipRules,
 		]);
 
-		await this.delete({ versionId: In(grouped.removed.map((x) => x.versionId)) });
-		return { seen: workflows.length, deleted: versionsToDelete.length };
+		const result = await this.delete({ versionId: In(grouped.removed.map((x) => x.versionId)) });
+		return { seen: workflows.length, deleted: grouped.removed.length };
 	}
 }

--- a/packages/cli/test/integration/database/repositories/workflow-history.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/workflow-history.repository.test.ts
@@ -113,7 +113,7 @@ describe('WorkflowHistoryRepository', () => {
 			}
 		});
 
-		it.only('should never prune previously active or named versions', async () => {
+		it('should never prune previously active or named versions', async () => {
 			// ARRANGE
 			const id1 = uuid();
 			const id2 = uuid();
@@ -170,15 +170,13 @@ describe('WorkflowHistoryRepository', () => {
 
 			// ASSERT
 			expect(seen).toBe(5);
-			// expect(deleted).toBe(1);
+			expect(deleted).toBe(2);
 
 			const history = await repository.find();
 			// expect(history.length).toBe(4);
 			expect(history).toEqual([
 				expect.objectContaining({ versionId: id1 }),
-				// expect.objectContaining({ versionId: id2 }),
-				// expect.objectContaining({ versionId: id3 }),
-				// expect.objectContaining({ versionId: id4 }),
+				expect.objectContaining({ versionId: id2 }),
 				expect.objectContaining({ versionId: id5 }),
 			]);
 

--- a/packages/cli/test/integration/database/repositories/workflow-history.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/workflow-history.repository.test.ts
@@ -113,7 +113,7 @@ describe('WorkflowHistoryRepository', () => {
 			}
 		});
 
-		it('should never prune previously active or named versions', async () => {
+		it.only('should never prune previously active or named versions', async () => {
 			// ARRANGE
 			const id1 = uuid();
 			const id2 = uuid();
@@ -169,15 +169,16 @@ describe('WorkflowHistoryRepository', () => {
 			]);
 
 			// ASSERT
-			expect(deleted).toBe(1);
 			expect(seen).toBe(5);
+			// expect(deleted).toBe(1);
 
 			const history = await repository.find();
-			expect(history.length).toBe(4);
+			// expect(history.length).toBe(4);
 			expect(history).toEqual([
 				expect.objectContaining({ versionId: id1 }),
-				expect.objectContaining({ versionId: id2 }),
-				expect.objectContaining({ versionId: id4 }),
+				// expect.objectContaining({ versionId: id2 }),
+				// expect.objectContaining({ versionId: id3 }),
+				// expect.objectContaining({ versionId: id4 }),
 				expect.objectContaining({ versionId: id5 }),
 			]);
 

--- a/packages/cli/test/integration/database/repositories/workflow-history.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/workflow-history.repository.test.ts
@@ -224,7 +224,6 @@ describe('WorkflowHistoryRepository', () => {
 			expect(deleted).toBe(2);
 
 			const history = await repository.find();
-			// expect(history.length).toBe(4);
 			expect(history).toEqual([
 				expect.objectContaining({ versionId: id2 }),
 				expect.objectContaining({ versionId: id4 }),

--- a/packages/cli/test/integration/workflow-history-compaction.service.test.ts
+++ b/packages/cli/test/integration/workflow-history-compaction.service.test.ts
@@ -115,7 +115,7 @@ describe('compacting cycle', () => {
 		}
 
 		// ACT
-		await compactionService['compactHistories']();
+		await compactionService['compactRecentHistories']();
 
 		// ASSERT
 		const allHistories = await Container.get(WorkflowHistoryRepository).find({});
@@ -196,7 +196,7 @@ describe('compacting cycle', () => {
 		);
 
 		// Expect wf1 and wf2 to be handled in the first batch, with wf3 untouched due to the long delay after batching
-		void compactionService['compactHistories']();
+		void compactionService['compactRecentHistories']();
 		await sleep(500);
 
 		// ASSERT

--- a/packages/cli/test/integration/workflow-history-compaction.service.test.ts
+++ b/packages/cli/test/integration/workflow-history-compaction.service.test.ts
@@ -203,23 +203,20 @@ describe('compacting cycle', () => {
 		const allHistories = await Container.get(WorkflowHistoryRepository).find({});
 		const allVersions = allHistories.map((x) => x.versionId);
 
-		const expectedVersions = [
-			wf1_history[0],
-			wf1_history[1],
-			wf1_history[3],
-			wf2_history[0],
-			wf2_history[2],
-			wf3_history[0],
-			wf3_history[2],
-		].map((x) => x[1]);
+		const expectedVersions = [wf1_history[0], wf1_history[3], wf2_history[2], wf3_history[2]].map(
+			(x) => x[1],
+		);
 		expect(allVersions).toEqual(expect.arrayContaining(expectedVersions));
 
-		const includesWf1 = allVersions.includes(wf1_history[2][1]);
-		const includesWf2 = allVersions.includes(wf2_history[1][1]);
-		const includesWf3 = allVersions.includes(wf3_history[1][1]);
+		// Here we check that exactly one of the three workflows was not handled yet
+		// To confirm that batching made us stop after the second workflow
+		const includesWf1 =
+			allVersions.includes(wf1_history[1][1]) && allVersions.includes(wf1_history[2][1]);
+		const includesWf2 =
+			allVersions.includes(wf2_history[0][1]) && allVersions.includes(wf2_history[1][1]);
+		const includesWf3 =
+			allVersions.includes(wf3_history[0][1]) && allVersions.includes(wf3_history[1][1]);
 
-		// Batching should cause the compaction to stop before one of the three workflows
-		// Is handled.
 		expect(0 + +includesWf1 + +includesWf2 + +includesWf3).toBe(1);
 	});
 });

--- a/packages/workflow/src/workflow-diff.ts
+++ b/packages/workflow/src/workflow-diff.ts
@@ -14,7 +14,7 @@ export type DiffableWorkflow<N extends DiffableNode = DiffableNode> = {
 	nodes: N[];
 	connections: IConnections;
 	createdAt: Date;
-	user?: unknown;
+	authors?: string;
 };
 
 export const enum NodeDiffStatus {
@@ -159,7 +159,7 @@ function skipDifferentUsers<N extends DiffableNode = DiffableNode>(
 	prev: DiffableWorkflow<N>,
 	next: DiffableWorkflow<N>,
 ) {
-	return next.user !== prev.user;
+	return next.authors !== prev.authors;
 }
 
 export const RULES = {
@@ -231,7 +231,7 @@ export function groupWorkflows<W extends WorkflowDiffBase = WorkflowDiffBase>(
 				const shouldMerge = rule(diffs[i - 1].from, diffs[i].to, wcs);
 				if (shouldMerge) {
 					const right = diffs.splice(i, 1)[0];
-					if (!right) throw new Error('invariant broken - no ');
+					if (!right) throw new Error('invariant broken');
 
 					// merge diffs
 					diffs[i - 1].workflowChangeSet = wcs;

--- a/packages/workflow/test/workflow-diff.test.ts
+++ b/packages/workflow/test/workflow-diff.test.ts
@@ -289,159 +289,84 @@ describe('groupWorkflows', () => {
 		workflows = [];
 	});
 	describe('basic grouping', () => {
-		it('should group workflows with no changes', () => {
+		it('should not merge workflows without rule', () => {
 			workflows = mock<[IWorkflowBase, IWorkflowBase]>([
 				{ id: '1', nodes: [node1, node2] },
 				{ id: '1', nodes: [node1, node2] },
 			]);
-			const grouped = groupWorkflows(workflows, rules, []);
+			const { removed, remaining } = groupWorkflows(workflows, []);
 
-			expect(grouped.length).toBe(1);
-			expect(grouped[0].from).toEqual(workflows[0]);
-			expect(grouped[0].to).toEqual(workflows[1]);
-			expect(grouped[0].workflowChangeSet.nodes.size).toBe(2);
-			expect(grouped[0].workflowChangeSet.nodes.get(node1.id)?.status).toBe(NodeDiffStatus.Eq);
-			expect(grouped[0].workflowChangeSet.nodes.get(node2.id)?.status).toBe(NodeDiffStatus.Eq);
-			expect(grouped[0].groupedWorkflows).toEqual([]);
+			expect(remaining.length).toBe(2);
+			expect(removed.length).toBe(0);
 		});
 
-		it('should group workflows with added nodes', () => {
+		it('should group workflows with true rule', () => {
 			workflows = mock<[IWorkflowBase, IWorkflowBase]>([
 				{ id: '1', nodes: [node1] },
 				{ id: '1', nodes: [node1, node2] },
 			]);
 
-			const grouped = groupWorkflows(workflows, rules, []);
+			const { removed, remaining } = groupWorkflows(workflows, [() => true]);
 
-			expect(grouped.length).toBe(1);
-			expect(grouped[0].from).toEqual(workflows[0]);
-			expect(grouped[0].to).toEqual(workflows[1]);
-			expect(grouped[0].workflowChangeSet.nodes.size).toBe(2);
-			expect(grouped[0].workflowChangeSet.nodes.get(node1.id)?.status).toBe(NodeDiffStatus.Eq);
-			expect(grouped[0].workflowChangeSet.nodes.get(node2.id)?.status).toBe(NodeDiffStatus.Added);
-			expect(grouped[0].groupedWorkflows).toEqual([]);
+			expect(removed.length).toBe(1);
+			expect(remaining.length).toBe(1);
+			expect(removed[0]).toBe(workflows[0]);
+			expect(remaining[0]).toBe(workflows[1]);
 		});
 
-		it('should group workflows with deleted nodes', () => {
-			workflows = mock<[IWorkflowBase, IWorkflowBase]>([
-				{ id: '1', nodes: [node1, node2] },
-				{ id: '1', nodes: [node1] },
-			]);
-
-			const grouped = groupWorkflows(workflows, rules, []);
-
-			expect(grouped.length).toBe(1);
-			expect(grouped[0].from).toEqual(workflows[0]);
-			expect(grouped[0].to).toEqual(workflows[1]);
-			expect(grouped[0].workflowChangeSet.nodes.size).toBe(2);
-			expect(grouped[0].workflowChangeSet.nodes.get(node1.id)?.status).toBe(NodeDiffStatus.Eq);
-			expect(grouped[0].workflowChangeSet.nodes.get(node2.id)?.status).toBe(NodeDiffStatus.Deleted);
-
-			expect(grouped[0].groupedWorkflows).toEqual([]);
-		});
-
-		it('should group workflows with modified nodes', () => {
-			const modifiedNode2 = { id: '2', parameter: { a: 3 } };
-			workflows = mock<[IWorkflowBase, IWorkflowBase]>([
-				{ id: '1', nodes: [node1, node2] },
-				{ id: '1', nodes: [node1, modifiedNode2] },
-			]);
-
-			const grouped = groupWorkflows(workflows, rules, []);
-
-			expect(grouped.length).toBe(1);
-			expect(grouped[0].from).toEqual(workflows[0]);
-			expect(grouped[0].to).toEqual(workflows[1]);
-			expect(grouped[0].workflowChangeSet.nodes.size).toBe(2);
-			expect(grouped[0].workflowChangeSet.nodes.get(node1.id)?.status).toBe(NodeDiffStatus.Eq);
-			expect(grouped[0].workflowChangeSet.nodes.get(modifiedNode2.id)?.status).toBe(
-				NodeDiffStatus.Modified,
-			);
-			expect(grouped[0].groupedWorkflows).toEqual([]);
-		});
-
-		it('should handle multiple workflow groups', () => {
+		it('should handle multiple workflows when always merging', () => {
 			workflows = mock<IWorkflowBase[]>([
 				{ id: '1', nodes: [node1] },
 				{ id: '1', nodes: [node1, node2] },
 				{ id: '1', nodes: [node1] },
+				{ id: '1', nodes: [] },
+				{ id: '1', nodes: [node1, node2] },
 			]);
 
-			const grouped = groupWorkflows(workflows, rules, []);
+			const { removed, remaining } = groupWorkflows(workflows, [() => true]);
 
-			expect(grouped.length).toBe(2);
-			expect(grouped[0].from).toEqual(workflows[0]);
-			expect(grouped[0].to).toEqual(workflows[1]);
-			expect(grouped[0].workflowChangeSet.nodes.size).toBe(2);
-			expect(grouped[0].workflowChangeSet.nodes.get(node1.id)?.status).toBe(NodeDiffStatus.Eq);
-			expect(grouped[0].workflowChangeSet.nodes.get(node2.id)?.status).toBe(NodeDiffStatus.Added);
+			expect(removed.length).toBe(4);
+			expect(remaining.length).toBe(1);
+		});
 
-			expect(grouped[1].from).toEqual(workflows[1]);
-			expect(grouped[1].to).toEqual(workflows[2]);
-			expect(grouped[1].workflowChangeSet.nodes.size).toBe(2);
-			expect(grouped[1].workflowChangeSet.nodes.get(node1.id)?.status).toBe(NodeDiffStatus.Eq);
-			expect(grouped[1].workflowChangeSet.nodes.get(node2.id)?.status).toBe(NodeDiffStatus.Deleted);
+		it('should handle multiple workflows when sometimes merging', () => {
+			workflows = mock<IWorkflowBase[]>([
+				{ id: '1', versionId: '1', nodes: [node1] },
+				{ id: '1', versionId: '2', nodes: [node1, node2] },
+				{ id: '1', versionId: '3', nodes: [node1] },
+				{ id: '1', versionId: '4', nodes: [] },
+				{ id: '1', versionId: '5', nodes: [node1, node2] },
+			]);
+
+			const { removed, remaining } = groupWorkflows(
+				workflows,
+				[() => true],
+				[(prev, _next) => ['2', '4'].includes(prev.versionId ?? '')],
+			);
+
+			expect(removed.length).toBe(2);
+			expect(remaining.length).toBe(3);
+			expect(remaining).toEqual([workflows[1], workflows[3], workflows[4]]);
+			expect(removed).toEqual(expect.arrayContaining([workflows[2], workflows[0]]));
 		});
 
 		it('should handle empty workflows array', () => {
-			const grouped = groupWorkflows(workflows, rules, []);
+			const { remaining, removed } = groupWorkflows(workflows, rules, []);
 
-			expect(grouped.length).toBe(0);
+			expect(remaining.length).toBe(0);
+			expect(removed.length).toBe(0);
 		});
 
 		it('should handle single workflow', () => {
 			const workflows = mock<IWorkflowBase[]>([{ id: '1', nodes: [node1] }]);
 
-			const grouped = groupWorkflows(workflows, rules, []);
+			const { removed, remaining } = groupWorkflows(workflows, rules, []);
 
-			expect(grouped.length).toBe(1);
-			expect(grouped[0].from).toEqual(workflows[0]);
-			expect(grouped[0].to).toEqual(workflows[0]);
-			expect(grouped[0].workflowChangeSet.nodes.size).toEqual(1);
-			expect(grouped[0].workflowChangeSet.nodes.get(node1.id)?.status).toEqual(NodeDiffStatus.Eq);
-			expect(grouped[0].groupedWorkflows).toEqual([]);
+			expect(removed.length).toBe(0);
+			expect(remaining.length).toBe(1);
 		});
 	});
 	describe('rules', () => {
-		it('should not apply an inapplicable rule', () => {
-			workflows = mock<IWorkflowBase[]>([
-				{ id: '1', nodes: [node1] },
-				{ id: '1', nodes: [node1, node2] },
-				{ id: '1', nodes: [node1] },
-			]);
-
-			const alwaysMergeRule: DiffRule = (_l, _r) => false;
-			const rules = [alwaysMergeRule];
-
-			const grouped = groupWorkflows(workflows, rules, []);
-
-			expect(grouped.length).toBe(2);
-			expect(grouped[0].from).toEqual(workflows[0]);
-			expect(grouped[0].to).toEqual(workflows[1]);
-			expect(grouped[0].groupedWorkflows).toEqual([]);
-			expect(grouped[1].from).toEqual(workflows[1]);
-			expect(grouped[1].to).toEqual(workflows[2]);
-			expect(grouped[1].groupedWorkflows).toEqual([]);
-		});
-		it('should apply a given rule', () => {
-			workflows = mock<IWorkflowBase[]>([
-				{ id: '1', nodes: [node1] },
-				{ id: '1', nodes: [node1, node2] },
-				{ id: '1', nodes: [node1] },
-			]);
-
-			const alwaysMergeRule: DiffRule = (_l, _r) => true;
-			const rules = [alwaysMergeRule];
-
-			const grouped = groupWorkflows(workflows, rules, []);
-
-			expect(grouped.length).toBe(1);
-			expect(grouped[0].from).toEqual(workflows[0]);
-			expect(grouped[0].to).toEqual(workflows[2]);
-			expect(grouped[0].groupedWorkflows).toEqual([workflows[1]]);
-			expect(grouped[0].workflowChangeSet.nodes.size).toBe(1);
-			expect(grouped[0].workflowChangeSet.nodes.get(node1.id)?.status).toBe(NodeDiffStatus.Eq);
-		});
 		describe('mergeAdditiveChanges', () => {
 			const createWorkflow = (id: string, nodes: DiffableNode[]): IWorkflowBase => {
 				return {
@@ -590,11 +515,11 @@ describe('groupWorkflows', () => {
 			});
 		});
 		describe('skipDifferentUsers', () => {
-			const createWorkflow = (user: unknown): DiffableWorkflow<DiffableNode> => ({
+			const createWorkflow = (authors?: string): DiffableWorkflow<DiffableNode> => ({
 				nodes: [],
 				connections: {},
 				createdAt: new Date(),
-				user,
+				authors,
 			});
 
 			it('should return true when users are different', () => {
@@ -632,80 +557,6 @@ describe('groupWorkflows', () => {
 
 				expect(result).toBe(true);
 			});
-
-			it('should handle complex user objects', () => {
-				const user1 = { id: 1, name: 'User One' };
-				const user2 = { id: 2, name: 'User Two' };
-
-				const prev = createWorkflow(user1);
-				const next = createWorkflow(user2);
-
-				const result = SKIP_RULES.skipDifferentUsers(prev, next);
-
-				expect(result).toBe(true);
-			});
-
-			it('should return false when complex user objects are deeply equal', () => {
-				const user = { id: 1, name: 'User One' };
-
-				const prev = createWorkflow(user);
-				const next = createWorkflow(user);
-
-				const result = SKIP_RULES.skipDifferentUsers(prev, next);
-
-				expect(result).toBe(false);
-			});
-		});
-	});
-	describe('groupWorkflows - skipRules', () => {
-		const node1 = mock<DiffableNode>({ id: '1', parameters: { a: 1 } });
-		const node2 = mock<DiffableNode>({ id: '2', parameters: { a: 2 } });
-
-		let workflows: IWorkflowBase[];
-		beforeEach(() => {
-			workflows = [];
-		});
-
-		it('should skip merging workflows when skipRules apply', () => {
-			workflows = mock<IWorkflowBase[]>([
-				{ id: '1', nodes: [node1] },
-				{ id: '1', nodes: [node1, node2] },
-				{ id: '1', nodes: [node1] },
-				{ id: '1', nodes: [node1, node2] },
-			]);
-
-			const trueRule: DiffRule = (_l, _r) => true;
-			const grouped = groupWorkflows(workflows, [trueRule], [trueRule]);
-
-			expect(grouped.length).toBe(3);
-			expect(grouped[0].from).toEqual(workflows[0]);
-			expect(grouped[0].to).toEqual(workflows[1]);
-			expect(grouped[0].groupedWorkflows).toEqual([]);
-			expect(grouped[1].from).toEqual(workflows[1]);
-			expect(grouped[1].to).toEqual(workflows[2]);
-			expect(grouped[1].groupedWorkflows).toEqual([]);
-			expect(grouped[2].from).toEqual(workflows[2]);
-			expect(grouped[2].to).toEqual(workflows[3]);
-			expect(grouped[2].groupedWorkflows).toEqual([]);
-		});
-
-		it('should not skip merging workflows when skipRules do not apply', () => {
-			workflows = mock<IWorkflowBase[]>([
-				{ id: '1', nodes: [node1] },
-				{ id: '1', nodes: [node1, node2] },
-				{ id: '1', nodes: [node1] },
-			]);
-
-			const skipRule: DiffRule = (_l, _r) => false; // Never skip merging
-			const grouped = groupWorkflows(workflows, [], [skipRule]);
-
-			expect(grouped.length).toBe(2);
-			expect(grouped[0].from).toEqual(workflows[0]);
-			expect(grouped[0].to).toEqual(workflows[1]);
-			expect(grouped[0].groupedWorkflows).toEqual([]);
-			expect(grouped[1].from).toEqual(workflows[1]);
-			expect(grouped[1].to).toEqual(workflows[2]);
-			expect(grouped[1].groupedWorkflows).toEqual([]);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

A few changes here:
- Actually include rule to never delete consecutive versions by different users
- Simplify groupWorkflows severely - this proves unnecessary and introduced two bugs this PR fixes
- Move rules definition from workflow-history.repo to the service in preparation of a second compaction cycle after a week
- Remove more unused code

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4601

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
