### PR TITLE
ci(core): Add automated AI workflow builder evaluations

### DIFF
--- a/.github/workflows/test-evals-ai-release.yml
+++ b/.github/workflows/test-evals-ai-release.yml
@@ -38,8 +38,8 @@ jobs:
     uses: ./.github/workflows/test-evals-ai-reusable.yml
     with:
       branch: ${{ github.event.release.tag_name }}
-      dataset: workflow-builder-canvas-prompts
+      dataset: notion-pairwise-fresh
       repetitions: 2
-      num_judges: 3
+      judges: 3
       experiment_name_prefix: CI_${{ needs.check-minor-release.outputs.version }}
     secrets: inherit

--- a/.github/workflows/test-evals-ai-release.yml
+++ b/.github/workflows/test-evals-ai-release.yml
@@ -31,15 +31,32 @@ jobs:
             echo "Not a minor release, skipping evals"
           fi
 
-  run-evals:
-    name: Run Evaluations
+  run-pairwise-evals:
+    name: Run Pairwise (Spec) Evaluations
     needs: check-minor-release
     if: needs.check-minor-release.outputs.is_minor == 'true'
     uses: ./.github/workflows/test-evals-ai-reusable.yml
     with:
       branch: ${{ github.event.release.tag_name }}
+      suite: pairwise
       dataset: notion-pairwise-fresh
+      # Spec evals on minor release: 2 reps, 3 judges
       repetitions: 2
+      judges: 3
+      experiment_name_prefix: CI_${{ needs.check-minor-release.outputs.version }}
+    secrets: inherit
+
+  run-llm-judge-evals:
+    name: Run LLM Judge (Matrix) Evaluations
+    needs: check-minor-release
+    if: needs.check-minor-release.outputs.is_minor == 'true'
+    uses: ./.github/workflows/test-evals-ai-reusable.yml
+    with:
+      branch: ${{ github.event.release.tag_name }}
+      suite: llm-judge
+      dataset: workflow-builder-canvas-prompts
+      # Matrix evals always use 3 reps, 3 judges
+      repetitions: 3
       judges: 3
       experiment_name_prefix: CI_${{ needs.check-minor-release.outputs.version }}
     secrets: inherit

--- a/.github/workflows/test-evals-ai-release.yml
+++ b/.github/workflows/test-evals-ai-release.yml
@@ -1,0 +1,45 @@
+name: 'Test: Evals AI (Release)'
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  check-minor-release:
+    name: Check Minor Release
+    runs-on: ubuntu-latest
+    outputs:
+      is_minor: ${{ steps.check.outputs.is_minor }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - name: Check if minor release
+        id: check
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          echo "Release tag: $TAG"
+
+          # Check if it's a minor release (e.g., v1.2.0, not v1.2.1)
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.0$ ]]; then
+            echo "is_minor=true" >> "$GITHUB_OUTPUT"
+            # Extract version without patch (e.g., v1.2.0 -> v1.2)
+            VERSION="${TAG%.0}"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "Minor release detected: $VERSION"
+          else
+            echo "is_minor=false" >> "$GITHUB_OUTPUT"
+            echo "version=" >> "$GITHUB_OUTPUT"
+            echo "Not a minor release, skipping evals"
+          fi
+
+  run-evals:
+    name: Run Evaluations
+    needs: check-minor-release
+    if: needs.check-minor-release.outputs.is_minor == 'true'
+    uses: ./.github/workflows/test-evals-ai-reusable.yml
+    with:
+      branch: ${{ github.event.release.tag_name }}
+      dataset: workflow-builder-canvas-prompts
+      repetitions: 2
+      num_judges: 3
+      experiment_name_prefix: CI_${{ needs.check-minor-release.outputs.version }}
+    secrets: inherit

--- a/.github/workflows/test-evals-ai-release.yml
+++ b/.github/workflows/test-evals-ai-release.yml
@@ -21,10 +21,8 @@ jobs:
           # Check if it's a minor release (e.g., v1.2.0, not v1.2.1)
           if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.0$ ]]; then
             echo "is_minor=true" >> "$GITHUB_OUTPUT"
-            # Extract version without patch (e.g., v1.2.0 -> v1.2)
-            VERSION="${TAG%.0}"
-            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-            echo "Minor release detected: $VERSION"
+            echo "version=$TAG" >> "$GITHUB_OUTPUT"
+            echo "Minor release detected: $TAG"
           else
             echo "is_minor=false" >> "$GITHUB_OUTPUT"
             echo "version=" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-evals-ai-reusable.yml
