### PR TITLE
feat(core): add worker max jobs flag

### DIFF
--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -21,12 +21,18 @@ import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 
 const flagsSchema = z.object({
 	concurrency: z.number().int().default(10).describe('How many jobs can run in parallel.'),
+	maxJobs: z
+		.number()
+		.int()
+		.positive()
+		.optional()
+		.describe('How many jobs to process before shutting down. Leave unset to keep running.'),
 });
 
 @Command({
 	name: 'worker',
 	description: 'Starts a n8n worker',
-	examples: ['--concurrency=5'],
+	examples: ['--concurrency=5 --max-jobs=1'],
 	flagsSchema,
 })
 export class Worker extends BaseCommand<z.infer<typeof flagsSchema>> {
@@ -37,6 +43,8 @@ export class Worker extends BaseCommand<z.infer<typeof flagsSchema>> {
 	 * other than -1, else taken from `--concurrency` flag.
 	 */
 	private concurrency: number;
+
+	private maxJobs?: number;
 
 	private scalingService: ScalingService;
 
@@ -86,6 +94,7 @@ export class Worker extends BaseCommand<z.infer<typeof flagsSchema>> {
 		this.logger.debug(`Host ID: ${this.instanceSettings.hostId}`);
 
 		await this.setConcurrency();
+		this.maxJobs = this.flags.maxJobs;
 		await super.init();
 
 		Container.get(DeprecationService).warn();
@@ -164,13 +173,22 @@ export class Worker extends BaseCommand<z.infer<typeof flagsSchema>> {
 
 		await this.scalingService.setupQueue();
 
-		this.scalingService.setupWorker(this.concurrency);
+		const workerOptions = this.maxJobs
+			? { maxJobs: this.maxJobs, onMaxJobsReached: this.handleMaxJobsReached }
+			: undefined;
+
+		this.scalingService.setupWorker(this.concurrency, workerOptions);
 	}
 
 	async run() {
 		this.logger.info('\nn8n worker is now ready');
 		this.logger.info(` * Version: ${N8N_VERSION}`);
 		this.logger.info(` * Concurrency: ${this.concurrency}`);
+		if (this.maxJobs) {
+			this.logger.info(
+				` * Max jobs: ${this.maxJobs} (worker will shut down after reaching this limit)`,
+			);
+		}
 		this.logger.info('');
 
 		const endpointsConfig: WorkerServerEndpointsConfig = {
@@ -197,6 +215,14 @@ export class Worker extends BaseCommand<z.infer<typeof flagsSchema>> {
 		// Make sure that the process does not close
 		if (!inTest) await new Promise(() => {});
 	}
+
+	private handleMaxJobsReached = () => {
+		if (!this.maxJobs) return;
+
+		const jobsWord = this.maxJobs === 1 ? 'job' : 'jobs';
+		this.logger.info(`Processed ${this.maxJobs} ${jobsWord}. Shutting down worker...`);
+		process.kill(process.pid, 'SIGTERM');
+	};
 
 	async catch(error: Error) {
 		await this.exitWithCrash('Worker exiting due to an error.', error);

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -80,9 +80,27 @@ export class ScalingService {
 		this.logger.debug('Queue setup completed');
 	}
 
-	setupWorker(concurrency: number) {
+	setupWorker(concurrency: number, options?: { maxJobs?: number; onMaxJobsReached?: () => void }) {
 		this.assertWorker();
 		this.assertQueue();
+
+		const { maxJobs, onMaxJobsReached } = options ?? {};
+		let processedJobs = 0;
+		let limitTriggered = false;
+
+		const maybeTriggerShutdown = () => {
+			if (!maxJobs) return;
+
+			processedJobs += 1;
+
+			if (!limitTriggered && processedJobs >= maxJobs) {
+				limitTriggered = true;
+				this.logger.info(
+					`Reached configured max jobs limit (${maxJobs}). Initiating worker shutdown.`,
+				);
+				void onMaxJobsReached?.();
+			}
+		};
 
 		void this.queue.process(JOB_TYPE_NAME, concurrency, async (job: Job) => {
 			try {
@@ -102,6 +120,8 @@ export class ScalingService {
 				await this.jobProcessor.processJob(job);
 			} catch (error) {
 				await this.reportJobProcessingError(ensureError(error), job);
+			} finally {
+				maybeTriggerShutdown();
 			}
 		});
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

We expose --max-jobs on n8n worker so operators can spin up “one-shot” or short-lived workers that process a fixed number of executions and then exit cleanly. This is useful when:

autoscaling platforms (Kubernetes jobs, spot instances, serverless batch) need workers to shut themselves down after finishing their assigned queue slice, so the orchestrator can recycle the
node without leaving dangling processes.
you want to run one-off or canary executions without keeping an idle worker alive indefinitely.
Usage: start workers with the flag (n8n worker --concurrency=5 --max-jobs=25). Each worker will process 25 jobs, log that the cap was reached, and send SIGTERM to itself so BaseCommand’s
shutdown flow drains gracefully. Leaving --max-jobs unset preserves the current behavior (run forever).

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
