### PR TITLE
ci: Auto-mark GitHub release as latest after channel push

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -35,6 +35,8 @@ jobs:
     outputs:
       release: ${{ steps.set-release.outputs.release }}
       release_type: ${{ steps.set-release.outputs.release_type }}
+      current_beta: ${{ steps.get-dist-tags.outputs.current_beta }}
+      current_stable: ${{ steps.get-dist-tags.outputs.current_stable }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -51,6 +53,12 @@ jobs:
           else
             echo "type=stable" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Get current npm dist-tags
+        id: get-dist-tags
+        run: |
+          echo "current_beta=$(npm view n8n@beta version 2>/dev/null || echo '')" >> "$GITHUB_OUTPUT"
+          echo "current_stable=$(npm view n8n@stable version 2>/dev/null || echo '')" >> "$GITHUB_OUTPUT"
 
       - name: Setup and Build
         uses: ./.github/actions/setup-nodejs
@@ -233,3 +241,105 @@ jobs:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           message: |
             <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}| Release tag merge to master failed for n8n@${{ needs.publish-to-npm.outputs.release }} >
+
+  # =============================================================================
+  # Channel Push Jobs - Minor Release
+  # =============================================================================
+
+  push-to-beta:
+    name: Push to beta channel
+    needs: [publish-to-npm, publish-to-docker-hub]
+    if: |
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'release:minor') &&
+      !contains(needs.publish-to-npm.outputs.release, '-rc.')
+    uses: ./.github/workflows/release-push-to-channel.yml
+    with:
+      version: ${{ needs.publish-to-npm.outputs.release }}
+      release-channel: beta
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      N8N_WEBHOOK_DOCS_PASSWORD: ${{ secrets.N8N_WEBHOOK_DOCS_PASSWORD }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  push-prev-to-stable:
+    name: Push previous beta to stable channel
+    needs: [publish-to-npm, publish-to-docker-hub]
+    if: |
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'release:minor') &&
+      !contains(needs.publish-to-npm.outputs.release, '-rc.') &&
+      needs.publish-to-npm.outputs.current_beta != ''
+    uses: ./.github/workflows/release-push-to-channel.yml
+    with:
+      version: ${{ needs.publish-to-npm.outputs.current_beta }}
+      release-channel: stable
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      N8N_WEBHOOK_DOCS_PASSWORD: ${{ secrets.N8N_WEBHOOK_DOCS_PASSWORD }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  # =============================================================================
+  # Channel Push Jobs - Patch Release
+  # =============================================================================
+
+  get-channel-for-patch:
+    name: Determine channel for patch
+    needs: [publish-to-npm, publish-to-docker-hub]
+    if: |
+      github.event.pull_request.merged == true &&
+      !contains(github.event.pull_request.labels.*.name, 'release:minor') &&
+      !contains(needs.publish-to-npm.outputs.release, '-rc.')
+    runs-on: ubuntu-latest
+    outputs:
+      channel: ${{ steps.detect.outputs.channel }}
+    steps:
+      - name: Detect target channel
+        id: detect
+        env:
+          PATCH_VERSION: ${{ needs.publish-to-npm.outputs.release }}
+          CURRENT_BETA: ${{ needs.publish-to-npm.outputs.current_beta }}
+          CURRENT_STABLE: ${{ needs.publish-to-npm.outputs.current_stable }}
+        run: |
+          if [[ -z "$CURRENT_BETA" || -z "$CURRENT_STABLE" ]]; then
+            echo "::error::Could not fetch dist-tags from npm (beta='$CURRENT_BETA', stable='$CURRENT_STABLE')"
+            exit 1
+          fi
+
+          patch_minor=$(echo "$PATCH_VERSION" | cut -d. -f1,2)
+          beta_minor=$(echo "$CURRENT_BETA" | cut -d. -f1,2)
+          stable_minor=$(echo "$CURRENT_STABLE" | cut -d. -f1,2)
+
+          echo "Patch version: $PATCH_VERSION (minor: $patch_minor)"
+          echo "Current beta: $CURRENT_BETA (minor: $beta_minor)"
+          echo "Current stable: $CURRENT_STABLE (minor: $stable_minor)"
+
+          if [[ "$patch_minor" == "$beta_minor" ]]; then
+            echo "→ Pushing to channel: beta"
+            echo "channel=beta" >> "$GITHUB_OUTPUT"
+          elif [[ "$patch_minor" == "$stable_minor" ]]; then
+            echo "→ Pushing to channel: stable"
+            echo "channel=stable" >> "$GITHUB_OUTPUT"
+          else
+            echo "→ No channel push needed (older minor)"
+            echo "channel=none" >> "$GITHUB_OUTPUT"
+          fi
+
+  push-patch-to-channel:
+    name: Push patch to channel
+    needs: [publish-to-npm, publish-to-docker-hub, get-channel-for-patch]
+    if: needs.get-channel-for-patch.outputs.channel != 'none'
+    uses: ./.github/workflows/release-push-to-channel.yml
+    with:
+      version: ${{ needs.publish-to-npm.outputs.release }}
+      release-channel: ${{ needs.get-channel-for-patch.outputs.channel }}
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      N8N_WEBHOOK_DOCS_PASSWORD: ${{ secrets.N8N_WEBHOOK_DOCS_PASSWORD }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -343,3 +343,49 @@ jobs:
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       N8N_WEBHOOK_DOCS_PASSWORD: ${{ secrets.N8N_WEBHOOK_DOCS_PASSWORD }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  # =============================================================================
+  # Mark GitHub Release as Latest
+  # =============================================================================
+
+  mark-github-release-minor:
+    name: Mark GitHub release as latest (minor)
+    needs: [publish-to-npm, push-prev-to-stable]
+    if: |
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'release:minor') &&
+      !contains(needs.publish-to-npm.outputs.release, '-rc.') &&
+      needs.publish-to-npm.outputs.current_beta != ''
+    runs-on: ubuntu-slim
+    permissions:
+      contents: write
+    steps:
+      - name: Mark previous beta as latest stable release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.publish-to-npm.outputs.current_beta }}
+        run: |
+          echo "Marking n8n@${VERSION} as latest release"
+          gh release edit "n8n@${VERSION}" \
+            --repo "${{ github.repository }}" \
+            --prerelease=false \
+            --latest
+
+  mark-github-release-patch:
+    name: Mark GitHub release as latest (patch)
+    needs: [publish-to-npm, create-github-release, get-channel-for-patch, push-patch-to-channel]
+    if: needs.get-channel-for-patch.outputs.channel == 'stable'
+    runs-on: ubuntu-slim
+    permissions:
+      contents: write
+    steps:
+      - name: Mark patch as latest stable release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.publish-to-npm.outputs.release }}
+        run: |
+          echo "Marking n8n@${VERSION} as latest release"
+          gh release edit "n8n@${VERSION}" \
+            --repo "${{ github.repository }}" \
+            --prerelease=false \
+            --latest

