### PR TITLE
fix(core): Publish indicator not shown when lacking publish scope (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.test.ts
@@ -141,6 +141,7 @@ describe('WorkflowHeaderDraftPublishActions', () => {
 			const { queryByTestId } = renderComponent();
 
 			expect(queryByTestId('workflow-active-version-info')).not.toBeInTheDocument();
+			expect(queryByTestId('workflow-active-version-indicator')).not.toBeInTheDocument();
 		});
 
 		it('should show active version indicator when there is an active version', () => {
@@ -149,6 +150,7 @@ describe('WorkflowHeaderDraftPublishActions', () => {
 			const { getByTestId } = renderComponent();
 
 			expect(getByTestId('workflow-active-version-info')).toBeInTheDocument();
+			expect(getByTestId('workflow-active-version-indicator')).toBeInTheDocument();
 		});
 
 		it('should use latest activation date from workflowPublishHistory when available', () => {

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.test.ts
@@ -140,7 +140,7 @@ describe('WorkflowHeaderDraftPublishActions', () => {
 
 			const { queryByTestId } = renderComponent();
 
-			expect(queryByTestId('workflow-active-version-indicator')).not.toBeInTheDocument();
+			expect(queryByTestId('workflow-active-version-info')).not.toBeInTheDocument();
 		});
 
 		it('should show active version indicator when there is an active version', () => {
@@ -148,7 +148,7 @@ describe('WorkflowHeaderDraftPublishActions', () => {
 
 			const { getByTestId } = renderComponent();
 
-			expect(getByTestId('workflow-active-version-indicator')).toBeInTheDocument();
+			expect(getByTestId('workflow-active-version-info')).toBeInTheDocument();
 		});
 
 		it('should use latest activation date from workflowPublishHistory when available', () => {
@@ -199,8 +199,26 @@ describe('WorkflowHeaderDraftPublishActions', () => {
 				},
 			});
 
-			expect(getByTestId('workflow-active-version-indicator')).toBeInTheDocument();
+			expect(getByTestId('workflow-active-version-info')).toBeInTheDocument();
 			expect(getByTestId('time-ago-stub')).toHaveTextContent(latestActivationDate);
+		});
+
+		it('should show active version indicator when user does not have workflow:publish permission but workflow is currently published', () => {
+			workflowsStore.workflow.activeVersion = createMockActiveVersion('active-version-1');
+			const { getByTestId } = renderComponent({
+				props: {
+					...defaultWorkflowProps,
+					readOnly: false,
+					workflowPermissions: {
+						...defaultWorkflowProps.workflowPermissions,
+						update: true,
+						publish: false,
+					},
+				},
+			});
+
+			expect(getByTestId('workflow-active-version-indicator')).toBeInTheDocument();
+			expect(getByTestId('workflow-active-version-info')).toBeInTheDocument();
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
@@ -158,10 +158,8 @@ const publishButtonConfig = computed(() => {
 			tooltip: i18n.baseText('workflows.publish.permissionDenied'),
 			showVersionInfo: false,
 		};
-		const isWorkflowPublished = workflowsStore.workflow.activeVersion;
+		const isWorkflowPublished = !!workflowsStore.workflow.activeVersion;
 		if (isWorkflowPublished) {
-			defaultConfigForNoPermission.showIndicator = true;
-			defaultConfigForNoPermission.indicatorClass = 'published';
 			return {
 				...defaultConfigForNoPermission,
 				showIndicator: true,

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
@@ -150,7 +150,7 @@ const onPublishButtonClick = async () => {
 const publishButtonConfig = computed(() => {
 	// Handle permission-denied state first
 	if (!props.workflowPermissions.publish) {
-		return {
+		const defaultConfigForNoPermission = {
 			text: i18n.baseText('workflows.publish'),
 			enabled: false,
 			showIndicator: false,
@@ -158,6 +158,19 @@ const publishButtonConfig = computed(() => {
 			tooltip: i18n.baseText('workflows.publish.permissionDenied'),
 			showVersionInfo: false,
 		};
+		const isWorkflowPublished = workflowsStore.workflow.activeVersion;
+		if (isWorkflowPublished) {
+			defaultConfigForNoPermission.showIndicator = true;
+			defaultConfigForNoPermission.indicatorClass = 'published';
+			return {
+				...defaultConfigForNoPermission,
+				showIndicator: true,
+				showVersionInfo: true,
+				indicatorClass: 'published',
+			};
+		} else {
+			return defaultConfigForNoPermission;
+		}
 	}
 
 	// Handle new workflow state
@@ -288,7 +301,7 @@ defineExpose({
 							{{ publishButtonConfig.tooltip }} <br />
 						</template>
 						<template v-if="activeVersion && publishButtonConfig.showVersionInfo">
-							<span data-test-id="workflow-active-version-indicator">{{ activeVersionName }}</span
+							<span data-test-id="workflow-active-version-info">{{ activeVersionName }}</span
 							><br />{{ i18n.baseText('workflowHistory.item.active') }}
 							<TimeAgo v-if="latestPublishDate" :date="latestPublishDate" />
 						</template>
@@ -304,6 +317,7 @@ defineExpose({
 					<div :class="[$style.flex]">
 						<span
 							v-if="publishButtonConfig.showIndicator"
+							data-test-id="workflow-active-version-indicator"
 							:class="{
 								[$style.indicatorDot]: true,
 								[$style.indicatorPublished]: publishButtonConfig.indicatorClass === 'published',


### PR DESCRIPTION
## Summary

This was discovered while working on https://github.com/n8n-io/n8n/pull/24111

With the most recent changes for shipping auto-save, the published indicator is not longer visible on published workflows when the active user does not have the workflow:publish permission.
This is not consistent, because in the workflow history and workflow list view, these users can see the published indicator.
And they should be able to see it to get the right picture anyway.

### Before

Indicator is visible on version history, but not on disabled publish button.

<img width="460" height="416" alt="image" src="https://github.com/user-attachments/assets/4821a029-b8f5-44c7-9377-82839c1f825a" />


### After

Indicator is visible on disabled publish button too.

<img width="250" height="146" alt="image" src="https://github.com/user-attachments/assets/49ae7fd9-a358-44c0-9ee1-0537b5d2f078" />


## Related Linear tickets, Github issues, and Community forum posts

Closes https://linear.app/n8n/issue/LIGO-88/fe-fix-publish-button-doesnt-show-published-indicator-when-user-has-no


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
