### PR TITLE
test: Adds export and debugging features for e2e

### DIFF
--- a/packages/testing/containers/services/victoria-logs.ts
+++ b/packages/testing/containers/services/victoria-logs.ts
@@ -92,6 +92,11 @@ export interface LogQueryOptions {
 export class LogsHelper {
 	constructor(private readonly endpoint: string) {}
 
+	async exportAll(options: LogQueryOptions = {}): Promise<string> {
+		const logs = await this.query('*', { limit: 10000, ...options });
+		return logs.map((log) => JSON.stringify(log)).join('\n');
+	}
+
 	async query(query: string, options: LogQueryOptions = {}): Promise<LogEntry[]> {
 		const params = new URLSearchParams({ query });
 		if (options.limit) params.set('limit', String(options.limit));

--- a/packages/testing/containers/services/victoria-metrics.ts
+++ b/packages/testing/containers/services/victoria-metrics.ts
@@ -155,6 +155,21 @@ export interface WaitForMetricOptions {
 export class MetricsHelper {
 	constructor(private readonly endpoint: string) {}
 
+	async exportAll(options: { start?: string; end?: string } = {}): Promise<string> {
+		const params = new URLSearchParams({
+			'match[]': '{__name__=~".+"}',
+		});
+		if (options.start) params.set('start', options.start);
+		if (options.end) params.set('end', options.end);
+
+		const response = await fetch(`${this.endpoint}/api/v1/export?${params}`);
+		if (!response.ok) {
+			throw new Error(`VictoriaMetrics export failed: ${response.status}`);
+		}
+
+		return response.text();
+	}
+
 	async query(query: string): Promise<MetricResult[]> {
 		const response = await fetch(`${this.endpoint}/api/v1/query?${new URLSearchParams({ query })}`);
 		if (!response.ok) {

--- a/packages/testing/containers/services/victoria-metrics.ts
+++ b/packages/testing/containers/services/victoria-metrics.ts
@@ -167,7 +167,7 @@ export class MetricsHelper {
 			throw new Error(`VictoriaMetrics export failed: ${response.status}`);
 		}
 
-		return response.text();
+		return await response.text();
 	}
 
 	async query(query: string): Promise<MetricResult[]> {

--- a/packages/testing/playwright/AGENTS.md
+++ b/packages/testing/playwright/AGENTS.md
@@ -99,6 +99,12 @@ BasePage - Common utilities
 
 See `CONTRIBUTING.md` for detailed patterns and conventions.
 
+## Debugging
+
+See [README.md#debugging](./README.md#debugging) for detailed instructions on:
+- **Keepalive mode** - Keep containers running after tests with `N8N_CONTAINERS_KEEPALIVE=true`
+- **Victoria exports** - Logs/metrics automatically attached on failure, importable locally via `scripts/import-victoria-data.mjs`
+
 ## Reference Files
 
 | Purpose | File |

--- a/packages/testing/playwright/fixtures/base.ts
+++ b/packages/testing/playwright/fixtures/base.ts
@@ -73,6 +73,16 @@ export const test = base.extend<
 
 			const container = await createN8NStack(config);
 			await use(container);
+
+			if (process.env.N8N_CONTAINERS_KEEPALIVE === 'true') {
+				console.log('\n=== KEEPALIVE: Containers left running for debugging ===');
+				console.log(`    URL: ${container.baseUrl}`);
+				console.log(`    Project: ${container.projectName}`);
+				console.log('    Cleanup: pnpm --filter n8n-containers stack:clean:all');
+				console.log('=========================================================\n');
+				return;
+			}
+
 			await container.stop();
 		},
 		{ scope: 'worker', box: true },

--- a/packages/testing/playwright/fixtures/base.ts
+++ b/packages/testing/playwright/fixtures/base.ts
@@ -68,6 +68,7 @@ export const test = base.extend<
 			const config: N8NConfig = {
 				...base,
 				...override,
+				services: [...new Set([...(base.services ?? []), ...(override.services ?? [])])],
 				env: { ...base.env, ...override.env, E2E_TESTS: 'true', N8N_RESTRICT_FILE_ACCESS_TO: '' },
 			};
 

--- a/packages/testing/playwright/fixtures/observability.ts
+++ b/packages/testing/playwright/fixtures/observability.ts
@@ -1,46 +1,32 @@
 import type { Fixtures, TestInfo } from '@playwright/test';
 import type { N8NStack } from 'n8n-containers/stack';
 
-/**
- * Fixture type for auto-attaching logs on test failure.
- * Uses undefined instead of void to satisfy eslint @typescript-eslint/no-invalid-void-type
- */
 export type ObservabilityTestFixtures = {
 	autoAttachLogs: undefined;
 };
 
-/**
- * Worker fixtures required by observability fixtures.
- */
 export type ObservabilityWorkerFixtures = {
 	n8nContainer: N8NStack;
 };
 
-/**
- * Queries VictoriaLogs and attaches logs to test info on failure.
- * Retrieves logs from the last 5 minutes to capture test context.
- */
 async function attachLogsOnFailure(
 	stack: N8NStack,
 	testInfo: TestInfo,
 	options: { lookbackMinutes?: number } = {},
 ): Promise<void> {
-	// Use the observability service helper if available
 	const obs = stack.services?.observability;
 	if (!obs) return;
 
 	const lookback = options.lookbackMinutes ?? 5;
 
 	try {
-		// Query all logs from the last N minutes
 		const logs = await obs.logs.query('*', {
-			limit: 1000,
+			limit: 10000,
 			start: `${lookback}m`,
 		});
 
 		if (logs.length === 0) return;
 
-		// Group logs by container for readability
 		const groupedLogs = logs.reduce<Record<string, typeof logs>>((acc, log) => {
 			const container = log.container_name ?? 'unknown';
 			acc[container] ??= [];
@@ -48,12 +34,10 @@ async function attachLogsOnFailure(
 			return acc;
 		}, {});
 
-		// Sort logs within each container by timestamp
 		for (const containerLogs of Object.values(groupedLogs)) {
 			containerLogs.sort((a, b) => (a._time ?? '').localeCompare(b._time ?? ''));
 		}
 
-		// Format logs for attachment (containers sorted alphabetically)
 		const formattedLogs = Object.entries(groupedLogs)
 			.sort(([a], [b]) => a.localeCompare(b))
 			.map(([container, containerLogs]) => {
@@ -66,30 +50,38 @@ async function attachLogsOnFailure(
 			body: formattedLogs,
 			contentType: 'text/plain',
 		});
+
+		const jsonLinesExport = logs.map((log) => JSON.stringify(log)).join('\n');
+		await testInfo.attach('victoria-logs-export.jsonl', {
+			body: jsonLinesExport,
+			contentType: 'application/x-ndjson',
+		});
 	} catch (error) {
-		// Don't fail the test if log collection fails
 		console.warn('Failed to collect container logs:', error);
 	}
 }
 
+async function attachMetricsOnFailure(stack: N8NStack, testInfo: TestInfo): Promise<void> {
+	const obs = stack.services?.observability;
+	if (!obs) return;
+
+	try {
+		const metricsExport = await obs.metrics.exportAll();
+
+		if (!metricsExport.trim()) return;
+
+		await testInfo.attach('victoria-metrics-export.jsonl', {
+			body: metricsExport,
+			contentType: 'application/x-ndjson',
+		});
+	} catch (error) {
+		console.warn('Failed to export metrics:', error);
+	}
+}
+
 /**
- * Observability fixtures that can be spread into the main test fixtures.
- * Provides auto-attachment of container logs on test failure.
- *
- * Usage in base.ts:
- * ```typescript
- * import { observabilityFixtures } from './observability';
- *
- * export const test = base.extend<TestFixtures & { autoAttachLogs: void }, WorkerFixtures>({
- *   ...observabilityFixtures,
- *   // other fixtures
- * });
- * ```
- *
- * The autoAttachLogs fixture:
- * - Runs automatically for every test (auto: true)
- * - Only collects logs when a test fails AND observability is enabled
- * - Attaches logs as plaintext, sorted by container and timestamp
+ * Auto-attaches container logs and metrics on test failure.
+ * Import exports locally with scripts/import-victoria-data.mjs
  */
 export const observabilityFixtures: Fixtures<
 	ObservabilityTestFixtures,
@@ -97,12 +89,13 @@ export const observabilityFixtures: Fixtures<
 > = {
 	autoAttachLogs: [
 		async ({ n8nContainer }, use, testInfo) => {
-			// Run the test
 			await use(undefined);
 
-			// After test: attach logs if failed
 			if (testInfo.status !== testInfo.expectedStatus && n8nContainer?.services?.observability) {
-				await attachLogsOnFailure(n8nContainer, testInfo);
+				await Promise.all([
+					attachLogsOnFailure(n8nContainer, testInfo),
+					attachMetricsOnFailure(n8nContainer, testInfo),
+				]);
 			}
 		},
 		{ auto: true },

--- a/packages/testing/playwright/scripts/import-victoria-data.mjs
+++ b/packages/testing/playwright/scripts/import-victoria-data.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * Imports Victoria logs/metrics exports into local containers for analysis.
+ * Usage: node import-victoria-data.mjs [metrics_file] [logs_file]
+ *        node import-victoria-data.mjs --start [metrics_file] [logs_file]
+ */
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { setTimeout } from 'node:timers/promises';
+
+const VM_PORT = 8428;
+const VL_PORT = 9428;
+
+const args = process.argv.slice(2);
+const startContainers = args[0] === '--start';
+if (startContainers) args.shift();
+
+const metricsFile = args[0] ?? 'victoria-metrics-export.jsonl';
+const logsFile = args[1] ?? 'victoria-logs-export.jsonl';
+
+if (startContainers) {
+	try {
+		execSync(`docker run -d --name victoria-metrics-local -p ${VM_PORT}:8428 victoriametrics/victoria-metrics:v1.115.0 -storageDataPath=/victoria-metrics-data -retentionPeriod=7d`, { stdio: 'ignore' });
+	} catch {}
+	try {
+		execSync(`docker run -d --name victoria-logs-local -p ${VL_PORT}:9428 victoriametrics/victoria-logs:v1.21.0-victorialogs -storageDataPath=/victoria-logs-data -retentionPeriod=7d`, { stdio: 'ignore' });
+	} catch {}
+	await setTimeout(2000);
+}
+
+const hasMetrics = existsSync(metricsFile);
+const hasLogs = existsSync(logsFile);
+
+if (!hasMetrics && !hasLogs) {
+	console.log('No export files found');
+	process.exit(1);
+}
+
+if (hasMetrics) {
+	const res = await fetch(`http://localhost:${VM_PORT}/api/v1/import`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: readFileSync(metricsFile),
+	});
+	if (!res.ok) console.error(`Metrics import failed: ${res.status}`);
+	else console.log(`Metrics: http://localhost:${VM_PORT}/vmui/`);
+}
+
+if (hasLogs) {
+	const res = await fetch(`http://localhost:${VL_PORT}/insert/jsonline`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: readFileSync(logsFile),
+	});
+	if (!res.ok) console.error(`Logs import failed: ${res.status}`);
+	else console.log(`Logs: http://localhost:${VL_PORT}/select/vmui/`);
+}


### PR DESCRIPTION
## Summary

Adds functionality to export logs and metrics from Victoria containers for easier debugging.
Introduces keepalive mode to leave containers running after tests, enabling inspection of the n8n instance state and manual testing.

Also adds a script to import Victoria exports into local containers for querying.
Updates documentation with debugging instructions.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
