### PR TITLE
fix(benchmark): Add dockerignore exceptions for benchmark image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,3 +25,16 @@
 !docker/images/n8n/docker-entrypoint.sh
 !docker/images/runners
 !docker/images/runners/n8n-task-runners.json
+
+# === benchmark image (packages/@n8n/benchmark/Dockerfile) ===
+!package.json
+!pnpm-lock.yaml
+!pnpm-workspace.yaml
+!patches
+!patches/**
+!scripts
+!scripts/**
+!packages/@n8n/benchmark
+!packages/@n8n/benchmark/**
+!packages/@n8n/typescript-config
+!packages/@n8n/typescript-config/**


### PR DESCRIPTION
## Summary

Fixed the benchmark Docker image CI build failure by adding missing files to `.dockerignore`. The build was failing because the whitelist-based `.dockerignore` was excluding necessary files like `package.json`, `pnpm-lock.yaml`, and `scripts/` that the benchmark Dockerfile requires.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Link to Linear ticket if applicable -->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included (build verification)
- [ ] Docs updated or follow-up ticket created
- [ ] PR Labeled with `release/backport` (if applicable)