### PR TITLE
feat: Update log streaming to unwrap nested proxy

### DIFF
--- a/packages/cli/src/modules/log-streaming.ee/destinations/message-event-bus-destination-webhook.ee.ts
+++ b/packages/cli/src/modules/log-streaming.ee/destinations/message-event-bus-destination-webhook.ee.ts
@@ -130,7 +130,8 @@ export class MessageEventBusDestinationWebhook
 
 		// Unwrap nested proxy: fixedCollection in logStreaming.constants uses name 'proxy' for both
 		// the collection and its single option, producing options.proxy = { proxy: { protocol, host, port } }.
-		// Axios expects proxy to be { protocol, host, port } or false.
+		// Axios expects proxy to be { protocol, host, port }. Only set when explicitly configured;
+		// leaving proxy undefined allows axios to use HTTP_PROXY/HTTPS_PROXY from the environment.
 		let proxy = axiosParameters.options?.proxy;
 		if (
 			proxy &&
@@ -140,7 +141,9 @@ export class MessageEventBusDestinationWebhook
 		) {
 			proxy = (proxy as { proxy: typeof proxy }).proxy;
 		}
-		axiosSetting.proxy = proxy ?? false;
+		if (proxy) {
+			axiosSetting.proxy = proxy;
+		}
 
 		axiosSetting.timeout =
 			axiosParameters.options?.timeout ?? LOGSTREAMING_DEFAULT_SOCKET_TIMEOUT_MS;

--- a/packages/cli/src/modules/log-streaming.ee/destinations/message-event-bus-destination-webhook.ee.ts
+++ b/packages/cli/src/modules/log-streaming.ee/destinations/message-event-bus-destination-webhook.ee.ts
@@ -128,7 +128,19 @@ export class MessageEventBusDestinationWebhook
 			axiosSetting.maxRedirects = axiosParameters.options.redirect?.maxRedirects;
 		}
 
-		axiosSetting.proxy = axiosParameters.options?.proxy;
+		// Unwrap nested proxy: fixedCollection in logStreaming.constants uses name 'proxy' for both
+		// the collection and its single option, producing options.proxy = { proxy: { protocol, host, port } }.
+		// Axios expects proxy to be { protocol, host, port } or false.
+		let proxy = axiosParameters.options?.proxy;
+		if (
+			proxy &&
+			typeof proxy === 'object' &&
+			'proxy' in proxy &&
+			typeof (proxy as { proxy?: unknown }).proxy === 'object'
+		) {
+			proxy = (proxy as { proxy: typeof proxy }).proxy;
+		}
+		axiosSetting.proxy = proxy ?? false;
 
 		axiosSetting.timeout =
 			axiosParameters.options?.timeout ?? LOGSTREAMING_DEFAULT_SOCKET_TIMEOUT_MS;


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR fixes the issue where proxy configurations were nested when passed to log streaming, causing issues. Now, we check and unwrap any nested proxy configurations.

## Related Linear tickets, Github issues, and Community forum posts

IAM-61

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
