### PR TITLE
fix(core): Make Respond to Chat nodes work on Chat hub with multi-main instances

### DIFF
--- a/packages/cli/src/modules/chat-hub/__tests__/chat-hub.service.integration.test.ts
+++ b/packages/cli/src/modules/chat-hub/__tests__/chat-hub.service.integration.test.ts
@@ -24,6 +24,7 @@ import { ActiveExecutions } from '../../../active-executions';
 import { ChatExecutionManager } from '../../../chat/chat-execution-manager';
 import { WorkflowExecutionService } from '../../../workflows/workflow-execution.service';
 import { ChatHubAgentRepository } from '../chat-hub-agent.repository';
+import * as chatHubConstants from '../chat-hub.constants';
 import { STREAM_CLOSE_TIMEOUT } from '../chat-hub.constants';
 import { ChatHubService } from '../chat-hub.service';
 import { ChatHubMessageRepository } from '../chat-message.repository';
@@ -2051,6 +2052,432 @@ describe('chatHub', () => {
 							attachments: [],
 						}),
 					).rejects.toThrow('Chat Trigger node response mode must be set to');
+				});
+			});
+
+			describe('multi-main mode execution waiting', () => {
+				const TEST_POLL_INTERVAL = 50;
+				const originalPollInterval = chatHubConstants.EXECUTION_POLL_INTERVAL;
+
+				beforeEach(() => {
+					Object.defineProperty(chatHubConstants, 'EXECUTION_POLL_INTERVAL', {
+						value: TEST_POLL_INTERVAL,
+						writable: true,
+						configurable: true,
+					});
+				});
+
+				afterEach(() => {
+					Object.defineProperty(chatHubConstants, 'EXECUTION_POLL_INTERVAL', {
+						value: originalPollInterval,
+						writable: true,
+						configurable: true,
+					});
+				});
+
+				it('should poll and complete when execution finishes with "waiting" status', async () => {
+					jest.spyOn(instanceSettings, 'isMultiMain', 'get').mockReturnValue(true);
+
+					// Spy on findSingleExecution to verify polling occurs
+					const findSingleExecutionSpy = jest.spyOn(executionRepository, 'findSingleExecution');
+
+					const workflow = await createActiveWorkflow(
+						{
+							name: 'Multi-Main Wait Workflow',
+							nodes: [
+								{
+									id: 'chat-trigger-1',
+									name: 'Chat Trigger',
+									type: CHAT_TRIGGER_NODE_TYPE,
+									typeVersion: 1.4,
+									position: [0, 0],
+									parameters: {
+										availableInChat: true,
+										options: {
+											responseMode: 'responseNodes',
+										},
+									},
+								},
+								{
+									id: 'respond-1',
+									name: 'Respond to Chat',
+									type: CHAT_NODE_TYPE,
+									typeVersion: 1,
+									position: [200, 0],
+									parameters: {
+										message: 'Waiting for your input',
+										waitUserReply: true,
+									},
+								},
+							],
+							connections: {
+								'Chat Trigger': {
+									main: [[{ node: 'Respond to Chat', type: 'main', index: 0 }]],
+								},
+							},
+						},
+						member,
+					);
+
+					spyExecute.mockImplementationOnce(async (_user, workflowData, executionData) => {
+						const executionId = await executionRepository.createNewExecution({
+							finished: false,
+							mode: 'webhook',
+							status: 'running',
+							workflowId: workflowData.id,
+							data: executionData,
+							workflowData,
+						});
+
+						// Update execution status to 'waiting' after multiple poll intervals
+						// This ensures the poller runs at least 3 times before finding a finished status
+						setTimeout(async () => {
+							await executionRepository.updateExistingExecution(executionId, {
+								status: 'waiting',
+								data: createRunExecutionData({
+									resultData: {
+										runData: {
+											'Respond to Chat': [
+												{
+													startTime: Date.now(),
+													executionTime: 100,
+													executionIndex: 0,
+													executionStatus: 'success',
+													source: [],
+													data: {
+														main: [
+															[
+																{
+																	json: {},
+																	sendMessage: 'Waiting for your input',
+																},
+															],
+														],
+													},
+												},
+											],
+										},
+										lastNodeExecuted: 'Respond to Chat',
+									},
+								}),
+							});
+						}, TEST_POLL_INTERVAL * 3);
+
+						return { executionId };
+					});
+
+					await chatHubService.sendHumanMessage(mockResponse, member, {
+						userId: member.id,
+						sessionId,
+						messageId,
+						message: 'Test message',
+						model: { provider: 'n8n', workflowId: workflow.id },
+						credentials: {},
+						previousMessageId: null,
+						tools: [],
+						attachments: [],
+					});
+
+					const messages = await retryUntil(async () => {
+						const messages = await messagesRepository.getManyBySessionId(sessionId);
+						expect(messages.length).toBeGreaterThanOrEqual(2);
+						expect(messages[1]?.status).toBe('waiting');
+						return messages;
+					});
+
+					expect(messages[0]?.type).toBe('human');
+					expect(messages[0]?.content).toBe('Test message');
+
+					expect(messages[1]?.type).toBe('ai');
+					expect(messages[1]?.status).toBe('waiting');
+					expect(messages[1]?.content).toBe('Waiting for your input');
+
+					// Ensure polling happened
+					expect(findSingleExecutionSpy.mock.calls.length).toBeGreaterThanOrEqual(3);
+
+					findSingleExecutionSpy.mockRestore();
+				});
+
+				it('should poll and complete when execution finishes with "success" status', async () => {
+					jest.spyOn(instanceSettings, 'isMultiMain', 'get').mockReturnValue(true);
+
+					const findSingleExecutionSpy = jest.spyOn(executionRepository, 'findSingleExecution');
+
+					const workflow = await createActiveWorkflow(
+						{
+							name: 'Multi-Main Success Workflow',
+							nodes: [
+								{
+									id: 'chat-trigger-1',
+									name: 'Chat Trigger',
+									type: CHAT_TRIGGER_NODE_TYPE,
+									typeVersion: 1.4,
+									position: [0, 0],
+									parameters: {
+										availableInChat: true,
+										options: {
+											responseMode: 'lastNode',
+										},
+									},
+								},
+								{
+									id: 'agent-1',
+									name: 'AI Agent',
+									type: '@n8n/n8n-nodes-langchain.agent',
+									typeVersion: 2.2,
+									position: [200, 0],
+									parameters: {},
+								},
+							],
+							connections: {
+								'Chat Trigger': {
+									main: [[{ node: 'AI Agent', type: 'main', index: 0 }]],
+								},
+							},
+						},
+						member,
+					);
+
+					spyExecute.mockImplementationOnce(async (_user, workflowData, executionData) => {
+						const executionId = await executionRepository.createNewExecution({
+							finished: false,
+							mode: 'webhook',
+							status: 'running',
+							workflowId: workflowData.id,
+							data: executionData,
+							workflowData,
+						});
+
+						// Update execution status to 'success' after multiple poll intervals
+						setTimeout(async () => {
+							await executionRepository.updateExistingExecution(executionId, {
+								status: 'success',
+								data: createRunExecutionData({
+									resultData: {
+										runData: {
+											'AI Agent': [
+												{
+													startTime: Date.now(),
+													executionTime: 100,
+													executionIndex: 0,
+													executionStatus: 'success',
+													source: [],
+													data: {
+														main: [
+															[
+																{
+																	json: { output: 'Hello from multi-main!' },
+																},
+															],
+														],
+													},
+												},
+											],
+										},
+										lastNodeExecuted: 'AI Agent',
+									},
+								}),
+							});
+						}, TEST_POLL_INTERVAL * 3);
+
+						return { executionId };
+					});
+
+					await chatHubService.sendHumanMessage(mockResponse, member, {
+						userId: member.id,
+						sessionId,
+						messageId,
+						message: 'Test message',
+						model: { provider: 'n8n', workflowId: workflow.id },
+						credentials: {},
+						previousMessageId: null,
+						tools: [],
+						attachments: [],
+					});
+
+					const messages = await retryUntil(async () => {
+						const messages = await messagesRepository.getManyBySessionId(sessionId);
+						expect(messages.length).toBeGreaterThanOrEqual(2);
+						expect(messages[1]?.status).toBe('success');
+						return messages;
+					});
+
+					expect(messages[0]?.type).toBe('human');
+					expect(messages[0]?.content).toBe('Test message');
+
+					expect(messages[1]?.type).toBe('ai');
+					expect(messages[1]?.status).toBe('success');
+					expect(messages[1]?.content).toBe('Hello from multi-main!');
+
+					// Ensure polling happened
+					expect(findSingleExecutionSpy.mock.calls.length).toBeGreaterThanOrEqual(3);
+
+					findSingleExecutionSpy.mockRestore();
+				});
+
+				it('should poll and complete when execution finishes with "error" status', async () => {
+					jest.spyOn(instanceSettings, 'isMultiMain', 'get').mockReturnValue(true);
+
+					const findSingleExecutionSpy = jest.spyOn(executionRepository, 'findSingleExecution');
+
+					const workflow = await createActiveWorkflow(
+						{
+							name: 'Multi-Main Error Workflow',
+							nodes: [
+								{
+									id: 'chat-trigger-1',
+									name: 'Chat Trigger',
+									type: CHAT_TRIGGER_NODE_TYPE,
+									typeVersion: 1.4,
+									position: [0, 0],
+									parameters: {
+										availableInChat: true,
+										options: {
+											responseMode: 'lastNode',
+										},
+									},
+								},
+								{
+									id: 'agent-1',
+									name: 'AI Agent',
+									type: '@n8n/n8n-nodes-langchain.agent',
+									typeVersion: 2.2,
+									position: [200, 0],
+									parameters: {},
+								},
+							],
+							connections: {
+								'Chat Trigger': {
+									main: [[{ node: 'AI Agent', type: 'main', index: 0 }]],
+								},
+							},
+						},
+						member,
+					);
+
+					spyExecute.mockImplementationOnce(async (_user, workflowData, executionData) => {
+						const executionId = await executionRepository.createNewExecution({
+							finished: false,
+							mode: 'webhook',
+							status: 'running',
+							workflowId: workflowData.id,
+							data: executionData,
+							workflowData,
+						});
+
+						// Update execution status to 'error' after multiple poll intervals
+						setTimeout(async () => {
+							await executionRepository.updateExistingExecution(executionId, {
+								status: 'error',
+								data: createRunExecutionData({
+									resultData: {
+										runData: {},
+										error: new NodeOperationError(mock<INode>(), 'Multi-main execution failed'),
+									},
+								}),
+							});
+						}, TEST_POLL_INTERVAL * 3);
+
+						return { executionId };
+					});
+
+					await chatHubService.sendHumanMessage(mockResponse, member, {
+						userId: member.id,
+						sessionId,
+						messageId,
+						message: 'Test message',
+						model: { provider: 'n8n', workflowId: workflow.id },
+						credentials: {},
+						previousMessageId: null,
+						tools: [],
+						attachments: [],
+					});
+
+					const messages = await retryUntil(async () => {
+						const messages = await messagesRepository.getManyBySessionId(sessionId);
+						expect(messages.length).toBeGreaterThanOrEqual(2);
+						expect(messages[1]?.status).toBe('error');
+						return messages;
+					});
+
+					expect(messages[0]?.type).toBe('human');
+					expect(messages[0]?.content).toBe('Test message');
+
+					expect(messages[1]?.type).toBe('ai');
+					expect(messages[1]?.status).toBe('error');
+					expect(messages[1]?.content).toBe('Multi-main execution failed');
+
+					// Ensure polling happened
+					expect(findSingleExecutionSpy.mock.calls.length).toBeGreaterThanOrEqual(3);
+
+					findSingleExecutionSpy.mockRestore();
+				});
+
+				it('should handle poll error by writing error response when finding execution throws', async () => {
+					jest.spyOn(instanceSettings, 'isMultiMain', 'get').mockReturnValue(true);
+
+					const findSingleExecutionSpy = jest
+						.spyOn(executionRepository, 'findSingleExecution')
+						.mockRejectedValue(new Error('Database error'));
+
+					const workflow = await createActiveWorkflow(
+						{
+							name: 'Multi-Main DB Error Workflow',
+							nodes: [
+								{
+									id: 'chat-trigger-1',
+									name: 'Chat Trigger',
+									type: CHAT_TRIGGER_NODE_TYPE,
+									typeVersion: 1.4,
+									position: [0, 0],
+									parameters: {
+										availableInChat: true,
+										options: {
+											responseMode: 'lastNode',
+										},
+									},
+								},
+							],
+							connections: {},
+						},
+						member,
+					);
+
+					spyExecute.mockImplementationOnce(async (_user, workflowData, executionData) => {
+						const executionId = await executionRepository.createNewExecution({
+							finished: false,
+							mode: 'webhook',
+							status: 'running',
+							workflowId: workflowData.id,
+							data: executionData,
+							workflowData,
+						});
+
+						return { executionId };
+					});
+
+					await chatHubService.sendHumanMessage(mockResponse, member, {
+						userId: member.id,
+						sessionId,
+						messageId,
+						message: 'Test message',
+						model: { provider: 'n8n', workflowId: workflow.id },
+						credentials: {},
+						previousMessageId: null,
+						tools: [],
+						attachments: [],
+					});
+
+					// Ensure polling was attempted
+					expect(findSingleExecutionSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
+
+					// Verify error was written to response
+					const errorChunkCall = writeMock.mock.calls[1][0];
+					expect(errorChunkCall).toBeDefined();
+					const parsedError = JSON.parse(errorChunkCall.trim());
+					expect(parsedError.content).toBe('Database error');
+
+					findSingleExecutionSpy.mockRestore();
 				});
 			});
 		});

--- a/packages/cli/src/modules/chat-hub/chat-hub.constants.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.constants.ts
@@ -8,6 +8,8 @@ export const STREAM_CLOSE_TIMEOUT = 5 * 60 * 1000; // 5 minutes
 export const EXECUTION_FINISHED_STATUSES: ExecutionStatus[] = [
 	'canceled',
 	'crashed',
+	'unknown',
+	'waiting',
 	'error',
 	'success',
 ] as const satisfies ExecutionStatus[];


### PR DESCRIPTION
## Summary

We didn't consider `waiting` state as a finished state, so execution polling never stopped on multi-main instances.
Stopping like this if workflow enters waiting state isn't maybe ideal either, but Chat hub doesn't really support messages after waits of other type than Respond to Chat nodes.

This PR fixes the bug by simply accepting `waiting` (and `unknown`) as finished states in polling, and  adds tests for multi-main polling.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-110/bug-respond-to-chat-nodes-dont-work-on-multi-main-on-chat-hub

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
