### PR TITLE
update rudder-sdk-node

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -114,7 +114,7 @@
     "@n8n_io/ai-assistant-sdk": "catalog:",
     "@n8n_io/license-sdk": "2.24.1",
     "@parcel/watcher": "^2.5.1",
-    "@rudderstack/rudder-sdk-node": "2.1.4",
+    "@rudderstack/rudder-sdk-node": "3.0.0",
     "@sentry/node": "catalog:",
     "aws4": "1.11.0",
     "axios": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1685,8 +1685,8 @@ importers:
         specifier: ^2.5.1
         version: 2.5.1
       '@rudderstack/rudder-sdk-node':
-        specifier: 2.1.4
-        version: 2.1.4(tslib@2.8.1)
+        specifier: 3.0.0
+        version: 3.0.0
       '@sentry/node':
         specifier: 'catalog:'
         version: 9.42.1
@@ -7464,10 +7464,8 @@ packages:
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
-  '@rudderstack/rudder-sdk-node@2.1.4':
-    resolution: {integrity: sha512-Y/WJRcIYss+gCipzCMYcbJ3WPkj4SxsqNcb/HYjKhaLjdfjCmuWVSsJFEajfpA8EpkKRh3OamerBO5kftwXLxQ==}
-    peerDependencies:
-      tslib: ^2.6.2
+  '@rudderstack/rudder-sdk-node@3.0.0':
+    resolution: {integrity: sha512-zWdyYzpuUG/sa6cMr8FspYZtxdxee7G5SXYPkAYWwqd72lVO8MKXf+CX9eoIkix7Mc3qzgTFdyKleZN9QYvwQg==}
 
   '@rushstack/node-core-library@5.12.0':
     resolution: {integrity: sha512-QSwwzgzWoil1SCQse+yCHwlhRxNv2dX9siPnAb9zR/UmMhac4mjMrlMZpk64BlCeOFi1kJKgXRkihSwRMbboAQ==}
@@ -10153,6 +10151,10 @@ packages:
 
   bull@4.16.4:
     resolution: {integrity: sha512-CF+nGsJyfsCC9MJL8hFxqXzbwq+jGBXhaz1j15G+5N/XtKIPFUUy5O1mfWWKbKunfuH/x+UV4NYRQDHSkjCOgA==}
+    engines: {node: '>=12'}
+
+  bull@4.16.5:
+    resolution: {integrity: sha512-lDsx2BzkKe7gkCYiT5Acj02DpTwDznl/VNN7Psn7M3USPG7Vs/BaClZJJTAG+ufAR9++N1/NiUTdaFBWDIl5TQ==}
     engines: {node: '>=12'}
 
   bundle-name@4.1.0:
@@ -17920,10 +17922,6 @@ packages:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
     hasBin: true
 
-  uuid@11.0.2:
-    resolution: {integrity: sha512-14FfcOJmqdjbBPdDjFQyk/SdT4NySW4eM0zcG+HqbHP5jzuH56xO3J1DGhgs/cEMCfwYi3HQI1gnTO62iaG+tQ==}
-    hasBin: true
-
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
@@ -23916,7 +23914,7 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
-  '@rudderstack/rudder-sdk-node@2.1.4(tslib@2.8.1)':
+  '@rudderstack/rudder-sdk-node@3.0.0':
     dependencies:
       axios: 1.12.0
       axios-retry: 4.5.0(axios@1.12.0)
@@ -23927,11 +23925,9 @@ snapshots:
       md5: 2.3.0
       ms: 2.1.3
       remove-trailing-slash: 0.1.1
-      serialize-javascript: 6.0.2
-      tslib: 2.8.1
-      uuid: 11.0.2
+      uuid: 11.1.0
     optionalDependencies:
