### PR TITLE
feat(ai-builder): Add webhook notifications for AI evaluation results

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/argument-parser.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/argument-parser.test.ts
@@ -67,4 +67,37 @@ describe('argument-parser', () => {
 			parseEvaluationArgs(['--suite', 'pairwise', '--backend', 'langsmith', '--filter', 'nope']),
 		).toThrow('Invalid `--filter` format');
 	});
+
+	describe('--webhook-url', () => {
+		it('parses valid HTTPS webhook URL', () => {
+			const args = parseEvaluationArgs(['--webhook-url', 'https://example.com/webhook']);
+			expect(args.webhookUrl).toBe('https://example.com/webhook');
+		});
+
+		it('parses webhook URL with inline = syntax', () => {
+			const args = parseEvaluationArgs(['--webhook-url=https://api.example.com/hook']);
+			expect(args.webhookUrl).toBe('https://api.example.com/hook');
+		});
+
+		it('rejects invalid URL format', () => {
+			expect(() => parseEvaluationArgs(['--webhook-url', 'not-a-url'])).toThrow();
+		});
+
+		it('rejects non-URL strings', () => {
+			expect(() => parseEvaluationArgs(['--webhook-url', 'just-some-text'])).toThrow();
+		});
+
+		it('allows webhook URL to be undefined when not provided', () => {
+			const args = parseEvaluationArgs([]);
+			expect(args.webhookUrl).toBeUndefined();
+		});
+
+		it('parses webhook URL with path and query params', () => {
+			const args = parseEvaluationArgs([
+				'--webhook-url',
+				'https://hooks.example.com/api/v1/notify?token=abc123',
+			]);
+			expect(args.webhookUrl).toBe('https://hooks.example.com/api/v1/notify?token=abc123');
+		});
+	});
 });

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/runner-langsmith.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/runner-langsmith.test.ts
@@ -690,11 +690,13 @@ describe('Runner - LangSmith Mode', () => {
 				]);
 
 				// Mock evaluate to call the target function with test inputs
