### PR TITLE
perf(core): Optimize access for webhooks and workflows

### DIFF
--- a/packages/@n8n/db/src/repositories/shared-workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/shared-workflow.repository.ts
@@ -168,7 +168,7 @@ export class SharedWorkflowRepository extends Repository<SharedWorkflow> {
 			},
 			relations: {
 				workflow: {
-					shared: { project: { projectRelations: { user: true } } },
+					shared: { project: true },
 					tags: includeTags,
 					parentFolder: includeParentFolder,
 					activeVersion: includeActiveVersion ? { workflowPublishHistory: true } : false,

--- a/packages/cli/src/webhooks/live-webhooks.ts
+++ b/packages/cli/src/webhooks/live-webhooks.ts
@@ -98,7 +98,7 @@ export class LiveWebhooks implements IWebhookManager {
 			where: { id: webhook.workflowId },
 			relations: {
 				activeVersion: true,
-				shared: { project: true },
+				shared: true,
 			},
 		});
 
@@ -133,8 +133,9 @@ export class LiveWebhooks implements IWebhookManager {
 			settings: workflowData.settings,
 		});
 
-		const ownerProjectId = workflowData.shared.find((share) => share.role === 'workflow:owner')
-			?.project.id;
+		const ownerProjectId = workflowData.shared.find(
+			(share) => share.role === 'workflow:owner',
+		)?.projectId;
 		const additionalData = await WorkflowExecuteAdditionalData.getBase({
 			projectId: ownerProjectId,
 		});

--- a/packages/cli/src/webhooks/live-webhooks.ts
+++ b/packages/cli/src/webhooks/live-webhooks.ts
@@ -98,7 +98,7 @@ export class LiveWebhooks implements IWebhookManager {
 			where: { id: webhook.workflowId },
 			relations: {
 				activeVersion: true,
-				shared: { project: { projectRelations: true } },
+				shared: { project: true },
 			},
 		});
 


### PR DESCRIPTION
## Summary

Two query paths eagerly load `projectRelations` (and in one case `user`) through the `shared` relation, but no consumer ever reads those fields, so we can trim relation depth to:

- remove 1 unneeded JOIN from the webhook handling hot path, and 
- remove 2 unneeded JOINs from 27 callsites across workflow CRUD, workflow history, workflow statistics, MCP, ChatHub, Public API, and bootup.

`live-webhooks.ts` → The onlyaccess to `shared` after the query is `workflowData.shared.find((s) => s.role === 'workflow:owner')?.project.id`. Reads `role` and `project.id`. Later `workflowData` is spread into `activeWorkflowData` and passed to `WebhookHelpers.executeWebhook`, which does not access `shared`.

`findWorkflowWithOptions` → Called only by `findWorkflowForUser`
- 23 don't access `.shared` at all. They use the workflow for `null` checks, reading `.id`, `.activeVersionId`, `.settings`, `.nodes`, etc.
- 2 pass it to `addOwnerAndSharings` (`workflows.controller.ts:241, 378`) which delegates to `addOwnedByAndSharedWith`. That function iterates `shared[]` reading only `role` and `project.{id, type, name, icon}`. The `.shared` field is then deleted from the response before returning to the client.
- 1 reads `.shared[].role` and `.shared[].projectId` (`workflows.controller.ts:687`) to find editor project IDs.
- 1 reads `.shared[].role` and `.shared[].project` (`workflow.service.ee.ts:354`) to find the owner project during transfer. Accesses `project` directly, never `project.projectRelations`.
0 of these 27 call sites access `projectRelations` or `user`.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
n/a

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
