### PR TITLE
fix(editor): Adjust insertion rectangle margins for improved layou…

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -1407,9 +1407,9 @@ export function useCanvasOperations() {
 		const margin = GRID_SIZE;
 		const insertRect = {
 			x: insertPosition[0],
-			y: insertPosition[1],
+			y: insertPosition[1] - margin,
 			width: nodeSize[0] + margin,
-			height: nodeSize[1],
+			height: nodeSize[1] + 2 * margin,
 		};
 
 		for (const node of nodesToCheck) {
@@ -1540,9 +1540,9 @@ export function useCanvasOperations() {
 		const margin = GRID_SIZE;
 		const insertRect = {
 			x: insertPosition[0],
-			y: insertPosition[1],
+			y: insertPosition[1] - margin,
 			width: nodeSize[0] + margin,
-			height: nodeSize[1],
+			height: nodeSize[1] + 2 * margin,
 		};
 
 		// First check if there are any regular nodes blocking the insertion position
@@ -1627,7 +1627,6 @@ export function useCanvasOperations() {
 		const nodesToCheck = Object.values(workflowsStore.nodesByName).filter(
 			(n) => n.name !== sourceNodeName && n.type !== STICKY_NODE_TYPE,
 		);
-
 		// Check if there's enough space - if so, don't move anything
 		if (hasSpaceForInsertion(insertPosition, nodeSize, nodesToCheck)) {
 			return;


### PR DESCRIPTION
## Summary
**Problem:** The hasSpaceForInsertion function didn't detect nodes that touch the insertion position vertically because the margin was only applied to width, not height.

**Root Cause:** The insertRect only extended downward (margin added to height), but not upward, so nodes directly above the insertion point weren't detected.

**Solution:** Extended the insertRect in both vertical directions:
Changed y: insertPosition[1] to y: insertPosition[1] - margin (starts 16px earlier)
Changed height: nodeSize[1] + margin to height: nodeSize[1] + 2 * margin (extends 16px up and 16px down)

**Fix Applied To:**
hasSpaceForInsertion function
getYPositionForStickyOverlap function (same pattern)

The function now detects edge-to-edge touches in all directions, and nodes are correctly shifted when there's insufficient space for insertion.

## Related Linear tickets, Github issues, and Community forum posts

Fixes [https://linear.app/n8n/issue/LIGO-41/bug-node-shifting-on-insert-doesnt-work-properly#comment-61774c3f](https://linear.app/n8n/issue/LIGO-41/bug-node-shifting-on-insert-doesnt-work-properly#comment-61774c3f)


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
