### PR TITLE
fix(editor): Fix source control sidebar icon width when collapsed (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/MainSidebarSourceControl.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainSidebarSourceControl.vue
@@ -99,7 +99,12 @@ function pullWorkfolder() {
 			:class="$style.connected"
 			data-test-id="main-sidebar-source-control-connected"
 		>
-			<N8nTooltip :disabled="!isCollapsed" :show-after="tooltipOpenDelay" placement="right">
+			<N8nTooltip
+				:disabled="!isCollapsed"
+				:show-after="tooltipOpenDelay"
+				placement="right"
+				:avoid-collisions="false"
+			>
 				<template #content>
 					<div>
 						{{ currentBranch }}
@@ -222,6 +227,10 @@ function pullWorkfolder() {
 		flex-direction: column-reverse;
 		gap: var(--spacing--3xs);
 		padding-right: 0;
+
+		> span:first-child {
+			width: 100%;
+		}
 
 		.icon {
 			width: 100%;


### PR DESCRIPTION
## Summary

Fixes issues with the source control sidebar in the collapsed state:                                                                                                                    
  - Tooltip was repositioning unexpectedly when hovering                                                                                                                                  
  - Git icon background was not filling the full width of the collapsed sidebar          

Before: 
<img width="127" height="69" alt="image" src="https://github.com/user-attachments/assets/fe29c886-4e09-4454-96c5-7dde0d3b3c8c" />

After:
<img width="153" height="86" alt="image" src="https://github.com/user-attachments/assets/b571e745-4d98-49bb-a83e-2eadbe745e7d" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-158/bug-environmentgit-icon-background-not-filling-width-with-collapsed

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
