### PR TITLE
fix(AI Agent Node): Fix gemini thought signatures for parallel tool calls

### DIFF
--- a/packages/@n8n/nodes-langchain/utils/agent-execution/createEngineRequests.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/createEngineRequests.ts
@@ -142,7 +142,7 @@ function extractThinkingMetadata(
 									const toolCallIndex = msgToolCalls.findIndex(
 										(tc) => tc.id === toolCall.toolCallId,
 									);
-									if (toolCallIndex !== -1 && toolCallIndex < signatures.length) {
+									if (toolCallIndex > 0 && toolCallIndex < signatures.length) {
 										thoughtSignature = signatures[toolCallIndex];
 									}
 								}


### PR DESCRIPTION
## Summary
Fixes a problem with parallel tool calls with Gemini 3. Gemini needs parallel tool calls to be aggregated in one message to successfully check the thought signature. 

Refactored the code.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
