### PR TITLE
test: Add MySQL integration tests

### DIFF
--- a/packages/nodes-base/jest.config.js
+++ b/packages/nodes-base/jest.config.js
@@ -4,6 +4,7 @@ process.env.TZ = 'UTC';
 /** @type {import('jest').Config} */
 module.exports = {
 	...require('../../jest.config'),
+	testPathIgnorePatterns: ['/dist/', '/node_modules/', '\\.integration\\.test\\.ts$'],
 	collectCoverageFrom: ['credentials/**/*.ts', 'nodes/**/*.ts', 'utils/**/*.ts'],
 	globalSetup: '<rootDir>/test/globalSetup.ts',
 	setupFilesAfterEnv: ['jest-expect-message', '<rootDir>/test/setup.ts'],

--- a/packages/nodes-base/nodes/MySql/test/v2/mysql.integration.test.ts
+++ b/packages/nodes-base/nodes/MySql/test/v2/mysql.integration.test.ts
@@ -1,0 +1,127 @@
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import { createServiceStack, type N8NStack } from 'n8n-containers';
+import { constructExecutionMetaData } from 'n8n-core';
+import type { IDataObject, IExecuteFunctions, INode } from 'n8n-workflow';
+
+import { router } from '../../v2/actions/router';
+import type { MysqlNodeCredentials } from '../../v2/helpers/interfaces';
+
+let stack: N8NStack;
+let credentials: MysqlNodeCredentials;
+
+beforeAll(async () => {
+	stack = await createServiceStack({ services: ['mysql'] });
+	const meta = stack.serviceResults.mysql!.meta as {
+		externalHost: string;
+		externalPort: number;
+		database: string;
+		username: string;
+		password: string;
+	};
+	credentials = {
+		host: meta.externalHost,
+		port: meta.externalPort,
+		database: meta.database,
+		user: meta.username,
+		password: meta.password,
+		ssl: false,
+		sshTunnel: false,
+	};
+});
+
+afterAll(async () => {
+	await stack?.stop();
+});
+
+const node: INode = {
+	id: '1',
+	name: 'MySQL',
+	typeVersion: 2.5,
+	type: 'n8n-nodes-base.mySql',
+	position: [0, 0],
+	parameters: {},
+};
+
+function mockExecuteFunctions(
+	params: IDataObject,
+	creds: MysqlNodeCredentials,
+	continueOnFail = false,
+): IExecuteFunctions {
+	return {
+		getNodeParameter: (name: string, _i: number, fallback?: unknown) => params[name] ?? fallback,
+		getNode: () => node,
+		getInputData: () => [{ json: {} }],
+		continueOnFail: () => continueOnFail,
+		getCredentials: async () => creds,
+		helpers: {
+			constructExecutionMetaData,
+			getSSHClient: () => {
+				throw new Error('No SSH');
+			},
+		},
+	} as unknown as IExecuteFunctions;
+}
+
+const badCreds: MysqlNodeCredentials = {
+	host: 'invalid.host',
+	port: 3306,
+	database: 'x',
+	user: 'x',
+	password: 'x',
+	ssl: false,
+	sshTunnel: false,
+};
+
+describe('MySQL Integration - NODE-4174', () => {
+	test('happy path: SELECT against real MySQL', async () => {
+		const params = {
+			resource: 'database',
+			operation: 'executeQuery',
+			query: 'SELECT 1 as result',
+			options: { queryBatching: 'single', nodeVersion: 2.5 },
+		};
+
+		const result = await router.call(mockExecuteFunctions(params, credentials));
+
+		expect(result[0][0].json).toEqual({ result: 1 });
+	});
+
+	test('bad path: query error returns error item with continueOnFail', async () => {
+		const params = {
+			resource: 'database',
+			operation: 'executeQuery',
+			query: 'SELECT * FROM table_that_does_not_exist',
+			options: { queryBatching: 'single', nodeVersion: 2.5 },
+		};
+
+		const result = await router.call(mockExecuteFunctions(params, credentials, true));
+
+		expect(result[0][0].json).toHaveProperty('message');
+	});
+
+	// NODE-4174: createPool() is outside try-catch, so connection errors bypass continueOnFail.
+	// Remove .fails when fixed.
+	test.fails('bug: connection error should return error item with continueOnFail', async () => {
+		const params = {
+			resource: 'database',
+			operation: 'executeQuery',
+			query: 'SELECT 1',
+			options: { queryBatching: 'single', nodeVersion: 2.5, connectTimeout: 1000 },
+		};
+
+		const result = await router.call(mockExecuteFunctions(params, badCreds, true));
+
+		expect(result[0][0].json).toHaveProperty('error');
+	});
+
+	test('connection error throws when continueOnFail is false', async () => {
+		const params = {
+			resource: 'database',
+			operation: 'executeQuery',
+			query: 'SELECT 1',
+			options: { queryBatching: 'single', nodeVersion: 2.5, connectTimeout: 1000 },
+		};
+
+		await expect(router.call(mockExecuteFunctions(params, badCreds, false))).rejects.toThrow();
+	});
+});

--- a/packages/nodes-base/nodes/MySql/test/v2/mysql.integration.test.ts
+++ b/packages/nodes-base/nodes/MySql/test/v2/mysql.integration.test.ts
@@ -24,6 +24,7 @@ beforeAll(async () => {
 		database: meta.database,
 		user: meta.username,
 		password: meta.password,
+		connectTimeout: 10000,
 		ssl: false,
 		sshTunnel: false,
 	};
@@ -68,6 +69,7 @@ const badCreds: MysqlNodeCredentials = {
 	database: 'x',
 	user: 'x',
 	password: 'x',
+	connectTimeout: 1000,
 	ssl: false,
 	sshTunnel: false,
 };

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -15,7 +15,8 @@
     "lint:fix": "eslint nodes credentials utils test --fix",
     "watch": "tsc-watch -p tsconfig.build.cjs.json --onCompilationComplete \"pnpm copy-nodes-json && tsc-alias -p tsconfig.build.cjs.json\" --onSuccess \"pnpm n8n-generate-metadata\"",
     "test": "jest",
-    "test:dev": "jest --watch"
+    "test:dev": "jest --watch",
+    "test:integration": "vitest run --config vitest.integration.config.ts"
   },
   "files": [
     "dist"
@@ -850,6 +851,9 @@
     "@n8n/client-oauth2": "workspace:*",
     "@n8n/eslint-plugin-community-nodes": "workspace:*",
     "@n8n/typescript-config": "workspace:*",
+    "@n8n/vitest-config": "workspace:*",
+    "n8n-containers": "workspace:*",
+    "vitest": "catalog:",
     "@types/amqplib": "^0.10.1",
     "@types/aws4": "^1.5.1",
     "@types/basic-auth": "catalog:",

--- a/packages/nodes-base/tsconfig.json
+++ b/packages/nodes-base/tsconfig.json
@@ -42,6 +42,7 @@
 		"../core/nodes-testing/**/*.ts",
 		"../../node_modules/jest-expect-message/types/index.d.ts"
 	],
+	"exclude": [],
 	"references": [
 		{ "path": "../@n8n/imap/tsconfig.build.json" },
 		{ "path": "../workflow/tsconfig.build.esm.json" },

--- a/packages/nodes-base/vitest.integration.config.ts
+++ b/packages/nodes-base/vitest.integration.config.ts
@@ -1,0 +1,27 @@
+import { resolve } from 'path';
+import { mergeConfig } from 'vitest/config';
+import { createVitestConfigWithDecorators } from '@n8n/vitest-config/node-decorators';
+
+export default mergeConfig(
+	createVitestConfigWithDecorators({
+		include: ['**/*.integration.test.ts'],
+		testTimeout: 120_000,
+		hookTimeout: 120_000,
+	}),
+	{
+		resolve: {
+			alias: {
+				'@credentials': resolve(__dirname, 'credentials'),
+				'@test': resolve(__dirname, 'test'),
+				'@utils': resolve(__dirname, 'utils'),
+				'@nodes-testing': resolve(__dirname, '../core/nodes-testing'),
+			},
+		},
+		test: {
+			fileParallelism: false,
+			sequence: { concurrent: false },
+			pool: 'forks',
+			poolOptions: { forks: { singleFork: true } },
+		},
+	},
+);

--- a/packages/testing/containers/index.ts
+++ b/packages/testing/containers/index.ts
@@ -20,3 +20,4 @@ export * from './performance-plans';
 // Types used externally by tests
 export { type LogEntry, type MetricsHelper } from './services/observability';
 export { type GiteaHelper } from './services/gitea';
+export { KafkaHelper } from './services/kafka';

--- a/packages/testing/containers/package.json
+++ b/packages/testing/containers/package.json
@@ -26,6 +26,7 @@
   "license": "ISC",
   "devDependencies": {
     "@testcontainers/kafka": "^11.11.0",
+    "@testcontainers/mysql": "^11.11.0",
     "@testcontainers/postgresql": "^11.0.3",
     "@testcontainers/redis": "^11.0.3",
     "get-port": "^7.1.0",

--- a/packages/testing/containers/services/mysql.ts
+++ b/packages/testing/containers/services/mysql.ts
@@ -1,0 +1,60 @@
+import { MySqlContainer, type StartedMySqlContainer } from '@testcontainers/mysql';
+import type { StartedNetwork } from 'testcontainers';
+
+import { TEST_CONTAINER_IMAGES } from '../test-containers';
+import type { Service, ServiceResult } from './types';
+
+const HOSTNAME = 'mysql';
+
+export interface MySqlMeta {
+	database: string;
+	username: string;
+	password: string;
+	port: number;
+	internalHost: string;
+	externalHost: string;
+	externalPort: number;
+}
+
+export type MySqlResult = ServiceResult<MySqlMeta> & {
+	container: StartedMySqlContainer;
+};
+
+export const mysqlService: Service<MySqlResult> = {
+	description: 'MySQL database for integration testing',
+
+	async start(network: StartedNetwork, projectName: string): Promise<MySqlResult> {
+		const container = await new MySqlContainer(TEST_CONTAINER_IMAGES.mysql)
+			.withNetwork(network)
+			.withNetworkAliases(HOSTNAME)
+			.withDatabase('n8n_test')
+			.withUsername('n8n_user')
+			.withRootPassword('root_password')
+			.withUserPassword('test_password')
+			.withStartupTimeout(60_000)
+			.withLabels({
+				'com.docker.compose.project': projectName,
+				'com.docker.compose.service': HOSTNAME,
+			})
+			.withName(`${projectName}-${HOSTNAME}`)
+			.withReuse()
+			.start();
+
+		return {
+			container,
+			meta: {
+				database: container.getDatabase(),
+				username: container.getUsername(),
+				password: container.getUserPassword(),
+				port: 3306,
+				internalHost: HOSTNAME,
+				externalHost: container.getHost(),
+				externalPort: container.getPort(),
+			},
+		};
+	},
+
+	env(): Record<string, string> {
+		return {};
+	},
+};

--- a/packages/testing/containers/services/registry.ts
+++ b/packages/testing/containers/services/registry.ts
@@ -4,6 +4,7 @@ import { kafka, createKafkaHelper } from './kafka';
 import { keycloak, createKeycloakHelper } from './keycloak';
 import { loadBalancer } from './load-balancer';
 import { mailpit, createMailpitHelper } from './mailpit';
+import { mysqlService } from './mysql';
 import { createObservabilityHelper } from './observability';
 import { postgres } from './postgres';
 import { proxy } from './proxy';
@@ -31,6 +32,7 @@ export const services: Record<ServiceName, Service<ServiceResult>> = {
 	loadBalancer,
 	cloudflared,
 	kafka,
+	mysql: mysqlService,
 };
 
 export const helperFactories: Partial<HelperFactories> = {

--- a/packages/testing/containers/services/types.ts
+++ b/packages/testing/containers/services/types.ts
@@ -15,6 +15,7 @@ export const SERVICE_NAMES = [
 	'loadBalancer',
 	'cloudflared',
 	'kafka',
+	'mysql',
 ] as const;
 
 export type ServiceName = (typeof SERVICE_NAMES)[number];

--- a/packages/testing/containers/test-containers.ts
+++ b/packages/testing/containers/test-containers.ts
@@ -32,8 +32,8 @@ const DEFAULT_IMAGES = {
 	n8nTracer: 'ghcr.io/ivov/n8n-tracer:0.1.0',
 	jaeger: 'jaegertracing/all-in-one:1.76.0',
 	cloudflared: 'cloudflare/cloudflared:2025.1.1',
-	// Kafka for message queue testing
 	kafka: 'confluentinc/cp-kafka:8.0.3',
+	mysql: 'mysql:9.6.0',
 } as const;
 
 /**
@@ -97,4 +97,6 @@ export const TEST_CONTAINER_IMAGES = {
 	n8nTracer: getImage('n8nTracer'),
 	jaeger: getImage('jaeger'),
 	cloudflared: getImage('cloudflared'),
+	kafka: getImage('kafka'),
+	mysql: getImage('mysql'),
 } as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3386,6 +3386,9 @@ importers:
       '@n8n/typescript-config':
         specifier: workspace:*
         version: link:../@n8n/typescript-config
+      '@n8n/vitest-config':
+        specifier: workspace:*
+        version: link:../@n8n/vitest-config
       '@types/amqplib':
         specifier: ^0.10.1
         version: 0.10.1
@@ -3461,13 +3464,22 @@ importers:
       eslint-plugin-n8n-nodes-base:
         specifier: ^1.16.3
         version: 1.16.3(eslint@9.29.0(jiti@2.6.1))(typescript@5.9.2)
+      n8n-containers:
+        specifier: workspace:*
+        version: link:../testing/containers
       n8n-core:
         specifier: workspace:*
         version: link:../core
+      vitest:
+        specifier: 'catalog:'
+        version: 3.1.3(@types/debug@4.1.12)(@types/node@20.19.21)(jiti@2.6.1)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(sass@1.89.2)(terser@5.16.1)(tsx@4.19.3)
 
   packages/testing/containers:
     devDependencies:
       '@testcontainers/kafka':
+        specifier: ^11.11.0
+        version: 11.11.0
+      '@testcontainers/mysql':
         specifier: ^11.11.0
         version: 11.11.0
       '@testcontainers/postgresql':
@@ -8386,6 +8398,9 @@ packages:
 
   '@testcontainers/kafka@11.11.0':
     resolution: {integrity: sha512-DGGoQL0wELifn1GHrfe4tW7ejYDIXNFHisx6wlgFzQ1xqaN8ppYlO658Fgg8B9+rcl0wY2rZF0oF0QFADKgqEg==}
+
+  '@testcontainers/mysql@11.11.0':
+    resolution: {integrity: sha512-2EfFhUDEvEdwBwez+F/NhqP+h2rFzLzHYbRX0N/9/Lgdlq8TbsYWZ9SaWL9V0f1FWX89XnyZrT3i/j7m8MIESg==}
 
   '@testcontainers/postgresql@11.0.3':
     resolution: {integrity: sha512-nMq0lBLguZecp9JDV4J8nlPWwxOQ4XiXUIGkV5Lvj1CMdVqbqQJe4eVrNHVC3rIM/w8nadNp5ecEoxnwkhG33w==}
@@ -25281,6 +25296,12 @@ snapshots:
   '@testcontainers/kafka@11.11.0':
     dependencies:
       compare-versions: 6.1.1
+      testcontainers: 11.11.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@testcontainers/mysql@11.11.0':
+    dependencies:
       testcontainers: 11.11.0
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
## Summary

Adds integration tests for the MySQL node using testcontainers.

This change introduces a new integration test suite for the MySQL node, leveraging testcontainers to create a real MySQL instance for testing. The tests cover basic query execution and error handling scenarios.

The tests are excluded from the regular test suite and can be run with `pnpm test:integration`.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
