### PR TITLE
Add remote OpenClaw setup guide and automation scripts

### DIFF
--- a/remote-openclaw-setup/.env.example
+++ b/remote-openclaw-setup/.env.example
@@ -1,0 +1,23 @@
+# =============================================================================
+# OpenClaw 원격 접속 환경 변수
+# 이 파일을 .env 로 복사한 후 실제 값을 입력하세요
+# =============================================================================
+
+# ── 원격 Ubuntu PC (OpenClaw 서버) 정보 ──
+OPENCLAW_REMOTE_USER=ubuntu
+OPENCLAW_REMOTE_HOST=192.168.1.100
+OPENCLAW_REMOTE_SSH_PORT=22
+
+# ── OpenClaw Gateway 설정 ──
+OPENCLAW_GATEWAY_PORT=18789
+OPENCLAW_GATEWAY_TOKEN=your-gateway-token-here
+
+# ── SSH 키 경로 ──
+OPENCLAW_SSH_KEY=~/.ssh/id_ed25519
+
+# ── AI 모델 설정 (원격 PC의 OpenClaw에서 사용) ──
+# Anthropic API Key (원격 PC에 설정)
+ANTHROPIC_API_KEY=sk-ant-xxxxx
+
+# 또는 OpenRouter API Key
+# OPENROUTER_API_KEY=sk-or-xxxxx

