### PR TITLE
chore: Remove beta label from API page

### DIFF
--- a/packages/frontend/editor-ui/src/features/settings/apiKeys/views/SettingsApiView.vue
+++ b/packages/frontend/editor-ui/src/features/settings/apiKeys/views/SettingsApiView.vue
@@ -117,9 +117,6 @@ function onEdit(id: string) {
 		<div :class="$style.header">
 			<N8nHeading size="2xlarge">
 				{{ i18n.baseText('settings.api') }}
-				<span :style="{ fontSize: 'var(--font-size--sm)', color: 'var(--color--text--tint-1)' }">
-					({{ i18n.baseText('generic.beta') }})
-				</span>
 			</N8nHeading>
 		</div>
 		<p v-if="isPublicApiEnabled && apiKeysSortByCreationDate.length" :class="$style.topHint">


### PR DESCRIPTION
## Summary

The public API has been around since 2022 so this PR removes the `beta` label.

### Before

<img width="1074" height="129" alt="CleanShot 2026-01-28 at 15 22 12" src="https://github.com/user-attachments/assets/3e7a7dbc-0eb4-42ce-9608-19a1d4132caf" />


### After
<img width="1131" height="147" alt="CleanShot 2026-01-28 at 15 21 41" src="https://github.com/user-attachments/assets/12d9c533-07ce-4eb2-bf1f-b7ef96678be1" />

## Related Linear tickets, Github issues, and Community forum posts

FIxes: LIGO-159

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- ~[ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- ~[ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->~
- ~[ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
