### PR TITLE
feat(core): Test connection & refresh secrets

### DIFF
--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -186,3 +186,8 @@ export type {
 	TestSecretProviderConnectionResponse,
 	ReloadSecretProviderConnectionResponse,
 } from './schemas/secrets-provider.schema';
+
+export {
+	testSecretProviderConnectionResponseSchema,
+	reloadSecretProviderConnectionResponseSchema,
+} from './schemas/secrets-provider.schema';

--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -184,4 +184,5 @@ export type {
 	SecretProviderTypeResponse,
 	SecretCompletionsResponse,
 	TestSecretProviderConnectionResponse,
+	ReloadSecretProviderConnectionResponse,
 } from './schemas/secrets-provider.schema';

--- a/packages/@n8n/api-types/src/schemas/secrets-provider.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/secrets-provider.schema.ts
@@ -109,5 +109,15 @@ export type TestSecretProviderConnectionResponse = z.infer<
 	typeof testSecretProviderConnectionResponseSchema
 >;
 
+/**
+ * Reload connection result
+ */
+export const reloadSecretProviderConnectionResponseSchema = z.object({
+	success: z.boolean(),
+});
+export type ReloadSecretProviderConnectionResponse = z.infer<
+	typeof reloadSecretProviderConnectionResponseSchema
+>;
+
 // ==========
 // #endregion

