### PR TITLE
fix(editor): Add checksum validation when archive/unpublish workflow from canvas

### DIFF
--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -71,6 +71,8 @@ export { UpdateWorkflowDto } from './workflows/update-workflow.dto';
 export { ImportWorkflowFromUrlDto } from './workflows/import-workflow-from-url.dto';
 export { TransferWorkflowBodyDto } from './workflows/transfer.dto';
 export { ActivateWorkflowDto } from './workflows/activate-workflow.dto';
+export { DeactivateWorkflowDto } from './workflows/deactivate-workflow.dto';
+export { ArchiveWorkflowDto } from './workflows/archive-workflow.dto';
 
 export { CreateOrUpdateTagRequestDto } from './tag/create-or-update-tag-request.dto';
 export { RetrieveTagQueryDto } from './tag/retrieve-tag-query.dto';

--- a/packages/@n8n/api-types/src/dto/workflows/archive-workflow.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/archive-workflow.dto.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+import { Z } from 'zod-class';
+
+export class ArchiveWorkflowDto extends Z.class({
+	expectedChecksum: z.string().optional(),
+}) {}

--- a/packages/@n8n/api-types/src/dto/workflows/deactivate-workflow.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/deactivate-workflow.dto.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+import { Z } from 'zod-class';
+
+export class DeactivateWorkflowDto extends Z.class({
+	expectedChecksum: z.string().optional(),
+}) {}

