### PR TITLE
feat: Implement Secret Providers Types API endpoints (no-changelog)

### DIFF
--- a/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-providers.ee.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-providers.ee.test.ts
@@ -1,0 +1,48 @@
+import { ExternalSecretsProviders } from '@/modules/external-secrets.ee/external-secrets-providers.ee';
+
+describe('ExternalSecretsProviders', () => {
+	const providers = new ExternalSecretsProviders();
+
+	describe('toProviderTypeResponse', () => {
+		it('should map a provider to SecretProviderTypeResponse', () => {
+			const AwsSecretsManager = providers.getProvider('awsSecretsManager');
+			const provider = new AwsSecretsManager();
+
+			const result = providers.toProviderTypeResponse(provider);
+
+			expect(result).toEqual({
+				type: 'awsSecretsManager',
+				displayName: 'AWS Secrets Manager',
+				icon: 'awsSecretsManager',
+				properties: provider.properties,
+			});
+		});
+
+		it('should map vault provider correctly', () => {
+			const VaultProvider = providers.getProvider('vault');
+			const provider = new VaultProvider();
+
+			const result = providers.toProviderTypeResponse(provider);
+
+			expect(result).toEqual({
+				type: 'vault',
+				displayName: 'HashiCorp Vault',
+				icon: 'vault',
+				properties: provider.properties,
+			});
+		});
+
+		it('should include all required fields', () => {
+			const AwsSecretsManager = providers.getProvider('awsSecretsManager');
+			const provider = new AwsSecretsManager();
+
+			const result = providers.toProviderTypeResponse(provider);
+
+			expect(result).toHaveProperty('type');
+			expect(result).toHaveProperty('displayName');
+			expect(result).toHaveProperty('icon');
+			expect(result).toHaveProperty('properties');
+			expect(Array.isArray(result.properties)).toBe(true);
+		});
+	});
+});

--- a/packages/cli/src/modules/external-secrets.ee/external-secrets-providers.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets-providers.ee.ts
@@ -1,3 +1,4 @@
+import type { SecretProviderTypeResponse, SecretsProviderType } from '@n8n/api-types';
 import { Service } from '@n8n/di';
 
 import { AwsSecretsManager } from './providers/aws-secrets-manager';
