### PR TITLE
fix(LmChatOpenAi Node): Fix tool calling with responses api against OpenAI-compatible backends

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
@@ -801,6 +801,9 @@ export class LmChatOpenAi implements INodeType {
 			callbacks: [new N8nLlmTracing(this)],
 			modelKwargs,
 			onFailedAttempt: makeN8nLlmFailedAttemptHandler(this, openAiFailedAttemptHandler),
+			// Set to false to ensure compatibility with OpenAI-compatible backends (LM Studio, vLLM, etc.)
+			// that reject strict: null in tool definitions
+			supportsStrictToolCalling: false,
 		};
 
 		// by default ChatOpenAI can switch to responses API automatically, so force it only on 1.3 and above to keep backwards compatibility

--- a/packages/@n8n/nodes-langchain/nodes/llms/test/LmChatOpenAi.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/test/LmChatOpenAi.test.ts
@@ -390,6 +390,24 @@ describe('LmChatOpenAi', () => {
 			);
 		});
 
+		it('should set supportsStrictToolCalling to false for OpenAI-compatible backends', async () => {
+			const mockContext = setupMockContext();
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'gpt-4o-mini';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await lmChatOpenAi.supplyData.call(mockContext, 0);
+
+			expect(MockedChatOpenAI).toHaveBeenCalledWith(
+				expect.objectContaining({
+					supportsStrictToolCalling: false,
+				}),
+			);
+		});
+
 		it('should prioritize options.baseURL over credentials.url', async () => {
 			const optionsBaseURL = 'https://options-api.example.com/v1';
 			const credentialsURL = 'https://credentials-api.example.com/v1';


### PR DESCRIPTION
## Summary
When using the AI Agent node (V3) with LM Studio's OpenAI-compatible API endpoint, requests fail with a 400 error:

```
{
  "error": {
    "message": "Expected boolean, received null",
    "type": "invalid_request_error",
    "param": "tools.0.strict",
    "code": "invalid_type"
  }
}
```

Root Cause
The AI Agent V3 generates a tools array for OpenAI-style tool definitions, but includes "strict": null for each tool. OpenAI-compatible backends expect strict to be a proper boolean (true or false), not null.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://github.com/n8n-io/n8n/issues/23656

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
