### PR TITLE
chore(core): Add dtos for log streaming controller. Use zod to validate existing destination option types

### DIFF
--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -81,6 +81,17 @@ export { TransferFolderBodyDto } from './folders/transfer-folder.dto';
 export { ListInsightsWorkflowQueryDto } from './insights/list-workflow-query.dto';
 export { InsightsDateFilterDto } from './insights/date-filter.dto';
 
+export { GetDestinationQueryDto } from './log-streaming/get-destination-query.dto';
+export {
+	CreateDestinationDto,
+	type CreateDestinationDto as CreateDestinationDtoType,
+	type WebhookDestination,
+	type SentryDestination,
+	type SyslogDestination,
+} from './log-streaming/create-destination.dto';
+export { TestDestinationQueryDto } from './log-streaming/test-destination-query.dto';
+export { DeleteDestinationQueryDto } from './log-streaming/delete-destination-query.dto';
+
 export { PaginationDto } from './pagination/pagination.dto';
 export {
 	UsersListFilterDto,

--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -84,7 +84,6 @@ export { InsightsDateFilterDto } from './insights/date-filter.dto';
 export { GetDestinationQueryDto } from './log-streaming/get-destination-query.dto';
 export {
 	CreateDestinationDto,
-	type CreateDestinationDto as CreateDestinationDtoType,
 	type WebhookDestination,
 	type SentryDestination,
 	type SyslogDestination,

--- a/packages/@n8n/api-types/src/dto/log-streaming/__tests__/create-destination.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/log-streaming/__tests__/create-destination.dto.test.ts
@@ -1,0 +1,422 @@
+import { CreateDestinationDto } from '../create-destination.dto';
+
+describe('CreateDestinationDto', () => {
+	describe('Webhook Destination - Valid requests', () => {
+		test.each([
+			{
+				name: 'minimal webhook destination',
+				request: {
+					__type: '$$MessageEventBusDestinationWebhook',
+					url: 'https://example.com/webhook',
+				},
+				parsedResult: {
+					__type: '$$MessageEventBusDestinationWebhook',
+					url: 'https://example.com/webhook',
+				},
+			},
+			{
+				name: 'webhook with all optional fields',
+				request: {
+					__type: '$$MessageEventBusDestinationWebhook',
+					url: 'https://example.com/webhook',
+					id: '550e8400-e29b-41d4-a716-446655440000',
+					label: 'Production Webhook',
+					enabled: true,
+					subscribedEvents: ['n8n.audit', 'n8n.workflow'],
+					anonymizeAuditMessages: false,
+					method: 'POST',
+					authentication: 'none',
+					sendPayload: true,
+				},
+				parsedResult: {
+					__type: '$$MessageEventBusDestinationWebhook',
+					url: 'https://example.com/webhook',
+					id: '550e8400-e29b-41d4-a716-446655440000',
+					label: 'Production Webhook',
+					enabled: true,
+					subscribedEvents: ['n8n.audit', 'n8n.workflow'],
+					anonymizeAuditMessages: false,
+					method: 'POST',
+					authentication: 'none',
+					sendPayload: true,
+				},
+			},
+			{
+				name: 'webhook with circuit breaker options',
+				request: {
+					__type: '$$MessageEventBusDestinationWebhook',
+					url: 'https://example.com/webhook',
+					circuitBreaker: {
+						maxFailures: 5,
+						maxDuration: 10000,
+						halfOpenRequests: 3,
+						failureWindow: 60000,
+						maxConcurrentHalfOpenRequests: 2,
+					},
+				},
+				parsedResult: {
+					__type: '$$MessageEventBusDestinationWebhook',
+					url: 'https://example.com/webhook',
+					circuitBreaker: {
+						maxFailures: 5,
+						maxDuration: 10000,
+						halfOpenRequests: 3,
+						failureWindow: 60000,
+						maxConcurrentHalfOpenRequests: 2,
+					},
+				},
+			},
+		])('should validate $name', ({ request, parsedResult }) => {
+			const result = CreateDestinationDto.safeParse(request);
+			expect(result.success).toBe(true);
+			expect(result.data).toMatchObject(parsedResult);
+		});
+	});
+
+	describe('Sentry Destination - Valid requests', () => {
+		test.each([
+			{
+				name: 'minimal sentry destination',
+				request: {
+					__type: '$$MessageEventBusDestinationSentry',
+					dsn: 'https://public@sentry.io/1',
+				},
+				parsedResult: {
+					__type: '$$MessageEventBusDestinationSentry',
+					dsn: 'https://public@sentry.io/1',
+				},
+			},
+			{
+				name: 'sentry with all optional fields',
+				request: {
+					__type: '$$MessageEventBusDestinationSentry',
+					dsn: 'https://public@sentry.io/1',
+					id: '550e8400-e29b-41d4-a716-446655440000',
+					label: 'Production Sentry',
+					enabled: true,
+					subscribedEvents: ['n8n.audit'],
+					anonymizeAuditMessages: true,
+					tracesSampleRate: 0.5,
+					sendPayload: false,
+				},
+				parsedResult: {
+					__type: '$$MessageEventBusDestinationSentry',
+					dsn: 'https://public@sentry.io/1',
+					id: '550e8400-e29b-41d4-a716-446655440000',
+					label: 'Production Sentry',
+					enabled: true,
+					subscribedEvents: ['n8n.audit'],
+					anonymizeAuditMessages: true,
+					tracesSampleRate: 0.5,
+					sendPayload: false,
+				},
+			},
+			{
+				name: 'sentry with traces sample rate 0',
+				request: {
+					__type: '$$MessageEventBusDestinationSentry',
+					dsn: 'https://public@sentry.io/1',
+					tracesSampleRate: 0,
+				},
+				parsedResult: {
+					__type: '$$MessageEventBusDestinationSentry',
+					dsn: 'https://public@sentry.io/1',
+					tracesSampleRate: 0,
+				},
+			},
+			{
+				name: 'sentry with traces sample rate 1',
+				request: {
+					__type: '$$MessageEventBusDestinationSentry',
+					dsn: 'https://public@sentry.io/1',
+					tracesSampleRate: 1,
+				},
+				parsedResult: {
+					__type: '$$MessageEventBusDestinationSentry',
+					dsn: 'https://public@sentry.io/1',
+					tracesSampleRate: 1,
+				},
+			},
+		])('should validate $name', ({ request, parsedResult }) => {
+			const result = CreateDestinationDto.safeParse(request);
+			expect(result.success).toBe(true);
+			expect(result.data).toMatchObject(parsedResult);
+		});
+	});
+
+	describe('Syslog Destination - Valid requests', () => {
+		test.each([
+			{
+				name: 'minimal syslog destination',
+				request: {
+					__type: '$$MessageEventBusDestinationSyslog',
+					host: '127.0.0.1',
+				},
+				parsedResult: {
+					__type: '$$MessageEventBusDestinationSyslog',
+					host: '127.0.0.1',
+				},
+			},
+			{
+				name: 'syslog with all optional fields',
+				request: {
+					__type: '$$MessageEventBusDestinationSyslog',
+					host: 'syslog.example.com',
+					id: '550e8400-e29b-41d4-a716-446655440000',
+					label: 'Production Syslog',
+					enabled: true,
+					subscribedEvents: ['n8n.workflow', 'n8n.execution'],
+					anonymizeAuditMessages: false,
+					port: 514,
+					protocol: 'tcp',
+					facility: 16,
+					app_name: 'n8n-production',
+					eol: '\n',
+				},
+				parsedResult: {
+					__type: '$$MessageEventBusDestinationSyslog',
+					host: 'syslog.example.com',
+					id: '550e8400-e29b-41d4-a716-446655440000',
+					label: 'Production Syslog',
+					enabled: true,
+					subscribedEvents: ['n8n.workflow', 'n8n.execution'],
+					anonymizeAuditMessages: false,
+					port: 514,
+					protocol: 'tcp',
+					facility: 16,
+					app_name: 'n8n-production',
+					eol: '\n',
+				},
+			},
+			{
+				name: 'syslog with UDP protocol',
+				request: {
+					__type: '$$MessageEventBusDestinationSyslog',
+					host: 'localhost',
+					protocol: 'udp',
+				},
+				parsedResult: {
+					__type: '$$MessageEventBusDestinationSyslog',
+					host: 'localhost',
+					protocol: 'udp',
+				},
+			},
+			{
+				name: 'syslog with TLS protocol',
+				request: {
+					__type: '$$MessageEventBusDestinationSyslog',
+					host: 'secure.syslog.com',
+					protocol: 'tls',
+					port: 6514,
+				},
+				parsedResult: {
+					__type: '$$MessageEventBusDestinationSyslog',
+					host: 'secure.syslog.com',
+					protocol: 'tls',
+					port: 6514,
+				},
+			},
+			{
+				name: 'syslog with minimum facility (0)',
+				request: {
+					__type: '$$MessageEventBusDestinationSyslog',
+					host: 'localhost',
+					facility: 0,
+				},
+				parsedResult: {
+					__type: '$$MessageEventBusDestinationSyslog',
+					host: 'localhost',
+					facility: 0,
+				},
+			},
+			{
+				name: 'syslog with maximum facility (23)',
+				request: {
+					__type: '$$MessageEventBusDestinationSyslog',
+					host: 'localhost',
+					facility: 23,
+				},
+				parsedResult: {
+					__type: '$$MessageEventBusDestinationSyslog',
+					host: 'localhost',
+					facility: 23,
+				},
+			},
+		])('should validate $name', ({ request, parsedResult }) => {
+			const result = CreateDestinationDto.safeParse(request);
+			expect(result.success).toBe(true);
+			expect(result.data).toMatchObject(parsedResult);
+		});
+	});
+
+	describe('Invalid requests', () => {
+		test.each([
+			{
+				name: 'invalid __type',
+				request: {
+					__type: 'InvalidType',
+					url: 'https://example.com/webhook',
+				},
+				expectedErrorPaths: ['__type'],
+			},
+			{
+				name: 'webhook missing required url',
+				request: {
+					__type: '$$MessageEventBusDestinationWebhook',
+				},
+				expectedErrorPaths: ['url'],
+			},
+			{
+				name: 'webhook with invalid url',
+				request: {
+					__type: '$$MessageEventBusDestinationWebhook',
+					url: 'not-a-url',
+				},
+				expectedErrorPaths: ['url'],
+			},
+			{
+				name: 'webhook with invalid id format',
+				request: {
+					__type: '$$MessageEventBusDestinationWebhook',
+					url: 'https://example.com/webhook',
+					id: 'not-a-uuid',
+				},
+				expectedErrorPaths: ['id'],
+			},
+			{
+				name: 'webhook with invalid authentication type',
+				request: {
+					__type: '$$MessageEventBusDestinationWebhook',
+					url: 'https://example.com/webhook',
+					authentication: 'invalidAuth',
+				},
+				expectedErrorPaths: ['authentication'],
+			},
+			{
+				name: 'sentry missing required dsn',
+				request: {
+					__type: '$$MessageEventBusDestinationSentry',
+				},
+				expectedErrorPaths: ['dsn'],
+			},
+			{
+				name: 'sentry with invalid dsn',
+				request: {
+					__type: '$$MessageEventBusDestinationSentry',
+					dsn: 'not-a-url',
+				},
+				expectedErrorPaths: ['dsn'],
+			},
+			{
+				name: 'sentry with traces sample rate below 0',
+				request: {
+					__type: '$$MessageEventBusDestinationSentry',
+					dsn: 'https://public@sentry.io/1',
+					tracesSampleRate: -0.1,
+				},
+				expectedErrorPaths: ['tracesSampleRate'],
+			},
+			{
+				name: 'sentry with traces sample rate above 1',
+				request: {
+					__type: '$$MessageEventBusDestinationSentry',
+					dsn: 'https://public@sentry.io/1',
+					tracesSampleRate: 1.1,
+				},
+				expectedErrorPaths: ['tracesSampleRate'],
+			},
+			{
+				name: 'syslog missing required host',
+				request: {
+					__type: '$$MessageEventBusDestinationSyslog',
+				},
+				expectedErrorPaths: ['host'],
+			},
+			{
+				name: 'syslog with empty host',
+				request: {
+					__type: '$$MessageEventBusDestinationSyslog',
+					host: '',
+				},
+				expectedErrorPaths: ['host'],
+			},
+			{
+				name: 'syslog with invalid port (negative)',
+				request: {
+					__type: '$$MessageEventBusDestinationSyslog',
+					host: 'localhost',
+					port: -1,
+				},
+				expectedErrorPaths: ['port'],
+			},
+			{
+				name: 'syslog with invalid port (zero)',
+				request: {
+					__type: '$$MessageEventBusDestinationSyslog',
+					host: 'localhost',
+					port: 0,
+				},
+				expectedErrorPaths: ['port'],
+			},
+			{
+				name: 'syslog with invalid protocol',
+				request: {
+					__type: '$$MessageEventBusDestinationSyslog',
+					host: 'localhost',
+					protocol: 'http',
+				},
+				expectedErrorPaths: ['protocol'],
+			},
+			{
+				name: 'syslog with facility below 0',
+				request: {
+					__type: '$$MessageEventBusDestinationSyslog',
+					host: 'localhost',
+					facility: -1,
+				},
+				expectedErrorPaths: ['facility'],
+			},
+			{
+				name: 'syslog with facility above 23',
+				request: {
+					__type: '$$MessageEventBusDestinationSyslog',
+					host: 'localhost',
+					facility: 24,
+				},
+				expectedErrorPaths: ['facility'],
+			},
+			{
+				name: 'circuit breaker with negative maxFailures',
+				request: {
+					__type: '$$MessageEventBusDestinationWebhook',
+					url: 'https://example.com/webhook',
+					circuitBreaker: {
+						maxFailures: -1,
+					},
+				},
+				expectedErrorPaths: ['circuitBreaker', 'maxFailures'],
+			},
+			{
+				name: 'circuit breaker with zero maxFailures',
+				request: {
+					__type: '$$MessageEventBusDestinationWebhook',
+					url: 'https://example.com/webhook',
+					circuitBreaker: {
+						maxFailures: 0,
+					},
+				},
+				expectedErrorPaths: ['circuitBreaker', 'maxFailures'],
+			},
+		])('should fail validation for $name', ({ request, expectedErrorPaths }) => {
+			const result = CreateDestinationDto.safeParse(request);
+			const issuesPaths = result.error?.issues.map((issue) => issue.path.join('.')) ?? [];
+
+			expect(result.success).toBe(false);
+
+			// Check that all expected error paths are present
+			for (const expectedPath of expectedErrorPaths) {
+				expect(issuesPaths.some((path) => path.includes(expectedPath))).toBe(true);
+			}
+		});
+	});
+});

--- a/packages/@n8n/api-types/src/dto/log-streaming/__tests__/create-destination.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/log-streaming/__tests__/create-destination.dto.test.ts
@@ -275,15 +275,6 @@ describe('CreateDestinationDto', () => {
 				expectedErrorPaths: ['url'],
 			},
 			{
-				name: 'webhook with invalid id format',
-				request: {
-					__type: '$$MessageEventBusDestinationWebhook',
-					url: 'https://example.com/webhook',
-					id: 'not-a-uuid',
-				},
-				expectedErrorPaths: ['id'],
-			},
-			{
 				name: 'webhook with invalid authentication type',
 				request: {
 					__type: '$$MessageEventBusDestinationWebhook',

--- a/packages/@n8n/api-types/src/dto/log-streaming/__tests__/delete-destination-query.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/log-streaming/__tests__/delete-destination-query.dto.test.ts
@@ -1,0 +1,81 @@
+import { DeleteDestinationQueryDto } from '../delete-destination-query.dto';
+
+describe('DeleteDestinationQueryDto', () => {
+	describe('Valid requests', () => {
+		test.each([
+			{
+				name: 'valid UUID',
+				request: {
+					id: '550e8400-e29b-41d4-a716-446655440000',
+				},
+				parsedResult: {
+					id: '550e8400-e29b-41d4-a716-446655440000',
+				},
+			},
+			{
+				name: 'another valid UUID',
+				request: {
+					id: '123e4567-e89b-12d3-a456-426614174000',
+				},
+				parsedResult: {
+					id: '123e4567-e89b-12d3-a456-426614174000',
+				},
+			},
+		])('should validate $name', ({ request, parsedResult }) => {
+			const result = DeleteDestinationQueryDto.safeParse(request);
+			expect(result.success).toBe(true);
+			expect(result.data).toMatchObject(parsedResult);
+		});
+	});
+
+	describe('Invalid requests', () => {
+		test.each([
+			{
+				name: 'missing id',
+				request: {},
+				expectedErrorPaths: ['id'],
+			},
+			{
+				name: 'invalid UUID format',
+				request: {
+					id: 'not-a-uuid',
+				},
+				expectedErrorPaths: ['id'],
+			},
+			{
+				name: 'empty string',
+				request: {
+					id: '',
+				},
+				expectedErrorPaths: ['id'],
+			},
+			{
+				name: 'numeric value',
+				request: {
+					id: 123,
+				},
+				expectedErrorPaths: ['id'],
+			},
+			{
+				name: 'null value',
+				request: {
+					id: null,
+				},
+				expectedErrorPaths: ['id'],
+			},
+			{
+				name: 'invalid UUID (too short)',
+				request: {
+					id: '550e8400-e29b-41d4',
+				},
+				expectedErrorPaths: ['id'],
+			},
+		])('should fail validation for $name', ({ request, expectedErrorPaths }) => {
+			const result = DeleteDestinationQueryDto.safeParse(request);
+			const issuesPaths = new Set(result.error?.issues.map((issue) => issue.path[0]));
+
+			expect(result.success).toBe(false);
+			expect(new Set(issuesPaths)).toEqual(new Set(expectedErrorPaths));
+		});
+	});
+});

--- a/packages/@n8n/api-types/src/dto/log-streaming/__tests__/delete-destination-query.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/log-streaming/__tests__/delete-destination-query.dto.test.ts
@@ -21,6 +21,24 @@ describe('DeleteDestinationQueryDto', () => {
 					id: '123e4567-e89b-12d3-a456-426614174000',
 				},
 			},
+			{
+				name: 'non-UUID string (backward compatibility)',
+				request: {
+					id: 'e2e-tls-test',
+				},
+				parsedResult: {
+					id: 'e2e-tls-test',
+				},
+			},
+			{
+				name: 'short string',
+				request: {
+					id: '550e8400-e29b-41d4',
+				},
+				parsedResult: {
+					id: '550e8400-e29b-41d4',
+				},
+			},
 		])('should validate $name', ({ request, parsedResult }) => {
 			const result = DeleteDestinationQueryDto.safeParse(request);
 			expect(result.success).toBe(true);
@@ -33,13 +51,6 @@ describe('DeleteDestinationQueryDto', () => {
 			{
 				name: 'missing id',
 				request: {},
-				expectedErrorPaths: ['id'],
-			},
-			{
-				name: 'invalid UUID format',
-				request: {
-					id: 'not-a-uuid',
-				},
 				expectedErrorPaths: ['id'],
 			},
 			{
@@ -60,13 +71,6 @@ describe('DeleteDestinationQueryDto', () => {
 				name: 'null value',
 				request: {
 					id: null,
-				},
-				expectedErrorPaths: ['id'],
-			},
-			{
-				name: 'invalid UUID (too short)',
-				request: {
-					id: '550e8400-e29b-41d4',
 				},
 				expectedErrorPaths: ['id'],
 			},

--- a/packages/@n8n/api-types/src/dto/log-streaming/__tests__/get-destination-query.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/log-streaming/__tests__/get-destination-query.dto.test.ts
@@ -1,0 +1,83 @@
+import { GetDestinationQueryDto } from '../get-destination-query.dto';
+
+describe('GetDestinationQueryDto', () => {
+	describe('Valid requests', () => {
+		test.each([
+			{
+				name: 'empty object (no id - get all destinations)',
+				request: {},
+				parsedResult: {},
+			},
+			{
+				name: 'valid UUID',
+				request: {
+					id: '550e8400-e29b-41d4-a716-446655440000',
+				},
+				parsedResult: {
+					id: '550e8400-e29b-41d4-a716-446655440000',
+				},
+			},
+			{
+				name: 'another valid UUID',
+				request: {
+					id: '123e4567-e89b-12d3-a456-426614174000',
+				},
+				parsedResult: {
+					id: '123e4567-e89b-12d3-a456-426614174000',
+				},
+			},
+		])('should validate $name', ({ request, parsedResult }) => {
+			const result = GetDestinationQueryDto.safeParse(request);
+			expect(result.success).toBe(true);
+			if (parsedResult) {
+				expect(result.data).toMatchObject(parsedResult);
+			}
+		});
+	});
+
+	describe('Invalid requests', () => {
+		test.each([
+			{
+				name: 'invalid UUID format',
+				request: {
+					id: 'not-a-uuid',
+				},
+				expectedErrorPaths: ['id'],
+			},
+			{
+				name: 'empty string',
+				request: {
+					id: '',
+				},
+				expectedErrorPaths: ['id'],
+			},
+			{
+				name: 'numeric value',
+				request: {
+					id: 123,
+				},
+				expectedErrorPaths: ['id'],
+			},
+			{
+				name: 'invalid UUID (too short)',
+				request: {
+					id: '550e8400-e29b-41d4',
+				},
+				expectedErrorPaths: ['id'],
+			},
+			{
+				name: 'invalid UUID (wrong format)',
+				request: {
+					id: '550e8400e29b41d4a716446655440000',
+				},
+				expectedErrorPaths: ['id'],
+			},
+		])('should fail validation for $name', ({ request, expectedErrorPaths }) => {
+			const result = GetDestinationQueryDto.safeParse(request);
+			const issuesPaths = new Set(result.error?.issues.map((issue) => issue.path[0]));
+
+			expect(result.success).toBe(false);
+			expect(new Set(issuesPaths)).toEqual(new Set(expectedErrorPaths));
+		});
+	});
+});

--- a/packages/@n8n/api-types/src/dto/log-streaming/__tests__/get-destination-query.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/log-streaming/__tests__/get-destination-query.dto.test.ts
@@ -26,6 +26,33 @@ describe('GetDestinationQueryDto', () => {
 					id: '123e4567-e89b-12d3-a456-426614174000',
 				},
 			},
+			{
+				name: 'non-UUID string (backward compatibility)',
+				request: {
+					id: 'e2e-tls-test',
+				},
+				parsedResult: {
+					id: 'e2e-tls-test',
+				},
+			},
+			{
+				name: 'short string',
+				request: {
+					id: '550e8400-e29b-41d4',
+				},
+				parsedResult: {
+					id: '550e8400-e29b-41d4',
+				},
+			},
+			{
+				name: 'string without dashes',
+				request: {
+					id: '550e8400e29b41d4a716446655440000',
+				},
+				parsedResult: {
+					id: '550e8400e29b41d4a716446655440000',
+				},
+			},
 		])('should validate $name', ({ request, parsedResult }) => {
 			const result = GetDestinationQueryDto.safeParse(request);
 			expect(result.success).toBe(true);
@@ -38,13 +65,6 @@ describe('GetDestinationQueryDto', () => {
 	describe('Invalid requests', () => {
 		test.each([
 			{
-				name: 'invalid UUID format',
-				request: {
-					id: 'not-a-uuid',
-				},
-				expectedErrorPaths: ['id'],
-			},
-			{
 				name: 'empty string',
 				request: {
 					id: '',
@@ -55,20 +75,6 @@ describe('GetDestinationQueryDto', () => {
 				name: 'numeric value',
 				request: {
 					id: 123,
-				},
-				expectedErrorPaths: ['id'],
-			},
-			{
-				name: 'invalid UUID (too short)',
-				request: {
-					id: '550e8400-e29b-41d4',
-				},
-				expectedErrorPaths: ['id'],
-			},
-			{
-				name: 'invalid UUID (wrong format)',
-				request: {
-					id: '550e8400e29b41d4a716446655440000',
 				},
 				expectedErrorPaths: ['id'],
 			},

--- a/packages/@n8n/api-types/src/dto/log-streaming/__tests__/test-destination-query.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/log-streaming/__tests__/test-destination-query.dto.test.ts
@@ -1,0 +1,81 @@
+import { TestDestinationQueryDto } from '../test-destination-query.dto';
+
+describe('TestDestinationQueryDto', () => {
+	describe('Valid requests', () => {
+		test.each([
+			{
+				name: 'valid UUID',
+				request: {
+					id: '550e8400-e29b-41d4-a716-446655440000',
+				},
+				parsedResult: {
+					id: '550e8400-e29b-41d4-a716-446655440000',
+				},
+			},
+			{
+				name: 'another valid UUID',
+				request: {
+					id: '123e4567-e89b-12d3-a456-426614174000',
+				},
+				parsedResult: {
+					id: '123e4567-e89b-12d3-a456-426614174000',
+				},
+			},
+		])('should validate $name', ({ request, parsedResult }) => {
+			const result = TestDestinationQueryDto.safeParse(request);
+			expect(result.success).toBe(true);
+			expect(result.data).toMatchObject(parsedResult);
+		});
+	});
+
+	describe('Invalid requests', () => {
+		test.each([
+			{
+				name: 'missing id',
+				request: {},
+				expectedErrorPaths: ['id'],
+			},
+			{
+				name: 'invalid UUID format',
+				request: {
+					id: 'not-a-uuid',
+				},
+				expectedErrorPaths: ['id'],
+			},
+			{
+				name: 'empty string',
+				request: {
+					id: '',
+				},
+				expectedErrorPaths: ['id'],
+			},
+			{
+				name: 'numeric value',
+				request: {
+					id: 123,
+				},
+				expectedErrorPaths: ['id'],
+			},
+			{
+				name: 'null value',
+				request: {
+					id: null,
+				},
+				expectedErrorPaths: ['id'],
+			},
+			{
+				name: 'invalid UUID (too short)',
+				request: {
+					id: '550e8400-e29b-41d4',
+				},
+				expectedErrorPaths: ['id'],
+			},
+		])('should fail validation for $name', ({ request, expectedErrorPaths }) => {
+			const result = TestDestinationQueryDto.safeParse(request);
+			const issuesPaths = new Set(result.error?.issues.map((issue) => issue.path[0]));
+
+			expect(result.success).toBe(false);
+			expect(new Set(issuesPaths)).toEqual(new Set(expectedErrorPaths));
+		});
+	});
+});

--- a/packages/@n8n/api-types/src/dto/log-streaming/__tests__/test-destination-query.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/log-streaming/__tests__/test-destination-query.dto.test.ts
@@ -21,6 +21,24 @@ describe('TestDestinationQueryDto', () => {
 					id: '123e4567-e89b-12d3-a456-426614174000',
 				},
 			},
+			{
+				name: 'non-UUID string (backward compatibility)',
+				request: {
+					id: 'e2e-tls-test',
+				},
+				parsedResult: {
+					id: 'e2e-tls-test',
+				},
+			},
+			{
+				name: 'short string',
+				request: {
+					id: '550e8400-e29b-41d4',
+				},
+				parsedResult: {
+					id: '550e8400-e29b-41d4',
+				},
+			},
 		])('should validate $name', ({ request, parsedResult }) => {
 			const result = TestDestinationQueryDto.safeParse(request);
 			expect(result.success).toBe(true);
@@ -33,13 +51,6 @@ describe('TestDestinationQueryDto', () => {
 			{
 				name: 'missing id',
 				request: {},
-				expectedErrorPaths: ['id'],
-			},
-			{
-				name: 'invalid UUID format',
-				request: {
-					id: 'not-a-uuid',
-				},
 				expectedErrorPaths: ['id'],
 			},
 			{
@@ -60,13 +71,6 @@ describe('TestDestinationQueryDto', () => {
 				name: 'null value',
 				request: {
 					id: null,
-				},
-				expectedErrorPaths: ['id'],
-			},
-			{
-				name: 'invalid UUID (too short)',
-				request: {
-					id: '550e8400-e29b-41d4',
 				},
 				expectedErrorPaths: ['id'],
 			},

--- a/packages/@n8n/api-types/src/dto/log-streaming/create-destination.dto.ts
+++ b/packages/@n8n/api-types/src/dto/log-streaming/create-destination.dto.ts
@@ -1,0 +1,25 @@
+import {
+	MessageEventBusDestinationSentryOptionsSchema,
+	MessageEventBusDestinationSyslogOptionsSchema,
+	MessageEventBusDestinationWebhookOptionsSchema,
+} from 'n8n-workflow';
+import { z } from 'zod';
+
+// Union of all destination types - discriminated union based on __type field
+const destinationSchema = z.discriminatedUnion('__type', [
+	MessageEventBusDestinationWebhookOptionsSchema,
+	MessageEventBusDestinationSentryOptionsSchema,
+	MessageEventBusDestinationSyslogOptionsSchema,
+]);
+
+// The body is the destination object directly, not wrapped
+export const CreateDestinationDto = destinationSchema;
+
+export type CreateDestinationDto = z.infer<typeof CreateDestinationDto>;
+
+// Type exports for use in other files - re-export from workflow package
+export type {
+	MessageEventBusDestinationWebhookOptions as WebhookDestination,
+	MessageEventBusDestinationSentryOptions as SentryDestination,
+	MessageEventBusDestinationSyslogOptions as SyslogDestination,
+} from 'n8n-workflow';

--- a/packages/@n8n/api-types/src/dto/log-streaming/create-destination.dto.ts
+++ b/packages/@n8n/api-types/src/dto/log-streaming/create-destination.dto.ts
@@ -6,16 +6,11 @@ import {
 import { z } from 'zod';
 
 // Union of all destination types - discriminated union based on __type field
-const destinationSchema = z.discriminatedUnion('__type', [
+export const CreateDestinationDto = z.discriminatedUnion('__type', [
 	MessageEventBusDestinationWebhookOptionsSchema,
 	MessageEventBusDestinationSentryOptionsSchema,
 	MessageEventBusDestinationSyslogOptionsSchema,
 ]);
-
-// The body is the destination object directly, not wrapped
-export const CreateDestinationDto = destinationSchema;
-
-export type CreateDestinationDto = z.infer<typeof CreateDestinationDto>;
 
 // Type exports for use in other files - re-export from workflow package
 export type {

--- a/packages/@n8n/api-types/src/dto/log-streaming/delete-destination-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/log-streaming/delete-destination-query.dto.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+import { Z } from 'zod-class';
+
+export class DeleteDestinationQueryDto extends Z.class({
+	id: z.string().uuid(),
+}) {}

--- a/packages/@n8n/api-types/src/dto/log-streaming/delete-destination-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/log-streaming/delete-destination-query.dto.ts
@@ -2,5 +2,5 @@ import { z } from 'zod';
 import { Z } from 'zod-class';
 
 export class DeleteDestinationQueryDto extends Z.class({
-	id: z.string().uuid(),
+	id: z.string(),
 }) {}

--- a/packages/@n8n/api-types/src/dto/log-streaming/delete-destination-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/log-streaming/delete-destination-query.dto.ts
@@ -2,5 +2,5 @@ import { z } from 'zod';
 import { Z } from 'zod-class';
 
 export class DeleteDestinationQueryDto extends Z.class({
-	id: z.string(),
+	id: z.string().min(1),
 }) {}

--- a/packages/@n8n/api-types/src/dto/log-streaming/get-destination-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/log-streaming/get-destination-query.dto.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+import { Z } from 'zod-class';
+
+export class GetDestinationQueryDto extends Z.class({
+	id: z.string().uuid().optional(),
+}) {}

--- a/packages/@n8n/api-types/src/dto/log-streaming/get-destination-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/log-streaming/get-destination-query.dto.ts
@@ -2,5 +2,5 @@ import { z } from 'zod';
 import { Z } from 'zod-class';
 
 export class GetDestinationQueryDto extends Z.class({
-	id: z.string().optional(),
+	id: z.string().min(1).optional(),
 }) {}

--- a/packages/@n8n/api-types/src/dto/log-streaming/get-destination-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/log-streaming/get-destination-query.dto.ts
@@ -2,5 +2,5 @@ import { z } from 'zod';
 import { Z } from 'zod-class';
 
 export class GetDestinationQueryDto extends Z.class({
-	id: z.string().uuid().optional(),
+	id: z.string().optional(),
 }) {}

--- a/packages/@n8n/api-types/src/dto/log-streaming/test-destination-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/log-streaming/test-destination-query.dto.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+import { Z } from 'zod-class';
+
+export class TestDestinationQueryDto extends Z.class({
+	id: z.string().uuid(),
+}) {}

--- a/packages/@n8n/api-types/src/dto/log-streaming/test-destination-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/log-streaming/test-destination-query.dto.ts
@@ -2,5 +2,5 @@ import { z } from 'zod';
 import { Z } from 'zod-class';
 
 export class TestDestinationQueryDto extends Z.class({
-	id: z.string().uuid(),
+	id: z.string(),
 }) {}

--- a/packages/@n8n/api-types/src/dto/log-streaming/test-destination-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/log-streaming/test-destination-query.dto.ts
@@ -2,5 +2,5 @@ import { z } from 'zod';
 import { Z } from 'zod-class';
 
 export class TestDestinationQueryDto extends Z.class({
-	id: z.string(),
+	id: z.string().min(1),
 }) {}

--- a/packages/cli/src/modules/log-streaming.ee/database/repositories/event-destination.repository.ts
+++ b/packages/cli/src/modules/log-streaming.ee/database/repositories/event-destination.repository.ts
@@ -1,5 +1,6 @@
 import { Service } from '@n8n/di';
 import { DataSource, Repository } from '@n8n/typeorm';
+
 import { EventDestinations } from '../entities';
 
 @Service()

--- a/packages/cli/src/modules/log-streaming.ee/destinations/message-event-bus-destination-webhook.ee.ts
+++ b/packages/cli/src/modules/log-streaming.ee/destinations/message-event-bus-destination-webhook.ee.ts
@@ -201,7 +201,7 @@ export class MessageEventBusDestinationWebhook
 		const sendHeaders = this.sendHeaders;
 		const specifyHeaders = this.specifyHeaders;
 
-		if (this.sendQuery && this.options.queryParameterArrays) {
+		if (this.sendQuery && this.options?.queryParameterArrays) {
 			Object.assign(this.axiosRequestOptions, {
 				qsStringifyOptions: { arrayFormat: this.options.queryParameterArrays },
 			});

--- a/packages/cli/src/modules/log-streaming.ee/log-streaming.controller.ts
+++ b/packages/cli/src/modules/log-streaming.ee/log-streaming.controller.ts
@@ -1,9 +1,24 @@
-import { AuthenticatedRequest } from '@n8n/db';
-import { RestController, Get, Post, Delete, GlobalScope, Licensed } from '@n8n/decorators';
-import express from 'express';
+import {
+	CreateDestinationDto,
+	DeleteDestinationQueryDto,
+	GetDestinationQueryDto,
+	TestDestinationQueryDto,
+} from '@n8n/api-types';
+import {
+	Body,
+	Delete,
+	Get,
+	GlobalScope,
+	Licensed,
+	Post,
+	Query,
+	RestController,
+} from '@n8n/decorators';
 import type {
-	MessageEventBusDestinationWebhookOptions,
 	MessageEventBusDestinationOptions,
+	MessageEventBusDestinationSentryOptions,
+	MessageEventBusDestinationSyslogOptions,
+	MessageEventBusDestinationWebhookOptions,
 } from 'n8n-workflow';
 import { MessageEventBusDestinationTypeNames } from 'n8n-workflow';
 
@@ -11,39 +26,11 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { eventNamesAll } from '@/eventbus/event-message-classes';
 import { MessageEventBus } from '@/eventbus/message-event-bus/message-event-bus';
 
-import {
-	isMessageEventBusDestinationSentryOptions,
-	MessageEventBusDestinationSentry,
-} from './destinations/message-event-bus-destination-sentry.ee';
-import {
-	isMessageEventBusDestinationSyslogOptions,
-	MessageEventBusDestinationSyslog,
-} from './destinations/message-event-bus-destination-syslog.ee';
+import { MessageEventBusDestinationSentry } from './destinations/message-event-bus-destination-sentry.ee';
+import { MessageEventBusDestinationSyslog } from './destinations/message-event-bus-destination-syslog.ee';
 import { MessageEventBusDestinationWebhook } from './destinations/message-event-bus-destination-webhook.ee';
-import { MessageEventBusDestination } from './destinations/message-event-bus-destination.ee';
+import type { MessageEventBusDestination } from './destinations/message-event-bus-destination.ee';
 import { LogStreamingDestinationService } from './log-streaming-destination.service';
-
-const isWithIdString = (candidate: unknown): candidate is { id: string } => {
-	const o = candidate as { id: string };
-	if (!o) return false;
-	return o.id !== undefined;
-};
-
-const isMessageEventBusDestinationWebhookOptions = (
-	candidate: unknown,
-): candidate is MessageEventBusDestinationWebhookOptions => {
-	const o = candidate as MessageEventBusDestinationWebhookOptions;
-	if (!o) return false;
-	return o.url !== undefined;
-};
-
-const isMessageEventBusDestinationOptions = (
-	candidate: unknown,
-): candidate is MessageEventBusDestinationOptions => {
-	const o = candidate as MessageEventBusDestinationOptions;
-	if (!o) return false;
-	return o.__type !== undefined;
-};
 
 @RestController('/eventbus')
 export class EventBusController {
@@ -60,76 +47,63 @@ export class EventBusController {
 	@Licensed('feat:logStreaming')
 	@Get('/destination')
 	@GlobalScope('eventBusDestination:list')
-	async getDestination(req: express.Request): Promise<MessageEventBusDestinationOptions[]> {
-		if (isWithIdString(req.query)) {
-			return await this.destinationService.findDestination(req.query.id);
-		} else {
-			return await this.destinationService.findDestination();
-		}
+	async getDestination(
+		@Query query: GetDestinationQueryDto,
+	): Promise<MessageEventBusDestinationOptions[]> {
+		return await this.destinationService.findDestination(query.id);
 	}
 
 	@Licensed('feat:logStreaming')
 	@Post('/destination')
 	@GlobalScope('eventBusDestination:create')
-	async postDestination(req: AuthenticatedRequest): Promise<any> {
-		let result: MessageEventBusDestination | undefined;
-		if (isMessageEventBusDestinationOptions(req.body)) {
-			switch (req.body.__type) {
-				case MessageEventBusDestinationTypeNames.sentry:
-					if (isMessageEventBusDestinationSentryOptions(req.body)) {
-						result = await this.destinationService.addDestination(
-							new MessageEventBusDestinationSentry(this.eventBus, req.body),
-						);
-					}
-					break;
-				case MessageEventBusDestinationTypeNames.webhook:
-					if (isMessageEventBusDestinationWebhookOptions(req.body)) {
-						result = await this.destinationService.addDestination(
-							new MessageEventBusDestinationWebhook(this.eventBus, req.body),
-						);
-					}
-					break;
-				case MessageEventBusDestinationTypeNames.syslog:
-					if (isMessageEventBusDestinationSyslogOptions(req.body)) {
-						result = await this.destinationService.addDestination(
-							new MessageEventBusDestinationSyslog(this.eventBus, req.body),
-						);
-					}
-					break;
-				default:
-					throw new BadRequestError(
-						`Body is missing ${req.body.__type} options or type ${req.body.__type} is unknown`,
-					);
-			}
-			if (result) {
-				return {
-					...result.serialize(),
-					eventBusInstance: undefined,
-				};
-			}
-			throw new BadRequestError('There was an error adding the destination');
+	async postDestination(
+		@Body body: CreateDestinationDto,
+	): Promise<MessageEventBusDestinationOptions> {
+		let result: MessageEventBusDestination;
+
+		switch (body.__type) {
+			case MessageEventBusDestinationTypeNames.sentry:
+				result = await this.destinationService.addDestination(
+					new MessageEventBusDestinationSentry(
+						this.eventBus,
+						body as MessageEventBusDestinationSentryOptions,
+					),
+				);
+				break;
+			case MessageEventBusDestinationTypeNames.webhook:
+				result = await this.destinationService.addDestination(
+					new MessageEventBusDestinationWebhook(
+						this.eventBus,
+						body as MessageEventBusDestinationWebhookOptions,
+					),
+				);
+				break;
+			case MessageEventBusDestinationTypeNames.syslog:
+				result = await this.destinationService.addDestination(
+					new MessageEventBusDestinationSyslog(
+						this.eventBus,
+						body as MessageEventBusDestinationSyslogOptions,
+					),
+				);
+				break;
+			default:
+				throw new BadRequestError(`Unknown destination type: ${body.__type}`);
 		}
-		throw new BadRequestError('Body is not configuring MessageEventBusDestinationOptions');
+
+		return result.serialize();
 	}
 
 	@Licensed('feat:logStreaming')
 	@Get('/testmessage')
 	@GlobalScope('eventBusDestination:test')
-	async sendTestMessage(req: express.Request): Promise<boolean> {
-		if (isWithIdString(req.query)) {
-			return await this.destinationService.testDestination(req.query.id);
-		}
-		return false;
+	async sendTestMessage(@Query query: TestDestinationQueryDto): Promise<boolean> {
+		return await this.destinationService.testDestination(query.id);
 	}
 
 	@Licensed('feat:logStreaming')
 	@Delete('/destination')
 	@GlobalScope('eventBusDestination:delete')
-	async deleteDestination(req: AuthenticatedRequest) {
-		if (isWithIdString(req.query)) {
-			await this.destinationService.removeDestination(req.query.id);
-		} else {
-			throw new BadRequestError('Query is missing id');
-		}
+	async deleteDestination(@Query query: DeleteDestinationQueryDto): Promise<void> {
+		await this.destinationService.removeDestination(query.id);
 	}
 }

--- a/packages/cli/src/modules/log-streaming.ee/log-streaming.controller.ts
+++ b/packages/cli/src/modules/log-streaming.ee/log-streaming.controller.ts
@@ -51,8 +51,14 @@ export class EventBusController {
 	@Post('/destination')
 	@GlobalScope('eventBusDestination:create')
 	async postDestination(req: AuthenticatedRequest): Promise<MessageEventBusDestinationOptions> {
-		// Manually validate using the union schema since TypeScript reflection doesn't work with plain Zod schemas
-		const body = CreateDestinationDto.parse(req.body);
+		// Manually validate using the discriminated union schema since TypeScript reflection doesn't work with plain Zod schemas
+		// And ZodClass doesn't support discriminated unions directly
+		const parseResult = CreateDestinationDto.safeParse(req.body);
+		if (!parseResult.success) {
+			throw new BadRequestError(parseResult.error.errors[0].message);
+		}
+
+		const body = parseResult.data;
 		let result: MessageEventBusDestination;
 
 		switch (body.__type) {

--- a/packages/cli/test/integration/eventbus.ee.test.ts
+++ b/packages/cli/test/integration/eventbus.ee.test.ts
@@ -319,12 +319,11 @@ test('DELETE /eventbus/destination delete all destinations by id', async () => {
 		return acc;
 	}, []);
 
-	await Promise.all(
-		existingDestinationIds.map(async (id) => {
-			const response = await authOwnerAgent.del('/eventbus/destination').query({ id });
-			expect(response.statusCode).toBe(200);
-		}),
-	);
+	// Delete sequentially to avoid race conditions
+	for (const id of existingDestinationIds) {
+		const response = await authOwnerAgent.del('/eventbus/destination').query({ id });
+		expect(response.statusCode).toBe(200);
+	}
 
 	const remainingDestinations = await destinationService.findDestination();
 	expect(remainingDestinations.length).toBe(0);

--- a/packages/cli/test/integration/eventbus/syslog-tls.test.ts
+++ b/packages/cli/test/integration/eventbus/syslog-tls.test.ts
@@ -5,8 +5,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type TestAgent from 'supertest/lib/agent';
 
-import { MessageEventBus } from '@/eventbus/message-event-bus/message-event-bus';
 import { EventMessageGeneric } from '@/eventbus/event-message-classes/event-message-generic';
+import { MessageEventBus } from '@/eventbus/message-event-bus/message-event-bus';
 import { LogStreamingDestinationService } from '@/modules/log-streaming.ee/log-streaming-destination.service';
 
 import { TlsSyslogServer } from './tls-server';

--- a/packages/cli/test/integration/log-streaming.controller.test.ts
+++ b/packages/cli/test/integration/log-streaming.controller.test.ts
@@ -1,0 +1,157 @@
+import { mockInstance } from '@n8n/backend-test-utils';
+import { GLOBAL_OWNER_ROLE, type User } from '@n8n/db';
+import { Container } from '@n8n/di';
+
+import { MessageEventBus } from '@/eventbus/message-event-bus/message-event-bus';
+import { ExecutionRecoveryService } from '@/executions/execution-recovery.service';
+import { LogStreamingDestinationService } from '@/modules/log-streaming.ee/log-streaming-destination.service';
+import { Publisher } from '@/scaling/pubsub/publisher.service';
+
+import { createUser } from './shared/db/users';
+import type { SuperAgentTest } from './shared/types';
+import * as utils from './shared/utils';
+
+jest.unmock('@/eventbus/message-event-bus/message-event-bus');
+
+mockInstance(Publisher);
+mockInstance(ExecutionRecoveryService);
+
+const testServer = utils.setupTestServer({
+	endpointGroups: ['eventBus'],
+	enabledFeatures: ['feat:logStreaming'],
+	modules: ['log-streaming'],
+});
+
+let owner: User;
+let authOwnerAgent: SuperAgentTest;
+
+beforeAll(async () => {
+	owner = await createUser({ role: GLOBAL_OWNER_ROLE });
+	authOwnerAgent = testServer.authAgentFor(owner);
+
+	const eventBus = Container.get(MessageEventBus);
+	await eventBus.initialize();
+
+	const destinationService = Container.get(LogStreamingDestinationService);
+	await destinationService.initialize();
+});
+
+describe('POST /eventbus/destination', () => {
+	describe('Valid destination creation', () => {
+		test('should create a webhook destination', async () => {
+			const webhookPayload = {
+				__type: '$$MessageEventBusDestinationWebhook',
+				url: 'http://localhost:3456',
+				method: 'POST',
+				label: 'Test Webhook',
+				enabled: false,
+				subscribedEvents: ['n8n.test.message'],
+				options: {},
+			};
+
+			const response = await authOwnerAgent.post('/eventbus/destination').send(webhookPayload);
+
+			expect(response.statusCode).toBe(200);
+			expect(response.body.data).toHaveProperty('id');
+			expect(response.body.data.__type).toBe('$$MessageEventBusDestinationWebhook');
+			expect(response.body.data.label).toBe('Test Webhook');
+		});
+
+		test('should create a sentry destination', async () => {
+			const sentryPayload = {
+				__type: '$$MessageEventBusDestinationSentry',
+				dsn: 'http://localhost:3000',
+				label: 'Test Sentry',
+				enabled: false,
+				subscribedEvents: ['n8n.test.message'],
+			};
+
+			const response = await authOwnerAgent.post('/eventbus/destination').send(sentryPayload);
+
+			expect(response.statusCode).toBe(200);
+			expect(response.body.data).toHaveProperty('id');
+			expect(response.body.data.__type).toBe('$$MessageEventBusDestinationSentry');
+			expect(response.body.data.label).toBe('Test Sentry');
+		});
+
+		test('should create a syslog destination', async () => {
+			const syslogPayload = {
+				__type: '$$MessageEventBusDestinationSyslog',
+				protocol: 'udp',
+				host: 'localhost',
+				port: 514,
+				label: 'Test Syslog',
+				enabled: false,
+				subscribedEvents: ['n8n.test.message'],
+			};
+
+			const response = await authOwnerAgent.post('/eventbus/destination').send(syslogPayload);
+
+			expect(response.statusCode).toBe(200);
+			expect(response.body.data).toHaveProperty('id');
+			expect(response.body.data.__type).toBe('$$MessageEventBusDestinationSyslog');
+			expect(response.body.data.label).toBe('Test Syslog');
+		});
+	});
+
+	describe('Invalid payloads', () => {
+		test('should return 400 for missing __type', async () => {
+			const invalidPayload = {
+				label: 'Test',
+			};
+
+			const response = await authOwnerAgent.post('/eventbus/destination').send(invalidPayload);
+
+			expect(response.statusCode).toBe(400);
+		});
+
+		test('should return 400 for invalid __type', async () => {
+			const invalidPayload = {
+				__type: 'InvalidType',
+				label: 'Test',
+			};
+
+			const response = await authOwnerAgent.post('/eventbus/destination').send(invalidPayload);
+
+			expect(response.statusCode).toBe(400);
+		});
+
+		test('should return 400 for webhook with missing url', async () => {
+			const invalidPayload = {
+				__type: '$$MessageEventBusDestinationWebhook',
+				url: '',
+				label: 'Test Webhook',
+				options: {},
+			};
+
+			const response = await authOwnerAgent.post('/eventbus/destination').send(invalidPayload);
+
+			expect(response.statusCode).toBe(400);
+		});
+
+		test('should return 400 for sentry with missing dsn', async () => {
+			const invalidPayload = {
+				__type: '$$MessageEventBusDestinationSentry',
+				dsn: '',
+				label: 'Test Sentry',
+			};
+
+			const response = await authOwnerAgent.post('/eventbus/destination').send(invalidPayload);
+
+			expect(response.statusCode).toBe(400);
+		});
+
+		test('should return 400 for syslog with invalid protocol', async () => {
+			const invalidPayload = {
+				__type: '$$MessageEventBusDestinationSyslog',
+				protocol: 'invalid-protocol',
+				host: 'localhost',
+				label: 'Test Syslog',
+			};
+
+			const response = await authOwnerAgent.post('/eventbus/destination').send(invalidPayload);
+
+			expect(response.statusCode).toBe(400);
+		});
+	});
+});

--- a/packages/workflow/src/message-event-bus.ts
+++ b/packages/workflow/src/message-event-bus.ts
@@ -195,10 +195,12 @@ export const MessageEventBusDestinationSyslogOptionsSchema =
 // Event Destination Types (Inferred from Zod Schemas)
 // ===============================
 
-export type MessageEventBusDestinationOptions = z.infer<
-	typeof MessageEventBusDestinationOptionsSchema
+// Base destination options type - __type is optional
+export type MessageEventBusDestinationOptions = Omit<
+	z.infer<typeof MessageEventBusDestinationOptionsSchema>,
+	'__type' | 'credentials'
 > & {
-	// Override credentials type to be more specific than z.record(z.unknown())
+	__type?: MessageEventBusDestinationTypeNames;
 	credentials?: INodeCredentials;
 };
 
@@ -210,24 +212,28 @@ export type MessageEventBusDestinationWebhookParameterOptions = z.infer<
 	typeof webhookParameterOptionsSchema
 >;
 
-export type MessageEventBusDestinationWebhookOptions = z.infer<
-	typeof MessageEventBusDestinationWebhookOptionsSchema
+// Specific destination types - use full enum type for compatibility with classes
+export type MessageEventBusDestinationWebhookOptions = Omit<
+	z.infer<typeof MessageEventBusDestinationWebhookOptionsSchema>,
+	'__type' | 'credentials'
 > & {
-	// Override credentials type to be more specific than z.record(z.unknown())
+	__type?: MessageEventBusDestinationTypeNames;
 	credentials?: INodeCredentials;
 };
 
-export type MessageEventBusDestinationSyslogOptions = z.infer<
-	typeof MessageEventBusDestinationSyslogOptionsSchema
+export type MessageEventBusDestinationSyslogOptions = Omit<
+	z.infer<typeof MessageEventBusDestinationSyslogOptionsSchema>,
+	'__type' | 'credentials'
 > & {
-	// Override credentials type to be more specific than z.record(z.unknown())
+	__type?: MessageEventBusDestinationTypeNames;
 	credentials?: INodeCredentials;
 };
 
-export type MessageEventBusDestinationSentryOptions = z.infer<
-	typeof MessageEventBusDestinationSentryOptionsSchema
+export type MessageEventBusDestinationSentryOptions = Omit<
+	z.infer<typeof MessageEventBusDestinationSentryOptionsSchema>,
+	'__type' | 'credentials'
 > & {
-	// Override credentials type to be more specific than z.record(z.unknown())
+	__type?: MessageEventBusDestinationTypeNames;
 	credentials?: INodeCredentials;
 };
 

--- a/packages/workflow/src/message-event-bus.ts
+++ b/packages/workflow/src/message-event-bus.ts
@@ -134,7 +134,7 @@ export const MessageEventBusDestinationOptionsSchema = z.object({
 			'$$MessageEventBusDestinationSyslog',
 		])
 		.optional(),
-	id: z.string().uuid().optional(),
+	id: z.string().optional(),
 	label: z.string().min(1).optional(),
 	enabled: z.boolean().optional(),
 	subscribedEvents: z.array(z.string()).optional(),

--- a/packages/workflow/src/message-event-bus.ts
+++ b/packages/workflow/src/message-event-bus.ts
@@ -134,7 +134,7 @@ export const MessageEventBusDestinationOptionsSchema = z.object({
 			'$$MessageEventBusDestinationSyslog',
 		])
 		.optional(),
-	id: z.string().optional(),
+	id: z.string().min(1).optional(),
 	label: z.string().min(1).optional(),
 	enabled: z.boolean().optional(),
 	subscribedEvents: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Create DTOs for log streaming crud controller.
Manually parse the create DTO because of limitation when inferring discriminated union schemas

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/IAM-3/extract-log-streaming-clean-up-architecture


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
