### PR TITLE
fix: Implements SLSA L3 provenance and VEX attestation

### DIFF
--- a/.github/scripts/docker/get-manifest-digests.mjs
+++ b/.github/scripts/docker/get-manifest-digests.mjs
@@ -19,16 +19,11 @@ const githubOutput = process.env.GITHUB_OUTPUT || null;
 
 function getDigest(imageRef) {
 	if (!imageRef) return '';
-	try {
-		const raw = execSync(`docker buildx imagetools inspect "${imageRef}" --raw`, {
-			encoding: 'utf8',
-			stdio: ['pipe', 'pipe', 'pipe'],
-		});
-		const hash = execSync('sha256sum', { input: raw, encoding: 'utf8' }).split(' ')[0].trim();
-		return `sha256:${hash}`;
-	} catch {
-		return '';
-	}
+	const raw = execSync(`docker buildx imagetools inspect "${imageRef}" --raw`, {
+		encoding: 'utf8',
+	});
+	const hash = execSync('sha256sum', { input: raw, encoding: 'utf8' }).split(' ')[0].trim();
+	return `sha256:${hash}`;
 }
 
 function getImageName(imageRef) {

--- a/.github/scripts/docker/get-manifest-digests.mjs
+++ b/.github/scripts/docker/get-manifest-digests.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * Extracts manifest digests and image names for SLSA provenance and VEX attestation.
+ *
+ * Usage:
+ *   N8N_TAG=ghcr.io/n8n-io/n8n:1.0.0 node get-manifest-digests.mjs
+ *
+ * Environment variables:
+ *   N8N_TAG              - Full image reference for n8n image
+ *   RUNNERS_TAG          - Full image reference for runners image
+ *   DISTROLESS_TAG       - Full image reference for runners-distroless image
+ *   GITHUB_OUTPUT        - Path to GitHub Actions output file (optional)
+ */
+
+import { execSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+
+const githubOutput = process.env.GITHUB_OUTPUT || null;
+
+function getDigest(imageRef) {
+	if (!imageRef) return '';
+	try {
+		const raw = execSync(`docker buildx imagetools inspect "${imageRef}" --raw`, {
+			encoding: 'utf8',
+			stdio: ['pipe', 'pipe', 'pipe'],
+		});
+		const hash = execSync('sha256sum', { input: raw, encoding: 'utf8' }).split(' ')[0].trim();
+		return `sha256:${hash}`;
+	} catch {
+		return '';
+	}
+}
+
+function getImageName(imageRef) {
+	if (!imageRef) return '';
+	return imageRef.replace(/:([^:]+)$/, '');
+}
+
+function setOutput(name, value) {
+	if (githubOutput && value) appendFileSync(githubOutput, `${name}=${value}\n`);
+}
+
+const n8nTag = process.env.N8N_TAG || '';
+const runnersTag = process.env.RUNNERS_TAG || '';
+const distrolessTag = process.env.DISTROLESS_TAG || '';
+
+const results = {
+	n8n: { digest: getDigest(n8nTag), image: getImageName(n8nTag) },
+	runners: { digest: getDigest(runnersTag), image: getImageName(runnersTag) },
+	runners_distroless: { digest: getDigest(distrolessTag), image: getImageName(distrolessTag) },
+};
+
+setOutput('n8n_digest', results.n8n.digest);
+setOutput('n8n_image', results.n8n.image);
+setOutput('runners_digest', results.runners.digest);
+setOutput('runners_image', results.runners.image);
+setOutput('runners_distroless_digest', results.runners_distroless.digest);
+setOutput('runners_distroless_image', results.runners_distroless.image);
+
+console.log('=== Manifest Digests ===');
+console.log(`n8n: ${results.n8n.digest || 'N/A'}`);
+console.log(`runners: ${results.runners.digest || 'N/A'}`);
+console.log(`runners-distroless: ${results.runners_distroless.digest || 'N/A'}`);
+console.log('');
+console.log('=== Image Names ===');
+console.log(`n8n: ${results.n8n.image || 'N/A'}`);
+console.log(`runners: ${results.runners.image || 'N/A'}`);
+console.log(`runners-distroless: ${results.runners_distroless.image || 'N/A'}`);

--- a/.github/trivy.yaml
+++ b/.github/trivy.yaml
@@ -1,0 +1,5 @@
+# Trivy configuration for n8n security scans
+# See: https://trivy.dev/latest/docs/references/configuration/config-file/
+vulnerability:
+  vex:
+    - vex.openvex.json

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -251,45 +251,11 @@ jobs:
 
       - name: Get manifest digests for attestation
         id: get-digests
-        run: |
-          # Get the digest of each multi-arch manifest for SLSA provenance and VEX attestation
-          get_digest() {
-            local IMAGE=$1
-            docker buildx imagetools inspect "$IMAGE" --format '{{json .Manifest.Digest}}' | tr -d '"'
-          }
-
-          # Extract image name (without tag) from a full image reference
-          get_image_name() {
-            local TAG=$1
-            echo "${TAG%:*}"  # Remove everything after the last colon
-          }
-
-          N8N_TAG="${{ needs.build-and-push-docker.outputs.primary_ghcr_manifest_tag }}"
-          RUNNERS_TAG="${{ needs.build-and-push-docker.outputs.runners_primary_ghcr_manifest_tag }}"
-          DISTROLESS_TAG="${{ needs.build-and-push-docker.outputs.runners_distroless_primary_ghcr_manifest_tag }}"
-
-          if [[ -n "$N8N_TAG" ]]; then
-            echo "n8n_digest=$(get_digest "$N8N_TAG")" >> "$GITHUB_OUTPUT"
-            echo "n8n_image=$(get_image_name "$N8N_TAG")" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ -n "$RUNNERS_TAG" ]]; then
-            echo "runners_digest=$(get_digest "$RUNNERS_TAG")" >> "$GITHUB_OUTPUT"
-            echo "runners_image=$(get_image_name "$RUNNERS_TAG")" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ -n "$DISTROLESS_TAG" ]]; then
-            echo "runners_distroless_digest=$(get_digest "$DISTROLESS_TAG")" >> "$GITHUB_OUTPUT"
-            echo "runners_distroless_image=$(get_image_name "$DISTROLESS_TAG")" >> "$GITHUB_OUTPUT"
-          fi
-
-          echo "=== Manifest Digests ==="
-          echo "n8n: $(get_digest "$N8N_TAG" 2>/dev/null || echo 'N/A')"
-          echo "runners: $(get_digest "$RUNNERS_TAG" 2>/dev/null || echo 'N/A')"
-          echo "runners-distroless: $(get_digest "$DISTROLESS_TAG" 2>/dev/null || echo 'N/A')"
-          echo ""
-          echo "=== Image Names ==="
-          echo "n8n: $(get_image_name "$N8N_TAG")"
-          echo "runners: $(get_image_name "$RUNNERS_TAG")"
-          echo "runners-distroless: $(get_image_name "$DISTROLESS_TAG")"
+        env:
+          N8N_TAG: ${{ needs.build-and-push-docker.outputs.primary_ghcr_manifest_tag }}
+          RUNNERS_TAG: ${{ needs.build-and-push-docker.outputs.runners_primary_ghcr_manifest_tag }}
+          DISTROLESS_TAG: ${{ needs.build-and-push-docker.outputs.runners_distroless_primary_ghcr_manifest_tag }}
+        run: node .github/scripts/docker/get-manifest-digests.mjs
 
   call-success-url:
     name: Call Success URL

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -115,6 +115,7 @@ jobs:
           dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push n8n Docker image
