### PR TITLE
fix(editor): Fix parameter path in multipleValues=false fixedCollection

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterNew.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterNew.test.ts
@@ -560,7 +560,7 @@ describe('FixedCollectionParameterNew.vue', () => {
 	});
 
 	describe('multipleValues=false fixedCollection', () => {
-		it('renders correctly and emits changes', async () => {
+		it('renders values correctly', async () => {
 			const { getByTestId } = renderComponent({
 				props: {
 					...baseProps,

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterNew.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterNew.test.ts
@@ -559,6 +559,27 @@ describe('FixedCollectionParameterNew.vue', () => {
 		});
 	});
 
+	describe('multipleValues=false fixedCollection', () => {
+		it('renders correctly and emits changes', async () => {
+			const { getByTestId } = renderComponent({
+				props: {
+					...baseProps,
+					parameter: {
+						...baseProps.parameter,
+						typeOptions: { multipleValues: false },
+					},
+					values: { values: { outputKey: 'My Custom Value' } },
+					nodeValues: { parameters: { rules: { values: { outputKey: 'My Custom Value' } } } },
+				},
+			});
+
+			await waitFor(() => {
+				const input = getByTestId('parameter-item').querySelector('input') as HTMLInputElement;
+				expect(input?.value).toBe('My Custom Value');
+			});
+		});
+	});
+
 	describe('hideOptionalFields mode', () => {
 		const hideOptionalFieldsProps: Props = {
 			parameter: {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterNew.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterNew.vue
@@ -653,7 +653,7 @@ const onAddButtonClick = () => {
 						hide-delete
 						:parameters="getVisiblePropertyValues(property)"
 						:node-values="nodeValues"
-						:path="getPropertyPath(property.name, 0)"
+						:path="getPropertyPath(property.name)"
 						:is-read-only="!!isReadOnly"
 						:is-nested="false"
 						:remove-first-parameter-margin="true"
@@ -846,7 +846,7 @@ const onAddButtonClick = () => {
 						hide-delete
 						:parameters="getVisiblePropertyValues(property)"
 						:node-values="nodeValues"
-						:path="getPropertyPath(property.name, 0)"
+						:path="getPropertyPath(property.name)"
 						:is-read-only="!!isReadOnly"
 						:is-nested="false"
 						:remove-first-parameter-margin="true"


### PR DESCRIPTION
## Summary

Parameter path for inputs had an additional `[0]` that prevented correctly rendering the selected value

Can be verified in any HITL node:

<img width="623" height="345" alt="image" src="https://github.com/user-attachments/assets/a49f412a-3336-43fa-a781-320550ffd5f1" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4201/cannot-add-approval-options-in-hitl-nodes

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
