### PR TITLE
fix(core): Prevent dual loading of community packages

### DIFF
--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.service.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.service.test.ts
@@ -810,4 +810,26 @@ describe('CommunityPackagesService', () => {
 			);
 		});
 	});
+
+	describe('handleInstallEvent', () => {
+		test('should call unloadPackage before loadPackage to handle already-loaded packages', async () => {
+			const callOrder: string[] = [];
+			loadNodesAndCredentials.unloadPackage.mockImplementation(async () => {
+				callOrder.push('unloadPackage');
+			});
+			loadNodesAndCredentials.loadPackage.mockImplementation(async () => {
+				callOrder.push('loadPackage');
+				return mock<PackageDirectoryLoader>();
+			});
+
+			jest.spyOn(communityPackagesService as any, 'downloadPackage').mockResolvedValue(undefined);
+
+			await communityPackagesService.handleInstallEvent({
+				packageName: 'n8n-nodes-test',
+				packageVersion: '1.0.0',
+			});
+
+			expect(callOrder).toEqual(['unloadPackage', 'loadPackage']);
+		});
+	});
 });

--- a/packages/cli/src/modules/community-packages/community-packages.service.ts
+++ b/packages/cli/src/modules/community-packages/community-packages.service.ts
@@ -495,6 +495,7 @@ export class CommunityPackagesService {
 
 	private async installOrUpdateNpmPackage(packageName: string, packageVersion: string) {
 		await this.downloadPackage(packageName, packageVersion);
+		await this.loadNodesAndCredentials.unloadPackage(packageName);
 		await this.loadNodesAndCredentials.loadPackage(packageName);
 		await this.loadNodesAndCredentials.postProcessLoaders();
 		this.loadNodesAndCredentials.releaseTypes();


### PR DESCRIPTION
## Summary

When a worker receives a `community-package-install` or `community-package-update` pubsub event, it calls `installOrUpdateNpmPackage`. This loads the package directly without unloading it first, so if the package is already loaded (e.g., the worker loaded it from disk at startup), `loadPackage` throws because the package already exists in `loaders`. 

https://github.com/n8n-io/n8n/blob/78a16b70314f65d9a5dca29d92a43a5d7a7131f3/packages/cli/src/modules/community-packages/community-packages.service.ts#L496-L502


Compare to `installPackage` which unloads first:

https://github.com/n8n-io/n8n/blob/78a16b70314f65d9a5dca29d92a43a5d7a7131f3/packages/cli/src/modules/community-packages/community-packages.service.ts#L442-L443

To reproduce:

1. Start main + worker
2. Install a community package like `n8n-nodes-baserow`
3. Restart only the worker
4. Update the community package → `error: nodes package n8n-nodes-baserow is already loaded. Please delete this second copy at path /Users/ivov/.n8n/nodes/node_modules/n8n-nodes-baserow { "file": "error-reporter.js", "function": "defaultReport" }`

## Related Linear tickets, Github issues, and Community forum posts

n/a
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
