### PR TITLE
 fixed Missing reasoning_content field error

### DIFF
--- a/packages/@n8n/nodes-langchain/utils/agent-execution/createEngineRequests.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/createEngineRequests.ts
@@ -158,6 +158,36 @@ function extractThinkingMetadata(
 		}
 	}
 
+	// Extract DeepSeek reasoning_content from additional_kwargs
+	let reasoningContent: string | undefined;
+	if (effectiveAdditionalKwargs) {
+		reasoningContent =
+			typeof effectiveAdditionalKwargs.reasoning_content === 'string'
+				? effectiveAdditionalKwargs.reasoning_content
+				: undefined;
+	}
+
+	// Also check messageLog for reasoning_content in additional_kwargs
+	if (!reasoningContent && effectiveMessageLog && Array.isArray(effectiveMessageLog)) {
+		for (const message of effectiveMessageLog) {
+			if (message && typeof message === 'object' && 'additional_kwargs' in message) {
+				const msgAdditionalKwargs = message.additional_kwargs as
+					| Record<string, unknown>
+					| undefined;
+				if (msgAdditionalKwargs) {
+					const msgReasoningContent =
+						typeof msgAdditionalKwargs.reasoning_content === 'string'
+							? msgAdditionalKwargs.reasoning_content
+							: undefined;
+					if (msgReasoningContent) {
+						reasoningContent = msgReasoningContent;
+						break;
+					}
+				}
+			}
+		}
+	}
+
 	// Build result object
 	if (thoughtSignature) {
 		result.google = { thoughtSignature };
@@ -169,6 +199,10 @@ function extractThinkingMetadata(
 			thinkingType,
 			...(thinkingSignature ? { thinkingSignature } : {}),
 		};
+	}
+
+	if (reasoningContent) {
+		result.deepseek = { reasoningContent };
 	}
 
 	return result;

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/memoryManagement.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/memoryManagement.ts
@@ -89,6 +89,10 @@ export function buildMessagesFromSteps(steps: ToolCallData[]): BaseMessage[] {
 			existingToolCallId ?? extractToolCallId(step.action.toolCallId, step.action.tool);
 
 		// Use existing AIMessage or create a synthetic one
+		// Preserve reasoning_content from existing message if present (for DeepSeek Reasoner)
+		const existingReasoningContent =
+			existingAIMessage?.additional_kwargs?.reasoning_content as string | undefined;
+
 		const aiMessage =
 			existingAIMessage ??
 			new AIMessage({
@@ -101,6 +105,12 @@ export function buildMessagesFromSteps(steps: ToolCallData[]): BaseMessage[] {
 						type: 'tool_call',
 					},
 				],
+				// Preserve reasoning_content for DeepSeek Reasoner
+				...(existingReasoningContent && {
+					additional_kwargs: {
+						reasoning_content: existingReasoningContent,
+					},
+				}),
 			});
 
 		// Create ToolMessage with the observation result

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/memoryManagement.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/memoryManagement.test.ts
@@ -361,6 +361,69 @@ describe('memoryManagement', () => {
 			const result = buildMessagesFromSteps([]);
 			expect(result).toHaveLength(0);
 		});
