### PR TITLE
ci: Change COVERAGE_ENABLED to pass through

### DIFF
--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -8,9 +8,6 @@ concurrency:
   group: ci-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.ref }}
   cancel-in-progress: true
 
-env:
-  COVERAGE_ENABLED: 'true' # Set globally for all jobs - ensures Turbo cache consistency
-
 jobs:
   install-and-build:
     name: Install & Build

--- a/.github/workflows/test-e2e-reusable.yml
+++ b/.github/workflows/test-e2e-reusable.yml
@@ -67,8 +67,6 @@ env:
   # Disable Ryuk to avoid issues with Docker since it needs privileged access, containers are cleaned on teardown anyway
   TESTCONTAINERS_RYUK_DISABLED: true
   PLAYWRIGHT_WORKERS: ${{ inputs.workers != '' && inputs.workers || '2' }}
-  # Must match CI's COVERAGE_ENABLED to ensure Turbo cache hits (it's a globalEnv in turbo.json)
-  COVERAGE_ENABLED: 'true'
   # Browser cache location - must match install-browsers script
   PLAYWRIGHT_BROWSERS_PATH: packages/testing/playwright/.playwright-browsers
   N8N_DOCKER_IMAGE: ${{ inputs.test-mode == 'docker-build' && 'n8nio/n8n:local' || inputs.docker-image }}

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
-	"globalEnv": ["CI", "COVERAGE_ENABLED", "BUILD_WITH_COVERAGE"],
-	"globalPassThroughEnv": ["CODECOV_TOKEN"],
+	"globalEnv": ["CI", "BUILD_WITH_COVERAGE"],
+	"globalPassThroughEnv": ["CODECOV_TOKEN", "COVERAGE_ENABLED"],
 	"tasks": {
 		"clean": { "cache": false },
 		"build": {


### PR DESCRIPTION
## Summary

All jobs will now cache as expected on sha


## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
