### PR TITLE
ci: Add container stack telemetry

### DIFF
--- a/.github/workflows/test-e2e-reusable.yml
+++ b/.github/workflows/test-e2e-reusable.yml
@@ -65,6 +65,8 @@ on:
         required: false
       N8N_ENCRYPTION_KEY:
         required: false
+      CONTAINER_TELEMETRY_WEBHOOK:
+        required: false
 
 env:
   NODE_OPTIONS: ${{ contains(inputs.runner, '2vcpu') && '--max-old-space-size=6144' || '' }}
@@ -143,6 +145,7 @@ jobs:
           N8N_LICENSE_ACTIVATION_KEY: ${{ secrets.N8N_LICENSE_ACTIVATION_KEY }}
           N8N_LICENSE_CERT: ${{ secrets.N8N_LICENSE_CERT }}
           N8N_ENCRYPTION_KEY: ${{ secrets.N8N_ENCRYPTION_KEY }}
+          CONTAINER_TELEMETRY_WEBHOOK: ${{secrets.CONTAINER_TELEMETRY_WEBHOOK}}
 
       - name: Upload Failure Artifacts
         if: ${{ failure() && inputs.upload-failure-artifacts }}

--- a/packages/testing/containers/README.md
+++ b/packages/testing/containers/README.md
@@ -367,8 +367,47 @@ The `observability` capability shortcut handles this automatically: `test.use({ 
 | `--name <name>` | Custom project name for parallel runs |
 | `--env KEY=VALUE` | Set environment variables |
 | `--observability` | Enable metrics/logs stack |
+| `--tracing` | Enable tracing stack (Jaeger) |
 | `--oidc` | Enable Keycloak |
 | `--source-control` | Enable Gitea |
+| `--mailpit` | Enable email testing (Mailpit) |
+
+## Telemetry
+
+Container stack telemetry tracks startup timing, configuration, and runner info. Useful for monitoring CI performance and debugging slow stacks.
+
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `CONTAINER_TELEMETRY_WEBHOOK` | POST telemetry JSON to this URL |
+| `CONTAINER_TELEMETRY_VERBOSE` | Set to `1` for JSON output to console |
+
+### What's Collected
+
+```typescript
+{
+  timestamp: string;              // ISO timestamp
+  git: { sha, branch, pr? };      // Git context from CI env vars
+  ci: { runId, job, workflow };   // GitHub Actions context
+  runner: { provider, cpuCores, memoryGb };  // github | blacksmith | local
+  stack: { type, mains, workers, postgres, services };
+  timing: { total, network, n8nStartup, services: Record<string, number> };
+  containers: { total, services, n8n };
+  success: boolean;
+  errorMessage?: string;
+}
+```
+
+### Usage
+
+```bash
+# Verbose output locally
+CONTAINER_TELEMETRY_VERBOSE=1 pnpm stack
+
+# Send to webhook (CI)
+CONTAINER_TELEMETRY_WEBHOOK=https://n8n.example.com/webhook/telemetry
+```
 
 ## Cleanup
 

--- a/packages/testing/containers/helpers/utils.ts
+++ b/packages/testing/containers/helpers/utils.ts
@@ -4,11 +4,14 @@ import type { StartedTestContainer } from 'testcontainers';
 
 /**
  * Create a logger that prefixes messages with elapsed time since creation.
+ * Only outputs when CONTAINER_TELEMETRY_VERBOSE=1 is set.
  */
 export function createElapsedLogger(prefix: string) {
 	const startTime = Date.now();
+	const isVerbose = process.env.CONTAINER_TELEMETRY_VERBOSE === '1';
 
 	return (message: string) => {
+		if (!isVerbose) return;
 		const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
 		console.log(`[${prefix} +${elapsed}s] ${message}`);
 	};

--- a/packages/testing/containers/index.ts
+++ b/packages/testing/containers/index.ts
@@ -9,6 +9,8 @@
 export { createN8NStack } from './stack';
 export type { N8NConfig, N8NStack } from './stack';
 
+export type { StackTelemetryRecord } from './telemetry';
+
 // Performance plans (CLI-only)
 export * from './performance-plans';
 

--- a/packages/testing/containers/n8n-start-stack.ts
+++ b/packages/testing/containers/n8n-start-stack.ts
@@ -5,6 +5,7 @@ import { getDockerImageFromEnv } from './docker-image';
 import { DockerImageNotFoundError } from './docker-image-not-found-error';
 import { BASE_PERFORMANCE_PLANS, isValidPerformancePlan } from './performance-plans';
 import type { KeycloakResult } from './services/keycloak';
+import type { MailpitResult } from './services/mailpit';
 import type { TracingResult } from './services/tracing';
 import type { ServiceName } from './services/types';
 import type { VictoriaLogsResult } from './services/victoria-logs';
@@ -47,6 +48,7 @@ ${colors.yellow}Options:${colors.reset}
   --oidc            Enable OIDC testing with Keycloak (requires PostgreSQL)
   --observability   Enable observability stack (VictoriaLogs + VictoriaMetrics + Vector)
   --tracing         Enable tracing stack (n8n-tracer + Jaeger) for workflow visualization
+  --mailpit         Enable Mailpit for email testing
   --mains <n>       Number of main instances (default: 1)
   --workers <n>     Number of worker instances (default: 1)
   --name <name>     Project name for parallel runs
@@ -123,6 +125,7 @@ async function main() {
 			oidc: { type: 'boolean' },
 			observability: { type: 'boolean' },
 			tracing: { type: 'boolean' },
+			mailpit: { type: 'boolean' },
 			mains: { type: 'string' },
 			workers: { type: 'string' },
 			name: { type: 'string' },
@@ -144,6 +147,7 @@ async function main() {
 	if (values.oidc) services.push('keycloak');
 	if (values.observability) services.push('victoriaLogs', 'victoriaMetrics', 'vector');
 	if (values.tracing) services.push('tracing');
+	if (values.mailpit) services.push('mailpit');
 
 	// Build configuration
 	const config: N8NConfig = {
@@ -164,10 +168,6 @@ async function main() {
 
 		config.mains = mains;
 		config.workers = workers;
-
-		if (!values.queue && (values.mains ?? values.workers)) {
-			log.warn('--mains and --workers imply queue mode');
-		}
 	}
 
 	if (values.plan) {
@@ -230,7 +230,6 @@ async function main() {
 			throw error;
 		}
 
-		log.success('All containers started successfully!');
 		console.log('');
 		log.info(`n8n URL: ${colors.bright}${colors.green}${stack.baseUrl}${colors.reset}`);
 
@@ -276,10 +275,12 @@ async function main() {
 			log.info(`Jaeger UI: ${colors.cyan}${tracingResult.meta.jaeger.uiUrl}${colors.reset}`);
 		}
 
-		console.log('');
-		log.info('Containers are running in the background');
-		log.info('Cleanup with: pnpm stack:clean:all (stops containers and removes networks)');
-		console.log('');
+		const mailpitResult = stack.serviceResults.mailpit as MailpitResult | undefined;
+		if (mailpitResult) {
+			console.log('');
+			log.header('Email Testing (Mailpit)');
+			log.info(`Mailpit UI: ${colors.cyan}${mailpitResult.meta.apiBaseUrl}${colors.reset}`);
+		}
 	} catch (error) {
 		log.error(`Failed to start: ${error as string}`);
 		process.exit(1);
@@ -288,83 +289,43 @@ async function main() {
 
 function displayConfig(config: N8NConfig) {
 	const dockerImage = getDockerImageFromEnv();
-	log.info(`Docker image: ${dockerImage}`);
-
 	const mains = config.mains ?? 1;
 	const workers = config.workers ?? 0;
 	const isQueueMode = mains > 1 || workers > 0;
 	const services = config.services ?? [];
 
-	// Determine actual database
 	// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
 	const usePostgres = config.postgres || isQueueMode || services.includes('keycloak');
-	log.info(`Database: ${usePostgres ? 'PostgreSQL' : 'SQLite'}`);
 
+	let modeStr: string;
 	if (isQueueMode) {
-		log.info(`Queue mode: ${mains} main(s), ${workers} worker(s)`);
-		if (!config.postgres) {
-			log.info('(PostgreSQL automatically enabled for queue mode)');
-		}
-		if (mains > 1) {
-			log.info('(load balancer will be configured)');
-		}
+		const parts = [`${mains}M/${workers}W`, usePostgres ? 'PostgreSQL' : 'SQLite'];
+		if (mains > 1) parts.push('load-balanced');
+		modeStr = parts.join(', ');
 	} else {
-		log.info('Queue mode: disabled');
+		modeStr = usePostgres ? 'single, PostgreSQL' : 'single, SQLite';
 	}
 
-	log.info('Task runner: enabled');
+	log.info(`Image: ${dockerImage}`);
+	log.info(`Mode: ${modeStr}`);
 
-	// Display source control status
-	if (services.includes('gitea')) {
-		log.info('Source Control: enabled (Git server - Gitea 1.24.6)');
-		log.info('  Admin: giteaadmin / giteapassword');
-		log.info('  Repository: n8n-test-repo');
-	} else {
-		log.info('Source Control: disabled');
-	}
+	const enabledFeatures: string[] = [];
+	if (services.includes('gitea')) enabledFeatures.push('Source Control (Gitea)');
+	if (services.includes('keycloak')) enabledFeatures.push('OIDC (Keycloak)');
+	if (services.includes('victoriaLogs')) enabledFeatures.push('Observability');
+	if (services.includes('tracing')) enabledFeatures.push('Tracing (Jaeger)');
+	if (services.includes('mailpit')) enabledFeatures.push('Email (Mailpit)');
 
-	// Display OIDC status
-	if (services.includes('keycloak')) {
-		log.info('OIDC: enabled (Keycloak)');
-		if (!config.postgres && !isQueueMode) {
-			log.info('(PostgreSQL automatically enabled for OIDC)');
-		}
-	} else {
-		log.info('OIDC: disabled');
-	}
-
-	// Display observability status
-	if (services.includes('victoriaLogs')) {
-		log.info('Observability: enabled (VictoriaLogs + VictoriaMetrics + Vector)');
-	} else {
-		log.info('Observability: disabled');
-	}
-
-	// Display tracing status
-	if (services.includes('tracing')) {
-		log.info('Tracing: enabled (n8n-tracer + Jaeger)');
-	} else {
-		log.info('Tracing: disabled');
+	if (enabledFeatures.length > 0) {
+		log.info(`Services: ${enabledFeatures.join(', ')}`);
 	}
 
 	if (config.resourceQuota) {
-		log.info(
-			`Resource limits: ${config.resourceQuota.memory}GB RAM, ${config.resourceQuota.cpu} CPU cores`,
-		);
+		log.info(`Resources: ${config.resourceQuota.memory}GB RAM, ${config.resourceQuota.cpu} CPU`);
 	}
 
-	if (config.env) {
-		const envCount = Object.keys(config.env).length;
-		if (envCount > 0) {
-			log.info(`Environment variables: ${envCount} custom variable(s)`);
-			Object.entries(config.env).forEach(([key, value]) => {
-				console.log(`  ${key}=${value}`);
-			});
-		}
-	}
-
-	if (process.env.TESTCONTAINERS_REUSE_ENABLE === 'true') {
-		log.info('Container reuse: enabled (containers will persist)');
+	if (config.env && Object.keys(config.env).length > 0) {
+		log.info(`Custom env: ${Object.keys(config.env).join(', ')}`);
 	}
 }
 

--- a/packages/testing/containers/telemetry.ts
+++ b/packages/testing/containers/telemetry.ts
@@ -1,0 +1,224 @@
+import * as os from 'os';
+
+import type { StackConfig } from './services/types';
+
+export interface StackTelemetryRecord {
+	/** ISO timestamp when stack creation started */
+	timestamp: string;
+
+	/** Git context from environment */
+	git: {
+		sha: string;
+		branch: string;
+		pr?: number;
+	};
+
+	/** CI context from GitHub Actions environment */
+	ci: {
+		runId?: string;
+		job?: string;
+		workflow?: string;
+		attempt?: number;
+	};
+
+	/** Runner info - provider detected from env vars, specs from runtime */
+	runner: {
+		provider: 'github' | 'blacksmith' | 'local';
+		cpuCores: number;
+		memoryGb: number;
+	};
+
+	/** Stack configuration */
+	stack: {
+		type: 'single' | 'queue' | 'multi-main';
+		mains: number;
+		workers: number;
+		postgres: boolean;
+		services: string[];
+	};
+
+	/** Timing metrics in milliseconds */
+	timing: {
+		total: number;
+		network: number;
+		n8nStartup: number;
+		services: Record<string, number>;
+	};
+
+	/** Container counts */
+	containers: {
+		total: number;
+		services: number;
+		n8n: number;
+	};
+
+	/** Outcome */
+	success: boolean;
+	errorMessage?: string;
+}
+
+function getGitContext(): StackTelemetryRecord['git'] {
+	const ref = process.env.GITHUB_REF ?? '';
+	const prMatch = ref.match(/refs\/pull\/(\d+)/);
+
+	return {
+		sha: process.env.GITHUB_SHA?.slice(0, 8) ?? 'local',
+		branch: process.env.GITHUB_HEAD_REF ?? process.env.GITHUB_REF_NAME ?? 'local',
+		pr: prMatch ? parseInt(prMatch[1], 10) : undefined,
+	};
+}
+
+function getCIContext(): StackTelemetryRecord['ci'] {
+	return {
+		runId: process.env.GITHUB_RUN_ID,
+		job: process.env.GITHUB_JOB,
+		workflow: process.env.GITHUB_WORKFLOW,
+		attempt: process.env.GITHUB_RUN_ATTEMPT
+			? parseInt(process.env.GITHUB_RUN_ATTEMPT, 10)
+			: undefined,
+	};
+}
+
+function getRunnerProvider(): StackTelemetryRecord['runner']['provider'] {
+	// Not in CI = local development
+	if (!process.env.CI) {
+		return 'local';
+	}
+	// GitHub-hosted runners explicitly identify themselves
+	if (process.env.RUNNER_ENVIRONMENT === 'github-hosted') {
+		return 'github';
+	}
+	// Everything else in CI is Blacksmith
+	return 'blacksmith';
+}
+
+function getRunnerInfo(): StackTelemetryRecord['runner'] {
+	const cpus = os.cpus();
+	return {
+		provider: getRunnerProvider(),
+		cpuCores: cpus.length,
+		memoryGb: Math.round((os.totalmem() / (1024 * 1024 * 1024)) * 10) / 10,
+	};
+}
+
+function inferStackType(config: StackConfig): 'single' | 'queue' | 'multi-main' {
+	if ((config.mains ?? 1) > 1) return 'multi-main';
+	if ((config.workers ?? 0) > 0) return 'queue';
+	return 'single';
+}
+
+function inferPostgres(config: StackConfig): boolean {
+	const isQueueMode = (config.mains ?? 1) > 1 || (config.workers ?? 0) > 0;
+	const hasKeycloak = config.services?.includes('keycloak') ?? false;
+	return (config.postgres ?? false) || isQueueMode || hasKeycloak;
+}
+
+export class TelemetryRecorder {
+	private startTimestamp = Date.now();
+	private startPerf = performance.now();
+	private networkTime = 0;
+	private n8nStartupTime = 0;
+	private serviceTimings: Record<string, number> = {};
+	private serviceCount = 0;
+	private n8nCount = 0;
+
+	constructor(private config: StackConfig) {}
+
+	recordNetwork(durationMs: number): void {
+		this.networkTime = durationMs;
+	}
+
+	recordService(name: string, durationMs: number): void {
+		this.serviceTimings[name] = durationMs;
+		this.serviceCount++;
+	}
+
+	recordN8nStartup(durationMs: number, count: number): void {
+		this.n8nStartupTime = durationMs;
+		this.n8nCount = count;
+	}
+
+	private buildRecord(success: boolean, errorMessage?: string): StackTelemetryRecord {
+		return {
+			timestamp: new Date(this.startTimestamp).toISOString(),
+			git: getGitContext(),
+			ci: getCIContext(),
+			runner: getRunnerInfo(),
+			stack: {
+				type: inferStackType(this.config),
+				mains: this.config.mains ?? 1,
+				workers: this.config.workers ?? 0,
+				postgres: inferPostgres(this.config),
+				services: [...(this.config.services ?? [])],
+			},
+			timing: {
+				total: Math.round(performance.now() - this.startPerf),
+				network: this.networkTime,
+				n8nStartup: this.n8nStartupTime,
+				services: { ...this.serviceTimings },
+			},
+			containers: {
+				total: this.serviceCount + this.n8nCount,
+				services: this.serviceCount,
+				n8n: this.n8nCount,
+			},
+			success,
+			errorMessage,
+		};
+	}
+
+	/**
+	 * Flush telemetry - outputs based on environment configuration
+	 *
+	 * Output modes:
+	 * - CONTAINER_TELEMETRY_WEBHOOK: Send to webhook (fire and forget)
+	 * - CONTAINER_TELEMETRY_VERBOSE=1: Full breakdown + elapsed logs (via utils.ts)
+	 * - Default: One-liner summary only
+	 */
+	flush(success: boolean, errorMessage?: string): void {
+		const record = this.buildRecord(success, errorMessage);
+
+		const isVerbose = process.env.CONTAINER_TELEMETRY_VERBOSE === '1';
+		const webhookUrl = process.env.CONTAINER_TELEMETRY_WEBHOOK;
+
+		if (webhookUrl) {
+			void this.sendToWebhook(record, webhookUrl);
+		}
+
+		if (isVerbose) {
+			console.log(JSON.stringify(record, null, 2));
+		} else {
+			this.printSummaryLine(record);
+		}
+	}
+
+	private printSummaryLine(record: StackTelemetryRecord): void {
+		const time = this.formatMs(record.timing.total);
+		const containers = record.containers.total;
+		const services = record.stack.services.length;
+
+		if (record.success) {
+			const serviceInfo = services > 0 ? `, ${services} services` : '';
+			console.log(`\x1b[32m✓\x1b[0m Stack ready (${time}, ${containers} containers${serviceInfo})`);
+		} else {
+			console.log(`\x1b[31m✗\x1b[0m Stack failed: ${record.errorMessage} (${time})`);
+		}
+	}
+
+	private sendToWebhook(record: StackTelemetryRecord, webhookUrl: string): void {
+		fetch(webhookUrl, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(record),
+		}).catch(() => {});
+	}
+
+	private formatMs(ms: number): string {
+		if (ms < 1000) return `${ms.toFixed(0)}ms`;
+		return `${(ms / 1000).toFixed(2)}s`;
+	}
+}
+
+export function createTelemetryRecorder(config: StackConfig): TelemetryRecorder {
+	return new TelemetryRecorder(config);
+}


### PR DESCRIPTION
## Summary

Introduces telemetry tracking for container stack startups.

This change adds metrics collection to the container stack creation process, including timing information, configuration details, and runner environment. Collected data is outputted to the console or sent to a configured webhook for monitoring and debugging purposes, providing insights into CI performance.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2140/container-stack-telemetry-for-ci-performance-tracking
https://n8n.metabaseapp.com/dashboard/139-quality-dashboard?tab=334

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
