### PR TITLE
feat(editor): Add a clarifying callout to Merge Node schema view

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -952,6 +952,7 @@
 	"dataMapping.schemaView.execution.resumeUrl": "The URL for resuming a 'Wait' node",
 	"dataMapping.schemaView.variablesUpgrade": "Set global variables and use them across workflows with the Pro or Enterprise plan. <a href=\"https://docs.n8n.io/code/variables/\" target=\"_blank\">Details</a>",
 	"dataMapping.schemaView.variablesEmpty": "Create variables that can be used across workflows <a href=\"/variables\" target=\"_blank\">here</a>",
+	"dataMapping.schemaView.mergeNotice": "This schema shows fields from multiple items. Some fields may be absent in individual items.",
 	"displayWithChange.cancelEdit": "Cancel Edit",
 	"displayWithChange.clickToChange": "Click to Change",
 	"displayWithChange.setValue": "Set Value",

--- a/packages/frontend/editor-ui/src/app/composables/useDataSchema.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useDataSchema.ts
@@ -318,6 +318,14 @@ export type RenderNotice = {
 	message: string;
 };
 
+export type RenderCallout = {
+	id: string;
+	type: 'callout';
+	level: number;
+	message: string;
+	theme?: 'info' | 'success' | 'warning' | 'danger' | 'secondary';
+};
+
 export type RenderEmpty = {
 	id: string;
 	type: 'empty';
@@ -326,7 +334,13 @@ export type RenderEmpty = {
 	key: 'emptyData' | 'emptySchema' | 'emptySchemaWithBinary' | 'executeSchema';
 };
 
-export type Renders = RenderHeader | RenderItem | RenderIcon | RenderNotice | RenderEmpty;
+export type Renders =
+	| RenderHeader
+	| RenderItem
+	| RenderIcon
+	| RenderNotice
+	| RenderCallout
+	| RenderEmpty;
 
 const icons = {
 	binary: DATA_TYPE_ICON_MAP.file,
@@ -505,6 +519,17 @@ export const useFlattenSchema = () => {
 
 			if (closedNodes.value.has(item.node.name)) {
 				return acc;
+			}
+
+			if (item.node.type === 'n8n-nodes-base.merge' && item.itemsCount > 1) {
+				const mergeCallout: RenderCallout = {
+					id: 'ndv.schema.mergeNotice',
+					type: 'callout',
+					level: 2,
+					message: useI18n().baseText('dataMapping.schemaView.mergeNotice'),
+					theme: 'info',
+				};
+				acc.push(mergeCallout);
 			}
 
 			if (isEmptySchema(item.schema)) {

--- a/packages/frontend/editor-ui/src/app/composables/useDataSchema.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useDataSchema.ts
@@ -523,7 +523,7 @@ export const useFlattenSchema = () => {
 
 			if (item.node.type === 'n8n-nodes-base.merge' && item.itemsCount > 1) {
 				const mergeCallout: RenderCallout = {
-					id: 'ndv.schema.mergeNotice',
+					id: `${item.node.name}-mergeNotice`,
 					type: 'callout',
 					level: 2,
 					message: useI18n().baseText('dataMapping.schemaView.mergeNotice'),

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.test.ts
@@ -1333,7 +1333,7 @@ describe('VirtualSchema.vue', () => {
 		it('should hide callout when dismissed', async () => {
 			const dismissMock = vi.fn();
 			vi.spyOn(calloutHelpers, 'useCalloutHelpers').mockReturnValue({
-				isCalloutDismissed: vi.fn((id: string) => id === 'ndv.schema.mergeNotice'),
+				isCalloutDismissed: vi.fn((id: string) => id === 'Merge-mergeNotice'),
 				dismissCallout: dismissMock,
 				openSampleWorkflowTemplate: vi.fn(),
 				getTutorialTemplatesNodeCreatorItems: vi.fn(() => []),

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.test.ts
@@ -7,6 +7,7 @@ import { createComponentRenderer } from '@/__tests__/render';
 import VirtualSchema from './VirtualSchema.vue';
 import * as nodeHelpers from '@/app/composables/useNodeHelpers';
 import { useTelemetry } from '@/app/composables/useTelemetry';
+import * as calloutHelpers from '@/app/composables/useCalloutHelpers';
 import {
 	IF_NODE_TYPE,
 	MANUAL_TRIGGER_NODE_TYPE,
@@ -21,6 +22,7 @@ import { createTestingPinia } from '@pinia/testing';
 import { fireEvent } from '@testing-library/dom';
 import { userEvent } from '@testing-library/user-event';
 import { cleanup, waitFor } from '@testing-library/vue';
+import { computed } from 'vue';
 import {
 	createResultOk,
 	NodeConnectionTypes,
@@ -97,6 +99,13 @@ const customerDatastoreNode = createTestNode({
 	disabled: false,
 });
 
+const mergeNode = createTestNode({
+	name: 'Merge',
+	type: 'n8n-nodes-base.merge',
+	typeVersion: 3,
+	disabled: false,
+});
+
 const defaultNodes = [
 	{ name: 'Manual Trigger', indicies: [], depth: 1 },
 	{ name: 'Set2', indicies: [], depth: 2 },
@@ -122,6 +131,8 @@ const mockI18nKeys: Record<string, string> = {
 		'The fields below come from the last successful execution. {execute} to refresh them.',
 	'dataMapping.schemaView.previewLastExecution.executePreviousNodes': 'Execute node',
 	'dataMapping.schemaView.preview.executeNode': 'Execute the node',
+	'dataMapping.schemaView.mergeNotice':
+		'This schema shows fields from multiple items. Some fields may be absent in individual items.',
 	'node.disabled': 'Deactivated',
 	'ndv.input.noOutputData.executePrevious': 'Execute previous nodes',
 	'ndv.search.noNodeMatch.title': 'No matching nodes',
@@ -146,6 +157,7 @@ async function setupStore() {
 			nodeWithCredential,
 			splitInBatchesNode,
 			customerDatastoreNode,
+			mergeNode,
 		],
 	};
 
@@ -178,6 +190,10 @@ async function setupStore() {
 		}),
 		mockNodeTypeDescription({
 			name: 'n8n-nodes-base.n8nTrainingCustomerDatastore',
+			outputs: [NodeConnectionTypes.Main],
+		}),
+		mockNodeTypeDescription({
+			name: 'n8n-nodes-base.merge',
 			outputs: [NodeConnectionTypes.Main],
 		}),
 	]);
@@ -221,6 +237,7 @@ describe('VirtualSchema.vue', () => {
 	const DynamicScrollerItemStub = {
 		template: '<slot></slot>',
 	};
+
 	const NoticeStub = {
 		template: '<div v-bind="$attrs"><slot></slot></div>',
 	};
@@ -230,11 +247,29 @@ describe('VirtualSchema.vue', () => {
 			'<button v-bind="$attrs" @click="(e) => { e.stopPropagation(); $emit(\'click\', e); }"><slot></slot></button>',
 	};
 
+	const N8nCalloutStub = {
+		template:
+			'<div class="n8n-callout" v-bind="$attrs"><slot></slot><slot name="trailingContent"></slot></div>',
+	};
+
+	const NodeIconStub = {
+		template: '<node-icon-stub :node-type="nodeType.name" :size="size"></node-icon-stub>',
+		props: ['node-type', 'size'],
+	};
+
 	beforeEach(async () => {
 		cleanup();
 		vi.resetAllMocks();
 		vi.setSystemTime('2025-01-01');
 		const pinia = await setupStore();
+
+		vi.spyOn(calloutHelpers, 'useCalloutHelpers').mockReturnValue({
+			isCalloutDismissed: vi.fn(() => false),
+			dismissCallout: vi.fn(),
+			openSampleWorkflowTemplate: vi.fn(),
+			getTutorialTemplatesNodeCreatorItems: vi.fn(() => []),
+			isRagStarterCalloutVisible: computed(() => false),
+		});
 
 		renderComponent = createComponentRenderer(VirtualSchema, {
 			global: {
@@ -243,11 +278,9 @@ describe('VirtualSchema.vue', () => {
 					DynamicScrollerItem: DynamicScrollerItemStub,
 					N8nIcon: true,
 					N8nLink: N8nLinkStub,
+					N8nCallout: N8nCalloutStub,
 					Notice: NoticeStub,
-					NodeIcon: {
-						template: '<node-icon-stub :node-type="nodeType.name" :size="size"></node-icon-stub>',
-						props: ['node-type', 'size'],
-					},
+					NodeIcon: NodeIconStub,
 				},
 				mocks: {
 					$locale: {
@@ -1215,6 +1248,113 @@ describe('VirtualSchema.vue', () => {
 			const allItems = queryAllByTestId('run-data-schema-item');
 			const hasPreviewData = allItems.some((item) => item.textContent?.includes('Preview Data'));
 			expect(hasPreviewData).toBe(false);
+		});
+	});
+
+	describe('merge node callout', () => {
+		it('should show callout when viewing Merge node output with more than 1 item', async () => {
+			const testData = [{ field1: 'value1', field2: 'value2' }, { field1: 'value3' }];
+			expect(testData.length).toBeGreaterThan(1);
+
+			const { getByText } = renderComponent({
+				props: {
+					node: mergeNode,
+					paneType: 'output',
+					data: testData,
+				},
+			});
+
+			await waitFor(() => {
+				expect(
+					getByText(
+						'This schema shows fields from multiple items. Some fields may be absent in individual items.',
+					),
+				).toBeInTheDocument();
+			});
+		});
+
+		it.each([
+			{ itemCount: 0, data: [] },
+			{ itemCount: 1, data: [{ field1: 'value1' }] },
+		])(
+			'should not show callout when Merge node output has $itemCount item(s)',
+			async ({ data }) => {
+				const { queryByText } = renderComponent({
+					props: {
+						node: mergeNode,
+						paneType: 'output',
+						data,
+					},
+				});
+
+				await waitFor(() => {
+					expect(
+						queryByText(
+							'This schema shows fields from multiple items. Some fields may be absent in individual items.',
+						),
+					).toBe(null);
+				});
+			},
+		);
+
+		it('should not show callout when viewing non-Merge node', async () => {
+			mockNodeOutputData(mockNode1.name, [{ json: { field1: 'value1' } }]);
+
+			const { queryByText } = renderComponent({
+				props: {
+					paneType: 'input',
+					nodes: [{ name: mockNode1.name, indicies: [], depth: 1 }],
+				},
+			});
+
+			await waitFor(() => {
+				expect(
+					queryByText(
+						'This schema shows fields from multiple items. Some fields may be absent in individual items.',
+					),
+				).toBe(null);
+			});
+		});
+
+		it('should show dismiss button on callout in output panel', async () => {
+			const { getByTestId } = renderComponent({
+				props: {
+					node: mergeNode,
+					paneType: 'output',
+					data: [{ field1: 'value1', field2: 'value2' }, { field1: 'value3' }],
+				},
+			});
+
+			await waitFor(() => {
+				expect(getByTestId('callout-dismiss-icon')).toBeInTheDocument();
+			});
+		});
+
+		it('should hide callout when dismissed', async () => {
+			const dismissMock = vi.fn();
+			vi.spyOn(calloutHelpers, 'useCalloutHelpers').mockReturnValue({
+				isCalloutDismissed: vi.fn((id: string) => id === 'ndv.schema.mergeNotice'),
+				dismissCallout: dismissMock,
+				openSampleWorkflowTemplate: vi.fn(),
+				getTutorialTemplatesNodeCreatorItems: vi.fn(() => []),
+				isRagStarterCalloutVisible: computed(() => false),
+			});
+
+			const { queryByText } = renderComponent({
+				props: {
+					node: mergeNode,
+					paneType: 'output',
+					data: [{ field1: 'value1', field2: 'value2' }, { field1: 'value3' }],
+				},
+			});
+
+			await waitFor(() => {
+				expect(
+					queryByText(
+						'This schema shows fields from multiple items. Some fields may be absent in individual items.',
+					),
+				).toBe(null);
+			});
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.vue
@@ -5,6 +5,7 @@ import Draggable from '@/app/components/Draggable.vue';
 import VirtualSchemaHeader from './VirtualSchemaHeader.vue';
 import VirtualSchemaItem from './VirtualSchemaItem.vue';
 import {
+	RenderCallout,
 	useDataSchema,
 	useFlattenSchema,
 	type RenderHeader,
@@ -16,6 +17,7 @@ import { useExternalHooks } from '@/app/composables/useExternalHooks';
 import { useI18n } from '@n8n/i18n';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { useTelemetry } from '@/app/composables/useTelemetry';
+import { useCalloutHelpers } from '@/app/composables/useCalloutHelpers';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
@@ -50,7 +52,7 @@ import { I18nT } from 'vue-i18n';
 import { useTelemetryContext } from '@/app/composables/useTelemetryContext';
 import NDVEmptyState from '@/features/ndv/panel/components/NDVEmptyState.vue';
 
-import { N8nIcon, N8nText, N8nTooltip } from '@n8n/design-system';
+import { N8nCallout, N8nIcon, N8nText, N8nTooltip } from '@n8n/design-system';
 type Props = {
 	nodes?: IConnectedNode[];
 	node?: INodeUi | null;
@@ -93,6 +95,7 @@ const { getSchemaForExecutionData, getSchemaForJsonSchema, getSchema, filterSche
 	useDataSchema();
 const { closedNodes, flattenSchema, flattenMultipleSchemas, toggleNode } = useFlattenSchema();
 const { getNodeInputData, getLastRunIndexWithData, hasNodeExecuted } = useNodeHelpers();
+const { dismissCallout, isCalloutDismissed } = useCalloutHelpers();
 
 const emit = defineEmits<{
 	'clear:search': [];
@@ -104,6 +107,10 @@ const closedNodesBeforeSearch = ref(new Set<string>());
 
 const canDraggableDrop = computed(() => ndvStore.canDraggableDrop);
 const draggableStickyPosition = computed(() => ndvStore.draggableStickyPos);
+
+const onCalloutDismiss = async (calloutId: string) => {
+	await dismissCallout(calloutId);
+};
 
 const toggleNodeExclusiveAndScrollTop = (id: string) => {
 	const isClosed = closedNodes.value.has(id);
@@ -392,11 +399,37 @@ const flattenNodeSchema = computed(() =>
 const isDebugging = computed(() => !props.nodes.length);
 
 const items = computed(() => {
+	let allItems: Renders[];
+
 	if (isDebugging.value || props.paneType === 'output') {
-		return flattenNodeSchema.value;
+		allItems = flattenNodeSchema.value;
+
+		if (
+			props.node?.type === 'n8n-nodes-base.merge' &&
+			props.paneType === 'output' &&
+			props.data &&
+			props.data.length > 1
+		) {
+			const mergeCallout: RenderCallout = {
+				id: 'ndv.schema.mergeNotice',
+				type: 'callout',
+				level: 0,
+				message: i18n.baseText('dataMapping.schemaView.mergeNotice'),
+				theme: 'info',
+			};
+			allItems = [mergeCallout, ...allItems];
+		}
+	} else {
+		allItems = flattenedNodes.value.concat(contextItems.value);
 	}
 
-	return flattenedNodes.value.concat(contextItems.value);
+	// Filter out dismissed callouts
+	return allItems.filter((item) => {
+		if (item.type === 'callout') {
+			return !isCalloutDismissed(item.id);
+		}
+		return true;
+	});
 });
 
 const noSearchResults = computed(() => {
@@ -548,6 +581,34 @@ const onDragEnd = (el: HTMLElement) => {
 							class="notice"
 							:style="{ '--schema-level': item.level }"
 						/>
+
+						<div
+							v-else-if="item.type === 'callout'"
+							class="callout-wrapper"
+							:style="{ '--schema-level': item.level }"
+							@click.stop
+						>
+							<N8nCallout
+								:theme="item.theme || 'info'"
+								:slim="true"
+								:round-corners="true"
+								:iconless="false"
+							>
+								{{ item.message }}
+								<template #trailingContent>
+									<N8nIcon
+										icon="x"
+										:title="i18n.baseText('generic.dismiss')"
+										size="medium"
+										type="secondary"
+										class="callout-dismiss"
+										data-test-id="callout-dismiss-icon"
+										@click="onCalloutDismiss(item.id)"
+									/>
+								</template>
+							</N8nCallout>
+						</div>
+
 						<div
 							v-else-if="item.type === 'empty'"
 							class="empty-schema"
@@ -632,5 +693,20 @@ const onDragEnd = (el: HTMLElement) => {
 	padding-bottom: var(--spacing--xs);
 	/* stylelint-disable-next-line @n8n/css-var-naming */
 	margin-left: calc((var(--spacing--xl) * var(--schema-level)));
+}
+
+.callout-wrapper {
+	padding-bottom: var(--spacing--xs);
+	/* stylelint-disable-next-line @n8n/css-var-naming */
+	margin-left: calc(var(--spacing--lg) * var(--schema-level));
+}
+
+.callout-dismiss {
+	margin-left: var(--spacing--xs);
+	line-height: 1;
+	cursor: pointer;
+}
+.callout-dismiss:hover {
+	color: var(--icon--color--hover);
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.vue
@@ -5,9 +5,9 @@ import Draggable from '@/app/components/Draggable.vue';
 import VirtualSchemaHeader from './VirtualSchemaHeader.vue';
 import VirtualSchemaItem from './VirtualSchemaItem.vue';
 import {
-	RenderCallout,
 	useDataSchema,
 	useFlattenSchema,
+	type RenderCallout,
 	type RenderHeader,
 	type RenderNotice,
 	type Renders,
@@ -411,7 +411,7 @@ const items = computed(() => {
 			props.data.length > 1
 		) {
 			const mergeCallout: RenderCallout = {
-				id: 'ndv.schema.mergeNotice',
+				id: `${props.node.name}-mergeNotice`,
 				type: 'callout',
 				level: 0,
 				message: i18n.baseText('dataMapping.schemaView.mergeNotice'),


### PR DESCRIPTION
## Summary

- Add a possibility to add dismissive callouts to the input and output panes (reuses the existing `useCalloutHelpers`)
- Add a callout to the input panel of nodes receiving data from Merge Nodes that appears if there is more than 1 item [changes in `useDataSchema.ts`] 
<img height="300" alt="image" src="https://github.com/user-attachments/assets/7cd9700b-fe89-44e4-bdc3-c21bc7fdbb50" />

- Add a callout to the output panel of the Merge Node that appears if there is more than 1 input item [changes in `VirtualSchema.vue`]
<img height="250" alt="image" src="https://github.com/user-attachments/assets/69d6e0a3-be5c-4ddc-b331-3c73e00c7104" />

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-4633](https://linear.app/n8n/issue/ADO-4633/add-a-clarifying-note-in-the-merge-node-output-in-schema-view)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
