### PR TITLE
fix(core): Allow resetting Error Workflow settings to default

### DIFF
--- a/packages/cli/src/__tests__/workflow-helpers.test.ts
+++ b/packages/cli/src/__tests__/workflow-helpers.test.ts
@@ -1,5 +1,6 @@
 import { mockInstance } from '@n8n/backend-test-utils';
 import type { Project, Variables } from '@n8n/db';
+import type { IWorkflowSettings } from 'n8n-workflow';
 
 import { VariablesService } from '@/environments.ee/variables/variables.service.ee';
 import { OwnershipService } from '@/services/ownership.service';
@@ -103,10 +104,11 @@ describe('shouldRestartParentExecution', () => {
 
 describe('removeDefaultValues', () => {
 	const DEFAULT_EXECUTION_TIMEOUT = 3600;
+	const DEFAULT = 'DEFAULT';
 
 	it('should remove errorWorkflow when set to DEFAULT', () => {
-		const settings = {
-			errorWorkflow: 'DEFAULT' as const,
+		const settings: IWorkflowSettings = {
+			errorWorkflow: DEFAULT,
 			timezone: 'America/New_York',
 		};
 		const result = removeDefaultValues(settings, DEFAULT_EXECUTION_TIMEOUT);
@@ -116,14 +118,14 @@ describe('removeDefaultValues', () => {
 	});
 
 	it('should remove all keys set to DEFAULT', () => {
-		const settings = {
-			errorWorkflow: 'DEFAULT' as const,
-			timezone: 'DEFAULT' as const,
-			saveDataErrorExecution: 'DEFAULT' as const,
-			saveDataSuccessExecution: 'DEFAULT' as const,
-			saveManualExecutions: 'DEFAULT' as const,
-			saveExecutionProgress: 'DEFAULT' as const,
-			callerPolicy: 'workflowsFromSameOwner' as const,
+		const settings: IWorkflowSettings = {
+			errorWorkflow: DEFAULT,
+			timezone: DEFAULT,
+			saveDataErrorExecution: DEFAULT,
+			saveDataSuccessExecution: DEFAULT,
+			saveManualExecutions: DEFAULT,
+			saveExecutionProgress: DEFAULT,
+			callerPolicy: 'workflowsFromSameOwner',
 		};
 		const result = removeDefaultValues(settings, DEFAULT_EXECUTION_TIMEOUT);
 		expect(result).toEqual({
@@ -132,7 +134,7 @@ describe('removeDefaultValues', () => {
 	});
 
 	it('should remove executionTimeout when it matches default', () => {
-		const settings = {
+		const settings: IWorkflowSettings = {
 			executionTimeout: 3600,
 			timezone: 'America/New_York',
 		};
@@ -143,7 +145,7 @@ describe('removeDefaultValues', () => {
 	});
 
 	it('should keep executionTimeout when it differs from default', () => {
-		const settings = {
+		const settings: IWorkflowSettings = {
 			executionTimeout: 7200,
 			timezone: 'America/New_York',
 		};
@@ -155,10 +157,10 @@ describe('removeDefaultValues', () => {
 	});
 
 	it('should keep non-DEFAULT values', () => {
-		const settings = {
+		const settings: IWorkflowSettings = {
 			errorWorkflow: 'some-workflow-id',
 			timezone: 'America/New_York',
-			saveDataErrorExecution: 'all' as const,
+			saveDataErrorExecution: 'all',
 		};
 		const result = removeDefaultValues(settings, DEFAULT_EXECUTION_TIMEOUT);
 		expect(result).toEqual({
@@ -170,7 +172,7 @@ describe('removeDefaultValues', () => {
 
 	it('should not mutate the original settings object', () => {
 		const settings = {
-			errorWorkflow: 'DEFAULT' as const,
+			errorWorkflow: DEFAULT,
 			timezone: 'America/New_York',
 			executionTimeout: 3600,
 		};

--- a/packages/cli/src/workflow-helpers.ts
+++ b/packages/cli/src/workflow-helpers.ts
@@ -7,6 +7,7 @@ import type {
 	IRun,
 	ITaskData,
 	IWorkflowBase,
+	IWorkflowSettings,
 	RelatedExecution,
 } from 'n8n-workflow';
 import { v4 as uuid } from 'uuid';
@@ -65,6 +66,44 @@ export function addNodeIds(workflow: IWorkflowBase) {
 			node.id = uuid();
 		}
 	});
+}
+
+/**
+ * Removes default values from workflow settings to avoid storing them in the database.
+ * Returns a new settings object without mutating the original.
+ *
+ * @param settings - The workflow settings to clean
+ * @param defaultExecutionTimeout - The default execution timeout from global config
+ * @returns A new settings object with default values removed
+ */
+export function removeDefaultValues(
+	settings: IWorkflowSettings,
+	defaultExecutionTimeout: number,
+): IWorkflowSettings {
+	const cleanedSettings = { ...settings };
+
+	// Remove settings that are set to 'DEFAULT'
+	const keysAllowingDefault = [
+		'errorWorkflow',
+		'timezone',
+		'saveDataErrorExecution',
+		'saveDataSuccessExecution',
+		'saveManualExecutions',
+		'saveExecutionProgress',
+	] as const;
+
+	for (const key of keysAllowingDefault) {
+		if (cleanedSettings[key] === 'DEFAULT') {
+			delete cleanedSettings[key];
+		}
+	}
+
+	// Remove executionTimeout if it matches the default
+	if (cleanedSettings.executionTimeout === defaultExecutionTimeout) {
+		delete cleanedSettings.executionTimeout;
+	}
+
+	return cleanedSettings;
 }
 
 // Checking if credentials of old format are in use and run a DB check if they might exist uniquely

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -308,10 +308,12 @@ export class WorkflowService {
 
 		await this.externalHooks.run('workflow.update', [workflowUpdateData]);
 
-		workflowUpdateData.settings = WorkflowHelpers.removeDefaultValues(
-			workflowUpdateData.settings ?? {},
-			this.globalConfig.executions.timeout,
-		);
+		if (workflowUpdateData.settings) {
+			workflowUpdateData.settings = WorkflowHelpers.removeDefaultValues(
+				workflowUpdateData.settings,
+				this.globalConfig.executions.timeout,
+			);
+		}
 
 		// Check if settings actually changed
 		const settingsChanged =

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -308,28 +308,10 @@ export class WorkflowService {
 
 		await this.externalHooks.run('workflow.update', [workflowUpdateData]);
 
-		// Clean up settings
-		if (workflowUpdateData.settings) {
-			const keysAllowingDefault = [
-				'errorWorkflow',
-				'timezone',
-				'saveDataErrorExecution',
-				'saveDataSuccessExecution',
-				'saveManualExecutions',
-				'saveExecutionProgress',
-			] as const;
-			for (const key of keysAllowingDefault) {
-				// Do not save the default value
-				if (workflowUpdateData.settings[key] === 'DEFAULT') {
-					delete workflowUpdateData.settings[key];
-				}
-			}
-
-			if (workflowUpdateData.settings.executionTimeout === this.globalConfig.executions.timeout) {
-				// Do not save when default got set
-				delete workflowUpdateData.settings.executionTimeout;
-			}
-		}
+		workflowUpdateData.settings = WorkflowHelpers.removeDefaultValues(
+			workflowUpdateData.settings ?? {},
+			this.globalConfig.executions.timeout,
+		);
 
 		// Check if settings actually changed
 		const settingsChanged =

--- a/packages/frontend/editor-ui/src/app/components/WorkflowSettings.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowSettings.vue
@@ -409,7 +409,7 @@ const loadWorkflows = async (searchTerm?: string) => {
 	});
 
 	workflowsData.unshift({
-		id: undefined as unknown as string,
+		id: 'DEFAULT',
 		name: i18n.baseText('workflowSettings.noWorkflow'),
 	} as IWorkflowShortResponse);
 
@@ -644,6 +644,9 @@ onMounted(async () => {
 
 	if (workflowSettingsData.timeSavedMode === undefined) {
 		workflowSettingsData.timeSavedMode = 'fixed';
+	}
+	if (workflowSettingsData.errorWorkflow === undefined) {
+		workflowSettingsData.errorWorkflow = 'DEFAULT';
 	}
 	if (workflowSettingsData.timezone === undefined) {
 		workflowSettingsData.timezone = 'DEFAULT';

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2803,7 +2803,7 @@ export type WorkflowSettingsBinaryMode = typeof BINARY_MODE_SEPARATE | typeof BI
 
 export interface IWorkflowSettings {
 	timezone?: 'DEFAULT' | string;
-	errorWorkflow?: string;
+	errorWorkflow?: 'DEFAULT' | string;
 	callerIds?: string;
 	callerPolicy?: WorkflowSettings.CallerPolicy;
 	saveDataErrorExecution?: WorkflowSettings.SaveDataExecution;


### PR DESCRIPTION
## Summary

There was a bug happening when trying to reset error workflow settings back to the default value - the UI showed that the request was successful, but after page reload you could see that the error workflow settings was kept intact.

- The main change is in `WorkflowSettings.vue`. 
- I also moved cleaning up settings to a util and removed object mutation. 
- Moved `settingsChanged` assignment to a better place, after the clean-up (it didn't change the behavior for now, but could have caused issues in the future).
- Added tests.

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-4640](https://linear.app/n8n/issue/ADO-4640/workflow-publish-option-isnt-being-triggered-for-workflow-settings)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
