### PR TITLE
fix(editor): Prevent focus loss during IME input composition in InlineTextEdit

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nInlineTextEdit/InlineTextEdit.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInlineTextEdit/InlineTextEdit.vue
@@ -31,6 +31,9 @@ const measureSpan = useTemplateRef('measureSpan');
 // Internal editing value
 const editingValue = ref(props.modelValue);
 
+// Composition state for IME input
+const composing = ref(false);
+
 // Content for width calculation
 const displayContent = computed(() => editingValue.value || props.placeholder);
 
@@ -83,6 +86,14 @@ function onStateChange(state: string) {
 	if (state === 'cancel') {
 		editingValue.value = props.modelValue;
 	}
+	// Prevent submit when composing (IME input)
+	// When IME composition is ongoing, reka-ui triggers a submit state
+	// We catch this and force the editable root back into edit mode to prevent focus loss
+	if (state === 'submit' && composing.value) {
+		composing.value = false;
+		// Force the editable root back into edit mode to maintain focus
+		editableRoot.value?.edit();
+	}
 }
 
 defineExpose({ forceFocus, forceCancel });
@@ -128,6 +139,8 @@ defineExpose({ forceFocus, forceCancel });
 				:style="computedInlineStyles"
 				@input="onInput($event.target.value)"
 				@keydown.space.stop
+				@compositionstart="composing = true"
+				@compositionend="composing = false"
 			/>
 		</EditableArea>
 	</EditableRoot>


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Fix IME (Japanese, Chinese, Korean) input handling in N8nInlineTextEdit component. When using IME input methods to enter text, pressing Enter to confirm the input would incorrectly trigger form submission and lose focus, preventing users from continuing to edit.

### Changes

- Track IME composition state during input with `compositionstart` and `compositionend` events

### Testing

- Manual testing with IME input (tested with Japanese input methods) on Storybook ( http://localhost:6006/?path=/docs/atoms-inlinetextedit--docs )

https://github.com/user-attachments/assets/1f6f6406-e595-4037-8e2d-fd4a6450c646

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
