### PR TITLE
test(editor): Fix flaky chat session ID reset E2E test

### DIFF
--- a/packages/testing/playwright/pages/components/LogsPanel.ts
+++ b/packages/testing/playwright/pages/components/LogsPanel.ts
@@ -1,7 +1,7 @@
 import type { Locator } from '@playwright/test';
 
-import type { ClipboardHelper } from '../../helpers/ClipboardHelper';
 import { RunDataPanel } from './RunDataPanel';
+import type { ClipboardHelper } from '../../helpers/ClipboardHelper';
 
 /**
  * Page object for the log view with configurable root element.

--- a/packages/testing/playwright/pages/components/LogsPanel.ts
+++ b/packages/testing/playwright/pages/components/LogsPanel.ts
@@ -1,5 +1,6 @@
 import type { Locator } from '@playwright/test';
 
+import type { ClipboardHelper } from '../../helpers/ClipboardHelper';
 import { RunDataPanel } from './RunDataPanel';
 
 /**
@@ -64,14 +65,6 @@ export class LogsPanel {
 	}
 
 	/**
-	 * Returns the session ID tooltip locator.
-	 * Filters by "click to copy" text to avoid matching other tooltips in the header.
-	 */
-	getSessionIdTooltip(): Locator {
-		return this.root.page().locator('.n8n-tooltip').filter({ hasText: 'click to copy' });
-	}
-
-	/**
 	 * Actions
 	 */
 
@@ -107,17 +100,14 @@ export class LogsPanel {
 	}
 
 	/**
-	 * Clicks the session ID button to show the tooltip and extracts the full session ID.
+	 * Clicks the session ID button to copy the session ID to clipboard and returns it.
+	 * @param clipboard - ClipboardHelper instance for reading clipboard
 	 * @returns The full session ID string
 	 */
-	async getSessionId(): Promise<string> {
+	async getSessionId(clipboard: ClipboardHelper): Promise<string> {
+		await clipboard.grant();
 		await this.getSessionIdButton().click();
-		const tooltipText = await this.getSessionIdTooltip().textContent();
-		if (!tooltipText) {
-			throw new Error('Session ID tooltip text is empty');
-		}
-		// Extract session ID before "(click to copy)"
-		return tooltipText.split('(')[0].trim();
+		return await clipboard.readText();
 	}
 
 	/**

--- a/packages/testing/playwright/tests/e2e/ai/chat-session.spec.ts
+++ b/packages/testing/playwright/tests/e2e/ai/chat-session.spec.ts
@@ -13,7 +13,7 @@ test.describe('Chat session ID reset', () => {
 		await n8n.canvas.logsPanel.sendManualChatMessage('Test message 1');
 		await expect(n8n.canvas.logsPanel.getManualChatMessages()).toHaveCount(2);
 
-		const initialSessionId = await n8n.canvas.logsPanel.getSessionId();
+		const initialSessionId = await n8n.canvas.logsPanel.getSessionId(n8n.clipboard);
 		await n8n.canvas.logsPanel.clickLogEntryAtRow(0);
 		await expect(n8n.canvas.logsPanel.outputPanel.getTbodyCell(0, 0)).toContainText(
 			initialSessionId,
@@ -22,7 +22,7 @@ test.describe('Chat session ID reset', () => {
 		await n8n.canvas.logsPanel.refreshSession();
 		await expect(n8n.canvas.logsPanel.getManualChatMessages()).not.toBeAttached();
 
-		const newSessionId = await n8n.canvas.logsPanel.getSessionId();
+		const newSessionId = await n8n.canvas.logsPanel.getSessionId(n8n.clipboard);
 		expect(newSessionId).not.toEqual(initialSessionId);
 
 		await n8n.canvas.logsPanel.sendManualChatMessage('Test message 2');


### PR DESCRIPTION
## Summary

Fixes the flaky E2E test `Chat session ID reset > should update session ID in node output when session is reset` which had an 8-25% failure rate.

**Root Cause:** The test used a tooltip locator `.n8n-tooltip` with `hasText: 'click to copy'` which matched multiple elements during tooltip transitions when both old and new tooltips were visible simultaneously.

**Fix:** Use clipboard to extract session ID instead of parsing tooltip text. The session ID button already copies the full session ID to clipboard when clicked, so we can read it directly - avoiding any tooltip matching issues.

**Verification:** Ran 20 repetitions of the test with 0 failures (previously 8-25% flaky rate).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-1935

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)