### PR TITLE
feat(FormTrigger Node): Support ip filtering for the FormTrigger node

### DIFF
--- a/packages/nodes-base/nodes/Form/common.descriptions.ts
+++ b/packages/nodes-base/nodes/Form/common.descriptions.ts
@@ -93,6 +93,16 @@ export const formDescription: INodeProperties = {
 	},
 };
 
+export const ipAllowlist: INodeProperties = {
+	displayName: 'IP(s) Allowlist',
+	name: 'ipWhitelist',
+	type: 'string',
+	placeholder: 'e.g. 127.0.0.1, 192.168.1.0/24',
+	default: '',
+	description:
+		'Comma-separated list of allowed IP addresses or CIDR ranges. Leave empty to allow all IPs.',
+};
+
 const formOptions: INodePropertyCollection[] = [
 	{
 		displayName: 'Values',

--- a/packages/nodes-base/nodes/Form/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/utils.test.ts
@@ -27,7 +27,7 @@ import {
 	addFormResponseDataToReturnItem,
 	validateSafeRedirectUrl,
 } from '../utils/utils';
-import { isIpWhitelisted } from '../../Webhook/utils';
+import { isIpAllowed } from '../../Webhook/utils';
 
 describe('FormTrigger, parseFormDescription', () => {
 	it('should remove HTML tags and truncate to 150 characters', () => {
@@ -2777,40 +2777,40 @@ describe('FormTrigger, prepareFormData - Default Value', () => {
 });
 
 describe('FormTrigger IP Whitelist', () => {
-	describe('isIpWhitelisted (reused from Webhook)', () => {
+	describe('isIpAllowed (reused from Webhook)', () => {
 		it('should return true if whitelist is undefined', () => {
-			expect(isIpWhitelisted(undefined, ['192.168.1.1'], '192.168.1.1')).toBe(true);
+			expect(isIpAllowed(undefined, ['192.168.1.1'], '192.168.1.1')).toBe(true);
 		});
 
 		it('should return true if whitelist is an empty string', () => {
-			expect(isIpWhitelisted('', ['192.168.1.1'], '192.168.1.1')).toBe(true);
+			expect(isIpAllowed('', ['192.168.1.1'], '192.168.1.1')).toBe(true);
 		});
 
 		it('should allow IP in whitelist', () => {
-			expect(isIpWhitelisted('192.168.1.1', [], '192.168.1.1')).toBe(true);
+			expect(isIpAllowed('192.168.1.1', [], '192.168.1.1')).toBe(true);
 		});
 
 		it('should block IP not in whitelist', () => {
-			expect(isIpWhitelisted('192.168.1.1', [], '192.168.1.2')).toBe(false);
+			expect(isIpAllowed('192.168.1.1', [], '192.168.1.2')).toBe(false);
 		});
 
 		it('should support CIDR notation', () => {
-			expect(isIpWhitelisted('192.168.1.0/24', [], '192.168.1.50')).toBe(true);
-			expect(isIpWhitelisted('192.168.1.0/24', [], '192.168.2.1')).toBe(false);
+			expect(isIpAllowed('192.168.1.0/24', [], '192.168.1.50')).toBe(true);
+			expect(isIpAllowed('192.168.1.0/24', [], '192.168.2.1')).toBe(false);
 		});
 
 		it('should support comma-separated mixed entries', () => {
-			expect(isIpWhitelisted('127.0.0.1, 192.168.1.0/24', [], '192.168.1.100')).toBe(true);
-			expect(isIpWhitelisted('127.0.0.1, 192.168.1.0/24', [], '10.0.0.1')).toBe(false);
+			expect(isIpAllowed('127.0.0.1, 192.168.1.0/24', [], '192.168.1.100')).toBe(true);
+			expect(isIpAllowed('127.0.0.1, 192.168.1.0/24', [], '10.0.0.1')).toBe(false);
 		});
 
 		it('should handle IPv6 addresses', () => {
-			expect(isIpWhitelisted('::1', [], '::1')).toBe(true);
-			expect(isIpWhitelisted('::1', [], '::2')).toBe(false);
+			expect(isIpAllowed('::1', [], '::1')).toBe(true);
+			expect(isIpAllowed('::1', [], '::2')).toBe(false);
 		});
 
 		it('should check both direct IP and proxy IPs', () => {
-			expect(isIpWhitelisted('192.168.1.1', ['192.168.1.1', '10.0.0.1'], '10.0.0.2')).toBe(true);
+			expect(isIpAllowed('192.168.1.1', ['192.168.1.1', '10.0.0.1'], '10.0.0.2')).toBe(true);
 		});
 	});
 });

--- a/packages/nodes-base/nodes/Form/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/utils.test.ts
@@ -2774,3 +2774,45 @@ describe('FormTrigger, prepareFormData - Default Value', () => {
 		expect(result.formFields[0].defaultValue).toBe('');
 	});
 });
+
+describe('FormTrigger IP Whitelist', () => {
+	describe('isIpWhitelisted (reused from Webhook)', () => {
+		// Import the function from Webhook utils for testing
+		const { isIpWhitelisted } = require('../../Webhook/utils');
+
+		it('should return true if whitelist is undefined', () => {
+			expect(isIpWhitelisted(undefined, ['192.168.1.1'], '192.168.1.1')).toBe(true);
+		});
+
+		it('should return true if whitelist is an empty string', () => {
+			expect(isIpWhitelisted('', ['192.168.1.1'], '192.168.1.1')).toBe(true);
+		});
+
+		it('should allow IP in whitelist', () => {
+			expect(isIpWhitelisted('192.168.1.1', [], '192.168.1.1')).toBe(true);
+		});
+
+		it('should block IP not in whitelist', () => {
+			expect(isIpWhitelisted('192.168.1.1', [], '192.168.1.2')).toBe(false);
+		});
+
+		it('should support CIDR notation', () => {
+			expect(isIpWhitelisted('192.168.1.0/24', [], '192.168.1.50')).toBe(true);
+			expect(isIpWhitelisted('192.168.1.0/24', [], '192.168.2.1')).toBe(false);
+		});
+
+		it('should support comma-separated mixed entries', () => {
+			expect(isIpWhitelisted('127.0.0.1, 192.168.1.0/24', [], '192.168.1.100')).toBe(true);
+			expect(isIpWhitelisted('127.0.0.1, 192.168.1.0/24', [], '10.0.0.1')).toBe(false);
+		});
+
+		it('should handle IPv6 addresses', () => {
+			expect(isIpWhitelisted('::1', [], '::1')).toBe(true);
+			expect(isIpWhitelisted('::1', [], '::2')).toBe(false);
+		});
+
+		it('should check both direct IP and proxy IPs', () => {
+			expect(isIpWhitelisted('192.168.1.1', ['192.168.1.1', '10.0.0.1'], '10.0.0.2')).toBe(true);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Form/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/utils.test.ts
@@ -27,6 +27,7 @@ import {
 	addFormResponseDataToReturnItem,
 	validateSafeRedirectUrl,
 } from '../utils/utils';
+import { isIpWhitelisted } from '../../Webhook/utils';
 
 describe('FormTrigger, parseFormDescription', () => {
 	it('should remove HTML tags and truncate to 150 characters', () => {
@@ -2777,9 +2778,6 @@ describe('FormTrigger, prepareFormData - Default Value', () => {
 
 describe('FormTrigger IP Whitelist', () => {
 	describe('isIpWhitelisted (reused from Webhook)', () => {
-		// Import the function from Webhook utils for testing
-		const { isIpWhitelisted } = require('../../Webhook/utils');
-
 		it('should return true if whitelist is undefined', () => {
 			expect(isIpWhitelisted(undefined, ['192.168.1.1'], '192.168.1.1')).toBe(true);
 		});

--- a/packages/nodes-base/nodes/Form/utils/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils/utils.ts
@@ -28,7 +28,7 @@ import { getResolvables } from '../../../utils/utilities';
 import { WebhookAuthorizationError } from '../../Webhook/error';
 import {
 	generateFormPostBasicAuthToken,
-	isIpWhitelisted,
+	isIpAllowed,
 	validateWebhookAuthentication,
 } from '../../Webhook/utils';
 import { FORM_TRIGGER_AUTHENTICATION_PROPERTY } from '../interfaces';
@@ -597,10 +597,10 @@ export async function formWebhook(
 	const res = context.getResponseObject();
 	const req = context.getRequestObject();
 
-	// Check IP whitelist first (before bot detection and authentication)
-	if (!isIpWhitelisted(options.ipWhitelist, req.ips, req.ip)) {
+	// Check IP allowlist first (before bot detection and authentication)
+	if (!isIpAllowed(options.ipWhitelist, req.ips, req.ip)) {
 		res.writeHead(403);
-		res.end('IP is not whitelisted to access this form!');
+		res.end('IP is not allowed to access this form!');
 		return { noWebhookResponse: true };
 	}
 

--- a/packages/nodes-base/nodes/Form/utils/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils/utils.ts
@@ -26,7 +26,11 @@ import sanitize from 'sanitize-html';
 
 import { getResolvables } from '../../../utils/utilities';
 import { WebhookAuthorizationError } from '../../Webhook/error';
-import { generateFormPostBasicAuthToken, validateWebhookAuthentication } from '../../Webhook/utils';
+import {
+	generateFormPostBasicAuthToken,
+	isIpWhitelisted,
+	validateWebhookAuthentication,
+} from '../../Webhook/utils';
 import { FORM_TRIGGER_AUTHENTICATION_PROPERTY } from '../interfaces';
 import type { FormTriggerData, FormField } from '../interfaces';
 
@@ -576,6 +580,7 @@ export async function formWebhook(
 	const node = context.getNode();
 	const options = context.getNodeParameter('options', {}) as {
 		ignoreBots?: boolean;
+		ipWhitelist?: string;
 		respondWithOptions?: {
 			values: {
 				respondWith: 'text' | 'redirect';
@@ -591,6 +596,13 @@ export async function formWebhook(
 	};
 	const res = context.getResponseObject();
 	const req = context.getRequestObject();
+
+	// Check IP whitelist first (before bot detection and authentication)
+	if (!isIpWhitelisted(options.ipWhitelist, req.ips, req.ip)) {
+		res.writeHead(403);
+		res.end('IP is not whitelisted to access this form!');
+		return { noWebhookResponse: true };
+	}
 
 	try {
 		if (options.ignoreBots && isbot(req.headers['user-agent'])) {

--- a/packages/nodes-base/nodes/Form/v1/FormTriggerV1.node.ts
+++ b/packages/nodes-base/nodes/Form/v1/FormTriggerV1.node.ts
@@ -78,7 +78,7 @@ const descriptionV1: INodeTypeDescription = {
 					default: 'Your response has been recorded',
 				},
 				{
-					displayName: 'IP(s) Whitelist',
+					displayName: 'IP(s) Allowlist',
 					name: 'ipWhitelist',
 					type: 'string',
 					placeholder: 'e.g. 127.0.0.1, 192.168.1.0/24',

--- a/packages/nodes-base/nodes/Form/v1/FormTriggerV1.node.ts
+++ b/packages/nodes-base/nodes/Form/v1/FormTriggerV1.node.ts
@@ -77,6 +77,15 @@ const descriptionV1: INodeTypeDescription = {
 					type: 'string',
 					default: 'Your response has been recorded',
 				},
+				{
+					displayName: 'IP(s) Whitelist',
+					name: 'ipWhitelist',
+					type: 'string',
+					placeholder: 'e.g. 127.0.0.1, 192.168.1.0/24',
+					default: '',
+					description:
+						'Comma-separated list of allowed IP addresses or CIDR ranges. Leave empty to allow all IPs.',
+				},
 			],
 		},
 	],

--- a/packages/nodes-base/nodes/Form/v1/FormTriggerV1.node.ts
+++ b/packages/nodes-base/nodes/Form/v1/FormTriggerV1.node.ts
@@ -14,6 +14,7 @@ import {
 	formTitle,
 	formTriggerPanel,
 	webhookPath,
+	ipAllowlist,
 } from '../common.descriptions';
 import { formWebhook } from '../utils/utils';
 
@@ -58,6 +59,7 @@ const descriptionV1: INodeTypeDescription = {
 		formDescription,
 		formFields,
 		formRespondMode,
+		ipAllowlist,
 		{
 			displayName: 'Options',
 			name: 'options',
@@ -76,15 +78,6 @@ const descriptionV1: INodeTypeDescription = {
 					description: 'The text displayed to users after they filled the form',
 					type: 'string',
 					default: 'Your response has been recorded',
-				},
-				{
-					displayName: 'IP(s) Allowlist',
-					name: 'ipWhitelist',
-					type: 'string',
-					placeholder: 'e.g. 127.0.0.1, 192.168.1.0/24',
-					default: '',
-					description:
-						'Comma-separated list of allowed IP addresses or CIDR ranges. Leave empty to allow all IPs.',
 				},
 			],
 		},

--- a/packages/nodes-base/nodes/Form/v1/FormTriggerV1.node.ts
+++ b/packages/nodes-base/nodes/Form/v1/FormTriggerV1.node.ts
@@ -59,7 +59,6 @@ const descriptionV1: INodeTypeDescription = {
 		formDescription,
 		formFields,
 		formRespondMode,
-		ipAllowlist,
 		{
 			displayName: 'Options',
 			name: 'options',
@@ -72,6 +71,7 @@ const descriptionV1: INodeTypeDescription = {
 				},
 			},
 			options: [
+				ipAllowlist,
 				{
 					displayName: 'Form Submitted Text',
 					name: 'formSubmittedText',

--- a/packages/nodes-base/nodes/Form/v2/FormTriggerV2.node.ts
+++ b/packages/nodes-base/nodes/Form/v2/FormTriggerV2.node.ts
@@ -166,7 +166,7 @@ const descriptionV2: INodeTypeDescription = {
 					description: 'Whether to ignore requests from bots like link previewers and web crawlers',
 				},
 				{
-					displayName: 'IP(s) Whitelist',
+					displayName: 'IP(s) Allowlist',
 					name: 'ipWhitelist',
 					type: 'string',
 					placeholder: 'e.g. 127.0.0.1, 192.168.1.0/24',

--- a/packages/nodes-base/nodes/Form/v2/FormTriggerV2.node.ts
+++ b/packages/nodes-base/nodes/Form/v2/FormTriggerV2.node.ts
@@ -166,6 +166,15 @@ const descriptionV2: INodeTypeDescription = {
 					description: 'Whether to ignore requests from bots like link previewers and web crawlers',
 				},
 				{
+					displayName: 'IP(s) Whitelist',
+					name: 'ipWhitelist',
+					type: 'string',
+					placeholder: 'e.g. 127.0.0.1, 192.168.1.0/24',
+					default: '',
+					description:
+						'Comma-separated list of allowed IP addresses or CIDR ranges. Leave empty to allow all IPs.',
+				},
+				{
 					...useWorkflowTimezone,
 					default: false,
 					description: "Whether to use the workflow timezone in 'submittedAt' field or UTC",

--- a/packages/nodes-base/nodes/Form/v2/FormTriggerV2.node.ts
+++ b/packages/nodes-base/nodes/Form/v2/FormTriggerV2.node.ts
@@ -17,6 +17,7 @@ import {
 	formRespondMode,
 	formTitle,
 	formTriggerPanel,
+	ipAllowlist,
 	respondWithOptions,
 	webhookPath,
 } from '../common.descriptions';
@@ -113,6 +114,7 @@ const descriptionV2: INodeTypeDescription = {
 			),
 			displayOptions: { show: { '@version': [{ _cnd: { gte: 2.2 } }] } },
 		},
+		ipAllowlist,
 		{
 			displayName:
 				"In the 'Respond to Webhook' node, select 'Respond With JSON' and set the <strong>formSubmittedText</strong> key to display a custom response in the form, or the <strong>redirectURL</strong> key to redirect users to a URL",
@@ -164,15 +166,6 @@ const descriptionV2: INodeTypeDescription = {
 					type: 'boolean',
 					default: false,
 					description: 'Whether to ignore requests from bots like link previewers and web crawlers',
-				},
-				{
-					displayName: 'IP(s) Allowlist',
-					name: 'ipWhitelist',
-					type: 'string',
-					placeholder: 'e.g. 127.0.0.1, 192.168.1.0/24',
-					default: '',
-					description:
-						'Comma-separated list of allowed IP addresses or CIDR ranges. Leave empty to allow all IPs.',
 				},
 				{
 					...useWorkflowTimezone,

--- a/packages/nodes-base/nodes/Form/v2/FormTriggerV2.node.ts
+++ b/packages/nodes-base/nodes/Form/v2/FormTriggerV2.node.ts
@@ -114,7 +114,6 @@ const descriptionV2: INodeTypeDescription = {
 			),
 			displayOptions: { show: { '@version': [{ _cnd: { gte: 2.2 } }] } },
 		},
-		ipAllowlist,
 		{
 			displayName:
 				"In the 'Respond to Webhook' node, select 'Respond With JSON' and set the <strong>formSubmittedText</strong> key to display a custom response in the form, or the <strong>redirectURL</strong> key to redirect users to a URL",
@@ -140,6 +139,7 @@ const descriptionV2: INodeTypeDescription = {
 			default: {},
 			options: [
 				appendAttributionToForm,
+				ipAllowlist,
 				{
 					displayName: 'Button Label',
 					description: 'The label of the submit button in the form',

--- a/packages/nodes-base/nodes/Webhook/Webhook.node.ts
+++ b/packages/nodes-base/nodes/Webhook/Webhook.node.ts
@@ -33,7 +33,7 @@ import {
 	checkResponseModeConfiguration,
 	configuredOutputs,
 	handleFormData,
-	isIpWhitelisted,
+	isIpAllowed,
 	setupOutputConnection,
 	validateWebhookAuthentication,
 } from './utils';
@@ -222,9 +222,9 @@ export class Webhook extends Node {
 		const resp = context.getResponseObject();
 		const requestMethod = context.getRequestObject().method;
 
-		if (!isIpWhitelisted(options.ipWhitelist, req.ips, req.ip)) {
+		if (!isIpAllowed(options.ipWhitelist, req.ips, req.ip)) {
 			resp.writeHead(403);
-			resp.end('IP is not whitelisted to access the webhook!');
+			resp.end('IP is not allowed to access the webhook!');
 			return { noWebhookResponse: true };
 		}
 

--- a/packages/nodes-base/nodes/Webhook/description.ts
+++ b/packages/nodes-base/nodes/Webhook/description.ts
@@ -289,9 +289,10 @@ export const optionsProperty: INodeProperties = {
 			displayName: 'IP(s) Whitelist',
 			name: 'ipWhitelist',
 			type: 'string',
-			placeholder: 'e.g. 127.0.0.1',
+			placeholder: 'e.g. 127.0.0.1, 192.168.1.0/24',
 			default: '',
-			description: 'Comma-separated list of allowed IP addresses. Leave empty to allow all IPs.',
+			description:
+				'Comma-separated list of allowed IP addresses or CIDR ranges. Leave empty to allow all IPs.',
 		},
 		{
 			displayName: 'No Response Body',

--- a/packages/nodes-base/nodes/Webhook/description.ts
+++ b/packages/nodes-base/nodes/Webhook/description.ts
@@ -286,7 +286,7 @@ export const optionsProperty: INodeProperties = {
 			description: 'Whether to ignore requests from bots like link previewers and web crawlers',
 		},
 		{
-			displayName: 'IP(s) Whitelist',
+			displayName: 'IP(s) Allowlist',
 			name: 'ipWhitelist',
 			type: 'string',
 			placeholder: 'e.g. 127.0.0.1, 192.168.1.0/24',

--- a/packages/nodes-base/nodes/Webhook/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Webhook/test/utils.test.ts
@@ -18,7 +18,7 @@ import {
 	getResponseCode,
 	getResponseData,
 	handleFormData,
-	isIpWhitelisted,
+	isIpAllowed,
 	setupOutputConnection,
 	validateWebhookAuthentication,
 } from '../utils';
@@ -217,94 +217,84 @@ describe('Webhook Utils', () => {
 		});
 	});
 
-	describe('isIpWhitelisted', () => {
-		it('should return true if whitelist is undefined', () => {
-			expect(isIpWhitelisted(undefined, ['192.168.1.1'], '192.168.1.1')).toBe(true);
+	describe('isIpAllowed', () => {
+		it('should return true if allowlist is undefined', () => {
+			expect(isIpAllowed(undefined, ['192.168.1.1'], '192.168.1.1')).toBe(true);
 		});
 
-		it('should return true if whitelist is an empty string', () => {
-			expect(isIpWhitelisted('', ['192.168.1.1'], '192.168.1.1')).toBe(true);
+		it('should return true if allowlist is an empty string', () => {
+			expect(isIpAllowed('', ['192.168.1.1'], '192.168.1.1')).toBe(true);
 		});
 
-		it('should return true if ip is in the whitelist', () => {
-			expect(isIpWhitelisted('192.168.1.1', ['192.168.1.2'], '192.168.1.1')).toBe(true);
+		it('should return true if ip is in the allowlist', () => {
+			expect(isIpAllowed('192.168.1.1', ['192.168.1.2'], '192.168.1.1')).toBe(true);
 		});
 
-		it('should return true if any ip in ips is in the whitelist', () => {
-			expect(isIpWhitelisted('192.168.1.1', ['192.168.1.1', '192.168.1.2'])).toBe(true);
+		it('should return true if any ip in ips is in the allowlist', () => {
+			expect(isIpAllowed('192.168.1.1', ['192.168.1.1', '192.168.1.2'])).toBe(true);
 		});
 
-		it('should return false if ip and ips are not in the whitelist', () => {
-			expect(isIpWhitelisted('192.168.1.3', ['192.168.1.1', '192.168.1.2'], '192.168.1.4')).toBe(
-				false,
-			);
+		it('should return false if ip and ips are not in the allowlist', () => {
+			expect(isIpAllowed('192.168.1.3', ['192.168.1.1', '192.168.1.2'], '192.168.1.4')).toBe(false);
 		});
 
-		it('should return true if any ip in ips matches any address in the whitelist array', () => {
-			expect(isIpWhitelisted(['192.168.1.1', '192.168.1.2'], ['192.168.1.2', '192.168.1.3'])).toBe(
+		it('should return true if any ip in ips matches any address in the allowlist array', () => {
+			expect(isIpAllowed(['192.168.1.1', '192.168.1.2'], ['192.168.1.2', '192.168.1.3'])).toBe(
 				true,
 			);
 		});
 
-		it('should return true if ip matches any address in the whitelist array', () => {
-			expect(isIpWhitelisted(['192.168.1.1', '192.168.1.2'], ['192.168.1.3'], '192.168.1.2')).toBe(
+		it('should return true if ip matches any address in the allowlist array', () => {
+			expect(isIpAllowed(['192.168.1.1', '192.168.1.2'], ['192.168.1.3'], '192.168.1.2')).toBe(
 				true,
 			);
 		});
 
-		it('should return false if ip and ips do not match any address in the whitelist array', () => {
+		it('should return false if ip and ips do not match any address in the allowlist array', () => {
 			expect(
-				isIpWhitelisted(
-					['192.168.1.4', '192.168.1.5'],
-					['192.168.1.1', '192.168.1.2'],
-					'192.168.1.3',
-				),
+				isIpAllowed(['192.168.1.4', '192.168.1.5'], ['192.168.1.1', '192.168.1.2'], '192.168.1.3'),
 			).toBe(false);
 		});
 
-		it('CAT-1846: should use CIDR matching to determine if ip is in the whitelist', () => {
-			expect(isIpWhitelisted('192.168.1.3', [], '192.168.1.30')).toBe(false);
+		it('CAT-1846: should use CIDR matching to determine if ip is in the allowlist', () => {
+			expect(isIpAllowed('192.168.1.3', [], '192.168.1.30')).toBe(false);
 		});
 
-		it('should handle comma-separated whitelist string', () => {
-			expect(isIpWhitelisted('192.168.1.1, 192.168.1.2', ['192.168.1.3'], '192.168.1.2')).toBe(
-				true,
-			);
+		it('should handle comma-separated allowlist string', () => {
+			expect(isIpAllowed('192.168.1.1, 192.168.1.2', ['192.168.1.3'], '192.168.1.2')).toBe(true);
 		});
 
-		it('should trim whitespace in comma-separated whitelist string', () => {
-			expect(isIpWhitelisted(' 192.168.1.1 , 192.168.1.2 ', ['192.168.1.3'], '192.168.1.2')).toBe(
-				true,
-			);
+		it('should trim whitespace in comma-separated allowlist string', () => {
+			expect(isIpAllowed(' 192.168.1.1 , 192.168.1.2 ', ['192.168.1.3'], '192.168.1.2')).toBe(true);
 		});
 
 		it('should support IPv4 CIDR notation', () => {
-			expect(isIpWhitelisted('192.168.1.0/24', [], '192.168.1.50')).toBe(true);
-			expect(isIpWhitelisted('192.168.1.0/24', [], '192.168.1.255')).toBe(true);
-			expect(isIpWhitelisted('192.168.1.0/24', [], '192.168.2.1')).toBe(false);
+			expect(isIpAllowed('192.168.1.0/24', [], '192.168.1.50')).toBe(true);
+			expect(isIpAllowed('192.168.1.0/24', [], '192.168.1.255')).toBe(true);
+			expect(isIpAllowed('192.168.1.0/24', [], '192.168.2.1')).toBe(false);
 		});
 
 		it('should support IPv6 CIDR notation', () => {
-			expect(isIpWhitelisted('2001:db8::/32', [], '2001:db8::1')).toBe(true);
-			expect(isIpWhitelisted('2001:db8::/32', [], '2001:db9::1')).toBe(false);
+			expect(isIpAllowed('2001:db8::/32', [], '2001:db8::1')).toBe(true);
+			expect(isIpAllowed('2001:db8::/32', [], '2001:db9::1')).toBe(false);
 		});
 
 		it('should support mixed single IPs and CIDR ranges', () => {
-			expect(isIpWhitelisted('127.0.0.1, 192.168.0.0/16', [], '192.168.100.50')).toBe(true);
-			expect(isIpWhitelisted('127.0.0.1, 192.168.0.0/16', [], '10.0.0.1')).toBe(false);
-			expect(isIpWhitelisted('127.0.0.1, 192.168.0.0/16', [], '127.0.0.1')).toBe(true);
+			expect(isIpAllowed('127.0.0.1, 192.168.0.0/16', [], '192.168.100.50')).toBe(true);
+			expect(isIpAllowed('127.0.0.1, 192.168.0.0/16', [], '10.0.0.1')).toBe(false);
+			expect(isIpAllowed('127.0.0.1, 192.168.0.0/16', [], '127.0.0.1')).toBe(true);
 		});
 
 		it('should handle invalid CIDR notation gracefully', () => {
-			expect(isIpWhitelisted('192.168.1.0/abc', [], '192.168.1.1')).toBe(false);
-			expect(isIpWhitelisted('192.168.1.0/99', [], '192.168.1.1')).toBe(false);
-			expect(isIpWhitelisted('invalid/24', [], '192.168.1.1')).toBe(false);
+			expect(isIpAllowed('192.168.1.0/abc', [], '192.168.1.1')).toBe(false);
+			expect(isIpAllowed('192.168.1.0/99', [], '192.168.1.1')).toBe(false);
+			expect(isIpAllowed('invalid/24', [], '192.168.1.1')).toBe(false);
 		});
 
 		it('should handle /32 and /128 CIDR (single IP)', () => {
-			expect(isIpWhitelisted('192.168.1.1/32', [], '192.168.1.1')).toBe(true);
-			expect(isIpWhitelisted('192.168.1.1/32', [], '192.168.1.2')).toBe(false);
-			expect(isIpWhitelisted('::1/128', [], '::1')).toBe(true);
+			expect(isIpAllowed('192.168.1.1/32', [], '192.168.1.1')).toBe(true);
+			expect(isIpAllowed('192.168.1.1/32', [], '192.168.1.2')).toBe(false);
+			expect(isIpAllowed('::1/128', [], '::1')).toBe(true);
 		});
 	});
 

--- a/packages/nodes-base/nodes/Webhook/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Webhook/test/utils.test.ts
@@ -277,6 +277,35 @@ describe('Webhook Utils', () => {
 				true,
 			);
 		});
+
+		it('should support IPv4 CIDR notation', () => {
+			expect(isIpWhitelisted('192.168.1.0/24', [], '192.168.1.50')).toBe(true);
+			expect(isIpWhitelisted('192.168.1.0/24', [], '192.168.1.255')).toBe(true);
+			expect(isIpWhitelisted('192.168.1.0/24', [], '192.168.2.1')).toBe(false);
+		});
+
+		it('should support IPv6 CIDR notation', () => {
+			expect(isIpWhitelisted('2001:db8::/32', [], '2001:db8::1')).toBe(true);
+			expect(isIpWhitelisted('2001:db8::/32', [], '2001:db9::1')).toBe(false);
+		});
+
+		it('should support mixed single IPs and CIDR ranges', () => {
+			expect(isIpWhitelisted('127.0.0.1, 192.168.0.0/16', [], '192.168.100.50')).toBe(true);
+			expect(isIpWhitelisted('127.0.0.1, 192.168.0.0/16', [], '10.0.0.1')).toBe(false);
+			expect(isIpWhitelisted('127.0.0.1, 192.168.0.0/16', [], '127.0.0.1')).toBe(true);
+		});
+
+		it('should handle invalid CIDR notation gracefully', () => {
+			expect(isIpWhitelisted('192.168.1.0/abc', [], '192.168.1.1')).toBe(false);
+			expect(isIpWhitelisted('192.168.1.0/99', [], '192.168.1.1')).toBe(false);
+			expect(isIpWhitelisted('invalid/24', [], '192.168.1.1')).toBe(false);
+		});
+
+		it('should handle /32 and /128 CIDR (single IP)', () => {
+			expect(isIpWhitelisted('192.168.1.1/32', [], '192.168.1.1')).toBe(true);
+			expect(isIpWhitelisted('192.168.1.1/32', [], '192.168.1.2')).toBe(false);
+			expect(isIpWhitelisted('::1/128', [], '::1')).toBe(true);
+		});
 	});
 
 	describe('checkResponseModeConfiguration', () => {

--- a/packages/nodes-base/nodes/Webhook/utils.ts
+++ b/packages/nodes-base/nodes/Webhook/utils.ts
@@ -127,20 +127,20 @@ export const setupOutputConnection = (
 	};
 };
 
-export const isIpWhitelisted = (
-	whitelist: string | string[] | undefined,
+export const isIpAllowed = (
+	allowlist: string | string[] | undefined,
 	ips: string[],
 	ip?: string,
 ) => {
-	if (whitelist === undefined || whitelist === '') {
+	if (allowlist === undefined || allowlist === '') {
 		return true;
 	}
 
-	if (!Array.isArray(whitelist)) {
-		whitelist = whitelist.split(',').map((entry) => entry.trim());
+	if (!Array.isArray(allowlist)) {
+		allowlist = allowlist.split(',').map((entry) => entry.trim());
 	}
 
-	const allowList = getAllowList(whitelist);
+	const allowList = getAllowList(allowlist);
 
 	// Check the primary IP address with proper family detection
 	if (ip) {
@@ -163,10 +163,10 @@ export const isIpWhitelisted = (
 	return false;
 };
 
-const getAllowList = (whitelist: string[]) => {
+const getAllowList = (allowlist: string[]) => {
 	const allowList = new BlockList();
 
-	for (const entry of whitelist) {
+	for (const entry of allowlist) {
 		try {
 			// Check if entry is in CIDR notation (contains /)
 			if (entry.includes('/')) {

--- a/packages/nodes-base/nodes/Webhook/utils.ts
+++ b/packages/nodes-base/nodes/Webhook/utils.ts
@@ -190,14 +190,8 @@ const getAllowList = (allowlist: string[]) => {
 				allowList.addSubnet(network, prefix, type);
 			} else {
 				// Single IP address
-				// Note: IPv6 addresses need to use addSubnet() with /128 in Node.js BlockList
-				// because addAddress() throws "Invalid socket address" for IPv6
 				const type = entry.includes(':') ? 'ipv6' : 'ipv4';
-				if (type === 'ipv6') {
-					allowList.addSubnet(entry, 128, type);
-				} else {
-					allowList.addAddress(entry);
-				}
+				allowList.addAddress(entry, type);
 			}
 		} catch {
 			// Ignore invalid entries


### PR DESCRIPTION
## Summary

Bring the same IP filtering that the Webhook node has into the Form trigger node.

Also adds support for CIDR ranges and IPv6; previously we only supported specific IPv4 addresses.

Verified locally that individual addresses as well as ranges are enforced.

## Related Linear tickets, Github issues, and Community forum posts

https://community.n8n.io/t/allowlist-trusted-ip-ranges-for-forms-submissions/252770

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
