### PR TITLE
feat: Remove context establishment hook targets on test webhook endpoints

### DIFF
--- a/packages/cli/src/webhooks/test-webhooks.ts
+++ b/packages/cli/src/webhooks/test-webhooks.ts
@@ -14,7 +14,10 @@ import type {
 } from 'n8n-workflow';
 
 import { authAllowlistedNodes } from './constants';
-import { sanitizeWebhookRequest } from './webhook-request-sanitizer';
+import {
+	removeContextEstablishmentHookTargets,
+	sanitizeWebhookRequest,
+} from './webhook-request-sanitizer';
 import { WebhookService } from './webhook.service';
 import type {
 	IWebhookResponseCallbackData,
@@ -123,6 +126,9 @@ export class TestWebhooks implements IWebhookManager {
 		if (workflowStartNode === null) {
 			throw new NotFoundError('Could not find node to process webhook.');
 		}
+
+		// Remove headers targeted by context establishment hooks
+		removeContextEstablishmentHookTargets(request, workflow, workflowStartNode);
 
 		if (!authAllowlistedNodes.has(workflowStartNode.type)) {
 			sanitizeWebhookRequest(request);

--- a/packages/cli/src/webhooks/webhook-request-sanitizer.ts
+++ b/packages/cli/src/webhooks/webhook-request-sanitizer.ts
@@ -1,8 +1,11 @@
 import { Container } from '@n8n/di';
 import type { Request } from 'express';
 import { ExecutionContextHookRegistry } from 'n8n-core';
-import { toExecutionContextEstablishmentHookParameter, type Workflow } from 'n8n-workflow';
-import type { INode } from 'n8n-workflow';
+import {
+	toExecutionContextEstablishmentHookParameter,
+	type Workflow,
+	type INode,
+} from 'n8n-workflow';
 
 import { AUTH_COOKIE_NAME } from '@/constants';
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR enforces removal of a user provided auth token that is destined for a context establishment hook from test webhook endpoints.

In production webhooks, these targets make it into the execution context, but this is not required for the test webhook endpoint.

## Related Linear tickets, Github issues, and Community forum posts

IAM-133

Before:

<img width="372" height="441" alt="image" src="https://github.com/user-attachments/assets/5ad5ba06-3b52-420e-b252-db4005646f47" />

After: 

<img width="372" height="363" alt="image" src="https://github.com/user-attachments/assets/b940f9c5-66b7-4ff4-b8e9-232dc7b9cb8b" />

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
