### PR TITLE
feat(core): Add type overriding to `getNodeParameter` (w/ index) and `getCurrentNodeParameter`

### DIFF
--- a/packages/core/src/execution-engine/__tests__/routing-node.test.ts
+++ b/packages/core/src/execution-engine/__tests__/routing-node.test.ts
@@ -2,6 +2,7 @@ import { mock } from 'jest-mock-extended';
 import get from 'lodash/get';
 import type {
 	DeclarativeRestApiSettings,
+	NodeParameterValueType,
 	IExecuteData,
 	IExecuteSingleFunctions,
 	IHttpRequestOptions,
@@ -54,7 +55,7 @@ const getExecuteSingleFunctions = (
 ) =>
 	mock<executionContexts.ExecuteSingleContext>({
 		getItemIndex: () => itemIndex,
-		getNodeParameter: (parameterName: string) =>
+		getNodeParameter: <T = NodeParameterValueType | object>(parameterName: string) =>
 			workflow.expression.getParameterValue(
 				get(node.parameters, parameterName),
 				runExecutionData,
@@ -64,7 +65,7 @@ const getExecuteSingleFunctions = (
 				[],
 				'internal',
 				{},
-			),
+			) as T,
 		getWorkflow: () => ({
 			id: workflow.id,
 			name: workflow.name,

--- a/packages/core/src/execution-engine/node-execution-context/execute-single-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/execute-single-context.ts
@@ -10,6 +10,7 @@ import type {
 	WorkflowExecuteMode,
 	ITaskDataConnections,
 	IExecuteData,
+	NodeParameterValueType,
 } from 'n8n-workflow';
 import { ApplicationError, createDeferredPromise, NodeConnectionTypes } from 'n8n-workflow';
 
@@ -112,8 +113,12 @@ export class ExecuteSingleContext extends BaseExecuteContext implements IExecute
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	getNodeParameter(parameterName: string, fallbackValue?: any, options?: IGetNodeParameterOptions) {
-		return this._getNodeParameter(parameterName, this.itemIndex, fallbackValue, options);
+	getNodeParameter<T = NodeParameterValueType | object>(
+		parameterName: string,
+		fallbackValue?: any,
+		options?: IGetNodeParameterOptions,
+	) {
+		return this._getNodeParameter<T>(parameterName, this.itemIndex, fallbackValue, options);
 	}
 
 	async getCredentials<T extends object = ICredentialDataDecryptedObject>(type: string) {

--- a/packages/core/src/execution-engine/node-execution-context/load-options-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/load-options-context.ts
@@ -37,10 +37,10 @@ export class LoadOptionsContext extends NodeExecutionContext implements ILoadOpt
 		return await this._getCredentials<T>(type);
 	}
 
-	getCurrentNodeParameter(
+	getCurrentNodeParameter<T = NodeParameterValueType | object | undefined>(
 		parameterPath: string,
 		options?: IGetNodeParameterOptions,
-	): NodeParameterValueType | object | undefined {
+	): T {
 		const nodeParameters = this.additionalData.currentNodeParameters;
 
 		if (parameterPath.charAt(0) === '&') {
@@ -63,7 +63,7 @@ export class LoadOptionsContext extends NodeExecutionContext implements ILoadOpt
 			) as NodeParameterValueType;
 		}
 
-		return returnData;
+		return returnData as T;
 	}
 
 	getCurrentNodeParameters() {

--- a/packages/core/src/execution-engine/node-execution-context/local-load-options-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/local-load-options-context.ts
@@ -24,9 +24,8 @@ export class LocalLoadOptionsContext implements ILocalLoadOptionsFunctions {
 		nodeType: string,
 		useActiveVersion: boolean = false,
 	): Promise<IWorkflowNodeContext | null> {
-		const { value: workflowId } = this.getCurrentNodeParameter(
-			'workflowId',
-		) as INodeParameterResourceLocator;
+		const { value: workflowId } =
+			this.getCurrentNodeParameter<INodeParameterResourceLocator>('workflowId');
 
 		if (typeof workflowId !== 'string' || !workflowId) {
 			throw new ApplicationError(`No workflowId parameter defined on node of type "${nodeType}"!`);
@@ -67,11 +66,13 @@ export class LocalLoadOptionsContext implements ILocalLoadOptionsFunctions {
 		return null;
 	}
 
-	getCurrentNodeParameter(parameterPath: string): NodeParameterValueType | object | undefined {
+	getCurrentNodeParameter<T = NodeParameterValueType | object | undefined>(
+		parameterPath: string,
+	): T {
 		const nodeParameters = this.additionalData.currentNodeParameters;
 
 		parameterPath = resolveRelativePath(this.path, parameterPath);
 
-		return get(nodeParameters, parameterPath);
+		return get(nodeParameters, parameterPath) as T;
 	}
 }

--- a/packages/core/src/execution-engine/node-execution-context/node-execution-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/node-execution-context.ts
@@ -422,23 +422,23 @@ export abstract class NodeExecutionContext implements Omit<FunctionsBase, 'getCr
 	}
 
 	/** Returns the requested resolved (all expressions replaced) node parameters. */
-	getNodeParameter(
+	getNodeParameter<T = NodeParameterValueType | object>(
 		parameterName: string,
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		fallbackValue?: any,
 		options?: IGetNodeParameterOptions,
-	): NodeParameterValueType | object {
+	): T {
 		const itemIndex = 0;
-		return this._getNodeParameter(parameterName, itemIndex, fallbackValue, options);
+		return this._getNodeParameter<T>(parameterName, itemIndex, fallbackValue, options);
 	}
 
-	protected _getNodeParameter(
+	protected _getNodeParameter<T = NodeParameterValueType | object>(
 		parameterName: string,
 		itemIndex: number,
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		fallbackValue?: any,
 		options?: IGetNodeParameterOptions,
-	): NodeParameterValueType | object {
+	): T {
 		const { workflow, node, mode, runExecutionData, runIndex, connectionInputData, executeData } =
 			this;
 
@@ -508,7 +508,7 @@ export abstract class NodeExecutionContext implements Omit<FunctionsBase, 'getCr
 			});
 		}
 
-		if (options?.skipValidation) return returnData;
+		if (options?.skipValidation) return returnData as T;
 
 		// Validate parameter value if it has a schema defined(RMC) or validateType defined
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -653,43 +653,36 @@ namespace ExecuteFunctions {
 		export type NodeParameter = 'additionalFields' | 'filters' | 'options' | 'updateFields';
 	}
 
-	export type GetNodeParameterFn = {
+	type NodeValueMap = {
+		[K in StringReturning.NodeParameter]: string;
+	} & {
+		[K in RecordReturning.NodeParameter]: IDataObject;
+	} & {
+		[K in BooleanReturning.NodeParameter]: boolean;
+	} & {
+		[K in NumberReturning.NodeParameter]: number;
+	};
+
+	export type GetNodeParameterWithIndexFn = {
 		// @TECH_DEBT: Refactor to remove this barely used overload - N8N-5632
 		getNodeParameter<T extends { resource: string }>(
 			parameterName: 'resource',
 			itemIndex?: number,
 		): T['resource'];
 
-		getNodeParameter(
-			parameterName: StringReturning.NodeParameter,
+		getNodeParameter<P extends keyof NodeValueMap, T = NodeValueMap[P]>(
+			parameterName: P,
 			itemIndex: number,
-			fallbackValue?: string,
+			fallbackValue?: NodeValueMap[P],
 			options?: IGetNodeParameterOptions,
-		): string;
-		getNodeParameter(
-			parameterName: RecordReturning.NodeParameter,
+		): [T] extends [never] ? NodeValueMap[P] : T;
+
+		getNodeParameter<T = NodeParameterValueType | object, P extends string = string>(
+			parameterName: P,
 			itemIndex: number,
-			fallbackValue?: IDataObject,
+			fallbackValue?: P extends keyof NodeValueMap ? NodeValueMap[P] : any,
 			options?: IGetNodeParameterOptions,
-		): IDataObject;
-		getNodeParameter(
-			parameterName: BooleanReturning.NodeParameter,
-			itemIndex: number,
-			fallbackValue?: boolean,
-			options?: IGetNodeParameterOptions,
-		): boolean;
-		getNodeParameter(
-			parameterName: NumberReturning.NodeParameter,
-			itemIndex: number,
-			fallbackValue?: number,
-			options?: IGetNodeParameterOptions,
-		): number;
-		getNodeParameter(
-			parameterName: string,
-			itemIndex: number,
-			fallbackValue?: any,
-			options?: IGetNodeParameterOptions,
-		): NodeParameterValueType | object;
+		): T;
 	};
 }
 
@@ -983,6 +976,14 @@ type FunctionsBaseWithRequiredKeys<Keys extends keyof FunctionsBase> = Functions
 	[K in Keys]: NonNullable<FunctionsBase[K]>;
 };
 
+export type GetNodeParameterFn = {
+	getNodeParameter(
+		parameterName: string,
+		fallbackValue?: any,
+		options?: IGetNodeParameterOptions,
+	): NodeParameterValueType | object;
+};
+
 export type ContextType = 'flow' | 'node';
 
 export type DataTableProxyProvider = {
@@ -1019,7 +1020,7 @@ type BaseExecutionFunctions = FunctionsBaseWithRequiredKeys<'getMode'> & {
 };
 
 // TODO: Create later own type only for Config-Nodes
-export type IExecuteFunctions = ExecuteFunctions.GetNodeParameterFn &
+export type IExecuteFunctions = ExecuteFunctions.GetNodeParameterWithIndexFn &
 	BaseExecutionFunctions & {
 		executeWorkflow(
 			workflowInfo: IExecuteWorkflowInfo,
@@ -1097,14 +1098,9 @@ export type IExecuteFunctions = ExecuteFunctions.GetNodeParameterFn &
 		getRunnerStatus(taskType: string): { available: true } | { available: false; reason?: string };
 	};
 
-export interface IExecuteSingleFunctions extends BaseExecutionFunctions {
+export interface IExecuteSingleFunctions extends BaseExecutionFunctions, GetNodeParameterFn {
 	getInputData(inputIndex?: number, connectionType?: NodeConnectionType): INodeExecutionData;
 	getItemIndex(): number;
-	getNodeParameter(
-		parameterName: string,
-		fallbackValue?: any,
-		options?: IGetNodeParameterOptions,
-	): NodeParameterValueType | object;
 
 	helpers: RequestHelperFunctions &
 		BaseHelperFunctions &
@@ -1115,7 +1111,7 @@ export interface IExecuteSingleFunctions extends BaseExecutionFunctions {
 		};
 }
 
-export type ISupplyDataFunctions = ExecuteFunctions.GetNodeParameterFn &
+export type ISupplyDataFunctions = ExecuteFunctions.GetNodeParameterWithIndexFn &
 	FunctionsBaseWithRequiredKeys<'getMode'> &
 	Pick<
 		IExecuteFunctions,
@@ -1151,16 +1147,11 @@ export interface IExecutePaginationFunctions extends IExecuteSingleFunctions {
 	): Promise<INodeExecutionData[]>;
 }
 
-export interface ILoadOptionsFunctions extends FunctionsBase {
-	getNodeParameter(
-		parameterName: string,
-		fallbackValue?: any,
-		options?: IGetNodeParameterOptions,
-	): NodeParameterValueType | object;
-	getCurrentNodeParameter(
+export interface ILoadOptionsFunctions extends FunctionsBase, GetNodeParameterFn {
+	getCurrentNodeParameter<T = NodeParameterValueType | object | undefined>(
 		parameterName: string,
 		options?: IGetNodeParameterOptions,
-	): NodeParameterValueType | object | undefined;
+	): T;
 	getCurrentNodeParameters(): INodeParameters | undefined;
 
 	helpers: RequestHelperFunctions & SSHTunnelFunctions & DataTableProxyFunctions;
@@ -1168,7 +1159,7 @@ export interface ILoadOptionsFunctions extends FunctionsBase {
 
 export type FieldValueOption = { name: string; type: FieldType | 'any' };
 
-export type IWorkflowNodeContext = ExecuteFunctions.GetNodeParameterFn &
+export type IWorkflowNodeContext = ExecuteFunctions.GetNodeParameterWithIndexFn &
 	Pick<FunctionsBase, 'getNode' | 'getWorkflow'>;
 
 export interface ILocalLoadOptionsFunctions {
@@ -1183,18 +1174,14 @@ export interface IWorkflowLoader {
 }
 
 export interface IPollFunctions
-	extends FunctionsBaseWithRequiredKeys<'getMode' | 'getActivationMode'> {
+	extends FunctionsBaseWithRequiredKeys<'getMode' | 'getActivationMode'>,
+		GetNodeParameterFn {
 	__emit(
 		data: INodeExecutionData[][],
 		responsePromise?: IDeferredPromise<IExecuteResponsePromiseData>,
 		donePromise?: IDeferredPromise<IRun>,
 	): void;
 	__emitError(error: Error, responsePromise?: IDeferredPromise<IExecuteResponsePromiseData>): void;
-	getNodeParameter(
-		parameterName: string,
-		fallbackValue?: any,
-		options?: IGetNodeParameterOptions,
-	): NodeParameterValueType | object;
 	helpers: RequestHelperFunctions &
 		BaseHelperFunctions &
 		BinaryHelperFunctions &
@@ -1202,18 +1189,14 @@ export interface IPollFunctions
 }
 
 export interface ITriggerFunctions
-	extends FunctionsBaseWithRequiredKeys<'getMode' | 'getActivationMode'> {
+	extends FunctionsBaseWithRequiredKeys<'getMode' | 'getActivationMode'>,
+		GetNodeParameterFn {
 	emit(
 		data: INodeExecutionData[][],
 		responsePromise?: IDeferredPromise<IExecuteResponsePromiseData>,
 		donePromise?: IDeferredPromise<IRun>,
 	): void;
 	emitError(error: Error, responsePromise?: IDeferredPromise<IExecuteResponsePromiseData>): void;
-	getNodeParameter(
-		parameterName: string,
-		fallbackValue?: any,
-		options?: IGetNodeParameterOptions,
-	): NodeParameterValueType | object;
 	helpers: RequestHelperFunctions &
 		BaseHelperFunctions &
 		BinaryHelperFunctions &
@@ -1222,19 +1205,17 @@ export interface ITriggerFunctions
 }
 
 export interface IHookFunctions
-	extends FunctionsBaseWithRequiredKeys<'getMode' | 'getActivationMode'> {
+	extends FunctionsBaseWithRequiredKeys<'getMode' | 'getActivationMode'>,
+		GetNodeParameterFn {
 	getWebhookName(): string;
 	getWebhookDescription(name: WebhookType): IWebhookDescription | undefined;
 	getNodeWebhookUrl: (name: WebhookType) => string | undefined;
-	getNodeParameter(
-		parameterName: string,
-		fallbackValue?: any,
-		options?: IGetNodeParameterOptions,
-	): NodeParameterValueType | object;
 	helpers: RequestHelperFunctions;
 }
 
-export interface IWebhookFunctions extends FunctionsBaseWithRequiredKeys<'getMode'> {
+export interface IWebhookFunctions
+	extends FunctionsBaseWithRequiredKeys<'getMode'>,
+		GetNodeParameterFn {
 	getBodyData(): IDataObject;
 	getHeaderData(): IncomingHttpHeaders;
 	getInputConnectionData(
@@ -1242,11 +1223,6 @@ export interface IWebhookFunctions extends FunctionsBaseWithRequiredKeys<'getMod
 		itemIndex: number,
 		inputIndex?: number,
 	): Promise<unknown>;
-	getNodeParameter(
-		parameterName: string,
-		fallbackValue?: any,
-		options?: IGetNodeParameterOptions,
-	): NodeParameterValueType | object;
 	getNodeWebhookUrl: (name: WebhookType) => string | undefined;
 	evaluateExpression(expression: string, itemIndex?: number): NodeParameterValueType;
 	getParamsData(): object;


### PR DESCRIPTION
## Summary

- `GetNodeParameterFn` type has been renamed to `GetNodeParameterWithIndexFn`:
  - A variant without index has been extracted as a type, using this name instead. The following interfaces implement it: `IExecuteSingleFunctions`, `ILoadOptionsFunctions`, `IPollFunctions`, `ITriggerFunctions`, `IHookFunctions` and `IWebhookFunctions`.
- `getCurrentNodeParameter` now supports type overrides with the following syntax: 
```js
.getCurrentNodeParameter<SomeType>(...)
```
- `getNodeParameter` now supports type overrides with the following syntax:
```js
.getNodeParameter<SomeType>(...)
```
- Boilerplate code for "known" parameter names has been reduced, by using a helper type map i.e., `NodeValueMap` as fallbackValue and return types share values.
- Type overrides for `getNodeParameter` _only work_ for the following interfaces:
  - `IExecuteFunctions`, `ISupplyDataFunctions` and `IWorkflowNodeContext`
  - Supporting non-index variant would require adding some function overloads and exposing unavailable arguments, just for the sake of union compatibility,
  - e.g., `IExecuteFunctions | IPollFunctions` cannot have type overrides but `IExecuteFunctions`, `IExecuteFunctions | ISupplyDataFunctions` (_or other implementors of itemIndex_) can.

Typechecks & tests pass, **no migrations required**.

### About `getNodeParameter` syntax

```ts
// Type is inferred by default.
const options1 = this.getNodeParameter('custom', itemIndex, {});
//     ^? object | NodeParameterValueType

const options2 = this.getNodeParameter('options', itemIndex);
//     ^? IDataObject

// When a type is defined, fallbackValue becomes `any` for known params.
const options3 = this.getNodeParameter<{ hi?: string; }>('options', itemIndex);
//     ^? { hi?: string | undefined; }

// fallbackValue is now `IDataObject | undefined`.
const options4 = this.getNodeParameter<'options', { hi?: string }>('options', itemIndex, {});
//     ^? { hi?: string | undefined; }

const options5 = this.getNodeParameter<'a' | 'b'>('options', itemIndex, {});
//     ^? 'a' | 'b'

// Edge case: to override with a type that equals parameterName,
// one must use either
const options6 = this.getNodeParameter<'options', 'options'>('options', itemIndex);
//     ^? 'options'
// or cast as unknown first
const options7 = this.getNodeParameter('options', itemIndex, {}) as unknown as 'options';
//     ^? 'options'

// `as` casts still work
const options8 = this.getNodeParameter('options', itemIndex) as { hi?: string; };
//     ^? { hi?: string | undefined; }
```

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
