### PR TITLE
refactor(editor): Improve text styles in Chat Hub (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/package.json
+++ b/packages/frontend/editor-ui/package.json
@@ -52,6 +52,7 @@
     "@sentry/vue": "catalog:frontend",
     "@types/semver": "^7.7.0",
     "@typescript/vfs": "^1.6.0",
+    "@vscode/markdown-it-katex": "^1.1.2",
     "@vue-flow/background": "1.3.2",
     "@vue-flow/controls": "1.1.3",
     "@vue-flow/core": "1.48.0",

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
@@ -748,15 +748,15 @@ function onFilesDropped(files: File[]) {
 
 .messageList {
 	width: 100%;
-	max-width: 55rem;
+	max-width: 78ch;
 	min-height: 100%;
 	align-self: center;
 	display: flex;
 	flex-direction: column;
-	gap: var(--spacing--md);
-	padding-top: 30px;
+	gap: var(--spacing--xl);
+	padding-top: var(--spacing--2xl);
 	padding-bottom: 200px;
-	padding-inline: 64px;
+	padding-inline: var(--spacing--xl);
 
 	.isMobileDevice & {
 		padding-inline: var(--spacing--md);

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.test.ts
@@ -57,6 +57,56 @@ describe('ChatMessage', () => {
 		});
 	});
 
+	it('should render KaTeX inline math expressions', async () => {
+		const message: ChatMessageType = createMockMessage({
+			type: 'ai',
+			content: 'The quadratic formula is $x = \\frac{-b \\pm \\sqrt{b^2-4ac}}{2a}$',
+		});
+
+		const { container } = renderComponent({
+			props: {
+				message,
+				compact: false,
+				isEditing: false,
+				hasSessionStreaming: false,
+				cachedAgentDisplayName: null,
+				cachedAgentIcon: null,
+				containerWidth: 100,
+			},
+			pinia,
+		});
+
+		await waitFor(() => {
+			const katexElements = container.querySelectorAll('.katex');
+			expect(katexElements.length).toBeGreaterThan(0);
+		});
+	});
+
+	it('should render KaTeX block math expressions', async () => {
+		const message: ChatMessageType = createMockMessage({
+			type: 'ai',
+			content: '$$\\sum_{i=1}^{n} i = \\frac{n(n+1)}{2}$$',
+		});
+
+		const { container } = renderComponent({
+			props: {
+				message,
+				compact: false,
+				isEditing: false,
+				hasSessionStreaming: false,
+				cachedAgentDisplayName: null,
+				cachedAgentIcon: null,
+				containerWidth: 100,
+			},
+			pinia,
+		});
+
+		await waitFor(() => {
+			const katexDisplayElements = container.querySelectorAll('.katex-display');
+			expect(katexDisplayElements.length).toBeGreaterThan(0);
+		});
+	});
+
 	it('should allow to copy code block contents', async () => {
 		const codeContent = 'const foo = "bar";\nfunction test() {\n  return true;\n}';
 		const message: ChatMessageType = createMockMessage({

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
@@ -346,7 +346,9 @@ onBeforeMount(() => {
 							:href="attachment.downloadUrl"
 						/>
 					</div>
-					<div v-if="message.type === 'human'">{{ message.content }}</div>
+					<div :class="$style.messageContent" v-if="message.type === 'human'">
+						{{ message.content }}
+					</div>
 					<VueMarkdown
 						v-else
 						:key="markdown.forceReRenderKey.value"
@@ -379,7 +381,9 @@ onBeforeMount(() => {
 			v-if="hoveredCodeBlockActions && hoveredCodeBlockContent"
 			:to="hoveredCodeBlockActions"
 		>
-			<CopyButton :content="hoveredCodeBlockContent" />
+			<div :class="$style.codeBlockActions">
+				<CopyButton :content="hoveredCodeBlockContent" />
+			</div>
 		</Teleport>
 	</div>
 </template>
@@ -388,6 +392,15 @@ onBeforeMount(() => {
 .message {
 	position: relative;
 	scroll-margin-block: var(--spacing--sm);
+}
+
+.messageContent {
+	font-size: var(--font-size--md);
+	line-height: var(--line-height--xl);
+}
+
+.codeBlockActions > * {
+	margin-top: -2px;
 }
 
 .avatar {
@@ -453,7 +466,7 @@ onBeforeMount(() => {
 .chatMessageMarkdown {
 	display: block;
 	box-sizing: border-box;
-	color: var(--color--text);
+	color: var(--color--text--shade-1);
 
 	// Base spacing rhythm between sibling elements
 	> * + * {
@@ -468,14 +481,16 @@ onBeforeMount(() => {
 		margin-bottom: 0;
 	}
 
-	& * {
-		font-size: var(--font-size--sm);
+	// Paragraphs and normal text
+	p,
+	li {
+		font-size: var(--font-size--md);
 		line-height: var(--line-height--xl);
+		margin: var(--spacing--sm) 0;
 	}
 
-	// Paragraphs
-	p {
-		margin: var(--spacing--sm) 0;
+	li {
+		margin: 0;
 	}
 
 	// Headings - with scroll margin for anchor navigation
@@ -524,12 +539,14 @@ onBeforeMount(() => {
 	// Strong/bold text
 	strong,
 	b {
+		font-size: var(--font-size--md);
 		color: var(--color--text--shade-1);
 		font-weight: var(--font-weight--bold);
 	}
 
 	// Links
 	a:not(:where(h1, h2, h3, h4, h5, h6) *) {
+		font-size: var(--font-size--md);
 		color: var(--color--text--shade-1);
 		font-weight: var(--font-weight--medium);
 		text-decoration: underline;
@@ -551,13 +568,11 @@ onBeforeMount(() => {
 	:not(pre) > code {
 		font-family: var(--font-family--monospace);
 		font-weight: var(--font-weight--medium);
-		color: var(--color--text--shade-1);
+		font-size: var(--font-size--sm);
+		line-height: var(--line-height--lg);
+		background-color: var(--chat--message--pre--background);
+		border-radius: var(--radius--sm);
 		font-variant-ligatures: none;
-
-		&::before,
-		&::after {
-			content: '`';
-		}
 	}
 
 	// Code in headings
@@ -622,6 +637,7 @@ onBeforeMount(() => {
 
 	// Blockquotes
 	blockquote {
+		font-size: var(--font-size--md);
 		font-style: italic;
 		border-left: var(--spacing--4xs) solid var(--color--foreground--shade-1);
 		padding-left: var(--spacing--sm);
@@ -650,33 +666,27 @@ onBeforeMount(() => {
 
 	// Ordered lists
 	ol {
-		padding-left: var(--spacing--lg);
+		padding-left: 0;
 		list-style-type: decimal;
+		list-style-position: inside;
 		margin: var(--spacing--sm) 0;
 
-		li {
-			padding-left: var(--spacing--xs);
-		}
-
 		li + li {
-			margin-top: var(--spacing--2xs);
+			margin-top: var(--spacing--xs);
 		}
 
 		li::marker {
-			font-weight: var(--font-weight--bold);
-			color: var(--color--text--shade-1);
+			font-family: var(--font-family--monospace);
+			color: var(--color--text);
 		}
 	}
 
 	// Unordered lists
 	ul {
-		padding-left: var(--spacing--lg);
+		padding-left: 0;
 		list-style-type: disc;
+		list-style-position: inside;
 		margin: var(--spacing--sm) 0;
-
-		li {
-			padding-left: var(--spacing--xs);
-		}
 
 		li + li {
 			margin-top: var(--spacing--2xs);
@@ -694,6 +704,7 @@ onBeforeMount(() => {
 	ol ul {
 		margin-top: var(--spacing--2xs);
 		margin-bottom: 0;
+		padding-left: var(--spacing--lg);
 	}
 
 	// Tables
@@ -705,7 +716,7 @@ onBeforeMount(() => {
 	table {
 		width: 100%;
 		table-layout: auto;
-		margin: var(--spacing--lg) 0;
+		margin: var(--spacing--sm) 0;
 		font-size: var(--font-size--sm);
 		line-height: var(--line-height--lg);
 	}

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
@@ -551,12 +551,11 @@ onBeforeMount(() => {
 		font-weight: var(--font-weight--medium);
 		text-decoration: underline;
 		text-underline-offset: 3px;
-		text-decoration-color: var(--color--secondary);
 		text-decoration-thickness: 1px;
-		transition: text-decoration-thickness 0.15s ease;
+		transition: color 0.15s ease;
 
 		&:hover {
-			text-decoration-thickness: 2px;
+			color: var(--color--primary);
 		}
 
 		code {
@@ -666,7 +665,7 @@ onBeforeMount(() => {
 
 	// Ordered lists
 	ol {
-		padding-left: 0;
+		padding-left: var(--spacing--sm);
 		list-style-type: decimal;
 		list-style-position: inside;
 		margin: var(--spacing--sm) 0;
@@ -683,7 +682,7 @@ onBeforeMount(() => {
 
 	// Unordered lists
 	ul {
-		padding-left: 0;
+		padding-left: var(--spacing--sm);
 		list-style-type: disc;
 		list-style-position: inside;
 		margin: var(--spacing--sm) 0;

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
@@ -453,6 +453,12 @@ onBeforeMount(() => {
 .chatMessageMarkdown {
 	display: block;
 	box-sizing: border-box;
+	color: var(--color--text);
+
+	// Base spacing rhythm between sibling elements
+	> * + * {
+		margin-top: var(--spacing--sm);
+	}
 
 	> *:first-child {
 		margin-top: 0;
@@ -464,24 +470,26 @@ onBeforeMount(() => {
 
 	& * {
 		font-size: var(--font-size--sm);
-		line-height: 1.5;
+		line-height: var(--line-height--xl);
 	}
 
+	// Paragraphs
 	p {
-		margin: var(--spacing--xs) 0;
+		margin: var(--spacing--sm) 0;
 	}
 
+	// Headings - with scroll margin for anchor navigation
 	h1,
 	h2,
 	h3,
 	h4,
 	h5,
 	h6 {
-		margin: 1em 0 0.8em;
+		color: var(--color--text--shade-1);
 		line-height: var(--line-height--md);
+		scroll-margin-top: var(--spacing--xl);
 	}
 
-	// Override heading sizes to be smaller
 	h1 {
 		font-size: var(--font-size--xl);
 		font-weight: var(--font-weight--bold);
@@ -497,35 +505,97 @@ onBeforeMount(() => {
 		font-weight: var(--font-weight--bold);
 	}
 
+	h2 + h3 {
+		margin-top: var(--spacing--sm);
+	}
+
 	h4 {
 		font-size: var(--font-size--sm);
 		font-weight: var(--font-weight--bold);
 	}
 
-	h5 {
-		font-size: var(--font-size--sm);
-		font-weight: var(--font-weight--bold);
-	}
-
+	h5,
 	h6 {
 		font-size: var(--font-size--sm);
 		font-weight: var(--font-weight--bold);
+		margin-top: var(--spacing--sm);
 	}
 
+	// Strong/bold text
+	strong,
+	b {
+		color: var(--color--text--shade-1);
+		font-weight: var(--font-weight--bold);
+	}
+
+	// Links
+	a:not(:where(h1, h2, h3, h4, h5, h6) *) {
+		color: var(--color--text--shade-1);
+		font-weight: var(--font-weight--medium);
+		text-decoration: underline;
+		text-underline-offset: 3px;
+		text-decoration-color: var(--color--secondary);
+		text-decoration-thickness: 1px;
+		transition: text-decoration-thickness 0.15s ease;
+
+		&:hover {
+			text-decoration-thickness: 2px;
+		}
+
+		code {
+			font-weight: var(--font-weight--medium);
+		}
+	}
+
+	// Inline code (not in pre blocks)
+	:not(pre) > code {
+		font-family: var(--font-family--monospace);
+		font-weight: var(--font-weight--medium);
+		color: var(--color--text--shade-1);
+		font-variant-ligatures: none;
+
+		&::before,
+		&::after {
+			content: '`';
+		}
+	}
+
+	// Code in headings
+	:is(h1, h2, h3, h4, h5, h6) code {
+		font-weight: var(--font-weight--bold);
+	}
+
+	// Code blocks
 	pre {
 		width: 100%;
-		font-family: inherit;
-		font-size: inherit;
-		margin: 0;
+		font-family: var(--font-family--monospace);
+		font-size: var(--font-size--sm);
+		line-height: var(--line-height--xl);
+		margin: var(--spacing--2xs) 0 var(--spacing--md);
 		white-space: pre-wrap;
 		box-sizing: border-box;
-		padding: var(--chat--spacing);
+		padding: var(--spacing--sm);
 		background: var(--chat--message--pre--background);
-		border-radius: var(--chat--border-radius);
+		border-radius: var(--radius--lg);
 		position: relative;
+
+		code {
+			font-family: var(--font-family--monospace);
+			font-variant-ligatures: none;
+
+			&::before,
+			&::after {
+				content: none;
+			}
+		}
 
 		code:last-of-type {
 			padding-bottom: 0;
+		}
+
+		// Reset spacing inside code blocks
+		code * + * {
+			margin-top: 0;
 		}
 
 		& .codeBlockActions {
@@ -546,43 +616,192 @@ onBeforeMount(() => {
 		}
 
 		& ~ pre {
-			margin-bottom: 1em;
+			margin-bottom: var(--spacing--md);
 		}
 	}
 
+	// Blockquotes
+	blockquote {
+		font-style: italic;
+		border-left: var(--spacing--4xs) solid var(--color--foreground--shade-1);
+		padding-left: var(--spacing--sm);
+		margin: var(--spacing--sm) 0;
+		color: var(--color--text--tint-1);
+
+		p:first-of-type::before {
+			content: open-quote;
+		}
+
+		p:last-of-type::after {
+			content: close-quote;
+		}
+	}
+
+	// Horizontal rules
+	hr {
+		border: none;
+		border-top: var(--border-width) var(--border-style) var(--color--foreground);
+		margin: var(--spacing--lg) 0;
+
+		& + h2 {
+			margin-top: var(--spacing--lg);
+		}
+	}
+
+	// Ordered lists
+	ol {
+		padding-left: var(--spacing--lg);
+		list-style-type: decimal;
+		margin: var(--spacing--sm) 0;
+
+		li {
+			padding-left: var(--spacing--xs);
+		}
+
+		li + li {
+			margin-top: var(--spacing--2xs);
+		}
+
+		li::marker {
+			font-weight: var(--font-weight--bold);
+			color: var(--color--text--shade-1);
+		}
+	}
+
+	// Unordered lists
+	ul {
+		padding-left: var(--spacing--lg);
+		list-style-type: disc;
+		margin: var(--spacing--sm) 0;
+
+		li {
+			padding-left: var(--spacing--xs);
+		}
+
+		li + li {
+			margin-top: var(--spacing--2xs);
+		}
+
+		li::marker {
+			color: var(--color--foreground--shade-1);
+		}
+	}
+
+	// Nested lists
+	ul ul,
+	ol ol,
+	ul ol,
+	ol ul {
+		margin-top: var(--spacing--2xs);
+		margin-bottom: 0;
+	}
+
+	// Tables
 	.tableContainer {
-		width: var(--container--width);
-		padding-bottom: 1em;
-		padding-left: calc((var(--container--width) - 100%) / 2);
-		padding-right: var(--spacing--lg);
-		margin-left: calc(-1 * (var(--container--width) - 100%) / 2);
+		width: 100%;
 		overflow-x: auto;
 	}
 
 	table {
-		width: fit-content;
-		border-bottom: var(--border);
-		border-top: var(--border);
-		border-width: 2px;
-		border-color: var(--color--text--shade-1);
+		width: 100%;
+		table-layout: auto;
+		margin: var(--spacing--lg) 0;
+		font-size: var(--font-size--sm);
+		line-height: var(--line-height--lg);
+	}
+
+	thead {
+		border-bottom-width: 1px;
+		border-bottom-style: solid;
+		border-bottom-color: var(--color--neutral-300);
+	}
+
+	thead th {
+		color: var(--color--text--shade-1);
+		font-weight: var(--font-weight--bold);
+		vertical-align: bottom;
+		padding-inline-start: 0.6em;
+		padding-inline-end: 0.6em;
+		padding-bottom: 0.8em;
+		text-align: start;
+	}
+
+	thead th:first-child {
+		padding-inline-start: 0;
+	}
+
+	thead th:last-child {
+		padding-inline-end: 0;
+	}
+
+	tbody tr {
+		border-bottom-width: 1px;
+		border-bottom-style: solid;
+		border-bottom-color: var(--color--neutral-200);
+	}
+
+	tbody tr:last-child {
+		border-bottom-width: 0;
+	}
+
+	tbody td {
+		vertical-align: baseline;
+		padding-top: 0.8em;
+		padding-inline-start: 0.6em;
+		padding-inline-end: 0.6em;
+		padding-bottom: 0.8em;
+	}
+
+	tbody td:first-child {
+		padding-inline-start: 0;
+	}
+
+	tbody td:last-child {
+		padding-inline-end: 0;
+	}
+
+	tfoot {
+		border-top-width: 1px;
+		border-top-style: solid;
+		border-top-color: var(--color--neutral-300);
+	}
+
+	tfoot td {
+		vertical-align: top;
+		padding-top: 0.8em;
+		padding-inline-start: 0.6em;
+		padding-inline-end: 0.6em;
+		padding-bottom: 0.8em;
+	}
+
+	tfoot td:first-child {
+		padding-inline-start: 0;
+	}
+
+	tfoot td:last-child {
+		padding-inline-end: 0;
+	}
+
+	td code {
+		font-size: var(--font-size--xs);
 	}
 
 	th,
 	td {
-		padding: 0.25em 1em 0.25em 0;
-		min-width: 12em;
+		text-align: start;
 	}
 
-	th {
-		border-bottom: var(--border);
-		border-color: var(--color--text--shade-1);
+	// Figures and captions
+	figure {
+		margin: var(--spacing--sm) 0;
 	}
 
-	ul,
-	ol {
-		li {
-			margin-bottom: 0.125rem;
-		}
+	figcaption {
+		margin-top: var(--spacing--xs);
+		text-align: center;
+		font-size: var(--font-size--sm);
+		font-style: italic;
+		color: var(--color--text--tint-1);
 	}
 }
 

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatPrompt.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatPrompt.vue
@@ -401,7 +401,7 @@ defineExpose({
 	border: var(--border);
 	display: flex;
 	flex-direction: column;
-	gap: var(--spacing--sm);
+	gap: var(--spacing--md);
 	transition: border-color 0.2s cubic-bezier(0.645, 0.045, 0.355, 1);
 
 	&:focus-within,
@@ -410,7 +410,7 @@ defineExpose({
 	}
 
 	& textarea {
-		font: inherit;
+		font-size: var(--font-size--md);
 		line-height: 1.5em;
 		resize: none;
 		background-color: transparent !important;

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatStarter.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatStarter.vue
@@ -20,7 +20,7 @@ const greetings = computed(() => {
 
 <template>
 	<div :class="[$style.starter, { [$style.isMobileDevice]: isMobileDevice }]">
-		<N8nHeading tag="h2" bold size="xlarge">
+		<N8nHeading tag="h2" bold size="2xlarge">
 			{{ greetings }}
 		</N8nHeading>
 	</div>

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatHubMarkdownOptions.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatHubMarkdownOptions.ts
@@ -3,6 +3,8 @@ import { type HLJSApi } from 'highlight.js';
 import { computed, ref } from 'vue';
 import type MarkdownIt from 'markdown-it';
 import markdownLink from 'markdown-it-link-attributes';
+import markdownItKatex from '@vscode/markdown-it-katex';
+import 'katex/dist/katex.min.css';
 
 let hljsInstance: HLJSApi | undefined;
 let asyncImport:
@@ -124,7 +126,13 @@ export function useChatHubMarkdownOptions(
 			};
 		};
 
-		return [linksNewTabPlugin, codeBlockPlugin, tablePlugin];
+		const mathPlugin = (vueMarkdownItInstance: MarkdownIt) => {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const katexPlugin = (markdownItKatex as any).default ?? markdownItKatex;
+			vueMarkdownItInstance.use(katexPlugin, { throwOnError: false });
+		};
+
+		return [linksNewTabPlugin, codeBlockPlugin, tablePlugin, mathPlugin];
 	});
 
 	return { options, forceReRenderKey, plugins, codeBlockContents };

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatHubMarkdownOptions.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatHubMarkdownOptions.ts
@@ -127,8 +127,9 @@ export function useChatHubMarkdownOptions(
 		};
 
 		const mathPlugin = (vueMarkdownItInstance: MarkdownIt) => {
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const katexPlugin = (markdownItKatex as any).default ?? markdownItKatex;
+			const katexPlugin =
+				(markdownItKatex as typeof markdownItKatex & { default?: typeof markdownItKatex })
+					.default ?? markdownItKatex;
 			vueMarkdownItInstance.use(katexPlugin, { throwOnError: false });
 		};
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2824,6 +2824,9 @@ importers:
       '@typescript/vfs':
         specifier: ^1.6.0
         version: 1.6.0(typescript@5.9.2)
+      '@vscode/markdown-it-katex':
+        specifier: ^1.1.2
+        version: 1.1.2
       '@vue-flow/background':
         specifier: 1.3.2
         version: 1.3.2(@vue-flow/core@1.48.0(vue@3.5.26(typescript@5.9.2)))(vue@3.5.26(typescript@5.9.2))
@@ -9337,6 +9340,9 @@ packages:
   '@volar/typescript@2.4.12':
     resolution: {integrity: sha512-HJB73OTJDgPc80K30wxi3if4fSsZZAOScbj2fcicMuOPoOkcf9NNAINb33o+DzhBdF9xTKC1gnPmIRDous5S0g==}
 
+  '@vscode/markdown-it-katex@1.1.2':
+    resolution: {integrity: sha512-+4IIv5PgrmhKvW/3LpkpkGg257OViEhXkOOgCyj5KMsjsOfnRXkni8XAuuF9Ui5p3B8WnUovlDXAQNb8RJ/RaQ==}
+
   '@vue-flow/background@1.3.2':
     resolution: {integrity: sha512-eJPhDcLj1wEo45bBoqTXw1uhl0yK2RaQGnEINqvvBsAFKh/camHJd5NPmOdS1w+M9lggc9igUewxaEd3iCQX2w==}
     peerDependencies:
@@ -10624,6 +10630,10 @@ packages:
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
 
   commander@9.4.1:
     resolution: {integrity: sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==}
@@ -13716,6 +13726,10 @@ packages:
     resolution: {integrity: sha512-j/YeapB1vfPT2iOIUn/vxdyKEuhuY2PxMBvf5JWux6iSaukAccrMtXEY/Lb7OvavDhOWME589bpLrEdnVHjfjA==}
     engines: {node: '>=14.0.0'}
 
+  katex@0.16.27:
+    resolution: {integrity: sha512-aeQoDkuRWSqQN6nSvVCEFvfXdqo1OQiCmmW1kc9xSdjutPv7BGO7pqY9sQRJpMOGrEdfDgF2TfRXe5eUAD2Waw==}
+    hasBin: true
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -15989,6 +16003,7 @@ packages:
     resolution: {integrity: sha512-gv6vLGcmAOg96/fgo3d9tvA4dJNZL3fMyBqVRrGxQ+Q/o4k9QzbJ3NQF9cOO/71wRodoXhaPgphvMFU68qVAJQ==}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qrcode.vue@3.3.4:
@@ -17245,6 +17260,7 @@ packages:
   tar@7.5.3:
     resolution: {integrity: sha512-ENg5JUHUm2rDD7IvKNFGzyElLXNjachNLp6RaGf4+JOgxXHkqA+gq81ZAMCUmtMtqBsoU62lcp6S27g1LCYGGQ==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   tarn@3.0.2:
     resolution: {integrity: sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==}
@@ -21684,7 +21700,7 @@ snapshots:
       '@currents/commit-info': 1.0.1-beta.0
       async-retry: 1.3.3
       axios: 1.12.0(debug@4.4.3)
-      axios-retry: 4.5.0(axios@1.12.0(debug@4.4.3))
+      axios-retry: 4.5.0(axios@1.12.0)
       c12: 1.11.2(magicast@0.3.5)
       chalk: 4.1.2
       commander: 12.1.0
@@ -26539,6 +26555,10 @@ snapshots:
       path-browserify: 1.0.1
       vscode-uri: 3.0.8
 
+  '@vscode/markdown-it-katex@1.1.2':
+    dependencies:
+      katex: 0.16.27
+
   '@vue-flow/background@1.3.2(@vue-flow/core@1.48.0(vue@3.5.26(typescript@5.9.2)))(vue@3.5.26(typescript@5.9.2))':
     dependencies:
       '@vue-flow/core': 1.48.0(vue@3.5.26(typescript@5.9.2))
@@ -27206,11 +27226,6 @@ snapshots:
   aws4@1.11.0: {}
 
   axe-core@4.7.2: {}
-
-  axios-retry@4.5.0(axios@1.12.0(debug@4.4.3)):
-    dependencies:
-      axios: 1.12.0(debug@4.4.3)
-      is-retry-allowed: 2.2.0
 
   axios-retry@4.5.0(axios@1.12.0):
     dependencies:
@@ -28075,6 +28090,8 @@ snapshots:
   commander@6.2.1: {}
 
   commander@7.2.0: {}
+
+  commander@8.3.0: {}
 
   commander@9.4.1: {}
 
@@ -30721,7 +30738,7 @@ snapshots:
       '@types/debug': 4.1.12
       '@types/node': 20.19.21
       '@types/tough-cookie': 4.0.5
-      axios: 1.12.0(debug@4.4.3)
+      axios: 1.12.0
       camelcase: 6.3.0
       debug: 4.4.3(supports-color@8.1.1)
       dotenv: 16.6.1
@@ -30731,7 +30748,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.12.0)
+      retry-axios: 2.6.0(axios@1.12.0(debug@4.4.3))
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -32173,6 +32190,10 @@ snapshots:
       safe-buffer: 5.2.1
 
   kafkajs@2.2.4: {}
+
+  katex@0.16.27:
+    dependencies:
+      commander: 8.3.0
 
   keyv@4.5.4:
     dependencies:
@@ -35172,7 +35193,7 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
-  retry-axios@2.6.0(axios@1.12.0):
+  retry-axios@2.6.0(axios@1.12.0(debug@4.4.3)):
     dependencies:
       axios: 1.12.0
 


### PR DESCRIPTION
## Summary

This PR improves the typography and markdown rendering in the Chat Hub:

- **Typography & readability**: Larger font sizes, improved line heights, and 78ch max-width for optimal reading
- **Spacing & layout**: Consistent vertical rhythm using design system variables, larger greeting size
- **Rich content styling**: Proper list markers/nesting, clean tables with header/body/footer separation, styled blockquotes with left border
- **Code presentation**: Improved code blocks (background, border radius, copy button), better inline code with monospace font
- **Headings & links**: Properly sized h1-h6 with scroll margins, links with underline offset and hover states
- **Math support**: Added @vscode/markdown-it-katex for mathematical expressions

| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/07c6456e-8296-4a40-8184-c66b5f5da180" width="960"/> | <img src="https://github.com/user-attachments/assets/6fbe4daf-7206-466a-9090-fb87ba5c5a1e" width="960"/> |
| <img width="1632" height="990" alt="CleanShot 2026-01-22 at 16 36 22@2x" src="https://github.com/user-attachments/assets/b2595a34-86d3-4ff0-87a1-7a420d2c8008" /> | <img width="1168" height="1768" alt="CleanShot 2026-01-22 at 16 36 01@2x" src="https://github.com/user-attachments/assets/6465f2a0-561f-4040-8f5f-150a4d295046" /> |

## Related Linear tickets, Github issues, and Community forum posts
[CHA-111](https://linear.app/n8n/issue/CHA-111/design-improve-markdown-styling)

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)