+        id: build-n8n
         uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
         with:
           context: .
@@ -124,12 +125,13 @@ jobs:
             N8N_VERSION=${{ needs.determine-build-context.outputs.n8n_version }}
             N8N_RELEASE_TYPE=${{ needs.determine-build-context.outputs.release_type }}
           platforms: ${{ matrix.docker_platform }}
-          provenance: true
+          provenance: false # Disabled - using SLSA L3 generator for isolated provenance
           sbom: true
           push: ${{ needs.determine-build-context.outputs.push_enabled == 'true' }}
           tags: ${{ steps.determine-tags.outputs.n8n_tags }}
 
       - name: Build and push task runners Docker image (Alpine)
+        id: build-runners
         uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
         with:
           context: .
@@ -139,12 +141,13 @@ jobs:
             N8N_VERSION=${{ needs.determine-build-context.outputs.n8n_version }}
             N8N_RELEASE_TYPE=${{ needs.determine-build-context.outputs.release_type }}
           platforms: ${{ matrix.docker_platform }}
-          provenance: true
+          provenance: false # Disabled - using SLSA L3 generator for isolated provenance
           sbom: true
           push: ${{ needs.determine-build-context.outputs.push_enabled == 'true' }}
           tags: ${{ steps.determine-tags.outputs.runners_tags }}
 
       - name: Build and push task runners Docker image (distroless)
