### PR TITLE
fix(core): Syslog message id RFC5424 compliance

### DIFF
--- a/packages/@n8n/syslog-client/src/schemas.ts
+++ b/packages/@n8n/syslog-client/src/schemas.ts
@@ -42,7 +42,7 @@ export const logOptionsSchema = z.object({
 	appName: z.string().max(48).optional(),
 	syslogHostname: z.string().optional(),
 	timestamp: z.instanceof(Date).optional(),
-	msgid: z.string().optional(),
+	msgid: z.string().max(32).optional(), // RFC 5424 limit
 });
 
 /**

--- a/packages/cli/src/modules/log-streaming.ee/destinations/message-event-bus-destination-syslog.ee.ts
+++ b/packages/cli/src/modules/log-streaming.ee/destinations/message-event-bus-destination-syslog.ee.ts
@@ -95,7 +95,7 @@ export class MessageEventBusDestinationSyslog
 				JSON.stringify(serializedMessage),
 				{
 					severity: msg.eventName.toLowerCase().endsWith('error') ? Severity.Error : Severity.Debug,
-					msgid: msg.id,
+					msgid: msg.id.length > 32 ? msg.id.replace(/-/g, '').substring(0, 32) : msg.id,
 					timestamp: msg.ts.toJSDate(),
 				},
 				async (error) => {


### PR DESCRIPTION
## Summary

The msg.id property in RFC5424 is limited to 32 characters, this ensures that we only send 32 characters to a syslog destination. The approach is, if the id is too long, we strip hyphens (for UUID normalization), in case this is not enough, we truncated the it to 32 characters.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/IAM-60/syslog-logstream-not-in-valid-rfc5424-format

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
