### PR TITLE
fix(Airtable): Process binary data when typecast is enabled

### DIFF
--- a/packages/nodes-base/nodes/Airtable/test/v2/node/record/create.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/record/create.test.ts
@@ -155,7 +155,7 @@ describe('Test AirtableV2, create operation', () => {
 		});
 	});
 
-	it('should skip validation if typecast option is true', async () => {
+	it('should process binary data even when typecast option is true', async () => {
 		const nodeParameters = {
 			operation: 'create',
 			columns: {
@@ -192,9 +192,8 @@ describe('Test AirtableV2, create operation', () => {
 		const mockExecuteFunctions = createMockExecuteFunction(nodeParameters);
 		await create.execute.call(mockExecuteFunctions, [{ json: {} }], 'appYoLbase', 'tblltable');
 
-		expect(mockExecuteFunctions.getNodeParameter).toHaveBeenCalledWith('columns.value', 0, [], {
-			skipValidation: true,
-		});
+		// Verify that skipValidation is NOT passed, so binary data can be processed
+		expect(mockExecuteFunctions.getNodeParameter).toHaveBeenCalledWith('columns.value', 0, []);
 
 		expect(transport.apiRequest).toHaveBeenCalledTimes(1);
 		expect(transport.apiRequest).toHaveBeenCalledWith('POST', 'appYoLbase/tblltable', {

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/record/create.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/record/create.test.ts
@@ -155,7 +155,7 @@ describe('Test AirtableV2, create operation', () => {
 		});
 	});
 
-	it('should process binary data even when typecast option is true', async () => {
+	it('should not skip validation when typecast option is true', async () => {
 		const nodeParameters = {
 			operation: 'create',
 			columns: {

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/record/update.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/record/update.test.ts
@@ -48,7 +48,7 @@ describe('Test AirtableV2, update operation', () => {
 		jest.clearAllMocks();
 	});
 
-	it('should process binary data even when typecast option is true', async () => {
+	it('should not skip validation when typecast option is true', async () => {
 		mockExecuteFunctions = mock<IExecuteFunctions>();
 		mockExecuteFunctions.helpers.constructExecutionMetaData = jest.fn(() => []);
 		mockExecuteFunctions.getNodeParameter.mockImplementation((key: string) => {

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/record/update.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/record/update.test.ts
@@ -48,7 +48,7 @@ describe('Test AirtableV2, update operation', () => {
 		jest.clearAllMocks();
 	});
 
-	it('should skip validation if typecast option is true', async () => {
+	it('should process binary data even when typecast option is true', async () => {
 		mockExecuteFunctions = mock<IExecuteFunctions>();
 		mockExecuteFunctions.helpers.constructExecutionMetaData = jest.fn(() => []);
 		mockExecuteFunctions.getNodeParameter.mockImplementation((key: string) => {
@@ -75,9 +75,8 @@ describe('Test AirtableV2, update operation', () => {
 
 		await update.execute.call(mockExecuteFunctions, [{ json: {} }], 'base', 'table');
 
-		expect(mockExecuteFunctions.getNodeParameter).toHaveBeenCalledWith('columns.value', 0, [], {
-			skipValidation: true,
-		});
+		// Verify that skipValidation is NOT passed, so binary data can be processed
+		expect(mockExecuteFunctions.getNodeParameter).toHaveBeenCalledWith('columns.value', 0, []);
 	});
 
 	it('should update a record by id, autoMapInputData', async () => {

--- a/packages/nodes-base/nodes/Airtable/v2/actions/record/create.operation.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/record/create.operation.ts
@@ -72,9 +72,8 @@ export async function execute(
 			}
 
 			if (dataMode === 'defineBelow') {
-				const fields = this.getNodeParameter('columns.value', i, [], {
-					skipValidation: typecast,
-				}) as IDataObject;
+				// Get fields without skipValidation first to ensure binary data is processed
+				const fields = this.getNodeParameter('columns.value', i, []) as IDataObject;
 
 				body.fields = fields;
 			}

--- a/packages/nodes-base/nodes/Airtable/v2/actions/record/create.operation.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/record/create.operation.ts
@@ -73,7 +73,7 @@ export async function execute(
 
 			if (dataMode === 'defineBelow') {
 				// Get fields without skipValidation first to ensure binary data is processed
-				const fields = this.getNodeParameter('columns.value', i, []) as IDataObject;
+				const fields: IDataObject = this.getNodeParameter('columns.value', i, []);
 
 				body.fields = fields;
 			}

--- a/packages/nodes-base/nodes/Airtable/v2/actions/record/update.operation.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/record/update.operation.ts
@@ -111,18 +111,19 @@ export async function execute(
 				// Get fields without skipValidation first to ensure binary data is processed
 				// The resource mapper needs to process binary data into attachment format
 				if (columnsToMatchOn.includes('id')) {
-					const { id, ...fields } = this.getNodeParameter(
+					const fieldsValue: IDataObject = this.getNodeParameter(
 						'columns.value',
 						i,
 						[],
-					) as IDataObject;
+					);
+					const { id, ...fields } = fieldsValue;
 					records.push({ id: id as string, fields });
 				} else {
-					const fields = this.getNodeParameter(
+					const fields: IDataObject = this.getNodeParameter(
 						'columns.value',
 						i,
 						[],
-					) as IDataObject;
+					);
 
 					const matches = findMatches(
 						tableData,

--- a/packages/nodes-base/nodes/Airtable/v2/actions/record/update.operation.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/record/update.operation.ts
@@ -108,13 +108,13 @@ export async function execute(
 			}
 
 			if (dataMode === 'defineBelow') {
-				const getNodeParameterOptions = typecast ? { skipValidation: true } : undefined;
+				// Get fields without skipValidation first to ensure binary data is processed
+				// The resource mapper needs to process binary data into attachment format
 				if (columnsToMatchOn.includes('id')) {
 					const { id, ...fields } = this.getNodeParameter(
 						'columns.value',
 						i,
 						[],
-						getNodeParameterOptions,
 					) as IDataObject;
 					records.push({ id: id as string, fields });
 				} else {
@@ -122,7 +122,6 @@ export async function execute(
 						'columns.value',
 						i,
 						[],
-						getNodeParameterOptions,
 					) as IDataObject;
 
 					const matches = findMatches(


### PR DESCRIPTION
## Description

Fixes issue #22999 where attachments were not uploaded when typecast option was enabled in the Airtable node.

## Problem

When the typecast option was enabled, the code passed `skipValidation: true` to `getNodeParameter`, which prevented the resource mapper from processing binary data into the proper Airtable attachment format. This forced users to split the operation into two steps:
1. Upload attachment without typecast
2. Create single-select options with typecast

## Solution

Removed the `skipValidation` option from `getNodeParameter` calls in both create and update operations. The typecast functionality still works correctly because it's a flag in the API request body, not dependent on skipValidation.

## Changes

- Removed `skipValidation` option from `getNodeParameter` calls in `create.operation.ts` and `update.operation.ts`
- Updated tests to reflect that `skipValidation` is no longer passed when typecast is enabled
- Added comments explaining why we don't skip validation (to ensure binary data processing)

## Testing

- Updated existing tests to verify that `skipValidation` is not passed
- Tests confirm that typecast flag is still sent in API requests
- Binary data processing now works correctly even when typecast is enabled

## Related Issues

Fixes #22999

## Checklist

- [x] Tests included
- [x] Code follows n8n's coding standards
- [x] PR aligns with contribution guidelines
- [x] Bug fix (not a new node)