### PR TITLE
ci: Cancel currents run when cancelled in GH

### DIFF
--- a/.github/workflows/test-e2e-reusable.yml
+++ b/.github/workflows/test-e2e-reusable.yml
@@ -159,6 +159,8 @@ jobs:
         run: |
           if [ -n "$CURRENTS_API_KEY" ]; then
             curl --location --request PUT \
-              "https://api.currents.dev/v1/runs/${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt }}/cancel" \
-              --header "Authorization: Bearer $CURRENTS_API_KEY"
+              "https://api.currents.dev/v1/runs/cancel-ci/github" \
+              --header "Authorization: Bearer $CURRENTS_API_KEY" \
+              --header "Content-Type: application/json" \
+              --data "{\"githubRunId\": \"${{ github.run_id }}\", \"githubRunAttempt\": \"${{ github.run_attempt }}\"}"
           fi

--- a/.github/workflows/test-e2e-reusable.yml
+++ b/.github/workflows/test-e2e-reusable.yml
@@ -154,7 +154,11 @@ jobs:
 
       - name: Cancel Currents run if workflow is cancelled
         if: ${{ cancelled() }}
+        env:
+          CURRENTS_API_KEY: ${{ secrets.CURRENTS_API_KEY }}
         run: |
-          curl --location --request PUT \
-            "https://api.currents.dev/v1/runs/${{ env.CURRENTS_CI_BUILD_ID }}/cancel" \
-            --header "Authorization: Bearer ${{ secrets.CURRENTS_API_KEY }}"
+          if [ -n "$CURRENTS_API_KEY" ]; then
+            curl --location --request PUT \
+              "https://api.currents.dev/v1/runs/${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt }}/cancel" \
+              --header "Authorization: Bearer $CURRENTS_API_KEY"
+          fi

--- a/.github/workflows/test-e2e-reusable.yml
+++ b/.github/workflows/test-e2e-reusable.yml
@@ -51,6 +51,8 @@ on:
     secrets:
       CURRENTS_RECORD_KEY:
         required: false
+      CURRENTS_API_KEY:
+        required: false
       QA_PERFORMANCE_METRICS_WEBHOOK_URL:
         required: false
       QA_PERFORMANCE_METRICS_WEBHOOK_USER:
@@ -73,6 +75,7 @@ env:
   PLAYWRIGHT_BROWSERS_PATH: packages/testing/playwright/.playwright-browsers
   N8N_DOCKER_IMAGE: ${{ inputs.test-mode == 'docker-build' && 'n8nio/n8n:local' || inputs.docker-image }}
   N8N_SKIP_LICENSES: 'true'
+  CURRENTS_CI_BUILD_ID: ${{ github.repository }}-${{ github.run_id }}-${{ github.run_attempt }}
 
 jobs:
   matrix:
@@ -148,3 +151,10 @@ jobs:
             packages/testing/playwright/test-results/
             packages/testing/playwright/playwright-report/
           retention-days: 7
+
+      - name: Cancel Currents run if workflow is cancelled
+        if: ${{ cancelled() }}
+        run: |
+          curl --location --request PUT \
+            "https://api.currents.dev/v1/runs/${{ env.CURRENTS_CI_BUILD_ID }}/cancel" \
+            --header "Authorization: Bearer ${{ secrets.CURRENTS_API_KEY }}"


### PR DESCRIPTION
## Summary

Simple cancellation for Currents runs when the workflow is cancelled (prevents them from showing as failed due to timeout)

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
