### PR TITLE
fix(core): Prevent SQL syntax error when filtering users with empty ids array

### DIFF
--- a/packages/@n8n/db/src/repositories/user.repository.ts
+++ b/packages/@n8n/db/src/repositories/user.repository.ts
@@ -242,7 +242,7 @@ export class UserRepository extends Repository<User> {
 			}
 		}
 
-		if (filter?.ids !== undefined) {
+		if (filter?.ids !== undefined && filter.ids.length > 0) {
 			queryBuilder.andWhere('user.id IN (:...ids)', {
 				ids: filter.ids,
 			});

--- a/packages/cli/test/integration/user.repository.test.ts
+++ b/packages/cli/test/integration/user.repository.test.ts
@@ -1,5 +1,6 @@
+import type { UsersListFilterDto } from '@n8n/api-types';
 import { randomEmail, testDb } from '@n8n/backend-test-utils';
-import { ProjectRelationRepository, UserRepository } from '@n8n/db';
+import { ProjectRelationRepository, type User, UserRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 
 import { createAdmin, createChatUser, createMember, createOwner } from './shared/db/users';
@@ -79,6 +80,61 @@ describe('UserRepository', () => {
 			});
 
 			expect(projectRelation.project.id).toBe(project.id);
+		});
+	});
+
+	describe('buildUserQuery()', () => {
+		let user1: User;
+		let user2: User;
+		let user3: User;
+
+		beforeAll(async () => {
+			await testDb.truncate(['User']);
+			[user1, user2, user3] = await Promise.all([createMember(), createMember(), createMember()]);
+		});
+
+		describe('ids filter', () => {
+			test('should return only users matching the provided ids', async () => {
+				const options: UsersListFilterDto = {
+					filter: { ids: [user1.id, user2.id] },
+					take: 10,
+					skip: 0,
+				};
+
+				const query = userRepository.buildUserQuery(options);
+				const [users, count] = await query.getManyAndCount();
+
+				expect(count).toBe(2);
+				expect(users.map((u) => u.id).sort()).toStrictEqual([user1.id, user2.id].sort());
+			});
+
+			test('should return all users when ids is not provided', async () => {
+				const options: UsersListFilterDto = {
+					filter: {},
+					take: 10,
+					skip: 0,
+				};
+
+				const query = userRepository.buildUserQuery(options);
+				const [users, count] = await query.getManyAndCount();
+
+				expect(count).toBe(3);
+				expect(users.map((u) => u.id).sort()).toStrictEqual([user1.id, user2.id, user3.id].sort());
+			});
+
+			test('should return all users when ids is an empty array', async () => {
+				const options: UsersListFilterDto = {
+					filter: { ids: [] },
+					take: 10,
+					skip: 0,
+				};
+
+				const query = userRepository.buildUserQuery(options);
+				const [users, count] = await query.getManyAndCount();
+
+				expect(count).toBe(3);
+				expect(users.map((u) => u.id).sort()).toStrictEqual([user1.id, user2.id, user3.id].sort());
+			});
 		});
 	});
 });


### PR DESCRIPTION
## Summary

The `buildUserQuery` method would generate invalid SQL `IN ()` when `filter.ids` was an empty array. Added a length check to skip the IN clause when the array is empty.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2268/error-cannot-read-properties-of-null-reading-map-line-3
https://n8nio.sentry.io/organizations/n8nio/issues/6734869174/events/87e6fb5ea375488f8f728f8f2cacbbef/?project=4503924908883968


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
