### PR TITLE
feat(ai-builder): Add auto-fix for missing AI node connections + prompt guide

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/builder.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/builder.prompt.ts
@@ -132,6 +132,101 @@ AI Connection Examples (SOURCE → TARGET [connectionType]):
 The AI Agent only has ONE "main" output for regular data flow.
 All inputs to the AI Agent come FROM sub-nodes via ai_* connection types.`;
 
+const AI_CONNECTION_PATTERNS = `CRITICAL: AI NODES REQUIRE MANDATORY SUB-NODE CONNECTIONS
+
+The following nodes CANNOT function without their required ai_* inputs being connected:
+
+**AI Agent** (@n8n/n8n-nodes-langchain.agent):
+- MANDATORY: ai_languageModel - Must have a Chat Model connected (e.g., OpenAI Chat Model, Anthropic Chat Model)
+- OPTIONAL: ai_tool, ai_memory, ai_outputParser
+
+**Basic LLM Chain** (@n8n/n8n-nodes-langchain.chainLlm):
+- MANDATORY: ai_languageModel - Must have a Chat Model connected
+- OPTIONAL: ai_memory, ai_outputParser
+
+**Vector Store** (in insert/load modes):
+- MANDATORY: ai_embedding - Must have an Embeddings node connected (e.g., OpenAI Embeddings)
+- CONDITIONAL: ai_document (required in insert mode)
+
+**Question and Answer Chain** (@n8n/n8n-nodes-langchain.chainRetrievalQa):
+- MANDATORY: ai_languageModel - Must have a Chat Model connected
+- MANDATORY: ai_retriever - Must have a Retriever node connected
+
+**Vector Store Tool** (@n8n/n8n-nodes-langchain.toolVectorStore):
+- MANDATORY: ai_vectorStore - Must have a Vector Store connected
+- MANDATORY: ai_languageModel - Must have a Chat Model connected
+
+## Connection Patterns
+
+**Pattern 1: Simple AI Agent**
+What: Basic conversational AI that responds to user input using only its language model capabilities.
+When to use: Simple Q&A chatbots, text generation, summarization, or any task where the AI just needs to process text without external data or actions.
+Example prompts: "Create a chatbot", "Summarize incoming emails", "Generate product descriptions"
+\`\`\`mermaid
+graph TD
+    T[Trigger] --> A[AI Agent]
+    CM[OpenAI Chat Model] -.ai_languageModel.-> A
+    A --> OUT[Output Node]
+\`\`\`
+
+**Pattern 2: AI Agent with Tools**
+What: AI Agent enhanced with tools that let it perform actions (calculations, API calls, database queries) and memory to maintain conversation context.
+When to use: When the AI needs to DO things (not just respond), access external systems, perform calculations, or remember previous interactions.
+Example prompts: "Create an assistant that can search the web and do math", "Build a bot that can create calendar events", "Assistant that remembers conversation history"
+\`\`\`mermaid
+graph TD
+    T[Trigger] --> A[AI Agent]
+    CM[Chat Model] -.ai_languageModel.-> A
+    TOOL1[Calculator Tool] -.ai_tool.-> A
+    TOOL2[HTTP Request Tool] -.ai_tool.-> A
+    MEM[Window Buffer Memory] -.ai_memory.-> A
+    A --> OUT[Output]
+\`\`\`
+
+**Pattern 3: RAG Pipeline (Vector Store Insert)**
+What: Ingestion pipeline that processes documents, splits them into chunks, generates embeddings, and stores them in a vector database for later retrieval.
+When to use: Building a knowledge base from documents (PDFs, web pages, files). This is the "indexing" or "loading" phase of RAG - run this BEFORE querying.
+Example prompts: "Index my company documents", "Load PDFs into a knowledge base", "Store website content for later search"
+\`\`\`mermaid
+graph TD
+    T[Trigger] --> VS[Vector Store<br/>mode: insert]
+    EMB[OpenAI Embeddings] -.ai_embedding.-> VS
+    DL[Default Data Loader] -.ai_document.-> VS
+    TS[Token Text Splitter] -.ai_textSplitter.-> DL
+\`\`\`
+
+**Pattern 4: RAG Query with AI Agent**
+What: AI Agent that can search a vector database to find relevant information before responding, grounding its answers in your custom data.
+When to use: "Chat with your documents" scenarios - when the AI needs to answer questions using information from a previously indexed knowledge base.
+Example prompts: "Answer questions about my documentation", "Chat with uploaded PDFs", "Search knowledge base and respond"
+\`\`\`mermaid
+graph TD
+    T[Trigger] --> A[AI Agent]
+    CM[Chat Model] -.ai_languageModel.-> A
+    VS[Vector Store<br/>mode: retrieve-as-tool] -.ai_tool.-> A
+    EMB[Embeddings] -.ai_embedding.-> VS
+\`\`\`
+
+**Pattern 5: Multi-Agent System**
+What: Hierarchical agent setup where a main "supervisor" agent delegates specialized tasks to sub-agents, each with their own capabilities.
+When to use: Complex workflows requiring different expertise (research agent + writing agent), task decomposition, or when one agent needs to orchestrate multiple specialized agents.
+Example prompts: "Create a team of agents", "Supervisor that delegates to specialists", "Research agent that calls a coding agent"
+\`\`\`mermaid
+graph TD
+    T[Trigger] --> MAIN[Main AI Agent]
+    CM1[Chat Model 1] -.ai_languageModel.-> MAIN
+    SUB[AI Agent Tool] -.ai_tool.-> MAIN
+    CM2[Chat Model 2] -.ai_languageModel.-> SUB
+\`\`\`
+
+## Validation Checklist
+1. Every AI Agent has a Chat Model connected via ai_languageModel
+2. Every Vector Store has Embeddings connected via ai_embedding
+3. All sub-nodes (Chat Models, Tools, Memory) are connected to their target nodes
+4. Sub-nodes connect TO parent nodes, not FROM them
+
+REMEMBER: Every AI Agent MUST have a Chat Model. Never create an AI Agent without also creating and connecting a Chat Model.`;
+
 const BRANCHING = `If two nodes (B and C) are both connected to the same output of a node (A), both will execute (with the same data). Whether B or C executes first is determined by their position on the canvas: the highest one executes first. Execution happens depth-first, i.e. any downstream nodes connected to the higher node will execute before the lower node is executed.
 Nodes that route the flow (e.g. if, switch) apply their conditions independently to each input item. They may route different items to different branches in the same execution.`;
 
