### PR TITLE
fix(core): Send worker status data via websocket only to requesting user

### DIFF
--- a/packages/cli/src/controllers/orchestration.controller.ts
+++ b/packages/cli/src/controllers/orchestration.controller.ts
@@ -1,4 +1,5 @@
 import { Post, RestController, GlobalScope } from '@n8n/decorators';
+import type { AuthenticatedRequest } from '@n8n/db';
 
 import { License } from '@/license';
 import { WorkerStatusService } from '@/scaling/worker-status.service.ee';
@@ -16,9 +17,9 @@ export class OrchestrationController {
 	 */
 	@GlobalScope('orchestration:read')
 	@Post('/worker/status')
-	async getWorkersStatusAll() {
+	async getWorkersStatusAll(req: AuthenticatedRequest) {
 		if (!this.licenseService.isWorkerViewLicensed()) return;
 
-		return await this.workerStatusService.requestWorkerStatus();
+		return await this.workerStatusService.requestWorkerStatus(req.user.id);
 	}
 }

--- a/packages/cli/src/scaling/__tests__/worker-status.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/worker-status.service.test.ts
@@ -1,28 +1,16 @@
 import type { WorkerStatus } from '@n8n/api-types';
-import type { UserRepository } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 
 import type { Push } from '@/push';
 import { WorkerStatusService } from '@/scaling/worker-status.service.ee';
-import type { RoleService } from '@/services/role.service';
 
 describe('WorkerStatusService', () => {
 	let workerStatusService: WorkerStatusService;
 	let mockPush: jest.Mocked<Push>;
-	let mockRoleService: jest.Mocked<RoleService>;
-	let mockUserRepository: jest.Mocked<UserRepository>;
 
 	beforeEach(() => {
 		mockPush = {
 			sendToUsers: jest.fn(),
-		} as any;
-
-		mockRoleService = {
-			rolesWithScope: jest.fn(),
-		} as any;
-
-		mockUserRepository = {
-			find: jest.fn(),
 		} as any;
 
 		workerStatusService = new WorkerStatusService(
@@ -30,8 +18,6 @@ describe('WorkerStatusService', () => {
 			mock(), // instanceSettings
 			mock(), // publisher
 			mockPush,
-			mockRoleService,
-			mockUserRepository,
 		);
 	});
 
@@ -40,7 +26,9 @@ describe('WorkerStatusService', () => {
 	});
 
 	describe('handleWorkerStatusResponse', () => {
-		const createMockWorkerStatus = (overrides?: Partial<WorkerStatus>): WorkerStatus => ({
+		const createMockWorkerStatus = (
+			overrides?: Partial<WorkerStatus & { requestingUserId: string }>,
+		): WorkerStatus & { requestingUserId: string } => ({
 			senderId: 'test-worker-1',
 			runningJobsSummary: [],
 			freeMem: 1000000,
@@ -70,45 +58,51 @@ describe('WorkerStatusService', () => {
 					free: 1000000,
 				},
 			},
+			requestingUserId: 'user-123',
 			...overrides,
 		});
 
-		describe('authorization', () => {
-			it('should send worker status only to users with orchestration:read permission', async () => {
-				const ownerId = 'owner-user-id';
-				const adminId = 'admin-user-id';
+		it('should send worker status only to requesting user', () => {
+			const requestingUserId = 'user-123';
+			const mockWorkerStatus = createMockWorkerStatus({ requestingUserId });
 
-				mockRoleService.rolesWithScope.mockResolvedValue(['global:owner', 'global:admin']);
-				mockUserRepository.find.mockResolvedValue([{ id: ownerId } as any, { id: adminId } as any]);
+			workerStatusService.handleWorkerStatusResponse(mockWorkerStatus);
 
-				const mockWorkerStatus = createMockWorkerStatus();
-
-				await workerStatusService.handleWorkerStatusResponse(mockWorkerStatus);
-
-				expect(mockRoleService.rolesWithScope).toHaveBeenCalledWith('global', 'orchestration:read');
-				expect(mockPush.sendToUsers).toHaveBeenCalledWith(
-					{
-						type: 'sendWorkerStatusMessage',
-						data: {
-							workerId: 'test-worker-1',
-							status: mockWorkerStatus,
-						},
+			expect(mockPush.sendToUsers).toHaveBeenCalledWith(
+				{
+					type: 'sendWorkerStatusMessage',
+					data: {
+						workerId: 'test-worker-1',
+						status: mockWorkerStatus,
 					},
-					[ownerId, adminId],
-				);
+				},
+				[requestingUserId],
+			);
+		});
+
+		it('should include worker status data in push message', () => {
+			const requestingUserId = 'user-456';
+			const mockWorkerStatus = createMockWorkerStatus({
+				requestingUserId,
+				senderId: 'worker-2',
+				freeMem: 2000000,
 			});
 
-			it("should not send worker status to users who don't have orchestration:read permission", async () => {
-				mockRoleService.rolesWithScope.mockResolvedValue([]);
+			workerStatusService.handleWorkerStatusResponse(mockWorkerStatus);
 
-				const mockWorkerStatus = createMockWorkerStatus();
-
-				await workerStatusService.handleWorkerStatusResponse(mockWorkerStatus);
-
-				expect(mockRoleService.rolesWithScope).toHaveBeenCalledWith('global', 'orchestration:read');
-				expect(mockUserRepository.find).not.toHaveBeenCalled();
-				expect(mockPush.sendToUsers).not.toHaveBeenCalled();
-			});
+			expect(mockPush.sendToUsers).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: 'sendWorkerStatusMessage',
+					data: expect.objectContaining({
+						workerId: 'worker-2',
+						status: expect.objectContaining({
+							freeMem: 2000000,
+							requestingUserId,
+						}),
+					}),
+				}),
+				[requestingUserId],
+			);
 		});
 	});
 });

--- a/packages/cli/src/scaling/pubsub/pubsub.event-map.ts
+++ b/packages/cli/src/scaling/pubsub/pubsub.event-map.ts
@@ -50,7 +50,9 @@ export type PubSubCommandMap = {
 
 	'get-worker-id': never;
 
-	'get-worker-status': never;
+	'get-worker-status': {
+		requestingUserId: string;
+	};
 
 	// #endregion
 
@@ -94,7 +96,9 @@ export type PubSubCommandMap = {
 };
 
 export type PubSubWorkerResponseMap = {
-	'response-to-get-worker-status': WorkerStatus;
+	'response-to-get-worker-status': WorkerStatus & {
+		requestingUserId: string;
+	};
 };
 
 export type PubSubEventMap = PubSubCommandMap & PubSubWorkerResponseMap;


### PR DESCRIPTION
## Summary

Implements a more granular approach than in https://github.com/n8n-io/n8n/pull/24550.
This PR here will only publish the worker status updated to the user who originally requested them.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-82/n8n-worker-path-is-not-protected

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
