### PR TITLE
fix(core): Fix missing early return on Bull error

### DIFF
--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -460,7 +460,9 @@ export class WorkflowRunner {
 						lifecycleHooks,
 					);
 
-					reject(error);
+					this.scalingService.popJobResult(executionId);
+
+					return reject(error);
 				}
 
 				const jobResult = this.scalingService.popJobResult(executionId);


### PR DESCRIPTION
## Summary

When `job.finished()` throws for any reason, the catch block calls `reject(error)` but is missing a return, so the execution falls through to the happy path, i.e. we fetch and `flatted.parse` an execution we don't need, we run the `workflowExecuteAfter` hook twice, and we further continue to process a run failed due to any Bull error. The promise ends up both rejected and resolved.

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C0AA207KJBH/p1769767938287129


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
