### PR TITLE
feat: Allow skipping migration checks for imports

### DIFF
--- a/packages/cli/src/commands/import/__tests__/entities.test.ts
+++ b/packages/cli/src/commands/import/__tests__/entities.test.ts
@@ -31,7 +31,12 @@ describe('ImportEntitiesCommand', () => {
 			await command.run();
 
 			// Verify service call with transaction-based approach
-			expect(mockImportService.importEntities).toHaveBeenCalledWith('./outputs', false, undefined);
+			expect(mockImportService.importEntities).toHaveBeenCalledWith(
+				'./outputs',
+				false,
+				undefined,
+				false,
+			);
 		});
 
 		it('should import entities with custom input directory', async () => {
@@ -55,6 +60,7 @@ describe('ImportEntitiesCommand', () => {
 				'/custom/path',
 				false,
 				undefined,
+				false,
 			);
 		});
 
@@ -76,7 +82,12 @@ describe('ImportEntitiesCommand', () => {
 			await command.run();
 
 			// Verify service call with truncation enabled
-			expect(mockImportService.importEntities).toHaveBeenCalledWith('./outputs', true, undefined);
+			expect(mockImportService.importEntities).toHaveBeenCalledWith(
+				'./outputs',
+				true,
+				undefined,
+				false,
+			);
 		});
 
 		it('should import entities with a custom encryption key', async () => {
@@ -96,7 +107,38 @@ describe('ImportEntitiesCommand', () => {
 
 			await command.run();
 
-			expect(mockImportService.importEntities).toHaveBeenCalledWith('./outputs', false, 'key.txt');
+			expect(mockImportService.importEntities).toHaveBeenCalledWith(
+				'./outputs',
+				false,
+				'key.txt',
+				false,
+			);
+		});
+
+		it('should skip migration checks when skipMigrationChecks flag is true', async () => {
+			const command = new ImportEntitiesCommand();
+			// @ts-expect-error Protected property
+			command.flags = {
+				inputDir: './outputs',
+				truncateTables: false,
+				skipMigrationChecks: true,
+			};
+			// @ts-expect-error Protected property
+			command.logger = {
+				info: jest.fn(),
+				error: jest.fn(),
+			};
+
+			mockImportService.importEntities.mockResolvedValue(undefined);
+
+			await command.run();
+
+			expect(mockImportService.importEntities).toHaveBeenCalledWith(
+				'./outputs',
+				false,
+				undefined,
+				true,
+			);
 		});
 
 		it('should handle service errors gracefully', async () => {
@@ -117,7 +159,12 @@ describe('ImportEntitiesCommand', () => {
 			await expect(command.run()).rejects.toThrow('Database connection failed');
 
 			// Verify service was called
-			expect(mockImportService.importEntities).toHaveBeenCalledWith('./outputs', false, undefined);
+			expect(mockImportService.importEntities).toHaveBeenCalledWith(
+				'./outputs',
+				false,
+				undefined,
+				false,
+			);
 		});
 
 		it('should handle import errors with transactions', async () => {
@@ -138,7 +185,12 @@ describe('ImportEntitiesCommand', () => {
 			await expect(command.run()).rejects.toThrow('Transaction failed');
 
 			// Verify service was called with truncation enabled
-			expect(mockImportService.importEntities).toHaveBeenCalledWith('./outputs', true, undefined);
+			expect(mockImportService.importEntities).toHaveBeenCalledWith(
+				'./outputs',
+				true,
+				undefined,
+				false,
+			);
 		});
 	});
 

--- a/packages/cli/src/commands/import/entities.ts
+++ b/packages/cli/src/commands/import/entities.ts
@@ -16,6 +16,10 @@ const flagsSchema = z.object({
 		.string()
 		.describe('Optional path to a file containing a custom encryption key')
 		.optional(),
+	skipMigrationChecks: z.coerce
+		.boolean()
+		.describe('Skip migration validation checks')
+		.default(false),
 });
 
 @Command({
@@ -29,6 +33,8 @@ const flagsSchema = z.object({
 		'--inputDir=./exports --truncateTables',
 		'--keyFile=/path/to/key.txt',
 		'--inputDir=./exports --keyFile=/path/to/key.txt',
+		'--skipMigrationChecks',
+		'--inputDir=./exports --skipMigrationChecks',
 	],
 	flagsSchema,
 })
@@ -37,13 +43,22 @@ export class ImportEntitiesCommand extends BaseCommand<z.infer<typeof flagsSchem
 		const inputDir = this.flags.inputDir;
 		const truncateTables = this.flags.truncateTables;
 		const keyFilePath = this.flags.keyFile ? safeJoinPath(this.flags.keyFile) : undefined;
+		const skipMigrationChecks = this.flags.skipMigrationChecks ?? false;
 
 		this.logger.info('\n⚠️⚠️ This feature is currently under development. ⚠️⚠️');
 		this.logger.info('\n🚀 Starting entity import...');
 		this.logger.info(`📁 Input directory: ${inputDir}`);
 		this.logger.info(`🗑️  Truncate tables: ${truncateTables}`);
+		if (skipMigrationChecks) {
+			this.logger.info(`⏭️  Skipping migration checks`);
+		}
 
-		await Container.get(ImportService).importEntities(inputDir, truncateTables, keyFilePath);
+		await Container.get(ImportService).importEntities(
+			inputDir,
+			truncateTables,
+			keyFilePath,
+			skipMigrationChecks,
+		);
 	}
 
 	catch(error: Error) {

--- a/packages/cli/src/commands/import/entities.ts
+++ b/packages/cli/src/commands/import/entities.ts
@@ -50,7 +50,7 @@ export class ImportEntitiesCommand extends BaseCommand<z.infer<typeof flagsSchem
 		this.logger.info(`📁 Input directory: ${inputDir}`);
 		this.logger.info(`🗑️  Truncate tables: ${truncateTables}`);
 		if (skipMigrationChecks) {
-			this.logger.info(`⏭️  Skipping migration checks`);
+			this.logger.info('⏭️  Skipping migration checks');
 		}
 
 		await Container.get(ImportService).importEntities(

--- a/packages/cli/src/services/import.service.ts
+++ b/packages/cli/src/services/import.service.ts
@@ -321,7 +321,12 @@ export class ImportService {
 		this.logger.info('✅ Successfully decompressed entities.zip');
 	}
 
-	async importEntities(inputDir: string, truncateTables: boolean, keyFilePath?: string) {
+	async importEntities(
+		inputDir: string,
+		truncateTables: boolean,
+		keyFilePath?: string,
+		skipMigrationChecks = false,
+	) {
 		validateDbTypeForImportEntities(this.dataSource.options.type);
 
 		// Read custom encryption key from file if provided
@@ -339,7 +344,11 @@ export class ImportService {
 		}
 
 		await this.decompressEntitiesZip(inputDir);
-		await this.validateMigrations(inputDir, customEncryptionKey);
+		if (!skipMigrationChecks) {
+			await this.validateMigrations(inputDir, customEncryptionKey);
+		} else {
+			this.logger.info('⏭️  Skipping migration validation checks');
+		}
 
 		await this.dataSource.transaction(async (transactionManager: EntityManager) => {
 			await this.disableForeignKeyConstraints(transactionManager);


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This feature adds a new flag to allow skipping migration validation on database imports, for the cases where the final database migration doesn't match due to differing DB types.

## Related Linear tickets, Github issues, and Community forum posts

IAM-33

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
