### PR TITLE
feat(Twilio Trigger Node): Add webhook signature verification

### DIFF
--- a/packages/nodes-base/nodes/Twilio/TwilioTriggerHelpers.ts
+++ b/packages/nodes-base/nodes/Twilio/TwilioTriggerHelpers.ts
@@ -1,0 +1,89 @@
+import { createHash, createHmac } from 'crypto';
+import type { IWebhookFunctions } from 'n8n-workflow';
+
+import { verifySignature as verifySignatureGeneric } from '../../utils/webhook-signature-verification';
+
+/**
+ * Verifies the Twilio Event Streams webhook signature.
+ *
+ * Twilio Event Streams webhooks use the following verification:
+ * 1. The request body is hashed with SHA-256 (hex encoded)
+ * 2. The bodySHA256 is appended as a query parameter to the webhook URL
+ * 3. The URL (with bodySHA256 query param) is signed with HMAC-SHA1 using the Auth Token
+ * 4. The signature is sent in the `X-Twilio-Signature` header, base64 encoded
+ *
+ * @see https://www.twilio.com/docs/usage/webhooks/webhooks-security
+ * @see https://www.twilio.com/en-us/blog/validate-twilio-event-streams-webhooks-php
+ *
+ * @returns true if the signature is valid, false otherwise
+ * @returns true if no auth token is available (backwards compatibility)
+ */
+export async function verifySignature(this: IWebhookFunctions): Promise<boolean> {
+	const credentials = await this.getCredentials('twilioApi');
+	const req = this.getRequestObject();
+	const webhookUrl = this.getNodeWebhookUrl('default');
+
+	// Skip verification only when using API Key auth or no auth token
+	// (backwards compatibility for users who haven't configured auth token)
+	const hasAuthToken = credentials.authType === 'authToken' && credentials.authToken;
+
+	return verifySignatureGeneric({
+		getExpectedSignature: () => {
+			if (!hasAuthToken) {
+				return null;
+			}
+
+			// If we have auth token but missing webhook URL, we can't verify - fail
+			if (!webhookUrl) {
+				return null;
+			}
+
+			const authToken = credentials.authToken as string;
+
+			// Get raw body for hash computation
+			const rawBody = getRawBodyAsString(req);
+			if (!rawBody) {
+				return null;
+			}
+
+			// Compute SHA256 hash of the body (hex encoded, as per Twilio's algorithm)
+			const bodyHash = createHash('sha256').update(rawBody).digest('hex');
+
+			// Build the URL with bodySHA256 parameter
+			const url = new URL(webhookUrl);
+			url.searchParams.set('bodySHA256', bodyHash);
+			const signatureBaseString = url.toString();
+
+			// Compute HMAC-SHA1 signature
+			const hmac = createHmac('sha1', authToken);
+			hmac.update(signatureBaseString);
+			return hmac.digest('base64');
+		},
+		// Only skip when no auth token configured (backwards compatibility)
+		skipIfNoExpectedSignature: !hasAuthToken,
+		getActualSignature: () => {
+			const signature = req.header('x-twilio-signature');
+			return typeof signature === 'string' ? signature : null;
+		},
+	});
+}
+
+/**
+ * Get the raw body as a string for hash verification.
+ */
+function getRawBodyAsString(req: {
+	rawBody?: Buffer | string;
+	body?: unknown;
+}): string | null {
+	if (Buffer.isBuffer(req.rawBody)) {
+		return req.rawBody.toString('utf8');
+	}
+	if (typeof req.rawBody === 'string') {
+		return req.rawBody;
+	}
+	// Fallback to stringified body if rawBody is not available
+	if (req.body !== undefined) {
+		return typeof req.body === 'string' ? req.body : JSON.stringify(req.body);
+	}
+	return null;
+}

