### PR TITLE
perf(core): Remove more JOINs from workflow queries

### DIFF
--- a/packages/@n8n/db/src/repositories/workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow.repository.ts
@@ -74,7 +74,6 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 		const result = await this.find({
 			select: { id: true },
 			where: { activeVersionId: Not(IsNull()) },
-			relations: { shared: { project: { projectRelations: true } } },
 		});
 
 		return result.map(({ id }) => id);
@@ -114,7 +113,7 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 	async findById(workflowId: string) {
 		return await this.findOne({
 			where: { id: workflowId },
-			relations: { shared: { project: { projectRelations: true } }, activeVersion: true },
+			relations: { shared: { project: true }, activeVersion: true },
 		});
 	}
 

--- a/packages/cli/src/workflows/workflow-finder.service.ts
+++ b/packages/cli/src/workflows/workflow-finder.service.ts
@@ -107,7 +107,7 @@ export class WorkflowFinderService {
 			where,
 			relations: {
 				workflow: {
-					shared: { project: { projectRelations: { user: true } } },
+					shared: { project: true },
 				},
 			},
 		});


### PR DESCRIPTION
## Summary

The single callsite for `getAllActiveIds()` only uses the returned string[] of IDs. The relatiosn were loaded and immediately discarded.

`findById()` has 3 callers, none access `projectRelations`:
  - `activeWorkflowManager.ts:506` — reads `activeVersion`, `id`, `name`, `staticData`, `settings`
  - `testRunnerService.ee.ts:500` — existence check only
  - `execute-workflow.tool.ts:`212 — existence check only

`findAllWorkflowsForUser()` has 3 callers, none access `projectRelations` or `user`:
  - `workflows.handler.ts:198` (public API) — reads workflow.projectId and workflow.id only
  - `workflows.handler.ts:218` (public API) — reads workflow.id and workflow.projectId only
  - `workflow.service.ee.ts:427` passes result to `addOwnedByAndSharedWith()`, which only reads `project.id`, `project.type`, `project.name`, `project.icon`, no access to `projectRelations`

## Related Linear tickets, Github issues, and Community forum posts

n/a

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
