### PR TITLE
fix(core): Log warning where file values contain white space at the start or end (e.g. new lines)

### DIFF
--- a/packages/@n8n/config/src/decorators.ts
+++ b/packages/@n8n/config/src/decorators.ts
@@ -21,7 +21,7 @@ const readEnv = (envName: string) => {
 
 	// Read the value from a file, if "_FILE" environment variable is defined
 	const filePath = process.env[`${envName}_FILE`];
-	if (filePath) return readFileSync(filePath, 'utf8');
+	if (filePath) return readFileSync(filePath, 'utf8').trim();
 
 	return undefined;
 };

--- a/packages/@n8n/config/src/decorators.ts
+++ b/packages/@n8n/config/src/decorators.ts
@@ -21,7 +21,15 @@ const readEnv = (envName: string) => {
 
 	// Read the value from a file, if "_FILE" environment variable is defined
 	const filePath = process.env[`${envName}_FILE`];
-	if (filePath) return readFileSync(filePath, 'utf8').trim();
+	if (filePath) {
+		const value = readFileSync(filePath, 'utf8');
+		if (value !== value.trim()) {
+			console.warn(
+				`[n8n] Warning: The file specified by ${envName}_FILE contains leading or trailing whitespace, which may cause authentication failures.`,
+			);
+		}
+		return value;
+	}
 
 	return undefined;
 };

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -511,6 +511,19 @@ describe('GlobalConfig', () => {
 		expect(mockFs.readFileSync).toHaveBeenCalled();
 	});
 
