### PR TITLE
feat(ai-builder): Remove techniques selection limit of 5

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/chains/prompt-categorization.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/chains/prompt-categorization.ts
@@ -15,8 +15,7 @@ export async function promptCategorizationChain(
 		techniques: z
 			.array(z.nativeEnum(WorkflowTechnique))
 			.min(0)
-			.max(5)
-			.describe('Zero to five workflow techniques identified in the prompt (maximum of 5)'),
+			.describe('Workflow techniques identified in the prompt'),
 		confidence: z
 			.number()
 			.min(0)

--- a/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/discovery.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/discovery.prompt.ts
@@ -166,7 +166,6 @@ const TECHNIQUE_CLARIFICATIONS = `Common distinctions to get right:
 
 Technique selection rules:
 - Select ALL techniques that apply (most workflows use 2-4)
-- Maximum 5 techniques
 - Only select techniques you're confident apply`;
 
 const CONNECTION_PARAMETERS = `A parameter is connection-changing ONLY IF it appears in <input> or <output> expressions within <node_details>.

--- a/packages/@n8n/ai-workflow-builder.ee/src/prompts/chains/categorization.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/prompts/chains/categorization.prompt.ts
@@ -91,7 +91,7 @@ of how the categorization should be carried out.
 ${formatExamplePrompts()}
 </example_categorization>
 
-Select a maximum of 5 techniques that you believe are applicable, but only select them if you are
+Select the techniques that you believe are applicable, but only select them if you are
 confident that they are applicable. If the prompt is ambiguous or does not provide an obvious workflow
 do not provide any techniques - if confidence is low avoid providing techniques.
 


### PR DESCRIPTION
## Summary
  - Removes the hard limit of 5 techniques that can be selected during workflow discovery
  - Updates prompts and Zod schema validation to allow any number of applicable techniques to be selected
  
LangSmith experiments results: https://smith.langchain.com/o/f3711c2a-fe3f-43a3-96aa-692f8f979c5a/datasets/06956533-5582-4d9c-8b4c-7fe21c31d572/compare?selectedSessions=ff05b035-2e28-4fde-b6cc-edcbfd3b3749%2C41c49ee7-144c-485a-bbab-dabb3ef01283

## Related Linear ticket
  https://linear.app/n8n/issue/AI-1924