### PR TITLE
ci: GH actions for private fork

### DIFF
--- a/.github/workflows/sec-publish-fix.yml
+++ b/.github/workflows/sec-publish-fix.yml
@@ -54,6 +54,8 @@ jobs:
           git remote add public https://x-access-token:${{ steps.generate_token.outputs.token }}@github.com/n8n-io/n8n.git
           git fetch public master
           git checkout public/master
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git cherry-pick "$MERGE_COMMIT"
           git push public HEAD:master
 

--- a/.github/workflows/sec-publish-fix.yml
+++ b/.github/workflows/sec-publish-fix.yml
@@ -51,18 +51,18 @@ jobs:
       - name: Cherry-pick to public repo
         run: |
           COMMIT_TO_PUBLISH=$(git rev-parse HEAD)
-          git remote add public https://x-access-token:${{ steps.generate_token.outputs.token }}@github.com/n8n-io/n8n.git
-          git fetch public master
-          git checkout public/master
+          git remote add public-repo https://x-access-token:${{ steps.generate_token.outputs.token }}@github.com/n8n-io/n8n.git
+          git fetch public-repo master
+          git checkout public-repo/master
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git cherry-pick "$COMMIT_TO_PUBLISH"
-          git push public HEAD:master
+          git push public-repo HEAD:master
 
       - name: Sync public back to private
         run: |
-          git fetch public master
-          git push origin public/master:master --force
+          git fetch public-repo master
+          git push origin public-repo/master:master --force
 
       - name: Notify on failure
         if: failure()

--- a/.github/workflows/sec-publish-fix.yml
+++ b/.github/workflows/sec-publish-fix.yml
@@ -50,13 +50,13 @@ jobs:
 
       - name: Cherry-pick to public repo
         run: |
-          MERGE_COMMIT=$(git rev-parse HEAD)
+          COMMIT_TO_PUBLISH=$(git rev-parse HEAD)
           git remote add public https://x-access-token:${{ steps.generate_token.outputs.token }}@github.com/n8n-io/n8n.git
           git fetch public master
           git checkout public/master
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git cherry-pick "$MERGE_COMMIT"
+          git cherry-pick "$COMMIT_TO_PUBLISH"
           git push public HEAD:master
 
       - name: Sync public back to private

--- a/.github/workflows/sec-publish-fix.yml
+++ b/.github/workflows/sec-publish-fix.yml
@@ -60,7 +60,9 @@ jobs:
           git push public HEAD:master
 
       - name: Sync public back to private
-        run: git push origin HEAD:master --force
+        run: |
+          git fetch public master
+          git push origin public/master:master --force
 
       - name: Notify on failure
         if: failure()

--- a/.github/workflows/sec-publish-fix.yml
+++ b/.github/workflows/sec-publish-fix.yml
@@ -1,0 +1,70 @@
+# Publish security fix from n8n-io/n8n-private to n8n-io/n8n
+#
+# On PR merge to n8n-private's master:
+#
+# 1. Cherrypick the squashed commit onto n8n's master
+# 2. Sync n8n's master onto n8n-private's master
+#
+# Before:
+#   private master: A -- B -- C -- D       (D = security fix)
+#   public master:  A -- B -- C -- E       (E = normal development)
+#
+# After:
+#   private master: A -- B -- C -- E -- D'
+#   public master:  A -- B -- C -- E -- D'
+#
+# On cherrypick conflict:
+#
+# 1. Run "Security: Sync from Public" workflow
+# 2. Rebase your branch: `git checkout fix-123 && git rebase master`
+# 3. Reopen PR and merge again
+
+name: 'Security: Publish fix'
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [master]
+
+jobs:
+  sync-security-fix:
+    if: github.repository == 'n8n-io/n8n-private' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Generate GitHub App Token
+        id: generate_token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        with:
+          app-id: ${{ secrets.N8N_ASSISTANT_APP_ID }}
+          private-key: ${{ secrets.N8N_ASSISTANT_PRIVATE_KEY }}
+          owner: n8n-io
+          repositories: n8n
+
+      - name: Cherry-pick to public repo
+        run: |
+          MERGE_COMMIT=$(git rev-parse HEAD)
+          git remote add public https://x-access-token:${{ steps.generate_token.outputs.token }}@github.com/n8n-io/n8n.git
+          git fetch public master
+          git checkout public/master
+          git cherry-pick "$MERGE_COMMIT"
+          git push public HEAD:master
+
+      - name: Sync public back to private
+        run: git push origin HEAD:master --force
+
+      - name: Notify on failure
+        if: failure()
+        uses: act10ns/slack@44541246747a30eb3102d87f7a4cc5471b0ffb7d # v2.1.0
+        with:
+          status: ${{ job.status }}
+          channel: '#alerts-security'
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          message: 'Security fix cherry-pick failed. Run "Security: Sync from Public" workflow, rebase your branch, reopen PR. (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})'

--- a/.github/workflows/sec-sync-public-to-private.yml
+++ b/.github/workflows/sec-sync-public-to-private.yml
@@ -1,0 +1,54 @@
+# Sync n8n-io/n8n to n8n-io/n8n-private
+#
+# Runs hourly to keep private in sync with public.
+# Can also be triggered manually for conflict recovery.
+#
+# Scheduled runs only sync if private is not ahead of public.
+# Manual runs always sync (for conflict recovery after failed cherry-pick).
+
+name: 'Security: Sync from Public'
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+    inputs:
+      force:
+        description: Sync even if private is ahead (for conflict recovery)
+        type: boolean
+        default: true
+
+jobs:
+  sync-from-public:
+    if: github.repository == 'n8n-io/n8n-private'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Sync from public
+        run: |
+          git fetch https://github.com/n8n-io/n8n.git master:public-master
+
+          # Check if private is ahead of public
+          AHEAD_COUNT=$(git rev-list public-master..HEAD --count)
+
+          if [ "$AHEAD_COUNT" -gt 0 ]; then
+            if [ "${{ github.event_name }}" = "schedule" ]; then
+              echo "Private is $AHEAD_COUNT commit(s) ahead of public, skipping scheduled sync"
+              exit 0
+            elif [ "${{ inputs.force }}" != "true" ]; then
+              echo "Private is $AHEAD_COUNT commit(s) ahead of public, skipping (force not enabled)"
+              exit 0
+            else
+              echo "Private is $AHEAD_COUNT commit(s) ahead of public, force syncing anyway"
+            fi
+          fi
+
+          git reset --hard public-master
+          git push origin master --force

--- a/.github/workflows/sec-sync-public-to-private.yml
+++ b/.github/workflows/sec-sync-public-to-private.yml
@@ -51,4 +51,4 @@ jobs:
           fi
 
           git reset --hard public-master
-          git push origin master --force
+          git push origin master --force-with-lease


### PR DESCRIPTION
Add GH actions to manage the private security fork:

- On PR merge to private's master, cherry-picks the security fix onto public's master, then syncs back to private
- Regularly keep private in sync with public, can be triggered manually for conflict recovery
