### PR TITLE
fix(openapi): update execution.workflowId type to string

### DIFF
--- a/packages/cli/src/public-api/v1/handlers/executions/spec/schemas/execution.yml
+++ b/packages/cli/src/public-api/v1/handlers/executions/spec/schemas/execution.yml
@@ -39,8 +39,8 @@ properties:
     nullable: true
     description: The time at which the execution stopped. Will only be null for executions that still have the status 'running'.
   workflowId:
-    type: number
-    example: '1000'
+    type: string
+    example: '2tUt1wbLX592XDdX'
   waitTill:
     type: string
     nullable: true


### PR DESCRIPTION
## Summary

Fixed a bug in the OpenAPI schema where `execution.workflowId` was incorrectly typed as a `number`. The n8n API returns workflow IDs as alphanumeric strings (e.g., `"2tUt1wbLX592XDdX"`), causing issues for API clients trying to parse the response.

**Changes:**
* Updated `packages/cli/src/public-api/v1/handlers/executions/spec/schemas/execution.yml`: Changed `workflowId` type from `number` to `string` and updated the example.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #24122

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport`