### PR TITLE
fix(editor): Disable hover effects on non-drop-targets during drag

### DIFF
--- a/packages/frontend/editor-ui/src/app/css/_global.scss
+++ b/packages/frontend/editor-ui/src/app/css/_global.scss
@@ -242,3 +242,14 @@
 		}
 	}
 }
+
+// Drag and drop: disable hover effects on all elements except valid drop targets
+body.dragging-resource {
+	* {
+		pointer-events: none;
+	}
+
+	[data-droppable] {
+		pointer-events: auto;
+	}
+}

--- a/packages/frontend/editor-ui/src/app/views/WorkflowsView.vue
+++ b/packages/frontend/editor-ui/src/app/views/WorkflowsView.vue
@@ -1954,6 +1954,7 @@ const onNameSubmit = async (name: string) => {
 					}"
 					:show-ownership-badge="showCardsBadge"
 					data-target="folder"
+					data-droppable
 					class="mb-2xs"
 					@action="onFolderCardAction"
 					@mouseenter="folderHelpers.onDragEnter"

--- a/packages/frontend/editor-ui/src/features/core/folders/components/ProjectBreadcrumb.vue
+++ b/packages/frontend/editor-ui/src/features/core/folders/components/ProjectBreadcrumb.vue
@@ -80,6 +80,7 @@ const onProjectMouseUp = () => {
 	<div
 		:class="{ [$style['home-project']]: true, [$style.dragging]: isDragging }"
 		data-test-id="home-project"
+		data-droppable
 		@mouseenter="onHover"
 		@mouseup="isDragging ? onProjectMouseUp() : null"
 	>

--- a/packages/frontend/editor-ui/src/features/core/folders/composables/useFolders.ts
+++ b/packages/frontend/editor-ui/src/features/core/folders/composables/useFolders.ts
@@ -73,12 +73,14 @@ export function useFolders() {
 				id: dragTarget.id,
 				name: dragTarget.name,
 			};
+			document.body.classList.add('dragging-resource');
 		}
 	}
 
 	function onDragEnd(): void {
 		foldersStore.draggedElement = null;
 		foldersStore.activeDropTarget = null;
+		document.body.classList.remove('dragging-resource');
 	}
 
 	function onDragEnter(event: MouseEvent): void {


### PR DESCRIPTION
## Summary

Fixes misleading UX where ALL interactive elements (sidebar menu items, icon buttons, pagination, filters) show hover styling when users drag a workflow, even though most aren't valid drop targets.

**Changes:**
- Adds `dragging-resource` class to `document.body` when drag starts
- Global CSS disables `pointer-events` on all elements during drag
- Only elements with `data-droppable` attribute retain pointer events (valid drop targets)
- Folder cards marked with `data-droppable` attribute

**How to test:**
1. Navigate to a project with folders and workflows
2. Start dragging a workflow card
3. Move cursor over sidebar items, buttons, pagination - **no hover effects**
4. Move cursor over folder cards - **hover effect works** (valid drop target)
5. Drop onto a folder or release outside - works as expected
6. Verify normal hover behavior is restored after drag ends

### Before

https://github.com/user-attachments/assets/27c32fdd-d6ad-4988-9d48-4a26ac9097e1

### After

https://github.com/user-attachments/assets/44e6d761-242f-423d-b319-dcbfb30a6d37

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-1967

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

