### PR TITLE
feat(core): Add log streaming for personal publishing restriction changes

### DIFF
--- a/packages/cli/src/controllers/mfa.controller.ts
+++ b/packages/cli/src/controllers/mfa.controller.ts
@@ -37,6 +37,13 @@ export class MFAController {
 			);
 		}
 		await this.mfaService.enforceMFA(req.body.enforce);
+
+		this.eventService.emit('instance-policies-updated', {
+			userId: req.user.id,
+			settingName: '2fa_enforcement',
+			value: req.body.enforce,
+		});
+
 		return;
 	}
 

--- a/packages/cli/src/controllers/mfa.controller.ts
+++ b/packages/cli/src/controllers/mfa.controller.ts
@@ -39,7 +39,7 @@ export class MFAController {
 		await this.mfaService.enforceMFA(req.body.enforce);
 
 		this.eventService.emit('instance-policies-updated', {
-			userId: req.user.id,
+			user: req.user,
 			settingName: '2fa_enforcement',
 			value: req.body.enforce,
 		});

--- a/packages/cli/src/controllers/mfa.controller.ts
+++ b/packages/cli/src/controllers/mfa.controller.ts
@@ -39,7 +39,13 @@ export class MFAController {
 		await this.mfaService.enforceMFA(req.body.enforce);
 
 		this.eventService.emit('instance-policies-updated', {
-			user: req.user,
+			user: {
+				id: req.user.id,
+				email: req.user.email,
+				firstName: req.user.firstName,
+				lastName: req.user.lastName,
+				role: req.user.role,
+			},
 			settingName: '2fa_enforcement',
 			value: req.body.enforce,
 		});

--- a/packages/cli/src/eventbus/event-message-classes/index.ts
+++ b/packages/cli/src/eventbus/event-message-classes/index.ts
@@ -96,6 +96,8 @@ export const eventNamesAudit = [
 	'n8n.audit.personal-publishing-restricted.disabled',
 	'n8n.audit.personal-sharing-restricted.enabled',
 	'n8n.audit.personal-sharing-restricted.disabled',
+	'n8n.audit.2fa-enforcement.enabled',
+	'n8n.audit.2fa-enforcement.disabled',
 ] as const;
 
 export type EventNamesWorkflowType = (typeof eventNamesWorkflow)[number];

--- a/packages/cli/src/eventbus/event-message-classes/index.ts
+++ b/packages/cli/src/eventbus/event-message-classes/index.ts
@@ -92,6 +92,10 @@ export const eventNamesAudit = [
 	'n8n.audit.variable.deleted',
 	'n8n.audit.external-secrets.provider.settings.saved',
 	'n8n.audit.external-secrets.provider.reloaded',
+	'n8n.audit.personal-publishing-restricted.enabled',
+	'n8n.audit.personal-publishing-restricted.disabled',
+	'n8n.audit.personal-sharing-restricted.enabled',
+	'n8n.audit.personal-sharing-restricted.disabled',
 ] as const;
 
 export type EventNamesWorkflowType = (typeof eventNamesWorkflow)[number];

--- a/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
@@ -2368,5 +2368,59 @@ describe('LogStreamingEventRelay', () => {
 				},
 			});
 		});
