### PR TITLE
test: Improve log streaming test reliability for community

### DIFF
--- a/packages/testing/playwright/pages/SettingsLogStreamingPage.ts
+++ b/packages/testing/playwright/pages/SettingsLogStreamingPage.ts
@@ -19,6 +19,10 @@ export class SettingsLogStreamingPage extends BasePage {
 		return this.getActionBoxLicensed().locator('button');
 	}
 
+	getAddNewDestinationButton(): Locator {
+		return this.page.getByRole('button', { name: 'Add new destination' });
+	}
+
 	getDestinationModal(): Locator {
 		return this.page.getByTestId('destination-modal');
 	}
@@ -83,8 +87,10 @@ export class SettingsLogStreamingPage extends BasePage {
 		return this.page.locator('.btn--confirm');
 	}
 
-	async clickAddFirstDestination(): Promise<void> {
-		await this.getAddFirstDestinationButton().click();
+	async addDestination(): Promise<void> {
+		const addFirstButton = this.getAddFirstDestinationButton();
+		const addNewButton = this.getAddNewDestinationButton();
+		await addFirstButton.or(addNewButton).click();
 	}
 
 	async clickSelectDestinationType(): Promise<void> {
@@ -122,7 +128,11 @@ export class SettingsLogStreamingPage extends BasePage {
 	}
 
 	async saveDestination(): Promise<void> {
+		const responsePromise = this.page.waitForResponse(
+			(res) => res.url().includes('/eventbus/destination') && res.request().method() === 'POST',
+		);
 		await this.getDestinationSaveButton().click();
+		await responsePromise;
 	}
 
 	async deleteDestination(): Promise<void> {
@@ -162,7 +172,7 @@ export class SettingsLogStreamingPage extends BasePage {
 	 * @param destinationName - The name to give the new destination
 	 */
 	async createDestination(destinationName: string): Promise<void> {
-		await this.clickAddFirstDestination();
+		await this.addDestination();
 		await this.getDestinationModal().waitFor({ state: 'visible' });
 		await this.clickSelectDestinationType();
 		await this.selectDestinationType(0); // Webhook
@@ -184,7 +194,7 @@ export class SettingsLogStreamingPage extends BasePage {
 		host: string;
 		port: number;
 	}): Promise<void> {
-		await this.clickAddFirstDestination();
+		await this.addDestination();
 		await this.getDestinationModal().waitFor({ state: 'visible' });
 		await this.clickSelectDestinationType();
 		await this.selectDestinationType(2); // Syslog (0=Webhook, 1=Sentry, 2=Syslog)

--- a/packages/testing/playwright/services/api-helper.ts
+++ b/packages/testing/playwright/services/api-helper.ts
@@ -375,6 +375,16 @@ export class ApiHelpers {
 		return result.data ?? result;
 	}
 
+	/**
+	 * Delete all log streaming destinations.
+	 */
+	async deleteAllLogStreamingDestinations(): Promise<void> {
+		const destinations = await this.getLogStreamingDestinations();
+		for (const destination of destinations) {
+			await this.deleteLogStreamingDestination(destination.id);
+		}
+	}
+
 	// ===== PRIVATE METHODS =====
 
 	private async loginAndSetCookies(

--- a/packages/testing/playwright/tests/e2e/settings/log-streaming/log-streaming.spec.ts
+++ b/packages/testing/playwright/tests/e2e/settings/log-streaming/log-streaming.spec.ts
@@ -25,6 +25,7 @@ test.describe('Log Streaming Settings', () => {
 	test.describe('licensed', () => {
 		test.beforeEach(async ({ n8n }) => {
 			await n8n.api.enableFeature('logStreaming');
+			await n8n.api.deleteAllLogStreamingDestinations();
 			await n8n.navigate.toLogStreaming();
 		});
 
@@ -35,7 +36,7 @@ test.describe('Log Streaming Settings', () => {
 		});
 
 		test('should show the add destination modal', async ({ n8n }) => {
-			await n8n.settingsLogStreaming.clickAddFirstDestination();
+			await n8n.settingsLogStreaming.addDestination();
 			await expect(n8n.settingsLogStreaming.getDestinationModal()).toBeVisible();
 			await expect(n8n.settingsLogStreaming.getSelectDestinationType()).toBeVisible();
 			await expect(n8n.settingsLogStreaming.getSelectDestinationButton()).toBeVisible();


### PR DESCRIPTION
## Summary

The Log streaming test was a bit unreliable due to not waiting on streams to be added before interacting with the cards. This waits on the requests now. Also handle cleanup between tests so retries will work.

Updated flaky test triage doc too: https://www.notion.so/n8n/How-To-Debug-a-Flaky-Test-2e95b6e0c94f812ea1daf1807a7b96a1

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
