### PR TITLE
refactor(core): Simplify date validation by removing inThePast check

### DIFF
--- a/packages/cli/src/modules/insights/__tests__/insights.controller.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.controller.test.ts
@@ -252,32 +252,6 @@ describe('InsightsController', () => {
 					new BadRequestError('endDate must be the same as or after startDate'),
 				);
 			});
-
-			it('should throw a BadRequestError when endDate is in the future', async () => {
-				// ARRANGE
-				const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000); // 1 day in the future
-
-				// ACT & ASSERT
-				await expect(
-					controller.getInsightsSummary(mock<AuthenticatedRequest>(), mock<Response>(), {
-						startDate: new Date('2025-06-10'),
-						endDate: futureDate,
-						projectId: 'test-project',
-					}),
-				).rejects.toThrowError(new BadRequestError('must be in the past'));
-			});
-
-			it('should throw a BadRequestError when startDate is in the future', async () => {
-				// ARRANGE
-				const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000); // 1 day in the future
-
-				// ACT & ASSERT
-				await expect(
-					controller.getInsightsSummary(mock<AuthenticatedRequest>(), mock<Response>(), {
-						startDate: futureDate,
-					}),
-				).rejects.toThrowError(new BadRequestError('must be in the past'));
-			});
 		});
 
 		describe('with license restrictions', () => {
@@ -527,32 +501,6 @@ describe('InsightsController', () => {
 					new BadRequestError('endDate must be the same as or after startDate'),
 				);
 			});
-
-			it('should throw a BadRequestError when endDate is in the future', async () => {
-				const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000); // 1 day in the future
-
-				await expect(
-					controller.getInsightsByWorkflow(mock<AuthenticatedRequest>(), mock<Response>(), {
-						startDate: new Date('2025-06-10'),
-						endDate: futureDate,
-						skip: 20,
-						take: 5,
-						projectId: 'test-project',
-					}),
-				).rejects.toThrowError(new BadRequestError('must be in the past'));
-			});
-
-			it('should throw a BadRequestError when startDate is in the future', async () => {
-				const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000); // 1 day in the future
-
-				await expect(
-					controller.getInsightsByWorkflow(mock<AuthenticatedRequest>(), mock<Response>(), {
-						startDate: futureDate,
-						skip: 0,
-						take: 5,
-					}),
-				).rejects.toThrowError(new BadRequestError('must be in the past'));
-			});
 		});
 
 		describe('with license restrictions', () => {
@@ -779,28 +727,6 @@ describe('InsightsController', () => {
 					new BadRequestError('endDate must be the same as or after startDate'),
 				);
 			});
-
-			it('should throw a BadRequestError when endDate is in the future', async () => {
-				const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000);
-
-				await expect(
-					controller.getInsightsByTime(mock<AuthenticatedRequest>(), mock<Response>(), {
-						startDate: new Date('2025-06-10'),
-						endDate: futureDate,
-						projectId: 'test-project',
-					}),
-				).rejects.toThrowError(new BadRequestError('must be in the past'));
-			});
-
-			it('should throw a BadRequestError when startDate is in the future', async () => {
-				const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000);
-
-				await expect(
-					controller.getInsightsByTime(mock<AuthenticatedRequest>(), mock<Response>(), {
-						startDate: futureDate,
-					}),
-				).rejects.toThrowError(new BadRequestError('must be in the past'));
-			});
 		});
 
 		describe('with license restrictions', () => {
@@ -948,28 +874,6 @@ describe('InsightsController', () => {
 				).rejects.toThrowError(
 					new BadRequestError('endDate must be the same as or after startDate'),
 				);
-			});
-
-			it('should throw a BadRequestError when endDate is in the future', async () => {
-				const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000);
-
-				await expect(
-					controller.getTimeSavedInsightsByTime(mock<AuthenticatedRequest>(), mock<Response>(), {
-						startDate: new Date('2025-06-10'),
-						endDate: futureDate,
-						projectId: 'test-project',
-					}),
-				).rejects.toThrowError(new BadRequestError('must be in the past'));
-			});
-
-			it('should throw a BadRequestError when startDate is in the future', async () => {
-				const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000);
-
-				await expect(
-					controller.getTimeSavedInsightsByTime(mock<AuthenticatedRequest>(), mock<Response>(), {
-						startDate: futureDate,
-					}),
-				).rejects.toThrowError(new BadRequestError('must be in the past'));
 			});
 		});
 

