### PR TITLE
fix: Make cache check non blocking for startup

### DIFF
--- a/packages/cli/src/mfa/mfa.service.ts
+++ b/packages/cli/src/mfa/mfa.service.ts
@@ -38,7 +38,9 @@ export class MfaService {
 
 	private async loadMFASettings() {
 		const value = (await this.settingsRepository.findByKey(MFA_ENFORCE_SETTING))?.value;
-		await this.cacheService.set(MFA_CACHE_KEY, value);
+		this.cacheService.set(MFA_CACHE_KEY, value).catch((err) => {
+			this.logger.warn('Failed to cache MFA setting', { error: err });
+		});
 		return value === 'true';
 	}
 


### PR DESCRIPTION
## Summary

Makes cache checks non blocking on startup.

This was causing a large delay in the multimain test setup and caused it to go from 16 -> 30+ second start up time. 

<img width="525" height="287" alt="image" src="https://github.com/user-attachments/assets/53f70255-7225-4daa-a13c-6e53f127b268" />

We have a fallback in place to check the DB so this should be enough.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
