### PR TITLE
fix(editor-ui): hide dropdown placeholder after selection

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/CollectionParameter.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/CollectionParameter.vue
@@ -40,6 +40,10 @@ const nodeHelpers = useNodeHelpers();
 const { activeNode } = storeToRefs(ndvStore);
 
 const getPlaceholderText = computed(() => {
+	// Hide placeholder once an option is selected
+	if (selectedOption.value !== undefined && selectedOption.value !== null) {
+		return '';
+	}
 	return (
 		i18n.nodeText(activeNode.value?.type).placeholder(props.parameter, props.path) ??
 		i18n.baseText('collectionParameter.choose')


### PR DESCRIPTION
## Summary
Improve dropdown placeholder behavior in NDV parameters.

## Changes
- Show placeholder only when no option is selected
- Hide placeholder once a value is chosen to avoid UX confusion
- Preserve existing i18n placeholder behavior as fallback

## Testing
- Tested locally with collection/dropdown parameters
- Verified placeholder is visible before selection and hidden after selecting an option