+
+		it('should preserve reasoning_content from existing AIMessage for DeepSeek Reasoner', () => {
+			const aiMessage = new AIMessage({
+				content: 'Calling calculator',
+				tool_calls: [
+					{
+						id: 'call-123',
+						name: 'calculator',
+						args: { expression: '2+2' },
+						type: 'tool_call',
+					},
+				],
+				additional_kwargs: {
+					reasoning_content: 'DeepSeek reasoning content preserved',
+				},
+			});
+
+			const steps: ToolCallData[] = [
+				{
+					action: {
+						tool: 'calculator',
+						toolInput: { expression: '2+2' },
+						log: 'Calc',
+						messageLog: [aiMessage],
+						toolCallId: 'call-123',
+						type: 'tool_call',
+					},
+					observation: '4',
+				},
+			];
+
+			const result = buildMessagesFromSteps(steps);
+
+			expect(result).toHaveLength(2);
+			// Should preserve the original AIMessage with reasoning_content
+			expect(result[0]).toBe(aiMessage);
+			expect(result[0].additional_kwargs?.reasoning_content).toBe(
+				'DeepSeek reasoning content preserved',
+			);
+		});
+
+		it('should not add reasoning_content when creating synthetic AIMessage without it', () => {
+			const steps: ToolCallData[] = [
+				{
+					action: {
+						tool: 'calculator',
+						toolInput: { expression: '2+2' },
+						log: 'Calc',
+						// No messageLog - will create synthetic AIMessage
+						toolCallId: 'call-123',
+						type: 'tool_call',
+					},
+					observation: '4',
+				},
+			];
+
+			const result = buildMessagesFromSteps(steps);
+
+			expect(result).toHaveLength(2);
+			expect(result[0]).toBeInstanceOf(AIMessage);
+			// Synthetic message should not have reasoning_content
+			expect(result[0].additional_kwargs?.reasoning_content).toBeUndefined();
+		});
 	});
 
 	describe('saveToMemory with steps (message-based storage)', () => {

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/types.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/types.ts
@@ -115,6 +115,14 @@ export type AnthropicThinkingMetadata = {
 };
 
 /**
+ * DeepSeek-specific metadata for Reasoner models.
+ */
+export type DeepSeekThinkingMetadata = {
+	/** Reasoning content required by DeepSeek Reasoner API when calling tools */
+	reasoningContent?: string;
+};
+
+/**
  * HITL (Human-in-the-Loop) metadata - presence indicates this is an HITL tool action.
  */
 export type HitlMetadata = {
@@ -127,11 +135,12 @@ export type HitlMetadata = {
 };
 
 /**
- * Thinking metadata extracted from LLM responses (Anthropic/Google extended thinking).
+ * Thinking metadata extracted from LLM responses (Anthropic/Google extended thinking, DeepSeek reasoning).
  */
 export type ThinkingMetadata = {
 	google?: GoogleThinkingMetadata;
 	anthropic?: AnthropicThinkingMetadata;
+	deepseek?: DeepSeekThinkingMetadata;
 };
 
 /**
@@ -150,6 +159,8 @@ export type RequestResponseMetadata = {
 	google?: GoogleThinkingMetadata;
 	/** Anthropic-specific metadata */
 	anthropic?: AnthropicThinkingMetadata;
+	/** DeepSeek-specific metadata */
+	deepseek?: DeepSeekThinkingMetadata;
 	/** HITL (Human-in-the-Loop) metadata - presence indicates this is an HITL tool action */
 	hitl?: HitlMetadata;
 };


### PR DESCRIPTION
## Summary

This PR fixes an issue where DeepSeek Reasoner models fail when calling tools in AI Agent workflows. The DeepSeek API requires a `reasoning_content` field in assistant messages when using the Reasoner model with tools, but this field was not being preserved across tool call iterations.

### Changes Made

1. **Added DeepSeek-specific metadata types** to track `reasoning_content` throughout the agent execution flow
2. **Updated extraction logic** to capture `reasoning_content` from API responses and store it in metadata
3. **Modified message building** to include `reasoning_content` in `additional_kwargs` when constructing AIMessage objects for tool calls
4. **Enhanced memory management** to preserve `reasoning_content` when rebuilding messages from conversation history

### How to Test

1. Create an AI Agent workflow with DeepSeek Reasoner model (`deepseek-reasoner`)
2. Connect tools to the agent (e.g., HTTP Request, Code node, or any AI Tool)
3. Execute the workflow with a prompt that requires tool usage
4. Verify that tool calls complete successfully without the "Missing reasoning_content field" error
5. Test multiple tool call iterations to ensure `reasoning_content` is preserved across turns

### Technical Details

The fix ensures that when DeepSeek Reasoner responds with tool calls, the `reasoning_content` field from the API response is:
- Extracted from `additional_kwargs` in the LLM response
- Stored in request/response metadata
- Included in subsequent AIMessage objects via `additional_kwargs`
- Preserved when messages are rebuilt from memory or conversation history

LangChain's ChatOpenAI wrapper automatically includes `additional_kwargs` when formatting messages for the API, so DeepSeek receives the required field.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #25161

https://github.com/n8n-io/n8n/issues/25161

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
