### PR TITLE
fix(core): Stronger allowed path enforcement for read/write Node (no-changelog)

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
@@ -1,8 +1,13 @@
 import { SecurityConfig } from '@n8n/config';
 import { Container } from '@n8n/di';
 import type { INode } from 'n8n-workflow';
-import { constants, createReadStream } from 'node:fs';
-import { access as fsAccess, realpath as fsRealpath } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import {
+	access as fsAccess,
+	realpath as fsRealpath,
+	stat as fsStat,
+	open as fsOpen,
+} from 'node:fs/promises';
 import { join } from 'node:path';
 
 import {
@@ -287,11 +292,14 @@ describe('getFileSystemHelperFunctions', () => {
 	});
 
 	describe('createReadStream', () => {
+		const mockFileStats = { dev: 123, ino: 456 };
+
 		it('should throw error for non-existent file', async () => {
 			const filePath = '/non/existent/file';
 			const error = new Error('ENOENT');
 			// @ts-expect-error undefined property
 			error.code = 'ENOENT';
+			(fsStat as jest.Mock).mockResolvedValueOnce(mockFileStats);
 			(fsAccess as jest.Mock).mockRejectedValueOnce(error);
 
 			await expect(
@@ -300,20 +308,16 @@ describe('getFileSystemHelperFunctions', () => {
 		});
 
 		it('should throw when file access is blocked', async () => {
-			process.env[RESTRICT_FILE_ACCESS_TO] = '/allowed/path';
-			(fsAccess as jest.Mock).mockResolvedValueOnce({});
+			securityConfig.restrictFileAccessTo = '/allowed/path';
+			(fsStat as jest.Mock).mockResolvedValueOnce(mockFileStats);
 			await expect(
 				helperFunctions.createReadStream(await helperFunctions.resolvePath('/blocked/path')),
 			).rejects.toThrow('Access to the file is not allowed');
 		});
 
 		it('should not reveal if file exists if it is within restricted path', async () => {
-			process.env[RESTRICT_FILE_ACCESS_TO] = '/allowed/path';
-
-			const error = new Error('ENOENT');
-			// @ts-expect-error undefined property
-			error.code = 'ENOENT';
-			(fsAccess as jest.Mock).mockRejectedValueOnce(error);
+			securityConfig.restrictFileAccessTo = '/allowed/path';
+			(fsStat as jest.Mock).mockResolvedValueOnce(mockFileStats);
 
 			await expect(
 				helperFunctions.createReadStream(await helperFunctions.resolvePath('/blocked/path')),
@@ -322,60 +326,62 @@ describe('getFileSystemHelperFunctions', () => {
 
 		it('should create a read stream if file access is permitted', async () => {
 			const filePath = '/allowed/path';
-			(fsAccess as jest.Mock).mockResolvedValueOnce({});
-
-			// Mock createReadStream to return a proper stream-like object
-			const mockStream: { once: jest.Mock } = {
-				once: jest.fn((event: string, callback: (error?: Error) => void): typeof mockStream => {
-					if (event === 'open') {
-						// Immediately call the open callback
-						setImmediate(() => callback());
-					}
-					return mockStream;
-				}),
+			const mockStream = { pipe: jest.fn() };
+			const mockFileHandle = {
+				stat: jest.fn().mockResolvedValue(mockFileStats),
+				createReadStream: jest.fn().mockReturnValue(mockStream),
 			};
-			(createReadStream as jest.Mock).mockReturnValueOnce(mockStream);
 
-			await helperFunctions.createReadStream(await helperFunctions.resolvePath(filePath));
-			expect(createReadStream).toHaveBeenCalledWith(
-				filePath,
-				expect.objectContaining({
-					flags: expect.any(Number),
-				}),
+			(fsStat as jest.Mock).mockResolvedValueOnce(mockFileStats);
+			(fsAccess as jest.Mock).mockResolvedValueOnce(undefined);
+			(fsOpen as jest.Mock).mockResolvedValueOnce(mockFileHandle);
+
+			const result = await helperFunctions.createReadStream(
+				await helperFunctions.resolvePath(filePath),
 			);
+
+			expect(result).toBe(mockStream);
+			expect(fsOpen).toHaveBeenCalledWith(filePath, constants.O_RDONLY | constants.O_NOFOLLOW);
 		});
 
-		it('should reject symlinks with O_NOFOLLOW to prevent TOCTOU attacks', async () => {
+		it('should reject symlinks with ELOOP error', async () => {
 			const filePath = '/allowed/path/file';
-
-			// Clear previous mocks and set up fresh mocks
-			(fsAccess as jest.Mock).mockReset();
-			(fsAccess as jest.Mock).mockResolvedValue(undefined);
-
-			// Simulate the ELOOP error that occurs when O_NOFOLLOW encounters a symlink
 			const eloopError = new Error('ELOOP: too many symbolic links encountered');
 			// @ts-expect-error undefined property
 			eloopError.code = 'ELOOP';
 
-			// Mock createReadStream to return a stream that emits an error event
-			const mockStream: { once: jest.Mock } = {
-				once: jest.fn((event: string, callback: (error?: Error) => void): typeof mockStream => {
-					if (event === 'error') {
-						// Emit the error asynchronously
-						setImmediate(() => callback(eloopError));
-					}
-					return mockStream;
-				}),
-			};
-			(createReadStream as jest.Mock).mockReturnValueOnce(mockStream);
+			(fsStat as jest.Mock).mockResolvedValueOnce(mockFileStats);
+			(fsAccess as jest.Mock).mockResolvedValueOnce(undefined);
+			(fsOpen as jest.Mock).mockRejectedValueOnce(eloopError);
 
 			await expect(
 				helperFunctions.createReadStream(await helperFunctions.resolvePath(filePath)),
-			).rejects.toThrow('ELOOP: too many symbolic links encountered');
+			).rejects.toThrow('Symlinks are not allowed.');
+		});
+
+		it('should reject when file identity changes', async () => {
+			const filePath = '/allowed/path/file';
+			const differentStats = { dev: 999, ino: 888 };
+			const mockFileHandle = {
+				stat: jest.fn().mockResolvedValue(differentStats),
+				createReadStream: jest.fn(),
+				close: jest.fn(),
+			};
+
+			(fsStat as jest.Mock).mockResolvedValueOnce(mockFileStats);
+			(fsAccess as jest.Mock).mockResolvedValueOnce(undefined);
+			(fsOpen as jest.Mock).mockResolvedValueOnce(mockFileHandle);
+
+			await expect(
+				helperFunctions.createReadStream(await helperFunctions.resolvePath(filePath)),
+			).rejects.toThrow('The file has changed and cannot be accessed.');
+			expect(mockFileHandle.close).toHaveBeenCalled();
 		});
 	});
 
 	describe('writeContentToFile', () => {
+		const mockFileStats = { dev: 123, ino: 456, isFile: () => true };
+
 		it('should throw error for blocked file path', async () => {
 			process.env[BLOCK_FILE_ACCESS_TO_N8N_FILES] = 'true';
 
@@ -386,6 +392,146 @@ describe('getFileSystemHelperFunctions', () => {
 					constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC,
 				),
 			).rejects.toThrow('not writable');
+		});
+
+		it('should reject symlinks with ELOOP error', async () => {
+			const filePath = '/allowed/path/file';
+			const eloopError = new Error('ELOOP: too many symbolic links encountered');
+			// @ts-expect-error undefined property
+			eloopError.code = 'ELOOP';
+
+			(fsStat as jest.Mock).mockResolvedValueOnce(mockFileStats);
+			(fsOpen as jest.Mock).mockRejectedValueOnce(eloopError);
+
+			await expect(
+				helperFunctions.writeContentToFile(
+					await helperFunctions.resolvePath(filePath),
+					'test content',
+				),
+			).rejects.toThrow('Symlinks are not allowed.');
+		});
+
+		it('should reject when file identity changes', async () => {
+			const filePath = '/allowed/path/file';
+			const differentStats = { dev: 999, ino: 888, isFile: () => true };
+			const mockFileHandle = {
+				stat: jest.fn().mockResolvedValue(differentStats),
+				truncate: jest.fn(),
+				write: jest.fn(),
+				close: jest.fn(),
+			};
+
+			(fsStat as jest.Mock).mockResolvedValueOnce(mockFileStats);
+			(fsOpen as jest.Mock).mockResolvedValueOnce(mockFileHandle);
+
+			await expect(
+				helperFunctions.writeContentToFile(
+					await helperFunctions.resolvePath(filePath),
+					'test content',
+				),
+			).rejects.toThrow('The file has changed and cannot be written.');
+
+			expect(mockFileHandle.close).toHaveBeenCalled();
+		});
+
+		it('should successfully write to file when identity matches', async () => {
+			const filePath = '/allowed/path/file';
+			const mockFileHandle = {
+				stat: jest.fn().mockResolvedValue(mockFileStats),
+				truncate: jest.fn().mockResolvedValue(undefined),
+				writeFile: jest.fn().mockResolvedValue(undefined),
+				close: jest.fn().mockResolvedValue(undefined),
+			};
+
+			(fsStat as jest.Mock).mockResolvedValueOnce(mockFileStats);
+			(fsOpen as jest.Mock).mockResolvedValueOnce(mockFileHandle);
+
+			await helperFunctions.writeContentToFile(
+				await helperFunctions.resolvePath(filePath),
+				'test content',
+			);
+
+			expect(fsOpen).toHaveBeenCalledWith(
+				filePath,
+				constants.O_WRONLY | constants.O_CREAT | constants.O_NOFOLLOW,
+			);
+			expect(mockFileHandle.truncate).toHaveBeenCalledWith(0);
+			expect(mockFileHandle.writeFile).toHaveBeenCalledWith('test content', { encoding: 'binary' });
+			expect(mockFileHandle.close).toHaveBeenCalled();
+		});
+
+		it('should successfully create and write to new file', async () => {
+			const filePath = '/allowed/path/newfile';
+			const enoentError = new Error('ENOENT');
+			// @ts-expect-error undefined property
+			enoentError.code = 'ENOENT';
+
+			const newFileStats = { dev: 123, ino: 789, isFile: () => true };
+			const mockFileHandle = {
+				stat: jest.fn().mockResolvedValue(newFileStats),
+				truncate: jest.fn().mockResolvedValue(undefined),
+				writeFile: jest.fn().mockResolvedValue(undefined),
+				close: jest.fn().mockResolvedValue(undefined),
+			};
+
+			(fsStat as jest.Mock).mockRejectedValueOnce(enoentError);
+			(fsStat as jest.Mock).mockResolvedValueOnce(newFileStats);
+			(fsOpen as jest.Mock).mockResolvedValueOnce(mockFileHandle);
+
+			await helperFunctions.writeContentToFile(
+				await helperFunctions.resolvePath(filePath),
+				'new content',
+			);
+
+			expect(mockFileHandle.truncate).toHaveBeenCalledWith(0);
+			expect(mockFileHandle.writeFile).toHaveBeenCalledWith('new content', { encoding: 'binary' });
+			expect(mockFileHandle.close).toHaveBeenCalled();
+		});
+
+		it('should strip O_TRUNC flag from user flags', async () => {
+			const filePath = '/allowed/path/file';
+			const mockFileHandle = {
+				stat: jest.fn().mockResolvedValue(mockFileStats),
+				truncate: jest.fn().mockResolvedValue(undefined),
+				writeFile: jest.fn().mockResolvedValue(undefined),
+				close: jest.fn().mockResolvedValue(undefined),
+			};
+
+			(fsStat as jest.Mock).mockResolvedValueOnce(mockFileStats);
+			(fsOpen as jest.Mock).mockResolvedValueOnce(mockFileHandle);
+
+			await helperFunctions.writeContentToFile(
+				await helperFunctions.resolvePath(filePath),
+				'test content',
+				constants.O_TRUNC, // This should be stripped
+			);
+
+			// Verify O_TRUNC was not passed to fsOpen
+			expect(fsOpen).toHaveBeenCalledWith(
+				filePath,
+				constants.O_WRONLY | constants.O_CREAT | constants.O_NOFOLLOW,
+			);
+		});
+
+		it('should reject non-regular files (directories)', async () => {
+			const filePath = '/allowed/path/directory';
+			const dirStats = { dev: 123, ino: 456, isFile: () => false };
+			const mockFileHandle = {
+				stat: jest.fn().mockResolvedValue(dirStats),
+				close: jest.fn().mockResolvedValue(undefined),
+			};
+
+			(fsStat as jest.Mock).mockResolvedValueOnce(dirStats);
+			(fsOpen as jest.Mock).mockResolvedValueOnce(mockFileHandle);
+
+			await expect(
+				helperFunctions.writeContentToFile(
+					await helperFunctions.resolvePath(filePath),
+					'test content',
+				),
+			).rejects.toThrow('The path is not a regular file.');
+
+			expect(mockFileHandle.close).toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
@@ -308,7 +308,7 @@ describe('getFileSystemHelperFunctions', () => {
 		});
 
 		it('should throw when file access is blocked', async () => {
-			securityConfig.restrictFileAccessTo = '/allowed/path';
+			process.env[RESTRICT_FILE_ACCESS_TO] = '/allowed/path';
 			(fsStat as jest.Mock).mockResolvedValueOnce(mockFileStats);
 			await expect(
 				helperFunctions.createReadStream(await helperFunctions.resolvePath('/blocked/path')),
@@ -316,7 +316,7 @@ describe('getFileSystemHelperFunctions', () => {
 		});
 
 		it('should not reveal if file exists if it is within restricted path', async () => {
-			securityConfig.restrictFileAccessTo = '/allowed/path';
+			process.env[RESTRICT_FILE_ACCESS_TO] = '/allowed/path';
 			(fsStat as jest.Mock).mockResolvedValueOnce(mockFileStats);
 
 			await expect(

--- a/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
@@ -4,11 +4,12 @@ import { Container } from '@n8n/di';
 import { NodeOperationError } from 'n8n-workflow';
 import type { FileSystemHelperFunctions, INode, ResolvedFilePath } from 'n8n-workflow';
 import type { PathLike } from 'node:fs';
-import { constants, createReadStream } from 'node:fs';
+import { constants } from 'node:fs';
 import {
 	access as fsAccess,
-	writeFile as fsWriteFile,
 	realpath as fsRealpath,
+	stat as fsStat,
+	open as fsOpen,
 } from 'node:fs/promises';
 import { resolve, posix } from 'node:path';
 
@@ -89,6 +90,9 @@ function isFilePathBlocked(resolvedFilePath: ResolvedFilePath): boolean {
 
 export const getFileSystemHelperFunctions = (node: INode): FileSystemHelperFunctions => ({
 	async createReadStream(resolvedFilePath) {
+		// Get the device and inode number of the path we're checking.
+		const pathIdentity = await fsStat(resolvedFilePath);
+		// Check that the path is allowed.
 		if (isFilePathBlocked(resolvedFilePath)) {
 			const allowedPaths = getAllowedPaths();
 			const message = allowedPaths.length ? ` Allowed paths: ${allowedPaths.join(', ')}` : '';
@@ -110,27 +114,42 @@ export const getFileSystemHelperFunctions = (node: INode): FileSystemHelperFunct
 				: error;
 		}
 
-		// Use O_NOFOLLOW to prevent createReadStream from following symlinks. We require that the path
-		// already be resolved beforehand.
-		const stream = createReadStream(resolvedFilePath, {
-			flags: (constants.O_RDONLY | constants.O_NOFOLLOW) as unknown as string,
-		});
+		// Open a file handle.
+		let fileHandle;
+		try {
+			fileHandle = await fsOpen(resolvedFilePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+		} catch (error) {
+			if ('code' in error && (error as unknown as { code: string }).code === 'ELOOP') {
+				throw new NodeOperationError(node, error instanceof Error ? error : '', {
+					message: 'Symlinks are not allowed.',
+					level: 'warning',
+				});
+			} else {
+				throw error;
+			}
+		}
 
-		return await new Promise<ReturnType<typeof createReadStream>>((resolve, reject) => {
-			stream.once('error', (error) => {
-				if ((error as NodeJS.ErrnoException).code === 'ELOOP') {
-					reject(
-						new NodeOperationError(node, error, {
-							level: 'warning',
-							description: 'Symlinks are not allowed.',
-						}),
-					);
-				} else {
-					reject(error);
-				}
-			});
-			stream.once('open', () => resolve(stream));
-		});
+		try {
+			// Verify that the handle we've opened is the same as the path we checked earlier.
+			// This ensures nothing has changed between checking and reading.
+			const fileHandleIdentity = await fileHandle.stat();
+			if (
+				fileHandleIdentity.dev !== pathIdentity.dev ||
+				fileHandleIdentity.ino !== pathIdentity.ino
+			) {
+				throw new NodeOperationError(node, 'The file has changed and cannot be accessed.', {
+					level: 'warning',
+				});
+			}
+
+			// The file handle we opened matches the path we checked, and the path is allowed,
+			// so we can go ahead and read the file.
+			return fileHandle.createReadStream();
+		} catch (error) {
+			// Ensure the file handle is closed if verification fails or an error occurs.
+			await fileHandle.close();
+			throw error;
+		}
 	},
 
 	getStoragePath() {
@@ -138,6 +157,24 @@ export const getFileSystemHelperFunctions = (node: INode): FileSystemHelperFunct
 	},
 
 	async writeContentToFile(resolvedFilePath, content, flag) {
+		// Get the device and inode number of the path we're checking, if it exists.
+		// This establishes the file's identity before we open it.
+		let pathIdentity;
+		let fileExists = true;
+		try {
+			pathIdentity = await fsStat(resolvedFilePath);
+		} catch (error) {
+			// NOTE: for some reason instanceof Error does not work here in tests,
+			// so we just look for the code to catch ENOENT.
+			if ('code' in error && (error as unknown as { code: string }).code === 'ENOENT') {
+				// It's possible the file does not exist yet. In this case we'll create it later.
+				fileExists = false;
+			} else {
+				throw error;
+			}
+		}
+
+		// Check that the path is allowed.
 		if (isFilePathBlocked(resolvedFilePath)) {
 			throw new NodeOperationError(
 				node,
@@ -147,10 +184,91 @@ export const getFileSystemHelperFunctions = (node: INode): FileSystemHelperFunct
 				},
 			);
 		}
-		return await fsWriteFile(resolvedFilePath, content, {
-			encoding: 'binary',
-			flag: (flag ?? 0) | constants.O_NOFOLLOW,
-		});
+
+		const shouldTruncate = flag === undefined || (flag & constants.O_TRUNC) === constants.O_TRUNC;
+		// We intentionally remove O_TRUNC to avoid destructive operations before verification.
+		// If we should truncate the file instead we will do it after verification.
+		const userFlags = flag ?? 0;
+		const openFlags =
+			constants.O_WRONLY |
+			constants.O_CREAT |
+			constants.O_NOFOLLOW |
+			(userFlags & ~constants.O_TRUNC); // Strip O_TRUNC if present
+
+		let fileHandle;
+		try {
+			fileHandle = await fsOpen(resolvedFilePath, openFlags);
+		} catch (error) {
+			if ('code' in error && (error as unknown as { code: string }).code === 'ELOOP') {
+				throw new NodeOperationError(node, error instanceof Error ? error : '', {
+					message: 'Symlinks are not allowed.',
+					level: 'warning',
+				});
+			} else {
+				throw error;
+			}
+		}
+
+		try {
+			// Verify that the handle we've opened is the same as the path we checked earlier.
+			// This ensures nothing has changed between checking and opening (TOCTOU protection).
+			const fileHandleIdentity = await fileHandle.stat();
+
+			if (fileExists && pathIdentity) {
+				if (
+					fileHandleIdentity.dev !== pathIdentity.dev ||
+					fileHandleIdentity.ino !== pathIdentity.ino
+				) {
+					throw new NodeOperationError(node, 'The file has changed and cannot be written.', {
+						level: 'warning',
+					});
+				}
+			} else {
+				// If the file did not exist before, ensure that we opened the path we expected.
+				pathIdentity = await fsStat(resolvedFilePath);
+				if (
+					fileHandleIdentity.dev !== pathIdentity.dev ||
+					fileHandleIdentity.ino !== pathIdentity.ino
+				) {
+					throw new NodeOperationError(
+						node,
+						'The file was created but its identity does not match and cannot be written.',
+						{
+							level: 'warning',
+						},
+					);
+				}
+			}
+
+			// Verify that the opened file is a regular file, not a directory or special file
+			if (!fileHandleIdentity.isFile()) {
+				throw new NodeOperationError(node, 'The path is not a regular file.', {
+					level: 'warning',
+				});
+			}
+
+			// The file handle we opened matches the path we checked (or the file was newly created),
+			// and the path is allowed, so we can now safely truncate and write.
+			if (shouldTruncate) {
+				await fileHandle.truncate(0);
+			} // Otherwise we'll append.
+
+			// Handle different content types
+			if (typeof content === 'string' || Buffer.isBuffer(content)) {
+				// FileHandle.writeFile supports string and Buffer
+				await fileHandle.writeFile(content, { encoding: 'binary' });
+			} else {
+				// Content is a Readable stream
+				const writeStream = fileHandle.createWriteStream({ encoding: 'binary' });
+				await new Promise<void>((resolve, reject) => {
+					content.pipe(writeStream);
+					writeStream.on('finish', resolve);
+					writeStream.on('error', reject);
+				});
+			}
+		} finally {
+			await fileHandle.close();
+		}
 	},
 	resolvePath,
 	isFilePathBlocked,

--- a/packages/nodes-base/nodes/Crypto/test/Crypto.test.ts
+++ b/packages/nodes-base/nodes/Crypto/test/Crypto.test.ts
@@ -1,21 +1,45 @@
 import { NodeTestHarness } from '@nodes-testing/node-test-harness';
-import fs from 'fs';
-import fsPromises from 'fs/promises';
+import type fs from 'fs';
+import fsPromises, { type FileHandle } from 'fs/promises';
 import { Readable } from 'stream';
 
 describe('Test Crypto Node', () => {
 	jest.mock('fast-glob', () => async () => ['/test/binary.data']);
 	jest.mock('fs/promises');
 	fsPromises.access = async () => {};
+	fsPromises.stat = jest.fn(async (path: fs.PathLike) => {
+		if (path === '/test/binary.data') {
+			return {
+				isFile: () => true,
+				dev: 123456,
+				ino: 654321,
+			} as fs.Stats;
+		}
+		throw Object.assign(new Error('File not found'), { code: 'ENOENT' });
+	}) as unknown as typeof fsPromises.stat;
+	fsPromises.open = jest.fn(async (path: fs.PathLike) => {
+		if (path === '/test/binary.data') {
+			return {
+				close: async () => {},
+				// eslint-disable-next-line @typescript-eslint/require-await
+				stat: async () =>
+					({
+						isFile: () => true,
+						dev: 123456,
+						ino: 654321,
+					}) as fs.Stats,
+				createReadStream: () => {
+					const stream = Readable.from(Buffer.from('test')) as fs.ReadStream;
+					// Emit 'open' event asynchronously to match real fs.ReadStream behavior
+					setImmediate(() => stream.emit('open'));
+					return stream;
+				},
+			} as FileHandle;
+		}
+		throw Object.assign(new Error('File not found'), { code: 'ENOENT' });
+	}) as unknown as typeof fsPromises.open;
 	const realpathSpy = jest.spyOn(fsPromises, 'realpath');
 	realpathSpy.mockImplementation(async (path) => path as string);
-	jest.mock('fs');
-	fs.createReadStream = () => {
-		const stream = Readable.from(Buffer.from('test')) as fs.ReadStream;
-		// Emit 'open' event asynchronously to match real fs.ReadStream behavior
-		setImmediate(() => stream.emit('open'));
-		return stream;
-	};
 
 	new NodeTestHarness().setupTests();
 });


### PR DESCRIPTION
## Summary

Backport of https://github.com/n8n-io/n8n/pull/23542.

NOTE: this is not a pure backport, because there were merge conflicts and subsequent test failures. https://github.com/n8n-io/n8n/pull/24887/changes/30f4d27664dc6da63597705cc91371fde42bb869 contains the changes I made after cherrypicking the original commit.

## Related Linear tickets, Github issues, and Community forum posts

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
