### PR TITLE
fix(editor): Tweak publish tooltips for migrated workflows (no-changes)

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
@@ -251,7 +251,7 @@ const activeVersionName = computed(() => {
 	if (!activeVersion.value) {
 		return '';
 	}
-	return activeVersion.value.name ?? generateVersionName(activeVersion.value.versionId);
+	return activeVersion.value.name || generateVersionName(activeVersion.value.versionId);
 });
 
 const latestPublishDate = computed(() => {

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
@@ -251,7 +251,7 @@ const activeVersionName = computed(() => {
 	if (!activeVersion.value) {
 		return '';
 	}
-	return activeVersion.value.name || generateVersionName(activeVersion.value.versionId);
+	return activeVersion.value.name ?? generateVersionName(activeVersion.value.versionId);
 });
 
 const latestPublishDate = computed(() => {

--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryListItem.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryListItem.vue
@@ -111,7 +111,10 @@ const mainTooltipContent = computed(() => {
 	}
 
 	if (props.isVersionActive) {
-		return i18n.baseText('workflowHistory.item.publishedBy');
+		const hasUser = !!getPublishedUserName(lastPublishInfo.value?.userId);
+		return hasUser
+			? i18n.baseText('workflowHistory.item.publishedBy')
+			: i18n.baseText('workflowHistory.item.active');
 	}
 
 	if (props.index === 0 && !props.isVersionActive) {
@@ -119,7 +122,10 @@ const mainTooltipContent = computed(() => {
 	}
 
 	if (versionPublishInfo.value) {
-		return `${i18n.baseText('workflowHistory.item.publishedBy')}`;
+		const hasUser = !!getPublishedUserName(versionPublishInfo.value?.userId);
+		return hasUser
+			? i18n.baseText('workflowHistory.item.publishedBy')
+			: i18n.baseText('workflowHistory.item.active');
 	}
 
 	return formattedCreatedAt.value;
@@ -206,7 +212,10 @@ onMounted(() => {
 				<template v-if="mainTooltipUser">
 					{{ mainTooltipUser }}
 				</template>
-				<span v-if="mainTooltipFormattedDate">{{ ', ' + mainTooltipFormattedDate }}</span>
+				<template v-if="mainTooltipFormattedDate">
+					<template v-if="mainTooltipUser">, </template>
+					{{ mainTooltipFormattedDate }}
+				</template>
 			</div>
 		</template>
 		<li


### PR DESCRIPTION
## Summary

Workflows that have been active in v1 are migrated to v2 without version names and publisher user. The tooltips were not looking very good in those cases.
before:
<img width="566" height="122" alt="image" src="https://github.com/user-attachments/assets/b297fc44-23f3-4def-9dae-6ae3b8a82236" />
after:
<img width="586" height="151" alt="image" src="https://github.com/user-attachments/assets/b2d5b0fb-9d12-4d3d-b19a-bbfae27ba979" />



## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
