### PR TITLE
perf(core): Skip serialization for push messages with no recipients

### DIFF
--- a/packages/cli/src/push/__tests__/websocket.push.test.ts
+++ b/packages/cli/src/push/__tests__/websocket.push.test.ts
@@ -107,6 +107,13 @@ describe('WebSocketPush', () => {
 		expect(mockWebSocket2.send).toHaveBeenCalledWith(expectedMsg, { binary: false });
 	});
 
+	it('skips sending when user has no connections', () => {
+		webSocketPush.add(pushRef1, userId, mockWebSocket1);
+		webSocketPush.sendToUsers(pushMessage, ['nonexistent-user']);
+
+		expect(mockWebSocket1.send).not.toHaveBeenCalled();
+	});
+
 	it('emits message event when connection receives data', async () => {
 		jest.useRealTimers();
 		const mockOnMessageReceived = jest.fn();

--- a/packages/cli/src/push/abstract.push.ts
+++ b/packages/cli/src/push/abstract.push.ts
@@ -74,6 +74,8 @@ export abstract class AbstractPush<Connection> extends TypedEmitter<AbstractPush
 	}
 
 	private sendTo({ type, data }: PushMessage, pushRefs: string[], asBinary: boolean = false) {
+		if (pushRefs.length === 0) return;
+
 		this.logger.debug(`Pushed to frontend: ${type}`, {
 			dataType: type,
 			pushRefs: pushRefs.join(', '),


### PR DESCRIPTION
## Summary

In multi-main, chathub messages are broadcast via Redis pub/sub to all main instances, but only one holds the WS connection. This means (n-1)/n of push operations were doing serialization work for messages that should never be sent.

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C0AA207KJBH/p1770209091658719
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