--- a/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
@@ -361,11 +361,9 @@ export = {
 			const { id } = req.params;
 
 			try {
-				const workflow = await Container.get(WorkflowService).deactivateWorkflow(
-					req.user,
-					id,
-					true,
-				);
+				const workflow = await Container.get(WorkflowService).deactivateWorkflow(req.user, id, {
+					publicApi: true,
+				});
 
 				return res.json(workflow);
 			} catch (error) {

--- a/packages/cli/src/services/folder.service.ts
+++ b/packages/cli/src/services/folder.service.ts
@@ -153,7 +153,7 @@ export class FolderService {
 		);
 
 		for (const workflowId of workflowIds) {
-			await this.workflowService.archive(user, workflowId, true);
+			await this.workflowService.archive(user, workflowId, { skipArchived: true });
 		}
 
 		await this.workflowRepository.moveToFolder(workflowIds, PROJECT_ROOT);

--- a/packages/frontend/editor-ui/src/app/api/workflows.ts
+++ b/packages/frontend/editor-ui/src/app/api/workflows.ts
@@ -144,10 +144,12 @@ export async function activateWorkflow(
 export async function deactivateWorkflow(
 	context: IRestApiContext,
 	workflowId: string,
+	expectedChecksum?: string,
 ): Promise<IWorkflowDb> {
 	return await makeRestApiRequest<IWorkflowDb>(
 		context,
 		'POST',
 		`/workflows/${workflowId}/deactivate`,
+		{ expectedChecksum },
 	);
 }

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.test.ts
@@ -167,6 +167,8 @@ describe('WorkflowDetails', () => {
 			'123': workflow,
 		};
 		workflowsStore.isWorkflowSaved = { '1': true, '123': true };
+		workflowsStore.workflowId = workflow.id;
+		workflowsStore.workflowChecksum = 'test-checksum';
 		projectsStore.currentProject = null;
 		projectsStore.personalProject = { id: 'personal', name: 'Personal' } as Project;
 		collaborationStore.shouldBeReadOnly = false;
@@ -474,7 +476,7 @@ describe('WorkflowDetails', () => {
 			expect(toast.showError).toHaveBeenCalledTimes(0);
 			expect(toast.showMessage).toHaveBeenCalledTimes(1);
 			expect(workflowsStore.archiveWorkflow).toHaveBeenCalledTimes(1);
-			expect(workflowsStore.archiveWorkflow).toHaveBeenCalledWith(workflow.id);
+			expect(workflowsStore.archiveWorkflow).toHaveBeenCalledWith(workflow.id, 'test-checksum');
 			expect(router.push).toHaveBeenCalledTimes(1);
 			expect(router.push).toHaveBeenCalledWith({
 				name: VIEWS.WORKFLOWS,
@@ -507,7 +509,7 @@ describe('WorkflowDetails', () => {
 			await userEvent.click(getByTestId('workflow-menu'));
 			await userEvent.click(getByTestId('workflow-menu-item-archive'));
 
-			expect(workflowsStore.archiveWorkflow).toHaveBeenCalledWith(teamWorkflow.id);
+			expect(workflowsStore.archiveWorkflow).toHaveBeenCalledWith(teamWorkflow.id, 'test-checksum');
 			expect(router.push).toHaveBeenCalledWith({
 				name: VIEWS.PROJECTS_WORKFLOWS,
 				params: { projectId: teamProjectId },
@@ -539,7 +541,10 @@ describe('WorkflowDetails', () => {
 			await userEvent.click(getByTestId('workflow-menu'));
 			await userEvent.click(getByTestId('workflow-menu-item-archive'));
 
-			expect(workflowsStore.archiveWorkflow).toHaveBeenCalledWith(personalWorkflow.id);
+			expect(workflowsStore.archiveWorkflow).toHaveBeenCalledWith(
+				personalWorkflow.id,
+				'test-checksum',
+			);
 			expect(router.push).toHaveBeenCalledWith({
 				name: VIEWS.WORKFLOWS,
 			});
@@ -564,7 +569,7 @@ describe('WorkflowDetails', () => {
 			expect(toast.showError).toHaveBeenCalledTimes(0);
 			expect(toast.showMessage).toHaveBeenCalledTimes(1);
 			expect(workflowsStore.archiveWorkflow).toHaveBeenCalledTimes(1);
-			expect(workflowsStore.archiveWorkflow).toHaveBeenCalledWith(workflow.id);
+			expect(workflowsStore.archiveWorkflow).toHaveBeenCalledWith(workflow.id, 'test-checksum');
 			expect(router.push).toHaveBeenCalledTimes(1);
 			expect(router.push).toHaveBeenCalledWith({
 				name: VIEWS.WORKFLOWS,

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.vue
@@ -251,7 +251,9 @@ async function handleArchiveWorkflow() {
 	}
 
 	try {
-		await workflowsStore.archiveWorkflow(props.id);
+		const expectedChecksum =
+			props.id === workflowsStore.workflowId ? workflowsStore.workflowChecksum : undefined;
+		await workflowsStore.archiveWorkflow(props.id, expectedChecksum);
 	} catch (error) {
 		toast.showError(error, locale.baseText('generic.archiveWorkflowError'));
 		return;

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.ts
@@ -168,7 +168,10 @@ export function useWorkflowActivate() {
 		void useExternalHooks().run('workflowActivate.updateWorkflowActivation', telemetryPayload);
 
 		try {
-			await workflowsStore.deactivateWorkflow(workflowId);
+			const expectedChecksum =
+				workflowId === workflowsStore.workflowId ? workflowsStore.workflowChecksum : undefined;
+
+			await workflowsStore.deactivateWorkflow(workflowId, expectedChecksum);
 
 			void useExternalHooks().run('workflow.unpublished', {
 				workflowId,

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -734,8 +734,8 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		return updatedNodesCount;
 	}
 
-	async function archiveWorkflow(id: string) {
-		const updatedWorkflow = await workflowsListStore.archiveWorkflowInList(id);
+	async function archiveWorkflow(id: string, expectedChecksum?: string) {
+		const updatedWorkflow = await workflowsListStore.archiveWorkflowInList(id, expectedChecksum);
 		setWorkflowInactive(id);
 
 		if (id === workflow.value.id) {
@@ -1474,11 +1474,12 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		return updatedWorkflow;
 	}
 
-	async function deactivateWorkflow(id: string): Promise<IWorkflowDb> {
+	async function deactivateWorkflow(id: string, expectedChecksum?: string): Promise<IWorkflowDb> {
 		const updatedWorkflow = await makeRestApiRequest<IWorkflowDb>(
 			rootStore.restApiContext,
 			'POST',
 			`/workflows/${id}/deactivate`,
+			{ expectedChecksum },
 		);
 		if (!updatedWorkflow.checksum) {
 			throw new Error('Failed to deactivate workflow');

--- a/packages/frontend/editor-ui/src/app/stores/workflowsList.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowsList.store.test.ts
@@ -509,6 +509,36 @@ describe('useWorkflowsListStore', () => {
 			expect(workflowsListStore.activeWorkflows).not.toContain('123');
 		});
 
+		it('should pass expectedChecksum to the API when provided', async () => {
+			const versionId = '00000000-0000-0000-0000-000000000000';
+			const updatedVersionId = '11111111-1111-1111-1111-111111111111';
+			const expectedChecksum = 'test-checksum-123';
+
+			workflowsListStore.addWorkflow(
+				createTestWorkflow({
+					id: '123',
+					active: true,
+					isArchived: false,
+					versionId,
+				}),
+			);
+			workflowsListStore.activeWorkflows = ['123'];
+
+			const makeRestApiRequestSpy = vi.spyOn(apiUtils, 'makeRestApiRequest').mockResolvedValue({
+				versionId: updatedVersionId,
+				checksum: 'checksum',
+			});
+
+			await workflowsListStore.archiveWorkflowInList('123', expectedChecksum);
+
+			expect(makeRestApiRequestSpy).toHaveBeenCalledWith(
+				expect.anything(),
+				'POST',
+				'/workflows/123/archive',
+				{ expectedChecksum },
+			);
+		});
+
 		it('should throw error if checksum is missing', async () => {
 			workflowsListStore.addWorkflow(createTestWorkflow({ id: '123' }));
 

--- a/packages/frontend/editor-ui/src/app/stores/workflowsList.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowsList.store.ts
@@ -210,11 +210,15 @@ export const useWorkflowsListStore = defineStore(STORES.WORKFLOWS_LIST, () => {
 		removeWorkflow(id);
 	}
 
-	async function archiveWorkflowInList(id: string): Promise<IWorkflowDb> {
+	async function archiveWorkflowInList(
+		id: string,
+		expectedChecksum?: string,
+	): Promise<IWorkflowDb> {
 		const updatedWorkflow = await makeRestApiRequest<IWorkflowDb>(
 			rootStore.restApiContext,
 			'POST',
 			`/workflows/${id}/archive`,
+			{ expectedChecksum },
 		);
 		if (!updatedWorkflow.checksum) {
 			throw new Error('Failed to archive workflow');


### PR DESCRIPTION
## Summary

Performing un-publish or archive workflow from workflow canvas that's outdated may lead to unwanted results.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4624/feature-send-checksum-for-archive-endpoint
https://linear.app/n8n/issue/ADO-4515/bug-conflicts-are-not-checked-when-unpublishing-a-workflow


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
