### PR TITLE
ci: Add Kent for local testing of Sentry events and traces

### DIFF
--- a/packages/core/src/errors/error-reporter.ts
+++ b/packages/core/src/errors/error-reporter.ts
@@ -143,8 +143,14 @@ export class ErrorReporter {
 		Error.stackTraceLimit = 50;
 
 		const sentry = await import('@sentry/node');
-		const { init, captureException, setTag, requestDataIntegration, rewriteFramesIntegration } =
-			sentry;
+		const {
+			init,
+			captureException,
+			setTag,
+			setUser,
+			requestDataIntegration,
+			rewriteFramesIntegration,
+		} = sentry;
 
 		// Most of the integrations are listed here:
 		// https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/
@@ -210,6 +216,10 @@ export class ErrorReporter {
 		});
 
 		setTag('server_type', serverType);
+
+		if (serverName) {
+			setUser({ id: serverName });
+		}
 
 		this.report = (error, options) => captureException(error, options);
 		this.beforeSendFilter = beforeSendFilter;

--- a/packages/frontend/editor-ui/src/app/plugins/sentry.ts
+++ b/packages/frontend/editor-ui/src/app/plugins/sentry.ts
@@ -76,6 +76,7 @@ export const SentryPlugin: Plugin = {
 
 		if (serverName) {
 			Sentry.setTag('server_name', serverName);
+			Sentry.setUser({ id: serverName });
 		}
 	},
 };

--- a/packages/testing/containers/dockerfiles/kent/Dockerfile
+++ b/packages/testing/containers/dockerfiles/kent/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+# Install Kent and flask-cors for browser CORS support
+RUN pip install --no-cache-dir kent flask-cors
+
+# Kent default port
+EXPOSE 8000
+
+# Copy and use our wrapper script that enables CORS
+COPY kent_cors.py /app/kent_cors.py
+
+CMD ["python", "/app/kent_cors.py"]

--- a/packages/testing/containers/dockerfiles/kent/Dockerfile
+++ b/packages/testing/containers/dockerfiles/kent/Dockerfile
@@ -1,12 +1,9 @@
 FROM python:3.12-slim
 
-# Install Kent and flask-cors for browser CORS support
 RUN pip install --no-cache-dir kent flask-cors
 
-# Kent default port
 EXPOSE 8000
 
-# Copy and use our wrapper script that enables CORS
 COPY kent_cors.py /app/kent_cors.py
 
 CMD ["python", "/app/kent_cors.py"]

--- a/packages/testing/containers/dockerfiles/kent/kent_cors.py
+++ b/packages/testing/containers/dockerfiles/kent/kent_cors.py
@@ -1,0 +1,9 @@
+"""Kent server wrapper with CORS support for browser-based testing."""
+from flask_cors import CORS
+from kent.app import create_app
+
+app = create_app()
+CORS(app)  # Enable CORS for all origins
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000)

--- a/packages/testing/containers/n8n-start-stack.ts
+++ b/packages/testing/containers/n8n-start-stack.ts
@@ -4,6 +4,7 @@ import { parseArgs } from 'node:util';
 import { DockerImageNotFoundError } from './docker-image-not-found-error';
 import { BASE_PERFORMANCE_PLANS, isValidPerformancePlan } from './performance-plans';
 import type { CloudflaredResult } from './services/cloudflared';
+import type { KentResult } from './services/kent';
 import type { KeycloakResult } from './services/keycloak';
 import type { MailpitResult } from './services/mailpit';
 import type { NgrokResult } from './services/ngrok';
@@ -54,6 +55,7 @@ ${colors.yellow}Options:${colors.reset}
   --tunnel          Enable Cloudflare Tunnel for public URL (via trycloudflare.com)
   --ngrok           Enable ngrok tunnel for public URL (requires NGROK_AUTHTOKEN env var)
   --mailpit         Enable Mailpit for email testing
+  --kent            Enable Kent (Sentry mock) for error tracking testing
   --mains <n>       Number of main instances (default: 1)
   --workers <n>     Number of worker instances (default: 1)
   --name <name>     Project name for parallel runs
