### PR TITLE
feat: Add telemetry for dynamic credential changes

### DIFF
--- a/packages/cli/src/credentials/__tests__/credentials.controller.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.controller.test.ts
@@ -91,6 +91,7 @@ describe('CredentialsController', () => {
 				projectType: projectOwningCredentialData.type,
 				publicApi: false,
 				uiContext: newCredentialsPayload.uiContext,
+				isDynamic: false,
 			});
 
 			expect(newApiKey).toEqual(createdCredentials);
@@ -192,6 +193,7 @@ describe('CredentialsController', () => {
 				user: ownerReq.user,
 				credentialType: existingCredential.type,
 				credentialId: existingCredential.id,
+				isDynamic: false,
 			});
 		});
 

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -194,6 +194,7 @@ export class CredentialsController {
 			projectId: project?.id,
 			projectType: project?.type,
 			uiContext: payload.uiContext,
+			isDynamic: newCredential.isResolvable ?? false,
 		});
 
 		return newCredential;
@@ -274,6 +275,7 @@ export class CredentialsController {
 			user: req.user,
 			credentialType: credential.type,
 			credentialId: credential.id,
+			isDynamic: newCredentialData.isResolvable ?? false,
 		});
 
 		const scopes = await this.credentialsService.getCredentialScopes(req.user, credential.id);

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -659,6 +659,7 @@ describe('TelemetryEventRelay', () => {
 				publicApi: false,
 				projectId: 'project123',
 				projectType: 'personal',
+				isDynamic: false,
 			};
 
 			eventService.emit('credentials-created', event);
@@ -669,6 +670,7 @@ describe('TelemetryEventRelay', () => {
 				credential_id: 'cred123',
 				project_id: 'project123',
 				project_type: 'personal',
+				is_dynamic: false,
 			});
 		});
 
@@ -711,6 +713,7 @@ describe('TelemetryEventRelay', () => {
 				},
 				credentialId: 'cred123',
 				credentialType: 'github',
+				isDynamic: true,
 			};
 
 			eventService.emit('credentials-updated', event);
@@ -719,6 +722,7 @@ describe('TelemetryEventRelay', () => {
 				user_id: 'user123',
 				credential_type: 'github',
 				credential_id: 'cred123',
+				is_dynamic: true,
 			});
 		});
 
