### PR TITLE
fix(editor): Render sidebar synchronously to avoid layout shift (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/app/AppLayout.vue
+++ b/packages/frontend/editor-ui/src/app/components/app/AppLayout.vue
@@ -1,13 +1,19 @@
 <script lang="ts" setup>
-import { ref } from 'vue';
+import { defineAsyncComponent, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 
-import DefaultLayout from '@/app/layouts/DefaultLayout.vue';
-import SettingsLayout from '@/app/layouts/SettingsLayout.vue';
-import WorkflowLayout from '@/app/layouts/WorkflowLayout.vue';
-import AuthLayout from '@/app/layouts/AuthLayout.vue';
-import DemoLayout from '@/app/layouts/DemoLayout.vue';
-import ChatLayout from '@/app/layouts/ChatLayout.vue';
+const DefaultLayout = defineAsyncComponent(
+	async () => await import('@/app/layouts/DefaultLayout.vue'),
+);
+const SettingsLayout = defineAsyncComponent(
+	async () => await import('@/app/layouts/SettingsLayout.vue'),
+);
+const WorkflowLayout = defineAsyncComponent(
+	async () => await import('@/app/layouts/WorkflowLayout.vue'),
+);
+const AuthLayout = defineAsyncComponent(async () => await import('@/app/layouts/AuthLayout.vue'));
+const DemoLayout = defineAsyncComponent(async () => await import('@/app/layouts/DemoLayout.vue'));
+const ChatLayout = defineAsyncComponent(async () => await import('@/app/layouts/ChatLayout.vue'));
 
 const route = useRoute();
 const router = useRouter();
@@ -30,10 +36,12 @@ function onMounted(element: Element) {
 
 <template>
 	<div v-if="!initialized" />
-	<SettingsLayout v-else-if="route.meta.layout === 'settings'" @mounted="onMounted" />
-	<WorkflowLayout v-else-if="route.meta.layout === 'workflow'" @mounted="onMounted" />
-	<AuthLayout v-else-if="route.meta.layout === 'auth'" @mounted="onMounted" />
-	<DemoLayout v-else-if="route.meta.layout === 'demo'" @mounted="onMounted" />
-	<ChatLayout v-else-if="route.meta.layout === 'chat'" @mounted="onMounted" />
-	<DefaultLayout v-else @mounted="onMounted" />
+	<Suspense v-else>
+		<SettingsLayout v-if="route.meta.layout === 'settings'" @mounted="onMounted" />
+		<WorkflowLayout v-else-if="route.meta.layout === 'workflow'" @mounted="onMounted" />
+		<AuthLayout v-else-if="route.meta.layout === 'auth'" @mounted="onMounted" />
+		<DemoLayout v-else-if="route.meta.layout === 'demo'" @mounted="onMounted" />
+		<ChatLayout v-else-if="route.meta.layout === 'chat'" @mounted="onMounted" />
+		<DefaultLayout v-else @mounted="onMounted" />
+	</Suspense>
 </template>

--- a/packages/frontend/editor-ui/src/app/layouts/ChatLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/ChatLayout.vue
@@ -1,18 +1,12 @@
 <script lang="ts" setup>
-import { defineAsyncComponent } from 'vue';
 import BaseLayout from './BaseLayout.vue';
-
-const ChatSidebar = defineAsyncComponent(
-	async () => await import('@/features/ai/chatHub/components/ChatSidebar.vue'),
-);
+import ChatSidebar from '@/features/ai/chatHub/components/ChatSidebar.vue';
 </script>
 
 <template>
 	<BaseLayout>
 		<template #sidebar>
-			<Suspense>
-				<ChatSidebar />
-			</Suspense>
+			<ChatSidebar />
 		</template>
 		<RouterView />
 	</BaseLayout>

--- a/packages/frontend/editor-ui/src/app/layouts/DefaultLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/DefaultLayout.vue
@@ -1,18 +1,12 @@
 <script lang="ts" setup>
-import { defineAsyncComponent } from 'vue';
 import BaseLayout from './BaseLayout.vue';
-
-const AppSidebar = defineAsyncComponent(
-	async () => await import('@/app/components/app/AppSidebar.vue'),
-);
+import AppSidebar from '@/app/components/app/AppSidebar.vue';
 </script>
 
 <template>
 	<BaseLayout>
 		<template #sidebar>
-			<Suspense>
-				<AppSidebar />
-			</Suspense>
+			<AppSidebar />
 		</template>
 		<RouterView />
 	</BaseLayout>

--- a/packages/frontend/editor-ui/src/app/layouts/DemoLayout.test.ts
+++ b/packages/frontend/editor-ui/src/app/layouts/DemoLayout.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { createComponentRenderer } from '@/__tests__/render';
 import DemoLayout from './DemoLayout.vue';
+import { createTestingPinia } from '@pinia/testing';
 
 const renderComponent = createComponentRenderer(DemoLayout, {
 	global: {
@@ -16,6 +17,7 @@ const renderComponent = createComponentRenderer(DemoLayout, {
 			},
 		},
 	},
+	pinia: createTestingPinia(),
 });
 
 describe('DemoLayout', () => {

--- a/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
@@ -1,19 +1,13 @@
 <script lang="ts" setup>
-import { defineAsyncComponent } from 'vue';
 import BaseLayout from './BaseLayout.vue';
-
-const DemoFooter = defineAsyncComponent(
-	async () => await import('@/features/execution/logs/components/DemoFooter.vue'),
-);
+import DemoFooter from '@/features/execution/logs/components/DemoFooter.vue';
 </script>
 
 <template>
 	<BaseLayout>
 		<RouterView />
 		<template #footer>
-			<Suspense>
-				<DemoFooter />
-			</Suspense>
+			<DemoFooter />
 		</template>
 	</BaseLayout>
 </template>

--- a/packages/frontend/editor-ui/src/app/layouts/SettingsLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/SettingsLayout.vue
@@ -2,13 +2,10 @@
 import BaseLayout from './BaseLayout.vue';
 import { VIEWS } from '@/app/constants';
 import { isRouteLocationRaw } from '@/app/utils/typeGuards';
-import { defineAsyncComponent, onMounted, ref } from 'vue';
+import { onMounted, ref } from 'vue';
 import type { HistoryState } from 'vue-router';
 import { useRouter } from 'vue-router';
-
-const SettingsSidebar = defineAsyncComponent(
-	async () => await import('@/app/components/SettingsSidebar.vue'),
-);
+import SettingsSidebar from '@/app/components/SettingsSidebar.vue';
 
 const router = useRouter();
 
@@ -35,9 +32,7 @@ onMounted(() => {
 <template>
 	<BaseLayout>
 		<template #sidebar>
-			<Suspense>
-				<SettingsSidebar @return="onReturn" />
-			</Suspense>
+			<SettingsSidebar @return="onReturn" />
 		</template>
 
 		<div :class="$style.contentContainer">

--- a/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
@@ -1,36 +1,24 @@
 <script lang="ts" setup>
-import { defineAsyncComponent } from 'vue';
 import BaseLayout from './BaseLayout.vue';
 import { useLayoutProps } from '@/app/composables/useLayoutProps';
 import AskAssistantFloatingButton from '@/features/ai/assistant/components/Chat/AskAssistantFloatingButton.vue';
 import { useAssistantStore } from '@/features/ai/assistant/assistant.store';
+import AppHeader from '@/app/components/app/AppHeader.vue';
+import AppSidebar from '@/app/components/app/AppSidebar.vue';
+import LogsPanel from '@/features/execution/logs/components/LogsPanel.vue';
 
 const { layoutProps } = useLayoutProps();
 
 const assistantStore = useAssistantStore();
-
-const AppHeader = defineAsyncComponent(
-	async () => await import('@/app/components/app/AppHeader.vue'),
-);
-const AppSidebar = defineAsyncComponent(
-	async () => await import('@/app/components/app/AppSidebar.vue'),
-);
-const LogsPanel = defineAsyncComponent(
-	async () => await import('@/features/execution/logs/components/LogsPanel.vue'),
-);
 </script>
 
 <template>
 	<BaseLayout>
 		<template #header>
-			<Suspense>
-				<AppHeader />
-			</Suspense>
+			<AppHeader />
 		</template>
 		<template #sidebar>
-			<Suspense>
-				<AppSidebar />
-			</Suspense>
+			<AppSidebar />
 		</template>
 		<RouterView v-slot="{ Component }">
 			<KeepAlive include="NodeView" :max="1">
@@ -38,9 +26,7 @@ const LogsPanel = defineAsyncComponent(
 			</KeepAlive>
 		</RouterView>
 		<template v-if="layoutProps.logs" #footer>
-			<Suspense>
-				<LogsPanel />
-			</Suspense>
+			<LogsPanel />
 		</template>
 		<template #overlays>
 			<AskAssistantFloatingButton v-if="assistantStore.isFloatingButtonShown" />

--- a/packages/testing/playwright/tests/e2e/app-config/demo.spec.ts
+++ b/packages/testing/playwright/tests/e2e/app-config/demo.spec.ts
@@ -25,6 +25,7 @@ test.describe('Demo', () => {
 
 	test('can import workflow with pin data', async ({ n8n }) => {
 		await n8n.demo.visitDemoPage();
+		await expect(n8n.canvas.canvasPane()).toBeVisible();
 		await n8n.demo.importWorkflow(workflowWithPinned);
 		await expect(n8n.canvas.getCanvasNodes()).toHaveCount(2);
 		await n8n.canvas.openNode('Webhook');

--- a/packages/testing/playwright/tests/e2e/workflows/editor/viewer-permissions.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/viewer-permissions.spec.ts
@@ -31,6 +31,7 @@ async function setupProjectWithWorkflowAndSignInAsMember({
 	await n8n.navigate.toHome();
 	await n8n.sideBar.clickProjectMenuItem(createdProjectName);
 	await n8n.workflows.cards.getWorkflows().first().click();
+	await expect(n8n.canvas.canvasPane()).toBeVisible();
 	await expect(n8n.canvas.getLoadingMask()).toBeHidden({ timeout: 30000 });
 	await expect(n8n.canvas.getLoadingMask()).not.toBeAttached();
 }
@@ -113,7 +114,7 @@ test.describe('Workflow Viewer Permissions @isolated', () => {
 		await n8n.canvas.dragNodeToRelativePosition('Edit Fields', 100, 50);
 
 		// Position SHOULD change
-		await expect.poll(async () => await node.boundingBox()).not.toBe(initialPosition?.x);
+		await expect.poll(async () => (await node.boundingBox())?.x).not.toBe(initialPosition?.x);
 
 		// Copy and paste should work
 		await n8n.canvasComposer.selectAllAndCopy();

--- a/packages/testing/playwright/tests/e2e/workflows/editor/viewer-permissions.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/viewer-permissions.spec.ts
@@ -112,10 +112,8 @@ test.describe('Workflow Viewer Permissions @isolated', () => {
 
 		await n8n.canvas.dragNodeToRelativePosition('Edit Fields', 100, 50);
 
-		const finalPosition = await node.boundingBox();
-
 		// Position SHOULD change
-		expect(finalPosition?.x).not.toBe(initialPosition?.x);
+		await expect.poll(async () => await node.boundingBox()).not.toBe(initialPosition?.x);
 
 		// Copy and paste should work
 		await n8n.canvasComposer.selectAllAndCopy();


### PR DESCRIPTION
## Summary

This PR fixes layout shift on initial render caused by async import of sidebars.

**Before**: Open n8n -> empty screen -> main content without sidebar -> finish rendering with sidebar
**After**: Open n8n -> empty screen -> finish rendering with sidebar

## Related Linear tickets, Github issues, and Community forum posts

N/A


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
