### PR TITLE
fix(Outlook): Add missing contentType field to draft attachments

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/draft/create.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/draft/create.test.ts
@@ -200,6 +200,7 @@ describe('Test MicrosoftOutlookV2, draft => create', () => {
 						{
 							'@odata.type': '#microsoft.graph.fileAttachment',
 							name: 'test-file.txt',
+							contentType: 'text/plain',
 							contentBytes: Buffer.from('Hello World').toString('base64'),
 						},
 					],
@@ -254,6 +255,7 @@ describe('Test MicrosoftOutlookV2, draft => create', () => {
 						{
 							'@odata.type': '#microsoft.graph.fileAttachment',
 							name: 'direct-file.txt',
+							contentType: 'text/plain',
 							contentBytes: mockBinaryData.data,
 						},
 					],
@@ -279,10 +281,12 @@ describe('Test MicrosoftOutlookV2, draft => create', () => {
 			(mockExecuteFunctions.helpers.assertBinaryData as jest.Mock)
 				.mockReturnValueOnce({
 					id: 'id1',
+					mimeType: 'text/plain',
 					fileName: 'file1.txt',
 				})
 				.mockReturnValueOnce({
 					data: 'ZmlsZTI=',
+					mimeType: 'text/plain',
 					fileName: 'file2.txt',
 				});
 
@@ -303,10 +307,12 @@ describe('Test MicrosoftOutlookV2, draft => create', () => {
 					attachments: expect.arrayContaining([
 						expect.objectContaining({
 							name: 'file1.txt',
+							contentType: expect.any(String),
 							contentBytes: Buffer.from('file1').toString('base64'),
 						}),
 						expect.objectContaining({
 							name: 'file2.txt',
+							contentType: expect.any(String),
 							contentBytes: 'ZmlsZTI=',
 						}),
 					]),

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/draft/create.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/draft/create.operation.ts
@@ -238,6 +238,7 @@ export async function execute(this: IExecuteFunctions, index: number, _: INodeEx
 				return {
 					'@odata.type': '#microsoft.graph.fileAttachment',
 					name: binaryData.fileName,
+					contentType: binaryData.mimeType || 'application/octet-stream',
 					contentBytes: fileBase64,
 				};
 			}),

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/message/reply.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/message/reply.operation.ts
@@ -274,6 +274,7 @@ export async function execute(this: IExecuteFunctions, index: number, _: INodeEx
 			data.push({
 				'@odata.type': '#microsoft.graph.fileAttachment',
 				name: binaryData.fileName,
+				contentType: binaryData.mimeType || 'application/octet-stream',
 				contentBytes: fileBase64,
 			});
 		}

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/message/send.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/message/send.operation.ts
@@ -246,6 +246,7 @@ export async function execute(this: IExecuteFunctions, index: number, _: INodeEx
 			messageAttachments.push({
 				'@odata.type': '#microsoft.graph.fileAttachment',
 				name: binaryData.fileName,
+				contentType: binaryData.mimeType || 'application/octet-stream',
 				contentBytes: fileBase64,
 			});
 		}

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/messageAttachment/add.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/messageAttachment/add.operation.ts
@@ -122,6 +122,7 @@ export async function execute(this: IExecuteFunctions, index: number, _: INodeEx
 		const body: IDataObject = {
 			'@odata.type': '#microsoft.graph.fileAttachment',
 			name: fileName,
+			contentType: binaryData.mimeType || 'application/octet-stream',
 			contentBytes: binaryData.data,
 		};
 


### PR DESCRIPTION
## Description
Fixes the issue where Outlook draft creation with attachments fails with `UnableToDeserializePostBody` error (HTTP 400).

## Problem
Microsoft Graph API requires the `contentType` field for file attachments, but the attachment objects in draft creation (and other operations) were missing this required field, causing draft creation to fail.

## Solution
Added the missing `contentType` field to all attachment objects:
- Uses `binaryData.mimeType` when available
- Falls back to `'application/octet-stream'` if not available
- Applied to draft/create, message/send, message/reply, and messageAttachment/add for consistency

## Changes
- Added `contentType` field to attachment objects in 4 operation files
- Updated test expectations to include `contentType` in draft/create.test.ts

## Testing
- All linting checks pass
- Test expectations updated to match new attachment format
- Changes follow existing code patterns

## Related Issue
Fixes #19261