### PR TITLE
refactor(editor): Extract workflow list management into dedicated store (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/stores/src/constants.ts
+++ b/packages/frontend/@n8n/stores/src/constants.ts
@@ -5,6 +5,7 @@ export const STORES = {
 	UI: 'ui',
 	USERS: 'users',
 	WORKFLOWS: 'workflows',
+	WORKFLOWS_LIST: 'workflowsList',
 	WORKFLOWS_V2: 'workflowsV2',
 	WORKFLOWS_EE: 'workflowsEE',
 	EXECUTIONS: 'executions',

--- a/packages/frontend/editor-ui/src/app/components/DuplicateWorkflowDialog.vue
+++ b/packages/frontend/editor-ui/src/app/components/DuplicateWorkflowDialog.vue
@@ -6,6 +6,7 @@ import WorkflowTagsDropdown from '@/features/shared/tags/components/WorkflowTags
 import Modal from '@/app/components/Modal.vue';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import type { WorkflowDataUpdate } from '@n8n/rest-api-client/api/workflows';
 import { createEventBus, type EventBus } from '@n8n/utils/event-bus';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
@@ -39,6 +40,7 @@ const telemetry = useTelemetry();
 const credentialsStore = useCredentialsStore();
 const settingsStore = useSettingsStore();
 const workflowsStore = useWorkflowsStore();
+const workflowsListStore = useWorkflowsListStore();
 
 const name = ref('');
 const currentTagIds = ref(props.data.tags);
@@ -101,7 +103,7 @@ const save = async (): Promise<void> => {
 				activeVersion,
 				active,
 				...workflow
-			} = await workflowsStore.fetchWorkflow(props.data.id);
+			} = await workflowsListStore.fetchWorkflow(props.data.id);
 			workflowToUpdate = workflow;
 
 			workflowHelpers.removeForeignCredentialsFromWorkflow(

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/ActionsDropdownMenu.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/ActionsDropdownMenu.vue
@@ -32,6 +32,7 @@ import saveAs from 'file-saver';
 import { nodeViewEventBus } from '@/app/event-bus';
 import type { FolderShortInfo } from '@/features/core/folders/folders.types';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useTagsStore } from '@/features/shared/tags/tags.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
@@ -61,6 +62,7 @@ const projectsStore = useProjectsStore();
 const sourceControlStore = useSourceControlStore();
 const collaborationStore = useCollaborationStore();
 const workflowsStore = useWorkflowsStore();
+const workflowsListStore = useWorkflowsListStore();
 const uiStore = useUIStore();
 const $style = useCssModule();
 const rootStore = useRootStore();
@@ -284,7 +286,7 @@ async function onWorkflowMenuSelect(action: WORKFLOW_MENU_ACTIONS): Promise<void
 			const workflowId = getWorkflowId(props.id, route.params.name);
 			if (!workflowId) return;
 
-			const workflowDescription = workflowsStore.getWorkflowById(workflowId).description;
+			const workflowDescription = workflowsListStore.getWorkflowById(workflowId).description;
 			uiStore.openModalWithData({
 				name: WORKFLOW_DESCRIPTION_MODAL_KEY,
 				data: {
@@ -413,7 +415,7 @@ async function onWorkflowMenuSelect(action: WORKFLOW_MENU_ACTIONS): Promise<void
 			uiStore.openModalWithData({
 				name: PROJECT_MOVE_RESOURCE_MODAL,
 				data: {
-					resource: workflowsStore.workflowsById[workflowId],
+					resource: workflowsListStore.workflowsById[workflowId],
 					resourceType: ResourceType.Workflow,
 					resourceTypeLabel: locale.baseText('generic.workflow').toLowerCase(),
 					eventBus: changeOwnerEventBus,

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.vue
@@ -15,6 +15,7 @@ import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { computed, onBeforeMount, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import type { RouteLocation, RouteLocationRaw } from 'vue-router';
 import { useRoute, useRouter } from 'vue-router';
@@ -33,6 +34,7 @@ const toast = useToast();
 const ndvStore = useNDVStore();
 const uiStore = useUIStore();
 const workflowsStore = useWorkflowsStore();
+const workflowsListStore = useWorkflowsListStore();
 const executionsStore = useExecutionsStore();
 const settingsStore = useSettingsStore();
 
@@ -254,7 +256,7 @@ async function onWorkflowDeactivated() {
 	if (settingsStore.isModuleActive('mcp') && workflow.value.settings?.availableInMCP) {
 		try {
 			// Fetch the updated workflow to get the latest settings after backend processing
-			const updatedWorkflow = await workflowsStore.fetchWorkflow(workflow.value.id);
+			const updatedWorkflow = await workflowsListStore.fetchWorkflow(workflow.value.id);
 			workflowsStore.setWorkflow(updatedWorkflow);
 			toast.showToast({
 				title: locale.baseText('mcp.workflowDeactivated.title'),

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.test.ts
@@ -17,6 +17,7 @@ import { useRoute, useRouter } from 'vue-router';
 import { useMessage } from '@/app/composables/useMessage';
 import { useToast } from '@/app/composables/useToast';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { useCollaborationStore } from '@/features/collaboration/collaboration/collaboration.store';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
@@ -130,6 +131,7 @@ const renderComponent = createComponentRenderer(WorkflowDetails, {
 
 let uiStore: ReturnType<typeof useUIStore>;
 let workflowsStore: MockedStore<typeof useWorkflowsStore>;
+let workflowsListStore: MockedStore<typeof useWorkflowsListStore>;
 let projectsStore: MockedStore<typeof useProjectsStore>;
 let collaborationStore: MockedStore<typeof useCollaborationStore>;
 let sourceControlStore: MockedStore<typeof useSourceControlStore>;
@@ -151,6 +153,7 @@ describe('WorkflowDetails', () => {
 	beforeEach(() => {
 		uiStore = useUIStore();
 		workflowsStore = mockedStore(useWorkflowsStore);
+		workflowsListStore = mockedStore(useWorkflowsListStore);
 		projectsStore = mockedStore(useProjectsStore);
 		collaborationStore = mockedStore(useCollaborationStore);
 		sourceControlStore = mockedStore(useSourceControlStore);
@@ -158,7 +161,7 @@ describe('WorkflowDetails', () => {
 		// Set up default mocks
 		mockSaveCurrentWorkflow.mockClear();
 		mockSaveCurrentWorkflow.mockResolvedValue(true);
-		workflowsStore.workflowsById = {
+		workflowsListStore.workflowsById = {
 			'1': workflow as unknown as IWorkflowDb,
 			'123': workflow as unknown as IWorkflowDb,
 		};
@@ -488,7 +491,7 @@ describe('WorkflowDetails', () => {
 				},
 			};
 
-			workflowsStore.getWorkflowById = vi.fn().mockReturnValue(teamWorkflow);
+			workflowsListStore.getWorkflowById.mockReturnValue(teamWorkflow as unknown as IWorkflowDb);
 			workflowsStore.archiveWorkflow.mockResolvedValue(undefined);
 
 			const { getByTestId } = renderComponent({
@@ -520,7 +523,9 @@ describe('WorkflowDetails', () => {
 				},
 			};
 
-			workflowsStore.getWorkflowById = vi.fn().mockReturnValue(personalWorkflow);
+			workflowsListStore.getWorkflowById.mockReturnValue(
+				personalWorkflow as unknown as IWorkflowDb,
+			);
 			workflowsStore.archiveWorkflow.mockResolvedValue(undefined);
 
 			const { getByTestId } = renderComponent({
@@ -600,8 +605,8 @@ describe('WorkflowDetails', () => {
 			expect(message.confirm).toHaveBeenCalledTimes(1);
 			expect(toast.showError).toHaveBeenCalledTimes(0);
 			expect(toast.showMessage).toHaveBeenCalledTimes(1);
-			expect(workflowsStore.deleteWorkflow).toHaveBeenCalledTimes(1);
-			expect(workflowsStore.deleteWorkflow).toHaveBeenCalledWith(workflow.id);
+			expect(workflowsListStore.deleteWorkflow).toHaveBeenCalledTimes(1);
+			expect(workflowsListStore.deleteWorkflow).toHaveBeenCalledWith(workflow.id);
 			expect(router.push).toHaveBeenCalledTimes(1);
 			expect(router.push).toHaveBeenCalledWith({
 				name: VIEWS.WORKFLOWS,
@@ -620,8 +625,8 @@ describe('WorkflowDetails', () => {
 				},
 			};
 
-			workflowsStore.getWorkflowById = vi.fn().mockReturnValue(teamWorkflow);
-			workflowsStore.deleteWorkflow.mockResolvedValue(undefined);
+			workflowsListStore.getWorkflowById.mockReturnValue(teamWorkflow as unknown as IWorkflowDb);
+			workflowsListStore.deleteWorkflow.mockResolvedValue(undefined);
 
 			const { getByTestId } = renderComponent({
 				props: {
@@ -634,7 +639,7 @@ describe('WorkflowDetails', () => {
 			await userEvent.click(getByTestId('workflow-menu'));
 			await userEvent.click(getByTestId('workflow-menu-item-delete'));
 
-			expect(workflowsStore.deleteWorkflow).toHaveBeenCalledWith(teamWorkflow.id);
+			expect(workflowsListStore.deleteWorkflow).toHaveBeenCalledWith(teamWorkflow.id);
 			expect(router.push).toHaveBeenCalledWith({
 				name: VIEWS.PROJECTS_WORKFLOWS,
 				params: { projectId: teamProjectId },
@@ -652,8 +657,10 @@ describe('WorkflowDetails', () => {
 				},
 			};
 
-			workflowsStore.getWorkflowById = vi.fn().mockReturnValue(personalWorkflow);
-			workflowsStore.deleteWorkflow.mockResolvedValue(undefined);
+			workflowsListStore.getWorkflowById.mockReturnValue(
+				personalWorkflow as unknown as IWorkflowDb,
+			);
+			workflowsListStore.deleteWorkflow.mockResolvedValue(undefined);
 
 			const { getByTestId } = renderComponent({
 				props: {
@@ -666,7 +673,7 @@ describe('WorkflowDetails', () => {
 			await userEvent.click(getByTestId('workflow-menu'));
 			await userEvent.click(getByTestId('workflow-menu-item-delete'));
 
-			expect(workflowsStore.deleteWorkflow).toHaveBeenCalledWith(personalWorkflow.id);
+			expect(workflowsListStore.deleteWorkflow).toHaveBeenCalledWith(personalWorkflow.id);
 			expect(router.push).toHaveBeenCalledWith({
 				name: VIEWS.WORKFLOWS,
 			});
@@ -675,7 +682,7 @@ describe('WorkflowDetails', () => {
 		it("should call onWorkflowMenuSelect on 'Change owner' option click", async () => {
 			const openModalSpy = vi.spyOn(uiStore, 'openModalWithData');
 
-			workflowsStore.workflowsById = { [workflow.id]: workflow as unknown as IWorkflowDb };
+			workflowsListStore.workflowsById = { [workflow.id]: workflow as unknown as IWorkflowDb };
 
 			const { getByTestId } = renderComponent({
 				props: {

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.test.ts
@@ -1,6 +1,8 @@
 import WorkflowDetails from '@/app/components/MainHeader/WorkflowDetails.vue';
 import { createComponentRenderer } from '@/__tests__/render';
 import { type MockedStore, mockedStore } from '@/__tests__/utils';
+import { createTestWorkflow } from '@/__tests__/mocks';
+import type { IWorkflowDb } from '@/Interface';
 import {
 	EnterpriseEditionFeature,
 	MODAL_CONFIRM,
@@ -8,7 +10,6 @@ import {
 	WORKFLOW_SHARE_MODAL_KEY,
 } from '@/app/constants';
 import { PROJECT_MOVE_RESOURCE_MODAL } from '@/features/collaboration/projects/projects.constants';
-import type { IWorkflowDb } from '@/Interface';
 import { STORES } from '@n8n/stores';
 import { createTestingPinia } from '@pinia/testing';
 import userEvent from '@testing-library/user-event';
@@ -139,7 +140,7 @@ let message: ReturnType<typeof useMessage>;
 let toast: ReturnType<typeof useToast>;
 let router: ReturnType<typeof useRouter>;
 
-const workflow = {
+const workflow = createTestWorkflow({
 	id: '1',
 	name: 'Test Workflow',
 	tags: ['1', '2'],
@@ -147,7 +148,7 @@ const workflow = {
 	isArchived: false,
 	scopes: [],
 	meta: {},
-};
+});
 
 describe('WorkflowDetails', () => {
 	beforeEach(() => {
@@ -162,8 +163,8 @@ describe('WorkflowDetails', () => {
 		mockSaveCurrentWorkflow.mockClear();
 		mockSaveCurrentWorkflow.mockResolvedValue(true);
 		workflowsListStore.workflowsById = {
-			'1': workflow as unknown as IWorkflowDb,
-			'123': workflow as unknown as IWorkflowDb,
+			'1': workflow,
+			'123': workflow,
 		};
 		workflowsStore.isWorkflowSaved = { '1': true, '123': true };
 		projectsStore.currentProject = null;
@@ -491,7 +492,7 @@ describe('WorkflowDetails', () => {
 				},
 			};
 
-			workflowsListStore.getWorkflowById.mockReturnValue(teamWorkflow as unknown as IWorkflowDb);
+			workflowsListStore.getWorkflowById.mockReturnValue(teamWorkflow as IWorkflowDb);
 			workflowsStore.archiveWorkflow.mockResolvedValue(undefined);
 
 			const { getByTestId } = renderComponent({
@@ -523,9 +524,7 @@ describe('WorkflowDetails', () => {
 				},
 			};
 
-			workflowsListStore.getWorkflowById.mockReturnValue(
-				personalWorkflow as unknown as IWorkflowDb,
-			);
+			workflowsListStore.getWorkflowById.mockReturnValue(personalWorkflow as IWorkflowDb);
 			workflowsStore.archiveWorkflow.mockResolvedValue(undefined);
 
 			const { getByTestId } = renderComponent({
@@ -625,7 +624,7 @@ describe('WorkflowDetails', () => {
 				},
 			};
 
-			workflowsListStore.getWorkflowById.mockReturnValue(teamWorkflow as unknown as IWorkflowDb);
+			workflowsListStore.getWorkflowById.mockReturnValue(teamWorkflow as IWorkflowDb);
 			workflowsListStore.deleteWorkflow.mockResolvedValue(undefined);
 
 			const { getByTestId } = renderComponent({
@@ -657,9 +656,7 @@ describe('WorkflowDetails', () => {
 				},
 			};
 
-			workflowsListStore.getWorkflowById.mockReturnValue(
-				personalWorkflow as unknown as IWorkflowDb,
-			);
+			workflowsListStore.getWorkflowById.mockReturnValue(personalWorkflow as IWorkflowDb);
 			workflowsListStore.deleteWorkflow.mockResolvedValue(undefined);
 
 			const { getByTestId } = renderComponent({
@@ -682,7 +679,7 @@ describe('WorkflowDetails', () => {
 		it("should call onWorkflowMenuSelect on 'Change owner' option click", async () => {
 			const openModalSpy = vi.spyOn(uiStore, 'openModalWithData');
 
-			workflowsListStore.workflowsById = { [workflow.id]: workflow as unknown as IWorkflowDb };
+			workflowsListStore.workflowsById = { [workflow.id]: workflow };
 
 			const { getByTestId } = renderComponent({
 				props: {

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.vue
@@ -41,6 +41,7 @@ import { N8nBadge, N8nInlineTextEdit } from '@n8n/design-system';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { getWorkflowId } from '@/app/components/MainHeader/utils';
 const WORKFLOW_NAME_BP_TO_WIDTH: { [key: string]: number } = {
 	XS: 150,
@@ -67,6 +68,7 @@ const $style = useCssModule();
 const settingsStore = useSettingsStore();
 const uiStore = useUIStore();
 const workflowsStore = useWorkflowsStore();
+const workflowsListStore = useWorkflowsListStore();
 const projectsStore = useProjectsStore();
 const collaborationStore = useCollaborationStore();
 const sourceControlStore = useSourceControlStore();
@@ -277,7 +279,7 @@ async function handleArchiveWorkflow() {
 	});
 
 	// Navigate to the appropriate project's workflow list
-	const workflow = workflowsStore.getWorkflowById(props.id);
+	const workflow = workflowsListStore.getWorkflowById(props.id);
 	if (workflow?.homeProject?.type === ProjectTypes.Team) {
 		await router.push({
 			name: VIEWS.PROJECTS_WORKFLOWS,
@@ -320,11 +322,11 @@ async function handleDeleteWorkflow() {
 	}
 
 	// Get workflow before deletion to know which project to navigate to
-	const workflow = workflowsStore.getWorkflowById(props.id);
+	const workflow = workflowsListStore.getWorkflowById(props.id);
 	const isTeamProject = workflow?.homeProject?.type === ProjectTypes.Team;
 
 	try {
-		await workflowsStore.deleteWorkflow(props.id);
+		await workflowsListStore.deleteWorkflow(props.id);
 	} catch (error) {
 		toast.showError(error, locale.baseText('generic.deleteWorkflowError'));
 		return;

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowPublishModal.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowPublishModal.test.ts
@@ -3,6 +3,7 @@ import { createComponentRenderer } from '@/__tests__/render';
 import { type MockedStore, mockedStore } from '@/__tests__/utils';
 import WorkflowPublishModal from '@/app/components/MainHeader/WorkflowPublishModal.vue';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { WORKFLOW_PUBLISH_MODAL_KEY } from '@/app/constants';
 import { STORES } from '@n8n/stores';
 import { waitFor } from '@testing-library/vue';
@@ -71,9 +72,11 @@ const renderComponent = createComponentRenderer(WorkflowPublishModal, {
 
 describe('WorkflowPublishModal', () => {
 	let workflowsStore: MockedStore<typeof useWorkflowsStore>;
+	let workflowsListStore: MockedStore<typeof useWorkflowsListStore>;
 
 	beforeEach(() => {
 		workflowsStore = mockedStore(useWorkflowsStore);
+		workflowsListStore = mockedStore(useWorkflowsListStore);
 
 		workflowsStore.workflow = {
 			id: 'workflow-1',
@@ -128,7 +131,7 @@ describe('WorkflowPublishModal', () => {
 				success: false,
 				errorHandled: true,
 			});
-			workflowsStore.fetchWorkflow.mockResolvedValue({
+			workflowsListStore.fetchWorkflow.mockResolvedValue({
 				id: 'conflicting-workflow-123',
 				name: 'Conflicting Workflow Name',
 				active: true,
@@ -160,7 +163,7 @@ describe('WorkflowPublishModal', () => {
 				success: false,
 				errorHandled: false,
 			});
-			workflowsStore.fetchWorkflow.mockResolvedValue({
+			workflowsListStore.fetchWorkflow.mockResolvedValue({
 				id: 'conflicting-workflow-123',
 				name: 'Conflicting Workflow Name',
 				active: true,

--- a/packages/frontend/editor-ui/src/app/components/WorkflowCard.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowCard.test.ts
@@ -14,6 +14,7 @@ import type { ProjectListItem } from '@/features/collaboration/projects/projects
 import { useMessage } from '@/app/composables/useMessage';
 import { useToast } from '@/app/composables/useToast';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { createTestingPinia } from '@pinia/testing';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
@@ -98,6 +99,7 @@ describe('WorkflowCard', () => {
 	let projectsStore: MockedStore<typeof useProjectsStore>;
 	let settingsStore: MockedStore<typeof useSettingsStore>;
 	let workflowsStore: MockedStore<typeof useWorkflowsStore>;
+	let workflowsListStore: MockedStore<typeof useWorkflowsListStore>;
 	let usersStore: MockedStore<typeof useUsersStore>;
 	let message: ReturnType<typeof useMessage>;
 	let toast: ReturnType<typeof useToast>;
@@ -107,6 +109,7 @@ describe('WorkflowCard', () => {
 		projectsStore = mockedStore(useProjectsStore);
 		settingsStore = mockedStore(useSettingsStore);
 		workflowsStore = mockedStore(useWorkflowsStore);
+		workflowsListStore = mockedStore(useWorkflowsListStore);
 		usersStore = mockedStore(useUsersStore);
 		message = useMessage();
 		toast = useToast();
@@ -467,8 +470,8 @@ describe('WorkflowCard', () => {
 		await userEvent.click(getByTestId('action-delete'));
 
 		expect(message.confirm).toHaveBeenCalledTimes(1);
-		expect(workflowsStore.deleteWorkflow).toHaveBeenCalledTimes(1);
-		expect(workflowsStore.deleteWorkflow).toHaveBeenCalledWith(data.id);
+		expect(workflowsListStore.deleteWorkflow).toHaveBeenCalledTimes(1);
+		expect(workflowsListStore.deleteWorkflow).toHaveBeenCalledWith(data.id);
 		expect(toast.showError).not.toHaveBeenCalled();
 		expect(toast.showMessage).toHaveBeenCalledTimes(1);
 		expect(emitted()['workflow:deleted']).toHaveLength(1);

--- a/packages/frontend/editor-ui/src/app/components/WorkflowCard.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowCard.vue
@@ -15,6 +15,7 @@ import dateformat from 'dateformat';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import TimeAgo from '@/app/components/TimeAgo.vue';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import ProjectCardBadge from '@/features/collaboration/projects/components/ProjectCardBadge.vue';
@@ -113,6 +114,7 @@ const { check: checkEnvFeatureFlag } = useEnvFeatureFlag();
 const uiStore = useUIStore();
 const usersStore = useUsersStore();
 const workflowsStore = useWorkflowsStore();
+const workflowsListStore = useWorkflowsListStore();
 const projectsStore = useProjectsStore();
 const foldersStore = useFoldersStore();
 const mcpStore = useMCPStore();
@@ -463,7 +465,7 @@ async function deleteWorkflow() {
 	}
 
 	try {
-		await workflowsStore.deleteWorkflow(props.data.id);
+		await workflowsListStore.deleteWorkflow(props.data.id);
 	} catch (error) {
 		toast.showError(error, locale.baseText('generic.deleteWorkflowError'));
 		return;

--- a/packages/frontend/editor-ui/src/app/components/WorkflowSettings.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowSettings.test.ts
@@ -10,6 +10,7 @@ import { getDropdownItems, mockedStore, type MockedStore } from '@/__tests__/uti
 import { EnterpriseEditionFeature } from '@/app/constants';
 import WorkflowSettingsVue from '@/app/components/WorkflowSettings.vue';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
 import * as restApiClient from '@n8n/rest-api-client';
@@ -48,11 +49,12 @@ vi.mock('@n8n/rest-api-client', async (importOriginal) => {
 });
 
 let workflowsStore: MockedStore<typeof useWorkflowsStore>;
+let workflowsListStore: MockedStore<typeof useWorkflowsListStore>;
 let settingsStore: MockedStore<typeof useSettingsStore>;
 let sourceControlStore: MockedStore<typeof useSourceControlStore>;
 let pinia: ReturnType<typeof createTestingPinia>;
 
-let searchWorkflowsSpy: MockInstance<(typeof workflowsStore)['searchWorkflows']>;
+let searchWorkflowsSpy: MockInstance<(typeof workflowsListStore)['searchWorkflows']>;
 
 const createComponent = createComponentRenderer(WorkflowSettingsVue, {
 	global: {
@@ -69,6 +71,7 @@ describe('WorkflowSettingsVue', () => {
 	beforeEach(async () => {
 		pinia = createTestingPinia();
 		workflowsStore = mockedStore(useWorkflowsStore);
+		workflowsListStore = mockedStore(useWorkflowsListStore);
 		settingsStore = mockedStore(useSettingsStore);
 		sourceControlStore = mockedStore(useSourceControlStore);
 
@@ -88,9 +91,9 @@ describe('WorkflowSettingsVue', () => {
 			active: true,
 			scopes: ['workflow:update'],
 		});
-		workflowsStore.workflowsById = { '1': testWorkflow };
-		searchWorkflowsSpy = workflowsStore.searchWorkflows.mockResolvedValue([testWorkflow]);
-		workflowsStore.getWorkflowById.mockImplementation(() => testWorkflow);
+		workflowsListStore.workflowsById = { '1': testWorkflow };
+		searchWorkflowsSpy = workflowsListStore.searchWorkflows.mockResolvedValue([testWorkflow]);
+		workflowsListStore.getWorkflowById.mockImplementation(() => testWorkflow);
 	});
 
 	afterEach(() => {
@@ -378,8 +381,8 @@ describe('WorkflowSettingsVue', () => {
 			active: true,
 			scopes: ['workflow:read'],
 		});
-		workflowsStore.workflowsById = { '1': readOnlyWorkflow };
-		workflowsStore.getWorkflowById.mockImplementation(() => readOnlyWorkflow);
+		workflowsListStore.workflowsById = { '1': readOnlyWorkflow };
+		workflowsListStore.getWorkflowById.mockImplementation(() => readOnlyWorkflow);
 
 		const { getByTestId } = createComponent({ pinia });
 		await nextTick();
@@ -535,7 +538,7 @@ describe('WorkflowSettingsVue', () => {
 		});
 
 		it('should disable execution order dropdown when user has no update permission', async () => {
-			workflowsStore.getWorkflowById.mockImplementation(() => ({
+			workflowsListStore.getWorkflowById.mockImplementation(() => ({
 				id: '1',
 				name: 'Test Workflow',
 				active: true,
@@ -694,7 +697,7 @@ describe('WorkflowSettingsVue', () => {
 		});
 
 		it('should disable credential resolver dropdown when user has no update permission', async () => {
-			workflowsStore.getWorkflowById.mockImplementation(() => ({
+			workflowsListStore.getWorkflowById.mockImplementation(() => ({
 				id: '1',
 				name: 'Test Workflow',
 				active: true,

--- a/packages/frontend/editor-ui/src/app/components/WorkflowSettings.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowSettings.vue
@@ -31,6 +31,7 @@ import { useSettingsStore } from '@/app/stores/settings.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useWorkflowsEEStore } from '@/app/stores/workflows.ee.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { createEventBus } from '@n8n/utils/event-bus';
 import { useExternalHooks } from '@/app/composables/useExternalHooks';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
@@ -64,6 +65,7 @@ const settingsStore = useSettingsStore();
 const sourceControlStore = useSourceControlStore();
 const collaborationStore = useCollaborationStore();
 const workflowsStore = useWorkflowsStore();
+const workflowsListStore = useWorkflowsListStore();
 const workflowState = injectWorkflowState();
 const workflowsEEStore = useWorkflowsEEStore();
 const nodeCreatorStore = useNodeCreatorStore();
@@ -150,7 +152,7 @@ const readOnlyEnv = computed(
 );
 const workflowName = computed(() => workflowsStore.workflowName);
 const workflowId = computed(() => workflowsStore.workflowId);
-const workflow = computed(() => workflowsStore.getWorkflowById(workflowId.value));
+const workflow = computed(() => workflowsListStore.getWorkflowById(workflowId.value));
 const isSharingEnabled = computed(
 	() => settingsStore.isEnterpriseFeatureEnabled[EnterpriseEditionFeature.Sharing],
 );
@@ -394,7 +396,7 @@ const loadTimezones = async () => {
 };
 
 const loadWorkflows = async (searchTerm?: string) => {
-	const workflowsData = (await workflowsStore.searchWorkflows({
+	const workflowsData = (await workflowsListStore.searchWorkflows({
 		query: searchTerm,
 		isArchived: false,
 		triggerNodeTypes: ['n8n-nodes-base.errorTrigger'],
@@ -618,7 +620,7 @@ onMounted(async () => {
 
 	try {
 		const promises = [
-			workflowsStore.fetchWorkflow(workflowId.value),
+			workflowsListStore.fetchWorkflow(workflowId.value),
 			loadWorkflows(),
 			loadSaveDataErrorExecutionOptions(),
 			loadSaveDataSuccessExecutionOptions(),

--- a/packages/frontend/editor-ui/src/app/components/WorkflowShareModal.ee.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowShareModal.ee.vue
@@ -12,6 +12,7 @@ import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useWorkflowsEEStore } from '@/app/stores/workflows.ee.store';
 import type { ITelemetryTrackProperties } from 'n8n-workflow';
 import type { BaseTextKey } from '@n8n/i18n';
@@ -36,6 +37,7 @@ const props = defineProps<{
 const { data } = props;
 
 const workflowsStore = useWorkflowsStore();
+const workflowsListStore = useWorkflowsListStore();
 const settingsStore = useSettingsStore();
 const uiStore = useUIStore();
 const usersStore = useUsersStore();
@@ -52,8 +54,8 @@ const route = useRoute();
 const workflowSaving = useWorkflowSaving({ router });
 
 const workflow = ref(
-	data.id && workflowsStore.workflowsById[data.id]
-		? workflowsStore.workflowsById[data.id]
+	data.id && workflowsListStore.workflowsById[data.id]
+		? workflowsListStore.workflowsById[data.id]
 		: workflowsStore.workflow,
 );
 const loading = ref(true);
@@ -211,7 +213,7 @@ const initialize = async () => {
 
 		// Fetch workflow if it exists and is not new
 		if (workflowsStore.isWorkflowSaved[workflow.value.id]) {
-			await workflowsStore.fetchWorkflow(workflow.value.id);
+			await workflowsListStore.fetchWorkflow(workflow.value.id);
 		}
 
 		if (isHomeTeamProject.value && workflow.value.homeProject) {

--- a/packages/frontend/editor-ui/src/app/composables/useCalloutHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCalloutHelpers.test.ts
@@ -39,6 +39,11 @@ vi.mock('@/app/stores/workflows.store', () => ({
 		workflowObject: {
 			id: '1',
 		},
+	}),
+}));
+
+vi.mock('@/app/stores/workflowsList.store', () => ({
+	useWorkflowsListStore: () => ({
 		getWorkflowById: mocks.getWorkflowById,
 	}),
 }));

--- a/packages/frontend/editor-ui/src/app/composables/useCalloutHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCalloutHelpers.ts
@@ -4,6 +4,7 @@ import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { updateCurrentUserSettings } from '@n8n/rest-api-client/api/users';
 import { VIEWS } from '@/app/constants';
@@ -24,6 +25,7 @@ export function useCalloutHelpers() {
 
 	const rootStore = useRootStore();
 	const workflowsStore = useWorkflowsStore();
+	const workflowsListStore = useWorkflowsListStore();
 	const usersStore = useUsersStore();
 	const nodeTypesStore = useNodeTypesStore();
 	const projectsStore = useProjectsStore();
@@ -33,7 +35,7 @@ export function useCalloutHelpers() {
 
 		const routeTemplateId = route.query.templateId;
 		const workflowObject = workflowsStore.workflowObject;
-		const workflow = workflowsStore.getWorkflowById(workflowObject.id);
+		const workflow = workflowsListStore.getWorkflowById(workflowObject.id);
 
 		// Hide the RAG starter callout if we're currently on the RAG starter template
 		if ((routeTemplateId ?? workflow?.meta?.templateId) === template.meta.templateId) {

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.test.ts
@@ -16,6 +16,7 @@ import type { WorkflowState } from '@/app/composables/useWorkflowState';
 import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { mockedStore } from '@/__tests__/utils';
 import { useReadyToRunStore } from '@/features/workflows/readyToRun/stores/readyToRun.store';
@@ -258,10 +259,11 @@ describe('executionFinished', () => {
 			setActivePinia(pinia);
 
 			const workflowsStore = useWorkflowsStore();
+			const workflowsListStore = useWorkflowsListStore();
 			const readyToRunStore = useReadyToRunStore();
 
 			vi.spyOn(workflowsStore, 'activeExecutionId', 'get').mockReturnValue('123');
-			vi.spyOn(workflowsStore, 'getWorkflowById').mockReturnValue({
+			vi.spyOn(workflowsListStore, 'getWorkflowById').mockReturnValue({
 				id: '1',
 				name: 'Test Workflow',
 				meta: { templateId: 'ready-to-run-ai-workflow' },
@@ -301,10 +303,11 @@ describe('executionFinished', () => {
 			setActivePinia(pinia);
 
 			const workflowsStore = useWorkflowsStore();
+			const workflowsListStore = useWorkflowsListStore();
 			const readyToRunStore = useReadyToRunStore();
 
 			vi.spyOn(workflowsStore, 'activeExecutionId', 'get').mockReturnValue('123');
-			vi.spyOn(workflowsStore, 'getWorkflowById').mockReturnValue({
+			vi.spyOn(workflowsListStore, 'getWorkflowById').mockReturnValue({
 				id: '1',
 				name: 'Test Workflow',
 				meta: { templateId: 'ready-to-run-ai-workflow' },
@@ -341,10 +344,11 @@ describe('executionFinished', () => {
 			setActivePinia(pinia);
 
 			const workflowsStore = useWorkflowsStore();
+			const workflowsListStore = useWorkflowsListStore();
 			const readyToRunStore = useReadyToRunStore();
 
 			vi.spyOn(workflowsStore, 'activeExecutionId', 'get').mockReturnValue('123');
-			vi.spyOn(workflowsStore, 'getWorkflowById').mockReturnValue({
+			vi.spyOn(workflowsListStore, 'getWorkflowById').mockReturnValue({
 				id: '1',
 				name: 'Test Workflow',
 				meta: { templateId: 'ready-to-run-ai-workflow-v5' },
@@ -384,10 +388,11 @@ describe('executionFinished', () => {
 			setActivePinia(pinia);
 
 			const workflowsStore = useWorkflowsStore();
+			const workflowsListStore = useWorkflowsListStore();
 			const readyToRunStore = useReadyToRunStore();
 
 			vi.spyOn(workflowsStore, 'activeExecutionId', 'get').mockReturnValue('123');
-			vi.spyOn(workflowsStore, 'getWorkflowById').mockReturnValue({
+			vi.spyOn(workflowsListStore, 'getWorkflowById').mockReturnValue({
 				id: '1',
 				name: 'Test Workflow',
 				meta: { templateId: 'ready-to-run-ai-workflow-v6' },
@@ -424,10 +429,11 @@ describe('executionFinished', () => {
 			setActivePinia(pinia);
 
 			const workflowsStore = useWorkflowsStore();
+			const workflowsListStore = useWorkflowsListStore();
 			const readyToRunStore = useReadyToRunStore();
 
 			vi.spyOn(workflowsStore, 'activeExecutionId', 'get').mockReturnValue('123');
-			vi.spyOn(workflowsStore, 'getWorkflowById').mockReturnValue({
+			vi.spyOn(workflowsListStore, 'getWorkflowById').mockReturnValue({
 				id: '1',
 				name: 'Test Workflow',
 				meta: { templateId: 'some-other-template' },
@@ -477,20 +483,21 @@ describe('executionFinished', () => {
 		setActivePinia(pinia);
 
 		const workflowsStore = mockedStore(useWorkflowsStore);
+		const workflowsListStore = mockedStore(useWorkflowsListStore);
 		const uiStore = mockedStore(useUIStore);
 
 		// Set activeExecutionId directly on the store
 		workflowsStore.activeExecutionId = '123';
 
 		// Mock getWorkflowById to return a workflow
-		vi.spyOn(workflowsStore, 'getWorkflowById').mockReturnValue({
+		vi.spyOn(workflowsListStore, 'getWorkflowById').mockReturnValue({
 			id: '1',
 			name: 'Test Workflow',
 			nodes: [],
 			connections: {},
 			active: false,
 			settings: {},
-		} as unknown as ReturnType<typeof workflowsStore.getWorkflowById>);
+		} as unknown as ReturnType<typeof workflowsListStore.getWorkflowById>);
 
 		vi.spyOn(workflowsStore, 'fetchExecutionDataById').mockResolvedValue(null);
 

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
@@ -14,6 +14,7 @@ import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useBuilderStore } from '@/features/ai/assistant/builder.store';
 import {
 	SampleTemplates,
@@ -62,6 +63,7 @@ export async function executionFinished(
 	options: ExecutionFinishedOptions,
 ) {
 	const workflowsStore = useWorkflowsStore();
+	const workflowsListStore = useWorkflowsListStore();
 	const uiStore = useUIStore();
 	const aiTemplatesStarterCollectionStore = useAITemplatesStarterCollectionStore();
 	const readyToRunStore = useReadyToRunStore();
@@ -77,7 +79,7 @@ export async function executionFinished(
 
 	clearPopupWindowState();
 
-	const workflow = workflowsStore.getWorkflowById(data.workflowId);
+	const workflow = workflowsListStore.getWorkflowById(data.workflowId);
 	const templateId = workflow?.meta?.templateId;
 
 	if (templateId) {

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowActivated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowActivated.ts
@@ -1,5 +1,6 @@
 import type { WorkflowActivated } from '@n8n/api-types/push/workflow';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useBannersStore } from '@/features/shared/banners/banners.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
@@ -7,6 +8,7 @@ import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
 export async function workflowActivated({ data }: WorkflowActivated) {
 	const { initializeWorkspace } = useCanvasOperations();
 	const workflowsStore = useWorkflowsStore();
+	const workflowsListStore = useWorkflowsListStore();
 	const bannersStore = useBannersStore();
 	const uiStore = useUIStore();
 
@@ -17,7 +19,7 @@ export async function workflowActivated({ data }: WorkflowActivated) {
 	if (workflowIsBeingViewed && activeVersionIsSet) {
 		// Only update workflow if there are no unsaved changes
 		if (!uiStore.stateIsDirty) {
-			const updatedWorkflow = await workflowsStore.fetchWorkflow(workflowId);
+			const updatedWorkflow = await workflowsListStore.fetchWorkflow(workflowId);
 			if (!updatedWorkflow.checksum) {
 				throw new Error('Failed to fetch workflow');
 			}

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowAutoDeactivated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowAutoDeactivated.ts
@@ -1,11 +1,13 @@
 import type { WorkflowAutoDeactivated } from '@n8n/api-types/push/workflow';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useBannersStore } from '@/features/shared/banners/banners.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
 
 export async function workflowAutoDeactivated({ data }: WorkflowAutoDeactivated) {
 	const workflowsStore = useWorkflowsStore();
+	const workflowsListStore = useWorkflowsListStore();
 	const { initializeWorkspace } = useCanvasOperations();
 	const bannersStore = useBannersStore();
 	const uiStore = useUIStore();
@@ -15,7 +17,7 @@ export async function workflowAutoDeactivated({ data }: WorkflowAutoDeactivated)
 	if (workflowsStore.workflowId === data.workflowId) {
 		// Only update workflow if there are no unsaved changes
 		if (!uiStore.stateIsDirty) {
-			const updatedWorkflow = await workflowsStore.fetchWorkflow(data.workflowId);
+			const updatedWorkflow = await workflowsListStore.fetchWorkflow(data.workflowId);
 			if (!updatedWorkflow.checksum) {
 				throw new Error('Failed to fetch workflow');
 			}

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowDeactivated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowDeactivated.ts
@@ -1,17 +1,19 @@
 import type { WorkflowDeactivated } from '@n8n/api-types/push/workflow';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
 
 export async function workflowDeactivated({ data }: WorkflowDeactivated) {
 	const { initializeWorkspace } = useCanvasOperations();
 	const workflowsStore = useWorkflowsStore();
+	const workflowsListStore = useWorkflowsListStore();
 	const uiStore = useUIStore();
 
 	if (workflowsStore.workflowId === data.workflowId) {
 		// Only update workflow if there are no unsaved changes
 		if (!uiStore.stateIsDirty) {
-			const updatedWorkflow = await workflowsStore.fetchWorkflow(data.workflowId);
+			const updatedWorkflow = await workflowsListStore.fetchWorkflow(data.workflowId);
 			if (!updatedWorkflow.checksum) {
 				throw new Error('Failed to fetch workflow');
 			}

--- a/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.test.ts
@@ -68,20 +68,6 @@ vi.mock('@/app/stores/workflows.store', () => {
 			activeVersionId: null,
 		},
 		workflowId: '123',
-		workflowsById: {
-			'123': {
-				id: '123',
-				name: 'Test Workflow',
-				active: false,
-				isArchived: false,
-				createdAt: '',
-				updatedAt: '',
-				connections: {},
-				nodes: [],
-				versionId: '',
-				activeVersionId: null,
-			},
-		},
 		isWorkflowSaved: {
 			'123': true,
 		},
@@ -107,6 +93,29 @@ vi.mock('@/app/stores/workflows.store', () => {
 
 	return {
 		useWorkflowsStore: vi.fn().mockReturnValue(storeState),
+	};
+});
+
+vi.mock('@/app/stores/workflowsList.store', () => {
+	const storeState = {
+		activeWorkflows: [] as string[],
+		workflowsById: {
+			'123': {
+				id: '123',
+				name: 'Test Workflow',
+				active: false,
+				isArchived: false,
+				createdAt: '',
+				updatedAt: '',
+				connections: {},
+				nodes: [],
+				versionId: '',
+				activeVersionId: null,
+			},
+		},
+	};
+	return {
+		useWorkflowsListStore: vi.fn().mockReturnValue(storeState),
 	};
 });
 
@@ -1097,7 +1106,13 @@ describe('useRunWorkflow({ router })', () => {
 			const markStoppedSpy = vi.spyOn(workflowState, 'markExecutionAsStopped');
 			const getExecutionSpy = vi.spyOn(workflowsStore, 'getExecution');
 
-			workflowsStore.activeWorkflows = ['test-wf-id'];
+			const { useWorkflowsListStore } = await import('@/app/stores/workflowsList.store');
+			const workflowsListStore = useWorkflowsListStore();
+			(workflowsListStore.activeWorkflows as string[]).splice(
+				0,
+				workflowsListStore.activeWorkflows.length,
+				'test-wf-id',
+			);
 			workflowState.setActiveExecutionId('test-exec-id');
 			workflowsStore.executionWaitingForWebhook = false;
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.ts
@@ -7,6 +7,7 @@ import {
 } from '@/app/constants';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useExternalHooks } from '@/app/composables/useExternalHooks';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useToast } from '@/app/composables/useToast';
@@ -21,6 +22,7 @@ export function useWorkflowActivate() {
 	const updatingWorkflowActivation = ref(false);
 
 	const workflowsStore = useWorkflowsStore();
+	const workflowsListStore = useWorkflowsListStore();
 	const uiStore = useUIStore();
 	const telemetry = useTelemetry();
 	const toast = useToast();
@@ -54,7 +56,7 @@ export function useWorkflowActivate() {
 		let workflowName = conflict?.workflowId;
 		try {
 			if (conflict?.workflowId) {
-				const conflictingWorkflow = await workflowsStore.fetchWorkflow(conflict?.workflowId);
+				const conflictingWorkflow = await workflowsListStore.fetchWorkflow(conflict?.workflowId);
 				workflowName = conflictingWorkflow.name;
 			}
 		} catch {}
@@ -82,7 +84,7 @@ export function useWorkflowActivate() {
 
 		collaborationStore.requestWriteAccess();
 
-		const workflow = workflowsStore.getWorkflowById(workflowId);
+		const workflow = workflowsListStore.getWorkflowById(workflowId);
 		const hadPublishedVersion = !!workflow.activeVersion;
 
 		if (!hadPublishedVersion) {
@@ -152,7 +154,7 @@ export function useWorkflowActivate() {
 
 		collaborationStore.requestWriteAccess();
 
-		const workflow = workflowsStore.getWorkflowById(workflowId);
+		const workflow = workflowsListStore.getWorkflowById(workflowId);
 		const wasPublished = !!workflow.activeVersion;
 
 		const telemetryPayload = {

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
@@ -5,6 +5,7 @@ import { resolveParameter, useWorkflowHelpers } from '@/app/composables/useWorkf
 import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useWorkflowsEEStore } from '@/app/stores/workflows.ee.store';
 import { useTagsStore } from '@/features/shared/tags/tags.store';
 import { useUIStore } from '@/app/stores/ui.store';
@@ -44,6 +45,7 @@ vi.mock('@/app/composables/useWorkflowState', async () => {
 
 describe('useWorkflowHelpers', () => {
 	let workflowsStore: ReturnType<typeof mockedStore<typeof useWorkflowsStore>>;
+	let workflowsListStore: ReturnType<typeof mockedStore<typeof useWorkflowsListStore>>;
 	let workflowState: WorkflowState;
 	let workflowsEEStore: ReturnType<typeof useWorkflowsEEStore>;
 	let tagsStore: ReturnType<typeof useTagsStore>;
@@ -52,6 +54,7 @@ describe('useWorkflowHelpers', () => {
 	beforeAll(() => {
 		setActivePinia(createTestingPinia());
 		workflowsStore = mockedStore(useWorkflowsStore);
+		workflowsListStore = mockedStore(useWorkflowsListStore);
 
 		workflowState = useWorkflowState();
 		vi.mocked(injectWorkflowState).mockReturnValue(workflowState);
@@ -237,7 +240,7 @@ describe('useWorkflowHelpers', () => {
 				sharedWithProjects: [],
 				tags: [],
 			});
-			const addWorkflowSpy = vi.spyOn(workflowsStore, 'addWorkflow');
+			const addWorkflowSpy = vi.spyOn(workflowsListStore, 'addWorkflow');
 			const setActiveSpy = vi.spyOn(workflowState, 'setActive');
 			const setWorkflowIdSpy = vi.spyOn(workflowState, 'setWorkflowId');
 			const setWorkflowNameSpy = vi.spyOn(workflowState, 'setWorkflowName');
@@ -323,7 +326,7 @@ describe('useWorkflowHelpers', () => {
 		it('should return null if no conflicts', async () => {
 			const workflowHelpers = useWorkflowHelpers();
 			uiStore.markStateClean();
-			vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue({
+			vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue({
 				nodes: [],
 			} as unknown as IWorkflowDb);
 			expect(await workflowHelpers.checkConflictingWebhooks('12345')).toEqual(null);
@@ -332,7 +335,7 @@ describe('useWorkflowHelpers', () => {
 		it('should return conflicting webhook data and workflow id is different', async () => {
 			const workflowHelpers = useWorkflowHelpers();
 			uiStore.markStateClean();
-			vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue({
+			vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue({
 				nodes: [
 					{
 						type: WEBHOOK_NODE_TYPE,
@@ -371,7 +374,7 @@ describe('useWorkflowHelpers', () => {
 		it('should return conflicting webhook data and workflow id is different in trigger', async () => {
 			const workflowHelpers = useWorkflowHelpers();
 			uiStore.markStateClean();
-			vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue({
+			vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue({
 				nodes: [
 					{
 						type: SLACK_TRIGGER_NODE_TYPE,
@@ -404,7 +407,7 @@ describe('useWorkflowHelpers', () => {
 		it('should return conflicting webhook data and workflow id is different in chat', async () => {
 			const workflowHelpers = useWorkflowHelpers();
 			uiStore.markStateClean();
-			vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue({
+			vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue({
 				nodes: [
 					{
 						type: CHAT_TRIGGER_NODE_TYPE,
@@ -437,7 +440,7 @@ describe('useWorkflowHelpers', () => {
 		it('should return null if webhook already exist but workflow id is the same', async () => {
 			const workflowHelpers = useWorkflowHelpers();
 			uiStore.markStateClean();
-			vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue({
+			vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue({
 				nodes: [
 					{
 						type: WEBHOOK_NODE_TYPE,
@@ -472,7 +475,7 @@ describe('useWorkflowHelpers', () => {
 			const workflowHelpers = useWorkflowHelpers();
 			const uiStore = mockedStore(useUIStore);
 			uiStore.markStateClean();
-			vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue({
+			vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue({
 				nodes: [
 					{
 						type: 'n8n-nodes-base.formTrigger',
@@ -492,7 +495,7 @@ describe('useWorkflowHelpers', () => {
 		it('should return conflicting webhook data and workflow id is different with FORM_TRIGGER_NODE_TYPE', async () => {
 			const workflowHelpers = useWorkflowHelpers();
 			uiStore.markStateClean();
-			vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue({
+			vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue({
 				nodes: [
 					{
 						type: 'n8n-nodes-base.formTrigger',
@@ -533,7 +536,7 @@ describe('useWorkflowHelpers', () => {
 		it('should return null if webhook already exist but workflow id is the same with FORM_TRIGGER_NODE_TYPE', async () => {
 			const workflowHelpers = useWorkflowHelpers();
 			uiStore.markStateClean();
-			vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue({
+			vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue({
 				nodes: [
 					{
 						type: 'n8n-nodes-base.formTrigger',
@@ -558,7 +561,7 @@ describe('useWorkflowHelpers', () => {
 		it('should return trigger.parameters.path when both trigger.parameters.path and trigger.webhookId are strings', async () => {
 			const workflowHelpers = useWorkflowHelpers();
 			uiStore.markStateClean();
-			vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue({
+			vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue({
 				nodes: [
 					{
 						type: WEBHOOK_NODE_TYPE,
@@ -583,7 +586,7 @@ describe('useWorkflowHelpers', () => {
 		it('should return trigger.webhookId when trigger.parameters.path is an empty string', async () => {
 			const workflowHelpers = useWorkflowHelpers();
 			uiStore.markStateClean();
-			vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue({
+			vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue({
 				nodes: [
 					{
 						type: WEBHOOK_NODE_TYPE,
@@ -608,7 +611,7 @@ describe('useWorkflowHelpers', () => {
 		it('should find conflicting webhook data with multiple methods', async () => {
 			const workflowHelpers = useWorkflowHelpers();
 			uiStore.markStateClean();
-			vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue({
+			vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue({
 				nodes: [
 					{
 						type: WEBHOOK_NODE_TYPE,
@@ -649,7 +652,7 @@ describe('useWorkflowHelpers', () => {
 		it('should return null if no conflicts with multiple methods', async () => {
 			const workflowHelpers = useWorkflowHelpers();
 			uiStore.markStateClean();
-			vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue({
+			vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue({
 				nodes: [
 					{
 						type: WEBHOOK_NODE_TYPE,
@@ -668,7 +671,7 @@ describe('useWorkflowHelpers', () => {
 
 		it('should fallback to GET, POST if httpMethod is not set and multipleMethods is true', async () => {
 			const workflowHelpers = useWorkflowHelpers();
-			vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue({
+			vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue({
 				nodes: [
 					{
 						type: WEBHOOK_NODE_TYPE,
@@ -694,7 +697,7 @@ describe('useWorkflowHelpers', () => {
 
 		it('should fallback to GET if httpMethod is not set and multipleMethods is false', async () => {
 			const workflowHelpers = useWorkflowHelpers();
-			vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue({
+			vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue({
 				nodes: [
 					{
 						type: WEBHOOK_NODE_TYPE,

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
@@ -45,6 +45,7 @@ import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { getSourceItems } from '@/app/utils/pairedItemUtils';
 import { getCredentialTypeName, isCredentialOnlyNodeType } from '@/app/utils/credentialOnlyNodes';
 import { convertWorkflowTagsToIds } from '@/app/utils/workflowUtils';
@@ -522,6 +523,7 @@ export function useWorkflowHelpers() {
 	const nodeTypesStore = useNodeTypesStore();
 	const rootStore = useRootStore();
 	const workflowsStore = useWorkflowsStore();
+	const workflowsListStore = useWorkflowsListStore();
 	const workflowState = injectWorkflowState();
 	const workflowsEEStore = useWorkflowsEEStore();
 	const uiStore = useUIStore();
@@ -847,7 +849,7 @@ export function useWorkflowHelpers() {
 				? { versionId: workflowsStore.workflowVersionId }
 				: await getWorkflowDataToSave();
 		} else {
-			const { versionId } = await workflowsStore.fetchWorkflow(workflowId);
+			const { versionId } = await workflowsListStore.fetchWorkflow(workflowId);
 			data.versionId = versionId;
 		}
 
@@ -931,7 +933,7 @@ export function useWorkflowHelpers() {
 	}
 
 	function getWorkflowProjectRole(workflowId: string): 'owner' | 'sharee' | 'member' {
-		const workflow = workflowsStore.workflowsById[workflowId];
+		const workflow = workflowsListStore.getWorkflowById(workflowId);
 
 		// Check if workflow is new (not saved) or belongs to personal project
 		if (workflow?.homeProject?.id === projectsStore.personalProject?.id || !workflow?.id) {
@@ -949,7 +951,7 @@ export function useWorkflowHelpers() {
 
 	async function initState(workflowData: IWorkflowDb, overrideWorkflowState?: WorkflowState) {
 		const ws = overrideWorkflowState ?? workflowState;
-		workflowsStore.addWorkflow(workflowData);
+		workflowsListStore.addWorkflow(workflowData);
 		ws.setActive(workflowData.activeVersionId);
 		workflowsStore.setIsArchived(workflowData.isArchived);
 		workflowsStore.setDescription(workflowData.description);
@@ -1020,7 +1022,7 @@ export function useWorkflowHelpers() {
 		if (uiStore.stateIsDirty) {
 			data = await getWorkflowDataToSave();
 		} else {
-			data = await workflowsStore.fetchWorkflow(workflowId);
+			data = await workflowsListStore.fetchWorkflow(workflowId);
 		}
 
 		const triggers = data.nodes.filter(

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
@@ -7,6 +7,7 @@ import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
 import { useNpsSurveyStore } from '@/app/stores/npsSurvey.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useWorkflowAutosaveStore } from '@/app/stores/workflowAutosave.store';
 import type { WorkflowDataUpdate } from '@n8n/rest-api-client/api/workflows';
 import { mockedStore } from '@/__tests__/utils';
@@ -92,6 +93,7 @@ const getDuplicateTestWorkflow = (): WorkflowDataUpdate => ({
 
 describe('useWorkflowSaving', () => {
 	let workflowsStore: ReturnType<typeof mockedStore<typeof useWorkflowsStore>>;
+	let workflowsListStore: ReturnType<typeof mockedStore<typeof useWorkflowsListStore>>;
 	let nodeTypesStore: ReturnType<typeof mockedStore<typeof useNodeTypesStore>>;
 
 	afterEach(() => {
@@ -102,6 +104,7 @@ describe('useWorkflowSaving', () => {
 		setActivePinia(createTestingPinia({ stubActions: false }));
 
 		workflowsStore = mockedStore(useWorkflowsStore);
+		workflowsListStore = mockedStore(useWorkflowsListStore);
 
 		nodeTypesStore = mockedStore(useNodeTypesStore);
 		nodeTypesStore.setNodeTypes([
@@ -121,7 +124,7 @@ describe('useWorkflowSaving', () => {
 				active: true,
 			});
 
-			vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue(workflow);
+			vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue(workflow);
 			vi.spyOn(workflowsStore, 'updateWorkflow').mockResolvedValue({
 				...workflow,
 				checksum: 'test-checksum',
@@ -129,7 +132,7 @@ describe('useWorkflowSaving', () => {
 
 			workflowsStore.setWorkflow(workflow);
 			// Populate workflowsById to mark workflow as existing (not new)
-			workflowsStore.workflowsById = { [workflow.id]: workflow };
+			workflowsListStore.workflowsById = { [workflow.id]: workflow };
 			workflowsStore.workflowId = workflow.id;
 
 			const next = vi.fn();
@@ -212,11 +215,12 @@ describe('useWorkflowSaving', () => {
 			uiStore.markStateDirty();
 
 			const workflowStore = useWorkflowsStore();
+			const workflowListStore = useWorkflowsListStore();
 			const MOCK_ID = 'existing-workflow-id';
 			const existingWorkflow = createTestWorkflow({ id: MOCK_ID });
 			workflowStore.workflow.id = MOCK_ID;
 			// Populate workflowsById to mark workflow as existing (not new)
-			workflowStore.workflowsById = { [MOCK_ID]: existingWorkflow };
+			workflowListStore.workflowsById = { [MOCK_ID]: existingWorkflow };
 
 			// Mock message.confirm
 			modalConfirmSpy.mockResolvedValue('close');
@@ -296,12 +300,12 @@ describe('useWorkflowSaving', () => {
 				active: true,
 			});
 
-			vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue(workflow);
+			vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue(workflow);
 			vi.spyOn(workflowsStore, 'updateWorkflow').mockResolvedValue(workflow);
 
 			workflowsStore.setWorkflow(workflow);
 			// Populate workflowsById to mark workflow as existing (not new)
-			workflowsStore.workflowsById = { [workflow.id]: workflow };
+			workflowsListStore.workflowsById = { [workflow.id]: workflow };
 
 			const updateWorkflowSpy = vi.spyOn(workflowsStore, 'updateWorkflow');
 			updateWorkflowSpy.mockImplementation(() => {
@@ -444,12 +448,12 @@ describe('useWorkflowSaving', () => {
 				active: true,
 			});
 
-			vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue(workflow);
+			vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue(workflow);
 			vi.spyOn(workflowsStore, 'updateWorkflow').mockResolvedValue(workflow);
 
 			workflowsStore.setWorkflow(workflow);
 			// Populate workflowsById to mark workflow as existing (not new)
-			workflowsStore.workflowsById = { [workflow.id]: workflow };
+			workflowsListStore.workflowsById = { [workflow.id]: workflow };
 
 			const { saveCurrentWorkflow } = useWorkflowSaving({ router });
 			await saveCurrentWorkflow({ id: 'w0' });
@@ -467,12 +471,12 @@ describe('useWorkflowSaving', () => {
 				active: true,
 			});
 
-			vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue(workflow);
+			vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue(workflow);
 			vi.spyOn(workflowsStore, 'updateWorkflow').mockResolvedValue(workflow);
 
 			workflowsStore.setWorkflow(workflow);
 			// Populate workflowsById to mark workflow as existing (not new)
-			workflowsStore.workflowsById = { [workflow.id]: workflow };
+			workflowsListStore.workflowsById = { [workflow.id]: workflow };
 
 			const { saveCurrentWorkflow } = useWorkflowSaving({ router });
 			await saveCurrentWorkflow({ id: 'w1' });
@@ -490,11 +494,11 @@ describe('useWorkflowSaving', () => {
 				active: true,
 			});
 
-			vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue(workflow);
+			vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue(workflow);
 			vi.spyOn(workflowsStore, 'updateWorkflow').mockResolvedValue(workflow);
 
 			workflowsStore.setWorkflow(workflow);
-			workflowsStore.workflowsById = { w2: workflow };
+			workflowsListStore.workflowsById = { w2: workflow };
 			workflowsStore.isWorkflowSaved = { w2: true };
 
 			const { saveCurrentWorkflow } = useWorkflowSaving({ router });
@@ -513,11 +517,11 @@ describe('useWorkflowSaving', () => {
 				active: true,
 			});
 
-			vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue(workflow);
+			vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue(workflow);
 			vi.spyOn(workflowsStore, 'updateWorkflow').mockResolvedValue(workflow);
 
 			workflowsStore.setWorkflow(workflow);
-			workflowsStore.workflowsById = { w3: workflow };
+			workflowsListStore.workflowsById = { w3: workflow };
 			workflowsStore.isWorkflowSaved = { w3: true };
 
 			const { saveCurrentWorkflow } = useWorkflowSaving({ router });
@@ -546,11 +550,11 @@ describe('useWorkflowSaving', () => {
 				checksum: 'test-checksum',
 			};
 
-			vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue(workflow);
+			vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue(workflow);
 			vi.spyOn(workflowsStore, 'updateWorkflow').mockResolvedValue(workflowResponse);
 
 			workflowsStore.setWorkflow(workflow);
-			workflowsStore.workflowsById = { [workflow.id]: workflow };
+			workflowsListStore.workflowsById = { [workflow.id]: workflow };
 			workflowsStore.workflowId = workflow.id;
 
 			const setWorkflowTagIdsSpy = vi.fn();
@@ -610,14 +614,14 @@ describe('useWorkflowSaving', () => {
 				active: true,
 			});
 
-			vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue(workflow);
+			vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue(workflow);
 			vi.spyOn(workflowsStore, 'updateWorkflow').mockResolvedValue({
 				...workflow,
 				checksum: 'test-checksum',
 			});
 
 			workflowsStore.setWorkflow(workflow);
-			workflowsStore.workflowsById = { [workflow.id]: workflow };
+			workflowsListStore.workflowsById = { [workflow.id]: workflow };
 			workflowsStore.workflowId = workflow.id;
 
 			const uiStore = useUIStore();
@@ -662,14 +666,14 @@ describe('useWorkflowSaving', () => {
 				active: true,
 			});
 
-			vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue(workflow);
+			vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue(workflow);
 			vi.spyOn(workflowsStore, 'updateWorkflow').mockResolvedValue({
 				...workflow,
 				checksum: 'test-checksum',
 			});
 
 			workflowsStore.setWorkflow(workflow);
-			workflowsStore.workflowsById = { [workflow.id]: workflow };
+			workflowsListStore.workflowsById = { [workflow.id]: workflow };
 			workflowsStore.workflowId = workflow.id;
 
 			const uiStore = useUIStore();
@@ -702,14 +706,14 @@ describe('useWorkflowSaving', () => {
 				active: true,
 			});
 
-			vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue(workflow);
+			vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue(workflow);
 			vi.spyOn(workflowsStore, 'updateWorkflow').mockResolvedValue({
 				...workflow,
 				checksum: 'test-checksum',
 			});
 
 			workflowsStore.setWorkflow(workflow);
-			workflowsStore.workflowsById = { [workflow.id]: workflow };
+			workflowsListStore.workflowsById = { [workflow.id]: workflow };
 			workflowsStore.workflowId = workflow.id;
 
 			const uiStore = useUIStore();

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
@@ -14,6 +14,7 @@ import {
 } from '@/app/constants';
 import { useWorkflowHelpers } from '@/app/composables/useWorkflowHelpers';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
 import { useCanvasStore } from '@/app/stores/canvas.store';
 import type { IUpdateInformation, IWorkflowDb } from '@/Interface';
@@ -48,6 +49,7 @@ export function useWorkflowSaving({
 	const message = useMessage();
 	const i18n = useI18n();
 	const workflowsStore = useWorkflowsStore();
+	const workflowsListStore = useWorkflowsListStore();
 	const workflowState = providedWorkflowState ?? injectWorkflowState();
 	const focusPanelStore = useFocusPanelStore();
 	const toast = useToast();
@@ -170,7 +172,9 @@ export function useWorkflowSaving({
 		}
 
 		// Check if workflow needs to be saved as new (doesn't exist in store yet)
-		const existingWorkflow = currentWorkflow ? workflowsStore.workflowsById[currentWorkflow] : null;
+		const existingWorkflow = currentWorkflow
+			? workflowsListStore.getWorkflowById(currentWorkflow)
+			: null;
 		if (!currentWorkflow || !existingWorkflow?.id) {
 			const workflowId = await saveAsNewWorkflow(
 				{ name, tags, parentFolderId, uiContext, autosaved },
@@ -410,7 +414,7 @@ export function useWorkflowSaving({
 
 			const workflowData = await workflowsStore.createNewWorkflow(workflowDataRequest);
 
-			workflowsStore.addWorkflow(workflowData);
+			workflowsListStore.addWorkflow(workflowData);
 
 			focusPanelStore.onNewWorkflowSave(workflowData.id);
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowState.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowState.ts
@@ -12,6 +12,7 @@ import type {
 } from '@/features/execution/executions/executions.types';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useBuilderStore } from '@/features/ai/assistant/builder.store';
 import { getPairedItemsMapping } from '@/app/utils/pairedItemUtils';
 import {
@@ -49,6 +50,7 @@ export const workflowStateEventBus = createEventBus<WorkflowStateBusEvents>();
 
 export function useWorkflowState() {
 	const ws = useWorkflowsStore();
+	const workflowsListStore = useWorkflowsListStore();
 	const workflowStateStore = useWorkflowStateStore();
 	const uiStore = useUIStore();
 	const rootStore = useRootStore();
@@ -65,8 +67,8 @@ export function useWorkflowState() {
 		ws.workflow.name = data.newName;
 		ws.workflowObject.name = data.newName;
 
-		if (ws.workflow.id && ws.workflowsById[ws.workflow.id]) {
-			ws.workflowsById[ws.workflow.id].name = data.newName;
+		if (ws.workflow.id && workflowsListStore.workflowsById[ws.workflow.id]) {
+			workflowsListStore.workflowsById[ws.workflow.id].name = data.newName;
 		}
 	}
 

--- a/packages/frontend/editor-ui/src/app/stores/workflows.ee.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.ee.store.ts
@@ -5,6 +5,7 @@ import { useRootStore } from '@n8n/stores/useRootStore';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { defineStore } from 'pinia';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { i18n } from '@n8n/i18n';
 import type { ProjectSharingData } from '@/features/collaboration/projects/projects.types';
 import { splitName } from '@/features/collaboration/projects/projects.utils';
@@ -14,6 +15,7 @@ export const useWorkflowsEEStore = defineStore(STORES.WORKFLOWS_EE, () => {
 	const rootStore = useRootStore();
 	const settingsStore = useSettingsStore();
 	const workflowStore = useWorkflowsStore();
+	const workflowsListStore = useWorkflowsListStore();
 
 	const getWorkflowOwnerName = computed(() => {
 		return (
@@ -36,10 +38,9 @@ export const useWorkflowsEEStore = defineStore(STORES.WORKFLOWS_EE, () => {
 		sharedWithProjects: ProjectSharingData[];
 	}) => {
 		const workflowsStore = useWorkflowsStore();
-		workflowsStore.workflowsById[payload.workflowId] = {
-			...workflowsStore.workflowsById[payload.workflowId],
+		workflowsListStore.updateWorkflowInCache(payload.workflowId, {
 			sharedWithProjects: payload.sharedWithProjects,
-		};
+		});
 		workflowsStore.workflow = {
 			...workflowsStore.workflow,
 			sharedWithProjects: payload.sharedWithProjects,

--- a/packages/frontend/editor-ui/src/app/stores/workflows.ee.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.ee.store.ts
@@ -14,7 +14,6 @@ import { computed } from 'vue';
 export const useWorkflowsEEStore = defineStore(STORES.WORKFLOWS_EE, () => {
 	const rootStore = useRootStore();
 	const settingsStore = useSettingsStore();
-	const workflowStore = useWorkflowsStore();
 	const workflowsListStore = useWorkflowsListStore();
 
 	const getWorkflowOwnerName = computed(() => {
@@ -22,7 +21,7 @@ export const useWorkflowsEEStore = defineStore(STORES.WORKFLOWS_EE, () => {
 			workflowId: string,
 			fallback = i18n.baseText('workflows.shareModal.info.sharee.fallback'),
 		): string => {
-			const workflow = workflowStore.getWorkflowById(workflowId);
+			const workflow = workflowsListStore.getWorkflowById(workflowId);
 			const { name, email } = splitName(workflow?.homeProject?.name ?? '');
 			const trimmedName = name?.replace(/\s+/g, ' ')?.trim();
 			return trimmedName

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.test.ts
@@ -8,6 +8,7 @@ import {
 	WAIT_NODE_TYPE,
 } from '@/app/constants';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import type { INodeUi, IWorkflowDb, IWorkflowSettings } from '@/Interface';
 import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
 
@@ -102,11 +103,13 @@ vi.mock('@n8n/permissions', () => ({
 
 describe('useWorkflowsStore', () => {
 	let workflowsStore: ReturnType<typeof useWorkflowsStore>;
+	let workflowsListStore: ReturnType<typeof useWorkflowsListStore>;
 	let uiStore: ReturnType<typeof useUIStore>;
 
 	beforeEach(() => {
 		setActivePinia(createPinia());
 		workflowsStore = useWorkflowsStore();
+		workflowsListStore = useWorkflowsListStore();
 		uiStore = useUIStore();
 		track.mockReset();
 	});
@@ -265,22 +268,24 @@ describe('useWorkflowsStore', () => {
 
 	describe('allWorkflows', () => {
 		it('should return sorted workflows by name', () => {
-			workflowsStore.setWorkflows([
+			const workflowsListStore = useWorkflowsListStore();
+			workflowsListStore.setWorkflows([
 				{ id: '3', name: 'Zeta' },
 				{ id: '1', name: 'Alpha' },
 				{ id: '2', name: 'Beta' },
 			] as IWorkflowDb[]);
 
-			const allWorkflows = workflowsStore.allWorkflows;
+			const allWorkflows = workflowsListStore.allWorkflows;
 			expect(allWorkflows[0].name).toBe('Alpha');
 			expect(allWorkflows[1].name).toBe('Beta');
 			expect(allWorkflows[2].name).toBe('Zeta');
 		});
 
 		it('should return empty array when no workflows are set', () => {
-			workflowsStore.setWorkflows([]);
+			const workflowsListStore = useWorkflowsListStore();
+			workflowsListStore.setWorkflows([]);
 
-			const allWorkflows = workflowsStore.allWorkflows;
+			const allWorkflows = workflowsListStore.allWorkflows;
 			expect(allWorkflows).toEqual([]);
 		});
 	});
@@ -293,7 +298,7 @@ describe('useWorkflowsStore', () => {
 		it('should return true for an existing workflow', () => {
 			useWorkflowState().setWorkflowId('123');
 			// Add the workflow to workflowsById to simulate it being loaded from backend
-			workflowsStore.addWorkflow(
+			workflowsListStore.addWorkflow(
 				createTestWorkflow({
 					id: '123',
 					name: 'Test Workflow',
@@ -699,16 +704,17 @@ describe('useWorkflowsStore', () => {
 
 	describe('fetchAllWorkflows()', () => {
 		it('should fetch workflows successfully', async () => {
+			const workflowsListStore = useWorkflowsListStore();
 			const mockWorkflows = [{ id: '1', name: 'Test Workflow' }] as IWorkflowDb[];
 			vi.mocked(workflowsApi).getWorkflows.mockResolvedValue({
 				count: mockWorkflows.length,
 				data: mockWorkflows,
 			});
 
-			await workflowsStore.fetchAllWorkflows();
+			await workflowsListStore.fetchAllWorkflows();
 
 			expect(workflowsApi.getWorkflows).toHaveBeenCalled();
-			expect(Object.values(workflowsStore.workflowsById)).toEqual(mockWorkflows);
+			expect(Object.values(workflowsListStore.workflowsById)).toEqual(mockWorkflows);
 		});
 	});
 
@@ -727,7 +733,7 @@ describe('useWorkflowsStore', () => {
 				data: mockWorkflows,
 			});
 
-			const result = await workflowsStore.searchWorkflows({});
+			const result = await workflowsListStore.searchWorkflows({});
 
 			expect(workflowsApi.getWorkflows).toHaveBeenCalledWith(
 				expect.any(Object),
@@ -745,7 +751,7 @@ describe('useWorkflowsStore', () => {
 				data: mockWorkflows,
 			});
 
-			const result = await workflowsStore.searchWorkflows({ query: 'test' });
+			const result = await workflowsListStore.searchWorkflows({ query: 'test' });
 
 			expect(workflowsApi.getWorkflows).toHaveBeenCalledWith(
 				expect.any(Object),
@@ -766,7 +772,7 @@ describe('useWorkflowsStore', () => {
 				data: mockWorkflows,
 			});
 
-			const result = await workflowsStore.searchWorkflows({ isArchived: false });
+			const result = await workflowsListStore.searchWorkflows({ isArchived: false });
 
 			expect(workflowsApi.getWorkflows).toHaveBeenCalledWith(
 				expect.any(Object),
@@ -787,7 +793,7 @@ describe('useWorkflowsStore', () => {
 				data: mockWorkflows,
 			});
 
-			const result = await workflowsStore.searchWorkflows({ isArchived: true });
+			const result = await workflowsListStore.searchWorkflows({ isArchived: true });
 
 			expect(workflowsApi.getWorkflows).toHaveBeenCalledWith(
 				expect.any(Object),
@@ -807,7 +813,7 @@ describe('useWorkflowsStore', () => {
 				data: mockWorkflows,
 			});
 
-			const result = await workflowsStore.searchWorkflows({
+			const result = await workflowsListStore.searchWorkflows({
 				query: 'test',
 				isArchived: false,
 				projectId: 'project-123',
@@ -840,7 +846,7 @@ describe('useWorkflowsStore', () => {
 				data: mockWorkflows,
 			});
 
-			const result = await workflowsStore.searchWorkflows({
+			const result = await workflowsListStore.searchWorkflows({
 				select: ['id', 'name'],
 			});
 
@@ -860,7 +866,7 @@ describe('useWorkflowsStore', () => {
 				data: mockWorkflows,
 			});
 
-			const result = await workflowsStore.searchWorkflows({
+			const result = await workflowsListStore.searchWorkflows({
 				projectId: undefined,
 				query: undefined,
 				nodeTypes: undefined,
@@ -887,7 +893,7 @@ describe('useWorkflowsStore', () => {
 				data: mockWorkflows,
 			});
 
-			const result = await workflowsStore.searchWorkflows({ query: 'workflow' });
+			const result = await workflowsListStore.searchWorkflows({ query: 'workflow' });
 
 			expect(workflowsApi.getWorkflows).toHaveBeenCalledWith(
 				expect.any(Object),
@@ -901,8 +907,9 @@ describe('useWorkflowsStore', () => {
 
 	describe('setWorkflowActive()', () => {
 		it('should set workflow as active when it is not already active', async () => {
+			const workflowsListStore = useWorkflowsListStore();
 			uiStore.markStateDirty();
-			workflowsStore.workflowsById = { '1': { active: false } as IWorkflowDb };
+			workflowsListStore.workflowsById = { '1': { active: false } as IWorkflowDb };
 			workflowsStore.workflow.id = '1';
 
 			const mockActiveVersion: WorkflowHistory = {
@@ -917,15 +924,16 @@ describe('useWorkflowsStore', () => {
 
 			workflowsStore.setWorkflowActive('1', mockActiveVersion, true);
 
-			expect(workflowsStore.activeWorkflows).toContain('1');
-			expect(workflowsStore.workflowsById['1'].active).toBe(true);
+			expect(workflowsListStore.activeWorkflows).toContain('1');
+			expect(workflowsListStore.workflowsById['1'].active).toBe(true);
 			expect(workflowsStore.workflow.active).toBe(true);
 			expect(uiStore.stateIsDirty).toBe(false);
 		});
 
 		it('should not modify active workflows when workflow is already active', () => {
-			workflowsStore.activeWorkflows = ['1'];
-			workflowsStore.workflowsById = { '1': { active: true } as IWorkflowDb };
+			const workflowsListStore = useWorkflowsListStore();
+			workflowsListStore.activeWorkflows = ['1'];
+			workflowsListStore.workflowsById = { '1': { active: true } as IWorkflowDb };
 			workflowsStore.workflow.id = '1';
 
 			const mockActiveVersion: WorkflowHistory = {
@@ -940,15 +948,16 @@ describe('useWorkflowsStore', () => {
 
 			workflowsStore.setWorkflowActive('1', mockActiveVersion, true);
 
-			expect(workflowsStore.activeWorkflows).toEqual(['1']);
-			expect(workflowsStore.workflowsById['1'].active).toBe(true);
+			expect(workflowsListStore.activeWorkflows).toEqual(['1']);
+			expect(workflowsListStore.workflowsById['1'].active).toBe(true);
 			expect(workflowsStore.workflow.active).toBe(true);
 		});
 
 		it('should not set current workflow as active when it is not the target', () => {
+			const workflowsListStore = useWorkflowsListStore();
 			uiStore.markStateDirty();
 			workflowsStore.workflow.id = '1';
-			workflowsStore.workflowsById = { '1': { active: false } as IWorkflowDb };
+			workflowsListStore.workflowsById = { '1': { active: false } as IWorkflowDb };
 
 			const mockActiveVersion: WorkflowHistory = {
 				versionId: 'test-version-id',
@@ -961,26 +970,28 @@ describe('useWorkflowsStore', () => {
 			};
 
 			workflowsStore.setWorkflowActive('2', mockActiveVersion, true);
-			expect(workflowsStore.workflowsById['1'].active).toBe(false);
+			expect(workflowsListStore.workflowsById['1'].active).toBe(false);
 			expect(uiStore.stateIsDirty).toBe(true);
 		});
 	});
 
 	describe('setWorkflowInactive()', () => {
 		it('should set workflow as inactive when it exists', () => {
-			workflowsStore.activeWorkflows = ['1', '2'];
-			workflowsStore.workflowsById = { '1': { active: true } as IWorkflowDb };
+			const workflowsListStore = useWorkflowsListStore();
+			workflowsListStore.activeWorkflows = ['1', '2'];
+			workflowsListStore.workflowsById = { '1': { active: true } as IWorkflowDb };
 			workflowsStore.setWorkflowInactive('1');
-			expect(workflowsStore.workflowsById['1'].active).toBe(false);
-			expect(workflowsStore.activeWorkflows).toEqual(['2']);
+			expect(workflowsListStore.workflowsById['1'].active).toBe(false);
+			expect(workflowsListStore.activeWorkflows).toEqual(['2']);
 		});
 
 		it('should not modify active workflows when workflow is not active', () => {
-			workflowsStore.workflowsById = { '2': { active: true } as IWorkflowDb };
-			workflowsStore.activeWorkflows = ['2'];
+			const workflowsListStore = useWorkflowsListStore();
+			workflowsListStore.workflowsById = { '2': { active: true } as IWorkflowDb };
+			workflowsListStore.activeWorkflows = ['2'];
 			workflowsStore.setWorkflowInactive('1');
-			expect(workflowsStore.activeWorkflows).toEqual(['2']);
-			expect(workflowsStore.workflowsById['2'].active).toBe(true);
+			expect(workflowsListStore.activeWorkflows).toEqual(['2']);
+			expect(workflowsListStore.workflowsById['2'].active).toBe(true);
 		});
 
 		it('should set current workflow as inactive when it is the target', () => {
@@ -1458,11 +1469,12 @@ describe('useWorkflowsStore', () => {
 
 	describe('archiveWorkflow', () => {
 		it('should call the API to archive the workflow', async () => {
+			const workflowsListStore = useWorkflowsListStore();
 			const workflowId = '1';
 			const versionId = '00000000-0000-0000-0000-000000000000';
 			const updatedVersionId = '11111111-1111-1111-1111-111111111111';
 
-			workflowsStore.workflowsById = {
+			workflowsListStore.workflowsById = {
 				'1': { active: true, isArchived: false, versionId } as IWorkflowDb,
 			};
 			workflowsStore.workflow.active = true;
@@ -1479,9 +1491,9 @@ describe('useWorkflowsStore', () => {
 
 			await workflowsStore.archiveWorkflow(workflowId);
 
-			expect(workflowsStore.workflowsById['1'].active).toBe(false);
-			expect(workflowsStore.workflowsById['1'].isArchived).toBe(true);
-			expect(workflowsStore.workflowsById['1'].versionId).toBe(updatedVersionId);
+			expect(workflowsListStore.workflowsById['1'].active).toBe(false);
+			expect(workflowsListStore.workflowsById['1'].isArchived).toBe(true);
+			expect(workflowsListStore.workflowsById['1'].versionId).toBe(updatedVersionId);
 			expect(workflowsStore.workflow.active).toBe(false);
 			expect(workflowsStore.workflow.isArchived).toBe(true);
 			expect(workflowsStore.workflow.versionId).toBe(updatedVersionId);
@@ -1498,11 +1510,12 @@ describe('useWorkflowsStore', () => {
 
 	describe('unarchiveWorkflow', () => {
 		it('should call the API to unarchive the workflow', async () => {
+			const workflowsListStore = useWorkflowsListStore();
 			const workflowId = '1';
 			const versionId = '00000000-0000-0000-0000-000000000000';
 			const updatedVersionId = '11111111-1111-1111-1111-111111111111';
 
-			workflowsStore.workflowsById = {
+			workflowsListStore.workflowsById = {
 				'1': { active: false, isArchived: true, versionId } as IWorkflowDb,
 			};
 			workflowsStore.workflow.active = false;
@@ -1519,9 +1532,9 @@ describe('useWorkflowsStore', () => {
 
 			await workflowsStore.unarchiveWorkflow(workflowId);
 
-			expect(workflowsStore.workflowsById['1'].active).toBe(false);
-			expect(workflowsStore.workflowsById['1'].isArchived).toBe(false);
-			expect(workflowsStore.workflowsById['1'].versionId).toBe(updatedVersionId);
+			expect(workflowsListStore.workflowsById['1'].active).toBe(false);
+			expect(workflowsListStore.workflowsById['1'].isArchived).toBe(false);
+			expect(workflowsListStore.workflowsById['1'].versionId).toBe(updatedVersionId);
 			expect(workflowsStore.workflow.active).toBe(false);
 			expect(workflowsStore.workflow.isArchived).toBe(false);
 			expect(workflowsStore.workflow.versionId).toBe(updatedVersionId);
@@ -1588,7 +1601,8 @@ describe('useWorkflowsStore', () => {
 		});
 
 		it('updates cached workflow without fetching when present in store', async () => {
-			workflowsStore.workflowsById = {
+			const workflowsListStore = useWorkflowsListStore();
+			workflowsListStore.workflowsById = {
 				w2: createTestWorkflow({
 					id: 'w2',
 					name: 'Cached',
@@ -1622,15 +1636,16 @@ describe('useWorkflowsStore', () => {
 
 			// Should not fetch since cached with versionId exists
 			expect(getWorkflowSpy).not.toHaveBeenCalled();
-			expect(workflowsStore.workflowsById['w2'].versionId).toBe('v3');
-			expect(workflowsStore.workflowsById['w2'].settings).toEqual({
+			expect(workflowsListStore.workflowsById['w2'].versionId).toBe('v3');
+			expect(workflowsListStore.workflowsById['w2'].settings).toEqual({
 				executionOrder: 'v1',
 				timezone: 'Europe/Berlin',
 			});
 		});
 
 		it('fetches workflow when not cached and updates store', async () => {
-			workflowsStore.workflowsById = {} as Record<string, IWorkflowDb>;
+			const workflowsListStore = useWorkflowsListStore();
+			workflowsListStore.workflowsById = {} as Record<string, IWorkflowDb>;
 
 			vi.mocked(workflowsApi).getWorkflow.mockResolvedValue(
 				createTestWorkflow({
@@ -1666,8 +1681,8 @@ describe('useWorkflowsStore', () => {
 				{ baseUrl: '/rest', pushRef: expect.any(String) },
 				'w3',
 			);
-			expect(workflowsStore.workflowsById['w3'].versionId).toBe('v101');
-			expect(workflowsStore.workflowsById['w3'].settings).toEqual({
+			expect(workflowsListStore.workflowsById['w3'].versionId).toBe('v101');
+			expect(workflowsListStore.workflowsById['w3'].settings).toEqual({
 				executionOrder: 'v1',
 				timezone: 'Asia/Tokyo',
 			});
@@ -2231,7 +2246,7 @@ describe('useWorkflowsStore', () => {
 
 			workflowsStore.workflow = testWorkflow;
 			// Add workflow to workflowsById to simulate it being loaded from backend
-			workflowsStore.addWorkflow(testWorkflow);
+			workflowsListStore.addWorkflow(testWorkflow);
 
 			// Verify the mock is set up correctly
 			expect(workflowsStore.workflow.scopes).toContain('workflow:update');
@@ -2260,7 +2275,7 @@ describe('useWorkflowsStore', () => {
 
 			workflowsStore.workflow = testWorkflow;
 			// Add workflow to workflowsById to simulate it being loaded from backend
-			workflowsStore.addWorkflow(testWorkflow);
+			workflowsListStore.addWorkflow(testWorkflow);
 
 			vi.mocked(workflowsApi).getLastSuccessfulExecution.mockResolvedValue(null);
 
@@ -2284,7 +2299,7 @@ describe('useWorkflowsStore', () => {
 
 			workflowsStore.workflow = testWorkflow;
 			// Add workflow to workflowsById to simulate it being loaded from backend
-			workflowsStore.addWorkflow(testWorkflow);
+			workflowsListStore.addWorkflow(testWorkflow);
 
 			const error = new Error('API Error');
 			vi.mocked(workflowsApi).getLastSuccessfulExecution.mockRejectedValue(error);

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -439,9 +439,8 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		);
 	}
 
-	function getWorkflowById(id: string): IWorkflowDb {
-		return workflowsListStore.getWorkflowById(id);
-	}
+	// Delegated to workflowsListStore for backward compatibility
+	const getWorkflowById = workflowsListStore.getWorkflowById;
 
 	function getNodeByName(nodeName: string): INodeUi | null {
 		return workflowUtils.getNodeByName(nodesByName.value, nodeName);

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -1,7 +1,6 @@
 import {
 	AI_NODES_PACKAGE_NAME,
 	CHAT_TRIGGER_NODE_TYPE,
-	DEFAULT_WORKFLOW_PAGE_SIZE,
 	DUPLICATE_POSTFFIX,
 	ERROR_TRIGGER_NODE_TYPE,
 	FORM_NODE_TYPE,
@@ -14,9 +13,7 @@ import type {
 	INodeUi,
 	IStartRunData,
 	IWorkflowDb,
-	IWorkflowsMap,
 	NodeMetadataMap,
-	WorkflowListResource,
 	WorkflowValidationIssue,
 } from '@/Interface';
 import type {
@@ -90,6 +87,7 @@ import { snapPositionToGrid } from '@/app/utils/nodeViewUtils';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
 import { getResourcePermissions } from '@n8n/permissions';
 import { hasRole } from '@/app/utils/rbac/checks';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 
 const defaults: Omit<IWorkflowDb, 'id'> & { settings: NonNullable<IWorkflowDb['settings']> } = {
 	name: '',
@@ -126,6 +124,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 	const usersStore = useUsersStore();
 	const nodeTypesStore = useNodeTypesStore();
 	const sourceControlStore = useSourceControlStore();
+	const workflowsListStore = useWorkflowsListStore();
 
 	const workflow = ref<IWorkflowDb>(createEmptyWorkflow());
 	const workflowObject = ref<Workflow>(
@@ -133,11 +132,8 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		createWorkflowObject(workflow.value.nodes, workflow.value.connections),
 	);
 
-	// For paginated workflow lists
-	const totalWorkflowCount = ref(0);
 	const usedCredentials = ref<Record<string, IUsedCredential>>({});
 
-	const activeWorkflows = ref<string[]>([]);
 	const currentWorkflowExecutions = ref<ExecutionSummary[]>([]);
 	const workflowExecutionData = ref<IExecutionResponse | null>(null);
 	const lastSuccessfulExecution = ref<IExecutionResponse | null>(null);
@@ -146,7 +142,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 	const workflowExecutionResultDataLastUpdate = ref<number>();
 	const workflowExecutionPairedItemMappings = ref<Record<string, Set<string>>>({});
 	const executionWaitingForWebhook = ref(false);
-	const workflowsById = ref<Record<string, IWorkflowDb>>({});
 	const nodeMetadata = ref<NodeMetadataMap>({});
 	const isInDebugMode = ref(false);
 	const chatMessages = ref<string[]>([]);
@@ -165,26 +160,25 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 
 	const workflowTags = computed(() => workflow.value.tags as string[]);
 
-	const allWorkflows = computed(() =>
-		Object.values(workflowsById.value).sort((a, b) => a.name.localeCompare(b.name)),
-	);
-
 	// A workflow is new if it hasn't been saved to the backend yet
 	const isNewWorkflow = computed(() => {
 		if (!workflow.value.id) return true;
 
 		// Check if the workflow exists in workflowsById
-		const existingWorkflow = workflowsById.value[workflow.value.id];
+		const existingWorkflow = workflowsListStore.getWorkflowById(workflow.value.id);
 		// If workflow doesn't exist in the store or has no ID, it's new
 		return !existingWorkflow?.id;
 	});
 
 	// A workflow is new if it hasn't been saved to the backend yet
 	const isWorkflowSaved = computed(() => {
-		return Object.keys(workflowsById.value).reduce<Record<string, boolean>>((acc, workflowId) => {
-			acc[workflowId] = true;
-			return acc;
-		}, {});
+		return Object.keys(workflowsListStore.workflowsById).reduce<Record<string, boolean>>(
+			(acc, workflowId) => {
+				acc[workflowId] = true;
+				return acc;
+			},
+			{},
+		);
 	});
 
 	const isWorkflowActive = computed(() => workflow.value.activeVersionId !== null);
@@ -446,7 +440,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 	}
 
 	function getWorkflowById(id: string): IWorkflowDb {
-		return workflowsById.value[id];
+		return workflowsListStore.getWorkflowById(id);
 	}
 
 	function getNodeByName(nodeName: string): INodeUi | null {
@@ -583,7 +577,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 
 		let id: string | undefined = workflow.value.id;
 		// If workflow doesn't exist in store, treat as new (no ID)
-		if (id && !workflowsById.value[id]?.id) {
+		if (id && !workflowsListStore.getWorkflowById(id)?.id) {
 			id = undefined;
 		}
 
@@ -644,114 +638,13 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		);
 	}
 
-	async function fetchWorkflowsPage(
-		projectId?: string,
-		page = 1,
-		pageSize = DEFAULT_WORKFLOW_PAGE_SIZE,
-		sortBy?: string,
-		filters: {
-			query?: string;
-			tags?: string[];
-			active?: boolean;
-			isArchived?: boolean;
-			parentFolderId?: string;
-			availableInMCP?: boolean;
-			triggerNodeTypes?: string[];
-		} = {},
-		includeFolders = false,
-		onlySharedWithMe = false,
-	): Promise<WorkflowListResource[]> {
-		const filter = { ...filters, projectId };
-		const options = {
-			skip: (page - 1) * pageSize,
-			take: pageSize,
-			sortBy,
-		};
-
-		const { count, data } = await workflowsApi.getWorkflowsAndFolders(
-			rootStore.restApiContext,
-			Object.keys(filter).length ? filter : undefined,
-			Object.keys(options).length ? options : undefined,
-			includeFolders ? includeFolders : undefined,
-			onlySharedWithMe ? onlySharedWithMe : undefined,
-		);
-		totalWorkflowCount.value = count;
-		// Also set fetched workflows to store
-		// When fetching workflows from overview page, they don't have resource property
-		// so in order to filter out folders, we need to check if resource is not folder
-		data
-			.filter((item) => item.resource !== 'folder')
-			.forEach((item) => {
-				addWorkflow({
-					...item,
-					nodes: [],
-					connections: {},
-					versionId: '',
-				});
-			});
-		return data;
-	}
-
-	async function searchWorkflows({
-		projectId,
-		query,
-		nodeTypes,
-		tags,
-		select,
-		isArchived,
-		triggerNodeTypes,
-	}: {
-		projectId?: string;
-		query?: string;
-		nodeTypes?: string[];
-		tags?: string[];
-		select?: string[];
-		isArchived?: boolean;
-		triggerNodeTypes?: string[];
-	}): Promise<IWorkflowDb[]> {
-		const filter = {
-			projectId,
-			query,
-			nodeTypes,
-			tags,
-			isArchived,
-			triggerNodeTypes,
-		};
-
-		// Check if filter has meaningful values (not just undefined, null, or empty arrays/strings)
-		const hasFilter = Object.values(filter).some(
-			(v) => isPresent(v) && (Array.isArray(v) ? v.length > 0 : v !== ''),
-		);
-
-		const { data: workflows } = await workflowsApi.getWorkflows(
-			rootStore.restApiContext,
-			hasFilter ? filter : undefined,
-			undefined,
-			select,
-		);
-		return workflows;
-	}
-
-	async function fetchAllWorkflows(projectId?: string): Promise<IWorkflowDb[]> {
-		const workflows = await searchWorkflows({ projectId });
-		setWorkflows(workflows);
-		return workflows;
-	}
-
-	async function fetchWorkflow(id: string): Promise<IWorkflowDb> {
-		const workflowData = await workflowsApi.getWorkflow(rootStore.restApiContext, id);
-		addWorkflow(workflowData);
-		return workflowData;
-	}
-
-	async function fetchWorkflowsWithNodesIncluded(nodeTypes: string[]) {
-		return await workflowsApi.getWorkflowsWithNodesIncluded(rootStore.restApiContext, nodeTypes);
-	}
-
-	async function checkWorkflowExists(id: string): Promise<boolean> {
-		const result = await workflowsApi.workflowExists(rootStore.restApiContext, id);
-		return result.exists;
-	}
+	// Delegated to workflowsListStore for backward compatibility
+	const fetchWorkflowsPage = workflowsListStore.fetchWorkflowsPage;
+	const searchWorkflows = workflowsListStore.searchWorkflows;
+	const fetchAllWorkflows = workflowsListStore.fetchAllWorkflows;
+	const fetchWorkflow = workflowsListStore.fetchWorkflow;
+	const fetchWorkflowsWithNodesIncluded = workflowsListStore.fetchWorkflowsWithNodesIncluded;
+	const checkWorkflowExists = workflowsListStore.checkWorkflowExists;
 
 	function resetWorkflow() {
 		workflow.value = createEmptyWorkflow();
@@ -853,87 +746,40 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		return updatedNodesCount;
 	}
 
-	function setWorkflows(workflows: IWorkflowDb[]) {
-		workflowsById.value = workflows.reduce<IWorkflowsMap>((acc, workflow: IWorkflowDb) => {
-			if (workflow.id) {
-				acc[workflow.id] = workflow;
-			}
-			return acc;
-		}, {});
-	}
+	// Delegated to workflowsListStore for backward compatibility
+	const setWorkflows = workflowsListStore.setWorkflows;
 
-	async function deleteWorkflow(id: string) {
-		await makeRestApiRequest(rootStore.restApiContext, 'DELETE', `/workflows/${id}`);
-		const { [id]: deletedWorkflow, ...workflows } = workflowsById.value;
-		workflowsById.value = workflows;
-	}
+	// Delegated to workflowsListStore for backward compatibility
+	const deleteWorkflow = workflowsListStore.deleteWorkflow;
 
 	async function archiveWorkflow(id: string) {
-		const updatedWorkflow = await makeRestApiRequest<IWorkflowDb>(
-			rootStore.restApiContext,
-			'POST',
-			`/workflows/${id}/archive`,
-		);
-		if (!updatedWorkflow.checksum) {
-			throw new Error('Failed to archive workflow');
-		}
-		if (workflowsById.value[id]) {
-			workflowsById.value[id].isArchived = true;
-			workflowsById.value[id].versionId = updatedWorkflow.versionId;
-		}
-
+		const updatedWorkflow = await workflowsListStore.archiveWorkflowInList(id);
 		setWorkflowInactive(id);
 
 		if (id === workflow.value.id) {
 			setIsArchived(true);
-			setWorkflowVersionId(updatedWorkflow.versionId, updatedWorkflow.checksum);
+			setWorkflowVersionId(updatedWorkflow.versionId, updatedWorkflow.checksum!);
 		}
 	}
 
 	async function unarchiveWorkflow(id: string) {
-		const updatedWorkflow = await makeRestApiRequest<IWorkflowDb>(
-			rootStore.restApiContext,
-			'POST',
-			`/workflows/${id}/unarchive`,
-		);
-		if (!updatedWorkflow.checksum) {
-			throw new Error('Failed to unarchive workflow');
-		}
-		if (workflowsById.value[id]) {
-			workflowsById.value[id].isArchived = false;
-			workflowsById.value[id].versionId = updatedWorkflow.versionId;
-		}
+		const updatedWorkflow = await workflowsListStore.unarchiveWorkflowInList(id);
+
 		if (id === workflow.value.id) {
 			setIsArchived(false);
-			setWorkflowVersionId(updatedWorkflow.versionId, updatedWorkflow.checksum);
+			setWorkflowVersionId(updatedWorkflow.versionId, updatedWorkflow.checksum!);
 		}
 	}
 
-	function addWorkflow(workflow: IWorkflowDb) {
-		workflowsById.value = {
-			...workflowsById.value,
-			[workflow.id]: {
-				...workflowsById.value[workflow.id],
-				...deepCopy(workflow),
-			},
-		};
-	}
+	// Delegated to workflowsListStore for backward compatibility
+	const addWorkflow = workflowsListStore.addWorkflow;
 
 	function setWorkflowActive(
 		targetWorkflowId: string,
 		activeVersion: WorkflowHistory,
 		clearDirtyState: boolean,
 	) {
-		if (activeWorkflows.value.indexOf(targetWorkflowId) === -1) {
-			activeWorkflows.value.push(targetWorkflowId);
-		}
-
-		const cachedWorkflow = workflowsById.value[targetWorkflowId];
-		if (cachedWorkflow) {
-			cachedWorkflow.active = true;
-			cachedWorkflow.activeVersionId = activeVersion.versionId;
-			cachedWorkflow.activeVersion = activeVersion;
-		}
+		workflowsListStore.setWorkflowActiveInCache(targetWorkflowId, activeVersion);
 
 		if (targetWorkflowId === workflow.value.id) {
 			if (clearDirtyState) {
@@ -946,16 +792,8 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 	}
 
 	function setWorkflowInactive(targetWorkflowId: string) {
-		const index = activeWorkflows.value.indexOf(targetWorkflowId);
-		if (index !== -1) {
-			activeWorkflows.value.splice(index, 1);
-		}
-		const targetWorkflow = workflowsById.value[targetWorkflowId];
-		if (targetWorkflow) {
-			targetWorkflow.active = false;
-			targetWorkflow.activeVersionId = null;
-			targetWorkflow.activeVersion = null;
-		}
+		workflowsListStore.setWorkflowInactiveInCache(targetWorkflowId);
+
 		if (targetWorkflowId === workflow.value.id) {
 			workflow.value.active = false;
 			workflow.value.activeVersionId = null;
@@ -963,11 +801,8 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		}
 	}
 
-	async function fetchActiveWorkflows(): Promise<string[]> {
-		const data = await workflowsApi.getActiveWorkflows(rootStore.restApiContext);
-		activeWorkflows.value = data;
-		return data;
-	}
+	// Delegated to workflowsListStore for backward compatibility
+	const fetchActiveWorkflows = workflowsListStore.fetchActiveWorkflows;
 
 	function setIsArchived(isArchived: boolean) {
 		workflow.value.isArchived = isArchived;
@@ -1699,7 +1534,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			currentVersionId = workflow.value.versionId;
 			currentChecksum = workflowChecksum.value;
 		} else {
-			const cached = workflowsById.value[id];
+			const cached = workflowsListStore.getWorkflowById(id);
 			if (cached && cached.versionId) {
 				currentSettings = cached.settings ?? ({} as IWorkflowSettings);
 				currentVersionId = cached.versionId;
@@ -1724,12 +1559,11 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		// Update local store state to reflect the change
 		if (isCurrentWorkflow) {
 			setWorkflowSettings(updated.settings ?? {});
-		} else if (workflowsById.value[id]) {
-			workflowsById.value[id] = {
-				...workflowsById.value[id],
+		} else if (workflowsListStore.getWorkflowById(id)) {
+			workflowsListStore.updateWorkflowInCache(id, {
 				settings: updated.settings,
 				versionId: updated.versionId,
-			};
+			});
 		}
 
 		return updated;
@@ -1747,7 +1581,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			currentVersionId = workflow.value.versionId;
 			currentChecksum = workflowChecksum.value;
 		} else {
-			const cached = workflowsById.value[id];
+			const cached = workflowsListStore.getWorkflowById(id);
 			if (cached?.versionId) {
 				currentVersionId = cached.versionId;
 			} else {
@@ -1762,12 +1596,11 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			expectedChecksum: currentChecksum,
 		});
 
-		if (workflowsById.value[id]) {
-			workflowsById.value[id] = {
-				...workflowsById.value[id],
+		if (workflowsListStore.getWorkflowById(id)) {
+			workflowsListStore.updateWorkflowInCache(id, {
 				description: updated.description,
 				versionId: updated.versionId,
-			};
+			});
 		}
 
 		// Update local store state
@@ -1959,7 +1792,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 	return {
 		workflow,
 		usedCredentials,
-		activeWorkflows,
 		currentWorkflowExecutions,
 		workflowExecutionData,
 		workflowExecutionPairedItemMappings,
@@ -1968,7 +1800,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		activeExecutionId: readonlyActiveExecutionId,
 		previousExecutionId: readonlyPreviousExecutionId,
 		executionWaitingForWebhook,
-		workflowsById,
 		nodeMetadata,
 		isInDebugMode,
 		chatMessages,
@@ -1979,9 +1810,14 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		workflowChecksum,
 		workflowSettings,
 		workflowTags,
-		allWorkflows,
 		isNewWorkflow,
 		isWorkflowSaved,
+
+		// Re-exported from workflowsListStore for backward compatibility
+		workflowsById: workflowsListStore.workflowsById,
+		activeWorkflows: workflowsListStore.activeWorkflows,
+		allWorkflows: workflowsListStore.allWorkflows,
+		totalWorkflowCount: workflowsListStore.totalWorkflowCount,
 		isWorkflowActive,
 		workflowTriggerNodes,
 		currentWorkflowHasWebhookNode,
@@ -2097,7 +1933,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		findNodeByPartialId,
 		getPartialIdForNode,
 		setSelectedTriggerNodeName,
-		totalWorkflowCount,
 		fetchLastSuccessfulExecution,
 		lastSuccessfulExecution,
 		getWebhookUrl,

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -740,7 +740,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 
 		if (id === workflow.value.id) {
 			setIsArchived(true);
-			setWorkflowVersionId(updatedWorkflow.versionId, updatedWorkflow.checksum!);
+			setWorkflowVersionId(updatedWorkflow.versionId, updatedWorkflow.checksum);
 		}
 	}
 
@@ -749,7 +749,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 
 		if (id === workflow.value.id) {
 			setIsArchived(false);
-			setWorkflowVersionId(updatedWorkflow.versionId, updatedWorkflow.checksum!);
+			setWorkflowVersionId(updatedWorkflow.versionId, updatedWorkflow.checksum);
 		}
 	}
 

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -439,9 +439,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		);
 	}
 
-	// Delegated to workflowsListStore for backward compatibility
-	const getWorkflowById = workflowsListStore.getWorkflowById;
-
 	function getNodeByName(nodeName: string): INodeUi | null {
 		return workflowUtils.getNodeByName(nodesByName.value, nodeName);
 	}
@@ -637,14 +634,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		);
 	}
 
-	// Delegated to workflowsListStore for backward compatibility
-	const fetchWorkflowsPage = workflowsListStore.fetchWorkflowsPage;
-	const searchWorkflows = workflowsListStore.searchWorkflows;
-	const fetchAllWorkflows = workflowsListStore.fetchAllWorkflows;
-	const fetchWorkflow = workflowsListStore.fetchWorkflow;
-	const fetchWorkflowsWithNodesIncluded = workflowsListStore.fetchWorkflowsWithNodesIncluded;
-	const checkWorkflowExists = workflowsListStore.checkWorkflowExists;
-
 	function resetWorkflow() {
 		workflow.value = createEmptyWorkflow();
 		workflowChecksum.value = '';
@@ -745,12 +734,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		return updatedNodesCount;
 	}
 
-	// Delegated to workflowsListStore for backward compatibility
-	const setWorkflows = workflowsListStore.setWorkflows;
-
-	// Delegated to workflowsListStore for backward compatibility
-	const deleteWorkflow = workflowsListStore.deleteWorkflow;
-
 	async function archiveWorkflow(id: string) {
 		const updatedWorkflow = await workflowsListStore.archiveWorkflowInList(id);
 		setWorkflowInactive(id);
@@ -769,9 +752,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			setWorkflowVersionId(updatedWorkflow.versionId, updatedWorkflow.checksum!);
 		}
 	}
-
-	// Delegated to workflowsListStore for backward compatibility
-	const addWorkflow = workflowsListStore.addWorkflow;
 
 	function setWorkflowActive(
 		targetWorkflowId: string,
@@ -799,9 +779,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			workflow.value.activeVersion = null;
 		}
 	}
-
-	// Delegated to workflowsListStore for backward compatibility
-	const fetchActiveWorkflows = workflowsListStore.fetchActiveWorkflows;
 
 	function setIsArchived(isArchived: boolean) {
 		workflow.value.isArchived = isArchived;
@@ -1538,7 +1515,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 				currentSettings = cached.settings ?? ({} as IWorkflowSettings);
 				currentVersionId = cached.versionId;
 			} else {
-				const fetched = await fetchWorkflow(id);
+				const fetched = await workflowsListStore.fetchWorkflow(id);
 				currentSettings = fetched.settings ?? ({} as IWorkflowSettings);
 				currentVersionId = fetched.versionId;
 			}
@@ -1584,7 +1561,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			if (cached?.versionId) {
 				currentVersionId = cached.versionId;
 			} else {
-				const fetched = await fetchWorkflow(id);
+				const fetched = await workflowsListStore.fetchWorkflow(id);
 				currentVersionId = fetched.versionId;
 			}
 		}
@@ -1811,12 +1788,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		workflowTags,
 		isNewWorkflow,
 		isWorkflowSaved,
-
-		// Re-exported from workflowsListStore for backward compatibility
-		workflowsById: workflowsListStore.workflowsById,
-		activeWorkflows: workflowsListStore.activeWorkflows,
-		allWorkflows: workflowsListStore.allWorkflows,
-		totalWorkflowCount: workflowsListStore.totalWorkflowCount,
 		isWorkflowActive,
 		workflowTriggerNodes,
 		currentWorkflowHasWebhookNode,
@@ -1846,7 +1817,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		incomingConnectionsByNodeName,
 		nodeHasOutputConnection,
 		isNodeInOutgoingNodeConnections,
-		getWorkflowById,
 		getNodeByName,
 		findRootWithMainConnection,
 		getNodeById,
@@ -1865,12 +1835,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		cloneWorkflowObject,
 		getWorkflowFromUrl,
 		getActivationError,
-		searchWorkflows,
-		fetchAllWorkflows,
-		fetchWorkflowsPage,
-		fetchWorkflow,
-		fetchWorkflowsWithNodesIncluded,
-		checkWorkflowExists,
 		resetWorkflow,
 		addNodeExecutionStartedData,
 		setUsedCredentials,
@@ -1878,14 +1842,10 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		setWorkflowActiveVersion,
 		replaceInvalidWorkflowCredentials,
 		assignCredentialToMatchingNodes,
-		setWorkflows,
-		deleteWorkflow,
 		archiveWorkflow,
 		unarchiveWorkflow,
-		addWorkflow,
 		setWorkflowActive,
 		setWorkflowInactive,
-		fetchActiveWorkflows,
 		setIsArchived,
 		setDescription,
 		getDuplicateCurrentWorkflowName,

--- a/packages/frontend/editor-ui/src/app/stores/workflowsList.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowsList.store.test.ts
@@ -1,7 +1,7 @@
 import { setActivePinia, createPinia } from 'pinia';
 import * as workflowsApi from '@/app/api/workflows';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
-import type { IWorkflowDb } from '@/Interface';
+import type { IWorkflowDb, WorkflowListResource, WorkflowResource } from '@/Interface';
 import * as apiUtils from '@n8n/rest-api-client';
 import { createTestWorkflow } from '@/__tests__/mocks';
 import type { WorkflowHistory } from '@n8n/rest-api-client';
@@ -253,7 +253,7 @@ describe('useWorkflowsListStore', () => {
 			const mockWorkflows = [
 				{ id: '1', name: 'Workflow 1', resource: 'workflow' },
 				{ id: '2', name: 'Workflow 2', resource: 'workflow' },
-			];
+			] as WorkflowListResource[];
 			vi.mocked(workflowsApi).getWorkflowsAndFolders.mockResolvedValue({
 				count: 2,
 				data: mockWorkflows,
@@ -270,7 +270,7 @@ describe('useWorkflowsListStore', () => {
 			const mockData = [
 				{ id: '1', name: 'Workflow 1', resource: 'workflow' },
 				{ id: 'folder-1', name: 'Folder', resource: 'folder' },
-			];
+			] as WorkflowListResource[];
 			vi.mocked(workflowsApi).getWorkflowsAndFolders.mockResolvedValue({
 				count: 2,
 				data: mockData,
@@ -413,7 +413,7 @@ describe('useWorkflowsListStore', () => {
 
 	describe('fetchWorkflowsWithNodesIncluded', () => {
 		it('should fetch workflows containing specified node types', async () => {
-			const mockWorkflows = [{ id: '1', name: 'Workflow with HTTP' }];
+			const mockWorkflows = [{ id: '1', name: 'Workflow with HTTP' }] as WorkflowResource[];
 			vi.mocked(workflowsApi).getWorkflowsWithNodesIncluded.mockResolvedValue({
 				count: 1,
 				data: mockWorkflows,

--- a/packages/frontend/editor-ui/src/app/stores/workflowsList.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowsList.store.test.ts
@@ -1,0 +1,563 @@
+import { setActivePinia, createPinia } from 'pinia';
+import * as workflowsApi from '@/app/api/workflows';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
+import type { IWorkflowDb } from '@/Interface';
+import * as apiUtils from '@n8n/rest-api-client';
+import { createTestWorkflow } from '@/__tests__/mocks';
+import type { WorkflowHistory } from '@n8n/rest-api-client';
+
+vi.mock('@/app/api/workflows', () => ({
+	getWorkflows: vi.fn(),
+	getWorkflow: vi.fn(),
+	getWorkflowsAndFolders: vi.fn(),
+	getWorkflowsWithNodesIncluded: vi.fn(),
+	getActiveWorkflows: vi.fn(),
+	workflowExists: vi.fn(),
+}));
+
+vi.mock('@vueuse/core', async (importOriginal) => {
+	const actual = await importOriginal<{}>();
+	return {
+		...actual,
+		useLocalStorage: vi.fn().mockReturnValue({ value: undefined }),
+	};
+});
+
+describe('useWorkflowsListStore', () => {
+	let workflowsListStore: ReturnType<typeof useWorkflowsListStore>;
+
+	beforeEach(() => {
+		setActivePinia(createPinia());
+		workflowsListStore = useWorkflowsListStore();
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('initial state', () => {
+		it('should initialize with default state', () => {
+			expect(workflowsListStore.totalWorkflowCount).toBe(0);
+			expect(workflowsListStore.workflowsById).toEqual({});
+			expect(workflowsListStore.activeWorkflows).toEqual([]);
+		});
+	});
+
+	describe('allWorkflows', () => {
+		it('should return sorted workflows by name', () => {
+			workflowsListStore.setWorkflows([
+				{ id: '3', name: 'Zeta' },
+				{ id: '1', name: 'Alpha' },
+				{ id: '2', name: 'Beta' },
+			] as IWorkflowDb[]);
+
+			const allWorkflows = workflowsListStore.allWorkflows;
+			expect(allWorkflows[0].name).toBe('Alpha');
+			expect(allWorkflows[1].name).toBe('Beta');
+			expect(allWorkflows[2].name).toBe('Zeta');
+		});
+
+		it('should return empty array when no workflows are set', () => {
+			workflowsListStore.setWorkflows([]);
+
+			const allWorkflows = workflowsListStore.allWorkflows;
+			expect(allWorkflows).toEqual([]);
+		});
+	});
+
+	describe('getWorkflowById', () => {
+		it('should return workflow by id', () => {
+			const workflow = createTestWorkflow({ id: '123', name: 'Test Workflow' });
+			workflowsListStore.addWorkflow(workflow);
+
+			const result = workflowsListStore.getWorkflowById('123');
+			expect(result.id).toBe('123');
+			expect(result.name).toBe('Test Workflow');
+		});
+
+		it('should return undefined for non-existent workflow', () => {
+			const result = workflowsListStore.getWorkflowById('non-existent');
+			expect(result).toBeUndefined();
+		});
+	});
+
+	describe('setWorkflows', () => {
+		it('should set workflows and index by id', () => {
+			const workflows = [
+				{ id: '1', name: 'Workflow 1' },
+				{ id: '2', name: 'Workflow 2' },
+			] as IWorkflowDb[];
+
+			workflowsListStore.setWorkflows(workflows);
+
+			expect(Object.keys(workflowsListStore.workflowsById)).toHaveLength(2);
+			expect(workflowsListStore.workflowsById['1'].name).toBe('Workflow 1');
+			expect(workflowsListStore.workflowsById['2'].name).toBe('Workflow 2');
+		});
+
+		it('should replace existing workflows', () => {
+			workflowsListStore.setWorkflows([{ id: '1', name: 'Old' }] as IWorkflowDb[]);
+			workflowsListStore.setWorkflows([{ id: '2', name: 'New' }] as IWorkflowDb[]);
+
+			expect(Object.keys(workflowsListStore.workflowsById)).toHaveLength(1);
+			expect(workflowsListStore.workflowsById['1']).toBeUndefined();
+			expect(workflowsListStore.workflowsById['2'].name).toBe('New');
+		});
+
+		it('should skip workflows without id', () => {
+			workflowsListStore.setWorkflows([
+				{ id: '1', name: 'Workflow 1' },
+				{ id: '', name: 'No ID' },
+			] as IWorkflowDb[]);
+
+			expect(Object.keys(workflowsListStore.workflowsById)).toHaveLength(1);
+			expect(workflowsListStore.workflowsById['1']).toBeDefined();
+		});
+	});
+
+	describe('addWorkflow', () => {
+		it('should add a new workflow', () => {
+			const workflow = createTestWorkflow({ id: '123', name: 'New Workflow' });
+			workflowsListStore.addWorkflow(workflow);
+
+			expect(workflowsListStore.workflowsById['123']).toBeDefined();
+			expect(workflowsListStore.workflowsById['123'].name).toBe('New Workflow');
+		});
+
+		it('should merge with existing workflow data', () => {
+			workflowsListStore.addWorkflow(
+				createTestWorkflow({ id: '123', name: 'Original', active: false }),
+			);
+			workflowsListStore.addWorkflow(createTestWorkflow({ id: '123', name: 'Updated' }));
+
+			expect(workflowsListStore.workflowsById['123'].name).toBe('Updated');
+		});
+	});
+
+	describe('removeWorkflow', () => {
+		it('should remove workflow by id', () => {
+			workflowsListStore.addWorkflow(createTestWorkflow({ id: '123', name: 'To Remove' }));
+			workflowsListStore.addWorkflow(createTestWorkflow({ id: '456', name: 'To Keep' }));
+
+			workflowsListStore.removeWorkflow('123');
+
+			expect(workflowsListStore.workflowsById['123']).toBeUndefined();
+			expect(workflowsListStore.workflowsById['456']).toBeDefined();
+		});
+
+		it('should handle removing non-existent workflow', () => {
+			workflowsListStore.addWorkflow(createTestWorkflow({ id: '123', name: 'Existing' }));
+
+			workflowsListStore.removeWorkflow('non-existent');
+
+			expect(Object.keys(workflowsListStore.workflowsById)).toHaveLength(1);
+		});
+	});
+
+	describe('updateWorkflowInCache', () => {
+		it('should update existing workflow properties', () => {
+			workflowsListStore.addWorkflow(
+				createTestWorkflow({ id: '123', name: 'Original', active: false }),
+			);
+
+			workflowsListStore.updateWorkflowInCache('123', { name: 'Updated', active: true });
+
+			expect(workflowsListStore.workflowsById['123'].name).toBe('Updated');
+			expect(workflowsListStore.workflowsById['123'].active).toBe(true);
+		});
+
+		it('should not create workflow if it does not exist', () => {
+			workflowsListStore.updateWorkflowInCache('non-existent', { name: 'New' });
+
+			expect(workflowsListStore.workflowsById['non-existent']).toBeUndefined();
+		});
+	});
+
+	describe('setWorkflowActiveInCache', () => {
+		const mockActiveVersion: WorkflowHistory = {
+			versionId: 'test-version-id',
+			name: 'Test Version',
+			authors: 'Test Author',
+			description: 'A test workflow version',
+			createdAt: new Date().toISOString(),
+			updatedAt: new Date().toISOString(),
+			workflowPublishHistory: [],
+		};
+
+		it('should add workflow to activeWorkflows array', () => {
+			workflowsListStore.addWorkflow(createTestWorkflow({ id: '123', active: false }));
+
+			workflowsListStore.setWorkflowActiveInCache('123', mockActiveVersion);
+
+			expect(workflowsListStore.activeWorkflows).toContain('123');
+		});
+
+		it('should not duplicate workflow in activeWorkflows', () => {
+			workflowsListStore.activeWorkflows = ['123'];
+			workflowsListStore.addWorkflow(createTestWorkflow({ id: '123', active: true }));
+
+			workflowsListStore.setWorkflowActiveInCache('123', mockActiveVersion);
+
+			expect(workflowsListStore.activeWorkflows.filter((id) => id === '123')).toHaveLength(1);
+		});
+
+		it('should update cached workflow active state', () => {
+			workflowsListStore.addWorkflow(createTestWorkflow({ id: '123', active: false }));
+
+			workflowsListStore.setWorkflowActiveInCache('123', mockActiveVersion);
+
+			expect(workflowsListStore.workflowsById['123'].active).toBe(true);
+			expect(workflowsListStore.workflowsById['123'].activeVersionId).toBe('test-version-id');
+			expect(workflowsListStore.workflowsById['123'].activeVersion).toEqual(mockActiveVersion);
+		});
+	});
+
+	describe('setWorkflowInactiveInCache', () => {
+		it('should remove workflow from activeWorkflows array', () => {
+			workflowsListStore.activeWorkflows = ['123', '456'];
+			workflowsListStore.addWorkflow(createTestWorkflow({ id: '123', active: true }));
+
+			workflowsListStore.setWorkflowInactiveInCache('123');
+
+			expect(workflowsListStore.activeWorkflows).not.toContain('123');
+			expect(workflowsListStore.activeWorkflows).toContain('456');
+		});
+
+		it('should update cached workflow active state', () => {
+			workflowsListStore.activeWorkflows = ['123'];
+			workflowsListStore.addWorkflow(
+				createTestWorkflow({
+					id: '123',
+					active: true,
+				}),
+			);
+
+			workflowsListStore.setWorkflowInactiveInCache('123');
+
+			expect(workflowsListStore.workflowsById['123'].active).toBe(false);
+			expect(workflowsListStore.workflowsById['123'].activeVersionId).toBeNull();
+			expect(workflowsListStore.workflowsById['123'].activeVersion).toBeNull();
+		});
+
+		it('should handle workflow not in activeWorkflows', () => {
+			workflowsListStore.activeWorkflows = ['456'];
+
+			workflowsListStore.setWorkflowInactiveInCache('123');
+
+			expect(workflowsListStore.activeWorkflows).toEqual(['456']);
+		});
+	});
+
+	describe('fetchWorkflowsPage', () => {
+		it('should fetch workflows and update store', async () => {
+			const mockWorkflows = [
+				{ id: '1', name: 'Workflow 1', resource: 'workflow' },
+				{ id: '2', name: 'Workflow 2', resource: 'workflow' },
+			];
+			vi.mocked(workflowsApi).getWorkflowsAndFolders.mockResolvedValue({
+				count: 2,
+				data: mockWorkflows,
+			});
+
+			const result = await workflowsListStore.fetchWorkflowsPage();
+
+			expect(workflowsApi.getWorkflowsAndFolders).toHaveBeenCalled();
+			expect(workflowsListStore.totalWorkflowCount).toBe(2);
+			expect(result).toEqual(mockWorkflows);
+		});
+
+		it('should filter out folders from cache', async () => {
+			const mockData = [
+				{ id: '1', name: 'Workflow 1', resource: 'workflow' },
+				{ id: 'folder-1', name: 'Folder', resource: 'folder' },
+			];
+			vi.mocked(workflowsApi).getWorkflowsAndFolders.mockResolvedValue({
+				count: 2,
+				data: mockData,
+			});
+
+			await workflowsListStore.fetchWorkflowsPage();
+
+			expect(workflowsListStore.workflowsById['1']).toBeDefined();
+			expect(workflowsListStore.workflowsById['folder-1']).toBeUndefined();
+		});
+
+		it('should pass pagination parameters', async () => {
+			vi.mocked(workflowsApi).getWorkflowsAndFolders.mockResolvedValue({
+				count: 0,
+				data: [],
+			});
+
+			await workflowsListStore.fetchWorkflowsPage('project-1', 2, 25, 'name:asc');
+
+			expect(workflowsApi.getWorkflowsAndFolders).toHaveBeenCalledWith(
+				expect.any(Object),
+				{ projectId: 'project-1' },
+				{ skip: 25, take: 25, sortBy: 'name:asc' },
+				undefined,
+				undefined,
+			);
+		});
+
+		it('should pass filter parameters', async () => {
+			vi.mocked(workflowsApi).getWorkflowsAndFolders.mockResolvedValue({
+				count: 0,
+				data: [],
+			});
+
+			await workflowsListStore.fetchWorkflowsPage(undefined, 1, 10, undefined, {
+				query: 'test',
+				tags: ['tag1'],
+				active: true,
+				isArchived: false,
+			});
+
+			expect(workflowsApi.getWorkflowsAndFolders).toHaveBeenCalledWith(
+				expect.any(Object),
+				{
+					query: 'test',
+					tags: ['tag1'],
+					active: true,
+					isArchived: false,
+					projectId: undefined,
+				},
+				expect.any(Object),
+				undefined,
+				undefined,
+			);
+		});
+	});
+
+	describe('searchWorkflows', () => {
+		it('should search workflows with filters', async () => {
+			const mockWorkflows = [{ id: '1', name: 'Test Workflow' }] as IWorkflowDb[];
+			vi.mocked(workflowsApi).getWorkflows.mockResolvedValue({
+				count: mockWorkflows.length,
+				data: mockWorkflows,
+			});
+
+			const result = await workflowsListStore.searchWorkflows({ query: 'test' });
+
+			expect(workflowsApi.getWorkflows).toHaveBeenCalledWith(
+				expect.any(Object),
+				{ query: 'test' },
+				undefined,
+				undefined,
+			);
+			expect(result).toEqual(mockWorkflows);
+		});
+
+		it('should pass undefined filter when no meaningful values', async () => {
+			vi.mocked(workflowsApi).getWorkflows.mockResolvedValue({
+				count: 0,
+				data: [],
+			});
+
+			await workflowsListStore.searchWorkflows({});
+
+			expect(workflowsApi.getWorkflows).toHaveBeenCalledWith(
+				expect.any(Object),
+				undefined,
+				undefined,
+				undefined,
+			);
+		});
+
+		it('should pass select fields', async () => {
+			vi.mocked(workflowsApi).getWorkflows.mockResolvedValue({
+				count: 0,
+				data: [],
+			});
+
+			await workflowsListStore.searchWorkflows({ select: ['id', 'name'] });
+
+			expect(workflowsApi.getWorkflows).toHaveBeenCalledWith(
+				expect.any(Object),
+				undefined,
+				undefined,
+				['id', 'name'],
+			);
+		});
+	});
+
+	describe('fetchAllWorkflows', () => {
+		it('should fetch and set all workflows', async () => {
+			const mockWorkflows = [
+				{ id: '1', name: 'Workflow 1' },
+				{ id: '2', name: 'Workflow 2' },
+			] as IWorkflowDb[];
+			vi.mocked(workflowsApi).getWorkflows.mockResolvedValue({
+				count: mockWorkflows.length,
+				data: mockWorkflows,
+			});
+
+			const result = await workflowsListStore.fetchAllWorkflows();
+
+			expect(result).toEqual(mockWorkflows);
+			expect(Object.values(workflowsListStore.workflowsById)).toEqual(mockWorkflows);
+		});
+	});
+
+	describe('fetchWorkflow', () => {
+		it('should fetch single workflow and add to cache', async () => {
+			const mockWorkflow = createTestWorkflow({ id: '123', name: 'Fetched Workflow' });
+			vi.mocked(workflowsApi).getWorkflow.mockResolvedValue(mockWorkflow);
+
+			const result = await workflowsListStore.fetchWorkflow('123');
+
+			expect(workflowsApi.getWorkflow).toHaveBeenCalledWith(expect.any(Object), '123');
+			expect(result.id).toBe('123');
+			expect(workflowsListStore.workflowsById['123']).toBeDefined();
+		});
+	});
+
+	describe('fetchWorkflowsWithNodesIncluded', () => {
+		it('should fetch workflows containing specified node types', async () => {
+			const mockWorkflows = [{ id: '1', name: 'Workflow with HTTP' }];
+			vi.mocked(workflowsApi).getWorkflowsWithNodesIncluded.mockResolvedValue({
+				count: 1,
+				data: mockWorkflows,
+			});
+
+			const result = await workflowsListStore.fetchWorkflowsWithNodesIncluded([
+				'n8n-nodes-base.httpRequest',
+			]);
+
+			expect(workflowsApi.getWorkflowsWithNodesIncluded).toHaveBeenCalledWith(expect.any(Object), [
+				'n8n-nodes-base.httpRequest',
+			]);
+			expect(result.data).toEqual(mockWorkflows);
+		});
+	});
+
+	describe('fetchActiveWorkflows', () => {
+		it('should fetch and store active workflow ids', async () => {
+			const mockActiveIds = ['1', '2', '3'];
+			vi.mocked(workflowsApi).getActiveWorkflows.mockResolvedValue(mockActiveIds);
+
+			const result = await workflowsListStore.fetchActiveWorkflows();
+
+			expect(workflowsApi.getActiveWorkflows).toHaveBeenCalled();
+			expect(result).toEqual(mockActiveIds);
+			expect(workflowsListStore.activeWorkflows).toEqual(mockActiveIds);
+		});
+	});
+
+	describe('checkWorkflowExists', () => {
+		it('should return true when workflow exists', async () => {
+			vi.mocked(workflowsApi).workflowExists.mockResolvedValue({ exists: true });
+
+			const result = await workflowsListStore.checkWorkflowExists('123');
+
+			expect(workflowsApi.workflowExists).toHaveBeenCalledWith(expect.any(Object), '123');
+			expect(result).toBe(true);
+		});
+
+		it('should return false when workflow does not exist', async () => {
+			vi.mocked(workflowsApi).workflowExists.mockResolvedValue({ exists: false });
+
+			const result = await workflowsListStore.checkWorkflowExists('non-existent');
+
+			expect(result).toBe(false);
+		});
+	});
+
+	describe('deleteWorkflow', () => {
+		it('should call API and remove workflow from cache', async () => {
+			workflowsListStore.addWorkflow(createTestWorkflow({ id: '123', name: 'To Delete' }));
+			const makeRestApiRequestSpy = vi
+				.spyOn(apiUtils, 'makeRestApiRequest')
+				.mockResolvedValue(undefined);
+
+			await workflowsListStore.deleteWorkflow('123');
+
+			expect(makeRestApiRequestSpy).toHaveBeenCalledWith(
+				expect.any(Object),
+				'DELETE',
+				'/workflows/123',
+			);
+			expect(workflowsListStore.workflowsById['123']).toBeUndefined();
+		});
+	});
+
+	describe('archiveWorkflowInList', () => {
+		it('should archive workflow and update cache', async () => {
+			const versionId = '00000000-0000-0000-0000-000000000000';
+			const updatedVersionId = '11111111-1111-1111-1111-111111111111';
+
+			workflowsListStore.addWorkflow(
+				createTestWorkflow({
+					id: '123',
+					active: true,
+					isArchived: false,
+					versionId,
+				}),
+			);
+			workflowsListStore.activeWorkflows = ['123'];
+
+			vi.spyOn(apiUtils, 'makeRestApiRequest').mockResolvedValue({
+				versionId: updatedVersionId,
+				checksum: 'checksum',
+			});
+
+			const result = await workflowsListStore.archiveWorkflowInList('123');
+
+			expect(result.versionId).toBe(updatedVersionId);
+			expect(workflowsListStore.workflowsById['123'].isArchived).toBe(true);
+			expect(workflowsListStore.workflowsById['123'].versionId).toBe(updatedVersionId);
+			expect(workflowsListStore.workflowsById['123'].active).toBe(false);
+			expect(workflowsListStore.activeWorkflows).not.toContain('123');
+		});
+
+		it('should throw error if checksum is missing', async () => {
+			workflowsListStore.addWorkflow(createTestWorkflow({ id: '123' }));
+
+			vi.spyOn(apiUtils, 'makeRestApiRequest').mockResolvedValue({
+				versionId: 'new-version',
+			});
+
+			await expect(workflowsListStore.archiveWorkflowInList('123')).rejects.toThrow(
+				'Failed to archive workflow',
+			);
+		});
+	});
+
+	describe('unarchiveWorkflowInList', () => {
+		it('should unarchive workflow and update cache', async () => {
+			const versionId = '00000000-0000-0000-0000-000000000000';
+			const updatedVersionId = '11111111-1111-1111-1111-111111111111';
+
+			workflowsListStore.addWorkflow(
+				createTestWorkflow({
+					id: '123',
+					active: false,
+					isArchived: true,
+					versionId,
+				}),
+			);
+
+			vi.spyOn(apiUtils, 'makeRestApiRequest').mockResolvedValue({
+				versionId: updatedVersionId,
+				checksum: 'checksum',
+			});
+
+			const result = await workflowsListStore.unarchiveWorkflowInList('123');
+
+			expect(result.versionId).toBe(updatedVersionId);
+			expect(workflowsListStore.workflowsById['123'].isArchived).toBe(false);
+			expect(workflowsListStore.workflowsById['123'].versionId).toBe(updatedVersionId);
+		});
+
+		it('should throw error if checksum is missing', async () => {
+			workflowsListStore.addWorkflow(createTestWorkflow({ id: '123', isArchived: true }));
+
+			vi.spyOn(apiUtils, 'makeRestApiRequest').mockResolvedValue({
+				versionId: 'new-version',
+			});
+
+			await expect(workflowsListStore.unarchiveWorkflowInList('123')).rejects.toThrow(
+				'Failed to unarchive workflow',
+			);
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/app/stores/workflowsList.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowsList.store.ts
@@ -1,0 +1,280 @@
+import { DEFAULT_WORKFLOW_PAGE_SIZE } from '@/app/constants';
+import { STORES } from '@n8n/stores';
+import type { IWorkflowDb, IWorkflowsMap, WorkflowListResource } from '@/Interface';
+import { defineStore } from 'pinia';
+import { deepCopy } from 'n8n-workflow';
+import { useRootStore } from '@n8n/stores/useRootStore';
+import * as workflowsApi from '@/app/api/workflows';
+import { makeRestApiRequest, type WorkflowHistory } from '@n8n/rest-api-client';
+import { computed, ref } from 'vue';
+import { isPresent } from '@/app/utils/typesUtils';
+
+export const useWorkflowsListStore = defineStore(STORES.WORKFLOWS_LIST, () => {
+	const rootStore = useRootStore();
+
+	// State
+	const totalWorkflowCount = ref(0);
+	const workflowsById = ref<Record<string, IWorkflowDb>>({});
+	const activeWorkflows = ref<string[]>([]);
+
+	// Computed
+	const allWorkflows = computed(() =>
+		Object.values(workflowsById.value).sort((a, b) => a.name.localeCompare(b.name)),
+	);
+
+	// Methods - Getters
+	function getWorkflowById(id: string): IWorkflowDb {
+		return workflowsById.value[id];
+	}
+
+	// Methods - Cache Management
+	function setWorkflows(workflows: IWorkflowDb[]) {
+		workflowsById.value = workflows.reduce<IWorkflowsMap>((acc, workflow: IWorkflowDb) => {
+			if (workflow.id) {
+				acc[workflow.id] = workflow;
+			}
+			return acc;
+		}, {});
+	}
+
+	function addWorkflow(workflow: IWorkflowDb) {
+		workflowsById.value = {
+			...workflowsById.value,
+			[workflow.id]: {
+				...workflowsById.value[workflow.id],
+				...deepCopy(workflow),
+			},
+		};
+	}
+
+	function removeWorkflow(id: string) {
+		const { [id]: _, ...workflows } = workflowsById.value;
+		workflowsById.value = workflows;
+	}
+
+	function updateWorkflowInCache(id: string, updates: Partial<IWorkflowDb>) {
+		if (workflowsById.value[id]) {
+			workflowsById.value[id] = {
+				...workflowsById.value[id],
+				...updates,
+			};
+		}
+	}
+
+	// Methods - Active Workflows Cache
+	function setWorkflowActiveInCache(targetWorkflowId: string, activeVersion: WorkflowHistory) {
+		if (activeWorkflows.value.indexOf(targetWorkflowId) === -1) {
+			activeWorkflows.value.push(targetWorkflowId);
+		}
+
+		const cachedWorkflow = workflowsById.value[targetWorkflowId];
+		if (cachedWorkflow) {
+			cachedWorkflow.active = true;
+			cachedWorkflow.activeVersionId = activeVersion.versionId;
+			cachedWorkflow.activeVersion = activeVersion;
+		}
+	}
+
+	function setWorkflowInactiveInCache(targetWorkflowId: string) {
+		const index = activeWorkflows.value.indexOf(targetWorkflowId);
+		if (index !== -1) {
+			activeWorkflows.value.splice(index, 1);
+		}
+		const targetWorkflow = workflowsById.value[targetWorkflowId];
+		if (targetWorkflow) {
+			targetWorkflow.active = false;
+			targetWorkflow.activeVersionId = null;
+			targetWorkflow.activeVersion = null;
+		}
+	}
+
+	// Methods - Fetching
+	async function fetchWorkflowsPage(
+		projectId?: string,
+		page = 1,
+		pageSize = DEFAULT_WORKFLOW_PAGE_SIZE,
+		sortBy?: string,
+		filters: {
+			query?: string;
+			tags?: string[];
+			active?: boolean;
+			isArchived?: boolean;
+			parentFolderId?: string;
+			availableInMCP?: boolean;
+			triggerNodeTypes?: string[];
+		} = {},
+		includeFolders = false,
+		onlySharedWithMe = false,
+	): Promise<WorkflowListResource[]> {
+		const filter = { ...filters, projectId };
+		const options = {
+			skip: (page - 1) * pageSize,
+			take: pageSize,
+			sortBy,
+		};
+
+		const { count, data } = await workflowsApi.getWorkflowsAndFolders(
+			rootStore.restApiContext,
+			Object.keys(filter).length ? filter : undefined,
+			Object.keys(options).length ? options : undefined,
+			includeFolders ? includeFolders : undefined,
+			onlySharedWithMe ? onlySharedWithMe : undefined,
+		);
+		totalWorkflowCount.value = count;
+		// Also set fetched workflows to store
+		// When fetching workflows from overview page, they don't have resource property
+		// so in order to filter out folders, we need to check if resource is not folder
+		data
+			.filter((item) => item.resource !== 'folder')
+			.forEach((item) => {
+				addWorkflow({
+					...item,
+					nodes: [],
+					connections: {},
+					versionId: '',
+				});
+			});
+		return data;
+	}
+
+	async function searchWorkflows({
+		projectId,
+		query,
+		nodeTypes,
+		tags,
+		select,
+		isArchived,
+		triggerNodeTypes,
+	}: {
+		projectId?: string;
+		query?: string;
+		nodeTypes?: string[];
+		tags?: string[];
+		select?: string[];
+		isArchived?: boolean;
+		triggerNodeTypes?: string[];
+	}): Promise<IWorkflowDb[]> {
+		const filter = {
+			projectId,
+			query,
+			nodeTypes,
+			tags,
+			isArchived,
+			triggerNodeTypes,
+		};
+
+		// Check if filter has meaningful values (not just undefined, null, or empty arrays/strings)
+		const hasFilter = Object.values(filter).some(
+			(v) => isPresent(v) && (Array.isArray(v) ? v.length > 0 : v !== ''),
+		);
+
+		const { data: workflows } = await workflowsApi.getWorkflows(
+			rootStore.restApiContext,
+			hasFilter ? filter : undefined,
+			undefined,
+			select,
+		);
+		return workflows;
+	}
+
+	async function fetchAllWorkflows(projectId?: string): Promise<IWorkflowDb[]> {
+		const workflows = await searchWorkflows({ projectId });
+		setWorkflows(workflows);
+		return workflows;
+	}
+
+	async function fetchWorkflow(id: string): Promise<IWorkflowDb> {
+		const workflowData = await workflowsApi.getWorkflow(rootStore.restApiContext, id);
+		addWorkflow(workflowData);
+		return workflowData;
+	}
+
+	async function fetchWorkflowsWithNodesIncluded(nodeTypes: string[]) {
+		return await workflowsApi.getWorkflowsWithNodesIncluded(rootStore.restApiContext, nodeTypes);
+	}
+
+	async function fetchActiveWorkflows(): Promise<string[]> {
+		const data = await workflowsApi.getActiveWorkflows(rootStore.restApiContext);
+		activeWorkflows.value = data;
+		return data;
+	}
+
+	async function checkWorkflowExists(id: string): Promise<boolean> {
+		const result = await workflowsApi.workflowExists(rootStore.restApiContext, id);
+		return result.exists;
+	}
+
+	// Methods - API + Cache Operations
+	async function deleteWorkflow(id: string) {
+		await makeRestApiRequest(rootStore.restApiContext, 'DELETE', `/workflows/${id}`);
+		removeWorkflow(id);
+	}
+
+	async function archiveWorkflowInList(id: string): Promise<IWorkflowDb> {
+		const updatedWorkflow = await makeRestApiRequest<IWorkflowDb>(
+			rootStore.restApiContext,
+			'POST',
+			`/workflows/${id}/archive`,
+		);
+		if (!updatedWorkflow.checksum) {
+			throw new Error('Failed to archive workflow');
+		}
+		if (workflowsById.value[id]) {
+			workflowsById.value[id].isArchived = true;
+			workflowsById.value[id].versionId = updatedWorkflow.versionId;
+		}
+		setWorkflowInactiveInCache(id);
+		return updatedWorkflow;
+	}
+
+	async function unarchiveWorkflowInList(id: string): Promise<IWorkflowDb> {
+		const updatedWorkflow = await makeRestApiRequest<IWorkflowDb>(
+			rootStore.restApiContext,
+			'POST',
+			`/workflows/${id}/unarchive`,
+		);
+		if (!updatedWorkflow.checksum) {
+			throw new Error('Failed to unarchive workflow');
+		}
+		if (workflowsById.value[id]) {
+			workflowsById.value[id].isArchived = false;
+			workflowsById.value[id].versionId = updatedWorkflow.versionId;
+		}
+		return updatedWorkflow;
+	}
+
+	return {
+		// State
+		totalWorkflowCount,
+		workflowsById,
+		activeWorkflows,
+
+		// Computed
+		allWorkflows,
+
+		// Getters
+		getWorkflowById,
+
+		// Cache Management
+		setWorkflows,
+		addWorkflow,
+		removeWorkflow,
+		updateWorkflowInCache,
+		setWorkflowActiveInCache,
+		setWorkflowInactiveInCache,
+
+		// Fetching
+		fetchWorkflowsPage,
+		searchWorkflows,
+		fetchAllWorkflows,
+		fetchWorkflow,
+		fetchWorkflowsWithNodesIncluded,
+		fetchActiveWorkflows,
+		checkWorkflowExists,
+
+		// API + Cache Operations
+		deleteWorkflow,
+		archiveWorkflowInList,
+		unarchiveWorkflowInList,
+	};
+});

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -23,6 +23,7 @@ import { useUIStore } from '@/app/stores/ui.store';
 import CanvasRunWorkflowButton from '@/features/workflows/canvas/components/elements/buttons/CanvasRunWorkflowButton.vue';
 import { useI18n } from '@n8n/i18n';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useRunWorkflow } from '@/app/composables/useRunWorkflow';
 import { useGlobalLinkActions } from '@/app/composables/useGlobalLinkActions';
 import type {
@@ -195,6 +196,7 @@ const clipboard = useClipboard({ onPaste: onClipboardPaste });
 const nodeTypesStore = useNodeTypesStore();
 const uiStore = useUIStore();
 const workflowsStore = useWorkflowsStore();
+const workflowsListStore = useWorkflowsListStore();
 const sourceControlStore = useSourceControlStore();
 const nodeCreatorStore = useNodeCreatorStore();
 const settingsStore = useSettingsStore();
@@ -353,7 +355,7 @@ async function initializeData() {
 		if (settingsStore.isPreviewMode && isDemoRoute.value) return [];
 
 		const promises: Array<Promise<unknown>> = [
-			workflowsStore.fetchActiveWorkflows(),
+			workflowsListStore.fetchActiveWorkflows(),
 			credentialsStore.fetchCredentialTypes(true),
 			loadCredentials(),
 		];
@@ -445,7 +447,7 @@ async function initializeRoute(force = false) {
 
 			// Check if we should initialize for a new workflow
 			if (isNewWorkflowRoute.value) {
-				const exists = await workflowsStore.checkWorkflowExists(workflowId.value);
+				const exists = await workflowsListStore.checkWorkflowExists(workflowId.value);
 				if (!exists && route.meta?.nodeView === true) {
 					return await initializeWorkspaceForNewWorkflow();
 				} else {
@@ -498,7 +500,7 @@ async function initializeWorkspaceForNewWorkflow() {
 
 async function initializeWorkspaceForExistingWorkflow(id: string) {
 	try {
-		const workflowData = await workflowsStore.fetchWorkflow(id);
+		const workflowData = await workflowsListStore.fetchWorkflow(id);
 
 		await openWorkflow(workflowData);
 
@@ -1211,7 +1213,7 @@ function onClickReplaceNode(nodeId: string) {
 
 const workflowPermissions = computed(() => {
 	return workflowId.value
-		? getResourcePermissions(workflowsStore.getWorkflowById(workflowId.value)?.scopes).workflow
+		? getResourcePermissions(workflowsListStore.getWorkflowById(workflowId.value)?.scopes).workflow
 		: {};
 });
 
@@ -1510,7 +1512,7 @@ async function onSourceControlPull() {
 		]);
 
 		if (workflowId.value && !uiStore.stateIsDirty) {
-			const workflowData = await workflowsStore.fetchWorkflow(workflowId.value);
+			const workflowData = await workflowsListStore.fetchWorkflow(workflowId.value);
 			if (workflowData) {
 				await openWorkflow(workflowData);
 			}

--- a/packages/frontend/editor-ui/src/app/views/WorkflowsView.test.ts
+++ b/packages/frontend/editor-ui/src/app/views/WorkflowsView.test.ts
@@ -11,7 +11,7 @@ import { useSettingsStore } from '@/app/stores/settings.store';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
 import { useTagsStore } from '@/features/shared/tags/tags.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import type { Project } from '@/features/collaboration/projects/projects.types';
 import WorkflowsView from '@/app/views/WorkflowsView.vue';
 import { STORES } from '@n8n/stores';
@@ -76,7 +76,7 @@ vi.mock('@n8n/rest-api-client/api/usage', () => ({
 
 let pinia: ReturnType<typeof createTestingPinia>;
 let foldersStore: ReturnType<typeof mockedStore<typeof useFoldersStore>>;
-let workflowsStore: ReturnType<typeof mockedStore<typeof useWorkflowsStore>>;
+let workflowsListStore: ReturnType<typeof mockedStore<typeof useWorkflowsListStore>>;
 let settingsStore: ReturnType<typeof mockedStore<typeof useSettingsStore>>;
 let projectPages: ReturnType<typeof useProjectPages>;
 
@@ -101,11 +101,11 @@ describe('WorkflowsView', () => {
 		await router.isReady();
 		pinia = createTestingPinia({ initialState });
 		foldersStore = mockedStore(useFoldersStore);
-		workflowsStore = mockedStore(useWorkflowsStore);
+		workflowsListStore = mockedStore(useWorkflowsListStore);
 		settingsStore = mockedStore(useSettingsStore);
 
-		workflowsStore.fetchWorkflowsPage.mockResolvedValue([]);
-		workflowsStore.fetchActiveWorkflows.mockResolvedValue([]);
+		workflowsListStore.fetchWorkflowsPage.mockResolvedValue([]);
+		workflowsListStore.fetchActiveWorkflows.mockResolvedValue([]);
 
 		foldersStore.totalWorkflowCount = 0;
 		foldersStore.fetchTotalWorkflowsAndFoldersCount.mockResolvedValue(0);
@@ -165,7 +165,7 @@ describe('WorkflowsView', () => {
 
 	describe('fetch workflow options', () => {
 		it('should not fetch folders for overview page', async () => {
-			workflowsStore.fetchWorkflowsPage.mockResolvedValue([]);
+			workflowsListStore.fetchWorkflowsPage.mockResolvedValue([]);
 			settingsStore.isFoldersFeatureEnabled = true;
 			vi.spyOn(projectPages, 'isOverviewSubPage', 'get').mockReturnValue(true);
 			vi.spyOn(projectPages, 'isSharedSubPage', 'get').mockReturnValue(false);
@@ -173,7 +173,7 @@ describe('WorkflowsView', () => {
 			renderComponent({ pinia });
 			await waitAllPromises();
 
-			expect(workflowsStore.fetchWorkflowsPage).toHaveBeenCalledWith(
+			expect(workflowsListStore.fetchWorkflowsPage).toHaveBeenCalledWith(
 				expect.any(String),
 				expect.any(Number),
 				expect.any(Number),
@@ -185,7 +185,7 @@ describe('WorkflowsView', () => {
 		});
 
 		it('should send proper API parameters for "Shared with you" page', async () => {
-			workflowsStore.fetchWorkflowsPage.mockResolvedValue([]);
+			workflowsListStore.fetchWorkflowsPage.mockResolvedValue([]);
 			settingsStore.isFoldersFeatureEnabled = true;
 			vi.spyOn(projectPages, 'isOverviewSubPage', 'get').mockReturnValue(false);
 			vi.spyOn(projectPages, 'isSharedSubPage', 'get').mockReturnValue(true);
@@ -193,7 +193,7 @@ describe('WorkflowsView', () => {
 			renderComponent({ pinia });
 			await waitAllPromises();
 
-			expect(workflowsStore.fetchWorkflowsPage).toHaveBeenCalledWith(
+			expect(workflowsListStore.fetchWorkflowsPage).toHaveBeenCalledWith(
 				expect.any(String),
 				expect.any(Number),
 				expect.any(Number),
@@ -216,12 +216,12 @@ describe('WorkflowsView', () => {
 			tagStore.tagsById = {
 				'test-tag': TEST_TAG,
 			};
-			workflowsStore.fetchWorkflowsPage.mockResolvedValue([]);
+			workflowsListStore.fetchWorkflowsPage.mockResolvedValue([]);
 
 			renderComponent({ pinia });
 			await waitAllPromises();
 
-			expect(workflowsStore.fetchWorkflowsPage).toHaveBeenCalledWith(
+			expect(workflowsListStore.fetchWorkflowsPage).toHaveBeenCalledWith(
 				expect.any(String),
 				expect.any(Number),
 				expect.any(Number),
@@ -238,12 +238,12 @@ describe('WorkflowsView', () => {
 		it('should set search filter based on query parameters', async () => {
 			await router.replace({ query: { search: 'one' } });
 
-			workflowsStore.fetchWorkflowsPage.mockResolvedValue([]);
+			workflowsListStore.fetchWorkflowsPage.mockResolvedValue([]);
 
 			renderComponent({ pinia });
 			await waitAllPromises();
 
-			expect(workflowsStore.fetchWorkflowsPage).toHaveBeenCalledWith(
+			expect(workflowsListStore.fetchWorkflowsPage).toHaveBeenCalledWith(
 				expect.any(String),
 				expect.any(Number),
 				expect.any(Number),
@@ -260,12 +260,12 @@ describe('WorkflowsView', () => {
 		it('should set active status filter based on query parameters', async () => {
 			await router.replace({ query: { status: 'true' } });
 
-			workflowsStore.fetchWorkflowsPage.mockResolvedValue([]);
+			workflowsListStore.fetchWorkflowsPage.mockResolvedValue([]);
 
 			renderComponent({ pinia });
 			await waitAllPromises();
 
-			expect(workflowsStore.fetchWorkflowsPage).toHaveBeenCalledWith(
+			expect(workflowsListStore.fetchWorkflowsPage).toHaveBeenCalledWith(
 				expect.any(String),
 				expect.any(Number),
 				expect.any(Number),
@@ -282,12 +282,12 @@ describe('WorkflowsView', () => {
 		it('should set deactivated status filter based on query parameters', async () => {
 			await router.replace({ query: { status: 'false' } });
 
-			workflowsStore.fetchWorkflowsPage.mockResolvedValue([]);
+			workflowsListStore.fetchWorkflowsPage.mockResolvedValue([]);
 
 			renderComponent({ pinia });
 			await waitAllPromises();
 
-			expect(workflowsStore.fetchWorkflowsPage).toHaveBeenCalledWith(
+			expect(workflowsListStore.fetchWorkflowsPage).toHaveBeenCalledWith(
 				expect.any(String),
 				expect.any(Number),
 				expect.any(Number),
@@ -304,12 +304,12 @@ describe('WorkflowsView', () => {
 		it('should unset isArchived filter based on query parameters', async () => {
 			await router.replace({ query: { showArchived: 'true' } });
 
-			workflowsStore.fetchWorkflowsPage.mockResolvedValue([]);
+			workflowsListStore.fetchWorkflowsPage.mockResolvedValue([]);
 
 			renderComponent({ pinia });
 			await waitAllPromises();
 
-			expect(workflowsStore.fetchWorkflowsPage).toHaveBeenCalledWith(
+			expect(workflowsListStore.fetchWorkflowsPage).toHaveBeenCalledWith(
 				expect.any(String),
 				expect.any(Number),
 				expect.any(Number),
@@ -325,7 +325,7 @@ describe('WorkflowsView', () => {
 		it('should reset filters', async () => {
 			await router.replace({ query: { status: 'true' } });
 
-			workflowsStore.fetchWorkflowsPage.mockResolvedValue([]);
+			workflowsListStore.fetchWorkflowsPage.mockResolvedValue([]);
 
 			const { queryByTestId, getByTestId } = renderComponent({ pinia });
 			await waitAllPromises();
@@ -342,7 +342,7 @@ describe('WorkflowsView', () => {
 
 		it('should remove incomplete properties', async () => {
 			await router.replace({ query: { tags: '' } });
-			workflowsStore.fetchWorkflowsPage.mockResolvedValue([]);
+			workflowsListStore.fetchWorkflowsPage.mockResolvedValue([]);
 			renderComponent({ pinia });
 			await waitAllPromises();
 			await waitFor(() => expect(router.currentRoute.value.query).toStrictEqual({}));
@@ -350,7 +350,7 @@ describe('WorkflowsView', () => {
 
 		it('should remove invalid tags', async () => {
 			await router.replace({ query: { tags: 'non-existing-tag' } });
-			workflowsStore.fetchWorkflowsPage.mockResolvedValue([]);
+			workflowsListStore.fetchWorkflowsPage.mockResolvedValue([]);
 			const tagStore = mockedStore(useTagsStore);
 			tagStore.allTags = [{ id: 'test-tag', name: 'tag' }];
 			renderComponent({ pinia });
@@ -360,7 +360,7 @@ describe('WorkflowsView', () => {
 
 		it('should show archived only hint', async () => {
 			foldersStore.totalWorkflowCount = 1;
-			workflowsStore.fetchWorkflowsPage.mockResolvedValue([]);
+			workflowsListStore.fetchWorkflowsPage.mockResolvedValue([]);
 			const { getByTestId } = renderComponent({ pinia });
 			await waitAllPromises();
 
@@ -378,10 +378,10 @@ describe('WorkflowsView', () => {
 			foldersStore = mockedStore(useFoldersStore);
 			foldersStore.totalWorkflowCount = 0;
 			foldersStore.fetchTotalWorkflowsAndFoldersCount.mockResolvedValue(0);
-			workflowsStore = mockedStore(useWorkflowsStore);
+			workflowsListStore = mockedStore(useWorkflowsListStore);
 
-			workflowsStore.fetchWorkflowsPage.mockResolvedValue([]);
-			workflowsStore.fetchActiveWorkflows.mockResolvedValue([]);
+			workflowsListStore.fetchWorkflowsPage.mockResolvedValue([]);
+			workflowsListStore.fetchActiveWorkflows.mockResolvedValue([]);
 		});
 		it('should reinitialize on source control pullWorkfolder', async () => {
 			vi.spyOn(usersApi, 'getUsers').mockResolvedValue({
@@ -407,7 +407,7 @@ describe('Folders', () => {
 		await router.isReady();
 		pinia = createTestingPinia({ initialState });
 		foldersStore = mockedStore(useFoldersStore);
-		workflowsStore = mockedStore(useWorkflowsStore);
+		workflowsListStore = mockedStore(useWorkflowsListStore);
 		settingsStore = mockedStore(useSettingsStore);
 
 		settingsStore.isFoldersFeatureEnabled = true;
@@ -457,11 +457,11 @@ describe('Folders', () => {
 			href: '/projects/1/folders/1',
 		});
 		foldersStore.totalWorkflowCount = 2;
-		workflowsStore.fetchWorkflowsPage.mockResolvedValue([
+		workflowsListStore.fetchWorkflowsPage.mockResolvedValue([
 			TEST_WORKFLOW_RESOURCE,
 			TEST_FOLDER_RESOURCE,
 		]);
-		workflowsStore.fetchActiveWorkflows.mockResolvedValue([]);
+		workflowsListStore.fetchActiveWorkflows.mockResolvedValue([]);
 		const { getByTestId } = renderComponent({
 			pinia,
 		});
@@ -476,7 +476,7 @@ describe('Folders', () => {
 		vi.spyOn(projectPages, 'isOverviewSubPage', 'get').mockReturnValue(false);
 		vi.spyOn(projectPages, 'isSharedSubPage', 'get').mockReturnValue(false);
 
-		workflowsStore.fetchWorkflowsPage.mockResolvedValue([TEST_WORKFLOW_RESOURCE]);
+		workflowsListStore.fetchWorkflowsPage.mockResolvedValue([TEST_WORKFLOW_RESOURCE]);
 		const { getByTestId } = renderComponent({
 			pinia,
 		});
@@ -489,7 +489,7 @@ describe('Folders', () => {
 		vi.spyOn(projectPages, 'isOverviewSubPage', 'get').mockReturnValue(true);
 		vi.spyOn(projectPages, 'isSharedSubPage', 'get').mockReturnValue(false);
 
-		workflowsStore.fetchWorkflowsPage.mockResolvedValue([TEST_WORKFLOW_RESOURCE]);
+		workflowsListStore.fetchWorkflowsPage.mockResolvedValue([TEST_WORKFLOW_RESOURCE]);
 		const { queryByTestId } = renderComponent({
 			pinia,
 		});
@@ -502,7 +502,7 @@ describe('Folders', () => {
 		vi.spyOn(projectPages, 'isOverviewSubPage', 'get').mockReturnValue(false);
 		vi.spyOn(projectPages, 'isSharedSubPage', 'get').mockReturnValue(true);
 
-		workflowsStore.fetchWorkflowsPage.mockResolvedValue([TEST_WORKFLOW_RESOURCE]);
+		workflowsListStore.fetchWorkflowsPage.mockResolvedValue([TEST_WORKFLOW_RESOURCE]);
 		const { queryByTestId } = renderComponent({
 			pinia,
 		});
@@ -518,10 +518,10 @@ describe('Simplified Layout', () => {
 		await router.isReady();
 		pinia = createTestingPinia({ initialState });
 		foldersStore = mockedStore(useFoldersStore);
-		workflowsStore = mockedStore(useWorkflowsStore);
+		workflowsListStore = mockedStore(useWorkflowsListStore);
 
-		workflowsStore.fetchWorkflowsPage.mockResolvedValue([]);
-		workflowsStore.fetchActiveWorkflows.mockResolvedValue([]);
+		workflowsListStore.fetchWorkflowsPage.mockResolvedValue([]);
+		workflowsListStore.fetchActiveWorkflows.mockResolvedValue([]);
 		foldersStore.totalWorkflowCount = 0;
 		foldersStore.fetchTotalWorkflowsAndFoldersCount.mockResolvedValue(0);
 	});

--- a/packages/frontend/editor-ui/src/app/views/WorkflowsView.vue
+++ b/packages/frontend/editor-ui/src/app/views/WorkflowsView.vue
@@ -58,6 +58,7 @@ import { useUIStore } from '@/app/stores/ui.store';
 import { useUsageStore } from '@/features/settings/usage/usage.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import {
 	type Project,
 	type ProjectSharingData,
@@ -123,6 +124,7 @@ const folderHelpers = useFolders();
 const sourceControlStore = useSourceControlStore();
 const usersStore = useUsersStore();
 const workflowsStore = useWorkflowsStore();
+const workflowsListStore = useWorkflowsListStore();
 const settingsStore = useSettingsStore();
 const projectsStore = useProjectsStore();
 const telemetry = useTelemetry();
@@ -587,7 +589,7 @@ const initialize = async () => {
 	const [, resourcesPage] = await Promise.all([
 		usersStore.fetchUsers(),
 		fetchWorkflows(),
-		workflowsStore.fetchActiveWorkflows(),
+		workflowsListStore.fetchActiveWorkflows(),
 		usageStore.getLicenseInfo(),
 		foldersStore.fetchTotalWorkflowsAndFoldersCount(
 			route.params.projectId as string | undefined,
@@ -631,7 +633,7 @@ const fetchWorkflows = async () => {
 	const fetchFolders = showFolders.value && !tags.length && activeFilter === undefined;
 
 	try {
-		const fetchedResources = await workflowsStore.fetchWorkflowsPage(
+		const fetchedResources = await workflowsListStore.fetchWorkflowsPage(
 			routeProjectId ?? homeProjectFilter,
 			currentPage.value,
 			pageSize.value,
@@ -995,7 +997,7 @@ const onWorkflowActiveToggle = async (data: { id: string; active: boolean }) => 
 
 	// Fetch the updated workflow to get the latest settings
 	try {
-		const updatedWorkflow = await workflowsStore.fetchWorkflow(data.id);
+		const updatedWorkflow = await workflowsListStore.fetchWorkflow(data.id);
 		if (updatedWorkflow.settings) {
 			workflow.settings = updatedWorkflow.settings;
 		}
@@ -1765,7 +1767,7 @@ const onNameSubmit = async (name: string) => {
 		:loading="false"
 		:resources-refreshing="loading"
 		:custom-page-size="DEFAULT_WORKFLOW_PAGE_SIZE"
-		:total-items="workflowsStore.totalWorkflowCount"
+		:total-items="workflowsListStore.totalWorkflowCount"
 		:dont-perform-sorting-and-filtering="true"
 		:has-empty-state="foldersStore.totalWorkflowCount === 0 && !currentFolderId"
 		@click:add="addWorkflow"

--- a/packages/frontend/editor-ui/src/experiments/personalizedTemplatesV3/stores/personalizedTemplatesV3.store.ts
+++ b/packages/frontend/editor-ui/src/experiments/personalizedTemplatesV3/stores/personalizedTemplatesV3.store.ts
@@ -4,7 +4,7 @@ import { useCloudPlanStore } from '@/app/stores/cloudPlan.store';
 import { usePostHog } from '@/app/stores/posthog.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useTemplatesStore } from '@/features/workflows/templates/templates.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { STORES } from '@n8n/stores';
 import { defineStore } from 'pinia';
 import { computed, ref, watch } from 'vue';
@@ -15,7 +15,7 @@ export const usePersonalizedTemplatesV3Store = defineStore(STORES.PERSONALIZED_T
 	const cloudPlanStore = useCloudPlanStore();
 	const settingsStore = useSettingsStore();
 	const templatesStore = useTemplatesStore();
-	const workflowsStore = useWorkflowsStore();
+	const workflowsListStore = useWorkflowsListStore();
 
 	const INTERACTION_STORAGE_KEY = 'n8n-personalizedTemplatesV3-hasInteracted';
 
@@ -46,7 +46,7 @@ export const usePersonalizedTemplatesV3Store = defineStore(STORES.PERSONALIZED_T
 	});
 
 	const shouldShowTemplateTooltip = computed(() => {
-		const allWorkflows = workflowsStore.allWorkflows;
+		const allWorkflows = workflowsListStore.allWorkflows;
 
 		return (
 			isFeatureEnabled() &&

--- a/packages/frontend/editor-ui/src/experiments/utils.test.ts
+++ b/packages/frontend/editor-ui/src/experiments/utils.test.ts
@@ -23,9 +23,8 @@ vi.mock('@/app/stores/cloudPlan.store', () => ({
 	})),
 }));
 
-vi.mock('@/app/stores/workflows.store', () => ({
-	useWorkflowsStore: vi.fn(() => ({
-		userIsTrialing: isTrialing,
+vi.mock('@/app/stores/workflowsList.store', () => ({
+	useWorkflowsListStore: vi.fn(() => ({
 		activeWorkflows: [1, 2, 3],
 	})),
 }));

--- a/packages/frontend/editor-ui/src/experiments/utils.ts
+++ b/packages/frontend/editor-ui/src/experiments/utils.ts
@@ -2,7 +2,7 @@ import { useTelemetry } from '@/app/composables/useTelemetry';
 import { EXTRA_TEMPLATE_LINKS_EXPERIMENT } from '@/app/constants';
 import { useCloudPlanStore } from '@/app/stores/cloudPlan.store';
 import { usePostHog } from '@/app/stores/posthog.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 
 /*
  * Extra template links
@@ -56,7 +56,7 @@ export const getTemplatePathByRole = (role: string | null | undefined) => {
 export const trackTemplatesClick = (source: TemplateClickSource) => {
 	useTelemetry().track('User clicked on templates', {
 		role: useCloudPlanStore().currentUserCloudInfo?.role,
-		active_workflow_count: useWorkflowsStore().activeWorkflows.length,
+		active_workflow_count: useWorkflowsListStore().activeWorkflows.length,
 		source,
 	});
 };

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/AskAssistantBuild.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/AskAssistantBuild.test.ts
@@ -132,6 +132,7 @@ import { useBuilderStore } from '../../builder.store';
 import { mockedStore } from '@/__tests__/utils';
 import { STORES } from '@n8n/stores';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useHistoryStore } from '@/app/stores/history.store';
 import type { INodeUi } from '@/Interface';
 import { useUsersStore } from '@/features/settings/users/users.store';
@@ -221,6 +222,7 @@ describe('AskAssistantBuild', () => {
 	const renderComponent = createComponentRenderer(AskAssistantBuild);
 	let builderStore: ReturnType<typeof mockedStore<typeof useBuilderStore>>;
 	let workflowsStore: ReturnType<typeof mockedStore<typeof useWorkflowsStore>>;
+	let workflowsListStore: ReturnType<typeof mockedStore<typeof useWorkflowsListStore>>;
 	let historyStore: ReturnType<typeof mockedStore<typeof useHistoryStore>>;
 	let collaborationStore: ReturnType<typeof mockedStore<typeof useCollaborationStore>>;
 
@@ -270,6 +272,7 @@ describe('AskAssistantBuild', () => {
 		setActivePinia(pinia);
 		builderStore = mockedStore(useBuilderStore);
 		workflowsStore = mockedStore(useWorkflowsStore);
+		workflowsListStore = mockedStore(useWorkflowsListStore);
 		historyStore = mockedStore(useHistoryStore);
 		collaborationStore = mockedStore(useCollaborationStore);
 
@@ -451,7 +454,7 @@ describe('AskAssistantBuild', () => {
 		it('should initialize builder chat when a user sends a message', async () => {
 			// Mock empty workflow to ensure initialGeneration is true
 			workflowsStore.$patch({ workflow: { nodes: [], connections: {} } });
-			workflowsStore.$patch({ workflowsById: { abc123: { id: 'abc123' } } });
+			workflowsListStore.$patch({ workflowsById: { abc123: { id: 'abc123' } } });
 
 			const { container } = renderComponent();
 			const testMessage = 'Create a workflow to send emails';
@@ -472,7 +475,7 @@ describe('AskAssistantBuild', () => {
 
 		it('should request write access when sending a message', async () => {
 			workflowsStore.$patch({ workflow: { nodes: [], connections: {} } });
-			workflowsStore.$patch({ workflowsById: { abc123: { id: 'abc123' } } });
+			workflowsListStore.$patch({ workflowsById: { abc123: { id: 'abc123' } } });
 
 			const { container } = renderComponent();
 			const testMessage = 'Create a workflow';
@@ -666,7 +669,7 @@ describe('AskAssistantBuild', () => {
 		it('should reset initialGeneration flag when streaming ends and workflow has nodes', async () => {
 			// Setup: empty workflow
 			workflowsStore.$patch({ workflow: { nodes: [], connections: {} } });
-			workflowsStore.$patch({ workflowsById: { abc123: { id: 'abc123' } } });
+			workflowsListStore.$patch({ workflowsById: { abc123: { id: 'abc123' } } });
 
 			renderComponent();
 
@@ -705,7 +708,7 @@ describe('AskAssistantBuild', () => {
 		it('should NOT reset initialGeneration flag when workflow is still empty', async () => {
 			// Setup: empty workflow
 			workflowsStore.$patch({ workflow: { nodes: [], connections: {} } });
-			workflowsStore.$patch({ workflowsById: { abc123: { id: 'abc123' } } });
+			workflowsListStore.$patch({ workflowsById: { abc123: { id: 'abc123' } } });
 
 			renderComponent();
 
@@ -1082,7 +1085,7 @@ describe('AskAssistantBuild', () => {
 
 		it('should reset accumulated node IDs on new user message', async () => {
 			workflowsStore.$patch({ workflow: { nodes: [], connections: {} } });
-			workflowsStore.$patch({ workflowsById: { abc123: { id: 'abc123' } } });
+			workflowsListStore.$patch({ workflowsById: { abc123: { id: 'abc123' } } });
 
 			const { container } = renderComponent();
 

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsRootView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsRootView.test.ts
@@ -5,6 +5,7 @@ import { createComponentRenderer } from '@/__tests__/render';
 import EvaluationRootView from './EvaluationsRootView.vue';
 
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useEvaluationStore } from '../evaluation.store';
 import { useUsageStore } from '@/features/settings/usage/usage.store';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
@@ -110,6 +111,7 @@ describe('EvaluationsRootView', () => {
 
 	it('should initialize workflow on mount if not already initialized', async () => {
 		const workflowsStore = mockedStore(useWorkflowsStore);
+		const workflowsListStore = mockedStore(useWorkflowsListStore);
 		const usageStore = mockedStore(useUsageStore);
 		const evaluationStore = mockedStore(useEvaluationStore);
 
@@ -120,23 +122,26 @@ describe('EvaluationsRootView', () => {
 		// Mock the async operations that run before fetchWorkflow
 		usageStore.getLicenseInfo.mockResolvedValue(undefined);
 		evaluationStore.fetchTestRuns.mockResolvedValue([]);
-		workflowsStore.fetchWorkflow.mockResolvedValue(mockWorkflow);
+		workflowsListStore.fetchWorkflow.mockResolvedValue(mockWorkflow);
 		workflowsStore.isWorkflowSaved = { workflow123: true };
 
 		renderComponent({ props: { name: newWorkflowId } });
 
 		// Wait for async operation to complete
 		await flushPromises();
-		await waitFor(() => expect(workflowsStore.fetchWorkflow).toHaveBeenCalledWith(newWorkflowId));
+		await waitFor(() =>
+			expect(workflowsListStore.fetchWorkflow).toHaveBeenCalledWith(newWorkflowId),
+		);
 	});
 
 	it('should not initialize workflow if already loaded', async () => {
 		const workflowsStore = mockedStore(useWorkflowsStore);
+		const workflowsListStore = mockedStore(useWorkflowsListStore);
 		workflowsStore.workflow = mockWorkflow;
 
 		renderComponent({ props: { name: mockWorkflow.id } });
 
-		expect(workflowsStore.fetchWorkflow).not.toHaveBeenCalled();
+		expect(workflowsListStore.fetchWorkflow).not.toHaveBeenCalled();
 	});
 
 	it('should load test data', async () => {
@@ -151,8 +156,8 @@ describe('EvaluationsRootView', () => {
 	});
 
 	it('should not render setup wizard when there are test runs', async () => {
-		const workflowsStore = mockedStore(useWorkflowsStore);
-		workflowsStore.fetchWorkflow.mockResolvedValue(mockWorkflow);
+		const workflowsListStore = mockedStore(useWorkflowsListStore);
+		workflowsListStore.fetchWorkflow.mockResolvedValue(mockWorkflow);
 		const evaluationStore = mockedStore(useEvaluationStore);
 		evaluationStore.testRunsById = { foo: mock<TestRunRecord>({ workflowId: mockWorkflow.id }) };
 
@@ -164,11 +169,12 @@ describe('EvaluationsRootView', () => {
 
 	it('should render the setup wizard when there there are no test runs', async () => {
 		const workflowsStore = mockedStore(useWorkflowsStore);
+		const workflowsListStore = mockedStore(useWorkflowsListStore);
 		const usageStore = mockedStore(useUsageStore);
 		const evaluationStore = mockedStore(useEvaluationStore);
 
 		workflowsStore.workflow = mockWorkflow;
-		workflowsStore.fetchWorkflow.mockResolvedValue(mockWorkflow);
+		workflowsListStore.fetchWorkflow.mockResolvedValue(mockWorkflow);
 		usageStore.getLicenseInfo.mockResolvedValue(undefined);
 		evaluationStore.fetchTestRuns.mockResolvedValue([]);
 		evaluationStore.testRunsById = {};
@@ -181,12 +187,13 @@ describe('EvaluationsRootView', () => {
 
 	it('should render read-only callout when in protected environment', async () => {
 		const workflowsStore = mockedStore(useWorkflowsStore);
+		const workflowsListStore = mockedStore(useWorkflowsListStore);
 		const usageStore = mockedStore(useUsageStore);
 		const evaluationStore = mockedStore(useEvaluationStore);
 		const sourceControlStore = mockedStore(useSourceControlStore);
 
 		workflowsStore.workflow = mockWorkflow;
-		workflowsStore.fetchWorkflow.mockResolvedValue(mockWorkflow);
+		workflowsListStore.fetchWorkflow.mockResolvedValue(mockWorkflow);
 		usageStore.getLicenseInfo.mockResolvedValue(undefined);
 		evaluationStore.fetchTestRuns.mockResolvedValue([]);
 		evaluationStore.testRunsById = {};

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsRootView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsRootView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useUsageStore } from '@/features/settings/usage/usage.store';
 import { useAsyncState } from '@vueuse/core';
 import { EVALUATIONS_DOCS_URL } from '@/app/constants';
@@ -22,6 +23,7 @@ const props = defineProps<{
 }>();
 
 const workflowsStore = useWorkflowsStore();
+const workflowsListStore = useWorkflowsListStore();
 const usageStore = useUsageStore();
 const evaluationStore = useEvaluationStore();
 const nodeTypesStore = useNodeTypesStore();
@@ -98,9 +100,9 @@ const { isReady } = useAsyncState(async () => {
 	}
 
 	// Check if we are loading the Evaluation tab directly, without having loaded the workflow
-	if (!workflowsStore.workflowsById[workflowId]) {
+	if (!workflowsListStore.workflowsById[workflowId]) {
 		try {
-			const data = await workflowsStore.fetchWorkflow(workflowId);
+			const data = await workflowsListStore.fetchWorkflow(workflowId);
 
 			// We need to check for the evaluation node with setMetrics operation, so we need to initialize the nodeTypesStore to have node properties initialized
 			if (nodeTypesStore.allNodeTypes.length === 0) {

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/TestRunDetailView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/TestRunDetailView.vue
@@ -7,7 +7,7 @@ import { useToast } from '@/app/composables/useToast';
 import { VIEWS } from '@/app/constants';
 import type { BaseTextKey } from '@n8n/i18n';
 import { useEvaluationStore } from '../evaluation.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { convertToDisplayDate } from '@/app/utils/formatters/dateFormatter';
 import { computed, onMounted, ref } from 'vue';
 import { useRouter } from 'vue-router';
@@ -55,7 +55,7 @@ export type Header = TestTableColumn<TestCaseExecutionRecord & { index: number }
 const router = useRouter();
 const toast = useToast();
 const evaluationStore = useEvaluationStore();
-const workflowsStore = useWorkflowsStore();
+const workflowsListStore = useWorkflowsListStore();
 const locale = useI18n();
 const workflowsCache = useWorkflowSettingsCache();
 
@@ -65,7 +65,9 @@ const hasFailedTestCases = ref<boolean>(false);
 
 const runId = computed(() => router.currentRoute.value.params.runId as string);
 const workflowId = computed(() => router.currentRoute.value.params.name as string);
-const workflowName = computed(() => workflowsStore.getWorkflowById(workflowId.value)?.name ?? '');
+const workflowName = computed(
+	() => workflowsListStore.getWorkflowById(workflowId.value)?.name ?? '',
+);
 
 const cachedUserPreferences = ref<UserEvaluationPreferences | undefined>();
 const expandedRows = ref<Set<string>>(new Set());

--- a/packages/frontend/editor-ui/src/features/ai/mcpAccess/mcp.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/mcpAccess/mcp.store.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia';
 import { MCP_STORE } from './mcp.constants';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import type { WorkflowListItem } from '@/Interface';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import {
@@ -19,6 +20,7 @@ import type { ApiKey, OAuthClientResponseDto, DeleteOAuthClientResponseDto } fro
 
 export const useMCPStore = defineStore(MCP_STORE, () => {
 	const workflowsStore = useWorkflowsStore();
+	const workflowsListStore = useWorkflowsListStore();
 	const rootStore = useRootStore();
 	const settingsStore = useSettingsStore();
 
@@ -32,7 +34,7 @@ export const useMCPStore = defineStore(MCP_STORE, () => {
 		page = 1,
 		pageSize = 50,
 	): Promise<WorkflowListItem[]> {
-		const workflows = await workflowsStore.fetchWorkflowsPage(
+		const workflows = await workflowsListStore.fetchWorkflowsPage(
 			undefined, // projectId
 			page,
 			pageSize,
@@ -79,9 +81,9 @@ export const useMCPStore = defineStore(MCP_STORE, () => {
 				workflowsStore.private.setWorkflowSettings(settings);
 			}
 		}
-		if (workflowsStore.workflowsById[id]) {
-			workflowsStore.workflowsById[id] = {
-				...workflowsStore.workflowsById[id],
+		if (workflowsListStore.workflowsById[id]) {
+			workflowsListStore.workflowsById[id] = {
+				...workflowsListStore.workflowsById[id],
 				settings,
 				versionId,
 			};

--- a/packages/frontend/editor-ui/src/features/collaboration/collaboration/collaboration.store.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/collaboration/collaboration.store.ts
@@ -9,6 +9,7 @@ import { TIME } from '@/app/constants';
 import { STORES } from '@n8n/stores';
 import { useBeforeUnload } from '@/app/composables/useBeforeUnload';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { usePushConnectionStore } from '@/app/stores/pushConnection.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useUIStore } from '@/app/stores/ui.store';
@@ -29,6 +30,7 @@ const INACTIVITY_TIMEOUT_THRESHOLD = 20 * TIME.SECOND;
 export const useCollaborationStore = defineStore(STORES.COLLABORATION, () => {
 	const pushStore = usePushConnectionStore();
 	const workflowsStore = useWorkflowsStore();
+	const workflowsListStore = useWorkflowsListStore();
 	const usersStore = useUsersStore();
 	const uiStore = useUIStore();
 	const rootStore = useRootStore();
@@ -257,7 +259,7 @@ export const useCollaborationStore = defineStore(STORES.COLLABORATION, () => {
 
 		try {
 			// Fetch the latest workflow data
-			const updatedWorkflow = await workflowsStore.fetchWorkflow(workflowsStore.workflowId);
+			const updatedWorkflow = await workflowsListStore.fetchWorkflow(workflowsStore.workflowId);
 
 			// Refresh the canvas with the new workflow data
 			if (refreshCanvasCallback) {

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectMoveResourceModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectMoveResourceModal.test.ts
@@ -9,7 +9,7 @@ import { PROJECT_MOVE_RESOURCE_MODAL } from '../projects.constants';
 import ProjectMoveResourceModal from './ProjectMoveResourceModal.vue';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useProjectsStore } from '../projects.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
 import type { ComponentProps } from 'vue-component-type-helpers';
 import { ResourceType } from '../projects.utils';
@@ -29,7 +29,7 @@ const renderComponent = createComponentRenderer(ProjectMoveResourceModal, {
 
 let telemetry: ReturnType<typeof useTelemetry>;
 let projectsStore: MockedStore<typeof useProjectsStore>;
-let workflowsStore: MockedStore<typeof useWorkflowsStore>;
+let workflowsListStore: MockedStore<typeof useWorkflowsListStore>;
 let credentialsStore: MockedStore<typeof useCredentialsStore>;
 
 describe('ProjectMoveResourceModal', () => {
@@ -37,7 +37,7 @@ describe('ProjectMoveResourceModal', () => {
 		vi.clearAllMocks();
 		telemetry = useTelemetry();
 		projectsStore = mockedStore(useProjectsStore);
-		workflowsStore = mockedStore(useWorkflowsStore);
+		workflowsListStore = mockedStore(useWorkflowsListStore);
 		credentialsStore = mockedStore(useCredentialsStore);
 	});
 
@@ -45,7 +45,7 @@ describe('ProjectMoveResourceModal', () => {
 		const telemetryTrackSpy = vi.spyOn(telemetry, 'track');
 
 		projectsStore.availableProjects = [createProjectListItem()];
-		workflowsStore.fetchWorkflow.mockResolvedValueOnce(createTestWorkflow());
+		workflowsListStore.fetchWorkflow.mockResolvedValueOnce(createTestWorkflow());
 
 		const props: ComponentProps<typeof ProjectMoveResourceModal> = {
 			modalName: PROJECT_MOVE_RESOURCE_MODAL,
@@ -71,7 +71,7 @@ describe('ProjectMoveResourceModal', () => {
 
 	it('should show no available projects message', async () => {
 		projectsStore.availableProjects = [];
-		workflowsStore.fetchWorkflow.mockResolvedValueOnce(createTestWorkflow());
+		workflowsListStore.fetchWorkflow.mockResolvedValueOnce(createTestWorkflow());
 
 		const props: ComponentProps<typeof ProjectMoveResourceModal> = {
 			modalName: PROJECT_MOVE_RESOURCE_MODAL,
@@ -153,7 +153,7 @@ describe('ProjectMoveResourceModal', () => {
 			'User clicked to move a credential',
 			expect.objectContaining({ credential_id: '1' }),
 		);
-		expect(workflowsStore.fetchWorkflow).not.toHaveBeenCalled();
+		expect(workflowsListStore.fetchWorkflow).not.toHaveBeenCalled();
 		expect(getByText(/Moving will remove any existing sharing for this credential/)).toBeVisible();
 	});
 
@@ -180,7 +180,7 @@ describe('ProjectMoveResourceModal', () => {
 
 		projectsStore.currentProjectId = currentProjectId;
 		projectsStore.availableProjects = [destinationProject];
-		workflowsStore.fetchWorkflow.mockResolvedValueOnce(movedWorkflow);
+		workflowsListStore.fetchWorkflow.mockResolvedValueOnce(movedWorkflow);
 		credentialsStore.fetchAllCredentials.mockResolvedValueOnce([
 			{
 				id: '1',
@@ -246,7 +246,7 @@ describe('ProjectMoveResourceModal', () => {
 	it('should prevent duplicate submissions when button clicked multiple times', async () => {
 		const destinationProject = createProjectListItem();
 		projectsStore.availableProjects = [destinationProject];
-		workflowsStore.fetchWorkflow.mockResolvedValueOnce(createTestWorkflow());
+		workflowsListStore.fetchWorkflow.mockResolvedValueOnce(createTestWorkflow());
 
 		// Make moveResourceToProject take time to simulate slow operation
 		let resolveMove: () => void;

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectMoveResourceModal.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectMoveResourceModal.vue
@@ -14,7 +14,7 @@ import { getResourcePermissions } from '@n8n/permissions';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
 import { useProjectsStore } from '../projects.store';
 import { useUIStore } from '@/app/stores/ui.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { ProjectTypes } from '../projects.types';
 import {
 	getTruncatedProjectName,
@@ -55,7 +55,7 @@ const uiStore = useUIStore();
 const toast = useToast();
 const router = useRouter();
 const projectsStore = useProjectsStore();
-const workflowsStore = useWorkflowsStore();
+const workflowsListStore = useWorkflowsListStore();
 const credentialsStore = useCredentialsStore();
 const telemetry = useTelemetry();
 
@@ -212,7 +212,7 @@ onMounted(async () => {
 
 	if (isResourceWorkflow.value) {
 		const [workflow, credentials] = await Promise.all([
-			workflowsStore.fetchWorkflow(props.data.resource.id),
+			workflowsListStore.fetchWorkflow(props.data.resource.id),
 			credentialsStore.fetchAllCredentials(),
 		]);
 

--- a/packages/frontend/editor-ui/src/features/core/folders/components/MoveToFolderModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/folders/components/MoveToFolderModal.test.ts
@@ -24,7 +24,7 @@ import type {
 } from '@/features/credentials/credentials.types';
 import type { ChangeLocationSearchResult } from '../folders.types';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useFoldersStore } from '../folders.store';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import MoveToFolderModal from './MoveToFolderModal.vue';
@@ -71,7 +71,7 @@ const TEST_WORKFLOW_RESOURCE = {
 let uiStore: MockedStore<typeof useUIStore>;
 let settingsStore: MockedStore<typeof useSettingsStore>;
 let credentialsStore: MockedStore<typeof useCredentialsStore>;
-let workflowsStore: MockedStore<typeof useWorkflowsStore>;
+let workflowsListStore: MockedStore<typeof useWorkflowsListStore>;
 let foldersStore: MockedStore<typeof useFoldersStore>;
 let projectsStore: MockedStore<typeof useProjectsStore>;
 
@@ -161,8 +161,8 @@ describe('MoveToFolderModal', () => {
 		credentialsStore = mockedStore(useCredentialsStore);
 		credentialsStore.fetchAllCredentials = vi.fn().mockResolvedValue([]);
 
-		workflowsStore = mockedStore(useWorkflowsStore);
-		workflowsStore.fetchWorkflow = vi.fn().mockResolvedValue({
+		workflowsListStore = mockedStore(useWorkflowsListStore);
+		workflowsListStore.fetchWorkflow = vi.fn().mockResolvedValue({
 			id: TEST_WORKFLOW_RESOURCE.id,
 			name: TEST_WORKFLOW_RESOURCE.name,
 			parentFolderId: TEST_WORKFLOW_RESOURCE.parentFolderId,
@@ -683,7 +683,7 @@ describe('MoveToFolderModal', () => {
 		});
 		await waitFor(() => expect(getByTestId('moveFolder-modal')).toBeInTheDocument());
 		expect(screen.getByText(`Move workflow ${TEST_WORKFLOW_RESOURCE.name}`)).toBeInTheDocument();
-		expect(workflowsStore.fetchWorkflow).toHaveBeenCalledWith(TEST_WORKFLOW_RESOURCE.id);
+		expect(workflowsListStore.fetchWorkflow).toHaveBeenCalledWith(TEST_WORKFLOW_RESOURCE.id);
 	});
 
 	it('should move selected workflow on submit', async () => {

--- a/packages/frontend/editor-ui/src/features/core/folders/components/MoveToFolderModal.vue
+++ b/packages/frontend/editor-ui/src/features/core/folders/components/MoveToFolderModal.vue
@@ -29,7 +29,7 @@ import {
 	ResourceType,
 	getTruncatedProjectName,
 } from '@/features/collaboration/projects/projects.utils';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { I18nT } from 'vue-i18n';
 
 import { N8nButton, N8nCallout, N8nCheckbox, N8nText, N8nTooltip } from '@n8n/design-system';
@@ -68,7 +68,7 @@ const foldersStore = useFoldersStore();
 const projectsStore = useProjectsStore();
 const uiStore = useUIStore();
 const credentialsStore = useCredentialsStore();
-const workflowsStore = useWorkflowsStore();
+const workflowsListStore = useWorkflowsListStore();
 
 const selectedFolder = ref<ChangeLocationSearchResult | null>(null);
 const selectedProject = ref<ProjectSharingData | null>(projectsStore.currentProject);
@@ -329,7 +329,7 @@ onMounted(async () => {
 	}
 	if (isResourceWorkflow.value) {
 		const [workflow, credentials] = await Promise.all([
-			workflowsStore.fetchWorkflow(props.data.resource.id),
+			workflowsListStore.fetchWorkflow(props.data.resource.id),
 			credentialsStore.fetchAllCredentials(),
 		]);
 

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/global/GlobalExecutionsList.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/global/GlobalExecutionsList.vue
@@ -7,6 +7,7 @@ import { useToast } from '@/app/composables/useToast';
 import { EnterpriseEditionFeature, MODAL_CONFIRM } from '@/app/constants';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import type { IWorkflowDb } from '@/Interface';
 import { useI18n } from '@n8n/i18n';
 import type { PermissionsRecord } from '@n8n/permissions';
@@ -47,6 +48,7 @@ const emit = defineEmits<{
 const i18n = useI18n();
 const telemetry = useTelemetry();
 const workflowsStore = useWorkflowsStore();
+const workflowsListStore = useWorkflowsListStore();
 const executionsStore = useExecutionsStore();
 const settingsStore = useSettingsStore();
 const pageRedirectionHelper = usePageRedirectionHelper();
@@ -72,7 +74,7 @@ const workflows = computed<IWorkflowDb[]>(() => {
 			id: 'all',
 			name: i18n.baseText('executionsList.allWorkflows'),
 		} as IWorkflowDb,
-		...workflowsStore.allWorkflows,
+		...workflowsListStore.allWorkflows,
 	];
 });
 

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionAnnotationPanel.ee.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionAnnotationPanel.ee.vue
@@ -3,7 +3,7 @@ import { computed, ref } from 'vue';
 import type { ExecutionSummary } from 'n8n-workflow';
 import { useI18n } from '@n8n/i18n';
 import { getResourcePermissions } from '@n8n/permissions';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useRoute } from 'vue-router';
 
 import { ElDropdown } from 'element-plus';
@@ -14,7 +14,7 @@ const props = defineProps<{
 	};
 }>();
 
-const workflowsStore = useWorkflowsStore();
+const workflowsListStore = useWorkflowsListStore();
 const route = useRoute();
 const i18n = useI18n();
 
@@ -23,7 +23,8 @@ const isDropdownVisible = ref(false);
 
 const workflowId = computed(() => route.params.name as string);
 const workflowPermissions = computed(
-	() => getResourcePermissions(workflowsStore.getWorkflowById(workflowId.value)?.scopes).workflow,
+	() =>
+		getResourcePermissions(workflowsListStore.getWorkflowById(workflowId.value)?.scopes).workflow,
 );
 
 const customDataLength = computed(() => {

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsPreview.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsPreview.test.ts
@@ -6,7 +6,7 @@ import { randomInt, type ExecutionSummary, type AnnotationVote } from 'n8n-workf
 import { useSettingsStore } from '@/app/stores/settings.store';
 import WorkflowExecutionsPreview from './WorkflowExecutionsPreview.vue';
 import { EnterpriseEditionFeature, VIEWS } from '@/app/constants';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import type { IWorkflowDb } from '@/Interface';
 import type { ExecutionSummaryWithScopes } from '../../executions.types';
 import { createComponentRenderer } from '@/__tests__/render';
@@ -111,14 +111,14 @@ describe('WorkflowExecutionsPreview.vue', () => {
 		'when debug enterprise feature is %s with workflow scopes %s it should handle debug link click accordingly',
 		async (availability, scopes, path) => {
 			const settingsStore = mockedStore(useSettingsStore);
-			const workflowsStore = mockedStore(useWorkflowsStore);
+			const workflowsListStore = mockedStore(useWorkflowsListStore);
 
 			settingsStore.settings.enterprise = {
 				...(settingsStore.settings.enterprise ?? {}),
 				[EnterpriseEditionFeature.DebugInEditor]: availability,
 			} as FrontendSettings['enterprise'];
 
-			workflowsStore.workflowsById[executionData.workflowId] = { scopes } as IWorkflowDb;
+			workflowsListStore.workflowsById[executionData.workflowId] = { scopes } as IWorkflowDb;
 
 			await router.push(path);
 

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsPreview.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsPreview.vue
@@ -11,7 +11,7 @@ import { useMessage } from '@/app/composables/useMessage';
 import { EnterpriseEditionFeature, MODAL_CONFIRM, VIEWS } from '@/app/constants';
 import { getResourcePermissions } from '@n8n/permissions';
 import { useSettingsStore } from '@/app/stores/settings.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import type { AnnotationVote, ExecutionSummary } from 'n8n-workflow';
 import { computed, ref } from 'vue';
 import { useRoute } from 'vue-router';
@@ -40,12 +40,13 @@ const { showError } = useToast();
 const executionHelpers = useExecutionHelpers();
 const message = useMessage();
 const executionDebugging = useExecutionDebugging();
-const workflowsStore = useWorkflowsStore();
+const workflowsListStore = useWorkflowsListStore();
 const settingsStore = useSettingsStore();
 const retryDropdownRef = ref<RetryDropdownRef | null>(null);
 const workflowId = computed(() => route.params.name as string);
 const workflowPermissions = computed(
-	() => getResourcePermissions(workflowsStore.getWorkflowById(workflowId.value)?.scopes).workflow,
+	() =>
+		getResourcePermissions(workflowsListStore.getWorkflowById(workflowId.value)?.scopes).workflow,
 );
 const executionId = computed(() => route.params.executionId as string);
 const nodeId = computed(() => route.params.nodeId as string);

--- a/packages/frontend/editor-ui/src/features/execution/executions/views/ExecutionsView.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/views/ExecutionsView.vue
@@ -12,6 +12,7 @@ import InsightsSummary from '@/features/execution/insights/components/InsightsSu
 import { useInsightsStore } from '@/features/execution/insights/insights.store';
 import { useExecutionsStore } from '../executions.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { storeToRefs } from 'pinia';
 import { onBeforeMount, onBeforeUnmount, onMounted } from 'vue';
 import { useRoute } from 'vue-router';
@@ -21,6 +22,7 @@ const i18n = useI18n();
 const telemetry = useTelemetry();
 const externalHooks = useExternalHooks();
 const workflowsStore = useWorkflowsStore();
+const workflowsListStore = useWorkflowsListStore();
 const executionsStore = useExecutionsStore();
 const insightsStore = useInsightsStore();
 const documentTitle = useDocumentTitle();
@@ -58,7 +60,7 @@ onBeforeUnmount(() => {
 
 async function loadWorkflows() {
 	try {
-		await workflowsStore.fetchAllWorkflows(route.params?.projectId as string | undefined);
+		await workflowsListStore.fetchAllWorkflows(route.params?.projectId as string | undefined);
 	} catch (error) {
 		toast.showError(error, i18n.baseText('executionsList.showError.loadWorkflows.title'));
 	}

--- a/packages/frontend/editor-ui/src/features/execution/executions/views/WorkflowExecutionsView.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/views/WorkflowExecutionsView.vue
@@ -6,6 +6,7 @@ import { useI18n } from '@n8n/i18n';
 import type { ExecutionFilterType } from '../executions.types';
 import type { IWorkflowDb } from '@/Interface';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { NO_NETWORK_ERROR_CODE } from '@n8n/rest-api-client';
@@ -20,6 +21,7 @@ import { executionRetryMessage } from '../executions.utils';
 
 const executionsStore = useExecutionsStore();
 const workflowsStore = useWorkflowsStore();
+const workflowsListStore = useWorkflowsListStore();
 const nodeTypesStore = useNodeTypesStore();
 const projectsStore = useProjectsStore();
 const i18n = useI18n();
@@ -150,21 +152,21 @@ async function fetchWorkflow() {
 
 	// Check if we are loading the Executions tab directly, without having loaded the workflow
 	if (workflowId.value) {
-		if (!workflowsStore.workflowsById[workflowId.value]) {
+		if (!workflowsListStore.workflowsById[workflowId.value]) {
 			try {
-				await workflowsStore.fetchActiveWorkflows();
-				const data = await workflowsStore.fetchWorkflow(workflowId.value);
+				await workflowsListStore.fetchActiveWorkflows();
+				const data = await workflowsListStore.fetchWorkflow(workflowId.value);
 				await initializeWorkspace(data);
 			} catch (error) {
 				toast.showError(error, i18n.baseText('nodeView.showError.openWorkflow.title'));
 			}
 
-			workflow.value = workflowsStore.getWorkflowById(workflowId.value);
-			const workflowData = await workflowsStore.fetchWorkflow(workflow.value.id);
+			workflow.value = workflowsListStore.getWorkflowById(workflowId.value);
+			const workflowData = await workflowsListStore.fetchWorkflow(workflow.value.id);
 
 			await projectsStore.setProjectNavActiveIdByWorkflowHomeProject(workflowData.homeProject);
 		} else {
-			workflow.value = workflowsStore.workflowsById[workflowId.value];
+			workflow.value = workflowsListStore.workflowsById[workflowId.value];
 		}
 	}
 }

--- a/packages/frontend/editor-ui/src/features/execution/logs/composables/useLogsExecutionData.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/composables/useLogsExecutionData.test.ts
@@ -4,6 +4,7 @@ import { waitFor } from '@testing-library/vue';
 import { createTestingPinia } from '@pinia/testing';
 import { mockedStore, waitAllPromises } from '@/__tests__/utils';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { nodeTypes } from '../__test__/data';
 import {
@@ -36,12 +37,14 @@ let workflowState: WorkflowState;
 
 describe(useLogsExecutionData, () => {
 	let workflowsStore: ReturnType<typeof mockedStore<typeof useWorkflowsStore>>;
+	let workflowsListStore: ReturnType<typeof mockedStore<typeof useWorkflowsListStore>>;
 	let nodeTypeStore: ReturnType<typeof mockedStore<typeof useNodeTypesStore>>;
 
 	beforeEach(() => {
 		setActivePinia(createTestingPinia({ stubActions: false }));
 
 		workflowsStore = mockedStore(useWorkflowsStore);
+		workflowsListStore = mockedStore(useWorkflowsListStore);
 
 		workflowState = useWorkflowState();
 		vi.mocked(injectWorkflowState).mockReturnValue(workflowState);
@@ -146,7 +149,7 @@ describe(useLogsExecutionData, () => {
 				typeof useToastMock
 			>);
 
-			workflowsStore.fetchWorkflow.mockResolvedValueOnce(createTestWorkflow());
+			workflowsListStore.fetchWorkflow.mockResolvedValueOnce(createTestWorkflow());
 			workflowsStore.fetchExecutionDataById.mockRejectedValueOnce(
 				new Error('test execution fetch fail'),
 			);

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.test.ts
@@ -17,7 +17,7 @@ import {
 	createTestWorkflowObject,
 	createTestNodeProperties,
 } from '@/__tests__/mocks';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { NodeConnectionTypes, type INodeParameterResourceLocator } from 'n8n-workflow';
 import type { IWorkflowDb, WorkflowListResource } from '@/Interface';
 import { mock } from 'vitest-mock-extended';
@@ -122,7 +122,7 @@ const renderComponent = createComponentRenderer(ParameterInput, {
 });
 
 const settingsStore = mockedStore(useSettingsStore);
-const workflowsStore = mockedStore(useWorkflowsStore);
+const workflowsListStore = mockedStore(useWorkflowsListStore);
 
 describe('ParameterInput.vue', () => {
 	beforeEach(() => {
@@ -425,7 +425,7 @@ describe('ParameterInput.vue', () => {
 			value: workflowId,
 		};
 
-		workflowsStore.fetchWorkflowsPage.mockResolvedValue([
+		workflowsListStore.fetchWorkflowsPage.mockResolvedValue([
 			mock<WorkflowListResource>({
 				id: workflowId,
 				name: 'Test',
@@ -487,8 +487,10 @@ describe('ParameterInput.vue', () => {
 			updatedAt: new Date().toISOString(),
 			versionId: faker.string.uuid(),
 		};
-		workflowsStore.allWorkflows = [mock<IWorkflowDb>(workflowBase)];
-		workflowsStore.fetchWorkflowsPage.mockResolvedValue([mock<WorkflowListResource>(workflowBase)]);
+		workflowsListStore.allWorkflows = [mock<IWorkflowDb>(workflowBase)];
+		workflowsListStore.fetchWorkflowsPage.mockResolvedValue([
+			mock<WorkflowListResource>(workflowBase),
+		]);
 
 		const { emitted, container, getByTestId } = renderComponent({
 			props: {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
@@ -81,6 +81,7 @@ import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import type { EventBus } from '@n8n/utils/event-bus';
 import { createEventBus } from '@n8n/utils/event-bus';
@@ -174,6 +175,7 @@ const telemetry = useTelemetry();
 const credentialsStore = useCredentialsStore();
 const ndvStore = useNDVStore();
 const workflowsStore = useWorkflowsStore();
+const workflowsListStore = useWorkflowsListStore();
 const workflowState = injectWorkflowState();
 const settingsStore = useSettingsStore();
 const nodeTypesStore = useNodeTypesStore();
@@ -529,7 +531,7 @@ const getIssues = computed<string[]>(() => {
 	} else if (props.parameter.type === 'workflowSelector') {
 		const selected = modelValueResourceLocator.value?.value;
 		if (selected) {
-			const isSelectedArchived = workflowsStore.allWorkflows.some(
+			const isSelectedArchived = workflowsListStore.allWorkflows.some(
 				(resource) => resource.id === selected && resource.isArchived,
 			);
 

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/WorkflowSelectorParameterInput/WorkflowSelectorParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/WorkflowSelectorParameterInput/WorkflowSelectorParameterInput.vue
@@ -2,6 +2,7 @@
 import type { ComponentPublicInstance } from 'vue';
 import { computed, ref, onMounted, onUnmounted, watch } from 'vue';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import type { EventBus } from '@n8n/utils/event-bus';
 import { createEventBus } from '@n8n/utils/event-bus';
 import type {
@@ -77,6 +78,7 @@ const emit = defineEmits<{
 }>();
 
 const workflowsStore = useWorkflowsStore();
+const workflowsListStore = useWorkflowsListStore();
 const projectStore = useProjectsStore();
 
 const router = useRouter();
@@ -180,7 +182,7 @@ function onInputChange(workflowId: NodeParameterValue): void {
 		cachedResultUrl: getWorkflowUrl(workflowId),
 	};
 	if (isListMode.value) {
-		const resource = workflowsStore.getWorkflowById(workflowId);
+		const resource = workflowsListStore.getWorkflowById(workflowId);
 		if (resource?.name) {
 			params.cachedResultName = getWorkflowName(workflowId);
 		}
@@ -231,7 +233,7 @@ async function refreshCachedWorkflow() {
 
 	const workflowId = props.modelValue.value;
 	try {
-		await workflowsStore.fetchWorkflow(`${workflowId}`);
+		await workflowsListStore.fetchWorkflow(`${workflowId}`);
 		onInputChange(workflowId);
 	} catch (e) {
 		// keep old cached value
@@ -283,7 +285,7 @@ const onAddResourceClicked = async () => {
 		const projectId = projectStore.currentProjectId;
 		const sampleWorkflow = props.sampleWorkflow;
 		const workflowName = sampleWorkflow.name ?? 'My Sub-Workflow';
-		const sampleSubWorkflows = workflowsStore.allWorkflows.filter(
+		const sampleSubWorkflows = workflowsListStore.allWorkflows.filter(
 			(w) => w.name && new RegExp(workflowName).test(w.name),
 		);
 

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/composables/useWorkflowResourcesLocator.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/composables/useWorkflowResourcesLocator.test.ts
@@ -7,6 +7,7 @@ import { useWorkflowResourcesLocator } from './useWorkflowResourcesLocator';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { type MockedStore, mockedStore } from '@/__tests__/utils';
+import { createTestWorkflow } from '@/__tests__/mocks';
 import type { IWorkflowDb } from '@/Interface';
 import type { Router } from 'vue-router';
 import { createTestingPinia } from '@pinia/testing';
@@ -41,42 +42,42 @@ describe('useWorkflowResourcesLocator', () => {
 			{
 				activeNodeName: 'Execute Workflow',
 				workflowId: 'workflow-id',
-				mockedWorkflow: { name: 'Test Workflow' },
+				mockedWorkflow: createTestWorkflow({ name: 'Test Workflow' }),
 				expectedRename: "Call 'Test Workflow'",
 				expectedCalledWith: 'Execute Workflow',
 			},
 			{
 				activeNodeName: 'Execute Workflow1',
 				workflowId: 'workflow-id',
-				mockedWorkflow: { name: 'Test Workflow' },
+				mockedWorkflow: createTestWorkflow({ name: 'Test Workflow' }),
 				expectedRename: "Call 'Test Workflow'",
 				expectedCalledWith: 'Execute Workflow1',
 			},
 			{
 				activeNodeName: 'Execute Workflow2',
 				workflowId: 'workflow-id',
-				mockedWorkflow: { name: 'Another Workflow' },
+				mockedWorkflow: createTestWorkflow({ name: 'Another Workflow' }),
 				expectedRename: "Call 'Another Workflow'",
 				expectedCalledWith: 'Execute Workflow2',
 			},
 			{
 				activeNodeName: 'Call n8n Workflow Tool',
 				workflowId: 'workflow-id',
-				mockedWorkflow: { name: 'Test Workflow' },
+				mockedWorkflow: createTestWorkflow({ name: 'Test Workflow' }),
 				expectedRename: "Call 'Test Workflow'",
 				expectedCalledWith: 'Call n8n Workflow Tool',
 			},
 			{
 				activeNodeName: 'Call n8n Workflow Tool1',
 				workflowId: 'workflow-id',
-				mockedWorkflow: { name: 'Test Workflow' },
+				mockedWorkflow: createTestWorkflow({ name: 'Test Workflow' }),
 				expectedRename: "Call 'Test Workflow'",
 				expectedCalledWith: 'Call n8n Workflow Tool1',
 			},
 			{
 				activeNodeName: "Call 'Old Workflow'",
 				workflowId: 'workflow-id',
-				mockedWorkflow: { name: 'New Workflow' },
+				mockedWorkflow: createTestWorkflow({ name: 'New Workflow' }),
 				expectedRename: "Call 'New Workflow'",
 				expectedCalledWith: "Call 'Old Workflow'",
 			},
@@ -86,9 +87,7 @@ describe('useWorkflowResourcesLocator', () => {
 				const { applyDefaultExecuteWorkflowNodeName } = useWorkflowResourcesLocator(routerMock);
 
 				ndvStoreMock.activeNodeName = activeNodeName;
-				workflowsListStoreMock.getWorkflowById.mockReturnValue(
-					mockedWorkflow as unknown as IWorkflowDb,
-				);
+				workflowsListStoreMock.getWorkflowById.mockReturnValue(mockedWorkflow);
 
 				applyDefaultExecuteWorkflowNodeName(workflowId);
 
@@ -124,12 +123,10 @@ describe('useWorkflowResourcesLocator', () => {
 			const { applyDefaultExecuteWorkflowNodeName } = useWorkflowResourcesLocator(routerMock);
 			const workflowId = 'workflow-id';
 			const activeNodeName = 'Some Other Node';
-			const mockedWorkflow = { name: 'Test Workflow' };
+			const mockedWorkflow = createTestWorkflow({ name: 'Test Workflow' });
 
 			ndvStoreMock.activeNodeName = activeNodeName;
-			workflowsListStoreMock.getWorkflowById.mockReturnValue(
-				mockedWorkflow as unknown as IWorkflowDb,
-			);
+			workflowsListStoreMock.getWorkflowById.mockReturnValue(mockedWorkflow);
 
 			applyDefaultExecuteWorkflowNodeName(workflowId);
 

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/composables/useWorkflowResourcesLocator.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/composables/useWorkflowResourcesLocator.ts
@@ -1,5 +1,5 @@
 import { ref, computed } from 'vue';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import type { Router } from 'vue-router';
 import { VIEWS } from '@/app/constants';
 
@@ -9,7 +9,7 @@ import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
 
 export function useWorkflowResourcesLocator(router: Router) {
-	const workflowsStore = useWorkflowsStore();
+	const workflowsListStore = useWorkflowsListStore();
 	const ndvStore = useNDVStore();
 	const { renameNode } = useCanvasOperations();
 
@@ -34,7 +34,7 @@ export function useWorkflowResourcesLocator(router: Router) {
 	}
 
 	function getWorkflowName(id: string): string {
-		const workflow = workflowsStore.getWorkflowById(id);
+		const workflow = workflowsListStore.getWorkflowById(id);
 		if (workflow) {
 			return constructName(workflow);
 		}
@@ -42,7 +42,7 @@ export function useWorkflowResourcesLocator(router: Router) {
 	}
 
 	function getWorkflowBaseName(id: string): string | null {
-		const workflow = workflowsStore.getWorkflowById(id);
+		const workflow = workflowsListStore.getWorkflowById(id);
 		if (workflow) {
 			return workflow.name;
 		}
@@ -70,7 +70,7 @@ export function useWorkflowResourcesLocator(router: Router) {
 		}
 
 		currentPage.value++;
-		const workflows = await workflowsStore.fetchWorkflowsPage(
+		const workflows = await workflowsListStore.fetchWorkflowsPage(
 			undefined,
 			currentPage.value,
 			PAGE_SIZE,
@@ -80,7 +80,7 @@ export function useWorkflowResourcesLocator(router: Router) {
 				triggerNodeTypes: ['n8n-nodes-base.executeWorkflowTrigger'],
 			},
 		);
-		totalCount.value = workflowsStore.totalWorkflowCount;
+		totalCount.value = workflowsListStore.totalWorkflowCount;
 
 		if (reset) {
 			workflowsResources.value = workflows.map(workflowDbToResourceMapper);

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
@@ -45,6 +45,7 @@ import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import type { NodeSettingsTab } from '@/app/types/nodeSettings';
 import { getNodeIconSource } from '@/app/utils/nodeIcon';
 import {
@@ -121,6 +122,7 @@ const nodeValues = ref<INodeParameters>(getNodeSettingsInitialValues());
 const nodeTypesStore = useNodeTypesStore();
 const ndvStore = useNDVStore();
 const workflowsStore = useWorkflowsStore();
+const workflowsListStore = useWorkflowsListStore();
 const workflowState = injectWorkflowState();
 const credentialsStore = useCredentialsStore();
 const historyStore = useHistoryStore();
@@ -156,7 +158,7 @@ const isDemoRoute = computed(() => route?.name === VIEWS.DEMO);
 const { isPreviewMode } = useSettingsStore();
 const isDemoPreview = computed(() => isDemoRoute.value && isPreviewMode);
 const currentWorkflow = computed(
-	() => workflowsStore.getWorkflowById(workflowsStore.workflowObject.id), // @TODO check if we actually need workflowObject here
+	() => workflowsListStore.getWorkflowById(workflowsStore.workflowObject.id), // @TODO check if we actually need workflowObject here
 );
 const hasForeignCredential = computed(() => props.foreignCredentials.length > 0);
 const isHomeProjectTeam = computed(

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/components/CommunityPackageManageConfirmModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/components/CommunityPackageManageConfirmModal.test.ts
@@ -10,8 +10,8 @@ import { STORES } from '@n8n/stores';
 import { COMMUNITY_PACKAGE_CONFIRM_MODAL_KEY } from '../communityNodes.constants';
 
 const fetchWorkflowsWithNodesIncluded = vi.fn();
-vi.mock('@/app/stores/workflows.store', () => ({
-	useWorkflowsStore: vi.fn(() => ({
+vi.mock('@/app/stores/workflowsList.store', () => ({
+	useWorkflowsListStore: vi.fn(() => ({
 		fetchWorkflowsWithNodesIncluded,
 	})),
 }));

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/components/CommunityPackageManageConfirmModal.vue
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/components/CommunityPackageManageConfirmModal.vue
@@ -15,7 +15,7 @@ import type { CommunityNodeType } from '@n8n/api-types';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import semver from 'semver';
 import { useUIStore } from '@/app/stores/ui.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import type { WorkflowResource } from '@/Interface';
 
 import { N8nButton, N8nNotice, N8nText } from '@n8n/design-system';
@@ -34,7 +34,7 @@ const props = defineProps<Props>();
 const communityNodesStore = useCommunityNodesStore();
 const nodeTypesStore = useNodeTypesStore();
 const settingsStore = useSettingsStore();
-const workflowsStore = useWorkflowsStore();
+const workflowsListStore = useWorkflowsListStore();
 
 const modalBus = createEventBus();
 
@@ -227,7 +227,7 @@ onMounted(async () => {
 
 	if (communityStorePackage.value?.installedNodes.length) {
 		const nodeTypes = communityStorePackage.value.installedNodes.map((node) => node.type);
-		const response = await workflowsStore.fetchWorkflowsWithNodesIncluded(nodeTypes);
+		const response = await workflowsListStore.fetchWorkflowsWithNodesIncluded(nodeTypes);
 		workflowsWithPackageNodes.value = response?.data ?? [];
 	}
 

--- a/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useExecutionCommands.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useExecutionCommands.ts
@@ -3,7 +3,7 @@ import { useRouter, useRoute } from 'vue-router';
 import { useI18n } from '@n8n/i18n';
 import { N8nIcon } from '@n8n/design-system';
 import { useExecutionsStore } from '@/features/execution/executions/executions.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useToast } from '@/app/composables/useToast';
 import { useMessage } from '@/app/composables/useMessage';
@@ -29,7 +29,7 @@ export function useExecutionCommands(): CommandGroup {
 	const router = useRouter();
 	const route = useRoute();
 	const executionsStore = useExecutionsStore();
-	const workflowsStore = useWorkflowsStore();
+	const workflowsListStore = useWorkflowsListStore();
 	const settingsStore = useSettingsStore();
 	const toast = useToast();
 	const message = useMessage();
@@ -44,7 +44,8 @@ export function useExecutionCommands(): CommandGroup {
 	});
 
 	const workflowPermissions = computed(
-		() => getResourcePermissions(workflowsStore.getWorkflowById(workflowId.value)?.scopes).workflow,
+		() =>
+			getResourcePermissions(workflowsListStore.getWorkflowById(workflowId.value)?.scopes).workflow,
 	);
 
 	const isAnnotationEnabled = computed(

--- a/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useRecentResources.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useRecentResources.ts
@@ -6,6 +6,7 @@ import { useRouter } from 'vue-router';
 import { useLocalStorage } from '@vueuse/core';
 import { VIEWS } from '@/app/constants';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { N8nIcon } from '@n8n/design-system';
 import NodeIcon from '@/app/components/NodeIcon.vue';
@@ -32,6 +33,7 @@ export function useRecentResources() {
 	const i18n = useI18n();
 	const router = useRouter();
 	const workflowsStore = useWorkflowsStore();
+	const workflowsListStore = useWorkflowsListStore();
 	const nodeTypesStore = useNodeTypesStore();
 	const { setNodeActive } = useCanvasOperations();
 
@@ -137,7 +139,7 @@ export function useRecentResources() {
 				}
 
 				// Get workflow from store (will be loaded by initialize())
-				const workflow = workflowsStore.getWorkflowById(recentWorkflow.id);
+				const workflow = workflowsListStore.getWorkflowById(recentWorkflow.id);
 				if (!workflow) {
 					continue;
 				}
@@ -178,10 +180,10 @@ export function useRecentResources() {
 		await Promise.all(
 			workflowsToFetch.map(async (recentWorkflow) => {
 				try {
-					const workflow = workflowsStore.getWorkflowById(recentWorkflow.id);
+					const workflow = workflowsListStore.getWorkflowById(recentWorkflow.id);
 
 					if (!workflow) {
-						await workflowsStore.fetchWorkflow(recentWorkflow.id);
+						await workflowsListStore.fetchWorkflow(recentWorkflow.id);
 					}
 				} catch {
 					// If fetch fails, skip this workflow (it may have been deleted)

--- a/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useWorkflowCommands.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useWorkflowCommands.test.ts
@@ -6,6 +6,7 @@ import { useTagsStore } from '@/features/shared/tags/tags.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { canvasEventBus } from '@/features/workflows/canvas/canvas.eventBus';
 import { nodeViewEventBus } from '@/app/event-bus';
 import { createTestWorkflow } from '@/__tests__/mocks';
@@ -63,6 +64,7 @@ describe('useWorkflowCommands', () => {
 	let mockUIStore: ReturnType<typeof useUIStore>;
 	let mockTagsStore: ReturnType<typeof useTagsStore>;
 	let mockWorkflowsStore: ReturnType<typeof useWorkflowsStore>;
+	let mockWorkflowsListStore: ReturnType<typeof useWorkflowsListStore>;
 	let mockSourceControlStore: ReturnType<typeof useSourceControlStore>;
 
 	beforeEach(() => {
@@ -83,6 +85,7 @@ describe('useWorkflowCommands', () => {
 		mockUIStore = useUIStore();
 		mockTagsStore = useTagsStore();
 		mockWorkflowsStore = useWorkflowsStore();
+		mockWorkflowsListStore = useWorkflowsListStore();
 		mockSourceControlStore = useSourceControlStore();
 
 		getWorkflowDataToSaveMock.mockResolvedValue(mockWorkflow.value);
@@ -90,7 +93,7 @@ describe('useWorkflowCommands', () => {
 
 		mockWorkflowsStore.workflow = mockWorkflow.value;
 		// Mark workflow as existing by adding it to workflowsById
-		mockWorkflowsStore.workflowsById = { [mockWorkflow.value.id]: mockWorkflow.value };
+		mockWorkflowsListStore.workflowsById = { [mockWorkflow.value.id]: mockWorkflow.value };
 
 		Object.defineProperty(mockUIStore, 'isActionActive', {
 			value: { workflowSaving: false } as unknown as typeof mockUIStore.isActionActive,
@@ -453,7 +456,7 @@ describe('useWorkflowCommands', () => {
 
 		it('should allow actions for new workflows regardless of permissions', () => {
 			// For new workflows, remove from workflowsById so isNewWorkflow returns true
-			mockWorkflowsStore.workflowsById = {};
+			mockWorkflowsListStore.workflowsById = {};
 			mockWorkflowsStore.workflow.scopes = ['workflow:read'];
 
 			const { commands } = useWorkflowCommands();

--- a/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useWorkflowNavigationCommands.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useWorkflowNavigationCommands.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ref } from 'vue';
 import { waitFor } from '@testing-library/vue';
 import type { IWorkflowDb } from '@/Interface';
-import { useWorkflowNavigationCommands } from './useWorkflowNavigationCommands';
 import { ProjectTypes } from '@/features/collaboration/projects/projects.types';
+import { useWorkflowNavigationCommands } from './useWorkflowNavigationCommands';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
@@ -64,7 +64,7 @@ describe('useWorkflowNavigationCommands', () => {
 	let mockSourceControlStore: ReturnType<typeof useSourceControlStore>;
 	let mockFoldersStore: ReturnType<typeof useFoldersStore>;
 
-	const allWorkflows = [
+	const allWorkflows: IWorkflowDb[] = [
 		{
 			id: 'w1',
 			name: 'Alpha',
@@ -73,25 +73,25 @@ describe('useWorkflowNavigationCommands', () => {
 			homeProject: { id: 'proj-1', type: ProjectTypes.Personal },
 			parentFolder: { id: 'f2', name: 'Child' },
 			tags: ['Marketing'],
-		},
+		} as unknown as IWorkflowDb,
 		{
 			id: 'w2',
 			name: 'Beta',
 			active: true,
 			isArchived: false,
 			homeProject: { id: 'proj-2', name: 'Team A' },
-			parentFolder: null,
+			parentFolder: undefined,
 			tags: [],
-		},
+		} as unknown as IWorkflowDb,
 		{
 			id: 'w3',
 			name: 'Gamma',
 			active: true,
 			isArchived: true, // should be filtered out
 			homeProject: { id: 'proj-2', name: 'Team A' },
-			parentFolder: null,
+			parentFolder: undefined,
 			tags: [],
-		},
+		} as unknown as IWorkflowDb,
 	];
 
 	beforeEach(() => {
@@ -151,16 +151,16 @@ describe('useWorkflowNavigationCommands', () => {
 			async (params: { query?: string; nodeTypes?: string[]; tags?: string[] }) => {
 				if (params.nodeTypes && params.nodeTypes.length > 0) {
 					return [
-						{ ...allWorkflows[0], nodes: [{ type: 'n8n-nodes-base.httpRequest' }] },
-					] as unknown as IWorkflowDb[];
+						{ ...allWorkflows[0], nodes: [{ type: 'n8n-nodes-base.httpRequest' }] } as IWorkflowDb,
+					];
 				}
 				if (params.tags && params.tags.length > 0) {
-					return [allWorkflows[0]] as unknown as IWorkflowDb[];
+					return [allWorkflows[0]];
 				}
 				if (typeof params.query === 'string') {
-					return [allWorkflows[0], allWorkflows[1], allWorkflows[2]] as unknown as IWorkflowDb[];
+					return [allWorkflows[0], allWorkflows[1], allWorkflows[2]];
 				}
-				return [] as IWorkflowDb[];
+				return [];
 			},
 		);
 

--- a/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useWorkflowNavigationCommands.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useWorkflowNavigationCommands.test.ts
@@ -3,6 +3,7 @@ import { ref } from 'vue';
 import { waitFor } from '@testing-library/vue';
 import type { IWorkflowDb } from '@/Interface';
 import { ProjectTypes } from '@/features/collaboration/projects/projects.types';
+import { createTestWorkflow } from '@/__tests__/mocks';
 import { useWorkflowNavigationCommands } from './useWorkflowNavigationCommands';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
@@ -64,34 +65,34 @@ describe('useWorkflowNavigationCommands', () => {
 	let mockSourceControlStore: ReturnType<typeof useSourceControlStore>;
 	let mockFoldersStore: ReturnType<typeof useFoldersStore>;
 
-	const allWorkflows: IWorkflowDb[] = [
-		{
+	const allWorkflows = [
+		createTestWorkflow({
 			id: 'w1',
 			name: 'Alpha',
 			active: false,
 			isArchived: false,
-			homeProject: { id: 'proj-1', type: ProjectTypes.Personal },
-			parentFolder: { id: 'f2', name: 'Child' },
-			tags: ['Marketing'],
-		} as unknown as IWorkflowDb,
-		{
+			homeProject: { id: 'proj-1', type: ProjectTypes.Personal } as IWorkflowDb['homeProject'],
+			parentFolder: { id: 'f2', name: 'Child' } as IWorkflowDb['parentFolder'],
+			tags: ['Marketing'] as IWorkflowDb['tags'],
+		}),
+		createTestWorkflow({
 			id: 'w2',
 			name: 'Beta',
 			active: true,
 			isArchived: false,
-			homeProject: { id: 'proj-2', name: 'Team A' },
+			homeProject: { id: 'proj-2', name: 'Team A' } as IWorkflowDb['homeProject'],
 			parentFolder: undefined,
 			tags: [],
-		} as unknown as IWorkflowDb,
-		{
+		}),
+		createTestWorkflow({
 			id: 'w3',
 			name: 'Gamma',
 			active: true,
 			isArchived: true, // should be filtered out
-			homeProject: { id: 'proj-2', name: 'Team A' },
+			homeProject: { id: 'proj-2', name: 'Team A' } as IWorkflowDb['homeProject'],
 			parentFolder: undefined,
 			tags: [],
-		} as unknown as IWorkflowDb,
+		}),
 	];
 
 	beforeEach(() => {

--- a/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useWorkflowNavigationCommands.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useWorkflowNavigationCommands.ts
@@ -10,6 +10,7 @@ import debounce from 'lodash/debounce';
 import { VIEWS } from '@/app/constants';
 import type { IWorkflowDb } from '@/Interface';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import type { CommandGroup, CommandBarItem } from '../types';
 import { useTagsStore } from '@/features/shared/tags/tags.store';
@@ -35,6 +36,7 @@ export function useWorkflowNavigationCommands(options: {
 	const nodeTypesStore = useNodeTypesStore();
 	const credentialsStore = useCredentialsStore();
 	const workflowsStore = useWorkflowsStore();
+	const workflowsListStore = useWorkflowsListStore();
 	const projectsStore = useProjectsStore();
 	const tagsStore = useTagsStore();
 	const sourceControlStore = useSourceControlStore();
@@ -78,14 +80,14 @@ export function useWorkflowNavigationCommands(options: {
 			const matchedTag = tagsStore.allTags.find((tag) => tag.name.toLowerCase() === trimmedLower);
 
 			// Search workflows by name with minimal fields
-			const nameSearchPromise = workflowsStore.searchWorkflows({
+			const nameSearchPromise = workflowsListStore.searchWorkflows({
 				query: trimmed,
 				select: ['id', 'name', 'active', 'ownedBy', 'parentFolder', 'isArchived', 'description'],
 			});
 
 			const nodeTypeSearchPromise =
 				matchedNodeTypeNames.length > 0
-					? workflowsStore.searchWorkflows({
+					? workflowsListStore.searchWorkflows({
 							nodeTypes: matchedNodeTypeNames,
 							select: [
 								'id',
@@ -101,7 +103,7 @@ export function useWorkflowNavigationCommands(options: {
 					: Promise.resolve([]);
 
 			const tagSearchPromise = matchedTag
-				? workflowsStore.searchWorkflows({
+				? workflowsListStore.searchWorkflows({
 						tags: [matchedTag.name],
 						select: [
 							'id',

--- a/packages/frontend/editor-ui/src/features/workflows/templates/templates.store.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/templates.store.ts
@@ -19,7 +19,7 @@ import { defineStore } from 'pinia';
 import { computed, ref } from 'vue';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 
 export interface ITemplateState {
 	categories: ITemplatesCategory[];
@@ -84,7 +84,7 @@ export const useTemplatesStore = defineStore(STORES.TEMPLATES, () => {
 	const rootStore = useRootStore();
 	const userStore = useUsersStore();
 	const cloudPlanStore = useCloudPlanStore();
-	const workflowsStore = useWorkflowsStore();
+	const workflowsListStore = useWorkflowsListStore();
 
 	const allCategories = computed(() => {
 		return categories.value.sort((a: ITemplatesCategory, b: ITemplatesCategory) =>
@@ -180,7 +180,7 @@ export const useTemplatesStore = defineStore(STORES.TEMPLATES, () => {
 			...TEMPLATES_URLS.UTM_QUERY,
 			utm_instance: currentN8nPath.value,
 			utm_n8n_version: rootStore.versionCli,
-			utm_awc: String(workflowsStore.activeWorkflows.length),
+			utm_awc: String(workflowsListStore.activeWorkflows.length),
 		};
 		if (userRole.value) {
 			defaultParameters.utm_user_role = userRole.value;

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/WorkflowDiffModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/WorkflowDiffModal.test.ts
@@ -6,7 +6,7 @@ import { createTestingPinia } from '@pinia/testing';
 import { createEventBus } from '@n8n/utils/event-bus';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { mockedStore, type MockedStore } from '@/__tests__/utils';
 import { reactive, ref } from 'vue';
 import { createTestWorkflow } from '@/__tests__/mocks';
@@ -116,7 +116,7 @@ const renderModal = createComponentRenderer(WorkflowDiffModal, {
 describe('WorkflowDiffModal', () => {
 	let nodeTypesStore: MockedStore<typeof useNodeTypesStore>;
 	let sourceControlStore: MockedStore<typeof useSourceControlStore>;
-	let workflowsStore: MockedStore<typeof useWorkflowsStore>;
+	let workflowsListStore: MockedStore<typeof useWorkflowsListStore>;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -134,14 +134,14 @@ describe('WorkflowDiffModal', () => {
 		createTestingPinia();
 		nodeTypesStore = mockedStore(useNodeTypesStore);
 		sourceControlStore = mockedStore(useSourceControlStore);
-		workflowsStore = mockedStore(useWorkflowsStore);
+		workflowsListStore = mockedStore(useWorkflowsListStore);
 
 		nodeTypesStore.loadNodeTypesIfNotLoaded.mockResolvedValue();
 		sourceControlStore.getRemoteWorkflow.mockResolvedValue({
 			content: mockWorkflow,
 			type: 'workflow',
 		});
-		workflowsStore.fetchWorkflow.mockResolvedValue(mockWorkflow);
+		workflowsListStore.fetchWorkflow.mockResolvedValue(mockWorkflow);
 		sourceControlStore.preferences.branchName = 'main';
 	});
 
@@ -265,7 +265,7 @@ describe('WorkflowDiffModal', () => {
 			content: remoteWorkflow,
 			type: 'workflow',
 		});
-		workflowsStore.fetchWorkflow.mockResolvedValue(localWorkflow);
+		workflowsListStore.fetchWorkflow.mockResolvedValue(localWorkflow);
 
 		const { getByText } = renderModal({
 			props: {
@@ -419,7 +419,7 @@ describe('WorkflowDiffModal', () => {
 				content: mockWorkflow,
 				type: 'workflow',
 			});
-			workflowsStore.fetchWorkflow.mockRejectedValue(new Error('Workflow not found'));
+			workflowsListStore.fetchWorkflow.mockRejectedValue(new Error('Workflow not found'));
 
 			const { getByText } = renderModal({
 				props: {
@@ -440,7 +440,7 @@ describe('WorkflowDiffModal', () => {
 
 		it('should handle missing target workflow without crashing', async () => {
 			sourceControlStore.getRemoteWorkflow.mockRejectedValue(new Error('Workflow not found'));
-			workflowsStore.fetchWorkflow.mockResolvedValue(mockWorkflow);
+			workflowsListStore.fetchWorkflow.mockResolvedValue(mockWorkflow);
 
 			const { getByText } = renderModal({
 				props: {
@@ -534,14 +534,14 @@ describe('WorkflowDiffModal', () => {
 			});
 
 			await vi.waitFor(() => {
-				expect(workflowsStore.fetchWorkflow).toHaveBeenCalledWith('test-workflow-id');
+				expect(workflowsListStore.fetchWorkflow).toHaveBeenCalledWith('test-workflow-id');
 			});
 		});
 	});
 
 	describe('Error Handling - Local Workflow', () => {
 		it('should show toast error and close modal when local workflow fails to load', async () => {
-			workflowsStore.fetchWorkflow.mockRejectedValue(new Error('Local API error') as never);
+			workflowsListStore.fetchWorkflow.mockRejectedValue(new Error('Local API error') as never);
 
 			renderModal({
 				props: {
@@ -561,7 +561,7 @@ describe('WorkflowDiffModal', () => {
 		});
 
 		it('should continue loading remote workflow when local fails', async () => {
-			workflowsStore.fetchWorkflow.mockRejectedValue(new Error('Local API error') as never);
+			workflowsListStore.fetchWorkflow.mockRejectedValue(new Error('Local API error') as never);
 
 			renderModal({
 				props: {
@@ -585,7 +585,7 @@ describe('WorkflowDiffModal', () => {
 			sourceControlStore.getRemoteWorkflow.mockRejectedValue(
 				new Error('Remote API error') as never,
 			);
-			workflowsStore.fetchWorkflow.mockRejectedValue(new Error('Local API error') as never);
+			workflowsListStore.fetchWorkflow.mockRejectedValue(new Error('Local API error') as never);
 
 			renderModal({
 				props: {
@@ -620,7 +620,7 @@ describe('WorkflowDiffModal', () => {
 
 			await vi.waitFor(() => {
 				expect(sourceControlStore.getRemoteWorkflow).toHaveBeenCalledWith('test-workflow-id');
-				expect(workflowsStore.fetchWorkflow).toHaveBeenCalledWith('test-workflow-id');
+				expect(workflowsListStore.fetchWorkflow).toHaveBeenCalledWith('test-workflow-id');
 			});
 		});
 
@@ -655,7 +655,7 @@ describe('WorkflowDiffModal', () => {
 
 			await vi.waitFor(() => {
 				expect(sourceControlStore.getRemoteWorkflow).toHaveBeenCalled();
-				expect(workflowsStore.fetchWorkflow).toHaveBeenCalled();
+				expect(workflowsListStore.fetchWorkflow).toHaveBeenCalled();
 			});
 
 			expect(mockShowError).not.toHaveBeenCalled();
@@ -733,7 +733,7 @@ describe('WorkflowDiffModal', () => {
 			});
 
 			await vi.waitFor(() => {
-				expect(workflowsStore.fetchWorkflow).toHaveBeenCalledWith('test-workflow-id');
+				expect(workflowsListStore.fetchWorkflow).toHaveBeenCalledWith('test-workflow-id');
 			});
 
 			expect(sourceControlStore.getRemoteWorkflow).not.toHaveBeenCalled();

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/WorkflowDiffModal.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/WorkflowDiffModal.vue
@@ -14,7 +14,7 @@ import type { IWorkflowDb } from '@/Interface';
 import type { SourceControlledFileStatus } from '@n8n/api-types';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { removeWorkflowExecutionData } from '@/app/utils/workflowUtils';
 import type { BaseTextKey } from '@n8n/i18n';
 import { useI18n } from '@n8n/i18n';
@@ -55,7 +55,7 @@ const i18n = useI18n();
 const router = useRouter();
 const route = useRoute();
 
-const workflowsStore = useWorkflowsStore();
+const workflowsListStore = useWorkflowsListStore();
 
 const manualAsyncConfiguration = {
 	resetOnExecute: true,
@@ -89,7 +89,7 @@ const local = useAsyncState<{ workflow?: IWorkflowDb; remote: boolean } | undefi
 	async () => {
 		try {
 			const { workflowId } = props.data;
-			const workflow = await workflowsStore.fetchWorkflow(workflowId);
+			const workflow = await workflowsListStore.fetchWorkflow(workflowId);
 			return { workflow, remote: false };
 		} catch (error) {
 			toast.showError(error, i18n.baseText('generic.error'));

--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/views/WorkflowHistory.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/views/WorkflowHistory.test.ts
@@ -10,7 +10,7 @@ import { createComponentRenderer } from '@/__tests__/render';
 import { SETTINGS_STORE_DEFAULT_STATE } from '@/__tests__/utils';
 import WorkflowHistoryPage from './WorkflowHistory.vue';
 import { useWorkflowHistoryStore } from '../workflowHistory.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { STORES } from '@n8n/stores';
 import { VIEWS } from '@/app/constants';
 import { workflowHistoryDataFactory, workflowVersionDataFactory } from '../__tests__/utils';
@@ -70,7 +70,7 @@ let pinia: ReturnType<typeof createTestingPinia>;
 let router: ReturnType<typeof useRouter>;
 let route: ReturnType<typeof useRoute>;
 let workflowHistoryStore: ReturnType<typeof useWorkflowHistoryStore>;
-let workflowsStore: ReturnType<typeof useWorkflowsStore>;
+let workflowsListStore: ReturnType<typeof useWorkflowsListStore>;
 let windowOpenSpy: MockInstance;
 
 describe('WorkflowHistory', () => {
@@ -81,11 +81,11 @@ describe('WorkflowHistory', () => {
 			},
 		});
 		workflowHistoryStore = useWorkflowHistoryStore();
-		workflowsStore = useWorkflowsStore();
+		workflowsListStore = useWorkflowsListStore();
 		route = useRoute();
 		router = useRouter();
 
-		vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue({} as IWorkflowDb);
+		vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue({} as IWorkflowDb);
 		vi.spyOn(workflowHistoryStore, 'getWorkflowHistory').mockResolvedValue(historyData);
 		vi.spyOn(workflowHistoryStore, 'getWorkflowVersion').mockResolvedValue(versionData);
 		vi.spyOn(telemetry, 'track').mockImplementation(() => {});
@@ -230,7 +230,7 @@ describe('WorkflowHistory', () => {
 	});
 
 	it('should display archived tag on header if workflow is archived', async () => {
-		vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue({
+		vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue({
 			id: workflowId,
 			name: 'Test Workflow',
 			isArchived: true,
@@ -246,7 +246,7 @@ describe('WorkflowHistory', () => {
 	});
 
 	it('should not display archived tag on header if workflow is not archived', async () => {
-		vi.spyOn(workflowsStore, 'fetchWorkflow').mockResolvedValue({
+		vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue({
 			id: workflowId,
 			name: 'Test Workflow',
 			isArchived: false,

--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/workflowHistory.store.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/workflowHistory.store.ts
@@ -13,12 +13,14 @@ import * as whApi from '@n8n/rest-api-client/api/workflowHistory';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { getNewWorkflow } from '@/app/api/workflows';
 
 export const useWorkflowHistoryStore = defineStore('workflowHistory', () => {
 	const rootStore = useRootStore();
 	const settingsStore = useSettingsStore();
 	const workflowsStore = useWorkflowsStore();
+	const workflowsListStore = useWorkflowsListStore();
 
 	const licensePruneTime = computed(() => settingsStore.settings.workflowHistory?.licensePruneTime);
 	// pruneTime is already evaluated by backend (getWorkflowHistoryPruneTime)
@@ -48,7 +50,7 @@ export const useWorkflowHistoryStore = defineStore('workflowHistory', () => {
 		data: { formattedCreatedAt: string },
 	) => {
 		const [workflow, workflowVersion] = await Promise.all([
-			workflowsStore.fetchWorkflow(workflowId),
+			workflowsListStore.fetchWorkflow(workflowId),
 			getWorkflowVersion(workflowId, workflowVersionId),
 		]);
 		const { connections, nodes } = workflowVersion;
@@ -64,7 +66,7 @@ export const useWorkflowHistoryStore = defineStore('workflowHistory', () => {
 		data: { formattedCreatedAt: string },
 	): Promise<IWorkflowDb> => {
 		const [workflow, workflowVersion] = await Promise.all([
-			workflowsStore.fetchWorkflow(workflowId),
+			workflowsListStore.fetchWorkflow(workflowId),
 			getWorkflowVersion(workflowId, workflowVersionId),
 		]);
 		const { connections, nodes } = workflowVersion;
@@ -96,7 +98,7 @@ export const useWorkflowHistoryStore = defineStore('workflowHistory', () => {
 					typeof error.message === 'string' &&
 					error.message.includes('can not be activated')
 				) {
-					return await workflowsStore.fetchWorkflow(workflowId);
+					return await workflowsListStore.fetchWorkflow(workflowId);
 				} else {
 					throw new Error(error);
 				}


### PR DESCRIPTION
## Summary

This pull request refactors several workflow-related components in the frontend to use the new `workflowsList` store instead of the older `workflows` store for certain operations. The changes improve code organization and clarify the separation of concerns between workflow data management and workflow list management. The update also includes corresponding changes in tests to mock and verify the correct store usage.

**Store Refactoring and Usage Updates:**

* Added a new entry `WORKFLOWS_LIST` to the `STORES` constant in `constants.ts`, enabling the use of the new store throughout the application.
* Updated imports and store initializations in multiple components (`DuplicateWorkflowDialog.vue`, `ActionsDropdownMenu.vue`, `MainHeader.vue`, `WorkflowDetails.vue`) to use `useWorkflowsListStore` where appropriate. [[1]](diffhunk://#diff-13b8c8669f05323307c575008d11e8c7b1fa166ab7e63d52cafbf4c03015b557R9) [[2]](diffhunk://#diff-53e384161ee5cc0982c24aac5a5a3fcc0cfc9bfc11b1063e2a47f85c0e74c4acR35) [[3]](diffhunk://#diff-97aaffc73b9f3d4bdd4590bbc1dc99444206c85f383ac02eab50be857a636b5eR18) [[4]](diffhunk://#diff-b5088e218e48601bfab4966fbdec63319cbe26139a54314548518f3095508e83R44)
* Replaced calls to fetch, get, and delete workflows from `workflowsStore` with equivalent methods from `workflowsListStore` in workflow-related components, ensuring that workflow list operations are routed through the correct store. [[1]](diffhunk://#diff-13b8c8669f05323307c575008d11e8c7b1fa166ab7e63d52cafbf4c03015b557L104-R106) [[2]](diffhunk://#diff-53e384161ee5cc0982c24aac5a5a3fcc0cfc9bfc11b1063e2a47f85c0e74c4acL287-R289) [[3]](diffhunk://#diff-53e384161ee5cc0982c24aac5a5a3fcc0cfc9bfc11b1063e2a47f85c0e74c4acL416-R418) [[4]](diffhunk://#diff-97aaffc73b9f3d4bdd4590bbc1dc99444206c85f383ac02eab50be857a636b5eL257-R259) [[5]](diffhunk://#diff-b5088e218e48601bfab4966fbdec63319cbe26139a54314548518f3095508e83L280-R282) [[6]](diffhunk://#diff-b5088e218e48601bfab4966fbdec63319cbe26139a54314548518f3095508e83L323-R329)

**Test Updates:**

* Updated test files (`WorkflowDetails.test.ts`, `WorkflowPublishModal.test.ts`) to mock and assert against `workflowsListStore` instead of `workflowsStore` for workflow list operations, ensuring tests reflect the new store usage. [[1]](diffhunk://#diff-e430746bcaefa02e0a47c1177d16b5e92cfb24118ba564135136819038bf3163R21) [[2]](diffhunk://#diff-e430746bcaefa02e0a47c1177d16b5e92cfb24118ba564135136819038bf3163R135-R167) [[3]](diffhunk://#diff-e430746bcaefa02e0a47c1177d16b5e92cfb24118ba564135136819038bf3163L491-R495) [[4]](diffhunk://#diff-e430746bcaefa02e0a47c1177d16b5e92cfb24118ba564135136819038bf3163L523-R527) [[5]](diffhunk://#diff-e430746bcaefa02e0a47c1177d16b5e92cfb24118ba564135136819038bf3163L603-R608) [[6]](diffhunk://#diff-e430746bcaefa02e0a47c1177d16b5e92cfb24118ba564135136819038bf3163L623-R628) [[7]](diffhunk://#diff-e430746bcaefa02e0a47c1177d16b5e92cfb24118ba564135136819038bf3163L637-R641) [[8]](diffhunk://#diff-e430746bcaefa02e0a47c1177d16b5e92cfb24118ba564135136819038bf3163L655-R660) [[9]](diffhunk://#diff-e430746bcaefa02e0a47c1177d16b5e92cfb24118ba564135136819038bf3163L669-R673) [[10]](diffhunk://#diff-e430746bcaefa02e0a47c1177d16b5e92cfb24118ba564135136819038bf3163L678-R682) [[11]](diffhunk://#diff-0e36796c29e25e2269c54504376285daf1132e82c65f2620c8fc60d293abcca7R6) [[12]](diffhunk://#diff-0e36796c29e25e2269c54504376285daf1132e82c65f2620c8fc60d293abcca7R75-R79) [[13]](diffhunk://#diff-0e36796c29e25e2269c54504376285daf1132e82c65f2620c8fc60d293abcca7L131-R134)


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2238/separate-workflows-list-and-workflows-list-store

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
