### PR TITLE
fix(editor): Always ensure data worker tables exist (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/workers/data/worker.ts
+++ b/packages/frontend/editor-ui/src/app/workers/data/worker.ts
@@ -139,16 +139,12 @@ async function initialize({ version }: { version: string }): Promise<void> {
 		console.log('[DataWorker] VFS name:', VFS_NAME);
 		console.log('[DataWorker] Database name:', DB_NAME);
 
-		if (!databaseExists) {
-			console.log('[DataWorker] Creating tables...');
-			const tableSchemas = getAllTableSchemas();
-			for (const schema of tableSchemas) {
-				await state.sqlite3.exec(state.db, schema);
-			}
-			console.log('[DataWorker] Tables created successfully');
-		} else {
-			console.log('[DataWorker] Skipping table creation - database already exists');
+		console.log('[DataWorker] Ensuring tables...');
+		const tableSchemas = getAllTableSchemas();
+		for (const schema of tableSchemas) {
+			await state.sqlite3.exec(state.db, schema);
 		}
+		console.log('[DataWorker] Tables ensured successfully');
 
 		state.initialized = true;
 		state.version = version;


### PR DESCRIPTION

## Summary

Remove database existence check to always run table schema creation, ensuring tables are properly initialized regardless of database state.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
