### PR TITLE
feat(core): Add placeholders for external secret provider connections

### DIFF
--- a/packages/cli/src/modules/external-secrets.ee/external-secrets.module.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets.module.ts
@@ -7,6 +7,11 @@ export class ExternalSecretsModule implements ModuleInterface {
 	async init() {
 		await import('./external-secrets.controller.ee');
 
+		await import('./secrets-providers-types.controller.ee');
+		await import('./secrets-providers-connections.controller.ee');
+		await import('./secrets-providers-autocomplete.controller.ee');
+		await import('./secrets-providers-project.controller.ee');
+
 		const { ExternalSecretsManager } = await import('./external-secrets-manager.ee');
 		const { ExternalSecretsProxy } = await import('n8n-core');
 

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-autocomplete.controller.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-autocomplete.controller.ee.ts
@@ -25,7 +25,7 @@ export class SecretProvidersAutocompleteController {
 	}
 
 	@Get('/secrets/global')
-	@GlobalScope('externalSecretsProvider:read')
+	@GlobalScope('externalSecret:list')
 	async listGlobalSecrets() {
 		this.logger.debug('Listing global secrets');
 		//TODO implement

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-autocomplete.controller.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-autocomplete.controller.ee.ts
@@ -1,6 +1,5 @@
 import { Logger } from '@n8n/backend-common';
-import { Get, RestController, Middleware } from '@n8n/decorators';
-import { GlobalScope, ProjectScope } from '@n8n/decorators/src';
+import { GlobalScope, ProjectScope, Get, RestController, Middleware } from '@n8n/decorators';
 import { Request, Response, NextFunction } from 'express';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-autocomplete.controller.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-autocomplete.controller.ee.ts
@@ -1,5 +1,5 @@
 import { Logger } from '@n8n/backend-common';
-import { GlobalScope, ProjectScope, Get, RestController, Middleware } from '@n8n/decorators';
+import { GlobalScope, Get, RestController, Middleware } from '@n8n/decorators';
 import { Request, Response, NextFunction } from 'express';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-autocomplete.controller.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-autocomplete.controller.ee.ts
@@ -7,7 +7,7 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ExternalSecretsConfig } from './external-secrets.config';
 
 @RestController('/secret-providers/autocomplete')
-export class SecretProvidersController {
+export class SecretProvidersAutocompleteController {
 	// Returns also the secret keys for a specific project
 	constructor(
 		private readonly config: ExternalSecretsConfig,

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-autocomplete.controller.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-autocomplete.controller.ee.ts
@@ -33,7 +33,7 @@ export class SecretProvidersAutocompleteController {
 	}
 
 	@Get('/secrets/project/:projectId')
-	@ProjectScope('externalSecretsProvider:read')
+	@GlobalScope('externalSecret:list')
 	async listProjectSecrets() {
 		this.logger.debug('Listing secrets for project');
 		//TODO implement

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-autocomplete.controller.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-autocomplete.controller.ee.ts
@@ -1,0 +1,43 @@
+import { Logger } from '@n8n/backend-common';
+import { Get, RestController, Middleware } from '@n8n/decorators';
+import { GlobalScope, ProjectScope } from '@n8n/decorators/src';
+import { Request, Response, NextFunction } from 'express';
+
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+
+import { ExternalSecretsConfig } from './external-secrets.config';
+
+@RestController('/secret-providers/autocomplete')
+export class SecretProvidersController {
+	// Returns also the secret keys for a specific project
+	constructor(
+		private readonly config: ExternalSecretsConfig,
+		private readonly logger: Logger,
+	) {
+		this.logger = this.logger.scoped('external-secrets');
+	}
+
+	@Middleware()
+	checkFeatureFlag(_req: Request, _res: Response, next: NextFunction) {
+		if (!this.config.externalSecretsForProjects) {
+			throw new BadRequestError('External secrets for projects feature is not enabled');
+		}
+		next();
+	}
+
+	@Get('/secrets/global')
+	@GlobalScope('externalSecretsProvider:read')
+	async listGlobalSecrets() {
+		this.logger.debug('Listing global secrets');
+		//TODO implement
+		return await Promise.resolve();
+	}
+
+	@Get('/secrets/project/:projectId')
+	@ProjectScope('externalSecretsProvider:read')
+	async listProjectSecrets() {
+		this.logger.debug('Listing secrets for project');
+		//TODO implement
+		return await Promise.resolve();
+	}
+}

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.controller.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.controller.ee.ts
@@ -41,7 +41,7 @@ export class SecretProvidersController {
 	}
 
 	@Patch('/:providerKey')
-	@GlobalScope('externalSecretsProvider:create')
+	@GlobalScope('externalSecretsProvider:update')
 	async updateConnectionValues() {
 		this.logger.debug('Update specific fields only (update projectIds, or connection settings)');
 		//TODO implement

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.controller.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.controller.ee.ts
@@ -1,6 +1,14 @@
 import { Logger } from '@n8n/backend-common';
-import { Delete, Post, Get, Patch, RestController, GlobalScope, Middleware } from '@n8n/decorators';
-import { Put } from '@n8n/decorators/src';
+import {
+	Delete,
+	Put,
+	Post,
+	Get,
+	Patch,
+	RestController,
+	GlobalScope,
+	Middleware,
+} from '@n8n/decorators';
 import { Request, Response, NextFunction } from 'express';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.controller.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.controller.ee.ts
@@ -16,7 +16,7 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ExternalSecretsConfig } from './external-secrets.config';
 
 @RestController('/secret-providers/connections')
-export class SecretProvidersController {
+export class SecretProvidersConnectionsController {
 	constructor(
 		private readonly config: ExternalSecretsConfig,
 		private readonly logger: Logger,

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.controller.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.controller.ee.ts
@@ -1,0 +1,96 @@
+import { Logger } from '@n8n/backend-common';
+import { Delete, Post, Get, Patch, RestController, GlobalScope, Middleware } from '@n8n/decorators';
+import { Put } from '@n8n/decorators/src';
+import { Request, Response, NextFunction } from 'express';
+
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+
+import { ExternalSecretsConfig } from './external-secrets.config';
+
+@RestController('/secret-providers/connections')
+export class SecretProvidersController {
+	constructor(
+		private readonly config: ExternalSecretsConfig,
+		private readonly logger: Logger,
+	) {
+		this.logger = this.logger.scoped('external-secrets');
+	}
+
+	@Middleware()
+	checkFeatureFlag(_req: Request, _res: Response, next: NextFunction) {
+		if (!this.config.externalSecretsForProjects) {
+			throw new BadRequestError('External secrets for projects feature is not enabled');
+		}
+		next();
+	}
+
+	@Put('/:providerKey')
+	@GlobalScope('externalSecretsProvider:create')
+	async createConnection() {
+		this.logger.debug('Create a new connection');
+		//TODO implement
+		return await Promise.resolve();
+	}
+
+	@Patch('/:providerKey')
+	@GlobalScope('externalSecretsProvider:create')
+	async updateConnectionValues() {
+		this.logger.debug('Update specific fields only (update projectIds, or connection settings)');
+		//TODO implement
+		return await Promise.resolve();
+	}
+
+	@Delete('/:providerKey')
+	@GlobalScope('externalSecretsProvider:delete')
+	async deleteConnection() {
+		this.logger.debug('Delete a connection');
+		//TODO implement
+		return await Promise.resolve();
+	}
+
+	@Get('/')
+	@GlobalScope('externalSecretsProvider:read')
+	async listConnections() {
+		this.logger.debug('list all secret provider connections');
+		//TODO implement
+		return await Promise.resolve();
+	}
+
+	@Get('/:providerKey')
+	@GlobalScope('externalSecretsProvider:read')
+	async getConnection() {
+		this.logger.debug('Read specific provider connection properties');
+		//TODO implement
+		return await Promise.resolve();
+	}
+
+	@Post('/:providerKey/test')
+	@GlobalScope('externalSecretsProvider:read')
+	testConnection() {
+		this.logger.debug('Testing provider connnection');
+		//TODO implement
+		return;
+	}
+
+	@Post('/:providerKey/connect')
+	@GlobalScope('externalSecretsProvider:update')
+	toggleConnectionStatus() {
+		this.logger.debug('Toggling connection status');
+		//TODO implement
+		return;
+	}
+
+	@Post('/:providerKey/reload')
+	@GlobalScope('externalSecretsProvider:sync')
+	reloadConnectionSecrets() {
+		this.logger.debug('Reloading secrets for secret provider connection');
+		return;
+	}
+
+	@Post('/:providerKey/share')
+	@GlobalScope('externalSecretsProvider:update')
+	shareConnection() {
+		this.logger.debug('Share connection with other projects');
+		return;
+	}
+}

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-project.controller.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-project.controller.ee.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@n8n/backend-common';
-import { Get, RestController, Middleware } from '@n8n/decorators';
-import { ProjectScope } from '@n8n/decorators/src';
+import { Get, ProjectScope, RestController, Middleware } from '@n8n/decorators';
+import {} from '@n8n/decorators/src';
 import { Request, Response, NextFunction } from 'express';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-project.controller.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-project.controller.ee.ts
@@ -1,0 +1,34 @@
+import { Logger } from '@n8n/backend-common';
+import { Get, RestController, Middleware } from '@n8n/decorators';
+import { ProjectScope } from '@n8n/decorators/src';
+import { Request, Response, NextFunction } from 'express';
+
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+
+import { ExternalSecretsConfig } from './external-secrets.config';
+
+@RestController('/secret-providers/projects')
+export class SecretProvidersController {
+	constructor(
+		private readonly config: ExternalSecretsConfig,
+		private readonly logger: Logger,
+	) {
+		this.logger = this.logger.scoped('external-secrets');
+	}
+
+	@Middleware()
+	checkFeatureFlag(_req: Request, _res: Response, next: NextFunction) {
+		if (!this.config.externalSecretsForProjects) {
+			throw new BadRequestError('External secrets for projects feature is not enabled');
+		}
+		next();
+	}
+
+	@Get('/:projectId/connections')
+	@ProjectScope('externalSecretsProvider:list')
+	async listConnectionsForAProject() {
+		this.logger.debug('List all connections within a project');
+		//TODO implement
+		return await Promise.resolve([]);
+	}
+}

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-project.controller.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-project.controller.ee.ts
@@ -8,7 +8,7 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ExternalSecretsConfig } from './external-secrets.config';
 
 @RestController('/secret-providers/projects')
-export class SecretProvidersController {
+export class SecretProvidersProjectController {
 	constructor(
 		private readonly config: ExternalSecretsConfig,
 		private readonly logger: Logger,

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-types.controller.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-types.controller.ee.ts
@@ -1,0 +1,42 @@
+import { Logger } from '@n8n/backend-common';
+import { Get, RestController, Middleware } from '@n8n/decorators';
+import { GlobalScope } from '@n8n/decorators/src';
+import { Request, Response, NextFunction } from 'express';
+
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+
+import { ExternalSecretsConfig } from './external-secrets.config';
+
+@RestController('/secret-providers/types')
+export class SecretProvidersController {
+	constructor(
+		private readonly config: ExternalSecretsConfig,
+		private readonly logger: Logger,
+	) {
+		this.logger = this.logger.scoped('external-secrets');
+	}
+
+	@Middleware()
+	checkFeatureFlag(_req: Request, _res: Response, next: NextFunction) {
+		if (!this.config.externalSecretsForProjects) {
+			throw new BadRequestError('External secrets for projects feature is not enabled');
+		}
+		next();
+	}
+
+	@Get('/')
+	@GlobalScope('externalSecretsProvider:list')
+	async listSecretProviderTypes() {
+		this.logger.debug('List provider connection types');
+		//TODO implement
+		return await Promise.resolve([]);
+	}
+
+	@Get('/:type')
+	@GlobalScope('externalSecretsProvider:list')
+	async getSecretProviderType() {
+		this.logger.debug('Get provider connection type');
+		//TODO implement
+		return await Promise.resolve({});
+	}
+}

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-types.controller.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-types.controller.ee.ts
@@ -1,6 +1,5 @@
 import { Logger } from '@n8n/backend-common';
-import { Get, RestController, Middleware } from '@n8n/decorators';
-import { GlobalScope } from '@n8n/decorators/src';
+import { Get, GlobalScope, RestController, Middleware } from '@n8n/decorators';
 import { Request, Response, NextFunction } from 'express';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-types.controller.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-types.controller.ee.ts
@@ -7,7 +7,7 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ExternalSecretsConfig } from './external-secrets.config';
 
 @RestController('/secret-providers/types')
-export class SecretProvidersController {
+export class SecretProvidersTypesController {
 	constructor(
 		private readonly config: ExternalSecretsConfig,
 		private readonly logger: Logger,


### PR DESCRIPTION
## Summary
Adds controller endpoints for external secret provider credentials. To enable parallel working

## Related Linear tickets, Github issues, and Community forum posts
Closes LIGO-140

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
