### PR TITLE
chore(ai-builder): Add CSV output for evaluation results

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/evaluation-helpers.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/evaluation-helpers.test.ts
@@ -4,7 +4,7 @@
 
 import pLimit from 'p-limit';
 
-import { withTimeout } from '../harness/evaluation-helpers';
+import { withTimeout, extractSubgraphMetrics } from '../harness/evaluation-helpers';
 
 describe('evaluation-helpers', () => {
 	describe('withTimeout()', () => {
@@ -40,6 +40,114 @@ describe('evaluation-helpers', () => {
 
 			await p1;
 			jest.useRealTimers();
+		});
+	});
+
+	describe('extractSubgraphMetrics()', () => {
+		it('should return empty object when both inputs are undefined', () => {
+			const result = extractSubgraphMetrics(undefined, undefined);
+			expect(result).toEqual({});
+		});
+
+		it('should include nodeCount when provided', () => {
+			const result = extractSubgraphMetrics(undefined, 5);
+			expect(result).toEqual({ nodeCount: 5 });
+		});
+
+		it('should include nodeCount of 0', () => {
+			const result = extractSubgraphMetrics(undefined, 0);
+			expect(result).toEqual({ nodeCount: 0 });
+		});
+
+		it('should calculate discovery duration from in_progress to completed', () => {
+			const coordinationLog = [
+				{ phase: 'discovery' as const, status: 'in_progress' as const, timestamp: 1000 },
+				{ phase: 'discovery' as const, status: 'completed' as const, timestamp: 1500 },
+			];
+			const result = extractSubgraphMetrics(coordinationLog, undefined);
+			expect(result).toEqual({ discoveryDurationMs: 500 });
+		});
+
+		it('should calculate builder duration from in_progress to completed', () => {
+			const coordinationLog = [
+				{ phase: 'builder' as const, status: 'in_progress' as const, timestamp: 2000 },
+				{ phase: 'builder' as const, status: 'completed' as const, timestamp: 3500 },
+			];
+			const result = extractSubgraphMetrics(coordinationLog, undefined);
+			expect(result).toEqual({ builderDurationMs: 1500 });
+		});
+
+		it('should calculate both discovery and builder durations', () => {
+			const coordinationLog = [
+				{ phase: 'discovery' as const, status: 'in_progress' as const, timestamp: 1000 },
+				{ phase: 'discovery' as const, status: 'completed' as const, timestamp: 1500 },
+				{ phase: 'builder' as const, status: 'in_progress' as const, timestamp: 2000 },
+				{ phase: 'builder' as const, status: 'completed' as const, timestamp: 3000 },
+			];
+			const result = extractSubgraphMetrics(coordinationLog, 10);
+			expect(result).toEqual({
+				nodeCount: 10,
+				discoveryDurationMs: 500,
+				builderDurationMs: 1000,
+			});
+		});
+
+		it('should calculate duration from first to last entry when no in_progress status', () => {
+			const coordinationLog = [
+				{ phase: 'discovery' as const, status: 'completed' as const, timestamp: 1000 },
+				{ phase: 'discovery' as const, status: 'completed' as const, timestamp: 1800 },
+			];
+			const result = extractSubgraphMetrics(coordinationLog, undefined);
+			expect(result).toEqual({ discoveryDurationMs: 800 });
+		});
+
+		it('should ignore state_management phase', () => {
+			const coordinationLog = [
+				{ phase: 'state_management' as const, status: 'in_progress' as const, timestamp: 500 },
+				{ phase: 'state_management' as const, status: 'completed' as const, timestamp: 600 },
+			];
+			const result = extractSubgraphMetrics(coordinationLog, undefined);
+			expect(result).toEqual({});
+		});
+
+		it('should return undefined for phase with only one entry', () => {
+			const coordinationLog = [
+				{ phase: 'discovery' as const, status: 'completed' as const, timestamp: 1000 },
+			];
+			const result = extractSubgraphMetrics(coordinationLog, undefined);
+			expect(result).toEqual({});
+		});
+
+		it('should return empty object for empty coordination log', () => {
+			const result = extractSubgraphMetrics([], undefined);
+			expect(result).toEqual({});
+		});
+
+		it('should calculate responder duration from in_progress to completed', () => {
+			const coordinationLog = [
+				{ phase: 'responder' as const, status: 'in_progress' as const, timestamp: 5000 },
+				{ phase: 'responder' as const, status: 'completed' as const, timestamp: 5800 },
+			];
+			const result = extractSubgraphMetrics(coordinationLog, undefined);
+			expect(result).toEqual({ responderDurationMs: 800 });
+		});
+
+		it('should calculate all three phase durations together', () => {
+			const coordinationLog = [
+				{ phase: 'discovery' as const, status: 'in_progress' as const, timestamp: 1000 },
+				{ phase: 'discovery' as const, status: 'completed' as const, timestamp: 1500 },
+				{ phase: 'builder' as const, status: 'in_progress' as const, timestamp: 2000 },
+				{ phase: 'builder' as const, status: 'completed' as const, timestamp: 4000 },
+				{ phase: 'responder' as const, status: 'in_progress' as const, timestamp: 4500 },
+				{ phase: 'responder' as const, status: 'completed' as const, timestamp: 5000 },
+			];
+			const result = extractSubgraphMetrics(coordinationLog, 8);
+			expect(result).toEqual({
+				nodeCount: 8,
+				discoveryDurationMs: 500,
+				builderDurationMs: 2000,
+				responderDurationMs: 500,
+			});
 		});
 	});
 });

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/feedback.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/feedback.test.ts
@@ -38,6 +38,38 @@ describe('langsmithMetricKey()', () => {
 		expect(langsmithMetricKey(detail)).toBe('pairwise.judge1');
 	});
 
