### PR TITLE
perf(core): Optimize credentials access

### DIFF
--- a/packages/@n8n/db/src/repositories/shared-credentials.repository.ts
+++ b/packages/@n8n/db/src/repositories/shared-credentials.repository.ts
@@ -100,7 +100,7 @@ export class SharedCredentialsRepository extends Repository<SharedCredentials> {
 			where,
 			relations: {
 				credentials: {
-					shared: { project: { projectRelations: { user: true } } },
+					shared: { project: true },
 				},
 			},
 		});

--- a/packages/cli/src/credentials/credentials-finder.service.ts
+++ b/packages/cli/src/credentials/credentials-finder.service.ts
@@ -42,7 +42,7 @@ export class CredentialsFinderService {
 	 */
 	async findGlobalCredentialById(
 		credentialId: string,
-		relations?: { shared: { project: { projectRelations: { user: boolean } } } },
+		relations?: { shared: { project: boolean } },
 	): Promise<CredentialsEntity | null> {
 		return await this.credentialsRepository.findOne({
 			where: {
@@ -148,7 +148,7 @@ export class CredentialsFinderService {
 			// TODO: write a small relations merger and use that one here
 			relations: {
 				credentials: {
-					shared: { project: { projectRelations: { user: true } } },
+					shared: { project: true },
 				},
 			},
 		});
@@ -160,7 +160,7 @@ export class CredentialsFinderService {
 		// Check for global credentials with read-only access
 		if (this.hasGlobalReadOnlyAccess(scopes)) {
 			return await this.findGlobalCredentialById(credentialsId, {
-				shared: { project: { projectRelations: { user: true } } },
+				shared: { project: true },
 			});
 		}
 

--- a/packages/cli/src/services/__tests__/credentials-finder.service.test.ts
+++ b/packages/cli/src/services/__tests__/credentials-finder.service.test.ts
@@ -82,7 +82,7 @@ describe('CredentialsFinderService', () => {
 				where: { credentialsId },
 				relations: {
 					credentials: {
-						shared: { project: { projectRelations: { user: true } } },
+						shared: { project: true },
 					},
 				},
 			});
@@ -120,7 +120,7 @@ describe('CredentialsFinderService', () => {
 				},
 				relations: {
 					credentials: {
-						shared: { project: { projectRelations: { user: true } } },
+						shared: { project: true },
 					},
 				},
 			});
@@ -153,7 +153,7 @@ describe('CredentialsFinderService', () => {
 				},
 				relations: {
 					credentials: {
-						shared: { project: { projectRelations: { user: true } } },
+						shared: { project: true },
 					},
 				},
 			});
@@ -163,7 +163,7 @@ describe('CredentialsFinderService', () => {
 					isGlobal: true,
 				},
 				relations: {
-					shared: { project: { projectRelations: { user: true } } },
+					shared: { project: true },
 				},
 			});
 			expect(credential).toEqual(null);
@@ -186,7 +186,7 @@ describe('CredentialsFinderService', () => {
 					isGlobal: true,
 				},
 				relations: {
-					shared: { project: { projectRelations: { user: true } } },
+					shared: { project: true },
 				},
 			});
 			expect(credential).toEqual(globalCredential);
@@ -248,7 +248,7 @@ describe('CredentialsFinderService', () => {
 				},
 				relations: {
 					credentials: {
-						shared: { project: { projectRelations: { user: true } } },
+						shared: { project: true },
 					},
 				},
 			});
