### PR TITLE
fix(core): Route both Python options to the native Python runner

### DIFF
--- a/packages/frontend/editor-ui/src/features/shared/editors/components/CodeNodeEditor/completer.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/components/CodeNodeEditor/completer.ts
@@ -25,7 +25,7 @@ export const useCompleter = (
 	editor: MaybeRefOrGetter<EditorView | null>,
 ) => {
 	function autocompletionExtension(language: 'javaScript' | 'python' | 'pythonNative'): Extension {
-		if (language === 'pythonNative') {
+		if (language === 'python' || language === 'pythonNative') {
 			const completions = (context: CompletionContext): CompletionResult | null => {
 				const word = context.matchBefore(/\w*/);
 				if (!word) return null;

--- a/packages/frontend/editor-ui/src/features/shared/editors/components/CodeNodeEditor/utils.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/components/CodeNodeEditor/utils.ts
@@ -79,12 +79,6 @@ const pythonInsert = (value: string, mode: CodeExecutionMode): string => {
 	return toBracketNotation(base);
 };
 
-const pyodideInsert = (value: string, mode: CodeExecutionMode): string => {
-	return value
-		.replace('$json', mode === 'runOnceForAllItems' ? '_input.first().json' : '_input.item.json')
-		.replace(/\$\((.*)\)\.item/, mode === 'runOnceForAllItems' ? '_($1).first()' : '_($1).item');
-};
-
 const jsInsertForAllItems = (value: string, binaryMode?: WorkflowSettingsBinaryMode): string => {
 	const isCombinedBinaryMode = binaryMode === BINARY_MODE_COMBINED;
 
@@ -94,8 +88,8 @@ const jsInsertForAllItems = (value: string, binaryMode?: WorkflowSettingsBinaryM
 	return value.replace(jsonTarget, jsonReplacement).replace(/\$\((.*)\)\.item/, '$($1).first()');
 };
 
-const isPyodide = (language: CodeNodeLanguageOption) => language === 'python';
-const isPython = (language: CodeNodeLanguageOption) => language === 'pythonNative';
+const isPython = (language: CodeNodeLanguageOption) =>
+	language === 'python' || language === 'pythonNative';
 
 export const valueToInsert = (
 	value: string,
@@ -104,7 +98,6 @@ export const valueToInsert = (
 	binaryMode: WorkflowSettingsBinaryMode = BINARY_MODE_SEPARATE,
 ): string => {
 	if (isPython(language)) return pythonInsert(value, mode);
-	if (isPyodide(language)) return pyodideInsert(value, mode);
 	if (mode === 'runOnceForAllItems') return jsInsertForAllItems(value, binaryMode);
 
 	return value;

--- a/packages/nodes-base/nodes/Code/Code.node.ts
+++ b/packages/nodes-base/nodes/Code/Code.node.ts
@@ -118,7 +118,7 @@ export class Code implements INodeType {
 				: 'javaScript';
 
 		const isJsLang = language === 'javaScript';
-		const isPyLang = language === 'pythonNative';
+		const isPyLang = language === 'python' || language === 'pythonNative';
 		const runnersConfig = Container.get(TaskRunnersConfig);
 		const isJsRunner = runnersConfig.enabled;
 
@@ -128,7 +128,7 @@ export class Code implements INodeType {
 
 		const nodeMode = this.getNodeParameter('mode', 0) as CodeExecutionMode;
 		const workflowMode = this.getMode();
-		const codeParameterName = language === 'pythonNative' ? 'pythonCode' : 'jsCode';
+		const codeParameterName = isPyLang ? 'pythonCode' : 'jsCode';
 
 		if (isJsLang && isJsRunner) {
 			const code = this.getNodeParameter(codeParameterName, 0) as string;

--- a/packages/nodes-base/nodes/Code/Code.node.ts
+++ b/packages/nodes-base/nodes/Code/Code.node.ts
@@ -118,7 +118,7 @@ export class Code implements INodeType {
 				: 'javaScript';
 
 		const isJsLang = language === 'javaScript';
-		const isPyLang = language === 'python' || language === 'pythonNative';
+		const isPyLang = language === 'python' || language === 'pythonNative'; // keep legacy `python` for backwards compatibility
 		const runnersConfig = Container.get(TaskRunnersConfig);
 		const isJsRunner = runnersConfig.enabled;
 

--- a/packages/nodes-base/nodes/Code/descriptions/PythonCodeDescription.ts
+++ b/packages/nodes-base/nodes/Code/descriptions/PythonCodeDescription.ts
@@ -22,7 +22,7 @@ export const pythonCodeDescription: INodeProperties[] = [
 		...commonDescription,
 		displayOptions: {
 			show: {
-				language: ['pythonNative'],
+				language: ['python', 'pythonNative'],
 				mode: ['runOnceForAllItems'],
 			},
 		},
@@ -31,7 +31,7 @@ export const pythonCodeDescription: INodeProperties[] = [
 		...commonDescription,
 		displayOptions: {
 			show: {
-				language: ['pythonNative'],
+				language: ['python', 'pythonNative'],
 				mode: ['runOnceForEachItem'],
 			},
 		},
@@ -42,7 +42,7 @@ export const pythonCodeDescription: INodeProperties[] = [
 		type: 'notice',
 		displayOptions: {
 			show: {
-				language: ['pythonNative'],
+				language: ['python', 'pythonNative'],
 			},
 		},
 		default: '',

--- a/packages/nodes-base/nodes/Code/test/Code.node.test.ts
+++ b/packages/nodes-base/nodes/Code/test/Code.node.test.ts
@@ -1,8 +1,9 @@
 import { NodeVM } from '@n8n/vm2';
 import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import type { MockProxy } from 'jest-mock-extended';
 import { anyNumber, mock } from 'jest-mock-extended';
 import { normalizeItems } from 'n8n-core';
-import type { IExecuteFunctions, IWorkflowDataProxyData } from 'n8n-workflow';
+import type { IExecuteFunctions, INode, IWorkflowDataProxyData } from 'n8n-workflow';
 import { ApplicationError } from '@n8n/errors';
 
 import { Code } from '../Code.node';
@@ -146,13 +147,12 @@ describe('Code Node unit test', () => {
 
 	describe('python language routing', () => {
 		it('should route legacy `python` language to native Python runner', async () => {
-			const pythonThisArg = mock<IExecuteFunctions>({
-				getNode: () => mock({ typeVersion: 2 }),
-				helpers: { normalizeItems },
-				getMode: () => 'manual',
-				getRunnerStatus: () => ({ available: true }),
-			});
+			const pythonThisArg: MockProxy<IExecuteFunctions> = mock<IExecuteFunctions>();
+			pythonThisArg.helpers = { normalizeItems } as IExecuteFunctions['helpers'];
+			pythonThisArg.getNode.mockReturnValue(mock<INode>({ typeVersion: 2 }));
 			pythonThisArg.getWorkflowDataProxy.mockReturnValue(workflowDataProxy);
+			pythonThisArg.getMode.mockReturnValue('manual');
+			pythonThisArg.getRunnerStatus.mockReturnValue({ available: true });
 			pythonThisArg.getNodeParameter.calledWith('language', 0).mockReturnValue('python');
 			pythonThisArg.getNodeParameter.calledWith('mode', 0).mockReturnValue('runOnceForAllItems');
 			pythonThisArg.getNodeParameter.calledWith('pythonCode', 0).mockReturnValue('return []');

--- a/packages/workflow/src/telemetry-helpers.ts
+++ b/packages/workflow/src/telemetry-helpers.ts
@@ -440,8 +440,8 @@ export function generateNodesGraph(
 			nodeItem.language =
 				language === undefined
 					? 'javascript'
-					: language === 'pythonNative'
-						? 'pythonNative'
+					: language === 'python' || language === 'pythonNative'
+						? 'python'
 						: 'unknown';
 		} else if (node.type === GUARDRAILS_NODE_TYPE) {
 			nodeItem.operation = node.parameters.operation as string;


### PR DESCRIPTION
## Summary

Walk back over-eager post-v2 cleanup

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C035KBDA917/p1768670003727299
https://community.n8n.io/t/urgunet-help-needed-pyodide-code-is-gone-and-not-visible-after-updating-to-v2-3-5/250818

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
