### PR TITLE
ci: Add SQLite sanity check to e2e tests

### DIFF
--- a/.github/workflows/test-e2e-ci-reusable.yml
+++ b/.github/workflows/test-e2e-ci-reusable.yml
@@ -51,6 +51,21 @@ jobs:
         id: generate-matrix
         run: echo "matrix=$(node packages/testing/playwright/scripts/distribute-tests.mjs --matrix 16 --orchestrate)" >> "$GITHUB_OUTPUT"
 
+  sqlite-sanity:
+    needs: [prepare]
+    name: 'SQLite: Sanity Check'
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+    uses: ./.github/workflows/test-e2e-reusable.yml
+    with:
+      branch: ${{ inputs.branch }}
+      test-mode: docker-pull
+      docker-image: ghcr.io/n8n-io/n8n:pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
+      test-command: pnpm --filter=n8n-playwright test:container:sqlite:e2e tests/e2e/building-blocks/workflow-entry-points.spec.ts
+      shards: 1
+      runner: blacksmith-2vcpu-ubuntu-2204
+      workers: '1'
+      pre-generated-matrix: '[{"shard":1,"images":""}]'
+
   # Multi-main: postgres + redis + caddy + 2 mains + 1 worker
   # Only runs for internal PRs (not community/fork PRs)
   # Pulls pre-built Docker image from GHCR
@@ -89,7 +104,7 @@ jobs:
   # Cleanup ephemeral Docker image from GHCR after tests complete
   cleanup-docker:
     name: 'Cleanup Docker Image'
-    needs: [prepare, multi-main-e2e]
+    needs: [prepare, multi-main-e2e, sqlite-sanity]
     if: ${{ !failure() && !cancelled() && !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-slim
     permissions:


### PR DESCRIPTION
## Summary

Introduces an SQLite sanity check as part of the end-to-end testing suite.

This check runs a focused set of tests against an SQLite database to ensure basic functionality and stability. It is only triggered on internal PRs.

Also updates the cleanup-docker job to wait for the sqlite-sanity job to complete before cleaning up the docker image.


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
