### PR TITLE
feat(core): Populate workflow published version mapping

### DIFF
--- a/packages/@n8n/db/src/entities/index.ts
+++ b/packages/@n8n/db/src/entities/index.ts
@@ -34,6 +34,7 @@ import { WorkflowDependency } from './workflow-dependency-entity';
 import { WorkflowEntity } from './workflow-entity';
 import { WorkflowHistory } from './workflow-history';
 import { WorkflowPublishHistory } from './workflow-publish-history';
+import { WorkflowPublishedVersion } from './workflow-published-version';
 import { WorkflowStatistics } from './workflow-statistics';
 import { WorkflowTagMapping } from './workflow-tag-mapping';
 
@@ -66,6 +67,7 @@ export {
 	FolderTagMapping,
 	AuthProviderSyncHistory,
 	WorkflowHistory,
+	WorkflowPublishedVersion,
 	WorkflowPublishHistory,
 	ExecutionData,
 	ExecutionMetadata,
@@ -105,6 +107,7 @@ export const entities = {
 	FolderTagMapping,
 	AuthProviderSyncHistory,
 	WorkflowHistory,
+	WorkflowPublishedVersion,
 	WorkflowPublishHistory,
 	ExecutionData,
 	ExecutionMetadata,

--- a/packages/@n8n/db/src/entities/workflow-published-version.ts
+++ b/packages/@n8n/db/src/entities/workflow-published-version.ts
@@ -13,13 +13,13 @@ export class WorkflowPublishedVersion extends WithTimestamps {
 	publishedVersionId: string;
 
 	@ManyToOne('WorkflowEntity', {
-		onDelete: 'CASCADE',
+		onDelete: 'RESTRICT',
 	})
 	@JoinColumn({ name: 'workflowId' })
 	workflow: Relation<WorkflowEntity>;
 
 	@ManyToOne('WorkflowHistory', {
-		onDelete: 'CASCADE',
+		onDelete: 'RESTRICT',
 	})
 	@JoinColumn({ name: 'publishedVersionId', referencedColumnName: 'versionId' })
 	publishedVersion: Relation<WorkflowHistory>;

--- a/packages/@n8n/db/src/entities/workflow-published-version.ts
+++ b/packages/@n8n/db/src/entities/workflow-published-version.ts
@@ -1,0 +1,26 @@
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn, Relation } from '@n8n/typeorm';
+
+import { WithTimestamps } from './abstract-entity';
+import type { WorkflowEntity } from './workflow-entity';
+import type { WorkflowHistory } from './workflow-history';
+
+@Entity({ name: 'workflow_published_version' })
+export class WorkflowPublishedVersion extends WithTimestamps {
+	@PrimaryColumn({ type: 'varchar', length: 36 })
+	workflowId: string;
+
+	@Column({ type: 'varchar', length: 36 })
+	publishedVersionId: string;
+
+	@ManyToOne('WorkflowEntity', {
+		onDelete: 'CASCADE',
+	})
+	@JoinColumn({ name: 'workflowId' })
+	workflow: Relation<WorkflowEntity>;
+
+	@ManyToOne('WorkflowHistory', {
+		onDelete: 'CASCADE',
+	})
+	@JoinColumn({ name: 'publishedVersionId', referencedColumnName: 'versionId' })
+	publishedVersion: Relation<WorkflowHistory>;
+}

--- a/packages/@n8n/db/src/migrations/common/1769698710000-CreateWorkflowPublishedVersionTable.ts
+++ b/packages/@n8n/db/src/migrations/common/1769698710000-CreateWorkflowPublishedVersionTable.ts
@@ -17,12 +17,12 @@ export class CreateWorkflowPublishedVersionTable1769698710000 implements Reversi
 			.withForeignKey('workflowId', {
 				tableName: 'workflow_entity',
 				columnName: 'id',
-				onDelete: 'CASCADE',
+				onDelete: 'RESTRICT',
 			})
 			.withForeignKey('publishedVersionId', {
 				tableName: 'workflow_history',
 				columnName: 'versionId',
-				onDelete: 'CASCADE',
+				onDelete: 'RESTRICT',
 			}).withTimestamps;
 	}
 

--- a/packages/@n8n/db/src/migrations/common/1769698710000-CreateWorkflowPublishedVersionTable.ts
+++ b/packages/@n8n/db/src/migrations/common/1769698710000-CreateWorkflowPublishedVersionTable.ts
@@ -17,12 +17,12 @@ export class CreateWorkflowPublishedVersionTable1769698710000 implements Reversi
 			.withForeignKey('workflowId', {
 				tableName: 'workflow_entity',
 				columnName: 'id',
-				onDelete: 'RESTRICT',
+				onDelete: 'CASCADE',
 			})
 			.withForeignKey('publishedVersionId', {
 				tableName: 'workflow_history',
 				columnName: 'versionId',
-				onDelete: 'RESTRICT',
+				onDelete: 'CASCADE',
 			}).withTimestamps;
 	}
 

