### PR TITLE
fix(core): attempt to refresh credentials even for forbidden resources

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
@@ -1111,9 +1111,9 @@ export async function httpRequestWithAuthentication(
 		return await httpRequest(requestOptions, additionalData.ssrfBridge);
 	} catch (error) {
 		// if there is a pre authorization method defined and
-		// the method failed due to unauthorized request
+		// the method failed due to unauthorized or forbidden request
 		if (
-			error.response?.status === 401 &&
+			(error.response?.status === 401 || error.response?.status === 403) &&
 			additionalData.credentialsHelper.preAuthentication !== undefined
 		) {
 			try {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Some HTTP services respond to requests with expired credentials with status code 403 instead of 401. This means that with the current implementation, the refresh of the credentials is not triggered. Unfortunately, it is not possible to configure the error code(s) for which the refresh is attempted, nor is it possible to trigger the refresh manually using a helper. For this reason, I believe it would be beneficial to attempt the refresh even with status code 403, as is done with status code 401.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

n/a

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
