### PR TITLE
fix: Update mime-types to fixed version 3.0.2

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/binary-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/binary-helper-functions.test.ts
@@ -669,6 +669,18 @@ describe('prepareBinaryData', () => {
 		);
 	});
 
+	it('correctly determines video mime type based on file name', async () => {
+		const result = await prepareBinaryData(buffer, executionId, workflowId, 'some-file.mp4');
+
+		expect(result.mimeType).toEqual('video/mp4');
+	});
+
+	it('correctly determines audio mime type based on file name', async () => {
+		const result = await prepareBinaryData(buffer, executionId, workflowId, 'some-file.mp3');
+
+		expect(result.mimeType).toEqual('audio/mpeg');
+	});
+
 	it('handles IncomingMessage with responseUrl', async () => {
 		const incomingMessage = bufferToIncomingMessage(buffer);
 		incomingMessage.responseUrl = 'http://example.com/file.txt';

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/request-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/request-helper-functions.test.ts
@@ -336,7 +336,7 @@ describe('Request Helper Functions', () => {
 
 			test('on regular requests', async () => {
 				const axiosOptions = await parseRequestObject(requestObject);
-				expect((axiosOptions.httpsAgent as HttpsAgent).options).toEqual({
+				expect((axiosOptions.httpsAgent as HttpsAgent).options).toMatchObject({
 					servername: 'example.de',
 					...agentOptions,
 					noDelay: true,
@@ -355,7 +355,7 @@ describe('Request Helper Functions', () => {
 				};
 				axiosOptions.beforeRedirect!(redirectOptions, mock());
 				expect(redirectOptions.agent).toEqual(redirectOptions.agents.https);
-				expect((redirectOptions.agent as HttpsAgent).options).toEqual({
+				expect((redirectOptions.agent as HttpsAgent).options).toMatchObject({
 					servername: 'example.de',
 					...agentOptions,
 					noDelay: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,8 +91,8 @@ catalogs:
       specifier: 3.4.4
       version: 3.4.4
     mime-types:
-      specifier: 3.0.1
-      version: 3.0.1
+      specifier: 3.0.2
+      version: 3.0.2
     mysql2:
       specifier: 3.15.0
       version: 3.15.0
@@ -1239,7 +1239,7 @@ importers:
         version: 1.11.0
       mime-types:
         specifier: 'catalog:'
-        version: 3.0.1
+        version: 3.0.2
       mongodb:
         specifier: ^6.17.0
         version: 6.21.0(@aws-sdk/credential-providers@3.808.0)(gcp-metadata@5.3.0)(socks@2.8.3)
@@ -1960,7 +1960,7 @@ importers:
         version: 3.4.4
       mime-types:
         specifier: 'catalog:'
-        version: 3.0.1
+        version: 3.0.2
       n8n-workflow:
         specifier: workspace:*
         version: link:../workflow
@@ -3031,7 +3031,7 @@ importers:
         version: 3.6.7
       mime-types:
         specifier: 'catalog:'
-        version: 3.0.1
+        version: 3.0.2
       minifaker:
         specifier: 1.34.1
         version: 1.34.1(patch_hash=bc707e2c34a2464da2c9c93ead33e80fd9883a00434ef64907ddc45208a08b33)
@@ -14154,6 +14154,10 @@ packages:
   mime-types@3.0.1:
     resolution: {integrity: sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mime@2.6.0:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
@@ -32369,6 +32373,10 @@ snapshots:
       mime-db: 1.52.0
 
   mime-types@3.0.1:
+    dependencies:
+      mime-db: 1.54.0
+
+  mime-types@3.0.2:
     dependencies:
       mime-db: 1.54.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,7 +38,7 @@ catalog:
   jsonwebtoken: 9.0.2
   lodash: 4.17.23
   luxon: 3.4.4
-  mime-types: 3.0.1
+  mime-types: 3.0.2
   mysql2: 3.15.0
   nanoid: 3.3.8
   nodemailer: 7.0.11


### PR DESCRIPTION
Backport of #23858

## Summary

Updates `mime-types` package to a fixed version [`3.0.2`](https://github.com/jshttp/mime-types/releases/tag/v3.0.2) (fix: https://github.com/jshttp/mime-types/pull/140)

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/NODE-4072/community-issue-incorrect-mime-type-when-reading-file-using-readwrite
- Fixes #22007


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. 
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
