### PR TITLE
perf(core): Make MCP module exclusive to main

### DIFF
--- a/packages/cli/src/modules/__tests__/main-only-modules.test.ts
+++ b/packages/cli/src/modules/__tests__/main-only-modules.test.ts
@@ -6,11 +6,12 @@ import '../sso-saml/sso-saml.module';
 import '../source-control.ee/source-control.module';
 import '../provisioning.ee/provisioning.module';
 import '../breaking-changes/breaking-changes.module';
+import '../mcp/mcp.module';
 
 describe('main-only modules', () => {
 	const metadata = Container.get(ModuleMetadata);
 
-	test.each(['sso-oidc', 'sso-saml', 'source-control', 'provisioning', 'breaking-changes'])(
+	test.each(['sso-oidc', 'sso-saml', 'source-control', 'provisioning', 'breaking-changes', 'mcp'])(
 		'%s should only run on main',
 		(moduleName) => {
 			expect(metadata.get(moduleName)?.instanceTypes).toEqual(['main']);

--- a/packages/cli/src/modules/mcp/mcp.module.ts
+++ b/packages/cli/src/modules/mcp/mcp.module.ts
@@ -7,7 +7,7 @@ import { Container } from '@n8n/di';
  * Runs MCP server and exposes endpoints for MCP clients to connect to.
  * Requires MCP access to be enabled in settings and a valid API key.
  */
-@BackendModule({ name: 'mcp' })
+@BackendModule({ name: 'mcp', instanceTypes: ['main'] })
 export class McpModule implements ModuleInterface {
 	async init() {
 		await import('./mcp.controller');


### PR DESCRIPTION
## Summary

Unfamiliar with this feature, but it looks like this is main-only.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
