### PR TITLE
feat(core): Support multiOptions scope for OAuth2 credentials

### DIFF
--- a/packages/@n8n/client-oauth2/src/index.ts
+++ b/packages/@n8n/client-oauth2/src/index.ts
@@ -2,5 +2,5 @@ export type { ClientOAuth2Options, ClientOAuth2RequestObject } from './client-oa
 export { ClientOAuth2 } from './client-oauth2';
 export type { ClientOAuth2TokenData } from './client-oauth2-token';
 export { ClientOAuth2Token } from './client-oauth2-token';
-export { AuthError } from './utils';
+export { AuthError, parseOAuth2Scopes } from './utils';
 export type * from './types';

--- a/packages/@n8n/client-oauth2/src/types.ts
+++ b/packages/@n8n/client-oauth2/src/types.ts
@@ -10,7 +10,11 @@ export interface OAuth2CredentialData {
 	accessTokenUrl: string;
 	authentication?: OAuth2AuthenticationMethod;
 	authUrl?: string;
-	scope?: string;
+	/**
+	 * OAuth2 scopes. Usually a space-separated string, but credential fields
+	 * defined as `multiOptions` provide the selected scopes as an array.
+	 */
+	scope?: string | string[];
 	authQueryParameters?: string;
 	additionalBodyProperties?: string;
 	grantType: OAuth2GrantType;

--- a/packages/@n8n/client-oauth2/src/utils.ts
+++ b/packages/@n8n/client-oauth2/src/utils.ts
@@ -46,6 +46,18 @@ export function getAuthError(body: {
 }
 
 /**
+ * Normalize an OAuth2 `scope` credential value into a list of scope tokens.
+ *
+ * The value may be a space-separated string or, for `multiOptions` credential
+ * fields, an array. Empty tokens are dropped because they are not RFC 6749
+ * compliant and may be rejected by authorization servers.
+ */
+export function parseOAuth2Scopes(scope: string | string[] | undefined): string[] {
+	const tokens = Array.isArray(scope) ? scope : (scope ?? '').split(' ');
+	return tokens.map((token) => token.trim()).filter(Boolean);
+}
+
+/**
  * Ensure a value is a string.
  */
 function toString(str: string | null | undefined) {

--- a/packages/@n8n/client-oauth2/test/utils.test.ts
+++ b/packages/@n8n/client-oauth2/test/utils.test.ts
@@ -1,0 +1,35 @@
+import { parseOAuth2Scopes } from '@/utils';
+
+describe('parseOAuth2Scopes', () => {
+	test('returns an empty array for undefined', () => {
+		expect(parseOAuth2Scopes(undefined)).toEqual([]);
+	});
+
+	test('returns an empty array for an empty string', () => {
+		expect(parseOAuth2Scopes('')).toEqual([]);
+	});
+
+	test('returns an empty array for a whitespace-only string', () => {
+		expect(parseOAuth2Scopes('   ')).toEqual([]);
+	});
+
+	test('splits a space-separated string into tokens', () => {
+		expect(parseOAuth2Scopes('read write')).toEqual(['read', 'write']);
+	});
+
+	test('trims and filters extra whitespace between tokens', () => {
+		expect(parseOAuth2Scopes('  read   write  ')).toEqual(['read', 'write']);
+	});
+
+	test('returns the array as-is for an array of scopes', () => {
+		expect(parseOAuth2Scopes(['read', 'write'])).toEqual(['read', 'write']);
+	});
+
+	test('trims and filters empty tokens from an array', () => {
+		expect(parseOAuth2Scopes([' read ', '', 'write', '   '])).toEqual(['read', 'write']);
+	});
+
+	test('returns an empty array for an empty array', () => {
+		expect(parseOAuth2Scopes([])).toEqual([]);
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/__tests__/N8nOAuth2TokenCredential.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/__tests__/N8nOAuth2TokenCredential.test.ts
@@ -29,7 +29,8 @@ const { MockClientOAuth2 } = vi.hoisted(() => {
 	return { MockClientOAuth2, MockCredentialsFlow };
 });
 
-vi.mock('@n8n/client-oauth2', () => ({
+vi.mock('@n8n/client-oauth2', async (importActual) => ({
+	...(await importActual()),
 	ClientOAuth2: MockClientOAuth2,
 }));
 

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/credentials/N8nOAuth2TokenCredential.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/credentials/N8nOAuth2TokenCredential.ts
@@ -1,6 +1,6 @@
 import type { TokenCredential, AccessToken } from '@azure/identity';
 import type { ClientOAuth2TokenData } from '@n8n/client-oauth2';
-import { ClientOAuth2 } from '@n8n/client-oauth2';
+import { ClientOAuth2, parseOAuth2Scopes } from '@n8n/client-oauth2';
 import type { INode } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 
@@ -26,7 +26,7 @@ export class N8nOAuth2TokenCredential implements TokenCredential {
 				clientId: this.credential.clientId,
 				clientSecret: this.credential.clientSecret,
 				accessTokenUri: this.credential.accessTokenUrl,
-				scopes: this.credential.scope?.split(' '),
+				scopes: parseOAuth2Scopes(this.credential.scope),
 				authentication: this.credential.authentication,
 				authorizationUri: this.credential.authUrl,
 				additionalBodyProperties: {

--- a/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
+++ b/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@n8n/backend-common';
 import type { ClientOAuth2Options, OAuth2CredentialData } from '@n8n/client-oauth2';
-import { ClientOAuth2 } from '@n8n/client-oauth2';
+import { ClientOAuth2, parseOAuth2Scopes } from '@n8n/client-oauth2';
 import { Get, RestController } from '@n8n/decorators';
 import { Response } from 'express';
 import omit from 'lodash/omit';
@@ -171,8 +171,11 @@ export class OAuth2CredentialController {
 			authorizationUri: credential.authUrl ?? '',
 			authentication: credential.authentication ?? 'header',
 			redirectUri: `${this.oauthService.getBaseUrl(OauthVersion.V2)}/callback`,
-			scopes: split(credential.scope ?? 'openid', ','),
-			scopesSeparator: credential.scope?.includes(',') ? ',' : ' ',
+			scopes: Array.isArray(credential.scope)
+				? parseOAuth2Scopes(credential.scope)
+				: split(credential.scope ?? 'openid', ','),
+			scopesSeparator:
+				!Array.isArray(credential.scope) && credential.scope?.includes(',') ? ',' : ' ',
 			resource: credential.resource,
 			ignoreSSLIssues: credential.ignoreSSLIssues ?? false,
 		};

--- a/packages/cli/src/oauth/__tests__/oauth.service.test.ts
+++ b/packages/cli/src/oauth/__tests__/oauth.service.test.ts
@@ -1,5 +1,6 @@
 import { Logger } from '@n8n/backend-common';
 import { mockInstance } from '@n8n/backend-test-utils';
+import { parseOAuth2Scopes } from '@n8n/client-oauth2';
 import type { OAuth2CredentialData } from '@n8n/client-oauth2';
 import { GlobalConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
@@ -3976,6 +3977,45 @@ describe('OauthService', () => {
 				});
 
 				expect(options.resource).toBeUndefined();
+			});
+
+			it('should default to the openid scope when no scope is set', () => {
+				const options = (service as any).convertCredentialToOptions({
+					clientId: 'client-id',
+					clientSecret: 'client-secret',
+					accessTokenUrl: 'https://auth.example.com/oauth2/token',
+				});
+
+				expect(options.scopes).toEqual(['openid']);
+				expect(options.scopesSeparator).toBe(' ');
+			});
+
+			it('should split a comma-separated scope string and keep the comma separator', () => {
+				const options = (service as any).convertCredentialToOptions({
+					clientId: 'client-id',
+					clientSecret: 'client-secret',
+					accessTokenUrl: 'https://auth.example.com/oauth2/token',
+					scope: 'read,write',
+				});
+
+				expect(options.scopes).toEqual(['read', 'write']);
+				expect(options.scopesSeparator).toBe(',');
+			});
+
+			it('should accept scopes provided as an array (multiOptions credential field)', () => {
+				jest
+					.mocked(parseOAuth2Scopes)
+					.mockImplementation(jest.requireActual('@n8n/client-oauth2').parseOAuth2Scopes);
+
+				const options = (service as any).convertCredentialToOptions({
+					clientId: 'client-id',
+					clientSecret: 'client-secret',
+					accessTokenUrl: 'https://auth.example.com/oauth2/token',
+					scope: ['read', 'write'],
+				});
+
+				expect(options.scopes).toEqual(['read', 'write']);
+				expect(options.scopesSeparator).toBe(' ');
 			});
 		});
 	});

--- a/packages/cli/src/oauth/oauth.service.ts
+++ b/packages/cli/src/oauth/oauth.service.ts
@@ -30,6 +30,7 @@ import {
 	type OAuth2AuthenticationMethod,
 	type OAuth2CredentialData,
 	type OAuth2GrantType,
+	parseOAuth2Scopes,
 } from '@n8n/client-oauth2';
 import axios from 'axios';
 import {
@@ -622,16 +623,13 @@ export class OauthService {
 		const oauthTokenData = oauthCredentials.oauthTokenData as ClientOAuth2TokenData | undefined;
 		if (!oauthTokenData) return null;
 
-		const scopes = oauthCredentials.scope
-			?.split(' ')
-			.map((s) => s.trim())
-			.filter(Boolean);
+		const scopes = parseOAuth2Scopes(oauthCredentials.scope);
 
 		const oAuthClient = new ClientOAuth2({
 			clientId: oauthCredentials.clientId,
 			clientSecret: oauthCredentials.clientSecret,
 			accessTokenUri: oauthCredentials.accessTokenUrl,
-			scopes: scopes?.length ? scopes : undefined,
+			scopes: scopes.length ? scopes : undefined,
 			ignoreSSLIssues: oauthCredentials.ignoreSSLIssues,
 			authentication: oauthCredentials.authentication ?? 'header',
 		});
@@ -1148,8 +1146,11 @@ export class OauthService {
 			authorizationUri: credential.authUrl ?? '',
 			authentication: credential.authentication ?? 'header',
 			redirectUri: `${this.getBaseUrl(OauthVersion.V2)}/callback`,
-			scopes: split(credential.scope ?? 'openid', ','),
-			scopesSeparator: credential.scope?.includes(',') ? ',' : ' ',
+			scopes: Array.isArray(credential.scope)
+				? parseOAuth2Scopes(credential.scope)
+				: split(credential.scope ?? 'openid', ','),
+			scopesSeparator:
+				!Array.isArray(credential.scope) && credential.scope?.includes(',') ? ',' : ' ',
 			resource: credential.resource,
 			ignoreSSLIssues: credential.ignoreSSLIssues ?? false,
 		};

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/create-oauth2-client.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/create-oauth2-client.test.ts
@@ -10,7 +10,8 @@ const { mockGetToken, mockSign, mockCreateToken, MockClientOAuth2 } = vi.hoisted
 	MockClientOAuth2: vi.fn(),
 }));
 
-vi.mock('@n8n/client-oauth2', () => ({
+vi.mock('@n8n/client-oauth2', async (importActual) => ({
+	...(await importActual()),
 	ClientOAuth2: MockClientOAuth2,
 }));
 
@@ -112,5 +113,36 @@ describe('createOAuth2Client - scope handling', () => {
 		expect(MockClientOAuth2).toHaveBeenCalledWith(
 			expect.objectContaining({ scopes: ['read', 'write'] }),
 		);
+	});
+
+	test('should accept scopes provided as an array (multiOptions credential field)', async () => {
+		mockThis.getCredentials.mockResolvedValue({ ...baseCredentials, scope: ['read', 'write'] });
+
+		await call();
+
+		expect(MockClientOAuth2).toHaveBeenCalledWith(
+			expect.objectContaining({ scopes: ['read', 'write'] }),
+		);
+	});
+
+	test('should trim and filter empty entries from a scopes array', async () => {
+		mockThis.getCredentials.mockResolvedValue({
+			...baseCredentials,
+			scope: [' read ', '', 'write'],
+		});
+
+		await call();
+
+		expect(MockClientOAuth2).toHaveBeenCalledWith(
+			expect.objectContaining({ scopes: ['read', 'write'] }),
+		);
+	});
+
+	test('should pass undefined scopes when scope is an empty array', async () => {
+		mockThis.getCredentials.mockResolvedValue({ ...baseCredentials, scope: [] });
+
+		await call();
+
+		expect(MockClientOAuth2).toHaveBeenCalledWith(expect.objectContaining({ scopes: undefined }));
 	});
 });

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/oauth.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/oauth.ts
@@ -12,7 +12,7 @@ import type {
 	ClientOAuth2TokenData,
 	OAuth2CredentialData,
 } from '@n8n/client-oauth2';
-import { AuthError, ClientOAuth2 } from '@n8n/client-oauth2';
+import { AuthError, ClientOAuth2, parseOAuth2Scopes } from '@n8n/client-oauth2';
 import type { AxiosError } from 'axios';
 import { createHmac } from 'crypto';
 import get from 'lodash/get';
@@ -34,16 +34,13 @@ import clientOAuth1 from 'oauth-1.0a';
 import type { IResponseError } from '@/interfaces';
 
 function createOAuth2Client(credentials: OAuth2CredentialData): ClientOAuth2 {
-	// Split and trim scopes; empty scope tokens are not RFC 6749-compliant and may be rejected by authorization servers
-	const scopes = credentials.scope
-		?.split(' ')
-		.map((s) => s.trim())
-		.filter(Boolean);
+	// `scope` may be a space-separated string or an array (multiOptions credential fields)
+	const scopes = parseOAuth2Scopes(credentials.scope);
 	return new ClientOAuth2({
 		clientId: credentials.clientId,
 		clientSecret: credentials.clientSecret,
 		accessTokenUri: credentials.accessTokenUrl,
-		scopes: scopes?.length ? scopes : undefined,
+		scopes: scopes.length ? scopes : undefined,
 		ignoreSSLIssues: credentials.ignoreSSLIssues,
 		authentication: credentials.authentication ?? 'header',
 		...(credentials.additionalBodyProperties && {

--- a/packages/nodes-base/credentials/OAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/OAuth2Api.credentials.ts
@@ -108,6 +108,10 @@ export class OAuth2Api implements ICredentialType {
 		// WARNING: if you are extending from this credentials and allow user to set their own scopes
 		// you HAVE TO add it to GENERIC_OAUTH2_CREDENTIALS_WITH_EDITABLE_SCOPE in packages/cli/src/constants.ts
 		// track any updates to this behavior in N8N-7424
+		//
+		// `scope` accepts either a space-separated string (as below) or, when a
+		// node overrides this field with `type: 'multiOptions'`, an array of the
+		// selected scopes. Both forms are normalized before the OAuth2 request.
 		{
 			displayName: 'Scope',
 			name: 'scope',


### PR DESCRIPTION
## Summary
This PR add the possibility for a scope multiOption in oauth2 credentials

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
<img width="957" height="223" alt="image" src="https://github.com/user-attachments/assets/83b4a769-f916-44f5-960e-96b98c003029" />
Test via creating a new oauth2 credential with :
``` json 
{
			displayName: 'Scope',
			name: 'scope',
			type: 'multiOptions',
			default: [],
			options: ['scope1","scope2'].map((scope) => ({
				name: scope,
				value: scope,
			})),
			// multiple values can be selected
			required: true,
		}
```
## Related Linear tickets, Github issues, and Community forum posts
N/A
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
N/A

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)


If accepted i'll provide the tests and doc 