### PR TITLE
ci: Optimize GHCR cleanup script with early termination and parallel pagination

### DIFF
--- a/.github/workflows/test-e2e-ci-reusable.yml
+++ b/.github/workflows/test-e2e-ci-reusable.yml
@@ -123,7 +123,7 @@ jobs:
     name: 'Cleanup Docker Image'
     needs: [multi-main-e2e, multi-main-isolated]
     if: ${{ !failure() && !cancelled() && !github.event.pull_request.head.repo.fork }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/test-e2e-ci-reusable.yml
+++ b/.github/workflows/test-e2e-ci-reusable.yml
@@ -137,4 +137,4 @@ jobs:
       - name: Delete images from GHCR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node .github/scripts/cleanup-ghcr-images.mjs --tag pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
+        run: node .github/scripts/cleanup-ghcr-images.mjs --pr ${{ github.event.pull_request.number }}

--- a/.github/workflows/test-e2e-ci-reusable.yml
+++ b/.github/workflows/test-e2e-ci-reusable.yml
@@ -137,4 +137,11 @@ jobs:
       - name: Delete images from GHCR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node .github/scripts/cleanup-ghcr-images.mjs --pr ${{ github.event.pull_request.number }}
+        run: |
+          if [ -n "${{ github.event.pull_request.number }}" ]; then
+            echo "PR context: cleaning all images for PR ${{ github.event.pull_request.number }}"
+            node .github/scripts/cleanup-ghcr-images.mjs --pr ${{ github.event.pull_request.number }}
+          else
+            echo "Merge queue context: cleaning image pr--${{ github.run_id }}"
+            node .github/scripts/cleanup-ghcr-images.mjs --tag pr--${{ github.run_id }}
+          fi

--- a/.github/workflows/util-cleanup-pr-images.yml
+++ b/.github/workflows/util-cleanup-pr-images.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   cleanup:
     name: 'Delete all PR images'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/util-cleanup-pr-images.yml
+++ b/.github/workflows/util-cleanup-pr-images.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   cleanup:
-    name: 'Delete all PR images'
+    name: 'Delete stale PR images'
     runs-on: ubuntu-slim
     permissions:
       packages: write
@@ -19,7 +19,7 @@ jobs:
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
 
-      - name: Delete all PR images
+      - name: Delete stale PR images
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node .github/scripts/cleanup-ghcr-images.mjs --all
+        run: node .github/scripts/cleanup-ghcr-images.mjs --stale 7

--- a/.github/workflows/util-cleanup-pr-images.yml
+++ b/.github/workflows/util-cleanup-pr-images.yml
@@ -1,18 +1,13 @@
 name: 'Util: Cleanup PR Docker Images'
 
 on:
-  pull_request:
-    types: [closed]
   schedule:
     # Weekly cleanup: Sunday at 3 AM UTC
     - cron: '0 3 * * 0'
 
 jobs:
   cleanup:
-    name: 'Delete PR images'
-    # Skip for fork PRs (they don't have GHCR images)
-    # Always run on schedule
-    if: ${{ github.event_name == 'schedule' || !github.event.pull_request.head.repo.fork }}
+    name: 'Delete all PR images'
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -21,20 +16,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          # On PR close, the PR branch may be deleted - use default branch
-          # On schedule, use the default ref
-          ref: ${{ github.event.repository.default_branch || github.ref }}
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
 
-      - name: Delete images for closed PR
-        if: ${{ github.event_name == 'pull_request' }}
+      - name: Delete all PR images
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node .github/scripts/cleanup-ghcr-images.mjs --pr ${{ github.event.pull_request.number }}
-
-      - name: Delete stale PR images
-        if: ${{ github.event_name == 'schedule' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node .github/scripts/cleanup-ghcr-images.mjs --stale 7
+        run: node .github/scripts/cleanup-ghcr-images.mjs --all


### PR DESCRIPTION
## Summary
  Optimizes GHCR cleanup from ~80s → ~5-20s by reducing unnecessary API pagination:
  [Before](https://github.com/n8n-io/n8n/actions/runs/21375714483/job/61533131186?pr=24884) - [After](https://github.com/n8n-io/n8n/actions/runs/21378455420/job/61541436523?pr=24892)  
  - PR cleanup (--pr): Early termination after 3 consecutive pages with no matches
  - Weekly cleanup: Replace --all with --stale <days> - parallel pagination + age-based filtering
  - Async refactor: execSync → execAsync for proper error handling
  - Fail-fast: Abort after 3 consecutive delete failures
  - Runner: Use ubuntu-slim for cleanup jobs

## Related Linear tickets, Github issues, and Community forum posts

  https://linear.app/n8n/issue/CAT-2226


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
