### PR TITLE
feat(core): Improve MCP server telemetry (no-changelog)

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/execute-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/execute-workflow.tool.test.ts
@@ -146,8 +146,8 @@ describe('execute-workflow MCP tool', () => {
 				(workflowRepository.findById as jest.Mock).mockResolvedValue(existingWorkflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(null);
 
-				try {
-					await executeWorkflow(
+				await expect(
+					executeWorkflow(
 						user,
 						workflowFinderService,
 						workflowRepository,
@@ -155,11 +155,10 @@ describe('execute-workflow MCP tool', () => {
 						workflowRunner,
 						'no-permission-workflow',
 						undefined,
-					);
-				} catch (error) {
-					expect(error).toBeInstanceOf(WorkflowAccessError);
-					expect((error as WorkflowAccessError).reason).toBe('no_permission');
-				}
+					),
+				).rejects.toMatchObject({
+					reason: 'no_permission',
+				});
 			});
 
 			test('throws error when workflow is archived', async () => {
@@ -197,8 +196,8 @@ describe('execute-workflow MCP tool', () => {
 				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 
-				try {
-					await executeWorkflow(
+				await expect(
+					executeWorkflow(
 						user,
 						workflowFinderService,
 						workflowRepository,
@@ -206,11 +205,10 @@ describe('execute-workflow MCP tool', () => {
 						workflowRunner,
 						'archived-workflow',
 						undefined,
-					);
-				} catch (error) {
-					expect(error).toBeInstanceOf(WorkflowAccessError);
-					expect((error as WorkflowAccessError).reason).toBe('workflow_archived');
-				}
+					),
+				).rejects.toMatchObject({
+					reason: 'workflow_archived',
+				});
 			});
 
 			test('throws error when workflow is not available in MCP', async () => {
@@ -242,8 +240,8 @@ describe('execute-workflow MCP tool', () => {
 				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 
-				try {
-					await executeWorkflow(
+				await expect(
+					executeWorkflow(
 						user,
 						workflowFinderService,
 						workflowRepository,
@@ -251,11 +249,10 @@ describe('execute-workflow MCP tool', () => {
 						workflowRunner,
 						'unavailable-workflow',
 						undefined,
-					);
-				} catch (error) {
-					expect(error).toBeInstanceOf(WorkflowAccessError);
-					expect((error as WorkflowAccessError).reason).toBe('not_available_in_mcp');
-				}
+					),
+				).rejects.toMatchObject({
+					reason: 'not_available_in_mcp',
+				});
 			});
 
 			test('throws error when workflow has unsupported trigger nodes', async () => {
@@ -319,8 +316,8 @@ describe('execute-workflow MCP tool', () => {
 				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 
-				try {
-					await executeWorkflow(
+				await expect(
+					executeWorkflow(
 						user,
 						workflowFinderService,
 						workflowRepository,
@@ -328,11 +325,10 @@ describe('execute-workflow MCP tool', () => {
 						workflowRunner,
 						'unsupported-trigger',
 						undefined,
-					);
-				} catch (error) {
-					expect(error).toBeInstanceOf(WorkflowAccessError);
-					expect((error as WorkflowAccessError).reason).toBe('unsupported_trigger');
-				}
+					),
+				).rejects.toMatchObject({
+					reason: 'unsupported_trigger',
+				});
 			});
 
 			test('throws error when no supported trigger node is found', async () => {

--- a/packages/cli/src/modules/mcp/__tests__/execute-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/execute-workflow.tool.test.ts
@@ -1,5 +1,5 @@
 import { mockInstance } from '@n8n/backend-test-utils';
-import { User } from '@n8n/db';
+import { User, WorkflowRepository } from '@n8n/db';
 import {
 	CHAT_TRIGGER_NODE_TYPE,
 	FORM_TRIGGER_NODE_TYPE,
@@ -8,10 +8,10 @@ import {
 	type INode,
 	type IWorkflowExecutionDataProcess,
 	UnexpectedError,
-	UserError,
 } from 'n8n-workflow';
 
 import { createWorkflow } from './mock.utils';
+import { WorkflowAccessError } from '../mcp.errors';
 import { createExecuteWorkflowTool, executeWorkflow } from '../tools/execute-workflow.tool';
 
 import { ActiveExecutions } from '@/active-executions';
@@ -23,12 +23,14 @@ import { v4 as uuid } from 'uuid';
 describe('execute-workflow MCP tool', () => {
 	const user = Object.assign(new User(), { id: 'user-1' });
 	let workflowFinderService: WorkflowFinderService;
+	let workflowRepository: WorkflowRepository;
 	let activeExecutions: ActiveExecutions;
 	let workflowRunner: WorkflowRunner;
 	let telemetry: Telemetry;
 
 	beforeEach(() => {
 		workflowFinderService = mockInstance(WorkflowFinderService);
+		workflowRepository = mockInstance(WorkflowRepository);
 		activeExecutions = mockInstance(ActiveExecutions);
 		workflowRunner = mockInstance(WorkflowRunner);
 		telemetry = mockInstance(Telemetry, {
@@ -41,6 +43,7 @@ describe('execute-workflow MCP tool', () => {
 			const tool = createExecuteWorkflowTool(
 				user,
 				workflowFinderService,
+				workflowRepository,
 				activeExecutions,
 				workflowRunner,
 				telemetry,
@@ -60,46 +63,154 @@ describe('execute-workflow MCP tool', () => {
 
 	describe('handler tests', () => {
 		describe('workflow validation', () => {
-			test('throws error when workflow is not found', async () => {
+			test('throws error when workflow does not exist', async () => {
+				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(null);
+				(workflowRepository.findById as jest.Mock).mockResolvedValue(null);
+
+				await expect(
+					executeWorkflow(
+						user,
+						workflowFinderService,
+						workflowRepository,
+						activeExecutions,
+						workflowRunner,
+						'missing-workflow',
+						undefined,
+					),
+				).rejects.toThrow(WorkflowAccessError);
+
+				await expect(
+					executeWorkflow(
+						user,
+						workflowFinderService,
+						workflowRepository,
+						activeExecutions,
+						workflowRunner,
+						'missing-workflow',
+						undefined,
+					),
+				).rejects.toThrow("Workflow with ID 'missing-workflow' does not exist");
+			});
+
+			test('throws error with correct reason when workflow does not exist', async () => {
+				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(null);
+				(workflowRepository.findById as jest.Mock).mockResolvedValue(null);
+
+				await expect(
+					executeWorkflow(
+						user,
+						workflowFinderService,
+						workflowRepository,
+						activeExecutions,
+						workflowRunner,
+						'missing-workflow',
+						undefined,
+					),
+				).rejects.toMatchObject({
+					reason: 'workflow_does_not_exist',
+				});
+			});
+
+			test('throws error when user has no permission to access workflow', async () => {
+				const existingWorkflow = createWorkflow({ activeVersionId: uuid() });
+				(workflowRepository.findById as jest.Mock).mockResolvedValue(existingWorkflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(null);
 
 				await expect(
 					executeWorkflow(
 						user,
 						workflowFinderService,
+						workflowRepository,
 						activeExecutions,
 						workflowRunner,
-						'missing-workflow',
+						'no-permission-workflow',
 						undefined,
 					),
-				).rejects.toThrow(UserError);
+				).rejects.toThrow(WorkflowAccessError);
 
 				await expect(
 					executeWorkflow(
 						user,
 						workflowFinderService,
+						workflowRepository,
 						activeExecutions,
 						workflowRunner,
-						'missing-workflow',
+						'no-permission-workflow',
 						undefined,
 					),
-				).rejects.toThrow('Workflow not found');
+				).rejects.toThrow("You don't have permission to execute workflow 'no-permission-workflow'");
+			});
+
+			test('throws error with correct reason when user has no permission', async () => {
+				const existingWorkflow = createWorkflow({ activeVersionId: uuid() });
+				(workflowRepository.findById as jest.Mock).mockResolvedValue(existingWorkflow);
+				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(null);
+
+				try {
+					await executeWorkflow(
+						user,
+						workflowFinderService,
+						workflowRepository,
+						activeExecutions,
+						workflowRunner,
+						'no-permission-workflow',
+						undefined,
+					);
+				} catch (error) {
+					expect(error).toBeInstanceOf(WorkflowAccessError);
+					expect((error as WorkflowAccessError).reason).toBe('no_permission');
+				}
 			});
 
 			test('throws error when workflow is archived', async () => {
 				const workflow = createWorkflow({ activeVersionId: uuid(), isArchived: true });
+				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 
 				await expect(
 					executeWorkflow(
 						user,
 						workflowFinderService,
+						workflowRepository,
 						activeExecutions,
 						workflowRunner,
 						'archived-workflow',
 						undefined,
 					),
-				).rejects.toThrow(UserError);
+				).rejects.toThrow(WorkflowAccessError);
+
+				await expect(
+					executeWorkflow(
+						user,
+						workflowFinderService,
+						workflowRepository,
+						activeExecutions,
+						workflowRunner,
+						'archived-workflow',
+						undefined,
+					),
+				).rejects.toThrow("Workflow 'archived-workflow' is archived and cannot be executed");
+			});
+
+			test('throws error with correct reason when workflow is archived', async () => {
+				const workflow = createWorkflow({ activeVersionId: uuid(), isArchived: true });
+				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
+				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
+
+				try {
+					await executeWorkflow(
+						user,
+						workflowFinderService,
+						workflowRepository,
+						activeExecutions,
+						workflowRunner,
+						'archived-workflow',
+						undefined,
+					);
+				} catch (error) {
+					expect(error).toBeInstanceOf(WorkflowAccessError);
+					expect((error as WorkflowAccessError).reason).toBe('workflow_archived');
+				}
 			});
 
 			test('throws error when workflow is not available in MCP', async () => {
@@ -107,18 +218,44 @@ describe('execute-workflow MCP tool', () => {
 					activeVersionId: uuid(),
 					settings: { availableInMCP: false },
 				});
+				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 
 				await expect(
 					executeWorkflow(
 						user,
 						workflowFinderService,
+						workflowRepository,
 						activeExecutions,
 						workflowRunner,
 						'unavailable-workflow',
 						undefined,
 					),
-				).rejects.toThrow(UserError);
+				).rejects.toThrow(WorkflowAccessError);
+			});
+
+			test('throws error with correct reason when workflow is not available in MCP', async () => {
+				const workflow = createWorkflow({
+					activeVersionId: uuid(),
+					settings: { availableInMCP: false },
+				});
+				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
+				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
+
+				try {
+					await executeWorkflow(
+						user,
+						workflowFinderService,
+						workflowRepository,
+						activeExecutions,
+						workflowRunner,
+						'unavailable-workflow',
+						undefined,
+					);
+				} catch (error) {
+					expect(error).toBeInstanceOf(WorkflowAccessError);
+					expect((error as WorkflowAccessError).reason).toBe('not_available_in_mcp');
+				}
 			});
 
 			test('throws error when workflow has unsupported trigger nodes', async () => {
@@ -136,29 +273,66 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
+				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 
 				await expect(
 					executeWorkflow(
 						user,
 						workflowFinderService,
+						workflowRepository,
 						activeExecutions,
 						workflowRunner,
 						'unsupported-trigger',
 						undefined,
 					),
-				).rejects.toThrow(UserError);
+				).rejects.toThrow(WorkflowAccessError);
 
 				await expect(
 					executeWorkflow(
 						user,
 						workflowFinderService,
+						workflowRepository,
 						activeExecutions,
 						workflowRunner,
 						'unsupported-trigger',
 						undefined,
 					),
 				).rejects.toThrow(/Only workflows with the following trigger nodes can be executed/);
+			});
+
+			test('throws error with correct reason when workflow has unsupported trigger', async () => {
+				const workflow = createWorkflow({
+					activeVersionId: uuid(),
+					nodes: [
+						{
+							id: 'node-1',
+							name: 'Manual',
+							type: MANUAL_TRIGGER_NODE_TYPE,
+							typeVersion: 1,
+							position: [0, 0],
+							disabled: false,
+							parameters: {},
+						} as INode,
+					],
+				});
+				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
+				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
+
+				try {
+					await executeWorkflow(
+						user,
+						workflowFinderService,
+						workflowRepository,
+						activeExecutions,
+						workflowRunner,
+						'unsupported-trigger',
+						undefined,
+					);
+				} catch (error) {
+					expect(error).toBeInstanceOf(WorkflowAccessError);
+					expect((error as WorkflowAccessError).reason).toBe('unsupported_trigger');
+				}
 			});
 
 			test('throws error when no supported trigger node is found', async () => {
@@ -176,18 +350,20 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
+				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 
 				await expect(
 					executeWorkflow(
 						user,
 						workflowFinderService,
+						workflowRepository,
 						activeExecutions,
 						workflowRunner,
 						'disabled-trigger',
 						undefined,
 					),
-				).rejects.toThrow(UserError);
+				).rejects.toThrow(WorkflowAccessError);
 			});
 		});
 
@@ -207,6 +383,7 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
+				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-123');
 				(activeExecutions.getPostExecutePromise as jest.Mock).mockResolvedValue({
@@ -223,6 +400,7 @@ describe('execute-workflow MCP tool', () => {
 				const result = await executeWorkflow(
 					user,
 					workflowFinderService,
+					workflowRepository,
 					activeExecutions,
 					workflowRunner,
 					'webhook-workflow',
@@ -277,6 +455,7 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
+				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-456');
 				(activeExecutions.getPostExecutePromise as jest.Mock).mockResolvedValue({
@@ -287,6 +466,7 @@ describe('execute-workflow MCP tool', () => {
 				await executeWorkflow(
 					user,
 					workflowFinderService,
+					workflowRepository,
 					activeExecutions,
 					workflowRunner,
 					'webhook-workflow',
@@ -331,6 +511,7 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
+				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-789');
 				(activeExecutions.getPostExecutePromise as jest.Mock).mockResolvedValue({
@@ -341,6 +522,7 @@ describe('execute-workflow MCP tool', () => {
 				const result = await executeWorkflow(
 					user,
 					workflowFinderService,
+					workflowRepository,
 					activeExecutions,
 					workflowRunner,
 					'chat-workflow',
@@ -388,6 +570,7 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
+				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-101');
 				(activeExecutions.getPostExecutePromise as jest.Mock).mockResolvedValue({
@@ -398,6 +581,7 @@ describe('execute-workflow MCP tool', () => {
 				const result = await executeWorkflow(
 					user,
 					workflowFinderService,
+					workflowRepository,
 					activeExecutions,
 					workflowRunner,
 					'form-workflow',
@@ -451,6 +635,7 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
+				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-success');
 				(activeExecutions.getPostExecutePromise as jest.Mock).mockResolvedValue({
@@ -467,6 +652,7 @@ describe('execute-workflow MCP tool', () => {
 				const result = await executeWorkflow(
 					user,
 					workflowFinderService,
+					workflowRepository,
 					activeExecutions,
 					workflowRunner,
 					'success-workflow',
@@ -497,6 +683,7 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
+				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-error');
 				(activeExecutions.getPostExecutePromise as jest.Mock).mockResolvedValue({
@@ -514,6 +701,7 @@ describe('execute-workflow MCP tool', () => {
 				const result = await executeWorkflow(
 					user,
 					workflowFinderService,
+					workflowRepository,
 					activeExecutions,
 					workflowRunner,
 					'error-workflow',
@@ -545,6 +733,7 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
+				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-data-error');
 				(activeExecutions.getPostExecutePromise as jest.Mock).mockResolvedValue({
@@ -562,6 +751,7 @@ describe('execute-workflow MCP tool', () => {
 				const result = await executeWorkflow(
 					user,
 					workflowFinderService,
+					workflowRepository,
 					activeExecutions,
 					workflowRunner,
 					'data-error-workflow',
@@ -593,6 +783,7 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
+				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-no-data');
 				(activeExecutions.getPostExecutePromise as jest.Mock).mockResolvedValue(undefined);
@@ -601,6 +792,7 @@ describe('execute-workflow MCP tool', () => {
 					executeWorkflow(
 						user,
 						workflowFinderService,
+						workflowRepository,
 						activeExecutions,
 						workflowRunner,
 						'no-data-workflow',
@@ -612,6 +804,7 @@ describe('execute-workflow MCP tool', () => {
 					executeWorkflow(
 						user,
 						workflowFinderService,
+						workflowRepository,
 						activeExecutions,
 						workflowRunner,
 						'no-data-workflow',
@@ -637,6 +830,7 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
+				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-no-inputs');
 				(activeExecutions.getPostExecutePromise as jest.Mock).mockResolvedValue({
@@ -647,6 +841,7 @@ describe('execute-workflow MCP tool', () => {
 				await executeWorkflow(
 					user,
 					workflowFinderService,
+					workflowRepository,
 					activeExecutions,
 					workflowRunner,
 					'no-inputs-workflow',
@@ -685,6 +880,7 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
+				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-telemetry');
 				(activeExecutions.getPostExecutePromise as jest.Mock).mockResolvedValue({
@@ -695,6 +891,7 @@ describe('execute-workflow MCP tool', () => {
 				const tool = createExecuteWorkflowTool(
 					user,
 					workflowFinderService,
+					workflowRepository,
 					activeExecutions,
 					workflowRunner,
 					telemetry,
@@ -725,13 +922,14 @@ describe('execute-workflow MCP tool', () => {
 				);
 			});
 
-			test('tracks failed execution with tool handler', async () => {
-				const error = new UserError('Test error');
-				(workflowFinderService.findWorkflowForUser as jest.Mock).mockRejectedValue(error);
+			test('tracks failed execution with tool handler and error reason', async () => {
+				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(null);
+				(workflowRepository.findById as jest.Mock).mockResolvedValue(null);
 
 				const tool = createExecuteWorkflowTool(
 					user,
 					workflowFinderService,
+					workflowRepository,
 					activeExecutions,
 					workflowRunner,
 					telemetry,
@@ -751,7 +949,47 @@ describe('execute-workflow MCP tool', () => {
 						},
 						results: {
 							success: false,
-							error: 'Test error',
+							error: expect.objectContaining({
+								message: "Workflow with ID 'error-tracking' does not exist",
+							}),
+							error_reason: 'workflow_does_not_exist',
+						},
+					}),
+				);
+			});
+
+			test('tracks failed execution for no permission with error reason', async () => {
+				const workflow = createWorkflow({ activeVersionId: uuid() });
+				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
+				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(null);
+
+				const tool = createExecuteWorkflowTool(
+					user,
+					workflowFinderService,
+					workflowRepository,
+					activeExecutions,
+					workflowRunner,
+					telemetry,
+				);
+
+				// Call through the tool handler to test telemetry
+				await tool.handler({ workflowId: 'no-perm-workflow', inputs: undefined }, {} as any);
+
+				expect(telemetry.track).toHaveBeenCalledWith(
+					'User called mcp tool',
+					expect.objectContaining({
+						user_id: 'user-1',
+						tool_name: 'execute_workflow',
+						parameters: {
+							workflowId: 'no-perm-workflow',
+							inputs: undefined,
+						},
+						results: {
+							success: false,
+							error: expect.objectContaining({
+								message: "You don't have permission to execute workflow 'no-perm-workflow'",
+							}),
+							error_reason: 'no_permission',
 						},
 					}),
 				);
@@ -792,6 +1030,7 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
+				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-multi');
 				(activeExecutions.getPostExecutePromise as jest.Mock).mockResolvedValue({
@@ -802,6 +1041,7 @@ describe('execute-workflow MCP tool', () => {
 				await executeWorkflow(
 					user,
 					workflowFinderService,
+					workflowRepository,
 					activeExecutions,
 					workflowRunner,
 					'multi-trigger-workflow',

--- a/packages/cli/src/modules/mcp/__tests__/search-workflows.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/search-workflows.tool.test.ts
@@ -50,20 +50,26 @@ describe('search-workflows MCP tool', () => {
 	describe('handler tests', () => {
 		test('formats the output correctly', async () => {
 			const workflows = [
-				createWorkflow({
-					id: 'a',
-					activeVersionId: uuid(),
-					name: 'Alpha',
-					nodes: [{ name: 'Start', type: MANUAL_TRIGGER_NODE_TYPE } as INode],
-				}),
-				createWorkflow({
-					id: 'b',
-					name: 'Beta',
-					activeVersionId: 'version-b',
-					nodes: [
-						{ name: 'Execute subworkflow', type: EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE } as INode,
-					],
-				}),
+				{
+					...createWorkflow({
+						id: 'a',
+						activeVersionId: uuid(),
+						name: 'Alpha',
+						nodes: [{ name: 'Start', type: MANUAL_TRIGGER_NODE_TYPE } as INode],
+					}),
+					scopes: ['workflow:read', 'workflow:execute'],
+				},
+				{
+					...createWorkflow({
+						id: 'b',
+						name: 'Beta',
+						activeVersionId: 'version-b',
+						nodes: [
+							{ name: 'Execute subworkflow', type: EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE } as INode,
+						],
+					}),
+					scopes: ['workflow:read'],
+				},
 			];
 
 			const workflowService = mockInstance(WorkflowService, {
@@ -82,6 +88,8 @@ describe('search-workflows MCP tool', () => {
 					updatedAt: new Date('2024-01-02T00:00:00.000Z').toISOString(),
 					triggerCount: 1,
 					nodes: [{ name: 'Start', type: MANUAL_TRIGGER_NODE_TYPE }],
+					scopes: ['workflow:read', 'workflow:execute'],
+					canExecute: true,
 				},
 				{
 					id: 'b',
@@ -92,6 +100,8 @@ describe('search-workflows MCP tool', () => {
 					updatedAt: new Date('2024-01-02T00:00:00.000Z').toISOString(),
 					triggerCount: 1,
 					nodes: [{ name: 'Execute subworkflow', type: EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE }],
+					scopes: ['workflow:read'],
+					canExecute: false,
 				},
 			]);
 		});
@@ -136,7 +146,12 @@ describe('search-workflows MCP tool', () => {
 				getMany: jest.fn().mockResolvedValue({ workflows, count: 1 }),
 			});
 			const result = await searchWorkflows(user, workflowService as unknown as WorkflowService, {});
-			expect(result.data[0]).toMatchObject({ id: 'no-nodes', nodes: [] });
+			expect(result.data[0]).toMatchObject({
+				id: 'no-nodes',
+				nodes: [],
+				scopes: [],
+				canExecute: false,
+			});
 		});
 	});
 });

--- a/packages/cli/src/modules/mcp/mcp.errors.ts
+++ b/packages/cli/src/modules/mcp/mcp.errors.ts
@@ -3,6 +3,8 @@ import { UserError } from 'n8n-workflow';
 
 import { AuthError } from '@/errors/response-errors/auth.error';
 
+import type { WorkflowNotFoundReason } from './mcp.types';
+
 /**
  * Error thrown when MCP workflow execution times out
  */
@@ -31,5 +33,18 @@ export class AccessTokenNotFoundError extends AuthError {
 	constructor() {
 		super('Access Token Not Found in Database');
 		this.name = 'AccessTokenNotFoundError';
+	}
+}
+
+/**
+ * Error thrown when workflow access fails during MCP execution.
+ * Includes a reason for better error messages and telemetry.
+ */
+export class WorkflowAccessError extends UserError {
+	readonly reason: WorkflowNotFoundReason;
+
+	constructor(message: string, reason: WorkflowNotFoundReason) {
+		super(message);
+		this.reason = reason;
 	}
 }

--- a/packages/cli/src/modules/mcp/mcp.errors.ts
+++ b/packages/cli/src/modules/mcp/mcp.errors.ts
@@ -45,6 +45,7 @@ export class WorkflowAccessError extends UserError {
 
 	constructor(message: string, reason: WorkflowNotFoundReason) {
 		super(message);
+		this.name = 'WorkflowAccessError';
 		this.reason = reason;
 	}
 }

--- a/packages/cli/src/modules/mcp/mcp.service.ts
+++ b/packages/cli/src/modules/mcp/mcp.service.ts
@@ -9,6 +9,8 @@ import { createSearchWorkflowsTool } from './tools/search-workflows.tool';
 
 import { ActiveExecutions } from '@/active-executions';
 import { CredentialsService } from '@/credentials/credentials.service';
+import { ProjectService } from '@/services/project.service.ee';
+import { RoleService } from '@/services/role.service';
 import { UrlService } from '@/services/url.service';
 import { Telemetry } from '@/telemetry';
 import { WorkflowRunner } from '@/workflow-runner';
@@ -26,6 +28,8 @@ export class McpService {
 		private readonly globalConfig: GlobalConfig,
 		private readonly telemetry: Telemetry,
 		private readonly workflowRunner: WorkflowRunner,
+		private readonly roleService: RoleService,
+		private readonly projectService: ProjectService,
 	) {}
 
 	getServer(user: User) {
@@ -68,6 +72,8 @@ export class McpService {
 				webhookTest: this.globalConfig.endpoints.webhookTest,
 			},
 			this.telemetry,
+			this.roleService,
+			this.projectService,
 		);
 		server.registerTool(
 			workflowDetailsTool.name,

--- a/packages/cli/src/modules/mcp/mcp.service.ts
+++ b/packages/cli/src/modules/mcp/mcp.service.ts
@@ -1,6 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { GlobalConfig } from '@n8n/config';
-import { User } from '@n8n/db';
+import { User, WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 
 import { createExecuteWorkflowTool } from './tools/execute-workflow.tool';
@@ -21,6 +21,7 @@ import { WorkflowService } from '@/workflows/workflow.service';
 export class McpService {
 	constructor(
 		private readonly workflowFinderService: WorkflowFinderService,
+		private readonly workflowRepository: WorkflowRepository,
 		private readonly workflowService: WorkflowService,
 		private readonly urlService: UrlService,
 		private readonly credentialsService: CredentialsService,
@@ -52,6 +53,7 @@ export class McpService {
 		const executeWorkflowTool = createExecuteWorkflowTool(
 			user,
 			this.workflowFinderService,
+			this.workflowRepository,
 			this.activeExecutions,
 			this.workflowRunner,
 			this.telemetry,

--- a/packages/cli/src/modules/mcp/mcp.types.ts
+++ b/packages/cli/src/modules/mcp/mcp.types.ts
@@ -74,6 +74,18 @@ export type UserConnectedToMCPEventPayload = {
 	error?: string;
 };
 
+export type ExecuteWorkflowsInputMeta = {
+	type: 'webhook' | 'chat' | 'schedule' | 'form';
+	parameter_count: number;
+};
+
+export type WorkflowNotFoundReason =
+	| 'workflow_does_not_exist'
+	| 'no_permission'
+	| 'workflow_archived'
+	| 'not_available_in_mcp'
+	| 'unsupported_trigger';
+
 export type UserCalledMCPToolEventPayload = {
 	user_id?: string;
 	tool_name: string;
@@ -82,12 +94,8 @@ export type UserCalledMCPToolEventPayload = {
 		success: boolean;
 		data?: unknown;
 		error?: string | Record<string, unknown>;
+		error_reason?: WorkflowNotFoundReason;
 	};
-};
-
-export type ExecuteWorkflowsInputMeta = {
-	type: 'webhook' | 'chat' | 'schedule' | 'form';
-	parameter_count: number;
 };
 
 type SupportedTriggerNodeTypes = keyof typeof SUPPORTED_MCP_TRIGGERS;

--- a/packages/cli/src/modules/mcp/mcp.types.ts
+++ b/packages/cli/src/modules/mcp/mcp.types.ts
@@ -79,7 +79,7 @@ export type UserCalledMCPToolEventPayload = {
 	results?: {
 		success: boolean;
 		data?: unknown;
-		error?: string;
+		error?: string | Record<string, unknown>;
 	};
 };
 

--- a/packages/cli/src/modules/mcp/mcp.types.ts
+++ b/packages/cli/src/modules/mcp/mcp.types.ts
@@ -38,6 +38,8 @@ export type SearchWorkflowsItem = {
 	updatedAt: string | null;
 	triggerCount: number | null;
 	nodes: Array<{ name: string; type: string }>;
+	scopes: string[];
+	canExecute: boolean;
 };
 
 export type SearchWorkflowsResult = {

--- a/packages/cli/src/modules/mcp/tools/execute-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/execute-workflow.tool.ts
@@ -151,8 +151,8 @@ export const createExecuteWorkflowTool = (
 				success: false,
 				executionId: isTimeout ? error.executionId : null,
 				error: isTimeout
-					? `Workflow execution timed out after ${WORKFLOW_EXECUTION_TIMEOUT_MS / Time.milliseconds.toSeconds} seconds`
-					: error.message,
+					? `Workflow execution timed out after ${WORKFLOW_EXECUTION_TIMEOUT_MS / Time.milliseconds.toSeconds} seconds (Enforced MCP timeout)`
+					: (error.message ?? `${error.constructor.name}: (no message)`),
 			};
 
 			telemetryPayload.results = {

--- a/packages/cli/src/modules/mcp/tools/execute-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/execute-workflow.tool.ts
@@ -35,6 +35,7 @@ import type { WorkflowRunner } from '@/workflow-runner';
 import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
 const WORKFLOW_EXECUTION_TIMEOUT_MS = 5 * Time.minutes.toMilliseconds; // 5 minutes
+const ERROR_KEYS_TO_IGNORE = ['stack', 'node'];
 
 const inputSchema = z.object({
 	workflowId: z.string().describe('The ID of the workflow to execute'),
@@ -131,6 +132,12 @@ export const createExecuteWorkflowTool = (
 					executionId: output.executionId,
 				},
 			};
+			if (!output.success && output.error) {
+				telemetryPayload.results.error = JSON.stringify(
+					output.error,
+					(key: string, value: unknown) => (ERROR_KEYS_TO_IGNORE.includes(key) ? undefined : value),
+				);
+			}
 			telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
 
 			return {

--- a/packages/cli/src/modules/mcp/tools/execute-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/execute-workflow.tool.ts
@@ -147,6 +147,20 @@ export const createExecuteWorkflowTool = (
 		} catch (er) {
 			const error = ensureError(er);
 			const isTimeout = error instanceof McpExecutionTimeoutError;
+
+			const errorInfo: Record<string, unknown> = {
+				message: error.message || 'Unknown error',
+				name: error.constructor.name,
+			};
+
+			if ('extra' in error && error.extra) {
+				errorInfo.extra = error.extra;
+			}
+			if (error.cause) {
+				errorInfo.cause =
+					error.cause instanceof Error ? error.cause.message : jsonStringify(error.cause);
+			}
+
 			const output: ExecuteWorkflowOutput = {
 				success: false,
 				executionId: isTimeout ? error.executionId : null,
@@ -157,7 +171,7 @@ export const createExecuteWorkflowTool = (
 
 			telemetryPayload.results = {
 				success: false,
-				error: isTimeout ? 'Workflow execution timed out' : error.message,
+				error: isTimeout ? 'Workflow execution timed out' : errorInfo,
 			};
 			telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
 

--- a/packages/cli/src/modules/mcp/tools/schemas.ts
+++ b/packages/cli/src/modules/mcp/tools/schemas.ts
@@ -36,6 +36,8 @@ export const workflowDetailsOutputSchema = z.object({
 			meta: workflowMetaSchema,
 			parentFolderId: z.string().nullable(),
 			description: z.string().optional().describe('The description of the workflow'),
+			scopes: z.array(z.string()).describe('User permissions for this workflow'),
+			canExecute: z.boolean().describe('Whether the user has permission to execute this workflow'),
 		})
 		.passthrough()
 		.describe('Sanitized workflow data safe for MCP consumption'),

--- a/packages/cli/src/modules/mcp/tools/search-workflows.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/search-workflows.tool.ts
@@ -51,6 +51,10 @@ const outputSchema = {
 					.nullable()
 					.describe('The number of triggers associated with the workflow'),
 				nodes: z.array(nodeSchema).describe('List of nodes in the workflow'),
+				scopes: z.array(z.string()).describe('User permissions for this workflow'),
+				canExecute: z
+					.boolean()
+					.describe('Whether the user has permission to execute this workflow'),
 			}),
 		)
 		.describe('List of workflows matching the query'),
@@ -154,19 +158,20 @@ export async function searchWorkflows(
 			updatedAt: true,
 			triggerCount: true,
 			activeVersion: true,
+			ownedBy: true, // Required for loading 'shared' relation used in scope computation
 		},
 	};
 
 	const { workflows, count } = await workflowService.getMany(
 		user,
 		options,
-		false, // includeScopes
+		true, // includeScopes
 		false, // includeFolders
 		false, // onlySharedWithMe
 	);
 
-	const formattedWorkflows: SearchWorkflowsItem[] = (workflows as WorkflowEntity[]).map(
-		({
+	const formattedWorkflows: SearchWorkflowsItem[] = workflows.map((workflow) => {
+		const {
 			id,
 			name,
 			description,
@@ -175,7 +180,10 @@ export async function searchWorkflows(
 			updatedAt,
 			triggerCount,
 			activeVersion,
-		}) => ({
+		} = workflow as WorkflowEntity;
+		const scopes = ('scopes' in workflow ? (workflow.scopes as string[]) : undefined) ?? [];
+
+		return {
 			id,
 			name,
 			description,
@@ -187,8 +195,10 @@ export async function searchWorkflows(
 				name: node.name,
 				type: node.type,
 			})),
-		}),
-	);
+			scopes,
+			canExecute: scopes.includes('workflow:execute'),
+		};
+	});
 
 	return { data: formattedWorkflows, count };
 }


### PR DESCRIPTION
## Summary
Improve MCP error logging and telemetry by:
- Introducing more detailed errors when workflow is not found in the `Execute workflow` tool
- Handling error messages coming from the execution
- Handling cases when execution exceptions don't have `message` property
- Adding scopes to `Search workflows` and `Get workflow details` tools
- Adding new flag that informs agents if the workflow can be executed by the current user
- Adding execution mode to failed execution telemetry event

## Related Linear tickets, Github issues, and Community forum posts
Closes ADO-4634

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
