### PR TITLE
feat(core): Implement two-layered rate limiting system

### DIFF
--- a/packages/@n8n/decorators/src/controller/__tests__/route.test.ts
+++ b/packages/@n8n/decorators/src/controller/__tests__/route.test.ts
@@ -38,7 +38,7 @@ describe('Route Decorators', () => {
 			expect(routeMetadata.middlewares).toEqual([]);
 			expect(routeMetadata.usesTemplates).toBe(false);
 			expect(routeMetadata.skipAuth).toBe(false);
-			expect(routeMetadata.rateLimit).toBeUndefined();
+			expect(routeMetadata.ipRateLimit).toBeUndefined();
 		});
 
 		it('should accept and apply route options', () => {
@@ -49,7 +49,8 @@ describe('Route Decorators', () => {
 					middlewares: [middleware],
 					usesTemplates: true,
 					skipAuth: true,
-					rateLimit: { limit: 10, windowMs: 60000 },
+					ipRateLimit: { limit: 10, windowMs: 60000 },
+					keyedRateLimit: { limit: 10, windowMs: 60000, source: 'body', field: 'email' },
 				})
 				testMethod() {}
 			}
@@ -62,12 +63,18 @@ describe('Route Decorators', () => {
 			expect(routeMetadata.middlewares).toEqual([middleware]);
 			expect(routeMetadata.usesTemplates).toBe(true);
 			expect(routeMetadata.skipAuth).toBe(true);
-			expect(routeMetadata.rateLimit).toEqual({ limit: 10, windowMs: 60000 });
+			expect(routeMetadata.ipRateLimit).toEqual({ limit: 10, windowMs: 60000 });
+			expect(routeMetadata.keyedRateLimit).toEqual({
+				limit: 10,
+				windowMs: 60000,
+				source: 'body',
+				field: 'email',
+			});
 		});
 
-		it('should work with boolean rateLimit option', () => {
+		it('should work with boolean ipRateLimit option', () => {
 			class TestController {
-				@decorator('/test', { rateLimit: true })
+				@decorator('/test', { ipRateLimit: true })
 				testMethod() {}
 			}
 
@@ -76,7 +83,7 @@ describe('Route Decorators', () => {
 				'testMethod',
 			);
 
-			expect(routeMetadata.rateLimit).toBe(true);
+			expect(routeMetadata.ipRateLimit).toBe(true);
 		});
 
 		it('should work with multiple routes on the same controller', () => {

--- a/packages/@n8n/decorators/src/controller/index.ts
+++ b/packages/@n8n/decorators/src/controller/index.ts
@@ -11,6 +11,7 @@ export type {
 	Controller,
 	CorsOptions,
 	Method,
-	RateLimit,
+	RateLimiterLimits,
+	KeyedRateLimiterConfig,
 	StaticRouterMetadata,
 } from './types';

--- a/packages/@n8n/decorators/src/controller/route.ts
+++ b/packages/@n8n/decorators/src/controller/route.ts
@@ -2,7 +2,13 @@ import { Container } from '@n8n/di';
 import type { RequestHandler } from 'express';
 
 import { ControllerRegistryMetadata } from './controller-registry-metadata';
-import type { Controller, CorsOptions, Method, RateLimit } from './types';
+import type {
+	Controller,
+	CorsOptions,
+	Method,
+	RateLimiterLimits,
+	KeyedRateLimiterConfig,
+} from './types';
 
 interface RouteOptions {
 	middlewares?: RequestHandler[];
@@ -12,8 +18,10 @@ interface RouteOptions {
 	allowSkipPreviewAuth?: boolean;
 	/** When this flag is set to true, the auth cookie does not enforce MFA to be used in the token */
 	allowSkipMFA?: boolean;
-	/** When these options are set, calls to this endpoint are rate limited using the options */
-	rateLimit?: boolean | RateLimit;
+	/** When these options are set, calls to this endpoint are rate limited based on IP address */
+	ipRateLimit?: boolean | RateLimiterLimits;
+	/** When these options are set, calls to this endpoint are rate limited based on a key extracted from the request */
+	keyedRateLimit?: KeyedRateLimiterConfig;
 	/** When this flag is set to true, the endpoint is protected by API key */
 	apiKeyAuth?: boolean;
 	/** CORS options for the route, this does not handle preflight requests */
@@ -36,7 +44,8 @@ const RouteFactory =
 		routeMetadata.allowSkipPreviewAuth = options.allowSkipPreviewAuth ?? false;
 		routeMetadata.allowSkipMFA = options.allowSkipMFA ?? false;
 		routeMetadata.apiKeyAuth = options.apiKeyAuth ?? false;
-		routeMetadata.rateLimit = options.rateLimit;
+		routeMetadata.ipRateLimit = options.ipRateLimit;
+		routeMetadata.keyedRateLimit = options.keyedRateLimit;
 		routeMetadata.cors = options.cors;
 	};
 

--- a/packages/@n8n/decorators/src/controller/types.ts
+++ b/packages/@n8n/decorators/src/controller/types.ts
@@ -15,7 +15,7 @@ export interface CorsOptions {
 	maxAge?: number;
 }
 
-export interface RateLimit {
+export interface RateLimiterLimits {
 	/**
 	 * The maximum number of requests to allow during the `window` before rate limiting the client.
 	 * @default 5
@@ -27,6 +27,30 @@ export interface RateLimit {
 	 */
 	windowMs?: number;
 }
+
+/**
+ * Configuration for extracting a key from the request body.
+ * @example
+ * { source: 'body', field: 'email' }
+ */
+export interface BodyKeyedRateLimiterConfig extends RateLimiterLimits {
+	/** How to extract key from request */
+	source: 'body';
+	/** The field name in the request body to use as the key */
+	field: string;
+}
+
+/**
+ * Configuration for extracting a key from the authenticated user.
+ * @example
+ * { source: 'user' }
+ */
+export interface UserKeyedRateLimiterConfig extends RateLimiterLimits {
+	/** How to extract key from request */
+	source: 'user';
+}
+
+export type KeyedRateLimiterConfig = BodyKeyedRateLimiterConfig | UserKeyedRateLimiterConfig;
 
 export type HandlerName = string;
 
@@ -45,7 +69,10 @@ export interface RouteMetadata {
 	allowSkipMFA: boolean;
 	apiKeyAuth: boolean;
 	cors?: Partial<CorsOptions> | true;
-	rateLimit?: boolean | RateLimit;
+	/** Whether to apply IP-based rate limiting to the route */
+	ipRateLimit?: boolean | RateLimiterLimits;
+	/** Whether to apply keyed rate limiting to the route */
+	keyedRateLimit?: KeyedRateLimiterConfig;
 	licenseFeature?: BooleanLicenseFeature;
 	accessScope?: AccessScope;
 	args: Arg[];
@@ -66,7 +93,8 @@ export type StaticRouterMetadata = {
 		| 'allowSkipPreviewAuth'
 		| 'allowSkipMFA'
 		| 'middlewares'
-		| 'rateLimit'
+		| 'ipRateLimit'
+		| 'keyedRateLimit'
 		| 'licenseFeature'
 		| 'accessScope'
 	>

--- a/packages/cli/src/controller.registry.ts
+++ b/packages/cli/src/controller.registry.ts
@@ -1,19 +1,25 @@
 import { RESPONSE_ERROR_MESSAGES } from '@/constants';
-import { inProduction } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { type BooleanLicenseFeature } from '@n8n/constants';
 import type { AuthenticatedRequest } from '@n8n/db';
 import { ControllerRegistryMetadata } from '@n8n/decorators';
-import type { AccessScope, Controller, RateLimit, StaticRouterMetadata } from '@n8n/decorators';
+import type {
+	AccessScope,
+	Controller,
+	RateLimiterLimits,
+	StaticRouterMetadata,
+	KeyedRateLimiterConfig,
+} from '@n8n/decorators';
 import { Container, Service } from '@n8n/di';
 import { Router } from 'express';
 import type { Application, Request, Response, RequestHandler } from 'express';
-import { rateLimit as expressRateLimit } from 'express-rate-limit';
 import { UnexpectedError } from 'n8n-workflow';
+import assert from 'node:assert';
 import type { ZodClass } from 'zod-class';
 
 import { NotFoundError } from './errors/response-errors/not-found.error';
 import { LastActiveAtService } from './services/last-active-at.service';
+import { RateLimitService } from './services/rate-limit.service';
 
 import { AuthService } from '@/auth/auth.service';
 import { UnauthenticatedError } from '@/errors/response-errors/unauthenticated.error';
@@ -21,6 +27,7 @@ import { License } from '@/license';
 import { userHasScopes } from '@/permissions.ee/check-access';
 import { send } from '@/response-helper';
 import { CorsService } from './services/cors-service';
+import { inProduction } from '@n8n/backend-common';
 
 @Service()
 export class ControllerRegistry {
@@ -30,6 +37,7 @@ export class ControllerRegistry {
 		private readonly globalConfig: GlobalConfig,
 		private readonly metadata: ControllerRegistryMetadata,
 		private readonly lastActiveAtService: LastActiveAtService,
+		private readonly rateLimitService: RateLimitService,
 	) {}
 
 	activate(app: Application) {
@@ -122,7 +130,8 @@ export class ControllerRegistry {
 			skipAuth?: boolean;
 			allowSkipMFA?: boolean;
 			allowSkipPreviewAuth?: boolean;
-			rateLimit?: boolean | RateLimit;
+			ipRateLimit?: boolean | RateLimiterLimits;
+			keyedRateLimit?: KeyedRateLimiterConfig;
 			licenseFeature?: BooleanLicenseFeature;
 			accessScope?: AccessScope;
 			middlewares?: RequestHandler[];
@@ -131,8 +140,14 @@ export class ControllerRegistry {
 	): RequestHandler[] {
 		const middlewares: RequestHandler[] = [];
 
-		if (inProduction && route.rateLimit) {
-			middlewares.push(this.createRateLimitMiddleware(route.rateLimit));
+		// LAYER 1: IP-based rate limiting (always before auth)
+		if (inProduction && route.ipRateLimit) {
+			middlewares.push(this.rateLimitService.createIpRateLimitMiddleware(route.ipRateLimit));
+		}
+
+		// LAYER 2a: Keyed rate limiting with body source (BEFORE auth)
+		if (inProduction && route.keyedRateLimit?.source === 'body') {
+			middlewares.push(this.rateLimitService.createKeyedRateLimitMiddleware(route.keyedRateLimit));
 		}
 
 		if (!route.skipAuth) {
@@ -143,6 +158,21 @@ export class ControllerRegistry {
 				}),
 				this.lastActiveAtService.middleware.bind(this.lastActiveAtService) as RequestHandler,
 			);
+		}
+
+		// LAYER 2b: User-based rate limiting with user source (AFTER auth)
+		if (route.keyedRateLimit?.source === 'user') {
+			assert(
+				!route.skipAuth,
+				`User-based rate limiting is only supported for authenticated endpoints. Route: ${JSON.stringify(route)}`,
+			);
+
+			// Separate ifs itentionally to prevent configuration errors in development
+			if (inProduction) {
+				middlewares.push(
+					this.rateLimitService.createKeyedRateLimitMiddleware(route.keyedRateLimit),
+				);
+			}
 		}
 
 		if (route.licenseFeature) {
@@ -160,15 +190,6 @@ export class ControllerRegistry {
 		}
 
 		return middlewares;
-	}
-
-	private createRateLimitMiddleware(rateLimit: true | RateLimit): RequestHandler {
-		if (typeof rateLimit === 'boolean') rateLimit = {};
-		return expressRateLimit({
-			windowMs: rateLimit.windowMs,
-			limit: rateLimit.limit,
-			message: { message: 'Too many requests' },
-		});
 	}
 
 	private createLicenseMiddleware(feature: BooleanLicenseFeature): RequestHandler {

--- a/packages/cli/src/controller.registry.ts
+++ b/packages/cli/src/controller.registry.ts
@@ -167,7 +167,7 @@ export class ControllerRegistry {
 				`User-based rate limiting is only supported for authenticated endpoints. Route: ${JSON.stringify(route)}`,
 			);
 
-			// Separate ifs itentionally to prevent configuration errors in development
+			// Separate ifs intentionally to prevent configuration errors in development
 			if (inProduction) {
 				middlewares.push(
 					this.rateLimitService.createKeyedRateLimitMiddleware(route.keyedRateLimit),

--- a/packages/cli/src/controllers/ai.controller.ts
+++ b/packages/cli/src/controllers/ai.controller.ts
@@ -41,7 +41,7 @@ export class AiController {
 	// "Cannot set headers after they are sent" error for streaming responses.
 	// This ensures errors during streaming are handled within the stream itself.
 	@Licensed('feat:aiBuilder')
-	@Post('/build', { rateLimit: { limit: 100 }, usesTemplates: true })
+	@Post('/build', { ipRateLimit: { limit: 100 }, usesTemplates: true })
 	async build(
 		req: AuthenticatedRequest,
 		res: FlushableResponse,
@@ -119,7 +119,7 @@ export class AiController {
 		}
 	}
 
-	@Post('/chat', { rateLimit: { limit: 100 } })
+	@Post('/chat', { ipRateLimit: { limit: 100 } })
 	async chat(req: AuthenticatedRequest, res: FlushableResponse, @Body payload: AiChatRequestDto) {
 		try {
 			const aiResponse = await this.aiService.chat(payload, req.user);
@@ -214,7 +214,7 @@ export class AiController {
 	}
 
 	@Licensed('feat:aiBuilder')
-	@Post('/sessions', { rateLimit: { limit: 100 } })
+	@Post('/sessions', { ipRateLimit: { limit: 100 } })
 	async getSessions(
 		req: AuthenticatedRequest,
 		_: Response,
@@ -244,7 +244,7 @@ export class AiController {
 	}
 
 	@Licensed('feat:aiBuilder')
-	@Post('/build/truncate-messages', { rateLimit: { limit: 100 } })
+	@Post('/build/truncate-messages', { ipRateLimit: { limit: 100 } })
 	async truncateMessages(
 		req: AuthenticatedRequest,
 		_: Response,

--- a/packages/cli/src/controllers/invitation.controller.ts
+++ b/packages/cli/src/controllers/invitation.controller.ts
@@ -160,12 +160,6 @@ export class InvitationController {
 		// Two layered rate limit to ensure multiple users can accept an invitation from
 		// the same IP address but aggressive per inviteeId limit.
 		ipRateLimit: { limit: 100, windowMs: 1 * Time.minutes.toMilliseconds },
-		keyedRateLimit: {
-			limit: 10,
-			windowMs: 1 * Time.minutes.toMilliseconds,
-			source: 'body',
-			field: 'inviteeId' satisfies keyof AcceptInvitationRequestDto,
-		},
 	})
 	async acceptInvitationWithToken(
 		req: AuthlessRequest,
@@ -211,12 +205,12 @@ export class InvitationController {
 		skipAuth: true,
 		// Two layered rate limit to ensure multiple users can accept an invitation from
 		// the same IP address but aggressive per inviteeId limit.
-		ipRateLimit: { limit: 100, windowMs: 1 * Time.minutes.toMilliseconds },
+		ipRateLimit: { limit: 100, windowMs: 5 * Time.minutes.toMilliseconds },
 		keyedRateLimit: {
 			limit: 10,
 			windowMs: 1 * Time.minutes.toMilliseconds,
 			source: 'body',
-			field: 'inviteeId' satisfies keyof AcceptInvitationRequestDto,
+			field: 'inviterId' satisfies keyof AcceptInvitationRequestDto,
 		},
 	})
 	async acceptInvitation(

--- a/packages/cli/src/controllers/invitation.controller.ts
+++ b/packages/cli/src/controllers/invitation.controller.ts
@@ -18,6 +18,7 @@ import { PasswordUtility } from '@/services/password.utility';
 import { UserService } from '@/services/user.service';
 import { OwnershipService } from '@/services/ownership.service';
 import { isSsoCurrentAuthenticationMethod } from '@/sso.ee/sso-helpers';
+import { Time } from '@n8n/constants';
 
 @RestController('/invitations')
 export class InvitationController {
@@ -38,7 +39,7 @@ export class InvitationController {
 	 * Send email invite(s) to one or multiple users and create user shell(s).
 	 */
 
-	@Post('/', { rateLimit: { limit: 10 } })
+	@Post('/', { ipRateLimit: { limit: 10 } })
 	@GlobalScope('user:create')
 	async inviteUser(
 		req: AuthenticatedRequest,
@@ -154,7 +155,18 @@ export class InvitationController {
 	/**
 	 * Fill out user shell with first name, last name, and password using JWT token.
 	 */
-	@Post('/accept', { skipAuth: true })
+	@Post('/accept', {
+		skipAuth: true,
+		// Two layered rate limit to ensure multiple users can accept an invitation from
+		// the same IP address but aggressive per inviteeId limit.
+		ipRateLimit: { limit: 100, windowMs: 1 * Time.minutes.toMilliseconds },
+		keyedRateLimit: {
+			limit: 10,
+			windowMs: 1 * Time.minutes.toMilliseconds,
+			source: 'body',
+			field: 'inviteeId' satisfies keyof AcceptInvitationRequestDto,
+		},
+	})
 	async acceptInvitationWithToken(
 		req: AuthlessRequest,
 		res: Response,
@@ -195,7 +207,18 @@ export class InvitationController {
 	/**
 	 * Fill out user shell with first name, last name, and password (legacy format with inviterId/inviteeId).
 	 */
-	@Post('/:id/accept', { skipAuth: true })
+	@Post('/:id/accept', {
+		skipAuth: true,
+		// Two layered rate limit to ensure multiple users can accept an invitation from
+		// the same IP address but aggressive per inviteeId limit.
+		ipRateLimit: { limit: 100, windowMs: 1 * Time.minutes.toMilliseconds },
+		keyedRateLimit: {
+			limit: 10,
+			windowMs: 1 * Time.minutes.toMilliseconds,
+			source: 'body',
+			field: 'inviteeId' satisfies keyof AcceptInvitationRequestDto,
+		},
+	})
 	async acceptInvitation(
 		req: AuthlessRequest,
 		res: Response,

--- a/packages/cli/src/controllers/me.controller.ts
+++ b/packages/cli/src/controllers/me.controller.ts
@@ -165,7 +165,11 @@ export class MeController {
 	/**
 	 * Update the logged-in user's password.
 	 */
-	@Patch('/password', { rateLimit: true })
+	@Patch('/password', {
+		keyedRateLimit: {
+			source: 'user',
+		},
+	})
 	async updatePassword(
 		req: AuthenticatedRequest,
 		res: Response,

--- a/packages/cli/src/controllers/mfa.controller.ts
+++ b/packages/cli/src/controllers/mfa.controller.ts
@@ -84,7 +84,12 @@ export class MFAController {
 		};
 	}
 
-	@Post('/enable', { rateLimit: true, allowSkipMFA: true })
+	@Post('/enable', {
+		allowSkipMFA: true,
+		keyedRateLimit: {
+			source: 'user',
+		},
+	})
 	async activateMFA(req: MFA.Activate, res: Response) {
 		const { mfaCode = null } = req.body;
 		const { id, mfaEnabled } = req.user;
@@ -122,7 +127,12 @@ export class MFAController {
 		this.authService.issueCookie(res, updatedUser, verified, req.browserId);
 	}
 
-	@Post('/disable', { rateLimit: true })
+	@Post('/disable', {
+		ipRateLimit: true,
+		keyedRateLimit: {
+			source: 'user',
+		},
+	})
 	async disableMFA(req: MFA.Disable, res: Response) {
 		const { id: userId } = req.user;
 
@@ -163,7 +173,12 @@ export class MFAController {
 		this.authService.issueCookie(res, updatedUser, false, req.browserId);
 	}
 
-	@Post('/verify', { rateLimit: true, allowSkipMFA: true })
+	@Post('/verify', {
+		allowSkipMFA: true,
+		keyedRateLimit: {
+			source: 'user',
+		},
+	})
 	async verifyMFA(req: MFA.Verify) {
 		const { id } = req.user;
 		const { mfaCode } = req.body;

--- a/packages/cli/src/controllers/password-reset.controller.ts
+++ b/packages/cli/src/controllers/password-reset.controller.ts
@@ -50,7 +50,7 @@ export class PasswordResetController {
 	 */
 	@Post('/forgot-password', {
 		skipAuth: true,
-		ipRateLimit: { limit: 100, windowMs: 1 * Time.minutes.toMilliseconds },
+		ipRateLimit: { limit: 20, windowMs: 5 * Time.minutes.toMilliseconds },
 		keyedRateLimit: {
 			limit: 3,
 			source: 'body',

--- a/packages/cli/src/controllers/password-reset.controller.ts
+++ b/packages/cli/src/controllers/password-reset.controller.ts
@@ -28,6 +28,7 @@ import {
 	isSamlCurrentAuthenticationMethod,
 } from '@/sso.ee/sso-helpers';
 import { UserManagementMailer } from '@/user-management/email';
+import { Time } from '@n8n/constants';
 
 @RestController()
 export class PasswordResetController {
@@ -47,7 +48,15 @@ export class PasswordResetController {
 	/**
 	 * Send a password reset email.
 	 */
-	@Post('/forgot-password', { skipAuth: true, rateLimit: { limit: 3 } })
+	@Post('/forgot-password', {
+		skipAuth: true,
+		ipRateLimit: { limit: 100, windowMs: 1 * Time.minutes.toMilliseconds },
+		keyedRateLimit: {
+			limit: 3,
+			source: 'body',
+			field: 'email' satisfies keyof ForgotPasswordRequestDto,
+		},
+	})
 	async forgotPassword(
 		_req: AuthlessRequest,
 		_res: Response,
@@ -162,7 +171,10 @@ export class PasswordResetController {
 	/**
 	 * Verify password reset token and update password.
 	 */
-	@Post('/change-password', { skipAuth: true })
+	@Post('/change-password', {
+		skipAuth: true,
+		ipRateLimit: true,
+	})
 	async changePassword(
 		req: AuthlessRequest,
 		res: Response,

--- a/packages/cli/src/controllers/posthog.controller.ts
+++ b/packages/cli/src/controllers/posthog.controller.ts
@@ -31,43 +31,43 @@ export class PostHogController {
 	}
 
 	// Main event capture endpoint
-	@Post('/capture/', { skipAuth: true, rateLimit: { limit: 200, windowMs: 60_000 } })
+	@Post('/capture/', { skipAuth: true, ipRateLimit: { limit: 200, windowMs: 60_000 } })
 	async capture(req: AuthenticatedRequest, res: Response, next: NextFunction) {
 		return await this.proxy(req, res, next);
 	}
 
 	// Feature flags and configuration
-	@Post('/decide/', { skipAuth: true, rateLimit: { limit: 100, windowMs: 60_000 } })
+	@Post('/decide/', { skipAuth: true, ipRateLimit: { limit: 100, windowMs: 60_000 } })
 	async decide(req: AuthenticatedRequest, res: Response, next: NextFunction) {
 		return await this.proxy(req, res, next);
 	}
 
 	// Session recording events
-	@Post('/s/', { skipAuth: true, rateLimit: { limit: 50, windowMs: 60_000 } })
+	@Post('/s/', { skipAuth: true, ipRateLimit: { limit: 50, windowMs: 60_000 } })
 	async sessionRecording(req: AuthenticatedRequest, res: Response, next: NextFunction) {
 		return await this.proxy(req, res, next);
 	}
 
 	// Session recording events (alternative endpoint)
-	@Post('/e/', { skipAuth: true, rateLimit: { limit: 50, windowMs: 60_000 } })
+	@Post('/e/', { skipAuth: true, ipRateLimit: { limit: 50, windowMs: 60_000 } })
 	async sessionEvents(req: AuthenticatedRequest, res: Response, next: NextFunction) {
 		return await this.proxy(req, res, next);
 	}
 
 	// Person/profile updates
-	@Post('/engage/', { skipAuth: true, rateLimit: { limit: 50, windowMs: 60_000 } })
+	@Post('/engage/', { skipAuth: true, ipRateLimit: { limit: 50, windowMs: 60_000 } })
 	async engage(req: AuthenticatedRequest, res: Response, next: NextFunction) {
 		return await this.proxy(req, res, next);
 	}
 
 	// Batch endpoint (for multiple events)
-	@Post('/batch/', { skipAuth: true, rateLimit: { limit: 100, windowMs: 60_000 } })
+	@Post('/batch/', { skipAuth: true, ipRateLimit: { limit: 100, windowMs: 60_000 } })
 	async batch(req: AuthenticatedRequest, res: Response, next: NextFunction) {
 		return await this.proxy(req, res, next);
 	}
 
 	// Feature flags endpoint - /flags/
-	@Post('/flags/', { skipAuth: true, rateLimit: { limit: 100, windowMs: 60_000 } })
+	@Post('/flags/', { skipAuth: true, ipRateLimit: { limit: 100, windowMs: 60_000 } })
 	async flags(req: AuthenticatedRequest, res: Response, next: NextFunction) {
 		return await this.proxy(req, res, next);
 	}
@@ -76,7 +76,7 @@ export class PostHogController {
 	@Get('/static/array.js', {
 		skipAuth: true,
 		usesTemplates: true,
-		rateLimit: { limit: 50, windowMs: 60_000 },
+		ipRateLimit: { limit: 50, windowMs: 60_000 },
 	})
 	staticArrayJs(req: AuthenticatedRequest, res: Response, next: NextFunction) {
 		void this.proxy(req, res, next);
@@ -85,7 +85,7 @@ export class PostHogController {
 	@Get('/static/lazy-recorder.js', {
 		skipAuth: true,
 		usesTemplates: true,
-		rateLimit: { limit: 50, windowMs: 60_000 },
+		ipRateLimit: { limit: 50, windowMs: 60_000 },
 	})
 	staticLazyRecorderJs(req: AuthenticatedRequest, res: Response, next: NextFunction) {
 		void this.proxy(req, res, next);
@@ -94,7 +94,7 @@ export class PostHogController {
 	// Configuration endpoints for array.js
 	@Get('/array/:apiKey/config.js', {
 		skipAuth: true,
-		rateLimit: { limit: 20, windowMs: 60_000 },
+		ipRateLimit: { limit: 20, windowMs: 60_000 },
 		usesTemplates: true,
 	})
 	arrayConfig(req: AuthenticatedRequest, res: Response, next: NextFunction) {

--- a/packages/cli/src/controllers/telemetry.controller.ts
+++ b/packages/cli/src/controllers/telemetry.controller.ts
@@ -25,23 +25,23 @@ export class TelemetryController {
 		});
 	}
 
-	@Post('/proxy/:version/track', { skipAuth: true, rateLimit: { limit: 100, windowMs: 60_000 } })
+	@Post('/proxy/:version/track', { skipAuth: true, ipRateLimit: { limit: 100, windowMs: 60_000 } })
 	async track(req: AuthenticatedRequest, res: Response, next: NextFunction) {
 		await this.proxy(req, res, next);
 	}
 
-	@Post('/proxy/:version/identify', { skipAuth: true, rateLimit: true })
+	@Post('/proxy/:version/identify', { skipAuth: true, ipRateLimit: true })
 	async identify(req: AuthenticatedRequest, res: Response, next: NextFunction) {
 		await this.proxy(req, res, next);
 	}
 
-	@Post('/proxy/:version/page', { skipAuth: true, rateLimit: { limit: 50, windowMs: 60_000 } })
+	@Post('/proxy/:version/page', { skipAuth: true, ipRateLimit: { limit: 50, windowMs: 60_000 } })
 	async page(req: AuthenticatedRequest, res: Response, next: NextFunction) {
 		await this.proxy(req, res, next);
 	}
 	@Get('/rudderstack/sourceConfig', {
 		skipAuth: true,
-		rateLimit: { limit: 50, windowMs: 60_000 },
+		ipRateLimit: { limit: 50, windowMs: 60_000 },
 		usesTemplates: true,
 	})
 	async sourceConfig(_: Request, res: Response) {

--- a/packages/cli/src/modules/mcp/mcp.controller.ts
+++ b/packages/cli/src/modules/mcp/mcp.controller.ts
@@ -69,7 +69,7 @@ export class McpController {
 	}
 
 	@Post('/http', {
-		rateLimit: { limit: 100 },
+		ipRateLimit: { limit: 100 },
 		middlewares: [getAuthMiddleware()],
 		skipAuth: true,
 		usesTemplates: true,

--- a/packages/cli/src/services/rate-limit.service.ts
+++ b/packages/cli/src/services/rate-limit.service.ts
@@ -54,10 +54,12 @@ export class RateLimitService {
 
 		if (source === 'body') {
 			const body = req.body;
-			const value = body[config.field];
+			if (!body) {
+				return 'skip:no-body';
+			}
 
-			// Only consider string or number values
-			if (value === '' || (typeof value !== 'string' && typeof value !== 'number')) {
+			const value = body[config.field];
+			if (typeof value !== 'string' && typeof value !== 'number') {
 				return 'skip:no-identifier';
 			}
 

--- a/packages/cli/src/services/rate-limit.service.ts
+++ b/packages/cli/src/services/rate-limit.service.ts
@@ -5,6 +5,12 @@ import type { Request, RequestHandler } from 'express';
 import { rateLimit as expressRateLimit } from 'express-rate-limit';
 import assert from 'node:assert';
 import { ErrorReporter } from 'n8n-core';
+import { Time } from '@n8n/constants';
+
+const defaultLimits: Required<RateLimiterLimits> = {
+	limit: 5,
+	windowMs: 5 * Time.minutes.toMilliseconds,
+};
 
 /**
  * Service for creating rate limiters for endpoints. We use a 2 layered approach
@@ -26,8 +32,8 @@ export class RateLimitService {
 		if (typeof rateLimit === 'boolean') rateLimit = {};
 
 		return expressRateLimit({
-			limit: rateLimit.limit,
-			windowMs: rateLimit.windowMs,
+			limit: rateLimit.limit ?? defaultLimits.limit,
+			windowMs: rateLimit.windowMs ?? defaultLimits.windowMs,
 			message: { message: 'Too many requests' },
 		});
 	}
@@ -38,8 +44,8 @@ export class RateLimitService {
 	 */
 	createKeyedRateLimitMiddleware(config: KeyedRateLimiterConfig): RequestHandler {
 		return expressRateLimit({
-			windowMs: config.windowMs,
-			limit: config.limit,
+			limit: config.limit ?? defaultLimits.limit,
+			windowMs: config.windowMs ?? defaultLimits.windowMs,
 			keyGenerator: (req: Request) => this.extractReqIdentifier(req, config),
 			skip: (req: Request) => {
 				const identifier = this.extractReqIdentifier(req, config);

--- a/packages/cli/src/services/rate-limit.service.ts
+++ b/packages/cli/src/services/rate-limit.service.ts
@@ -1,0 +1,86 @@
+import { Service } from '@n8n/di';
+import type { RateLimiterLimits, KeyedRateLimiterConfig } from '@n8n/decorators';
+import type { AuthenticatedRequest } from '@n8n/db';
+import type { Request, RequestHandler } from 'express';
+import { rateLimit as expressRateLimit } from 'express-rate-limit';
+import assert from 'node:assert';
+import { ErrorReporter } from 'n8n-core';
+
+/**
+ * Service for creating rate limiters for endpoints. We use a 2 layered approach
+ * to rate limiting for better balance between security and usability. This helps
+ * in situations where multiple users are using the same IP address.
+ *
+ * Layer 1: IP-based rate limit middleware
+ * Layer 2: User-based rate limit middleware
+ */
+@Service()
+export class RateLimitService {
+	constructor(private readonly errorReporter: ErrorReporter) {}
+
+	/**
+	 * Creates Layer 1: IP-based rate limit middleware
+	 * Always runs BEFORE authentication.
+	 */
+	createIpRateLimitMiddleware(rateLimit: boolean | RateLimiterLimits): RequestHandler {
+		if (typeof rateLimit === 'boolean') rateLimit = {};
+
+		return expressRateLimit({
+			limit: rateLimit.limit,
+			windowMs: rateLimit.windowMs,
+			message: { message: 'Too many requests' },
+		});
+	}
+
+	/**
+	 * Creates Layer 2: Keyed rate limit middleware
+	 * Position (before/after auth) depends on identifier source
+	 */
+	createKeyedRateLimitMiddleware(config: KeyedRateLimiterConfig): RequestHandler {
+		return expressRateLimit({
+			windowMs: config.windowMs,
+			limit: config.limit,
+			keyGenerator: (req: Request) => this.extractReqIdentifier(req, config),
+			skip: (req: Request) => {
+				const identifier = this.extractReqIdentifier(req, config);
+				return identifier.startsWith('skip:');
+			},
+			message: { message: 'Too many requests' },
+		});
+	}
+
+	private extractReqIdentifier(req: Request, config: KeyedRateLimiterConfig): string {
+		const { source } = config;
+
+		if (source === 'body') {
+			const body = req.body;
+			const value = body[config.field];
+
+			// Only consider string or number values
+			if (value === '' || (typeof value !== 'string' && typeof value !== 'number')) {
+				return 'skip:no-identifier';
+			}
+
+			return `body:${value}`;
+		}
+
+		if (source === 'user') {
+			const authReq = req as AuthenticatedRequest;
+			if (!authReq.user) {
+				this.errorReporter.error(new Error('Missing user for user-based rate limited endpoint'), {
+					extra: {
+						request: {
+							method: req.method,
+							url: req.url,
+						},
+					},
+				});
+				return 'skip:not-authenticated';
+			}
+
+			return `user:${authReq.user.id}`;
+		}
+
+		assert.fail(`Unknown source for keyed rate limiting: ${JSON.stringify(config)}`);
+	}
+}


### PR DESCRIPTION
## Summary

Introduces a two-layered rate limiting approach to better balance security and usability, particularly for scenarios where multiple users share the same IP address (e.g., corporate networks).

Layer 1 (IP-based): Applies rate limits based on IP address before authentication to prevent brute force attacks at the network level.

Layer 2 (Keyed): Applies more granular rate limits based on:
- Request body fields (e.g., email during login attempts)
- Authenticated user IDs (after authentication)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2168

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
