### PR TITLE
fix(editor): Layout changes to the input triple

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterNew.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterNew.vue
@@ -879,7 +879,7 @@ const onAddButtonClick = () => {
 }
 
 .sectionHeader {
-	margin-bottom: 0;
+	margin-bottom: var(--spacing--xs);
 }
 
 .controls {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterNew.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterNew.vue
@@ -879,7 +879,7 @@ const onAddButtonClick = () => {
 }
 
 .sectionHeader {
-	margin-bottom: var(--spacing--xs);
+	margin-bottom: 0;
 }
 
 .controls {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/InputTriple/InputTriple.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/InputTriple/InputTriple.vue
@@ -92,6 +92,10 @@ withDefaults(defineProps<Props>(), { middleWidth: '160px' });
 	flex-basis: 160px;
 }
 
+.default .middle {
+	padding-top: var(--parameter-input-options--height);
+}
+
 .item:first-of-type {
 	--input--radius--top-left: var(--radius);
 	--input--radius--bottom-left: var(--radius);
@@ -111,6 +115,7 @@ withDefaults(defineProps<Props>(), { middleWidth: '160px' });
 
 	.middle {
 		margin-left: -1px;
+		padding-top: var(--parameter-input-options--height);
 
 		--input-triple--radius--top-right: var(--radius);
 		--input-triple--radius--bottom-right: 0;


### PR DESCRIPTION
## Summary
<img width="710" height="620" alt="Screenshot 2026-01-19 at 12 39 27" src="https://github.com/user-attachments/assets/90e90fc4-ad36-4f40-9a56-4c84560e0143" />
<img width="1018" height="515" alt="Screenshot 2026-01-19 at 12 39 31" src="https://github.com/user-attachments/assets/c84f2f44-4921-46d0-b3c1-94dc161542eb" />
<img width="952" height="534" alt="Screenshot 2026-01-19 at 12 39 44" src="https://github.com/user-attachments/assets/e593e554-4a41-4589-8fcb-099336a98e0d" />

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/ADO-4680/set-field-node-fields-have-broken-spacing
https://linear.app/n8n/issue/ADO-4678/set-fields-node-layout-broken
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
