### PR TITLE
feat(core): Introduce table to track actually published workflow versions (no-changelog)

### DIFF
--- a/packages/@n8n/db/src/migrations/common/1769698710000-CreateWorkflowPublishedVersionTable.ts
+++ b/packages/@n8n/db/src/migrations/common/1769698710000-CreateWorkflowPublishedVersionTable.ts
@@ -1,0 +1,32 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+/**
+ * Creates the workflow_published_version table to track the actually-published
+ * workflow version in production. This is distinct from workflow_entity.activeVersionId
+ * which tracks the requested/intended published version. Since publication is an
+ * asynchronous process, this table is updated only when the new version is fully
+ * deployed and ready for production executions.
+ */
+export class CreateWorkflowPublishedVersionTable1769698710000 implements ReversibleMigration {
+	async up({ schemaBuilder: { createTable, column } }: MigrationContext) {
+		await createTable('workflow_published_version')
+			.withColumns(
+				column('workflowId').varchar(36).primary.notNull,
+				column('publishedVersionId').varchar(36).notNull,
+			)
+			.withForeignKey('workflowId', {
+				tableName: 'workflow_entity',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			})
+			.withForeignKey('publishedVersionId', {
+				tableName: 'workflow_history',
+				columnName: 'versionId',
+				onDelete: 'CASCADE',
+			}).withTimestamps;
+	}
+
+	async down({ schemaBuilder: { dropTable } }: MigrationContext) {
+		await dropTable('workflow_published_version');
+	}
+}

--- a/packages/@n8n/db/src/migrations/mysqldb/index.ts
+++ b/packages/@n8n/db/src/migrations/mysqldb/index.ts
@@ -129,6 +129,7 @@ import { AddIconToAgentTable1765788427674 } from '../common/1765788427674-AddIco
 import { AddAgentIdForeignKeys1765886667897 } from '../common/1765886667897-AddAgentIdForeignKeys';
 import { AddWorkflowVersionIdToExecutionData1765892199653 } from '../common/1765892199653-AddVersionIdToExecutionData';
 import { AddPublishedVersionIdToWorkflowDependency1769000000000 } from '../common/1769000000000-AddPublishedVersionIdToWorkflowDependency';
+import { CreateWorkflowPublishedVersionTable1769698710000 } from '../common/1769698710000-CreateWorkflowPublishedVersionTable';
 import type { Migration } from '../migration-types';
 
 export const mysqlMigrations: Migration[] = [
@@ -263,4 +264,5 @@ export const mysqlMigrations: Migration[] = [
 	AddAgentIdForeignKeys1765886667897,
 	AddWorkflowVersionIdToExecutionData1765892199653,
 	AddPublishedVersionIdToWorkflowDependency1769000000000,
+	CreateWorkflowPublishedVersionTable1769698710000,
 ];

--- a/packages/@n8n/db/src/migrations/mysqldb/index.ts
+++ b/packages/@n8n/db/src/migrations/mysqldb/index.ts
@@ -129,7 +129,6 @@ import { AddIconToAgentTable1765788427674 } from '../common/1765788427674-AddIco
 import { AddAgentIdForeignKeys1765886667897 } from '../common/1765886667897-AddAgentIdForeignKeys';
 import { AddWorkflowVersionIdToExecutionData1765892199653 } from '../common/1765892199653-AddVersionIdToExecutionData';
 import { AddPublishedVersionIdToWorkflowDependency1769000000000 } from '../common/1769000000000-AddPublishedVersionIdToWorkflowDependency';
-import { CreateWorkflowPublishedVersionTable1769698710000 } from '../common/1769698710000-CreateWorkflowPublishedVersionTable';
 import type { Migration } from '../migration-types';
 
 export const mysqlMigrations: Migration[] = [
@@ -264,5 +263,4 @@ export const mysqlMigrations: Migration[] = [
 	AddAgentIdForeignKeys1765886667897,
 	AddWorkflowVersionIdToExecutionData1765892199653,
 	AddPublishedVersionIdToWorkflowDependency1769000000000,
-	CreateWorkflowPublishedVersionTable1769698710000,
 ];

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -138,6 +138,7 @@ import { AddStoredAtToExecutionEntity1768557000000 } from '../common/17685570000
 import { AddDynamicCredentialUserEntryTable1768901721000 } from '../common/1768901721000-AddDynamicCredentialUserEntryTable';
 import { AddPublishedVersionIdToWorkflowDependency1769000000000 } from '../common/1769000000000-AddPublishedVersionIdToWorkflowDependency';
 import { CreateSecretsProviderConnectionTables1769433700000 } from '../common/1769433700000-CreateSecretsProvidersConnectionTables';
+import { CreateWorkflowPublishedVersionTable1769698710000 } from '../common/1769698710000-CreateWorkflowPublishedVersionTable';
 import type { Migration } from '../migration-types';
 
 export const postgresMigrations: Migration[] = [
@@ -281,4 +282,5 @@ export const postgresMigrations: Migration[] = [
 	AddDynamicCredentialUserEntryTable1768901721000,
 	AddPublishedVersionIdToWorkflowDependency1769000000000,
 	CreateSecretsProviderConnectionTables1769433700000,
+	CreateWorkflowPublishedVersionTable1769698710000,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -132,6 +132,7 @@ import { AddStoredAtToExecutionEntity1768557000000 } from '../common/17685570000
 import { AddDynamicCredentialUserEntryTable1768901721000 } from '../common/1768901721000-AddDynamicCredentialUserEntryTable';
 import { AddPublishedVersionIdToWorkflowDependency1769000000000 } from '../common/1769000000000-AddPublishedVersionIdToWorkflowDependency';
 import { CreateSecretsProviderConnectionTables1769433700000 } from '../common/1769433700000-CreateSecretsProvidersConnectionTables';
+import { CreateWorkflowPublishedVersionTable1769698710000 } from '../common/1769698710000-CreateWorkflowPublishedVersionTable';
 import type { Migration } from '../migration-types';
 
 const sqliteMigrations: Migration[] = [
@@ -269,6 +270,7 @@ const sqliteMigrations: Migration[] = [
 	AddDynamicCredentialUserEntryTable1768901721000,
 	AddPublishedVersionIdToWorkflowDependency1769000000000,
 	CreateSecretsProviderConnectionTables1769433700000,
+	CreateWorkflowPublishedVersionTable1769698710000,
 ];
 
 export { sqliteMigrations };


### PR DESCRIPTION
## Summary

Introduce a new table to track what version of a workflow is *actually* published.

This is part of the workflow publication project. A subsequent PR will update the various webhooks/triggers/etc to use this table.

Today: webhooks read from the `workflow_entity` table (with a caching layer). Triggers/pollers/timers hold the workflow definition in memory. This means that when a new version of a workflow is published, there's no synchronization between the various triggers - they switch from the old version to the new version gradually.

After this PR and follow-ups: every trigger will read from this table, with a caching layer in front of it. When a new version is published and we're ready to start executing it, we'll invalidate the cache and update this table.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2190

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
