### PR TITLE
perf(core): Minimize execution data fetching

### DIFF
--- a/packages/cli/src/active-executions.ts
+++ b/packages/cli/src/active-executions.ts
@@ -10,6 +10,7 @@ import type {
 	ExecutionStatus,
 	IWorkflowExecutionDataProcess,
 	StructuredChunk,
+	WebhookResponseMode,
 } from 'n8n-workflow';
 import {
 	createDeferredPromise,
@@ -37,6 +38,9 @@ export class ActiveExecutions {
 	private activeExecutions: {
 		[executionId: string]: IExecutingWorkflowData;
 	} = {};
+
+	/** Response mode by execution ID, if webhook-initiated. */
+	private responseModes = new Map<string, WebhookResponseMode>();
 
 	constructor(
 		private readonly logger: Logger,
@@ -144,6 +148,7 @@ export class ActiveExecutions {
 					delete execution.workflowExecution;
 				} else {
 					delete this.activeExecutions[executionId];
+					this.responseModes.delete(executionId);
 					this.logger.debug('Execution removed', { executionId });
 				}
 			});
@@ -204,6 +209,7 @@ export class ActiveExecutions {
 			// A waiting execution will not have a valid workflowExecution or postExecutePromise
 			// So we can't rely on the `.finally` on the postExecutePromise for the execution removal
 			delete this.activeExecutions[executionId];
+			this.responseModes.delete(executionId);
 		} else {
 			execution.workflowExecution?.cancel();
 			execution.postExecutePromise.reject(cancellationError);
@@ -285,6 +291,14 @@ export class ActiveExecutions {
 
 	getStatus(executionId: string): ExecutionStatus {
 		return this.getExecutionOrFail(executionId).status;
+	}
+
+	setResponseMode(executionId: string, responseMode: WebhookResponseMode): void {
+		this.responseModes.set(executionId, responseMode);
+	}
+
+	getResponseMode(executionId: string): WebhookResponseMode | undefined {
+		return this.responseModes.get(executionId);
 	}
 
 	/** Wait for all active executions to finish */

--- a/packages/cli/src/external-hooks.ts
+++ b/packages/cli/src/external-hooks.ts
@@ -147,6 +147,10 @@ export class ExternalHooks {
 		}
 	}
 
+	hasHook<HookName extends HookNames>(hookName: HookName): boolean {
+		return !!this.registered[hookName]?.length;
+	}
+
 	async run<HookName extends HookNames>(
 		hookName: HookName,
 		hookParameters?: ExternalHooksMap[HookName],

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -14,22 +14,23 @@ import type {
 import { BINARY_ENCODING, Workflow, UnexpectedError, createRunExecutionData } from 'n8n-workflow';
 import type PCancelable from 'p-cancelable';
 
-import type {
-	Job,
-	JobFinishedMessage,
-	JobId,
-	JobResult,
-	RespondToWebhookMessage,
-	RunningJob,
-	SendChunkMessage,
-} from './scaling.types';
-
 import { EventService } from '@/events/event.service';
 import { getLifecycleHooksForScalingWorker } from '@/execution-lifecycle/execution-lifecycle-hooks';
 import { getWorkflowActiveStatusFromWorkflowData } from '@/executions/execution.utils';
 import { ManualExecutionService } from '@/manual-execution.service';
 import { NodeTypes } from '@/node-types';
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
+
+import type {
+	Job,
+	JobFinishedMessage,
+	JobFinishedProps,
+	JobId,
+	JobResult,
+	RespondToWebhookMessage,
+	RunningJob,
+	SendChunkMessage,
+} from './scaling.types';
 
 /**
  * Responsible for processing jobs from the queue, i.e. running enqueued executions.
@@ -246,23 +247,26 @@ export class JobProcessor {
 
 		this.runningJobs[job.id] = runningJob;
 
-		await workflowRun;
+		const run = await workflowRun;
 
 		delete this.runningJobs[job.id];
 
-		const hasErrors = await this.executionHasErrors(executionId);
+		const props = process.env.N8N_MINIMIZE_EXECUTION_DATA_FETCHING
+			? this.deriveJobFinishedProps(run, startedAt)
+			: await this.fetchJobFinishedResult(executionId);
+
 		this.logger.info(`Worker finished execution ${executionId} (job ${job.id})`, {
 			executionId,
 			workflowId,
 			jobId: job.id,
-			success: !hasErrors,
+			success: props.success,
 		});
 
 		const msg: JobFinishedMessage = {
 			kind: 'job-finished',
 			executionId,
 			workerId: this.instanceSettings.hostId,
-			success: !hasErrors,
+			...props,
 		};
 
 		await job.progress(msg);
@@ -275,13 +279,41 @@ export class JobProcessor {
 		return { success: true };
 	}
 
-	private async executionHasErrors(executionId: string): Promise<boolean> {
+	private deriveJobFinishedProps(run: IRun, startedAt: Date): JobFinishedProps {
+		return {
+			success: run.status !== 'error' && run.data.resultData.error === undefined,
+			status: run.status,
+			error: run.data.resultData.error,
+			startedAt,
+			stoppedAt: run.stoppedAt!,
+			lastNodeExecuted: run.data.resultData.lastNodeExecuted,
+			usedDynamicCredentials: !!run.data.executionData?.runtimeData?.credentials,
+			metadata: run.data.resultData.metadata,
+		};
+	}
+
+	private async fetchJobFinishedResult(executionId: string): Promise<JobFinishedProps> {
 		const execution = await this.executionRepository.findSingleExecution(executionId, {
 			includeData: true,
 			unflattenData: true,
 		});
 
-		return execution?.status === 'error' || execution?.data?.resultData?.error !== undefined;
+		if (!execution) {
+			throw new UnexpectedError(
+				`Worker failed to find execution ${executionId} immediately after workflow completed`,
+			);
+		}
+
+		return {
+			success: execution.status !== 'error' && execution.data?.resultData?.error === undefined,
+			status: execution.status,
+			error: execution.data?.resultData?.error,
+			startedAt: execution.startedAt,
+			stoppedAt: execution.stoppedAt!,
+			lastNodeExecuted: execution.data?.resultData?.lastNodeExecuted,
+			usedDynamicCredentials: !!execution.data?.executionData?.runtimeData?.credentials,
+			metadata: execution.data?.resultData?.metadata,
+		};
 	}
 
 	stopJob(jobId: JobId) {

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -264,6 +264,7 @@ export class JobProcessor {
 
 		const msg: JobFinishedMessage = {
 			kind: 'job-finished',
+			version: 2,
 			executionId,
 			workerId: this.instanceSettings.hostId,
 			...props,

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -350,7 +350,7 @@ export class ScalingService {
 					 * because `removeOnComplete: true` prevents `job.finished()`
 					 * from returning a value that is no longer in Redis.
 					 */
-					if ('version' in msg && msg.version === 2) {
+					if (msg.version === 2) {
 						this.jobResults.set(msg.executionId, {
 							success: msg.success,
 							error: msg.error,

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -30,6 +30,7 @@ import type {
 	JobOptions,
 	JobStatus,
 	JobId,
+	JobFinishedProps,
 	QueueRecoveryContext,
 	JobMessage,
 	JobFailedMessage,
@@ -38,6 +39,8 @@ import type {
 @Service()
 export class ScalingService {
 	private queue: JobQueue;
+
+	private jobResults = new Map<string, JobFinishedProps>();
 
 	constructor(
 		private readonly logger: Logger,
@@ -175,6 +178,13 @@ export class ScalingService {
 	// #endregion
 
 	// #region Jobs
+
+	/** Get and remove the result for a completed job. */
+	popJobResult(executionId: string): JobFinishedProps | undefined {
+		const result = this.jobResults.get(executionId);
+		this.jobResults.delete(executionId);
+		return result;
+	}
 
 	async getPendingJobCounts() {
 		const { active, waiting } = await this.queue.getJobCounts();
@@ -334,6 +344,22 @@ export class ScalingService {
 							statusCode: 500,
 						});
 					}
+
+					/**
+					 * We track the result received via `job-finished` message,
+					 * because `removeOnComplete: true` prevents `job.finished()`
+					 * from returning a value that is no longer in Redis.
+					 */
+					this.jobResults.set(msg.executionId, {
+						success: msg.success,
+						error: msg.error,
+						status: msg.status,
+						lastNodeExecuted: msg.lastNodeExecuted,
+						usedDynamicCredentials: msg.usedDynamicCredentials,
+						metadata: msg.metadata,
+						startedAt: new Date(msg.startedAt),
+						stoppedAt: new Date(msg.stoppedAt),
+					});
 
 					this.logger.info(`Execution ${msg.executionId} (job ${jobId}) finished`, {
 						workerId: msg.workerId,

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -350,16 +350,18 @@ export class ScalingService {
 					 * because `removeOnComplete: true` prevents `job.finished()`
 					 * from returning a value that is no longer in Redis.
 					 */
-					this.jobResults.set(msg.executionId, {
-						success: msg.success,
-						error: msg.error,
-						status: msg.status,
-						lastNodeExecuted: msg.lastNodeExecuted,
-						usedDynamicCredentials: msg.usedDynamicCredentials,
-						metadata: msg.metadata,
-						startedAt: new Date(msg.startedAt),
-						stoppedAt: new Date(msg.stoppedAt),
-					});
+					if ('version' in msg && msg.version === 2) {
+						this.jobResults.set(msg.executionId, {
+							success: msg.success,
+							error: msg.error,
+							status: msg.status,
+							lastNodeExecuted: msg.lastNodeExecuted,
+							usedDynamicCredentials: msg.usedDynamicCredentials,
+							metadata: msg.metadata,
+							startedAt: new Date(msg.startedAt),
+							stoppedAt: new Date(msg.stoppedAt),
+						});
+					}
 
 					this.logger.info(`Execution ${msg.executionId} (job ${jobId}) finished`, {
 						workerId: msg.workerId,

--- a/packages/cli/src/scaling/scaling.types.ts
+++ b/packages/cli/src/scaling/scaling.types.ts
@@ -69,6 +69,7 @@ export type JobFinishedMessage = JobFinishedMessageV1 | JobFinishedMessageV2;
 /** @deprecated Old format without execution result details. */
 type JobFinishedMessageV1 = {
 	kind: 'job-finished';
+	version?: undefined;
 	executionId: string;
 	workerId: string;
 	success: boolean;

--- a/packages/cli/src/scaling/scaling.types.ts
+++ b/packages/cli/src/scaling/scaling.types.ts
@@ -64,8 +64,19 @@ export type JobFinishedProps = {
 };
 
 /** Message sent by worker to main to report a job has finished. */
-export type JobFinishedMessage = {
+export type JobFinishedMessage = JobFinishedMessageV1 | JobFinishedMessageV2;
+
+/** @deprecated Old format without execution result details. */
+type JobFinishedMessageV1 = {
 	kind: 'job-finished';
+	executionId: string;
+	workerId: string;
+	success: boolean;
+};
+
+type JobFinishedMessageV2 = {
+	kind: 'job-finished';
+	version: 2;
 	executionId: string;
 	workerId: string;
 } & JobFinishedProps;

--- a/packages/cli/src/scaling/scaling.types.ts
+++ b/packages/cli/src/scaling/scaling.types.ts
@@ -2,6 +2,7 @@ import type { RunningJobSummary } from '@n8n/api-types';
 import type Bull from 'bull';
 import type {
 	ExecutionError,
+	ExecutionStatus,
 	IExecuteResponsePromiseData,
 	IRun,
 	StructuredChunk,
@@ -24,7 +25,6 @@ export type JobData = {
 
 export type JobResult = {
 	success: boolean;
-	error?: ExecutionError;
 };
 
 export type JobStatus = Bull.JobStatus;
@@ -52,13 +52,23 @@ export type RespondToWebhookMessage = {
 	workerId: string;
 };
 
-/** Message sent by worker to main to report a job has finished successfully. */
+export type JobFinishedProps = {
+	success: boolean;
+	error?: ExecutionError;
+	status: ExecutionStatus;
+	lastNodeExecuted?: string;
+	usedDynamicCredentials?: boolean;
+	metadata?: Record<string, string>;
+	startedAt: Date;
+	stoppedAt: Date;
+};
+
+/** Message sent by worker to main to report a job has finished. */
 export type JobFinishedMessage = {
 	kind: 'job-finished';
 	executionId: string;
 	workerId: string;
-	success: boolean;
-};
+} & JobFinishedProps;
 
 export type SendChunkMessage = {
 	kind: 'send-chunk';

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -631,6 +631,10 @@ export async function executeWebhook(
 			responsePromise,
 		);
 
+		/**
+		 * We track the webhook response mode so that `WorkflowRunner` can decide whether it
+		 * needs to fetch full execution data from the DB when a job finishes in scaling mdoe.
+		 */
 		Container.get(ActiveExecutions).setResponseMode(executionId, responseMode);
 
 		if (shouldDeferOnReceivedResponse) {

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -631,6 +631,8 @@ export async function executeWebhook(
 			responsePromise,
 		);
 
+		Container.get(ActiveExecutions).setResponseMode(executionId, responseMode);
+
 		if (shouldDeferOnReceivedResponse) {
 			additionalKeys.$executionId = executionId;
 			additionalKeys.$execution = {

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -465,15 +465,9 @@ export class WorkflowRunner {
 
 				const jobResult = this.scalingService.popJobResult(executionId);
 
-				if (!jobResult) {
-					return reject(new Error(`Could not find job result for execution ${executionId}`));
-				}
-
-				const needsFullData = this.needsFullExecutionData(data.executionMode, executionId);
-
 				let runData: IRun;
 
-				if (needsFullData) {
+				if (!jobResult || this.needsFullExecutionData(data.executionMode, executionId)) {
 					const fullExecutionData = await this.executionRepository.findSingleExecution(
 						executionId,
 						{

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -536,6 +536,14 @@ export class WorkflowRunner {
 
 	/**
 	 * Whether main must retrieve full execution data from the DB on job completion.
+	 *
+	 * Full data is needed when:
+	 * - `integrated` mode: parent workflow needs child execution output data
+	 * - `lastNode` response mode: webhook response is built from the last node's output
+	 * - `workflow.postExecute` hook: external hooks receive full execution data
+	 *
+	 * In all other cases we can skip the DB fetch and use the lightweight
+	 * result summary sent by the worker via the job progress message.
 	 */
 	private needsFullExecutionData(executionMode: WorkflowExecuteMode, executionId: string): boolean {
 		if (!process.env.N8N_MINIMIZE_EXECUTION_DATA_FETCHING) return true;


### PR DESCRIPTION
## Summary

In scaling mode, a main instance can experience event loop blocking for seconds when sync running `flatted.parse` on execution data at job completion. `flatted.parse` is ~50x slower than `JSON.parse` and execution data can be hundreds of MB.

In the current flow:

1. Worker executes workflow, writes execution data to DB
2. Worker signals job completion via Bull
3. Main receives `job.finished()` notification
4. Main fetches full execution data (blocking parse)
5. Main runs `workflowExecuteAfter` hooks
6. Main resolves `postExecutePromise` for listeners

But, it is rare for main to actually need the entire execution data for post-execution handling. And a similar issue happens in the worker, where we fetch execution data immediatelyafter execution completion, despite already having the result in memory. Been this way ever since queue mode was introduced at #1340.

This PR adds a flag so the worker skips fetching and sends a handful of props via a Bull job progress message, so main can in the majority of cases read those props instead of fetching the full execution data. There is still a minority of cases when we can't skip fetching, to optimize in future.

## Related Linear tickets, Github issues, and Community forum posts

n/a


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
