### PR TITLE
fix: Prevent agent to pass json input to tool

### DIFF
--- a/packages/core/src/execution-engine/requests-response.ts
+++ b/packages/core/src/execution-engine/requests-response.ts
@@ -63,14 +63,13 @@ function prepareRequestedNodesForExecution(
 		const parentSourceNode = parentSourceData?.previousNode ?? currentNode.name;
 
 		// Get the item index from action metadata to access the correct agent input data
-		const itemIndex = (action.metadata as { itemIndex?: number })?.itemIndex ?? 0;
+		// const itemIndex = (action.metadata as { itemIndex?: number })?.itemIndex ?? 0;
 		// Use index 0 for main input as agents have only one main input connection
-		const agentInputData = executionData.data.main?.[0]?.[itemIndex];
+		// const agentInputData = executionData.data.main?.[0]?.[itemIndex];
 
 		// Merge agent's input data with action.input so tools have access to workflow data
 		// action.input takes precedence to allow tool-specific parameters to override
 		const mergedJson = {
-			...(agentInputData?.json ?? {}),
 			...action.input,
 			toolCallId: action.id,
 		};


### PR DESCRIPTION
## Summary

Fixes agent merging it's json input with action input

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-4110/agent-implicitly-passes-parameters-to-mcp-tool

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
