### PR TITLE
fix(ai-builder): Responder mentions workflow activation (no-changelog)

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/responder.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/responder.prompt.ts
@@ -22,7 +22,8 @@ const WORKFLOW_COMPLETION = `When you receive [Internal Context], synthesize a c
 3. Include setup instructions if provided
 4. If Data Table setup is required, include the exact steps provided in the context (do NOT say data tables will be created automatically)
 5. Ask if user wants adjustments
-6. Do not tell user to activate/publish their workflow, because they will do this themselves when they are ready.
+
+IMPORTANT: Never tell the user to activate, publish, or turn on their workflow. Users will activate workflows themselves when ready.
 
 Example response structure:
 "I've created your [workflow type] workflow! Here's what it does:

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/best-practices/monitoring.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/best-practices/monitoring.ts
@@ -19,9 +19,7 @@ Example pattern for website monitoring:
 
 For monitoring multiple services, store URLs/endpoints in Google Sheets or databases and loop through them rather than duplicating workflows.
 
-## Scheduling & Activation
-
-Always activate the workflow after configuration - forgetting this means no monitoring occurs. Test schedules with manual execution before relying on them in production.
+## Scheduling
 
 Configure appropriate check intervals based on criticality:
 - Critical services: 1-5 minutes
@@ -87,7 +85,6 @@ Purpose: Periodic workflow execution at fixed intervals or Cron schedules
 
 Configuration:
 - Set appropriate intervals based on service criticality
-- Always activate the workflow after configuration
 
 ### HTTP Request (n8n-nodes-base.httpRequest)
 
@@ -138,10 +135,6 @@ Purpose: Store monitoring configuration, log results, track state changes
 Purpose: Modular monitoring design with sub-workflows for different service types
 
 ## Common Pitfalls to Avoid
-
-### Forgetting to Activate Workflow
-
-The #1 monitoring failure - creating the perfect monitoring workflow but forgetting to activate it. Always verify the workflow is active (toggle in top-right of editor).
 
 ### No Error Handling on Check Nodes
 

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/best-practices/scheduling.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/best-practices/scheduling.ts
@@ -15,8 +15,6 @@ For recurring tasks, use Schedule Trigger node with clear naming (e.g., "Daily 0
 
 Prevent overlapping executions by ensuring worst-case execution time < schedule interval. For frequent schedules, implement mutex/lock mechanisms using external systems if needed.
 
-CRITICAL: Always save and activate workflows with Schedule Trigger nodes - scheduled workflows only run in active mode. Manual execution works during development but activation is required for automatic runs.
-
 ## Scheduling Patterns
 
 ### Recurring Schedules


### PR DESCRIPTION
## Summary

This PR addresses minor issue, when AI workflow builder tells users to activate workflow.
It turned out there are conflicting instructions in different parts of the prompt:
- Best practice document for technique "scheduling" contained instructions to "always activate the workflow"
- This ended up in the coordination log
- Responder prompt has instruction NOT to mention workflow activation, but it was not enough to prevent responder from translating an item from coordination log

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-1569/feature-builder-should-not-tell-users-to-activate-their-workflow-for

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
