### PR TITLE
chore(core): Support cookie for auth token extraction in dynamic credential endpoints

### DIFF
--- a/packages/@n8n/decorators/src/controller/route.ts
+++ b/packages/@n8n/decorators/src/controller/route.ts
@@ -11,6 +11,8 @@ interface RouteOptions {
 	/** When this flag is set to true, auth cookie isn't validated, and req.user will not be set */
 	skipAuth?: boolean;
 	allowSkipPreviewAuth?: boolean;
+	/** When this flag is set to true, the endpoint can be accessed without authentication */
+	allowUnauthenticated?: boolean;
 	/** When this flag is set to true, the auth cookie does not enforce MFA to be used in the token */
 	allowSkipMFA?: boolean;
 	/** When these options are set, calls to this endpoint are rate limited based on IP address */
@@ -38,6 +40,7 @@ const RouteFactory =
 		routeMetadata.skipAuth = options.skipAuth ?? false;
 		routeMetadata.allowSkipPreviewAuth = options.allowSkipPreviewAuth ?? false;
 		routeMetadata.allowSkipMFA = options.allowSkipMFA ?? false;
+		routeMetadata.allowUnauthenticated = options.allowUnauthenticated ?? false;
 		routeMetadata.apiKeyAuth = options.apiKeyAuth ?? false;
 		routeMetadata.ipRateLimit = options.ipRateLimit;
 		routeMetadata.keyedRateLimit = options.keyedRateLimit;

--- a/packages/@n8n/decorators/src/controller/types.ts
+++ b/packages/@n8n/decorators/src/controller/types.ts
@@ -32,6 +32,7 @@ export interface RouteMetadata {
 	skipAuth: boolean;
 	allowSkipPreviewAuth: boolean;
 	allowSkipMFA: boolean;
+	allowUnauthenticated: boolean;
 	apiKeyAuth: boolean;
 	cors?: Partial<CorsOptions> | true;
 	/** Whether to apply IP-based rate limiting to the route */

--- a/packages/@n8n/decorators/src/credential-resolver/credential-resolver.ts
+++ b/packages/@n8n/decorators/src/credential-resolver/credential-resolver.ts
@@ -91,10 +91,10 @@ export interface ICredentialResolver {
 	/**
 	 * Validates if the userIdentity provided has access to the resolver capable credential
 	 *
-	 * @param identity - The identity of the entity to validate access for
+	 * @param context - The identity of the entity to validate access for
 	 * @throws {CredentialResolverAccessValidationError} When access is invalid
 	 */
-	validateIdentity?(identity: string, handle: CredentialResolverHandle): Promise<void>;
+	validateIdentity?(context: ICredentialContext, handle: CredentialResolverHandle): Promise<void>;
 
 	/**
 	 * Runs initialization logic for the resolver. This might be called multiple times!

--- a/packages/cli/src/auth/auth.service.ts
+++ b/packages/cli/src/auth/auth.service.ts
@@ -6,7 +6,7 @@ import type { AuthenticatedRequest, User } from '@n8n/db';
 import { GLOBAL_OWNER_ROLE, InvalidAuthTokenRepository, UserRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { createHash } from 'crypto';
-import type { NextFunction, Response } from 'express';
+import type { NextFunction, Request, Response } from 'express';
 import { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken';
 import type { StringValue as TimeUnitValue } from 'ms';
 
@@ -156,19 +156,28 @@ export class AuthService {
 		};
 	}
 
-	getCookieToken(req: AuthenticatedRequest) {
-		return req.cookies[AUTH_COOKIE_NAME];
+	getCookieToken(req: Request) {
+		// This models the behavior of
+		if (typeof req.cookies === 'object' && req.cookies !== null) {
+			const cookies = req.cookies as Record<string, string | undefined>;
+			return cookies[AUTH_COOKIE_NAME];
+		}
+		return undefined;
 	}
 
-	getBrowserId(req: AuthenticatedRequest) {
-		return req.browserId;
+	getBrowserId(req: Request) {
+		// This models the behavior of APIRequest type having an optional browserId property of type string
+		if ('browserId' in req && typeof req.browserId === 'string') {
+			return req.browserId;
+		}
+		return undefined;
 	}
 
-	getMethod(req: AuthenticatedRequest) {
+	getMethod(req: Request) {
 		return req.method;
 	}
 
-	getEndpoint(req: AuthenticatedRequest) {
+	getEndpoint(req: Request) {
 		return req.route ? `${req.baseUrl}${req.route.path}` : req.baseUrl;
 	}
 

--- a/packages/cli/src/auth/auth.service.ts
+++ b/packages/cli/src/auth/auth.service.ts
@@ -157,7 +157,7 @@ export class AuthService {
 	}
 
 	getCookieToken(req: Request) {
-		// This models the behavior of
+		// This models the behavior of an AuthenticatedRequest type having an optional cookies property of type Record<string, string>
 		if (typeof req.cookies === 'object' && req.cookies !== null) {
 			const cookies = req.cookies as Record<string, string | undefined>;
 			return cookies[AUTH_COOKIE_NAME];

--- a/packages/cli/src/controller.registry.ts
+++ b/packages/cli/src/controller.registry.ts
@@ -133,6 +133,7 @@ export class ControllerRegistry {
 			skipAuth?: boolean;
 			allowSkipMFA?: boolean;
 			allowSkipPreviewAuth?: boolean;
+			allowUnauthenticated?: boolean;
 			ipRateLimit?: boolean | RateLimiterLimits;
 			keyedRateLimit?: KeyedRateLimiterConfig;
 			licenseFeature?: BooleanLicenseFeature;
@@ -169,6 +170,7 @@ export class ControllerRegistry {
 				this.authService.createAuthMiddleware({
 					allowSkipMFA: route.allowSkipMFA ?? false,
 					allowSkipPreviewAuth: route.allowSkipPreviewAuth ?? false,
+					allowUnauthenticated: route.allowUnauthenticated ?? false,
 				}),
 				this.lastActiveAtService.middleware.bind(this.lastActiveAtService) as RequestHandler,
 			);

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/__tests__/n8n-credential-resolver.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/__tests__/n8n-credential-resolver.test.ts
@@ -226,26 +226,5 @@ describe('N8NCredentialResolver', () => {
 				expect(mockStorage.deleteAllCredentialData).toHaveBeenCalledWith(handle);
 			});
 		});
-
-		describe('validateIdentity', () => {
-			it('should validate JWT with browserId set to false', async () => {
-				const identity = 'jwt-token-to-validate';
-				const handle = testHelpers.createHandle({});
-
-				await resolver.validateIdentity(identity, handle);
-
-				// Verify N8NIdentifier was called with browserId=false
-				expect(mockIdentifier.resolve).toHaveBeenCalledWith(
-					{
-						identity: 'jwt-token-to-validate',
-						version: 1,
-						metadata: {
-							browserId: false,
-						},
-					},
-					{},
-				);
-			});
-		});
 	});
 });

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/n8n-credential-resolver.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/n8n-credential-resolver.ts
@@ -114,18 +114,10 @@ export class N8NCredentialResolver implements ICredentialResolver {
 		return await this.n8nIdentifier.resolve(context, configuration);
 	}
 
-	async validateIdentity(identity: string, handle: CredentialResolverHandle): Promise<void> {
-		await this.resolveIdentifier(
-			{
-				identity,
-				version: 1,
-				metadata: {
-					// Skip browserId check for identity validation only
-					// Full session validation happens during actual credential resolution
-					browserId: false,
-				},
-			},
-			handle.configuration,
-		);
+	async validateIdentity(
+		context: ICredentialContext,
+		handle: CredentialResolverHandle,
+	): Promise<void> {
+		await this.resolveIdentifier(context, handle.configuration);
 	}
 }

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/oauth-credential-resolver.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/oauth-credential-resolver.ts
@@ -223,15 +223,11 @@ export class OAuthCredentialResolver implements ICredentialResolver {
 		return await identifier.resolve(context, parsedOptions);
 	}
 
-	async validateIdentity(identity: string, handle: CredentialResolverHandle): Promise<void> {
+	async validateIdentity(
+		context: ICredentialContext,
+		handle: CredentialResolverHandle,
+	): Promise<void> {
 		const parsedOptions = await this.parseOptions(handle.configuration);
-		await this.resolveIdentifier(
-			{
-				identity,
-				version: 1,
-				metadata: {},
-			},
-			parsedOptions,
-		);
+		await this.resolveIdentifier(context, parsedOptions);
 	}
 }

--- a/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.controller.ts
@@ -74,7 +74,10 @@ export class DynamicCredentialsController {
 		this.dynamicCredentialCorsService.preflightHandler(req, res, ['delete', 'options']);
 	}
 
-	@Delete('/:id/revoke', { skipAuth: true, middlewares: getDynamicCredentialMiddlewares() })
+	@Delete('/:id/revoke', {
+		allowUnauthenticated: true,
+		middlewares: getDynamicCredentialMiddlewares(),
+	})
 	async revokeCredential(req: Request, res: Response): Promise<void> {
 		this.dynamicCredentialCorsService.applyCorsHeadersIfEnabled(req, res, ['delete', 'options']);
 		const credentialContext = this.dynamicCredentialWebService.getCredentialContextFromRequest(req);
@@ -108,7 +111,10 @@ export class DynamicCredentialsController {
 		this.dynamicCredentialCorsService.preflightHandler(req, res, ['post', 'options']);
 	}
 
-	@Post('/:id/authorize', { skipAuth: true, middlewares: getDynamicCredentialMiddlewares() })
+	@Post('/:id/authorize', {
+		allowUnauthenticated: true,
+		middlewares: getDynamicCredentialMiddlewares(),
+	})
 	async authorizeCredential(req: Request, res: Response): Promise<string> {
 		this.dynamicCredentialCorsService.applyCorsHeadersIfEnabled(req, res, ['post', 'options']);
 		const credentialContext = this.dynamicCredentialWebService.getCredentialContextFromRequest(req);

--- a/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.controller.ts
@@ -8,10 +8,11 @@ import { CreateCsrfStateData, OauthService } from '@/oauth/oauth.service';
 import { CredentialsEntity } from '@n8n/db';
 import { DynamicCredentialResolverRepository } from './database/repositories/credential-resolver.repository';
 import { DynamicCredentialResolverRegistry } from './services';
-import { getBearerToken, getDynamicCredentialMiddlewares } from './utils';
+import { getDynamicCredentialMiddlewares } from './utils';
 import { Cipher } from 'n8n-core';
 import { jsonParse } from 'n8n-workflow';
 import { DynamicCredentialCorsService } from './services/dynamic-credential-cors.service';
+import { DynamicCredentialWebService } from './services/dynamic-credential-web.service';
 
 @RestController('/credentials')
 export class DynamicCredentialsController {
@@ -22,6 +23,7 @@ export class DynamicCredentialsController {
 		private readonly resolverRegistry: DynamicCredentialResolverRegistry,
 		private readonly cipher: Cipher,
 		private readonly dynamicCredentialCorsService: DynamicCredentialCorsService,
+		private readonly dynamicCredentialWebService: DynamicCredentialWebService,
 	) {}
 
 	private async findCredentialToUse(credentialId: string): Promise<CredentialsEntity> {
@@ -75,7 +77,7 @@ export class DynamicCredentialsController {
 	@Delete('/:id/revoke', { skipAuth: true, middlewares: getDynamicCredentialMiddlewares() })
 	async revokeCredential(req: Request, res: Response): Promise<void> {
 		this.dynamicCredentialCorsService.applyCorsHeadersIfEnabled(req, res, ['delete', 'options']);
-		const token = getBearerToken(req);
+		const credentialContext = this.dynamicCredentialWebService.getCredentialContextFromRequest(req);
 		const credential = await this.findCredentialToUse(req.params.id);
 
 		const resolverId = req.query.resolverId as string | undefined;
@@ -86,18 +88,11 @@ export class DynamicCredentialsController {
 			const decryptedConfig = this.cipher.decrypt(resolverEntity.config);
 			const resolverConfig = jsonParse<Record<string, unknown>>(decryptedConfig);
 
-			await resolver.deleteSecret(
-				credential.id,
-				{
-					identity: token,
-					version: 1,
-				},
-				{
-					configuration: resolverConfig,
-					resolverId: resolverEntity.id,
-					resolverName: resolverEntity.type,
-				},
-			);
+			await resolver.deleteSecret(credential.id, credentialContext, {
+				configuration: resolverConfig,
+				resolverId: resolverEntity.id,
+				resolverName: resolverEntity.type,
+			});
 		}
 
 		res.status(204).send(); // 204 No Content indicates successful deletion
@@ -116,7 +111,7 @@ export class DynamicCredentialsController {
 	@Post('/:id/authorize', { skipAuth: true, middlewares: getDynamicCredentialMiddlewares() })
 	async authorizeCredential(req: Request, res: Response): Promise<string> {
 		this.dynamicCredentialCorsService.applyCorsHeadersIfEnabled(req, res, ['post', 'options']);
-		const token = getBearerToken(req);
+		const credentialContext = this.dynamicCredentialWebService.getCredentialContextFromRequest(req);
 		const credential = await this.findCredentialToUse(req.params.id);
 
 		const resolverId = req.query.resolverId as string | undefined;
@@ -127,7 +122,7 @@ export class DynamicCredentialsController {
 			const decryptedConfig = this.cipher.decrypt(resolverEntity.config);
 			const resolverConfig = jsonParse<Record<string, unknown>>(decryptedConfig);
 
-			await resolver.validateIdentity(token, {
+			await resolver.validateIdentity(credentialContext, {
 				resolverId: resolverEntity.id,
 				resolverName: resolverEntity.type,
 				configuration: resolverConfig,

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-resolver-workflow.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-resolver-workflow.service.test.ts
@@ -125,15 +125,23 @@ describe('CredentialResolverWorkflowService', () => {
 		it('should throw when workflow not found', async () => {
 			mockWorkflowRepository.get.mockResolvedValue(null);
 
-			await expect(service.getWorkflowStatus('workflow-1', 'token-123')).rejects.toThrow(
-				'Workflow not found',
-			);
+			await expect(
+				service.getWorkflowStatus('workflow-1', {
+					identity: 'token-123',
+					version: 1 as const,
+					metadata: {},
+				}),
+			).rejects.toThrow('Workflow not found');
 		});
 
 		it('should return empty array when workflow has no nodes', async () => {
 			mockWorkflowRepository.get.mockResolvedValue(createMockWorkflow({ nodes: [] }));
 
-			const result = await service.getWorkflowStatus('workflow-1', 'token-123');
+			const result = await service.getWorkflowStatus('workflow-1', {
+				identity: 'token-123',
+				version: 1 as const,
+				metadata: {},
+			});
 
 			expect(result).toEqual([]);
 			expect(mockCredentialRepository.find).not.toHaveBeenCalled();
@@ -146,7 +154,11 @@ describe('CredentialResolverWorkflowService', () => {
 				}),
 			);
 
-			const result = await service.getWorkflowStatus('workflow-1', 'token-123');
+			const result = await service.getWorkflowStatus('workflow-1', {
+				identity: 'token-123',
+				version: 1 as const,
+				metadata: {},
+			});
 
 			expect(result).toEqual([]);
 			expect(mockCredentialRepository.find).not.toHaveBeenCalled();
@@ -185,7 +197,13 @@ describe('CredentialResolverWorkflowService', () => {
 			mockCipher.decrypt.mockReturnValue(JSON.stringify({ prefix: 'test' }));
 			mockResolverImplementation.getSecret.mockResolvedValue('secret-value' as any);
 
-			const result = await service.getWorkflowStatus('workflow-1', 'token-123');
+			const credentialContext = {
+				identity: 'token-123',
+				version: 1 as const,
+				metadata: {},
+			};
+
+			const result = await service.getWorkflowStatus('workflow-1', credentialContext);
 
 			expect(result).toHaveLength(1);
 			expect(result[0]).toEqual({
@@ -197,7 +215,7 @@ describe('CredentialResolverWorkflowService', () => {
 			});
 			expect(mockResolverImplementation.getSecret).toHaveBeenCalledWith(
 				'cred-1',
-				{ identity: 'token-123', version: 1 },
+				credentialContext,
 				{
 					configuration: { prefix: 'test' },
 					resolverName: 'test.resolver',
@@ -239,7 +257,11 @@ describe('CredentialResolverWorkflowService', () => {
 			mockCipher.decrypt.mockReturnValue(JSON.stringify({ prefix: 'test' }));
 			mockResolverImplementation.getSecret.mockRejectedValue(new Error('Secret not found'));
 
-			const result = await service.getWorkflowStatus('workflow-1', 'token-123');
+			const result = await service.getWorkflowStatus('workflow-1', {
+				identity: 'token-123',
+				version: 1 as const,
+				metadata: {},
+			});
 
 			expect(result).toHaveLength(1);
 			expect(result[0]).toEqual({
@@ -293,13 +315,19 @@ describe('CredentialResolverWorkflowService', () => {
 				.mockReturnValueOnce(JSON.stringify({ prefix: 'test-2' }));
 			mockResolverImplementation.getSecret.mockResolvedValue('secret-value' as any);
 
-			const result = await service.getWorkflowStatus('workflow-1', 'token-123');
+			const credentialContext = {
+				identity: 'token-123',
+				version: 1 as const,
+				metadata: {},
+			};
+
+			const result = await service.getWorkflowStatus('workflow-1', credentialContext);
 
 			expect(result).toHaveLength(1);
 			expect(result[0].resolverId).toBe('resolver-2');
 			expect(mockResolverImplementation.getSecret).toHaveBeenCalledWith(
 				'cred-1',
-				{ identity: 'token-123', version: 1 },
+				credentialContext,
 				{
 					configuration: { prefix: 'test-2' },
 					resolverName: 'test.resolver',
@@ -330,7 +358,11 @@ describe('CredentialResolverWorkflowService', () => {
 			mockWorkflowRepository.get.mockResolvedValue(mockWorkflow);
 			mockCredentialRepository.find.mockResolvedValue([mockCredential]);
 
-			const result = await service.getWorkflowStatus('workflow-1', 'token-123');
+			const result = await service.getWorkflowStatus('workflow-1', {
+				identity: 'token-123',
+				version: 1 as const,
+				metadata: {},
+			});
 
 			expect(result).toEqual([]);
 			expect(mockResolverImplementation.getSecret).not.toHaveBeenCalled();
@@ -379,7 +411,11 @@ describe('CredentialResolverWorkflowService', () => {
 				.mockResolvedValueOnce('secret-1' as any)
 				.mockResolvedValueOnce('secret-2' as any);
 
-			const result = await service.getWorkflowStatus('workflow-1', 'token-123');
+			const result = await service.getWorkflowStatus('workflow-1', {
+				identity: 'token-123',
+				version: 1 as const,
+				metadata: {},
+			});
 
 			expect(result).toHaveLength(2);
 			expect(mockResolverImplementation.getSecret).toHaveBeenCalledTimes(2);
@@ -430,7 +466,11 @@ describe('CredentialResolverWorkflowService', () => {
 				.mockResolvedValueOnce('secret-1' as any)
 				.mockRejectedValueOnce(new Error('Secret not found'));
 
-			const result = await service.getWorkflowStatus('workflow-1', 'token-123');
+			const result = await service.getWorkflowStatus('workflow-1', {
+				identity: 'token-123',
+				version: 1 as const,
+				metadata: {},
+			});
 
 			expect(result).toHaveLength(2);
 			expect(result[0].status).toBe('configured');

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential-web.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential-web.service.test.ts
@@ -1,0 +1,302 @@
+import { mock } from 'jest-mock-extended';
+import type { Request } from 'express';
+import type { AuthService } from '@/auth/auth.service';
+import { DynamicCredentialWebService } from '../dynamic-credential-web.service';
+
+describe('DynamicCredentialWebService', () => {
+	let service: DynamicCredentialWebService;
+	let mockAuthService: jest.Mocked<AuthService>;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		mockAuthService = mock<AuthService>({
+			getCookieToken: jest.fn(),
+			getBrowserId: jest.fn(),
+			getMethod: jest.fn(),
+			getEndpoint: jest.fn(),
+		});
+
+		service = new DynamicCredentialWebService(mockAuthService);
+	});
+
+	describe('getCredentialContextFromRequest', () => {
+		describe('with explicit authSource=bearer', () => {
+			it('should extract bearer token when authSource query param is "bearer"', () => {
+				const req = mock<Request>({
+					query: { authSource: 'bearer' },
+					headers: { authorization: 'Bearer my-token-123' },
+				});
+
+				const result = service.getCredentialContextFromRequest(req);
+
+				expect(result).toEqual({
+					identity: 'my-token-123',
+					version: 1,
+					metadata: {},
+				});
+				expect(mockAuthService.getCookieToken).not.toHaveBeenCalled();
+			});
+
+			it('should accept case-insensitive bearer prefix', () => {
+				const req = mock<Request>({
+					query: { authSource: 'bearer' },
+					headers: { authorization: 'bearer lowercase-token' },
+				});
+
+				const result = service.getCredentialContextFromRequest(req);
+
+				expect(result.identity).toBe('lowercase-token');
+			});
+
+			it('should accept mixed-case bearer prefix', () => {
+				const req = mock<Request>({
+					query: { authSource: 'bearer' },
+					headers: { authorization: 'BeArEr mixed-case-token' },
+				});
+
+				const result = service.getCredentialContextFromRequest(req);
+
+				expect(result.identity).toBe('mixed-case-token');
+			});
+
+			it('should throw error when bearer token is missing with authSource=bearer', () => {
+				const req = mock<Request>({
+					query: { authSource: 'bearer' },
+					headers: {},
+				});
+
+				expect(() => service.getCredentialContextFromRequest(req)).toThrow(
+					'Bearer token is missing',
+				);
+			});
+
+			it('should throw error when authorization header has no Bearer prefix', () => {
+				const req = mock<Request>({
+					query: { authSource: 'bearer' },
+					headers: { authorization: 'token-without-bearer' },
+				});
+
+				expect(() => service.getCredentialContextFromRequest(req)).toThrow(
+					'Bearer token is missing',
+				);
+			});
+
+			it('should throw error when bearer token is empty after prefix', () => {
+				const req = mock<Request>({
+					query: { authSource: 'bearer' },
+					headers: { authorization: 'Bearer ' },
+				});
+
+				expect(() => service.getCredentialContextFromRequest(req)).toThrow(
+					'Bearer token is missing',
+				);
+			});
+		});
+
+		describe('with explicit authSource=cookie', () => {
+			it('should extract cookie token when authSource query param is "cookie"', () => {
+				const req = mock<Request>({
+					query: { authSource: 'cookie' },
+					headers: {},
+				});
+
+				mockAuthService.getCookieToken.mockReturnValue('cookie-session-123');
+				mockAuthService.getBrowserId.mockReturnValue('browser-abc');
+				mockAuthService.getMethod.mockReturnValue('GET');
+				mockAuthService.getEndpoint.mockReturnValue('/api/test');
+
+				const result = service.getCredentialContextFromRequest(req);
+
+				expect(result).toEqual({
+					identity: 'cookie-session-123',
+					version: 1,
+					metadata: {
+						source: 'cookie-source',
+						browserId: 'browser-abc',
+						method: 'GET',
+						endpoint: '/api/test',
+					},
+				});
+				expect(mockAuthService.getCookieToken).toHaveBeenCalledWith(req);
+				expect(mockAuthService.getBrowserId).toHaveBeenCalledWith(req);
+				expect(mockAuthService.getMethod).toHaveBeenCalledWith(req);
+				expect(mockAuthService.getEndpoint).toHaveBeenCalledWith(req);
+			});
+
+			it('should throw error when session cookie is missing with authSource=cookie', () => {
+				const req = mock<Request>({
+					query: { authSource: 'cookie' },
+					headers: {},
+				});
+
+				mockAuthService.getCookieToken.mockReturnValue(undefined);
+
+				expect(() => service.getCredentialContextFromRequest(req)).toThrow(
+					'Session cookie is missing',
+				);
+			});
+		});
+
+		describe('fallback behavior (no authSource query param)', () => {
+			it('should extract bearer token when present without authSource param', () => {
+				const req = mock<Request>({
+					query: {},
+					headers: { authorization: 'Bearer fallback-token' },
+				});
+
+				const result = service.getCredentialContextFromRequest(req);
+
+				expect(result).toEqual({
+					identity: 'fallback-token',
+					version: 1,
+					metadata: {},
+				});
+				expect(mockAuthService.getCookieToken).not.toHaveBeenCalled();
+			});
+
+			it('should fall back to cookie when bearer token is not present', () => {
+				const req = mock<Request>({
+					query: {},
+					headers: {},
+				});
+
+				mockAuthService.getCookieToken.mockReturnValue('cookie-fallback-123');
+				mockAuthService.getBrowserId.mockReturnValue('browser-xyz');
+				mockAuthService.getMethod.mockReturnValue('POST');
+				mockAuthService.getEndpoint.mockReturnValue('/api/workflow');
+
+				const result = service.getCredentialContextFromRequest(req);
+
+				expect(result).toEqual({
+					identity: 'cookie-fallback-123',
+					version: 1,
+					metadata: {
+						source: 'cookie-source',
+						browserId: 'browser-xyz',
+						method: 'POST',
+						endpoint: '/api/workflow',
+					},
+				});
+				expect(mockAuthService.getCookieToken).toHaveBeenCalledWith(req);
+			});
+
+			it('should fall back to cookie when authorization header is malformed', () => {
+				const req = mock<Request>({
+					query: {},
+					headers: { authorization: 'malformed-header' },
+				});
+
+				mockAuthService.getCookieToken.mockReturnValue('cookie-fallback-456');
+				mockAuthService.getBrowserId.mockReturnValue('browser-123');
+				mockAuthService.getMethod.mockReturnValue('GET');
+				mockAuthService.getEndpoint.mockReturnValue('/api/test');
+
+				const result = service.getCredentialContextFromRequest(req);
+
+				expect(result.identity).toBe('cookie-fallback-456');
+				expect(mockAuthService.getCookieToken).toHaveBeenCalledWith(req);
+			});
+
+			it('should throw error when both bearer and cookie are missing', () => {
+				const req = mock<Request>({
+					query: {},
+					headers: {},
+				});
+
+				mockAuthService.getCookieToken.mockReturnValue(undefined);
+
+				expect(() => service.getCredentialContextFromRequest(req)).toThrow(
+					'Session cookie is missing',
+				);
+			});
+		});
+
+		describe('edge cases', () => {
+			it('should handle bearer token with special characters', () => {
+				const specialToken = 'token-with-special!@#$%^&*()chars';
+				const req = mock<Request>({
+					query: { authSource: 'bearer' },
+					headers: { authorization: `Bearer ${specialToken}` },
+				});
+
+				const result = service.getCredentialContextFromRequest(req);
+
+				expect(result.identity).toBe(specialToken);
+			});
+
+			it('should handle very long bearer tokens', () => {
+				const longToken = 'a'.repeat(1000);
+				const req = mock<Request>({
+					query: { authSource: 'bearer' },
+					headers: { authorization: `Bearer ${longToken}` },
+				});
+
+				const result = service.getCredentialContextFromRequest(req);
+
+				expect(result.identity).toBe(longToken);
+			});
+
+			it('should handle undefined browserId from AuthService', () => {
+				const req = mock<Request>({
+					query: { authSource: 'cookie' },
+					headers: {},
+				});
+
+				mockAuthService.getCookieToken.mockReturnValue('cookie-token');
+				mockAuthService.getBrowserId.mockReturnValue(undefined);
+				mockAuthService.getMethod.mockReturnValue('GET');
+				mockAuthService.getEndpoint.mockReturnValue('/api/test');
+
+				const result = service.getCredentialContextFromRequest(req);
+
+				expect(result.metadata).toEqual({
+					source: 'cookie-source',
+					browserId: undefined,
+					method: 'GET',
+					endpoint: '/api/test',
+				});
+			});
+
+			it('should prioritize authSource=bearer over existing bearer token in fallback mode', () => {
+				const req = mock<Request>({
+					query: { authSource: 'cookie' },
+					headers: { authorization: 'Bearer should-be-ignored' },
+				});
+
+				mockAuthService.getCookieToken.mockReturnValue('cookie-token');
+				mockAuthService.getBrowserId.mockReturnValue('browser-id');
+				mockAuthService.getMethod.mockReturnValue('GET');
+				mockAuthService.getEndpoint.mockReturnValue('/api/test');
+
+				const result = service.getCredentialContextFromRequest(req);
+
+				expect(result.identity).toBe('cookie-token');
+				expect(result.metadata?.source).toBe('cookie-source');
+			});
+
+			it('should handle empty query object', () => {
+				const req = mock<Request>({
+					query: {},
+					headers: { authorization: 'Bearer empty-query-token' },
+				});
+
+				const result = service.getCredentialContextFromRequest(req);
+
+				expect(result.identity).toBe('empty-query-token');
+			});
+
+			it('should handle authSource with invalid value', () => {
+				const req = mock<Request>({
+					query: { authSource: 'invalid' as any },
+					headers: { authorization: 'Bearer token' },
+				});
+
+				// Should fall back to default behavior (bearer first)
+				const result = service.getCredentialContextFromRequest(req);
+
+				expect(result.identity).toBe('token');
+			});
+		});
+	});
+});

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential.service.test.ts
@@ -1,6 +1,6 @@
 import type { Logger } from '@n8n/backend-common';
 import { CredentialResolverDataNotFoundError, type ICredentialResolver } from '@n8n/decorators';
-import type { Request, Response } from 'express';
+import type { Response } from 'express';
 import type { Cipher } from 'n8n-core';
 import type {
 	ICredentialContext,
@@ -19,6 +19,7 @@ import { CredentialResolutionError } from '../../errors/credential-resolution.er
 import type { DynamicCredentialResolverRegistry } from '../credential-resolver-registry.service';
 import { DynamicCredentialService } from '../dynamic-credential.service';
 import type { ResolverConfigExpressionService } from '../resolver-config-expression.service';
+import type { AuthenticatedRequest } from '@n8n/db';
 
 describe('DynamicCredentialService', () => {
 	let service: DynamicCredentialService;
@@ -1088,7 +1089,9 @@ describe('DynamicCredentialService', () => {
 					mockExpressionService,
 				);
 				const middleware = service.getDynamicCredentialsEndpointsMiddleware();
-				const mockReq = {} as Request;
+				const mockReq = {
+					cookies: {},
+				} as AuthenticatedRequest;
 				const mockRes = {
 					status: jest.fn().mockReturnThis(),
 					json: jest.fn(),

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential-web.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential-web.service.ts
@@ -4,6 +4,7 @@ import { Z } from 'zod-class';
 import { z } from 'zod';
 import { ICredentialContext } from 'n8n-workflow';
 import { Request } from 'express';
+import { UnauthenticatedError } from '@/errors/response-errors/unauthenticated.error';
 
 class AuthSourceQuerySchema extends Z.class({
 	authSource: z.enum(['bearer', 'cookie']).optional(),
@@ -35,7 +36,7 @@ export class DynamicCredentialWebService {
 	private buildCookieCredentialContext(req: Request): ICredentialContext {
 		const sessionCookie = this.authService.getCookieToken(req);
 		if (sessionCookie === undefined) {
-			throw new Error('Session cookie is missing');
+			throw new UnauthenticatedError('Session cookie is missing');
 		}
 		return {
 			identity: sessionCookie,
@@ -57,7 +58,7 @@ export class DynamicCredentialWebService {
 			if (authSource === 'bearer') {
 				const token = getBearerToken(req);
 				if (token === null) {
-					throw new Error('Bearer token is missing');
+					throw new UnauthenticatedError('Bearer token is missing');
 				}
 				return {
 					identity: token,
@@ -67,7 +68,7 @@ export class DynamicCredentialWebService {
 			} else if (authSource === 'cookie') {
 				return this.buildCookieCredentialContext(req);
 			} else {
-				throw new Error('Invalid auth source');
+				throw new UnauthenticatedError('Invalid auth source');
 			}
 		}
 

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential-web.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential-web.service.ts
@@ -1,0 +1,85 @@
+import { AuthService } from '@/auth/auth.service';
+import { Service } from '@n8n/di';
+import { Z } from 'zod-class';
+import { z } from 'zod';
+import { ICredentialContext } from 'n8n-workflow';
+import { Request } from 'express';
+
+class AuthSourceQuerySchema extends Z.class({
+	authSource: z.enum(['bearer', 'cookie']).optional(),
+}) {}
+
+const BEARER_TOKEN_REGEX = /^[Bb][Ee][Aa][Rr][Ee][Rr]\s+(.+)$/;
+
+function getBearerToken(req: Request): string | null {
+	const headerValue = req.headers['authorization']?.toString();
+
+	if (!headerValue) {
+		return null;
+	}
+
+	const result = BEARER_TOKEN_REGEX.exec(headerValue);
+	const token = result ? result[1] : null;
+
+	if (!token) {
+		return null;
+	}
+
+	return token;
+}
+
+@Service()
+export class DynamicCredentialWebService {
+	constructor(private readonly authService: AuthService) {}
+
+	private buildCookieCredentialContext(req: Request): ICredentialContext {
+		const sessionCookie = this.authService.getCookieToken(req);
+		if (sessionCookie === undefined) {
+			throw new Error('Session cookie is missing');
+		}
+		return {
+			identity: sessionCookie,
+			version: 1,
+			metadata: {
+				source: 'cookie-source',
+				browserId: this.authService.getBrowserId(req),
+				method: this.authService.getMethod(req),
+				endpoint: this.authService.getEndpoint(req),
+			},
+		};
+	}
+
+	getCredentialContextFromRequest(req: Request): ICredentialContext {
+		const parseResult = AuthSourceQuerySchema.safeParse(req.query);
+
+		if (parseResult.success && parseResult.data.authSource !== undefined) {
+			const { authSource } = parseResult.data;
+			if (authSource === 'bearer') {
+				const token = getBearerToken(req);
+				if (token === null) {
+					throw new Error('Bearer token is missing');
+				}
+				return {
+					identity: token,
+					version: 1,
+					metadata: {},
+				};
+			} else if (authSource === 'cookie') {
+				return this.buildCookieCredentialContext(req);
+			} else {
+				throw new Error('Invalid auth source');
+			}
+		}
+
+		const token = getBearerToken(req);
+		if (token !== null) {
+			return {
+				identity: token,
+				version: 1,
+				metadata: {},
+			};
+		}
+
+		return this.buildCookieCredentialContext(req);
+	}
+}

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential.service.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@n8n/backend-common';
 import { CredentialResolverDataNotFoundError } from '@n8n/decorators';
 import { Service } from '@n8n/di';
-import { NextFunction, Request, Response } from 'express';
+import { NextFunction, Response } from 'express';
 import { Cipher } from 'n8n-core';
 import type {
 	ICredentialDataDecryptedObject,
@@ -23,6 +23,7 @@ import type {
 import { DynamicCredentialResolverRepository } from '../database/repositories/credential-resolver.repository';
 import { DynamicCredentialsConfig } from '../dynamic-credentials.config';
 import { CredentialResolutionError } from '../errors/credential-resolution.error';
+import { AuthenticatedRequest } from '@n8n/db';
 
 /**
  * Service for resolving credentials dynamically via configured resolvers.
@@ -250,7 +251,11 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 	getDynamicCredentialsEndpointsMiddleware() {
 		const { endpointAuthToken } = this.dynamicCredentialConfig;
 		if (!endpointAuthToken?.trim()) {
-			return (_req: Request, res: Response, _next: NextFunction) => {
+			return (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+				// If a user was authenticated for this request, we allow access irrelevant of the static authentication
+				if (req.user) {
+					return next();
+				}
 				this.logger.error(
 					'Dynamic credentials external endpoints require an endpoint auth token. Please set the N8N_DYNAMIC_CREDENTIALS_ENDPOINT_AUTH_TOKEN environment variable to enable access.',
 				);
@@ -261,6 +266,17 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 			};
 		}
 
-		return StaticAuthService.getStaticAuthMiddleware(endpointAuthToken, 'x-authorization')!;
+		const staticAuthMiddlware = StaticAuthService.getStaticAuthMiddleware(
+			endpointAuthToken,
+			'x-authorization',
+		)!;
+
+		return (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+			// If a user was authenticated for this request, we allow access irrelevant of the static authentication
+			if (req.user) {
+				return next();
+			}
+			return staticAuthMiddlware(req, res, next);
+		};
 	}
 }

--- a/packages/cli/src/modules/dynamic-credentials.ee/utils.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/utils.ts
@@ -1,27 +1,5 @@
-import { BadRequestError } from '@/errors/response-errors/bad-request.error';
-import { UnauthenticatedError } from '@/errors/response-errors/unauthenticated.error';
-import type { Request } from 'express';
 import { Container } from '@n8n/di';
 import { DynamicCredentialService } from './services/dynamic-credential.service';
-
-const BEARER_TOKEN_REGEX = /^[Bb][Ee][Aa][Rr][Ee][Rr]\s+(.+)$/;
-
-export function getBearerToken(req: Request): string {
-	const headerValue = req.headers['authorization']?.toString();
-
-	if (!headerValue) {
-		throw new UnauthenticatedError();
-	}
-
-	const result = BEARER_TOKEN_REGEX.exec(headerValue);
-	const token = result ? result[1] : null;
-
-	if (!token) {
-		throw new BadRequestError('Authorization header is malformed');
-	}
-
-	return token;
-}
 
 export const getDynamicCredentialMiddlewares = () => {
 	return [Container.get(DynamicCredentialService).getDynamicCredentialsEndpointsMiddleware()];

--- a/packages/cli/src/modules/dynamic-credentials.ee/workflow-status.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/workflow-status.controller.ts
@@ -40,7 +40,7 @@ export class WorkflowStatusController {
 	 * @throws {BadRequestError} When authorization header is missing or malformed
 	 */
 	@Get('/:workflowId/execution-status', {
-		skipAuth: true,
+		allowUnauthenticated: true,
 		middlewares: getDynamicCredentialMiddlewares(),
 	})
 	async checkWorkflowForExecution(req: Request, res: Response): Promise<WorkflowExecutionStatus> {

--- a/packages/cli/src/modules/dynamic-credentials.ee/workflow-status.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/workflow-status.controller.ts
@@ -4,10 +4,11 @@ import { Request, Response } from 'express';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { CredentialResolverWorkflowService } from './services/credential-resolver-workflow.service';
 import { WorkflowExecutionStatus } from '@n8n/api-types';
-import { getBearerToken, getDynamicCredentialMiddlewares } from './utils';
+import { getDynamicCredentialMiddlewares } from './utils';
 import { UrlService } from '@/services/url.service';
 import { GlobalConfig } from '@n8n/config';
 import { DynamicCredentialCorsService } from './services/dynamic-credential-cors.service';
+import { DynamicCredentialWebService } from './services/dynamic-credential-web.service';
 
 @RestController('/workflows')
 export class WorkflowStatusController {
@@ -16,6 +17,7 @@ export class WorkflowStatusController {
 		private readonly urlService: UrlService,
 		private readonly globalConfig: GlobalConfig,
 		private readonly dynamicCredentialCorsService: DynamicCredentialCorsService,
+		private readonly dynamicCredentialWebService: DynamicCredentialWebService,
 	) {}
 
 	/**
@@ -44,7 +46,7 @@ export class WorkflowStatusController {
 	async checkWorkflowForExecution(req: Request, res: Response): Promise<WorkflowExecutionStatus> {
 		this.dynamicCredentialCorsService.applyCorsHeadersIfEnabled(req, res, ['get', 'options']);
 		const workflowId = req.params['workflowId'];
-		const token = getBearerToken(req);
+		const credentialContext = this.dynamicCredentialWebService.getCredentialContextFromRequest(req);
 
 		if (!workflowId) {
 			throw new BadRequestError('Workflow ID is missing');
@@ -52,7 +54,7 @@ export class WorkflowStatusController {
 
 		const status = await this.credentialResolverWorkflowService.getWorkflowStatus(
 			workflowId,
-			token,
+			credentialContext,
 		);
 
 		const isReady = status.every((s) => s.status === 'configured');


### PR DESCRIPTION
## Summary

This PR refactors the dynamic credentials authentication system to support both bearer token and cookie-based authentication. Previously, the system only supported bearer token authentication. This change enables the system to:
1. Accept authentication via bearer tokens OR session cookies
2. Support an explicit authSource query parameter to specify which authentication method to use
3. Maintain backward compatibility with existing bearer token authentication

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/IAM-90/support-cookie-for-auth-token-extraction

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
