### PR TITLE
perf(core): Disable unused modules on workers

### DIFF
--- a/packages/cli/src/modules/__tests__/main-only-modules.test.ts
+++ b/packages/cli/src/modules/__tests__/main-only-modules.test.ts
@@ -1,0 +1,19 @@
+import { ModuleMetadata } from '@n8n/decorators';
+import { Container } from '@n8n/di';
+
+import '../sso-oidc/sso-oidc.module';
+import '../sso-saml/sso-saml.module';
+import '../source-control.ee/source-control.module';
+import '../provisioning.ee/provisioning.module';
+import '../breaking-changes/breaking-changes.module';
+
+describe('main-only modules', () => {
+	const metadata = Container.get(ModuleMetadata);
+
+	test.each(['sso-oidc', 'sso-saml', 'source-control', 'provisioning', 'breaking-changes'])(
+		'%s should only run on main',
+		(moduleName) => {
+			expect(metadata.get(moduleName)?.instanceTypes).toEqual(['main']);
+		},
+	);
+});

--- a/packages/cli/src/modules/breaking-changes/breaking-changes.module.ts
+++ b/packages/cli/src/modules/breaking-changes/breaking-changes.module.ts
@@ -1,7 +1,7 @@
 import type { ModuleInterface } from '@n8n/decorators';
 import { BackendModule } from '@n8n/decorators';
 
-@BackendModule({ name: 'breaking-changes' })
+@BackendModule({ name: 'breaking-changes', instanceTypes: ['main'] })
 export class BreakingChangesModule implements ModuleInterface {
 	async init() {
 		await import('./breaking-changes.controller');

--- a/packages/cli/src/modules/provisioning.ee/provisioning.module.ts
+++ b/packages/cli/src/modules/provisioning.ee/provisioning.module.ts
@@ -1,7 +1,11 @@
 import type { ModuleInterface } from '@n8n/decorators';
 import { BackendModule } from '@n8n/decorators';
 
-@BackendModule({ name: 'provisioning', licenseFlag: ['feat:oidc', 'feat:saml', 'feat:ldap'] })
+@BackendModule({
+	name: 'provisioning',
+	licenseFlag: ['feat:oidc', 'feat:saml', 'feat:ldap'],
+	instanceTypes: ['main'],
+})
 export class ProvisioningModule implements ModuleInterface {
 	async init() {
 		await import('./provisioning.controller.ee');

--- a/packages/cli/src/modules/source-control.ee/source-control.module.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control.module.ts
@@ -2,7 +2,11 @@ import type { ModuleInterface } from '@n8n/decorators';
 import { BackendModule } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 
-@BackendModule({ name: 'source-control', licenseFlag: 'feat:sourceControl' })
+@BackendModule({
+	name: 'source-control',
+	licenseFlag: 'feat:sourceControl',
+	instanceTypes: ['main'],
+})
 export class SourceControlModule implements ModuleInterface {
 	async init() {
 		await import('./source-control.controller.ee');

--- a/packages/cli/src/modules/sso-oidc/sso-oidc.module.ts
+++ b/packages/cli/src/modules/sso-oidc/sso-oidc.module.ts
@@ -2,7 +2,7 @@ import type { ModuleInterface } from '@n8n/decorators';
 import { BackendModule } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 
-@BackendModule({ name: 'sso-oidc', licenseFlag: 'feat:oidc' })
+@BackendModule({ name: 'sso-oidc', licenseFlag: 'feat:oidc', instanceTypes: ['main'] })
 export class OidcModule implements ModuleInterface {
 	async init() {
 		await import('./oidc.controller.ee');

--- a/packages/cli/src/modules/sso-saml/sso-saml.module.ts
+++ b/packages/cli/src/modules/sso-saml/sso-saml.module.ts
@@ -2,7 +2,7 @@ import type { ModuleInterface } from '@n8n/decorators';
 import { BackendModule } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 
-@BackendModule({ name: 'sso-saml', licenseFlag: 'feat:saml' })
+@BackendModule({ name: 'sso-saml', licenseFlag: 'feat:saml', instanceTypes: ['main'] })
 export class SamlModule implements ModuleInterface {
 	async init() {
 		await import('./saml.controller.ee');


### PR DESCRIPTION
## Summary

Workers are initializing several modules that are only needed on main.

## Related Linear tickets, Github issues, and Community forum posts

n/a

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
