### PR TITLE
fix(Google Drive Node): Add Markdown export format for Google Docs files

### DIFF
--- a/packages/nodes-base/nodes/Google/Drive/v2/actions/file/download.operation.ts
+++ b/packages/nodes-base/nodes/Google/Drive/v2/actions/file/download.operation.ts
@@ -79,6 +79,11 @@ const properties: INodeProperties[] = [
 										name: 'Text (txt)',
 										value: 'text/plain',
 									},
+									{
+										// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
+										name: 'Markdown (md)',
+										value: 'text/markdown',
+									},
 								],
 								default: 'text/html',
 								description: 'Format used to export when downloading Google Docs files',


### PR DESCRIPTION
## Summary

Add Markdown format downloads of Google Drive documents.

## Motivation

The markdown format is widely used in AI. This format is very convenient with RecursiveCharacterTextSplitter node configured with splitCode=markdown. And it is a format that Google Docs can export[1].

Ref:
[1] https://developers.google.com/workspace/drive/api/guides/ref-export-formats

## Workaround

Right now, it is possible to set the document conversion field as an expression with the value `text/markdown`.

<img width="346" height="157" alt="image" src="https://github.com/user-attachments/assets/70875f7d-793f-414c-b2b6-bb034046a985" />

## Related Linear tickets, Github issues, and Community forum posts

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