--- a/packages/cli/src/modules/insights/insights.controller.ts
+++ b/packages/cli/src/modules/insights/insights.controller.ts
@@ -100,22 +100,10 @@ export class InsightsController {
 	}
 
 	private validateQueryDates(query: InsightsDateFilterDto | ListInsightsWorkflowQueryDto) {
-		// Allow 60 second buffer for clock skew
-		const inThePast = (date?: Date) => {
-			if (!date) return true;
-			const now = new Date();
-			const bufferMs = 60000; // 60 second tolerance
-			return date.getTime() <= now.getTime() + bufferMs;
-		};
-		const dateInThePastSchema = z.coerce
-			.date()
-			.optional()
-			.refine(inThePast, { message: 'must be in the past' });
-
 		const schema = z
 			.object({
-				startDate: dateInThePastSchema,
-				endDate: dateInThePastSchema,
+				startDate: z.coerce.date().optional(),
+				endDate: z.coerce.date().optional(),
 			})
 			.refine(
 				(data) => {

--- a/packages/cli/src/modules/insights/insights.controller.ts
+++ b/packages/cli/src/modules/insights/insights.controller.ts
@@ -100,11 +100,11 @@ export class InsightsController {
 	}
 
 	private validateQueryDates(query: InsightsDateFilterDto | ListInsightsWorkflowQueryDto) {
-		// Allow 2 second buffer for clock skew and network latency
+		// Allow 60 second buffer for clock skew
 		const inThePast = (date?: Date) => {
 			if (!date) return true;
 			const now = new Date();
-			const bufferMs = 2000; // 2 second tolerance
+			const bufferMs = 60000; // 60 second tolerance
 			return date.getTime() <= now.getTime() + bufferMs;
 		};
 		const dateInThePastSchema = z.coerce

--- a/packages/cli/src/modules/insights/insights.controller.ts
+++ b/packages/cli/src/modules/insights/insights.controller.ts
@@ -100,7 +100,13 @@ export class InsightsController {
 	}
 
 	private validateQueryDates(query: InsightsDateFilterDto | ListInsightsWorkflowQueryDto) {
-		const inThePast = (date?: Date) => !date || date <= new Date();
+		// Allow 2 second buffer for clock skew and network latency
+		const inThePast = (date?: Date) => {
+			if (!date) return true;
+			const now = new Date();
+			const bufferMs = 2000; // 2 second tolerance
+			return date.getTime() <= now.getTime() + bufferMs;
+		};
 		const dateInThePastSchema = z.coerce
 			.date()
 			.optional()

--- a/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDashboard.vue
+++ b/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDashboard.vue
@@ -6,7 +6,7 @@ import type { ProjectSharingData } from '@/features/collaboration/projects/proje
 import InsightsSummary from '@/features/execution/insights/components/InsightsSummary.vue';
 import { useInsightsStore } from '@/features/execution/insights/insights.store';
 import type { DateValue } from '@internationalized/date';
-import { getLocalTimeZone, now, toCalendarDateTime, today } from '@internationalized/date';
+import { getLocalTimeZone, today } from '@internationalized/date';
 import type { InsightsSummaryType } from '@n8n/api-types';
 import { useI18n } from '@n8n/i18n';
 import {
@@ -20,7 +20,7 @@ import {
 } from 'vue';
 import { useRoute } from 'vue-router';
 import { INSIGHT_TYPES } from '../insights.constants';
-import { getTimeRangeLabels, timeRangeMappings } from '../insights.utils';
+import { getAdjustedDateRange, getTimeRangeLabels, timeRangeMappings } from '../insights.utils';
 import InsightsDataRangePicker from './InsightsDataRangePicker.vue';
 
 import { N8nHeading, N8nSpinner } from '@n8n/design-system';
@@ -122,17 +122,10 @@ const range = shallowRef<{
 });
 
 /**
- * Converts the range to a UTC date range with the current time
+ * Converts the range to adjusted Date objects for API calls
  */
 const getFilteredRange = () => {
-	const timezone = getLocalTimeZone();
-	const startDate = toCalendarDateTime(range.value.start, now(timezone)).toDate(timezone);
-	const endDate = toCalendarDateTime(range.value.end, now(timezone)).toDate(timezone);
-
-	return {
-		startDate,
-		endDate,
-	};
+	return getAdjustedDateRange(range.value);
 };
 
 const fetchPaginatedTableData = ({

--- a/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDataRangePicker.vue
+++ b/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDataRangePicker.vue
@@ -9,7 +9,7 @@ import type {
 } from '@n8n/design-system';
 import { N8nButton, N8nDateRangePicker, N8nIcon } from '@n8n/design-system';
 import { computed, ref, shallowRef, watch } from 'vue';
-import { formatDateRange } from '../insights.utils';
+import { formatDateRange, getAdjustedDateRange } from '../insights.utils';
 import InsightsUpgradeModal from './InsightsUpgradeModal.vue';
 
 type Props = Pick<N8nDateRangePickerProps, 'maxValue' | 'minValue'>;
@@ -78,6 +78,8 @@ function syncWithParentValue() {
 	}
 }
 
+let lastSyncedRange: DateRange | null = null;
+
 function syncData(isOpen: boolean) {
 	if (isOpen) {
 		syncWithParentValue();
@@ -95,17 +97,30 @@ function syncData(isOpen: boolean) {
 		return;
 	}
 
+	// Check if this is the same range we just synced (prevent double sync)
+	if (
+		lastSyncedRange &&
+		isEqual(normalizedRange.start, lastSyncedRange.start) &&
+		isEqual(normalizedRange.end, lastSyncedRange.end)
+	) {
+		return;
+	}
+
 	if (
 		isEqual(normalizedRange.start, props.modelValue.start) &&
 		isEqual(normalizedRange.end, props.modelValue.end)
 	) {
 		return;
 	}
+
+	lastSyncedRange = normalizedRange;
 	emit('update:modelValue', normalizedRange);
 
+	const { startDate, endDate } = getAdjustedDateRange(normalizedRange);
+
 	const trackData = {
-		start_date: normalizedRange.start?.toDate(getLocalTimeZone()).toISOString(),
-		end_date: normalizedRange.end?.toDate(getLocalTimeZone()).toISOString(),
+		start_date: startDate.toISOString(),
+		end_date: endDate.toISOString(),
 		range_length_days: getDaysDiff(normalizedRange),
 		type: actionType.value,
 	};
@@ -114,8 +129,10 @@ function syncData(isOpen: boolean) {
 }
 const open = ref(false);
 watch(open, (opened) => {
+	if (opened) {
+		actionType.value = 'custom';
+	}
 	syncData(opened);
-	actionType.value = 'custom';
 });
 
 function setPresetRange(days: number) {


### PR DESCRIPTION
## Summary

**1. Adjusts date validation to allow a 60-second buffer for clock skew**

The backend validation (date <= new Date()) had no tolerance for timing differences between when the frontend generates timestamps and when the backend validates them:
Minor clock skew - Client and server clocks may be slightly out of sync

**Update:** After discussion, we decided to remove the "must be in the past" validation entirely. Since this is a read-only operation, allowing future dates (which will simply return no data) is a cleaner solution to the clock skew problem than maintaining a buffer.

**2. Adjust date ranges in FE to properly query multi-day ranges: uses start-of-day for start, end-of-day or current time for end.**

<section id="markdown-section-0eced4bf-2d0a-42c8-9709-d457df27ac22-26" class="markdown-section chat-fade-in" data-markdown-raw="

**New Behavior: Examples**

" data-section-index="26" style="border-radius: 4px; line-height: 19.5px; margin: 6px 0px; position: relative; scroll-margin-bottom: 40px; scroll-margin-top: 40px; color: rgb(123, 136, 161); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 33, 39); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 style="animation: 0.25s ease 0s 1 normal none running fade-in; font-weight: 600 !important; font-size: 1.15em; line-height: 1.25; margin-bottom: 8px; margin-top: 18px;"><span style="animation: 0.25s ease 0s 1 normal none running fade-in;">Behavior Examples</span></h3></section><div class="monaco-scrollable-element mac markdown-table-container" role="presentation" style="scrollbar-width: none; overflow: hidden; color: rgb(123, 136, 161); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(30, 33, 39); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; position: relative; margin: 1em 0px; width: fit-content; max-width: 100%; border-color: color(srgb 0.482353 0.533333 0.631373 / 0.08); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; border-radius: 6px;"><div class="markdown-table-wrapper" style="--fade-start: rgba(0,0,0,.25); --fade-end: #000; --markdown-table-fade-width: 10px; mask-image: none; overflow: hidden;">

Scenario | Start Date | End Date
-- | -- | --
"Last 24 hours" at 14:30:45 | Yesterday 14:30:45 | Today 14:30:45
"Last 7 days" at 14:30:45 | 7 days ago 00:00:00 | Today 14:30:45
Past date range | Start date 00:00:00 | End date 23:59:59

</div></div>
<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

Fixes [LIGO-135](https://linear.app/n8n/issue/LIGO-135/cannot-view-insights)


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
