### PR TITLE
feat(core): Add workflowExecuteResume lifecycle hook

### DIFF
--- a/packages/@n8n/decorators/src/execution-lifecycle/__tests__/on-lifecycle-event.test.ts
+++ b/packages/@n8n/decorators/src/execution-lifecycle/__tests__/on-lifecycle-event.test.ts
@@ -43,9 +43,12 @@ describe('OnLifecycleEvent', () => {
 
 			@OnLifecycleEvent('workflowExecuteAfter')
 			async handleWorkflowExecuteAfter() {}
+
+			@OnLifecycleEvent('workflowExecuteResume')
+			async handleWorkflowExecuteResume() {}
 		}
 
-		expect(lifecycleMetadata.register).toHaveBeenCalledTimes(4);
+		expect(lifecycleMetadata.register).toHaveBeenCalledTimes(5);
 		expect(lifecycleMetadata.register).toHaveBeenCalledWith(
 			expect.objectContaining({ eventName: 'nodeExecuteBefore' }),
 		);
@@ -57,6 +60,9 @@ describe('OnLifecycleEvent', () => {
 		);
 		expect(lifecycleMetadata.register).toHaveBeenCalledWith(
 			expect.objectContaining({ eventName: 'workflowExecuteAfter' }),
+		);
+		expect(lifecycleMetadata.register).toHaveBeenCalledWith(
+			expect.objectContaining({ eventName: 'workflowExecuteResume' }),
 		);
 	});
 

--- a/packages/@n8n/decorators/src/execution-lifecycle/index.ts
+++ b/packages/@n8n/decorators/src/execution-lifecycle/index.ts
@@ -5,5 +5,6 @@ export type {
 	NodeExecuteAfterContext,
 	WorkflowExecuteBeforeContext,
 	WorkflowExecuteAfterContext,
+	WorkflowExecuteResumeContext,
 } from './lifecycle-metadata';
 export { LifecycleMetadata } from './lifecycle-metadata';

--- a/packages/@n8n/decorators/src/execution-lifecycle/lifecycle-metadata.ts
+++ b/packages/@n8n/decorators/src/execution-lifecycle/lifecycle-metadata.ts
@@ -44,12 +44,21 @@ export type WorkflowExecuteAfterContext = {
 	newStaticData: IDataObject;
 };
 
+export type WorkflowExecuteResumeContext = {
+	type: 'workflowExecuteResume';
+	workflow: IWorkflowBase;
+	workflowInstance: Workflow;
+	executionData: IRunExecutionData;
+	executionId: string;
+};
+
 /** Context arg passed to a lifecycle event handler method. */
 export type LifecycleContext =
 	| NodeExecuteBeforeContext
 	| NodeExecuteAfterContext
 	| WorkflowExecuteBeforeContext
