### PR TITLE
fix(VectorStoreAzureAISearch Node): Clear Azure AI Search index once per batch

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreAzureAISearch/VectorStoreAzureAISearch.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreAzureAISearch/VectorStoreAzureAISearch.node.ts
@@ -412,6 +412,9 @@ export class VectorStoreAzureAISearch extends createVectorStoreNode({
 	retrieveFields,
 	loadFields: retrieveFields,
 	insertFields,
+	async beforeInsert(context, _embeddings, itemIndex) {
+		await clearAzureSearchIndex(context, itemIndex);
+	},
 	async getVectorStoreClient(context, _filter, embeddings, itemIndex) {
 		const vectorStore = await getAzureAISearchClient(context, embeddings, itemIndex);
 
@@ -465,9 +468,6 @@ export class VectorStoreAzureAISearch extends createVectorStoreNode({
 	},
 	async populateVectorStore(context, embeddings, documents, itemIndex) {
 		try {
-			// Clear the index if requested (delete and recreate)
-			await clearAzureSearchIndex(context, itemIndex);
-
 			const metadataKeysToInsertRaw = getOptionValue<string>(
 				'metadataKeysToInsert',
 				context,

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/operations/insertOperation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/operations/insertOperation.ts
@@ -64,6 +64,10 @@ export async function handleInsertOperation<T extends VectorStore = VectorStore>
 
 	// For the version 1.1, we run the populateVectorStore in batches
 	if (nodeVersion >= 1.1) {
+		if (args.beforeInsert) {
+			await args.beforeInsert(context, embeddings, 0);
+		}
+
 		const embeddingBatchSize =
 			(context.getNodeParameter('embeddingBatchSize', 0, 200) as number) ?? 200;
 

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/types.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/types.ts
@@ -55,6 +55,17 @@ export interface VectorStoreNodeConstructorArgs<T extends VectorStore = VectorSt
 	updateFields?: INodeProperties[];
 
 	/**
+	 * Optional function called once before any documents are inserted.
+	 * Use this for one-time setup operations like clearing an index.
+	 * Only called for node version 1.1+ where batch processing is used.
+	 */
+	beforeInsert?: (
+		context: IExecuteFunctions | ISupplyDataFunctions,
+		embeddings: Embeddings,
+		itemIndex: number,
+	) => Promise<void>;
+
+	/**
 	 * Function to populate the vector store with documents
 	 * Used during the 'insert' operation mode
 	 */


### PR DESCRIPTION
## Summary                                                                  
- Fixes bug where Azure AI Search Vector Store cleared the index on each batch instead of once                                                       
- Adds `beforeInsert` hook to vector store node interface for one-time setup operations                                                                 
- Moves index clearing from `populateVectorStore` to `beforeInsert` hook    

## Related Linear ticket                                                    
https://linear.app/n8n/issue/AI-1981  