### PR TITLE
fix(editor): Show publish actions on read-only instances

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/MainHeader/ActionsDropdownMenu.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/ActionsDropdownMenu.vue
@@ -40,11 +40,11 @@ import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useWorkflowHelpers } from '@/app/composables/useWorkflowHelpers';
 import { useWorkflowActivate } from '@/app/composables/useWorkflowActivate';
 import { getWorkflowId } from '@/app/components/MainHeader/utils';
+import { useCollaborationStore } from '@/features/collaboration/collaboration/collaboration.store';
 
 const props = defineProps<{
 	workflowPermissions: PermissionsRecord['workflow'];
 	isNewWorkflow: boolean;
-	readOnly?: boolean;
 	isArchived: IWorkflowDb['isArchived'];
 	id: IWorkflowDb['id'];
 	name: IWorkflowDb['name'];
@@ -59,6 +59,7 @@ const locale = useI18n();
 const route = useRoute();
 const projectsStore = useProjectsStore();
 const sourceControlStore = useSourceControlStore();
+const collaborationStore = useCollaborationStore();
 const workflowsStore = useWorkflowsStore();
 const uiStore = useUIStore();
 const $style = useCssModule();
@@ -82,6 +83,8 @@ const onExecutionsTab = computed(() => {
 		VIEWS.EXECUTION_PREVIEW,
 	].includes((route.name as string) || '');
 });
+
+const collaborationReadOnly = computed(() => collaborationStore.shouldBeReadOnly);
 
 const activeVersion = computed(() => workflowsStore.workflow.activeVersion);
 
@@ -140,7 +143,11 @@ const workflowMenuItems = computed<Array<ActionDropdownItem<WORKFLOW_MENU_ACTION
 		});
 	}
 
