### PR TITLE
fix(core): Increase the model column length from 64 to 256

### DIFF
--- a/packages/@n8n/db/src/migrations/common/1768402473068-ExpandModelColumnLength.ts
+++ b/packages/@n8n/db/src/migrations/common/1768402473068-ExpandModelColumnLength.ts
@@ -1,0 +1,78 @@
+import type { ReversibleMigration, MigrationContext } from '../migration-types';
+
+export class ExpandModelColumnLength1768402473068 implements ReversibleMigration {
+	async up({ isSqlite, isMysql, isPostgres, escape, queryRunner }: MigrationContext) {
+		const messagesTable = escape.tableName('chat_hub_messages');
+		const sessionsTable = escape.tableName('chat_hub_sessions');
+		const modelColumn = escape.columnName('model');
+
+		if (isPostgres) {
+			await queryRunner.query(
+				`ALTER TABLE ${messagesTable} ALTER COLUMN ${modelColumn} TYPE VARCHAR(256);`,
+			);
+			await queryRunner.query(
+				`ALTER TABLE ${sessionsTable} ALTER COLUMN ${modelColumn} TYPE VARCHAR(256);`,
+			);
+		} else if (isMysql) {
+			await queryRunner.query(
+				`ALTER TABLE ${messagesTable} MODIFY COLUMN ${modelColumn} VARCHAR(256);`,
+			);
+			await queryRunner.query(
+				`ALTER TABLE ${sessionsTable} MODIFY COLUMN ${modelColumn} VARCHAR(256);`,
+			);
+		} else if (isSqlite) {
+			for (const table of [messagesTable, sessionsTable]) {
+				await queryRunner.query(`ALTER TABLE ${table} ADD COLUMN "model_tmp" VARCHAR(256);`);
+				await queryRunner.query(`UPDATE ${table} SET "model_tmp" = ${modelColumn};`);
+				await queryRunner.query(`ALTER TABLE ${table} DROP COLUMN ${modelColumn};`);
+				await queryRunner.query(`ALTER TABLE ${table} ADD COLUMN ${modelColumn} VARCHAR(256);`);
+				await queryRunner.query(`UPDATE ${table} SET ${modelColumn} = "model_tmp";`);
+				await queryRunner.query(`ALTER TABLE ${table} DROP COLUMN "model_tmp";`);
+			}
+		}
+	}
+
+	async down({ isSqlite, isMysql, isPostgres, escape, queryRunner }: MigrationContext) {
+		const messagesTable = escape.tableName('chat_hub_messages');
+		const sessionsTable = escape.tableName('chat_hub_sessions');
+		const modelColumn = escape.columnName('model');
+
+		// Truncate values longer than 64 chars before changing type
+		if (isPostgres) {
+			await queryRunner.query(
+				`UPDATE ${messagesTable} SET ${modelColumn} = LEFT(${modelColumn}, 64) WHERE LENGTH(${modelColumn}) > 64;`,
+			);
+			await queryRunner.query(
+				`UPDATE ${sessionsTable} SET ${modelColumn} = LEFT(${modelColumn}, 64) WHERE LENGTH(${modelColumn}) > 64;`,
+			);
+			await queryRunner.query(
+				`ALTER TABLE ${messagesTable} ALTER COLUMN ${modelColumn} TYPE VARCHAR(64);`,
+			);
+			await queryRunner.query(
+				`ALTER TABLE ${sessionsTable} ALTER COLUMN ${modelColumn} TYPE VARCHAR(64);`,
+			);
+		} else if (isMysql) {
+			await queryRunner.query(
+				`UPDATE ${messagesTable} SET ${modelColumn} = LEFT(${modelColumn}, 64) WHERE CHAR_LENGTH(${modelColumn}) > 64;`,
+			);
+			await queryRunner.query(
+				`UPDATE ${sessionsTable} SET ${modelColumn} = LEFT(${modelColumn}, 64) WHERE CHAR_LENGTH(${modelColumn}) > 64;`,
+			);
+			await queryRunner.query(
+				`ALTER TABLE ${messagesTable} MODIFY COLUMN ${modelColumn} VARCHAR(64);`,
+			);
+			await queryRunner.query(
+				`ALTER TABLE ${sessionsTable} MODIFY COLUMN ${modelColumn} VARCHAR(64);`,
+			);
+		} else if (isSqlite) {
+			for (const table of [messagesTable, sessionsTable]) {
+				await queryRunner.query(`ALTER TABLE ${table} ADD COLUMN "model_tmp" VARCHAR(64);`);
+				await queryRunner.query(`UPDATE ${table} SET "model_tmp" = SUBSTR(${modelColumn}, 1, 64);`);
+				await queryRunner.query(`ALTER TABLE ${table} DROP COLUMN ${modelColumn};`);
+				await queryRunner.query(`ALTER TABLE ${table} ADD COLUMN ${modelColumn} VARCHAR(64);`);
+				await queryRunner.query(`UPDATE ${table} SET ${modelColumn} = "model_tmp";`);
+				await queryRunner.query(`ALTER TABLE ${table} DROP COLUMN "model_tmp";`);
+			}
+		}
+	}
+}

