### PR TITLE
feat(Trello Trigger Node): Add webhook signature verification

### DIFF
--- a/packages/nodes-base/credentials/TrelloApi.credentials.ts
+++ b/packages/nodes-base/credentials/TrelloApi.credentials.ts
@@ -33,9 +33,11 @@ export class TrelloApi implements ICredentialType {
 		{
 			displayName: 'OAuth Secret',
 			name: 'oauthSecret',
-			type: 'hidden',
+			type: 'string',
 			typeOptions: { password: true },
 			default: '',
+			description:
+				'The OAuth secret used to verify webhook signatures. Find it on your <a href="https://trello.com/power-ups/admin" target="_blank">Power-Up admin page</a> under "API Key".',
 		},
 	];
 

--- a/packages/nodes-base/nodes/Trello/TrelloTriggerHelpers.ts
+++ b/packages/nodes-base/nodes/Trello/TrelloTriggerHelpers.ts
@@ -1,0 +1,53 @@
+import { createHmac } from 'crypto';
+import type { IWebhookFunctions } from 'n8n-workflow';
+
+import { verifySignature as verifySignatureGeneric } from '../../utils/webhook-signature-verification';
+
+/**
+ * Verifies the Trello webhook signature.
+ *
+ * Trello signs webhooks using HMAC-SHA1:
+ * 1. Create HMAC SHA-1 hash of (raw body + callbackURL) using the OAuth secret as key
+ * 2. Encode the hash in base64 format
+ * 3. Compare with the signature in the `X-Trello-Webhook` header
+ *
+ * @see https://developer.atlassian.com/cloud/trello/guides/rest-api/webhooks/#webhook-signatures
+ *
+ * @returns true if the signature is valid, false otherwise
+ * @returns true if no OAuth secret is configured (backward compatibility with existing triggers)
+ */
+export async function verifySignature(this: IWebhookFunctions): Promise<boolean> {
+	const credentials = await this.getCredentials('trelloApi');
+	const req = this.getRequestObject();
+	const oauthSecret = credentials?.oauthSecret;
+
+	return verifySignatureGeneric({
+		getExpectedSignature: () => {
+			if (!oauthSecret || typeof oauthSecret !== 'string' || !req.rawBody) {
+				return null;
+			}
+
+			// Get the callback URL that was used during webhook creation
+			const callbackURL = this.getNodeWebhookUrl('default');
+
+			// Compute: base64(HMAC-SHA1(body + callbackURL))
+			const hmac = createHmac('sha1', oauthSecret);
+
+			let rawBodyString: string;
+			if (Buffer.isBuffer(req.rawBody)) {
+				rawBodyString = req.rawBody.toString('utf8');
+			} else {
+				rawBodyString = typeof req.rawBody === 'string' ? req.rawBody : JSON.stringify(req.rawBody);
+			}
+
+			// Content to hash is body + callbackURL (exactly as Trello docs specify)
+			hmac.update(rawBodyString + callbackURL);
+			return hmac.digest('base64');
+		},
+		skipIfNoExpectedSignature: !oauthSecret || typeof oauthSecret !== 'string',
+		getActualSignature: () => {
+			const signature = req.header('x-trello-webhook');
+			return typeof signature === 'string' ? signature : null;
+		},
+	});
+}

