### PR TITLE
fix(lmChatOpenAi Node): Allow retry on 429 rate limit errors

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/error-classification.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/error-classification.test.ts
@@ -1,0 +1,246 @@
+import {
+	NON_RETRYABLE_STATUS_CODES,
+	NON_RETRYABLE_RATE_LIMIT_CODES,
+	getErrorStatus,
+	getErrorCode,
+	isCancellationError,
+	isConnectionAbortError,
+	isRetryableStatusCode,
+	isRetryableRateLimitCode,
+	classifyError,
+	isRetryableError,
+} from './error-classification';
+
+describe('error-classification', () => {
+	describe('NON_RETRYABLE_STATUS_CODES', () => {
+		it('should not include 429 (rate limit)', () => {
+			expect(NON_RETRYABLE_STATUS_CODES).not.toContain(429);
+		});
+
+		it('should include common client errors', () => {
+			expect(NON_RETRYABLE_STATUS_CODES).toContain(400);
+			expect(NON_RETRYABLE_STATUS_CODES).toContain(401);
+			expect(NON_RETRYABLE_STATUS_CODES).toContain(403);
+			expect(NON_RETRYABLE_STATUS_CODES).toContain(404);
+		});
+	});
+
+	describe('NON_RETRYABLE_RATE_LIMIT_CODES', () => {
+		it('should include insufficient_quota', () => {
+			expect(NON_RETRYABLE_RATE_LIMIT_CODES).toContain('insufficient_quota');
+		});
+
+		it('should not include rate_limit_exceeded', () => {
+			expect(NON_RETRYABLE_RATE_LIMIT_CODES).not.toContain('rate_limit_exceeded');
+		});
+	});
+
+	describe('getErrorStatus', () => {
+		it('should extract status from error.status', () => {
+			expect(getErrorStatus({ status: 429 })).toBe(429);
+		});
+
+		it('should extract status from error.response.status', () => {
+			expect(getErrorStatus({ response: { status: 500 } })).toBe(500);
+		});
+
+		it('should prefer error.response.status over error.status', () => {
+			expect(getErrorStatus({ status: 400, response: { status: 500 } })).toBe(500);
+		});
+
+		it('should return undefined for non-object errors', () => {
+			expect(getErrorStatus(null)).toBeUndefined();
+			expect(getErrorStatus(undefined)).toBeUndefined();
+			expect(getErrorStatus('string error')).toBeUndefined();
+			expect(getErrorStatus(123)).toBeUndefined();
+		});
+
+		it('should return undefined when no status is present', () => {
+			expect(getErrorStatus({})).toBeUndefined();
+			expect(getErrorStatus({ message: 'error' })).toBeUndefined();
+		});
+	});
+
+	describe('getErrorCode', () => {
+		it('should extract code from error.code', () => {
+			expect(getErrorCode({ code: 'insufficient_quota' })).toBe('insufficient_quota');
+		});
+
+		it('should return undefined for non-object errors', () => {
+			expect(getErrorCode(null)).toBeUndefined();
+			expect(getErrorCode(undefined)).toBeUndefined();
+		});
+
+		it('should return undefined when no code is present', () => {
+			expect(getErrorCode({})).toBeUndefined();
+		});
+	});
+
+	describe('isCancellationError', () => {
+		it('should detect AbortError by name', () => {
+			const error = new Error('Aborted');
+			error.name = 'AbortError';
+			expect(isCancellationError(error)).toBe(true);
+		});
+
+		it('should detect Cancel message prefix', () => {
+			expect(isCancellationError({ message: 'Cancel: user requested' })).toBe(true);
+		});
+
+		it('should detect AbortError message prefix', () => {
+			expect(isCancellationError({ message: 'AbortError: signal was aborted' })).toBe(true);
+		});
+
+		it('should return false for regular errors', () => {
+			expect(isCancellationError(new Error('Network error'))).toBe(false);
+			expect(isCancellationError({ message: 'Something failed' })).toBe(false);
+		});
+
+		it('should return false for non-object errors', () => {
+			expect(isCancellationError(null)).toBe(false);
+			expect(isCancellationError(undefined)).toBe(false);
+		});
+	});
+
+	describe('isConnectionAbortError', () => {
+		it('should detect ECONNABORTED', () => {
+			expect(isConnectionAbortError({ code: 'ECONNABORTED' })).toBe(true);
+		});
+
+		it('should return false for other codes', () => {
+			expect(isConnectionAbortError({ code: 'ECONNRESET' })).toBe(false);
+			expect(isConnectionAbortError({ code: 'ETIMEDOUT' })).toBe(false);
+		});
+
+		it('should return false for non-object errors', () => {
+			expect(isConnectionAbortError(null)).toBe(false);
+		});
+	});
+
+	describe('isRetryableStatusCode', () => {
+		it('should return false for 400 Bad Request', () => {
+			expect(isRetryableStatusCode(400)).toBe(false);
+		});
+
+		it('should return false for 401 Unauthorized', () => {
+			expect(isRetryableStatusCode(401)).toBe(false);
+		});
+
+		it('should return false for 403 Forbidden', () => {
+			expect(isRetryableStatusCode(403)).toBe(false);
+		});
+
+		it('should return false for 404 Not Found', () => {
+			expect(isRetryableStatusCode(404)).toBe(false);
+		});
+
+		it('should return true for 429 Too Many Requests (rate limit)', () => {
+			expect(isRetryableStatusCode(429)).toBe(true);
+		});
+
+		it('should return true for 500 Internal Server Error', () => {
+			expect(isRetryableStatusCode(500)).toBe(true);
+		});
+
+		it('should return true for 502 Bad Gateway', () => {
+			expect(isRetryableStatusCode(502)).toBe(true);
+		});
+
+		it('should return true for 503 Service Unavailable', () => {
+			expect(isRetryableStatusCode(503)).toBe(true);
+		});
+
+		it('should return true for undefined status', () => {
+			expect(isRetryableStatusCode(undefined)).toBe(true);
+		});
+	});
+
+	describe('isRetryableRateLimitCode', () => {
+		it('should return false for insufficient_quota', () => {
+			expect(isRetryableRateLimitCode('insufficient_quota')).toBe(false);
+		});
+
+		it('should return true for rate_limit_exceeded', () => {
+			expect(isRetryableRateLimitCode('rate_limit_exceeded')).toBe(true);
+		});
+
+		it('should return true for unknown codes', () => {
+			expect(isRetryableRateLimitCode('unknown_code')).toBe(true);
+		});
+
+		it('should return true for undefined', () => {
+			expect(isRetryableRateLimitCode(undefined)).toBe(true);
+		});
+	});
+
+	describe('classifyError', () => {
+		it('should classify cancellation errors as non-retryable', () => {
+			const error = new Error('Cancel');
+			error.name = 'AbortError';
+
+			const result = classifyError(error);
+
+			expect(result.retryable).toBe(false);
+			expect(result.reason).toBe('Request was cancelled');
+		});
+
+		it('should classify ECONNABORTED as non-retryable', () => {
+			const result = classifyError({ code: 'ECONNABORTED' });
+
+			expect(result.retryable).toBe(false);
+			expect(result.reason).toBe('Connection was aborted');
+		});
+
+		it('should classify 401 errors as non-retryable', () => {
+			const result = classifyError({ status: 401 });
+
+			expect(result.retryable).toBe(false);
+			expect(result.reason).toBe('HTTP 401 is not retryable');
+		});
+
+		it('should classify 429 errors as retryable', () => {
+			const result = classifyError({ status: 429 });
+
+			expect(result.retryable).toBe(true);
+		});
+
+		it('should classify insufficient_quota as non-retryable', () => {
+			const result = classifyError({ status: 429, code: 'insufficient_quota' });
+
+			expect(result.retryable).toBe(false);
+			expect(result.reason).toBe("Error code 'insufficient_quota' is not retryable");
+		});
+
+		it('should classify rate_limit_exceeded as retryable', () => {
+			const result = classifyError({ status: 429, code: 'rate_limit_exceeded' });
+
+			expect(result.retryable).toBe(true);
+		});
+
+		it('should classify 500 errors as retryable', () => {
+			const result = classifyError({ status: 500 });
+
+			expect(result.retryable).toBe(true);
+		});
+
+		it('should classify errors without status as retryable', () => {
+			const result = classifyError(new Error('Unknown error'));
+
+			expect(result.retryable).toBe(true);
+		});
+	});
+
+	describe('isRetryableError', () => {
+		it('should return true for retryable errors', () => {
+			expect(isRetryableError({ status: 429 })).toBe(true);
+			expect(isRetryableError({ status: 500 })).toBe(true);
+			expect(isRetryableError({ status: 429, code: 'rate_limit_exceeded' })).toBe(true);
+		});
+
+		it('should return false for non-retryable errors', () => {
+			expect(isRetryableError({ status: 401 })).toBe(false);
+			expect(isRetryableError({ status: 403 })).toBe(false);
+			expect(isRetryableError({ code: 'insufficient_quota' })).toBe(false);
+		});
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/llms/error-classification.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/error-classification.ts
@@ -1,0 +1,201 @@
+/**
+ * Error classification utilities for LLM retry logic.
+ *
+ * This module provides centralized logic for determining whether errors
+ * should be retried or should fail immediately.
+ */
+
+/**
+ * HTTP status codes that should NOT be retried.
+ * These are typically client errors that won't resolve with retries.
+ */
+export const NON_RETRYABLE_STATUS_CODES = [
+	400, // Bad Request
+	401, // Unauthorized
+	402, // Payment Required
+	403, // Forbidden
+	404, // Not Found
+	405, // Method Not Allowed
+	406, // Not Acceptable
+	407, // Proxy Authentication Required
+	409, // Conflict
+] as const;
+
+/**
+ * Error codes that indicate non-retryable rate limit conditions.
+ * These are typically billing/quota issues that won't resolve with retries.
+ */
+export const NON_RETRYABLE_RATE_LIMIT_CODES = [
+	'insufficient_quota', // Billing/quota exhausted - requires payment
+] as const;
+
+/**
+ * Error names/messages that indicate the request was intentionally cancelled.
+ * These should not be retried as they represent user/system intent.
+ */
+const CANCELLATION_INDICATORS = ['Cancel', 'AbortError'] as const;
+
+export interface ErrorWithStatus {
+	status?: number;
+	response?: { status?: number };
+}
+
+export interface ErrorWithCode {
+	code?: string;
+}
+
+export interface ErrorWithMessage {
+	message?: string;
+	name?: string;
+}
+
+/**
+ * Extracts the HTTP status code from an error object.
+ * Handles various error shapes from different HTTP libraries.
+ */
+export function getErrorStatus(error: unknown): number | undefined {
+	if (typeof error !== 'object' || error === null) {
+		return undefined;
+	}
+
+	const errorWithStatus = error as ErrorWithStatus;
+	return errorWithStatus.response?.status ?? errorWithStatus.status;
+}
+
+/**
+ * Extracts the error code from an error object (e.g., OpenAI error codes).
+ */
+export function getErrorCode(error: unknown): string | undefined {
+	if (typeof error !== 'object' || error === null) {
+		return undefined;
+	}
+
+	return (error as ErrorWithCode).code;
+}
+
+/**
+ * Checks if an error represents a cancelled/aborted request.
+ * These should not be retried as they represent intentional cancellation.
+ */
+export function isCancellationError(error: unknown): boolean {
+	if (typeof error !== 'object' || error === null) {
+		return false;
+	}
+
+	const errorWithMessage = error as ErrorWithMessage;
+
+	// Check error name
+	if (errorWithMessage.name === 'AbortError') {
+		return true;
+	}
+
+	// Check error message prefix
+	if (typeof errorWithMessage.message === 'string') {
+		return CANCELLATION_INDICATORS.some((indicator) =>
+			errorWithMessage.message?.startsWith(indicator),
+		);
+	}
+
+	return false;
+}
+
+/**
+ * Checks if an error represents a connection abort.
+ */
+export function isConnectionAbortError(error: unknown): boolean {
+	if (typeof error !== 'object' || error === null) {
+		return false;
+	}
+
+	return (error as ErrorWithCode).code === 'ECONNABORTED';
+}
+
+/**
+ * Checks if an HTTP status code is retryable.
+ * Returns true for server errors (5xx) and rate limits (429).
+ * Returns false for client errors that won't resolve with retries.
+ */
+export function isRetryableStatusCode(status: number | undefined): boolean {
+	if (status === undefined) {
+		return true; // Unknown status - allow retry
+	}
+
+	// Non-retryable status codes (client errors that won't fix themselves)
+	if (NON_RETRYABLE_STATUS_CODES.includes(status as (typeof NON_RETRYABLE_STATUS_CODES)[number])) {
+		return false;
+	}
+
+	// 429 (Too Many Requests) IS retryable - it's a temporary condition
+	// 5xx errors are retryable - server issues may resolve
+	return true;
+}
+
+/**
+ * Checks if a rate limit error code is retryable.
+ * Some rate limit errors (like quota exhaustion) are not retryable.
+ */
+export function isRetryableRateLimitCode(code: string | undefined): boolean {
+	if (!code) {
+		return true; // Unknown code - allow retry
+	}
+
+	return !NON_RETRYABLE_RATE_LIMIT_CODES.includes(
+		code as (typeof NON_RETRYABLE_RATE_LIMIT_CODES)[number],
+	);
+}
+
+export interface RetryClassification {
+	retryable: boolean;
+	reason?: string;
+}
+
+/**
+ * Classifies an error to determine if it should be retried.
+ *
+ * @param error - The error to classify
+ * @returns Classification result with retryable flag and optional reason
+ *
+ * @example
+ * ```typescript
+ * const result = classifyError(error);
+ * if (!result.retryable) {
+ *   throw new Error(`Non-retryable error: ${result.reason}`);
+ * }
+ * // Allow retry...
+ * ```
+ */
+export function classifyError(error: unknown): RetryClassification {
+	// Cancellation errors should not be retried
+	if (isCancellationError(error)) {
+		return { retryable: false, reason: 'Request was cancelled' };
+	}
+
+	// Connection abort errors should not be retried
+	if (isConnectionAbortError(error)) {
+		return { retryable: false, reason: 'Connection was aborted' };
+	}
+
+	// Check HTTP status code
+	const status = getErrorStatus(error);
+	if (!isRetryableStatusCode(status)) {
+		return { retryable: false, reason: `HTTP ${status} is not retryable` };
+	}
+
+	// Check error code (for rate limit classification)
+	const code = getErrorCode(error);
+	if (!isRetryableRateLimitCode(code)) {
+		return { retryable: false, reason: `Error code '${code}' is not retryable` };
+	}
+
+	return { retryable: true };
+}
+
+/**
+ * Simple helper to check if an error is retryable.
+ *
+ * @param error - The error to check
+ * @returns true if the error should be retried, false otherwise
+ */
+export function isRetryableError(error: unknown): boolean {
+	return classifyError(error).retryable;
+}

--- a/packages/@n8n/nodes-langchain/nodes/llms/n8nDefaultFailedAttemptHandler.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/n8nDefaultFailedAttemptHandler.test.ts
@@ -59,6 +59,12 @@ describe('n8nDefaultFailedAttemptHandler', () => {
 		expect(() => n8nDefaultFailedAttemptHandler(error)).not.toThrow();
 	});
 
+	it('should not throw error for 429 rate limit (should be retried)', () => {
+		const error = new MockHttpError('Rate limited', 429);
+
+		expect(() => n8nDefaultFailedAttemptHandler(error)).not.toThrow();
+	});
+
 	it('should not throw error if no conditions are met', () => {
 		const error = new Error('Some random error');
 		expect(() => n8nDefaultFailedAttemptHandler(error)).not.toThrow();

--- a/packages/@n8n/nodes-langchain/nodes/llms/n8nDefaultFailedAttemptHandler.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/n8nDefaultFailedAttemptHandler.ts
@@ -1,41 +1,23 @@
-const STATUS_NO_RETRY = [
-	400, // Bad Request
-	401, // Unauthorized
-	402, // Payment Required
-	403, // Forbidden
-	404, // Not Found
-	405, // Method Not Allowed
-	406, // Not Acceptable
-	407, // Proxy Authentication Required
-	409, // Conflict
-];
+import { classifyError } from './error-classification';
 
 /**
  * This function is used as a default handler for failed attempts in all LLMs.
  * It is based on a default handler from the langchain core package.
  * It throws an error when it encounters a known error that should not be retried.
- * @param error
+ *
+ * Uses centralized error classification logic from error-classification.ts
+ * to determine retryability based on:
+ * - HTTP status codes (4xx client errors are not retried, except 429)
+ * - Cancellation/abort signals
+ * - Connection errors
+ *
+ * @param error - The error from a failed LLM request
+ * @throws The original error if it should not be retried
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const n8nDefaultFailedAttemptHandler = (error: any) => {
-	if (
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
-		error?.message?.startsWith?.('Cancel') ||
-		error?.message?.startsWith?.('AbortError') ||
-		error?.name === 'AbortError'
-	) {
-		throw error;
-	}
+export const n8nDefaultFailedAttemptHandler = (error: unknown) => {
+	const classification = classifyError(error);
 
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-	if (error?.code === 'ECONNABORTED') {
-		throw error;
-	}
-
-	const status =
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-		error?.response?.status ?? error?.status;
-	if (status && STATUS_NO_RETRY.includes(+status)) {
+	if (!classification.retryable) {
 		throw error;
 	}
 };

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/error-handling.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/error-handling.ts
@@ -2,17 +2,22 @@ import { OperationalError } from 'n8n-workflow';
 import { RateLimitError } from 'openai';
 import { OpenAIError } from 'openai/error';
 
-const errorMap: Record<string, string> = {
+import { isRetryableRateLimitCode } from '../../../llms/error-classification';
+
+/**
+ * Custom error messages for specific OpenAI error codes.
+ * Only includes non-retryable errors that need special messaging.
+ */
+const errorMessages: Record<string, string> = {
 	insufficient_quota:
 		'Insufficient quota detected. <a href="https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/common-issues/#insufficient-quota" target="_blank">Learn more</a> about resolving this issue',
-	rate_limit_exceeded: 'OpenAI: Rate limit reached',
 };
 
 export function getCustomErrorMessage(errorCode: string): string | undefined {
-	return errorMap[errorCode];
+	return errorMessages[errorCode];
 }
 
-export function isOpenAiError(error: any): error is OpenAIError {
+export function isOpenAiError(error: unknown): error is OpenAIError {
 	return error instanceof OpenAIError;
 }
 
@@ -33,7 +38,24 @@ function isNonChatModelError(error: unknown): boolean {
 	);
 }
 
+/**
+ * OpenAI-specific failed attempt handler.
+ *
+ * This handler processes OpenAI errors and determines if they should
+ * prevent retries. It works in conjunction with the centralized
+ * error classification logic.
+ *
+ * Behavior:
+ * - Non-chat model errors: Throws with helpful message (non-retryable)
+ * - Rate limit with quota issues: Throws with custom message (non-retryable)
+ * - Rate limit (temporary): Returns without throwing (allows retry)
+ * - Other errors: Returns without throwing (default handling applies)
+ *
+ * @param error - The error from a failed OpenAI request
+ * @throws OperationalError for non-retryable OpenAI-specific errors
+ */
 export const openAiFailedAttemptHandler = (error: unknown) => {
+	// Handle non-chat model errors with a helpful message
 	if (isNonChatModelError(error)) {
 		throw new OperationalError(
 			'This model requires the Responses API. Enable "Use Responses API" in the OpenAI Chat Model node options to use this model.',
@@ -41,12 +63,21 @@ export const openAiFailedAttemptHandler = (error: unknown) => {
 		);
 	}
 
+	// Handle OpenAI rate limit errors
 	if (error instanceof RateLimitError) {
-		// If the error is a rate limit error, we want to handle it differently
-		// because OpenAI has multiple different rate limit errors
-		const errorCode = error?.code;
-		const errorMessage =
-			getCustomErrorMessage(errorCode ?? 'rate_limit_exceeded') ?? errorMap.rate_limit_exceeded;
-		throw new OperationalError(errorMessage, { cause: error });
+		const errorCode = error.code ?? undefined;
+
+		// Only throw for non-retryable rate limit codes (e.g., quota exhausted)
+		// Temporary rate limits (429) should be retried
+		if (!isRetryableRateLimitCode(errorCode)) {
+			const errorMessage = getCustomErrorMessage(errorCode!);
+			throw new OperationalError(errorMessage ?? 'OpenAI rate limit error', { cause: error });
+		}
+
+		// For retryable rate limits, return without throwing to allow retry
+		return;
 	}
+
+	// For other errors, return without throwing
+	// The default handler will apply standard retry classification
 };


### PR DESCRIPTION
## Summary

The OpenAI Chat Model node now correctly retries on 429 rate limit errors 
when "Retry on fail" is enabled.

## Related Linear tickets, Github issues, and Community forum posts

Issue: https://github.com/n8n-io/n8n/issues/25136
fixes #25136 


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
