### PR TITLE
fix: Change RegEx in Data Table Schema to throw error on ID in Column

### DIFF
--- a/packages/@n8n/api-types/src/schemas/data-table.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/data-table.schema.ts
@@ -8,16 +8,20 @@ export const dataTableNameSchema = z.string().trim().min(1).max(128);
 export const dataTableIdSchema = z.string().max(36);
 
 // Postgres does not allow leading numbers or -
-export const DATA_TABLE_COLUMN_REGEX = /^[a-zA-Z][a-zA-Z0-9_]*$/;
-export const DATA_TABLE_COLUMN_MAX_LENGTH = 63; // Postgres has a maximum of 63 characters
-export const DATA_TABLE_COLUMN_ERROR_MESSAGE =
-	'Only alphabetical characters and non-leading numbers and underscores are allowed for column names, and the maximum length is 63 characters.';
+const DATA_TABLE_COLUMN_REGEX = /^[a-zA-Z][a-zA-Z0-9_]*$/;
+const DATA_TABLE_COLUMN_MAX_LENGTH = 63; // Postgres has a maximum of 63 characters
+const DATA_TABLE_COLUMN_NAME_NOT_ID = /^(?!id$).+/i
+const DATA_TABLE_COLUMN_NAME_NOT_ID_ERROR_MESSAGE =
+  'Column name cannot be id';
+const DATA_TABLE_COLUMN_ERROR_MESSAGE =
+  'Only alphabetical characters and non-leading numbers and underscores are allowed for column names, and the maximum length is 63 characters.';
 
 export const dataTableColumnNameSchema = z
 	.string()
 	.trim()
 	.min(1)
 	.max(DATA_TABLE_COLUMN_MAX_LENGTH) // Postgres has a maximum of 63 characters
+	.regex(DATA_TABLE_COLUMN_NAME_NOT_ID, DATA_TABLE_COLUMN_NAME_NOT_ID_ERROR_MESSAGE)
 	.regex(DATA_TABLE_COLUMN_REGEX, DATA_TABLE_COLUMN_ERROR_MESSAGE);
 export const dataTableColumnTypeSchema = z.enum(['string', 'number', 'boolean', 'date']);
 


### PR DESCRIPTION
<img width="2090" height="1269" alt="image" src="https://github.com/user-attachments/assets/1cfa1610-518b-4a95-bb16-96f7155a5868" />


## Summary

Change Zod behaviour to throw error when column name is `ID`.

## Related Linear tickets, Github issues, and Community forum posts

solves #24815 


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
