### PR TITLE
fix(editor): Hide credential modal for r2r workflows (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/readyToRun/stores/readyToRun.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/readyToRun/stores/readyToRun.store.test.ts
@@ -380,6 +380,32 @@ describe('useReadyToRunStore', () => {
 		});
 	});
 
+	describe('isReadyToRunTemplateId', () => {
+		it('should return true for ready-to-run-ai-workflow', () => {
+			expect(store.isReadyToRunTemplateId('ready-to-run-ai-workflow')).toBe(true);
+		});
+
+		it('should return true for ready-to-run-ai-workflow-v5', () => {
+			expect(store.isReadyToRunTemplateId('ready-to-run-ai-workflow-v5')).toBe(true);
+		});
+
+		it('should return true for ready-to-run-ai-workflow-v6', () => {
+			expect(store.isReadyToRunTemplateId('ready-to-run-ai-workflow-v6')).toBe(true);
+		});
+
+		it('should return false for other template IDs', () => {
+			expect(store.isReadyToRunTemplateId('some-other-template')).toBe(false);
+		});
+
+		it('should return false for undefined', () => {
+			expect(store.isReadyToRunTemplateId(undefined)).toBe(false);
+		});
+
+		it('should return false for empty string', () => {
+			expect(store.isReadyToRunTemplateId('')).toBe(false);
+		});
+	});
+
 	describe('claimingCredits state', () => {
 		it('should be false initially', () => {
 			expect(store.claimingCredits).toBe(false);

--- a/packages/frontend/editor-ui/src/features/workflows/readyToRun/stores/readyToRun.store.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/readyToRun/stores/readyToRun.store.ts
@@ -20,6 +20,12 @@ import { useReadyToRunWorkflowsV2Store } from '@/experiments/readyToRunWorkflows
 const LOCAL_STORAGE_CREDENTIAL_KEY = 'N8N_READY_TO_RUN_OPENAI_CREDENTIAL_ID';
 
 export const useReadyToRunStore = defineStore(STORES.READY_TO_RUN, () => {
+	const READY_TO_RUN_TEMPLATE_IDS = [
+		'ready-to-run-ai-workflow',
+		'ready-to-run-ai-workflow-v5',
+		'ready-to-run-ai-workflow-v6',
+	];
+
 	const telemetry = useTelemetry();
 	const i18n = useI18n();
 	const toast = useToast();
@@ -159,6 +165,10 @@ export const useReadyToRunStore = defineStore(STORES.READY_TO_RUN, () => {
 		return isTrulyEmpty(route);
 	};
 
+	const isReadyToRunTemplateId = (templateId: string | undefined): boolean => {
+		return !!templateId && READY_TO_RUN_TEMPLATE_IDS.includes(templateId);
+	};
+
 	return {
 		claimingCredits,
 		userCanClaimOpenAiCredits,
@@ -170,5 +180,6 @@ export const useReadyToRunStore = defineStore(STORES.READY_TO_RUN, () => {
 		getSimplifiedLayoutVisibility,
 		trackExecuteAiWorkflow,
 		trackExecuteAiWorkflowSuccess,
+		isReadyToRunTemplateId,
 	};
 });

--- a/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.test.ts
@@ -3,6 +3,9 @@ import SetupWorkflowCredentialsButton from './SetupWorkflowCredentialsButton.vue
 import { createTestingPinia } from '@pinia/testing';
 import { mockedStore } from '@/__tests__/utils';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useUIStore } from '@/app/stores/ui.store';
+import { useReadyToRunStore } from '@/features/workflows/readyToRun/stores/readyToRun.store';
+import { SETUP_CREDENTIALS_MODAL_KEY, TEMPLATE_SETUP_EXPERIENCE } from '@/app/constants';
 
 vi.mock('vue-router', async () => {
 	const actual = await vi.importActual('vue-router');
@@ -21,6 +24,16 @@ vi.mock('vue-router', async () => {
 });
 
 let workflowsStore: ReturnType<typeof mockedStore<typeof useWorkflowsStore>>;
+let uiStore: ReturnType<typeof mockedStore<typeof useUIStore>>;
+let readyToRunStore: ReturnType<typeof mockedStore<typeof useReadyToRunStore>>;
+
+const mockGetVariant = vi.fn();
+
+vi.mock('@/app/stores/posthog.store', () => ({
+	usePostHog: () => ({
+		getVariant: mockGetVariant,
+	}),
+}));
 
 const renderComponent = createComponentRenderer(SetupWorkflowCredentialsButton);
 
@@ -41,8 +54,11 @@ const EMPTY_WORKFLOW = {
 
 describe('SetupWorkflowCredentialsButton', () => {
 	beforeEach(() => {
+		vi.clearAllMocks();
 		createTestingPinia();
 		workflowsStore = mockedStore(useWorkflowsStore);
+		uiStore = mockedStore(useUIStore);
+		readyToRunStore = mockedStore(useReadyToRunStore);
 	});
 
 	it('renders', () => {
@@ -54,5 +70,53 @@ describe('SetupWorkflowCredentialsButton', () => {
 		workflowsStore.workflow = EMPTY_WORKFLOW;
 		const { queryByTestId } = renderComponent();
 		expect(queryByTestId('setup-credentials-button')).toBeNull();
+	});
+
+	it('does not auto-open modal for ready-to-run AI workflows even when showButton would be true', () => {
+		const readyToRunWorkflow = {
+			...EMPTY_WORKFLOW,
+			meta: { templateId: 'ready-to-run-ai-workflow', templateCredsSetupCompleted: false },
+			nodes: [
+				{
+					id: '1',
+					name: 'OpenAI Model',
+					type: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				},
+			],
+		};
+		workflowsStore.workflow = readyToRunWorkflow;
+		workflowsStore.getNodes.mockReturnValue(readyToRunWorkflow.nodes);
+
+		// Enable the feature flag
+		mockGetVariant.mockReturnValue(TEMPLATE_SETUP_EXPERIENCE.variant);
+
+		// Mock the ready-to-run check to return true
+		readyToRunStore.isReadyToRunTemplateId.mockReturnValue(true);
+
+		renderComponent();
+
+		// Modal should NOT be opened for ready-to-run workflows
+		expect(uiStore.openModal).not.toHaveBeenCalled();
+	});
+
+	it('calls isReadyToRunTemplateId with the correct template ID', () => {
+		const templateWorkflow = {
+			...EMPTY_WORKFLOW,
+			meta: { templateId: 'ready-to-run-ai-workflow-v5', templateCredsSetupCompleted: false },
+			nodes: [],
+		};
+		workflowsStore.workflow = templateWorkflow;
+		workflowsStore.getNodes.mockReturnValue([]);
+
+		mockGetVariant.mockReturnValue(TEMPLATE_SETUP_EXPERIENCE.variant);
+
+		renderComponent();
+
+		expect(readyToRunStore.isReadyToRunTemplateId).toHaveBeenCalledWith(
+			'ready-to-run-ai-workflow-v5',
+		);
 	});
 });

--- a/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.test.ts
@@ -5,7 +5,7 @@ import { mockedStore } from '@/__tests__/utils';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useReadyToRunStore } from '@/features/workflows/readyToRun/stores/readyToRun.store';
-import { SETUP_CREDENTIALS_MODAL_KEY, TEMPLATE_SETUP_EXPERIENCE } from '@/app/constants';
+import { TEMPLATE_SETUP_EXPERIENCE } from '@/app/constants';
 
 vi.mock('vue-router', async () => {
 	const actual = await vi.importActual('vue-router');
@@ -82,18 +82,16 @@ describe('SetupWorkflowCredentialsButton', () => {
 					name: 'OpenAI Model',
 					type: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
 					typeVersion: 1,
-					position: [0, 0],
+					position: [0, 0] as [number, number],
 					parameters: {},
 				},
 			],
 		};
 		workflowsStore.workflow = readyToRunWorkflow;
-		workflowsStore.getNodes.mockReturnValue(readyToRunWorkflow.nodes);
+		workflowsStore.getNodes.mockReturnValue(readyToRunWorkflow.nodes as never);
 
-		// Enable the feature flag
 		mockGetVariant.mockReturnValue(TEMPLATE_SETUP_EXPERIENCE.variant);
 
-		// Mock the ready-to-run check to return true
 		readyToRunStore.isReadyToRunTemplateId.mockReturnValue(true);
 
 		renderComponent();

--- a/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.vue
@@ -10,7 +10,10 @@ import { doesNodeHaveAllCredentialsFilled } from '@/app/utils/nodes/nodeTransfor
 import { N8nButton } from '@n8n/design-system';
 import { usePostHog } from '@/app/stores/posthog.store';
 import { injectWorkflowState } from '@/app/composables/useWorkflowState';
+import { useReadyToRunStore } from '@/features/workflows/readyToRun/stores/readyToRun.store';
+
 const workflowsStore = useWorkflowsStore();
+const readyToRunStore = useReadyToRunStore();
 const workflowState = injectWorkflowState();
 const nodeTypesStore = useNodeTypesStore();
 const posthogStore = usePostHog();
@@ -68,7 +71,10 @@ onBeforeUnmount(() => {
 });
 
 onMounted(() => {
-	if (isNewTemplatesSetupEnabled.value && showButton.value) {
+	const templateId = workflowsStore.workflow?.meta?.templateId;
+	const isReadyToRunWorkflow = readyToRunStore.isReadyToRunTemplateId(templateId);
+
+	if (isNewTemplatesSetupEnabled.value && showButton.value && !isReadyToRunWorkflow) {
 		openSetupModal();
 	}
 });


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Don't show credential setup modal for ready-to-run workflows.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
