### PR TITLE
feat(core): Add $tool.name and $tool.parameters expressions

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/ToolExecutor/ToolExecutor.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/ToolExecutor/ToolExecutor.node.ts
@@ -153,8 +153,7 @@ export class ToolExecutor implements INodeType {
 										nodeName: node,
 										input: {
 											tool: toolName,
-											// stringify parameters so that they can be accessed with $fromAI method
-											toolParameters: JSON.stringify(toolInput.toolParameters),
+											toolParameters: toolInput.toolParameters as IDataObject,
 											...hitlInput,
 										},
 										type: 'ai_tool',

--- a/packages/@n8n/nodes-langchain/nodes/ToolExecutor/ToolExecutor.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/ToolExecutor/ToolExecutor.node.ts
@@ -154,7 +154,7 @@ export class ToolExecutor implements INodeType {
 										input: {
 											tool: toolName,
 											// stringify parameters so that they can be accessed with $fromAI method
-											toolParameters: JSON.stringify(toolInput),
+											toolParameters: JSON.stringify(toolInput.toolParameters),
 											...hitlInput,
 										},
 										type: 'ai_tool',

--- a/packages/@n8n/nodes-langchain/nodes/ToolExecutor/test/ToolExecutor.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/ToolExecutor/test/ToolExecutor.node.test.ts
@@ -345,7 +345,7 @@ describe('ToolExecutor Node', () => {
 			expect(result.actions[0].actionType).toBe('ExecutionNodeAction');
 			expect(result.actions[0].input).toMatchObject({
 				tool: 'gated_tool',
-				toolParameters: JSON.stringify({ param: 'value' }),
+				toolParameters: { param: 'value' },
 				approval: 'pending',
 			});
 		});

--- a/packages/@n8n/nodes-langchain/nodes/ToolExecutor/test/ToolExecutor.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/ToolExecutor/test/ToolExecutor.node.test.ts
@@ -291,7 +291,7 @@ describe('ToolExecutor Node', () => {
 		it('should handle gated tool in toolkit and return engine request', async () => {
 			const mockHitlMetadata = {
 				tool: 'gated_tool',
-				toolInput: { param: 'value' },
+				toolInput: { toolParameters: { param: 'value' } },
 			};
 
 			mockHasGatedToolNodeName.mockReturnValue(true);
@@ -345,6 +345,7 @@ describe('ToolExecutor Node', () => {
 			expect(result.actions[0].actionType).toBe('ExecutionNodeAction');
 			expect(result.actions[0].input).toMatchObject({
 				tool: 'gated_tool',
+				toolParameters: JSON.stringify({ param: 'value' }),
 				approval: 'pending',
 			});
 		});

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/createEngineRequests.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/createEngineRequests.ts
@@ -227,8 +227,7 @@ export function createEngineRequests(
 					// omit hitlParameters, because they are destructured into the input instead
 					...omit(input, 'hitlParameters'),
 					...(input.hitlParameters as IDataObject),
-					// stringify parameters so that they can be accessed with $fromAI method
-					toolParameters: JSON.stringify(input.toolParameters),
+					toolParameters: input.toolParameters,
 				};
 			}
 

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/createEngineRequests.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/createEngineRequests.test.ts
@@ -401,7 +401,7 @@ describe('createEngineRequests', () => {
 
 			expect(result).toHaveLength(1);
 			expect(result[0].input).toEqual({
-				toolParameters: '{"param1":"value1"}',
+				toolParameters: { param1: 'value1' },
 				hitlParam1: 'hitlValue1',
 				hitlParam2: 'hitlValue2',
 			});
@@ -461,7 +461,7 @@ describe('createEngineRequests', () => {
 
 			expect(result).toHaveLength(1);
 			expect(result[0].input).toEqual({
-				toolParameters: '{"param1":"value1"}',
+				toolParameters: { param1: 'value1' },
 				tool: 'gated_toolkit_tool',
 				hitlParam1: 'hitlValue1',
 			});
@@ -506,7 +506,7 @@ describe('createEngineRequests', () => {
 			});
 			// Input should remain the same when hitlParameters is missing
 			expect(result[0].input).toEqual({
-				toolParameters: '{"param1":"value1"}',
+				toolParameters: { param1: 'value1' },
 			});
 		});
 

--- a/packages/cli/src/tool-generation/__tests__/hitl-tools.test.ts
+++ b/packages/cli/src/tool-generation/__tests__/hitl-tools.test.ts
@@ -296,7 +296,7 @@ describe('hitl-tools', () => {
 			);
 			expect(messageProp).toBeDefined();
 			expect(messageProp?.type).toBe('string');
-			expect(messageProp?.default).toBe('=The agent wants to call {{ $tool }}');
+			expect(messageProp?.default).toBe('=The agent wants to call {{ $tool.name }}');
 		});
 
 		it('should replace original message property with HITL message', () => {
@@ -318,7 +318,7 @@ describe('hitl-tools', () => {
 			);
 			// Should only have one message property (our HITL one, not the original)
 			expect(messageProps).toHaveLength(1);
-			expect(messageProps[0].default).toBe('=The agent wants to call {{ $tool }}');
+			expect(messageProps[0].default).toBe('=The agent wants to call {{ $tool.name }}');
 		});
 
 		it('should set codex categories correctly for HITL', () => {

--- a/packages/cli/src/tool-generation/hitl-tools.ts
+++ b/packages/cli/src/tool-generation/hitl-tools.ts
@@ -88,11 +88,11 @@ function filterHitlToolProperties(
 		displayName: 'Message',
 		name: 'message',
 		type: 'string',
-		default: '=The agent wants to call {{ $tool }}',
+		default: '=The agent wants to call {{ $tool.name }}',
 		required: true,
 		typeOptions: { rows: 3 },
 		description:
-			'Message to send for approval. Use expressions to include tool details: {{ $tool }}, {{ $json.toolCallId }}, {{ $json.toolParameters }}',
+			'Message to send for approval. Use expressions to include tool details: {{ $tool.parameters }}, {{ $json.toolCallId }}',
 	});
 
 	for (const prop of properties) {

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -555,7 +555,7 @@
 	"codeNodeEditor.completer.$prevNode.runIndex": "The run of the previous node that generated the current input. \n\nAlways uses the current node's first input connector if there is more than one (e.g. in the 'Merge' node). ",
 	"codeNodeEditor.completer.$runIndex": "The index of the current run of the current node execution. Starts at 0.",
 	"codeNodeEditor.completer.$nodeVersion": "The version of the current node (as displayed at the bottom of the nodes's settings pane)",
-	"codeNodeEditor.completer.$tool": "The name of the tool that is currently being executed. Only available in HITL nodes",
+	"codeNodeEditor.completer.$tool": "The name and parameters of the tool that is currently being executed. Only available in HITL nodes",
 	"codeNodeEditor.completer.$today": "A DateTime representing midnight at the start of the current day. \n\nUses the instance's time zone (unless overridden in the workflow's settings).",
 	"codeNodeEditor.completer.$vars": "The <a target=\"_blank\"  href=\"https://docs.n8n.io/code/variables/\">variables</a> available to the workflow",
 	"codeNodeEditor.completer.$vars.varName.global": "Global variable defined for this n8n instance. All variables evaluate to strings.",

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
@@ -9,12 +9,14 @@ import { useWorkflowsEEStore } from '@/app/stores/workflows.ee.store';
 import { useTagsStore } from '@/features/shared/tags/tags.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import {
+	createMockNodeTypes,
 	createTestExpressionLocalResolveContext,
 	createTestNode,
 	createTestTaskData,
 	createTestWorkflow,
 	createTestWorkflowExecutionResponse,
 	createTestWorkflowObject,
+	mockLoadedNodeType,
 } from '@/__tests__/mocks';
 import {
 	CHAT_TRIGGER_NODE_TYPE,
@@ -25,7 +27,7 @@ import {
 import type { AssignmentCollectionValue, IConnections } from 'n8n-workflow';
 import * as apiWebhooks from '@n8n/rest-api-client/api/webhooks';
 import { mockedStore } from '@/__tests__/utils';
-import { SLACK_TRIGGER_NODE_TYPE } from '../constants';
+import { SLACK_TRIGGER_NODE_TYPE, SET_NODE_TYPE } from '../constants';
 import {
 	injectWorkflowState,
 	useWorkflowState,
@@ -1166,6 +1168,102 @@ describe(resolveParameter, () => {
 				f0: { foo: 777 },
 				f1: { foo: 777 },
 			});
+		});
+
+		it('should include $tool in additionalKeys for tool node types', async () => {
+			const toolNodeType = 'n8n-nodes-base.someTool';
+			const toolNodeTypes = createMockNodeTypes({
+				[toolNodeType]: mockLoadedNodeType(toolNodeType),
+			});
+
+			const result = await resolveParameter(
+				{
+					toolName: '={{ $tool.name }}',
+					toolParams: '={{ $tool.parameters }}',
+				},
+				{
+					localResolve: true,
+					workflow: createTestWorkflowObject({
+						nodes: [createTestNode({ name: 'toolNode', type: toolNodeType })],
+						nodeTypes: toolNodeTypes,
+					}),
+					execution: null,
+					nodeName: 'toolNode',
+					additionalKeys: {},
+				},
+			);
+
+			expect(result?.toolName).toBeDefined();
+			expect(result?.toolParams).toBeDefined();
+		});
+
+		it('should not include $tool in additionalKeys for non-tool node types', async () => {
+			const result = await resolveParameter(
+				{
+					toolCheck: '={{ $tool }}',
+				},
+				{
+					localResolve: true,
+					workflow: createTestWorkflowObject({
+						nodes: [createTestNode({ name: 'regularNode', type: SET_NODE_TYPE })],
+					}),
+					execution: null,
+					nodeName: 'regularNode',
+					additionalKeys: {},
+				},
+			);
+
+			expect(result?.toolCheck).toBeUndefined();
+		});
+
+		it('should resolve $tool.name expression for tool nodes', async () => {
+			const toolNodeType = 'n8n-nodes-base.hitlTool';
+			const toolNodeTypes = createMockNodeTypes({
+				[toolNodeType]: mockLoadedNodeType(toolNodeType),
+			});
+
+			const result = await resolveParameter(
+				{
+					message: '={{ "The agent wants to call " + $tool.name }}',
+				},
+				{
+					localResolve: true,
+					workflow: createTestWorkflowObject({
+						nodes: [createTestNode({ name: 'hitlTool', type: toolNodeType })],
+						nodeTypes: toolNodeTypes,
+					}),
+					execution: null,
+					nodeName: 'hitlTool',
+					additionalKeys: {},
+				},
+			);
+
+			expect(result?.message).toContain('The agent wants to call');
+		});
+
+		it('should resolve $tool.parameters expression for tool nodes', async () => {
+			const toolNodeType = 'n8n-nodes-base.customTool';
+			const toolNodeTypes = createMockNodeTypes({
+				[toolNodeType]: mockLoadedNodeType(toolNodeType),
+			});
+
+			const result = await resolveParameter(
+				{
+					params: '={{ $tool.parameters }}',
+				},
+				{
+					localResolve: true,
+					workflow: createTestWorkflowObject({
+						nodes: [createTestNode({ name: 'someTool', type: toolNodeType })],
+						nodeTypes: toolNodeTypes,
+					}),
+					execution: null,
+					nodeName: 'someTool',
+					additionalKeys: {},
+				},
+			);
+
+			expect(result?.params).toBeDefined();
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
@@ -1170,8 +1170,8 @@ describe(resolveParameter, () => {
 			});
 		});
 
-		it('should include $tool in additionalKeys for tool node types', async () => {
-			const toolNodeType = 'n8n-nodes-base.someTool';
+		it('should include $tool in additionalKeys for hitl tool node types', async () => {
+			const toolNodeType = 'n8n-nodes-base.someHitlTool';
 			const toolNodeTypes = createMockNodeTypes({
 				[toolNodeType]: mockLoadedNodeType(toolNodeType),
 			});
@@ -1217,7 +1217,7 @@ describe(resolveParameter, () => {
 		});
 
 		it('should resolve $tool.name expression for tool nodes', async () => {
-			const toolNodeType = 'n8n-nodes-base.hitlTool';
+			const toolNodeType = 'n8n-nodes-base.someHitlTool';
 			const toolNodeTypes = createMockNodeTypes({
 				[toolNodeType]: mockLoadedNodeType(toolNodeType),
 			});
@@ -1241,8 +1241,8 @@ describe(resolveParameter, () => {
 			expect(result?.message).toContain('The agent wants to call');
 		});
 
-		it('should resolve $tool.parameters expression for tool nodes', async () => {
-			const toolNodeType = 'n8n-nodes-base.customTool';
+		it('should resolve $tool.parameters expression for hitl tool nodes', async () => {
+			const toolNodeType = 'n8n-nodes-base.someHitlTool';
 			const toolNodeTypes = createMockNodeTypes({
 				[toolNodeType]: mockLoadedNodeType(toolNodeType),
 			});

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
@@ -22,7 +22,7 @@ import {
 	CHAT_TRIGGER_NODE_TYPE,
 	createEmptyRunExecutionData,
 	FORM_TRIGGER_NODE_TYPE,
-	isToolType,
+	isHitlToolType,
 	NodeConnectionTypes,
 	NodeHelpers,
 	WEBHOOK_NODE_TYPE,
@@ -125,7 +125,7 @@ function resolveParameterImpl<T = IDataObject>(
 			resumeFormUrl: PLACEHOLDER_FILLED_AT_EXECUTION_TIME,
 		},
 		$vars: envVars,
-		$tool: isToolType(activeNode?.type)
+		$tool: isHitlToolType(activeNode?.type)
 			? {
 					name: PLACEHOLDER_FILLED_AT_EXECUTION_TIME,
 					parameters: PLACEHOLDER_FILLED_AT_EXECUTION_TIME,

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
@@ -125,7 +125,12 @@ function resolveParameterImpl<T = IDataObject>(
 			resumeFormUrl: PLACEHOLDER_FILLED_AT_EXECUTION_TIME,
 		},
 		$vars: envVars,
-		$tool: isToolType(activeNode?.type) ? PLACEHOLDER_FILLED_AT_EXECUTION_TIME : undefined,
+		$tool: isToolType(activeNode?.type)
+			? {
+					name: PLACEHOLDER_FILLED_AT_EXECUTION_TIME,
+					parameters: PLACEHOLDER_FILLED_AT_EXECUTION_TIME,
+				}
+			: undefined,
 
 		// deprecated
 		$executionId: PLACEHOLDER_FILLED_AT_EXECUTION_TIME,

--- a/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/completions/constants.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/completions/constants.ts
@@ -387,7 +387,7 @@ export const ROOT_DOLLAR_COMPLETIONS: Completion[] = [
 		section: METADATA_SECTION,
 		info: createInfoBoxRenderer({
 			name: '$tool',
-			returnType: 'string',
+			returnType: 'Object',
 			description: i18n.baseText('codeNodeEditor.completer.$tool'),
 		}),
 	},

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2414,7 +2414,7 @@ export type IWorkflowDataProxyAdditionalKeys = IDataObject & {
 	$vars?: IDataObject;
 	$secrets?: IDataObject;
 	$pageCount?: number;
-
+	$tool?: { name: string; parameters: string };
 	/** @deprecated */
 	$executionId?: string;
 	/** @deprecated */

--- a/packages/workflow/src/workflow-data-proxy.ts
+++ b/packages/workflow/src/workflow-data-proxy.ts
@@ -1079,8 +1079,8 @@ export class WorkflowDataProxy {
 		const handleTool = (throwOnError = true) => {
 			const fallbackValue = that.additionalKeys?.['$tool'];
 			try {
-				const toolName = handleFromAi('tool', '', 'string');
-				const toolParameters = handleFromAi('toolParameters', '', 'string');
+				const toolName = handleFromAi('tool', '');
+				const toolParameters = handleFromAi('toolParameters', '');
 				return {
 					name: toolName ?? fallbackValue?.name,
 					parameters: toolParameters ?? fallbackValue?.parameters,

--- a/packages/workflow/src/workflow-data-proxy.ts
+++ b/packages/workflow/src/workflow-data-proxy.ts
@@ -1079,7 +1079,12 @@ export class WorkflowDataProxy {
 		const handleTool = (throwOnError = true) => {
 			const fallbackValue = that.additionalKeys?.['$tool'];
 			try {
-				return handleFromAi('tool', '', 'string', fallbackValue);
+				const toolName = handleFromAi('tool', '', 'string');
+				const toolParameters = handleFromAi('toolParameters', '', 'string');
+				return {
+					name: toolName ?? fallbackValue?.name,
+					parameters: toolParameters ?? fallbackValue?.parameters,
+				};
 			} catch (error) {
 				const isNoExecutionDataError =
 					error instanceof ExpressionError && error.context.type === 'no_execution_data';
@@ -1506,7 +1511,7 @@ export class WorkflowDataProxy {
 
 				return that.getNodeExecutionData(nodeName, false, outputIndex, runIndex);
 			},
-			$tool: '', // Placeholder
+			$tool: {}, // Placeholder
 			$json: {}, // Placeholder
 			$node: this.nodeGetter(),
 			$self: this.selfGetter(),

--- a/packages/workflow/test/workflow-data-proxy.test.ts
+++ b/packages/workflow/test/workflow-data-proxy.test.ts
@@ -1060,20 +1060,22 @@ describe('WorkflowDataProxy', () => {
 				additionalKeys,
 			});
 
-		test('Behaves like $fromAI("tool") when execution data exists', () => {
-			// $tool should behave the same as $fromAI('tool') when execution data is available
+		test('Returns object with name and parameters when execution data exists', () => {
 			const proxy = getToolProxy();
 			const toolValue = proxy.$tool;
-			const fromAiToolValue = proxy.$fromAI('tool');
-			// Both should return the same value (or both undefined if tool key doesn't exist)
-			expect(toolValue).toEqual(fromAiToolValue);
+			// $tool should now return an object with name and parameters
+			expect(toolValue).toBeDefined();
+			expect(typeof toolValue).toBe('object');
+			expect(toolValue).toHaveProperty('name');
+			expect(toolValue).toHaveProperty('parameters');
 		});
 
 		test('Works consistently across different items', () => {
 			const proxy0 = getToolProxy(0);
 			const proxy1 = getToolProxy(1);
-			// Both should behave consistently
-			expect(typeof proxy0.$tool).toBe(typeof proxy1.$tool);
+			// Both should return objects
+			expect(typeof proxy0.$tool).toBe('object');
+			expect(typeof proxy1.$tool).toBe('object');
 		});
 
 		test('Falls back to additionalKeys when no execution data exists', () => {
@@ -1115,25 +1117,29 @@ describe('WorkflowDataProxy', () => {
 				[], // Empty connectionInputData - this triggers no_execution_data error
 				{},
 				'manual',
-				{ $tool: 'fallback-tool-value' }, // Fallback value
+				{ $tool: { name: 'fallback-tool', parameters: 'fallback-params' } }, // Fallback value
 				undefined,
 			);
 
 			const proxy = dataProxy.getDataProxy();
 
 			// Should return the fallback value since there's no execution data
-			expect(proxy.$tool).toEqual('fallback-tool-value');
+			expect(proxy.$tool).toEqual({ name: 'fallback-tool', parameters: 'fallback-params' });
 		});
 
 		test('Uses execution data when available, ignoring fallback', () => {
 			// When execution data exists, it should use that instead of fallback
-			const proxy = getToolProxy(0, { $tool: 'fallback-tool-value' });
-			// Should use the actual value from execution data (or undefined if tool key doesn't exist)
+			const proxy = getToolProxy(0, {
+				$tool: { name: 'fallback-tool', parameters: 'fallback-params' },
+			});
+			// Should use the actual value from execution data
 			// The fallback should be ignored when execution data is available
 			const toolValue = proxy.$tool;
-			const fromAiToolValue = proxy.$fromAI('tool');
-			// Both should return the same value (execution data takes precedence over fallback)
-			expect(toolValue).toEqual(fromAiToolValue);
+			// Should return an object with name and parameters from execution data
+			expect(toolValue).toBeDefined();
+			expect(typeof toolValue).toBe('object');
+			expect(toolValue).toHaveProperty('name');
+			expect(toolValue).toHaveProperty('parameters');
 		});
 	});
 


### PR DESCRIPTION
## Summary

This PR adds a new shortcut for `fromAI('toolParameters')`
It also removes stringification of `toolParameters` when it's passed to tool. Previously it was done for simpler access, because by default object get converted to `[object Object]` and requires use of JSON.stringify
<img width="1363" height="467" alt="image" src="https://github.com/user-attachments/assets/67945eab-2f35-4c9d-86bd-282dbcf21e75" />



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4235/add-dollartoolname-and-dollartoolparameters-expressions-and-update-the


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
