### PR TITLE
fix(ai-builder): Disabling flaky E2E workflow builder test

### DIFF
--- a/packages/testing/playwright/pages/AIAssistantPage.ts
+++ b/packages/testing/playwright/pages/AIAssistantPage.ts
@@ -123,14 +123,18 @@ export class AIAssistantPage extends BasePage {
 	async waitForStreamingComplete(options?: { timeout?: number }) {
 		const timeout = options?.timeout ?? 60000;
 		// Wait for at least one assistant message to appear (indicating streaming has produced output)
-		// and ensure the send button is re-enabled (indicating streaming is complete)
 		await this.getChatMessagesAssistant().first().waitFor({ state: 'visible', timeout });
+		// Wait for streaming to end by checking for the send button's arrow-up icon
+		// During streaming, a stop button with filled-square icon is shown instead
+		// After streaming, the send button with arrow-up icon appears
 		await this.page.waitForFunction(
 			() => {
-				const sendButton = document.querySelector(
-					'[data-test-id="send-message-button"]',
-				) as HTMLButtonElement;
-				return sendButton && !sendButton.disabled;
+				const sendButton = document.querySelector('[data-test-id="send-message-button"]');
+				if (!sendButton) return false;
+				// The arrow-up icon indicates the send button (not streaming)
+				// The filled-square icon indicates the stop button (streaming)
+				const sendIcon = sendButton.querySelector('[data-icon="arrow-up"]');
+				return sendIcon !== null;
 			},
 			{ timeout },
 		);

--- a/packages/testing/playwright/tests/e2e/ai/workflow-builder.spec.ts
+++ b/packages/testing/playwright/tests/e2e/ai/workflow-builder.spec.ts
@@ -57,7 +57,8 @@ test.describe('Workflow Builder @auth:owner @ai @capability:proxy', () => {
 		await expect(suggestions).toHaveCount(8);
 	});
 
-	// @AI team to look at this
+	// @AI team - investigated issues with this test, the replay of recorded events not working as expected
+	// doesn't appear to be matching in the correct order/some requests make it past the proxy leading to 401 error
 	test.fixme('should build workflow from suggested prompt @fixme', async ({ n8n }) => {
 		await n8n.page.goto('/workflow/new');
 		await openBuilderAndClickSuggestion(n8n, 'YouTube video chapters');
@@ -76,19 +77,23 @@ test.describe('Workflow Builder @auth:owner @ai @capability:proxy', () => {
 		await expect(n8n.page.getByRole('button', { name: 'Execute and refine' })).toBeVisible();
 	});
 
-	test('should display assistant messages during workflow generation', async ({ n8n }) => {
-		await n8n.page.goto('/workflow/new');
-		await openBuilderAndClickSuggestion(n8n, 'YouTube video chapters');
+	// suffers from the same issue as test above
+	test.fixme(
+		'should display assistant messages during workflow generation @fixme',
+		async ({ n8n }) => {
+			await n8n.page.goto('/workflow/new');
+			await openBuilderAndClickSuggestion(n8n, 'YouTube video chapters');
 
-		await expect(n8n.aiAssistant.getChatMessagesUser().first()).toBeVisible();
-		await n8n.aiAssistant.waitForStreamingComplete();
+			await expect(n8n.aiAssistant.getChatMessagesUser().first()).toBeVisible();
+			await n8n.aiAssistant.waitForStreamingComplete();
 
-		const assistantMessages = n8n.aiAssistant.getChatMessagesAssistant();
-		await expect(assistantMessages.first()).toBeVisible();
+			const assistantMessages = n8n.aiAssistant.getChatMessagesAssistant();
+			await expect(assistantMessages.first()).toBeVisible();
 
-		const messageCount = await assistantMessages.count();
-		expect(messageCount).toBeGreaterThan(0);
-	});
+			const messageCount = await assistantMessages.count();
+			expect(messageCount).toBeGreaterThan(0);
+		},
+	);
 
 	test('should stop workflow generation and show task aborted message', async ({ n8n }) => {
 		await n8n.page.goto('/workflow/new');


### PR DESCRIPTION
## Summary

There appears to be an issue with replaying of recorded events for the workflow builder - this needs investigation but for now disabling the tests causing problems.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
