### PR TITLE
fix(core): Wrong pagination argument order for sqlite in copyTables helper

### DIFF
--- a/packages/@n8n/db/src/migrations/migration-helpers.test.ts
+++ b/packages/@n8n/db/src/migrations/migration-helpers.test.ts
@@ -1,0 +1,102 @@
+import { Container } from '@n8n/di';
+import { DataSource } from '@n8n/typeorm';
+
+import { DbConnection } from '../index';
+import { copyTable } from './migration-helpers';
+
+describe('Migration Helpers', () => {
+	let dataSource: DataSource;
+
+	beforeEach(async () => {
+		const dbConnection = Container.get(DbConnection);
+		await dbConnection.init();
+		dataSource = Container.get(DataSource);
+	});
+
+	afterEach(async () => {
+		const dbConnection = Container.get(DbConnection);
+		await dbConnection.close();
+	});
+
+	describe('copyTable', () => {
+		it('should put OFFSET after LIMIT in INSERT statement for sqlite support', async () => {
+			// Regression test for SQLite LIMIT/OFFSET ordering bug
+			// copyTable should correctly copy rows when count exceeds batch size
+			const testTableName = 'test_copy_source';
+			const destTableName = 'test_copy_dest';
+			const rowCount = 25; // More than default batch size of 10
+
+			// Cleanup any existing tables from previous test runs
+			await dataSource.query(`DROP TABLE IF EXISTS ${testTableName}`);
+			await dataSource.query(`DROP TABLE IF EXISTS ${destTableName}`);
+
+			// Create source table and populate with test data
+			await dataSource.query(`
+				CREATE TABLE ${testTableName} (
+					id INTEGER PRIMARY KEY,
+					value TEXT
+				)
+			`);
+
+			// Insert 25 rows
+			for (let i = 1; i <= rowCount; i++) {
+				await dataSource.query(`INSERT INTO ${testTableName} (id, value) VALUES (?, ?)`, [
+					i,
+					`value_${i}`,
+				]);
+			}
+
+			// Create destination table with same schema
+			await dataSource.query(`
+				CREATE TABLE ${destTableName} (
+					id INTEGER PRIMARY KEY,
+					value TEXT
+				)
+			`);
+
+			const queryRunner = dataSource.createQueryRunner();
+
+			// Spy on queryRunner.query to capture the actual SQL being executed
+			const querySpy = jest.spyOn(queryRunner, 'query');
+
+			// Copy all data using copyTable (should trigger multiple batches with OFFSET)
+			await copyTable(queryRunner, '', testTableName, destTableName);
+
+			// Verify the SQL queries have correct LIMIT/OFFSET ordering
+			const insertCalls = querySpy.mock.calls.filter(
+				([sql]) => typeof sql === 'string' && sql.includes('INSERT INTO'),
+			);
+
+			// Should have 3 INSERT calls: batch 1 (rows 1-10), batch 2 (rows 11-20), batch 3 (rows 21-25)
+			expect(insertCalls.length).toBe(3);
+
+			// Get the escaped table names to construct expected queries
+			const { driver } = queryRunner.connection;
+			const escapedSource = driver.escape('test_copy_source');
+			const escapedDest = driver.escape('test_copy_dest');
+
+			// First batch should not have OFFSET
+			const firstBatchQuery = insertCalls[0][0];
+			expect(firstBatchQuery).toBe(
+				`INSERT INTO ${escapedDest}  SELECT * FROM ${escapedSource} LIMIT 10`,
+			);
+
+			const secondBatchQuery = insertCalls[1][0];
+			expect(secondBatchQuery).toBe(
+				`INSERT INTO ${escapedDest}  SELECT * FROM ${escapedSource} LIMIT 10 OFFSET 10`,
+			);
+
+			const thirdBatchQuery = insertCalls[2][0];
+			expect(thirdBatchQuery).toBe(
+				`INSERT INTO ${escapedDest}  SELECT * FROM ${escapedSource} LIMIT 10 OFFSET 20`,
+			);
+
+			querySpy.mockRestore();
+
+			// Cleanup
+			await queryRunner.release();
+			await dataSource.query(`DROP TABLE ${testTableName}`);
+			await dataSource.query(`DROP TABLE ${destTableName}`);
+		});
+	});
+});

--- a/packages/cli/test/migration/1769784356000-expand-subject-id-column-length.test.ts
+++ b/packages/cli/test/migration/1769784356000-expand-subject-id-column-length.test.ts
@@ -39,7 +39,7 @@ function getParamPlaceholder(context: TestMigrationContext, index = 1): string {
 describe('ExpandSubjectIDColumnLength Migration', () => {
 	let dataSource: DataSource;
 
-	beforeAll(async () => {
+	beforeEach(async () => {
 		const dbConnection = Container.get(DbConnection);
 		await dbConnection.init();
 
@@ -49,7 +49,7 @@ describe('ExpandSubjectIDColumnLength Migration', () => {
 		await initDbUpToMigration(MIGRATION_NAME);
 	});
 
-	afterAll(async () => {
+	afterEach(async () => {
 		const dbConnection = Container.get(DbConnection);
 		await dbConnection.close();
 	});


### PR DESCRIPTION
## Summary

Today we came across a failing migration on a crash-looping cloud instance:
```
Starting migration ChangeValueTypesForInsights1759399811000                      
Migration "ChangeValueTypesForInsights1759399811000" failed, error: SQLITE_ERROR: near "10": syntax error
```

In sqlite, OFFSET needs to come after LIMIT, otherwise the statement will fail.

This only affects 2.7.x. Regression from https://github.com/n8n-io/n8n/pull/25044

The CI for our migrations runs in multi-main mode with postgres, which is likely why this wasn't caught before merging.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
