### PR TITLE
chore(core): Make projectId of workflow available in execution context

### DIFF
--- a/packages/cli/src/chat/chat-execution-manager.ts
+++ b/packages/cli/src/chat/chat-execution-manager.ts
@@ -90,7 +90,16 @@ export class ChatExecutionManager {
 		const workflow = this.getWorkflow(execution);
 		const lastNodeExecuted = execution.data.resultData.lastNodeExecuted as string;
 		const node = workflow.getNode(lastNodeExecuted);
-		const additionalData = await WorkflowExecuteAdditionalData.getBase({ workflowId: workflow.id });
+
+		// TODO: verify this context actually needs projectId because it resolves external secret expressions down the line
+		const project = await this.ownershipService
+			.getWorkflowProjectCached(execution.workflowData.id)
+			.catch(() => undefined);
+
+		const additionalData = await WorkflowExecuteAdditionalData.getBase({
+			workflowId: workflow.id,
+			projectId: project?.id,
+		});
 		const executionData = execution.data.executionData?.nodeExecutionStack[0];
 
 		if (!node || !executionData) return null;

--- a/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
@@ -153,7 +153,9 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 		return this.secretsCache.getSecret(provider, name);
 	}
 
-	hasSecret(provider: string, name: string): boolean {
+	hasSecret(provider: string, name: string, projectId?: string): boolean {
+		this.logger.info(`ExternalSecretsManager.hasSecret: projectId ${projectId}`);
+		// TODO: use projectId to validate that the given provider is available to the given projectId
 		return this.secretsCache.hasSecret(provider, name);
 	}
 

--- a/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
@@ -78,6 +78,7 @@ describe('JobProcessor', () => {
 			mock(),
 			executionsConfig,
 			mock(),
+			mock(),
 		);
 
 		const result = await jobProcessor.processJob(mock<Job>());
@@ -108,6 +109,7 @@ describe('JobProcessor', () => {
 				mock(),
 				manualExecutionService,
 				executionsConfig,
+				mock(),
 				mock(),
 			);
 
@@ -160,6 +162,7 @@ describe('JobProcessor', () => {
 			manualExecutionService,
 			executionsConfig,
 			mock(),
+			mock(),
 		);
 
 		const job = mock<Job>();
@@ -205,6 +208,7 @@ describe('JobProcessor', () => {
 			mock(),
 			manualExecutionService,
 			executionsConfig,
+			mock(),
 			mock(),
 		);
 
@@ -269,6 +273,7 @@ describe('JobProcessor', () => {
 				mock(),
 				manualExecutionService,
 				executionsConfig,
+				mock(),
 				mock(),
 			);
 

--- a/packages/cli/src/webhooks/__tests__/waiting-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/waiting-webhooks.test.ts
@@ -32,6 +32,7 @@ describe('WaitingWebhooks', () => {
 		executionRepository,
 		mockWebhookService,
 		mockInstanceSettings,
+		mock(),
 	);
 
 	beforeEach(() => {

--- a/packages/cli/src/webhooks/__tests__/waiting-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/waiting-webhooks.test.ts
@@ -32,7 +32,6 @@ describe('WaitingWebhooks', () => {
 		executionRepository,
 		mockWebhookService,
 		mockInstanceSettings,
-		mock(),
 	);
 
 	beforeEach(() => {

--- a/packages/cli/src/webhooks/waiting-webhooks.ts
+++ b/packages/cli/src/webhooks/waiting-webhooks.ts
@@ -252,6 +252,7 @@ export class WaitingWebhooks implements IWebhookManager {
 			throw new NotFoundError('Could not find node to process webhook.');
 		}
 
+		// TODO: verify that projectId is not needed in additionalData because external secrets are not evaluated
 		const additionalData = await WorkflowExecuteAdditionalData.getBase({
 			workflowId: workflow.id,
 		});

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -294,6 +294,7 @@ async function startExecution(
 		const workflowSettings = workflowData.settings;
 		const additionalDataIntegrated = await getBase({
 			workflowId: workflowData.id,
+			projectId: additionalData.projectId, // TODO: fully understand who depends on this / if this is needed here
 			workflowSettings,
 		});
 		additionalDataIntegrated.hooks = getLifecycleHooksForSubExecutions(
@@ -481,6 +482,7 @@ export async function getBase({
 		currentNodeParameters,
 		executionTimeoutTimestamp,
 		userId,
+		projectId,
 		setExecutionStatus,
 		variables,
 		workflowSettings,

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -248,6 +248,7 @@ export class WorkflowRunner {
 		const additionalData = await WorkflowExecuteAdditionalData.getBase({
 			userId: data.userId,
 			workflowId: workflow.id,
+			projectId: data.projectId,
 			executionTimeoutTimestamp:
 				workflowTimeout <= 0 ? undefined : Date.now() + workflowTimeout * 1000,
 			workflowSettings,

--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -90,6 +90,7 @@ describe('WorkflowExecutionService', () => {
 		mock(),
 		mock(),
 		mock(),
+		mock(),
 	);
 
 	const additionalData = mock<IWorkflowExecuteAdditionalData>({});
@@ -376,6 +377,7 @@ describe('WorkflowExecutionService', () => {
 				mock(),
 				mock(),
 				mock(),
+				mock(),
 			);
 
 			const runPayload: WorkflowRequest.FullManualExecutionFromKnownTriggerPayload = {
@@ -557,6 +559,7 @@ describe('WorkflowExecutionService', () => {
 				mock(),
 				mock(),
 				mock(),
+				mock(),
 			);
 		});
 
@@ -699,6 +702,7 @@ describe('WorkflowExecutionService', () => {
 				mock(),
 				workflowRunnerMock,
 				globalConfig,
+				mock(),
 				mock(),
 				mock(),
 				mock(),

--- a/packages/core/src/execution-engine/external-secrets-proxy.ts
+++ b/packages/core/src/execution-engine/external-secrets-proxy.ts
@@ -2,7 +2,7 @@ import { Service } from '@n8n/di';
 
 export interface IExternalSecretsManager {
 	updateSecrets(): Promise<void>;
-	hasSecret(provider: string, name: string): boolean;
+	hasSecret(provider: string, name: string, projectId?: string): boolean;
 	getSecret(provider: string, name: string): unknown;
 	getSecretNames(provider: string): string[];
 	hasProvider(provider: string): boolean;
@@ -25,8 +25,8 @@ export class ExternalSecretsProxy {
 		return this.manager?.getSecret(provider, name);
 	}
 
-	hasSecret(provider: string, name: string): boolean {
-		return !!this.manager && this.manager.hasSecret(provider, name);
+	hasSecret(provider: string, name: string, projectId?: string): boolean {
+		return !!this.manager && this.manager.hasSecret(provider, name, projectId);
 	}
 
 	hasProvider(provider: string): boolean {

--- a/packages/core/src/execution-engine/node-execution-context/utils/get-secrets-proxy.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/get-secrets-proxy.ts
@@ -23,7 +23,7 @@ function buildSecretsValueProxy(value: IDataObject): unknown {
 }
 
 export function getSecretsProxy(additionalData: IWorkflowExecuteAdditionalData): IDataObject {
-	const { externalSecretsProxy } = additionalData;
+	const { externalSecretsProxy, projectId } = additionalData;
 	return new Proxy(
 		{},
 		{
@@ -39,7 +39,7 @@ export function getSecretsProxy(additionalData: IWorkflowExecuteAdditionalData):
 								if (typeof secretName !== 'string') {
 									return;
 								}
-								if (!externalSecretsProxy.hasSecret(providerName, secretName)) {
+								if (!externalSecretsProxy.hasSecret(providerName, secretName, projectId)) {
 									throw new ExpressionError('Could not load secrets', {
 										description:
 											'The credential in use tries to use secret from an external store that could not be found',

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2808,6 +2808,7 @@ export interface IWorkflowExecuteAdditionalData {
 	currentNodeParameters?: INodeParameters;
 	executionTimeoutTimestamp?: number;
 	userId?: string;
+	projectId?: string;
 	variables: IDataObject;
 	logAiEvent: (eventName: AiEvent, payload: AiEventPayload) => void;
 	parentCallbackManager?: CallbackManager;


### PR DESCRIPTION
## Summary

Description redacted

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-149/investigate-adding-projectid-to-execution-context-to-be-able-to


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
