### PR TITLE
fix(editor): Hold autosave when new template is imported until the user makes a change/run the workflow

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -5142,6 +5142,21 @@ describe('useCanvasOperations', () => {
 				query: { templateId: 'template-id' },
 			});
 		});
+
+		it('should not mark UI state as dirty on template import', async () => {
+			const uiStore = mockedStore(useUIStore);
+
+			templatesStore.getFixedWorkflowTemplate = vi.fn().mockReturnValue({
+				id: 'workflow-id',
+				name: 'Template Name',
+				workflow: { nodes: [], connections: {} },
+			});
+
+			const { openWorkflowTemplate } = useCanvasOperations();
+			await openWorkflowTemplate('template-id');
+
+			expect(uiStore.markStateDirty).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('openWorkflowTempalateFromJSON', () => {
@@ -5185,6 +5200,23 @@ describe('useCanvasOperations', () => {
 					parentFolderId: undefined,
 				},
 			});
+		});
+
+		it('should not mark UI state as dirty on template import', async () => {
+			const uiStore = mockedStore(useUIStore);
+
+			const template: WorkflowDataWithTemplateId = {
+				id: 'workflow-id',
+				name: 'Template Name',
+				nodes: [],
+				connections: {},
+				meta: { templateId: 'template-id' },
+			};
+
+			const { openWorkflowTemplateFromJSON } = useCanvasOperations();
+			await openWorkflowTemplateFromJSON(template);
+
+			expect(uiStore.markStateDirty).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -2701,7 +2701,7 @@ export function useCanvasOperations() {
 		if (workflow.connections) {
 			workflowsStore.setConnections(workflow.connections);
 		}
-		await addNodes(convertedNodes ?? []);
+		await addNodes(convertedNodes ?? [], { keepPristine: true });
 		await workflowState.getNewWorkflowDataAndMakeShareable(name, projectsStore.currentProjectId);
 		workflowState.addToWorkflowMetadata({ templateId: `${id}` });
 	}
@@ -2870,8 +2870,6 @@ export function useCanvasOperations() {
 			workflowState.setWorkflowId(route.params.name);
 		}
 
-		uiStore.markStateDirty();
-
 		canvasStore.stopLoading();
 
 		void externalHooks.run('template.open', {
@@ -2917,8 +2915,6 @@ export function useCanvasOperations() {
 			name: workflow.name,
 			workflow,
 		});
-
-		uiStore.markStateDirty();
 
 		canvasStore.stopLoading();
 

--- a/packages/testing/playwright/tests/e2e/workflows/templates/templates.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/templates/templates.spec.ts
@@ -228,9 +228,10 @@ test.describe('Workflow templates', () => {
 		test('should save template id with the workflow', async ({ n8n }) => {
 			await n8n.templatesComposer.importFirstTemplate();
 
-			// Trigger manual save since imported templates don't auto-save immediately
+			// Execute workflow to trigger autosave (imported templates don't auto-save immediately)
+			await n8n.canvas.hitExecuteWorkflow();
+
 			const saveResponsePromise = n8n.canvas.waitForSaveWorkflowCompleted();
-			await n8n.canvas.hitSaveWorkflow();
 			const saveResponse = await saveResponsePromise;
 
 			const requestBody = saveResponse.request().postDataJSON();

--- a/packages/testing/playwright/tests/e2e/workflows/templates/templates.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/templates/templates.spec.ts
@@ -228,7 +228,10 @@ test.describe('Workflow templates', () => {
 		test('should save template id with the workflow', async ({ n8n }) => {
 			await n8n.templatesComposer.importFirstTemplate();
 
-			const saveResponse = await n8n.canvas.waitForSaveWorkflowCompleted();
+			// Trigger manual save since imported templates don't auto-save immediately
+			const saveResponsePromise = n8n.canvas.waitForSaveWorkflowCompleted();
+			await n8n.canvas.hitSaveWorkflow();
+			const saveResponse = await saveResponsePromise;
 
 			const requestBody = saveResponse.request().postDataJSON();
 			expect(requestBody.meta.templateId).toBe(TEMPLATE_ID);


### PR DESCRIPTION
## Summary

Update the import workflow functionalities to not set the workflow state as dirty which fixes autosave being triggered incorrectly.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4636/inserted-template-is-being-saved-immediately

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
