### PR TITLE
feat: Add credentials list endpoint + new scopes

### DIFF
--- a/packages/@n8n/db/src/repositories/__tests__/credentials.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/credentials.repository.test.ts
@@ -1,0 +1,55 @@
+import { Container } from '@n8n/di';
+import { In } from '@n8n/typeorm';
+
+import { CredentialsEntity } from '../../entities';
+import { mockEntityManager } from '../../utils/test-utils/mock-entity-manager';
+import { CredentialsRepository } from '../credentials.repository';
+
+describe('CredentialsRepository', () => {
+	const entityManager = mockEntityManager(CredentialsEntity);
+	const credentialsRepository = Container.get(CredentialsRepository);
+
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
+	describe('findManyAndCount', () => {
+		it('should call findAndCount with options from toFindManyOptions and return [entities, count]', async () => {
+			const mockCredentials = [
+				{ id: '1', name: 'Cred 1', type: 'githubApi' },
+				{ id: '2', name: 'Cred 2', type: 'githubApi' },
+			] as CredentialsEntity[];
+			const count = 2;
+			entityManager.findAndCount.mockResolvedValueOnce([mockCredentials, count]);
+
+			const [credentials, total] = await credentialsRepository.findManyAndCount({
+				take: 10,
+				skip: 0,
+			});
+
+			expect(credentials).toEqual(mockCredentials);
+			expect(total).toBe(count);
+			expect(entityManager.findAndCount).toHaveBeenCalledTimes(1);
+			const callArg = entityManager.findAndCount.mock.calls[0]?.[1];
+			expect(callArg).toBeDefined();
+			expect(callArg!.take).toBe(10);
+			expect(callArg!.select).toBeDefined();
+			expect(callArg!.relations).toEqual([
+				'shared',
+				'shared.project',
+				'shared.project.projectRelations',
+			]);
+		});
+
+		it('should apply credentialIds filter when provided', async () => {
+			entityManager.findAndCount.mockResolvedValueOnce([[], 0]);
+
+			await credentialsRepository.findManyAndCount({ take: 5, skip: 0 }, ['id1', 'id2']);
+
+			expect(entityManager.findAndCount).toHaveBeenCalledTimes(1);
+			const callArg = entityManager.findAndCount.mock.calls[0]?.[1];
+			expect(callArg).toBeDefined();
+			expect(callArg!.where).toEqual(expect.objectContaining({ id: In(['id1', 'id2']) }));
+		});
+	});
+});

--- a/packages/@n8n/db/src/repositories/__tests__/credentials.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/credentials.repository.test.ts
@@ -39,7 +39,7 @@ describe('CredentialsRepository', () => {
 				'shared.project',
 				'shared.project.projectRelations',
 			]);
