### PR TITLE
feat(ai-builder): Add RLC options fetch tool for configurator sub-agent

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/ai-workflow-builder-agent.service.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/ai-workflow-builder-agent.service.ts
@@ -12,7 +12,7 @@ import type { IUser, INodeTypeDescription, ITelemetryTrackProperties } from 'n8n
 import { LLMServiceError } from '@/errors';
 import { anthropicClaudeSonnet45 } from '@/llm-config';
 import { SessionManagerService } from '@/session-manager.service';
-import type { ResourceLocatorCallbackFactory } from '@/types/callbacks';
+import { ResourceLocatorCallbackFactory } from '@/types/callbacks';
 import {
 	BuilderFeatureFlags,
 	WorkflowBuilderAgent,
@@ -37,7 +37,6 @@ export class AiWorkflowBuilderService {
 		private readonly n8nVersion?: string,
 		private readonly onCreditsUpdated?: OnCreditsUpdated,
 		private readonly onTelemetryEvent?: OnTelemetryEvent,
-		// eslint-disable-next-line n8n-local-rules/no-type-only-import-in-di -- function type, not DI-injected
 		private readonly resourceLocatorCallbackFactory?: ResourceLocatorCallbackFactory,
 	) {
 		this.parsedNodeTypes = this.filterNodeTypes(parsedNodeTypes);

--- a/packages/@n8n/ai-workflow-builder.ee/src/multi-agent-workflow-subgraphs.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/multi-agent-workflow-subgraphs.ts
@@ -17,6 +17,7 @@ import { BuilderSubgraph } from './subgraphs/builder.subgraph';
 import { ConfiguratorSubgraph } from './subgraphs/configurator.subgraph';
 import { DiscoverySubgraph } from './subgraphs/discovery.subgraph';
 import type { BaseSubgraph } from './subgraphs/subgraph-interface';
+import type { ResourceLocatorCallback } from './types/callbacks';
 import type { SubgraphPhase } from './types/coordination';
 import { createErrorMetadata } from './types/coordination';
 import { getNextPhaseFromLog, hasErrorInLog } from './utils/coordination-log';
@@ -57,6 +58,8 @@ export interface MultiAgentSubgraphConfig {
 	featureFlags?: BuilderFeatureFlags;
 	/** Callback invoked when a successful generation completes (e.g., for credit deduction) */
 	onGenerationSuccess?: () => Promise<void>;
+	/** Callback for fetching resource locator options */
+	resourceLocatorCallback?: ResourceLocatorCallback;
 }
 
 /**
@@ -129,6 +132,7 @@ export function createMultiAgentWorkflowWithSubgraphs(config: MultiAgentSubgraph
 		autoCompactThresholdTokens = DEFAULT_AUTO_COMPACT_THRESHOLD_TOKENS,
 		featureFlags,
 		onGenerationSuccess,
+		resourceLocatorCallback,
 	} = config;
 
 	const supervisorAgent = new SupervisorAgent({ llm: llmComplexTask });
@@ -158,6 +162,7 @@ export function createMultiAgentWorkflowWithSubgraphs(config: MultiAgentSubgraph
 		logger,
 		instanceUrl,
 		featureFlags,
+		resourceLocatorCallback,
 	});
 
 	// Build graph using method chaining for proper TypeScript inference

--- a/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/configurator.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/configurator.prompt.ts
@@ -146,6 +146,35 @@ For numeric ranges (e.g., $100-$1000):
 
 Always set renameOutput: true and provide descriptive outputKey labels.`;
 
+const RESOURCE_LOCATOR_CONFIGURATION = `RESOURCE LOCATOR PARAMETERS:
+Some node parameters use "resource locators" to select from dynamic lists (calendars, documents, boards, channels, etc.).
+These parameters have a specific structure in the workflow JSON:
+{{
+  "__rl": true,
+  "mode": "list",
+  "value": "<selected_id>",
+  "cachedResultName: "<display_name>"
+}}
+
+REQUIRED PROCESS for resource locator parameters:
+1. BEFORE configuring any parameter with "__rl": true, call get_resource_locator_options
+   - Provide the nodeId and parameterPath (e.g., "documentId", "calendarId", "boardId")
+   - The tool returns available options with display names and IDs
+2. If the user specifies which resource they want, match it to the options and use the correct ID
+3. USE BOTH the display name and the ID when updating the parameter:
+   - Format: "Document Name (ID: 1abc...xyz)"
+4. ONLY use values returned by get_resource_locator_options - NEVER assume available options, NEVER guess or hallucinate IDs
+
+Example:
+- User says "use the Q4 Report document"
+- Call get_resource_locator_options for the documentId parameter
+- Find "Q4 Report" in the results with ID "1mtaEwM07..."
+- Configure the parameter with the correct ID value and display name
+
+NEVER configure resource locator parameters without first calling get_resource_locator_options
+
+Run get_resource_locator_options for all resource locator parameters BEFORE configuring nodes IN PARALLEL to save time`;
+
 const NODE_CONFIGURATION_EXAMPLES = `NODE CONFIGURATION EXAMPLES:
 When configuring complex nodes, use get_node_configuration_examples to see real-world examples from community templates:
 
@@ -209,6 +238,7 @@ export function buildConfiguratorPrompt(): string {
 		.section('mandatory_execution_sequence', EXECUTION_SEQUENCE)
 		.section('workflow_json_detection', WORKFLOW_JSON_DETECTION)
 		.section('parameter_configuration', PARAMETER_CONFIGURATION)
+		.section('resource_locator_configuration', RESOURCE_LOCATOR_CONFIGURATION)
 		.section('data_referencing', DATA_REFERENCING)
 		.section('expression_techniques', EXPRESSION_TECHNIQUES)
 		.section('tool_node_expressions', TOOL_NODE_EXPRESSIONS)

--- a/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/configurator.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/configurator.prompt.ts
@@ -147,8 +147,8 @@ For numeric ranges (e.g., $100-$1000):
 Always set renameOutput: true and provide descriptive outputKey labels.`;
 
 const RESOURCE_LOCATOR_CONFIGURATION = `RESOURCE LOCATOR PARAMETERS:
-Some node parameters use "resource locators" to select from dynamic lists (calendars, documents, boards, channels, etc.).
-These parameters have a specific structure in the workflow JSON:
+Some node parameters use "resource locator" type. This allows user to select from dynamic lists (calendars, documents, boards, channels, etc.).
+These parameters have a specific structure in the node configuration:
 {{
   "__rl": true,
   "mode": "list",
@@ -171,7 +171,7 @@ Example:
 - Find "Q4 Report" in the results with ID "1mtaEwM07..."
 - Configure the parameter with the correct ID value and display name
 
-NEVER configure resource locator parameters without first calling get_resource_locator_options
+NEVER configure resource locator parameters without fetching a list of possible options using get_resource_locator_options
 
 Run get_resource_locator_options for all resource locator parameters BEFORE configuring nodes IN PARALLEL to save time`;
 

--- a/packages/@n8n/ai-workflow-builder.ee/src/prompts/chains/parameter-updater/examples/resource-locator.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/prompts/chains/parameter-updater/examples/resource-locator.ts
@@ -31,7 +31,7 @@ Expected Output:
   "otherOptions": {}
 }
 
-#### Example 2: Slack Node - Channel by List Selection
+#### Example 2: Slack Node - Channel by name
 Current Parameters:
 {
   "select": "channel",
@@ -57,7 +57,7 @@ Expected Output:
   "otherOptions": {}
 }
 
-#### Example 3: Google Sheets Node - Spreadsheet by List Selection
+#### Example 3: Google Sheets Node - Spreadsheet by name
 Current Parameters:
 {
   "operation": "read",
@@ -154,7 +154,7 @@ Current Parameters:
   }
 }
 
-Requested Changes: Use the "Customer Database (ID: 9XYZ789DEF)" spreadsheet
+Requested Changes: Use the "Customer Database" spreadsheet
 
 Expected Output:
 {

--- a/packages/@n8n/ai-workflow-builder.ee/src/prompts/chains/parameter-updater/examples/resource-locator.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/prompts/chains/parameter-updater/examples/resource-locator.ts
@@ -31,7 +31,71 @@ Expected Output:
   "otherOptions": {}
 }
 
-#### Example 2: Google Drive Node - File by URL
+#### Example 2: Slack Node - Channel by List Selection
+Current Parameters:
+{
+  "select": "channel",
+  "channelId": {
+    "__rl": true,
+    "value": "",
+    "mode": "list"
+  },
+  "otherOptions": {}
+}
+
+Requested Changes: Send to general channel
+
+Expected Output:
+{
+  "select": "channel",
+  "channelId": {
+    "__rl": true,
+    "mode": "list",
+		"value": "C0A45D6GBLD",
+		"cachedResultName": "general"
+  },
+  "otherOptions": {}
+}
+
+#### Example 3: Google Sheets Node - Spreadsheet by List Selection
+Current Parameters:
+{
+  "operation": "read",
+  "documentId": {
+    "__rl": true,
+    "value": "",
+    "mode": "list"
+  },
+  "sheetName": {
+    "__rl": true,
+    "value": "",
+    "mode": "list"
+  }
+}
+
+Requested Changes: Use the "Sales Report 2024" spreadsheet and "Q1 Data" sheet
+
+Expected Output:
+{
+  "operation": "read",
+  "documentId": {
+    "__rl": true,
+    "mode": "list",
+    "value": "2wtaOwM07OTFmEijOVvzDAlxtR76hBYVBRlIwuUgDsVE",
+    "cachedResultName": "Sales Report 2024",
+    "cachedResultUrl": "https://docs.google.com/spreadsheets/d/2wtaOwM07OTFmEijOVvzDAlxtR76hBYVBRlIwuUgDsVE/edit?usp=drivesdk"
+    
+  },
+  "sheetName": {
+    "__rl": true,
+    "mode": "list",
+    "value": "gid=0",
+    "cachedResultName": "Q1 Data"
+    "cachedResultUrl": "https://docs.google.com/spreadsheets/d/2wtaOwM07OTFmEijOVvzDAlxtR76hBYVBRlIwuUgDsVE/edit#gid=0"
+  }
+}
+
+#### Example 4: Google Drive Node - File by URL
 Current Parameters:
 {
   "operation": "download",
@@ -54,7 +118,7 @@ Expected Output:
   }
 }
 
-#### Example 3: Notion Node - Page ID from Expression
+#### Example 5: Notion Node - Page ID from Expression
 Current Parameters:
 {
   "resource": "databasePage",
@@ -76,6 +140,30 @@ Expected Output:
     "__rl": true,
     "mode": "id",
     "value": "={{ $('Previous Node').item.json.pageId }}"
+  }
+}
+
+#### Example 6: Mode Switch - From ID to List
+Current Parameters:
+{
+  "operation": "append",
+  "documentId": {
+    "__rl": true,
+    "value": "1ABC123XYZ",
+    "mode": "id"
+  }
+}
+
+Requested Changes: Use the "Customer Database (ID: 9XYZ789DEF)" spreadsheet
+
+Expected Output:
+{
+  "operation": "append",
+  "documentId": {
+    "__rl": true,
+    "mode": "list",
+    "value": "9XYZ789DEF",
+    "cachedResultName": "Customer Database"
   }
 }`,
 };

--- a/packages/@n8n/ai-workflow-builder.ee/src/prompts/chains/parameter-updater/examples/resource-locator.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/prompts/chains/parameter-updater/examples/resource-locator.ts
@@ -43,7 +43,7 @@ Current Parameters:
   "otherOptions": {}
 }
 
-Requested Changes: Send to general channel
+Requested Changes: Set channel to general (ID: C0A45D6GBLD)
 
 Expected Output:
 {
@@ -154,7 +154,7 @@ Current Parameters:
   }
 }
 
-Requested Changes: Use the "Customer Database" spreadsheet
+Requested Changes: Use the "Customer Database" (ID: 9XYZ789DEF) spreadsheet
 
 Expected Output:
 {

--- a/packages/@n8n/ai-workflow-builder.ee/src/prompts/chains/parameter-updater/guides/resource-locator.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/prompts/chains/parameter-updater/guides/resource-locator.ts
@@ -8,90 +8,31 @@ export const RESOURCE_LOCATOR_GUIDE: NodeTypeGuide = {
 
 ResourceLocator parameters are special fields used for selecting resources like Slack channels, Google Drive files, Notion pages, etc. They MUST have a specific structure:
 
-### Required ResourceLocator Structure:
+### Required ResourceLocator Structure (required fields):
 \`\`\`json
 {
   "__rl": true,
-  "mode": "id" | "url" | "list" | "name",
+  "mode": "id" | "url" | "list",
   "value": "the-actual-value"
 }
 \`\`\`
 
 ### Mode Detection Guidelines:
+- Prefer default mode from node type definition when possible
+- Use the node type definition to determine the default mode and available modes for specific parameter
+- Switch the mode based on the input value format when necessary
+- Use mode "list" when the value is an ID + display name (e.g. "Marketing Team (ID: C0122KQ70S7E)")
 - Use mode "url" when the value is a URL (starts with http:// or https://)
-- Use mode "id" when the value looks like an ID (alphanumeric string)
-- Use mode "name" when the value has a prefix like # (Slack channels) or @ (users)
-- Use mode "list" when referencing a dropdown selection (rarely needed in updates)
+- Use mode "id" when the value looks like an ID (alphanumeric string, UUID, or other identifier)
 
-### ResourceLocator Examples:
-
-#### Example 1: Slack Channel by ID
-Parameter name: channelId
-Change: "Set channel to C0122KQ70S7E"
-Output:
+List mode structure with optional cached fields:
 \`\`\`json
 {
-  "channelId": {
-    "__rl": true,
-    "mode": "id",
-    "value": "C0122KQ70S7E"
-  }
+  "__rl": true,
+  "mode": "list",
+  "value": "actual-id-from-list",
+  "cachedResultName": "Display Name"
 }
 \`\`\`
-
-#### Example 2: Google Drive File by URL
-Parameter name: fileId
-Change: "Use file https://drive.google.com/file/d/1Nvdl7bEfDW33cKQuwfItPhIk479--WYY/view"
-Output:
-\`\`\`json
-{
-  "fileId": {
-    "__rl": true,
-    "mode": "url",
-    "value": "https://drive.google.com/file/d/1Nvdl7bEfDW33cKQuwfItPhIk479--WYY/view"
-  }
-}
-\`\`\`
-
-#### Example 3: Notion Page by ID
-Parameter name: pageId
-Change: "Set page ID to 123e4567-e89b-12d3"
-Output:
-\`\`\`json
-{
-  "pageId": {
-    "__rl": true,
-    "mode": "id",
-    "value": "123e4567-e89b-12d3"
-  }
-}
-\`\`\`
-
-#### Example 4: Slack Channel by Name
-Parameter name: channelId
-Change: "Send to #general channel"
-Output:
-\`\`\`json
-{
-  "channelId": {
-    "__rl": true,
-    "mode": "name",
-    "value": "#general"
-  }
-}
-\`\`\`
-
-#### Example 5: Using Expression with ResourceLocator
-Parameter name: channelId
-Change: "Use channel ID from previous node"
-Output:
-\`\`\`json
-{
-  "channelId": {
-    "__rl": true,
-    "mode": "id",
-    "value": "={{ $('Previous Node').item.json.channelId }}"
-  }
-}
-\`\`\``,
+`,
 };

--- a/packages/@n8n/ai-workflow-builder.ee/src/prompts/chains/parameter-updater/guides/resource-locator.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/prompts/chains/parameter-updater/guides/resource-locator.ts
@@ -12,16 +12,16 @@ ResourceLocator parameters are special fields used for selecting resources like 
 \`\`\`json
 {
   "__rl": true,
-  "mode": "id" | "url" | "list",
+  "mode": "id" | "url" | "list" | "name",
   "value": "the-actual-value"
 }
 \`\`\`
 
 ### Mode Detection Guidelines:
-- Prefer default mode from node type definition when possible
 - Use the node type definition to determine the default mode and available modes for specific parameter
+- Prefer default mode from node type definition when possible
 - Switch the mode based on the input value format when necessary
-- Use mode "list" when the value is an ID + display name (e.g. "Marketing Team (ID: C0122KQ70S7E)")
+- Use mode "list" when the value is an ID + display name (e.g. "Marketing Team (ID: C0122KQ70S7E)"). Value should be set to the ID part, and cachedResultName to the display name part
 - Use mode "url" when the value is a URL (starts with http:// or https://)
 - Use mode "id" when the value looks like an ID (alphanumeric string, UUID, or other identifier)
 

--- a/packages/@n8n/ai-workflow-builder.ee/src/subgraphs/configurator.subgraph.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/subgraphs/configurator.subgraph.ts
@@ -13,12 +13,14 @@ import {
 	buildRecoveryModeContext,
 	INSTANCE_URL_PROMPT,
 } from '@/prompts/agents/configurator.prompt';
+import type { ResourceLocatorCallback } from '@/types/callbacks';
 import type { BuilderFeatureFlags, ChatPayload } from '@/workflow-builder-agent';
 
 import { BaseSubgraph } from './subgraph-interface';
 import type { ParentGraphState } from '../parent-graph-state';
 import { createGetNodeConfigurationExamplesTool } from '../tools/get-node-examples.tool';
 import { createGetNodeParameterTool } from '../tools/get-node-parameter.tool';
+import { createGetResourceLocatorOptionsTool } from '../tools/get-resource-locator-options.tool';
 import { createUpdateNodeParametersTool } from '../tools/update-node-parameters.tool';
 import { createValidateConfigurationTool } from '../tools/validate-configuration.tool';
 import type { CoordinationLogEntry } from '../types/coordination';
@@ -104,6 +106,7 @@ export interface ConfiguratorSubgraphConfig {
 	logger?: Logger;
 	instanceUrl?: string;
 	featureFlags?: BuilderFeatureFlags;
+	resourceLocatorCallback?: ResourceLocatorCallback;
 }
 
 export class ConfiguratorSubgraph extends BaseSubgraph<
@@ -134,6 +137,16 @@ export class ConfiguratorSubgraph extends BaseSubgraph<
 			),
 			createGetNodeParameterTool(),
 			createValidateConfigurationTool(config.parsedNodeTypes),
+			// Conditionally add resource locator tool if callback is provided
+			...(config.resourceLocatorCallback
+				? [
+						createGetResourceLocatorOptionsTool(
+							config.parsedNodeTypes,
+							config.resourceLocatorCallback,
+							config.logger,
+						),
+					]
+				: []),
 		];
 
 		// Conditionally add node configuration examples tool if feature flag is enabled

--- a/packages/@n8n/ai-workflow-builder.ee/src/subgraphs/configurator.subgraph.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/subgraphs/configurator.subgraph.ts
@@ -202,7 +202,7 @@ export class ConfiguratorSubgraph extends BaseSubgraph<
 		/**
 		 * Prefetch node - pre-fetches RLC options for required empty parameters
 		 * This runs before the agent to provide all necessary resource options upfront
-		 * Mutates messages in place to append RLC context (similar to applySubgraphCacheMarkers)
+		 * Mutates messages in place to append RLC context
 		 */
 		const prefetchRLCNode = async (state: typeof ConfiguratorSubgraphState.State) => {
 			// Skip if no callback is available

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/get-resource-locator-options.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/get-resource-locator-options.tool.ts
@@ -149,9 +149,14 @@ export function createGetResourceLocatorOptionsTool(
 					return createErrorResponse(config, error);
 				}
 
-				// Check if node has credentials configured
+				// Check if node has credentials configured (only if node type requires them)
+				// Internal nodes like DataTable don't require credentials
+				const nodeTypeRequiresCredentials =
+					Array.isArray(nodeType.credentials) && nodeType.credentials.length > 0;
 				const credentials = node.credentials;
-				if (!credentials || Object.keys(credentials).length === 0) {
+				const hasCredentials = credentials && Object.keys(credentials).length > 0;
+
+				if (nodeTypeRequiresCredentials && !hasCredentials) {
 					const error = new ValidationError(
 						`Node "${node.name}" does not have credentials configured. Set up credentials before fetching resource options.`,
 					);

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/get-resource-locator-options.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/get-resource-locator-options.tool.ts
@@ -77,9 +77,6 @@ function formatOptionsForLLM(options: INodeListSearchItems[], parameterPath: str
 		parts.push(`  <option index="${index}">`);
 		parts.push(`    <display_name>${opt.name}</display_name>`);
 		parts.push(`    <id>${String(opt.value)}</id>`);
-		if (opt.description) {
-			parts.push(`    <description>${opt.description}</description>`);
-		}
 		parts.push('  </option>');
 	});
 

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/get-resource-locator-options.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/get-resource-locator-options.tool.ts
@@ -1,0 +1,248 @@
+import { tool } from '@langchain/core/tools';
+import type { Logger } from '@n8n/backend-common';
+import type { INodeTypeDescription, INodePropertyMode, INodeListSearchItems } from 'n8n-workflow';
+import { z } from 'zod';
+
+import { ValidationError, ToolExecutionError } from '../errors';
+import type { ResourceLocatorCallback } from '../types/callbacks';
+import type { BuilderTool, BuilderToolBase } from '../utils/stream-processor';
+import { createProgressReporter, reportProgress } from './helpers/progress';
+import { createSuccessResponse, createErrorResponse } from './helpers/response';
+import { getCurrentWorkflow, getWorkflowState } from './helpers/state';
+import {
+	validateNodeExists,
+	findNodeType,
+	createNodeNotFoundError,
+	createNodeTypeNotFoundError,
+} from './helpers/validation';
+
+const TOOL_NAME = 'get_resource_locator_options';
+const DISPLAY_TITLE = 'Fetching resource options';
+const DEFAULT_TIMEOUT_MS = 30000;
+
+/**
+ * Schema for get resource locator options input
+ */
+const getResourceLocatorOptionsSchema = z.object({
+	nodeId: z.string().describe('The ID of the node to fetch resource locator options for'),
+	parameterPath: z
+		.string()
+		.describe(
+			'The path to the resource locator parameter (e.g., "calendarId", "model", "boardId")',
+		),
+	filter: z.string().optional().describe('Optional filter string to narrow down results'),
+});
+
+export const GET_RESOURCE_LOCATOR_OPTIONS_TOOL: BuilderToolBase = {
+	toolName: TOOL_NAME,
+	displayTitle: DISPLAY_TITLE,
+};
+
+/**
+ * Extract the searchListMethod from a resourceLocator property's modes
+ */
+function extractSearchMethod(nodeType: INodeTypeDescription, parameterPath: string): string | null {
+	// Find the property matching the parameter path
+	const property = nodeType.properties.find(
+		(p) => p.name === parameterPath && p.type === 'resourceLocator',
+	);
+
+	if (!property?.modes) {
+		return null;
+	}
+
+	// Find a mode with type='list' that has searchListMethod
+	const listMode = property.modes.find(
+		(mode: INodePropertyMode) => mode.type === 'list' && mode.typeOptions?.searchListMethod,
+	);
+
+	return listMode?.typeOptions?.searchListMethod ?? null;
+}
+
+/**
+ * Format options for LLM consumption
+ */
+function formatOptionsForLLM(options: INodeListSearchItems[], parameterPath: string): string {
+	if (options.length === 0) {
+		return `No options available for parameter "${parameterPath}". The resource may require credentials to be set up first or the external service returned no results.`;
+	}
+
+	const parts: string[] = [
+		`<resource_locator_options parameter="${parameterPath}">`,
+		`<total_count>${options.length}</total_count>`,
+		'<options>',
+	];
+
+	options.forEach((opt, index) => {
+		parts.push(`  <option index="${index}">`);
+		parts.push(`    <display_name>${opt.name}</display_name>`);
+		parts.push(`    <id>${String(opt.value)}</id>`);
+		if (opt.description) {
+			parts.push(`    <description>${opt.description}</description>`);
+		}
+		parts.push('  </option>');
+	});
+
+	parts.push('</options>');
+	parts.push('</resource_locator_options>');
+
+	return parts.join('\n');
+}
+
+/**
+ * Factory function to create the get resource locator options tool
+ */
+export function createGetResourceLocatorOptionsTool(
+	nodeTypes: INodeTypeDescription[],
+	resourceLocatorCallback?: ResourceLocatorCallback,
+	logger?: Logger,
+): BuilderTool {
+	const dynamicTool = tool(
+		async (input, config) => {
+			const reporter = createProgressReporter(config, TOOL_NAME, DISPLAY_TITLE);
+
+			try {
+				// Validate input
+				const validatedInput = getResourceLocatorOptionsSchema.parse(input);
+				const { nodeId, parameterPath, filter } = validatedInput;
+
+				// Report tool start
+				reporter.start(validatedInput);
+
+				// Check if callback is available
+				if (!resourceLocatorCallback) {
+					const error = new ValidationError(
+						'Resource locator fetching is not available. The workflow builder service may not have been configured with credentials support.',
+					);
+					reporter.error(error);
+					return createErrorResponse(config, error);
+				}
+
+				// Get current state
+				const state = getWorkflowState();
+				const workflow = getCurrentWorkflow(state);
+
+				// Find the node
+				const node = validateNodeExists(nodeId, workflow.nodes);
+				if (!node) {
+					const error = createNodeNotFoundError(nodeId);
+					reporter.error(error);
+					return createErrorResponse(config, error);
+				}
+
+				// Find the node type
+				const nodeType = findNodeType(node.type, node.typeVersion, nodeTypes);
+				if (!nodeType) {
+					const error = createNodeTypeNotFoundError(node.type);
+					reporter.error(error);
+					return createErrorResponse(config, error);
+				}
+
+				// Extract search method from node type definition
+				const searchMethod = extractSearchMethod(nodeType, parameterPath);
+				if (!searchMethod) {
+					const error = new ValidationError(
+						`Parameter "${parameterPath}" on node "${node.name}" is not a resource locator with list search capability`,
+						{ extra: { nodeId, parameterPath } },
+					);
+					reporter.error(error);
+					return createErrorResponse(config, error);
+				}
+
+				// Check if node has credentials configured
+				const credentials = node.credentials;
+				if (!credentials || Object.keys(credentials).length === 0) {
+					const error = new ValidationError(
+						`Node "${node.name}" does not have credentials configured. Set up credentials before fetching resource options.`,
+					);
+					reporter.error(error);
+					return createErrorResponse(config, error);
+				}
+
+				reportProgress(reporter, `Fetching options for "${parameterPath}" on node "${node.name}"`, {
+					nodeId,
+					parameterPath,
+					searchMethod,
+				});
+
+				// Call the resource locator callback with timeout
+				try {
+					const result = await Promise.race([
+						resourceLocatorCallback(
+							searchMethod,
+							`parameters.${parameterPath}`,
+							{ name: node.type, version: node.typeVersion },
+							node.parameters ?? {},
+							credentials,
+							filter,
+						),
+						new Promise<never>((_, reject) =>
+							setTimeout(() => reject(new Error('Request timed out')), DEFAULT_TIMEOUT_MS),
+						),
+					]);
+
+					const formattedOptions = formatOptionsForLLM(result.results, parameterPath);
+
+					reporter.complete({
+						parameterPath,
+						optionsCount: result.results.length,
+						hasPagination: !!result.paginationToken,
+					});
+
+					return createSuccessResponse(config, formattedOptions);
+				} catch (callbackError) {
+					const errorMessage =
+						callbackError instanceof Error
+							? callbackError.message
+							: 'Unknown error fetching options';
+
+					logger?.warn('Resource locator callback failed', {
+						nodeId,
+						parameterPath,
+						searchMethod,
+						error: errorMessage,
+					});
+
+					const error = new ToolExecutionError(
+						`Failed to fetch options for "${parameterPath}": ${errorMessage}`,
+						{
+							toolName: TOOL_NAME,
+							cause: callbackError instanceof Error ? callbackError : undefined,
+						},
+					);
+					reporter.error(error);
+					return createErrorResponse(config, error);
+				}
+			} catch (error) {
+				if (error instanceof z.ZodError) {
+					const validationError = new ValidationError('Invalid input parameters', {
+						extra: { errors: error.errors },
+					});
+					reporter.error(validationError);
+					return createErrorResponse(config, validationError);
+				}
+
+				const toolError = new ToolExecutionError(
+					error instanceof Error ? error.message : 'Unknown error occurred',
+					{
+						toolName: TOOL_NAME,
+						cause: error instanceof Error ? error : undefined,
+					},
+				);
+				reporter.error(toolError);
+				return createErrorResponse(config, toolError);
+			}
+		},
+		{
+			name: TOOL_NAME,
+			description:
+				'Fetch available options for a resource locator parameter. Use this when a node parameter requires selecting from a dynamic list (e.g., calendars, boards, models, channels). Returns the available options that can be used to configure the parameter.',
+			schema: getResourceLocatorOptionsSchema,
+		},
+	);
+
+	return {
+		tool: dynamicTool,
+		...GET_RESOURCE_LOCATOR_OPTIONS_TOOL,
+	};
+}

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/get-resource-locator-options.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/get-resource-locator-options.tool.ts
@@ -18,7 +18,7 @@ import {
 
 const TOOL_NAME = 'get_resource_locator_options';
 const DISPLAY_TITLE = 'Fetching resource options';
-const DEFAULT_TIMEOUT_MS = 30000;
+const DEFAULT_TIMEOUT_MS = 10000;
 
 /**
  * Schema for get resource locator options input

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/test/get-resource-locator-options.tool.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/test/get-resource-locator-options.tool.test.ts
@@ -1,0 +1,321 @@
+import { getCurrentTaskInput } from '@langchain/langgraph';
+import type { INodeTypeDescription } from 'n8n-workflow';
+
+import {
+	createWorkflow,
+	createNode,
+	nodeTypes,
+	parseToolResult,
+	createToolConfig,
+	setupWorkflowState,
+	expectToolError,
+	type ParsedToolContent,
+	createNodeTypeWithResourceLocator,
+	mockResourceLocatorCallback,
+	createResourceLocatorResults,
+} from '../../../test/test-utils';
+import type { ResourceLocatorCallback } from '../../types/callbacks';
+import {
+	createGetResourceLocatorOptionsTool,
+	GET_RESOURCE_LOCATOR_OPTIONS_TOOL,
+} from '../get-resource-locator-options.tool';
+
+jest.mock('@langchain/langgraph', () => ({
+	getCurrentTaskInput: jest.fn(),
+	Command: jest.fn().mockImplementation((params: Record<string, unknown>) => ({
+		content: JSON.stringify(params),
+	})),
+}));
+
+describe('getResourceLocatorOptions tool', () => {
+	const mockGetCurrentTaskInput = getCurrentTaskInput as jest.MockedFunction<
+		typeof getCurrentTaskInput
+	>;
+	let parsedNodeTypes: INodeTypeDescription[];
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		parsedNodeTypes = [
+			nodeTypes.code,
+			nodeTypes.httpRequest,
+			createNodeTypeWithResourceLocator(
+				'n8n-nodes-base.googleCalendar',
+				'calendarId',
+				'getCalendars',
+			),
+		];
+	});
+
+	it('should have correct tool metadata', () => {
+		expect(GET_RESOURCE_LOCATOR_OPTIONS_TOOL.toolName).toBe('get_resource_locator_options');
+		expect(GET_RESOURCE_LOCATOR_OPTIONS_TOOL.displayTitle).toBe('Fetching resource options');
+	});
+
+	describe('callback not provided', () => {
+		it('should return error when callback is not available', async () => {
+			const tool = createGetResourceLocatorOptionsTool(parsedNodeTypes, undefined).tool;
+			const workflow = createWorkflow([
+				createNode({
+					id: 'calendar1',
+					name: 'Google Calendar',
+					type: 'n8n-nodes-base.googleCalendar',
+					credentials: { googleCalendarOAuth2Api: { id: 'cred1', name: 'Google Calendar' } },
+				}),
+			]);
+
+			setupWorkflowState(mockGetCurrentTaskInput, workflow);
+			const config = createToolConfig('get_resource_locator_options', 'call-1');
+
+			const result = await tool.invoke(
+				{ nodeId: 'calendar1', parameterPath: 'calendarId' },
+				config,
+			);
+			const content = parseToolResult<ParsedToolContent>(result);
+
+			expectToolError(content, /Resource locator fetching is not available/);
+		});
+	});
+
+	describe('node validation', () => {
+		it('should return error when node is not found', async () => {
+			const mockCallback = mockResourceLocatorCallback();
+			const tool = createGetResourceLocatorOptionsTool(parsedNodeTypes, mockCallback).tool;
+			const workflow = createWorkflow([]);
+
+			setupWorkflowState(mockGetCurrentTaskInput, workflow);
+			const config = createToolConfig('get_resource_locator_options', 'call-2');
+
+			const result = await tool.invoke(
+				{ nodeId: 'nonexistent', parameterPath: 'calendarId' },
+				config,
+			);
+			const content = parseToolResult<ParsedToolContent>(result);
+
+			expectToolError(content, /not found/i);
+		});
+
+		it('should return error when node type is not found', async () => {
+			const mockCallback = mockResourceLocatorCallback();
+			const tool = createGetResourceLocatorOptionsTool(parsedNodeTypes, mockCallback).tool;
+			const workflow = createWorkflow([
+				createNode({
+					id: 'unknown1',
+					name: 'Unknown Node',
+					type: 'n8n-nodes-base.unknownNode',
+					credentials: { api: { id: 'cred1', name: 'API' } },
+				}),
+			]);
+
+			setupWorkflowState(mockGetCurrentTaskInput, workflow);
+			const config = createToolConfig('get_resource_locator_options', 'call-3');
+
+			const result = await tool.invoke({ nodeId: 'unknown1', parameterPath: 'calendarId' }, config);
+			const content = parseToolResult<ParsedToolContent>(result);
+
+			expectToolError(content, /Node type .* not found/i);
+		});
+	});
+
+	describe('credentials validation', () => {
+		it('should return error when node has no credentials', async () => {
+			const mockCallback = mockResourceLocatorCallback();
+			const tool = createGetResourceLocatorOptionsTool(parsedNodeTypes, mockCallback).tool;
+			const workflow = createWorkflow([
+				createNode({
+					id: 'calendar1',
+					name: 'Google Calendar',
+					type: 'n8n-nodes-base.googleCalendar',
+					// No credentials
+				}),
+			]);
+
+			setupWorkflowState(mockGetCurrentTaskInput, workflow);
+			const config = createToolConfig('get_resource_locator_options', 'call-4');
+
+			const result = await tool.invoke(
+				{ nodeId: 'calendar1', parameterPath: 'calendarId' },
+				config,
+			);
+			const content = parseToolResult<ParsedToolContent>(result);
+
+			expectToolError(content, /does not have credentials configured/i);
+		});
+	});
+
+	describe('parameter validation', () => {
+		it('should return error when parameter is not a resource locator', async () => {
+			const mockCallback = mockResourceLocatorCallback();
+			const tool = createGetResourceLocatorOptionsTool(parsedNodeTypes, mockCallback).tool;
+			const workflow = createWorkflow([
+				createNode({
+					id: 'http1',
+					name: 'HTTP Request',
+					type: 'n8n-nodes-base.httpRequest',
+					credentials: { httpBasicAuth: { id: 'cred1', name: 'HTTP Auth' } },
+				}),
+			]);
+
+			setupWorkflowState(mockGetCurrentTaskInput, workflow);
+			const config = createToolConfig('get_resource_locator_options', 'call-5');
+
+			const result = await tool.invoke({ nodeId: 'http1', parameterPath: 'url' }, config);
+			const content = parseToolResult<ParsedToolContent>(result);
+
+			expectToolError(content, /not a resource locator/i);
+		});
+	});
+
+	describe('successful fetch', () => {
+		it('should return formatted options when callback succeeds', async () => {
+			const mockResults = createResourceLocatorResults([
+				{ name: 'Primary Calendar', value: 'primary' },
+				{ name: 'Work Calendar', value: 'work@example.com' },
+			]);
+			const mockCallback = mockResourceLocatorCallback(mockResults);
+			const tool = createGetResourceLocatorOptionsTool(parsedNodeTypes, mockCallback).tool;
+			const workflow = createWorkflow([
+				createNode({
+					id: 'calendar1',
+					name: 'Google Calendar',
+					type: 'n8n-nodes-base.googleCalendar',
+					credentials: { googleCalendarOAuth2Api: { id: 'cred1', name: 'Google Calendar' } },
+				}),
+			]);
+
+			setupWorkflowState(mockGetCurrentTaskInput, workflow);
+			const config = createToolConfig('get_resource_locator_options', 'call-6');
+
+			const result = await tool.invoke(
+				{ nodeId: 'calendar1', parameterPath: 'calendarId' },
+				config,
+			);
+			const content = parseToolResult<ParsedToolContent>(result);
+			const message = content.update.messages[0]?.kwargs.content;
+
+			expect(message).toContain('<resource_locator_options');
+			expect(message).toContain('<display_name>Primary Calendar</display_name>');
+			expect(message).toContain('<id>primary</id>');
+			expect(message).toContain('<display_name>Work Calendar</display_name>');
+			expect(message).toContain('<total_count>2</total_count>');
+			expect(message).toContain('<instructions>');
+		});
+
+		it('should pass filter to callback when provided', async () => {
+			const mockResults = createResourceLocatorResults([
+				{ name: 'Filtered Calendar', value: 'filtered' },
+			]);
+			const mockCallback = mockResourceLocatorCallback(mockResults);
+			const tool = createGetResourceLocatorOptionsTool(parsedNodeTypes, mockCallback).tool;
+			const workflow = createWorkflow([
+				createNode({
+					id: 'calendar1',
+					name: 'Google Calendar',
+					type: 'n8n-nodes-base.googleCalendar',
+					credentials: { googleCalendarOAuth2Api: { id: 'cred1', name: 'Google Calendar' } },
+				}),
+			]);
+
+			setupWorkflowState(mockGetCurrentTaskInput, workflow);
+			const config = createToolConfig('get_resource_locator_options', 'call-7');
+
+			await tool.invoke(
+				{ nodeId: 'calendar1', parameterPath: 'calendarId', filter: 'work' },
+				config,
+			);
+
+			expect(mockCallback).toHaveBeenCalledWith(
+				'getCalendars',
+				'parameters.calendarId',
+				{ name: 'n8n-nodes-base.googleCalendar', version: 1 },
+				{},
+				{ googleCalendarOAuth2Api: { id: 'cred1', name: 'Google Calendar' } },
+				'work',
+			);
+		});
+
+		it('should handle empty results', async () => {
+			const mockResults = createResourceLocatorResults([]);
+			const mockCallback = mockResourceLocatorCallback(mockResults);
+			const tool = createGetResourceLocatorOptionsTool(parsedNodeTypes, mockCallback).tool;
+			const workflow = createWorkflow([
+				createNode({
+					id: 'calendar1',
+					name: 'Google Calendar',
+					type: 'n8n-nodes-base.googleCalendar',
+					credentials: { googleCalendarOAuth2Api: { id: 'cred1', name: 'Google Calendar' } },
+				}),
+			]);
+
+			setupWorkflowState(mockGetCurrentTaskInput, workflow);
+			const config = createToolConfig('get_resource_locator_options', 'call-8');
+
+			const result = await tool.invoke(
+				{ nodeId: 'calendar1', parameterPath: 'calendarId' },
+				config,
+			);
+			const content = parseToolResult<ParsedToolContent>(result);
+			const message = content.update.messages[0]?.kwargs.content;
+
+			expect(message).toContain('No options available');
+		});
+	});
+
+	describe('callback errors', () => {
+		it('should handle callback errors gracefully', async () => {
+			const mockCallback = jest
+				.fn()
+				.mockRejectedValue(
+					new Error('API rate limit exceeded'),
+				) as jest.MockedFunction<ResourceLocatorCallback>;
+			const tool = createGetResourceLocatorOptionsTool(parsedNodeTypes, mockCallback).tool;
+			const workflow = createWorkflow([
+				createNode({
+					id: 'calendar1',
+					name: 'Google Calendar',
+					type: 'n8n-nodes-base.googleCalendar',
+					credentials: { googleCalendarOAuth2Api: { id: 'cred1', name: 'Google Calendar' } },
+				}),
+			]);
+
+			setupWorkflowState(mockGetCurrentTaskInput, workflow);
+			const config = createToolConfig('get_resource_locator_options', 'call-9');
+
+			const result = await tool.invoke(
+				{ nodeId: 'calendar1', parameterPath: 'calendarId' },
+				config,
+			);
+			const content = parseToolResult<ParsedToolContent>(result);
+
+			expectToolError(content, /Failed to fetch options.*API rate limit exceeded/i);
+		});
+
+		it('should handle callback timeout', async () => {
+			const mockCallback = jest.fn().mockImplementation(
+				async () =>
+					await new Promise((_, reject) => {
+						setTimeout(() => reject(new Error('Request timed out')), 100);
+					}),
+			) as jest.MockedFunction<ResourceLocatorCallback>;
+			const tool = createGetResourceLocatorOptionsTool(parsedNodeTypes, mockCallback).tool;
+			const workflow = createWorkflow([
+				createNode({
+					id: 'calendar1',
+					name: 'Google Calendar',
+					type: 'n8n-nodes-base.googleCalendar',
+					credentials: { googleCalendarOAuth2Api: { id: 'cred1', name: 'Google Calendar' } },
+				}),
+			]);
+
+			setupWorkflowState(mockGetCurrentTaskInput, workflow);
+			const config = createToolConfig('get_resource_locator_options', 'call-10');
+
+			const result = await tool.invoke(
+				{ nodeId: 'calendar1', parameterPath: 'calendarId' },
+				config,
+			);
+			const content = parseToolResult<ParsedToolContent>(result);
+
+			expectToolError(content, /Failed to fetch options.*timed out/i);
+		});
+	});
+});

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/test/get-resource-locator-options.tool.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/test/get-resource-locator-options.tool.test.ts
@@ -15,10 +15,7 @@ import {
 	createResourceLocatorResults,
 } from '../../../test/test-utils';
 import type { ResourceLocatorCallback } from '../../types/callbacks';
-import {
-	createGetResourceLocatorOptionsTool,
-	GET_RESOURCE_LOCATOR_OPTIONS_TOOL,
-} from '../get-resource-locator-options.tool';
+import { createGetResourceLocatorOptionsTool } from '../get-resource-locator-options.tool';
 
 jest.mock('@langchain/langgraph', () => ({
 	getCurrentTaskInput: jest.fn(),
@@ -44,11 +41,6 @@ describe('getResourceLocatorOptions tool', () => {
 				'getCalendars',
 			),
 		];
-	});
-
-	it('should have correct tool metadata', () => {
-		expect(GET_RESOURCE_LOCATOR_OPTIONS_TOOL.toolName).toBe('get_resource_locator_options');
-		expect(GET_RESOURCE_LOCATOR_OPTIONS_TOOL.displayTitle).toBe('Fetching resource options');
 	});
 
 	describe('callback not provided', () => {

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/test/get-resource-locator-options.tool.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/test/get-resource-locator-options.tool.test.ts
@@ -197,7 +197,6 @@ describe('getResourceLocatorOptions tool', () => {
 			expect(message).toContain('<id>primary</id>');
 			expect(message).toContain('<display_name>Work Calendar</display_name>');
 			expect(message).toContain('<total_count>2</total_count>');
-			expect(message).toContain('<instructions>');
 		});
 
 		it('should pass filter to callback when provided', async () => {

--- a/packages/@n8n/ai-workflow-builder.ee/src/types/callbacks.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/types/callbacks.ts
@@ -1,0 +1,26 @@
+import type {
+	INodeCredentials,
+	INodeListSearchResult,
+	INodeParameters,
+	INodeTypeNameVersion,
+} from 'n8n-workflow';
+
+/**
+ * Callback type for fetching resource locator options.
+ * This callback is injected from the CLI package where DynamicNodeParametersService is available.
+ */
+export type ResourceLocatorCallback = (
+	methodName: string,
+	path: string,
+	nodeTypeAndVersion: INodeTypeNameVersion,
+	currentNodeParameters: INodeParameters,
+	credentials?: INodeCredentials,
+	filter?: string,
+	paginationToken?: string,
+) => Promise<INodeListSearchResult>;
+
+/**
+ * Factory type for creating resource locator callbacks.
+ * The factory is called with userId to create a callback scoped to that user's credentials context.
+ */
+export type ResourceLocatorCallbackFactory = (userId: string) => ResourceLocatorCallback;

--- a/packages/@n8n/ai-workflow-builder.ee/src/types/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/types/index.ts
@@ -1,5 +1,6 @@
 // Re-export all types from their respective modules
 
+export type * from './callbacks';
 export type * from './workflow';
 export type * from './messages';
 export type * from './tools';

--- a/packages/@n8n/ai-workflow-builder.ee/src/utils/rlc-prefetch.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/utils/rlc-prefetch.ts
@@ -111,11 +111,10 @@ export function detectRLCParametersForPrefetch(
 			continue; // Skip - can't fetch without required credentials
 		}
 
-		// Track if we've already found an RLC parameter for this node
-		// We only fetch the first (root) one to avoid dependent parameter issues
-		let foundRLCForNode = false;
-
 		// Check each property for resourceLocator type
+		// Only fetch the first (root) RLC parameter per node to avoid dependent parameter issues
+		// Dependent parameters (like sheetName depending on documentId) should be fetched
+		// by the agent after setting the root parameter
 		for (const property of nodeType.properties) {
 			if (property.type !== 'resourceLocator') continue;
 
@@ -136,12 +135,6 @@ export function detectRLCParametersForPrefetch(
 			const currentValue = node.parameters?.[property.name];
 			if (!isRLCValueEmpty(currentValue)) continue;
 
-			// Only add the first empty RLC parameter per node (the root one)
-			// Dependent parameters (like sheetName depending on documentId)
-			// should be fetched by the agent after setting the root parameter
-			if (foundRLCForNode) continue;
-			foundRLCForNode = true;
-
 			result.push({
 				nodeId: node.id,
 				nodeName: node.name,
@@ -150,6 +143,7 @@ export function detectRLCParametersForPrefetch(
 				parameterPath: property.name,
 				searchMethod,
 			});
+			break;
 		}
 	}
 

--- a/packages/@n8n/ai-workflow-builder.ee/src/utils/rlc-prefetch.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/utils/rlc-prefetch.ts
@@ -1,0 +1,271 @@
+/**
+ * Utility functions for pre-fetching ResourceLocator options before configuration.
+ * This allows the Configurator agent to have all necessary resource options upfront.
+ */
+
+import type { Logger } from '@n8n/backend-common';
+import type {
+	INode,
+	INodeTypeDescription,
+	INodePropertyMode,
+	INodeListSearchItems,
+} from 'n8n-workflow';
+
+import { findNodeType } from '../tools/helpers/validation';
+import type { ResourceLocatorCallback } from '../types/callbacks';
+
+/**
+ * Represents a ResourceLocator parameter that needs options to be fetched
+ */
+export interface RLCParameterInfo {
+	nodeId: string;
+	nodeName: string;
+	nodeType: string;
+	nodeTypeVersion: number;
+	parameterPath: string;
+	searchMethod: string;
+}
+
+/**
+ * Result of pre-fetching RLC options
+ */
+export interface RLCPrefetchResult {
+	nodeId: string;
+	nodeName: string;
+	parameterPath: string;
+	options: INodeListSearchItems[];
+	error?: string;
+}
+
+/**
+ * Check if a ResourceLocator value is empty/unset
+ */
+function isRLCValueEmpty(value: unknown): boolean {
+	if (!value) return true;
+	if (typeof value !== 'object') return false;
+
+	const rlcValue = value as { __rl?: boolean; value?: unknown };
+	if (!rlcValue.__rl) return false;
+
+	// Check if the value is empty
+	return !rlcValue.value || rlcValue.value === '';
+}
+
+/**
+ * Extract the searchListMethod from a resourceLocator property's modes
+ */
+function extractSearchMethod(nodeType: INodeTypeDescription, parameterPath: string): string | null {
+	const property = nodeType.properties.find(
+		(p) => p.name === parameterPath && p.type === 'resourceLocator',
+	);
+
+	if (!property?.modes) {
+		return null;
+	}
+
+	// Find a mode with type='list' that has searchListMethod
+	const listMode = property.modes.find(
+		(mode: INodePropertyMode) => mode.type === 'list' && mode.typeOptions?.searchListMethod,
+	);
+
+	return listMode?.typeOptions?.searchListMethod ?? null;
+}
+
+/**
+ * Check if a node type requires credentials to fetch RLC options
+ */
+function nodeTypeRequiresCredentials(nodeType: INodeTypeDescription): boolean {
+	return Array.isArray(nodeType.credentials) && nodeType.credentials.length > 0;
+}
+
+/**
+ * Check if a node has credentials configured
+ */
+function nodeHasCredentials(node: INode): boolean {
+	return !!node.credentials && Object.keys(node.credentials).length > 0;
+}
+
+/**
+ * Detect all required empty RLC parameters in the workflow that can be pre-fetched.
+ * Only fetches the first (root) RLC parameter per node to avoid fetching dependent
+ * parameters that require parent values to be set first.
+ */
+export function detectRLCParametersForPrefetch(
+	nodes: INode[],
+	nodeTypes: INodeTypeDescription[],
+): RLCParameterInfo[] {
+	const result: RLCParameterInfo[] = [];
+
+	for (const node of nodes) {
+		// Find the node type definition (handles array versions correctly)
+		const nodeType = findNodeType(node.type, node.typeVersion, nodeTypes);
+		if (!nodeType) continue;
+
+		// Check credentials requirements:
+		// - If node type requires credentials, only proceed if node has them configured
+		// - If node type doesn't require credentials (internal nodes like DataTable), proceed anyway
+		const requiresCredentials = nodeTypeRequiresCredentials(nodeType);
+		const hasCredentials = nodeHasCredentials(node);
+
+		if (requiresCredentials && !hasCredentials) {
+			continue; // Skip - can't fetch without required credentials
+		}
+
+		// Track if we've already found an RLC parameter for this node
+		// We only fetch the first (root) one to avoid dependent parameter issues
+		let foundRLCForNode = false;
+
+		// Check each property for resourceLocator type
+		for (const property of nodeType.properties) {
+			if (property.type !== 'resourceLocator') continue;
+
+			// Check if this RLC parameter has a list mode with searchListMethod
+			const searchMethod = extractSearchMethod(nodeType, property.name);
+			if (!searchMethod) continue;
+
+			// Check if the parameter is required
+			// Note: In n8n, "required" might not always be set, so we also check
+			// if the parameter appears to be a primary resource selector
+			const isRequired = property.required === true;
+			const isPrimaryResource =
+				property.name.toLowerCase().includes('id') ||
+				property.name.toLowerCase().includes('name') ||
+				property.name === 'resource';
+
+			if (!isRequired && !isPrimaryResource) continue;
+
+			// Check if the value is empty/unset
+			const currentValue = node.parameters?.[property.name];
+			if (!isRLCValueEmpty(currentValue)) continue;
+
+			// Only add the first empty RLC parameter per node (the root one)
+			// Dependent parameters (like sheetName depending on documentId)
+			// should be fetched by the agent after setting the root parameter
+			if (foundRLCForNode) continue;
+			foundRLCForNode = true;
+
+			result.push({
+				nodeId: node.id,
+				nodeName: node.name,
+				nodeType: node.type,
+				nodeTypeVersion: node.typeVersion,
+				parameterPath: property.name,
+				searchMethod,
+			});
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Pre-fetch RLC options for all detected parameters in parallel
+ */
+export async function prefetchRLCOptions(
+	parameters: RLCParameterInfo[],
+	nodes: INode[],
+	resourceLocatorCallback: ResourceLocatorCallback,
+	logger?: Logger,
+	timeoutMs = 15000,
+): Promise<RLCPrefetchResult[]> {
+	if (parameters.length === 0) {
+		return [];
+	}
+
+	const fetchPromises = parameters.map(async (param): Promise<RLCPrefetchResult> => {
+		const node = nodes.find((n) => n.id === param.nodeId);
+		if (!node) {
+			return {
+				nodeId: param.nodeId,
+				nodeName: param.nodeName,
+				parameterPath: param.parameterPath,
+				options: [],
+				error: 'Node not found',
+			};
+		}
+
+		try {
+			const result = await Promise.race([
+				resourceLocatorCallback(
+					param.searchMethod,
+					`parameters.${param.parameterPath}`,
+					{ name: param.nodeType, version: param.nodeTypeVersion },
+					node.parameters ?? {},
+					node.credentials,
+					undefined, // no filter
+				),
+				new Promise<never>((_, reject) =>
+					setTimeout(() => reject(new Error('Request timed out')), timeoutMs),
+				),
+			]);
+
+			return {
+				nodeId: param.nodeId,
+				nodeName: param.nodeName,
+				parameterPath: param.parameterPath,
+				options: result.results,
+			};
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+			logger?.warn('Failed to prefetch RLC options', {
+				nodeId: param.nodeId,
+				parameterPath: param.parameterPath,
+				error: errorMessage,
+			});
+
+			return {
+				nodeId: param.nodeId,
+				nodeName: param.nodeName,
+				parameterPath: param.parameterPath,
+				options: [],
+				error: errorMessage,
+			};
+		}
+	});
+
+	// Execute all fetches in parallel
+	return await Promise.all(fetchPromises);
+}
+
+/**
+ * Format pre-fetched RLC options for LLM consumption
+ */
+export function formatPrefetchedOptionsForLLM(results: RLCPrefetchResult[]): string {
+	if (results.length === 0) {
+		return '';
+	}
+
+	const successfulResults = results.filter((r) => !r.error && r.options.length > 0);
+	if (successfulResults.length === 0) {
+		return '';
+	}
+
+	const parts: string[] = ['=== PRE-FETCHED RESOURCE OPTIONS ==='];
+	parts.push(
+		'The following resource options have been pre-fetched for your convenience. Use these values when configuring the corresponding parameters:',
+	);
+	parts.push('');
+
+	for (const result of successfulResults) {
+		parts.push(`<resource_options node="${result.nodeName}" parameter="${result.parameterPath}">`);
+
+		for (const opt of result.options) {
+			parts.push('  <option>');
+			parts.push(`    <display_name>${opt.name}</display_name>`);
+			parts.push(`    <id>${String(opt.value)}</id>`);
+			if (opt.url) {
+				parts.push(`    <url>${opt.url}</url>`);
+			}
+			parts.push('  </option>');
+		}
+
+		parts.push('</resource_options>');
+		parts.push('');
+	}
+
+	parts.push(
+		'<note>Use the "id" value for the ResourceLocator "value" field, and optionally store the "display_name" in "cachedResultName".</note>',
+	);
+
+	return parts.join('\n');
+}

--- a/packages/@n8n/ai-workflow-builder.ee/src/utils/rlc-prefetch.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/utils/rlc-prefetch.ts
@@ -128,9 +128,7 @@ export function detectRLCParametersForPrefetch(
 			// if the parameter appears to be a primary resource selector
 			const isRequired = property.required === true;
 			const isPrimaryResource =
-				property.name.toLowerCase().includes('id') ||
-				property.name.toLowerCase().includes('name') ||
-				property.name === 'resource';
+				property.name.toLowerCase().includes('id') || property.name.toLowerCase().includes('name');
 
 			if (!isRequired && !isPrimaryResource) continue;
 

--- a/packages/@n8n/ai-workflow-builder.ee/src/utils/rlc-prefetch.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/utils/rlc-prefetch.ts
@@ -240,10 +240,7 @@ export function formatPrefetchedOptionsForLLM(results: RLCPrefetchResult[]): str
 		return '';
 	}
 
-	const parts: string[] = ['=== PRE-FETCHED RESOURCE OPTIONS ==='];
-	parts.push(
-		'The following resource options have been pre-fetched for your convenience. Use these values when configuring the corresponding parameters:',
-	);
+	const parts: string[] = ['=== PRE-FETCHED RESOURCE LOCATOR PARAMETERS OPTIONS ==='];
 	parts.push('');
 
 	for (const result of successfulResults) {
@@ -253,19 +250,11 @@ export function formatPrefetchedOptionsForLLM(results: RLCPrefetchResult[]): str
 			parts.push('  <option>');
 			parts.push(`    <display_name>${opt.name}</display_name>`);
 			parts.push(`    <id>${String(opt.value)}</id>`);
-			if (opt.url) {
-				parts.push(`    <url>${opt.url}</url>`);
-			}
 			parts.push('  </option>');
 		}
 
 		parts.push('</resource_options>');
-		parts.push('');
 	}
-
-	parts.push(
-		'<note>Use the "id" value for the ResourceLocator "value" field, and optionally store the "display_name" in "cachedResultName".</note>',
-	);
 
 	return parts.join('\n');
 }

--- a/packages/@n8n/ai-workflow-builder.ee/src/workflow-builder-agent.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/workflow-builder-agent.ts
@@ -20,6 +20,7 @@ import { MAX_AI_BUILDER_PROMPT_LENGTH, MAX_MULTI_AGENT_STREAM_ITERATIONS } from 
 import { ValidationError } from './errors';
 import { createMultiAgentWorkflowWithSubgraphs } from './multi-agent-workflow-subgraphs';
 import { SessionManagerService } from './session-manager.service';
+import type { ResourceLocatorCallback } from './types/callbacks';
 import type { SimpleWorkflow } from './types/workflow';
 import { createStreamProcessor, type StreamEvent } from './utils/stream-processor';
 import type { WorkflowState } from './workflow-state';
@@ -51,6 +52,8 @@ export interface WorkflowBuilderAgentConfig {
 	featureFlags?: BuilderFeatureFlags;
 	/** Callback when generation completes successfully (not aborted) */
 	onGenerationSuccess?: () => Promise<void>;
+	/** Callback for fetching resource locator options */
+	resourceLocatorCallback?: ResourceLocatorCallback;
 }
 
 export interface ExpressionValue {
@@ -87,6 +90,7 @@ export class WorkflowBuilderAgent {
 	private instanceUrl?: string;
 	private runMetadata?: Record<string, unknown>;
 	private onGenerationSuccess?: () => Promise<void>;
+	private resourceLocatorCallback?: ResourceLocatorCallback;
 
 	constructor(config: WorkflowBuilderAgentConfig) {
 		this.parsedNodeTypes = config.parsedNodeTypes;
@@ -98,6 +102,7 @@ export class WorkflowBuilderAgent {
 		this.instanceUrl = config.instanceUrl;
 		this.runMetadata = config.runMetadata;
 		this.onGenerationSuccess = config.onGenerationSuccess;
+		this.resourceLocatorCallback = config.resourceLocatorCallback;
 	}
 
 	/**
@@ -114,6 +119,7 @@ export class WorkflowBuilderAgent {
 			checkpointer: this.checkpointer,
 			featureFlags,
 			onGenerationSuccess: this.onGenerationSuccess,
+			resourceLocatorCallback: this.resourceLocatorCallback,
 		});
 	}
 

--- a/packages/@n8n/ai-workflow-builder.ee/test/test-utils.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/test/test-utils.ts
@@ -624,6 +624,7 @@ export const createNodeTypeWithResourceLocator = (
 	createNodeType({
 		name: nodeName,
 		displayName: overrides.displayName ?? 'Test Resource Node',
+		credentials: overrides.credentials ?? [{ name: 'testApi', required: true }],
 		properties: [
 			{
 				displayName: 'Resource',

--- a/packages/@n8n/ai-workflow-builder.ee/test/test-utils.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/test/test-utils.ts
@@ -9,11 +9,13 @@ import type {
 	INodeParameters,
 	IConnection,
 	NodeConnectionType,
+	INodeListSearchResult,
 } from 'n8n-workflow';
 import { jsonParse } from 'n8n-workflow';
 
 import type { ProgrammaticEvaluationResult } from '@/validation/types';
 
+import type { ResourceLocatorCallback } from '../src/types/callbacks';
 import type { ProgressReporter, ToolProgressMessage } from '../src/types/tools';
 import type { SimpleWorkflow } from '../src/types/workflow';
 
@@ -609,3 +611,63 @@ export const REASONING = {
 	TRIGGER_NODE: 'Trigger node, no connection parameters needed',
 	WEBHOOK_NODE: 'Webhook is a trigger node, no connection parameters needed',
 } as const;
+
+// ========== Resource Locator Testing Utilities ==========
+
+// Create a node type with resource locator property
+export const createNodeTypeWithResourceLocator = (
+	nodeName: string,
+	parameterName: string,
+	searchMethod: string,
+	overrides: Partial<INodeTypeDescription> = {},
+): INodeTypeDescription =>
+	createNodeType({
+		name: nodeName,
+		displayName: overrides.displayName ?? 'Test Resource Node',
+		properties: [
+			{
+				displayName: 'Resource',
+				name: parameterName,
+				type: 'resourceLocator',
+				default: { mode: 'list', value: '' },
+				modes: [
+					{
+						displayName: 'From List',
+						name: 'list',
+						type: 'list',
+						typeOptions: {
+							searchListMethod: searchMethod,
+							searchable: true,
+						},
+					},
+					{
+						displayName: 'By ID',
+						name: 'id',
+						type: 'string',
+					},
+				],
+			},
+			...(overrides.properties ?? []),
+		],
+		...overrides,
+	});
+
+// Create a mock resource locator callback
+export const mockResourceLocatorCallback = (
+	results: INodeListSearchResult = { results: [] },
+): jest.MockedFunction<ResourceLocatorCallback> => {
+	return jest.fn().mockResolvedValue(results);
+};
+
+// Create sample resource locator results
+export const createResourceLocatorResults = (
+	items: Array<{ name: string; value: string; description?: string }>,
+	paginationToken?: string,
+): INodeListSearchResult => ({
+	results: items.map((item) => ({
+		name: item.name,
+		value: item.value,
+		...(item.description && { description: item.description }),
+	})),
+	...(paginationToken && { paginationToken }),
+});

--- a/packages/cli/src/services/__tests__/ai-workflow-builder.service.test.ts
+++ b/packages/cli/src/services/__tests__/ai-workflow-builder.service.test.ts
@@ -9,6 +9,7 @@ import type { IUser, INodeTypeDescription, ITelemetryTrackProperties } from 'n8n
 import type { License } from '@/license';
 import type { Push } from '@/push';
 import { WorkflowBuilderService } from '@/services/ai-workflow-builder.service';
+import type { DynamicNodeParametersService } from '@/services/dynamic-node-parameters.service';
 import type { UrlService } from '@/services/url.service';
 import type { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 import type { Telemetry } from '@/telemetry';
@@ -32,6 +33,7 @@ describe('WorkflowBuilderService', () => {
 	let mockPush: Push;
 	let mockTelemetry: Telemetry;
 	let mockInstanceSettings: InstanceSettings;
+	let mockDynamicNodeParametersService: DynamicNodeParametersService;
 	let mockUser: IUser;
 
 	beforeEach(() => {
@@ -67,6 +69,7 @@ describe('WorkflowBuilderService', () => {
 		mockPush = mock<Push>();
 		mockTelemetry = mock<Telemetry>();
 		mockInstanceSettings = mock<InstanceSettings>();
+		mockDynamicNodeParametersService = mock<DynamicNodeParametersService>();
 		mockUser = mock<IUser>();
 		mockUser.id = 'test-user-id';
 
@@ -90,6 +93,7 @@ describe('WorkflowBuilderService', () => {
 			mockPush,
 			mockTelemetry,
 			mockInstanceSettings,
+			mockDynamicNodeParametersService,
 		);
 	});
 
@@ -127,6 +131,7 @@ describe('WorkflowBuilderService', () => {
 				expect.any(String), // n8nVersion
 				expect.any(Function), // onCreditsUpdated callback
 				expect.any(Function), // onTelemetryEvent callback
+				expect.any(Function), // resourceLocatorCallbackFactory
 			);
 
 			expect(result.value).toEqual({ messages: ['response'] });
@@ -169,6 +174,7 @@ describe('WorkflowBuilderService', () => {
 				expect.any(String), // n8nVersion
 				expect.any(Function), // onCreditsUpdated callback
 				expect.any(Function), // onTelemetryEvent callback
+				expect.any(Function), // resourceLocatorCallbackFactory
 			);
 		});
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
@@ -11,6 +11,7 @@ import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useBuilderStore } from '@/features/ai/assistant/builder.store';
 import { injectWorkflowState } from '@/app/composables/useWorkflowState';
 import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
+import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { canvasEventBus } from '@/features/workflows/canvas/canvas.eventBus';
 import { mapLegacyConnectionsToCanvasConnections } from '@/features/workflows/canvas/canvas.utils';
 import { getAuthTypeForNodeCredential, getMainAuthField } from '@/app/utils/nodeTypesUtils';
@@ -42,6 +43,7 @@ export function useWorkflowUpdate() {
 	const nodeTypesStore = useNodeTypesStore();
 	const builderStore = useBuilderStore();
 	const canvasOperations = useCanvasOperations();
+	const nodeHelpers = useNodeHelpers();
 
 	/**
 	 * Categorize nodes into those to update, add, or remove
@@ -123,6 +125,11 @@ export function useWorkflowUpdate() {
 		// Sync state back to store
 		workflowsStore.setNodes(Object.values(workflow.nodes));
 		workflowsStore.setConnections(workflow.connectionsBySourceNode);
+		// Revalidate updated nodes to refresh error indicators on canvas
+		for (const { existing } of nodesToUpdate) {
+			const nodeName = renamedNodes.get(existing.id) ?? existing.name;
+			nodeHelpers.updateNodeParameterIssuesByName(nodeName);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Adds a new tool and prefetch mechanism for Resource Locator Component (RLC) parameter options in the AI workflow builder configurator sub-agent.

### Changes:
- **New `get_resource_locator_options` tool**: Allows the configurator agent to fetch available options for RLC parameters (calendars, documents, boards, channels, etc.)
- **RLC prefetch mechanism**: Automatically prefetches RLC options before the configurator agent runs. Fetches options for required parameters that do not have value yet, for nodes with credentials already set up
- **Context integration**: Prefetched RLC options are formatted and injected into the configurator sub-agent's context message
- **Fixed node parameter validation after changes by AI Builder** – Re-validate node parameters after they were changed by AI-builder. This may happen when node had missing required parameter, that was set by AI builder on some iteration. Error icon on a node will now disappear automatically

### How it works:
1. Before the configurator agent runs, `prefetchRLCNode` detects empty RLC parameters that need options
2. Options are fetched in parallel for all detected parameters
3. Formatted options are appended to the first context message
4. The agent can use prefetched options or call `get_resource_locator_options` for additional parameters

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-1609

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)