### PR TITLE
fix(editor): Handle large values breaking data tables UI grid

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -3651,6 +3651,7 @@
 	"dataTable.addColumn.testingColumnDescription": "This column is used for testing, choose a different name",
 	"dataTable.search.dateSearchInfo": "Date searches use UTC format, while the table displays dates in your local timezone",
 	"dataTable.cell.oversized": "Value too large to display",
+	"dataTable.cell.oversized.tooltip": "The value can be modified using the data table node",
 	"settings.ldap": "LDAP",
 	"settings.ldap.note": "LDAP allows users to authenticate with their centralized account. It's compatible with services that provide an LDAP interface like Active Directory, Okta and Jumpcloud.",
 	"settings.ldap.infoTip": "Learn more about <a href='https://docs.n8n.io/user-management/ldap/' target='_blank'>LDAP in the Docs</a>",

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -3650,6 +3650,7 @@
 	"dataTable.addColumn.alreadyExistsDescription": "Column name already exists, choose a different name",
 	"dataTable.addColumn.testingColumnDescription": "This column is used for testing, choose a different name",
 	"dataTable.search.dateSearchInfo": "Date searches use UTC format, while the table displays dates in your local timezone",
+	"dataTable.cell.oversized": "Value too large to display",
 	"settings.ldap": "LDAP",
 	"settings.ldap.note": "LDAP allows users to authenticate with their centralized account. It's compatible with services that provide an LDAP interface like Active Directory, Okta and Jumpcloud.",
 	"settings.ldap.infoTip": "Learn more about <a href='https://docs.n8n.io/user-management/ldap/' target='_blank'>LDAP in the Docs</a>",

