### PR TITLE
fix: Disable usage of IMAP trigger as a tool

### DIFF
--- a/packages/nodes-base/nodes/EmailReadImap/v2/EmailReadImapV2.node.ts
+++ b/packages/nodes-base/nodes/EmailReadImap/v2/EmailReadImapV2.node.ts
@@ -53,7 +53,6 @@ const versionDescription: INodeTypeDescription = {
 		activationHint:
 			'Once you’ve finished building your workflow, publish it to have it also listen continuously (you just won’t see those executions here).',
 	},
-	usableAsTool: true,
 	inputs: [],
 	outputs: [NodeConnectionTypes.Main],
 	credentials: [


### PR DESCRIPTION
## Summary

Email Trigger (IMAP) was marked with `usableAsTool` flag by mistake.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