--- a/packages/@n8n/db/src/migrations/common/1768402473068-ExpandModelColumnLength.ts
+++ b/packages/@n8n/db/src/migrations/common/1768402473068-ExpandModelColumnLength.ts
@@ -1,7 +1,7 @@
 import type { ReversibleMigration, MigrationContext } from '../migration-types';
 
 export class ExpandModelColumnLength1768402473068 implements ReversibleMigration {
-	async up({ isSqlite, isMysql, isPostgres, escape, queryRunner }: MigrationContext) {
+	async up({ isSqlite, isPostgres, escape, queryRunner }: MigrationContext) {
 		const messagesTable = escape.tableName('chat_hub_messages');
 		const sessionsTable = escape.tableName('chat_hub_sessions');
 		const modelColumn = escape.columnName('model');
@@ -12,13 +12,6 @@ export class ExpandModelColumnLength1768402473068 implements ReversibleMigration
 			);
 			await queryRunner.query(
 				`ALTER TABLE ${sessionsTable} ALTER COLUMN ${modelColumn} TYPE VARCHAR(256);`,
-			);
-		} else if (isMysql) {
-			await queryRunner.query(
-				`ALTER TABLE ${messagesTable} MODIFY COLUMN ${modelColumn} VARCHAR(256);`,
-			);
-			await queryRunner.query(
-				`ALTER TABLE ${sessionsTable} MODIFY COLUMN ${modelColumn} VARCHAR(256);`,
 			);
 		} else if (isSqlite) {
 			for (const table of [messagesTable, sessionsTable]) {
@@ -32,7 +25,7 @@ export class ExpandModelColumnLength1768402473068 implements ReversibleMigration
 		}
 	}
 
-	async down({ isSqlite, isMysql, isPostgres, escape, queryRunner }: MigrationContext) {
+	async down({ isSqlite, isPostgres, escape, queryRunner }: MigrationContext) {
 		const messagesTable = escape.tableName('chat_hub_messages');
 		const sessionsTable = escape.tableName('chat_hub_sessions');
 		const modelColumn = escape.columnName('model');
@@ -50,19 +43,6 @@ export class ExpandModelColumnLength1768402473068 implements ReversibleMigration
 			);
 			await queryRunner.query(
 				`ALTER TABLE ${sessionsTable} ALTER COLUMN ${modelColumn} TYPE VARCHAR(64);`,
-			);
-		} else if (isMysql) {
-			await queryRunner.query(
-				`UPDATE ${messagesTable} SET ${modelColumn} = LEFT(${modelColumn}, 64) WHERE CHAR_LENGTH(${modelColumn}) > 64;`,
-			);
-			await queryRunner.query(
-				`UPDATE ${sessionsTable} SET ${modelColumn} = LEFT(${modelColumn}, 64) WHERE CHAR_LENGTH(${modelColumn}) > 64;`,
-			);
-			await queryRunner.query(
-				`ALTER TABLE ${messagesTable} MODIFY COLUMN ${modelColumn} VARCHAR(64);`,
-			);
-			await queryRunner.query(
-				`ALTER TABLE ${sessionsTable} MODIFY COLUMN ${modelColumn} VARCHAR(64);`,
 			);
 		} else if (isSqlite) {
 			for (const table of [messagesTable, sessionsTable]) {

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -133,6 +133,7 @@ import { AddAgentIdForeignKeys1765886667897 } from '../common/1765886667897-AddA
 import { AddWorkflowVersionIdToExecutionData1765892199653 } from '../common/1765892199653-AddVersionIdToExecutionData';
 import { AddWorkflowPublishScopeToProjectRoles1766064542000 } from '../common/1766064542000-AddWorkflowPublishScopeToProjectRoles';
 import { AddChatMessageIndices1766068346315 } from '../common/1766068346315-AddChatMessageIndices';
+import { ExpandModelColumnLength1768402473068 } from '../common/1768402473068-ExpandModelColumnLength';
 import type { Migration } from '../migration-types';
 
 export const postgresMigrations: Migration[] = [
@@ -271,4 +272,5 @@ export const postgresMigrations: Migration[] = [
 	AddChatMessageIndices1766068346315,
 	ExpandInsightsWorkflowIdLength1766500000000,
 	ChangeWorkflowStatisticsFKToNoAction1767018516000,
+	ExpandModelColumnLength1768402473068,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -127,6 +127,7 @@ import { BackfillMissingWorkflowHistoryRecords1765448186933 } from '../common/17
 import { AddIconToAgentTable1765788427674 } from '../common/1765788427674-AddIconToAgentTable';
 import { AddWorkflowVersionIdToExecutionData1765892199653 } from '../common/1765892199653-AddVersionIdToExecutionData';
 import { AddWorkflowPublishScopeToProjectRoles1766064542000 } from '../common/1766064542000-AddWorkflowPublishScopeToProjectRoles';
+import { ExpandModelColumnLength1768402473068 } from '../common/1768402473068-ExpandModelColumnLength';
 import type { Migration } from '../migration-types';
 
 const sqliteMigrations: Migration[] = [
@@ -259,6 +260,7 @@ const sqliteMigrations: Migration[] = [
 	AddWorkflowPublishScopeToProjectRoles1766064542000,
 	AddChatMessageIndices1766068346315,
 	ChangeWorkflowStatisticsFKToNoAction1767018516000,
+	ExpandModelColumnLength1768402473068,
 ];
 
 export { sqliteMigrations };

--- a/packages/cli/src/modules/chat-hub/chat-hub-message.entity.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-message.entity.ts
@@ -59,7 +59,7 @@ export class ChatHubMessage extends WithTimestamps {
 	 * The LLM model that generated this message (if applicable).
 	 * Human messages have this field set to NULL.
 	 */
-	@Column({ type: 'varchar', length: 64, nullable: true })
+	@Column({ type: 'varchar', length: 256, nullable: true })
 	model: string | null;
 
 	/**

--- a/packages/cli/src/modules/chat-hub/chat-hub-session.entity.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-session.entity.ts
@@ -91,7 +91,7 @@ export class ChatHubSession extends WithTimestamps {
 	/*
 	 * LLM model to use from the provider (if applicable)
 	 */
-	@Column({ type: 'varchar', length: 64, nullable: true })
+	@Column({ type: 'varchar', length: 256, nullable: true })
 	model: string | null;
 
 	/*


### PR DESCRIPTION
## Summary

Turns out `varchar(64)` was too short for some (AWS Bedrock) model names.
Lets increase the column length to 256.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-106/model-is-too-long-for-type-character-varying-64#comment-b2dadb0f

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
