### PR TITLE
ci: Authenticate before syncing to private repo

### DIFF
--- a/.github/workflows/sec-sync-public-to-private.yml
+++ b/.github/workflows/sec-sync-public-to-private.yml
@@ -26,10 +26,18 @@ jobs:
       contents: write
 
     steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.N8N_ASSISTANT_APP_ID }}
+          private-key: ${{ secrets.N8N_ASSISTANT_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Sync from public
         run: |

--- a/.github/workflows/sec-sync-public-to-private.yml
+++ b/.github/workflows/sec-sync-public-to-private.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Generate App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         with:
           app-id: ${{ secrets.N8N_ASSISTANT_APP_ID }}
           private-key: ${{ secrets.N8N_ASSISTANT_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

The GH action to force-sync public onto private repo is [coming up against branch protection rules](https://github.com/n8n-io/n8n-private/actions/runs/21216638370/job/61039500913). I've enabled `n8n-assistant` under `Allow specified actors to bypass required pull requests` so this change should allow force-syncing to work.

## Related Linear tickets, Github issues, and Community forum posts

n/a
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
