### PR TITLE
fix(editor): Remove duplicate error toasts in ready-to-run workflow

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/layouts/EmptyStateLayout.vue
+++ b/packages/frontend/editor-ui/src/app/components/layouts/EmptyStateLayout.vue
@@ -8,7 +8,6 @@ import { useProjectsStore } from '@/features/collaboration/projects/projects.sto
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
 import { getResourcePermissions } from '@n8n/permissions';
 import { useProjectPages } from '@/features/collaboration/projects/composables/useProjectPages';
-import { useToast } from '@/app/composables/useToast';
 import { useReadyToRunStore } from '@/features/workflows/readyToRun/stores/readyToRun.store';
 import { useTemplatesDataQualityStore } from '@/experiments/templatesDataQuality/stores/templatesDataQuality.store';
 import TemplatesDataQualityInlineSection from '@/experiments/templatesDataQuality/components/TemplatesDataQualityInlineSection.vue';
@@ -20,7 +19,6 @@ const emit = defineEmits<{
 
 const route = useRoute();
 const i18n = useI18n();
-const toast = useToast();
 const usersStore = useUsersStore();
 const projectsStore = useProjectsStore();
 const sourceControlStore = useSourceControlStore();
@@ -79,9 +77,9 @@ const handleReadyToRunClick = async () => {
 			route.params.folderId as string,
 			projectId,
 		);
-	} catch (error) {
+	} catch {
 		isLoadingReadyToRun.value = false;
-		toast.showError(error, i18n.baseText('generic.error'));
+		// Error already shown by store functions
 	}
 };
 

--- a/packages/frontend/editor-ui/src/features/workflows/readyToRun/components/ReadyToRunButton.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/readyToRun/components/ReadyToRunButton.vue
@@ -8,7 +8,6 @@ import { useProjectPages } from '@/features/collaboration/projects/composables/u
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
 import { useFoldersStore } from '@/features/core/folders/folders.store';
-import { useToast } from '@/app/composables/useToast';
 import { useReadyToRunStore } from '../stores/readyToRun.store';
 
 const props = defineProps<{
@@ -17,7 +16,6 @@ const props = defineProps<{
 
 const route = useRoute();
 const i18n = useI18n();
-const toast = useToast();
 const projectPages = useProjectPages();
 const projectsStore = useProjectsStore();
 const sourceControlStore = useSourceControlStore();
@@ -51,8 +49,8 @@ const handleClick = async () => {
 			route.params.folderId as string,
 			projectId,
 		);
-	} catch (error) {
-		toast.showError(error, i18n.baseText('generic.error'));
+	} catch {
+		// Error already shown by store functions
 	}
 };
 </script>


### PR DESCRIPTION
## Summary

- Removes duplicate error toasts when "Try an AI Workflow" fails
- The error was being shown twice: once in the store functions and again in the component catch blocks
- This caused what appeared as irregular spacing between error notifications

<img width="850" height="2586" alt="image" src="https://github.com/user-attachments/assets/a468950d-19c4-4616-aa57-b761714527d4" />


## Root Cause

When clicking "Try an AI Workflow" and an error occurred:
1. `claimFreeAiCredits()` in `readyToRun.store.ts` showed an error toast and re-threw
2. The component catch block also called `toast.showError()` showing a second toast

The "irregular spacing" reported in the bug was actually multiple duplicate toasts appearing for the same error.

## Changes

- `EmptyStateLayout.vue`: Removed duplicate `toast.showError` call (already had it commented out, cleaned up imports)
- `ReadyToRunButton.vue`: Removed duplicate `toast.showError` call and unused imports

## Test Plan

- [ ] Click "Try an AI Workflow" when it will fail (e.g., on internal instance)
- [ ] Verify only one error toast appears per error
- [ ] Verify toast appears with consistent spacing

https://linear.app/n8n/issue/AI-1761

🤖 Generated with [Claude Code](https://claude.ai/code)