### PR TITLE
feat(core): Allow changing the oauth token data for oauth2 credentials on public API PATCH

### DIFF
--- a/packages/cli/src/public-api/v1/handlers/credentials/credentials.service.ts
+++ b/packages/cli/src/public-api/v1/handlers/credentials/credentials.service.ts
@@ -135,11 +135,6 @@ export async function updateCredential(
 
 	// If data is provided, encrypt it
 	if (updateData.data !== undefined) {
-		// Never allow changing oauthTokenData via API
-		if (updateData.data?.oauthTokenData) {
-			delete updateData.data.oauthTokenData;
-		}
-
 		const credentialsService = Container.get(CredentialsService);
 
 		// Decrypt existing data to access oauthTokenData
@@ -161,11 +156,6 @@ export async function updateCredential(
 		} else {
 			// isPartialData is false or undefined (default): replace entire data object
 			dataToEncrypt = updateData.data;
-		}
-
-		// Preserve oauthTokenData from existing credential
-		if (decryptedData.oauthTokenData) {
-			dataToEncrypt.oauthTokenData = decryptedData.oauthTokenData;
 		}
 
 		const newCredential = new CredentialsEntity();


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Currently, we have a logic in place to prevent the overriding of `oauthTokenData` field for credentials when patching this credentials data. This is mostly here to prevent users from corruption their oauth data which is most of the time managed by the credentials itself.
But some use cases like WIF (Workload Identity Federation) requires getting dynamic access tokens for oauth provider services, and thus updating credentials oauth data manually.

This PR disables the oauthTokenData preservation. It's fine because if the customer want to update 

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/IAM-205/public-api-authorize-oauth-token-data-update-on-patch-credentialsid
## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
