### PR TITLE
perf(core): Remove redundant webhook cache rebuild on activation

### DIFF
--- a/packages/cli/src/active-workflow-manager.ts
+++ b/packages/cli/src/active-workflow-manager.ts
@@ -223,7 +223,6 @@ export class ActiveWorkflowManager {
 				throw error;
 			}
 		}
-		await this.webhookService.populateCache();
 
 		await this.workflowStaticDataService.saveStaticData(workflow);
 


### PR DESCRIPTION
Every time a workflow with webhooks is activated, `populateCache()` fetches _all_ webhooks from the DB and rebuils the entire cache. During bootup for an instance with 500 active workflows, this causes ~500 redundant `SELECT * FROM webhook` queries.

This PR removes that redundant cache rebuild. This is safe because `storeWebhook()` already caches each webhook, i.e. when a webhook is created, it's immediately cached before being written to DB. And `findWebhook()` populates the cache lazily, so on cache miss it queries DB and caches the result. The cache ends up with the same data, just without the redundant full-table scans.