### PR TITLE
chore(core): Add auth handler registry to reverse control of the ldap call

### DIFF
--- a/packages/@n8n/decorators/src/auth-handler/__tests__/auth-handler-metadata.test.ts
+++ b/packages/@n8n/decorators/src/auth-handler/__tests__/auth-handler-metadata.test.ts
@@ -12,8 +12,9 @@ describe('AuthHandlerEntryMetadata', () => {
 	});
 
 	it('should register handler classes', () => {
-		class TestHandler implements IPasswordAuthHandler {
+		class TestHandler implements IPasswordAuthHandler<object> {
 			metadata = { name: 'test', type: 'password' as const };
+			readonly userClass = Object;
 			async handleLogin() {
 				return undefined;
 			}
@@ -24,14 +25,16 @@ describe('AuthHandlerEntryMetadata', () => {
 	});
 
 	it('should return all registered entries', () => {
-		class Handler1 implements IPasswordAuthHandler {
+		class Handler1 implements IPasswordAuthHandler<object> {
 			metadata = { name: 'test1', type: 'password' as const };
+			readonly userClass = Object;
 			async handleLogin() {
 				return undefined;
 			}
 		}
-		class Handler2 implements IPasswordAuthHandler {
+		class Handler2 implements IPasswordAuthHandler<object> {
 			metadata = { name: 'test2', type: 'password' as const };
+			readonly userClass = Object;
 			async handleLogin() {
 				return undefined;
 			}
@@ -45,14 +48,16 @@ describe('AuthHandlerEntryMetadata', () => {
 	});
 
 	it('should return all registered classes', () => {
-		class Handler1 implements IPasswordAuthHandler {
+		class Handler1 implements IPasswordAuthHandler<object> {
 			metadata = { name: 'test1', type: 'password' as const };
+			readonly userClass = Object;
 			async handleLogin() {
 				return undefined;
 			}
 		}
-		class Handler2 implements IPasswordAuthHandler {
+		class Handler2 implements IPasswordAuthHandler<object> {
 			metadata = { name: 'test2', type: 'password' as const };
+			readonly userClass = Object;
 			async handleLogin() {
 				return undefined;
 			}
@@ -73,8 +78,9 @@ describe('@AuthHandler decorator', () => {
 
 	it('should register handler in metadata', () => {
 		@AuthHandler()
-		class TestAuthHandler implements IPasswordAuthHandler {
+		class TestAuthHandler implements IPasswordAuthHandler<object> {
 			metadata = { name: 'test', type: 'password' as const };
+			readonly userClass = Object;
 			async handleLogin() {
 				return undefined;
 			}
@@ -88,8 +94,9 @@ describe('@AuthHandler decorator', () => {
 
 	it('should enable dependency injection', () => {
 		@AuthHandler()
-		class TestAuthHandler implements IPasswordAuthHandler {
+		class TestAuthHandler implements IPasswordAuthHandler<object> {
 			metadata = { name: 'test', type: 'password' as const };
+			readonly userClass = Object;
 			async handleLogin() {
 				return undefined;
 			}
@@ -110,9 +117,10 @@ describe('@AuthHandler decorator', () => {
 		}
 
 		@AuthHandler()
-		class TestAuthHandler implements IPasswordAuthHandler {
+		class TestAuthHandler implements IPasswordAuthHandler<object> {
 			metadata = { name: 'test', type: 'password' as const };
 			constructor(private logger: Logger) {}
+			readonly userClass = Object;
 
 			async handleLogin() {
 				this.logger.log('login');

--- a/packages/@n8n/decorators/src/auth-handler/__tests__/auth-handler-metadata.test.ts
+++ b/packages/@n8n/decorators/src/auth-handler/__tests__/auth-handler-metadata.test.ts
@@ -1,0 +1,126 @@
+/* eslint-disable @typescript-eslint/require-await */
+import { Container, Service } from '@n8n/di';
+
+import type { AuthHandlerClass, IPasswordAuthHandler } from '../auth-handler';
+import { AuthHandler, AuthHandlerEntryMetadata } from '../auth-handler-metadata';
+
+describe('AuthHandlerEntryMetadata', () => {
+	let metadata: AuthHandlerEntryMetadata;
+
+	beforeEach(() => {
+		metadata = new AuthHandlerEntryMetadata();
+	});
+
+	it('should register handler classes', () => {
+		class TestHandler implements IPasswordAuthHandler {
+			metadata = { name: 'test', type: 'password' as const };
+			async handleLogin() {
+				return undefined;
+			}
+		}
+		metadata.register({ class: TestHandler as AuthHandlerClass });
+
+		expect(metadata.getClasses()).toContain(TestHandler);
+	});
+
+	it('should return all registered entries', () => {
+		class Handler1 implements IPasswordAuthHandler {
+			metadata = { name: 'test1', type: 'password' as const };
+			async handleLogin() {
+				return undefined;
+			}
+		}
+		class Handler2 implements IPasswordAuthHandler {
+			metadata = { name: 'test2', type: 'password' as const };
+			async handleLogin() {
+				return undefined;
+			}
+		}
+
+		metadata.register({ class: Handler1 as AuthHandlerClass });
+		metadata.register({ class: Handler2 as AuthHandlerClass });
+
+		const entries = metadata.getEntries();
+		expect(entries).toHaveLength(2);
+	});
+
+	it('should return all registered classes', () => {
+		class Handler1 implements IPasswordAuthHandler {
+			metadata = { name: 'test1', type: 'password' as const };
+			async handleLogin() {
+				return undefined;
+			}
+		}
+		class Handler2 implements IPasswordAuthHandler {
+			metadata = { name: 'test2', type: 'password' as const };
+			async handleLogin() {
+				return undefined;
+			}
+		}
+
+		metadata.register({ class: Handler1 as AuthHandlerClass });
+		metadata.register({ class: Handler2 as AuthHandlerClass });
+
+		const classes = metadata.getClasses();
+		expect(classes).toEqual([Handler1, Handler2]);
+	});
+});
+
+describe('@AuthHandler decorator', () => {
+	beforeEach(() => {
+		Container.reset();
+	});
+
+	it('should register handler in metadata', () => {
+		@AuthHandler()
+		class TestAuthHandler implements IPasswordAuthHandler {
+			metadata = { name: 'test', type: 'password' as const };
+			async handleLogin() {
+				return undefined;
+			}
+		}
+
+		const metadata = Container.get(AuthHandlerEntryMetadata);
+		const registeredClasses = metadata.getClasses();
+
+		expect(registeredClasses).toContain(TestAuthHandler);
+	});
+
+	it('should enable dependency injection', () => {
+		@AuthHandler()
+		class TestAuthHandler implements IPasswordAuthHandler {
+			metadata = { name: 'test', type: 'password' as const };
+			async handleLogin() {
+				return undefined;
+			}
+		}
+
+		const instance = Container.get(TestAuthHandler);
+		expect(instance).toBeInstanceOf(TestAuthHandler);
+		expect(instance.metadata.name).toBe('test');
+		expect(instance.metadata.type).toBe('password');
+	});
+
+	it('should support handlers with dependencies', () => {
+		@Service()
+		class Logger {
+			log(message: string) {
+				return message;
+			}
+		}
+
+		@AuthHandler()
+		class TestAuthHandler implements IPasswordAuthHandler {
+			metadata = { name: 'test', type: 'password' as const };
+			constructor(private logger: Logger) {}
+
+			async handleLogin() {
+				this.logger.log('login');
+				return undefined;
+			}
+		}
+
+		const instance = Container.get(TestAuthHandler);
+		expect(instance).toBeInstanceOf(TestAuthHandler);
+	});
+});

--- a/packages/@n8n/decorators/src/auth-handler/auth-handler-metadata.ts
+++ b/packages/@n8n/decorators/src/auth-handler/auth-handler-metadata.ts
@@ -1,0 +1,55 @@
+import { Container, Service } from '@n8n/di';
+
+import { AuthHandlerClass } from './auth-handler';
+
+type AuthHandlerEntry = {
+	class: AuthHandlerClass;
+};
+
+/**
+ * Registry service for auth handler type discovery and instantiation.
+ * Handler classes decorated with @AuthHandler() are automatically registered.
+ */
+@Service()
+export class AuthHandlerEntryMetadata {
+	private readonly authHandlerEntries: Set<AuthHandlerEntry> = new Set();
+
+	/** Registers an auth handler class. Called automatically by @AuthHandler() decorator. */
+	register(authHandlerEntry: AuthHandlerEntry) {
+		this.authHandlerEntries.add(authHandlerEntry);
+	}
+
+	/** Returns all registered handler entries as [index, entry] tuples. */
+	getEntries() {
+		return [...this.authHandlerEntries.entries()];
+	}
+
+	/** Returns all registered handler classes. */
+	getClasses() {
+		return [...this.authHandlerEntries.values()].map((entry) => entry.class);
+	}
+}
+
+/**
+ * Decorator to mark a class as an authentication handler.
+ * Automatically registers the handler for discovery and enables dependency injection.
+ *
+ * @example
+ * @AuthHandler()
+ * class LdapAuthHandler implements IPasswordAuthHandler {
+ *   metadata = { name: 'ldap', type: 'password' };
+ *   async handleLogin(loginId: string, password: string) { ... }
+ * }
+ */
+export const AuthHandler =
+	<T extends AuthHandlerClass>() =>
+	(target: T) => {
+		// Register handler class for discovery by registry
+		Container.get(AuthHandlerEntryMetadata).register({
+			class: target,
+		});
+
+		// Enable dependency injection for the handler class
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+		return Service()(target);
+	};

--- a/packages/@n8n/decorators/src/auth-handler/auth-handler.ts
+++ b/packages/@n8n/decorators/src/auth-handler/auth-handler.ts
@@ -1,0 +1,64 @@
+import type { Constructable } from '@n8n/di';
+
+/**
+ * Authentication type discriminator.
+ * Extend this union as new authentication methods are added (e.g., 'password' | 'oauth' | 'saml').
+ */
+export type AuthType = 'password';
+
+/**
+ * Metadata describing an auth handler.
+ */
+export interface AuthHandlerMetadata {
+	/** Unique name of the auth handler (e.g., 'ldap', 'saml') */
+	name: string;
+	/** Type of authentication this handler provides */
+	type: AuthType;
+}
+
+/**
+ * Base interface for all authentication handlers.
+ * Contains common fields shared across all auth types.
+ */
+interface IAuthHandlerBase {
+	/**
+	 * Metadata identifying this auth handler.
+	 */
+	readonly metadata: AuthHandlerMetadata;
+
+	/**
+	 * Optional lifecycle hook called during handler initialization.
+	 * Use this to set up connections, load config, etc.
+	 */
+	init?(): Promise<void>;
+}
+
+/**
+ * Interface for password-based authentication handlers.
+ * Implementations can provide custom authentication logic for different auth methods (LDAP, SAML, etc.).
+ *
+ * @template TUser - The user type returned by the auth handler (typically from @n8n/db)
+ */
+export interface IPasswordAuthHandler<TUser = unknown> extends IAuthHandlerBase {
+	readonly metadata: AuthHandlerMetadata & { type: 'password' };
+
+	/**
+	 * Handles login attempt with provided credentials.
+	 *
+	 * @param loginId - User identifier (email, username, LDAP ID, etc.)
+	 * @param password - User password
+	 * @returns User object if authentication succeeds, undefined otherwise
+	 */
+	handleLogin(loginId: string, password: string): Promise<TUser | undefined>;
+}
+
+/**
+ * Union type of all authentication handler interfaces.
+ * TypeScript uses the `metadata.type` field to discriminate between handler types.
+ */
+export type IAuthHandler<TUser = unknown> = IPasswordAuthHandler<TUser>;
+
+/**
+ * Type helper for auth handler class constructors.
+ */
+export type AuthHandlerClass = Constructable<IAuthHandler>;

--- a/packages/@n8n/decorators/src/auth-handler/auth-handler.ts
+++ b/packages/@n8n/decorators/src/auth-handler/auth-handler.ts
@@ -20,11 +20,14 @@ export interface AuthHandlerMetadata {
  * Base interface for all authentication handlers.
  * Contains common fields shared across all auth types.
  */
-interface IAuthHandlerBase {
+interface IAuthHandlerBase<TUser> {
 	/**
 	 * Metadata identifying this auth handler.
 	 */
 	readonly metadata: AuthHandlerMetadata;
+
+	/** The user type returned by the auth handler */
+	readonly userClass: Constructable<TUser>;
 
 	/**
 	 * Optional lifecycle hook called during handler initialization.
@@ -39,7 +42,7 @@ interface IAuthHandlerBase {
  *
  * @template TUser - The user type returned by the auth handler (typically from @n8n/db)
  */
-export interface IPasswordAuthHandler<TUser = unknown> extends IAuthHandlerBase {
+export interface IPasswordAuthHandler<TUser> extends IAuthHandlerBase<TUser> {
 	readonly metadata: AuthHandlerMetadata & { type: 'password' };
 
 	/**

--- a/packages/@n8n/decorators/src/auth-handler/index.ts
+++ b/packages/@n8n/decorators/src/auth-handler/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Authentication Handler Module
+ *
+ * Provides interfaces and infrastructure for authentication handlers.
+ * Handlers can implement custom authentication logic for different auth methods (LDAP, SAML, OAuth, etc.).
+ *
+ * The system uses a discriminated union pattern based on the `type` field in metadata:
+ * - 'password': Username/password authentication (IPasswordAuthHandler)
+ * - Future: 'oauth', 'saml', etc.
+ */
+
+export { AuthHandlerEntryMetadata, AuthHandler } from './auth-handler-metadata';
+export type * from './auth-handler';

--- a/packages/@n8n/decorators/src/index.ts
+++ b/packages/@n8n/decorators/src/index.ts
@@ -3,6 +3,7 @@ export * from './command';
 export { Debounce } from './debounce';
 export * from './execution-lifecycle';
 export { Memoized } from './memoized';
+export * from './auth-handler';
 export * from './context-establishment';
 export * from './credential-resolver';
 export * from './module';

--- a/packages/cli/src/auth/__tests__/auth-handler.registry.test.ts
+++ b/packages/cli/src/auth/__tests__/auth-handler.registry.test.ts
@@ -36,7 +36,7 @@ describe('AuthHandlerRegistry', () => {
 			await registry.init();
 
 			expect(registry.has('ldap')).toBe(true);
-			expect(registry.get('ldap')).toBe(mockHandler);
+			expect(registry.get('ldap', 'password')).toBe(mockHandler);
 		});
 
 		it('should call handler init() if present', async () => {
@@ -110,45 +110,19 @@ describe('AuthHandlerRegistry', () => {
 			await registry.init();
 
 			expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('already registered'));
-			expect(registry.get('ldap')).toBe(handler1);
+			expect(registry.get('ldap', 'password')).toBe(handler1);
 		});
 	});
 
 	describe('get', () => {
 		it('should return undefined for non-existent handler', () => {
-			expect(registry.get('nonexistent')).toBeUndefined();
+			expect(registry.get('nonexistent', 'password')).toBeUndefined();
 		});
 	});
 
 	describe('has', () => {
 		it('should return false for non-existent handler', () => {
 			expect(registry.has('nonexistent')).toBe(false);
-		});
-	});
-
-	describe('getAllHandlers', () => {
-		it('should return all registered handlers', async () => {
-			const handler1 = mock<IPasswordAuthHandler<User>>({
-				metadata: { name: 'ldap', type: 'password' },
-			});
-			const handler2 = mock<IPasswordAuthHandler<User>>({
-				metadata: { name: 'saml', type: 'password' },
-			});
-
-			class MockHandlerClass1 {}
-			class MockHandlerClass2 {}
-
-			jest
-				.spyOn(mockMetadata, 'getClasses')
-				.mockReturnValue([MockHandlerClass1 as any, MockHandlerClass2 as any]);
-			jest.spyOn(Container, 'get').mockReturnValueOnce(handler1).mockReturnValueOnce(handler2);
-
-			await registry.init();
-
-			const allHandlers = registry.getAllHandlers();
-			expect(allHandlers).toHaveLength(2);
-			expect(allHandlers).toContain(handler1);
-			expect(allHandlers).toContain(handler2);
 		});
 	});
 });

--- a/packages/cli/src/auth/__tests__/auth-handler.registry.test.ts
+++ b/packages/cli/src/auth/__tests__/auth-handler.registry.test.ts
@@ -1,51 +1,154 @@
+import type { Logger } from '@n8n/backend-common';
 import type { User } from '@n8n/db';
+import type { IPasswordAuthHandler, AuthHandlerEntryMetadata } from '@n8n/decorators';
+import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
 
-import type { AuthHandler } from '@/auth/auth-handler.registry';
 import { AuthHandlerRegistry } from '@/auth/auth-handler.registry';
 
 describe('AuthHandlerRegistry', () => {
 	let registry: AuthHandlerRegistry;
+	let mockLogger: Logger;
+	let mockMetadata: AuthHandlerEntryMetadata;
 
 	beforeEach(() => {
-		registry = new AuthHandlerRegistry();
+		mockLogger = mock<Logger>();
+		mockMetadata = mock<AuthHandlerEntryMetadata>();
+		registry = new AuthHandlerRegistry(mockMetadata, mockLogger);
 	});
 
-	it('should register and retrieve an auth handler', () => {
-		const mockHandler = mock<AuthHandler>();
+	describe('init', () => {
+		it('should discover and register auth handlers', async () => {
+			const mockHandler = mock<IPasswordAuthHandler<User>>({
+				metadata: { name: 'ldap', type: 'password' },
+			});
 
-		registry.register('ldap', mockHandler);
+			class MockHandlerClass {
+				metadata = { name: 'ldap', type: 'password' as const };
+				async handleLogin() {
+					return await mockHandler.handleLogin('', '');
+				}
+			}
 
-		expect(registry.has('ldap')).toBe(true);
-		expect(registry.get('ldap')).toBe(mockHandler);
+			jest.spyOn(mockMetadata, 'getClasses').mockReturnValue([MockHandlerClass as any]);
+			jest.spyOn(Container, 'get').mockReturnValue(mockHandler);
+
+			await registry.init();
+
+			expect(registry.has('ldap')).toBe(true);
+			expect(registry.get('ldap')).toBe(mockHandler);
+		});
+
+		it('should call handler init() if present', async () => {
+			const mockHandler = mock<IPasswordAuthHandler<User>>({
+				metadata: { name: 'ldap', type: 'password' },
+				init: jest.fn().mockResolvedValue(undefined),
+			});
+
+			class MockHandlerClass {}
+
+			jest.spyOn(mockMetadata, 'getClasses').mockReturnValue([MockHandlerClass as any]);
+			jest.spyOn(Container, 'get').mockReturnValue(mockHandler);
+
+			await registry.init();
+
+			expect(mockHandler.init).toHaveBeenCalled();
+		});
+
+		it('should skip handler on instantiation error', async () => {
+			class MockHandlerClass {}
+
+			jest.spyOn(mockMetadata, 'getClasses').mockReturnValue([MockHandlerClass as any]);
+			jest.spyOn(Container, 'get').mockImplementation(() => {
+				throw new Error('Instantiation failed');
+			});
+
+			await registry.init();
+
+			expect(mockLogger.error).toHaveBeenCalledWith(
+				expect.stringContaining('Failed to instantiate'),
+				expect.any(Object),
+			);
+		});
+
+		it('should skip handler on init error', async () => {
+			const mockHandler = mock<IPasswordAuthHandler<User>>({
+				metadata: { name: 'ldap', type: 'password' },
+				init: jest.fn().mockRejectedValue(new Error('Init failed')),
+			});
+
+			class MockHandlerClass {}
+
+			jest.spyOn(mockMetadata, 'getClasses').mockReturnValue([MockHandlerClass as any]);
+			jest.spyOn(Container, 'get').mockReturnValue(mockHandler);
+
+			await registry.init();
+
+			expect(mockLogger.error).toHaveBeenCalledWith(
+				expect.stringContaining('Failed to initialize'),
+				expect.any(Object),
+			);
+			expect(registry.has('ldap')).toBe(false);
+		});
+
+		it('should warn on duplicate handler names', async () => {
+			const handler1 = mock<IPasswordAuthHandler<User>>({
+				metadata: { name: 'ldap', type: 'password' },
+			});
+			const handler2 = mock<IPasswordAuthHandler<User>>({
+				metadata: { name: 'ldap', type: 'password' },
+			});
+
+			class MockHandlerClass1 {}
+			class MockHandlerClass2 {}
+
+			jest
+				.spyOn(mockMetadata, 'getClasses')
+				.mockReturnValue([MockHandlerClass1 as any, MockHandlerClass2 as any]);
+			jest.spyOn(Container, 'get').mockReturnValueOnce(handler1).mockReturnValueOnce(handler2);
+
+			await registry.init();
+
+			expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('already registered'));
+			expect(registry.get('ldap')).toBe(handler1);
+		});
 	});
 
-	it('should return undefined for non-existent handler', () => {
-		expect(registry.has('nonexistent')).toBe(false);
-		expect(registry.get('nonexistent')).toBeUndefined();
+	describe('get', () => {
+		it('should return undefined for non-existent handler', () => {
+			expect(registry.get('nonexistent')).toBeUndefined();
+		});
 	});
 
-	it('should handle multiple registered handlers', () => {
-		const ldapHandler = mock<AuthHandler>();
-		const samlHandler = mock<AuthHandler>();
-
-		registry.register('ldap', ldapHandler);
-		registry.register('saml', samlHandler);
-
-		expect(registry.get('ldap')).toBe(ldapHandler);
-		expect(registry.get('saml')).toBe(samlHandler);
+	describe('has', () => {
+		it('should return false for non-existent handler', () => {
+			expect(registry.has('nonexistent')).toBe(false);
+		});
 	});
 
-	it('should allow handler to be called', async () => {
-		const mockUser = mock<User>({ id: '123' });
-		const mockHandler: AuthHandler = {
-			handleLogin: jest.fn().mockResolvedValue(mockUser),
-		};
+	describe('getAllHandlers', () => {
+		it('should return all registered handlers', async () => {
+			const handler1 = mock<IPasswordAuthHandler<User>>({
+				metadata: { name: 'ldap', type: 'password' },
+			});
+			const handler2 = mock<IPasswordAuthHandler<User>>({
+				metadata: { name: 'saml', type: 'password' },
+			});
 
-		registry.register('ldap', mockHandler);
-		const result = await registry.get('ldap')!.handleLogin('user', 'pass');
+			class MockHandlerClass1 {}
+			class MockHandlerClass2 {}
 
-		expect(result).toBe(mockUser);
-		expect(mockHandler.handleLogin).toHaveBeenCalledWith('user', 'pass');
+			jest
+				.spyOn(mockMetadata, 'getClasses')
+				.mockReturnValue([MockHandlerClass1 as any, MockHandlerClass2 as any]);
+			jest.spyOn(Container, 'get').mockReturnValueOnce(handler1).mockReturnValueOnce(handler2);
+
+			await registry.init();
+
+			const allHandlers = registry.getAllHandlers();
+			expect(allHandlers).toHaveLength(2);
+			expect(allHandlers).toContain(handler1);
+			expect(allHandlers).toContain(handler2);
+		});
 	});
 });

--- a/packages/cli/src/auth/__tests__/auth-handler.registry.test.ts
+++ b/packages/cli/src/auth/__tests__/auth-handler.registry.test.ts
@@ -1,5 +1,5 @@
 import type { Logger } from '@n8n/backend-common';
-import type { User } from '@n8n/db';
+import { User } from '@n8n/db';
 import type { IPasswordAuthHandler, AuthHandlerEntryMetadata } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
@@ -21,10 +21,12 @@ describe('AuthHandlerRegistry', () => {
 		it('should discover and register auth handlers', async () => {
 			const mockHandler = mock<IPasswordAuthHandler<User>>({
 				metadata: { name: 'ldap', type: 'password' },
+				userClass: User,
 			});
 
 			class MockHandlerClass {
 				metadata = { name: 'ldap', type: 'password' as const };
+				readonly userClass = User;
 				async handleLogin() {
 					return await mockHandler.handleLogin('', '');
 				}
@@ -42,6 +44,7 @@ describe('AuthHandlerRegistry', () => {
 		it('should call handler init() if present', async () => {
 			const mockHandler = mock<IPasswordAuthHandler<User>>({
 				metadata: { name: 'ldap', type: 'password' },
+				userClass: User,
 				init: jest.fn().mockResolvedValue(undefined),
 			});
 
@@ -74,6 +77,7 @@ describe('AuthHandlerRegistry', () => {
 		it('should skip handler on init error', async () => {
 			const mockHandler = mock<IPasswordAuthHandler<User>>({
 				metadata: { name: 'ldap', type: 'password' },
+				userClass: User,
 				init: jest.fn().mockRejectedValue(new Error('Init failed')),
 			});
 
@@ -94,9 +98,11 @@ describe('AuthHandlerRegistry', () => {
 		it('should warn on duplicate handler names', async () => {
 			const handler1 = mock<IPasswordAuthHandler<User>>({
 				metadata: { name: 'ldap', type: 'password' },
+				userClass: User,
 			});
 			const handler2 = mock<IPasswordAuthHandler<User>>({
 				metadata: { name: 'ldap', type: 'password' },
+				userClass: User,
 			});
 
 			class MockHandlerClass1 {}

--- a/packages/cli/src/auth/__tests__/auth-handler.registry.test.ts
+++ b/packages/cli/src/auth/__tests__/auth-handler.registry.test.ts
@@ -1,0 +1,51 @@
+import type { User } from '@n8n/db';
+import { mock } from 'jest-mock-extended';
+
+import type { AuthHandler } from '@/auth/auth-handler.registry';
+import { AuthHandlerRegistry } from '@/auth/auth-handler.registry';
+
+describe('AuthHandlerRegistry', () => {
+	let registry: AuthHandlerRegistry;
+
+	beforeEach(() => {
+		registry = new AuthHandlerRegistry();
+	});
+
+	it('should register and retrieve an auth handler', () => {
+		const mockHandler = mock<AuthHandler>();
+
+		registry.register('ldap', mockHandler);
+
+		expect(registry.has('ldap')).toBe(true);
+		expect(registry.get('ldap')).toBe(mockHandler);
+	});
+
+	it('should return undefined for non-existent handler', () => {
+		expect(registry.has('nonexistent')).toBe(false);
+		expect(registry.get('nonexistent')).toBeUndefined();
+	});
+
+	it('should handle multiple registered handlers', () => {
+		const ldapHandler = mock<AuthHandler>();
+		const samlHandler = mock<AuthHandler>();
+
+		registry.register('ldap', ldapHandler);
+		registry.register('saml', samlHandler);
+
+		expect(registry.get('ldap')).toBe(ldapHandler);
+		expect(registry.get('saml')).toBe(samlHandler);
+	});
+
+	it('should allow handler to be called', async () => {
+		const mockUser = mock<User>({ id: '123' });
+		const mockHandler: AuthHandler = {
+			handleLogin: jest.fn().mockResolvedValue(mockUser),
+		};
+
+		registry.register('ldap', mockHandler);
+		const result = await registry.get('ldap')!.handleLogin('user', 'pass');
+
+		expect(result).toBe(mockUser);
+		expect(mockHandler.handleLogin).toHaveBeenCalledWith('user', 'pass');
+	});
+});

--- a/packages/cli/src/auth/auth-handler.registry.ts
+++ b/packages/cli/src/auth/auth-handler.registry.ts
@@ -1,0 +1,27 @@
+import type { User } from '@n8n/db';
+import { Service } from '@n8n/di';
+
+export interface AuthHandler {
+	handleLogin(loginId: string, password: string): Promise<User | undefined>;
+}
+
+/**
+ * Registry for authentication handlers. Allows modules to register
+ * themselves dynamically without creating direct dependencies.
+ */
+@Service()
+export class AuthHandlerRegistry {
+	private handlers = new Map<string, AuthHandler>();
+
+	register(authMethod: string, handler: AuthHandler): void {
+		this.handlers.set(authMethod, handler);
+	}
+
+	get(authMethod: string): AuthHandler | undefined {
+		return this.handlers.get(authMethod);
+	}
+
+	has(authMethod: string): boolean {
+		return this.handlers.has(authMethod);
+	}
+}

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -249,6 +249,10 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 
 		await this.moduleRegistry.initModules(this.instanceSettings.instanceType);
 
+		// Initialize auth handler registry after modules are loaded
+		const { AuthHandlerRegistry } = await import('@/auth/auth-handler.registry');
+		await Container.get(AuthHandlerRegistry).init();
+
 		if (this.instanceSettings.isMultiMain) {
 			// we instantiate `PrometheusMetricsService` early to register its multi-main event handlers
 			if (this.globalConfig.endpoints.metrics.enable) {

--- a/packages/cli/src/controllers/__tests__/auth.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/auth.controller.test.ts
@@ -8,6 +8,7 @@ import type { Response } from 'express';
 import { mock } from 'jest-mock-extended';
 
 import * as auth from '@/auth';
+import { AuthHandlerRegistry } from '@/auth/auth-handler.registry';
 import { AuthService } from '@/auth/auth.service';
 import config from '@/config';
 import { EventService } from '@/events/event.service';
@@ -41,6 +42,7 @@ describe('AuthController', () => {
 	mockInstance(PostHogClient);
 	mockInstance(License);
 	const ldapService = mockInstance(LdapService);
+	const authHandlerRegistry = mockInstance(AuthHandlerRegistry);
 	const controller = Container.get(AuthController);
 	const userService = Container.get(UserService);
 	const authService = Container.get(AuthService);
@@ -50,6 +52,13 @@ describe('AuthController', () => {
 	describe('login', () => {
 		beforeEach(() => {
 			jest.resetAllMocks();
+			// Setup auth handler registry to return ldapService for 'ldap'
+			authHandlerRegistry.get.mockImplementation((method: string) => {
+				if (method === 'ldap') {
+					return ldapService;
+				}
+				return undefined;
+			});
 		});
 
 		it('should not validate email in "emailOrLdapLoginId" if LDAP is enabled', async () => {
@@ -78,7 +87,7 @@ describe('AuthController', () => {
 
 			mockedAuth.handleEmailLogin.mockResolvedValue(member);
 
-			ldapService.handleLdapLogin.mockResolvedValue(member);
+			ldapService.handleLogin.mockResolvedValue(member);
 
 			config.set('userManagement.authenticationMethod', 'ldap');
 
@@ -93,10 +102,7 @@ describe('AuthController', () => {
 				body.password,
 			);
 
-			expect(ldapService.handleLdapLogin).toHaveBeenCalledWith(
-				body.emailOrLdapLoginId,
-				body.password,
-			);
+			expect(ldapService.handleLogin).toHaveBeenCalledWith(body.emailOrLdapLoginId, body.password);
 
 			expect(authService.issueCookie).toHaveBeenCalledWith(res, member, false, browserId);
 			expect(eventsService.emit).toHaveBeenCalledWith('user-logged-in', {
@@ -207,6 +213,7 @@ describe('AuthController', () => {
 				license,
 				userRepository,
 				eventService,
+				authHandlerRegistry,
 				postHog,
 			);
 
@@ -239,6 +246,7 @@ describe('AuthController', () => {
 				license,
 				userRepository,
 				eventService,
+				authHandlerRegistry,
 				postHog,
 			);
 
@@ -275,6 +283,7 @@ describe('AuthController', () => {
 				license,
 				userRepository,
 				eventService,
+				authHandlerRegistry,
 				postHog,
 			);
 
@@ -312,6 +321,7 @@ describe('AuthController', () => {
 				license,
 				userRepository,
 				eventService,
+				authHandlerRegistry,
 				postHog,
 			);
 
@@ -358,6 +368,7 @@ describe('AuthController', () => {
 				license,
 				userRepository,
 				eventService,
+				authHandlerRegistry,
 				postHog,
 			);
 
@@ -406,6 +417,7 @@ describe('AuthController', () => {
 				license,
 				userRepository,
 				eventService,
+				authHandlerRegistry,
 				postHog,
 			);
 
@@ -463,6 +475,7 @@ describe('AuthController', () => {
 				license,
 				userRepository,
 				eventService,
+				authHandlerRegistry,
 				postHog,
 			);
 
@@ -519,6 +532,7 @@ describe('AuthController', () => {
 				license,
 				userRepository,
 				eventService,
+				authHandlerRegistry,
 				postHog,
 			);
 
@@ -552,6 +566,7 @@ describe('AuthController', () => {
 				license,
 				userRepository,
 				eventService,
+				authHandlerRegistry,
 				postHog,
 			);
 
@@ -584,6 +599,7 @@ describe('AuthController', () => {
 				license,
 				userRepository,
 				eventService,
+				authHandlerRegistry,
 				postHog,
 			);
 

--- a/packages/cli/src/controllers/auth.controller.ts
+++ b/packages/cli/src/controllers/auth.controller.ts
@@ -98,9 +98,9 @@ export class AuthController {
 				usedAuthenticationMethod = 'email';
 			} else {
 				// Check if an auth handler is registered for the current auth method
-				const authHandler = this.authHandlerRegistry.get(usedAuthenticationMethod);
+				const authHandler = this.authHandlerRegistry.get(usedAuthenticationMethod, 'password');
 				if (authHandler) {
-					user = await authHandler.handleLogin(emailOrLdapLoginId, password);
+					user = (await authHandler.handleLogin(emailOrLdapLoginId, password)) as User | undefined;
 				}
 			}
 		} else {

--- a/packages/cli/src/controllers/auth.controller.ts
+++ b/packages/cli/src/controllers/auth.controller.ts
@@ -100,7 +100,7 @@ export class AuthController {
 				// Check if an auth handler is registered for the current auth method
 				const authHandler = this.authHandlerRegistry.get(usedAuthenticationMethod, 'password');
 				if (authHandler) {
-					user = (await authHandler.handleLogin(emailOrLdapLoginId, password)) as User | undefined;
+					user = await authHandler.handleLogin(emailOrLdapLoginId, password);
 				}
 			}
 		} else {

--- a/packages/cli/src/controllers/auth.controller.ts
+++ b/packages/cli/src/controllers/auth.controller.ts
@@ -11,11 +11,11 @@ import {
 	Query,
 	RestController,
 } from '@n8n/decorators';
-import { Container } from '@n8n/di';
 import { isEmail } from 'class-validator';
 import { Response } from 'express';
 
 import { handleEmailLogin } from '@/auth';
+import { AuthHandlerRegistry } from '@/auth/auth-handler.registry';
 import { AuthService } from '@/auth/auth.service';
 import { RESPONSE_ERROR_MESSAGES } from '@/constants';
 import { AuthError } from '@/errors/response-errors/auth.error';
@@ -29,7 +29,6 @@ import { AuthlessRequest } from '@/requests';
 import { UserService } from '@/services/user.service';
 import {
 	getCurrentAuthenticationMethod,
-	isLdapCurrentAuthenticationMethod,
 	isOidcCurrentAuthenticationMethod,
 	isSamlCurrentAuthenticationMethod,
 	isSsoCurrentAuthenticationMethod,
@@ -45,6 +44,7 @@ export class AuthController {
 		private readonly license: License,
 		private readonly userRepository: UserRepository,
 		private readonly eventService: EventService,
+		private readonly authHandlerRegistry: AuthHandlerRegistry,
 		private readonly postHog?: PostHogClient,
 	) {}
 
@@ -91,14 +91,17 @@ export class AuthController {
 			} else {
 				throw new AuthError('SSO is enabled, please log in with SSO');
 			}
-		} else if (isLdapCurrentAuthenticationMethod()) {
+		} else if (usedAuthenticationMethod !== 'email') {
 			const preliminaryUser = await handleEmailLogin(emailOrLdapLoginId, password);
 			if (preliminaryUser?.role.slug === GLOBAL_OWNER_ROLE.slug) {
 				user = preliminaryUser;
 				usedAuthenticationMethod = 'email';
 			} else {
-				const { LdapService } = await import('@/modules/ldap.ee/ldap.service.ee');
-				user = await Container.get(LdapService).handleLdapLogin(emailOrLdapLoginId, password);
+				// Check if an auth handler is registered for the current auth method
+				const authHandler = this.authHandlerRegistry.get(usedAuthenticationMethod);
+				if (authHandler) {
+					user = await authHandler.handleLogin(emailOrLdapLoginId, password);
+				}
 			}
 		} else {
 			user = await handleEmailLogin(emailOrLdapLoginId, password);

--- a/packages/cli/src/modules/ldap.ee/__tests__/ldap.service.test.ts
+++ b/packages/cli/src/modules/ldap.ee/__tests__/ldap.service.test.ts
@@ -1479,7 +1479,7 @@ describe('LdapService', () => {
 		});
 	});
 
-	describe('handleLdapLogin()', () => {
+	describe('handleLogin()', () => {
 		describe('enforceEmailUniqueness', () => {
 			const mockUser: User = mock<User>({
 				email: 'jdoe@example.com',
@@ -1523,7 +1523,7 @@ describe('LdapService', () => {
 
 				await ldapService.init();
 
-				const result = await ldapService.handleLdapLogin('jdoe', 'password');
+				const result = await ldapService.handleLogin('jdoe', 'password');
 				expect(result).toEqual(mockUser);
 			});
 
@@ -1535,7 +1535,7 @@ describe('LdapService', () => {
 
 				await ldapService.init();
 
-				const result = await ldapService.handleLdapLogin('jdoe', 'password');
+				const result = await ldapService.handleLogin('jdoe', 'password');
 				expect(result).toBeUndefined();
 			});
 		});

--- a/packages/cli/src/modules/ldap.ee/ldap.module.ts
+++ b/packages/cli/src/modules/ldap.ee/ldap.module.ts
@@ -2,6 +2,8 @@ import type { ModuleInterface } from '@n8n/decorators';
 import { BackendModule } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 
+import { AuthHandlerRegistry } from '@/auth/auth-handler.registry';
+
 @BackendModule({ name: 'ldap', licenseFlag: 'feat:ldap', instanceTypes: ['main'] })
 export class LdapModule implements ModuleInterface {
 	async init() {
@@ -10,5 +12,8 @@ export class LdapModule implements ModuleInterface {
 		const { LdapService } = await import('./ldap.service.ee');
 		const ldapService = Container.get(LdapService);
 		await ldapService.init();
+
+		// Register LDAP auth handler
+		Container.get(AuthHandlerRegistry).register('ldap', ldapService);
 	}
 }

--- a/packages/cli/src/modules/ldap.ee/ldap.module.ts
+++ b/packages/cli/src/modules/ldap.ee/ldap.module.ts
@@ -1,19 +1,12 @@
 import type { ModuleInterface } from '@n8n/decorators';
 import { BackendModule } from '@n8n/decorators';
-import { Container } from '@n8n/di';
-
-import { AuthHandlerRegistry } from '@/auth/auth-handler.registry';
 
 @BackendModule({ name: 'ldap', licenseFlag: 'feat:ldap', instanceTypes: ['main'] })
 export class LdapModule implements ModuleInterface {
 	async init() {
 		await import('./ldap.controller.ee');
 
-		const { LdapService } = await import('./ldap.service.ee');
-		const ldapService = Container.get(LdapService);
-		await ldapService.init();
-
-		// Register LDAP auth handler
-		Container.get(AuthHandlerRegistry).register('ldap', ldapService);
+		// Import LdapService to trigger @PasswordAuthHandler() decorator registration
+		await import('./ldap.service.ee');
 	}
 }

--- a/packages/cli/src/modules/ldap.ee/ldap.service.ee.ts
+++ b/packages/cli/src/modules/ldap.ee/ldap.service.ee.ts
@@ -4,14 +4,15 @@ import type { LdapConfig } from '@n8n/constants';
 import { LDAP_FEATURE_NAME } from '@n8n/constants';
 import { isValidEmail, SettingsRepository } from '@n8n/db';
 import type { User, RunningMode, SyncStatus } from '@n8n/db';
-import { Service, Container } from '@n8n/di';
+import { Container } from '@n8n/di';
+import type { IPasswordAuthHandler } from '@n8n/decorators';
+import { AuthHandler } from '@n8n/decorators';
 import { QueryFailedError } from '@n8n/typeorm';
 import type { Entry as LdapUser, ClientOptions, Client } from 'ldapts';
 import { Cipher } from 'n8n-core';
 import { jsonParse, UnexpectedError } from 'n8n-workflow';
 import type { ConnectionOptions } from 'tls';
 
-import type { AuthHandler } from '@/auth/auth-handler.registry';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { InternalServerError } from '@/errors/response-errors/internal-server.error';
 import { EventService } from '@/events/event.service';
@@ -46,8 +47,9 @@ import {
 	getUserByLdapId,
 } from './helpers.ee';
 
-@Service()
-export class LdapService implements AuthHandler {
+@AuthHandler()
+export class LdapService implements IPasswordAuthHandler<User> {
+	readonly metadata = { name: 'ldap', type: 'password' as const };
 	private client: Client | undefined;
 
 	// eslint-disable-next-line @typescript-eslint/consistent-type-imports

--- a/packages/cli/src/modules/ldap.ee/ldap.service.ee.ts
+++ b/packages/cli/src/modules/ldap.ee/ldap.service.ee.ts
@@ -2,9 +2,9 @@ import { LicenseState, Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import type { LdapConfig } from '@n8n/constants';
 import { LDAP_FEATURE_NAME } from '@n8n/constants';
-import { isValidEmail, SettingsRepository } from '@n8n/db';
-import type { User, RunningMode, SyncStatus } from '@n8n/db';
-import { Container } from '@n8n/di';
+import { isValidEmail, SettingsRepository, User } from '@n8n/db';
+import type { RunningMode, SyncStatus } from '@n8n/db';
+import { Constructable, Container } from '@n8n/di';
 import type { IPasswordAuthHandler } from '@n8n/decorators';
 import { AuthHandler } from '@n8n/decorators';
 import { QueryFailedError } from '@n8n/typeorm';
@@ -58,6 +58,8 @@ export class LdapService implements IPasswordAuthHandler<User> {
 	private syncTimer: NodeJS.Timeout | undefined = undefined;
 
 	config: LdapConfig;
+
+	readonly userClass: Constructable<User> = User;
 
 	constructor(
 		private readonly logger: Logger,

--- a/packages/cli/src/modules/ldap.ee/ldap.service.ee.ts
+++ b/packages/cli/src/modules/ldap.ee/ldap.service.ee.ts
@@ -11,6 +11,7 @@ import { Cipher } from 'n8n-core';
 import { jsonParse, UnexpectedError } from 'n8n-workflow';
 import type { ConnectionOptions } from 'tls';
 
+import type { AuthHandler } from '@/auth/auth-handler.registry';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { InternalServerError } from '@/errors/response-errors/internal-server.error';
 import { EventService } from '@/events/event.service';
@@ -46,7 +47,7 @@ import {
 } from './helpers.ee';
 
 @Service()
-export class LdapService {
+export class LdapService implements AuthHandler {
 	private client: Client | undefined;
 
 	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
@@ -496,7 +497,7 @@ export class LdapService {
 		return localLdapIds.filter((user) => !remoteAdUserIds.includes(user));
 	}
 
-	async handleLdapLogin(loginId: string, password: string): Promise<User | undefined> {
+	async handleLogin(loginId: string, password: string): Promise<User | undefined> {
 		if (!this.licenseState.isLdapLicensed()) return undefined;
 
 		if (!this.config.loginEnabled) return undefined;

--- a/packages/cli/test/integration/ldap/ldap.api.test.ts
+++ b/packages/cli/test/integration/ldap/ldap.api.test.ts
@@ -39,6 +39,7 @@ let authOwnerAgent: SuperAgentTest;
 const testServer = utils.setupTestServer({
 	endpointGroups: ['auth', 'ldap'],
 	enabledFeatures: ['feat:ldap'],
+	modules: ['ldap'],
 });
 
 beforeAll(async () => {

--- a/packages/cli/test/integration/shared/types.ts
+++ b/packages/cli/test/integration/shared/types.ts
@@ -55,7 +55,8 @@ type ModuleName =
 	| 'data-table'
 	| 'mcp'
 	| 'dynamic-credentials'
-	| 'log-streaming';
+	| 'log-streaming'
+	| 'ldap';
 
 export interface SetupProps {
 	endpointGroups?: EndpointGroup[];

--- a/packages/cli/test/integration/shared/utils/test-server.ts
+++ b/packages/cli/test/integration/shared/utils/test-server.ts
@@ -9,6 +9,7 @@ import type superagent from 'superagent';
 import request from 'supertest';
 import { URL } from 'url';
 
+import { AuthHandlerRegistry } from '@/auth/auth-handler.registry';
 import { AuthService } from '@/auth/auth.service';
 import { AUTH_COOKIE_NAME } from '@/constants';
 import { ControllerRegistry } from '@/controller.registry';
@@ -324,6 +325,8 @@ export const setupTestServer = ({
 
 			await Container.get(ModuleRegistry).initModules('main');
 			Container.get(ControllerRegistry).activate(app);
+
+			await Container.get(AuthHandlerRegistry).init();
 		}
 	});
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Introduce an auth handler registry to avoid manually calling the ldap module. The ldap service instead registers as an auth handler to be called by the auth controller

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/IAM-99/improve-auth-providers-core-coupling


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
