### PR TITLE
fix(editor): Replace O(n) find with O(1) Map lookup in `getConnectionLabel` (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.ts
@@ -803,7 +803,7 @@ export function useCanvasMapping({
 	}
 
 	function getConnectionLabel(connection: CanvasConnection): string {
-		const fromNode = nodes.value.find((node) => node.name === connection.data?.source.node);
+		const fromNode = nodesByName.value.get(connection.data?.source.node ?? '');
 		if (!fromNode) {
 			return '';
 		}


### PR DESCRIPTION
Replace inefficient linear search with existing nodesByName Map to improve connection label lookup from O(n) to O(1) time complexity.

## Summary

This pull request includes a minor update to the `useCanvasMapping` composable. The change improves the way source nodes are retrieved by switching from searching the `nodes` array to using the `nodesByName` map, which should enhance lookup performance and code clarity.

- Improved node lookup in `getConnectionLabel` by replacing an array search with a map lookup using `nodesByName` in `useCanvasMapping.ts`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2235/replace-on-find-with-o1-map-lookup-in-getconnectionlabel

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
