### PR TITLE
fix(GitLab Node): Handle binary data in all modes by converting to base64

### DIFF
--- a/packages/nodes-base/nodes/Gitlab/Gitlab.node.ts
+++ b/packages/nodes-base/nodes/Gitlab/Gitlab.node.ts
@@ -1626,18 +1626,25 @@ export class Gitlab implements INodeType {
 							// Currently internally n8n uses base64 and also GitLab expects it base64 encoded.
 							// If that ever changes the data has to get converted here.
 							const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i);
-							const binaryData = this.helpers.assertBinaryData(i, binaryPropertyName);
-							// TODO: Does this work with filesystem mode
-							body.content = binaryData.data;
+							const buffer = await this.helpers.getBinaryDataBuffer(i, binaryPropertyName);
+							body.content = buffer.toString('base64');
 							body.encoding = 'base64';
 						} else {
 							// Is text file
+							const fileContent = this.getNodeParameter('fileContent', i);
+							if (typeof fileContent !== 'string') {
+								throw new NodeOperationError(
+									this.getNode(),
+									'The parameter "fileContent" should be a string.',
+									{ itemIndex: i },
+								);
+							}
 							if (additionalParameters.encoding === 'base64') {
-								body.content = Buffer.from(
-									this.getNodeParameter('fileContent', i) as string,
-								).toString('base64');
+								body.content = Buffer.from(fileContent).toString('base64');
+								body.encoding = 'base64';
 							} else {
-								body.content = this.getNodeParameter('fileContent', i) as string;
+								body.content = fileContent;
+								body.encoding = 'text';
 							}
 						}
 

--- a/packages/nodes-base/nodes/Gitlab/__tests__/Gitlab.file.create.test.ts
+++ b/packages/nodes-base/nodes/Gitlab/__tests__/Gitlab.file.create.test.ts
@@ -1,0 +1,186 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+import { Gitlab } from '../Gitlab.node';
+import * as GenericFunctions from '../GenericFunctions';
+
+jest.mock('../GenericFunctions', () => ({
+	...jest.requireActual('../GenericFunctions'),
+	gitlabApiRequest: jest.fn(),
+	gitlabApiRequestAllItems: jest.fn(),
+}));
+
+describe('Gitlab Node - File Create Operations', () => {
+	let gitlab: Gitlab;
+	let mockExecuteFunctions: jest.Mocked<IExecuteFunctions>;
+
+	beforeEach(() => {
+		gitlab = new Gitlab();
+		jest.clearAllMocks();
+
+		mockExecuteFunctions = {
+			getNodeParameter: jest.fn(),
+			getInputData: jest.fn().mockReturnValue([{ json: {} }]),
+			getNode: jest.fn().mockReturnValue({
+				id: 'test-node-id',
+				name: 'GitLab',
+				type: 'n8n-nodes-base.gitlab',
+				typeVersion: 1,
+				position: [0, 0],
+				parameters: {},
+			}),
+			helpers: {
+				prepareBinaryData: jest.fn(),
+				getBinaryDataBuffer: jest.fn(),
+				returnJsonArray: jest.fn((data) => (Array.isArray(data) ? data : [data])),
+				constructExecutionMetaData: jest.fn((data) => data),
+			},
+			continueOnFail: jest.fn().mockReturnValue(false),
+		} as unknown as jest.Mocked<IExecuteFunctions>;
+	});
+
+	it('should create file with binary data from filesystem', async () => {
+		(mockExecuteFunctions.getNodeParameter as jest.Mock).mockImplementation(
+			(paramName: string, _itemIndex: number, fallback?: any) => {
+				const params: Record<string, any> = {
+					resource: 'file',
+					operation: 'create',
+					owner: 'test-owner',
+					repository: 'test-repo',
+					filePath: 'test-file.txt',
+					commitMessage: 'Test commit',
+					binaryData: true,
+					binaryPropertyName: 'data',
+					additionalParameters: {},
+				};
+				return params[paramName] ?? fallback;
+			},
+		);
+
+		const expectedBuffer = Buffer.from('test content');
+		(mockExecuteFunctions.helpers.getBinaryDataBuffer as jest.Mock).mockResolvedValue(
+			expectedBuffer,
+		);
+
+		(GenericFunctions.gitlabApiRequest as jest.Mock).mockResolvedValue({
+			file_path: 'test.txt',
+			branch: 'main',
+		});
+
+		const result = await gitlab.execute.call(mockExecuteFunctions);
+
+		expect(mockExecuteFunctions.helpers.getBinaryDataBuffer).toHaveBeenCalledWith(0, 'data');
+		expect(GenericFunctions.gitlabApiRequest).toHaveBeenCalledWith(
+			'POST',
+			'/projects/test-owner%2Ftest-repo/repository/files/test-file.txt',
+			expect.objectContaining({
+				content: expectedBuffer.toString('base64'),
+				encoding: 'base64',
+				commit_message: 'Test commit',
+			}),
+			{},
+		);
+		expect(result).toBeDefined();
+	});
+
+	it('should create file with text content and base64 encoding', async () => {
+		(mockExecuteFunctions.getNodeParameter as jest.Mock).mockImplementation(
+			(paramName: string, _itemIndex: number, fallback?: any) => {
+				const params: Record<string, any> = {
+					resource: 'file',
+					operation: 'create',
+					owner: 'test-owner',
+					repository: 'test-repo',
+					filePath: 'test-text.txt',
+					commitMessage: 'Test commit',
+					binaryData: false,
+					fileContent: 'Hello World',
+					additionalParameters: {
+						encoding: 'base64',
+					},
+				};
+				return params[paramName] ?? fallback;
+			},
+		);
+
+		(GenericFunctions.gitlabApiRequest as jest.Mock).mockResolvedValue({
+			file_path: 'test.txt',
+			branch: 'main',
+		});
+
+		const result = await gitlab.execute.call(mockExecuteFunctions);
+
+		expect(GenericFunctions.gitlabApiRequest).toHaveBeenCalledWith(
+			'POST',
+			'/projects/test-owner%2Ftest-repo/repository/files/test-text.txt',
+			expect.objectContaining({
+				content: Buffer.from('Hello World').toString('base64'),
+				encoding: 'base64',
+			}),
+			{},
+		);
+		expect(result).toBeDefined();
+	});
+
+	it('should create file with plain text content', async () => {
+		(mockExecuteFunctions.getNodeParameter as jest.Mock).mockImplementation(
+			(paramName: string, _itemIndex: number, fallback?: any) => {
+				const params: Record<string, any> = {
+					resource: 'file',
+					operation: 'create',
+					owner: 'test-owner',
+					repository: 'test-repo',
+					filePath: 'test-plain.txt',
+					commitMessage: 'Test commit',
+					binaryData: false,
+					fileContent: 'Plain text content',
+					additionalParameters: {
+						encoding: 'text',
+					},
+				};
+				return params[paramName] ?? fallback;
+			},
+		);
+
+		(GenericFunctions.gitlabApiRequest as jest.Mock).mockResolvedValue({
+			file_path: 'test.txt',
+			branch: 'main',
+		});
+
+		const result = await gitlab.execute.call(mockExecuteFunctions);
+
+		expect(GenericFunctions.gitlabApiRequest).toHaveBeenCalledWith(
+			'POST',
+			'/projects/test-owner%2Ftest-repo/repository/files/test-plain.txt',
+			expect.objectContaining({
+				content: 'Plain text content',
+				encoding: 'text',
+			}),
+			{},
+		);
+		expect(result).toBeDefined();
+	});
+
+	it('should throw error when fileContent is not a string', async () => {
+		(mockExecuteFunctions.getNodeParameter as jest.Mock).mockImplementation(
+			(paramName: string, _itemIndex: number, fallback?: any) => {
+				const params: Record<string, any> = {
+					resource: 'file',
+					operation: 'create',
+					owner: 'test-owner',
+					repository: 'test-repo',
+					filePath: 'test-error.txt',
+					commitMessage: 'Test commit',
+					binaryData: false,
+					fileContent: 12345, // Invalid non-string input
+					additionalParameters: {
+						encoding: 'text',
+					},
+				};
+				return params[paramName] ?? fallback;
+			},
+		);
+
+		await expect(gitlab.execute.call(mockExecuteFunctions)).rejects.toThrow(
+			'The parameter "fileContent" should be a string.',
+		);
+	});
+});


