### PR TITLE
fix(editor): Fix ParameterInput formatting breaking existing newlines

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.test.ts
@@ -898,4 +898,70 @@ describe('ParameterInput.vue', () => {
 			expect(mockBuilderState.trackWorkflowBuilderJourney).not.toHaveBeenCalled();
 		});
 	});
+
+	describe('multi-line string handling', () => {
+		test('should replace all newlines with pipes in single-line string display', async () => {
+			const multiLineValue = 'line1\nline2\nline3';
+			const { container } = renderComponent({
+				props: {
+					path: 'description',
+					parameter: createTestNodeProperties({
+						displayName: 'Description',
+						name: 'description',
+						type: 'string',
+					}),
+					modelValue: multiLineValue,
+					expressionEvaluated: undefined,
+				},
+			});
+
+			await nextTick();
+			const input = container.querySelector('input') as HTMLInputElement;
+			await waitFor(() => {
+				expect(input.value).toBe('line1|line2|line3');
+			});
+		});
+
+		test('should preserve newlines in multi-row textarea', async () => {
+			const multiLineValue = 'line1\nline2\nline3';
+			const { container } = renderComponent({
+				props: {
+					path: 'description',
+					parameter: createTestNodeProperties({
+						displayName: 'Description',
+						name: 'description',
+						type: 'string',
+						typeOptions: { rows: 5 },
+					}),
+					modelValue: multiLineValue,
+					expressionEvaluated: undefined,
+				},
+			});
+
+			await nextTick();
+			const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+			expect(textarea.value).toBe(multiLineValue);
+		});
+
+		test('should handle consecutive newlines correctly', async () => {
+			const { container } = renderComponent({
+				props: {
+					path: 'test',
+					parameter: createTestNodeProperties({
+						displayName: 'Test',
+						name: 'test',
+						type: 'string',
+					}),
+					modelValue: 'a\n\n\nb',
+					expressionEvaluated: undefined,
+				},
+			});
+
+			await nextTick();
+			const input = container.querySelector('input') as HTMLInputElement;
+			await waitFor(() => {
+				expect(input.value).toBe('a|||b');
+			});
+		});
+	});
 });

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
@@ -397,7 +397,7 @@ const displayValue = computed(() => {
 	if (returnValue !== undefined && returnValue !== null && props.parameter.type === 'string') {
 		const rows = editorRows.value;
 		if (rows === undefined || rows === 1) {
-			returnValue = (returnValue as string).toString().replace(/\n/, '|');
+			returnValue = (returnValue as string).toString().replace(/\n/g, '|');
 		}
 	}
 
@@ -1064,6 +1064,12 @@ function onResourceLocatorDrop(data: string) {
 }
 
 function onUpdateTextInput(value: string) {
+	if (
+		props.parameter.type === 'string' &&
+		(editorRows.value === undefined || editorRows.value === 1)
+	) {
+		value = value.replace(/\|/g, '\n');
+	}
 	valueChanged(value);
 	onTextInputChange(value);
 }


### PR DESCRIPTION
## Summary

The newline handling logic for the single line input was incomplete

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4717/ndv-editing-a-multi-line-string-in-ndv-removes-newline-characters


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
