### PR TITLE
feat(editor): Add dynamic templates experiment (no-changelog)

### DIFF
--- a/packages/@n8n/config/src/configs/templates.config.ts
+++ b/packages/@n8n/config/src/configs/templates.config.ts
@@ -9,4 +9,8 @@ export class TemplatesConfig {
 	/** Host to retrieve workflow templates from endpoints. */
 	@Env('N8N_TEMPLATES_HOST')
 	host: string = 'https://api.n8n.io/api/';
+
+	/** Host to retrieve dynamic templates from. */
+	@Env('N8N_DYNAMIC_TEMPLATES_HOST')
+	dynamicTemplatesHost: string = 'https://dynamic-templates.n8n.io/templates';
 }

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -169,6 +169,7 @@ describe('GlobalConfig', () => {
 		templates: {
 			enabled: true,
 			host: 'https://api.n8n.io/api/',
+			dynamicTemplatesHost: 'https://dynamic-templates.n8n.io/templates',
 		},
 		versionNotifications: {
 			enabled: true,

--- a/packages/cli/src/controllers/__tests__/dynamic-templates.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/dynamic-templates.controller.test.ts
@@ -1,0 +1,66 @@
+import type { AuthenticatedRequest } from '@n8n/db';
+import { mock } from 'jest-mock-extended';
+
+import { DynamicTemplatesController } from '@/controllers/dynamic-templates.controller';
+import { InternalServerError } from '@/errors/response-errors/internal-server.error';
+import type { DynamicTemplatesService } from '@/services/dynamic-templates.service';
+
+describe('DynamicTemplatesController', () => {
+	const mockDynamicTemplatesService = mock<DynamicTemplatesService>();
+	let dynamicTemplatesController: DynamicTemplatesController;
+	let mockRequest: AuthenticatedRequest;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		dynamicTemplatesController = new DynamicTemplatesController(mockDynamicTemplatesService);
+		mockRequest = { user: { id: 'user-123' } } as unknown as AuthenticatedRequest;
+	});
+
+	describe('getRecommendedTemplates', () => {
+		it('should return templates from the service', async () => {
+			const mockTemplates = [
+				{ id: 1, name: 'Template 1' },
+				{ id: 2, name: 'Template 2' },
+			];
+
+			mockDynamicTemplatesService.fetchDynamicTemplates.mockResolvedValue(mockTemplates);
+
+			const result = await dynamicTemplatesController.getRecommendedTemplates(mockRequest);
+
+			expect(result).toEqual({ templates: mockTemplates });
+			expect(mockDynamicTemplatesService.fetchDynamicTemplates).toHaveBeenCalledTimes(1);
+		});
+
+		it('should return empty templates array when service returns empty', async () => {
+			mockDynamicTemplatesService.fetchDynamicTemplates.mockResolvedValue([]);
+
+			const result = await dynamicTemplatesController.getRecommendedTemplates(mockRequest);
+
+			expect(result).toEqual({ templates: [] });
+		});
+
+		it('should throw InternalServerError when service fails', async () => {
+			mockDynamicTemplatesService.fetchDynamicTemplates.mockRejectedValue(
+				new Error('External API error'),
+			);
+
+			await expect(dynamicTemplatesController.getRecommendedTemplates(mockRequest)).rejects.toThrow(
+				InternalServerError,
+			);
+		});
+
+		it('should throw InternalServerError with correct message when service fails', async () => {
+			mockDynamicTemplatesService.fetchDynamicTemplates.mockRejectedValue(
+				new Error('Network timeout'),
+			);
+
+			try {
+				await dynamicTemplatesController.getRecommendedTemplates(mockRequest);
+				fail('Expected error to be thrown');
+			} catch (error) {
+				expect(error).toBeInstanceOf(InternalServerError);
+				expect((error as InternalServerError).message).toBe('Failed to fetch dynamic templates');
+			}
+		});
+	});
+});

--- a/packages/cli/src/controllers/__tests__/dynamic-templates.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/dynamic-templates.controller.test.ts
@@ -16,7 +16,7 @@ describe('DynamicTemplatesController', () => {
 		mockRequest = { user: { id: 'user-123' } } as unknown as AuthenticatedRequest;
 	});
 
-	describe('getRecommendedTemplates', () => {
+	describe('get', () => {
 		it('should return templates from the service', async () => {
 			const mockTemplates = [
 				{ id: 1, name: 'Template 1' },
@@ -25,7 +25,7 @@ describe('DynamicTemplatesController', () => {
 
 			mockDynamicTemplatesService.fetchDynamicTemplates.mockResolvedValue(mockTemplates);
 
-			const result = await dynamicTemplatesController.getRecommendedTemplates(mockRequest);
+			const result = await dynamicTemplatesController.get(mockRequest);
 
 			expect(result).toEqual({ templates: mockTemplates });
 			expect(mockDynamicTemplatesService.fetchDynamicTemplates).toHaveBeenCalledTimes(1);
@@ -34,7 +34,7 @@ describe('DynamicTemplatesController', () => {
 		it('should return empty templates array when service returns empty', async () => {
 			mockDynamicTemplatesService.fetchDynamicTemplates.mockResolvedValue([]);
 
-			const result = await dynamicTemplatesController.getRecommendedTemplates(mockRequest);
+			const result = await dynamicTemplatesController.get(mockRequest);
 
 			expect(result).toEqual({ templates: [] });
 		});
@@ -44,7 +44,7 @@ describe('DynamicTemplatesController', () => {
 				new Error('External API error'),
 			);
 
-			await expect(dynamicTemplatesController.getRecommendedTemplates(mockRequest)).rejects.toThrow(
+			await expect(dynamicTemplatesController.get(mockRequest)).rejects.toThrow(
 				InternalServerError,
 			);
 		});
@@ -55,7 +55,7 @@ describe('DynamicTemplatesController', () => {
 			);
 
 			try {
-				await dynamicTemplatesController.getRecommendedTemplates(mockRequest);
+				await dynamicTemplatesController.get(mockRequest);
 				fail('Expected error to be thrown');
 			} catch (error) {
 				expect(error).toBeInstanceOf(InternalServerError);

--- a/packages/cli/src/controllers/dynamic-templates.controller.ts
+++ b/packages/cli/src/controllers/dynamic-templates.controller.ts
@@ -1,0 +1,20 @@
+import type { AuthenticatedRequest } from '@n8n/db';
+import { Get, RestController } from '@n8n/decorators';
+
+import { InternalServerError } from '@/errors/response-errors/internal-server.error';
+import { DynamicTemplatesService } from '@/services/dynamic-templates.service';
+
+@RestController('/dynamic-templates')
+export class DynamicTemplatesController {
+	constructor(private readonly dynamicTemplatesService: DynamicTemplatesService) {}
+
+	@Get('/')
+	async getRecommendedTemplates(_req: AuthenticatedRequest) {
+		try {
+			const templates = await this.dynamicTemplatesService.fetchDynamicTemplates();
+			return { templates };
+		} catch {
+			throw new InternalServerError('Failed to fetch dynamic templates');
+		}
+	}
+}

--- a/packages/cli/src/controllers/dynamic-templates.controller.ts
+++ b/packages/cli/src/controllers/dynamic-templates.controller.ts
@@ -9,7 +9,7 @@ export class DynamicTemplatesController {
 	constructor(private readonly dynamicTemplatesService: DynamicTemplatesService) {}
 
 	@Get('/')
-	async getRecommendedTemplates(_req: AuthenticatedRequest) {
+	async get(_req: AuthenticatedRequest) {
 		try {
 			const templates = await this.dynamicTemplatesService.fetchDynamicTemplates();
 			return { templates };

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -35,6 +35,7 @@ import '@/controllers/auth.controller';
 import '@/controllers/binary-data.controller';
 import '@/controllers/ai.controller';
 import '@/controllers/dynamic-node-parameters.controller';
+import '@/controllers/dynamic-templates.controller';
 import '@/controllers/invitation.controller';
 import '@/controllers/me.controller';
 import '@/controllers/node-types.controller';

--- a/packages/cli/src/services/__tests__/dynamic-templates.service.test.ts
+++ b/packages/cli/src/services/__tests__/dynamic-templates.service.test.ts
@@ -1,24 +1,26 @@
 import type { Logger } from '@n8n/backend-common';
+import type { GlobalConfig } from '@n8n/config';
 import axios from 'axios';
 import { mock } from 'jest-mock-extended';
 
-import {
-	DynamicTemplatesService,
-	DYNAMIC_TEMPLATES_URL,
-	REQUEST_TIMEOUT_MS,
-} from '@/services/dynamic-templates.service';
+import { DynamicTemplatesService, REQUEST_TIMEOUT_MS } from '@/services/dynamic-templates.service';
 
 jest.mock('axios');
 
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
+const MOCK_DYNAMIC_TEMPLATES_HOST = 'https://dynamic-templates.n8n.io/templates';
+
 describe('DynamicTemplatesService', () => {
 	const mockLogger = mock<Logger>();
+	const mockGlobalConfig = mock<GlobalConfig>({
+		templates: { dynamicTemplatesHost: MOCK_DYNAMIC_TEMPLATES_HOST },
+	});
 	let dynamicTemplatesService: DynamicTemplatesService;
 
 	beforeEach(() => {
 		jest.clearAllMocks();
-		dynamicTemplatesService = new DynamicTemplatesService(mockLogger);
+		dynamicTemplatesService = new DynamicTemplatesService(mockLogger, mockGlobalConfig);
 	});
 
 	describe('fetchDynamicTemplates', () => {
@@ -35,7 +37,7 @@ describe('DynamicTemplatesService', () => {
 			const result = await dynamicTemplatesService.fetchDynamicTemplates();
 
 			expect(result).toEqual(mockTemplates);
-			expect(mockedAxios.get).toHaveBeenCalledWith(DYNAMIC_TEMPLATES_URL, {
+			expect(mockedAxios.get).toHaveBeenCalledWith(MOCK_DYNAMIC_TEMPLATES_HOST, {
 				headers: { 'Content-Type': 'application/json' },
 				timeout: REQUEST_TIMEOUT_MS,
 			});

--- a/packages/cli/src/services/__tests__/dynamic-templates.service.test.ts
+++ b/packages/cli/src/services/__tests__/dynamic-templates.service.test.ts
@@ -1,0 +1,76 @@
+import type { Logger } from '@n8n/backend-common';
+import axios from 'axios';
+import { mock } from 'jest-mock-extended';
+
+import {
+	DynamicTemplatesService,
+	DYNAMIC_TEMPLATES_URL,
+	REQUEST_TIMEOUT_MS,
+} from '@/services/dynamic-templates.service';
+
+jest.mock('axios');
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('DynamicTemplatesService', () => {
+	const mockLogger = mock<Logger>();
+	let dynamicTemplatesService: DynamicTemplatesService;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		dynamicTemplatesService = new DynamicTemplatesService(mockLogger);
+	});
+
+	describe('fetchDynamicTemplates', () => {
+		it('should return templates from the external API', async () => {
+			const mockTemplates = [
+				{ id: 1, name: 'Template 1' },
+				{ id: 2, name: 'Template 2' },
+			];
+
+			mockedAxios.get.mockResolvedValue({
+				data: { templates: mockTemplates },
+			});
+
+			const result = await dynamicTemplatesService.fetchDynamicTemplates();
+
+			expect(result).toEqual(mockTemplates);
+			expect(mockedAxios.get).toHaveBeenCalledWith(DYNAMIC_TEMPLATES_URL, {
+				headers: { 'Content-Type': 'application/json' },
+				timeout: REQUEST_TIMEOUT_MS,
+			});
+		});
+
+		it('should return empty array when API returns empty templates', async () => {
+			mockedAxios.get.mockResolvedValue({
+				data: { templates: [] },
+			});
+
+			const result = await dynamicTemplatesService.fetchDynamicTemplates();
+
+			expect(result).toEqual([]);
+		});
+
+		it('should log error and throw when API call fails', async () => {
+			const mockError = new Error('Network error');
+			mockedAxios.get.mockRejectedValue(mockError);
+
+			await expect(dynamicTemplatesService.fetchDynamicTemplates()).rejects.toThrow(
+				'Network error',
+			);
+			expect(mockLogger.error).toHaveBeenCalledWith('Error fetching dynamic templates', {
+				error: mockError,
+			});
+		});
+
+		it('should throw on timeout', async () => {
+			const timeoutError = new Error(`timeout of ${REQUEST_TIMEOUT_MS}ms exceeded`);
+			mockedAxios.get.mockRejectedValue(timeoutError);
+
+			await expect(dynamicTemplatesService.fetchDynamicTemplates()).rejects.toThrow(
+				`timeout of ${REQUEST_TIMEOUT_MS}ms exceeded`,
+			);
+			expect(mockLogger.error).toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/cli/src/services/dynamic-templates.service.ts
+++ b/packages/cli/src/services/dynamic-templates.service.ts
@@ -1,0 +1,26 @@
+import { Logger } from '@n8n/backend-common';
+import { Service } from '@n8n/di';
+import axios from 'axios';
+
+export const DYNAMIC_TEMPLATES_URL = 'https://dynamic-templates.n8n.io/templates';
+export const REQUEST_TIMEOUT_MS = 5000;
+
+type DynamicTemplate = Record<string, unknown>;
+
+@Service()
+export class DynamicTemplatesService {
+	constructor(private readonly logger: Logger) {}
+
+	async fetchDynamicTemplates(): Promise<DynamicTemplate[]> {
+		try {
+			const response = await axios.get<{ templates: DynamicTemplate[] }>(DYNAMIC_TEMPLATES_URL, {
+				headers: { 'Content-Type': 'application/json' },
+				timeout: REQUEST_TIMEOUT_MS,
+			});
+			return response.data.templates;
+		} catch (error) {
+			this.logger.error('Error fetching dynamic templates', { error });
+			throw error;
+		}
+	}
+}

--- a/packages/cli/src/services/dynamic-templates.service.ts
+++ b/packages/cli/src/services/dynamic-templates.service.ts
@@ -15,6 +15,9 @@ export class DynamicTemplatesService {
 	) {}
 
 	async fetchDynamicTemplates(): Promise<DynamicTemplate[]> {
+		if (!this.globalConfig.templates.dynamicTemplatesHost) {
+			return [];
+		}
 		try {
 			const response = await axios.get<{ templates: DynamicTemplate[] }>(
 				this.globalConfig.templates.dynamicTemplatesHost,

--- a/packages/cli/src/services/dynamic-templates.service.ts
+++ b/packages/cli/src/services/dynamic-templates.service.ts
@@ -1,22 +1,28 @@
 import { Logger } from '@n8n/backend-common';
+import { GlobalConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
 import axios from 'axios';
 
-export const DYNAMIC_TEMPLATES_URL = 'https://dynamic-templates.n8n.io/templates';
 export const REQUEST_TIMEOUT_MS = 5000;
 
 type DynamicTemplate = Record<string, unknown>;
 
 @Service()
 export class DynamicTemplatesService {
-	constructor(private readonly logger: Logger) {}
+	constructor(
+		private readonly logger: Logger,
+		private readonly globalConfig: GlobalConfig,
+	) {}
 
 	async fetchDynamicTemplates(): Promise<DynamicTemplate[]> {
 		try {
-			const response = await axios.get<{ templates: DynamicTemplate[] }>(DYNAMIC_TEMPLATES_URL, {
-				headers: { 'Content-Type': 'application/json' },
-				timeout: REQUEST_TIMEOUT_MS,
-			});
+			const response = await axios.get<{ templates: DynamicTemplate[] }>(
+				this.globalConfig.templates.dynamicTemplatesHost,
+				{
+					headers: { 'Content-Type': 'application/json' },
+					timeout: REQUEST_TIMEOUT_MS,
+				},
+			);
 			return response.data.templates;
 		} catch (error) {
 			this.logger.error('Error fetching dynamic templates', { error });

--- a/packages/frontend/editor-ui/src/app/constants/experiments.ts
+++ b/packages/frontend/editor-ui/src/app/constants/experiments.ts
@@ -67,7 +67,7 @@ export const RESOURCE_CENTER_EXPERIMENT = createExperiment('063_resource_center_
 	variantInspiration: 'variant-inspiration',
 });
 
-export const DYNAMIC_TEMPLATES_EXPERIMENT = createExperiment('064_dynamic_templates');
+export const DYNAMIC_TEMPLATES_EXPERIMENT = createExperiment('068_dynamic_templates');
 
 export const EXPERIMENTS_TO_TRACK = [
 	EXTRA_TEMPLATE_LINKS_EXPERIMENT.name,

--- a/packages/frontend/editor-ui/src/app/constants/experiments.ts
+++ b/packages/frontend/editor-ui/src/app/constants/experiments.ts
@@ -67,6 +67,8 @@ export const RESOURCE_CENTER_EXPERIMENT = createExperiment('063_resource_center_
 	variantInspiration: 'variant-inspiration',
 });
 
+export const DYNAMIC_TEMPLATES_EXPERIMENT = createExperiment('064_dynamic_templates');
+
 export const EXPERIMENTS_TO_TRACK = [
 	EXTRA_TEMPLATE_LINKS_EXPERIMENT.name,
 	TEMPLATE_ONBOARDING_EXPERIMENT.name,
@@ -80,4 +82,5 @@ export const EXPERIMENTS_TO_TRACK = [
 	COLLECTION_OVERHAUL_EXPERIMENT.name,
 	TAMPER_PROOF_INVITE_LINKS.name,
 	EMPTY_STATE_BUILDER_PROMPT_EXPERIMENT.name,
+	DYNAMIC_TEMPLATES_EXPERIMENT.name,
 ];

--- a/packages/frontend/editor-ui/src/features/workflows/templates/recommendations/dynamicTemplates.api.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/recommendations/dynamicTemplates.api.ts
@@ -2,7 +2,7 @@ import type { IRestApiContext, ITemplatesWorkflowFull } from '@n8n/rest-api-clie
 import { makeRestApiRequest } from '@n8n/rest-api-client';
 
 export interface DynamicTemplatesResponse {
-	templates: { workflow: ITemplatesWorkflowFull }[];
+	templates: Array<{ workflow: ITemplatesWorkflowFull }>;
 }
 
 export async function getDynamicRecommendedTemplates(

--- a/packages/frontend/editor-ui/src/features/workflows/templates/recommendations/dynamicTemplates.api.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/recommendations/dynamicTemplates.api.ts
@@ -1,0 +1,12 @@
+import type { IRestApiContext, ITemplatesWorkflowFull } from '@n8n/rest-api-client';
+import { makeRestApiRequest } from '@n8n/rest-api-client';
+
+export interface DynamicTemplatesResponse {
+	templates: { workflow: ITemplatesWorkflowFull }[];
+}
+
+export async function getDynamicRecommendedTemplates(
+	ctx: IRestApiContext,
+): Promise<DynamicTemplatesResponse> {
+	return await makeRestApiRequest(ctx, 'GET', '/dynamic-templates');
+}

--- a/packages/frontend/editor-ui/src/features/workflows/templates/recommendations/recommendedTemplates.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/recommendations/recommendedTemplates.store.test.ts
@@ -1,0 +1,239 @@
+import { createPinia, setActivePinia } from 'pinia';
+import type { ITemplatesWorkflowFull } from '@n8n/rest-api-client';
+import { mock } from 'vitest-mock-extended';
+import { useRecommendedTemplatesStore, NUMBER_OF_TEMPLATES } from './recommendedTemplates.store';
+import { VIEWS } from '@/app/constants';
+
+const { getDynamicRecommendedTemplates, mockTelemetry, mockPostHog, mockFetchTemplateById } =
+	vi.hoisted(() => {
+		return {
+			getDynamicRecommendedTemplates: vi.fn(),
+			mockTelemetry: {
+				track: vi.fn(),
+			},
+			mockPostHog: {
+				isVariantEnabled: vi.fn(),
+			},
+			mockFetchTemplateById: vi.fn(),
+		};
+	});
+
+vi.mock('./dynamicTemplates.api', () => ({
+	getDynamicRecommendedTemplates,
+}));
+
+vi.mock('@/app/composables/useTelemetry', () => ({
+	useTelemetry: () => mockTelemetry,
+}));
+
+vi.mock('@/app/stores/settings.store', () => ({
+	useSettingsStore: vi.fn(() => ({
+		isTemplatesEnabled: true,
+	})),
+}));
+
+vi.mock('@/app/stores/nodeTypes.store', () => ({
+	useNodeTypesStore: vi.fn(() => ({
+		loadNodeTypesIfNotLoaded: vi.fn(),
+	})),
+}));
+
+vi.mock('@/app/stores/posthog.store', () => ({
+	usePostHog: () => mockPostHog,
+}));
+
+vi.mock('@n8n/stores/useRootStore', () => ({
+	useRootStore: vi.fn(() => ({
+		restApiContext: { baseUrl: '/rest' },
+	})),
+}));
+
+vi.mock('@/features/workflows/templates/templates.store', () => ({
+	useTemplatesStore: vi.fn(() => ({
+		hasCustomTemplatesHost: false,
+		fetchTemplateById: mockFetchTemplateById,
+	})),
+}));
+
+const createMockTemplate = (id: number): ITemplatesWorkflowFull =>
+	mock<ITemplatesWorkflowFull>({
+		id,
+		name: `Template ${id}`,
+		full: true,
+	});
+
+describe('useRecommendedTemplatesStore', () => {
+	let store: ReturnType<typeof useRecommendedTemplatesStore>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		setActivePinia(createPinia());
+		store = useRecommendedTemplatesStore();
+	});
+
+	describe('isFeatureEnabled', () => {
+		it('should return true when templates are enabled and no custom host', () => {
+			expect(store.isFeatureEnabled()).toBe(true);
+		});
+	});
+
+	describe('getRandomTemplateIds', () => {
+		it('should return the correct number of template IDs', () => {
+			const ids = store.getRandomTemplateIds();
+			expect(ids).toHaveLength(NUMBER_OF_TEMPLATES);
+		});
+
+		it('should return unique IDs', () => {
+			const ids = store.getRandomTemplateIds();
+			const uniqueIds = new Set(ids);
+			expect(uniqueIds.size).toBe(ids.length);
+		});
+	});
+
+	describe('getTemplateRoute', () => {
+		it('should return the correct route object', () => {
+			const route = store.getTemplateRoute(123);
+			expect(route).toEqual({
+				name: VIEWS.TEMPLATE,
+				params: { id: 123 },
+			});
+		});
+	});
+
+	describe('getTemplateData', () => {
+		it('should fetch template by ID', async () => {
+			const mockTemplate = createMockTemplate(123);
+			mockFetchTemplateById.mockResolvedValue(mockTemplate);
+
+			const result = await store.getTemplateData(123);
+
+			expect(mockFetchTemplateById).toHaveBeenCalledWith('123');
+			expect(result).toBe(mockTemplate);
+		});
+
+		it('should return null when template not found', async () => {
+			mockFetchTemplateById.mockResolvedValue(null);
+
+			const result = await store.getTemplateData(999);
+
+			expect(result).toBeNull();
+		});
+	});
+
+	describe('trackTemplateTileClick', () => {
+		it('should track template detail view', () => {
+			store.trackTemplateTileClick(123);
+
+			expect(mockTelemetry.track).toHaveBeenCalledWith('User viewed template detail', {
+				templateId: 123,
+			});
+		});
+	});
+
+	describe('trackTemplateShown', () => {
+		it('should track template cell view', () => {
+			store.trackTemplateShown(123, 2);
+
+			expect(mockTelemetry.track).toHaveBeenCalledWith('User viewed template cell', {
+				tileNumber: 2,
+				templateId: 123,
+			});
+		});
+	});
+
+	describe('loadRecommendedTemplates', () => {
+		describe('when dynamic templates experiment is enabled', () => {
+			beforeEach(() => {
+				mockPostHog.isVariantEnabled.mockReturnValue(true);
+			});
+
+			it('should fetch templates from dynamic API on success', async () => {
+				const mockTemplates = [
+					{ workflow: createMockTemplate(1) },
+					{ workflow: createMockTemplate(2) },
+					{ workflow: createMockTemplate(3) },
+				];
+				getDynamicRecommendedTemplates.mockResolvedValue({ templates: mockTemplates });
+
+				const result = await store.loadRecommendedTemplates();
+
+				expect(getDynamicRecommendedTemplates).toHaveBeenCalledWith({ baseUrl: '/rest' });
+				expect(result).toHaveLength(3);
+				expect(result[0].id).toBe(1);
+				expect(result[1].id).toBe(2);
+				expect(result[2].id).toBe(3);
+			});
+
+			it('should limit templates to NUMBER_OF_TEMPLATES', async () => {
+				const mockTemplates = Array.from({ length: 10 }, (_, i) => ({
+					workflow: createMockTemplate(i + 1),
+				}));
+				getDynamicRecommendedTemplates.mockResolvedValue({ templates: mockTemplates });
+
+				const result = await store.loadRecommendedTemplates();
+
+				expect(result).toHaveLength(NUMBER_OF_TEMPLATES);
+			});
+
+			it('should fallback to static IDs when API fails', async () => {
+				const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+				getDynamicRecommendedTemplates.mockRejectedValue(new Error('API Error'));
+
+				const mockTemplate = createMockTemplate(7607);
+				mockFetchTemplateById.mockResolvedValue(mockTemplate);
+
+				const result = await store.loadRecommendedTemplates();
+
+				expect(consoleSpy).toHaveBeenCalledWith(
+					'Dynamic templates failed, falling back to static IDs',
+					expect.any(Error),
+				);
+				expect(mockFetchTemplateById).toHaveBeenCalled();
+				expect(result.length).toBeGreaterThan(0);
+
+				consoleSpy.mockRestore();
+			});
+
+			it('should return empty array when API returns empty templates', async () => {
+				getDynamicRecommendedTemplates.mockResolvedValue({ templates: [] });
+
+				const result = await store.loadRecommendedTemplates();
+
+				expect(result).toEqual([]);
+			});
+		});
+
+		describe('when dynamic templates experiment is disabled', () => {
+			beforeEach(() => {
+				mockPostHog.isVariantEnabled.mockReturnValue(false);
+			});
+
+			it('should fetch templates using static IDs', async () => {
+				const mockTemplate = createMockTemplate(7607);
+				mockFetchTemplateById.mockResolvedValue(mockTemplate);
+
+				const result = await store.loadRecommendedTemplates();
+
+				expect(getDynamicRecommendedTemplates).not.toHaveBeenCalled();
+				expect(mockFetchTemplateById).toHaveBeenCalled();
+				expect(result.length).toBeGreaterThan(0);
+			});
+
+			it('should filter out failed template fetches', async () => {
+				mockFetchTemplateById
+					.mockResolvedValueOnce(createMockTemplate(1))
+					.mockResolvedValueOnce(null)
+					.mockResolvedValueOnce(createMockTemplate(3))
+					.mockRejectedValueOnce(new Error('Fetch error'))
+					.mockResolvedValueOnce(createMockTemplate(5))
+					.mockResolvedValueOnce(createMockTemplate(6));
+
+				const result = await store.loadRecommendedTemplates();
+
+				// Should only include successfully fetched non-null templates
+				const successfulTemplates = result.filter((t) => t !== null);
+				expect(successfulTemplates.length).toBeLessThanOrEqual(NUMBER_OF_TEMPLATES);
+			});
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/features/workflows/templates/recommendations/recommendedTemplates.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/recommendations/recommendedTemplates.store.test.ts
@@ -220,6 +220,7 @@ describe('useRecommendedTemplatesStore', () => {
 			});
 
 			it('should filter out failed template fetches', async () => {
+				// Setup: 4 successful, 1 null, 1 rejected
 				mockFetchTemplateById
 					.mockResolvedValueOnce(createMockTemplate(1))
 					.mockResolvedValueOnce(null)
@@ -230,9 +231,12 @@ describe('useRecommendedTemplatesStore', () => {
 
 				const result = await store.loadRecommendedTemplates();
 
-				// Should only include successfully fetched non-null templates
-				const successfulTemplates = result.filter((t) => t !== null);
-				expect(successfulTemplates.length).toBeLessThanOrEqual(NUMBER_OF_TEMPLATES);
+				// Verify no null values in result
+				expect(result.every((t) => t !== null)).toBe(true);
+
+				// Verify only successfully fetched templates are included (4 out of 6)
+				expect(result).toHaveLength(4);
+				expect(result.map((t) => t.id)).toEqual([1, 3, 5, 6]);
 			});
 		});
 	});

--- a/packages/frontend/editor-ui/src/features/workflows/templates/recommendations/recommendedTemplates.store.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/recommendations/recommendedTemplates.store.ts
@@ -1,12 +1,15 @@
 import { useTelemetry } from '@/app/composables/useTelemetry';
-import { VIEWS } from '@/app/constants';
+import { DYNAMIC_TEMPLATES_EXPERIMENT, VIEWS } from '@/app/constants';
 import { useTemplatesStore } from '@/features/workflows/templates/templates.store';
 import { defineStore } from 'pinia';
 import templateIds from './data/recommendedTemplateIds.json';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
+import { usePostHog } from '@/app/stores/posthog.store';
+import { useRootStore } from '@n8n/stores/useRootStore';
 import type { ITemplatesWorkflowFull } from '@n8n/rest-api-client';
 import sampleSize from 'lodash/sampleSize';
+import { getDynamicRecommendedTemplates } from './dynamicTemplates.api';
 
 export const NUMBER_OF_TEMPLATES = 6;
 
@@ -15,9 +18,18 @@ export const useRecommendedTemplatesStore = defineStore('recommendedTemplates', 
 	const templatesStore = useTemplatesStore();
 	const settingsStore = useSettingsStore();
 	const nodeTypesStore = useNodeTypesStore();
+	const posthogStore = usePostHog();
+	const rootStore = useRootStore();
 
 	const isFeatureEnabled = () => {
 		return settingsStore.isTemplatesEnabled && !templatesStore.hasCustomTemplatesHost;
+	};
+
+	const isDynamicTemplatesEnabled = () => {
+		return posthogStore.isVariantEnabled(
+			DYNAMIC_TEMPLATES_EXPERIMENT.name,
+			DYNAMIC_TEMPLATES_EXPERIMENT.variant,
+		);
 	};
 
 	async function getTemplateData(templateId: number): Promise<ITemplatesWorkflowFull | null> {
@@ -49,6 +61,19 @@ export const useRecommendedTemplatesStore = defineStore('recommendedTemplates', 
 	async function loadRecommendedTemplates(): Promise<ITemplatesWorkflowFull[]> {
 		await nodeTypesStore.loadNodeTypesIfNotLoaded();
 
+		if (isDynamicTemplatesEnabled()) {
+			try {
+				const response = await getDynamicRecommendedTemplates(rootStore.restApiContext);
+				return response.templates
+					.map((template) => template.workflow)
+					.slice(0, NUMBER_OF_TEMPLATES);
+			} catch (error) {
+				// Fallback to existing behavior on error
+				console.warn('Dynamic templates failed, falling back to static IDs', error);
+			}
+		}
+
+		// Existing behavior (fallback or flag disabled)
 		const ids = getRandomTemplateIds();
 		const promises = ids.map(async (id) => await getTemplateData(id));
 		const results = await Promise.allSettled(promises);


### PR DESCRIPTION
## Summary

As part of https://www.notion.so/n8n/Dynamic-templates-API-2f55b6e0c94f80bd9b97c01ed33e21fa?source=copy_link

Fetch the templates that we show on the empty screen from a new service where they're more dynamically configured. As a next step we'll be updating this request to include user parameters which can be used to pick specific templates based on them.

TODO: make sure that the templates service url is finalized before merging this

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4709/spike-api-to-return-a-list-of-templates

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
