### PR TITLE
fix: Renames and clarifies test metric options

### DIFF
--- a/packages/nodes-base/nodes/Currents/descriptions/ActionDescription.ts
+++ b/packages/nodes-base/nodes/Currents/descriptions/ActionDescription.ts
@@ -228,7 +228,7 @@ export const actionFields: INodeProperties[] = [
 		],
 		routing: {
 			send: {
-				type: 'body',
+				type: 'query',
 				property: 'projectId',
 				value: '={{ $value }}',
 			},
@@ -271,7 +271,9 @@ export const actionFields: INodeProperties[] = [
 				type: 'multiOptions',
 				options: [
 					{ name: 'Active', value: 'active' },
+					{ name: 'Archived', value: 'archived' },
 					{ name: 'Disabled', value: 'disabled' },
+					{ name: 'Expired', value: 'expired' },
 				],
 				default: [],
 				routing: {
@@ -328,7 +330,8 @@ export const actionFields: INodeProperties[] = [
 		routing: {
 			send: {
 				type: 'body',
-				property: 'action.type',
+				property: 'action',
+				value: '={{ [{ "op": $value }] }}',
 			},
 		},
 	},
@@ -347,8 +350,9 @@ export const actionFields: INodeProperties[] = [
 		routing: {
 			send: {
 				type: 'body',
-				property: 'action.tags',
-				value: '={{ $value.split(",").map(t => t.trim()).filter(t => t) }}',
+				property: 'action',
+				value:
+					'={{ [{ "op": "tag", "details": { "tags": $value.split(",").map(t => t.trim()).filter(t => t) } }] }}',
 			},
 		},
 		description: 'Comma-separated list of tags to apply',
@@ -372,12 +376,7 @@ export const actionFields: INodeProperties[] = [
 				operation: ['create'],
 			},
 		},
-		routing: {
-			send: {
-				type: 'body',
-				property: 'matcher.type',
-			},
-		},
+		// No routing - matcherValue will build the complete matcher object
 		description: 'How to match tests for this action',
 	},
 	{
@@ -395,7 +394,9 @@ export const actionFields: INodeProperties[] = [
 		routing: {
 			send: {
 				type: 'body',
-				property: 'matcher.value',
+				property: 'matcher',
+				value:
+					'={{ { "op": "AND", "cond": [{ "type": { "signature": "testId", "titleContains": "title", "titleEquals": "title", "specContains": "file", "specEquals": "file" }[$parameter.matcherType] || "title", "op": { "signature": "eq", "titleContains": "inc", "titleEquals": "eq", "specContains": "inc", "specEquals": "eq" }[$parameter.matcherType] || "inc", "value": $value }] } }}',
 			},
 		},
 		description: 'The value to match against (test title, spec file path, or signature)',

--- a/packages/nodes-base/nodes/Currents/descriptions/ProjectDescription.ts
+++ b/packages/nodes-base/nodes/Currents/descriptions/ProjectDescription.ts
@@ -201,7 +201,7 @@ export const projectFields: INodeProperties[] = [
 				routing: {
 					send: {
 						type: 'query',
-						property: 'authors',
+						property: 'author',
 					},
 				},
 				description: 'Filter by commit author names (comma-separated)',
@@ -214,7 +214,7 @@ export const projectFields: INodeProperties[] = [
 				routing: {
 					send: {
 						type: 'query',
-						property: 'branches',
+						property: 'branch',
 					},
 				},
 				description: 'Filter by branch names (comma-separated)',
@@ -227,7 +227,7 @@ export const projectFields: INodeProperties[] = [
 				routing: {
 					send: {
 						type: 'query',
-						property: 'groups',
+						property: 'group',
 					},
 				},
 				description: 'Filter by group names (comma-separated)',
@@ -258,7 +258,7 @@ export const projectFields: INodeProperties[] = [
 				routing: {
 					send: {
 						type: 'query',
-						property: 'tags',
+						property: 'tag',
 					},
 				},
 				description: 'Filter by tags (comma-separated)',

--- a/packages/nodes-base/nodes/Currents/descriptions/SpecFileDescription.ts
+++ b/packages/nodes-base/nodes/Currents/descriptions/SpecFileDescription.ts
@@ -159,7 +159,7 @@ export const specFileFields: INodeProperties[] = [
 				routing: {
 					send: {
 						type: 'query',
-						property: 'authors',
+						property: 'author',
 					},
 				},
 				description: 'Filter by git author names (comma-separated for multiple)',
@@ -172,7 +172,7 @@ export const specFileFields: INodeProperties[] = [
 				routing: {
 					send: {
 						type: 'query',
-						property: 'branches',
+						property: 'branch',
 					},
 				},
 				description: 'Filter by branch names (comma-separated for multiple)',
@@ -185,7 +185,7 @@ export const specFileFields: INodeProperties[] = [
 				routing: {
 					send: {
 						type: 'query',
-						property: 'groups',
+						property: 'group',
 					},
 				},
 				description: 'Filter by group names (comma-separated for multiple)',
@@ -211,7 +211,7 @@ export const specFileFields: INodeProperties[] = [
 				routing: {
 					send: {
 						type: 'query',
-						property: 'tags',
+						property: 'tag',
 					},
 				},
 				description: 'Filter by tags (comma-separated for multiple)',

--- a/packages/nodes-base/nodes/Currents/descriptions/TestDescription.ts
+++ b/packages/nodes-base/nodes/Currents/descriptions/TestDescription.ts
@@ -159,7 +159,7 @@ export const testFields: INodeProperties[] = [
 				routing: {
 					send: {
 						type: 'query',
-						property: 'authors',
+						property: 'author',
 					},
 				},
 				description: 'Filter by git author names (comma-separated for multiple)',
@@ -172,7 +172,7 @@ export const testFields: INodeProperties[] = [
 				routing: {
 					send: {
 						type: 'query',
-						property: 'branches',
+						property: 'branch',
 					},
 				},
 				description: 'Filter by branch names (comma-separated for multiple)',
@@ -185,7 +185,7 @@ export const testFields: INodeProperties[] = [
 				routing: {
 					send: {
 						type: 'query',
-						property: 'groups',
+						property: 'group',
 					},
 				},
 				description: 'Filter by group names (comma-separated for multiple)',
@@ -227,7 +227,7 @@ export const testFields: INodeProperties[] = [
 				routing: {
 					send: {
 						type: 'query',
-						property: 'tags',
+						property: 'tag',
 					},
 				},
 				description: 'Filter by tags (comma-separated for multiple)',
@@ -246,7 +246,7 @@ export const testFields: INodeProperties[] = [
 				routing: {
 					send: {
 						type: 'query',
-						property: 'test_state',
+						property: 'testState',
 					},
 				},
 				description: 'Filter by test state',
@@ -285,13 +285,14 @@ export const testFields: INodeProperties[] = [
 				type: 'options',
 				options: [
 					{ name: 'Duration', value: 'duration' },
-					{ name: 'Duration (Weighted)', value: 'duration_x_samples' },
+					{ name: 'Duration Impact', value: 'durationXSamples' },
 					{ name: 'Executions', value: 'executions' },
-					{ name: 'Failure Rate Delta', value: 'failure_rate_delta' },
+					{ name: 'Failure Impact', value: 'failRateXSamples' },
+					{ name: 'Failure Rate Delta', value: 'failureRateDelta' },
 					{ name: 'Failures', value: 'failures' },
 					{ name: 'Flakiness', value: 'flakiness' },
-					{ name: 'Flakiness (Weighted)', value: 'flakiness_x_samples' },
-					{ name: 'Flakiness Rate Delta', value: 'flakiness_rate_delta' },
+					{ name: 'Flakiness Impact', value: 'flakinessXSamples' },
+					{ name: 'Flakiness Rate Delta', value: 'flakinessRateDelta' },
 					{ name: 'Passes', value: 'passes' },
 					{ name: 'Title', value: 'title' },
 				],

--- a/packages/nodes-base/nodes/Currents/descriptions/TestResultDescription.ts
+++ b/packages/nodes-base/nodes/Currents/descriptions/TestResultDescription.ts
@@ -155,7 +155,7 @@ export const testResultFields: INodeProperties[] = [
 				routing: {
 					send: {
 						type: 'query',
-						property: 'git_author',
+						property: 'gitAuthor',
 					},
 				},
 				description: 'Filter by git author names (comma-separated for multiple)',


### PR DESCRIPTION
## Summary

Updates test metric option values for clarity and consistency.

Renames options to improve readability and understanding of their impact.

The currents docs didn't match the API, this brings it back in line.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
