### PR TITLE
docs: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/build-unit-test-pr-comment.yml
+++ b/.github/workflows/build-unit-test-pr-comment.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Validate user permissions and collect PR data
         id: check_permissions
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/build-unit-test-pr-comment.yml
+++ b/.github/workflows/build-unit-test-pr-comment.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Validate user permissions and collect PR data
         id: check_permissions
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/ci-manual-unit-tests.yml
+++ b/.github/workflows/ci-manual-unit-tests.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Create pending check run on PR
         id: create
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -88,7 +88,7 @@ jobs:
     steps:
       - name: Update check run on PR (if triggered from PR comment)
         if: inputs.pr_number != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/ci-manual-unit-tests.yml
+++ b/.github/workflows/ci-manual-unit-tests.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Create pending check run on PR
         id: create
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -88,7 +88,7 @@ jobs:
     steps:
       - name: Update check run on PR (if triggered from PR comment)
         if: inputs.pr_number != ''
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/create-patch-release-branch.yml
+++ b/.github/workflows/create-patch-release-branch.yml
@@ -23,7 +23,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Validate inputs

--- a/.github/workflows/create-patch-release-branch.yml
+++ b/.github/workflows/create-patch-release-branch.yml
@@ -23,7 +23,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
       - name: Validate inputs

--- a/.github/workflows/test-workflows-pr-comment.yml
+++ b/.github/workflows/test-workflows-pr-comment.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Validate User, Get PR Details, and React
         id: pr_check_and_details
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/test-workflows-pr-comment.yml
+++ b/.github/workflows/test-workflows-pr-comment.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Validate User, Get PR Details, and React
         id: pr_check_and_details
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/util-claude.yml
+++ b/.github/workflows/util-claude.yml
@@ -25,7 +25,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/util-claude.yml
+++ b/.github/workflows/util-claude.yml
@@ -25,7 +25,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
## Summary  
This PR updates outdated GitHub Action versions in several workflow files. The changes include upgrading `actions/checkout` from `v4` to `v6` and `actions/github-script` from `v7` to `v8` to ensure compatibility with newer GitHub Actions. The updates will be tested in the CI pipeline of the pull request.

## Related Linear tickets, Github issues, and Community forum posts  
<!-- Use "closes #<issue-number>" to automatically close issues when the PR is merged. -->

## Review / Merge checklist  
- [x] PR title and summary are descriptive.  
- [ ] Docs updated or follow-up ticket created.  
- [ ] Tests included.  
- [ ] PR Labeled with `release/backport` (if applicable).  

## Changes  
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/util-claude.yml`  
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/create-patch-release-branch.yml`  
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/util-claude-task.yml`  
- Updated `actions/github-script` from `v7` to `v8` in `.github/workflows/test-workflows-pr-comment.yml`  
- Updated `actions/github-script` from `v7` to `v8` in `.github/workflows/ci-manual-unit-tests.yml`  
- Updated `actions/github-script` from `v7` to `v8` in `.github/workflows/build-unit-test-pr-comment.yml`