### PR TITLE
fix(core): Fix execution startedAt timezone issue with PostgreSQL

### DIFF
--- a/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
@@ -448,7 +448,7 @@ describe('ExecutionRepository', () => {
 				status: 'running',
 				startedAt: expect.any(Function),
 			});
-			expect(updateQueryBuilder.setParameter).toHaveBeenCalledWith('startedAt', expect.any(String));
+			expect(updateQueryBuilder.setParameter).toHaveBeenCalledWith('startedAt', expect.any(Date));
 			expect(updateQueryBuilder.where).toHaveBeenCalledWith('id = :id', { id: executionId });
 			expect(updateQueryBuilder.execute).toHaveBeenCalled();
 

--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -396,7 +396,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 					status: 'running',
 					startedAt: () => 'COALESCE(startedAt, :startedAt)',
 				})
-				.setParameter('startedAt', DateUtils.mixedDateToUtcDatetimeString(startedAt))
+				.setParameter('startedAt', startedAt)
 				.where('id = :id', { id: executionId })
 				.execute();
 


### PR DESCRIPTION
## Summary

This PR fixes a bug introduced in **v2.5.0** where execution timestamps (`startedAt`) were incorrectly stored in PostgreSQL when the database is configured for a non-UTC timezone (e.g., `Asia/Tokyo`).

### Problem
Following the changes in #23146, the storage logic for `startedAt` was modified to use `DateUtils.mixedDateToUtcDatetimeString`. This helper explicitly converts `Date` objects to a UTC string before persistence.

In environments where PostgreSQL is set to a local timezone like JST (UTC+9), this causes a discrepancy:
- **Expected:** `2026-01-30 22:50:00 JST` stored as `2026-01-30 22:50:00+09`.
- **Actual (v2.5.0):** The UTC string `13:50:00` is stored as `2026-01-30 13:50:00+09`, resulting in a 9-hour offset in the UI.

### Solution
I have reverted the logic to pass the `Date` object directly to the query builder. This allows the database driver to handle the timezone conversion naturally based on the system/database configuration, restoring the original and correct behavior.

<img width="1876" height="488" alt="Before modification" src="https://github.com/user-attachments/assets/d82bc984-133d-4d8b-b9a7-ba513ad7a5c4" />

## Related Linear tickets, Github issues, and Community forum posts

#23146

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
