### PR TITLE
fix(editor-ui): respect placeholder defined on form parameters

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
@@ -660,6 +660,9 @@ function credentialSelected(updateInformation: INodeUpdatePropertiesInformation)
 }
 
 function getPlaceholder(): string {
+	if (props.parameter.placeholder) {
+		return props.parameter.placeholder;
+	}
 	return props.isForCredential
 		? i18n.credText(uiStore.activeCredentialType).placeholder(props.parameter)
 		: i18n.nodeText(ndvStore.activeNode?.type).placeholder(props.parameter, props.path);

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
@@ -660,7 +660,7 @@ function credentialSelected(updateInformation: INodeUpdatePropertiesInformation)
 }
 
 function getPlaceholder(): string {
-	if (props.parameter.placeholder) {
+	if (props.parameter.placeholder != undefined) {
 		return props.parameter.placeholder;
 	}
 	return props.isForCredential


### PR DESCRIPTION
## Summary
Fixes #23993

## Changes
- Give priority to placeholders defined directly on parameters (e.g. via JSON)
- Preserve existing i18n placeholder behavior as fallback

## Testing
- Reproduced issue locally
- Verified placeholder renders correctly in rendered form
