### PR TITLE
chore(core): Adopt UI/UX for user identifier and fix parsing for hook definitions

### DIFF
--- a/packages/cli/src/load-nodes-and-credentials.ts
+++ b/packages/cli/src/load-nodes-and-credentials.ts
@@ -353,9 +353,10 @@ export class LoadNodesAndCredentials {
 		// Each hook becomes a separate item that can be added multiple times
 		const allHookValues: INodeProperties[] = [
 			{
-				displayName: 'Hook',
+				displayName: 'User Identifier',
 				name: 'hookName',
 				type: 'options',
+				noDataExpression: true,
 				options: hooks.map((hook) => {
 					const displayName = hook.hookDescription.displayName ?? hook.hookDescription.name;
 					return {
@@ -367,7 +368,8 @@ export class LoadNodesAndCredentials {
 				// No default - force user to explicitly select a hook
 				// This ensures hookName is always serialized in the workflow JSON
 				default: '',
-				description: 'Select which context establishment hook to use',
+				description:
+					'Configure how n8n extracts the identity token of the user triggering a webhook. It is used to run each execution with the correct user.',
 				required: true,
 			},
 		];
@@ -403,13 +405,14 @@ export class LoadNodesAndCredentials {
 
 		// Create the main context establishment hooks property as a fixedCollection
 		const contextHooksProperty: INodeProperties = {
-			displayName: 'Context Establishment Hooks',
+			displayName: 'Identify user for dynamic credentials',
 			name: 'contextEstablishmentHooks',
 			type: 'fixedCollection',
-			placeholder: 'Add Hook',
+			placeholder: 'Add User Identifier',
 			default: {},
 			typeOptions: {
 				multipleValues: true,
+				hideEmptyMessage: true,
 			},
 			options: [
 				{
@@ -419,21 +422,26 @@ export class LoadNodesAndCredentials {
 				},
 			],
 			description:
-				'Add and configure context establishment hooks to extract data from trigger items. <a href="https://docs.n8n.io/integrations/builtin/core-nodes/hooks/" target="_blank">Learn more</a>',
+				'Configure how n8n extracts the identity token of the user triggering a webhook. It is used to run each execution with the correct user.',
 		};
 
 		// Create a notice that always appears after the hooks collection
 		const contextHooksNotice: INodeProperties = {
 			displayName:
-				'Context establishment hooks allow you to extract data from trigger items to use in subsequent nodes. <a href="https://docs.n8n.io/integrations/builtin/core-nodes/hooks/" target="_blank">Learn more</a>',
+				'Configure how n8n extracts the identity token of the user triggering a webhook. It is used to run each execution with the correct user.',
 			name: 'contextHooksNotice',
 			type: 'notice',
 			default: '',
 		};
 
-		node.properties.push(executionsHooksVersion);
-		node.properties.push(contextHooksProperty);
-		node.properties.push(contextHooksNotice);
+		let index = node.properties.findIndex((p) => p.name === 'options');
+		if (index === -1) {
+			index = node.properties.length;
+		}
+
+		node.properties.splice(index, 0, contextHooksNotice);
+		node.properties.splice(index, 0, contextHooksProperty);
+		node.properties.splice(index, 0, executionsHooksVersion);
 	};
 
 	/**

--- a/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/http-header-extractor.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/http-header-extractor.ts
@@ -83,12 +83,14 @@ export class HttpHeaderExtractor implements IContextEstablishmentHook {
 				displayName: 'Header Name',
 				type: 'string',
 				default: 'authorization',
+				noDataExpression: true,
 				description: 'The name of the HTTP header to extract the value from.',
 			},
 			{
 				name: 'headerValue',
 				displayName: 'Header Value Pattern',
 				type: 'string',
+				noDataExpression: true,
 				default: '[Bb][Ee][Aa][Rr][Ee][Rr]\\s+(.+)',
 				description:
 					'A regular expression pattern to extract the identity from the header value. Use a capturing group to specify the identity part.',

--- a/packages/core/src/execution-engine/__tests__/execution-context.service.test.ts
+++ b/packages/core/src/execution-engine/__tests__/execution-context.service.test.ts
@@ -262,6 +262,56 @@ describe('ExecutionContextService', () => {
 			expect(mockRegistry.getHookByName).not.toHaveBeenCalled();
 		});
 
+		it('should handle node with contextEstablishmentHooks but undefined hooks array', async () => {
+			// Temporarily use real parsing function
+			const realModule = jest.requireActual('n8n-workflow');
+			toExecutionContextEstablishmentHookParameter.mockImplementationOnce(
+				realModule.toExecutionContextEstablishmentHookParameter,
+			);
+
+			// Node parameters with executionsHooksVersion but no hooks array
+			const startItem: IExecuteData = {
+				node: {
+					name: 'Webhook',
+					parameters: {
+						executionsHooksVersion: 1,
+						contextEstablishmentHooks: {
+							// hooks array is undefined - should default to []
+						},
+					},
+				} as unknown as INode,
+				data: { main: [[{ json: {} }]] },
+				source: { main: [{ previousNode: 'test' }] },
+			};
+
+			const context: IExecutionContext = {
+				version: 1,
+				establishedAt: Date.now(),
+				source: 'manual',
+			};
+
+			// Mock workflow.getNode to return null (service handles this gracefully)
+			mockWorkflow.getNode = jest.fn().mockReturnValue(null);
+
+			const result = await service.augmentExecutionContextWithHooks(
+				mockWorkflow,
+				startItem,
+				context,
+			);
+
+			// Should return original context unchanged
+			expect(result).toEqual({
+				context,
+				triggerItems: startItem.data.main[0],
+			});
+
+			// No hooks should be called since array defaults to empty
+			expect(mockRegistry.getHookByName).not.toHaveBeenCalled();
+
+			// No warning should be logged (valid schema with optional hooks)
+			expect(mockLogger.warn).not.toHaveBeenCalled();
+		});
+
 		it('should execute hooks sequentially and merge context updates', async () => {
 			const triggerItems: INodeExecutionData[] = [{ json: { data: 'value' } }];
 			const hookConfig = {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterLegacy.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterLegacy.vue
@@ -79,6 +79,7 @@ const getPropertyPath = (name: string, index?: number): string => {
 };
 
 const multipleValues = computed(() => !!props.parameter.typeOptions?.multipleValues);
+const hideEmptyMessage = computed(() => !props.parameter.typeOptions?.hideEmptyMessage);
 const sortable = computed(() => !!props.parameter.typeOptions?.sortable);
 
 const getPlaceholderText = computed(() => {
@@ -429,7 +430,7 @@ function getItemKey(_item: INodeParameters, index: number) {
 		@keydown.stop
 	>
 		<div v-if="getProperties.length === 0" :class="$style.noItemsExist">
-			<N8nText size="small">{{
+			<N8nText v-if="hideEmptyMessage" size="small">{{
 				locale.baseText('fixedCollectionParameter.currentlyNoItemsExist')
 			}}</N8nText>
 		</div>

--- a/packages/workflow/src/execution-context-establishment-hooks.ts
+++ b/packages/workflow/src/execution-context-establishment-hooks.ts
@@ -3,14 +3,17 @@ import z from 'zod/v4';
 const ExecutionContextEstablishmentHookParameterSchemaV1 = z.object({
 	executionsHooksVersion: z.literal(1),
 	contextEstablishmentHooks: z.object({
-		hooks: z.array(
-			z
-				.object({
-					hookName: z.string(),
-					isAllowedToFail: z.boolean().optional().default(false),
-				})
-				.loose(),
-		),
+		hooks: z
+			.array(
+				z
+					.object({
+						hookName: z.string(),
+						isAllowedToFail: z.boolean().optional().default(false),
+					})
+					.loose(),
+			)
+			.optional()
+			.default([]),
 	}),
 });
 


### PR DESCRIPTION
## Summary

Small adoptions to UI/UX for user identifier and fix parsing for establishment hooks.

<img width="616" height="881" alt="image" src="https://github.com/user-attachments/assets/7737ec64-a13c-4846-8be2-e1c2c9325dcf" />
<img width="616" height="881" alt="image" src="https://github.com/user-attachments/assets/ad51fc3b-c660-4336-8a0e-bfe45b48a88b" />


## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/IAM-110/update-ui-and-copy-for-configuring-identity-extract-in-webhook
closes https://linear.app/n8n/issue/IAM-141/fix-hook-options-parsing-failure-when-hooks-are-not-configured

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
