### PR TITLE
feat(nodes-langchain): add vectorName parameter to Qdrant node

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreQdrant/VectorStoreQdrant.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreQdrant/VectorStoreQdrant.node.ts
@@ -45,6 +45,14 @@ const sharedOptions: INodeProperties[] = [
 		default: 'metadata',
 		description: 'The key to use for the metadata payload in Qdrant. Default is "metadata".',
 	},
+	{
+		displayName: 'Vector Name',
+		name: 'vectorName',
+		type: 'string',
+		default: '',
+		description:
+			'The name of the vector to use for the query. Required if the collection uses named vectors.',
+	},
 ];
 
 const insertFields: INodeProperties[] = [
@@ -129,6 +137,8 @@ export class VectorStoreQdrant extends createVectorStoreNode<ExtendedQdrantVecto
 		);
 		assertParamIsString('metadataPayloadKey', metadataPayloadKey, context.getNode());
 
+		const vectorName = context.getNodeParameter('options.vectorName', itemIndex, '') as string;
+
 		const credentials = await context.getCredentials('qdrantApi');
 
 		const client = createQdrantClient(credentials as QdrantCredential);
@@ -138,6 +148,7 @@ export class VectorStoreQdrant extends createVectorStoreNode<ExtendedQdrantVecto
 			collectionName: collection,
 			contentPayloadKey: contentPayloadKey !== '' ? contentPayloadKey : undefined,
 			metadataPayloadKey: metadataPayloadKey !== '' ? metadataPayloadKey : undefined,
+			vectorName: vectorName !== '' ? vectorName : undefined,
 		};
 
 		return await ExtendedQdrantVectorStore.fromExistingCollection(embeddings, config, filter);
@@ -157,6 +168,8 @@ export class VectorStoreQdrant extends createVectorStoreNode<ExtendedQdrantVecto
 		);
 		assertParamIsString('metadataPayloadKey', metadataPayloadKey, context.getNode());
 
+		const vectorName = context.getNodeParameter('options.vectorName', itemIndex, '') as string;
+
 		// If collection config is not provided, the collection will be created with default settings
 		// i.e. with the size of the passed embeddings and "Cosine" distance metric
 		const { collectionConfig } = context.getNodeParameter('options', itemIndex, {}) as {
@@ -172,6 +185,7 @@ export class VectorStoreQdrant extends createVectorStoreNode<ExtendedQdrantVecto
 			collectionConfig,
 			contentPayloadKey: contentPayloadKey !== '' ? contentPayloadKey : undefined,
 			metadataPayloadKey: metadataPayloadKey !== '' ? metadataPayloadKey : undefined,
+			vectorName: vectorName !== '' ? vectorName : undefined,
 		};
 
 		await QdrantVectorStore.fromDocuments(documents, embeddings, config);

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreQdrant/VectorStoreQdrant.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreQdrant/VectorStoreQdrant.node.ts
@@ -137,7 +137,8 @@ export class VectorStoreQdrant extends createVectorStoreNode<ExtendedQdrantVecto
 		);
 		assertParamIsString('metadataPayloadKey', metadataPayloadKey, context.getNode());
 
-		const vectorName = context.getNodeParameter('options.vectorName', itemIndex, '') as string;
+		const vectorName = context.getNodeParameter('options.vectorName', itemIndex, '');
+		assertParamIsString('vectorName', vectorName, context.getNode());
 
 		const credentials = await context.getCredentials('qdrantApi');
 
@@ -168,7 +169,8 @@ export class VectorStoreQdrant extends createVectorStoreNode<ExtendedQdrantVecto
 		);
 		assertParamIsString('metadataPayloadKey', metadataPayloadKey, context.getNode());
 
-		const vectorName = context.getNodeParameter('options.vectorName', itemIndex, '') as string;
+		const vectorName = context.getNodeParameter('options.vectorName', itemIndex, '');
+		assertParamIsString('vectorName', vectorName, context.getNode());
 
 		// If collection config is not provided, the collection will be created with default settings
 		// i.e. with the size of the passed embeddings and "Cosine" distance metric


### PR DESCRIPTION
## Summary

Added a `vectorName` parameter to the Qdrant Vector Store node. This allows users to target specific named vectors in a collection (e.g., for multi-model embeddings or FastEmbed), fixing "Bad Request" errors when using such collections.

**Changes:**
* Added `vectorName` string input to `sharedOptions`.
* Passed `vectorName` to the `QdrantLibArgs` config in both `getVectorStoreClient` and `populateVectorStore` methods.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #24131
Checklist:

[x] PR title and summary are descriptive.

[ ] Docs updated or follow-up ticket created.

[ ] Tests included.

[ ] PR Labeled with release/backport