### PR TITLE
fix(core): Reconcile remote and local state for leader election

### DIFF
--- a/packages/cli/src/scaling/multi-main-setup.ee.ts
+++ b/packages/cli/src/scaling/multi-main-setup.ee.ts
@@ -3,11 +3,12 @@ import { GlobalConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
 import { MultiMainMetadata } from '@n8n/decorators';
 import { Container, Service } from '@n8n/di';
-import { InstanceSettings } from 'n8n-core';
+import { ErrorReporter, InstanceSettings } from 'n8n-core';
 
 import { Publisher } from '@/scaling/pubsub/publisher.service';
 import { RedisClientService } from '@/services/redis-client.service';
 import { TypedEmitter } from '@/typed-emitter';
+import { error } from 'node:console';
 
 type MultiMainEvents = {
 	/**
@@ -35,6 +36,7 @@ export class MultiMainSetup extends TypedEmitter<MultiMainEvents> {
 		private readonly redisClientService: RedisClientService,
 		private readonly globalConfig: GlobalConfig,
 		private readonly metadata: MultiMainMetadata,
+		private readonly errorReporter: ErrorReporter,
 	) {
 		super();
 		this.logger = this.logger.scoped(['scaling', 'multi-main-setup']);
@@ -73,6 +75,19 @@ export class MultiMainSetup extends TypedEmitter<MultiMainEvents> {
 		const { hostId } = this.instanceSettings;
 
 		if (leaderId === hostId) {
+			if (!this.instanceSettings.isLeader) {
+				// This indicates that the remote state indicated that this host is the leader, but this
+				// host believed it was a follower. See CAT-2200 for more context.
+				this.errorReporter.info(
+					`[Instance ID ${hostId}] Remote/Local leadership mismatch, marking self as leader`,
+					{
+						shouldBeLogged: true,
+						shouldReport: true,
+					},
+				);
+			}
+			this.instanceSettings.markAsLeader();
+
 			this.logger.debug(`[Instance ID ${hostId}] Leader is this instance`);
 
 			await this.publisher.setExpiration(this.leaderKey, this.leaderKeyTtl);

--- a/packages/cli/src/scaling/multi-main-setup.ee.ts
+++ b/packages/cli/src/scaling/multi-main-setup.ee.ts
@@ -8,7 +8,6 @@ import { ErrorReporter, InstanceSettings } from 'n8n-core';
 import { Publisher } from '@/scaling/pubsub/publisher.service';
 import { RedisClientService } from '@/services/redis-client.service';
 import { TypedEmitter } from '@/typed-emitter';
-import { error } from 'node:console';
 
 type MultiMainEvents = {
 	/**


### PR DESCRIPTION
## Summary

If remote state indicates that some host is the leader, but the host itself thinks it's a follower, then the host should listen to the remote and mark itself as a leader.

This could happen if e.g., the remote state accepts the write to mark the host as the leader, but then gets disconnected before sending a response. Then other nodes will accept the state but the leader itself will never process it.

This isn't bulletproof but (probably) it can't hurt.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2200

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
