### PR TITLE
feat(Zendesk Trigger Node): Add webhook signature verification

### DIFF
--- a/packages/nodes-base/nodes/Zendesk/ZendeskTriggerHelpers.ts
+++ b/packages/nodes-base/nodes/Zendesk/ZendeskTriggerHelpers.ts
@@ -1,0 +1,72 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+import type { IWebhookFunctions } from 'n8n-workflow';
+
+/**
+ * Verifies the Zendesk webhook signature using HMAC-SHA256.
+ *
+ * Zendesk sends a signature in the `X-Zendesk-Webhook-Signature` header
+ * which is a base64-encoded HMAC-SHA256 digest of (timestamp + body).
+ *
+ * The timestamp is provided in the `X-Zendesk-Webhook-Signature-Timestamp` header.
+ *
+ * This function computes the expected signature using the stored webhook secret
+ * and compares it with the provided signature using a constant-time comparison.
+ *
+ * @returns true if signature is valid or no secret is configured, false otherwise
+ */
+export function verifySignature(this: IWebhookFunctions): boolean {
+	// Get the secret from workflow static data (set during webhook creation)
+	const webhookData = this.getWorkflowStaticData('node');
+	const webhookSecret = webhookData.webhookSecret as string | undefined;
+
+	// If no secret is configured, skip verification (backwards compatibility).
+	// This handles legacy webhooks created before signature verification was implemented.
+	// To enable verification, deactivate and reactivate the workflow.
+	if (!webhookSecret) {
+		return true;
+	}
+
+	const req = this.getRequestObject();
+	const headerData = this.getHeaderData() as Record<string, string | undefined>;
+
+	// Get the signature and timestamp from Zendesk's headers
+	const signature = headerData['x-zendesk-webhook-signature'];
+	const timestamp = headerData['x-zendesk-webhook-signature-timestamp'];
+
+	if (!signature || !timestamp) {
+		return false;
+	}
+
+	try {
+		// Get the raw request body
+		if (!req.rawBody) {
+			return false;
+		}
+
+		// Compute: base64(HMACSHA256(TIMESTAMP + BODY))
+		const hmac = createHmac('sha256', webhookSecret);
+
+		let rawBodyString: string;
+		if (Buffer.isBuffer(req.rawBody)) {
+			rawBodyString = req.rawBody.toString('utf8');
+		} else {
+			rawBodyString = typeof req.rawBody === 'string' ? req.rawBody : JSON.stringify(req.rawBody);
+		}
+
+		hmac.update(timestamp + rawBodyString);
+		const computedSignature = hmac.digest('base64');
+
+		// Constant-time comparison to prevent timing attacks
+		const computedBuffer = Buffer.from(computedSignature, 'utf8');
+		const providedBuffer = Buffer.from(signature, 'utf8');
+
+		// Buffers must be same length for timingSafeEqual
+		if (computedBuffer.length !== providedBuffer.length) {
+			return false;
+		}
+
+		return timingSafeEqual(computedBuffer, providedBuffer);
+	} catch {
+		return false;
+	}
+}