--- a/.github/workflows/release-push-to-channel.yml
+++ b/.github/workflows/release-push-to-channel.yml
@@ -17,18 +17,40 @@ on:
           - beta
           - stable
 
+  workflow_call:
+    inputs:
+      version:
+        description: 'n8n Release version to push to a channel'
+        required: true
+        type: string
+      release-channel:
+        description: 'Release channel (beta or stable)'
+        required: true
+        type: string
+    secrets:
+      NPM_TOKEN:
+        required: true
+      DOCKER_USERNAME:
+        required: true
+      DOCKER_PASSWORD:
+        required: true
+      N8N_WEBHOOK_DOCS_PASSWORD:
+        required: true
+      SLACK_WEBHOOK_URL:
+        required: true
+
 jobs:
   validate-inputs:
     name: Validate Inputs
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.check_version.outputs.version }}
-      release_channel: ${{ github.event.inputs.release-channel }}
+      release_channel: ${{ inputs.release-channel }}
     steps:
       - name: Check Version Format
         id: check_version
         env:
-          INPUT_VERSION: ${{ github.event.inputs.version }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           input_version="${{ env.INPUT_VERSION }}"
           version_regex='^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$'
@@ -43,14 +65,22 @@ jobs:
 
       - name: Block RC promotion to stable/beta
         env:
-          INPUT_VERSION: ${{ github.event.inputs.version }}
-          CHANNEL: ${{ github.event.inputs.release-channel }}
+          INPUT_VERSION: ${{ inputs.version }}
+          CHANNEL: ${{ inputs.release-channel }}
         run: |
           if [[ "$INPUT_VERSION" == *"-rc."* ]]; then
             echo "::error::RC versions cannot be promoted to '$CHANNEL' channel. Version '$INPUT_VERSION' contains '-rc.'"
             exit 1
           fi
           echo "✅ Version '$INPUT_VERSION' is allowed for '$CHANNEL' channel"
+
+      - name: Verify version exists on npm
+        run: |
+          if ! npm view "n8n@${{ inputs.version }}" version > /dev/null 2>&1; then
+            echo "::error::Version ${{ inputs.version }} not found on npm"
+            exit 1
+          fi
+          echo "✅ Version '${{ inputs.version }}' exists on npm"
 
   release-to-npm:
     name: Release to NPM
@@ -144,3 +174,18 @@ jobs:
     steps:
       - continue-on-error: true
         run: curl -u docsWorkflows:${{ secrets.N8N_WEBHOOK_DOCS_PASSWORD }} --request GET 'https://internal.users.n8n.cloud/webhook/update-latest-next'
+
+  notify-on-failure:
+    name: Notify Slack on failure
+    needs: [release-to-npm, release-to-docker-hub, release-to-github-container-registry]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: act10ns/slack@44541246747a30eb3102d87f7a4cc5471b0ffb7d # v2.1.0
+        with:
+          status: failure
+          channel: '#updates-and-product-releases'
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          message: |
+            Channel push failed for n8n@${{ inputs.version }} → ${{ inputs.release-channel }}
+            <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>


### PR DESCRIPTION
## Summary
  Add jobs to automatically mark GitHub releases as "Latest" after channel pushes:
  - Minor releases: Mark the previous beta (now promoted to stable) as latest release
  - Patch releases on stable: Mark the patch as latest release
  - Patch releases on beta remain as pre-release (no action taken)
  
 Note: to review after https://github.com/n8n-io/n8n/pull/24960 is merged

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2158


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
