### PR TITLE
fix(editor): Move version store init after authentication

### DIFF
--- a/packages/frontend/editor-ui/src/app/init.ts
+++ b/packages/frontend/editor-ui/src/app/init.ts
@@ -47,7 +47,6 @@ export async function initializeCore() {
 	}
 
 	const settingsStore = useSettingsStore();
-	const versionsStore = useVersionsStore();
 	const usersStore = useUsersStore();
 	const ssoStore = useSSOStore();
 
@@ -82,8 +81,6 @@ export async function initializeCore() {
 			oidc: settingsStore.isEnterpriseFeatureEnabled[EnterpriseEditionFeature.Oidc],
 		},
 	});
-
-	versionsStore.initialize(settingsStore.settings.versionNotifications);
 
 	if (!settingsStore.isPreviewMode) {
 		await usersStore.initialize();
@@ -196,6 +193,7 @@ export async function initializeAuthenticatedFeatures(
 
 	// Don't check for new versions in preview mode or demo view (ex: executions iframe)
 	if (!settingsStore.isPreviewMode && routeName !== VIEWS.DEMO) {
+		versionsStore.initialize(settingsStore.settings.versionNotifications);
 		void versionsStore.checkForNewVersions();
 	}
 


### PR DESCRIPTION
## Summary

The `GET /settings` endpoint returns `PublicFrontendSettings` for unauthenticated users, which omits `versionNotifications`. This passed `undefined` to `versionsStore.initialize()` so overwriting the ref's safe default and causing an error when `checkForNewVersions()` later accessed `versionNotificationSettings.value.enabled`. Moved the call into `initializeAuthenticatedFeatures()` where full settings are available.

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C035KBDA917/p1769774236926769?thread_ts=1769770861.072359&cid=C035KBDA917

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