-      bull: 4.16.4(patch_hash=a4b6d56db16fe5870646929938466d6a5c668435fd1551bed6a93fffb597ba42)
+      bull: 4.16.5
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -27496,6 +27492,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  bull@4.16.5:
+    dependencies:
+      cron-parser: 4.9.0
+      get-port: 5.1.1
+      ioredis: 5.3.2
+      lodash: 4.17.21
+      msgpackr: 1.11.2
+      semver: 7.7.3
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
@@ -30580,7 +30589,7 @@ snapshots:
       '@types/debug': 4.1.12
       '@types/node': 20.19.21
       '@types/tough-cookie': 4.0.5
-      axios: 1.12.0
+      axios: 1.12.0(debug@4.4.3)
       camelcase: 6.3.0
       debug: 4.4.3(supports-color@8.1.1)
       dotenv: 16.6.1
@@ -30590,7 +30599,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.12.0(debug@4.4.3))
+      retry-axios: 2.6.0(axios@1.12.0)
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -35019,7 +35028,7 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
-  retry-axios@2.6.0(axios@1.12.0(debug@4.4.3)):
+  retry-axios@2.6.0(axios@1.12.0):
     dependencies:
       axios: 1.12.0
 
@@ -37135,8 +37144,6 @@ snapshots:
   uuencode@0.0.4: {}
 
   uuid@10.0.0: {}
-
-  uuid@11.0.2: {}
 
   uuid@11.1.0: {}
 


### PR DESCRIPTION
Patches critical RCE vulnerability in Redis job deserialization by replacing unsafe eval() with secure JSON parsing, preventing potential remote code execution.

<details>

<summary>✅ Code not affected by breaking changes.</summary>

<br>


The breaking change in version 3.0.0 relates to the elimination of an RCE vulnerability in the persistence queue feature. After analyzing the codebase, I found that:


1. **No persistence queue configuration is used**: The RudderStack SDK is initialized in two locations:

   - `packages/cli/src/telemetry/index.ts` (lines 80-87): Initializes with `axiosInstance`, `logLevel`, `dataPlaneUrl`, `gzip: false`, and `errorHandler` - no persistence queue options

   - `packages/cli/src/services/hooks.service.ts` (line 118): Returns a new RudderStack instance with options passed from external callers, but no persistence configuration is found in the codebase


2. **No persistence-related options found**: Searches for `persistence`, `queue`, `flushAt`, `flushInterval`, `maxQueueSize`, and `maxInternalQueueSize` in the RudderStack configuration contexts returned no matches.


3. **Default behavior**: The codebase relies on the default in-memory queue behavior of the SDK without enabling file-based persistence.


Since the breaking change specifically affects the persistence queue feature (which may restrict previously working behavior related to queue persistence), and this codebase does not use queue persistence functionality, the upgrade will not cause any breaking changes.

All breaking changes by upgrading @rudderstack/rudder-sdk-node from version 2.1.4 to 3.0.0 ([CHANGELOG](https://github.com/rudderlabs/rudder-sdk-node/blob/develop/CHANGELOG.md))

| Version | Description |
| --- | --- |
| <pre>3.0.0</pre> | Eliminated RCE vulnerability in persistence queue, which may restrict previously working behavior related to queue persistence |


</details>

<details>

<summary>✅ 1 CVE resolved by this upgrade</summary>

<br>


This PR will resolve the following CVEs:

| Issue | Severity&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Description |
| --- | --- | --- |
| <pre>[AIKIDO-2026-10021](https://app.aikido.dev/issues/19769350/detail?groupId=1590#AIKIDO-2026-10021)</pre> | <pre>HIGH</pre> | Remote Code Execution via insecure deserialization in Redis job processing. Attackers can inject malicious JavaScript into job data, which is then executed server-side using unsafe eval(), enabling system compromise. |


</details>

<details>

<summary>🔗 Related Tasks</summary>

<br>


- [https://linear.app/n8n/issue/SEC-419/major-upgrade-for-rudderstackrudder-sdk-node-n8n](https://linear.app/n8n/issue/SEC-419/major-upgrade-for-rudderstackrudder-sdk-node-n8n)


</details>