### PR TITLE
fix(editor): Fix layout of insights tab

### DIFF
--- a/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsSummary.vue
+++ b/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsSummary.vue
@@ -201,6 +201,12 @@ const trackTabClick = (insightType: keyof InsightsSummary) => {
 			&:first-child {
 				border-left: 0;
 			}
+
+			> span {
+				display: flex;
+				width: 100%;
+				height: 100%;
+			}
 		}
 
 		a {


### PR DESCRIPTION
## Summary

The interactive area of the insights tab buttons is not filling out available space anymore

<img width="1655" height="875" alt="image" src="https://github.com/user-attachments/assets/33fcfcc1-f363-4343-ab1c-5daad10d6f1f" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-203/insights-tab-links-layout-is-broken

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