@@ -27,5 +28,14 @@ export class ExternalSecretsProviders {
 
 	getAllProviders() {
 		return this.providers;
+	}
+
+	toProviderTypeResponse(provider: SecretsProvider): SecretProviderTypeResponse {
+		return {
+			type: provider.name as SecretsProviderType,
+			displayName: provider.displayName,
+			icon: provider.name,
+			properties: provider.properties,
+		};
 	}
 }

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-autocomplete.controller.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-autocomplete.controller.ee.ts
@@ -19,6 +19,7 @@ export class SecretProvidersAutocompleteController {
 	@Middleware()
 	checkFeatureFlag(_req: Request, _res: Response, next: NextFunction) {
 		if (!this.config.externalSecretsForProjects) {
+			this.logger.warn('External secrets for projects feature is not enabled');
 			throw new BadRequestError('External secrets for projects feature is not enabled');
 		}
 		next();

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.controller.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.controller.ee.ts
@@ -36,6 +36,7 @@ export class SecretProvidersConnectionsController {
 	@Middleware()
 	checkFeatureFlag(_req: Request, _res: Response, next: NextFunction) {
 		if (!this.config.externalSecretsForProjects) {
+			this.logger.warn('External secrets for projects feature is not enabled');
 			throw new BadRequestError('External secrets for projects feature is not enabled');
 		}
 		next();

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-project.controller.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-project.controller.ee.ts
@@ -19,6 +19,7 @@ export class SecretProvidersProjectController {
 	@Middleware()
 	checkFeatureFlag(_req: Request, _res: Response, next: NextFunction) {
 		if (!this.config.externalSecretsForProjects) {
+			this.logger.warn('External secrets for projects feature is not enabled');
 			throw new BadRequestError('External secrets for projects feature is not enabled');
 		}
 		next();

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-types.controller.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-types.controller.ee.ts
@@ -1,4 +1,4 @@
-import type { SecretProviderTypeResponse, SecretsProviderType } from '@n8n/api-types';
+import type { SecretProviderTypeResponse } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import type { AuthenticatedRequest } from '@n8n/db';
 import { Get, GlobalScope, Middleware, Param, RestController } from '@n8n/decorators';
@@ -9,7 +9,6 @@ import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
 import { ExternalSecretsProviders } from './external-secrets-providers.ee';
 import { ExternalSecretsConfig } from './external-secrets.config';
-import { SecretsProvider } from './types';
 
 @RestController('/secret-providers/types')
 export class SecretProvidersTypesController {
@@ -34,9 +33,9 @@ export class SecretProvidersTypesController {
 	listSecretProviderTypes(): SecretProviderTypeResponse[] {
 		this.logger.debug('List provider connection types');
 		const allProviders = this.secretsProviders.getAllProviders();
-		return Object.entries(allProviders).map(([_name, providerClass]) => {
+		return Object.values(allProviders).map((providerClass) => {
 			const provider = new providerClass();
-			return this.mapProviderToSecretProviderTypeResponse(provider);
+			return this.secretsProviders.toProviderTypeResponse(provider);
 		});
 	}
 
@@ -53,17 +52,6 @@ export class SecretProvidersTypesController {
 		}
 		const providerClass = this.secretsProviders.getProvider(type);
 		const provider = new providerClass();
-		return this.mapProviderToSecretProviderTypeResponse(provider);
-	}
-
-	private mapProviderToSecretProviderTypeResponse(
-		provider: SecretsProvider,
-	): SecretProviderTypeResponse {
-		return {
-			type: provider.name as SecretsProviderType,
-			displayName: provider.displayName,
-			icon: provider.name,
-			properties: provider.properties,
-		};
+		return this.secretsProviders.toProviderTypeResponse(provider);
 	}
 }

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-types.controller.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-types.controller.ee.ts
@@ -1,16 +1,21 @@
+import type { SecretProviderTypeResponse, SecretsProviderType } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
-import { Get, GlobalScope, RestController, Middleware } from '@n8n/decorators';
-import { Request, Response, NextFunction } from 'express';
+import { Get, GlobalScope, Param, RestController, Middleware } from '@n8n/decorators';
+import type { NextFunction, Request, Response } from 'express';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
+import { ExternalSecretsProviders } from './external-secrets-providers.ee';
 import { ExternalSecretsConfig } from './external-secrets.config';
+import { SecretsProvider } from './types';
 
 @RestController('/secret-providers/types')
 export class SecretProvidersTypesController {
 	constructor(
 		private readonly config: ExternalSecretsConfig,
 		private readonly logger: Logger,
+		private readonly secretsProviders: ExternalSecretsProviders,
 	) {
 		this.logger = this.logger.scoped('external-secrets');
 	}
@@ -25,17 +30,35 @@ export class SecretProvidersTypesController {
 
 	@Get('/')
 	@GlobalScope('externalSecretsProvider:list')
-	async listSecretProviderTypes() {
+	listSecretProviderTypes(): SecretProviderTypeResponse[] {
 		this.logger.debug('List provider connection types');
-		//TODO implement
-		return await Promise.resolve([]);
+		const allProviders = this.secretsProviders.getAllProviders();
+		return Object.entries(allProviders).map(([_name, providerClass]) => {
+			const provider = new providerClass();
+			return this.mapProviderToSecretProviderTypeResponse(provider);
+		});
 	}
 
 	@Get('/:type')
 	@GlobalScope('externalSecretsProvider:list')
-	async getSecretProviderType() {
-		this.logger.debug('Get provider connection type');
-		//TODO implement
-		return await Promise.resolve({});
+	getSecretProviderType(@Param('type') type: string): SecretProviderTypeResponse {
+		this.logger.debug('Get provider connection type', { type });
+		if (!this.secretsProviders.hasProvider(type)) {
+			throw new NotFoundError(`Provider type "${type}" not found`);
+		}
+		const providerClass = this.secretsProviders.getProvider(type);
+		const provider = new providerClass();
+		return this.mapProviderToSecretProviderTypeResponse(provider);
+	}
+
+	private mapProviderToSecretProviderTypeResponse(
+		provider: SecretsProvider,
+	): SecretProviderTypeResponse {
+		return {
+			type: provider.name as SecretsProviderType,
+			displayName: provider.displayName,
+			icon: provider.name,
+			properties: provider.properties,
+		};
 	}
 }

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-types.controller.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-types.controller.ee.ts
@@ -23,6 +23,7 @@ export class SecretProvidersTypesController {
 	@Middleware()
 	checkFeatureFlag(_req: Request, _res: Response, next: NextFunction) {
 		if (!this.config.externalSecretsForProjects) {
+			this.logger.warn('External secrets for projects feature is not enabled');
 			throw new BadRequestError('External secrets for projects feature is not enabled');
 		}
 		next();

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-types.controller.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-types.controller.ee.ts
@@ -1,6 +1,7 @@
 import type { SecretProviderTypeResponse, SecretsProviderType } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
-import { Get, GlobalScope, Param, RestController, Middleware } from '@n8n/decorators';
+import type { AuthenticatedRequest } from '@n8n/db';
+import { Get, GlobalScope, Middleware, Param, RestController } from '@n8n/decorators';
 import type { NextFunction, Request, Response } from 'express';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
@@ -41,7 +42,11 @@ export class SecretProvidersTypesController {
 
 	@Get('/:type')
 	@GlobalScope('externalSecretsProvider:list')
-	getSecretProviderType(@Param('type') type: string): SecretProviderTypeResponse {
+	getSecretProviderType(
+		_req: AuthenticatedRequest,
+		_res: Response,
+		@Param('type') type: string,
+	): SecretProviderTypeResponse {
 		this.logger.debug('Get provider connection type', { type });
 		if (!this.secretsProviders.hasProvider(type)) {
 			throw new NotFoundError(`Provider type "${type}" not found`);

--- a/packages/cli/test/integration/external-secrets/external-secrets.api.test.ts
+++ b/packages/cli/test/integration/external-secrets/external-secrets.api.test.ts
@@ -1,7 +1,9 @@
 import { LicenseState } from '@n8n/backend-common';
-import { mockLogger, mockInstance } from '@n8n/backend-test-utils';
+import { mockInstance, mockLogger } from '@n8n/backend-test-utils';
+import { SecretsProviderConnectionRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
+import { Cipher } from 'n8n-core';
 import type { IDataObject } from 'n8n-workflow';
 
 import { CREDENTIAL_BLANKING_VALUE } from '@/constants';
@@ -28,8 +30,6 @@ import {
 import { createOwner, createUser } from '../shared/db/users';
 import type { SuperAgentTest } from '../shared/types';
 import { setupTestServer } from '../shared/utils';
-import { Cipher } from 'n8n-core';
-import { SecretsProviderConnectionRepository } from '@n8n/db';
 
 let authOwnerAgent: SuperAgentTest;
 let authMemberAgent: SuperAgentTest;

--- a/packages/cli/test/integration/external-secrets/external-secrets.module.test.ts
+++ b/packages/cli/test/integration/external-secrets/external-secrets.module.test.ts
@@ -56,10 +56,11 @@ describe('ExternalSecretsModule', () => {
 
 			const settingsRepository = Container.get(SettingsRepository);
 			const cipher = Container.get(Cipher);
-			const config = Container.get(ExternalSecretsConfig);
-			module = Container.get(ExternalSecretsModule);
 
-			(config as any).externalSecretsForProjects = false;
+			const config = Container.get(ExternalSecretsConfig);
+			config.externalSecretsForProjects = false;
+
+			module = Container.get(ExternalSecretsModule);
 
 			const settings = {
 				dummy: {
@@ -137,10 +138,11 @@ describe('ExternalSecretsModule', () => {
 
 			connectionRepository = Container.get(SecretsProviderConnectionRepository);
 			cipher = Container.get(Cipher);
-			const config = Container.get(ExternalSecretsConfig);
-			module = Container.get(ExternalSecretsModule);
 
-			(config as any).externalSecretsForProjects = true;
+			const config = Container.get(ExternalSecretsConfig);
+			config.externalSecretsForProjects = true;
+
+			module = Container.get(ExternalSecretsModule);
 
 			const encryptedSettings = cipher.encrypt(JSON.stringify({}));
 			await connectionRepository.save({

--- a/packages/cli/test/integration/external-secrets/secret-providers-types.api.test.ts
+++ b/packages/cli/test/integration/external-secrets/secret-providers-types.api.test.ts
@@ -18,25 +18,14 @@ import { createAdmin, createMember, createOwner } from '../shared/db/users';
 import type { SuperAgentTest } from '../shared/types';
 import { setupTestServer } from '../shared/utils';
 
-const mockProvidersInstance = new MockProviders();
-mockInstance(ExternalSecretsProviders, mockProvidersInstance);
-
-const licenseMock = mock<LicenseState>();
-licenseMock.isLicensed.mockReturnValue(true);
-Container.set(LicenseState, licenseMock);
-
-mockInstance(ExternalSecretsConfig, {
-	externalSecretsForProjects: true,
-	updateInterval: 300,
-	preferGet: false,
-});
-
 describe('Secret Providers Types API', () => {
 	const testServer = setupTestServer({
 		endpointGroups: ['externalSecrets'],
 		enabledFeatures: ['feat:externalSecrets'],
 		modules: ['external-secrets'],
 	});
+
+	const mockProvidersInstance = new MockProviders();
 
 	let ownerAgent: SuperAgentTest;
 	let adminAgent: SuperAgentTest;
@@ -45,6 +34,16 @@ describe('Secret Providers Types API', () => {
 	beforeAll(async () => {
 		await testModules.loadModules(['external-secrets']);
 		await testDb.init();
+
+		mockInstance(ExternalSecretsProviders, mockProvidersInstance);
+
+		const licenseMock = mock<LicenseState>();
+		licenseMock.isLicensed.mockReturnValue(true);
+		Container.set(LicenseState, licenseMock);
+
+		mockInstance(ExternalSecretsConfig, {
+			externalSecretsForProjects: true,
+		});
 
 		Container.set(Logger, mockLogger());
 

--- a/packages/cli/test/integration/external-secrets/secret-providers-types.api.test.ts
+++ b/packages/cli/test/integration/external-secrets/secret-providers-types.api.test.ts
@@ -1,0 +1,56 @@
+describe('Secret Providers Types API', () => {
+	describe('Feature Flag', () => {
+		it('should return 400 when externalSecretsForProjects feature is disabled');
+	});
+
+	describe('GET /secret-providers/types', () => {
+		describe('Authorization', () => {
+			it('should authorize owner to list provider types');
+			it('should authorize global admin to list provider types');
+			it('should refuse member to list provider types');
+		});
+
+		describe('with providers', () => {
+			beforeAll(async () => {
+				// call the endpoint
+			});
+
+			it('should return all available provider types when providers exist');
+			it('should return multiple provider types when multiple are registered');
+			it(
+				'should return correct structure with type, displayName, icon, and properties for each provider',
+			);
+		});
+
+		describe('without providers', () => {
+			it('should return empty array when no providers are registered');
+		});
+	});
+
+	describe('GET /secret-providers/types/:type', () => {
+		describe('Authorization', () => {
+			it('should authorize owner to get specific provider type');
+			it('should authorize global admin to get specific provider type');
+			it('should refuse member to get provider type');
+		});
+
+		describe('with provider', () => {
+			beforeAll(async () => {
+				// call the endpoint
+			});
+
+			it('should return provider type details for valid existing type');
+			it('should return correct structure with type, displayName, icon, and properties');
+			it('should return provider-specific properties matching the provider');
+		});
+
+		describe('without provider', () => {
+			beforeAll(async () => {
+				// call the endpoint
+			});
+
+			it('should return 404 for non-existent provider type');
+			it('should return 404 with appropriate error message');
+		});
+	});
+});

--- a/packages/cli/test/integration/external-secrets/secret-providers-types.api.test.ts
+++ b/packages/cli/test/integration/external-secrets/secret-providers-types.api.test.ts
@@ -1,13 +1,77 @@
+import { LicenseState, Logger } from '@n8n/backend-common';
+import { mockInstance, mockLogger, testDb, testModules } from '@n8n/backend-test-utils';
+import { Container } from '@n8n/di';
+import { mock } from 'jest-mock-extended';
+
+import { ExternalSecretsProviders } from '@/modules/external-secrets.ee/external-secrets-providers.ee';
+import { ExternalSecretsConfig } from '@/modules/external-secrets.ee/external-secrets.config';
+
+import { DummyProvider, MockProviders } from '../../shared/external-secrets/utils';
+import { createOwner } from '../shared/db/users';
+import type { SuperAgentTest } from '../shared/types';
+import { setupTestServer } from '../shared/utils';
+
+const mockProvidersInstance = new MockProviders();
+mockInstance(ExternalSecretsProviders, mockProvidersInstance);
+
+const licenseMock = mock<LicenseState>();
+licenseMock.isLicensed.mockReturnValue(true);
+Container.set(LicenseState, licenseMock);
+
+mockInstance(ExternalSecretsConfig, {
+	externalSecretsForProjects: false,
+	updateInterval: 300,
+	preferGet: false,
+});
+
 describe('Secret Providers Types API', () => {
+	const testServer = setupTestServer({
+		endpointGroups: ['externalSecrets'],
+		enabledFeatures: ['feat:externalSecrets'],
+		modules: ['external-secrets'],
+	});
+
+	let ownerAgent: SuperAgentTest;
+
+	beforeAll(async () => {
+		await testModules.loadModules(['external-secrets']);
+		await testDb.init();
+
+		Container.set(Logger, mockLogger());
+
+		const owner = await createOwner();
+		ownerAgent = testServer.authAgentFor(owner);
+	});
+
+	afterAll(async () => {
+		await testDb.terminate();
+	});
+
 	describe('Feature Flag', () => {
-		it('should return 400 when externalSecretsForProjects feature is disabled');
+		it('should return 400 when externalSecretsForProjects feature is disabled', async () => {
+			const config = Container.get(ExternalSecretsConfig);
+			config.externalSecretsForProjects = false;
+
+			mockProvidersInstance.setProviders({
+				dummy: DummyProvider,
+			});
+
+			const response = await ownerAgent.get('/secret-providers/types');
+
+			// TODO: Check why middleware response is 500 instead of 400
+			expect(response.status).toBe(400);
+			expect(response.body).toEqual({
+				code: 400,
+				message: 'External secrets for projects feature is not enabled',
+			});
+		});
 	});
 
 	describe('GET /secret-providers/types', () => {
 		describe('Authorization', () => {
-			it('should authorize owner to list provider types');
-			it('should authorize global admin to list provider types');
-			it('should refuse member to list provider types');
+			it.todo('should authorize owner to list provider types');
+			it.todo('should authorize global admin to list provider types');
+			it.todo('should refuse member to list provider types');
 		});
 
 		describe('with providers', () => {
@@ -15,23 +79,23 @@ describe('Secret Providers Types API', () => {
 				// call the endpoint
 			});
 
-			it('should return all available provider types when providers exist');
-			it('should return multiple provider types when multiple are registered');
-			it(
+			it.todo('should return all available provider types when providers exist');
+			it.todo('should return multiple provider types when multiple are registered');
+			it.todo(
 				'should return correct structure with type, displayName, icon, and properties for each provider',
 			);
 		});
 
 		describe('without providers', () => {
-			it('should return empty array when no providers are registered');
+			it.todo('should return empty array when no providers are registered');
 		});
 	});
 
 	describe('GET /secret-providers/types/:type', () => {
 		describe('Authorization', () => {
-			it('should authorize owner to get specific provider type');
-			it('should authorize global admin to get specific provider type');
-			it('should refuse member to get provider type');
+			it.todo('should authorize owner to get specific provider type');
+			it.todo('should authorize global admin to get specific provider type');
+			it.todo('should refuse member to get provider type');
 		});
 
 		describe('with provider', () => {
@@ -39,9 +103,9 @@ describe('Secret Providers Types API', () => {
 				// call the endpoint
 			});
 
-			it('should return provider type details for valid existing type');
-			it('should return correct structure with type, displayName, icon, and properties');
-			it('should return provider-specific properties matching the provider');
+			it.todo('should return provider type details for valid existing type');
+			it.todo('should return correct structure with type, displayName, icon, and properties');
+			it.todo('should return provider-specific properties matching the provider');
 		});
 
 		describe('without provider', () => {
@@ -49,8 +113,8 @@ describe('Secret Providers Types API', () => {
 				// call the endpoint
 			});
 
-			it('should return 404 for non-existent provider type');
-			it('should return 404 with appropriate error message');
+			it.todo('should return 404 for non-existent provider type');
+			it.todo('should return 404 with appropriate error message');
 		});
 	});
 });

--- a/packages/cli/test/integration/external-secrets/secret-providers-types.api.test.ts
+++ b/packages/cli/test/integration/external-secrets/secret-providers-types.api.test.ts
@@ -18,14 +18,23 @@ import { createAdmin, createMember, createOwner } from '../shared/db/users';
 import type { SuperAgentTest } from '../shared/types';
 import { setupTestServer } from '../shared/utils';
 
+const mockProvidersInstance = new MockProviders();
+mockInstance(ExternalSecretsProviders, mockProvidersInstance);
+
+const licenseMock = mock<LicenseState>();
+licenseMock.isLicensed.mockReturnValue(true);
+Container.set(LicenseState, licenseMock);
+
+mockInstance(ExternalSecretsConfig, {
+	externalSecretsForProjects: true,
+});
+
 describe('Secret Providers Types API', () => {
 	const testServer = setupTestServer({
 		endpointGroups: ['externalSecrets'],
 		enabledFeatures: ['feat:externalSecrets'],
 		modules: ['external-secrets'],
 	});
-
-	const mockProvidersInstance = new MockProviders();
 
 	let ownerAgent: SuperAgentTest;
 	let adminAgent: SuperAgentTest;
@@ -34,16 +43,6 @@ describe('Secret Providers Types API', () => {
 	beforeAll(async () => {
 		await testModules.loadModules(['external-secrets']);
 		await testDb.init();
-
-		mockInstance(ExternalSecretsProviders, mockProvidersInstance);
-
-		const licenseMock = mock<LicenseState>();
-		licenseMock.isLicensed.mockReturnValue(true);
-		Container.set(LicenseState, licenseMock);
-
-		mockInstance(ExternalSecretsConfig, {
-			externalSecretsForProjects: true,
-		});
 
 		Container.set(Logger, mockLogger());
 

--- a/packages/cli/test/integration/external-secrets/secret-providers-types.api.test.ts
+++ b/packages/cli/test/integration/external-secrets/secret-providers-types.api.test.ts
@@ -26,7 +26,7 @@ licenseMock.isLicensed.mockReturnValue(true);
 Container.set(LicenseState, licenseMock);
 
 mockInstance(ExternalSecretsConfig, {
-	externalSecretsForProjects: false,
+	externalSecretsForProjects: true,
 	updateInterval: 300,
 	preferGet: false,
 });
@@ -62,14 +62,9 @@ describe('Secret Providers Types API', () => {
 		await testDb.terminate();
 	});
 
-	beforeAll(async () => {
-		const config = Container.get(ExternalSecretsConfig);
-		config.externalSecretsForProjects = true;
-	});
-
 	describe('GET /secret-providers/types', () => {
 		describe('Authorization', () => {
-			beforeAll(async () => {
+			beforeAll(() => {
 				mockProvidersInstance.setProviders({
 					dummy: DummyProvider,
 				});
@@ -147,7 +142,7 @@ describe('Secret Providers Types API', () => {
 				response = await ownerAgent.get('/secret-providers/types');
 			});
 
-			it('should return all available provider typesp', async () => {
+			it('should return all available provider types', () => {
 				const { data } = response.body as { data: SecretProviderTypeResponse[] };
 				expect(response.status).toBe(200);
 				expect(data).toBeInstanceOf(Array);
@@ -192,7 +187,7 @@ describe('Secret Providers Types API', () => {
 
 	describe('GET /secret-providers/types/:type', () => {
 		describe('Authorization', () => {
-			beforeAll(async () => {
+			beforeAll(() => {
 				mockProvidersInstance.setProviders({
 					dummy: DummyProvider,
 				});

--- a/packages/cli/test/shared/external-secrets/utils.ts
+++ b/packages/cli/test/shared/external-secrets/utils.ts
@@ -296,9 +296,13 @@ export class TestFailProvider extends SecretsProvider {
 export function createDummyProvider({
 	name,
 	secrets,
+	displayName,
+	properties,
 }: {
 	name: string;
+	displayName?: string;
 	secrets?: Record<string, string>;
+	properties?: INodeProperties[];
 }): { new (): SecretsProvider } {
 	const defaultSecrets = secrets ?? {
 		test1: 'value1',
@@ -307,9 +311,9 @@ export function createDummyProvider({
 
 	class FreshProvider extends SecretsProvider {
 		name = name;
-		displayName = name;
+		displayName = displayName ?? name;
 
-		properties: INodeProperties[] = [
+		properties: INodeProperties[] = properties ?? [
 			{
 				name: 'username',
 				displayName: 'Username',

--- a/packages/cli/test/shared/external-secrets/utils.ts
+++ b/packages/cli/test/shared/external-secrets/utils.ts
@@ -1,27 +1,16 @@
 import type { IDataObject, INodeProperties } from 'n8n-workflow';
 
+import { ExternalSecretsProviders } from '@/modules/external-secrets.ee/external-secrets-providers.ee';
 import { SecretsProvider } from '@/modules/external-secrets.ee/types';
 import type { SecretsProviderSettings } from '@/modules/external-secrets.ee/types';
 
-export class MockProviders {
-	providers: Record<string, { new (): SecretsProvider }> = {
+export class MockProviders extends ExternalSecretsProviders {
+	override providers: Record<string, { new (): SecretsProvider }> = {
 		dummy: DummyProvider,
 	};
 
 	setProviders(providers: Record<string, { new (): SecretsProvider }>) {
 		this.providers = providers;
-	}
-
-	getProvider(name: string): { new (): SecretsProvider } {
-		return this.providers[name];
-	}
-
-	hasProvider(name: string) {
-		return name in this.providers;
-	}
-
-	getAllProviders() {
-		return this.providers;
 	}
 }
 

--- a/packages/cli/test/shared/external-secrets/utils.ts
+++ b/packages/cli/test/shared/external-secrets/utils.ts
@@ -262,3 +262,109 @@ export class TestFailProvider extends SecretsProvider {
 		return Object.keys(this.secrets);
 	}
 }
+
+/**
+ * Factory function to create a fresh provider class with a custom name.
+ * Each call returns a new class with its own implementation, allowing you to spy on instance methods.
+ *
+ * @param name - The name for the provider (used as the provider's identifier)
+ * @param secrets - Optional secrets list to use as default secrets (used in both initial state and update)
+ * @returns A new SecretsProvider class constructor with its own implementation
+ *
+ * @example
+ * // Create a fresh provider class
+ * const TestProvider = createDummyProvider({ name: 'test_provider' });
+ * const provider = new TestProvider();
+ *
+ * // Create with pre-populated secrets
+ * const ProviderWithSecrets = createDummyProvider({
+ *   name: 'my_provider',
+ *   secrets: { key1: 'value1', key2: 'value2' }
+ * });
+ *
+ * // Spy on instance methods
+ * jest.spyOn(provider, 'update');
+ * jest.spyOn(provider, 'getSecret');
+ *
+ * // Use with MockProviders
+ * const mockProviders = new MockProviders();
+ * mockProviders.setProviders({
+ *   provider1: createDummyProvider({ name: 'provider1' }),
+ *   provider2: createDummyProvider({ name: 'provider2', secrets: { foo: 'bar' } }),
+ * });
+ */
+export function createDummyProvider({
+	name,
+	secrets,
+}: {
+	name: string;
+	secrets?: Record<string, string>;
+}): { new (): SecretsProvider } {
+	const defaultSecrets = secrets ?? {
+		test1: 'value1',
+		test2: 'value2',
+	};
+
+	class FreshProvider extends SecretsProvider {
+		name = name;
+		displayName = name;
+
+		properties: INodeProperties[] = [
+			{
+				name: 'username',
+				displayName: 'Username',
+				type: 'string',
+				default: '',
+				required: true,
+			},
+			{
+				name: 'other',
+				displayName: 'Other',
+				type: 'string',
+				default: '',
+			},
+			{
+				name: 'password',
+				displayName: 'Password',
+				type: 'string',
+				default: '',
+				typeOptions: {
+					password: true,
+				},
+			},
+		];
+
+		secrets: Record<string, string> = { ...defaultSecrets };
+
+		_updateSecrets: Record<string, string> = { ...defaultSecrets };
+
+		async init(_settings: SecretsProviderSettings<IDataObject>): Promise<void> {}
+
+		protected async doConnect(): Promise<void> {
+			// Connected successfully - base class will set state
+		}
+
+		async disconnect(): Promise<void> {}
+
+		async update(): Promise<void> {
+			this.secrets = this._updateSecrets;
+		}
+
+		async test(): Promise<[boolean] | [boolean, string]> {
+			return [true];
+		}
+
+		getSecret(name: string): IDataObject | undefined {
+			return this.secrets[name] as unknown as IDataObject | undefined;
+		}
+
+		hasSecret(name: string): boolean {
+			return name in this.secrets;
+		}
+
+		getSecretNames(): string[] {
+			return Object.keys(this.secrets);
+		}
+	}
+	return FreshProvider;
+}


### PR DESCRIPTION
## Summary

Implements two new API endpoints for listing and retrieving secret provider types:

- `GET /secret-providers/types` - Lists all available secret provider types with their configuration properties
- `GET /secret-providers/types/:type` - Retrieves a specific secret provider type by name

Each response includes:
- `type`: Provider identifier
- `displayName`: Human-readable name
- `icon`: Icon identifier  
- `properties`: Configuration properties for the provider

### Testing
The implementation includes comprehensive integration tests covering:
- Authorization checks (owner, admin, member roles)
- Listing providers with various configurations
- Getting specific provider types
- Error handling (404 for non-existent providers)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-120

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)