### PR TITLE
fix(editor): Truncate long project names with ellipsis in breadcrumb

### DIFF
--- a/packages/frontend/editor-ui/src/features/core/folders/components/ProjectBreadcrumb.vue
+++ b/packages/frontend/editor-ui/src/features/core/folders/components/ProjectBreadcrumb.vue
@@ -85,7 +85,12 @@ const onProjectMouseUp = () => {
 	>
 		<N8nLink :to="projectLink" :class="[$style['project-link']]">
 			<ProjectIcon :icon="projectIcon" :border-less="true" size="mini" :title="projectName" />
-			<N8nText size="medium" color="text-base" :class="$style['project-label']">
+			<N8nText
+				size="medium"
+				color="text-base"
+				:class="$style['project-label']"
+				:title="projectName"
+			>
 				{{ projectName }}
 			</N8nText>
 		</N8nLink>
@@ -120,6 +125,11 @@ const onProjectMouseUp = () => {
 }
 
 :global(.n8n-text).project-label {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	max-width: 200px;
+
 	@media (max-width: $breakpoint-sm) {
 		display: none;
 	}


### PR DESCRIPTION
The changes add text truncation with ellipsis for project names that exceed 200px in the ProjectBreadcrumb component, along with a title attribute to show the full name on hover.

https://linear.app/n8n/issue/AI-1962/poor-project-name-display-when-opening-ai-wfb-panel