### PR TITLE
fix(core): Check user auth identities to know whether or not they can update their profile

### DIFF
--- a/packages/cli/src/controllers/auth.controller.ts
+++ b/packages/cli/src/controllers/auth.controller.ts
@@ -126,7 +126,10 @@ export class AuthController {
 		allowSkipMFA: true,
 	})
 	async currentUser(req: AuthenticatedRequest): Promise<PublicUser> {
-		return await this.userService.toPublic(req.user, {
+		// We need auth identities to determine signInType in toPublic method
+		const user = await this.userService.findUserWithAuthIdentities(req.user.id);
+
+		return await this.userService.toPublic(user, {
 			posthog: this.postHog,
 			withScopes: true,
 			mfaAuthenticated: req.authInfo?.usedMfa,

--- a/packages/cli/src/controllers/me.controller.ts
+++ b/packages/cli/src/controllers/me.controller.ts
@@ -60,7 +60,7 @@ export class MeController {
 		const isFirstNameChanged = firstName !== currentFirstName;
 		const isLastNameChanged = lastName !== currentLastName;
 
-		// Check if the user is authenticated via LDAP or OIDC - they cannot change their profile info
+		// Check if the user is authenticated via SSO - they cannot change their profile info
 		if (isEmailBeingChanged || isFirstNameChanged || isLastNameChanged) {
 			const ssoIdentity = await this.userService.findSsoIdentity(userId);
 

--- a/packages/cli/src/controllers/me.controller.ts
+++ b/packages/cli/src/controllers/me.controller.ts
@@ -21,12 +21,7 @@ import { MfaService } from '@/mfa/mfa.service';
 import { MeRequest } from '@/requests';
 import { PasswordUtility } from '@/services/password.utility';
 import { UserService } from '@/services/user.service';
-import {
-	getCurrentAuthenticationMethod,
-	isLdapCurrentAuthenticationMethod,
-	isOidcCurrentAuthenticationMethod,
-	isSamlLicensedAndEnabled,
-} from '@/sso.ee/sso-helpers';
+import { isSamlLicensedAndEnabled } from '@/sso.ee/sso-helpers';
 
 import { PersonalizationSurveyAnswersV4 } from './survey-answers.dto';
 
@@ -65,20 +60,22 @@ export class MeController {
 		const isFirstNameChanged = firstName !== currentFirstName;
 		const isLastNameChanged = lastName !== currentLastName;
 
-		if (
-			(isLdapCurrentAuthenticationMethod() || isOidcCurrentAuthenticationMethod()) &&
-			(isEmailBeingChanged || isFirstNameChanged || isLastNameChanged)
-		) {
-			this.logger.debug(
-				`Request to update user failed because ${getCurrentAuthenticationMethod()} user may not change their profile information`,
-				{
-					userId,
-					payload: payloadWithoutPassword,
-				},
-			);
-			throw new BadRequestError(
-				` ${getCurrentAuthenticationMethod()} user may not change their profile information`,
-			);
+		// Check if the user is authenticated via LDAP or OIDC - they cannot change their profile info
+		if (isEmailBeingChanged || isFirstNameChanged || isLastNameChanged) {
+			const ssoIdentity = await this.userService.findSsoIdentity(userId);
+
+			if (ssoIdentity) {
+				this.logger.debug(
+					`Request to update user failed because ${ssoIdentity.providerType} user may not change their profile information`,
+					{
+						userId,
+						payload: payloadWithoutPassword,
+					},
+				);
+				throw new BadRequestError(
+					`${ssoIdentity.providerType.toUpperCase()} user may not change their profile information`,
+				);
+			}
 		}
 
 		await this.validateChangingUserEmail(req.user, payload);
@@ -91,10 +88,7 @@ export class MeController {
 
 		const preUpdateUser = await this.userRepository.findOneByOrFail({ id: userId });
 		await this.userService.update(userId, payloadWithoutPassword);
-		const user = await this.userRepository.findOneOrFail({
-			where: { id: userId },
-			relations: ['role'],
-		});
+		const user = await this.userService.findUserWithAuthIdentities(userId);
 
 		this.logger.info('User updated successfully', { userId });
 

--- a/packages/cli/src/services/__tests__/user.service.test.ts
+++ b/packages/cli/src/services/__tests__/user.service.test.ts
@@ -934,4 +934,50 @@ describe('UserService', () => {
 			);
 		});
 	});
+
+	describe('findSsoIdentity', () => {
+		it('should return undefined when user has no SSO identity', async () => {
+			const userId = uuid();
+			userRepository.findOne.mockResolvedValue(
+				Object.assign(new User(), {
+					id: userId,
+					authIdentities: [{ providerType: 'email' }],
+				}),
+			);
+
+			const result = await userService.findSsoIdentity(userId);
+
+			expect(result).toBeUndefined();
+		});
+
+		it('should return SSO identity when user has LDAP identity', async () => {
+			const userId = uuid();
+			const ldapIdentity = { providerType: 'ldap', providerId: 'ldap-id' };
+			userRepository.findOne.mockResolvedValue(
+				Object.assign(new User(), {
+					id: userId,
+					authIdentities: [ldapIdentity],
+				}),
+			);
+
+			const result = await userService.findSsoIdentity(userId);
+
+			expect(result).toEqual(ldapIdentity);
+		});
+
+		it('should return SSO identity when user has both email and SSO identity', async () => {
+			const userId = uuid();
+			const samlIdentity = { providerType: 'saml', providerId: 'saml-id' };
+			userRepository.findOne.mockResolvedValue(
+				Object.assign(new User(), {
+					id: userId,
+					authIdentities: [{ providerType: 'email' }, samlIdentity],
+				}),
+			);
+
+			const result = await userService.findSsoIdentity(userId);
+
+			expect(result).toEqual(samlIdentity);
+		});
+	});
 });


### PR DESCRIPTION

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Add the auth identities to know whether or not the user can update their profile, instead of relying on the current authentication method.
Fetch the auth identities when getting public user (toPublic method), in order to feel the signinType for frontend

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/IAM-64/bug-when-ldap-enabled-members-can-update-their-profile-information


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
