### PR TITLE
feat(editor): Show tooltips for canvas edge buttons

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasEdge.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasEdge.vue
@@ -179,8 +179,13 @@ function onEdgeLabelMouseLeave() {
 			@mouseenter="onEdgeLabelMouseEnter"
 			@mouseleave="onEdgeLabelMouseLeave"
 		>
-			<CanvasEdgeToolbar :type="connectionType" @add="onAdd" @delete="onDelete" />
-			<!-- <div v-else :class="$style.edgeLabel">{{ label }}</div> -->
+			<CanvasEdgeToolbar
+				v-if="renderToolbar"
+				:type="connectionType"
+				@add="onAdd"
+				@delete="onDelete"
+			/>
+			<div v-else :class="$style.edgeLabel">{{ label }}</div>
 		</div>
 	</EdgeLabelRenderer>
 </template>

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasEdge.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasEdge.vue
@@ -179,13 +179,8 @@ function onEdgeLabelMouseLeave() {
 			@mouseenter="onEdgeLabelMouseEnter"
 			@mouseleave="onEdgeLabelMouseLeave"
 		>
-			<CanvasEdgeToolbar
-				v-if="renderToolbar"
-				:type="connectionType"
-				@add="onAdd"
-				@delete="onDelete"
-			/>
-			<div v-else :class="$style.edgeLabel">{{ label }}</div>
+			<CanvasEdgeToolbar :type="connectionType" @add="onAdd" @delete="onDelete" />
+			<!-- <div v-else :class="$style.edgeLabel">{{ label }}</div> -->
 		</div>
 	</EdgeLabelRenderer>
 </template>

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasEdgeToolbar.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasEdgeToolbar.vue
@@ -5,6 +5,8 @@ import type { NodeConnectionType } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
 
 import { N8nIconButton } from '@n8n/design-system';
+import CanvasEdgeTooltip from './CanvasEdgeTooltip.vue';
+
 const emit = defineEmits<{
 	add: [];
 	delete: [];
@@ -35,27 +37,28 @@ function onDelete() {
 
 <template>
 	<div :class="classes" data-test-id="canvas-edge-toolbar">
-		<N8nIconButton
-			v-if="isAddButtonVisible"
-			class="canvas-edge-toolbar-button"
-			data-test-id="add-connection-button"
-			type="tertiary"
-			size="small"
-			icon-size="medium"
-			icon="plus"
-			:title="i18n.baseText('node.add')"
-			@click="onAdd"
-		/>
-		<N8nIconButton
-			data-test-id="delete-connection-button"
-			class="canvas-edge-toolbar-button"
-			type="tertiary"
-			size="small"
-			icon-size="medium"
-			icon="trash-2"
-			:title="i18n.baseText('node.delete')"
-			@click="onDelete"
-		/>
+		<CanvasEdgeTooltip v-if="isAddButtonVisible" :content="i18n.baseText('node.add')">
+			<N8nIconButton
+				class="canvas-edge-toolbar-button"
+				data-test-id="add-connection-button"
+				type="tertiary"
+				size="small"
+				icon-size="medium"
+				icon="plus"
+				@click="onAdd"
+			/>
+		</CanvasEdgeTooltip>
+		<CanvasEdgeTooltip :content="i18n.baseText('node.delete')">
+			<N8nIconButton
+				data-test-id="delete-connection-button"
+				class="canvas-edge-toolbar-button"
+				type="tertiary"
+				size="small"
+				icon-size="medium"
+				icon="trash-2"
+				@click="onDelete"
+			/>
+		</CanvasEdgeTooltip>
 	</div>
 </template>
 
@@ -70,10 +73,15 @@ function onDelete() {
 	/* stylelint-disable-next-line @n8n/css-var-naming */
 	transform: scale(var(--canvas-zoom-compensation-factor, 1));
 }
+
+.addContainer {
+	position: relative;
+}
 </style>
 
 <style lang="scss">
 .canvas-edge-toolbar-button {
+	position: relative;
 	border-width: 0;
 	--button--color--text: light-dark(var(--color--neutral-700), var(--color--neutral-250));
 	--button--color--text--hover: light-dark(var(--color--neutral-850), var(--color--neutral-150));

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasEdgeToolbar.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasEdgeToolbar.vue
@@ -73,15 +73,10 @@ function onDelete() {
 	/* stylelint-disable-next-line @n8n/css-var-naming */
 	transform: scale(var(--canvas-zoom-compensation-factor, 1));
 }
-
-.addContainer {
-	position: relative;
-}
 </style>
 
 <style lang="scss">
 .canvas-edge-toolbar-button {
-	position: relative;
 	border-width: 0;
 	--button--color--text: light-dark(var(--color--neutral-700), var(--color--neutral-250));
 	--button--color--text--hover: light-dark(var(--color--neutral-850), var(--color--neutral-150));

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasEdgeTooltip.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasEdgeTooltip.vue
@@ -1,0 +1,54 @@
+<script lang="ts" setup>
+import { ref, useCssModule } from 'vue';
+import { N8nTooltip } from '@n8n/design-system';
+
+const props = defineProps<{
+	content: string;
+}>();
+
+const $style = useCssModule();
+
+const visible = ref(false);
+
+function onMouseEnter() {
+	visible.value = true;
+}
+
+function onMouseLeave() {
+	visible.value = false;
+}
+</script>
+
+<template>
+	<div :class="$style.tooltipContainer">
+		<N8nTooltip
+			:visible="visible"
+			:content="content"
+			placement="top"
+			:teleported="false"
+			:offset="8"
+			popper-class="canvas-edge-toolbar-popper"
+		>
+			<div @mouseenter="onMouseEnter" @mouseleave="onMouseLeave">
+				<slot />
+			</div>
+		</N8nTooltip>
+	</div>
+</template>
+
+<style lang="scss" module>
+.tooltipContainer {
+	position: relative;
+}
+</style>
+
+<style lang="scss">
+.canvas-edge-toolbar-popper {
+	white-space: nowrap;
+
+	.el-popper__arrow {
+		// override default margin as it moves the arrow off the center
+		margin: 0 !important;
+	}
+}
+</style>

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasEdgeTooltip.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasEdgeTooltip.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ref, useCssModule } from 'vue';
+import { useCssModule } from 'vue';
 import { N8nTooltip } from '@n8n/design-system';
 
 const props = defineProps<{
@@ -7,31 +7,18 @@ const props = defineProps<{
 }>();
 
 const $style = useCssModule();
-
-const visible = ref(false);
-
-function onMouseEnter() {
-	visible.value = true;
-}
-
-function onMouseLeave() {
-	visible.value = false;
-}
 </script>
 
 <template>
 	<div :class="$style.tooltipContainer">
 		<N8nTooltip
-			:visible="visible"
 			:content="content"
 			placement="top"
 			:teleported="false"
 			:offset="8"
 			popper-class="canvas-edge-toolbar-popper"
 		>
-			<div @mouseenter="onMouseEnter" @mouseleave="onMouseLeave">
-				<slot />
-			</div>
+			<slot />
 		</N8nTooltip>
 	</div>
 </template>

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasEdgeTooltip.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasEdgeTooltip.vue
@@ -2,7 +2,7 @@
 import { useCssModule } from 'vue';
 import { N8nTooltip } from '@n8n/design-system';
 
-const props = defineProps<{
+defineProps<{
 	content: string;
 }>();
 

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/render-types/CanvasHandleNonMainInput.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/render-types/CanvasHandleNonMainInput.vue
@@ -82,7 +82,7 @@ function onClickAdd() {
 
 .label {
 	position: absolute;
-	top: 20px;
+	top: var(--spacing--lg);
 	left: 50%;
 	/* stylelint-disable-next-line @n8n/css-var-naming */
 	transform: translate(-50%, 0) scale(var(--canvas-zoom-compensation-factor, 1));

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/render-types/CanvasHandleNonMainOutput.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/render-types/CanvasHandleNonMainOutput.vue
@@ -42,7 +42,7 @@ const handleStyles = computed(() => ({
 
 .label {
 	position: absolute;
-	top: -20px;
+	top: calc(-1 * var(--spacing--lg));
 	left: 50%;
 	/* stylelint-disable-next-line @n8n/css-var-naming */
 	transform: translate(-50%, 0) scale(var(--canvas-zoom-compensation-factor, 1));


### PR DESCRIPTION
## Summary

This PR introduces new tooltips for canvas edge buttons. It also slightly changes label paddings for node handles, so that labels are aligned with node toolbar

<img width="1082" height="497" alt="image" src="https://github.com/user-attachments/assets/4e53d7e9-342c-45f4-ac36-60fe07b5c915" />

Before:
<img width="554" height="340" alt="image" src="https://github.com/user-attachments/assets/b648533f-47b8-456d-943b-8c2e69306887" />



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4210/show-tooltips-when-hovering-canvas-edge-buttons

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