+++ b/.github/workflows/test-evals-ai-reusable.yml
@@ -10,12 +10,12 @@ on:
       dataset:
         description: 'LangSmith dataset to use.'
         type: string
-        default: 'workflow-builder-canvas-prompts'
+        default: 'notion-pairwise-fresh'
       repetitions:
         description: 'Number of repetitions to run.'
         type: number
         default: 1
-      num_judges:
+      judges:
         description: 'Number of judges to use.'
         type: number
         default: 1
@@ -88,8 +88,8 @@ jobs:
       - name: Run Evaluations
         working-directory: packages/@n8n/ai-workflow-builder.ee/evaluations
         run: |
-          pnpm eval:langsmith \
+          pnpm eval:pairwise:langsmith \
             --dataset "${{ inputs.dataset }}" \
             --repetitions ${{ inputs.repetitions }} \
-            --num-judges ${{ inputs.num_judges }} \
+            --judges ${{ inputs.judges }} \
             --name "${{ steps.experiment.outputs.name }}"

--- a/.github/workflows/test-evals-ai-reusable.yml
+++ b/.github/workflows/test-evals-ai-reusable.yml
@@ -1,0 +1,95 @@
+name: 'Test: Evals AI'
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: 'GitHub branch to test.'
+        type: string
+        default: 'master'
+      dataset:
+        description: 'LangSmith dataset to use.'
+        type: string
+        default: 'workflow-builder-canvas-prompts'
+      repetitions:
+        description: 'Number of repetitions to run.'
+        type: number
+        default: 1
+      num_judges:
+        description: 'Number of judges to use.'
+        type: number
+        default: 1
+      experiment_name_prefix:
+        description: 'Prefix for the experiment name. If empty, will be auto-generated from branch name.'
+        type: string
+        default: ''
+
+jobs:
+  evals:
+    name: Run Evaluations
+    runs-on: blacksmith-2vcpu-ubuntu-2204
+    env:
+      N8N_AI_ANTHROPIC_KEY: ${{ secrets.EVALS_ANTHROPIC_KEY }}
+      LANGSMITH_TRACING: true
+      LANGSMITH_ENDPOINT: ${{ secrets.EVALS_LANGSMITH_ENDPOINT }}
+      LANGSMITH_API_KEY: ${{ secrets.EVALS_LANGSMITH_API_KEY }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Generate experiment name
+        id: experiment
+        run: |
+          DATE=$(date +%Y_%m_%d)
+          PREFIX="${{ inputs.experiment_name_prefix }}"
+
+          if [ -n "$PREFIX" ]; then
+            NAME="${PREFIX}_${DATE}"
+          else
+            # Extract ticket ID from branch name (e.g., AI-1234 from ai-1234-feature-name)
+            BRANCH="${{ inputs.branch }}"
+            TICKET=$(echo "$BRANCH" | grep -oE '^[Aa][Ii]-[0-9]+' | tr '[:lower:]' '[:upper:]' || true)
+            if [ -n "$TICKET" ]; then
+              NAME="${TICKET}_${DATE}"
+            else
+              # Sanitize branch name for experiment name
+              SANITIZED_BRANCH=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9_.-]/_/g' | sed 's/__*/_/g')
+              NAME="CI_${SANITIZED_BRANCH}_${DATE}"
+            fi
+          fi
+
+          echo "name=$NAME" >> "$GITHUB_OUTPUT"
+          echo "Generated experiment name: $NAME"
+
+      - name: Setup and Build
+        uses: ./.github/actions/setup-nodejs
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1 # 6.5.0
+        with:
+          enable-cache: true
+
+      - name: Install just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
+
+      - name: Install Python
+        working-directory: packages/@n8n/ai-workflow-builder.ee/evaluations/programmatic/python
+        run: uv python install 3.11
+
+      - name: Install workflow comparison dependencies
+        working-directory: packages/@n8n/ai-workflow-builder.ee/evaluations/programmatic/python
+        run: just sync-all
+
+      - name: Export Node Types
+        run: |
+          ./packages/cli/bin/n8n export:nodes --output ./packages/@n8n/ai-workflow-builder.ee/evaluations/nodes.json
+
+      - name: Run Evaluations
+        working-directory: packages/@n8n/ai-workflow-builder.ee/evaluations
+        run: |
+          pnpm eval:langsmith \
+            --dataset "${{ inputs.dataset }}" \
+            --repetitions ${{ inputs.repetitions }} \
+            --num-judges ${{ inputs.num_judges }} \
+            --name "${{ steps.experiment.outputs.name }}"

