### PR TITLE
feat(TextSplitterRecursiveCharacterTextSplitter Node): Added separators as Arguments instead of hardcode

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/text_splitters/TextSplitterRecursiveCharacterTextSplitter/TextSplitterRecursiveCharacterTextSplitter.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/text_splitters/TextSplitterRecursiveCharacterTextSplitter/TextSplitterRecursiveCharacterTextSplitter.node.ts
@@ -31,6 +31,9 @@ const supportedLanguages: SupportedTextSplitterLanguage[] = [
 	'latex',
 	'html',
 ];
+
+const DEFAULT_SEPARATORS = ['\n\n', '\n', ' ', ''];
+
 export class TextSplitterRecursiveCharacterTextSplitter implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'Recursive Character Text Splitter',
@@ -76,6 +79,14 @@ export class TextSplitterRecursiveCharacterTextSplitter implements INodeType {
 				default: 0,
 			},
 			{
+				displayName: 'Separators',
+				name: 'separators',
+				type: 'json',
+				default: DEFAULT_SEPARATORS,
+				description:
+					'JSON array of separators, evaluated in order. Defaults match LangChain.',
+			},
+			{
 				displayName: 'Options',
 				name: 'options',
 				placeholder: 'Add Option',
@@ -88,7 +99,10 @@ export class TextSplitterRecursiveCharacterTextSplitter implements INodeType {
 						name: 'splitCode',
 						default: 'markdown',
 						type: 'options',
-						options: supportedLanguages.map((lang) => ({ name: lang, value: lang })),
+						options: supportedLanguages.map((lang) => ({
+							name: lang,
+							value: lang,
+						})),
 					},
 				],
 			},
@@ -105,9 +119,15 @@ export class TextSplitterRecursiveCharacterTextSplitter implements INodeType {
 			itemIndex,
 			null,
 		) as SupportedTextSplitterLanguage | null;
+
+		const separators = (this.getNodeParameter(
+			'separators',
+			itemIndex,
+			DEFAULT_SEPARATORS,
+		) ?? DEFAULT_SEPARATORS) as string[];
+
 		const params: RecursiveCharacterTextSplitterParams = {
-			// TODO: These are the default values, should we allow the user to change them?
-			separators: ['\n\n', '\n', ' ', ''],
+			separators,
 			chunkSize,
 			chunkOverlap,
 			keepSeparator: false,

--- a/packages/@n8n/nodes-langchain/nodes/text_splitters/TextSplitterRecursiveCharacterTextSplitter/TextSplitterRecursiveCharacterTextSplitter.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/text_splitters/TextSplitterRecursiveCharacterTextSplitter/TextSplitterRecursiveCharacterTextSplitter.node.ts
@@ -120,11 +120,20 @@ export class TextSplitterRecursiveCharacterTextSplitter implements INodeType {
 			null,
 		) as SupportedTextSplitterLanguage | null;
 
-		const separators = (this.getNodeParameter(
+		const rawSeparators = this.getNodeParameter(
 			'separators',
 			itemIndex,
 			DEFAULT_SEPARATORS,
-		) ?? DEFAULT_SEPARATORS) as string[];
+		);
+
+		if (
+			!Array.isArray(rawSeparators) ||
+			!rawSeparators.every((el) => typeof el === 'string')
+		) {
+			throw new Error('Separators must be a JSON array of strings');
+		}
+
+		const separators: string[] = rawSeparators;
 
 		const params: RecursiveCharacterTextSplitterParams = {
 			separators,

--- a/packages/@n8n/nodes-langchain/nodes/text_splitters/TextSplitterRecursiveCharacterTextSplitter/TextSplitterRecursiveCharacterTextSplitter.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/text_splitters/TextSplitterRecursiveCharacterTextSplitter/TextSplitterRecursiveCharacterTextSplitter.node.ts
@@ -126,10 +126,17 @@ export class TextSplitterRecursiveCharacterTextSplitter implements INodeType {
 			DEFAULT_SEPARATORS,
 		);
 
-		if (
-			!Array.isArray(rawSeparators) ||
-			!rawSeparators.every((el) => typeof el === 'string')
+		let separators: string[];
+
+		// If the fallback default was returned
+		if (rawSeparators === null || rawSeparators === undefined) {
+			separators = DEFAULT_SEPARATORS;
+		} else if (
+			Array.isArray(rawSeparators) &&
+			rawSeparators.every((el) => typeof el === 'string')
 		) {
+			separators = rawSeparators;
+		} else {
 			throw new Error('Separators must be a JSON array of strings');
 		}
 


### PR DESCRIPTION
## Summary

Sets hardcoded separator characters to node's arguments sections to let users customize splitting logic

## Related Linear tickets, Github issues, and Community forum posts

closes https://community.n8n.io/t/add-charaters-options-in-recursive-character-text-splitter-node/248723

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
