### PR TITLE
fix(core): Do not send an undefined location header on form redirects

### DIFF
--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -250,7 +250,7 @@ export const handleFormRedirectionCase = (
 				redirectURL: validatedUrl,
 			};
 		}
-		(data.headers as IDataObject).location = undefined;
+		delete (data.headers as IDataObject).location;
 	}
 
 	return data;


### PR DESCRIPTION
## Summary

Remove the location header properly for form redirects.

Form redirection is handled by sending the redirectURL in the response body rather than in the location header.

We have a function that takes the location header and puts it in the response body.

However, it then explicitly sets the location header to undefined. This means we try to send a header with a value of undefined, which generates an error.

This change removes it from the headers altogether.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-1797

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