+
+		it('should log `2fa-enforcement.enabled` when 2fa_enforcement is enabled', () => {
+			const event: RelayEventMap['instance-policies-updated'] = {
+				user: {
+					id: 'user202',
+					email: 'admin5@example.com',
+					firstName: 'Fifth',
+					lastName: 'Admin',
+					role: { slug: 'global:admin' },
+				},
+				settingName: '2fa_enforcement',
+				value: true,
+			};
+
+			eventService.emit('instance-policies-updated', event);
+
+			expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
+				eventName: 'n8n.audit.2fa-enforcement.enabled',
+				payload: {
+					userId: 'user202',
+					_email: 'admin5@example.com',
+					_firstName: 'Fifth',
+					_lastName: 'Admin',
+					globalRole: 'global:admin',
+				},
+			});
+		});
+
+		it('should log `2fa-enforcement.disabled` when 2fa_enforcement is disabled', () => {
+			const event: RelayEventMap['instance-policies-updated'] = {
+				user: {
+					id: 'user303',
+					email: 'admin6@example.com',
+					firstName: 'Sixth',
+					lastName: 'Admin',
+					role: { slug: 'global:admin' },
+				},
+				settingName: '2fa_enforcement',
+				value: false,
+			};
+
+			eventService.emit('instance-policies-updated', event);
+
+			expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
+				eventName: 'n8n.audit.2fa-enforcement.disabled',
+				payload: {
+					userId: 'user303',
+					_email: 'admin6@example.com',
+					_firstName: 'Sixth',
+					_lastName: 'Admin',
+					globalRole: 'global:admin',
+				},
+			});
+		});
 	});
 });

--- a/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
@@ -2368,23 +2368,5 @@ describe('LogStreamingEventRelay', () => {
 				},
 			});
 		});
-
-		it('should not log audit event for other settings like 2fa_enforcement', () => {
-			const event: RelayEventMap['instance-policies-updated'] = {
-				user: {
-					id: 'user999',
-					email: 'user@example.com',
-					firstName: 'Test',
-					lastName: 'User',
-					role: { slug: 'global:member' },
-				},
-				settingName: '2fa_enforcement',
-				value: true,
-			};
-
-			eventService.emit('instance-policies-updated', event);
-
-			expect(eventBus.sendAuditEvent).not.toHaveBeenCalled();
-		});
 	});
 });

--- a/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
@@ -2259,4 +2259,132 @@ describe('LogStreamingEventRelay', () => {
 			});
 		});
 	});
+
+	describe('instance policies events', () => {
+		it('should log `personal-publishing-restricted.enabled` when workflow_publishing is disabled', () => {
+			const event: RelayEventMap['instance-policies-updated'] = {
+				user: {
+					id: 'user123',
+					email: 'admin@example.com',
+					firstName: 'Admin',
+					lastName: 'User',
+					role: { slug: 'global:owner' },
+				},
+				settingName: 'workflow_publishing',
+				value: false,
+			};
+
+			eventService.emit('instance-policies-updated', event);
+
+			expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
+				eventName: 'n8n.audit.personal-publishing-restricted.enabled',
+				payload: {
+					userId: 'user123',
+					_email: 'admin@example.com',
+					_firstName: 'Admin',
+					_lastName: 'User',
+					globalRole: 'global:owner',
+				},
+			});
+		});
+
+		it('should log `personal-publishing-restricted.disabled` when workflow_publishing is enabled', () => {
+			const event: RelayEventMap['instance-policies-updated'] = {
+				user: {
+					id: 'user456',
+					email: 'admin2@example.com',
+					firstName: 'Another',
+					lastName: 'Admin',
+					role: { slug: 'global:admin' },
+				},
+				settingName: 'workflow_publishing',
+				value: true,
+			};
+
+			eventService.emit('instance-policies-updated', event);
+
+			expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
+				eventName: 'n8n.audit.personal-publishing-restricted.disabled',
+				payload: {
+					userId: 'user456',
+					_email: 'admin2@example.com',
+					_firstName: 'Another',
+					_lastName: 'Admin',
+					globalRole: 'global:admin',
+				},
+			});
+		});
+
+		it('should log `personal-sharing-restricted.enabled` when workflow_sharing is disabled', () => {
+			const event: RelayEventMap['instance-policies-updated'] = {
+				user: {
+					id: 'user789',
+					email: 'admin3@example.com',
+					firstName: 'Third',
+					lastName: 'Admin',
+					role: { slug: 'global:owner' },
+				},
+				settingName: 'workflow_sharing',
+				value: false,
+			};
+
+			eventService.emit('instance-policies-updated', event);
+
+			expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
+				eventName: 'n8n.audit.personal-sharing-restricted.enabled',
+				payload: {
+					userId: 'user789',
+					_email: 'admin3@example.com',
+					_firstName: 'Third',
+					_lastName: 'Admin',
+					globalRole: 'global:owner',
+				},
+			});
+		});
+
+		it('should log `personal-sharing-restricted.disabled` when workflow_sharing is enabled', () => {
+			const event: RelayEventMap['instance-policies-updated'] = {
+				user: {
+					id: 'user101',
+					email: 'admin4@example.com',
+					firstName: 'Fourth',
+					lastName: 'Admin',
+					role: { slug: 'global:admin' },
+				},
+				settingName: 'workflow_sharing',
+				value: true,
+			};
+
+			eventService.emit('instance-policies-updated', event);
+
+			expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
+				eventName: 'n8n.audit.personal-sharing-restricted.disabled',
+				payload: {
+					userId: 'user101',
+					_email: 'admin4@example.com',
+					_firstName: 'Fourth',
+					_lastName: 'Admin',
+					globalRole: 'global:admin',
+				},
+			});
+		});
+
+		it('should not log audit event for other settings like 2fa_enforcement', () => {
+			const event: RelayEventMap['instance-policies-updated'] = {
+				user: {
+					id: 'user999',
+					email: 'user@example.com',
+					firstName: 'Test',
+					lastName: 'User',
+					role: { slug: 'global:member' },
+				},
+				settingName: '2fa_enforcement',
+				value: true,
+			};
+
+			eventService.emit('instance-policies-updated', event);
+
+			expect(eventBus.sendAuditEvent).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -2084,6 +2084,21 @@ describe('TelemetryEventRelay', () => {
 			});
 		});
 
