### PR TITLE
fix: Update stack cleanup command message to work from any directory

### DIFF
--- a/packages/testing/containers/n8n-start-stack.ts
+++ b/packages/testing/containers/n8n-start-stack.ts
@@ -314,7 +314,9 @@ async function main() {
 
 		console.log('');
 		log.info('Containers are running in the background');
-		log.info('Cleanup with: pnpm stack:clean:all (stops containers and removes networks)');
+		log.info(
+			'Cleanup with: pnpm --filter n8n-containers stack:clean:all (stops containers and removes networks)',
+		);
 		console.log('');
 	} catch (error) {
 		log.error(`Failed to start: ${error as string}`);


### PR DESCRIPTION
## Summary
While spinning up the repo as my first-time doing it I got hit with this when copying the command that appears after Starting the n8n stack. 
<img width="844" height="93" alt="Screenshot 2026-01-29 at 13 30 01" src="https://github.com/user-attachments/assets/889772d4-1186-4114-bb8c-dfbee7dd8694" />

Making the message more explainable and adding a command that works in all the monorepo, for those who come after me:

- Updates the cleanup message in `n8n-start-stack.ts` to show the correct command that works from anywhere in the monorepo                            
- Changed from `pnpm stack:clean:all` to `pnpm --filter n8n-containers stack:clean:all`  