### PR TITLE
fix(editor): Ensure personal project is used when a user is picked in workflow filter

### DIFF
--- a/packages/cli/src/workflows/__tests__/workflow.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow.service.test.ts
@@ -45,6 +45,7 @@ describe('WorkflowService', () => {
 				mock(), // nodeTypes
 				webhookServiceMock, // webhookService
 				mock(), // licenseState
+				mock(), // projectRepository
 			);
 		});
 

--- a/packages/cli/src/workflows/workflow-sharing.service.ts
+++ b/packages/cli/src/workflows/workflow-sharing.service.ts
@@ -111,14 +111,14 @@ export class WorkflowSharingService {
 		});
 	}
 
-	async getOwnedWorkflowsInPersonalProject(user: User): Promise<string[]> {
+	async getOwnedWorkflowsInPersonalProject(userId: string): Promise<string[]> {
 		const sharedWorkflows = await this.sharedWorkflowRepository.find({
 			select: ['workflowId'],
 			where: {
 				role: 'workflow:owner',
 				project: {
 					projectRelations: {
-						userId: user.id,
+						userId,
 						role: { slug: PROJECT_OWNER_ROLE_SLUG },
 					},
 				},

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -20,6 +20,7 @@ import {
 } from '@n8n/db';
 import { Container, Service } from '@n8n/di';
 import type { Scope } from '@n8n/permissions';
+import { hasGlobalScope } from '@n8n/permissions';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import type { EntityManager } from '@n8n/typeorm';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
@@ -122,6 +123,10 @@ export class WorkflowService {
 		}
 
 		if (isPersonalProject && personalProjectOwnerId) {
+			if (personalProjectOwnerId !== user.id && !hasGlobalScope(user, 'workflow:read')) {
+				return { workflows: [], count: 0 };
+			}
+
 			sharedWorkflowIds =
 				await this.workflowSharingService.getOwnedWorkflowsInPersonalProject(
 					personalProjectOwnerId,

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -106,17 +106,19 @@ export class WorkflowService {
 		let workflowsAndFolders: WorkflowFolderUnionFull[] = [];
 		let sharedWorkflowIds: string[] = [];
 		let isPersonalProject = false;
+		let personalProjectOwnerId: string | null = null;
 
 		if (options?.filter?.projectId) {
-			const projects = await this.projectService.getProjectRelationsForUser(user);
-			isPersonalProject = !!projects.find(
-				(p) => p.project.id === options.filter?.projectId && p.project.type === 'personal',
-			);
+			const project = await this.projectService.getProject(options.filter.projectId as string);
+			isPersonalProject = project.type === 'personal';
+			personalProjectOwnerId = project.creatorId;
 		}
 
-		if (isPersonalProject) {
+		if (isPersonalProject && personalProjectOwnerId) {
 			sharedWorkflowIds =
-				await this.workflowSharingService.getOwnedWorkflowsInPersonalProject(user);
+				await this.workflowSharingService.getOwnedWorkflowsInPersonalProject(
+					personalProjectOwnerId,
+				);
 		} else if (onlySharedWithMe) {
 			sharedWorkflowIds = await this.workflowSharingService.getSharedWithMeIds(user);
 		} else {

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -16,6 +16,7 @@ import {
 	SharedWorkflowRepository,
 	WorkflowRepository,
 	WorkflowPublishHistoryRepository,
+	ProjectRepository,
 } from '@n8n/db';
 import { Container, Service } from '@n8n/di';
 import type { Scope } from '@n8n/permissions';
@@ -91,6 +92,7 @@ export class WorkflowService {
 		private readonly nodeTypes: NodeTypes,
 		private readonly webhookService: WebhookService,
 		private readonly licenseState: LicenseState,
+		private readonly projectRepository: ProjectRepository,
 	) {}
 
 	async getMany(
@@ -109,7 +111,12 @@ export class WorkflowService {
 		let personalProjectOwnerId: string | null = null;
 
 		if (options?.filter?.projectId) {
-			const project = await this.projectService.getProject(options.filter.projectId as string);
+			const project = await this.projectRepository.findOneBy({
+				id: options.filter.projectId as string,
+			});
+			if (!project) {
+				return { workflows: [], count: 0 };
+			}
 			isPersonalProject = project.type === 'personal';
 			personalProjectOwnerId = project.creatorId;
 		}

--- a/packages/cli/test/integration/workflows/workflow.service.test.ts
+++ b/packages/cli/test/integration/workflows/workflow.service.test.ts
@@ -5,6 +5,7 @@ import {
 	createActiveWorkflow,
 	createTeamProject,
 	linkUserToProject,
+	createWorkflow,
 } from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
 import {
@@ -12,6 +13,7 @@ import {
 	type WorkflowEntity,
 	WorkflowPublishHistoryRepository,
 	WorkflowRepository,
+	ProjectRepository,
 } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
@@ -26,6 +28,9 @@ import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
 import { WorkflowValidationService } from '@/workflows/workflow-validation.service';
 import { WorkflowService } from '@/workflows/workflow.service';
+import { WorkflowSharingService } from '@/workflows/workflow-sharing.service';
+import { OwnershipService } from '@/services/ownership.service';
+import { ProjectService } from '@/services/project.service.ee';
 
 import { createCustomRoleWithScopeSlugs, cleanupRolesAndScopes } from '../shared/db/roles';
 import { createOwner, createMember } from '../shared/db/users';
@@ -57,14 +62,14 @@ beforeAll(async () => {
 		workflowRepository,
 		mock(),
 		mock(),
-		mock(),
+		Container.get(OwnershipService), // ownershipService
 		mock(),
 		workflowHistoryService,
 		mock(),
 		activeWorkflowManager,
 		mock(),
-		mock(),
-		mock(),
+		Container.get(WorkflowSharingService), // workflowSharingService
+		Container.get(ProjectService), // projectService
 		mock(),
 		mock(),
 		globalConfig,
@@ -75,7 +80,7 @@ beforeAll(async () => {
 		nodeTypes,
 		webhookServiceMock,
 		mock(), // licenseState
-		mock(), // projectRepository
+		Container.get(ProjectRepository), // projectRepository
 	);
 });
 
@@ -475,5 +480,136 @@ describe('deactivateWorkflow()', () => {
 		const workflowAfter = await workflowRepository.findOne({ where: { id: workflow.id } });
 		expect(workflowAfter?.active).toBe(true);
 		expect(workflowAfter?.activeVersionId).toBe(workflow.activeVersionId);
+	});
+});
+
+describe('getMany()', () => {
+	describe('filtering by personal project', () => {
+		test('should return only workflows owned by user in their personal project', async () => {
+			const owner = await createOwner();
+			const member = await createMember();
+
+			const projectRepository = Container.get(ProjectRepository);
+			const memberPersonalProject = await projectRepository.getPersonalProjectForUserOrFail(
+				member.id,
+			);
+
+			const memberOwnedWorkflow = await createWorkflow({ name: 'Member Owned Workflow' }, member);
+			const sharedWorkflow = await createWorkflow({ name: 'Shared Workflow' }, owner);
+			await Container.get(SharedWorkflowRepository).save(
+				Container.get(SharedWorkflowRepository).create({
+					projectId: memberPersonalProject.id,
+					workflowId: sharedWorkflow.id,
+					role: 'workflow:editor',
+				}),
+			);
+
+			const result = await workflowService.getMany(
+				owner,
+				{ filter: { projectId: memberPersonalProject.id } },
+				false,
+				false,
+				false,
+			);
+
+			expect(result.workflows).toHaveLength(1);
+			expect(result.workflows[0].id).toBe(memberOwnedWorkflow.id);
+			expect(result.workflows[0].name).toBe('Member Owned Workflow');
+			expect(result.count).toBe(1);
+		});
+
+		test('should return empty when filtering by personal project of user with no owned workflows', async () => {
+			const owner = await createOwner();
+			const member = await createMember();
+
+			const projectRepository = Container.get(ProjectRepository);
+			const memberPersonalProject = await projectRepository.getPersonalProjectForUserOrFail(
+				member.id,
+			);
+
+			const sharedWorkflow = await createWorkflow({ name: 'Shared Workflow' }, owner);
+			await Container.get(SharedWorkflowRepository).save(
+				Container.get(SharedWorkflowRepository).create({
+					projectId: memberPersonalProject.id,
+					workflowId: sharedWorkflow.id,
+					role: 'workflow:editor',
+				}),
+			);
+
+			const result = await workflowService.getMany(
+				owner,
+				{ filter: { projectId: memberPersonalProject.id } },
+				false,
+				false,
+				false,
+			);
+
+			expect(result.workflows).toHaveLength(0);
+			expect(result.count).toBe(0);
+		});
+
+		test('should return empty when filtering by non-existent project', async () => {
+			const owner = await createOwner();
+
+			const result = await workflowService.getMany(
+				owner,
+				{ filter: { projectId: 'non-existent-project-id' } },
+				false,
+				false,
+				false,
+			);
+
+			expect(result.workflows).toHaveLength(0);
+			expect(result.count).toBe(0);
+		});
+
+		test('should return user owned workflows when user queries their own personal project', async () => {
+			const member = await createMember();
+
+			const projectRepository = Container.get(ProjectRepository);
+			const memberPersonalProject = await projectRepository.getPersonalProjectForUserOrFail(
+				member.id,
+			);
+
+			const workflow1 = await createWorkflow({ name: 'Workflow 1' }, member);
+			const workflow2 = await createWorkflow({ name: 'Workflow 2' }, member);
+
+			const result = await workflowService.getMany(
+				member,
+				{ filter: { projectId: memberPersonalProject.id } },
+				false,
+				false,
+				false,
+			);
+
+			expect(result.workflows).toHaveLength(2);
+			expect(result.count).toBe(2);
+			const workflowIds = result.workflows.map((w) => w.id).sort();
+			expect(workflowIds).toEqual([workflow1.id, workflow2.id].sort());
+		});
+
+		test('should handle team project filtering correctly', async () => {
+			const owner = await createOwner();
+			const member = await createMember();
+
+			const teamProject = await createTeamProject('Team Project', owner);
+			await linkUserToProject(member, teamProject, 'project:editor');
+
+			const teamWorkflow1 = await createWorkflow({ name: 'Team Workflow 1' }, teamProject);
+			const teamWorkflow2 = await createWorkflow({ name: 'Team Workflow 2' }, teamProject);
+
+			const result = await workflowService.getMany(
+				member,
+				{ filter: { projectId: teamProject.id } },
+				false,
+				false,
+				false,
+			);
+
+			expect(result.workflows).toHaveLength(2);
+			expect(result.count).toBe(2);
+			const workflowIds = result.workflows.map((w) => w.id).sort();
+			expect(workflowIds).toEqual([teamWorkflow1.id, teamWorkflow2.id].sort());
+		});
 	});
 });

--- a/packages/cli/test/integration/workflows/workflow.service.test.ts
+++ b/packages/cli/test/integration/workflows/workflow.service.test.ts
@@ -485,7 +485,7 @@ describe('deactivateWorkflow()', () => {
 
 describe('getMany()', () => {
 	describe('filtering by personal project', () => {
-		test('[SECURITY] should return empty when regular user queries another users personal project', async () => {
+		test('should return empty when regular user queries another users personal project', async () => {
 			const member1 = await createMember();
 			const member2 = await createMember();
 
@@ -512,7 +512,7 @@ describe('getMany()', () => {
 			expect(result.count).toBe(0);
 		});
 
-		test('[SECURITY] should allow admin with global workflow:read to query another users personal project', async () => {
+		test('should allow admin with global workflow:read to query another users personal project', async () => {
 			const owner = await createOwner(); // Owner has global workflow:read scope
 			const member = await createMember();
 

--- a/packages/cli/test/integration/workflows/workflow.service.test.ts
+++ b/packages/cli/test/integration/workflows/workflow.service.test.ts
@@ -75,6 +75,7 @@ beforeAll(async () => {
 		nodeTypes,
 		webhookServiceMock,
 		mock(), // licenseState
+		mock(), // projectRepository
 	);
 });
 


### PR DESCRIPTION

When an admin filtered by another user's personal project, it checked if the user's project was in the admin's project relations → false → returned all shared workflows
With the change, It queries the project directly, sees it's a personal project, gets user's creatorId, and returns only workflows owned by the user in his personal project.

To test:
- Create multiple users 
- Share workflows with them
- Filter for workflows owned by them from the Overview tab
- It should show none if they have not created any workflows on their own. (Shared workflows should not be shown)
- 
## Summary
<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/ADO-4704/workflow-list-owner-filter-includes-results-where-selected-owner-is

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
