### PR TITLE
ci: Fix release tag merge failing with unrelated histories

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -202,7 +202,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: master
-          fetch-depth: 0
+          fetch-depth: 500
           token: ${{ steps.generate_token.outputs.token }}
 
       - name: Verify release tag exists

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -202,7 +202,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: master
-          fetch-depth: 1
+          fetch-depth: 0
           token: ${{ steps.generate_token.outputs.token }}
 
       - name: Verify release tag exists
@@ -219,7 +219,7 @@ jobs:
         run: |
           git config user.name "n8n-release-tag-merge[bot]"
           git config user.email "256767729+n8n-release-tag-merge[bot]@users.noreply.github.com"
-          git merge --ff-only "n8n@${VERSION}"
+          git merge --ff "n8n@${VERSION}"
 
       - name: Push to master
         run: git push origin HEAD:master


### PR DESCRIPTION
## Summary

  Fixes the [release tag merge job](https://github.com/n8n-io/n8n/actions/runs/21363602394/job/61491568277) failing with "unrelated histories" error by:
  - Using full clone (fetch-depth: 0) instead of shallow clone to provide git with complete history
  - Changing --ff-only to --ff to allow merge commits when master has diverged (PRs merged during release publishing)

## Related Linear tickets, Github issues, and Community forum posts

  https://linear.app/n8n/issue/CAT-2224


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
