### PR TITLE
chore(core): Remove gracefull error handling for http header extractor

### DIFF
--- a/packages/core/src/execution-engine/execution-context.ts
+++ b/packages/core/src/execution-engine/execution-context.ts
@@ -7,9 +7,9 @@ import {
 	type Workflow,
 } from 'n8n-workflow';
 
-import { assertExecutionDataExists } from '@/utils/assertions';
-
 import { ExecutionContextService } from './execution-context.service';
+
+import { assertExecutionDataExists } from '@/utils/assertions';
 
 /**
  * Establishes the execution context for a workflow run.
@@ -197,7 +197,8 @@ export const establishExecutionContext = async (
 			startItem.data['main'][0] = triggerItems;
 		}
 	} catch (error) {
-		// Log the error but proceed with the established context
+		// Log the error
 		Container.get(Logger).error('Failed to augment execution context with hooks.', { error });
+		throw error;
 	}
 };

--- a/packages/core/src/execution-engine/execution-context.ts
+++ b/packages/core/src/execution-engine/execution-context.ts
@@ -7,9 +7,9 @@ import {
 	type Workflow,
 } from 'n8n-workflow';
 
-import { ExecutionContextService } from './execution-context.service';
-
 import { assertExecutionDataExists } from '@/utils/assertions';
+
+import { ExecutionContextService } from './execution-context.service';
 
 /**
  * Establishes the execution context for a workflow run.


### PR DESCRIPTION
## Summary

Removes graceful error handling from the HTTP header extractor to enforce fail-fast behavior. The extractor now throws explicit, descriptive errors when configuration is invalid, tokens are missing, or parsing fails, instead of silently degrading. This improves security by ensuring tokens are always properly extracted and redacted, and makes misconfiguration issues immediately visible during development.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/IAM-139/remove-gracefull-error-handling-for-http-extractor

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
