### PR TITLE
feat(core): Check if dynamic credentials auth token is set, return 400 otherwise

### DIFF
--- a/packages/cli/src/middlewares/cors.ts
+++ b/packages/cli/src/middlewares/cors.ts
@@ -8,7 +8,7 @@ export const corsMiddleware: RequestHandler = (req, res, next) => {
 		res.header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE');
 		res.header(
 			'Access-Control-Allow-Headers',
-			'Origin, X-Requested-With, Content-Type, Accept, push-ref, browser-id, anonymousid, authorization',
+			'Origin, X-Requested-With, Content-Type, Accept, push-ref, browser-id, anonymousid, authorization, x-authorization',
 		);
 	}
 

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential-cors.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential-cors.service.test.ts
@@ -68,6 +68,7 @@ describe('DynamicCredentialCorsService', () => {
 				'Authorization',
 				'Content-Type',
 				'X-Requested-With',
+				'X-Authorization',
 			]);
 
 			// Test 2: 'https://app.com,https://admin.com' → ['https://app.com', 'https://admin.com']
@@ -89,6 +90,7 @@ describe('DynamicCredentialCorsService', () => {
 				'Authorization',
 				'Content-Type',
 				'X-Requested-With',
+				'X-Authorization',
 			]);
 		});
 
