### PR TITLE
feat(Kafka Trigger Node): Race donePromise against execution timeout

### DIFF
--- a/packages/nodes-base/nodes/Kafka/KafkaTrigger.node.ts
+++ b/packages/nodes-base/nodes/Kafka/KafkaTrigger.node.ts
@@ -343,6 +343,26 @@ export class KafkaTrigger implements INodeType {
 						description: 'The maximum time allowed for a consumer to join the group',
 					},
 					{
+						displayName: 'Retry Delay on Error',
+						name: 'errorRetryDelay',
+						type: 'number',
+						default: 5000,
+						description:
+							'Delay in milliseconds before retrying after a failed offset resolution. This prevents rapid retry loops that could overwhelm the Kafka broker.',
+						hint: 'Value in milliseconds',
+						typeOptions: {
+							minValue: 1000,
+						},
+						displayOptions: {
+							show: {
+								'@version': [{ _cnd: { gte: 1.3 } }],
+							},
+							hide: {
+								'/resolveOffset': ['immediately'],
+							},
+						},
+					},
+					{
 						displayName: 'Session Timeout',
 						name: 'sessionTimeout',
 						type: 'number',

--- a/packages/nodes-base/nodes/Kafka/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Kafka/test/utils.test.ts
@@ -1,7 +1,18 @@
 import { mock } from 'jest-mock-extended';
-import type { ITriggerFunctions } from 'n8n-workflow';
+import type { ITriggerFunctions, IRun, INode, Logger, IDeferredPromise } from 'n8n-workflow';
+import { NodeOperationError, sleep } from 'n8n-workflow';
 
-import { getAutoCommitSettings, type KafkaTriggerOptions } from '../utils';
+import { getAutoCommitSettings, configureDataEmitter, type KafkaTriggerOptions } from '../utils';
+
+jest.mock('n8n-workflow', () => {
+	const actual = jest.requireActual('n8n-workflow');
+	return {
+		...actual,
+		sleep: jest.fn().mockResolvedValue(undefined),
+	};
+});
+
+const mockedSleep = jest.mocked(sleep);
 
 describe('Kafka Utils', () => {
 	describe('getAutoCommitSettings', () => {
@@ -188,6 +199,463 @@ describe('Kafka Utils', () => {
 				eachBatchAutoResolve: true,
 				autoCommitInterval: 5000,
 				autoCommitThreshold: 100,
+			});
+		});
+	});
+
+	describe('configureDataEmitter', () => {
+		const mockNode: INode = {
+			id: 'test-node-id',
+			name: 'Test Kafka Trigger',
+			type: 'n8n-nodes-base.kafkaTrigger',
+			typeVersion: 1.3,
+			position: [0, 0],
+			parameters: {},
+		};
+
+		interface TestDeferredPromise<T> extends IDeferredPromise<T> {
+			resolveWith: (value: T) => void;
+			rejectWith: (error: Error) => void;
+		}
+
+		const createDeferredPromise = <T>(): TestDeferredPromise<T> => {
+			let resolveFunc: (value: T) => void;
+			let rejectFunc: (error: Error) => void;
+			const promise = new Promise<T>((res, rej) => {
+				resolveFunc = res;
+				rejectFunc = rej;
+			});
+			return {
+				promise,
+				resolve: () => {},
+				reject: () => {},
+				resolveWith: (value: T) => resolveFunc(value),
+				rejectWith: (error: Error) => rejectFunc(error),
+			};
+		};
+
+		const createMockContext = (
+			params: Record<string, unknown> = {},
+			mode: 'manual' | 'trigger' = 'trigger',
+			deferredPromise?: TestDeferredPromise<IRun>,
+		) => {
+			const ctx = mock<ITriggerFunctions>();
+			const mockLogger = mock<Logger>();
+
+			ctx.getNodeParameter.mockImplementation(
+				(name: string, fallback?: unknown) => (params[name] ?? fallback) as never,
+			);
+			ctx.getMode.mockReturnValue(mode);
+			ctx.getNode.mockReturnValue(mockNode);
+			ctx.logger = mockLogger;
+			ctx.getWorkflowSettings.mockReturnValue({ executionTimeout: 3600 });
+
+			// Mock helpers.createDeferredPromise
+			if (deferredPromise) {
+				ctx.helpers = {
+					...ctx.helpers,
+					createDeferredPromise: jest.fn().mockReturnValue(deferredPromise),
+				} as unknown as ITriggerFunctions['helpers'];
+			}
+
+			return ctx;
+		};
+
+		beforeEach(() => {
+			jest.clearAllMocks();
+			jest.useFakeTimers();
+		});
+
+		afterEach(() => {
+			jest.useRealTimers();
+		});
+
+		describe('immediate emit mode', () => {
+			it('should emit immediately in manual mode regardless of resolveOffset setting', async () => {
+				const ctx = createMockContext({ resolveOffset: 'onCompletion' }, 'manual');
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const result = await emitter(testData);
+
+				expect(ctx.emit).toHaveBeenCalledWith([testData]);
+				expect(result).toEqual({ success: true });
+			});
+
+			it('should emit immediately for version 1 (resolveOffset mode is "immediately")', async () => {
+				const ctx = createMockContext({}, 'trigger');
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1);
+				const testData = [{ json: { message: 'test' } }];
+
+				const result = await emitter(testData);
+
+				expect(ctx.emit).toHaveBeenCalledWith([testData]);
+				expect(result).toEqual({ success: true });
+			});
+
+			it('should emit immediately for version 1.1 with parallelProcessing enabled', async () => {
+				const ctx = createMockContext({}, 'trigger');
+				const options: KafkaTriggerOptions = { parallelProcessing: true };
+
+				const emitter = configureDataEmitter(ctx, options, 1.1);
+				const testData = [{ json: { message: 'test' } }];
+
+				const result = await emitter(testData);
+
+				expect(ctx.emit).toHaveBeenCalledWith([testData]);
+				expect(result).toEqual({ success: true });
+			});
+
+			it('should emit immediately when resolveOffset is explicitly set to "immediately"', async () => {
+				const ctx = createMockContext({ resolveOffset: 'immediately' }, 'trigger');
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const result = await emitter(testData);
+
+				expect(ctx.emit).toHaveBeenCalledWith([testData]);
+				expect(result).toEqual({ success: true });
+			});
+		});
+
+		describe('deferred emit mode - onCompletion', () => {
+			it('should wait for execution completion and return success', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext(
+					{ resolveOffset: 'onCompletion' },
+					'trigger',
+					deferredPromise,
+				);
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const resultPromise = emitter(testData);
+
+				// Simulate successful execution completion
+				deferredPromise.resolveWith({ status: 'success' } as unknown as IRun);
+
+				const result = await resultPromise;
+
+				expect(ctx.emit).toHaveBeenCalledWith([testData], undefined, deferredPromise);
+				expect(result).toEqual({ success: true });
+			});
+
+			it('should return success for any status in onCompletion mode', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext(
+					{ resolveOffset: 'onCompletion' },
+					'trigger',
+					deferredPromise,
+				);
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const resultPromise = emitter(testData);
+
+				// Simulate failed execution - should still succeed in onCompletion mode
+				deferredPromise.resolveWith({ status: 'error' } as unknown as IRun);
+
+				const result = await resultPromise;
+
+				expect(result).toEqual({ success: true });
+			});
+
+			it('should use version 1.1 onCompletion mode when parallelProcessing is false', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext({}, 'trigger', deferredPromise);
+				const options: KafkaTriggerOptions = { parallelProcessing: false };
+
+				const emitter = configureDataEmitter(ctx, options, 1.1);
+				const testData = [{ json: { message: 'test' } }];
+
+				const resultPromise = emitter(testData);
+
+				deferredPromise.resolveWith({ status: 'success' } as unknown as IRun);
+
+				const result = await resultPromise;
+
+				expect(ctx.emit).toHaveBeenCalledWith([testData], undefined, deferredPromise);
+				expect(result).toEqual({ success: true });
+			});
+		});
+
+		describe('deferred emit mode - onSuccess', () => {
+			it('should return success when execution status is "success"', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext({ resolveOffset: 'onSuccess' }, 'trigger', deferredPromise);
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const resultPromise = emitter(testData);
+
+				deferredPromise.resolveWith({ status: 'success' } as unknown as IRun);
+
+				const result = await resultPromise;
+
+				expect(result).toEqual({ success: true });
+			});
+
+			it('should return failure and sleep when execution status is not "success"', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext({ resolveOffset: 'onSuccess' }, 'trigger', deferredPromise);
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const resultPromise = emitter(testData);
+
+				deferredPromise.resolveWith({ status: 'error' } as unknown as IRun);
+
+				const result = await resultPromise;
+
+				expect(mockedSleep).toHaveBeenCalledWith(5000); // DEFAULT_ERROR_RETRY_DELAY_MS
+				expect(ctx.logger.error).toHaveBeenCalled();
+				expect(result).toEqual({ success: false });
+			});
+
+			it('should use custom errorRetryDelay when provided', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext({ resolveOffset: 'onSuccess' }, 'trigger', deferredPromise);
+				const options: KafkaTriggerOptions = { errorRetryDelay: 10000 };
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const resultPromise = emitter(testData);
+
+				deferredPromise.resolveWith({ status: 'error' } as unknown as IRun);
+
+				await resultPromise;
+
+				expect(mockedSleep).toHaveBeenCalledWith(10000);
+			});
+		});
+
+		describe('deferred emit mode - onStatus', () => {
+			it('should throw error when no statuses are selected', () => {
+				const ctx = createMockContext(
+					{ resolveOffset: 'onStatus', allowedStatuses: [] },
+					'trigger',
+				);
+				const options: KafkaTriggerOptions = {};
+
+				expect(() => configureDataEmitter(ctx, options, 1.3)).toThrow(NodeOperationError);
+			});
+
+			it('should return success when execution status matches allowed statuses', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext(
+					{ resolveOffset: 'onStatus', allowedStatuses: ['success', 'warning'] },
+					'trigger',
+					deferredPromise,
+				);
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const resultPromise = emitter(testData);
+
+				deferredPromise.resolveWith({ status: 'warning' } as unknown as IRun);
+
+				const result = await resultPromise;
+
+				expect(result).toEqual({ success: true });
+			});
+
+			it('should return failure when execution status does not match allowed statuses', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext(
+					{ resolveOffset: 'onStatus', allowedStatuses: ['success'] },
+					'trigger',
+					deferredPromise,
+				);
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const resultPromise = emitter(testData);
+
+				deferredPromise.resolveWith({ status: 'error' } as unknown as IRun);
+
+				const result = await resultPromise;
+
+				expect(mockedSleep).toHaveBeenCalled();
+				expect(result).toEqual({ success: false });
+			});
+		});
+
+		describe('timeout handling', () => {
+			it('should timeout and return failure when execution takes too long', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext(
+					{ resolveOffset: 'onCompletion' },
+					'trigger',
+					deferredPromise,
+				);
+				ctx.getWorkflowSettings.mockReturnValue({ executionTimeout: 1 }); // 1 second timeout
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const resultPromise = emitter(testData);
+
+				// Advance timers past the timeout
+				jest.advanceTimersByTime(1001);
+
+				const result = await resultPromise;
+
+				expect(mockedSleep).toHaveBeenCalled();
+				expect(ctx.logger.error).toHaveBeenCalled();
+				expect(result).toEqual({ success: false });
+			});
+
+			it('should use default timeout of 3600 seconds when not configured', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext(
+					{ resolveOffset: 'onCompletion' },
+					'trigger',
+					deferredPromise,
+				);
+				ctx.getWorkflowSettings.mockReturnValue({}); // No timeout configured
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const resultPromise = emitter(testData);
+
+				// Resolve before timeout
+				deferredPromise.resolveWith({ status: 'success' } as unknown as IRun);
+
+				const result = await resultPromise;
+
+				expect(result).toEqual({ success: true });
+			});
+
+			it('should clear timeout when execution completes before timeout', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext(
+					{ resolveOffset: 'onCompletion' },
+					'trigger',
+					deferredPromise,
+				);
+				ctx.getWorkflowSettings.mockReturnValue({ executionTimeout: 10 });
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const resultPromise = emitter(testData);
+
+				// Resolve quickly
+				deferredPromise.resolveWith({ status: 'success' } as unknown as IRun);
+
+				const result = await resultPromise;
+
+				// Advance timers past what would have been the timeout
+				jest.advanceTimersByTime(15000);
+
+				// Should not have logged any timeout error
+				expect(result).toEqual({ success: true });
+			});
+		});
+
+		describe('error handling', () => {
+			it('should handle promise rejection and return failure', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext(
+					{ resolveOffset: 'onCompletion' },
+					'trigger',
+					deferredPromise,
+				);
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const resultPromise = emitter(testData);
+
+				deferredPromise.rejectWith(new Error('Execution failed'));
+
+				const result = await resultPromise;
+
+				expect(mockedSleep).toHaveBeenCalledWith(5000);
+				expect(ctx.logger.error).toHaveBeenCalledWith('Execution failed', expect.any(Object));
+				expect(result).toEqual({ success: false });
+			});
+
+			it('should handle non-Error objects in catch block', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext(
+					{ resolveOffset: 'onCompletion' },
+					'trigger',
+					deferredPromise,
+				);
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const resultPromise = emitter(testData);
+
+				// Reject with a string instead of Error
+				deferredPromise.rejectWith('String error' as unknown as Error);
+
+				const result = await resultPromise;
+
+				expect(mockedSleep).toHaveBeenCalled();
+				expect(result).toEqual({ success: false });
+			});
+		});
+
+		describe('data emission', () => {
+			it('should emit data array wrapped in another array', async () => {
+				const ctx = createMockContext({}, 'manual');
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test1' } }, { json: { message: 'test2' } }];
+
+				await emitter(testData);
+
+				expect(ctx.emit).toHaveBeenCalledWith([testData]);
+			});
+
+			it('should pass deferred promise to emit in deferred mode', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext(
+					{ resolveOffset: 'onCompletion' },
+					'trigger',
+					deferredPromise,
+				);
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const resultPromise = emitter(testData);
+
+				deferredPromise.resolveWith({ status: 'success' } as unknown as IRun);
+
+				await resultPromise;
+
+				expect(ctx.emit).toHaveBeenCalledWith([testData], undefined, deferredPromise);
 			});
 		});
 	});

--- a/packages/nodes-base/nodes/Kafka/utils.ts
+++ b/packages/nodes-base/nodes/Kafka/utils.ts
@@ -374,8 +374,6 @@ export function configureDataEmitter(
 
 			const run = await Promise.race([responsePromise.promise, timeoutPromise]);
 
-			if (timeoutId) clearTimeout(timeoutId);
-
 			if (resolveOffsetMode !== 'onCompletion' && !allowedStatuses.includes(run.status)) {
 				throw new NodeOperationError(
 					ctx.getNode(),
@@ -385,11 +383,12 @@ export function configureDataEmitter(
 
 			return { success: true };
 		} catch (e) {
-			if (timeoutId) clearTimeout(timeoutId);
 			await sleep(errorRetryDelay);
 			const error = ensureError(e);
 			ctx.logger.error(error.message, { error });
 			return { success: false };
+		} finally {
+			if (timeoutId) clearTimeout(timeoutId);
 		}
 	};
 }


### PR DESCRIPTION
## Summary

fix: donePromise will now race with execution timeout to prevent issues where it was never resolved.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-4338/kafka-race-donepromise-against-execution-timeout
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
