### PR TITLE
fix(core): prevent multiple directories in N8N_CUSTOM_EXTENSIONS

### DIFF
--- a/packages/cli/src/load-nodes-and-credentials.ts
+++ b/packages/cli/src/load-nodes-and-credentials.ts
@@ -306,6 +306,13 @@ export class LoadNodesAndCredentials {
 
 		if (process.env[CUSTOM_EXTENSION_ENV] !== undefined) {
 			const customExtensionFolders = process.env[CUSTOM_EXTENSION_ENV].split(';');
+			if (customExtensionFolders.length > 1) {
+				throw new UserError(
+					picocolors.red(
+						`Multiple directories in N8N_CUSTOM_EXTENSIONS are not supported yet. Please provide a single directory path.`,
+					),
+				);
+			}
 			customDirectories.push(...customExtensionFolders);
 		}
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

If multiple directories are specified in N8N_CUSTOM_EXTENSIONS using semicolons, only the last one takes effect due to the override behavior. Therefore, an exception should be thrown when multiple directories are specified.


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

resolves #24574


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
