### PR TITLE
fix(ai-builder): Ask/Build coachmark appearing as chat panel slides out (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/AskModeCoachmark.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/AskModeCoachmark.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useI18n } from '@n8n/i18n';
-import { N8nButton, N8nTooltip } from '@n8n/design-system';
+import { N8nButton, N8nPopover } from '@n8n/design-system';
 
 defineProps<{
 	visible: boolean;
@@ -14,61 +14,83 @@ const i18n = useI18n();
 </script>
 
 <template>
-	<N8nTooltip :visible="visible" :content-class="$style.content">
+	<N8nPopover
+		:open="visible"
+		:show-arrow="true"
+		:enable-scrolling="false"
+		:suppress-auto-focus="true"
+		side="bottom"
+		align="center"
+		:side-offset="8"
+		:z-index="2200"
+		content-class="ask-mode-coachmark"
+	>
+		<template #trigger>
+			<slot />
+		</template>
 		<template #content>
-			<div :class="$style.header">
-				<span :class="$style.title">{{ i18n.baseText('aiAssistant.coachmark.title') }}</span>
+			<div class="ask-mode-coachmark__header">
+				<span class="ask-mode-coachmark__title">{{
+					i18n.baseText('aiAssistant.coachmark.title')
+				}}</span>
 			</div>
-			<p :class="$style.body">
+			<p class="ask-mode-coachmark__body">
 				{{ i18n.baseText('aiAssistant.coachmark.body') }}
 			</p>
-			<div :class="$style.footer">
+			<div class="ask-mode-coachmark__footer">
 				<N8nButton
 					size="small"
 					:label="i18n.baseText('aiAssistant.coachmark.gotIt')"
-					:class="$style.gotItButton"
+					class="ask-mode-coachmark__button"
 					@click="emit('dismiss')"
 				/>
 			</div>
 		</template>
-		<slot />
-	</N8nTooltip>
+	</N8nPopover>
 </template>
 
-<style lang="scss" module>
-.header {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	padding: var(--spacing--2xs) var(--spacing--2xs) var(--spacing--4xs) var(--spacing--2xs);
-}
-
-.title {
-	font-size: var(--font-size--sm);
-	font-weight: var(--font-weight--bold);
-	line-height: 1.45;
-}
-
-.body {
-	font-size: var(--font-size--sm);
-	line-height: var(--line-height--xl);
-	padding: 0 var(--spacing--2xs);
-	margin: 0;
-}
-
-.footer {
-	padding: var(--spacing--2xs);
-}
-
-.gotItButton {
-	background-color: var(--color--primary);
-
-	&:hover {
-		background-color: var(--color--primary--shade-1);
-	}
-}
-
-.content {
+<style lang="scss">
+.ask-mode-coachmark {
 	width: 289px;
+	padding: var(--spacing--xs);
+	background: var(--color--background--shade-2);
+	color: var(--color--foreground--tint-2);
+
+	// Style the popover arrow to match the dark background
+	svg {
+		fill: var(--color--background--shade-2);
+		stroke: var(--color--background--shade-2);
+	}
+
+	&__header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding-bottom: var(--spacing--4xs);
+	}
+
+	&__title {
+		font-size: var(--font-size--sm);
+		font-weight: var(--font-weight--bold);
+		line-height: 1.45;
+	}
+
+	&__body {
+		font-size: var(--font-size--sm);
+		line-height: var(--line-height--xl);
+		margin: 0;
+	}
+
+	&__footer {
+		padding-top: var(--spacing--2xs);
+	}
+
+	&__button {
+		background-color: var(--color--primary);
+
+		&:hover {
+			background-color: var(--color--primary--shade-1);
+		}
+	}
 }
 </style>


### PR DESCRIPTION
## Summary
Addressing an issue found by @harshalnpatil with work carried out in https://github.com/n8n-io/n8n/pull/24406

The Coachmark was appearing as the chat panel was sliding out which would occasionally leave the coachmark in the wrong location. Waiting until after animation has completed.

I've also switched this over to use a Popover rather than a tooltip, the new tooltip version doesn't have a controlled mode as its not how a tooltip should be used, the controlled mode also had some issues like appearing on hover despite being controlled.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
