### PR TITLE
feat(ClickUp Node): Add points field support

### DIFF
--- a/packages/nodes-base/nodes/ClickUp/ClickUp.node.ts
+++ b/packages/nodes-base/nodes/ClickUp/ClickUp.node.ts
@@ -924,6 +924,9 @@ export class ClickUp implements INodeType {
 						if (additionalFields.parentId) {
 							body.parent = additionalFields.parentId as string;
 						}
+						if (additionalFields.points !== undefined) {
+							body.points = additionalFields.points as number;
+						}
 						if (additionalFields.markdownContent) {
 							delete body.content;
 							body.markdown_content = additionalFields.content as string;
@@ -968,6 +971,9 @@ export class ClickUp implements INodeType {
 						}
 						if (updateFields.parentId) {
 							body.parent = updateFields.parentId as string;
+						}
+						if (updateFields.points !== undefined) {
+							body.points = updateFields.points as number;
 						}
 						if (updateFields.addAssignees) {
 							//@ts-ignore

--- a/packages/nodes-base/nodes/ClickUp/TaskDescription.ts
+++ b/packages/nodes-base/nodes/ClickUp/TaskDescription.ts
@@ -261,6 +261,16 @@ export const taskFields: INodeProperties[] = [
 				default: '',
 			},
 			{
+				displayName: 'Points',
+				name: 'points',
+				type: 'number',
+				typeOptions: {
+					minValue: 0,
+				},
+				description: 'Sprint points for the task',
+				default: 0,
+			},
+			{
 				displayName: 'Priority',
 				name: 'priority',
 				type: 'number',
@@ -394,6 +404,16 @@ export const taskFields: INodeProperties[] = [
 				name: 'parentId',
 				type: 'string',
 				default: '',
+			},
+			{
+				displayName: 'Points',
+				name: 'points',
+				type: 'number',
+				typeOptions: {
+					minValue: 0,
+				},
+				description: 'Sprint points for the task',
+				default: 0,
 			},
 			{
 				displayName: 'Priority',

--- a/packages/nodes-base/nodes/ClickUp/TaskInterface.ts
+++ b/packages/nodes-base/nodes/ClickUp/TaskInterface.ts
@@ -15,5 +15,6 @@ export interface ITask {
 	markdown_content?: string;
 	notify_all?: boolean;
 	parent?: string;
+	points?: number;
 	custom_fields?: IDataObject[];
 }

--- a/packages/nodes-base/nodes/ClickUp/__schema__/v1.0.0/task/create.json
+++ b/packages/nodes-base/nodes/ClickUp/__schema__/v1.0.0/task/create.json
@@ -148,7 +148,7 @@
             "type": "string"
         },
         "points": {
-            "type": "null"
+            "type": ["null", "number"]
         },
         "project": {
             "type": "object",

--- a/packages/nodes-base/nodes/ClickUp/__schema__/v1.0.0/task/get.json
+++ b/packages/nodes-base/nodes/ClickUp/__schema__/v1.0.0/task/get.json
@@ -317,7 +317,7 @@
             "type": "string"
         },
         "points": {
-            "type": "null"
+            "type": ["null", "number"]
         },
         "project": {
             "type": "object",

--- a/packages/nodes-base/nodes/ClickUp/__schema__/v1.0.0/task/getAll.json
+++ b/packages/nodes-base/nodes/ClickUp/__schema__/v1.0.0/task/getAll.json
@@ -233,6 +233,9 @@
         "permission_level": {
             "type": "string"
         },
+        "points": {
+            "type": ["null", "number"]
+        },
         "project": {
             "type": "object",
             "properties": {

--- a/packages/nodes-base/nodes/ClickUp/__schema__/v1.0.0/task/update.json
+++ b/packages/nodes-base/nodes/ClickUp/__schema__/v1.0.0/task/update.json
@@ -359,6 +359,9 @@
         "permission_level": {
             "type": "string"
         },
+        "points": {
+            "type": ["null", "number"]
+        },
         "project": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
Add support for the points field in ClickUp tasks, allowing users to set sprint points when creating or updating tasks via the native ClickUp node.

Changes:
- Add points parameter to task create operation
- Add points parameter to task update operation
- Update TaskInterface to include points field
- Update JSON schemas for create, update, get, and getAll operations

The points field accepts numeric values (minimum 0) and aligns with ClickUp's API specification for sprint point tracking.

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
