### PR TITLE
fix(editor): Prevent connection lines from overlapping plus handle bu…

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/render-types/CanvasHandleNonMainInput.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/render-types/CanvasHandleNonMainInput.vue
@@ -28,6 +28,8 @@ const isHandlePlusAvailable = computed(
 	() => !isConnected.value || !maxConnections.value || maxConnections.value > 1,
 );
 
+const isHovered = ref(false);
+
 const isHandlePlusVisible = computed(
 	() => !isConnecting.value || isHovered.value || !maxConnections.value || maxConnections.value > 1,
 );
@@ -38,8 +40,6 @@ const handleStyles = computed(() => ({
 	'--handle--border--lightness--light': handleLightness.value.light,
 	'--handle--border--lightness--dark': handleLightness.value.dark,
 }));
-
-const isHovered = ref(false);
 
 function onMouseEnter() {
 	isHovered.value = true;

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/render-types/parts/CanvasHandlePlus.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/render-types/parts/CanvasHandlePlus.test.ts
@@ -40,7 +40,8 @@ describe('CanvasHandlePlus', () => {
 			const { container } = renderComponent({
 				props: { position },
 			});
-			expect(container.firstChild).toHaveClass(position);
+			const wrapper = container.querySelector('[data-test-id="canvas-handle-plus-wrapper"]');
+			expect(wrapper).toHaveClass(position);
 		});
 	});
 
@@ -49,15 +50,22 @@ describe('CanvasHandlePlus', () => {
 			props: { type: 'success' },
 		});
 
