### PR TITLE
fix(core): Skip AuthRolesService.init() for workers to prevent scope deletion

### DIFF
--- a/packages/cli/src/commands/base-command.ts
+++ b/packages/cli/src/commands/base-command.ts
@@ -136,7 +136,11 @@ export abstract class BaseCommand<F = never> {
 			);
 
 		// Initialize the auth roles service to make sure that roles are correctly setup for the instance.
-		await Container.get(AuthRolesService).init();
+		// Only run on main instance - workers should not modify auth roles/scopes as they may have
+		// different code versions, and scope sync would incorrectly delete scopes they don't know about.
+		if (this.instanceSettings.instanceType === 'main') {
+			await Container.get(AuthRolesService).init();
+		}
 
 		if (process.env.EXECUTIONS_PROCESS === 'own') process.exit(-1);
 


### PR DESCRIPTION
## Summary

Workers should not modify auth roles/scopes as they may have different code versions. When a worker's ALL_SCOPES doesn't include a scope that exists in the database (e.g., workflow:publish), the syncScopes() method would incorrectly identify it as "obsolete" and delete it, stripping it from all roles.

This fixes a regression where workspace owners with global permissions could not publish workflows after upgrading to n8n 2.3.5+ when running in queue mode with workers.

## Related Linear tickets, Github issues, and Community forum posts

Fixes: IAM-220

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
