### PR TITLE
feat(editor): Store n8n version in SQLite WASM and reinitialize nodeTypes on change (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/init.ts
+++ b/packages/frontend/editor-ui/src/app/init.ts
@@ -217,7 +217,7 @@ export async function initializeAuthenticatedFeatures(
 	// Initialize run data worker and load node types
 	if (window.localStorage.getItem(LOCAL_STORAGE_DATA_WORKER) === 'true') {
 		const coordinator = await import('@/app/workers');
-		await coordinator.initialize();
+		await coordinator.initialize({ version: settingsStore.settings.versionCli });
 		await coordinator.loadNodeTypes(rootStore.baseUrl);
 	}
 

--- a/packages/frontend/editor-ui/src/app/workers/coordinator/operations/loadNodeTypes.test.ts
+++ b/packages/frontend/editor-ui/src/app/workers/coordinator/operations/loadNodeTypes.test.ts
@@ -44,6 +44,7 @@ describe('Coordinator loadNodeTypes Operation', () => {
 			tabs: new Map(),
 			activeTabId: null,
 			initialized: false,
+			version: null,
 			...overrides,
 		};
 	}
@@ -64,7 +65,7 @@ describe('Coordinator loadNodeTypes Operation', () => {
 
 	describe('loadNodeTypes', () => {
 		it('should throw error when no active data worker is available', async () => {
-			const state = createMockState();
+			const state = createMockState({ version: '1.0.0' }); // Version required for ensureInitialized
 
 			await expect(loadNodeTypes(state, 'http://localhost:5678')).rejects.toThrow(
 				'[Coordinator] No active data worker available',
@@ -85,11 +86,12 @@ describe('Coordinator loadNodeTypes Operation', () => {
 		it('should ensure initialization before loading node types', async () => {
 			const state = createStateWithActiveTab();
 			state.initialized = false;
+			state.version = '1.0.0'; // Required for ensureInitialized
 			const worker = state.tabs.get('active-tab')?.dataWorker;
 
 			await loadNodeTypes(state, 'http://localhost:5678');
 
-			expect(worker?.initialize).toHaveBeenCalled();
+			expect(worker?.initialize).toHaveBeenCalledWith({ version: '1.0.0' });
 			expect(worker?.loadNodeTypes).toHaveBeenCalled();
 		});
 
@@ -149,6 +151,7 @@ describe('Coordinator loadNodeTypes Operation', () => {
 				initialize: vi.fn().mockRejectedValue(new Error('Initialization failed')),
 			});
 			state.initialized = false;
+			state.version = '1.0.0'; // Required for ensureInitialized
 
 			await expect(loadNodeTypes(state, 'http://localhost:5678')).rejects.toThrow(
 				'Initialization failed',
@@ -162,6 +165,7 @@ describe('Coordinator loadNodeTypes Operation', () => {
 				loadNodeTypes: loadNodeTypesFn,
 			});
 			state.initialized = false;
+			state.version = '1.0.0'; // Required for ensureInitialized
 
 			await expect(loadNodeTypes(state, 'http://localhost:5678')).rejects.toThrow();
 

--- a/packages/frontend/editor-ui/src/app/workers/coordinator/operations/storeVersion.ts
+++ b/packages/frontend/editor-ui/src/app/workers/coordinator/operations/storeVersion.ts
@@ -1,0 +1,31 @@
+/**
+ * Store Version Operation
+ *
+ * This module provides the operation for storing the n8n version
+ * through the coordinator to the active tab's data worker.
+ */
+
+import { withActiveWorker } from '../utils';
+
+/**
+ * Store the n8n version (routes to active tab's worker)
+ *
+ * @param worker - The active data worker
+ * @param state - The coordinator state
+ * @param version - The n8n version string
+ */
+export const storeVersion = withActiveWorker(async (worker, version: string) => {
+	console.log('[Coordinator] storeVersion:', version);
+	return await worker.storeVersion(version);
+});
+
+/**
+ * Get the stored n8n version (routes to active tab's worker)
+ *
+ * @param worker - The active data worker
+ * @param state - The coordinator state
+ */
+export const getStoredVersion = withActiveWorker(async (worker) => {
+	console.log('[Coordinator] getStoredVersion');
+	return await worker.getStoredVersion();
+});

--- a/packages/frontend/editor-ui/src/app/workers/coordinator/operations/storeVersion.ts
+++ b/packages/frontend/editor-ui/src/app/workers/coordinator/operations/storeVersion.ts
@@ -10,7 +10,6 @@ import { withActiveWorker } from '../utils';
 /**
  * Store the n8n version (routes to active tab's worker)
  *
- * @param worker - The active data worker
  * @param state - The coordinator state
  * @param version - The n8n version string
  */
@@ -22,8 +21,8 @@ export const storeVersion = withActiveWorker(async (worker, version: string) => 
 /**
  * Get the stored n8n version (routes to active tab's worker)
  *
- * @param worker - The active data worker
  * @param state - The coordinator state
+ * @returns The stored version string or null if not found
  */
 export const getStoredVersion = withActiveWorker(async (worker) => {
 	console.log('[Coordinator] getStoredVersion');

--- a/packages/frontend/editor-ui/src/app/workers/coordinator/tabs.test.ts
+++ b/packages/frontend/editor-ui/src/app/workers/coordinator/tabs.test.ts
@@ -38,6 +38,7 @@ describe('Coordinator Tab Operations', () => {
 			tabs: new Map(),
 			activeTabId: null,
 			initialized: false,
+			version: null,
 			...overrides,
 		};
 	}
@@ -164,7 +165,7 @@ describe('Coordinator Tab Operations', () => {
 			const tabWithWorker = createMockTabConnection({
 				id: 'tab-with-worker',
 			});
-			const state = createMockState();
+			const state = createMockState({ version: '1.0.0' }); // Version required for initialization
 			state.tabs.set('tab-no-worker', tabWithoutWorker);
 			state.tabs.set('tab-with-worker', tabWithWorker);
 
@@ -180,19 +181,19 @@ describe('Coordinator Tab Operations', () => {
 				id: 'tab-1',
 				dataWorker: mockDataWorker,
 			});
-			const state = createMockState();
+			const state = createMockState({ version: '1.0.0' }); // Version required for initialization
 			state.tabs.set('tab-1', tabConnection);
 
 			await selectNewActiveTab(state);
 
 			expect(state.activeTabId).toBe('tab-1');
 			expect(tabConnection.isActive).toBe(true);
-			expect(mockDataWorker.initialize).toHaveBeenCalled();
+			expect(mockDataWorker.initialize).toHaveBeenCalledWith({ version: '1.0.0' });
 		});
 
 		it('should set initialized to true after successful initialization', async () => {
 			const tabConnection = createMockTabConnection({ id: 'tab-1' });
-			const state = createMockState({ initialized: false });
+			const state = createMockState({ initialized: false, version: '1.0.0' }); // Version required for initialization
 			state.tabs.set('tab-1', tabConnection);
 
 			await selectNewActiveTab(state);
@@ -215,7 +216,7 @@ describe('Coordinator Tab Operations', () => {
 				dataWorker: successWorker,
 			});
 
-			const state = createMockState();
+			const state = createMockState({ version: '1.0.0' }); // Version required for initialization
 			state.tabs.set('tab-failing', failingTab);
 			state.tabs.set('tab-success', successTab);
 
@@ -236,7 +237,7 @@ describe('Coordinator Tab Operations', () => {
 				dataWorker: failingWorker,
 			});
 
-			const state = createMockState({ initialized: true });
+			const state = createMockState({ initialized: true, version: '1.0.0' }); // Version required for initialization
 			state.tabs.set('tab-failing', failingTab);
 
 			await selectNewActiveTab(state);
@@ -297,6 +298,7 @@ describe('Coordinator Tab Operations', () => {
 			const state = createMockState({
 				activeTabId: 'tab-1',
 				initialized: true,
+				version: '1.0.0', // Version required for initialization
 			});
 			state.tabs.set('tab-1', tab1);
 			state.tabs.set('tab-2', tab2);

--- a/packages/frontend/editor-ui/src/app/workers/coordinator/tabs.ts
+++ b/packages/frontend/editor-ui/src/app/workers/coordinator/tabs.ts
@@ -60,7 +60,10 @@ export async function selectNewActiveTab(state: CoordinatorState): Promise<void>
 
 			// Initialize the new active tab's data worker
 			try {
-				await tab.dataWorker.initialize();
+				if (!state.version) {
+					throw new Error('[Coordinator] Cannot initialize without version');
+				}
+				await tab.dataWorker.initialize({ version: state.version });
 				state.initialized = true;
 				console.log(`[Coordinator] New active tab ${tabId} initialized`);
 			} catch (error) {

--- a/packages/frontend/editor-ui/src/app/workers/coordinator/types.ts
+++ b/packages/frontend/editor-ui/src/app/workers/coordinator/types.ts
@@ -26,6 +26,7 @@ export interface CoordinatorState {
 	tabs: Map<string, TabConnection>;
 	activeTabId: string | null;
 	initialized: boolean;
+	version: string | null;
 }
 
 /**

--- a/packages/frontend/editor-ui/src/app/workers/coordinator/worker.ts
+++ b/packages/frontend/editor-ui/src/app/workers/coordinator/worker.ts
@@ -32,12 +32,17 @@ import {
 	getTabCount as getTabCountOp,
 } from './operations/query';
 import { loadNodeTypes as loadNodeTypesOp } from './operations/loadNodeTypes';
+import {
+	storeVersion as storeVersionOp,
+	getStoredVersion as getStoredVersionOp,
+} from './operations/storeVersion';
 import { initialize as initializeOp } from './initialize';
 
 const state: CoordinatorState = {
 	tabs: new Map(),
 	activeTabId: null,
 	initialized: false,
+	version: null,
 };
 
 // ============================================================================
@@ -61,9 +66,11 @@ const coordinatorApi = {
 
 	/**
 	 * Initialize the database (routes to active tab's worker)
+	 *
+	 * @param options.version - The current n8n version from settings
 	 */
-	async initialize(): Promise<void> {
-		await initializeOp(state);
+	async initialize({ version }: { version: string }): Promise<void> {
+		await initializeOp(state, { version });
 	},
 
 	/**
@@ -113,6 +120,20 @@ const coordinatorApi = {
 	 */
 	async loadNodeTypes(baseUrl: string): Promise<void> {
 		await loadNodeTypesOp(state, baseUrl);
+	},
+
+	/**
+	 * Store the n8n version (routes to active tab's worker)
+	 */
+	async storeVersion(version: string): Promise<void> {
+		await storeVersionOp(state, version);
+	},
+
+	/**
+	 * Get the stored n8n version (routes to active tab's worker)
+	 */
+	async getStoredVersion(): Promise<string | null> {
+		return await getStoredVersionOp(state);
 	},
 };
 

--- a/packages/frontend/editor-ui/src/app/workers/data/db.test.ts
+++ b/packages/frontend/editor-ui/src/app/workers/data/db.test.ts
@@ -7,8 +7,12 @@ describe('Data Worker Database Schema', () => {
 			expect(databaseSchema.tables).toHaveProperty('nodeTypes');
 		});
 
-		it('should have exactly 1 table', () => {
-			expect(Object.keys(databaseSchema.tables)).toHaveLength(1);
+		it('should have exactly 2 tables', () => {
+			expect(Object.keys(databaseSchema.tables)).toHaveLength(2);
+		});
+
+		it('should have metadata table defined', () => {
+			expect(databaseSchema.tables).toHaveProperty('metadata');
 		});
 
 		describe('nodeTypes table', () => {
@@ -37,9 +41,9 @@ describe('Data Worker Database Schema', () => {
 			expect(Array.isArray(schemas)).toBe(true);
 		});
 
-		it('should return 1 schema (one for each table)', () => {
+		it('should return 2 schemas (one for each table)', () => {
 			const schemas = getAllTableSchemas();
-			expect(schemas).toHaveLength(1);
+			expect(schemas).toHaveLength(2);
 		});
 
 		it('should return strings containing CREATE TABLE statements', () => {

--- a/packages/frontend/editor-ui/src/app/workers/data/db.ts
+++ b/packages/frontend/editor-ui/src/app/workers/data/db.ts
@@ -32,6 +32,16 @@ export const databaseSchema: DatabaseSchema = {
 				);
 			`,
 		},
+		metadata: {
+			name: 'metadata',
+			schema: `
+				CREATE TABLE IF NOT EXISTS metadata (
+					key TEXT PRIMARY KEY,
+					value TEXT NOT NULL,
+					updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+				);
+			`,
+		},
 	},
 } as const;
 

--- a/packages/frontend/editor-ui/src/app/workers/data/operations/loadNodeTypes.test.ts
+++ b/packages/frontend/editor-ui/src/app/workers/data/operations/loadNodeTypes.test.ts
@@ -173,18 +173,18 @@ describe('Data Worker loadNodeTypes Operations', () => {
 				// Should insert for each version with parameterized queries
 				expect(execWithParams).toHaveBeenCalledWith(
 					state,
-					'INSERT OR REPLACE INTO nodeTypes (id, data, updated_at) VALUES (?, ?, datetime(?))',
-					['n8n-nodes-base.multiVersion@1', expect.any(String), 'now'],
+					"INSERT OR REPLACE INTO nodeTypes (id, data, updated_at) VALUES (?, ?, datetime('now'))",
+					['n8n-nodes-base.multiVersion@1', expect.any(String)],
 				);
 				expect(execWithParams).toHaveBeenCalledWith(
 					state,
-					'INSERT OR REPLACE INTO nodeTypes (id, data, updated_at) VALUES (?, ?, datetime(?))',
-					['n8n-nodes-base.multiVersion@2', expect.any(String), 'now'],
+					"INSERT OR REPLACE INTO nodeTypes (id, data, updated_at) VALUES (?, ?, datetime('now'))",
+					['n8n-nodes-base.multiVersion@2', expect.any(String)],
 				);
 				expect(execWithParams).toHaveBeenCalledWith(
 					state,
-					'INSERT OR REPLACE INTO nodeTypes (id, data, updated_at) VALUES (?, ?, datetime(?))',
-					['n8n-nodes-base.multiVersion@3', expect.any(String), 'now'],
+					"INSERT OR REPLACE INTO nodeTypes (id, data, updated_at) VALUES (?, ?, datetime('now'))",
+					['n8n-nodes-base.multiVersion@3', expect.any(String)],
 				);
 			});
 
@@ -207,8 +207,8 @@ describe('Data Worker loadNodeTypes Operations', () => {
 				// With parameterized queries, single quotes are handled by the database driver
 				expect(execWithParams).toHaveBeenCalledWith(
 					state,
-					'INSERT OR REPLACE INTO nodeTypes (id, data, updated_at) VALUES (?, ?, datetime(?))',
-					['n8n-nodes-base.test@1', expect.stringContaining("It's a test node"), 'now'],
+					"INSERT OR REPLACE INTO nodeTypes (id, data, updated_at) VALUES (?, ?, datetime('now'))",
+					['n8n-nodes-base.test@1', expect.stringContaining("It's a test node")],
 				);
 			});
 		});

--- a/packages/frontend/editor-ui/src/app/workers/data/operations/loadNodeTypes.test.ts
+++ b/packages/frontend/editor-ui/src/app/workers/data/operations/loadNodeTypes.test.ts
@@ -62,6 +62,7 @@ describe('Data Worker loadNodeTypes Operations', () => {
 			db: 1,
 			vfs: null,
 			initPromise: null,
+			version: null,
 			...overrides,
 		};
 	}

--- a/packages/frontend/editor-ui/src/app/workers/data/operations/loadNodeTypes.ts
+++ b/packages/frontend/editor-ui/src/app/workers/data/operations/loadNodeTypes.ts
@@ -71,8 +71,8 @@ async function upsertNodeType(
 ): Promise<void> {
 	await execWithParams(
 		state,
-		'INSERT OR REPLACE INTO nodeTypes (id, data, updated_at) VALUES (?, ?, datetime(?))',
-		[id, JSON.stringify(nodeType), 'now'],
+		"INSERT OR REPLACE INTO nodeTypes (id, data, updated_at) VALUES (?, ?, datetime('now'))",
+		[id, JSON.stringify(nodeType)],
 	);
 }
 

--- a/packages/frontend/editor-ui/src/app/workers/data/operations/loadNodeTypes.ts
+++ b/packages/frontend/editor-ui/src/app/workers/data/operations/loadNodeTypes.ts
@@ -16,7 +16,7 @@ import {
 import type { INodeTypeDescription } from 'n8n-workflow';
 import { jsonParse } from 'n8n-workflow';
 import type { DataWorkerState } from '../types';
-import { exec, execWithParams, query, withTrx } from './query';
+import { exec, execWithParams, query, queryWithParams, withTrx } from './query';
 import { getStoredVersion, storeVersion } from './storeVersion';
 
 /**
@@ -220,7 +220,7 @@ export async function getNodeType(
 	version: number,
 ): Promise<INodeTypeDescription | null> {
 	const id = getNodeTypeId(name, version);
-	const result = await query(state, `SELECT data FROM nodeTypes WHERE id = '${id}'`);
+	const result = await queryWithParams(state, 'SELECT data FROM nodeTypes WHERE id = ?', [id]);
 
 	if (result.rows.length === 0) {
 		return null;

--- a/packages/frontend/editor-ui/src/app/workers/data/operations/storeVersion.ts
+++ b/packages/frontend/editor-ui/src/app/workers/data/operations/storeVersion.ts
@@ -1,0 +1,55 @@
+/**
+ * Store Version Operation
+ *
+ * This module handles storing and retrieving the n8n version
+ * in the local SQLite database metadata table.
+ */
+
+import type { DataWorkerState } from '../types';
+import { execWithParams, queryWithParams } from './query';
+
+const VERSION_KEY = 'version';
+
+/**
+ * Store the n8n version in the database
+ *
+ * @param state - The data worker state
+ * @param version - The n8n version string (e.g., "1.75.0")
+ */
+export async function storeVersion(state: DataWorkerState, version: string): Promise<void> {
+	console.log('[DataWorker] storeVersion:', version);
+
+	if (!state.initialized) {
+		throw new Error('[DataWorker] Database not initialized');
+	}
+
+	await execWithParams(
+		state,
+		'INSERT OR REPLACE INTO metadata (key, value, updated_at) VALUES (?, ?, datetime("now"))',
+		[VERSION_KEY, version],
+	);
+
+	console.log('[DataWorker] Version stored successfully');
+}
+
+/**
+ * Get the stored n8n version from the database
+ *
+ * @param state - The data worker state
+ * @returns The stored version string or null if not found
+ */
+export async function getStoredVersion(state: DataWorkerState): Promise<string | null> {
+	if (!state.initialized) {
+		throw new Error('[DataWorker] Database not initialized');
+	}
+
+	const result = await queryWithParams(state, 'SELECT value FROM metadata WHERE key = ?', [
+		VERSION_KEY,
+	]);
+
+	if (result.rows.length === 0) {
+		return null;
+	}
+
+	return result.rows[0][0] as string;
+}

--- a/packages/frontend/editor-ui/src/app/workers/data/operations/storeVersion.ts
+++ b/packages/frontend/editor-ui/src/app/workers/data/operations/storeVersion.ts
@@ -25,7 +25,7 @@ export async function storeVersion(state: DataWorkerState, version: string): Pro
 
 	await execWithParams(
 		state,
-		'INSERT OR REPLACE INTO metadata (key, value, updated_at) VALUES (?, ?, datetime("now"))',
+		"INSERT OR REPLACE INTO metadata (key, value, updated_at) VALUES (?, ?, datetime('now'))",
 		[VERSION_KEY, version],
 	);
 

--- a/packages/frontend/editor-ui/src/app/workers/data/types.ts
+++ b/packages/frontend/editor-ui/src/app/workers/data/types.ts
@@ -48,6 +48,7 @@ export interface DataWorkerState {
 	db: number | null;
 	vfs: AccessHandlePoolVFS | null;
 	initPromise: Promise<void> | null;
+	version: string | null;
 }
 
 /**
@@ -66,5 +67,11 @@ export interface QueryResult {
 export interface NodeTypeRow {
 	id: string;
 	data: string;
+	updated_at: string;
+}
+
+export interface MetadataRow {
+	key: string;
+	value: string;
 	updated_at: string;
 }

--- a/packages/frontend/editor-ui/src/app/workers/data/types.ts
+++ b/packages/frontend/editor-ui/src/app/workers/data/types.ts
@@ -69,9 +69,3 @@ export interface NodeTypeRow {
 	data: string;
 	updated_at: string;
 }
-
-export interface MetadataRow {
-	key: string;
-	value: string;
-	updated_at: string;
-}

--- a/packages/frontend/editor-ui/src/app/workers/data/worker.ts
+++ b/packages/frontend/editor-ui/src/app/workers/data/worker.ts
@@ -26,6 +26,10 @@ import {
 	queryWithParams as queryWithParamsOp,
 	close as closeOp,
 } from './operations/query';
+import {
+	storeVersion as storeVersionOp,
+	getStoredVersion as getStoredVersionOp,
+} from './operations/storeVersion';
 import type { DataWorkerState, QueryResult, SQLiteAPI, SQLiteParam } from './types';
 
 export type { DataWorkerState, QueryResult, SQLiteAPI, SQLiteParam } from './types';
@@ -36,6 +40,7 @@ const state: DataWorkerState = {
 	db: null,
 	vfs: null,
 	initPromise: null,
+	version: null,
 };
 
 const DB_NAME = 'n8n';
@@ -80,8 +85,10 @@ function databaseAlreadyExists(): boolean {
 
 /**
  * Initialize the SQLite database with OPFS persistence
+ *
+ * @param options.version - The current n8n version from settings
  */
-async function initialize(): Promise<void> {
+async function initialize({ version }: { version: string }): Promise<void> {
 	// Return cached promise if initialization is already in progress
 	if (state.initPromise) {
 		return await state.initPromise;
@@ -144,6 +151,26 @@ async function initialize(): Promise<void> {
 		}
 
 		state.initialized = true;
+
+		// Check stored version and handle version changes
+		const storedVersion = await getStoredVersionOp(state);
+		console.log('[DataWorker] Stored version:', storedVersion);
+		console.log('[DataWorker] Current version:', version);
+
+		if (storedVersion !== null && storedVersion !== version) {
+			console.log(
+				`[DataWorker] Version changed: ${storedVersion} -> ${version}, clearing node types`,
+			);
+			await state.sqlite3.exec(state.db, 'DELETE FROM nodeTypes');
+			console.log('[DataWorker] Node types cleared');
+		}
+
+		// Update stored version if different
+		if (storedVersion !== version) {
+			await storeVersionOp(state, version);
+		}
+
+		state.version = version;
 	})();
 
 	try {
@@ -199,6 +226,20 @@ async function loadNodeTypes(baseUrl: string): Promise<void> {
 	await loadNodeTypesOp(state, baseUrl);
 }
 
+/**
+ * Store the n8n version in the database
+ */
+async function storeVersion(version: string): Promise<void> {
+	await storeVersionOp(state, version);
+}
+
+/**
+ * Get the stored n8n version from the database
+ */
+async function getStoredVersion(): Promise<string | null> {
+	return await getStoredVersionOp(state);
+}
+
 // Export the worker API
 export const dataWorkerApi = {
 	initialize,
@@ -208,6 +249,8 @@ export const dataWorkerApi = {
 	close,
 	isInitialized,
 	loadNodeTypes,
+	storeVersion,
+	getStoredVersion,
 };
 
 export type DataWorkerApi = typeof dataWorkerApi;

--- a/packages/frontend/editor-ui/src/app/workers/data/worker.ts
+++ b/packages/frontend/editor-ui/src/app/workers/data/worker.ts
@@ -151,25 +151,6 @@ async function initialize({ version }: { version: string }): Promise<void> {
 		}
 
 		state.initialized = true;
-
-		// Check stored version and handle version changes
-		const storedVersion = await getStoredVersionOp(state);
-		console.log('[DataWorker] Stored version:', storedVersion);
-		console.log('[DataWorker] Current version:', version);
-
-		if (storedVersion !== null && storedVersion !== version) {
-			console.log(
-				`[DataWorker] Version changed: ${storedVersion} -> ${version}, clearing node types`,
-			);
-			await state.sqlite3.exec(state.db, 'DELETE FROM nodeTypes');
-			console.log('[DataWorker] Node types cleared');
-		}
-
-		// Update stored version if different
-		if (storedVersion !== version) {
-			await storeVersionOp(state, version);
-		}
-
 		state.version = version;
 	})();
 

--- a/packages/frontend/editor-ui/src/app/workers/index.ts
+++ b/packages/frontend/editor-ui/src/app/workers/index.ts
@@ -23,10 +23,12 @@ async function ensureRegistered(): Promise<void> {
 /**
  * Initialize the database
  * This will route to the active tab's data worker
+ *
+ * @param options.version - The current n8n version from settings
  */
-export async function initialize(): Promise<void> {
+export async function initialize({ version }: { version: string }): Promise<void> {
 	await ensureRegistered();
-	await coordinator.initialize();
+	await coordinator.initialize({ version });
 }
 
 /**
@@ -69,4 +71,20 @@ export async function isInitialized(): Promise<boolean> {
 export async function loadNodeTypes(baseUrl: string): Promise<void> {
 	await ensureRegistered();
 	await coordinator.loadNodeTypes(baseUrl);
+}
+
+/**
+ * Store the n8n version in the database
+ */
+export async function storeVersion(version: string): Promise<void> {
+	await ensureRegistered();
+	await coordinator.storeVersion(version);
+}
+
+/**
+ * Get the stored n8n version from the database
+ */
+export async function getStoredVersion(): Promise<string | null> {
+	await ensureRegistered();
+	return await coordinator.getStoredVersion();
 }


### PR DESCRIPTION
## Summary

This pull request improves the initialization process for the coordinator and its interaction with data workers by requiring the n8n version to be explicitly provided and stored. It also introduces new operations for storing and retrieving the n8n version via the coordinator. The changes ensure that initialization is more robust and version-aware, and all relevant tests have been updated to reflect this new requirement.

Key changes include:

**Coordinator Initialization and Version Handling**
- The `initialize` and `ensureInitialized` functions for the coordinator now require and store the n8n version, throwing an error if the version is missing. This ensures consistent versioning across worker operations and prevents accidental initialization without version context. [[1]](diffhunk://#diff-bfd6b5d5c76d6e33a453b69eb41081274fe73d35a5b51d238c82ea2d5e1ea002R7-R19) [[2]](diffhunk://#diff-bfd6b5d5c76d6e33a453b69eb41081274fe73d35a5b51d238c82ea2d5e1ea002R31-R48) [[3]](diffhunk://#diff-3d48c16a85e832cb680b5279608b7f514a72667e2a3e1c21ce828624220b1888L220-R220)
- All coordinator operations and tests have been updated to provide the version parameter where necessary, and to expect the worker's `initialize` method to be called with the version. [[1]](diffhunk://#diff-0d1051267d00e42a2b1a0fd708bb019b0e5cd40ac06bc0d91b57441aba3b07f1R47) [[2]](diffhunk://#diff-0d1051267d00e42a2b1a0fd708bb019b0e5cd40ac06bc0d91b57441aba3b07f1L67-R68) [[3]](diffhunk://#diff-0d1051267d00e42a2b1a0fd708bb019b0e5cd40ac06bc0d91b57441aba3b07f1R89-R94) [[4]](diffhunk://#diff-0d1051267d00e42a2b1a0fd708bb019b0e5cd40ac06bc0d91b57441aba3b07f1R154) [[5]](diffhunk://#diff-0d1051267d00e42a2b1a0fd708bb019b0e5cd40ac06bc0d91b57441aba3b07f1R168) [[6]](diffhunk://#diff-c21abf5e88a6447d6b7de10dad0406174e63ff98622d0502a0bb582d15457ef6R56) [[7]](diffhunk://#diff-c21abf5e88a6447d6b7de10dad0406174e63ff98622d0502a0bb582d15457ef6R79-R84) [[8]](diffhunk://#diff-c21abf5e88a6447d6b7de10dad0406174e63ff98622d0502a0bb582d15457ef6R102-R157) [[9]](diffhunk://#diff-c21abf5e88a6447d6b7de10dad0406174e63ff98622d0502a0bb582d15457ef6L149-R171) [[10]](diffhunk://#diff-c21abf5e88a6447d6b7de10dad0406174e63ff98622d0502a0bb582d15457ef6L163-R184) [[11]](diffhunk://#diff-c21abf5e88a6447d6b7de10dad0406174e63ff98622d0502a0bb582d15457ef6L172-R193) [[12]](diffhunk://#diff-c21abf5e88a6447d6b7de10dad0406174e63ff98622d0502a0bb582d15457ef6R214-R219) [[13]](diffhunk://#diff-c21abf5e88a6447d6b7de10dad0406174e63ff98622d0502a0bb582d15457ef6L230-R256) [[14]](diffhunk://#diff-c21abf5e88a6447d6b7de10dad0406174e63ff98622d0502a0bb582d15457ef6L244-R270) [[15]](diffhunk://#diff-c21abf5e88a6447d6b7de10dad0406174e63ff98622d0502a0bb582d15457ef6R309-R314) [[16]](diffhunk://#diff-c21abf5e88a6447d6b7de10dad0406174e63ff98622d0502a0bb582d15457ef6L303-R330) [[17]](diffhunk://#diff-c21abf5e88a6447d6b7de10dad0406174e63ff98622d0502a0bb582d15457ef6R391-R396) [[18]](diffhunk://#diff-18efa5b7a30b2f3b5fa2cb37cdbff8f5e7edc2112df61825c99f40173822aabbR41) [[19]](diffhunk://#diff-18efa5b7a30b2f3b5fa2cb37cdbff8f5e7edc2112df61825c99f40173822aabbL167-R168) [[20]](diffhunk://#diff-18efa5b7a30b2f3b5fa2cb37cdbff8f5e7edc2112df61825c99f40173822aabbL183-R196) [[21]](diffhunk://#diff-18efa5b7a30b2f3b5fa2cb37cdbff8f5e7edc2112df61825c99f40173822aabbL218-R219) [[22]](diffhunk://#diff-18efa5b7a30b2f3b5fa2cb37cdbff8f5e7edc2112df61825c99f40173822aabbL239-R240) [[23]](diffhunk://#diff-18efa5b7a30b2f3b5fa2cb37cdbff8f5e7edc2112df61825c99f40173822aabbR301)

**New Operations for Version Storage**
- Added `storeVersion` and `getStoredVersion` operations to the coordinator, allowing the active data worker to store and retrieve the n8n version, which can be useful for version checks and migrations.

**Test Suite Updates**
- All affected test files have been updated to mock and verify the new version-aware initialization logic, ensuring that the version requirement is enforced and that initialization behaves correctly in all scenarios. [[1]](diffhunk://#diff-0d1051267d00e42a2b1a0fd708bb019b0e5cd40ac06bc0d91b57441aba3b07f1R47) [[2]](diffhunk://#diff-c21abf5e88a6447d6b7de10dad0406174e63ff98622d0502a0bb582d15457ef6R56) [[3]](diffhunk://#diff-18efa5b7a30b2f3b5fa2cb37cdbff8f5e7edc2112df61825c99f40173822aabbR41)

These changes make the coordinator more robust, enforce version consistency, and provide new utilities for version management.

## Related Linear tickets, Github issues, and Community forum posts

Continuation of #24308
https://linear.app/n8n/issue/CAT-2153/reload-nodetypes-when-n8n-version-changes

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] Tests included and passing
- [x] Code follows existing patterns