### PR TITLE
fix: Fix CLI import

### DIFF
--- a/packages/cli/src/services/__tests__/import.service.test.ts
+++ b/packages/cli/src/services/__tests__/import.service.test.ts
@@ -1,10 +1,6 @@
 import { safeJoinPath, type Logger } from '@n8n/backend-common';
 import type { DatabaseConfig } from '@n8n/config';
-import type {
-	CredentialsRepository,
-	TagRepository,
-	WorkflowPublishHistoryRepository,
-} from '@n8n/db';
+import type { CredentialsRepository, TagRepository } from '@n8n/db';
 import { type DataSource, type EntityManager } from '@n8n/typeorm';
 import { readdir, readFile } from 'fs/promises';
 import { mock } from 'jest-mock-extended';
@@ -46,7 +42,6 @@ describe('ImportService', () => {
 	let mockActiveWorkflowManager: ActiveWorkflowManager;
 	let mockWorkflowIndexService: WorkflowIndexService;
 	let mockDatabaseConfig: DatabaseConfig;
-	let mockWorkflowPublishHistoryRepository: WorkflowPublishHistoryRepository;
 
 	beforeEach(() => {
 		jest.clearAllMocks();
@@ -60,7 +55,6 @@ describe('ImportService', () => {
 		mockActiveWorkflowManager = mock<ActiveWorkflowManager>();
 		mockWorkflowIndexService = mock<WorkflowIndexService>();
 		mockDatabaseConfig = mock<DatabaseConfig>();
-		mockWorkflowPublishHistoryRepository = mock<WorkflowPublishHistoryRepository>();
 
 		// Set up cipher mock
 		mockCipher.decrypt = jest.fn((data: string) => data.replace('encrypted:', ''));
@@ -93,6 +87,7 @@ describe('ImportService', () => {
 		});
 		mockEntityManager.query = jest.fn().mockResolvedValue(undefined);
 		mockEntityManager.insert = jest.fn().mockResolvedValue(undefined);
+		mockEntityManager.upsert = jest.fn().mockResolvedValue(undefined);
 
 		// Mock transaction method
 		mockDataSource.transaction = jest.fn().mockImplementation(async (callback) => {
@@ -108,7 +103,6 @@ describe('ImportService', () => {
 			mockActiveWorkflowManager,
 			mockWorkflowIndexService,
 			mockDatabaseConfig,
-			mockWorkflowPublishHistoryRepository,
 		);
 	});
 


### PR DESCRIPTION
## Summary

We forgot to add records to workflow history during workflow import. This led to having problems with adding workflow publish history records, but even if we remove these, the problem will still be with not being able to activate imported workflows because of missing workflow history records.

This PR always adds workflow history records and adds records to workflow publish history only when an existing workflow has an active version.

I'm creating new uuids for versions during import so that if this version already exists, we wouldn't update it, but rather create a new version with "import" as author.

I also fixed issues with trying to deactivate non-existent non-active workflows which led to console errors:
```
Importing 1 workflows...                                                                                                             
  Could not find workflow                                                                                                              
  Error: Could not find workflow                                                                                                       
  at ActiveWorkflowManager.clearWebhooks (/n8n/packages/cli/src/active-workflow-manager.ts:246:10)                    
  at ActiveWorkflowManager.remove (/n8n/packages/cli/src/active-workflow-manager.ts:883:4)          
```

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-4632](https://linear.app/n8n/issue/ADO-4632/bug-cli-import-still-broken)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
