### PR TITLE
test: Skip NPS survey test due to timeouts

### DIFF
--- a/packages/testing/playwright/tests/e2e/app-config/nps-survey.spec.ts
+++ b/packages/testing/playwright/tests/e2e/app-config/nps-survey.spec.ts
@@ -40,7 +40,7 @@ const getNpsTestRequirements: TestRequirements = {
 	},
 };
 
-test.describe('NPS Survey', () => {
+test.fixme('NPS Survey @fixme', () => {
 	test.beforeEach(async ({ n8n }) => {
 		await n8n.page.route('**/rest/login', async (route) => {
 			const response = await route.fetch();


### PR DESCRIPTION
## Summary

Auto Save + additional overhead in this test have it taking longer than 60 seconds causing timeouts. Skipping instead of extending duration till it's resolved.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
