### PR TITLE
refactor(editor): Use Map for node lookup in connection mapping (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/canvas/canvas.utils.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/canvas.utils.ts
@@ -20,9 +20,10 @@ export function mapLegacyConnectionsToCanvasConnections(
 	nodes: INodeUi[],
 ): CanvasConnection[] {
 	const mappedConnections: CanvasConnection[] = [];
+	const nodeIdByName = new Map(nodes.map((n) => [n.name, n.id]));
 
 	Object.keys(legacyConnections).forEach((fromNodeName) => {
-		const fromId = nodes.find((node) => node.name === fromNodeName)?.id ?? '';
+		const fromId = nodeIdByName.get(fromNodeName) ?? '';
 		const fromConnectionTypes = Object.keys(
 			legacyConnections[fromNodeName],
 		) as NodeConnectionType[];
@@ -32,7 +33,7 @@ export function mapLegacyConnectionsToCanvasConnections(
 			fromPorts?.forEach((toPorts, fromIndex) => {
 				toPorts?.forEach((toPort) => {
 					const toNodeName = toPort.node;
-					const toId = nodes.find((node) => node.name === toNodeName)?.id ?? '';
+					const toId = nodeIdByName.get(toNodeName) ?? '';
 					const toConnectionType = toPort.type;
 					const toIndex = toPort.index;
 


### PR DESCRIPTION
## Summary

Replace repeated Array.find() calls with a Map-based lookup to improve performance when mapping legacy connections to canvas connections, especially for workflows with many nodes and connections.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2236/fix-on-lookups-in-canvasutilsts

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
