### PR TITLE
fix: Unfork `@n8n/vm2`

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/code/Code.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/code/Code.node.ts
@@ -1,5 +1,5 @@
 import type { Tool } from '@langchain/core/tools';
-import { makeResolverFromLegacyOptions } from '@n8n/vm2';
+import { makeResolverFromLegacyOptions } from 'vm2';
 import { JavaScriptSandbox } from 'n8n-nodes-base/dist/nodes/Code/JavaScriptSandbox';
 import { getSandboxContext } from 'n8n-nodes-base/dist/nodes/Code/Sandbox';
 import { standardizeOutput } from 'n8n-nodes-base/dist/nodes/Code/utils';

--- a/packages/@n8n/nodes-langchain/package.json
+++ b/packages/@n8n/nodes-langchain/package.json
@@ -212,7 +212,7 @@
     "@n8n/json-schema-to-zod": "workspace:*",
     "@n8n/typeorm": "catalog:",
     "@n8n/typescript-config": "workspace:*",
-    "@n8n/vm2": "3.9.25",
+    "vm2": "catalog:",
     "@pinecone-database/pinecone": "^5.0.2",
     "@qdrant/js-client-rest": "^1.16.2",
     "@supabase/supabase-js": "2.49.9",

--- a/packages/nodes-base/nodes/Code/JavaScriptSandbox.ts
+++ b/packages/nodes-base/nodes/Code/JavaScriptSandbox.ts
@@ -1,4 +1,4 @@
-import { NodeVM, makeResolverFromLegacyOptions, type Resolver } from '@n8n/vm2';
+import { NodeVM, makeResolverFromLegacyOptions, type Resolver } from 'vm2';
 import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 
 import { ExecutionError } from './ExecutionError';

--- a/packages/nodes-base/nodes/Code/test/Code.node.test.ts
+++ b/packages/nodes-base/nodes/Code/test/Code.node.test.ts
@@ -1,4 +1,4 @@
-import { NodeVM } from '@n8n/vm2';
+import { NodeVM } from 'vm2';
 import { NodeTestHarness } from '@nodes-testing/node-test-harness';
 import { anyNumber, mock } from 'jest-mock-extended';
 import { normalizeItems } from 'n8n-core';

