### PR TITLE
fix(core): Make restartExecutionId get passed on queue mode

### DIFF
--- a/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
@@ -228,6 +228,42 @@ describe('JobProcessor', () => {
 		);
 	});
 
+	it('should set restartExecutionId on additionalData when provided in job data', async () => {
+		const executionRepository = mock<ExecutionRepository>();
+		const execution = mock<IExecutionResponse>({
+			mode: 'manual',
+			workflowData: { id: 'workflow-id', nodes: [] },
+			data: mock<IRunExecutionData>({
+				resultData: { runData: {} },
+				executionData: undefined,
+			}),
+		});
+		executionRepository.findSingleExecution.mockResolvedValue(execution);
+
+		const additionalData = mock<IWorkflowExecuteAdditionalData>();
+		jest.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue(additionalData);
+
+		const manualExecutionService = mock<ManualExecutionService>();
+		const jobProcessor = new JobProcessor(
+			logger,
+			executionRepository,
+			mock(),
+			mock(),
+			mock(),
+			manualExecutionService,
+			executionsConfig,
+			mock(),
+		);
+
+		const executionId = 'execution-id';
+		const restartExecutionId = 'restart-execution-id';
+		await jobProcessor.processJob(
+			mock<Job>({ data: { executionId, loadStaticData: false, restartExecutionId } }),
+		);
+
+		expect(additionalData.restartExecutionId).toBe(restartExecutionId);
+	});
+
 	it.each(['manual', 'evaluation', 'trigger'] satisfies WorkflowExecuteMode[])(
 		'should use workflowExecute to process a job with mode %p with execution data',
 		async (mode) => {

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -128,6 +128,7 @@ export class JobProcessor {
 			workflowSettings: execution.workflowData.settings,
 		});
 		additionalData.streamingEnabled = job.data.streamingEnabled;
+		additionalData.restartExecutionId = job.data.restartExecutionId;
 
 		const { pushRef } = job.data;
 

--- a/packages/cli/src/scaling/scaling.types.ts
+++ b/packages/cli/src/scaling/scaling.types.ts
@@ -21,6 +21,7 @@ export type JobData = {
 	loadStaticData: boolean;
 	pushRef?: string;
 	streamingEnabled?: boolean;
+	restartExecutionId?: string;
 };
 
 export type JobResult = {

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -175,7 +175,14 @@ export class WorkflowRunner {
 				: this.executionsConfig.mode === 'queue' && data.executionMode !== 'manual';
 
 		if (shouldEnqueue) {
-			await this.enqueueExecution(executionId, workflowId, data, loadStaticData, realtime);
+			await this.enqueueExecution(
+				executionId,
+				workflowId,
+				data,
+				loadStaticData,
+				realtime,
+				restartExecutionId,
+			);
 		} else {
 			await this.runMainProcess(executionId, data, loadStaticData, restartExecutionId);
 		}
@@ -254,7 +261,6 @@ export class WorkflowRunner {
 				workflowTimeout <= 0 ? undefined : Date.now() + workflowTimeout * 1000,
 			workflowSettings,
 		});
-		// TODO: set this in queue mode as well
 		additionalData.restartExecutionId = restartExecutionId;
 		additionalData.streamingEnabled = data.streamingEnabled;
 
@@ -375,6 +381,7 @@ export class WorkflowRunner {
 		data: IWorkflowExecutionDataProcess,
 		loadStaticData?: boolean,
 		realtime?: boolean,
+		restartExecutionId?: string,
 	): Promise<void> {
 		const jobData: JobData = {
 			workflowId,
@@ -382,6 +389,7 @@ export class WorkflowRunner {
 			loadStaticData: !!loadStaticData,
 			pushRef: data.pushRef,
 			streamingEnabled: data.streamingEnabled,
+			restartExecutionId,
 		};
 
 		if (!this.scalingService) {


### PR DESCRIPTION
## Summary

Turns out we're not passing `restartExecutionId` to workers in queue mode, which causes workers to always emit `workflowExecuteBefore` at https://github.com/n8n-io/n8n/blob/master/packages/core/src/execution-engine/workflow-execute.ts#L1439-L1441 even when workflow is resumed, unlike in single main mode.

Passing this in `JobData` and handling it in job-processor fixes this.

This is a prerequisite for new lifecycle hook `workflowExecuteResume`, that I need in Chat hub related code to monitor executions resuming.

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C03MZF137FV/p1770105386939879

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
