### PR TITLE
fix(ai-builder): Reducing confusion in spec evals from double negative don't criteria

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/pairwise/judge-chain.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/pairwise/judge-chain.test.ts
@@ -61,7 +61,7 @@ describe('evaluateWorkflowPairwise', () => {
 		expect(baseEvaluator.invokeEvaluatorChain).toHaveBeenCalledWith(
 			undefined, // The chain (undefined because createEvaluatorChain mock returns undefined)
 			expect.objectContaining({
-				userPrompt: expect.stringContaining('[DO]'),
+				userPrompt: expect.stringContaining('<do>'),
 				generatedWorkflow: input.workflowJSON,
 			}),
 			undefined, // config parameter (not passed in this test)

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/pairwise/judge-chain.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/pairwise/judge-chain.ts
@@ -18,27 +18,21 @@ const pairwiseEvaluationLLMResultSchema = z.object({
 	violations: z
 		.array(
 			z.object({
-				rule: z.string().describe('The criterion that was violated'),
-				justification: z
-					.string()
-					.describe('Evidence from the workflow explaining why this is a violation'),
+				rule: z.string(),
+				justification: z.string(),
 			}),
 		)
 		.describe(
-			'List of criteria that were violated. If no criteria passed, include an entry explaining why.',
+			'List of criteria that were violated, this must be passed as a JSON array not a string.',
 		),
 	passes: z
 		.array(
 			z.object({
-				rule: z.string().describe('The criterion that was passed'),
-				justification: z
-					.string()
-					.describe('Evidence from the workflow proving the criterion is satisfied'),
+				rule: z.string(),
+				justification: z.string(),
 			}),
 		)
-		.describe(
-			'List of criteria that were passed. Return an empty array [] if no criteria could be verified as passing.',
-		),
+		.describe('The criterion that was passed, this must be passed as a JSON array not a string.'),
 });
 
 export type PairwiseEvaluationResult = z.infer<typeof pairwiseEvaluationLLMResultSchema> & {

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/pairwise/judge-chain.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/pairwise/judge-chain.ts
@@ -54,6 +54,15 @@ const EVALUATOR_SYSTEM_PROMPT = prompt()
 - You verify every claim against the actual node configurations, connections, and parameters.`,
 	)
 	.section(
+		'clarifications',
+		`When evaluating criteria about "provider-specific nodes" or "using a specific AI provider":
+
+- Provider-specific nodes (e.g., n8n-nodes-langchain.openAi, n8n-nodes-langchain.anthropic) are standalone nodes that directly call a provider's API.
+- Chat model sub-nodes (e.g., @n8n/n8n-nodes-langchain.lmChatAnthropic, @n8n/n8n-nodes-langchain.lmChatOpenAi) are NOT provider-specific nodes. They are required infrastructure for connecting generic nodes like the AI Agent to a language model.
+
+If a criterion says "do not use provider-specific nodes" or similar, the presence of lmChat* sub-nodes should NOT count as a violation - these are necessary connectors, not provider-specific workflow nodes.`,
+	)
+	.section(
 		'constraints',
 		`- Judge ONLY against the provided evaluation criteria. Do not apply external "best practices" unless explicitly asked.
 - If a criterion is "not verifiable" from the JSON alone (e.g., requires runtime data), mark it as a violation and explain why.


### PR DESCRIPTION
## Summary
There was a pattern in the spec evals which was potentially causing some confusion for the judge, with double negatives in the don't categories.

An example of this is that the don't criteria could map into the prompt like:
```
[DON'T]
DO NOT use a code node
DO NOT use a http request node
```
This is sort of clear, but the fact it is wrapped in a don't section can lead to confusion/negating the DO NOT, causing it to think it should check for it using a code node. Running the same evals which were failing previously, they now pass with this change.

I've also clarified the properties of the output parser to hopefully reduce the chance of it getting ignored/not being filled in and throwing an error.

Finally, updated the judge chain to use the new prompt builder for consistency.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