--- a/.github/workflows/test-evals-ai-reusable.yml
+++ b/.github/workflows/test-evals-ai-reusable.yml
@@ -7,10 +7,14 @@ on:
         description: 'GitHub branch to test.'
         type: string
         default: 'master'
+      suite:
+        description: 'Evaluation suite to run (pairwise or llm-judge).'
+        type: string
+        default: 'pairwise'
       dataset:
         description: 'LangSmith dataset to use.'
         type: string
-        default: 'notion-pairwise-fresh'
+        required: true
       repetitions:
         description: 'Number of repetitions to run.'
         type: number
@@ -19,6 +23,10 @@ on:
         description: 'Number of judges to use.'
         type: number
         default: 1
+      concurrency:
+        description: 'Max concurrent evaluations.'
+        type: number
+        default: 10
       experiment_name_prefix:
         description: 'Prefix for the experiment name. If empty, will be auto-generated from branch name.'
         type: string
@@ -26,7 +34,7 @@ on:
 
 jobs:
   evals:
-    name: Run Evaluations
+    name: Run ${{ inputs.suite }} Evaluations
     runs-on: blacksmith-2vcpu-ubuntu-2204
     env:
       N8N_AI_ANTHROPIC_KEY: ${{ secrets.EVALS_ANTHROPIC_KEY }}
@@ -88,8 +96,11 @@ jobs:
       - name: Run Evaluations
         working-directory: packages/@n8n/ai-workflow-builder.ee/evaluations
         run: |
-          pnpm eval:pairwise:langsmith \
+          pnpm eval \
+            --suite "${{ inputs.suite }}" \
+            --backend langsmith \
             --dataset "${{ inputs.dataset }}" \
             --repetitions ${{ inputs.repetitions }} \
             --judges ${{ inputs.judges }} \
+            --concurrency ${{ inputs.concurrency }} \
             --name "${{ steps.experiment.outputs.name }}"

--- a/.github/workflows/test-evals-ai.yml
+++ b/.github/workflows/test-evals-ai.yml
@@ -5,7 +5,8 @@ on:
     branches:
       - master
     paths:
-      - 'packages/@n8n/ai-workflow-builder.ee/**'
+      - 'packages/@n8n/ai-workflow-builder.ee/src/prompts/**'
+      - 'packages/@n8n/ai-workflow-builder.ee/**/*.prompt.ts'
       - '.github/workflows/test-evals-ai.yml'
       - '.github/workflows/test-evals-ai-reusable.yml'
   schedule:
@@ -19,12 +20,12 @@ on:
       dataset:
         description: 'LangSmith dataset to use.'
         required: false
-        default: 'workflow-builder-canvas-prompts'
+        default: 'notion-pairwise-fresh'
       repetitions:
         description: 'Number of repetitions to run.'
         required: false
         default: '3'
-      num_judges:
+      judges:
         description: 'Number of judges to use.'
         required: false
         default: '3'
@@ -102,7 +103,7 @@ jobs:
       branch: ${{ steps.config.outputs.branch }}
       dataset: ${{ steps.config.outputs.dataset }}
       repetitions: ${{ steps.config.outputs.repetitions }}
-      num_judges: ${{ steps.config.outputs.num_judges }}
+      judges: ${{ steps.config.outputs.judges }}
       experiment_prefix: ${{ steps.config.outputs.experiment_prefix }}
     steps:
       - name: Set configuration based on trigger
@@ -114,9 +115,9 @@ jobs:
             # Merge to master: lighter config (1 rep, 1 judge)
             {
               echo "branch=${{ github.ref_name }}"
-              echo "dataset=workflow-builder-canvas-prompts"
+              echo "dataset=notion-pairwise-fresh"
               echo "repetitions=1"
-              echo "num_judges=1"
+              echo "judges=1"
               echo "experiment_prefix="
             } >> "$GITHUB_OUTPUT"
           elif [ "$EVENT_NAME" = "schedule" ]; then
@@ -125,7 +126,7 @@ jobs:
               echo "branch=master"
               echo "dataset=prompts-v2"
               echo "repetitions=3"
-              echo "num_judges=3"
+              echo "judges=3"
               echo "experiment_prefix=CI_scheduled"
             } >> "$GITHUB_OUTPUT"
           else
@@ -134,7 +135,7 @@ jobs:
               echo "branch=${{ inputs.branch || 'master' }}"
               echo "dataset=${{ inputs.dataset || 'workflow-builder-canvas-prompts' }}"
               echo "repetitions=${{ inputs.repetitions || '3' }}"