### PR DESCRIPTION
## Summary

This PR fixes issue #24809 where binary files were corrupted when uploaded to GitLab using the filesystem binary data storage mode. Files were being truncated to 6-9 bytes with garbled content instead of uploading correctly.

## Note
This is a recreation of #24814, which was accidentally closed when I deleted my fork. I'm new to contributing to open source and didn't realize this would happen. I apologize for any inconvenience!

### The Problem
When n8n v2 uses `filesystem` binary data storage mode (`N8N_DEFAULT_BINARY_DATA_MODE=filesystem`), the `binaryData.data` field contains a storage reference string (e.g., `filesystem-v2:...`) instead of the actual binary content. The GitLab node was attempting to upload this reference string directly instead of retrieving the actual file buffer from disk.

### The Solution
This fix mirrors the solution implemented for the GitHub node in #23497:
- Uses `getBinaryDataBuffer()` helper to correctly retrieve binary data from filesystem storage
- Converts the buffer to base64 format as expected by the GitLab API
- Properly handles both binary data uploads and text file uploads with encoding options

### Testing
Tested with `N8N_DEFAULT_BINARY_DATA_MODE=filesystem`:

**Before fix:**
- ❌ Binary file uploads resulted in 6-9 byte corrupted files
- ❌ File content showed garbled characters like `~)^+-zk`

**After fix:**
- ✅ Binary files (images) upload correctly with proper file size (9.21 kB tested)
- ✅ File content is intact and viewable in GitLab
- ✅ Text files with base64 encoding work correctly

### Demo
**Before:**
<img width="1608" height="447" alt="image" src="https://github.com/user-attachments/assets/c5fa6ed0-8de6-4178-aa3b-eb81ee0b62eb" />

File shows 9 B with corrupted content

**After:**
<img width="1624" height="798" alt="image" src="https://github.com/user-attachments/assets/0fdf4ed2-d80f-40cc-9669-975b5615418f" />

File shows correct size (7.41 kB) and displays properly in GitLab

## Related Linear tickets, Github issues, and Community forum posts

Fixes #24809

This fix follows the same pattern as:
- #23497 (GitHub Node binary data fix)
- #23334 (Original GitHub issue that #23497 fixed)

## Review / Merge checklist
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)