### PR TITLE
fix(core): Connect to external secrets provider before testing

### DIFF
--- a/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
@@ -210,7 +210,7 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 
 		const errorState = {
 			success: false,
-			testState: 'error',
+			testState: 'error' as const,
 		};
 
 		const result = await this.providerLifecycle.initialize(provider, testSettings);
@@ -220,6 +220,12 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 		}
 
 		try {
+			// Connect the provider to authenticate before testing
+			const connectResult = await this.providerLifecycle.connect(result.provider);
+			if (!connectResult.success) {
+				return { ...errorState, error: connectResult.error?.message };
+			}
+
 			const [success, error] = await result.provider.test();
 			const currentSettings = await this.settingsStore.getProvider(provider);
 			const testState = this.determineTestState(success, currentSettings?.connected ?? false);


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
After the last refactor of external secrets module (https://github.com/n8n-io/n8n/pull/23337), there was a regression on the testing of providers that requires a connect step.
Fixed it by calling provider.connect before testing

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-4426/community-issue-vault-login-ommited-and-going-straight-to-test


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