--- a/packages/cli/src/modules/external-secrets.ee/__tests__/secrets-providers-connections.service.ee.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/secrets-providers-connections.service.ee.test.ts
@@ -21,7 +21,6 @@ describe('SecretsProvidersConnectionsService', () => {
 				id: 1,
 				providerKey: 'my-aws',
 				type: 'awsSecretsManager',
-				isEnabled: true,
 				projectAccess: [
 					{ project: { id: 'p1', name: 'Project 1' } },
 					{ project: { id: 'p2', name: 'Project 2' } },
@@ -34,7 +33,6 @@ describe('SecretsProvidersConnectionsService', () => {
 				id: '1',
 				name: 'my-aws',
 				type: 'awsSecretsManager',
-				isEnabled: true,
 				projects: [
 					{ id: 'p1', name: 'Project 1' },
 					{ id: 'p2', name: 'Project 2' },
@@ -49,7 +47,6 @@ describe('SecretsProvidersConnectionsService', () => {
 				id: 2,
 				providerKey: 'my-vault',
 				type: 'vault',
-				isEnabled: false,
 				projectAccess: [],
 				createdAt: new Date('2024-01-01'),
 				updatedAt: new Date('2024-01-02'),
@@ -59,7 +56,6 @@ describe('SecretsProvidersConnectionsService', () => {
 				id: '2',
 				name: 'my-vault',
 				type: 'vault',
-				isEnabled: false,
 				projects: [],
 				createdAt: '2024-01-01T00:00:00.000Z',
 				updatedAt: '2024-01-02T00:00:00.000Z',

--- a/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
@@ -20,12 +20,7 @@ import { ExternalSecretsProviderRegistry } from './provider-registry.service';
 import { ExternalSecretsRetryManager } from './retry-manager.service';
 import { ExternalSecretsSecretsCache } from './secrets-cache.service';
 import { ExternalSecretsSettingsStore } from './settings-store.service';
-import type {
-	ExternalSecretsSettings,
-	SecretsProvider,
-	SecretsProviderSettings,
-	TestProviderSettingsResult,
-} from './types';
+import type { ExternalSecretsSettings, SecretsProvider, SecretsProviderSettings } from './types';
 
 /**
  * Orchestrates external secrets management
@@ -209,10 +204,7 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 		this.broadcastReload();
 	}
 
-	async testProviderSettings(
-		provider: string,
-		data: IDataObject,
-	): Promise<TestProviderSettingsResult> {
+	async testProviderSettings(provider: string, data: IDataObject) {
 		const testSettings: SecretsProviderSettings = {
 			connected: true,
 			connectedAt: new Date(),
@@ -242,7 +234,7 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 
 			const [success, error] = await result.provider.test();
 
-			// Explicitly handle the discriminated union
+			// This mostly forces the "typing" to work correctly
 			if (!success) {
 				return { success: false, testState: 'error', error };
 			}

--- a/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
@@ -20,7 +20,12 @@ import { ExternalSecretsProviderRegistry } from './provider-registry.service';
 import { ExternalSecretsRetryManager } from './retry-manager.service';
 import { ExternalSecretsSecretsCache } from './secrets-cache.service';
 import { ExternalSecretsSettingsStore } from './settings-store.service';
-import type { ExternalSecretsSettings, SecretsProvider, SecretsProviderSettings } from './types';
+import type {
+	ExternalSecretsSettings,
+	SecretsProvider,
+	SecretsProviderSettings,
+	TestProviderSettingsResult,
+} from './types';
 
 /**
  * Orchestrates external secrets management
@@ -204,7 +209,10 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 		this.broadcastReload();
 	}
 
-	async testProviderSettings(provider: string, data: IDataObject) {
+	async testProviderSettings(
+		provider: string,
+		data: IDataObject,
+	): Promise<TestProviderSettingsResult> {
 		const testSettings: SecretsProviderSettings = {
 			connected: true,
 			connectedAt: new Date(),
@@ -213,8 +221,8 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 
 		const errorState = {
 			success: false,
-			testState: 'error' as const,
-		};
+			testState: 'error',
+		} as const;
 
 		const result = await this.providerLifecycle.initialize(provider, testSettings);
 
@@ -226,14 +234,23 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 			// Connect the provider to authenticate before testing
 			const connectResult = await this.providerLifecycle.connect(result.provider);
 			if (!connectResult.success) {
-				return { ...errorState, error: connectResult.error?.message };
+				return {
+					...errorState,
+					error: connectResult.error?.message,
+				};
 			}
 
 			const [success, error] = await result.provider.test();
-			const currentSettings = await this.settingsStore.getProvider(provider);
-			const testState = this.determineTestState(success, currentSettings?.connected ?? false);
 
-			return { success, testState, error };
+			// Explicitly handle the discriminated union
+			if (!success) {
+				return { success: false, testState: 'error', error };
+			}
+
+			const currentSettings = await this.settingsStore.getProvider(provider);
+			const testState: 'connected' | 'tested' = currentSettings?.connected ? 'connected' : 'tested';
+
+			return { success: true, testState };
 		} catch {
 			return errorState;
 		} finally {
@@ -408,16 +425,6 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 			isValid: testResult?.[0] ?? false,
 			errorMessage: testResult?.[1],
 		});
-	}
-
-	private determineTestState(
-		success: boolean,
-		isConnected: boolean,
-	): 'connected' | 'tested' | 'error' {
-		if (!success) {
-			return 'error';
-		}
-		return isConnected ? 'connected' : 'tested';
 	}
 
 	private getCachedSettings(): ExternalSecretsSettings {

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.controller.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.controller.ee.ts
@@ -1,6 +1,8 @@
 import {
 	CreateSecretsProviderConnectionDto,
 	UpdateSecretsProviderConnectionDto,
+	ReloadSecretProviderConnectionResponse,
+	TestSecretProviderConnectionResponse,
 } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import type { AuthenticatedRequest } from '@n8n/db';
@@ -103,48 +105,24 @@ export class SecretProvidersConnectionsController {
 	}
 
 	@Post('/:providerKey/test')
-	@GlobalScope('externalSecretsProvider:read')
-	testConnection(
-		_req: AuthenticatedRequest,
-		_res: Response,
-		@Param('providerKey') _providerKey: string,
-	) {
-		this.logger.debug('Testing provider connnection');
-		//TODO implement
-		return;
-	}
-
-	@Post('/:providerKey/connect')
 	@GlobalScope('externalSecretsProvider:update')
-	toggleConnectionStatus(
+	async testConnection(
 		_req: AuthenticatedRequest,
 		_res: Response,
-		@Param('providerKey') _providerKey: string,
-	) {
-		this.logger.debug('Toggling connection status');
-		//TODO implement
-		return;
+		@Param('providerKey') providerKey: string,
+	): Promise<TestSecretProviderConnectionResponse> {
+		this.logger.debug('Testing provider connection', { providerKey });
+		return await this.connectionsService.testConnection(providerKey);
 	}
 
 	@Post('/:providerKey/reload')
 	@GlobalScope('externalSecretsProvider:sync')
-	reloadConnectionSecrets(
+	async reloadConnectionSecrets(
 		_req: AuthenticatedRequest,
 		_res: Response,
-		@Param('providerKey') _providerKey: string,
-	) {
-		this.logger.debug('Reloading secrets for secret provider connection');
-		return;
-	}
-
-	@Post('/:providerKey/share')
-	@GlobalScope('externalSecretsProvider:update')
-	shareConnection(
-		_req: AuthenticatedRequest,
-		_res: Response,
-		@Param('providerKey') _providerKey: string,
-	) {
-		this.logger.debug('Share connection with other projects');
-		return;
+		@Param('providerKey') providerKey: string,
+	): Promise<ReloadSecretProviderConnectionResponse> {
+		this.logger.debug('Reloading secrets for secret provider connection', { providerKey });
+		return await this.connectionsService.reloadConnectionSecrets(providerKey);
 	}
 }

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.service.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.service.ee.ts
@@ -2,7 +2,10 @@ import type { SecretCompletionsResponse, SecretsProviderType } from '@n8n/api-ty
 import {
 	CreateSecretsProviderConnectionDto,
 	TestSecretProviderConnectionResponse,
-} from '@n8n/api-types/src';
+	testSecretProviderConnectionResponseSchema,
+	reloadSecretProviderConnectionResponseSchema,
+	ReloadSecretProviderConnectionResponse,
+} from '@n8n/api-types';
 import type { SecretsProviderConnection } from '@n8n/db';
 import {
 	ProjectSecretsProviderAccessRepository,
@@ -12,17 +15,11 @@ import { Service } from '@n8n/di';
 import { Cipher } from 'n8n-core';
 import type { IDataObject } from 'n8n-workflow';
 
+import { jsonParse } from 'n8n-workflow';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { ExternalSecretsManager } from '@/modules/external-secrets.ee/external-secrets-manager.ee';
 import { SecretsProvidersResponses } from '@/modules/external-secrets.ee/secrets-providers.responses.ee';
-import { jsonParse } from 'n8n-workflow';
-
-import {
-	ReloadProviderResult,
-	TestProviderSettingsResult,
-} from '@/modules/external-secrets.ee/types';
-import { testSecretProviderConnectionResponseSchema } from '@n8n/api-types/src/schemas/secrets-provider.schema';
 
 @Service()
 export class SecretsProvidersConnectionsService {
@@ -175,10 +172,12 @@ export class SecretsProvidersConnectionsService {
 		return testSecretProviderConnectionResponseSchema.parse(result);
 	}
 
-	async reloadConnectionSecrets(providerKey: string): Promise<ReloadProviderResult> {
+	async reloadConnectionSecrets(
+		providerKey: string,
+	): Promise<ReloadSecretProviderConnectionResponse> {
 		await this.getConnection(providerKey);
 		await this.externalSecretsManager.updateProvider(providerKey);
-		return { success: true };
+		return reloadSecretProviderConnectionResponseSchema.parse({ success: true });
 	}
 
 	private encryptConnectionSettings(settings: IDataObject): string {

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.service.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.service.ee.ts
@@ -1,5 +1,8 @@
 import type { SecretCompletionsResponse, SecretsProviderType } from '@n8n/api-types';
-import { CreateSecretsProviderConnectionDto } from '@n8n/api-types/src';
+import {
+	CreateSecretsProviderConnectionDto,
+	TestSecretProviderConnectionResponse,
+} from '@n8n/api-types/src';
 import type { SecretsProviderConnection } from '@n8n/db';
 import {
 	ProjectSecretsProviderAccessRepository,
@@ -13,6 +16,13 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { ExternalSecretsManager } from '@/modules/external-secrets.ee/external-secrets-manager.ee';
 import { SecretsProvidersResponses } from '@/modules/external-secrets.ee/secrets-providers.responses.ee';
+import { jsonParse } from 'n8n-workflow';
+
+import {
+	ReloadProviderResult,
+	TestProviderSettingsResult,
+} from '@/modules/external-secrets.ee/types';
+import { testSecretProviderConnectionResponseSchema } from '@n8n/api-types/src/schemas/secrets-provider.schema';
 
 @Service()
 export class SecretsProvidersConnectionsService {
@@ -40,7 +50,7 @@ export class SecretsProvidersConnectionsService {
 		const connection = this.repository.create({
 			...proposedConnection,
 			encryptedSettings,
-			isEnabled: false,
+			isEnabled: true,
 		});
 
 		const savedConnection = await this.repository.save(connection);
@@ -146,7 +156,6 @@ export class SecretsProvidersConnectionsService {
 			id: String(connection.id),
 			name: connection.providerKey,
 			type: connection.type as SecretsProviderType,
-			isEnabled: connection.isEnabled,
 			projects: connection.projectAccess.map((access) => ({
 				id: access.project.id,
 				name: access.project.name,
@@ -156,7 +165,27 @@ export class SecretsProvidersConnectionsService {
 		};
 	}
 
+	async testConnection(providerKey: string): Promise<TestSecretProviderConnectionResponse> {
+		const connection = await this.getConnection(providerKey);
+		const decryptedSettings = this.decryptConnectionSettings(connection.encryptedSettings);
+		const result = await this.externalSecretsManager.testProviderSettings(
+			connection.type,
+			decryptedSettings,
+		);
+		return testSecretProviderConnectionResponseSchema.parse(result);
+	}
+
+	async reloadConnectionSecrets(providerKey: string): Promise<ReloadProviderResult> {
+		await this.getConnection(providerKey);
+		await this.externalSecretsManager.updateProvider(providerKey);
+		return { success: true };
+	}
+
 	private encryptConnectionSettings(settings: IDataObject): string {
 		return this.cipher.encrypt(settings);
+	}
+
+	private decryptConnectionSettings(encryptedSettings: string): IDataObject {
+		return jsonParse(this.cipher.decrypt(encryptedSettings));
 	}
 }

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers.responses.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers.responses.ee.ts
@@ -1,8 +1,12 @@
 import type { SecretProviderConnection } from '@n8n/api-types';
 
 export declare namespace SecretsProvidersResponses {
-	type StrippedConnection = Omit<SecretProviderConnection, 'settings' | 'secretsCount' | 'state'>;
+	type StrippedConnection = Omit<
+		SecretProviderConnection,
+		'settings' | 'secretsCount' | 'state' | 'isEnabled'
+	>;
 
 	type PublicConnection = Promise<StrippedConnection>;
 	type PublicConnectionList = Promise<StrippedConnection[]>;
+	type TestConnectionResult = Promise<{ success: boolean; error?: string }>;
 }

--- a/packages/cli/src/modules/external-secrets.ee/types.ts
+++ b/packages/cli/src/modules/external-secrets.ee/types.ts
@@ -1,3 +1,7 @@
+import type {
+	ReloadSecretProviderConnectionResponse,
+	TestSecretProviderConnectionResponse,
+} from '@n8n/api-types';
 import type { AuthenticatedRequest } from '@n8n/db';
 import type { IDataObject, INodeProperties } from 'n8n-workflow';
 

--- a/packages/cli/src/modules/external-secrets.ee/types.ts
+++ b/packages/cli/src/modules/external-secrets.ee/types.ts
@@ -1,7 +1,3 @@
-import type {
-	ReloadSecretProviderConnectionResponse,
-	TestSecretProviderConnectionResponse,
-} from '@n8n/api-types';
 import type { AuthenticatedRequest } from '@n8n/db';
 import type { IDataObject, INodeProperties } from 'n8n-workflow';
 


### PR DESCRIPTION
## Summary
* Add `test` endpoint
* Add `reload` endpoint
* Remove `isEnabled` from the frontend
* Update responses to use zod from `@n8n/api-types` instead of typing only

## Related Linear tickets, Github issues, and Community forum posts
Closes #ligo-116

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
