### PR TITLE
fix(core): Allow manual execution from pinned trigger with no destination node

### DIFF
--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -530,6 +530,18 @@ describe('WorkflowExecutionService', () => {
 
 			expect(node).toEqual(secondWebhookNode);
 		});
+
+		it('should return first pinned trigger if no destination node', () => {
+			workflow.nodes.push(webhookNode, executeWorkflowTriggerNode, hackerNewsNode);
+			workflow.connections = {
+				...createMainConnection(hackerNewsNode.name, webhookNode.name),
+				...createMainConnection(hackerNewsNode.name, executeWorkflowTriggerNode.name),
+			};
+
+			const node = workflowExecutionService.selectPinnedTrigger(workflow, undefined, pinData);
+
+			expect(node).toEqual(webhookNode);
+		});
 	});
 
 	describe('offloading manual executions to workers', () => {

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -136,6 +136,8 @@ export class WorkflowExecutionService {
 			}
 		}
 
+		console.log(payload);
+
 		// Case 2: Full execution from a known trigger.
 		if (isFullExecutionFromKnownTrigger(payload)) {
 			// Check if we need a webhook.
@@ -455,19 +457,23 @@ export class WorkflowExecutionService {
 	 * trigger types in the sorting order.
 	 *
 	 * @param workflow The workflow containing the nodes and connections
-	 * @param destinationNode The name of the node to find a pinned trigger for
+	 * @param destinationNode The name of the node to find a pinned trigger for. If undefined, any pinned trigger is valid.
 	 * @param pinData Pin data mapping node names to their pinned data
 	 * @returns The pinned trigger node if found, undefined otherwise
 	 */
 	selectPinnedTrigger(
 		workflow: IWorkflowBase,
-		destinationNode: string,
+		destinationNode: string | undefined,
 		pinData: IPinData,
 	): INode | undefined {
 		const allPinnedTriggers = this.findAllPinnedTriggers(workflow, pinData);
 
 		if (allPinnedTriggers.length === 0) return undefined;
 
+		if (destinationNode === undefined) {
+			// If there's no destination node, return the first pinned trigger.
+			return allPinnedTriggers[0];
+		}
 		const destinationParents = new Set(
 			new Workflow({
 				nodes: workflow.nodes,


### PR DESCRIPTION
## Summary

Allow manual executions with neither start node or destination node.

WIP. Still need to do something with the request types to reflect this (either introduce a new variant, or update the existing one).

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
