### PR TITLE
fix(Mattermost Node): Add user scoped channels endpoint fallback

### DIFF
--- a/packages/nodes-base/nodes/Mattermost/v1/methods/loadOptions.ts
+++ b/packages/nodes-base/nodes/Mattermost/v1/methods/loadOptions.ts
@@ -5,8 +5,15 @@ import { apiRequestAllItems } from '../transport';
 
 // Get all the available channels
 export async function getChannels(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-	const endpoint = 'channels';
-	const responseData = await apiRequestAllItems.call(this, 'GET', endpoint, {});
+	let responseData;
+
+	try {
+		// Try admin endpoint first (returns all channels across teams)
+		responseData = await apiRequestAllItems.call(this, 'GET', 'channels', {});
+	} catch {
+		// Fall back to user-scoped endpoint (works for non-admin users)
+		responseData = await apiRequestAllItems.call(this, 'GET', 'users/me/channels', {});
+	}
 
 	if (responseData === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No data got returned');


### PR DESCRIPTION
## Summary

The Mattermost node was non-functional for non-admin users because the `getChannels` method used the `GET /api/v4/channels` endpoint which requires admin access.
This PR adds a backup call to the user scoped `GET /api/v4/users/me/channels` in case the prior fails.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #14851 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
