### PR TITLE
fix(editor): Make code block's copy button in ChatHub follow scroll

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.test.ts
@@ -1,10 +1,24 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createComponentRenderer } from '@/__tests__/render';
 import { createTestingPinia } from '@pinia/testing';
 import ChatMessage from './ChatMessage.vue';
 import type { ChatMessage as ChatMessageType } from '../chat.types';
-import { waitFor } from '@testing-library/vue';
+import { waitFor, within } from '@testing-library/vue';
 import { createMockMessage } from '../__test__/data';
+
+const mockCopy = vi.fn();
+vi.mock('@vueuse/core', async () => {
+	const actual = await vi.importActual('@vueuse/core');
+	return {
+		...actual,
+		useClipboard: () => ({
+			copy: mockCopy,
+			copied: { value: false },
+			isSupported: { value: true },
+			text: { value: '' },
+		}),
+	};
+});
 
 const renderComponent = createComponentRenderer(ChatMessage);
 
@@ -13,6 +27,7 @@ describe('ChatMessage', () => {
 
 	beforeEach(() => {
 		pinia = createTestingPinia();
+		mockCopy.mockClear();
 	});
 
 	it('should render syntax highlighting for code blocks', async () => {
@@ -40,5 +55,34 @@ describe('ChatMessage', () => {
 
 			expect(highlightedElements.length).toBeGreaterThan(0);
 		});
+	});
+
+	it('should allow to copy code block contents', async () => {
+		const codeContent = 'const foo = "bar";\nfunction test() {\n  return true;\n}';
+		const message: ChatMessageType = createMockMessage({
+			type: 'ai',
+			content: `\`\`\`javascript\n${codeContent}\n\`\`\``,
+		});
+
+		const rendered = renderComponent({
+			props: {
+				message,
+				compact: false,
+				isEditing: false,
+				hasSessionStreaming: false,
+				cachedAgentDisplayName: null,
+				cachedAgentIcon: null,
+				containerWidth: 100,
+			},
+			pinia,
+		});
+
+		const preElement = (await rendered.findByText(/function/)).closest('pre')!;
+
+		preElement.dispatchEvent(new MouseEvent('mousemove', { bubbles: true }));
+
+		(await within(preElement).findByRole('button', { name: /copy/i })).click();
+
+		expect(mockCopy).toHaveBeenCalledWith(codeContent);
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
@@ -529,10 +529,15 @@ onBeforeMount(() => {
 		}
 
 		& .codeBlockActions {
-			position: absolute;
-			top: 0;
-			right: 0;
-			margin: var(--spacing--2xs);
+			position: sticky;
+			top: var(--spacing--sm);
+			display: flex;
+			justify-content: flex-end;
+			height: 32px;
+		}
+
+		& .codeBlockActions ~ code {
+			margin-top: -32px;
 		}
 
 		& ~ pre {

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
@@ -534,6 +534,11 @@ onBeforeMount(() => {
 			display: flex;
 			justify-content: flex-end;
 			height: 32px;
+			pointer-events: none;
+
+			& > * {
+				pointer-events: auto;
+			}
 		}
 
 		& .codeBlockActions ~ code {

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/CopyButton.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/CopyButton.vue
@@ -31,6 +31,7 @@ async function handleCopy() {
 			text
 			:class="$style.button"
 			tabindex="0"
+			:aria-label="copyTooltip"
 			@click="handleCopy"
 		/>
 		<template #content>{{ copyTooltip }}</template>

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatHubMarkdownOptions.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatHubMarkdownOptions.ts
@@ -98,8 +98,9 @@ export function useChatHubMarkdownOptions(
 				}
 
 				return defaultRendered.replace(
-					'</pre>',
-					`<div data-markdown-token-idx="${idx}" class="${codeBlockActionsClassName}"></div></pre>`,
+					/<pre([^>]*)>/,
+					(_, attrs) =>
+						`<pre${attrs}><div data-markdown-token-idx="${idx}" class="${codeBlockActionsClassName}"></div>`,
 				);
 			};
 		};

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatHubMarkdownOptions.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatHubMarkdownOptions.ts
@@ -98,9 +98,8 @@ export function useChatHubMarkdownOptions(
 				}
 
 				return defaultRendered.replace(
-					/<pre([^>]*)>/,
-					(_, attrs) =>
-						`<pre${attrs}><div data-markdown-token-idx="${idx}" class="${codeBlockActionsClassName}"></div>`,
+					'<pre>',
+					`<pre><div data-markdown-token-idx="${idx}" class="${codeBlockActionsClassName}"></div>`,
 				);
 			};
 		};


### PR DESCRIPTION
## Summary

This PR makes code block's copy button in ChatHub conversation UI sticky, to easily copy long code block's content.


https://github.com/user-attachments/assets/0f1d03bb-1f68-43cb-9ff4-bd741774cacc



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-101/bug-code-blocks-copy-button-doesnt-follow-scroll


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
