### PR TITLE
fix(editor): Improve command bar loading state

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nCommandBar/CommandBar.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nCommandBar/CommandBar.test.ts
@@ -140,6 +140,43 @@ describe('components', () => {
 			);
 		});
 
+		describe('loading state', () => {
+			it('shows spinner only when isLoading is true', async () => {
+				const { rerender } = render(N8nCommandBar, {
+					props: { items: createSampleItems(), isLoading: false },
+				});
+				await openCommandBar();
+
+				expect(screen.queryByTestId('command-bar-input-spinner')).not.toBeInTheDocument();
+
+				await rerender({ items: createSampleItems(), isLoading: true });
+
+				expect(screen.getByTestId('command-bar-input-spinner')).toBeInTheDocument();
+			});
+
+			it('shows loading items when isLoading is true', async () => {
+				render(N8nCommandBar, {
+					props: { items: [], isLoading: true },
+				});
+				await openCommandBar();
+
+				expect(screen.getByTestId('command-bar-items-list')).toBeInTheDocument();
+			});
+
+			it('hides spinner when isLoading becomes false', async () => {
+				const { rerender } = render(N8nCommandBar, {
+					props: { items: createSampleItems(), isLoading: true },
+				});
+				await openCommandBar();
+
+				expect(screen.getByTestId('command-bar-input-spinner')).toBeInTheDocument();
+
+				await rerender({ items: createSampleItems(), isLoading: false });
+
+				expect(screen.queryByTestId('command-bar-input-spinner')).not.toBeInTheDocument();
+			});
+		});
+
 		describe('matchAnySearchTerm', () => {
 			it('should match entire query string when matchAnySearchTerm is false', async () => {
 				const items = [

--- a/packages/frontend/@n8n/design-system/src/components/N8nCommandBar/CommandBar.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nCommandBar/CommandBar.vue
@@ -296,7 +296,7 @@ onUnmounted(() => {
 							type="text"
 						/>
 						<div
-							v-if="isLoading || true"
+							v-if="isLoading"
 							:class="$style.inputSpinner"
 							data-test-id="command-bar-input-spinner"
 							aria-hidden="true"

--- a/packages/frontend/@n8n/design-system/src/components/N8nCommandBar/CommandBar.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nCommandBar/CommandBar.vue
@@ -7,6 +7,7 @@ import type { CommandBarItem } from './types';
 import N8nBadge from '../N8nBadge';
 import N8nLoading from '../N8nLoading/Loading.vue';
 import N8nScrollArea from '../N8nScrollArea/N8nScrollArea.vue';
+import N8nSpinner from '../N8nSpinner';
 
 interface CommandBarProps {
 	placeholder?: string;
@@ -29,7 +30,8 @@ const emit = defineEmits<{
 	navigateTo: [parentId: string | null];
 }>();
 
-const NUM_LOADING_ITEMS = 8;
+const NUM_LOADING_ITEMS_FULL = 8;
+const NUM_LOADING_ITEMS_PARTIAL = 3;
 
 const isOpen = ref(false);
 const inputRef = ref<HTMLInputElement>();
@@ -50,7 +52,6 @@ const currentPlaceholder = computed(() => {
 });
 
 const commandBarRef = ref<HTMLElement>();
-const itemsListRef = ref<HTMLElement>();
 const scrollAreaRef = ref<InstanceType<typeof N8nScrollArea>>();
 
 const filteredItems = computed(() => {
@@ -116,6 +117,10 @@ const flattenedItems = computed(() => {
 	});
 
 	return result;
+});
+
+const numLoadingItems = computed(() => {
+	return flattenedItems.value.length > 0 ? NUM_LOADING_ITEMS_PARTIAL : NUM_LOADING_ITEMS_FULL;
 });
 
 const getGlobalIndex = (item: CommandBarItem): number => {
@@ -282,26 +287,31 @@ onUnmounted(() => {
 					<div v-if="context" :class="$style.contextContainer">
 						<N8nBadge size="small">{{ context }}</N8nBadge>
 					</div>
-					<input
-						ref="inputRef"
-						v-model="inputValue"
-						:placeholder="currentPlaceholder"
-						:class="$style.input"
-						type="text"
-					/>
-					<div v-if="isLoading" :class="$style.loadingContainer">
-						<div v-for="i in NUM_LOADING_ITEMS" :key="i" :class="$style.loadingItem">
-							<N8nLoading variant="custom" :class="$style.loading" />
+					<div :class="$style.inputWrapper">
+						<input
+							ref="inputRef"
+							v-model="inputValue"
+							:placeholder="currentPlaceholder"
+							:class="$style.input"
+							type="text"
+						/>
+						<div
+							v-if="isLoading || true"
+							:class="$style.inputSpinner"
+							data-test-id="command-bar-input-spinner"
+							aria-hidden="true"
+						>
+							<N8nSpinner size="medium" />
 						</div>
 					</div>
 					<N8nScrollArea
-						v-else-if="flattenedItems.length > 0"
+						v-if="flattenedItems.length > 0 || isLoading"
 						ref="scrollAreaRef"
 						max-height="350px"
 						:class="$style.scrollArea"
 						data-test-id="command-bar-items-list"
 					>
-						<div ref="itemsListRef" :class="$style.itemsList">
+						<div :class="$style.itemsList">
 							<div v-if="groupedItems.ungrouped.length > 0" :class="$style.ungroupedSection">
 								<div v-for="item in groupedItems.ungrouped" :key="item.id">
 									<N8nCommandBarItem
@@ -322,6 +332,15 @@ onUnmounted(() => {
 									/>
 								</div>
 							</template>
+
+							<div
+								v-if="isLoading"
+								:class="[$style.loadingSection, { [$style.hasItems]: flattenedItems.length > 0 }]"
+							>
+								<div v-for="i in numLoadingItems" :key="i" :class="$style.loadingItem">
+									<N8nLoading variant="custom" :class="$style.loading" />
+								</div>
+							</div>
 						</div>
 					</N8nScrollArea>
 					<div v-else-if="inputValue && flattenedItems.length === 0" :class="$style.noResults">
@@ -348,6 +367,10 @@ onUnmounted(() => {
 	max-width: 700px;
 }
 
+.inputWrapper {
+	position: relative;
+}
+
 .input {
 	width: 100%;
 	border: none;
@@ -359,11 +382,21 @@ onUnmounted(() => {
 	height: var(--spacing--2xl);
 	padding: 0 var(--spacing--2xs);
 	padding-left: var(--spacing--sm);
+	padding-right: var(--spacing--xl);
 	border-bottom: var(--border);
 
 	&::placeholder {
 		color: var(--color--text--tint-1);
 	}
+}
+
+.inputSpinner {
+	position: absolute;
+	top: 0;
+	right: var(--spacing--sm);
+	height: 100%;
+	display: flex;
+	align-items: center;
 }
 
 .scrollArea {
@@ -401,14 +434,21 @@ onUnmounted(() => {
 	padding: var(--spacing--xs) var(--spacing--xs) 0;
 }
 
-.loadingContainer {
-	max-height: 300px;
-	overflow-y: auto;
+.loadingSection {
+	padding-top: var(--spacing--2xs);
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--5xs);
+
+	&.hasItems {
+		padding-top: 0;
+	}
 }
 
 .loadingItem {
-	height: var(--spacing--2xl);
-	padding: var(--spacing--xs) var(--spacing--sm);
+	height: var(--command-bar-item--height);
+	display: flex;
+	align-items: center;
 }
 </style>
 

--- a/packages/frontend/@n8n/design-system/src/components/N8nCommandBar/CommandBarItem.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nCommandBar/CommandBarItem.vue
@@ -66,7 +66,7 @@ const handleMouseLeave = () => {
 	display: flex;
 	gap: var(--spacing--2xs);
 	align-items: center;
-	height: 40px;
+	height: var(--command-bar-item--height);
 	padding: 0 var(--spacing--2xs);
 	cursor: pointer;
 	border-radius: var(--radius);

--- a/packages/frontend/@n8n/design-system/src/css/_tokens.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.scss
@@ -724,6 +724,7 @@
 	--grid--cell--border-color--editing: 2px solid var(--color--secondary);
 
 	--command-bar-item--color--background--hover: var(--color--background);
+	--command-bar-item--height: 40px;
 	--command-bar--shadow: 0 15px 45px 0 hsla(0, 0%, 0%, 0.13), 0 5px 10px 0 hsla(0, 0%, 0%, 0.08);
 
 	// Animation

--- a/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useCredentialNavigationCommands.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useCredentialNavigationCommands.test.ts
@@ -574,7 +574,7 @@ describe('useCredentialNavigationCommands', () => {
 
 			handlers.onCommandBarChange('gma');
 
-			expect(isLoading.value).toBe(false); // Not in parent node, so shouldn't be loading
+			expect(isLoading.value).toBe(true); // Should show loading during fetch
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useCredentialNavigationCommands.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useCredentialNavigationCommands.test.ts
@@ -503,6 +503,20 @@ describe('useCredentialNavigationCommands', () => {
 			expect(isLoading.value).toBe(true);
 		});
 
+		it('should reset loading state when navigating back to root', () => {
+			const { isLoading, handlers } = useCredentialNavigationCommands({
+				lastQuery: ref(''),
+				activeNodeId: ref(null),
+				currentProjectName: ref('Team Project'),
+			});
+
+			handlers.onCommandBarNavigateTo('open-credential');
+			expect(isLoading.value).toBe(true);
+
+			handlers.onCommandBarNavigateTo(null);
+			expect(isLoading.value).toBe(false);
+		});
+
 		it('should clear credential results when navigating back to root', async () => {
 			(mockCredentialsStore.allCredentials as unknown) = [
 				createMockCredential('cred-1', 'Gmail Account', 'gmailOAuth2', 'project-1', 'Team Project'),

--- a/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useCredentialNavigationCommands.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useCredentialNavigationCommands.ts
@@ -195,7 +195,7 @@ export function useCredentialNavigationCommands(options: {
 		const isRootWithQuery = activeNodeId.value === null && trimmed.length > 2;
 
 		if (isInCredentialParent || isRootWithQuery) {
-			isLoading.value = isInCredentialParent;
+			isLoading.value = true;
 			void fetchCredentialsDebounced(trimmed);
 		}
 	}
@@ -207,6 +207,7 @@ export function useCredentialNavigationCommands(options: {
 			isLoading.value = true;
 			void fetchCredentialsImpl('');
 		} else if (to === null) {
+			isLoading.value = false;
 			credentialResults.value = [];
 		}
 	}

--- a/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useDataTableNavigationCommands.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useDataTableNavigationCommands.test.ts
@@ -557,7 +557,7 @@ describe('useDataTableNavigationCommands', () => {
 			expect(isLoading.value).toBe(false);
 		});
 
-		it('should not set loading state when searching from root with query longer than 2 chars', () => {
+		it('should set loading state when searching from root with query longer than 2 chars', () => {
 			const activeNodeId = ref<string | null>(null);
 			const lastQuery = ref('cus');
 			const { isLoading, handlers } = useDataTableNavigationCommands({
@@ -568,7 +568,7 @@ describe('useDataTableNavigationCommands', () => {
 
 			handlers.onCommandBarChange('cus');
 
-			expect(isLoading.value).toBe(false); // Not in parent node, so shouldn't be loading
+			expect(isLoading.value).toBe(true); // Should show loading during fetch
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useDataTableNavigationCommands.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useDataTableNavigationCommands.ts
@@ -193,7 +193,7 @@ export function useDataTableNavigationCommands(options: {
 		const isRootWithQuery = activeNodeId.value === null && trimmed.length > 2;
 
 		if (isInDataTableParent || isRootWithQuery) {
-			isLoading.value = isInDataTableParent;
+			isLoading.value = true;
 			void fetchDataTablesDebounced(trimmed);
 		}
 	}
@@ -205,6 +205,7 @@ export function useDataTableNavigationCommands(options: {
 			isLoading.value = true;
 			void fetchDataTablesImpl('');
 		} else if (to === null) {
+			isLoading.value = false;
 			dataTableResults.value = [];
 			hasDataFetched.value = false;
 		}

--- a/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useWorkflowNavigationCommands.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useWorkflowNavigationCommands.ts
@@ -378,7 +378,7 @@ export function useWorkflowNavigationCommands(options: {
 		const isRootWithQuery = activeNodeId.value === null && trimmed.length > 2;
 
 		if (isInWorkflowParent || isRootWithQuery) {
-			isLoading.value = isInWorkflowParent;
+			isLoading.value = true;
 			void fetchWorkflowsDebounced(trimmed);
 		}
 	}
@@ -390,6 +390,7 @@ export function useWorkflowNavigationCommands(options: {
 			isLoading.value = true;
 			void fetchWorkflowsImpl('');
 		} else if (to === null) {
+			isLoading.value = false;
 			workflowResults.value = [];
 			workflowKeywords.value.clear();
 			workflowMatchedNodeTypes.value.clear();


### PR DESCRIPTION
## Summary

* Fix misleading “no results” state while commands are still loading by keeping the results list visible during fetch and rendering loading placeholders (full skeleton on empty list, partial skeleton when results already exist).
* Added loading spinner in the search input when the component is loading to better communicate loading state when the placeholders are after many items and not visible
* Tweak loading placeholders styling

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4652/bug-command-bar-shows-no-results-while-loading-misleading-esp-if#comment-dc4ed3e6


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
