### PR TITLE
fix: Regenerate form webhook ids when pasting workflow data

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -43,6 +43,7 @@ import {
 	OPEN_AI_CHAT_MODEL_NODE_TYPE,
 	SET_NODE_TYPE,
 	STICKY_NODE_TYPE,
+	UPDATE_WEBHOOK_ID_NODE_TYPES,
 	VIEWS,
 	WEBHOOK_NODE_TYPE,
 } from '@/app/constants';
@@ -4181,8 +4182,8 @@ describe('useCanvasOperations', () => {
 			expect(toast.showError).not.toHaveBeenCalled();
 		});
 
-		it.each([WEBHOOK_NODE_TYPE, FORM_TRIGGER_NODE_TYPE, MCP_TRIGGER_NODE_TYPE])(
-			'should regenerate webhook ids for node type "%s"',
+		it.each(UPDATE_WEBHOOK_ID_NODE_TYPES)(
+			'should regenerate webhook ids for node type "%s" on pasting into canvas',
 			async (type) => {
 				const workflowsStore = mockedStore(useWorkflowsStore);
 
@@ -4203,7 +4204,7 @@ describe('useCanvasOperations', () => {
 						position: [200, 200] as [number, number],
 						webhookId: 'first-webhook',
 						parameters: {
-							options: {},
+							path: 'some-path',
 						},
 					},
 					{
@@ -4214,7 +4215,9 @@ describe('useCanvasOperations', () => {
 						position: [300, 300] as [number, number],
 						webhookId: 'second-webhook',
 						parameters: {
-							options: {},
+							options: {
+								path: 'some-path',
+							},
 						},
 					},
 				];
@@ -4232,12 +4235,80 @@ describe('useCanvasOperations', () => {
 
 				// This should not throw even when nodes can't be added due to maxNodes limit
 				const workflow = await canvasOperations.importWorkflowData(workflowDataToImport, 'paste');
-				console.log(workflow);
+
 				expect(workflow.nodes).toHaveLength(2);
 				expect(workflow.nodes![0].name).toBe('Execute Workflow Trigger 1');
 				expect(workflow.nodes![0].webhookId).not.toBe('first-webhook');
+				expect(workflow.nodes![0].parameters.path).not.toBe('some-path');
 				expect(workflow.nodes![1].name).toBe('Execute Workflow Trigger 2');
 				expect(workflow.nodes![1].webhookId).not.toBe('second-webhook');
+				expect((workflow.nodes![1].parameters.options as { path: string }).path).not.toBe(
+					'some-path',
+				);
+			},
+		);
+
+		it.each([WEBHOOK_NODE_TYPE, MCP_TRIGGER_NODE_TYPE])(
+			'should not regenerate webhook ids for node type "%s" on pasting into canvas',
+			async (type) => {
+				const workflowsStore = mockedStore(useWorkflowsStore);
+
+				// This mock is needed for addImportedNodesToWorkflow to work
+				workflowsStore.createWorkflowObject = vi.fn().mockReturnValue({
+					nodes: {},
+					connections: {},
+					connectionsBySourceNode: {},
+					renameNode: vi.fn(),
+				});
+
+				const nodesToImport = [
+					{
+						id: 'import-1',
+						name: 'Execute Workflow Trigger 1',
+						type,
+						typeVersion: 1,
+						position: [200, 200] as [number, number],
+						webhookId: 'first-webhook',
+						parameters: {
+							path: 'some-path',
+						},
+					},
+					{
+						id: 'import-2',
+						name: 'Execute Workflow Trigger 2',
+						type,
+						typeVersion: 1,
+						position: [300, 300] as [number, number],
+						webhookId: 'second-webhook',
+						parameters: {
+							options: {
+								path: 'some-path',
+							},
+						},
+					},
+				];
+
+				const workflowDataToImport = {
+					nodes: nodesToImport,
+					connections: {},
+					pinData: {
+						'Execute Workflow Trigger 1': [{ json: { test: 'data1' } }],
+						'Execute Workflow Trigger 2': [{ json: { test: 'data2' } }],
+					},
+				};
+
+				const canvasOperations = useCanvasOperations();
+
+				// This should not throw even when nodes can't be added due to maxNodes limit
+				const workflow = await canvasOperations.importWorkflowData(workflowDataToImport, 'paste');
+
+				expect(workflow.nodes).toHaveLength(2);
+				expect(workflow.nodes![0].name).toBe('Execute Workflow Trigger 1');
+				expect(workflow.nodes![0].webhookId).toBe('first-webhook');
+				expect(workflow.nodes![0].parameters.path).toBe('some-path');
+				expect(workflow.nodes![1].name).toBe('Execute Workflow Trigger 2');
+				expect(workflow.nodes![1].webhookId).toBe('second-webhook');
+				expect((workflow.nodes![1].parameters.options as { path: string }).path).toBe('some-path');
 			},
 		);
 	});

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -39,6 +39,7 @@ import {
 	AGENT_NODE_TYPE,
 	EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE,
 	FORM_TRIGGER_NODE_TYPE,
+	MCP_TRIGGER_NODE_TYPE,
 	OPEN_AI_CHAT_MODEL_NODE_TYPE,
 	SET_NODE_TYPE,
 	STICKY_NODE_TYPE,
@@ -4179,6 +4180,66 @@ describe('useCanvasOperations', () => {
 			).resolves.not.toThrow();
 			expect(toast.showError).not.toHaveBeenCalled();
 		});
+
+		it.each([WEBHOOK_NODE_TYPE, FORM_TRIGGER_NODE_TYPE, MCP_TRIGGER_NODE_TYPE])(
+			'should regenerate webhook ids for node type "%s"',
+			async (type) => {
+				const workflowsStore = mockedStore(useWorkflowsStore);
+
+				// This mock is needed for addImportedNodesToWorkflow to work
+				workflowsStore.createWorkflowObject = vi.fn().mockReturnValue({
+					nodes: {},
+					connections: {},
+					connectionsBySourceNode: {},
+					renameNode: vi.fn(),
+				});
+
+				const nodesToImport = [
+					{
+						id: 'import-1',
+						name: 'Execute Workflow Trigger 1',
+						type,
+						typeVersion: 1,
+						position: [200, 200] as [number, number],
+						webhookId: 'first-webhook',
+						parameters: {
+							options: {},
+						},
+					},
+					{
+						id: 'import-2',
+						name: 'Execute Workflow Trigger 2',
+						type,
+						typeVersion: 1,
+						position: [300, 300] as [number, number],
+						webhookId: 'second-webhook',
+						parameters: {
+							options: {},
+						},
+					},
+				];
+
+				const workflowDataToImport = {
+					nodes: nodesToImport,
+					connections: {},
+					pinData: {
+						'Execute Workflow Trigger 1': [{ json: { test: 'data1' } }],
+						'Execute Workflow Trigger 2': [{ json: { test: 'data2' } }],
+					},
+				};
+
+				const canvasOperations = useCanvasOperations();
+
+				// This should not throw even when nodes can't be added due to maxNodes limit
+				const workflow = await canvasOperations.importWorkflowData(workflowDataToImport, 'paste');
+				console.log(workflow);
+				expect(workflow.nodes).toHaveLength(2);
+				expect(workflow.nodes![0].name).toBe('Execute Workflow Trigger 1');
+				expect(workflow.nodes![0].webhookId).not.toBe('first-webhook');
+				expect(workflow.nodes![1].name).toBe('Execute Workflow Trigger 2');
+				expect(workflow.nodes![1].webhookId).not.toBe('second-webhook');
+			},
+		);
 	});
 
 	describe('duplicateNodes', () => {

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -2309,7 +2309,7 @@ export function useCanvasOperations() {
 						nodeNames.add(newName);
 					}
 
-					// Generate new webhookId for all webhook nodes
+					// Generate new webhookId
 					if (node.webhookId && UPDATE_WEBHOOK_ID_NODE_TYPES.includes(node.type)) {
 						if (node.webhookId) {
 							nodeHelpers.assignWebhookId(node);

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -2314,7 +2314,7 @@ export function useCanvasOperations() {
 
 						if (node.parameters.path) {
 							node.parameters.path = node.webhookId;
-						} else if ((node.parameters.options as IDataObject).path) {
+						} else if ((node.parameters.options as IDataObject)?.path) {
 							(node.parameters.options as IDataObject).path = node.webhookId;
 						}
 					}

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -31,7 +31,6 @@ import {
 	FORM_TRIGGER_NODE_TYPE,
 	MCP_TRIGGER_NODE_TYPE,
 	STICKY_NODE_TYPE,
-	UPDATE_WEBHOOK_ID_NODE_TYPES,
 	VIEWS,
 	WEBHOOK_NODE_TYPE,
 } from '@/app/constants';
@@ -2309,19 +2308,14 @@ export function useCanvasOperations() {
 						nodeNames.add(newName);
 					}
 
-					// Generate new webhookId if workflow already contains a node with the same webhookId
-					if (node.webhookId && UPDATE_WEBHOOK_ID_NODE_TYPES.includes(node.type)) {
-						const isDuplicate = Object.values(workflowsStore.workflowObject.nodes).some(
-							(n) => n.webhookId === node.webhookId,
-						);
-						if (isDuplicate) {
-							nodeHelpers.assignWebhookId(node);
+					// Generate new webhookId for all webhook nodes
+					if (node.webhookId) {
+						nodeHelpers.assignWebhookId(node);
 
-							if (node.parameters.path) {
-								node.parameters.path = node.webhookId;
-							} else if ((node.parameters.options as IDataObject).path) {
-								(node.parameters.options as IDataObject).path = node.webhookId;
-							}
+						if (node.parameters.path) {
+							node.parameters.path = node.webhookId;
+						} else if ((node.parameters.options as IDataObject).path) {
+							(node.parameters.options as IDataObject).path = node.webhookId;
 						}
 					}
 

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -31,6 +31,7 @@ import {
 	FORM_TRIGGER_NODE_TYPE,
 	MCP_TRIGGER_NODE_TYPE,
 	STICKY_NODE_TYPE,
+	UPDATE_WEBHOOK_ID_NODE_TYPES,
 	VIEWS,
 	WEBHOOK_NODE_TYPE,
 } from '@/app/constants';
@@ -2309,13 +2310,15 @@ export function useCanvasOperations() {
 					}
 
 					// Generate new webhookId for all webhook nodes
-					if (node.webhookId) {
-						nodeHelpers.assignWebhookId(node);
+					if (node.webhookId && UPDATE_WEBHOOK_ID_NODE_TYPES.includes(node.type)) {
+						if (node.webhookId) {
+							nodeHelpers.assignWebhookId(node);
 
-						if (node.parameters.path) {
-							node.parameters.path = node.webhookId;
-						} else if ((node.parameters.options as IDataObject)?.path) {
-							(node.parameters.options as IDataObject).path = node.webhookId;
+							if (node.parameters.path) {
+								node.parameters.path = node.webhookId;
+							} else if ((node.parameters.options as IDataObject)?.path) {
+								(node.parameters.options as IDataObject).path = node.webhookId;
+							}
 						}
 					}
 


### PR DESCRIPTION
## Summary

When form nodes containing webhooks are copy&pasted into a workflow the webhook url (form url) will always be regenerated.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/NODE-4054


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
