### PR TITLE
refactor(editor): Centralize workflow ID via provide/inject

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.test.ts
@@ -90,7 +90,7 @@ const renderComponent = createComponentRenderer(MainHeader, {
 			TabBar: { template: '<div></div>' },
 		},
 		provide: {
-			[WorkflowIdKey as symbol]: computed(() => 'test-workflow-id'),
+			[WorkflowIdKey]: computed(() => 'test-workflow-id'),
 		},
 	},
 });

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.test.ts
@@ -6,6 +6,8 @@ import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
 import { useCollaborationStore } from '@/features/collaboration/collaboration/collaboration.store';
 import { STORES } from '@n8n/stores';
+import { WorkflowIdKey } from '@/app/constants/injectionKeys';
+import { computed } from 'vue';
 
 vi.mock('@n8n/permissions', () => ({
 	getResourcePermissions: vi.fn(() => ({
@@ -86,6 +88,9 @@ const renderComponent = createComponentRenderer(MainHeader, {
 			},
 			GithubButton: { template: '<div></div>' },
 			TabBar: { template: '<div></div>' },
+		},
+		provide: {
+			[WorkflowIdKey as symbol]: computed(() => 'test-workflow-id'),
 		},
 	},
 });

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.vue
@@ -19,6 +19,8 @@ import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { computed, onBeforeMount, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import type { RouteLocation, RouteLocationRaw } from 'vue-router';
 import { useRoute, useRouter } from 'vue-router';
+import { injectStrict } from '@/app/utils/injectStrict';
+import { WorkflowIdKey } from '@/app/constants/injectionKeys';
 
 import { useLocalStorage } from '@vueuse/core';
 import GithubButton from 'vue-github-button';
@@ -70,7 +72,7 @@ const hideMenuBar = computed(() =>
 	Boolean(activeNode.value && activeNode.value.type !== STICKY_NODE_TYPE),
 );
 const workflow = computed(() => workflowsStore.workflow);
-const workflowId = computed(() => String(route.params.name || workflowsStore.workflowId));
+const workflowId = injectStrict(WorkflowIdKey);
 const onWorkflowPage = computed(() => !!(route.meta.nodeView || route.meta.keepWorkflowAlive));
 
 const isEnterprise = computed(

--- a/packages/frontend/editor-ui/src/app/constants/injectionKeys.ts
+++ b/packages/frontend/editor-ui/src/app/constants/injectionKeys.ts
@@ -8,7 +8,7 @@ import type { ExpressionLocalResolveContext } from '@/app/types/expressions';
 import type { TelemetryContext } from '@/app/types/telemetry';
 import type { WorkflowState } from '@/app/composables/useWorkflowState';
 
-export const WorkflowIdKey: InjectionKey<ComputedRef<string>> = Symbol('WorkflowId');
+export const WorkflowIdKey = 'workflowId' as unknown as InjectionKey<ComputedRef<string>>;
 export const CanvasKey = 'canvas' as unknown as InjectionKey<CanvasInjectionData>;
 export const CanvasNodeKey = 'canvasNode' as unknown as InjectionKey<CanvasNodeInjectionData>;
 export const CanvasNodeHandleKey =

--- a/packages/frontend/editor-ui/src/app/constants/injectionKeys.ts
+++ b/packages/frontend/editor-ui/src/app/constants/injectionKeys.ts
@@ -8,6 +8,7 @@ import type { ExpressionLocalResolveContext } from '@/app/types/expressions';
 import type { TelemetryContext } from '@/app/types/telemetry';
 import type { WorkflowState } from '@/app/composables/useWorkflowState';
 
+export const WorkflowIdKey: InjectionKey<ComputedRef<string>> = Symbol('WorkflowId');
 export const CanvasKey = 'canvas' as unknown as InjectionKey<CanvasInjectionData>;
 export const CanvasNodeKey = 'canvasNode' as unknown as InjectionKey<CanvasNodeInjectionData>;
 export const CanvasNodeHandleKey =

--- a/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
@@ -1,6 +1,18 @@
 <script lang="ts" setup>
+import { provide, computed } from 'vue';
+import { useRoute } from 'vue-router';
 import BaseLayout from './BaseLayout.vue';
 import DemoFooter from '@/features/execution/logs/components/DemoFooter.vue';
+import { WorkflowIdKey } from '@/app/constants/injectionKeys';
+
+const route = useRoute();
+
+const workflowId = computed(() => {
+	const name = route.params.name;
+	return (Array.isArray(name) ? name[0] : name) as string;
+});
+
+provide(WorkflowIdKey, workflowId);
 </script>
 
 <template>

--- a/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
@@ -1,4 +1,6 @@
 <script lang="ts" setup>
+import { provide, computed } from 'vue';
+import { useRoute } from 'vue-router';
 import BaseLayout from './BaseLayout.vue';
 import { useLayoutProps } from '@/app/composables/useLayoutProps';
 import AskAssistantFloatingButton from '@/features/ai/assistant/components/Chat/AskAssistantFloatingButton.vue';
@@ -6,10 +8,18 @@ import { useAssistantStore } from '@/features/ai/assistant/assistant.store';
 import AppHeader from '@/app/components/app/AppHeader.vue';
 import AppSidebar from '@/app/components/app/AppSidebar.vue';
 import LogsPanel from '@/features/execution/logs/components/LogsPanel.vue';
+import { WorkflowIdKey } from '@/app/constants/injectionKeys';
 
+const route = useRoute();
 const { layoutProps } = useLayoutProps();
-
 const assistantStore = useAssistantStore();
+
+const workflowId = computed(() => {
+	const name = route.params.name;
+	return (Array.isArray(name) ? name[0] : name) as string;
+});
+
+provide(WorkflowIdKey, workflowId);
 </script>
 
 <template>

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -152,6 +152,8 @@ import { useWorkflowState } from '@/app/composables/useWorkflowState';
 import { useActivityDetection } from '@/app/composables/useActivityDetection';
 import { useParentFolder } from '@/features/core/folders/composables/useParentFolder';
 import { useCollaborationStore } from '@/features/collaboration/collaboration/collaboration.store';
+import { injectStrict } from '@/app/utils/injectStrict';
+import { WorkflowIdKey } from '@/app/constants/injectionKeys';
 
 import { N8nCallout, N8nCanvasThinkingPill, N8nCanvasCollaborationPill } from '@n8n/design-system';
 
@@ -300,10 +302,7 @@ const hideNodeIssues = ref(false);
 const fallbackNodes = ref<INodeUi[]>([]);
 
 const initializedWorkflowId = ref<string | undefined>();
-const workflowId = computed(() => {
-	const name = route.params.name;
-	return Array.isArray(name) ? name[0] : name;
-});
+const workflowId = injectStrict(WorkflowIdKey);
 const routeNodeId = computed(() => {
 	const nodeId = route.params.nodeId;
 	return Array.isArray(nodeId) ? nodeId[0] : nodeId;

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/TestRunDetailView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/TestRunDetailView.test.ts
@@ -128,7 +128,7 @@ describe('TestRunDetailView', () => {
 		}),
 		global: {
 			provide: {
-				[WorkflowIdKey as symbol]: computed(() => 'test-workflow-id'),
+				[WorkflowIdKey]: computed(() => 'test-workflow-id'),
 			},
 		},
 	});

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/TestRunDetailView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/TestRunDetailView.test.ts
@@ -7,6 +7,8 @@ import TestRunDetailView from './TestRunDetailView.vue';
 import type { TestCaseExecutionRecord, TestRunRecord } from '../evaluation.api';
 import type { IWorkflowDb } from '@/Interface';
 import { mock } from 'vitest-mock-extended';
+import { WorkflowIdKey } from '@/app/constants/injectionKeys';
+import { computed } from 'vue';
 
 vi.mock('@/app/composables/useToast', () => ({
 	useToast: () => ({
@@ -124,6 +126,11 @@ describe('TestRunDetailView', () => {
 			},
 			stubActions: false,
 		}),
+		global: {
+			provide: {
+				[WorkflowIdKey as symbol]: computed(() => 'test-workflow-id'),
+			},
+		},
 	});
 
 	beforeEach(() => {

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/TestRunDetailView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/TestRunDetailView.vue
@@ -5,6 +5,8 @@ import TestTableBase from '../components/shared/TestTableBase.vue';
 import { useI18n } from '@n8n/i18n';
 import { useToast } from '@/app/composables/useToast';
 import { VIEWS } from '@/app/constants';
+import { injectStrict } from '@/app/utils/injectStrict';
+import { WorkflowIdKey } from '@/app/constants/injectionKeys';
 import type { BaseTextKey } from '@n8n/i18n';
 import { useEvaluationStore } from '../evaluation.store';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
@@ -64,7 +66,7 @@ const testCases = ref<TestCaseExecutionRecord[]>([]);
 const hasFailedTestCases = ref<boolean>(false);
 
 const runId = computed(() => router.currentRoute.value.params.runId as string);
-const workflowId = computed(() => router.currentRoute.value.params.name as string);
+const workflowId = injectStrict(WorkflowIdKey);
 const workflowName = computed(
 	() => workflowsListStore.getWorkflowById(workflowId.value)?.name ?? '',
 );

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionAnnotationPanel.ee.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionAnnotationPanel.ee.vue
@@ -4,7 +4,8 @@ import type { ExecutionSummary } from 'n8n-workflow';
 import { useI18n } from '@n8n/i18n';
 import { getResourcePermissions } from '@n8n/permissions';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
-import { useRoute } from 'vue-router';
+import { injectStrict } from '@/app/utils/injectStrict';
+import { WorkflowIdKey } from '@/app/constants/injectionKeys';
 
 import { ElDropdown } from 'element-plus';
 import { N8nBadge, N8nButton, N8nHeading, N8nText } from '@n8n/design-system';
@@ -15,13 +16,12 @@ const props = defineProps<{
 }>();
 
 const workflowsListStore = useWorkflowsListStore();
-const route = useRoute();
 const i18n = useI18n();
 
 const annotationDropdownRef = ref<InstanceType<typeof ElDropdown> | null>(null);
 const isDropdownVisible = ref(false);
 
-const workflowId = computed(() => route.params.name as string);
+const workflowId = injectStrict(WorkflowIdKey);
 const workflowPermissions = computed(
 	() =>
 		getResourcePermissions(workflowsListStore.getWorkflowById(workflowId.value)?.scopes).workflow,

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsCard.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsCard.test.ts
@@ -5,6 +5,8 @@ import { createTestingPinia } from '@pinia/testing';
 import { STORES } from '@n8n/stores';
 import type { ComponentProps } from 'vue-component-type-helpers';
 import type { ExecutionSummary } from 'n8n-workflow';
+import { WorkflowIdKey } from '@/app/constants/injectionKeys';
+import { computed } from 'vue';
 
 vi.mock('vue-router', () => ({
 	useRoute: () => ({
@@ -43,6 +45,9 @@ const renderComponent = createComponentRenderer(WorkflowExecutionsCard, {
 			$route: {
 				params: {},
 			},
+		},
+		provide: {
+			[WorkflowIdKey as symbol]: computed(() => 'test-workflow-id'),
 		},
 	},
 });

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsCard.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsCard.test.ts
@@ -47,7 +47,7 @@ const renderComponent = createComponentRenderer(WorkflowExecutionsCard, {
 			},
 		},
 		provide: {
-			[WorkflowIdKey as symbol]: computed(() => 'test-workflow-id'),
+			[WorkflowIdKey]: computed(() => 'test-workflow-id'),
 		},
 	},
 });

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsCard.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsCard.vue
@@ -3,10 +3,11 @@ import { computed, onMounted } from 'vue';
 import { useRoute } from 'vue-router';
 import type { IExecutionUIData } from '../../composables/useExecutionHelpers';
 import { EnterpriseEditionFeature, VIEWS } from '@/app/constants';
+import { injectStrict } from '@/app/utils/injectStrict';
+import { WorkflowIdKey } from '@/app/constants/injectionKeys';
 import ExecutionsTime from '../ExecutionsTime.vue';
 import { useExecutionHelpers } from '../../composables/useExecutionHelpers';
 import type { ExecutionSummary } from 'n8n-workflow';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useI18n } from '@n8n/i18n';
 import type { PermissionsRecord } from '@n8n/permissions';
 import { useSettingsStore } from '@/app/stores/settings.store';
@@ -36,7 +37,6 @@ const route = useRoute();
 const locale = useI18n();
 
 const executionHelpers = useExecutionHelpers();
-const workflowsStore = useWorkflowsStore();
 const settingsStore = useSettingsStore();
 
 const isAdvancedExecutionFilterEnabled = computed(
@@ -44,7 +44,7 @@ const isAdvancedExecutionFilterEnabled = computed(
 );
 const isAnnotationEnabled = computed(() => isAdvancedExecutionFilterEnabled.value);
 
-const currentWorkflow = computed(() => (route.params.name as string) || workflowsStore.workflowId);
+const workflowId = injectStrict(WorkflowIdKey);
 const retryExecutionActions = computed(() => [
 	{
 		id: 'current-workflow',
@@ -85,7 +85,7 @@ function onRetryMenuItemSelect(action: string): void {
 			:class="$style.executionLink"
 			:to="{
 				name: VIEWS.EXECUTION_PREVIEW,
-				params: { name: currentWorkflow, executionId: execution.id },
+				params: { name: workflowId, executionId: execution.id },
 				query: route.query,
 			}"
 			:data-test-execution-status="executionUIDetails.name"

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsPreview.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsPreview.test.ts
@@ -80,7 +80,7 @@ const renderComponent = createComponentRenderer(WorkflowExecutionsPreview, {
 		},
 		plugins: [router],
 		provide: {
-			[WorkflowIdKey as symbol]: computed(() => 'test-workflow-id'),
+			[WorkflowIdKey]: computed(() => 'test-workflow-id'),
 		},
 	},
 });

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsPreview.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsPreview.test.ts
@@ -6,6 +6,7 @@ import { randomInt, type ExecutionSummary, type AnnotationVote } from 'n8n-workf
 import { useSettingsStore } from '@/app/stores/settings.store';
 import WorkflowExecutionsPreview from './WorkflowExecutionsPreview.vue';
 import { EnterpriseEditionFeature, VIEWS } from '@/app/constants';
+import { WorkflowIdKey } from '@/app/constants/injectionKeys';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import type { IWorkflowDb } from '@/Interface';
 import type { ExecutionSummaryWithScopes } from '../../executions.types';
@@ -14,7 +15,7 @@ import { createTestingPinia } from '@pinia/testing';
 import { mockedStore } from '@/__tests__/utils';
 import type { FrontendSettings } from '@n8n/api-types';
 import { STORES } from '@n8n/stores';
-import { nextTick } from 'vue';
+import { nextTick, computed } from 'vue';
 
 const showMessage = vi.fn();
 const showError = vi.fn();
@@ -78,6 +79,9 @@ const renderComponent = createComponentRenderer(WorkflowExecutionsPreview, {
 			RouterLink,
 		},
 		plugins: [router],
+		provide: {
+			[WorkflowIdKey as symbol]: computed(() => 'test-workflow-id'),
+		},
 	},
 });
 

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsPreview.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsPreview.vue
@@ -9,6 +9,8 @@ import { useI18n } from '@n8n/i18n';
 import { useToast } from '@/app/composables/useToast';
 import { useMessage } from '@/app/composables/useMessage';
 import { EnterpriseEditionFeature, MODAL_CONFIRM, VIEWS } from '@/app/constants';
+import { injectStrict } from '@/app/utils/injectStrict';
+import { WorkflowIdKey } from '@/app/constants/injectionKeys';
 import { getResourcePermissions } from '@n8n/permissions';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
@@ -43,7 +45,7 @@ const executionDebugging = useExecutionDebugging();
 const workflowsListStore = useWorkflowsListStore();
 const settingsStore = useSettingsStore();
 const retryDropdownRef = ref<RetryDropdownRef | null>(null);
-const workflowId = computed(() => route.params.name as string);
+const workflowId = injectStrict(WorkflowIdKey);
 const workflowPermissions = computed(
 	() =>
 		getResourcePermissions(workflowsListStore.getWorkflowById(workflowId.value)?.scopes).workflow,

--- a/packages/frontend/editor-ui/src/features/execution/executions/views/WorkflowExecutionsView.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/views/WorkflowExecutionsView.vue
@@ -13,6 +13,8 @@ import { NO_NETWORK_ERROR_CODE } from '@n8n/rest-api-client';
 import { useToast } from '@/app/composables/useToast';
 import { VIEWS } from '@/app/constants';
 import { useRoute, useRouter } from 'vue-router';
+import { injectStrict } from '@/app/utils/injectStrict';
+import { WorkflowIdKey } from '@/app/constants/injectionKeys';
 import type { ExecutionSummary } from 'n8n-workflow';
 import { useDebounce } from '@/app/composables/useDebounce';
 import { useTelemetry } from '@/app/composables/useTelemetry';
@@ -38,10 +40,7 @@ const loadingMore = ref(false);
 
 const workflow = ref<IWorkflowDb | undefined>();
 
-const workflowId = computed(() => {
-	const name = route.params.name;
-	return typeof name === 'string' ? name : undefined;
-});
+const workflowId = injectStrict(WorkflowIdKey);
 
 const executionId = computed(() => {
 	const id = route.params.executionId;


### PR DESCRIPTION
## Summary

Introduce WorkflowIdKey injection key to provide workflow ID at the layout level instead of extracting it from route params in individual components. This eliminates duplicated logic, reduces component coupling to the router, and ensures consistency across the application.

- Add WorkflowIdKey injection key with type ComputedRef<string>
- Provide workflow ID from WorkflowLayout.vue to all child components
- Update components to inject and use the provided workflow ID
- Remove redundant route param extraction logic
- Update tests with appropriate mock providers

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
