### PR TITLE
fix(editor): Fix node suggestion in node creator to always be request node

### DIFF
--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Modes/NodesMode.vue
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Modes/NodesMode.vue
@@ -11,7 +11,6 @@ import type {
 import {
 	TRIGGER_NODE_CREATOR_VIEW,
 	HTTP_REQUEST_NODE_TYPE,
-	WEBHOOK_NODE_TYPE,
 	REGULAR_NODE_CREATOR_VIEW,
 	AI_NODE_CREATOR_VIEW,
 	AI_OTHERS_NODE_CREATOR_VIEW,
@@ -324,7 +323,6 @@ registerKeyHook('MainViewArrowLeft', {
 					:root-view="activeViewStack.rootView"
 					show-icon
 					show-request
-					@add-webhook-node="emit('nodeTypeSelected', [{ type: WEBHOOK_NODE_TYPE }])"
 					@add-http-node="emit('nodeTypeSelected', [{ type: HTTP_REQUEST_NODE_TYPE }])"
 				/>
 			</template>

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Modes/NodesMode.vue
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Modes/NodesMode.vue
@@ -12,6 +12,7 @@ import {
 	TRIGGER_NODE_CREATOR_VIEW,
 	HTTP_REQUEST_NODE_TYPE,
 	REGULAR_NODE_CREATOR_VIEW,
+	WEBHOOK_NODE_TYPE,
 	AI_NODE_CREATOR_VIEW,
 	AI_OTHERS_NODE_CREATOR_VIEW,
 	HITL_SUBCATEGORY,
@@ -324,6 +325,7 @@ registerKeyHook('MainViewArrowLeft', {
 					show-icon
 					show-request
 					@add-http-node="emit('nodeTypeSelected', [{ type: HTTP_REQUEST_NODE_TYPE }])"
+					@add-webhook-node="emit('nodeTypeSelected', [{ type: WEBHOOK_NODE_TYPE }])"
 				/>
 			</template>
 		</ItemsRenderer>

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Modes/NodesMode.vue
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Modes/NodesMode.vue
@@ -11,8 +11,8 @@ import type {
 import {
 	TRIGGER_NODE_CREATOR_VIEW,
 	HTTP_REQUEST_NODE_TYPE,
-	REGULAR_NODE_CREATOR_VIEW,
 	WEBHOOK_NODE_TYPE,
+	REGULAR_NODE_CREATOR_VIEW,
 	AI_NODE_CREATOR_VIEW,
 	AI_OTHERS_NODE_CREATOR_VIEW,
 	HITL_SUBCATEGORY,
@@ -324,8 +324,8 @@ registerKeyHook('MainViewArrowLeft', {
 					:root-view="activeViewStack.rootView"
 					show-icon
 					show-request
-					@add-http-node="emit('nodeTypeSelected', [{ type: HTTP_REQUEST_NODE_TYPE }])"
 					@add-webhook-node="emit('nodeTypeSelected', [{ type: WEBHOOK_NODE_TYPE }])"
+					@add-http-node="emit('nodeTypeSelected', [{ type: HTTP_REQUEST_NODE_TYPE }])"
 				/>
 			</template>
 		</ItemsRenderer>

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Panel/NoResults.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Panel/NoResults.test.ts
@@ -1,0 +1,85 @@
+import { cleanup, fireEvent, screen } from '@testing-library/vue';
+
+import { createComponentRenderer } from '@/__tests__/render';
+import {
+	REQUEST_NODE_FORM_URL,
+	REGULAR_NODE_CREATOR_VIEW,
+	TRIGGER_NODE_CREATOR_VIEW,
+} from '@/app/constants';
+
+import NoResults from './NoResults.vue';
+
+const renderComponent = createComponentRenderer(NoResults, {
+	global: {
+		stubs: {
+			NoResultsIcon: {
+				template: '<div data-test-id="no-results-icon" />',
+			},
+			N8nIcon: {
+				template: '<span data-test-id="n8n-icon" />',
+				props: ['icon', 'title'],
+			},
+			N8nLink: {
+				template:
+					'<a :href="href" data-test-id="n8n-link" @click="$emit(\'click\', $event)"><slot /></a>',
+				props: ['to'],
+				emits: ['click'],
+				computed: {
+					href() {
+						return typeof this.to === 'string' ? this.to : '#';
+					},
+				},
+			},
+		},
+	},
+});
+
+describe('NoResults', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('should render icon only when showIcon is true', () => {
+		renderComponent({ props: { showIcon: true } });
+		expect(screen.getByTestId('no-results-icon')).toBeInTheDocument();
+
+		cleanup();
+		renderComponent({ props: { showIcon: false } });
+		expect(screen.queryByTestId('no-results-icon')).not.toBeInTheDocument();
+	});
+
+	it('should render Regular view action and emit addHttpNode on click', async () => {
+		const wrapper = renderComponent({
+			props: { rootView: REGULAR_NODE_CREATOR_VIEW, showRequest: false, showIcon: false },
+		});
+
+		expect(screen.getByText('HTTP Request')).toBeInTheDocument();
+		expect(screen.queryByText('Webhook')).not.toBeInTheDocument();
+
+		await fireEvent.click(screen.getByText('HTTP Request'));
+		expect(wrapper.emitted('addHttpNode')).toHaveLength(1);
+	});
+
+	it('should render Trigger view actions and emit addWebhookNode/addHttpNode on click', async () => {
+		const wrapper = renderComponent({
+			props: { rootView: TRIGGER_NODE_CREATOR_VIEW, showRequest: false, showIcon: false },
+		});
+
+		expect(screen.getByText('Webhook')).toBeInTheDocument();
+		expect(screen.getByText('HTTP Request')).toBeInTheDocument();
+
+		await fireEvent.click(screen.getByText('Webhook'));
+		await fireEvent.click(screen.getByText('HTTP Request'));
+
+		expect(wrapper.emitted('addWebhookNode')).toHaveLength(1);
+		expect(wrapper.emitted('addHttpNode')).toHaveLength(1);
+	});
+
+	it('should render request section when showRequest is true, linking to the request form', () => {
+		renderComponent({ props: { showRequest: true, showIcon: false } });
+
+		expect(screen.getByText('Want us to make it faster?')).toBeInTheDocument();
+		const link = screen.getByText('Request the node').closest('a');
+		expect(link).toHaveAttribute('href', REQUEST_NODE_FORM_URL);
+	});
+});

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Panel/NoResults.vue
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Panel/NoResults.vue
@@ -36,11 +36,13 @@ const i18n = useI18n();
 				:class="$style.action"
 			>
 				{{ i18n.baseText('nodeCreator.noResults.dontWorryYouCanProbablyDoItWithThe') }}
-				<N8nLink v-if="rootView === REGULAR_NODE_CREATOR_VIEW" @click="$emit('addHttpNode')">
-					{{ i18n.baseText('nodeCreator.noResults.httpRequest') }}
-				</N8nLink>
-
-				<N8nLink v-if="rootView === TRIGGER_NODE_CREATOR_VIEW" @click="$emit('addHttpNode')">
+				<template v-if="rootView === TRIGGER_NODE_CREATOR_VIEW">
+					<N8nLink @click="$emit('addWebhookNode')">
+						{{ i18n.baseText('nodeCreator.noResults.webhook') }}
+					</N8nLink>
+					{{ `${i18n.baseText('nodeCreator.noResults.or')} ` }}
+				</template>
+				<N8nLink @click="$emit('addHttpNode')">
 					{{ i18n.baseText('nodeCreator.noResults.httpRequest') }}
 				</N8nLink>
 				{{ i18n.baseText('nodeCreator.noResults.node') }}
@@ -51,8 +53,7 @@ const i18n = useI18n();
 			<p v-text="i18n.baseText('nodeCreator.noResults.wantUsToMakeItFaster')" />
 			<div>
 				<N8nLink :to="REQUEST_NODE_FORM_URL">
-					<span>{{ i18n.baseText('nodeCreator.noResults.requestTheNode') }}</span
-					>&nbsp;
+					<span>{{ i18n.baseText('nodeCreator.noResults.requestTheNode') }}</span>
 					<span>
 						<N8nIcon
 							:class="$style.external"

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Panel/NoResults.vue
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Panel/NoResults.vue
@@ -40,8 +40,8 @@ const i18n = useI18n();
 					{{ i18n.baseText('nodeCreator.noResults.httpRequest') }}
 				</N8nLink>
 
-				<N8nLink v-if="rootView === TRIGGER_NODE_CREATOR_VIEW" @click="$emit('addWebhookNode')">
-					{{ i18n.baseText('nodeCreator.noResults.webhook') }}
+				<N8nLink v-if="rootView === TRIGGER_NODE_CREATOR_VIEW" @click="$emit('addHttpNode')">
+					{{ i18n.baseText('nodeCreator.noResults.httpRequest') }}
 				</N8nLink>
 				{{ i18n.baseText('nodeCreator.noResults.node') }}
 			</div>


### PR DESCRIPTION
## Summary

Decided to add both nodes as suggestions as both are likely to be useful on that step

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4738/no-result-state-in-node-panel-suggesting-webhook-node

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