-              echo "num_judges=${{ inputs.num_judges || '3' }}"
+              echo "judges=${{ inputs.judges || '3' }}"
               echo "experiment_prefix=CI_manual"
             } >> "$GITHUB_OUTPUT"
           fi
@@ -147,6 +148,6 @@ jobs:
       branch: ${{ needs.determine-config.outputs.branch }}
       dataset: ${{ needs.determine-config.outputs.dataset }}
       repetitions: ${{ fromJson(needs.determine-config.outputs.repetitions) }}
-      num_judges: ${{ fromJson(needs.determine-config.outputs.num_judges) }}
+      judges: ${{ fromJson(needs.determine-config.outputs.judges) }}
       experiment_name_prefix: ${{ needs.determine-config.outputs.experiment_prefix }}
     secrets: inherit

--- a/.github/workflows/test-evals-ai.yml
+++ b/.github/workflows/test-evals-ai.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'packages/@n8n/ai-workflow-builder.ee/**'
       - '.github/workflows/test-evals-ai.yml'
+      - '.github/workflows/test-evals-ai-reusable.yml'
   schedule:
     - cron: '0 22 * * 6'
   workflow_dispatch:
@@ -19,58 +20,68 @@ on:
         description: 'LangSmith dataset to use.'
         required: false
         default: 'workflow-builder-canvas-prompts'
+      repetitions:
+        description: 'Number of repetitions to run.'
+        required: false
+        default: '3'
+      num_judges:
+        description: 'Number of judges to use.'
+        required: false
+        default: '3'
 
 jobs:
-  evals:
-    name: Run Evaluations
-    runs-on: blacksmith-2vcpu-ubuntu-2204
-    env:
-      N8N_AI_ANTHROPIC_KEY: ${{ secrets.EVALS_ANTHROPIC_KEY }}
-      LANGSMITH_TRACING: true
-      LANGSMITH_ENDPOINT: ${{ secrets.EVALS_LANGSMITH_ENDPOINT }}
-      LANGSMITH_API_KEY: ${{ secrets.EVALS_LANGSMITH_API_KEY }}
+  determine-config:
+    name: Determine Configuration
+    runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.config.outputs.branch }}
+      dataset: ${{ steps.config.outputs.dataset }}
+      repetitions: ${{ steps.config.outputs.repetitions }}
+      num_judges: ${{ steps.config.outputs.num_judges }}
+      experiment_prefix: ${{ steps.config.outputs.experiment_prefix }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ github.event.inputs.branch || github.ref }}
-
-      - name: Select dataset
-        env:
-          DATASET_INPUT: ${{ github.event.inputs.dataset }}
-          EVENT_NAME: ${{ github.event_name }}
+      - name: Set configuration based on trigger
+        id: config
         run: |
-          DATASET="workflow-builder-canvas-prompts"
-          if [ "$EVENT_NAME" = "schedule" ]; then
-            DATASET="prompts-v2"
-          elif [ -n "$DATASET_INPUT" ]; then
-            DATASET="$DATASET_INPUT"
+          EVENT_NAME="${{ github.event_name }}"
+
+          if [ "$EVENT_NAME" = "push" ]; then
+            # Merge to master: lighter config (1 rep, 1 judge)
+            {
+              echo "branch=${{ github.ref_name }}"
+              echo "dataset=workflow-builder-canvas-prompts"
+              echo "repetitions=1"
+              echo "num_judges=1"
+              echo "experiment_prefix="
+            } >> "$GITHUB_OUTPUT"
+          elif [ "$EVENT_NAME" = "schedule" ]; then
+            # Scheduled run: full config (3 reps, 3 judges)
+            {
+              echo "branch=master"
+              echo "dataset=prompts-v2"
+              echo "repetitions=3"
+              echo "num_judges=3"
+              echo "experiment_prefix=CI_scheduled"
+            } >> "$GITHUB_OUTPUT"
+          else
+            # Manual dispatch: use provided values
+            {
+              echo "branch=${{ inputs.branch || 'master' }}"
+              echo "dataset=${{ inputs.dataset || 'workflow-builder-canvas-prompts' }}"
+              echo "repetitions=${{ inputs.repetitions || '3' }}"
+              echo "num_judges=${{ inputs.num_judges || '3' }}"
+              echo "experiment_prefix=CI_manual"
+            } >> "$GITHUB_OUTPUT"
           fi
