### PR TITLE
feat(core): Index both draft and published workflow versions (no-changelog)

### DIFF
--- a/packages/@n8n/db/src/repositories/workflow-dependency.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-dependency.repository.ts
@@ -1,9 +1,8 @@
 import { DatabaseConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
-import { DataSource, EntityManager, IsNull, LessThan, Repository } from '@n8n/typeorm';
+import { DataSource, EntityManager, IsNull, LessThan, Repository, Not } from '@n8n/typeorm';
 
 import { WorkflowDependency } from '../entities';
-import { Not } from '@n8n/typeorm';
 
 const INDEX_VERSION_ID = 1;
 

--- a/packages/@n8n/db/src/repositories/workflow-dependency.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-dependency.repository.ts
@@ -64,6 +64,10 @@ export class WorkflowDependencyRepository extends Repository<WorkflowDependency>
 		dependencies: WorkflowDependencies,
 		tx: EntityManager,
 	): Promise<boolean> {
+		// Scope delete by publishedVersionId: use IsNull() for drafts, exact value for published versions
+		const publishedVersionCondition =
+			dependencies.publishedVersionId === null ? IsNull() : dependencies.publishedVersionId;
+
 		const deleteResult = await tx.delete(WorkflowDependency, {
 			workflowId,
 			workflowVersionId: LessThan(dependencies.workflowVersionId),

--- a/packages/cli/src/modules/workflow-index/__tests__/workflow-index.service.test.ts
+++ b/packages/cli/src/modules/workflow-index/__tests__/workflow-index.service.test.ts
@@ -88,7 +88,7 @@ describe('WorkflowIndexService', () => {
 				}),
 			]);
 
-			await service.updateIndexFor(workflow, /* publishedVersionId= */ null);
+			await service.updateIndexForDraft(workflow);
 
 			expect(mockWorkflowDependencyRepository.updateDependenciesForWorkflow).toHaveBeenCalledWith(
 				'workflow-123',
@@ -159,7 +159,7 @@ describe('WorkflowIndexService', () => {
 				}),
 			]);
 
-			await service.updateIndexFor(workflow, /* publishedVersionId= */ null);
+			await service.updateIndexForDraft(workflow);
 
 			expect(mockLogger.error).toHaveBeenCalledWith(
 				'Failed to update workflow draft dependency index for workflow workflow-123: Database error',
@@ -188,7 +188,7 @@ describe('WorkflowIndexService', () => {
 				}),
 			]);
 
-			await service.updateIndexFor(workflow, /* publishedVersionId= */ null);
+			await service.updateIndexForDraft(workflow);
 
 			expect(mockWorkflowDependencyRepository.updateDependenciesForWorkflow).toHaveBeenCalledWith(
 				'workflow-123',
@@ -217,7 +217,7 @@ describe('WorkflowIndexService', () => {
 				}),
 			]);
 
-			await service.updateIndexFor(workflow, /* publishedVersionId= */ null);
+			await service.updateIndexForDraft(workflow);
 
 			expect(mockWorkflowDependencyRepository.updateDependenciesForWorkflow).toHaveBeenCalledWith(
 				'workflow-123',
@@ -258,7 +258,7 @@ describe('WorkflowIndexService', () => {
 				}),
 			]);
 
-			await service.updateIndexFor(workflow, /* publishedVersionId= */ null);
+			await service.updateIndexForDraft(workflow);
 
 			const call = mockWorkflowDependencyRepository.updateDependenciesForWorkflow.mock.calls[0];
 			const dependencies = call[1].dependencies;
@@ -298,7 +298,7 @@ describe('WorkflowIndexService', () => {
 				} as INode,
 			]);
 
-			await service.updateIndexFor(workflow, /* publishedVersionId= */ null);
+			await service.updateIndexForDraft(workflow);
 
 			const call = mockWorkflowDependencyRepository.updateDependenciesForWorkflow.mock.calls[0];
 			const dependencies = call[1].dependencies;
