### PR TITLE
fix(ai-builder): Detect placeholder values inside larger parameters generated by workflow builder

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useBuilderTodos.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useBuilderTodos.test.ts
@@ -74,6 +74,20 @@ describe('useBuilderTodos', () => {
 			`;
 			expect(extractPlaceholderLabels(code)).toEqual(['Base URL', 'API Token']);
 		});
+
+		it('extracts label from alternative placeholder format with colon', () => {
+			expect(extractPlaceholderLabels('<__PLACEHOLDER__: Add your custom code here__>')).toEqual([
+				'Add your custom code here',
+			]);
+		});
+
+		it('extracts labels from mixed placeholder formats', () => {
+			const code = `
+				const apiKey = '<__PLACEHOLDER_VALUE__API_KEY__>';
+				const customCode = '<__PLACEHOLDER__: Add your code here__>';
+			`;
+			expect(extractPlaceholderLabels(code)).toEqual(['API_KEY', 'Add your code here']);
+		});
 	});
 
 	describe('findPlaceholderDetails', () => {

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useBuilderTodos.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useBuilderTodos.test.ts
@@ -49,7 +49,7 @@ describe('useBuilderTodos', () => {
 		});
 
 		it('extracts single embedded placeholder from code', () => {
-			const code = `const apiKey = '<__PLACEHOLDER_VALUE__API_KEY__>';`;
+			const code = "const apiKey = '<__PLACEHOLDER_VALUE__API_KEY__>';";
 			expect(extractPlaceholderLabels(code)).toEqual(['API_KEY']);
 		});
 
@@ -192,7 +192,7 @@ describe('useBuilderTodos', () => {
 
 		it('finds embedded placeholder in code string', () => {
 			const result = findPlaceholderDetails({
-				jsCode: `const apiKey = '<__PLACEHOLDER_VALUE__API_KEY__>';`,
+				jsCode: "const apiKey = '<__PLACEHOLDER_VALUE__API_KEY__>';",
 			});
 			expect(result).toEqual([{ path: ['jsCode'], label: 'API_KEY' }]);
 		});
@@ -223,7 +223,7 @@ describe('useBuilderTodos', () => {
 
 		it('finds embedded placeholders in Python code', () => {
 			const result = findPlaceholderDetails({
-				pythonCode: `api_key = '<__PLACEHOLDER_VALUE__Python API Key__>'`,
+				pythonCode: "api_key = '<__PLACEHOLDER_VALUE__Python API Key__>'",
 			});
 			expect(result).toEqual([{ path: ['pythonCode'], label: 'Python API Key' }]);
 		});

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useBuilderTodos.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useBuilderTodos.test.ts
@@ -1,49 +1,78 @@
 import { describe, it, expect } from 'vitest';
 import {
-	extractPlaceholderLabel,
+	extractPlaceholderLabels,
 	findPlaceholderDetails,
 	formatPlaceholderPath,
 	isPlaceholderValue,
 } from './useBuilderTodos';
 
 describe('useBuilderTodos', () => {
-	describe('extractPlaceholderLabel', () => {
-		it('returns null for non-string values', () => {
-			expect(extractPlaceholderLabel(123)).toBeNull();
-			expect(extractPlaceholderLabel(true)).toBeNull();
-			expect(extractPlaceholderLabel(null)).toBeNull();
-			expect(extractPlaceholderLabel(undefined)).toBeNull();
-			expect(extractPlaceholderLabel({})).toBeNull();
-			expect(extractPlaceholderLabel([])).toBeNull();
+	describe('extractPlaceholderLabels', () => {
+		it('returns empty array for non-string values', () => {
+			expect(extractPlaceholderLabels(123)).toEqual([]);
+			expect(extractPlaceholderLabels(true)).toEqual([]);
+			expect(extractPlaceholderLabels(null)).toEqual([]);
+			expect(extractPlaceholderLabels(undefined)).toEqual([]);
+			expect(extractPlaceholderLabels({})).toEqual([]);
+			expect(extractPlaceholderLabels([])).toEqual([]);
 		});
 
-		it('returns null for strings without placeholder format', () => {
-			expect(extractPlaceholderLabel('regular string')).toBeNull();
-			expect(extractPlaceholderLabel('https://example.com')).toBeNull();
-			expect(extractPlaceholderLabel('')).toBeNull();
+		it('returns empty array for strings without placeholder format', () => {
+			expect(extractPlaceholderLabels('regular string')).toEqual([]);
+			expect(extractPlaceholderLabels('https://example.com')).toEqual([]);
+			expect(extractPlaceholderLabels('')).toEqual([]);
 		});
 
-		it('returns null for partial placeholder format', () => {
-			expect(extractPlaceholderLabel('<__PLACEHOLDER_VALUE__missing end')).toBeNull();
-			expect(extractPlaceholderLabel('PLACEHOLDER__test__>')).toBeNull();
-			expect(extractPlaceholderLabel('__PLACEHOLDER_VALUE__test__>')).toBeNull();
+		it('returns empty array for partial placeholder format', () => {
+			expect(extractPlaceholderLabels('<__PLACEHOLDER_VALUE__missing end')).toEqual([]);
+			expect(extractPlaceholderLabels('PLACEHOLDER__test__>')).toEqual([]);
+			expect(extractPlaceholderLabels('__PLACEHOLDER_VALUE__test__>')).toEqual([]);
 		});
 
-		it('returns null for empty label', () => {
-			expect(extractPlaceholderLabel('<__PLACEHOLDER_VALUE____>')).toBeNull();
+		it('returns empty array for empty label', () => {
+			expect(extractPlaceholderLabels('<__PLACEHOLDER_VALUE____>')).toEqual([]);
 		});
 
-		it('returns null for whitespace-only label', () => {
-			expect(extractPlaceholderLabel('<__PLACEHOLDER_VALUE__   __>')).toBeNull();
+		it('returns empty array for whitespace-only label', () => {
+			expect(extractPlaceholderLabels('<__PLACEHOLDER_VALUE__   __>')).toEqual([]);
 		});
 
 		it('extracts label from valid placeholder', () => {
-			expect(extractPlaceholderLabel('<__PLACEHOLDER_VALUE__Enter URL__>')).toBe('Enter URL');
-			expect(extractPlaceholderLabel('<__PLACEHOLDER_VALUE__API Key__>')).toBe('API Key');
+			expect(extractPlaceholderLabels('<__PLACEHOLDER_VALUE__Enter URL__>')).toEqual(['Enter URL']);
+			expect(extractPlaceholderLabels('<__PLACEHOLDER_VALUE__API Key__>')).toEqual(['API Key']);
 		});
 
 		it('trims whitespace from label', () => {
-			expect(extractPlaceholderLabel('<__PLACEHOLDER_VALUE__  Enter URL  __>')).toBe('Enter URL');
+			expect(extractPlaceholderLabels('<__PLACEHOLDER_VALUE__  Enter URL  __>')).toEqual([
+				'Enter URL',
+			]);
+		});
+
+		it('extracts single embedded placeholder from code', () => {
+			const code = `const apiKey = '<__PLACEHOLDER_VALUE__API_KEY__>';`;
+			expect(extractPlaceholderLabels(code)).toEqual(['API_KEY']);
+		});
+
+		it('extracts multiple embedded placeholders from code', () => {
+			const code = `
+				const apiKey = '<__PLACEHOLDER_VALUE__API_KEY__>';
+				const endpoint = '<__PLACEHOLDER_VALUE__API_ENDPOINT__>';
+			`;
+			expect(extractPlaceholderLabels(code)).toEqual(['API_KEY', 'API_ENDPOINT']);
+		});
+
+		it('handles placeholders in complex code', () => {
+			const code = `
+				// This is a comment
+				function getData() {
+					const url = '<__PLACEHOLDER_VALUE__Base URL__>' + '/api/data';
+					const headers = {
+						'Authorization': 'Bearer <__PLACEHOLDER_VALUE__API Token__>'
+					};
+					return fetch(url, { headers });
+				}
+			`;
+			expect(extractPlaceholderLabels(code)).toEqual(['Base URL', 'API Token']);
 		});
 	});
 
@@ -145,6 +174,44 @@ describe('useBuilderTodos', () => {
 				'parameters',
 			]);
 			expect(result).toEqual([{ path: ['parameters', 'url'], label: 'Enter URL' }]);
+		});
+
+		it('finds embedded placeholder in code string', () => {
+			const result = findPlaceholderDetails({
+				jsCode: `const apiKey = '<__PLACEHOLDER_VALUE__API_KEY__>';`,
+			});
+			expect(result).toEqual([{ path: ['jsCode'], label: 'API_KEY' }]);
+		});
+
+		it('finds multiple embedded placeholders in code string', () => {
+			const code = `
+				const apiKey = '<__PLACEHOLDER_VALUE__API_KEY__>';
+				const endpoint = '<__PLACEHOLDER_VALUE__API_ENDPOINT__>';
+			`;
+			const result = findPlaceholderDetails({ jsCode: code });
+			expect(result).toHaveLength(2);
+			expect(result).toContainEqual({ path: ['jsCode'], label: 'API_KEY' });
+			expect(result).toContainEqual({ path: ['jsCode'], label: 'API_ENDPOINT' });
+		});
+
+		it('finds embedded placeholders in Code node parameters', () => {
+			const result = findPlaceholderDetails({
+				mode: 'runOnceForAllItems',
+				language: 'javaScript',
+				jsCode: `
+					// Fetch data from API
+					const response = await fetch('<__PLACEHOLDER_VALUE__API URL__>');
+					return response.json();
+				`,
+			});
+			expect(result).toEqual([{ path: ['jsCode'], label: 'API URL' }]);
+		});
+
+		it('finds embedded placeholders in Python code', () => {
+			const result = findPlaceholderDetails({
+				pythonCode: `api_key = '<__PLACEHOLDER_VALUE__Python API Key__>'`,
+			});
+			expect(result).toEqual([{ path: ['pythonCode'], label: 'Python API Key' }]);
 		});
 	});
 


### PR DESCRIPTION
## Summary
Sometimes the workflow builder generates parameters which contain a placeholder, like a code node that has a parameter in the code for the user to complete. This PR surfaces those to the user as part of the todo list.

Addresses: https://linear.app/n8n/issue/AI-1836/bug-used-placeholders-in-the-code-node

Screenshot:
<img width="399" height="279" alt="image" src="https://github.com/user-attachments/assets/61eb00a7-06af-4fe4-bed4-89e12c5cbeaf" />

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
