### PR TITLE
fix(core): Use proxy for all npm commands

### DIFF
--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -70,7 +70,7 @@ export const NPM_COMMAND_TOKENS = {
 	NPM_NO_VERSION_AVAILABLE: 'No valid versions available',
 	NPM_DISK_NO_SPACE: 'ENOSPC',
 	NPM_DISK_INSUFFICIENT_SPACE: 'insufficient space',
-};
+} as const;
 
 export const NPM_PACKAGE_STATUS_GOOD = 'OK';
 

--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.controller.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.controller.test.ts
@@ -1,3 +1,4 @@
+import type { InstanceSettings } from 'n8n-core';
 import type { CommunityNodeType } from '@n8n/api-types';
 import { mock } from 'jest-mock-extended';
 
@@ -15,12 +16,15 @@ describe('CommunityPackagesController', () => {
 	const communityPackagesService = mock<CommunityPackagesService>();
 	const eventService = mock<EventService>();
 	const communityNodeTypesService = mock<CommunityNodeTypesService>();
+	const instanceSettings = mock<InstanceSettings>();
+	(instanceSettings as any).nodesDownloadDir = '/tmp/n8n-nodes-download';
 
 	const controller = new CommunityPackagesController(
 		push,
 		communityPackagesService,
 		eventService,
 		communityNodeTypesService,
+		instanceSettings,
 	);
 
 	beforeEach(() => {

--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.integration.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.integration.test.ts
@@ -1,3 +1,8 @@
+jest.mock('../npm-utils', () => ({
+	...jest.requireActual('../npm-utils'),
+	executeNpmCommand: jest.fn(),
+}));
+
 import { mockInstance } from '@n8n/backend-test-utils';
 import path from 'path';
 
@@ -5,6 +10,7 @@ import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 import { CommunityPackagesService } from '@/modules/community-packages/community-packages.service';
 import type { InstalledNodes } from '@/modules/community-packages/installed-nodes.entity';
 import type { InstalledPackages } from '@/modules/community-packages/installed-packages.entity';
+import { executeNpmCommand } from '@/modules/community-packages/npm-utils';
 
 import { COMMUNITY_PACKAGE_VERSION } from '../../../../test/integration/shared/constants';
 import { createOwner } from '../../../../test/integration/shared/db/users';
@@ -19,6 +25,7 @@ import {
 const communityPackagesService = mockInstance(CommunityPackagesService, {
 	hasMissingPackages: false,
 });
+const mockedExecuteNpmCommand = jest.mocked(executeNpmCommand);
 mockInstance(LoadNodesAndCredentials);
 
 const testServer = setupTestServer({
@@ -114,7 +121,7 @@ describe('GET /community-packages', () => {
 	test('should not check for updates if no packages installed', async () => {
 		await authAgent.get('/community-packages');
 
-		expect(communityPackagesService.executeNpmCommand).not.toHaveBeenCalled();
+		expect(mockedExecuteNpmCommand).not.toHaveBeenCalled();
 	});
 
 	test('should check for updates if packages installed', async () => {
@@ -124,14 +131,14 @@ describe('GET /community-packages', () => {
 
 		const args = [['outdated', '--json'], { doNotHandleError: true }];
 
-		expect(communityPackagesService.executeNpmCommand).toHaveBeenCalledWith(...args);
+		expect(mockedExecuteNpmCommand).toHaveBeenCalledWith(...args);
 	});
 
 	test('should report package updates if available', async () => {
 		const pkg = mockPackage();
 		communityPackagesService.getAllInstalledPackages.mockResolvedValue([pkg]);
 
-		communityPackagesService.executeNpmCommand.mockImplementation(() => {
+		mockedExecuteNpmCommand.mockImplementation(() => {
 			throw {
 				code: 1,
 				stdout: JSON.stringify({

--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.integration.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.integration.test.ts
@@ -129,7 +129,7 @@ describe('GET /community-packages', () => {
 
 		await authAgent.get('/community-packages').expect(200);
 
-		const args = [['outdated', '--json'], { doNotHandleError: true }];
+		const args = [['outdated', '--json'], { doNotHandleError: true, cwd: expect.any(String) }];
 
 		expect(mockedExecuteNpmCommand).toHaveBeenCalledWith(...args);
 	});

--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.service.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.service.test.ts
@@ -10,12 +10,7 @@ import { execFile } from 'node:child_process';
 import { access, constants, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import path, { join } from 'node:path';
 
-import {
-	NODE_PACKAGE_PREFIX,
-	NPM_COMMAND_TOKENS,
-	NPM_PACKAGE_STATUS_GOOD,
-	RESPONSE_ERROR_MESSAGES,
-} from '@/constants';
+import { NODE_PACKAGE_PREFIX, NPM_PACKAGE_STATUS_GOOD } from '@/constants';
 import { FeatureNotLicensedError } from '@/errors/feature-not-licensed.error';
 import type { License } from '@/license';
 import type { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
@@ -23,8 +18,8 @@ import type { Publisher } from '@/scaling/pubsub/publisher.service';
 import { COMMUNITY_NODE_VERSION, COMMUNITY_PACKAGE_VERSION } from '@test-integration/constants';
 import { mockPackageName, mockPackagePair } from '@test-integration/utils';
 
-import type { CommunityPackagesConfig } from '../community-packages.config';
 import { getCommunityNodeTypes } from '../community-node-types-utils';
+import type { CommunityPackagesConfig } from '../community-packages.config';
 import { CommunityPackagesService } from '../community-packages.service';
 import type { CommunityPackages } from '../community-packages.types';
 import { InstalledNodes } from '../installed-nodes.entity';
@@ -376,11 +371,11 @@ describe('CommunityPackagesService', () => {
 			jest.clearAllMocks();
 
 			mocked(execFile).mockImplementation(execMockForThisBlock);
-			mocked(executeNpmCommand).mockImplementation((args: string[]) => {
+			mocked(executeNpmCommand).mockImplementation(async (args: string[]) => {
 				if (args[0] === 'pack') {
-					return Promise.resolve(testBlockTarballName);
+					return testBlockTarballName;
 				}
-				return Promise.resolve('Done');
+				return 'Done';
 			});
 
 			mocked(readFile).mockResolvedValue(

--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.service.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.service.test.ts
@@ -39,7 +39,6 @@ jest.mock('../npm-utils', () => ({
 	executeNpmCommand: jest.fn(),
 }));
 
-type ExecFileOptions = NonNullable<Parameters<typeof execFile>[2]>;
 type ExecFileCallback = NonNullable<Parameters<typeof execFile>[3]>;
 
 const execMock: typeof execFile = ((...args) => {

--- a/packages/cli/src/modules/community-packages/__tests__/npm-utils.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/npm-utils.test.ts
@@ -22,6 +22,7 @@ jest.mock('node:util', () => {
 });
 
 import { executeNpmCommand, verifyIntegrity, checkIfVersionExistsOrThrow } from '../npm-utils';
+import { NPM_COMMAND_TOKENS } from '@/constants';
 
 describe('executeNpmCommand', () => {
 	beforeEach(() => {
@@ -83,7 +84,9 @@ describe('executeNpmCommand', () => {
 
 		it('should throw UnexpectedError for package not found (E404)', async () => {
 			mockAsyncExec.mockRejectedValue(
-				new Error('E404 - GET https://registry.npmjs.org/nonexistent-package'),
+				new Error(
+					`${NPM_COMMAND_TOKENS.NPM_PACKAGE_NOT_FOUND_ERROR} - GET https://registry.npmjs.org/nonexistent-package`,
+				),
 			);
 
 			await expect(executeNpmCommand(['view', 'nonexistent-package'])).rejects.toThrow(
@@ -108,7 +111,9 @@ describe('executeNpmCommand', () => {
 		});
 
 		it('should throw UnexpectedError for package version not found', async () => {
-			mockAsyncExec.mockRejectedValue(new Error('version not found for package@1.2.3'));
+			mockAsyncExec.mockRejectedValue(
+				new Error(`${NPM_COMMAND_TOKENS.NPM_PACKAGE_VERSION_NOT_FOUND_ERROR} package@1.2.3`),
+			);
 
 			await expect(executeNpmCommand(['install', 'package@1.2.3'])).rejects.toThrow(
 				new UnexpectedError('Package version not found in npm registry'),
@@ -116,7 +121,9 @@ describe('executeNpmCommand', () => {
 		});
 
 		it('should throw UnexpectedError for disk full (ENOSPC)', async () => {
-			mockAsyncExec.mockRejectedValue(new Error('ENOSPC: no space left on device'));
+			mockAsyncExec.mockRejectedValue(
+				new Error(`${NPM_COMMAND_TOKENS.NPM_DISK_NO_SPACE}: no space left on device`),
+			);
 
 			await expect(executeNpmCommand(['install', 'some-package'])).rejects.toThrow(
 				new UnexpectedError('Disk is full - insufficient space to install package'),

--- a/packages/cli/src/modules/community-packages/__tests__/npm-utils.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/npm-utils.test.ts
@@ -22,7 +22,7 @@ jest.mock('node:util', () => {
 });
 
 import { executeNpmCommand, verifyIntegrity, checkIfVersionExistsOrThrow } from '../npm-utils';
-import { NPM_COMMAND_TOKENS } from '@/constants';
+import { NPM_COMMAND_TOKENS, RESPONSE_ERROR_MESSAGES } from '@/constants';
 
 describe('executeNpmCommand', () => {
 	beforeEach(() => {
@@ -78,7 +78,7 @@ describe('executeNpmCommand', () => {
 			);
 
 			await expect(executeNpmCommand(['install', 'nonexistent-package'])).rejects.toThrow(
-				new UnexpectedError('Package not found in npm registry'),
+				new UnexpectedError(RESPONSE_ERROR_MESSAGES.PACKAGE_NOT_FOUND),
 			);
 		});
 
@@ -90,7 +90,7 @@ describe('executeNpmCommand', () => {
 			);
 
 			await expect(executeNpmCommand(['view', 'nonexistent-package'])).rejects.toThrow(
-				new UnexpectedError('Package not found in npm registry'),
+				new UnexpectedError(RESPONSE_ERROR_MESSAGES.PACKAGE_NOT_FOUND),
 			);
 		});
 
@@ -98,7 +98,7 @@ describe('executeNpmCommand', () => {
 			mockAsyncExec.mockRejectedValue(new Error('404 Not Found - package does not exist'));
 
 			await expect(executeNpmCommand(['install', 'nonexistent-package'])).rejects.toThrow(
-				new UnexpectedError('Package not found in npm registry'),
+				new UnexpectedError(RESPONSE_ERROR_MESSAGES.PACKAGE_NOT_FOUND),
 			);
 		});
 
@@ -106,7 +106,7 @@ describe('executeNpmCommand', () => {
 			mockAsyncExec.mockRejectedValue(new Error('No valid versions available for package'));
 
 			await expect(executeNpmCommand(['install', 'some-package'])).rejects.toThrow(
-				new UnexpectedError('Package not found in npm registry'),
+				new UnexpectedError(RESPONSE_ERROR_MESSAGES.PACKAGE_NOT_FOUND),
 			);
 		});
 
@@ -116,7 +116,7 @@ describe('executeNpmCommand', () => {
 			);
 
 			await expect(executeNpmCommand(['install', 'package@1.2.3'])).rejects.toThrow(
-				new UnexpectedError('Package version not found in npm registry'),
+				new UnexpectedError(RESPONSE_ERROR_MESSAGES.PACKAGE_VERSION_NOT_FOUND),
 			);
 		});
 
@@ -126,7 +126,7 @@ describe('executeNpmCommand', () => {
 			);
 
 			await expect(executeNpmCommand(['install', 'some-package'])).rejects.toThrow(
-				new UnexpectedError('Disk is full - insufficient space to install package'),
+				new UnexpectedError(RESPONSE_ERROR_MESSAGES.DISK_IS_FULL),
 			);
 		});
 
@@ -134,7 +134,7 @@ describe('executeNpmCommand', () => {
 			mockAsyncExec.mockRejectedValue(new Error('Error: insufficient space on device'));
 
 			await expect(executeNpmCommand(['install', 'large-package'])).rejects.toThrow(
-				new UnexpectedError('Disk is full - insufficient space to install package'),
+				new UnexpectedError(RESPONSE_ERROR_MESSAGES.DISK_IS_FULL),
 			);
 		});
 
@@ -208,14 +208,14 @@ describe('executeNpmCommand', () => {
 
 			await expect(
 				executeNpmCommand(['install', 'nonexistent'], { doNotHandleError: false }),
-			).rejects.toThrow(new UnexpectedError('Package not found in npm registry'));
+			).rejects.toThrow(new UnexpectedError(RESPONSE_ERROR_MESSAGES.PACKAGE_NOT_FOUND));
 		});
 
 		it('should handle errors normally when doNotHandleError is undefined (default)', async () => {
 			mockAsyncExec.mockRejectedValue(new Error('npm ERR! 404 Not Found'));
 
 			await expect(executeNpmCommand(['install', 'nonexistent'])).rejects.toThrow(
-				new UnexpectedError('Package not found in npm registry'),
+				new UnexpectedError(RESPONSE_ERROR_MESSAGES.PACKAGE_NOT_FOUND),
 			);
 		});
 	});

--- a/packages/cli/src/modules/community-packages/__tests__/npm-utils.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/npm-utils.test.ts
@@ -21,7 +21,263 @@ jest.mock('node:util', () => {
 	};
 });
 
-import { verifyIntegrity, checkIfVersionExistsOrThrow } from '../npm-utils';
+import { executeNpmCommand, verifyIntegrity, checkIfVersionExistsOrThrow } from '../npm-utils';
+
+describe('executeNpmCommand', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockAsyncExec.mockReset();
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('successful execution', () => {
+		it('should execute npm command and return stdout as string', async () => {
+			mockAsyncExec.mockResolvedValue({
+				stdout: 'command output',
+				stderr: '',
+			});
+
+			const result = await executeNpmCommand(['install', 'some-package']);
+
+			expect(result).toBe('command output');
+			expect(mockAsyncExec).toHaveBeenCalledWith('npm', ['install', 'some-package'], undefined);
+		});
+
+		it('should execute npm command with cwd option', async () => {
+			mockAsyncExec.mockResolvedValue({
+				stdout: 'command output',
+				stderr: '',
+			});
+
+			const result = await executeNpmCommand(['install'], { cwd: '/some/path' });
+
+			expect(result).toBe('command output');
+			expect(mockAsyncExec).toHaveBeenCalledWith('npm', ['install'], { cwd: '/some/path' });
+		});
+
+		it('should convert Buffer stdout to string', async () => {
+			mockAsyncExec.mockResolvedValue({
+				stdout: Buffer.from('buffer output'),
+				stderr: '',
+			});
+
+			const result = await executeNpmCommand(['list']);
+
+			expect(result).toBe('buffer output');
+		});
+	});
+
+	describe('error handling', () => {
+		it('should throw UnexpectedError for package not found (npm ERR! 404)', async () => {
+			mockAsyncExec.mockRejectedValue(
+				new Error('npm ERR! 404 Not Found - GET https://registry.npmjs.org/nonexistent-package'),
+			);
+
+			await expect(executeNpmCommand(['install', 'nonexistent-package'])).rejects.toThrow(
+				new UnexpectedError('Package not found in npm registry'),
+			);
+		});
+
+		it('should throw UnexpectedError for package not found (E404)', async () => {
+			mockAsyncExec.mockRejectedValue(
+				new Error('E404 - GET https://registry.npmjs.org/nonexistent-package'),
+			);
+
+			await expect(executeNpmCommand(['view', 'nonexistent-package'])).rejects.toThrow(
+				new UnexpectedError('Package not found in npm registry'),
+			);
+		});
+
+		it('should throw UnexpectedError for package not found (404 Not Found)', async () => {
+			mockAsyncExec.mockRejectedValue(new Error('404 Not Found - package does not exist'));
+
+			await expect(executeNpmCommand(['install', 'nonexistent-package'])).rejects.toThrow(
+				new UnexpectedError('Package not found in npm registry'),
+			);
+		});
+
+		it('should throw UnexpectedError for no version available', async () => {
+			mockAsyncExec.mockRejectedValue(new Error('No valid versions available for package'));
+
+			await expect(executeNpmCommand(['install', 'some-package'])).rejects.toThrow(
+				new UnexpectedError('Package not found in npm registry'),
+			);
+		});
+
+		it('should throw UnexpectedError for package version not found', async () => {
+			mockAsyncExec.mockRejectedValue(new Error('version not found for package@1.2.3'));
+
+			await expect(executeNpmCommand(['install', 'package@1.2.3'])).rejects.toThrow(
+				new UnexpectedError('Package version not found in npm registry'),
+			);
+		});
+
+		it('should throw UnexpectedError for disk full (ENOSPC)', async () => {
+			mockAsyncExec.mockRejectedValue(new Error('ENOSPC: no space left on device'));
+
+			await expect(executeNpmCommand(['install', 'some-package'])).rejects.toThrow(
+				new UnexpectedError('Disk is full - insufficient space to install package'),
+			);
+		});
+
+		it('should throw UnexpectedError for insufficient disk space', async () => {
+			mockAsyncExec.mockRejectedValue(new Error('Error: insufficient space on device'));
+
+			await expect(executeNpmCommand(['install', 'large-package'])).rejects.toThrow(
+				new UnexpectedError('Disk is full - insufficient space to install package'),
+			);
+		});
+
+		it('should throw UnexpectedError for DNS getaddrinfo errors', async () => {
+			mockAsyncExec.mockRejectedValue(new Error('getaddrinfo ENOTFOUND registry.npmjs.org'));
+
+			await expect(executeNpmCommand(['install', 'some-package'])).rejects.toThrow(
+				new UnexpectedError(
+					'Network error: Unable to reach npm registry. Please check your internet connection.',
+				),
+			);
+		});
+
+		it('should throw UnexpectedError for DNS ENOTFOUND errors', async () => {
+			mockAsyncExec.mockRejectedValue(new Error('ENOTFOUND registry.npmjs.org'));
+
+			await expect(executeNpmCommand(['install', 'some-package'])).rejects.toThrow(
+				new UnexpectedError(
+					'Network error: Unable to reach npm registry. Please check your internet connection.',
+				),
+			);
+		});
+
+		it('should throw generic UnexpectedError for unknown errors', async () => {
+			mockAsyncExec.mockRejectedValue(new Error('Some unknown error'));
+
+			await expect(executeNpmCommand(['install', 'some-package'])).rejects.toThrow(
+				'Failed to execute npm command',
+			);
+		});
+
+		it('should preserve the original error as cause', async () => {
+			const originalError = new Error('Some unknown error');
+			mockAsyncExec.mockRejectedValue(originalError);
+
+			try {
+				await executeNpmCommand(['install', 'some-package']);
+				fail('Should have thrown an error');
+			} catch (error) {
+				expect(error).toBeInstanceOf(UnexpectedError);
+				expect((error as UnexpectedError).cause).toBe(originalError);
+			}
+		});
+	});
+
+	describe('doNotHandleError option', () => {
+		it('should throw raw error when doNotHandleError is true', async () => {
+			const rawError = new Error('Raw npm error');
+			mockAsyncExec.mockRejectedValue(rawError);
+
+			await expect(
+				executeNpmCommand(['outdated', '--json'], { doNotHandleError: true }),
+			).rejects.toThrow(rawError);
+		});
+
+		it('should not convert error to UnexpectedError when doNotHandleError is true', async () => {
+			const rawError = new Error('npm ERR! 404 Not Found');
+			mockAsyncExec.mockRejectedValue(rawError);
+
+			try {
+				await executeNpmCommand(['install', 'nonexistent'], { doNotHandleError: true });
+				fail('Should have thrown an error');
+			} catch (error) {
+				expect(error).toBe(rawError);
+				expect(error).not.toBeInstanceOf(UnexpectedError);
+			}
+		});
+
+		it('should handle errors normally when doNotHandleError is false', async () => {
+			mockAsyncExec.mockRejectedValue(new Error('npm ERR! 404 Not Found'));
+
+			await expect(
+				executeNpmCommand(['install', 'nonexistent'], { doNotHandleError: false }),
+			).rejects.toThrow(new UnexpectedError('Package not found in npm registry'));
+		});
+
+		it('should handle errors normally when doNotHandleError is undefined (default)', async () => {
+			mockAsyncExec.mockRejectedValue(new Error('npm ERR! 404 Not Found'));
+
+			await expect(executeNpmCommand(['install', 'nonexistent'])).rejects.toThrow(
+				new UnexpectedError('Package not found in npm registry'),
+			);
+		});
+	});
+
+	describe('command arguments', () => {
+		it('should pass all arguments to npm command', async () => {
+			mockAsyncExec.mockResolvedValue({
+				stdout: 'success',
+				stderr: '',
+			});
+
+			await executeNpmCommand([
+				'install',
+				'package-name@1.0.0',
+				'--registry=https://custom-registry.com',
+				'--json',
+			]);
+
+			expect(mockAsyncExec).toHaveBeenCalledWith(
+				'npm',
+				['install', 'package-name@1.0.0', '--registry=https://custom-registry.com', '--json'],
+				undefined,
+			);
+		});
+
+		it('should handle empty arguments array', async () => {
+			mockAsyncExec.mockResolvedValue({
+				stdout: 'npm help output',
+				stderr: '',
+			});
+
+			const result = await executeNpmCommand([]);
+
+			expect(result).toBe('npm help output');
+			expect(mockAsyncExec).toHaveBeenCalledWith('npm', [], undefined);
+		});
+	});
+
+	describe('edge cases', () => {
+		it('should handle non-Error objects being thrown', async () => {
+			mockAsyncExec.mockRejectedValue('string error');
+
+			await expect(executeNpmCommand(['install', 'some-package'])).rejects.toThrow(
+				new UnexpectedError('Failed to execute npm command'),
+			);
+		});
+
+		it('should handle errors with no message', async () => {
+			const errorWithoutMessage = new Error();
+			errorWithoutMessage.message = '';
+			mockAsyncExec.mockRejectedValue(errorWithoutMessage);
+
+			await expect(executeNpmCommand(['install', 'some-package'])).rejects.toThrow(
+				'Failed to execute npm command',
+			);
+		});
+
+		it('should handle empty stdout', async () => {
+			mockAsyncExec.mockResolvedValue({
+				stdout: '',
+				stderr: '',
+			});
+
+			const result = await executeNpmCommand(['prune']);
+
+			expect(result).toBe('');
+		});
+	});
+});
 
 describe('verifyIntegrity', () => {
 	const registryUrl = 'https://registry.npmjs.org';
@@ -133,13 +389,17 @@ describe('verifyIntegrity', () => {
 			).resolves.not.toThrow();
 
 			expect(mockAsyncExec).toHaveBeenCalledTimes(1);
-			expect(mockAsyncExec).toHaveBeenCalledWith('npm', [
-				'view',
-				`${packageName}@${version}`,
-				'dist.integrity',
-				`--registry=${registryUrl}`,
-				'--json',
-			]);
+			expect(mockAsyncExec).toHaveBeenCalledWith(
+				'npm',
+				[
+					'view',
+					`${packageName}@${version}`,
+					'dist.integrity',
+					`--registry=${registryUrl}`,
+					'--json',
+				],
+				undefined,
+			);
 		});
 
 		it('should fallback to npm CLI and throw error when integrity does not match', async () => {
@@ -177,13 +437,17 @@ describe('verifyIntegrity', () => {
 			await verifyIntegrity(specialPackageName, specialVersion, registryUrl, integrity);
 
 			expect(mockAsyncExec).toHaveBeenCalledTimes(1);
-			expect(mockAsyncExec).toHaveBeenCalledWith('npm', [
-				'view',
-				`${specialPackageName}@${specialVersion}`,
-				'dist.integrity',
-				`--registry=${registryUrl}`,
-				'--json',
-			]);
+			expect(mockAsyncExec).toHaveBeenCalledWith(
+				'npm',
+				[
+					'view',
+					`${specialPackageName}@${specialVersion}`,
+					'dist.integrity',
+					`--registry=${registryUrl}`,
+					'--json',
+				],
+				undefined,
+			);
 		});
 
 		it('should handle DNS errors in CLI fallback', async () => {
@@ -353,13 +617,11 @@ describe('checkIfVersionExistsOrThrow', () => {
 			const result = await checkIfVersionExistsOrThrow(packageName, version, registryUrl);
 			expect(result).toBe(true);
 			expect(mockAsyncExec).toHaveBeenCalledTimes(1);
-			expect(mockAsyncExec).toHaveBeenCalledWith('npm', [
-				'view',
-				`${packageName}@${version}`,
-				'version',
-				`--registry=${registryUrl}`,
-				'--json',
-			]);
+			expect(mockAsyncExec).toHaveBeenCalledWith(
+				'npm',
+				['view', `${packageName}@${version}`, 'version', `--registry=${registryUrl}`, '--json'],
+				undefined,
+			);
 		});
 
 		it('should fallback to npm CLI and throw error when version does not match', async () => {
@@ -400,13 +662,17 @@ describe('checkIfVersionExistsOrThrow', () => {
 			);
 			expect(result).toBe(true);
 			expect(mockAsyncExec).toHaveBeenCalledTimes(1);
-			expect(mockAsyncExec).toHaveBeenCalledWith('npm', [
-				'view',
-				`${specialPackageName}@${specialVersion}`,
-				'version',
-				`--registry=${registryUrl}`,
-				'--json',
-			]);
+			expect(mockAsyncExec).toHaveBeenCalledWith(
+				'npm',
+				[
+					'view',
+					`${specialPackageName}@${specialVersion}`,
+					'version',
+					`--registry=${registryUrl}`,
+					'--json',
+				],
+				undefined,
+			);
 		});
 
 		it('should handle 404 errors in CLI fallback', async () => {

--- a/packages/cli/src/modules/community-packages/community-node.command.ts
+++ b/packages/cli/src/modules/community-packages/community-node.command.ts
@@ -2,6 +2,7 @@ import type { User } from '@n8n/db';
 import { CredentialsRepository, UserRepository } from '@n8n/db';
 import { Command } from '@n8n/decorators';
 import { Container } from '@n8n/di';
+import { InstanceSettings } from 'n8n-core';
 import { z } from 'zod';
 
 import { BaseCommand } from '@/commands/base-command';
@@ -11,6 +12,7 @@ import { CommunityPackagesService } from './community-packages.service';
 import { InstalledNodes } from './installed-nodes.entity';
 import { InstalledNodesRepository } from './installed-nodes.repository';
 import { InstalledPackages } from './installed-packages.entity';
+import { executeNpmCommand } from './npm-utils';
 
 const flagsSchema = z.object({
 	uninstall: z.boolean().describe('Uninstalls the node').optional(),
@@ -137,7 +139,8 @@ export class CommunityNode extends BaseCommand<z.infer<typeof flagsSchema>> {
 	}
 
 	async pruneDependencies() {
-		await Container.get(CommunityPackagesService).executeNpmCommand(['prune']);
+		const instanceSettings = Container.get(InstanceSettings);
+		await executeNpmCommand(['prune'], { cwd: instanceSettings.nodesDownloadDir });
 	}
 
 	async deleteCommunityNode(node: InstalledNodes) {

--- a/packages/cli/src/modules/community-packages/community-packages.controller.ts
+++ b/packages/cli/src/modules/community-packages/community-packages.controller.ts
@@ -17,6 +17,7 @@ import { CommunityPackagesService } from './community-packages.service';
 import type { CommunityPackages } from './community-packages.types';
 import { InstalledPackages } from './installed-packages.entity';
 import { executeNpmCommand } from './npm-utils';
+import { InstanceSettings } from 'n8n-core';
 
 const {
 	PACKAGE_NOT_INSTALLED,
@@ -42,6 +43,7 @@ export class CommunityPackagesController {
 		private readonly communityPackagesService: CommunityPackagesService,
 		private readonly eventService: EventService,
 		private readonly communityNodeTypesService: CommunityNodeTypesService,
+		private readonly instanceSettings: InstanceSettings,
 	) {}
 
 	@Post('/')
@@ -170,7 +172,10 @@ export class CommunityPackagesController {
 		let pendingUpdates: CommunityPackages.AvailableUpdates | undefined;
 
 		try {
-			await executeNpmCommand(['outdated', '--json'], { doNotHandleError: true });
+			await executeNpmCommand(['outdated', '--json'], {
+				doNotHandleError: true,
+				cwd: this.instanceSettings.nodesDownloadDir,
+			});
 		} catch (error) {
 			// when there are updates, npm exits with code 1
 			// when there are no updates, command succeeds

--- a/packages/cli/src/modules/community-packages/npm-utils.ts
+++ b/packages/cli/src/modules/community-packages/npm-utils.ts
@@ -1,4 +1,4 @@
-import { NPM_COMMAND_TOKENS } from '@/constants';
+import { NPM_COMMAND_TOKENS, RESPONSE_ERROR_MESSAGES } from '@/constants';
 import axios from 'axios';
 import { jsonParse, UnexpectedError, LoggerProxy } from 'n8n-workflow';
 import { execFile } from 'node:child_process';
@@ -71,22 +71,22 @@ export async function executeNpmCommand(
 
 		// Check for specific error patterns
 		if (matchesErrorPattern(errorMessage, NPM_ERROR_PATTERNS.PACKAGE_NOT_FOUND)) {
-			throw new UnexpectedError('Package not found in npm registry');
+			throw new UnexpectedError(RESPONSE_ERROR_MESSAGES.PACKAGE_NOT_FOUND);
 		}
 
 		if (matchesErrorPattern(errorMessage, NPM_ERROR_PATTERNS.NO_VERSION_AVAILABLE)) {
-			throw new UnexpectedError('Package not found in npm registry');
+			throw new UnexpectedError(RESPONSE_ERROR_MESSAGES.PACKAGE_NOT_FOUND);
 		}
 
 		if (matchesErrorPattern(errorMessage, NPM_ERROR_PATTERNS.PACKAGE_VERSION_NOT_FOUND)) {
-			throw new UnexpectedError('Package version not found in npm registry');
+			throw new UnexpectedError(RESPONSE_ERROR_MESSAGES.PACKAGE_VERSION_NOT_FOUND);
 		}
 
 		if (
 			matchesErrorPattern(errorMessage, NPM_ERROR_PATTERNS.DISK_NO_SPACE) ||
 			matchesErrorPattern(errorMessage, NPM_ERROR_PATTERNS.DISK_INSUFFICIENT_SPACE)
 		) {
-			throw new UnexpectedError('Disk is full - insufficient space to install package');
+			throw new UnexpectedError(RESPONSE_ERROR_MESSAGES.DISK_IS_FULL);
 		}
 
 		if (isDnsError(error)) {

--- a/packages/cli/src/modules/community-packages/npm-utils.ts
+++ b/packages/cli/src/modules/community-packages/npm-utils.ts
@@ -1,11 +1,24 @@
 import axios from 'axios';
-import { jsonParse, UnexpectedError } from 'n8n-workflow';
+import { jsonParse, UnexpectedError, LoggerProxy } from 'n8n-workflow';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
 const asyncExecFile = promisify(execFile);
 
 const REQUEST_TIMEOUT = 30000;
+
+const NPM_ERROR_PATTERNS = {
+	PACKAGE_NOT_FOUND: ['npm ERR! 404', 'E404', '404 Not Found'],
+	NO_VERSION_AVAILABLE: ['No valid versions available'],
+	PACKAGE_VERSION_NOT_FOUND: ['version not found'],
+	DISK_NO_SPACE: ['ENOSPC'],
+	DISK_INSUFFICIENT_SPACE: ['insufficient space'],
+} as const;
+
+interface NpmCommandOptions {
+	cwd?: string;
+	doNotHandleError?: boolean;
+}
 
 function isDnsError(error: unknown): boolean {
 	const message = error instanceof Error ? error.message : String(error);
@@ -24,6 +37,65 @@ function isNpmError(error: unknown): boolean {
 
 function sanitizeRegistryUrl(registryUrl: string): string {
 	return registryUrl.replace(/\/+$/, '');
+}
+
+function matchesErrorPattern(message: string, patterns: readonly string[]): boolean {
+	return patterns.some((pattern) => message.includes(pattern));
+}
+
+/**
+ * Executes an npm command with proper error handling.
+ * @param args - Array of npm command arguments
+ * @param options - Execution options (cwd, throwOnError)
+ * @returns The stdout from the npm command
+ * @throws {UnexpectedError} When the command fails and throwOnError is true
+ */
+export async function executeNpmCommand(
+	args: string[],
+	options: NpmCommandOptions = {},
+): Promise<string> {
+	const { cwd, doNotHandleError } = options;
+
+	try {
+		const { stdout } = await asyncExecFile('npm', args, cwd ? { cwd } : undefined);
+		return typeof stdout === 'string' ? stdout : stdout.toString();
+	} catch (error) {
+		if (doNotHandleError) {
+			throw error;
+		}
+
+		const errorMessage = error instanceof Error ? error.message : String(error);
+
+		LoggerProxy.warn('Failed to execute npm command', { errorMessage });
+
+		// Check for specific error patterns
+		if (matchesErrorPattern(errorMessage, NPM_ERROR_PATTERNS.PACKAGE_NOT_FOUND)) {
+			throw new UnexpectedError('Package not found in npm registry');
+		}
+
+		if (matchesErrorPattern(errorMessage, NPM_ERROR_PATTERNS.NO_VERSION_AVAILABLE)) {
+			throw new UnexpectedError('Package not found in npm registry');
+		}
+
+		if (matchesErrorPattern(errorMessage, NPM_ERROR_PATTERNS.PACKAGE_VERSION_NOT_FOUND)) {
+			throw new UnexpectedError('Package version not found in npm registry');
+		}
+
+		if (
+			matchesErrorPattern(errorMessage, NPM_ERROR_PATTERNS.DISK_NO_SPACE) ||
+			matchesErrorPattern(errorMessage, NPM_ERROR_PATTERNS.DISK_INSUFFICIENT_SPACE)
+		) {
+			throw new UnexpectedError('Disk is full - insufficient space to install package');
+		}
+
+		if (isDnsError(error)) {
+			throw new UnexpectedError(
+				'Network error: Unable to reach npm registry. Please check your internet connection.',
+			);
+		}
+
+		throw new UnexpectedError('Failed to execute npm command', { cause: error });
+	}
 }
 
 export async function verifyIntegrity(
@@ -46,13 +118,16 @@ export async function verifyIntegrity(
 		return;
 	} catch (error) {
 		try {
-			const { stdout } = await asyncExecFile('npm', [
-				'view',
-				`${packageName}@${version}`,
-				'dist.integrity',
-				`--registry=${sanitizeRegistryUrl(registryUrl)}`,
-				'--json',
-			]);
+			const stdout = await executeNpmCommand(
+				[
+					'view',
+					`${packageName}@${version}`,
+					'dist.integrity',
+					`--registry=${sanitizeRegistryUrl(registryUrl)}`,
+					'--json',
+				],
+				{ doNotHandleError: true },
+			);
 
 			const integrity = jsonParse(stdout);
 			if (integrity !== expectedIntegrity) {
@@ -84,13 +159,16 @@ export async function checkIfVersionExistsOrThrow(
 		return true;
 	} catch (error) {
 		try {
-			const { stdout } = await asyncExecFile('npm', [
-				'view',
-				`${packageName}@${version}`,
-				'version',
-				`--registry=${sanitizeRegistryUrl(registryUrl)}`,
-				'--json',
-			]);
+			const stdout = await executeNpmCommand(
+				[
+					'view',
+					`${packageName}@${version}`,
+					'version',
+					`--registry=${sanitizeRegistryUrl(registryUrl)}`,
+					'--json',
+				],
+				{ doNotHandleError: true },
+			);
 
 			const versionInfo = jsonParse(stdout);
 			if (versionInfo === version) {

--- a/packages/cli/src/modules/community-packages/npm-utils.ts
+++ b/packages/cli/src/modules/community-packages/npm-utils.ts
@@ -1,3 +1,4 @@
+import { NPM_COMMAND_TOKENS } from '@/constants';
 import axios from 'axios';
 import { jsonParse, UnexpectedError, LoggerProxy } from 'n8n-workflow';
 import { execFile } from 'node:child_process';
@@ -8,11 +9,11 @@ const asyncExecFile = promisify(execFile);
 const REQUEST_TIMEOUT = 30000;
 
 const NPM_ERROR_PATTERNS = {
-	PACKAGE_NOT_FOUND: ['npm ERR! 404', 'E404', '404 Not Found'],
-	NO_VERSION_AVAILABLE: ['No valid versions available'],
-	PACKAGE_VERSION_NOT_FOUND: ['version not found'],
-	DISK_NO_SPACE: ['ENOSPC'],
-	DISK_INSUFFICIENT_SPACE: ['insufficient space'],
+	PACKAGE_NOT_FOUND: [NPM_COMMAND_TOKENS.NPM_PACKAGE_NOT_FOUND_ERROR],
+	NO_VERSION_AVAILABLE: [NPM_COMMAND_TOKENS.NPM_NO_VERSION_AVAILABLE],
+	PACKAGE_VERSION_NOT_FOUND: [NPM_COMMAND_TOKENS.NPM_PACKAGE_VERSION_NOT_FOUND_ERROR],
+	DISK_NO_SPACE: [NPM_COMMAND_TOKENS.NPM_DISK_NO_SPACE],
+	DISK_INSUFFICIENT_SPACE: [NPM_COMMAND_TOKENS.NPM_DISK_INSUFFICIENT_SPACE],
 } as const;
 
 interface NpmCommandOptions {


### PR DESCRIPTION
## Summary

This PR refactors all `npm` usages on backend to use a single helper method. It fixes issues when some npm commands that were using deprecated `executeNpmCommand` would not use proxy configuration because not all envs were passed to the command.

How to test:
- install tinyproxy
- use default configuration from their [website](https://tinyproxy.github.io/)
- set `HTTP_PROXY=http://127.0.0.1:port` and `HTTPS_PROXY=http://127.0.0.1:port` in n8n env variables
- Verify that requests to npm registry go through proxy

<img width="970" height="516" alt="image" src="https://github.com/user-attachments/assets/4fcd5887-ef7b-4860-ab4f-168628bad764" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4197/community-issue-bug-http-proxy-environment-variables-not-passed
closes #24162 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
