### PR TITLE
fix(core): Support scoped package names with dots in node type parsing

### DIFF
--- a/packages/cli/src/load-nodes-and-credentials.ts
+++ b/packages/cli/src/load-nodes-and-credentials.ts
@@ -557,15 +557,20 @@ export class LoadNodesAndCredentials {
 		}
 	}
 
+	private parseFullNodeType(fullNodeType: string): [string, string] {
+		const lastDotIndex = fullNodeType.lastIndexOf('.');
+		return [fullNodeType.substring(0, lastDotIndex), fullNodeType.substring(lastDotIndex + 1)];
+	}
+
 	recognizesNode(fullNodeType: string): boolean {
-		const [packageName, nodeType] = fullNodeType.split('.');
+		const [packageName, nodeType] = this.parseFullNodeType(fullNodeType);
 		const { loaders } = this;
 		const loader = loaders[packageName];
 		return !!loader && nodeType in loader.known.nodes;
 	}
 
 	getNode(fullNodeType: string): LoadedClass<INodeType | IVersionedNodeType> {
-		const [packageName, nodeType] = fullNodeType.split('.');
+		const [packageName, nodeType] = this.parseFullNodeType(fullNodeType);
 		const { loaders } = this;
 		const loader = loaders[packageName];
 		if (!loader) {

--- a/packages/core/nodes-testing/load-nodes-and-credentials.ts
+++ b/packages/core/nodes-testing/load-nodes-and-credentials.ts
@@ -85,7 +85,9 @@ export class LoadNodesAndCredentials {
 	}
 
 	getNode(fullNodeType: string): LoadedClass<INodeType | IVersionedNodeType> {
-		const [packageName, nodeType] = fullNodeType.split('.');
+		const lastDotIndex = fullNodeType.lastIndexOf('.');
+		const packageName = fullNodeType.substring(0, lastDotIndex);
+		const nodeType = fullNodeType.substring(lastDotIndex + 1);
 		const { loaders } = this;
 		const loader = loaders[packageName];
 		if (!loader) {

--- a/packages/core/src/nodes-loader/directory-loader.ts
+++ b/packages/core/src/nodes-loader/directory-loader.ts
@@ -139,7 +139,10 @@ export abstract class DirectoryLoader {
 
 	protected extractNodeTypes(fullNodeTypes: string[], packageName: string): string[] {
 		return fullNodeTypes
-			.map((fullNodeType) => fullNodeType.split('.'))
+			.map((fullNodeType) => {
+				const lastDotIndex = fullNodeType.lastIndexOf('.');
+				return [fullNodeType.substring(0, lastDotIndex), fullNodeType.substring(lastDotIndex + 1)];
+			})
 			.filter(([pkg]) => pkg === packageName)
 			.map(([_, nodeType]) => nodeType);
 	}


### PR DESCRIPTION
## Summary

Fixed an issue where scoped npm package names containing dots (e.g., `@my.org/n8n-nodes-my-package`) were incorrectly parsed when loading custom nodes.

### Problem

Package names like `@my.org/n8n-nodes-my-package` were incorrectly parsed because `split('.')` was used to separate package name from node type.

```
"@my.org/n8n-nodes-my-package.MyNode".split('.')
→ ["@my", "org/n8n-nodes-my-package", "MyNode"]  // Wrong!
```

### Solution

Changed to use `lastIndexOf('.')` to correctly handle dots in scoped package names.

```
Using lastIndexOf('.')
→ packageName: "@my.org/n8n-nodes-my-package"
→ nodeType: "MyNode"  // Correct!
```

### Files Modified

- `packages/core/src/nodes-loader/directory-loader.ts` (`extractNodeTypes`)
- `packages/cli/src/load-nodes-and-credentials.ts` (`recognizesNode`, `getNode`)
- `packages/core/nodes-testing/load-nodes-and-credentials.ts` (`getNode`)

### Tests Added

- `packages/cli/src/__tests__/node-types.test.ts` - Tests for scoped package with dot in org name
- `packages/core/src/nodes-loader/__tests__/directory-loader.test.ts` - Tests for `includeNodes`/`excludeNodes` with dotted scoped packages

## Related Linear tickets, Github issues, and Community forum posts

N/A - Community contribution for custom node package name support

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
