### PR TITLE
feat(Trello Trigger Node): Add webhook signature verification

### DIFF
--- a/packages/nodes-base/credentials/TrelloApi.credentials.ts
+++ b/packages/nodes-base/credentials/TrelloApi.credentials.ts
@@ -33,9 +33,11 @@ export class TrelloApi implements ICredentialType {
 		{
 			displayName: 'OAuth Secret',
 			name: 'oauthSecret',
-			type: 'hidden',
+			type: 'string',
 			typeOptions: { password: true },
 			default: '',
+			description:
+				'The OAuth secret from your Trello Power-Up admin page. Required for webhook signature verification.',
 		},
 	];
 

--- a/packages/nodes-base/nodes/Trello/TrelloTriggerHelpers.ts
+++ b/packages/nodes-base/nodes/Trello/TrelloTriggerHelpers.ts
@@ -1,0 +1,73 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+import type { IWebhookFunctions } from 'n8n-workflow';
+
+/**
+ * Verifies the Trello webhook signature using HMAC-SHA1.
+ *
+ * Trello sends a signature in the `X-Trello-Webhook` header which is a
+ * base64-encoded HMAC-SHA1 digest of (body + callbackURL).
+ *
+ * The content to hash is the concatenation of JSON.stringify(body) and the callbackURL
+ * exactly as it was provided during webhook creation.
+ *
+ * The secret is the application's OAuth secret from the Trello Power-Up admin page.
+ *
+ * @returns true if signature is valid or no secret is configured, false otherwise
+ */
+export async function verifySignature(this: IWebhookFunctions): Promise<boolean> {
+	const credentials = await this.getCredentials('trelloApi');
+
+	// If no OAuth secret is configured, skip verification (backwards compatibility)
+	if (!credentials?.oauthSecret) {
+		return true;
+	}
+
+	const oauthSecret = credentials.oauthSecret as string;
+
+	const req = this.getRequestObject();
+	const headerData = this.getHeaderData() as Record<string, string | undefined>;
+
+	// Get the signature from Trello's header (lowercase)
+	const signature = headerData['x-trello-webhook'];
+
+	if (!signature) {
+		return false;
+	}
+
+	try {
+		// Get the raw request body
+		if (!req.rawBody) {
+			return false;
+		}
+
+		// Get the callback URL that was used during webhook creation
+		const callbackURL = this.getNodeWebhookUrl('default');
+
+		// Compute: base64(HMACSHA1(JSON.stringify(body) + callbackURL))
+		const hmac = createHmac('sha1', oauthSecret);
+
+		let rawBodyString: string;
+		if (Buffer.isBuffer(req.rawBody)) {
+			rawBodyString = req.rawBody.toString('utf8');
+		} else {
+			rawBodyString = typeof req.rawBody === 'string' ? req.rawBody : JSON.stringify(req.rawBody);
+		}
+
+		// Content to hash is body + callbackURL (exactly as Trello docs specify)
+		hmac.update(rawBodyString + callbackURL);
+		const computedSignature = hmac.digest('base64');
+
+		// Constant-time comparison to prevent timing attacks
+		const computedBuffer = Buffer.from(computedSignature, 'utf8');
+		const providedBuffer = Buffer.from(signature, 'utf8');
+
+		// Buffers must be same length for timingSafeEqual
+		if (computedBuffer.length !== providedBuffer.length) {
+			return false;
+		}
+
+		return timingSafeEqual(computedBuffer, providedBuffer);
+	} catch {
+		return false;
+	}
+}

