### PR TITLE
fix(ai-builder): Examples omitted in spec evals

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/pairwise/judge-chain.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/pairwise/judge-chain.ts
@@ -2,15 +2,13 @@ import type { BaseChatModel } from '@langchain/core/language_models/chat_models'
 import type { RunnableConfig } from '@langchain/core/runnables';
 import { z } from 'zod';
 
+import type { EvalCriteria } from './types';
 import { prompt } from '../../src/prompts/builder';
 import type { SimpleWorkflow } from '../../src/types/workflow';
 import { createEvaluatorChain, invokeEvaluatorChain } from '../chains/evaluators/base';
 
 export interface PairwiseEvaluationInput {
-	evalCriteria: {
-		dos: string;
-		donts: string;
-	};
+	evalCriteria: EvalCriteria;
 	workflowJSON: SimpleWorkflow;
 }
 

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/pairwise/judge-panel.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/pairwise/judge-panel.ts
@@ -4,8 +4,6 @@ import { evaluateWorkflowPairwise, type PairwiseEvaluationResult } from './judge
 import type { EvalCriteria } from './types';
 import type { SimpleWorkflow } from '../../src/types/workflow';
 
-export type { EvalCriteria };
-
 // ============================================================================
 // Types
 // ============================================================================

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/pairwise/judge-panel.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/pairwise/judge-panel.ts
@@ -1,16 +1,14 @@
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 
 import { evaluateWorkflowPairwise, type PairwiseEvaluationResult } from './judge-chain';
+import type { EvalCriteria } from './types';
 import type { SimpleWorkflow } from '../../src/types/workflow';
+
+export type { EvalCriteria };
 
 // ============================================================================
 // Types
 // ============================================================================
-
-export interface EvalCriteria {
-	dos: string;
-	donts: string;
-}
 
 export interface JudgePanelResult {
 	judgeResults: PairwiseEvaluationResult[];

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/pairwise/runner.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/pairwise/runner.ts
@@ -47,9 +47,10 @@ function filterByEvalField(
 	const fieldLabel = field === 'dos' ? 'do' : "don't";
 
 	log.warn(`🔍 Filtering by ${fieldLabel} containing: "${search}"`);
-	const filtered = examples.filter((e) =>
-		e.inputs.evals[field].toLowerCase().includes(searchLower),
-	);
+	const filtered = examples.filter((e) => {
+		const fieldValue = e.inputs.evals[field];
+		return fieldValue?.toLowerCase().includes(searchLower) ?? false;
+	});
 
 	if (filtered.length === 0) {
 		throw new Error(`No examples found with ${fieldLabel} containing: "${search}"`);

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/pairwise/types.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/pairwise/types.ts
@@ -1,7 +1,12 @@
 import type { EvaluationResult as LangsmithEvaluationResult } from 'langsmith/evaluation';
 import type { Example } from 'langsmith/schemas';
 
-import type { EvalCriteria } from './judge-panel';
+// ============================================================================
+// Evaluation Criteria
+// ============================================================================
+
+/** Evaluation criteria requiring at least one of dos or donts */
+export type EvalCriteria = { dos: string; donts?: string } | { dos?: string; donts: string };
 
 // ============================================================================
 // Dataset Input/Output Types

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/pairwise/types.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/pairwise/types.ts
@@ -48,7 +48,6 @@ export function isPairwiseExample(example: Example): example is PairwiseExample 
 
 	return (
 		typeof inputs.prompt === 'string' &&
-		typeof evals.dos === 'string' &&
-		typeof evals.donts === 'string'
+		(typeof evals.dos === 'string' || typeof evals.donts === 'string')
 	);
 }


### PR DESCRIPTION
## Summary

Fixes the issue with skipped examples in spec evals if they had only single dos/donts field provided and not both.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