@@ -966,7 +966,7 @@ describe('CredentialsFinderService', () => {
 		});
 
 		test('should find global credential by ID with relations', async () => {
-			const relations = { shared: { project: { projectRelations: { user: true } } } };
+			const relations = { shared: { project: true as const } };
 			credentialsRepository.findOne.mockResolvedValueOnce(mockGlobalCredential);
 
 			const result = await credentialsFinderService.findGlobalCredentialById(

--- a/packages/cli/src/workflows/workflow.service.ee.ts
+++ b/packages/cli/src/workflows/workflow.service.ee.ts
@@ -18,6 +18,7 @@ import {
 	WorkflowPublishHistoryRepository,
 } from '@n8n/db';
 import { Service } from '@n8n/di';
+import { hasGlobalScope } from '@n8n/permissions';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In, type EntityManager } from '@n8n/typeorm';
 import omit from 'lodash/omit';
@@ -599,18 +600,23 @@ export class EnterpriseWorkflowService {
 		projectId: string,
 	) {
 		await this.workflowRepository.manager.transaction(async (trx) => {
-			const allCredentials = await this.credentialsFinderService.findAllCredentialsForUser(
-				user,
-				['credential:share'],
-				trx,
-			);
+			let credentialIdsToShare: string[];
 
-			const credentialsToShare = allCredentials.filter((c) => credentialIds.includes(c.id));
+			if (hasGlobalScope(user, ['credential:share'], { mode: 'allOf' })) {
+				credentialIdsToShare = credentialIds;
+			} else {
+				const accessibleIds = await this.credentialsFinderService.getCredentialIdsByUserAndRole(
+					[user.id],
+					{ scopes: ['credential:share'] },
+					trx,
+				);
+				credentialIdsToShare = credentialIds.filter((id) => accessibleIds.includes(id));
+			}
 
-			for (const credential of credentialsToShare) {
+			for (const credentialId of credentialIdsToShare) {
 				await this.enterpriseCredentialsService.shareWithProjects(
 					user,
-					credential.id,
+					credentialId,
 					[projectId],
 					trx,
 				);

--- a/packages/cli/src/workflows/workflow.service.ee.ts
+++ b/packages/cli/src/workflows/workflow.service.ee.ts
@@ -605,12 +605,14 @@ export class EnterpriseWorkflowService {
 			if (hasGlobalScope(user, ['credential:share'], { mode: 'allOf' })) {
 				credentialIdsToShare = credentialIds;
 			} else {
-				const accessibleIds = await this.credentialsFinderService.getCredentialIdsByUserAndRole(
-					[user.id],
-					{ scopes: ['credential:share'] },
-					trx,
+				const accessibleIds = new Set(
+					await this.credentialsFinderService.getCredentialIdsByUserAndRole(
+						[user.id],
+						{ scopes: ['credential:share'] },
+						trx,
+					),
 				);
-				credentialIdsToShare = credentialIds.filter((id) => accessibleIds.includes(id));
+				credentialIdsToShare = credentialIds.filter((id) => accessibleIds.has(id));
 			}
 
 			for (const credentialId of credentialIdsToShare) {


### PR DESCRIPTION
## Summary

Found via `pg_stat_statements` on staging internal a 4s query where we eagerly load a deep relation chain: `credentials` → `shared_credentials` (self-join) → `project` → `project_relation` → `user`, with no WHERE clause

When transferring a workflow between projects, `cli` needs to re-share the workflow's credentials with the destination project. To figure out which credentials the user is allowed to share, it ran a query that loaded the entire sharing graph (every credential, every project it's shared with, every member of those projects). And for admin users, no WHERE clause.

It turns out `shareCredentialsWithProject` only needed to know which credential IDs the user was allowed to share. It fetched the full relationship tree, then threw everything away except the IDs. And the only downstream code that does consume the relationship tree like `addOwnedByAndSharedWith` only reads the project name + type + icon from each sharing, it never looks at project members or users, so two of the five JOINs were producing rows that nobody ever read.

<details>
<summary>Query</summary>


```sql
SELECT "SharedCredentials"."updatedAt" AS "SharedCredentials_updatedAt", "SharedCredentials"."createdAt" AS "SharedCredentials_createdAt", "SharedCredentials"."role" AS "SharedCredentials_role", "SharedCredentials"."credentialsId" AS "SharedCredentials_credentialsId", "SharedCredentials"."projectId" AS "SharedCredentials_projectId", "SharedCredentials__SharedCredentials_credentials"."updatedAt" AS "SharedCredentials__SharedCredentials_credentials_updatedAt", "SharedCredentials__SharedCredentials_credentials"."createdAt" AS "SharedCredentials__SharedCredentials_credentials_createdAt", "SharedCredentials__SharedCredentials_credentials"."id" AS "SharedCredentials__SharedCredentials_credentials_id", "SharedCredentials__SharedCredentials_credentials"."name" AS "SharedCredentials__SharedCredentials_credentials_name", "SharedCredentials__SharedCredentials_credentials"."data" AS "SharedCredentials__SharedCredentials_credentials_data", "SharedCredentials__SharedCredentials_credentials"."type" AS "SharedCredentials__SharedCredentials_credentials_type", "SharedCredentials__SharedCredentials_credentials"."isManaged" AS "SharedCredentials__SharedCredentials_credentials_isManaged", "SharedCredentials__SharedCredentials_credentials"."isGlobal" AS "SharedCredentials__SharedCredentials_credentials_isGlobal", "SharedCredentials__SharedCredentials_credentials"."isResolvable" AS "SharedCredentials__SharedCredentials_credentials_isResolvable", "SharedCredentials__SharedCredentials_credentials"."resolvableAllowFallback" AS "a62403a59580e7186cc53473ab018a2fd11ecaab", "SharedCredentials__SharedCredentials_credentials"."resolverId" AS "SharedCredentials__SharedCredentials_credentials_resolverId", "83d845fa0c63620f22c95ff1f2e06f6be2b6e72f"."updatedAt" AS "83d845fa0c63620f22c95ff1f2e06f6be2b6e72f_updatedAt", "83d845fa0c63620f22c95ff1f2e06f6be2b6e72f"."createdAt" AS "83d845fa0c63620f22c95ff1f2e06f6be2b6e72f_createdAt", "83d845fa0c63620f22c95ff1f2e06f6be2b6e72f"."role" AS "83d845fa0c63620f22c95ff1f2e06f6be2b6e72f_role", "83d845fa0c63620f22c95ff1f2e06f6be2b6e72f"."credentialsId" AS "83d845fa0c63620f22c95ff1f2e06f6be2b6e72f_credentialsId", "83d845fa0c63620f22c95ff1f2e06f6be2b6e72f"."projectId" AS "83d845fa0c63620f22c95ff1f2e06f6be2b6e72f_projectId", "b5855296e38ccfd02a0fa9788198e3a37c89b41f"."updatedAt" AS "b5855296e38ccfd02a0fa9788198e3a37c89b41f_updatedAt", "b5855296e38ccfd02a0fa9788198e3a37c89b41f"."createdAt" AS "b5855296e38ccfd02a0fa9788198e3a37c89b41f_createdAt", "b5855296e38ccfd02a0fa9788198e3a37c89b41f"."id" AS "b5855296e38ccfd02a0fa9788198e3a37c89b41f_id", "b5855296e38ccfd02a0fa9788198e3a37c89b41f"."name" AS "b5855296e38ccfd02a0fa9788198e3a37c89b41f_name", "b5855296e38ccfd02a0fa9788198e3a37c89b41f"."type" AS "b5855296e38ccfd02a0fa9788198e3a37c89b41f_type", "b5855296e38ccfd02a0fa9788198e3a37c89b41f"."icon" AS "b5855296e38ccfd02a0fa9788198e3a37c89b41f_icon", "b5855296e38ccfd02a0fa9788198e3a37c89b41f"."description" AS "b5855296e38ccfd02a0fa9788198e3a37c89b41f_description", "b5855296e38ccfd02a0fa9788198e3a37c89b41f"."creatorId" AS "b5855296e38ccfd02a0fa9788198e3a37c89b41f_creatorId", "83a3a393c02512b9673b27fecdffd7a88647f29e"."updatedAt" AS "83a3a393c02512b9673b27fecdffd7a88647f29e_updatedAt", "83a3a393c02512b9673b27fecdffd7a88647f29e"."createdAt" AS "83a3a393c02512b9673b27fecdffd7a88647f29e_createdAt", "83a3a393c02512b9673b27fecdffd7a88647f29e"."userId" AS "83a3a393c02512b9673b27fecdffd7a88647f29e_userId", "83a3a393c02512b9673b27fecdffd7a88647f29e"."projectId" AS "83a3a393c02512b9673b27fecdffd7a88647f29e_projectId", "83a3a393c02512b9673b27fecdffd7a88647f29e"."role" AS "83a3a393c02512b9673b27fecdffd7a88647f29e_role", "297ed33ce6aa1c102b65feb08971b56056aba252"."updatedAt" AS "297ed33ce6aa1c102b65feb08971b56056aba252_updatedAt", "297ed33ce6aa1c102b65feb08971b56056aba252"."createdAt" AS "297ed33ce6aa1c102b65feb08971b56056aba252_createdAt", "297ed33ce6aa1c102b65feb08971b56056aba252"."id" AS "297ed33ce6aa1c102b65feb08971b56056aba252_id", "297ed33ce6aa1c102b65feb08971b56056aba252"."email" AS "297ed33ce6aa1c102b65feb08971b56056aba252_email", "297ed33ce6aa1c102b65feb08971b56056aba252"."firstName" AS "297ed33ce6aa1c102b65feb08971b56056aba252_firstName", "297ed33ce6aa1c102b65feb08971b56056aba252"."lastName" AS "297ed33ce6aa1c102b65feb08971b56056aba252_lastName", "297ed33ce6aa1c102b65feb08971b56056aba252"."password" AS "297ed33ce6aa1c102b65feb08971b56056aba252_password", "297ed33ce6aa1c102b65feb08971b56056aba252"."personalizationAnswers" AS "297ed33ce6aa1c102b65feb08971b56056aba252_personalizationAnswers", "297ed33ce6aa1c102b65feb08971b56056aba252"."settings" AS "297ed33ce6aa1c102b65feb08971b56056aba252_settings", "297ed33ce6aa1c102b65feb08971b56056aba252"."disabled" AS "297ed33ce6aa1c102b65feb08971b56056aba252_disabled", "297ed33ce6aa1c102b65feb08971b56056aba252"."mfaEnabled" AS "297ed33ce6aa1c102b65feb08971b56056aba252_mfaEnabled", "297ed33ce6aa1c102b65feb08971b56056aba252"."mfaSecret" AS "297ed33ce6aa1c102b65feb08971b56056aba252_mfaSecret", "297ed33ce6aa1c102b65feb08971b56056aba252"."mfaRecoveryCodes" AS "297ed33ce6aa1c102b65feb08971b56056aba252_mfaRecoveryCodes", "297ed33ce6aa1c102b65feb08971b56056aba252"."lastActiveAt" AS "297ed33ce6aa1c102b65feb08971b56056aba252_lastActiveAt", "297ed33ce6aa1c102b65feb08971b56056aba252"."roleSlug" AS "297ed33ce6aa1c102b65feb08971b56056aba252_roleSlug" FROM "public"."shared_credentials" "SharedCredentials" LEFT JOIN "public"."credentials_entity" "SharedCredentials__SharedCredentials_credentials" ON "SharedCredentials__SharedCredentials_credentials"."id"="SharedCredentials"."credentialsId"  LEFT JOIN "public"."shared_credentials" "83d845fa0c63620f22c95ff1f2e06f6be2b6e72f" ON "83d845fa0c63620f22c95ff1f2e06f6be2b6e72f"."credentialsId"="SharedCredentials__SharedCredentials_credentials"."id"  LEFT JOIN "public"."project" "b5855296e38ccfd02a0fa9788198e3a37c89b41f" ON "b5855296e38ccfd02a0fa9788198e3a37c89b41f"."id"="83d845fa0c63620f22c95ff1f2e06f6be2b6e72f"."projectId"  LEFT JOIN "public"."project_relation" "83a3a393c02512b9673b27fecdffd7a88647f29e" ON "83a3a393c02512b9673b27fecdffd7a88647f29e"."projectId"="b5855296e38ccfd02a0fa9788198e3a37c89b41f"."id"  LEFT JOIN "public"."user" "297ed33ce6aa1c102b65feb08971b56056aba252" ON "297ed33ce6aa1c102b65feb08971b56056aba252"."id"="83a3a393c02512b9673b27fecdffd7a88647f29e"."userId"
```
</details>

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
