### PR TITLE
Change default read status to 'both' in GmailTrigger

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -155,7 +155,7 @@ export class GmailTrigger implements INodeType {
 						displayName: 'Read Status',
 						name: 'readStatus',
 						type: 'options',
-						default: 'unread',
+						default: 'both',
 						hint: 'Filter emails by whether they have been read or not',
 						options: [
 							{


### PR DESCRIPTION
Seems more intuitive to leave it on both by default.

## Summary

Instead of reading unread emails only, the trigger should check all emails by default. Then if someone specifically wants it to read only unread/read emails they can change it using the filter.