@@ -137,6 +139,7 @@ async function main() {
 			tunnel: { type: 'boolean' },
 			ngrok: { type: 'boolean' },
 			mailpit: { type: 'boolean' },
+			kent: { type: 'boolean' },
 			mains: { type: 'string' },
 			workers: { type: 'string' },
 			name: { type: 'string' },
@@ -162,6 +165,7 @@ async function main() {
 	if (values.tunnel) services.push('cloudflared');
 	if (values.ngrok) services.push('ngrok');
 	if (values.mailpit) services.push('mailpit');
+	if (values.kent) services.push('kent');
 
 	// Build configuration
 	const config: N8NConfig = {
@@ -312,6 +316,15 @@ async function main() {
 			log.info(`Mailpit UI: ${colors.cyan}${mailpitResult.meta.apiBaseUrl}${colors.reset}`);
 		}
 
+		const kentResult = stack.serviceResults.kent as KentResult | undefined;
+		if (kentResult) {
+			console.log('');
+			log.header('Sentry Mock (Kent)');
+			log.info(`Kent UI: ${colors.cyan}${kentResult.meta.apiUrl}${colors.reset}`);
+			log.info(`Backend DSN: ${colors.cyan}${kentResult.meta.sentryDsn}${colors.reset}`);
+			log.info(`Frontend DSN: ${colors.cyan}${kentResult.meta.frontendDsn}${colors.reset}`);
+		}
+
 		console.log('');
 		log.info('Containers are running in the background');
 		log.info(
@@ -352,6 +365,7 @@ function displayConfig(config: N8NConfig) {
 	if (services.includes('victoriaLogs')) enabledFeatures.push('Observability');
 	if (services.includes('tracing')) enabledFeatures.push('Tracing (Jaeger)');
 	if (services.includes('mailpit')) enabledFeatures.push('Email (Mailpit)');
+	if (services.includes('kent')) enabledFeatures.push('Sentry Mock (Kent)');
 
 	if (enabledFeatures.length > 0) {
 		log.info(`Services: ${enabledFeatures.join(', ')}`);

--- a/packages/testing/containers/services/kent.ts
+++ b/packages/testing/containers/services/kent.ts
@@ -1,0 +1,156 @@
+/**
+ * Kent - Sentry's mock server for testing SDK integrations
+ * @see https://github.com/getsentry/kent
+ */
+import { resolve } from 'node:path';
+import { GenericContainer, Wait } from 'testcontainers';
+import type { StartedNetwork } from 'testcontainers';
+
+import type { HelperContext, Service, ServiceResult, ServiceMeta } from './types';
+
+const HOSTNAME = 'kent';
+const PORT = 8000;
+const DOCKERFILE_PATH = resolve(__dirname, '../dockerfiles/kent');
+
+export interface KentMeta extends ServiceMeta {
+	host: string;
+	port: number;
+	apiUrl: string;
+	sentryDsn: string;
+	frontendDsn: string;
+}
+
+export type KentResult = ServiceResult<KentMeta>;
+
+export const kent: Service<KentResult> = {
+	description: 'Sentry mock server for testing',
+
+	async start(network: StartedNetwork, projectName: string): Promise<KentResult> {
+		const container = await GenericContainer.fromDockerfile(DOCKERFILE_PATH)
+			.build('n8n-kent:local', { deleteOnExit: false })
+			.then(
+				async (image) =>
+					await image
+						.withNetwork(network)
+						.withNetworkAliases(HOSTNAME)
+						.withExposedPorts(PORT)
+						.withWaitStrategy(Wait.forListeningPorts())
+						.withLabels({
+							'com.docker.compose.project': projectName,
+							'com.docker.compose.service': HOSTNAME,
+						})
+						.withName(`${projectName}-${HOSTNAME}`)
+						.withReuse()
+						.start(),
+			);
+
+		const mappedPort = container.getMappedPort(PORT);
+		const host = container.getHost();
+
+		return {
+			container,
+			meta: {
+				host: HOSTNAME,
+				port: PORT,
+				apiUrl: `http://${host}:${mappedPort}`,
+				sentryDsn: `http://testkey@${HOSTNAME}:${PORT}/1`,
+				frontendDsn: `http://testkey@${host}:${mappedPort}/1`,
+			},
+		};
+	},
+
+	env(result: KentResult): Record<string, string> {
+		return {
+			N8N_SENTRY_DSN: result.meta.sentryDsn,
+			N8N_FRONTEND_SENTRY_DSN: result.meta.frontendDsn,
+			N8N_SENTRY_TRACES_SAMPLE_RATE: '1.0',
+			ENVIRONMENT: 'test',
+			N8N_SENTRY_DISABLE_FILTERING: 'true',
+		};
+	},
+};
+
+// ==================== Types ====================
+
+export type EventSource = 'backend' | 'frontend' | 'task_runner' | 'unknown';
+export type EventType = 'error' | 'transaction' | 'session' | 'unknown';
+
+export interface KentEvent {
+	event_id: string;
+	project_id: number;
+	payload: {
+		body: {
+			sdk?: { name: string; version: string };
+			platform?: string;
+			type?: string;
+			transaction?: string;
+			tags?: Record<string, string>;
+			exception?: { values: Array<{ type: string; value: string }> };
+			spans?: unknown[];
+			[key: string]: unknown;
+		};
+	};
+}
+
+// ==================== Helper (thin API client) ====================
+
+export class KentHelper {
+	constructor(private readonly apiUrl: string) {}
+
+	/** Clear all captured events */
+	async clear(): Promise<void> {
+		const res = await fetch(`${this.apiUrl}/api/flush/`, { method: 'POST' });
+		if (!res.ok) throw new Error(`Kent API error: ${res.status}`);
+	}
+
+	/** Get all captured events */
+	async getEvents(): Promise<KentEvent[]> {
+		const res = await fetch(`${this.apiUrl}/api/eventlist/`);
+		if (!res.ok) throw new Error(`Kent API error: ${res.status}`);
+		const { events } = (await res.json()) as { events: Array<{ event_id: string }> };
+		return await Promise.all(events.map(async (e) => await this.getEvent(e.event_id)));
+	}
+
+	/** Get event source (frontend/backend/task_runner) */
+	getSource(event: KentEvent): EventSource {
+		const sdk = event.payload.body.sdk?.name ?? '';
+		if (sdk.includes('vue') || sdk.includes('browser')) return 'frontend';
+		if (sdk === 'sentry.javascript.node' || event.payload.body.platform === 'node') {
+			return event.payload.body.tags?.server_type === 'task_runner' ? 'task_runner' : 'backend';
+		}
+		if ('sid' in event.payload.body) return 'frontend';
+		return 'unknown';
+	}
+
+	/** Get event type (error/transaction/session) */
+	getType(event: KentEvent): EventType {
+		const body = event.payload.body;
+		if ('sid' in body) return 'session';
+		if (body.exception) return 'error';
+		if (body.type === 'transaction' || Array.isArray(body.spans)) return 'transaction';
+		return 'unknown';
+	}
+
+	/** Get error message from event */
+	getErrorMessage(event: KentEvent): string {
+		return event.payload.body.exception?.values?.[0]?.value ?? '';
+	}
+
+	private async getEvent(eventId: string): Promise<KentEvent> {
+		const res = await fetch(`${this.apiUrl}/api/event/${eventId}`);
+		if (!res.ok) throw new Error(`Kent API error: ${res.status}`);
+		return (await res.json()) as KentEvent;
+	}
+}
+
+export function createKentHelper(ctx: HelperContext): KentHelper {
+	const result = ctx.serviceResults.kent as KentResult | undefined;
+	if (!result) throw new Error('Kent service not found. Add "kent" to your services array.');
+	return new KentHelper(result.meta.apiUrl);
+}
+
+declare module './types' {
+	interface ServiceHelpers {
+		kent: KentHelper;
+	}
+}

--- a/packages/testing/containers/services/registry.ts
+++ b/packages/testing/containers/services/registry.ts
@@ -1,6 +1,7 @@
 import { cloudflared } from './cloudflared';
 import { gitea, createGiteaHelper } from './gitea';
 import { kafka, createKafkaHelper } from './kafka';
+import { kent, createKentHelper } from './kent';
 import { keycloak, createKeycloakHelper } from './keycloak';
 import { loadBalancer } from './load-balancer';
 import { localstack, createLocalStackHelper } from './localstack';
@@ -37,6 +38,7 @@ export const services: Record<ServiceName, Service<ServiceResult>> = {
 	kafka,
 	mysql: mysqlService,
 	localstack,
+	kent,
 };
 
 export const helperFactories: Partial<HelperFactories> = {
@@ -47,4 +49,5 @@ export const helperFactories: Partial<HelperFactories> = {
 	tracing: createTracingHelper,
 	kafka: createKafkaHelper,
 	localstack: createLocalStackHelper,
+	kent: createKentHelper,
 };

--- a/packages/testing/containers/services/types.ts
+++ b/packages/testing/containers/services/types.ts
@@ -18,6 +18,7 @@ export const SERVICE_NAMES = [
 	'ngrok',
 	'mysql',
 	'localstack',
+	'kent',
 ] as const;
 
 export type ServiceName = (typeof SERVICE_NAMES)[number];

--- a/packages/testing/playwright/fixtures/capabilities.ts
+++ b/packages/testing/playwright/fixtures/capabilities.ts
@@ -22,6 +22,7 @@ export const CAPABILITIES = {
 			N8N_ENV_FEAT_EXTERNAL_SECRETS_FOR_PROJECTS: 'true',
 		},
 	},
+	kent: { services: ['kent'] },
 } as const satisfies Record<string, Partial<N8NConfig>>;
 
 export type Capability = keyof typeof CAPABILITIES;

--- a/packages/testing/playwright/tests/e2e/sentry/sentry-baseline.spec.ts
+++ b/packages/testing/playwright/tests/e2e/sentry/sentry-baseline.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from '../../../fixtures/base';
+
+/**
+ * Sentry Baseline Tests - verifies what Sentry captures to establish a baseline.
+ * Run with: pnpm test:e2e --grep "Sentry baseline"
+ */
+
+test.use({ capability: 'kent' });
+
+test.beforeEach(async ({ n8nContainer }) => {
+	await n8nContainer.services.kent.clear();
+});
+
+test.describe('Sentry baseline', () => {
+	test('frontend error is captured', async ({ n8n, n8nContainer }) => {
+		const kent = n8nContainer.services.kent;
+		await n8n.navigate.toHome();
+
+		// Trigger unhandled error
+		n8n.page.on('pageerror', () => {}); // Suppress Playwright error
+		await n8n.page.evaluate(() => {
+			setTimeout(() => {
+				throw new Error('Test frontend error');
+			}, 0);
+		});
+
+		// Poll until Kent captures the frontend error
+		await expect
+			.poll(
+				async () => {
+					const events = await kent.getEvents();
+					return events.find(
+						(e) =>
+							kent.getSource(e) === 'frontend' &&
+							kent.getType(e) === 'error' &&
+							kent.getErrorMessage(e).includes('Test frontend error'),
+					);
+				},
+				{ timeout: 10000 },
+			)
+			.toBeTruthy();
+	});
+
+	test('backend transaction is captured', async ({ n8n, n8nContainer }) => {
+		const kent = n8nContainer.services.kent;
+		await n8n.navigate.toHome();
+
+		// Poll until Kent captures a backend transaction
+		await expect
+			.poll(
+				async () => {
+					const events = await kent.getEvents();
+					return events.find(
+						(e) => kent.getSource(e) === 'backend' && kent.getType(e) === 'transaction',
+					);
+				},
+				{ timeout: 10000 },
+			)
+			.toBeTruthy();
+	});
+
+	test('can count events by source and type', async ({ n8n, n8nContainer }) => {
+		const kent = n8nContainer.services.kent;
+		await n8n.navigate.toHome();
+
+		// Poll until we have backend transactions, then verify count
+		await expect
+			.poll(
+				async () => {
+					const events = await kent.getEvents();
+					return events.filter(
+						(e) => kent.getSource(e) === 'backend' && kent.getType(e) === 'transaction',
+					).length;
+				},
+				{ timeout: 10000 },
+			)
+			.toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
## Summary

Adds **Kent** (Sentry's official mock server) to the testcontainers infrastructure for testing Sentry SDK integrations. This enables E2E tests to verify that errors and traces are actually captured and sent to Sentry - critical for the Shift-Right Observability initiative.

### Why this approach

Currently, we have no way to verify that Sentry is working correctly in E2E tests. We configure DSNs and sample rates, but never validate that:
- Frontend errors actually reach Sentry
- Backend transactions are traced
- Task runner events have correct tags
- Filters (like user code error suppression) work as intended

Kent is Sentry's own testing tool - it's a mock Sentry server that captures events for inspection. By running it in our testcontainers setup, we can assert on actual Sentry payloads.

### What's included

1. **Kent service** (`packages/testing/containers/services/kent.ts`)
   - Docker container running Kent with CORS support (required for browser → container communication)
   - `KentHelper` thin API client exposed via `n8nContainer.services.kent`
   - Methods: `clear()`, `getEvents()`, `getSource()`, `getType()`, `getErrorMessage()`

2. **CORS wrapper** (`packages/testing/containers/dockerfiles/kent/`)
   - Flask-CORS wrapper for Kent to allow browser-based testing
   - Without CORS, the frontend SDK can't send events to Kent in the container

3. **Capability integration** (`kent` capability in `capabilities.ts`)
   - Use with `test.use({ capability: 'kent' })` in tests
   - Automatically sets `N8N_SENTRY_DSN`, `N8N_FRONTEND_SENTRY_DSN`, and related env vars

4. **Baseline tests** (`tests/e2e/sentry/sentry-baseline.spec.ts`)
   - Verifies frontend errors are captured
   - Verifies backend transactions are captured
   - Demonstrates event filtering by source/type

### How to test locally

```bash
# From packages/testing/playwright
pnpm test:e2e --grep "Sentry baseline"
```

Requirements:
- Docker running (testcontainers will build Kent image on first run)
- n8n container mode (not local dev - tests need the container environment)

The tests will:
1. Start Kent container with CORS support
2. Start n8n with Sentry DSNs pointing to Kent
3. Trigger frontend errors / navigate to capture transactions
4. Poll Kent API to verify events were received

### Use cases this enables

- **Baseline validation**: Verify current Sentry behavior before making changes
- **Filter testing**: Add tests for specific Sentry filters (e.g., user code error suppression)
- **Regression prevention**: Ensure Sentry config changes don't break event capture
- **Future @n8n/sentry-config**: Validate central Sentry config produces same events

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-429/add-sentry-monitoring-in-staging

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)