### PR TITLE
feat(core): Implement test connection endpoint for external secrets

### DIFF
--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.controller.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.controller.ee.ts
@@ -103,15 +103,14 @@ export class SecretProvidersConnectionsController {
 	}
 
 	@Post('/:providerKey/test')
-	@GlobalScope('externalSecretsProvider:read')
-	testConnection(
+	@GlobalScope('externalSecretsProvider:update')
+	async testConnection(
 		_req: AuthenticatedRequest,
 		_res: Response,
-		@Param('providerKey') _providerKey: string,
-	) {
-		this.logger.debug('Testing provider connnection');
-		//TODO implement
-		return;
+		@Param('providerKey') providerKey: string,
+	): SecretsProvidersResponses.TestConnectionResult {
+		this.logger.debug('Testing provider connection', { providerKey });
+		return await this.connectionsService.testConnection(providerKey);
 	}
 
 	@Post('/:providerKey/connect')

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.service.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.service.ee.ts
@@ -156,7 +156,26 @@ export class SecretsProvidersConnectionsService {
 		};
 	}
 
+	async testConnection(providerKey: string): Promise<{ success: boolean; error?: string }> {
+		const connection = await this.getConnection(providerKey);
+		const decryptedSettings = this.decryptConnectionSettings(connection.encryptedSettings);
+
+		const testResult = await this.externalSecretsManager.testProviderSettings(
+			connection.type,
+			decryptedSettings,
+		);
+
+		return {
+			success: testResult.success,
+			error: (testResult as Record<string, unknown>).error as string | undefined,
+		};
+	}
+
 	private encryptConnectionSettings(settings: IDataObject): string {
 		return this.cipher.encrypt(settings);
+	}
+
+	private decryptConnectionSettings(encryptedSettings: string): IDataObject {
+		return JSON.parse(this.cipher.decrypt(encryptedSettings));
 	}
 }

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers.responses.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers.responses.ee.ts
@@ -5,4 +5,5 @@ export declare namespace SecretsProvidersResponses {
 
 	type PublicConnection = Promise<StrippedConnection>;
 	type PublicConnectionList = Promise<StrippedConnection[]>;
+	type TestConnectionResult = Promise<{ success: boolean; error?: string }>;
 }

--- a/packages/cli/test/integration/external-secrets/secret-providers-connections.api.test.ts
+++ b/packages/cli/test/integration/external-secrets/secret-providers-connections.api.test.ts
@@ -37,12 +37,27 @@ describe('Secret Providers Connections API', () => {
 	});
 
 	let ownerAgent: SuperAgentTest;
+	let memberAgent: SuperAgentTest;
+	let adminAgent: SuperAgentTest;
+	let agents: Record<string, SuperAgentTest>;
 	let teamProject1: Project;
 	let teamProject2: Project;
