### PR TITLE
fix(core): Worker status in multi-main only accessible to admin

### DIFF
--- a/packages/cli/src/controllers/orchestration.controller.ts
+++ b/packages/cli/src/controllers/orchestration.controller.ts
@@ -1,4 +1,5 @@
 import { Post, RestController, GlobalScope } from '@n8n/decorators';
+import type { AuthenticatedRequest } from '@n8n/db';
 
 import { License } from '@/license';
 import { WorkerStatusService } from '@/scaling/worker-status.service.ee';
@@ -16,9 +17,9 @@ export class OrchestrationController {
 	 */
 	@GlobalScope('orchestration:read')
 	@Post('/worker/status')
-	async getWorkersStatusAll() {
+	async getWorkersStatusAll(req: AuthenticatedRequest) {
 		if (!this.licenseService.isWorkerViewLicensed()) return;
 
-		return await this.workerStatusService.requestWorkerStatus();
+		return await this.workerStatusService.requestWorkerStatus(req.user.id);
 	}
 }

--- a/packages/cli/src/scaling/__tests__/worker-status.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/worker-status.service.test.ts
@@ -1,0 +1,108 @@
+import type { WorkerStatus } from '@n8n/api-types';
+import { mock } from 'jest-mock-extended';
+
+import type { Push } from '@/push';
+import { WorkerStatusService } from '@/scaling/worker-status.service.ee';
+
+describe('WorkerStatusService', () => {
+	let workerStatusService: WorkerStatusService;
+	let mockPush: jest.Mocked<Push>;
+
+	beforeEach(() => {
+		mockPush = {
+			sendToUsers: jest.fn(),
+		} as any;
+
+		workerStatusService = new WorkerStatusService(
+			mock(), // jobProcessor
+			mock(), // instanceSettings
+			mock(), // publisher
+			mockPush,
+		);
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('handleWorkerStatusResponse', () => {
+		const createMockWorkerStatus = (
+			overrides?: Partial<WorkerStatus & { requestingUserId: string }>,
+		): WorkerStatus & { requestingUserId: string } => ({
+			senderId: 'test-worker-1',
+			runningJobsSummary: [],
+			freeMem: 1000000,
+			totalMem: 2000000,
+			uptime: 3600,
+			loadAvg: [1.0, 1.5, 2.0],
+			cpus: '4x Intel Core',
+			arch: 'x64',
+			platform: 'linux',
+			hostname: 'test-worker',
+			interfaces: [],
+			version: '1.0.0',
+			isInContainer: false,
+			process: {
+				memory: {
+					available: 1000000,
+					constraint: 2000000,
+					rss: 100000,
+					heapTotal: 50000,
+					heapUsed: 30000,
+				},
+				uptime: 3600,
+			},
+			host: {
+				memory: {
+					total: 2000000,
+					free: 1000000,
+				},
+			},
+			requestingUserId: 'user-123',
+			...overrides,
+		});
+
+		it('should send worker status only to requesting user', () => {
+			const requestingUserId = 'user-123';
+			const mockWorkerStatus = createMockWorkerStatus({ requestingUserId });
+
+			workerStatusService.handleWorkerStatusResponse(mockWorkerStatus);
+
+			expect(mockPush.sendToUsers).toHaveBeenCalledWith(
+				{
+					type: 'sendWorkerStatusMessage',
+					data: {
+						workerId: 'test-worker-1',
+						status: mockWorkerStatus,
+					},
+				},
+				[requestingUserId],
+			);
+		});
+
+		it('should include worker status data in push message', () => {
+			const requestingUserId = 'user-456';
+			const mockWorkerStatus = createMockWorkerStatus({
+				requestingUserId,
+				senderId: 'worker-2',
+				freeMem: 2000000,
+			});
+
+			workerStatusService.handleWorkerStatusResponse(mockWorkerStatus);
+
+			expect(mockPush.sendToUsers).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: 'sendWorkerStatusMessage',
+					data: expect.objectContaining({
+						workerId: 'worker-2',
+						status: expect.objectContaining({
+							freeMem: 2000000,
+							requestingUserId,
+						}),
+					}),
+				}),
+				[requestingUserId],
+			);
+		});
+	});
+});

--- a/packages/cli/src/scaling/pubsub/pubsub.event-map.ts
+++ b/packages/cli/src/scaling/pubsub/pubsub.event-map.ts
@@ -50,7 +50,9 @@ export type PubSubCommandMap = {
 
 	'get-worker-id': never;
 
-	'get-worker-status': never;
+	'get-worker-status': {
+		requestingUserId: string;
+	};
 
 	// #endregion
 
@@ -94,7 +96,9 @@ export type PubSubCommandMap = {
 };
 
 export type PubSubWorkerResponseMap = {
-	'response-to-get-worker-status': WorkerStatus;
+	'response-to-get-worker-status': WorkerStatus & {
+		requestingUserId: string;
+	};
 };
 
 export type PubSubEventMap = PubSubCommandMap & PubSubWorkerResponseMap;

--- a/packages/frontend/editor-ui/src/app/router.ts
+++ b/packages/frontend/editor-ui/src/app/router.ts
@@ -735,7 +735,12 @@ export const routes: RouteRecordRaw[] = [
 				name: VIEWS.WORKER_VIEW,
 				component: WorkerView,
 				meta: {
-					middleware: ['authenticated'],
+					middleware: ['authenticated', 'rbac'],
+					middlewareOptions: {
+						rbac: {
+							scope: 'workersView:manage',
+						},
+					},
 				},
 			},
 			{


### PR DESCRIPTION
## Summary

While the [sidebar navigation item](https://github.com/n8n-io/n8n/blob/master/packages/frontend/editor-ui/src/app/composables/useSettingsItems.ts#L107) for the worker overview checks for workersView:manage scope to be present, the vue router definition does not.

This PR [adds](https://github.com/n8n-io/n8n/pull/24548/commits/f753eca53e6f15b9b6355f13b0e6649a620f30e6) the missing route guard, and [will only publish](https://github.com/n8n-io/n8n/pull/24548/commits/47c45cd928421808713c67a3c23e387bc332c5f3) the worker status updates to the user who originally requested them.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
