### PR TITLE
fix(deps): update diff to 8.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
       "brace-expansion@1": "1.1.12",
       "brace-expansion@2": "2.0.2",
       "date-fns": "2.30.0",
+      "diff@8": "8.0.3",
       "date-fns-tz": "2.0.0",
       "form-data": "4.0.4",
       "tmp": "0.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,6 +297,7 @@ overrides:
   brace-expansion@1: 1.1.12
   brace-expansion@2: 2.0.2
   date-fns: 2.30.0
+  diff@8: 8.0.3
   date-fns-tz: 2.0.0
   form-data: 4.0.4
   tmp: 0.2.4
@@ -11230,8 +11231,8 @@ packages:
     resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
     engines: {node: '>=0.3.1'}
 
-  diff@8.0.2:
-    resolution: {integrity: sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==}
+  diff@8.0.3:
+    resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
 
   diffie-hellman@5.0.3:
@@ -28658,7 +28659,7 @@ snapshots:
 
   diff@5.2.0: {}
 
-  diff@8.0.2: {}
+  diff@8.0.3: {}
 
   diffie-hellman@5.0.3:
     dependencies:
@@ -30601,7 +30602,7 @@ snapshots:
       '@types/debug': 4.1.12
       '@types/node': 20.19.21
       '@types/tough-cookie': 4.0.5
-      axios: 1.12.0(debug@4.4.3)
+      axios: 1.12.0
       camelcase: 6.3.0
       debug: 4.4.3(supports-color@8.1.1)
       dotenv: 16.6.1
@@ -30611,7 +30612,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.12.0)
+      retry-axios: 2.6.0(axios@1.12.0(debug@4.4.3))
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -35042,7 +35043,7 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
-  retry-axios@2.6.0(axios@1.12.0):
+  retry-axios@2.6.0(axios@1.12.0(debug@4.4.3)):
     dependencies:
       axios: 1.12.0
 
@@ -36707,7 +36708,7 @@ snapshots:
       ansis: 4.2.0
       cac: 6.7.14
       chokidar: 4.0.3
-      diff: 8.0.2
+      diff: 8.0.3
       empathic: 2.0.0
       hookable: 5.5.3
       obug: 2.1.1


### PR DESCRIPTION
## Summary
Automated task completed by Claude.

### Task Description
Fix these CVE's please, read the templates first ┌───────────────────────┬─────────────────────┬──────────┬────────┬───────────────────┬────────────────┬────────────────────────────────────────────────────────────┐ │        Library        │    Vulnerability    │ Severity │ Status │ Installed Version │ Fixed Version  │                           Title                            │ ├───────────────────────┼─────────────────────┼──────────┼────────┼───────────────────┼────────────────┼────────────────────────────────────────────────────────────┤ │ diff (package.json)   │ GHSA-73rr-hh4g-fpgx │ LOW      │ fixed  │ 8.0.2             │ 8.0.3          │ jsdiff has a Denial of Service vulnerability in parsePatch │ │                       │                     │          │        │                   │                │ and applyPatch                                             │ │                       │                     │          │        │                   │                │ https://github.com/advisories/GHSA-73rr-

### Generated by
[Workflow Run #21040212498](https://github.com/n8n-io/n8n/actions/runs/21040212498)

---
*Triggered by @shortstacked via the Claude Task Runner workflow.*