--- a/packages/nodes-base/nodes/Trello/__tests__/TrelloTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Trello/__tests__/TrelloTrigger.node.test.ts
@@ -1,0 +1,89 @@
+import type { IWebhookFunctions } from 'n8n-workflow';
+
+import { TrelloTrigger } from '../TrelloTrigger.node';
+import { verifySignature } from '../TrelloTriggerHelpers';
+
+jest.mock('../TrelloTriggerHelpers', () => ({
+	verifySignature: jest.fn(),
+}));
+
+const mockedVerifySignature = jest.mocked(verifySignature);
+
+describe('TrelloTrigger Node', () => {
+	let node: TrelloTrigger;
+
+	beforeEach(() => {
+		node = new TrelloTrigger();
+		jest.clearAllMocks();
+	});
+
+	describe('webhook', () => {
+		let mockWebhookFunctions: IWebhookFunctions;
+		const testBody = {
+			action: { type: 'createCard', id: 'action123' },
+			model: { id: 'board123', name: 'Test Board' },
+		};
+
+		beforeEach(() => {
+			mockWebhookFunctions = {
+				getWebhookName: jest.fn().mockReturnValue('default'),
+				getBodyData: jest.fn().mockReturnValue(testBody),
+				getResponseObject: jest.fn().mockReturnValue({
+					status: jest.fn().mockReturnThis(),
+					send: jest.fn().mockReturnThis(),
+					end: jest.fn(),
+				}),
+				helpers: {
+					returnJsonArray: jest.fn().mockImplementation((data) => [data]),
+				},
+			} as unknown as IWebhookFunctions;
+
+			mockedVerifySignature.mockResolvedValue(true);
+		});
+
+		it('should respond with 200 for setup webhook (HEAD request)', async () => {
+			(mockWebhookFunctions.getWebhookName as jest.Mock).mockReturnValue('setup');
+
+			const result = await node.webhook.call(mockWebhookFunctions);
+
+			expect(result).toEqual({ noWebhookResponse: true });
+			expect(mockWebhookFunctions.getResponseObject).toHaveBeenCalled();
+			const res = (mockWebhookFunctions.getResponseObject as jest.Mock).mock.results[0].value;
+			expect(res.status).toHaveBeenCalledWith(200);
+			expect(res.end).toHaveBeenCalled();
+			expect(mockedVerifySignature).not.toHaveBeenCalled();
+		});
+
+		it('should process webhook with valid signature', async () => {
+			mockedVerifySignature.mockResolvedValue(true);
+
+			const result = await node.webhook.call(mockWebhookFunctions);
+
+			expect(result).toEqual({
+				workflowData: [[testBody]],
+			});
+			expect(mockedVerifySignature).toHaveBeenCalled();
+			expect(mockWebhookFunctions.helpers.returnJsonArray).toHaveBeenCalledWith(testBody);
+		});
+
+		it('should reject webhook with invalid signature and return 401', async () => {
+			mockedVerifySignature.mockResolvedValue(false);
+
+			const result = await node.webhook.call(mockWebhookFunctions);
+
+			expect(result).toEqual({ noWebhookResponse: true });
+			expect(mockedVerifySignature).toHaveBeenCalled();
+			const res = (mockWebhookFunctions.getResponseObject as jest.Mock).mock.results[0].value;
+			expect(res.status).toHaveBeenCalledWith(401);
+			expect(res.send).toHaveBeenCalledWith('Unauthorized');
+		});
+
+		it('should not call verifySignature for setup webhook', async () => {
+			(mockWebhookFunctions.getWebhookName as jest.Mock).mockReturnValue('setup');
+
+			await node.webhook.call(mockWebhookFunctions);
+
+			expect(mockedVerifySignature).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Trello/__tests__/TrelloTriggerHelpers.test.ts
+++ b/packages/nodes-base/nodes/Trello/__tests__/TrelloTriggerHelpers.test.ts
@@ -1,0 +1,190 @@
+import { createHmac } from 'crypto';
+
+import { verifySignature } from '../TrelloTriggerHelpers';
+
+describe('TrelloTriggerHelpers', () => {
+	let mockWebhookFunctions: any;
+	const testOauthSecret = 'test-oauth-secret-12345';
+	const testCallbackURL = 'https://example.com/webhook';
+	const testPayload = '{"action":{"type":"createCard"},"model":{"id":"123"}}';
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		mockWebhookFunctions = {
+			getCredentials: jest.fn(),
+			getRequestObject: jest.fn(),
+			getNodeWebhookUrl: jest.fn().mockReturnValue(testCallbackURL),
+		};
+	});
+
+	describe('verifySignature', () => {
+		it('should return true if no OAuth secret is configured', async () => {
+			// No OAuth secret configured (backward compatibility)
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				apiKey: 'test-key',
+				apiToken: 'test-token',
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue(null),
+				rawBody: Buffer.from(testPayload),
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return true if OAuth secret is empty string', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				apiKey: 'test-key',
+				apiToken: 'test-token',
+				oauthSecret: '',
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue(null),
+				rawBody: Buffer.from(testPayload),
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return true if signatures match (Buffer rawBody)', async () => {
+			// Compute the expected signature exactly as Trello does
+			const hmac = createHmac('sha1', testOauthSecret);
+			hmac.update(testPayload + testCallbackURL);
+			const expectedSignature = hmac.digest('base64');
+
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				apiKey: 'test-key',
+				apiToken: 'test-token',
+				oauthSecret: testOauthSecret,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header) => {
+					if (header === 'x-trello-webhook') return expectedSignature;
+					return null;
+				}),
+				rawBody: Buffer.from(testPayload),
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return true if signatures match (string rawBody)', async () => {
+			// Compute the expected signature exactly as Trello does
+			const hmac = createHmac('sha1', testOauthSecret);
+			hmac.update(testPayload + testCallbackURL);
+			const expectedSignature = hmac.digest('base64');
+
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				apiKey: 'test-key',
+				apiToken: 'test-token',
+				oauthSecret: testOauthSecret,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header) => {
+					if (header === 'x-trello-webhook') return expectedSignature;
+					return null;
+				}),
+				rawBody: testPayload,
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false if signatures do not match', async () => {
+			const wrongSignature = 'wrongsignature1234567890';
+
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				apiKey: 'test-key',
+				apiToken: 'test-token',
+				oauthSecret: testOauthSecret,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header) => {
+					if (header === 'x-trello-webhook') return wrongSignature;
+					return null;
+				}),
+				rawBody: Buffer.from(testPayload),
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false if signature header is missing but secret is configured', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				apiKey: 'test-key',
+				apiToken: 'test-token',
+				oauthSecret: testOauthSecret,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue(null),
+				rawBody: Buffer.from(testPayload),
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false if rawBody is missing but secret is configured', async () => {
+			const hmac = createHmac('sha1', testOauthSecret);
+			hmac.update(testPayload + testCallbackURL);
+			const expectedSignature = hmac.digest('base64');
+
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				apiKey: 'test-key',
+				apiToken: 'test-token',
+				oauthSecret: testOauthSecret,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header) => {
+					if (header === 'x-trello-webhook') return expectedSignature;
+					return null;
+				}),
+				rawBody: undefined,
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should correctly compute signature using callback URL', async () => {
+			const customCallbackURL = 'https://custom.example.com/trello/callback?param=value';
+			mockWebhookFunctions.getNodeWebhookUrl.mockReturnValue(customCallbackURL);
+
+			// Compute signature with custom callback URL
+			const hmac = createHmac('sha1', testOauthSecret);
+			hmac.update(testPayload + customCallbackURL);
+			const expectedSignature = hmac.digest('base64');
+
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				apiKey: 'test-key',
+				apiToken: 'test-token',
+				oauthSecret: testOauthSecret,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header) => {
+					if (header === 'x-trello-webhook') return expectedSignature;
+					return null;
+				}),
+				rawBody: Buffer.from(testPayload),
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+			expect(mockWebhookFunctions.getNodeWebhookUrl).toHaveBeenCalledWith('default');
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Add HMAC-SHA1 signature verification for incoming Trello webhook requests using the shared `webhook-signature-verification` utility.

### Changes
- Add `TrelloTriggerHelpers.ts` with `verifySignature` function
- Update `TrelloTrigger.node.ts` to verify webhook signatures
- Make OAuth secret visible in Trello API credentials (was hidden)
- Return 401 Unauthorized for invalid signatures
- Maintain backward compatibility when no OAuth secret is configured

### How to test
1. Set up a Trello trigger node with API credentials
2. Add the OAuth secret from your [Power-Up admin page](https://trello.com/power-ups/admin)
3. Create a webhook for a Trello board/card
4. Verify that:
   - Valid webhooks from Trello are processed correctly
   - Invalid/forged requests receive 401 Unauthorized
   - Existing triggers without OAuth secret continue to work

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4316

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)