@@ -329,7 +329,7 @@ describe('WorkflowIndexService', () => {
 				}),
 			]);
 
-			await service.updateIndexFor(workflow, /* publishedVersionId= */ null);
+			await service.updateIndexForDraft(workflow);
 
 			const call = mockWorkflowDependencyRepository.updateDependenciesForWorkflow.mock.calls[0];
 			const dependencies = call[1].dependencies;
@@ -361,7 +361,7 @@ describe('WorkflowIndexService', () => {
 
 			const workflow = createWorkflow([]);
 
-			await service.updateIndexFor(workflow, /* publishedVersionId= */ null);
+			await service.updateIndexForDraft(workflow);
 
 			expect(mockWorkflowDependencyRepository.updateDependenciesForWorkflow).toHaveBeenCalledWith(
 				'workflow-123',
@@ -396,7 +396,7 @@ describe('WorkflowIndexService', () => {
 				} as INode,
 			]);
 
-			await service.updateIndexFor(workflow, /* publishedVersionId= */ null);
+			await service.updateIndexForDraft(workflow);
 
 			expect(mockWorkflowDependencyRepository.updateDependenciesForWorkflow).toHaveBeenCalledWith(
 				'workflow-123',
@@ -414,6 +414,47 @@ describe('WorkflowIndexService', () => {
 			// Verify only the placeholder exists (exactly 1 dependency)
 			const call = mockWorkflowDependencyRepository.updateDependenciesForWorkflow.mock.calls[0];
 			expect(call[1].dependencies).toHaveLength(1);
+		});
+
+		it('should pass publishedVersionId when calling updateIndexForPublished', async () => {
+			mockWorkflowDependencyRepository.updateDependenciesForWorkflow.mockResolvedValue(true);
+
+			const workflow = createWorkflow([
+				createNode({
+					id: 'node-1',
+					type: 'n8n-nodes-base.manualTrigger',
+				}),
+			]);
+
+			const publishedVersionId = 'published-version-123';
+			await service.updateIndexForPublished(workflow, publishedVersionId);
+
+			expect(mockWorkflowDependencyRepository.updateDependenciesForWorkflow).toHaveBeenCalledWith(
+				'workflow-123',
+				expect.objectContaining({
+					publishedVersionId: 'published-version-123',
+				}),
+			);
+		});
+
+		it('should pass null publishedVersionId when calling updateIndexForDraft', async () => {
+			mockWorkflowDependencyRepository.updateDependenciesForWorkflow.mockResolvedValue(true);
+
+			const workflow = createWorkflow([
+				createNode({
+					id: 'node-1',
+					type: 'n8n-nodes-base.manualTrigger',
+				}),
+			]);
+
+			await service.updateIndexForDraft(workflow);
+
+			expect(mockWorkflowDependencyRepository.updateDependenciesForWorkflow).toHaveBeenCalledWith(
+				'workflow-123',
+				expect.objectContaining({
+					publishedVersionId: null,
+				}),
+			);
 		});
 	});
 

--- a/packages/cli/src/modules/workflow-index/__tests__/workflow-index.service.test.ts
+++ b/packages/cli/src/modules/workflow-index/__tests__/workflow-index.service.test.ts
@@ -421,11 +421,12 @@ describe('WorkflowIndexService', () => {
 		it('should register event listeners for workflow events', () => {
 			service.init();
 
-			expect(mockEventService.on).toHaveBeenCalledTimes(4);
+			expect(mockEventService.on).toHaveBeenCalledTimes(5);
 			expect(mockEventService.on).toHaveBeenCalledWith('server-started', expect.any(Function));
 			expect(mockEventService.on).toHaveBeenCalledWith('workflow-created', expect.any(Function));
 			expect(mockEventService.on).toHaveBeenCalledWith('workflow-saved', expect.any(Function));
 			expect(mockEventService.on).toHaveBeenCalledWith('workflow-deleted', expect.any(Function));
+			expect(mockEventService.on).toHaveBeenCalledWith('workflow-activated', expect.any(Function));
 		});
 	});
 

--- a/packages/cli/src/modules/workflow-index/__tests__/workflow-index.service.test.ts
+++ b/packages/cli/src/modules/workflow-index/__tests__/workflow-index.service.test.ts
@@ -88,7 +88,7 @@ describe('WorkflowIndexService', () => {
 				}),
 			]);
 
