### PR TITLE
fix(core): Improve SSH host key verification for source control

### DIFF
--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-git.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-git.service.test.ts
@@ -329,7 +329,7 @@ describe('SourceControlGitService', () => {
 
 			expect(mockGitInstance.env).toHaveBeenCalledWith(
 				'GIT_SSH_COMMAND',
-				'ssh -o UserKnownHostsFile=".ssh/known_hosts" -o StrictHostKeyChecking=no -i "private-key"',
+				'ssh -o UserKnownHostsFile=".ssh/known_hosts" -o StrictHostKeyChecking=accept-new -i "private-key"',
 			);
 			expect(mockGitInstance.env).toHaveBeenCalledWith('GIT_TERMINAL_PROMPT', '0');
 		});
@@ -573,7 +573,7 @@ describe('SourceControlGitService', () => {
 				);
 				expect(mockGitInstance.env).toHaveBeenCalledWith(
 					'GIT_SSH_COMMAND',
-					expect.stringContaining('StrictHostKeyChecking=no'),
+					expect.stringContaining('StrictHostKeyChecking=accept-new'),
 				);
 			});
 

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-preferences.service.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-preferences.service.ee.test.ts
@@ -3,7 +3,7 @@ import type { SettingsRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
 import type { InstanceSettings, Cipher } from 'n8n-core';
-import { readFile, access, mkdir } from 'fs/promises';
+import { readFile, writeFile, access, mkdir } from 'fs/promises';
 import os from 'os';
 import path from 'path';
 
@@ -390,6 +390,50 @@ describe('SourceControlPreferencesService', () => {
 				username: 'decrypted-encryptedUser',
 				password: 'decrypted-encryptedPass',
 			});
+		});
+	});
+
+	describe('resetKnownHosts', () => {
+		let tempDir: string;
+		let sshFolder: string;
+
+		beforeEach(async () => {
+			tempDir = path.join(os.tmpdir(), 'n8n-test-' + Date.now());
+			sshFolder = path.join(tempDir, 'ssh');
+			await mkdir(sshFolder, { recursive: true });
+		});
+
+		it('should delete the known_hosts file when it exists', async () => {
+			const instanceSettings = mock<InstanceSettings>({ n8nFolder: tempDir });
+			const testService = new SourceControlPreferencesService(
+				instanceSettings,
+				mock(),
+				mock(),
+				mock(),
+				mock(),
+			);
+
+			const knownHostsPath = path.join(sshFolder, 'known_hosts');
+			await writeFile(knownHostsPath, 'github.com ssh-rsa AAAA...\n');
+
+			await expect(access(knownHostsPath)).resolves.toBeUndefined();
+
+			await testService.resetKnownHosts();
+
+			await expect(access(knownHostsPath)).rejects.toThrow();
+		});
+
+		it('should complete successfully when known_hosts file does not exist', async () => {
+			const instanceSettings = mock<InstanceSettings>({ n8nFolder: tempDir });
+			const testService = new SourceControlPreferencesService(
+				instanceSettings,
+				mock(),
+				mock(),
+				mock(),
+				mock(),
+			);
+
+			await expect(testService.resetKnownHosts()).resolves.toBeUndefined();
 		});
 	});
 });

--- a/packages/cli/src/modules/source-control.ee/source-control-git.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-git.service.ee.ts
@@ -164,7 +164,10 @@ export class SourceControlGitService {
 			const escapedKnownHostsPath = normalizedKnownHostsPath.replace(/"/g, '\\"');
 
 			// Quote paths to handle spaces and special characters
-			const sshCommand = `ssh -o UserKnownHostsFile="${escapedKnownHostsPath}" -o StrictHostKeyChecking=no -i "${escapedPrivateKeyPath}"`;
+			// Use StrictHostKeyChecking=accept-new to protect against MITM attacks:
+			// - First connection: accepts and saves host key to known_hosts
+			// - Subsequent connections: verifies against saved key
+			const sshCommand = `ssh -o UserKnownHostsFile="${escapedKnownHostsPath}" -o StrictHostKeyChecking=accept-new -i "${escapedPrivateKeyPath}"`;
 
 			this.git = simpleGit(this.gitOptions)
 				.env('GIT_SSH_COMMAND', sshCommand)

--- a/packages/cli/src/modules/source-control.ee/source-control-preferences.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-preferences.service.ee.ts
@@ -186,6 +186,20 @@ export class SourceControlPreferencesService {
 	}
 
 	/**
+	 * Clears the SSH known_hosts file.
+	 * This allows reconnecting to repositories after a host key change.
+	 */
+	async resetKnownHosts(): Promise<void> {
+		const knownHostsPath = path.join(this.sshFolder, 'known_hosts');
+		try {
+			await fsRm(knownHostsPath, { force: true });
+			this.logger.debug('Cleared SSH known_hosts file');
+		} catch (error) {
+			this.logger.warn('Failed to clear known_hosts file', { error });
+		}
+	}
+
+	/**
 	 * Generate an SSH key pair and write it to the database, overwriting any existing key pair.
 	 */
 	async generateAndSaveKeyPair(keyPairType?: KeyPairType): Promise<SourceControlPreferences> {


### PR DESCRIPTION
## Summary

Fixes a security vulnerability with SSH connections. This PR changes the SSH configuration to verify host keys on first connection and protects against MITM attacks on subsequent connections. Adds error handling for host key verification failures and clears the `known_hosts` file during disconnect for easier recovery.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-87

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)