### PR TITLE
fix: Skip SafeChain setup on Windows

### DIFF
--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -34,6 +34,7 @@ runs:
         cache: 'pnpm'
 
     - name: Install Aikido SafeChain
+      if: runner.os != 'Windows'
       run: |
         VERSION="1.4.1"
         EXPECTED_SHA256="628235987175072a4255aa3f5f0128f31795b63970f1970ae8a04d07bf8527b0"
@@ -49,6 +50,7 @@ runs:
       shell: bash
 
     - name: Disable safe-chain
+      if: runner.os != 'Windows'
       run: safe-chain teardown
       shell: bash
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -24,6 +24,7 @@ on:
       - '**/package.json'
       - '**/turbo.json'
       - '.github/workflows/build-windows.yml'
+      - '.github/actions/setup-nodejs/**'
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

Avoids running SafeChain installation and teardown steps on Windows runners. This prevents errors and ensures the build process completes successfully on the Windows platform.

Also, adds the setup-nodejs action to the build-windows workflow trigger paths.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
