### PR TITLE
fix(core): Update computeIsPending logic to account for external auth identities

### DIFF
--- a/packages/@n8n/db/src/entities/__tests__/user.entity.test.ts
+++ b/packages/@n8n/db/src/entities/__tests__/user.entity.test.ts
@@ -1,6 +1,74 @@
+import { AuthIdentity } from '../auth-identity';
+import { Role } from '../role';
 import { User } from '../user';
 
 describe('User Entity', () => {
+	describe('computeIsPending', () => {
+		const createUser = (overrides: Partial<User> = {}) => {
+			const user = new User();
+			user.password = null;
+			user.role = { slug: 'global:member' } as Role;
+			user.authIdentities = [];
+			return Object.assign(user, overrides);
+		};
+
+		const createAuthIdentity = (providerType: 'email' | 'saml' | 'oidc' | 'ldap'): AuthIdentity => {
+			const identity = new AuthIdentity();
+			identity.providerType = providerType;
+			identity.providerId = 'test-provider-id';
+			return identity;
+		};
+
+		it('should be pending when password is null and no auth identities', () => {
+			const user = createUser();
+			user.computeIsPending();
+			expect(user.isPending).toBe(true);
+		});
+
+		it('should NOT be pending when password is set', () => {
+			const user = createUser({ password: 'hashed-password' });
+			user.computeIsPending();
+			expect(user.isPending).toBe(false);
+		});
+
+		it('should NOT be pending when user is global owner (even without password)', () => {
+			const user = createUser({ role: { slug: 'global:owner' } as Role });
+			user.computeIsPending();
+			expect(user.isPending).toBe(false);
+		});
+
+		it('should NOT be pending when user has SAML auth identity', () => {
+			const user = createUser({ authIdentities: [createAuthIdentity('saml')] });
+			user.computeIsPending();
+			expect(user.isPending).toBe(false);
+		});
+
+		it('should NOT be pending when user has OIDC auth identity', () => {
+			const user = createUser({ authIdentities: [createAuthIdentity('oidc')] });
+			user.computeIsPending();
+			expect(user.isPending).toBe(false);
+		});
+
+		it('should NOT be pending when user has LDAP auth identity', () => {
+			const user = createUser({ authIdentities: [createAuthIdentity('ldap')] });
+			user.computeIsPending();
+			expect(user.isPending).toBe(false);
+		});
+
+		it('should be pending when user only has email auth identity (no password)', () => {
+			const user = createUser({ authIdentities: [createAuthIdentity('email')] });
+			user.computeIsPending();
+			expect(user.isPending).toBe(true);
+		});
+
+		it('should handle undefined authIdentities gracefully', () => {
+			const user = createUser();
+			user.authIdentities = undefined as unknown as AuthIdentity[];
+			user.computeIsPending();
+			expect(user.isPending).toBe(true);
+		});
+	});
+
 	describe('JSON.stringify', () => {
 		it('should not serialize sensitive data', () => {
 			const user = Object.assign(new User(), {

--- a/packages/@n8n/db/src/entities/__tests__/user.entity.test.ts
+++ b/packages/@n8n/db/src/entities/__tests__/user.entity.test.ts
@@ -1,5 +1,5 @@
 import { AuthIdentity } from '../auth-identity';
-import { Role } from '../role';
+import { type Role } from '../role';
 import { User } from '../user';
 
 describe('User Entity', () => {

--- a/packages/@n8n/db/src/entities/user.ts
+++ b/packages/@n8n/db/src/entities/user.ts
@@ -113,7 +113,12 @@ export class User extends WithTimestamps implements IUser, AuthPrincipal {
 	@AfterLoad()
 	@AfterUpdate()
 	computeIsPending(): void {
-		this.isPending = this.password === null && this.role?.slug !== GLOBAL_OWNER_ROLE.slug;
+		const hasExternalAuthIdentity =
+			this.authIdentities?.some((identity) => identity.providerType !== 'email') ?? false;
+		this.isPending =
+			this.password === null &&
+			!hasExternalAuthIdentity &&
+			this.role?.slug !== GLOBAL_OWNER_ROLE.slug;
 	}
 
 	toJSON() {


### PR DESCRIPTION
## Summary

Fix `pending` user state for other auth identities like SSO, LDAP

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-72/user-management-active-user-showing-up-as-pending-after-rolling-out

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
