### PR TITLE
fix(editor): Sidebar labels are not visible

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useSidebarLayout.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useSidebarLayout.test.ts
@@ -4,7 +4,7 @@ import { useSidebarLayout } from './useSidebarLayout';
 
 // Mock UI Store
 const mockUIStore = {
-	sidebarMenuCollapsed: false,
+	sidebarMenuCollapsed: false as boolean | null,
 	toggleSidebarMenuCollapse: vi.fn(),
 };
 
@@ -44,6 +44,15 @@ describe('useSidebarLayout', () => {
 			const { sidebarWidth } = useSidebarLayout();
 
 			expect(sidebarWidth.value).toBe(42);
+		});
+
+		it('should default to expanded (not collapsed) when sidebarMenuCollapsed is null', () => {
+			mockUIStore.sidebarMenuCollapsed = null;
+
+			const { isCollapsed, sidebarWidth } = useSidebarLayout();
+
+			expect(isCollapsed.value).toBe(false);
+			expect(sidebarWidth.value).toBe(300);
 		});
 
 		it('should return computed isCollapsed from store', () => {

--- a/packages/frontend/editor-ui/src/app/composables/useSidebarLayout.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useSidebarLayout.ts
@@ -5,7 +5,7 @@ import { LOCAL_STORAGE_SIDEBAR_WIDTH } from '../constants';
 
 export function useSidebarLayout() {
 	const uiStore = useUIStore();
-	const isCollapsed = computed(() => uiStore.sidebarMenuCollapsed ?? true);
+	const isCollapsed = computed(() => uiStore.sidebarMenuCollapsed ?? false);
 	const sidebarWidth = useLocalStorage(LOCAL_STORAGE_SIDEBAR_WIDTH, isCollapsed.value ? 42 : 300);
 
 	const toggleCollapse = () => {

--- a/packages/frontend/editor-ui/src/app/stores/ui.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/ui.store.ts
@@ -265,7 +265,12 @@ export const useUIStore = defineStore(STORES.UI, () => {
 	});
 
 	const modalStack = ref<string[]>([]);
-	const sidebarMenuCollapsed = useLocalStorage<boolean | null>('sidebar.collapsed', null);
+	const sidebarMenuCollapsed = useLocalStorage<boolean | null>('sidebar.collapsed', null, {
+		serializer: {
+			read: (v) => (v === 'null' ? null : v === 'true'),
+			write: (v) => String(v),
+		},
+	});
 	const currentView = ref<string>('');
 	const stateIsDirty = ref<boolean>(false);
 	const dirtyStateSetCount = ref<number>(0);


### PR DESCRIPTION
## Summary                                              
                                                       
  Fixes a bug where sidebar menu labels (Home,         
  Personal, Shared, etc.) disappeared after refreshing 
  the page, showing only icons.                        
                                                       
  ### Root Cause:                                          
  In commit 83bf5e16ec (#25096), the sidebar collapse  
  state was changed to default to true (collapsed) when
   the value is null:                                  
                                                       
  // Before:                                           
  const isCollapsed = computed(() =>                   
  uiStore.sidebarMenuCollapsed);                       
                                                       
  // After (buggy):                                    
  const isCollapsed = computed(() =>                   
  uiStore.sidebarMenuCollapsed ?? true);               
                                                       
  When the page loads, sidebarMenuCollapsed is         
  initially null before the SIDEBAR_EXPANDED_EXPERIMENT
   logic runs. This caused the sidebar to render in    
  collapsed mode (icons only, no labels) before the    
  experiment could determine the user's variant.       
                                                       
  ### The Fix:                                             
  Changed the default from true to false, so the       
  sidebar defaults to expanded mode (showing labels)   
  when the state is null:                              
                                                       
  const isCollapsed = computed(() =>                   
  uiStore.sidebarMenuCollapsed ?? false);              
                                                       
  This ensures labels are visible by default, providing
   a better initial experience while the A/B experiment
   determines the final state.                         
                                     

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