--- a/packages/nodes-base/nodes/Zendesk/__tests__/ZendeskTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Zendesk/__tests__/ZendeskTrigger.node.test.ts
@@ -1,0 +1,166 @@
+import { ZendeskTrigger } from '../ZendeskTrigger.node';
+import * as GenericFunctions from '../GenericFunctions';
+import * as ZendeskTriggerHelpers from '../ZendeskTriggerHelpers';
+
+describe('ZendeskTrigger Node', () => {
+	describe('create webhook method', () => {
+		let mockThis: any;
+		let webhookData: Record<string, any>;
+
+		beforeEach(() => {
+			webhookData = {};
+			mockThis = {
+				getNodeWebhookUrl: () => 'https://example.com/webhook',
+				getNodeParameter: jest.fn().mockImplementation((name: string) => {
+					if (name === 'service') return 'support';
+					if (name === 'conditions')
+						return { all: [{ field: 'status', operation: 'is', value: 'open' }] };
+					if (name === 'options') return {};
+				}),
+				getWorkflowStaticData: () => webhookData,
+				getNode: () => ({}),
+			};
+		});
+
+		it('should fetch and store signing secret after creating webhook', async () => {
+			const createdWebhook = { id: 'webhook-123' };
+			const signingSecretResponse = { signing_secret: { secret: 'test-signing-secret' } };
+			const createdTrigger = { id: 'trigger-456' };
+
+			jest
+				.spyOn(GenericFunctions, 'zendeskApiRequest')
+				.mockResolvedValueOnce({ webhook: createdWebhook }) // POST /webhooks
+				.mockResolvedValueOnce(signingSecretResponse) // GET /webhooks/{id}/signing_secret
+				.mockResolvedValueOnce({ trigger: createdTrigger }); // POST /triggers
+
+			const trigger = new ZendeskTrigger();
+			const result = await trigger.webhookMethods.default.create.call(mockThis);
+
+			expect(result).toBe(true);
+			expect(webhookData.webhookSecret).toBe('test-signing-secret');
+			expect(webhookData.webhookId).toBe('trigger-456');
+			expect(webhookData.targetId).toBe('webhook-123');
+		});
+
+		it('should call signing_secret API with correct webhook ID', async () => {
+			const createdWebhook = { id: 'webhook-789' };
+			const signingSecretResponse = { signing_secret: { secret: 'secret-123' } };
+			const createdTrigger = { id: 'trigger-101' };
+
+			const apiRequestSpy = jest
+				.spyOn(GenericFunctions, 'zendeskApiRequest')
+				.mockResolvedValueOnce({ webhook: createdWebhook })
+				.mockResolvedValueOnce(signingSecretResponse)
+				.mockResolvedValueOnce({ trigger: createdTrigger });
+
+			const trigger = new ZendeskTrigger();
+			await trigger.webhookMethods.default.create.call(mockThis);
+
+			expect(apiRequestSpy).toHaveBeenCalledWith('GET', '/webhooks/webhook-789/signing_secret');
+		});
+	});
+
+	describe('delete webhook method', () => {
+		let webhookData: Record<string, any>;
+		let mockThis: any;
+
+		beforeEach(() => {
+			webhookData = {
+				webhookId: 'trigger-123',
+				targetId: 'webhook-456',
+				webhookSecret: 'test-secret',
+			};
+
+			mockThis = {
+				getWorkflowStaticData: () => webhookData,
+			};
+		});
+
+		it('should delete webhook data including secret when deletion succeeds', async () => {
+			jest
+				.spyOn(GenericFunctions, 'zendeskApiRequest')
+				.mockResolvedValueOnce({}) // DELETE /triggers
+				.mockResolvedValueOnce({}); // DELETE /webhooks
+
+			const trigger = new ZendeskTrigger();
+			const result = await trigger.webhookMethods.default.delete.call(mockThis);
+
+			expect(result).toBe(true);
+			expect(webhookData.webhookId).toBeUndefined();
+			expect(webhookData.targetId).toBeUndefined();
+			expect(webhookData.webhookSecret).toBeUndefined();
+		});
+
+		it('should return false when deletion fails', async () => {
+			jest
+				.spyOn(GenericFunctions, 'zendeskApiRequest')
+				.mockRejectedValueOnce(new Error('API error'));
+
+			const trigger = new ZendeskTrigger();
+			const result = await trigger.webhookMethods.default.delete.call(mockThis);
+
+			expect(result).toBe(false);
+		});
+	});
+
+	describe('webhook method', () => {
+		let mockThis: any;
+		let webhookData: Record<string, any>;
+
+		beforeEach(() => {
+			webhookData = {
+				webhookSecret: 'test-secret',
+			};
+
+			mockThis = {
+				getWorkflowStaticData: () => webhookData,
+				getResponseObject: jest.fn().mockReturnValue({
+					status: jest.fn().mockReturnThis(),
+					send: jest.fn().mockReturnThis(),
+					end: jest.fn(),
+				}),
+				getRequestObject: jest.fn().mockReturnValue({
+					body: { ticket: { id: '123' } },
+					rawBody: '{"ticket":{"id":"123"}}',
+				}),
+				getHeaderData: jest.fn().mockReturnValue({}),
+				helpers: {
+					returnJsonArray: jest.fn().mockImplementation((data) => [data]),
+				},
+			};
+		});
+
+		it('should reject with 401 when signature verification fails', async () => {
+			jest.spyOn(ZendeskTriggerHelpers, 'verifySignature').mockReturnValueOnce(false);
+
+			const trigger = new ZendeskTrigger();
+			const result = await trigger.webhook.call(mockThis);
+
+			expect(result).toEqual({ noWebhookResponse: true });
+			expect(mockThis.getResponseObject).toHaveBeenCalled();
+			const responseObj = mockThis.getResponseObject();
+			expect(responseObj.status).toHaveBeenCalledWith(401);
+			expect(responseObj.send).toHaveBeenCalledWith('Unauthorized');
+		});
+
+		it('should process webhook when signature verification succeeds', async () => {
+			jest.spyOn(ZendeskTriggerHelpers, 'verifySignature').mockReturnValueOnce(true);
+
+			const trigger = new ZendeskTrigger();
+			const result = await trigger.webhook.call(mockThis);
+
+			expect(result).toHaveProperty('workflowData');
+			expect(mockThis.helpers.returnJsonArray).toHaveBeenCalledWith({ ticket: { id: '123' } });
+		});
+
+		it('should return workflow data with the request body', async () => {
+			jest.spyOn(ZendeskTriggerHelpers, 'verifySignature').mockReturnValueOnce(true);
+
+			const trigger = new ZendeskTrigger();
+			const result = await trigger.webhook.call(mockThis);
+
+			expect(result.workflowData).toBeDefined();
+			expect(result.workflowData).toHaveLength(1);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Zendesk/__tests__/ZendeskTriggerHelpers.test.ts
+++ b/packages/nodes-base/nodes/Zendesk/__tests__/ZendeskTriggerHelpers.test.ts
@@ -1,0 +1,193 @@
+import { createHmac } from 'crypto';
+import type { IWebhookFunctions } from 'n8n-workflow';
+
+import { verifySignature } from '../ZendeskTriggerHelpers';
+
+describe('ZendeskTriggerHelpers', () => {
+	describe('verifySignature', () => {
+		let mockWebhookFunctions: IWebhookFunctions;
+		const testWebhookSecret = 'dGhpc19zZWNyZXRfaXNfZm9yX3Rlc3Rpbmdfb25seQ==';
+		const testBody = '{"ticket":{"id":"123","subject":"Test ticket","status":"open"}}';
+		const testTimestamp = '2024-01-15T10:30:00Z';
+
+		function generateValidSignature(timestamp: string, body: string, secret: string): string {
+			// Zendesk signature: base64(HMACSHA256(TIMESTAMP + BODY))
+			return createHmac('sha256', secret)
+				.update(timestamp + body)
+				.digest('base64');
+		}
+
+		beforeEach(() => {
+			mockWebhookFunctions = {
+				getWorkflowStaticData: jest.fn().mockReturnValue({
+					webhookSecret: testWebhookSecret,
+				}),
+				getRequestObject: jest.fn().mockReturnValue({
+					rawBody: Buffer.from(testBody),
+				}),
+				getHeaderData: jest.fn().mockReturnValue({
+					'x-zendesk-webhook-signature': generateValidSignature(
+						testTimestamp,
+						testBody,
+						testWebhookSecret,
+					),
+					'x-zendesk-webhook-signature-timestamp': testTimestamp,
+				}),
+			} as unknown as IWebhookFunctions;
+		});
+
+		it('should return true when no webhook secret is stored (backwards compatibility)', () => {
+			(mockWebhookFunctions.getWorkflowStaticData as jest.Mock).mockReturnValue({});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+			expect(mockWebhookFunctions.getWorkflowStaticData).toHaveBeenCalledWith('node');
+		});
+
+		it('should return false when signature header is missing', () => {
+			(mockWebhookFunctions.getHeaderData as jest.Mock).mockReturnValue({
+				'x-zendesk-webhook-signature-timestamp': testTimestamp,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false when timestamp header is missing', () => {
+			(mockWebhookFunctions.getHeaderData as jest.Mock).mockReturnValue({
+				'x-zendesk-webhook-signature': generateValidSignature(
+					testTimestamp,
+					testBody,
+					testWebhookSecret,
+				),
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false when rawBody is missing', () => {
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				rawBody: undefined,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return true when signature is valid', () => {
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false when signature is invalid', () => {
+			(mockWebhookFunctions.getHeaderData as jest.Mock).mockReturnValue({
+				'x-zendesk-webhook-signature': 'invalid-signature',
+				'x-zendesk-webhook-signature-timestamp': testTimestamp,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false when signature is computed with wrong secret', () => {
+			const wrongSecret = 'wrong_secret_key';
+			(mockWebhookFunctions.getHeaderData as jest.Mock).mockReturnValue({
+				'x-zendesk-webhook-signature': generateValidSignature(testTimestamp, testBody, wrongSecret),
+				'x-zendesk-webhook-signature-timestamp': testTimestamp,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should handle Buffer rawBody correctly', () => {
+			const bufferBody = Buffer.from(testBody);
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				rawBody: bufferBody,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should handle string rawBody correctly', () => {
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				rawBody: testBody, // String instead of Buffer
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false when computed and provided signatures have different lengths', () => {
+			(mockWebhookFunctions.getHeaderData as jest.Mock).mockReturnValue({
+				'x-zendesk-webhook-signature': 'short',
+				'x-zendesk-webhook-signature-timestamp': testTimestamp,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should handle different timestamp formats', () => {
+			const differentTimestamp = '1705315800';
+			const validSignature = generateValidSignature(
+				differentTimestamp,
+				testBody,
+				testWebhookSecret,
+			);
+			(mockWebhookFunctions.getHeaderData as jest.Mock).mockReturnValue({
+				'x-zendesk-webhook-signature': validSignature,
+				'x-zendesk-webhook-signature-timestamp': differentTimestamp,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should handle empty body', () => {
+			const emptyBody = '';
+			const validSignature = generateValidSignature(testTimestamp, emptyBody, testWebhookSecret);
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				rawBody: Buffer.from(emptyBody),
+			});
+			(mockWebhookFunctions.getHeaderData as jest.Mock).mockReturnValue({
+				'x-zendesk-webhook-signature': validSignature,
+				'x-zendesk-webhook-signature-timestamp': testTimestamp,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should handle complex JSON body with special characters', () => {
+			const complexBody =
+				'{"ticket":{"id":"123","subject":"Test with émojis 🎉 and spëcial chars"}}';
+			const validSignature = generateValidSignature(testTimestamp, complexBody, testWebhookSecret);
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				rawBody: Buffer.from(complexBody, 'utf8'),
+			});
+			(mockWebhookFunctions.getHeaderData as jest.Mock).mockReturnValue({
+				'x-zendesk-webhook-signature': validSignature,
+				'x-zendesk-webhook-signature-timestamp': testTimestamp,
+			});
+
+			const result = verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
Adds HMAC-SHA256 signature verification for incoming webhook requests in the `ZendeskTrigger` node, ensuring only authentic requests from Zendesk are processed.

Solution based on the **[GitHub Node](https://github.com/n8n-io/n8n/pull/24203)**.

### Changes
- Verify `X-Zendesk-Webhook-Signature` HMAC header before processing webhook requests
- Fetch signing secret from Zendesk API (`GET /webhooks/{id}/signing_secret`) after webhook creation
- Store signing secret in workflow static data for signature verification
- Return 401 Unauthorized for invalid/missing signatures
- Fix: delete `webhookId` instead of `triggerId` in cleanup

### Implementation Details
- Uses HMAC-SHA256 with base64 encoding per Zendesk's specification
- Constant-time comparison (`timingSafeEqual`) to prevent timing attacks
- Backwards compatible: existing workflows without stored secrets continue to work

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
https://linear.app/n8n/issue/NODE-4226


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
