### PR TITLE
fix(AI Agent Node): Clarify error message for empty prompt values in `define` mode

### DIFF
--- a/packages/@n8n/nodes-langchain/utils/helpers.ts
+++ b/packages/@n8n/nodes-langchain/utils/helpers.ts
@@ -95,10 +95,17 @@ export function getPromptInputByType(options: {
 	}
 
 	if (input === undefined) {
-		const key = promptType === 'auto' ? 'chatInput' : 'guardrailsInput';
-		throw new NodeOperationError(ctx.getNode(), 'No prompt specified', {
-			description: `Expected to find the prompt in an input field called '${key}' (this is what the ${promptType === 'auto' ? 'chat trigger node' : 'guardrails node'} node outputs). To use something else, change the 'Prompt' parameter`,
-		});
+		if (promptType === 'auto' || promptType === 'guardrails') {
+			const key = promptType === 'auto' ? 'chatInput' : 'guardrailsInput';
+			throw new NodeOperationError(ctx.getNode(), 'No prompt specified', {
+				description: `Expected to find the prompt in an input field called '${key}' (this is what the ${promptType === 'auto' ? 'chat trigger node' : 'guardrails node'} node outputs). To use something else, change the 'Prompt' parameter`,
+			});
+		} else {
+			throw new NodeOperationError(ctx.getNode(), 'No prompt specified', {
+				description:
+					'The prompt field is empty or the expression used could not be resolved. Please check the configured prompt value.',
+			});
+		}
 	}
 
 	return input;


### PR DESCRIPTION
 ## Summary

  When using an AI Agent with `promptType: define` (user-defined prompt), if the prompt value was empty or the expression couldn't be resolved, the
  error message incorrectly referenced a non-existent `guardrails` node and `guardrailsInput` field. This was confusing because the workflow didn't
  contain any guardrails node.

  The fix adds a proper condition check:
  - For `auto` or `guardrails` prompt types: keeps the existing specific error messages
  - For `define` mode: shows a clearer message: "The prompt field is empty or the expression used could not be resolved. Please check the configured
  prompt value."

  This particularly affected workflows using Anthropic as the parent agent LLM with sub-agents as tools.

  ## Related Linear tickets, Github issues, and Community forum posts

  https://linear.app/n8n/issue/AI-1957/bug-misleading-guardrails-error-in-sub-agent-workflow



## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
