### PR TITLE
fix(core): Bug with import command in CLI

### DIFF
--- a/packages/cli/src/services/__tests__/import.service.test.ts
+++ b/packages/cli/src/services/__tests__/import.service.test.ts
@@ -1,10 +1,6 @@
 import { safeJoinPath, type Logger } from '@n8n/backend-common';
 import type { DatabaseConfig } from '@n8n/config';
-import type {
-	CredentialsRepository,
-	TagRepository,
-	WorkflowPublishHistoryRepository,
-} from '@n8n/db';
+import type { CredentialsRepository, TagRepository } from '@n8n/db';
 import { type DataSource, type EntityManager } from '@n8n/typeorm';
 import { readdir, readFile } from 'fs/promises';
 import { mock } from 'jest-mock-extended';
@@ -46,7 +42,6 @@ describe('ImportService', () => {
 	let mockActiveWorkflowManager: ActiveWorkflowManager;
 	let mockWorkflowIndexService: WorkflowIndexService;
 	let mockDatabaseConfig: DatabaseConfig;
-	let mockWorkflowPublishHistoryRepository: WorkflowPublishHistoryRepository;
 
 	beforeEach(() => {
 		jest.clearAllMocks();
@@ -60,7 +55,6 @@ describe('ImportService', () => {
 		mockActiveWorkflowManager = mock<ActiveWorkflowManager>();
 		mockWorkflowIndexService = mock<WorkflowIndexService>();
 		mockDatabaseConfig = mock<DatabaseConfig>();
-		mockWorkflowPublishHistoryRepository = mock<WorkflowPublishHistoryRepository>();
 
 		// Set up cipher mock
 		mockCipher.decrypt = jest.fn((data: string) => data.replace('encrypted:', ''));
@@ -108,7 +102,6 @@ describe('ImportService', () => {
 			mockActiveWorkflowManager,
 			mockWorkflowIndexService,
 			mockDatabaseConfig,
-			mockWorkflowPublishHistoryRepository,
 		);
 	});
 

--- a/packages/cli/src/services/import.service.ts
+++ b/packages/cli/src/services/import.service.ts
@@ -79,11 +79,7 @@ export class ImportService {
 
 			// Remove workflows from ActiveWorkflowManager BEFORE transaction to prevent orphaned trigger listeners
 			if (workflow.id) {
-				try {
-					await this.activeWorkflowManager.remove(workflow.id);
-				} catch {
-					// Workflow doesn't exist or has no active version, nothing to remove
-				}
+				await this.activeWorkflowManager.remove(workflow.id);
 			}
 		}
 

--- a/packages/cli/test/integration/import.service.test.ts
+++ b/packages/cli/test/integration/import.service.test.ts
@@ -58,7 +58,6 @@ describe('ImportService', () => {
 			mockActiveWorkflowManager,
 			mockWorkflowIndexService,
 			Container.get(DatabaseConfig),
-			mock(),
 		);
 	});
 


### PR DESCRIPTION
## Summary

  Fix workflow import failures introduced in v1.123.7 when importing workflows with active: true or activeVersionId set. This resolves foreign key constraint violations and "Could not find workflow" errors during import operations.

  Problem

  After the introduction of the workflow_publish_history table in commit 9f2efb75aaf (v1.123.7), importing workflows began failing with two critical errors:

  Foreign Key Constraint Violation
  SQLITE_CONSTRAINT: FOREIGN KEY constraint failed
  insert or update on table "workflow_publish_history" violates foreign key constraint
    - Occurred when importing workflows with active: true or activeVersionId set
    - Caused by attempting to insert publish history records BEFORE the workflow existed in the database
    - The versionId from exported workflows references workflow_history records that don't exist in the target instance

  Root Cause Analysis

  Version Timeline

  - v1.113.3 ✅ Working - Simple import logic without publish history
  - v1.123.7 ❌ Broken - Bug introduced with workflow publish history feature
  - v2.2.3+ ❌ Still broken - Issue persisted in later versions

  Technical Issues

Incorrect Operation Order
  The code attempted to add publish history records BEFORE upserting the workflow:
```
  // WRONG ORDER - causes foreign key violation
  if (workflow.active || workflow.activeVersionId) {
      await this.workflowPublishHistoryRepository.addRecord({...}); // ❌ Workflow doesn't exist yet
  }
  const upsertResult = await tx.upsert(WorkflowEntity, workflow, ['id']);
```

Solution

  1. Removed Publish History Tracking from Import

  Import is a data migration operation, not a workflow lifecycle event. Publish history should track activation/deactivation during normal operation, not data migration:

  Rationale:
  - Version IDs from exports don't exist in target database
  - Import is not semantically an "activation" or "deactivation" event
  - Cleaner separation between data migration and workflow operations

How to test:

Go to the version with the issue
git checkout n8n@1.123.7
pnpm build

Run n8n, add a workflow and publish it.

Export workflow via the CLI 
cd packages/cli/bin
./n8n export:workflow --backup --output={your path}

Run n8n with another database
export DB_SQLITE_DATABASE={some path different to the first db}
Start n8n so the migrations run

Import workflow via the CLI
./n8n import:workflow --separate --input={the path where the export is}

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4632/bug-cli-import-still-broken

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
