### PR TITLE
fix(core): Preserve source overwrite in chained tool calls

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/index.ts
+++ b/packages/core/src/execution-engine/node-execution-context/index.ts
@@ -15,4 +15,5 @@ export { normalizeItems } from './utils/normalize-items';
 export { parseIncomingMessage } from './utils/parse-incoming-message';
 export { parseRequestObject } from './utils/request-helper-functions';
 export { returnJsonArray } from './utils/return-json-array';
+export { resolveSourceOverwrite } from './utils/resolve-source-overwrite';
 export * from './utils/binary-helper-functions';

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/resolve-source-overwrite.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/resolve-source-overwrite.test.ts
@@ -1,0 +1,302 @@
+import type { IExecuteData, INodeExecutionData, ISourceData } from 'n8n-workflow';
+
+import { resolveSourceOverwrite } from '../resolve-source-overwrite';
+
+describe('resolveSourceOverwrite', () => {
+	describe('should return null when', () => {
+		test('preserveSourceOverwrite is false', () => {
+			const item: INodeExecutionData = {
+				json: { data: 'test' },
+				pairedItem: {
+					item: 0,
+					sourceOverwrite: {
+						previousNode: 'Node1',
+						previousNodeOutput: 0,
+						previousNodeRun: 0,
+					},
+				},
+			};
+
+			const executionData: IExecuteData = {
+				data: { main: [[item]] },
+				source: { main: [{ previousNode: 'Node0', previousNodeOutput: 0, previousNodeRun: 0 }] },
+				node: {
+					id: '123',
+					name: 'CurrentNode',
+					type: 'test',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				},
+				metadata: {
+					preserveSourceOverwrite: false,
+				},
+			};
+
+			const result = resolveSourceOverwrite(item, executionData);
+			expect(result).toBeNull();
+		});
+
+		test('preserveSourceOverwrite is not set', () => {
+			const item: INodeExecutionData = {
+				json: { data: 'test' },
+				pairedItem: {
+					item: 0,
+					sourceOverwrite: {
+						previousNode: 'Node1',
+						previousNodeOutput: 0,
+						previousNodeRun: 0,
+					},
+				},
+			};
+
+			const executionData: IExecuteData = {
+				data: { main: [[item]] },
+				source: { main: [{ previousNode: 'Node0', previousNodeOutput: 0, previousNodeRun: 0 }] },
+				node: {
+					id: '123',
+					name: 'CurrentNode',
+					type: 'test',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				},
+			};
+
+			const result = resolveSourceOverwrite(item, executionData);
+			expect(result).toBeNull();
+		});
+
+		test('metadata is not set', () => {
+			const item: INodeExecutionData = {
+				json: { data: 'test' },
+			};
+
+			const executionData: IExecuteData = {
+				data: { main: [[item]] },
+				source: { main: [{ previousNode: 'Node0', previousNodeOutput: 0, previousNodeRun: 0 }] },
+				node: {
+					id: '123',
+					name: 'CurrentNode',
+					type: 'test',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				},
+			};
+
+			const result = resolveSourceOverwrite(item, executionData);
+			expect(result).toBeNull();
+		});
+
+		test('preserveSourceOverwrite is true but no sourceOverwrite data exists', () => {
+			const item: INodeExecutionData = {
+				json: { data: 'test' },
+				pairedItem: { item: 0 },
+			};
+
+			const executionData: IExecuteData = {
+				data: { main: [[item]] },
+				source: { main: [{ previousNode: 'Node0', previousNodeOutput: 0, previousNodeRun: 0 }] },
+				node: {
+					id: '123',
+					name: 'CurrentNode',
+					type: 'test',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				},
+				metadata: {
+					preserveSourceOverwrite: true,
+				},
+			};
+
+			const result = resolveSourceOverwrite(item, executionData);
+			expect(result).toBeNull();
+		});
+
+		test('pairedItem is not an object', () => {
+			const item: INodeExecutionData = {
+				json: { data: 'test' },
+				pairedItem: 0,
+			};
+
+			const executionData: IExecuteData = {
+				data: { main: [[item]] },
+				source: { main: [{ previousNode: 'Node0', previousNodeOutput: 0, previousNodeRun: 0 }] },
+				node: {
+					id: '123',
+					name: 'CurrentNode',
+					type: 'test',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				},
+				metadata: {
+					preserveSourceOverwrite: true,
+				},
+			};
+
+			const result = resolveSourceOverwrite(item, executionData);
+			expect(result).toBeNull();
+		});
+	});
+
+	describe('should return preservedSourceOverwrite when', () => {
+		test('it is set in metadata', () => {
+			const preservedSourceData: ISourceData = {
+				previousNode: 'PreservedNode',
+				previousNodeOutput: 1,
+				previousNodeRun: 2,
+			};
+
+			const item: INodeExecutionData = {
+				json: { data: 'test' },
+				pairedItem: {
+					item: 0,
+					sourceOverwrite: {
+						previousNode: 'DifferentNode',
+						previousNodeOutput: 0,
+						previousNodeRun: 0,
+					},
+				},
+			};
+
+			const executionData: IExecuteData = {
+				data: { main: [[item]] },
+				source: { main: [{ previousNode: 'Node0', previousNodeOutput: 0, previousNodeRun: 0 }] },
+				node: {
+					id: '123',
+					name: 'CurrentNode',
+					type: 'test',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				},
+				metadata: {
+					preserveSourceOverwrite: true,
+					preservedSourceOverwrite: preservedSourceData,
+				},
+			};
+
+			const result = resolveSourceOverwrite(item, executionData);
+			expect(result).toEqual(preservedSourceData);
+		});
+
+		test('it is set in metadata even without sourceOverwrite in pairedItem', () => {
+			const preservedSourceData: ISourceData = {
+				previousNode: 'PreservedNode',
+				previousNodeOutput: 1,
+				previousNodeRun: 2,
+			};
+
+			const item: INodeExecutionData = {
+				json: { data: 'test' },
+				pairedItem: { item: 0 },
+			};
+
+			const executionData: IExecuteData = {
+				data: { main: [[item]] },
+				source: { main: [{ previousNode: 'Node0', previousNodeOutput: 0, previousNodeRun: 0 }] },
+				node: {
+					id: '123',
+					name: 'CurrentNode',
+					type: 'test',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				},
+				metadata: {
+					preserveSourceOverwrite: true,
+					preservedSourceOverwrite: preservedSourceData,
+				},
+			};
+
+			const result = resolveSourceOverwrite(item, executionData);
+			expect(result).toEqual(preservedSourceData);
+		});
+	});
+
+	describe('should return sourceOverwrite from pairedItem when', () => {
+		test('preserveSourceOverwrite is true and preservedSourceOverwrite is not set', () => {
+			const sourceOverwriteData: ISourceData = {
+				previousNode: 'SourceNode',
+				previousNodeOutput: 1,
+				previousNodeRun: 1,
+			};
+
+			const item: INodeExecutionData = {
+				json: { data: 'test' },
+				pairedItem: {
+					item: 0,
+					sourceOverwrite: sourceOverwriteData,
+				},
+			};
+
+			const executionData: IExecuteData = {
+				data: { main: [[item]] },
+				source: { main: [{ previousNode: 'Node0', previousNodeOutput: 0, previousNodeRun: 0 }] },
+				node: {
+					id: '123',
+					name: 'CurrentNode',
+					type: 'test',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				},
+				metadata: {
+					preserveSourceOverwrite: true,
+				},
+			};
+
+			const result = resolveSourceOverwrite(item, executionData);
+			expect(result).toEqual(sourceOverwriteData);
+		});
+	});
+
+	describe('should prioritize preservedSourceOverwrite over pairedItem.sourceOverwrite', () => {
+		test('when both are present', () => {
+			const preservedSourceData: ISourceData = {
+				previousNode: 'PreservedNode',
+				previousNodeOutput: 2,
+				previousNodeRun: 3,
+			};
+
+			const sourceOverwriteData: ISourceData = {
+				previousNode: 'PairedItemNode',
+				previousNodeOutput: 1,
+				previousNodeRun: 1,
+			};
+
+			const item: INodeExecutionData = {
+				json: { data: 'test' },
+				pairedItem: {
+					item: 0,
+					sourceOverwrite: sourceOverwriteData,
+				},
+			};
+
+			const executionData: IExecuteData = {
+				data: { main: [[item]] },
+				source: { main: [{ previousNode: 'Node0', previousNodeOutput: 0, previousNodeRun: 0 }] },
+				node: {
+					id: '123',
+					name: 'CurrentNode',
+					type: 'test',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				},
+				metadata: {
+					preserveSourceOverwrite: true,
+					preservedSourceOverwrite: preservedSourceData,
+				},
+			};
+
+			const result = resolveSourceOverwrite(item, executionData);
+			// Should return preservedSourceOverwrite, not pairedItem.sourceOverwrite
+			expect(result).toEqual(preservedSourceData);
+			expect(result).not.toEqual(sourceOverwriteData);
+		});
+	});
+});

