### PR TITLE
fix(core): Ensure workflows with response promises respect graceful shutdown

### DIFF
--- a/packages/cli/src/__tests__/active-executions.test.ts
+++ b/packages/cli/src/__tests__/active-executions.test.ts
@@ -382,7 +382,7 @@ describe('ActiveExecutions', () => {
 			activeExecutions.setStatus(waitingExecutionId2, 'waiting');
 		});
 
-		test('Should cancel only executions with response-promises by default', async () => {
+		test('Should wait for all running executions including those with response promises', async () => {
 			const stopExecutionSpy = jest.spyOn(activeExecutions, 'stopExecution');
 
 			expect(activeExecutions.getActiveExecutions()).toHaveLength(4);
@@ -391,24 +391,11 @@ describe('ActiveExecutions', () => {
 
 			expect(concurrencyControl.disable).toHaveBeenCalled();
 
-			const removeAllCaptor = captor<string[]>();
-			expect(concurrencyControl.removeAll).toHaveBeenCalledWith(removeAllCaptor);
-			expect(removeAllCaptor.value.sort()).toEqual([newExecutionId1, waitingExecutionId1].sort());
+			expect(stopExecutionSpy).not.toHaveBeenCalled();
 
-			expect(stopExecutionSpy).toHaveBeenCalledTimes(2);
-			expect(stopExecutionSpy).toHaveBeenCalledWith(
-				newExecutionId1,
-				expect.any(SystemShutdownExecutionCancelledError),
-			);
-			expect(stopExecutionSpy).toHaveBeenCalledWith(
-				waitingExecutionId1,
-				expect.any(SystemShutdownExecutionCancelledError),
-			);
-			expect(stopExecutionSpy).not.toHaveBeenCalledWith(newExecutionId2);
-			expect(stopExecutionSpy).not.toHaveBeenCalledWith(waitingExecutionId2);
+			expect(concurrencyControl.removeAll).toHaveBeenCalledWith([]);
 
 			await new Promise(setImmediate);
-			// the other two executions aren't cancelled, but still removed from memory
 			expect(activeExecutions.getActiveExecutions()).toHaveLength(0);
 		});
 

--- a/packages/cli/src/active-executions.ts
+++ b/packages/cli/src/active-executions.ts
@@ -299,9 +299,8 @@ export class ActiveExecutions {
 		let executionIds = Object.keys(this.activeExecutions);
 		const toCancel: string[] = [];
 		for (const executionId of executionIds) {
-			const { responsePromise, status } = this.activeExecutions[executionId];
-			if (!!responsePromise || (isRegularMode && cancelAll)) {
-				// Cancel all executions that have a response promise, because these promises can't be retained between restarts
+			const { status } = this.activeExecutions[executionId];
+			if (isRegularMode && cancelAll) {
 				this.stopExecution(executionId, new SystemShutdownExecutionCancelledError(executionId));
 				toCancel.push(executionId);
 			} else if (status === 'waiting' || status === 'new') {


### PR DESCRIPTION
## Summary

- Before: Workflows using "Respond to Webhook" were immediately cancelled on `SIGTERM`, even though the HTTP connection remains open until the process actually dies
- After: These workflows are now given the same graceful shutdown treatment as regular workflows, allowing them to complete and respond if they manage to finish before `N8N_GRACEFUL_SHUTDOWN_TIMEOUT`

The original logic assumed the response couldn't be sent after `SIGTERM`, but that's only true after the process terminates, not at the moment the signal is received

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2212/

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
