### PR TITLE
fix: Set NODE_PATH for DHI images

### DIFF
--- a/docker/images/n8n-base/Dockerfile
+++ b/docker/images/n8n-base/Dockerfile
@@ -2,6 +2,8 @@ ARG NODE_VERSION=22.22.0
 
 FROM dhi.io/node:${NODE_VERSION}-alpine3.22-dev
 
+ARG NODE_VERSION
+
 # Install all dependencies in a single layer to minimize image size
 RUN apk add --no-cache busybox-binsh && \
     # Install fonts
@@ -30,4 +32,7 @@ RUN apk add --no-cache busybox-binsh && \
 
 WORKDIR /home/node
 ENV NODE_ICU_DATA=/usr/local/lib/node_modules/full-icu
+# DHI images use a non-standard global npm path, so we need to set NODE_PATH
+# to allow externally installed npm packages to be found by require()
+ENV NODE_PATH=/opt/nodejs/node-v${NODE_VERSION}/lib/node_modules
 EXPOSE 5678/tcp


### PR DESCRIPTION
## Summary

Configures the `NODE_PATH` environment variable to allow externally installed npm packages to be found.

The base Docker images from DHI use a non-standard global npm path, so `NODE_PATH` must be explicitly set.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
