### PR TITLE
fix(ai-builder): Clarify with spec eval judge node type potential mis-matches (no-changelog)

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/pairwise/judge-chain.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/pairwise/judge-chain.ts
@@ -58,7 +58,12 @@ const EVALUATOR_SYSTEM_PROMPT = prompt()
 - Provider-specific nodes (e.g., n8n-nodes-langchain.openAi, n8n-nodes-langchain.anthropic) are standalone nodes that directly call a provider's API.
 - Chat model sub-nodes (e.g., @n8n/n8n-nodes-langchain.lmChatAnthropic, @n8n/n8n-nodes-langchain.lmChatOpenAi) are NOT provider-specific nodes. They are required infrastructure for connecting generic nodes like the AI Agent to a language model.
 
-If a criterion says "do not use provider-specific nodes" or similar, the presence of lmChat* sub-nodes should NOT count as a violation - these are necessary connectors, not provider-specific workflow nodes.`,
+If a criterion says "do not use provider-specific nodes" or similar, the presence of lmChat* sub-nodes should NOT count as a violation - these are necessary connectors, not provider-specific workflow nodes.
+
+When evaluating whether a specific node type has been used:
+- The "@n8n/" prefix in node types is OPTIONAL - ignore it when comparing
+- "@n8n/n8n-nodes-langchain.chatTrigger" and "n8n-nodes-langchain.chatTrigger" are the SAME node type
+- This applies regardless of which form appears in the criteria or the workflow`,
 	)
 	.section(
 		'constraints',


### PR DESCRIPTION
## Summary

The spec eval judge was incorrectly judging that "@n8n/n8n-nodes-langchain.chatTrigger" and "n8n-nodes-langchain.chatTrigger" are different node types when specified in the spec eval criteria. We should allow for shortening of the node types/a mismatch like this - clarifying with the judge that this is acceptable.

Addresses: https://linear.app/n8n/issue/AI-1929/bug-spec-eval-judge-gets-confused-about-precise-nodetype-match-with

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
