### PR TITLE
chore(core): Introduce n8n resolver for dynamic credentials

### DIFF
--- a/packages/cli/src/auth/__tests__/auth.service.test.ts
+++ b/packages/cli/src/auth/__tests__/auth.service.test.ts
@@ -6,7 +6,7 @@ import type {
 	InvalidAuthTokenRepository,
 	UserRepository,
 } from '@n8n/db';
-import { GLOBAL_OWNER_ROLE } from '@n8n/db';
+import { GLOBAL_MEMBER_ROLE, GLOBAL_OWNER_ROLE } from '@n8n/db';
 import type { NextFunction, Response } from 'express';
 import { mock } from 'jest-mock-extended';
 import jwt from 'jsonwebtoken';
@@ -525,18 +525,16 @@ describe('AuthService', () => {
 
 		describe('when user limit is reached', () => {
 			it('should block issuance if the user is not the global owner', async () => {
-				const nonOwnerUser = mock<User>({
-					...userData,
-					role: { id: 'member', slug: 'member', name: 'Member' },
-				});
+				user.role = GLOBAL_MEMBER_ROLE;
 				license.isWithinUsersLimit.mockReturnValue(false);
 				expect(() => {
-					authService.issueCookie(res, nonOwnerUser, false, browserId);
+					authService.issueCookie(res, user, false, browserId);
 				}).toThrowError('Maximum number of users reached');
 			});
 
 			it('should allow issuance if the user is the global owner', async () => {
 				license.isWithinUsersLimit.mockReturnValue(false);
+				user.role = GLOBAL_OWNER_ROLE;
 				expect(() => {
 					authService.issueCookie(res, user, false, browserId);
 				}).not.toThrowError('Maximum number of users reached');

--- a/packages/cli/src/auth/__tests__/auth.service.test.ts
+++ b/packages/cli/src/auth/__tests__/auth.service.test.ts
@@ -26,6 +26,7 @@ describe('AuthService', () => {
 		password: 'passwordHash',
 		disabled: false,
 		mfaEnabled: false,
+		role: GLOBAL_OWNER_ROLE,
 	};
 	const user = mock<User>(userData);
 	const globalConfig = mock<GlobalConfig>({
@@ -524,15 +525,18 @@ describe('AuthService', () => {
 
 		describe('when user limit is reached', () => {
 			it('should block issuance if the user is not the global owner', async () => {
+				const nonOwnerUser = mock<User>({
+					...userData,
+					role: { id: 'member', slug: 'member', name: 'Member' },
+				});
 				license.isWithinUsersLimit.mockReturnValue(false);
 				expect(() => {
-					authService.issueCookie(res, user, false, browserId);
+					authService.issueCookie(res, nonOwnerUser, false, browserId);
 				}).toThrowError('Maximum number of users reached');
 			});
 
 			it('should allow issuance if the user is the global owner', async () => {
 				license.isWithinUsersLimit.mockReturnValue(false);
-				user.role = GLOBAL_OWNER_ROLE;
 				expect(() => {
 					authService.issueCookie(res, user, false, browserId);
 				}).not.toThrowError('Maximum number of users reached');
@@ -883,8 +887,6 @@ describe('AuthService', () => {
 
 			const token = authService.getCookieToken(req);
 
-			console.log(token);
-
 			expect(token).toBeUndefined();
 		});
 	});
@@ -934,6 +936,324 @@ describe('AuthService', () => {
 			const endpoint = authService.getEndpoint(req);
 
 			expect(endpoint).toBe('/api');
+		});
+	});
+
+	describe('authenticateUserBasedOnToken', () => {
+		const method = 'POST';
+		const endpoint = '/api/users';
+
+		beforeEach(() => {
+			jest.resetAllMocks();
+		});
+
+		describe('successful authentication', () => {
+			it('should authenticate successfully when MFA was used', async () => {
+				// Generate a fresh token with MFA
+				const tokenWithMfa = authService.issueJWT(user, true, browserId);
+
+				invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
+				userRepository.findOne.mockResolvedValue(user);
+
+				const result = await authService.authenticateUserBasedOnToken(
+					tokenWithMfa,
+					method,
+					endpoint,
+					browserId,
+				);
+
+				expect(result).toEqual(user);
+				expect(invalidAuthTokenRepository.existsBy).toHaveBeenCalledWith({ token: tokenWithMfa });
+				expect(userRepository.findOne).toHaveBeenCalled();
+			});
+
+			it('should authenticate successfully when MFA not enforced and user has no MFA', async () => {
+				// Generate a fresh token without MFA
+				const tokenWithoutMfa = authService.issueJWT(user, false, browserId);
+
+				invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
+				userRepository.findOne.mockResolvedValue(user);
+				mfaService.isMFAEnforced.mockResolvedValue(false);
+
+				const result = await authService.authenticateUserBasedOnToken(
+					tokenWithoutMfa,
+					method,
+					endpoint,
+					browserId,
+				);
+
+				expect(result).toEqual(user);
+				expect(invalidAuthTokenRepository.existsBy).toHaveBeenCalledWith({
+					token: tokenWithoutMfa,
+				});
+				expect(userRepository.findOne).toHaveBeenCalled();
+				expect(mfaService.isMFAEnforced).toHaveBeenCalled();
+			});
+
+			it('should authenticate successfully without browserId on skip endpoints with GET', async () => {
+				// Generate token without browserId
+				const tokenNoBrowser = authService.issueJWT(user, false, undefined);
+
+				invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
+				userRepository.findOne.mockResolvedValue(user);
+				mfaService.isMFAEnforced.mockResolvedValue(false);
+
+				const skipEndpoint = '/rest/push';
+				const result = await authService.authenticateUserBasedOnToken(
+					tokenNoBrowser,
+					'GET',
+					skipEndpoint,
+					undefined,
+				);
+
+				expect(result).toEqual(user);
+			});
+		});
+
+		describe('token validation failures', () => {
+			it('should throw when token is in invalid token repository', async () => {
+				const token = authService.issueJWT(user, false, browserId);
+				invalidAuthTokenRepository.existsBy.mockResolvedValue(true);
+
+				await expect(
+					authService.authenticateUserBasedOnToken(token, method, endpoint, browserId),
+				).rejects.toThrow('Unauthorized');
+
+				expect(invalidAuthTokenRepository.existsBy).toHaveBeenCalledWith({ token });
+				expect(userRepository.findOne).not.toHaveBeenCalled();
+			});
+
+			it('should throw when JWT is expired', async () => {
+				const token = authService.issueJWT(user, false, browserId);
+				invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
+				jest.advanceTimersByTime(365 * Time.days.toMilliseconds);
+
+				await expect(
+					authService.authenticateUserBasedOnToken(token, method, endpoint, browserId),
+				).rejects.toThrow('jwt expired');
+
+				expect(invalidAuthTokenRepository.existsBy).toHaveBeenCalled();
+			});
+
+			it('should throw when JWT is malformed', async () => {
+				invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
+
+				await expect(
+					authService.authenticateUserBasedOnToken('invalid-token', method, endpoint, browserId),
+				).rejects.toThrow('jwt malformed');
+
+				expect(invalidAuthTokenRepository.existsBy).toHaveBeenCalled();
+			});
+
+			it('should throw when user is not found', async () => {
+				const token = authService.issueJWT(user, false, browserId);
+				invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
+				userRepository.findOne.mockResolvedValue(null);
+
+				await expect(
+					authService.authenticateUserBasedOnToken(token, method, endpoint, browserId),
+				).rejects.toThrow('Unauthorized');
+
+				expect(userRepository.findOne).toHaveBeenCalled();
+			});
+
+			it('should throw when user is disabled', async () => {
+				const token = authService.issueJWT(user, false, browserId);
+				invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
+				userRepository.findOne.mockResolvedValue(mock<User>({ ...userData, disabled: true }));
+
+				await expect(
+					authService.authenticateUserBasedOnToken(token, method, endpoint, browserId),
+				).rejects.toThrow('Unauthorized');
+			});
+
+			it('should throw when user password has changed', async () => {
+				const token = authService.issueJWT(user, false, browserId);
+				invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
+				userRepository.findOne.mockResolvedValue(
+					mock<User>({ ...userData, password: 'newPasswordHash' }),
+				);
+
+				await expect(
+					authService.authenticateUserBasedOnToken(token, method, endpoint, browserId),
+				).rejects.toThrow('Unauthorized');
+			});
+		});
+
+		describe('browserId validation', () => {
+			it('should throw when browserId does not match', async () => {
+				const token = authService.issueJWT(user, false, browserId);
+				invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
+				userRepository.findOne.mockResolvedValue(user);
+
+				await expect(
+					authService.authenticateUserBasedOnToken(token, method, endpoint, 'different-browser-id'),
+				).rejects.toThrow('Unauthorized');
+			});
+
+			it('should throw when browserId is missing but required', async () => {
+				const token = authService.issueJWT(user, false, browserId);
+				invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
+				userRepository.findOne.mockResolvedValue(user);
+
+				await expect(
+					authService.authenticateUserBasedOnToken(token, method, endpoint, undefined),
+				).rejects.toThrow('Unauthorized');
+			});
+
+			it('should not throw when browserId check is skipped for GET on skip endpoints', async () => {
+				const token = authService.issueJWT(user, false, browserId);
+				invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
+				userRepository.findOne.mockResolvedValue(user);
+				mfaService.isMFAEnforced.mockResolvedValue(false);
+
+				// Use an endpoint that's definitely in the skip list
+				const skipEndpoint = '/types/nodes.json';
+				const result = await authService.authenticateUserBasedOnToken(
+					token,
+					'GET',
+					skipEndpoint,
+					'different-browser-id',
+				);
+
+				expect(result).toEqual(user);
+			});
+
+			it('should throw when browserId check is not skipped for POST on skip endpoints', async () => {
+				const token = authService.issueJWT(user, false, browserId);
+				invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
+				userRepository.findOne.mockResolvedValue(user);
+
+				const skipEndpoint = '/rest/push';
+				await expect(
+					authService.authenticateUserBasedOnToken(
+						token,
+						'POST',
+						skipEndpoint,
+						'different-browser-id',
+					),
+				).rejects.toThrow('Unauthorized');
+			});
+		});
+
+		describe('MFA validation', () => {
+			it('should throw when MFA is enforced and user has MFA enabled but did not use it', async () => {
+				const userWithMfa = mock<User>({
+					...userData,
+					mfaEnabled: true,
+					mfaSecret: 'secret',
+				});
+				// Need to generate a token for this user to make the hash match
+				const tokenForMfaUser = authService.issueJWT(userWithMfa, false, browserId);
+
+				invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
+				userRepository.findOne.mockResolvedValue(userWithMfa);
+				mfaService.isMFAEnforced.mockResolvedValue(true);
+
+				await expect(
+					authService.authenticateUserBasedOnToken(tokenForMfaUser, method, endpoint, browserId),
+				).rejects.toThrow('Unauthorized');
+
+				expect(mfaService.isMFAEnforced).toHaveBeenCalled();
+			});
+
+			it('should throw when MFA is enforced, user has no MFA, and token did not use MFA', async () => {
+				// Generate token without MFA
+				const tokenWithoutMfa = authService.issueJWT(user, false, browserId);
+
+				invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
+				userRepository.findOne.mockResolvedValue(user); // user has mfaEnabled: false
+				mfaService.isMFAEnforced.mockResolvedValue(true);
+
+				await expect(
+					authService.authenticateUserBasedOnToken(tokenWithoutMfa, method, endpoint, browserId),
+				).rejects.toThrow('Unauthorized');
+
+				expect(mfaService.isMFAEnforced).toHaveBeenCalled();
+			});
+
+			it('should throw when MFA is not enforced but user has MFA enabled and did not use it', async () => {
+				const userWithMfa = mock<User>({
+					...userData,
+					mfaEnabled: true,
+					mfaSecret: 'secret',
+				});
+				// Need to generate a token for this user to make the hash match
+				const tokenForMfaUser = authService.issueJWT(userWithMfa, false, browserId);
+
+				invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
+				userRepository.findOne.mockResolvedValue(userWithMfa);
+				mfaService.isMFAEnforced.mockResolvedValue(false);
+
+				await expect(
+					authService.authenticateUserBasedOnToken(tokenForMfaUser, method, endpoint, browserId),
+				).rejects.toThrow('Unauthorized');
+
+				expect(mfaService.isMFAEnforced).toHaveBeenCalled();
+			});
+
+			it('should succeed when MFA is enforced, user has MFA enabled, and used it', async () => {
+				const userWithMfa = mock<User>({
+					...userData,
+					mfaEnabled: true,
+					mfaSecret: 'secret',
+				});
+				// Need to generate a token with MFA for this user
+				const tokenForMfaUser = authService.issueJWT(userWithMfa, true, browserId);
+
+				invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
+				userRepository.findOne.mockResolvedValue(userWithMfa);
+				mfaService.isMFAEnforced.mockResolvedValue(true);
+
+				const result = await authService.authenticateUserBasedOnToken(
+					tokenForMfaUser,
+					method,
+					endpoint,
+					browserId,
+				);
+
+				expect(result).toEqual(userWithMfa);
+				// MFA enforcement check is skipped when usedMfa is true
+				expect(mfaService.isMFAEnforced).not.toHaveBeenCalled();
+			});
+		});
+
+		describe('edge cases', () => {
+			it('should handle token with missing usedMfa field as false', async () => {
+				// Generate fresh token - usedMfa field defaults to false when not explicitly set
+				const tokenWithoutMfa = authService.issueJWT(user, false, browserId);
+
+				invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
+				userRepository.findOne.mockResolvedValue(user);
+				mfaService.isMFAEnforced.mockResolvedValue(false);
+
+				const result = await authService.authenticateUserBasedOnToken(
+					tokenWithoutMfa,
+					method,
+					endpoint,
+					browserId,
+				);
+
+				expect(result).toEqual(user);
+				expect(mfaService.isMFAEnforced).toHaveBeenCalled();
+			});
+
+			it('should handle token without browserId successfully', async () => {
+				// Token without browserId field
+				const tokenWithoutBrowserId = authService.issueJWT(user, false, undefined);
+				invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
+				userRepository.findOne.mockResolvedValue(user);
+				mfaService.isMFAEnforced.mockResolvedValue(false);
+
+				const result = await authService.authenticateUserBasedOnToken(
+					tokenWithoutBrowserId,
+					method,
+					endpoint,
+					undefined,
+				);
+
+				expect(result).toEqual(user);
+			});
 		});
 	});
 });

--- a/packages/cli/src/auth/auth.service.ts
+++ b/packages/cli/src/auth/auth.service.ts
@@ -222,11 +222,60 @@ export class AuthService {
 		});
 	}
 
-	async resolveJwt(
+	async authenticateUserBasedOnToken(
 		token: string,
-		req: AuthenticatedRequest,
-		res: Response,
-	): Promise<[User, { usedMfa: boolean }]> {
+		method: string,
+		endpoint: string,
+		browserId: string | undefined,
+	): Promise<User> {
+		const isInvalid = await this.invalidAuthTokenRepository.existsBy({ token });
+		if (isInvalid) throw new AuthError('Unauthorized');
+
+		const { user, jwtPayload } = await this.validateToken(token);
+
+		this.validateBrowserId(jwtPayload, browserId, endpoint, method);
+
+		const usedMfa = jwtPayload.usedMfa ?? false;
+
+		// MFA was used, we are good either way.
+		if (usedMfa) {
+			return user;
+		}
+		const mfaEnforced = await this.mfaService.isMFAEnforced();
+
+		if (!mfaEnforced && !user.mfaEnabled) {
+			// MFA is not enforced and the user has MFA not enabled
+			// we are good
+			return user;
+		}
+
+		// either MFA is enforced or user has MFA enabled
+		throw new AuthError('Unauthorized');
+	}
+
+	private validateBrowserId(
+		jwtPayload: IssuedJWT,
+		browserId: string | undefined,
+		endpoint: string,
+		method: string,
+	) {
+		if (method === 'GET' && this.skipBrowserIdCheckEndpoints.includes(endpoint)) {
+			this.logger.debug(`Skipped browserId check on ${endpoint}`);
+		} else if (
+			jwtPayload.browserId &&
+			(!browserId || jwtPayload.browserId !== this.hash(browserId))
+		) {
+			this.logger.warn(`browserId check failed on ${endpoint}`);
+			throw new AuthError('Unauthorized');
+		}
+	}
+
+	private async validateToken(
+		token: string
+	): Promise<{
+		user: User;
+		jwtPayload: IssuedJWT;
+	}> {
 		const jwtPayload: IssuedJWT = this.jwtService.verify(token, {
 			algorithms: ['HS256'],
 		});
@@ -248,17 +297,23 @@ export class AuthService {
 			throw new AuthError('Unauthorized');
 		}
 
+		return {
+			user,
+			jwtPayload,
+		};
+	}
+
+	async resolveJwt(
+		token: string,
+		req: AuthenticatedRequest,
+		res: Response,
+	): Promise<[User, { usedMfa: boolean }]> {
+		const { user, jwtPayload } = await this.validateToken(token);
+
 		const browserId = this.getBrowserId(req);
 		const endpoint = this.getEndpoint(req);
-		if (req.method === 'GET' && this.skipBrowserIdCheckEndpoints.includes(endpoint)) {
-			this.logger.debug(`Skipped browserId check on ${endpoint}`);
-		} else if (
-			jwtPayload.browserId &&
-			(!browserId || jwtPayload.browserId !== this.hash(browserId))
-		) {
-			this.logger.warn(`browserId check failed on ${endpoint}`);
-			throw new AuthError('Unauthorized');
-		}
+		const method = this.getMethod(req);
+		this.validateBrowserId(jwtPayload, browserId, endpoint, method);
 
 		if (jwtPayload.exp * 1000 - Date.now() < this.jwtRefreshTimeout) {
 			this.logger.debug('JWT about to expire. Will be refreshed');

--- a/packages/cli/src/auth/auth.service.ts
+++ b/packages/cli/src/auth/auth.service.ts
@@ -270,9 +270,7 @@ export class AuthService {
 		}
 	}
 
-	private async validateToken(
-		token: string
-	): Promise<{
+	private async validateToken(token: string): Promise<{
 		user: User;
 		jwtPayload: IssuedJWT;
 	}> {

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/__tests__/n8n-credential-resolver.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/__tests__/n8n-credential-resolver.test.ts
@@ -1,0 +1,251 @@
+import type { Logger } from '@n8n/backend-common';
+import {
+	CredentialResolverDataNotFoundError,
+	CredentialResolverValidationError,
+} from '@n8n/decorators';
+import type { Cipher } from 'n8n-core';
+
+import type { N8NIdentifier } from '../identifiers/n8n-identifier';
+import { N8NCredentialResolver } from '../n8n-credential-resolver';
+import type { DynamicCredentialUserEntryStorage } from '../storage/dynamic-credential-user-entry-storage';
+import { testCredentialResolverContract, testHelpers } from './resolver-contract-tests';
+
+describe('N8NCredentialResolver', () => {
+	let mockLogger: jest.Mocked<Logger>;
+	let mockIdentifier: jest.Mocked<N8NIdentifier>;
+	let mockStorage: jest.Mocked<DynamicCredentialUserEntryStorage>;
+	let mockCipher: jest.Mocked<Cipher>;
+
+	beforeEach(() => {
+		mockLogger = {
+			debug: jest.fn(),
+			info: jest.fn(),
+			warn: jest.fn(),
+			error: jest.fn(),
+		} as unknown as jest.Mocked<Logger>;
+
+		mockIdentifier = {
+			resolve: jest.fn(),
+			validateOptions: jest.fn(),
+		} as unknown as jest.Mocked<N8NIdentifier>;
+
+		mockStorage = {
+			getCredentialData: jest.fn(),
+			setCredentialData: jest.fn(),
+			deleteCredentialData: jest.fn(),
+			deleteAllCredentialData: jest.fn(),
+		} as unknown as jest.Mocked<DynamicCredentialUserEntryStorage>;
+
+		mockCipher = {
+			encrypt: jest.fn(),
+			decrypt: jest.fn(),
+		} as unknown as jest.Mocked<Cipher>;
+	});
+
+	// Run the standard contract tests
+	testCredentialResolverContract({
+		createResolver: () => {
+			// Create in-memory storage for contract tests
+			const storage = new Map<string, string>();
+
+			// Reset mocks with stateful implementations
+			// Make identifier return different user IDs for different identities
+			mockIdentifier.resolve.mockImplementation(async (context) => {
+				return `user-${context.identity}`;
+			});
+			// N8N resolver has no actual validation, but contract tests require at least one "invalid" case
+			// Mock validation to throw only for the placeholder test case
+			mockIdentifier.validateOptions.mockImplementation(async (options) => {
+				if (options && 'placeholder' in options) {
+					throw new CredentialResolverValidationError(
+						'Placeholder validation error for contract test',
+					);
+				}
+				return undefined;
+			});
+
+			mockStorage.getCredentialData.mockImplementation(async (credentialId, userId, resolverId) => {
+				const key = `${credentialId}:${userId}:${resolverId}`;
+				return storage.get(key) ?? null;
+			});
+
+			mockStorage.setCredentialData.mockImplementation(
+				async (credentialId, userId, resolverId, data) => {
+					const key = `${credentialId}:${userId}:${resolverId}`;
+					storage.set(key, data);
+				},
+			);
+
+			mockStorage.deleteCredentialData.mockImplementation(
+				async (credentialId, userId, resolverId) => {
+					const key = `${credentialId}:${userId}:${resolverId}`;
+					storage.delete(key);
+				},
+			);
+
+			mockCipher.encrypt.mockImplementation((data) => JSON.stringify(data));
+			mockCipher.decrypt.mockImplementation((data) => data);
+
+			return new N8NCredentialResolver(mockLogger, mockIdentifier, mockStorage, mockCipher);
+		},
+		validationTests: {
+			validOptions: [
+				['empty config (no options required)', {}],
+				['any config (ignored)', { foo: 'bar', baz: 123 }],
+			],
+			// Note: N8N resolver has no configuration validation, so no options are truly "invalid"
+			// However, the contract test framework requires at least one test case for it.each()
+			// This placeholder ensures the framework doesn't throw an error
+			invalidOptions: [['placeholder (N8N resolver accepts all options)', { placeholder: true }]],
+		},
+	});
+
+	// N8N-specific behavior tests
+	describe('N8N-specific behavior', () => {
+		let resolver: N8NCredentialResolver;
+
+		beforeEach(() => {
+			mockIdentifier.resolve.mockResolvedValue('user-123');
+			mockIdentifier.validateOptions.mockResolvedValue(undefined);
+
+			resolver = new N8NCredentialResolver(mockLogger, mockIdentifier, mockStorage, mockCipher);
+		});
+
+		describe('getSecret', () => {
+			it('should use N8NIdentifier to resolve user ID from JWT', async () => {
+				const credentialId = 'cred-123';
+				const context = testHelpers.createContext('jwt-token-abc');
+				const handle = testHelpers.createHandle({});
+
+				mockStorage.getCredentialData.mockResolvedValue('encrypted-data');
+				mockCipher.decrypt.mockReturnValue('{"apiKey":"secret-123"}');
+
+				await resolver.getSecret(credentialId, context, handle);
+
+				// Verify N8NIdentifier was called with correct context
+				expect(mockIdentifier.resolve).toHaveBeenCalledWith(context, {});
+				// Verify storage was queried with resolved user ID
+				expect(mockStorage.getCredentialData).toHaveBeenCalledWith(
+					credentialId,
+					'user-123',
+					handle.resolverId,
+					{},
+				);
+			});
+
+			it('should throw CredentialResolverDataNotFoundError when decrypted data is invalid JSON', async () => {
+				const credentialId = 'cred-123';
+				const context = testHelpers.createContext('jwt-token-abc');
+				const handle = testHelpers.createHandle({});
+
+				mockStorage.getCredentialData.mockResolvedValue('encrypted-data');
+				mockCipher.decrypt.mockReturnValue('invalid-json{{{');
+
+				await expect(resolver.getSecret(credentialId, context, handle)).rejects.toThrow(
+					CredentialResolverDataNotFoundError,
+				);
+
+				expect(mockLogger.error).toHaveBeenCalledWith(
+					'Failed to parse decrypted credential data',
+					expect.any(Object),
+				);
+			});
+		});
+
+		describe('setSecret', () => {
+			it('should encrypt data before storing', async () => {
+				const credentialId = 'cred-123';
+				const context = testHelpers.createContext('jwt-token-xyz');
+				const data = testHelpers.createCredentialData({ apiKey: 'new-secret' });
+				const handle = testHelpers.createHandle({});
+
+				mockCipher.encrypt.mockReturnValue('encrypted-new-data');
+
+				await resolver.setSecret(credentialId, context, data, handle);
+
+				expect(mockCipher.encrypt).toHaveBeenCalledWith(data);
+				expect(mockStorage.setCredentialData).toHaveBeenCalledWith(
+					credentialId,
+					'user-123',
+					handle.resolverId,
+					'encrypted-new-data',
+					{},
+				);
+			});
+
+			it('should use resolved user ID as storage key', async () => {
+				const credentialId = 'cred-456';
+				const context = testHelpers.createContext('jwt-token-xyz');
+				const data = testHelpers.createCredentialData();
+				const handle = testHelpers.createHandle({});
+
+				mockIdentifier.resolve.mockResolvedValue('user-resolved-789');
+				mockCipher.encrypt.mockReturnValue('encrypted-data');
+
+				await resolver.setSecret(credentialId, context, data, handle);
+
+				// Verify user ID was resolved first
+				expect(mockIdentifier.resolve).toHaveBeenCalledWith(context, {});
+				// Verify storage uses resolved user ID
+				expect(mockStorage.setCredentialData).toHaveBeenCalledWith(
+					credentialId,
+					'user-resolved-789',
+					handle.resolverId,
+					'encrypted-data',
+					{},
+				);
+			});
+		});
+
+		describe('deleteSecret', () => {
+			it('should use resolved user ID for deletion', async () => {
+				const credentialId = 'cred-123';
+				const context = testHelpers.createContext('jwt-token-abc');
+				const handle = testHelpers.createHandle({});
+
+				mockIdentifier.resolve.mockResolvedValue('user-to-delete-456');
+
+				await resolver.deleteSecret(credentialId, context, handle);
+
+				expect(mockIdentifier.resolve).toHaveBeenCalledWith(context, {});
+				expect(mockStorage.deleteCredentialData).toHaveBeenCalledWith(
+					credentialId,
+					'user-to-delete-456',
+					handle.resolverId,
+					{},
+				);
+			});
+		});
+
+		describe('deleteAllSecrets', () => {
+			it('should delegate to storage.deleteAllCredentialData', async () => {
+				const handle = testHelpers.createHandle({});
+
+				await resolver.deleteAllSecrets(handle);
+
+				expect(mockStorage.deleteAllCredentialData).toHaveBeenCalledWith(handle);
+			});
+		});
+
+		describe('validateIdentity', () => {
+			it('should validate JWT with browserId set to false', async () => {
+				const identity = 'jwt-token-to-validate';
+				const handle = testHelpers.createHandle({});
+
+				await resolver.validateIdentity(identity, handle);
+
+				// Verify N8NIdentifier was called with browserId=false
+				expect(mockIdentifier.resolve).toHaveBeenCalledWith(
+					{
+						identity: 'jwt-token-to-validate',
+						version: 1,
+						metadata: {
+							browserId: false,
+						},
+					},
+					{},
+				);
+			});
+		});
+	});
+});

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/n8n-identifier.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/n8n-identifier.test.ts
@@ -1,0 +1,148 @@
+import type { User } from '@n8n/db';
+import { CredentialResolverError } from '@n8n/decorators';
+import { mock } from 'jest-mock-extended';
+
+import type { AuthService } from '@/auth/auth.service';
+import { AuthError } from '@/errors/response-errors/auth.error';
+
+import { N8NIdentifier } from '../n8n-identifier';
+
+describe('N8NIdentifier', () => {
+	let identifier: N8NIdentifier;
+	let mockAuthService: jest.Mocked<AuthService>;
+
+	const mockUser = mock<User>({ id: 'user-123' });
+
+	beforeEach(() => {
+		mockAuthService = {
+			authenticateUserBasedOnToken: jest.fn(),
+		} as unknown as jest.Mocked<AuthService>;
+
+		identifier = new N8NIdentifier(mockAuthService);
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('validateOptions', () => {
+		it('should always succeed as no validation is required', async () => {
+			await expect(identifier.validateOptions({})).resolves.not.toThrow();
+			await expect(identifier.validateOptions({ foo: 'bar' })).resolves.not.toThrow();
+		});
+	});
+
+	describe('resolve', () => {
+		describe('successful resolution', () => {
+			it('should resolve user ID with browserId string', async () => {
+				mockAuthService.authenticateUserBasedOnToken.mockResolvedValue(mockUser);
+
+				const context = {
+					identity: 'valid-jwt-token',
+					version: 1 as const,
+					metadata: { browserId: 'browser-abc' },
+				};
+
+				const result = await identifier.resolve(context, {});
+
+				expect(result).toBe('user-123');
+				expect(mockAuthService.authenticateUserBasedOnToken).toHaveBeenCalledWith(
+					'valid-jwt-token',
+					'browser-abc',
+				);
+			});
+
+			it('should resolve user ID with browserId undefined', async () => {
+				mockAuthService.authenticateUserBasedOnToken.mockResolvedValue(mockUser);
+
+				const context = {
+					identity: 'valid-jwt-token',
+					version: 1 as const,
+					metadata: { browserId: undefined },
+				};
+
+				const result = await identifier.resolve(context, {});
+
+				expect(result).toBe('user-123');
+				expect(mockAuthService.authenticateUserBasedOnToken).toHaveBeenCalledWith(
+					'valid-jwt-token',
+					undefined,
+				);
+			});
+
+			it('should resolve user ID with browserId false (skip check)', async () => {
+				mockAuthService.authenticateUserBasedOnToken.mockResolvedValue(mockUser);
+
+				const context = {
+					identity: 'valid-jwt-token',
+					version: 1 as const,
+					metadata: { browserId: false },
+				};
+
+				const result = await identifier.resolve(context, {});
+
+				expect(result).toBe('user-123');
+				expect(mockAuthService.authenticateUserBasedOnToken).toHaveBeenCalledWith(
+					'valid-jwt-token',
+					false,
+				);
+			});
+		});
+
+		describe('metadata validation errors', () => {
+			it('should throw CredentialResolverError when metadata is missing', async () => {
+				const context = {
+					identity: 'valid-jwt-token',
+					version: 1 as const,
+					metadata: undefined,
+				};
+
+				await expect(identifier.resolve(context, {})).rejects.toThrow(CredentialResolverError);
+
+				// Verify auth service was never called
+				expect(mockAuthService.authenticateUserBasedOnToken).not.toHaveBeenCalled();
+			});
+
+			it('should throw CredentialResolverError when browserId has invalid type', async () => {
+				const context = {
+					identity: 'valid-jwt-token',
+					version: 1 as const,
+					metadata: { browserId: 123 }, // Number instead of string/undefined/false
+				};
+
+				await expect(identifier.resolve(context, {})).rejects.toThrow(CredentialResolverError);
+				await expect(identifier.resolve(context, {})).rejects.toThrow(/Invalid context metadata/);
+
+				expect(mockAuthService.authenticateUserBasedOnToken).not.toHaveBeenCalled();
+			});
+		});
+
+		describe('authentication errors', () => {
+			it('should propagate AuthError when token is invalid', async () => {
+				const authError = new AuthError('Unauthorized');
+				mockAuthService.authenticateUserBasedOnToken.mockRejectedValue(authError);
+
+				const context = {
+					identity: 'invalid-token',
+					version: 1 as const,
+					metadata: { browserId: 'browser-abc' },
+				};
+
+				await expect(identifier.resolve(context, {})).rejects.toThrow('Unauthorized');
+			});
+
+			it('should propagate error when authentication fails', async () => {
+				const genericError = new Error('Database connection failed');
+				mockAuthService.authenticateUserBasedOnToken.mockRejectedValue(genericError);
+
+				const context = {
+					identity: 'valid-token',
+					version: 1 as const,
+					metadata: { browserId: false },
+				};
+
+				await expect(identifier.resolve(context, {})).rejects.toThrow('Database connection failed');
+			});
+		});
+	});
+});

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/n8n-identifier.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/n8n-identifier.ts
@@ -1,0 +1,40 @@
+import { Service } from '@n8n/di';
+import type { ICredentialContext } from 'n8n-workflow';
+import { ITokenIdentifier } from './identifier-interface';
+import { AuthService } from '@/auth/auth.service';
+import { z } from 'zod';
+import { CredentialResolverError } from '@n8n/decorators';
+
+const BrowserIDMetadataSchema = z.object({
+	browserId: z.union([z.string(), z.undefined(), z.literal(false)]),
+});
+
+/**
+ * N8N JWT token identifier.
+ * Validates n8n authentication tokens and resolves them to user IDs.
+ * Used by the N8N credential resolver to authenticate users via n8n's
+ * built-in JWT authentication and store credentials per user.
+ */
+@Service()
+export class N8NIdentifier implements ITokenIdentifier {
+	constructor(private readonly authService: AuthService) {}
+
+	async validateOptions(_: Record<string, unknown>): Promise<void> {
+		return;
+	}
+
+	async resolve(context: ICredentialContext, _: Record<string, unknown>): Promise<string> {
+		const browserIdResult = BrowserIDMetadataSchema.safeParse(context.metadata);
+		if (!browserIdResult.success) {
+			throw new CredentialResolverError(
+				`Invalid context metadata: ${browserIdResult.error.message}`,
+			);
+		}
+
+		const user = await this.authService.authenticateUserBasedOnToken(
+			context.identity,
+			browserIdResult.data.browserId,
+		);
+		return user.id;
+	}
+}

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/n8n-credential-resolver.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/n8n-credential-resolver.ts
@@ -1,0 +1,131 @@
+import { Logger } from '@n8n/backend-common';
+import {
+	CredentialResolver,
+	CredentialResolverConfiguration,
+	CredentialResolverDataNotFoundError,
+	CredentialResolverHandle,
+	ICredentialResolver,
+} from '@n8n/decorators';
+import { Cipher } from 'n8n-core';
+import { ICredentialContext, ICredentialDataDecryptedObject, jsonParse } from 'n8n-workflow';
+
+import { N8NIdentifier } from './identifiers/n8n-identifier';
+import { DynamicCredentialUserEntryStorage } from './storage/dynamic-credential-user-entry-storage';
+
+/**
+ * N8N JWT-based credential resolver.
+ * Resolves user identity via n8n JWT authentication and stores credentials
+ * encrypted in the database per user.
+ */
+@CredentialResolver()
+export class N8NCredentialResolver implements ICredentialResolver {
+	constructor(
+		private readonly logger: Logger,
+		private readonly n8nIdentifier: N8NIdentifier,
+		private readonly storage: DynamicCredentialUserEntryStorage,
+		private readonly cipher: Cipher,
+	) {}
+
+	metadata = {
+		name: 'credential-resolver.n8n-1.0',
+		description: 'N8N based credential resolver',
+		displayName: 'N8N Resolver',
+		options: [],
+	};
+
+	/**
+	 * Retrieves stored credential data for the given identity.
+	 * @throws {CredentialResolverDataNotFoundError} When no data exists for the key
+	 */
+	async getSecret(
+		credentialId: string,
+		context: ICredentialContext,
+		handle: CredentialResolverHandle,
+	): Promise<ICredentialDataDecryptedObject> {
+		const key = await this.resolveIdentifier(context, handle.configuration);
+
+		const data = await this.storage.getCredentialData(
+			credentialId,
+			key,
+			handle.resolverId,
+			handle.configuration,
+		);
+
+		if (!data) {
+			throw new CredentialResolverDataNotFoundError();
+		}
+		const plaintext = this.cipher.decrypt(data);
+		try {
+			const secret = jsonParse<ICredentialDataDecryptedObject>(plaintext);
+			return secret;
+		} catch (error) {
+			this.logger.error('Failed to parse decrypted credential data', { error });
+			throw new CredentialResolverDataNotFoundError();
+		}
+	}
+
+	/** Stores credential data for the given identity */
+	async setSecret(
+		credentialId: string,
+		context: ICredentialContext,
+		data: ICredentialDataDecryptedObject,
+		handle: CredentialResolverHandle,
+	): Promise<void> {
+		const key = await this.resolveIdentifier(context, handle.configuration);
+
+		const encryptedData = this.cipher.encrypt(data);
+
+		await this.storage.setCredentialData(
+			credentialId,
+			key,
+			handle.resolverId,
+			encryptedData,
+			handle.configuration,
+		);
+	}
+
+	/** Deletes credential data for the given identity. Succeeds silently if not found. */
+	async deleteSecret(
+		credentialId: string,
+		context: ICredentialContext,
+		handle: CredentialResolverHandle,
+	): Promise<void> {
+		const key = await this.resolveIdentifier(context, handle.configuration);
+		await this.storage.deleteCredentialData(
+			credentialId,
+			key,
+			handle.resolverId,
+			handle.configuration,
+		);
+	}
+
+	async deleteAllSecrets(handle: CredentialResolverHandle): Promise<void> {
+		await this.storage.deleteAllCredentialData(handle);
+	}
+
+	async validateOptions(configuration: CredentialResolverConfiguration): Promise<void> {
+		return await this.n8nIdentifier.validateOptions(configuration);
+	}
+
+	private async resolveIdentifier(
+		context: ICredentialContext,
+		configuration: CredentialResolverConfiguration,
+	): Promise<string> {
+		return await this.n8nIdentifier.resolve(context, configuration);
+	}
+
+	async validateIdentity(identity: string, handle: CredentialResolverHandle): Promise<void> {
+		await this.resolveIdentifier(
+			{
+				identity,
+				version: 1,
+				metadata: {
+					// Skip browserId check for identity validation only
+					// Full session validation happens during actual credential resolution
+					browserId: false,
+				},
+			},
+			handle.configuration,
+		);
+	}
+}


### PR DESCRIPTION
## Summary

This introduces an n8n resolver for the dynamic credential system.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/IAM-88/refactor-auth-service-to-expose-shared-functions-for-validation-of
closes https://linear.app/n8n/issue/IAM-89/implement-n8n-internal-resolver

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