-	| WorkflowExecuteAfterContext;
+	| WorkflowExecuteAfterContext
+	| WorkflowExecuteResumeContext;
 
 type LifecycleHandler = {
 	/** Class holding the method to call on a lifecycle event. */

--- a/packages/@n8n/decorators/src/execution-lifecycle/lifecycle-metadata.ts
+++ b/packages/@n8n/decorators/src/execution-lifecycle/lifecycle-metadata.ts
@@ -35,6 +35,7 @@ export type WorkflowExecuteBeforeContext = {
 	workflow: IWorkflowBase;
 	workflowInstance: Workflow;
 	executionData?: IRunExecutionData;
+	executionId: string;
 };
 
 export type WorkflowExecuteAfterContext = {
@@ -42,6 +43,7 @@ export type WorkflowExecuteAfterContext = {
 	workflow: IWorkflowBase;
 	runData: IRun;
 	newStaticData: IDataObject;
+	executionId: string;
 };
 
 export type WorkflowExecuteResumeContext = {

--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -326,6 +326,7 @@ describe('Execution Lifecycle Hooks', () => {
 			expect(handlers.nodeExecuteAfter).toHaveLength(2);
 			expect(handlers.workflowExecuteBefore).toHaveLength(3);
 			expect(handlers.workflowExecuteAfter).toHaveLength(5);
+			expect(handlers.workflowExecuteResume).toHaveLength(0);
 			expect(handlers.nodeFetchedData).toHaveLength(1);
 			expect(handlers.sendResponse).toHaveLength(0);
 			expect(handlers.sendChunk).toHaveLength(0);
@@ -733,6 +734,7 @@ describe('Execution Lifecycle Hooks', () => {
 			expect(handlers.nodeExecuteAfter).toHaveLength(0);
 			expect(handlers.workflowExecuteBefore).toHaveLength(2);
 			expect(handlers.workflowExecuteAfter).toHaveLength(4);
+			expect(handlers.workflowExecuteResume).toHaveLength(0);
 			expect(handlers.nodeFetchedData).toHaveLength(0);
 			expect(handlers.sendResponse).toHaveLength(0);
 			expect(handlers.sendChunk).toHaveLength(0);
@@ -868,6 +870,7 @@ describe('Execution Lifecycle Hooks', () => {
 			expect(handlers.nodeExecuteAfter).toHaveLength(2);
 			expect(handlers.workflowExecuteBefore).toHaveLength(2);
 			expect(handlers.workflowExecuteAfter).toHaveLength(4);
+			expect(handlers.workflowExecuteResume).toHaveLength(0);
 			expect(handlers.nodeFetchedData).toHaveLength(1);
 			expect(handlers.sendResponse).toHaveLength(0);
 			expect(handlers.sendChunk).toHaveLength(0);
@@ -992,6 +995,7 @@ describe('Execution Lifecycle Hooks', () => {
 			expect(handlers.nodeExecuteAfter).toHaveLength(1);
 			expect(handlers.workflowExecuteBefore).toHaveLength(2);
 			expect(handlers.workflowExecuteAfter).toHaveLength(4);
+			expect(handlers.workflowExecuteResume).toHaveLength(0);
 			expect(handlers.nodeFetchedData).toHaveLength(1);
 			expect(handlers.sendResponse).toHaveLength(0);
 			expect(handlers.sendChunk).toHaveLength(0);

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -57,6 +57,7 @@ class ModulesHooksRegistry {
 							workflow: this.workflowData,
 							runData,
 							newStaticData,
+							executionId: this.executionId,
 						};
 						// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 						return await instance[methodName].call(instance, context);
@@ -97,6 +98,7 @@ class ModulesHooksRegistry {
 							workflow: this.workflowData,
 							workflowInstance,
 							executionData,
+							executionId: this.executionId,
 						};
 						// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 						return await instance[methodName].call(instance, context);

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -102,6 +102,20 @@ class ModulesHooksRegistry {
 						return await instance[methodName].call(instance, context);
 					});
 					break;
+
+				case 'workflowExecuteResume':
+					hooks.addHandler(eventName, async function (workflowInstance, executionData) {
+						const context = {
+							type: 'workflowExecuteResume',
+							workflow: this.workflowData,
+							workflowInstance,
+							executionData,
+							executionId: this.executionId,
+						};
+						// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+						return await instance[methodName].call(instance, context);
+					});
+					break;
 			}
 		}
 	}

--- a/packages/core/src/execution-engine/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/core/src/execution-engine/__tests__/execution-lifecycle-hooks.test.ts
@@ -39,6 +39,7 @@ describe('ExecutionLifecycleHooks', () => {
 				sendResponse: [],
 				workflowExecuteAfter: [],
 				workflowExecuteBefore: [],
+				workflowExecuteResume: [],
 				sendChunk: [],
 			});
 		});
@@ -63,6 +64,7 @@ describe('ExecutionLifecycleHooks', () => {
 			},
 			{ hook: 'workflowExecuteBefore', args: [mock<Workflow>(), mock<IRunExecutionData>()] },
 			{ hook: 'workflowExecuteAfter', args: [mock<IRun>(), mock<IDataObject>()] },
+			{ hook: 'workflowExecuteResume', args: [mock<Workflow>(), mock<IRunExecutionData>()] },
 			{ hook: 'sendResponse', args: [mock<IExecuteResponsePromiseData>()] },
 			{ hook: 'nodeFetchedData', args: ['workflow123', mock<INode>()] },
 		];

--- a/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
@@ -464,6 +464,79 @@ describe('WorkflowExecute', () => {
 		});
 	});
 
+	describe('workflowExecuteResume hook', () => {
+		const executionMode = 'manual';
+		const executionOrder = 'v1';
+		const nodeTypes = Helpers.NodeTypes();
+
+		test('should call workflowExecuteResume instead of workflowExecuteBefore when restartExecutionId is set', async () => {
+			// ARRANGE
+			const trigger = createNodeData({ name: 'trigger', type: 'n8n-nodes-base.manualTrigger' });
+			const node1 = createNodeData({ name: 'node1' });
+			const workflowInstance = new DirectedGraph()
+				.addNodes(trigger, node1)
+				.addConnections({ from: trigger, to: node1 })
+				.toWorkflow({ name: '', active: false, nodeTypes, settings: { executionOrder } });
+
+			const additionalData = Helpers.WorkflowExecuteAdditionalData(createDeferredPromise<IRun>());
+			// Set restartExecutionId to simulate a resumed execution
+			additionalData.restartExecutionId = 'previous-execution-id';
+			const runHookSpy = jest.spyOn(additionalData.hooks!, 'runHook');
+
+			const workflowExecute = new WorkflowExecute(additionalData, executionMode);
+
+			// ACT
+			await workflowExecute.run({ workflow: workflowInstance, startNode: trigger });
+
+			// ASSERT
+			const workflowHooks = runHookSpy.mock.calls.filter(
+				(call) =>
+					call[0] === 'workflowExecuteBefore' ||
+					call[0] === 'workflowExecuteAfter' ||
+					call[0] === 'workflowExecuteResume',
+			);
+
+			// Should have workflowExecuteResume instead of workflowExecuteBefore
+			expect(workflowHooks.map((hook) => hook[0])).toEqual([
+				'workflowExecuteResume',
+				'workflowExecuteAfter',
+			]);
+		});
+
+		test('should call workflowExecuteBefore when restartExecutionId is not set', async () => {
+			// ARRANGE
+			const trigger = createNodeData({ name: 'trigger', type: 'n8n-nodes-base.manualTrigger' });
+			const node1 = createNodeData({ name: 'node1' });
+			const workflowInstance = new DirectedGraph()
+				.addNodes(trigger, node1)
+				.addConnections({ from: trigger, to: node1 })
+				.toWorkflow({ name: '', active: false, nodeTypes, settings: { executionOrder } });
+
+			const additionalData = Helpers.WorkflowExecuteAdditionalData(createDeferredPromise<IRun>());
+			// restartExecutionId is undefined by default
+			const runHookSpy = jest.spyOn(additionalData.hooks!, 'runHook');
+
+			const workflowExecute = new WorkflowExecute(additionalData, executionMode);
+
+			// ACT
+			await workflowExecute.run({ workflow: workflowInstance, startNode: trigger });
+
+			// ASSERT
+			const workflowHooks = runHookSpy.mock.calls.filter(
+				(call) =>
+					call[0] === 'workflowExecuteBefore' ||
+					call[0] === 'workflowExecuteAfter' ||
+					call[0] === 'workflowExecuteResume',
+			);
+
+			// Should have workflowExecuteBefore, not workflowExecuteResume
+			expect(workflowHooks.map((hook) => hook[0])).toEqual([
+				'workflowExecuteBefore',
+				'workflowExecuteAfter',
+			]);
+		});
+	});
+
 	//run tests on json files from specified directory, default 'workflows'
 	//workflows must have pinned data that would be used to test output after execution
 	describe('run test workflows', () => {

--- a/packages/core/src/execution-engine/execution-lifecycle-hooks.ts
+++ b/packages/core/src/execution-engine/execution-lifecycle-hooks.ts
@@ -38,6 +38,14 @@ export type ExecutionLifecycleHookHandlers = {
 		) => Promise<void> | void
 	>;
 
+	workflowExecuteResume: Array<
+		(
+			this: ExecutionLifecycleHooks,
+			workflow: Workflow,
+			data?: IRunExecutionData,
+		) => Promise<void> | void
+	>;
+
 	workflowExecuteAfter: Array<
 		(this: ExecutionLifecycleHooks, data: IRun, newStaticData: IDataObject) => Promise<void> | void
 	>;
@@ -88,6 +96,7 @@ export class ExecutionLifecycleHooks {
 		sendResponse: [],
 		workflowExecuteAfter: [],
 		workflowExecuteBefore: [],
+		workflowExecuteResume: [],
 		sendChunk: [],
 	};
 

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1438,6 +1438,8 @@ export class WorkflowExecute {
 
 					if (!this.additionalData.restartExecutionId) {
 						await hooks.runHook('workflowExecuteBefore', [workflow, this.runExecutionData]);
+					} else {
+						await hooks.runHook('workflowExecuteResume', [workflow, this.runExecutionData]);
 					}
 				} catch (error) {
 					const e = error as unknown as ExecutionBaseError;


### PR DESCRIPTION
## Summary

Add a new lifecycle hook `workflowExecuteResume` that allows using lifecycle hooks to monitor workflows resuming execution after a wait.

This is needed for chat hub functionality to monitor executions that are started on chat hub and put into waiting state, and later resumed through external trigger / wait tracker.

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C03MZF137FV/p1770105386939879

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
