### PR TITLE
feat: Selectively skip auth only for dynamic creds

### DIFF
--- a/packages/cli/src/oauth/__tests__/oauth.service.test.ts
+++ b/packages/cli/src/oauth/__tests__/oauth.service.test.ts
@@ -386,6 +386,11 @@ describe('OauthService', () => {
 	});
 
 	describe('decodeCsrfState', () => {
+		// Auth logic: dynamic credentials (origin === 'dynamic-credential') always skip user validation.
+		// Static credentials: skip user validation only when N8N_SKIP_AUTH_ON_OAUTH_CALLBACK is true
+		// (e.g. embed/iframe); otherwise req.user.id must match decryptedState.userId (BOLA prevention).
+		// skipAuthOnOAuthCallback is read at module load, so the "skip for static" path is not tested here.
+
 		it('should decode valid CSRF state', () => {
 			const csrfData = {
 				cid: 'credential-id',
@@ -505,7 +510,7 @@ describe('OauthService', () => {
 			expect(() => (service as any).decodeCsrfState(encodedState, req)).toThrow(AuthError);
 		});
 
-		it('should bypass user validation for dynamic-credential origin', () => {
+		it('should bypass user validation for dynamic-credential origin (no userId check)', () => {
 			const csrfData = {
 				cid: 'credential-id',
 				userId: 'different-user-id',

--- a/packages/cli/src/oauth/oauth.service.ts
+++ b/packages/cli/src/oauth/oauth.service.ts
@@ -214,7 +214,7 @@ export class OauthService {
 			throw new UnexpectedError(errorMessage);
 		}
 
-		// user validation not required for dynamic credentials
+		// Dynamic credentials: skip user validation (e.g. embed/iframe flows) as they do not contain an n8n user
 		if (decryptedState.origin === 'dynamic-credential') {
 			return {
 				...decoded,
@@ -222,8 +222,15 @@ export class OauthService {
 			};
 		}
 
-		// if we skip auth on oauth callback, we cannot validate user id
-		if (!skipAuthOnOAuthCallback && decryptedState.userId !== req.user?.id) {
+		// Static credentials: skip user validation only when N8N_SKIP_AUTH_ON_OAUTH_CALLBACK is true (e.g. embed/iframe)
+		if (skipAuthOnOAuthCallback) {
+			return {
+				...decoded,
+				...decryptedState,
+			};
+		}
+
+		if (req.user?.id === undefined || decryptedState.userId !== req.user.id) {
 			throw new AuthError('Unauthorized');
 		}
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR fixes a loophole where static credentials would have their oauth callback checks disabled inadvertently for dynamic credentials. We now always skip auth checks for dynamic (as they have no user to check against) and allow the previous feature flag to work only for static credentials as expected

## Related Linear tickets, Github issues, and Community forum posts

IAM-214

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