-			expect(callArg!.order).toEqual({ createdAt: 'DESC' });
+			expect(callArg!.order).toBeUndefined();
 		});
 
 		it('should apply credentialIds filter when provided', async () => {

--- a/packages/@n8n/db/src/repositories/__tests__/credentials.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/credentials.repository.test.ts
@@ -39,6 +39,7 @@ describe('CredentialsRepository', () => {
 				'shared.project',
 				'shared.project.projectRelations',
 			]);
+			expect(callArg!.order).toEqual({ createdAt: 'DESC' });
 		});
 
 		it('should apply credentialIds filter when provided', async () => {

--- a/packages/@n8n/db/src/repositories/credentials.repository.ts
+++ b/packages/@n8n/db/src/repositories/credentials.repository.ts
@@ -32,6 +32,19 @@ export class CredentialsRepository extends Repository<CredentialsEntity> {
 		return await this.find(findManyOptions);
 	}
 
+	async findManyAndCount(
+		listQueryOptions?: ListQuery.Options & { includeData?: boolean; user?: User },
+		credentialIds?: string[],
+	): Promise<[CredentialsEntity[], number]> {
+		const findManyOptions = this.toFindManyOptions(listQueryOptions);
+
+		if (credentialIds) {
+			findManyOptions.where = { ...findManyOptions.where, id: In(credentialIds) };
+		}
+
+		return await this.findAndCount(findManyOptions);
+	}
+
 	private toFindManyOptions(listQueryOptions?: ListQuery.Options & { includeData?: boolean }) {
 		const findManyOptions: FindManyOptions<CredentialsEntity> = {};
 

--- a/packages/@n8n/db/src/repositories/credentials.repository.ts
+++ b/packages/@n8n/db/src/repositories/credentials.repository.ts
@@ -64,7 +64,14 @@ export class CredentialsRepository extends Repository<CredentialsEntity> {
 			'resolvableAllowFallback',
 		];
 
-		if (!listQueryOptions) return { select: defaultSelect, relations: defaultRelations };
+		const defaultOrder = { createdAt: 'DESC' as const };
+		if (!listQueryOptions) {
+			return {
+				select: defaultSelect,
+				relations: defaultRelations,
+				order: defaultOrder,
+			} as FindManyOptions<CredentialsEntity>;
+		}
 
 		const { filter, select, take, skip } = listQueryOptions;
 
@@ -90,6 +97,10 @@ export class CredentialsRepository extends Repository<CredentialsEntity> {
 		if (!findManyOptions.select) {
 			findManyOptions.select = defaultSelect;
 			findManyOptions.relations = defaultRelations;
+		}
+
+		if (!findManyOptions.order) {
+			findManyOptions.order = { createdAt: 'DESC' as const };
 		}
 
 		if (listQueryOptions.includeData) {

--- a/packages/@n8n/db/src/repositories/credentials.repository.ts
+++ b/packages/@n8n/db/src/repositories/credentials.repository.ts
@@ -20,7 +20,12 @@ export class CredentialsRepository extends Repository<CredentialsEntity> {
 	}
 
 	async findMany(
-		listQueryOptions?: ListQuery.Options & { includeData?: boolean; user?: User },
+		listQueryOptions?: ListQuery.Options & {
+			includeData?: boolean;
+			user?: User;
+			/** When provided, sets sort order for the query. */
+			order?: FindManyOptions<CredentialsEntity>['order'];
+		},
 		credentialIds?: string[],
 	) {
 		const findManyOptions = this.toFindManyOptions(listQueryOptions);
@@ -33,7 +38,12 @@ export class CredentialsRepository extends Repository<CredentialsEntity> {
 	}
 
 	async findManyAndCount(
-		listQueryOptions?: ListQuery.Options & { includeData?: boolean; user?: User },
+		listQueryOptions?: ListQuery.Options & {
+			includeData?: boolean;
+			user?: User;
+			/** When provided, sets sort order for the query. */
+			order?: FindManyOptions<CredentialsEntity>['order'];
+		},
 		credentialIds?: string[],
 	): Promise<[CredentialsEntity[], number]> {
 		const findManyOptions = this.toFindManyOptions(listQueryOptions);
@@ -45,7 +55,12 @@ export class CredentialsRepository extends Repository<CredentialsEntity> {
 		return await this.findAndCount(findManyOptions);
 	}
 
-	private toFindManyOptions(listQueryOptions?: ListQuery.Options & { includeData?: boolean }) {
+	private toFindManyOptions(
+		listQueryOptions?: ListQuery.Options & {
+			includeData?: boolean;
+			order?: FindManyOptions<CredentialsEntity>['order'];
+		},
+	) {
 		const findManyOptions: FindManyOptions<CredentialsEntity> = {};
 
 		type Select = Array<keyof CredentialsEntity>;
@@ -64,16 +79,14 @@ export class CredentialsRepository extends Repository<CredentialsEntity> {
 			'resolvableAllowFallback',
 		];
 
-		const defaultOrder = { createdAt: 'DESC' as const };
 		if (!listQueryOptions) {
 			return {
 				select: defaultSelect,
 				relations: defaultRelations,
-				order: defaultOrder,
 			} as FindManyOptions<CredentialsEntity>;
 		}
 
-		const { filter, select, take, skip } = listQueryOptions;
+		const { filter, select, take, skip, order } = listQueryOptions;
 
 		if (typeof filter?.name === 'string' && filter?.name !== '') {
 			filter.name = Like(`%${filter.name}%`);
@@ -99,8 +112,8 @@ export class CredentialsRepository extends Repository<CredentialsEntity> {
 			findManyOptions.relations = defaultRelations;
 		}
 
-		if (!findManyOptions.order) {
-			findManyOptions.order = { createdAt: 'DESC' as const };
+		if (order !== undefined) {
+			findManyOptions.order = order;
 		}
 
 		if (listQueryOptions.includeData) {

--- a/packages/@n8n/permissions/src/constants.ee.ts
+++ b/packages/@n8n/permissions/src/constants.ee.ts
@@ -66,7 +66,7 @@ export const API_KEY_RESOURCES = {
 	project: ['create', 'update', 'delete', 'list'] as const,
 	user: ['read', 'list', 'create', 'changeRole', 'delete', 'enforceMfa'] as const,
 	execution: ['delete', 'read', 'retry', 'list', 'get'] as const,
-	credential: ['create', 'update', 'move', 'delete'] as const,
+	credential: ['create', 'update', 'move', 'delete', 'list'] as const,
 	sourceControl: ['pull'] as const,
 	workflowTags: ['update', 'list'] as const,
 	dataTable: ['create', 'read', 'update', 'delete', 'list'] as const,

--- a/packages/@n8n/permissions/src/public-api-permissions.ee.ts
+++ b/packages/@n8n/permissions/src/public-api-permissions.ee.ts
@@ -46,6 +46,7 @@ export const OWNER_API_KEY_SCOPES: ApiKeyScope[] = [
 	'credential:update',
 	'credential:move',
 	'credential:delete',
+	'credential:list',
 	'dataTable:create',
 	'dataTable:read',
 	'dataTable:update',

--- a/packages/cli/src/public-api/types.ts
+++ b/packages/cli/src/public-api/types.ts
@@ -145,6 +145,13 @@ export declare namespace UserRequest {
 }
 
 export declare namespace CredentialRequest {
+	type GetAll = AuthenticatedRequest<
+		{},
+		{},
+		{},
+		{ limit?: number; cursor?: string; offset?: number }
+	>;
+
 	type Create = AuthenticatedRequest<
 		{},
 		{},

--- a/packages/cli/src/public-api/v1/handlers/credentials/spec/paths/credentials.yml
+++ b/packages/cli/src/public-api/v1/handlers/credentials/spec/paths/credentials.yml
@@ -1,3 +1,22 @@
+get:
+  x-eov-operation-id: getCredentials
+  x-eov-operation-handler: v1/handlers/credentials/credentials.handler
+  tags:
+    - Credential
+  summary: List credentials
+  description: Retrieve all credentials from your instance. Only available for the instance owner and admin. Credential data (secrets) is not included.
+  parameters:
+    - $ref: '../../../../shared/spec/parameters/limit.yml'
+    - $ref: '../../../../shared/spec/parameters/cursor.yml'
+  responses:
+    '200':
+      description: Operation successful.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/credentialList.yml'
+    '401':
+      $ref: '../../../../shared/spec/responses/unauthorized.yml'
 post:
   x-eov-operation-id: createCredential
   x-eov-operation-handler: v1/handlers/credentials/credentials.handler

--- a/packages/cli/src/public-api/v1/handlers/credentials/spec/paths/credentials.yml
+++ b/packages/cli/src/public-api/v1/handlers/credentials/spec/paths/credentials.yml
@@ -1,4 +1,5 @@
 get:
+  operationId: getCredentials
   x-eov-operation-id: getCredentials
   x-eov-operation-handler: v1/handlers/credentials/credentials.handler
   tags:
@@ -18,6 +19,7 @@ get:
     '401':
       $ref: '../../../../shared/spec/responses/unauthorized.yml'
 post:
+  operationId: createCredential
   x-eov-operation-id: createCredential
   x-eov-operation-handler: v1/handlers/credentials/credentials.handler
   tags:

--- a/packages/cli/src/public-api/v1/handlers/credentials/spec/schemas/credentialList.yml
+++ b/packages/cli/src/public-api/v1/handlers/credentials/spec/schemas/credentialList.yml
@@ -1,0 +1,11 @@
+type: object
+properties:
+  data:
+    type: array
+    items:
+      $ref: './create-credential-response.yml'
+  nextCursor:
+    type: string
+    description: Paginate through credentials by setting the cursor parameter to a nextCursor attribute returned by a previous request. Default value fetches the first "page" of the collection.
+    nullable: true
+    example: MTIzZTQ1NjctZTg5Yi0xMmQzLWE0NTYtNDI2NjE0MTc0MDA


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR adds a new `credentials:list` scope, and a new GET /credentials endpoint available on the public API. As a follow up, we will extend this endpoint to allow expansion in to sharing details 

## Related Linear tickets, Github issues, and Community forum posts

<img width="339" height="405" alt="image" src="https://github.com/user-attachments/assets/194cfd05-aceb-413d-a929-5873b2747805" />

IAM-172

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
