### PR TITLE
refactor(core): Introduce `ExecutionPersistence` service

### DIFF
--- a/packages/@n8n/db/src/entities/execution-entity.ts
+++ b/packages/@n8n/db/src/entities/execution-entity.ts
@@ -20,7 +20,7 @@ import type { ExecutionMetadata } from './execution-metadata';
 import { WorkflowEntity } from './workflow-entity';
 import { idStringifier } from '../utils/transformers';
 
-export type ExecutionDataStorageLocation = 'db' | 'fs' | 's3';
+export type ExecutionDataStorageLocation = 'db' | 'fs';
 
 @Entity()
 @Index(['workflowId', 'id'])

--- a/packages/@n8n/db/src/entities/index.ts
+++ b/packages/@n8n/db/src/entities/index.ts
@@ -8,6 +8,7 @@ import { CredentialsEntity } from './credentials-entity';
 import { ExecutionAnnotation } from './execution-annotation.ee';
 import { ExecutionData } from './execution-data';
 import { ExecutionEntity } from './execution-entity';
+import type { ExecutionDataStorageLocation } from './execution-entity';
 import { ExecutionMetadata } from './execution-metadata';
 import { Folder } from './folder';
 import { FolderTagMapping } from './folder-tag-mapping';
@@ -44,6 +45,7 @@ export {
 	BinaryDataFile,
 	SourceTypeSchema,
 	type SourceType,
+	type ExecutionDataStorageLocation,
 	WebhookEntity,
 	AuthIdentity,
 	CredentialsEntity,

--- a/packages/@n8n/db/src/entities/types-db.ts
+++ b/packages/@n8n/db/src/entities/types-db.ts
@@ -19,6 +19,7 @@ import type {
 import { z } from 'zod';
 
 import type { CredentialsEntity } from './credentials-entity';
+import type { ExecutionDataStorageLocation } from './execution-entity';
 import type { Folder } from './folder';
 import type { Project } from './project';
 import type { SharedCredentials } from './shared-credentials';
@@ -58,6 +59,7 @@ export interface IExecutionBase {
 	retrySuccessId?: string; // If it failed and a retry did succeed. The id of the successful retry.
 	status: ExecutionStatus;
 	waitTill?: Date | null;
+	storedAt: ExecutionDataStorageLocation;
 }
 
 // Required by PublicUser
@@ -153,7 +155,10 @@ export interface WorkflowWithSharingsMetaDataAndCredentials extends Omit<Workflo
 }
 
 /** Payload for creating an execution. */
-export type CreateExecutionPayload = Omit<IExecutionDb, 'id' | 'createdAt' | 'startedAt'>;
+export type CreateExecutionPayload = Omit<
+	IExecutionDb,
+	'id' | 'createdAt' | 'startedAt' | 'storedAt'
+>;
 
 // Data in regular format with references
 export interface IExecutionDb extends IExecutionBase {

--- a/packages/@n8n/db/src/index.ts
+++ b/packages/@n8n/db/src/index.ts
@@ -40,5 +40,5 @@ export { DbConnectionOptions } from './connection/db-connection-options';
 export { AuthRolesService } from './services/auth.roles.service';
 
 export { In, Like, Not, DataSource } from '@n8n/typeorm';
-export type { FindOptionsWhere } from '@n8n/typeorm';
+export type { FindManyOptions, FindOptionsWhere } from '@n8n/typeorm';
 export type { EntityManager } from '@n8n/typeorm';

--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -81,6 +81,15 @@ export interface IGetExecutionsQueryFilter {
 	startedBefore?: string;
 }
 
+export type ExecutionDeletionCriteria = {
+	filters: IGetExecutionsQueryFilter | undefined;
+	accessibleWorkflowIds: string[];
+	deleteConditions: {
+		deleteBefore?: Date;
+		ids?: string[];
+	};
+};
+
 function parseFiltersToQueryBuilder(
 	qb: SelectQueryBuilder<ExecutionEntity>,
 	filters?: IGetExecutionsQueryFilter,
@@ -455,14 +464,11 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 		});
 	}
 
-	async deleteExecutionsByFilter(
-		filters: IGetExecutionsQueryFilter | undefined,
-		accessibleWorkflowIds: string[],
-		deleteConditions: {
-			deleteBefore?: Date;
-			ids?: string[];
-		},
-	): Promise<
+	async deleteExecutionsByFilter({
+		filters,
+		accessibleWorkflowIds,
+		deleteConditions,
+	}: ExecutionDeletionCriteria): Promise<
 		Array<{ executionId: string; workflowId: string; storedAt: ExecutionDataStorageLocation }>
 	> {
 		if (!deleteConditions?.deleteBefore && !deleteConditions?.ids) {

--- a/packages/@n8n/db/src/repositories/index.ts
+++ b/packages/@n8n/db/src/repositories/index.ts
@@ -8,7 +8,7 @@ export { CredentialsRepository } from './credentials.repository';
 export { ExecutionAnnotationRepository } from './execution-annotation.repository';
 export { ExecutionDataRepository } from './execution-data.repository';
 export { ExecutionMetadataRepository } from './execution-metadata.repository';
-export { ExecutionRepository } from './execution.repository';
+export { ExecutionRepository, type ExecutionDeletionCriteria } from './execution.repository';
 export { FolderRepository } from './folder.repository';
 export { FolderTagMappingRepository } from './folder-tag-mapping.repository';
 export { ScopeRepository } from './scope.repository';

--- a/packages/cli/src/__tests__/active-executions.test.ts
+++ b/packages/cli/src/__tests__/active-executions.test.ts
@@ -53,6 +53,7 @@ describe('ActiveExecutions', () => {
 		mode: 'manual',
 		startedAt: new Date(),
 		status: 'new',
+		storedAt: 'db',
 	};
 
 	const executionData: IWorkflowExecutionDataProcess = {

--- a/packages/cli/src/__tests__/active-workflow-manager.test.ts
+++ b/packages/cli/src/__tests__/active-workflow-manager.test.ts
@@ -34,6 +34,7 @@ describe('ActiveWorkflowManager', () => {
 			mock(),
 			mock(),
 			mock(),
+			mock(),
 		);
 	});
 

--- a/packages/cli/src/__tests__/wait-tracker.test.ts
+++ b/packages/cli/src/__tests__/wait-tracker.test.ts
@@ -205,6 +205,7 @@ describe('WaitTracker', () => {
 							lastNodeExecuted: finalNodeName,
 						},
 					}),
+					storedAt: 'db',
 				};
 
 				executionRepository.findSingleExecution
@@ -340,6 +341,7 @@ describe('WaitTracker', () => {
 					startedAt: new Date(),
 					mode: 'manual',
 					workflowId: 'parent_workflow_id',
+					storedAt: 'db',
 					data: createRunExecutionData({ executionData: { nodeExecutionStack: [executeData] } }),
 				};
 
@@ -371,6 +373,7 @@ describe('WaitTracker', () => {
 							lastNodeExecuted: finalNodeName,
 						},
 					}),
+					storedAt: 'db',
 				};
 
 				// Setup ExecutionRepository and ActiveExecutions
