### PR TITLE
fix(Simple Memory Node): Don't allow adding simple memory node if instance in queue or multi-main mode

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryBufferWindow/MemoryBufferWindow.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryBufferWindow/MemoryBufferWindow.node.ts
@@ -106,6 +106,13 @@ export class MemoryBufferWindow implements INodeType {
 		properties: [
 			getConnectionHintNoticeField([NodeConnectionTypes.AiAgent]),
 			{
+				displayName:
+					'This node stores memory locally in the n8n instance. It is not compatible with Queue Mode or Multi-Main setups, as memory will not be shared across workers. For production use with scaling, consider using an external memory store such as Redis, Postgres, or another persistent memory node.',
+				name: 'scalingNotice',
+				type: 'notice',
+				default: '',
+			},
+			{
 				displayName: 'Session Key',
 				name: 'sessionKey',
 				type: 'string',

--- a/packages/frontend/editor-ui/src/app/constants/nodeTypes.ts
+++ b/packages/frontend/editor-ui/src/app/constants/nodeTypes.ts
@@ -41,6 +41,7 @@ export const OPEN_AI_NODE_TYPE = '@n8n/n8n-nodes-langchain.openAi';
 export const OPEN_AI_NODE_MESSAGE_ASSISTANT_TYPE =
 	'@n8n/n8n-nodes-langchain.openAi.assistant.message';
 export const OPEN_AI_ASSISTANT_NODE_TYPE = '@n8n/n8n-nodes-langchain.openAiAssistant';
+export const SIMPLE_MEMORY_NODE_TYPE = '@n8n/n8n-nodes-langchain.memoryBufferWindow';
 export const BASIC_CHAIN_NODE_TYPE = '@n8n/n8n-nodes-langchain.chainLlm';
 export const QA_CHAIN_NODE_TYPE = '@n8n/n8n-nodes-langchain.chainRetrievalQa';
 export const MICROSOFT_TEAMS_NODE_TYPE = 'n8n-nodes-base.microsoftTeams';

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/composables/useActionsGeneration.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/composables/useActionsGeneration.ts
@@ -5,6 +5,7 @@ import {
 	AI_SUBCATEGORY,
 	CUSTOM_API_CALL_KEY,
 	HTTP_REQUEST_NODE_TYPE,
+	SIMPLE_MEMORY_NODE_TYPE,
 } from '@/app/constants';
 import memoize from 'lodash/memoize';
 import startCase from 'lodash/startCase';
@@ -19,6 +20,7 @@ import type {
 import { i18n } from '@n8n/i18n';
 
 import { getCredentialOnlyNodeType } from '@/app/utils/credentialOnlyNodes';
+import { useSettingsStore } from '@/app/stores/settings.store';
 import { formatTriggerActionName } from '../nodeCreator.utils';
 import { useEvaluationStore } from '@/features/ai/evaluation.ee/evaluation.store';
 
@@ -367,15 +369,28 @@ export function useActionsGenerator() {
 		httpOnlyCredentials: ICredentialType[],
 	) {
 		const evaluationStore = useEvaluationStore();
+		const settingsStore = useSettingsStore();
 
 		const visibleNodeTypes = nodeTypes.filter((node) => {
-			if (evaluationStore.isEvaluationEnabled) {
-				return true;
+			// Filter out evaluation nodes if evaluation is not enabled
+			if (!evaluationStore.isEvaluationEnabled) {
+				if (
+					node.name === 'n8n-nodes-base.evaluation' ||
+					node.name === 'n8n-nodes-base.evaluationTrigger'
+				) {
+					return false;
+				}
 			}
-			return (
-				node.name !== 'n8n-nodes-base.evaluation' &&
-				node.name !== 'n8n-nodes-base.evaluationTrigger'
-			);
+
+			// Filter out Simple Memory node in queue mode or multi-main setup
+			// because it stores memory in-process which doesn't work with multiple workers
+			if (settingsStore.isQueueModeEnabled || settingsStore.isMultiMain) {
+				if (node.name === SIMPLE_MEMORY_NODE_TYPE) {
+					return false;
+				}
+			}
+
+			return true;
 		});
 
 		const actions: ActionsRecord<typeof mergedNodes> = {};

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/composables/useActionsGeneration.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/composables/useActionsGeneration.ts
@@ -9,12 +9,14 @@ import {
 } from '@/app/constants';
 import memoize from 'lodash/memoize';
 import startCase from 'lodash/startCase';
-import type {
-	ICredentialType,
-	INodeProperties,
-	INodePropertyCollection,
-	INodePropertyOptions,
-	INodeTypeDescription,
+import {
+	EVALUATION_NODE_TYPE,
+	EVALUATION_TRIGGER_NODE_TYPE,
+	type ICredentialType,
+	type INodeProperties,
+	type INodePropertyCollection,
+	type INodePropertyOptions,
+	type INodeTypeDescription,
 } from 'n8n-workflow';
 
 import { i18n } from '@n8n/i18n';
@@ -374,10 +376,7 @@ export function useActionsGenerator() {
 		const visibleNodeTypes = nodeTypes.filter((node) => {
 			// Filter out evaluation nodes if evaluation is not enabled
 			if (!evaluationStore.isEvaluationEnabled) {
-				if (
-					node.name === 'n8n-nodes-base.evaluation' ||
-					node.name === 'n8n-nodes-base.evaluationTrigger'
-				) {
+				if ([EVALUATION_NODE_TYPE, EVALUATION_TRIGGER_NODE_TYPE].includes(node.name)) {
 					return false;
 				}
 			}

--- a/packages/testing/playwright/config/constants.ts
+++ b/packages/testing/playwright/config/constants.ts
@@ -30,6 +30,7 @@ export const AI_TOOL_WIKIPEDIA_NODE_NAME = 'Wikipedia';
 export const AI_TOOL_HTTP_NODE_NAME = 'HTTP Request Tool';
 export const AI_LANGUAGE_MODEL_OPENAI_CHAT_MODEL_NODE_NAME = 'OpenAI Chat Model';
 export const AI_MEMORY_POSTGRES_NODE_NAME = 'Postgres Chat Memory';
+export const AI_MEMORY_REDIS_CHAT_NODE_NAME = 'Redis Chat Memory';
 export const AI_OUTPUT_PARSER_AUTO_FIXING_NODE_NAME = 'Auto-fixing Output Parser';
 export const WEBHOOK_NODE_NAME = 'Webhook';
 export const EXECUTE_WORKFLOW_NODE_NAME = 'Execute Workflow';

--- a/packages/testing/playwright/tests/e2e/ai/langchain-agents.spec.ts
+++ b/packages/testing/playwright/tests/e2e/ai/langchain-agents.spec.ts
@@ -2,7 +2,7 @@ import {
 	AGENT_NODE_NAME,
 	EDIT_FIELDS_SET_NODE_NAME,
 	AI_LANGUAGE_MODEL_OPENAI_CHAT_MODEL_NODE_NAME,
-	AI_MEMORY_WINDOW_BUFFER_MEMORY_NODE_NAME,
+	AI_MEMORY_REDIS_CHAT_NODE_NAME,
 	AI_TOOL_CALCULATOR_NODE_NAME,
 	AI_OUTPUT_PARSER_AUTO_FIXING_NODE_NAME,
 	AI_TOOL_CODE_NODE_NAME,
@@ -122,7 +122,7 @@ test.describe('Langchain Integration @capability:proxy', () => {
 		test('should add nodes to all Agent node input types', async ({ n8n }) => {
 			const agentSubNodes = [
 				AI_LANGUAGE_MODEL_OPENAI_CHAT_MODEL_NODE_NAME,
-				AI_MEMORY_WINDOW_BUFFER_MEMORY_NODE_NAME,
+				AI_MEMORY_REDIS_CHAT_NODE_NAME,
 				AI_TOOL_CALCULATOR_NODE_NAME,
 				AI_OUTPUT_PARSER_AUTO_FIXING_NODE_NAME,
 			];
@@ -138,7 +138,7 @@ test.describe('Langchain Integration @capability:proxy', () => {
 			);
 
 			await n8n.canvas.addSupplementalNodeToParent(
-				AI_MEMORY_WINDOW_BUFFER_MEMORY_NODE_NAME,
+				AI_MEMORY_REDIS_CHAT_NODE_NAME,
 				'ai_memory',
 				AGENT_NODE_NAME,
 				{ closeNDV: true },

--- a/packages/testing/playwright/tests/e2e/workflows/editor/ndv/ndv-floating-nodes.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/ndv/ndv-floating-nodes.spec.ts
@@ -85,10 +85,10 @@ test.describe('NDV Floating Nodes Navigation', () => {
 		await expect(n8n.ndv.getContainer()).toBeVisible();
 
 		await n8n.ndv.connectAISubNode('ai_languageModel', 'Anthropic Chat Model');
-		await n8n.ndv.connectAISubNode('ai_memory', 'Simple Memory');
+		await n8n.ndv.connectAISubNode('ai_memory', 'Redis Chat Memory');
 		await n8n.ndv.connectAISubNode('ai_tool', 'HTTP Request Tool');
 
-		await expect(n8n.ndv.getNodesWithIssues()).toHaveCount(2);
+		await expect(n8n.ndv.getNodesWithIssues()).toHaveCount(3);
 	});
 
 	test('should have the floating nodes in correct order', async ({ n8n }) => {


### PR DESCRIPTION
## Summary

In queue and multi-main mode there is no guarantee the simple memory sub-node will function correctly, especially in queue mode where the request could be handled by any of the different workers. Disabling adding the sub-node to avoid this foot-gun.

Addresses: https://linear.app/n8n/issue/AI-1869/disable-simple-memory-tool-unavailable-for-queue-mode-setup

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
