### PR TITLE
perf(core): Disable data tables cleanup checks on workers

### DIFF
--- a/packages/cli/src/modules/data-table/data-table-file-cleanup.service.ts
+++ b/packages/cli/src/modules/data-table/data-table-file-cleanup.service.ts
@@ -1,6 +1,7 @@
 import { safeJoinPath } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
+import { InstanceSettings } from 'n8n-core';
 import { promises as fs } from 'fs';
 
 @Service()
@@ -9,7 +10,10 @@ export class DataTableFileCleanupService {
 
 	private cleanupInterval?: NodeJS.Timeout;
 
-	constructor(private readonly globalConfig: GlobalConfig) {
+	constructor(
+		private readonly globalConfig: GlobalConfig,
+		private readonly instanceSettings: InstanceSettings,
+	) {
 		this.uploadDir = this.globalConfig.dataTable.uploadDir;
 	}
 
@@ -24,6 +28,8 @@ export class DataTableFileCleanupService {
 
 	async start() {
 		// Run cleanup periodically to delete orphaned files
+		if (this.instanceSettings.instanceType !== 'main') return;
+
 		this.cleanupInterval = setInterval(() => {
 			void this.cleanupOrphanedFiles();
 		}, this.globalConfig.dataTable.cleanupIntervalMs);


### PR DESCRIPTION
## Summary

The `DataTableFileCleanupService` was running a cleanup interval on every instance type, causing workers to periodically scan the filesystem for orphan files that cannot exist there, because only mains receive CSV uploads.

## Related Linear tickets, Github issues, and Community forum posts

n/a


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
