### PR TITLE
fix: Update urllib3 to 2.6.3 in task runner

### DIFF
--- a/packages/@n8n/task-runner-python/pyproject.toml
+++ b/packages/@n8n/task-runner-python/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
 sentry = ["sentry-sdk>=2.35.2"]
 
 [tool.uv]
-constraint-dependencies = ["urllib3>=2.6.0"]
+constraint-dependencies = ["urllib3>=2.6.3"]
 
 [dependency-groups]
 dev = [

--- a/packages/@n8n/task-runner-python/uv.lock
+++ b/packages/@n8n/task-runner-python/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.13"
 
 [manifest]
-constraints = [{ name = "urllib3", specifier = ">=2.6.0" }]
+constraints = [{ name = "urllib3", specifier = ">=2.6.3" }]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -462,11 +462,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.1"
+version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/1d/0f3a93cca1ac5e8287842ed4eebbd0f7a991315089b1a0b01c7788aa7b63/urllib3-2.6.1.tar.gz", hash = "sha256:5379eb6e1aba4088bae84f8242960017ec8d8e3decf30480b3a1abdaa9671a3f", size = 432678, upload-time = "2025-12-08T15:25:26.773Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/56/190ceb8cb10511b730b564fb1e0293fa468363dbad26145c34928a60cb0c/urllib3-2.6.1-py3-none-any.whl", hash = "sha256:e67d06fe947c36a7ca39f4994b08d73922d40e6cca949907be05efa6fd75110b", size = 131138, upload-time = "2025-12-08T15:25:25.51Z" },
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Automated task completed by Claude.

### Task Description
Clean up this CVE in the runners image Package: urllib3@2.6.1 → 2.6.3 

### Generated by
[Workflow Run #20997539860](https://github.com/n8n-io/n8n/actions/runs/20997539860)

---
*Triggered by @shortstacked via the Claude Task Runner workflow.*
