### PR TITLE
chore: Skip notify CI job outside main repo

### DIFF
--- a/.github/workflows/util-notify-pr-status.yml
+++ b/.github/workflows/util-notify-pr-status.yml
@@ -14,9 +14,11 @@ jobs:
       (github.event_name == 'pull_request_review' && github.event.review.state == 'dismissed') ||
       (github.event_name == 'pull_request' && github.event.pull_request.merged == true) ||
       (github.event_name == 'pull_request' && github.event.pull_request.merged == false && github.event.action == 'closed')
+    env:
+      NOTIFY_URL: ${{ secrets.N8N_NOTIFY_PR_STATUS_CHANGED_URL }}
     steps:
       - uses: fjogeleit/http-request-action@bf78da14118941f7e940279dd58f67e863cbeff6 # v1
-        if: ${{!contains(github.event.pull_request.labels.*.name, 'community')}}
+        if: ${{ env.NOTIFY_URL != '' && !contains(github.event.pull_request.labels.*.name, 'community') }}
         name: Notify
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Setting up the private fork, notify job fails outside main repo: https://github.com/n8n-io/n8n-private/actions/runs/20962916727/job/60244900165?pr=1