### PR TITLE
fix(core): Insert a workflow index placeholder for workflows with no dependencies

### DIFF
--- a/packages/@n8n/db/src/entities/workflow-dependency-entity.ts
+++ b/packages/@n8n/db/src/entities/workflow-dependency-entity.ts
@@ -11,7 +11,12 @@ import {
 import { WithCreatedAt } from './abstract-entity';
 import type { WorkflowEntity } from './workflow-entity';
 
-export type DependencyType = 'credentialId' | 'nodeType' | 'webhookPath' | 'workflowCall';
+export type DependencyType =
+	| 'credentialId'
+	| 'nodeType'
+	| 'webhookPath'
+	| 'workflowCall'
+	| 'workflowIndexed';
 
 @Entity({ name: 'workflow_dependency' })
 export class WorkflowDependency extends WithCreatedAt {
@@ -34,7 +39,7 @@ export class WorkflowDependency extends WithCreatedAt {
 
 	/**
 	 * The type of the dependency.
-	 * credentialId | nodeType | webhookPath | workflowCall
+	 * credentialId | nodeType | webhookPath | workflowCall | workflowIndexed
 	 */
 	@Column({ length: 32 })
 	@Index()

--- a/packages/cli/src/modules/workflow-index/__tests__/workflow-index.service.test.ts
+++ b/packages/cli/src/modules/workflow-index/__tests__/workflow-index.service.test.ts
@@ -355,6 +355,66 @@ describe('WorkflowIndexService', () => {
 				]),
 			);
 		});
+
+		it('should insert placeholder for workflow with no nodes', async () => {
+			mockWorkflowDependencyRepository.updateDependenciesForWorkflow.mockResolvedValue(true);
+
+			const workflow = createWorkflow([]);
+
+			await service.updateIndexFor(workflow);
+
+			expect(mockWorkflowDependencyRepository.updateDependenciesForWorkflow).toHaveBeenCalledWith(
+				'workflow-123',
+				expect.objectContaining({
+					dependencies: expect.arrayContaining([
+						expect.objectContaining({
+							dependencyType: 'workflowIndexed',
+							dependencyKey: '__INDEXED__',
+							dependencyInfo: null,
+						}),
+					]),
+				}),
+			);
+
+			// Verify only the placeholder exists (exactly 1 dependency)
+			const call = mockWorkflowDependencyRepository.updateDependenciesForWorkflow.mock.calls[0];
+			expect(call[1].dependencies).toHaveLength(1);
+		});
+
+		it('should insert placeholder for workflow with nodes but no extractable dependencies', async () => {
+			mockWorkflowDependencyRepository.updateDependenciesForWorkflow.mockResolvedValue(true);
+
+			// Node with empty type - no nodeType dependency will be created
+			const workflow = createWorkflow([
+				{
+					id: 'node-1',
+					name: 'EmptyNode',
+					type: '', // Empty type - no dependency extracted
+					typeVersion: 1,
+					position: [0, 0] as [number, number],
+					parameters: {},
+				} as INode,
+			]);
+
+			await service.updateIndexFor(workflow);
+
+			expect(mockWorkflowDependencyRepository.updateDependenciesForWorkflow).toHaveBeenCalledWith(
+				'workflow-123',
+				expect.objectContaining({
+					dependencies: expect.arrayContaining([
+						expect.objectContaining({
+							dependencyType: 'workflowIndexed',
+							dependencyKey: '__INDEXED__',
+							dependencyInfo: null,
+						}),
+					]),
+				}),
+			);
+
+			// Verify only the placeholder exists (exactly 1 dependency)
+			const call = mockWorkflowDependencyRepository.updateDependenciesForWorkflow.mock.calls[0];
+			expect(call[1].dependencies).toHaveLength(1);
+		});
 	});
 
 	describe('init()', () => {

--- a/packages/cli/src/modules/workflow-index/workflow-index.service.ts
+++ b/packages/cli/src/modules/workflow-index/workflow-index.service.ts
@@ -9,6 +9,9 @@ import { EventService } from '@/events/event.service';
 // A safety limit to prevent infinite loops in indexing.
 const LOOP_LIMIT = 1_000_000_000;
 
+// Placeholder key for workflows with no dependencies.
+const WORKFLOW_INDEXED_PLACEHOLDER_KEY = '__INDEXED__';
+
 /**
  * Service for managing the workflow dependency index. The index tracks dependencies such as node types,
  * credentials, workflow calls, and webhook paths used by each workflow. The service builds the index on server start
@@ -99,6 +102,15 @@ export class WorkflowIndexService {
 			this.addWorkflowCallDependencies(node, dependencyUpdates);
 			this.addWebhookPathDependencies(node, dependencyUpdates);
 		});
+
+		// If no dependencies were extracted, add a placeholder to mark the workflow as indexed
+		if (dependencyUpdates.dependencies.length === 0) {
+			dependencyUpdates.add({
+				dependencyType: 'workflowIndexed',
+				dependencyKey: WORKFLOW_INDEXED_PLACEHOLDER_KEY,
+				dependencyInfo: null,
+			});
+		}
 
 		let updated: boolean;
 		try {


### PR DESCRIPTION
## Summary

Insert a placeholder entry for workflows with no dependencies. Specifically, this will be empty workflows.

Without this, we will wind up in an infinite loop trying to re-index these workflows.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2074

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
