### PR TITLE
feat(ai-builder): Add per-stage model configuration for evaluations (no-changelog)

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/cli.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/cli.test.ts
@@ -14,6 +14,7 @@ import type { SimpleWorkflow } from '@/types/workflow';
 
 // Store mocks for dependencies
 const mockParseEvaluationArgs = jest.fn();
+const mockArgsToStageModels = jest.fn();
 const mockSetupTestEnvironment = jest.fn();
 const mockCreateAgent = jest.fn();
 const mockGenerateRunId = jest.fn();
@@ -30,6 +31,7 @@ const mockCreatePairwiseEvaluator = jest.fn();
 // Mock all external modules
 jest.mock('../cli/argument-parser', () => ({
 	parseEvaluationArgs: (): unknown => mockParseEvaluationArgs(),
+	argsToStageModels: (...args: unknown[]): unknown => mockArgsToStageModels(...args),
 	getDefaultDatasetName: (suite: unknown): unknown =>
 		suite === 'pairwise' ? 'notion-pairwise-workflows' : 'workflow-builder-canvas-prompts',
 	getDefaultExperimentName: (suite: unknown): unknown =>
@@ -98,9 +100,19 @@ function createMockArgs(overrides: Record<string, unknown> = {}) {
 
 /** Helper to create mock environment */
 function createMockEnvironment() {
+	const mockLlm = mock<BaseChatModel>();
 	return {
 		parsedNodeTypes: [] as INodeTypeDescription[],
-		llm: mock<BaseChatModel>(),
+		llms: {
+			default: mockLlm,
+			supervisor: mockLlm,
+			responder: mockLlm,
+			discovery: mockLlm,
+			builder: mockLlm,
+			configurator: mockLlm,
+			parameterUpdater: mockLlm,
+			judge: mockLlm,
+		},
 		lsClient: mock<Client>(),
 	};
 }
@@ -147,6 +159,7 @@ describe('CLI', () => {
 
 		// Setup default mocks
 		mockParseEvaluationArgs.mockReturnValue(createMockArgs());
+		mockArgsToStageModels.mockReturnValue({ default: 'claude-sonnet-4.5' });
 		mockSetupTestEnvironment.mockResolvedValue(createMockEnvironment());
 		mockCreateAgent.mockReturnValue(createMockAgentInstance());
 		mockGenerateRunId.mockReturnValue('test-run-id');

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/runner-langsmith.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/runner-langsmith.test.ts
@@ -174,7 +174,8 @@ describe('Runner - LangSmith Mode', () => {
 			expect(isLangsmithTargetOutput(result)).toBe(true);
 			if (!isLangsmithTargetOutput(result)) throw new Error('Expected LangSmith target output');
 
-			expect(generateWorkflow).toHaveBeenCalledWith('Create a workflow');
+			// Callbacks are passed explicitly from the traceable wrapper (undefined in tests without traceable context)
+			expect(generateWorkflow).toHaveBeenCalledWith('Create a workflow', undefined);
 			expect(evaluator.evaluate).toHaveBeenCalledWith(
 				workflow,
 				expect.objectContaining({ prompt: 'Create a workflow' }),

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/argument-parser.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/argument-parser.ts
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { z } from 'zod';
 
-import { AVAILABLE_MODELS, DEFAULT_MODEL, type ModelId } from '../../src/llm-config.js';
-import type { BuilderFeatureFlags } from '../../src/workflow-builder-agent.js';
+import { AVAILABLE_MODELS, DEFAULT_MODEL, type ModelId } from '@/llm-config';
+import type { BuilderFeatureFlags } from '@/workflow-builder-agent';
+
 import type { LangsmithExampleFilters } from '../harness/harness-types';
 import { DEFAULTS } from '../support/constants';
 import type { StageModels } from '../support/environment.js';

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/argument-parser.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/argument-parser.ts
@@ -1,9 +1,11 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { z } from 'zod';
 
+import { AVAILABLE_MODELS, DEFAULT_MODEL, type ModelId } from '../../src/llm-config.js';
 import type { BuilderFeatureFlags } from '../../src/workflow-builder-agent.js';
 import type { LangsmithExampleFilters } from '../harness/harness-types';
 import { DEFAULTS } from '../support/constants';
+import type { StageModels } from '../support/environment.js';
 
 export type EvaluationSuite = 'llm-judge' | 'pairwise' | 'programmatic' | 'similarity';
 export type EvaluationBackend = 'local' | 'langsmith';
@@ -32,10 +34,39 @@ export interface EvaluationArgs {
 	numJudges: number;
 
 	featureFlags?: BuilderFeatureFlags;
+
+	// Model configuration
+	/** Default model for all stages */
+	model: ModelId;
+	/** Model for LLM judge evaluation */
+	judgeModel?: ModelId;
+	/** Model for supervisor stage */
+	supervisorModel?: ModelId;
+	/** Model for responder stage */
+	responderModel?: ModelId;
+	/** Model for discovery stage */
+	discoveryModel?: ModelId;
+	/** Model for builder stage */
+	builderModel?: ModelId;
+	/** Model for configurator stage */
+	configuratorModel?: ModelId;
+	/** Model for parameter updater (within configurator) */
+	parameterUpdaterModel?: ModelId;
 }
 
 type CliValueKind = 'boolean' | 'string';
-type FlagGroup = 'input' | 'eval' | 'pairwise' | 'langsmith' | 'output' | 'feature' | 'advanced';
+type FlagGroup =
+	| 'input'
+	| 'eval'
+	| 'pairwise'
+	| 'langsmith'
+	| 'output'
+	| 'feature'
+	| 'model'
+	| 'advanced';
+
+// Model ID validation schema
+const modelIdSchema = z.enum(AVAILABLE_MODELS as [ModelId, ...ModelId[]]);
 
 const cliSchema = z
 	.object({
@@ -65,6 +96,16 @@ const cliSchema = z
 
 		langsmith: z.boolean().optional(),
 		templateExamples: z.boolean().default(false),
+
+		// Model configuration
+		model: modelIdSchema.default(DEFAULT_MODEL),
+		judgeModel: modelIdSchema.optional(),
+		supervisorModel: modelIdSchema.optional(),
+		responderModel: modelIdSchema.optional(),
+		discoveryModel: modelIdSchema.optional(),
+		builderModel: modelIdSchema.optional(),
+		configuratorModel: modelIdSchema.optional(),
+		parameterUpdaterModel: modelIdSchema.optional(),
 	})
 	.strict();
 
@@ -185,6 +226,56 @@ const FLAG_DEFS: Record<string, FlagDef> = {
 		desc: 'Enable template examples phase',
 	},
 
+	// Model configuration
+	'--model': {
+		key: 'model',
+		kind: 'string',
+		group: 'model',
+		desc: `Default model for all stages (default: ${DEFAULT_MODEL})`,
+	},
+	'--judge-model': {
+		key: 'judgeModel',
+		kind: 'string',
+		group: 'model',
+		desc: 'Model for LLM judge evaluation',
+	},
+	'--supervisor-model': {
+		key: 'supervisorModel',
+		kind: 'string',
+		group: 'model',
+		desc: 'Model for supervisor stage',
+	},
+	'--responder-model': {
+		key: 'responderModel',
+		kind: 'string',
+		group: 'model',
+		desc: 'Model for responder stage',
+	},
+	'--discovery-model': {
+		key: 'discoveryModel',
+		kind: 'string',
+		group: 'model',
+		desc: 'Model for discovery stage',
+	},
+	'--builder-model': {
+		key: 'builderModel',
+		kind: 'string',
+		group: 'model',
+		desc: 'Model for builder stage',
+	},
+	'--configurator-model': {
+		key: 'configuratorModel',
+		kind: 'string',
+		group: 'model',
+		desc: 'Model for configurator stage',
+	},
+	'--parameter-updater-model': {
+		key: 'parameterUpdaterModel',
+		kind: 'string',
+		group: 'model',
+		desc: 'Model for parameter updater',
+	},
+
 	// Advanced
 	'--judges': { key: 'numJudges', kind: 'string', group: 'advanced', desc: 'Number of LLM judges' },
 };
@@ -217,6 +308,7 @@ const GROUP_TITLES: Record<FlagGroup, string> = {
 	langsmith: 'LangSmith Options',
 	output: 'Output',
 	feature: 'Feature Flags',
+	model: 'Model Configuration',
 	advanced: 'Advanced',
 };
 
@@ -235,6 +327,7 @@ function formatHelp(): string {
 		'langsmith',
 		'output',
 		'feature',
+		'model',
 		'advanced',
 	];
 
@@ -431,6 +524,31 @@ export function parseEvaluationArgs(argv: string[] = process.argv.slice(2)): Eva
 		donts: parsed.donts,
 		numJudges: parsed.numJudges,
 		featureFlags,
+		// Model configuration
+		model: parsed.model,
+		judgeModel: parsed.judgeModel,
+		supervisorModel: parsed.supervisorModel,
+		responderModel: parsed.responderModel,
+		discoveryModel: parsed.discoveryModel,
+		builderModel: parsed.builderModel,
+		configuratorModel: parsed.configuratorModel,
+		parameterUpdaterModel: parsed.parameterUpdaterModel,
+	};
+}
+
+/**
+ * Converts EvaluationArgs to StageModels for use with environment setup.
+ */
+export function argsToStageModels(args: EvaluationArgs): StageModels {
+	return {
+		default: args.model,
+		supervisor: args.supervisorModel,
+		responder: args.responderModel,
+		discovery: args.discoveryModel,
+		builder: args.builderModel,
+		configurator: args.configuratorModel,
+		parameterUpdater: args.parameterUpdaterModel,
+		judge: args.judgeModel,
 	};
 }
 

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
@@ -5,7 +5,6 @@
  * Can be run directly or used as a reference for custom setups.
  */
 
-import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import type { INodeTypeDescription } from 'n8n-workflow';
 import pLimit from 'p-limit';
 
@@ -13,6 +12,7 @@ import type { SimpleWorkflow } from '@/types/workflow';
 import type { BuilderFeatureFlags } from '@/workflow-builder-agent';
 
 import {
+	argsToStageModels,
 	getDefaultDatasetName,
 	getDefaultExperimentName,
 	parseEvaluationArgs,
@@ -42,7 +42,7 @@ import {
 import { createLogger } from '../harness/logger';
 import { generateRunId, isWorkflowStateValues } from '../langsmith/types';
 import { EVAL_TYPES, EVAL_USERS } from '../support/constants';
-import { setupTestEnvironment, createAgent } from '../support/environment';
+import { setupTestEnvironment, createAgent, type ResolvedStageLLMs } from '../support/environment';
 
 /**
  * Create a workflow generator function.
@@ -51,7 +51,7 @@ import { setupTestEnvironment, createAgent } from '../support/environment';
  */
 function createWorkflowGenerator(
 	parsedNodeTypes: INodeTypeDescription[],
-	llm: BaseChatModel,
+	llms: ResolvedStageLLMs,
 	featureFlags?: BuilderFeatureFlags,
 ): (prompt: string) => Promise<SimpleWorkflow> {
 	return async (prompt: string): Promise<SimpleWorkflow> => {
@@ -60,7 +60,7 @@ function createWorkflowGenerator(
 
 		const agent = createAgent({
 			parsedNodeTypes,
-			llm,
+			llms,
 			featureFlags,
 		});
 
@@ -149,30 +149,35 @@ export async function runV2Evaluation(): Promise<void> {
 		);
 	}
 
-	// Setup environment
+	// Setup environment with per-stage model configuration
 	const logger = createLogger(args.verbose);
 	const lifecycle = createConsoleLifecycle({ verbose: args.verbose, logger });
-	const env = await setupTestEnvironment(logger);
+	const stageModels = argsToStageModels(args);
+	const env = await setupTestEnvironment(stageModels, logger);
 
 	// Validate LangSmith client early if langsmith backend is requested
 	if (args.backend === 'langsmith' && !env.lsClient) {
 		throw new Error('LangSmith client not initialized - check LANGSMITH_API_KEY');
 	}
 
-	// Create workflow generator (tracing handled via traceable() in runner)
-	const generateWorkflow = createWorkflowGenerator(env.parsedNodeTypes, env.llm, args.featureFlags);
+	// Create workflow generator with per-stage LLMs
+	const generateWorkflow = createWorkflowGenerator(
+		env.parsedNodeTypes,
+		env.llms,
+		args.featureFlags,
+	);
 
-	// Create evaluators based on mode
+	// Create evaluators based on mode (using judge LLM for evaluation)
 	const evaluators: Array<Evaluator<EvaluationContext>> = [];
 
 	switch (args.suite) {
 		case 'llm-judge':
-			evaluators.push(createLLMJudgeEvaluator(env.llm, env.parsedNodeTypes));
+			evaluators.push(createLLMJudgeEvaluator(env.llms.judge, env.parsedNodeTypes));
 			evaluators.push(createProgrammaticEvaluator(env.parsedNodeTypes));
 			break;
 		case 'pairwise':
 			evaluators.push(
-				createPairwiseEvaluator(env.llm, {
+				createPairwiseEvaluator(env.llms.judge, {
 					numJudges: args.numJudges,
 				}),
 			);

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/support/environment.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/support/environment.ts
@@ -5,7 +5,12 @@ import { Client } from 'langsmith/client';
 import type { INodeTypeDescription } from 'n8n-workflow';
 
 import { loadNodesFromFile } from './load-nodes.js';
-import { anthropicClaudeSonnet45 } from '../../src/llm-config.js';
+import {
+	DEFAULT_MODEL,
+	getApiKeyEnvVar,
+	MODEL_FACTORIES,
+	type ModelId,
+} from '../../src/llm-config.js';
 import type { BuilderFeatureFlags } from '../../src/workflow-builder-agent.js';
 import { WorkflowBuilderAgent } from '../../src/workflow-builder-agent.js';
 import type { EvalLogger } from '../harness/logger.js';
@@ -18,9 +23,52 @@ import {
 /** Maximum memory for trace queue (3GB) */
 const MAX_INGEST_MEMORY_BYTES = 3 * 1024 * 1024 * 1024;
 
+// ============================================================================
+// Stage Models Configuration
+// ============================================================================
+
+/**
+ * Configuration for per-stage model selection.
+ * All fields except 'default' are optional - unspecified stages use the default model.
+ */
+export interface StageModels {
+	/** Default model for all stages */
+	default: ModelId;
+	/** Model for supervisor stage (routing decisions) */
+	supervisor?: ModelId;
+	/** Model for responder stage (final user responses) */
+	responder?: ModelId;
+	/** Model for discovery stage (node discovery) */
+	discovery?: ModelId;
+	/** Model for builder stage (workflow structure) */
+	builder?: ModelId;
+	/** Model for configurator stage (node configuration) */
+	configurator?: ModelId;
+	/** Model for parameter updater (within configurator) */
+	parameterUpdater?: ModelId;
+	/** Model for LLM judge evaluation */
+	judge?: ModelId;
+}
+
+/**
+ * Resolved LLM instances for each stage.
+ * All fields are populated (using default model as fallback).
+ */
+export interface ResolvedStageLLMs {
+	default: BaseChatModel;
+	supervisor: BaseChatModel;
+	responder: BaseChatModel;
+	discovery: BaseChatModel;
+	builder: BaseChatModel;
+	configurator: BaseChatModel;
+	parameterUpdater: BaseChatModel;
+	judge: BaseChatModel;
+}
+
 export interface TestEnvironment {
 	parsedNodeTypes: INodeTypeDescription[];
-	llm: BaseChatModel;
+	/** Resolved LLM instances for each stage */
+	llms: ResolvedStageLLMs;
 	tracer?: LangChainTracer;
 	lsClient?: Client;
 	/** Trace filtering utilities (only present when minimal tracing is enabled) */
@@ -28,16 +76,48 @@ export interface TestEnvironment {
 }
 
 /**
- * Sets up the LLM with proper configuration
+ * Sets up an LLM with proper configuration
+ * @param modelId - Model identifier (defaults to DEFAULT_MODEL)
  * @returns Configured LLM instance
- * @throws Error if N8N_AI_ANTHROPIC_KEY environment variable is not set
+ * @throws Error if the required API key environment variable is not set
  */
-export async function setupLLM(): Promise<BaseChatModel> {
-	const apiKey = process.env.N8N_AI_ANTHROPIC_KEY;
+export async function setupLLM(modelId: ModelId = DEFAULT_MODEL): Promise<BaseChatModel> {
+	const envVar = getApiKeyEnvVar(modelId);
+	const apiKey = process.env[envVar];
 	if (!apiKey) {
-		throw new Error('N8N_AI_ANTHROPIC_KEY environment variable is required');
+		throw new Error(`${envVar} environment variable is required for model ${modelId}`);
 	}
-	return await anthropicClaudeSonnet45({ apiKey });
+	const factory = MODEL_FACTORIES[modelId];
+	return await factory({ apiKey });
+}
+
+/**
+ * Resolves all stage models to LLM instances.
+ * Unspecified stages fall back to the default model.
+ * @param stageModels - Per-stage model configuration
+ * @returns Resolved LLM instances for each stage
+ */
+export async function resolveStageModels(stageModels: StageModels): Promise<ResolvedStageLLMs> {
+	const defaultLLM = await setupLLM(stageModels.default);
+
+	// For stages without specific model, use default
+	// For parameter updater, fall back to configurator if not specified
+	const configuratorLLM = stageModels.configurator
+		? await setupLLM(stageModels.configurator)
+		: defaultLLM;
+
+	return {
+		default: defaultLLM,
+		supervisor: stageModels.supervisor ? await setupLLM(stageModels.supervisor) : defaultLLM,
+		responder: stageModels.responder ? await setupLLM(stageModels.responder) : defaultLLM,
+		discovery: stageModels.discovery ? await setupLLM(stageModels.discovery) : defaultLLM,
+		builder: stageModels.builder ? await setupLLM(stageModels.builder) : defaultLLM,
+		configurator: configuratorLLM,
+		parameterUpdater: stageModels.parameterUpdater
+			? await setupLLM(stageModels.parameterUpdater)
+			: configuratorLLM,
+		judge: stageModels.judge ? await setupLLM(stageModels.judge) : defaultLLM,
+	};
 }
 
 /**
@@ -97,24 +177,39 @@ export function createLangsmithClient(logger?: EvalLogger): LangsmithClientResul
 
 /**
  * Sets up the test environment with LLM, nodes, and tracing
+ * @param stageModels - Per-stage model configuration (optional, uses default model if not provided)
  * @param logger - Optional logger for trace filter output
  * @returns Test environment configuration
  */
-export async function setupTestEnvironment(logger?: EvalLogger): Promise<TestEnvironment> {
+export async function setupTestEnvironment(
+	stageModels?: StageModels,
+	logger?: EvalLogger,
+): Promise<TestEnvironment> {
 	const parsedNodeTypes = loadNodesFromFile();
-	const llm = await setupLLM();
+
+	// Use provided stage models or default configuration
+	const models: StageModels = stageModels ?? { default: DEFAULT_MODEL };
+	const llms = await resolveStageModels(models);
+
 	const lsClientResult = createLangsmithClient(logger);
 
 	const lsClient = lsClientResult?.client;
 	const traceFilters = lsClientResult?.traceFilters;
 	const tracer = lsClient ? createTracer(lsClient, 'workflow-builder-evaluation') : undefined;
 
-	return { parsedNodeTypes, llm, tracer, lsClient, traceFilters };
+	return {
+		parsedNodeTypes,
+		llms,
+		tracer,
+		lsClient,
+		traceFilters,
+	};
 }
 
 export interface CreateAgentOptions {
 	parsedNodeTypes: INodeTypeDescription[];
-	llm: BaseChatModel;
+	/** Per-stage LLMs resolved from model configuration */
+	llms: ResolvedStageLLMs;
 	tracer?: LangChainTracer;
 	featureFlags?: BuilderFeatureFlags;
 	experimentName?: string;
@@ -126,12 +221,18 @@ export interface CreateAgentOptions {
  * @returns Configured WorkflowBuilderAgent
  */
 export function createAgent(options: CreateAgentOptions): WorkflowBuilderAgent {
-	const { parsedNodeTypes, llm, tracer, featureFlags, experimentName } = options;
+	const { parsedNodeTypes, llms, tracer, featureFlags, experimentName } = options;
 
 	return new WorkflowBuilderAgent({
 		parsedNodeTypes,
-		llmSimpleTask: llm,
-		llmComplexTask: llm,
+		stageLLMs: {
+			supervisor: llms.supervisor,
+			responder: llms.responder,
+			discovery: llms.discovery,
+			builder: llms.builder,
+			configurator: llms.configurator,
+			parameterUpdater: llms.parameterUpdater,
+		},
 		checkpointer: new MemorySaver(),
 		tracer,
 		featureFlags,

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/support/environment.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/support/environment.ts
@@ -4,15 +4,11 @@ import { MemorySaver } from '@langchain/langgraph';
 import { Client } from 'langsmith/client';
 import type { INodeTypeDescription } from 'n8n-workflow';
 
+import { DEFAULT_MODEL, getApiKeyEnvVar, MODEL_FACTORIES, type ModelId } from '@/llm-config';
+import type { BuilderFeatureFlags } from '@/workflow-builder-agent';
+import { WorkflowBuilderAgent } from '@/workflow-builder-agent';
+
 import { loadNodesFromFile } from './load-nodes.js';
-import {
-	DEFAULT_MODEL,
-	getApiKeyEnvVar,
-	MODEL_FACTORIES,
-	type ModelId,
-} from '../../src/llm-config.js';
-import type { BuilderFeatureFlags } from '../../src/workflow-builder-agent.js';
-import { WorkflowBuilderAgent } from '../../src/workflow-builder-agent.js';
 import type { EvalLogger } from '../harness/logger.js';
 import {
 	createTraceFilters,

--- a/packages/@n8n/ai-workflow-builder.ee/src/agents/responder.agent.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/agents/responder.agent.ts
@@ -1,6 +1,6 @@
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
-import type { AIMessage, BaseMessage } from '@langchain/core/messages';
-import { HumanMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
 import { ChatPromptTemplate } from '@langchain/core/prompts';
 import type { RunnableConfig } from '@langchain/core/runnables';
 
@@ -13,6 +13,7 @@ import {
 
 import type { CoordinationLogEntry } from '../types/coordination';
 import type { DiscoveryContext } from '../types/discovery-types';
+import { isAIMessage } from '../types/langchain';
 import type { SimpleWorkflow } from '../types/workflow';
 import {
 	getErrorEntry,
@@ -162,6 +163,12 @@ export class ResponderAgent {
 			? [...context.messages, contextMessage]
 			: context.messages;
 
-		return (await agent.invoke({ messages: messagesToSend }, config)) as AIMessage;
+		const result = await agent.invoke({ messages: messagesToSend }, config);
+		if (!isAIMessage(result)) {
+			return new AIMessage({
+				content: 'I encountered an issue generating a response. Please try again.',
+			});
+		}
+		return result;
 	}
 }

--- a/packages/@n8n/ai-workflow-builder.ee/src/agents/responder.agent.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/agents/responder.agent.ts
@@ -2,6 +2,7 @@ import type { BaseChatModel } from '@langchain/core/language_models/chat_models'
 import type { AIMessage, BaseMessage } from '@langchain/core/messages';
 import { HumanMessage } from '@langchain/core/messages';
 import { ChatPromptTemplate } from '@langchain/core/prompts';
+import type { RunnableConfig } from '@langchain/core/runnables';
 
 import {
 	buildResponderPrompt,
@@ -150,8 +151,10 @@ export class ResponderAgent {
 
 	/**
 	 * Invoke the responder agent with the given context
+	 * @param context - Responder context with messages and workflow state
+	 * @param config - Optional RunnableConfig for tracing callbacks
 	 */
-	async invoke(context: ResponderContext): Promise<AIMessage> {
+	async invoke(context: ResponderContext, config?: RunnableConfig): Promise<AIMessage> {
 		const agent = systemPrompt.pipe(this.llm);
 
 		const contextMessage = this.buildContextMessage(context);
@@ -159,6 +162,6 @@ export class ResponderAgent {
 			? [...context.messages, contextMessage]
 			: context.messages;
 
-		return (await agent.invoke({ messages: messagesToSend })) as AIMessage;
+		return (await agent.invoke({ messages: messagesToSend }, config)) as AIMessage;
 	}
 }

--- a/packages/@n8n/ai-workflow-builder.ee/src/agents/supervisor.agent.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/agents/supervisor.agent.ts
@@ -2,6 +2,7 @@ import type { BaseChatModel } from '@langchain/core/language_models/chat_models'
 import type { BaseMessage } from '@langchain/core/messages';
 import { HumanMessage } from '@langchain/core/messages';
 import { ChatPromptTemplate } from '@langchain/core/prompts';
+import type { RunnableConfig } from '@langchain/core/runnables';
 import { z } from 'zod';
 
 import { buildSupervisorPrompt } from '@/prompts/agents/supervisor.prompt';
@@ -104,8 +105,10 @@ export class SupervisorAgent {
 
 	/**
 	 * Invoke the supervisor to get routing decision
+	 * @param context - Supervisor context with messages and workflow state
+	 * @param config - Optional RunnableConfig for tracing callbacks
 	 */
-	async invoke(context: SupervisorContext): Promise<SupervisorRouting> {
+	async invoke(context: SupervisorContext, config?: RunnableConfig): Promise<SupervisorRouting> {
 		const agent = systemPrompt.pipe<SupervisorRouting>(
 			this.llm.withStructuredOutput(supervisorRoutingSchema, {
 				name: 'routing_decision',
@@ -117,6 +120,6 @@ export class SupervisorAgent {
 			? [...context.messages, contextMessage]
 			: context.messages;
 
-		return await agent.invoke({ messages: messagesToSend });
+		return await agent.invoke({ messages: messagesToSend }, config);
 	}
 }

--- a/packages/@n8n/ai-workflow-builder.ee/src/ai-workflow-builder-agent.service.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/ai-workflow-builder-agent.service.ts
@@ -169,9 +169,15 @@ export class AiWorkflowBuilderService {
 
 		const agent = new WorkflowBuilderAgent({
 			parsedNodeTypes: this.parsedNodeTypes,
-			// We use Sonnet both for simple and complex tasks
-			llmSimpleTask: anthropicClaude,
-			llmComplexTask: anthropicClaude,
+			// Use the same model for all stages in production
+			stageLLMs: {
+				supervisor: anthropicClaude,
+				responder: anthropicClaude,
+				discovery: anthropicClaude,
+				builder: anthropicClaude,
+				configurator: anthropicClaude,
+				parameterUpdater: anthropicClaude,
+			},
 			logger: this.logger,
 			checkpointer: this.sessionManager.getCheckpointer(),
 			tracer: tracingClient

--- a/packages/@n8n/ai-workflow-builder.ee/src/chains/conversation-compact.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/chains/conversation-compact.ts
@@ -1,6 +1,7 @@
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import type { BaseMessage } from '@langchain/core/messages';
 import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import type { RunnableConfig } from '@langchain/core/runnables';
 import z from 'zod';
 
 import { compactPromptTemplate } from '@/prompts/chains/compact.prompt';
@@ -9,6 +10,7 @@ export async function conversationCompactChain(
 	llm: BaseChatModel,
 	messages: BaseMessage[],
 	previousSummary: string = '',
+	config?: RunnableConfig,
 ) {
 	// Use structured output for consistent summary format
 	const CompactedSession = z.object({
@@ -44,7 +46,7 @@ export async function conversationCompactChain(
 		conversationText,
 	});
 
-	const structuredOutput = await modelWithStructure.invoke(compactPrompt);
+	const structuredOutput = await modelWithStructure.invoke(compactPrompt, config);
 
 	const formattedSummary = `## Previous Conversation Summary
 

--- a/packages/@n8n/ai-workflow-builder.ee/src/chains/workflow-name.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/chains/workflow-name.ts
@@ -1,9 +1,14 @@
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
+import type { RunnableConfig } from '@langchain/core/runnables';
 import z from 'zod';
 
 import { workflowNamingPromptTemplate } from '@/prompts/chains/workflow-name.prompt';
 
-export async function workflowNameChain(llm: BaseChatModel, initialPrompt: string) {
+export async function workflowNameChain(
+	llm: BaseChatModel,
+	initialPrompt: string,
+	config?: RunnableConfig,
+) {
 	// Use structured output for the workflow name to ensure it meets the required format and length
 	const nameSchema = z.object({
 		name: z.string().min(10).max(128).describe('Name of the workflow based on the prompt'),
@@ -15,7 +20,9 @@ export async function workflowNameChain(llm: BaseChatModel, initialPrompt: strin
 		initialPrompt,
 	});
 
-	const structuredOutput = (await modelWithStructure.invoke(prompt)) as z.infer<typeof nameSchema>;
+	const structuredOutput = (await modelWithStructure.invoke(prompt, config)) as z.infer<
+		typeof nameSchema
+	>;
 
 	return {
 		name: structuredOutput.name,

--- a/packages/@n8n/ai-workflow-builder.ee/src/chains/workflow-name.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/chains/workflow-name.ts
@@ -20,9 +20,8 @@ export async function workflowNameChain(
 		initialPrompt,
 	});
 
-	const structuredOutput = (await modelWithStructure.invoke(prompt, config)) as z.infer<
-		typeof nameSchema
-	>;
+	const rawOutput = await modelWithStructure.invoke(prompt, config);
+	const structuredOutput = nameSchema.parse(rawOutput);
 
 	return {
 		name: structuredOutput.name,

--- a/packages/@n8n/ai-workflow-builder.ee/src/llm-config.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/llm-config.ts
@@ -177,6 +177,20 @@ export const minimaxM21 = createOpenRouterModel('minimax/minimax-m1');
 // ============================================================================
 
 /**
+ * IMPORTANT: Generation stages currently only support Anthropic models.
+ *
+ * Non-Anthropic models (OpenAI, OpenRouter) are available for evaluation/judging
+ * purposes only. Using them for generation stages (supervisor, discovery, builder,
+ * configurator, responder, parameterUpdater) will likely fail due to:
+ *
+ * 1. Prompt caching: Our prompts use Anthropic's cache_control for efficiency
+ * 2. Tool schemas: add_nodes and update_parameters tools use passthrough() schemas
+ *    which only Anthropic models handle correctly
+ *
+ * TODO: Add provider-agnostic prompt/tool support to enable non-Anthropic generation.
+ */
+
+/**
  * Available model identifiers for the eval CLI.
  * These can be used with --model, --judge-model, and per-stage model flags.
  */

--- a/packages/@n8n/ai-workflow-builder.ee/src/llm-config.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/llm-config.ts
@@ -14,44 +14,12 @@ export interface LLMProviderConfig {
 	headers?: Record<string, string>;
 }
 
-export const o4mini = async (config: LLMProviderConfig) => {
+export const gpt52 = async (config: LLMProviderConfig) => {
 	const { ChatOpenAI } = await import('@langchain/openai');
 	return new ChatOpenAI({
-		model: 'o4-mini-2025-04-16',
-		apiKey: config.apiKey,
-		configuration: {
-			baseURL: config.baseUrl,
-			defaultHeaders: config.headers,
-			fetchOptions: {
-				dispatcher: getProxyAgent(config.baseUrl ?? 'https://api.openai.com/v1'),
-			},
-		},
-	});
-};
-
-export const gpt41mini = async (config: LLMProviderConfig) => {
-	const { ChatOpenAI } = await import('@langchain/openai');
-	return new ChatOpenAI({
-		model: 'gpt-4.1-mini-2025-04-14',
+		model: 'gpt-5.2-2025-12-11',
 		apiKey: config.apiKey,
 		temperature: 0,
-		maxTokens: -1,
-		configuration: {
-			baseURL: config.baseUrl,
-			defaultHeaders: config.headers,
-			fetchOptions: {
-				dispatcher: getProxyAgent(config.baseUrl ?? 'https://api.openai.com/v1'),
-			},
-		},
-	});
-};
-
-export const gpt41 = async (config: LLMProviderConfig) => {
-	const { ChatOpenAI } = await import('@langchain/openai');
-	return new ChatOpenAI({
-		model: 'gpt-4.1-2025-04-14',
-		apiKey: config.apiKey,
-		temperature: 0.3,
 		maxTokens: -1,
 		configuration: {
 			baseURL: config.baseUrl,
@@ -164,13 +132,10 @@ function createOpenRouterModel(modelName: string) {
 
 // OpenRouter model factories
 export const glm47 = createOpenRouterModel('thudm/glm-4-plus');
-export const grokCodeFast = createOpenRouterModel('x-ai/grok-3-fast');
-export const gemini3Flash = createOpenRouterModel('google/gemini-2.5-flash-preview');
+export const gemini3Flash = createOpenRouterModel('google/gemini-3-flash-preview');
 export const deepseekV32 = createOpenRouterModel('deepseek/deepseek-chat-v3-0324');
-export const grok41Fast = createOpenRouterModel('x-ai/grok-3-mini-fast');
-export const gemini3Pro = createOpenRouterModel('google/gemini-2.5-pro-preview');
+export const gemini3Pro = createOpenRouterModel('google/gemini-3-pro-preview');
 export const devstral = createOpenRouterModel('mistralai/devstral-small');
-export const minimaxM21 = createOpenRouterModel('minimax/minimax-m1');
 
 // ============================================================================
 // Model Registry
@@ -199,18 +164,13 @@ export type ModelId =
 	| 'claude-opus-4.5'
 	| 'claude-sonnet-4.5'
 	| 'claude-haiku-4.5'
-	| 'gpt-4.1'
-	| 'gpt-4.1-mini'
-	| 'o4-mini'
+	| 'gpt-5.2'
 	// OpenRouter models
 	| 'glm-4.7'
-	| 'grok-code-fast'
 	| 'gemini-3-flash'
 	| 'deepseek-v3.2'
-	| 'grok-4.1-fast'
 	| 'gemini-3-pro'
-	| 'devstral'
-	| 'minimax-m2.1';
+	| 'devstral';
 
 /**
  * Model factory functions mapped by model ID.
@@ -223,30 +183,22 @@ export const MODEL_FACTORIES: Record<
 	'claude-opus-4.5': anthropicClaudeOpus45,
 	'claude-sonnet-4.5': anthropicClaudeSonnet45,
 	'claude-haiku-4.5': anthropicHaiku45,
-	'gpt-4.1': gpt41,
-	'gpt-4.1-mini': gpt41mini,
-	'o4-mini': o4mini,
+	'gpt-5.2': gpt52,
 	// OpenRouter models
 	'glm-4.7': glm47,
-	'grok-code-fast': grokCodeFast,
 	'gemini-3-flash': gemini3Flash,
 	'deepseek-v3.2': deepseekV32,
-	'grok-4.1-fast': grok41Fast,
 	'gemini-3-pro': gemini3Pro,
 	devstral,
-	'minimax-m2.1': minimaxM21,
 };
 
 /** OpenRouter model IDs for API key resolution */
 const OPENROUTER_MODELS: ModelId[] = [
 	'glm-4.7',
-	'grok-code-fast',
 	'gemini-3-flash',
 	'deepseek-v3.2',
-	'grok-4.1-fast',
 	'gemini-3-pro',
 	'devstral',
-	'minimax-m2.1',
 ];
 
 /**
@@ -256,7 +208,7 @@ export function getApiKeyEnvVar(modelId: ModelId): string {
 	if (OPENROUTER_MODELS.includes(modelId)) {
 		return 'OPENROUTER_API_KEY';
 	}
-	if (modelId.startsWith('gpt') || modelId.startsWith('o4')) {
+	if (modelId.startsWith('gpt')) {
 		return 'N8N_AI_OPENAI_KEY';
 	}
 	return 'N8N_AI_ANTHROPIC_KEY';
@@ -264,8 +216,21 @@ export function getApiKeyEnvVar(modelId: ModelId): string {
 
 /**
  * List of available model IDs for CLI help text.
+ * Explicitly defined to avoid type casting Object.keys().
  */
-export const AVAILABLE_MODELS: ModelId[] = Object.keys(MODEL_FACTORIES) as ModelId[];
+export const AVAILABLE_MODELS: readonly ModelId[] = [
+	// Native models
+	'claude-opus-4.5',
+	'claude-sonnet-4.5',
+	'claude-haiku-4.5',
+	'gpt-5.2',
+	// OpenRouter models
+	'glm-4.7',
+	'gemini-3-flash',
+	'deepseek-v3.2',
+	'gemini-3-pro',
+	'devstral',
+] as const;
 
 /**
  * Default model used when no model is specified.

--- a/packages/@n8n/ai-workflow-builder.ee/src/multi-agent-workflow-subgraphs.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/multi-agent-workflow-subgraphs.ts
@@ -1,4 +1,5 @@
 import { HumanMessage } from '@langchain/core/messages';
+import type { RunnableConfig } from '@langchain/core/runnables';
 import { StateGraph, END, START, type MemorySaver } from '@langchain/langgraph';
 import type { Logger } from '@n8n/backend-common';
 import type { INodeTypeDescription } from 'n8n-workflow';
@@ -59,7 +60,8 @@ export interface MultiAgentSubgraphConfig {
 }
 
 /**
- * Creates a subgraph node handler with standardized error handling
+ * Creates a subgraph node handler with standardized error handling.
+ * Accepts RunnableConfig as second parameter to propagate callbacks for tracing.
  */
 function createSubgraphNodeHandler<
 	TSubgraph extends BaseSubgraph<unknown, Record<string, unknown>, Record<string, unknown>>,
@@ -70,10 +72,15 @@ function createSubgraphNodeHandler<
 	logger?: Logger,
 	recursionLimit?: number,
 ) {
-	return async (state: typeof ParentGraphState.State) => {
+	return async (state: typeof ParentGraphState.State, config?: RunnableConfig) => {
 		try {
 			const input = subgraph.transformInput(state);
-			const result = await compiledGraph.invoke(input, { recursionLimit });
+			// Merge parent config (callbacks, metadata) with recursionLimit
+			const invokeConfig: RunnableConfig = {
+				...config,
+				recursionLimit,
+			};
+			const result = await compiledGraph.invoke(input, invokeConfig);
 			const output = subgraph.transformOutput(result, state);
 
 			return output;
@@ -164,27 +171,35 @@ export function createMultiAgentWorkflowWithSubgraphs(config: MultiAgentSubgraph
 	return (
 		new StateGraph(ParentGraphState)
 			// Add Supervisor Node (only used for initial routing)
-			.addNode('supervisor', async (state) => {
-				const routing = await supervisorAgent.invoke({
-					messages: state.messages,
-					workflowJSON: state.workflowJSON,
-					coordinationLog: state.coordinationLog,
-					previousSummary: state.previousSummary,
-				});
+			// Accepts config as second param to propagate callbacks for tracing
+			.addNode('supervisor', async (state, config) => {
+				const routing = await supervisorAgent.invoke(
+					{
+						messages: state.messages,
+						workflowJSON: state.workflowJSON,
+						coordinationLog: state.coordinationLog,
+						previousSummary: state.previousSummary,
+					},
+					config,
+				);
 
 				return {
 					nextPhase: routing.next,
 				};
 			})
 			// Add Responder Node (synthesizes final user-facing response)
-			.addNode('responder', async (state) => {
-				const response = await responderAgent.invoke({
-					messages: state.messages,
-					coordinationLog: state.coordinationLog,
-					discoveryContext: state.discoveryContext,
-					workflowJSON: state.workflowJSON,
-					previousSummary: state.previousSummary,
-				});
+			// Accepts config as second param to propagate callbacks for tracing
+			.addNode('responder', async (state, config) => {
+				const response = await responderAgent.invoke(
+					{
+						messages: state.messages,
+						coordinationLog: state.coordinationLog,
+						discoveryContext: state.discoveryContext,
+						workflowJSON: state.workflowJSON,
+						previousSummary: state.previousSummary,
+					},
+					config,
+				);
 
 				// Call success callback only when generation completed without errors
 				if (onGenerationSuccess && !hasErrorInLog(state.coordinationLog)) {
@@ -212,25 +227,27 @@ export function createMultiAgentWorkflowWithSubgraphs(config: MultiAgentSubgraph
 				nextPhase: determineStateAction(state, autoCompactThresholdTokens),
 			}))
 			.addNode('cleanup_dangling', (state) => handleCleanupDangling(state.messages, logger))
-			.addNode('compact_messages', async (state) => {
+			.addNode('compact_messages', async (state, config) => {
 				const isAutoCompact = state.messages[state.messages.length - 1]?.content !== '/compact';
 				return await handleCompactMessages(
 					state.messages,
 					state.previousSummary ?? '',
 					stageLLMs.responder,
 					isAutoCompact,
+					config,
 				);
 			})
 			.addNode('delete_messages', (state) => handleDeleteMessages(state.messages))
 			.addNode('clear_error_state', (state) => handleClearErrorState(state.coordinationLog, logger))
 			.addNode(
 				'create_workflow_name',
-				async (state) =>
+				async (state, config) =>
 					await handleCreateWorkflowName(
 						state.messages,
 						state.workflowJSON,
 						stageLLMs.responder,
 						logger,
+						config,
 					),
 			)
 			// Add Subgraph Nodes (using helper to reduce duplication)

--- a/packages/@n8n/ai-workflow-builder.ee/src/multi-agent-workflow-subgraphs.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/multi-agent-workflow-subgraphs.ts
@@ -1,4 +1,3 @@
-import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { HumanMessage } from '@langchain/core/messages';
 import { StateGraph, END, START, type MemorySaver } from '@langchain/langgraph';
 import type { Logger } from '@n8n/backend-common';
@@ -29,7 +28,7 @@ import {
 	handleCreateWorkflowName,
 	handleDeleteMessages,
 } from './utils/state-modifier';
-import type { BuilderFeatureFlags } from './workflow-builder-agent';
+import type { BuilderFeatureFlags, StageLLMs } from './workflow-builder-agent';
 
 /**
  * Maps routing decisions to graph node names.
@@ -47,8 +46,8 @@ function routeToNode(next: string): string {
 
 export interface MultiAgentSubgraphConfig {
 	parsedNodeTypes: INodeTypeDescription[];
-	llmSimpleTask: BaseChatModel;
-	llmComplexTask: BaseChatModel;
+	/** Per-stage LLM configuration */
+	stageLLMs: StageLLMs;
 	logger?: Logger;
 	instanceUrl?: string;
 	checkpointer?: MemorySaver;
@@ -122,7 +121,7 @@ function createSubgraphNodeHandler<
 export function createMultiAgentWorkflowWithSubgraphs(config: MultiAgentSubgraphConfig) {
 	const {
 		parsedNodeTypes,
-		llmComplexTask,
+		stageLLMs,
 		logger,
 		instanceUrl,
 		checkpointer,
@@ -131,30 +130,31 @@ export function createMultiAgentWorkflowWithSubgraphs(config: MultiAgentSubgraph
 		onGenerationSuccess,
 	} = config;
 
-	const supervisorAgent = new SupervisorAgent({ llm: llmComplexTask });
-	const responderAgent = new ResponderAgent({ llm: llmComplexTask });
+	const supervisorAgent = new SupervisorAgent({ llm: stageLLMs.supervisor });
+	const responderAgent = new ResponderAgent({ llm: stageLLMs.responder });
 
 	// Create subgraph instances
 	const discoverySubgraph = new DiscoverySubgraph();
 	const builderSubgraph = new BuilderSubgraph();
 	const configuratorSubgraph = new ConfiguratorSubgraph();
 
-	// Compile subgraphs
+	// Compile subgraphs with per-stage LLMs
 	const compiledDiscovery = discoverySubgraph.create({
 		parsedNodeTypes,
-		llm: llmComplexTask,
+		llm: stageLLMs.discovery,
 		logger,
 		featureFlags,
 	});
 	const compiledBuilder = builderSubgraph.create({
 		parsedNodeTypes,
-		llm: llmComplexTask,
+		llm: stageLLMs.builder,
 		logger,
 		featureFlags,
 	});
 	const compiledConfigurator = configuratorSubgraph.create({
 		parsedNodeTypes,
-		llm: llmComplexTask,
+		llm: stageLLMs.configurator,
+		llmParameterUpdater: stageLLMs.parameterUpdater,
 		logger,
 		instanceUrl,
 		featureFlags,
@@ -217,7 +217,7 @@ export function createMultiAgentWorkflowWithSubgraphs(config: MultiAgentSubgraph
 				return await handleCompactMessages(
 					state.messages,
 					state.previousSummary ?? '',
-					llmComplexTask,
+					stageLLMs.responder,
 					isAutoCompact,
 				);
 			})
@@ -229,7 +229,7 @@ export function createMultiAgentWorkflowWithSubgraphs(config: MultiAgentSubgraph
 					await handleCreateWorkflowName(
 						state.messages,
 						state.workflowJSON,
-						llmComplexTask,
+						stageLLMs.responder,
 						logger,
 					),
 			)

--- a/packages/@n8n/ai-workflow-builder.ee/src/subgraphs/configurator.subgraph.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/subgraphs/configurator.subgraph.ts
@@ -100,6 +100,8 @@ export const ConfiguratorSubgraphState = Annotation.Root({
 export interface ConfiguratorSubgraphConfig {
 	parsedNodeTypes: INodeTypeDescription[];
 	llm: BaseChatModel;
+	/** Separate LLM for parameter updater chain (defaults to llm if not provided) */
+	llmParameterUpdater?: BaseChatModel;
 	logger?: Logger;
 	instanceUrl?: string;
 	featureFlags?: BuilderFeatureFlags;
@@ -123,11 +125,14 @@ export class ConfiguratorSubgraph extends BaseSubgraph<
 		// Check if template examples are enabled
 		const includeExamples = config.featureFlags?.templateExamples === true;
 
+		// Use separate LLM for parameter updater if provided
+		const parameterUpdaterLLM = config.llmParameterUpdater ?? config.llm;
+
 		// Create base tools
 		const baseTools = [
 			createUpdateNodeParametersTool(
 				config.parsedNodeTypes,
-				config.llm, // Uses same LLM for parameter updater chain
+				parameterUpdaterLLM, // Uses separate LLM for parameter updater chain
 				config.logger,
 				config.instanceUrl,
 			),

--- a/packages/@n8n/ai-workflow-builder.ee/src/subgraphs/test/integration/multi-agent-error-handling.integration.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/subgraphs/test/integration/multi-agent-error-handling.integration.test.ts
@@ -110,8 +110,14 @@ describe('Multi-Agent Error Handling - Integration Tests (AI-1812)', () => {
 			// Don't use checkpointer for this test - we're just testing error message
 			const graph = createMultiAgentWorkflowWithSubgraphs({
 				parsedNodeTypes,
-				llmSimpleTask: llm,
-				llmComplexTask: llm,
+				stageLLMs: {
+					supervisor: llm,
+					responder: llm,
+					discovery: llm,
+					builder: llm,
+					configurator: llm,
+					parameterUpdater: llm,
+				},
 				logger: mockLogger,
 			});
 

--- a/packages/@n8n/ai-workflow-builder.ee/src/test/workflow-builder-agent.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/test/workflow-builder-agent.test.ts
@@ -56,8 +56,7 @@ import {
 
 describe('WorkflowBuilderAgent', () => {
 	let agent: WorkflowBuilderAgent;
-	let mockLlmSimple: BaseChatModel;
-	let mockLlmComplex: BaseChatModel;
+	let mockLlm: BaseChatModel;
 	let mockLogger: Logger;
 	let mockCheckpointer: MemorySaver;
 	let parsedNodeTypes: INodeTypeDescription[];
@@ -68,14 +67,8 @@ describe('WorkflowBuilderAgent', () => {
 	>;
 
 	beforeEach(() => {
-		mockLlmSimple = mock<BaseChatModel>({
+		mockLlm = mock<BaseChatModel>({
 			_llmType: jest.fn().mockReturnValue('test-llm'),
-			bindTools: jest.fn().mockReturnThis(),
-			invoke: jest.fn(),
-		});
-
-		mockLlmComplex = mock<BaseChatModel>({
-			_llmType: jest.fn().mockReturnValue('test-llm-complex'),
 			bindTools: jest.fn().mockReturnThis(),
 			invoke: jest.fn(),
 		});
@@ -108,8 +101,14 @@ describe('WorkflowBuilderAgent', () => {
 
 		config = {
 			parsedNodeTypes,
-			llmSimpleTask: mockLlmSimple,
-			llmComplexTask: mockLlmComplex,
+			stageLLMs: {
+				supervisor: mockLlm,
+				responder: mockLlm,
+				discovery: mockLlm,
+				builder: mockLlm,
+				configurator: mockLlm,
+				parameterUpdater: mockLlm,
+			},
 			logger: mockLogger,
 			checkpointer: mockCheckpointer,
 		};
@@ -172,7 +171,7 @@ describe('WorkflowBuilderAgent', () => {
 			mockCreateStreamProcessor.mockReturnValue(mockAsyncGenerator);
 
 			// Mock the LLM to return a simple response
-			(mockLlmSimple.invoke as jest.Mock).mockResolvedValue({
+			(mockLlm.invoke as jest.Mock).mockResolvedValue({
 				content: 'Mocked response',
 				tool_calls: [],
 			});


### PR DESCRIPTION
## Summary

Add per-stage custom model support for AI workflow builder evaluations. This allows running evaluations with different LLM models for each stage of the multi-agent workflow.

## Changes

### New CLI Flags

```bash
# Default model for all stages
pnpm eval --model claude-sonnet-4.5 --prompt "Create a Slack workflow"

# Mix models per stage
pnpm eval \
  --model claude-sonnet-4.5 \
  --builder-model claude-opus-4.5 \
  --judge-model gpt-4.1 \
  --prompt "..."
```

| Flag | Description |
|------|-------------|
| `--model` | Default model for all stages (default: `claude-sonnet-4.5`) |
| `--judge-model` | Model for LLM judge evaluation |
| `--supervisor-model` | Model for supervisor stage (routing) |
| `--responder-model` | Model for responder stage (user responses) |
| `--discovery-model` | Model for discovery stage (node discovery) |
| `--builder-model` | Model for builder stage (workflow structure) |
| `--configurator-model` | Model for configurator stage (node params) |
| `--parameter-updater-model` | Model for parameter updater chain |

### Simplified LLM Configuration

Replaced `llmSimpleTask` and `llmComplexTask` with a single required `stageLLMs` interface:

```typescript
// Before
interface WorkflowBuilderAgentConfig {
  llmSimpleTask: BaseChatModel;
  llmComplexTask: BaseChatModel;
  stageLLMs?: StageLLMs; // optional overrides
}

// After
interface WorkflowBuilderAgentConfig {
  stageLLMs: StageLLMs; // required, all stages explicit
}

interface StageLLMs {
  supervisor: BaseChatModel;
  responder: BaseChatModel;
  discovery: BaseChatModel;
  builder: BaseChatModel;
  configurator: BaseChatModel;
  parameterUpdater: BaseChatModel;
}
```

### Limitations

> **Note:** Generation stages currently only support Anthropic models. Non-Anthropic models (OpenAI, OpenRouter) are available for evaluation/judging purposes only due to:
> 1. Prompt caching relies on Anthropic's `cache_control`
> 2. `add_nodes` and `update_parameters` tools use `passthrough()` schemas which only Anthropic handles correctly

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