--- a/packages/nodes-base/nodes/Function/Function.node.ts
+++ b/packages/nodes-base/nodes/Function/Function.node.ts
@@ -1,5 +1,5 @@
-import type { NodeVMOptions } from '@n8n/vm2';
-import { NodeVM } from '@n8n/vm2';
+import type { NodeVMOptions } from 'vm2';
+import { NodeVM } from 'vm2';
 import type {
 	IExecuteFunctions,
 	IBinaryKeyData,

--- a/packages/nodes-base/nodes/FunctionItem/FunctionItem.node.ts
+++ b/packages/nodes-base/nodes/FunctionItem/FunctionItem.node.ts
@@ -1,5 +1,5 @@
-import type { NodeVMOptions } from '@n8n/vm2';
-import { NodeVM } from '@n8n/vm2';
+import type { NodeVMOptions } from 'vm2';
+import { NodeVM } from 'vm2';
 import type {
 	IExecuteFunctions,
 	IBinaryKeyData,

--- a/packages/nodes-base/nodes/ItemLists/V3/helpers/utils.ts
+++ b/packages/nodes-base/nodes/ItemLists/V3/helpers/utils.ts
@@ -1,4 +1,4 @@
-import { NodeVM } from '@n8n/vm2';
+import { NodeVM } from 'vm2';
 import type {
 	IExecuteFunctions,
 	IBinaryData,

--- a/packages/nodes-base/nodes/Transform/Sort/utils.ts
+++ b/packages/nodes-base/nodes/Transform/Sort/utils.ts
@@ -1,4 +1,4 @@
-import { NodeVM } from '@n8n/vm2';
+import { NodeVM } from 'vm2';
 import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -884,7 +884,7 @@
     "@n8n/di": "workspace:*",
     "@n8n/errors": "workspace:*",
     "@n8n/imap": "workspace:*",
-    "@n8n/vm2": "3.9.25",
+    "vm2": "catalog:",
     "@thednp/dommatrix": "^2.0.12",
     "alasql": "4.4.0",
     "amqplib": "0.10.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ catalogs:
     vitest-mock-extended:
       specifier: ^3.1.0
       version: 3.1.0
+    vm2:
+      specifier: ^3.10.2
+      version: 3.10.2
     xml2js:
       specifier: 0.6.2
       version: 0.6.2
@@ -1297,9 +1300,6 @@ importers:
       '@n8n/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
-      '@n8n/vm2':
-        specifier: 3.9.25
-        version: 3.9.25
       '@pinecone-database/pinecone':
         specifier: ^5.0.2
         version: 5.1.2
@@ -1402,6 +1402,9 @@ importers:
       undici:
         specifier: ^6.21.0
         version: 6.21.3
+      vm2:
+        specifier: 'catalog:'
+        version: 3.10.2
       weaviate-client:
         specifier: 3.9.0
         version: 3.9.0(encoding@0.1.13)
@@ -3106,9 +3109,6 @@ importers:
       '@n8n/imap':
         specifier: workspace:*
         version: link:../@n8n/imap
-      '@n8n/vm2':
-        specifier: 3.9.25
-        version: 3.9.25
       '@thednp/dommatrix':
         specifier: ^2.0.12
         version: 2.0.12
@@ -3298,6 +3298,9 @@ importers:
       uuid:
         specifier: 'catalog:'
         version: 10.0.0
+      vm2:
+        specifier: 'catalog:'
+        version: 3.10.2
       xlsx:
         specifier: https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz
         version: https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz
@@ -6511,11 +6514,6 @@ packages:
       sqlite3:
         optional: true
 
-  '@n8n/vm2@3.9.25':
-    resolution: {integrity: sha512-qoGLFzyHBW7HKpwXkl05QKsIh3GkDw6lOiTOWYlUDnOIQ1b7EgM+O5EMjrMGy7r+kz52+Q7o6GLxBIcxVI8rEg==}
-    engines: {node: '>=18.10', pnpm: '>=9.6'}
-    hasBin: true
-
   '@n8n_io/ai-assistant-sdk@1.20.0':
     resolution: {integrity: sha512-uXa6EDufQIV46tvqQ222441dWZYLnT219HC5H8grfAVd6Mpp2Rs4NoBM6YPWnGFWBp8XVsgXUud0EKRbJsw0eA==}
     engines: {node: '>=20.15', pnpm: '>=8.14'}
@@ -9483,11 +9481,6 @@ packages:
 
   acorn@7.4.1:
     resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
-  acorn@8.12.1:
-    resolution: {integrity: sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -18168,6 +18161,11 @@ packages:
   vm-browserify@1.1.2:
     resolution: {integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==}
 
+  vm2@3.10.2:
+    resolution: {integrity: sha512-qTnbvpada8qlEEyIPFwhTcF5Ns+k83fVlOSE8XvAtHkhcQ+okMnbvryVQBfP/ExRT1CRsQpYusdATR+FBJfrnQ==}
+    engines: {node: '>=6.0'}
+    hasBin: true
+
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
@@ -23030,11 +23028,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@n8n/vm2@3.9.25':
-    dependencies:
-      acorn: 8.12.1
-      acorn-walk: 8.3.4
-
   '@n8n_io/ai-assistant-sdk@1.20.0': {}
 
   '@n8n_io/license-sdk@2.25.0':
@@ -26708,8 +26701,6 @@ snapshots:
       acorn: 8.15.0
 
   acorn@7.4.1: {}
-
-  acorn@8.12.1: {}
 
   acorn@8.14.0: {}
 
@@ -37403,6 +37394,11 @@ snapshots:
       - yaml
 
   vm-browserify@1.1.2: {}
+
+  vm2@3.10.2:
+    dependencies:
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
 
   void-elements@3.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -71,6 +71,7 @@ catalog:
   typescript: 5.9.2
   uuid: 10.0.0
   vite: npm:rolldown-vite@latest
+  vm2: ^3.10.2
   vite-plugin-dts: ^4.5.4
   vitest: ^3.1.3
   vitest-mock-extended: ^3.1.0
@@ -128,3 +129,4 @@ minimumReleaseAgeExclude:
   - '@google/genai'
   - body-parser
   - node-forge
+  - vm2 # Security fix for CVSS 9.8 sandbox escape vulnerability

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -129,4 +129,4 @@ minimumReleaseAgeExclude:
   - '@google/genai'
   - body-parser
   - node-forge
-  - vm2 # Security fix for CVSS 9.8 sandbox escape vulnerability
+  - vm2


### PR DESCRIPTION
## Summary

Removes the `@n8n/vm2` package and replaces it with the original `vm2` package.


## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
