### PR TITLE
fix(ai-builder): Call onGenerationSuccess callback in multi-agent workflow

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/workflow-builder-agent.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/workflow-builder-agent.ts
@@ -227,6 +227,7 @@ export class WorkflowBuilderAgent {
 			instanceUrl: this.instanceUrl,
 			checkpointer: this.checkpointer,
 			featureFlags,
+			onGenerationSuccess: this.onGenerationSuccess,
 		});
 	}
 


### PR DESCRIPTION
## Summary

The onGenerationSuccess callback (used for credit deduction) was only being called in the legacy single-agent workflow. This adds the callback to the multi-agent workflow by invoking it in the responder node.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
