### PR TITLE
fix(editor): Update click behaviour on breadcrumb items

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nBreadcrumbs/Breadcrumbs.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nBreadcrumbs/Breadcrumbs.vue
@@ -252,17 +252,12 @@ const handleTooltipClose = () => {
 					:data-resourceid="item.id"
 					data-test-id="breadcrumbs-item"
 					data-target="folder-breadcrumb-item"
+					@click="(event: MouseEvent) => emitItemSelected(item.id, event)"
 					@mouseenter="emitItemHover(item.id)"
 					@mouseup="onItemMouseUp(item)"
 				>
-					<N8nLink
-						v-if="item.href"
-						:href="item.href"
-						theme="text"
-						@click="(event: MouseEvent) => emitItemSelected(item.id, event)"
-						>{{ item.label }}</N8nLink
-					>
-					<N8nText v-else @click="emitItemSelected(item.id)">{{ item.label }}</N8nText>
+					<N8nLink v-if="item.href" :to="item.href" theme="text">{{ item.label }}</N8nLink>
+					<N8nText v-else>{{ item.label }}</N8nText>
 				</li>
 				<li v-if="index !== items.length - 1" :class="$style.separator">
 					{{ separator }}

--- a/packages/frontend/@n8n/design-system/src/components/N8nBreadcrumbs/Breadcrumbs.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nBreadcrumbs/Breadcrumbs.vue
@@ -119,11 +119,22 @@ const onHiddenMenuVisibleChange = async (visible: boolean) => {
 	}
 };
 
