### PR TITLE
feat(Twilio Trigger Node): Add webhook signature verification

### DIFF
--- a/packages/nodes-base/nodes/Twilio/TwilioTrigger.node.ts
+++ b/packages/nodes-base/nodes/Twilio/TwilioTrigger.node.ts
@@ -8,6 +8,7 @@ import {
 } from 'n8n-workflow';
 
 import { twilioTriggerApiRequest } from './GenericFunctions';
+import { verifySignature } from './TwilioTriggerHelpers';
 
 export class TwilioTrigger implements INodeType {
 	description: INodeTypeDescription = {
@@ -188,6 +189,16 @@ export class TwilioTrigger implements INodeType {
 	};
 
 	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
+		// Verify the webhook signature before processing
+		if (!(await verifySignature.call(this))) {
+			const res = this.getResponseObject();
+			res.status(401).send('Unauthorized').end();
+
+			return {
+				noWebhookResponse: true,
+			};
+		}
+
 		const bodyData = this.getBodyData();
 
 		return {

--- a/packages/nodes-base/nodes/Twilio/TwilioTriggerHelpers.ts
+++ b/packages/nodes-base/nodes/Twilio/TwilioTriggerHelpers.ts
@@ -1,0 +1,104 @@
+import { createHmac, createHash, timingSafeEqual } from 'crypto';
+import type { IWebhookFunctions } from 'n8n-workflow';
+
+/**
+ * Verifies the Twilio webhook signature using HMAC-SHA1.
+ *
+ * Twilio sends a signature in the `X-Twilio-Signature` header, which is a
+ * Base64-encoded HMAC-SHA1 hash computed from:
+ *
+ * For application/x-www-form-urlencoded:
+ *   - The full URL (with query string)
+ *   - POST parameters sorted alphabetically by name, concatenated as key+value pairs
+ *
+ * For application/json:
+ *   - The full URL (which must include a `bodySHA256` query parameter)
+ *   - The `bodySHA256` is a SHA-256 hash of the request body
+ *
+ * This function uses the Auth Token from credentials as the HMAC key.
+ *
+ * @returns true if signature is valid or no auth token is configured, false otherwise
+ */
+export async function verifySignature(this: IWebhookFunctions): Promise<boolean> {
+	const credentials = await this.getCredentials('twilioApi');
+
+	// Get the auth token - only works with authToken auth type
+	if (credentials.authType !== 'authToken' || !credentials.authToken) {
+		// If using API Key auth or no auth token configured, skip verification
+		// This maintains backwards compatibility
+		return true;
+	}
+
+	const authToken = credentials.authToken as string;
+	const req = this.getRequestObject();
+
+	// Get the signature from Twilio's header
+	const signature = req.header('x-twilio-signature');
+	if (!signature) {
+		return false;
+	}
+
+	try {
+		// Get the full webhook URL
+		const webhookUrl = this.getNodeWebhookUrl('default');
+		if (!webhookUrl) {
+			return false;
+		}
+
+		const contentType = req.header('content-type') ?? '';
+		let signatureBaseString: string;
+
+		if (contentType.includes('application/json')) {
+			// For JSON bodies, Twilio includes a bodySHA256 query parameter
+			// The signature is computed from the URL (including the bodySHA256 param)
+			// We need to verify the bodySHA256 matches the actual body hash first
+			if (!req.rawBody) {
+				return false;
+			}
+
+			const rawBody = Buffer.isBuffer(req.rawBody)
+				? req.rawBody.toString('utf8')
+				: typeof req.rawBody === 'string'
+					? req.rawBody
+					: JSON.stringify(req.rawBody);
+
+			// Compute SHA256 hash of the body
+			const bodyHash = createHash('sha256').update(rawBody).digest('hex');
+
+			// Build the URL with bodySHA256 parameter
+			const url = new URL(webhookUrl);
+			url.searchParams.set('bodySHA256', bodyHash);
+			signatureBaseString = url.toString();
+		} else {
+			// For form-urlencoded bodies, sort POST params and append to URL
+			const bodyData = this.getBodyData() as Record<string, unknown>;
+			signatureBaseString = webhookUrl;
+
+			// Sort parameters alphabetically (case-sensitive Unix-style sort)
+			const sortedKeys = Object.keys(bodyData).sort();
+			for (const key of sortedKeys) {
+				const value = bodyData[key];
+				// Append key and value with no delimiter
+				signatureBaseString += key + String(value ?? '');
+			}
+		}
+
+		// Compute HMAC-SHA1 signature
+		const hmac = createHmac('sha1', authToken);
+		hmac.update(signatureBaseString);
+		const computedSignature = hmac.digest('base64');
+
+		// Use timing-safe comparison
+		const computedBuffer = Buffer.from(computedSignature, 'utf8');
+		const providedBuffer = Buffer.from(signature, 'utf8');
+
+		// Buffers must be same length for timingSafeEqual
+		if (computedBuffer.length !== providedBuffer.length) {
+			return false;
+		}
+
+		return timingSafeEqual(computedBuffer, providedBuffer);
+	} catch {
+		return false;
+	}
+}

--- a/packages/nodes-base/nodes/Twilio/__tests__/TwilioTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Twilio/__tests__/TwilioTrigger.node.test.ts
@@ -1,0 +1,73 @@
+import { TwilioTrigger } from '../TwilioTrigger.node';
+import * as TwilioTriggerHelpers from '../TwilioTriggerHelpers';
+
+describe('TwilioTrigger Node', () => {
+	describe('webhook method', () => {
+		let mockThis: {
+			getBodyData: jest.Mock;
+			getResponseObject: jest.Mock;
+			helpers: { returnJsonArray: jest.Mock };
+		};
+
+		beforeEach(() => {
+			jest.clearAllMocks();
+
+			mockThis = {
+				getBodyData: jest.fn().mockReturnValue({
+					specversion: '1.0',
+					type: 'com.twilio.messaging.inbound-message.received',
+					data: { messageSid: 'SM123' },
+				}),
+				getResponseObject: jest.fn().mockReturnValue({
+					status: jest.fn().mockReturnThis(),
+					send: jest.fn().mockReturnThis(),
+					end: jest.fn(),
+				}),
+				helpers: {
+					returnJsonArray: jest.fn().mockImplementation((data) => [{ json: data }]),
+				},
+			};
+		});
+
+		it('should reject with 401 when signature verification fails', async () => {
+			jest.spyOn(TwilioTriggerHelpers, 'verifySignature').mockResolvedValueOnce(false);
+
+			const trigger = new TwilioTrigger();
+			const result = await trigger.webhook.call(mockThis as never);
+
+			expect(result).toEqual({ noWebhookResponse: true });
+			expect(mockThis.getResponseObject).toHaveBeenCalled();
+			const res = mockThis.getResponseObject();
+			expect(res.status).toHaveBeenCalledWith(401);
+			expect(res.send).toHaveBeenCalledWith('Unauthorized');
+			expect(res.end).toHaveBeenCalled();
+		});
+
+		it('should process webhook when signature verification succeeds', async () => {
+			jest.spyOn(TwilioTriggerHelpers, 'verifySignature').mockResolvedValueOnce(true);
+
+			const trigger = new TwilioTrigger();
+			const result = await trigger.webhook.call(mockThis as never);
+
+			expect(result).toHaveProperty('workflowData');
+			expect(mockThis.getBodyData).toHaveBeenCalled();
+			expect(mockThis.helpers.returnJsonArray).toHaveBeenCalled();
+		});
+
+		it('should return the body data as workflow data when verification passes', async () => {
+			const testBodyData = {
+				specversion: '1.0',
+				type: 'com.twilio.messaging.inbound-message.received',
+				data: { messageSid: 'SM456', from: '+1234567890' },
+			};
+			mockThis.getBodyData.mockReturnValue(testBodyData);
+			jest.spyOn(TwilioTriggerHelpers, 'verifySignature').mockResolvedValueOnce(true);
+
+			const trigger = new TwilioTrigger();
+			const result = await trigger.webhook.call(mockThis as never);
+
+			expect(result.workflowData).toBeDefined();
+			expect(mockThis.helpers.returnJsonArray).toHaveBeenCalledWith(testBodyData);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Twilio/__tests__/TwilioTriggerHelpers.test.ts
+++ b/packages/nodes-base/nodes/Twilio/__tests__/TwilioTriggerHelpers.test.ts
@@ -1,0 +1,266 @@
+import { createHmac, createHash, timingSafeEqual } from 'crypto';
+import { verifySignature } from '../TwilioTriggerHelpers';
+
+jest.mock('crypto', () => ({
+	...jest.requireActual('crypto'),
+	createHmac: jest.fn().mockReturnValue({
+		update: jest.fn().mockReturnThis(),
+		digest: jest.fn().mockReturnValue('GxVchyDnq5TeTNrQjvRwST4VaEc='),
+	}),
+	createHash: jest.fn().mockReturnValue({
+		update: jest.fn().mockReturnThis(),
+		digest: jest
+			.fn()
+			.mockReturnValue('5ccde7145dfb8f56479710896586cb9d5911809d83afbe34627818790db0aec9'),
+	}),
+	timingSafeEqual: jest.fn(),
+}));
+
+describe('TwilioTriggerHelpers', () => {
+	let mockWebhookFunctions: {
+		getCredentials: jest.Mock;
+		getRequestObject: jest.Mock;
+		getNodeWebhookUrl: jest.Mock;
+		getBodyData: jest.Mock;
+	};
+	const testAuthToken = 'test_auth_token_12345';
+	const testWebhookUrl = 'https://example.com/webhook/twiliotrigger';
+	const testFormBody = {
+		CallSid: 'CA1234567890ABCDE',
+		From: '+14158675310',
+		To: '+18005551212',
+	};
+	const testJsonBody = '{"event":"message","data":{"id":"123"}}';
+	const testSignature = 'GxVchyDnq5TeTNrQjvRwST4VaEc=';
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		mockWebhookFunctions = {
+			getCredentials: jest.fn(),
+			getRequestObject: jest.fn(),
+			getNodeWebhookUrl: jest.fn().mockReturnValue(testWebhookUrl),
+			getBodyData: jest.fn().mockReturnValue(testFormBody),
+		};
+
+		// Default mock return values for form-urlencoded request
+		mockWebhookFunctions.getRequestObject.mockReturnValue({
+			header: jest.fn().mockImplementation((header) => {
+				if (header === 'x-twilio-signature') return testSignature;
+				if (header === 'content-type') return 'application/x-www-form-urlencoded';
+				return null;
+			}),
+			rawBody: 'CallSid=CA1234567890ABCDE&From=%2B14158675310&To=%2B18005551212',
+		});
+	});
+
+	describe('verifySignature', () => {
+		it('should return true when using API Key auth type (skip verification)', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'apiKey',
+				apiKeySid: 'test-api-key',
+				apiKeySecret: 'test-api-secret',
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions as never);
+
+			expect(result).toBe(true);
+			expect(mockWebhookFunctions.getCredentials).toHaveBeenCalledWith('twilioApi');
+		});
+
+		it('should return true when no auth token is configured (backwards compatibility)', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				accountSid: 'test-account-sid',
+				authToken: '',
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions as never);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false when signature header is missing', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				accountSid: 'test-account-sid',
+				authToken: testAuthToken,
+			});
+
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header) => {
+					if (header === 'content-type') return 'application/x-www-form-urlencoded';
+					return null;
+				}),
+				rawBody: 'test',
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions as never);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false when webhook URL is not available', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				accountSid: 'test-account-sid',
+				authToken: testAuthToken,
+			});
+			mockWebhookFunctions.getNodeWebhookUrl.mockReturnValue(undefined);
+
+			const result = await verifySignature.call(mockWebhookFunctions as never);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return true when signature is valid for form-urlencoded body', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				accountSid: 'test-account-sid',
+				authToken: testAuthToken,
+			});
+			(timingSafeEqual as jest.Mock).mockReturnValue(true);
+
+			const result = await verifySignature.call(mockWebhookFunctions as never);
+
+			expect(result).toBe(true);
+			expect(createHmac).toHaveBeenCalledWith('sha1', testAuthToken);
+			expect(timingSafeEqual).toHaveBeenCalled();
+		});
+
+		it('should return false when signature is invalid', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				accountSid: 'test-account-sid',
+				authToken: testAuthToken,
+			});
+			(timingSafeEqual as jest.Mock).mockReturnValue(false);
+
+			const result = await verifySignature.call(mockWebhookFunctions as never);
+
+			expect(result).toBe(false);
+			expect(createHmac).toHaveBeenCalledWith('sha1', testAuthToken);
+			expect(timingSafeEqual).toHaveBeenCalled();
+		});
+
+		it('should sort POST parameters alphabetically for form-urlencoded body', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				accountSid: 'test-account-sid',
+				authToken: testAuthToken,
+			});
+			mockWebhookFunctions.getBodyData.mockReturnValue({
+				CallSid: 'CA123',
+				From: '+1234',
+				To: '+5678',
+			});
+			(timingSafeEqual as jest.Mock).mockReturnValue(true);
+
+			await verifySignature.call(mockWebhookFunctions as never);
+
+			expect(createHmac).toHaveBeenCalledWith('sha1', testAuthToken);
+			const mockHmac = createHmac('sha1', testAuthToken);
+			// Parameters should be sorted: CallSid, From, To
+			expect(mockHmac.update).toHaveBeenCalledWith(`${testWebhookUrl}CallSidCA123From+1234To+5678`);
+		});
+
+		it('should handle JSON body with bodySHA256 parameter', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				accountSid: 'test-account-sid',
+				authToken: testAuthToken,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header) => {
+					if (header === 'x-twilio-signature') return testSignature;
+					if (header === 'content-type') return 'application/json';
+					return null;
+				}),
+				rawBody: testJsonBody,
+			});
+			(timingSafeEqual as jest.Mock).mockReturnValue(true);
+
+			await verifySignature.call(mockWebhookFunctions as never);
+
+			expect(createHash).toHaveBeenCalledWith('sha256');
+			expect(createHmac).toHaveBeenCalledWith('sha1', testAuthToken);
+		});
+
+		it('should return false when JSON body rawBody is missing', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				accountSid: 'test-account-sid',
+				authToken: testAuthToken,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header) => {
+					if (header === 'x-twilio-signature') return testSignature;
+					if (header === 'content-type') return 'application/json';
+					return null;
+				}),
+				rawBody: undefined,
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions as never);
+
+			expect(result).toBe(false);
+		});
+
+		it('should handle Buffer rawBody correctly for JSON', async () => {
+			const bufferBody = Buffer.from(testJsonBody);
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				accountSid: 'test-account-sid',
+				authToken: testAuthToken,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header) => {
+					if (header === 'x-twilio-signature') return testSignature;
+					if (header === 'content-type') return 'application/json';
+					return null;
+				}),
+				rawBody: bufferBody,
+			});
+			(timingSafeEqual as jest.Mock).mockReturnValue(true);
+
+			const result = await verifySignature.call(mockWebhookFunctions as never);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false when computed and provided signatures have different lengths', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				accountSid: 'test-account-sid',
+				authToken: testAuthToken,
+			});
+			// Mock a different length signature
+			const mockHmacInstance = {
+				update: jest.fn().mockReturnThis(),
+				digest: jest.fn().mockReturnValue('short'),
+			};
+			(createHmac as jest.Mock).mockReturnValue(mockHmacInstance);
+
+			const result = await verifySignature.call(mockWebhookFunctions as never);
+
+			expect(result).toBe(false);
+			// timingSafeEqual should not be called if lengths don't match
+			expect(timingSafeEqual).not.toHaveBeenCalled();
+		});
+
+		it('should return false when an error occurs during verification', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				accountSid: 'test-account-sid',
+				authToken: testAuthToken,
+			});
+			(createHmac as jest.Mock).mockImplementation(() => {
+				throw new Error('Crypto error');
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions as never);
+
+			expect(result).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Add webhook signature verification for the Twilio Trigger node using Twilio's request validation algorithm.

The implementation:
- Verifies incoming webhook requests using the `X-Twilio-Signature` header
- Supports both form-urlencoded and JSON body formats
- Uses the auth token from credentials as the HMAC-SHA1 key
- Maintains backwards compatibility when using API Key auth type or no secret configured
- Returns 401 Unauthorized for invalid signatures

**How to test:**
1. Create a Twilio API credential with Auth Token
2. Set up a TwilioTrigger workflow
3. Trigger webhook events from Twilio
4. Verify requests with valid signatures are processed and invalid ones are rejected

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4317

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)