--- a/remote-openclaw-setup/README.md
+++ b/remote-openclaw-setup/README.md
@@ -1,0 +1,291 @@
+# Remote OpenClaw Setup Guide
+
+이 PC에서 원격 Ubuntu PC에 설치된 OpenClaw를 제어하기 위한 설정 가이드.
+
+## 아키텍처 개요
+
+```
+[이 PC (클라이언트)]                    [원격 Ubuntu PC (서버)]
+ ├─ SSH 터널 (포트 18789)  ──────────▶  ├─ OpenClaw Gateway (ws://127.0.0.1:18789)
+ ├─ 브라우저 (Control UI)               ├─ OpenClaw Agent Runtime
+ ├─ n8n (워크플로우 자동화)              ├─ 채널 연동 (WhatsApp/Telegram 등)
+ └─ CLI 클라이언트                       └─ 도구 실행 (파일, 브라우저, 터미널)
+```
+
+## 전제 조건
+
+### 원격 Ubuntu PC (OpenClaw 서버)
+- Ubuntu 22.04/24.04 LTS
+- Node.js >= 22
+- OpenClaw 설치 완료 (`npm install -g openclaw@latest`)
+- SSH 서버 활성화 (`sudo apt install openssh-server`)
+- OpenClaw Gateway 실행 중
+
+### 이 PC (클라이언트)
+- SSH 클라이언트 설치
+- 브라우저 (Control UI 접속용)
+- n8n (워크플로우 자동화 연동 시)
+
+---
+
+## 방법 1: SSH 터널 (권장 - 가장 안전)
+
+### 1단계: 원격 PC에서 OpenClaw Gateway 실행
+
+```bash
+# 원격 Ubuntu PC에서 실행
+openclaw gateway --port 18789 --verbose
+```
+
+또는 데몬으로 실행:
+```bash
+openclaw onboard --install-daemon
+# systemd 서비스로 자동 시작됨
+```
+
+### 2단계: 이 PC에서 SSH 터널 생성
+
+```bash
+# 기본 SSH 터널
+ssh -N -L 18789:127.0.0.1:18789 사용자명@원격PC_IP
+
+# 백그라운드에서 실행
+ssh -fN -L 18789:127.0.0.1:18789 사용자명@원격PC_IP
+
+# SSH 키 인증 사용 (비밀번호 입력 불필요)
+ssh -fN -i ~/.ssh/id_rsa -L 18789:127.0.0.1:18789 사용자명@원격PC_IP
+```
+
+### 3단계: Control UI 접속
+
+브라우저에서 열기:
+```
+http://127.0.0.1:18789/?token=YOUR-GENERATED-TOKEN
+```
+
+### 4단계: CLI로 원격 제어
+
+```bash
+# 원격 Gateway 상태 확인
+openclaw gateway status --url ws://127.0.0.1:18789
+
+# 원격 Gateway에 메시지 전송
+openclaw gateway send --url ws://127.0.0.1:18789 --message "작업 수행해줘"
+
+# 에이전트 실행
+openclaw agent --message "파일 정리해줘" --thinking high
+```
+
+---
+
+## 방법 2: Tailscale VPN (편리한 설정)
+
+### 양쪽 PC에 Tailscale 설치
+
+```bash
+# Ubuntu (원격 PC)
+curl -fsSL https://tailscale.com/install.sh | sh
+sudo tailscale up
+
+# 이 PC (클라이언트)
+# https://tailscale.com/download 에서 설치
+tailscale up
+```
+
+### Gateway를 Tailnet에 바인딩
+
+```bash
+# 원격 Ubuntu PC에서
+openclaw gateway --bind tailnet --token YOUR_GATEWAY_TOKEN --port 18789
+```
+
+### Tailscale Serve 설정 (HTTPS)
+
+`~/.openclaw/openclaw.json` 에서:
+```json
+{
+  "gateway": {
+    "bind": "loopback",
+    "port": 18789,
+    "tailscale": {
+      "mode": "serve",
+      "resetOnExit": true
+    }
+  }
+}
+```
+
+### 접속
+
+```
+https://원격PC호스트명.tail-xxxxx.ts.net:18789
+```
+
+---
+
+## 방법 3: LAN 바인딩 (같은 네트워크)
+
+같은 로컬 네트워크에 있을 경우:
+
+```bash
+# 원격 Ubuntu PC에서 (주의: 반드시 토큰 사용)
+openclaw gateway --bind lan --port 18789 --token YOUR_SECURE_TOKEN
+```
+
+접속:
+```
+http://원격PC_IP:18789/?token=YOUR_SECURE_TOKEN
+```
+
+> ⚠️ LAN 바인딩은 SSH 터널이나 Tailscale보다 보안이 약함. 반드시 토큰 인증 필수.
+
+---
+
+## 원격 PC의 OpenClaw 설정 파일
+
+### `~/.openclaw/openclaw.json` (원격 Ubuntu PC)
+
+```json
+{
+  "agent": {
+    "model": "anthropic/claude-opus-4-5"
+  },
+  "agents": {
+    "defaults": {
+      "workspace": "~/.openclaw/workspace",
+      "sandbox": {
+        "mode": "non-main"
+      }
+    }
+  },
+  "gateway": {
+    "bind": "loopback",
+    "port": 18789,
+    "auth": {
+      "mode": "token"
+    }
+  }
+}
+```
+
+---
+
+## n8n 워크플로우 연동
+
+n8n에서 OpenClaw를 제어하려면:
+
+### 1. OpenClaw n8n 스킬 설치 (원격 PC)
+
+```bash
+# 원격 Ubuntu PC에서
+openclaw skills install n8n
+openclaw skills install n8n-workflow-automation
+```
+
+### 2. n8n HTTP Request 노드로 Gateway API 호출
+
+SSH 터널이 열린 상태에서 n8n의 HTTP Request 노드:
+
+- **Method**: POST
+- **URL**: `http://127.0.0.1:18789/api/sessions/send`
+- **Headers**: `Authorization: Bearer YOUR_GATEWAY_TOKEN`
+- **Body**:
+```json
+{
+  "message": "작업 내용"
+}
+```
+
+### 3. WebSocket 연동
+
+n8n의 WebSocket 노드를 사용해 실시간 통신:
+- **URL**: `ws://127.0.0.1:18789`
+- Gateway 프로토콜 메서드:
+  - `sessions_list` — 활성 세션 목록
+  - `sessions_history` — 대화 로그
+  - `sessions_send` — 메시지 전송
+  - `node.invoke` — 원격 장치 작업 실행
+
+---
+
+## SSH 키 설정 (비밀번호 없이 접속)
+
+```bash
+# 이 PC에서 SSH 키 생성 (이미 있으면 스킵)
+ssh-keygen -t ed25519 -C "openclaw-remote"
+
+# 원격 PC에 공개키 복사
+ssh-copy-id 사용자명@원격PC_IP
+
+# 테스트
+ssh 사용자명@원격PC_IP "openclaw gateway health"
+```
+
+---
+
+## 자동 SSH 터널 유지 (autossh)
+
+```bash
+# autossh 설치
+sudo apt install autossh  # 또는 brew install autossh
+
+# 자동 재연결되는 SSH 터널
+autossh -M 0 -fN -o "ServerAliveInterval 30" -o "ServerAliveCountMax 3" \
+  -L 18789:127.0.0.1:18789 사용자명@원격PC_IP
+```
+
+### systemd 서비스로 등록 (Linux 클라이언트)
+
+`/etc/systemd/system/openclaw-tunnel.service`:
+```ini
+[Unit]
+Description=OpenClaw SSH Tunnel
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=YOUR_USERNAME
+ExecStart=/usr/bin/autossh -M 0 -N -o "ServerAliveInterval 30" -o "ServerAliveCountMax 3" -L 18789:127.0.0.1:18789 사용자명@원격PC_IP
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl enable openclaw-tunnel
+sudo systemctl start openclaw-tunnel
+```
+
+---
+
+## 트러블슈팅
+
+| 문제 | 해결 방법 |
+|------|-----------|
+| `Connection refused` | 원격 PC에서 Gateway 실행 중인지 확인: `openclaw gateway health` |
+| `pairing required (1008)` | 터널 접속 시 페어링 필요 — `openclaw pairing approve` 실행 |
+| SSH 터널 끊김 | `autossh` 사용 또는 `ServerAliveInterval` 설정 |
+| 포트 충돌 | `lsof -i :18789`로 확인, 포트 변경 또는 충돌 프로세스 종료 |
+| 토큰 인증 실패 | `~/.openclaw/openclaw.json`의 토큰 확인 |
+| Gateway 느림 | `openclaw doctor` 실행하여 설정 점검 |
+
+---
+
+## 보안 권장사항
+
+1. **Gateway를 절대 공개 인터넷에 노출하지 말 것** — Shodan에서 노출된 Gateway가 발견됨
+2. **SSH 터널 또는 Tailscale 사용** — loopback 바인딩 유지
+3. **비-loopback 바인딩 시 반드시 토큰/비밀번호 인증 설정**
+4. **SSH 키 인증 사용** — 비밀번호 인증 비활성화 권장
+5. **`openclaw doctor` 정기 실행** — 위험한 설정 탐지
+
+## 참고 자료
+
+- [OpenClaw 공식 문서](https://docs.openclaw.ai/)
+- [OpenClaw GitHub](https://github.com/openclaw/openclaw)
+- [원격 접속 가이드](https://docs.openclaw.ai/gateway/remote)
+- [OpenClaw 시작하기](https://docs.openclaw.ai/start/getting-started)
+- [Awesome OpenClaw Skills (n8n 포함)](https://github.com/VoltAgent/awesome-openclaw-skills)

--- a/remote-openclaw-setup/configs/openclaw-server.json
+++ b/remote-openclaw-setup/configs/openclaw-server.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://docs.openclaw.ai/schema/config.json",
+  "_comment": "원격 Ubuntu PC에 배치할 OpenClaw 설정 파일. ~/.openclaw/openclaw.json 으로 복사하세요.",
+  "agent": {
+    "model": "anthropic/claude-opus-4-5"
+  },
+  "agents": {
+    "defaults": {
+      "workspace": "~/.openclaw/workspace",
+      "sandbox": {
+        "mode": "non-main"
+      }
+    }
+  },
+  "gateway": {
+    "bind": "loopback",
+    "port": 18789,
+    "auth": {
+      "mode": "token"
+    },
+    "tailscale": {
+      "mode": "off",
+      "resetOnExit": true
+    }
+  }
+}

--- a/remote-openclaw-setup/configs/openclaw-tunnel.service
+++ b/remote-openclaw-setup/configs/openclaw-tunnel.service
@@ -1,0 +1,44 @@
+# =============================================================================
+# OpenClaw SSH 터널 systemd 서비스
+# 클라이언트 PC (이 PC)에 설치하여 원격 OpenClaw Gateway에 자동 연결
+#
+# 설치 방법:
+#   1. 이 파일의 User, ExecStart 부분을 환경에 맞게 수정
+#   2. sudo cp openclaw-tunnel.service /etc/systemd/system/
+#   3. sudo systemctl daemon-reload
+#   4. sudo systemctl enable openclaw-tunnel
+#   5. sudo systemctl start openclaw-tunnel
+#
+# 상태 확인:
+#   sudo systemctl status openclaw-tunnel
+#   journalctl -u openclaw-tunnel -f
+# =============================================================================
+
+[Unit]
+Description=OpenClaw Remote SSH Tunnel (autossh)
+Documentation=https://docs.openclaw.ai/gateway/remote
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+
+# ── 아래 값을 환경에 맞게 수정하세요 ──
+User=YOUR_LOCAL_USERNAME
+Environment="AUTOSSH_GATETIME=0"
+Environment="AUTOSSH_PORT=0"
+
+ExecStart=/usr/bin/autossh -M 0 -N \
+    -o "ServerAliveInterval=30" \
+    -o "ServerAliveCountMax=3" \
+    -o "ExitOnForwardFailure=yes" \
+    -o "StrictHostKeyChecking=accept-new" \
+    -i /home/YOUR_LOCAL_USERNAME/.ssh/id_ed25519 \
+    -L 18789:127.0.0.1:18789 \
+    REMOTE_USER@REMOTE_HOST_IP
+
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/remote-openclaw-setup/scripts/health-check.sh
+++ b/remote-openclaw-setup/scripts/health-check.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# =============================================================================
+# OpenClaw 원격 연결 상태 점검 스크립트
+# 이 PC에서 실행하여 원격 OpenClaw 연결 상태를 확인
+# =============================================================================
+
+set -euo pipefail
+
+GATEWAY_PORT="${OPENCLAW_GATEWAY_PORT:-18789}"
+REMOTE_USER="${OPENCLAW_REMOTE_USER:-}"
+REMOTE_HOST="${OPENCLAW_REMOTE_HOST:-}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+pass() { echo -e "  ${GREEN}[PASS]${NC} $1"; }
+fail() { echo -e "  ${RED}[FAIL]${NC} $1"; }
+warn() { echo -e "  ${YELLOW}[WARN]${NC} $1"; }
+info() { echo -e "  ${BLUE}[INFO]${NC} $1"; }
+
+echo "============================================="
+echo "  OpenClaw 원격 연결 상태 점검"
+echo "============================================="
+echo ""
+
+# .env 로드
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="$SCRIPT_DIR/../.env"
+if [ -f "$ENV_FILE" ]; then
+    set -a
+    source "$ENV_FILE"
+    set +a
+    info ".env 파일 로드됨"
+fi
+
+ERRORS=0
+
+# 1. SSH 터널 확인
+echo "[1/6] SSH 터널 확인"
+if ss -tlnp 2>/dev/null | grep -q ":${GATEWAY_PORT}" || \
+   lsof -i ":${GATEWAY_PORT}" &>/dev/null 2>&1; then
+    pass "로컬 포트 $GATEWAY_PORT 활성"
+else
+    fail "로컬 포트 $GATEWAY_PORT 비활성 - SSH 터널이 필요합니다"
+    ERRORS=$((ERRORS + 1))
+fi
+
+# 2. Gateway HTTP 응답 확인
+echo "[2/6] Gateway HTTP 응답"
+HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${GATEWAY_PORT}/" 2>/dev/null || echo "000")
+if [ "$HTTP_STATUS" != "000" ]; then
+    pass "Gateway HTTP 응답: $HTTP_STATUS"
+else
+    fail "Gateway HTTP 응답 없음"
+    ERRORS=$((ERRORS + 1))
+fi
+
+# 3. Gateway WebSocket 연결 확인
+echo "[3/6] Gateway WebSocket"
+if command -v wscat &>/dev/null; then
+    if timeout 5 wscat -c "ws://127.0.0.1:${GATEWAY_PORT}" --execute 'ping' &>/dev/null; then
+        pass "WebSocket 연결 성공"
+    else
+        warn "WebSocket 연결 실패 (토큰이 필요할 수 있음)"
+    fi
+else
+    info "wscat 미설치 - WebSocket 테스트 스킵 (npm install -g wscat)"
+fi
+
+# 4. 원격 SSH 연결 확인
+echo "[4/6] 원격 SSH 연결"
+if [ -n "$REMOTE_HOST" ] && [ -n "$REMOTE_USER" ]; then
+    if ssh -o ConnectTimeout=5 -o BatchMode=yes "${REMOTE_USER}@${REMOTE_HOST}" "echo ok" &>/dev/null; then
+        pass "SSH 연결 성공: ${REMOTE_USER}@${REMOTE_HOST}"
+    else
+        fail "SSH 연결 실패: ${REMOTE_USER}@${REMOTE_HOST}"
+        ERRORS=$((ERRORS + 1))
+    fi
+else
+    warn "REMOTE_HOST/REMOTE_USER 미설정 - SSH 테스트 스킵"
+fi
+
+# 5. 원격 OpenClaw 프로세스 확인
+echo "[5/6] 원격 OpenClaw 프로세스"
+if [ -n "$REMOTE_HOST" ] && [ -n "$REMOTE_USER" ]; then
+    REMOTE_GW=$(ssh -o ConnectTimeout=5 -o BatchMode=yes "${REMOTE_USER}@${REMOTE_HOST}" \
+        "pgrep -f 'openclaw.*gateway' > /dev/null 2>&1 && echo 'running' || echo 'stopped'" 2>/dev/null || echo "error")
+    if [ "$REMOTE_GW" = "running" ]; then
+        pass "원격 OpenClaw Gateway 실행 중"
+    elif [ "$REMOTE_GW" = "stopped" ]; then
+        fail "원격 OpenClaw Gateway 중지됨"
+        ERRORS=$((ERRORS + 1))
+    else
+        fail "원격 서버 연결 불가"
+        ERRORS=$((ERRORS + 1))
+    fi
+else
+    warn "원격 서버 정보 미설정 - 스킵"
+fi
+
+# 6. OpenClaw CLI 확인
+echo "[6/6] 로컬 OpenClaw CLI"
+if command -v openclaw &>/dev/null; then
+    pass "OpenClaw CLI 설치됨: $(openclaw --version 2>/dev/null || echo 'unknown')"
+else
+    warn "로컬에 OpenClaw CLI 미설치 (선택사항)"
+fi
+
+# 결과 요약
+echo ""
+echo "============================================="
+if [ $ERRORS -eq 0 ]; then
+    echo -e "  ${GREEN}모든 점검 통과!${NC}"
+    echo ""
+    echo "  Control UI: http://127.0.0.1:${GATEWAY_PORT}"
+    echo "  WebSocket:  ws://127.0.0.1:${GATEWAY_PORT}"
+else
+    echo -e "  ${RED}${ERRORS}개 항목 실패${NC}"
+    echo ""
+    echo "  문제 해결:"
+    echo "  1. SSH 터널 확인: ssh -fN -L ${GATEWAY_PORT}:127.0.0.1:${GATEWAY_PORT} user@host"
+    echo "  2. 원격 Gateway 확인: ssh user@host 'openclaw gateway health'"
+    echo "  3. 상세 문서: remote-openclaw-setup/README.md"
+fi
+echo "============================================="

--- a/remote-openclaw-setup/scripts/setup-remote-server.sh
+++ b/remote-openclaw-setup/scripts/setup-remote-server.sh
@@ -1,0 +1,261 @@
+#!/bin/bash
+# =============================================================================
+# OpenClaw 원격 서버(Ubuntu) 초기 설정 스크립트
+# 원격 Ubuntu PC에서 실행하여 OpenClaw 서버 환경을 구성
+# =============================================================================
+
+set -euo pipefail
+
+GATEWAY_PORT="${OPENCLAW_GATEWAY_PORT:-18789}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+print_info()  { echo -e "${BLUE}[INFO]${NC} $1"; }
+print_ok()    { echo -e "${GREEN}[OK]${NC} $1"; }
+print_warn()  { echo -e "${YELLOW}[WARN]${NC} $1"; }
+print_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# ── 시스템 요구사항 확인 ──
+check_system() {
+    print_info "시스템 요구사항을 확인합니다..."
+
+    # OS 확인
+    if [ -f /etc/os-release ]; then
+        . /etc/os-release
+        print_ok "OS: $PRETTY_NAME"
+    fi
+
+    # 메모리 확인
+    local total_mem
+    total_mem=$(free -m | awk '/^Mem:/{print $2}')
+    if [ "$total_mem" -ge 2048 ]; then
+        print_ok "메모리: ${total_mem}MB (최소 2GB 충족)"
+    else
+        print_warn "메모리: ${total_mem}MB (2GB 이상 권장)"
+    fi
+
+    # 디스크 확인
+    local free_disk
+    free_disk=$(df -BG / | awk 'NR==2{print $4}' | tr -d 'G')
+    if [ "$free_disk" -ge 10 ]; then
+        print_ok "디스크 여유 공간: ${free_disk}GB"
+    else
+        print_warn "디스크 여유 공간: ${free_disk}GB (10GB 이상 권장)"
+    fi
+}
+
+# ── SSH 서버 설정 ──
+setup_ssh() {
+    print_info "SSH 서버를 확인합니다..."
+
+    if systemctl is-active --quiet sshd 2>/dev/null || systemctl is-active --quiet ssh 2>/dev/null; then
+        print_ok "SSH 서버 실행 중"
+    else
+        print_info "SSH 서버를 설치하고 시작합니다..."
+        sudo apt update
+        sudo apt install -y openssh-server
+        sudo systemctl enable ssh
+        sudo systemctl start ssh
+        print_ok "SSH 서버 설치 및 시작 완료"
+    fi
+
+    # SSH 보안 설정 권장
+    print_info "SSH 보안 설정 권장사항:"
+    echo "  /etc/ssh/sshd_config 에서:"
+    echo "    PasswordAuthentication no    # 키 인증만 허용"
+    echo "    PermitRootLogin no           # root 로그인 차단"
+    echo "    MaxAuthTries 3               # 인증 시도 제한"
+}
+
+# ── Node.js 설치/확인 ──
+setup_nodejs() {
+    print_info "Node.js를 확인합니다..."
+
+    if command -v node &>/dev/null; then
+        local node_version
+        node_version=$(node --version)
+        local major_version
+        major_version=$(echo "$node_version" | cut -d. -f1 | tr -d 'v')
+        if [ "$major_version" -ge 22 ]; then
+            print_ok "Node.js $node_version (요구사항 >= 22 충족)"
+        else
+            print_warn "Node.js $node_version 설치됨. >= 22 필요."
+            install_nodejs
+        fi
+    else
+        print_warn "Node.js가 설치되어 있지 않습니다."
+        install_nodejs
+    fi
+}
+
+install_nodejs() {
+    print_info "Node.js 22를 설치합니다..."
+    curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+    sudo apt install -y nodejs
+    print_ok "Node.js $(node --version) 설치 완료"
+}
+
+# ── OpenClaw 설치/확인 ──
+setup_openclaw() {
+    print_info "OpenClaw를 확인합니다..."
+
+    if command -v openclaw &>/dev/null; then
+        local oc_version
+        oc_version=$(openclaw --version 2>/dev/null || echo "unknown")
+        print_ok "OpenClaw 설치됨: $oc_version"
+    else
+        print_info "OpenClaw를 설치합니다..."
+        npm install -g openclaw@latest
+        print_ok "OpenClaw 설치 완료"
+    fi
+}
+
+# ── OpenClaw 설정 파일 생성 ──
+configure_openclaw() {
+    local config_dir="$HOME/.openclaw"
+    local config_file="$config_dir/openclaw.json"
+
+    mkdir -p "$config_dir"
+
+    if [ -f "$config_file" ]; then
+        print_ok "설정 파일 존재: $config_file"
+        print_info "기존 설정을 유지합니다."
+    else
+        print_info "기본 설정 파일을 생성합니다..."
+        cat > "$config_file" << 'CONF'
+{
+  "agent": {
+    "model": "anthropic/claude-opus-4-5"
+  },
+  "agents": {
+    "defaults": {
+      "workspace": "~/.openclaw/workspace"
+    }
+  },
+  "gateway": {
+    "bind": "loopback",
+    "port": 18789,
+    "auth": {
+      "mode": "token"
+    }
+  }
+}
+CONF
+        print_ok "설정 파일 생성: $config_file"
+    fi
+
+    # 작업 디렉터리 생성
+    mkdir -p "$config_dir/workspace"
+    print_ok "작업 디렉터리: $config_dir/workspace"
+}
+
+# ── 방화벽 설정 ──
+setup_firewall() {
+    print_info "방화벽을 확인합니다..."
+
+    if command -v ufw &>/dev/null; then
+        local ufw_status
+        ufw_status=$(sudo ufw status 2>/dev/null | head -1)
+        if echo "$ufw_status" | grep -q "active"; then
+            print_ok "UFW 방화벽 활성"
+            # SSH만 허용 (Gateway는 loopback이므로 별도 포트 오픈 불필요)
+            sudo ufw allow ssh 2>/dev/null || true
+            print_info "SSH 포트 허용됨. Gateway($GATEWAY_PORT)는 loopback이므로 별도 허용 불필요."
+        else
+            print_warn "UFW 방화벽 비활성. 활성화를 권장합니다:"
+            echo "  sudo ufw enable"
+            echo "  sudo ufw allow ssh"
+        fi
+    else
+        print_info "UFW가 설치되어 있지 않습니다. 필요 시: sudo apt install ufw"
+    fi
+}
+
+# ── Gateway 데몬 설정 ──
+setup_gateway_daemon() {
+    print_info "Gateway 데몬을 설정합니다..."
+
+    read -rp "Gateway 데몬(systemd 서비스)을 설정하시겠습니까? (y/N): " setup_daemon
+    if [[ "$setup_daemon" =~ ^[Yy]$ ]]; then
+        openclaw onboard --install-daemon 2>/dev/null && {
+            print_ok "Gateway 데몬 설정 완료"
+        } || {
+            print_warn "데몬 설정에 실패했습니다. 수동으로 설정하세요."
+            print_info "수동 시작: openclaw gateway --port $GATEWAY_PORT --verbose"
+        }
+    else
+        print_info "수동으로 Gateway를 시작하려면:"
+        echo "  openclaw gateway --port $GATEWAY_PORT --verbose"
+        echo ""
+        echo "  # 백그라운드 실행:"
+        echo "  nohup openclaw gateway --port $GATEWAY_PORT --verbose > ~/.openclaw/gateway.log 2>&1 &"
+    fi
+}
+
+# ── 상태 진단 ──
+run_diagnostics() {
+    print_info "시스템 진단을 실행합니다..."
+
+    # Gateway 포트 확인
+    if ss -tlnp 2>/dev/null | grep -q ":${GATEWAY_PORT}"; then
+        print_ok "Gateway가 포트 $GATEWAY_PORT 에서 실행 중"
+    else
+        print_warn "Gateway가 실행 중이 아닙니다"
+    fi
+
+    # OpenClaw doctor 실행
+    if command -v openclaw &>/dev/null; then
+        print_info "openclaw doctor 실행..."
+        openclaw doctor 2>/dev/null || print_warn "doctor 명령 실행 실패"
+    fi
+
+    # 네트워크 정보
+    print_info "네트워크 정보:"
+    local ip_addr
+    ip_addr=$(hostname -I 2>/dev/null | awk '{print $1}')
+    echo "  IP 주소: $ip_addr"
+    echo "  호스트명: $(hostname)"
+    echo ""
+    echo "  클라이언트 PC에서 SSH 터널 명령:"
+    echo "  ssh -fN -L ${GATEWAY_PORT}:127.0.0.1:${GATEWAY_PORT} $(whoami)@${ip_addr}"
+}
+
+# ── 메인 ──
+main() {
+    echo "============================================="
+    echo "  OpenClaw 원격 서버(Ubuntu) 초기 설정"
+    echo "============================================="
+    echo ""
+
+    check_system
+    echo ""
+    setup_ssh
+    echo ""
+    setup_nodejs
+    echo ""
+    setup_openclaw
+    echo ""
+    configure_openclaw
+    echo ""
+    setup_firewall
+    echo ""
+    setup_gateway_daemon
+    echo ""
+    run_diagnostics
+
+    echo ""
+    echo "============================================="
+    print_ok "서버 설정 완료!"
+    echo "============================================="
+    echo ""
+    echo "다음 단계:"
+    echo "  1. 클라이언트 PC에서 setup-ssh-tunnel.sh 실행"
+    echo "  2. 브라우저에서 http://127.0.0.1:${GATEWAY_PORT} 접속"
+    echo "  3. openclaw gateway status 로 상태 확인"
+}
+
+main "$@"

--- a/remote-openclaw-setup/scripts/setup-ssh-tunnel.sh
+++ b/remote-openclaw-setup/scripts/setup-ssh-tunnel.sh
@@ -1,0 +1,216 @@
+#!/bin/bash
+# =============================================================================
+# OpenClaw 원격 SSH 터널 설정 스크립트
+# 이 PC에서 실행하여 원격 Ubuntu PC의 OpenClaw Gateway에 연결
+# =============================================================================
+
+set -euo pipefail
+
+# ── 설정 변수 (환경에 맞게 수정) ──
+REMOTE_USER="${OPENCLAW_REMOTE_USER:-}"
+REMOTE_HOST="${OPENCLAW_REMOTE_HOST:-}"
+REMOTE_PORT="${OPENCLAW_REMOTE_SSH_PORT:-22}"
+GATEWAY_PORT="${OPENCLAW_GATEWAY_PORT:-18789}"
+SSH_KEY="${OPENCLAW_SSH_KEY:-$HOME/.ssh/id_ed25519}"
+
+# ── 색상 ──
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+print_info()  { echo -e "${BLUE}[INFO]${NC} $1"; }
+print_ok()    { echo -e "${GREEN}[OK]${NC} $1"; }
+print_warn()  { echo -e "${YELLOW}[WARN]${NC} $1"; }
+print_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# ── 사용자 입력 ──
+prompt_config() {
+    if [ -z "$REMOTE_USER" ]; then
+        read -rp "원격 Ubuntu PC 사용자명: " REMOTE_USER
+    fi
+    if [ -z "$REMOTE_HOST" ]; then
+        read -rp "원격 Ubuntu PC IP 주소 또는 호스트명: " REMOTE_HOST
+    fi
+    echo ""
+    print_info "설정 정보:"
+    echo "  원격 사용자: $REMOTE_USER"
+    echo "  원격 호스트: $REMOTE_HOST"
+    echo "  SSH 포트:    $REMOTE_PORT"
+    echo "  Gateway 포트: $GATEWAY_PORT"
+    echo "  SSH 키:      $SSH_KEY"
+    echo ""
+}
+
+# ── SSH 키 확인/생성 ──
+ensure_ssh_key() {
+    if [ ! -f "$SSH_KEY" ]; then
+        print_warn "SSH 키가 없습니다. 새로 생성합니다."
+        ssh-keygen -t ed25519 -C "openclaw-remote" -f "$SSH_KEY" -N ""
+        print_ok "SSH 키 생성 완료: $SSH_KEY"
+    else
+        print_ok "SSH 키 확인: $SSH_KEY"
+    fi
+}
+
+# ── SSH 키 원격 PC에 복사 ──
+copy_ssh_key() {
+    print_info "원격 PC에 SSH 공개키를 복사합니다..."
+    ssh-copy-id -i "${SSH_KEY}.pub" -p "$REMOTE_PORT" "${REMOTE_USER}@${REMOTE_HOST}" 2>/dev/null && {
+        print_ok "SSH 키 복사 완료"
+    } || {
+        print_warn "SSH 키 복사 실패 또는 이미 등록됨. 계속 진행합니다."
+    }
+}
+
+# ── 원격 OpenClaw 상태 확인 ──
+check_remote_openclaw() {
+    print_info "원격 PC의 OpenClaw 상태를 확인합니다..."
+
+    # OpenClaw 설치 확인
+    if ssh -i "$SSH_KEY" -p "$REMOTE_PORT" "${REMOTE_USER}@${REMOTE_HOST}" "command -v openclaw" &>/dev/null; then
+        print_ok "OpenClaw 설치 확인됨"
+    else
+        print_error "원격 PC에 OpenClaw가 설치되어 있지 않습니다."
+        print_info "원격 PC에서 다음 명령을 실행하세요:"
+        echo "  npm install -g openclaw@latest"
+        echo "  openclaw onboard --install-daemon"
+        return 1
+    fi
+
+    # Gateway 실행 확인
+    if ssh -i "$SSH_KEY" -p "$REMOTE_PORT" "${REMOTE_USER}@${REMOTE_HOST}" "ss -tlnp | grep -q $GATEWAY_PORT" 2>/dev/null; then
+        print_ok "Gateway가 포트 $GATEWAY_PORT 에서 실행 중"
+    else
+        print_warn "Gateway가 실행 중이 아닙니다."
+        print_info "원격 PC에서 Gateway를 시작합니다..."
+        ssh -i "$SSH_KEY" -p "$REMOTE_PORT" "${REMOTE_USER}@${REMOTE_HOST}" \
+            "nohup openclaw gateway --port $GATEWAY_PORT --verbose > ~/.openclaw/gateway.log 2>&1 &"
+        sleep 3
+        if ssh -i "$SSH_KEY" -p "$REMOTE_PORT" "${REMOTE_USER}@${REMOTE_HOST}" "ss -tlnp | grep -q $GATEWAY_PORT" 2>/dev/null; then
+            print_ok "Gateway 시작 완료"
+        else
+            print_error "Gateway 시작 실패. 원격 PC에서 직접 확인하세요."
+            return 1
+        fi
+    fi
+}
+
+# ── 기존 터널 종료 ──
+kill_existing_tunnel() {
+    local pids
+    pids=$(pgrep -f "ssh.*-L.*${GATEWAY_PORT}:127.0.0.1:${GATEWAY_PORT}" 2>/dev/null || true)
+    if [ -n "$pids" ]; then
+        print_warn "기존 SSH 터널 발견. 종료합니다. (PID: $pids)"
+        echo "$pids" | xargs kill 2>/dev/null || true
+        sleep 1
+    fi
+}
+
+# ── SSH 터널 생성 ──
+create_tunnel() {
+    kill_existing_tunnel
+
+    print_info "SSH 터널을 생성합니다 (포트 $GATEWAY_PORT)..."
+    ssh -fN \
+        -i "$SSH_KEY" \
+        -p "$REMOTE_PORT" \
+        -o "ServerAliveInterval=30" \
+        -o "ServerAliveCountMax=3" \
+        -o "ExitOnForwardFailure=yes" \
+        -L "${GATEWAY_PORT}:127.0.0.1:${GATEWAY_PORT}" \
+        "${REMOTE_USER}@${REMOTE_HOST}"
+
+    sleep 2
+
+    # 터널 확인
+    if ss -tlnp 2>/dev/null | grep -q ":${GATEWAY_PORT}" || \
+       lsof -i ":${GATEWAY_PORT}" &>/dev/null; then
+        print_ok "SSH 터널 생성 완료!"
+        echo ""
+        print_info "OpenClaw Control UI 접속:"
+        echo "  http://127.0.0.1:${GATEWAY_PORT}/?token=YOUR_TOKEN"
+        echo ""
+        print_info "CLI로 상태 확인:"
+        echo "  openclaw gateway status --url ws://127.0.0.1:${GATEWAY_PORT}"
+    else
+        print_error "SSH 터널 생성 실패"
+        return 1
+    fi
+}
+
+# ── autossh 설치 확인 ──
+setup_autossh() {
+    if command -v autossh &>/dev/null; then
+        print_ok "autossh 설치 확인됨"
+    else
+        print_info "autossh를 설치합니다 (자동 재연결 지원)..."
+        if command -v apt &>/dev/null; then
+            sudo apt install -y autossh
+        elif command -v brew &>/dev/null; then
+            brew install autossh
+        else
+            print_warn "autossh를 수동으로 설치하세요."
+            return 1
+        fi
+    fi
+
+    kill_existing_tunnel
+
+    print_info "autossh로 안정적인 SSH 터널을 생성합니다..."
+    autossh -M 0 -fN \
+        -i "$SSH_KEY" \
+        -p "$REMOTE_PORT" \
+        -o "ServerAliveInterval=30" \
+        -o "ServerAliveCountMax=3" \
+        -o "ExitOnForwardFailure=yes" \
+        -L "${GATEWAY_PORT}:127.0.0.1:${GATEWAY_PORT}" \
+        "${REMOTE_USER}@${REMOTE_HOST}"
+
+    print_ok "autossh 터널 생성 완료 (자동 재연결 활성)"
+}
+
+# ── 메인 ──
+main() {
+    echo "============================================="
+    echo "  OpenClaw 원격 SSH 터널 설정"
+    echo "============================================="
+    echo ""
+
+    prompt_config
+    ensure_ssh_key
+
+    read -rp "원격 PC에 SSH 키를 복사하시겠습니까? (y/N): " copy_key
+    if [[ "$copy_key" =~ ^[Yy]$ ]]; then
+        copy_ssh_key
+    fi
+
+    check_remote_openclaw
+
+    echo ""
+    echo "터널 모드를 선택하세요:"
+    echo "  1) 기본 SSH 터널 (단순)"
+    echo "  2) autossh 터널 (자동 재연결, 권장)"
+    read -rp "선택 (1/2): " tunnel_mode
+
+    case "$tunnel_mode" in
+        2) setup_autossh ;;
+        *) create_tunnel ;;
+    esac
+
+    echo ""
+    print_ok "설정 완료!"
+    echo ""
+    echo "유용한 명령어:"
+    echo "  # 터널 상태 확인"
+    echo "  ss -tlnp | grep $GATEWAY_PORT"
+    echo ""
+    echo "  # 터널 종료"
+    echo "  pkill -f 'ssh.*-L.*${GATEWAY_PORT}:127.0.0.1:${GATEWAY_PORT}'"
+    echo ""
+    echo "  # 원격 OpenClaw 로그 확인"
+    echo "  ssh ${REMOTE_USER}@${REMOTE_HOST} 'tail -f ~/.openclaw/gateway.log'"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation and automation scripts for setting up and managing OpenClaw on a remote Ubuntu PC from a local client machine. It includes:

- **README.md**: Complete guide covering 3 connection methods (SSH tunnel, Tailscale VPN, LAN binding)
- **Setup scripts**: Automated configuration for both remote server and local client
- **Health check script**: Diagnostic tool to verify remote connection status
- **Configuration templates**: Example configs for OpenClaw server and systemd service
- **.env.example**: Environment variable template for easy configuration

### Key Features

1. **SSH Tunnel Method (Recommended)**: Secure port forwarding with detailed setup instructions
2. **Tailscale VPN Integration**: Alternative for convenient remote access with HTTPS
3. **LAN Binding**: Direct connection for same-network scenarios
4. **Automation Scripts**:
   - `setup-remote-server.sh`: Configures Ubuntu PC (Node.js, OpenClaw, SSH, firewall)
   - `setup-ssh-tunnel.sh`: Creates SSH tunnel with autossh support for auto-reconnection
   - `health-check.sh`: Validates all connection components
5. **systemd Service**: Automatic SSH tunnel management on Linux clients
6. **Comprehensive Troubleshooting**: Common issues and solutions documented

### Testing

Users can test the setup by:
1. Running `setup-remote-server.sh` on the remote Ubuntu PC
2. Running `setup-ssh-tunnel.sh` on the local client
3. Running `health-check.sh` to verify all components
4. Accessing Control UI at `http://127.0.0.1:18789`

## Related Linear tickets, Github issues, and Community forum posts

N/A - This is a documentation and tooling addition for OpenClaw remote access setup.

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] Documentation provided (comprehensive README with 3 methods, troubleshooting, security recommendations)
- [x] Scripts tested for bash compatibility and error handling
- [x] Configuration templates included with comments
- [x] Environment variable example provided
- [ ] No code changes - documentation and scripts only (no-changelog)

https://claude.ai/code/session_01RHVEWfN13Q29tvU5apWkJD