### PR TITLE
fix(editor): Prevent duplicate field_focus_placeholder_in_ndv telemetry event

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.test.ts
@@ -824,10 +824,13 @@ describe('ParameterInput.vue', () => {
 				await fireEvent.focus(input);
 			}
 
-			expect(mockBuilderState.trackWorkflowBuilderJourney).toHaveBeenCalledWith(
-				'field_focus_placeholder_in_ndv',
-				{ node_type: 'n8n-nodes-base.httpRequest' },
-			);
+			// Wait for debounced tracking call
+			await waitFor(() => {
+				expect(mockBuilderState.trackWorkflowBuilderJourney).toHaveBeenCalledWith(
+					'field_focus_placeholder_in_ndv',
+					{ node_type: 'n8n-nodes-base.httpRequest' },
+				);
+			});
 		});
 
 		it('does not track when value is not a placeholder', async () => {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, inject, nextTick, onBeforeUnmount, onMounted, onUpdated, ref, watch } from 'vue';
+import { useDebounceFn } from '@vueuse/core';
 
 import get from 'lodash/get';
 
@@ -824,13 +825,13 @@ function selectInput() {
 	}
 }
 
-function trackBuilderPlaceholders() {
+const trackBuilderPlaceholders = useDebounceFn(() => {
 	if (node.value && isPlaceholderValue(props.modelValue) && builderStore.isAIBuilderEnabled) {
 		builderStore.trackWorkflowBuilderJourney('field_focus_placeholder_in_ndv', {
 			node_type: node.value.type,
 		});
 	}
-}
+}, 100);
 
 async function setFocus(fromModeSwitch: boolean | FocusEvent = false) {
 	// When called from template @focus="setFocus", the first arg is a FocusEvent, not a boolean

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
@@ -877,7 +877,7 @@ async function setFocus(fromModeSwitch: boolean | FocusEvent = false) {
 	}
 
 	emit('focus');
-	trackBuilderPlaceholders();
+	void trackBuilderPlaceholders();
 }
 
 function rgbaToHex(value: string): string | null {


### PR DESCRIPTION
## Summary
- Debounce `trackBuilderPlaceholders` function (100ms) to prevent duplicate `field_focus_placeholder_in_ndv` telemetry events
- The duplicate firing was caused by multiple focus events cascading through the component hierarchy during a single click on placeholder fields

## Test plan
- [ ] Click on a placeholder field in the NDV and verify the telemetry event fires exactly once
- [ ] Run existing tests: `cd packages/frontend/editor-ui && pnpm test ParameterInput.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)