### PR TITLE
fix(editor): Return actual node name from rename operation

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -1611,7 +1611,7 @@ describe('useCanvasOperations', () => {
 	});
 
 	describe('renameNode', () => {
-		it('should rename node and return true on success', async () => {
+		it('should rename node and return the actual new name on success', async () => {
 			const workflowsStore = mockedStore(useWorkflowsStore);
 			const ndvStore = mockedStore(useNDVStore);
 			const oldName = 'Old Node';
@@ -1627,7 +1627,7 @@ describe('useCanvasOperations', () => {
 			const { renameNode } = useCanvasOperations();
 			const result = await renameNode(oldName, newName);
 
-			expect(result).toBe(true);
+			expect(result).toBe(newName);
 			expect(workflowObject.renameNode).toHaveBeenCalledWith(oldName, newName);
 			expect(ndvStore.setActiveNodeName).toHaveBeenCalledWith(newName, expect.any(String));
 		});

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -327,13 +327,13 @@ export function useCanvasOperations() {
 
 	/**
 	 * Rename a node and update all references (connections, expressions, pinData, etc.)
-	 * @returns `true` if rename succeeded, `false` if it failed or was skipped
+	 * @returns The actual new name used (after uniquification) if rename succeeded, `false` if it failed or was skipped
 	 */
 	async function renameNode(
 		currentName: string,
 		newName: string,
 		{ trackHistory = false, trackBulk = true, showErrorToast = true } = {},
-	): Promise<boolean> {
+	): Promise<string | false> {
 		if (currentName === newName) {
 			return false;
 		}
@@ -378,7 +378,7 @@ export function useCanvasOperations() {
 			historyStore.stopRecordingUndo();
 		}
 
-		return true;
+		return newName;
 	}
 
 	async function revertRenameNode(currentName: string, previousName: string) {

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
@@ -83,19 +83,19 @@ export function useWorkflowUpdate() {
 	): Promise<void> {
 		if (nodesToUpdate.length === 0) return;
 
-		// Track successful renames (nodeId -> newName)
+		// Track successful renames (nodeId -> actualNewName after uniquification)
 		const renamedNodes = new Map<string, string>();
 
 		// First handle renames via canvasOperations (handles pinData, metadata, etc.)
 		for (const { existing, updated } of nodesToUpdate) {
 			if (existing.name !== updated.name) {
-				const success = await canvasOperations.renameNode(existing.name, updated.name, {
+				const actualNewName = await canvasOperations.renameNode(existing.name, updated.name, {
 					trackHistory: true,
 					trackBulk: false,
 					showErrorToast: false,
 				});
-				if (success) {
-					renamedNodes.set(existing.id, updated.name);
+				if (actualNewName) {
+					renamedNodes.set(existing.id, actualNewName);
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
Fixes the `renameNode` operation to return the actual node name used after uniquification, rather than just returning `true` on success.

![Kapture 2026-02-03 at 12 16 35](https://github.com/user-attachments/assets/1d46f60d-fa2a-4cb0-8e67-65a9fc2395c8)



**The problem:**
When renaming a node, if the requested name already exists, n8n automatically makes it unique (e.g., "My Node" becomes "My Node 1"). Previously, the `renameNode` function returned `true` on success, and callers would use the originally requested name, not the actual unique name that was assigned.

**The fix:**
- Changed `renameNode` in `useCanvasOperations.ts` to return the actual `newName` (after uniquification) instead of `true`
- Updated `useWorkflowUpdate.ts` to use the returned actual name when tracking renamed nodes

This ensures that subsequent operations that depend on node names (like the AI workflow builder's rename-node tool) get the correct name that was actually assigned to the node.

## Test plan
- [x] Unit tests updated to verify `renameNode` returns the actual name

Fixes https://linear.app/n8n/issue/AI-1990/fix-rename-node

🤖 Generated with [Claude Code](https://claude.com/claude-code)