### PR TITLE
feat(nodes-langchain): Add Azure API Management (APIM) support for Azure OpenAI

### DIFF
--- a/packages/@n8n/nodes-langchain/credentials/AzureEntraCognitiveServicesOAuth2Api.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/AzureEntraCognitiveServicesOAuth2Api.credentials.ts
@@ -20,25 +20,12 @@ export class AzureEntraCognitiveServicesOAuth2Api implements ICredentialType {
 			default: 'authorizationCode',
 		},
 		{
-			displayName: 'Resource Name',
-			name: 'resourceName',
-			type: 'string',
-			required: true,
-			default: '',
-		},
-		{
 			displayName: 'API Version',
 			name: 'apiVersion',
 			type: 'string',
 			required: true,
 			default: '2025-03-01-preview',
-		},
-		{
-			displayName: 'Endpoint',
-			name: 'endpoint',
-			type: 'string',
-			default: undefined,
-			placeholder: 'https://westeurope.api.cognitive.microsoft.com',
+			description: 'The Azure OpenAI API version to use',
 		},
 		{
 			displayName: 'Tenant ID',
@@ -46,8 +33,156 @@ export class AzureEntraCognitiveServicesOAuth2Api implements ICredentialType {
 			type: 'string',
 			default: 'common',
 			description:
-				'Enter your Azure Tenant ID (Directory ID) or keep "common" for multi-tenant apps. Using a specific Tenant ID is generally recommended and required for certain authentication flows.',
+				'Enter your Azure Tenant ID (Directory ID) or keep "common" for multi-tenant apps. Required for OAuth2 authentication with Entra ID.',
 			placeholder: 'e.g., xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx or common',
+		},
+		{
+			displayName: 'Use APIM (Azure API Management)',
+			name: 'useApim',
+			type: 'boolean',
+			default: false,
+			description:
+				'Enable if accessing Azure OpenAI through Azure API Management gateway. When enabled, you can configure a custom APIM endpoint with query parameters and headers.',
+		},
+		// APIM fields - shown when useApim is true
+		{
+			displayName: 'APIM Endpoint',
+			name: 'apimBasePath',
+			type: 'string',
+			required: true,
+			displayOptions: {
+				show: {
+					useApim: [true],
+				},
+			},
+			default: '',
+			placeholder: 'https://your-apim.azure-api.net',
+			description:
+				'The APIM gateway base URL (e.g., https://my-apim.azure-api.net). The path /openai/deployments/{model}/chat/completions will be appended automatically.',
+		},
+		{
+			displayName: 'APIM Query Parameters',
+			name: 'apimQueryParams',
+			type: 'fixedCollection',
+			typeOptions: {
+				multipleValues: true,
+			},
+			displayOptions: {
+				show: {
+					useApim: [true],
+				},
+			},
+			default: {},
+			placeholder: 'Add Query Parameter',
+			description:
+				'Custom query parameters to include with every LLM API request (e.g., subscription-key)',
+			options: [
+				{
+					name: 'params',
+					displayName: 'Parameters',
+					values: [
+						{
+							displayName: 'Name',
+							name: 'name',
+							type: 'string',
+							default: '',
+							placeholder: 'subscription-key',
+							description: 'Query parameter name',
+						},
+						{
+							displayName: 'Value',
+							name: 'value',
+							type: 'string',
+							default: '',
+							typeOptions: {
+								password: true,
+							},
+							description: 'Query parameter value',
+						},
+					],
+				},
+			],
+		},
+		{
+			displayName: 'APIM Headers',
+			name: 'apimHeaders',
+			type: 'fixedCollection',
+			typeOptions: {
+				multipleValues: true,
+			},
+			displayOptions: {
+				show: {
+					useApim: [true],
+				},
+			},
+			default: {},
+			placeholder: 'Add Header',
+			description:
+				'Custom headers to include with every LLM API request (e.g., Ocp-Apim-Subscription-Key)',
+			options: [
+				{
+					name: 'headers',
+					displayName: 'Headers',
+					values: [
+						{
+							displayName: 'Name',
+							name: 'name',
+							type: 'string',
+							default: '',
+							placeholder: 'Ocp-Apim-Subscription-Key',
+							description: 'Header name',
+						},
+						{
+							displayName: 'Value',
+							name: 'value',
+							type: 'string',
+							default: '',
+							typeOptions: {
+								password: true,
+							},
+							description: 'Header value',
+						},
+					],
+				},
+			],
+		},
+		{
+			displayName: 'Approved Models',
+			name: 'approvedModels',
+			type: 'string',
+			default: '',
+			description:
+				'Comma-separated list of approved model/deployment names for the dropdown (e.g., "gpt-4o,gpt-4o-mini,o3-mini"). Leave empty to allow manual entry.',
+			placeholder: 'gpt-4o,gpt-4o-mini,o3-mini',
+		},
+		// Direct Azure OpenAI fields - shown when useApim is false
+		{
+			displayName: 'Resource Name',
+			name: 'resourceName',
+			type: 'string',
+			required: true,
+			displayOptions: {
+				show: {
+					useApim: [false],
+				},
+			},
+			default: '',
+			description: 'The name of your Azure OpenAI resource',
+			placeholder: 'my-azure-openai-resource',
+		},
+		{
+			displayName: 'Endpoint',
+			name: 'endpoint',
+			type: 'string',
+			displayOptions: {
+				show: {
+					useApim: [false],
+				},
+			},
+			default: undefined,
+			placeholder: 'https://westeurope.api.cognitive.microsoft.com',
+			description:
+				'Optional custom endpoint URL. If not provided, the standard Azure OpenAI URL is used.',
 		},
 		{
 			displayName: 'Authorization URL',

--- a/packages/@n8n/nodes-langchain/credentials/AzureOpenAiApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/AzureOpenAiApi.credentials.ts
@@ -37,6 +37,15 @@ export class AzureOpenAiApi implements ICredentialType {
 			default: undefined,
 			placeholder: 'https://westeurope.api.cognitive.microsoft.com',
 		},
+		{
+			displayName: 'Approved Models',
+			name: 'approvedModels',
+			type: 'string',
+			default: '',
+			description:
+				'Comma-separated list of approved model/deployment names for the dropdown (e.g., "gpt-4o,gpt-4o-mini,o3-mini"). Leave empty to allow manual entry.',
+			placeholder: 'gpt-4o,gpt-4o-mini,o3-mini',
+		},
 	];
 
 	authenticate: IAuthenticateGeneric = {

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/LmChatAzureOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/LmChatAzureOpenAi.node.ts
@@ -11,6 +11,7 @@ import {
 
 import { setupApiKeyAuthentication } from './credentials/api-key';
 import { setupOAuth2Authentication } from './credentials/oauth2';
+import { getDeployments } from './methods/listDeployments';
 import { properties } from './properties';
 import { AuthenticationType } from './types';
 import type {
@@ -18,6 +19,22 @@ import type {
 	AzureOpenAIOAuth2ModelConfig,
 	AzureOpenAIOptions,
 } from './types';
+
+/**
+ * Type guard to check if value is a valid AuthenticationType
+ */
+function isAuthenticationType(value: unknown): value is AuthenticationType {
+	return value === AuthenticationType.ApiKey || value === AuthenticationType.EntraOAuth2;
+}
+
+/**
+ * Type guard to check if modelConfig has apimConfig property (OAuth2 config)
+ */
+function hasApimConfig(
+	config: AzureOpenAIApiKeyModelConfig | AzureOpenAIOAuth2ModelConfig,
+): config is AzureOpenAIOAuth2ModelConfig {
+	return 'apimConfig' in config;
+}
 
 export class LmChatAzureOpenAi implements INodeType {
 	description: INodeTypeDescription = {
@@ -73,13 +90,26 @@ export class LmChatAzureOpenAi implements INodeType {
 		properties,
 	};
 
+	methods = {
+		loadOptions: {
+			getDeployments,
+		},
+	};
+
 	async supplyData(this: ISupplyDataFunctions, itemIndex: number): Promise<SupplyData> {
 		try {
-			const authenticationMethod = this.getNodeParameter(
-				'authentication',
-				itemIndex,
-			) as AuthenticationType;
-			const modelName = this.getNodeParameter('model', itemIndex) as string;
+			const authenticationMethodValue = this.getNodeParameter('authentication', itemIndex);
+			if (!isAuthenticationType(authenticationMethodValue)) {
+				throw new NodeOperationError(this.getNode(), 'Invalid authentication method');
+			}
+			const authenticationMethod = authenticationMethodValue;
+
+			const modelNameValue = this.getNodeParameter('model', itemIndex);
+			if (typeof modelNameValue !== 'string') {
+				throw new NodeOperationError(this.getNode(), 'Model name must be a string');
+			}
+			const modelName = modelNameValue;
+
 			const options = this.getNodeParameter('options', itemIndex, {}) as AzureOpenAIOptions;
 
 			// Set up Authentication based on selection and get configuration
@@ -101,7 +131,41 @@ export class LmChatAzureOpenAi implements INodeType {
 			this.logger.info(`Instantiating AzureChatOpenAI model with deployment: ${modelName}`);
 
 			const timeout = options.timeout;
-			const model = new AzureChatOpenAI({
+
+			// Extract APIM config if present (only available with OAuth2 authentication)
+			const apimConfig = hasApimConfig(modelConfig) ? modelConfig.apimConfig : undefined;
+
+			// Build configuration object with APIM settings if configured
+			const configuration: Record<string, unknown> = {
+				fetchOptions: {
+					dispatcher: getProxyAgent(undefined, {
+						headersTimeout: timeout,
+						bodyTimeout: timeout,
+					}),
+				},
+			};
+
+			if (apimConfig?.queryParams && Object.keys(apimConfig.queryParams).length > 0) {
+				configuration.defaultQuery = apimConfig.queryParams;
+				this.logger.debug('APIM query parameters configured for LLM requests');
+			}
+
+			if (apimConfig?.headers && Object.keys(apimConfig.headers).length > 0) {
+				configuration.defaultHeaders = apimConfig.headers;
+				this.logger.debug('APIM headers configured for LLM requests');
+			}
+
+			let modelConfigForOptions:
+				| AzureOpenAIApiKeyModelConfig
+				| Omit<AzureOpenAIOAuth2ModelConfig, 'apimConfig'>;
+			if (hasApimConfig(modelConfig)) {
+				const { apimConfig: _, ...rest } = modelConfig;
+				modelConfigForOptions = rest;
+			} else {
+				modelConfigForOptions = modelConfig;
+			}
+
+			const modelOptions: Record<string, unknown> = {
 				// Force completions API — Azure's SDK doesn't rewrite the /responses path,
 				// so the Responses API hits an invalid endpoint and causes a connection error.
 				// See: https://github.com/langchain-ai/langchainjs/issues/9038
@@ -110,26 +174,31 @@ export class LmChatAzureOpenAi implements INodeType {
 				// Also ensures internal logic (like mapping "maxTokens" to "maxCompletionTokens") is correct
 				model: modelName,
 				azureOpenAIApiDeploymentName: modelName,
-				...modelConfig,
+				...modelConfigForOptions,
 				...options,
 				timeout,
 				maxRetries: options.maxRetries ?? 2,
 				callbacks: [new N8nLlmTracing(this)],
-				configuration: {
-					fetchOptions: {
-						dispatcher: getProxyAgent(undefined, {
-							headersTimeout: timeout,
-							bodyTimeout: timeout,
-						}),
-					},
-				},
+				configuration,
 				modelKwargs: options.responseFormat
 					? {
 							response_format: { type: options.responseFormat },
 						}
 					: undefined,
 				onFailedAttempt: makeN8nLlmFailedAttemptHandler(this),
-			});
+			};
+
+			// Add custom endpoint for APIM if configured
+			// Use azureOpenAIEndpoint (not azureOpenAIBasePath) so LangChain constructs:
+			// {endpoint}/openai/deployments/{deployment}/chat/completions
+			if (apimConfig?.basePath) {
+				modelOptions.azureOpenAIEndpoint = apimConfig.basePath;
+				// Clear resourceName to prevent URL conflicts
+				delete modelOptions.azureOpenAIApiInstanceName;
+				this.logger.debug(`APIM endpoint configured: ${apimConfig.basePath}`);
+			}
+
+			const model = new AzureChatOpenAI(modelOptions);
 
 			this.logger.info(`Azure OpenAI client initialized for deployment: ${modelName}`);
 
@@ -137,7 +206,8 @@ export class LmChatAzureOpenAi implements INodeType {
 				response: model,
 			};
 		} catch (error) {
-			this.logger.error(`Error in LmChatAzureOpenAi.supplyData: ${error.message}`, error);
+			const errorMessage = error instanceof Error ? error.message : String(error);
+			this.logger.error(`Error in LmChatAzureOpenAi.supplyData: ${errorMessage}`, { error });
 
 			// Re-throw NodeOperationError directly, wrap others
 			if (error instanceof NodeOperationError) {
@@ -146,8 +216,7 @@ export class LmChatAzureOpenAi implements INodeType {
 
 			throw new NodeOperationError(
 				this.getNode(),
-				`Failed to initialize Azure OpenAI client: ${error.message}`,
-				error,
+				`Failed to initialize Azure OpenAI client: ${errorMessage}`,
 			);
 		}
 	}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/credentials/N8nOAuth2TokenCredential.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/credentials/N8nOAuth2TokenCredential.ts
@@ -1,5 +1,4 @@
 import type { TokenCredential, AccessToken } from '@azure/identity';
-import type { ClientOAuth2TokenData } from '@n8n/client-oauth2';
 import { ClientOAuth2 } from '@n8n/client-oauth2';
 import type { INode } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
@@ -15,6 +14,39 @@ export class N8nOAuth2TokenCredential implements TokenCredential {
 	) {}
 
 	/**
+	 * Type guard to check if token data has the required access_token property
+	 */
+	private hasAccessToken(
+		data: unknown,
+	): data is { access_token: string; expires_on?: number; expires_in?: number } {
+		return (
+			typeof data === 'object' &&
+			data !== null &&
+			'access_token' in data &&
+			typeof (data as Record<string, unknown>).access_token === 'string'
+		);
+	}
+
+	/**
+	 * Gets the expiration timestamp from token data
+	 * Azure returns expires_on (timestamp), standard OAuth returns expires_in (seconds)
+	 */
+	private getExpiresOnTimestamp(data: {
+		expires_on?: number;
+		expires_in?: number;
+	}): number {
+		if (typeof data.expires_on === 'number') {
+			return data.expires_on;
+		}
+		if (typeof data.expires_in === 'number') {
+			// Convert expires_in (seconds from now) to timestamp
+			return Math.floor(Date.now() / 1000) + data.expires_in;
+		}
+		// Default to 1 hour from now if no expiration info
+		return Math.floor(Date.now() / 1000) + 3600;
+	}
+
+	/**
 	 * Gets an access token from OAuth credential
 	 */
 	async getToken(): Promise<AccessToken | null> {
@@ -22,36 +54,84 @@ export class N8nOAuth2TokenCredential implements TokenCredential {
 			if (!this.credential?.oauthTokenData?.access_token) {
 				throw new NodeOperationError(this.node, 'Failed to retrieve access token');
 			}
+
+			// Determine if token endpoint is v1.0 or v2.0 based on URL
+			// v1.0: /oauth2/token - requires 'resource' parameter
+			// v2.0: /oauth2/v2.0/token - uses 'scope' parameter
+			const tokenUrl = this.credential.accessTokenUrl || '';
+			const isV2Endpoint = tokenUrl.includes('/v2.0/');
+			const credentialScope = this.credential.scope || '';
+
+			// Build additional body properties
+			const additionalBodyProperties: Record<string, string> = {};
+			let scopes: string[] = [];
+
+			if (isV2Endpoint) {
+				// v2.0 endpoint - use scope parameter
+				scopes = credentialScope.split(' ').filter(Boolean);
+			} else {
+				// v1.0 endpoint - use resource parameter
+				// Strip .default suffix if present to get the resource URI
+				let resource = credentialScope.trim();
+				if (resource.endsWith('/.default')) {
+					resource = resource.replace('/.default', '');
+				}
+				if (resource) {
+					additionalBodyProperties.resource = resource;
+				}
+			}
+
 			const oAuthClient = new ClientOAuth2({
 				clientId: this.credential.clientId,
 				clientSecret: this.credential.clientSecret,
-				accessTokenUri: this.credential.accessTokenUrl,
-				scopes: this.credential.scope?.split(' '),
+				accessTokenUri: tokenUrl,
+				scopes: isV2Endpoint ? scopes : undefined,
 				authentication: this.credential.authentication,
 				authorizationUri: this.credential.authUrl,
-				additionalBodyProperties: {
-					resource: 'https://cognitiveservices.azure.com/',
-				},
+				additionalBodyProperties:
+					Object.keys(additionalBodyProperties).length > 0 ? additionalBodyProperties : undefined,
 			});
 
 			const token = await oAuthClient.credentials.getToken();
-			const data = token.data as ClientOAuth2TokenData & {
-				expires_on: number;
-			};
+
+			if (!this.hasAccessToken(token.data)) {
+				throw new NodeOperationError(this.node, 'Token response missing access_token');
+			}
+
+			const expiresOnTimestamp = this.getExpiresOnTimestamp(token.data);
+
 			return {
-				token: data.access_token,
-				expiresOnTimestamp: data.expires_on,
+				token: token.data.access_token,
+				expiresOnTimestamp,
 			};
 		} catch (error) {
 			// Re-throw with better error message
-			throw new NodeOperationError(this.node, 'Failed to retrieve OAuth2 access token', error);
+			if (error instanceof NodeOperationError) {
+				throw error;
+			}
+			const errorMessage = error instanceof Error ? error.message : String(error);
+			throw new NodeOperationError(
+				this.node,
+				`Failed to retrieve OAuth2 access token: ${errorMessage}`,
+			);
 		}
 	}
 
 	/**
 	 * Gets the deployment details from the credential
+	 * When APIM is enabled, resourceName and endpoint are derived from apimBasePath
 	 */
 	async getDeploymentDetails() {
+		if (this.credential.useApim && this.credential.apimBasePath) {
+			// When using APIM, derive endpoint from apimBasePath
+			// resourceName can be empty or a placeholder since azureOpenAIBasePath will be used
+			return {
+				apiVersion: this.credential.apiVersion,
+				endpoint: undefined, // Will use azureOpenAIBasePath instead
+				resourceName: 'apim', // Placeholder - not used when azureOpenAIBasePath is set
+			};
+		}
+
 		return {
 			apiVersion: this.credential.apiVersion,
 			endpoint: this.credential.endpoint,

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/credentials/oauth2.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/credentials/oauth2.ts
@@ -5,9 +5,53 @@ import { N8nOAuth2TokenCredential } from './N8nOAuth2TokenCredential';
 import type {
 	AzureEntraCognitiveServicesOAuth2ApiCredential,
 	AzureOpenAIOAuth2ModelConfig,
+	ApimConfig,
 } from '../types';
 
 const AZURE_OPENAI_SCOPE = 'https://cognitiveservices.azure.com/.default';
+
+/**
+ * Extracts APIM configuration from credential if useApim is enabled
+ */
+function extractApimConfig(
+	credential: AzureEntraCognitiveServicesOAuth2ApiCredential,
+): ApimConfig | undefined {
+	if (!credential.useApim) {
+		return undefined;
+	}
+
+	const config: ApimConfig = {};
+
+	if (credential.apimBasePath) {
+		config.basePath = credential.apimBasePath;
+	}
+
+	// Convert array of {name, value} to Record<string, string>
+	if (credential.apimQueryParams?.params?.length) {
+		config.queryParams = {};
+		for (const param of credential.apimQueryParams.params) {
+			if (param.name && param.value) {
+				config.queryParams[param.name] = param.value;
+			}
+		}
+	}
+
+	if (credential.apimHeaders?.headers?.length) {
+		config.headers = {};
+		for (const header of credential.apimHeaders.headers) {
+			if (header.name && header.value) {
+				config.headers[header.name] = header.value;
+			}
+		}
+	}
+
+	// Only return config if at least one property is set
+	if (config.basePath || config.queryParams || config.headers) {
+		return config;
+	}
+
+	return undefined;
+}
 /**
  * Creates Entra ID (OAuth2) authentication for Azure OpenAI
  */
@@ -26,21 +70,28 @@ export async function setupOAuth2Authentication(
 		// Pass the required scope for Azure Cognitive Services
 		const azureADTokenProvider = getBearerTokenProvider(entraTokenCredential, AZURE_OPENAI_SCOPE);
 
+		// Extract APIM configuration if enabled
+		const apimConfig = extractApimConfig(credential);
+
 		this.logger.debug('Successfully created Azure AD Token Provider.');
+		if (apimConfig) {
+			this.logger.debug('APIM configuration detected and will be applied to LLM requests.');
+		}
 
 		return {
 			azureADTokenProvider,
 			azureOpenAIApiInstanceName: deploymentDetails.resourceName,
 			azureOpenAIApiVersion: deploymentDetails.apiVersion,
 			azureOpenAIEndpoint: deploymentDetails.endpoint,
+			apimConfig,
 		};
 	} catch (error) {
-		this.logger.error(`Error setting up Entra ID authentication: ${error.message}`, error);
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		this.logger.error(`Error setting up Entra ID authentication: ${errorMessage}`, { error });
 
 		throw new NodeOperationError(
 			this.getNode(),
-			`Error setting up Entra ID authentication: ${error.message}`,
-			error,
+			`Error setting up Entra ID authentication: ${errorMessage}`,
 		);
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/methods/listDeployments.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/methods/listDeployments.ts
@@ -1,0 +1,81 @@
+import type { ILoadOptionsFunctions, INodePropertyOptions } from 'n8n-workflow';
+
+import { AuthenticationType } from '../types';
+import type {
+	AzureEntraCognitiveServicesOAuth2ApiCredential,
+	AzureOpenAiApiCredential,
+} from '../types';
+
+/**
+ * Type guard to check if value is a valid AuthenticationType
+ */
+function isAuthenticationType(value: unknown): value is AuthenticationType {
+	return value === AuthenticationType.ApiKey || value === AuthenticationType.EntraOAuth2;
+}
+
+/**
+ * Fetches approved models from credential configuration
+ * Returns models defined in the approvedModels field as dropdown options
+ */
+export async function getDeployments(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+	const returnData: INodePropertyOptions[] = [];
+
+	try {
+		const authenticationMethodValue = this.getNodeParameter('authentication', 0);
+		if (!isAuthenticationType(authenticationMethodValue)) {
+			throw new Error('Invalid authentication method');
+		}
+		const authenticationMethod = authenticationMethodValue;
+
+		let approvedModels = '';
+
+		if (authenticationMethod === AuthenticationType.ApiKey) {
+			// API Key authentication
+			const credential = await this.getCredentials<AzureOpenAiApiCredential>('azureOpenAiApi');
+			approvedModels = credential.approvedModels || '';
+		} else {
+			// OAuth2 authentication
+			const credential = await this.getCredentials<AzureEntraCognitiveServicesOAuth2ApiCredential>(
+				'azureEntraCognitiveServicesOAuth2Api',
+			);
+			approvedModels = credential.approvedModels || '';
+		}
+
+		// If no approved models configured, return a hint
+		if (!approvedModels.trim()) {
+			return [
+				{
+					name: 'No Approved Models Configured - Enter Manually',
+					value: '',
+					description: 'Configure "Approved Models" in your credential to populate this dropdown',
+				},
+			];
+		}
+
+		// Parse comma-separated list and create options
+		const models = approvedModels
+			.split(',')
+			.map((m) => m.trim())
+			.filter(Boolean);
+
+		for (const model of models) {
+			returnData.push({
+				name: model,
+				value: model,
+			});
+		}
+
+		// Sort alphabetically
+		returnData.sort((a, b) => a.name.localeCompare(b.name));
+	} catch (error) {
+		// If we can't read credentials, return empty list with a hint
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		returnData.push({
+			name: 'Could Not Load Models - Enter Manually',
+			value: '',
+			description: `Error: ${errorMessage}`,
+		});
+	}
+
+	return returnData;
+}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/properties.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/properties.ts
@@ -36,14 +36,23 @@ export const properties: INodeProperties[] = [
 			},
 		},
 	},
+	/* eslint-disable n8n-nodes-base/node-param-display-name-wrong-for-dynamic-options */
+	/* eslint-disable n8n-nodes-base/node-param-description-wrong-for-dynamic-options */
 	{
 		displayName: 'Model (Deployment) Name',
 		name: 'model',
-		type: 'string',
-		description: 'The name of the model(deployment) to use (e.g., gpt-4, gpt-35-turbo)',
+		type: 'options',
+		description:
+			'The deployment name to use. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 		required: true,
 		default: '',
+		typeOptions: {
+			loadOptionsMethod: 'getDeployments',
+		},
+		hint: 'If deployments cannot be loaded, you can type the deployment name manually',
 	},
+	/* eslint-enable n8n-nodes-base/node-param-display-name-wrong-for-dynamic-options */
+	/* eslint-enable n8n-nodes-base/node-param-description-wrong-for-dynamic-options */
 	{
 		displayName: 'Options',
 		name: 'options',

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/types.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/types.ts
@@ -56,6 +56,16 @@ export interface AzureOpenAIApiKeyModelConfig extends AzureOpenAIBaseModelConfig
 export interface AzureOpenAIOAuth2ModelConfig extends AzureOpenAIBaseModelConfig {
 	azureOpenAIApiKey?: undefined;
 	azureADTokenProvider: () => Promise<string>;
+	apimConfig?: ApimConfig;
+}
+
+/**
+ * APIM (Azure API Management) configuration for custom gateway access
+ */
+export interface ApimConfig {
+	basePath?: string;
+	queryParams?: Record<string, string>;
+	headers?: Record<string, string>;
 }
 
 /**
@@ -83,6 +93,19 @@ type TokenData = OAuth2CredentialData['oauthTokenData'] & {
 	expires_on: number;
 	ext_expires_on: number;
 };
+/**
+ * APIM credential field types for fixedCollection
+ */
+export interface ApimQueryParam {
+	name: string;
+	value: string;
+}
+
+export interface ApimHeader {
+	name: string;
+	value: string;
+}
+
 export type AzureEntraCognitiveServicesOAuth2ApiCredential = OAuth2CredentialData & {
 	customScopes: boolean;
 	authentication: string;
@@ -91,4 +114,26 @@ export type AzureEntraCognitiveServicesOAuth2ApiCredential = OAuth2CredentialDat
 	resourceName: string;
 	tenantId: string;
 	oauthTokenData: TokenData;
+	// APIM configuration fields
+	useApim?: boolean;
+	apimBasePath?: string;
+	apimQueryParams?: {
+		params?: ApimQueryParam[];
+	};
+	apimHeaders?: {
+		headers?: ApimHeader[];
+	};
+	// Approved models list (comma-separated)
+	approvedModels?: string;
 };
+
+/**
+ * API Key credential type used by Azure OpenAI node
+ */
+export interface AzureOpenAiApiCredential {
+	apiKey: string;
+	resourceName: string;
+	apiVersion: string;
+	endpoint?: string;
+	approvedModels?: string;
+}


### PR DESCRIPTION
## Summary

Adds support for Azure API Management (APIM) when accessing Azure OpenAI resources through the Azure OpenAI Chat Model node.

### Features Added

**Azure Entra ID OAuth2 Credential:**
- **APIM Endpoint**: Configure the APIM gateway base URL (e.g., `https://my-apim.azure-api.net`)
- **Custom Query Parameters**: Add query params to every LLM request (e.g., `subscription-key`)
- **Custom HTTP Headers**: Add headers to every LLM request
- **Approved Models**: Comma-separated list of allowed model/deployment names that populate the node's dropdown

**API Key Credential:**
- **Approved Models**: Same comma-separated list for controlling available models

**Token Endpoint Fix:**
- Correctly detects Azure AD v1.0 vs v2.0 token endpoints
- v1.0 (`/oauth2/token`) uses `resource` parameter
- v2.0 (`/oauth2/v2.0/token`) uses `scope` parameter
- Fixes 401 errors when APIM expects tokens with specific audience claims

### How to Test

1. Create an Azure Entra ID OAuth2 credential with APIM enabled
2. Configure APIM endpoint (e.g., `https://your-apim.azure-api.net`)
3. Add any required query params (e.g., `subscription-key`)
4. Set approved models (e.g., `gpt-4,gpt-35-turbo`)
5. Use the Azure OpenAI Chat Model node - model dropdown should show approved models
6. Execute a workflow - requests should go through APIM with correct authentication

## Related Linear tickets, Github issues, and Community forum posts

<!-- Link to Linear ticket if applicable -->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)