### PR TITLE
fix(editor): Include autonamed nodes with numbers in the end

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/composables/useWorkflowResourcesLocator.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/composables/useWorkflowResourcesLocator.test.ts
@@ -46,11 +46,32 @@ describe('useWorkflowResourcesLocator', () => {
 				expectedCalledWith: 'Execute Workflow',
 			},
 			{
+				activeNodeName: 'Execute Workflow1',
+				workflowId: 'workflow-id',
+				mockedWorkflow: { name: 'Test Workflow' },
+				expectedRename: "Call 'Test Workflow'",
+				expectedCalledWith: 'Execute Workflow1',
+			},
+			{
+				activeNodeName: 'Execute Workflow2',
+				workflowId: 'workflow-id',
+				mockedWorkflow: { name: 'Another Workflow' },
+				expectedRename: "Call 'Another Workflow'",
+				expectedCalledWith: 'Execute Workflow2',
+			},
+			{
 				activeNodeName: 'Call n8n Workflow Tool',
 				workflowId: 'workflow-id',
 				mockedWorkflow: { name: 'Test Workflow' },
 				expectedRename: "Call 'Test Workflow'",
 				expectedCalledWith: 'Call n8n Workflow Tool',
+			},
+			{
+				activeNodeName: 'Call n8n Workflow Tool1',
+				workflowId: 'workflow-id',
+				mockedWorkflow: { name: 'Test Workflow' },
+				expectedRename: "Call 'Test Workflow'",
+				expectedCalledWith: 'Call n8n Workflow Tool1',
 			},
 			{
 				activeNodeName: "Call 'Old Workflow'",

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/composables/useWorkflowResourcesLocator.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/composables/useWorkflowResourcesLocator.ts
@@ -105,9 +105,10 @@ export function useWorkflowResourcesLocator(router: Router) {
 
 		const nodeName = ndvStore.activeNodeName;
 		if (
-			nodeName === 'Execute Workflow' ||
-			nodeName === 'Call n8n Workflow Tool' ||
-			(nodeName?.startsWith("Call '") && nodeName?.endsWith("'"))
+			nodeName &&
+			(/^Execute Workflow\d*$/.test(nodeName) ||
+				/^Call n8n Workflow Tool\d*$/.test(nodeName) ||
+				(nodeName.startsWith("Call '") && nodeName.endsWith("'")))
 		) {
 			const baseName = getWorkflowBaseName(workflowId);
 			if (baseName !== null) {


### PR DESCRIPTION
## Summary

Auto rename the nodes with numbers in the end, 
ex: 
[
<img width="992" height="263" alt="Screenshot 2026-01-22 at 16 19 58" src="https://github.com/user-attachments/assets/f4c28913-9362-4683-8099-0623dc8024df" />
](url)

should rename these nodes 
ex:
<img width="888" height="261" alt="Screenshot 2026-01-22 at 16 20 20" src="https://github.com/user-attachments/assets/ecc9e01d-4959-4c4c-a185-87e42bb56543" />



<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/ADO-4690/bug-sub-workflow-auto-rename-ignores-autonamed-workflows-with-number
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