-          echo "LANGSMITH_DATASET_NAME=$DATASET" >> "$GITHUB_ENV"
 
-      - name: Setup and Build
-        uses: ./.github/actions/setup-nodejs
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1 # 6.5.0
-        with:
-          enable-cache: true
-
-      - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
-
-      - name: Install Python
-        working-directory: packages/@n8n/ai-workflow-builder.ee/evaluations/programmatic/python
-        run: uv python install 3.11
-
-      - name: Install workflow comparison dependencies
-        working-directory: packages/@n8n/ai-workflow-builder.ee/evaluations/programmatic/python
-        run: just sync-all
-
-      - name: Export Node Types
-        run: |
-          ./packages/cli/bin/n8n export:nodes --output ./packages/@n8n/ai-workflow-builder.ee/evaluations/nodes.json
-
-      - name: Run Evaluations
-        working-directory: packages/@n8n/ai-workflow-builder.ee/evaluations
-        run: |
-          pnpm eval:langsmith --repetitions 3
+  run-evals:
+    name: Run Evaluations
+    needs: determine-config
+    uses: ./.github/workflows/test-evals-ai-reusable.yml
+    with:
+      branch: ${{ needs.determine-config.outputs.branch }}
+      dataset: ${{ needs.determine-config.outputs.dataset }}
+      repetitions: ${{ fromJson(needs.determine-config.outputs.repetitions) }}
+      num_judges: ${{ fromJson(needs.determine-config.outputs.num_judges) }}
+      experiment_name_prefix: ${{ needs.determine-config.outputs.experiment_prefix }}
+    secrets: inherit

--- a/.github/workflows/test-evals-ai.yml
+++ b/.github/workflows/test-evals-ai.yml
@@ -30,8 +30,73 @@ on:
         default: '3'
 
 jobs:
+  check-skip:
+    name: Check Skip Label
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.check.outputs.should_skip }}
+    steps:
+      - name: Check for no-prompt-changes opt-out
+        id: check
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const SKIP_TAG = '(no-prompt-changes)';
+            const SKIP_LABEL = 'no-prompt-changes';
+
+            // Only check for push events (merges to master)
+            if (context.eventName !== 'push') {
+              core.setOutput('should_skip', 'false');
+              return;
+            }
+
+            // Check commit message for skip tag
+            const commitMessage = context.payload.head_commit?.message || '';
+            if (commitMessage.includes(SKIP_TAG)) {
+              console.log(`Found ${SKIP_TAG} in commit message, skipping evals`);
+              core.setOutput('should_skip', 'true');
+              return;
+            }
+
+            // Find the PR associated with this merge commit
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha
+            });
+
+            if (prs.length === 0) {
+              console.log('No PR found for this commit, running evals');
+              core.setOutput('should_skip', 'false');
+              return;
+            }
+
+            const pr = prs[0];
+            console.log(`PR #${pr.number}: "${pr.title}"`);
+
+            // Check PR title for skip tag
+            if (pr.title.includes(SKIP_TAG)) {
+              console.log(`Found ${SKIP_TAG} in PR title, skipping evals`);
+              core.setOutput('should_skip', 'true');
+              return;
+            }
+
+            // Check PR labels for skip label
+            const labels = pr.labels.map(l => l.name);
+            console.log(`PR labels: ${labels.join(', ') || '(none)'}`);
+
+            if (labels.includes(SKIP_LABEL)) {
+              console.log(`Found ${SKIP_LABEL} label, skipping evals`);
+              core.setOutput('should_skip', 'true');
+            } else {
+              console.log('No skip indicator found, running evals');
+              core.setOutput('should_skip', 'false');
+            }
+
   determine-config:
     name: Determine Configuration
+    needs: check-skip
+    if: needs.check-skip.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     outputs:
       branch: ${{ steps.config.outputs.branch }}

--- a/.github/workflows/test-evals-ai.yml
+++ b/.github/workflows/test-evals-ai.yml
@@ -9,26 +9,20 @@ on:
       - 'packages/@n8n/ai-workflow-builder.ee/**/*.prompt.ts'
       - '.github/workflows/test-evals-ai.yml'
       - '.github/workflows/test-evals-ai-reusable.yml'
-  schedule:
-    - cron: '0 22 * * 6'
   workflow_dispatch:
     inputs:
       branch:
         description: 'GitHub branch to test.'
         required: false
         default: 'master'
-      dataset:
-        description: 'LangSmith dataset to use.'
+      spec_repetitions:
+        description: 'Number of repetitions for spec (pairwise) evals.'
         required: false
