### PR TITLE
chore(core): Don't force report external hook failures

### DIFF
--- a/packages/cli/src/__tests__/external-hooks.test.ts
+++ b/packages/cli/src/__tests__/external-hooks.test.ts
@@ -113,16 +113,9 @@ describe('ExternalHooks', () => {
 			externalHooks['registered']['workflow.create'] = [hookFn];
 
 			await expect(externalHooks.run('workflow.create', [workflowData])).rejects.toThrow(error);
-			expect(errorReporter.error).toHaveBeenCalledWith(
-				expect.objectContaining({
-					message: 'External hook "workflow.create" failed',
-					cause: error,
-				}),
-				{ level: 'fatal' },
-			);
-			expect(logger.error).toHaveBeenCalledWith(
-				'There was a problem running hook "workflow.create"',
-			);
+			expect(errorReporter.error).toHaveBeenCalledWith(error, {
+				extra: { hookName: 'workflow.create' },
+			});
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Instead of treating all hook failures as unexpected, respect the original error's properties and base the reporting decision on those. This omits reporting of errors that are e.g. user errors.

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.sentry.io/issues/6291548570/

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
