### PR TITLE
feat(Acuity Scheduling Trigger Node): Add webhook signature verification

### DIFF
--- a/packages/nodes-base/nodes/AcuityScheduling/AcuitySchedulingTrigger.node.ts
+++ b/packages/nodes-base/nodes/AcuityScheduling/AcuitySchedulingTrigger.node.ts
@@ -8,6 +8,7 @@ import type {
 } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
 
+import { verifySignature } from './AcuitySchedulingTriggerHelpers';
 import { acuitySchedulingApiRequest } from './GenericFunctions';
 
 export class AcuitySchedulingTrigger implements INodeType {
@@ -161,6 +162,15 @@ export class AcuitySchedulingTrigger implements INodeType {
 	};
 
 	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
+		// Verify webhook signature
+		if (!(await verifySignature.call(this))) {
+			const res = this.getResponseObject();
+			res.status(401).send('Unauthorized').end();
+			return {
+				noWebhookResponse: true,
+			};
+		}
+
 		const req = this.getRequestObject();
 
 		const resolveData = this.getNodeParameter('resolveData', false) as boolean;

--- a/packages/nodes-base/nodes/AcuityScheduling/AcuitySchedulingTriggerHelpers.ts
+++ b/packages/nodes-base/nodes/AcuityScheduling/AcuitySchedulingTriggerHelpers.ts
@@ -1,0 +1,56 @@
+import { createHmac } from 'crypto';
+import type { IWebhookFunctions } from 'n8n-workflow';
+
+import { verifySignature as verifySignatureGeneric } from '../../utils/webhook-signature-verification';
+
+/**
+ * Verifies the Acuity Scheduling webhook signature.
+ *
+ * Acuity signs webhooks using HMAC SHA-256:
+ * 1. Create HMAC SHA-256 hash of the request body using the API key as the secret
+ * 2. Encode the hash in base64 format
+ * 3. Compare with the signature in the `x-acuity-signature` header
+ *
+ * Note: For OAuth2 authentication, no API key is available for verification,
+ * so we skip signature verification (backward compatible).
+ *
+ * @see https://developers.acuityscheduling.com/docs/webhooks#verifying-webhook-requests
+ * @returns true if the signature is valid, false otherwise
+ * @returns true if no API key is available (OAuth2 or backward compatibility)
+ */
+export async function verifySignature(this: IWebhookFunctions): Promise<boolean> {
+	const req = this.getRequestObject();
+	const authentication = this.getNodeParameter('authentication', 'apiKey') as string;
+
+	// For OAuth2, we don't have an API key to verify signatures
+	// Skip verification for backward compatibility
+	if (authentication !== 'apiKey') {
+		return true;
+	}
+
+	let apiKey: string | undefined;
+	try {
+		const credentials = await this.getCredentials('acuitySchedulingApi');
+		apiKey = credentials?.apiKey as string | undefined;
+	} catch {
+		// If credentials can't be retrieved, skip verification
+		return true;
+	}
+
+	return verifySignatureGeneric({
+		getExpectedSignature: () => {
+			if (!apiKey || !req.rawBody) {
+				return null;
+			}
+			const hmac = createHmac('sha256', apiKey);
+			const payload = Buffer.isBuffer(req.rawBody) ? req.rawBody : Buffer.from(req.rawBody);
+			hmac.update(payload);
+			return hmac.digest('base64');
+		},
+		skipIfNoExpectedSignature: !apiKey,
+		getActualSignature: () => {
+			const receivedSignature = req.header('x-acuity-signature');
+			return typeof receivedSignature === 'string' ? receivedSignature : null;
+		},
+	});
+}

--- a/packages/nodes-base/nodes/AcuityScheduling/__tests__/AcuitySchedulingTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/AcuityScheduling/__tests__/AcuitySchedulingTrigger.node.test.ts
@@ -1,0 +1,157 @@
+import type { IHookFunctions, IWebhookFunctions } from 'n8n-workflow';
+
+import { AcuitySchedulingTrigger } from '../AcuitySchedulingTrigger.node';
+import { verifySignature } from '../AcuitySchedulingTriggerHelpers';
+import { acuitySchedulingApiRequest } from '../GenericFunctions';
+
+jest.mock('../GenericFunctions', () => ({
+	acuitySchedulingApiRequest: jest.fn(),
+}));
+
+jest.mock('../AcuitySchedulingTriggerHelpers', () => ({
+	verifySignature: jest.fn().mockResolvedValue(true),
+}));
+
+const mockedAcuitySchedulingApiRequest = jest.mocked(acuitySchedulingApiRequest);
+const mockedVerifySignature = jest.mocked(verifySignature);
+
+describe('AcuityScheduling Trigger Node', () => {
+	let node: AcuitySchedulingTrigger;
+	let mockNodeFunctions: IHookFunctions;
+
+	beforeEach(() => {
+		node = new AcuitySchedulingTrigger();
+
+		mockNodeFunctions = {
+			getNodeWebhookUrl: jest.fn().mockReturnValue('https://webhook.url/test'),
+			getNodeParameter: jest.fn(),
+			getWorkflowStaticData: jest.fn().mockReturnValue({}),
+			getNode: jest.fn().mockReturnValue({ name: 'AcuitySchedulingTrigger' }),
+		} as unknown as IHookFunctions;
+
+		mockedAcuitySchedulingApiRequest.mockResolvedValue({
+			id: 123,
+			event: 'appointment.scheduled',
+			target: 'https://webhook.url/test',
+			status: 'active',
+		});
+
+		mockedAcuitySchedulingApiRequest.mockClear();
+		mockedVerifySignature.mockClear();
+	});
+
+	afterAll(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('webhookMethods', () => {
+		it('should create webhook with correct parameters', async () => {
+			(mockNodeFunctions.getNodeParameter as jest.Mock).mockReturnValue('appointment.scheduled');
+
+			await node.webhookMethods.default.create.call(mockNodeFunctions);
+
+			expect(mockedAcuitySchedulingApiRequest).toHaveBeenCalledWith('POST', '/webhooks', {
+				target: 'https://webhook.url/test',
+				event: 'appointment.scheduled',
+			});
+		});
+
+		it('should check if webhook exists', async () => {
+			const staticData = { webhookId: 123 };
+			(mockNodeFunctions.getWorkflowStaticData as jest.Mock).mockReturnValue(staticData);
+			mockedAcuitySchedulingApiRequest.mockResolvedValue([{ id: 123 }]);
+
+			const result = await node.webhookMethods.default.checkExists.call(mockNodeFunctions);
+
+			expect(result).toBe(true);
+			expect(mockedAcuitySchedulingApiRequest).toHaveBeenCalledWith('GET', '/webhooks');
+		});
+
+		it('should return false when webhook does not exist', async () => {
+			const staticData = { webhookId: 123 };
+			(mockNodeFunctions.getWorkflowStaticData as jest.Mock).mockReturnValue(staticData);
+			mockedAcuitySchedulingApiRequest.mockResolvedValue([{ id: 456 }]);
+
+			const result = await node.webhookMethods.default.checkExists.call(mockNodeFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should delete webhook', async () => {
+			const staticData = { webhookId: 123 };
+			(mockNodeFunctions.getWorkflowStaticData as jest.Mock).mockReturnValue(staticData);
+
+			const result = await node.webhookMethods.default.delete.call(mockNodeFunctions);
+
+			expect(result).toBe(true);
+			expect(mockedAcuitySchedulingApiRequest).toHaveBeenCalledWith('DELETE', '/webhooks/123');
+			expect(staticData.webhookId).toBeUndefined();
+		});
+	});
+
+	describe('webhook signature verification', () => {
+		let mockWebhookFunctions: IWebhookFunctions;
+		const testBody = { action: 'appointment.scheduled', id: 123, calendarID: 1 };
+
+		beforeEach(() => {
+			mockWebhookFunctions = {
+				getBodyData: jest.fn().mockReturnValue(testBody),
+				getRequestObject: jest.fn().mockReturnValue({
+					body: testBody,
+				}),
+				getResponseObject: jest.fn().mockReturnValue({
+					status: jest.fn().mockReturnThis(),
+					send: jest.fn().mockReturnThis(),
+					end: jest.fn(),
+				}),
+				getNodeParameter: jest.fn().mockReturnValue(false),
+				helpers: {
+					returnJsonArray: jest.fn().mockImplementation((data) => [data]),
+				},
+			} as unknown as IWebhookFunctions;
+
+			mockedVerifySignature.mockResolvedValue(true);
+		});
+
+		it('should process webhook with valid signature', async () => {
+			mockedVerifySignature.mockResolvedValue(true);
+
+			const result = await node.webhook.call(mockWebhookFunctions);
+
+			expect(result).toEqual({
+				workflowData: [[testBody]],
+			});
+			expect(mockedVerifySignature).toHaveBeenCalled();
+		});
+
+		it('should reject webhook with invalid signature', async () => {
+			mockedVerifySignature.mockResolvedValue(false);
+
+			const result = await node.webhook.call(mockWebhookFunctions);
+
+			expect(result).toEqual({
+				noWebhookResponse: true,
+			});
+			expect(mockedVerifySignature).toHaveBeenCalled();
+		});
+
+		it('should resolve data when resolveData is true', async () => {
+			(mockWebhookFunctions.getNodeParameter as jest.Mock).mockImplementation((param) => {
+				if (param === 'resolveData') return true;
+				if (param === 'event') return 'appointment.scheduled';
+				return undefined;
+			});
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				body: { id: 123 },
+			});
+			mockedAcuitySchedulingApiRequest.mockResolvedValue({ id: 123, name: 'Test Appointment' });
+
+			const result = await node.webhook.call(mockWebhookFunctions);
+
+			expect(mockedAcuitySchedulingApiRequest).toHaveBeenCalledWith('GET', '/appointments/123', {});
+			expect(result).toEqual({
+				workflowData: [[{ id: 123, name: 'Test Appointment' }]],
+			});
+		});
+	});
+});

--- a/packages/nodes-base/nodes/AcuityScheduling/__tests__/AcuitySchedulingTriggerHelpers.test.ts
+++ b/packages/nodes-base/nodes/AcuityScheduling/__tests__/AcuitySchedulingTriggerHelpers.test.ts
@@ -1,0 +1,142 @@
+import { createHmac } from 'crypto';
+import type { IWebhookFunctions } from 'n8n-workflow';
+
+import { verifySignature } from '../AcuitySchedulingTriggerHelpers';
+
+describe('AcuitySchedulingTriggerHelpers', () => {
+	describe('verifySignature', () => {
+		let mockWebhookFunctions: IWebhookFunctions;
+		const apiKey = 'test-api-key-123';
+		const testBody = { action: 'appointment.scheduled', id: '123', calendarID: '1' };
+		const rawBody = JSON.stringify(testBody);
+
+		function generateValidSignature(body: string, secret: string): string {
+			return createHmac('sha256', secret).update(body).digest('base64');
+		}
+
+		beforeEach(() => {
+			mockWebhookFunctions = {
+				getCredentials: jest.fn().mockResolvedValue({
+					userId: 'test-user',
+					apiKey,
+				}),
+				getNodeParameter: jest.fn().mockReturnValue('apiKey'),
+				getRequestObject: jest.fn().mockReturnValue({
+					header: jest.fn(),
+					rawBody: Buffer.from(rawBody),
+				}),
+			} as unknown as IWebhookFunctions;
+		});
+
+		it('should return true when signature is valid', async () => {
+			const validSignature = generateValidSignature(rawBody, apiKey);
+			const mockHeader = jest.fn().mockReturnValue(validSignature);
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				header: mockHeader,
+				rawBody: Buffer.from(rawBody),
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+			expect(mockHeader).toHaveBeenCalledWith('x-acuity-signature');
+		});
+
+		it('should return false when signature is invalid', async () => {
+			const invalidSignature = generateValidSignature(rawBody, 'wrong-api-key');
+			const mockHeader = jest.fn().mockReturnValue(invalidSignature);
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				header: mockHeader,
+				rawBody: Buffer.from(rawBody),
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false when x-acuity-signature header is missing', async () => {
+			const mockHeader = jest.fn().mockReturnValue(undefined);
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				header: mockHeader,
+				rawBody: Buffer.from(rawBody),
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(false);
+			expect(mockHeader).toHaveBeenCalledWith('x-acuity-signature');
+		});
+
+		it('should return true when authentication is OAuth2 (no API key available)', async () => {
+			(mockWebhookFunctions.getNodeParameter as jest.Mock).mockReturnValue('oAuth2');
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return true when credentials cannot be retrieved', async () => {
+			(mockWebhookFunctions.getCredentials as jest.Mock).mockRejectedValue(
+				new Error('Credentials error'),
+			);
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return true when API key is not available in credentials', async () => {
+			(mockWebhookFunctions.getCredentials as jest.Mock).mockResolvedValue({
+				userId: 'test-user',
+				// No apiKey
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should handle string rawBody', async () => {
+			const validSignature = generateValidSignature(rawBody, apiKey);
+			const mockHeader = jest.fn().mockReturnValue(validSignature);
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				header: mockHeader,
+				rawBody, // String instead of Buffer
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return true when rawBody is missing and no API key', async () => {
+			(mockWebhookFunctions.getCredentials as jest.Mock).mockResolvedValue({
+				userId: 'test-user',
+			});
+			const mockHeader = jest.fn().mockReturnValue('some-signature');
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				header: mockHeader,
+				rawBody: null,
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false when rawBody is missing but API key is present', async () => {
+			const mockHeader = jest.fn().mockReturnValue('some-signature');
+			(mockWebhookFunctions.getRequestObject as jest.Mock).mockReturnValue({
+				header: mockHeader,
+				rawBody: null,
+			});
+
+			const result = await verifySignature.call(mockWebhookFunctions);
+
+			// Should return false because we can't compute expected signature without body
+			// but we have an API key so we don't skip
+			expect(result).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Add webhook signature verification to the Acuity Scheduling Trigger node using the shared verifySignature utility.

**Changes:**
- Add AcuitySchedulingTriggerHelpers.ts with HMAC SHA-256 signature verification
- Uses the API key from credentials as the signing secret (per Acuity's webhook docs)
- Skips verification for OAuth2 users (no API key available) for backward compatibility
- Add comprehensive unit tests for both helpers and trigger node

**How to test:**
1. Configure an Acuity Scheduling Trigger node with API Key authentication
2. Register the webhook with Acuity
3. Verify incoming webhook requests are validated using the x-acuity-signature header

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4299

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with release/backport (if the PR is an urgent fix that needs to be backported)