--- a/packages/core/src/execution-engine/node-execution-context/utils/resolve-source-overwrite.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/resolve-source-overwrite.ts
@@ -1,0 +1,19 @@
+import type { IExecuteData, INodeExecutionData } from 'n8n-workflow';
+
+/**
+ * This method checks if preserveSourceOverwrite is enabled and if so, returns the source overwrite data.
+ * If preservedSourceOverwrite is set, it returns that, otherwise looks for sourceOverwrite in the pairedItem.
+ */
+export function resolveSourceOverwrite(item: INodeExecutionData, executionData: IExecuteData) {
+	const isToolExecution = !!executionData.metadata?.preserveSourceOverwrite;
+	if (!isToolExecution) {
+		return null;
+	}
+	if (executionData.metadata?.preservedSourceOverwrite) {
+		return executionData.metadata.preservedSourceOverwrite;
+	}
+	if (typeof item.pairedItem === 'object' && 'sourceOverwrite' in item.pairedItem) {
+		return item.pairedItem.sourceOverwrite;
+	}
+	return null;
+}

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -66,7 +66,7 @@ import { isJsonCompatible } from '@/utils/is-json-compatible';
 
 import { establishExecutionContext } from './execution-context';
 import type { ExecutionLifecycleHooks } from './execution-lifecycle-hooks';