@@ -1057,6 +1061,54 @@ describe('TelemetryEventRelay', () => {
 				workflow_edited_no_pos: false,
 				credential_edited: false,
 				ai_builder_assisted: false,
+				identity_extractor_changed: false,
+			});
+		});
+
+		it('should track resolver settings when credentialResolverId changes', async () => {
+			const event: RelayEventMap['workflow-saved'] = {
+				user: {
+					id: 'user123',
+					email: 'user@example.com',
+					firstName: 'John',
+					lastName: 'Doe',
+					role: { slug: GLOBAL_OWNER_ROLE.slug },
+				},
+				workflow: mock<IWorkflowDb>({
+					id: 'workflow123',
+					name: 'Test Workflow',
+					nodes: [],
+					settings: { credentialResolverId: 'resolver-123' },
+				}),
+				publicApi: false,
+				settingsChanged: {
+					credentialResolverId: {
+						from: null,
+						to: 'resolver-123',
+					},
+				},
+			};
+
+			eventService.emit('workflow-saved', event);
+
+			await flushPromises();
+
+			expect(telemetry.track).toHaveBeenCalledWith('User saved workflow', {
+				user_id: 'user123',
+				workflow_id: 'workflow123',
+				node_graph_string: expect.any(String),
+				notes_count_overlapping: 0,
+				notes_count_non_overlapping: 0,
+				version_cli: expect.any(String),
+				num_tags: 0,
+				public_api: false,
+				sharing_role: undefined,
+				meta: undefined,
+				workflow_edited_no_pos: false,
+				credential_edited: false,
+				ai_builder_assisted: false,
+				credential_resolver_id: 'resolver-123',
+				identity_extractor_changed: false,
 			});
 		});
 

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -1027,6 +1027,7 @@ describe('TelemetryEventRelay', () => {
 				user_id: 'user123',
 				version_cli: N8N_VERSION,
 				workflow_id: 'workflow123',
+				used_dynamic_credentials: false,
 			});
 		});
 

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -358,6 +358,7 @@ export type RelayEventMap = {
 		projectId?: string;
 		projectType?: string;
 		uiContext?: string;
+		isDynamic?: boolean;
 	};
 
 	'credentials-shared': {
@@ -373,6 +374,7 @@ export type RelayEventMap = {
 		user: UserLike;
 		credentialType: string;
 		credentialId: string;
+		isDynamic?: boolean;
 	};
 
 	'credentials-deleted': {

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -1295,7 +1295,8 @@ export class TelemetryEventRelay extends EventRelay {
 	 */
 	private hasIdentityExtractors(nodes: INode[]): boolean {
 		for (const node of nodes) {
-			if (this.extractIdentityExtractorHooks(node).length > 0) {
+			const hooks = this.extractIdentityExtractorHooks(node);
+			if (hooks.length > 0) {
 				return true;
 			}
 		}
@@ -1303,9 +1304,13 @@ export class TelemetryEventRelay extends EventRelay {
 	}
 
 	/**
-	 * Extracts identity extractor hook names from a node's parameters.
+	 * Extracts identity extractor hook configurations from a node's parameters.
+	 * Returns the full hook objects including all parameters (hookName, isAllowedToFail, etc.)
+	 * to enable detection of any configuration changes.
 	 */
-	private extractIdentityExtractorHooks(node: INode): string[] {
+	private extractIdentityExtractorHooks(
+		node: INode,
+	): Array<{ hookName: string; isAllowedToFail?: boolean; [key: string]: unknown }> {
 		const nodeParams = {
 			...(node.parameters ?? {}),
 		};
@@ -1315,9 +1320,7 @@ export class TelemetryEventRelay extends EventRelay {
 			return [];
 		}
 
-		return (
-			hookParamsResult.data.contextEstablishmentHooks?.hooks?.map((hook) => hook.hookName) ?? []
-		);
+		return hookParamsResult.data.contextEstablishmentHooks?.hooks ?? [];
 	}
 
 	// #endregion

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -9,8 +9,20 @@ import { Service } from '@n8n/di';
 import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
 import { snakeCase } from 'change-case';
 import { BinaryDataConfig, InstanceSettings } from 'n8n-core';
-import type { ExecutionStatus, INodesGraphResult, ITelemetryTrackProperties } from 'n8n-workflow';
-import { hasCredentialChanges, hasNonPositionalChanges, TelemetryHelpers } from 'n8n-workflow';
+import type {
+	ExecutionStatus,
+	INode,
+	INodesGraphResult,
+	ITelemetryTrackProperties,
+	IWorkflowDb,
+	JsonValue,
+} from 'n8n-workflow';
+import {
+	hasCredentialChanges,
+	hasNonPositionalChanges,
+	TelemetryHelpers,
+	toExecutionContextEstablishmentHookParameter,
+} from 'n8n-workflow';
 import os from 'node:os';
 import { get as pslGet } from 'psl';
 
@@ -451,6 +463,7 @@ export class TelemetryEventRelay extends EventRelay {
 		projectId,
 		projectType,
 		uiContext,
+		isDynamic,
 	}: RelayEventMap['credentials-created']) {
 		this.telemetry.track('User created credentials', {
 			user_id: user.id,
@@ -459,6 +472,7 @@ export class TelemetryEventRelay extends EventRelay {
 			project_id: projectId,
 			project_type: projectType,
 			uiContext,
+			is_dynamic: isDynamic ?? false,
 		});
 	}
 
@@ -484,11 +498,13 @@ export class TelemetryEventRelay extends EventRelay {
 		user,
 		credentialId,
 		credentialType,
+		isDynamic,
 	}: RelayEventMap['credentials-updated']) {
 		this.telemetry.track('User updated credentials', {
 			user_id: user.id,
 			credential_type: credentialType,
 			credential_id: credentialId,
+			is_dynamic: isDynamic ?? false,
 		});
 	}
 
@@ -657,6 +673,7 @@ export class TelemetryEventRelay extends EventRelay {
 		publicApi,
 		previousWorkflow,
 		aiBuilderAssisted,
+		settingsChanged,
 	}: RelayEventMap['workflow-saved']) {
 		const isCloudDeployment = this.globalConfig.deployment.type === 'cloud';
 
@@ -702,6 +719,17 @@ export class TelemetryEventRelay extends EventRelay {
 			credentialEdited = hasCredentialChanges(previousWorkflow.nodes, workflow.nodes);
 		}
 
+		let credentialResolverId: JsonValue | undefined = undefined;
+
+		if (settingsChanged?.credentialResolverId) {
+			credentialResolverId = settingsChanged.credentialResolverId.to;
+		}
+
+		const identityExtractorChanged = this.detectIdentityExtractorChanges(
+			previousWorkflow,
+			workflow,
+		);
+
 		this.telemetry.track('User saved workflow', {
 			user_id: user.id,
 			workflow_id: workflow.id,
@@ -716,6 +744,8 @@ export class TelemetryEventRelay extends EventRelay {
 			workflow_edited_no_pos: workflowEditedNoPos,
 			credential_edited: credentialEdited,
 			ai_builder_assisted: aiBuilderAssisted ?? false,
+			credential_resolver_id: credentialResolverId,
+			identity_extractor_changed: identityExtractorChanged,
 		});
 	}
 
@@ -1198,6 +1228,94 @@ export class TelemetryEventRelay extends EventRelay {
 			message_type: messageType,
 			public_api: publicApi,
 		});
+	}
+
+	/**
+	 * Detects if identity extractor (context establishment hook) parameters changed
+	 * between previous and current workflow versions.
+	 */
+	private detectIdentityExtractorChanges(
+		previousWorkflow: IWorkflowDb | undefined,
+		currentWorkflow: IWorkflowDb,
+	): boolean {
+		if (!previousWorkflow) {
+			// New workflow - check if any nodes have identity extractors
+			return this.hasIdentityExtractors(currentWorkflow.nodes);
+		}
+
+		// Create a map of nodes by name for efficient lookup
+		const previousNodesMap = new Map<string, INode>();
+		for (const node of previousWorkflow.nodes) {
+			previousNodesMap.set(node.name, node);
+		}
+
+		// Check each node in current workflow
+		for (const currentNode of currentWorkflow.nodes) {
+			const previousNode = previousNodesMap.get(currentNode.name);
+
+			if (!previousNode) {
+				// New node - check if it has identity extractors
+				if (this.hasIdentityExtractors([currentNode])) {
+					return true;
+				}
+				continue;
+			}
+
+			// Compare identity extractor parameters
+			const currentHooks = this.extractIdentityExtractorHooks(currentNode);
+			const previousHooks = this.extractIdentityExtractorHooks(previousNode);
+
+			if (JSON.stringify(currentHooks) !== JSON.stringify(previousHooks)) {
+				return true;
+			}
+		}
+
+		// Check if any nodes were removed that had identity extractors
+		const currentNodesMap = new Map<string, INode>();
+		for (const node of currentWorkflow.nodes) {
+			currentNodesMap.set(node.name, node);
+		}
+
+		for (const previousNode of previousWorkflow.nodes) {
+			if (!currentNodesMap.has(previousNode.name)) {
+				// Node was removed - check if it had identity extractors
+				if (this.hasIdentityExtractors([previousNode])) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks if any nodes have identity extractors configured.
+	 */
+	private hasIdentityExtractors(nodes: INode[]): boolean {
+		for (const node of nodes) {
+			if (this.extractIdentityExtractorHooks(node).length > 0) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Extracts identity extractor hook names from a node's parameters.
+	 */
+	private extractIdentityExtractorHooks(node: INode): string[] {
+		const nodeParams = {
+			...(node.parameters ?? {}),
+		};
+
+		const hookParamsResult = toExecutionContextEstablishmentHookParameter(nodeParams);
+		if (!hookParamsResult || hookParamsResult.error || !hookParamsResult.data) {
+			return [];
+		}
+
+		return (
+			hookParamsResult.data.contextEstablishmentHooks?.hooks?.map((hook) => hook.hookName) ?? []
+		);
 	}
 
 	// #endregion

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -4,6 +4,7 @@ import {
 	ProjectRelationRepository,
 	SharedWorkflowRepository,
 	WorkflowRepository,
+	type IWorkflowDb,
 } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
@@ -14,7 +15,6 @@ import type {
 	INode,
 	INodesGraphResult,
 	ITelemetryTrackProperties,
-	IWorkflowDb,
 	JsonValue,
 } from 'n8n-workflow';
 import {
@@ -764,6 +764,7 @@ export class TelemetryEventRelay extends EventRelay {
 			is_manual: false,
 			version_cli: N8N_VERSION,
 			success: false,
+			used_dynamic_credentials: !!runData?.data?.executionData?.runtimeData?.credentials,
 		};
 
 		if (userId) {
@@ -860,6 +861,7 @@ export class TelemetryEventRelay extends EventRelay {
 					is_managed: false,
 					eval_rows_left: null,
 					meta: JSON.stringify(workflow.meta),
+					used_dynamic_credentials: telemetryProperties.used_dynamic_credentials,
 					...TelemetryHelpers.resolveAIMetrics(workflow.nodes, this.nodeTypes),
 					...TelemetryHelpers.resolveVectorStoreMetrics(workflow.nodes, this.nodeTypes, runData),
 					...TelemetryHelpers.extractLastExecutedNodeStructuredOutputErrorInfo(

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -1311,11 +1311,7 @@ export class TelemetryEventRelay extends EventRelay {
 	private extractIdentityExtractorHooks(
 		node: INode,
 	): Array<{ hookName: string; isAllowedToFail?: boolean; [key: string]: unknown }> {
-		const nodeParams = {
-			...(node.parameters ?? {}),
-		};
-
-		const hookParamsResult = toExecutionContextEstablishmentHookParameter(nodeParams);
+		const hookParamsResult = toExecutionContextEstablishmentHookParameter(node.parameters);
 		if (!hookParamsResult || hookParamsResult.error || !hookParamsResult.data) {
 			return [];
 		}

--- a/packages/cli/src/interfaces.ts
+++ b/packages/cli/src/interfaces.ts
@@ -168,6 +168,7 @@ export interface IExecutionTrackProperties extends ITelemetryTrackProperties {
 	error_node_type?: string;
 	is_manual: boolean;
 	crashed?: boolean;
+	used_dynamic_credentials?: boolean;
 }
 
 // ----------------------------------

--- a/packages/cli/src/public-api/v1/handlers/credentials/credentials.service.ts
+++ b/packages/cli/src/public-api/v1/handlers/credentials/credentials.service.ts
@@ -96,6 +96,7 @@ export async function saveCredential(
 		projectId: project?.id,
 		projectType: project?.type,
 		publicApi: true,
+		isDynamic: credential.isResolvable ?? false,
 	});
 
 	return result;


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR adds telemetry for the following:

* When a workflow changes (create, update), tracks the resolverId, and says whether the identity extractor changed
* When a credential is created / updated, whether it was configured to be dynamic
* When an execution happens, did it use dynamic credentials

## Related Linear tickets, Github issues, and Community forum posts

IAM-74

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
