### PR TITLE
fix(editor): Adjust line height and vertical placement of icon in notification permission banner

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/NotificationPermissionBanner.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/NotificationPermissionBanner.vue
@@ -59,10 +59,10 @@ function onDismissClick() {
 	border-radius: var(--radius--lg) var(--radius--lg) 0 0;
 	border-bottom: none;
 	margin: 0 var(--spacing--2xs);
+	line-height: var(--line-height--xl);
 }
 
 .icon {
-	align-self: flex-start;
 	flex-shrink: 0;
 }
 


### PR DESCRIPTION
small tweak from design review, fixes https://linear.app/n8n/issue/AI-1945/tweak-ai-builder-notification-banner-line-height-and-icon

<img width="391" height="155" alt="Screenshot 2026-01-19 at 18 27 32" src="https://github.com/user-attachments/assets/9b99ae8f-9422-4c37-9654-46149aaa7362" />