-		expect(container.firstChild).toHaveClass('success');
+		const wrapper = container.querySelector('[data-test-id="canvas-handle-plus-wrapper"]');
+
+		expect(wrapper).toHaveClass('success');
 	});
 
 	it('should render SVG elements correctly', () => {
 		const { container } = renderComponent();
 
+		const wrapper = container.querySelector('[data-test-id="canvas-handle-plus-wrapper"]');
+		expect(wrapper).toBeTruthy();
+		expect(wrapper?.tagName).toBe('DIV');
+
 		const svg = container.querySelector('svg');
 		expect(svg).toBeTruthy();
 		expect(svg?.getAttribute('viewBox')).toBe('0 0 70 24');
+		expect(svg?.parentElement).toBe(wrapper);
 
 		const lineSvg = container.querySelector('line');
 		expect(lineSvg).toBeTruthy();

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/render-types/parts/CanvasHandlePlus.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/render-types/parts/CanvasHandlePlus.vue
@@ -32,8 +32,7 @@ const emit = defineEmits<{
 const style = useCssModule();
 
 const classes = computed(() => [
-	'canvas-handle-plus-wrapper',
-	style.wrapper,
+	style.container,
 	style[props.position],
 	style[props.type],
 	props.handleClasses,
@@ -55,7 +54,7 @@ const viewBox = computed(() => {
 	}
 });
 
-const styles = computed(() => ({
+const svgStyles = computed(() => ({
 	width: `${viewBox.value.width}px`,
 	height: `${viewBox.value.height}px`,
 	'--canvas-handle-plus-line--color--lightness--light': lineLightness.value.light,
@@ -106,50 +105,67 @@ function onClick(event: MouseEvent) {
 </script>
 
 <template>
-	<svg
-		data-test-id="canvas-handle-plus-wrapper"
-		:class="classes"
-		:viewBox="`0 0 ${viewBox.width} ${viewBox.height}`"
-		:style="styles"
-	>
-		<line
-			:class="[handleClasses, $style.line]"
-			:x1="linePosition[0][0]"
-			:y1="linePosition[0][1]"
-			:x2="linePosition[1][0]"
-			:y2="linePosition[1][1]"
-			stroke-width="2"
-		/>
-		<g
-			data-test-id="canvas-handle-plus"
-			:class="[$style.plus, handleClasses, 'clickable']"
-			:transform="`translate(${plusPosition[0]}, ${plusPosition[1]})`"
-			@click.stop="onClick"
+	<div :class="classes" data-test-id="canvas-handle-plus-wrapper">
+		<svg
+			:class="$style.wrapper"
+			:style="svgStyles"
+			:viewBox="`0 0 ${viewBox.width} ${viewBox.height}`"
 		>
-			<rect
-				:class="[handleClasses, 'clickable']"
-				x="2"
-				y="2"
-				width="20"
-				height="20"
-				stroke="light-dark(var(--color--neutral-200), var(--color--neutral-850))"
+			<line
+				:class="[handleClasses, $style.line]"
+				:x1="linePosition[0][0]"
+				:y1="linePosition[0][1]"
+				:x2="linePosition[1][0]"
+				:y2="linePosition[1][1]"
 				stroke-width="2"
-				rx="4"
-				fill="light-dark(var(--color--neutral-200), var(--color--neutral-850))"
 			/>
-			<path
-				stroke="currentColor"
-				stroke-width="1.5"
-				stroke-linecap="round"
-				stroke-linejoin="round"
-				d="M8 12h8m-4-4v8"
-				class="source clickable"
-			/>
-		</g>
-	</svg>
+			<g
+				data-test-id="canvas-handle-plus"
+				:class="[$style.plus, handleClasses, 'clickable']"
+				:transform="`translate(${plusPosition[0]}, ${plusPosition[1]})`"
+				@click.stop="onClick"
+			>
+				<rect
+					:class="[handleClasses, 'clickable']"
+					x="2"
+					y="2"
+					width="20"
+					height="20"
+					stroke="light-dark(var(--color--neutral-200), var(--color--neutral-850))"
+					stroke-width="2"
+					rx="4"
+					fill="light-dark(var(--color--neutral-200), var(--color--neutral-850))"
+				/>
+				<path
+					stroke="currentColor"
+					stroke-width="1.5"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					d="M8 12h8m-4-4v8"
+					class="source clickable"
+				/>
+			</g>
+		</svg>
+	</div>
 </template>
 
 <style lang="scss" module>
+.container {
+	position: relative;
+
+	&::before {
+		content: '';
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		width: 200%;
+		height: 150%;
+		pointer-events: auto;
+		/* stylelint-disable-next-line @n8n/css-var-naming */
+		transform: translate(-50%, -50%) scale(var(--canvas-zoom-compensation-factor, 1));
+	}
+}
+
 .wrapper {
 	position: relative;
 	/* stylelint-disable-next-line @n8n/css-var-naming */

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/render-types/parts/__snapshots__/CanvasHandlePlus.test.ts.snap
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/render-types/parts/__snapshots__/CanvasHandlePlus.test.ts.snap
@@ -1,11 +1,11 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`CanvasHandlePlus > should render with default props 1`] = `
-"<svg data-test-id="canvas-handle-plus-wrapper" class="canvas-handle-plus-wrapper wrapper right default" viewBox="0 0 70 24" style="width: 70px; height: 24px; --canvas-handle-plus-line--color--lightness--light: 0.840; --canvas-handle-plus-line--color--lightness--dark: 0.420;">
-  <line class="line" x1="0" y1="12" x2="47" y2="12" stroke-width="2"></line>
-  <g data-test-id="canvas-handle-plus" class="plus clickable" transform="translate(46, 0)">
-    <rect class="clickable" x="2" y="2" width="20" height="20" stroke="light-dark(var(--color--neutral-200), var(--color--neutral-850))" stroke-width="2" rx="4" fill="light-dark(var(--color--neutral-200), var(--color--neutral-850))"></rect>
-    <path stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" d="M8 12h8m-4-4v8" class="source clickable"></path>
-  </g>
-</svg>"
+"<div class="container right default" data-test-id="canvas-handle-plus-wrapper"><svg class="wrapper" style="width: 70px; height: 24px; --canvas-handle-plus-line--color--lightness--light: 0.840; --canvas-handle-plus-line--color--lightness--dark: 0.420;" viewBox="0 0 70 24">
+    <line class="line" x1="0" y1="12" x2="47" y2="12" stroke-width="2"></line>
+    <g data-test-id="canvas-handle-plus" class="plus clickable" transform="translate(46, 0)">
+      <rect class="clickable" x="2" y="2" width="20" height="20" stroke="light-dark(var(--color--neutral-200), var(--color--neutral-850))" stroke-width="2" rx="4" fill="light-dark(var(--color--neutral-200), var(--color--neutral-850))"></rect>
+      <path stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" d="M8 12h8m-4-4v8" class="source clickable"></path>
+    </g>
+  </svg></div>"
 `;


### PR DESCRIPTION
## Summary

Fixes an issue where connection lines would visually overlap and interfere with the plus handle buttons on input handles. The plus handle now contains a pseudo element acting as event blocker which prevents edges from being brought to front when hovering over the plus handle area.

**Changes:**
- Added ::before pseudo element as event blocker that prevents edge hover detection when mouse is over plus handle area
- Fixed linting issue with `isHovered` declaration order

**How to test:**
1. Create a workflow with nodes that have non-main input handles (e.g., AI Agent)
2. Connect a node/ tool so that the delete icon of the edge is close or exactly below the plus handle button
3. Hover over the plus handle button - it should remain visible and clickable above the connection lines

## Related Linear tickets, Github issues, and Community forum posts

Fixes (LIGO-104)[https://linear.app/n8n/issue/LIGO-104]

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)