### PR TITLE
chore: Merge n8n@1.123.16 tag into 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.123.16](https://github.com/n8n-io/n8n/compare/n8n@1.123.15...n8n@1.123.16) (2026-01-16)
+
+
+
 ## [1.123.15](https://github.com/n8n-io/n8n/compare/n8n@1.123.14...n8n@1.123.15) (2026-01-15)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-monorepo",
-  "version": "1.123.15",
+  "version": "1.123.16",
   "private": true,
   "engines": {
     "node": ">=22.16",

--- a/packages/@n8n/ai-workflow-builder.ee/package.json
+++ b/packages/@n8n/ai-workflow-builder.ee/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@n8n/ai-workflow-builder",
-  "version": "0.33.6",
+  "version": "0.33.7",
   "scripts": {
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",

--- a/packages/@n8n/api-types/package.json
+++ b/packages/@n8n/api-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@n8n/api-types",
-  "version": "0.57.5",
+  "version": "0.57.6",
   "scripts": {
     "clean": "rimraf dist .turbo",
     "dev": "pnpm watch",

--- a/packages/@n8n/backend-common/package.json
+++ b/packages/@n8n/backend-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@n8n/backend-common",
-  "version": "0.33.7",
+  "version": "0.33.8",
   "scripts": {
     "clean": "rimraf dist .turbo",
     "dev": "pnpm watch",

--- a/packages/@n8n/backend-test-utils/package.json
+++ b/packages/@n8n/backend-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@n8n/backend-test-utils",
-  "version": "0.26.7",
+  "version": "0.26.8",
   "scripts": {
     "clean": "rimraf dist .turbo",
     "dev": "pnpm watch",

--- a/packages/@n8n/db/package.json
+++ b/packages/@n8n/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@n8n/db",
-  "version": "0.34.10",
+  "version": "0.34.11",
   "scripts": {
     "clean": "rimraf dist .turbo",
     "dev": "pnpm watch",

--- a/packages/@n8n/decorators/package.json
+++ b/packages/@n8n/decorators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@n8n/decorators",
-  "version": "0.33.6",
+  "version": "0.33.7",
   "scripts": {
     "clean": "rimraf dist .turbo",
     "dev": "pnpm watch",

--- a/packages/@n8n/nodes-langchain/package.json
+++ b/packages/@n8n/nodes-langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@n8n/n8n-nodes-langchain",
-  "version": "1.122.10",
+  "version": "1.122.11",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/@n8n/task-runner/package.json
+++ b/packages/@n8n/task-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@n8n/task-runner",
-  "version": "1.59.9",
+  "version": "1.59.10",
   "scripts": {
     "clean": "rimraf dist .turbo",
     "start": "node dist/start.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n",
-  "version": "1.123.15",
+  "version": "1.123.16",
   "description": "n8n Workflow Automation Tool",
   "main": "dist/index",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-core",
-  "version": "1.122.9",
+  "version": "1.122.10",
   "description": "Core functionality of n8n",
   "main": "dist/index",
   "types": "dist/index.d.ts",

--- a/packages/frontend/@n8n/i18n/package.json
+++ b/packages/frontend/@n8n/i18n/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@n8n/i18n",
   "type": "module",
-  "version": "1.27.5",
+  "version": "1.27.6",
   "files": [
     "dist"
   ],

--- a/packages/frontend/@n8n/rest-api-client/package.json
+++ b/packages/frontend/@n8n/rest-api-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@n8n/rest-api-client",
   "type": "module",
-  "version": "1.26.5",
+  "version": "1.26.6",
   "files": [
     "dist"
   ],

--- a/packages/frontend/@n8n/stores/package.json
+++ b/packages/frontend/@n8n/stores/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@n8n/stores",
   "type": "module",
-  "version": "1.30.5",
+  "version": "1.30.6",
   "files": [
     "dist"
   ],

--- a/packages/frontend/editor-ui/package.json
+++ b/packages/frontend/editor-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-editor-ui",
-  "version": "1.123.6",
+  "version": "1.123.7",
   "description": "Workflow Editor UI for n8n",
   "main": "index.js",
   "type": "module",

--- a/packages/node-dev/package.json
+++ b/packages/node-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-node-dev",
-  "version": "1.121.7",
+  "version": "1.121.8",
   "description": "CLI to simplify n8n credentials/node development",
   "main": "dist/src/index",
   "types": "dist/src/index.d.ts",

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-base",
-  "version": "1.121.9",
+  "version": "1.121.10",
   "description": "Base nodes of n8n",
   "main": "index.js",
   "scripts": {

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-workflow",
-  "version": "1.120.5",
+  "version": "1.120.6",
   "description": "Workflow base code of n8n",
   "types": "dist/esm/index.d.ts",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
Cherry-picks version bump from 1.123.16 release so the next release will be 1.123.17.