### PR TITLE
fix(core): Put source control preferences behind auth

### DIFF
--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control.controller.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control.controller.ee.test.ts
@@ -1,5 +1,7 @@
 import type { PullWorkFolderRequestDto, PushWorkFolderRequestDto } from '@n8n/api-types';
 import type { AuthenticatedRequest } from '@n8n/db';
+import { ControllerRegistryMetadata, type Controller } from '@n8n/decorators';
+import { Container } from '@n8n/di';
 import type { Response } from 'express';
 import { mock } from 'jest-mock-extended';
 
@@ -164,6 +166,43 @@ describe('SourceControlController', () => {
 
 			await controller.status(req);
 			expect(sourceControlService.getStatus).toHaveBeenCalledWith(user, query);
+		});
+	});
+
+	describe('getPreferences', () => {
+		it('should return preferences with public key', async () => {
+			const mockPreferences = {
+				branchName: 'main',
+				repositoryUrl: 'git@github.com:example/repo.git',
+				connected: true,
+				publicKey: '',
+			};
+			const mockPublicKey = 'ssh-rsa AAAAB3NzaC1yc2E...';
+
+			(sourceControlPreferencesService.getPreferences as jest.Mock).mockReturnValue(
+				mockPreferences,
+			);
+			(sourceControlPreferencesService.getPublicKey as jest.Mock).mockResolvedValue(mockPublicKey);
+
+			const result = await controller.getPreferences();
+
+			expect(sourceControlPreferencesService.getPublicKey).toHaveBeenCalled();
+			expect(sourceControlPreferencesService.getPreferences).toHaveBeenCalled();
+			expect(result).toEqual({
+				...mockPreferences,
+				publicKey: mockPublicKey,
+			});
+		});
+
+		it('should require authentication', () => {
+			const registry = Container.get(ControllerRegistryMetadata);
+			const controllerMetadata = registry.getControllerMetadata(
+				SourceControlController as Controller,
+			);
+
+			const getPreferencesRoute = controllerMetadata.routes.get('getPreferences');
+			expect(getPreferencesRoute).toBeDefined();
+			expect(getPreferencesRoute?.skipAuth).toBe(false);
 		});
 	});
 });

--- a/packages/cli/src/modules/source-control.ee/source-control.controller.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control.controller.ee.ts
@@ -34,7 +34,7 @@ export class SourceControlController {
 		private readonly eventService: EventService,
 	) {}
 
-	@Get('/preferences', { skipAuth: true })
+	@Get('/preferences')
 	async getPreferences(): Promise<SourceControlPreferences> {
 		// returns the settings with the privateKey property redacted
 		const publicKey = await this.sourceControlPreferencesService.getPublicKey();


### PR DESCRIPTION
## Summary

Tested that source control preferences still work manual, however, related e2e tests are currently disabled. should be enabled again after https://linear.app/n8n/issue/PAY-4365/bug-source-control-operations-fail-in-multi-main-deployment

Given that this endpoint is for internal use of the n8n instance, I assume the changelog would be enough & we don't need to call this out to customers.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-3328/restsource-controlpreferences-should-be-behind-auth

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
