### PR TITLE
ci: Add timing stats for unit tests

### DIFF
--- a/.github/scripts/send-build-stats.mjs
+++ b/.github/scripts/send-build-stats.mjs
@@ -12,10 +12,15 @@
  *   BUILD_STATS_WEBHOOK_PASSWORD - Basic auth password (required if URL set)
  */
 
-import { readFileSync, readdirSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import * as os from 'node:os';
 import { join } from 'node:path';
 
 const runsDir = '.turbo/runs';
+if (!existsSync(runsDir)) {
+	console.log('No .turbo/runs directory found (turbo --summarize not used), skipping.');
+	process.exit(0);
+}
 const files = readdirSync(runsDir).filter((f) => f.endsWith('.json'));
 const summaryPath = files.length > 0 ? join(runsDir, files[0]) : null;
 
@@ -39,8 +44,6 @@ if (!webhookUser || !webhookPassword) {
 }
 
 const basicAuth = Buffer.from(`${webhookUser}:${webhookPassword}`).toString('base64');
-
-import * as os from 'node:os';
 
 const summary = JSON.parse(readFileSync(summaryPath, 'utf-8'));
 

--- a/.github/workflows/ci-manual-unit-tests.yml
+++ b/.github/workflows/ci-manual-unit-tests.yml
@@ -72,6 +72,9 @@ jobs:
       collectCoverage: true
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      BUILD_STATS_WEBHOOK_URL: ${{ secrets.BUILD_STATS_WEBHOOK_URL }}
+      BUILD_STATS_WEBHOOK_USER: ${{ secrets.BUILD_STATS_WEBHOOK_USER }}
+      BUILD_STATS_WEBHOOK_PASSWORD: ${{ secrets.BUILD_STATS_WEBHOOK_PASSWORD }}
 
   lint:
     name: Lint

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -30,6 +30,9 @@ jobs:
       collectCoverage: ${{ matrix.node-version == '22.x' }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      BUILD_STATS_WEBHOOK_URL: ${{ secrets.BUILD_STATS_WEBHOOK_URL }}
+      BUILD_STATS_WEBHOOK_USER: ${{ secrets.BUILD_STATS_WEBHOOK_USER }}
+      BUILD_STATS_WEBHOOK_PASSWORD: ${{ secrets.BUILD_STATS_WEBHOOK_PASSWORD }}
 
   lint:
     name: Lint

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -60,6 +60,9 @@ jobs:
       collectCoverage: true
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      BUILD_STATS_WEBHOOK_URL: ${{ secrets.BUILD_STATS_WEBHOOK_URL }}
+      BUILD_STATS_WEBHOOK_USER: ${{ secrets.BUILD_STATS_WEBHOOK_USER }}
+      BUILD_STATS_WEBHOOK_PASSWORD: ${{ secrets.BUILD_STATS_WEBHOOK_PASSWORD }}
 
   typecheck:
     name: Typecheck

--- a/.github/workflows/test-unit-reusable.yml
+++ b/.github/workflows/test-unit-reusable.yml
@@ -21,6 +21,15 @@ on:
       CODECOV_TOKEN:
         description: 'Codecov upload token.'
         required: false
+      BUILD_STATS_WEBHOOK_URL:
+        description: 'Webhook URL for test stats.'
+        required: false
+      BUILD_STATS_WEBHOOK_USER:
+        description: 'Basic auth username for test stats webhook.'
+        required: false
+      BUILD_STATS_WEBHOOK_PASSWORD:
+        description: 'Basic auth password for test stats webhook.'
+        required: false
 
 env:
   NODE_OPTIONS: --max-old-space-size=7168
@@ -42,7 +51,15 @@ jobs:
           node-version: ${{ inputs.nodeVersion }}
 
       - name: Test Unit
-        run: pnpm test:ci:backend:unit
+        run: pnpm test:ci:backend:unit --summarize
+
+      - name: Send Test Stats
+        if: ${{ !cancelled() }}
+        run: node .github/scripts/send-build-stats.mjs || true
+        env:
+          BUILD_STATS_WEBHOOK_URL: ${{ secrets.BUILD_STATS_WEBHOOK_URL }}
+          BUILD_STATS_WEBHOOK_USER: ${{ secrets.BUILD_STATS_WEBHOOK_USER }}
+          BUILD_STATS_WEBHOOK_PASSWORD: ${{ secrets.BUILD_STATS_WEBHOOK_PASSWORD }}
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
@@ -75,7 +92,15 @@ jobs:
           node-version: ${{ inputs.nodeVersion }}
 
       - name: Test Integration
-        run: pnpm test:ci:backend:integration
+        run: pnpm test:ci:backend:integration --summarize
+
+      - name: Send Test Stats
+        if: ${{ !cancelled() }}
+        run: node .github/scripts/send-build-stats.mjs || true
+        env:
+          BUILD_STATS_WEBHOOK_URL: ${{ secrets.BUILD_STATS_WEBHOOK_URL }}
+          BUILD_STATS_WEBHOOK_USER: ${{ secrets.BUILD_STATS_WEBHOOK_USER }}
+          BUILD_STATS_WEBHOOK_PASSWORD: ${{ secrets.BUILD_STATS_WEBHOOK_PASSWORD }}
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
@@ -108,7 +133,15 @@ jobs:
           node-version: ${{ inputs.nodeVersion }}
 
       - name: Test Nodes
-        run: pnpm turbo test --filter=n8n-nodes-base
+        run: pnpm turbo test --filter=n8n-nodes-base --summarize
+
+      - name: Send Test Stats
+        if: ${{ !cancelled() }}
+        run: node .github/scripts/send-build-stats.mjs || true
+        env:
+          BUILD_STATS_WEBHOOK_URL: ${{ secrets.BUILD_STATS_WEBHOOK_URL }}
+          BUILD_STATS_WEBHOOK_USER: ${{ secrets.BUILD_STATS_WEBHOOK_USER }}
+          BUILD_STATS_WEBHOOK_PASSWORD: ${{ secrets.BUILD_STATS_WEBHOOK_PASSWORD }}
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
@@ -145,9 +178,17 @@ jobs:
           node-version: ${{ inputs.nodeVersion }}
 
       - name: Test
-        run: pnpm test:ci:frontend -- --shard=${{ matrix.shard }}/2
+        run: pnpm test:ci:frontend --summarize -- --shard=${{ matrix.shard }}/2
         env:
           VITEST_SHARD: ${{ matrix.shard }}/2
+
+      - name: Send Test Stats
+        if: ${{ !cancelled() }}
+        run: node .github/scripts/send-build-stats.mjs || true
+        env:
+          BUILD_STATS_WEBHOOK_URL: ${{ secrets.BUILD_STATS_WEBHOOK_URL }}
+          BUILD_STATS_WEBHOOK_USER: ${{ secrets.BUILD_STATS_WEBHOOK_USER }}
+          BUILD_STATS_WEBHOOK_PASSWORD: ${{ secrets.BUILD_STATS_WEBHOOK_PASSWORD }}
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}

--- a/scripts/build-n8n.mjs
+++ b/scripts/build-n8n.mjs
@@ -101,7 +101,7 @@ try {
 	installProcess.pipe(process.stdout);
 	await installProcess;
 
-	const buildProcess = $`cd ${config.rootDir} && pnpm build`;
+	const buildProcess = $`cd ${config.rootDir} && pnpm build --summarize`;
 	buildProcess.pipe(process.stdout);
 	await buildProcess;
 


### PR DESCRIPTION
## Summary

Adds timing stats to unit tests job so we can benchmark pre/post jest/vitest

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