--- a/packages/@n8n/db/src/migrations/common/1772619247762-ChangeWorkflowPublishedVersionFKsToRestrict.ts
+++ b/packages/@n8n/db/src/migrations/common/1772619247762-ChangeWorkflowPublishedVersionFKsToRestrict.ts
@@ -1,0 +1,57 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+/**
+ * Changes the foreign key constraints on workflow_published_version from CASCADE
+ * to RESTRICT. CASCADE could silently remove the published version mapping while
+ * triggers and webhooks are still running. RESTRICT ensures the mapping must be
+ * explicitly removed (via deactivation) before the referenced rows can be deleted.
+ */
+export class ChangeWorkflowPublishedVersionFKsToRestrict1772619247762
+	implements ReversibleMigration
+{
+	async up({ schemaBuilder: { dropForeignKey, addForeignKey } }: MigrationContext) {
+		await dropForeignKey('workflow_published_version', 'workflowId', ['workflow_entity', 'id']);
+		await addForeignKey(
+			'workflow_published_version',
+			'workflowId',
+			['workflow_entity', 'id'],
+			undefined,
+			'RESTRICT',
+		);
+
+		await dropForeignKey('workflow_published_version', 'publishedVersionId', [
+			'workflow_history',
+			'versionId',
+		]);
+		await addForeignKey(
+			'workflow_published_version',
+			'publishedVersionId',
+			['workflow_history', 'versionId'],
+			undefined,
+			'RESTRICT',
+		);
+	}
+
+	async down({ schemaBuilder: { dropForeignKey, addForeignKey } }: MigrationContext) {
+		await dropForeignKey('workflow_published_version', 'workflowId', ['workflow_entity', 'id']);
+		await addForeignKey(
+			'workflow_published_version',
+			'workflowId',
+			['workflow_entity', 'id'],
+			undefined,
+			'CASCADE',
+		);
+
+		await dropForeignKey('workflow_published_version', 'publishedVersionId', [
+			'workflow_history',
+			'versionId',
+		]);
+		await addForeignKey(
+			'workflow_published_version',
+			'publishedVersionId',
+			['workflow_history', 'versionId'],
+			undefined,
+			'CASCADE',
+		);
+	}
+}

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -150,6 +150,7 @@ import { AddUnshareScopeToCustomRoles1771500000001 } from '../common/17715000000
 import { AddFilesColumnToChatHubAgents1771500000002 } from '../common/1771500000002-AddFilesColumnToChatHubAgents';
 import { AddSuggestedPromptsToAgentTable1772000000000 } from '../common/1772000000000-AddSuggestedPromptsToAgentTable';
 import { AddRoleColumnToProjectSecretsProviderAccess1772619247761 } from '../common/1772619247761-AddRoleColumnToProjectSecretsProviderAccess';