--- a/packages/frontend/editor-ui/src/features/core/dataTable/components/dataGrid/DataTableTable.vue
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/components/dataGrid/DataTableTable.vue
@@ -289,6 +289,10 @@ defineExpose({
 		color: var(--color--text--tint-1);
 	}
 
+	:global(.oversized-cell) {
+		cursor: not-allowed;
+	}
+
 	:global(.ag-header-cell[col-id='id']) {
 		text-align: center;
 	}

--- a/packages/frontend/editor-ui/src/features/core/dataTable/components/dataGrid/OversizedCellRenderer.vue
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/components/dataGrid/OversizedCellRenderer.vue
@@ -1,11 +1,17 @@
 <script setup lang="ts">
 import { useI18n } from '@n8n/i18n';
+import { N8nTooltip } from '@n8n/design-system';
 
 const i18n = useI18n();
 </script>
 
 <template>
-	<span class="n8n-oversized-value">{{ i18n.baseText('dataTable.cell.oversized') }}</span>
+	<N8nTooltip placement="top">
+		<template #content>
+			{{ i18n.baseText('dataTable.cell.oversized.tooltip') }}
+		</template>
+		<span class="n8n-oversized-value">{{ i18n.baseText('dataTable.cell.oversized') }}</span>
+	</N8nTooltip>
 </template>
 
 <style lang="scss">

--- a/packages/frontend/editor-ui/src/features/core/dataTable/components/dataGrid/OversizedCellRenderer.vue
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/components/dataGrid/OversizedCellRenderer.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { useI18n } from '@n8n/i18n';
+
+const i18n = useI18n();
+</script>
+
+<template>
+	<span class="n8n-oversized-value">{{ i18n.baseText('dataTable.cell.oversized') }}</span>
+</template>
+
+<style lang="scss">
+.n8n-oversized-value {
+	font-style: italic;
+	color: var(--color--warning);
+}
+</style>

--- a/packages/frontend/editor-ui/src/features/core/dataTable/composables/useDataTableColumns.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/composables/useDataTableColumns.test.ts
@@ -36,7 +36,7 @@ vi.mock('@/features/core/dataTable/components/dataGrid/AddRowButton.vue', () => 
 }));
 
 vi.mock('@/features/core/dataTable/utils/columnUtils', () => ({
-	getCellClass: vi.fn(),
+	createCellClass: vi.fn(),
 	createValueGetter: vi.fn(),
 	createCellRendererSelector: vi.fn(),
 	createStringValueSetter: vi.fn(),
@@ -47,6 +47,7 @@ vi.mock('@/features/core/dataTable/utils/columnUtils', () => ({
 	getDateColumnFilterOptions: vi.fn(() => []),
 	getNumberColumnFilterOptions: vi.fn(() => []),
 	getBooleanColumnFilterOptions: vi.fn(() => []),
+	isOversizedValue: vi.fn(() => false),
 }));
 
 describe('useDataTableColumns', () => {

--- a/packages/frontend/editor-ui/src/features/core/dataTable/composables/useDataTableColumns.ts
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/composables/useDataTableColumns.ts
@@ -20,7 +20,7 @@ import AddColumnButton from '@/features/core/dataTable/components/dataGrid/AddCo
 import AddRowButton from '@/features/core/dataTable/components/dataGrid/AddRowButton.vue';
 import { reorderItem } from '@/features/core/dataTable/utils';
 import {
-	getCellClass,
+	createCellClass,
 	createValueGetter,
 	createCellRendererSelector,
 	createStringValueSetter,
@@ -31,6 +31,7 @@ import {
 	getDateColumnFilterOptions,
 	getNumberColumnFilterOptions,
 	getBooleanColumnFilterOptions,
+	isOversizedValue,
 } from '@/features/core/dataTable/utils/columnUtils';
 import { useI18n } from '@n8n/i18n';
 import { GRID_FILTER_CONFIG } from '@/features/core/dataTable/utils/filterMappings';
@@ -59,7 +60,8 @@ export const useDataTableColumns = ({
 			filter: !GRID_FILTER_CONFIG.excludedColumns.includes(col.id),
 			headerName: col.name,
 			sortable: true,
-			editable: (params) => params.data?.id !== ADD_ROW_ROW_ID,
+			editable: (params) =>
+				params.data?.id !== ADD_ROW_ROW_ID && !isOversizedValue(params.data?.[col.name]),
 			resizable: true,
 			lockPinned: true,
 			headerComponent: ColumnHeader,
@@ -70,7 +72,7 @@ export const useDataTableColumns = ({
 			},
 			cellEditorPopup: false,
 			cellDataType: mapToAGCellType(col.type),
-			cellClass: getCellClass,
+			cellClass: createCellClass(col),
 			valueGetter: createValueGetter(col),
 			cellRendererSelector: createCellRendererSelector(col),
 			width: DEFAULT_COLUMN_WIDTH,

--- a/packages/frontend/editor-ui/src/features/core/dataTable/constants.ts
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/constants.ts
@@ -36,6 +36,7 @@ export const MIN_LOADING_TIME = 500; // ms
 
 export const NULL_VALUE = 'Null';
 export const EMPTY_VALUE = 'Empty';
+export const MAX_CELL_DISPLAY_LENGTH = 10000;
 
 export const DATA_TABLE_MODULE_NAME = 'data-table';
 

--- a/packages/frontend/editor-ui/src/features/core/dataTable/utils/columnUtils.ts
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/utils/columnUtils.ts
@@ -28,14 +28,14 @@ export const isOversizedValue = (value: unknown): boolean =>
 
 export const createCellClass =
 	(col: DataTableColumn) =>
-	(params: CellClassParams): string => {
+	(params: CellClassParams<DataTableRow>): string => {
 		if (params.data?.id === ADD_ROW_ROW_ID) {
 			return 'add-row-cell';
 		}
 		if (params.column.getUserProvidedColDef()?.cellDataType === 'boolean') {
 			return 'boolean-cell';
 		}
-		const rowValue = (params.data as DataTableRow | undefined)?.[col.name];
+		const rowValue = params.data?.[col.name];
 		if (isOversizedValue(rowValue)) {
 			return 'oversized-cell';
 		}
@@ -57,11 +57,11 @@ export const createValueGetter =
 	};
 
 export const createCellRendererSelector =
-	(col: DataTableColumn) => (params: ICellRendererParams) => {
+	(col: DataTableColumn) => (params: ICellRendererParams<DataTableRow>) => {
 		if (params.data?.id === ADD_ROW_ROW_ID || col.id === 'add-column') {
 			return {};
 		}
-		let rowValue = (params.data as DataTableRow | undefined)?.[col.name];
+		let rowValue = params.data?.[col.name];
 		if (rowValue === undefined) {
 			rowValue = null;
 		}


### PR DESCRIPTION
## Summary

Inserting huge values in data table cells (mostly via the node) was causing the UI grid to hang and crash the browser page

<img width="1315" height="500" alt="image" src="https://github.com/user-attachments/assets/47558c6d-36a7-46cd-8e1a-df1e2fed7d55" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4256/community-issue-data-table-ui-breaks-if-a-cell-contains-too-much-data


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
