### PR TITLE
fix(ai-builder): Fixing padding in WFB chat when message feedback is showing

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
@@ -263,20 +263,21 @@ const showBottomInput = computed(() => {
 });
 
 const showFooterRating = computed(() => {
-	if (props.streaming || !props.messages?.length) {
-		return false;
-	}
-
-	// Check if there's a workflow-updated message in the original messages
-	// (workflow-updated is filtered out of normalizedMessages since it's not rendered visually)
-	// and check the last visible message (from normalizedMessages)
-	const hasWorkflowUpdate = props.messages.some((msg) => msg.type === 'workflow-updated');
-	if (!hasWorkflowUpdate || !normalizedMessages.value.length) {
-		return false;
-	}
-
-	const lastMsg = normalizedMessages.value[normalizedMessages.value.length - 1];
-	return lastMsg.role !== 'user' && lastMsg.type !== 'thinking-group';
+	// if (props.streaming || !props.messages?.length) {
+	// 	return false;
+	// }
+	//
+	// // Check if there's a workflow-updated message in the original messages
+	// // (workflow-updated is filtered out of normalizedMessages since it's not rendered visually)
+	// // and check the last visible message (from normalizedMessages)
+	// const hasWorkflowUpdate = props.messages.some((msg) => msg.type === 'workflow-updated');
+	// if (!hasWorkflowUpdate || !normalizedMessages.value.length) {
+	// 	return false;
+	// }
+	//
+	// const lastMsg = normalizedMessages.value[normalizedMessages.value.length - 1];
+	// return lastMsg.role !== 'user' && lastMsg.type !== 'thinking-group';
+	return true;
 });
 
 function isEndOfSessionEvent(event?: ChatUI.AssistantMessage) {
@@ -681,7 +682,7 @@ defineExpose({
 
 .messagesContent {
 	padding: var(--spacing--xs);
-	padding-bottom: var(--spacing--l);
+	padding-bottom: var(--spacing--lg);
 
 	// Override p line-height from reset.scss (1.8) to use chat standard (1.5)
 	:global(p) {

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
@@ -263,21 +263,20 @@ const showBottomInput = computed(() => {
 });
 
 const showFooterRating = computed(() => {
-	// if (props.streaming || !props.messages?.length) {
-	// 	return false;
-	// }
-	//
-	// // Check if there's a workflow-updated message in the original messages
-	// // (workflow-updated is filtered out of normalizedMessages since it's not rendered visually)
-	// // and check the last visible message (from normalizedMessages)
-	// const hasWorkflowUpdate = props.messages.some((msg) => msg.type === 'workflow-updated');
-	// if (!hasWorkflowUpdate || !normalizedMessages.value.length) {
-	// 	return false;
-	// }
-	//
-	// const lastMsg = normalizedMessages.value[normalizedMessages.value.length - 1];
-	// return lastMsg.role !== 'user' && lastMsg.type !== 'thinking-group';
-	return true;
+	if (props.streaming || !props.messages?.length) {
+		return false;
+	}
+
+	// Check if there's a workflow-updated message in the original messages
+	// (workflow-updated is filtered out of normalizedMessages since it's not rendered visually)
+	// and check the last visible message (from normalizedMessages)
+	const hasWorkflowUpdate = props.messages.some((msg) => msg.type === 'workflow-updated');
+	if (!hasWorkflowUpdate || !normalizedMessages.value.length) {
+		return false;
+	}
+
+	const lastMsg = normalizedMessages.value[normalizedMessages.value.length - 1];
+	return lastMsg.role !== 'user' && lastMsg.type !== 'thinking-group';
 });
 
 function isEndOfSessionEvent(event?: ChatUI.AssistantMessage) {


### PR DESCRIPTION
## Summary

Fixing a mis-set padding value for the workflow builder chat.

Addresses an issue @Tuukkaa raised with work that was done in: https://linear.app/n8n/issue/AI-1943/ux-move-the-feedback-buttons-next-to-prompt-box

<img width="414" height="413" alt="image" src="https://github.com/user-attachments/assets/db6789aa-f623-4566-a569-ab2df88950cf" />

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
