### PR TITLE
chore(core): Exclude storybook package from test commands (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/storybook/turbo.json
+++ b/packages/frontend/@n8n/storybook/turbo.json
@@ -3,6 +3,15 @@
 	"tasks": {
 		"build": {
 			"extends": false
+		},
+		"test": {
+			"extends": false
+		},
+		"test:unit": {
+			"extends": false
+		},
+		"test:integration": {
+			"extends": false
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Ensures that scripts like `pnpm test:ci:frontend` don't end up building `@n8n/storybook` unnecessarily.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-40/fix-broken-build-command-on-latest-master-and-speed-it-up-by-excluding


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