+	it('should trim whitespace from _FILE env variable values', () => {
+		const passwordFile = '/path/to/postgres/password';
+		process.env = {
+			DB_POSTGRESDB_PASSWORD_FILE: passwordFile,
+		};
+		mockFs.readFileSync
+			.calledWith(passwordFile, 'utf8')
+			.mockReturnValueOnce('password-from-file\n');
+
+		const config = Container.get(GlobalConfig);
+		expect(config.database.postgresdb.password).toBe('password-from-file');
+	});
+
 	it('should handle invalid numbers', () => {
 		process.env = {
 			DB_LOGGING_MAX_EXECUTION_TIME: 'abcd',

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -511,7 +511,7 @@ describe('GlobalConfig', () => {
 		expect(mockFs.readFileSync).toHaveBeenCalled();
 	});
 
-	it('should trim whitespace from _FILE env variable values', () => {
+	it('should warn when _FILE env variable value contains whitespace', () => {
 		const passwordFile = '/path/to/postgres/password';
 		process.env = {
 			DB_POSTGRESDB_PASSWORD_FILE: passwordFile,
@@ -522,6 +522,11 @@ describe('GlobalConfig', () => {
 
 		const config = Container.get(GlobalConfig);
 		expect(config.database.postgresdb.password).toBe('password-from-file');
+		expect(consoleWarnMock).toHaveBeenCalledWith(
+			expect.stringContaining(
+				'DB_POSTGRESDB_PASSWORD_FILE contains leading or trailing whitespace',
+			),
+		);
 	});
 
 	it('should handle invalid numbers', () => {

--- a/packages/@n8n/config/test/decorators.test.ts
+++ b/packages/@n8n/config/test/decorators.test.ts
@@ -1,10 +1,22 @@
 import { Container } from '@n8n/di';
+import fs from 'fs';
 
 import { Config, Env } from '../src/decorators';
 
+jest.mock('fs');
+const mockFs = jest.mocked(fs);
+
 describe('decorators', () => {
+	const originalEnv = process.env;
+
 	beforeEach(() => {
 		Container.reset();
+		process.env = {};
+		jest.clearAllMocks();
+	});
+
+	afterEach(() => {
+		process.env = originalEnv;
 	});
 
 	it('should throw when explicit typing is missing', () => {
@@ -18,5 +30,52 @@ describe('decorators', () => {
 		}).toThrowError(
 			'Invalid decorator metadata on key "value" on InvalidConfig\n Please use explicit typing on all config fields',
 		);
+	});
+
+	it('should read value from _FILE env variable', () => {
+		const filePath = '/path/to/secret';
+		process.env.TEST_VALUE_FILE = filePath;
+		mockFs.readFileSync.mockReturnValueOnce('secret-value');
+
+		@Config
+		class TestConfig {
+			@Env('TEST_VALUE')
+			value: string = 'default';
+		}
+
+		const config = Container.get(TestConfig);
+		expect(config.value).toBe('secret-value');
+		expect(mockFs.readFileSync).toHaveBeenCalledWith(filePath, 'utf8');
+	});
+
+	it('should trim whitespace from _FILE env variable values', () => {
+		const filePath = '/path/to/secret';
+		process.env.TEST_VALUE_FILE = filePath;
+		mockFs.readFileSync.mockReturnValueOnce('secret-value\n');
+
+		@Config
+		class TestConfig {
+			@Env('TEST_VALUE')
+			value: string = 'default';
+		}
+
+		const config = Container.get(TestConfig);
+		expect(config.value).toBe('secret-value');
+	});
+
+	it('should prefer direct env variable over _FILE variant', () => {
+		const filePath = '/path/to/secret';
+		process.env.TEST_VALUE = 'direct-value';
+		process.env.TEST_VALUE_FILE = filePath;
+
+		@Config
+		class TestConfig {
+			@Env('TEST_VALUE')
+			value: string = 'default';
+		}
+
+		const config = Container.get(TestConfig);
+		expect(config.value).toBe('direct-value');
+		expect(mockFs.readFileSync).not.toHaveBeenCalled();
 	});
 });

--- a/packages/@n8n/config/test/decorators.test.ts
+++ b/packages/@n8n/config/test/decorators.test.ts
@@ -48,10 +48,11 @@ describe('decorators', () => {
 		expect(mockFs.readFileSync).toHaveBeenCalledWith(filePath, 'utf8');
 	});
 
-	it('should trim whitespace from _FILE env variable values', () => {
+	it('should warn when _FILE env variable value contains whitespace', () => {
 		const filePath = '/path/to/secret';
 		process.env.TEST_VALUE_FILE = filePath;
 		mockFs.readFileSync.mockReturnValueOnce('secret-value\n');
+		const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
 
 		@Config
 		class TestConfig {
@@ -61,6 +62,10 @@ describe('decorators', () => {
 
 		const config = Container.get(TestConfig);
 		expect(config.value).toBe('secret-value');
+		expect(consoleWarnSpy).toHaveBeenCalledWith(
+			expect.stringContaining('TEST_VALUE_FILE contains leading or trailing whitespace'),
+		);
+		consoleWarnSpy.mockRestore();
 	});
 
 	it('should prefer direct env variable over _FILE variant', () => {

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -41,7 +41,7 @@ if (!inE2ETests && !inTest) {
 			if (key) {
 				let value: string;
 				try {
-					value = readFileSync(fileName, 'utf8');
+					value = readFileSync(fileName, 'utf8').trim();
 				} catch (error) {
 					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 					if (error.code === 'ENOENT') {

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -41,13 +41,18 @@ if (!inE2ETests && !inTest) {
 			if (key) {
 				let value: string;
 				try {
-					value = readFileSync(fileName, 'utf8').trim();
+					value = readFileSync(fileName, 'utf8');
 				} catch (error) {
 					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 					if (error.code === 'ENOENT') {
 						throw new UserError('File not found', { extra: { fileName } });
 					}
 					throw error;
+				}
+				if (value !== value.trim()) {
+					console.warn(
+						`[n8n] Warning: The file specified by ${envName} contains leading or trailing whitespace, which may cause authentication failures.`,
+					);
 				}
 				config.set(key, value);
 			}


### PR DESCRIPTION
## Summary

Partially fixes an issue where trailing newlines in Docker secret files cause authentication failures. When reading database credentials from secret files (using `*_FILE` environment variables), we warn if the file content has leading and trailing whitespace. The newlines are NOT trimmed as this may be considered an invisible breaking change.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-1971

Partially closes https://github.com/n8n-io/n8n/issues/10818

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included.
- [ ] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~