### PR TITLE
fix(core): Websocket events on worker status are only sent to admins

### DIFF
--- a/packages/cli/src/controllers/orchestration.controller.ts
+++ b/packages/cli/src/controllers/orchestration.controller.ts
@@ -1,4 +1,5 @@
 import { Post, RestController, GlobalScope } from '@n8n/decorators';
+import type { AuthenticatedRequest } from '@n8n/db';
 
 import { License } from '@/license';
 import { WorkerStatusService } from '@/scaling/worker-status.service.ee';
@@ -16,9 +17,9 @@ export class OrchestrationController {
 	 */
 	@GlobalScope('orchestration:read')
 	@Post('/worker/status')
-	async getWorkersStatusAll() {
+	async getWorkersStatusAll(req: AuthenticatedRequest) {
 		if (!this.licenseService.isWorkerViewLicensed()) return;
 
-		return await this.workerStatusService.requestWorkerStatus();
+		return await this.workerStatusService.requestWorkerStatus(req.user.id);
 	}
 }

--- a/packages/cli/src/scaling/__tests__/worker-status.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/worker-status.service.test.ts
@@ -1,28 +1,16 @@
 import type { WorkerStatus } from '@n8n/api-types';
-import type { UserRepository } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 
 import type { Push } from '@/push';
 import { WorkerStatusService } from '@/scaling/worker-status.service.ee';
-import type { RoleService } from '@/services/role.service';
 
 describe('WorkerStatusService', () => {
 	let workerStatusService: WorkerStatusService;
 	let mockPush: jest.Mocked<Push>;
-	let mockRoleService: jest.Mocked<RoleService>;
-	let mockUserRepository: jest.Mocked<UserRepository>;
 
 	beforeEach(() => {
 		mockPush = {
 			sendToUsers: jest.fn(),
-		} as any;
-
-		mockRoleService = {
-			rolesWithScope: jest.fn(),
-		} as any;
-
-		mockUserRepository = {
-			find: jest.fn(),
 		} as any;
 
 		workerStatusService = new WorkerStatusService(
@@ -30,8 +18,6 @@ describe('WorkerStatusService', () => {
 			mock(), // instanceSettings
 			mock(), // publisher
 			mockPush,
-			mockRoleService,
-			mockUserRepository,
 		);
 	});
 
@@ -40,7 +26,9 @@ describe('WorkerStatusService', () => {
 	});
 
 	describe('handleWorkerStatusResponse', () => {
-		const createMockWorkerStatus = (overrides?: Partial<WorkerStatus>): WorkerStatus => ({
+		const createMockWorkerStatus = (
+			overrides?: Partial<WorkerStatus & { requestingUserId: string }>,
+		): WorkerStatus & { requestingUserId: string } => ({
 			senderId: 'test-worker-1',
 			runningJobsSummary: [],
 			freeMem: 1000000,
@@ -70,45 +58,51 @@ describe('WorkerStatusService', () => {
 					free: 1000000,
 				},
 			},
+			requestingUserId: 'user-123',
 			...overrides,
 		});
 
-		describe('authorization', () => {
-			it('should send worker status only to users with orchestration:read permission', async () => {
-				const ownerId = 'owner-user-id';
-				const adminId = 'admin-user-id';
+		it('should send worker status only to requesting user', () => {
+			const requestingUserId = 'user-123';
+			const mockWorkerStatus = createMockWorkerStatus({ requestingUserId });
 
-				mockRoleService.rolesWithScope.mockResolvedValue(['global:owner', 'global:admin']);
-				mockUserRepository.find.mockResolvedValue([{ id: ownerId } as any, { id: adminId } as any]);
+			workerStatusService.handleWorkerStatusResponse(mockWorkerStatus);
 
-				const mockWorkerStatus = createMockWorkerStatus();
-
-				await workerStatusService.handleWorkerStatusResponse(mockWorkerStatus);
-
-				expect(mockRoleService.rolesWithScope).toHaveBeenCalledWith('global', 'orchestration:read');
-				expect(mockPush.sendToUsers).toHaveBeenCalledWith(
-					{
-						type: 'sendWorkerStatusMessage',
-						data: {
-							workerId: 'test-worker-1',
-							status: mockWorkerStatus,
-						},
+			expect(mockPush.sendToUsers).toHaveBeenCalledWith(
+				{
+					type: 'sendWorkerStatusMessage',
+					data: {
+						workerId: 'test-worker-1',
+						status: mockWorkerStatus,
 					},
-					[ownerId, adminId],
-				);
+				},
+				[requestingUserId],
+			);
+		});
+
+		it('should include worker status data in push message', () => {
+			const requestingUserId = 'user-456';
+			const mockWorkerStatus = createMockWorkerStatus({
+				requestingUserId,
+				senderId: 'worker-2',
+				freeMem: 2000000,
 			});
 
-			it("should not send worker status to users who don't have orchestration:read permission", async () => {
-				mockRoleService.rolesWithScope.mockResolvedValue([]);
+			workerStatusService.handleWorkerStatusResponse(mockWorkerStatus);
 
-				const mockWorkerStatus = createMockWorkerStatus();
-
-				await workerStatusService.handleWorkerStatusResponse(mockWorkerStatus);
-
-				expect(mockRoleService.rolesWithScope).toHaveBeenCalledWith('global', 'orchestration:read');
-				expect(mockUserRepository.find).not.toHaveBeenCalled();
-				expect(mockPush.sendToUsers).not.toHaveBeenCalled();
-			});
+			expect(mockPush.sendToUsers).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: 'sendWorkerStatusMessage',
+					data: expect.objectContaining({
+						workerId: 'worker-2',
+						status: expect.objectContaining({
+							freeMem: 2000000,
+							requestingUserId,
+						}),
+					}),
+				}),
+				[requestingUserId],
+			);
 		});
 	});
 });

--- a/packages/cli/src/scaling/__tests__/worker-status.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/worker-status.service.test.ts
@@ -1,0 +1,114 @@
+import type { WorkerStatus } from '@n8n/api-types';
+import type { UserRepository } from '@n8n/db';
+import { mock } from 'jest-mock-extended';
+
+import type { Push } from '@/push';
+import { WorkerStatusService } from '@/scaling/worker-status.service.ee';
+import type { RoleService } from '@/services/role.service';
+
+describe('WorkerStatusService', () => {
+	let workerStatusService: WorkerStatusService;
+	let mockPush: jest.Mocked<Push>;
+	let mockRoleService: jest.Mocked<RoleService>;
+	let mockUserRepository: jest.Mocked<UserRepository>;
+
+	beforeEach(() => {
+		mockPush = {
+			sendToUsers: jest.fn(),
+		} as any;
+
+		mockRoleService = {
+			rolesWithScope: jest.fn(),
+		} as any;
+
+		mockUserRepository = {
+			find: jest.fn(),
+		} as any;
+
+		workerStatusService = new WorkerStatusService(
+			mock(), // jobProcessor
+			mock(), // instanceSettings
+			mock(), // publisher
+			mockPush,
+			mockRoleService,
+			mockUserRepository,
+		);
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('handleWorkerStatusResponse', () => {
+		const createMockWorkerStatus = (overrides?: Partial<WorkerStatus>): WorkerStatus => ({
+			senderId: 'test-worker-1',
+			runningJobsSummary: [],
+			freeMem: 1000000,
+			totalMem: 2000000,
+			uptime: 3600,
+			loadAvg: [1.0, 1.5, 2.0],
+			cpus: '4x Intel Core',
+			arch: 'x64',
+			platform: 'linux',
+			hostname: 'test-worker',
+			interfaces: [],
+			version: '1.0.0',
+			isInContainer: false,
+			process: {
+				memory: {
+					available: 1000000,
+					constraint: 2000000,
+					rss: 100000,
+					heapTotal: 50000,
+					heapUsed: 30000,
+				},
+				uptime: 3600,
+			},
+			host: {
+				memory: {
+					total: 2000000,
+					free: 1000000,
+				},
+			},
+			...overrides,
+		});
+
+		describe('authorization', () => {
+			it('should send worker status only to users with orchestration:read permission', async () => {
+				const ownerId = 'owner-user-id';
+				const adminId = 'admin-user-id';
+
+				mockRoleService.rolesWithScope.mockResolvedValue(['global:owner', 'global:admin']);
+				mockUserRepository.find.mockResolvedValue([{ id: ownerId } as any, { id: adminId } as any]);
+
+				const mockWorkerStatus = createMockWorkerStatus();
+
+				await workerStatusService.handleWorkerStatusResponse(mockWorkerStatus);
+
+				expect(mockRoleService.rolesWithScope).toHaveBeenCalledWith('global', 'orchestration:read');
+				expect(mockPush.sendToUsers).toHaveBeenCalledWith(
+					{
+						type: 'sendWorkerStatusMessage',
+						data: {
+							workerId: 'test-worker-1',
+							status: mockWorkerStatus,
+						},
+					},
+					[ownerId, adminId],
+				);
+			});
+
+			it("should not send worker status to users who don't have orchestration:read permission", async () => {
+				mockRoleService.rolesWithScope.mockResolvedValue([]);
+
+				const mockWorkerStatus = createMockWorkerStatus();
+
+				await workerStatusService.handleWorkerStatusResponse(mockWorkerStatus);
+
+				expect(mockRoleService.rolesWithScope).toHaveBeenCalledWith('global', 'orchestration:read');
+				expect(mockUserRepository.find).not.toHaveBeenCalled();
+				expect(mockPush.sendToUsers).not.toHaveBeenCalled();
+			});
+		});
+	});
+});

--- a/packages/cli/src/scaling/pubsub/pubsub.event-map.ts
+++ b/packages/cli/src/scaling/pubsub/pubsub.event-map.ts
@@ -50,7 +50,9 @@ export type PubSubCommandMap = {
 
 	'get-worker-id': never;
 
-	'get-worker-status': never;
+	'get-worker-status': {
+		requestingUserId: string;
+	};
 
 	// #endregion
 
@@ -94,7 +96,9 @@ export type PubSubCommandMap = {
 };
 
 export type PubSubWorkerResponseMap = {
-	'response-to-get-worker-status': WorkerStatus;
+	'response-to-get-worker-status': WorkerStatus & {
+		requestingUserId: string;
+	};
 };
 
 export type PubSubEventMap = PubSubCommandMap & PubSubWorkerResponseMap;


### PR DESCRIPTION
## Summary

UPDATE: Please review this refactoring first: https://github.com/n8n-io/n8n/pull/24554 That one ensures that the worker status payloads are only sent to the user ID who originally requested them, rather than all admin users.

This is a follow-up to this PR which hardens the frontend authorization: https://github.com/n8n-io/n8n/pull/24548

**Mitigates this authorization loop hole:**
Here's exactly how a Member gets unauthorized data:

**Owner opens `/settings/workers`**

Owner is authorized and allowed
Frontend polls: calls POST /orchestration/worker/status every 1 second
This triggers workers to respond

**Member has a WebSocket connection open**

Member is logged in and has a Push connection (for notifications, etc.)
Member doesn't even need to try accessing /settings/workers (frontend blocks them)
Member just needs to be logged in with any page open

**Worker responds to Owner's request**

Worker sends status via pubsub
Main instance receives it and calls handleWorkerStatusResponse()
Broadcasts to ALL connected clients (including the Member!)

**Member receives the data**

Member's browser receives sendWorkerStatusMessage via WebSocket
Frontend's push handler processes it: orchestrationStore.updateWorkerStatus(data.status)
Member now has worker status data in memory

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
