### PR TITLE
feat(core): Add URL blocklist for HTTP Request node

### DIFF
--- a/packages/@n8n/config/src/configs/security.config.ts
+++ b/packages/@n8n/config/src/configs/security.config.ts
@@ -76,4 +76,11 @@ export class SecurityConfig {
 	 */
 	@Env('N8N_GIT_NODE_ENABLE_ALL_CONFIG_KEYS')
 	enableGitNodeAllConfigKeys: boolean = false;
+
+	/**
+	 * Comma-separated list of hosts, IPs, or patterns to block in HTTP Request node.
+	 * Supports shortcuts: `cloud-metadata`, `apipa`, `private-ip`, `localhost`.
+	 */
+	@Env('N8N_HTTP_REQUEST_BLOCK')
+	httpRequestBlock: string = '';
 }

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -329,6 +329,7 @@ describe('GlobalConfig', () => {
 			awsSystemCredentialsAccess: false,
 			enableGitNodeHooks: false,
 			enableGitNodeAllConfigKeys: false,
+			httpRequestBlock: '',
 		},
 		executions: {
 			mode: 'regular',

--- a/packages/core/src/__tests__/url-blocklist.test.ts
+++ b/packages/core/src/__tests__/url-blocklist.test.ts
@@ -1,0 +1,234 @@
+import {
+	expandPatterns,
+	matchesBlocklist,
+	matchesPattern,
+	validateUrlAgainstBlocklist,
+} from '../url-blocklist';
+
+describe('URL Blocklist', () => {
+	describe('expandPatterns', () => {
+		it('should expand cloud-metadata shortcut', () => {
+			const result = expandPatterns(['cloud-metadata']);
+			expect(result).toEqual(['169.254.169.254']);
+		});
+
+		it('should expand apipa shortcut', () => {
+			const result = expandPatterns(['apipa']);
+			expect(result).toEqual(['169.254.*']);
+		});
+
+		it('should expand localhost shortcut', () => {
+			const result = expandPatterns(['localhost']);
+			expect(result).toEqual(['127.*', '::1', 'localhost']);
+		});
+
+		it('should expand private-ip shortcut to all RFC 1918 ranges', () => {
+			const result = expandPatterns(['private-ip']);
+			expect(result).toContain('10.*');
+			expect(result).toContain('172.16.*');
+			expect(result).toContain('172.17.*');
+			expect(result).toContain('172.31.*');
+			expect(result).toContain('192.168.*');
+			expect(result).toHaveLength(18); // 1 + 16 + 1
+		});
+
+		it('should pass through non-shortcut patterns unchanged', () => {
+			const result = expandPatterns(['example.com', '10.0.0.*']);
+			expect(result).toEqual(['example.com', '10.0.0.*']);
+		});
+
+		it('should handle mixed shortcuts and custom patterns', () => {
+			const result = expandPatterns(['cloud-metadata', 'custom.host']);
+			expect(result).toEqual(['169.254.169.254', 'custom.host']);
+		});
+
+		it('should handle empty strings and whitespace', () => {
+			const result = expandPatterns(['', '  ', 'cloud-metadata', '']);
+			expect(result).toEqual(['169.254.169.254']);
+		});
+
+		it('should be case-insensitive for shortcuts', () => {
+			const result = expandPatterns(['CLOUD-METADATA', 'APIPA']);
+			expect(result).toEqual(['169.254.169.254', '169.254.*']);
+		});
+	});
+
+	describe('matchesPattern', () => {
+		it('should match exact hostnames', () => {
+			expect(matchesPattern('localhost', 'localhost')).toBe(true);
+			expect(matchesPattern('example.com', 'example.com')).toBe(true);
+		});
+
+		it('should be case-insensitive', () => {
+			expect(matchesPattern('LOCALHOST', 'localhost')).toBe(true);
+			expect(matchesPattern('localhost', 'LOCALHOST')).toBe(true);
+		});
+
+		it('should match wildcard patterns', () => {
+			expect(matchesPattern('169.254.169.254', '169.254.*')).toBe(true);
+			expect(matchesPattern('169.254.0.1', '169.254.*')).toBe(true);
+			expect(matchesPattern('10.0.0.1', '10.*')).toBe(true);
+			expect(matchesPattern('10.255.255.255', '10.*')).toBe(true);
+		});
+
+		it('should not match non-matching wildcards', () => {
+			expect(matchesPattern('192.168.1.1', '169.254.*')).toBe(false);
+			expect(matchesPattern('11.0.0.1', '10.*')).toBe(false);
+		});
+
+		it('should not match partial hostnames without wildcards', () => {
+			expect(matchesPattern('localhost.localdomain', 'localhost')).toBe(false);
+			expect(matchesPattern('example.com', 'example')).toBe(false);
+		});
+	});
+
+	describe('matchesBlocklist', () => {
+		it('should return true when URL matches any pattern', () => {
+			const blocklist = ['169.254.169.254', '10.*'];
+			expect(matchesBlocklist('http://169.254.169.254/latest/meta-data', blocklist)).toBe(true);
+			expect(matchesBlocklist('http://10.0.0.1:8080/api', blocklist)).toBe(true);
+		});
+
+		it('should return false when URL does not match any pattern', () => {
+			const blocklist = ['169.254.*', 'localhost'];
+			expect(matchesBlocklist('https://api.example.com/data', blocklist)).toBe(false);
+			expect(matchesBlocklist('http://192.168.1.1:8080/api', blocklist)).toBe(false);
+		});
+
+		it('should handle IPv6 addresses', () => {
+			const blocklist = ['::1'];
+			expect(matchesBlocklist('http://[::1]:8080/api', blocklist)).toBe(true);
+			expect(matchesBlocklist('http://[::1]/api', blocklist)).toBe(true);
+		});
+
+		it('should return false for invalid URLs', () => {
+			const blocklist = ['169.254.*'];
+			expect(matchesBlocklist('not-a-valid-url', blocklist)).toBe(false);
+		});
+
+		it('should handle localhost hostname', () => {
+			const blocklist = ['localhost'];
+			expect(matchesBlocklist('http://localhost:5678/healthz', blocklist)).toBe(true);
+			expect(matchesBlocklist('http://localhost/api', blocklist)).toBe(true);
+		});
+
+		it('should handle 127.x.x.x loopback range', () => {
+			const blocklist = ['127.*'];
+			expect(matchesBlocklist('http://127.0.0.1:8080', blocklist)).toBe(true);
+			expect(matchesBlocklist('http://127.255.255.255/test', blocklist)).toBe(true);
+		});
+	});
+
+	describe('validateUrlAgainstBlocklist', () => {
+		it('should not throw when blocklist is empty', () => {
+			expect(() => validateUrlAgainstBlocklist('http://169.254.169.254', '')).not.toThrow();
+		});
+
+		it('should not throw when blocklist is whitespace only', () => {
+			expect(() => validateUrlAgainstBlocklist('http://169.254.169.254', '   ')).not.toThrow();
+		});
+
+		it('should throw when URL matches blocklist', () => {
+			expect(() =>
+				validateUrlAgainstBlocklist('http://169.254.169.254/latest/meta-data', 'cloud-metadata'),
+			).toThrow(/Request blocked/);
+		});
+
+		it('should not throw when URL does not match blocklist', () => {
+			expect(() =>
+				validateUrlAgainstBlocklist('https://api.example.com/data', 'cloud-metadata,localhost'),
+			).not.toThrow();
+		});
+
+		it('should handle comma-separated patterns', () => {
+			expect(() =>
+				validateUrlAgainstBlocklist('http://localhost:8080', 'cloud-metadata,localhost'),
+			).toThrow(/Request blocked/);
+		});
+
+		it('should include hostname in error message', () => {
+			expect(() =>
+				validateUrlAgainstBlocklist('http://169.254.169.254/meta-data', 'cloud-metadata'),
+			).toThrow(/169\.254\.169\.254/);
+		});
+	});
+
+	describe('cloud and private network blocking scenarios', () => {
+		const cloudConfig = 'cloud-metadata,apipa,private-ip';
+
+		it('should block AWS metadata endpoint', () => {
+			expect(() =>
+				validateUrlAgainstBlocklist(
+					'http://169.254.169.254/latest/meta-data/iam/security-credentials/role-name',
+					cloudConfig,
+				),
+			).toThrow(/Request blocked/);
+		});
+
+		it('should block GCP metadata endpoint', () => {
+			expect(() =>
+				validateUrlAgainstBlocklist(
+					'http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token',
+					cloudConfig,
+				),
+			).toThrow(/Request blocked/);
+		});
+
+		it('should block Azure metadata endpoint', () => {
+			expect(() =>
+				validateUrlAgainstBlocklist(
+					'http://169.254.169.254/metadata/identity/oauth2/token',
+					cloudConfig,
+				),
+			).toThrow(/Request blocked/);
+		});
+
+		it('should block Docker bridge gateway access', () => {
+			expect(() =>
+				validateUrlAgainstBlocklist('http://172.17.0.1:8080/internal-api', cloudConfig),
+			).toThrow(/Request blocked/);
+		});
+
+		it('should block private 10.x.x.x network', () => {
+			expect(() => validateUrlAgainstBlocklist('http://10.0.0.1:3000/api', cloudConfig)).toThrow(
+				/Request blocked/,
+			);
+		});
+
+		it('should block private 192.168.x.x network', () => {
+			expect(() =>
+				validateUrlAgainstBlocklist('http://192.168.1.100:8080/internal', cloudConfig),
+			).toThrow(/Request blocked/);
+		});
+
+		it('should allow public internet URLs', () => {
+			expect(() =>
+				validateUrlAgainstBlocklist('https://api.github.com/repos', cloudConfig),
+			).not.toThrow();
+		});
+
+		it('should allow public IP addresses', () => {
+			expect(() =>
+				validateUrlAgainstBlocklist('http://8.8.8.8/dns-query', cloudConfig),
+			).not.toThrow();
+		});
+	});
+
+	describe('self-hosted scenarios (no blocklist)', () => {
+		it('should allow localhost when no blocklist configured', () => {
+			expect(() => validateUrlAgainstBlocklist('http://localhost:5678/api', '')).not.toThrow();
+		});
+
+		it('should allow 127.0.0.1 when no blocklist configured', () => {
+			expect(() => validateUrlAgainstBlocklist('http://127.0.0.1:5678/healthz', '')).not.toThrow();
+		});
+
+		it('should allow Docker bridge when no blocklist configured', () => {
+			expect(() => validateUrlAgainstBlocklist('http://172.17.0.1:8080/service', '')).not.toThrow();
+		});
+
+		it('should allow private network when no blocklist configured', () => {
+			expect(() => validateUrlAgainstBlocklist('http://192.168.1.50:3000/api', '')).not.toThrow();
+		});
+	});
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export * from './instance-settings';
 export * from './nodes-loader';
 export * from './utils';
 export * from './http-proxy';
+export * from './url-blocklist';
 export { WorkflowHasIssuesError } from './errors/workflow-has-issues.error';
 
 export type * from './interfaces';

--- a/packages/core/src/url-blocklist.ts
+++ b/packages/core/src/url-blocklist.ts
@@ -1,0 +1,147 @@
+import { UnexpectedError } from 'n8n-workflow';
+
+/**
+ * Pattern shortcuts for common URL blocking scenarios.
+ * These expand to specific IP patterns when used in N8N_HTTP_REQUEST_BLOCK.
+ */
+const PATTERN_SHORTCUTS: Record<string, string[]> = {
+	// Cloud metadata endpoints (AWS, GCP, Azure all use this IP)
+	'cloud-metadata': ['169.254.169.254'],
+
+	// All link-local addresses (APIPA - Automatic Private IP Addressing)
+	// Includes cloud metadata endpoint
+	apipa: ['169.254.*'],
+
+	// RFC 1918 private IP ranges
+	'private-ip': [
+		'10.*', // 10.0.0.0/8
+		'172.16.*',
+		'172.17.*',
+		'172.18.*',
+		'172.19.*',
+		'172.20.*',
+		'172.21.*',
+		'172.22.*',
+		'172.23.*',
+		'172.24.*',
+		'172.25.*',
+		'172.26.*',
+		'172.27.*',
+		'172.28.*',
+		'172.29.*',
+		'172.30.*',
+		'172.31.*', // 172.16.0.0/12
+		'192.168.*', // 192.168.0.0/16
+	],
+
+	// Loopback addresses
+	localhost: ['127.*', '::1', 'localhost'],
+};
+
+/**
+ * Expand pattern shortcuts to their actual patterns.
+ * Patterns that are not shortcuts are passed through unchanged.
+ */
+export function expandPatterns(patterns: string[]): string[] {
+	const expanded: string[] = [];
+
+	for (const pattern of patterns) {
+		const trimmed = pattern.trim().toLowerCase();
+		if (!trimmed) continue;
+
+		if (trimmed in PATTERN_SHORTCUTS) {
+			expanded.push(...PATTERN_SHORTCUTS[trimmed]);
+		} else {
+			expanded.push(trimmed);
+		}
+	}
+
+	return expanded;
+}
+
+/**
+ * Check if a hostname/IP matches a pattern.
+ * Supports wildcards (*) at the end of patterns.
+ *
+ * @example
+ * matchesPattern('169.254.169.254', '169.254.*') // true
+ * matchesPattern('10.0.0.1', '10.*') // true
+ * matchesPattern('localhost', 'localhost') // true
+ */
+export function matchesPattern(hostname: string, pattern: string): boolean {
+	const normalizedHostname = hostname.toLowerCase();
+	const normalizedPattern = pattern.toLowerCase();
+
+	// Exact match
+	if (normalizedHostname === normalizedPattern) {
+		return true;
+	}
+
+	// Wildcard match (pattern ends with *)
+	if (normalizedPattern.endsWith('*')) {
+		const prefix = normalizedPattern.slice(0, -1);
+		return normalizedHostname.startsWith(prefix);
+	}
+
+	return false;
+}
+
+/**
+ * Check if a URL's hostname matches any pattern in the blocklist.
+ */
+export function matchesBlocklist(url: string, blocklist: string[]): boolean {
+	let hostname: string;
+
+	try {
+		const parsedUrl = new URL(url);
+		hostname = parsedUrl.hostname.toLowerCase();
+
+		// Handle IPv6 addresses wrapped in brackets
+		if (hostname.startsWith('[') && hostname.endsWith(']')) {
+			hostname = hostname.slice(1, -1);
+		}
+	} catch {
+		// If URL parsing fails, we can't validate it
+		return false;
+	}
+
+	for (const pattern of blocklist) {
+		if (matchesPattern(hostname, pattern)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Validate a URL against the configured blocklist.
+ * Throws an error if the URL matches any blocked pattern.
+ *
+ * @param url - The URL to validate
+ * @param blocklistConfig - Comma-separated blocklist configuration string
+ * @throws {UnexpectedError} If the URL matches a blocked pattern
+ */
+export function validateUrlAgainstBlocklist(url: string, blocklistConfig: string): void {
+	// No blocklist configured = allow all
+	if (!blocklistConfig || blocklistConfig.trim() === '') {
+		return;
+	}
+
+	const patterns = blocklistConfig.split(',').map((p) => p.trim());
+	const expandedPatterns = expandPatterns(patterns);
+
+	if (matchesBlocklist(url, expandedPatterns)) {
+		let hostname: string;
+		try {
+			hostname = new URL(url).hostname;
+		} catch {
+			hostname = url;
+		}
+
+		throw new UnexpectedError(
+			`Request blocked: The URL targets "${hostname}" which matches a blocked pattern. ` +
+				'This is configured via N8N_HTTP_REQUEST_BLOCK for security reasons.',
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Adds configurable URL blocking for HTTP Request node via `N8N_HTTP_REQUEST_BLOCK` environment variable.

**Features:**
- Block specific hosts, IPs, or patterns from being accessed by HTTP Request node
- Pattern shortcuts for common scenarios: `cloud-metadata`, `apipa`, `private-ip`, `localhost`
- Wildcard support (e.g., `169.254.*`, `10.0.0.*`)
- Empty by default (no breaking changes for self-hosted users)

**Example usage:**
```bash
N8N_HTTP_REQUEST_BLOCK=cloud-metadata,apipa,private-ip
```

**How to test:**
1. Set `N8N_HTTP_REQUEST_BLOCK=localhost` environment variable
2. Create a workflow with HTTP Request node targeting `http://localhost:5678`
3. Execute - should see blocked error message
4. Remove env var, retry - should work normally

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-4326

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)