### PR TITLE
ci: Add merge-release-tag-to-master job with dedicated GitHub App

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -199,7 +199,6 @@ jobs:
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
           token: ${{ steps.generate_token.outputs.token }}
 
       - name: Merge release tag to master

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -179,19 +179,45 @@ jobs:
       - name: Trigger a release note
         run: curl -u docsWorkflows:${{ secrets.N8N_WEBHOOK_DOCS_PASSWORD }} --request GET 'https://internal.users.n8n.cloud/webhook/trigger-release-note' --header 'Content-Type:application/json' --data '{"version":"${{ needs.publish-to-npm.outputs.release }}"}'
 
-  # merge-back-into-master:
-  #   name: Merge back into master
-  #   needs: [publish-to-npm, create-github-release]
-  #   if: ${{ github.event.pull_request.merged == true && !contains(github.event.pull_request.labels.*.name, 'release:patch') }}
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-  # v4.1.1
-  #         fetch-depth: 0
-  #     - run: |
-  #         git checkout --track origin/master
-  #         git config user.name "github-actions[bot]"
-  #         git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-  #         git merge --ff n8n@${{ needs.publish-to-npm.outputs.release }}
-  #         git push origin master
-  #         git push origin :${{github.event.pull_request.base.ref}}
+  merge-release-tag-to-master:
+    name: Merge release tag to master
+    needs: [publish-to-npm, create-github-release]
+    if: |
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'release:minor') &&
+      !contains(needs.publish-to-npm.outputs.release, '-rc.')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App Token
+        id: generate_token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.RELEASE_TAG_MERGE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_TAG_MERGE_PRIVATE_KEY }}
+          skip-token-revoke: false
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          token: ${{ steps.generate_token.outputs.token }}
+
+      # TODO: Update bot user ID once n8n-release-tag-merge App is created
+      # Get ID from: https://api.github.com/users/n8n-release-tag-merge[bot]
+      - name: Merge release tag to master
+        run: |
+          git config user.name "n8n-release-tag-merge[bot]"
+          git config user.email "000000000+n8n-release-tag-merge[bot]@users.noreply.github.com"
+          git fetch origin master
+          git checkout --track origin/master
+          git merge --ff-only n8n@${{ needs.publish-to-npm.outputs.release }}
+          git push origin master
+
+      - name: Notify Slack on failure
+        if: failure()
+        uses: act10ns/slack@44541246747a30eb3102d87f7a4cc5471b0ffb7d # v2.1.0
+        with:
+          status: ${{ job.status }}
+          channel: '#alerts-build'
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          message: |
+            <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}| Release tag merge to master failed for n8n@${{ needs.publish-to-npm.outputs.release }} >

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -229,7 +229,7 @@ jobs:
         uses: act10ns/slack@44541246747a30eb3102d87f7a4cc5471b0ffb7d # v2.1.0
         with:
           status: ${{ job.status }}
-          channel: '#C036AELNMV0'
+          channel: '#updates-and-product-releases'
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           message: |
             <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}| Release tag merge to master failed for n8n@${{ needs.publish-to-npm.outputs.release }} >

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -188,6 +188,8 @@ jobs:
       !contains(needs.publish-to-npm.outputs.release, '-rc.')
     runs-on: ubuntu-latest
     environment: minor-release-tag-merge
+    env:
+      VERSION: ${{ needs.publish-to-npm.outputs.release }}
     steps:
       - name: Generate GitHub App Token
         id: generate_token
@@ -204,8 +206,6 @@ jobs:
           token: ${{ steps.generate_token.outputs.token }}
 
       - name: Verify release tag exists
-        env:
-          VERSION: ${{ needs.publish-to-npm.outputs.release }}
         run: |
           if ! git ls-remote --tags origin "refs/tags/n8n@${VERSION}" | grep -q .; then
             echo "::error::Tag n8n@${VERSION} not found on remote"
@@ -213,13 +213,9 @@ jobs:
           fi
 
       - name: Fetch release tag
-        env:
-          VERSION: ${{ needs.publish-to-npm.outputs.release }}
         run: git fetch --depth=1 origin "refs/tags/n8n@${VERSION}:refs/tags/n8n@${VERSION}"
 
       - name: Merge release tag to master