@@ -411,6 +506,7 @@ export function buildBuilderPrompt(): string {
 		.section('resource_operation_pattern', RESOURCE_OPERATION_PATTERN)
 		.section('structured_output_parser_guidance', STRUCTURED_OUTPUT_PARSER)
 		.section('node_connections_understanding', AI_CONNECTIONS)
+		.section('AI_CONNECTION_PATTERNS', AI_CONNECTION_PATTERNS)
 		.section('branching', BRANCHING)
 		.section('merging', MERGING)
 		.section('agent_node_distinction', AGENT_NODE_DISTINCTION)

--- a/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/builder.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/builder.prompt.ts
@@ -118,19 +118,10 @@ When calling connect_nodes for AI sub-nodes:
 - targetNodeName: The AI Agent (or Vector Store, Document Loader)
 - connectionType: The appropriate ai_* type
 
-AI Connection Examples (SOURCE → TARGET [connectionType]):
-- OpenAI Chat Model → AI Agent [ai_languageModel]
-- Calculator Tool → AI Agent [ai_tool]
-- HTTP Request Tool → AI Agent [ai_tool]
-- Window Buffer Memory → AI Agent [ai_memory]
-- Structured Output Parser → AI Agent [ai_outputParser]
-- Token Splitter → Default Data Loader [ai_textSplitter]
-- Default Data Loader → Vector Store [ai_document]
-- Embeddings OpenAI → Vector Store [ai_embedding]
-- Vector Store (retrieve-as-tool mode) → AI Agent [ai_tool]
-
 The AI Agent only has ONE "main" output for regular data flow.
-All inputs to the AI Agent come FROM sub-nodes via ai_* connection types.`;
+All inputs to the AI Agent come FROM sub-nodes via ai_* connection types.
+
+Note: The connect_nodes tool will auto-detect connection types - see tool description for examples.`;
 
 const AI_CONNECTION_PATTERNS = `CRITICAL: AI NODES REQUIRE MANDATORY SUB-NODE CONNECTIONS
 
@@ -506,7 +497,7 @@ export function buildBuilderPrompt(): string {
 		.section('resource_operation_pattern', RESOURCE_OPERATION_PATTERN)
 		.section('structured_output_parser_guidance', STRUCTURED_OUTPUT_PARSER)
 		.section('node_connections_understanding', AI_CONNECTIONS)
-		.section('AI_CONNECTION_PATTERNS', AI_CONNECTION_PATTERNS)
+		.section('ai_connection_patterns', AI_CONNECTION_PATTERNS)
 		.section('branching', BRANCHING)
 		.section('merging', MERGING)
 		.section('agent_node_distinction', AGENT_NODE_DISTINCTION)

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/validate-structure.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/validate-structure.tool.ts
@@ -39,7 +39,6 @@ export function createValidateStructureTool(parsedNodeTypes: INodeTypeDescriptio
 
 				const connectionViolations = validateConnections(state.workflowJSON, parsedNodeTypes);
 				const triggerViolations = validateTrigger(state.workflowJSON, parsedNodeTypes);
-
 				const allViolations = [...connectionViolations, ...triggerViolations];
 
 				let message: string;
@@ -52,9 +51,11 @@ export function createValidateStructureTool(parsedNodeTypes: INodeTypeDescriptio
 
 				reporter.complete({ message });
 
-				return createSuccessResponse(config, message, {
+				const stateUpdates: Record<string, unknown> = {
 					structureValidation: { connections: connectionViolations, trigger: triggerViolations },
-				});
+				};
+
+				return createSuccessResponse(config, message, stateUpdates);
 			} catch (error) {
 				if (error instanceof z.ZodError) {
 					const validationError = new ValidationError('Invalid input parameters', {

--- a/packages/@n8n/ai-workflow-builder.ee/src/validation/auto-fix/__tests__/auto-fix-connections.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/validation/auto-fix/__tests__/auto-fix-connections.test.ts
@@ -1,0 +1,518 @@
+import type { INodeTypeDescription, INode, IConnections } from 'n8n-workflow';
+import { NodeConnectionTypes } from 'n8n-workflow';
+
+import type { SimpleWorkflow } from '@/types';
+import type { ProgrammaticViolation } from '@/validation/types';
+
+import { autoFixConnections } from '../auto-fix-connections';
+
+describe('autoFixConnections', () => {
+	// Mock node types
+	const mockAgentNodeType: INodeTypeDescription = {
+		displayName: 'AI Agent',
+		name: '@n8n/n8n-nodes-langchain.agent',
+		group: ['transform'],
+		version: 1,
+		inputs: [
+			NodeConnectionTypes.Main,
+			{ type: 'ai_languageModel', required: true, displayName: 'Model', maxConnections: 1 },
+			{ type: 'ai_tool', required: false, displayName: 'Tools' },
+			{ type: 'ai_memory', required: false, displayName: 'Memory', maxConnections: 1 },
+		],
+		outputs: [NodeConnectionTypes.Main],
+		properties: [],
+		defaults: { name: 'AI Agent' },
+		description: '',
+	};
+
+	const mockChatModelNodeType: INodeTypeDescription = {
+		displayName: 'OpenAI Chat Model',
+		name: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
+		group: ['output'],
+		version: 1,
+		inputs: [],
+		outputs: ['ai_languageModel'],
+		properties: [],
+		defaults: { name: 'OpenAI Chat Model' },
+		description: '',
+	};
+
+	const mockVectorStoreNodeType: INodeTypeDescription = {
+		displayName: 'Vector Store',
+		name: '@n8n/n8n-nodes-langchain.vectorStoreInMemory',
+		group: ['transform'],
+		version: 1,
+		inputs: [
+			NodeConnectionTypes.Main,
+			{ type: 'ai_embedding', required: true, displayName: 'Embeddings', maxConnections: 1 },
+			{ type: 'ai_document', required: false, displayName: 'Documents' },
+		],
+		outputs: [NodeConnectionTypes.Main],
+		properties: [],
+		defaults: { name: 'Vector Store' },
+		description: '',
+	};
+
+	const mockEmbeddingsNodeType: INodeTypeDescription = {
+		displayName: 'OpenAI Embeddings',
+		name: '@n8n/n8n-nodes-langchain.embeddingsOpenAi',
+		group: ['output'],
+		version: 1,
+		inputs: [],
+		outputs: ['ai_embedding'],
+		properties: [],
+		defaults: { name: 'OpenAI Embeddings' },
+		description: '',
+	};
+
+	const mockTriggerNodeType: INodeTypeDescription = {
+		displayName: 'Manual Trigger',
+		name: 'n8n-nodes-base.manualTrigger',
+		group: ['trigger'],
+		version: 1,
+		inputs: [],
+		outputs: [NodeConnectionTypes.Main],
+		properties: [],
+		defaults: { name: 'Manual Trigger' },
+		description: '',
+	};
+
+	const mockNodeTypes = [
+		mockAgentNodeType,
+		mockChatModelNodeType,
+		mockVectorStoreNodeType,
+		mockEmbeddingsNodeType,
+		mockTriggerNodeType,
+	];
+
+	// Helper to create nodes
+	function createNode(overrides: Partial<INode> & { name: string; type: string }): INode {
+		return {
+			id: overrides.id ?? `id-${overrides.name}`,
+			name: overrides.name,
+			type: overrides.type,
+			typeVersion: overrides.typeVersion ?? 1,
+			position: overrides.position ?? [0, 0],
+			parameters: overrides.parameters ?? {},
+			disabled: overrides.disabled ?? false,
+		};
+	}
+
+	// Helper to create workflow
+	function createWorkflow(nodes: INode[], connections: IConnections = {}): SimpleWorkflow {
+		return {
+			name: 'Test Workflow',
+			nodes,
+			connections,
+		};
+	}
+
+	describe('Pass 1: Fix nodes missing required inputs', () => {
+		it('should auto-fix when exactly one sub-node can provide the missing input', () => {
+			const workflow = createWorkflow(
+				[
+					createNode({ name: 'Manual Trigger', type: 'n8n-nodes-base.manualTrigger' }),
+					createNode({ name: 'AI Agent', type: '@n8n/n8n-nodes-langchain.agent' }),
+					createNode({ name: 'OpenAI Model', type: '@n8n/n8n-nodes-langchain.lmChatOpenAi' }),
+				],
+				{
+					'Manual Trigger': {
+						main: [[{ node: 'AI Agent', type: 'main', index: 0 }]],
+					},
+				},
+			);
+
+			const violations: ProgrammaticViolation[] = [
+				{
+					name: 'node-missing-required-input',
+					type: 'critical',
+					description:
+						'Node AI Agent (@n8n/n8n-nodes-langchain.agent) is missing required input of type ai_languageModel',
+					pointsDeducted: 50,
+				},
+				{
+					name: 'sub-node-not-connected',
+					type: 'critical',
+					description:
+						'Sub-node OpenAI Model (@n8n/n8n-nodes-langchain.lmChatOpenAi) provides ai_languageModel but is not connected to a root node.',
+					pointsDeducted: 50,
+				},
+			];
+
+			const result = autoFixConnections(workflow, mockNodeTypes, violations);
+
+			expect(result.fixed).toHaveLength(1);
+			expect(result.fixed[0]).toMatchObject({
+				sourceNodeName: 'OpenAI Model',
+				targetNodeName: 'AI Agent',
+				connectionType: 'ai_languageModel',
+			});
+			expect(result.unfixable).toHaveLength(0);
+			expect(result.updatedConnections['OpenAI Model']?.ai_languageModel).toBeDefined();
+		});
+
+		it('should report unfixable when multiple sub-nodes can provide the same input', () => {
+			const workflow = createWorkflow([
+				createNode({ name: 'AI Agent', type: '@n8n/n8n-nodes-langchain.agent' }),
+				createNode({ name: 'OpenAI Model 1', type: '@n8n/n8n-nodes-langchain.lmChatOpenAi' }),
+				createNode({ name: 'OpenAI Model 2', type: '@n8n/n8n-nodes-langchain.lmChatOpenAi' }),
+			]);
+
+			const violations: ProgrammaticViolation[] = [
+				{
+					name: 'node-missing-required-input',
+					type: 'critical',
+					description:
+						'Node AI Agent (@n8n/n8n-nodes-langchain.agent) is missing required input of type ai_languageModel',
+					pointsDeducted: 50,
+				},
+			];
+
+			const result = autoFixConnections(workflow, mockNodeTypes, violations);
+
+			expect(result.fixed).toHaveLength(0);
+			expect(result.unfixable).toHaveLength(1);
+			expect(result.unfixable[0].reason).toContain('Multiple sub-nodes');
+			expect(result.unfixable[0].candidateCount).toBe(2);
+		});
+
+		it('should report unfixable when no sub-node can provide the input', () => {
+			const workflow = createWorkflow([
+				createNode({ name: 'AI Agent', type: '@n8n/n8n-nodes-langchain.agent' }),
+			]);
+
+			const violations: ProgrammaticViolation[] = [
+				{
+					name: 'node-missing-required-input',
+					type: 'critical',
+					description:
+						'Node AI Agent (@n8n/n8n-nodes-langchain.agent) is missing required input of type ai_languageModel',
+					pointsDeducted: 50,
+				},
+			];
+
+			const result = autoFixConnections(workflow, mockNodeTypes, violations);
+
+			expect(result.fixed).toHaveLength(0);
+			expect(result.unfixable).toHaveLength(1);
+			expect(result.unfixable[0].reason).toContain('No available sub-node');
+			expect(result.unfixable[0].candidateCount).toBe(0);
+		});
+
+		it('should skip disabled nodes when searching for candidates', () => {
+			const workflow = createWorkflow([
+				createNode({ name: 'AI Agent', type: '@n8n/n8n-nodes-langchain.agent' }),
+				createNode({
+					name: 'OpenAI Model',
+					type: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
+					disabled: true,
+				}),
+			]);
+
+			const violations: ProgrammaticViolation[] = [
+				{
+					name: 'node-missing-required-input',
+					type: 'critical',
+					description:
+						'Node AI Agent (@n8n/n8n-nodes-langchain.agent) is missing required input of type ai_languageModel',
+					pointsDeducted: 50,
+				},
+			];
+
+			const result = autoFixConnections(workflow, mockNodeTypes, violations);
+
+			expect(result.fixed).toHaveLength(0);
+			expect(result.unfixable).toHaveLength(1);
+			expect(result.unfixable[0].reason).toContain('No available sub-node');
+		});
+
+		it('should not use a sub-node that is already connected', () => {
+			const workflow = createWorkflow(
+				[
+					createNode({ name: 'AI Agent 1', type: '@n8n/n8n-nodes-langchain.agent' }),
+					createNode({ name: 'AI Agent 2', type: '@n8n/n8n-nodes-langchain.agent' }),
+					createNode({ name: 'OpenAI Model', type: '@n8n/n8n-nodes-langchain.lmChatOpenAi' }),
+				],
+				{
+					'OpenAI Model': {
+						ai_languageModel: [[{ node: 'AI Agent 1', type: 'ai_languageModel', index: 0 }]],
+					},
+				},
+			);
+
+			const violations: ProgrammaticViolation[] = [
+				{
+					name: 'node-missing-required-input',
+					type: 'critical',
+					description:
+						'Node AI Agent 2 (@n8n/n8n-nodes-langchain.agent) is missing required input of type ai_languageModel',
+					pointsDeducted: 50,
+				},
+			];
+
+			const result = autoFixConnections(workflow, mockNodeTypes, violations);
+
+			expect(result.fixed).toHaveLength(0);
+			expect(result.unfixable).toHaveLength(1);
+			expect(result.unfixable[0].reason).toContain('No available sub-node');
+		});
+
+		it('should fix Vector Store missing embeddings', () => {
+			const workflow = createWorkflow([
+				createNode({ name: 'Manual Trigger', type: 'n8n-nodes-base.manualTrigger' }),
+				createNode({ name: 'Vector Store', type: '@n8n/n8n-nodes-langchain.vectorStoreInMemory' }),
+				createNode({ name: 'Embeddings', type: '@n8n/n8n-nodes-langchain.embeddingsOpenAi' }),
+			]);
+
+			const violations: ProgrammaticViolation[] = [
+				{
+					name: 'node-missing-required-input',
+					type: 'critical',
+					description:
+						'Node Vector Store (@n8n/n8n-nodes-langchain.vectorStoreInMemory) is missing required input of type ai_embedding',
+					pointsDeducted: 50,
+				},
+			];
+
+			const result = autoFixConnections(workflow, mockNodeTypes, violations);
+
+			expect(result.fixed).toHaveLength(1);
+			expect(result.fixed[0]).toMatchObject({
+				sourceNodeName: 'Embeddings',
+				targetNodeName: 'Vector Store',
+				connectionType: 'ai_embedding',
+			});
+		});
+	});
+
+	describe('Pass 2: Fix disconnected sub-nodes', () => {
+		it('should connect orphaned sub-node to only available target', () => {
+			const workflow = createWorkflow([
+				createNode({ name: 'AI Agent', type: '@n8n/n8n-nodes-langchain.agent' }),
+				createNode({ name: 'OpenAI Model', type: '@n8n/n8n-nodes-langchain.lmChatOpenAi' }),
+			]);
+
+			// Only sub-node-not-connected violation, no node-missing-required-input
+			const violations: ProgrammaticViolation[] = [
+				{
+					name: 'sub-node-not-connected',
+					type: 'critical',
+					description:
+						'Sub-node OpenAI Model (@n8n/n8n-nodes-langchain.lmChatOpenAi) provides ai_languageModel but is not connected to a root node.',
+					pointsDeducted: 50,
+				},
+			];
+
+			const result = autoFixConnections(workflow, mockNodeTypes, violations);
+
+			expect(result.fixed).toHaveLength(1);
+			expect(result.fixed[0]).toMatchObject({
+				sourceNodeName: 'OpenAI Model',
+				targetNodeName: 'AI Agent',
+				connectionType: 'ai_languageModel',
+			});
+		});
+
+		it('should report unfixable when multiple targets accept the same input', () => {
+			const workflow = createWorkflow([
+				createNode({ name: 'AI Agent 1', type: '@n8n/n8n-nodes-langchain.agent' }),
+				createNode({ name: 'AI Agent 2', type: '@n8n/n8n-nodes-langchain.agent' }),
+				createNode({ name: 'OpenAI Model', type: '@n8n/n8n-nodes-langchain.lmChatOpenAi' }),
+			]);
+
+			const violations: ProgrammaticViolation[] = [
+				{
+					name: 'sub-node-not-connected',
+					type: 'critical',
+					description:
+						'Sub-node OpenAI Model (@n8n/n8n-nodes-langchain.lmChatOpenAi) provides ai_languageModel but is not connected to a root node.',
+					pointsDeducted: 50,
+				},
+			];
+
+			const result = autoFixConnections(workflow, mockNodeTypes, violations);
+
+			expect(result.fixed).toHaveLength(0);
+			expect(result.unfixable).toHaveLength(1);
+			expect(result.unfixable[0].reason).toContain('Multiple targets');
+		});
+
+		it('should skip sub-node already fixed in Pass 1', () => {
+			const workflow = createWorkflow([
+				createNode({ name: 'AI Agent', type: '@n8n/n8n-nodes-langchain.agent' }),
+				createNode({ name: 'OpenAI Model', type: '@n8n/n8n-nodes-langchain.lmChatOpenAi' }),
+			]);
+
+			// Both violations - Pass 1 should fix, Pass 2 should skip
+			const violations: ProgrammaticViolation[] = [
+				{
+					name: 'node-missing-required-input',
+					type: 'critical',
+					description:
+						'Node AI Agent (@n8n/n8n-nodes-langchain.agent) is missing required input of type ai_languageModel',
+					pointsDeducted: 50,
+				},
+				{
+					name: 'sub-node-not-connected',
+					type: 'critical',
+					description:
+						'Sub-node OpenAI Model (@n8n/n8n-nodes-langchain.lmChatOpenAi) provides ai_languageModel but is not connected to a root node.',
+					pointsDeducted: 50,
+				},
+			];
+
+			const result = autoFixConnections(workflow, mockNodeTypes, violations);
+
+			// Should only have 1 fix, not 2
+			expect(result.fixed).toHaveLength(1);
+			expect(result.unfixable).toHaveLength(0);
+		});
+	});
+
+	describe('Edge cases', () => {
+		it('should handle empty violations array', () => {
+			const workflow = createWorkflow([
+				createNode({ name: 'AI Agent', type: '@n8n/n8n-nodes-langchain.agent' }),
+			]);
+
+			const result = autoFixConnections(workflow, mockNodeTypes, []);
+
+			expect(result.fixed).toHaveLength(0);
+			expect(result.unfixable).toHaveLength(0);
+		});
+
+		it('should handle empty workflow', () => {
+			const workflow = createWorkflow([]);
+
+			const violations: ProgrammaticViolation[] = [
+				{
+					name: 'node-missing-required-input',
+					type: 'critical',
+					description:
+						'Node AI Agent (@n8n/n8n-nodes-langchain.agent) is missing required input of type ai_languageModel',
+					pointsDeducted: 50,
+				},
+			];
+
+			const result = autoFixConnections(workflow, mockNodeTypes, violations);
+
+			expect(result.fixed).toHaveLength(0);
+			expect(result.unfixable).toHaveLength(0);
+		});
+
+		it('should only fix AI connections (skip main)', () => {
+			const workflow = createWorkflow([
+				createNode({ name: 'AI Agent', type: '@n8n/n8n-nodes-langchain.agent' }),
+			]);
+
+			const violations: ProgrammaticViolation[] = [
+				{
+					name: 'node-missing-required-input',
+					type: 'critical',
+					description:
+						'Node AI Agent (@n8n/n8n-nodes-langchain.agent) is missing required input of type main',
+					pointsDeducted: 50,
+				},
+			];
+
+			const result = autoFixConnections(workflow, mockNodeTypes, violations);
+
+			// main connections are not auto-fixed
+			expect(result.fixed).toHaveLength(0);
+			expect(result.unfixable).toHaveLength(0);
+		});
+
+		it('should not create duplicate connections', () => {
+			const workflow = createWorkflow(
+				[
+					createNode({ name: 'AI Agent', type: '@n8n/n8n-nodes-langchain.agent' }),
+					createNode({ name: 'OpenAI Model', type: '@n8n/n8n-nodes-langchain.lmChatOpenAi' }),
+				],
+				{
+					'OpenAI Model': {
+						ai_languageModel: [[{ node: 'AI Agent', type: 'ai_languageModel', index: 0 }]],
+					},
+				},
+			);
+
+			// Violation says missing, but connection already exists
+			const violations: ProgrammaticViolation[] = [
+				{
+					name: 'node-missing-required-input',
+					type: 'critical',
+					description:
+						'Node AI Agent (@n8n/n8n-nodes-langchain.agent) is missing required input of type ai_languageModel',
+					pointsDeducted: 50,
+				},
+			];
+
+			const result = autoFixConnections(workflow, mockNodeTypes, violations);
+
+			// Sub-node is already connected, so it shouldn't be a candidate
+			expect(result.fixed).toHaveLength(0);
+			expect(result.unfixable).toHaveLength(1);
+		});
+
+		it('should handle unknown node types gracefully', () => {
+			const workflow = createWorkflow([
+				createNode({ name: 'Unknown Node', type: 'n8n-nodes-base.unknown' }),
+				createNode({ name: 'OpenAI Model', type: '@n8n/n8n-nodes-langchain.lmChatOpenAi' }),
+			]);
+
+			const violations: ProgrammaticViolation[] = [
+				{
+					name: 'node-missing-required-input',
+					type: 'critical',
+					description:
+						'Node Unknown Node (n8n-nodes-base.unknown) is missing required input of type ai_languageModel',
+					pointsDeducted: 50,
+				},
+			];
+
+			const result = autoFixConnections(workflow, mockNodeTypes, violations);
+
+			// Auto-fix should still work based on the violation description
+			// The node type doesn't need to be known since the violation already tells us what input is needed
+			expect(result.fixed).toHaveLength(1);
+			expect(result.fixed[0].targetNodeName).toBe('Unknown Node');
+			expect(result.fixed[0].connectionType).toBe('ai_languageModel');
+		});
+
+		it('should preserve existing connections when adding new ones', () => {
+			const existingConnections: IConnections = {
+				'Manual Trigger': {
+					main: [[{ node: 'AI Agent', type: 'main', index: 0 }]],
+				},
+			};
+
+			const workflow = createWorkflow(
+				[
+					createNode({ name: 'Manual Trigger', type: 'n8n-nodes-base.manualTrigger' }),
+					createNode({ name: 'AI Agent', type: '@n8n/n8n-nodes-langchain.agent' }),
+					createNode({ name: 'OpenAI Model', type: '@n8n/n8n-nodes-langchain.lmChatOpenAi' }),
+				],
+				existingConnections,
+			);
+
+			const violations: ProgrammaticViolation[] = [
+				{
+					name: 'node-missing-required-input',
+					type: 'critical',
+					description:
+						'Node AI Agent (@n8n/n8n-nodes-langchain.agent) is missing required input of type ai_languageModel',
+					pointsDeducted: 50,
+				},
+			];
+
+			const result = autoFixConnections(workflow, mockNodeTypes, violations);
+
+			// Existing connection should be preserved
+			expect(result.updatedConnections['Manual Trigger']).toBeDefined();
+			expect(result.updatedConnections['Manual Trigger'].main[0]?.[0].node).toBe('AI Agent');
+
+			// New connection should be added
+			expect(result.updatedConnections['OpenAI Model']).toBeDefined();
+			expect(result.fixed).toHaveLength(1);
+		});
+	});
+});

--- a/packages/@n8n/ai-workflow-builder.ee/src/validation/auto-fix/__tests__/auto-fix-connections.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/validation/auto-fix/__tests__/auto-fix-connections.test.ts
@@ -129,6 +129,11 @@ describe('autoFixConnections', () => {
 					description:
 						'Node AI Agent (@n8n/n8n-nodes-langchain.agent) is missing required input of type ai_languageModel',
 					pointsDeducted: 50,
+					metadata: {
+						nodeName: 'AI Agent',
+						nodeType: '@n8n/n8n-nodes-langchain.agent',
+						missingType: 'ai_languageModel',
+					},
 				},
 				{
 					name: 'sub-node-not-connected',
@@ -136,6 +141,11 @@ describe('autoFixConnections', () => {
 					description:
 						'Sub-node OpenAI Model (@n8n/n8n-nodes-langchain.lmChatOpenAi) provides ai_languageModel but is not connected to a root node.',
 					pointsDeducted: 50,
+					metadata: {
+						nodeName: 'OpenAI Model',
+						nodeType: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
+						outputType: 'ai_languageModel',
+					},
 				},
 			];
 
@@ -165,6 +175,11 @@ describe('autoFixConnections', () => {
 					description:
 						'Node AI Agent (@n8n/n8n-nodes-langchain.agent) is missing required input of type ai_languageModel',
 					pointsDeducted: 50,
+					metadata: {
+						nodeName: 'AI Agent',
+						nodeType: '@n8n/n8n-nodes-langchain.agent',
+						missingType: 'ai_languageModel',
+					},
 				},
 			];
 
@@ -188,6 +203,11 @@ describe('autoFixConnections', () => {
 					description:
 						'Node AI Agent (@n8n/n8n-nodes-langchain.agent) is missing required input of type ai_languageModel',
 					pointsDeducted: 50,
+					metadata: {
+						nodeName: 'AI Agent',
+						nodeType: '@n8n/n8n-nodes-langchain.agent',
+						missingType: 'ai_languageModel',
+					},
 				},
 			];
 
@@ -216,6 +236,11 @@ describe('autoFixConnections', () => {
 					description:
 						'Node AI Agent (@n8n/n8n-nodes-langchain.agent) is missing required input of type ai_languageModel',
 					pointsDeducted: 50,
+					metadata: {
+						nodeName: 'AI Agent',
+						nodeType: '@n8n/n8n-nodes-langchain.agent',
+						missingType: 'ai_languageModel',
+					},
 				},
 			];
 
@@ -226,7 +251,7 @@ describe('autoFixConnections', () => {
 			expect(result.unfixable[0].reason).toContain('No available sub-node');
 		});
 
-		it('should not use a sub-node that is already connected', () => {
+		it('should allow a sub-node to connect to multiple root nodes', () => {
 			const workflow = createWorkflow(
 				[
 					createNode({ name: 'AI Agent 1', type: '@n8n/n8n-nodes-langchain.agent' }),
@@ -247,14 +272,24 @@ describe('autoFixConnections', () => {
 					description:
 						'Node AI Agent 2 (@n8n/n8n-nodes-langchain.agent) is missing required input of type ai_languageModel',
 					pointsDeducted: 50,
+					metadata: {
+						nodeName: 'AI Agent 2',
+						nodeType: '@n8n/n8n-nodes-langchain.agent',
+						missingType: 'ai_languageModel',
+					},
 				},
 			];
 
 			const result = autoFixConnections(workflow, mockNodeTypes, violations);
 
-			expect(result.fixed).toHaveLength(0);
-			expect(result.unfixable).toHaveLength(1);
-			expect(result.unfixable[0].reason).toContain('No available sub-node');
+			// Sub-node is connected to Agent 1 but can still connect to Agent 2
+			expect(result.fixed).toHaveLength(1);
+			expect(result.fixed[0]).toMatchObject({
+				sourceNodeName: 'OpenAI Model',
+				targetNodeName: 'AI Agent 2',
+				connectionType: 'ai_languageModel',
+			});
+			expect(result.unfixable).toHaveLength(0);
 		});
 
 		it('should fix Vector Store missing embeddings', () => {
@@ -271,6 +306,11 @@ describe('autoFixConnections', () => {
 					description:
 						'Node Vector Store (@n8n/n8n-nodes-langchain.vectorStoreInMemory) is missing required input of type ai_embedding',
 					pointsDeducted: 50,
+					metadata: {
+						nodeName: 'Vector Store',
+						nodeType: '@n8n/n8n-nodes-langchain.vectorStoreInMemory',
+						missingType: 'ai_embedding',
+					},
 				},
 			];
 
@@ -300,6 +340,11 @@ describe('autoFixConnections', () => {
 					description:
 						'Sub-node OpenAI Model (@n8n/n8n-nodes-langchain.lmChatOpenAi) provides ai_languageModel but is not connected to a root node.',
 					pointsDeducted: 50,
+					metadata: {
+						nodeName: 'OpenAI Model',
+						nodeType: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
+						outputType: 'ai_languageModel',
+					},
 				},
 			];
 
@@ -327,6 +372,11 @@ describe('autoFixConnections', () => {
 					description:
 						'Sub-node OpenAI Model (@n8n/n8n-nodes-langchain.lmChatOpenAi) provides ai_languageModel but is not connected to a root node.',
 					pointsDeducted: 50,
+					metadata: {
+						nodeName: 'OpenAI Model',
+						nodeType: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
+						outputType: 'ai_languageModel',
+					},
 				},
 			];
 
@@ -351,6 +401,11 @@ describe('autoFixConnections', () => {
 					description:
 						'Node AI Agent (@n8n/n8n-nodes-langchain.agent) is missing required input of type ai_languageModel',
 					pointsDeducted: 50,
+					metadata: {
+						nodeName: 'AI Agent',
+						nodeType: '@n8n/n8n-nodes-langchain.agent',
+						missingType: 'ai_languageModel',
+					},
 				},
 				{
 					name: 'sub-node-not-connected',
@@ -358,6 +413,11 @@ describe('autoFixConnections', () => {
 					description:
 						'Sub-node OpenAI Model (@n8n/n8n-nodes-langchain.lmChatOpenAi) provides ai_languageModel but is not connected to a root node.',
 					pointsDeducted: 50,
+					metadata: {
+						nodeName: 'OpenAI Model',
+						nodeType: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
+						outputType: 'ai_languageModel',
+					},
 				},
 			];
 
@@ -391,6 +451,11 @@ describe('autoFixConnections', () => {
 					description:
 						'Node AI Agent (@n8n/n8n-nodes-langchain.agent) is missing required input of type ai_languageModel',
 					pointsDeducted: 50,
+					metadata: {
+						nodeName: 'AI Agent',
+						nodeType: '@n8n/n8n-nodes-langchain.agent',
+						missingType: 'ai_languageModel',
+					},
 				},
 			];
 
@@ -412,6 +477,11 @@ describe('autoFixConnections', () => {
 					description:
 						'Node AI Agent (@n8n/n8n-nodes-langchain.agent) is missing required input of type main',
 					pointsDeducted: 50,
+					metadata: {
+						nodeName: 'AI Agent',
+						nodeType: '@n8n/n8n-nodes-langchain.agent',
+						missingType: 'main',
+					},
 				},
 			];
 
@@ -443,14 +513,21 @@ describe('autoFixConnections', () => {
 					description:
 						'Node AI Agent (@n8n/n8n-nodes-langchain.agent) is missing required input of type ai_languageModel',
 					pointsDeducted: 50,
+					metadata: {
+						nodeName: 'AI Agent',
+						nodeType: '@n8n/n8n-nodes-langchain.agent',
+						missingType: 'ai_languageModel',
+					},
 				},
 			];
 
 			const result = autoFixConnections(workflow, mockNodeTypes, violations);
 
-			// Sub-node is already connected, so it shouldn't be a candidate
+			// Sub-node is already connected to this target, so no fix needed
 			expect(result.fixed).toHaveLength(0);
+			// Reports unfixable because the only candidate is already connected to this target
 			expect(result.unfixable).toHaveLength(1);
+			expect(result.unfixable[0].reason).toContain('No available sub-node');
 		});
 
 		it('should handle unknown node types gracefully', () => {
@@ -466,13 +543,18 @@ describe('autoFixConnections', () => {
 					description:
 						'Node Unknown Node (n8n-nodes-base.unknown) is missing required input of type ai_languageModel',
 					pointsDeducted: 50,
+					metadata: {
+						nodeName: 'Unknown Node',
+						nodeType: 'n8n-nodes-base.unknown',
+						missingType: 'ai_languageModel',
+					},
 				},
 			];
 
 			const result = autoFixConnections(workflow, mockNodeTypes, violations);
 
-			// Auto-fix should still work based on the violation description
-			// The node type doesn't need to be known since the violation already tells us what input is needed
+			// Auto-fix should still work based on the metadata
+			// The node type doesn't need to be known since the metadata already tells us what input is needed
 			expect(result.fixed).toHaveLength(1);
 			expect(result.fixed[0].targetNodeName).toBe('Unknown Node');
 			expect(result.fixed[0].connectionType).toBe('ai_languageModel');
@@ -501,6 +583,11 @@ describe('autoFixConnections', () => {
 					description:
 						'Node AI Agent (@n8n/n8n-nodes-langchain.agent) is missing required input of type ai_languageModel',
 					pointsDeducted: 50,
+					metadata: {
+						nodeName: 'AI Agent',
+						nodeType: '@n8n/n8n-nodes-langchain.agent',
+						missingType: 'ai_languageModel',
+					},
 				},
 			];
 

--- a/packages/@n8n/ai-workflow-builder.ee/src/validation/auto-fix/auto-fix-connections.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/validation/auto-fix/auto-fix-connections.ts
@@ -1,0 +1,342 @@
+import type { INodeTypeDescription, NodeConnectionType, IConnections } from 'n8n-workflow';
+
+import { createConnection } from '@/tools/utils/connection.utils';
+import type { SimpleWorkflow } from '@/types';
+import { isSubNode } from '@/utils/node-helpers';
+import { createNodeTypeMaps, getNodeTypeForNode } from '@/validation/utils/node-type-map';
+import { resolveNodeInputs, resolveNodeOutputs } from '@/validation/utils/resolve-connections';
+
+import type { ProgrammaticViolation, NodeResolvedConnectionTypesInfo } from '../types';
+
+export interface AutoFixResult {
+	fixed: AutoFixedConnection[];
+	unfixable: UnfixableConnection[];
+	updatedConnections: IConnections;
+}
+
+export interface AutoFixedConnection {
+	sourceNodeName: string;
+	targetNodeName: string;
+	connectionType: NodeConnectionType;
+	reason: string;
+}
+
+export interface UnfixableConnection {
+	nodeName: string;
+	missingInputType: NodeConnectionType;
+	reason: string;
+	candidateCount: number;
+}
+
+interface AutoFixContext {
+	result: AutoFixResult;
+	nodeTypeMap: Map<string, INodeTypeDescription>;
+	nodeTypesByName: Map<string, INodeTypeDescription>;
+	nodesByName: Map<string, SimpleWorkflow['nodes'][0]>;
+	subNodeOutputs: Map<string, Set<NodeConnectionType>>;
+	connectedSubNodes: Set<string>;
+	workflow: SimpleWorkflow;
+}
+
+/**
+ * Check if a sub-node already has an outgoing connection of a specific type
+ */
+function findExistingOutgoingConnection(
+	connections: IConnections,
+	nodeName: string,
+	connectionType: NodeConnectionType,
+): boolean {
+	const nodeConnections = connections[nodeName];
+	if (!nodeConnections) return false;
+
+	const typeConnections = nodeConnections[connectionType];
+	if (!typeConnections) return false;
+
+	return typeConnections.some((connArray) => connArray && connArray.length > 0);
+}
+
+/**
+ * Check if a target node already has an incoming connection of a specific type
+ */
+function checkNodeHasInputConnection(
+	connections: IConnections,
+	targetNodeName: string,
+	connectionType: NodeConnectionType,
+): boolean {
+	for (const [, nodeConns] of Object.entries(connections)) {
+		const typeConns = nodeConns[connectionType];
+		if (!typeConns) continue;
+
+		for (const connArray of typeConns) {
+			if (connArray?.some((conn) => conn.node === targetNodeName)) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+/**
+ * Build a map of what each sub-node outputs
+ */
+function buildSubNodeOutputsMap(
+	workflow: SimpleWorkflow,
+	nodeTypeMap: Map<string, INodeTypeDescription>,
+	nodeTypesByName: Map<string, INodeTypeDescription>,
+): Map<string, Set<NodeConnectionType>> {
+	const subNodeOutputs = new Map<string, Set<NodeConnectionType>>();
+
+	for (const node of workflow.nodes) {
+		if (node.disabled) continue;
+
+		const nodeType = getNodeTypeForNode(node, nodeTypeMap, nodeTypesByName);
+		if (!nodeType) continue;
+
+		if (isSubNode(nodeType, node)) {
+			try {
+				const nodeInfo: NodeResolvedConnectionTypesInfo = { node, nodeType };
+				const outputs = resolveNodeOutputs(nodeInfo);
+				if (outputs.size > 0) {
+					subNodeOutputs.set(node.name, outputs);
+				}
+			} catch {
+				// Skip nodes where we can't resolve outputs
+			}
+		}
+	}
+
+	return subNodeOutputs;
+}
+
+/**
+ * Find candidate sub-nodes that can provide a specific input type
+ */
+function findCandidateSubNodes(ctx: AutoFixContext, missingType: NodeConnectionType): string[] {
+	const candidates: string[] = [];
+
+	for (const [subNodeName, outputs] of ctx.subNodeOutputs) {
+		if (outputs.has(missingType)) {
+			const existingConnection = findExistingOutgoingConnection(
+				ctx.result.updatedConnections,
+				subNodeName,
+				missingType,
+			);
+
+			if (!existingConnection && !ctx.connectedSubNodes.has(subNodeName)) {
+				candidates.push(subNodeName);
+			}
+		}
+	}
+
+	return candidates;
+}
+
+/**
+ * Process a single missing input violation
+ */
+function processMissingInputViolation(ctx: AutoFixContext, violation: ProgrammaticViolation): void {
+	const match = violation.description.match(
+		/Node (.+) \((.+)\) is missing required input of type (.+)/,
+	);
+	if (!match) return;
+
+	const [, nodeName, , missingType] = match;
+	const targetNode = ctx.nodesByName.get(nodeName);
+	if (!targetNode || targetNode.disabled) return;
+
+	// Only auto-fix AI connections (ai_*)
+	if (!missingType.startsWith('ai_')) return;
+
+	const candidates = findCandidateSubNodes(ctx, missingType as NodeConnectionType);
+
+	if (candidates.length === 1) {
+		const sourceNodeName = candidates[0];
+		ctx.result.updatedConnections = createConnection(
+			ctx.result.updatedConnections,
+			sourceNodeName,
+			nodeName,
+			missingType as NodeConnectionType,
+			0,
+			0,
+		);
+		ctx.connectedSubNodes.add(sourceNodeName);
+		ctx.result.fixed.push({
+			sourceNodeName,
+			targetNodeName: nodeName,
+			connectionType: missingType as NodeConnectionType,
+			reason: `Auto-connected orphaned sub-node to target requiring ${missingType}`,
+		});
+	} else if (candidates.length === 0) {
+		ctx.result.unfixable.push({
+			nodeName,
+			missingInputType: missingType as NodeConnectionType,
+			reason: `No available sub-node provides ${missingType}`,
+			candidateCount: 0,
+		});
+	} else {
+		ctx.result.unfixable.push({
+			nodeName,
+			missingInputType: missingType as NodeConnectionType,
+			reason: `Multiple sub-nodes (${candidates.join(', ')}) can provide ${missingType} - ambiguous`,
+			candidateCount: candidates.length,
+		});
+	}
+}
+
+/**
+ * Find target nodes that accept a specific output type
+ */
+function findTargetCandidates(
+	ctx: AutoFixContext,
+	subNodeName: string,
+	outputType: NodeConnectionType,
+): string[] {
+	const targetCandidates: string[] = [];
+
+	for (const node of ctx.workflow.nodes) {
+		if (node.disabled || node.name === subNodeName) continue;
+
+		const nodeType = getNodeTypeForNode(node, ctx.nodeTypeMap, ctx.nodeTypesByName);
+		if (!nodeType) continue;
+
+		if (isSubNode(nodeType, node)) continue;
+
+		try {
+			const nodeInfo: NodeResolvedConnectionTypesInfo = { node, nodeType };
+			const inputs = resolveNodeInputs(nodeInfo);
+			const acceptsType = inputs.some((input) => input.type === outputType);
+
+			if (acceptsType) {
+				const hasConnection = checkNodeHasInputConnection(
+					ctx.result.updatedConnections,
+					node.name,
+					outputType,
+				);
+
+				if (!hasConnection) {
+					targetCandidates.push(node.name);
+				}
+			}
+		} catch {
+			// Skip nodes where we can't resolve inputs
+		}
+	}
+
+	return targetCandidates;
+}
+
+/**
+ * Process a single disconnected sub-node violation
+ */
+function processDisconnectedSubNodeViolation(
+	ctx: AutoFixContext,
+	violation: ProgrammaticViolation,
+): void {
+	const match = violation.description.match(
+		/Sub-node (.+) \((.+)\) provides (.+) but is not connected/,
+	);
+	if (!match) return;
+
+	const [, subNodeName, , outputType] = match;
+	const subNode = ctx.nodesByName.get(subNodeName);
+	if (!subNode || subNode.disabled) return;
+
+	if (ctx.connectedSubNodes.has(subNodeName)) return;
+
+	const nowConnected = findExistingOutgoingConnection(
+		ctx.result.updatedConnections,
+		subNodeName,
+		outputType as NodeConnectionType,
+	);
+	if (nowConnected) return;
+
+	const targetCandidates = findTargetCandidates(ctx, subNodeName, outputType as NodeConnectionType);
+
+	if (targetCandidates.length === 1) {
+		const targetNodeName = targetCandidates[0];
+		ctx.result.updatedConnections = createConnection(
+			ctx.result.updatedConnections,
+			subNodeName,
+			targetNodeName,
+			outputType as NodeConnectionType,
+			0,
+			0,
+		);
+		ctx.connectedSubNodes.add(subNodeName);
+		ctx.result.fixed.push({
+			sourceNodeName: subNodeName,
+			targetNodeName,
+			connectionType: outputType as NodeConnectionType,
+			reason: 'Auto-connected disconnected sub-node to only available target',
+		});
+	} else if (targetCandidates.length === 0) {
+		ctx.result.unfixable.push({
+			nodeName: subNodeName,
+			missingInputType: outputType as NodeConnectionType,
+			reason: `No target node accepts ${outputType} input`,
+			candidateCount: 0,
+		});
+	} else {
+		ctx.result.unfixable.push({
+			nodeName: subNodeName,
+			missingInputType: outputType as NodeConnectionType,
+			reason: `Multiple targets (${targetCandidates.join(', ')}) accept ${outputType} - ambiguous`,
+			candidateCount: targetCandidates.length,
+		});
+	}
+}
+
+/**
+ * Attempts to automatically fix missing required AI connections.
+ *
+ * Algorithm:
+ * Pass 1 - For each node missing a required AI input:
+ *   1. Find candidate sub-nodes that output the required type
+ *   2. If exactly 1 candidate exists -> AUTO-FIX
+ *   3. If 0 candidates exist -> UNFIXABLE (no provider)
+ *   4. If multiple candidates exist -> UNFIXABLE (ambiguous)
+ *
+ * Pass 2 - For remaining disconnected sub-nodes:
+ *   1. Find target nodes that require the sub-node's output type
+ *   2. If exactly 1 target exists -> AUTO-FIX
+ *   3. If multiple targets exist -> UNFIXABLE (ambiguous)
+ */
+export function autoFixConnections(
+	workflow: SimpleWorkflow,
+	nodeTypes: INodeTypeDescription[],
+	violations: ProgrammaticViolation[],
+): AutoFixResult {
+	const { nodeTypeMap, nodeTypesByName } = createNodeTypeMaps(nodeTypes);
+	const nodesByName = new Map(workflow.nodes.map((node) => [node.name, node]));
+	const subNodeOutputs = buildSubNodeOutputsMap(workflow, nodeTypeMap, nodeTypesByName);
+
+	const ctx: AutoFixContext = {
+		result: {
+			fixed: [],
+			unfixable: [],
+			updatedConnections: structuredClone(workflow.connections ?? {}),
+		},
+		nodeTypeMap,
+		nodeTypesByName,
+		nodesByName,
+		subNodeOutputs,
+		connectedSubNodes: new Set<string>(),
+		workflow,
+	};
+
+	// Pass 1: Fix nodes missing required inputs
+	const missingInputViolations = violations.filter((v) => v.name === 'node-missing-required-input');
+	for (const violation of missingInputViolations) {
+		processMissingInputViolation(ctx, violation);
+	}
+
+	// Pass 2: Fix disconnected sub-nodes
+	const disconnectedSubNodeViolations = violations.filter(
+		(v) => v.name === 'sub-node-not-connected',
+	);
+	for (const violation of disconnectedSubNodeViolations) {
+		processDisconnectedSubNodeViolation(ctx, violation);
+	}
+
+	return ctx.result;
+}

--- a/packages/@n8n/ai-workflow-builder.ee/src/validation/auto-fix/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/validation/auto-fix/index.ts
@@ -1,0 +1,6 @@
+export { autoFixConnections } from './auto-fix-connections';
+export type {
+	AutoFixResult,
+	AutoFixedConnection,
+	UnfixableConnection,
+} from './auto-fix-connections';

--- a/packages/@n8n/ai-workflow-builder.ee/src/validation/checks/connections.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/validation/checks/connections.ts
@@ -50,6 +50,11 @@ function checkMissingRequiredInputs(
 				type: 'critical',
 				description: `Node ${nodeInfo.node.name} (${nodeInfo.node.type}) is missing required input of type ${input.type}`,
 				pointsDeducted: 50,
+				metadata: {
+					nodeName: nodeInfo.node.name,
+					nodeType: nodeInfo.node.type,
+					missingType: input.type,
+				},
 			});
 		}
 	}
@@ -171,6 +176,11 @@ function checkSubNodeRootConnections(
 				type: 'critical',
 				description: `Sub-node ${node.name} (${node.type}) provides ${outputType} but is not connected to a root node.`,
 				pointsDeducted: 50,
+				metadata: {
+					nodeName: node.name,
+					nodeType: node.type,
+					outputType,
+				},
 			});
 		}
 	}

--- a/packages/@n8n/ai-workflow-builder.ee/src/validation/types.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/validation/types.ts
@@ -42,6 +42,7 @@ export interface ProgrammaticViolation {
 	type: ProgrammaticViolationType;
 	description: string;
 	pointsDeducted: number;
+	metadata?: Record<string, string>;
 }
 
 export interface SingleEvaluatorResult {


### PR DESCRIPTION
## Summary                                                                
- Add prompt enhancements with mandatory AI connection requirements and mermaid diagram patterns                                                  
- Implement auto-fix post-processing that connects orphaned sub-nodes when unambiguous                                                              
- Implement auto-fix post-processing in builder subgraph that automatically connects orphaned sub-nodes:                                
  - **Pass 1**: For nodes missing required inputs (e.g., AI Agent missing `ai_languageModel`), finds candidate sub-nodes that output the required type. Auto-fixes if exactly 1 candidate exists.                           
  - **Pass 2**: For disconnected sub-nodes, finds target nodes that accept the sub-node's output type. Auto-fixes if exactly 1 target exists.       
    - Reports unfixable issues when multiple candidates exist (ambiguous) or no candidates exist                                                      
    - Auto-fix runs transparently after builder completes, before workflow goes to configurator 
    
---
**related ticket: https://linear.app/n8n/issue/AI-1939/implement-fixes-for-node-missing-required-input-validation-failures-in**