### PR TITLE
fix(core): Handle JSON parsing errors gracefully in ActivateExecuteWorkflowTriggerWorkflows migration

### DIFF
--- a/packages/@n8n/db/src/migrations/common/1763048000000-ActivateExecuteWorkflowTriggerWorkflows.ts
+++ b/packages/@n8n/db/src/migrations/common/1763048000000-ActivateExecuteWorkflowTriggerWorkflows.ts
@@ -46,7 +46,15 @@ export class ActivateExecuteWorkflowTriggerWorkflows1763048000000 implements Irr
 		return { executeWorkflowTriggerNode, errorTriggerNode };
 	}
 
-	async up({ escape, runQuery, runInBatches, parseJson, isPostgres }: MigrationContext) {
+	async up({
+		escape,
+		runQuery,
+		runInBatches,
+		parseJson,
+		isPostgres,
+		logger,
+		migrationName,
+	}: MigrationContext) {
 		const tableName = escape.tableName('workflow_entity');
 		const historyTableName = escape.tableName('workflow_history');
 		const idColumn = escape.columnName('id');
@@ -66,7 +74,15 @@ export class ActivateExecuteWorkflowTriggerWorkflows1763048000000 implements Irr
 
 		await runInBatches<Workflow>(inactiveWorkflows, async (workflows) => {
 			for (const workflow of workflows) {
-				const nodes = parseJson(workflow.nodes);
+				let nodes: Node[];
+				try {
+					nodes = parseJson(workflow.nodes);
+				} catch (error) {
+					logger.warn(
+						`[${migrationName}] Failed to parse nodes for workflow ${workflow.id}: ${error instanceof Error ? error.message : 'Unknown error'}. Skipping this workflow.`,
+					);
+					continue;
+				}
 
 				const { executeWorkflowTriggerNode, errorTriggerNode } =
 					this.findExecuteWfAndErrorTriggers(nodes);


### PR DESCRIPTION
## Summary

Fixes migration failure when workflows contain unescaped control characters in their nodes JSON, which was blocking v1 to v2 upgrades for some customers.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4612/bug-activateexecuteworkflowtriggerworkflows1763048000000-migration

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