-        env:
-          VERSION: ${{ needs.publish-to-npm.outputs.release }}
         run: |
           git config user.name "n8n-release-tag-merge[bot]"
           git config user.email "256767729+n8n-release-tag-merge[bot]@users.noreply.github.com"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -187,6 +187,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'release:minor') &&
       !contains(needs.publish-to-npm.outputs.release, '-rc.')
     runs-on: ubuntu-latest
+    environment: minor-release-tag-merge
     steps:
       - name: Generate GitHub App Token
         id: generate_token
@@ -201,12 +202,10 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.generate_token.outputs.token }}
 
-      # TODO: Update bot user ID once n8n-release-tag-merge App is created
-      # Get ID from: https://api.github.com/users/n8n-release-tag-merge[bot]
       - name: Merge release tag to master
         run: |
           git config user.name "n8n-release-tag-merge[bot]"
-          git config user.email "000000000+n8n-release-tag-merge[bot]@users.noreply.github.com"
+          git config user.email "256767729+n8n-release-tag-merge[bot]@users.noreply.github.com"
           git fetch origin master
           git checkout --track origin/master
           git merge --ff-only n8n@${{ needs.publish-to-npm.outputs.release }}
@@ -217,7 +216,7 @@ jobs:
         uses: act10ns/slack@44541246747a30eb3102d87f7a4cc5471b0ffb7d # v2.1.0
         with:
           status: ${{ job.status }}
-          channel: '#alerts-build'
+          channel: '#C036AELNMV0'
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           message: |
             <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}| Release tag merge to master failed for n8n@${{ needs.publish-to-npm.outputs.release }} >

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -199,16 +199,34 @@ jobs:
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          ref: master
+          fetch-depth: 1
           token: ${{ steps.generate_token.outputs.token }}
 
+      - name: Verify release tag exists
+        env:
+          VERSION: ${{ needs.publish-to-npm.outputs.release }}
+        run: |
+          if ! git ls-remote --tags origin "refs/tags/n8n@${VERSION}" | grep -q .; then
+            echo "::error::Tag n8n@${VERSION} not found on remote"
+            exit 1
+          fi
+
+      - name: Fetch release tag
+        env:
+          VERSION: ${{ needs.publish-to-npm.outputs.release }}
+        run: git fetch --depth=1 origin "refs/tags/n8n@${VERSION}:refs/tags/n8n@${VERSION}"
+
       - name: Merge release tag to master
+        env:
+          VERSION: ${{ needs.publish-to-npm.outputs.release }}
         run: |
           git config user.name "n8n-release-tag-merge[bot]"
           git config user.email "256767729+n8n-release-tag-merge[bot]@users.noreply.github.com"
-          git fetch origin master
-          git checkout --track origin/master
-          git merge --ff-only n8n@${{ needs.publish-to-npm.outputs.release }}
-          git push origin master
+          git merge --ff-only "n8n@${VERSION}"
+
+      - name: Push to master
+        run: git push origin HEAD:master
 
       - name: Notify Slack on failure
         if: failure()

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -213,7 +213,7 @@ jobs:
           fi
 
       - name: Fetch release tag
-        run: git fetch --depth=1 origin "refs/tags/n8n@${VERSION}:refs/tags/n8n@${VERSION}"
+        run: git fetch origin "refs/tags/n8n@${VERSION}:refs/tags/n8n@${VERSION}"
 
       - name: Merge release tag to master
         run: |


### PR DESCRIPTION
### Summary

  Automate merging release tags to master for minor releases using a dedicated GitHub App (`n8n-release-tag-merge`) with minimal permissions.

  **Changes:**
  - Add `merge-release-tag-to-master` job in release workflow
  - Use `actions/create-github-app-token` for secure token generation
  - Require `release:minor` label (excludes patch/major/RC releases)
  - Use `--ff-only` merge strategy for safety
  - Add pre-flight tag verification before merge
  - Use shallow fetch for efficiency
  - Add Slack notification on failure


  ### Related Linear tickets, Github issues, and Community forum posts

  https://linear.app/n8n/issue/CAT-2184


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
