### PR TITLE
chore: Remove error reporting of too large telemetry events

### DIFF
--- a/packages/cli/src/telemetry/index.ts
+++ b/packages/cli/src/telemetry/index.ts
@@ -248,19 +248,6 @@ export class Telemetry {
 		const maxPayloadSize = 32 << 10; // 32 KB
 
 		if (payloadSize > maxPayloadSize) {
-			this.errorReporter.warn(
-				new Error(
-					`Telemetry event "${eventName}" payload size (${payloadSize} bytes) exceeds limit (${maxPayloadSize} bytes). Skipping event.`,
-				),
-				{
-					extra: {
-						eventName,
-						payloadSize,
-						maxPayloadSize,
-						userId: payload.userId,
-					},
-				},
-			);
 			return;
 		}
 


### PR DESCRIPTION
## Summary

Remove error reporting of too large telemetry events. These cause unnecessary noise and eat our quota

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
