### PR TITLE
docs(Microsoft Teams Node): Remove non-existent Subscription.ReadWrite.All from description (no-changelog)

### DIFF
--- a/packages/nodes-base/credentials/MicrosoftTeamsOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftTeamsOAuth2Api.credentials.ts
@@ -63,7 +63,7 @@ export class MicrosoftTeamsOAuth2Api implements ICredentialType {
       <br><code>ChannelMessage.Read.All</code>
       <br><code>Chat.Read.All</code>
       <br><code>Team.ReadBasic.All</code>
-      <br><code>Subscription.ReadWrite.All</code>
+      <br><code>Subscription.Read.All</code>
       <br>Configure these permissions in <a href="https://portal.azure.com">Microsoft Entra</a>
     `,
 			name: 'notice',


### PR DESCRIPTION
## Summary

Removes incorrect `Subscription.ReadWrite.All` reference from MS Teams Trigger node description.

This scope does not exist as a delegated permission in Microsoft Graph API, it was listed in error and causes confusion for users configuring Azure permissions.

## Related Linear tickets, Github issues, and Community forum posts

- Related: #17887
- Related: NODE-4364

## Review / Merge checklist

- [x] PR title and summary are descriptive. (no-changelog)
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with release/backport (if the PR is an urgent fix that needs to be backported)