### PR TITLE
feat(LmChatOpenAi Node): Update default model to gpt-5-mini

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
@@ -186,7 +186,7 @@ export class LmChatOpenAi implements INodeType {
 						property: 'model',
 					},
 				},
-				default: 'gpt-4o-mini',
+				default: 'gpt-5-mini',
 				displayOptions: {
 					hide: {
 						'@version': [{ _cnd: { gte: 1.2 } }],
@@ -197,7 +197,7 @@ export class LmChatOpenAi implements INodeType {
 				displayName: 'Model',
 				name: 'model',
 				type: 'resourceLocator',
-				default: { mode: 'list', value: 'gpt-4.1-mini' },
+				default: { mode: 'list', value: 'gpt-5-mini' },
 				required: true,
 				modes: [
 					{
@@ -214,7 +214,7 @@ export class LmChatOpenAi implements INodeType {
 						displayName: 'ID',
 						name: 'id',
 						type: 'string',
-						placeholder: 'gpt-4.1-mini',
+						placeholder: 'gpt-5-mini',
 					},
 				],
 				description: 'The model. Choose from the list, or specify an ID.',


### PR DESCRIPTION
## Summary
                                                                            
Updates the default OpenAI model in the LmChatOpenAi node from gpt-4.1-mini to gpt-5-mini, latest model with free credits                                          
                                                                            
## Changes:                                                                  
                                                                            
- Updated the default model value from gpt-4o-mini to gpt-5-mini (for versions < 1.2)                                                           
- Updated the resourceLocator default from gpt-4.1-mini to gpt-5-mini (for versions >= 1.2)                                                         
- Updated the placeholder text from gpt-4.1-mini to gpt-5-mini            

---
fixes: https://linear.app/n8n/issue/AI-1891/update-ai-workflow-builder-prompts-with-latest-openai-models as discussed in: https://n8nio.slack.com/archives/C07BV4T1P6Y/p1767795920504299