### PR TITLE
fix(OpenAI Node): Convert error null to undefined to prevent false retries

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/transport/index.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/transport/index.ts
@@ -53,5 +53,11 @@ export async function apiRequest(
 		Object.assign(options, option);
 	}
 
-	return await this.helpers.requestWithAuthentication.call(this, 'openAiApi', options);
+	const response = await this.helpers.requestWithAuthentication.call(this, 'openAiApi', options);
+
+	if (response && response.error === null) {
+		response.error = undefined;
+	}
+
+	return response;
 }

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/transport/test/transport.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/transport/test/transport.test.ts
@@ -59,4 +59,23 @@ describe('apiRequest', () => {
 			},
 		);
 	});
+
+	it('should normalize error: null to error: undefined', async () => {
+		// Arrange
+		mockedExecutionContext.getCredentials.mockResolvedValue({});
+		mockedExecutionContext.helpers.requestWithAuthentication.mockResolvedValue({
+			id: 'test',
+			error: null,
+		});
+
+		// Act
+		const response = await apiRequest.call(
+			mockedExecutionContext as unknown as IExecuteFunctions,
+			'GET',
+			'/test',
+		);
+
+		// Assert
+		expect(response.error).toBeUndefined();
+	});
 });


### PR DESCRIPTION
## Summary

In packages/core/src/execution-engine/workflow-execute.ts, it checks if the node has failed by:

    runNodeData.data?.[0]?.[0]?.json?.error !== undefined

However, OpenAI API reponse contains a field "error" with "null" when the call is successful, which will fail the check. This will cause the OpenAI node execute multiple times, despite the calls are all successful.

This commit should fix this issue.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #24205


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
