### PR TITLE
fix(core): Stop showing setup on first load in demo mode

### DIFF
--- a/packages/cli/src/services/__tests__/frontend.service.test.ts
+++ b/packages/cli/src/services/__tests__/frontend.service.test.ts
@@ -273,6 +273,16 @@ describe('FrontendService', () => {
 
 			expect(settings).toEqual(expectedPublicSettings);
 		});
+
+		it('should set showSetupOnFirstLoad to false in preview mode', async () => {
+			process.env.N8N_PREVIEW_MODE = 'true';
+
+			const { service } = createMockService();
+			const settings = await service.getPublicSettings(false);
+
+			expect(settings.previewMode).toBe(true);
+			expect(settings.userManagement.showSetupOnFirstLoad).toBe(false);
+		});
 	});
 
 	describe('envFeatureFlags functionality', () => {

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -549,7 +549,12 @@ export class FrontendService {
 		const publicSettings: PublicFrontendSettings = {
 			settingsMode: 'public',
 			defaultLocale,
-			userManagement: { authenticationMethod, showSetupOnFirstLoad, smtpSetup },
+			userManagement: {
+				authenticationMethod,
+				// In preview mode, skip the setup redirect to allow accessing demo routes
+				showSetupOnFirstLoad: previewMode ? false : showSetupOnFirstLoad,
+				smtpSetup,
+			},
 			sso: {
 				saml: {
 					loginEnabled: ssoSaml.loginEnabled,


### PR DESCRIPTION
## Summary
Fixed a bug introduced in https://github.com/n8n-io/n8n/pull/22520 that forced setup screen show up in demo mode.

## How to test:

1. `export N8N_PREVIEW_MODE=true`
2. Run n8n with fresh DB (no owner setup)
3. Navigate to `/workflows/demo` --> You should see empty canvas in read-only mode


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
