### PR TITLE
feat(editor): Auto-focus chat input when typing

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
@@ -67,6 +67,7 @@ import ChatGreetings from './components/ChatGreetings.vue';
 import { useChatPushHandler } from './composables/useChatPushHandler';
 import ChatArtifactViewer from './components/ChatArtifactViewer.vue';
 import { useChatArtifacts } from './composables/useChatArtifacts';
+import { useChatInputFocus } from './composables/useChatInputFocus';
 
 const router = useRouter();
 const route = useRoute();
@@ -343,6 +344,12 @@ const canAcceptFiles = computed(() => {
 });
 
 const fileDrop = useFileDrop(canAcceptFiles, onFilesDropped);
+
+// Enable "type-to-focus" behavior: when user starts typing anywhere in the view,
+// focus the chat input and insert the typed character
+useChatInputFocus(inputRef, {
+	disabled: computed(() => showWelcomeScreen.value === true || messagingState.value !== 'idle'),
+});
 
 function scrollToBottom(smooth: boolean) {
 	scrollContainerRef.value?.scrollTo({

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
@@ -345,8 +345,6 @@ const canAcceptFiles = computed(() => {
 
 const fileDrop = useFileDrop(canAcceptFiles, onFilesDropped);
 
-// Enable "type-to-focus" behavior: when user starts typing anywhere in the view,
-// focus the chat input and insert the typed character
 useChatInputFocus(inputRef, {
 	disabled: computed(() => showWelcomeScreen.value === true || messagingState.value !== 'idle'),
 });

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatPrompt.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatPrompt.vue
@@ -209,8 +209,8 @@ defineExpose({
 		committedSpokenMessage.value = '';
 		attachments.value = [];
 	},
-	setText: (text: string) => {
-		message.value = text;
+	appendText: (text: string) => {
+		message.value += text;
 	},
 	addAttachments: (files: File[]) => {
 		attachments.value.push(...files);

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatInputFocus.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatInputFocus.test.ts
@@ -28,10 +28,10 @@ describe('useChatInputFocus', () => {
 	let mockUIStore: { isAnyModalOpen: boolean };
 	let activeElementRef: ReturnType<typeof ref<HTMLElement | null>>;
 	let mockInputRef: ReturnType<
-		typeof ref<{ focus: () => void; setText: (text: string) => void } | null>
+		typeof ref<{ focus: () => void; appendText: (text: string) => void } | null>
 	>;
 	let focusSpy: ReturnType<typeof vi.fn>;
-	let setTextSpy: ReturnType<typeof vi.fn>;
+	let appendTextSpy: ReturnType<typeof vi.fn>;
 
 	function createKeyboardEvent(key: string, options: Partial<KeyboardEvent> = {}): KeyboardEvent {
 		return new KeyboardEvent('keydown', {
@@ -58,10 +58,10 @@ describe('useChatInputFocus', () => {
 		vi.mocked(useActiveElement).mockReturnValue(activeElementRef);
 
 		focusSpy = vi.fn();
-		setTextSpy = vi.fn();
+		appendTextSpy = vi.fn();
 		mockInputRef = ref({
 			focus: focusSpy,
-			setText: setTextSpy,
+			appendText: appendTextSpy,
 		});
 
 		vi.spyOn(canvasUtils, 'shouldIgnoreCanvasShortcut').mockReturnValue(false);
@@ -72,12 +72,12 @@ describe('useChatInputFocus', () => {
 	});
 
 	describe('basic functionality', () => {
-		it('should focus input and set text when printable key is pressed', () => {
+		it('should focus input and append text when printable key is pressed', () => {
 			useChatInputFocus(mockInputRef);
 
 			dispatchKeydown('a');
 
-			expect(setTextSpy).toHaveBeenCalledWith('a');
+			expect(appendTextSpy).toHaveBeenCalledWith('a');
 			expect(focusSpy).toHaveBeenCalled();
 		});
 
@@ -86,7 +86,7 @@ describe('useChatInputFocus', () => {
 
 			dispatchKeydown('A', { shiftKey: true });
 
-			expect(setTextSpy).toHaveBeenCalledWith('A');
+			expect(appendTextSpy).toHaveBeenCalledWith('A');
 			expect(focusSpy).toHaveBeenCalled();
 		});
 
@@ -95,7 +95,7 @@ describe('useChatInputFocus', () => {
 
 			dispatchKeydown('5');
 
-			expect(setTextSpy).toHaveBeenCalledWith('5');
+			expect(appendTextSpy).toHaveBeenCalledWith('5');
 			expect(focusSpy).toHaveBeenCalled();
 		});
 
@@ -104,7 +104,7 @@ describe('useChatInputFocus', () => {
 
 			dispatchKeydown('@');
 
-			expect(setTextSpy).toHaveBeenCalledWith('@');
+			expect(appendTextSpy).toHaveBeenCalledWith('@');
 			expect(focusSpy).toHaveBeenCalled();
 		});
 
@@ -125,7 +125,7 @@ describe('useChatInputFocus', () => {
 			dispatchKeydown('a');
 
 			expect(focusSpy).not.toHaveBeenCalled();
-			expect(setTextSpy).not.toHaveBeenCalled();
+			expect(appendTextSpy).not.toHaveBeenCalled();
 		});
 	});
 
@@ -136,7 +136,7 @@ describe('useChatInputFocus', () => {
 			dispatchKeydown('a', { ctrlKey: true });
 
 			expect(focusSpy).not.toHaveBeenCalled();
-			expect(setTextSpy).not.toHaveBeenCalled();
+			expect(appendTextSpy).not.toHaveBeenCalled();
 		});
 
 		it('should not trigger when Meta/Cmd key is pressed', () => {
@@ -145,7 +145,7 @@ describe('useChatInputFocus', () => {
 			dispatchKeydown('a', { metaKey: true });
 
 			expect(focusSpy).not.toHaveBeenCalled();
-			expect(setTextSpy).not.toHaveBeenCalled();
+			expect(appendTextSpy).not.toHaveBeenCalled();
 		});
 
 		it('should not trigger when Alt key is pressed', () => {
@@ -154,7 +154,7 @@ describe('useChatInputFocus', () => {
 			dispatchKeydown('a', { altKey: true });
 
 			expect(focusSpy).not.toHaveBeenCalled();
-			expect(setTextSpy).not.toHaveBeenCalled();
+			expect(appendTextSpy).not.toHaveBeenCalled();
 		});
 
 		it('should not trigger Ctrl+C (copy shortcut)', () => {
@@ -186,8 +186,19 @@ describe('useChatInputFocus', () => {
 
 			dispatchKeydown('A', { shiftKey: true });
 
-			expect(setTextSpy).toHaveBeenCalledWith('A');
+			expect(appendTextSpy).toHaveBeenCalledWith('A');
 			expect(focusSpy).toHaveBeenCalled();
+		});
+
+		it('should append multiple characters on consecutive keypresses', () => {
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('h');
+			dispatchKeydown('i');
+
+			expect(appendTextSpy).toHaveBeenCalledTimes(2);
+			expect(appendTextSpy).toHaveBeenNthCalledWith(1, 'h');
+			expect(appendTextSpy).toHaveBeenNthCalledWith(2, 'i');
 		});
 	});
 
@@ -351,7 +362,7 @@ describe('useChatInputFocus', () => {
 			await nextTick();
 
 			dispatchKeydown('b');
-			expect(setTextSpy).toHaveBeenCalledWith('b');
+			expect(appendTextSpy).toHaveBeenCalledWith('b');
 			expect(focusSpy).toHaveBeenCalled();
 		});
 

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatInputFocus.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatInputFocus.test.ts
@@ -439,5 +439,14 @@ describe('useChatInputFocus', () => {
 
 			expect(focusSpy).not.toHaveBeenCalled();
 		});
+
+		it('should not interfere with [ (collapse sidebar shortcut)', () => {
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('[');
+
+			expect(focusSpy).not.toHaveBeenCalled();
+			expect(appendTextSpy).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatInputFocus.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatInputFocus.test.ts
@@ -1,0 +1,432 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ref, nextTick } from 'vue';
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
+import { useChatInputFocus } from './useChatInputFocus';
+import { useUIStore } from '@/app/stores/ui.store';
+import * as canvasUtils from '@/features/workflows/canvas/canvas.utils';
+
+vi.mock('@/app/stores/ui.store', () => ({
+	useUIStore: vi.fn(),
+}));
+
+vi.mock('@vueuse/core', async () => {
+	const actual = await vi.importActual('@vueuse/core');
+	return {
+		...actual,
+		useActiveElement: vi.fn(),
+		useEventListener: vi.fn((target, event, handler) => {
+			target.addEventListener(event, handler);
+			return () => target.removeEventListener(event, handler);
+		}),
+	};
+});
+
+import { useActiveElement } from '@vueuse/core';
+
+describe('useChatInputFocus', () => {
+	let mockUIStore: { isAnyModalOpen: boolean };
+	let activeElementRef: ReturnType<typeof ref<HTMLElement | null>>;
+	let mockInputRef: ReturnType<
+		typeof ref<{ focus: () => void; setText: (text: string) => void } | null>
+	>;
+	let focusSpy: ReturnType<typeof vi.fn>;
+	let setTextSpy: ReturnType<typeof vi.fn>;
+
+	function createKeyboardEvent(key: string, options: Partial<KeyboardEvent> = {}): KeyboardEvent {
+		return new KeyboardEvent('keydown', {
+			key,
+			bubbles: true,
+			cancelable: true,
+			...options,
+		});
+	}
+
+	function dispatchKeydown(key: string, options: Partial<KeyboardEvent> = {}) {
+		const event = createKeyboardEvent(key, options);
+		document.dispatchEvent(event);
+		return event;
+	}
+
+	beforeEach(() => {
+		setActivePinia(createTestingPinia());
+
+		mockUIStore = { isAnyModalOpen: false };
+		vi.mocked(useUIStore).mockReturnValue(mockUIStore as ReturnType<typeof useUIStore>);
+
+		activeElementRef = ref<HTMLElement | null>(document.body);
+		vi.mocked(useActiveElement).mockReturnValue(activeElementRef);
+
+		focusSpy = vi.fn();
+		setTextSpy = vi.fn();
+		mockInputRef = ref({
+			focus: focusSpy,
+			setText: setTextSpy,
+		});
+
+		vi.spyOn(canvasUtils, 'shouldIgnoreCanvasShortcut').mockReturnValue(false);
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('basic functionality', () => {
+		it('should focus input and set text when printable key is pressed', () => {
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('a');
+
+			expect(setTextSpy).toHaveBeenCalledWith('a');
+			expect(focusSpy).toHaveBeenCalled();
+		});
+
+		it('should handle uppercase letters', () => {
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('A', { shiftKey: true });
+
+			expect(setTextSpy).toHaveBeenCalledWith('A');
+			expect(focusSpy).toHaveBeenCalled();
+		});
+
+		it('should handle numbers', () => {
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('5');
+
+			expect(setTextSpy).toHaveBeenCalledWith('5');
+			expect(focusSpy).toHaveBeenCalled();
+		});
+
+		it('should handle special characters', () => {
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('@');
+
+			expect(setTextSpy).toHaveBeenCalledWith('@');
+			expect(focusSpy).toHaveBeenCalled();
+		});
+
+		it('should prevent default behavior', () => {
+			useChatInputFocus(mockInputRef);
+
+			const event = createKeyboardEvent('a');
+			const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
+			document.dispatchEvent(event);
+
+			expect(preventDefaultSpy).toHaveBeenCalled();
+		});
+
+		it('should not do anything if inputRef is null', () => {
+			const nullInputRef = ref(null);
+			useChatInputFocus(nullInputRef);
+
+			dispatchKeydown('a');
+
+			expect(focusSpy).not.toHaveBeenCalled();
+			expect(setTextSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('modifier keys', () => {
+		it('should not trigger when Ctrl key is pressed', () => {
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('a', { ctrlKey: true });
+
+			expect(focusSpy).not.toHaveBeenCalled();
+			expect(setTextSpy).not.toHaveBeenCalled();
+		});
+
+		it('should not trigger when Meta/Cmd key is pressed', () => {
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('a', { metaKey: true });
+
+			expect(focusSpy).not.toHaveBeenCalled();
+			expect(setTextSpy).not.toHaveBeenCalled();
+		});
+
+		it('should not trigger when Alt key is pressed', () => {
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('a', { altKey: true });
+
+			expect(focusSpy).not.toHaveBeenCalled();
+			expect(setTextSpy).not.toHaveBeenCalled();
+		});
+
+		it('should not trigger Ctrl+C (copy shortcut)', () => {
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('c', { ctrlKey: true });
+
+			expect(focusSpy).not.toHaveBeenCalled();
+		});
+
+		it('should not trigger Cmd+V (paste shortcut)', () => {
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('v', { metaKey: true });
+
+			expect(focusSpy).not.toHaveBeenCalled();
+		});
+
+		it('should not trigger Ctrl+Z (undo shortcut)', () => {
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('z', { ctrlKey: true });
+
+			expect(focusSpy).not.toHaveBeenCalled();
+		});
+
+		it('should trigger with Shift key (for uppercase)', () => {
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('A', { shiftKey: true });
+
+			expect(setTextSpy).toHaveBeenCalledWith('A');
+			expect(focusSpy).toHaveBeenCalled();
+		});
+	});
+
+	describe('non-printable keys', () => {
+		it('should not trigger on Enter key', () => {
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('Enter');
+
+			expect(focusSpy).not.toHaveBeenCalled();
+		});
+
+		it('should not trigger on Escape key', () => {
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('Escape');
+
+			expect(focusSpy).not.toHaveBeenCalled();
+		});
+
+		it('should not trigger on ArrowUp key', () => {
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('ArrowUp');
+
+			expect(focusSpy).not.toHaveBeenCalled();
+		});
+
+		it('should not trigger on ArrowDown key', () => {
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('ArrowDown');
+
+			expect(focusSpy).not.toHaveBeenCalled();
+		});
+
+		it('should not trigger on Tab key', () => {
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('Tab');
+
+			expect(focusSpy).not.toHaveBeenCalled();
+		});
+
+		it('should not trigger on Backspace key', () => {
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('Backspace');
+
+			expect(focusSpy).not.toHaveBeenCalled();
+		});
+
+		it('should not trigger on Delete key', () => {
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('Delete');
+
+			expect(focusSpy).not.toHaveBeenCalled();
+		});
+
+		it('should not trigger on F1 function key', () => {
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('F1');
+
+			expect(focusSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('form field focus detection', () => {
+		it('should not trigger when focused on input element', () => {
+			vi.mocked(canvasUtils.shouldIgnoreCanvasShortcut).mockReturnValue(true);
+
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('a');
+
+			expect(focusSpy).not.toHaveBeenCalled();
+		});
+
+		it('should not trigger when focused on textarea element', () => {
+			vi.mocked(canvasUtils.shouldIgnoreCanvasShortcut).mockReturnValue(true);
+
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('a');
+
+			expect(focusSpy).not.toHaveBeenCalled();
+		});
+
+		it('should not trigger when focused on contenteditable element', () => {
+			vi.mocked(canvasUtils.shouldIgnoreCanvasShortcut).mockReturnValue(true);
+
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('a');
+
+			expect(focusSpy).not.toHaveBeenCalled();
+		});
+
+		it('should not trigger when focused inside .ignore-key-press-canvas', () => {
+			vi.mocked(canvasUtils.shouldIgnoreCanvasShortcut).mockReturnValue(true);
+
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('a');
+
+			expect(focusSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('modal detection', () => {
+		it('should not trigger when a modal is open', () => {
+			mockUIStore.isAnyModalOpen = true;
+
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('a');
+
+			expect(focusSpy).not.toHaveBeenCalled();
+		});
+
+		it('should trigger when modal is closed', () => {
+			mockUIStore.isAnyModalOpen = false;
+
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('a');
+
+			expect(focusSpy).toHaveBeenCalled();
+		});
+	});
+
+	describe('disabled option', () => {
+		it('should not trigger when disabled is true', async () => {
+			const disabled = ref(true);
+			useChatInputFocus(mockInputRef, { disabled });
+
+			dispatchKeydown('a');
+
+			expect(focusSpy).not.toHaveBeenCalled();
+		});
+
+		it('should trigger when disabled is false', async () => {
+			const disabled = ref(false);
+			useChatInputFocus(mockInputRef, { disabled });
+
+			dispatchKeydown('a');
+
+			expect(focusSpy).toHaveBeenCalled();
+		});
+
+		it('should react to disabled state changes', async () => {
+			const disabled = ref(true);
+			useChatInputFocus(mockInputRef, { disabled });
+
+			dispatchKeydown('a');
+			expect(focusSpy).not.toHaveBeenCalled();
+
+			disabled.value = false;
+			await nextTick();
+
+			dispatchKeydown('b');
+			expect(setTextSpy).toHaveBeenCalledWith('b');
+			expect(focusSpy).toHaveBeenCalled();
+		});
+
+		it('should work with getter function for disabled', () => {
+			const disabledState = ref(false);
+			useChatInputFocus(mockInputRef, { disabled: () => disabledState.value });
+
+			dispatchKeydown('a');
+			expect(focusSpy).toHaveBeenCalled();
+
+			focusSpy.mockClear();
+			disabledState.value = true;
+
+			dispatchKeydown('b');
+			expect(focusSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('IME composition', () => {
+		it('should not trigger during IME composition', () => {
+			useChatInputFocus(mockInputRef);
+
+			const event = new KeyboardEvent('keydown', {
+				key: 'a',
+				bubbles: true,
+				cancelable: true,
+			});
+			Object.defineProperty(event, 'isComposing', { value: true });
+			document.dispatchEvent(event);
+
+			expect(focusSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('key repeat', () => {
+		it('should not trigger on key repeat', () => {
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('a', { repeat: true });
+
+			expect(focusSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('shortcut conflicts', () => {
+		it('should not interfere with Ctrl+A (select all)', () => {
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('a', { ctrlKey: true });
+
+			expect(focusSpy).not.toHaveBeenCalled();
+		});
+
+		it('should not interfere with Cmd+S (save)', () => {
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('s', { metaKey: true });
+
+			expect(focusSpy).not.toHaveBeenCalled();
+		});
+
+		it('should not interfere with Alt+Tab', () => {
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('Tab', { altKey: true });
+
+			expect(focusSpy).not.toHaveBeenCalled();
+		});
+
+		it('should not interfere with Ctrl+Shift+T (reopen tab)', () => {
+			useChatInputFocus(mockInputRef);
+
+			dispatchKeydown('t', { ctrlKey: true, shiftKey: true });
+
+			expect(focusSpy).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatInputFocus.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatInputFocus.ts
@@ -1,8 +1,9 @@
+import { computed, toValue } from 'vue';
+import type { MaybeRefOrGetter, Ref } from 'vue';
+import { useActiveElement, useEventListener } from '@vueuse/core';
+
 import { shouldIgnoreCanvasShortcut } from '@/features/workflows/canvas/canvas.utils';
 import { useUIStore } from '@/app/stores/ui.store';
-import { useActiveElement, useEventListener } from '@vueuse/core';
-import type { MaybeRefOrGetter, Ref } from 'vue';
-import { computed, toValue } from 'vue';
 
 interface ChatInputRef {
 	focus: () => void;
@@ -27,15 +28,15 @@ export function useChatInputFocus(
 		return false;
 	});
 
-	function isPrintableKey(event: KeyboardEvent): boolean {
+	const isPrintableKey = (event: KeyboardEvent): boolean => {
 		return event.key.length === 1;
-	}
+	};
 
-	function hasModifierKey(event: KeyboardEvent): boolean {
+	const hasModifierKey = (event: KeyboardEvent): boolean => {
 		return event.ctrlKey || event.metaKey || event.altKey;
-	}
+	};
 
-	function onKeyDown(event: KeyboardEvent) {
+	const onKeyDown = (event: KeyboardEvent) => {
 		if (shouldIgnoreKeypress.value) return;
 		if (event.isComposing) return;
 		if (event.repeat) return;
@@ -48,7 +49,7 @@ export function useChatInputFocus(
 		event.preventDefault();
 		input.setText(event.key);
 		input.focus();
-	}
+	};
 
 	useEventListener(document, 'keydown', onKeyDown);
 }

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatInputFocus.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatInputFocus.ts
@@ -7,7 +7,7 @@ import { useUIStore } from '@/app/stores/ui.store';
 
 interface ChatInputRef {
 	focus: () => void;
-	setText: (text: string) => void;
+	appendText: (text: string) => void;
 }
 
 export function useChatInputFocus(
@@ -47,7 +47,7 @@ export function useChatInputFocus(
 		if (!input) return;
 
 		event.preventDefault();
-		input.setText(event.key);
+		input.appendText(event.key);
 		input.focus();
 	};
 

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatInputFocus.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatInputFocus.ts
@@ -28,8 +28,14 @@ export function useChatInputFocus(
 		return false;
 	});
 
+	const RESERVED_SHORTCUT_KEYS = ['['];
+
 	const isPrintableKey = (event: KeyboardEvent): boolean => {
 		return event.key.length === 1;
+	};
+
+	const isReservedShortcut = (event: KeyboardEvent): boolean => {
+		return RESERVED_SHORTCUT_KEYS.includes(event.key);
 	};
 
 	const hasModifierKey = (event: KeyboardEvent): boolean => {
@@ -42,6 +48,7 @@ export function useChatInputFocus(
 		if (event.repeat) return;
 		if (hasModifierKey(event)) return;
 		if (!isPrintableKey(event)) return;
+		if (isReservedShortcut(event)) return;
 
 		const input = inputRef.value;
 		if (!input) return;

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatInputFocus.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatInputFocus.ts
@@ -1,0 +1,73 @@
+import { shouldIgnoreCanvasShortcut } from '@/features/workflows/canvas/canvas.utils';
+import { useUIStore } from '@/app/stores/ui.store';
+import { useActiveElement, useEventListener } from '@vueuse/core';
+import type { MaybeRefOrGetter, Ref } from 'vue';
+import { computed, toValue } from 'vue';
+
+interface ChatInputRef {
+	focus: () => void;
+	setText: (text: string) => void;
+}
+
+/**
+ * Composable that enables "type-to-focus" behavior for the chat input.
+ * When the user starts typing anywhere in the view (and isn't already
+ * focused on an input), the chat input will be focused and the typed
+ * character will be inserted.
+ *
+ * Guards:
+ * - Skips if user is focused on input/textarea/contenteditable
+ * - Skips if any modal is open
+ * - Skips modifier key combinations (Ctrl/Cmd/Alt)
+ * - Skips non-printable keys (arrows, escape, etc.)
+ * - Skips during IME composition
+ */
+export function useChatInputFocus(
+	inputRef: Ref<ChatInputRef | null | undefined>,
+	options?: {
+		disabled?: MaybeRefOrGetter<boolean>;
+	},
+) {
+	const uiStore = useUIStore();
+	const activeElement = useActiveElement();
+
+	const isDisabled = computed(() => toValue(options?.disabled) ?? false);
+
+	const shouldIgnoreKeypress = computed(() => {
+		if (isDisabled.value) return true;
+		if (uiStore.isAnyModalOpen) return true;
+		if (activeElement.value && shouldIgnoreCanvasShortcut(activeElement.value)) return true;
+		return false;
+	});
+
+	function isPrintableKey(event: KeyboardEvent): boolean {
+		// Printable characters have a key length of 1
+		// This excludes special keys like "Enter", "Escape", "ArrowUp", etc.
+		return event.key.length === 1;
+	}
+
+	function hasModifierKey(event: KeyboardEvent): boolean {
+		// Skip if any modifier key is pressed (except Shift, which is needed for uppercase/symbols)
+		return event.ctrlKey || event.metaKey || event.altKey;
+	}
+
+	function onKeyDown(event: KeyboardEvent) {
+		if (shouldIgnoreKeypress.value) return;
+		if (event.isComposing) return;
+		if (event.repeat) return;
+		if (hasModifierKey(event)) return;
+		if (!isPrintableKey(event)) return;
+
+		const input = inputRef.value;
+		if (!input) return;
+
+		// Prevent the default behavior and handle it ourselves
+		event.preventDefault();
+
+		// Set the typed character and focus the input
+		input.setText(event.key);
+		input.focus();
+	}
+
+	useEventListener(document, 'keydown', onKeyDown);
+}

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatInputFocus.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatInputFocus.ts
@@ -9,19 +9,6 @@ interface ChatInputRef {
 	setText: (text: string) => void;
 }
 
-/**
- * Composable that enables "type-to-focus" behavior for the chat input.
- * When the user starts typing anywhere in the view (and isn't already
- * focused on an input), the chat input will be focused and the typed
- * character will be inserted.
- *
- * Guards:
- * - Skips if user is focused on input/textarea/contenteditable
- * - Skips if any modal is open
- * - Skips modifier key combinations (Ctrl/Cmd/Alt)
- * - Skips non-printable keys (arrows, escape, etc.)
- * - Skips during IME composition
- */
 export function useChatInputFocus(
 	inputRef: Ref<ChatInputRef | null | undefined>,
 	options?: {
@@ -41,13 +28,10 @@ export function useChatInputFocus(
 	});
 
 	function isPrintableKey(event: KeyboardEvent): boolean {
-		// Printable characters have a key length of 1
-		// This excludes special keys like "Enter", "Escape", "ArrowUp", etc.
 		return event.key.length === 1;
 	}
 
 	function hasModifierKey(event: KeyboardEvent): boolean {
-		// Skip if any modifier key is pressed (except Shift, which is needed for uppercase/symbols)
 		return event.ctrlKey || event.metaKey || event.altKey;
 	}
 
@@ -61,10 +45,7 @@ export function useChatInputFocus(
 		const input = inputRef.value;
 		if (!input) return;
 
-		// Prevent the default behavior and handle it ourselves
 		event.preventDefault();
-
-		// Set the typed character and focus the input
 		input.setText(event.key);
 		input.focus();
 	}


### PR DESCRIPTION
## Summary

Implements "type-to-focus" behavior for the chat input. When users start typing anywhere in the chat view (without being focused on another input), the chat input is automatically focused and the typed character is inserted.

This matches the UX pattern used by ChatGPT and similar chat applications, making interaction more seamless. Means you can start a chat without ever touching your mouse oh yeah!

### How it works:
- Listens for `keydown` events at the document level
- Guards against:
  - User already focused on input/textarea/contenteditable
  - Any modal being open
  - Modifier key combinations (Ctrl/Cmd/Alt)
  - Non-printable keys (arrows, escape, etc.)
  - IME composition
  - Welcome screen or non-idle messaging states


https://github.com/user-attachments/assets/47d9c86b-7000-426a-bd74-0183f2bd2c94


### How to test:
1. Open the chat view
2. Click somewhere outside the chat input (e.g., on a message or empty space)
3. Start typing - the input should auto-focus and capture the typed character

## Tests

Added 37 unit tests for `useChatInputFocus` composable covering:

| Category | Tests |
|----------|-------|
| Basic functionality | 6 tests - printable keys, uppercase, numbers, special chars, preventDefault, null ref |
| Modifier keys | 7 tests - Ctrl, Meta/Cmd, Alt blocked; Shift allowed; common shortcuts (Ctrl+C, Cmd+V, Ctrl+Z) |
| Non-printable keys | 8 tests - Enter, Escape, arrows, Tab, Backspace, Delete, function keys |
| Form field focus | 4 tests - input, textarea, contenteditable, .ignore-key-press-canvas |
| Modal detection | 2 tests - blocked when modal open, allowed when closed |
| Disabled option | 4 tests - ref, getter function, reactive state changes |
| IME composition | 1 test - blocked during composition |
| Key repeat | 1 test - blocked on repeat |
| Shortcut conflicts | 4 tests - Ctrl+A, Cmd+S, Alt+Tab, Ctrl+Shift+T |

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-112

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)