### PR TITLE
fix(editor): Only open template setup modal on import

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.test.ts
@@ -5,7 +5,20 @@ import { mockedStore } from '@/__tests__/utils';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useReadyToRunStore } from '@/features/workflows/readyToRun/stores/readyToRun.store';
-import { TEMPLATE_SETUP_EXPERIENCE } from '@/app/constants';
+import { SETUP_CREDENTIALS_MODAL_KEY, TEMPLATE_SETUP_EXPERIENCE } from '@/app/constants';
+
+const mockDoesNodeHaveAllCredentialsFilled = vi.fn();
+
+vi.mock('@/app/utils/nodes/nodeTransforms', async () => {
+	const actual = await vi.importActual('@/app/utils/nodes/nodeTransforms');
+	return {
+		...actual,
+		doesNodeHaveAllCredentialsFilled: (...args: unknown[]) =>
+			mockDoesNodeHaveAllCredentialsFilled(...args),
+	};
+});
+
+const mockRouteQuery = vi.fn<() => Record<string, string | undefined>>(() => ({}));
 
 vi.mock('vue-router', async () => {
 	const actual = await vi.importActual('vue-router');
@@ -19,6 +32,9 @@ vi.mock('vue-router', async () => {
 		useRoute: () => ({
 			params,
 			location,
+			get query() {
+				return mockRouteQuery();
+			},
 		}),
 	};
 });
@@ -116,5 +132,121 @@ describe('SetupWorkflowCredentialsButton', () => {
 		expect(readyToRunStore.isReadyToRunTemplateId).toHaveBeenCalledWith(
 			'ready-to-run-ai-workflow-v5',
 		);
+	});
+
+	describe('modal auto-open on mount', () => {
+		const workflowWithUnfilledCredentials = {
+			...EMPTY_WORKFLOW,
+			meta: { templateId: '123', templateCredsSetupCompleted: false },
+			nodes: [
+				{
+					id: '1',
+					name: 'OpenAI Model',
+					type: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
+					typeVersion: 1,
+					position: [0, 0] as [number, number],
+					parameters: {},
+				},
+			],
+		};
+
+		it('opens modal when all conditions are met', () => {
+			workflowsStore.workflow = workflowWithUnfilledCredentials;
+			workflowsStore.getNodes.mockReturnValue(workflowWithUnfilledCredentials.nodes as never);
+			mockDoesNodeHaveAllCredentialsFilled.mockReturnValue(false);
+			mockGetVariant.mockReturnValue(TEMPLATE_SETUP_EXPERIENCE.variant);
+			readyToRunStore.isReadyToRunTemplateId.mockReturnValue(false);
+			mockRouteQuery.mockReturnValue({ templateId: '123' });
+
+			renderComponent();
+
+			expect(uiStore.openModal).toHaveBeenCalledWith(SETUP_CREDENTIALS_MODAL_KEY);
+		});
+
+		it('does not open modal when not on template import route (no templateId in query)', () => {
+			workflowsStore.workflow = workflowWithUnfilledCredentials;
+			workflowsStore.getNodes.mockReturnValue(workflowWithUnfilledCredentials.nodes as never);
+			mockDoesNodeHaveAllCredentialsFilled.mockReturnValue(false);
+			mockGetVariant.mockReturnValue(TEMPLATE_SETUP_EXPERIENCE.variant);
+			readyToRunStore.isReadyToRunTemplateId.mockReturnValue(false);
+			mockRouteQuery.mockReturnValue({});
+
+			renderComponent();
+
+			expect(uiStore.openModal).not.toHaveBeenCalled();
+		});
+
+		it('does not open modal when feature flag is disabled', () => {
+			workflowsStore.workflow = workflowWithUnfilledCredentials;
+			workflowsStore.getNodes.mockReturnValue(workflowWithUnfilledCredentials.nodes as never);
+			mockDoesNodeHaveAllCredentialsFilled.mockReturnValue(false);
+			mockGetVariant.mockReturnValue('control');
+			readyToRunStore.isReadyToRunTemplateId.mockReturnValue(false);
+			mockRouteQuery.mockReturnValue({ templateId: '123' });
+
+			renderComponent();
+
+			expect(uiStore.openModal).not.toHaveBeenCalled();
+		});
+
+		it('does not open modal when template credentials setup is already completed', () => {
+			const completedWorkflow = {
+				...workflowWithUnfilledCredentials,
+				meta: { templateId: '123', templateCredsSetupCompleted: true },
+			};
+			workflowsStore.workflow = completedWorkflow;
+			workflowsStore.getNodes.mockReturnValue(completedWorkflow.nodes as never);
+			mockDoesNodeHaveAllCredentialsFilled.mockReturnValue(false);
+			mockGetVariant.mockReturnValue(TEMPLATE_SETUP_EXPERIENCE.variant);
+			readyToRunStore.isReadyToRunTemplateId.mockReturnValue(false);
+			mockRouteQuery.mockReturnValue({ templateId: '123' });
+
+			renderComponent();
+
+			expect(uiStore.openModal).not.toHaveBeenCalled();
+		});
+
+		it('does not open modal when workflow is not created from a template', () => {
+			const nonTemplateWorkflow = {
+				...workflowWithUnfilledCredentials,
+				meta: {},
+			};
+			workflowsStore.workflow = nonTemplateWorkflow;
+			workflowsStore.getNodes.mockReturnValue(nonTemplateWorkflow.nodes as never);
+			mockDoesNodeHaveAllCredentialsFilled.mockReturnValue(false);
+			mockGetVariant.mockReturnValue(TEMPLATE_SETUP_EXPERIENCE.variant);
+			readyToRunStore.isReadyToRunTemplateId.mockReturnValue(false);
+			mockRouteQuery.mockReturnValue({ templateId: '123' });
+
+			renderComponent();
+
+			expect(uiStore.openModal).not.toHaveBeenCalled();
+		});
+
+		it('does not open modal when all credentials are already filled', () => {
+			workflowsStore.workflow = workflowWithUnfilledCredentials;
+			workflowsStore.getNodes.mockReturnValue(workflowWithUnfilledCredentials.nodes as never);
+			mockDoesNodeHaveAllCredentialsFilled.mockReturnValue(true);
+			mockGetVariant.mockReturnValue(TEMPLATE_SETUP_EXPERIENCE.variant);
+			readyToRunStore.isReadyToRunTemplateId.mockReturnValue(false);
+			mockRouteQuery.mockReturnValue({ templateId: '123' });
+
+			renderComponent();
+
+			expect(uiStore.openModal).not.toHaveBeenCalled();
+		});
+
+		it('does not open modal for ready-to-run workflows', () => {
+			workflowsStore.workflow = workflowWithUnfilledCredentials;
+			workflowsStore.getNodes.mockReturnValue(workflowWithUnfilledCredentials.nodes as never);
+			mockDoesNodeHaveAllCredentialsFilled.mockReturnValue(false);
+			mockGetVariant.mockReturnValue(TEMPLATE_SETUP_EXPERIENCE.variant);
+			readyToRunStore.isReadyToRunTemplateId.mockReturnValue(true);
+			mockRouteQuery.mockReturnValue({ templateId: '123' });
+
+			renderComponent();
+
+			expect(uiStore.openModal).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.vue
@@ -11,6 +11,7 @@ import { N8nButton } from '@n8n/design-system';
 import { usePostHog } from '@/app/stores/posthog.store';
 import { injectWorkflowState } from '@/app/composables/useWorkflowState';
 import { useReadyToRunStore } from '@/features/workflows/readyToRun/stores/readyToRun.store';
+import { useRoute } from 'vue-router';
 
 const workflowsStore = useWorkflowsStore();
 const readyToRunStore = useReadyToRunStore();
@@ -19,6 +20,11 @@ const nodeTypesStore = useNodeTypesStore();
 const posthogStore = usePostHog();
 const uiStore = useUIStore();
 const i18n = useI18n();
+const route = useRoute();
+
+const isTemplateImportRoute = computed(() => {
+	return route.query.templateId !== undefined;
+});
 
 const isTemplateSetupCompleted = computed(() => {
 	return !!workflowsStore.workflow?.meta?.templateCredsSetupCompleted;
@@ -74,7 +80,12 @@ onMounted(() => {
 	const templateId = workflowsStore.workflow?.meta?.templateId;
 	const isReadyToRunWorkflow = readyToRunStore.isReadyToRunTemplateId(templateId);
 
-	if (isNewTemplatesSetupEnabled.value && showButton.value && !isReadyToRunWorkflow) {
+	if (
+		isNewTemplatesSetupEnabled.value &&
+		showButton.value &&
+		!isReadyToRunWorkflow &&
+		isTemplateImportRoute.value
+	) {
 		openSetupModal();
 	}
 });


### PR DESCRIPTION
## Summary
Do not open the modal when re-opening workflows created form templates.

## Related Linear tickets, Github issues, and Community forum posts
Fixes ADO-4645

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
