### PR TITLE
fix(core): Only show AI-provided tool call arguments in input logs

### DIFF
--- a/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
@@ -403,7 +403,7 @@ describe('processRunExecutionData', () => {
 				ai_tool: [
 					[
 						{
-							json: { prompt: 'test prompt', query: 'test input', toolCallId: 'action_1' },
+							json: { query: 'test input' },
 							pairedItem: {
 								input: 0,
 								item: 0,
@@ -423,7 +423,7 @@ describe('processRunExecutionData', () => {
 				ai_tool: [
 					[
 						{
-							json: { prompt: 'test prompt', data: 'another input', toolCallId: 'action_2' },
+							json: { data: 'another input' },
 							pairedItem: {
 								input: 0,
 								item: 0,
@@ -530,7 +530,7 @@ describe('processRunExecutionData', () => {
 				ai_tool: [
 					[
 						{
-							json: { prompt: 'test prompt', query: 'test input', toolCallId: 'action_1' },
+							json: { query: 'test input' },
 							pairedItem: {
 								input: 0,
 								item: 0,
@@ -720,9 +720,7 @@ describe('processRunExecutionData', () => {
 			expect(toolRunData.inputOverride).toBeDefined();
 			expect(toolRunData.inputOverride?.ai_tool).toBeDefined();
 			expect(toolRunData.inputOverride?.ai_tool?.[0]?.[0]?.json).toMatchObject({
-				prompt: 'test prompt',
 				query: 'test input that will fail',
-				toolCallId: 'action_1',
 			});
 
 			// Error output should be set under the correct connection type (ai_tool)

--- a/packages/core/src/execution-engine/requests-response.ts
+++ b/packages/core/src/execution-engine/requests-response.ts
@@ -60,7 +60,7 @@ function initializeNodeRunData(
 	parentRunIndex: number,
 	actionMetadata: ActionMetadata | undefined,
 	runIndex: number,
-	parentOutputData: INodeExecutionData[][],
+	displayOutputData: INodeExecutionData[][],
 ): number {
 	runData[nodeName] ||= [];
 	const nodeRunData = runData[nodeName];
@@ -73,8 +73,8 @@ function initializeNodeRunData(
 		previousNodeRun: actionMetadata?.parentNodeName ? parentRunIndex : runIndex,
 	};
 	nodeRunData.push({
-		// Necessary for the log on the canvas.
-		inputOverride: { ai_tool: parentOutputData },
+		// Necessary for the log on the canvas. Only show AI-provided tool call arguments.
+		inputOverride: { ai_tool: displayOutputData },
 		// Source must point to the parent node for the frontend logs panel
 		// to correctly display this sub-node under the parent.
 		source: [sourceData],
@@ -126,8 +126,20 @@ function prepareRequestedNodesForExecution(
 			toolCallId: action.id,
 		};
 
+		// For display: only show AI-provided tool call arguments (not parent/agent input or toolCallId)
+		const displayJson = {
+			...action.input,
+		};
+
 		const parentOutputData = buildParentOutputData(
 			mergedJson,
+			parentRunIndex,
+			defaultParentOutputIndex,
+			defaultParentSourceNode,
+		);
+
+		const displayOutputData = buildParentOutputData(
+			displayJson,
 			parentRunIndex,
 			defaultParentOutputIndex,
 			defaultParentSourceNode,
@@ -141,7 +153,7 @@ function prepareRequestedNodesForExecution(
 			parentRunIndex,
 			actionMetadata,
 			runIndex,
-			parentOutputData,
+			displayOutputData,
 		);
 
 		nodesToBeExecuted.push({


### PR DESCRIPTION
## Summary
Previously, inputOverride for tool executions included both the parent agent's input data and the AI tool call arguments. This was confusing for users.

Now inputOverride only contains the pure AI-provided tool call arguments, making the input log on the canvas cleaner.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-1948/tech-debt-only-show-input-from-ai-on-tool-calls


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
