### PR TITLE
refactor(core): Normalize exception attribute access in Python task runner

### DIFF
--- a/packages/@n8n/task-runner-python/src/constants.py
+++ b/packages/@n8n/task-runner-python/src/constants.py
@@ -153,6 +153,7 @@ BLOCKED_ATTRIBUTES = {
     "cr_code",
     "ag_frame",
     "ag_code",
+    "obj",
     "__thisclass__",
     "__self_class__",
     # introspection attributes

--- a/packages/@n8n/task-runner-python/tests/unit/test_task_analyzer.py
+++ b/packages/@n8n/task-runner-python/tests/unit/test_task_analyzer.py
@@ -150,6 +150,18 @@ class TestAttributeAccessValidation(TestTaskAnalyzer):
                 analyzer.validate(code)
             assert "name-mangled" in exc_info.value.description.lower()
 
+    def test_attribute_error_obj_blocked(self, analyzer: TaskAnalyzer) -> None:
+        exploit_attempts = [
+            "e.obj",
+            "exception.obj",
+            "error.obj",
+        ]
+
+        for code in exploit_attempts:
+            with pytest.raises(SecurityViolationError) as exc_info:
+                analyzer.validate(code)
+            assert "obj" in exc_info.value.description
+
 
 class TestDynamicImportDetection(TestTaskAnalyzer):
     def test_various_dynamic_import_patterns(self, analyzer: TaskAnalyzer) -> None:


### PR DESCRIPTION
Replay of #24216 onto `1.x`