### PR TITLE
feat: Centralizes debounce timing constants

### DIFF
--- a/packages/frontend/AGENTS.md
+++ b/packages/frontend/AGENTS.md
@@ -114,3 +114,15 @@ application. These variables cover colors, spacing, typography, and borders.
 --border-style: solid
 --border: var(--border-width) var(--border-style) var(--color--foreground)
 ```
+
+### Debounce Timing
+
+Use centralized constants from `@/app/constants/durations` instead of hardcoding:
+
+```typescript
+import { DEBOUNCE_TIME, getDebounceTime } from '@/app/constants';
+
+useDebounceFn(() => { ... }, getDebounceTime(DEBOUNCE_TIME.INPUT.SEARCH));
+```
+
+Categories: `UI`, `INPUT`, `API`, `TELEMETRY`, `COLLABORATION`, `CONNECTION`.

--- a/packages/frontend/editor-ui/src/app/composables/useActivityDetection.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useActivityDetection.ts
@@ -1,13 +1,14 @@
 import { onMounted, onUnmounted, watch } from 'vue';
 import { useDebounceFn } from '@vueuse/core';
 import { useCollaborationStore } from '@/features/collaboration/collaboration/collaboration.store';
+import { DEBOUNCE_TIME, getDebounceTime } from '@/app/constants/durations';
 
 export function useActivityDetection() {
 	const collaborationStore = useCollaborationStore();
 
 	const recordActivity = useDebounceFn(() => {
 		collaborationStore.recordActivity();
-	}, 100);
+	}, getDebounceTime(DEBOUNCE_TIME.COLLABORATION.ACTIVITY));
 
 	const events = ['mousedown', 'keydown', 'touchstart'];
 

--- a/packages/frontend/editor-ui/src/app/composables/useDebounce.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useDebounce.ts
@@ -1,6 +1,8 @@
 import { ref } from 'vue';
 import _debounce from 'lodash/debounce';
 
+import { getDebounceTime } from '@/app/constants/durations';
+
 export interface DebounceOptions {
 	debounceTime: number;
 	trailing?: boolean;
@@ -17,6 +19,8 @@ export function useDebounce() {
 	const debounce = <T extends AnyFunction>(fn: T, options: DebounceOptions): DebouncedFunc<T> => {
 		const { trailing, debounceTime } = options;
 
+		const effectiveDebounceTime = getDebounceTime(debounceTime);
+
 		// Check if a debounced version of the function is already stored in the WeakMap.
 		let debouncedFn = debounceCache.value.get(fn);
 
@@ -26,7 +30,7 @@ export function useDebounce() {
 				async (...args: Parameters<T>) => {
 					return fn(...args);
 				},
-				debounceTime,
+				effectiveDebounceTime,
 				trailing ? { trailing } : { leading: true },
 			);
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
@@ -3,7 +3,15 @@ import { useUIStore } from '@/app/stores/ui.store';
 import type { LocationQuery, NavigationGuardNext, useRouter } from 'vue-router';
 import { useMessage } from './useMessage';
 import { useI18n } from '@n8n/i18n';
-import { MODAL_CANCEL, MODAL_CLOSE, MODAL_CONFIRM, VIEWS, AutoSaveState } from '@/app/constants';
+import {
+	MODAL_CANCEL,
+	MODAL_CLOSE,
+	MODAL_CONFIRM,
+	VIEWS,
+	AutoSaveState,
+	DEBOUNCE_TIME,
+	getDebounceTime,
+} from '@/app/constants';
 import { useWorkflowHelpers } from '@/app/composables/useWorkflowHelpers';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
@@ -516,8 +524,8 @@ export function useWorkflowSaving({
 
 			autosaveStore.setPendingAutoSave(savePromise);
 		},
-		1500,
-		{ maxWait: 5000 },
+		getDebounceTime(DEBOUNCE_TIME.API.AUTOSAVE),
+		{ maxWait: getDebounceTime(DEBOUNCE_TIME.API.AUTOSAVE_MAX_WAIT) },
 	);
 
 	const scheduleAutoSave = () => {

--- a/packages/frontend/editor-ui/src/app/constants/durations.test.ts
+++ b/packages/frontend/editor-ui/src/app/constants/durations.test.ts
@@ -1,0 +1,39 @@
+import { getDebounceTime } from './durations';
+
+describe('getDebounceTime', () => {
+	beforeEach(() => {
+		sessionStorage.clear();
+	});
+
+	it('returns original time when no multiplier is set', () => {
+		expect(getDebounceTime(100)).toBe(100);
+		expect(getDebounceTime(1500)).toBe(1500);
+	});
+
+	it('applies multiplier from sessionStorage', () => {
+		sessionStorage.setItem('N8N_DEBOUNCE_MULTIPLIER', '0.5');
+		expect(getDebounceTime(100)).toBe(50);
+		expect(getDebounceTime(1500)).toBe(750);
+	});
+
+	it('returns 0 when multiplier is 0', () => {
+		sessionStorage.setItem('N8N_DEBOUNCE_MULTIPLIER', '0');
+		expect(getDebounceTime(100)).toBe(0);
+		expect(getDebounceTime(1500)).toBe(0);
+	});
+
+	it('handles multiplier greater than 1', () => {
+		sessionStorage.setItem('N8N_DEBOUNCE_MULTIPLIER', '2');
+		expect(getDebounceTime(100)).toBe(200);
+	});
+
+	it('defaults to 1 for invalid multiplier values', () => {
+		sessionStorage.setItem('N8N_DEBOUNCE_MULTIPLIER', 'invalid');
+		expect(getDebounceTime(100)).toBe(100);
+	});
+
+	it('rounds to nearest integer', () => {
+		sessionStorage.setItem('N8N_DEBOUNCE_MULTIPLIER', '0.33');
+		expect(getDebounceTime(100)).toBe(33);
+	});
+});

--- a/packages/frontend/editor-ui/src/app/constants/durations.ts
+++ b/packages/frontend/editor-ui/src/app/constants/durations.ts
@@ -25,3 +25,66 @@ export const SEVEN_DAYS_IN_MILLIS = 7 * TIME.DAY;
 export const SIX_MONTHS_IN_MILLIS = 6 * 30 * TIME.DAY;
 
 export const LOADING_ANIMATION_MIN_DURATION = 1000;
+
+/**
+ * Get debounce time with optional multiplier from sessionStorage.
+ * Reads 'N8N_DEBOUNCE_MULTIPLIER' - defaults to 1 if not set.
+ */
+export function getDebounceTime(time: number): number {
+	const stored = sessionStorage.getItem('N8N_DEBOUNCE_MULTIPLIER');
+	const multiplier = stored !== null ? parseFloat(stored) : 1;
+	return Math.round(time * (Number.isNaN(multiplier) ? 1 : multiplier));
+}
+
+/** Centralized debounce timing constants. Use with getDebounceTime(). */
+export const DEBOUNCE_TIME = {
+	/** UI responsiveness - very fast feedback */
+	UI: {
+		/** Window/element resize events */
+		RESIZE: 50,
+		/** Quick UI state changes */
+		QUICK: 10,
+	},
+
+	/** Input validation and real-time feedback */
+	INPUT: {
+		/** Fast validation feedback (100ms) */
+		VALIDATION: 100,
+		/** Text input changes (200ms) */
+		TEXT_CHANGE: 200,
+		/** Search input in UI (250-300ms) */
+		SEARCH: 300,
+	},
+
+	/** API and resource operations */
+	API: {
+		/** Resource dropdown search (500ms) */
+		RESOURCE_SEARCH: 500,
+		/** Heavy operations like pagination (1000ms) */
+		HEAVY_OPERATION: 1000,
+		/** Workflow autosave debounce (1500ms) */
+		AUTOSAVE: 1500,
+		/** Workflow autosave max wait - forces save (5000ms) */
+		AUTOSAVE_MAX_WAIT: 5000,
+	},
+
+	/** Telemetry and analytics */
+	TELEMETRY: {
+		/** Analytics event batching (2000ms) */
+		BATCH: 2000,
+		/** Tracking filter changes (1000ms) */
+		TRACK: 1000,
+	},
+
+	/** Collaboration features */
+	COLLABORATION: {
+		/** Activity recording (100ms) */
+		ACTIVITY: 100,
+	},
+
+	/** Connection management */
+	CONNECTION: {
+		/** WebSocket disconnect debounce (500ms) */
+		WEBSOCKET_DISCONNECT: 500,
+	},
+} as const;

--- a/packages/frontend/editor-ui/src/app/stores/pushConnection.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/pushConnection.store.ts
@@ -3,6 +3,7 @@ import { computed, ref, watch } from 'vue';
 import type { PushMessage } from '@n8n/api-types';
 
 import { STORES } from '@n8n/stores';
+import { DEBOUNCE_TIME, getDebounceTime } from '@/app/constants/durations';
 import { useSettingsStore } from './settings.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useWebSocketClient } from '@/app/push-connection/useWebSocketClient';
@@ -96,7 +97,8 @@ export const usePushConnectionStore = defineStore(STORES.PUSH, () => {
 	 * Debounce window in ms for disconnect. If pushConnect is called within this
 	 * window (before or after pushDisconnect), the connection is kept.
 	 */
-	const DISCONNECT_DEBOUNCE_MS = 500;
+	const getDisconnectDebounceMs = () =>
+		getDebounceTime(DEBOUNCE_TIME.CONNECTION.WEBSOCKET_DISCONNECT);
 
 	/**
 	 * Tracks whether a connect was recently requested. Used to handle race conditions
@@ -125,7 +127,7 @@ export const usePushConnectionStore = defineStore(STORES.PUSH, () => {
 		connectIntentTimeout = setTimeout(() => {
 			recentConnectIntent = false;
 			connectIntentTimeout = null;
-		}, DISCONNECT_DEBOUNCE_MS);
+		}, getDisconnectDebounceMs());
 
 		// Cancel any pending disconnect timeout
 		if (disconnectTimeout) {
@@ -158,7 +160,7 @@ export const usePushConnectionStore = defineStore(STORES.PUSH, () => {
 			isConnectionRequested.value = false;
 			client.value.disconnect();
 			disconnectTimeout = null;
-		}, DISCONNECT_DEBOUNCE_MS);
+		}, getDisconnectDebounceMs());
 	};
 
 	watch(

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectSettings.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectSettings.vue
@@ -9,7 +9,7 @@ import { useI18n } from '@n8n/i18n';
 import { type ResourceCounts, useProjectsStore } from '../projects.store';
 import type { Project, ProjectRelation, ProjectMemberData } from '../projects.types';
 import { useToast } from '@/app/composables/useToast';
-import { VIEWS } from '@/app/constants';
+import { DEBOUNCE_TIME, getDebounceTime, VIEWS } from '@/app/constants';
 import ProjectDeleteDialog from '../components/ProjectDeleteDialog.vue';
 import ProjectRoleUpgradeDialog from '../components/ProjectRoleUpgradeDialog.vue';
 import ProjectMembersTable from '../components/ProjectMembersTable.vue';
@@ -463,7 +463,7 @@ watch(shouldShowSearch, (show) => {
 
 const debouncedSearch = useDebounceFn(() => {
 	membersTableState.value.page = 0; // Reset to first page on search
-}, 300);
+}, getDebounceTime(DEBOUNCE_TIME.INPUT.SEARCH));
 
 const onSearch = (value: string) => {
 	search.value = value;

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
@@ -61,7 +61,9 @@ import {
 	APP_MODALS_ELEMENT_ID,
 	CORE_NODES_CATEGORY,
 	CUSTOM_API_CALL_KEY,
+	DEBOUNCE_TIME,
 	ExpressionLocalResolveContextSymbol,
+	getDebounceTime,
 	HTML_NODE_TYPE,
 	NODES_USING_CODE_NODE_EDITOR,
 } from '@/app/constants';
@@ -831,7 +833,7 @@ const trackBuilderPlaceholders = useDebounceFn(() => {
 			node_type: node.value.type,
 		});
 	}
-}, 100);
+}, getDebounceTime(DEBOUNCE_TIME.INPUT.VALIDATION));
 
 async function setFocus(fromModeSwitch: boolean | FocusEvent = false) {
 	// When called from template @focus="setFocus", the first arg is a FocusEvent, not a boolean

--- a/packages/frontend/editor-ui/src/features/settings/migrationReport/MigrationRuleDetail.vue
+++ b/packages/frontend/editor-ui/src/features/settings/migrationReport/MigrationRuleDetail.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import TimeAgo from '@/app/components/TimeAgo.vue';
 import ResourceFiltersDropdown from '@/app/components/forms/ResourceFiltersDropdown.vue';
-import { VIEWS } from '@/app/constants';
+import { DEBOUNCE_TIME, getDebounceTime, VIEWS } from '@/app/constants';
 import type { BreakingChangeWorkflowRuleResult } from '@n8n/api-types';
 import {
 	N8nButton,
@@ -109,7 +109,7 @@ const statusFilter = ref<'' | 'active' | 'deactivated'>('');
 // Debounced search to avoid excessive filtering
 const debouncedSearch = useDebounceFn((value: string) => {
 	searchQuery.value = value;
-}, 300);
+}, getDebounceTime(DEBOUNCE_TIME.INPUT.SEARCH));
 
 const onSearchInput = (value: string) => {
 	searchInput.value = value; // Update input immediately

--- a/packages/frontend/editor-ui/src/features/settings/users/views/SettingsUsersView.vue
+++ b/packages/frontend/editor-ui/src/features/settings/users/views/SettingsUsersView.vue
@@ -10,7 +10,12 @@ import {
 } from '@n8n/api-types';
 import type { UserAction } from '@n8n/design-system';
 import type { TableOptions } from '@n8n/design-system/components/N8nDataTableServer';
-import { EnterpriseEditionFeature, MODAL_CONFIRM } from '@/app/constants';
+import {
+	DEBOUNCE_TIME,
+	EnterpriseEditionFeature,
+	getDebounceTime,
+	MODAL_CONFIRM,
+} from '@/app/constants';
 import { DELETE_USER_MODAL_KEY, INVITE_USER_MODAL_KEY } from '../users.constants';
 import EnterpriseEdition from '@/app/components/EnterpriseEdition.ee.vue';
 import type { InvitableRoleName } from '../users.types';
@@ -426,7 +431,7 @@ const updateUsersTableData = async ({ page, itemsPerPage, sortBy }: TableOptions
 const debouncedUpdateUsersTableData = useDebounceFn(() => {
 	usersTableState.value.page = 0; // Reset to first page on search
 	void updateUsersTableData(usersTableState.value);
-}, 300);
+}, getDebounceTime(DEBOUNCE_TIME.INPUT.SEARCH));
 
 const onSearch = (value: string) => {
 	search.value = value;

--- a/packages/testing/playwright/fixtures/base.ts
+++ b/packages/testing/playwright/fixtures/base.ts
@@ -136,6 +136,12 @@ export const test = base.extend<
 		await setupDefaultInterceptors(context);
 		const page = await context.newPage();
 
+		// Set debounce multiplier for E2E tests - 1 means normal timing (no change)
+		// Can be lowered (e.g. 0.5) to speed up tests, but avoid 0 as it causes race conditions
+		await page.addInitScript(() => {
+			sessionStorage.setItem('N8N_DEBOUNCE_MULTIPLIER', '1');
+		});
+
 		const useSeparateApiContext = backendUrl !== frontendUrl;
 
 		if (useSeparateApiContext) {

--- a/packages/testing/playwright/pages/BasePage.ts
+++ b/packages/testing/playwright/pages/BasePage.ts
@@ -43,4 +43,23 @@ export abstract class BasePage extends FloatingUiHelper {
 			return matches && (method ? res.request().method() === method : true);
 		});
 	}
+
+	/**
+	 * Wait for debounce to complete.
+	 * Respects the N8N_DEBOUNCE_MULTIPLIER sessionStorage setting.
+	 * With multiplier=0 (test mode), returns immediately.
+	 * @param baseTime - Base debounce time in milliseconds (default: 150)
+	 */
+	protected async waitForDebounce(baseTime = 150): Promise<void> {
+		const effectiveTime = await this.page.evaluate((time) => {
+			const stored = sessionStorage.getItem('N8N_DEBOUNCE_MULTIPLIER');
+			const multiplier = stored !== null ? parseFloat(stored) : 1;
+			return Math.round(time * (Number.isNaN(multiplier) ? 1 : multiplier));
+		}, baseTime);
+
+		if (effectiveTime > 0) {
+			// eslint-disable-next-line playwright/no-wait-for-timeout
+			await this.page.waitForTimeout(effectiveTime);
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Introduces centralized debounce timing constants and a helper function to apply a multiplier from sessionStorage. This allows for easier management and modification of debounce times across the application, especially for testing purposes.

Replaces hardcoded debounce values with constants from the new module.

## Related Linear tickets, Github issues, and Community forum posts

Note: There are other debounce functions (lodash) that also need to be migrated but that can be after this.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
