### PR TITLE
fix(MySQL Node): Support "Continue on Error" for connection-related errors

### DIFF
--- a/packages/nodes-base/nodes/MySql/test/v2/mysql.integration.test.ts
+++ b/packages/nodes-base/nodes/MySql/test/v2/mysql.integration.test.ts
@@ -101,9 +101,7 @@ describe('MySQL Integration - NODE-4174', () => {
 		expect(result[0][0].json).toHaveProperty('message');
 	});
 
-	// NODE-4174: createPool() is outside try-catch, so connection errors bypass continueOnFail.
-	// Remove .fails when fixed.
-	test.fails('bug: connection error should return error item with continueOnFail', async () => {
+	test('connection error should return error item with continueOnFail', async () => {
 		const params = {
 			resource: 'database',
 			operation: 'executeQuery',

--- a/packages/nodes-base/nodes/MySql/v2/helpers/interfaces.ts
+++ b/packages/nodes-base/nodes/MySql/v2/helpers/interfaces.ts
@@ -4,6 +4,7 @@ import type { IDataObject, INodeExecutionData, SSHCredentials } from 'n8n-workfl
 export type Mysql2Connection = mysql2.Connection;
 export type Mysql2Pool = mysql2.Pool;
 export type Mysql2OkPacket = mysql2.OkPacket;
+export type Mysql2PoolConnection = mysql2.PoolConnection;
 
 export type QueryValues = Array<string | number | IDataObject>;
 export type QueryWithValues = { query: string; values: QueryValues };

--- a/packages/nodes-base/nodes/MySql/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/MySql/v2/helpers/utils.ts
@@ -544,7 +544,7 @@ export function addWhereClauses(
 		}${valueReplacement}${operator}`;
 	});
 
-	return [`${query}${whereQuery}`, replacements.concat(...values)];
+	return [`${query}${whereQuery}`, replacements.concat.apply(replacements, values)];
 }
 
 export function addSortRules(
@@ -563,7 +563,7 @@ export function addSortRules(
 		orderByQuery += ` ${escapeSqlIdentifier(rule.column)} ${direction}${endWith}`;
 	});
 
-	return [`${query}${orderByQuery}`, replacements.concat(...values)];
+	return [`${query}${orderByQuery}`, replacements.concat.apply(replacements, values)];
 }
 
 export function replaceEmptyStringsByNulls(


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Make sure that the call to `pool.getConnection`, which actually establishes the connection, is inside `try/catch`, where the `this.continueOnFail()` is handled

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-4174/mysql-node-doesnt-consider-a-connection-problems-to-be-an-error

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
