### PR TITLE
fix(editor): Fix node issue not triggered on node disconnection

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -2745,6 +2745,46 @@ describe('useCanvasOperations', () => {
 				],
 			});
 		});
+
+		it('should update node input issues for both nodes after deleting connection', async () => {
+			const workflowsStore = mockedStore(useWorkflowsStore);
+
+			const nodeA = createTestNode({
+				id: 'a',
+				type: 'node',
+				name: 'Node A',
+			});
+
+			const nodeB = createTestNode({
+				id: 'b',
+				type: 'node',
+				name: 'Node B',
+			});
+
+			const connection: Connection = {
+				source: nodeA.id,
+				sourceHandle: `outputs/${NodeConnectionTypes.Main}/0`,
+				target: nodeB.id,
+				targetHandle: `inputs/${NodeConnectionTypes.Main}/0`,
+			};
+
+			workflowsStore.getNodeById.mockReturnValueOnce(nodeA).mockReturnValueOnce(nodeB);
+
+			const updateNodeInputIssuesSpy = vi.fn();
+			const nodeHelpersOriginal = nodeHelpers.useNodeHelpers();
+			vi.spyOn(nodeHelpers, 'useNodeHelpers').mockImplementation(() => ({
+				...nodeHelpersOriginal,
+				updateNodeInputIssues: updateNodeInputIssuesSpy,
+			}));
+
+			const { deleteConnection } = useCanvasOperations();
+			deleteConnection(connection);
+
+			await nextTick();
+
+			expect(updateNodeInputIssuesSpy).toHaveBeenCalledWith(nodeA);
+			expect(updateNodeInputIssuesSpy).toHaveBeenCalledWith(nodeB);
+		});
 	});
 
 	describe('revertDeleteConnection', () => {

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -1802,6 +1802,11 @@ export function useCanvasOperations() {
 			connection: mappedConnection,
 		});
 
+		void nextTick(() => {
+			nodeHelpers.updateNodeInputIssues(sourceNode);
+			nodeHelpers.updateNodeInputIssues(targetNode);
+		});
+
 		if (trackHistory) {
 			historyStore.pushCommandToUndo(new RemoveConnectionCommand(mappedConnection, Date.now()));
 

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsPanel.test.ts
@@ -33,6 +33,7 @@ import * as useChatMessaging from '@/features/execution/logs/composables/useChat
 import { chatEventBus } from '@n8n/chat/event-buses';
 import { useToast } from '@/app/composables/useToast';
 import { useWorkflowState, type WorkflowState } from '@/app/composables/useWorkflowState';
+import type * as useNodeHelpersModule from '@/app/composables/useNodeHelpers';
 
 vi.mock('@/app/composables/useToast', () => {
 	const showMessage = vi.fn();
@@ -58,7 +59,7 @@ vi.mock('@/app/stores/pushConnection.store', () => ({
 const workflowStateRef: { current: WorkflowState | undefined } = { current: undefined };
 
 vi.mock('@/app/composables/useNodeHelpers', async (importOriginal) => {
-	const actual = await importOriginal<typeof import('@/app/composables/useNodeHelpers')>();
+	const actual = await importOriginal<typeof useNodeHelpersModule>();
 	return {
 		...actual,
 		useNodeHelpers: (opts = {}) =>

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsPanel.test.ts
@@ -1,5 +1,6 @@
 import { renderComponent } from '@/__tests__/render';
 import { fireEvent, waitFor, within } from '@testing-library/vue';
+import { flushPromises } from '@vue/test-utils';
 import { mockedStore } from '@/__tests__/utils';
 import LogsPanel from '@/features/execution/logs/components/LogsPanel.vue';
 import { createTestingPinia, type TestingPinia } from '@pinia/testing';
@@ -53,6 +54,18 @@ vi.mock('@/app/stores/pushConnection.store', () => ({
 	}),
 }));
 
+// Use a mutable reference so the mock always returns the current workflowState
+const workflowStateRef: { current: WorkflowState | undefined } = { current: undefined };
+
+vi.mock('@/app/composables/useNodeHelpers', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('@/app/composables/useNodeHelpers')>();
+	return {
+		...actual,
+		useNodeHelpers: (opts = {}) =>
+			actual.useNodeHelpers({ ...opts, workflowState: workflowStateRef.current }),
+	};
+});
+
 describe('LogsPanel', () => {
 	const VIEWPORT_HEIGHT = 800;
 
@@ -98,6 +111,7 @@ describe('LogsPanel', () => {
 
 		workflowsStore = mockedStore(useWorkflowsStore);
 		workflowState = useWorkflowState();
+		workflowStateRef.current = workflowState;
 		workflowState.setWorkflowExecutionData(null);
 
 		logsStore = mockedStore(useLogsStore);
@@ -126,8 +140,9 @@ describe('LogsPanel', () => {
 		aiChatExecutionResponse = deepCopy(aiChatExecutionResponseTemplate);
 	});
 
-	afterEach(() => {
-		vi.clearAllMocks();
+	afterEach(async () => {
+		await flushPromises();
+		await vi.runOnlyPendingTimersAsync();
 	});
 
 	it('should render collapsed panel by default', async () => {


### PR DESCRIPTION
## Summary

The check for node issues was missing when nodes are disconnected

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4496/bug-publishing-invalid-workflows-is-possible


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