-				mockEvaluate.mockImplementationOnce(async (target) => {
+				mockEvaluate.mockImplementationOnce(async (target, _options) => {
 					// Call the target to populate capturedResults
 					await callLangsmithTarget(target, { prompt: 'Test prompt 1' });
 					await callLangsmithTarget(target, { prompt: 'Test prompt 2' });
-					return { experimentName: 'test-experiment' };
+					return { experimentName: 'test-experiment' } as Awaited<
+						ReturnType<typeof langsmithEvaluate>
+					>;
 				});
 
 				const config: RunConfig = {

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/runner-langsmith.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/runner-langsmith.test.ts
@@ -24,7 +24,7 @@ import { createLogger } from '../harness/logger';
 const silentLogger = createLogger(false);
 
 jest.mock('langsmith/evaluation', () => ({
-	evaluate: jest.fn(),
+	evaluate: jest.fn().mockResolvedValue({ experimentName: 'test-experiment' }),
 }));
 
 jest.mock('langsmith/traceable', () => ({
@@ -674,6 +674,56 @@ describe('Runner - LangSmith Mode', () => {
 
 			const { runEvaluation } = await import('../harness/runner');
 			await expect(runEvaluation(config)).rejects.toThrow('No examples matched filters');
+		});
+
+		it('should include evaluatorAverages in summary', async () => {
+			const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'eval-test-'));
+			try {
+				const mockEvaluate = jest.mocked(langsmithEvaluate);
+				const lsClient = createMockLangsmithClient();
+
+				const evaluator1 = createMockEvaluator('pairwise', [
+					{ evaluator: 'pairwise', metric: 'score', score: 0.8, kind: 'score' },
+				]);
+				const evaluator2 = createMockEvaluator('programmatic', [
+					{ evaluator: 'programmatic', metric: 'overall', score: 0.9, kind: 'score' },
+				]);
+
+				// Mock evaluate to call the target function with test inputs
+				mockEvaluate.mockImplementationOnce(async (target) => {
+					// Call the target to populate capturedResults
+					await callLangsmithTarget(target, { prompt: 'Test prompt 1' });
+					await callLangsmithTarget(target, { prompt: 'Test prompt 2' });
+					return { experimentName: 'test-experiment' };
+				});
+
+				const config: RunConfig = {
+					mode: 'langsmith',
+					dataset: 'test-dataset',
+					generateWorkflow: jest.fn().mockResolvedValue(createMockWorkflow()),
+					evaluators: [evaluator1, evaluator2],
+					langsmithClient: lsClient,
+					langsmithOptions: {
+						experimentName: 'test',
+						repetitions: 1,
+						concurrency: 1,
+					},
+					outputDir: tempDir, // Enable artifact saving to capture results
+					logger: silentLogger,
+				};
+
+				const { runEvaluation } = await import('../harness/runner');
+				const summary = await runEvaluation(config);
+
+				// The summary should include evaluatorAverages computed from captured results
+				expect(summary.evaluatorAverages).toBeDefined();
+				expect(summary.evaluatorAverages).toEqual({
+					pairwise: 0.8,
+					programmatic: 0.9,
+				});
+			} finally {
+				fs.rmSync(tempDir, { recursive: true, force: true });
+			}
 		});
 	});
 });

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/webhook.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/webhook.test.ts
@@ -1,0 +1,476 @@
+/**
+ * Tests for webhook utilities.
+ */
+
+import { jsonParse } from 'n8n-workflow';
+
+import { validateWebhookUrl, sendWebhookNotification, type WebhookPayload } from '../cli/webhook';
+import type { RunSummary } from '../harness/harness-types';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+jest.mock('node:dns/promises', () => ({
+	resolve: jest.fn().mockResolvedValue(['93.184.216.34']),
+	resolve6: jest.fn().mockRejectedValue(new Error('ENODATA')),
+}));
+
+/** Helper to create a mock logger */
+function createMockLogger() {
+	return {
+		info: jest.fn(),
+		error: jest.fn(),
+		warn: jest.fn(),
+		verbose: jest.fn(),
+		debug: jest.fn(),
+		success: jest.fn(),
+		dim: jest.fn(),
+		isVerbose: false,
+	};
+}
+
+/** Helper to create a mock run summary */
+function createMockSummary(overrides: Partial<RunSummary> = {}): RunSummary {
+	return {
+		totalExamples: 10,
+		passed: 8,
+		failed: 2,
+		errors: 0,
+		averageScore: 0.85,
+		totalDurationMs: 5000,
+		evaluatorAverages: {
+			'llm-judge': 0.85,
+			programmatic: 0.9,
+		},
+		langsmith: {
+			experimentName: 'test-experiment-2024',
+			experimentId: 'exp-uuid-123',
+			datasetId: 'dataset-uuid-456',
+		},
+		...overrides,
+	};
+}
+
+describe('webhook utilities', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('validateWebhookUrl()', () => {
+		describe('protocol validation', () => {
+			it('accepts valid HTTPS URLs', () => {
+				expect(() => validateWebhookUrl('https://example.com/webhook')).not.toThrow();
+				expect(() => validateWebhookUrl('https://api.example.com/v1/hook')).not.toThrow();
+				expect(() =>
+					validateWebhookUrl('https://hooks.slack.com/services/T00/B00/xxx'),
+				).not.toThrow();
+			});
+
+			it('rejects HTTP URLs', () => {
+				expect(() => validateWebhookUrl('http://example.com/webhook')).toThrow(
+					'Webhook URL must use HTTPS',
+				);
+			});
+
+			it('rejects other protocols', () => {
+				expect(() => validateWebhookUrl('ftp://example.com/webhook')).toThrow(
+					'Webhook URL must use HTTPS',
+				);
+				expect(() => validateWebhookUrl('file:///etc/passwd')).toThrow(
+					'Webhook URL must use HTTPS',
+				);
+			});
+		});
+
+		describe('localhost blocking', () => {
+			it('rejects localhost', () => {
+				expect(() => validateWebhookUrl('https://localhost/webhook')).toThrow(
+					'Webhook URL cannot target localhost',
+				);
+				expect(() => validateWebhookUrl('https://localhost:3000/webhook')).toThrow(
+					'Webhook URL cannot target localhost',
+				);
+			});
+
+			it('rejects 127.0.0.1', () => {
+				expect(() => validateWebhookUrl('https://127.0.0.1/webhook')).toThrow(
+					'Webhook URL cannot target localhost',
+				);
+				expect(() => validateWebhookUrl('https://127.0.0.1:8080/webhook')).toThrow(
+					'Webhook URL cannot target localhost',
+				);
+			});
+
+			it('rejects IPv6 localhost (::1)', () => {
+				expect(() => validateWebhookUrl('https://[::1]/webhook')).toThrow(
+					'Webhook URL cannot target localhost',
+				);
+			});
+		});
+
+		describe('private IP blocking (SSRF prevention)', () => {
+			it('rejects 10.x.x.x addresses', () => {
+				expect(() => validateWebhookUrl('https://10.0.0.1/webhook')).toThrow(
+					'Webhook URL cannot target private/internal IP addresses',
+				);
+				expect(() => validateWebhookUrl('https://10.255.255.255/webhook')).toThrow(
+					'Webhook URL cannot target private/internal IP addresses',
+				);
+				expect(() => validateWebhookUrl('https://10.1.2.3:8080/webhook')).toThrow(
+					'Webhook URL cannot target private/internal IP addresses',
+				);
+			});
+
+			it('rejects 172.16-31.x.x addresses', () => {
+				expect(() => validateWebhookUrl('https://172.16.0.1/webhook')).toThrow(
+					'Webhook URL cannot target private/internal IP addresses',
+				);
+				expect(() => validateWebhookUrl('https://172.31.255.255/webhook')).toThrow(
+					'Webhook URL cannot target private/internal IP addresses',
+				);
+				expect(() => validateWebhookUrl('https://172.20.10.5/webhook')).toThrow(
+					'Webhook URL cannot target private/internal IP addresses',
+				);
+			});
+
+			it('allows 172.x.x.x addresses outside private range', () => {
+				expect(() => validateWebhookUrl('https://172.15.0.1/webhook')).not.toThrow();
+				expect(() => validateWebhookUrl('https://172.32.0.1/webhook')).not.toThrow();
+			});
+
+			it('rejects 192.168.x.x addresses', () => {
+				expect(() => validateWebhookUrl('https://192.168.0.1/webhook')).toThrow(
+					'Webhook URL cannot target private/internal IP addresses',
+				);
+				expect(() => validateWebhookUrl('https://192.168.1.100/webhook')).toThrow(
+					'Webhook URL cannot target private/internal IP addresses',
+				);
+				expect(() => validateWebhookUrl('https://192.168.255.255/webhook')).toThrow(
+					'Webhook URL cannot target private/internal IP addresses',
+				);
+			});
+
+			it('rejects 169.254.x.x link-local addresses', () => {
+				expect(() => validateWebhookUrl('https://169.254.0.1/webhook')).toThrow(
+					'Webhook URL cannot target private/internal IP addresses',
+				);
+				expect(() => validateWebhookUrl('https://169.254.169.254/webhook')).toThrow(
+					'Webhook URL cannot target private/internal IP addresses',
+				);
+			});
+
+			it('rejects 0.0.0.0', () => {
+				expect(() => validateWebhookUrl('https://0.0.0.0/webhook')).toThrow(
+					'Webhook URL cannot target private/internal IP addresses',
+				);
+			});
+		});
+
+		describe('internal hostname blocking', () => {
+			it('rejects "internal" hostname', () => {
+				expect(() => validateWebhookUrl('https://internal/webhook')).toThrow(
+					'Webhook URL cannot target internal hostname',
+				);
+				expect(() => validateWebhookUrl('https://api.internal/webhook')).toThrow(
+					'Webhook URL cannot target internal hostname',
+				);
+			});
+
+			it('rejects "intranet" hostname', () => {
+				expect(() => validateWebhookUrl('https://intranet/webhook')).toThrow(
+					'Webhook URL cannot target internal hostname',
+				);
+				expect(() => validateWebhookUrl('https://app.intranet/webhook')).toThrow(
+					'Webhook URL cannot target internal hostname',
+				);
+			});
+
+			it('rejects "corp" hostname', () => {
+				expect(() => validateWebhookUrl('https://corp/webhook')).toThrow(
+					'Webhook URL cannot target internal hostname',
+				);
+				expect(() => validateWebhookUrl('https://api.corp/webhook')).toThrow(
+					'Webhook URL cannot target internal hostname',
+				);
+			});
+
+			it('rejects "private" hostname', () => {
+				expect(() => validateWebhookUrl('https://private/webhook')).toThrow(
+					'Webhook URL cannot target internal hostname',
+				);
+				expect(() => validateWebhookUrl('https://services.private/webhook')).toThrow(
+					'Webhook URL cannot target internal hostname',
+				);
+			});
+
+			it('rejects "local" hostname', () => {
+				expect(() => validateWebhookUrl('https://local/webhook')).toThrow(
+					'Webhook URL cannot target internal hostname',
+				);
+				expect(() => validateWebhookUrl('https://api.local/webhook')).toThrow(
+					'Webhook URL cannot target internal hostname',
+				);
+			});
+
+			it('allows hostnames containing blocked words but not ending with them', () => {
+				expect(() => validateWebhookUrl('https://internal-api.example.com/webhook')).not.toThrow();
+				expect(() =>
+					validateWebhookUrl('https://my-intranet-app.example.com/webhook'),
+				).not.toThrow();
+			});
+		});
+
+		describe('valid URLs', () => {
+			it('accepts various valid public URLs', () => {
+				expect(() => validateWebhookUrl('https://hooks.slack.com/services/xxx')).not.toThrow();
+				expect(() => validateWebhookUrl('https://api.github.com/webhooks')).not.toThrow();
+				expect(() => validateWebhookUrl('https://webhook.site/unique-id')).not.toThrow();
+				expect(() => validateWebhookUrl('https://n8n.io/webhook/abc123')).not.toThrow();
+			});
+
+			it('accepts URLs with paths, query params, and ports', () => {
+				expect(() =>
+					validateWebhookUrl('https://example.com:8443/api/v1/webhook?token=abc'),
+				).not.toThrow();
+				expect(() =>
+					validateWebhookUrl('https://api.example.com/webhooks/eval/notify'),
+				).not.toThrow();
+			});
+		});
+
+		describe('invalid URL format', () => {
+			it('throws on invalid URL strings', () => {
+				expect(() => validateWebhookUrl('not-a-url')).toThrow();
+				expect(() => validateWebhookUrl('')).toThrow();
+				expect(() => validateWebhookUrl('://missing-protocol.com')).toThrow();
+			});
+		});
+	});
+
+	describe('sendWebhookNotification()', () => {
+		it('sends POST request with correct payload', async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				statusText: 'OK',
+			});
+
+			const logger = createMockLogger();
+			const summary = createMockSummary();
+
+			await sendWebhookNotification({
+				webhookUrl: 'https://example.com/webhook',
+				summary,
+				dataset: 'test-dataset',
+				suite: 'llm-judge',
+				metadata: { source: 'ci', trigger: 'push' },
+				logger,
+			});
+
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+			expect(mockFetch).toHaveBeenCalledWith('https://example.com/webhook', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: expect.any(String),
+			});
+
+			// Verify payload structure
+			const callArgs = mockFetch.mock.calls[0] as [string, RequestInit];
+			const payload = jsonParse<WebhookPayload>(callArgs[1].body as string);
+
+			expect(payload).toEqual({
+				suite: 'llm-judge',
+				summary: {
+					totalExamples: 10,
+					passed: 8,
+					failed: 2,
+					errors: 0,
+					averageScore: 0.85,
+				},
+				evaluatorAverages: {
+					'llm-judge': 0.85,
+					programmatic: 0.9,
+				},
+				totalDurationMs: 5000,
+				metadata: { source: 'ci', trigger: 'push' },
+				langsmith: {
+					experimentName: 'test-experiment-2024',
+					experimentId: 'exp-uuid-123',
+					datasetId: 'dataset-uuid-456',
+					datasetName: 'test-dataset',
+				},
+			});
+		});
+
+		it('logs info messages on success', async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				statusText: 'OK',
+			});
+
+			const logger = createMockLogger();
+
+			await sendWebhookNotification({
+				webhookUrl: 'https://example.com/webhook',
+				summary: createMockSummary(),
+				dataset: 'test-dataset',
+				suite: 'llm-judge',
+				metadata: {},
+				logger,
+			});
+
+			expect(logger.info).toHaveBeenCalledWith(
+				'Sending results to webhook: https://example.com/***',
+			);
+			expect(logger.info).toHaveBeenCalledWith(
+				'Webhook notification sent successfully (status: 200)',
+			);
+		});
+
+		it('throws error when webhook URL validation fails', async () => {
+			const logger = createMockLogger();
+
+			await expect(
+				sendWebhookNotification({
+					webhookUrl: 'http://example.com/webhook', // HTTP not allowed
+					summary: createMockSummary(),
+					dataset: 'test-dataset',
+					suite: 'llm-judge',
+					metadata: {},
+					logger,
+				}),
+			).rejects.toThrow('Webhook URL must use HTTPS');
+
+			expect(mockFetch).not.toHaveBeenCalled();
+		});
+
+		it('throws error when fetch returns non-ok response', async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: false,
+				status: 500,
+				statusText: 'Internal Server Error',
+			});
+
+			const logger = createMockLogger();
+
+			await expect(
+				sendWebhookNotification({
+					webhookUrl: 'https://example.com/webhook',
+					summary: createMockSummary(),
+					dataset: 'test-dataset',
+					suite: 'llm-judge',
+					metadata: {},
+					logger,
+				}),
+			).rejects.toThrow('Webhook request failed: 500 Internal Server Error');
+		});
+
+		it('throws error when fetch returns 4xx response', async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: false,
+				status: 401,
+				statusText: 'Unauthorized',
+			});
+
+			const logger = createMockLogger();
+
+			await expect(
+				sendWebhookNotification({
+					webhookUrl: 'https://example.com/webhook',
+					summary: createMockSummary(),
+					dataset: 'test-dataset',
+					suite: 'llm-judge',
+					metadata: {},
+					logger,
+				}),
+			).rejects.toThrow('Webhook request failed: 401 Unauthorized');
+		});
+
+		it('throws error when fetch fails with network error', async () => {
+			mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+			const logger = createMockLogger();
+
+			await expect(
+				sendWebhookNotification({
+					webhookUrl: 'https://example.com/webhook',
+					summary: createMockSummary(),
+					dataset: 'test-dataset',
+					suite: 'llm-judge',
+					metadata: {},
+					logger,
+				}),
+			).rejects.toThrow('Network error');
+		});
+
+		it('handles summary without evaluatorAverages', async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				statusText: 'OK',
+			});
+
+			const logger = createMockLogger();
+			const summary = createMockSummary({ evaluatorAverages: undefined });
+
+			await sendWebhookNotification({
+				webhookUrl: 'https://example.com/webhook',
+				summary,
+				dataset: 'test-dataset',
+				suite: 'llm-judge',
+				metadata: {},
+				logger,
+			});
+
+			const callArgs = mockFetch.mock.calls[0] as [string, RequestInit];
+			const payload = jsonParse<WebhookPayload>(callArgs[1].body as string);
+
+			expect(payload.evaluatorAverages).toBeUndefined();
+		});
+
+		it('handles summary without langsmith data (local mode)', async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				statusText: 'OK',
+			});
+
+			const logger = createMockLogger();
+			const summary = createMockSummary({ langsmith: undefined });
+
+			await sendWebhookNotification({
+				webhookUrl: 'https://example.com/webhook',
+				summary,
+				dataset: 'test-dataset',
+				suite: 'llm-judge',
+				metadata: {},
+				logger,
+			});
+
+			const callArgs = mockFetch.mock.calls[0] as [string, RequestInit];
+			const payload = jsonParse<WebhookPayload>(callArgs[1].body as string);
+
+			expect(payload.langsmith).toBeUndefined();
+		});
+
+		it('validates URL before making fetch request (SSRF prevention)', async () => {
+			const logger = createMockLogger();
+
+			await expect(
+				sendWebhookNotification({
+					webhookUrl: 'https://192.168.1.1/webhook',
+					summary: createMockSummary(),
+					dataset: 'test-dataset',
+					suite: 'llm-judge',
+					metadata: {},
+					logger,
+				}),
+			).rejects.toThrow('Webhook URL cannot target private/internal IP addresses');
+
+			expect(mockFetch).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/argument-parser.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/argument-parser.ts
@@ -36,6 +36,9 @@ export interface EvaluationArgs {
 
 	featureFlags?: BuilderFeatureFlags;
 
+	/** URL to POST evaluation results to when complete */
+	webhookUrl?: string;
+
 	// Model configuration
 	/** Default model for all stages */
 	model: ModelId;
@@ -97,6 +100,7 @@ const cliSchema = z
 
 		langsmith: z.boolean().optional(),
 		templateExamples: z.boolean().default(false),
+		webhookUrl: z.string().url().optional(),
 
 		// Model configuration
 		model: modelIdSchema.default(DEFAULT_MODEL),
@@ -218,6 +222,12 @@ const FLAG_DEFS: Record<string, FlagDef> = {
 		desc: 'Directory for artifacts',
 	},
 	'--verbose': { key: 'verbose', kind: 'boolean', group: 'output', desc: 'Verbose logging' },
+	'--webhook-url': {
+		key: 'webhookUrl',
+		kind: 'string',
+		group: 'output',
+		desc: 'URL to POST results to when complete',
+	},
 
 	// Feature flags
 	'--template-examples': {
@@ -525,6 +535,7 @@ export function parseEvaluationArgs(argv: string[] = process.argv.slice(2)): Eva
 		donts: parsed.donts,
 		numJudges: parsed.numJudges,
 		featureFlags,
+		webhookUrl: parsed.webhookUrl,
 		// Model configuration
 		model: parsed.model,
 		judgeModel: parsed.judgeModel,

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/webhook.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/webhook.ts
@@ -1,0 +1,202 @@
+/**
+ * Webhook utilities for sending evaluation results.
+ */
+
+import dns from 'node:dns/promises';
+
+import type { RunSummary } from '../harness/harness-types';
+import type { EvalLogger } from '../harness/logger';
+
+/**
+ * Mask a webhook URL for safe logging (hide potential tokens in path/query).
+ */
+function maskWebhookUrl(webhookUrl: string): string {
+	const url = new URL(webhookUrl);
+	return `${url.protocol}//${url.hostname}${url.port ? `:${url.port}` : ''}/***`;
+}
+
+/**
+ * Webhook payload sent after evaluation completes.
+ */
+export interface WebhookPayload {
+	suite: string;
+	summary: {
+		totalExamples: number;
+		passed: number;
+		failed: number;
+		errors: number;
+		averageScore: number;
+	};
+	evaluatorAverages?: Record<string, number>;
+	totalDurationMs: number;
+	metadata: Record<string, unknown>;
+	/** LangSmith IDs for constructing comparison URLs (only available in langsmith mode) */
+	langsmith?: {
+		experimentName: string;
+		experimentId: string;
+		datasetId: string;
+		datasetName: string;
+	};
+}
+
+/**
+ * Check if an IP address is private/internal.
+ */
+function isPrivateIp(ip: string): boolean {
+	const ipv4PrivatePatterns = [
+		/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/, // 127.0.0.0/8 (loopback)
+		/^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/, // 10.0.0.0/8
+		/^172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}$/, // 172.16.0.0/12
+		/^192\.168\.\d{1,3}\.\d{1,3}$/, // 192.168.0.0/16
+		/^169\.254\.\d{1,3}\.\d{1,3}$/, // 169.254.0.0/16 (link-local)
+		/^0\.0\.0\.0$/, // 0.0.0.0
+	];
+
+	for (const pattern of ipv4PrivatePatterns) {
+		if (pattern.test(ip)) {
+			return true;
+		}
+	}
+
+	const ipLower = ip.toLowerCase();
+	if (
+		ipLower === '::1' || // loopback
+		ipLower.startsWith('fe80:') || // link-local
+		ipLower.startsWith('fc') || // unique local (fc00::/7)
+		ipLower.startsWith('fd') // unique local (fc00::/7)
+	) {
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * Validate webhook URL for security (hostname-based checks only).
+ * - Must be HTTPS
+ * - Must not target localhost or private/internal IP addresses (SSRF prevention)
+ *
+ * Note: This performs synchronous hostname string validation.
+ * For full SSRF protection, use validateWebhookUrlWithDns() which also resolves DNS.
+ */
+export function validateWebhookUrl(webhookUrl: string): void {
+	const url = new URL(webhookUrl);
+
+	if (url.protocol !== 'https:') {
+		throw new Error(`Webhook URL must use HTTPS. Got: ${url.protocol}`);
+	}
+
+	const hostname = url.hostname.toLowerCase();
+
+	if (
+		hostname === 'localhost' ||
+		hostname === '127.0.0.1' ||
+		hostname === '::1' ||
+		hostname === '[::1]'
+	) {
+		throw new Error('Webhook URL cannot target localhost');
+	}
+
+	if (isPrivateIp(hostname)) {
+		throw new Error('Webhook URL cannot target private/internal IP addresses');
+	}
+
+	const blockedHostnames = ['internal', 'intranet', 'corp', 'private', 'local'];
+	for (const blocked of blockedHostnames) {
+		if (hostname === blocked || hostname.endsWith(`.${blocked}`)) {
+			throw new Error(`Webhook URL cannot target internal hostname: ${hostname}`);
+		}
+	}
+}
+
+/**
+ * Validate webhook URL with DNS resolution for comprehensive SSRF protection.
+ * Resolves the hostname and validates that resolved IPs are not private/internal.
+ */
+export async function validateWebhookUrlWithDns(webhookUrl: string): Promise<void> {
+	validateWebhookUrl(webhookUrl);
+
+	const url = new URL(webhookUrl);
+	const hostname = url.hostname.toLowerCase();
+
+	if (isPrivateIp(hostname)) {
+		throw new Error('Webhook URL cannot target private/internal IP addresses');
+	}
+
+	try {
+		const addresses = await dns.resolve(hostname);
+		for (const ip of addresses) {
+			if (isPrivateIp(ip)) {
+				throw new Error('Webhook URL hostname resolves to a private/internal IP address');
+			}
+		}
+
+		try {
+			const ipv6Addresses = await dns.resolve6(hostname);
+			for (const ip of ipv6Addresses) {
+				if (isPrivateIp(ip)) {
+					throw new Error('Webhook URL hostname resolves to a private/internal IP address');
+				}
+			}
+		} catch {
+			// IPv6 resolution may fail if no AAAA records exist, which is fine
+		}
+	} catch (error) {
+		if (error instanceof Error && error.message.includes('private/internal')) {
+			throw error;
+		}
+	}
+}
+
+/**
+ * Send evaluation results to a webhook URL.
+ */
+export async function sendWebhookNotification(params: {
+	webhookUrl: string;
+	summary: RunSummary;
+	dataset: string;
+	suite: string;
+	metadata: Record<string, unknown>;
+	logger: EvalLogger;
+}): Promise<void> {
+	const { webhookUrl, summary, dataset, suite, metadata, logger } = params;
+
+	await validateWebhookUrlWithDns(webhookUrl);
+
+	const payload: WebhookPayload = {
+		suite,
+		summary: {
+			totalExamples: summary.totalExamples,
+			passed: summary.passed,
+			failed: summary.failed,
+			errors: summary.errors,
+			averageScore: summary.averageScore,
+		},
+		evaluatorAverages: summary.evaluatorAverages,
+		totalDurationMs: summary.totalDurationMs,
+		metadata,
+		langsmith: summary.langsmith
+			? {
+					...summary.langsmith,
+					datasetName: dataset,
+				}
+			: undefined,
+	};
+
+	// Log masked URL to avoid exposing potential tokens in path/query
+	logger.info(`Sending results to webhook: ${maskWebhookUrl(webhookUrl)}`);
+
+	const response = await fetch(webhookUrl, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify(payload),
+	});
+
+	if (!response.ok) {
+		throw new Error(`Webhook request failed: ${response.status} ${response.statusText}`);
+	}
+
+	logger.info(`Webhook notification sent successfully (status: ${response.status})`);
+}

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/harness-types.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/harness-types.ts
@@ -193,6 +193,13 @@ export interface RunSummary {
 	averageScore: number;
 	totalDurationMs: number;
 	evaluatorAverages?: Record<string, number>;
+	/** LangSmith IDs for constructing comparison URLs (only available in langsmith mode) */
+	langsmith?: {
+		experimentName: string;
+		experimentId: string;
+		datasetId: string;
+		datasetName?: string;
+	};
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `--webhook-url` option to evaluation CLI to send results to external services (Slack, Discord, etc.)
- Implement secure webhook delivery with:
  - HTTPS enforcement
  - SSRF protection (block localhost, private IPs, internal hostnames)
  - DNS resolution validation to catch hostnames resolving to private IPs
  - Masked URL logging to protect embedded tokens
- Include LangSmith metadata in payload (`experimentName`, `experimentId`, `datasetId`, `datasetName`) for constructing comparison URLs

## Why
LangSmith's `evaluate()` function has no native webhook support for experiment completion notifications. LangSmith only offers:
- **Trace Rules** — triggered on individual traces, not experiment completions
- **API endpoint webhooks** — for specific API events, but not for `evaluate()` completions
- **API polling** — requires external orchestration

This custom webhook fires after all evaluations complete with a summary payload including LangSmith IDs.

## Webhook Payload

```json
{
  "suite": "llm-judge",
  "summary": {
    "totalExamples": 50,
    "passed": 45,
    "failed": 5,
    "errors": 0,
    "averageScore": 0.87
  },
  "evaluatorAverages": {
    "llm-judge": 0.85,
    "programmatic": 0.92
  },
  "totalDurationMs": 120000,
  "metadata": {
    "source": "ci",
    "trigger": "push",
    "runId": "12345678"
  },
  "langsmith": {
    "experimentName": "AI-1234_2026_01_20",
    "experimentId": "48660e0e-0ed5-4e32-9e04-88803d7c161f",
    "datasetId": "b04d1ce8-8e3f-455a-818c-ee2c7e14c458",
    "datasetName": "workflow-builder-canvas-prompts"
  }
}
```

The `langsmith` object is only present in LangSmith mode and contains identifiers for constructing comparison URLs.

## Test plan
- [x] Unit tests for URL validation (HTTPS, localhost, private IPs, internal hostnames)
- [x] Unit tests for DNS resolution validation
- [x] Unit tests for webhook payload structure
- [x] Unit tests for error handling (network failures, non-2xx responses)
- [x] Unit tests for URL masking in logs
- [x] Unit tests for LangSmith IDs in payload

https://linear.app/n8n/issue/AI-1961