### PR TITLE
feat(core): Forbid updating archived workflows

### DIFF
--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -265,6 +265,10 @@ export class WorkflowService {
 			);
 		}
 
+		if (workflow.isArchived) {
+			throw new BadRequestError('Cannot update an archived workflow.');
+		}
+
 		if (!forceSave && expectedChecksum) {
 			await this._detectConflicts(workflow, expectedChecksum);
 		}

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -533,6 +533,10 @@ export class WorkflowService {
 			);
 		}
 
+		if (workflow.isArchived) {
+			throw new BadRequestError('Cannot activate an archived workflow.');
+		}
+
 		const versionIdToActivate = options?.versionId ?? workflow.versionId;
 		const wasActive = workflow.activeVersionId !== null;
 

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -3300,6 +3300,24 @@ describe('PATCH /workflows/:workflowId', () => {
 		expect(activeWorkflowManagerLike.add).not.toHaveBeenCalled();
 	});
 
+	test('should not update an archived workflow', async () => {
+		const workflow = await createWorkflowWithHistory({ isArchived: true }, owner);
+
+		const response = await authOwnerAgent
+			.patch(`/workflows/${workflow.id}`)
+			.send({
+				name: 'Updated Name',
+			})
+			.expect(400);
+
+		expect(response.body.message).toBe('Cannot update an archived workflow.');
+
+		const updatedWorkflow = await workflowRepository.findById(workflow.id);
+		expect(updatedWorkflow).not.toBeNull();
+		expect(updatedWorkflow!.name).toBe(workflow.name);
+		expect(updatedWorkflow!.isArchived).toBe(true);
+	});
+
 	describe('Security: Mass Assignment Protection on Update', () => {
 		test.each([
 			{


### PR DESCRIPTION
## Summary

It is currently possible to update or publish an archived workflow. This PR forbids it on backend.

How to test: If you have the same workflow opened in different tabs and you archive the workflow in one tab, you can try to update or publish the workflow in the old tab.

Now after publishing an archived workflow you will see this:
<img height="170" alt="image" src="https://github.com/user-attachments/assets/c9d31a7f-39db-4cc5-af98-2a0d572074fe" />

Now after updating an archived workflow, you will see errors like this (with an exponential backoff):
<img height="100" alt="image" src="https://github.com/user-attachments/assets/bfc99ff5-6063-4c09-97b8-42fde44e4c41" />

I considered updating the state and making the workflow read-only, but it would mean we will mess up the user's state and they might want to save what they currently have. Also, it's possible that they archived the workflow by mistake, so they can go to another tab, unarchive it and then the request will finish successfully. So for now I think it's fine to continue trying to save.

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-4506](https://linear.app/n8n/issue/ADO-4506/bug-it-is-possible-to-publish-or-update-an-archived-workflow)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
