### PR TITLE
chore(core): Silence disallowed strings eval error

### DIFF
--- a/packages/@n8n/task-runner/src/__tests__/task-runner-sentry.test.ts
+++ b/packages/@n8n/task-runner/src/__tests__/task-runner-sentry.test.ts
@@ -173,6 +173,34 @@ describe('TaskRunnerSentry', () => {
 			expect(sentry.filterOutUserCodeErrors(event)).toBe(true);
 		});
 
+		it('should filter out EvalError from disallowed code generation', () => {
+			const event: ErrorEvent = {
+				type: undefined,
+				exception: {
+					values: [
+						{
+							type: 'EvalError',
+							value: 'Code generation from strings disallowed for this context',
+							stacktrace: {
+								frames: [
+									{
+										filename: 'app:///dist/js-task-runner/js-task-runner.js',
+										module: 'js-task-runner:js-task-runner',
+										function: 'JsTaskRunner.executeTask',
+									},
+								],
+							},
+							mechanism: { type: 'generic', handled: true },
+						},
+					],
+				},
+				event_id: '18bb78bb3d9d44c4acf3d774c2cfbfdd',
+				platform: 'node',
+			};
+
+			expect(sentry.filterOutUserCodeErrors(event)).toBe(true);
+		});
+
 		it('should not filter out task runner errors', () => {
 			const event: ErrorEvent = {
 				type: undefined,

--- a/packages/@n8n/task-runner/src/task-runner-sentry.ts
+++ b/packages/@n8n/task-runner/src/task-runner-sentry.ts
@@ -59,6 +59,13 @@ export class TaskRunnerSentry {
 	 * that end up in the sentry error reporting.
 	 */
 	private isUserCodeError(error: Exception) {
+		if (
+			error.type === 'EvalError' &&
+			error.value === 'Code generation from strings disallowed for this context' // from --disallow-code-generation-from-strings
+		) {
+			return true;
+		}
+
 		const frames = error.stacktrace?.frames;
 		if (!frames) return false;
 


### PR DESCRIPTION
## Summary

Stop reporting to Sentry errors coming from `--disallow-code-generation-from-strings` violations.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2239


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
