### PR TITLE
ci: Support license cert in E2E tests

### DIFF
--- a/.github/workflows/test-e2e-reusable.yml
+++ b/.github/workflows/test-e2e-reusable.yml
@@ -61,6 +61,8 @@ on:
         required: false
       N8N_LICENSE_ACTIVATION_KEY:
         required: false
+      N8N_LICENSE_CERT:
+        required: false
       N8N_ENCRYPTION_KEY:
         required: false
 
@@ -139,6 +141,8 @@ jobs:
           QA_PERFORMANCE_METRICS_WEBHOOK_USER: ${{ secrets.QA_PERFORMANCE_METRICS_WEBHOOK_USER }}
           QA_PERFORMANCE_METRICS_WEBHOOK_PASSWORD: ${{ secrets.QA_PERFORMANCE_METRICS_WEBHOOK_PASSWORD }}
           N8N_LICENSE_ACTIVATION_KEY: ${{ secrets.N8N_LICENSE_ACTIVATION_KEY }}
+          N8N_LICENSE_CERT: ${{ secrets.N8N_LICENSE_CERT }}
+          N8N_ENCRYPTION_KEY: ${{ secrets.N8N_ENCRYPTION_KEY }}
 
       - name: Upload Failure Artifacts
         if: ${{ failure() && inputs.upload-failure-artifacts }}

--- a/packages/testing/containers/services/n8n.ts
+++ b/packages/testing/containers/services/n8n.ts
@@ -84,8 +84,10 @@ function computeEnvironment(options: N8NInstancesOptions): Record<string, string
 		env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS = 'true';
 
 		if (mains > 1) {
-			if (!process.env.N8N_LICENSE_ACTIVATION_KEY) {
-				throw new Error('N8N_LICENSE_ACTIVATION_KEY is required for multi-main instances');
+			if (!process.env.N8N_LICENSE_ACTIVATION_KEY && !process.env.N8N_LICENSE_CERT) {
+				throw new Error(
+					'N8N_LICENSE_ACTIVATION_KEY or N8N_LICENSE_CERT is required for multi-main instances',
+				);
 			}
 			env.N8N_MULTI_MAIN_SETUP_ENABLED = 'true';
 		}


### PR DESCRIPTION
## Summary

Add support for `N8N_LICENSE_CERT` in E2E tests as an alternative to activation key for multi-main setups. Also passes `N8N_ENCRYPTION_KEY` to ensure consistent instance fingerprinting.

### Changes
- Pass `N8N_LICENSE_CERT` and `N8N_ENCRYPTION_KEY` secrets to E2E test workflow
- Accept either activation key or license cert for multi-main test containers

## Related Linear tickets, Github issues, and Community forum posts

N/A - CI improvement

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. (N/A - internal CI)
- [x] Tests included. (N/A - CI config)
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
