### PR TITLE
test: Add keepalive flag for testcontainers

### DIFF
--- a/packages/testing/playwright/AGENTS.md
+++ b/packages/testing/playwright/AGENTS.md
@@ -13,3 +13,25 @@
 
 - In writing locators, use specialized methods when available.
   For example, prefer `page.getByRole('button')` over `page.locator('[role=button]')`.
+
+## Debugging with Keepalive
+
+Use `N8N_CONTAINERS_KEEPALIVE=true` to keep containers running after tests complete. This is useful for:
+- Debugging test failures by inspecting the n8n instance state
+- Exploring configured integrations (source control, email, OIDC, etc.)
+- Manual testing against a pre-configured environment
+
+```bash
+N8N_CONTAINERS_KEEPALIVE=true pnpm --filter=n8n-playwright test:container:sqlite --grep "@capability:email" --workers 1
+```
+
+After tests complete, containers remain running and connection details are printed:
+```
+=== KEEPALIVE: Containers left running for debugging ===
+    URL: http://localhost:54321
+    Project: n8n-stack-abc123
+    Cleanup: pnpm --filter n8n-containers stack:clean:all
+=========================================================
+```
+
+Clean up when done: `pnpm --filter n8n-containers stack:clean:all`

--- a/packages/testing/playwright/fixtures/base.ts
+++ b/packages/testing/playwright/fixtures/base.ts
@@ -73,6 +73,16 @@ export const test = base.extend<
 
 			const container = await createN8NStack(config);
 			await use(container);
+
+			if (process.env.N8N_CONTAINERS_KEEPALIVE === 'true') {
+				console.log('\n=== KEEPALIVE: Containers left running for debugging ===');
+				console.log(`    URL: ${container.baseUrl}`);
+				console.log(`    Project: ${container.projectName}`);
+				console.log('    Cleanup: pnpm --filter n8n-containers stack:clean:all');
+				console.log('=========================================================\n');
+				return;
+			}
+
 			await container.stop();
 		},
 		{ scope: 'worker', box: true },


### PR DESCRIPTION
## Summary

Allows N8N_CONTAINERS_KEEPALIVE to be passed when running Playwright test commands. This will keep the container stack alive after so you can inspect/debug. Also useful for setting up an environment in an expected stage e.g setting up an instance with keycloak preconfigured.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
