### PR TITLE
refactor(editor): Move initialization logic to `WorkflowLayout` (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -2990,6 +2990,9 @@ export function useCanvasOperations() {
 		});
 
 		fitView();
+
+		// Clear the blank redirect flag after template import is complete
+		uiStore.isBlankRedirect = false;
 	}
 
 	async function openWorkflowTemplateFromJSON(workflow: WorkflowDataWithTemplateId) {
@@ -3030,6 +3033,9 @@ export function useCanvasOperations() {
 		canvasStore.stopLoading();
 
 		fitView();
+
+		// Clear the blank redirect flag after template import is complete
+		uiStore.isBlankRedirect = false;
 	}
 
 	return {

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -2990,9 +2990,6 @@ export function useCanvasOperations() {
 		});
 
 		fitView();
-
-		// Clear the blank redirect flag after template import is complete
-		uiStore.isBlankRedirect = false;
 	}
 
 	async function openWorkflowTemplateFromJSON(workflow: WorkflowDataWithTemplateId) {
@@ -3033,9 +3030,6 @@ export function useCanvasOperations() {
 		canvasStore.stopLoading();
 
 		fitView();
-
-		// Clear the blank redirect flag after template import is complete
-		uiStore.isBlankRedirect = false;
 	}
 
 	return {

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
@@ -287,9 +287,10 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 
 	async function initializeWorkflow(force = false) {
 		// Handle blank redirect (used by template import to prevent double initialization)
-		// The flag is set by openWorkflowTemplate before navigation and cleared after
-		// importTemplate completes, ensuring WorkflowLayout doesn't interfere.
+		// The flag is set by openWorkflowTemplate before navigation. We clear it here
+		// when detected, ensuring WorkflowLayout doesn't interfere with template import.
 		if (uiStore.isBlankRedirect) {
+			uiStore.isBlankRedirect = false;
 			isLoading.value = false;
 			return;
 		}

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
@@ -208,6 +208,12 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 			return;
 		}
 
+		// Handle blank redirect (used by template import to prevent double initialization)
+		if (uiStore.isBlankRedirect) {
+			isLoading.value = false;
+			return;
+		}
+
 		const isAlreadyInitialized =
 			!force && initializedWorkflowId.value && initializedWorkflowId.value === workflowId.value;
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
@@ -312,6 +312,9 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 			!force && initializedWorkflowId.value && initializedWorkflowId.value === workflowId.value;
 
 		if (isAlreadyInitialized) {
+			// Still need to handle debug mode when navigating to debug route
+			// even if the workflow is already initialized (e.g., from executions tab)
+			await handleDebugModeRoute();
 			isLoading.value = false;
 			return;
 		}

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
@@ -209,7 +209,10 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 		}
 
 		// Handle blank redirect (used by template import to prevent double initialization)
-		if (uiStore.isBlankRedirect) {
+		// Also check for templateId in query - this indicates a template import in progress
+		// where NodeView's openWorkflowTemplate handles the initialization
+		const isTemplateImportInProgress = uiStore.isBlankRedirect || route.query.templateId;
+		if (isTemplateImportInProgress) {
 			isLoading.value = false;
 			return;
 		}

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
@@ -57,7 +57,9 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 		openWorkflowTemplateFromJSON,
 	} = useCanvasOperations();
 	const { fetchAndSetParentFolder } = useParentFolder();
-	const { applyExecutionData } = useExecutionDebugging();
+	// Pass workflowState to useExecutionDebugging since we're in the same component
+	// that provides WorkflowStateKey (WorkflowLayout), so inject won't work
+	const { applyExecutionData } = useExecutionDebugging(workflowState);
 
 	const isLoading = ref(true);
 	const initializedWorkflowId = ref<string | undefined>();

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
@@ -1,0 +1,273 @@
+import { ref, computed } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { useI18n } from '@n8n/i18n';
+import { useToast } from '@/app/composables/useToast';
+import { useDocumentTitle } from '@/app/composables/useDocumentTitle';
+import { useExternalHooks } from '@/app/composables/useExternalHooks';
+import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
+import { useParentFolder } from '@/features/core/folders/composables/useParentFolder';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
+import { useUIStore } from '@/app/stores/ui.store';
+import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
+import { useCredentialsStore } from '@/features/credentials/credentials.store';
+import { useEnvironmentsStore } from '@/features/settings/environments.ee/environments.store';
+import { useExternalSecretsStore } from '@/features/integrations/externalSecrets.ee/externalSecrets.ee.store';
+import { useSettingsStore } from '@/app/stores/settings.store';
+import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
+import { useHistoryStore } from '@/app/stores/history.store';
+import { useBuilderStore } from '@/features/ai/assistant/builder.store';
+import { EnterpriseEditionFeature, VIEWS } from '@/app/constants';
+import type { WorkflowState } from '@/app/composables/useWorkflowState';
+import type { IWorkflowDb } from '@/Interface';
+
+export function useWorkflowInitialization(workflowState: WorkflowState) {
+	const route = useRoute();
+	const router = useRouter();
+	const i18n = useI18n();
+	const toast = useToast();
+	const documentTitle = useDocumentTitle();
+	const externalHooks = useExternalHooks();
+
+	const workflowsStore = useWorkflowsStore();
+	const workflowsListStore = useWorkflowsListStore();
+	const uiStore = useUIStore();
+	const nodeTypesStore = useNodeTypesStore();
+	const credentialsStore = useCredentialsStore();
+	const environmentsStore = useEnvironmentsStore();
+	const externalSecretsStore = useExternalSecretsStore();
+	const settingsStore = useSettingsStore();
+	const projectsStore = useProjectsStore();
+	const historyStore = useHistoryStore();
+	const builderStore = useBuilderStore();
+
+	const { resetWorkspace, initializeWorkspace, fitView } = useCanvasOperations();
+	const { fetchAndSetParentFolder } = useParentFolder();
+
+	const isLoading = ref(true);
+	const initializedWorkflowId = ref<string | undefined>();
+
+	const workflowId = computed(() => {
+		const name = route.params.name;
+		return (Array.isArray(name) ? name[0] : name) ?? '';
+	});
+
+	const isNewWorkflowRoute = computed(() => route.query.new === 'true');
+	const isDemoRoute = computed(() => route.name === VIEWS.DEMO);
+	const isTemplateRoute = computed(() => route.name === VIEWS.TEMPLATE_IMPORT);
+	const isOnboardingRoute = computed(() => route.name === VIEWS.WORKFLOW_ONBOARDING);
+	const isWorkflowRoute = computed(() => !!route?.meta?.nodeView || isDemoRoute.value);
+
+	async function loadCredentials() {
+		let options: { workflowId: string } | { projectId: string };
+
+		if (workflowId.value && !isNewWorkflowRoute.value) {
+			options = { workflowId: workflowId.value };
+		} else {
+			const queryParam =
+				typeof route.query?.projectId === 'string' ? route.query?.projectId : undefined;
+			const projectId = queryParam ?? projectsStore.personalProject?.id;
+			if (projectId === undefined) {
+				throw new Error(
+					'Could not find projectId in the query nor could I find the personal project in the project store',
+				);
+			}
+
+			options = { projectId };
+		}
+
+		await credentialsStore.fetchAllCredentialsForWorkflow(options);
+	}
+
+	async function initializeData() {
+		const loadPromises = (() => {
+			if (settingsStore.isPreviewMode && isDemoRoute.value) return [];
+
+			const promises: Array<Promise<unknown>> = [
+				workflowsListStore.fetchActiveWorkflows(),
+				credentialsStore.fetchCredentialTypes(true),
+				loadCredentials(),
+			];
+
+			if (settingsStore.isEnterpriseFeatureEnabled[EnterpriseEditionFeature.Variables]) {
+				promises.push(environmentsStore.fetchAllVariables());
+			}
+
+			if (settingsStore.isEnterpriseFeatureEnabled[EnterpriseEditionFeature.ExternalSecrets]) {
+				promises.push(externalSecretsStore.fetchGlobalSecrets());
+				const shouldFetchProjectSecrets =
+					route?.params?.projectId !== projectsStore.personalProject?.id;
+				if (shouldFetchProjectSecrets && typeof route?.params?.projectId === 'string') {
+					promises.push(externalSecretsStore.fetchProjectSecrets(route.params.projectId));
+				}
+			}
+
+			return promises;
+		})();
+
+		if (nodeTypesStore.allNodeTypes.length === 0) {
+			loadPromises.push(nodeTypesStore.getNodeTypes());
+		}
+
+		try {
+			await Promise.all(loadPromises);
+			void nodeTypesStore.fetchCommunityNodePreviews();
+		} catch (error) {
+			toast.showError(
+				error,
+				i18n.baseText('nodeView.showError.mounted1.title'),
+				i18n.baseText('nodeView.showError.mounted1.message') + ':',
+			);
+		}
+	}
+
+	async function openWorkflow(data: IWorkflowDb) {
+		resetWorkspace();
+
+		if (builderStore.streaming) {
+			documentTitle.setDocumentTitle(data.name, 'AI_BUILDING');
+		} else {
+			documentTitle.setDocumentTitle(data.name, 'IDLE');
+		}
+
+		await initializeWorkspace(data);
+
+		void externalHooks.run('workflow.open', {
+			workflowId: data.id,
+			workflowName: data.name,
+		});
+
+		fitView();
+	}
+
+	async function initializeWorkspaceForNewWorkflow() {
+		resetWorkspace();
+
+		const parentFolderId = route.query.parentFolderId as string | undefined;
+
+		await workflowState.getNewWorkflowDataAndMakeShareable(
+			undefined,
+			projectsStore.currentProjectId,
+			parentFolderId,
+		);
+
+		workflowState.setWorkflowId(workflowId.value);
+
+		await projectsStore.refreshCurrentProject();
+		await fetchAndSetParentFolder(parentFolderId);
+
+		uiStore.nodeViewInitialized = true;
+		initializedWorkflowId.value = workflowId.value;
+
+		fitView();
+	}
+
+	async function initializeWorkspaceForExistingWorkflow(id: string) {
+		try {
+			const workflowData = await workflowsListStore.fetchWorkflow(id);
+
+			await openWorkflow(workflowData);
+
+			if (workflowData.parentFolder) {
+				workflowsStore.setParentFolder(workflowData.parentFolder);
+			}
+
+			await projectsStore.setProjectNavActiveIdByWorkflowHomeProject(
+				workflowData.homeProject,
+				workflowData.sharedWithProjects,
+			);
+			void workflowsStore.fetchLastSuccessfulExecution();
+		} catch (error) {
+			if ((error as { httpStatusCode?: number }).httpStatusCode === 404) {
+				return await router.replace({
+					name: VIEWS.ENTITY_NOT_FOUND,
+					params: { entityType: 'workflow' },
+				});
+			}
+			if ((error as { httpStatusCode?: number }).httpStatusCode === 403) {
+				return await router.replace({
+					name: VIEWS.ENTITY_UNAUTHORIZED,
+					params: { entityType: 'workflow' },
+				});
+			}
+
+			toast.showError(error, i18n.baseText('openWorkflow.workflowNotFoundError'));
+			void router.push({
+				name: VIEWS.NEW_WORKFLOW,
+			});
+		} finally {
+			uiStore.nodeViewInitialized = true;
+			initializedWorkflowId.value = workflowId.value;
+		}
+	}
+
+	async function initializeWorkflow(force = false) {
+		// Skip if no workflowId (shouldn't happen in WorkflowLayout)
+		if (!workflowId.value) {
+			isLoading.value = false;
+			return;
+		}
+
+		const isAlreadyInitialized =
+			!force && initializedWorkflowId.value && initializedWorkflowId.value === workflowId.value;
+
+		if (isAlreadyInitialized) {
+			isLoading.value = false;
+			return;
+		}
+
+		isLoading.value = true;
+
+		try {
+			historyStore.reset();
+
+			if (isDemoRoute.value) {
+				await initializeWorkspaceForNewWorkflow();
+				return;
+			}
+
+			if (isNewWorkflowRoute.value) {
+				const exists = await workflowsListStore.checkWorkflowExists(workflowId.value);
+				if (!exists && route.meta?.nodeView === true) {
+					await initializeWorkspaceForNewWorkflow();
+					return;
+				} else {
+					await router.replace({
+						...route,
+						query: {
+							...route.query,
+							new: undefined,
+						},
+					});
+				}
+			}
+
+			await initializeWorkspaceForExistingWorkflow(workflowId.value);
+		} finally {
+			isLoading.value = false;
+		}
+	}
+
+	function cleanup() {
+		resetWorkspace();
+		uiStore.nodeViewInitialized = false;
+	}
+
+	return {
+		isLoading,
+		initializedWorkflowId,
+		workflowId,
+		isNewWorkflowRoute,
+		isDemoRoute,
+		isTemplateRoute,
+		isOnboardingRoute,
+		isWorkflowRoute,
+		loadCredentials,
+		initializeData,
+		openWorkflow,
+		initializeWorkspaceForNewWorkflow,
+		initializeWorkspaceForExistingWorkflow,
+		initializeWorkflow,
+		cleanup,
+	};
+}

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
@@ -209,10 +209,9 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 		}
 
 		// Handle blank redirect (used by template import to prevent double initialization)
