### PR TITLE
feat(core): Make database ping timeout configurable

### DIFF
--- a/packages/@n8n/db/src/connection/db-connection.ts
+++ b/packages/@n8n/db/src/connection/db-connection.ts
@@ -22,6 +22,7 @@ export class DbConnection {
 	private dataSource: DataSource;
 
 	private pingTimer: NodeJS.Timeout | undefined;
+	timeout: number;
 
 	readonly connectionState: ConnectionState = {
 		connected: false,
@@ -37,6 +38,9 @@ export class DbConnection {
 	) {
 		this.dataSource = new DataSource(this.options);
 		Container.set(DataSource, this.dataSource);
+		this.timeout = process.env.N8N_DB_PING_TIMEOUT
+			? Number.parseInt(process.env.N8N_DB_PING_TIMEOUT)
+			: 5000;
 	}
 
 	@Memoized
@@ -116,7 +120,7 @@ export class DbConnection {
 		try {
 			await Promise.race([
 				this.dataSource.query('SELECT 1'),
-				setTimeoutP(5000, undefined, { signal: abortController.signal }).then(() => {
+				setTimeoutP(this.timeout, undefined, { signal: abortController.signal }).then(() => {
 					throw new OperationalError('Database connection timed out');
 				}),
 			]);


### PR DESCRIPTION
## Summary

This PR adds the `N8N_DB_PING_TIMEOUT` environment variable to make the database connection ping timeout configurable. The default remains 5000ms (5 seconds).

Previously, the timeout was hardcoded. This change allows users to adjust the timeout based on their specific database environment and network conditions.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Add Linear ticket or GitHub issue if applicable -->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] ~~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~~
- [ ] Tests included.
- [ ] ~~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~~