### PR TITLE
fix(editor): Only shift downstream nodes to the right of insertion point

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -1443,7 +1443,22 @@ export function useCanvasOperations() {
 				editableWorkflowObject.value,
 				candidate.name,
 			);
-			downstream.forEach((name) => candidateNames.add(name));
+			downstream
+				// Filter the downstream nodes to find candidates that need to be shifted right.
+				.filter((name) => {
+					const node = workflowsStore.getNodeByName(name);
+					if (!node) {
+						return false;
+					}
+					const nodeRightEdge = node.position[0] + DEFAULT_NODE_SIZE[0];
+
+					// Check if the current node visually overlaps with, or is entirely to the right of,
+					// the new insertion point (insertX).
+					const overlapsOrIsToTheRight = nodeRightEdge > insertX || node.position[0] >= insertX;
+
+					return overlapsOrIsToTheRight;
+				})
+				.forEach((name) => candidateNames.add(name));
 		}
 
 		// Step 3: Get all candidate regular nodes (they overlap with or are downstream of insertion)
@@ -2924,6 +2939,7 @@ export function useCanvasOperations() {
 		cutNodes,
 		duplicateNodes,
 		getNodesToSave,
+		getNodesToShift,
 		revertDeleteNode,
 		addConnections,
 		createConnection,

--- a/packages/testing/playwright/tests/e2e/regression/PAY-4367-node-shifting-cyclic.spec.ts
+++ b/packages/testing/playwright/tests/e2e/regression/PAY-4367-node-shifting-cyclic.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '../../../fixtures/base';
+
+/**
+ * PAY-4367: Node shifting in cyclic workflows
+ *
+ * Bug: When inserting a node, ALL downstream nodes were shifted right,
+ * including nodes to the LEFT of the insertion point (reachable via cycle).
+ *
+ * Workflow structure:
+ *   Trigger(-220) → Start(0) → Middle(220) → End(440)
+ *                      ↑___________________________|  (cycle)
+ *
+ * When inserting between Start and Middle:
+ * - insertX ≈ 158 (midpoint between Start's right edge at 96 and Middle at 220)
+ * - Start is "downstream" via cycle: Middle → End → Start
+ * - But Start (x=0, rightEdge=96) is LEFT of insertX
+ *
+ * Fix filters downstream nodes by position:
+ *   overlapsOrIsToTheRight = (rightEdge > insertX) || (position >= insertX)
+ *
+ * Expected behavior:
+ * - Start: should NOT shift (rightEdge 96 < insertX ~158)
+ * - Middle, End: should shift right (position >= insertX)
+ */
+test.describe('PAY-4367: Node shifting in cyclic workflows', () => {
+	test('should not shift nodes to the left of insertion point in cyclic workflow', async ({
+		n8n,
+	}) => {
+		// Workflow: Trigger → Start(x=0) → Middle(x=220) → End(x=440) → Start (cycle)
+		await n8n.start.fromBlankCanvas();
+		await n8n.canvas.importWorkflow('Cyclic_workflow_for_insertion_test.json', 'Cyclic Test');
+
+		// Record positions BEFORE insertion
+		const posStartBefore = await n8n.canvas.getNodePosition('Start');
+		const posMiddleBefore = await n8n.canvas.getNodePosition('Middle');
+		const posEndBefore = await n8n.canvas.getNodePosition('End');
+
+		// ACT: Insert node between Start and Middle
+		await n8n.canvas.addNodeBetweenNodes('Start', 'Middle', 'HTTP Request');
+
+		// Record positions AFTER insertion
+		const posStartAfter = await n8n.canvas.getNodePosition('Start');
+		const posMiddleAfter = await n8n.canvas.getNodePosition('Middle');
+		const posEndAfter = await n8n.canvas.getNodePosition('End');
+
+		// ASSERT: Start should NOT have shifted (it's to the left of insertion)
+		// This was the bug - Start would shift because it's "downstream" via the cycle
+		expect(posStartAfter.x).toBeCloseTo(posStartBefore.x, 0);
+
+		// ASSERT: Middle and End should have shifted right
+		expect(posMiddleAfter.x).toBeGreaterThan(posMiddleBefore.x);
+		expect(posEndAfter.x).toBeGreaterThan(posEndBefore.x);
+
+		// Verify the new node was added (Trigger + Start + Middle + End + HTTP Request = 5)
+		await expect(n8n.canvas.nodeByName('HTTP Request')).toBeVisible();
+		await expect(n8n.canvas.getCanvasNodes()).toHaveCount(5);
+	});
+});

--- a/packages/testing/playwright/tests/e2e/regression/PAY-4367-node-shifting-cyclic.spec.ts
+++ b/packages/testing/playwright/tests/e2e/regression/PAY-4367-node-shifting-cyclic.spec.ts
@@ -45,7 +45,7 @@ test.describe('PAY-4367: Node shifting in cyclic workflows', () => {
 
 		// ASSERT: Start should NOT have shifted (it's to the left of insertion)
 		// This was the bug - Start would shift because it's "downstream" via the cycle
-		expect(posStartAfter.x).toBeCloseTo(posStartBefore.x, 0);
+		expect(posStartAfter.x).toBe(posStartBefore.x);
 
 		// ASSERT: Middle and End should have shifted right
 		expect(posMiddleAfter.x).toBeGreaterThan(posMiddleBefore.x);

--- a/packages/testing/playwright/workflows/Cyclic_workflow_for_insertion_test.json
+++ b/packages/testing/playwright/workflows/Cyclic_workflow_for_insertion_test.json
@@ -1,0 +1,58 @@
+{
+	"name": "Cyclic Workflow",
+	"nodes": [
+		{
+			"id": "trigger",
+			"name": "Trigger",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [-220, 300],
+			"parameters": {}
+		},
+		{
+			"id": "a",
+			"name": "Start",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [0, 300],
+			"parameters": {}
+		},
+		{
+			"id": "b",
+			"name": "Middle",
+			"type": "n8n-nodes-base.code",
+			"typeVersion": 2,
+			"position": [220, 300],
+			"parameters": {
+				"jsCode": "return items;"
+			}
+		},
+		{
+			"id": "c",
+			"name": "End",
+			"type": "n8n-nodes-base.set",
+			"typeVersion": 3.4,
+			"position": [440, 300],
+			"parameters": {
+				"options": {}
+			}
+		}
+	],
+	"connections": {
+		"Trigger": {
+			"main": [[{ "node": "Start", "type": "main", "index": 0 }]]
+		},
+		"Start": {
+			"main": [[{ "node": "Middle", "type": "main", "index": 0 }]]
+		},
+		"Middle": {
+			"main": [[{ "node": "End", "type": "main", "index": 0 }]]
+		},
+		"End": {
+			"main": [[{ "node": "Start", "type": "main", "index": 0 }]]
+		}
+	},
+	"settings": {
+		"executionOrder": "v1"
+	}
+}


### PR DESCRIPTION
## Summary

Refines the node shifting logic to prevent unnecessary layout changes when inserting a new node into a workflow.

Changes:
The set of downstream candidate nodes is now filtered based on their X position. Only nodes that visually overlap with the insertion point (`insertX`) or are entirely to the right of it are added to the list of nodes that must be shifted.

Previously, when a node was inserted, all nodes found in the 'downstream' path were shifted right, regardless of their current X position relative to the insertion point. In complex or looped workflows where downstream nodes might wrap back to the left, this caused:
1. Unnecessary shifting of all nodes to the right.
2. Incorrect final positioning for the newly inserted node.


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
