### PR TITLE
feat(ai-builder): Moving feedback buttons in workflow builder chat

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.test.ts
@@ -960,7 +960,7 @@ describe('AskAssistantChat', () => {
 			const wrapper = renderWithFooterRating(messages, false);
 
 			const ratingButton = wrapper.getByTestId('rating-button');
-			await ratingButton.click();
+			ratingButton.click();
 
 			expect(wrapper.emitted('feedback')).toBeTruthy();
 			expect(wrapper.emitted('feedback')?.[0]).toEqual([{ rating: 'up' }]);

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.test.ts
@@ -830,6 +830,143 @@ describe('AskAssistantChat', () => {
 		});
 	});
 
+	describe('Footer Rating', () => {
+		const MessageRatingMock = {
+			name: 'MessageRating',
+			props: ['minimal', 'showFeedback'],
+			emits: ['feedback'],
+			template:
+				'<div data-test-id="footer-rating-component"><button data-test-id="rating-button" @click="$emit(\'feedback\', { rating: \'up\' })">Rate</button></div>',
+		};
+
+		const renderWithFooterRating = (messages: ChatUI.AssistantMessage[], streaming = false) => {
+			return render(AskAssistantChat, {
+				global: {
+					directives: { n8nHtml },
+					stubs: {
+						...Object.fromEntries(stubs.map((stub) => [stub, true])),
+						MessageWrapper: MessageWrapperStub,
+						MessageRating: MessageRatingMock,
+					},
+				},
+				props: {
+					user: { firstName: 'Test', lastName: 'User' },
+					messages,
+					streaming,
+				},
+			});
+		};
+
+		it('should show footer rating when workflow-updated message exists and not streaming', () => {
+			const messages: ChatUI.AssistantMessage[] = [
+				{
+					id: '1',
+					role: 'assistant',
+					type: 'workflow-updated',
+					codeSnippet: '{}',
+				},
+				{
+					id: '2',
+					role: 'assistant',
+					type: 'text',
+					content: 'Workflow created successfully',
+				},
+			];
+
+			const wrapper = renderWithFooterRating(messages, false);
+
+			expect(wrapper.queryByTestId('footer-rating')).toBeTruthy();
+		});
+
+		it('should NOT show footer rating when streaming', () => {
+			const messages: ChatUI.AssistantMessage[] = [
+				{
+					id: '1',
+					role: 'assistant',
+					type: 'workflow-updated',
+					codeSnippet: '{}',
+				},
+				{
+					id: '2',
+					role: 'assistant',
+					type: 'text',
+					content: 'Workflow created successfully',
+				},
+			];
+
+			const wrapper = renderWithFooterRating(messages, true);
+
+			expect(wrapper.queryByTestId('footer-rating')).toBeFalsy();
+		});
+
+		it('should NOT show footer rating when no workflow-updated message exists', () => {
+			const messages: ChatUI.AssistantMessage[] = [
+				{
+					id: '1',
+					role: 'assistant',
+					type: 'text',
+					content: 'Hello, how can I help?',
+				},
+			];
+
+			const wrapper = renderWithFooterRating(messages, false);
+
+			expect(wrapper.queryByTestId('footer-rating')).toBeFalsy();
+		});
+
+		it('should NOT show footer rating when last message is from user', () => {
+			const messages: ChatUI.AssistantMessage[] = [
+				{
+					id: '1',
+					role: 'assistant',
+					type: 'workflow-updated',
+					codeSnippet: '{}',
+				},
+				{
+					id: '2',
+					role: 'user',
+					type: 'text',
+					content: 'Can you modify this?',
+				},
+			];
+
+			const wrapper = renderWithFooterRating(messages, false);
+
+			expect(wrapper.queryByTestId('footer-rating')).toBeFalsy();
+		});
+
+		it('should NOT show footer rating when there are no messages', () => {
+			const wrapper = renderWithFooterRating([], false);
+
+			expect(wrapper.queryByTestId('footer-rating')).toBeFalsy();
+		});
+
+		it('should emit feedback event when rating is submitted', async () => {
+			const messages: ChatUI.AssistantMessage[] = [
+				{
+					id: '1',
+					role: 'assistant',
+					type: 'workflow-updated',
+					codeSnippet: '{}',
+				},
+				{
+					id: '2',
+					role: 'assistant',
+					type: 'text',
+					content: 'Workflow created',
+				},
+			];
+
+			const wrapper = renderWithFooterRating(messages, false);
+
+			const ratingButton = wrapper.getByTestId('rating-button');
+			await ratingButton.click();
+
+			expect(wrapper.emitted('feedback')).toBeTruthy();
+			expect(wrapper.emitted('feedback')?.[0]).toEqual([{ rating: 'up' }]);
+		});
+	});
+
 	describe('onSendMessage', () => {
 		it('should emit message when N8nPromptInput submits', async () => {
 			const wrapper = mount(AskAssistantChat, {

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
@@ -264,12 +264,15 @@ const showBottomInput = computed(() => {
 
 const showFooterRating = computed(() => {
 	if (props.streaming) return false;
-	if (!normalizedMessages.value.length) return false;
+	if (!props.messages?.length) return false;
 
-	// Check if there's a workflow-updated message (same condition as original rating logic)
-	const hasWorkflowUpdate = normalizedMessages.value.some((msg) => msg.type === 'workflow-updated');
+	// Check if there's a workflow-updated message in the original messages
+	// (workflow-updated is filtered out of normalizedMessages since it's not rendered visually)
+	const hasWorkflowUpdate = props.messages.some((msg) => msg.type === 'workflow-updated');
 	if (!hasWorkflowUpdate) return false;
 
+	// Check the last visible message (from normalizedMessages)
+	if (!normalizedMessages.value.length) return false;
 	const lastMsg = normalizedMessages.value[normalizedMessages.value.length - 1];
 	if (lastMsg.role === 'user') return false;
 	if (lastMsg.type === 'thinking-group') return false;
@@ -551,7 +554,7 @@ defineExpose({
 			</div>
 		</div>
 		<div v-if="showFooterRating" :class="$style.feedbackWrapper" data-test-id="footer-rating">
-			<MessageRating @feedback="onRateMessage" />
+			<MessageRating minimal @feedback="onRateMessage" />
 		</div>
 		<div v-if="$slots.inputHeader && showBottomInput" :class="$style.inputHeaderWrapper">
 			<slot name="inputHeader" />
@@ -637,6 +640,19 @@ defineExpose({
 	code {
 		text-wrap: wrap;
 	}
+
+	// Add a gradient fade at the bottom of the messages area
+	&::after {
+		content: '';
+		position: absolute;
+		bottom: 0;
+		left: 0;
+		right: var(--spacing--xs);
+		height: var(--spacing--md);
+		background: linear-gradient(to bottom, transparent 0%, var(--color--background--light-2) 100%);
+		pointer-events: none;
+		z-index: 1;
+	}
 }
 
 .placeholder {
@@ -666,7 +682,7 @@ defineExpose({
 
 .messagesContent {
 	padding: var(--spacing--xs);
-	padding-bottom: var(--spacing--xl); // Extra padding for fade area
+	padding-bottom: var(--spacing--l);
 
 	// Override p line-height from reset.scss (1.8) to use chat standard (1.5)
 	:global(p) {
@@ -731,8 +747,8 @@ defineExpose({
 
 .feedbackWrapper {
 	display: flex;
-	justify-content: center;
-	padding: var(--spacing--xs);
+	justify-content: start;
+	padding: 0 0 var(--spacing--2xs) var(--spacing--2xs);
 	border-left: var(--border);
 	border-right: var(--border);
 	background-color: var(--color--background--light-2);
@@ -758,27 +774,10 @@ defineExpose({
 	position: relative;
 	border-left: var(--border);
 	border-right: var(--border);
-
-	// Add a gradient fade from the chat to the input
-	&::before {
-		content: '';
-		position: absolute;
-		top: calc(-1 * var(--spacing--md));
-		left: 0;
-		right: var(--spacing--xs);
-		height: var(--spacing--md);
-		background: linear-gradient(to bottom, transparent 0%, var(--color--background--light-2) 100%);
-		pointer-events: none;
-		z-index: 1;
-	}
 }
 
 .inputWrapperWithHeader {
 	padding-top: 0;
-
-	&::before {
-		display: none;
-	}
 }
 
 .disabledInput {

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
@@ -747,7 +747,7 @@ defineExpose({
 .feedbackWrapper {
 	display: flex;
 	justify-content: start;
-	padding: 0 0 var(--spacing--2xs) var(--spacing--2xs);
+	padding: 0 var(--spacing--2xs) var(--spacing--2xs) var(--spacing--2xs);
 	border-left: var(--border);
 	border-right: var(--border);
 	background-color: var(--color--background--light-2);

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
@@ -263,21 +263,20 @@ const showBottomInput = computed(() => {
 });
 
 const showFooterRating = computed(() => {
-	if (props.streaming) return false;
-	if (!props.messages?.length) return false;
+	if (props.streaming || !props.messages?.length) {
+		return false;
+	}
 
 	// Check if there's a workflow-updated message in the original messages
 	// (workflow-updated is filtered out of normalizedMessages since it's not rendered visually)
+	// and check the last visible message (from normalizedMessages)
 	const hasWorkflowUpdate = props.messages.some((msg) => msg.type === 'workflow-updated');
-	if (!hasWorkflowUpdate) return false;
+	if (!hasWorkflowUpdate || !normalizedMessages.value.length) {
+		return false;
+	}
 
-	// Check the last visible message (from normalizedMessages)
-	if (!normalizedMessages.value.length) return false;
 	const lastMsg = normalizedMessages.value[normalizedMessages.value.length - 1];
-	if (lastMsg.role === 'user') return false;
-	if (lastMsg.type === 'thinking-group') return false;
-
-	return true;
+	return lastMsg.role !== 'user' && lastMsg.type !== 'thinking-group';
 });
 
 function isEndOfSessionEvent(event?: ChatUI.AssistantMessage) {

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/__snapshots__/AskAssistantChat.test.ts.snap
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/__snapshots__/AskAssistantChat.test.ts.snap
@@ -82,6 +82,7 @@ exports[`AskAssistantChat > limits maximum input length when maxCharacterLength 
       </div>
     </div>
     <!--v-if-->
+    <!--v-if-->
     <div
       class="inputWrapper"
       data-test-id="chat-input-wrapper"
@@ -339,6 +340,7 @@ exports[`AskAssistantChat > renders chat with messages correctly 1`] = `
       </div>
     </div>
     <!--v-if-->
+    <!--v-if-->
     <div
       class="inputWrapper"
       data-test-id="chat-input-wrapper"
@@ -442,6 +444,7 @@ exports[`AskAssistantChat > renders default placeholder chat correctly 1`] = `
         
       </div>
     </div>
+    <!--v-if-->
     <!--v-if-->
     <div
       class="inputWrapper"
@@ -599,6 +602,7 @@ exports[`AskAssistantChat > renders end of session chat correctly 1`] = `
       </div>
     </div>
     <!--v-if-->
+    <!--v-if-->
     <div
       class="inputWrapper disabledInput"
       data-test-id="chat-input-wrapper"
@@ -735,6 +739,7 @@ exports[`AskAssistantChat > renders error message correctly with retry button 1`
         </div>
       </div>
     </div>
+    <!--v-if-->
     <!--v-if-->
     <div
       class="inputWrapper"
@@ -873,6 +878,7 @@ exports[`AskAssistantChat > renders message with code snippet 1`] = `
       </div>
     </div>
     <!--v-if-->
+    <!--v-if-->
     <div
       class="inputWrapper"
       data-test-id="chat-input-wrapper"
@@ -1009,6 +1015,7 @@ exports[`AskAssistantChat > renders streaming chat correctly 1`] = `
         </div>
       </div>
     </div>
+    <!--v-if-->
     <!--v-if-->
     <div
       class="inputWrapper"

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/BaseMessage.vue
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/BaseMessage.vue
@@ -31,7 +31,7 @@ function onRate(rating: RatingFeedback) {
 		<slot></slot>
 		<MessageRating
 			v-if="message.showRating && !isUserMessage"
-			:style="message.ratingStyle"
+			:minimal="message.ratingStyle === 'minimal'"
 			:show-feedback="message.showFeedback"
 			@feedback="onRate"
 		/>

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/MessageRating.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/MessageRating.test.ts
@@ -190,7 +190,7 @@ describe('MessageRating', () => {
 
 		it('should focus feedback input after thumbs down in regular mode', async () => {
 			const wrapper = render(MessageRating, {
-				props: { showFeedback: true, style: 'regular' },
+				props: { showFeedback: true },
 				global: { stubs },
 			});
 

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/MessageRating.vue
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/MessageRating.vue
@@ -8,12 +8,12 @@ import N8nIconButton from '../../N8nIconButton';
 import N8nInput from '../../N8nInput';
 
 interface Props {
-	style?: 'regular' | 'minimal';
+	minimal?: boolean;
 	showFeedback?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
-	style: 'regular',
+	minimal: false,
 	showFeedback: true,
 });
 
@@ -63,9 +63,9 @@ function onCancelFeedback() {
 </script>
 
 <template>
-	<div :class="[$style.rating, $style[style]]">
+	<div :class="[$style.rating, { [$style.minimal]: minimal }]">
 		<div v-if="showRatingButtons" :class="$style.buttons">
-			<template v-if="style === 'regular'">
+			<template v-if="!minimal">
 				<N8nButton
 					type="secondary"
 					size="small"

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/MessageRating.vue
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/MessageRating.vue
@@ -147,6 +147,7 @@ function onCancelFeedback() {
 	flex-direction: column;
 	gap: var(--spacing--2xs);
 	margin-top: var(--spacing--2xs);
+	width: 100%;
 }
 
 .buttons {

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/__snapshots__/MessageRating.test.ts.snap
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/__snapshots__/MessageRating.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`MessageRating > should render correctly with default props 1`] = `
-"<div class="rating regular">
+"<div class="rating">
   <div class="buttons">
     <n8n-button-stub icon="thumbs-up" block="false" element="button" label="assistantChat.builder.thumbsUp" square="false" active="false" disabled="false" loading="false" outline="false" size="small" text="false" type="secondary" data-test-id="message-thumbs-up-button"></n8n-button-stub>
     <n8n-button-stub icon="thumbs-down" block="false" element="button" label="assistantChat.builder.thumbsDown" square="false" active="false" disabled="false" loading="false" outline="false" size="small" text="false" type="secondary" data-test-id="message-thumbs-down-button"></n8n-button-stub>

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useBuilderMessages.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useBuilderMessages.test.ts
@@ -673,7 +673,7 @@ describe('useBuilderMessages', () => {
 			expect(result.shouldClearThinking).toBe(true);
 		});
 
-		it('should only apply rating to the last text message after workflow-updated', () => {
+		it('should not apply inline rating (rating is now in footer)', () => {
 			const currentMessages: ChatUI.AssistantMessage[] = [];
 			const newMessages: ChatRequest.MessageResponse[] = [
 				{
@@ -706,24 +706,14 @@ describe('useBuilderMessages', () => {
 
 			expect(result.messages).toHaveLength(4);
 
-			// First text message should NOT have showRating (comes before workflow-updated)
-			const firstText = result.messages[0];
-			expect(firstText.showRating).toBeUndefined();
-
-			// Workflow-updated message should not have rating
-			expect(result.messages[1].type).toBe('workflow-updated');
-
-			// Middle text message should NOT have rating
-			const middleText = result.messages[2];
-			expect(middleText.showRating).toBeUndefined();
-
-			// Only the LAST text message should have showRating with minimal style
-			const lastText = result.messages[3];
-			expect(lastText.showRating).toBe(true);
-			expect(lastText.ratingStyle).toBe('minimal');
+			// No messages should have inline rating (rating is now handled in footer)
+			result.messages.forEach((message) => {
+				expect(message.showRating).toBeUndefined();
+				expect(message.ratingStyle).toBeUndefined();
+			});
 		});
 
-		it('should not apply rating to text messages without workflow-updated', () => {
+		it('should not apply inline rating regardless of workflow state (rating is in footer)', () => {
 			const currentMessages: ChatUI.AssistantMessage[] = [];
 			const newMessages: ChatRequest.MessageResponse[] = [
 				{
@@ -745,7 +735,7 @@ describe('useBuilderMessages', () => {
 			expect(textMessage.ratingStyle).toBeUndefined();
 		});
 
-		it('should not apply rating when tools are still running', () => {
+		it('should not apply inline rating when tools are running (rating is in footer)', () => {
 			const currentMessages: ChatUI.AssistantMessage[] = [];
 			const newMessages: ChatRequest.MessageResponse[] = [
 				{
@@ -779,15 +769,13 @@ describe('useBuilderMessages', () => {
 				'test-id',
 			);
 
-			// No messages should have rating while tools are running
-			const firstMessage = result.messages[0];
-			expect(firstMessage.showRating).toBeUndefined();
-
-			const lastMessage = result.messages[3];
-			expect(lastMessage.showRating).toBeUndefined();
+			// No messages should have inline rating (rating is now in footer)
+			result.messages.forEach((message) => {
+				expect(message.showRating).toBeUndefined();
+			});
 		});
 
-		it('should apply rating to the last text message after all tools complete', () => {
+		it('should not apply inline rating even after all tools complete (rating is in footer)', () => {
 			const currentMessages: ChatUI.AssistantMessage[] = [
 				{
 					id: 'msg-1',
@@ -830,13 +818,11 @@ describe('useBuilderMessages', () => {
 				'test-id',
 			);
 
-			// Only the last text message should have rating
-			const firstMessage = result.messages[0];
-			expect(firstMessage.showRating).toBeUndefined();
-
-			const lastMessage = result.messages[3];
-			expect(lastMessage.showRating).toBe(true);
-			expect(lastMessage.ratingStyle).toBe('minimal');
+			// No messages should have inline rating (rating is now in footer)
+			result.messages.forEach((message) => {
+				expect(message.showRating).toBeUndefined();
+				expect(message.ratingStyle).toBeUndefined();
+			});
 		});
 	});
 
@@ -1215,10 +1201,10 @@ describe('useBuilderMessages', () => {
 			const workflowUpdates = result.messages.filter((m) => m.type === 'workflow-updated');
 			expect(workflowUpdates).toHaveLength(2);
 
-			// Check final text message has rating
+			// Check final text message does NOT have inline rating (rating is now in footer)
 			const textMessage = result.messages.find((m) => m.type === 'text');
-			expect(textMessage?.showRating).toBe(true);
-			expect(textMessage?.ratingStyle).toBe('minimal');
+			expect(textMessage?.showRating).toBeUndefined();
+			expect(textMessage?.ratingStyle).toBeUndefined();
 
 			// Should clear thinking since tools are complete and text is present
 			expect(result.shouldClearThinking).toBe(true);
@@ -1298,8 +1284,9 @@ describe('useBuilderMessages', () => {
 			const workflowUpdate = result.messages.find((m) => m.type === 'workflow-updated');
 			expect(workflowUpdate).toBeTruthy();
 
+			// Text message should NOT have inline rating (rating is now in footer)
 			const textMessage = result.messages.find((m) => m.type === 'text');
-			expect(textMessage?.showRating).toBe(true);
+			expect(textMessage?.showRating).toBeUndefined();
 			expect(textMessage?.content).toContain('error');
 		});
 

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useBuilderMessages.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useBuilderMessages.ts
@@ -286,11 +286,9 @@ export function useBuilderMessages() {
 
 		const thinkingMessage = determineThinkingMessage(mutableMessages);
 
-		// Apply rating logic only to messages after workflow-updated
-		const messagesWithRatingLogic = applyRatingLogic(mutableMessages);
-
+		// Rating is now handled in the footer of AskAssistantChat, not per-message
 		// Remove retry from all error messages except the last one
-		const messagesWithRetryLogic = removeRetryFromOldErrorMessages(messagesWithRatingLogic);
+		const messagesWithRetryLogic = removeRetryFromOldErrorMessages(mutableMessages);
 
 		return {
 			messages: messagesWithRetryLogic,


### PR DESCRIPTION
## Summary

I've moved the feedback buttons to always appear above the prompt input box, rather than alongside the most recent message - this helps to make it obvious the user can rate the message even if there is a big todo list.

This PR addresses ticket: https://linear.app/n8n/issue/AI-1943/ux-move-the-feedback-buttons-next-to-prompt-box

When shown:
<img width="404" height="288" alt="image" src="https://github.com/user-attachments/assets/d7994127-8275-4ad2-a97f-5febef4ec1b0" />

When thumbs down clicked:
<img width="405" height="161" alt="image" src="https://github.com/user-attachments/assets/bf4df09d-6cb1-4995-8888-552025785068" />

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
