### PR TITLE
refactor(core): Split title generation and executions handling from Chat hub service

### DIFF
--- a/packages/cli/src/modules/chat-hub/__tests__/chat-hub-models.service.integration.test.ts
+++ b/packages/cli/src/modules/chat-hub/__tests__/chat-hub-models.service.integration.test.ts
@@ -1,3 +1,4 @@
+import type { ChatHubN8nModel } from '@n8n/api-types';
 import {
 	createActiveWorkflow,
 	createWorkflow,
@@ -5,7 +6,6 @@ import {
 	testDb,
 	testModules,
 } from '@n8n/backend-test-utils';
-import assert from 'assert';
 import type { User } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { BinaryDataService } from 'n8n-core';
@@ -105,8 +105,7 @@ describe('ChatHubModelsService', () => {
 				expect(model.name).toBe(agentName);
 				expect(model.description).toBe(agentDescription);
 				expect(model.model.provider).toBe('n8n');
-				assert(model.model.provider === 'n8n');
-				expect(model.model.workflowId).toBeDefined();
+				expect((model.model as ChatHubN8nModel).workflowId).toBeDefined();
 				expect(model.metadata.available).toBe(true);
 			});
 

--- a/packages/cli/src/modules/chat-hub/__tests__/chat-hub-workflow.service.test.ts
+++ b/packages/cli/src/modules/chat-hub/__tests__/chat-hub-workflow.service.test.ts
@@ -1,15 +1,20 @@
-import type { WorkflowRepository, SharedWorkflowRepository } from '@n8n/db';
 import type { Logger } from '@n8n/backend-common';
+import type { WorkflowRepository, SharedWorkflowRepository } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 import type { Cipher, BinaryDataService } from 'n8n-core';
 import type { IBinaryData } from 'n8n-workflow';
 
-import { ChatHubWorkflowService } from '../chat-hub-workflow.service';
+import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
+
+import type { ChatHubAgentService } from '../chat-hub-agent.service';
+import type { ChatHubCredentialsService } from '../chat-hub-credentials.service';
+import type { ChatHubAuthenticationMetadata } from '../chat-hub-extractor';
 import { ChatHubMessage } from '../chat-hub-message.entity';
 import { ChatHubSession } from '../chat-hub-session.entity';
+import { ChatHubWorkflowService } from '../chat-hub-workflow.service';
 import { ChatHubAttachmentService } from '../chat-hub.attachment.service';
+import type { ChatHubSettingsService } from '../chat-hub.settings.service';
 import type { ChatHubMessageRepository } from '../chat-message.repository';
-import type { ChatHubAuthenticationMetadata } from '../chat-hub-extractor';
 
 describe('ChatHubWorkflowService', () => {
 	const logger = mock<Logger>();
@@ -17,6 +22,11 @@ describe('ChatHubWorkflowService', () => {
 	const sharedWorkflowRepository = mock<SharedWorkflowRepository>();
 	const binaryDataService = mock<BinaryDataService>();
 	const messageRepository = mock<ChatHubMessageRepository>();
+	const chatHubAgentService = mock<ChatHubAgentService>();
+	const chatHubSettingsService = mock<ChatHubSettingsService>();
+	const chatHubCredentialsService = mock<ChatHubCredentialsService>();
+	const workflowFinderService = mock<WorkflowFinderService>();
+
 	const mockCipher = mock<Cipher>();
 
 	let chatHubAttachmentService: ChatHubAttachmentService;
@@ -45,6 +55,10 @@ describe('ChatHubWorkflowService', () => {
 			workflowRepository,
 			sharedWorkflowRepository,
 			chatHubAttachmentService,
+			chatHubAgentService,
+			chatHubSettingsService,
+			chatHubCredentialsService,
+			workflowFinderService,
 			mockCipher,
 		);
 

--- a/packages/cli/src/modules/chat-hub/__tests__/chat-hub.service.integration.test.ts
+++ b/packages/cli/src/modules/chat-hub/__tests__/chat-hub.service.integration.test.ts
@@ -4,9 +4,6 @@ import { mockInstance, testDb, testModules, createActiveWorkflow } from '@n8n/ba
 import type { User, CredentialsEntity } from '@n8n/db';
 import { ExecutionRepository, SettingsRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
-import { saveCredential } from '@test-integration/db/credentials';
-import { createAdmin, createMember } from '@test-integration/db/users';
-import { retryUntil } from '@test-integration/retry-until';
 import { mock } from 'jest-mock-extended';
 import { InstanceSettings, BinaryDataService, Cipher } from 'n8n-core';
 import {
@@ -18,9 +15,13 @@ import {
 	type IRun,
 } from 'n8n-workflow';
 
+import { saveCredential } from '@test-integration/db/credentials';
+import { createAdmin, createMember } from '@test-integration/db/users';
+import { retryUntil } from '@test-integration/retry-until';
+
 import { ActiveExecutions } from '../../../active-executions';
-import { ExecutionPersistence } from '../../../executions/execution-persistence';
 import { ChatExecutionManager } from '../../../chat/chat-execution-manager';
+import { ExecutionPersistence } from '../../../executions/execution-persistence';
 import { Push } from '../../../push';
 import { WorkflowExecutionService } from '../../../workflows/workflow-execution.service';
 import { ChatHubAgentRepository } from '../chat-hub-agent.repository';

--- a/packages/cli/src/modules/chat-hub/chat-hub-execution.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-execution.service.ts
@@ -1,0 +1,891 @@
+import { type ChatMessageId, type ChatSessionId, ChatHubConversationModel } from '@n8n/api-types';
+import { Logger } from '@n8n/backend-common';
+import { ExecutionRepository, IExecutionResponse, User } from '@n8n/db';
+import { Service } from '@n8n/di';
+import type { Response } from 'express';
+import { InstanceSettings } from 'n8n-core';
+import {
+	OperationalError,
+	ManualExecutionCancelledError,
+	type INodeCredentials,
+	type IWorkflowBase,
+	jsonParse,
+	jsonStringify,
+	StructuredChunk,
+	IRunExecutionData,
+	type IBinaryData,
+	WorkflowExecuteMode,
+	NodeConnectionTypes,
+	INodeExecutionData,
+	sleep,
+} from 'n8n-workflow';
+import { v4 as uuidv4 } from 'uuid';
+
+import { ActiveExecutions } from '@/active-executions';
+import { ChatExecutionManager } from '@/chat/chat-execution-manager';
+import { ExecutionNotFoundError } from '@/errors/execution-not-found-error';
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { ExecutionService } from '@/executions/execution.service';
+import { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
+
+import { ChatHubTitleService } from './chat-hub-title.service';
+import { ChatHubWorkflowService } from './chat-hub-workflow.service';
+import {
+	EXECUTION_FINISHED_STATUSES,
+	EXECUTION_POLL_INTERVAL,
+	SUPPORTED_RESPONSE_MODES,
+} from './chat-hub.constants';
+import { ChatTriggerResponseMode, NonStreamingResponseMode } from './chat-hub.types';
+import { ChatHubMessageRepository } from './chat-message.repository';
+import { ChatStreamService } from './chat-stream.service';
+import { createStructuredChunkAggregator } from './stream-capturer';
+import { getLastNodeExecuted, shouldResumeImmediately } from '../../chat/utils';
+
+@Service()
+export class ChatHubExecutionService {
+	constructor(
+		private readonly logger: Logger,
+		private readonly executionService: ExecutionService,
+		private readonly workflowExecutionService: WorkflowExecutionService,
+		private readonly executionRepository: ExecutionRepository,
+		private readonly executionManager: ChatExecutionManager,
+		private readonly activeExecutions: ActiveExecutions,
+		private readonly instanceSettings: InstanceSettings,
+		private readonly chatStreamService: ChatStreamService,
+		private readonly chatHubWorkflowService: ChatHubWorkflowService,
+		private readonly messageRepository: ChatHubMessageRepository,
+		private readonly titleService: ChatHubTitleService,
+	) {
+		this.logger = this.logger.scoped('chat-hub');
+	}
+
+	async waitForExecutionCompletion(executionId: string): Promise<void> {
+		if (this.instanceSettings.isMultiMain) {
+			return await this.waitForExecutionPoller(executionId);
+		} else {
+			return await this.waitForExecutionPromise(executionId);
+		}
+	}
+
+	private async waitForExecutionPoller(executionId: string): Promise<void> {
+		return await new Promise<void>((resolve, reject) => {
+			const poller = setInterval(async () => {
+				try {
+					const execution = await this.executionRepository.findSingleExecution(executionId, {
+						includeData: false,
+						unflattenData: false,
+					});
+
+					// Stop polling when execution is done (or missing if instance doesn't save executions)
+					if (!execution || EXECUTION_FINISHED_STATUSES.includes(execution.status)) {
+						this.logger.debug(
+							`Execution ${executionId} finished with status ${execution?.status ?? 'missing'}`,
+						);
+						clearInterval(poller);
+
+						if (execution?.status === 'canceled') {
+							reject(new ManualExecutionCancelledError(executionId));
+						} else {
+							resolve();
+						}
+					}
+				} catch (error) {
+					this.logger.error(`Stopping polling for execution ${executionId} due to error.`);
+					clearInterval(poller);
+
+					if (error instanceof Error) {
+						this.logger.error(`Error while polling execution ${executionId}: ${error.message}`, {
+							error,
+						});
+					} else {
+						this.logger.error(`Unknown error while polling execution ${executionId}`, { error });
+					}
+
+					if (error instanceof Error) {
+						reject(error);
+					} else {
+						reject(new Error('Unknown error while polling execution status'));
+					}
+				}
+			}, EXECUTION_POLL_INTERVAL);
+		});
+	}
+
+	private async waitForExecutionPromise(executionId: string): Promise<void> {
+		try {
+			// Wait until the execution finishes (or errors) so that we don't delete the workflow too early
+			const result = await this.activeExecutions.getPostExecutePromise(executionId);
+			if (!result) {
+				throw new OperationalError('There was a problem executing the chat workflow.');
+			}
+		} catch (error: unknown) {
+			if (error instanceof ExecutionNotFoundError) {
+				return;
+			}
+
+			if (error instanceof ManualExecutionCancelledError) {
+				throw error;
+			}
+
+			if (error instanceof Error) {
+				this.logger.error(`Error during chat workflow execution: ${error}`);
+			}
+			throw error;
+		}
+	}
+
+	/**
+	 * Wait for error details to be available in execution DB using exponential backoff
+	 * @param executionId - The execution ID to fetch error details from
+	 * @param workflowId - The workflow ID for the execution
+	 * @returns The error message if found, undefined otherwise
+	 */
+	private async waitForErrorDetails(
+		executionId: string,
+		workflowId: string,
+	): Promise<string | undefined> {
+		const maxRetries = 5;
+		let retries = 0;
+		let errorText: string | undefined;
+
+		while (!errorText) {
+			try {
+				const execution = await this.executionRepository.findWithUnflattenedData(executionId, [
+					workflowId,
+				]);
+				if (execution && EXECUTION_FINISHED_STATUSES.includes(execution.status)) {
+					errorText = this.getErrorMessage(execution);
+					break;
+				}
+			} catch (error) {
+				this.logger.debug(
+					`Failed to fetch execution ${executionId} for error extraction: ${String(error)}`,
+				);
+			}
+
+			retries++;
+
+			if (maxRetries <= retries) {
+				break;
+			}
+
+			// Wait with exponential backoff (double wait time, cap at 2 second)
+			await sleep(Math.min(500 * Math.pow(2, retries), 2000));
+		}
+
+		return errorText;
+	}
+
+	async execute(user: User, workflowData: IWorkflowBase, executionData: IRunExecutionData) {
+		return await this.workflowExecutionService.executeChatWorkflow(
+			user,
+			workflowData,
+			executionData,
+			undefined,
+			false,
+			'chat',
+		);
+	}
+
+	async stop(executionId: string, workflowId: string) {
+		return await this.executionService.stop(executionId, [workflowId]);
+	}
+
+	/**
+	 * Execute a chat workflow with cleanup and streaming
+	 */
+	async executeChatWorkflowWithCleanup(
+		user: User,
+		model: ChatHubConversationModel,
+		workflowData: IWorkflowBase,
+		executionData: IRunExecutionData,
+		sessionId: ChatSessionId,
+		previousMessageId: ChatMessageId,
+		retryOfMessageId: ChatMessageId | null,
+		responseMode: ChatTriggerResponseMode,
+		originalPreviousMessageId: ChatMessageId | null,
+		credentials: INodeCredentials,
+		humanMessage: string,
+		processedAttachments: IBinaryData[],
+	) {
+		try {
+			const executionMode = model.provider === 'n8n' ? 'webhook' : 'chat';
+
+			await this.executeChatWorkflow(
+				user,
+				model,
+				workflowData,
+				executionData,
+				sessionId,
+				previousMessageId,
+				retryOfMessageId,
+				executionMode,
+				responseMode,
+			);
+		} catch (error) {
+			this.logger.error(`Error in chat execution: ${error}`);
+
+			const errorMessageId = uuidv4();
+			const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+			await this.messageRepository.createAIMessage({
+				id: errorMessageId,
+				sessionId,
+				previousMessageId,
+				content: errorMessage,
+				model,
+				retryOfMessageId,
+				status: 'error',
+			});
+
+			await this.chatStreamService.sendErrorDirect(
+				user.id,
+				sessionId,
+				errorMessageId,
+				errorMessage,
+			);
+			await this.chatStreamService.endExecution(user.id, sessionId, 'error');
+		} finally {
+			if (model.provider !== 'n8n') {
+				await this.chatHubWorkflowService.deleteChatWorkflow(workflowData.id);
+			}
+		}
+
+		// Generate title for the session on receiving the first human message
+		if (originalPreviousMessageId === null && humanMessage) {
+			try {
+				await this.titleService.generateSessionTitle(
+					user,
+					sessionId,
+					humanMessage,
+					processedAttachments,
+					credentials,
+					model,
+				);
+			} catch (error) {
+				this.logger.warn(`Title generation failed: ${error}`);
+			}
+		}
+	}
+
+	/**
+	 * Execute a chat workflow
+	 */
+	private async executeChatWorkflow(
+		user: User,
+		model: ChatHubConversationModel,
+		workflowData: IWorkflowBase,
+		executionData: IRunExecutionData,
+		sessionId: ChatSessionId,
+		previousMessageId: ChatMessageId,
+		retryOfMessageId: ChatMessageId | null,
+		executionMode: WorkflowExecuteMode,
+		responseMode: ChatTriggerResponseMode,
+	) {
+		this.logger.debug(
+			`Starting execution of workflow "${workflowData.name}" with ID ${workflowData.id}`,
+		);
+
+		if (!SUPPORTED_RESPONSE_MODES.includes(responseMode)) {
+			throw new BadRequestError(`Response mode "${responseMode}" is not supported yet.`);
+		}
+
+		if (responseMode === 'lastNode' || responseMode === 'responseNodes') {
+			return await this.executeLastNode(
+				user,
+				model,
+				workflowData,
+				executionData,
+				sessionId,
+				previousMessageId,
+				retryOfMessageId,
+				executionMode,
+				responseMode,
+			);
+		} else if (responseMode === 'streaming') {
+			return await this.executeWithStreaming(
+				user,
+				model,
+				workflowData,
+				executionData,
+				sessionId,
+				previousMessageId,
+				retryOfMessageId,
+				executionMode,
+			);
+		}
+	}
+
+	/**
+	 * Execute a workflow with streaming output
+	 */
+	private async executeWithStreaming(
+		user: User,
+		model: ChatHubConversationModel,
+		workflowData: IWorkflowBase,
+		executionData: IRunExecutionData,
+		sessionId: string,
+		previousMessageId: string,
+		retryOfMessageId: string | null,
+		executionMode: WorkflowExecuteMode,
+	) {
+		let executionId: string | undefined;
+		let executionStatus: 'success' | 'error' | 'cancelled' = 'success';
+
+		const workflowId = workflowData.id;
+
+		// Start the execution (tracks state for the whole streaming session)
+		await this.chatStreamService.startExecution(user.id, sessionId);
+
+		// Create aggregator to handle multiple messages (e.g., tool calls followed by response)
+		const aggregator = createStructuredChunkAggregator(previousMessageId, retryOfMessageId, {
+			onBegin: async (message) => {
+				// Save the AI message to DB
+				await this.messageRepository.createAIMessage({
+					id: message.id,
+					sessionId,
+					previousMessageId: message.previousMessageId ?? previousMessageId,
+					content: '',
+					model,
+					executionId,
+					retryOfMessageId: message.retryOfMessageId,
+					status: 'running',
+				});
+
+				// Start the stream for this message
+				await this.chatStreamService.startStream({
+					userId: user.id,
+					sessionId,
+					messageId: message.id,
+					previousMessageId: message.previousMessageId,
+					retryOfMessageId: message.retryOfMessageId,
+					executionId: executionId ? parseInt(executionId, 10) : null,
+				});
+			},
+			onItem: async (message, chunk) => {
+				await this.chatStreamService.sendChunk(sessionId, message.id, chunk);
+			},
+			onEnd: async (message) => {
+				// Update the message in the database
+				await this.messageRepository.updateChatMessage(message.id, {
+					content: message.content,
+					status: message.status,
+				});
+
+				// End the stream for this message
+				await this.chatStreamService.endStream(sessionId, message.id, message.status);
+			},
+			onError: async (message, errorText) => {
+				let contentToSave = message.content;
+				if (!contentToSave && errorText) {
+					contentToSave = errorText;
+				} else if (!contentToSave) {
+					contentToSave = executionId
+						? ((await this.waitForErrorDetails(executionId, workflowId)) ?? 'Unknown error')
+						: 'Request was not processed';
+				}
+
+				await this.messageRepository.manager.transaction(async (trx) => {
+					await this.messageRepository.updateChatMessage(
+						message.id,
+						{ content: contentToSave },
+						trx,
+					);
+
+					// When messages are cancelled they're already marked cancelled on `stopGeneration`
+					const savedMessage = await this.messageRepository.getOneById(
+						message.id,
+						sessionId,
+						[],
+						trx,
+					);
+					if (savedMessage?.status === 'cancelled') {
+						executionStatus = 'cancelled';
+						// End the stream with cancelled status
+						await this.chatStreamService.endStream(sessionId, message.id, 'cancelled');
+						return;
+					}
+
+					// Otherwise mark them as errored
+					executionStatus = 'error';
+					await this.messageRepository.updateChatMessage(message.id, { status: 'error' }, trx);
+
+					await this.chatStreamService.sendError(sessionId, message.id, contentToSave);
+					await this.chatStreamService.endStream(sessionId, message.id, 'error');
+				});
+			},
+			onCancel: async (message) => {
+				// Save content that was generated so far
+				await this.messageRepository.updateChatMessage(message.id, {
+					content: message.content,
+					status: 'cancelled',
+				});
+
+				// End stream with cancelled status
+				await this.chatStreamService.endStream(sessionId, message.id, 'cancelled');
+			},
+		});
+
+		// Create a fake Response-like object that routes to ChatStreamService via aggregator
+		const { adapter: streamAdapter, waitForPendingOperations } =
+			this.createStreamAdapter(aggregator);
+
+		try {
+			const execution = await this.workflowExecutionService.executeChatWorkflow(
+				user,
+				workflowData,
+				executionData,
+				streamAdapter,
+				true,
+				executionMode,
+			);
+
+			executionId = execution.executionId;
+
+			if (!executionId) {
+				throw new OperationalError('There was a problem starting the chat execution.');
+			}
+
+			await this.waitForExecutionCompletion(executionId);
+
+			// Wait for all pending aggregator operations to complete (message status updates, etc.)
+			await waitForPendingOperations();
+		} catch (error) {
+			if (error instanceof ManualExecutionCancelledError) {
+				executionStatus = 'cancelled';
+				// On multi-main, the stream doesn't send an error chunk on cancellation,
+				// so we need to explicitly cancel all active messages.
+				// On single-main, the onError handler already handles this via the error chunk.
+				if (this.instanceSettings.isMultiMain) {
+					await aggregator.cancelAll();
+				}
+			} else {
+				executionStatus = 'error';
+				throw error;
+			}
+		} finally {
+			// Wait for pending operations even on error to ensure proper cleanup
+			await waitForPendingOperations();
+			// End the execution (cleanup session state)
+			await this.chatStreamService.endExecution(user.id, sessionId, executionStatus);
+		}
+	}
+
+	/**
+	 * Execute a workflow and wait for completion (for lastNode and responseNodes modes)
+	 */
+	private async executeLastNode(
+		user: User,
+		model: ChatHubConversationModel,
+		workflowData: IWorkflowBase,
+		executionData: IRunExecutionData,
+		sessionId: string,
+		previousMessageId: string,
+		retryOfMessageId: string | null,
+		executionMode: WorkflowExecuteMode,
+		responseMode: NonStreamingResponseMode,
+	) {
+		const running = await this.workflowExecutionService.executeChatWorkflow(
+			user,
+			workflowData,
+			executionData,
+			undefined,
+			false,
+			executionMode,
+		);
+
+		const messageId = uuidv4();
+		const executionId = running.executionId;
+
+		if (!executionId) {
+			throw new OperationalError('There was a problem starting the chat execution.');
+		}
+
+		// Start the execution via WebSocket
+		await this.chatStreamService.startExecution(user.id, sessionId);
+
+		// Save the AI message as running
+		await this.messageRepository.createAIMessage({
+			id: messageId,
+			content: '',
+			sessionId,
+			executionId,
+			model,
+			previousMessageId,
+			retryOfMessageId,
+			status: 'running',
+		});
+
+		// Send begin event via WebSocket
+		await this.chatStreamService.startStream({
+			userId: user.id,
+			sessionId,
+			messageId,
+			previousMessageId,
+			retryOfMessageId,
+			executionId: parseInt(executionId, 10),
+		});
+
+		try {
+			await this.waitForExecutionCompletion(executionId);
+			const execution = await this.executionRepository.findSingleExecution(executionId, {
+				includeData: true,
+				unflattenData: true,
+			});
+			if (!execution) {
+				throw new OperationalError(
+					'Chat execution not found after completion - make sure your instance is saving executions.',
+				);
+			}
+
+			// Check for execution errors
+			if (!['success', 'waiting', 'canceled'].includes(execution.status)) {
+				const errorMessage = this.getErrorMessage(execution) ?? 'Failed to generate a response';
+				throw new OperationalError(errorMessage);
+			}
+
+			const message = this.getMessageFromExecution(execution, responseMode);
+			const status = execution?.status === 'waiting' ? 'waiting' : 'success';
+
+			// Send the message content via WebSocket
+			if (message) {
+				await this.chatStreamService.sendChunk(sessionId, messageId, message);
+			}
+
+			// Update message in DB
+			await this.messageRepository.updateChatMessage(messageId, {
+				content: message ?? '',
+				status,
+			});
+
+			// End the stream
+			await this.chatStreamService.endStream(sessionId, messageId, status);
+
+			// End the execution
+			await this.chatStreamService.endExecution(
+				user.id,
+				sessionId,
+				status === 'waiting' ? 'success' : status,
+			);
+
+			if (status === 'waiting' && responseMode === 'responseNodes') {
+				const lastNode = getLastNodeExecuted(execution);
+				if (lastNode && shouldResumeImmediately(lastNode)) {
+					this.logger.debug(
+						`Resuming execution ${execution.id} immediately after wait in node ${lastNode.name}`,
+					);
+					await this.resumeChatExecution(
+						execution,
+						'',
+						sessionId,
+						user,
+						messageId,
+						model,
+						responseMode,
+					);
+				}
+			}
+		} catch (e: unknown) {
+			if (e instanceof ManualExecutionCancelledError) {
+				// When messages are cancelled they're already marked cancelled on `stopGeneration`
+				await this.chatStreamService.endExecution(user.id, sessionId, 'cancelled');
+				return;
+			}
+
+			const errorMessage =
+				e instanceof Error ? e.message : 'Unknown error occurred during chat execution';
+
+			// Update message with error
+			await this.messageRepository.updateChatMessage(messageId, {
+				content: errorMessage,
+				status: 'error',
+			});
+
+			// Send error via WebSocket
+			await this.chatStreamService.sendChunk(sessionId, messageId, errorMessage);
+			await this.chatStreamService.endStream(sessionId, messageId, 'error');
+			await this.chatStreamService.endExecution(user.id, sessionId, 'error');
+		}
+	}
+
+	/**
+	 * Resume a chat execution (for responseNodes mode when execution is waiting)
+	 */
+	async resumeChatExecution(
+		execution: IExecutionResponse,
+		message: string,
+		sessionId: ChatSessionId,
+		user: User,
+		previousMessageId: ChatMessageId,
+		model: ChatHubConversationModel,
+		responseMode: 'responseNodes',
+	) {
+		let currentExecution = execution;
+		let currentMessage = message;
+		let currentPreviousMessageId = previousMessageId;
+
+		while (true) {
+			await this.resumeExecution(sessionId, currentExecution, currentMessage);
+			const messageId = uuidv4();
+
+			// Start new stream for the resumed execution
+			await this.chatStreamService.startExecution(user.id, sessionId);
+
+			// Save the AI message as running
+			await this.messageRepository.createAIMessage({
+				id: messageId,
+				content: '',
+				sessionId,
+				executionId: currentExecution.id,
+				model,
+				previousMessageId: currentPreviousMessageId,
+				retryOfMessageId: null,
+				status: 'running',
+			});
+
+			await this.chatStreamService.startStream({
+				userId: user.id,
+				sessionId,
+				messageId,
+				previousMessageId: currentPreviousMessageId,
+				retryOfMessageId: null,
+				executionId: parseInt(currentExecution.id, 10),
+			});
+
+			await this.waitForExecutionCompletion(currentExecution.id);
+
+			const completed = await this.executionRepository.findSingleExecution(currentExecution.id, {
+				includeData: true,
+				unflattenData: true,
+			});
+
+			if (!completed) {
+				throw new OperationalError(
+					'Chat execution not found after completion - make sure your instance is saving executions.',
+				);
+			}
+
+			if (!['success', 'waiting', 'canceled'].includes(completed.status)) {
+				const errorMessage = this.getErrorMessage(completed) ?? 'Failed to generate a response';
+				throw new OperationalError(errorMessage);
+			}
+
+			const reply = this.getMessageFromExecution(completed, responseMode);
+			const status = completed?.status === 'waiting' ? 'waiting' : 'success';
+
+			// Send the message content via WebSocket
+			if (reply) {
+				await this.chatStreamService.sendChunk(sessionId, messageId, reply);
+			}
+
+			// Update message in DB
+			await this.messageRepository.updateChatMessage(messageId, {
+				content: reply ?? '',
+				status,
+			});
+
+			// End the stream
+			await this.chatStreamService.endStream(sessionId, messageId, status);
+			await this.chatStreamService.endExecution(
+				user.id,
+				sessionId,
+				status === 'waiting' ? 'success' : status,
+			);
+
+			const lastNode = getLastNodeExecuted(completed);
+			if (status === 'waiting' && lastNode && shouldResumeImmediately(lastNode)) {
+				// Resuming execution immediately, so mark the last message as successful
+				this.logger.debug(
+					`Resuming execution ${completed.id} immediately after wait in node ${lastNode.name}`,
+				);
+				await this.messageRepository.updateChatMessage(messageId, {
+					status: 'success',
+				});
+
+				// There's no new human input
+				currentMessage = '';
+				currentExecution = completed;
+				currentPreviousMessageId = messageId;
+			} else {
+				// Finished or waiting for user input
+				return;
+			}
+		}
+	}
+
+	/**
+	 * Resume a paused execution with new input
+	 */
+	private async resumeExecution(
+		sessionId: ChatSessionId,
+		execution: IExecutionResponse,
+		message: string,
+	) {
+		await this.executionManager.runWorkflow(execution, {
+			action: 'sendMessage',
+			chatInput: message,
+			sessionId,
+		});
+	}
+
+	getErrorMessage(execution: IExecutionResponse): string | undefined {
+		if (execution.data.resultData.error) {
+			return execution.data.resultData.error.description ?? execution.data.resultData.error.message;
+		}
+
+		return undefined;
+	}
+
+	getAIOutput(execution: IExecutionResponse, nodeName: string): string | undefined {
+		const agent = execution.data.resultData.runData[nodeName];
+		if (!agent || !Array.isArray(agent) || agent.length === 0) return undefined;
+
+		const runIndex = agent.length - 1;
+		const mainOutputs = agent[runIndex].data?.main;
+
+		// Check all main output branches for a message
+		if (mainOutputs && Array.isArray(mainOutputs)) {
+			for (const branch of mainOutputs) {
+				if (branch && Array.isArray(branch) && branch.length > 0 && branch[0].json?.output) {
+					if (typeof branch[0].json.output === 'string') {
+						return branch[0].json.output;
+					}
+				}
+			}
+		}
+
+		return undefined;
+	}
+
+	/**
+	 * Returns the message from the last executed node
+	 */
+	private getMessageFromExecution(
+		execution: IExecutionResponse,
+		responseMode: ChatTriggerResponseMode,
+	) {
+		const nodeName = this.getLastNodeExecutedName(execution);
+		if (!nodeName) return undefined;
+
+		const outputs = this.getNodeOutputs(execution, nodeName);
+		const entry = this.getFirstOutputEntry(outputs);
+		if (!entry) return undefined;
+
+		const message = this.extractMessageFromEntry(entry, responseMode);
+		if (typeof message === 'object' && message !== null) {
+			return jsonStringify(message);
+		}
+
+		return message;
+	}
+
+	private getLastNodeExecutedName(execution: IExecutionResponse): string | undefined {
+		const lastNodeExecuted = execution.data.resultData.lastNodeExecuted;
+		return typeof lastNodeExecuted === 'string' ? lastNodeExecuted : undefined;
+	}
+
+	private getNodeOutputs(execution: IExecutionResponse, nodeName: string) {
+		const runData = execution.data.resultData.runData[nodeName];
+		if (!runData || runData.length === 0) return [];
+		const runIndex = runData.length - 1;
+		const data = runData[runIndex]?.data;
+
+		return data?.main ?? data?.[NodeConnectionTypes.AiTool] ?? [];
+	}
+
+	private getFirstOutputEntry(
+		outputs: Array<INodeExecutionData[] | null>,
+	): INodeExecutionData | undefined {
+		for (const branch of outputs) {
+			if (!Array.isArray(branch) || branch.length === 0) continue;
+
+			return branch[0];
+		}
+
+		return undefined;
+	}
+
+	private extractMessageFromEntry(
+		entry: INodeExecutionData,
+		responseMode: ChatTriggerResponseMode,
+	) {
+		if (responseMode === 'responseNodes') {
+			return entry.sendMessage ?? '';
+		}
+
+		if (responseMode === 'lastNode') {
+			const response: Record<string, unknown> = entry.json ?? {};
+			const message = response.output ?? response.text ?? response.message ?? '';
+			return typeof message === 'string' ? message : jsonStringify(message);
+		}
+
+		return undefined;
+	}
+
+	/**
+	 * Create a Response-like object that routes streaming data to ChatStreamService via aggregator
+	 * Returns both the adapter and a function to wait for all pending operations to complete
+	 */
+	private createStreamAdapter(aggregator: ReturnType<typeof createStructuredChunkAggregator>): {
+		adapter: Response;
+		waitForPendingOperations: () => Promise<void>;
+	} {
+		// Chain for sequential processing of chunks to avoid race conditions
+		// Each chunk must complete before the next one starts (e.g., 'begin' must finish
+		// setting up the message before 'item' or 'end' tries to use it)
+		let processingChain = Promise.resolve();
+
+		// Create a minimal Response-like object
+		const adapter = {
+			headersSent: false,
+			writableEnded: false,
+
+			writeHead: (_statusCode: number, _headers?: Record<string, string>) => {
+				adapter.headersSent = true;
+				return adapter;
+			},
+
+			flushHeaders: () => {},
+
+			write: (chunk: string | Buffer, _encoding?: BufferEncoding, doneCb?: () => void) => {
+				const text = Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk;
+
+				// Process each line (JSONL format) through the aggregator
+				const lines = text.split('\n').filter((line) => line.trim());
+				for (const line of lines) {
+					try {
+						const parsed = jsonParse<StructuredChunk>(line.trim());
+						// Chain the ingest calls to ensure sequential processing
+						// This prevents race conditions where 'item' arrives before 'begin' finishes
+						processingChain = processingChain.then(async () => {
+							await aggregator.ingest(parsed);
+						});
+					} catch {
+						// Not valid JSON, ignore
+					}
+				}
+
+				if (doneCb) doneCb();
+				return true;
+			},
+
+			end: (_chunk?: unknown, _encoding?: BufferEncoding, doneCb?: () => void) => {
+				adapter.writableEnded = true;
+				if (doneCb) doneCb();
+				return adapter;
+			},
+
+			flush: () => {},
+
+			on: (_event: string, _handler: (...args: unknown[]) => void) => adapter,
+			once: (_event: string, _handler: (...args: unknown[]) => void) => adapter,
+			emit: (_event: string, ..._args: unknown[]) => true,
+		};
+
+		const waitForPendingOperations = async () => {
+			await processingChain;
+		};
+
+		return { adapter: adapter as unknown as Response, waitForPendingOperations };
+	}
+}

--- a/packages/cli/src/modules/chat-hub/chat-hub-title.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-title.service.ts
@@ -30,14 +30,12 @@ import { ChatHubCredentialsService } from './chat-hub-credentials.service';
 import { ChatHubExecutionService } from './chat-hub-execution.service';
 import { ChatHubWorkflowService } from './chat-hub-workflow.service';
 import { NODE_NAMES, PROVIDER_NODE_TYPE_MAP } from './chat-hub.constants';
-import { ChatHubMessageRepository } from './chat-message.repository';
 import { ChatHubSessionRepository } from './chat-session.repository';
 
 @Service()
 export class ChatHubTitleService {
 	constructor(
 		private readonly logger: Logger,
-		private readonly messageRepository: ChatHubMessageRepository,
 		private readonly chatHubWorkflowService: ChatHubWorkflowService,
 		private readonly chatHubCredentialsService: ChatHubCredentialsService,
 		private readonly workflowFinderService: WorkflowFinderService,
@@ -84,7 +82,7 @@ export class ChatHubTitleService {
 		incomingCredentials: INodeCredentials,
 		incomingModel: ChatHubConversationModel,
 	) {
-		return await this.messageRepository.manager.transaction(async (trx) => {
+		return await this.sessionRepository.manager.transaction(async (trx) => {
 			const { resolvedCredentials, resolvedModel, credentialId, projectId } =
 				await this.resolveCredentialsAndModelForTitle(
 					user,

--- a/packages/cli/src/modules/chat-hub/chat-hub-title.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-title.service.ts
@@ -1,0 +1,304 @@
+import {
+	PROVIDER_CREDENTIAL_TYPE_MAP,
+	type ChatHubLLMProvider,
+	type ChatSessionId,
+	ChatHubConversationModel,
+	ChatHubN8nModel,
+	ChatHubCustomAgentModel,
+} from '@n8n/api-types';
+import { Logger } from '@n8n/backend-common';
+import { ExecutionRepository, User } from '@n8n/db';
+import type { EntityManager } from '@n8n/db';
+import { Service } from '@n8n/di';
+import {
+	OperationalError,
+	type INodeCredentials,
+	type IWorkflowBase,
+	jsonStringify,
+	IRunExecutionData,
+	INodeParameters,
+	INode,
+	type IBinaryData,
+	UserError,
+} from 'n8n-workflow';
+
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
+
+import { ChatHubAgentService } from './chat-hub-agent.service';
+import { ChatHubCredentialsService } from './chat-hub-credentials.service';
+import { ChatHubExecutionService } from './chat-hub-execution.service';
+import { ChatHubWorkflowService } from './chat-hub-workflow.service';
+import { NODE_NAMES, PROVIDER_NODE_TYPE_MAP } from './chat-hub.constants';
+import { ChatHubMessageRepository } from './chat-message.repository';
+import { ChatHubSessionRepository } from './chat-session.repository';
+
+@Service()
+export class ChatHubTitleService {
+	constructor(
+		private readonly logger: Logger,
+		private readonly messageRepository: ChatHubMessageRepository,
+		private readonly chatHubWorkflowService: ChatHubWorkflowService,
+		private readonly chatHubCredentialsService: ChatHubCredentialsService,
+		private readonly workflowFinderService: WorkflowFinderService,
+		private readonly executionService: ChatHubExecutionService,
+		private readonly sessionRepository: ChatHubSessionRepository,
+		private readonly executionRepository: ExecutionRepository,
+		private readonly chatHubAgentService: ChatHubAgentService,
+	) {
+		this.logger = this.logger.scoped('chat-hub');
+	}
+
+	async generateSessionTitle(
+		user: User,
+		sessionId: ChatSessionId,
+		humanMessage: string,
+		attachments: IBinaryData[],
+		credentials: INodeCredentials,
+		model: ChatHubConversationModel,
+	) {
+		const { executionData, workflowData } = await this.prepareTitleGenerationWorkflow(
+			user,
+			sessionId,
+			humanMessage,
+			attachments,
+			credentials,
+			model,
+		);
+
+		try {
+			const title = await this.runTitleWorkflowAndGetTitle(user, workflowData, executionData);
+			if (title) {
+				await this.sessionRepository.updateChatSession(sessionId, { title });
+			}
+		} finally {
+			await this.chatHubWorkflowService.deleteChatWorkflow(workflowData.id);
+		}
+	}
+
+	private async prepareTitleGenerationWorkflow(
+		user: User,
+		sessionId: ChatSessionId,
+		humanMessage: string,
+		attachments: IBinaryData[],
+		incomingCredentials: INodeCredentials,
+		incomingModel: ChatHubConversationModel,
+	) {
+		return await this.messageRepository.manager.transaction(async (trx) => {
+			const { resolvedCredentials, resolvedModel, credentialId, projectId } =
+				await this.resolveCredentialsAndModelForTitle(
+					user,
+					incomingModel,
+					incomingCredentials,
+					trx,
+				);
+
+			if (!credentialId || !projectId) {
+				throw new BadRequestError('Could not determine credentials for title generation');
+			}
+
+			this.logger.debug(
+				`Using credential ID ${credentialId} for title generation in project ${projectId}, model ${jsonStringify(resolvedModel)}`,
+			);
+
+			return await this.chatHubWorkflowService.createTitleGenerationWorkflow(
+				user.id,
+				sessionId,
+				projectId,
+				humanMessage,
+				attachments,
+				resolvedCredentials,
+				resolvedModel,
+				trx,
+			);
+		});
+	}
+
+	private async runTitleWorkflowAndGetTitle(
+		user: User,
+		workflowData: IWorkflowBase,
+		executionData: IRunExecutionData,
+	): Promise<string | null> {
+		const { executionId } = await this.executionService.execute(user, workflowData, executionData);
+
+		await this.executionService.waitForExecutionCompletion(executionId);
+
+		const execution = await this.executionRepository.findWithUnflattenedData(executionId, [
+			workflowData.id,
+		]);
+
+		if (!execution) {
+			throw new OperationalError(`Could not find execution with ID ${executionId}`);
+		}
+
+		if (!execution.status || execution.status !== 'success') {
+			const message =
+				this.executionService.getErrorMessage(execution) ?? 'Failed to generate a response';
+			throw new OperationalError(message);
+		}
+
+		const title = this.executionService.getAIOutput(execution, NODE_NAMES.TITLE_GENERATOR_AGENT);
+		return title ?? null;
+	}
+
+	private async resolveCredentialsAndModelForTitle(
+		user: User,
+		model: ChatHubConversationModel,
+		credentials: INodeCredentials,
+		trx: EntityManager,
+	): Promise<{
+		resolvedCredentials: INodeCredentials;
+		resolvedModel: ChatHubConversationModel;
+		credentialId: string;
+		projectId: string;
+	}> {
+		if (model.provider === 'n8n') {
+			return await this.resolveFromN8nWorkflow(user, model, trx);
+		}
+
+		if (model.provider === 'custom-agent') {
+			return await this.resolveFromCustomAgent(user, model, trx);
+		}
+
+		const credentialId = this.chatHubCredentialsService.findProviderCredential(
+			model.provider,
+			credentials,
+		);
+
+		const { id: projectId } = await this.chatHubCredentialsService.findPersonalProject(user, trx);
+
+		return {
+			resolvedCredentials: credentials,
+			resolvedModel: model,
+			credentialId,
+			projectId,
+		};
+	}
+
+	private async resolveFromN8nWorkflow(
+		user: User,
+		{ workflowId }: ChatHubN8nModel,
+		trx: EntityManager,
+	): Promise<{
+		resolvedCredentials: INodeCredentials;
+		resolvedModel: ChatHubConversationModel;
+		credentialId: string;
+		projectId: string;
+	}> {
+		const workflowEntity = await this.workflowFinderService.findWorkflowForUser(
+			workflowId,
+			user,
+			['workflow:execute-chat'],
+			{ includeTags: false, includeParentFolder: false, includeActiveVersion: true, em: trx },
+		);
+
+		if (!workflowEntity?.activeVersion) {
+			throw new UserError('Workflow not found for title generation');
+		}
+
+		const modelNodes = this.findSupportedLLMNodes(workflowEntity.activeVersion.nodes);
+		this.logger.debug(
+			`Found ${modelNodes.length} LLM nodes in workflow ${workflowEntity.id} for title generation`,
+		);
+
+		if (modelNodes.length === 0) {
+			throw new UserError('No supported Model nodes found in workflow for title generation');
+		}
+
+		const modelNode = modelNodes[0];
+		const llmModel = (modelNode.node.parameters?.model as INodeParameters)?.value;
+		if (!llmModel) {
+			throw new UserError(
+				`No model set on Model node "${modelNode.node.name}" for title generation`,
+			);
+		}
+
+		if (typeof llmModel !== 'string' || llmModel.length === 0 || llmModel.startsWith('=')) {
+			throw new UserError(
+				`Invalid model set on Model node "${modelNode.node.name}" for title generation`,
+			);
+		}
+
+		const llmCredentials = modelNode.node.credentials;
+		if (!llmCredentials) {
+			throw new UserError(
+				`No credentials found on Model node "${modelNode.node.name}" for title generation`,
+			);
+		}
+
+		const { credentialId, projectId } =
+			await this.chatHubCredentialsService.findWorkflowCredentialAndProject(
+				modelNode.provider,
+				llmCredentials,
+				workflowId,
+			);
+
+		const resolvedModel: ChatHubConversationModel = {
+			provider: modelNode.provider,
+			model: llmModel,
+		};
+
+		const resolvedCredentials: INodeCredentials = {
+			[PROVIDER_CREDENTIAL_TYPE_MAP[modelNode.provider]]: {
+				id: credentialId,
+				name: '',
+			},
+		};
+
+		return { resolvedCredentials, resolvedModel, credentialId, projectId };
+	}
+
+	private findSupportedLLMNodes(nodes: INode[]) {
+		return nodes.reduce<Array<{ node: INode; provider: ChatHubLLMProvider }>>((acc, node) => {
+			const supportedProvider = Object.entries(PROVIDER_NODE_TYPE_MAP).find(
+				([_provider, { name }]) => node.type === name,
+			);
+			if (supportedProvider) {
+				const [provider] = supportedProvider;
+				acc.push({ node, provider: provider as ChatHubLLMProvider });
+			}
+			return acc;
+		}, []);
+	}
+
+	private async resolveFromCustomAgent(
+		user: User,
+		model: ChatHubCustomAgentModel,
+		trx: EntityManager,
+	): Promise<{
+		resolvedCredentials: INodeCredentials;
+		resolvedModel: ChatHubConversationModel;
+		credentialId: string;
+		projectId: string;
+	}> {
+		const agent = await this.chatHubAgentService.getAgentById(model.agentId, user.id, trx);
+		if (!agent) {
+			throw new BadRequestError('Agent not found for title generation');
+		}
+
+		if (!agent.credentialId) {
+			throw new BadRequestError('Credentials not set for agent');
+		}
+
+		const resolvedModel: ChatHubConversationModel = {
+			provider: agent.provider,
+			model: agent.model,
+		};
+
+		const resolvedCredentials: INodeCredentials = {
+			[PROVIDER_CREDENTIAL_TYPE_MAP[agent.provider]]: {
+				id: agent.credentialId,
+				name: '',
+			},
+		};
+
+		const credentialId = this.chatHubCredentialsService.findProviderCredential(
+			agent.provider,
+			resolvedCredentials,
+		);
+
+		const { id: projectId } = await this.chatHubCredentialsService.findPersonalProject(user, trx);
+
+		return { resolvedCredentials, resolvedModel, credentialId, projectId };
+	}
+}

--- a/packages/cli/src/modules/chat-hub/chat-hub-workflow.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-workflow.service.ts
@@ -57,6 +57,10 @@ export class ChatHubWorkflowService {
 		this.logger = this.logger.scoped('chat-hub');
 	}
 
+	async deleteChatWorkflow(workflowId: string): Promise<void> {
+		await this.workflowRepository.delete(workflowId);
+	}
+
 	async createChatWorkflow(
 		userId: string,
 		sessionId: ChatSessionId,

--- a/packages/cli/src/modules/chat-hub/chat-hub-workflow.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-workflow.service.ts
@@ -1,6 +1,7 @@
 import {
 	ChatHubConversationModel,
 	ChatSessionId,
+	PROVIDER_CREDENTIAL_TYPE_MAP,
 	type ChatHubBaseLLMModel,
 	type ChatHubInputModality,
 	type ChatModelMetadataDto,
@@ -9,6 +10,7 @@ import { Logger } from '@n8n/backend-common';
 import {
 	SharedWorkflow,
 	SharedWorkflowRepository,
+	User,
 	withTransaction,
 	WorkflowEntity,
 	WorkflowRepository,
@@ -18,6 +20,7 @@ import { EntityManager } from '@n8n/typeorm';
 import { DateTime } from 'luxon';
 import { Cipher } from 'n8n-core';
 import {
+	CHAT_NODE_TYPE,
 	AGENT_LANGCHAIN_NODE_TYPE,
 	CHAT_TRIGGER_NODE_TYPE,
 	createRunExecutionData,
@@ -37,11 +40,30 @@ import {
 } from 'n8n-workflow';
 import { v4 as uuidv4 } from 'uuid';
 
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
+
+import { ChatHubAgentService } from './chat-hub-agent.service';
+import { ChatHubCredentialsService } from './chat-hub-credentials.service';
 import { CHATHUB_EXTRACTOR_NAME, ChatHubAuthenticationMetadata } from './chat-hub-extractor';
 import { ChatHubMessage } from './chat-hub-message.entity';
 import { ChatHubAttachmentService } from './chat-hub.attachment.service';
-import { getModelMetadata, NODE_NAMES, PROVIDER_NODE_TYPE_MAP } from './chat-hub.constants';
-import { MessageRecord, type ContentBlock, type ChatTriggerResponseMode } from './chat-hub.types';
+import {
+	CHAT_TRIGGER_NODE_MIN_VERSION,
+	getModelMetadata,
+	NODE_NAMES,
+	PROVIDER_NODE_TYPE_MAP,
+	SUPPORTED_RESPONSE_MODES,
+	TOOLS_AGENT_NODE_MIN_VERSION,
+} from './chat-hub.constants';
+import { ChatHubSettingsService } from './chat-hub.settings.service';
+import {
+	chatTriggerParamsShape,
+	MessageRecord,
+	PreparedChatWorkflow,
+	type ContentBlock,
+	type ChatTriggerResponseMode,
+} from './chat-hub.types';
 import { getMaxContextWindowTokens } from './context-limits';
 import { inE2ETests } from '../../constants';
 
@@ -52,6 +74,10 @@ export class ChatHubWorkflowService {
 		private readonly workflowRepository: WorkflowRepository,
 		private readonly sharedWorkflowRepository: SharedWorkflowRepository,
 		private readonly chatHubAttachmentService: ChatHubAttachmentService,
+		private readonly chatHubAgentService: ChatHubAgentService,
+		private readonly chatHubSettingsService: ChatHubSettingsService,
+		private readonly chatHubCredentialsService: ChatHubCredentialsService,
+		private readonly workflowFinderService: WorkflowFinderService,
 		private readonly cipher: Cipher,
 	) {
 		this.logger = this.logger.scoped('chat-hub');
@@ -190,55 +216,6 @@ export class ChatHubWorkflowService {
 				executionData,
 			};
 		});
-	}
-
-	prepareExecutionData(
-		triggerNode: INode,
-		sessionId: string,
-		message: string,
-		attachments: IBinaryData[],
-		executionMetadata: ChatHubAuthenticationMetadata,
-	): IExecuteData[] {
-		const encryptedMetadata = this.cipher.encrypt(executionMetadata);
-		// Attachments are already processed (id field populated) by the caller
-		return [
-			{
-				node: {
-					...triggerNode,
-					parameters: {
-						...triggerNode.parameters,
-						executionsHooksVersion: 1,
-						contextEstablishmentHooks: {
-							hooks: [
-								{
-									hookName: CHATHUB_EXTRACTOR_NAME,
-									isAllowedToFail: true,
-								},
-							],
-						},
-					},
-				},
-				data: {
-					main: [
-						[
-							{
-								encryptedMetadata,
-								json: {
-									sessionId,
-									action: 'sendMessage',
-									chatInput: message,
-									files: attachments.map(({ data, ...metadata }) => metadata),
-								},
-								binary: Object.fromEntries(
-									attachments.map((attachment, index) => [`data${index}`, attachment]),
-								),
-							},
-						],
-					],
-				},
-				source: null,
-			},
-		];
 	}
 
 	/**
@@ -943,5 +920,311 @@ Respond the title only:`,
 			return 'video';
 		}
 		return 'file';
+	}
+
+	prepareExecutionData(
+		triggerNode: INode,
+		sessionId: string,
+		message: string,
+		attachments: IBinaryData[],
+		executionMetadata: ChatHubAuthenticationMetadata,
+	): IExecuteData[] {
+		const encryptedMetadata = this.cipher.encrypt(executionMetadata);
+		// Attachments are already processed (id field populated) by the caller
+		return [
+			{
+				node: {
+					...triggerNode,
+					parameters: {
+						...triggerNode.parameters,
+						executionsHooksVersion: 1,
+						contextEstablishmentHooks: {
+							hooks: [
+								{
+									hookName: CHATHUB_EXTRACTOR_NAME,
+									isAllowedToFail: true,
+								},
+							],
+						},
+					},
+				},
+				data: {
+					main: [
+						[
+							{
+								encryptedMetadata,
+								json: {
+									sessionId,
+									action: 'sendMessage',
+									chatInput: message,
+									files: attachments.map(({ data, ...metadata }) => metadata),
+								},
+								binary: Object.fromEntries(
+									attachments.map((attachment, index) => [`data${index}`, attachment]),
+								),
+							},
+						],
+					],
+				},
+				source: null,
+			},
+		];
+	}
+
+	async prepareReplyWorkflow(
+		user: User,
+		sessionId: ChatSessionId,
+		credentials: INodeCredentials,
+		model: ChatHubConversationModel,
+		history: ChatHubMessage[],
+		message: string,
+		tools: INode[],
+		attachments: IBinaryData[],
+		timeZone: string,
+		trx: EntityManager,
+		executionMetadata: ChatHubAuthenticationMetadata,
+	): Promise<PreparedChatWorkflow> {
+		if (model.provider === 'n8n') {
+			return await this.prepareWorkflowAgentWorkflow(
+				user,
+				sessionId,
+				model.workflowId,
+				message,
+				attachments,
+				trx,
+				executionMetadata,
+			);
+		}
+
+		if (model.provider === 'custom-agent') {
+			return await this.prepareChatAgentWorkflow(
+				model.agentId,
+				user,
+				sessionId,
+				history,
+				message,
+				attachments,
+				timeZone,
+				trx,
+				executionMetadata,
+			);
+		}
+
+		return await this.prepareBaseChatWorkflow(
+			user,
+			sessionId,
+			credentials,
+			model,
+			history,
+			message,
+			undefined,
+			tools,
+			attachments,
+			timeZone,
+			trx,
+			executionMetadata,
+		);
+	}
+
+	private async prepareBaseChatWorkflow(
+		user: User,
+		sessionId: ChatSessionId,
+		credentials: INodeCredentials,
+		model: ChatHubBaseLLMModel,
+		history: ChatHubMessage[],
+		message: string,
+		systemMessage: string | undefined,
+		tools: INode[],
+		attachments: IBinaryData[],
+		timeZone: string,
+		trx: EntityManager,
+		executionMetadata: ChatHubAuthenticationMetadata,
+	) {
+		await this.chatHubSettingsService.ensureModelIsAllowed(model);
+		this.chatHubCredentialsService.findProviderCredential(model.provider, credentials);
+		const { id: projectId } = await this.chatHubCredentialsService.findPersonalProject(user, trx);
+
+		return await this.createChatWorkflow(
+			user.id,
+			sessionId,
+			projectId,
+			history,
+			message,
+			attachments,
+			credentials,
+			model,
+			systemMessage,
+			tools,
+			timeZone,
+			executionMetadata,
+			trx,
+		);
+	}
+
+	private async prepareChatAgentWorkflow(
+		agentId: string,
+		user: User,
+		sessionId: ChatSessionId,
+		history: ChatHubMessage[],
+		message: string,
+		attachments: IBinaryData[],
+		timeZone: string,
+		trx: EntityManager,
+		executionMetadata: ChatHubAuthenticationMetadata,
+	) {
+		const agent = await this.chatHubAgentService.getAgentById(agentId, user.id, trx);
+
+		if (!agent) {
+			throw new BadRequestError('Agent not found');
+		}
+
+		if (!agent.provider || !agent.model) {
+			throw new BadRequestError('Provider or model not set for agent');
+		}
+
+		const credentialId = agent.credentialId;
+		if (!credentialId) {
+			throw new BadRequestError('Credentials not set for agent');
+		}
+
+		const systemMessage = agent.systemPrompt + '\n\n' + this.getSystemMessageMetadata(timeZone);
+
+		const model: ChatHubBaseLLMModel = {
+			provider: agent.provider,
+			model: agent.model,
+		};
+
+		const credentials: INodeCredentials = {
+			[PROVIDER_CREDENTIAL_TYPE_MAP[agent.provider]]: {
+				id: credentialId,
+				name: '',
+			},
+		};
+
+		const { tools } = agent;
+
+		return await this.prepareBaseChatWorkflow(
+			user,
+			sessionId,
+			credentials,
+			model,
+			history,
+			message,
+			systemMessage,
+			tools,
+			attachments,
+			timeZone,
+			trx,
+			executionMetadata,
+		);
+	}
+
+	private async prepareWorkflowAgentWorkflow(
+		user: User,
+		sessionId: ChatSessionId,
+		workflowId: string,
+		message: string,
+		attachments: IBinaryData[],
+		trx: EntityManager,
+		executionMetadata: ChatHubAuthenticationMetadata,
+	) {
+		const workflow = await this.workflowFinderService.findWorkflowForUser(
+			workflowId,
+			user,
+			['workflow:execute-chat'],
+			{ includeTags: false, includeParentFolder: false, includeActiveVersion: true, em: trx },
+		);
+
+		if (!workflow?.activeVersion) {
+			throw new BadRequestError('Workflow not found');
+		}
+
+		const chatTriggers = workflow.activeVersion.nodes.filter(
+			(node) => node.type === CHAT_TRIGGER_NODE_TYPE,
+		);
+
+		if (chatTriggers.length !== 1) {
+			throw new BadRequestError('Workflow must have exactly one chat trigger');
+		}
+
+		const chatTrigger = chatTriggers[0];
+
+		if (chatTrigger.typeVersion < CHAT_TRIGGER_NODE_MIN_VERSION) {
+			throw new BadRequestError(
+				'Chat Trigger node version is too old to support Chat. Please update the node.',
+			);
+		}
+
+		const chatTriggerParams = chatTriggerParamsShape.safeParse(chatTrigger.parameters).data;
+		if (!chatTriggerParams) {
+			throw new BadRequestError('Chat Trigger node has invalid parameters');
+		}
+
+		if (!chatTriggerParams.availableInChat) {
+			throw new BadRequestError('Chat Trigger node must be made available in Chat');
+		}
+
+		const responseMode = chatTriggerParams.options?.responseMode ?? 'streaming';
+		if (!SUPPORTED_RESPONSE_MODES.includes(responseMode)) {
+			throw new BadRequestError(
+				'Chat Trigger node response mode must be set to "When Last Node Finishes", "Using Response Nodes" or "Streaming" to use the workflow on Chat',
+			);
+		}
+
+		const chatResponseNodes = workflow.activeVersion.nodes.filter(
+			(node) => node.type === CHAT_NODE_TYPE,
+		);
+
+		if (chatResponseNodes.length > 0 && responseMode !== 'responseNodes') {
+			throw new BadRequestError(
+				'Chat nodes are not supported with the selected response mode. Please set the response mode to "Using Response Nodes" or remove the nodes from the workflow.',
+			);
+		}
+
+		const agentNodes = workflow.activeVersion.nodes?.filter(
+			(node) => node.type === AGENT_LANGCHAIN_NODE_TYPE,
+		);
+
+		// Agents older than this can't do streaming
+		if (agentNodes.some((node) => node.typeVersion < TOOLS_AGENT_NODE_MIN_VERSION)) {
+			throw new BadRequestError(
+				'Agent node version is too old to support streaming responses. Please update the node.',
+			);
+		}
+
+		const nodeExecutionStack = this.prepareExecutionData(
+			chatTrigger,
+			sessionId,
+			message,
+			attachments,
+			executionMetadata,
+		);
+
+		const executionData = createRunExecutionData({
+			executionData: {
+				nodeExecutionStack,
+			},
+			manualData: {
+				userId: user.id,
+			},
+		});
+
+		const workflowData: IWorkflowBase = {
+			...workflow,
+			nodes: workflow.activeVersion.nodes,
+			connections: workflow.activeVersion.connections,
+			// Force saving data on successful executions for custom agent workflows
+			// to be able to read the results after execution.
+			settings: {
+				...workflow.settings,
+				saveDataSuccessExecution: 'all',
+			},
+		};
+
+		return {
+			workflowData,
+			executionData,
+			responseMode,
+		};
 	}
 }

--- a/packages/cli/src/modules/chat-hub/chat-hub.attachment.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.attachment.service.ts
@@ -7,10 +7,10 @@ import { BinaryDataService, FileLocation } from 'n8n-core';
 import { BINARY_ENCODING, type IBinaryData } from 'n8n-workflow';
 import type Stream from 'node:stream';
 
-import { ChatHubMessageRepository } from './chat-message.repository';
-
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
+
+import { ChatHubMessageRepository } from './chat-message.repository';
 
 @Service()
 export class ChatHubAttachmentService {

--- a/packages/cli/src/modules/chat-hub/chat-hub.models.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.models.service.ts
@@ -9,6 +9,7 @@ import {
 } from '@n8n/api-types';
 import { In, WorkflowRepository, type User, type WorkflowEntity } from '@n8n/db';
 import { Service } from '@n8n/di';
+import { Scope } from '@n8n/permissions';
 import {
 	CHAT_TRIGGER_NODE_TYPE,
 	type INodeCredentials,
@@ -16,16 +17,15 @@ import {
 	type IWorkflowExecuteAdditionalData,
 } from 'n8n-workflow';
 
-import { ChatHubAgentService } from './chat-hub-agent.service';
-import { ChatHubWorkflowService } from './chat-hub-workflow.service';
-import { getModelMetadata, PROVIDER_NODE_TYPE_MAP } from './chat-hub.constants';
-import { chatTriggerParamsShape } from './chat-hub.types';
-
 import { CredentialsFinderService } from '@/credentials/credentials-finder.service';
 import { DynamicNodeParametersService } from '@/services/dynamic-node-parameters.service';
 import { getBase } from '@/workflow-execute-additional-data';
 import { WorkflowService } from '@/workflows/workflow.service';
-import { Scope } from '@n8n/permissions';
+
+import { ChatHubAgentService } from './chat-hub-agent.service';
+import { ChatHubWorkflowService } from './chat-hub-workflow.service';
+import { getModelMetadata, PROVIDER_NODE_TYPE_MAP } from './chat-hub.constants';
+import { chatTriggerParamsShape } from './chat-hub.types';
 
 @Service()
 export class ChatHubModelsService {

--- a/packages/cli/src/modules/chat-hub/chat-hub.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.service.ts
@@ -7,7 +7,6 @@ import {
 	type ChatMessageId,
 	type ChatSessionId,
 	ChatHubConversationModel,
-	ChatHubBaseLLMModel,
 	type ChatHubUpdateConversationRequest,
 	type ChatHubSessionDto,
 } from '@n8n/api-types';
@@ -20,13 +19,9 @@ import { ErrorReporter } from 'n8n-core';
 import {
 	CHAT_TRIGGER_NODE_TYPE,
 	OperationalError,
-	type INodeCredentials,
-	type IWorkflowBase,
-	CHAT_NODE_TYPE,
 	INode,
+	type INodeCredentials,
 	type IBinaryData,
-	createRunExecutionData,
-	AGENT_LANGCHAIN_NODE_TYPE,
 	UnexpectedError,
 } from 'n8n-workflow';
 
@@ -35,7 +30,6 @@ import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
 import { ChatHubAgentService } from './chat-hub-agent.service';
-import { ChatHubCredentialsService } from './chat-hub-credentials.service';
 import { ChatHubExecutionService } from './chat-hub-execution.service';
 import { ChatHubAuthenticationMetadata } from './chat-hub-extractor';
 import type { ChatHubMessage } from './chat-hub-message.entity';
@@ -43,18 +37,11 @@ import type { ChatHubSession, IChatHubSession } from './chat-hub-session.entity'
 import { ChatHubTitleService } from './chat-hub-title.service';
 import { ChatHubWorkflowService } from './chat-hub-workflow.service';
 import { ChatHubAttachmentService } from './chat-hub.attachment.service';
-import {
-	CHAT_TRIGGER_NODE_MIN_VERSION,
-	SUPPORTED_RESPONSE_MODES,
-	TOOLS_AGENT_NODE_MIN_VERSION,
-} from './chat-hub.constants';
 import { ChatHubModelsService } from './chat-hub.models.service';
-import { ChatHubSettingsService } from './chat-hub.settings.service';
 import {
 	HumanMessagePayload,
 	RegenerateMessagePayload,
 	EditMessagePayload,
-	chatTriggerParamsShape,
 	PreparedChatWorkflow,
 } from './chat-hub.types';
 import { ChatHubMessageRepository } from './chat-message.repository';
@@ -71,14 +58,12 @@ export class ChatHubService {
 		private readonly sessionRepository: ChatHubSessionRepository,
 		private readonly messageRepository: ChatHubMessageRepository,
 		private readonly chatHubAgentService: ChatHubAgentService,
-		private readonly chatHubCredentialsService: ChatHubCredentialsService,
-		private readonly chatHubWorkflowService: ChatHubWorkflowService,
 		private readonly chatHubModelsService: ChatHubModelsService,
-		private readonly chatHubSettingsService: ChatHubSettingsService,
 		private readonly chatHubAttachmentService: ChatHubAttachmentService,
 		private readonly chatStreamService: ChatStreamService,
 		private readonly chatHubExecutionService: ChatHubExecutionService,
 		private readonly chatHubTitleService: ChatHubTitleService,
+		private readonly chatHubWorkflowService: ChatHubWorkflowService,
 		private readonly globalConfig: GlobalConfig,
 	) {
 		this.logger = this.logger.scoped('chat-hub');
@@ -93,264 +78,6 @@ export class ChatHubService {
 		}
 
 		return credentials[PROVIDER_CREDENTIAL_TYPE_MAP[provider]]?.id ?? null;
-	}
-
-	private async prepareReplyWorkflow(
-		user: User,
-		sessionId: ChatSessionId,
-		credentials: INodeCredentials,
-		model: ChatHubConversationModel,
-		history: ChatHubMessage[],
-		message: string,
-		tools: INode[],
-		attachments: IBinaryData[],
-		timeZone: string,
-		trx: EntityManager,
-		executionMetadata: ChatHubAuthenticationMetadata,
-	) {
-		if (model.provider === 'n8n') {
-			return await this.prepareWorkflowAgentWorkflow(
-				user,
-				sessionId,
-				model.workflowId,
-				message,
-				attachments,
-				trx,
-				executionMetadata,
-			);
-		}
-
-		if (model.provider === 'custom-agent') {
-			return await this.prepareChatAgentWorkflow(
-				model.agentId,
-				user,
-				sessionId,
-				history,
-				message,
-				attachments,
-				timeZone,
-				trx,
-				executionMetadata,
-			);
-		}
-
-		return await this.prepareBaseChatWorkflow(
-			user,
-			sessionId,
-			credentials,
-			model,
-			history,
-			message,
-			undefined,
-			tools,
-			attachments,
-			timeZone,
-			trx,
-			executionMetadata,
-		);
-	}
-
-	private async prepareBaseChatWorkflow(
-		user: User,
-		sessionId: ChatSessionId,
-		credentials: INodeCredentials,
-		model: ChatHubBaseLLMModel,
-		history: ChatHubMessage[],
-		message: string,
-		systemMessage: string | undefined,
-		tools: INode[],
-		attachments: IBinaryData[],
-		timeZone: string,
-		trx: EntityManager,
-		executionMetadata: ChatHubAuthenticationMetadata,
-	) {
-		await this.chatHubSettingsService.ensureModelIsAllowed(model);
-		this.chatHubCredentialsService.findProviderCredential(model.provider, credentials);
-		const { id: projectId } = await this.chatHubCredentialsService.findPersonalProject(user, trx);
-
-		return await this.chatHubWorkflowService.createChatWorkflow(
-			user.id,
-			sessionId,
-			projectId,
-			history,
-			message,
-			attachments,
-			credentials,
-			model,
-			systemMessage,
-			tools,
-			timeZone,
-			executionMetadata,
-			trx,
-		);
-	}
-
-	private async prepareChatAgentWorkflow(
-		agentId: string,
-		user: User,
-		sessionId: ChatSessionId,
-		history: ChatHubMessage[],
-		message: string,
-		attachments: IBinaryData[],
-		timeZone: string,
-		trx: EntityManager,
-		executionMetadata: ChatHubAuthenticationMetadata,
-	) {
-		const agent = await this.chatHubAgentService.getAgentById(agentId, user.id, trx);
-
-		if (!agent) {
-			throw new BadRequestError('Agent not found');
-		}
-
-		if (!agent.provider || !agent.model) {
-			throw new BadRequestError('Provider or model not set for agent');
-		}
-
-		const credentialId = agent.credentialId;
-		if (!credentialId) {
-			throw new BadRequestError('Credentials not set for agent');
-		}
-
-		const systemMessage =
-			agent.systemPrompt + '\n\n' + this.chatHubWorkflowService.getSystemMessageMetadata(timeZone);
-
-		const model: ChatHubBaseLLMModel = {
-			provider: agent.provider,
-			model: agent.model,
-		};
-
-		const credentials: INodeCredentials = {
-			[PROVIDER_CREDENTIAL_TYPE_MAP[agent.provider]]: {
-				id: credentialId,
-				name: '',
-			},
-		};
-
-		const { tools } = agent;
-
-		return await this.prepareBaseChatWorkflow(
-			user,
-			sessionId,
-			credentials,
-			model,
-			history,
-			message,
-			systemMessage,
-			tools,
-			attachments,
-			timeZone,
-			trx,
-			executionMetadata,
-		);
-	}
-
-	private async prepareWorkflowAgentWorkflow(
-		user: User,
-		sessionId: ChatSessionId,
-		workflowId: string,
-		message: string,
-		attachments: IBinaryData[],
-		trx: EntityManager,
-		executionMetadata: ChatHubAuthenticationMetadata,
-	) {
-		const workflow = await this.workflowFinderService.findWorkflowForUser(
-			workflowId,
-			user,
-			['workflow:execute-chat'],
-			{ includeTags: false, includeParentFolder: false, includeActiveVersion: true, em: trx },
-		);
-
-		if (!workflow?.activeVersion) {
-			throw new BadRequestError('Workflow not found');
-		}
-
-		const chatTriggers = workflow.activeVersion.nodes.filter(
-			(node) => node.type === CHAT_TRIGGER_NODE_TYPE,
-		);
-
-		if (chatTriggers.length !== 1) {
-			throw new BadRequestError('Workflow must have exactly one chat trigger');
-		}
-
-		const chatTrigger = chatTriggers[0];
-
-		if (chatTrigger.typeVersion < CHAT_TRIGGER_NODE_MIN_VERSION) {
-			throw new BadRequestError(
-				'Chat Trigger node version is too old to support Chat. Please update the node.',
-			);
-		}
-
-		const chatTriggerParams = chatTriggerParamsShape.safeParse(chatTrigger.parameters).data;
-		if (!chatTriggerParams) {
-			throw new BadRequestError('Chat Trigger node has invalid parameters');
-		}
-
-		if (!chatTriggerParams.availableInChat) {
-			throw new BadRequestError('Chat Trigger node must be made available in Chat');
-		}
-
-		const responseMode = chatTriggerParams.options?.responseMode ?? 'streaming';
-		if (!SUPPORTED_RESPONSE_MODES.includes(responseMode)) {
-			throw new BadRequestError(
-				'Chat Trigger node response mode must be set to "When Last Node Finishes", "Using Response Nodes" or "Streaming" to use the workflow on Chat',
-			);
-		}
-
-		const chatResponseNodes = workflow.activeVersion.nodes.filter(
-			(node) => node.type === CHAT_NODE_TYPE,
-		);
-
-		if (chatResponseNodes.length > 0 && responseMode !== 'responseNodes') {
-			throw new BadRequestError(
-				'Chat nodes are not supported with the selected response mode. Please set the response mode to "Using Response Nodes" or remove the nodes from the workflow.',
-			);
-		}
-
-		const agentNodes = workflow.activeVersion.nodes?.filter(
-			(node) => node.type === AGENT_LANGCHAIN_NODE_TYPE,
-		);
-
-		// Agents older than this can't do streaming
-		if (agentNodes.some((node) => node.typeVersion < TOOLS_AGENT_NODE_MIN_VERSION)) {
-			throw new BadRequestError(
-				'Agent node version is too old to support streaming responses. Please update the node.',
-			);
-		}
-
-		const nodeExecutionStack = this.chatHubWorkflowService.prepareExecutionData(
-			chatTrigger,
-			sessionId,
-			message,
-			attachments,
-			executionMetadata,
-		);
-
-		const executionData = createRunExecutionData({
-			executionData: {
-				nodeExecutionStack,
-			},
-			manualData: {
-				userId: user.id,
-			},
-		});
-
-		const workflowData: IWorkflowBase = {
-			...workflow,
-			nodes: workflow.activeVersion.nodes,
-			connections: workflow.activeVersion.connections,
-			// Force saving data on successful executions for custom agent workflows
-			// to be able to read the results after execution.
-			settings: {
-				...workflow.settings,
-				saveDataSuccessExecution: 'all',
-			},
-		};
-
-		return {
-			workflowData,
-			executionData,
-			responseMode,
-		};
 	}
 
 	private async ensurePreviousMessage(
@@ -676,7 +403,7 @@ export class ChatHubService {
 					trx,
 				);
 
-				const replyWorkflow = await this.prepareReplyWorkflow(
+				const replyWorkflow = await this.chatHubWorkflowService.prepareReplyWorkflow(
 					user,
 					sessionId,
 					credentials,
@@ -850,7 +577,7 @@ export class ChatHubService {
 						trx,
 					);
 
-					const workflow = await this.prepareReplyWorkflow(
+					const workflow = await this.chatHubWorkflowService.prepareReplyWorkflow(
 						user,
 						sessionId,
 						credentials,
@@ -959,7 +686,7 @@ export class ChatHubService {
 				const message = lastHumanMessage ? lastHumanMessage.content : '';
 				const attachments = lastHumanMessage.attachments ?? [];
 
-				const workflow = await this.prepareReplyWorkflow(
+				const workflow = await this.chatHubWorkflowService.prepareReplyWorkflow(
 					user,
 					sessionId,
 					credentials,

--- a/packages/cli/src/modules/chat-hub/chat-hub.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.service.ts
@@ -1,54 +1,42 @@
 import {
 	PROVIDER_CREDENTIAL_TYPE_MAP,
 	type ChatHubProvider,
-	type ChatHubLLMProvider,
 	type ChatHubConversationsResponse,
 	type ChatHubConversationResponse,
 	ChatHubMessageDto,
 	type ChatMessageId,
 	type ChatSessionId,
 	ChatHubConversationModel,
-	ChatHubMessageStatus,
 	ChatHubBaseLLMModel,
-	ChatHubN8nModel,
-	ChatHubCustomAgentModel,
 	type ChatHubUpdateConversationRequest,
 	type ChatHubSessionDto,
 } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
-import { ExecutionRepository, IExecutionResponse, User, WorkflowRepository } from '@n8n/db';
+import { ExecutionRepository, User } from '@n8n/db';
 import type { EntityManager } from '@n8n/db';
 import { Service } from '@n8n/di';
-import type { Response } from 'express';
-import { ErrorReporter, InstanceSettings } from 'n8n-core';
+import { ErrorReporter } from 'n8n-core';
 import {
 	CHAT_TRIGGER_NODE_TYPE,
 	OperationalError,
-	ManualExecutionCancelledError,
 	type INodeCredentials,
 	type IWorkflowBase,
-	jsonParse,
-	jsonStringify,
-	StructuredChunk,
 	CHAT_NODE_TYPE,
-	IRunExecutionData,
-	INodeParameters,
 	INode,
 	type IBinaryData,
 	createRunExecutionData,
-	WorkflowExecuteMode,
 	AGENT_LANGCHAIN_NODE_TYPE,
-	UserError,
 	UnexpectedError,
-	NodeConnectionTypes,
-	INodeExecutionData,
-	sleep,
 } from 'n8n-workflow';
-import { v4 as uuidv4 } from 'uuid';
+
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
 import { ChatHubAgentService } from './chat-hub-agent.service';
 import { ChatHubCredentialsService } from './chat-hub-credentials.service';
+import { ChatHubExecutionService } from './chat-hub-execution.service';
 import { ChatHubAuthenticationMetadata } from './chat-hub-extractor';
 import type { ChatHubMessage } from './chat-hub-message.entity';
 import type { ChatHubSession, IChatHubSession } from './chat-hub-session.entity';
@@ -56,10 +44,6 @@ import { ChatHubWorkflowService } from './chat-hub-workflow.service';
 import { ChatHubAttachmentService } from './chat-hub.attachment.service';
 import {
 	CHAT_TRIGGER_NODE_MIN_VERSION,
-	EXECUTION_FINISHED_STATUSES,
-	EXECUTION_POLL_INTERVAL,
-	NODE_NAMES,
-	PROVIDER_NODE_TYPE_MAP,
 	SUPPORTED_RESPONSE_MODES,
 	TOOLS_AGENT_NODE_MIN_VERSION,
 } from './chat-hub.constants';
@@ -70,37 +54,19 @@ import {
 	RegenerateMessagePayload,
 	EditMessagePayload,
 	chatTriggerParamsShape,
-	ChatTriggerResponseMode,
-	NonStreamingResponseMode,
 	PreparedChatWorkflow,
 } from './chat-hub.types';
 import { ChatHubMessageRepository } from './chat-message.repository';
 import { ChatHubSessionRepository } from './chat-session.repository';
 import { ChatStreamService } from './chat-stream.service';
-import { createStructuredChunkAggregator } from './stream-capturer';
-import { getLastNodeExecuted, shouldResumeImmediately } from '../../chat/utils';
-
-import { ActiveExecutions } from '@/active-executions';
-import { ChatExecutionManager } from '@/chat/chat-execution-manager';
-import { ExecutionNotFoundError } from '@/errors/execution-not-found-error';
-import { BadRequestError } from '@/errors/response-errors/bad-request.error';
-import { NotFoundError } from '@/errors/response-errors/not-found.error';
-import { ExecutionService } from '@/executions/execution.service';
-import { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
-import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
 @Service()
 export class ChatHubService {
 	constructor(
 		private readonly logger: Logger,
 		private readonly errorReporter: ErrorReporter,
-		private readonly executionService: ExecutionService,
 		private readonly executionRepository: ExecutionRepository,
-		private readonly workflowExecutionService: WorkflowExecutionService,
 		private readonly workflowFinderService: WorkflowFinderService,
-		private readonly workflowRepository: WorkflowRepository,
-		private readonly activeExecutions: ActiveExecutions,
-		private readonly executionManager: ChatExecutionManager,
 		private readonly sessionRepository: ChatHubSessionRepository,
 		private readonly messageRepository: ChatHubMessageRepository,
 		private readonly chatHubAgentService: ChatHubAgentService,
@@ -110,43 +76,10 @@ export class ChatHubService {
 		private readonly chatHubSettingsService: ChatHubSettingsService,
 		private readonly chatHubAttachmentService: ChatHubAttachmentService,
 		private readonly chatStreamService: ChatStreamService,
-		private readonly instanceSettings: InstanceSettings,
+		private readonly executionService: ChatHubExecutionService,
 		private readonly globalConfig: GlobalConfig,
 	) {
 		this.logger = this.logger.scoped('chat-hub');
-	}
-
-	private async deleteChatWorkflow(workflowId: string): Promise<void> {
-		await this.workflowRepository.delete(workflowId);
-	}
-
-	private getErrorMessage(execution: IExecutionResponse): string | undefined {
-		if (execution.data.resultData.error) {
-			return execution.data.resultData.error.description ?? execution.data.resultData.error.message;
-		}
-
-		return undefined;
-	}
-
-	private getAIOutput(execution: IExecutionResponse, nodeName: string): string | undefined {
-		const agent = execution.data.resultData.runData[nodeName];
-		if (!agent || !Array.isArray(agent) || agent.length === 0) return undefined;
-
-		const runIndex = agent.length - 1;
-		const mainOutputs = agent[runIndex].data?.main;
-
-		// Check all main output branches for a message
-		if (mainOutputs && Array.isArray(mainOutputs)) {
-			for (const branch of mainOutputs) {
-				if (branch && Array.isArray(branch) && branch.length > 0 && branch[0].json?.output) {
-					if (typeof branch[0].json.output === 'string') {
-						return branch[0].json.output;
-					}
-				}
-			}
-		}
-
-		return undefined;
 	}
 
 	private pickCredentialId(
@@ -460,444 +393,8 @@ export class ChatHubService {
 			throw new BadRequestError('Can only stop messages that are currently running');
 		}
 
-		await this.executionService.stop(message.execution.id, [message.execution.workflowId]);
+		await this.executionService.stop(message.execution.id, message.execution.workflowId);
 		await this.messageRepository.updateChatMessage(messageId, { status: 'cancelled' });
-	}
-
-	private async waitForExecutionCompletion(executionId: string): Promise<void> {
-		if (this.instanceSettings.isMultiMain) {
-			return await this.waitForExecutionPoller(executionId);
-		} else {
-			return await this.waitForExecutionPromise(executionId);
-		}
-	}
-
-	private async waitForExecutionPoller(executionId: string): Promise<void> {
-		return await new Promise<void>((resolve, reject) => {
-			const poller = setInterval(async () => {
-				try {
-					const execution = await this.executionRepository.findSingleExecution(executionId, {
-						includeData: false,
-						unflattenData: false,
-					});
-
-					// Stop polling when execution is done (or missing if instance doesn't save executions)
-					if (!execution || EXECUTION_FINISHED_STATUSES.includes(execution.status)) {
-						this.logger.debug(
-							`Execution ${executionId} finished with status ${execution?.status ?? 'missing'}`,
-						);
-						clearInterval(poller);
-
-						if (execution?.status === 'canceled') {
-							reject(new ManualExecutionCancelledError(executionId));
-						} else {
-							resolve();
-						}
-					}
-				} catch (error) {
-					this.logger.error(`Stopping polling for execution ${executionId} due to error.`);
-					clearInterval(poller);
-
-					if (error instanceof Error) {
-						this.logger.error(`Error while polling execution ${executionId}: ${error.message}`, {
-							error,
-						});
-					} else {
-						this.logger.error(`Unknown error while polling execution ${executionId}`, { error });
-					}
-
-					if (error instanceof Error) {
-						reject(error);
-					} else {
-						reject(new Error('Unknown error while polling execution status'));
-					}
-				}
-			}, EXECUTION_POLL_INTERVAL);
-		});
-	}
-
-	private async waitForExecutionPromise(executionId: string): Promise<void> {
-		try {
-			// Wait until the execution finishes (or errors) so that we don't delete the workflow too early
-			const result = await this.activeExecutions.getPostExecutePromise(executionId);
-			if (!result) {
-				throw new OperationalError('There was a problem executing the chat workflow.');
-			}
-		} catch (error: unknown) {
-			if (error instanceof ExecutionNotFoundError) {
-				return;
-			}
-
-			if (error instanceof ManualExecutionCancelledError) {
-				throw error;
-			}
-
-			if (error instanceof Error) {
-				this.logger.error(`Error during chat workflow execution: ${error}`);
-			}
-			throw error;
-		}
-	}
-
-	/**
-	 * Wait for error details to be available in execution DB using exponential backoff
-	 * @param executionId - The execution ID to fetch error details from
-	 * @param workflowId - The workflow ID for the execution
-	 * @returns The error message if found, undefined otherwise
-	 */
-	private async waitForErrorDetails(
-		executionId: string,
-		workflowId: string,
-	): Promise<string | undefined> {
-		const maxRetries = 5;
-		let retries = 0;
-		let errorText: string | undefined;
-
-		while (!errorText) {
-			try {
-				const execution = await this.executionRepository.findWithUnflattenedData(executionId, [
-					workflowId,
-				]);
-				if (execution && EXECUTION_FINISHED_STATUSES.includes(execution.status)) {
-					errorText = this.getErrorMessage(execution);
-					break;
-				}
-			} catch (error) {
-				this.logger.debug(
-					`Failed to fetch execution ${executionId} for error extraction: ${String(error)}`,
-				);
-			}
-
-			retries++;
-
-			if (maxRetries <= retries) {
-				break;
-			}
-
-			// Wait with exponential backoff (double wait time, cap at 2 second)
-			await sleep(Math.min(500 * Math.pow(2, retries), 2000));
-		}
-
-		return errorText;
-	}
-
-	private async generateSessionTitle(
-		user: User,
-		sessionId: ChatSessionId,
-		humanMessage: string,
-		attachments: IBinaryData[],
-		credentials: INodeCredentials,
-		model: ChatHubConversationModel,
-	) {
-		const { executionData, workflowData } = await this.prepareTitleGenerationWorkflow(
-			user,
-			sessionId,
-			humanMessage,
-			attachments,
-			credentials,
-			model,
-		);
-
-		try {
-			const title = await this.runTitleWorkflowAndGetTitle(user, workflowData, executionData);
-			if (title) {
-				await this.sessionRepository.updateChatSession(sessionId, { title });
-			}
-		} finally {
-			await this.deleteChatWorkflow(workflowData.id);
-		}
-	}
-
-	private async prepareTitleGenerationWorkflow(
-		user: User,
-		sessionId: ChatSessionId,
-		humanMessage: string,
-		attachments: IBinaryData[],
-		incomingCredentials: INodeCredentials,
-		incomingModel: ChatHubConversationModel,
-	) {
-		return await this.messageRepository.manager.transaction(async (trx) => {
-			const { resolvedCredentials, resolvedModel, credentialId, projectId } =
-				await this.resolveCredentialsAndModelForTitle(
-					user,
-					incomingModel,
-					incomingCredentials,
-					trx,
-				);
-
-			if (!credentialId || !projectId) {
-				throw new BadRequestError('Could not determine credentials for title generation');
-			}
-
-			this.logger.debug(
-				`Using credential ID ${credentialId} for title generation in project ${projectId}, model ${jsonStringify(resolvedModel)}`,
-			);
-
-			return await this.chatHubWorkflowService.createTitleGenerationWorkflow(
-				user.id,
-				sessionId,
-				projectId,
-				humanMessage,
-				attachments,
-				resolvedCredentials,
-				resolvedModel,
-				trx,
-			);
-		});
-	}
-
-	private async resolveCredentialsAndModelForTitle(
-		user: User,
-		model: ChatHubConversationModel,
-		credentials: INodeCredentials,
-		trx: EntityManager,
-	): Promise<{
-		resolvedCredentials: INodeCredentials;
-		resolvedModel: ChatHubConversationModel;
-		credentialId: string;
-		projectId: string;
-	}> {
-		if (model.provider === 'n8n') {
-			return await this.resolveFromN8nWorkflow(user, model, trx);
-		}
-
-		if (model.provider === 'custom-agent') {
-			return await this.resolveFromCustomAgent(user, model, trx);
-		}
-
-		const credentialId = this.chatHubCredentialsService.findProviderCredential(
-			model.provider,
-			credentials,
-		);
-
-		const { id: projectId } = await this.chatHubCredentialsService.findPersonalProject(user, trx);
-
-		return {
-			resolvedCredentials: credentials,
-			resolvedModel: model,
-			credentialId,
-			projectId,
-		};
-	}
-
-	private async resolveFromN8nWorkflow(
-		user: User,
-		{ workflowId }: ChatHubN8nModel,
-		trx: EntityManager,
-	): Promise<{
-		resolvedCredentials: INodeCredentials;
-		resolvedModel: ChatHubConversationModel;
-		credentialId: string;
-		projectId: string;
-	}> {
-		const workflowEntity = await this.workflowFinderService.findWorkflowForUser(
-			workflowId,
-			user,
-			['workflow:execute-chat'],
-			{ includeTags: false, includeParentFolder: false, includeActiveVersion: true, em: trx },
-		);
-
-		if (!workflowEntity?.activeVersion) {
-			throw new UserError('Workflow not found for title generation');
-		}
-
-		const modelNodes = this.findSupportedLLMNodes(workflowEntity.activeVersion.nodes);
-		this.logger.debug(
-			`Found ${modelNodes.length} LLM nodes in workflow ${workflowEntity.id} for title generation`,
-		);
-
-		if (modelNodes.length === 0) {
-			throw new UserError('No supported Model nodes found in workflow for title generation');
-		}
-
-		const modelNode = modelNodes[0];
-		const llmModel = (modelNode.node.parameters?.model as INodeParameters)?.value;
-		if (!llmModel) {
-			throw new UserError(
-				`No model set on Model node "${modelNode.node.name}" for title generation`,
-			);
-		}
-
-		if (typeof llmModel !== 'string' || llmModel.length === 0 || llmModel.startsWith('=')) {
-			throw new UserError(
-				`Invalid model set on Model node "${modelNode.node.name}" for title generation`,
-			);
-		}
-
-		const llmCredentials = modelNode.node.credentials;
-		if (!llmCredentials) {
-			throw new UserError(
-				`No credentials found on Model node "${modelNode.node.name}" for title generation`,
-			);
-		}
-
-		const { credentialId, projectId } =
-			await this.chatHubCredentialsService.findWorkflowCredentialAndProject(
-				modelNode.provider,
-				llmCredentials,
-				workflowId,
-			);
-
-		const resolvedModel: ChatHubConversationModel = {
-			provider: modelNode.provider,
-			model: llmModel,
-		};
-
-		const resolvedCredentials: INodeCredentials = {
-			[PROVIDER_CREDENTIAL_TYPE_MAP[modelNode.provider]]: {
-				id: credentialId,
-				name: '',
-			},
-		};
-
-		return { resolvedCredentials, resolvedModel, credentialId, projectId };
-	}
-
-	private findSupportedLLMNodes(nodes: INode[]) {
-		return nodes.reduce<Array<{ node: INode; provider: ChatHubLLMProvider }>>((acc, node) => {
-			const supportedProvider = Object.entries(PROVIDER_NODE_TYPE_MAP).find(
-				([_provider, { name }]) => node.type === name,
-			);
-			if (supportedProvider) {
-				const [provider] = supportedProvider;
-				acc.push({ node, provider: provider as ChatHubLLMProvider });
-			}
-			return acc;
-		}, []);
-	}
-
-	private async resolveFromCustomAgent(
-		user: User,
-		model: ChatHubCustomAgentModel,
-		trx: EntityManager,
-	): Promise<{
-		resolvedCredentials: INodeCredentials;
-		resolvedModel: ChatHubConversationModel;
-		credentialId: string;
-		projectId: string;
-	}> {
-		const agent = await this.chatHubAgentService.getAgentById(model.agentId, user.id, trx);
-		if (!agent) {
-			throw new BadRequestError('Agent not found for title generation');
-		}
-
-		if (!agent.credentialId) {
-			throw new BadRequestError('Credentials not set for agent');
-		}
-
-		const resolvedModel: ChatHubConversationModel = {
-			provider: agent.provider,
-			model: agent.model,
-		};
-
-		const resolvedCredentials: INodeCredentials = {
-			[PROVIDER_CREDENTIAL_TYPE_MAP[agent.provider]]: {
-				id: agent.credentialId,
-				name: '',
-			},
-		};
-
-		const credentialId = this.chatHubCredentialsService.findProviderCredential(
-			agent.provider,
-			resolvedCredentials,
-		);
-
-		const { id: projectId } = await this.chatHubCredentialsService.findPersonalProject(user, trx);
-
-		return { resolvedCredentials, resolvedModel, credentialId, projectId };
-	}
-
-	private async runTitleWorkflowAndGetTitle(
-		user: User,
-		workflowData: IWorkflowBase,
-		executionData: IRunExecutionData,
-	): Promise<string | null> {
-		const { executionId } = await this.workflowExecutionService.executeChatWorkflow(
-			user,
-			workflowData,
-			executionData,
-			undefined,
-			false,
-			'chat',
-		);
-
-		await this.waitForExecutionCompletion(executionId);
-
-		const execution = await this.executionRepository.findWithUnflattenedData(executionId, [
-			workflowData.id,
-		]);
-
-		if (!execution) {
-			throw new OperationalError(`Could not find execution with ID ${executionId}`);
-		}
-
-		if (!execution.status || execution.status !== 'success') {
-			const message = this.getErrorMessage(execution) ?? 'Failed to generate a response';
-			throw new OperationalError(message);
-		}
-
-		const title = this.getAIOutput(execution, NODE_NAMES.TITLE_GENERATOR_AGENT);
-		return title ?? null;
-	}
-
-	private async saveHumanMessage(
-		payload: HumanMessagePayload | EditMessagePayload,
-		attachments: IBinaryData[],
-		user: User,
-		previousMessageId: ChatMessageId | null,
-		model: ChatHubConversationModel,
-		revisionOfMessageId?: ChatMessageId,
-		trx?: EntityManager,
-	) {
-		await this.messageRepository.createChatMessage(
-			{
-				id: payload.messageId,
-				sessionId: payload.sessionId,
-				type: 'human',
-				status: 'success',
-				content: payload.message,
-				previousMessageId,
-				revisionOfMessageId,
-				name: user.firstName || 'User',
-				attachments,
-				...model,
-			},
-			trx,
-		);
-	}
-
-	private async saveAIMessage({
-		id,
-		sessionId,
-		executionId,
-		previousMessageId,
-		content,
-		model,
-		retryOfMessageId,
-		status,
-	}: {
-		id: ChatMessageId;
-		sessionId: ChatSessionId;
-		previousMessageId: ChatMessageId | null;
-		content: string;
-		model: ChatHubConversationModel;
-		executionId?: string;
-		retryOfMessageId: ChatMessageId | null;
-		editOfMessageId?: ChatMessageId;
-		status?: ChatHubMessageStatus;
-	}) {
-		await this.messageRepository.createChatMessage({
-			id,
-			sessionId,
-			previousMessageId,
-			executionId: executionId ? parseInt(executionId, 10) : null,
-			type: 'ai',
-			name: 'AI',
-			status,
-			content,
-			retryOfMessageId,
-			...model,
-		});
 	}
 
 	private getModelCredential(model: ChatHubConversationModel, credentials: INodeCredentials) {
@@ -1167,7 +664,7 @@ export class ChatHubService {
 					attachments,
 				);
 
-				await this.saveHumanMessage(
+				await this.messageRepository.createHumanMessage(
 					payload,
 					processedAttachments,
 					user,
@@ -1252,7 +749,7 @@ export class ChatHubService {
 				status: 'success',
 			});
 
-			void this.resumeChatExecution(
+			void this.executionService.resumeChatExecution(
 				execution,
 				message,
 				sessionId,
@@ -1265,7 +762,7 @@ export class ChatHubService {
 		}
 
 		// Start the workflow execution with streaming
-		void this.executeChatWorkflowWithCleanup(
+		void this.executionService.executeChatWorkflowWithCleanup(
 			user,
 			model,
 			workflow.workflowData,
@@ -1343,7 +840,7 @@ export class ChatHubService {
 
 					const attachments = [...keptAttachments, ...newStoredAttachments];
 
-					await this.saveHumanMessage(
+					await this.messageRepository.createHumanMessage(
 						payload,
 						attachments,
 						user,
@@ -1406,7 +903,7 @@ export class ChatHubService {
 		});
 
 		// Start the workflow execution with streaming
-		void this.executeChatWorkflowWithCleanup(
+		void this.executionService.executeChatWorkflowWithCleanup(
 			user,
 			model,
 			workflowData,
@@ -1486,7 +983,7 @@ export class ChatHubService {
 			});
 
 		// Start the workflow execution with streaming (fire and forget)
-		void this.executeChatWorkflowWithCleanup(
+		void this.executionService.executeChatWorkflowWithCleanup(
 			user,
 			model,
 			workflow.workflowData,
@@ -1500,675 +997,6 @@ export class ChatHubService {
 			'',
 			[],
 		);
-	}
-
-	/**
-	 * Execute a chat workflow with cleanup and streaming
-	 */
-	private async executeChatWorkflowWithCleanup(
-		user: User,
-		model: ChatHubConversationModel,
-		workflowData: IWorkflowBase,
-		executionData: IRunExecutionData,
-		sessionId: ChatSessionId,
-		previousMessageId: ChatMessageId,
-		retryOfMessageId: ChatMessageId | null,
-		responseMode: ChatTriggerResponseMode,
-		originalPreviousMessageId: ChatMessageId | null,
-		credentials: INodeCredentials,
-		humanMessage: string,
-		processedAttachments: IBinaryData[],
-	) {
-		try {
-			const executionMode = model.provider === 'n8n' ? 'webhook' : 'chat';
-
-			await this.executeChatWorkflow(
-				user,
-				model,
-				workflowData,
-				executionData,
-				sessionId,
-				previousMessageId,
-				retryOfMessageId,
-				executionMode,
-				responseMode,
-			);
-		} catch (error) {
-			this.logger.error(`Error in chat execution: ${error}`);
-
-			const errorMessageId = uuidv4();
-			const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-
-			await this.saveAIMessage({
-				id: errorMessageId,
-				sessionId,
-				previousMessageId,
-				content: errorMessage,
-				model,
-				retryOfMessageId,
-				status: 'error',
-			});
-
-			await this.chatStreamService.sendErrorDirect(
-				user.id,
-				sessionId,
-				errorMessageId,
-				errorMessage,
-			);
-			await this.chatStreamService.endExecution(user.id, sessionId, 'error');
-		} finally {
-			if (model.provider !== 'n8n') {
-				await this.deleteChatWorkflow(workflowData.id);
-			}
-		}
-
-		// Generate title for the session on receiving the first human message
-		if (originalPreviousMessageId === null && humanMessage) {
-			try {
-				await this.generateSessionTitle(
-					user,
-					sessionId,
-					humanMessage,
-					processedAttachments,
-					credentials,
-					model,
-				);
-			} catch (error) {
-				this.logger.warn(`Title generation failed: ${error}`);
-			}
-		}
-	}
-
-	/**
-	 * Execute a chat workflow
-	 */
-	private async executeChatWorkflow(
-		user: User,
-		model: ChatHubConversationModel,
-		workflowData: IWorkflowBase,
-		executionData: IRunExecutionData,
-		sessionId: ChatSessionId,
-		previousMessageId: ChatMessageId,
-		retryOfMessageId: ChatMessageId | null,
-		executionMode: WorkflowExecuteMode,
-		responseMode: ChatTriggerResponseMode,
-	) {
-		this.logger.debug(
-			`Starting execution of workflow "${workflowData.name}" with ID ${workflowData.id}`,
-		);
-
-		if (!SUPPORTED_RESPONSE_MODES.includes(responseMode)) {
-			throw new BadRequestError(`Response mode "${responseMode}" is not supported yet.`);
-		}
-
-		if (responseMode === 'lastNode' || responseMode === 'responseNodes') {
-			return await this.executeLastNode(
-				user,
-				model,
-				workflowData,
-				executionData,
-				sessionId,
-				previousMessageId,
-				retryOfMessageId,
-				executionMode,
-				responseMode,
-			);
-		} else if (responseMode === 'streaming') {
-			return await this.executeWithStreaming(
-				user,
-				model,
-				workflowData,
-				executionData,
-				sessionId,
-				previousMessageId,
-				retryOfMessageId,
-				executionMode,
-			);
-		}
-	}
-
-	/**
-	 * Execute a workflow and wait for completion (for lastNode and responseNodes modes)
-	 */
-	private async executeLastNode(
-		user: User,
-		model: ChatHubConversationModel,
-		workflowData: IWorkflowBase,
-		executionData: IRunExecutionData,
-		sessionId: string,
-		previousMessageId: string,
-		retryOfMessageId: string | null,
-		executionMode: WorkflowExecuteMode,
-		responseMode: NonStreamingResponseMode,
-	) {
-		const running = await this.workflowExecutionService.executeChatWorkflow(
-			user,
-			workflowData,
-			executionData,
-			undefined,
-			false,
-			executionMode,
-		);
-
-		const messageId = uuidv4();
-		const executionId = running.executionId;
-
-		if (!executionId) {
-			throw new OperationalError('There was a problem starting the chat execution.');
-		}
-
-		// Start the execution via WebSocket
-		await this.chatStreamService.startExecution(user.id, sessionId);
-
-		// Save the AI message as running
-		await this.saveAIMessage({
-			id: messageId,
-			content: '',
-			sessionId,
-			executionId,
-			model,
-			previousMessageId,
-			retryOfMessageId,
-			status: 'running',
-		});
-
-		// Send begin event via WebSocket
-		await this.chatStreamService.startStream({
-			userId: user.id,
-			sessionId,
-			messageId,
-			previousMessageId,
-			retryOfMessageId,
-			executionId: parseInt(executionId, 10),
-		});
-
-		try {
-			await this.waitForExecutionCompletion(executionId);
-			const execution = await this.executionRepository.findSingleExecution(executionId, {
-				includeData: true,
-				unflattenData: true,
-			});
-			if (!execution) {
-				throw new OperationalError(
-					'Chat execution not found after completion - make sure your instance is saving executions.',
-				);
-			}
-
-			// Check for execution errors
-			if (!['success', 'waiting', 'canceled'].includes(execution.status)) {
-				const errorMessage = this.getErrorMessage(execution) ?? 'Failed to generate a response';
-				throw new OperationalError(errorMessage);
-			}
-
-			const message = this.getMessageFromExecution(execution, responseMode);
-			const status = execution?.status === 'waiting' ? 'waiting' : 'success';
-
-			// Send the message content via WebSocket
-			if (message) {
-				await this.chatStreamService.sendChunk(sessionId, messageId, message);
-			}
-
-			// Update message in DB
-			await this.messageRepository.updateChatMessage(messageId, {
-				content: message ?? '',
-				status,
-			});
-
-			// End the stream
-			await this.chatStreamService.endStream(sessionId, messageId, status);
-
-			// End the execution
-			await this.chatStreamService.endExecution(
-				user.id,
-				sessionId,
-				status === 'waiting' ? 'success' : status,
-			);
-
-			if (status === 'waiting' && responseMode === 'responseNodes') {
-				const lastNode = getLastNodeExecuted(execution);
-				if (lastNode && shouldResumeImmediately(lastNode)) {
-					this.logger.debug(
-						`Resuming execution ${execution.id} immediately after wait in node ${lastNode.name}`,
-					);
-					await this.resumeChatExecution(
-						execution,
-						'',
-						sessionId,
-						user,
-						messageId,
-						model,
-						responseMode,
-					);
-				}
-			}
-		} catch (e: unknown) {
-			if (e instanceof ManualExecutionCancelledError) {
-				// When messages are cancelled they're already marked cancelled on `stopGeneration`
-				await this.chatStreamService.endExecution(user.id, sessionId, 'cancelled');
-				return;
-			}
-
-			const errorMessage =
-				e instanceof Error ? e.message : 'Unknown error occurred during chat execution';
-
-			// Update message with error
-			await this.messageRepository.updateChatMessage(messageId, {
-				content: errorMessage,
-				status: 'error',
-			});
-
-			// Send error via WebSocket
-			await this.chatStreamService.sendChunk(sessionId, messageId, errorMessage);
-			await this.chatStreamService.endStream(sessionId, messageId, 'error');
-			await this.chatStreamService.endExecution(user.id, sessionId, 'error');
-		}
-	}
-
-	/**
-	 * Resume a chat execution (for responseNodes mode when execution is waiting)
-	 */
-	private async resumeChatExecution(
-		execution: IExecutionResponse,
-		message: string,
-		sessionId: ChatSessionId,
-		user: User,
-		previousMessageId: ChatMessageId,
-		model: ChatHubConversationModel,
-		responseMode: 'responseNodes',
-	) {
-		let currentExecution = execution;
-		let currentMessage = message;
-		let currentPreviousMessageId = previousMessageId;
-
-		while (true) {
-			await this.resumeExecution(sessionId, currentExecution, currentMessage);
-			const messageId = uuidv4();
-
-			// Start new stream for the resumed execution
-			await this.chatStreamService.startExecution(user.id, sessionId);
-
-			// Save the AI message as running
-			await this.saveAIMessage({
-				id: messageId,
-				content: '',
-				sessionId,
-				executionId: currentExecution.id,
-				model,
-				previousMessageId: currentPreviousMessageId,
-				retryOfMessageId: null,
-				status: 'running',
-			});
-
-			await this.chatStreamService.startStream({
-				userId: user.id,
-				sessionId,
-				messageId,
-				previousMessageId: currentPreviousMessageId,
-				retryOfMessageId: null,
-				executionId: parseInt(currentExecution.id, 10),
-			});
-
-			await this.waitForExecutionCompletion(currentExecution.id);
-
-			const completed = await this.executionRepository.findSingleExecution(currentExecution.id, {
-				includeData: true,
-				unflattenData: true,
-			});
-
-			if (!completed) {
-				throw new OperationalError(
-					'Chat execution not found after completion - make sure your instance is saving executions.',
-				);
-			}
-
-			if (!['success', 'waiting', 'canceled'].includes(completed.status)) {
-				const errorMessage = this.getErrorMessage(completed) ?? 'Failed to generate a response';
-				throw new OperationalError(errorMessage);
-			}
-
-			const reply = this.getMessageFromExecution(completed, responseMode);
-			const status = completed?.status === 'waiting' ? 'waiting' : 'success';
-
-			// Send the message content via WebSocket
-			if (reply) {
-				await this.chatStreamService.sendChunk(sessionId, messageId, reply);
-			}
-
-			// Update message in DB
-			await this.messageRepository.updateChatMessage(messageId, {
-				content: reply ?? '',
-				status,
-			});
-
-			// End the stream
-			await this.chatStreamService.endStream(sessionId, messageId, status);
-			await this.chatStreamService.endExecution(
-				user.id,
-				sessionId,
-				status === 'waiting' ? 'success' : status,
-			);
-
-			const lastNode = getLastNodeExecuted(completed);
-			if (status === 'waiting' && lastNode && shouldResumeImmediately(lastNode)) {
-				// Resuming execution immediately, so mark the last message as successful
-				this.logger.debug(
-					`Resuming execution ${completed.id} immediately after wait in node ${lastNode.name}`,
-				);
-				await this.messageRepository.updateChatMessage(messageId, {
-					status: 'success',
-				});
-
-				// There's no new human input
-				currentMessage = '';
-				currentExecution = completed;
-				currentPreviousMessageId = messageId;
-			} else {
-				// Finished or waiting for user input
-				return;
-			}
-		}
-	}
-
-	/**
-	 * Returns the message from the last executed node
-	 */
-	private getMessageFromExecution(
-		execution: IExecutionResponse,
-		responseMode: ChatTriggerResponseMode,
-	) {
-		const nodeName = this.getLastNodeExecutedName(execution);
-		if (!nodeName) return undefined;
-
-		const outputs = this.getNodeOutputs(execution, nodeName);
-		const entry = this.getFirstOutputEntry(outputs);
-		if (!entry) return undefined;
-
-		const message = this.extractMessageFromEntry(entry, responseMode);
-		if (typeof message === 'object' && message !== null) {
-			return jsonStringify(message);
-		}
-
-		return message;
-	}
-
-	private getLastNodeExecutedName(execution: IExecutionResponse): string | undefined {
-		const lastNodeExecuted = execution.data.resultData.lastNodeExecuted;
-		return typeof lastNodeExecuted === 'string' ? lastNodeExecuted : undefined;
-	}
-
-	private getNodeOutputs(execution: IExecutionResponse, nodeName: string) {
-		const runData = execution.data.resultData.runData[nodeName];
-		if (!runData || runData.length === 0) return [];
-		const runIndex = runData.length - 1;
-		const data = runData[runIndex]?.data;
-
-		return data?.main ?? data?.[NodeConnectionTypes.AiTool] ?? [];
-	}
-
-	private getFirstOutputEntry(
-		outputs: Array<INodeExecutionData[] | null>,
-	): INodeExecutionData | undefined {
-		for (const branch of outputs) {
-			if (!Array.isArray(branch) || branch.length === 0) continue;
-
-			return branch[0];
-		}
-
-		return undefined;
-	}
-
-	private extractMessageFromEntry(
-		entry: INodeExecutionData,
-		responseMode: ChatTriggerResponseMode,
-	) {
-		if (responseMode === 'responseNodes') {
-			return entry.sendMessage ?? '';
-		}
-
-		if (responseMode === 'lastNode') {
-			const response: Record<string, unknown> = entry.json ?? {};
-			const message = response.output ?? response.text ?? response.message ?? '';
-			return typeof message === 'string' ? message : jsonStringify(message);
-		}
-
-		return undefined;
-	}
-
-	/**
-	 * Resume a paused execution with new input
-	 */
-	private async resumeExecution(
-		sessionId: ChatSessionId,
-		execution: IExecutionResponse,
-		message: string,
-	) {
-		await this.executionManager.runWorkflow(execution, {
-			action: 'sendMessage',
-			chatInput: message,
-			sessionId,
-		});
-	}
-
-	/**
-	 * Execute a workflow with streaming output
-	 */
-	private async executeWithStreaming(
-		user: User,
-		model: ChatHubConversationModel,
-		workflowData: IWorkflowBase,
-		executionData: IRunExecutionData,
-		sessionId: string,
-		previousMessageId: string,
-		retryOfMessageId: string | null,
-		executionMode: WorkflowExecuteMode,
-	) {
-		let executionId: string | undefined;
-		let executionStatus: 'success' | 'error' | 'cancelled' = 'success';
-
-		const workflowId = workflowData.id;
-
-		// Start the execution (tracks state for the whole streaming session)
-		await this.chatStreamService.startExecution(user.id, sessionId);
-
-		// Create aggregator to handle multiple messages (e.g., tool calls followed by response)
-		const aggregator = createStructuredChunkAggregator(previousMessageId, retryOfMessageId, {
-			onBegin: async (message) => {
-				// Save the AI message to DB
-				await this.saveAIMessage({
-					id: message.id,
-					sessionId,
-					previousMessageId: message.previousMessageId ?? previousMessageId,
-					content: '',
-					model,
-					executionId,
-					retryOfMessageId: message.retryOfMessageId,
-					status: 'running',
-				});
-
-				// Start the stream for this message
-				await this.chatStreamService.startStream({
-					userId: user.id,
-					sessionId,
-					messageId: message.id,
-					previousMessageId: message.previousMessageId,
-					retryOfMessageId: message.retryOfMessageId,
-					executionId: executionId ? parseInt(executionId, 10) : null,
-				});
-			},
-			onItem: async (message, chunk) => {
-				await this.chatStreamService.sendChunk(sessionId, message.id, chunk);
-			},
-			onEnd: async (message) => {
-				// Update the message in the database
-				await this.messageRepository.updateChatMessage(message.id, {
-					content: message.content,
-					status: message.status,
-				});
-
-				// End the stream for this message
-				await this.chatStreamService.endStream(sessionId, message.id, message.status);
-			},
-			onError: async (message, errorText) => {
-				let contentToSave = message.content;
-				if (!contentToSave && errorText) {
-					contentToSave = errorText;
-				} else if (!contentToSave) {
-					contentToSave = executionId
-						? ((await this.waitForErrorDetails(executionId, workflowId)) ?? 'Unknown error')
-						: 'Request was not processed';
-				}
-
-				await this.messageRepository.manager.transaction(async (trx) => {
-					await this.messageRepository.updateChatMessage(
-						message.id,
-						{ content: contentToSave },
-						trx,
-					);
-
-					// When messages are cancelled they're already marked cancelled on `stopGeneration`
-					const savedMessage = await this.messageRepository.getOneById(
-						message.id,
-						sessionId,
-						[],
-						trx,
-					);
-					if (savedMessage?.status === 'cancelled') {
-						executionStatus = 'cancelled';
-						// End the stream with cancelled status
-						await this.chatStreamService.endStream(sessionId, message.id, 'cancelled');
-						return;
-					}
-
-					// Otherwise mark them as errored
-					executionStatus = 'error';
-					await this.messageRepository.updateChatMessage(message.id, { status: 'error' }, trx);
-
-					await this.chatStreamService.sendError(sessionId, message.id, contentToSave);
-					await this.chatStreamService.endStream(sessionId, message.id, 'error');
-				});
-			},
-			onCancel: async (message) => {
-				// Save content that was generated so far
-				await this.messageRepository.updateChatMessage(message.id, {
-					content: message.content,
-					status: 'cancelled',
-				});
-
-				// End stream with cancelled status
-				await this.chatStreamService.endStream(sessionId, message.id, 'cancelled');
-			},
-		});
-
-		// Create a fake Response-like object that routes to ChatStreamService via aggregator
-		const { adapter: streamAdapter, waitForPendingOperations } =
-			this.createStreamAdapter(aggregator);
-
-		try {
-			const execution = await this.workflowExecutionService.executeChatWorkflow(
-				user,
-				workflowData,
-				executionData,
-				streamAdapter,
-				true,
-				executionMode,
-			);
-
-			executionId = execution.executionId;
-
-			if (!executionId) {
-				throw new OperationalError('There was a problem starting the chat execution.');
-			}
-
-			await this.waitForExecutionCompletion(executionId);
-
-			// Wait for all pending aggregator operations to complete (message status updates, etc.)
-			await waitForPendingOperations();
-		} catch (error) {
-			if (error instanceof ManualExecutionCancelledError) {
-				executionStatus = 'cancelled';
-				// On multi-main, the stream doesn't send an error chunk on cancellation,
-				// so we need to explicitly cancel all active messages.
-				// On single-main, the onError handler already handles this via the error chunk.
-				if (this.instanceSettings.isMultiMain) {
-					await aggregator.cancelAll();
-				}
-			} else {
-				executionStatus = 'error';
-				throw error;
-			}
-		} finally {
-			// Wait for pending operations even on error to ensure proper cleanup
-			await waitForPendingOperations();
-			// End the execution (cleanup session state)
-			await this.chatStreamService.endExecution(user.id, sessionId, executionStatus);
-		}
-	}
-
-	/**
-	 * Create a Response-like object that routes streaming data to ChatStreamService via aggregator
-	 * Returns both the adapter and a function to wait for all pending operations to complete
-	 */
-	private createStreamAdapter(aggregator: ReturnType<typeof createStructuredChunkAggregator>): {
-		adapter: Response;
-		waitForPendingOperations: () => Promise<void>;
-	} {
-		// Chain for sequential processing of chunks to avoid race conditions
-		// Each chunk must complete before the next one starts (e.g., 'begin' must finish
-		// setting up the message before 'item' or 'end' tries to use it)
-		let processingChain = Promise.resolve();
-
-		// Create a minimal Response-like object
-		const adapter = {
-			headersSent: false,
-			writableEnded: false,
-
-			writeHead: (_statusCode: number, _headers?: Record<string, string>) => {
-				adapter.headersSent = true;
-				return adapter;
-			},
-
-			flushHeaders: () => {},
-
-			write: (chunk: string | Buffer, _encoding?: BufferEncoding, doneCb?: () => void) => {
-				const text = Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk;
-
-				// Process each line (JSONL format) through the aggregator
-				const lines = text.split('\n').filter((line) => line.trim());
-				for (const line of lines) {
-					try {
-						const parsed = jsonParse<StructuredChunk>(line.trim());
-						// Chain the ingest calls to ensure sequential processing
-						// This prevents race conditions where 'item' arrives before 'begin' finishes
-						processingChain = processingChain.then(async () => {
-							await aggregator.ingest(parsed);
-						});
-					} catch {
-						// Not valid JSON, ignore
-					}
-				}
-
-				if (doneCb) doneCb();
-				return true;
-			},
-
-			end: (_chunk?: unknown, _encoding?: BufferEncoding, doneCb?: () => void) => {
-				adapter.writableEnded = true;
-				if (doneCb) doneCb();
-				return adapter;
-			},
-
-			flush: () => {},
-
-			on: (_event: string, _handler: (...args: unknown[]) => void) => adapter,
-			once: (_event: string, _handler: (...args: unknown[]) => void) => adapter,
-			emit: (_event: string, ..._args: unknown[]) => true,
-		};
-
-		const waitForPendingOperations = async () => {
-			await processingChain;
-		};
-
-		return { adapter: adapter as unknown as Response, waitForPendingOperations };
 	}
 
 	/**

--- a/packages/cli/src/modules/chat-hub/chat-message.repository.ts
+++ b/packages/cli/src/modules/chat-hub/chat-message.repository.ts
@@ -11,8 +11,8 @@ import { QueryDeepPartialEntity } from '@n8n/typeorm/query-builder/QueryPartialE
 import { UnexpectedError, type IBinaryData } from 'n8n-workflow';
 
 import { ChatHubMessage } from './chat-hub-message.entity';
-import { ChatHubSessionRepository } from './chat-session.repository';
 import { EditMessagePayload, HumanMessagePayload } from './chat-hub.types';
+import { ChatHubSessionRepository } from './chat-session.repository';
 
 @Service()
 export class ChatHubMessageRepository extends Repository<ChatHubMessage> {

--- a/packages/cli/src/modules/chat-hub/chat-message.repository.ts
+++ b/packages/cli/src/modules/chat-hub/chat-message.repository.ts
@@ -1,5 +1,10 @@
-import type { ChatHubMessageStatus, ChatMessageId, ChatSessionId } from '@n8n/api-types';
-import { withTransaction } from '@n8n/db';
+import type {
+	ChatHubConversationModel,
+	ChatHubMessageStatus,
+	ChatMessageId,
+	ChatSessionId,
+} from '@n8n/api-types';
+import { User, withTransaction } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { DataSource, EntityManager, Repository } from '@n8n/typeorm';
 import { QueryDeepPartialEntity } from '@n8n/typeorm/query-builder/QueryPartialEntity';
@@ -7,6 +12,7 @@ import { UnexpectedError, type IBinaryData } from 'n8n-workflow';
 
 import { ChatHubMessage } from './chat-hub-message.entity';
 import { ChatHubSessionRepository } from './chat-session.repository';
+import { EditMessagePayload, HumanMessagePayload } from './chat-hub.types';
 
 @Service()
 export class ChatHubMessageRepository extends Repository<ChatHubMessage> {
@@ -36,6 +42,66 @@ export class ChatHubMessageRepository extends Repository<ChatHubMessage> {
 				{ lastMessageAt: new Date() },
 				em,
 			);
+		});
+	}
+
+	async createHumanMessage(
+		payload: HumanMessagePayload | EditMessagePayload,
+		attachments: IBinaryData[],
+		user: User,
+		previousMessageId: ChatMessageId | null,
+		model: ChatHubConversationModel,
+		revisionOfMessageId?: ChatMessageId,
+		trx?: EntityManager,
+	) {
+		await this.createChatMessage(
+			{
+				id: payload.messageId,
+				sessionId: payload.sessionId,
+				type: 'human',
+				status: 'success',
+				content: payload.message,
+				previousMessageId,
+				revisionOfMessageId,
+				name: user.firstName || 'User',
+				attachments,
+				...model,
+			},
+			trx,
+		);
+	}
+
+	async createAIMessage({
+		id,
+		sessionId,
+		executionId,
+		previousMessageId,
+		content,
+		model,
+		retryOfMessageId,
+		status,
+	}: {
+		id: ChatMessageId;
+		sessionId: ChatSessionId;
+		previousMessageId: ChatMessageId | null;
+		content: string;
+		model: ChatHubConversationModel;
+		executionId?: string;
+		retryOfMessageId: ChatMessageId | null;
+		editOfMessageId?: ChatMessageId;
+		status?: ChatHubMessageStatus;
+	}) {
+		await this.createChatMessage({
+			id,
+			sessionId,
+			previousMessageId,
+			executionId: executionId ? parseInt(executionId, 10) : null,
+			type: 'ai',
+			name: 'AI',
+			status,
+			content,
+			retryOfMessageId,
+			...model,
 		});
 	}
 


### PR DESCRIPTION
## Summary

`chat-hub.service.ts` had gotten way too long and hard to maintain. Move title generation logic and execution handling out of it, and move workflow preparation logic to `ChatHubWorkflowService`. This PR shouldn't change anything, just move things around.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