+	it('should prefix metrics evaluator with evaluator name', () => {
+		const discoveryLatency: Feedback = {
+			evaluator: 'metrics',
+			metric: 'discovery_latency_ms',
+			score: 500,
+			kind: 'metric',
+		};
+		const builderLatency: Feedback = {
+			evaluator: 'metrics',
+			metric: 'builder_latency_ms',
+			score: 1500,
+			kind: 'metric',
+		};
+		const responderLatency: Feedback = {
+			evaluator: 'metrics',
+			metric: 'responder_latency_ms',
+			score: 200,
+			kind: 'metric',
+		};
+		const nodeCount: Feedback = {
+			evaluator: 'metrics',
+			metric: 'node_count',
+			score: 5,
+			kind: 'metric',
+		};
+
+		expect(langsmithMetricKey(discoveryLatency)).toBe('metrics.discovery_latency_ms');
+		expect(langsmithMetricKey(builderLatency)).toBe('metrics.builder_latency_ms');
+		expect(langsmithMetricKey(responderLatency)).toBe('metrics.responder_latency_ms');
+		expect(langsmithMetricKey(nodeCount)).toBe('metrics.node_count');
+	});
+
 	it('should not produce collisions for the known evaluator contract', () => {
 		const feedback: Feedback[] = [
 			{ evaluator: 'llm-judge', metric: 'connections', score: 1, kind: 'metric' },
@@ -47,6 +79,8 @@ describe('langsmithMetricKey()', () => {
 			{ evaluator: 'pairwise', metric: 'pairwise_primary', score: 1, kind: 'score' },
 			{ evaluator: 'pairwise', metric: 'pairwise_total_violations', score: 1, kind: 'detail' },
 			{ evaluator: 'pairwise', metric: 'judge1', score: 0, kind: 'detail' },
+			{ evaluator: 'metrics', metric: 'discovery_latency_ms', score: 500, kind: 'metric' },
+			{ evaluator: 'metrics', metric: 'node_count', score: 5, kind: 'metric' },
 		];
 
 		const keys = feedback.map(langsmithMetricKey);

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/runner-langsmith.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/runner-langsmith.test.ts
@@ -175,7 +175,7 @@ describe('Runner - LangSmith Mode', () => {
 			if (!isLangsmithTargetOutput(result)) throw new Error('Expected LangSmith target output');
 
 			// Callbacks are passed explicitly from the traceable wrapper (undefined in tests without traceable context)
-			expect(generateWorkflow).toHaveBeenCalledWith('Create a workflow', undefined);
+			expect(generateWorkflow).toHaveBeenCalledWith('Create a workflow', expect.any(Function));
 			expect(evaluator.evaluate).toHaveBeenCalledWith(
 				workflow,
 				expect.objectContaining({ prompt: 'Create a workflow' }),

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/runner-langsmith.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/runner-langsmith.test.ts
@@ -174,8 +174,14 @@ describe('Runner - LangSmith Mode', () => {
 			expect(isLangsmithTargetOutput(result)).toBe(true);
 			if (!isLangsmithTargetOutput(result)) throw new Error('Expected LangSmith target output');
 
-			// Callbacks are passed explicitly from the traceable wrapper (undefined in tests without traceable context)
-			expect(generateWorkflow).toHaveBeenCalledWith('Create a workflow', expect.any(Function));
+			// Collectors are passed explicitly from the traceable wrapper to capture token usage and subgraph metrics
+			expect(generateWorkflow).toHaveBeenCalledWith(
+				'Create a workflow',
+				expect.objectContaining({
+					tokenUsage: expect.any(Function),
+					subgraphMetrics: expect.any(Function),
+				}),
+			);
 			expect(evaluator.evaluate).toHaveBeenCalledWith(
 				workflow,
 				expect.objectContaining({ prompt: 'Create a workflow' }),

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/argument-parser.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/argument-parser.ts
@@ -229,7 +229,7 @@ const FLAG_DEFS: Record<string, FlagDef> = {
 		key: 'outputCsv',
 		kind: 'string',
 		group: 'output',
-		desc: 'CSV file for evaluation results',
+		desc: 'CSV file for evaluation results - if pre-existing file found it will be overwritten',
 	},
 	'--verbose': { key: 'verbose', kind: 'boolean', group: 'output', desc: 'Verbose logging' },
 	'--webhook-url': {

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/argument-parser.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/argument-parser.ts
@@ -41,6 +41,9 @@ export interface EvaluationArgs {
 	/** Secret for HMAC-SHA256 signature of webhook payload */
 	webhookSecret?: string;
 
+	/** CSV file path for evaluation results */
+	outputCsv?: string;
+
 	// Model configuration
 	/** Default model for all stages */
 	model: ModelId;
@@ -83,6 +86,7 @@ const cliSchema = z
 		timeoutMs: z.coerce.number().int().positive().default(DEFAULTS.TIMEOUT_MS),
 		experimentName: z.string().min(1).optional(),
 		outputDir: z.string().min(1).optional(),
+		outputCsv: z.string().min(1).optional(),
 		datasetName: z.string().min(1).optional(),
 		maxExamples: z.coerce.number().int().positive().optional(),
 		filter: z.array(z.string().min(1)).default([]),
@@ -220,6 +224,12 @@ const FLAG_DEFS: Record<string, FlagDef> = {
 		kind: 'string',
 		group: 'output',
 		desc: 'Directory for artifacts',
+	},
+	'--output-csv': {
+		key: 'outputCsv',
+		kind: 'string',
+		group: 'output',
+		desc: 'CSV file for evaluation results',
 	},
 	'--verbose': { key: 'verbose', kind: 'boolean', group: 'output', desc: 'Verbose logging' },
 	'--webhook-url': {
@@ -525,6 +535,7 @@ export function parseEvaluationArgs(argv: string[] = process.argv.slice(2)): Eva
 		timeoutMs: parsed.timeoutMs,
 		experimentName: parsed.experimentName,
 		outputDir: parsed.outputDir,
+		outputCsv: parsed.outputCsv,
 		datasetName: parsed.datasetName,
 		maxExamples: parsed.maxExamples,
 		filters,

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
@@ -213,6 +213,7 @@ export async function runV2Evaluation(): Promise<void> {
 		lifecycle,
 		logger,
 		outputDir: args.outputDir,
+		outputCsv: args.outputCsv,
 		timeoutMs: args.timeoutMs,
 		context: { llmCallLimiter },
 	};

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/cli/index.ts
@@ -12,7 +12,24 @@ import type { CoordinationLogEntry } from '@/types/coordination';
 import type { SimpleWorkflow } from '@/types/workflow';
 import type { BuilderFeatureFlags } from '@/workflow-builder-agent';
 
-import { extractSubgraphMetrics } from '../harness/evaluation-helpers';
+import {
+	argsToStageModels,
+	getDefaultDatasetName,
+	getDefaultExperimentName,
+	parseEvaluationArgs,
+} from './argument-parser';
+import { buildCIMetadata } from './ci-metadata';
+import {
+	loadTestCasesFromCsv,
+	loadDefaultTestCases,
+	getDefaultTestCaseIds,
+} from './csv-prompt-loader';
+import { sendWebhookNotification } from './webhook';
+import {
+	consumeGenerator,
+	extractSubgraphMetrics,
+	getChatPayload,
+} from '../harness/evaluation-helpers';
 import { createLogger } from '../harness/logger';
 import type { GenerationCollectors } from '../harness/runner';
 import { TokenUsageTrackingHandler } from '../harness/token-tracking-handler';
@@ -28,20 +45,6 @@ import {
 	type Evaluator,
 	type EvaluationContext,
 } from '../index';
-import {
-	argsToStageModels,
-	getDefaultDatasetName,
-	getDefaultExperimentName,
-	parseEvaluationArgs,
-} from './argument-parser';
-import { buildCIMetadata } from './ci-metadata';
-import {
-	loadTestCasesFromCsv,
-	loadDefaultTestCases,
-	getDefaultTestCaseIds,
-} from './csv-prompt-loader';
-import { sendWebhookNotification } from './webhook';
-import { consumeGenerator, getChatPayload } from '../harness/evaluation-helpers';
 import { generateRunId, isWorkflowStateValues } from '../langsmith/types';
 import { EVAL_TYPES, EVAL_USERS } from '../support/constants';
 import { setupTestEnvironment, createAgent, type ResolvedStageLLMs } from '../support/environment';
@@ -245,6 +248,7 @@ export async function runV2Evaluation(): Promise<void> {
 		logger,
 		outputDir: args.outputDir,
 		outputCsv: args.outputCsv,
+		suite: args.suite,
 		timeoutMs: args.timeoutMs,
 		context: { llmCallLimiter },
 	};

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/__tests__/csv-writer.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/__tests__/csv-writer.test.ts
@@ -83,11 +83,22 @@ describe('writeResultsCsv', () => {
 		expect(lines[1]).toContain('[CRITICAL] Missing trigger');
 	});
 
-	it('escapes commas and quotes in values', () => {
+	it.each([
+		{
+			description: 'commas and quotes',
+			prompt: 'Workflow with "quotes" and, commas',
+			expected: '"Workflow with ""quotes"" and, commas"',
+		},
+		{
+			description: 'newlines',
+			prompt: 'Workflow with\nnewline',
+			expected: '"Workflow with\nnewline"',
+		},
+	])('escapes $description in values', ({ prompt, expected }) => {
 		const results: ExampleResult[] = [
 			{
 				index: 1,
-				prompt: 'Workflow with "quotes" and, commas',
+				prompt,
 				status: 'pass',
 				score: 0.8,
 				feedback: [],
@@ -99,28 +110,7 @@ describe('writeResultsCsv', () => {
 		writeResultsCsv(results, outputPath);
 
 		const content = readFileSync(outputPath, 'utf-8');
-		// Should escape the prompt value
-		expect(content).toContain('"Workflow with ""quotes"" and, commas"');
-	});
-
-	it('escapes newlines in values', () => {
-		const results: ExampleResult[] = [
-			{
-				index: 1,
-				prompt: 'Workflow with\nnewline',
-				status: 'pass',
-				score: 0.8,
-				feedback: [],
-				durationMs: 1000,
-			},
-		];
-
-		const outputPath = join(tempDir, 'results.csv');
-		writeResultsCsv(results, outputPath);
-
-		const content = readFileSync(outputPath, 'utf-8');
-		// Should escape the prompt value containing newline
-		expect(content).toContain('"Workflow with\nnewline"');
+		expect(content).toContain(expected);
 	});
 
 	it('writes pairwise evaluation results with correct columns', () => {

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/__tests__/csv-writer.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/__tests__/csv-writer.test.ts
@@ -1,0 +1,125 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { writeResultsCsv } from '../csv-writer';
+import type { ExampleResult } from '../harness-types';
+
+describe('writeResultsCsv', () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), 'csv-writer-test-'));
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it('writes sorted results with correct columns', () => {
+		const results: ExampleResult[] = [
+			{
+				index: 2,
+				prompt: 'Zebra workflow',
+				status: 'pass',
+				score: 0.9,
+				feedback: [
+					{
+						evaluator: 'llm-judge',
+						metric: 'functionality',
+						score: 0.95,
+						kind: 'metric',
+						comment: '',
+					},
+					{
+						evaluator: 'llm-judge',
+						metric: 'connections',
+						score: 0.85,
+						kind: 'metric',
+						comment: 'Minor issue',
+					},
+				],
+				durationMs: 5000,
+				generationDurationMs: 3000,
+				generationInputTokens: 1000,
+				generationOutputTokens: 500,
+			},
+			{
+				index: 1,
+				prompt: 'Alpha workflow',
+				status: 'fail',
+				score: 0.6,
+				feedback: [
+					{
+						evaluator: 'llm-judge',
+						metric: 'functionality',
+						score: 0.5,
+						kind: 'metric',
+						comment: '[CRITICAL] Missing trigger',
+					},
+				],
+				durationMs: 4000,
+				generationDurationMs: 2500,
+				generationInputTokens: 800,
+				generationOutputTokens: 400,
+			},
+		];
+
+		const outputPath = join(tempDir, 'results.csv');
+		writeResultsCsv(results, outputPath);
+
+		const content = readFileSync(outputPath, 'utf-8');
+		const lines = content.trim().split('\n');
+
+		// Check header
+		expect(lines[0]).toContain('prompt,overall_score,status,gen_latency_ms');
+		expect(lines[0]).toContain('functionality,functionality_detail');
+
+		// Check sorting (Alpha before Zebra)
+		expect(lines[1]).toContain('Alpha workflow');
+		expect(lines[2]).toContain('Zebra workflow');
+
+		// Check violation text is included
+		expect(lines[1]).toContain('[CRITICAL] Missing trigger');
+	});
+
+	it('escapes commas and quotes in values', () => {
+		const results: ExampleResult[] = [
+			{
+				index: 1,
+				prompt: 'Workflow with "quotes" and, commas',
+				status: 'pass',
+				score: 0.8,
+				feedback: [],
+				durationMs: 1000,
+			},
+		];
+
+		const outputPath = join(tempDir, 'results.csv');
+		writeResultsCsv(results, outputPath);
+
+		const content = readFileSync(outputPath, 'utf-8');
+		// Should escape the prompt value
+		expect(content).toContain('"Workflow with ""quotes"" and, commas"');
+	});
+
+	it('escapes newlines in values', () => {
+		const results: ExampleResult[] = [
+			{
+				index: 1,
+				prompt: 'Workflow with\nnewline',
+				status: 'pass',
+				score: 0.8,
+				feedback: [],
+				durationMs: 1000,
+			},
+		];
+
+		const outputPath = join(tempDir, 'results.csv');
+		writeResultsCsv(results, outputPath);
+
+		const content = readFileSync(outputPath, 'utf-8');
+		// Should escape the prompt value containing newline
+		expect(content).toContain('"Workflow with\nnewline"');
+	});
+});

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/__tests__/token-tracking-handler.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/__tests__/token-tracking-handler.test.ts
@@ -96,6 +96,50 @@ describe('TokenUsageTrackingHandler', () => {
 				outputTokens: 0,
 			});
 		});
+
+		it('should accumulate tokens from OpenAI format (prompt_tokens/completion_tokens)', async () => {
+			const result: LLMResult = {
+				generations: [[]],
+				llmOutput: {
+					usage: {
+						prompt_tokens: 150,
+						completion_tokens: 75,
+					},
+				},
+			};
+
+			await handler.handleLLMEnd(result);
+
+			expect(handler.getUsage()).toEqual({
+				inputTokens: 150,
+				outputTokens: 75,
+			});
+		});
+
+		it('should accumulate tokens from OpenAI format in generationInfo', async () => {
+			const result: LLMResult = {
+				generations: [
+					[
+						{
+							text: 'response',
+							generationInfo: {
+								usage: {
+									prompt_tokens: 80,
+									completion_tokens: 40,
+								},
+							},
+						},
+					],
+				],
+			};
+
+			await handler.handleLLMEnd(result);
+
+			expect(handler.getUsage()).toEqual({
+				inputTokens: 80,
+				outputTokens: 40,
+			});
+		});
 	});
 
 	describe('reset', () => {

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/__tests__/token-tracking-handler.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/__tests__/token-tracking-handler.test.ts
@@ -10,43 +10,43 @@ describe('TokenUsageTrackingHandler', () => {
 	});
 
 	describe('handleLLMEnd', () => {
-		it('should accumulate tokens from llmOutput.usage', async () => {
-			const result: LLMResult = {
-				generations: [[]],
-				llmOutput: {
-					usage: {
-						input_tokens: 100,
-						output_tokens: 50,
-					},
-				},
-			};
+		it.each([
+			{
+				format: 'Anthropic (input_tokens/output_tokens)',
+				usage: { input_tokens: 100, output_tokens: 50 },
+				expected: { inputTokens: 100, outputTokens: 50 },
+			},
+			{
+				format: 'OpenAI (prompt_tokens/completion_tokens)',
+				usage: { prompt_tokens: 150, completion_tokens: 75 },
+				expected: { inputTokens: 150, outputTokens: 75 },
+			},
+		])(
+			'should accumulate tokens from llmOutput.usage in $format format',
+			async ({ usage, expected }) => {
+				const result: LLMResult = {
+					generations: [[]],
+					llmOutput: { usage },
+				};
 
-			await handler.handleLLMEnd(result);
+				await handler.handleLLMEnd(result);
 
-			expect(handler.getUsage()).toEqual({
-				inputTokens: 100,
-				outputTokens: 50,
-			});
-		});
+				expect(handler.getUsage()).toEqual(expected);
+			},
+		);
 
 		it('should accumulate tokens from multiple LLM calls', async () => {
 			const result1: LLMResult = {
 				generations: [[]],
 				llmOutput: {
-					usage: {
-						input_tokens: 100,
-						output_tokens: 50,
-					},
+					usage: { input_tokens: 100, output_tokens: 50 },
 				},
 			};
 
 			const result2: LLMResult = {
 				generations: [[]],
 				llmOutput: {
-					usage: {
-						input_tokens: 200,
-						output_tokens: 100,
-					},
+					usage: { input_tokens: 200, output_tokens: 100 },
 				},
 			};
 
@@ -59,30 +59,36 @@ describe('TokenUsageTrackingHandler', () => {
 			});
 		});
 
-		it('should extract tokens from generation info when llmOutput is empty', async () => {
-			const result: LLMResult = {
-				generations: [
-					[
-						{
-							text: 'response',
-							generationInfo: {
-								usage: {
-									input_tokens: 75,
-									output_tokens: 25,
-								},
+		it.each([
+			{
+				format: 'Anthropic (input_tokens/output_tokens)',
+				usage: { input_tokens: 75, output_tokens: 25 },
+				expected: { inputTokens: 75, outputTokens: 25 },
+			},
+			{
+				format: 'OpenAI (prompt_tokens/completion_tokens)',
+				usage: { prompt_tokens: 80, completion_tokens: 40 },
+				expected: { inputTokens: 80, outputTokens: 40 },
+			},
+		])(
+			'should extract tokens from generationInfo in $format format when llmOutput is empty',
+			async ({ usage, expected }) => {
+				const result: LLMResult = {
+					generations: [
+						[
+							{
+								text: 'response',
+								generationInfo: { usage },
 							},
-						},
+						],
 					],
-				],
-			};
+				};
 
-			await handler.handleLLMEnd(result);
+				await handler.handleLLMEnd(result);
 
-			expect(handler.getUsage()).toEqual({
-				inputTokens: 75,
-				outputTokens: 25,
-			});
-		});
+				expect(handler.getUsage()).toEqual(expected);
+			},
+		);
 
 		it('should handle missing usage data gracefully', async () => {
 			const result: LLMResult = {
@@ -94,50 +100,6 @@ describe('TokenUsageTrackingHandler', () => {
 			expect(handler.getUsage()).toEqual({
 				inputTokens: 0,
 				outputTokens: 0,
-			});
-		});
-
-		it('should accumulate tokens from OpenAI format (prompt_tokens/completion_tokens)', async () => {
-			const result: LLMResult = {
-				generations: [[]],
-				llmOutput: {
-					usage: {
-						prompt_tokens: 150,
-						completion_tokens: 75,
-					},
-				},
-			};
-
-			await handler.handleLLMEnd(result);
-
-			expect(handler.getUsage()).toEqual({
-				inputTokens: 150,
-				outputTokens: 75,
-			});
-		});
-
-		it('should accumulate tokens from OpenAI format in generationInfo', async () => {
-			const result: LLMResult = {
-				generations: [
-					[
-						{
-							text: 'response',
-							generationInfo: {
-								usage: {
-									prompt_tokens: 80,
-									completion_tokens: 40,
-								},
-							},
-						},
-					],
-				],
-			};
-
-			await handler.handleLLMEnd(result);
-
-			expect(handler.getUsage()).toEqual({
-				inputTokens: 80,
-				outputTokens: 40,
 			});
 		});
 	});

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/__tests__/token-tracking-handler.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/__tests__/token-tracking-handler.test.ts
@@ -1,0 +1,133 @@
+import type { LLMResult } from '@langchain/core/outputs';
+
+import { TokenUsageTrackingHandler } from '../token-tracking-handler';
+
+describe('TokenUsageTrackingHandler', () => {
+	let handler: TokenUsageTrackingHandler;
+
+	beforeEach(() => {
+		handler = new TokenUsageTrackingHandler();
+	});
+
+	describe('handleLLMEnd', () => {
+		it('should accumulate tokens from llmOutput.usage', async () => {
+			const result: LLMResult = {
+				generations: [[]],
+				llmOutput: {
+					usage: {
+						input_tokens: 100,
+						output_tokens: 50,
+					},
+				},
+			};
+
+			await handler.handleLLMEnd(result);
+
+			expect(handler.getUsage()).toEqual({
+				inputTokens: 100,
+				outputTokens: 50,
+			});
+		});
+
+		it('should accumulate tokens from multiple LLM calls', async () => {
+			const result1: LLMResult = {
+				generations: [[]],
+				llmOutput: {
+					usage: {
+						input_tokens: 100,
+						output_tokens: 50,
+					},
+				},
+			};
+
+			const result2: LLMResult = {
+				generations: [[]],
+				llmOutput: {
+					usage: {
+						input_tokens: 200,
+						output_tokens: 100,
+					},
+				},
+			};
+
+			await handler.handleLLMEnd(result1);
+			await handler.handleLLMEnd(result2);
+
+			expect(handler.getUsage()).toEqual({
+				inputTokens: 300,
+				outputTokens: 150,
+			});
+		});
+
+		it('should extract tokens from generation info when llmOutput is empty', async () => {
+			const result: LLMResult = {
+				generations: [
+					[
+						{
+							text: 'response',
+							generationInfo: {
+								usage: {
+									input_tokens: 75,
+									output_tokens: 25,
+								},
+							},
+						},
+					],
+				],
+			};
+
+			await handler.handleLLMEnd(result);
+
+			expect(handler.getUsage()).toEqual({
+				inputTokens: 75,
+				outputTokens: 25,
+			});
+		});
+
+		it('should handle missing usage data gracefully', async () => {
+			const result: LLMResult = {
+				generations: [[{ text: 'response' }]],
+			};
+
+			await handler.handleLLMEnd(result);
+
+			expect(handler.getUsage()).toEqual({
+				inputTokens: 0,
+				outputTokens: 0,
+			});
+		});
+	});
+
+	describe('reset', () => {
+		it('should reset accumulated usage to zero', async () => {
+			const result: LLMResult = {
+				generations: [[]],
+				llmOutput: {
+					usage: {
+						input_tokens: 100,
+						output_tokens: 50,
+					},
+				},
+			};
+
+			await handler.handleLLMEnd(result);
+			expect(handler.getUsage().inputTokens).toBe(100);
+
+			handler.reset();
+
+			expect(handler.getUsage()).toEqual({
+				inputTokens: 0,
+				outputTokens: 0,
+			});
+		});
+	});
+
+	describe('getUsage', () => {
+		it('should return zero for new handler', () => {
+			expect(handler.getUsage()).toEqual({
+				inputTokens: 0,
+				outputTokens: 0,
+			});
+		});
+	});
+});

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/csv-writer.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/csv-writer.ts
@@ -12,6 +12,10 @@ const FIXED_COLUMNS = [
 	'gen_latency_ms',
 	'gen_input_tokens',
 	'gen_output_tokens',
+	'node_count',
+	'discovery_latency_ms',
+	'builder_latency_ms',
+	'responder_latency_ms',
 ] as const;
 
 /**
@@ -111,6 +115,10 @@ function buildLlmJudgeRow(result: ExampleResult): string[] {
 	row.push(escapeCsvValue(result.generationDurationMs));
 	row.push(escapeCsvValue(result.generationInputTokens));
 	row.push(escapeCsvValue(result.generationOutputTokens));
+	row.push(escapeCsvValue(result.subgraphMetrics?.nodeCount));
+	row.push(escapeCsvValue(result.subgraphMetrics?.discoveryDurationMs));
+	row.push(escapeCsvValue(result.subgraphMetrics?.builderDurationMs));
+	row.push(escapeCsvValue(result.subgraphMetrics?.responderDurationMs));
 
 	// LLM Judge metric columns (score + detail pairs)
 	for (const metric of LLM_JUDGE_METRICS) {
@@ -134,6 +142,10 @@ function buildPairwiseRow(result: ExampleResult, judgeCount: number): string[] {
 	row.push(escapeCsvValue(result.generationDurationMs));
 	row.push(escapeCsvValue(result.generationInputTokens));
 	row.push(escapeCsvValue(result.generationOutputTokens));
+	row.push(escapeCsvValue(result.subgraphMetrics?.nodeCount));
+	row.push(escapeCsvValue(result.subgraphMetrics?.discoveryDurationMs));
+	row.push(escapeCsvValue(result.subgraphMetrics?.builderDurationMs));
+	row.push(escapeCsvValue(result.subgraphMetrics?.responderDurationMs));
 
 	// Pairwise metrics (scores only, no detail)
 	for (const metric of PAIRWISE_METRICS) {

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/csv-writer.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/csv-writer.ts
@@ -1,0 +1,121 @@
+import { writeFileSync } from 'node:fs';
+
+import type { ExampleResult, Feedback } from './harness-types';
+
+/**
+ * Fixed columns that appear first in the CSV (in order).
+ */
+const FIXED_COLUMNS = [
+	'prompt',
+	'overall_score',
+	'status',
+	'gen_latency_ms',
+	'gen_input_tokens',
+	'gen_output_tokens',
+] as const;
+
+/**
+ * LLM Judge metrics to include (in order).
+ * Each metric gets a score column and a _detail column.
+ */
+const LLM_JUDGE_METRICS = [
+	'functionality',
+	'connections',
+	'expressions',
+	'nodeConfiguration',
+	'efficiency',
+	'dataFlow',
+	'maintainability',
+	'bestPractices',
+] as const;
+
+/**
+ * Escape a value for CSV output.
+ * Wraps in quotes if contains comma, quote, or newline.
+ */
+function escapeCsvValue(value: string | number | undefined): string {
+	if (value === undefined || value === null) return '';
+	const str = String(value);
+	if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+		return `"${str.replace(/"/g, '""')}"`;
+	}
+	return str;
+}
+
+/**
+ * Extract the detail text from feedback for a given metric.
+ * Returns semicolon-separated violation text.
+ */
+function extractMetricDetail(feedback: Feedback[], metric: string): string {
+	const item = feedback.find(
+		(f) => f.evaluator === 'llm-judge' && f.metric === metric && f.comment,
+	);
+	return item?.comment ?? '';
+}
+
+/**
+ * Extract the score for a given metric.
+ */
+function extractMetricScore(feedback: Feedback[], metric: string): number | undefined {
+	const item = feedback.find((f) => f.evaluator === 'llm-judge' && f.metric === metric);
+	return item?.score;
+}
+
+/**
+ * Build a CSV row from an ExampleResult.
+ */
+function buildCsvRow(result: ExampleResult): string[] {
+	const row: string[] = [];
+
+	// Fixed columns
+	row.push(escapeCsvValue(result.prompt));
+	row.push(escapeCsvValue(result.score));
+	row.push(escapeCsvValue(result.status));
+	row.push(escapeCsvValue(result.generationDurationMs));
+	row.push(escapeCsvValue(result.generationInputTokens));
+	row.push(escapeCsvValue(result.generationOutputTokens));
+
+	// Metric columns (score + detail pairs)
+	for (const metric of LLM_JUDGE_METRICS) {
+		row.push(escapeCsvValue(extractMetricScore(result.feedback, metric)));
+		row.push(escapeCsvValue(extractMetricDetail(result.feedback, metric)));
+	}
+
+	return row;
+}
+
+/**
+ * Build the CSV header row.
+ */
+function buildCsvHeader(): string[] {
+	const header: string[] = [...FIXED_COLUMNS];
+
+	for (const metric of LLM_JUDGE_METRICS) {
+		header.push(metric);
+		header.push(`${metric}_detail`);
+	}
+
+	return header;
+}
+
+/**
+ * Write evaluation results to a CSV file.
+ * Results are sorted by prompt for consistent ordering across runs.
+ */
+export function writeResultsCsv(results: ExampleResult[], outputPath: string): void {
+	// Sort by prompt for consistent ordering
+	const sorted = [...results].sort((a, b) => a.prompt.localeCompare(b.prompt));
+
+	const lines: string[] = [];
+
+	// Header
+	lines.push(buildCsvHeader().join(','));
+
+	// Data rows
+	for (const result of sorted) {
+		lines.push(buildCsvRow(result).join(','));
+	}
+
+	// Write file (overwrites if exists)
+	writeFileSync(outputPath, lines.join('\n') + '\n', 'utf-8');
+}

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/feedback.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/feedback.ts
@@ -21,6 +21,7 @@ function isPairwiseV1Metric(metric: string): boolean {
  * - Programmatic: keep evaluator prefix (e.g. `programmatic.trigger`)
  * - LLM-judge: keep metrics unprefixed (e.g. `overallScore`, `connections`, `maintainability.nodeNamingQuality`)
  * - Pairwise: keep v1 metrics unprefixed (e.g. `pairwise_primary`), but namespace non-v1 details.
+ * - Metrics: keep evaluator prefix (e.g. `metrics.discovery_latency_ms`, `metrics.node_count`)
  */
 export function langsmithMetricKey(feedback: Feedback): string {
 	if (feedback.evaluator === 'pairwise') {
@@ -33,6 +34,10 @@ export function langsmithMetricKey(feedback: Feedback): string {
 
 	if (feedback.evaluator === 'llm-judge') {
 		return feedback.metric;
+	}
+
+	if (feedback.evaluator === 'metrics') {
+		return feedbackKey(feedback);
 	}
 
 	// Default: prefix unknown evaluators to avoid collisions with unprefixed `llm-judge` metrics.

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/harness-types.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/harness-types.ts
@@ -111,6 +111,8 @@ export interface RunConfigBase {
 	context?: GlobalRunContext;
 	/** Directory for JSON output files */
 	outputDir?: string;
+	/** CSV file path for evaluation results */
+	outputCsv?: string;
 	/** Threshold for pass/fail classification of an example score (0-1). */
 	passThreshold?: number;
 	/** Timeout for generation/evaluator operations (ms). */

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/harness-types.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/harness-types.ts
@@ -96,6 +96,9 @@ export interface TestCase {
 	referenceWorkflows?: SimpleWorkflow[];
 }
 
+/** Evaluation suite types supported by the harness */
+export type EvaluationSuite = 'llm-judge' | 'pairwise' | 'programmatic' | 'similarity';
+
 /**
  * Configuration for an evaluation run.
  */
@@ -110,6 +113,8 @@ export interface RunConfigBase {
 	outputDir?: string;
 	/** CSV file path for evaluation results */
 	outputCsv?: string;
+	/** Evaluation suite (used for CSV formatting). If not set, auto-detected from feedback. */
+	suite?: EvaluationSuite;
 	/** Threshold for pass/fail classification of an example score (0-1). */
 	passThreshold?: number;
 	/** Timeout for generation/evaluator operations (ms). */

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/harness-types.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/harness-types.ts
@@ -2,6 +2,7 @@ import type { Client as LangsmithClient } from 'langsmith/client';
 import type pLimit from 'p-limit';
 
 import type { EvalLogger } from './logger.js';
+import type { TokenUsageCollector } from './runner.js';
 import type { SimpleWorkflow } from '../../src/types/workflow.js';
 
 export type LlmCallLimiter = ReturnType<typeof pLimit>;
@@ -99,8 +100,11 @@ export interface TestCase {
  * Configuration for an evaluation run.
  */
 export interface RunConfigBase {
-	/** Function to generate workflow from prompt */
-	generateWorkflow: (prompt: string) => Promise<SimpleWorkflow>;
+	/** Function to generate workflow from prompt. Optional tokenUsageCollector receives token counts. */
+	generateWorkflow: (
+		prompt: string,
+		tokenUsageCollector?: TokenUsageCollector,
+	) => Promise<SimpleWorkflow>;
 	/** Evaluators to run on each generated workflow */
 	evaluators: Array<Evaluator<EvaluationContext>>;
 	/** Global context available to all evaluators */

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/harness-types.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/harness-types.ts
@@ -178,6 +178,10 @@ export interface ExampleResult {
 	generationDurationMs?: number;
 	/** Time spent running evaluators, when known. */
 	evaluationDurationMs?: number;
+	/** Input tokens used during workflow generation */
+	generationInputTokens?: number;
+	/** Output tokens used during workflow generation */
+	generationOutputTokens?: number;
 	workflow?: SimpleWorkflow;
 	error?: string;
 }

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/harness-types.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/harness-types.ts
@@ -2,7 +2,7 @@ import type { Client as LangsmithClient } from 'langsmith/client';
 import type pLimit from 'p-limit';
 
 import type { EvalLogger } from './logger.js';
-import type { TokenUsageCollector } from './runner.js';
+import type { GenerationCollectors } from './runner.js';
 import type { SimpleWorkflow } from '../../src/types/workflow.js';
 
 export type LlmCallLimiter = ReturnType<typeof pLimit>;
@@ -100,11 +100,8 @@ export interface TestCase {
  * Configuration for an evaluation run.
  */
 export interface RunConfigBase {
-	/** Function to generate workflow from prompt. Optional tokenUsageCollector receives token counts. */
-	generateWorkflow: (
-		prompt: string,
-		tokenUsageCollector?: TokenUsageCollector,
-	) => Promise<SimpleWorkflow>;
+	/** Function to generate workflow from prompt. Optional collectors receive metrics. */
+	generateWorkflow: (prompt: string, collectors?: GenerationCollectors) => Promise<SimpleWorkflow>;
 	/** Evaluators to run on each generated workflow */
 	evaluators: Array<Evaluator<EvaluationContext>>;
 	/** Global context available to all evaluators */
@@ -170,6 +167,20 @@ export interface LangsmithExampleFilters {
 }
 
 /**
+ * Subgraph timing metrics extracted from coordination log.
+ */
+export interface SubgraphMetrics {
+	/** Time spent in discovery subgraph (ms) */
+	discoveryDurationMs?: number;
+	/** Time spent in builder subgraph (ms) */
+	builderDurationMs?: number;
+	/** Time spent in responder generating the final response (ms) */
+	responderDurationMs?: number;
+	/** Number of nodes in the final workflow */
+	nodeCount?: number;
+}
+
+/**
  * Result of evaluating a single example.
  */
 export interface ExampleResult {
@@ -188,6 +199,8 @@ export interface ExampleResult {
 	generationInputTokens?: number;
 	/** Output tokens used during workflow generation */
 	generationOutputTokens?: number;
+	/** Subgraph timing and workflow metrics */
+	subgraphMetrics?: SubgraphMetrics;
 	workflow?: SimpleWorkflow;
 	error?: string;
 }

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/output.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/output.ts
@@ -146,7 +146,20 @@ function formatFeedbackForExport(result: ExampleResult): object {
 		index: result.index,
 		status: result.status,
 		durationMs: result.durationMs,
+		generationDurationMs: result.generationDurationMs,
+		evaluationDurationMs: result.evaluationDurationMs,
+		generationInputTokens: result.generationInputTokens,
+		generationOutputTokens: result.generationOutputTokens,
 		score: result.score,
+		// Include subgraph metrics if available
+		...(result.subgraphMetrics && {
+			subgraphMetrics: {
+				nodeCount: result.subgraphMetrics.nodeCount,
+				discoveryDurationMs: result.subgraphMetrics.discoveryDurationMs,
+				builderDurationMs: result.subgraphMetrics.builderDurationMs,
+				responderDurationMs: result.subgraphMetrics.responderDurationMs,
+			},
+		}),
 		evaluators: Object.entries(byEvaluator).map(([name, items]) => ({
 			name,
 			feedback: items.map((f) => ({
@@ -208,6 +221,15 @@ function formatSummaryForExport(summary: RunSummary, results: ExampleResult[]): 
 			status: r.status,
 			score: r.score,
 			durationMs: r.durationMs,
+			generationDurationMs: r.generationDurationMs,
+			generationInputTokens: r.generationInputTokens,
+			generationOutputTokens: r.generationOutputTokens,
+			...(r.subgraphMetrics && {
+				nodeCount: r.subgraphMetrics.nodeCount,
+				discoveryDurationMs: r.subgraphMetrics.discoveryDurationMs,
+				builderDurationMs: r.subgraphMetrics.builderDurationMs,
+				responderDurationMs: r.subgraphMetrics.responderDurationMs,
+			}),
 			...(r.error ? { error: r.error } : {}),
 		})),
 	};

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/runner.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/runner.ts
@@ -635,6 +635,7 @@ async function runLocal(config: LocalRunConfig): Promise<RunSummary> {
 		timeoutMs,
 		lifecycle,
 		outputDir,
+		outputCsv,
 		logger,
 	} = config;
 
@@ -668,6 +669,13 @@ async function runLocal(config: LocalRunConfig): Promise<RunSummary> {
 
 	// Save summary to disk if outputDir is provided
 	artifactSaver?.saveSummary(summary, results);
+
+	// Write CSV if requested
+	if (outputCsv) {
+		const { writeResultsCsv } = await import('./csv-writer.js');
+		writeResultsCsv(results, outputCsv);
+		logger.info(`Results written to: ${outputCsv}`);
+	}
 
 	lifecycle?.onEnd?.(summary);
 
@@ -888,6 +896,7 @@ async function runLangsmith(config: LangsmithRunConfig): Promise<RunSummary> {
 		evaluators,
 		context: globalContext,
 		outputDir,
+		outputCsv,
 		passThreshold = DEFAULT_PASS_THRESHOLD,
 		timeoutMs,
 		langsmithOptions,
@@ -1124,6 +1133,13 @@ async function runLangsmith(config: LangsmithRunConfig): Promise<RunSummary> {
 
 	if (artifactSaver) {
 		artifactSaver.saveSummary(summary, capturedResults);
+	}
+
+	// Write CSV if requested
+	if (outputCsv) {
+		const { writeResultsCsv } = await import('./csv-writer.js');
+		writeResultsCsv(capturedResults, outputCsv);
+		logger.info(`Results written to: ${outputCsv}`);
 	}
 
 	lifecycle?.onEnd?.(summary);

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/runner.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/runner.ts
@@ -669,6 +669,7 @@ async function runLocal(config: LocalRunConfig): Promise<RunSummary> {
 		lifecycle,
 		outputDir,
 		outputCsv,
+		suite,
 		logger,
 	} = config;
 
@@ -706,7 +707,9 @@ async function runLocal(config: LocalRunConfig): Promise<RunSummary> {
 	// Write CSV if requested
 	if (outputCsv) {
 		const { writeResultsCsv } = await import('./csv-writer.js');
-		writeResultsCsv(results, outputCsv);
+		// Map suite to CSV format (only llm-judge and pairwise are supported)
+		const csvSuite = suite === 'llm-judge' || suite === 'pairwise' ? suite : undefined;
+		writeResultsCsv(results, outputCsv, { suite: csvSuite });
 		logger.info(`Results written to: ${outputCsv}`);
 	}
 
@@ -930,6 +933,7 @@ async function runLangsmith(config: LangsmithRunConfig): Promise<RunSummary> {
 		context: globalContext,
 		outputDir,
 		outputCsv,
+		suite,
 		passThreshold = DEFAULT_PASS_THRESHOLD,
 		timeoutMs,
 		langsmithOptions,
@@ -1191,7 +1195,9 @@ async function runLangsmith(config: LangsmithRunConfig): Promise<RunSummary> {
 	// Write CSV if requested
 	if (outputCsv) {
 		const { writeResultsCsv } = await import('./csv-writer.js');
-		writeResultsCsv(capturedResults, outputCsv);
+		// Map suite to CSV format (only llm-judge and pairwise are supported)
+		const csvSuite = suite === 'llm-judge' || suite === 'pairwise' ? suite : undefined;
+		writeResultsCsv(capturedResults, outputCsv, { suite: csvSuite });
 		logger.info(`Results written to: ${outputCsv}`);
 	}
 

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/token-tracking-handler.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/token-tracking-handler.ts
@@ -1,0 +1,80 @@
+import { BaseCallbackHandler } from '@langchain/core/callbacks/base';
+import type { LLMResult } from '@langchain/core/outputs';
+
+/**
+ * Accumulated token usage from all LLM calls.
+ */
+export interface AccumulatedTokenUsage {
+	inputTokens: number;
+	outputTokens: number;
+}
+
+/**
+ * Callback handler that tracks token usage from all LLM calls.
+ * Used during evaluation to capture total generation costs across all agents
+ * (supervisor, discovery, builder, responder).
+ *
+ * Token usage is extracted from LLM response metadata, which includes:
+ * - input_tokens: tokens in the prompt
+ * - output_tokens: tokens in the completion
+ * - cache_read_input_tokens: cached prompt tokens (optional)
+ * - cache_creation_input_tokens: tokens added to cache (optional)
+ */
+export class TokenUsageTrackingHandler extends BaseCallbackHandler {
+	name = 'TokenUsageTrackingHandler';
+
+	private totalInputTokens = 0;
+	private totalOutputTokens = 0;
+
+	/**
+	 * Called when an LLM call completes.
+	 * Extracts and accumulates token usage from the response.
+	 */
+	async handleLLMEnd(output: LLMResult): Promise<void> {
+		// Token usage can be in different locations depending on the provider
+		// Check llmOutput first (common for Anthropic)
+		const llmOutput = output.llmOutput as Record<string, unknown> | undefined;
+		if (llmOutput?.usage && typeof llmOutput.usage === 'object') {
+			const usage = llmOutput.usage as Record<string, number>;
+			if (typeof usage.input_tokens === 'number') {
+				this.totalInputTokens += usage.input_tokens;
+			}
+			if (typeof usage.output_tokens === 'number') {
+				this.totalOutputTokens += usage.output_tokens;
+			}
+			return;
+		}
+
+		// Also check generations for token usage in response_metadata
+		for (const generation of output.generations.flat()) {
+			const genInfo = generation.generationInfo as Record<string, unknown> | undefined;
+			if (genInfo?.usage && typeof genInfo.usage === 'object') {
+				const usage = genInfo.usage as Record<string, number>;
+				if (typeof usage.input_tokens === 'number') {
+					this.totalInputTokens += usage.input_tokens;
+				}
+				if (typeof usage.output_tokens === 'number') {
+					this.totalOutputTokens += usage.output_tokens;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Get the total accumulated token usage.
+	 */
+	getUsage(): AccumulatedTokenUsage {
+		return {
+			inputTokens: this.totalInputTokens,
+			outputTokens: this.totalOutputTokens,
+		};
+	}
+
+	/**
+	 * Reset the accumulated usage (useful for reuse across multiple runs).
+	 */
+	reset(): void {
+		this.totalInputTokens = 0;
+		this.totalOutputTokens = 0;
+	}
+}

--- a/packages/@n8n/ai-workflow-builder.ee/src/multi-agent-workflow-subgraphs.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/multi-agent-workflow-subgraphs.ts
@@ -125,9 +125,7 @@ function createSubgraphNodeHandler<
 			};
 
 			// Extract coordination log from output, filtering to valid entries using type guard
-			const outputLogRaw: unknown[] = Array.isArray(output.coordinationLog)
-				? (output.coordinationLog as unknown[])
-				: [];
+			const outputLogRaw = Array.isArray(output.coordinationLog) ? output.coordinationLog : [];
 			const outputCoordinationLog = outputLogRaw.filter(isCoordinationLogEntry);
 
 			return {

--- a/packages/@n8n/ai-workflow-builder.ee/src/multi-agent-workflow-subgraphs.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/multi-agent-workflow-subgraphs.ts
@@ -99,10 +99,10 @@ function createSubgraphNodeHandler<
 				metadata: { phase } as { phase: 'discovery' } | { phase: 'builder' },
 			};
 
-			// Extract coordination log from output, ensuring it's an array
-			const outputCoordinationLog = Array.isArray(output.coordinationLog)
-				? output.coordinationLog
-				: [];
+			// Extract coordination log from output as properly typed array
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+			const outputLogRaw = Array.isArray(output.coordinationLog) ? output.coordinationLog : [];
+			const outputCoordinationLog = outputLogRaw as Array<typeof inProgressEntry>;
 
 			return {
 				...output,

--- a/packages/@n8n/ai-workflow-builder.ee/src/types/coordination.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/types/coordination.ts
@@ -7,6 +7,20 @@
 
 export type SubgraphPhase = 'discovery' | 'builder' | 'state_management' | 'responder';
 
+const SUBGRAPH_PHASES: readonly SubgraphPhase[] = [
+	'discovery',
+	'builder',
+	'state_management',
+	'responder',
+];
+
+/**
+ * Type guard to check if a string is a valid SubgraphPhase.
+ */
+export function isSubgraphPhase(value: string): value is SubgraphPhase {
+	return SUBGRAPH_PHASES.includes(value as SubgraphPhase);
+}
+
 /**
  * Entry in the coordination log tracking subgraph completion.
  */

--- a/packages/@n8n/ai-workflow-builder.ee/src/types/coordination.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/types/coordination.ts
@@ -5,7 +5,7 @@
  * and enable deterministic routing without polluting the messages array.
  */
 
-export type SubgraphPhase = 'discovery' | 'builder' | 'state_management';
+export type SubgraphPhase = 'discovery' | 'builder' | 'state_management' | 'responder';
 
 /**
  * Entry in the coordination log tracking subgraph completion.
@@ -34,6 +34,7 @@ export type CoordinationMetadata =
 	| DiscoveryMetadata
 	| BuilderMetadata
 	| StateManagementMetadata
+	| ResponderMetadata
 	| ErrorMetadata;
 
 export interface DiscoveryMetadata {
@@ -78,6 +79,12 @@ export interface StateManagementMetadata {
 	messagesRemoved?: number;
 }
 
+export interface ResponderMetadata {
+	phase: 'responder';
+	/** Length of the generated response */
+	responseLength: number;
+}
+
 /**
  * Helper functions to create typed metadata objects.
  * These eliminate the need for type assertions when creating coordination log entries.
@@ -98,4 +105,8 @@ export function createStateManagementMetadata(
 	data: Omit<StateManagementMetadata, 'phase'>,
 ): StateManagementMetadata {
 	return { phase: 'state_management', ...data };
+}
+
+export function createResponderMetadata(data: Omit<ResponderMetadata, 'phase'>): ResponderMetadata {
+	return { phase: 'responder', ...data };
 }

--- a/packages/@n8n/ai-workflow-builder.ee/src/utils/coordination-log.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/utils/coordination-log.ts
@@ -13,6 +13,7 @@ import type {
 	DiscoveryMetadata,
 	BuilderMetadata,
 	StateManagementMetadata,
+	ResponderMetadata,
 } from '../types/coordination';
 
 export type RoutingDecision = 'discovery' | 'builder' | 'responder';
@@ -75,7 +76,7 @@ export function getPhaseMetadata(
 export function getPhaseMetadata(
 	log: CoordinationLogEntry[],
 	phase: SubgraphPhase,
-): DiscoveryMetadata | BuilderMetadata | StateManagementMetadata | null {
+): DiscoveryMetadata | BuilderMetadata | StateManagementMetadata | ResponderMetadata | null {
 	const entry = getPhaseEntry(log, phase);
 	if (!entry) return null;
 


### PR DESCRIPTION
## Summary                     
In this PR I've added a method to output a CSV of vital information from an evaluation run (matrix or spec) with the goal of allowing multiple runs with easy local comparison. The columns focus on judge output, latency, token usage and the prompt used for the generation.
                                                                                                   
- Add `--output-csv <filename>` option to export evaluation results in a human-readable, diffable CSV format                      
- Track token usage (input/output tokens) during workflow generation                                                              
- CSV includes fixed columns (prompt, overall_score, status, latency, tokens) plus LLM judge metric scores with detail comments   
- Results are sorted by prompt for consistent ordering across runs

This PR also introduces some new statistics to the output summaries and to langsmith, recording the latency per stage of the process (discovery, builder and responder) as well as a count of nodes in the finished workflow.
<img width="841" height="98" alt="image" src="https://github.com/user-attachments/assets/2d71e05f-3cb8-483b-83ae-cf3445457777" />

Addresses: https://linear.app/n8n/issue/AI-1974

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
