### PR TITLE
feat(core): Add MCP queue mode and multi-main support

### DIFF
--- a/packages/@n8n/config/src/configs/logging.config.ts
+++ b/packages/@n8n/config/src/configs/logging.config.ts
@@ -8,6 +8,7 @@ export const LOG_SCOPES = [
 	'concurrency',
 	'external-secrets',
 	'license',
+	'mcp',
 	'multi-main-setup',
 	'pruning',
 	'pubsub',

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/FlushingTransport.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/FlushingTransport.ts
@@ -5,6 +5,34 @@ import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
 import type { Response } from 'express';
 import type { IncomingMessage, ServerResponse } from 'http';
 
+/**
+ * Internal interface for accessing the WebStandardStreamableHTTPServerTransport
+ * that is wrapped by StreamableHTTPServerTransport. This is needed because the SDK
+ * doesn't expose these properties publicly, but we need to access them for multi-main support.
+ */
+interface WebStandardTransportInternal {
+	_initialized: boolean;
+	sessionId: string;
+}
+
+interface StreamableHTTPTransportInternal {
+	_webStandardTransport?: WebStandardTransportInternal;
+}
+
+/**
+ * Type guard to check if an object has the internal _webStandardTransport property.
+ * Uses a separate parameter to avoid TypeScript intersection issues with private properties.
+ */
+function getWebStandardTransport(transport: unknown): WebStandardTransportInternal | undefined {
+	if (typeof transport === 'object' && transport !== null && '_webStandardTransport' in transport) {
+		const internal = (transport as StreamableHTTPTransportInternal)._webStandardTransport;
+		if (typeof internal === 'object' && internal !== null) {
+			return internal;
+		}
+	}
+	return undefined;
+}
+
 export type CompressionResponse = Response & {
 	/**
 	 * `flush()` is defined in the compression middleware.
@@ -15,6 +43,9 @@ export type CompressionResponse = Response & {
 };
 
 export class FlushingSSEServerTransport extends SSEServerTransport {
+	/** Transport type identifier for runtime type checking without instanceof */
+	readonly transportType = 'sse' as const;
+
 	constructor(
 		_endpoint: string,
 		private response: CompressionResponse,
@@ -38,11 +69,37 @@ export class FlushingSSEServerTransport extends SSEServerTransport {
 }
 
 export class FlushingStreamableHTTPTransport extends StreamableHTTPServerTransport {
+	/** Transport type identifier for runtime type checking without instanceof */
+	readonly transportType = 'streamableHttp' as const;
+
 	private response: CompressionResponse;
 
 	constructor(options: StreamableHTTPServerTransportOptions, response: CompressionResponse) {
 		super(options);
 		this.response = response;
+	}
+
+	/**
+	 * Marks the transport as initialized without going through the full initialization flow.
+	 * This is used for multi-main support when recreating a transport for an existing session
+	 * on a different main instance. The original session was already initialized on another main,
+	 * so we need to mark this recreated transport as initialized to accept subsequent requests.
+	 *
+	 * @param sessionId - The session ID from the original initialization on another main instance.
+	 *                    This must be set to match the mcp-session-id header from incoming requests,
+	 *                    otherwise the SDK will reject requests with 404 "Session not found".
+	 */
+	markAsInitialized(sessionId: string): void {
+		// Access the internal WebStandardStreamableHTTPServerTransport and set both
+		// _initialized = true and sessionId to the existing session's ID.
+		// This is necessary because:
+		// 1. The SDK rejects requests if _initialized is false
+		// 2. The SDK validates mcp-session-id header against its internal sessionId property
+		const webStandardTransport = getWebStandardTransport(this);
+		if (webStandardTransport) {
+			webStandardTransport._initialized = true;
+			webStandardTransport.sessionId = sessionId;
+		}
 	}
 
 	async send(message: JSONRPCMessage): Promise<void> {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpServer.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpServer.ts
@@ -21,6 +21,14 @@ import { FlushingSSEServerTransport, FlushingStreamableHTTPTransport } from './F
 import type { CompressionResponse } from './FlushingTransport';
 
 /**
+ * Marker object used in pub/sub to indicate a list tools request should be handled.
+ * When Main2 receives a tools/list request without local transport, it publishes
+ * this marker via mcp-response. Main1 (with the SSE transport) sees this marker
+ * and responds with the tools list.
+ */
+export const MCP_LIST_TOOLS_REQUEST_MARKER = { _listToolsRequest: true } as const;
+
+/**
  * Pending MCP response for queue mode support.
  * Stores the transport reference and resolve function to send results when worker responds.
  */
@@ -55,6 +63,23 @@ function wasToolCall(body: string) {
 			'method' in parsedMessage &&
 			'id' in parsedMessage &&
 			parsedMessage?.method === CallToolRequestSchema.shape.method.value
+		);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Parses the JSONRPC message and checks whether the method used was a tools/list request.
+ */
+function wasListToolsRequest(body: string): boolean {
+	try {
+		const message: unknown = JSON.parse(body);
+		const parsedMessage: JSONRPCMessage = JSONRPCMessageSchema.parse(message);
+		return (
+			'method' in parsedMessage &&
+			'id' in parsedMessage &&
+			parsedMessage?.method === ListToolsRequestSchema.shape.method.value
 		);
 	} catch {
 		return false;
@@ -157,6 +182,24 @@ export class McpServerManager {
 	 */
 	private _isQueueMode = false;
 
+	/**
+	 * Callback to register a newly created session in shared storage.
+	 * Set by CLI in queue mode to enable session validation across main instances.
+	 */
+	private sessionRegistrationCallback?: (sessionId: string) => Promise<void>;
+
+	/**
+	 * Callback to validate a session ID exists in shared storage.
+	 * Set by CLI in queue mode to prevent session fixation attacks.
+	 */
+	private sessionValidationCallback?: (sessionId: string) => Promise<boolean>;
+
+	/**
+	 * Callback to unregister a session from shared storage when it's closed.
+	 * Set by CLI in queue mode to cleanup session registry.
+	 */
+	private sessionUnregistrationCallback?: (sessionId: string) => Promise<void>;
+
 	logger: Logger;
 
 	private constructor(logger: Logger) {
@@ -177,6 +220,7 @@ export class McpServerManager {
 		serverName: string,
 		postUrl: string,
 		resp: CompressionResponse,
+		connectedTools?: Tool[],
 	): Promise<void> {
 		const server = new Server(
 			{
@@ -198,8 +242,17 @@ export class McpServerManager {
 		this.transports[sessionId] = transport;
 		this.servers[sessionId] = server;
 
+		// Register session in shared store for multi-main validation
+		await this.registerSession(sessionId);
+
+		// Register tools for this session
+		if (connectedTools) {
+			this.tools[sessionId] = connectedTools;
+		}
+
 		resp.on('close', async () => {
 			this.logger.debug(`Deleting transport for ${sessionId}`);
+			await this.unregisterSession(sessionId);
 			this.cleanupSessionPendingResponses(sessionId);
 			delete this.tools[sessionId];
 			delete this.transports[sessionId];
@@ -229,6 +282,7 @@ export class McpServerManager {
 		serverName: string,
 		resp: CompressionResponse,
 		req?: express.Request,
+		connectedTools?: Tool[],
 	): Promise<void> {
 		const server = new Server(
 			{
@@ -245,10 +299,13 @@ export class McpServerManager {
 		const transport = new FlushingStreamableHTTPTransport(
 			{
 				sessionIdGenerator: () => randomUUID(),
-				onsessioninitialized: (sessionId) => {
+				onsessioninitialized: async (sessionId) => {
 					this.logger.debug(`New session initialized: ${sessionId}`);
-					transport.onclose = () => {
+					// Register session in shared store for multi-main validation
+					await this.registerSession(sessionId);
+					transport.onclose = async () => {
 						this.logger.debug(`Deleting transport for ${sessionId}`);
+						await this.unregisterSession(sessionId);
 						this.cleanupSessionPendingResponses(sessionId);
 						delete this.tools[sessionId];
 						delete this.transports[sessionId];
@@ -256,6 +313,10 @@ export class McpServerManager {
 					};
 					this.transports[sessionId] = transport;
 					this.servers[sessionId] = server;
+					// Register tools for this session
+					if (connectedTools) {
+						this.tools[sessionId] = connectedTools;
+					}
 				},
 			},
 			resp,
@@ -271,15 +332,87 @@ export class McpServerManager {
 		}
 	}
 
+	/**
+	 * Recreate a StreamableHTTP transport for an existing session on a different main instance.
+	 * This enables multi-main support where POST requests can be load-balanced to any main.
+	 * The transport is recreated with the same session ID, allowing the request to be handled locally.
+	 *
+	 * @returns true if the transport was recreated successfully, false if session validation failed.
+	 */
+	private async recreateStreamableHTTPTransport(
+		sessionId: string,
+		serverName: string,
+		connectedTools: Tool[],
+		resp: CompressionResponse,
+	): Promise<boolean> {
+		// Validate the session ID exists in the shared store before recreating
+		// This prevents session fixation attacks where a client sends a fabricated session ID
+		const isValid = await this.isSessionValid(sessionId);
+		if (!isValid) {
+			this.logger.warn(`Rejecting recreate request for invalid session: ${sessionId}`);
+			return false;
+		}
+
+		const server = new Server(
+			{
+				name: serverName,
+				version: '0.1.0',
+			},
+			{
+				capabilities: {
+					tools: {},
+				},
+			},
+		);
+
+		// Create transport with the EXISTING session ID (not generating a new one)
+		const transport = new FlushingStreamableHTTPTransport(
+			{
+				sessionIdGenerator: () => sessionId,
+			},
+			resp,
+		);
+
+		// Mark transport as initialized and set the session ID since this session was already
+		// initialized on another main. Without this, the SDK would reject requests with either
+		// "Bad Request: Server not initialized" or "Session not found" (404).
+		transport.markAsInitialized(sessionId);
+
+		this.transports[sessionId] = transport;
+		this.servers[sessionId] = server;
+		this.tools[sessionId] = connectedTools;
+
+		transport.onclose = async () => {
+			this.logger.debug(`Deleting recreated transport for ${sessionId}`);
+			this.cleanupSessionPendingResponses(sessionId);
+			delete this.tools[sessionId];
+			delete this.transports[sessionId];
+			delete this.servers[sessionId];
+		};
+
+		this.setUpHandlers(server);
+		await server.connect(transport);
+		return true;
+	}
+
 	async handlePostMessage(
 		req: express.Request,
 		resp: CompressionResponse,
 		connectedTools: Tool[],
-	): Promise<{ wasToolCall: boolean; toolCallInfo?: McpToolCallInfo; messageId?: string }> {
+		serverName?: string,
+	): Promise<{
+		wasToolCall: boolean;
+		toolCallInfo?: McpToolCallInfo;
+		messageId?: string;
+		/** Session ID when request needs to be relayed via pub/sub */
+		relaySessionId?: string;
+		/** True when this is a list tools request that needs to be relayed to another main */
+		needsListToolsRelay?: boolean;
+	}> {
 		// Session ID can be passed either as a query parameter (SSE transport)
 		// or in the header (StreamableHTTP transport).
 		const sessionId = this.getSessionId(req);
-		const transport = this.getTransport(sessionId as string);
+		let transport = this.getTransport(sessionId as string);
 		const rawBody = req.rawBody.toString();
 		let toolCallInfo = extractToolCallInfo(rawBody);
 		let messageId: string | undefined;
@@ -294,6 +427,58 @@ export class McpServerManager {
 					sourceNodeName: tool.metadata.sourceNodeName,
 				};
 			}
+		}
+
+		// For StreamableHTTP: If no transport exists locally but we have a session ID from header,
+		// recreate the transport on this main instance. This enables multi-main support where
+		// requests can be load-balanced to any main.
+		// SSE is not affected as it uses query parameter for session ID and requires sticky sessions.
+		if (sessionId && !transport && req.headers['mcp-session-id'] && serverName) {
+			this.logger.debug(
+				`Recreating StreamableHTTP transport for session ${sessionId} on this main instance`,
+			);
+			const recreateSuccess = await this.recreateStreamableHTTPTransport(
+				sessionId,
+				serverName,
+				connectedTools,
+				resp,
+			);
+			if (!recreateSuccess) {
+				// Session validation failed - reject the request
+				resp.status(404).send('Session not found');
+				return { wasToolCall: false };
+			}
+			transport = this.getTransport(sessionId);
+		}
+
+		// For SSE in queue mode: If no transport exists locally but we have a session ID from query,
+		// the SSE connection is on a different main. Tool calls and tools/list can be forwarded via pub/sub.
+		// Other messages (initialize, etc.) require the actual MCP server on the main with the transport.
+		const isToolCall = wasToolCall(rawBody);
+		const isListToolsRequest = wasListToolsRequest(rawBody);
+		if (
+			sessionId &&
+			!transport &&
+			req.query.sessionId &&
+			this._isQueueMode &&
+			(isToolCall || isListToolsRequest)
+		) {
+			this.logger.debug(
+				`SSE queue mode: forwarding ${isToolCall ? 'tool call' : 'list tools'} for session ${sessionId} via pub/sub`,
+			);
+			const message = jsonParse(rawBody);
+			messageId = getRequestId(message);
+			// Return 202 Accepted like the SSE SDK does for async operations
+			// The response will be sent via pub/sub to the main with the SSE transport
+			resp.status(202).send('Accepted');
+			return {
+				wasToolCall: isToolCall,
+				toolCallInfo,
+				messageId,
+				// For list tools requests, include relay info so CLI can publish mcp-response
+				relaySessionId: isListToolsRequest ? sessionId : undefined,
+				needsListToolsRelay: isListToolsRequest,
+			};
 		}
 
 		if (sessionId && transport) {
@@ -396,15 +581,71 @@ export class McpServerManager {
 	 * Handle a response from a worker for an MCP Trigger execution.
 	 * In queue mode, the tool executes on the worker and sends back the result.
 	 * This resolves the pending tool call so the handler can return the result to the MCP client.
+	 *
+	 * Also handles relayed requests (like tools/list) that come from another main via pub/sub.
+	 * These are identified by a special marker in the result: { _listToolsRequest: true }
 	 */
 	handleWorkerResponse(sessionId: string, messageId: string, result: unknown): void {
 		const callId = messageId ? `${sessionId}_${messageId}` : sessionId;
 		const pending = this.pendingResponses[callId];
 		const pendingToolCall = this.pendingToolCalls[callId];
 
+		// Check if this is a relayed list tools request from another main
+		const isListToolsRequest =
+			typeof result === 'object' &&
+			result !== null &&
+			'_listToolsRequest' in result &&
+			(result as { _listToolsRequest: boolean })._listToolsRequest;
+
+		if (isListToolsRequest) {
+			// Handle list tools request - send the tools list directly via SSE transport
+			const transport = this.getTransport(sessionId);
+			if (transport && transport.transportType === 'sse' && messageId) {
+				this.logger.debug(
+					`SSE queue mode: handling relayed list tools request for session ${sessionId}`,
+				);
+
+				const tools = this.tools[sessionId] ?? [];
+				const toolsList = tools.map((tool) => ({
+					name: tool.name,
+					description: tool.description,
+					inputSchema: zodToJsonSchema(tool.schema, { removeAdditionalStrategy: 'strict' }),
+				}));
+
+				const response: JSONRPCMessage = {
+					jsonrpc: '2.0',
+					id: messageId,
+					result: { tools: toolsList },
+				};
+				void transport.send(response);
+			}
+			return;
+		}
+
 		// Resolve the pending tool call with the worker's result
 		if (pendingToolCall) {
 			this.resolveToolCall(callId, result);
+		} else {
+			// SSE queue mode: POST was on a different main, send directly via SSE transport.
+			// The pending tool call doesn't exist because the CallToolRequestSchema handler
+			// never ran on this main - the POST went to a different main which returned 202.
+			const transport = this.getTransport(sessionId);
+			if (transport && transport.transportType === 'sse' && messageId) {
+				this.logger.debug(
+					`SSE queue mode: sending response directly via transport for session ${sessionId}`,
+				);
+
+				// Format result the same way MCP Server handler does
+				const formattedResult = this.formatToolResult(result);
+
+				// Construct and send JSON-RPC response directly
+				const response: JSONRPCMessage = {
+					jsonrpc: '2.0',
+					id: messageId,
+					result: formattedResult,
+				};
+				void transport.send(response);
+			}
 		}
 
 		// Also resolve the handlePostMessage promise if it exists
@@ -417,6 +658,20 @@ export class McpServerManager {
 		if (pending) {
 			delete this.pendingResponses[callId];
 		}
+	}
+
+	/**
+	 * Format a tool result for MCP response.
+	 * Converts raw results into the MCP content format.
+	 */
+	private formatToolResult(result: unknown): { content: Array<{ type: string; text: string }> } {
+		if (typeof result === 'object') {
+			return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+		}
+		if (typeof result === 'string') {
+			return { content: [{ type: 'text', text: result }] };
+		}
+		return { content: [{ type: 'text', text: String(result) }] };
 	}
 
 	/**
@@ -479,6 +734,63 @@ export class McpServerManager {
 	 */
 	setQueueMode(isQueueMode: boolean): void {
 		this._isQueueMode = isQueueMode;
+	}
+
+	/**
+	 * Set callbacks for session management in multi-main queue mode.
+	 * These callbacks allow the CLI to manage session IDs in Redis to prevent
+	 * session fixation attacks when recreating transports on different main instances.
+	 *
+	 * @param onRegister - Called when a new session is created. Should store the session ID in Redis.
+	 * @param onValidate - Called before recreating a transport. Should check if session exists in Redis.
+	 * @param onUnregister - Called when a session is closed. Should remove the session ID from Redis.
+	 */
+	setSessionCallbacks(
+		onRegister: (sessionId: string) => Promise<void>,
+		onValidate: (sessionId: string) => Promise<boolean>,
+		onUnregister: (sessionId: string) => Promise<void>,
+	): void {
+		this.sessionRegistrationCallback = onRegister;
+		this.sessionValidationCallback = onValidate;
+		this.sessionUnregistrationCallback = onUnregister;
+	}
+
+	/**
+	 * Register a session ID in the shared store (if callback is set).
+	 * Called when a new session is legitimately created.
+	 */
+	private async registerSession(sessionId: string): Promise<void> {
+		if (this.sessionRegistrationCallback) {
+			await this.sessionRegistrationCallback(sessionId);
+			this.logger.debug(`Registered session in shared store: ${sessionId}`);
+		}
+	}
+
+	/**
+	 * Validate a session ID exists in the shared store.
+	 * Returns true if no callback is set (backwards compatibility for non-queue mode).
+	 */
+	private async isSessionValid(sessionId: string): Promise<boolean> {
+		if (!this.sessionValidationCallback) {
+			// No validation callback set - allow for backwards compatibility
+			return true;
+		}
+		const isValid = await this.sessionValidationCallback(sessionId);
+		if (!isValid) {
+			this.logger.warn(`Session validation failed for: ${sessionId}`);
+		}
+		return isValid;
+	}
+
+	/**
+	 * Unregister a session ID from the shared store (if callback is set).
+	 * Called when a session is closed.
+	 */
+	private async unregisterSession(sessionId: string): Promise<void> {
+		if (this.sessionUnregistrationCallback) {
+			await this.sessionUnregistrationCallback(sessionId);
+			this.logger.debug(`Unregistered session from shared store: ${sessionId}`);
+		}
 	}
 
 	/**
@@ -579,15 +891,19 @@ export class McpServerManager {
 
 				try {
 					if (this._isQueueMode) {
-						// Store pending response for tracking
-						this.storePendingResponse(extra.sessionId, extra.requestId?.toString() ?? '');
-						const toolResultPromise = this.storePendingToolCall(callId, toolName, toolArguments);
+						const requestId = extra.requestId?.toString() ?? '';
 
-						// IMPORTANT: Resolve handlePostMessage so webhook can return and enqueue execution.
-						// The async handler keeps running, waiting for worker response.
+						// Store pending response for tracking
+						this.storePendingResponse(extra.sessionId, requestId);
+
+						// Resolve handlePostMessage so webhook can return and enqueue execution.
 						if (this.resolveFunctions[callId]) {
 							this.resolveFunctions[callId]();
 						}
+
+						// Queue mode: Wait for worker to execute and return the result.
+						// The async handler keeps running, waiting for worker response.
+						const toolResultPromise = this.storePendingToolCall(callId, toolName, toolArguments);
 
 						const WORKER_TIMEOUT_MS = 120000;
 						const timeoutPromise = new Promise<never>((_, reject) => {
@@ -606,7 +922,7 @@ export class McpServerManager {
 								toolName,
 								error: error instanceof Error ? error.message : String(error),
 							});
-							this.removePendingResponse(extra.sessionId, extra.requestId?.toString() ?? '');
+							this.removePendingResponse(extra.sessionId, requestId);
 							throw error;
 						}
 

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
@@ -200,10 +200,29 @@ export class McpTrigger extends Node {
 					// Session exists - either handle locally or recreate transport for StreamableHTTP
 					// For StreamableHTTP, if transport doesn't exist locally, it will be recreated
 					const connectedTools = await getConnectedTools(context, true);
-					const { wasToolCall, toolCallInfo, messageId, relaySessionId, needsListToolsRelay } =
-						await mcpServerManager.handlePostMessage(req, resp, connectedTools, serverName);
+					const {
+						wasToolCall,
+						toolCallInfo,
+						messageId,
+						relaySessionId,
+						needsListToolsRelay,
+						enqueueMcpToolJob,
+						mcpToolJobData,
+					} = await mcpServerManager.handlePostMessage(req, resp, connectedTools, serverName);
+
+					// New pattern: MCP tool job should be enqueued directly (no workflow execution)
+					if (enqueueMcpToolJob && mcpToolJobData) {
+						const workflowData = {
+							_mcpToolJob: true,
+							mcpSessionId: sessionId,
+							mcpMessageId: messageId ?? '',
+							...mcpToolJobData,
+						};
+						return { noWebhookResponse: true, workflowData: [[{ json: workflowData }]] };
+					}
+
 					if (wasToolCall) {
-						// Include tool call info and messageId in workflowData for queue mode execution
+						// Legacy pattern: Include tool call info and messageId in workflowData for queue mode execution
 						// The messageId is the JSONRPC request ID, needed to correlate worker responses
 						// Always include messageId when present for proper correlation, even without toolCallInfo
 						const workflowData = {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
@@ -6,7 +6,7 @@ import { NodeConnectionTypes, Node, nodeNameToToolName } from 'n8n-workflow';
 import { getConnectedTools } from '@utils/helpers';
 
 import type { CompressionResponse } from './FlushingTransport';
-import { McpServerManager } from './McpServer';
+import { McpServerManager, MCP_LIST_TOOLS_REQUEST_MARKER } from './McpServer';
 
 const MCP_SSE_SETUP_PATH = 'sse';
 const MCP_SSE_MESSAGES_PATH = 'messages';
@@ -168,7 +168,16 @@ export class McpTrigger extends Node {
 				node.typeVersion < 2
 					? req.path.replace(new RegExp(`/${MCP_SSE_SETUP_PATH}$`), `/${MCP_SSE_MESSAGES_PATH}`)
 					: req.path;
-			await mcpServerManager.createServerWithSSETransport(serverName, postUrl, resp);
+
+			// Get connected tools and pass them to the transport for multi-main support
+			// This ensures tools are registered even if POST requests are forwarded from other mains
+			const connectedTools = await getConnectedTools(context, true);
+			await mcpServerManager.createServerWithSSETransport(
+				serverName,
+				postUrl,
+				resp,
+				connectedTools,
+			);
 
 			return { noWebhookResponse: true };
 		} else if (webhookName === 'default') {
@@ -185,13 +194,14 @@ export class McpTrigger extends Node {
 				// Check if there is a session and a transport is already established
 				const sessionId = mcpServerManager.getSessionId(req);
 
-				if (sessionId && mcpServerManager.getTransport(sessionId)) {
+				context.logger.debug('MCP POST request received for existing session');
+
+				if (sessionId) {
+					// Session exists - either handle locally or recreate transport for StreamableHTTP
+					// For StreamableHTTP, if transport doesn't exist locally, it will be recreated
 					const connectedTools = await getConnectedTools(context, true);
-					const { wasToolCall, toolCallInfo, messageId } = await mcpServerManager.handlePostMessage(
-						req,
-						resp,
-						connectedTools,
-					);
+					const { wasToolCall, toolCallInfo, messageId, relaySessionId, needsListToolsRelay } =
+						await mcpServerManager.handlePostMessage(req, resp, connectedTools, serverName);
 					if (wasToolCall) {
 						// Include tool call info and messageId in workflowData for queue mode execution
 						// The messageId is the JSONRPC request ID, needed to correlate worker responses
@@ -202,10 +212,29 @@ export class McpTrigger extends Node {
 						};
 						return { noWebhookResponse: true, workflowData: [[{ json: workflowData }]] };
 					}
+					if (needsListToolsRelay && relaySessionId && messageId) {
+						// List tools request in SSE queue mode needs to be relayed to the main with the transport
+						// Return the relay info so CLI can publish mcp-response with the marker
+						const workflowData = {
+							mcpListToolsRelay: {
+								sessionId: relaySessionId,
+								messageId,
+								marker: MCP_LIST_TOOLS_REQUEST_MARKER,
+							},
+						};
+						return { noWebhookResponse: true, workflowData: [[{ json: workflowData }]] };
+					}
 				} else {
 					// If no session is established, this is a setup request
 					// for the StreamableHTTPServerTransport, so we create a new transport
-					await mcpServerManager.createServerWithStreamableHTTPTransport(serverName, resp, req);
+					// Get connected tools and pass them for multi-main support
+					const connectedTools = await getConnectedTools(context, true);
+					await mcpServerManager.createServerWithStreamableHTTPTransport(
+						serverName,
+						resp,
+						req,
+						connectedTools,
+					);
 				}
 			}
 

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
@@ -187,8 +187,21 @@ export class McpTrigger extends Node {
 
 				if (sessionId && mcpServerManager.getTransport(sessionId)) {
 					const connectedTools = await getConnectedTools(context, true);
-					const wasToolCall = await mcpServerManager.handlePostMessage(req, resp, connectedTools);
-					if (wasToolCall) return { noWebhookResponse: true, workflowData: [[{ json: {} }]] };
+					const { wasToolCall, toolCallInfo, messageId } = await mcpServerManager.handlePostMessage(
+						req,
+						resp,
+						connectedTools,
+					);
+					if (wasToolCall) {
+						// Include tool call info and messageId in workflowData for queue mode execution
+						// The messageId is the JSONRPC request ID, needed to correlate worker responses
+						// Always include messageId when present for proper correlation, even without toolCallInfo
+						const workflowData = {
+							...(toolCallInfo && { mcpToolCall: toolCallInfo }),
+							...(messageId && { mcpMessageId: messageId }),
+						};
+						return { noWebhookResponse: true, workflowData: [[{ json: workflowData }]] };
+					}
 				} else {
 					// If no session is established, this is a setup request
 					// for the StreamableHTTPServerTransport, so we create a new transport

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
@@ -200,29 +200,10 @@ export class McpTrigger extends Node {
 					// Session exists - either handle locally or recreate transport for StreamableHTTP
 					// For StreamableHTTP, if transport doesn't exist locally, it will be recreated
 					const connectedTools = await getConnectedTools(context, true);
-					const {
-						wasToolCall,
-						toolCallInfo,
-						messageId,
-						relaySessionId,
-						needsListToolsRelay,
-						enqueueMcpToolJob,
-						mcpToolJobData,
-					} = await mcpServerManager.handlePostMessage(req, resp, connectedTools, serverName);
-
-					// New pattern: MCP tool job should be enqueued directly (no workflow execution)
-					if (enqueueMcpToolJob && mcpToolJobData) {
-						const workflowData = {
-							_mcpToolJob: true,
-							mcpSessionId: sessionId,
-							mcpMessageId: messageId ?? '',
-							...mcpToolJobData,
-						};
-						return { noWebhookResponse: true, workflowData: [[{ json: workflowData }]] };
-					}
-
+					const { wasToolCall, toolCallInfo, messageId, relaySessionId, needsListToolsRelay } =
+						await mcpServerManager.handlePostMessage(req, resp, connectedTools, serverName);
 					if (wasToolCall) {
-						// Legacy pattern: Include tool call info and messageId in workflowData for queue mode execution
+						// Include tool call info and messageId in workflowData for queue mode execution
 						// The messageId is the JSONRPC request ID, needed to correlate worker responses
 						// Always include messageId when present for proper correlation, even without toolCallInfo
 						const workflowData = {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpTrigger.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpTrigger.node.test.ts
@@ -39,6 +39,10 @@ describe('McpTrigger Node', () => {
 			name: 'McpTrigger',
 			typeVersion: 2,
 		} as INode);
+		// Mock logger.debug for POST request logging
+		mockContext.logger = {
+			debug: jest.fn(),
+		} as unknown as typeof mockContext.logger;
 		mockServerManager.transports = {};
 	});
 
@@ -50,11 +54,12 @@ describe('McpTrigger Node', () => {
 			// Call the webhook method
 			const result = await mcpTrigger.webhook(mockContext);
 
-			// Verify that the connectTransport method was called with correct URL
+			// Verify that the connectTransport method was called with correct URL and connected tools
 			expect(mockServerManager.createServerWithSSETransport).toHaveBeenCalledWith(
 				'McpTrigger',
 				'/custom-path',
 				mockResponse,
+				[mockTool],
 			);
 
 			// Verify the returned result has noWebhookResponse: true
@@ -75,10 +80,13 @@ describe('McpTrigger Node', () => {
 			// Call the webhook method
 			const result = await mcpTrigger.webhook(mockContext);
 
-			// Verify that handlePostMessage was called with request, response and tools
-			expect(mockServerManager.handlePostMessage).toHaveBeenCalledWith(mockRequest, mockResponse, [
-				mockTool,
-			]);
+			// Verify that handlePostMessage was called with request, response, tools and server name
+			expect(mockServerManager.handlePostMessage).toHaveBeenCalledWith(
+				mockRequest,
+				mockResponse,
+				[mockTool],
+				'McpTrigger',
+			);
 
 			// Verify the returned result when a tool was called
 			expect(result).toEqual({
@@ -115,11 +123,12 @@ describe('McpTrigger Node', () => {
 			// Call the webhook method
 			await mcpTrigger.webhook(mockContext);
 
-			// Verify that connectTransport was called with the sanitized server name
+			// Verify that connectTransport was called with the sanitized server name and connected tools
 			expect(mockServerManager.createServerWithSSETransport).toHaveBeenCalledWith(
 				'My_custom_MCP_server_',
 				'/custom-path',
 				mockResponse,
+				[mockTool],
 			);
 		});
 
@@ -133,11 +142,12 @@ describe('McpTrigger Node', () => {
 			// Call the webhook method
 			await mcpTrigger.webhook(mockContext);
 
-			// Verify that connectTransport was called with the default server name
+			// Verify that connectTransport was called with the default server name and connected tools
 			expect(mockServerManager.createServerWithSSETransport).toHaveBeenCalledWith(
 				'n8n-mcp-server',
 				'/custom-path',
 				mockResponse,
+				[mockTool],
 			);
 		});
 

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpTrigger.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpTrigger.node.test.ts
@@ -69,8 +69,8 @@ describe('McpTrigger Node', () => {
 			mockServerManager.getSessionId.mockReturnValue(sessionId);
 			mockServerManager.getTransport.mockReturnValue(mock<FlushingSSEServerTransport>({}));
 
-			// Mock that the server executes a tool and returns true
-			mockServerManager.handlePostMessage.mockResolvedValueOnce(true);
+			// Mock that the server executes a tool and returns wasToolCall: true
+			mockServerManager.handlePostMessage.mockResolvedValueOnce({ wasToolCall: true });
 
 			// Call the webhook method
 			const result = await mcpTrigger.webhook(mockContext);
@@ -95,8 +95,8 @@ describe('McpTrigger Node', () => {
 			mockServerManager.getSessionId.mockReturnValue(sessionId);
 			mockServerManager.getTransport.mockReturnValue(mock<FlushingSSEServerTransport>({}));
 
-			// Mock that the server doesn't execute a tool and returns false
-			mockServerManager.handlePostMessage.mockResolvedValueOnce(false);
+			// Mock that the server doesn't execute a tool and returns wasToolCall: false
+			mockServerManager.handlePostMessage.mockResolvedValueOnce({ wasToolCall: false });
 
 			// Call the webhook method
 			const result = await mcpTrigger.webhook(mockContext);

--- a/packages/cli/src/modules/mcp/__tests__/execute-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/execute-workflow.tool.test.ts
@@ -1085,5 +1085,179 @@ describe('execute-workflow MCP tool', () => {
 				expect(runCall.executionMode).toBe('webhook');
 			});
 		});
+
+		describe('queue mode support', () => {
+			let queueModeMcpService: McpService;
+
+			beforeEach(() => {
+				queueModeMcpService = mockInstance(McpService, {
+					isQueueMode: true,
+					hostId: 'main-host-id',
+					createPendingResponse: jest.fn().mockReturnValue({
+						promise: Promise.resolve({
+							status: 'success',
+							data: { resultData: { runData: {} } },
+						}),
+						resolve: jest.fn(),
+						reject: jest.fn(),
+					}),
+				});
+			});
+
+			test('uses pending response promise in queue mode', async () => {
+				const workflow = createWorkflow({
+					activeVersionId: uuid(),
+					nodes: [
+						{
+							id: 'node-1',
+							name: 'WebhookNode',
+							type: WEBHOOK_NODE_TYPE,
+							typeVersion: 1,
+							position: [0, 0],
+							disabled: false,
+							parameters: {},
+						} as INode,
+					],
+				});
+				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
+				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
+				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-queue');
+
+				const result = await executeWorkflow(
+					user,
+					workflowFinderService,
+					workflowRepository,
+					activeExecutions,
+					workflowRunner,
+					queueModeMcpService,
+					'queue-workflow',
+					undefined,
+				);
+
+				expect(queueModeMcpService.createPendingResponse).toHaveBeenCalledWith('exec-queue');
+				expect(activeExecutions.getPostExecutePromise).not.toHaveBeenCalled();
+				expect(result).toMatchObject({
+					success: true,
+					executionId: 'exec-queue',
+				});
+			});
+
+			test('passes MCP metadata in run data for queue mode', async () => {
+				const workflow = createWorkflow({
+					activeVersionId: uuid(),
+					nodes: [
+						{
+							id: 'node-1',
+							name: 'WebhookNode',
+							type: WEBHOOK_NODE_TYPE,
+							typeVersion: 1,
+							position: [0, 0],
+							disabled: false,
+							parameters: {},
+						} as INode,
+					],
+				});
+				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
+				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
+				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-mcp-meta');
+
+				await executeWorkflow(
+					user,
+					workflowFinderService,
+					workflowRepository,
+					activeExecutions,
+					workflowRunner,
+					queueModeMcpService,
+					'mcp-meta-workflow',
+					undefined,
+				);
+
+				const runCall = (workflowRunner.run as jest.Mock).mock
+					.calls[0][0] as IWorkflowExecutionDataProcess;
+				expect(runCall.isMcpExecution).toBe(true);
+				expect(runCall.mcpType).toBe('service');
+				expect(runCall.mcpSessionId).toBeDefined();
+				expect(runCall.mcpMessageId).toBeDefined();
+				expect(runCall.originMainId).toBe('main-host-id');
+			});
+
+			test('sets isMcpExecution to false in regular mode', async () => {
+				const workflow = createWorkflow({
+					activeVersionId: uuid(),
+					nodes: [
+						{
+							id: 'node-1',
+							name: 'WebhookNode',
+							type: WEBHOOK_NODE_TYPE,
+							typeVersion: 1,
+							position: [0, 0],
+							disabled: false,
+							parameters: {},
+						} as INode,
+					],
+				});
+				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
+				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
+				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-regular');
+				(activeExecutions.getPostExecutePromise as jest.Mock).mockResolvedValue({
+					status: 'success',
+					data: { resultData: {} },
+				});
+
+				await executeWorkflow(
+					user,
+					workflowFinderService,
+					workflowRepository,
+					activeExecutions,
+					workflowRunner,
+					mcpService,
+					'regular-workflow',
+					undefined,
+				);
+
+				const runCall = (workflowRunner.run as jest.Mock).mock
+					.calls[0][0] as IWorkflowExecutionDataProcess;
+				// isMcpExecution should be false in regular mode - this is the key flag that
+				// determines whether queue mode MCP handling is applied
+				expect(runCall.isMcpExecution).toBe(false);
+			});
+
+			test('uses activeExecutions.getPostExecutePromise in regular mode', async () => {
+				const workflow = createWorkflow({
+					activeVersionId: uuid(),
+					nodes: [
+						{
+							id: 'node-1',
+							name: 'WebhookNode',
+							type: WEBHOOK_NODE_TYPE,
+							typeVersion: 1,
+							position: [0, 0],
+							disabled: false,
+							parameters: {},
+						} as INode,
+					],
+				});
+				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
+				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
+				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-regular-2');
+				(activeExecutions.getPostExecutePromise as jest.Mock).mockResolvedValue({
+					status: 'success',
+					data: { resultData: {} },
+				});
+
+				await executeWorkflow(
+					user,
+					workflowFinderService,
+					workflowRepository,
+					activeExecutions,
+					workflowRunner,
+					mcpService,
+					'regular-workflow-2',
+					undefined,
+				);
+
+				expect(activeExecutions.getPostExecutePromise).toHaveBeenCalledWith('exec-regular-2');
+			});
+		});
 	});
 });

--- a/packages/cli/src/modules/mcp/__tests__/execute-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/execute-workflow.tool.test.ts
@@ -15,6 +15,7 @@ import { WorkflowAccessError } from '../mcp.errors';
 import { createExecuteWorkflowTool, executeWorkflow } from '../tools/execute-workflow.tool';
 
 import { ActiveExecutions } from '@/active-executions';
+import { McpService } from '@/modules/mcp/mcp.service';
 import { Telemetry } from '@/telemetry';
 import { WorkflowRunner } from '@/workflow-runner';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
@@ -27,6 +28,7 @@ describe('execute-workflow MCP tool', () => {
 	let activeExecutions: ActiveExecutions;
 	let workflowRunner: WorkflowRunner;
 	let telemetry: Telemetry;
+	let mcpService: McpService;
 
 	beforeEach(() => {
 		workflowFinderService = mockInstance(WorkflowFinderService);
@@ -35,6 +37,10 @@ describe('execute-workflow MCP tool', () => {
 		workflowRunner = mockInstance(WorkflowRunner);
 		telemetry = mockInstance(Telemetry, {
 			track: jest.fn(),
+		});
+		mcpService = mockInstance(McpService, {
+			isQueueMode: false,
+			hostId: 'test-host-id',
 		});
 	});
 
@@ -47,6 +53,7 @@ describe('execute-workflow MCP tool', () => {
 				activeExecutions,
 				workflowRunner,
 				telemetry,
+				mcpService,
 			);
 
 			expect(tool.name).toBe('execute_workflow');
@@ -74,6 +81,7 @@ describe('execute-workflow MCP tool', () => {
 						workflowRepository,
 						activeExecutions,
 						workflowRunner,
+						mcpService,
 						'missing-workflow',
 						undefined,
 					),
@@ -86,6 +94,7 @@ describe('execute-workflow MCP tool', () => {
 						workflowRepository,
 						activeExecutions,
 						workflowRunner,
+						mcpService,
 						'missing-workflow',
 						undefined,
 					),
@@ -103,6 +112,7 @@ describe('execute-workflow MCP tool', () => {
 						workflowRepository,
 						activeExecutions,
 						workflowRunner,
+						mcpService,
 						'missing-workflow',
 						undefined,
 					),
@@ -122,6 +132,7 @@ describe('execute-workflow MCP tool', () => {
 						workflowRepository,
 						activeExecutions,
 						workflowRunner,
+						mcpService,
 						'no-permission-workflow',
 						undefined,
 					),
@@ -134,6 +145,7 @@ describe('execute-workflow MCP tool', () => {
 						workflowRepository,
 						activeExecutions,
 						workflowRunner,
+						mcpService,
 						'no-permission-workflow',
 						undefined,
 					),
@@ -151,6 +163,7 @@ describe('execute-workflow MCP tool', () => {
 						workflowRepository,
 						activeExecutions,
 						workflowRunner,
+						mcpService,
 						'no-permission-workflow',
 						undefined,
 					),
@@ -171,6 +184,7 @@ describe('execute-workflow MCP tool', () => {
 						workflowRepository,
 						activeExecutions,
 						workflowRunner,
+						mcpService,
 						'archived-workflow',
 						undefined,
 					),
@@ -183,6 +197,7 @@ describe('execute-workflow MCP tool', () => {
 						workflowRepository,
 						activeExecutions,
 						workflowRunner,
+						mcpService,
 						'archived-workflow',
 						undefined,
 					),
@@ -201,6 +216,7 @@ describe('execute-workflow MCP tool', () => {
 						workflowRepository,
 						activeExecutions,
 						workflowRunner,
+						mcpService,
 						'archived-workflow',
 						undefined,
 					),
@@ -224,6 +240,7 @@ describe('execute-workflow MCP tool', () => {
 						workflowRepository,
 						activeExecutions,
 						workflowRunner,
+						mcpService,
 						'unavailable-workflow',
 						undefined,
 					),
@@ -245,6 +262,7 @@ describe('execute-workflow MCP tool', () => {
 						workflowRepository,
 						activeExecutions,
 						workflowRunner,
+						mcpService,
 						'unavailable-workflow',
 						undefined,
 					),
@@ -278,6 +296,7 @@ describe('execute-workflow MCP tool', () => {
 						workflowRepository,
 						activeExecutions,
 						workflowRunner,
+						mcpService,
 						'unsupported-trigger',
 						undefined,
 					),
@@ -290,6 +309,7 @@ describe('execute-workflow MCP tool', () => {
 						workflowRepository,
 						activeExecutions,
 						workflowRunner,
+						mcpService,
 						'unsupported-trigger',
 						undefined,
 					),
@@ -321,6 +341,7 @@ describe('execute-workflow MCP tool', () => {
 						workflowRepository,
 						activeExecutions,
 						workflowRunner,
+						mcpService,
 						'unsupported-trigger',
 						undefined,
 					),
@@ -354,6 +375,7 @@ describe('execute-workflow MCP tool', () => {
 						workflowRepository,
 						activeExecutions,
 						workflowRunner,
+						mcpService,
 						'disabled-trigger',
 						undefined,
 					),
@@ -397,6 +419,7 @@ describe('execute-workflow MCP tool', () => {
 					workflowRepository,
 					activeExecutions,
 					workflowRunner,
+					mcpService,
 					'webhook-workflow',
 					{
 						type: 'webhook',
@@ -463,6 +486,7 @@ describe('execute-workflow MCP tool', () => {
 					workflowRepository,
 					activeExecutions,
 					workflowRunner,
+					mcpService,
 					'webhook-workflow',
 					{
 						type: 'webhook',
@@ -519,6 +543,7 @@ describe('execute-workflow MCP tool', () => {
 					workflowRepository,
 					activeExecutions,
 					workflowRunner,
+					mcpService,
 					'chat-workflow',
 					{
 						type: 'chat',
@@ -578,6 +603,7 @@ describe('execute-workflow MCP tool', () => {
 					workflowRepository,
 					activeExecutions,
 					workflowRunner,
+					mcpService,
 					'form-workflow',
 					{
 						type: 'form',
@@ -649,6 +675,7 @@ describe('execute-workflow MCP tool', () => {
 					workflowRepository,
 					activeExecutions,
 					workflowRunner,
+					mcpService,
 					'success-workflow',
 					undefined,
 				);
@@ -698,6 +725,7 @@ describe('execute-workflow MCP tool', () => {
 					workflowRepository,
 					activeExecutions,
 					workflowRunner,
+					mcpService,
 					'error-workflow',
 					undefined,
 				);
@@ -748,6 +776,7 @@ describe('execute-workflow MCP tool', () => {
 					workflowRepository,
 					activeExecutions,
 					workflowRunner,
+					mcpService,
 					'data-error-workflow',
 					undefined,
 				);
@@ -789,6 +818,7 @@ describe('execute-workflow MCP tool', () => {
 						workflowRepository,
 						activeExecutions,
 						workflowRunner,
+						mcpService,
 						'no-data-workflow',
 						undefined,
 					),
@@ -801,6 +831,7 @@ describe('execute-workflow MCP tool', () => {
 						workflowRepository,
 						activeExecutions,
 						workflowRunner,
+						mcpService,
 						'no-data-workflow',
 						undefined,
 					),
@@ -838,6 +869,7 @@ describe('execute-workflow MCP tool', () => {
 					workflowRepository,
 					activeExecutions,
 					workflowRunner,
+					mcpService,
 					'no-inputs-workflow',
 					undefined,
 				);
@@ -889,6 +921,7 @@ describe('execute-workflow MCP tool', () => {
 					activeExecutions,
 					workflowRunner,
 					telemetry,
+					mcpService,
 				);
 
 				// Call through the tool handler to test telemetry
@@ -927,6 +960,7 @@ describe('execute-workflow MCP tool', () => {
 					activeExecutions,
 					workflowRunner,
 					telemetry,
+					mcpService,
 				);
 
 				// Call through the tool handler to test telemetry
@@ -963,6 +997,7 @@ describe('execute-workflow MCP tool', () => {
 					activeExecutions,
 					workflowRunner,
 					telemetry,
+					mcpService,
 				);
 
 				// Call through the tool handler to test telemetry
@@ -1037,6 +1072,7 @@ describe('execute-workflow MCP tool', () => {
 					workflowRepository,
 					activeExecutions,
 					workflowRunner,
+					mcpService,
 					'multi-trigger-workflow',
 					undefined,
 				);

--- a/packages/cli/src/modules/mcp/__tests__/execute-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/execute-workflow.tool.test.ts
@@ -40,7 +40,6 @@ describe('execute-workflow MCP tool', () => {
 		});
 		mcpService = mockInstance(McpService, {
 			isQueueMode: false,
-			hostId: 'test-host-id',
 		});
 	});
 
@@ -1092,7 +1091,6 @@ describe('execute-workflow MCP tool', () => {
 			beforeEach(() => {
 				queueModeMcpService = mockInstance(McpService, {
 					isQueueMode: true,
-					hostId: 'main-host-id',
 					createPendingResponse: jest.fn().mockReturnValue({
 						promise: Promise.resolve({
 							status: 'success',
@@ -1178,7 +1176,6 @@ describe('execute-workflow MCP tool', () => {
 				expect(runCall.mcpType).toBe('service');
 				expect(runCall.mcpSessionId).toBeDefined();
 				expect(runCall.mcpMessageId).toBeDefined();
-				expect(runCall.originMainId).toBe('main-host-id');
 			});
 
 			test('sets isMcpExecution to false in regular mode', async () => {

--- a/packages/cli/src/modules/mcp/__tests__/mcp.service.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.service.test.ts
@@ -1,0 +1,246 @@
+import { mockInstance, mockLogger } from '@n8n/backend-test-utils';
+import { ExecutionsConfig, GlobalConfig } from '@n8n/config';
+import { User, WorkflowRepository } from '@n8n/db';
+import { InstanceSettings } from 'n8n-core';
+import type { IRun } from 'n8n-workflow';
+import { ManualExecutionCancelledError } from 'n8n-workflow';
+
+import { McpService } from '../mcp.service';
+
+import { ActiveExecutions } from '@/active-executions';
+import { CredentialsService } from '@/credentials/credentials.service';
+import { ProjectService } from '@/services/project.service.ee';
+import { RoleService } from '@/services/role.service';
+import { UrlService } from '@/services/url.service';
+import { Telemetry } from '@/telemetry';
+import { WorkflowRunner } from '@/workflow-runner';
+import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
+import { WorkflowService } from '@/workflows/workflow.service';
+
+describe('McpService', () => {
+	let mcpService: McpService;
+	let activeExecutions: ActiveExecutions;
+	let executionsConfig: ExecutionsConfig;
+	let instanceSettings: InstanceSettings;
+
+	beforeEach(() => {
+		activeExecutions = mockInstance(ActiveExecutions);
+		executionsConfig = mockInstance(ExecutionsConfig, {
+			mode: 'regular',
+		});
+		instanceSettings = mockInstance(InstanceSettings, {
+			hostId: 'test-host-id',
+		});
+
+		mcpService = new McpService(
+			mockLogger(),
+			executionsConfig,
+			instanceSettings,
+			mockInstance(WorkflowFinderService),
+			mockInstance(WorkflowRepository),
+			mockInstance(WorkflowService),
+			mockInstance(UrlService),
+			mockInstance(CredentialsService),
+			activeExecutions,
+			mockInstance(GlobalConfig, {
+				endpoints: { webhook: '/webhook', webhookTest: '/webhook-test' },
+			}),
+			mockInstance(Telemetry),
+			mockInstance(WorkflowRunner),
+			mockInstance(RoleService),
+			mockInstance(ProjectService),
+		);
+	});
+
+	describe('Queue Mode Detection', () => {
+		it('should return false for isQueueMode when mode is regular', () => {
+			expect(mcpService.isQueueMode).toBe(false);
+		});
+
+		it('should return true for isQueueMode when mode is queue', () => {
+			// Create a new service with queue mode enabled
+			const queueExecutionsConfig = mockInstance(ExecutionsConfig, {
+				mode: 'queue',
+			});
+
+			const queueMcpService = new McpService(
+				mockLogger(),
+				queueExecutionsConfig,
+				instanceSettings,
+				mockInstance(WorkflowFinderService),
+				mockInstance(WorkflowRepository),
+				mockInstance(WorkflowService),
+				mockInstance(UrlService),
+				mockInstance(CredentialsService),
+				activeExecutions,
+				mockInstance(GlobalConfig, {
+					endpoints: { webhook: '/webhook', webhookTest: '/webhook-test' },
+				}),
+				mockInstance(Telemetry),
+				mockInstance(WorkflowRunner),
+				mockInstance(RoleService),
+				mockInstance(ProjectService),
+			);
+
+			expect(queueMcpService.isQueueMode).toBe(true);
+		});
+	});
+
+	describe('Host ID', () => {
+		it('should return the instance host ID', () => {
+			expect(mcpService.hostId).toBe('test-host-id');
+		});
+	});
+
+	describe('Pending Response Management', () => {
+		describe('createPendingResponse', () => {
+			it('should create a pending response with a deferred promise', () => {
+				const executionId = 'exec-123';
+				const deferred = mcpService.createPendingResponse(executionId);
+
+				expect(deferred).toBeDefined();
+				expect(deferred.promise).toBeInstanceOf(Promise);
+				expect(deferred.resolve).toBeInstanceOf(Function);
+				expect(deferred.reject).toBeInstanceOf(Function);
+				expect(mcpService.pendingExecutionCount).toBe(1);
+			});
+
+			it('should track multiple pending responses', () => {
+				mcpService.createPendingResponse('exec-1');
+				mcpService.createPendingResponse('exec-2');
+				mcpService.createPendingResponse('exec-3');
+
+				expect(mcpService.pendingExecutionCount).toBe(3);
+			});
+		});
+
+		describe('handleWorkerResponse', () => {
+			it('should resolve pending promise with run data', async () => {
+				const executionId = 'exec-456';
+				const deferred = mcpService.createPendingResponse(executionId);
+
+				const runData: IRun = {
+					status: 'success',
+					mode: 'trigger',
+					startedAt: new Date(),
+					finished: true,
+					data: { resultData: { runData: {} } },
+				};
+
+				mcpService.handleWorkerResponse(executionId, runData);
+
+				const result = await deferred.promise;
+				expect(result).toBe(runData);
+				expect(mcpService.pendingExecutionCount).toBe(0);
+			});
+
+			it('should resolve pending promise with undefined for failed execution', async () => {
+				const executionId = 'exec-789';
+				const deferred = mcpService.createPendingResponse(executionId);
+
+				mcpService.handleWorkerResponse(executionId, undefined);
+
+				const result = await deferred.promise;
+				expect(result).toBeUndefined();
+				expect(mcpService.pendingExecutionCount).toBe(0);
+			});
+
+			it('should ignore responses for unknown executions', () => {
+				// Should not throw
+				mcpService.handleWorkerResponse('unknown-exec', undefined);
+				expect(mcpService.pendingExecutionCount).toBe(0);
+			});
+		});
+
+		describe('removePendingResponse', () => {
+			it('should remove a pending response', () => {
+				const executionId = 'exec-remove';
+				mcpService.createPendingResponse(executionId);
+				expect(mcpService.pendingExecutionCount).toBe(1);
+
+				mcpService.removePendingResponse(executionId);
+				expect(mcpService.pendingExecutionCount).toBe(0);
+			});
+
+			it('should handle removing non-existent response gracefully', () => {
+				// Should not throw
+				mcpService.removePendingResponse('non-existent');
+				expect(mcpService.pendingExecutionCount).toBe(0);
+			});
+		});
+
+		describe('cancelPendingExecution', () => {
+			it('should reject pending promise with cancellation error', async () => {
+				const executionId = 'exec-cancel';
+				const deferred = mcpService.createPendingResponse(executionId);
+
+				// Attach error handler before cancelling to prevent unhandled rejection
+				const errorPromise = deferred.promise.catch((error) => error);
+
+				mcpService.cancelPendingExecution(executionId, 'User cancelled');
+
+				const error = await errorPromise;
+				expect(error).toBeInstanceOf(ManualExecutionCancelledError);
+				expect(mcpService.pendingExecutionCount).toBe(0);
+			});
+
+			it('should attempt to stop active execution', async () => {
+				const executionId = 'exec-active';
+				const deferred = mcpService.createPendingResponse(executionId);
+				(activeExecutions.has as jest.Mock).mockReturnValue(true);
+
+				// Attach error handler to prevent unhandled rejection
+				deferred.promise.catch(() => {});
+
+				mcpService.cancelPendingExecution(executionId);
+
+				expect(activeExecutions.stopExecution).toHaveBeenCalledWith(
+					executionId,
+					expect.any(ManualExecutionCancelledError),
+				);
+			});
+
+			it('should handle cancelling non-existent execution gracefully', () => {
+				// Should not throw
+				mcpService.cancelPendingExecution('non-existent');
+			});
+		});
+
+		describe('cancelAllPendingExecutions', () => {
+			it('should cancel all pending executions', async () => {
+				const deferred1 = mcpService.createPendingResponse('exec-1');
+				const deferred2 = mcpService.createPendingResponse('exec-2');
+				const deferred3 = mcpService.createPendingResponse('exec-3');
+
+				// Attach error handlers before cancelling to prevent unhandled rejections
+				const errorPromise1 = deferred1.promise.catch((error) => error);
+				const errorPromise2 = deferred2.promise.catch((error) => error);
+				const errorPromise3 = deferred3.promise.catch((error) => error);
+
+				expect(mcpService.pendingExecutionCount).toBe(3);
+
+				mcpService.cancelAllPendingExecutions('Shutdown');
+
+				expect(mcpService.pendingExecutionCount).toBe(0);
+
+				const error1 = await errorPromise1;
+				const error2 = await errorPromise2;
+				const error3 = await errorPromise3;
+
+				expect(error1).toBeInstanceOf(ManualExecutionCancelledError);
+				expect(error2).toBeInstanceOf(ManualExecutionCancelledError);
+				expect(error3).toBeInstanceOf(ManualExecutionCancelledError);
+			});
+		});
+	});
+
+	describe('getServer', () => {
+		it('should create MCP server with registered tools', async () => {
+			const user = Object.assign(new User(), { id: 'user-1' });
+
+			const server = await mcpService.getServer(user);
+
+			expect(server).toBeDefined();
+		});
+	});
+});

--- a/packages/cli/src/modules/mcp/tools/execute-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/execute-workflow.tool.ts
@@ -28,6 +28,7 @@ import type {
 import { findMcpSupportedTrigger } from '../mcp.utils';
 
 import type { ActiveExecutions } from '@/active-executions';
+import type { McpService } from '@/modules/mcp/mcp.service';
 import type { Telemetry } from '@/telemetry';
 import type { WorkflowRunner } from '@/workflow-runner';
 import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
@@ -94,6 +95,7 @@ export const createExecuteWorkflowTool = (
 	activeExecutions: ActiveExecutions,
 	workflowRunner: WorkflowRunner,
 	telemetry: Telemetry,
+	mcpService: McpService,
 ): ToolDefinition<typeof inputSchema.shape> => ({
 	name: 'execute_workflow',
 	config: {
@@ -122,6 +124,7 @@ export const createExecuteWorkflowTool = (
 				workflowRepository,
 				activeExecutions,
 				workflowRunner,
+				mcpService,
 				workflowId,
 				inputs,
 			);
@@ -197,6 +200,7 @@ export const executeWorkflow = async (
 	workflowRepository: WorkflowRepository,
 	activeExecutions: ActiveExecutions,
 	workflowRunner: WorkflowRunner,
+	mcpService: McpService,
 	workflowId: string,
 	inputs?: z.infer<typeof inputSchema>['inputs'],
 ): Promise<ExecuteWorkflowOutput> => {
@@ -250,10 +254,18 @@ export const executeWorkflow = async (
 		);
 	}
 
+	// Generate a unique MCP message ID for this execution (used for queue mode correlation)
+	const mcpMessageId = `mcp-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+
 	const runData: IWorkflowExecutionDataProcess = {
 		executionMode: getExecutionModeForTrigger(triggerNode),
 		workflowData: { ...workflow, nodes, connections },
 		userId: user.id,
+		// MCP metadata for queue mode support
+		isMcpExecution: mcpService.isQueueMode,
+		mcpSessionId: mcpMessageId, // Using messageId as sessionId for MCP Service (no persistent session)
+		mcpMessageId,
+		originMainId: mcpService.hostId,
 	};
 
 	// Set the trigger node as the start node and pin data for it
@@ -294,11 +306,14 @@ export const executeWorkflow = async (
 		}, WORKFLOW_EXECUTION_TIMEOUT_MS);
 	});
 
+	// In queue mode, use the MCP service's pending response mechanism
+	// In regular mode, use the standard activeExecutions promise
+	const resultPromise = mcpService.isQueueMode
+		? mcpService.createPendingResponse(executionId).promise
+		: activeExecutions.getPostExecutePromise(executionId);
+
 	try {
-		const data = await Promise.race([
-			activeExecutions.getPostExecutePromise(executionId),
-			timeoutPromise,
-		]);
+		const data = await Promise.race([resultPromise, timeoutPromise]);
 
 		// Executed successfully before timeout: clear the timeout
 		clearTimeout(timeoutId);
@@ -315,6 +330,11 @@ export const executeWorkflow = async (
 		};
 	} catch (error) {
 		if (timeoutId) clearTimeout(timeoutId);
+
+		// Clean up pending response in queue mode
+		if (mcpService.isQueueMode) {
+			mcpService.removePendingResponse(executionId);
+		}
 
 		// If we hit the timeout, attempt to stop the execution
 		if (error instanceof McpExecutionTimeoutError) {

--- a/packages/cli/src/modules/mcp/tools/execute-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/execute-workflow.tool.ts
@@ -263,6 +263,7 @@ export const executeWorkflow = async (
 		userId: user.id,
 		// MCP metadata for queue mode support
 		isMcpExecution: mcpService.isQueueMode,
+		mcpType: 'service',
 		mcpSessionId: mcpMessageId, // Using messageId as sessionId for MCP Service (no persistent session)
 		mcpMessageId,
 		originMainId: mcpService.hostId,

--- a/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
@@ -2,7 +2,7 @@ import type { Logger } from '@n8n/backend-common';
 import type { ExecutionsConfig } from '@n8n/config';
 import type { IExecutionResponse, ExecutionRepository, Project } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
-import type { WorkflowExecute as ActualWorkflowExecute } from 'n8n-core';
+import type { WorkflowExecute as ActualWorkflowExecute, InstanceSettings } from 'n8n-core';
 import { ExternalSecretsProxy } from 'n8n-core';
 import { mockInstance } from 'n8n-core/test/utils';
 import {
@@ -315,4 +315,183 @@ describe('JobProcessor', () => {
 			expect(processRunExecutionDataMock).toHaveBeenCalled();
 		},
 	);
+
+	describe('MCP execution support', () => {
+		it('should send mcp-response message for MCP executions after job completion', async () => {
+			const executionRepository = mock<ExecutionRepository>();
+			executionRepository.findSingleExecution.mockResolvedValueOnce(
+				mock<IExecutionResponse>({
+					mode: 'manual',
+					workflowData: { id: 'wf-1', nodes: [], staticData: {} },
+					data: mock<IRunExecutionData>({
+						executionData: undefined,
+					}),
+				}),
+			);
+			// Second call for checking errors
+			executionRepository.findSingleExecution.mockResolvedValueOnce(
+				mock<IExecutionResponse>({
+					status: 'success',
+					workflowData: { id: 'wf-1', nodes: [], staticData: {} },
+					data: { resultData: {} },
+				}),
+			);
+
+			const manualExecutionService = mock<ManualExecutionService>();
+			const mcpInstanceSettings = {
+				hostId: 'worker-host-123',
+			} as unknown as InstanceSettings;
+
+			const jobProcessor = new JobProcessor(
+				logger,
+				executionRepository,
+				mock(), // workflowRepository
+				mock(), // nodeTypes
+				mcpInstanceSettings, // instanceSettings
+				manualExecutionService,
+				executionsConfig,
+				mock(), // eventService
+			);
+
+			const job = mock<Job>();
+			job.data = {
+				executionId: 'exec-mcp-123',
+				loadStaticData: false,
+				isMcpExecution: true,
+				mcpType: 'service',
+				mcpSessionId: 'session-456',
+				mcpMessageId: 'msg-789',
+				originMainId: 'main-host-abc',
+			};
+
+			await jobProcessor.processJob(job);
+
+			// Should have called progress with mcp-response
+			expect(job.progress).toHaveBeenCalledWith(
+				expect.objectContaining({
+					kind: 'mcp-response',
+					executionId: 'exec-mcp-123',
+					mcpType: 'service',
+					sessionId: 'session-456',
+					messageId: 'msg-789',
+					workerId: 'worker-host-123',
+					targetMainId: 'main-host-abc',
+				}),
+			);
+		});
+
+		it('should not send mcp-response for non-MCP executions', async () => {
+			const executionRepository = mock<ExecutionRepository>();
+			executionRepository.findSingleExecution.mockResolvedValueOnce(
+				mock<IExecutionResponse>({
+					mode: 'manual',
+					workflowData: { id: 'wf-1', nodes: [], staticData: {} },
+					data: mock<IRunExecutionData>({
+						executionData: undefined,
+					}),
+				}),
+			);
+			executionRepository.findSingleExecution.mockResolvedValueOnce(
+				mock<IExecutionResponse>({
+					status: 'success',
+					workflowData: { id: 'wf-1', nodes: [], staticData: {} },
+					data: { resultData: {} },
+				}),
+			);
+
+			const manualExecutionService = mock<ManualExecutionService>();
+			const jobProcessor = new JobProcessor(
+				logger,
+				executionRepository,
+				mock(),
+				mock(),
+				mock(),
+				manualExecutionService,
+				executionsConfig,
+				mock(),
+			);
+
+			const job = mock<Job>();
+			job.data = {
+				executionId: 'exec-regular-123',
+				loadStaticData: false,
+				// No MCP fields - explicitly undefined
+				isMcpExecution: undefined,
+				mcpSessionId: undefined,
+				originMainId: undefined,
+			};
+
+			await jobProcessor.processJob(job);
+
+			// Should have called progress only with job-finished, not mcp-response
+			const progressCalls = (job.progress as jest.Mock).mock.calls;
+			const mcpResponseCalls = progressCalls.filter(
+				(call: unknown[]) => (call[0] as { kind: string }).kind === 'mcp-response',
+			);
+			expect(mcpResponseCalls).toHaveLength(0);
+		});
+
+		it('should include success=false in mcp-response when execution has errors', async () => {
+			const executionRepository = mock<ExecutionRepository>();
+			executionRepository.findSingleExecution.mockResolvedValueOnce(
+				mock<IExecutionResponse>({
+					mode: 'manual',
+					workflowData: { id: 'wf-1', nodes: [], staticData: {} },
+					data: mock<IRunExecutionData>({
+						executionData: undefined,
+					}),
+				}),
+			);
+			// Second call shows error
+			executionRepository.findSingleExecution.mockResolvedValueOnce(
+				mock<IExecutionResponse>({
+					status: 'error',
+					workflowData: { id: 'wf-1', nodes: [], staticData: {} },
+					data: {
+						resultData: {
+							error: mock<ExecutionError>({ message: 'Test error' }),
+						},
+					},
+				}),
+			);
+
+			const manualExecutionService = mock<ManualExecutionService>();
+			const mcpInstanceSettings = {
+				hostId: 'worker-host-123',
+			} as unknown as InstanceSettings;
+
+			const jobProcessor = new JobProcessor(
+				logger,
+				executionRepository,
+				mock(), // workflowRepository
+				mock(), // nodeTypes
+				mcpInstanceSettings, // instanceSettings
+				manualExecutionService,
+				executionsConfig,
+				mock(), // eventService
+			);
+
+			const job = mock<Job>();
+			job.data = {
+				executionId: 'exec-mcp-error',
+				loadStaticData: false,
+				isMcpExecution: true,
+				mcpType: 'service',
+				mcpSessionId: 'session-456',
+				mcpMessageId: 'msg-789',
+				originMainId: 'main-host-abc',
+			};
+
+			await jobProcessor.processJob(job);
+
+			expect(job.progress).toHaveBeenCalledWith(
+				expect.objectContaining({
+					kind: 'mcp-response',
+					response: expect.objectContaining({
+						success: false,
+					}),
+				}),
+			);
+		});
+	});
 });

--- a/packages/cli/src/scaling/__tests__/scaling.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/scaling.service.test.ts
@@ -460,7 +460,7 @@ describe('ScalingService', () => {
 	});
 
 	describe('MCP response handling', () => {
-		it('should ignore mcp-response messages targeted at other main instances', async () => {
+		it('should process mcp-response messages (broadcast to all mains)', async () => {
 			await scalingService.setupQueue();
 
 			const messageHandler = queue.on.mock.calls.find(
@@ -475,33 +475,10 @@ describe('ScalingService', () => {
 				messageId: 'msg-789',
 				response: { success: true },
 				workerId: 'worker-abc',
-				targetMainId: 'other-main-id', // Different from current instance
 			};
 
-			// Should not throw and should silently ignore
-			messageHandler('job-999', mcpResponseMessage);
-		});
-
-		it('should process mcp-response messages targeted at this main instance', async () => {
-			await scalingService.setupQueue();
-
-			const messageHandler = queue.on.mock.calls.find(
-				([event]) => (event as string) === 'global:progress',
-			)?.[1] as (jobId: JobId, msg: unknown) => void;
-
-			const mcpResponseMessage = {
-				kind: 'mcp-response',
-				executionId: 'exec-123',
-				mcpType: 'service',
-				sessionId: 'session-456',
-				messageId: 'msg-789',
-				response: { success: true },
-				workerId: 'worker-abc',
-				targetMainId: instanceSettings.hostId, // Current instance
-			};
-
-			// Should not throw - the handler will attempt to process
-			// (actual MCP service routing is tested in integration tests)
+			// Should not throw - all mains receive and try to process MCP responses
+			// Only the one with the pending response/session will handle it successfully
 			messageHandler('job-999', mcpResponseMessage);
 		});
 	});

--- a/packages/cli/src/scaling/constants.ts
+++ b/packages/cli/src/scaling/constants.ts
@@ -10,6 +10,9 @@ export const COMMAND_PUBSUB_CHANNEL = 'n8n.commands';
 /** Pubsub channel for messages sent by workers in response to commands from main processes. */
 export const WORKER_RESPONSE_PUBSUB_CHANNEL = 'n8n.worker-response';
 
+/** Pubsub channel for MCP relay messages between main instances in multi-main queue mode. */
+export const MCP_RELAY_PUBSUB_CHANNEL = 'n8n.mcp-relay';
+
 /**
  * Commands that should be sent to the sender as well, e.g. during workflow activation and
  * deactivation in multi-main setup. */

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -165,6 +165,7 @@ export class JobProcessor {
 				const msg: McpResponseMessage = {
 					kind: 'mcp-response',
 					executionId,
+					mcpType: job.data.mcpType ?? 'service',
 					sessionId: job.data.mcpSessionId,
 					messageId: job.data.mcpMessageId ?? '',
 					response,

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -14,6 +14,17 @@ import type {
 import { BINARY_ENCODING, Workflow, UnexpectedError, createRunExecutionData } from 'n8n-workflow';
 import type PCancelable from 'p-cancelable';
 
+import type {
+	Job,
+	JobFinishedMessage,
+	JobId,
+	JobResult,
+	McpResponseMessage,
+	RespondToWebhookMessage,
+	RunningJob,
+	SendChunkMessage,
+} from './scaling.types';
+
 import { EventService } from '@/events/event.service';
 import { getLifecycleHooksForScalingWorker } from '@/execution-lifecycle/execution-lifecycle-hooks';
 import { getWorkflowActiveStatusFromWorkflowData } from '@/executions/execution.utils';
@@ -149,6 +160,23 @@ export class JobProcessor {
 		}
 
 		lifecycleHooks.addHandler('sendResponse', async (response): Promise<void> => {
+			// Check if this is an MCP execution - route response back to the originating main
+			if (job.data.isMcpExecution && job.data.mcpSessionId && job.data.originMainId) {
+				const msg: McpResponseMessage = {
+					kind: 'mcp-response',
+					executionId,
+					sessionId: job.data.mcpSessionId,
+					messageId: job.data.mcpMessageId ?? '',
+					response,
+					workerId: this.instanceSettings.hostId,
+					targetMainId: job.data.originMainId,
+				};
+
+				await job.progress(msg);
+				return;
+			}
+
+			// Standard webhook response
 			const msg: RespondToWebhookMessage = {
 				kind: 'respond-to-webhook',
 				executionId,

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -3,13 +3,21 @@ import { Logger } from '@n8n/backend-common';
 import { ExecutionsConfig } from '@n8n/config';
 import { ExecutionRepository, WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
-import { WorkflowHasIssuesError, InstanceSettings, WorkflowExecute } from 'n8n-core';
+import {
+	WorkflowHasIssuesError,
+	InstanceSettings,
+	WorkflowExecute,
+	SupplyDataContext,
+	ExecutionLifecycleHooks,
+} from 'n8n-core';
 import type {
+	CloseFunction,
 	ExecutionStatus,
 	IExecuteData,
 	IExecuteResponsePromiseData,
 	INodeExecutionData,
 	IRun,
+	ITaskDataConnections,
 	IWorkflowExecutionDataProcess,
 	StructuredChunk,
 } from 'n8n-workflow';
@@ -37,6 +45,7 @@ import type {
 	JobResult,
 	RespondToWebhookMessage,
 	McpResponseMessage,
+	McpToolResultMessage,
 	RunningJob,
 	SendChunkMessage,
 } from './scaling.types';
@@ -62,6 +71,11 @@ export class JobProcessor {
 	}
 
 	async processJob(job: Job): Promise<JobResult> {
+		// Handle MCP tool jobs (new pattern: direct tool invocation without workflow execution)
+		if (job.data.jobType === 'mcp-tool' && job.data.mcpToolJobData) {
+			return await this.processMcpToolJob(job);
+		}
+
 		const { executionId, loadStaticData } = job.data;
 
 		const execution = await this.executionRepository.findSingleExecution(executionId, {
@@ -299,65 +313,6 @@ export class JobProcessor {
 
 		await job.progress(msg);
 
-		// For MCP Trigger executions with tool calls, execute the tool and send result
-		if (
-			job.data.isMcpExecution &&
-			job.data.mcpType === 'trigger' &&
-			job.data.mcpSessionId &&
-			job.data.mcpToolCall?.sourceNodeName
-		) {
-			const { toolName, arguments: toolArgs, sourceNodeName } = job.data.mcpToolCall;
-
-			let toolResult: unknown;
-			try {
-				toolResult = await this.executeToolNode(
-					workflow,
-					sourceNodeName,
-					toolArgs,
-					additionalData,
-					executionId,
-				);
-			} catch (error) {
-				this.logger.error('Tool node execution failed for MCP Trigger', {
-					executionId,
-					toolName,
-					sourceNodeName,
-					error: error instanceof Error ? error.message : String(error),
-				});
-				toolResult = {
-					error:
-						error instanceof Error
-							? { message: error.message, name: error.name }
-							: { message: String(error) },
-				};
-			}
-
-			const mcpMsg: McpResponseMessage = {
-				kind: 'mcp-response',
-				executionId,
-				mcpType: 'trigger',
-				sessionId: job.data.mcpSessionId,
-				messageId: job.data.mcpMessageId ?? '',
-				response: toolResult, // Actual tool result
-				workerId: this.instanceSettings.hostId,
-			};
-
-			await job.progress(mcpMsg);
-		} else if (job.data.isMcpExecution && job.data.mcpSessionId) {
-			// For MCP Service executions or MCP Trigger without tool call, send basic response
-			const mcpMsg: McpResponseMessage = {
-				kind: 'mcp-response',
-				executionId,
-				mcpType: job.data.mcpType ?? 'service',
-				sessionId: job.data.mcpSessionId,
-				messageId: job.data.mcpMessageId ?? '',
-				response: { success: props.success },
-				workerId: this.instanceSettings.hostId,
-			};
-
-			await job.progress(mcpMsg);
-		}
-
 		/**
 		 * @important Do NOT call `workflowExecuteAfter` hook here.
 		 * It is being called from processSuccessExecution() already.
@@ -440,79 +395,245 @@ export class JobProcessor {
 	}
 
 	/**
-	 * Execute a tool node for MCP Trigger in queue mode.
-	 * This method creates a minimal workflow execution to run just the tool node
-	 * and extract its output.
+	 * Process an MCP tool job: invoke tool directly without creating a workflow execution.
+	 * This implements the sendChunk-style pattern for clean execution logs.
 	 */
-	private async executeToolNode(
+	private async processMcpToolJob(job: Job): Promise<JobResult> {
+		const { workflowId, mcpToolJobData } = job.data;
+
+		if (!mcpToolJobData) {
+			throw new UnexpectedError('MCP tool job missing mcpToolJobData');
+		}
+
+		const { sessionId, messageId, toolName, arguments: toolArgs, sourceNodeName } = mcpToolJobData;
+
+		this.logger.info(`Worker processing MCP tool job (job ${job.id})`, {
+			workflowId,
+			toolName,
+			sourceNodeName,
+			jobId: job.id,
+		});
+
+		// Load workflow
+		const workflowData = await this.workflowRepository.findOne({
+			where: { id: workflowId },
+		});
+
+		if (!workflowData) {
+			throw new UnexpectedError(`Worker failed to find workflow ${workflowId} for MCP tool job`);
+		}
+
+		const workflow = new Workflow({
+			id: workflowId,
+			name: workflowData.name,
+			nodes: workflowData.nodes,
+			connections: workflowData.connections,
+			active: workflowData.active,
+			nodeTypes: this.nodeTypes,
+			staticData: workflowData.staticData,
+			settings: workflowData.settings,
+		});
+
+		// Create lifecycle hooks with sendMcpToolResult handler (sendChunk-style pattern)
+		const lifecycleHooks = new ExecutionLifecycleHooks(
+			'webhook', // mode
+			`mcp-tool-${job.id}`, // executionId (synthetic, not stored in DB)
+			workflowData,
+		);
+
+		lifecycleHooks.addHandler(
+			'sendMcpToolResult',
+			async (
+				sid: string,
+				mid: string,
+				result: unknown,
+				error?: { message: string; name: string },
+			): Promise<void> => {
+				const msg: McpToolResultMessage = {
+					kind: 'mcp-tool-result',
+					sessionId: sid,
+					messageId: mid,
+					result,
+					error,
+					workerId: this.instanceSettings.hostId,
+				};
+				await job.progress(msg);
+			},
+		);
+
+		try {
+			// Invoke tool directly
+			const result = await this.invokeToolDirectly(workflow, sourceNodeName, toolArgs, workflowId);
+
+			// Send result via hook (sendChunk-style pattern)
+			await lifecycleHooks.runHook('sendMcpToolResult', [sessionId, messageId, result, undefined]);
+
+			this.logger.info(`Worker finished MCP tool job (job ${job.id})`, {
+				workflowId,
+				toolName,
+				jobId: job.id,
+				success: true,
+			});
+
+			return { success: true };
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : String(error);
+			const errorName = error instanceof Error ? error.name : 'Error';
+
+			this.logger.error(`Worker MCP tool job failed (job ${job.id})`, {
+				workflowId,
+				toolName,
+				sourceNodeName,
+				jobId: job.id,
+				error: errorMessage,
+			});
+
+			// Send error via hook
+			await lifecycleHooks.runHook('sendMcpToolResult', [
+				sessionId,
+				messageId,
+				null,
+				{ message: errorMessage, name: errorName },
+			]);
+
+			return { success: false };
+		}
+	}
+
+	/**
+	 * Invoke a tool directly using the supplyData pattern.
+	 * This creates a minimal context and invokes the tool without creating a full workflow execution.
+	 */
+	private async invokeToolDirectly(
 		workflow: Workflow,
 		sourceNodeName: string,
 		toolArgs: Record<string, unknown>,
-		additionalData: ReturnType<typeof WorkflowExecuteAdditionalData.getBase> extends Promise<
-			infer T
-		>
-			? T
-			: never,
-		_executionId: string,
+		workflowId: string,
 	): Promise<unknown> {
 		const toolNode = workflow.getNode(sourceNodeName);
 		if (!toolNode) {
 			throw new UnexpectedError(`Tool node "${sourceNodeName}" not found in workflow`);
 		}
 
-		// Validate toolArgs is a proper object (not null/array) before using as input data
-		const validatedToolArgs =
-			typeof toolArgs === 'object' && toolArgs !== null && !Array.isArray(toolArgs) ? toolArgs : {};
+		// Get node type
+		const nodeType = this.nodeTypes.getByNameAndVersion(toolNode.type, toolNode.typeVersion);
+		if (!nodeType) {
+			throw new UnexpectedError(
+				`Node type "${toolNode.type}" version ${toolNode.typeVersion} not found`,
+			);
+		}
 
-		// Create input data for the tool node with the tool arguments
-		const inputData: INodeExecutionData[][] = [
-			[
-				{
-					json: validatedToolArgs as INodeExecutionData['json'],
-				},
-			],
-		];
-
-		// Create execution stack with just the tool node
-		const nodeExecutionStack: IExecuteData[] = [
-			{
-				node: toolNode,
-				data: {
-					main: inputData,
-				},
-				source: null,
-			},
-		];
-
-		// Create minimal run execution data for the tool node
-		const toolRunData = createRunExecutionData({
-			executionData: {
-				nodeExecutionStack,
-			},
+		// Create minimal additionalData
+		const additionalData = await WorkflowExecuteAdditionalData.getBase({
+			workflowId,
 		});
 
-		// Execute the tool node
-		const workflowExecute = new WorkflowExecute(additionalData, 'webhook', toolRunData);
-		const toolRun = await workflowExecute.processRunExecutionData(workflow);
+		// Create minimal run execution data
+		const runExecutionData = createRunExecutionData();
 
-		// Extract the tool node's output from the run data
-		const nodeRunData = toolRun.data.resultData.runData[sourceNodeName];
-		if (!nodeRunData || nodeRunData.length === 0) {
-			return { error: 'Tool execution produced no output' };
+		// Cast toolArgs to IDataObject for type compatibility
+		const toolArgsData = toolArgs as INodeExecutionData['json'];
+
+		// Create input data for the context
+		const connectionInputData: INodeExecutionData[] = [
+			{
+				json: toolArgsData,
+			},
+		];
+
+		const inputData: ITaskDataConnections = {
+			[NodeConnectionTypes.AiTool]: [[{ json: toolArgsData }]],
+		};
+
+		const executeData: IExecuteData = {
+			node: toolNode,
+			data: { main: [[{ json: toolArgsData }]] },
+			source: null,
+		};
+
+		const closeFunctions: CloseFunction[] = [];
+
+		// Create SupplyDataContext for tool invocation
+		const context = new SupplyDataContext(
+			workflow,
+			toolNode,
+			additionalData,
+			'webhook',
+			runExecutionData,
+			0, // runIndex
+			connectionInputData,
+			inputData,
+			NodeConnectionTypes.AiTool,
+			executeData,
+			closeFunctions,
+			undefined, // abortSignal
+			undefined, // parentNode
+		);
+
+		// Check if node has supplyData method
+		if (nodeType.supplyData) {
+			// Call supplyData to get the tool
+			const supplyResult = await nodeType.supplyData.call(context, 0);
+			const tool = supplyResult.response;
+
+			// Validate tool and invoke
+			if (
+				tool &&
+				typeof tool === 'object' &&
+				'invoke' in tool &&
+				typeof tool.invoke === 'function'
+			) {
+				const result = await tool.invoke(toolArgs);
+
+				// Run close functions
+				for (const closeFunction of closeFunctions) {
+					await closeFunction();
+				}
+
+				return result;
+			} else {
+				throw new UnexpectedError(`Tool "${sourceNodeName}" does not have an invoke method`);
+			}
+		} else {
+			// Fallback: execute the node directly if it doesn't have supplyData
+			// This is similar to the existing executeToolNode but simplified
+			const validatedToolArgs =
+				typeof toolArgs === 'object' && toolArgs !== null && !Array.isArray(toolArgs)
+					? toolArgs
+					: {};
+
+			const nodeInputData: INodeExecutionData[][] = [
+				[{ json: validatedToolArgs as INodeExecutionData['json'] }],
+			];
+
+			const nodeExecutionStack: IExecuteData[] = [
+				{
+					node: toolNode,
+					data: { main: nodeInputData },
+					source: null,
+				},
+			];
+
+			const toolRunData = createRunExecutionData({
+				executionData: { nodeExecutionStack },
+			});
+
+			const workflowExecute = new WorkflowExecute(additionalData, 'webhook', toolRunData);
+			const toolRun = await workflowExecute.processRunExecutionData(workflow);
+
+			const nodeRunData = toolRun.data.resultData.runData[sourceNodeName];
+			if (!nodeRunData || nodeRunData.length === 0) {
+				return { error: 'Tool execution produced no output' };
+			}
+
+			const lastRun = nodeRunData[nodeRunData.length - 1];
+			const outputData = lastRun.data?.[NodeConnectionTypes.Main]?.[0];
+
+			if (!outputData || outputData.length === 0) {
+				return { error: 'Tool execution produced empty output' };
+			}
+
+			return outputData[0]?.json;
 		}
-
-		// Get the output data from the last run
-		const lastRun = nodeRunData[nodeRunData.length - 1];
-		const outputData = lastRun.data?.[NodeConnectionTypes.Main]?.[0];
-
-		if (!outputData || outputData.length === 0) {
-			return { error: 'Tool execution produced empty output' };
-		}
-
-		// Return the JSON data from the first output item
-		// For tools, typically there's a single output item with the result
-		const result = outputData[0]?.json;
-
-		return result;
 	}
 }

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -307,6 +307,7 @@ export class JobProcessor {
 			const mcpMsg: McpResponseMessage = {
 				kind: 'mcp-response',
 				executionId,
+				mcpType: job.data.mcpType ?? 'service',
 				sessionId: job.data.mcpSessionId,
 				messageId: job.data.mcpMessageId ?? '',
 				response: { success: !hasErrors }, // Main will fetch full data from DB

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -327,7 +327,7 @@ export class JobProcessor {
 				toolResult = {
 					error:
 						error instanceof Error
-							? { message: error.message, name: error.name, stack: error.stack }
+							? { message: error.message, name: error.name }
 							: { message: String(error) },
 				};
 			}
@@ -460,12 +460,15 @@ export class JobProcessor {
 			throw new UnexpectedError(`Tool node "${sourceNodeName}" not found in workflow`);
 		}
 
+		// Validate toolArgs is a proper object (not null/array) before using as input data
+		const validatedToolArgs =
+			typeof toolArgs === 'object' && toolArgs !== null && !Array.isArray(toolArgs) ? toolArgs : {};
+
 		// Create input data for the tool node with the tool arguments
-		// Cast toolArgs to IDataObject since it comes from JSON-RPC which is type-safe
 		const inputData: INodeExecutionData[][] = [
 			[
 				{
-					json: toolArgs as unknown as INodeExecutionData['json'],
+					json: validatedToolArgs as INodeExecutionData['json'],
 				},
 			],
 		];

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -14,17 +14,6 @@ import type {
 import { BINARY_ENCODING, Workflow, UnexpectedError, createRunExecutionData } from 'n8n-workflow';
 import type PCancelable from 'p-cancelable';
 
-import type {
-	Job,
-	JobFinishedMessage,
-	JobId,
-	JobResult,
-	McpResponseMessage,
-	RespondToWebhookMessage,
-	RunningJob,
-	SendChunkMessage,
-} from './scaling.types';
-
 import { EventService } from '@/events/event.service';
 import { getLifecycleHooksForScalingWorker } from '@/execution-lifecycle/execution-lifecycle-hooks';
 import { getWorkflowActiveStatusFromWorkflowData } from '@/executions/execution.utils';
@@ -39,6 +28,7 @@ import type {
 	JobId,
 	JobResult,
 	RespondToWebhookMessage,
+	McpResponseMessage,
 	RunningJob,
 	SendChunkMessage,
 } from './scaling.types';
@@ -311,7 +301,7 @@ export class JobProcessor {
 				mcpType: job.data.mcpType ?? 'service',
 				sessionId: job.data.mcpSessionId,
 				messageId: job.data.mcpMessageId ?? '',
-				response: { success: !hasErrors }, // Main will fetch full data from DB
+				response: { success: props.success }, // Main will fetch full data from DB
 				workerId: this.instanceSettings.hostId,
 				targetMainId: job.data.originMainId,
 			};

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -301,6 +301,22 @@ export class JobProcessor {
 
 		await job.progress(msg);
 
+		// For MCP executions, send an mcp-response message to notify main
+		// Main will fetch the execution data from DB and resolve the pending promise
+		if (job.data.isMcpExecution && job.data.mcpSessionId && job.data.originMainId) {
+			const mcpMsg: McpResponseMessage = {
+				kind: 'mcp-response',
+				executionId,
+				sessionId: job.data.mcpSessionId,
+				messageId: job.data.mcpMessageId ?? '',
+				response: { success: !hasErrors }, // Main will fetch full data from DB
+				workerId: this.instanceSettings.hostId,
+				targetMainId: job.data.originMainId,
+			};
+
+			await job.progress(mcpMsg);
+		}
+
 		/**
 		 * @important Do NOT call `workflowExecuteAfter` hook here.
 		 * It is being called from processSuccessExecution() already.

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -386,6 +386,9 @@ export class ScalingService {
 					break;
 				case 'abort-job':
 					break; // only for worker
+				case 'mcp-response':
+					// TODO: Forward to MCP manager - will be implemented later
+					break;
 				default:
 					assertNever(msg);
 			}

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -387,7 +387,24 @@ export class ScalingService {
 				case 'abort-job':
 					break; // only for worker
 				case 'mcp-response':
+					// Only process if this main instance originated the request (multi-main support)
+					if (msg.targetMainId !== this.instanceSettings.hostId) {
+						break;
+					}
+
+					this.logger.debug(
+						`Received MCP response for execution ${msg.executionId} (job ${jobId})`,
+						{
+							workerId: msg.workerId,
+							executionId: msg.executionId,
+							sessionId: msg.sessionId,
+							messageId: msg.messageId,
+							jobId,
+						},
+					);
+
 					// TODO: Forward to MCP manager - will be implemented later
+					// mcpManager.handleWorkerResponse(msg.sessionId, msg.messageId, msg.response);
 					break;
 				default:
 					assertNever(msg);

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -256,6 +256,49 @@ export class ScalingService {
 		return job;
 	}
 
+	/**
+	 * Add an MCP tool job to the queue.
+	 * This creates a job that invokes a tool directly without creating a workflow execution.
+	 */
+	async addMcpToolJob(data: {
+		workflowId: string;
+		sessionId: string;
+		messageId: string;
+		toolName: string;
+		arguments: Record<string, unknown>;
+		sourceNodeName: string;
+	}) {
+		const jobData: JobData = {
+			workflowId: data.workflowId,
+			executionId: `mcp-tool-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`, // Synthetic ID (not stored in DB)
+			loadStaticData: false,
+			jobType: 'mcp-tool',
+			mcpToolJobData: {
+				sessionId: data.sessionId,
+				messageId: data.messageId,
+				toolName: data.toolName,
+				arguments: data.arguments,
+				sourceNodeName: data.sourceNodeName,
+			},
+		};
+
+		const jobOptions: JobOptions = {
+			priority: 1, // High priority for interactive tool calls
+			removeOnComplete: true,
+			removeOnFail: true,
+		};
+
+		const job = await this.queue.add(JOB_TYPE_NAME, jobData, jobOptions);
+
+		this.logger.info(`Enqueued MCP tool job (job ${job.id})`, {
+			workflowId: data.workflowId,
+			toolName: data.toolName,
+			jobId: job.id,
+		});
+
+		return job;
+	}
+
 	async getJob(jobId: JobId) {
 		return await this.queue.getJob(jobId);
 	}
@@ -420,7 +463,7 @@ export class ScalingService {
 				case 'abort-job':
 					break; // only for worker
 				case 'mcp-response':
-					// Route to appropriate MCP handler based on type
+					// Route to appropriate MCP handler based on type (legacy workflow-based pattern)
 					// All mains receive this; only the one with the session/pending response will handle it
 					void this.handleMcpResponse(
 						msg.executionId,
@@ -429,6 +472,11 @@ export class ScalingService {
 						msg.messageId,
 						msg.response,
 					);
+					break;
+				case 'mcp-tool-result':
+					// Handle MCP tool result from worker (new sendChunk-style pattern)
+					// All mains receive this; only the one with the session/pending tool call will handle it
+					void this.handleMcpToolResult(msg.sessionId, msg.messageId, msg.result, msg.error);
 					break;
 				default:
 					assertNever(msg);
@@ -500,6 +548,36 @@ export class ScalingService {
 				executionId,
 				mcpType,
 				error: ensureError(error).message,
+			});
+		}
+	}
+
+	/**
+	 * Handle MCP tool result from worker (new sendChunk-style pattern).
+	 * Forwards the result to McpServerManager which resolves the pending tool call.
+	 */
+	private async handleMcpToolResult(
+		sessionId: string,
+		messageId: string,
+		result: unknown,
+		error?: { message: string; name: string },
+	): Promise<void> {
+		try {
+			const { McpServerManager } = await import(
+				'@n8n/n8n-nodes-langchain/dist/nodes/mcp/McpTrigger/McpServer'
+			);
+			const mcpServerManager = McpServerManager.instance(this.logger);
+
+			if (error) {
+				mcpServerManager.rejectToolCall(`${sessionId}_${messageId}`, new Error(error.message));
+			} else {
+				mcpServerManager.handleWorkerResponse(sessionId, messageId, result);
+			}
+		} catch (handlerError) {
+			this.logger.error('Failed to handle MCP tool result', {
+				sessionId,
+				messageId,
+				error: ensureError(handlerError).message,
 			});
 		}
 	}

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -80,6 +80,13 @@ export class ScalingService {
 
 		this.scheduleQueueMetrics();
 
+		// Initialize MCP Server Manager with queue mode enabled
+		// This tells the MCP Trigger to delegate tool executions to workers
+		const { McpServerManager } = await import(
+			'@n8n/n8n-nodes-langchain/dist/nodes/mcp/McpTrigger/McpServer'
+		);
+		McpServerManager.instance(this.logger).setQueueMode(true);
+
 		this.logger.debug('Queue setup completed');
 	}
 
@@ -387,25 +394,15 @@ export class ScalingService {
 				case 'abort-job':
 					break; // only for worker
 				case 'mcp-response':
-					// Only process if this main instance originated the request (multi-main support)
-					if (msg.targetMainId !== this.instanceSettings.hostId) {
-						break;
-					}
-
-					this.logger.debug(
-						`Received MCP response for execution ${msg.executionId} (job ${jobId})`,
-						{
-							workerId: msg.workerId,
-							executionId: msg.executionId,
-							mcpType: msg.mcpType,
-							sessionId: msg.sessionId,
-							messageId: msg.messageId,
-							jobId,
-						},
-					);
-
 					// Route to appropriate MCP handler based on type
-					void this.handleMcpResponse(msg.executionId, msg.mcpType, msg.sessionId, msg.messageId);
+					// All mains receive this; only the one with the session/pending response will handle it
+					void this.handleMcpResponse(
+						msg.executionId,
+						msg.mcpType,
+						msg.sessionId,
+						msg.messageId,
+						msg.response,
+					);
 					break;
 				default:
 					assertNever(msg);
@@ -424,51 +421,53 @@ export class ScalingService {
 	}
 
 	/**
-	 * Handle MCP response from worker - fetch execution data and forward to appropriate MCP handler.
+	 * Handle MCP response from worker - forward to appropriate MCP handler.
+	 * For MCP Service: fetches execution data from DB and forwards IRun.
+	 * For MCP Trigger: forwards the response directly (tool result from sendResponse hook).
 	 */
 	private async handleMcpResponse(
 		executionId: string,
 		mcpType: 'service' | 'trigger',
 		sessionId: string,
 		messageId: string,
+		response: unknown,
 	): Promise<void> {
 		try {
-			// Fetch execution data from DB
-			const executionData = await this.executionRepository.findSingleExecution(executionId, {
-				includeData: true,
-				unflattenData: true,
-			});
-
-			if (!executionData) {
-				this.logger.error('MCP response: Execution not found in DB', { executionId });
-				return;
-			}
-
-			// Convert to IRun format
-			const runData: IRun = {
-				finished: executionData.finished,
-				mode: executionData.mode,
-				startedAt: executionData.startedAt,
-				stoppedAt: executionData.stoppedAt,
-				status: executionData.status,
-				data: executionData.data,
-				storedAt: executionData.storedAt,
-			};
-
 			if (mcpType === 'service') {
-				// Forward to MCP Service
+				// For MCP Service, fetch execution data from DB
+				const executionData = await this.executionRepository.findSingleExecution(executionId, {
+					includeData: true,
+					unflattenData: true,
+				});
+
+				if (!executionData) {
+					this.logger.error('Execution not found in DB for MCP response', { executionId });
+					return;
+				}
+
+				// Convert to IRun format
+				const runData: IRun = {
+					finished: executionData.finished,
+					mode: executionData.mode,
+					startedAt: executionData.startedAt,
+					stoppedAt: executionData.stoppedAt,
+					status: executionData.status,
+					data: executionData.data,
+					storedAt: executionData.storedAt,
+				};
+
 				const { McpService } = await import('@/modules/mcp/mcp.service');
 				const mcpService = Container.get(McpService);
 				mcpService.handleWorkerResponse(executionId, runData);
 			} else {
-				// Forward to MCP Trigger's McpServerManager
+				// For MCP Trigger, forward the response directly (tool result)
 				const { McpServerManager } = await import(
 					'@n8n/n8n-nodes-langchain/dist/nodes/mcp/McpTrigger/McpServer'
 				);
 				// McpServerManager is a singleton that requires a logger for first initialization
 				// At this point it should already be initialized by the MCP Trigger node
 				const mcpServerManager = McpServerManager.instance(this.logger);
-				mcpServerManager.handleWorkerResponse(sessionId, messageId, runData);
+				mcpServerManager.handleWorkerResponse(sessionId, messageId, response);
 			}
 		} catch (error) {
 			this.logger.error('Failed to handle MCP response', {

--- a/packages/cli/src/scaling/scaling.types.ts
+++ b/packages/cli/src/scaling/scaling.types.ts
@@ -22,6 +22,16 @@ export type JobData = {
 	pushRef?: string;
 	streamingEnabled?: boolean;
 	restartExecutionId?: string;
+
+	// MCP-specific fields for queue mode support
+	/** Whether this execution was triggered by an MCP tool call. */
+	isMcpExecution?: boolean;
+	/** MCP session ID for routing responses back to the correct client. */
+	mcpSessionId?: string;
+	/** MCP message ID for correlating responses with requests. */
+	mcpMessageId?: string;
+	/** ID of the main instance that enqueued this job (for multi-main routing). */
+	originMainId?: string;
 };
 
 export type JobResult = {
@@ -43,7 +53,8 @@ export type JobMessage =
 	| JobFinishedMessage
 	| JobFailedMessage
 	| AbortJobMessage
-	| SendChunkMessage;
+	| SendChunkMessage
+	| McpResponseMessage;
 
 /** Message sent by worker to main to respond to a webhook. */
 export type RespondToWebhookMessage = {
@@ -88,6 +99,17 @@ export type SendChunkMessage = {
 	executionId: string;
 	chunkText: StructuredChunk;
 	workerId: string;
+};
+
+/** Message sent by worker to main to respond to an MCP tool call. */
+export type McpResponseMessage = {
+	kind: 'mcp-response';
+	executionId: string;
+	sessionId: string;
+	messageId: string;
+	response: unknown;
+	workerId: string;
+	targetMainId: string;
 };
 
 /** Message sent by worker to main to report a job has failed. */

--- a/packages/cli/src/scaling/scaling.types.ts
+++ b/packages/cli/src/scaling/scaling.types.ts
@@ -32,8 +32,13 @@ export type JobData = {
 	mcpSessionId?: string;
 	/** MCP message ID for correlating responses with requests. */
 	mcpMessageId?: string;
-	/** ID of the main instance that enqueued this job (for multi-main routing). */
-	originMainId?: string;
+	/** Tool call info for MCP Trigger executions (tool name, args, source node). */
+	mcpToolCall?: {
+		toolName: string;
+		arguments: Record<string, unknown>;
+		/** The n8n node name that provides this tool. */
+		sourceNodeName?: string;
+	};
 };
 
 export type JobResult = {
@@ -113,7 +118,6 @@ export type McpResponseMessage = {
 	messageId: string;
 	response: unknown;
 	workerId: string;
-	targetMainId: string;
 };
 
 /** Message sent by worker to main to report a job has failed. */

--- a/packages/cli/src/scaling/scaling.types.ts
+++ b/packages/cli/src/scaling/scaling.types.ts
@@ -23,21 +23,7 @@ export type JobData = {
 	streamingEnabled?: boolean;
 	restartExecutionId?: string;
 
-	// Job type discriminator: 'workflow' (default) or 'mcp-tool'
-	// mcp-tool jobs invoke tool directly without creating workflow execution
-	jobType?: 'workflow' | 'mcp-tool';
-
-	// MCP tool job specific fields (only when jobType === 'mcp-tool')
-	mcpToolJobData?: {
-		sessionId: string;
-		messageId: string;
-		toolName: string;
-		arguments: Record<string, unknown>;
-		/** The n8n node name that provides this tool. */
-		sourceNodeName: string;
-	};
-
-	// Legacy MCP-specific fields for workflow-based queue mode support (deprecated)
+	// MCP-specific fields for queue mode support
 	/** Whether this execution was triggered by an MCP tool call. */
 	isMcpExecution?: boolean;
 	/** Type of MCP execution: 'service' for MCP Service, 'trigger' for MCP Trigger Node. */
@@ -75,8 +61,7 @@ export type JobMessage =
 	| JobFailedMessage
 	| AbortJobMessage
 	| SendChunkMessage
-	| McpResponseMessage
-	| McpToolResultMessage;
+	| McpResponseMessage;
 
 /** Message sent by worker to main to respond to a webhook. */
 export type RespondToWebhookMessage = {
@@ -123,7 +108,7 @@ export type SendChunkMessage = {
 	workerId: string;
 };
 
-/** Message sent by worker to main to respond to an MCP tool call (legacy workflow-based). */
+/** Message sent by worker to main to respond to an MCP tool call. */
 export type McpResponseMessage = {
 	kind: 'mcp-response';
 	executionId: string;
@@ -132,16 +117,6 @@ export type McpResponseMessage = {
 	sessionId: string;
 	messageId: string;
 	response: unknown;
-	workerId: string;
-};
-
-/** Message sent by worker to main with MCP tool result (new sendChunk-style pattern). */
-export type McpToolResultMessage = {
-	kind: 'mcp-tool-result';
-	sessionId: string;
-	messageId: string;
-	result: unknown;
-	error?: { message: string; name: string };
 	workerId: string;
 };
 

--- a/packages/cli/src/scaling/scaling.types.ts
+++ b/packages/cli/src/scaling/scaling.types.ts
@@ -26,6 +26,8 @@ export type JobData = {
 	// MCP-specific fields for queue mode support
 	/** Whether this execution was triggered by an MCP tool call. */
 	isMcpExecution?: boolean;
+	/** Type of MCP execution: 'service' for MCP Service, 'trigger' for MCP Trigger Node. */
+	mcpType?: 'service' | 'trigger';
 	/** MCP session ID for routing responses back to the correct client. */
 	mcpSessionId?: string;
 	/** MCP message ID for correlating responses with requests. */
@@ -105,6 +107,8 @@ export type SendChunkMessage = {
 export type McpResponseMessage = {
 	kind: 'mcp-response';
 	executionId: string;
+	/** Type of MCP execution: 'service' for MCP Service, 'trigger' for MCP Trigger Node. */
+	mcpType: 'service' | 'trigger';
 	sessionId: string;
 	messageId: string;
 	response: unknown;

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -114,6 +114,31 @@ function isMcpListToolsRelay(value: unknown): value is McpListToolsRelayPayload 
 	);
 }
 
+// Type guard for new MCP tool job pattern (sendChunk-style, no workflow execution)
+interface McpToolJobPayload {
+	_mcpToolJob: true;
+	mcpSessionId: string;
+	mcpMessageId: string;
+	toolName: string;
+	arguments: Record<string, unknown>;
+	sourceNodeName: string;
+}
+
+function isMcpToolJob(value: unknown): value is McpToolJobPayload {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		'_mcpToolJob' in value &&
+		(value as Record<string, unknown>)._mcpToolJob === true &&
+		'mcpSessionId' in value &&
+		typeof (value as Record<string, unknown>).mcpSessionId === 'string' &&
+		'toolName' in value &&
+		typeof (value as Record<string, unknown>).toolName === 'string' &&
+		'sourceNodeName' in value &&
+		typeof (value as Record<string, unknown>).sourceNodeName === 'string'
+	);
+}
+
 export function handleHostedChatResponse(
 	res: express.Response,
 	responseMode: WebhookResponseMode,
@@ -647,6 +672,28 @@ export async function executeWebhook(
 
 		const executionsConfig = Container.get(ExecutionsConfig);
 		if (workflowStartNode.type === MCP_TRIGGER_NODE_TYPE && executionsConfig.mode === 'queue') {
+			const firstItem = webhookResultData.workflowData?.[0]?.[0];
+
+			// New pattern: MCP tool job - enqueue directly without workflow execution
+			const mcpToolJobValue = firstItem && 'json' in firstItem ? firstItem.json : null;
+			if (isMcpToolJob(mcpToolJobValue)) {
+				const { ScalingService } = await import('@/scaling/scaling.service');
+				const scalingService = Container.get(ScalingService);
+
+				await scalingService.addMcpToolJob({
+					workflowId: workflowData.id,
+					sessionId: mcpToolJobValue.mcpSessionId,
+					messageId: mcpToolJobValue.mcpMessageId,
+					toolName: mcpToolJobValue.toolName,
+					arguments: mcpToolJobValue.arguments,
+					sourceNodeName: mcpToolJobValue.sourceNodeName,
+				});
+
+				// No execution created - tool will be invoked directly on worker
+				return undefined;
+			}
+
+			// Legacy pattern: full workflow execution for MCP
 			const querySessionId = req.query?.sessionId;
 			const headerSessionId = req.headers['mcp-session-id'];
 			const mcpSessionId =
@@ -656,7 +703,6 @@ export async function executeWebhook(
 						? headerSessionId
 						: '';
 
-			const firstItem = webhookResultData.workflowData?.[0]?.[0];
 			const mcpMessageId =
 				(firstItem && 'json' in firstItem && typeof firstItem.json?.mcpMessageId === 'string'
 					? firstItem.json.mcpMessageId

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -392,6 +392,7 @@ export class WorkflowRunner {
 			restartExecutionId,
 			// MCP-specific fields for queue mode support
 			isMcpExecution: data.isMcpExecution,
+			mcpType: data.mcpType,
 			mcpSessionId: data.mcpSessionId,
 			mcpMessageId: data.mcpMessageId,
 			originMainId: data.originMainId,

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -390,6 +390,11 @@ export class WorkflowRunner {
 			pushRef: data.pushRef,
 			streamingEnabled: data.streamingEnabled,
 			restartExecutionId,
+			// MCP-specific fields for queue mode support
+			isMcpExecution: data.isMcpExecution,
+			mcpSessionId: data.mcpSessionId,
+			mcpMessageId: data.mcpMessageId,
+			originMainId: data.originMainId,
 		};
 
 		if (!this.scalingService) {

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -395,7 +395,7 @@ export class WorkflowRunner {
 			mcpType: data.mcpType,
 			mcpSessionId: data.mcpSessionId,
 			mcpMessageId: data.mcpMessageId,
-			originMainId: data.originMainId,
+			mcpToolCall: data.mcpToolCall,
 		};
 
 		if (!this.scalingService) {

--- a/packages/core/src/execution-engine/execution-lifecycle-hooks.ts
+++ b/packages/core/src/execution-engine/execution-lifecycle-hooks.ts
@@ -50,6 +50,17 @@ export type ExecutionLifecycleHookHandlers = {
 	/** Used by nodes to send chunks to streaming responses */
 	sendChunk: Array<(this: ExecutionLifecycleHooks, chunk: StructuredChunk) => Promise<void> | void>;
 
+	/** Used to send MCP tool results from workers to main in queue mode */
+	sendMcpToolResult: Array<
+		(
+			this: ExecutionLifecycleHooks,
+			sessionId: string,
+			messageId: string,
+			result: unknown,
+			error?: { message: string; name: string },
+		) => Promise<void> | void
+	>;
+
 	/**
 	 * Executed after a node fetches data
 	 * - For a webhook node, after the node had been run.
@@ -89,6 +100,7 @@ export class ExecutionLifecycleHooks {
 		workflowExecuteAfter: [],
 		workflowExecuteBefore: [],
 		sendChunk: [],
+		sendMcpToolResult: [],
 	};
 
 	constructor(

--- a/packages/core/src/execution-engine/execution-lifecycle-hooks.ts
+++ b/packages/core/src/execution-engine/execution-lifecycle-hooks.ts
@@ -50,17 +50,6 @@ export type ExecutionLifecycleHookHandlers = {
 	/** Used by nodes to send chunks to streaming responses */
 	sendChunk: Array<(this: ExecutionLifecycleHooks, chunk: StructuredChunk) => Promise<void> | void>;
 
-	/** Used to send MCP tool results from workers to main in queue mode */
-	sendMcpToolResult: Array<
-		(
-			this: ExecutionLifecycleHooks,
-			sessionId: string,
-			messageId: string,
-			result: unknown,
-			error?: { message: string; name: string },
-		) => Promise<void> | void
-	>;
-
 	/**
 	 * Executed after a node fetches data
 	 * - For a webhook node, after the node had been run.
@@ -100,7 +89,6 @@ export class ExecutionLifecycleHooks {
 		workflowExecuteAfter: [],
 		workflowExecuteBefore: [],
 		sendChunk: [],
-		sendMcpToolResult: [],
 	};
 
 	constructor(

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2754,6 +2754,8 @@ export interface IWorkflowExecutionDataProcess {
 	// MCP-specific fields for queue mode support
 	/** Whether this execution was triggered by an MCP tool call. */
 	isMcpExecution?: boolean;
+	/** Type of MCP execution: 'service' for MCP Service, 'trigger' for MCP Trigger Node. */
+	mcpType?: 'service' | 'trigger';
 	/** MCP session ID for routing responses back to the correct client. */
 	mcpSessionId?: string;
 	/** MCP message ID for correlating responses with requests. */

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2750,6 +2750,16 @@ export interface IWorkflowExecutionDataProcess {
 	httpResponse?: express.Response; // Used for streaming responses
 	streamingEnabled?: boolean;
 	startedAt?: Date;
+
+	// MCP-specific fields for queue mode support
+	/** Whether this execution was triggered by an MCP tool call. */
+	isMcpExecution?: boolean;
+	/** MCP session ID for routing responses back to the correct client. */
+	mcpSessionId?: string;
+	/** MCP message ID for correlating responses with requests. */
+	mcpMessageId?: string;
+	/** ID of the main instance that started this execution (for multi-main routing). */
+	originMainId?: string;
 }
 
 export interface ExecuteWorkflowOptions {

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2760,8 +2760,12 @@ export interface IWorkflowExecutionDataProcess {
 	mcpSessionId?: string;
 	/** MCP message ID for correlating responses with requests. */
 	mcpMessageId?: string;
-	/** ID of the main instance that started this execution (for multi-main routing). */
-	originMainId?: string;
+	/** Tool call info for MCP Trigger executions in queue mode. */
+	mcpToolCall?: {
+		toolName: string;
+		arguments: Record<string, unknown>;
+		sourceNodeName?: string;
+	};
 }
 
 export interface ExecuteWorkflowOptions {


### PR DESCRIPTION
demo: [https://www.loom.com/share/11695991d948464d83714929eb01d043](<https://www.loom.com/share/11695991d948464d83714929eb01d043>)<br>full writeup: [https://www.notion.so/n8n/MCP-Trigger-Queue-Mode-Multi-Main-Support-2fc5b6e0c94f80f6952eca821a250e03](<https://www.notion.so/n8n/MCP-Trigger-Queue-Mode-Multi-Main-Support-2fc5b6e0c94f80f6952eca821a250e03>)

## Summary

Added support for MCP Trigger and MCP Service in **queue mode** and **multi-main** deployments, enabling distributed execution of MCP tool calls while maintaining session state and reliable response delivery.

## The Problem

### Queue Mode Incompatibility

In queue mode, workflows execute on workers via Redis job queues. When a worker completes an MCP tool call, it has no direct connection to the MCP client—the response must travel back through the main process.

```mermaid
graph TB
    subgraph "Queue Mode Challenge"
        Client[MCP Client]
        Main[Main Process]
        Redis[(Redis Queue)]
        Worker[Worker]
    end

    Client -->|POST| Main
    Main -->|Enqueue Job| Redis
    Redis -->|Dequeue| Worker
    Worker -.->|??? How to respond ???| Client
```

### Multi-Main Load Balancing

With load balancing, POST requests may land on a different main than the one holding the SSE session.

```mermaid
graph TB
    subgraph "Multi-Main Challenge"
        Client[MCP Client]
        LB[Load Balancer]
        Main1[Main 1 - Has SSE Session]
        Main2[Main 2 - No Session]
    end

    Client -->|SSE Connect| Main1
    Client -->|POST Tool Call| LB
    LB -->|Round Robin| Main2
    Main2 -.->|Session not found!| Client
```

## The Solution

### Architecture Overview

```mermaid
flowchart TB
    subgraph "MCP Client"
        MC[AI Agent]
    end

    subgraph "Main Layer"
        M1[Main 1]
        M2[Main 2]
        MSM[McpServerManager]
    end

    subgraph "Message Bus"
        BQ[(Bull Queue - Jobs)]
        PS[(Redis PubSub - Responses)]
    end

    subgraph "Worker Layer"
        W1[Worker]
    end

    MC -->|1. Tool Call| M1
    M1 -->|2. Enqueue Job| BQ
    BQ -->|3. Dequeue| W1
    W1 -->|4. Execute Workflow| W1
    W1 -->|5. Invoke Tool Directly| W1
    W1 -->|6. job.progress(McpResponseMessage)| PS
    PS -->|7. Receive| M1
    M1 -->|8. Route to Session| MSM
    MSM -->|9. Send Response| MC
```

### Key Design Decisions

1. **Workflow Execution + Tool Invocation**: Worker executes the workflow first, then invokes the requested tool directly via `invokeTool()` using the `supplyData` pattern
2. **Direct Response via job.progress()**: Tool results are sent back via Bull's `job.progress()` as `McpResponseMessage` - no special lifecycle hooks needed
3. **Async Acknowledgment**: Return `202 Accepted` immediately, complete asynchronously
4. **Broadcast Responses**: Workers broadcast to all mains via `job.progress()`; mains filter by session
5. **Session-Message Correlation**: Unique `sessionId + messageId` pairs track requests

### Tool Call Flow (MCP Trigger)

```mermaid
sequenceDiagram
    participant Client as MCP Client
    participant Main as Main Process
    participant MSM as McpServerManager
    participant Queue as Redis Queue
    participant Worker as Worker Process

    Client->>Main: POST /webhook/mcp-trigger
    Main->>MSM: handlePostMessage()
    MSM->>MSM: storePendingToolCall(callId)
    MSM-->>Main: Return {wasToolCall, toolCallInfo, messageId}
    Main->>Main: Set runData.mcpToolCall, mcpSessionId, mcpMessageId
    Main->>Queue: addJob (with MCP metadata)

    Queue->>Worker: Dequeue job
    Worker->>Worker: processJob() - Execute workflow
    Worker->>Worker: Check if MCP Trigger with tool call
    Worker->>Worker: invokeTool() via supplyData pattern
    Worker->>Queue: job.progress(McpResponseMessage)

    Queue-->>Main: global:progress event
    Main->>Main: handleMcpResponse()
    Main->>MSM: handleWorkerResponse(sessionId, messageId, result)
    MSM->>MSM: resolveToolCall(callId, result)
    MSM->>Client: Send formatted response via transport
```

### Multi-Main Relay (SSE Transport)

When POST lands on a different main than the SSE session:

```mermaid
sequenceDiagram
    participant Client as MCP Client
    participant Main1 as Main 1 (Has SSE)
    participant Main2 as Main 2 (Receives POST)
    participant PubSub as Redis PubSub

    Client->>Main1: SSE Connect
    Client->>Main2: POST tools/list
    Main2-->>Client: 202 Accepted + relaySessionId
    Main2->>PubSub: Publish to mcp-relay channel
    PubSub->>Main1: Receive relay message
    Main1->>Client: Send tools via SSE
```

### Multi-Main Support (Streamable HTTP Transport)

Unlike SSE, Streamable HTTP is stateless—each request is independent. When a request lands on a main that doesn't have the original session, the transport is recreated using the sessionId stored in Redis:

```mermaid
sequenceDiagram
    participant Client as MCP Client
    participant Main1 as Main 1 (Created Session)
    participant Main2 as Main 2 (Receives Request)
    participant Redis as Redis

    Note over Main1: Session created
    Main1->>Redis: Store sessionId
    Client->>Main2: POST with sessionId header
    Main2->>Redis: Validate sessionId exists
    Redis-->>Main2: Session valid
    Main2->>Main2: Recreate StreamableHTTP transport with sessionId
    Main2->>Main2: Process request locally
    Main2-->>Client: Response
```

**How it works:**

1. When a new MCP session is initialized, the `sessionId` is stored in Redis
2. Incoming Streamable HTTP requests include the `sessionId` in the header
3. If the receiving main doesn't have the session in memory, it checks Redis to validate the `sessionId`
4. If valid, a new `StreamableHTTPServerTransport` is recreated with the same `sessionId`
5. The request is processed locally on that main, no relay needed
6. This allows any main to handle requests for any session, enabling true horizontal scaling

## Implementation Details

### MCP Trigger Queue Mode

The MCP Trigger queue mode flow works as follows:

1. **Main receives tool call**: `McpServerManager.handlePostMessage()` extracts tool call info and stores a pending tool call
2. **Job is enqueued**: `webhook-helpers.ts` detects MCP Trigger in queue mode and adds MCP metadata to `runData`:
   * `isMcpExecution: true`
   * `mcpType: 'trigger'`
   * `mcpSessionId`, `mcpMessageId`
   * `mcpToolCall: { toolName, arguments, sourceNodeName }`
3. **Worker executes workflow**: `JobProcessor.processJob()` runs the workflow normally
4. **Worker invokes tool**: After workflow completion, if `mcpToolCall.sourceNodeName` is present, `invokeTool()` is called:
   * Creates a `SupplyDataContext` for the tool node
   * Calls `nodeType.supplyData()` to get the Tool instance
   * Invokes the tool with the provided arguments
5. **Result sent via job.progress()**: The tool result is broadcast as `McpResponseMessage`
6. **Main routes response**: `ScalingService.handleMcpResponse()` forwards to `McpServerManager.handleWorkerResponse()`
7. **Response delivered**: `handleWorkerResponse()` resolves the pending tool call and sends the response to the MCP client

### MCP Service Queue Mode

* `isQueueMode` detection and pending response tracking in `McpService`
* `execute_workflow` tool includes MCP metadata (`mcpType`, `mcpSessionId`, `mcpMessageId`)
* Worker responses handled via scaling service - uses `sendResponse` lifecycle hook

### Scaling Infrastructure

* `mcp-response` message type for worker-to-main communication (both Service and Trigger)
* MCP metadata added to job data for correlation
* Routing logic in `ScalingService.handleMcpResponse()` forwards to correct handler based on `mcpType`

### Multi-Main Support

* `mcp-relay` pub/sub channel for cross-main communication (SSE transport)
* StreamableHTTP transport recreation on alternate mains using Redis-validated sessionId
* SSE relay forwarding for tools/list requests

### Session Lifecycle & Cleanup

* Automatic cleanup on session close (pending responses, tool calls, resolve functions)
* Proper cleanup of `pendingToolCalls` on error/timeout to prevent memory leaks
* **2-minute timeout** protection prevents indefinite waiting
* Graceful shutdown cancels all pending executions

### Security: Session ID Validation

To prevent session injection attacks on the Streamable HTTP transport, MCP session IDs are validated against Redis before processing requests:

* When a new MCP session is created, its `sessionId` is stored in Redis
* Incoming Streamable HTTP requests are validated to ensure the `sessionId` exists in Redis before being processed or relayed
* This prevents malicious actors from injecting arbitrary session IDs to hijack or spoof MCP sessions
* Session IDs are automatically cleaned up from Redis when sessions are closed

## Changes

<!-- linear:table-colwidths:200,200 -->
| Component | Changes |
| -- | -- |
| `McpService` | Queue mode detection, pending response management |
| `McpServerManager` | Pending tool calls, worker response handling, session cleanup with proper `pendingToolCalls` cleanup on error/timeout, session ID Redis storage, transport recreation |
| `JobProcessor` | `invokeTool()` method for direct tool execution after workflow, MCP response broadcasting via `job.progress()` |
| `ScalingService` | MCP response routing via `handleMcpResponse()`, session validation callbacks |
| `webhook-helpers.ts` | MCP metadata extraction and `runData` enrichment for queue mode |
| `Publisher/Subscriber` | MCP relay channel for multi-main |
| `IWorkflowBase` | New MCP-related properties (`isMcpExecution`, `mcpType`, `mcpSessionId`, `mcpMessageId`, `mcpToolCall`) |

---

fixes: [AI-1090](https://linear.app/n8n/issue/AI-1090/use-lifecycle-hooks-to-support-queue-mode-in-mcp) and [AI-1829](https://linear.app/n8n/issue/AI-1829/tech-debt-make-mcp-server-trigger-queue-executions-instead-of-running)