-		// Also check for templateId in query - this indicates a template import in progress
-		// where NodeView's openWorkflowTemplate handles the initialization
-		const isTemplateImportInProgress = uiStore.isBlankRedirect || route.query.templateId;
-		if (isTemplateImportInProgress) {
+		// The flag is set by openWorkflowTemplate before navigation and cleared after
+		// importTemplate completes, ensuring WorkflowLayout doesn't interfere.
+		if (uiStore.isBlankRedirect) {
 			isLoading.value = false;
 			return;
 		}

--- a/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.test.ts
+++ b/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.test.ts
@@ -1,7 +1,25 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createComponentRenderer } from '@/__tests__/render';
 import WorkflowLayout from './WorkflowLayout.vue';
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
+import { createTestingPinia } from '@pinia/testing';
+
+vi.mock('vue-router', async (importOriginal) => {
+	const actual = (await importOriginal()) as object;
+	return {
+		...actual,
+		useRoute: () => ({
+			params: { name: 'test-workflow-id' },
+			query: {},
+			meta: {},
+			name: 'workflow',
+		}),
+		useRouter: () => ({
+			replace: vi.fn(),
+			push: vi.fn(),
+		}),
+	};
+});
 
 vi.mock('@/app/composables/useLayoutProps', () => ({
 	useLayoutProps: vi.fn(() => ({
@@ -15,35 +33,65 @@ vi.mock('@/features/ai/assistant/assistant.store', () => ({
 	})),
 }));
 
+vi.mock('@/app/composables/useWorkflowState', () => ({
+	useWorkflowState: vi.fn(() => ({
+		getNewWorkflowDataAndMakeShareable: vi.fn(),
+		setWorkflowId: vi.fn(),
+		resetState: vi.fn(),
+	})),
+}));
+
+vi.mock('@/app/composables/useWorkflowInitialization', () => ({
+	useWorkflowInitialization: vi.fn(() => ({
+		isLoading: ref(false),
+		workflowId: computed(() => 'test-workflow-id'),
+		isTemplateRoute: computed(() => false),
+		isOnboardingRoute: computed(() => false),
+		initializeData: vi.fn().mockResolvedValue(undefined),
+		initializeWorkflow: vi.fn().mockResolvedValue(undefined),
+		cleanup: vi.fn(),
+	})),
+}));
+
+const defaultStubs = {
+	AppHeader: {
+		template: '<div data-test-id="app-header">App Header</div>',
+	},
+	AppSidebar: {
+		template: '<div data-test-id="app-sidebar">App Sidebar</div>',
+	},
+	LogsPanel: {
+		template: '<div data-test-id="logs-panel">Logs Panel</div>',
+	},
+	AskAssistantFloatingButton: {
+		template: '<div data-test-id="ask-assistant-button">Ask Assistant</div>',
+	},
+	AppChatPanel: {
+		template: '<div data-test-id="app-chat-panel">Chat Panel</div>',
+	},
+	LoadingView: {
+		template: '<div data-test-id="loading-view">Loading...</div>',
+	},
+	RouterView: {
+		template: '<div>Workflow Content</div>',
+	},
+	Suspense: {
+		template: '<div><slot /></div>',
+	},
+};
+
 const renderComponent = createComponentRenderer(WorkflowLayout, {
 	global: {
-		stubs: {
-			AppHeader: {
-				template: '<div data-test-id="app-header">App Header</div>',
-			},
-			AppSidebar: {
-				template: '<div data-test-id="app-sidebar">App Sidebar</div>',
-			},
-			LogsPanel: {
-				template: '<div data-test-id="logs-panel">Logs Panel</div>',
-			},
-			AskAssistantFloatingButton: {
-				template: '<div data-test-id="ask-assistant-button">Ask Assistant</div>',
-			},
-			AppChatPanel: {
-				template: '<div data-test-id="app-chat-panel">Chat Panel</div>',
-			},
-			RouterView: {
-				template: '<div><slot /></div>',
-			},
-			Suspense: {
-				template: '<div><slot /></div>',
-			},
-		},
+		stubs: defaultStubs,
 	},
 });
 
 describe('WorkflowLayout', () => {
+	beforeEach(() => {
+		createTestingPinia();
+		vi.clearAllMocks();
+	});
+
 	it('should render the layout without throwing', () => {
 		expect(() => renderComponent()).not.toThrow();
 	});
@@ -60,34 +108,8 @@ describe('WorkflowLayout', () => {
 		expect(gridElement).toBeInTheDocument();
 	});
 
-	it('should render RouterView content', () => {
-		const { getByText } = renderComponent({
-			global: {
-				stubs: {
-					AppHeader: {
-						template: '<div data-test-id="app-header">App Header</div>',
-					},
-					AppSidebar: {
-						template: '<div data-test-id="app-sidebar">App Sidebar</div>',
-					},
-					LogsPanel: {
-						template: '<div data-test-id="logs-panel">Logs Panel</div>',
-					},
-					AskAssistantFloatingButton: {
-						template: '<div data-test-id="ask-assistant-button">Ask Assistant</div>',
-					},
-					AppChatPanel: {
-						template: '<div data-test-id="app-chat-panel">Chat Panel</div>',
-					},
-					RouterView: {
-						template: '<div>Workflow Content</div>',
-					},
-					Suspense: {
-						template: '<div><slot /></div>',
-					},
-				},
-			},
-		});
+	it('should render RouterView content when not loading', () => {
+		const { getByText } = renderComponent();
 		expect(getByText('Workflow Content')).toBeInTheDocument();
 	});
 
@@ -121,36 +143,10 @@ describe('WorkflowLayout', () => {
 	});
 
 	it('should render all header, sidebar and content together', () => {
-		const { getByText, getByTestId } = renderComponent({
-			global: {
-				stubs: {
-					AppHeader: {
-						template: '<div data-test-id="app-header">App Header</div>',
-					},
-					AppSidebar: {
-						template: '<div data-test-id="app-sidebar">App Sidebar</div>',
-					},
-					LogsPanel: {
-						template: '<div data-test-id="logs-panel">Logs Panel</div>',
-					},
-					AskAssistantFloatingButton: {
-						template: '<div data-test-id="ask-assistant-button">Ask Assistant</div>',
-					},
-					AppChatPanel: {
-						template: '<div data-test-id="app-chat-panel">Chat Panel</div>',
-					},
-					RouterView: {
-						template: '<div>Workflow Canvas</div>',
-					},
-					Suspense: {
-						template: '<div><slot /></div>',
-					},
-				},
-			},
-		});
+		const { getByText, getByTestId } = renderComponent();
 		expect(getByTestId('app-header')).toBeInTheDocument();
 		expect(getByTestId('app-sidebar')).toBeInTheDocument();
-		expect(getByText('Workflow Canvas')).toBeInTheDocument();
+		expect(getByText('Workflow Content')).toBeInTheDocument();
 	});
 
 	it('should wrap AppHeader in Suspense', () => {
@@ -168,39 +164,13 @@ describe('WorkflowLayout', () => {
 	});
 
 	it('should render complete workflow layout structure', () => {
-		const { container, getByText, getByTestId } = renderComponent({
-			global: {
-				stubs: {
-					AppHeader: {
-						template: '<div data-test-id="app-header">App Header</div>',
-					},
-					AppSidebar: {
-						template: '<div data-test-id="app-sidebar">App Sidebar</div>',
-					},
-					LogsPanel: {
-						template: '<div data-test-id="logs-panel">Logs Panel</div>',
-					},
-					AskAssistantFloatingButton: {
-						template: '<div data-test-id="ask-assistant-button">Ask Assistant</div>',
-					},
-					AppChatPanel: {
-						template: '<div data-test-id="app-chat-panel">Chat Panel</div>',
-					},
-					RouterView: {
-						template: '<div>Workflow Editor</div>',
-					},
-					Suspense: {
-						template: '<div><slot /></div>',
-					},
-				},
-			},
-		});
+		const { container, getByText, getByTestId } = renderComponent();
 		expect(container.querySelector('.app-grid')).toBeInTheDocument();
 		expect(container.querySelector('header#header')).toBeInTheDocument();
 		expect(container.querySelector('aside#sidebar')).toBeInTheDocument();
 		expect(container.querySelector('main#content')).toBeInTheDocument();
 		expect(getByTestId('app-header')).toBeInTheDocument();
 		expect(getByTestId('app-sidebar')).toBeInTheDocument();
-		expect(getByText('Workflow Editor')).toBeInTheDocument();
+		expect(getByText('Workflow Content')).toBeInTheDocument();
 	});
 });

--- a/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
@@ -60,7 +60,7 @@ onBeforeUnmount(() => cleanup());
 		<LoadingView v-if="isLoading" />
 		<RouterView v-else v-slot="{ Component }">
 			<KeepAlive include="NodeView" :max="1">
-				<Component :is="Component" />
+				<component :is="Component" />
 			</KeepAlive>
 		</RouterView>
 		<template v-if="layoutProps.logs" #footer>

--- a/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
@@ -1,25 +1,52 @@
 <script lang="ts" setup>
-import { provide, computed } from 'vue';
-import { useRoute } from 'vue-router';
+import { provide, watch, onMounted, onBeforeUnmount } from 'vue';
 import BaseLayout from './BaseLayout.vue';
 import { useLayoutProps } from '@/app/composables/useLayoutProps';
+import { useWorkflowState } from '@/app/composables/useWorkflowState';
+import { useWorkflowInitialization } from '@/app/composables/useWorkflowInitialization';
 import AskAssistantFloatingButton from '@/features/ai/assistant/components/Chat/AskAssistantFloatingButton.vue';
 import { useAssistantStore } from '@/features/ai/assistant/assistant.store';
 import AppHeader from '@/app/components/app/AppHeader.vue';
 import AppSidebar from '@/app/components/app/AppSidebar.vue';
 import LogsPanel from '@/features/execution/logs/components/LogsPanel.vue';
-import { WorkflowIdKey } from '@/app/constants/injectionKeys';
+import LoadingView from '@/app/views/LoadingView.vue';
+import { WorkflowIdKey, WorkflowStateKey } from '@/app/constants/injectionKeys';
 
-const route = useRoute();
 const { layoutProps } = useLayoutProps();
 const assistantStore = useAssistantStore();
 
-const workflowId = computed(() => {
-	const name = route.params.name;
-	return (Array.isArray(name) ? name[0] : name) as string;
-});
+const workflowState = useWorkflowState();
+provide(WorkflowStateKey, workflowState);
+
+const {
+	isLoading,
+	workflowId,
+	isTemplateRoute,
+	isOnboardingRoute,
+	initializeData,
+	initializeWorkflow,
+	cleanup,
+} = useWorkflowInitialization(workflowState);
 
 provide(WorkflowIdKey, workflowId);
+
+onMounted(async () => {
+	await initializeData();
+	await initializeWorkflow();
+});
+
+watch(
+	workflowId,
+	async (newId, oldId) => {
+		if (isTemplateRoute.value || isOnboardingRoute.value) return;
+		if (newId !== oldId && newId) {
+			await initializeWorkflow(true);
+		}
+	},
+	{ flush: 'post' },
+);
+
+onBeforeUnmount(() => cleanup());
 </script>
 
 <template>
@@ -30,11 +57,8 @@ provide(WorkflowIdKey, workflowId);
 		<template #sidebar>
 			<AppSidebar />
 		</template>
-		<RouterView v-slot="{ Component }">
-			<KeepAlive include="NodeView" :max="1">
-				<Component :is="Component" />
-			</KeepAlive>
-		</RouterView>
+		<LoadingView v-if="isLoading" />
+		<RouterView v-else />
 		<template v-if="layoutProps.logs" #footer>
 			<LogsPanel />
 		</template>

--- a/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
@@ -46,11 +46,12 @@ watch(
 );
 
 // Watch for entering debug mode on the same workflow (e.g., from executions tab)
-// The workflowId watch won't trigger because the ID doesn't change
+// The workflowId watch won't trigger because the ID doesn't change.
+// Skip if isLoading is true - initializeWorkflow already handles debug mode.
 watch(
 	isDebugRoute,
 	async (isDebug, wasDebug) => {
-		if (isDebug && !wasDebug) {
+		if (isDebug && !wasDebug && !isLoading.value) {
 			await handleDebugModeRoute();
 		}
 	},

--- a/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
@@ -18,15 +18,8 @@ const assistantStore = useAssistantStore();
 const workflowState = useWorkflowState();
 provide(WorkflowStateKey, workflowState);
 
-const {
-	isLoading,
-	workflowId,
-	isTemplateRoute,
-	isOnboardingRoute,
-	initializeData,
-	initializeWorkflow,
-	cleanup,
-} = useWorkflowInitialization(workflowState);
+const { isLoading, workflowId, initializeData, initializeWorkflow, cleanup } =
+	useWorkflowInitialization(workflowState);
 
 provide(WorkflowIdKey, workflowId);
 
@@ -38,7 +31,6 @@ onMounted(async () => {
 watch(
 	workflowId,
 	async (newId, oldId) => {
-		if (isTemplateRoute.value || isOnboardingRoute.value) return;
 		if (newId !== oldId && newId) {
 			await initializeWorkflow(true);
 		}

--- a/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
@@ -58,7 +58,11 @@ onBeforeUnmount(() => cleanup());
 			<AppSidebar />
 		</template>
 		<LoadingView v-if="isLoading" />
-		<RouterView v-else />
+		<RouterView v-else v-slot="{ Component }">
+			<KeepAlive include="NodeView" :max="1">
+				<Component :is="Component" />
+			</KeepAlive>
+		</RouterView>
 		<template v-if="layoutProps.logs" #footer>
 			<LogsPanel />
 		</template>

--- a/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
@@ -18,8 +18,15 @@ const assistantStore = useAssistantStore();
 const workflowState = useWorkflowState();
 provide(WorkflowStateKey, workflowState);
 
-const { isLoading, workflowId, initializeData, initializeWorkflow, cleanup } =
-	useWorkflowInitialization(workflowState);
+const {
+	isLoading,
+	workflowId,
+	isDebugRoute,
+	initializeData,
+	initializeWorkflow,
+	handleDebugModeRoute,
+	cleanup,
+} = useWorkflowInitialization(workflowState);
 
 provide(WorkflowIdKey, workflowId);
 
@@ -33,6 +40,18 @@ watch(
 	async (newId, oldId) => {
 		if (newId !== oldId && newId) {
 			await initializeWorkflow(true);
+		}
+	},
+	{ flush: 'post' },
+);
+
+// Watch for entering debug mode on the same workflow (e.g., from executions tab)
+// The workflowId watch won't trigger because the ID doesn't change
+watch(
+	isDebugRoute,
+	async (isDebug, wasDebug) => {
+		if (isDebug && !wasDebug) {
+			await handleDebugModeRoute();
 		}
 	},
 	{ flush: 'post' },

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -344,6 +344,8 @@ function initializeRoute() {
 	}
 
 	// Handle debug mode event binding (data loading is handled by WorkflowLayout)
+	// Always remove first to prevent duplicate listeners, then add only if on debug route
+	canvasEventBus.off('saved:workflow', onSaveFromWithinExecutionDebug);
 	if (route.name === VIEWS.EXECUTION_DEBUG) {
 		canvasEventBus.on('saved:workflow', onSaveFromWithinExecutionDebug);
 	}
@@ -1869,6 +1871,7 @@ onBeforeUnmount(() => {
 	removeExecutionOpenedEventBindings();
 	removeCommandBarEventBindings();
 	unregisterCustomActions();
+	canvasEventBus.off('saved:workflow', onSaveFromWithinExecutionDebug);
 	if (!isDemoRoute.value) {
 		pushConnectionStore.pushDisconnect();
 	}

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -348,9 +348,10 @@ async function initializeRoute() {
 		}
 	}
 
-	// Handle blank redirect
+	// Handle blank redirect - return early but don't clear the flag here.
+	// The flag is cleared by openWorkflowTemplate/openWorkflowTemplateFromJSON
+	// after the template import completes.
 	if (uiStore.isBlankRedirect) {
-		uiStore.isBlankRedirect = false;
 		return;
 	}
 

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -13,7 +13,6 @@ import {
 	h,
 	onBeforeUnmount,
 	useTemplateRef,
-	provide,
 } from 'vue';
 import { onBeforeRouteLeave, useRoute, useRouter } from 'vue-router';
 import WorkflowCanvas from '@/features/workflows/canvas/components/WorkflowCanvas.vue';
@@ -56,7 +55,6 @@ import {
 import {
 	CHAT_TRIGGER_NODE_TYPE,
 	DRAG_EVENT_DATA_KEY,
-	EnterpriseEditionFeature,
 	FROM_AI_PARAMETERS_MODAL_KEY,
 	MAIN_HEADER_TABS,
 	MANUAL_CHAT_TRIGGER_NODE_TYPE,
@@ -67,7 +65,6 @@ import {
 	VIEWS,
 	WORKFLOW_SETTINGS_MODAL_KEY,
 	ABOUT_MODAL_KEY,
-	WorkflowStateKey,
 	PRODUCTION_ONLY_TRIGGER_NODE_TYPES,
 	HUMAN_IN_THE_LOOP_CATEGORY,
 } from '@/app/constants';
@@ -90,10 +87,8 @@ import type {
 	INodeParameters,
 } from 'n8n-workflow';
 import { useToast } from '@/app/composables/useToast';
-import { useSettingsStore } from '@/app/stores/settings.store';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
 import { useEnvironmentsStore } from '@/features/settings/environments.ee/environments.store';
-import { useExternalSecretsStore } from '@/features/integrations/externalSecrets.ee/externalSecrets.ee.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { historyBus } from '@/app/models/history';
 import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
@@ -103,7 +98,6 @@ import { useMessage } from '@/app/composables/useMessage';
 import { useDocumentTitle } from '@/app/composables/useDocumentTitle';
 import { useNpsSurveyStore } from '@/app/stores/npsSurvey.store';
 import { useTelemetry } from '@/app/composables/useTelemetry';
-import { useHistoryStore } from '@/app/stores/history.store';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { useExecutionDebugging } from '@/features/execution/executions/composables/useExecutionDebugging';
@@ -141,16 +135,13 @@ import { useLogsStore } from '@/app/stores/logs.store';
 import { canvasEventBus } from '@/features/workflows/canvas/canvas.eventBus';
 import CanvasChatButton from '@/features/workflows/canvas/components/elements/buttons/CanvasChatButton.vue';
 import { useFocusPanelStore } from '@/app/stores/focusPanel.store';
-import { useAITemplatesStarterCollectionStore } from '@/experiments/aiTemplatesStarterCollection/stores/aiTemplatesStarterCollection.store';
-import { useReadyToRunWorkflowsStore } from '@/experiments/readyToRunWorkflows/stores/readyToRunWorkflows.store';
 import { useEmptyStateBuilderPromptStore } from '@/experiments/emptyStateBuilderPrompt/stores/emptyStateBuilderPrompt.store';
 import { useChatPanelStore } from '@/features/ai/assistant/chatPanel.store';
 import { useKeybindings } from '@/app/composables/useKeybindings';
 import { type ContextMenuAction } from '@/features/shared/contextMenu/composables/useContextMenuItems';
 import { useExperimentalNdvStore } from '@/features/workflows/canvas/experimental/experimentalNdv.store';
-import { useWorkflowState } from '@/app/composables/useWorkflowState';
+import { injectWorkflowState } from '@/app/composables/useWorkflowState';
 import { useActivityDetection } from '@/app/composables/useActivityDetection';
-import { useParentFolder } from '@/features/core/folders/composables/useParentFolder';
 import { useCollaborationStore } from '@/features/collaboration/collaboration/collaboration.store';
 import { injectStrict } from '@/app/utils/injectStrict';
 import { WorkflowIdKey } from '@/app/constants/injectionKeys';
@@ -201,15 +192,12 @@ const workflowsStore = useWorkflowsStore();
 const workflowsListStore = useWorkflowsListStore();
 const sourceControlStore = useSourceControlStore();
 const nodeCreatorStore = useNodeCreatorStore();
-const settingsStore = useSettingsStore();
 const credentialsStore = useCredentialsStore();
 const environmentsStore = useEnvironmentsStore();
-const externalSecretsStore = useExternalSecretsStore();
 const rootStore = useRootStore();
 const executionsStore = useExecutionsStore();
 const canvasStore = useCanvasStore();
 const npsSurveyStore = useNpsSurveyStore();
-const historyStore = useHistoryStore();
 const projectsStore = useProjectsStore();
 const usersStore = useUsersStore();
 const tagsStore = useTagsStore();
@@ -219,18 +207,15 @@ const focusPanelStore = useFocusPanelStore();
 const builderStore = useBuilderStore();
 const agentRequestStore = useAgentRequestStore();
 const logsStore = useLogsStore();
-const aiTemplatesStarterCollectionStore = useAITemplatesStarterCollectionStore();
-const readyToRunWorkflowsStore = useReadyToRunWorkflowsStore();
 const experimentalNdvStore = useExperimentalNdvStore();
 const collaborationStore = useCollaborationStore();
 const emptyStateBuilderPromptStore = useEmptyStateBuilderPromptStore();
 const chatPanelStore = useChatPanelStore();
 
-const workflowState = useWorkflowState();
+const workflowState = injectWorkflowState();
 
 // Initialize activity detection for collaboration
 useActivityDetection();
-provide(WorkflowStateKey, workflowState);
 
 const { addBeforeUnloadEventBindings, removeBeforeUnloadEventBindings } = useBeforeUnload({
 	route,
@@ -284,7 +269,6 @@ const {
 } = useCanvasOperations();
 const { extractWorkflow } = useWorkflowExtraction();
 const { applyExecutionData } = useExecutionDebugging();
-const { fetchAndSetParentFolder } = useParentFolder();
 
 useKeybindings({
 	ctrl_alt_o: () => uiStore.openModal(ABOUT_MODAL_KEY),
@@ -301,7 +285,6 @@ const canOpenNDV = ref(true);
 const hideNodeIssues = ref(false);
 const fallbackNodes = ref<INodeUi[]>([]);
 
-const initializedWorkflowId = ref<string | undefined>();
 const workflowId = injectStrict(WorkflowIdKey);
 const routeNodeId = computed(() => {
 	const nodeId = route.params.nodeId;
@@ -318,7 +301,6 @@ const hideCanvasControls = computed(() => {
 	return route.query.hideControls === 'true';
 });
 
-const isWorkflowRoute = computed(() => !!route?.meta?.nodeView || isDemoRoute.value);
 const isDemoRoute = computed(() => route.name === VIEWS.DEMO);
 const isReadOnlyRoute = computed(() => !!route?.meta?.readOnlyCanvas);
 const isReadOnlyEnvironment = computed(() => {
@@ -349,51 +331,7 @@ const isLogsPanelOpen = computed(() => logsStore.isOpen);
  * Initialization
  */
 
-async function initializeData() {
-	const loadPromises = (() => {
-		if (settingsStore.isPreviewMode && isDemoRoute.value) return [];
-
-		const promises: Array<Promise<unknown>> = [
-			workflowsListStore.fetchActiveWorkflows(),
-			credentialsStore.fetchCredentialTypes(true),
-			loadCredentials(),
-		];
-
-		if (settingsStore.isEnterpriseFeatureEnabled[EnterpriseEditionFeature.Variables]) {
-			promises.push(environmentsStore.fetchAllVariables());
-		}
-
-		if (settingsStore.isEnterpriseFeatureEnabled[EnterpriseEditionFeature.ExternalSecrets]) {
-			promises.push(externalSecretsStore.fetchGlobalSecrets());
-			const shouldFetchProjectSecrets =
-				route?.params?.projectId !== projectsStore.personalProject?.id;
-			if (shouldFetchProjectSecrets && typeof route?.params?.projectId === 'string') {
-				promises.push(externalSecretsStore.fetchProjectSecrets(route.params.projectId));
-			}
-		}
-
-		return promises;
-	})();
-
-	if (nodeTypesStore.allNodeTypes.length === 0) {
-		loadPromises.push(nodeTypesStore.getNodeTypes());
-	}
-
-	try {
-		await Promise.all(loadPromises);
-		//We don't need to await this as community node previews are not critical and needed only in nodes search panel
-		void nodeTypesStore.fetchCommunityNodePreviews();
-	} catch (error) {
-		toast.showError(
-			error,
-			i18n.baseText('nodeView.showError.mounted1.title'),
-			i18n.baseText('nodeView.showError.mounted1.message') + ':',
-		);
-		return;
-	}
-}
-
-async function initializeRoute(force = false) {
+async function initializeRoute() {
 	// Open node panel if the route has a corresponding action
 	if (route.query.action === 'addEvaluationTrigger') {
 		nodeCreatorStore.openNodeCreatorForTriggerNodes(
@@ -410,16 +348,14 @@ async function initializeRoute(force = false) {
 		}
 	}
 
-	const isAlreadyInitialized =
-		!force && initializedWorkflowId.value && initializedWorkflowId.value === workflowId.value;
-
-	// This function is called on route change as well, so we need to do the following:
-	// - if the redirect is blank, then do nothing
-	// - if the route is the template import view, then open the template
-	// - if the user is leaving the current view without saving the changes, then show a confirmation modal
+	// Handle blank redirect
 	if (uiStore.isBlankRedirect) {
 		uiStore.isBlankRedirect = false;
-	} else if (route.name === VIEWS.TEMPLATE_IMPORT) {
+		return;
+	}
+
+	// Handle template import route
+	if (route.name === VIEWS.TEMPLATE_IMPORT) {
 		const loadWorkflowFromJSON = route.query.fromJson === 'true';
 		const templateId = route.params.id;
 		if (!templateId) {
@@ -441,120 +377,18 @@ async function initializeRoute(force = false) {
 		} else {
 			await openWorkflowTemplate(templateId.toString());
 		}
-	} else if (isWorkflowRoute.value) {
-		if (!isAlreadyInitialized) {
-			historyStore.reset();
-
-			if (isDemoRoute.value) {
-				return await initializeWorkspaceForNewWorkflow();
-			}
-
-			// Check if we should initialize for a new workflow
-			if (isNewWorkflowRoute.value) {
-				const exists = await workflowsListStore.checkWorkflowExists(workflowId.value);
-				if (!exists && route.meta?.nodeView === true) {
-					return await initializeWorkspaceForNewWorkflow();
-				} else {
-					await router.replace({
-						...route,
-						query: {
-							...route.query,
-							new: undefined,
-						},
-					});
-				}
-			}
-
-			// Load existing workflow
-			await initializeWorkspaceForExistingWorkflow(workflowId.value);
-
-			void nextTick(() => {
-				updateNodesIssues();
-			});
-		}
-
-		if (route.name === VIEWS.EXECUTION_DEBUG) {
-			await initializeDebugMode();
-		}
+		return;
 	}
-}
 
-async function initializeWorkspaceForNewWorkflow() {
-	resetWorkspace();
-
-	const parentFolderId = route.query.parentFolderId as string | undefined;
-
-	await workflowState.getNewWorkflowDataAndMakeShareable(
-		undefined,
-		projectsStore.currentProjectId,
-		parentFolderId,
-	);
-
-	// Set the workflow ID from the route params (auto-generated by router)
-	workflowState.setWorkflowId(workflowId.value);
-
-	await projectsStore.refreshCurrentProject();
-	await fetchAndSetParentFolder(parentFolderId);
-
-	uiStore.nodeViewInitialized = true;
-	initializedWorkflowId.value = workflowId.value;
-
-	fitView();
-}
-
-async function initializeWorkspaceForExistingWorkflow(id: string) {
-	try {
-		const workflowData = await workflowsListStore.fetchWorkflow(id);
-
-		await openWorkflow(workflowData);
-
-		if (workflowData.parentFolder) {
-			workflowsStore.setParentFolder(workflowData.parentFolder);
-		}
-
-		if (workflowData.meta?.onboardingId) {
-			trackOpenWorkflowFromOnboardingTemplate();
-		}
-
-		if (workflowData.meta?.templateId?.startsWith('035_template_onboarding')) {
-			aiTemplatesStarterCollectionStore.trackUserOpenedWorkflow(
-				workflowData.meta.templateId.split('-').pop() ?? '',
-			);
-		}
-
-		if (workflowData.meta?.templateId?.startsWith('37_onboarding_experiments_batch_aug11')) {
-			readyToRunWorkflowsStore.trackOpenWorkflow(
-				workflowData.meta.templateId.split('-').pop() ?? '',
-			);
-		}
-
-		await projectsStore.setProjectNavActiveIdByWorkflowHomeProject(
-			workflowData.homeProject,
-			workflowData.sharedWithProjects,
-		);
-		void workflowsStore.fetchLastSuccessfulExecution();
-	} catch (error) {
-		if (error.httpStatusCode === 404) {
-			return await router.replace({
-				name: VIEWS.ENTITY_NOT_FOUND,
-				params: { entityType: 'workflow' },
-			});
-		}
-		if (error.httpStatusCode === 403) {
-			return await router.replace({
-				name: VIEWS.ENTITY_UNAUTHORIZED,
-				params: { entityType: 'workflow' },
-			});
-		}
-
-		toast.showError(error, i18n.baseText('openWorkflow.workflowNotFoundError'));
-		void router.push({
-			name: VIEWS.NEW_WORKFLOW,
-		});
-	} finally {
-		uiStore.nodeViewInitialized = true;
-		initializedWorkflowId.value = workflowId.value;
+	// Handle debug mode
+	if (route.name === VIEWS.EXECUTION_DEBUG) {
+		await initializeDebugMode();
 	}
+
+	// Update node issues after workflow is loaded
+	void nextTick(() => {
+		updateNodesIssues();
+	});
 }
 
 function updateNodesIssues() {
@@ -593,15 +427,6 @@ async function openWorkflow(data: IWorkflowDb) {
 	// }
 
 	fitView();
-}
-
-function trackOpenWorkflowFromOnboardingTemplate() {
-	telemetry.track(
-		`User opened workflow from onboarding template with ID ${editableWorkflow.value.meta?.onboardingId}`,
-		{
-			workflow_id: workflowId.value,
-		},
-	);
 }
 
 /**
@@ -996,8 +821,6 @@ async function importWorkflowExact({ workflow: workflowData }: { workflow: Workf
 
 	resetWorkspace();
 
-	await initializeData();
-
 	await initializeWorkspace({
 		...workflowData,
 		nodes: getNodesWithNormalizedPosition<INodeUi>(workflowData.nodes),
@@ -1335,7 +1158,6 @@ async function onOpenExecution(executionId: string, nodeId?: string) {
 	canvasStore.startLoading();
 
 	resetWorkspace();
-	await initializeData();
 
 	const data = await openExecution(executionId, nodeId);
 	if (!data) {
@@ -1647,7 +1469,7 @@ async function onPostMessageReceived(messageEvent: MessageEvent) {
  */
 
 function checkIfEditingIsAllowed(): boolean {
-	if (!initializedWorkflowId.value) {
+	if (!uiStore.nodeViewInitialized) {
 		return true;
 	}
 
@@ -1865,18 +1687,10 @@ function updateNodeRoute(nodeId: string) {
 	}
 }
 
-watch(
-	[() => route.name, () => route.params.name],
-	async ([newRouteName, newWorkflowId], [oldRouteName, oldWorkflowId]) => {
-		// When navigating from an existing workflow to a new workflow or the other way around we should load the new workflow
-		const force =
-			(newRouteName === VIEWS.NEW_WORKFLOW && oldRouteName === VIEWS.WORKFLOW) ||
-			(newRouteName === VIEWS.WORKFLOW && oldRouteName === VIEWS.NEW_WORKFLOW) ||
-			newWorkflowId !== oldWorkflowId;
-
-		await initializeRoute(force);
-	},
-);
+watch([() => route.name, () => route.params.name], async () => {
+	// Handle route-specific actions (template import, debug mode, etc.)
+	await initializeRoute();
+});
 
 watch(
 	() => {
@@ -2031,11 +1845,9 @@ onBeforeMount(() => {
 	addPostMessageEventBindings();
 });
 
-onMounted(() => {
+onMounted(async () => {
 	canvasStore.startLoading();
-
 	documentTitle.reset();
-	resetWorkspace();
 
 	// Register callback for collaboration store to refresh canvas when workflow updates arrive
 	collaborationStore.setRefreshCanvasCallback(async (workflow) => {
@@ -2043,41 +1855,38 @@ onMounted(() => {
 		await initializeWorkspace(workflow);
 	});
 
-	void initializeData().then(() => {
-		void initializeRoute()
-			.then(() => {
-				// Once view is initialized, pick up all toast notifications
-				// waiting in the store and display them
-				toast.showNotificationForViews([VIEWS.WORKFLOW, VIEWS.NEW_WORKFLOW]);
+	try {
+		await initializeRoute();
 
-				if (route.query.settings) {
-					uiStore.openModal(WORKFLOW_SETTINGS_MODAL_KEY);
-					void router.replace({ query: { settings: undefined } });
-				}
-			})
-			.finally(() => {
-				isLoading.value = false;
-				canvasStore.stopLoading();
+		// Once view is initialized, pick up all toast notifications
+		// waiting in the store and display them
+		toast.showNotificationForViews([VIEWS.WORKFLOW, VIEWS.NEW_WORKFLOW]);
 
-				void externalHooks.run('nodeView.mount').catch(() => {});
+		if (route.query.settings) {
+			uiStore.openModal(WORKFLOW_SETTINGS_MODAL_KEY);
+			void router.replace({ query: { settings: undefined } });
+		}
+	} finally {
+		isLoading.value = false;
+		canvasStore.stopLoading();
 
-				// A delay here makes opening the NDV a bit less jarring
-				setTimeout(() => {
-					if (routeNodeId.value) {
-						updateNodeRoute(routeNodeId.value);
-					}
-				}, 500);
+		void externalHooks.run('nodeView.mount').catch(() => {});
 
-				emitPostMessageReady();
+		// A delay here makes opening the NDV a bit less jarring
+		setTimeout(() => {
+			if (routeNodeId.value) {
+				updateNodeRoute(routeNodeId.value);
+			}
+		}, 500);
 
-				// Check for pending builder prompt from empty state experiment
-				void handlePendingBuilderPrompt();
-			});
+		emitPostMessageReady();
 
-		void usersStore.showPersonalizationSurvey();
+		// Check for pending builder prompt from empty state experiment
+		void handlePendingBuilderPrompt();
+	}
 
-		checkIfRouteIsAllowed();
-	});
+	void usersStore.showPersonalizationSurvey();
+	checkIfRouteIsAllowed();
 
 	addSourceControlEventBindings();
 	addWorkflowSavedEventBindings();

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsRootView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsRootView.vue
@@ -1,17 +1,12 @@
 <script setup lang="ts">
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
-import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useUsageStore } from '@/features/settings/usage/usage.store';
 import { useAsyncState } from '@vueuse/core';
 import { EVALUATIONS_DOCS_URL } from '@/app/constants';
-import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useToast } from '@/app/composables/useToast';
 import { useI18n } from '@n8n/i18n';
 import { useEvaluationStore } from '../evaluation.store';
-import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
-import { useRoute } from 'vue-router';
 
 import { computed, watch } from 'vue';
 import EvaluationsPaywall from '../components/Paywall/EvaluationsPaywall.vue';
@@ -22,18 +17,12 @@ const props = defineProps<{
 	name: string;
 }>();
 
-const workflowsStore = useWorkflowsStore();
-const workflowsListStore = useWorkflowsListStore();
 const usageStore = useUsageStore();
 const evaluationStore = useEvaluationStore();
-const nodeTypesStore = useNodeTypesStore();
 const telemetry = useTelemetry();
 const toast = useToast();
 const locale = useI18n();
-const route = useRoute();
 const sourceControlStore = useSourceControlStore();
-
-const { initializeWorkspace } = useCanvasOperations();
 
 const evaluationsLicensed = computed(() => {
 	return usageStore.workflowsWithEvaluationsLimit !== 0;
@@ -54,11 +43,6 @@ const hasRuns = computed(() => {
 });
 
 const showWizard = computed(() => !hasRuns.value);
-
-// Check if this is a new workflow by looking for the ?new query param
-const isNewWorkflowRoute = computed(() => {
-	return route.query.new === 'true';
-});
 
 // Method to run a test - will be used by the SetupWizard component
 async function runTest() {
@@ -89,30 +73,6 @@ const { isReady } = useAsyncState(async () => {
 		await evaluationStore.fetchTestRuns(props.name);
 	} catch (error) {
 		toast.showError(error, locale.baseText('evaluation.listRuns.error.cantFetchTestRuns'));
-	}
-
-	const workflowId = props.name;
-	const isAlreadyInitialized = workflowsStore.workflow.id === workflowId;
-
-	// Skip fetching if it's a new workflow that hasn't been saved yet
-	if (isNewWorkflowRoute.value || isAlreadyInitialized) {
-		return;
-	}
-
-	// Check if we are loading the Evaluation tab directly, without having loaded the workflow
-	if (!workflowsListStore.workflowsById[workflowId]) {
-		try {
-			const data = await workflowsListStore.fetchWorkflow(workflowId);
-
-			// We need to check for the evaluation node with setMetrics operation, so we need to initialize the nodeTypesStore to have node properties initialized
-			if (nodeTypesStore.allNodeTypes.length === 0) {
-				await nodeTypesStore.getNodeTypes();
-			}
-
-			await initializeWorkspace(data);
-		} catch (error) {
-			toast.showError(error, locale.baseText('nodeView.showError.openWorkflow.title'));
-		}
 	}
 }, undefined);
 

--- a/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionDebugging.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionDebugging.ts
@@ -3,7 +3,7 @@ import { useRouter } from 'vue-router';
 import { useI18n } from '@n8n/i18n';
 import { useMessage } from '@/app/composables/useMessage';
 import { useToast } from '@/app/composables/useToast';
-import { injectWorkflowState } from '@/app/composables/useWorkflowState';
+import { injectWorkflowState, type WorkflowState } from '@/app/composables/useWorkflowState';
 import { EnterpriseEditionFeature, MODAL_CONFIRM, VIEWS } from '@/app/constants';
 import { DEBUG_PAYWALL_MODAL_KEY } from '../executions.constants';
 import type { INodeUi } from '@/Interface';
@@ -16,7 +16,12 @@ import { isFullExecutionResponse } from '@/app/utils/typeGuards';
 import { sanitizeHtml } from '@/app/utils/htmlUtils';
 import { usePageRedirectionHelper } from '@/app/composables/usePageRedirectionHelper';
 
-export const useExecutionDebugging = () => {
+/**
+ * @param providedWorkflowState - Optional workflow state to use instead of injecting.
+ *   This is needed when called from the same component that provides WorkflowStateKey
+ *   (e.g., WorkflowLayout), since Vue's provide/inject works parent-to-child only.
+ */
+export const useExecutionDebugging = (providedWorkflowState?: WorkflowState) => {
 	const telemetry = useTelemetry();
 
 	const router = useRouter();
@@ -24,7 +29,7 @@ export const useExecutionDebugging = () => {
 	const message = useMessage();
 	const toast = useToast();
 	const workflowsStore = useWorkflowsStore();
-	const workflowState = injectWorkflowState();
+	const workflowState = providedWorkflowState ?? injectWorkflowState();
 	const settingsStore = useSettingsStore();
 	const uiStore = useUIStore();
 


### PR DESCRIPTION
## Summary

- Extract workflow initialization logic into composable
- Improve cleanup of notifications in WorkflowLayout
- Update tests to reflect new notification behavior

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2270/move-initialization-logic-to-workflowlayout

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
