### PR TITLE
chore(core): Remove allow failure toggle for context extractor

### DIFF
--- a/packages/cli/src/__tests__/load-nodes-and-credentials.test.ts
+++ b/packages/cli/src/__tests__/load-nodes-and-credentials.test.ts
@@ -827,8 +827,8 @@ describe('LoadNodesAndCredentials', () => {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			const hookValues = (hookProperty as any).options?.[0]?.values as INodeProperties[];
 
-			// Should have: hookName selector + isAllowedToFail + 2 options from first hook = 4 values
-			expect(hookValues).toHaveLength(4);
+			// Should have: hookName selector + 2 options from first hook = 3 values
+			expect(hookValues).toHaveLength(3);
 
 			// Verify hookName selector with both hook options
 			expect(hookValues[0].name).toBe('hookName');
@@ -839,22 +839,17 @@ describe('LoadNodesAndCredentials', () => {
 			expect(hookNameOptions[0].value).toBe('credentials.bearerToken');
 			expect(hookNameOptions[1].value).toBe('credentials.apiKey');
 
-			// Verify isAllowedToFail field
-			expect(hookValues[1].name).toBe('isAllowedToFail');
-			expect(hookValues[1].type).toBe('boolean');
-			expect(hookValues[1].default).toBe(false);
-
 			// Verify first option has display condition
-			expect(hookValues[2].name).toBe('removeFromItem');
-			expect(hookValues[2].displayOptions).toEqual({
+			expect(hookValues[1].name).toBe('removeFromItem');
+			expect(hookValues[1].displayOptions).toEqual({
 				show: {
 					hookName: ['credentials.bearerToken'],
 				},
 			});
 
 			// Verify second option merges existing displayOptions with hookName
-			expect(hookValues[3].name).toBe('advancedOption');
-			expect(hookValues[3].displayOptions).toEqual({
+			expect(hookValues[2].name).toBe('advancedOption');
+			expect(hookValues[2].displayOptions).toEqual({
 				show: {
 					someOtherField: ['value'],
 					hookName: ['credentials.bearerToken'],

--- a/packages/cli/src/load-nodes-and-credentials.ts
+++ b/packages/cli/src/load-nodes-and-credentials.ts
@@ -378,13 +378,6 @@ export class LoadNodesAndCredentials {
 				description: 'Select which context establishment hook to use',
 				required: true,
 			},
-			{
-				displayName: 'Allow Failure',
-				name: 'isAllowedToFail',
-				type: 'boolean',
-				default: false,
-				description: 'Whether to continue workflow execution if this hook fails',
-			},
 		];
 
 		// Add all hook-specific options with display conditions


### PR DESCRIPTION
## Summary

Remove allow failure toggle for context extractor.

<img width="626" height="449" alt="image" src="https://github.com/user-attachments/assets/a2d81278-cc4c-4004-bcc2-1203838f5789" />


## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/IAM-136/remove-allow-failure-toggle-for-extractors

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