@@ -182,7 +184,7 @@ describe('DynamicCredentialCorsService', () => {
 			// Verify: corsService.applyCorsHeaders called with allowedMethods
 			expect(mockCorsService.applyCorsHeaders).toHaveBeenCalledWith(mockRequest, mockResponse, {
 				allowedOrigins: ['https://app.com'],
-				allowedHeaders: ['Authorization', 'Content-Type', 'X-Requested-With'],
+				allowedHeaders: ['Authorization', 'Content-Type', 'X-Requested-With', 'X-Authorization'],
 				allowCredentials: true,
 				allowedMethods: ['post', 'options'],
 			});
@@ -232,7 +234,7 @@ describe('DynamicCredentialCorsService', () => {
 			// Verify: corsService called with merged options (defaultOptions + allowedMethods)
 			expect(mockCorsService.applyCorsHeaders).toHaveBeenCalledWith(mockRequest, mockResponse, {
 				allowedOrigins: ['https://app.com'],
-				allowedHeaders: ['Authorization', 'Content-Type', 'X-Requested-With'],
+				allowedHeaders: ['Authorization', 'Content-Type', 'X-Requested-With', 'X-Authorization'],
 				allowCredentials: true,
 				allowedMethods: ['get', 'options'],
 			});

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential.service.test.ts
@@ -1,5 +1,6 @@
 import type { Logger } from '@n8n/backend-common';
 import { CredentialResolverDataNotFoundError, type ICredentialResolver } from '@n8n/decorators';
+import type { Request, Response } from 'express';
 import type { Cipher } from 'n8n-core';
 import type {
 	ICredentialContext,
@@ -9,15 +10,15 @@ import type {
 
 import type { CredentialResolveMetadata } from '@/credentials/credential-resolution-provider.interface';
 import type { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
+import { StaticAuthService } from '@/services/static-auth-service';
 
 import type { DynamicCredentialResolver } from '../../database/entities/credential-resolver';
 import type { DynamicCredentialResolverRepository } from '../../database/repositories/credential-resolver.repository';
+import type { DynamicCredentialsConfig } from '../../dynamic-credentials.config';
 import { CredentialResolutionError } from '../../errors/credential-resolution.error';
 import type { DynamicCredentialResolverRegistry } from '../credential-resolver-registry.service';
 import { DynamicCredentialService } from '../dynamic-credential.service';
 import type { ResolverConfigExpressionService } from '../resolver-config-expression.service';
-import { StaticAuthService } from '@/services/static-auth-service';
-import type { DynamicCredentialsConfig } from '../../dynamic-credentials.config';
 
 describe('DynamicCredentialService', () => {
 	let service: DynamicCredentialService;
@@ -1077,6 +1078,35 @@ describe('DynamicCredentialService', () => {
 		});
 
 		describe('getDynamicCredentialsEndpointsMiddleware', () => {
+			it('should return a bad request middleware when no token is set', () => {
+				mockDynamicCredentialConfig.endpointAuthToken = ' ';
+				service = new DynamicCredentialService(
+					mockDynamicCredentialConfig,
+					mockResolverRegistry,
+					mockResolverRepository,
+					mockLoadNodesAndCredentials,
+					mockCipher,
+					mockLogger,
+					mockExpressionService,
+				);
+				const middleware = service.getDynamicCredentialsEndpointsMiddleware();
+				const mockReq = {} as Request;
+				const mockRes = {
+					status: jest.fn().mockReturnThis(),
+					json: jest.fn(),
+				} as unknown as Response;
+				const mockNext = jest.fn();
+
+				middleware(mockReq, mockRes, mockNext);
+
+				expect(mockRes.status).toHaveBeenCalledWith(400);
+				expect(mockRes.json).toHaveBeenCalledWith({
+					message:
+						'You must provide an endpoint auth token to access dynamic credentials external endpoints.',
+				});
+				expect(mockNext).not.toHaveBeenCalled();
+			});
+
 			it('should call the static auth middleware with the correct token', () => {
 				const getStaticAuthMiddlewareSpy = jest.spyOn(StaticAuthService, 'getStaticAuthMiddleware');
 				mockDynamicCredentialConfig.endpointAuthToken = 'test-token';

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential.service.test.ts
@@ -1099,10 +1099,9 @@ describe('DynamicCredentialService', () => {
 
 				middleware(mockReq, mockRes, mockNext);
 
-				expect(mockRes.status).toHaveBeenCalledWith(400);
+				expect(mockRes.status).toHaveBeenCalledWith(500);
 				expect(mockRes.json).toHaveBeenCalledWith({
-					message:
-						'You must provide an endpoint auth token to access dynamic credentials external endpoints.',
+					message: 'Dynamic credentials configuration is invalid. Check server logs for details.',
 				});
 				expect(mockNext).not.toHaveBeenCalled();
 			});

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential-cors.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential-cors.service.ts
@@ -43,7 +43,7 @@ export class DynamicCredentialCorsService {
 
 		this.defaultOptions = {
 			allowedOrigins,
-			allowedHeaders: ['Authorization', 'Content-Type', 'X-Requested-With'],
+			allowedHeaders: ['Authorization', 'Content-Type', 'X-Requested-With', 'X-Authorization'],
 			allowCredentials: this.dynamicCredentialConfig.corsAllowCredentials,
 		};
 	}

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential.service.ts
@@ -247,9 +247,11 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 		const { endpointAuthToken } = this.dynamicCredentialConfig;
 		if (!endpointAuthToken?.trim()) {
 			return (_req: Request, res: Response, _next: NextFunction) => {
-				res.status(400).json({
-					message:
-						'You must provide an endpoint auth token to access dynamic credentials external endpoints.',
+				this.logger.error(
+					'Dynamic credentials external endpoints require an endpoint auth token. Please set the N8N_DYNAMIC_CREDENTIALS_ENDPOINT_AUTH_TOKEN environment variable to enable access.',
+				);
+				res.status(500).json({
+					message: 'Dynamic credentials configuration is invalid. Check server logs for details.',
 				});
 				return;
 			};

--- a/packages/cli/src/modules/dynamic-credentials.ee/utils.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/utils.ts
@@ -24,7 +24,5 @@ export function getBearerToken(req: Request): string {
 }
 
 export const getDynamicCredentialMiddlewares = () => {
-	const dynamicCredentialEndpointsMiddleware =
-		Container.get(DynamicCredentialService).getDynamicCredentialsEndpointsMiddleware();
-	return dynamicCredentialEndpointsMiddleware ? [dynamicCredentialEndpointsMiddleware] : undefined;
+	return [Container.get(DynamicCredentialService).getDynamicCredentialsEndpointsMiddleware()];
 };

--- a/packages/cli/test/integration/dynamic-credentials.ee/dynamic-credentials.no-auth.api.test.ts
+++ b/packages/cli/test/integration/dynamic-credentials.ee/dynamic-credentials.no-auth.api.test.ts
@@ -120,28 +120,32 @@ describe('Dynamic Credentials API', () => {
 
 	describe('POST /credentials/:id/authorize', () => {
 		describe('when no static auth token is provided', () => {
-			it('should return the authorization URL for a credential', async () => {
+			it('should return a 400 Bad Request', async () => {
 				const response = await testServer.authlessAgent
 					.post(`/credentials/${savedCredential.id}/authorize`)
 					.query({ resolverId: resolver.id })
 					.set('Authorization', 'Bearer test-token')
-					.expect(200);
+					.expect(400);
 
-				expect(response.body.data).toBeDefined();
-				expect(typeof response.body.data).toBe('string');
-				expect(response.body.data).toContain('https://test.domain/oauth2/auth');
+				expect(response.body.message).toBe(
+					'You must provide an endpoint auth token to access dynamic credentials external endpoints.',
+				);
 			});
 		});
 	});
 
 	describe('DELETE /credentials/:id/revoke', () => {
 		describe('when no static auth token is provided', () => {
-			it('should revoke a credential', async () => {
-				await testServer.authlessAgent
+			it('should return a 400 Bad Request', async () => {
+				const response = await testServer.authlessAgent
 					.delete(`/credentials/${savedCredential.id}/revoke`)
 					.set('Authorization', 'Bearer test-token')
 					.query({ resolverId: resolver.id })
-					.expect(204);
+					.expect(400);
+
+				expect(response.body.message).toBe(
+					'You must provide an endpoint auth token to access dynamic credentials external endpoints.',
+				);
 			});
 		});
 	});

--- a/packages/cli/test/integration/dynamic-credentials.ee/dynamic-credentials.no-auth.api.test.ts
+++ b/packages/cli/test/integration/dynamic-credentials.ee/dynamic-credentials.no-auth.api.test.ts
@@ -120,15 +120,15 @@ describe('Dynamic Credentials API', () => {
 
 	describe('POST /credentials/:id/authorize', () => {
 		describe('when no static auth token is provided', () => {
-			it('should return a 400 Bad Request', async () => {
+			it('should return a 500 Internal Server Error', async () => {
 				const response = await testServer.authlessAgent
 					.post(`/credentials/${savedCredential.id}/authorize`)
 					.query({ resolverId: resolver.id })
 					.set('Authorization', 'Bearer test-token')
-					.expect(400);
+					.expect(500);
 
 				expect(response.body.message).toBe(
-					'You must provide an endpoint auth token to access dynamic credentials external endpoints.',
+					'Dynamic credentials configuration is invalid. Check server logs for details.',
 				);
 			});
 		});
@@ -136,15 +136,15 @@ describe('Dynamic Credentials API', () => {
 
 	describe('DELETE /credentials/:id/revoke', () => {
 		describe('when no static auth token is provided', () => {
-			it('should return a 400 Bad Request', async () => {
+			it('should return a 500 Internal Server Error', async () => {
 				const response = await testServer.authlessAgent
 					.delete(`/credentials/${savedCredential.id}/revoke`)
 					.set('Authorization', 'Bearer test-token')
 					.query({ resolverId: resolver.id })
-					.expect(400);
+					.expect(500);
 
 				expect(response.body.message).toBe(
-					'You must provide an endpoint auth token to access dynamic credentials external endpoints.',
+					'Dynamic credentials configuration is invalid. Check server logs for details.',
 				);
 			});
 		});

--- a/packages/cli/test/integration/dynamic-credentials.ee/workflow-status.no-auth.api.test.ts
+++ b/packages/cli/test/integration/dynamic-credentials.ee/workflow-status.no-auth.api.test.ts
@@ -157,19 +157,11 @@ describe('Workflow Status API', () => {
 				const response = await testServer.authlessAgent
 					.get(`/workflows/${savedWorkflow.id}/execution-status`)
 					.set('Authorization', 'Bearer test-token')
-					.expect(200);
+					.expect(400);
 
-				expect(response.body.data).toMatchObject({
-					workflowId: savedWorkflow.id,
-					readyToExecute: expect.any(Boolean),
-					credentials: expect.arrayContaining([
-						expect.objectContaining({
-							credentialId: savedCredential.id,
-							credentialName: savedCredential.name,
-							credentialType: savedCredential.type,
-							credentialStatus: expect.any(String),
-						}),
-					]),
+				expect(response.body).toMatchObject({
+					message:
+						'You must provide an endpoint auth token to access dynamic credentials external endpoints.',
 				});
 			});
 		});

--- a/packages/cli/test/integration/dynamic-credentials.ee/workflow-status.no-auth.api.test.ts
+++ b/packages/cli/test/integration/dynamic-credentials.ee/workflow-status.no-auth.api.test.ts
@@ -151,15 +151,14 @@ describe('Workflow Status API', () => {
 
 	describe('GET /workflows/:workflowId/execution-status', () => {
 		describe('when no static auth token is provided', () => {
-			it('should return the execution status of a workflow', async () => {
+			it('should return a 500 Internal Server Error', async () => {
 				const response = await testServer.authlessAgent
 					.get(`/workflows/${savedWorkflow.id}/execution-status`)
 					.set('Authorization', 'Bearer test-token')
-					.expect(400);
+					.expect(500);
 
 				expect(response.body).toMatchObject({
-					message:
-						'You must provide an endpoint auth token to access dynamic credentials external endpoints.',
+					message: 'Dynamic credentials configuration is invalid. Check server logs for details.',
 				});
 			});
 		});

--- a/packages/cli/test/integration/dynamic-credentials.ee/workflow-status.no-auth.api.test.ts
+++ b/packages/cli/test/integration/dynamic-credentials.ee/workflow-status.no-auth.api.test.ts
@@ -1,6 +1,5 @@
 import { LicenseState } from '@n8n/backend-common';
 import { mockInstance, getPersonalProject, testDb } from '@n8n/backend-test-utils';
-import type { CredentialsEntity } from '@n8n/db';
 import {
 	GLOBAL_OWNER_ROLE,
 	WorkflowRepository,
@@ -9,17 +8,17 @@ import {
 } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
+import type { INode } from 'n8n-workflow';
 import nock from 'nock';
 import { v4 as uuid } from 'uuid';
-import type { INode } from 'n8n-workflow';
 
-import * as utils from '../shared/utils';
+import { DynamicCredentialsConfig } from '@/modules/dynamic-credentials.ee/dynamic-credentials.config';
 import { DynamicCredentialResolverService } from '@/modules/dynamic-credentials.ee/services/credential-resolver.service';
 import { Telemetry } from '@/telemetry';
-import { createCredentials } from '../shared/db/credentials';
-import { DynamicCredentialsConfig } from '@/modules/dynamic-credentials.ee/dynamic-credentials.config';
 
+import { createCredentials } from '../shared/db/credentials';
 import { createUser } from '../shared/db/users';
+import * as utils from '../shared/utils';
 
 mockInstance(Telemetry);
 
@@ -107,7 +106,6 @@ const setupWorkflow = async () => {
 
 describe('Workflow Status API', () => {
 	let savedWorkflow: WorkflowEntity;
-	let savedCredential: CredentialsEntity;
 
 	beforeAll(async () => {
 		// Mock OAuth metadata endpoint for resolver validation
@@ -142,7 +140,7 @@ describe('Workflow Status API', () => {
 			'DynamicCredentialResolver',
 		]);
 
-		({ savedWorkflow, savedCredential } = await setupWorkflow());
+		({ savedWorkflow } = await setupWorkflow());
 	});
 
 	afterAll(async () => {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Force `N8N_DYNAMIC_CREDENTIALS_ENDPOINT_AUTH_TOKEN` environment variable to be set in order to call the dynamic credentials external endpoints for marketplace
Also allow x-authorization header to be sent from the marketplace on dev, so that the static auth token can be sent from a frontend marketplace in dev

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/IAM-132/force-static-authentication


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