-import { ExecuteContext, PollContext } from './node-execution-context';
+import { ExecuteContext, PollContext, resolveSourceOverwrite } from './node-execution-context';
 import {
 	DirectedGraph,
 	findStartNodes,
@@ -1527,18 +1527,14 @@ export class WorkflowExecute {
 									// paired items. This is necessary because the workflow data
 									// proxy works on input data which normally scrubs paired
 									// item information before executing the node.
-									const isToolExecution = !!executionData.metadata?.preserveSourceOverwrite;
-									if (
-										isToolExecution &&
-										typeof item.pairedItem === 'object' &&
-										'sourceOverwrite' in item.pairedItem
-									) {
+									const sourceOverwrite = resolveSourceOverwrite(item, executionData);
+									if (sourceOverwrite) {
 										return {
 											...item,
 											pairedItem: {
 												item: itemIndex,
 												input: inputIndex || undefined,
-												sourceOverwrite: item.pairedItem.sourceOverwrite,
+												sourceOverwrite,
 											},
 										};
 									}

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2529,6 +2529,7 @@ export interface ITaskMetadata {
 	 * tools to access data from nodes earlier in the workflow chain via $() expressions.
 	 */
 	preserveSourceOverwrite?: boolean;
+	preservedSourceOverwrite?: ISourceData;
 	/**
 	 * Indicates that this node execution is resuming from a previous pause (e.g., AI agent
 	 * resuming after tool execution). When true, the nodeExecuteBefore hook is skipped to


### PR DESCRIPTION
## Summary

This PR adds a new field `preservedSourceOverwrite` to execution metadata. 
This fixes a bug that occurs when there's a chain of tools like Agent -> Agent Tool -> HTTP request tool. 
Previously, Agent tool would reference a node that was before Agent as it's source, and HTTP request tool would reference Agent as it's source. 
After that change, both Agent Tool and HTTP request tool will reference the node before Agent as source.


https://github.com/user-attachments/assets/b7b7507e-6b11-4c2b-ae18-170dd743c076



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4203/dollarnode-name-throws-error-when-used-in-tool-behind-agent-tool


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