-	if (!props.readOnly && !props.isArchived) {
+	if (
+		!collaborationReadOnly.value &&
+		!props.isArchived &&
+		!sourceControlStore.preferences.branchReadOnly
+	) {
 		actions.push({
 			id: WORKFLOW_MENU_ACTIONS.RENAME,
 			label: locale.baseText('generic.rename'),
@@ -149,7 +156,10 @@ const workflowMenuItems = computed<Array<ActionDropdownItem<WORKFLOW_MENU_ACTION
 	}
 
 	if (
-		(props.workflowPermissions.update === true && !props.readOnly && !props.isArchived) ||
+		(props.workflowPermissions.update === true &&
+			!collaborationReadOnly.value &&
+			!props.isArchived &&
+			!sourceControlStore.preferences.branchReadOnly) ||
 		props.isNewWorkflow
 	) {
 		actions.unshift({
@@ -195,7 +205,7 @@ const workflowMenuItems = computed<Array<ActionDropdownItem<WORKFLOW_MENU_ACTION
 		disabled: !onWorkflowPage.value || props.isNewWorkflow,
 	});
 
-	if (activeVersion.value && props.workflowPermissions.publish && !props.readOnly) {
+	if (activeVersion.value && props.workflowPermissions.publish && !collaborationReadOnly.value) {
 		actions.push({
 			id: WORKFLOW_MENU_ACTIONS.UNPUBLISH,
 			label: locale.baseText('menuActions.unpublish'),
@@ -203,7 +213,12 @@ const workflowMenuItems = computed<Array<ActionDropdownItem<WORKFLOW_MENU_ACTION
 		});
 	}
 
-	if ((props.workflowPermissions.delete === true && !props.readOnly) || props.isNewWorkflow) {
+	if (
+		(props.workflowPermissions.delete === true &&
+			!collaborationReadOnly.value &&
+			!sourceControlStore.preferences.branchReadOnly) ||
+		props.isNewWorkflow
+	) {
 		if (props.isArchived) {
 			actions.push({
 				id: WORKFLOW_MENU_ACTIONS.UNARCHIVE,

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.test.ts
@@ -72,7 +72,6 @@ const renderComponent = createComponentRenderer(MainHeader, {
 		stubs: {
 			WorkflowDetails: {
 				props: [
-					'readOnly',
 					'id',
 					'tags',
 					'name',
@@ -83,8 +82,7 @@ const renderComponent = createComponentRenderer(MainHeader, {
 					'isArchived',
 					'description',
 				],
-				template:
-					'<div data-test-id="workflow-details-stub" :data-read-only="readOnly ? \'true\' : \'false\'"></div>',
+				template: '<div data-test-id="workflow-details-stub"></div>',
 			},
 			GithubButton: { template: '<div></div>' },
 			TabBar: { template: '<div></div>' },
@@ -123,38 +121,10 @@ describe('MainHeader', () => {
 		vi.spyOn(collaborationStore, 'shouldBeReadOnly', 'get').mockReturnValue(false);
 	});
 
-	describe('readOnly computed', () => {
-		it('should be false when there are no read-only conditions', () => {
-			sourceControlStore.preferences.branchReadOnly = false;
-			vi.spyOn(collaborationStore, 'shouldBeReadOnly', 'get').mockReturnValue(false);
-			workflowsStore.workflow.isArchived = false;
+	it('should render WorkflowDetails component', () => {
+		const { getByTestId } = renderComponent();
 
-			const { getByTestId } = renderComponent();
-
-			const workflowDetails = getByTestId('workflow-details-stub');
-			expect(workflowDetails).toHaveAttribute('data-read-only', 'false');
-		});
-
-		it('should be true when branch is read-only', () => {
-			sourceControlStore.preferences.branchReadOnly = true;
-			vi.spyOn(collaborationStore, 'shouldBeReadOnly', 'get').mockReturnValue(false);
-			workflowsStore.workflow.isArchived = false;
-
-			const { getByTestId } = renderComponent();
-
-			const workflowDetails = getByTestId('workflow-details-stub');
-			expect(workflowDetails).toHaveAttribute('data-read-only', 'true');
-		});
-
-		it('should be true when collaboration requires read-only', () => {
-			sourceControlStore.preferences.branchReadOnly = false;
-			vi.spyOn(collaborationStore, 'shouldBeReadOnly', 'get').mockReturnValue(true);
-			workflowsStore.workflow.isArchived = false;
-
-			const { getByTestId } = renderComponent();
-
-			const workflowDetails = getByTestId('workflow-details-stub');
-			expect(workflowDetails).toHaveAttribute('data-read-only', 'true');
-		});
+		const workflowDetails = getByTestId('workflow-details-stub');
+		expect(workflowDetails).toBeInTheDocument();
 	});
 });

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.vue
@@ -13,10 +13,8 @@ import {
 import { useExecutionsStore } from '@/features/execution/executions/executions.store';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
-import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
-import { useCollaborationStore } from '@/features/collaboration/collaboration/collaboration.store';
 import { computed, onBeforeMount, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import type { RouteLocation, RouteLocationRaw } from 'vue-router';
 import { useRoute, useRouter } from 'vue-router';
@@ -34,8 +32,6 @@ const pushConnection = usePushConnection({ router });
 const toast = useToast();
 const ndvStore = useNDVStore();
 const uiStore = useUIStore();
-const sourceControlStore = useSourceControlStore();
-const collaborationStore = useCollaborationStore();
 const workflowsStore = useWorkflowsStore();
 const executionsStore = useExecutionsStore();
 const settingsStore = useSettingsStore();
@@ -75,9 +71,6 @@ const workflow = computed(() => workflowsStore.workflow);
 const workflowId = computed(() => String(route.params.name || workflowsStore.workflowId));
 const onWorkflowPage = computed(() => !!(route.meta.nodeView || route.meta.keepWorkflowAlive));
 
-const readOnly = computed(
-	() => sourceControlStore.preferences.branchReadOnly || collaborationStore.shouldBeReadOnly,
-);
 const isEnterprise = computed(
 	() => settingsStore.isQueueModeEnabled && settingsStore.isWorkerViewAvailable,
 );
@@ -289,7 +282,6 @@ async function onWorkflowDeactivated() {
 					:meta="workflow.meta"
 					:scopes="workflow.scopes"
 					:active="workflow.active"
-					:read-only="readOnly"
 					:current-folder="parentFolderForBreadcrumbs"
 					:is-archived="workflow.isArchived"
 					:description="workflow.description"

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.test.ts
@@ -240,6 +240,24 @@ describe('WorkflowDetails', () => {
 			expect(queryByTestId('workflow-menu-item-import-from-file')).not.toBeInTheDocument();
 		});
 
+		it('should not have workflow duplicate and import when collaboration is read-only', async () => {
+			collaborationStore.shouldBeReadOnly = true;
+
+			const { getByTestId, queryByTestId } = renderComponent({
+				props: {
+					...workflow,
+					isArchived: false,
+					scopes: ['workflow:read'],
+				},
+			});
+
+			await userEvent.click(getByTestId('workflow-menu'));
+
+			expect(queryByTestId('workflow-menu-item-duplicate')).not.toBeInTheDocument();
+			expect(queryByTestId('workflow-menu-item-import-from-url')).not.toBeInTheDocument();
+			expect(queryByTestId('workflow-menu-item-import-from-file')).not.toBeInTheDocument();
+		});
+
 		it('should have workflow duplicate and import options if permission update is true', async () => {
 			const { getByTestId, queryByTestId } = renderComponent({
 				props: {
@@ -320,6 +338,23 @@ describe('WorkflowDetails', () => {
 			expect(queryByTestId('workflow-menu-item-archive')).not.toBeInTheDocument();
 		});
 
+		it("should not have 'Archive' option on non archived workflow when collaboration is read-only", async () => {
+			collaborationStore.shouldBeReadOnly = true;
+
+			const { getByTestId, queryByTestId } = renderComponent({
+				props: {
+					...workflow,
+					isArchived: false,
+					scopes: ['workflow:delete'],
+				},
+			});
+
+			await userEvent.click(getByTestId('workflow-menu'));
+			expect(queryByTestId('workflow-menu-item-delete')).not.toBeInTheDocument();
+			expect(queryByTestId('workflow-menu-item-unarchive')).not.toBeInTheDocument();
+			expect(queryByTestId('workflow-menu-item-archive')).not.toBeInTheDocument();
+		});
+
 		it("should not have 'Archive' option on non archived workflow without permission", async () => {
 			const { getByTestId, queryByTestId } = renderComponent({
 				props: {
@@ -354,6 +389,23 @@ describe('WorkflowDetails', () => {
 
 		it("should not have 'Unarchive' or 'Delete' options on archived workflow when branch is read-only", async () => {
 			sourceControlStore.preferences.branchReadOnly = true;
+
+			const { getByTestId, queryByTestId } = renderComponent({
+				props: {
+					...workflow,
+					isArchived: true,
+					scopes: ['workflow:delete'],
+				},
+			});
+
+			await userEvent.click(getByTestId('workflow-menu'));
+			expect(queryByTestId('workflow-menu-item-archive')).not.toBeInTheDocument();
+			expect(queryByTestId('workflow-menu-item-delete')).not.toBeInTheDocument();
+			expect(queryByTestId('workflow-menu-item-unarchive')).not.toBeInTheDocument();
+		});
+
+		it("should not have 'Unarchive' or 'Delete' options on archived workflow when collaboration is read-only", async () => {
+			collaborationStore.shouldBeReadOnly = true;
 
 			const { getByTestId, queryByTestId } = renderComponent({
 				props: {

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.test.ts
@@ -262,8 +262,9 @@ describe('WorkflowHeaderDraftPublishActions', () => {
 			expect(getByTestId('workflow-open-publish-modal-button')).toBeDisabled();
 		});
 
-		it('should be hidden when user has only workflow:publish permission', () => {
-			const { queryByTestId } = renderComponent({
+		it('should be visible when user has only workflow:publish permission', () => {
+			setupEnabledPublishButton();
+			const { getByTestId } = renderComponent({
 				props: {
 					...defaultWorkflowProps,
 					workflowPermissions: {
@@ -274,7 +275,8 @@ describe('WorkflowHeaderDraftPublishActions', () => {
 				},
 			});
 
-			expect(queryByTestId('workflow-open-publish-modal-button')).not.toBeInTheDocument();
+			expect(getByTestId('workflow-open-publish-modal-button')).toBeInTheDocument();
+			expect(getByTestId('workflow-open-publish-modal-button')).not.toBeDisabled();
 		});
 
 		it('should be visible when user has both workflow:update and workflow:publish permissions', () => {

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
@@ -21,9 +21,9 @@ import {
 import { nodeViewEventBus } from '@/app/event-bus';
 import CollaborationPane from '@/features/collaboration/collaboration/components/CollaborationPane.vue';
 import TimeAgo from '../TimeAgo.vue';
+import { useCollaborationStore } from '@/features/collaboration/collaboration/collaboration.store';
 
 const props = defineProps<{
-	readOnly?: boolean;
 	id: IWorkflowDb['id'];
 	tags: IWorkflowDb['tags'];
 	name: IWorkflowDb['name'];
@@ -36,22 +36,9 @@ const props = defineProps<{
 
 const actionsMenuRef = useTemplateRef<InstanceType<typeof ActionsDropdownMenu>>('actionsMenu');
 
-const readOnlyForPublish = computed(() => {
-	if (props.isNewWorkflow) return props.readOnly;
-	return (
-		props.readOnly ||
-		props.isArchived ||
-		!props.workflowPermissions.update ||
-		!props.workflowPermissions.publish
-	);
-});
-
-const shouldHidePublishButton = computed(() => {
-	return props.readOnly || props.isArchived || !props.workflowPermissions.update;
-});
-
 const uiStore = useUIStore();
 const workflowsStore = useWorkflowsStore();
+const collaborationStore = useCollaborationStore();
 const i18n = useI18n();
 const router = useRouter();
 
@@ -102,6 +89,20 @@ const workflowPublishState = computed((): WorkflowPublishState => {
 	return hasChanges ? 'published-with-changes' : 'published-no-changes';
 });
 
+const collaborationReadOnly = computed(() => collaborationStore.shouldBeReadOnly);
+const hasUpdatePermission = computed(() => props.workflowPermissions.update);
+const hasPublishPermission = computed(() => props.workflowPermissions.publish);
+
+const shouldHidePublishButton = computed(() => {
+	if (props.isNewWorkflow) return false;
+	return props.isArchived || !hasUpdatePermission.value;
+});
+
+const shouldDisablePublishButton = computed(() => {
+	if (props.isNewWorkflow) return true;
+	return collaborationReadOnly.value || !hasPublishPermission.value;
+});
+
 /**
  * Cancel autosave if scheduled or wait for it to finish if in progress
  * Save immediately if autosave idle or cancelled
@@ -149,7 +150,7 @@ const onPublishButtonClick = async () => {
 
 const publishButtonConfig = computed(() => {
 	// Handle permission-denied state first
-	if (!props.workflowPermissions.publish) {
+	if (!hasPublishPermission.value) {
 		const defaultConfigForNoPermission = {
 			text: i18n.baseText('workflows.publish'),
 			enabled: false,
@@ -308,7 +309,7 @@ defineExpose({
 				</template>
 				<N8nButton
 					:loading="autoSaveForPublish"
-					:disabled="!publishButtonConfig.enabled || readOnlyForPublish"
+					:disabled="!publishButtonConfig.enabled || shouldDisablePublishButton"
 					type="secondary"
 					data-test-id="workflow-open-publish-modal-button"
 					@click="onPublishButtonClick"
@@ -341,7 +342,6 @@ defineExpose({
 			ref="actionsMenu"
 			:workflow-permissions="workflowPermissions"
 			:is-new-workflow="isNewWorkflow"
-			:read-only="props.readOnly"
 			:is-archived="isArchived"
 			:name="name"
 			:tags="tags"

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
@@ -95,7 +95,7 @@ const hasPublishPermission = computed(() => props.workflowPermissions.publish);
 
 const shouldHidePublishButton = computed(() => {
 	if (props.isNewWorkflow) return false;
-	return props.isArchived || !hasUpdatePermission.value;
+	return props.isArchived || (!hasUpdatePermission.value && !hasPublishPermission.value);
 });
 
 const shouldDisablePublishButton = computed(() => {


### PR DESCRIPTION
## Summary

There was a bug with not showing publish actions (publish button & unpublish action) for read-only instances. This PR fixes that and refactors the read-only props to reduce confusion.

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-4703](https://linear.app/n8n/issue/ADO-4703/bug-publish-button-is-hidden-on-read-only-instances)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
