### PR TITLE
feat: Add revokeUrl to status endpoint

### DIFF
--- a/packages/@n8n/api-types/src/schemas/workflow-execution-status.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/workflow-execution-status.schema.ts
@@ -10,6 +10,7 @@ export const WorkflowExecutionStatusSchema = z.object({
 				credentialType: z.string(),
 				credentialStatus: z.enum(['missing', 'configured']),
 				authorizationUrl: z.string().optional(),
+				revokeUrl: z.string().optional(),
 			}),
 		)
 		.optional(),

--- a/packages/cli/src/modules/dynamic-credentials.ee/__tests__/workflow-status.controller.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/__tests__/workflow-status.controller.test.ts
@@ -186,6 +186,9 @@ describe('WorkflowStatusController', () => {
 			expect(result.credentials?.[0].authorizationUrl).toBe(
 				'https://n8n.example.com/rest/credentials/cred-1/authorize?resolverId=resolver-1',
 			);
+			expect(result.credentials?.[0].revokeUrl).toBe(
+				'https://n8n.example.com/rest/credentials/cred-1/revoke?resolverId=resolver-1',
+			);
 		});
 
 		it('should properly encode special characters in resolverId', async () => {
@@ -209,6 +212,9 @@ describe('WorkflowStatusController', () => {
 
 			expect(result.credentials?.[0].authorizationUrl).toBe(
 				'https://n8n.example.com/rest/credentials/cred-1/authorize?resolverId=resolver%2Fwith%2Fspecial%20chars',
+			);
+			expect(result.credentials?.[0].revokeUrl).toBe(
+				'https://n8n.example.com/rest/credentials/cred-1/revoke?resolverId=resolver%2Fwith%2Fspecial%20chars',
 			);
 		});
 
@@ -234,6 +240,8 @@ describe('WorkflowStatusController', () => {
 			// Verify that the URL is absolute and starts with the base URL
 			expect(result.credentials?.[0].authorizationUrl).toMatch(/^https:\/\//);
 			expect(result.credentials?.[0].authorizationUrl).toContain('https://n8n.example.com');
+			expect(result.credentials?.[0].revokeUrl).toMatch(/^https:\/\//);
+			expect(result.credentials?.[0].revokeUrl).toContain('https://n8n.example.com');
 			expect(mockUrlService.getInstanceBaseUrl).toHaveBeenCalled();
 		});
 
@@ -267,6 +275,8 @@ describe('WorkflowStatusController', () => {
 						credentialType: 'oauth2Api',
 						authorizationUrl:
 							'https://n8n.example.com/rest/credentials/cred-1/authorize?resolverId=resolver-1',
+						revokeUrl:
+							'https://n8n.example.com/rest/credentials/cred-1/revoke?resolverId=resolver-1',
 					},
 				],
 			});

--- a/packages/cli/src/modules/dynamic-credentials.ee/workflow-status.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/workflow-status.controller.ts
@@ -53,6 +53,7 @@ export class WorkflowStatusController {
 				credentialStatus: s.status,
 				credentialType: s.credentialType,
 				authorizationUrl: `${basePath}/${restPath}/credentials/${s.credentialId}/authorize?resolverId=${encodeURIComponent(s.resolverId)}`,
+				revokeUrl: `${basePath}/${restPath}/credentials/${s.credentialId}/revoke?resolverId=${encodeURIComponent(s.resolverId)}`,
 			})),
 		};
 		return executionStatus;


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR provides a revoke url to the workflow status endpoint to allow a user to revoke the credential.

## Related Linear tickets, Github issues, and Community forum posts

IAM-13

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