-        default: 'notion-pairwise-fresh'
-      repetitions:
-        description: 'Number of repetitions to run.'
+        default: '1'
+      spec_judges:
+        description: 'Number of judges for spec (pairwise) evals.'
         required: false
-        default: '3'
-      judges:
-        description: 'Number of judges to use.'
-        required: false
-        default: '3'
+        default: '1'
 
 jobs:
   check-skip:
@@ -101,9 +95,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       branch: ${{ steps.config.outputs.branch }}
-      dataset: ${{ steps.config.outputs.dataset }}
-      repetitions: ${{ steps.config.outputs.repetitions }}
-      judges: ${{ steps.config.outputs.judges }}
+      spec_repetitions: ${{ steps.config.outputs.spec_repetitions }}
+      spec_judges: ${{ steps.config.outputs.spec_judges }}
       experiment_prefix: ${{ steps.config.outputs.experiment_prefix }}
     steps:
       - name: Set configuration based on trigger
@@ -112,42 +105,46 @@ jobs:
           EVENT_NAME="${{ github.event_name }}"
 
           if [ "$EVENT_NAME" = "push" ]; then
-            # Merge to master: lighter config (1 rep, 1 judge)
+            # Merge to master: spec evals use 1 rep, 1 judge
             {
               echo "branch=${{ github.ref_name }}"
-              echo "dataset=notion-pairwise-fresh"
-              echo "repetitions=1"
-              echo "judges=1"
+              echo "spec_repetitions=1"
+              echo "spec_judges=1"
               echo "experiment_prefix="
             } >> "$GITHUB_OUTPUT"
-          elif [ "$EVENT_NAME" = "schedule" ]; then
-            # Scheduled run: full config (3 reps, 3 judges)
-            {
-              echo "branch=master"
-              echo "dataset=prompts-v2"
-              echo "repetitions=3"
-              echo "judges=3"
-              echo "experiment_prefix=CI_scheduled"
-            } >> "$GITHUB_OUTPUT"
           else
-            # Manual dispatch: use provided values
+            # Manual dispatch: use provided values for spec evals
             {
               echo "branch=${{ inputs.branch || 'master' }}"
-              echo "dataset=${{ inputs.dataset || 'workflow-builder-canvas-prompts' }}"
-              echo "repetitions=${{ inputs.repetitions || '3' }}"
-              echo "judges=${{ inputs.judges || '3' }}"
+              echo "spec_repetitions=${{ inputs.spec_repetitions || '1' }}"
+              echo "spec_judges=${{ inputs.spec_judges || '1' }}"
               echo "experiment_prefix=CI_manual"
             } >> "$GITHUB_OUTPUT"
           fi
 
-  run-evals:
-    name: Run Evaluations
+  run-pairwise-evals:
+    name: Run Pairwise (Spec) Evaluations
     needs: determine-config
     uses: ./.github/workflows/test-evals-ai-reusable.yml
     with:
       branch: ${{ needs.determine-config.outputs.branch }}
-      dataset: ${{ needs.determine-config.outputs.dataset }}
-      repetitions: ${{ fromJson(needs.determine-config.outputs.repetitions) }}
-      judges: ${{ fromJson(needs.determine-config.outputs.judges) }}
+      suite: pairwise
+      dataset: notion-pairwise-fresh
+      repetitions: ${{ fromJson(needs.determine-config.outputs.spec_repetitions) }}
+      judges: ${{ fromJson(needs.determine-config.outputs.spec_judges) }}
+      experiment_name_prefix: ${{ needs.determine-config.outputs.experiment_prefix }}
+    secrets: inherit
+
+  run-llm-judge-evals:
+    name: Run LLM Judge (Matrix) Evaluations
+    needs: determine-config
+    uses: ./.github/workflows/test-evals-ai-reusable.yml
+    with:
+      branch: ${{ needs.determine-config.outputs.branch }}
+      suite: llm-judge
+      dataset: workflow-builder-canvas-prompts
+      # Matrix evals always use 3 reps, 3 judges regardless of trigger
+      repetitions: 3
+      judges: 3
       experiment_name_prefix: ${{ needs.determine-config.outputs.experiment_prefix }}
     secrets: inherit

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/README.md
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/README.md
@@ -441,3 +441,71 @@ From `packages/@n8n/ai-workflow-builder.ee`:
 ```bash
 pnpm test:eval
 ```
