### PR TITLE
fix(core): Add pairedItem to declarative node outputs

### DIFF
--- a/packages/core/src/execution-engine/routing-node.ts
+++ b/packages/core/src/execution-engine/routing-node.ts
@@ -245,7 +245,11 @@ export class RoutingNode {
 				const error = responseData.reason;
 
 				if (itemContext[itemIndex].thisArgs?.continueOnFail()) {
-					returnData.push({ json: {}, error: error as NodeApiError });
+					returnData.push({
+						json: {},
+						error: error as NodeApiError,
+						pairedItem: { item: itemIndex },
+					});
 					continue;
 				}
 
@@ -267,6 +271,12 @@ export class RoutingNode {
 			if (itemContext[itemIndex].requestData.maxResults) {
 				// Remove not needed items in case APIs return to many
 				responseData.value.splice(itemContext[itemIndex].requestData.maxResults as number);
+			}
+
+			// Add pairedItem to each successful response item for data lineage tracking
+			// Only set if not already defined (postReceive actions may set custom pairing)
+			for (const item of responseData.value) {
+				item.pairedItem ??= { item: itemIndex };
 			}
 
 			returnData.push(...responseData.value);

--- a/packages/core/src/execution-engine/routing-node.ts
+++ b/packages/core/src/execution-engine/routing-node.ts
@@ -246,7 +246,9 @@ export class RoutingNode {
 
 				if (itemContext[itemIndex].thisArgs?.continueOnFail()) {
 					returnData.push({
-						json: {},
+						json: {
+							...items[itemIndex].json,
+						},
 						error: error as NodeApiError,
 						pairedItem: { item: itemIndex },
 					});

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1910,7 +1910,7 @@ export class WorkflowExecute {
 									error: (lineResult.json.$error as NodeApiError | NodeOperationError).message,
 								};
 							} else if (lineResult.error !== undefined) {
-								lineResult.json = { error: lineResult.error.message };
+								lineResult.json = { ...lineResult.json, error: lineResult.error.message };
 							}
 						}
 					}


### PR DESCRIPTION
## Summary

Declarative nodes (RoutingNode) don't set `pairedItem` on output items, breaking data lineage tracking. This causes `$('node').item` references to fail when using `continueOnFail` mode.

This may go unnoticed because implicit item matching works when input and output item counts are equal. When errors occur and items are filtered, the counts differ and matching fails.

Fixed by setting `pairedItem: { item: itemIndex }` on both error and success items in `RoutingNode.runNode()`. Uses `??=` on success items to preserve any custom pairing set by postReceive actions.

**Before:**
<img width="1274" height="795" alt="SCR-20260118-uhzi" src="https://github.com/user-attachments/assets/be770bb0-5cab-41e8-a0d9-6024592f5310" />


**After:**
<img width="1237" height="640" alt="image" src="https://github.com/user-attachments/assets/568a6882-98a0-4b6f-8229-d4d495dbc777" />


<details>
<summary>Click to expand test workflow</summary>

```json
{
  "nodes": [
    {
      "parameters": {},
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [
        -496,
        48
      ],
      "id": "b0081fb9-dedc-46b4-a937-a87a2cb3a868",
      "name": "When clicking ‘Execute workflow’"
    },
    {
      "parameters": {
        "category": "randomData"
      },
      "type": "n8n-nodes-base.debugHelper",
      "typeVersion": 1,
      "position": [
        -48,
        48
      ],
      "id": "74b5e87c-213e-463d-be39-ce334be4586a",
      "name": "DebugHelper"
    },
    {
      "parameters": {
        "operation": "get",
        "binId": "={{ $position % 2 == 0 ? $('Create Bin').item.json.binId : 'BAD_ID' }}",
        "requestOptions": {}
      },
      "type": "n8n-nodes-base.postBin",
      "typeVersion": 1,
      "position": [
        176,
        -144
      ],
      "id": "2e9db32e-bc41-4759-853c-a795188f0f2b",
      "name": "Continue on error",
      "onError": "continueRegularOutput"
    },
    {
      "parameters": {
        "operation": "get",
        "binId": "={{ $position % 2 == 0 ? $('Create Bin').item.json.binId : 'BAD_ID' }}",
        "requestOptions": {}
      },
      "type": "n8n-nodes-base.postBin",
      "typeVersion": 1,
      "position": [
        176,
        144
      ],
      "id": "5e5e245d-f34b-478a-8ce1-c2e2d5dca7c2",
      "name": "Continue using error output",
      "onError": "continueErrorOutput"
    },
    {
      "parameters": {
        "assignments": {
          "assignments": [
            {
              "id": "f9bee7dd-d576-429c-82a1-249f966bc002",
              "name": "OK",
              "value": "={{ $('DebugHelper').item.json.uid }} is OK",
              "type": "string"
            }
          ]
        },
        "includeOtherFields": true,
        "options": {}
      },
      "type": "n8n-nodes-base.set",
      "typeVersion": 3.4,
      "position": [
        400,
        48
      ],
      "id": "47cee640-cd79-41ce-8184-f2f09e09b827",
      "name": "Success Link Fail"
    },
    {
      "parameters": {
        "assignments": {
          "assignments": []
        },
        "includeOtherFields": true,
        "options": {}
      },
      "type": "n8n-nodes-base.set",
      "typeVersion": 3.4,
      "position": [
        400,
        240
      ],
      "id": "afd7d5b0-6837-46c6-9e43-b4f77efaec9d",
      "name": "Error Link Fail"
    },
    {
      "parameters": {
        "assignments": {
          "assignments": [
            {
              "id": "f9bee7dd-d576-429c-82a1-249f966bc002",
              "name": "OK",
              "value": "={{ $('DebugHelper').item.json.uid }} is OK",
              "type": "string"
            }
          ]
        },
        "includeOtherFields": true,
        "options": {}
      },
      "type": "n8n-nodes-base.set",
      "typeVersion": 3.4,
      "position": [
        400,
        -144
      ],
      "id": "0423579c-4ed5-4c4e-bb6b-77bcf5c89a48",
      "name": "Link OK"
    },
    {
      "parameters": {
        "requestOptions": {}
      },
      "type": "n8n-nodes-base.postBin",
      "typeVersion": 1,
      "position": [
        -272,
        48
      ],
      "id": "2a9c52b7-b968-4c87-a7ac-ba07fb2e6bf7",
      "name": "Create Bin",
      "onError": "continueRegularOutput"
    }
  ],
  "connections": {
    "When clicking ‘Execute workflow’": {
      "main": [
        [
          {
            "node": "Create Bin",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "DebugHelper": {
      "main": [
        [
          {
            "node": "Continue on error",
            "type": "main",
            "index": 0
          },
          {
            "node": "Continue using error output",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Continue on error": {
      "main": [
        [
          {
            "node": "Link OK",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Continue using error output": {
      "main": [
        [
          {
            "node": "Success Link Fail",
            "type": "main",
            "index": 0
          }
        ],
        [
          {
            "node": "Error Link Fail",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Create Bin": {
      "main": [
        [
          {
            "node": "DebugHelper",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {}
}
```

</details>

### Additional: Preserve input data in error output

Declarative nodes were also returning empty json on error. This brings them in line with programmatic nodes by spreading input item json with error output.

This won't impact existing workflows, declarative error output previously only contained `{ error: message }`. Adding original input fields alongside won't break downstream nodes.

The `workflow-execute.ts` change is backwards compatible, programmatic nodes set `json: {}` or omit it, so spreading has no effect.

Commits are split so these can be taken independently.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)