### PR TITLE
Add working example for N8N_CONTENT_SECURITY_POLICY trusted domains

### DIFF
--- a/packages/@n8n/config/src/configs/security.config.ts
+++ b/packages/@n8n/config/src/configs/security.config.ts
@@ -38,7 +38,7 @@ export class SecurityConfig {
 	 * Set [Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) headers as [helmet.js](https://helmetjs.github.io/#content-security-policy) nested directives object.
 	 * Example: { "frame-ancestors": ["http://localhost:3000"] }
 	 * Working example .env variable -- Add your trusted domain names at the end of this line:
-   * N8N_CONTENT_SECURITY_POLICY="{\"default-src\":[\"*\"],\"script-src\":[\"*\",\"'unsafe-inline'\",\"'unsafe-eval'\"],\"style-src\":[\"*\",\"'unsafe-inline'\"],\"frame-ancestors\":[\"'self'\",\"https://myapp.com\",\"https://subdomain.anotherapp.com\"]}"
+   * N8N_CONTENT_SECURITY_POLICY="{\"default-src\":[\"'self'\"],\"script-src\":[\"'self'\"],\"style-src\":[\"'self'\"],\"frame-ancestors\":[\"'self'\",\"https://myapp.com\",\"https://subdomain.anotherapp.com\"]}"
 	 */
 	// TODO: create a new type that parses and validates this string into a strongly-typed object
 	@Env('N8N_CONTENT_SECURITY_POLICY')

--- a/packages/@n8n/config/src/configs/security.config.ts
+++ b/packages/@n8n/config/src/configs/security.config.ts
@@ -39,7 +39,6 @@ export class SecurityConfig {
 	 * Example: { "frame-ancestors": ["http://localhost:3000"] }
 	 * Working example .env variable -- Add your trusted domain names at the end of this line:
    * N8N_CONTENT_SECURITY_POLICY="{\"default-src\":[\"*\"],\"script-src\":[\"*\",\"'unsafe-inline'\",\"'unsafe-eval'\"],\"style-src\":[\"*\",\"'unsafe-inline'\"],\"frame-ancestors\":[\"'self'\",\"https://myapp.com\",\"https://subdomain.anotherapp.com\"]}"
-
 	 */
 	// TODO: create a new type that parses and validates this string into a strongly-typed object
 	@Env('N8N_CONTENT_SECURITY_POLICY')

--- a/packages/@n8n/config/src/configs/security.config.ts
+++ b/packages/@n8n/config/src/configs/security.config.ts
@@ -37,6 +37,9 @@ export class SecurityConfig {
 	/**
 	 * Set [Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) headers as [helmet.js](https://helmetjs.github.io/#content-security-policy) nested directives object.
 	 * Example: { "frame-ancestors": ["http://localhost:3000"] }
+	 * Working example .env variable -- Add your trusted domain names at the end of this line:
+   * N8N_CONTENT_SECURITY_POLICY="{\"default-src\":[\"*\"],\"script-src\":[\"*\",\"'unsafe-inline'\",\"'unsafe-eval'\"],\"style-src\":[\"*\",\"'unsafe-inline'\"],\"frame-ancestors\":[\"'self'\",\"https://myapp.com\",\"https://subdomain.anotherapp.com\"]}"
+
 	 */
 	// TODO: create a new type that parses and validates this string into a strongly-typed object
 	@Env('N8N_CONTENT_SECURITY_POLICY')


### PR DESCRIPTION
The example that is currently in there does not work in prod and might prevent n8n frontend from loading and obviously webhooks too
- New example includes 'self' in the frame ancestors, should cover both n8n host == localhost or domain 
- Tested on ubuntu with nginx + https, embedding in the respective sites was not allowed -> is now allowed

## Summary

<!--
1. Insert in .env with trusted domains replaced at the end:
N8N_CONTENT_SECURITY_POLICY="{\"default-src\":[\"*\"],\"script-src\":[\"*\",\"'unsafe-inline'\",\"'unsafe-eval'\"],\"style-src\":[\"*\",\"'unsafe-inline'\"],\"frame-ancestors\":[\"'self'\",\"https://abc.xxx.com\",\"https://domain.com\"]}"
2. Embed webhook html response in those domains
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