+        id: build-runners-distroless
         uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
         with:
           context: .
@@ -154,7 +157,7 @@ jobs:
             N8N_VERSION=${{ needs.determine-build-context.outputs.n8n_version }}
             N8N_RELEASE_TYPE=${{ needs.determine-build-context.outputs.release_type }}
           platforms: ${{ matrix.docker_platform }}
-          provenance: true
+          provenance: false # Disabled - using SLSA L3 generator for isolated provenance
           sbom: true
           push: ${{ needs.determine-build-context.outputs.push_enabled == 'true' }}
           tags: ${{ steps.determine-tags.outputs.runners_distroless_tags }}
@@ -166,6 +169,13 @@ jobs:
     if: |
       needs.build-and-push-docker.result == 'success' &&
       needs.determine-build-context.outputs.push_enabled == 'true'
+    outputs:
+      n8n_digest: ${{ steps.get-digests.outputs.n8n_digest }}
+      n8n_image: ${{ steps.get-digests.outputs.n8n_image }}
+      runners_digest: ${{ steps.get-digests.outputs.runners_digest }}
+      runners_image: ${{ steps.get-digests.outputs.runners_image }}
+      runners_distroless_digest: ${{ steps.get-digests.outputs.runners_distroless_digest }}
+      runners_distroless_image: ${{ steps.get-digests.outputs.runners_distroless_image }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -239,6 +249,48 @@ jobs:
               "${DOCKER_BASE}/${IMAGE_NAME}:${TAG_SUFFIX}-arm64"
           done
 
+      - name: Get manifest digests for attestation
+        id: get-digests
+        run: |
+          # Get the digest of each multi-arch manifest for SLSA provenance and VEX attestation
+          get_digest() {
+            local IMAGE=$1
+            docker buildx imagetools inspect "$IMAGE" --format '{{json .Manifest.Digest}}' | tr -d '"'
+          }
+
+          # Extract image name (without tag) from a full image reference
+          get_image_name() {
+            local TAG=$1
+            echo "${TAG%:*}"  # Remove everything after the last colon
+          }
+
+          N8N_TAG="${{ needs.build-and-push-docker.outputs.primary_ghcr_manifest_tag }}"
+          RUNNERS_TAG="${{ needs.build-and-push-docker.outputs.runners_primary_ghcr_manifest_tag }}"
+          DISTROLESS_TAG="${{ needs.build-and-push-docker.outputs.runners_distroless_primary_ghcr_manifest_tag }}"
+
+          if [[ -n "$N8N_TAG" ]]; then
+            echo "n8n_digest=$(get_digest "$N8N_TAG")" >> "$GITHUB_OUTPUT"
+            echo "n8n_image=$(get_image_name "$N8N_TAG")" >> "$GITHUB_OUTPUT"
+          fi
+          if [[ -n "$RUNNERS_TAG" ]]; then
+            echo "runners_digest=$(get_digest "$RUNNERS_TAG")" >> "$GITHUB_OUTPUT"
+            echo "runners_image=$(get_image_name "$RUNNERS_TAG")" >> "$GITHUB_OUTPUT"
+          fi
+          if [[ -n "$DISTROLESS_TAG" ]]; then
+            echo "runners_distroless_digest=$(get_digest "$DISTROLESS_TAG")" >> "$GITHUB_OUTPUT"
+            echo "runners_distroless_image=$(get_image_name "$DISTROLESS_TAG")" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "=== Manifest Digests ==="
+          echo "n8n: $(get_digest "$N8N_TAG" 2>/dev/null || echo 'N/A')"
+          echo "runners: $(get_digest "$RUNNERS_TAG" 2>/dev/null || echo 'N/A')"
+          echo "runners-distroless: $(get_digest "$DISTROLESS_TAG" 2>/dev/null || echo 'N/A')"
+          echo ""
+          echo "=== Image Names ==="
+          echo "n8n: $(get_image_name "$N8N_TAG")"
+          echo "runners: $(get_image_name "$RUNNERS_TAG")"
+          echo "runners-distroless: $(get_image_name "$DISTROLESS_TAG")"
+
   call-success-url:
     name: Call Success URL
     needs: [create_multi_arch_manifest]
@@ -253,6 +305,113 @@ jobs:
           echo "Calling success URL: ${{ env.SUCCESS_URL }}"
           curl -v "${{ env.SUCCESS_URL }}" || echo "Failed to call success URL"
         shell: bash
+
+  # SLSA L3 Provenance - Must use version tags (@vX.Y.Z), NOT SHAs
+  provenance-n8n:
+    name: SLSA Provenance (n8n)
+    needs: [determine-build-context, build-and-push-docker, create_multi_arch_manifest]
+    if: |
+      needs.create_multi_arch_manifest.result == 'success' &&
+      needs.create_multi_arch_manifest.outputs.n8n_digest != ''
+    permissions:
+      id-token: write
+      packages: write
+      actions: read
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    with:
+      image: ${{ needs.create_multi_arch_manifest.outputs.n8n_image }}
+      digest: ${{ needs.create_multi_arch_manifest.outputs.n8n_digest }}
+      registry-username: ${{ github.actor }}
+    secrets:
+      registry-password: ${{ secrets.GITHUB_TOKEN }}
+
+  provenance-runners:
+    name: SLSA Provenance (runners)
+    needs: [determine-build-context, build-and-push-docker, create_multi_arch_manifest]
+    if: |
+      needs.create_multi_arch_manifest.result == 'success' &&
+      needs.create_multi_arch_manifest.outputs.runners_digest != ''
+    permissions:
+      id-token: write
+      packages: write
+      actions: read
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    with:
+      image: ${{ needs.create_multi_arch_manifest.outputs.runners_image }}
+      digest: ${{ needs.create_multi_arch_manifest.outputs.runners_digest }}
+      registry-username: ${{ github.actor }}
+    secrets:
+      registry-password: ${{ secrets.GITHUB_TOKEN }}
+
+  provenance-runners-distroless:
+    name: SLSA Provenance (runners-distroless)
+    needs: [determine-build-context, build-and-push-docker, create_multi_arch_manifest]
+    if: |
+      needs.create_multi_arch_manifest.result == 'success' &&
+      needs.create_multi_arch_manifest.outputs.runners_distroless_digest != ''
+    permissions:
+      id-token: write
+      packages: write
+      actions: read
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    with:
+      image: ${{ needs.create_multi_arch_manifest.outputs.runners_distroless_image }}
+      digest: ${{ needs.create_multi_arch_manifest.outputs.runners_distroless_digest }}
+      registry-username: ${{ github.actor }}
+    secrets:
+      registry-password: ${{ secrets.GITHUB_TOKEN }}
+
+  # VEX Attestation - Documents which CVEs affect us (vex.openvex.json)
+  vex-attestation:
+    name: VEX Attestation
+    needs: [determine-build-context, build-and-push-docker, create_multi_arch_manifest, provenance-n8n, provenance-runners, provenance-runners-distroless]
+    if: |
+      always() &&
+      needs.create_multi_arch_manifest.result == 'success' &&
+      (needs.determine-build-context.outputs.release_type == 'stable' ||
+       needs.determine-build-context.outputs.release_type == 'rc' ||
+       needs.determine-build-context.outputs.release_type == 'nightly')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0
+
+      - name: Login to GHCR
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Attest VEX to n8n image
+        if: needs.create_multi_arch_manifest.outputs.n8n_digest != ''
+        run: |
+          cosign attest --yes \
+            --type openvex \
+            --predicate vex.openvex.json \
+            ${{ needs.create_multi_arch_manifest.outputs.n8n_image }}@${{ needs.create_multi_arch_manifest.outputs.n8n_digest }}
+
+      - name: Attest VEX to runners image
+        if: needs.create_multi_arch_manifest.outputs.runners_digest != ''
+        run: |
+          cosign attest --yes \
+            --type openvex \
+            --predicate vex.openvex.json \
+            ${{ needs.create_multi_arch_manifest.outputs.runners_image }}@${{ needs.create_multi_arch_manifest.outputs.runners_digest }}
+
+      - name: Attest VEX to runners-distroless image
+        if: needs.create_multi_arch_manifest.outputs.runners_distroless_digest != ''
+        run: |
+          cosign attest --yes \
+            --type openvex \
+            --predicate vex.openvex.json \
+            ${{ needs.create_multi_arch_manifest.outputs.runners_distroless_image }}@${{ needs.create_multi_arch_manifest.outputs.runners_distroless_digest }}
 
   security-scan:
     name: Security Scan

--- a/.github/workflows/sbom-generation-callable.yml
+++ b/.github/workflows/sbom-generation-callable.yml
@@ -62,41 +62,27 @@ jobs:
           format: cyclonedx-json
           output-file: sbom-source.cdx.json
 
-      - name: Attest build provenance for source release
-        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a0 # v3.0.0
-        with:
-          subject-path: './package.json'
-
       - name: Attest SBOM for source release
         uses: actions/attest-sbom@4651f806c01d8637787e274ac3bdf724ef169f34 # v3.0.0
         with:
           subject-path: './package.json'
           sbom-path: 'sbom-source.cdx.json'
 
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0
-
-      - name: Sign SBOM (keyless)
-        run: |
-          # Sign SBOM using Cosign keyless signing with GitHub OIDC
-          # This provides cryptographic proof of authenticity and integrity
-          cosign sign-blob --yes --output-signature sbom-source.cdx.sig --output-certificate sbom-source.cdx.pem sbom-source.cdx.json
-
-      - name: Attach SBOM files to release
+      - name: Attach SBOM and VEX files to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Upload SBOM files to the existing release
+          # Upload SBOM and VEX files to the existing release
           gh release upload "${{ inputs.release_tag_ref }}" \
             sbom-source.cdx.json \
-            sbom-source.cdx.sig \
-            sbom-source.cdx.pem \
+            vex.openvex.json \
             --clobber
 
           COMPONENT_COUNT=$(jq '.components | length' sbom-source.cdx.json 2>/dev/null || echo "unknown")
-          echo "✅ SBOM workflow completed"
-          echo "📊 SBOM contains $COMPONENT_COUNT components"
-          echo "🛡️ GitHub attestations created for source release"
+          VEX_STATEMENTS=$(jq '.statements | length' vex.openvex.json 2>/dev/null || echo "0")
+          echo "SBOM and VEX attached to release"
+          echo "  - SBOM: $COMPONENT_COUNT components"
+          echo "  - VEX: $VEX_STATEMENTS CVE statements"
 
       - name: Notify Slack on failure
         if: failure()

--- a/.github/workflows/security-trivy-scan-callable.yml
+++ b/.github/workflows/security-trivy-scan-callable.yml
@@ -30,6 +30,14 @@ jobs:
     name: Security - Scan Docker Image With Trivy
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout for VEX file
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          sparse-checkout: |
+            vex.openvex.json
+            .github/trivy.yaml
+          sparse-checkout-cone-mode: false
+
       - name: Pull Docker image with retry
         run: |
           for i in {1..4}; do
@@ -47,6 +55,7 @@ jobs:
           severity: 'CRITICAL,HIGH,MEDIUM,LOW'
           ignore-unfixed: false
           exit-code: '0'
+          trivy-config: '.github/trivy.yaml'
 
       - name: Calculate vulnerability counts
         id: process_results

--- a/scripts/scan-n8n-image.mjs
+++ b/scripts/scan-n8n-image.mjs
@@ -27,6 +27,7 @@ const config = {
 	scanners: process.env.TRIVY_SCANNERS || 'vuln',
 	quiet: process.env.TRIVY_QUIET === 'true',
 	rootDir: rootDir,
+	vexFile: process.env.TRIVY_VEX || path.join(rootDir, 'vex.openvex.json'),
 };
 
 config.fullImageName = `${config.imageBaseName}:${config.imageTag}`;
@@ -52,6 +53,7 @@ const printSummary = (status, time, message) => {
 	echo(chalk.gray(`  • Target Image: ${config.fullImageName}`));
 	echo(chalk.gray(`  • Severity Levels: ${config.severity}`));
 	echo(chalk.gray(`  • Scanners: ${config.scanners}`));
+	echo(chalk.gray(`  • VEX file: ${config.vexFile}`));
 	if (config.ignoreUnfixed) echo(chalk.gray(`  • Ignored unfixed: yes`));
 	echo(chalk.blue.bold('========================'));
 };
@@ -90,6 +92,8 @@ const printSummary = (status, time, message) => {
 		'--rm',
 		'-v',
 		'/var/run/docker.sock:/var/run/docker.sock',
+		'-v',
+		`${config.vexFile}:/vex.openvex.json:ro`,
 		config.trivyImage,
 		'image',
 		'--severity',
@@ -101,6 +105,8 @@ const printSummary = (status, time, message) => {
 		'--scanners',
 		config.scanners,
 		'--no-progress',
+		'--vex',
+		'/vex.openvex.json',
 	];
 
 	if (config.ignoreUnfixed) trivyArgs.push('--ignore-unfixed');

--- a/vex.openvex.json
+++ b/vex.openvex.json
@@ -1,0 +1,9 @@
+{
+	"_comment": "VEX - CVE false positive triage. To add entries, see Quality Corner or .github/WORKFLOWS.md#vex",
+	"@context": "https://openvex.dev/ns/v0.2.0",
+	"@id": "https://github.com/n8n-io/n8n/vex",
+	"author": "n8n Security Team <security@n8n.io>",
+	"timestamp": "2026-01-15T00:00:00Z",
+	"version": 1,
+	"statements": []
+}


### PR DESCRIPTION
## Summary

Adds SLSA L3 provenance generation for Docker images using the slsa-github-generator. This provides cryptographic proof of build integrity.

Also introduces VEX (Vulnerability Exploitability eXchange) attestation to document which CVEs actually affect n8n, reducing false positives from scanners. VEX information is stored in `vex.openvex.json`.

The changes disable the default provenance generation in `build-push-action` in favor of the SLSA L3 generator and configure Trivy to use the VEX file during security scans.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2120/ci-upgrade-to-slsa-build-level-3-for-supply-chain-security


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