--- a/packages/nodes-base/nodes/Twilio/__tests__/TwilioTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Twilio/__tests__/TwilioTrigger.node.test.ts
@@ -1,0 +1,73 @@
+import { TwilioTrigger } from '../TwilioTrigger.node';
+import * as TwilioTriggerHelpers from '../TwilioTriggerHelpers';
+
+describe('TwilioTrigger Node', () => {
+	describe('webhook method', () => {
+		let mockThis: {
+			getBodyData: jest.Mock;
+			getResponseObject: jest.Mock;
+			helpers: { returnJsonArray: jest.Mock };
+		};
+
+		beforeEach(() => {
+			jest.clearAllMocks();
+
+			mockThis = {
+				getBodyData: jest.fn().mockReturnValue({
+					specversion: '1.0',
+					type: 'com.twilio.messaging.inbound-message.received',
+					data: { messageSid: 'SM123' },
+				}),
+				getResponseObject: jest.fn().mockReturnValue({
+					status: jest.fn().mockReturnThis(),
+					send: jest.fn().mockReturnThis(),
+					end: jest.fn(),
+				}),
+				helpers: {
+					returnJsonArray: jest.fn().mockImplementation((data) => [{ json: data }]),
+				},
+			};
+		});
+
+		it('should reject with 401 when signature verification fails', async () => {
+			jest.spyOn(TwilioTriggerHelpers, 'verifySignature').mockResolvedValueOnce(false);
+
+			const trigger = new TwilioTrigger();
+			const result = await trigger.webhook.call(mockThis as never);
+
+			expect(result).toEqual({ noWebhookResponse: true });
+			expect(mockThis.getResponseObject).toHaveBeenCalled();
+			const res = mockThis.getResponseObject();
+			expect(res.status).toHaveBeenCalledWith(401);
+			expect(res.send).toHaveBeenCalledWith('Unauthorized');
+			expect(res.end).toHaveBeenCalled();
+		});
+
+		it('should process webhook when signature verification succeeds', async () => {
+			jest.spyOn(TwilioTriggerHelpers, 'verifySignature').mockResolvedValueOnce(true);
+
+			const trigger = new TwilioTrigger();
+			const result = await trigger.webhook.call(mockThis as never);
+
+			expect(result).toHaveProperty('workflowData');
+			expect(mockThis.getBodyData).toHaveBeenCalled();
+			expect(mockThis.helpers.returnJsonArray).toHaveBeenCalled();
+		});
+
+		it('should return the body data as workflow data when verification passes', async () => {
+			const testBodyData = {
+				specversion: '1.0',
+				type: 'com.twilio.messaging.inbound-message.received',
+				data: { messageSid: 'SM456', from: '+1234567890' },
+			};
+			mockThis.getBodyData.mockReturnValue(testBodyData);
+			jest.spyOn(TwilioTriggerHelpers, 'verifySignature').mockResolvedValueOnce(true);
+
+			const trigger = new TwilioTrigger();
+			const result = await trigger.webhook.call(mockThis as never);
+
+			expect(result.workflowData).toBeDefined();
+			expect(mockThis.helpers.returnJsonArray).toHaveBeenCalledWith(testBodyData);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Twilio/__tests__/TwilioTriggerHelpers.test.ts
+++ b/packages/nodes-base/nodes/Twilio/__tests__/TwilioTriggerHelpers.test.ts
@@ -1,0 +1,231 @@
+import { createHmac, createHash, timingSafeEqual } from 'crypto';
+
+import { verifySignature } from '../TwilioTriggerHelpers';
+
+jest.mock('crypto', () => ({
+	...jest.requireActual('crypto'),
+	createHmac: jest.fn().mockReturnValue({
+		update: jest.fn().mockReturnThis(),
+		digest: jest.fn().mockReturnValue('GxVchyDnq5TeTNrQjvRwST4VaEc='),
+	}),
+	createHash: jest.fn().mockReturnValue({
+		update: jest.fn().mockReturnThis(),
+		digest: jest
+			.fn()
+			.mockReturnValue('5ccde7145dfb8f56479710896586cb9d5911809d83afbe34627818790db0aec9'),
+	}),
+	timingSafeEqual: jest.fn(),
+}));
+
+describe('TwilioTriggerHelpers', () => {
+	let mockWebhookFunctions: {
+		getCredentials: jest.Mock;
+		getRequestObject: jest.Mock;
+		getNodeWebhookUrl: jest.Mock;
+	};
+	const testAuthToken = 'test_auth_token_12345';
+	const testWebhookUrl = 'https://example.com/webhook/twiliotrigger';
+	const testJsonBody = '{"event":"message","data":{"id":"123"}}';
+	const testSignature = 'GxVchyDnq5TeTNrQjvRwST4VaEc=';
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		mockWebhookFunctions = {
+			getCredentials: jest.fn(),
+			getRequestObject: jest.fn(),
+			getNodeWebhookUrl: jest.fn().mockReturnValue(testWebhookUrl),
+		};
+
+		// Default mock return values for JSON request
+		mockWebhookFunctions.getRequestObject.mockReturnValue({
+			header: jest.fn().mockImplementation((header) => {
+				if (header === 'x-twilio-signature') return testSignature;
+				return null;
+			}),
+			rawBody: testJsonBody,
+		});
+	});
+
+	describe('verifySignature', () => {
+		it('should return true when using API Key auth type (skip verification)', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'apiKey',
+				apiKeySid: 'test-api-key',
+				apiKeySecret: 'test-api-secret',
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions as never);
+
+			expect(result).toBe(true);
+			expect(mockWebhookFunctions.getCredentials).toHaveBeenCalledWith('twilioApi');
+		});
+
+		it('should return true when no auth token is configured (backwards compatibility)', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				accountSid: 'test-account-sid',
+				authToken: '',
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions as never);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false when signature header is missing', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				accountSid: 'test-account-sid',
+				authToken: testAuthToken,
+			});
+
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockReturnValue(null),
+				rawBody: testJsonBody,
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions as never);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false when webhook URL is not available', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				accountSid: 'test-account-sid',
+				authToken: testAuthToken,
+			});
+			mockWebhookFunctions.getNodeWebhookUrl.mockReturnValue(undefined);
+
+			const result = await verifySignature.call(mockWebhookFunctions as never);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false when rawBody is missing', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				accountSid: 'test-account-sid',
+				authToken: testAuthToken,
+			});
+
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header) => {
+					if (header === 'x-twilio-signature') return testSignature;
+					return null;
+				}),
+				rawBody: undefined,
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions as never);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return true when signature is valid', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				accountSid: 'test-account-sid',
+				authToken: testAuthToken,
+			});
+			(timingSafeEqual as jest.Mock).mockReturnValue(true);
+
+			const result = await verifySignature.call(mockWebhookFunctions as never);
+
+			expect(result).toBe(true);
+			expect(createHash).toHaveBeenCalledWith('sha256');
+			expect(createHmac).toHaveBeenCalledWith('sha1', testAuthToken);
+			expect(timingSafeEqual).toHaveBeenCalled();
+		});
+
+		it('should return false when signature is invalid', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				accountSid: 'test-account-sid',
+				authToken: testAuthToken,
+			});
+			(timingSafeEqual as jest.Mock).mockReturnValue(false);
+
+			const result = await verifySignature.call(mockWebhookFunctions as never);
+
+			expect(result).toBe(false);
+			expect(createHmac).toHaveBeenCalledWith('sha1', testAuthToken);
+			expect(timingSafeEqual).toHaveBeenCalled();
+		});
+
+		it('should compute bodySHA256 and build signature base string correctly', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				accountSid: 'test-account-sid',
+				authToken: testAuthToken,
+			});
+			(timingSafeEqual as jest.Mock).mockReturnValue(true);
+
+			await verifySignature.call(mockWebhookFunctions as never);
+
+			// Should compute SHA256 hash of the body
+			expect(createHash).toHaveBeenCalledWith('sha256');
+			const mockHash = createHash('sha256');
+			expect(mockHash.update).toHaveBeenCalledWith(testJsonBody);
+			expect(mockHash.digest).toHaveBeenCalledWith('hex');
+
+			// Should compute HMAC-SHA1 of the URL with bodySHA256
+			expect(createHmac).toHaveBeenCalledWith('sha1', testAuthToken);
+		});
+
+		it('should handle Buffer rawBody correctly', async () => {
+			const bufferBody = Buffer.from(testJsonBody);
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				accountSid: 'test-account-sid',
+				authToken: testAuthToken,
+			});
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				header: jest.fn().mockImplementation((header) => {
+					if (header === 'x-twilio-signature') return testSignature;
+					return null;
+				}),
+				rawBody: bufferBody,
+			});
+			(timingSafeEqual as jest.Mock).mockReturnValue(true);
+
+			const result = await verifySignature.call(mockWebhookFunctions as never);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false when computed and provided signatures have different lengths', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				accountSid: 'test-account-sid',
+				authToken: testAuthToken,
+			});
+			// Mock a different length signature
+			const mockHmacInstance = {
+				update: jest.fn().mockReturnThis(),
+				digest: jest.fn().mockReturnValue('short'),
+			};
+			(createHmac as jest.Mock).mockReturnValue(mockHmacInstance);
+
+			const result = await verifySignature.call(mockWebhookFunctions as never);
+
+			expect(result).toBe(false);
+			// timingSafeEqual should not be called if lengths don't match
+			expect(timingSafeEqual).not.toHaveBeenCalled();
+		});
+
+		it('should use getNodeWebhookUrl to get the webhook URL', async () => {
+			mockWebhookFunctions.getCredentials.mockResolvedValue({
+				authType: 'authToken',
+				accountSid: 'test-account-sid',
+				authToken: testAuthToken,
+			});
+			(timingSafeEqual as jest.Mock).mockReturnValue(true);
+
+			await verifySignature.call(mockWebhookFunctions as never);
+
+			expect(mockWebhookFunctions.getNodeWebhookUrl).toHaveBeenCalledWith('default');
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Add webhook signature verification for the Twilio Trigger node to validate that incoming requests originate from Twilio.

### Implementation Details
- Uses Twilio's standard `X-Twilio-Signature` header for verification
- Validates the signature using HMAC-SHA1 with the account's Auth Token
- For Event Streams JSON payloads, also verifies the `bodySHA256` query parameter against the request body
- Backwards compatible: skips verification when using API Key authentication (no Auth Token available)
- Returns 401 Unauthorized for invalid signatures

### How to Test
1. Create a Twilio Trigger workflow
2. Configure it with valid Twilio API credentials (using Auth Token authentication)
3. Activate the workflow
4. Send a test event from the Twilio Console
5. Verify the event is processed correctly with valid signatures
6. Try sending a request with an invalid/missing signature and verify it returns 401

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4317

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)