### PR TITLE
feat: Allow editing / deleting project variables if you have the project scope

### DIFF
--- a/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectVariables.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectVariables.test.ts
@@ -122,7 +122,12 @@ describe('ProjectVariables', () => {
 		projectsStore.personalProject = {
 			id: 'personal-project-id',
 			name: 'Current Project',
-			scopes: ['projectVariable:create', 'projectVariable:read'],
+			scopes: [
+				'projectVariable:create',
+				'projectVariable:read',
+				'projectVariable:update',
+				'projectVariable:delete',
+			],
 		} as Project;
 		projectsStore.currentProject = projectsStore.personalProject;
 
@@ -423,7 +428,7 @@ describe('ProjectVariables', () => {
 	});
 
 	describe('permissions', () => {
-		it('should disable edit button when user lacks update permission', async () => {
+		it('should disable edit button when user lacks both global and project update permission', async () => {
 			const usersStore = mockedStore(useUsersStore);
 			usersStore.currentUser = { globalScopes: ['variable:read', 'variable:list'] } as IUser;
 
@@ -438,6 +443,13 @@ describe('ProjectVariables', () => {
 					value: 'value',
 				},
 			];
+
+			const projectsStore = mockedStore(useProjectsStore);
+			projectsStore.currentProject = {
+				id: 'project-id',
+				name: 'Test Project',
+				scopes: ['projectVariable:read', 'projectVariable:list'],
+			} as Project;
 
 			const { getByTestId } = renderComponent();
 			await waitFor(() => expect(getByTestId('variables-row')).toBeVisible());
@@ -447,7 +459,7 @@ describe('ProjectVariables', () => {
 			expect(editButton).toBeDisabled();
 		});
 
-		it('should disable delete button when user lacks delete permission', async () => {
+		it('should disable delete button when user lacks both global and project delete permission', async () => {
 			const usersStore = mockedStore(useUsersStore);
 			usersStore.currentUser = { globalScopes: ['variable:read', 'variable:list'] } as IUser;
 
@@ -463,6 +475,13 @@ describe('ProjectVariables', () => {
 				},
 			];
 
+			const projectsStore = mockedStore(useProjectsStore);
+			projectsStore.currentProject = {
+				id: 'project-id',
+				name: 'Test Project',
+				scopes: ['projectVariable:read', 'projectVariable:list'],
+			} as Project;
+
 			const { getByTestId } = renderComponent();
 
 			await waitFor(() => expect(getByTestId('variables-row')).toBeVisible());
@@ -470,6 +489,136 @@ describe('ProjectVariables', () => {
 			await userEvent.hover(getByTestId('variables-row'));
 			const deleteButton = getByTestId('variable-row-delete-button');
 			expect(deleteButton).toBeDisabled();
+		});
+
+		it('should enable edit button when user has global update permission', async () => {
+			const usersStore = mockedStore(useUsersStore);
+			usersStore.currentUser = {
+				globalScopes: ['variable:read', 'variable:list', 'variable:update'],
+			} as IUser;
+
+			const settingsStore = mockedStore(useSettingsStore);
+			settingsStore.settings.enterprise[EnterpriseEditionFeature.Variables] = true;
+
+			const environmentsStore = mockedStore(useEnvironmentsStore);
+			environmentsStore.variables = [
+				{
+					id: '1',
+					key: 'TEST_VAR',
+					value: 'value',
+				},
+			];
+
+			const projectsStore = mockedStore(useProjectsStore);
+			projectsStore.currentProject = {
+				id: 'project-id',
+				name: 'Test Project',
+				scopes: ['projectVariable:read', 'projectVariable:list'],
+			} as Project;
+
+			const { getByTestId } = renderComponent();
+			await waitFor(() => expect(getByTestId('variables-row')).toBeVisible());
+
+			await userEvent.hover(getByTestId('variables-row'));
+			const editButton = getByTestId('variable-row-edit-button');
+			expect(editButton).not.toBeDisabled();
+		});
+
+		it('should enable edit button when user has project update permission', async () => {
+			const usersStore = mockedStore(useUsersStore);
+			usersStore.currentUser = { globalScopes: ['variable:read', 'variable:list'] } as IUser;
+
+			const settingsStore = mockedStore(useSettingsStore);
+			settingsStore.settings.enterprise[EnterpriseEditionFeature.Variables] = true;
+
+			const environmentsStore = mockedStore(useEnvironmentsStore);
+			environmentsStore.variables = [
+				{
+					id: '1',
+					key: 'TEST_VAR',
+					value: 'value',
+				},
+			];
+
+			const projectsStore = mockedStore(useProjectsStore);
+			projectsStore.currentProject = {
+				id: 'project-id',
+				name: 'Test Project',
+				scopes: ['projectVariable:read', 'projectVariable:list', 'projectVariable:update'],
+			} as Project;
+
+			const { getByTestId } = renderComponent();
+			await waitFor(() => expect(getByTestId('variables-row')).toBeVisible());
+
+			await userEvent.hover(getByTestId('variables-row'));
+			const editButton = getByTestId('variable-row-edit-button');
+			expect(editButton).not.toBeDisabled();
+		});
+
+		it('should enable delete button when user has global delete permission', async () => {
+			const usersStore = mockedStore(useUsersStore);
+			usersStore.currentUser = {
+				globalScopes: ['variable:read', 'variable:list', 'variable:delete'],
+			} as IUser;
+
+			const settingsStore = mockedStore(useSettingsStore);
+			settingsStore.settings.enterprise[EnterpriseEditionFeature.Variables] = true;
+
+			const environmentsStore = mockedStore(useEnvironmentsStore);
+			environmentsStore.variables = [
+				{
+					id: '1',
+					key: 'TEST_VAR',
+					value: 'value',
+				},
+			];
+
+			const projectsStore = mockedStore(useProjectsStore);
+			projectsStore.currentProject = {
+				id: 'project-id',
+				name: 'Test Project',
+				scopes: ['projectVariable:read', 'projectVariable:list'],
+			} as Project;
+
+			const { getByTestId } = renderComponent();
+
+			await waitFor(() => expect(getByTestId('variables-row')).toBeVisible());
+
+			await userEvent.hover(getByTestId('variables-row'));
+			const deleteButton = getByTestId('variable-row-delete-button');
+			expect(deleteButton).not.toBeDisabled();
+		});
+
+		it('should enable delete button when user has project delete permission', async () => {
+			const usersStore = mockedStore(useUsersStore);
+			usersStore.currentUser = { globalScopes: ['variable:read', 'variable:list'] } as IUser;
+
+			const settingsStore = mockedStore(useSettingsStore);
+			settingsStore.settings.enterprise[EnterpriseEditionFeature.Variables] = true;
+
+			const environmentsStore = mockedStore(useEnvironmentsStore);
+			environmentsStore.variables = [
+				{
+					id: '1',
+					key: 'TEST_VAR',
+					value: 'value',
+				},
+			];
+
+			const projectsStore = mockedStore(useProjectsStore);
+			projectsStore.currentProject = {
+				id: 'project-id',
+				name: 'Test Project',
+				scopes: ['projectVariable:read', 'projectVariable:list', 'projectVariable:delete'],
+			} as Project;
+
+			const { getByTestId } = renderComponent();
+
+			await waitFor(() => expect(getByTestId('variables-row')).toBeVisible());
+
+			await userEvent.hover(getByTestId('variables-row'));
+			const deleteButton = getByTestId('variable-row-delete-button');
+			expect(deleteButton).not.toBeDisabled();
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectVariables.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectVariables.vue
@@ -418,7 +418,6 @@ onMounted(() => {
 							{{ data.project?.name ?? i18n.baseText('variables.table.scope.global') }}
 						</div>
 					</N8nBadge>
-					<div><h1>HELLO</h1></div>
 				</td>
 				<td v-if="isFeatureEnabled" align="right">
 					<div class="action-buttons">

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectVariables.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectVariables.vue
@@ -71,7 +71,6 @@ const globalPermissions = computed(
 const projectPermissions = computed(
 	() => getResourcePermissions(projectsStore.currentProject?.scopes).projectVariable,
 );
-
 const { isLoading, execute } = useAsyncState(environmentsStore.fetchAllVariables, [], {
 	immediate: true,
 });
@@ -419,15 +418,19 @@ onMounted(() => {
 							{{ data.project?.name ?? i18n.baseText('variables.table.scope.global') }}
 						</div>
 					</N8nBadge>
+					<div><h1>HELLO</h1></div>
 				</td>
 				<td v-if="isFeatureEnabled" align="right">
 					<div class="action-buttons">
-						<N8nTooltip :disabled="globalPermissions.update" placement="top">
+						<N8nTooltip
+							:disabled="globalPermissions.update ?? projectPermissions.update"
+							placement="top"
+						>
 							<N8nButton
 								data-test-id="variable-row-edit-button"
 								type="tertiary"
 								class="mr-xs"
-								:disabled="!globalPermissions.update"
+								:disabled="!(globalPermissions.update ?? projectPermissions.update)"
 								@click="openEditVariableModal(data)"
 							>
 								{{ i18n.baseText('variables.row.button.edit') }}
@@ -436,11 +439,14 @@ onMounted(() => {
 								{{ i18n.baseText('variables.row.button.edit.onlyRoleCanEdit') }}
 							</template>
 						</N8nTooltip>
-						<N8nTooltip :disabled="globalPermissions.delete" placement="top">
+						<N8nTooltip
+							:disabled="globalPermissions.delete ?? projectPermissions.delete"
+							placement="top"
+						>
 							<N8nButton
 								data-test-id="variable-row-delete-button"
 								type="tertiary"
-								:disabled="!globalPermissions.delete"
+								:disabled="!(globalPermissions.delete ?? projectPermissions.delete)"
 								@click="handleDeleteVariable(data)"
 							>
 								{{ i18n.baseText('variables.row.button.delete') }}


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR allows a project admin / editor to update and delete variables that they have scopes for from their permissions. Only a front-end change was required as the back-end permissions were already supported

[Screencast from 19-01-26 13:00:37.webm](https://github.com/user-attachments/assets/6100f8e8-29d2-4d10-9fa7-7af96bd173e9)

## Related Linear tickets, Github issues, and Community forum posts

IAM-21

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