-			await service.updateIndexFor(workflow);
+			await service.updateIndexFor(workflow, /* publishedVersionId= */ null);
 
 			expect(mockWorkflowDependencyRepository.updateDependenciesForWorkflow).toHaveBeenCalledWith(
 				'workflow-123',
@@ -159,7 +159,7 @@ describe('WorkflowIndexService', () => {
 				}),
 			]);
 
-			await service.updateIndexFor(workflow);
+			await service.updateIndexFor(workflow, /* publishedVersionId= */ null);
 
 			expect(mockLogger.error).toHaveBeenCalledWith(
 				'Failed to update workflow draft dependency index for workflow workflow-123: Database error',
@@ -188,7 +188,7 @@ describe('WorkflowIndexService', () => {
 				}),
 			]);
 
-			await service.updateIndexFor(workflow);
+			await service.updateIndexFor(workflow, /* publishedVersionId= */ null);
 
 			expect(mockWorkflowDependencyRepository.updateDependenciesForWorkflow).toHaveBeenCalledWith(
 				'workflow-123',
@@ -217,7 +217,7 @@ describe('WorkflowIndexService', () => {
 				}),
 			]);
 
-			await service.updateIndexFor(workflow);
+			await service.updateIndexFor(workflow, /* publishedVersionId= */ null);
 
 			expect(mockWorkflowDependencyRepository.updateDependenciesForWorkflow).toHaveBeenCalledWith(
 				'workflow-123',
@@ -258,7 +258,7 @@ describe('WorkflowIndexService', () => {
 				}),
 			]);
 
-			await service.updateIndexFor(workflow);
+			await service.updateIndexFor(workflow, /* publishedVersionId= */ null);
 
 			const call = mockWorkflowDependencyRepository.updateDependenciesForWorkflow.mock.calls[0];
 			const dependencies = call[1].dependencies;
@@ -298,7 +298,7 @@ describe('WorkflowIndexService', () => {
 				} as INode,
 			]);
 
-			await service.updateIndexFor(workflow);
+			await service.updateIndexFor(workflow, /* publishedVersionId= */ null);
 
 			const call = mockWorkflowDependencyRepository.updateDependenciesForWorkflow.mock.calls[0];
 			const dependencies = call[1].dependencies;
@@ -329,7 +329,7 @@ describe('WorkflowIndexService', () => {
 				}),
 			]);
 
-			await service.updateIndexFor(workflow);
+			await service.updateIndexFor(workflow, /* publishedVersionId= */ null);
 
 			const call = mockWorkflowDependencyRepository.updateDependenciesForWorkflow.mock.calls[0];
 			const dependencies = call[1].dependencies;