+		it('should track workflow_sharing update', () => {
+			const event: RelayEventMap['instance-policies-updated'] = {
+				user: { id: 'user789' },
+				settingName: 'workflow_sharing',
+				value: true,
+			};
+
+			eventService.emit('instance-policies-updated', event);
+
+			expect(telemetry.track).toHaveBeenCalledWith('User updated instance policies', {
+				user_id: 'user789',
+				workflow_sharing: true,
+			});
+		});
+
 		it('should track 2fa_enforcement update', () => {
 			const event: RelayEventMap['instance-policies-updated'] = {
 				user: { id: 'user456' },

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -2067,4 +2067,36 @@ describe('TelemetryEventRelay', () => {
 			});
 		});
 	});
+
+	describe('instance policies events', () => {
+		it('should track workflow_publishing update', () => {
+			const event: RelayEventMap['instance-policies-updated'] = {
+				userId: 'user123',
+				settingName: 'workflow_publishing',
+				value: true,
+			};
+
+			eventService.emit('instance-policies-updated', event);
+
+			expect(telemetry.track).toHaveBeenCalledWith('User updated instance policies', {
+				user_id: 'user123',
+				workflow_publishing: true,
+			});
+		});
+
+		it('should track 2fa_enforcement update', () => {
+			const event: RelayEventMap['instance-policies-updated'] = {
+				userId: 'user456',
+				settingName: '2fa_enforcement',
+				value: false,
+			};
+
+			eventService.emit('instance-policies-updated', event);
+
+			expect(telemetry.track).toHaveBeenCalledWith('User updated instance policies', {
+				user_id: 'user456',
+				'2fa_enforcement': false,
+			});
+		});
+	});
 });

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -2071,7 +2071,7 @@ describe('TelemetryEventRelay', () => {
 	describe('instance policies events', () => {
 		it('should track workflow_publishing update', () => {
 			const event: RelayEventMap['instance-policies-updated'] = {
-				userId: 'user123',
+				user: { id: 'user123' },
 				settingName: 'workflow_publishing',
 				value: true,
 			};
@@ -2086,7 +2086,7 @@ describe('TelemetryEventRelay', () => {
 
 		it('should track 2fa_enforcement update', () => {
 			const event: RelayEventMap['instance-policies-updated'] = {
-				userId: 'user456',
+				user: { id: 'user456' },
 				settingName: '2fa_enforcement',
 				value: false,
 			};

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -674,4 +674,14 @@ export type RelayEventMap = {
 		compactionStartTime: Date;
 	};
 	// #endregion
+
+	// #region Instance Policies
+
+	'instance-policies-updated': {
+		userId: string;
+		settingName: '2fa_enforcement' | 'workflow_publishing';
+		value: boolean;
+	};
+
+	// #endregion
 } & AiEventMap;

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -678,8 +678,8 @@ export type RelayEventMap = {
 	// #region Instance Policies
 
 	'instance-policies-updated': {
-		userId: string;
-		settingName: '2fa_enforcement' | 'workflow_publishing';
+		user: UserLike;
+		settingName: '2fa_enforcement' | 'workflow_publishing' | 'workflow_sharing';
 		value: boolean;
 	};
 

--- a/packages/cli/src/events/relays/log-streaming.event-relay.ts
+++ b/packages/cli/src/events/relays/log-streaming.event-relay.ts
@@ -7,6 +7,7 @@ import { MessageEventBus } from '@/eventbus/message-event-bus/message-event-bus'
 import { EventService } from '@/events/event.service';
 import type { RelayEventMap, UserLike } from '@/events/maps/relay.event-map';
 import { EventRelay } from '@/events/relays/event-relay';
+import { assertNever } from '@/utils';
 
 type WorkflowExecutedEvent = RelayEventMap['workflow-executed'];
 type WorkflowExecutedEventWithUser = WorkflowExecutedEvent & { user: UserLike };
@@ -843,10 +844,8 @@ export class LogStreamingEventRelay extends EventRelay {
 					payload: user,
 				});
 				break;
-			default: {
-				const _exhaustive: never = settingName;
-				throw new Error(`Unhandled settingName: ${_exhaustive as string}`);
-			}
+			default:
+				assertNever(settingName);
 		}
 	}
 

--- a/packages/cli/src/events/relays/log-streaming.event-relay.ts
+++ b/packages/cli/src/events/relays/log-streaming.event-relay.ts
@@ -818,20 +818,35 @@ export class LogStreamingEventRelay extends EventRelay {
 		settingName,
 		value,
 	}: RelayEventMap['instance-policies-updated']) {
-		if (settingName === 'workflow_publishing') {
-			void this.eventBus.sendAuditEvent({
-				eventName: value
-					? 'n8n.audit.personal-publishing-restricted.disabled'
-					: 'n8n.audit.personal-publishing-restricted.enabled',
-				payload: user,
-			});
-		} else if (settingName === 'workflow_sharing') {
-			void this.eventBus.sendAuditEvent({
-				eventName: value
-					? 'n8n.audit.personal-sharing-restricted.disabled'
-					: 'n8n.audit.personal-sharing-restricted.enabled',
-				payload: user,
-			});
+		switch (settingName) {
+			case 'workflow_publishing':
+				void this.eventBus.sendAuditEvent({
+					eventName: value
+						? 'n8n.audit.personal-publishing-restricted.disabled'
+						: 'n8n.audit.personal-publishing-restricted.enabled',
+					payload: user,
+				});
+				break;
+			case 'workflow_sharing':
+				void this.eventBus.sendAuditEvent({
+					eventName: value
+						? 'n8n.audit.personal-sharing-restricted.disabled'
+						: 'n8n.audit.personal-sharing-restricted.enabled',
+					payload: user,
+				});
+				break;
+			case '2fa_enforcement':
+				void this.eventBus.sendAuditEvent({
+					eventName: value
+						? 'n8n.audit.2fa-enforcement.enabled'
+						: 'n8n.audit.2fa-enforcement.disabled',
+					payload: user,
+				});
+				break;
+			default: {
+				const _exhaustive: never = settingName;
+				throw new Error(`Unhandled settingName: ${_exhaustive as string}`);
+			}
 		}
 	}
 

--- a/packages/cli/src/events/relays/log-streaming.event-relay.ts
+++ b/packages/cli/src/events/relays/log-streaming.event-relay.ts
@@ -90,6 +90,7 @@ export class LogStreamingEventRelay extends EventRelay {
 			'job-enqueued': (event) => this.jobEnqueued(event),
 			'job-dequeued': (event) => this.jobDequeued(event),
 			'job-stalled': (event) => this.jobStalled(event),
+			'instance-policies-updated': (event) => this.instancePoliciesUpdated(event),
 		});
 	}
 
@@ -805,6 +806,33 @@ export class LogStreamingEventRelay extends EventRelay {
 			eventName: 'n8n.queue.job.stalled',
 			payload,
 		});
+	}
+
+	// #endregion
+
+	// #region Instance Policies
+
+	@Redactable()
+	private instancePoliciesUpdated({
+		user,
+		settingName,
+		value,
+	}: RelayEventMap['instance-policies-updated']) {
+		if (settingName === 'workflow_publishing') {
+			void this.eventBus.sendAuditEvent({
+				eventName: value
+					? 'n8n.audit.personal-publishing-restricted.disabled'
+					: 'n8n.audit.personal-publishing-restricted.enabled',
+				payload: user,
+			});
+		} else if (settingName === 'workflow_sharing') {
+			void this.eventBus.sendAuditEvent({
+				eventName: value
+					? 'n8n.audit.personal-sharing-restricted.disabled'
+					: 'n8n.audit.personal-sharing-restricted.enabled',
+				payload: user,
+			});
+		}
 	}
 
 	// #endregion

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -1386,12 +1386,12 @@ export class TelemetryEventRelay extends EventRelay {
 	// #region Instance Policies
 
 	private instancePoliciesUpdated({
-		userId,
+		user,
 		settingName,
 		value,
 	}: RelayEventMap['instance-policies-updated']) {
 		this.telemetry.track('User updated instance policies', {
-			user_id: userId,
+			user_id: user.id,
 			[settingName]: value,
 		});
 	}

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -141,6 +141,7 @@ export class TelemetryEventRelay extends EventRelay {
 			'user-password-reset-email-click': (event) => this.userPasswordResetEmailClick(event),
 			'user-password-reset-request-click': (event) => this.userPasswordResetRequestClick(event),
 			'history-compacted': (event) => this.historyCompacted(event),
+			'instance-policies-updated': (event) => this.instancePoliciesUpdated(event),
 		});
 	}
 
@@ -1380,5 +1381,20 @@ export class TelemetryEventRelay extends EventRelay {
 				this.globalConfig.workflowHistoryCompaction.trimmingTimeWindowDays,
 		});
 	}
+	// #endregion
+
+	// #region Instance Policies
+
+	private instancePoliciesUpdated({
+		userId,
+		settingName,
+		value,
+	}: RelayEventMap['instance-policies-updated']) {
+		this.telemetry.track('User updated instance policies', {
+			user_id: userId,
+			[settingName]: value,
+		});
+	}
+
 	// #endregion
 }


### PR DESCRIPTION
## Summary

Add log streaming/audit events when admins enable or disable personal space publishing and sharing restrictions. The events capture admin changes and include user metadata for audit purposes.

- `n8n.audit.personal-publishing-restricted.enabled` - when publishing is restricted
- `n8n.audit.personal-publishing-restricted.disabled` - when publishing is allowed
- `n8n.audit.personal-sharing-restricted.enabled` - when sharing is restricted
- `n8n.audit.personal-sharing-restricted.disabled` - when sharing is allowed

## Related Linear tickets

https://linear.app/n8n/issue/IAM-123
https://linear.app/n8n/issue/IAM-119

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)