### PR TITLE
fix(Data Table Node): Fallback to workflow-derived projectId if undefined

### DIFF
--- a/packages/@n8n/api-types/src/dto/dynamic-node-parameters/base-dynamic-parameters-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/dynamic-node-parameters/base-dynamic-parameters-request.dto.ts
@@ -16,4 +16,5 @@ export class BaseDynamicParametersRequestDto extends Z.class({
 		INodeCredentials | undefined
 	>,
 	projectId: z.string().optional(),
+	workflowId: z.string().optional(),
 }) {}

--- a/packages/cli/src/controllers/dynamic-node-parameters.controller.ts
+++ b/packages/cli/src/controllers/dynamic-node-parameters.controller.ts
@@ -13,7 +13,7 @@ import { getBase } from '@/workflow-execute-additional-data';
 
 @RestController('/dynamic-node-parameters')
 export class DynamicNodeParametersController {
-	constructor(private readonly service: DynamicNodeParametersService) {}
+	constructor(private readonly dynamicNodeParametersService: DynamicNodeParametersService) {}
 
 	@Post('/options')
 	async getOptions(
@@ -21,7 +21,7 @@ export class DynamicNodeParametersController {
 		_res: Response,
 		@Body payload: OptionsRequestDto,
 	): Promise<INodePropertyOptions[]> {
-		await this.service.refineResourceIds(req.user, payload);
+		await this.dynamicNodeParametersService.refineResourceIds(req.user, payload);
 
 		const {
 			credentials,
@@ -41,7 +41,7 @@ export class DynamicNodeParametersController {
 		additionalData.dataTableProjectId = projectId;
 
 		if (methodName) {
-			return await this.service.getOptionsViaMethodName(
+			return await this.dynamicNodeParametersService.getOptionsViaMethodName(
 				methodName,
 				path,
 				additionalData,
@@ -52,7 +52,7 @@ export class DynamicNodeParametersController {
 		}
 
 		if (loadOptions) {
-			return await this.service.getOptionsViaLoadOptions(
+			return await this.dynamicNodeParametersService.getOptionsViaLoadOptions(
 				loadOptions,
 				additionalData,
 				nodeTypeAndVersion,
@@ -70,7 +70,7 @@ export class DynamicNodeParametersController {
 		_res: Response,
 		@Body payload: ResourceLocatorRequestDto,
 	) {
-		await this.service.refineResourceIds(req.user, payload);
+		await this.dynamicNodeParametersService.refineResourceIds(req.user, payload);
 
 		const {
 			path,
@@ -90,7 +90,7 @@ export class DynamicNodeParametersController {
 		});
 		additionalData.dataTableProjectId = projectId;
 
-		return await this.service.getResourceLocatorResults(
+		return await this.dynamicNodeParametersService.getResourceLocatorResults(
 			methodName,
 			path,
 			additionalData,
@@ -108,7 +108,7 @@ export class DynamicNodeParametersController {
 		_res: Response,
 		@Body payload: ResourceMapperFieldsRequestDto,
 	) {
-		await this.service.refineResourceIds(req.user, payload);
+		await this.dynamicNodeParametersService.refineResourceIds(req.user, payload);
 
 		const { path, methodName, credentials, currentNodeParameters, nodeTypeAndVersion, projectId } =
 			payload;
@@ -120,7 +120,7 @@ export class DynamicNodeParametersController {
 		});
 		additionalData.dataTableProjectId = projectId;
 
-		return await this.service.getResourceMappingFields(
+		return await this.dynamicNodeParametersService.getResourceMappingFields(
 			methodName,
 			path,
 			additionalData,
@@ -136,7 +136,7 @@ export class DynamicNodeParametersController {
 		_res: Response,
 		@Body payload: ResourceMapperFieldsRequestDto,
 	) {
-		await this.service.refineResourceIds(req.user, payload);
+		await this.dynamicNodeParametersService.refineResourceIds(req.user, payload);
 
 		const { path, methodName, currentNodeParameters, nodeTypeAndVersion, projectId } = payload;
 
@@ -146,7 +146,7 @@ export class DynamicNodeParametersController {
 			projectId,
 		});
 
-		return await this.service.getLocalResourceMappingFields(
+		return await this.dynamicNodeParametersService.getLocalResourceMappingFields(
 			methodName,
 			path,
 			additionalData,
@@ -160,7 +160,7 @@ export class DynamicNodeParametersController {
 		_res: Response,
 		@Body payload: ActionResultRequestDto,
 	): Promise<NodeParameterValueType> {
-		await this.service.refineResourceIds(req.user, payload);
+		await this.dynamicNodeParametersService.refineResourceIds(req.user, payload);
 
 		const {
 			currentNodeParameters,
@@ -178,7 +178,7 @@ export class DynamicNodeParametersController {
 			currentNodeParameters,
 		});
 
-		return await this.service.getActionResult(
+		return await this.dynamicNodeParametersService.getActionResult(
 			handler,
 			path,
 			additionalData,

--- a/packages/cli/src/controllers/dynamic-node-parameters.controller.ts
+++ b/packages/cli/src/controllers/dynamic-node-parameters.controller.ts
@@ -21,7 +21,7 @@ export class DynamicNodeParametersController {
 		_res: Response,
 		@Body payload: OptionsRequestDto,
 	): Promise<INodePropertyOptions[]> {
-		await this.service.refineProjectId(req.user, payload);
+		await this.service.refineResourceIds(req.user, payload);
 
 		const {
 			credentials,
@@ -70,7 +70,7 @@ export class DynamicNodeParametersController {
 		_res: Response,
 		@Body payload: ResourceLocatorRequestDto,
 	) {
-		await this.service.refineProjectId(req.user, payload);
+		await this.service.refineResourceIds(req.user, payload);
 
 		const {
 			path,
@@ -108,7 +108,7 @@ export class DynamicNodeParametersController {
 		_res: Response,
 		@Body payload: ResourceMapperFieldsRequestDto,
 	) {
-		await this.service.refineProjectId(req.user, payload);
+		await this.service.refineResourceIds(req.user, payload);
 
 		const { path, methodName, credentials, currentNodeParameters, nodeTypeAndVersion, projectId } =
 			payload;
@@ -136,7 +136,7 @@ export class DynamicNodeParametersController {
 		_res: Response,
 		@Body payload: ResourceMapperFieldsRequestDto,
 	) {
-		await this.service.refineProjectId(req.user, payload);
+		await this.service.refineResourceIds(req.user, payload);
 
 		const { path, methodName, currentNodeParameters, nodeTypeAndVersion, projectId } = payload;
 
@@ -160,7 +160,7 @@ export class DynamicNodeParametersController {
 		_res: Response,
 		@Body payload: ActionResultRequestDto,
 	): Promise<NodeParameterValueType> {
-		await this.service.refineProjectId(req.user, payload);
+		await this.service.refineResourceIds(req.user, payload);
 
 		const {
 			currentNodeParameters,

--- a/packages/cli/src/controllers/dynamic-node-parameters.controller.ts
+++ b/packages/cli/src/controllers/dynamic-node-parameters.controller.ts
@@ -21,7 +21,7 @@ export class DynamicNodeParametersController {
 		_res: Response,
 		@Body payload: OptionsRequestDto,
 	): Promise<INodePropertyOptions[]> {
-		await this.service.scrubInaccessibleProjectId(req.user, payload);
+		await this.service.refineProjectId(req.user, payload);
 
 		const {
 			credentials,
@@ -70,7 +70,7 @@ export class DynamicNodeParametersController {
 		_res: Response,
 		@Body payload: ResourceLocatorRequestDto,
 	) {
-		await this.service.scrubInaccessibleProjectId(req.user, payload);
+		await this.service.refineProjectId(req.user, payload);
 
 		const {
 			path,
@@ -108,7 +108,7 @@ export class DynamicNodeParametersController {
 		_res: Response,
 		@Body payload: ResourceMapperFieldsRequestDto,
 	) {
-		await this.service.scrubInaccessibleProjectId(req.user, payload);
+		await this.service.refineProjectId(req.user, payload);
 
 		const { path, methodName, credentials, currentNodeParameters, nodeTypeAndVersion, projectId } =
 			payload;
@@ -136,7 +136,7 @@ export class DynamicNodeParametersController {
 		_res: Response,
 		@Body payload: ResourceMapperFieldsRequestDto,
 	) {
-		await this.service.scrubInaccessibleProjectId(req.user, payload);
+		await this.service.refineProjectId(req.user, payload);
 
 		const { path, methodName, currentNodeParameters, nodeTypeAndVersion, projectId } = payload;
 
@@ -160,7 +160,7 @@ export class DynamicNodeParametersController {
 		_res: Response,
 		@Body payload: ActionResultRequestDto,
 	): Promise<NodeParameterValueType> {
-		await this.service.scrubInaccessibleProjectId(req.user, payload);
+		await this.service.refineProjectId(req.user, payload);
 
 		const {
 			currentNodeParameters,

--- a/packages/cli/src/services/__tests__/dynamic-node-parameters.service.test.ts
+++ b/packages/cli/src/services/__tests__/dynamic-node-parameters.service.test.ts
@@ -12,12 +12,19 @@ import { DynamicNodeParametersService } from '../dynamic-node-parameters.service
 import { WorkflowLoaderService } from '../workflow-loader.service';
 
 import { NodeTypes } from '@/node-types';
+import { SharedWorkflowRepository } from '@n8n/db';
 
 describe('DynamicNodeParametersService', () => {
 	const logger = mockInstance(Logger);
 	const nodeTypes = mockInstance(NodeTypes);
 	const workflowLoaderService = mockInstance(WorkflowLoaderService);
-	const service = new DynamicNodeParametersService(logger, nodeTypes, workflowLoaderService);
+	const sharedWorkflowRepository = mockInstance(SharedWorkflowRepository);
+	const service = new DynamicNodeParametersService(
+		logger,
+		nodeTypes,
+		workflowLoaderService,
+		sharedWorkflowRepository,
+	);
 
 	beforeEach(() => {
 		jest.resetAllMocks();

--- a/packages/cli/src/services/dynamic-node-parameters.service.ts
+++ b/packages/cli/src/services/dynamic-node-parameters.service.ts
@@ -57,10 +57,10 @@ export class DynamicNodeParametersService {
 		private logger: Logger,
 		private nodeTypes: NodeTypes,
 		private workflowLoaderService: WorkflowLoaderService,
-		private shared: SharedWorkflowRepository,
+		private sharedWorkflowRepository: SharedWorkflowRepository,
 	) {}
 
-	async refineProjectId(user: User, payload: { projectId?: string; workflowId?: string }) {
+	async refineResourceIds(user: User, payload: { projectId?: string; workflowId?: string }) {
 		// We want to avoid relying on generic project:read permissions to enable
 		// a future with fine-grained permission control dependent on the respective resource
 		// For now we use the dataTable:listProject scope as this is the existing consumer of
@@ -88,7 +88,9 @@ export class DynamicNodeParametersService {
 				);
 				payload.workflowId = undefined;
 			} else if (payload.projectId === undefined) {
-				const project = await this.shared.getWorkflowOwningProject(payload.workflowId);
+				const project = await this.sharedWorkflowRepository.getWorkflowOwningProject(
+					payload.workflowId,
+				);
 				if (project) {
 					payload.projectId = project.id;
 				}

--- a/packages/cli/src/services/dynamic-node-parameters.service.ts
+++ b/packages/cli/src/services/dynamic-node-parameters.service.ts
@@ -25,7 +25,7 @@ import { Workflow, UnexpectedError, createEmptyRunExecutionData } from 'n8n-work
 import { NodeTypes } from '@/node-types';
 
 import { WorkflowLoaderService } from './workflow-loader.service';
-import { User } from '@n8n/db';
+import { SharedWorkflowRepository, User } from '@n8n/db';
 import { userHasScopes } from '@/permissions.ee/check-access';
 import { Logger } from '@n8n/backend-common';
 
@@ -57,9 +57,10 @@ export class DynamicNodeParametersService {
 		private logger: Logger,
 		private nodeTypes: NodeTypes,
 		private workflowLoaderService: WorkflowLoaderService,
+		private shared: SharedWorkflowRepository,
 	) {}
 
-	async scrubInaccessibleProjectId(user: User, payload: { projectId?: string }) {
+	async refineProjectId(user: User, payload: { projectId?: string; workflowId?: string }) {
 		// We want to avoid relying on generic project:read permissions to enable
 		// a future with fine-grained permission control dependent on the respective resource
 		// For now we use the dataTable:listProject scope as this is the existing consumer of
@@ -74,6 +75,24 @@ export class DynamicNodeParametersService {
 				`Scrubbed inaccessible projectId ${payload.projectId} from DynamicNodeParameters request`,
 			);
 			payload.projectId = undefined;
+		}
+
+		if (payload.workflowId) {
+			if (
+				!(await userHasScopes(user, ['workflow:read'], false, {
+					workflowId: payload.workflowId,
+				}))
+			) {
+				this.logger.warn(
+					`Scrubbed inaccessible workflowId ${payload.workflowId} from DynamicNodeParameters request`,
+				);
+				payload.workflowId = undefined;
+			} else if (payload.projectId === undefined) {
+				const project = await this.shared.getWorkflowOwningProject(payload.workflowId);
+				if (project) {
+					payload.projectId = project.id;
+				}
+			}
 		}
 	}
 

--- a/packages/frontend/editor-ui/src/app/components/FromAiParametersModal.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/FromAiParametersModal.test.ts
@@ -8,13 +8,14 @@ import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useAgentRequestStore } from '@n8n/stores/useAgentRequestStore';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { useRouter } from 'vue-router';
-import type { Workflow } from 'n8n-workflow';
+import { Workflow } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { nextTick } from 'vue';
 import { mock } from 'vitest-mock-extended';
 import { createTestWorkflow } from '@/__tests__/mocks';
 import { type MockedStore, mockedStore } from '@/__tests__/utils';
+import { IWorkflowDb } from '@/Interface';
 
 const ModalStub = {
 	template: `
@@ -126,6 +127,7 @@ describe('FromAiParametersModal', () => {
 			},
 		});
 		workflowsStore = useWorkflowsStore();
+		workflowsStore.workflow = mock<IWorkflowDb>({ id: 'test-wf-id' });
 		workflowsStore.getNodeByName = vi.fn().mockImplementation((name: string) => {
 			switch (name) {
 				case 'Test Node':
@@ -326,6 +328,7 @@ describe('FromAiParametersModal', () => {
 			currentNodeParameters: {},
 			credentials: undefined,
 			projectId: 'test-project-id',
+			workflowId: 'test-wf-id',
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/components/FromAiParametersModal.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/FromAiParametersModal.test.ts
@@ -127,7 +127,6 @@ describe('FromAiParametersModal', () => {
 			},
 		});
 		workflowsStore = useWorkflowsStore();
-		workflowsStore.workflow = mock<IWorkflowDb>({ id: 'test-wf-id' });
 		workflowsStore.getNodeByName = vi.fn().mockImplementation((name: string) => {
 			switch (name) {
 				case 'Test Node':
@@ -328,7 +327,7 @@ describe('FromAiParametersModal', () => {
 			currentNodeParameters: {},
 			credentials: undefined,
 			projectId: 'test-project-id',
-			workflowId: 'test-wf-id',
+			workflowId: 'test-workflow',
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/components/FromAiParametersModal.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/FromAiParametersModal.test.ts
@@ -8,14 +8,13 @@ import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useAgentRequestStore } from '@n8n/stores/useAgentRequestStore';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { useRouter } from 'vue-router';
-import { Workflow } from 'n8n-workflow';
+import type { Workflow } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { nextTick } from 'vue';
 import { mock } from 'vitest-mock-extended';
 import { createTestWorkflow } from '@/__tests__/mocks';
 import { type MockedStore, mockedStore } from '@/__tests__/utils';
-import { IWorkflowDb } from '@/Interface';
 
 const ModalStub = {
 	template: `

--- a/packages/frontend/editor-ui/src/app/composables/useToolParameters.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useToolParameters.test.ts
@@ -260,6 +260,7 @@ describe('useToolParameters', () => {
 				currentNodeParameters: {},
 				credentials: undefined,
 				projectId: 'test-project',
+				workflowId: 'test-workflow',
 			});
 
 			expect(parameters.value).toHaveLength(1);

--- a/packages/frontend/editor-ui/src/app/composables/useToolParameters.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useToolParameters.ts
@@ -106,7 +106,7 @@ export function useToolParameters({ node }: GetToolParametersProps) {
 			currentNodeParameters: newNode.parameters,
 			credentials: newNode.credentials,
 			projectId: projectsStore.currentProjectId,
-			workflowId: workflowsStore.workflow.id,
+			workflowId: workflowsStore.workflowId,
 		});
 
 		// Load available tools

--- a/packages/frontend/editor-ui/src/app/composables/useToolParameters.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useToolParameters.ts
@@ -106,6 +106,7 @@ export function useToolParameters({ node }: GetToolParametersProps) {
 			currentNodeParameters: newNode.parameters,
 			credentials: newNode.credentials,
 			projectId: projectsStore.currentProjectId,
+			workflowId: workflowsStore.workflow.id,
 		});
 
 		// Load available tools

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/projects.store.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/projects.store.ts
@@ -20,7 +20,6 @@ import { getResourcePermissions } from '@n8n/permissions';
 import type { CreateProjectDto, UpdateProjectDto } from '@n8n/api-types';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
 import { hasRole } from '@/app/utils/rbac/checks';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 
 export type ResourceCounts = {
 	credentials: number;

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/projects.store.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/projects.store.ts
@@ -20,6 +20,7 @@ import { getResourcePermissions } from '@n8n/permissions';
 import type { CreateProjectDto, UpdateProjectDto } from '@n8n/api-types';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
 import { hasRole } from '@/app/utils/rbac/checks';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
 
 export type ResourceCounts = {
 	credentials: number;

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
@@ -749,7 +749,7 @@ async function loadRemoteParameterOptions() {
 			currentNodeParameters: resolvedNodeParameters,
 			credentials: node.value.credentials,
 			projectId: projectsStore.currentProjectId,
-			workflowId: workflowsStore.workflow.id,
+			workflowId: workflowsStore.workflowId,
 		});
 
 		remoteParameterOptions.value = remoteParameterOptions.value.concat(options);

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
@@ -738,7 +738,6 @@ async function loadRemoteParameterOptions() {
 		const loadOptionsMethod = getTypeOption('loadOptionsMethod');
 		const loadOptions = getTypeOption('loadOptions');
 
-		debugger;
 		const options = await nodeTypesStore.getNodeParameterOptions({
 			nodeTypeAndVersion: {
 				name: node.value.type,

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
@@ -738,6 +738,7 @@ async function loadRemoteParameterOptions() {
 		const loadOptionsMethod = getTypeOption('loadOptionsMethod');
 		const loadOptions = getTypeOption('loadOptions');
 
+		debugger;
 		const options = await nodeTypesStore.getNodeParameterOptions({
 			nodeTypeAndVersion: {
 				name: node.value.type,
@@ -749,6 +750,7 @@ async function loadRemoteParameterOptions() {
 			currentNodeParameters: resolvedNodeParameters,
 			credentials: node.value.credentials,
 			projectId: projectsStore.currentProjectId,
+			workflowId: workflowsStore.workflow.id,
 		});
 
 		remoteParameterOptions.value = remoteParameterOptions.value.concat(options);


### PR DESCRIPTION
## Summary

Fallback to the workflow's projectId if we have the workflow but not the project id. Ideally we'd figure this out in the front end, but there are rare edge cases where it's difficult to infer the project id, e.g. when an admin is browsing a workflow located in another users' project.

I'm favoring this approach as it may also fix other rare issues and provides general resilience, rather than covering one more edge case we happened to catch.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4350_wfid


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