+
+## CI Integration
+
+### Automated Eval Runs
+
+Evaluations run automatically via GitHub Actions:
+
+| Trigger | Reps | Judges | Dataset | When |
+|---------|------|--------|---------|------|
+| Push to master | 1 | 1 | `workflow-builder-canvas-prompts` | On changes to `ai-workflow-builder.ee/` |
+| Scheduled | 3 | 3 | `prompts-v2` | Saturdays 22:00 UTC |
+| Minor release | 2 | 3 | `workflow-builder-canvas-prompts` | On `vX.Y.0` releases |
+| Manual dispatch | Configurable | Configurable | Configurable | Via GitHub Actions UI |
+
+### Skipping Evals on Merge
+
+To skip eval runs when merging a PR that doesn't affect prompts/AI behavior, use any of:
+
+- **PR label**: Add `no-prompt-changes` label to the PR
+- **PR title**: Include `(no-prompt-changes)` in the PR title
+- **Commit message**: Include `(no-prompt-changes)` in the merge commit message
+
+### Experiment Naming Convention
+
+LangSmith experiments follow this naming pattern:
+
+| Source | Format | Example |
+|--------|--------|---------|
+| Branch with ticket | `{TICKET-ID}_{YYYY_MM_DD}` | `AI-1234_2026_01_20` |
+| Branch without ticket | `CI_{branch}_{YYYY_MM_DD}` | `CI_master_2026_01_20` |
+| Scheduled run | `CI_scheduled_{YYYY_MM_DD}` | `CI_scheduled_2026_01_20` |
+| Minor release | `CI_vX.Y_{YYYY_MM_DD}` | `CI_v1.70_2026_01_20` |
+| Manual dispatch | `CI_manual_{YYYY_MM_DD}` | `CI_manual_2026_01_20` |
+
+### CI Metadata
+
+All LangSmith experiments include metadata to distinguish CI runs from local development:
+
+```json
+{
+  "source": "ci",
+  "trigger": "push",
+  "commitSha": "abc123...",
+  "branch": "master",
+  "runId": "12345678"
+}
+```
+
+Local runs show `"source": "local"` with no other CI fields.
+
+### Debug Dataset
+
+For faster iteration during development, use a minimal dataset:
+
+```bash
+# Use the debug dataset with a single example
+pnpm eval:langsmith --dataset "workflow-builder-debug-single" --name "debug-run" --verbose
+```
+
+To create your own debug dataset in LangSmith:
+1. Go to LangSmith → Datasets
+2. Create a new dataset with 1-3 representative examples
+3. Use it with `--dataset "your-debug-dataset"`
+
+This is useful for:
+- Testing workflow changes quickly
+- Debugging evaluator issues
+- Validating CI workflow changes locally

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/ci-metadata.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/ci-metadata.ts
@@ -3,17 +3,16 @@
  *
  * Provides metadata to distinguish CI runs from local development runs
  * and to track provenance of automated evaluation results.
+ *
+ * Note: Git info (commit SHA, branch) is not included here as LangSmith
+ * automatically tracks it via LANGSMITH_REVISION_ID and LANGSMITH_BRANCH.
  */
 
 export interface CIMetadata {
 	/** Whether this run is from CI or local development */
 	source: 'ci' | 'local';
-	/** The GitHub Actions event that triggered this run (e.g., 'push', 'schedule', 'workflow_dispatch') */
+	/** The GitHub Actions event that triggered this run (e.g., 'push', 'release', 'workflow_dispatch') */
 	trigger?: string;
-	/** The Git commit SHA being evaluated */
-	commitSha?: string;
-	/** The Git branch or tag name */
-	branch?: string;
 	/** The GitHub Actions run ID for linking back to the workflow run */
 	runId?: string;
 }
