### PR TITLE
ci: Add empty vex.openvex.json for 1.x branch

### DIFF
--- a/vex.openvex.json
+++ b/vex.openvex.json
@@ -1,0 +1,7 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/n8n-io/n8n/vex/1.x",
+  "author": "n8n Security",
+  "timestamp": "2026-01-23T00:00:00Z",
+  "statements": []
+}


### PR DESCRIPTION
 ### Summary

  Adds an empty OpenVEX file to the 1.x branch. The `security-trivy-scan-callable.yml` workflow references this file for vulnerability exception handling, but it only exists on master. This causes
  Trivy scans to fail on 1.x releases.

  The file contains an empty `statements` array, meaning no vulnerabilities are currently suppressed on this branch.

  ### Related Linear tickets, Github issues, and Community forum posts

  https://linear.app/n8n/issue/CAT-2207


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
