### PR TITLE
feat(ai-builder): Make credentials validation minor instead of major

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/programmatic/evaluators/credentials.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/programmatic/evaluators/credentials.test.ts
@@ -109,7 +109,7 @@ describe('validateCredentials', () => {
 			expect(violations).toContainEqual(
 				expect.objectContaining({
 					name: 'http-request-hardcoded-credentials',
-					type: 'major',
+					type: 'minor',
 				}),
 			);
 			expect(violations[0].description).toContain('Authorization');
@@ -127,7 +127,7 @@ describe('validateCredentials', () => {
 			expect(violations).toContainEqual(
 				expect.objectContaining({
 					name: 'http-request-hardcoded-credentials',
-					type: 'major',
+					type: 'minor',
 				}),
 			);
 			expect(violations[0].description).toContain('X-API-Key');
@@ -172,7 +172,7 @@ describe('validateCredentials', () => {
 			expect(violations).toContainEqual(
 				expect.objectContaining({
 					name: 'http-request-hardcoded-credentials',
-					type: 'major',
+					type: 'minor',
 				}),
 			);
 			expect(violations[0].description).toContain('api_key');
@@ -217,7 +217,7 @@ describe('validateCredentials', () => {
 			expect(violations).toContainEqual(
 				expect.objectContaining({
 					name: 'set-node-credential-field',
-					type: 'major',
+					type: 'minor',
 				}),
 			);
 			expect(violations[0].description).toContain(fieldName);

--- a/packages/@n8n/ai-workflow-builder.ee/src/validation/checks/credentials.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/validation/checks/credentials.ts
@@ -144,9 +144,9 @@ function validateHttpRequestNode(
 		if (header.name && isSensitiveHeader(header.name) && hasHardcodedCredentialValue(header)) {
 			violations.push({
 				name: 'http-request-hardcoded-credentials',
-				type: 'major',
+				type: 'minor',
 				description: `HTTP Request node "${node.name}" has a hardcoded value for sensitive header "${header.name}". Use n8n credentials instead (e.g., httpHeaderAuth, httpBearerAuth).`,
-				pointsDeducted: 20,
+				pointsDeducted: 5,
 			});
 		}
 	}
@@ -156,9 +156,9 @@ function validateHttpRequestNode(
 		if (param.name && isCredentialFieldName(param.name) && hasHardcodedCredentialValue(param)) {
 			violations.push({
 				name: 'http-request-hardcoded-credentials',
-				type: 'major',
+				type: 'minor',
 				description: `HTTP Request node "${node.name}" has a hardcoded value for credential-like query parameter "${param.name}". Use n8n credentials instead (e.g., httpQueryAuth).`,
-				pointsDeducted: 20,
+				pointsDeducted: 5,
 			});
 		}
 	}
@@ -177,9 +177,9 @@ function validateSetNode(
 		if (assignment.name && isCredentialFieldName(assignment.name)) {
 			violations.push({
 				name: 'set-node-credential-field',
-				type: 'major',
+				type: 'minor',
 				description: `Set node "${node.name}" has a field named "${assignment.name}" which appears to be storing credentials. Credentials should be stored securely using n8n's credential system, not in workflow data.`,
-				pointsDeducted: 20,
+				pointsDeducted: 5,
 			});
 		}
 	}


### PR DESCRIPTION
## Summary                                                                                                                
  - Changed credential validation violations from `major` to `minor` severity                                               
  - Reduced points deducted from 20 to 5 for credential-related violations                                                  
                                                                                                                            
## Context                                                                                                                
The AI Workflow Builder has validation to prevent hardcoded credentials in workflows. However, the AI often finds workarounds, and hardcoded credentials currently reduce friction for users setting up workflows.                          

Until we implement the ability for the Builder to create credentials programmatically, making this a minor violation allows us to continue collecting telemetry for failures without blocking users.                                           
                                                                                                                     
https://linear.app/n8n/issue/AI-1933                          