### PR TITLE
perf(core): Use Map for O(n) execution deduplication

### DIFF
--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -843,40 +843,32 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 			}
 		>,
 	) {
-		return rawExecutionsWithTags.reduce(
-			(
-				acc,
-				{
-					annotation_id: _,
-					annotation_vote: vote,
-					annotation_tags_id: tagId,
-					annotation_tags_name: tagName,
-					...row
-				},
-			) => {
-				const existingExecution = acc.find((e) => e.id === row.id);
+		const map = new Map<string, ExecutionSummary>();
 
-				if (existingExecution) {
-					if (tagId) {
-						existingExecution.annotation = existingExecution.annotation ?? {
-							vote,
-							tags: [] as Array<{ id: string; name: string }>,
-						};
-						existingExecution.annotation.tags.push({ id: tagId, name: tagName });
-					}
-				} else {
-					acc.push({
-						...row,
-						annotation: {
-							vote,
-							tags: tagId ? [{ id: tagId, name: tagName }] : [],
-						},
-					});
-				}
-				return acc;
-			},
-			[] as ExecutionSummary[],
-		);
+		for (const {
+			annotation_id: _,
+			annotation_vote: vote,
+			annotation_tags_id: tagId,
+			annotation_tags_name: tagName,
+			...row
+		} of rawExecutionsWithTags) {
+			let execution = map.get(row.id);
+			if (!execution) {
+				execution = {
+					...row,
+					annotation: { vote, tags: tagId ? [{ id: tagId, name: tagName }] : [] },
+				};
+				map.set(row.id, execution);
+			} else if (tagId) {
+				execution.annotation = execution.annotation ?? {
+					vote,
+					tags: [] as Array<{ id: string; name: string }>,
+				};
+				execution.annotation.tags.push({ id: tagId, name: tagName });
+			}
+		}
+
+		return [...map.values()];
 	}
 
 	async findManyByRangeQuery(query: ExecutionSummaries.RangeQuery): Promise<ExecutionSummary[]> {

--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -843,7 +843,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 			}
 		>,
 	) {
-		const map = new Map<string, ExecutionSummary>();
+		const summariesById = new Map<string, ExecutionSummary>();
 
 		for (const {
 			annotation_id: _,
@@ -852,13 +852,16 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 			annotation_tags_name: tagName,
 			...row
 		} of rawExecutionsWithTags) {
-			let execution = map.get(row.id);
+			let execution = summariesById.get(row.id);
 			if (!execution) {
 				execution = {
 					...row,
-					annotation: { vote, tags: tagId ? [{ id: tagId, name: tagName }] : [] },
+					annotation: {
+						vote,
+						tags: tagId ? [{ id: tagId, name: tagName }] : [],
+					},
 				};
-				map.set(row.id, execution);
+				summariesById.set(row.id, execution);
 			} else if (tagId) {
 				execution.annotation = execution.annotation ?? {
 					vote,
@@ -868,7 +871,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 			}
 		}
 
-		return [...map.values()];
+		return [...summariesById.values()];
 	}
 
 	async findManyByRangeQuery(query: ExecutionSummaries.RangeQuery): Promise<ExecutionSummary[]> {


### PR DESCRIPTION
Replace `acc.find()` with a Map in `reduceExecutionsWithAnnotations`, to bring down execution list deduplication from O(n^2) to O(n). This endpoint is hit on every visit to the executions page and on each poll interval.
