### PR TITLE
fix(editor): I18n labels for time saved workflow settings

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -3307,7 +3307,7 @@
 	"workflowSettings.timeSavedPerExecution.tooltip": "Total time savings are summarised in the Overview page.",
 	"workflowSettings.timeSavedPerExecution.minutesSaved": "Minutes saved",
 	"workflowSettings.timeSavedPerExecution.tab.fixed": "Fixed",
-	"workflowSettings.timeSavedPerExecution.tab.conditional": "Conditional",
+	"workflowSettings.timeSavedPerExecution.tab.dynamic": "Dynamic (uses time saved nodes)",
 	"workflowSettings.timeSavedPerExecution.noNodesDetected": "No time saved nodes detected",
 	"workflowSettings.timeSavedPerExecution.noNodesDetected.hint": "Add one or more time saved nodes to calculate time saved dynamically",
 	"workflowSettings.timeSavedPerExecution.nodesDetected": "Active - {count} time saved nodes currently setup",

--- a/packages/frontend/editor-ui/src/app/components/WorkflowSettings.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowSettings.vue
@@ -194,11 +194,11 @@ const hasSavedTimeNodes = computed(() => {
 
 const timeSavedModeOptions = computed(() => [
 	{
-		label: 'Fixed',
+		label: i18n.baseText('workflowSettings.timeSavedPerExecution.tab.fixed'),
 		value: 'fixed' as const,
 	},
 	{
-		label: 'Dynamic (uses time saved nodes)',
+		label: i18n.baseText('workflowSettings.timeSavedPerExecution.tab.dynamic'),
 		value: 'dynamic' as const,
 	},
 ]);


### PR DESCRIPTION
## Summary

Workflow settings uses hard-coded strings for fixed and dynamic time saved options.

Translations have currently two unused keys with the prefix `workflowSettings.timeSavedPerExecution.tab` i.e., `.fixed` and `.conditional` endings respectively. 

This PR:
- Renames the latter i18n key from `conditional` to `dynamic`, adapting to current wording.
- Adds references to both keys in `WorkflowSettings.vue`

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