@@ -34,8 +33,6 @@ export function buildCIMetadata(): CIMetadata {
 	return {
 		source: 'ci',
 		trigger: process.env.GITHUB_EVENT_NAME,
-		commitSha: process.env.GITHUB_SHA,
-		branch: process.env.GITHUB_REF_NAME,
 		runId: process.env.GITHUB_RUN_ID,
 	};
 }

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/ci-metadata.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/ci-metadata.ts
@@ -1,0 +1,41 @@
+/**
+ * CI Metadata for LangSmith experiments.
+ *
+ * Provides metadata to distinguish CI runs from local development runs
+ * and to track provenance of automated evaluation results.
+ */
+
+export interface CIMetadata {
+	/** Whether this run is from CI or local development */
+	source: 'ci' | 'local';
+	/** The GitHub Actions event that triggered this run (e.g., 'push', 'schedule', 'workflow_dispatch') */
+	trigger?: string;
+	/** The Git commit SHA being evaluated */
+	commitSha?: string;
+	/** The Git branch or tag name */
+	branch?: string;
+	/** The GitHub Actions run ID for linking back to the workflow run */
+	runId?: string;
+}
+
+/**
+ * Build CI metadata from environment variables.
+ *
+ * When running in GitHub Actions, populates metadata from standard GH environment variables.
+ * When running locally, only sets source to 'local'.
+ */
+export function buildCIMetadata(): CIMetadata {
+	const isCI = process.env.GITHUB_ACTIONS === 'true';
+
+	if (!isCI) {
+		return { source: 'local' };
+	}
+
+	return {
+		source: 'ci',
+		trigger: process.env.GITHUB_EVENT_NAME,
+		commitSha: process.env.GITHUB_SHA,
+		branch: process.env.GITHUB_REF_NAME,
+		runId: process.env.GITHUB_RUN_ID,
+	};
+}

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
@@ -18,6 +18,7 @@ import {
 	getDefaultExperimentName,
 	parseEvaluationArgs,
 } from './argument-parser';
+import { buildCIMetadata } from './ci-metadata';
 import {
 	runEvaluation,
 	createConsoleLifecycle,
@@ -213,13 +214,13 @@ export async function runV2Evaluation(): Promise<void> {
 						concurrency: args.concurrency,
 						maxExamples: args.maxExamples,
 						filters: args.filters,
-						experimentMetadata:
-							args.suite === 'pairwise'
-								? {
-										numJudges: args.numJudges,
-										scoringMethod: 'hierarchical',
-									}
-								: undefined,
+						experimentMetadata: {
+							...buildCIMetadata(),
+							...(args.suite === 'pairwise' && {
+								numJudges: args.numJudges,
+								scoringMethod: 'hierarchical',
+							}),
+						},
 					},
 				}
 			: {


### PR DESCRIPTION
## Summary

Adds CI automation for running AI workflow builder evaluations against LangSmith, enabling quality tracking across releases and development. Runs **both** evaluation suites:
- **Pairwise (spec) evals**: Evaluates workflows against specific dos/donts requirements
- **LLM-judge (matrix) evals**: Evaluates workflows against general quality dimensions

## Key changes:
- Create reusable workflow (`test-evals-ai-reusable.yml`) for running evaluations with configurable suite and inputs
- Add trigger-based configuration with different eval intensities based on context (push vs release)
- Support release-triggered evals on minor versions (vX.Y.0) with higher repetition counts
- Add opt-out mechanism via `no-prompt-changes` label or PR title tag for non-AI changes
- Include CI metadata in LangSmith experiments for tracing provenance
- Run both pairwise and llm-judge suites in parallel
- Set concurrency to 10 for faster CI runs

## Evaluation triggers:

### Spec (pairwise) evals
| Trigger | Reps | Judges | Dataset |
|---------|------|--------|---------|
| Push to master | 1 | 1 | `notion-pairwise-fresh` |
| Minor release (vX.Y.0) | 2 | 3 | `notion-pairwise-fresh` |
| Manual dispatch | configurable (default 1/1) | configurable | `notion-pairwise-fresh` |

### Matrix (llm-judge) evals
| Trigger | Reps | Judges | Dataset |
|---------|------|--------|---------|
| Any trigger | 3 | 3 | `workflow-builder-canvas-prompts` |

### Evaluation suites explained:

| Suite | Question | Criteria | Dataset |
|-------|----------|----------|---------|
| **Pairwise (spec)** | "Does it meet the spec?" | Explicit dos/donts per prompt | `notion-pairwise-fresh` |
| **LLM-judge (matrix)** | "Is it well-built?" | General quality dimensions (functionality, connections, efficiency, etc.) | `workflow-builder-canvas-prompts` |

### Experiment metadata:
- `source`: `ci` or `local`
- `trigger`: GitHub event name (e.g., `push`, `release`, `workflow_dispatch`)
- `runId`: GitHub Actions run ID (for linking back to the workflow run)

Note: Git info (commit SHA, branch) is automatically tracked by LangSmith.

## Related Linear tickets

https://linear.app/n8n/issue/AI-1930

## Testing
```
gh workflow run "Test: Evals AI" --ref aalises/add-ci-for-evals -f branch=aalises/add-ci-for-evals -f spec_repetitions=1 -f spec_judges=1
```
example run: https://github.com/n8n-io/n8n/actions/runs/21181541533 (pre-10 concurrency)