### PR TITLE
fix: Validate OpenAI urls

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/OpenAiAssistant/OpenAiAssistant.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/OpenAiAssistant/OpenAiAssistant.node.ts
@@ -16,6 +16,7 @@ import { getTracingConfig } from '@utils/tracing';
 import { formatToOpenAIAssistantTool } from './utils';
 import { Container } from '@n8n/di';
 import { AiConfig } from '@n8n/config';
+import { checkDomainRestrictions } from '@utils/checkDomainRestrictions';
 
 export class OpenAiAssistant implements INodeType {
 	description: INodeTypeDescription = {
@@ -342,6 +343,10 @@ export class OpenAiAssistant implements INodeType {
 				}
 
 				const { openAiDefaultHeaders: defaultHeaders } = Container.get(AiConfig);
+
+				if (options.baseURL) {
+					checkDomainRestrictions(this, credentials, options.baseURL);
+				}
 
 				const client = new OpenAIClient({
 					apiKey: credentials.apiKey as string,

--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsOpenAI/EmbeddingsOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsOpenAI/EmbeddingsOpenAi.node.ts
@@ -1,20 +1,20 @@
 import { OpenAIEmbeddings } from '@langchain/openai';
+import { AiConfig } from '@n8n/config';
+import { Container } from '@n8n/di';
 import {
 	NodeConnectionTypes,
+	type INodeProperties,
 	type INodeType,
 	type INodeTypeDescription,
-	type SupplyData,
 	type ISupplyDataFunctions,
-	type INodeProperties,
+	type SupplyData,
 } from 'n8n-workflow';
 import type { ClientOptions } from 'openai';
 
-import { logWrapper } from '@utils/logWrapper';
-
+import { checkDomainRestrictions } from '@utils/checkDomainRestrictions';
 import { getProxyAgent } from '@utils/httpProxyAgent';
+import { logWrapper } from '@utils/logWrapper';
 import { getConnectionHintNoticeField } from '@utils/sharedFields';
-import { Container } from '@n8n/di';
-import { AiConfig } from '@n8n/config';
 
 const modelParameter: INodeProperties = {
 	displayName: 'Model',
@@ -253,6 +253,7 @@ export class EmbeddingsOpenAi implements INodeType {
 			defaultHeaders,
 		};
 		if (options.baseURL) {
+			checkDomainRestrictions(this, credentials, options.baseURL);
 			configuration.baseURL = options.baseURL;
 		} else if (credentials.url) {
 			configuration.baseURL = credentials.url as string;

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
@@ -10,6 +10,7 @@ import {
 	type SupplyData,
 } from 'n8n-workflow';
 
+import { checkDomainRestrictions } from '@utils/checkDomainRestrictions';
 import { getProxyAgent } from '@utils/httpProxyAgent';
 import { getConnectionHintNoticeField } from '@utils/sharedFields';
 
@@ -748,6 +749,7 @@ export class LmChatOpenAi implements INodeType {
 		};
 
 		if (options.baseURL) {
+			checkDomainRestrictions(this, credentials, options.baseURL);
 			configuration.baseURL = options.baseURL;
 		} else if (credentials.url) {
 			configuration.baseURL = credentials.url as string;

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v1/actions/assistant/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v1/actions/assistant/message.operation.ts
@@ -27,6 +27,7 @@ import { assistantRLC } from '../descriptions';
 import { getProxyAgent } from '@utils/httpProxyAgent';
 import { Container } from '@n8n/di';
 import { AiConfig } from '@n8n/config';
+import { checkDomainRestrictions } from '@utils/checkDomainRestrictions';
 
 const properties: INodeProperties[] = [
 	assistantRLC,
@@ -179,6 +180,10 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 		timeout: number;
 		preserveOriginalTools?: boolean;
 	};
+
+	if (options.baseURL) {
+		checkDomainRestrictions(this, credentials, options.baseURL);
+	}
 
 	const baseURL = (options.baseURL ?? credentials.url) as string;
 	const { openAiDefaultHeaders: defaultHeaders } = Container.get(AiConfig);

--- a/packages/@n8n/nodes-langchain/utils/checkDomainRestrictions.ts
+++ b/packages/@n8n/nodes-langchain/utils/checkDomainRestrictions.ts
@@ -1,0 +1,47 @@
+import type {
+	ICredentialDataDecryptedObject,
+	ISupplyDataFunctions,
+	IExecuteFunctions,
+} from 'n8n-workflow';
+import { isDomainAllowed, NodeOperationError } from 'n8n-workflow';
+
+/**
+ * Checks if the URL is allowed based on the allowed domains type and the allowed domains.
+ * If the allowed domains type is 'domains', it checks if the URL is in the allowed domains.
+ * If the allowed domains type is 'none', it checks if the URL is the same as the base URL in the credentials.
+ * @param ctx - The context of the node.
+ * @param credentials - The credentials of the node.
+ * @param url - The URL to check.
+ * @param credentialsUrlKey - The key of the base URL in the credentials.
+ */
+export const checkDomainRestrictions = (
+	ctx: ISupplyDataFunctions | IExecuteFunctions,
+	credentials: ICredentialDataDecryptedObject,
+	url: string,
+	credentialsUrlKey: string = 'url',
+): void => {
+	const allowedDomainsType = credentials.allowedHttpRequestDomains;
+	const restrictedMessage = `Domain not allowed: This credential is restricted from accessing ${url}. `;
+	if (allowedDomainsType === 'domains') {
+		const allowedDomains = credentials.allowedDomains as string;
+
+		if (!allowedDomains || allowedDomains.trim() === '') {
+			throw new NodeOperationError(
+				ctx.getNode(),
+				'No allowed domains specified. Configure allowed domains or change restriction setting.',
+			);
+		}
+
+		if (!isDomainAllowed(url, { allowedDomains })) {
+			throw new NodeOperationError(
+				ctx.getNode(),
+				restrictedMessage + `Only the following domains are allowed: ${allowedDomains}`,
+			);
+		}
+	}
+	if (allowedDomainsType === 'none' && credentials[credentialsUrlKey]) {
+		if (url !== credentials[credentialsUrlKey]) {
+			throw new NodeOperationError(ctx.getNode(), restrictedMessage);
+		}
+	}
+};

--- a/packages/@n8n/nodes-langchain/utils/tests/checkDomainRestrictions.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/tests/checkDomainRestrictions.test.ts
@@ -1,0 +1,356 @@
+import { createMockExecuteFunction } from 'n8n-nodes-base/test/nodes/Helpers';
+import { NodeOperationError } from 'n8n-workflow';
+import type {
+	ICredentialDataDecryptedObject,
+	IExecuteFunctions,
+	INode,
+	ISupplyDataFunctions,
+} from 'n8n-workflow';
+
+import { checkDomainRestrictions } from '../checkDomainRestrictions';
+
+describe('checkDomainRestrictions', () => {
+	let mockNode: INode;
+	let mockExecuteFunctions: IExecuteFunctions;
+	let mockSupplyDataFunctions: ISupplyDataFunctions;
+
+	beforeEach(() => {
+		mockNode = {
+			id: 'test-node',
+			name: 'Test Node',
+			type: 'test',
+			typeVersion: 1,
+			position: [0, 0] as [number, number],
+			parameters: {},
+		};
+
+		mockExecuteFunctions = createMockExecuteFunction({}, mockNode);
+		mockSupplyDataFunctions = mockExecuteFunctions as unknown as ISupplyDataFunctions;
+	});
+
+	describe('when allowedDomainsType is "domains"', () => {
+		it('should throw error when allowedDomains is empty', () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				allowedHttpRequestDomains: 'domains',
+				allowedDomains: '',
+			};
+
+			expect(() => {
+				checkDomainRestrictions(mockExecuteFunctions, credentials, 'https://example.com');
+			}).toThrow(NodeOperationError);
+
+			expect(() => {
+				checkDomainRestrictions(mockExecuteFunctions, credentials, 'https://example.com');
+			}).toThrow(
+				'No allowed domains specified. Configure allowed domains or change restriction setting.',
+			);
+		});
+
+		it('should throw error when allowedDomains is whitespace only', () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				allowedHttpRequestDomains: 'domains',
+				allowedDomains: '   ',
+			};
+
+			expect(() => {
+				checkDomainRestrictions(mockExecuteFunctions, credentials, 'https://example.com');
+			}).toThrow(NodeOperationError);
+
+			expect(() => {
+				checkDomainRestrictions(mockExecuteFunctions, credentials, 'https://example.com');
+			}).toThrow(
+				'No allowed domains specified. Configure allowed domains or change restriction setting.',
+			);
+		});
+
+		it('should throw error when allowedDomains is undefined', () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				allowedHttpRequestDomains: 'domains',
+			};
+
+			expect(() => {
+				checkDomainRestrictions(mockExecuteFunctions, credentials, 'https://example.com');
+			}).toThrow(NodeOperationError);
+
+			expect(() => {
+				checkDomainRestrictions(mockExecuteFunctions, credentials, 'https://example.com');
+			}).toThrow(
+				'No allowed domains specified. Configure allowed domains or change restriction setting.',
+			);
+		});
+
+		it('should throw error when URL is not in allowed domains', () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				allowedHttpRequestDomains: 'domains',
+				allowedDomains: 'example.com,test.com',
+			};
+
+			expect(() => {
+				checkDomainRestrictions(mockExecuteFunctions, credentials, 'https://notallowed.com');
+			}).toThrow(NodeOperationError);
+
+			expect(() => {
+				checkDomainRestrictions(mockExecuteFunctions, credentials, 'https://notallowed.com');
+			}).toThrow(
+				'Domain not allowed: This credential is restricted from accessing https://notallowed.com. Only the following domains are allowed: example.com,test.com',
+			);
+		});
+
+		it('should not throw error when URL is in allowed domains (exact match)', () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				allowedHttpRequestDomains: 'domains',
+				allowedDomains: 'example.com',
+			};
+
+			expect(() => {
+				checkDomainRestrictions(mockExecuteFunctions, credentials, 'https://example.com');
+			}).not.toThrow();
+		});
+
+		it('should not throw error when URL is in allowed domains (comma-separated list)', () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				allowedHttpRequestDomains: 'domains',
+				allowedDomains: 'example.com,test.com,another.com',
+			};
+
+			expect(() => {
+				checkDomainRestrictions(mockExecuteFunctions, credentials, 'https://test.com');
+			}).not.toThrow();
+		});
+
+		it('should not throw error when URL matches wildcard domain', () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				allowedHttpRequestDomains: 'domains',
+				allowedDomains: '*.example.com',
+			};
+
+			expect(() => {
+				checkDomainRestrictions(mockExecuteFunctions, credentials, 'https://sub.example.com');
+			}).not.toThrow();
+		});
+
+		it('should work with IExecuteFunctions context', () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				allowedHttpRequestDomains: 'domains',
+				allowedDomains: 'example.com',
+			};
+
+			expect(() => {
+				checkDomainRestrictions(mockExecuteFunctions, credentials, 'https://example.com');
+			}).not.toThrow();
+		});
+
+		it('should work with ISupplyDataFunctions context', () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				allowedHttpRequestDomains: 'domains',
+				allowedDomains: 'example.com',
+			};
+
+			expect(() => {
+				checkDomainRestrictions(mockSupplyDataFunctions, credentials, 'https://example.com');
+			}).not.toThrow();
+		});
+	});
+
+	describe('when allowedDomainsType is "none"', () => {
+		it('should not throw error when URL matches credentials URL', () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				allowedHttpRequestDomains: 'none',
+				url: 'https://example.com',
+			};
+
+			expect(() => {
+				checkDomainRestrictions(mockExecuteFunctions, credentials, 'https://example.com');
+			}).not.toThrow();
+		});
+
+		it('should throw error when URL does not match credentials URL', () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				allowedHttpRequestDomains: 'none',
+				url: 'https://example.com',
+			};
+
+			expect(() => {
+				checkDomainRestrictions(mockExecuteFunctions, credentials, 'https://different.com');
+			}).toThrow(NodeOperationError);
+
+			expect(() => {
+				checkDomainRestrictions(mockExecuteFunctions, credentials, 'https://different.com');
+			}).toThrow(
+				'Domain not allowed: This credential is restricted from accessing https://different.com. ',
+			);
+		});
+
+		it('should not throw error when credentials URL key does not exist', () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				allowedHttpRequestDomains: 'none',
+			};
+
+			expect(() => {
+				checkDomainRestrictions(mockExecuteFunctions, credentials, 'https://any-url.com');
+			}).not.toThrow();
+		});
+
+		it('should use custom credentialsUrlKey parameter', () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				allowedHttpRequestDomains: 'none',
+				baseUrl: 'https://custom.example.com',
+			};
+
+			expect(() => {
+				checkDomainRestrictions(
+					mockExecuteFunctions,
+					credentials,
+					'https://custom.example.com',
+					'baseUrl',
+				);
+			}).not.toThrow();
+
+			expect(() => {
+				checkDomainRestrictions(
+					mockExecuteFunctions,
+					credentials,
+					'https://different.com',
+					'baseUrl',
+				);
+			}).toThrow(NodeOperationError);
+		});
+
+		it('should work with IExecuteFunctions context', () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				allowedHttpRequestDomains: 'none',
+				url: 'https://example.com',
+			};
+
+			expect(() => {
+				checkDomainRestrictions(mockExecuteFunctions, credentials, 'https://example.com');
+			}).not.toThrow();
+		});
+
+		it('should work with ISupplyDataFunctions context', () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				allowedHttpRequestDomains: 'none',
+				url: 'https://example.com',
+			};
+
+			expect(() => {
+				checkDomainRestrictions(mockSupplyDataFunctions, credentials, 'https://example.com');
+			}).not.toThrow();
+		});
+	});
+
+	describe('when allowedDomainsType is undefined or other value', () => {
+		it('should not throw error when allowedDomainsType is undefined', () => {
+			const credentials: ICredentialDataDecryptedObject = {};
+
+			expect(() => {
+				checkDomainRestrictions(mockExecuteFunctions, credentials, 'https://any-url.com');
+			}).not.toThrow();
+		});
+
+		it('should not throw error when allowedDomainsType is empty string', () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				allowedHttpRequestDomains: '',
+			};
+
+			expect(() => {
+				checkDomainRestrictions(mockExecuteFunctions, credentials, 'https://any-url.com');
+			}).not.toThrow();
+		});
+
+		it('should not throw error when allowedDomainsType is other value', () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				allowedHttpRequestDomains: 'other' as any,
+			};
+
+			expect(() => {
+				checkDomainRestrictions(mockExecuteFunctions, credentials, 'https://any-url.com');
+			}).not.toThrow();
+		});
+	});
+
+	describe('edge cases', () => {
+		it('should handle URLs with paths and query parameters', () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				allowedHttpRequestDomains: 'domains',
+				allowedDomains: 'example.com',
+			};
+
+			expect(() => {
+				checkDomainRestrictions(
+					mockExecuteFunctions,
+					credentials,
+					'https://example.com/api/v1/endpoint?param=value',
+				);
+			}).not.toThrow();
+		});
+
+		it('should handle URLs with ports', () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				allowedHttpRequestDomains: 'domains',
+				allowedDomains: 'example.com',
+			};
+
+			expect(() => {
+				checkDomainRestrictions(mockExecuteFunctions, credentials, 'https://example.com:8080');
+			}).not.toThrow();
+		});
+
+		it('should handle case-insensitive domain matching', () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				allowedHttpRequestDomains: 'domains',
+				allowedDomains: 'EXAMPLE.COM',
+			};
+
+			expect(() => {
+				checkDomainRestrictions(mockExecuteFunctions, credentials, 'https://example.com');
+			}).not.toThrow();
+		});
+
+		it('should handle domains with trailing dots', () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				allowedHttpRequestDomains: 'domains',
+				allowedDomains: 'example.com.',
+			};
+
+			expect(() => {
+				checkDomainRestrictions(mockExecuteFunctions, credentials, 'https://example.com');
+			}).not.toThrow();
+		});
+
+		it('should handle multiple domains with spaces in allowedDomains', () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				allowedHttpRequestDomains: 'domains',
+				allowedDomains: 'example.com, test.com , another.com',
+			};
+
+			expect(() => {
+				checkDomainRestrictions(mockExecuteFunctions, credentials, 'https://test.com');
+			}).not.toThrow();
+		});
+
+		it('should handle exact URL match for "none" type with different protocols', () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				allowedHttpRequestDomains: 'none',
+				url: 'https://example.com',
+			};
+
+			// Should throw because protocol is different
+			expect(() => {
+				checkDomainRestrictions(mockExecuteFunctions, credentials, 'http://example.com');
+			}).toThrow(NodeOperationError);
+		});
+
+		it('should handle exact URL match for "none" type with different paths', () => {
+			const credentials: ICredentialDataDecryptedObject = {
+				allowedHttpRequestDomains: 'none',
+				url: 'https://example.com',
+			};
+
+			// Should throw because path is different
+			expect(() => {
+				checkDomainRestrictions(mockExecuteFunctions, credentials, 'https://example.com/path');
+			}).toThrow(NodeOperationError);
+		});
+	});
+});

--- a/packages/cli/src/load-nodes-and-credentials.ts
+++ b/packages/cli/src/load-nodes-and-credentials.ts
@@ -717,7 +717,7 @@ export class LoadNodesAndCredentials {
 						description: 'Block all requests when used in the HTTP Request node',
 					},
 				],
-				default: 'none',
+				default: 'all',
 				description: 'Control which domains this credential can be used with in HTTP Request nodes',
 			},
 			{


### PR DESCRIPTION
## Summary

This PR adds OpenAI base url verification.
It also reverts this [change](https://github.com/n8n-io/n8n/pull/24702), as it introduces a regression in how 'none' is being handled by default

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4259


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
