### PR TITLE
fix(editor): ignore TS2790 'delete' operator error in JavaScript nodes

### DIFF
--- a/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/typescript/worker/linter.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/typescript/worker/linter.ts
@@ -56,6 +56,10 @@ function isIgnoredDiagnostic(diagnostic: ts.Diagnostic) {
 		case 2307:
 		// 'await' expressions are only allowed within async functions and at the top levels of modules.
 		case 1308:
+		// The operand of a 'delete' operator must be optional.
+		// This is a TypeScript-specific strict mode check that doesn't apply to JavaScript.
+		// In JavaScript, any property can be deleted regardless of type definitions.
+		case 2790:
 			return true;
 	}
 


### PR DESCRIPTION
## Summary

When using the `delete` operator on object properties in the JavaScript code node, the editor shows TypeScript error:
> The operand of a 'delete' operator must be optional. (TS2790)

This is confusing because:
1. The code is written in JavaScript, not TypeScript
2. The code runs perfectly fine
3. This is a TypeScript strict mode check that doesn't apply to JavaScript

## Root Cause

The code editor uses TypeScript for syntax checking and intellisense, with `strict: true` in compiler options. TypeScript's strict mode enforces that `delete` can only be used on optional properties (marked with `?`), but JavaScript has no such restriction.

## Solution

Added TypeScript error code **2790** to the `isIgnoredDiagnostic` function in `linter.ts`, similar to how other TypeScript-specific errors are already being ignored:
- 7006: No implicit any
- 2307: Cannot find module
- 1308: await expressions only in async functions

## Changes

- `packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/typescript/worker/linter.ts`: Added TS2790 to ignored diagnostics

## Testing

1. Create a Code node in JavaScript mode
2. Add code that deletes a property: `delete item.json.Date;`
3. Verify no error is shown in the editor
4. Run the workflow - code executes correctly

Fixes #24351

---
This is a Gittensor contribution: [33f77537e7f32b9ddb9db247def29ada03f31fc9]