@@ -361,7 +361,7 @@ describe('WorkflowIndexService', () => {
 
 			const workflow = createWorkflow([]);
 
-			await service.updateIndexFor(workflow);
+			await service.updateIndexFor(workflow, /* publishedVersionId= */ null);
 
 			expect(mockWorkflowDependencyRepository.updateDependenciesForWorkflow).toHaveBeenCalledWith(
 				'workflow-123',
@@ -396,7 +396,7 @@ describe('WorkflowIndexService', () => {
 				} as INode,
 			]);
 
-			await service.updateIndexFor(workflow);
+			await service.updateIndexFor(workflow, /* publishedVersionId= */ null);
 
 			expect(mockWorkflowDependencyRepository.updateDependenciesForWorkflow).toHaveBeenCalledWith(
 				'workflow-123',

--- a/packages/cli/src/modules/workflow-index/workflow-index.service.ts
+++ b/packages/cli/src/modules/workflow-index/workflow-index.service.ts
@@ -1,4 +1,5 @@
 import { Logger } from '@n8n/backend-common';
+import type { IWorkflowDb, WorkflowEntity } from '@n8n/db';
 import { WorkflowDependencies, WorkflowDependencyRepository, WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { ErrorReporter } from 'n8n-core';
@@ -47,6 +48,9 @@ export class WorkflowIndexService {
 				workflowId,
 				/*publishedVersionId=*/ null,
 			);
+		});
+		this.eventService.on('workflow-activated', async ({ workflow }) => {
+			await this.updateIndexForPublishedVersion(workflow);
 		});
 	}
 

--- a/packages/cli/src/services/import.service.ts
+++ b/packages/cli/src/services/import.service.ts
@@ -181,7 +181,7 @@ export class ImportService {
 		// Directly update the index for the important workflows, since they don't generate
 		// workflow-update events during import.
 		for (const workflow of insertedWorkflows) {
-			await this.workflowIndexService.updateIndexFor(workflow);
+			await this.workflowIndexService.updateIndexFor(workflow, /* publishedVersionId= */ null);
 		}
 	}
 

--- a/packages/cli/src/services/import.service.ts
+++ b/packages/cli/src/services/import.service.ts
@@ -181,7 +181,7 @@ export class ImportService {
 		// Directly update the index for the important workflows, since they don't generate
 		// workflow-update events during import.
 		for (const workflow of insertedWorkflows) {
-			await this.workflowIndexService.updateIndexFor(workflow, /* publishedVersionId= */ null);
+			await this.workflowIndexService.updateIndexForDraft(workflow);
 		}
 	}
 

--- a/packages/cli/test/integration/database/repositories/workflow-dependency.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/workflow-dependency.repository.test.ts
@@ -232,10 +232,7 @@ describe('WorkflowDependencyRepository', () => {
 			//
 			// ACT
 			//
-			const result = await workflowDependencyRepository.removeDependenciesForWorkflow(
-				workflow.id,
-				null,
-			);
+			const result = await workflowDependencyRepository.removeDependenciesForWorkflow(workflow.id);
 
 			//
 			// ASSERT
@@ -256,10 +253,7 @@ describe('WorkflowDependencyRepository', () => {
 			//
 			// ACT
 			//
-			const result = await workflowDependencyRepository.removeDependenciesForWorkflow(
-				workflow.id,
-				null,
-			);
+			const result = await workflowDependencyRepository.removeDependenciesForWorkflow(workflow.id);
 
 			//
 			// ASSERT

--- a/packages/cli/test/integration/import.service.test.ts
+++ b/packages/cli/test/integration/import.service.test.ts
@@ -97,7 +97,7 @@ describe('ImportService', () => {
 		if (!dbWorkflow) fail('Expected to find workflow');
 
 		expect(dbWorkflow.id).toBe(workflowToImport.id);
-		expect(mockWorkflowIndexService.updateIndexFor).toHaveBeenCalledWith(workflowToImport);
+		expect(mockWorkflowIndexService.updateIndexFor).toHaveBeenCalledWith(workflowToImport, null);
 	});
 
 	test('should make user owner of imported workflow', async () => {

--- a/packages/cli/test/integration/import.service.test.ts
+++ b/packages/cli/test/integration/import.service.test.ts
@@ -97,7 +97,7 @@ describe('ImportService', () => {
 		if (!dbWorkflow) fail('Expected to find workflow');
 
 		expect(dbWorkflow.id).toBe(workflowToImport.id);
-		expect(mockWorkflowIndexService.updateIndexFor).toHaveBeenCalledWith(workflowToImport, null);
+		expect(mockWorkflowIndexService.updateIndexForDraft).toHaveBeenCalledWith(workflowToImport);
 	});
 
 	test('should make user owner of imported workflow', async () => {

--- a/packages/cli/test/integration/workflows/workflow-index.test.ts
+++ b/packages/cli/test/integration/workflows/workflow-index.test.ts
@@ -1,5 +1,10 @@
 import { Logger } from '@n8n/backend-common';
-import { testDb } from '@n8n/backend-test-utils';
+import {
+	testDb,
+	createWorkflow,
+	createWorkflowHistory,
+	setActiveVersion,
+} from '@n8n/backend-test-utils';
 import type { IWorkflowDb } from '@n8n/db';
 import { WorkflowDependencyRepository, WorkflowRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
@@ -39,7 +44,7 @@ beforeAll(async () => {
 });
 
 afterEach(async () => {
-	await testDb.truncate(['WorkflowEntity', 'WorkflowDependency']);
+	await testDb.truncate(['WorkflowEntity', 'WorkflowDependency', 'WorkflowHistory']);
 });
 
 afterAll(async () => {
@@ -47,9 +52,104 @@ afterAll(async () => {
 });
 
 describe('WorkflowIndexService Integration', () => {
+	const createUserPayload = (owner: Awaited<ReturnType<typeof createOwner>>) => ({
+		id: owner.id,
+		email: owner.email,
+		firstName: owner.firstName,
+		lastName: owner.lastName,
+		role: { slug: owner.role.slug },
+	});
+
+	/**
+	 * Creates a workflow with draft content, indexes it, then creates and indexes
+	 * a published version with different content.
+	 * Returns the workflow (with published nodes) and the published version ID.
+	 */
+	async function createAndIndexDraftAndPublishedWorkflow(
+		owner: Awaited<ReturnType<typeof createOwner>>,
+	) {
+		const draftWorkflow = await createWorkflow({
+			name: 'Workflow with Draft and Published',
+			nodes: [
+				{
+					id: 'node-1',
+					name: 'HTTP Request',
+					type: 'n8n-nodes-base.httpRequest',
+					typeVersion: 1,
+					position: [250, 300] as [number, number],
+					parameters: {},
+				},
+			],
+		});
+
+		// Index the draft version
+		eventService.emit('workflow-created', {
+			user: createUserPayload(owner),
+			workflow: draftWorkflow,
+			publicApi: false,
+			projectId: uuid(),
+			projectType: 'personal',
+		});
+
+		await retryUntil(async () => {
+			const deps = await workflowDependencyRepository.find({
+				where: { workflowId: draftWorkflow.id },
+			});
+			expect(deps).toHaveLength(1);
+		});
+
+		// Create and activate a published version with different content
+		const publishedVersionId = uuid();
+		const publishedNodes = [
+			{
+				id: 'node-2',
+				name: 'Slack',
+				type: 'n8n-nodes-base.slack',
+				typeVersion: 2,
+				position: [250, 300] as [number, number],
+				parameters: {},
+			},
+		];
+
+		draftWorkflow.active = true;
+		draftWorkflow.versionCounter = 2;
+		draftWorkflow.nodes = publishedNodes;
+		const savedWorkflow = await workflowRepository.save(draftWorkflow);
+
+		await createWorkflowHistory({
+			...savedWorkflow,
+			versionId: publishedVersionId,
+			nodes: publishedNodes,
+		});
+		await setActiveVersion(savedWorkflow.id, publishedVersionId);
+		savedWorkflow.activeVersionId = publishedVersionId;
+
+		// Index the published version
+		eventService.emit('workflow-activated', {
+			user: createUserPayload(owner),
+			workflow: savedWorkflow,
+			workflowId: savedWorkflow.id,
+			publicApi: false,
+		});
+
+		// Wait for both draft and published entries to be indexed with their expected content
+		await retryUntil(async () => {
+			const deps = await workflowDependencyRepository.find({
+				where: { workflowId: savedWorkflow.id },
+			});
+			expect(deps).toHaveLength(2);
+
+			const draftDep = deps.find((d) => d.publishedVersionId === null);
+			const publishedDep = deps.find((d) => d.publishedVersionId === publishedVersionId);
+			expect(draftDep).toBeDefined();
+			expect(publishedDep).toBeDefined();
+		});
+
+		return { workflow: savedWorkflow, publishedVersionId };
+	}
+
 	describe('workflow-created event', () => {
 		it('should index a new workflow with a single node', async () => {
-			// Arrange
 			const owner = await createOwner();
 			const workflowId = uuid();
 			const versionId = uuid();
@@ -79,18 +179,10 @@ describe('WorkflowIndexService Integration', () => {
 				updatedAt: new Date(),
 			} satisfies IWorkflowDb;
 
-			// Save the workflow to the database
 			const savedWorkflow = await workflowRepository.save(workflow);
 
-			// Act - emit the workflow-created event
 			eventService.emit('workflow-created', {
-				user: {
-					id: owner.id,
-					email: owner.email,
-					firstName: owner.firstName,
-					lastName: owner.lastName,
-					role: { slug: owner.role.slug },
-				},
+				user: createUserPayload(owner),
 				workflow: savedWorkflow,
 				publicApi: false,
 				projectId: uuid(),
@@ -98,7 +190,6 @@ describe('WorkflowIndexService Integration', () => {
 			});
 
 			await retryUntil(async () => {
-				// Assert - check that dependencies were indexed in the database
 				const dependencies = await workflowDependencyRepository.find({
 					where: { workflowId },
 				});
@@ -115,6 +206,68 @@ describe('WorkflowIndexService Integration', () => {
 					},
 					indexVersionId: 1,
 				});
+			});
+		});
+	});
+
+	describe('workflow-activated event (published version indexing)', () => {
+		it('should keep draft and published dependencies separate', async () => {
+			const owner = await createOwner();
+			const { workflow, publishedVersionId } = await createAndIndexDraftAndPublishedWorkflow(owner);
+
+			await retryUntil(async () => {
+				const allDependencies = await workflowDependencyRepository.find({
+					where: { workflowId: workflow.id },
+					order: { publishedVersionId: 'ASC' },
+				});
+
+				expect(allDependencies).toHaveLength(2);
+
+				const draftDep = allDependencies.find((d) => d.publishedVersionId === null);
+				expect(draftDep).toMatchObject({
+					workflowId: workflow.id,
+					publishedVersionId: null,
+					dependencyType: 'nodeType',
+					dependencyKey: 'n8n-nodes-base.httpRequest',
+					dependencyInfo: {
+						nodeId: 'node-1',
+						nodeVersion: 1,
+					},
+				});
+
+				const publishedDep = allDependencies.find((d) => d.publishedVersionId !== null);
+				expect(publishedDep).toMatchObject({
+					workflowId: workflow.id,
+					publishedVersionId,
+					dependencyType: 'nodeType',
+					dependencyKey: 'n8n-nodes-base.slack',
+					dependencyInfo: {
+						nodeId: 'node-2',
+						nodeVersion: 2,
+					},
+				});
+			});
+		});
+	});
+
+	describe('workflow-deleted event', () => {
+		it('should remove both draft and published index entries', async () => {
+			const owner = await createOwner();
+			const { workflow } = await createAndIndexDraftAndPublishedWorkflow(owner);
+
+			// Delete the workflow
+			eventService.emit('workflow-deleted', {
+				user: createUserPayload(owner),
+				workflowId: workflow.id,
+				publicApi: false,
+			});
+
+			// Verify all entries are removed
+			await retryUntil(async () => {
+				const remainingDeps = await workflowDependencyRepository.find({
+					where: { workflowId: workflow.id },
+				});
+				expect(remainingDeps).toHaveLength(0);
 			});
 		});
 	});


### PR DESCRIPTION
## Summary

Actually build the index for both draft and published versions.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/cat-2075

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
