### PR TITLE
feat(editor): Add user_message_id to AI assistant feedback telemetry

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
@@ -948,6 +948,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 		hasNoCreditsRemaining,
 		hasMessages: computed(() => hasMessages.value),
 		workflowTodos,
+		lastUserMessageId,
 
 		// Methods
 		abortStreaming,

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/AskAssistantBuild.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/AskAssistantBuild.test.ts
@@ -450,9 +450,12 @@ describe('AskAssistantBuild', () => {
 		const workflowJson = '{"nodes": [], "connections": {}}';
 
 		describe('when workflow-updated message exists', () => {
+			const testUserMessageId = 'test-user-message-id';
+
 			beforeEach(() => {
 				// Use $patch to ensure reactivity
 				builderStore.$patch({
+					lastUserMessageId: testUserMessageId,
 					chatMessages: [
 						{
 							id: faker.string.uuid(),
@@ -536,6 +539,7 @@ describe('AskAssistantBuild', () => {
 					expect.objectContaining({
 						feedback: feedbackText,
 						workflow_id: 'abc123',
+						user_message_id: testUserMessageId,
 					}),
 				);
 			});

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/AskAssistantBuild.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/AskAssistantBuild.vue
@@ -157,6 +157,7 @@ function onFeedback(feedback: RatingFeedback) {
 			feedback: feedback.feedback,
 			workflow_id: workflowsStore.workflowId,
 			session_id: builderStore.trackingSessionId,
+			user_message_id: builderStore.lastUserMessageId,
 		});
 	}
 }


### PR DESCRIPTION
## Summary                                                                
  - Exposes `lastUserMessageId` from the builder store                      
  - Includes `user_message_id` in the feedback telemetry event to track which user message the feedback is associated with
  ---
  Related ticket: https://linear.app/n8n/issue/AI-1897/telemetry-add-user-message-id-to-feedback-table