+import { ChangeWorkflowPublishedVersionFKsToRestrict1772619247762 } from '../common/1772619247762-ChangeWorkflowPublishedVersionFKsToRestrict';
 import type { Migration } from '../migration-types';
 
 export const postgresMigrations: Migration[] = [
@@ -305,4 +306,5 @@ export const postgresMigrations: Migration[] = [
 	AddFilesColumnToChatHubAgents1771500000002,
 	AddSuggestedPromptsToAgentTable1772000000000,
 	AddRoleColumnToProjectSecretsProviderAccess1772619247761,
+	ChangeWorkflowPublishedVersionFKsToRestrict1772619247762,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -144,6 +144,7 @@ import { AddUnshareScopeToCustomRoles1771500000001 } from '../common/17715000000
 import { AddFilesColumnToChatHubAgents1771500000002 } from '../common/1771500000002-AddFilesColumnToChatHubAgents';
 import { AddSuggestedPromptsToAgentTable1772000000000 } from '../common/1772000000000-AddSuggestedPromptsToAgentTable';
 import { AddRoleColumnToProjectSecretsProviderAccess1772619247761 } from '../common/1772619247761-AddRoleColumnToProjectSecretsProviderAccess';
+import { ChangeWorkflowPublishedVersionFKsToRestrict1772619247762 } from '../common/1772619247762-ChangeWorkflowPublishedVersionFKsToRestrict';
 import type { Migration } from '../migration-types';
 
 const sqliteMigrations: Migration[] = [
@@ -293,6 +294,7 @@ const sqliteMigrations: Migration[] = [
 	AddFilesColumnToChatHubAgents1771500000002,
 	AddSuggestedPromptsToAgentTable1772000000000,
 	AddRoleColumnToProjectSecretsProviderAccess1772619247761,
+	ChangeWorkflowPublishedVersionFKsToRestrict1772619247762,
 ];
 
 export { sqliteMigrations };

--- a/packages/@n8n/db/src/repositories/index.ts
+++ b/packages/@n8n/db/src/repositories/index.ts
@@ -33,6 +33,7 @@ export { WorkflowTagMappingRepository } from './workflow-tag-mapping.repository'
 export { SharedWorkflowRepository } from './shared-workflow.repository';
 export { SharedCredentialsRepository } from './shared-credentials.repository';
 export { WorkflowRepository } from './workflow.repository';
+export { WorkflowPublishedVersionRepository } from './workflow-published-version.repository';
 export { WorkflowPublishHistoryRepository } from './workflow-publish-history.repository';
 export {
 	WorkflowDependencyRepository,

--- a/packages/@n8n/db/src/repositories/workflow-published-version.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-published-version.repository.ts
@@ -18,7 +18,10 @@ export class WorkflowPublishedVersionRepository extends Repository<WorkflowPubli
 	}
 
 	async getPublishedVersionId(workflowId: string): Promise<string | null> {
-		const record = await this.findOne({ where: { workflowId } });
+		const record = await this.findOne({
+			where: { workflowId },
+			select: ['publishedVersionId'],
+		});
 		return record?.publishedVersionId ?? null;
 	}
 }

--- a/packages/@n8n/db/src/repositories/workflow-published-version.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-published-version.repository.ts
@@ -1,0 +1,24 @@
+import { Service } from '@n8n/di';
+import { DataSource, Repository } from '@n8n/typeorm';
+
+import { WorkflowPublishedVersion } from '../entities';
+
+@Service()
+export class WorkflowPublishedVersionRepository extends Repository<WorkflowPublishedVersion> {
+	constructor(dataSource: DataSource) {
+		super(WorkflowPublishedVersion, dataSource.manager);
+	}
+
+	async setPublishedVersion(workflowId: string, publishedVersionId: string): Promise<void> {
+		await this.upsert({ workflowId, publishedVersionId }, ['workflowId']);
+	}
+
+	async removePublishedVersion(workflowId: string): Promise<void> {
+		await this.delete({ workflowId });
+	}
+
+	async getPublishedVersionId(workflowId: string): Promise<string | null> {
+		const record = await this.findOne({ where: { workflowId } });
+		return record?.publishedVersionId ?? null;
+	}
+}

--- a/packages/cli/src/workflows/__tests__/workflow.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow.service.test.ts
@@ -53,6 +53,7 @@ describe('WorkflowService', () => {
 				mock(), // globalConfig
 				mock(), // folderRepository
 				mock(), // workflowFinderService
+				mock(), // workflowPublishedVersionRepository
 				mock(), // workflowPublishHistoryRepository
 				mock(), // workflowValidationService
 				mock(), // nodeTypes
@@ -190,6 +191,7 @@ describe('WorkflowService', () => {
 				mock(), // globalConfig
 				mock(), // folderRepository
 				workflowFinderServiceMock, // workflowFinderService
+				mock(), // workflowPublishedVersionRepository
 				mock(), // workflowPublishHistoryRepository
 				mock(), // workflowValidationService
 				mock(), // nodeTypes

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -545,6 +545,9 @@ export class WorkflowService {
 			if (didPublish) {
 				assert(workflow.activeVersionId !== null);
 
+				// Temporary: In the future, the workflow publication service will
+				// manage this mapping. We set it here for now to support incremental
+				// development and testing.
 				if (this.globalConfig.workflows.useWorkflowPublicationService) {
 					await this.workflowPublishedVersionRepository.setPublishedVersion(
 						workflowId,
@@ -792,6 +795,7 @@ export class WorkflowService {
 
 		const deactivatedVersionId = workflow.activeVersionId;
 
+		// Temporary: will be removed when the workflow publication service manages this.
 		if (this.globalConfig.workflows.useWorkflowPublicationService) {
 			await this.workflowPublishedVersionRepository.removePublishedVersion(workflowId);
 		}
@@ -892,6 +896,7 @@ export class WorkflowService {
 		if (workflow.activeVersionId !== null) {
 			await this.activeWorkflowManager.remove(workflowId);
 
+			// Temporary: will be removed when the workflow publication service manages this.
 			if (this.globalConfig.workflows.useWorkflowPublicationService) {
 				await this.workflowPublishedVersionRepository.removePublishedVersion(workflowId);
 			}

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -15,6 +15,7 @@ import {
 	WorkflowTagMappingRepository,
 	SharedWorkflowRepository,
 	WorkflowRepository,
+	WorkflowPublishedVersionRepository,
 	WorkflowPublishHistoryRepository,
 	ProjectRepository,
 } from '@n8n/db';
@@ -87,6 +88,7 @@ export class WorkflowService {
 		private readonly globalConfig: GlobalConfig,
 		private readonly folderRepository: FolderRepository,
 		private readonly workflowFinderService: WorkflowFinderService,
+		private readonly workflowPublishedVersionRepository: WorkflowPublishedVersionRepository,
 		private readonly workflowPublishHistoryRepository: WorkflowPublishHistoryRepository,
 		private readonly workflowValidationService: WorkflowValidationService,
 		private readonly nodeTypes: NodeTypes,
@@ -542,6 +544,14 @@ export class WorkflowService {
 		} finally {
 			if (didPublish) {
 				assert(workflow.activeVersionId !== null);
+
+				if (this.globalConfig.workflows.useWorkflowPublicationService) {
+					await this.workflowPublishedVersionRepository.setPublishedVersion(
+						workflowId,
+						workflow.activeVersionId,
+					);
+				}
+
 				await this.workflowPublishHistoryRepository.addRecord({
 					workflowId,
 					versionId: workflow.activeVersionId,
@@ -782,6 +792,10 @@ export class WorkflowService {
 
 		const deactivatedVersionId = workflow.activeVersionId;
 
+		if (this.globalConfig.workflows.useWorkflowPublicationService) {
+			await this.workflowPublishedVersionRepository.removePublishedVersion(workflowId);
+		}
+
 		await this.workflowPublishHistoryRepository.addRecord({
 			workflowId,
 			versionId: deactivatedVersionId,
@@ -877,6 +891,11 @@ export class WorkflowService {
 
 		if (workflow.activeVersionId !== null) {
 			await this.activeWorkflowManager.remove(workflowId);
+
+			if (this.globalConfig.workflows.useWorkflowPublicationService) {
+				await this.workflowPublishedVersionRepository.removePublishedVersion(workflowId);
+			}
+
 			await this.workflowPublishHistoryRepository.addRecord({
 				workflowId,
 				versionId: workflow.activeVersionId,

--- a/packages/cli/test/integration/workflows/workflow.service.test.ts
+++ b/packages/cli/test/integration/workflows/workflow.service.test.ts
@@ -507,7 +507,6 @@ describe('workflow_published_version table population', () => {
 			const publishedVersion = await workflowPublishedVersionRepository.findOne({
 				where: { workflowId: workflow.id },
 			});
-			expect(publishedVersion).not.toBeNull();
 			expect(publishedVersion?.publishedVersionId).toBe(workflow.versionId);
 		});
 

--- a/packages/cli/test/integration/workflows/workflow.service.test.ts
+++ b/packages/cli/test/integration/workflows/workflow.service.test.ts
@@ -11,6 +11,7 @@ import { GlobalConfig } from '@n8n/config';
 import {
 	SharedWorkflowRepository,
 	type WorkflowEntity,
+	WorkflowPublishedVersionRepository,
 	WorkflowPublishHistoryRepository,
 	WorkflowRepository,
 	ProjectRepository,
@@ -40,6 +41,7 @@ import { WebhookService } from '@/webhooks/webhook.service';
 let globalConfig: GlobalConfig;
 let workflowRepository: WorkflowRepository;
 let workflowService: WorkflowService;
+let workflowPublishedVersionRepository: WorkflowPublishedVersionRepository;
 let workflowPublishHistoryRepository: WorkflowPublishHistoryRepository;
 let workflowHistoryService: WorkflowHistoryService;
 const activeWorkflowManager = mockInstance(ActiveWorkflowManager);
@@ -54,6 +56,7 @@ beforeAll(async () => {
 
 	globalConfig = Container.get(GlobalConfig);
 	workflowRepository = Container.get(WorkflowRepository);
+	workflowPublishedVersionRepository = Container.get(WorkflowPublishedVersionRepository);
 	workflowPublishHistoryRepository = Container.get(WorkflowPublishHistoryRepository);
 	workflowHistoryService = Container.get(WorkflowHistoryService);
 	workflowService = new WorkflowService(
@@ -74,6 +77,7 @@ beforeAll(async () => {
 		globalConfig,
 		mock(),
 		Container.get(WorkflowFinderService),
+		workflowPublishedVersionRepository,
 		workflowPublishHistoryRepository,
 		workflowValidationService,
 		nodeTypes,
@@ -94,6 +98,7 @@ afterEach(async () => {
 	await testDb.truncate([
 		'SharedWorkflow',
 		'ProjectRelation',
+		'WorkflowPublishedVersion',
 		'WorkflowEntity',
 		'WorkflowHistory',
 		'WorkflowPublishHistory',
@@ -480,6 +485,108 @@ describe('deactivateWorkflow()', () => {
 		const workflowAfter = await workflowRepository.findOne({ where: { id: workflow.id } });
 		expect(workflowAfter?.active).toBe(true);
 		expect(workflowAfter?.activeVersionId).toBe(workflow.activeVersionId);
+	});
+});
+
+describe('workflow_published_version table population', () => {
+	describe('when feature flag is enabled', () => {
+		beforeEach(() => {
+			globalConfig.workflows.useWorkflowPublicationService = true;
+		});
+
+		afterEach(() => {
+			globalConfig.workflows.useWorkflowPublicationService = false;
+		});
+
+		test('should write to workflow_published_version on activation', async () => {
+			const owner = await createOwner();
+			const workflow = await createWorkflowWithHistory({}, owner);
+
+			await workflowService.activateWorkflow(owner, workflow.id);
+
+			const publishedVersion = await workflowPublishedVersionRepository.findOne({
+				where: { workflowId: workflow.id },
+			});
+			expect(publishedVersion).not.toBeNull();
+			expect(publishedVersion?.publishedVersionId).toBe(workflow.versionId);
+		});
+
+		test('should update workflow_published_version when activating a new version', async () => {
+			const owner = await createOwner();
+			const workflow = await createWorkflowWithHistory({}, owner);
+
+			await workflowService.activateWorkflow(owner, workflow.id);
+
+			const newVersionId = uuid();
+			await createWorkflowHistoryItem(workflow.id, { versionId: newVersionId });
+
+			await workflowService.activateWorkflow(owner, workflow.id, {
+				versionId: newVersionId,
+			});
+
+			const publishedVersion = await workflowPublishedVersionRepository.findOne({
+				where: { workflowId: workflow.id },
+			});
+			expect(publishedVersion?.publishedVersionId).toBe(newVersionId);
+		});
+
+		test('should remove workflow_published_version on deactivation', async () => {
+			const owner = await createOwner();
+			const workflow = await createWorkflowWithHistory({}, owner);
+
+			await workflowService.activateWorkflow(owner, workflow.id);
+
+			await workflowService.deactivateWorkflow(owner, workflow.id);
+
+			const publishedVersion = await workflowPublishedVersionRepository.findOne({
+				where: { workflowId: workflow.id },
+			});
+			expect(publishedVersion).toBeNull();
+		});
+
+		test('should remove workflow_published_version on archive', async () => {
+			const owner = await createOwner();
+			const workflow = await createWorkflowWithHistory({}, owner);
+
+			await workflowService.activateWorkflow(owner, workflow.id);
+
+			const publishedVersionBefore = await workflowPublishedVersionRepository.findOne({
+				where: { workflowId: workflow.id },
+			});
+			expect(publishedVersionBefore).not.toBeNull();
+
+			await workflowService.archive(owner, workflow.id);
+
+			const publishedVersionAfter = await workflowPublishedVersionRepository.findOne({
+				where: { workflowId: workflow.id },
+			});
+			expect(publishedVersionAfter).toBeNull();
+		});
+	});
+
+	describe('when feature flag is disabled', () => {
+		test('should not write to workflow_published_version on activation', async () => {
+			const owner = await createOwner();
+			const workflow = await createWorkflowWithHistory({}, owner);
+
+			await workflowService.activateWorkflow(owner, workflow.id);
+
+			const publishedVersion = await workflowPublishedVersionRepository.findOne({
+				where: { workflowId: workflow.id },
+			});
+			expect(publishedVersion).toBeNull();
+		});
+
+		test('should not write to workflow_published_version on deactivation', async () => {
+			const owner = await createOwner();
+			const workflow = await createWorkflowWithHistory({}, owner);
+
+			await workflowService.activateWorkflow(owner, workflow.id);
+			await workflowService.deactivateWorkflow(owner, workflow.id);
+
+			const count = await workflowPublishedVersionRepository.count();
+			expect(count).toBe(0);
+		});
 	});
 });
 


### PR DESCRIPTION
## Summary

Implement the workflow published version mapping by adding a new `WorkflowPublishedVersion` entity and repository.

This allows tracking the currently published workflow version in production, distinct from `workflow_entity.activeVersionId` which tracks the intended published version. When the `useWorkflowPublicationService` feature flag is enabled, workflow activation and deactivation now transactionally update both tables to maintain consistency.

NOTE:
- This PR shouldn't affect anything running when the feature flag is disabled.
- The point of this PR is mostly to add the repository/etc. We populate the field here so that we can start reading from it in the next PRs and add e2e tests to verify it, but ultimately we'll write this field from the workflow publication outbox consumer.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2192/populate-the-new-workflow-id-to-published-version-mapping

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] Tests included (integration tests for feature flag behavior)
- [ ] Docs updated or follow-up ticket created