--- a/packages/nodes-base/nodes/Trello/__tests__/TrelloTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Trello/__tests__/TrelloTrigger.node.test.ts
@@ -1,0 +1,107 @@
+import { TrelloTrigger } from '../TrelloTrigger.node';
+import * as TrelloTriggerHelpers from '../TrelloTriggerHelpers';
+
+describe('TrelloTrigger Node', () => {
+	describe('webhook method', () => {
+		let mockThis: {
+			getWebhookName: jest.Mock;
+			getResponseObject: jest.Mock;
+			getBodyData: jest.Mock;
+			helpers: {
+				returnJsonArray: jest.Mock;
+			};
+		};
+		let mockResponseObject: {
+			status: jest.Mock;
+			send: jest.Mock;
+			end: jest.Mock;
+		};
+
+		beforeEach(() => {
+			mockResponseObject = {
+				status: jest.fn().mockReturnThis(),
+				send: jest.fn().mockReturnThis(),
+				end: jest.fn(),
+			};
+
+			mockThis = {
+				getWebhookName: jest.fn().mockReturnValue('default'),
+				getResponseObject: jest.fn().mockReturnValue(mockResponseObject),
+				getBodyData: jest.fn().mockReturnValue({
+					action: { type: 'updateCard' },
+					model: { id: '123' },
+				}),
+				helpers: {
+					returnJsonArray: jest.fn().mockImplementation((data) => [data]),
+				},
+			};
+		});
+
+		afterEach(() => {
+			jest.restoreAllMocks();
+		});
+
+		it('should respond with 200 for setup (HEAD) request', async () => {
+			mockThis.getWebhookName.mockReturnValue('setup');
+
+			const trigger = new TrelloTrigger();
+			const result = await trigger.webhook.call(mockThis as never);
+
+			expect(result).toEqual({ noWebhookResponse: true });
+			expect(mockResponseObject.status).toHaveBeenCalledWith(200);
+			expect(mockResponseObject.end).toHaveBeenCalled();
+		});
+
+		it('should reject with 401 when signature verification fails', async () => {
+			jest.spyOn(TrelloTriggerHelpers, 'verifySignature').mockResolvedValueOnce(false);
+
+			const trigger = new TrelloTrigger();
+			const result = await trigger.webhook.call(mockThis as never);
+
+			expect(result).toEqual({ noWebhookResponse: true });
+			expect(mockResponseObject.status).toHaveBeenCalledWith(401);
+			expect(mockResponseObject.send).toHaveBeenCalledWith('Unauthorized');
+		});
+
+		it('should process webhook when signature verification succeeds', async () => {
+			jest.spyOn(TrelloTriggerHelpers, 'verifySignature').mockResolvedValueOnce(true);
+
+			const trigger = new TrelloTrigger();
+			const result = await trigger.webhook.call(mockThis as never);
+
+			expect(result).toHaveProperty('workflowData');
+			expect(mockThis.helpers.returnJsonArray).toHaveBeenCalledWith({
+				action: { type: 'updateCard' },
+				model: { id: '123' },
+			});
+		});
+
+		it('should return workflow data with the request body', async () => {
+			jest.spyOn(TrelloTriggerHelpers, 'verifySignature').mockResolvedValueOnce(true);
+
+			const trigger = new TrelloTrigger();
+			const result = await trigger.webhook.call(mockThis as never);
+
+			expect(result.workflowData).toBeDefined();
+			expect(result.workflowData).toHaveLength(1);
+		});
+
+		it('should not call getBodyData before signature is verified', async () => {
+			jest.spyOn(TrelloTriggerHelpers, 'verifySignature').mockResolvedValueOnce(false);
+
+			const trigger = new TrelloTrigger();
+			await trigger.webhook.call(mockThis as never);
+
+			expect(mockThis.getBodyData).not.toHaveBeenCalled();
+		});
+
+		it('should call getBodyData after signature is verified', async () => {
+			jest.spyOn(TrelloTriggerHelpers, 'verifySignature').mockResolvedValueOnce(true);
+
+			const trigger = new TrelloTrigger();
+			await trigger.webhook.call(mockThis as never);
+
+			expect(mockThis.getBodyData).toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Trello/__tests__/TrelloTriggerHelpers.test.ts
+++ b/packages/nodes-base/nodes/Trello/__tests__/TrelloTriggerHelpers.test.ts
@@ -1,0 +1,195 @@
+import { createHmac } from 'crypto';
+import type { IWebhookFunctions } from 'n8n-workflow';
+
+import { verifySignature } from '../TrelloTriggerHelpers';
+
+describe('TrelloTriggerHelpers', () => {
+	describe('verifySignature', () => {
+		let mockWebhookFunctions: IWebhookFunctions;
+		const testOauthSecret = 'test-oauth-secret-key-12345';
+		const testBody = '{"action":{"type":"updateCard"},"model":{"id":"123"}}';
+		const testCallbackURL = 'https://example.com/webhook/trello';
+
+		function generateValidSignature(body: string, callbackURL: string, secret: string): string {
+			// Trello signature: base64(HMACSHA1(body + callbackURL))
+			return createHmac('sha1', secret)
+				.update(body + callbackURL)
+				.digest('base64');
+		}
+
+		beforeEach(() => {
+			mockWebhookFunctions = {
+				getCredentials: jest.fn().mockResolvedValue({
+					oauthSecret: testOauthSecret,
+				}),
+				getRequestObject: jest.fn().mockReturnValue({
+					rawBody: Buffer.from(testBody),
+				}),
+				getHeaderData: jest.fn().mockReturnValue({
+					'x-trello-webhook': generateValidSignature(testBody, testCallbackURL, testOauthSecret),
+				}),
+				getNodeWebhookUrl: jest.fn().mockReturnValue(testCallbackURL),
+			} as unknown as IWebhookFunctions;
+		});
+
+		it('should return true when no OAuth secret is configured (backwards compatibility)', async () => {
+			(mockWebhookFunctions.getCredentials as jest.Mock).mockResolvedValue({});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return true when OAuth secret is null (backwards compatibility)', async () => {
+			(mockWebhookFunctions.getCredentials as jest.Mock).mockResolvedValue({
+				oauthSecret: null,
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return true when OAuth secret is empty string (backwards compatibility)', async () => {
+			(mockWebhookFunctions.getCredentials as jest.Mock).mockResolvedValue({
+				oauthSecret: '',
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false when signature header is missing', async () => {
+			(mockWebhookFunctions.getHeaderData as jest.Mock).mockReturnValue({});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false when rawBody is missing', async () => {
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				rawBody: undefined,
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return true when signature is valid', async () => {
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+			expect(mockWebhookFunctions.getNodeWebhookUrl).toHaveBeenCalledWith('default');
+		});
+
+		it('should return false when signature is invalid', async () => {
+			(mockWebhookFunctions.getHeaderData as jest.Mock).mockReturnValue({
+				'x-trello-webhook': 'invalid-signature',
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false when signature is computed with wrong secret', async () => {
+			const wrongSecret = 'wrong-secret-key';
+			(mockWebhookFunctions.getHeaderData as jest.Mock).mockReturnValue({
+				'x-trello-webhook': generateValidSignature(testBody, testCallbackURL, wrongSecret),
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false when signature is computed with wrong callbackURL', async () => {
+			const wrongCallbackURL = 'https://wrong-url.com/webhook';
+			(mockWebhookFunctions.getHeaderData as jest.Mock).mockReturnValue({
+				'x-trello-webhook': generateValidSignature(testBody, wrongCallbackURL, testOauthSecret),
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should handle Buffer rawBody correctly', async () => {
+			const bufferBody = Buffer.from(testBody);
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				rawBody: bufferBody,
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should handle string rawBody correctly', async () => {
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				rawBody: testBody, // String instead of Buffer
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false when computed and provided signatures have different lengths', async () => {
+			(mockWebhookFunctions.getHeaderData as jest.Mock).mockReturnValue({
+				'x-trello-webhook': 'short',
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should handle empty body', async () => {
+			const emptyBody = '';
+			const validSignature = generateValidSignature(emptyBody, testCallbackURL, testOauthSecret);
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				rawBody: Buffer.from(emptyBody),
+			});
+			(mockWebhookFunctions.getHeaderData as jest.Mock).mockReturnValue({
+				'x-trello-webhook': validSignature,
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should handle complex JSON body with special characters', async () => {
+			const complexBody =
+				'{"action":{"type":"commentCard","data":{"text":"Test with émojis 🎉 and spëcial chars"}}}';
+			const validSignature = generateValidSignature(complexBody, testCallbackURL, testOauthSecret);
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				rawBody: Buffer.from(complexBody, 'utf8'),
+			});
+			(mockWebhookFunctions.getHeaderData as jest.Mock).mockReturnValue({
+				'x-trello-webhook': validSignature,
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should handle different callbackURL formats', async () => {
+			const callbackWithParams = 'https://example.com/webhook/trello?param=value';
+			const validSignature = generateValidSignature(testBody, callbackWithParams, testOauthSecret);
+			(mockWebhookFunctions.getNodeWebhookUrl as jest.Mock).mockReturnValue(callbackWithParams);
+			(mockWebhookFunctions.getHeaderData as jest.Mock).mockReturnValue({
+				'x-trello-webhook': validSignature,
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Add webhook signature verification for the Trello Trigger node using HMAC-SHA1 with the OAuth secret.

The implementation:
- Verifies incoming webhook requests using the `X-Trello-Webhook` header signature
- Uses the application's OAuth secret as the HMAC key
- Maintains backwards compatibility when no secret is configured
- Returns 401 Unauthorized for invalid signatures

**How to test:**
1. Create a Trello API credential with OAuth secret from your Power-Up admin page
2. Set up a TrelloTrigger workflow watching a model
3. Trigger webhook events on the watched model
4. Verify requests with valid signatures are processed and invalid ones are rejected

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4316

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)