+
+	const FORBIDDEN_MESSAGE = 'User is missing a scope required to perform this action';
 
 	beforeAll(async () => {
 		const owner = await createOwner();
 		ownerAgent = testServer.authAgentFor(owner);
+
+		const [member, admin] = await Promise.all([createMember(), createAdmin()]);
+		memberAgent = testServer.authAgentFor(member);
+		adminAgent = testServer.authAgentFor(admin);
+
+		agents = {
+			owner: ownerAgent,
+			admin: adminAgent,
+			member: memberAgent,
+		};
 
 		teamProject1 = await createTeamProject('Engineering');
 		teamProject2 = await createTeamProject('Marketing');
@@ -485,25 +500,6 @@ describe('Secret Providers Connections API', () => {
 	});
 
 	describe('Access Control', () => {
-		let memberAgent: SuperAgentTest;
-		let adminAgent: SuperAgentTest;
-		let agents: Record<string, SuperAgentTest>;
-
-		const FORBIDDEN_MESSAGE = 'User is missing a scope required to perform this action';
-
-		beforeAll(async () => {
-			const [member, admin] = await Promise.all([createMember(), createAdmin()]);
-
-			memberAgent = testServer.authAgentFor(member);
-			adminAgent = testServer.authAgentFor(admin);
-
-			agents = {
-				owner: ownerAgent,
-				admin: adminAgent,
-				member: memberAgent,
-			};
-		});
-
 		async function createTestConnection(providerKey: string, projectIds: string[] = []) {
 			await ownerAgent
 				.post('/secret-providers/connections')
@@ -707,6 +703,118 @@ describe('Secret Providers Connections API', () => {
 				.get('/secret-providers/connections/orphan-test')
 				.expect(200);
 			expect(response.body.data.projects).toEqual([]);
+		});
+	});
+
+	describe('Test connection', () => {
+		beforeAll(async () => {
+			const { DummyProvider } = await import('../../shared/external-secrets/utils');
+			mockProvidersInstance.setProviders({ awsSecretsManager: DummyProvider });
+		});
+
+		afterEach(async () => {
+			const { DummyProvider } = await import('../../shared/external-secrets/utils');
+			mockProvidersInstance.setProviders({ awsSecretsManager: DummyProvider });
+		});
+
+		test('should successfully test connection with valid settings', async () => {
+			await ownerAgent
+				.post('/secret-providers/connections')
+				.send({
+					providerKey: 'test-success',
+					type: 'awsSecretsManager',
+					projectIds: [],
+					settings: { username: 'user', password: 'pass' },
+				})
+				.expect(200);
+
+			const testResponse = await ownerAgent
+				.post('/secret-providers/connections/test-success/test')
+				.expect(200);
+
+			expect(testResponse.body.data).toEqual({ success: true });
+		});
+
+		test('should return failure when provider test fails', async () => {
+			const { TestFailProvider } = await import('../../shared/external-secrets/utils');
+
+			mockProvidersInstance.setProviders({ awsSecretsManager: TestFailProvider });
+
+			await ownerAgent
+				.post('/secret-providers/connections')
+				.send({
+					providerKey: 'test-fail',
+					type: 'awsSecretsManager',
+					projectIds: [],
+					settings: { region: 'us-east-1' },
+				})
+				.expect(200);
+
+			const testResponse = await ownerAgent
+				.post('/secret-providers/connections/test-fail/test')
+				.expect(200);
+
+			expect(testResponse.body.data).toEqual({ success: false });
+		});
+
+		test('should return error when connection fails', async () => {
+			const { FailedProvider } = await import('../../shared/external-secrets/utils');
+
+			mockProvidersInstance.setProviders({ awsSecretsManager: FailedProvider });
+
+			await ownerAgent
+				.post('/secret-providers/connections')
+				.send({
+					providerKey: 'test-connection-fail',
+					type: 'awsSecretsManager',
+					projectIds: [],
+					settings: { region: 'us-east-1' },
+				})
+				.expect(200);
+
+			const testResponse = await ownerAgent
+				.post('/secret-providers/connections/test-connection-fail/test')
+				.expect(200);
+
+			expect(testResponse.body.data.success).toBe(false);
+			expect(testResponse.body.data.error).toBeDefined();
+		});
+
+		test('should return 404 for non-existent connection', async () => {
+			const response = await ownerAgent
+				.post('/secret-providers/connections/non-existent/test')
+				.expect(404);
+
+			expect(response.body.message).toBe('Connection with key "non-existent" not found');
+		});
+
+		describe('access control', () => {
+			test.each([
+				{ role: 'owner', allowed: true },
+				{ role: 'admin', allowed: true },
+				{ role: 'member', allowed: false },
+			])('should allow=$allowed for $role to test connection', async ({ role, allowed }) => {
+				const providerKey = `test-access-${role}`;
+				await ownerAgent
+					.post('/secret-providers/connections')
+					.send({
+						providerKey,
+						type: 'awsSecretsManager',
+						projectIds: [],
+						settings: { region: 'us-east-1' },
+					})
+					.expect(200);
+
+				const response = await agents[role]
+					.post(`/secret-providers/connections/${providerKey}/test`)
+					.expect(allowed ? 200 : 403);
+
+				if (allowed) {
+					expect(response.body.data).toHaveProperty('success');
+				} else {
+					expect(response.body.message).toBe(FORBIDDEN_MESSAGE);
+				}
+			});
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Implement the `POST /rest/secret-providers/connections/:providerKey/test` endpoint to test saved connection settings by decrypting them, instantiating the provider, and validating connectivity. The endpoint uses the existing `externalSecretsManager.testProviderSettings()` method to handle provider lifecycle management.

Includes comprehensive integration tests covering successful tests, failures, connection errors, 404 for non-existent connections, and access control for owner/admin (allowed) and member (forbidden) roles.

## Related Linear tickets, Github issues, and Community forum posts

Closes LIGO-116

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] Tests included (7 new integration tests, all passing)
- [ ] Docs updated or follow-up ticket created