### PR TITLE
refactor(editor): Extract node issue handling to separate composable and utilities (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/FocusPanel.vue
+++ b/packages/frontend/editor-ui/src/app/components/FocusPanel.vue
@@ -155,7 +155,7 @@ const isExecutable = computed(() => {
 
 	if (!isDisplayed.value) return false;
 
-	const foreignCredentials = nodeHelpers.getForeignCredentialsIfSharingEnabled(
+	const foreignCredentials = workflowState.getForeignCredentialsIfSharingEnabled(
 		node.value.credentials,
 	);
 	return nodeHelpers.isNodeExecutable(node.value, !props.isCanvasReadOnly, foreignCredentials);

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -57,11 +57,8 @@ import type { CanvasLayoutEvent } from '@/features/workflows/canvas/composables/
 import { useTelemetry } from './useTelemetry';
 import { useToast } from '@/app/composables/useToast';
 import * as nodeHelpers from '@/app/composables/useNodeHelpers';
-import {
-	injectWorkflowState,
-	useWorkflowState,
-	type WorkflowState,
-} from '@/app/composables/useWorkflowState';
+import type * as useNodeHelpersModule from '@/app/composables/useNodeHelpers';
+import { useWorkflowState, type WorkflowState } from '@/app/composables/useWorkflowState';
 
 import { useRouter } from 'vue-router';
 import { useTemplatesStore } from '@/features/workflows/templates/templates.store';
@@ -139,10 +136,20 @@ vi.mock('@/app/composables/useToast', () => {
 const workflowStateRef: { current: WorkflowState | undefined } = { current: undefined };
 
 vi.mock('@/app/composables/useWorkflowState', async (importOriginal) => {
+	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 	const actual = await importOriginal<typeof import('@/app/composables/useWorkflowState')>();
 	return {
 		...actual,
 		injectWorkflowState: () => workflowStateRef.current,
+	};
+});
+
+vi.mock('@/app/composables/useNodeHelpers', async (importOriginal) => {
+	const actual = await importOriginal<typeof useNodeHelpersModule>();
+	return {
+		...actual,
+		useNodeHelpers: (opts = {}) =>
+			actual.useNodeHelpers({ ...opts, workflowState: workflowStateRef.current }),
 	};
 });
 

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -860,9 +860,9 @@ export function useCanvasOperations() {
 
 			workflowsStore.setNodePristine(nodeData.name, true);
 			nodeHelpers.matchCredentials(nodeData);
-			nodeHelpers.updateNodeParameterIssues(nodeData);
-			nodeHelpers.updateNodeCredentialIssues(nodeData);
-			nodeHelpers.updateNodeInputIssues(nodeData);
+			workflowState.updateNodeParameterIssues(nodeData);
+			workflowState.updateNodeCredentialIssues(nodeData);
+			workflowState.updateNodeInputIssues(nodeData);
 
 			const isStickyNode = nodeData.type === STICKY_NODE_TYPE;
 			const nextView =
@@ -1790,8 +1790,8 @@ export function useCanvasOperations() {
 		});
 
 		void nextTick(() => {
-			nodeHelpers.updateNodeInputIssues(sourceNode);
-			nodeHelpers.updateNodeInputIssues(targetNode);
+			workflowState.updateNodeInputIssues(sourceNode);
+			workflowState.updateNodeInputIssues(targetNode);
 		});
 
 		if (!keepPristine) {
@@ -1901,8 +1901,8 @@ export function useCanvasOperations() {
 		});
 
 		void nextTick(() => {
-			nodeHelpers.updateNodeInputIssues(sourceNode);
-			nodeHelpers.updateNodeInputIssues(targetNode);
+			workflowState.updateNodeInputIssues(sourceNode);
+			workflowState.updateNodeInputIssues(targetNode);
 		});
 
 		if (trackHistory) {

--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.test.ts
@@ -229,7 +229,8 @@ describe('useNodeHelpers()', () => {
 
 	describe('getForeignCredentialsIfSharingEnabled()', () => {
 		it('should return an empty array when user has the wrong license', () => {
-			const { getForeignCredentialsIfSharingEnabled } = useNodeHelpers();
+			const workflowState = useWorkflowState();
+			const { getForeignCredentialsIfSharingEnabled } = workflowState;
 
 			const credentialWithoutAccess: IUsedCredential = {
 				id: faker.string.alphanumeric(10),
@@ -255,7 +256,8 @@ describe('useNodeHelpers()', () => {
 		});
 
 		it('should return an empty array when credentials are undefined', () => {
-			const { getForeignCredentialsIfSharingEnabled } = useNodeHelpers();
+			const workflowState = useWorkflowState();
+			const { getForeignCredentialsIfSharingEnabled } = workflowState;
 
 			mockedStore(useSettingsStore).isEnterpriseFeatureEnabled = createMockEnterpriseSettings({
 				[EnterpriseEditionFeature.Sharing]: true,
@@ -266,7 +268,8 @@ describe('useNodeHelpers()', () => {
 		});
 
 		it('should return an empty array when user has access to all credentials', () => {
-			const { getForeignCredentialsIfSharingEnabled } = useNodeHelpers();
+			const workflowState = useWorkflowState();
+			const { getForeignCredentialsIfSharingEnabled } = workflowState;
 
 			const credentialWithAccess1: IUsedCredential = {
 				id: faker.string.alphanumeric(10),
@@ -304,7 +307,8 @@ describe('useNodeHelpers()', () => {
 		});
 
 		it('should return an array of foreign credentials', () => {
-			const { getForeignCredentialsIfSharingEnabled } = useNodeHelpers();
+			const workflowState = useWorkflowState();
+			const { getForeignCredentialsIfSharingEnabled } = workflowState;
 
 			const credentialWithAccess: IUsedCredential = {
 				id: faker.string.alphanumeric(10),
@@ -745,7 +749,7 @@ describe('useNodeHelpers()', () => {
 			const getNodeParametersIssuesSpy = vi.spyOn(NodeHelpers, 'getNodeParametersIssues');
 
 			const workflowState = useWorkflowState();
-			const { updateNodeParameterIssues } = useNodeHelpers({ workflowState });
+			const { updateNodeParameterIssues } = workflowState;
 
 			updateNodeParameterIssues(node);
 

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
@@ -1,6 +1,5 @@
 import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
 import { useExternalHooks } from '@/app/composables/useExternalHooks';
-import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { useRunWorkflow } from '@/app/composables/useRunWorkflow';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useToast } from '@/app/composables/useToast';
@@ -454,7 +453,6 @@ export function setRunExecutionData(
 	workflowState: WorkflowState,
 ) {
 	const workflowsStore = useWorkflowsStore();
-	const nodeHelpers = useNodeHelpers({ workflowState });
 	const runDataExecutedErrorMessage = getRunDataExecutedErrorMessage(execution);
 	const workflowExecution = workflowsStore.getWorkflowExecution;
 
@@ -476,7 +474,7 @@ export function setRunExecutionData(
 
 	// Set the node execution issues on all the nodes which produced an error so that
 	// it can be displayed in the node-view
-	nodeHelpers.updateNodesExecutionIssues();
+	workflowState.updateNodesExecutionIssues();
 
 	const lastNodeExecuted: string | undefined = runExecutionData.resultData.lastNodeExecuted;
 	let itemsCount = 0;

--- a/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.ts
@@ -380,7 +380,7 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 				} as IWorkflowDb,
 			};
 			workflowState.setWorkflowExecutionData(executionData);
-			nodeHelpers.updateNodesExecutionIssues();
+			workflowState.updateNodesExecutionIssues();
 
 			useDocumentTitle().setDocumentTitle(workflowObject.value.name as string, 'EXECUTING');
 			const runWorkflowApiResponse = await runWorkflowApi(startRunData);

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowNodeIssuesState.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowNodeIssuesState.ts
@@ -40,7 +40,12 @@ declare namespace HttpRequestNode {
 
 type UpdateNodeAtIndexFn = (nodeIndex: number, nodeData: Partial<INodeUi>) => boolean;
 
-export function useWorkflowNodeIssuesState(updateNodeAtIndex: UpdateNodeAtIndexFn) {
+interface UseWorkflowNodeIssuesStateOptions {
+	updateNodeAtIndex: UpdateNodeAtIndexFn;
+}
+
+export function useWorkflowNodeIssuesState(options: UseWorkflowNodeIssuesStateOptions) {
+	const { updateNodeAtIndex } = options;
 	const credentialsStore = useCredentialsStore();
 	const nodeTypesStore = useNodeTypesStore();
 	const workflowsStore = useWorkflowsStore();

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowNodeIssuesState.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowNodeIssuesState.ts
@@ -1,0 +1,589 @@
+import { EnterpriseEditionFeature } from '@/app/constants';
+
+import { NodeHelpers } from 'n8n-workflow';
+import type {
+	INodeProperties,
+	INodeCredentialDescription,
+	INodeTypeDescription,
+	INodeIssues,
+	ICredentialType,
+	INodeIssueObjectProperty,
+	INodeInputConfiguration,
+	Workflow,
+	INodeCredentialsDetails,
+	NodeConnectionType,
+	INodeIssueData,
+	INodeCredentials,
+	INodeParameters,
+} from 'n8n-workflow';
+
+import type { ICredentialsResponse } from '@/features/credentials/credentials.types';
+import type { INodeUi } from '@/Interface';
+
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
+import { useCredentialsStore } from '@/features/credentials/credentials.store';
+import { useI18n } from '@n8n/i18n';
+import { useSettingsStore } from '@/app/stores/settings.store';
+import { hasPermission } from '@/app/utils/rbac/permissions';
+import { hasProxyAuth, displayParameter } from '@/app/utils/nodeIssueUtils';
+
+declare namespace HttpRequestNode {
+	namespace V2 {
+		type AuthParams = {
+			authentication: 'none' | 'genericCredentialType' | 'predefinedCredentialType';
+			genericAuthType: string;
+			nodeCredentialType: string;
+		};
+	}
+}
+
+type UpdateNodeAtIndexFn = (nodeIndex: number, nodeData: Partial<INodeUi>) => boolean;
+
+export function useWorkflowNodeIssuesState(updateNodeAtIndex: UpdateNodeAtIndexFn) {
+	const credentialsStore = useCredentialsStore();
+	const nodeTypesStore = useNodeTypesStore();
+	const workflowsStore = useWorkflowsStore();
+	const settingsStore = useSettingsStore();
+	const i18n = useI18n();
+
+	function setNodeIssue(nodeIssueData: INodeIssueData): void {
+		const nodeIndex = workflowsStore.workflow.nodes.findIndex((node) => {
+			return node.name === nodeIssueData.node;
+		});
+		if (nodeIndex === -1) {
+			return;
+		}
+
+		const node = workflowsStore.workflow.nodes[nodeIndex];
+
+		if (nodeIssueData.value === null) {
+			// Remove the value if one exists
+			if (node.issues?.[nodeIssueData.type] === undefined) {
+				// No values for type exist so nothing has to get removed
+				return;
+			}
+
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			const { [nodeIssueData.type]: _removedNodeIssue, ...remainingNodeIssues } = node.issues;
+			updateNodeAtIndex(nodeIndex, {
+				issues: remainingNodeIssues,
+			});
+		} else {
+			updateNodeAtIndex(nodeIndex, {
+				issues: {
+					...node.issues,
+					[nodeIssueData.type]: nodeIssueData.value as INodeIssueObjectProperty,
+				},
+			});
+		}
+	}
+
+	/**
+	 * Returns a list of credential IDs that the current user does not have access to,
+	 * if the Sharing feature is enabled.
+	 *
+	 * These are considered "foreign" credentials: the user can't view or manage them,
+	 * but can still execute workflows that use them.
+	 */
+	function getForeignCredentialsIfSharingEnabled(
+		credentials: INodeCredentials | undefined,
+	): string[] {
+		if (
+			!credentials ||
+			!settingsStore.isEnterpriseFeatureEnabled[EnterpriseEditionFeature.Sharing]
+		) {
+			return [];
+		}
+
+		const usedCredentials = workflowsStore.usedCredentials;
+
+		return Object.values(credentials)
+			.map(({ id }) => id)
+			.filter((id) => id !== null)
+			.filter((id) => id in usedCredentials && !usedCredentials[id]?.currentUserHasAccess);
+	}
+
+	function getNodeIssues(
+		nodeType: INodeTypeDescription | null,
+		node: INodeUi,
+		workflow: Workflow,
+		ignoreIssues?: string[],
+	): INodeIssues | null {
+		const pinDataNodeNames = Object.keys(workflowsStore.pinnedWorkflowData ?? {});
+
+		let nodeIssues: INodeIssues | null = null;
+		ignoreIssues = ignoreIssues ?? [];
+
+		if (node.disabled === true || pinDataNodeNames.includes(node.name)) {
+			// Ignore issues on disabled and pindata nodes
+			return null;
+		}
+
+		if (nodeType === null) {
+			// Node type is not known
+			if (!ignoreIssues.includes('typeUnknown')) {
+				nodeIssues = {
+					typeUnknown: true,
+				};
+			}
+		} else {
+			// Node type is known
+
+			// Add potential parameter issues
+			if (!ignoreIssues.includes('parameters')) {
+				nodeIssues = NodeHelpers.getNodeParametersIssues(nodeType.properties, node, nodeType);
+			}
+
+			if (!ignoreIssues.includes('credentials')) {
+				// Add potential credential issues
+				const nodeCredentialIssues = getNodeCredentialIssues(node, nodeType);
+				if (nodeIssues === null) {
+					nodeIssues = nodeCredentialIssues;
+				} else {
+					NodeHelpers.mergeIssues(nodeIssues, nodeCredentialIssues);
+				}
+			}
+
+			const nodeInputIssues = getNodeInputIssues(workflow, node, nodeType);
+			if (nodeIssues === null) {
+				nodeIssues = nodeInputIssues;
+			} else {
+				NodeHelpers.mergeIssues(nodeIssues, nodeInputIssues);
+			}
+		}
+
+		if (hasNodeExecutionIssues(node) && !ignoreIssues.includes('execution')) {
+			if (nodeIssues === null) {
+				nodeIssues = {};
+			}
+			nodeIssues.execution = true;
+		}
+
+		return nodeIssues;
+	}
+
+	// Set the status on all the nodes which produced an error so that it can be
+	// displayed in the node-view
+	function hasNodeExecutionIssues(node: INodeUi): boolean {
+		const workflowResultData = workflowsStore.getWorkflowRunData;
+
+		if (!workflowResultData?.hasOwnProperty(node.name)) {
+			return false;
+		}
+
+		for (const taskData of workflowResultData[node.name]) {
+			if (taskData.error !== undefined) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	function reportUnsetCredential(credentialType: ICredentialType) {
+		return {
+			credentials: {
+				[credentialType.name]: [
+					i18n.baseText('nodeHelpers.credentialsUnset', {
+						interpolate: {
+							credentialType: credentialType.displayName,
+						},
+					}),
+				],
+			},
+		};
+	}
+
+	function updateNodeInputIssues(node: INodeUi): void {
+		const nodeType = nodeTypesStore.getNodeType(node.type, node.typeVersion);
+		if (!nodeType) {
+			return;
+		}
+
+		const nodeInputIssues = getNodeInputIssues(
+			workflowsStore.workflowObject as Workflow,
+			node,
+			nodeType,
+		);
+
+		setNodeIssue({
+			node: node.name,
+			type: 'input',
+			value: nodeInputIssues?.input ? nodeInputIssues.input : null,
+		});
+	}
+
+	function updateNodesInputIssues() {
+		const nodes = workflowsStore.allNodes;
+
+		for (const node of nodes) {
+			updateNodeInputIssues(node);
+		}
+	}
+
+	function updateNodesExecutionIssues() {
+		const nodes = workflowsStore.allNodes;
+
+		for (const node of nodes) {
+			setNodeIssue({
+				node: node.name,
+				type: 'execution',
+				value: hasNodeExecutionIssues(node) ? true : null,
+			});
+		}
+	}
+
+	function updateNodesParameterIssues() {
+		const nodes = workflowsStore.allNodes;
+
+		for (const node of nodes) {
+			updateNodeParameterIssues(node);
+		}
+	}
+
+	function updateNodeCredentialIssuesByName(name: string): void {
+		const node = workflowsStore.getNodeByName(name);
+
+		if (node) {
+			updateNodeCredentialIssues(node);
+		}
+	}
+
+	function updateNodeCredentialIssues(node: INodeUi): void {
+		const fullNodeIssues: INodeIssues | null = getNodeCredentialIssues(node);
+
+		let newIssues: INodeIssueObjectProperty | null = null;
+		if (fullNodeIssues !== null) {
+			newIssues = fullNodeIssues.credentials!;
+		}
+
+		setNodeIssue({
+			node: node.name,
+			type: 'credentials',
+			value: newIssues,
+		});
+	}
+
+	function updateNodeParameterIssuesByName(name: string): void {
+		const node = workflowsStore.getNodeByName(name);
+
+		if (node) {
+			updateNodeParameterIssues(node);
+		}
+	}
+
+	function updateNodeParameterIssues(node: INodeUi, nodeType?: INodeTypeDescription | null): void {
+		const localNodeType = nodeType ?? nodeTypesStore.getNodeType(node.type, node.typeVersion);
+
+		if (localNodeType === null) {
+			// Could not find localNodeType so can not update issues
+			return;
+		}
+
+		// All data got updated everywhere so update now the issues
+		const fullNodeIssues: INodeIssues | null = NodeHelpers.getNodeParametersIssues(
+			localNodeType.properties,
+			node,
+			localNodeType,
+		);
+
+		let newIssues: INodeIssueObjectProperty | null = null;
+		if (fullNodeIssues !== null) {
+			newIssues = fullNodeIssues.parameters!;
+		}
+
+		setNodeIssue({
+			node: node.name,
+			type: 'parameters',
+			value: newIssues,
+		});
+	}
+
+	function getNodeInputIssues(
+		workflow: Workflow,
+		node: INodeUi,
+		nodeType?: INodeTypeDescription,
+	): INodeIssues | null {
+		const foundIssues: INodeIssueObjectProperty = {};
+
+		const workflowNode = workflow.getNode(node.name);
+		let inputs: Array<NodeConnectionType | INodeInputConfiguration> = [];
+		if (nodeType && workflowNode) {
+			inputs = NodeHelpers.getNodeInputs(workflow, workflowNode, nodeType);
+		}
+
+		inputs.forEach((input) => {
+			if (typeof input === 'string' || input.required !== true) {
+				return;
+			}
+
+			const parentNodes = workflow.getParentNodes(node.name, input.type, 1);
+
+			if (parentNodes.length === 0) {
+				foundIssues[input.type] = [
+					i18n.baseText('nodeIssues.input.missing', {
+						interpolate: { inputName: input.displayName || input.type },
+					}),
+				];
+			}
+		});
+
+		if (Object.keys(foundIssues).length) {
+			return {
+				input: foundIssues,
+			};
+		}
+
+		return null;
+	}
+
+	function getNodeCredentialIssues(
+		node: INodeUi,
+		nodeType?: INodeTypeDescription,
+	): INodeIssues | null {
+		const localNodeType = nodeType ?? nodeTypesStore.getNodeType(node.type, node.typeVersion);
+		if (node.disabled) {
+			// Node is disabled
+			return null;
+		}
+		if (!localNodeType?.credentials) {
+			// Node does not need any credentials or nodeType could not be found
+			return null;
+		}
+
+		const foundIssues: INodeIssueObjectProperty = {};
+
+		let userCredentials: ICredentialsResponse[] | null;
+		let credentialType: ICredentialType | undefined;
+		let credentialDisplayName: string;
+		let selectedCredentials: INodeCredentialsDetails;
+
+		const { authentication, genericAuthType, nodeCredentialType } =
+			node.parameters as HttpRequestNode.V2.AuthParams;
+
+		if (
+			authentication === 'genericCredentialType' &&
+			genericAuthType !== '' &&
+			selectedCredsAreUnusable(node, genericAuthType)
+		) {
+			const credential = credentialsStore.getCredentialTypeByName(genericAuthType);
+			return credential ? reportUnsetCredential(credential) : null;
+		}
+
+		if (
+			hasProxyAuth(node) &&
+			authentication === 'predefinedCredentialType' &&
+			nodeCredentialType !== '' &&
+			node.credentials !== undefined
+		) {
+			const stored = credentialsStore.getCredentialsByType(nodeCredentialType);
+			// Prevents HTTP Request node from being unusable if a sharee does not have direct
+			// access to a credential
+			const isCredentialUsedInWorkflow =
+				workflowsStore.usedCredentials?.[node.credentials?.[nodeCredentialType]?.id as string];
+
+			if (
+				selectedCredsDoNotExist(node, nodeCredentialType, stored) &&
+				!isCredentialUsedInWorkflow
+			) {
+				const credential = credentialsStore.getCredentialTypeByName(nodeCredentialType);
+				return credential ? reportUnsetCredential(credential) : null;
+			}
+		}
+
+		if (
+			hasProxyAuth(node) &&
+			authentication === 'predefinedCredentialType' &&
+			nodeCredentialType !== '' &&
+			selectedCredsAreUnusable(node, nodeCredentialType)
+		) {
+			const credential = credentialsStore.getCredentialTypeByName(nodeCredentialType);
+			return credential ? reportUnsetCredential(credential) : null;
+		}
+
+		for (const credentialTypeDescription of localNodeType.credentials) {
+			// Check if credentials should be displayed else ignore
+			const nodeTypeDescription = nodeTypesStore.getNodeType(node.type, node.typeVersion);
+			if (
+				!displayParameter(node.parameters, credentialTypeDescription, '', node, nodeTypeDescription)
+			) {
+				continue;
+			}
+
+			// Get the display name of the credential type
+			credentialType = credentialsStore.getCredentialTypeByName(credentialTypeDescription.name);
+			if (!credentialType) {
+				credentialDisplayName = credentialTypeDescription.name;
+			} else {
+				credentialDisplayName = credentialType.displayName;
+			}
+
+			if (!node.credentials?.[credentialTypeDescription.name]) {
+				// Credentials are not set
+				if (credentialTypeDescription.required) {
+					foundIssues[credentialTypeDescription.name] = [
+						i18n.baseText('nodeIssues.credentials.notSet', {
+							interpolate: { type: localNodeType.displayName },
+						}),
+					];
+				}
+			} else {
+				// If they are set check if the value is valid
+				selectedCredentials = node.credentials[credentialTypeDescription.name];
+				if (typeof selectedCredentials === 'string') {
+					selectedCredentials = {
+						id: null,
+						name: selectedCredentials,
+					};
+				}
+
+				userCredentials = credentialsStore.getCredentialsByType(credentialTypeDescription.name);
+
+				if (userCredentials === null) {
+					userCredentials = [];
+				}
+
+				if (selectedCredentials.id) {
+					const idMatch = userCredentials.find(
+						(credentialData) => credentialData.id === selectedCredentials.id,
+					);
+					if (idMatch) {
+						continue;
+					}
+				}
+
+				const nameMatches = userCredentials.filter(
+					(credentialData) => credentialData.name === selectedCredentials.name,
+				);
+				if (nameMatches.length > 1) {
+					foundIssues[credentialTypeDescription.name] = [
+						i18n.baseText('nodeIssues.credentials.notIdentified', {
+							interpolate: { name: selectedCredentials.name, type: credentialDisplayName },
+						}),
+						i18n.baseText('nodeIssues.credentials.notIdentified.hint'),
+					];
+					continue;
+				}
+
+				if (nameMatches.length === 0) {
+					const isCredentialUsedInWorkflow =
+						workflowsStore.usedCredentials?.[selectedCredentials.id as string];
+
+					if (
+						!isCredentialUsedInWorkflow &&
+						!hasPermission(['rbac'], { rbac: { scope: 'credential:read' } })
+					) {
+						foundIssues[credentialTypeDescription.name] = [
+							i18n.baseText('nodeIssues.credentials.doNotExist', {
+								interpolate: { name: selectedCredentials.name, type: credentialDisplayName },
+							}),
+							i18n.baseText('nodeIssues.credentials.doNotExist.hint'),
+						];
+					}
+				}
+			}
+		}
+
+		// TODO: Could later check also if the node has access to the credentials
+		if (Object.keys(foundIssues).length === 0) {
+			return null;
+		}
+
+		return {
+			credentials: foundIssues,
+		};
+	}
+
+	/**
+	 * Whether the node has no selected credentials, or none of the node's
+	 * selected credentials are of the specified type.
+	 */
+	function selectedCredsAreUnusable(node: INodeUi, credentialType: string) {
+		return !node.credentials || !Object.keys(node.credentials).includes(credentialType);
+	}
+
+	/**
+	 * Whether the node's selected credentials of the specified type
+	 * can no longer be found in the database.
+	 */
+	function selectedCredsDoNotExist(
+		node: INodeUi,
+		nodeCredentialType: string,
+		storedCredsByType: ICredentialsResponse[] | null,
+	) {
+		if (!node.credentials || !storedCredsByType) return false;
+
+		const selectedCredsByType = node.credentials[nodeCredentialType];
+
+		if (!selectedCredsByType) return false;
+
+		return !storedCredsByType.find((c) => c.id === selectedCredsByType.id);
+	}
+
+	function updateNodesCredentialsIssues() {
+		const nodes = workflowsStore.allNodes;
+		let issues: INodeIssues | null;
+
+		for (const node of nodes) {
+			issues = getNodeCredentialIssues(node);
+
+			setNodeIssue({
+				node: node.name,
+				type: 'credentials',
+				value: issues?.credentials ?? null,
+			});
+		}
+	}
+
+	/**
+	 * Wrapper for displayParameter that fetches nodeTypeDescription automatically.
+	 * Maintains backward compatibility with the original 5-arg signature.
+	 */
+	function displayParameterWithNodeType(
+		nodeValues: INodeParameters,
+		parameter: INodeProperties | INodeCredentialDescription,
+		path: string,
+		node: INodeUi | null,
+		displayKey: 'displayOptions' | 'disabledOptions' = 'displayOptions',
+	): boolean {
+		const nodeTypeDescription = node?.type
+			? nodeTypesStore.getNodeType(node.type, node.typeVersion)
+			: null;
+		return displayParameter(nodeValues, parameter, path, node, nodeTypeDescription, displayKey);
+	}
+
+	return {
+		// Issue checking
+		getNodeIssues,
+		hasNodeExecutionIssues,
+		getNodeInputIssues,
+		getNodeCredentialIssues,
+		selectedCredsAreUnusable,
+		selectedCredsDoNotExist,
+		reportUnsetCredential,
+		getForeignCredentialsIfSharingEnabled,
+
+		// Issue updates (single node)
+		setNodeIssue,
+		updateNodeInputIssues,
+		updateNodeCredentialIssues,
+		updateNodeCredentialIssuesByName,
+		updateNodeParameterIssues,
+		updateNodeParameterIssuesByName,
+
+		// Issue updates (all nodes)
+		updateNodesInputIssues,
+		updateNodesExecutionIssues,
+		updateNodesParameterIssues,
+		updateNodesCredentialsIssues,
+
+		// Parameter display utility
+		displayParameter: displayParameterWithNodeType,
+
+		// Re-export pure utilities for convenience
+		hasProxyAuth,
+	};
+}
+
+export type WorkflowNodeIssuesState = ReturnType<typeof useWorkflowNodeIssuesState>;

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowState.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowState.ts
@@ -443,7 +443,7 @@ export function useWorkflowState() {
 	}
 
 	// Create node issues state
-	const nodeIssuesState = useWorkflowNodeIssuesState(updateNodeAtIndex);
+	const nodeIssuesState = useWorkflowNodeIssuesState({ updateNodeAtIndex });
 
 	return {
 		// Workflow editing state

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowState.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowState.ts
@@ -16,8 +16,6 @@ import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useBuilderStore } from '@/features/ai/assistant/builder.store';
 import { getPairedItemsMapping } from '@/app/utils/pairedItemUtils';
 import {
-	type INodeIssueData,
-	type INodeIssueObjectProperty,
 	NodeHelpers,
 	type IDataObject,
 	type INodeParameters,
@@ -41,6 +39,7 @@ import pick from 'lodash/pick';
 import { createEventBus } from '@n8n/utils/event-bus';
 import type { WorkflowMetadata } from '@n8n/rest-api-client';
 import { dataPinningEventBus } from '../event-bus';
+import { useWorkflowNodeIssuesState } from './useWorkflowNodeIssuesState';
 
 export type WorkflowStateBusEvents = {
 	updateNodeProperties: [WorkflowState, INodeUpdatePropertiesInformation];
@@ -443,37 +442,8 @@ export function useWorkflowState() {
 		workflowStateEventBus.emit('updateNodeProperties', [this, updateInformation]);
 	}
 
-	function setNodeIssue(nodeIssueData: INodeIssueData): void {
-		const nodeIndex = ws.workflow.nodes.findIndex((node) => {
-			return node.name === nodeIssueData.node;
-		});
-		if (nodeIndex === -1) {
-			return;
-		}
-
-		const node = ws.workflow.nodes[nodeIndex];
-
-		if (nodeIssueData.value === null) {
-			// Remove the value if one exists
-			if (node.issues?.[nodeIssueData.type] === undefined) {
-				// No values for type exist so nothing has to get removed
-				return;
-			}
-
-			// eslint-disable-next-line @typescript-eslint/no-unused-vars
-			const { [nodeIssueData.type]: _removedNodeIssue, ...remainingNodeIssues } = node.issues;
-			updateNodeAtIndex(nodeIndex, {
-				issues: remainingNodeIssues,
-			});
-		} else {
-			updateNodeAtIndex(nodeIndex, {
-				issues: {
-					...node.issues,
-					[nodeIssueData.type]: nodeIssueData.value as INodeIssueObjectProperty,
-				},
-			});
-		}
-	}
+	// Create node issues state
+	const nodeIssuesState = useWorkflowNodeIssuesState(updateNodeAtIndex);
 
 	return {
 		// Workflow editing state
@@ -505,7 +475,6 @@ export function useWorkflowState() {
 		setLastNodeParameters,
 		setNodeValue,
 		setNodePositionById,
-		setNodeIssue,
 		updateNodeAtIndex,
 		updateNodeById,
 		updateNodeProperties,
@@ -513,6 +482,9 @@ export function useWorkflowState() {
 
 		// reexport
 		executingNode: workflowStateStore.executingNode,
+
+		// Node issues state
+		...nodeIssuesState,
 	};
 }
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
@@ -11,7 +11,6 @@ import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useBuilderStore } from '@/features/ai/assistant/builder.store';
 import { injectWorkflowState } from '@/app/composables/useWorkflowState';
 import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
-import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { canvasEventBus } from '@/features/workflows/canvas/canvas.eventBus';
 import { mapLegacyConnectionsToCanvasConnections } from '@/features/workflows/canvas/canvas.utils';
 import { getAuthTypeForNodeCredential, getMainAuthField } from '@/app/utils/nodeTypesUtils';
@@ -43,7 +42,6 @@ export function useWorkflowUpdate() {
 	const nodeTypesStore = useNodeTypesStore();
 	const builderStore = useBuilderStore();
 	const canvasOperations = useCanvasOperations();
-	const nodeHelpers = useNodeHelpers();
 
 	/**
 	 * Categorize nodes into those to update, add, or remove
@@ -128,7 +126,7 @@ export function useWorkflowUpdate() {
 		// Revalidate updated nodes to refresh error indicators on canvas
 		for (const { existing } of nodesToUpdate) {
 			const nodeName = renamedNodes.get(existing.id) ?? existing.name;
-			nodeHelpers.updateNodeParameterIssuesByName(nodeName);
+			workflowState.updateNodeParameterIssuesByName(nodeName);
 		}
 	}
 

--- a/packages/frontend/editor-ui/src/app/utils/nodeIssueUtils.ts
+++ b/packages/frontend/editor-ui/src/app/utils/nodeIssueUtils.ts
@@ -1,0 +1,72 @@
+import { NodeHelpers } from 'n8n-workflow';
+import type {
+	INodeProperties,
+	INodeCredentialDescription,
+	INodeTypeDescription,
+	INodeIssues,
+	INodeIssueObjectProperty,
+	INode,
+	INodeParameters,
+} from 'n8n-workflow';
+
+import type { INodeUi } from '@/Interface';
+
+export function hasProxyAuth(node: INodeUi): boolean {
+	return Object.keys(node.parameters).includes('nodeCredentialType');
+}
+
+/**
+ * Returns if the given parameter should be displayed or not
+ */
+export function displayParameter(
+	nodeValues: INodeParameters,
+	parameter: INodeProperties | INodeCredentialDescription,
+	path: string,
+	node: INodeUi | null,
+	nodeTypeDescription: INodeTypeDescription | null,
+	displayKey: 'displayOptions' | 'disabledOptions' = 'displayOptions',
+): boolean {
+	return NodeHelpers.displayParameterPath(
+		nodeValues,
+		parameter,
+		path,
+		node,
+		nodeTypeDescription,
+		displayKey,
+	);
+}
+
+/**
+ * Returns the issues of the node as string
+ */
+export function nodeIssuesToString(issues: INodeIssues, node?: INode): string[] {
+	const nodeIssues: string[] = [];
+
+	if (issues.execution !== undefined) {
+		nodeIssues.push('Execution Error.');
+	}
+
+	const objectProperties = ['parameters', 'credentials', 'input'];
+
+	let issueText: string;
+	let parameterName: string;
+	for (const propertyName of objectProperties) {
+		if (issues[propertyName] !== undefined) {
+			for (parameterName of Object.keys(issues[propertyName] as object)) {
+				for (issueText of (issues[propertyName] as INodeIssueObjectProperty)[parameterName]) {
+					nodeIssues.push(issueText);
+				}
+			}
+		}
+	}
+
+	if (issues.typeUnknown !== undefined) {
+		if (node !== undefined) {
+			nodeIssues.push(`Node Type "${node.type}" is not known.`);
+		} else {
+			nodeIssues.push('Node Type is not known.');
+		}
+	}
+
+	return nodeIssues;
+}

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -105,7 +105,6 @@ import { useNpsSurveyStore } from '@/app/stores/npsSurvey.store';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useHistoryStore } from '@/app/stores/history.store';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
-import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { useExecutionDebugging } from '@/features/execution/executions/composables/useExecutionDebugging';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import { sourceControlEventBus } from '@/features/integrations/sourceControl.ee/sourceControl.eventBus';
@@ -192,7 +191,6 @@ const workflowSaving = useWorkflowSaving({
 		canvasEventBus.emit('saved:workflow', { isFirstSave });
 	},
 });
-const nodeHelpers = useNodeHelpers();
 const clipboard = useClipboard({ onPaste: onClipboardPaste });
 
 const nodeTypesStore = useNodeTypesStore();
@@ -558,9 +556,9 @@ async function initializeWorkspaceForExistingWorkflow(id: string) {
 }
 
 function updateNodesIssues() {
-	nodeHelpers.updateNodesInputIssues();
-	nodeHelpers.updateNodesCredentialsIssues();
-	nodeHelpers.updateNodesParameterIssues();
+	workflowState.updateNodesInputIssues();
+	workflowState.updateNodesCredentialsIssues();
+	workflowState.updateNodesParameterIssues();
 }
 
 /**

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -22,7 +22,6 @@ import CredentialSharing from './CredentialSharing.ee.vue';
 import Modal from '@/app/components/Modal.vue';
 import SaveButton from '@/app/components/SaveButton.vue';
 import { useMessage } from '@/app/composables/useMessage';
-import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { useToast } from '@/app/composables/useToast';
 import { CREDENTIAL_EDIT_MODAL_KEY } from '../../credentials.constants';
 import { EnterpriseEditionFeature, MODAL_CONFIRM } from '@/app/constants';
@@ -84,7 +83,6 @@ const workflowState = injectWorkflowState();
 const nodeTypesStore = useNodeTypesStore();
 const projectsStore = useProjectsStore();
 
-const nodeHelpers = useNodeHelpers();
 const externalHooks = useExternalHooks();
 const toast = useToast();
 const message = useMessage();
@@ -474,7 +472,12 @@ function displayCredentialParameter(parameter: INodeProperties): boolean {
 		return true;
 	}
 
-	return nodeHelpers.displayParameter(credentialData.value as INodeParameters, parameter, '', null);
+	return workflowState.displayParameter(
+		credentialData.value as INodeParameters,
+		parameter,
+		'',
+		null,
+	);
 }
 
 function getCredentialProperties(name: string): INodeProperties[] {
@@ -968,7 +971,7 @@ async function updateCredential(
 
 	// Now that the credentials changed check if any nodes use credentials
 	// which have now a different name
-	nodeHelpers.updateNodesCredentialsIssues();
+	workflowState.updateNodesCredentialsIssues();
 
 	return credential;
 }
@@ -1013,7 +1016,7 @@ async function deleteCredential() {
 
 	isDeleting.value = false;
 	// Now that the credentials were removed check if any nodes used them
-	nodeHelpers.updateNodesCredentialsIssues();
+	workflowState.updateNodesCredentialsIssues();
 	credentialData.value = {};
 
 	toast.showMessage({

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
@@ -10,7 +10,7 @@ import type {
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { I18nT } from 'vue-i18n';
 
-import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
+import { hasProxyAuth } from '@/app/utils/nodeIssueUtils';
 import { useToast } from '@/app/composables/useToast';
 
 import TitledList from '@/app/components/TitledList.vue';
@@ -89,7 +89,6 @@ const canCreateCredentials = computed(
 		).credential.create,
 );
 
-const nodeHelpers = useNodeHelpers();
 const toast = useToast();
 
 const subscribedToCredentialType = ref('');
@@ -348,7 +347,7 @@ function onCredentialSelected(
 	telemetry.track('User selected credential from node modal', {
 		credential_type: credentialType,
 		node_type: props.node.type,
-		...(nodeHelpers.hasProxyAuth(props.node) ? { is_service_specific: true } : {}),
+		...(hasProxyAuth(props.node) ? { is_service_specific: true } : {}),
 		workflow_id: workflowsStore.workflowId,
 		credential_id: credentialId,
 	});
@@ -374,7 +373,7 @@ function onCredentialSelected(
 			invalid: oldCredentials,
 			type: selectedCredentialsType,
 		});
-		nodeHelpers.updateNodesCredentialsIssues();
+		workflowState.updateNodesCredentialsIssues();
 		toast.showMessage({
 			title: i18n.baseText('nodeCredentials.showMessage.title'),
 			message: i18n.baseText('nodeCredentials.showMessage.message', {
@@ -395,7 +394,7 @@ function onCredentialSelected(
 	});
 
 	if (updatedNodesCount > 0) {
-		nodeHelpers.updateNodesCredentialsIssues();
+		workflowState.updateNodesCredentialsIssues();
 		toast.showMessage({
 			title: i18n.baseText('nodeCredentials.showMessage.title'),
 			message: i18n.baseText('nodeCredentials.autoAssigned.message', {

--- a/packages/frontend/editor-ui/src/features/credentials/composables/useNodeCredentialOptions.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/useNodeCredentialOptions.ts
@@ -1,4 +1,4 @@
-import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
+import { injectWorkflowState } from '@/app/composables/useWorkflowState';
 import { KEEP_AUTH_IN_NDV_FOR_NODES } from '@/app/constants';
 import type { INodeUi } from '@/Interface';
 import type { ICredentialsResponse } from '../credentials.types';
@@ -25,7 +25,7 @@ export function useNodeCredentialOptions(
 	nodeType: ComputedRef<INodeTypeDescription | null>,
 	overrideCredType: MaybeRef<NodeParameterValueType | undefined>,
 ) {
-	const nodeHelpers = useNodeHelpers();
+	const workflowState = injectWorkflowState();
 	const credentialsStore = useCredentialsStore();
 	const mainNodeAuthField = computed(() => getMainAuthField(nodeType.value));
 
@@ -73,7 +73,7 @@ export function useNodeCredentialOptions(
 			// If it is not defined no need to do a proper check
 			return true;
 		}
-		return nodeHelpers.displayParameter(
+		return workflowState.displayParameter(
 			node.value.parameters,
 			credentialTypeDescription,
 			'',

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsPanel.test.ts
@@ -67,6 +67,14 @@ vi.mock('@/app/composables/useNodeHelpers', async (importOriginal) => {
 	};
 });
 
+vi.mock('@/app/composables/useWorkflowState', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('@/app/composables/useWorkflowState')>();
+	return {
+		...actual,
+		injectWorkflowState: () => workflowStateRef.current,
+	};
+});
+
 describe('LogsPanel', () => {
 	const VIEWPORT_HEIGHT = 800;
 

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsPanel.test.ts
@@ -68,6 +68,7 @@ vi.mock('@/app/composables/useNodeHelpers', async (importOriginal) => {
 });
 
 vi.mock('@/app/composables/useWorkflowState', async (importOriginal) => {
+	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 	const actual = await importOriginal<typeof import('@/app/composables/useWorkflowState')>();
 	return {
 		...actual,

--- a/packages/frontend/editor-ui/src/features/execution/logs/composables/useChatState.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/composables/useChatState.ts
@@ -1,7 +1,6 @@
 import type { RunWorkflowChatPayload } from '@/features/execution/logs/composables/useChatMessaging';
 import { useChatMessaging } from '@/features/execution/logs/composables/useChatMessaging';
 import { useI18n } from '@n8n/i18n';
-import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { useRunWorkflow } from '@/app/composables/useRunWorkflow';
 import { VIEWS } from '@/app/constants';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
@@ -46,7 +45,6 @@ export function useChatState(isReadOnly: boolean): ChatState {
 	const rootStore = useRootStore();
 	const logsStore = useLogsStore();
 	const router = useRouter();
-	const nodeHelpers = useNodeHelpers();
 	const { runWorkflow } = useRunWorkflow({ router });
 
 	const ws = ref<WebSocket | null>(null);
@@ -228,7 +226,7 @@ export function useChatState(isReadOnly: boolean): ChatState {
 
 	function refreshSession() {
 		workflowState.setWorkflowExecutionData(null);
-		nodeHelpers.updateNodesExecutionIssues();
+		workflowState.updateNodesExecutionIssues();
 		logsStore.resetChatSessionId();
 		logsStore.resetMessages();
 

--- a/packages/frontend/editor-ui/src/features/execution/logs/composables/useLogsExecutionData.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/composables/useLogsExecutionData.ts
@@ -2,7 +2,6 @@ import { watch, computed, ref, type ComputedRef } from 'vue';
 import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
 import { Workflow, type IRunExecutionData, type ITaskStartedData } from 'n8n-workflow';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
-import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import {
 	copyExecutionData,
 	createLogTree,
@@ -27,7 +26,6 @@ interface UseLogsExecutionDataOptions {
 }
 
 export function useLogsExecutionData({ isEnabled, filter }: UseLogsExecutionDataOptions = {}) {
-	const nodeHelpers = useNodeHelpers();
 	const workflowsStore = useWorkflowsStore();
 	const workflowState = injectWorkflowState();
 	const toast = useToast();
@@ -92,7 +90,7 @@ export function useLogsExecutionData({ isEnabled, filter }: UseLogsExecutionData
 	function resetExecutionData() {
 		state.value = undefined;
 		workflowState.setWorkflowExecutionData(null);
-		nodeHelpers.updateNodesExecutionIssues();
+		workflowState.updateNodesExecutionIssues();
 		void workflowsStore.fetchLastSuccessfulExecution();
 	}
 

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/NDVSubConnections.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/NDVSubConnections.vue
@@ -4,7 +4,8 @@ import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { computed, ref, watch } from 'vue';
 import { NodeHelpers } from 'n8n-workflow';
-import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
+import { injectWorkflowState } from '@/app/composables/useWorkflowState';
+import { nodeIssuesToString } from '@/app/utils/nodeIssueUtils';
 import NodeIcon from '@/app/components/NodeIcon.vue';
 import TitledList from '@/app/components/TitledList.vue';
 import type {
@@ -26,7 +27,7 @@ interface Props {
 const props = defineProps<Props>();
 const workflowsStore = useWorkflowsStore();
 const nodeTypesStore = useNodeTypesStore();
-const nodeHelpers = useNodeHelpers();
+const workflowState = injectWorkflowState();
 const i18n = useI18n();
 const { debounce } = useDebounce();
 const emit = defineEmits<{
@@ -65,7 +66,7 @@ const ndvStore = useNDVStore();
 const workflowObject = computed(() => workflowsStore.workflowObject as Workflow);
 
 const nodeInputIssues = computed(() => {
-	const issues = nodeHelpers.getNodeIssues(nodeType.value, props.rootNode, workflowObject.value, [
+	const issues = workflowState.getNodeIssues(nodeType.value, props.rootNode, workflowObject.value, [
 		'typeUnknown',
 		'parameters',
 		'credentials',
@@ -163,8 +164,8 @@ function getINodesFromNames(names: string[]): NodeConfig[] {
 			if (node) {
 				const matchedNodeType = nodeTypesStore.getNodeType(node.type);
 				if (matchedNodeType) {
-					const issues = nodeHelpers.getNodeIssues(matchedNodeType, node, workflowObject.value);
-					const stringifiedIssues = issues ? nodeHelpers.nodeIssuesToString(issues, node) : '';
+					const issues = workflowState.getNodeIssues(matchedNodeType, node, workflowObject.value);
+					const stringifiedIssues = issues ? nodeIssuesToString(issues, node) : '';
 					return { node, nodeType: matchedNodeType, issues: stringifiedIssues };
 				}
 			}

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/Collection/CollectionParameterLegacy.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/Collection/CollectionParameterLegacy.vue
@@ -15,7 +15,7 @@ import { deepCopy, isINodeProperties, isINodePropertyCollection } from 'n8n-work
 import get from 'lodash/get';
 
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
-import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
+import { injectWorkflowState } from '@/app/composables/useWorkflowState';
 import { useI18n } from '@n8n/i18n';
 import { storeToRefs } from 'pinia';
 
@@ -40,7 +40,7 @@ const emit = defineEmits<{
 const props = defineProps<Props>();
 const ndvStore = useNDVStore();
 const i18n = useI18n();
-const nodeHelpers = useNodeHelpers();
+const workflowState = injectWorkflowState();
 
 const { activeNode } = storeToRefs(ndvStore);
 
@@ -79,7 +79,12 @@ function displayNodeParameter(parameter: INodeProperties) {
 		// If it is not defined no need to do a proper check
 		return true;
 	}
-	return nodeHelpers.displayParameter(props.nodeValues, parameter, props.path, ndvStore.activeNode);
+	return workflowState.displayParameter(
+		props.nodeValues,
+		parameter,
+		props.path,
+		ndvStore.activeNode,
+	);
 }
 
 function getOptionProperties(

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/Collection/CollectionParameterNew.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/Collection/CollectionParameterNew.vue
@@ -15,7 +15,7 @@ import { deepCopy, isINodeProperties, isINodePropertyCollection } from 'n8n-work
 import get from 'lodash/get';
 
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
-import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
+import { injectWorkflowState } from '@/app/composables/useWorkflowState';
 import { useI18n } from '@n8n/i18n';
 import { storeToRefs } from 'pinia';
 
@@ -53,7 +53,7 @@ const props = withDefaults(defineProps<Props>(), {
 });
 const ndvStore = useNDVStore();
 const i18n = useI18n();
-const nodeHelpers = useNodeHelpers();
+const workflowState = injectWorkflowState();
 
 const { activeNode } = storeToRefs(ndvStore);
 
@@ -97,7 +97,12 @@ function displayNodeParameter(parameter: INodeProperties) {
 		// If it is not defined no need to do a proper check
 		return true;
 	}
-	return nodeHelpers.displayParameter(props.nodeValues, parameter, props.path, ndvStore.activeNode);
+	return workflowState.displayParameter(
+		props.nodeValues,
+		parameter,
+		props.path,
+		ndvStore.activeNode,
+	);
 }
 
 function getOptionProperties(

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterLegacy.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterLegacy.vue
@@ -20,7 +20,7 @@ import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { telemetry } from '@/app/plugins/telemetry';
 import { storeToRefs } from 'pinia';
-import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
+import { injectWorkflowState } from '@/app/composables/useWorkflowState';
 
 import {
 	N8nButton,
@@ -33,7 +33,7 @@ import {
 } from '@n8n/design-system';
 
 const locale = useI18n();
-const nodeHelpers = useNodeHelpers();
+const workflowState = injectWorkflowState();
 
 export type Props = {
 	nodeValues: INodeParameters;
@@ -255,8 +255,8 @@ const getPickerPropertyValues = (
 			return false;
 		}
 
-		// Use the existing displayParameter helper from node-helpers to check visibility
-		return nodeHelpers.displayParameter(props.nodeValues, value, itemPath, activeNode.value);
+		// Use the existing displayParameter helper from workflowState to check visibility
+		return workflowState.displayParameter(props.nodeValues, value, itemPath, activeNode.value);
 	});
 };
 

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterNew.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterNew.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { useFixedCollectionItemState } from '@/app/composables/useFixedCollectionItemState';
-import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
+import { injectWorkflowState } from '@/app/composables/useWorkflowState';
 import { telemetry } from '@/app/plugins/telemetry';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
@@ -33,7 +33,7 @@ import FixedCollectionItemList from './FixedCollectionItemList.vue';
 const locale = useI18n();
 const ndvStore = useNDVStore();
 const workflowsStore = useWorkflowsStore();
-const nodeHelpers = useNodeHelpers();
+const workflowState = injectWorkflowState();
 const { activeNode } = storeToRefs(ndvStore);
 
 export type Props = {
@@ -271,8 +271,8 @@ const getPickerPropertyValues = (
 			return false;
 		}
 
-		// Use the existing displayParameter helper from node-helpers to check visibility
-		return nodeHelpers.displayParameter(props.nodeValues, value, itemPath, activeNode.value);
+		// Use the existing displayParameter helper from workflowState to check visibility
+		return workflowState.displayParameter(props.nodeValues, value, itemPath, activeNode.value);
 	});
 };
 

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
@@ -71,7 +71,6 @@ import {
 import { useDebounce } from '@/app/composables/useDebounce';
 import { useExternalHooks } from '@/app/composables/useExternalHooks';
 import { useI18n } from '@n8n/i18n';
-import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useWorkflowHelpers } from '@/app/composables/useWorkflowHelpers';
 import { useNodeSettingsParameters } from '@/features/ndv/settings/composables/useNodeSettingsParameters';
@@ -166,7 +165,6 @@ const emit = defineEmits<{
 
 const externalHooks = useExternalHooks();
 const i18n = useI18n();
-const nodeHelpers = useNodeHelpers();
 const { debounce } = useDebounce();
 const workflowHelpers = useWorkflowHelpers();
 const nodeSettingsParameters = useNodeSettingsParameters();
@@ -686,7 +684,7 @@ function credentialSelected(updateInformation: INodeUpdatePropertiesInformation)
 
 	if (updateNode) {
 		// Update the issues
-		nodeHelpers.updateNodeCredentialIssues(updateNode);
+		workflowState.updateNodeCredentialIssues(updateNode);
 	}
 
 	void externalHooks.run('nodeSettings.credentialSelected', { updateInformation });

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
@@ -1041,7 +1041,7 @@ async function onTogglePinData({ source }: { source: PinDataSource | UnpinDataSo
 		telemetry.track('User clicked pin data icon', telemetryPayload);
 	}
 
-	nodeHelpers.updateNodeParameterIssues(node.value);
+	workflowState.updateNodeParameterIssues(node.value);
 
 	if (pinnedData.hasData.value) {
 		pinnedData.unsetData(source);

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
@@ -395,8 +395,8 @@ const valueChanged = (parameterData: IUpdateInformation) => {
 
 			workflowState.setNodeParameters(updateInformation);
 
-			nodeHelpers.updateNodeParameterIssuesByName(_node.name);
-			nodeHelpers.updateNodeCredentialIssuesByName(_node.name);
+			workflowState.updateNodeParameterIssuesByName(_node.name);
+			workflowState.updateNodeCredentialIssuesByName(_node.name);
 		}
 	} else if (nameIsParameter(parameterData)) {
 		// A node parameter changed
@@ -489,7 +489,7 @@ const credentialSelected = (updateInformation: INodeUpdatePropertiesInformation)
 
 	if (node) {
 		// Update the issues
-		nodeHelpers.updateNodeCredentialIssues(node);
+		workflowState.updateNodeCredentialIssues(node);
 	}
 
 	void externalHooks.run('nodeSettings.credentialSelected', { updateInformation });
@@ -556,7 +556,7 @@ onMounted(async () => {
 	setNodeValues();
 	props.eventBus?.on('openSettings', openSettings);
 	if (node.value !== null) {
-		nodeHelpers.updateNodeParameterIssues(node.value, nodeType.value);
+		workflowState.updateNodeParameterIssues(node.value, nodeType.value);
 	}
 	importCurlEventBus.on('setHttpNodeParameters', setHttpNodeParameters);
 	ndvEventBus.on('updateParameterValue', valueChanged);
@@ -576,7 +576,7 @@ function displayCredentials(credentialTypeDescription: INodeCredentialDescriptio
 
 	return (
 		!!node.value &&
-		nodeHelpers.displayParameter(node.value.parameters, credentialTypeDescription, '', node.value)
+		workflowState.displayParameter(node.value.parameters, credentialTypeDescription, '', node.value)
 	);
 }
 

--- a/packages/frontend/editor-ui/src/features/ndv/settings/composables/useNodeSettingsParameters.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/composables/useNodeSettingsParameters.test.ts
@@ -15,6 +15,18 @@ import { mockedStore } from '@/__tests__/utils';
 import type { INodeUi } from '@/Interface';
 import { CHAT_TRIGGER_NODE_TYPE, HTTP_REQUEST_NODE_TYPE, WEBHOOK_NODE_TYPE } from '@/app/constants';
 
+const displayParameterSpy = vi.fn();
+
+vi.mock('@/app/composables/useWorkflowState', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('@/app/composables/useWorkflowState')>();
+	return {
+		...actual,
+		injectWorkflowState: () => ({
+			displayParameter: displayParameterSpy,
+		}),
+	};
+});
+
 describe('useNodeSettingsParameters', () => {
 	beforeEach(() => {
 		setActivePinia(createTestingPinia());
@@ -97,7 +109,6 @@ describe('useNodeSettingsParameters', () => {
 	});
 
 	describe('shouldDisplayNodeParameter', () => {
-		const displayParameterSpy = vi.fn();
 		function mockNodeHelpers({ isCustomApiCallSelected = false } = {}) {
 			const originalNodeHelpers = nodeHelpers.useNodeHelpers();
 
@@ -105,7 +116,6 @@ describe('useNodeSettingsParameters', () => {
 				return {
 					...originalNodeHelpers,
 					isCustomApiCallSelected: vi.fn(() => isCustomApiCallSelected),
-					displayParameter: displayParameterSpy,
 				};
 			});
 		}

--- a/packages/frontend/editor-ui/src/features/ndv/settings/composables/useNodeSettingsParameters.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/composables/useNodeSettingsParameters.test.ts
@@ -18,6 +18,7 @@ import { CHAT_TRIGGER_NODE_TYPE, HTTP_REQUEST_NODE_TYPE, WEBHOOK_NODE_TYPE } fro
 const displayParameterSpy = vi.fn();
 
 vi.mock('@/app/composables/useWorkflowState', async (importOriginal) => {
+	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 	const actual = await importOriginal<typeof import('@/app/composables/useWorkflowState')>();
 	return {
 		...actual,

--- a/packages/frontend/editor-ui/src/features/ndv/settings/composables/useNodeSettingsParameters.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/composables/useNodeSettingsParameters.ts
@@ -142,8 +142,8 @@ export function useNodeSettingsParameters() {
 			oldNodeParameters,
 		});
 
-		nodeHelpers.updateNodeParameterIssuesByName(node.name);
-		nodeHelpers.updateNodeCredentialIssuesByName(node.name);
+		workflowState.updateNodeParameterIssuesByName(node.name);
+		workflowState.updateNodeCredentialIssuesByName(node.name);
 		telemetry.trackNodeParametersValuesChange(nodeTypeDescription.name, parameterData);
 	}
 
@@ -240,7 +240,7 @@ export function useNodeSettingsParameters() {
 
 		// Fast path: no keys means nothing to resolve
 		if (keyCount === 0) {
-			return nodeHelpers.displayParameter(nodeParameters, parameter, path, node, displayKey);
+			return workflowState.displayParameter(nodeParameters, parameter, path, node, displayKey);
 		}
 
 		// Check if we have any expressions to resolve (scan first to avoid unnecessary work)
@@ -255,7 +255,7 @@ export function useNodeSettingsParameters() {
 
 		// Fast path: no expressions means we can use original parameters directly
 		if (!hasExpressions) {
-			return nodeHelpers.displayParameter(nodeParameters, parameter, path, node, displayKey);
+			return workflowState.displayParameter(nodeParameters, parameter, path, node, displayKey);
 		}
 
 		// Resolve expressions - use index-based iteration for better performance
@@ -366,12 +366,12 @@ export function useNodeSettingsParameters() {
 			if (path) {
 				const resolvedValues = deepCopy(nodeParameters);
 				set(resolvedValues, path, nodeParams);
-				return nodeHelpers.displayParameter(resolvedValues, parameter, path, node, displayKey);
+				return workflowState.displayParameter(resolvedValues, parameter, path, node, displayKey);
 			}
-			return nodeHelpers.displayParameter(nodeParams, parameter, '', node, displayKey);
+			return workflowState.displayParameter(nodeParams, parameter, '', node, displayKey);
 		}
 
-		return nodeHelpers.displayParameter(nodeParameters, parameter, path, node, displayKey);
+		return workflowState.displayParameter(nodeParameters, parameter, path, node, displayKey);
 	}
 
 	return {

--- a/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsView.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsView.vue
@@ -27,6 +27,7 @@ import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useDeviceSupport } from '@n8n/composables/useDeviceSupport';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
+import { injectWorkflowState } from '@/app/composables/useWorkflowState';
 import { useMessage } from '@/app/composables/useMessage';
 import { useExternalHooks } from '@/app/composables/useExternalHooks';
 import { usePinnedData } from '@/app/composables/usePinnedData';
@@ -65,6 +66,7 @@ const props = withDefaults(
 const ndvStore = useNDVStore();
 const externalHooks = useExternalHooks();
 const nodeHelpers = useNodeHelpers();
+const workflowState = injectWorkflowState();
 const { activeNode } = storeToRefs(ndvStore);
 const pinnedData = usePinnedData(activeNode);
 const nodeTypesStore = useNodeTypesStore();
@@ -315,7 +317,7 @@ const blockUi = computed(
 );
 
 const foreignCredentials = computed(() =>
-	nodeHelpers.getForeignCredentialsIfSharingEnabled(activeNode.value?.credentials),
+	workflowState.getForeignCredentialsIfSharingEnabled(activeNode.value?.credentials),
 );
 
 const hasForeignCredential = computed(() => foreignCredentials.value.length > 0);

--- a/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsViewV2.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsViewV2.vue
@@ -15,6 +15,7 @@ import { useMessage } from '@/app/composables/useMessage';
 import { useNdvLayout } from '../../panel/composables/useNdvLayout';
 import { useNodeDocsUrl } from '@/app/composables/useNodeDocsUrl';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
+import { injectWorkflowState } from '@/app/composables/useWorkflowState';
 import { usePinnedData } from '@/app/composables/usePinnedData';
 import { useStyles } from '@/app/composables/useStyles';
 import { useTelemetry } from '@/app/composables/useTelemetry';
@@ -66,6 +67,7 @@ const props = withDefaults(
 const ndvStore = useNDVStore();
 const externalHooks = useExternalHooks();
 const nodeHelpers = useNodeHelpers();
+const workflowState = injectWorkflowState();
 const { activeNode } = storeToRefs(ndvStore);
 const pinnedData = usePinnedData(activeNode);
 const nodeTypesStore = useNodeTypesStore();
@@ -301,7 +303,7 @@ const isExecutionWaitingForWebhook = computed(() => workflowsStore.executionWait
 const blockUi = computed(() => isWorkflowRunning.value || isExecutionWaitingForWebhook.value);
 
 const foreignCredentials = computed(() =>
-	nodeHelpers.getForeignCredentialsIfSharingEnabled(activeNode.value?.credentials),
+	workflowState.getForeignCredentialsIfSharingEnabled(activeNode.value?.credentials),
 );
 
 const hasForeignCredential = computed(() => foreignCredentials.value.length > 0);

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.ts
@@ -57,6 +57,7 @@ import {
 import { sanitizeHtml } from '@/app/utils/htmlUtils';
 import { MarkerType } from '@vue-flow/core';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
+import { nodeIssuesToString } from '@/app/utils/nodeIssueUtils';
 import { getTriggerNodeServiceName } from '@/app/utils/nodeTypesUtils';
 import { useNodeDirtiness } from '@/app/composables/useNodeDirtiness';
 import { getNodeIconSource } from '@/app/utils/nodeIcon';
@@ -486,7 +487,7 @@ export function useCanvasMapping({
 			const validationErrors: string[] = [];
 
 			if (node?.issues !== undefined) {
-				validationErrors.push(...nodeHelpers.nodeIssuesToString(node.issues, node));
+				validationErrors.push(...nodeIssuesToString(node.issues, node));
 			}
 
 			acc[node.id] = validationErrors;

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/components/ExperimentalCanvasNodeSettings.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/components/ExperimentalCanvasNodeSettings.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import NodeSettings from '@/features/ndv/settings/components/NodeSettings.vue';
 import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
-import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
+import { injectWorkflowState } from '@/app/composables/useWorkflowState';
 import { type IUpdateInformation } from '@/Interface';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useUIStore } from '@/app/stores/ui.store';
@@ -24,12 +24,12 @@ const emit = defineEmits<{
 const workflowsStore = useWorkflowsStore();
 const uiStore = useUIStore();
 const { renameNode } = useCanvasOperations();
-const nodeHelpers = useNodeHelpers();
+const workflowState = injectWorkflowState();
 const ndvStore = useNDVStore();
 
 const activeNode = computed(() => workflowsStore.getNodeById(nodeId));
 const foreignCredentials = computed(() =>
-	nodeHelpers.getForeignCredentialsIfSharingEnabled(activeNode.value?.credentials),
+	workflowState.getForeignCredentialsIfSharingEnabled(activeNode.value?.credentials),
 );
 const isWorkflowRunning = computed(() => uiStore.isActionActive.workflowRunning);
 const isExecutionWaitingForWebhook = computed(() => workflowsStore.executionWaitingForWebhook);

--- a/packages/frontend/editor-ui/src/features/workflows/templates/composables/useSetupWorkflowCredentialsModalState.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/composables/useSetupWorkflowCredentialsModalState.ts
@@ -1,6 +1,5 @@
 import { computed } from 'vue';
 import type { INodeCredentialsDetails } from 'n8n-workflow';
-import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import type { TemplateCredentialKey } from '../utils/templateTransforms';
@@ -11,7 +10,6 @@ export const useSetupWorkflowCredentialsModalState = () => {
 	const workflowsStore = useWorkflowsStore();
 	const workflowState = injectWorkflowState();
 	const credentialsStore = useCredentialsStore();
-	const nodeHelpers = useNodeHelpers();
 
 	const workflowNodes = computed(() => {
 		return workflowsStore.allNodes;
@@ -78,7 +76,7 @@ export const useSetupWorkflowCredentialsModalState = () => {
 			// We can't use updateNodeCredentialIssues because the previous
 			// step creates a new instance of the node in the store and
 			// `node` no longer points to the correct node.
-			nodeHelpers.updateNodeCredentialIssuesByName(node.name);
+			workflowState.updateNodeCredentialIssuesByName(node.name);
 		});
 
 		setInitialCredentialSelection();
@@ -109,7 +107,7 @@ export const useSetupWorkflowCredentialsModalState = () => {
 			// We can't use updateNodeCredentialIssues because the previous
 			// step creates a new instance of the node in the store and
 			// `node` no longer points to the correct node.
-			nodeHelpers.updateNodeCredentialIssuesByName(node.name);
+			workflowState.updateNodeCredentialIssuesByName(node.name);
 		});
 
 		setInitialCredentialSelection();


### PR DESCRIPTION
## Summary

Move node issue state management logic from useNodeHelpers to a dedicated useWorkflowNodeIssuesState composable and extract utility functions into nodeIssueUtils. This improves code organization and separation of concerns.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2264/extract-node-issue-handling-to-separate-composable-and-utilities

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
