### PR TITLE
fix: Update diff to 8.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,8 @@
       "jws@4": "4.0.1",
       "qs@6": "6.14.1",
       "@smithy/config-resolver": ">=4.4.0",
-      "@rudderstack/rudder-sdk-node@<=3.0.0": "3.0.0"
+      "@rudderstack/rudder-sdk-node@<=3.0.0": "3.0.0",
+      "diff@8": "8.0.3"
     },
     "patchedDependencies": {
       "bull@4.16.4": "patches/bull@4.16.4.patch",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -313,6 +313,7 @@ overrides:
   qs@6: 6.14.1
   '@smithy/config-resolver': '>=4.4.0'
   '@rudderstack/rudder-sdk-node@<=3.0.0': 3.0.0
+  diff@8: 8.0.3
 
 patchedDependencies:
   '@lezer/highlight':
@@ -11230,8 +11231,8 @@ packages:
     resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
     engines: {node: '>=0.3.1'}
 
-  diff@8.0.2:
-    resolution: {integrity: sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==}
+  diff@8.0.3:
+    resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
 
   diffie-hellman@5.0.3:
@@ -28658,7 +28659,7 @@ snapshots:
 
   diff@5.2.0: {}
 
-  diff@8.0.2: {}
+  diff@8.0.3: {}
 
   diffie-hellman@5.0.3:
     dependencies:
@@ -36707,7 +36708,7 @@ snapshots:
       ansis: 4.2.0
       cac: 6.7.14
       chokidar: 4.0.3
-      diff: 8.0.2
+      diff: 8.0.3
       empathic: 2.0.0
       hookable: 5.5.3
       obug: 2.1.1


### PR DESCRIPTION
## Summary
Automated task completed by Claude.

### Task Description
Fix security vulnerability in diff package:

- Package: diff
- CVE: GHSA-73rr-hh4g-fpgx
- Severity: LOW
- Current version: 8.0.2
- Fixed version: 8.0.3
- Issue: jsdiff DoS vulnerability in parsePatch and applyPatch

Follow the security-fix.md template in .github/claude-templates/.
Use neutral commit message language (no CVE in title).

### Generated by
[Workflow Run #21048254973](https://github.com/n8n-io/n8n/actions/runs/21048254973)

---
*Triggered by @shortstacked via the Claude Task Runner workflow.*
