### PR TITLE
chore: Add feature flag env var for project-scope external secrets

### DIFF
--- a/packages/cli/src/modules/external-secrets.ee/external-secrets.config.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets.config.ts
@@ -9,4 +9,8 @@ export class ExternalSecretsConfig {
 	/** Whether to prefer GET over LIST when fetching secrets from Hashicorp Vault */
 	@Env('N8N_EXTERNAL_SECRETS_PREFER_GET')
 	preferGet: boolean = false;
+
+	/** Whether to enable project-scoped external secrets */
+	@Env('N8N_ENV_FEAT_EXTERNAL_SECRETS_FOR_PROJECTS')
+	externalSecretsForProjects: boolean = false;
 }


### PR DESCRIPTION
## Summary

Add `N8N_ENV_FEAT_EXTERNAL_SECRETS_FOR_PROJECTS` usage

- Automatically available to the FE via `settings.envFeatureFlags`
- Made available to the`ExternalSecretsModule` via the `ExternalSecretsConfig`

Response in the `GET /rest/settings` endpoint

```json
{
	"envFeatureFlags": {
		"N8N_ENV_FEAT_EXTERNAL_SECRETS_FOR_PROJECTS": "true"
	}
}
```
### Decisions

Considered adding this to the `module-settings` but I since this is meant to be removed once the feature is ready is best to keep it as simple as possible. 

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

closes LIGO-111

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
