### PR TITLE
fix(core): Add license check to LDAP configuration endpoints

### DIFF
--- a/packages/cli/src/ldap.ee/ldap.controller.ee.ts
+++ b/packages/cli/src/ldap.ee/ldap.controller.ee.ts
@@ -1,4 +1,4 @@
-import { Get, Post, Put, RestController, GlobalScope } from '@n8n/decorators';
+import { Get, Post, Put, RestController, GlobalScope, Licensed } from '@n8n/decorators';
 import pick from 'lodash/pick';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
@@ -17,12 +17,14 @@ export class LdapController {
 	) {}
 
 	@Get('/config')
+	@Licensed('feat:ldap')
 	@GlobalScope('ldap:manage')
 	async getConfig() {
 		return await this.ldapService.loadConfig();
 	}
 
 	@Post('/test-connection')
+	@Licensed('feat:ldap')
 	@GlobalScope('ldap:manage')
 	async testConnection() {
 		try {
@@ -33,6 +35,7 @@ export class LdapController {
 	}
 
 	@Put('/config')
+	@Licensed('feat:ldap')
 	@GlobalScope('ldap:manage')
 	async updateConfig(req: LdapConfiguration.Update) {
 		try {
@@ -52,6 +55,7 @@ export class LdapController {
 	}
 
 	@Get('/sync')
+	@Licensed('feat:ldap')
 	@GlobalScope('ldap:sync')
 	async getLdapSync(req: LdapConfiguration.GetSync) {
 		const { page = '0', perPage = '20' } = req.query;
@@ -59,6 +63,7 @@ export class LdapController {
 	}
 
 	@Post('/sync')
+	@Licensed('feat:ldap')
 	@GlobalScope('ldap:sync')
 	async syncLdap(req: LdapConfiguration.Sync) {
 		try {

--- a/packages/cli/test/integration/ldap/ldap.api.test.ts
+++ b/packages/cli/test/integration/ldap/ldap.api.test.ts
@@ -88,6 +88,11 @@ test('Chat user role should not be able to access ldap routes', async () => {
 });
 
 describe('PUT /ldap/config', () => {
+	test('should not allow access without license', async () => {
+		testServer.license.disable('feat:ldap');
+		await authOwnerAgent.put('/ldap/config').expect(403);
+	});
+
 	test('route should validate payload', async () => {
 		const invalidValuePayload = {
 			...LDAP_DEFAULT_CONFIGURATION,
@@ -168,23 +173,35 @@ describe('PUT /ldap/config', () => {
 	});
 });
 
-test('GET /ldap/config route should retrieve current configuration', async () => {
-	const validPayload = {
-		...LDAP_DEFAULT_CONFIGURATION,
-		loginEnabled: true,
-		loginLabel: '',
-	};
+describe('GET /ldap/config', () => {
+	test('should not allow access without license', async () => {
+		testServer.license.disable('feat:ldap');
+		await authOwnerAgent.get('/ldap/config').expect(403);
+	});
 
-	let response = await authOwnerAgent.put('/ldap/config').send(validPayload);
-	expect(response.statusCode).toBe(200);
-	expect(getCurrentAuthenticationMethod()).toBe('ldap');
+	test('route should retrieve current configuration', async () => {
+		const validPayload = {
+			...LDAP_DEFAULT_CONFIGURATION,
+			loginEnabled: true,
+			loginLabel: '',
+		};
 
-	response = await authOwnerAgent.get('/ldap/config');
+		let response = await authOwnerAgent.put('/ldap/config').send(validPayload);
+		expect(response.statusCode).toBe(200);
+		expect(getCurrentAuthenticationMethod()).toBe('ldap');
 
-	expect(response.body.data).toMatchObject(validPayload);
+		response = await authOwnerAgent.get('/ldap/config');
+
+		expect(response.body.data).toMatchObject(validPayload);
+	});
 });
 
 describe('POST /ldap/test-connection', () => {
+	test('should not allow access without license', async () => {
+		testServer.license.disable('feat:ldap');
+		await authOwnerAgent.post('/ldap/test-connection').expect(403);
+	});
+
 	test('route should success', async () => {
 		jest.spyOn(LdapService.prototype, 'testConnection').mockResolvedValue();
 
@@ -204,6 +221,11 @@ describe('POST /ldap/test-connection', () => {
 });
 
 describe('POST /ldap/sync', () => {
+	test('should not allow access without license', async () => {
+		testServer.license.disable('feat:ldap');
+		await authOwnerAgent.post('/ldap/sync').expect(403);
+	});
+
 	beforeEach(async () => {
 		const ldapConfig = await createLdapConfig({
 			ldapIdAttribute: 'uid',
@@ -539,26 +561,33 @@ describe('POST /ldap/sync', () => {
 	});
 });
 
-test('GET /ldap/sync should return paginated synchronizations', async () => {
-	for (let i = 0; i < 2; i++) {
-		await saveLdapSynchronization({
-			created: 0,
-			scanned: 0,
-			updated: 0,
-			disabled: 0,
-			startedAt: new Date(),
-			endedAt: new Date(),
-			status: 'success',
-			error: '',
-			runMode: 'dry',
-		});
-	}
+describe('GET /ldap/sync', () => {
+	test('should not allow access without license', async () => {
+		testServer.license.disable('feat:ldap');
+		await authOwnerAgent.get('/ldap/sync').expect(403);
+	});
 
-	let response = await authOwnerAgent.get('/ldap/sync?perPage=1&page=0');
-	expect(response.body.data.length).toBe(1);
+	test('should return paginated synchronizations', async () => {
+		for (let i = 0; i < 2; i++) {
+			await saveLdapSynchronization({
+				created: 0,
+				scanned: 0,
+				updated: 0,
+				disabled: 0,
+				startedAt: new Date(),
+				endedAt: new Date(),
+				status: 'success',
+				error: '',
+				runMode: 'dry',
+			});
+		}
 
-	response = await authOwnerAgent.get('/ldap/sync?perPage=1&page=1');
-	expect(response.body.data.length).toBe(1);
+		let response = await authOwnerAgent.get('/ldap/sync?perPage=1&page=0');
+		expect(response.body.data.length).toBe(1);
+
+		response = await authOwnerAgent.get('/ldap/sync?perPage=1&page=1');
+		expect(response.body.data.length).toBe(1);
+	});
 });
 
 describe('POST /login', () => {


### PR DESCRIPTION
## Summary

This PR fixes a security vulnerability (PAY-4416) where all LDAP controller endpoints were missing the `@Licensed('feat:ldap')` decorator, allowing LDAP configuration access without an enterprise license. Added integration tests to verify license enforcement on each endpoint

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-4416

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- ~[ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- ~[ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~