### PR TITLE
fix(editor): AI response text in ChatHub not selectable while responding

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chat.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chat.utils.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { splitMarkdownIntoChunks } from './chat.utils';
+
+describe('splitMarkdownIntoChunks', () => {
+	it('should return empty array for empty string', () => {
+		expect(splitMarkdownIntoChunks('')).toEqual([]);
+	});
+
+	it('should return single chunk for simple text', () => {
+		const result = splitMarkdownIntoChunks('Hello world');
+		expect(result).toHaveLength(1);
+		expect(result[0]).toBe('Hello world');
+	});
+
+	it('should split on two consecutive empty lines', () => {
+		const content = 'First paragraph\n\n\nSecond paragraph';
+		const result = splitMarkdownIntoChunks(content);
+		expect(result).toHaveLength(2);
+		expect(result[0]).toBe('First paragraph');
+		expect(result[1]).toBe('\nSecond paragraph');
+	});
+
+	it('should keep code blocks as single chunk even with double newlines inside', () => {
+		const content = '```typescript\nconst x = 1;\n\nconst y = 2;\n```';
+		const result = splitMarkdownIntoChunks(content);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toBe(content);
+	});
+
+	it('should split before headers', () => {
+		const content = 'Some text\n\n# Header\nMore text';
+		const result = splitMarkdownIntoChunks(content);
+		expect(result).toHaveLength(2);
+		expect(result[0]).toBe('Some text');
+		expect(result[1]).toBe('# Header\nMore text');
+	});
+
+	it('should handle multiple paragraphs and code blocks', () => {
+		const content =
+			'First paragraph\n\n\nSecond paragraph\n\n\n```js\ncode();\n```\n\n\nThird paragraph';
+		const result = splitMarkdownIntoChunks(content);
+		expect(result).toHaveLength(4);
+		expect(result[0]).toBe('First paragraph');
+		expect(result[1]).toBe('\nSecond paragraph');
+		expect(result[2]).toBe('\n```js\ncode();\n```');
+		expect(result[3]).toBe('\n\nThird paragraph');
+	});
+
+	it('should handle escaped code blocks', () => {
+		const content = '````markdown\n```python\nprint("Hello, World!")\n```\n````';
+		const result = splitMarkdownIntoChunks(content);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toBe('````markdown\n```python\nprint("Hello, World!")\n```\n````');
+	});
+
+	it('should handle tilde code blocks', () => {
+		const content = '~~~javascript\nconst x = 1;\n~~~';
+		const result = splitMarkdownIntoChunks(content);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toBe('~~~javascript\nconst x = 1;\n~~~');
+	});
+
+	it('should handle nested tilde code blocks', () => {
+		const content = '~~~~markdown\n~~~python\nprint("Hello")\n~~~\n~~~~';
+		const result = splitMarkdownIntoChunks(content);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toBe('~~~~markdown\n~~~python\nprint("Hello")\n~~~\n~~~~');
+	});
+
+	it('should handle indented code blocks', () => {
+		const content = 'Regular text\n\n    code()\n    more_code()\n\nMore text';
+		const result = splitMarkdownIntoChunks(content);
+		expect(result).toHaveLength(3);
+		expect(result[0]).toBe('Regular text');
+		expect(result[1]).toBe('    code()\n    more_code()');
+		expect(result[2]).toBe('More text');
+	});
+
+	it('should handle indented code blocks with blank lines', () => {
+		const content = '    code()\n\n    more_code()';
+		const result = splitMarkdownIntoChunks(content);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toBe('    code()\n\n    more_code()');
+	});
+
+	it('should handle tab-indented code blocks', () => {
+		const content = 'Text\n\n\tcode()\n\tmore()\n\nMore text';
+		const result = splitMarkdownIntoChunks(content);
+		expect(result).toHaveLength(3);
+		expect(result[0]).toBe('Text');
+		expect(result[1]).toBe('\tcode()\n\tmore()');
+		expect(result[2]).toBe('More text');
+	});
+
+	it('should handle nested code blocks', () => {
+		const content = '~~~markdown\n```python\nprint("Hello")\n```\n~~~';
+		const result = splitMarkdownIntoChunks(content);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toBe(content);
+	});
+
+	it('should handle nested tab-indented code blocks', () => {
+		const content = '```markdown\n    ```python\n    print("Hello")\n    ```\n```';
+		const result = splitMarkdownIntoChunks(content);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toBe(content);
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMarkdownChunk.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMarkdownChunk.vue
@@ -58,20 +58,22 @@ function handleMouseLeave() {
 
 <style lang="scss" module>
 .chatMessageMarkdown {
-	display: block;
-	box-sizing: border-box;
-
-	> *:first-child {
-		margin-top: 0;
-	}
-
-	> *:last-child {
-		margin-bottom: 0;
-	}
-
 	& * {
 		font-size: var(--font-size--sm);
 		line-height: 1.5;
+	}
+
+	& > div {
+		display: block;
+		box-sizing: border-box;
+	}
+
+	&:first-child > div > *:first-child {
+		margin-top: 0;
+	}
+
+	& > div > *:last-child {
+		margin-bottom: 0;
 	}
 
 	p {
@@ -120,7 +122,7 @@ function handleMouseLeave() {
 	}
 
 	pre {
-		width: 100%;
+		display: block;
 		font-family: inherit;
 		font-size: inherit;
 		margin: 0;
@@ -164,6 +166,10 @@ function handleMouseLeave() {
 		padding-right: var(--spacing--lg);
 		margin-left: calc(-1 * (var(--container--width) - 100%) / 2);
 		overflow-x: auto;
+
+		&:first-child {
+			padding-top: 1em;
+		}
 	}
 
 	table {

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMarkdownChunk.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMarkdownChunk.vue
@@ -1,0 +1,195 @@
+<script setup lang="ts">
+import VueMarkdown from 'vue-markdown-render';
+import { useChatHubMarkdownOptions } from '@/features/ai/chatHub/composables/useChatHubMarkdownOptions';
+import CopyButton from '@/features/ai/chatHub/components/CopyButton.vue';
+import { computed, ref, useCssModule } from 'vue';
+
+const { source, containerWidth } = defineProps<{
+	source: string;
+	containerWidth: number;
+}>();
+
+const styles = useCssModule();
+const markdown = useChatHubMarkdownOptions(styles.codeBlockActions, styles.tableContainer);
+const hoveredCodeBlockActions = ref<HTMLElement | null>(null);
+
+const hoveredCodeBlockContent = computed(() => {
+	const idx = hoveredCodeBlockActions.value?.getAttribute('data-markdown-token-idx');
+	return idx ? markdown.codeBlockContents.value?.get(idx) : undefined;
+});
+
+function handleMouseMove(e: MouseEvent | FocusEvent) {
+	const container =
+		e.target instanceof HTMLElement || e.target instanceof SVGElement
+			? e.target.closest('pre')?.querySelector(`.${styles.codeBlockActions}`)
+			: null;
+
+	hoveredCodeBlockActions.value = container instanceof HTMLElement ? container : null;
+}
+
+function handleMouseLeave() {
+	hoveredCodeBlockActions.value = null;
+}
+</script>
+
+<template>
+	<div
+		:class="[$style.chatMessageMarkdown, 'chat-message-markdown']"
+		:style="{
+			'--container--width': `${containerWidth}px`,
+		}"
+		@mousemove="handleMouseMove"
+		@mouseleave="handleMouseLeave"
+	>
+		<VueMarkdown
+			:key="markdown.forceReRenderKey.value"
+			:source="source"
+			:options="markdown.options"
+			:plugins="markdown.plugins.value"
+		/>
+		<Teleport
+			v-if="hoveredCodeBlockActions && hoveredCodeBlockContent"
+			:to="hoveredCodeBlockActions"
+		>
+			<CopyButton :content="hoveredCodeBlockContent" />
+		</Teleport>
+	</div>
+</template>
+
+<style lang="scss" module>
+.chatMessageMarkdown {
+	display: block;
+	box-sizing: border-box;
+
+	> *:first-child {
+		margin-top: 0;
+	}
+
+	> *:last-child {
+		margin-bottom: 0;
+	}
+
+	& * {
+		font-size: var(--font-size--sm);
+		line-height: 1.5;
+	}
+
+	p {
+		margin: var(--spacing--xs) 0;
+	}
+
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6 {
+		margin: 1em 0 0.8em;
+		line-height: var(--line-height--md);
+	}
+
+	// Override heading sizes to be smaller
+	h1 {
+		font-size: var(--font-size--xl);
+		font-weight: var(--font-weight--bold);
+	}
+
+	h2 {
+		font-size: var(--font-size--lg);
+		font-weight: var(--font-weight--bold);
+	}
+
+	h3 {
+		font-size: var(--font-size--md);
+		font-weight: var(--font-weight--bold);
+	}
+
+	h4 {
+		font-size: var(--font-size--sm);
+		font-weight: var(--font-weight--bold);
+	}
+
+	h5 {
+		font-size: var(--font-size--sm);
+		font-weight: var(--font-weight--bold);
+	}
+
+	h6 {
+		font-size: var(--font-size--sm);
+		font-weight: var(--font-weight--bold);
+	}
+
+	pre {
+		width: 100%;
+		font-family: inherit;
+		font-size: inherit;
+		margin: 0;
+		white-space: pre-wrap;
+		box-sizing: border-box;
+		padding: var(--chat--spacing);
+		background: var(--chat--message--pre--background);
+		border-radius: var(--chat--border-radius);
+		position: relative;
+
+		code:last-of-type {
+			padding-bottom: 0;
+		}
+
+		& .codeBlockActions {
+			position: sticky;
+			top: var(--spacing--sm);
+			display: flex;
+			justify-content: flex-end;
+			height: 32px;
+			pointer-events: none;
+
+			& > * {
+				pointer-events: auto;
+			}
+		}
+
+		& .codeBlockActions ~ code {
+			margin-top: -32px;
+		}
+
+		& ~ pre {
+			margin-bottom: 1em;
+		}
+	}
+
+	.tableContainer {
+		width: var(--container--width);
+		padding-bottom: 1em;
+		padding-left: calc((var(--container--width) - 100%) / 2);
+		padding-right: var(--spacing--lg);
+		margin-left: calc(-1 * (var(--container--width) - 100%) / 2);
+		overflow-x: auto;
+	}
+
+	table {
+		width: fit-content;
+		border-bottom: var(--border);
+		border-top: var(--border);
+		border-width: 2px;
+		border-color: var(--color--text--shade-1);
+	}
+
+	th,
+	td {
+		padding: 0.25em 1em 0.25em 0;
+		min-width: 12em;
+	}
+
+	th {
+		border-bottom: var(--border);
+		border-color: var(--color--text--shade-1);
+	}
+
+	ul,
+	ol {
+		li {
+			margin-bottom: 0.125rem;
+		}
+	}
+}
+</style>

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
@@ -316,7 +316,7 @@ onBeforeMount(() => {
 					</div>
 				</div>
 			</div>
-			<div v-else>
+			<template v-else>
 				<div :class="[$style.chatMessage, { [$style.errorMessage]: message.status === 'error' }]">
 					<div v-if="attachments.length > 0" :class="$style.attachments">
 						<ChatFile
@@ -349,7 +349,7 @@ onBeforeMount(() => {
 					@read-aloud="handleReadAloud"
 					@switchAlternative="handleSwitchAlternative"
 				/>
-			</div>
+			</template>
 		</div>
 	</div>
 </template>
@@ -382,12 +382,14 @@ onBeforeMount(() => {
 .content {
 	display: flex;
 	flex-direction: column;
+	align-items: stretch;
 }
 
 .attachments {
 	display: flex;
 	flex-wrap: wrap;
 	gap: var(--spacing--2xs);
+	padding-bottom: var(--spacing--2xs);
 
 	.chatMessage & {
 		margin-top: var(--spacing--xs);
@@ -397,14 +399,13 @@ onBeforeMount(() => {
 .chatMessage {
 	display: flex;
 	flex-direction: column;
-	gap: var(--spacing--2xs);
 	position: relative;
-	max-width: fit-content;
 	overflow-wrap: break-word;
 	font-size: var(--font-size--sm);
 	line-height: 1.5;
 
 	.user & {
+		max-width: fit-content;
 		padding: var(--spacing--2xs) var(--spacing--sm);
 		border-radius: var(--radius--xl);
 		background-color: var(--color--background);

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
@@ -1,12 +1,10 @@
 <script setup lang="ts">
 import ChatAgentAvatar from '@/features/ai/chatHub/components/ChatAgentAvatar.vue';
 import ChatTypingIndicator from '@/features/ai/chatHub/components/ChatTypingIndicator.vue';
-import { useChatHubMarkdownOptions } from '@/features/ai/chatHub/composables/useChatHubMarkdownOptions';
 import type { AgentIconOrEmoji, ChatMessageId, ChatModelDto } from '@n8n/api-types';
 import { N8nButton, N8nIcon, N8nIconButton, N8nInput } from '@n8n/design-system';
 import { useSpeechSynthesis } from '@vueuse/core';
-import { computed, onBeforeMount, ref, useCssModule, useTemplateRef, watch } from 'vue';
-import VueMarkdown from 'vue-markdown-render';
+import { computed, onBeforeMount, ref, useTemplateRef, watch } from 'vue';
 import type { ChatMessage } from '../chat.types';
 import ChatMessageActions from './ChatMessageActions.vue';
 import { unflattenModel, splitMarkdownIntoChunks } from '@/features/ai/chatHub/chat.utils';
@@ -16,7 +14,7 @@ import { buildChatAttachmentUrl } from '@/features/ai/chatHub/chat.api';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useDeviceSupport } from '@n8n/composables/useDeviceSupport';
 import { useI18n } from '@n8n/i18n';
-import CopyButton from '@/features/ai/chatHub/components/CopyButton.vue';
+import ChatMarkdownChunk from '@/features/ai/chatHub/components/ChatMarkdownChunk.vue';
 
 interface MergedAttachment {
 	isNew: boolean;
@@ -62,15 +60,12 @@ const chatStore = useChatStore();
 const rootStore = useRootStore();
 const { isCtrlKeyPressed } = useDeviceSupport();
 const i18n = useI18n();
-const styles = useCssModule();
 
 const editedText = ref('');
 const newFiles = ref<File[]>([]);
 const removedExistingIndices = ref<Set<number>>(new Set());
 const fileInputRef = useTemplateRef('fileInputRef');
-const hoveredCodeBlockActions = ref<HTMLElement | null>(null);
 const textareaRef = useTemplateRef('textarea');
-const markdown = useChatHubMarkdownOptions(styles.codeBlockActions, styles.tableContainer);
 const messageContent = computed(() => message.content);
 
 const messageChunks = computed(() => {
@@ -119,12 +114,6 @@ const mergedAttachments = computed(() => [
 
 const hideMessage = computed(() => {
 	return message.status === 'success' && message.content === '';
-});
-
-const hoveredCodeBlockContent = computed(() => {
-	const idx = hoveredCodeBlockActions.value?.getAttribute('data-markdown-token-idx');
-
-	return idx ? markdown.codeBlockContents.value?.get(idx) : undefined;
 });
 
 function handleEdit() {
@@ -219,19 +208,6 @@ function handleReadAloud() {
 
 function handleSwitchAlternative(messageId: ChatMessageId) {
 	emit('switchAlternative', messageId);
-}
-
-function handleMouseMove(e: MouseEvent | FocusEvent) {
-	const container =
-		e.target instanceof HTMLElement || e.target instanceof SVGElement
-			? e.target.closest('pre')?.querySelector(`.${styles.codeBlockActions}`)
-			: null;
-
-	hoveredCodeBlockActions.value = container instanceof HTMLElement ? container : null;
-}
-
-function handleMouseLeave() {
-	hoveredCodeBlockActions.value = null;
 }
 
 // Watch for isEditing prop changes to initialize edit mode
@@ -341,11 +317,7 @@ onBeforeMount(() => {
 				</div>
 			</div>
 			<div v-else>
-				<div
-					:class="[$style.chatMessage, { [$style.errorMessage]: message.status === 'error' }]"
-					@mousemove="handleMouseMove"
-					@mouseleave="handleMouseLeave"
-				>
+				<div :class="[$style.chatMessage, { [$style.errorMessage]: message.status === 'error' }]">
 					<div v-if="attachments.length > 0" :class="$style.attachments">
 						<ChatFile
 							v-for="(attachment, index) in attachments"
@@ -356,14 +328,12 @@ onBeforeMount(() => {
 						/>
 					</div>
 					<div v-if="message.type === 'human'">{{ message.content }}</div>
-					<VueMarkdown
+					<ChatMarkdownChunk
 						v-for="(chunk, index) in messageChunks"
 						v-else
-						:key="`${markdown.forceReRenderKey.value}-${index}`"
-						:class="[$style.chatMessageMarkdown, 'chat-message-markdown']"
+						:key="index"
 						:source="chunk"
-						:options="markdown.options"
-						:plugins="markdown.plugins.value"
+						:container-width="containerWidth"
 					/>
 				</div>
 				<ChatTypingIndicator v-if="message.status === 'running'" :class="$style.typingIndicator" />
@@ -381,12 +351,6 @@ onBeforeMount(() => {
 				/>
 			</div>
 		</div>
-		<Teleport
-			v-if="hoveredCodeBlockActions && hoveredCodeBlockContent"
-			:to="hoveredCodeBlockActions"
-		>
-			<CopyButton :content="hoveredCodeBlockContent" />
-		</Teleport>
 	</div>
 </template>
 
@@ -454,142 +418,6 @@ onBeforeMount(() => {
 	background-color: var(--color--danger--tint-4);
 	border: var(--border-width) var(--border-style) var(--color--danger--tint-3);
 	color: var(--color--danger);
-}
-
-.chatMessageMarkdown {
-	display: block;
-	box-sizing: border-box;
-
-	> *:first-child {
-		margin-top: 0;
-	}
-
-	> *:last-child {
-		margin-bottom: 0;
-	}
-
-	& * {
-		font-size: var(--font-size--sm);
-		line-height: 1.5;
-	}
-
-	p {
-		margin: var(--spacing--xs) 0;
-	}
-
-	h1,
-	h2,
-	h3,
-	h4,
-	h5,
-	h6 {
-		margin: 1em 0 0.8em;
-		line-height: var(--line-height--md);
-	}
-
-	// Override heading sizes to be smaller
-	h1 {
-		font-size: var(--font-size--xl);
-		font-weight: var(--font-weight--bold);
-	}
-
-	h2 {
-		font-size: var(--font-size--lg);
-		font-weight: var(--font-weight--bold);
-	}
-
-	h3 {
-		font-size: var(--font-size--md);
-		font-weight: var(--font-weight--bold);
-	}
-
-	h4 {
-		font-size: var(--font-size--sm);
-		font-weight: var(--font-weight--bold);
-	}
-
-	h5 {
-		font-size: var(--font-size--sm);
-		font-weight: var(--font-weight--bold);
-	}
-
-	h6 {
-		font-size: var(--font-size--sm);
-		font-weight: var(--font-weight--bold);
-	}
-
-	pre {
-		width: 100%;
-		font-family: inherit;
-		font-size: inherit;
-		margin: 0;
-		white-space: pre-wrap;
-		box-sizing: border-box;
-		padding: var(--chat--spacing);
-		background: var(--chat--message--pre--background);
-		border-radius: var(--chat--border-radius);
-		position: relative;
-
-		code:last-of-type {
-			padding-bottom: 0;
-		}
-
-		& .codeBlockActions {
-			position: sticky;
-			top: var(--spacing--sm);
-			display: flex;
-			justify-content: flex-end;
-			height: 32px;
-			pointer-events: none;
-
-			& > * {
-				pointer-events: auto;
-			}
-		}
-
-		& .codeBlockActions ~ code {
-			margin-top: -32px;
-		}
-
-		& ~ pre {
-			margin-bottom: 1em;
-		}
-	}
-
-	.tableContainer {
-		width: var(--container--width);
-		padding-bottom: 1em;
-		padding-left: calc((var(--container--width) - 100%) / 2);
-		padding-right: var(--spacing--lg);
-		margin-left: calc(-1 * (var(--container--width) - 100%) / 2);
-		overflow-x: auto;
-	}
-
-	table {
-		width: fit-content;
-		border-bottom: var(--border);
-		border-top: var(--border);
-		border-width: 2px;
-		border-color: var(--color--text--shade-1);
-	}
-
-	th,
-	td {
-		padding: 0.25em 1em 0.25em 0;
-		min-width: 12em;
-	}
-
-	th {
-		border-bottom: var(--border);
-		border-color: var(--color--text--shade-1);
-	}
-
-	ul,
-	ol {
-		li {
-			margin-bottom: 0.125rem;
-		}
-	}
 }
 
 .actions {


### PR DESCRIPTION
## Summary

This PR fixes the issue in ChatHub conversation UI where the AI generated response text cannot be selected until response is complete. The fix is implemented by splitting markdown into multiple chunks at double newlines (`\n\n`)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-116/bug-ai-response-text-not-selectable-while-responding


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
