### PR TITLE
fix(ai-builder): Use LangSmith SDK defaults for batch settings (no-changelog)

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/support/environment.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/support/environment.ts
@@ -15,11 +15,8 @@ import {
 	type TraceFilters,
 } from '../langsmith/trace-filters.js';
 
-/** Maximum batch size in bytes for trace uploads (2MB - reduced to avoid 403 errors) */
-const TRACE_BATCH_SIZE_LIMIT = 2_000_000;
-
-/** Number of concurrent trace batch uploads */
-const TRACE_BATCH_CONCURRENCY = 1;
+/** Maximum memory for trace queue (3GB) */
+const MAX_INGEST_MEMORY_BYTES = 3 * 1024 * 1024 * 1024;
 
 export interface TestEnvironment {
 	parsedNodeTypes: INodeTypeDescription[];
@@ -91,10 +88,8 @@ export function createLangsmithClient(logger?: EvalLogger): LangsmithClientResul
 		// Filter large fields from traces to avoid 403 payload errors
 		hideInputs: traceFilters.filterInputs,
 		hideOutputs: traceFilters.filterOutputs,
-		// Reduce batch size and concurrency for high-volume scenarios
-		batchSizeBytesLimit: TRACE_BATCH_SIZE_LIMIT,
-		batchSizeLimit: 10, // Limit runs per batch (default 100) to avoid 403 multipart errors
-		traceBatchConcurrency: TRACE_BATCH_CONCURRENCY,
+		// Increase queue memory limit for high-concurrency evals
+		maxIngestMemoryBytes: MAX_INGEST_MEMORY_BYTES,
 	});
 
 	return { client, traceFilters };


### PR DESCRIPTION
## Summary

- Remove custom batch size and concurrency limits that were causing queue buildup warnings at high eval concurrency. 
- Increase maxIngestMemoryBytes to 3GB to handle burst trace uploads during parallel evaluations.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
