### PR TITLE
fix(workflow): preserve node parameters during workflow import

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -1161,6 +1161,8 @@ export function useCanvasOperations() {
 	}
 
 	function resolveNodeParameters(node: INodeUi, nodeTypeDescription: INodeTypeDescription) {
+		if (node.parameters && Object.keys(node.parameters).length > 0) return;
+
 		const nodeParameters = NodeHelpers.getNodeParameters(
 			nodeTypeDescription?.properties ?? [],
 			node.parameters,

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -106,16 +106,19 @@ export class Workflow {
 				// });
 			}
 
-			// Add default values
-			const nodeParameters = NodeHelpers.getNodeParameters(
-				nodeType.description.properties,
-				node.parameters,
-				true,
-				false,
-				node,
-				nodeType.description,
-			);
-			node.parameters = nodeParameters !== null ? nodeParameters : {};
+			// Add default values ONLY if the node has no parameters set
+			// This prevents imported workflows from having their parameters stripped
+			if (!node.parameters || Object.keys(node.parameters).length === 0) {
+				const nodeParameters = NodeHelpers.getNodeParameters(
+					nodeType.description.properties,
+					node.parameters,
+					true,
+					false,
+					node,
+					nodeType.description,
+				);
+				node.parameters = nodeParameters !== null ? nodeParameters : {};
+			}
 		}
 
 		this.setNodes(parameters.nodes);

--- a/packages/workflow/test/workflow.test.ts
+++ b/packages/workflow/test/workflow.test.ts
@@ -29,6 +29,34 @@ interface StubNode {
 describe('Workflow', () => {
 	const nodeTypes = Helpers.NodeTypes();
 
+	it('should preserve existing node parameters when creating a workflow', () => {
+		const parameters: INodeParameters = {
+			resource: 'sheet',
+			operation: 'create',
+			range: 'A:F',
+			sheetId: 'sheet-123',
+			authentication: 'oAuth2',
+		};
+
+		const workflow = new Workflow({
+			nodeTypes,
+			nodes: [
+				{
+					parameters,
+					name: 'Google Sheets',
+					type: 'test.googleSheets',
+					typeVersion: 1,
+					id: 'uuid-1',
+					position: [240, 300],
+				},
+			],
+			connections: {},
+			active: false,
+		});
+
+		expect(workflow.nodes['Google Sheets'].parameters).toEqual(parameters);
+	});
+
 	const SIMPLE_WORKFLOW = new Workflow({
 		nodeTypes,
 		nodes: [


### PR DESCRIPTION
## What does this PR do?

Fixes a critical bug where importing workflows from JSON files strips all node parameters, leaving imported workflows completely non-functional.

## What is the context?

When a workflow is imported via the "Import from File" feature, the `Workflow` constructor calls `getNodeParameters()` with `returnDefaults=true` on all nodes. This function filters parameters based on display conditions, causing parameters that don't currently meet display criteria to be removed - even though they're valid and necessary for the workflow to function.

## How did you test this?

- Tested with workflows containing 20+ nodes with complex parameters
- Verified that imported workflows now retain all parameters
- Confirmed credentials are still properly mapped
- Tested with multiple node types (Gmail, S3, HTTP Request, Function, etc.)

## What are the relevant issues?

Closes #25254

## Checklist

- [x] The PR title is in the format `fix(workflow): preserve node parameters during import`
- [x] Tests for the changes have been added (if applicable)
- [x] Documentation has been updated (if applicable)
- [x] Code follows the project's style guidelines