@@ -455,6 +458,7 @@ describe('WaitTracker', () => {
 					stoppedAt: new Date(),
 					mode: 'manual',
 					workflowId: 'parent_workflow_id',
+					storedAt: 'db',
 					data: createRunExecutionData(),
 				};
 

--- a/packages/cli/src/active-workflow-manager.ts
+++ b/packages/cli/src/active-workflow-manager.ts
@@ -430,7 +430,7 @@ export class ActiveWorkflowManager {
 			startedAt: new Date(),
 			stoppedAt: new Date(),
 			status: 'running',
-			storedAt: this.storageConfig.mode === 'database' ? 'db' : 'fs',
+			storedAt: this.storageConfig.modeTag,
 		};
 
 		executeErrorWorkflow(workflowData, fullRunData, mode);

--- a/packages/cli/src/active-workflow-manager.ts
+++ b/packages/cli/src/active-workflow-manager.ts
@@ -17,6 +17,7 @@ import {
 	ErrorReporter,
 	InstanceSettings,
 	PollContext,
+	StorageConfig,
 	TriggerContext,
 	type IGetExecutePollFunctions,
 	type IGetExecuteTriggerFunctions,
@@ -94,6 +95,7 @@ export class ActiveWorkflowManager {
 		private readonly workflowsConfig: WorkflowsConfig,
 		private readonly push: Push,
 		private readonly eventService: EventService,
+		private readonly storageConfig: StorageConfig,
 	) {
 		this.logger = this.logger.scoped(['workflow-activation']);
 	}
@@ -428,6 +430,7 @@ export class ActiveWorkflowManager {
 			startedAt: new Date(),
 			stoppedAt: new Date(),
 			status: 'running',
+			storedAt: this.storageConfig.mode === 'database' ? 'db' : 'fs',
 		};
 
 		executeErrorWorkflow(workflowData, fullRunData, mode);

--- a/packages/cli/src/databases/repositories/__tests__/execution.repository.test.ts
+++ b/packages/cli/src/databases/repositories/__tests__/execution.repository.test.ts
@@ -66,7 +66,11 @@ describe('ExecutionRepository', () => {
 				}),
 			);
 
-			await executionRepository.deleteExecutionsByFilter({ id: '1' }, ['1'], { ids: ['1'] });
+			await executionRepository.deleteExecutionsByFilter({
+				filters: { id: '1' },
+				accessibleWorkflowIds: ['1'],
+				deleteConditions: { ids: ['1'] },
+			});
 
 			expect(binaryDataService.deleteMany).toHaveBeenCalledWith([
 				{ type: 'execution', executionId: '1', workflowId },

--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -24,6 +24,7 @@ import type {
 } from 'n8n-workflow';
 
 import { EventService } from '@/events/event.service';
+import { ExecutionPersistence } from '@/executions/execution-persistence';
 import { ExternalHooks } from '@/external-hooks';
 import { Push } from '@/push';
 import { ExecutionMetadataService } from '@/services/execution-metadata.service';
@@ -45,6 +46,7 @@ describe('Execution Lifecycle Hooks', () => {
 	const errorReporter = mockInstance(ErrorReporter);
 	const eventService = mockInstance(EventService);
 	const executionRepository = mockInstance(ExecutionRepository);
+	const executionPersistence = mockInstance(ExecutionPersistence);
 	const executionMetadataService = mockInstance(ExecutionMetadataService);
 	const externalHooks = mockInstance(ExternalHooks);
 	const push = mockInstance(Push);
@@ -532,13 +534,13 @@ describe('Execution Lifecycle Hooks', () => {
 
 					await lifecycleHooks.runHook('workflowExecuteAfter', [unfinishedRun, {}]);
 
-					expect(executionRepository.hardDelete).not.toHaveBeenCalled();
+					expect(executionPersistence.delete).not.toHaveBeenCalled();
 				});
 
 				it('should not delete waiting executions', async () => {
 					await lifecycleHooks.runHook('workflowExecuteAfter', [waitingRun, {}]);
 
-					expect(executionRepository.hardDelete).not.toHaveBeenCalled();
+					expect(executionPersistence.delete).not.toHaveBeenCalled();
 				});
 
 				it('should soft delete manual executions when manual saving is disabled', async () => {
@@ -588,7 +590,7 @@ describe('Execution Lifecycle Hooks', () => {
 						testKey1: 'testValue1',
 						testKey2: 'testValue2',
 					});
-					expect(executionRepository.hardDelete).not.toHaveBeenCalled();
+					expect(executionPersistence.delete).not.toHaveBeenCalled();
 				});
 			});
 
@@ -755,7 +757,7 @@ describe('Execution Lifecycle Hooks', () => {
 
 				await lifecycleHooks.runHook('workflowExecuteAfter', [successfulRun, {}]);
 
-				expect(executionRepository.hardDelete).toHaveBeenCalledWith({
+				expect(executionPersistence.delete).toHaveBeenCalledWith({
 					workflowId,
 					executionId,
 				});
@@ -778,7 +780,7 @@ describe('Execution Lifecycle Hooks', () => {
 
 				await lifecycleHooks.runHook('workflowExecuteAfter', [failedRun, {}]);
 
-				expect(executionRepository.hardDelete).toHaveBeenCalledWith({
+				expect(executionPersistence.delete).toHaveBeenCalledWith({
 					workflowId,
 					executionId,
 				});
@@ -815,7 +817,7 @@ describe('Execution Lifecycle Hooks', () => {
 					// Metadata should not be saved before deletion
 					expect(executionMetadataService.save).not.toHaveBeenCalled();
 					// Execution should be deleted
-					expect(executionRepository.hardDelete).toHaveBeenCalledWith({
+					expect(executionPersistence.delete).toHaveBeenCalledWith({
 						workflowId,
 						executionId,
 					});

--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -93,26 +93,31 @@ describe('Execution Lifecycle Hooks', () => {
 		status: 'success',
 		finished: true,
 		waitTill: undefined,
+		storedAt: 'db',
 	});
 	const successfulRun = mock<IRun>({
 		status: 'success',
 		finished: true,
 		waitTill: undefined,
+		storedAt: 'db',
 	});
 	const failedRun = mock<IRun>({
 		status: 'error',
 		finished: true,
 		waitTill: undefined,
+		storedAt: 'db',
 	});
 	const waitingRun = mock<IRun>({
 		finished: true,
 		status: 'waiting',
 		waitTill: new Date(),
+		storedAt: 'db',
 	});
 	const successfulRunWithMetadata = mock<IRun>({
 		status: 'success',
 		finished: true,
 		waitTill: undefined,
+		storedAt: 'db',
 		data: {
 			resultData: {
 				metadata: {
@@ -760,6 +765,7 @@ describe('Execution Lifecycle Hooks', () => {
 				expect(executionPersistence.delete).toHaveBeenCalledWith({
 					workflowId,
 					executionId,
+					storedAt: 'db',
 				});
 			});
 
@@ -783,6 +789,7 @@ describe('Execution Lifecycle Hooks', () => {
 				expect(executionPersistence.delete).toHaveBeenCalledWith({
 					workflowId,
 					executionId,
+					storedAt: 'db',
 				});
 			});
 
@@ -820,6 +827,7 @@ describe('Execution Lifecycle Hooks', () => {
 					expect(executionPersistence.delete).toHaveBeenCalledWith({
 						workflowId,
 						executionId,
+						storedAt: 'db',
 					});
 				});
 

--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -539,13 +539,13 @@ describe('Execution Lifecycle Hooks', () => {
 
 					await lifecycleHooks.runHook('workflowExecuteAfter', [unfinishedRun, {}]);
 
-					expect(executionPersistence.delete).not.toHaveBeenCalled();
+					expect(executionPersistence.hardDelete).not.toHaveBeenCalled();
 				});
 
 				it('should not delete waiting executions', async () => {
 					await lifecycleHooks.runHook('workflowExecuteAfter', [waitingRun, {}]);
 
-					expect(executionPersistence.delete).not.toHaveBeenCalled();
+					expect(executionPersistence.hardDelete).not.toHaveBeenCalled();
 				});
 
 				it('should soft delete manual executions when manual saving is disabled', async () => {
@@ -595,7 +595,7 @@ describe('Execution Lifecycle Hooks', () => {
 						testKey1: 'testValue1',
 						testKey2: 'testValue2',
 					});
-					expect(executionPersistence.delete).not.toHaveBeenCalled();
+					expect(executionPersistence.hardDelete).not.toHaveBeenCalled();
 				});
 			});
 
@@ -762,7 +762,7 @@ describe('Execution Lifecycle Hooks', () => {
 
 				await lifecycleHooks.runHook('workflowExecuteAfter', [successfulRun, {}]);
 
-				expect(executionPersistence.delete).toHaveBeenCalledWith({
+				expect(executionPersistence.hardDelete).toHaveBeenCalledWith({
 					workflowId,
 					executionId,
 					storedAt: 'db',
@@ -786,7 +786,7 @@ describe('Execution Lifecycle Hooks', () => {
 
 				await lifecycleHooks.runHook('workflowExecuteAfter', [failedRun, {}]);
 
-				expect(executionPersistence.delete).toHaveBeenCalledWith({
+				expect(executionPersistence.hardDelete).toHaveBeenCalledWith({
 					workflowId,
 					executionId,
 					storedAt: 'db',
@@ -824,7 +824,7 @@ describe('Execution Lifecycle Hooks', () => {
 					// Metadata should not be saved before deletion
 					expect(executionMetadataService.save).not.toHaveBeenCalled();
 					// Execution should be deleted
-					expect(executionPersistence.delete).toHaveBeenCalledWith({
+					expect(executionPersistence.hardDelete).toHaveBeenCalledWith({
 						workflowId,
 						executionId,
 						storedAt: 'db',

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -10,6 +10,8 @@ import {
 	InstanceSettings,
 	ExecutionLifecycleHooks,
 } from 'n8n-core';
+
+import { ExecutionPersistence } from '@/executions/execution-persistence';
 import type {
 	IRun,
 	IWorkflowBase,
@@ -348,6 +350,7 @@ function hookFunctionsSave(
 	const logger = Container.get(Logger);
 	const errorReporter = Container.get(ErrorReporter);
 	const executionRepository = Container.get(ExecutionRepository);
+	const executionPersistence = Container.get(ExecutionPersistence);
 	const binaryDataService = Container.get(BinaryDataService);
 	const workflowStaticDataService = Container.get(WorkflowStaticDataService);
 	const workflowStatisticsService = Container.get(WorkflowStatisticsService);
@@ -405,9 +408,10 @@ function hookFunctionsSave(
 			if (shouldNotSave && !fullRunData.waitTill && !isManualMode) {
 				executeErrorWorkflow(this.workflowData, fullRunData, this.mode, this.executionId, retryOf);
 
-				await executionRepository.hardDelete({
+				await executionPersistence.delete({
 					workflowId: this.workflowData.id,
 					executionId: this.executionId,
+					storedAt: fullRunData.storedAt,
 				});
 
 				return;
@@ -582,6 +586,7 @@ export function getLifecycleHooksForScalingMain(
 	const saveSettings = toSaveSettings(workflowData.settings);
 	const optionalParameters = { pushRef, retryOf: retryOf ?? undefined, saveSettings };
 	const executionRepository = Container.get(ExecutionRepository);
+	const executionPersistence = Container.get(ExecutionPersistence);
 
 	hookFunctionsWorkflowEvents(hooks, userId);
 	hookFunctionsSaveProgress(hooks, optionalParameters);
@@ -614,9 +619,10 @@ export function getLifecycleHooksForScalingMain(
 			(fullRunData.status !== 'success' && !saveSettings.error);
 
 		if (!isManualMode && shouldNotSave && !fullRunData.waitTill) {
-			await executionRepository.hardDelete({
+			await executionPersistence.delete({
 				workflowId: this.workflowData.id,
 				executionId: this.executionId,
+				storedAt: fullRunData.storedAt,
 			});
 		} else {
 			// Only save metadata if execution is being kept

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -408,7 +408,7 @@ function hookFunctionsSave(
 			if (shouldNotSave && !fullRunData.waitTill && !isManualMode) {
 				executeErrorWorkflow(this.workflowData, fullRunData, this.mode, this.executionId, retryOf);
 
-				await executionPersistence.delete({
+				await executionPersistence.hardDelete({
 					workflowId: this.workflowData.id,
 					executionId: this.executionId,
 					storedAt: fullRunData.storedAt,
@@ -619,7 +619,7 @@ export function getLifecycleHooksForScalingMain(
 			(fullRunData.status !== 'success' && !saveSettings.error);
 
 		if (!isManualMode && shouldNotSave && !fullRunData.waitTill) {
-			await executionPersistence.delete({
+			await executionPersistence.hardDelete({
 				workflowId: this.workflowData.id,
 				executionId: this.executionId,
 				storedAt: fullRunData.storedAt,

--- a/packages/cli/src/executions/__tests__/execution-persistence.test.ts
+++ b/packages/cli/src/executions/__tests__/execution-persistence.test.ts
@@ -22,13 +22,13 @@ describe('ExecutionPersistence', () => {
 		jest.clearAllMocks();
 	});
 
-	describe('delete', () => {
+	describe('hardDelete', () => {
 		const baseTarget = { workflowId: 'wf-1', executionId: 'exec-1' };
 
 		it('should delete execution, binary data, and fs data when storedAt is fs', async () => {
 			const target = { ...baseTarget, storedAt: 'fs' as const };
 
-			await executionPersistence.delete(target);
+			await executionPersistence.hardDelete(target);
 
 			expect(executionRepository.deleteByIds).toHaveBeenCalledWith(['exec-1']);
 			expect(binaryDataService.deleteMany).toHaveBeenCalledWith([{ type: 'execution', ...target }]);
@@ -38,7 +38,7 @@ describe('ExecutionPersistence', () => {
 		it('should delete execution and binary data but not fs data when storedAt is db', async () => {
 			const target = { ...baseTarget, storedAt: 'db' as const };
 
-			await executionPersistence.delete(target);
+			await executionPersistence.hardDelete(target);
 
 			expect(executionRepository.deleteByIds).toHaveBeenCalledWith(['exec-1']);
 			expect(binaryDataService.deleteMany).toHaveBeenCalledWith([{ type: 'execution', ...target }]);
@@ -51,7 +51,7 @@ describe('ExecutionPersistence', () => {
 				{ workflowId: 'wf-2', executionId: 'exec-2', storedAt: 'db' as const },
 			];
 
-			await executionPersistence.delete(targets);
+			await executionPersistence.hardDelete(targets);
 
 			expect(executionRepository.deleteByIds).toHaveBeenCalledWith(['exec-1', 'exec-2']);
 			expect(binaryDataService.deleteMany).toHaveBeenCalledWith([
@@ -62,7 +62,7 @@ describe('ExecutionPersistence', () => {
 		});
 
 		it('should skip all operations when given empty array', async () => {
-			await executionPersistence.delete([]);
+			await executionPersistence.hardDelete([]);
 
 			expect(executionRepository.deleteByIds).not.toHaveBeenCalled();
 			expect(binaryDataService.deleteMany).not.toHaveBeenCalled();

--- a/packages/cli/src/executions/__tests__/execution-persistence.test.ts
+++ b/packages/cli/src/executions/__tests__/execution-persistence.test.ts
@@ -1,0 +1,72 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+
+import type { ExecutionRepository } from '@n8n/db';
+import { mock } from 'jest-mock-extended';
+import type { BinaryDataService } from 'n8n-core';
+
+import type { FsStore } from '@/executions/execution-data/fs-store';
+import { ExecutionPersistence } from '@/executions/execution-persistence';
+
+describe('ExecutionPersistence', () => {
+	const executionRepository = mock<ExecutionRepository>();
+	const binaryDataService = mock<BinaryDataService>();
+	const fsStore = mock<FsStore>();
+
+	const executionPersistence = new ExecutionPersistence(
+		executionRepository,
+		binaryDataService,
+		fsStore,
+	);
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('delete', () => {
+		const baseTarget = { workflowId: 'wf-1', executionId: 'exec-1' };
+
+		it('should delete execution, binary data, and fs data when storedAt is fs', async () => {
+			const target = { ...baseTarget, storedAt: 'fs' as const };
+
+			await executionPersistence.delete(target);
+
+			expect(executionRepository.deleteByIds).toHaveBeenCalledWith(['exec-1']);
+			expect(binaryDataService.deleteMany).toHaveBeenCalledWith([{ type: 'execution', ...target }]);
+			expect(fsStore.delete).toHaveBeenCalledWith([target]);
+		});
+
+		it('should delete execution and binary data but not fs data when storedAt is db', async () => {
+			const target = { ...baseTarget, storedAt: 'db' as const };
+
+			await executionPersistence.delete(target);
+
+			expect(executionRepository.deleteByIds).toHaveBeenCalledWith(['exec-1']);
+			expect(binaryDataService.deleteMany).toHaveBeenCalledWith([{ type: 'execution', ...target }]);
+			expect(fsStore.delete).not.toHaveBeenCalled();
+		});
+
+		it('should handle array of targets', async () => {
+			const targets = [
+				{ workflowId: 'wf-1', executionId: 'exec-1', storedAt: 'fs' as const },
+				{ workflowId: 'wf-2', executionId: 'exec-2', storedAt: 'db' as const },
+			];
+
+			await executionPersistence.delete(targets);
+
+			expect(executionRepository.deleteByIds).toHaveBeenCalledWith(['exec-1', 'exec-2']);
+			expect(binaryDataService.deleteMany).toHaveBeenCalledWith([
+				{ type: 'execution', ...targets[0] },
+				{ type: 'execution', ...targets[1] },
+			]);
+			expect(fsStore.delete).toHaveBeenCalledWith([targets[0]]);
+		});
+
+		it('should skip all operations when given empty array', async () => {
+			await executionPersistence.delete([]);
+
+			expect(executionRepository.deleteByIds).not.toHaveBeenCalled();
+			expect(binaryDataService.deleteMany).not.toHaveBeenCalled();
+			expect(fsStore.delete).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/cli/src/executions/__tests__/execution.service.test.ts
+++ b/packages/cli/src/executions/__tests__/execution.service.test.ts
@@ -32,6 +32,7 @@ describe('ExecutionService', () => {
 		executionRepository,
 		mock(),
 		mock(),
+		mock(),
 		waitTracker,
 		mock(),
 		concurrencyControl,

--- a/packages/cli/src/executions/__tests__/failed-run-factory.test.ts
+++ b/packages/cli/src/executions/__tests__/failed-run-factory.test.ts
@@ -1,11 +1,13 @@
 import { mock } from 'jest-mock-extended';
+import type { StorageConfig } from 'n8n-core';
 import { NodeOperationError } from 'n8n-workflow';
 import type { INode, WorkflowExecuteMode } from 'n8n-workflow';
 
 import { FailedRunFactory } from '../failed-run-factory';
 
 describe('FailedRunFactory', () => {
-	const service = new FailedRunFactory();
+	const storageConfig = mock<StorageConfig>({ mode: 'database' });
+	const service = new FailedRunFactory(storageConfig);
 
 	describe('generateFailedExecutionFromError', () => {
 		const mode: WorkflowExecuteMode = 'manual';

--- a/packages/cli/src/executions/execution-persistence.ts
+++ b/packages/cli/src/executions/execution-persistence.ts
@@ -1,0 +1,50 @@
+import type { ExecutionDataStorageLocation } from '@n8n/db';
+import { ExecutionRepository } from '@n8n/db';
+import { Service } from '@n8n/di';
+import { BinaryDataService } from 'n8n-core';
+
+import { FsStore } from './execution-data/fs-store';
+import type { ExecutionRef } from './execution-data/types';
+
+type DeletionTarget = ExecutionRef & { storedAt: ExecutionDataStorageLocation };
+
+/**
+ * Performs a persistence operation on an execution and its blob of data.
+ * Writes per the configured storage mode. Reads per the recorded `storedAt` value.
+ */
+@Service()
+export class ExecutionPersistence {
+	constructor(
+		private readonly executionRepository: ExecutionRepository,
+		private readonly binaryDataService: BinaryDataService,
+		private readonly fsStore: FsStore,
+	) {}
+
+	async delete(target: DeletionTarget | DeletionTarget[]) {
+		const targets = Array.isArray(target) ? target : [target];
+		if (targets.length === 0) return;
+
+		const fsTargets = targets.filter((t) => t.storedAt === 'fs');
+
+		await Promise.all([
+			this.executionRepository.deleteByIds(targets.map((t) => t.executionId)),
+			this.binaryDataService.deleteMany(targets.map((t) => ({ type: 'execution' as const, ...t }))),
+			fsTargets.length > 0 ? this.fsStore.delete(fsTargets) : Promise.resolve(),
+		]);
+	}
+
+	async deleteBy(
+		filters: Parameters<typeof this.executionRepository.deleteExecutionsByFilter>[0],
+		accessibleWorkflowIds: Parameters<typeof this.executionRepository.deleteExecutionsByFilter>[1],
+		deleteConditions: Parameters<typeof this.executionRepository.deleteExecutionsByFilter>[2],
+	) {
+		const refs = await this.executionRepository.deleteExecutionsByFilter(
+			filters,
+			accessibleWorkflowIds,
+			deleteConditions,
+		);
+
+		const fsRefs = refs.filter((r) => r.storedAt === 'fs');
+		if (fsRefs.length > 0) await this.fsStore.delete(fsRefs);
+	}
+}

--- a/packages/cli/src/executions/execution-persistence.ts
+++ b/packages/cli/src/executions/execution-persistence.ts
@@ -1,4 +1,4 @@
-import type { ExecutionDataStorageLocation } from '@n8n/db';
+import type { ExecutionDataStorageLocation, ExecutionDeletionCriteria } from '@n8n/db';
 import { ExecutionRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { BinaryDataService } from 'n8n-core';
@@ -20,7 +20,7 @@ export class ExecutionPersistence {
 		private readonly fsStore: FsStore,
 	) {}
 
-	async delete(target: DeletionTarget | DeletionTarget[]) {
+	async hardDelete(target: DeletionTarget | DeletionTarget[]) {
 		const targets = Array.isArray(target) ? target : [target];
 		if (targets.length === 0) return;
 
@@ -33,16 +33,8 @@ export class ExecutionPersistence {
 		]);
 	}
 
-	async deleteBy(
-		filters: Parameters<typeof this.executionRepository.deleteExecutionsByFilter>[0],
-		accessibleWorkflowIds: Parameters<typeof this.executionRepository.deleteExecutionsByFilter>[1],
-		deleteConditions: Parameters<typeof this.executionRepository.deleteExecutionsByFilter>[2],
-	) {
-		const refs = await this.executionRepository.deleteExecutionsByFilter(
-			filters,
-			accessibleWorkflowIds,
-			deleteConditions,
-		);
+	async hardDeleteBy(criteria: ExecutionDeletionCriteria) {
+		const refs = await this.executionRepository.deleteExecutionsByFilter(criteria);
 
 		const fsRefs = refs.filter((r) => r.storedAt === 'fs');
 		if (fsRefs.length > 0) await this.fsStore.delete(fsRefs);

--- a/packages/cli/src/executions/execution-recovery.service.ts
+++ b/packages/cli/src/executions/execution-recovery.service.ts
@@ -271,6 +271,7 @@ export class ExecutionRecoveryService {
 			startedAt: execution.startedAt,
 			stoppedAt: execution.stoppedAt,
 			status: execution.status,
+			storedAt: execution.storedAt,
 		};
 
 		await lifecycleHooks.runHook('workflowExecuteAfter', [run]);

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -323,9 +323,10 @@ export class ExecutionService {
 			delete requestFilters.metadata;
 		}
 
-		await this.executionPersistence.deleteBy(requestFilters, sharedWorkflowIds, {
-			deleteBefore,
-			ids,
+		await this.executionPersistence.hardDeleteBy({
+			filters: requestFilters,
+			accessibleWorkflowIds: sharedWorkflowIds,
+			deleteConditions: { deleteBefore, ids },
 		});
 
 		this.eventService.emit('execution-deleted', {

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -49,6 +49,7 @@ import { WaitTracker } from '@/wait-tracker';
 import { WorkflowRunner } from '@/workflow-runner';
 import { WorkflowSharingService } from '@/workflows/workflow-sharing.service';
 
+import { ExecutionPersistence } from './execution-persistence';
 import type { ExecutionRequest, StopResult } from './execution.types';
 
 export const schemaGetExecutionsQueryFilter = {
@@ -104,6 +105,7 @@ export class ExecutionService {
 		private readonly executionAnnotationRepository: ExecutionAnnotationRepository,
 		private readonly annotationTagMappingRepository: AnnotationTagMappingRepository,
 		private readonly executionRepository: ExecutionRepository,
+		private readonly executionPersistence: ExecutionPersistence,
 		private readonly workflowRepository: WorkflowRepository,
 		private readonly nodeTypes: NodeTypes,
 		private readonly waitTracker: WaitTracker,
@@ -297,6 +299,7 @@ export class ExecutionService {
 			workflowData: execution.workflowData,
 			customData: execution.customData,
 			annotation: execution.annotation,
+			storedAt: execution.storedAt,
 		};
 	}
 
@@ -320,7 +323,7 @@ export class ExecutionService {
 			delete requestFilters.metadata;
 		}
 
-		await this.executionRepository.deleteExecutionsByFilter(requestFilters, sharedWorkflowIds, {
+		await this.executionPersistence.deleteBy(requestFilters, sharedWorkflowIds, {
 			deleteBefore,
 			ids,
 		});

--- a/packages/cli/src/executions/failed-run-factory.ts
+++ b/packages/cli/src/executions/failed-run-factory.ts
@@ -1,4 +1,5 @@
 import { Service } from '@n8n/di';
+import { StorageConfig } from 'n8n-core';
 import {
 	createRunExecutionData,
 	type ExecutionError,
@@ -9,6 +10,8 @@ import {
 
 @Service()
 export class FailedRunFactory {
+	constructor(private readonly storageConfig: StorageConfig) {}
+
 	generateFailedExecutionFromError(
 		mode: WorkflowExecuteMode,
 		error: ExecutionError,
@@ -32,6 +35,7 @@ export class FailedRunFactory {
 			startedAt: new Date(),
 			stoppedAt: new Date(),
 			status: 'error',
+			storedAt: this.storageConfig.mode === 'database' ? 'db' : 'fs',
 		};
 
 		if (node) {

--- a/packages/cli/src/executions/failed-run-factory.ts
+++ b/packages/cli/src/executions/failed-run-factory.ts
@@ -35,7 +35,7 @@ export class FailedRunFactory {
 			startedAt: new Date(),
 			stoppedAt: new Date(),
 			status: 'error',
-			storedAt: this.storageConfig.mode === 'database' ? 'db' : 'fs',
+			storedAt: this.storageConfig.modeTag,
 		};
 
 		if (node) {

--- a/packages/cli/src/interfaces.ts
+++ b/packages/cli/src/interfaces.ts
@@ -76,7 +76,7 @@ export type ICredentialsDecryptedResponse = ICredentialsDecryptedDb;
 export type SaveExecutionDataType = 'all' | 'none';
 
 /** Payload for updating an execution. */
-export type UpdateExecutionPayload = Omit<IExecutionDb, 'id' | 'createdAt'>;
+export type UpdateExecutionPayload = Omit<IExecutionDb, 'id' | 'createdAt' | 'storedAt'>;
 
 // Flatted data to save memory when saving in database or transferring
 // via REST API

--- a/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
@@ -53,7 +53,7 @@ export = {
 				});
 			}
 
-			await Container.get(ExecutionPersistence).delete({
+			await Container.get(ExecutionPersistence).hardDelete({
 				workflowId: execution.workflowId,
 				executionId: execution.id,
 				storedAt: execution.storedAt,

--- a/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
@@ -9,6 +9,7 @@ import { AbortedExecutionRetryError } from '@/errors/aborted-execution-retry.err
 import { QueuedExecutionRetryError } from '@/errors/queued-execution-retry.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { EventService } from '@/events/event.service';
+import { ExecutionPersistence } from '@/executions/execution-persistence';
 import { ExecutionService } from '@/executions/execution.service';
 
 import type { ExecutionRequest } from '../../../types';
@@ -52,9 +53,10 @@ export = {
 				});
 			}
 
-			await Container.get(ExecutionRepository).hardDelete({
+			await Container.get(ExecutionPersistence).delete({
 				workflowId: execution.workflowId,
 				executionId: execution.id,
+				storedAt: execution.storedAt,
 			});
 
 			execution.id = id;

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -223,6 +223,7 @@ export class JobProcessor {
 						startedAt: now,
 						stoppedAt: now,
 						data: createRunExecutionData({ resultData: { error, runData: {} } }),
+						storedAt: execution.storedAt,
 					};
 
 					await lifecycleHooks.runHook('workflowExecuteAfter', [runData]);

--- a/packages/cli/src/services/__tests__/workflow-statistics.service.integration.test.ts
+++ b/packages/cli/src/services/__tests__/workflow-statistics.service.integration.test.ts
@@ -72,6 +72,7 @@ describe('WorkflowStatisticsService', () => {
 					data: createEmptyRunExecutionData(),
 					mode,
 					startedAt: new Date(),
+					storedAt: 'db',
 				};
 
 				// ACT
@@ -104,6 +105,7 @@ describe('WorkflowStatisticsService', () => {
 					data: createEmptyRunExecutionData(),
 					mode,
 					startedAt: new Date(),
+					storedAt: 'db',
 				};
 
 				// ACT
@@ -132,6 +134,7 @@ describe('WorkflowStatisticsService', () => {
 				data: createEmptyRunExecutionData(),
 				mode: 'chat',
 				startedAt: new Date(),
+				storedAt: 'db',
 			};
 
 			// ACT
@@ -153,6 +156,7 @@ describe('WorkflowStatisticsService', () => {
 					data: createEmptyRunExecutionData(),
 					mode: 'trigger',
 					startedAt: new Date(),
+					storedAt: 'db',
 				};
 
 				// ACT
@@ -185,6 +189,7 @@ describe('WorkflowStatisticsService', () => {
 					// status used
 					mode: 'trigger',
 					startedAt: new Date(),
+					storedAt: 'db',
 				};
 
 				// ACT
@@ -213,6 +218,7 @@ describe('WorkflowStatisticsService', () => {
 				data: createEmptyRunExecutionData(),
 				mode: 'internal',
 				startedAt: new Date(),
+				storedAt: 'db',
 			};
 			const emitSpy = jest.spyOn(Container.get(EventService), 'emit');
 			const updateSettingsSpy = jest.spyOn(userService, 'updateSettings');
@@ -243,6 +249,7 @@ describe('WorkflowStatisticsService', () => {
 				data: createEmptyRunExecutionData(),
 				mode: 'internal',
 				startedAt: new Date(),
+				storedAt: 'db',
 			};
 			const emitSpy = jest.spyOn(Container.get(EventService), 'emit');
 			const updateSettingsSpy = jest.spyOn(userService, 'updateSettings');
@@ -266,6 +273,7 @@ describe('WorkflowStatisticsService', () => {
 				data: createEmptyRunExecutionData(),
 				mode: 'internal',
 				startedAt: new Date(),
+				storedAt: 'db',
 			};
 			await workflowStatisticsService.workflowExecutionCompleted(workflow, runData);
 			const emitSpy = jest.spyOn(Container.get(EventService), 'emit');
@@ -287,6 +295,7 @@ describe('WorkflowStatisticsService', () => {
 				data: createEmptyRunExecutionData(),
 				mode: 'trigger',
 				startedAt: new Date(),
+				storedAt: 'db',
 			};
 
 			// Create a fresh instance with workflowRepository returning false (no error workflows exist)
@@ -328,6 +337,7 @@ describe('WorkflowStatisticsService', () => {
 				data: createEmptyRunExecutionData(),
 				mode: 'trigger',
 				startedAt: new Date(),
+				storedAt: 'db',
 			};
 
 			// Create a fresh instance with workflowRepository returning false (no error workflows exist)
@@ -367,6 +377,7 @@ describe('WorkflowStatisticsService', () => {
 				data: createEmptyRunExecutionData(),
 				mode: 'trigger',
 				startedAt: new Date(),
+				storedAt: 'db',
 			};
 
 			// Create a fresh instance with workflowRepository returning true (error workflows exist)
@@ -406,6 +417,7 @@ describe('WorkflowStatisticsService', () => {
 				data: createEmptyRunExecutionData(),
 				mode: 'manual', // non-production mode
 				startedAt: new Date(),
+				storedAt: 'db',
 			};
 			const emitSpy = jest.spyOn(Container.get(EventService), 'emit');
 
@@ -428,6 +440,7 @@ describe('WorkflowStatisticsService', () => {
 				data: createEmptyRunExecutionData(),
 				mode: 'internal',
 				startedAt: new Date(),
+				storedAt: 'db',
 			};
 			const emitSpy = jest.spyOn(Container.get(EventService), 'emit');
 			const updateSettingsSpy = jest.spyOn(userService, 'updateSettings');
@@ -455,6 +468,7 @@ describe('WorkflowStatisticsService', () => {
 				data: createEmptyRunExecutionData(),
 				mode: 'trigger',
 				startedAt: new Date(),
+				storedAt: 'db',
 			};
 
 			// Create a fresh instance with workflowRepository returning false (no error workflows exist)

--- a/packages/cli/src/services/pruning/executions-pruning.service.ts
+++ b/packages/cli/src/services/pruning/executions-pruning.service.ts
@@ -4,9 +4,11 @@ import { Time } from '@n8n/constants';
 import { ExecutionRepository, DbConnection } from '@n8n/db';
 import { OnLeaderStepdown, OnLeaderTakeover, OnShutdown } from '@n8n/decorators';
 import { Service } from '@n8n/di';
-import { BinaryDataService, InstanceSettings } from 'n8n-core';
+import { InstanceSettings } from 'n8n-core';
 import { ensureError } from 'n8n-workflow';
 import { strict } from 'node:assert';
+
+import { ExecutionPersistence } from '@/executions/execution-persistence';
 
 /**
  * Responsible for deleting old executions from the database and deleting their
@@ -44,7 +46,7 @@ export class ExecutionsPruningService {
 		private readonly instanceSettings: InstanceSettings,
 		private readonly dbConnection: DbConnection,
 		private readonly executionRepository: ExecutionRepository,
-		private readonly binaryDataService: BinaryDataService,
+		private readonly executionPersistence: ExecutionPersistence,
 		private readonly executionsConfig: ExecutionsConfig,
 	) {
 		this.logger = this.logger.scoped('pruning');
@@ -131,20 +133,18 @@ export class ExecutionsPruningService {
 	 * @returns Delay in milliseconds until next hard-deletion
 	 */
 	private async hardDelete(): Promise<number> {
-		const ids = await this.executionRepository.findSoftDeletedExecutions();
+		const refs = await this.executionRepository.findSoftDeletedExecutions();
 
-		const executionIds = ids.map((o) => o.executionId);
-
-		if (executionIds.length === 0) {
+		if (refs.length === 0) {
 			this.logger.debug('Found no executions to hard-delete');
 
 			return this.rates.hardDeletion;
 		}
 
-		try {
-			await this.binaryDataService.deleteMany(ids);
+		const executionIds = refs.map((r) => r.executionId);
 
-			await this.executionRepository.deleteByIds(executionIds);
+		try {
+			await this.executionPersistence.delete(refs);
 
 			this.logger.debug('Hard-deleted executions', { executionIds });
 		} catch (error) {
@@ -155,7 +155,7 @@ export class ExecutionsPruningService {
 		}
 
 		// if high volume, speed up next hard-deletion
-		if (executionIds.length >= this.batchSize) return 1 * Time.seconds.toMilliseconds;
+		if (refs.length >= this.batchSize) return 1 * Time.seconds.toMilliseconds;
 
 		return this.rates.hardDeletion;
 	}

--- a/packages/cli/src/services/pruning/executions-pruning.service.ts
+++ b/packages/cli/src/services/pruning/executions-pruning.service.ts
@@ -144,7 +144,7 @@ export class ExecutionsPruningService {
 		const executionIds = refs.map((r) => r.executionId);
 
 		try {
-			await this.executionPersistence.delete(refs);
+			await this.executionPersistence.hardDelete(refs);
 
 			this.logger.debug('Hard-deleted executions', { executionIds });
 		} catch (error) {

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -121,7 +121,7 @@ export class WorkflowRunner {
 			startedAt,
 			stoppedAt: new Date(),
 			status: 'error',
-			storedAt: this.storageConfig.mode === 'database' ? 'db' : 'fs',
+			storedAt: this.storageConfig.modeTag,
 		};
 
 		// Remove from active execution with empty data. That will

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -7,7 +7,7 @@ import { ExecutionsConfig } from '@n8n/config';
 import { ExecutionRepository } from '@n8n/db';
 import { Container, Service } from '@n8n/di';
 import type { ExecutionLifecycleHooks } from 'n8n-core';
-import { ErrorReporter, InstanceSettings, WorkflowExecute } from 'n8n-core';
+import { ErrorReporter, InstanceSettings, StorageConfig, WorkflowExecute } from 'n8n-core';
 import type {
 	ExecutionError,
 	IDeferredPromise,
@@ -63,6 +63,7 @@ export class WorkflowRunner {
 		private readonly failedRunFactory: FailedRunFactory,
 		private readonly eventService: EventService,
 		private readonly executionsConfig: ExecutionsConfig,
+		private readonly storageConfig: StorageConfig,
 	) {}
 
 	/** The process did error */
@@ -120,6 +121,7 @@ export class WorkflowRunner {
 			startedAt,
 			stoppedAt: new Date(),
 			status: 'error',
+			storedAt: this.storageConfig.mode === 'database' ? 'db' : 'fs',
 		};
 
 		// Remove from active execution with empty data. That will
@@ -475,6 +477,7 @@ export class WorkflowRunner {
 					status: fullExecutionData.status,
 					data: fullExecutionData.data,
 					jobId: job.id.toString(),
+					storedAt: fullExecutionData.storedAt,
 				};
 
 				this.activeExecutions.finalizeExecution(executionId, runData);

--- a/packages/cli/test/integration/execution.service.integration.test.ts
+++ b/packages/cli/test/integration/execution.service.integration.test.ts
@@ -26,6 +26,7 @@ describe('ExecutionService', () => {
 			mock(),
 			mock(),
 			executionRepository,
+			mock(),
 			Container.get(WorkflowRepository),
 			mock(),
 			mock(),

--- a/packages/cli/test/integration/executions-pruning.service.test.ts
+++ b/packages/cli/test/integration/executions-pruning.service.test.ts
@@ -4,9 +4,10 @@ import { Time } from '@n8n/constants';
 import type { ExecutionEntity } from '@n8n/db';
 import { ExecutionRepository, DbConnection } from '@n8n/db';
 import { Container } from '@n8n/di';
-import { BinaryDataService, InstanceSettings } from 'n8n-core';
+import { InstanceSettings } from 'n8n-core';
 import type { ExecutionStatus, IWorkflowBase } from 'n8n-workflow';
 
+import { ExecutionPersistence } from '@/executions/execution-persistence';
 import { ExecutionsPruningService } from '@/services/pruning/executions-pruning.service';
 
 import {
@@ -34,7 +35,7 @@ describe('softDeleteOnPruningCycle()', () => {
 			instanceSettings,
 			Container.get(DbConnection),
 			Container.get(ExecutionRepository),
-			mockInstance(BinaryDataService),
+			mockInstance(ExecutionPersistence),
 			executionsConfig,
 		);
 

--- a/packages/cli/test/integration/shared/utils/index.ts
+++ b/packages/cli/test/integration/shared/utils/index.ts
@@ -43,6 +43,7 @@ export async function initActiveWorkflowManager() {
 	mockInstance(BinaryDataConfig);
 	mockInstance(InstanceSettings, {
 		isMultiMain: false,
+		n8nFolder: '/tmp/n8n-test',
 	});
 
 	mockInstance(Push);

--- a/packages/cli/test/integration/workflow-helpers.test.ts
+++ b/packages/cli/test/integration/workflow-helpers.test.ts
@@ -60,6 +60,7 @@ describe('workflow-helpers', () => {
 			const childResults: IRun = {
 				mode: 'manual',
 				startedAt: new Date(),
+				storedAt: 'db',
 				status: 'success',
 				data: createRunExecutionData({
 					resultData: {
@@ -124,6 +125,7 @@ describe('workflow-helpers', () => {
 			const childResults: IRun = {
 				mode: 'manual',
 				startedAt: new Date(),
+				storedAt: 'db',
 				status: 'success',
 				data: createRunExecutionData({
 					resultData: {
@@ -180,6 +182,7 @@ describe('workflow-helpers', () => {
 			const childResults: IRun = {
 				mode: 'manual',
 				startedAt: new Date(),
+				storedAt: 'db',
 				status: 'success',
 				data: createRunExecutionData({ resultData: { runData: {} } }),
 			};
@@ -235,6 +238,7 @@ describe('workflow-helpers', () => {
 			const childResults: IRun = {
 				mode: 'manual',
 				startedAt: new Date(),
+				storedAt: 'db',
 				status: 'success',
 				data: createRunExecutionData({
 					resultData: {

--- a/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
@@ -1959,6 +1959,7 @@ describe('WorkflowExecute', () => {
 				mode: 'manual',
 				startedAt,
 				stoppedAt: startedAt,
+				storedAt: 'db',
 				status: 'new',
 			});
 
@@ -1974,6 +1975,7 @@ describe('WorkflowExecute', () => {
 				mode: 'manual',
 				startedAt,
 				stoppedAt,
+				storedAt: 'db',
 				status: 'running',
 			});
 		});

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -11,6 +11,7 @@ import get from 'lodash/get';
 import type {
 	ExecutionBaseError,
 	ExecutionStatus,
+	ExecutionStorageLocation,
 	GenericValue,
 	IConnection,
 	IDataObject,
@@ -107,6 +108,7 @@ export class WorkflowExecute {
 		private readonly additionalData: IWorkflowExecuteAdditionalData,
 		private readonly mode: WorkflowExecuteMode,
 		private runExecutionData: IRunExecutionData = createRunExecutionData(),
+		private readonly storedAt: ExecutionStorageLocation = 'db',
 	) {}
 
 	/**
@@ -2481,6 +2483,7 @@ export class WorkflowExecute {
 			mode: this.mode,
 			startedAt,
 			stoppedAt: stoppedAt ?? new Date(),
+			storedAt: this.storedAt,
 			status: this.status,
 		};
 	}

--- a/packages/core/src/storage.config.ts
+++ b/packages/core/src/storage.config.ts
@@ -15,6 +15,10 @@ export class StorageConfig {
 	@Env('N8N_EXECUTION_DATA_STORAGE_MODE', modeSchema)
 	mode: z.infer<typeof modeSchema> = 'database';
 
+	get modeTag(): 'db' | 'fs' {
+		return this.mode === 'database' ? 'db' : 'fs';
+	}
+
 	/** Base path for filesystem storage. Defaults to `~/.n8n/storage`. */
 	@Env('N8N_STORAGE_PATH')
 	storagePath: string;

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -105,6 +105,8 @@ export type ExecutionError =
 	| NodeOperationError
 	| NodeApiError;
 
+export type ExecutionStorageLocation = 'db' | 'fs';
+
 // Get used to gives nodes access to credentials
 export interface IGetCredentials {
 	get(type: string, id: string | null): Promise<ICredentialsEncrypted>;
@@ -2505,6 +2507,7 @@ export interface IRun {
 	waitTill?: Date | null;
 	startedAt: Date;
 	stoppedAt?: Date;
+	storedAt: ExecutionStorageLocation;
 	status: ExecutionStatus;
 
 	/** ID of the job this execution belongs to. Only in scaling mode. */

--- a/packages/workflow/test/telemetry-helpers.test.ts
+++ b/packages/workflow/test/telemetry-helpers.test.ts
@@ -2874,6 +2874,7 @@ describe('extractLastExecutedNodeStructuredOutputErrorInfo', () => {
 		status: error ? 'error' : 'success',
 		startedAt: new Date(),
 		stoppedAt: new Date(),
+		storedAt: 'db',
 		data: {
 			startData: {},
 			resultData: {

--- a/packages/workflow/test/workflow-data-proxy.test.ts
+++ b/packages/workflow/test/workflow-data-proxy.test.ts
@@ -259,6 +259,7 @@ describe('WorkflowDataProxy', () => {
 			mode: 'manual',
 			startedAt: new Date(),
 			status: 'success',
+			storedAt: 'db',
 		});
 
 		describe('Default behavior (no binaryMode or separate mode)', () => {
@@ -1163,6 +1164,7 @@ describe('WorkflowDataProxy', () => {
 					mode: 'manual',
 					startedAt: new Date(),
 					status: 'success',
+					storedAt: 'db',
 				},
 				'Execute Workflow',
 				'manual',
@@ -1491,6 +1493,7 @@ describe('WorkflowDataProxy', () => {
 				mode: 'manual' as const,
 				startedAt: new Date(),
 				status: 'success' as const,
+				storedAt: 'db' as const,
 			};
 
 			const proxy = getProxyFromFixture(workflow, run, 'Send a text message');
@@ -1553,6 +1556,7 @@ describe('WorkflowDataProxy', () => {
 				mode: 'manual' as const,
 				startedAt: new Date(),
 				status: 'success' as const,
+				storedAt: 'db' as const,
 			};
 
 			const proxy = getProxyFromFixture(workflow, run, 'Process Data');
@@ -1611,6 +1615,7 @@ describe('WorkflowDataProxy', () => {
 				mode: 'manual' as const,
 				startedAt: new Date(),
 				status: 'success' as const,
+				storedAt: 'db' as const,
 			};
 
 			const proxy = getProxyFromFixture(workflow, run, 'End Node');
@@ -1698,6 +1703,7 @@ describe('WorkflowDataProxy', () => {
 				mode: 'manual' as const,
 				startedAt: new Date(),
 				status: 'success' as const,
+				storedAt: 'db' as const,
 			};
 
 			const proxy = getProxyFromFixture(workflow, run, 'Real Node');


### PR DESCRIPTION
## Summary

- Introduce the `ExecutionPersistence` service to centralize management of an execution entities and their associated data wherever located
- Add `ExecutionPersistence.delete` and `deleteBy` and use them at callsites
- Add `storedAt` to `IRun` and `IExecutionBase` to track storage location through the lifecycle

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2103

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
