### PR TITLE
fix(core): Use fsRealpath instead of resolve to get the real path

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
@@ -12,7 +12,7 @@ import {
 	open as fsOpen,
 } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { resolve, posix } from 'node:path';
+import { resolve, posix, dirname, basename, join } from 'node:path';
 
 import {
 	BINARY_DATA_STORAGE_PATH,
@@ -38,11 +38,17 @@ const getAllowedPaths = () => {
 };
 
 async function resolvePath(path: PathLike): Promise<ResolvedFilePath> {
+	const pathStr = path.toString();
+
 	try {
-		return (await fsRealpath(path)) as ResolvedFilePath; // apply brand, since we know it's resolved now
+		return (await fsRealpath(pathStr)) as ResolvedFilePath; // apply brand, since we know it's resolved now
 	} catch (error: unknown) {
 		if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
-			return resolve(path.toString()) as ResolvedFilePath; // apply brand, since we know it's resolved now
+			// File doesn't exist - resolve the parent directory and append filename
+			const dir = dirname(pathStr);
+			const file = basename(pathStr);
+			const resolvedDir = await fsRealpath(dir);
+			return join(resolvedDir, file) as ResolvedFilePath;
 		}
 		throw error;
 	}

--- a/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
@@ -12,7 +12,7 @@ import {
 	open as fsOpen,
 } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { resolve, posix, dirname, basename, join } from 'node:path';
+import { posix, dirname, basename, join } from 'node:path';
 
 import {
 	BINARY_DATA_STORAGE_PATH,


### PR DESCRIPTION
## Summary

Today, if we're resolving a filepath and the file doesn't exist, `fsRealpath` throws an error. In this case we fall back to `resolve`. This lets us handle the case where we want to create the file eventually e.g., if we're going to `write`. However, `resolve` doesn't actually resolve symlinks. This defeats part of the purpose of our `resolvePath` helper, which is to ensure that we're working with fully resolved, canonical path. (Since this is what we'll check against allow/block lists.)

This change introduces a strategy where:
- If the file doesn't exist, get the realpath of the containing directory. If *that* doesn't exist, then we return "file not found" (since the eventual write operation would fail anyway). If it _does_ exist, we append the basename and use that as our path. Note that we don't have to worry about symlinks in the "last hop" because we read/write with NO_FOLLOW.

Tested manually to verify that we can still write files that didn't previously exist. Also verified that symlinks end up getting resolved correctly.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1852

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