-const emitItemSelected = (id: string) => {
+const emitItemSelected = (id: string, event?: MouseEvent) => {
 	const item = [...props.items, ...loadedHiddenItems.value].find((i) => i.id === id);
 	if (!item) {
 		return;
 	}
+
+	// Allow default browser behavior for modifier keys (ctrl/cmd/shift + click) or middle mouse button
+	if (event && (event.ctrlKey || event.metaKey || event.shiftKey || event.button === 1)) {
+		return;
+	}
+
+	// Prevent default navigation and emit event for custom handling
+	if (event && item.href) {
+		event.preventDefault();
+	}
+
 	emit('itemSelected', item);
 };
 
@@ -241,12 +252,17 @@ const handleTooltipClose = () => {
 					:data-resourceid="item.id"
 					data-test-id="breadcrumbs-item"
 					data-target="folder-breadcrumb-item"
-					@click.prevent="emitItemSelected(item.id)"
 					@mouseenter="emitItemHover(item.id)"
 					@mouseup="onItemMouseUp(item)"
 				>
-					<N8nLink v-if="item.href" :href="item.href" theme="text">{{ item.label }}</N8nLink>
-					<N8nText v-else>{{ item.label }}</N8nText>
+					<N8nLink
+						v-if="item.href"
+						:href="item.href"
+						theme="text"
+						@click="(event: MouseEvent) => emitItemSelected(item.id, event)"
+						>{{ item.label }}</N8nLink
+					>
+					<N8nText v-else @click="emitItemSelected(item.id)">{{ item.label }}</N8nText>
 				</li>
 				<li v-if="index !== items.length - 1" :class="$style.separator">
 					{{ separator }}

--- a/packages/frontend/@n8n/design-system/src/components/N8nBreadcrumbs/__snapshots__/BreadCrumbs.test.ts.snap
+++ b/packages/frontend/@n8n/design-system/src/components/N8nBreadcrumbs/__snapshots__/BreadCrumbs.test.ts.snap
@@ -6,11 +6,11 @@ exports[`Breadcrumbs > does not highlight last item for "highlightLastItem = fal
     <!--v-if-->
     <!--v-if-->
     <!--v-if-->
-    <li class="item" title="Folder 1" data-resourceid="1" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder1" target="_blank" class="n8n-link"><span class="text"><span class="n8n-text size-medium regular">Folder 1</span></span></a></li>
+    <li class="item" title="Folder 1" data-resourceid="1" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder1" class="n8n-link" role="link"><span class="text"><span class="n8n-text size-medium regular">Folder 1</span></span></a></li>
     <li class="separator">/</li>
-    <li class="item" title="Folder 2" data-resourceid="2" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder2" target="_blank" class="n8n-link"><span class="text"><span class="n8n-text size-medium regular">Folder 2</span></span></a></li>
+    <li class="item" title="Folder 2" data-resourceid="2" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder2" class="n8n-link" role="link"><span class="text"><span class="n8n-text size-medium regular">Folder 2</span></span></a></li>
     <li class="separator">/</li>
-    <li class="item" title="Folder 3" data-resourceid="3" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder3" target="_blank" class="n8n-link"><span class="text"><span class="n8n-text size-medium regular">Folder 3</span></span></a></li>
+    <li class="item" title="Folder 3" data-resourceid="3" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder3" class="n8n-link" role="link"><span class="text"><span class="n8n-text size-medium regular">Folder 3</span></span></a></li>
     <li class="separator">/</li>
     <li class="item" title="Current" data-resourceid="4" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><span class="n8n-text size-medium regular">Current</span></li>
     <!--v-if-->
@@ -24,11 +24,11 @@ exports[`Breadcrumbs > renders custom separator correctly 1`] = `
     <!--v-if-->
     <!--v-if-->
     <!--v-if-->
-    <li class="item" title="Folder 1" data-resourceid="1" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder1" target="_blank" class="n8n-link"><span class="text"><span class="n8n-text size-medium regular">Folder 1</span></span></a></li>
+    <li class="item" title="Folder 1" data-resourceid="1" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder1" class="n8n-link" role="link"><span class="text"><span class="n8n-text size-medium regular">Folder 1</span></span></a></li>
     <li class="separator">➮</li>
-    <li class="item" title="Folder 2" data-resourceid="2" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder2" target="_blank" class="n8n-link"><span class="text"><span class="n8n-text size-medium regular">Folder 2</span></span></a></li>
+    <li class="item" title="Folder 2" data-resourceid="2" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder2" class="n8n-link" role="link"><span class="text"><span class="n8n-text size-medium regular">Folder 2</span></span></a></li>
     <li class="separator">➮</li>
-    <li class="item" title="Folder 3" data-resourceid="3" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder3" target="_blank" class="n8n-link"><span class="text"><span class="n8n-text size-medium regular">Folder 3</span></span></a></li>
+    <li class="item" title="Folder 3" data-resourceid="3" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder3" class="n8n-link" role="link"><span class="text"><span class="n8n-text size-medium regular">Folder 3</span></span></a></li>
     <li class="separator">➮</li>
     <li class="item current" title="Current" data-resourceid="4" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><span class="n8n-text size-medium regular">Current</span></li>
     <!--v-if-->
@@ -42,11 +42,11 @@ exports[`Breadcrumbs > renders default version correctly 1`] = `
     <!--v-if-->
     <!--v-if-->
     <!--v-if-->
-    <li class="item" title="Folder 1" data-resourceid="1" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder1" target="_blank" class="n8n-link"><span class="text"><span class="n8n-text size-medium regular">Folder 1</span></span></a></li>
+    <li class="item" title="Folder 1" data-resourceid="1" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder1" class="n8n-link" role="link"><span class="text"><span class="n8n-text size-medium regular">Folder 1</span></span></a></li>
     <li class="separator">/</li>
-    <li class="item" title="Folder 2" data-resourceid="2" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder2" target="_blank" class="n8n-link"><span class="text"><span class="n8n-text size-medium regular">Folder 2</span></span></a></li>
+    <li class="item" title="Folder 2" data-resourceid="2" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder2" class="n8n-link" role="link"><span class="text"><span class="n8n-text size-medium regular">Folder 2</span></span></a></li>
     <li class="separator">/</li>
-    <li class="item" title="Folder 3" data-resourceid="3" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder3" target="_blank" class="n8n-link"><span class="text"><span class="n8n-text size-medium regular">Folder 3</span></span></a></li>
+    <li class="item" title="Folder 3" data-resourceid="3" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder3" class="n8n-link" role="link"><span class="text"><span class="n8n-text size-medium regular">Folder 3</span></span></a></li>
     <li class="separator">/</li>
     <li class="item current" title="Current" data-resourceid="4" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><span class="n8n-text size-medium regular">Current</span></li>
     <!--v-if-->
@@ -61,11 +61,11 @@ exports[`Breadcrumbs > renders slots correctly 1`] = `
     <li class="separator">/</li>
     <!--v-if-->
     <!--v-if-->
-    <li class="item" title="Folder 1" data-resourceid="1" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder1" target="_blank" class="n8n-link"><span class="text"><span class="n8n-text size-medium regular">Folder 1</span></span></a></li>
+    <li class="item" title="Folder 1" data-resourceid="1" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder1" class="n8n-link" role="link"><span class="text"><span class="n8n-text size-medium regular">Folder 1</span></span></a></li>
     <li class="separator">/</li>
-    <li class="item" title="Folder 2" data-resourceid="2" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder2" target="_blank" class="n8n-link"><span class="text"><span class="n8n-text size-medium regular">Folder 2</span></span></a></li>
+    <li class="item" title="Folder 2" data-resourceid="2" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder2" class="n8n-link" role="link"><span class="text"><span class="n8n-text size-medium regular">Folder 2</span></span></a></li>
     <li class="separator">/</li>
-    <li class="item" title="Folder 3" data-resourceid="3" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder3" target="_blank" class="n8n-link"><span class="text"><span class="n8n-text size-medium regular">Folder 3</span></span></a></li>
+    <li class="item" title="Folder 3" data-resourceid="3" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder3" class="n8n-link" role="link"><span class="text"><span class="n8n-text size-medium regular">Folder 3</span></span></a></li>
     <li class="separator">/</li>
     <li class="item current" title="Current" data-resourceid="4" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><span class="n8n-text size-medium regular">Current</span></li>
     <!--v-if-->
@@ -80,11 +80,11 @@ exports[`Breadcrumbs > renders small version correctly 1`] = `
     <!--v-if-->
     <!--v-if-->
     <!--v-if-->
-    <li class="item" title="Folder 1" data-resourceid="1" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder1" target="_blank" class="n8n-link"><span class="text"><span class="n8n-text size-medium regular">Folder 1</span></span></a></li>
+    <li class="item" title="Folder 1" data-resourceid="1" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder1" class="n8n-link" role="link"><span class="text"><span class="n8n-text size-medium regular">Folder 1</span></span></a></li>
     <li class="separator">/</li>
-    <li class="item" title="Folder 2" data-resourceid="2" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder2" target="_blank" class="n8n-link"><span class="text"><span class="n8n-text size-medium regular">Folder 2</span></span></a></li>
+    <li class="item" title="Folder 2" data-resourceid="2" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder2" class="n8n-link" role="link"><span class="text"><span class="n8n-text size-medium regular">Folder 2</span></span></a></li>
     <li class="separator">/</li>
-    <li class="item" title="Folder 3" data-resourceid="3" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder3" target="_blank" class="n8n-link"><span class="text"><span class="n8n-text size-medium regular">Folder 3</span></span></a></li>
+    <li class="item" title="Folder 3" data-resourceid="3" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><a href="/folder3" class="n8n-link" role="link"><span class="text"><span class="n8n-text size-medium regular">Folder 3</span></span></a></li>
     <li class="separator">/</li>
     <li class="item current" title="Current" data-resourceid="4" data-test-id="breadcrumbs-item" data-target="folder-breadcrumb-item"><span class="n8n-text size-medium regular">Current</span></li>
     <!--v-if-->


### PR DESCRIPTION
## Summary
Breadcrumb items were using @click.prevent on the <li> element, which unconditionally prevented all default browser behaviours.

- Removed @click.prevent from <li> element
- Moved click handler to N8nLink and N8nText components directly
- Pass MouseEvent to emitItemSelected for modifier key detection

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/ADO-4695/cmmdctrl-click-opens-in-new-tab-everywhere-but-nested-breadcrumbs
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
