### PR TITLE
fix(ai-builder): Correctly connect Mermaid sub-graphs

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/utils/mermaid.utils.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/utils/mermaid.utils.ts
@@ -867,7 +867,7 @@ class MermaidBuilder {
 				nodeNames.includes(nodeName) && !nestedStickyIds.has(sticky.node.id ?? ''),
 		);
 		if (stickySubgraph) {
-			return `sticky:${stickySubgraph.sticky.node.id ?? stickySubgraph.sticky.content}`;
+			return `sticky:${stickySubgraph.sticky.node.id}`;
 		}
 
 		// Check if in an agent subgraph
@@ -876,7 +876,7 @@ class MermaidBuilder {
 				agentNode.name === nodeName || aiConnectedNodeNames.includes(nodeName),
 		);
 		if (agentSubgraph) {
-			return `agent:${agentSubgraph.agentNode.name}`;
+			return `agent:${agentSubgraph.agentNode.id}`;
 		}
 
 		return 'none';

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/utils/mermaid.utils.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/utils/mermaid.utils.ts
@@ -830,10 +830,11 @@ class MermaidBuilder {
 				if (this.isInNestedSticky(nodeName, nestedStickyIds)) continue;
 				if (this.isInNestedSticky(targetName, nestedStickyIds)) continue;
 
-				const sourceSubgraphType = this.getSubgraphType(nodeName, nestedStickyIds);
-				const targetSubgraphType = this.getSubgraphType(targetName, nestedStickyIds);
+				const sourceSubgraphId = this.getSubgraphId(nodeName, nestedStickyIds);
+				const targetSubgraphId = this.getSubgraphId(targetName, nestedStickyIds);
 
-				if (sourceSubgraphType === targetSubgraphType) continue;
+				// Skip if both nodes are in the same subgraph (connections already handled internally)
+				if (sourceSubgraphId === targetSubgraphId) continue;
 
 				const sourceId = this.nodeIdMap.get(nodeName);
 				const targetId = this.nodeIdMap.get(targetName);
@@ -855,21 +856,28 @@ class MermaidBuilder {
 		);
 	}
 
-	private getSubgraphType(
-		nodeName: string,
-		nestedStickyIds: Set<string>,
-	): 'sticky' | 'agent' | 'none' {
-		const inStandaloneSticky = this.stickyOverlaps.multiNodeOverlap.some(
+	/**
+	 * Returns a unique identifier for the subgraph a node belongs to.
+	 * This allows distinguishing between different sticky subgraphs or different agent subgraphs.
+	 */
+	private getSubgraphId(nodeName: string, nestedStickyIds: Set<string>): string {
+		// Check if in a standalone sticky subgraph
+		const stickySubgraph = this.stickyOverlaps.multiNodeOverlap.find(
 			({ sticky, nodeNames }) =>
 				nodeNames.includes(nodeName) && !nestedStickyIds.has(sticky.node.id ?? ''),
 		);
-		if (inStandaloneSticky) return 'sticky';
+		if (stickySubgraph) {
+			return `sticky:${stickySubgraph.sticky.node.id ?? stickySubgraph.sticky.content}`;
+		}
 
-		const inAgentSubgraph = this.agentSubgraphs.some(
+		// Check if in an agent subgraph
+		const agentSubgraph = this.agentSubgraphs.find(
 			({ agentNode, aiConnectedNodeNames }) =>
 				agentNode.name === nodeName || aiConnectedNodeNames.includes(nodeName),
 		);
-		if (inAgentSubgraph) return 'agent';
+		if (agentSubgraph) {
+			return `agent:${agentSubgraph.agentNode.name}`;
+		}
 
 		return 'none';
 	}


### PR DESCRIPTION
## Summary

Noticed an issue with some more recent templates, its becoming more prevalent to wrap every chunk of a template in a comment block - with the updates to Mermaid generation before the holiday break in https://github.com/n8n-io/n8n/pull/23417 comments are added to the mermaid chart as subgraphs. There was an issue where nodes within different subgraphs wouldn't be connected correctly, I've added a test for this and fixed these connections.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
