### PR TITLE
fix(core): Update AI Builder node types after community package changes

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/session-manager.service.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/session-manager.service.ts
@@ -12,11 +12,22 @@ import { formatMessages } from '@/utils/stream-processor';
 export class SessionManagerService {
 	private checkpointer: MemorySaver;
 
+	private nodeTypes: INodeTypeDescription[];
+
 	constructor(
-		private readonly parsedNodeTypes: INodeTypeDescription[],
+		parsedNodeTypes: INodeTypeDescription[],
 		private readonly logger?: Logger,
 	) {
+		this.nodeTypes = parsedNodeTypes;
 		this.checkpointer = new MemorySaver();
+	}
+
+	/**
+	 * Update the node types used for formatting messages.
+	 * Called when community packages are installed, updated, or uninstalled.
+	 */
+	updateNodeTypes(nodeTypes: INodeTypeDescription[]) {
+		this.nodeTypes = nodeTypes;
 	}
 
 	/**
@@ -68,7 +79,7 @@ export class SessionManagerService {
 					const formattedMessages = formatMessages(
 						messages,
 						getBuilderToolsForDisplay({
-							nodeTypes: this.parsedNodeTypes,
+							nodeTypes: this.nodeTypes,
 						}),
 					);
 

--- a/packages/cli/src/services/ai-workflow-builder.service.ts
+++ b/packages/cli/src/services/ai-workflow-builder.service.ts
@@ -45,7 +45,24 @@ export class WorkflowBuilderService {
 		private readonly telemetry: Telemetry,
 		private readonly instanceSettings: InstanceSettings,
 		private readonly dynamicNodeParametersService: DynamicNodeParametersService,
-	) {}
+	) {
+		// Register a post-processor to update node types when they change.
+		// This ensures newly installed/updated/uninstalled community packages are recognized
+		// while preserving existing sessions.
+		this.loadNodesAndCredentials.addPostProcessor(async () => this.refreshNodeTypes());
+	}
+
+	/**
+	 * Update the node types on the existing service instance.
+	 * Called automatically when postProcessLoaders() runs (e.g., after community package changes).
+	 * This preserves existing sessions while making new node types available.
+	 */
+	refreshNodeTypes() {
+		if (this.service) {
+			const { nodes: nodeTypeDescriptions } = this.loadNodesAndCredentials.types;
+			this.service.updateNodeTypes(nodeTypeDescriptions);
+		}
+	}
 
 	private async getService(): Promise<AiWorkflowBuilderService> {
 		if (this.service) return this.service;


### PR DESCRIPTION
## Summary

Fixes a bug where the AI Workflow Builder does not recognize newly installed community nodes until the instance is restarted.

### Problem
When a verified community node (e.g., ElevenLabs) is installed, the AI Builder continues to use HTTP Request nodes instead of the purpose-built community node. This happens because:

1. `WorkflowBuilderService` caches the `AiWorkflowBuilderService` instance at startup
2. The cached instance holds a snapshot of available node types from initialization
3. When community packages are installed/updated/uninstalled, `postProcessLoaders()` updates `LoadNodesAndCredentials.types`, but the AI Builder's cached node list is never refreshed

### Solution
1. Added `updateNodeTypes()` method to `AiWorkflowBuilderService` and `SessionManagerService`
2. Register a post-processor hook that calls `refreshNodeTypes()` when `postProcessLoaders()` runs
3. This updates the node types in place, preserving existing sessions

### How to test
1. Start n8n without any community nodes installed
2. Open AI Builder and ask it to create a workflow using ElevenLabs
3. Observe it uses HTTP Request node (expected - ElevenLabs node not available)
4. Install the ElevenLabs verified community node
5. Ask AI Builder again to create a workflow using ElevenLabs
6. Observe it now uses the ElevenLabs node directly (fixed!)
7. Verify existing AI Builder sessions are preserved

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-1947

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)