### PR TITLE
ci: Extract GHCR cleanup to shared script and add scheduled cleanup

### DIFF
--- a/.github/scripts/cleanup-ghcr-images.mjs
+++ b/.github/scripts/cleanup-ghcr-images.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/**
+ * Cleanup GHCR images for n8n CI
+ *
+ * Usage:
+ *   node cleanup-ghcr-images.mjs --tag <tag>     # Delete specific tag
+ *   node cleanup-ghcr-images.mjs --pr <number>   # Delete all pr-{number}-* tags
+ *   node cleanup-ghcr-images.mjs --stale <days>  # Delete all pr-* images older than N days
+ *
+ * Options:
+ *   --dry-run    Show what would be deleted without actually deleting
+ *
+ * Environment:
+ *   GH_TOKEN     GitHub token with packages:write permission (required)
+ */
+
+import { execSync } from 'child_process';
+
+const ORG = 'n8n-io';
+const PACKAGES = ['n8n', 'runners'];
+
+function parseArgs() {
+	const args = process.argv.slice(2);
+	const options = { dryRun: false };
+
+	for (let i = 0; i < args.length; i++) {
+		switch (args[i]) {
+			case '--tag':
+				options.tag = args[++i];
+				break;
+			case '--pr':
+				options.pr = args[++i];
+				break;
+			case '--stale':
+				options.stale = parseInt(args[++i], 10);
+				break;
+			case '--dry-run':
+				options.dryRun = true;
+				break;
+		}
+	}
+
+	const modes = [options.tag, options.pr, options.stale].filter(Boolean).length;
+	if (modes !== 1) {
+		console.error('Error: Specify exactly one of --tag, --pr, or --stale');
+		process.exit(1);
+	}
+
+	return options;
+}
+
+function gh(args, { json = true, ignoreError = false } = {}) {
+	const cmd = `gh api ${args}`;
+	try {
+		const output = execSync(cmd, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+		return json ? JSON.parse(output) : output;
+	} catch (error) {
+		if (ignoreError) return json ? [] : '';
+		throw error;
+	}
+}
+
+function getPackageVersions(packageName) {
+	// Paginate through all versions
+	const versions = [];
+	let page = 1;
+	while (true) {
+		const batch = gh(
+			`"/orgs/${ORG}/packages/container/${packageName}/versions?per_page=100&page=${page}" -H "Accept: application/vnd.github+json"`,
+			{ ignoreError: true },
+		);
+		if (!batch.length) break;
+		versions.push(...batch);
+		if (batch.length < 100) break;
+		page++;
+	}
+	return versions;
+}
+
+function deleteVersion(packageName, versionId, tags, dryRun) {
+	const tagStr = tags.join(', ');
+	if (dryRun) {
+		console.log(`  [dry-run] Would delete ${packageName}:${tagStr} (id: ${versionId})`);
+		return;
+	}
+
+	try {
+		gh(
+			`--method DELETE "/orgs/${ORG}/packages/container/${packageName}/versions/${versionId}" -H "Accept: application/vnd.github+json"`,
+			{ json: false },
+		);
+		console.log(`  Deleted ${packageName}:${tagStr}`);
+	} catch {
+		console.log(`  Failed to delete ${packageName}:${tagStr}`);
+	}
+}
+
+function deleteByTag(tag, dryRun) {
+	console.log(`Deleting images with tag: ${tag}`);
+
+	for (const packageName of PACKAGES) {
+		const versions = getPackageVersions(packageName);
+		const match = versions.find((v) => v.metadata?.container?.tags?.includes(tag));
+
+		if (match) {
+			deleteVersion(packageName, match.id, match.metadata.container.tags, dryRun);
+		} else {
+			console.log(`  ${packageName}:${tag} not found`);
+		}
+	}
+}
+
+function deleteByPr(prNumber, dryRun) {
+	const prefix = `pr-${prNumber}-`;
+	console.log(`Deleting all images matching: ${prefix}*`);
+
+	for (const packageName of PACKAGES) {
+		const versions = getPackageVersions(packageName);
+		const matches = versions.filter((v) =>
+			v.metadata?.container?.tags?.some((t) => t.startsWith(prefix)),
+		);
+
+		if (matches.length === 0) {
+			console.log(`  No ${packageName} images found for PR #${prNumber}`);
+			continue;
+		}
+
+		for (const version of matches) {
+			deleteVersion(packageName, version.id, version.metadata.container.tags, dryRun);
+		}
+	}
+}
+
+function deleteStale(days, dryRun) {
+	const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+	console.log(`Deleting pr-* images older than ${days} days (before ${cutoff.toISOString()})`);
+
+	for (const packageName of PACKAGES) {
+		const versions = getPackageVersions(packageName);
+		const stale = versions.filter((v) => {
+			const tags = v.metadata?.container?.tags || [];
+			const isPrImage = tags.some((t) => t.startsWith('pr-'));
+			const createdAt = new Date(v.created_at);
+			return isPrImage && createdAt < cutoff;
+		});
+
+		if (stale.length === 0) {
+			console.log(`  No stale ${packageName} images found`);
+			continue;
+		}
+
+		console.log(`  Found ${stale.length} stale ${packageName} images`);
+		for (const version of stale) {
+			deleteVersion(packageName, version.id, version.metadata.container.tags, dryRun);
+		}
+	}
+}
+
+// Main
+const options = parseArgs();
+
+if (options.tag) {
+	deleteByTag(options.tag, options.dryRun);
+} else if (options.pr) {
+	deleteByPr(options.pr, options.dryRun);
+} else if (options.stale) {
+	deleteStale(options.stale, options.dryRun);
+}
+
+console.log('Done');

--- a/.github/scripts/cleanup-ghcr-images.mjs
+++ b/.github/scripts/cleanup-ghcr-images.mjs
@@ -7,9 +7,6 @@
  *   node cleanup-ghcr-images.mjs --pr <number>   # Delete all pr-{number}-* tags
  *   node cleanup-ghcr-images.mjs --stale <days>  # Delete all pr-* images older than N days
  *
- * Options:
- *   --dry-run    Show what would be deleted without actually deleting
- *
  * Environment:
  *   GH_TOKEN     GitHub token with packages:write permission (required)
  */
@@ -19,24 +16,41 @@ import { execSync } from 'child_process';
 const ORG = 'n8n-io';
 const PACKAGES = ['n8n', 'runners'];
 
+let hasErrors = false;
+
 function parseArgs() {
 	const args = process.argv.slice(2);
-	const options = { dryRun: false };
+	const options = {};
 
 	for (let i = 0; i < args.length; i++) {
 		switch (args[i]) {
 			case '--tag':
+				if (i + 1 >= args.length || args[i + 1].startsWith('--')) {
+					console.error('Error: --tag requires a value');
+					process.exit(1);
+				}
 				options.tag = args[++i];
 				break;
 			case '--pr':
+				if (i + 1 >= args.length || args[i + 1].startsWith('--')) {
+					console.error('Error: --pr requires a value');
+					process.exit(1);
+				}
 				options.pr = args[++i];
 				break;
-			case '--stale':
-				options.stale = parseInt(args[++i], 10);
+			case '--stale': {
+				if (i + 1 >= args.length || args[i + 1].startsWith('--')) {
+					console.error('Error: --stale requires a value');
+					process.exit(1);
+				}
+				const days = parseInt(args[++i], 10);
+				if (isNaN(days) || days <= 0) {
+					console.error('Error: --stale requires a positive number');
+					process.exit(1);
+				}
+				options.stale = days;
 				break;
-			case '--dry-run':
-				options.dryRun = true;
-				break;
+			}
 		}
 	}
 
@@ -60,6 +74,15 @@ function gh(args, { json = true, ignoreError = false } = {}) {
 	}
 }
 
+function verifyAuth() {
+	try {
+		gh(`"/orgs/${ORG}/packages?package_type=container&per_page=1" -H "Accept: application/vnd.github+json"`);
+	} catch {
+		console.error('Error: Failed to authenticate with GitHub API. Check GH_TOKEN.');
+		process.exit(1);
+	}
+}
+
 function getPackageVersions(packageName) {
 	// Paginate through all versions
 	const versions = [];
@@ -77,12 +100,8 @@ function getPackageVersions(packageName) {
 	return versions;
 }
 
-function deleteVersion(packageName, versionId, tags, dryRun) {
+function deleteVersion(packageName, versionId, tags) {
 	const tagStr = tags.join(', ');
-	if (dryRun) {
-		console.log(`  [dry-run] Would delete ${packageName}:${tagStr} (id: ${versionId})`);
-		return;
-	}
 
 	try {
 		gh(
@@ -91,11 +110,12 @@ function deleteVersion(packageName, versionId, tags, dryRun) {
 		);
 		console.log(`  Deleted ${packageName}:${tagStr}`);
 	} catch {
-		console.log(`  Failed to delete ${packageName}:${tagStr}`);
+		console.error(`  Error: Failed to delete ${packageName}:${tagStr}`);
+		hasErrors = true;
 	}
 }
 
-function deleteByTag(tag, dryRun) {
+function deleteByTag(tag) {
 	console.log(`Deleting images with tag: ${tag}`);
 
 	for (const packageName of PACKAGES) {
@@ -103,14 +123,14 @@ function deleteByTag(tag, dryRun) {
 		const match = versions.find((v) => v.metadata?.container?.tags?.includes(tag));
 
 		if (match) {
-			deleteVersion(packageName, match.id, match.metadata.container.tags, dryRun);
+			deleteVersion(packageName, match.id, match.metadata.container.tags);
 		} else {
 			console.log(`  ${packageName}:${tag} not found`);
 		}
 	}
 }
 
-function deleteByPr(prNumber, dryRun) {
+function deleteByPr(prNumber) {
 	const prefix = `pr-${prNumber}-`;
 	console.log(`Deleting all images matching: ${prefix}*`);
 
@@ -126,12 +146,12 @@ function deleteByPr(prNumber, dryRun) {
 		}
 
 		for (const version of matches) {
-			deleteVersion(packageName, version.id, version.metadata.container.tags, dryRun);
+			deleteVersion(packageName, version.id, version.metadata.container.tags);
 		}
 	}
 }
 
-function deleteStale(days, dryRun) {
+function deleteStale(days) {
 	const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
 	console.log(`Deleting pr-* images older than ${days} days (before ${cutoff.toISOString()})`);
 
@@ -151,7 +171,7 @@ function deleteStale(days, dryRun) {
 
 		console.log(`  Found ${stale.length} stale ${packageName} images`);
 		for (const version of stale) {
-			deleteVersion(packageName, version.id, version.metadata.container.tags, dryRun);
+			deleteVersion(packageName, version.id, version.metadata.container.tags);
 		}
 	}
 }
@@ -159,12 +179,18 @@ function deleteStale(days, dryRun) {
 // Main
 const options = parseArgs();
 
+verifyAuth();
+
 if (options.tag) {
-	deleteByTag(options.tag, options.dryRun);
+	deleteByTag(options.tag);
 } else if (options.pr) {
-	deleteByPr(options.pr, options.dryRun);
+	deleteByPr(options.pr);
 } else if (options.stale) {
-	deleteStale(options.stale, options.dryRun);
+	deleteStale(options.stale);
 }
 
 console.log('Done');
+
+if (hasErrors) {
+	process.exit(1);
+}

--- a/.github/scripts/cleanup-ghcr-images.mjs
+++ b/.github/scripts/cleanup-ghcr-images.mjs
@@ -61,7 +61,9 @@ function shouldDelete(v) {
 }
 
 for (const pkg of PACKAGES) {
-	for (const v of getVersions(pkg).filter(shouldDelete)) {
+	const toDelete = getVersions(pkg).filter(shouldDelete);
+	if (!toDelete.length) console.log(`No matching images found for ${pkg}`);
+	for (const v of toDelete) {
 		ghApi(`${pkg}/versions/${v.id}`, true);
 		console.log(`Deleted ${pkg}:${v.metadata.container.tags.join(',')}`);
 	}

--- a/.github/scripts/cleanup-ghcr-images.mjs
+++ b/.github/scripts/cleanup-ghcr-images.mjs
@@ -11,7 +11,16 @@ import { execSync } from 'node:child_process';
 
 const ORG = 'n8n-io';
 const PACKAGES = ['n8n', 'runners'];
-const [mode, value] = process.argv.slice(2);
+const [mode, rawValue] = process.argv.slice(2);
+if (!['--tag', '--pr', '--stale'].includes(mode) || !rawValue) {
+	console.error('Usage: cleanup-ghcr-images.mjs --tag|--pr|--stale <value>');
+	process.exit(1);
+}
+const value = mode === '--stale' ? parseInt(rawValue, 10) : rawValue;
+if (mode === '--stale' && (!Number.isFinite(value) || value <= 0)) {
+	console.error('Error: --stale requires a positive number');
+	process.exit(1);
+}
 
 let hasErrors = false;
 

--- a/.github/scripts/cleanup-ghcr-images.mjs
+++ b/.github/scripts/cleanup-ghcr-images.mjs
@@ -5,192 +5,57 @@
  * Usage:
  *   node cleanup-ghcr-images.mjs --tag <tag>     # Delete specific tag
  *   node cleanup-ghcr-images.mjs --pr <number>   # Delete all pr-{number}-* tags
- *   node cleanup-ghcr-images.mjs --stale <days>  # Delete all pr-* images older than N days
- *
- * Environment:
- *   GH_TOKEN     GitHub token with packages:write permission (required)
+ *   node cleanup-ghcr-images.mjs --stale <days>  # Delete pr-* images older than N days
  */
-
-import { execSync } from 'child_process';
+import { execSync } from 'node:child_process';
 
 const ORG = 'n8n-io';
 const PACKAGES = ['n8n', 'runners'];
+const [mode, value] = process.argv.slice(2);
 
 let hasErrors = false;
 
-function parseArgs() {
-	const args = process.argv.slice(2);
-	const options = {};
-
-	for (let i = 0; i < args.length; i++) {
-		switch (args[i]) {
-			case '--tag':
-				if (i + 1 >= args.length || args[i + 1].startsWith('--')) {
-					console.error('Error: --tag requires a value');
-					process.exit(1);
-				}
-				options.tag = args[++i];
-				break;
-			case '--pr':
-				if (i + 1 >= args.length || args[i + 1].startsWith('--')) {
-					console.error('Error: --pr requires a value');
-					process.exit(1);
-				}
-				options.pr = args[++i];
-				break;
-			case '--stale': {
-				if (i + 1 >= args.length || args[i + 1].startsWith('--')) {
-					console.error('Error: --stale requires a value');
-					process.exit(1);
-				}
-				const days = parseInt(args[++i], 10);
-				if (isNaN(days) || days <= 0) {
-					console.error('Error: --stale requires a positive number');
-					process.exit(1);
-				}
-				options.stale = days;
-				break;
-			}
-		}
-	}
-
-	const modes = [options.tag, options.pr, options.stale].filter(Boolean).length;
-	if (modes !== 1) {
-		console.error('Error: Specify exactly one of --tag, --pr, or --stale');
-		process.exit(1);
-	}
-
-	return options;
-}
-
-function gh(args, { json = true, ignoreError = false } = {}) {
-	const cmd = `gh api ${args}`;
+function ghApi(path, del = false) {
+	const method = del ? '--method DELETE ' : '';
 	try {
-		const output = execSync(cmd, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
-		return json ? JSON.parse(output) : output;
-	} catch (error) {
-		if (ignoreError) return json ? [] : '';
-		throw error;
-	}
-}
-
-function verifyAuth() {
-	try {
-		gh(`"/orgs/${ORG}/packages?package_type=container&per_page=1" -H "Accept: application/vnd.github+json"`);
-	} catch {
-		console.error('Error: Failed to authenticate with GitHub API. Check GH_TOKEN.');
-		process.exit(1);
-	}
-}
-
-function getPackageVersions(packageName) {
-	// Paginate through all versions
-	const versions = [];
-	let page = 1;
-	while (true) {
-		const batch = gh(
-			`"/orgs/${ORG}/packages/container/${packageName}/versions?per_page=100&page=${page}" -H "Accept: application/vnd.github+json"`,
-			{ ignoreError: true },
+		const out = execSync(
+			`gh api ${method}"/orgs/${ORG}/packages/container/${path}" -H "Accept: application/vnd.github+json"`,
+			{ encoding: 'utf8', stdio: 'pipe' },
 		);
-		if (!batch.length) break;
+		return del ? null : JSON.parse(out);
+	} catch {
+		if (del) hasErrors = true;
+		return null;
+	}
+}
+
+function getVersions(pkg) {
+	const versions = [];
+	for (let page = 1; ; page++) {
+		const batch = ghApi(`${pkg}/versions?per_page=100&page=${page}`);
+		if (!batch?.length) break;
 		versions.push(...batch);
 		if (batch.length < 100) break;
-		page++;
 	}
 	return versions;
 }
 
-function deleteVersion(packageName, versionId, tags) {
-	const tagStr = tags.join(', ');
+function shouldDelete(v) {
+	const tags = v.metadata?.container?.tags || [];
+	if (mode === '--tag') return tags.includes(value);
+	if (mode === '--pr') return tags.some((t) => t.startsWith(`pr-${value}-`));
+	if (mode === '--stale') {
+		const cutoff = Date.now() - value * 86400000;
+		return tags.some((t) => t.startsWith('pr-')) && new Date(v.created_at) < cutoff;
+	}
+	return false;
+}
 
-	try {
-		gh(
-			`--method DELETE "/orgs/${ORG}/packages/container/${packageName}/versions/${versionId}" -H "Accept: application/vnd.github+json"`,
-			{ json: false },
-		);
-		console.log(`  Deleted ${packageName}:${tagStr}`);
-	} catch {
-		console.error(`  Error: Failed to delete ${packageName}:${tagStr}`);
-		hasErrors = true;
+for (const pkg of PACKAGES) {
+	for (const v of getVersions(pkg).filter(shouldDelete)) {
+		ghApi(`${pkg}/versions/${v.id}`, true);
+		console.log(`Deleted ${pkg}:${v.metadata.container.tags.join(',')}`);
 	}
 }
 
-function deleteByTag(tag) {
-	console.log(`Deleting images with tag: ${tag}`);
-
-	for (const packageName of PACKAGES) {
-		const versions = getPackageVersions(packageName);
-		const match = versions.find((v) => v.metadata?.container?.tags?.includes(tag));
-
-		if (match) {
-			deleteVersion(packageName, match.id, match.metadata.container.tags);
-		} else {
-			console.log(`  ${packageName}:${tag} not found`);
-		}
-	}
-}
-
-function deleteByPr(prNumber) {
-	const prefix = `pr-${prNumber}-`;
-	console.log(`Deleting all images matching: ${prefix}*`);
-
-	for (const packageName of PACKAGES) {
-		const versions = getPackageVersions(packageName);
-		const matches = versions.filter((v) =>
-			v.metadata?.container?.tags?.some((t) => t.startsWith(prefix)),
-		);
-
-		if (matches.length === 0) {
-			console.log(`  No ${packageName} images found for PR #${prNumber}`);
-			continue;
-		}
-
-		for (const version of matches) {
-			deleteVersion(packageName, version.id, version.metadata.container.tags);
-		}
-	}
-}
-
-function deleteStale(days) {
-	const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
-	console.log(`Deleting pr-* images older than ${days} days (before ${cutoff.toISOString()})`);
-
-	for (const packageName of PACKAGES) {
-		const versions = getPackageVersions(packageName);
-		const stale = versions.filter((v) => {
-			const tags = v.metadata?.container?.tags || [];
-			const isPrImage = tags.some((t) => t.startsWith('pr-'));
-			const createdAt = new Date(v.created_at);
-			return isPrImage && createdAt < cutoff;
-		});
-
-		if (stale.length === 0) {
-			console.log(`  No stale ${packageName} images found`);
-			continue;
-		}
-
-		console.log(`  Found ${stale.length} stale ${packageName} images`);
-		for (const version of stale) {
-			deleteVersion(packageName, version.id, version.metadata.container.tags);
-		}
-	}
-}
-
-// Main
-const options = parseArgs();
-
-verifyAuth();
-
-if (options.tag) {
-	deleteByTag(options.tag);
-} else if (options.pr) {
-	deleteByPr(options.pr);
-} else if (options.stale) {
-	deleteStale(options.stale);
-}
-
-console.log('Done');
-
-if (hasErrors) {
-	process.exit(1);
-}
+if (hasErrors) process.exit(1);

--- a/.github/workflows/test-e2e-ci-reusable.yml
+++ b/.github/workflows/test-e2e-ci-reusable.yml
@@ -18,7 +18,7 @@ jobs:
   build-docker:
     name: 'Build Docker Image'
     if: ${{ !github.event.pull_request.head.repo.fork }}
-    runs-on: blacksmith-2vcpu-ubuntu-2204
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     permissions:
       packages: write
       contents: read
@@ -126,25 +126,15 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
+      contents: read
     steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
       - name: Delete images from GHCR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
-        run: |
-          for PACKAGE in n8n runners; do
-            echo "Deleting $PACKAGE:$TAG..."
-            VERSION_ID=$(gh api \
-              -H "Accept: application/vnd.github+json" \
-              "/orgs/n8n-io/packages/container/$PACKAGE/versions" \
-              --jq ".[] | select(.metadata.container.tags[] == \"$TAG\") | .id")
-
-            if [ -n "$VERSION_ID" ]; then
-              gh api --method DELETE \
-                -H "Accept: application/vnd.github+json" \
-                "/orgs/n8n-io/packages/container/$PACKAGE/versions/$VERSION_ID"
-              echo "  Deleted $PACKAGE version $VERSION_ID"
-            else
-              echo "  Not found, may have already been deleted"
-            fi
-          done
+        run: node .github/scripts/cleanup-ghcr-images.mjs --tag pr-${{ github.event.pull_request.number }}-${{ github.run_id }}

--- a/.github/workflows/util-cleanup-pr-images.yml
+++ b/.github/workflows/util-cleanup-pr-images.yml
@@ -3,47 +3,38 @@ name: 'Util: Cleanup PR Docker Images'
 on:
   pull_request:
     types: [closed]
+  schedule:
+    # Weekly cleanup: Sunday at 3 AM UTC
+    - cron: '0 3 * * 0'
 
 jobs:
   cleanup:
     name: 'Delete PR images'
-    if: ${{ !github.event.pull_request.head.repo.fork }}
+    # Skip for fork PRs (they don't have GHCR images)
+    # Always run on schedule
+    if: ${{ github.event_name == 'schedule' || !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     permissions:
       packages: write
+      contents: read
     steps:
-      - name: Delete all images for this PR
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # On PR close, the PR branch may be deleted - use default branch
+          # On schedule, use the default ref
+          ref: ${{ github.event.repository.default_branch || github.ref }}
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Delete images for closed PR
+        if: ${{ github.event_name == 'pull_request' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
+        run: node .github/scripts/cleanup-ghcr-images.mjs --pr ${{ github.event.pull_request.number }}
 
-          echo "Cleaning up images for PR #$PR_NUMBER..."
-
-          for PACKAGE in n8n runners; do
-            echo "Checking $PACKAGE package..."
-
-            # Fetch all versions with pr-{number}-* tags
-            VERSIONS=$(gh api "/orgs/n8n-io/packages/container/$PACKAGE/versions" \
-              --paginate \
-              --jq ".[] | select(.metadata.container.tags | any(startswith(\"pr-${PR_NUMBER}-\"))) | {id, tags: .metadata.container.tags}" \
-            ) || { echo "  No images found or API error"; continue; }
-
-            if [ -z "$VERSIONS" ]; then
-              echo "  No images found"
-              continue
-            fi
-
-            while IFS= read -r version; do
-              [ -z "$version" ] && continue
-
-              ID=$(echo "$version" | jq -r '.id')
-              TAGS=$(echo "$version" | jq -r '.tags | join(", ")')
-
-              echo "  Deleting: $TAGS"
-              gh api --method DELETE "/orgs/n8n-io/packages/container/$PACKAGE/versions/$ID" || echo "    Failed"
-            done <<< "$VERSIONS"
-          done
-
-          echo "Cleanup complete"
+      - name: Delete stale PR images
+        if: ${{ github.event_name == 'schedule' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/cleanup-ghcr-images.mjs --stale 7


### PR DESCRIPTION
## Summary

  - Consolidate duplicate GHCR image cleanup bash into a reusable Node.js script (.github/scripts/cleanup-ghcr-images.mjs)
  - Add weekly scheduled cleanup (Sunday 3 AM UTC) to delete stale PR images older than 7 days
  - Bump build-docker runner from 2vcpu to 4vcpu

## Related Linear tickets, Github issues, and Community forum posts

  https://linear.app/n8n/issue/CAT-2222


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
