### PR TITLE
fix(editor): Allow '-' and '_' in subworkflow caller IDs

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/WorkflowSettings.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowSettings.test.ts
@@ -223,8 +223,9 @@ describe('WorkflowSettingsVue', () => {
 		});
 	});
 
-	it('should not remove valid workflow ID characters', async () => {
-		const validWorkflowList = '1234567890, abcde, efgh, 1234';
+	it('should not remove valid workflow ID characters including hyphens and underscores', async () => {
+		const validWorkflowList =
+			'1234567890, abcde, efgh, 1234, luPpn77f_KhU1e-F9bQXu, another-valid_id';
 
 		settingsStore.settings.enterprise[EnterpriseEditionFeature.Sharing] = true;
 		const { getByTestId } = createComponent({ pinia });

--- a/packages/frontend/editor-ui/src/app/components/WorkflowSettings.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowSettings.vue
@@ -221,9 +221,9 @@ const executionLogicOptions = computed(() => {
 });
 
 const onCallerIdsInput = (str: string) => {
-	workflowSettings.value.callerIds = /^[a-zA-Z0-9,\s]+$/.test(str)
+	workflowSettings.value.callerIds = /^[a-zA-Z0-9,\s_-]+$/.test(str)
 		? str
-		: str.replace(/[^a-zA-Z0-9,\s]/g, '');
+		: str.replace(/[^a-zA-Z0-9,\s_-]/g, '');
 };
 
 const closeDialog = () => {


### PR DESCRIPTION
## Summary

## Problem

When setting **Allowed Caller Workflows** for a subworkflow, IDs containing `-` or `_` were getting stripped out. So an ID like `luPpn77f_KhU1e-F9bQXu` would turn into `luPpn77fKhU1eF9bQXu`, making it impossible to authorize the right workflow.

## Solution

This updates the input validation to allow `-` and `_` in workflow IDs so they’re no longer removed. I also added a test case covering this to make sure it doesn’t break again in the future.

## Related Linear tickets, Github issues, and Community forum posts
Fixes #24841
Fixes GHC-6532


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
