### PR TITLE
fix(core): Revert auto publish on pull

### DIFF
--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
@@ -400,65 +400,6 @@ describe('SourceControlImportService', () => {
 			expect(activeWorkflowManager.add).toHaveBeenCalledWith('workflow1', 'activate');
 		});
 
-		it('should call publishVersion with the new version when reactivating workflows', async () => {
-			const mockUserId = 'user-id-123';
-			const mockWorkflowFile = '/mock/workflow1.json';
-			const newVersionId = 'new-version-456';
-			const mockWorkflowData = {
-				id: 'workflow1',
-				name: 'Active Workflow',
-				nodes: [],
-				parentFolderId: null,
-				versionId: newVersionId,
-			};
-			const candidates = [mock<SourceControlledFile>({ file: mockWorkflowFile, id: 'workflow1' })];
-
-			projectRepository.getPersonalProjectForUserOrFail.mockResolvedValue(
-				Object.assign(new Project(), { id: 'project1', type: 'personal' }),
-			);
-			workflowRepository.findByIds.mockResolvedValue([
-				Object.assign(new WorkflowEntity(), {
-					id: 'workflow1',
-					name: 'Active Workflow',
-					active: true,
-					activeVersionId: 'old-version-123',
-				}),
-			]);
-			folderRepository.find.mockResolvedValue([]);
-			sharedWorkflowRepository.findWithFields.mockResolvedValue([]);
-			workflowRepository.upsert.mockResolvedValue({
-				identifiers: [{ id: 'workflow1' }],
-				generatedMaps: [],
-				raw: [],
-			});
-			workflowRepository.publishVersion.mockResolvedValue({
-				generatedMaps: [],
-				raw: [],
-				affected: 1,
-			});
-			workflowRepository.update.mockResolvedValue({
-				generatedMaps: [],
-				raw: [],
-				affected: 1,
-			});
-
-			fsReadFile.mockResolvedValue(JSON.stringify(mockWorkflowData));
-
-			await service.importWorkflowFromWorkFolder(candidates, mockUserId);
-
-			// Verify publishVersion is called with the new version
-			expect(workflowRepository.publishVersion).toHaveBeenCalledWith('workflow1', newVersionId);
-			// Verify the workflow is deactivated before reactivation
-			expect(activeWorkflowManager.remove).toHaveBeenCalledWith('workflow1');
-			// Verify the workflow is reactivated
-			expect(activeWorkflowManager.add).toHaveBeenCalledWith('workflow1', 'activate');
-			// Verify the versionId is updated
-			expect(workflowRepository.update).toHaveBeenCalledWith(
-				{ id: 'workflow1' },
-				{ versionId: newVersionId },
-			);
-		});
-
 		it('should deactivate archived workflows even if they were previously active', async () => {
 			const mockUserId = 'user-id-123';
 			const mockWorkflowFile = '/mock/workflow1.json';

--- a/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
@@ -25,7 +25,6 @@ import {
 } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { PROJECT_ADMIN_ROLE_SLUG, PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
-// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In } from '@n8n/typeorm';
 import { QueryDeepPartialEntity } from '@n8n/typeorm/query-builder/QueryPartialEntity';
 import glob from 'fast-glob';
@@ -61,7 +60,6 @@ import {
 	getWorkflowExportPath,
 } from './source-control-helper.ee';
 import { SourceControlScopedService } from './source-control-scoped.service';
-import { VariablesService } from '../../environments.ee/variables/variables.service.ee';
 import type {
 	ExportableCredential,
 	StatusExportableCredential,
@@ -77,6 +75,7 @@ import type {
 } from './types/resource-owner';
 import type { SourceControlContext } from './types/source-control-context';
 import type { SourceControlWorkflowVersionId } from './types/source-control-workflow-version-id';
+import { VariablesService } from '../../environments.ee/variables/variables.service.ee';
 
 const findOwnerProject = (
 	owner: RemoteResourceOwner,
@@ -771,13 +770,6 @@ export class SourceControlImportService {
 			// If the workflow should be active (was active before and not archived),
 			// reactivate it with the new version
 			if (importedWorkflow.activeVersionId && !importedWorkflow.isArchived) {
-				// Publish the new version - this updates activeVersionId and active flag
-				// This ensures the workflow runs the new pulled version
-				this.logger.debug(
-					`Publishing workflow id ${existingWorkflow.id} with new version ${newVersionId}`,
-				);
-				await this.workflowRepository.publishVersion(existingWorkflow.id, newVersionId);
-
 				// Activate the workflow with the new published version
 				this.logger.debug(`Reactivating workflow id ${existingWorkflow.id}`);
 				await this.activeWorkflowManager.add(existingWorkflow.id, 'activate');


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR reverts this one: https://github.com/n8n-io/n8n/pull/23859
We do not want to auto publish already published existing workflow on update, because we settled on different environments having their own workflow publish state. Git should not be the source of truth for publish state.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-4404/bug-pulling-changed-workflow-auto-publishes-it-everytime


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
