### PR TITLE
fix(core): Workflow tag removal syncing

### DIFF
--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
@@ -11,6 +11,8 @@ import {
 	type ProjectRelationRepository,
 	type ProjectRepository,
 	type SharedWorkflowRepository,
+	type TagRepository,
+	type WorkflowTagMappingRepository,
 	User,
 	WorkflowEntity,
 	type WorkflowRepository,
@@ -51,6 +53,8 @@ describe('SourceControlImportService', () => {
 	const projectRepository = mock<ProjectRepository>();
 	const projectRelationRepository = mock<ProjectRelationRepository>();
 	const sharedWorkflowRepository = mock<SharedWorkflowRepository>();
+	const tagRepository = mock<TagRepository>();
+	const workflowTagMappingRepository = mock<WorkflowTagMappingRepository>();
 	const mockLogger = mock<Logger>();
 	const sourceControlScopedService = mock<SourceControlScopedService>();
 	const variableService = mock<VariablesService>();
@@ -64,13 +68,13 @@ describe('SourceControlImportService', () => {
 		mock(),
 		projectRepository,
 		projectRelationRepository,
-		mock(),
+		tagRepository,
 		sharedWorkflowRepository,
 		mock(),
 		mock(),
 		variablesRepository,
 		workflowRepository,
-		mock(),
+		workflowTagMappingRepository,
 		mock(),
 		mock(),
 		mock(),

--- a/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
@@ -537,10 +537,7 @@ export class SourceControlImportService {
 		return { tags: [], mappings: [] };
 	}
 
-	async getLocalTagsAndMappingsFromDb(context: SourceControlContext): Promise<{
-		tags: TagEntity[];
-		mappings: WorkflowTagMapping[];
-	}> {
+	async getLocalTagsAndMappingsFromDb(context: SourceControlContext): Promise<ExportableTags> {
 		const localTags = await this.tagRepository.find({
 			select: ['id', 'name'],
 		});

--- a/packages/cli/src/modules/source-control.ee/source-control.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control.service.ee.ts
@@ -521,7 +521,7 @@ export class SourceControlService {
 
 		const tagsToBeImported = getNonDeletedResources(statusResult, 'tags')[0];
 		if (tagsToBeImported) {
-			await this.sourceControlImportService.importTagsFromWorkFolder(tagsToBeImported);
+			await this.sourceControlImportService.importTagsFromWorkFolder(tagsToBeImported, user);
 		}
 		const tagsToBeDeleted = getDeletedResources(statusResult, 'tags');
 		await this.sourceControlImportService.deleteTagsNotInWorkfolder(tagsToBeDeleted);

--- a/packages/cli/src/modules/source-control.ee/types/exportable-tags.ts
+++ b/packages/cli/src/modules/source-control.ee/types/exportable-tags.ts
@@ -1,3 +1,9 @@
 import type { TagEntity, WorkflowTagMapping } from '@n8n/db';
 
-export type ExportableTags = { tags: TagEntity[]; mappings: WorkflowTagMapping[] };
+export type ExportableWorkflowTagMapping = Pick<WorkflowTagMapping, 'tagId' | 'workflowId'>;
+export type ExportableTagEntity = Pick<TagEntity, 'id' | 'name'>;
+
+export type ExportableTags = {
+	tags: ExportableTagEntity[];
+	mappings: ExportableWorkflowTagMapping[];
+};

--- a/packages/cli/test/integration/environments/source-control-import.service.test.ts
+++ b/packages/cli/test/integration/environments/source-control-import.service.test.ts
@@ -1102,6 +1102,83 @@ describe('SourceControlImportService', () => {
 		});
 	});
 
+	describe('importTagsFromWorkFolder()', () => {
+		const globMock = fastGlob.default as unknown as jest.Mock<Promise<string[]>, string[]>;
+		const fsReadFile = jest.spyOn(fsp, 'readFile');
+		const mockTagsFile = '/mock/tags.json';
+
+		const standardTags = [
+			{ id: 'tag-1', name: 'Tag 1' },
+			{ id: 'tag-2', name: 'Tag 2' },
+		];
+
+		function setupTagsFileMock(mappings: Array<{ tagId: string; workflowId: string }>): void {
+			globMock.mockResolvedValue([mockTagsFile]);
+			fsReadFile.mockResolvedValue(JSON.stringify({ tags: standardTags, mappings }));
+		}
+
+		function createTagsCandidate(): ReturnType<typeof mock<SourceControlledFile>> {
+			return mock<SourceControlledFile>({ id: 'tags', file: mockTagsFile, type: 'tags' });
+		}
+
+		async function getMappingsForWorkflow(workflowId: string) {
+			return await workflowTagMappingRepository.findBy({ workflowId });
+		}
+
+		it('should remove tags from workflows when they are removed in source control', async () => {
+			const teamProject = await createTeamProject('Team 1');
+			const workflow1 = await createWorkflowWithHistory(
+				{ id: 'workflow-1', name: 'Workflow 1' },
+				teamProject,
+			);
+			const [tag1, tag2] = await Promise.all([
+				createTag({ id: 'tag-1', name: 'Tag 1' }),
+				createTag({ id: 'tag-2', name: 'Tag 2' }),
+			]);
+
+			await assignTagToWorkflow(tag1, workflow1);
+			await assignTagToWorkflow(tag2, workflow1);
+			expect(await getMappingsForWorkflow(workflow1.id)).toHaveLength(2);
+
+			setupTagsFileMock([{ tagId: 'tag-1', workflowId: 'workflow-1' }]);
+			await service.importTagsFromWorkFolder(createTagsCandidate());
+
+			const finalMappings = await getMappingsForWorkflow(workflow1.id);
+			expect(finalMappings).toHaveLength(1);
+			expect(finalMappings[0].tagId).toBe('tag-1');
+
+			const tagsInDb = await tagRepository.find();
+			expect(tagsInDb).toHaveLength(2);
+		});
+
+		it('should only delete mappings for workflows present in the imported data', async () => {
+			const teamProject = await createTeamProject('Team 1');
+			const [workflow1, workflow2] = await Promise.all([
+				createWorkflowWithHistory({ id: 'workflow-1', name: 'Workflow 1' }, teamProject),
+				createWorkflowWithHistory({ id: 'workflow-2', name: 'Workflow 2' }, teamProject),
+			]);
+			const [tag1, tag2] = await Promise.all([
+				createTag({ id: 'tag-1', name: 'Tag 1' }),
+				createTag({ id: 'tag-2', name: 'Tag 2' }),
+			]);
+
+			await assignTagToWorkflow(tag1, workflow1);
+			await assignTagToWorkflow(tag2, workflow1);
+			await assignTagToWorkflow(tag1, workflow2);
+
+			setupTagsFileMock([{ tagId: 'tag-1', workflowId: 'workflow-1' }]);
+			await service.importTagsFromWorkFolder(createTagsCandidate());
+
+			const workflow1Mappings = await getMappingsForWorkflow(workflow1.id);
+			expect(workflow1Mappings).toHaveLength(1);
+			expect(workflow1Mappings[0].tagId).toBe('tag-1');
+
+			const workflow2Mappings = await getMappingsForWorkflow(workflow2.id);
+			expect(workflow2Mappings).toHaveLength(1);
+			expect(workflow2Mappings[0].tagId).toBe('tag-1');
+		});
+	});
+
 	describe('importCredentialsFromWorkFolder()', () => {
 		describe('if user email specified by `ownedBy` exists at target instance', () => {
 			it('should assign credential ownership to original user', async () => {


### PR DESCRIPTION
## Summary
Fixes a bug where removing tags from workflows did not sync the removal to the tags.json file on export and then also failed to import the changes correctly.

This lead to inconsistencies between instances when importing/export tags with source control

BONUS - I also added additional tests for tags as they seemed relatively light beforehand. Now we cover export and import. 

I think we'll cover it in other improvements but there are still other problems in this space. The main one being that tags can end up "orphaned" in the second instance. 

## Related Linear tickets, Github issues, and Community forum posts
LIGO-62

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
