### PR TITLE
ci: Fix security cherrypick workflow

### DIFF
--- a/.github/workflows/sec-publish-fix.yml
+++ b/.github/workflows/sec-publish-fix.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Generate GitHub App Token
         id: generate_token

--- a/.github/workflows/sec-publish-fix.yml
+++ b/.github/workflows/sec-publish-fix.yml
@@ -34,12 +34,6 @@ jobs:
       contents: write
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
       - name: Generate GitHub App Token
         id: generate_token
         uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
@@ -47,7 +41,13 @@ jobs:
           app-id: ${{ secrets.N8N_ASSISTANT_APP_ID }}
           private-key: ${{ secrets.N8N_ASSISTANT_PRIVATE_KEY }}
           owner: n8n-io
-          repositories: n8n
+          repositories: n8n,n8n-private
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Cherry-pick to public repo
         run: |


### PR DESCRIPTION
Prevent checkout from caching credentials so the cherry-pick workflow uses the App token instead of github-actions[bot] when pushing to the public repo.

https://github.com/n8n-io/n8n-private/actions/runs/21242054933/job/61122104076