### PR TITLE
feat(editor): Store workflow editable documents by id (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/stores/src/constants.ts
+++ b/packages/frontend/@n8n/stores/src/constants.ts
@@ -8,6 +8,7 @@ export const STORES = {
 	WORKFLOWS_LIST: 'workflowsList',
 	WORKFLOWS_V2: 'workflowsV2',
 	WORKFLOWS_EE: 'workflowsEE',
+	WORKFLOW_DOCUMENTS: 'workflowDocuments',
 	EXECUTIONS: 'executions',
 	NDV: 'ndv',
 	TEMPLATES: 'templates',

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/ActionsDropdownMenu.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/ActionsDropdownMenu.vue
@@ -49,7 +49,7 @@ const props = defineProps<{
 	isArchived: IWorkflowDb['isArchived'];
 	id: IWorkflowDb['id'];
 	name: IWorkflowDb['name'];
-	tags: IWorkflowDb['tags'];
+	tags: readonly string[];
 	currentFolder?: FolderShortInfo;
 	meta: IWorkflowDb['meta'];
 }>();

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.vue
@@ -16,11 +16,11 @@ import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
-import { computed, onBeforeMount, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { computed, inject, onBeforeMount, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import type { RouteLocation, RouteLocationRaw } from 'vue-router';
 import { useRoute, useRouter } from 'vue-router';
 import { injectStrict } from '@/app/utils/injectStrict';
-import { WorkflowIdKey } from '@/app/constants/injectionKeys';
+import { WorkflowIdKey, WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
 
 import { useLocalStorage } from '@vueuse/core';
 import GithubButton from 'vue-github-button';
@@ -73,6 +73,11 @@ const hideMenuBar = computed(() =>
 );
 const workflow = computed(() => workflowsStore.workflow);
 const workflowId = injectStrict(WorkflowIdKey);
+const workflowDocumentStore = inject(WorkflowDocumentStoreKey, null);
+const workflowTags = computed(() => {
+	const tags = workflowDocumentStore?.value?.tags;
+	return tags ? [...tags] : []; // Create mutable copy from readonly ref
+});
 const onWorkflowPage = computed(() => !!(route.meta.nodeView || route.meta.keepWorkflowAlive));
 
 const isEnterprise = computed(
@@ -281,7 +286,7 @@ async function onWorkflowDeactivated() {
 				<WorkflowDetails
 					v-if="workflow?.name"
 					:id="workflow.id"
-					:tags="workflow.tags"
+					:tags="workflowTags"
 					:name="workflow.name"
 					:meta="workflow.meta"
 					:scopes="workflow.scopes"

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.vue
@@ -74,10 +74,7 @@ const hideMenuBar = computed(() =>
 const workflow = computed(() => workflowsStore.workflow);
 const workflowId = injectStrict(WorkflowIdKey);
 const workflowDocumentStore = inject(WorkflowDocumentStoreKey, null);
-const workflowTags = computed(() => {
-	const tags = workflowDocumentStore?.value?.tags;
-	return tags ? [...tags] : []; // Create mutable copy from readonly ref
-});
+const workflowTags = computed(() => workflowDocumentStore?.value?.tags ?? []);
 const onWorkflowPage = computed(() => !!(route.meta.nodeView || route.meta.keepWorkflowAlive));
 
 const isEnterprise = computed(

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.test.ts
@@ -150,6 +150,18 @@ const workflow = createTestWorkflow({
 	meta: {},
 });
 
+// Extract props with correct types for WorkflowDetails component
+const defaultProps = {
+	id: workflow.id,
+	tags: ['1', '2'] as readonly string[],
+	name: workflow.name,
+	meta: workflow.meta,
+	scopes: workflow.scopes,
+	active: workflow.active,
+	isArchived: workflow.isArchived,
+	description: workflow.description,
+};
+
 describe('WorkflowDetails', () => {
 	beforeEach(() => {
 		uiStore = useUIStore();
@@ -189,7 +201,7 @@ describe('WorkflowDetails', () => {
 		} as unknown as ReturnType<typeof useRoute>);
 		const { getByTestId, getByText } = renderComponent({
 			props: {
-				...workflow,
+				...defaultProps,
 			},
 		});
 
@@ -205,7 +217,7 @@ describe('WorkflowDetails', () => {
 
 		const { getByTestId } = renderComponent({
 			props: {
-				...workflow,
+				...defaultProps,
 			},
 		});
 
@@ -233,7 +245,7 @@ describe('WorkflowDetails', () => {
 
 			const { getByTestId, queryByTestId } = renderComponent({
 				props: {
-					...workflow,
+					...defaultProps,
 					isArchived: false,
 					scopes: ['workflow:read'],
 				},
@@ -251,7 +263,7 @@ describe('WorkflowDetails', () => {
 
 			const { getByTestId, queryByTestId } = renderComponent({
 				props: {
-					...workflow,
+					...defaultProps,
 					isArchived: false,
 					scopes: ['workflow:read'],
 				},
@@ -267,7 +279,7 @@ describe('WorkflowDetails', () => {
 		it('should have workflow duplicate and import options if permission update is true', async () => {
 			const { getByTestId, queryByTestId } = renderComponent({
 				props: {
-					...workflow,
+					...defaultProps,
 					isArchived: false,
 					scopes: ['workflow:update'],
 				},
@@ -297,7 +309,7 @@ describe('WorkflowDetails', () => {
 
 			const { getByTestId, queryByTestId } = renderComponent({
 				props: {
-					...workflow,
+					...defaultProps,
 					id: 'new',
 					isArchived: false,
 					scopes: ['workflow:delete'],
@@ -314,7 +326,7 @@ describe('WorkflowDetails', () => {
 		it("should have 'Archive' option on non archived workflow", async () => {
 			const { getByTestId, queryByTestId } = renderComponent({
 				props: {
-					...workflow,
+					...defaultProps,
 					isArchived: false,
 					scopes: ['workflow:delete'],
 				},
@@ -332,7 +344,7 @@ describe('WorkflowDetails', () => {
 
 			const { getByTestId, queryByTestId } = renderComponent({
 				props: {
-					...workflow,
+					...defaultProps,
 					isArchived: false,
 					scopes: ['workflow:delete'],
 				},
@@ -349,7 +361,7 @@ describe('WorkflowDetails', () => {
 
 			const { getByTestId, queryByTestId } = renderComponent({
 				props: {
-					...workflow,
+					...defaultProps,
 					isArchived: false,
 					scopes: ['workflow:delete'],
 				},
@@ -364,7 +376,7 @@ describe('WorkflowDetails', () => {
 		it("should not have 'Archive' option on non archived workflow without permission", async () => {
 			const { getByTestId, queryByTestId } = renderComponent({
 				props: {
-					...workflow,
+					...defaultProps,
 					isArchived: false,
 					scopes: ['workflow:update'],
 				},
@@ -379,7 +391,7 @@ describe('WorkflowDetails', () => {
 		it("should have 'Unarchive' and 'Delete' options on archived workflow", async () => {
 			const { getByTestId, queryByTestId } = renderComponent({
 				props: {
-					...workflow,
+					...defaultProps,
 					isArchived: true,
 					scopes: ['workflow:delete'],
 				},
@@ -398,7 +410,7 @@ describe('WorkflowDetails', () => {
 
 			const { getByTestId, queryByTestId } = renderComponent({
 				props: {
-					...workflow,
+					...defaultProps,
 					isArchived: true,
 					scopes: ['workflow:delete'],
 				},
@@ -415,7 +427,7 @@ describe('WorkflowDetails', () => {
 
 			const { getByTestId, queryByTestId } = renderComponent({
 				props: {
-					...workflow,
+					...defaultProps,
 					isArchived: true,
 					scopes: ['workflow:delete'],
 				},
@@ -430,7 +442,7 @@ describe('WorkflowDetails', () => {
 		it("should not have 'Unarchive' or 'Delete' options on archived workflow without permission", async () => {
 			const { getByTestId, queryByTestId } = renderComponent({
 				props: {
-					...workflow,
+					...defaultProps,
 					isArchived: true,
 					scopes: ['workflow:update'],
 				},
@@ -445,7 +457,7 @@ describe('WorkflowDetails', () => {
 		it('should not have edit actions on archived workflow even with update permission', async () => {
 			const { getByTestId, queryByTestId } = renderComponent({
 				props: {
-					...workflow,
+					...defaultProps,
 					isArchived: true,
 					scopes: ['workflow:update', 'workflow:delete'],
 				},
@@ -460,7 +472,7 @@ describe('WorkflowDetails', () => {
 		it("should call onWorkflowMenuSelect on 'Archive' option click on nonactive workflow", async () => {
 			const { getByTestId } = renderComponent({
 				props: {
-					...workflow,
+					...defaultProps,
 					active: false,
 					isArchived: false,
 					scopes: ['workflow:delete'],
@@ -499,7 +511,7 @@ describe('WorkflowDetails', () => {
 
 			const { getByTestId } = renderComponent({
 				props: {
-					...teamWorkflow,
+					...defaultProps,
 					active: false,
 					isArchived: false,
 					scopes: ['workflow:delete'],
@@ -531,7 +543,7 @@ describe('WorkflowDetails', () => {
 
 			const { getByTestId } = renderComponent({
 				props: {
-					...personalWorkflow,
+					...defaultProps,
 					active: false,
 					isArchived: false,
 					scopes: ['workflow:delete'],
@@ -553,7 +565,7 @@ describe('WorkflowDetails', () => {
 		it("should confirm onWorkflowMenuSelect on 'Archive' option click on active workflow", async () => {
 			const { getByTestId } = renderComponent({
 				props: {
-					...workflow,
+					...defaultProps,
 					active: true,
 					isArchived: false,
 					scopes: ['workflow:delete'],
@@ -579,7 +591,7 @@ describe('WorkflowDetails', () => {
 		it("should call onWorkflowMenuSelect on 'Unarchive' option click", async () => {
 			const { getByTestId } = renderComponent({
 				props: {
-					...workflow,
+					...defaultProps,
 					isArchived: true,
 					scopes: ['workflow:delete'],
 				},
@@ -597,7 +609,7 @@ describe('WorkflowDetails', () => {
 		it("should call onWorkflowMenuSelect on 'Delete' option click", async () => {
 			const { getByTestId } = renderComponent({
 				props: {
-					...workflow,
+					...defaultProps,
 					isArchived: true,
 					scopes: ['workflow:delete'],
 				},
@@ -634,7 +646,7 @@ describe('WorkflowDetails', () => {
 
 			const { getByTestId } = renderComponent({
 				props: {
-					...teamWorkflow,
+					...defaultProps,
 					isArchived: true,
 					scopes: ['workflow:delete'],
 				},
@@ -666,7 +678,7 @@ describe('WorkflowDetails', () => {
 
 			const { getByTestId } = renderComponent({
 				props: {
-					...personalWorkflow,
+					...defaultProps,
 					isArchived: true,
 					scopes: ['workflow:delete'],
 				},
@@ -688,7 +700,7 @@ describe('WorkflowDetails', () => {
 
 			const { getByTestId } = renderComponent({
 				props: {
-					...workflow,
+					...defaultProps,
 					scopes: ['workflow:move'],
 				},
 			});
@@ -707,7 +719,7 @@ describe('WorkflowDetails', () => {
 		it('should show badge on archived workflow', async () => {
 			const { getByTestId } = renderComponent({
 				props: {
-					...workflow,
+					...defaultProps,
 					isArchived: true,
 					scopes: ['workflow:delete'],
 				},
@@ -719,7 +731,7 @@ describe('WorkflowDetails', () => {
 		it('should not show badge on non archived workflow', async () => {
 			const { queryByTestId } = renderComponent({
 				props: {
-					...workflow,
+					...defaultProps,
 					isArchived: false,
 					scopes: ['workflow:delete'],
 				},

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.vue
@@ -52,7 +52,7 @@ const WORKFLOW_NAME_BP_TO_WIDTH: { [key: string]: number } = {
 
 const props = defineProps<{
 	id: IWorkflowDb['id'];
-	tags: IWorkflowDb['tags'];
+	tags: readonly string[];
 	name: IWorkflowDb['name'];
 	meta: IWorkflowDb['meta'];
 	scopes: IWorkflowDb['scopes'];
@@ -91,7 +91,7 @@ const workflowHeaderActionsRef =
 	useTemplateRef<InstanceType<typeof WorkflowHeaderDraftPublishActions>>('workflowHeaderActions');
 const tagsEventBus = createEventBus();
 
-const hasChanged = (prev: string[], curr: string[]) => {
+const hasChanged = (prev: readonly string[], curr: readonly string[]) => {
 	if (prev.length !== curr.length) {
 		return true;
 	}
@@ -116,9 +116,7 @@ const readOnlyActions = computed(() => {
 	return readOnly.value || props.isArchived || !workflowPermissions.value.update;
 });
 
-const workflowTagIds = computed(() => {
-	return (props.tags ?? []).map((tag) => (typeof tag === 'string' ? tag : tag.id));
-});
+const workflowTagIds = computed(() => props.tags);
 
 const currentFolderForBreadcrumbs = computed(() => {
 	if (!isNewWorkflow.value && props.currentFolder) {
@@ -145,7 +143,7 @@ function onTagsEditEnable() {
 		return;
 	}
 
-	appliedTagIds.value = (props.tags ?? []) as string[];
+	appliedTagIds.value = [...props.tags];
 	isTagsEditEnabled.value = true;
 
 	setTimeout(() => {
@@ -156,7 +154,7 @@ function onTagsEditEnable() {
 }
 
 async function onTagsBlur() {
-	const current = (props.tags ?? []) as string[];
+	const current = props.tags;
 	const tags = appliedTagIds.value;
 	if (!hasChanged(current, tags)) {
 		isTagsEditEnabled.value = false;
@@ -425,7 +423,7 @@ onBeforeUnmount(() => {
 					@blur="onTagsBlur"
 					@esc="onTagsEditEsc"
 				/>
-				<div v-else-if="(tags ?? []).length === 0 && !readOnlyActions">
+				<div v-else-if="tags.length === 0 && !readOnlyActions">
 					<span class="add-tag clickable" data-test-id="new-tag-link" @click="onTagsEditEnable">
 						+ {{ i18n.baseText('workflowDetails.addTag') }}
 					</span>

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
@@ -25,7 +25,7 @@ import { useCollaborationStore } from '@/features/collaboration/collaboration/co
 
 const props = defineProps<{
 	id: IWorkflowDb['id'];
-	tags: IWorkflowDb['tags'];
+	tags: readonly string[];
 	name: IWorkflowDb['name'];
 	meta: IWorkflowDb['meta'];
 	currentFolder?: FolderShortInfo;

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -2168,7 +2168,7 @@ export function useCanvasOperations() {
 	}
 
 	async function initializeWorkspace(data: IWorkflowDb) {
-		await workflowHelpers.initState(data, useWorkflowState());
+		const { workflowDocumentStore } = await workflowHelpers.initState(data, useWorkflowState());
 		data.nodes.forEach((node) => {
 			const nodeTypeDescription = requireNodeTypeDescription(node.type, node.typeVersion);
 			const isUnknownNode =
@@ -2185,6 +2185,8 @@ export function useCanvasOperations() {
 		workflowsStore.setConnections(data.connections);
 		workflowState.setWorkflowProperty('createdAt', data.createdAt);
 		workflowState.setWorkflowProperty('updatedAt', data.updatedAt);
+
+		return { workflowDocumentStore };
 	}
 
 	const initializeUnknownNodes = (nodes: INode[]) => {

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -134,6 +134,10 @@ import { isValidNodeConnectionType } from '@/app/utils/typeGuards';
 import { useParentFolder } from '@/features/core/folders/composables/useParentFolder';
 import { useWorkflowState } from '@/app/composables/useWorkflowState';
 import { useClipboard } from '@vueuse/core';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 
 type AddNodeData = Partial<INodeUi> & {
 	type: string;
@@ -2584,7 +2588,9 @@ export function useCanvasOperations() {
 			return accu;
 		}, []);
 
-		workflowState.addWorkflowTagIds(tagIds);
+		const workflowDocumentId = createWorkflowDocumentId(workflowsStore.workflowId);
+		const workflowDocumentStore = useWorkflowDocumentStore(workflowDocumentId);
+		workflowDocumentStore.addTags(tagIds);
 	}
 
 	async function fetchWorkflowDataFromUrl(url: string): Promise<WorkflowDataUpdate | undefined> {

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
@@ -251,7 +251,6 @@ describe('useWorkflowHelpers', () => {
 			const setWorkflowScopesSpy = vi.spyOn(workflowState, 'setWorkflowScopes');
 			const setUsedCredentialsSpy = vi.spyOn(workflowsStore, 'setUsedCredentials');
 			const setWorkflowSharedWithSpy = vi.spyOn(workflowsEEStore, 'setWorkflowSharedWith');
-			const setWorkflowTagIdsSpy = vi.spyOn(workflowState, 'setWorkflowTagIds');
 			const upsertTagsSpy = vi.spyOn(tagsStore, 'upsertTags');
 
 			await initState(workflowData);
@@ -276,7 +275,7 @@ describe('useWorkflowHelpers', () => {
 				workflowId: '1',
 				sharedWithProjects: [],
 			});
-			expect(setWorkflowTagIdsSpy).toHaveBeenCalledWith([]);
+			// Tags are now managed by workflowDocumentStore
 			expect(upsertTagsSpy).toHaveBeenCalledWith([]);
 		});
 
@@ -312,12 +311,11 @@ describe('useWorkflowHelpers', () => {
 				meta: {},
 				scopes: [],
 			});
-			const setWorkflowTagIdsSpy = vi.spyOn(workflowState, 'setWorkflowTagIds');
 			const upsertTagsSpy = vi.spyOn(tagsStore, 'upsertTags');
 
 			await initState(workflowData);
 
-			expect(setWorkflowTagIdsSpy).toHaveBeenCalledWith([]);
+			// Tags are now managed by workflowDocumentStore
 			expect(upsertTagsSpy).toHaveBeenCalledWith([]);
 		});
 	});

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
@@ -56,6 +56,10 @@ import { useWorkflowsEEStore } from '@/app/stores/workflows.ee.store';
 import { findWebhook } from '@n8n/rest-api-client/api/webhooks';
 import type { ExpressionLocalResolveContext } from '@/app/types/expressions';
 import { injectWorkflowState, type WorkflowState } from '@/app/composables/useWorkflowState';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 
 export type ResolveParameterOptions = {
 	targetItem?: TargetItem;
@@ -982,8 +986,18 @@ export function useWorkflowHelpers() {
 		}
 
 		const tags = (workflowData.tags ?? []) as ITag[];
-		ws.setWorkflowTagIds(convertWorkflowTagsToIds(tags));
+		const tagIds = convertWorkflowTagsToIds(tags);
+
+		// Initialize workflowDocumentStore with tags (single source of truth)
+		const workflowDocumentId = createWorkflowDocumentId(workflowData.id);
+		const workflowDocumentStore = useWorkflowDocumentStore(workflowDocumentId);
+		workflowDocumentStore.setTags(tagIds);
+
+		// Keep workflowState in sync for backward compatibility
+		ws.setWorkflowTagIds(tagIds);
 		tagsStore.upsertTags(tags);
+
+		return { workflowDocumentStore };
 	}
 
 	/**

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
@@ -992,9 +992,6 @@ export function useWorkflowHelpers() {
 		const workflowDocumentId = createWorkflowDocumentId(workflowData.id);
 		const workflowDocumentStore = useWorkflowDocumentStore(workflowDocumentId);
 		workflowDocumentStore.setTags(tagIds);
-
-		// Keep workflowState in sync for backward compatibility
-		ws.setWorkflowTagIds(tagIds);
 		tagsStore.upsertTags(tags);
 
 		return { workflowDocumentStore };

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
@@ -1,4 +1,4 @@
-import { ref, computed } from 'vue';
+import { ref, computed, shallowRef } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useI18n } from '@n8n/i18n';
 import { useToast } from '@/app/composables/useToast';
@@ -25,6 +25,11 @@ import { getSampleWorkflowByTemplateId } from '@/features/workflows/templates/ut
 import { EnterpriseEditionFeature, VIEWS } from '@/app/constants';
 import type { WorkflowState } from '@/app/composables/useWorkflowState';
 import type { IWorkflowDb } from '@/Interface';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+	disposeWorkflowDocumentStore,
+} from '@/app/stores/workflowDocument.store';
 
 export function useWorkflowInitialization(workflowState: WorkflowState) {
 	const route = useRoute();
@@ -63,6 +68,22 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 
 	const isLoading = ref(true);
 	const initializedWorkflowId = ref<string | undefined>();
+
+	// Track the current workflow document store for cleanup and provide to children
+	const currentWorkflowDocumentStore = shallowRef<ReturnType<
+		typeof useWorkflowDocumentStore
+	> | null>(null);
+
+	function disposeCurrentWorkflowDocumentStore() {
+		if (currentWorkflowDocumentStore.value) {
+			const storeId = createWorkflowDocumentId(
+				currentWorkflowDocumentStore.value.workflowId,
+				currentWorkflowDocumentStore.value.workflowVersion,
+			);
+			disposeWorkflowDocumentStore(storeId);
+			currentWorkflowDocumentStore.value = null;
+		}
+	}
 
 	const workflowId = computed(() => {
 		const name = route.params.name;
@@ -106,6 +127,8 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 		const templateId = route.params.id;
 		if (!templateId) return false;
 
+		disposeCurrentWorkflowDocumentStore();
+
 		const loadWorkflowFromJSON = route.query.fromJson === 'true';
 
 		if (loadWorkflowFromJSON) {
@@ -122,6 +145,14 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 			await openWorkflowTemplateFromJSON(workflow);
 		} else {
 			await openWorkflowTemplate(templateId.toString());
+		}
+
+		// Create document store for template workflow (empty tags initially)
+		// The workflow ID was set during the template import
+		const currentWorkflowId = workflowsStore.workflowId;
+		if (currentWorkflowId) {
+			const workflowDocumentId = createWorkflowDocumentId(currentWorkflowId);
+			currentWorkflowDocumentStore.value = useWorkflowDocumentStore(workflowDocumentId);
 		}
 
 		return true;
@@ -188,6 +219,7 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 	}
 
 	async function openWorkflow(data: IWorkflowDb) {
+		disposeCurrentWorkflowDocumentStore();
 		resetWorkspace();
 
 		if (builderStore.streaming) {
@@ -196,7 +228,8 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 			documentTitle.setDocumentTitle(data.name, 'IDLE');
 		}
 
-		await initializeWorkspace(data);
+		const { workflowDocumentStore } = await initializeWorkspace(data);
+		currentWorkflowDocumentStore.value = workflowDocumentStore;
 
 		void externalHooks.run('workflow.open', {
 			workflowId: data.id,
@@ -207,6 +240,7 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 	}
 
 	async function initializeWorkspaceForNewWorkflow() {
+		disposeCurrentWorkflowDocumentStore();
 		resetWorkspace();
 
 		const parentFolderId = route.query.parentFolderId as string | undefined;
@@ -218,6 +252,10 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 		);
 
 		workflowState.setWorkflowId(workflowId.value);
+
+		// Create document store for new workflow (empty tags)
+		const workflowDocumentId = createWorkflowDocumentId(workflowId.value);
+		currentWorkflowDocumentStore.value = useWorkflowDocumentStore(workflowDocumentId);
 
 		await projectsStore.refreshCurrentProject();
 		await fetchAndSetParentFolder(parentFolderId);
@@ -358,6 +396,7 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 	}
 
 	function cleanup() {
+		disposeCurrentWorkflowDocumentStore();
 		resetWorkspace();
 		uiStore.nodeViewInitialized = false;
 	}
@@ -366,6 +405,7 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 		isLoading,
 		initializedWorkflowId,
 		workflowId,
+		currentWorkflowDocumentStore,
 		isNewWorkflowRoute,
 		isDemoRoute,
 		isTemplateRoute,

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
@@ -35,7 +35,6 @@ vi.mock('@n8n/permissions', () => ({
 const mockWorkflowState = {
 	setWorkflowProperty: vi.fn(),
 	setWorkflowName: vi.fn(),
-	setWorkflowTagIds: vi.fn(),
 	setActive: vi.fn(),
 	setWorkflowId: vi.fn(),
 	setWorkflowSettings: vi.fn(),
@@ -155,9 +154,8 @@ describe('useWorkflowSaving', () => {
 			modalConfirmSpy.mockResolvedValue(MODAL_CONFIRM);
 
 			const mockWorkflowState: Partial<WorkflowState> = {
-				setWorkflowTagIds: vi.fn(),
 				setWorkflowName: vi.fn(),
-				setWorkflowProperty: vi.fn(), // Add missing method
+				setWorkflowProperty: vi.fn(),
 			};
 
 			const resolveSpy = vi.fn();
@@ -562,9 +560,7 @@ describe('useWorkflowSaving', () => {
 			workflowsListStore.workflowsById = { [workflow.id]: workflow };
 			workflowsStore.workflowId = workflow.id;
 
-			const setWorkflowTagIdsSpy = vi.fn();
 			const mockWorkflowState: Partial<WorkflowState> = {
-				setWorkflowTagIds: setWorkflowTagIdsSpy,
 				setWorkflowName: vi.fn(),
 				setWorkflowProperty: vi.fn(),
 			};
@@ -576,7 +572,12 @@ describe('useWorkflowSaving', () => {
 
 			await saveCurrentWorkflow({ id: 'w5', tags: ['tag1', 'tag2'] }, true, false, false);
 
-			expect(setWorkflowTagIdsSpy).toHaveBeenCalledWith(['tag1', 'tag2']);
+			// Tags are now managed by workflowDocumentStore, not workflowState
+			expect(workflowsStore.updateWorkflow).toHaveBeenCalledWith(
+				'w5',
+				expect.objectContaining({ tags: ['tag1', 'tag2'] }),
+				false,
+			);
 		});
 	});
 
@@ -637,7 +638,6 @@ describe('useWorkflowSaving', () => {
 			const initialDirtyCount = uiStore.dirtyStateSetCount;
 
 			const mockWorkflowState: Partial<WorkflowState> = {
-				setWorkflowTagIds: vi.fn(),
 				setWorkflowName: vi.fn(),
 				setWorkflowProperty: vi.fn(),
 			};
@@ -687,7 +687,6 @@ describe('useWorkflowSaving', () => {
 			uiStore.markStateDirty();
 
 			const mockWorkflowState: Partial<WorkflowState> = {
-				setWorkflowTagIds: vi.fn(),
 				setWorkflowName: vi.fn(),
 				setWorkflowProperty: vi.fn(),
 			};
@@ -724,7 +723,6 @@ describe('useWorkflowSaving', () => {
 			const uiStore = useUIStore();
 
 			const mockWorkflowState: Partial<WorkflowState> = {
-				setWorkflowTagIds: vi.fn(),
 				setWorkflowName: vi.fn(),
 				setWorkflowProperty: vi.fn(),
 			};

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
@@ -36,6 +36,10 @@ import { useDebounceFn } from '@vueuse/core';
 import { useBuilderStore } from '@/features/ai/assistant/builder.store';
 import { useWorkflowAutosaveStore } from '@/app/stores/workflowAutosave.store';
 import { useBackendConnectionStore } from '@/app/stores/backendConnection.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 
 export function useWorkflowSaving({
 	router,
@@ -233,7 +237,13 @@ export function useWorkflowSaving({
 			}
 
 			if (tags) {
-				workflowState.setWorkflowTagIds(convertWorkflowTagsToIds(workflowData.tags));
+				const tagIds = convertWorkflowTagsToIds(workflowData.tags);
+				workflowState.setWorkflowTagIds(tagIds);
+
+				// Also update workflowDocumentStore (source of truth)
+				const workflowDocumentId = createWorkflowDocumentId(currentWorkflow);
+				const workflowDocumentStore = useWorkflowDocumentStore(workflowDocumentId);
+				workflowDocumentStore.setTags(tagIds);
 			}
 
 			// Only mark state clean if no new changes were made during the save
@@ -463,7 +473,13 @@ export function useWorkflowSaving({
 				workflowState.setNodeValue(changes);
 			});
 
-			workflowState.setWorkflowTagIds(convertWorkflowTagsToIds(workflowData.tags));
+			const tagIds = convertWorkflowTagsToIds(workflowData.tags);
+			workflowState.setWorkflowTagIds(tagIds);
+
+			// Also update workflowDocumentStore (source of truth)
+			const workflowDocumentId = createWorkflowDocumentId(workflowData.id);
+			const workflowDocumentStore = useWorkflowDocumentStore(workflowDocumentId);
+			workflowDocumentStore.setTags(tagIds);
 
 			const route = router.currentRoute.value;
 			const templateId = route.query.templateId;

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
@@ -238,9 +238,6 @@ export function useWorkflowSaving({
 
 			if (tags) {
 				const tagIds = convertWorkflowTagsToIds(workflowData.tags);
-				workflowState.setWorkflowTagIds(tagIds);
-
-				// Also update workflowDocumentStore (source of truth)
 				const workflowDocumentId = createWorkflowDocumentId(currentWorkflow);
 				const workflowDocumentStore = useWorkflowDocumentStore(workflowDocumentId);
 				workflowDocumentStore.setTags(tagIds);
@@ -474,9 +471,6 @@ export function useWorkflowSaving({
 			});
 
 			const tagIds = convertWorkflowTagsToIds(workflowData.tags);
-			workflowState.setWorkflowTagIds(tagIds);
-
-			// Also update workflowDocumentStore (source of truth)
 			const workflowDocumentId = createWorkflowDocumentId(workflowData.id);
 			const workflowDocumentStore = useWorkflowDocumentStore(workflowDocumentId);
 			workflowDocumentStore.setTags(tagIds);

--- a/packages/frontend/editor-ui/src/app/constants/injectionKeys.ts
+++ b/packages/frontend/editor-ui/src/app/constants/injectionKeys.ts
@@ -3,10 +3,11 @@ import type {
 	CanvasNodeHandleInjectionData,
 	CanvasNodeInjectionData,
 } from '@/features/workflows/canvas/canvas.types';
-import type { ComputedRef, InjectionKey, Ref } from 'vue';
+import type { ComputedRef, InjectionKey, Ref, ShallowRef } from 'vue';
 import type { ExpressionLocalResolveContext } from '@/app/types/expressions';
 import type { TelemetryContext } from '@/app/types/telemetry';
 import type { WorkflowState } from '@/app/composables/useWorkflowState';
+import type { useWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 
 export const WorkflowIdKey = 'workflowId' as unknown as InjectionKey<ComputedRef<string>>;
 export const CanvasKey = 'canvas' as unknown as InjectionKey<CanvasInjectionData>;
@@ -19,3 +20,6 @@ export const ExpressionLocalResolveContextSymbol: InjectionKey<
 > = Symbol('ExpressionLocalResolveContext');
 export const TelemetryContextSymbol: InjectionKey<TelemetryContext> = Symbol('TelemetryContext');
 export const WorkflowStateKey: InjectionKey<WorkflowState> = Symbol('WorkflowState');
+export const WorkflowDocumentStoreKey: InjectionKey<
+	ShallowRef<ReturnType<typeof useWorkflowDocumentStore> | null>
+> = Symbol('WorkflowDocumentStore');

--- a/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
@@ -10,7 +10,11 @@ import AppHeader from '@/app/components/app/AppHeader.vue';
 import AppSidebar from '@/app/components/app/AppSidebar.vue';
 import LogsPanel from '@/features/execution/logs/components/LogsPanel.vue';
 import LoadingView from '@/app/views/LoadingView.vue';
-import { WorkflowIdKey, WorkflowStateKey } from '@/app/constants/injectionKeys';
+import {
+	WorkflowIdKey,
+	WorkflowStateKey,
+	WorkflowDocumentStoreKey,
+} from '@/app/constants/injectionKeys';
 
 const { layoutProps } = useLayoutProps();
 const assistantStore = useAssistantStore();
@@ -21,6 +25,7 @@ provide(WorkflowStateKey, workflowState);
 const {
 	isLoading,
 	workflowId,
+	currentWorkflowDocumentStore,
 	isDebugRoute,
 	initializeData,
 	initializeWorkflow,
@@ -29,6 +34,7 @@ const {
 } = useWorkflowInitialization(workflowState);
 
 provide(WorkflowIdKey, workflowId);
+provide(WorkflowDocumentStoreKey, currentWorkflowDocumentStore);
 
 onMounted(async () => {
 	await initializeData();

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
@@ -1,0 +1,105 @@
+import { defineStore, getActivePinia, type StoreGeneric } from 'pinia';
+import { STORES } from '@n8n/stores';
+import { ref, readonly } from 'vue';
+import { useWorkflowsStore } from './workflows.store';
+
+// Pinia internal type - _s is the store registry Map
+type PiniaInternal = ReturnType<typeof getActivePinia> & {
+	_s: Map<string, StoreGeneric>;
+};
+
+type WorkflowDocumentId = `${string}@${string}`;
+
+type Action<N, P> = { name: N; payload: P };
+
+type SetTagsAction = Action<'setTags', { tags: string[] }>;
+
+/**
+ * Gets the store ID for a workflow document store.
+ */
+export function getWorkflowDocumentStoreId(id: string) {
+	return `${STORES.WORKFLOW_DOCUMENTS}/${id}`;
+}
+
+/**
+ * Creates a workflow document store for a specific workflow ID.
+ *
+ * Note: We use a factory function rather than a module-level cache because
+ * Pinia store instances must be tied to the active Pinia instance. A module-level
+ * cache would cause test isolation issues where stale store references persist
+ * across test runs with different Pinia instances.
+ *
+ * Pinia internally handles store deduplication per-instance via the store ID.
+ */
+export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
+	return defineStore(getWorkflowDocumentStoreId(id), () => {
+		const workflowsStore = useWorkflowsStore();
+
+		const [workflowId, workflowVersion] = id.split('@');
+
+		/**
+		 * Tags
+		 */
+
+		const tags = ref<string[]>([]);
+
+		function setTags(newTags: string[]) {
+			onChange({ name: 'setTags', payload: { tags: newTags } });
+		}
+
+		/**
+		 * Handle actions in a CRDT like manner
+		 */
+
+		function onChange(action: SetTagsAction) {
+			if (action.name === 'setTags') {
+				tags.value = action.payload.tags;
+			}
+		}
+
+		/**
+		 * Subscribe to workflow changes
+		 */
+
+		const unsubscribe = workflowsStore.$subscribe((mutation, state) => {
+			if (mutation.storeId === workflowsStore.$id && state.workflow?.id === workflowId) {
+				setTags((state.workflow.tags as string[]) || []);
+			}
+		});
+
+		return {
+			workflowId,
+			workflowVersion,
+			tags: readonly(tags),
+			setTags,
+			unsubscribe,
+		};
+	})();
+}
+
+/**
+ * Disposes a workflow document store by ID.
+ * Call this when a workflow document is unloaded (e.g., when navigating away from NodeView).
+ *
+ * This removes the store from Pinia's internal registry, freeing memory and preventing
+ * stale stores from accumulating over time.
+ */
+export function disposeWorkflowDocumentStore(id: string) {
+	const pinia = getActivePinia() as PiniaInternal;
+	if (!pinia) return;
+
+	const storeId = getWorkflowDocumentStoreId(id);
+
+	// Check if the store exists in the Pinia state
+	if (pinia.state.value[storeId]) {
+		// Get the store instance
+		const store = pinia._s.get(storeId);
+		if (store) {
+			// Unsubscribe from workflowsStore before disposing
+			store.unsubscribe?.();
+			store.$dispose();
+		}
+		// Remove from Pinia's state
+		delete pinia.state.value[storeId];
+	}
+}

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -8,7 +8,6 @@ import {
 	onDeactivated,
 	onMounted,
 	ref,
-	shallowRef,
 	useCssModule,
 	watch,
 	h,
@@ -143,12 +142,7 @@ import { injectWorkflowState } from '@/app/composables/useWorkflowState';
 import { useActivityDetection } from '@/app/composables/useActivityDetection';
 import { useCollaborationStore } from '@/features/collaboration/collaboration/collaboration.store';
 import { injectStrict } from '@/app/utils/injectStrict';
-import { WorkflowIdKey, WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
-import {
-	disposeWorkflowDocumentStore,
-	createWorkflowDocumentId,
-	useWorkflowDocumentStore,
-} from '@/app/stores/workflowDocument.store';
+import { WorkflowIdKey } from '@/app/constants/injectionKeys';
 
 import { N8nCallout, N8nCanvasThinkingPill, N8nCanvasCollaborationPill } from '@n8n/design-system';
 
@@ -220,12 +214,6 @@ const workflowState = injectWorkflowState();
 
 // Initialize activity detection for collaboration
 useActivityDetection();
-
-// Track the current workflow document store for cleanup and provide to children
-const currentWorkflowDocumentStore = shallowRef<ReturnType<typeof useWorkflowDocumentStore> | null>(
-	null,
-);
-provide(WorkflowDocumentStoreKey, currentWorkflowDocumentStore);
 
 const { addBeforeUnloadEventBindings, removeBeforeUnloadEventBindings } = useBeforeUnload({
 	route,
@@ -387,18 +375,7 @@ async function openWorkflow(data: IWorkflowDb) {
 		documentTitle.setDocumentTitle(data.name, 'IDLE');
 	}
 
-	// Dispose previous workflow document store if it exists
-	if (currentWorkflowDocumentStore.value) {
-		const previousStoreId = createWorkflowDocumentId(
-			currentWorkflowDocumentStore.value.workflowId,
-			currentWorkflowDocumentStore.value.workflowVersion,
-		);
-		disposeWorkflowDocumentStore(previousStoreId);
-		currentWorkflowDocumentStore.value = null;
-	}
-
-	const { workflowDocumentStore } = await initializeWorkspace(data);
-	currentWorkflowDocumentStore.value = workflowDocumentStore;
+	await initializeWorkspace(data);
 
 	void externalHooks.run('workflow.open', {
 		workflowId: data.id,
@@ -1828,18 +1805,8 @@ onMounted(async () => {
 
 	// Register callback for collaboration store to refresh canvas when workflow updates arrive
 	collaborationStore.setRefreshCanvasCallback(async (workflow) => {
-		// Dispose previous workflow document store if it exists
-		if (currentWorkflowDocumentStore.value) {
-			const previousStoreId = createWorkflowDocumentId(
-				currentWorkflowDocumentStore.value.workflowId,
-				currentWorkflowDocumentStore.value.workflowVersion,
-			);
-			disposeWorkflowDocumentStore(previousStoreId);
-			currentWorkflowDocumentStore.value = null;
-		}
 		// Refresh the canvas with updated workflow
-		const { workflowDocumentStore } = await initializeWorkspace(workflow);
-		currentWorkflowDocumentStore.value = workflowDocumentStore;
+		await initializeWorkspace(workflow);
 	});
 
 	try {
@@ -1907,16 +1874,6 @@ onBeforeUnmount(() => {
 	canvasEventBus.off('saved:workflow', onSaveFromWithinExecutionDebug);
 	if (!isDemoRoute.value) {
 		pushConnectionStore.pushDisconnect();
-	}
-
-	// Dispose the workflow document store when unmounting
-	if (currentWorkflowDocumentStore.value) {
-		const storeId = createWorkflowDocumentId(
-			currentWorkflowDocumentStore.value.workflowId,
-			currentWorkflowDocumentStore.value.workflowVersion,
-		);
-		disposeWorkflowDocumentStore(storeId);
-		currentWorkflowDocumentStore.value = null;
 	}
 });
 </script>

--- a/packages/frontend/editor-ui/src/features/shared/tags/components/TagsContainer.vue
+++ b/packages/frontend/editor-ui/src/features/shared/tags/components/TagsContainer.vue
@@ -10,7 +10,7 @@ import debounce from 'lodash/debounce';
 import { N8nTag } from '@n8n/design-system';
 
 interface TagsContainerProps {
-	tagIds: string[];
+	tagIds: readonly string[];
 	tagsById: { [id: string]: ITag };
 	limit?: number;
 	clickable?: boolean;

--- a/packages/frontend/editor-ui/src/features/shared/tags/components/WorkflowTagsContainer.vue
+++ b/packages/frontend/editor-ui/src/features/shared/tags/components/WorkflowTagsContainer.vue
@@ -5,7 +5,7 @@ import { useTagsStore } from '../tags.store';
 import type { ITag } from '@n8n/rest-api-client/api/tags';
 
 interface Props {
-	tagIds: string[];
+	tagIds: readonly string[];
 	limit?: number;
 	clickable?: boolean;
 	responsive?: boolean;

--- a/packages/frontend/editor-ui/src/features/shared/tags/tags.store.ts
+++ b/packages/frontend/editor-ui/src/features/shared/tags/tags.store.ts
@@ -6,6 +6,11 @@ import { useRootStore } from '@n8n/stores/useRootStore';
 import { computed, ref } from 'vue';
 import { hasPermission } from '@/app/utils/rbac/permissions';
 import { injectWorkflowState } from '@/app/composables/useWorkflowState';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
 
 const apiMapping = {
 	[STORES.TAGS]: createTagsApi('/tags'),
@@ -24,6 +29,7 @@ const createTagsStore = (id: typeof STORES.TAGS | typeof STORES.ANNOTATION_TAGS)
 			const fetchedUsageCount = ref(false);
 
 			const rootStore = useRootStore();
+			const workflowsStore = useWorkflowsStore();
 			const workflowState = injectWorkflowState();
 
 			// Computed
@@ -123,6 +129,13 @@ const createTagsStore = (id: typeof STORES.TAGS | typeof STORES.ANNOTATION_TAGS)
 
 				if (deleted) {
 					deleteTag(id);
+
+					// Update workflowDocumentStore (source of truth)
+					const workflowDocumentId = createWorkflowDocumentId(workflowsStore.workflowId);
+					const workflowDocumentStore = useWorkflowDocumentStore(workflowDocumentId);
+					workflowDocumentStore.removeTag(id);
+
+					// Keep workflowState in sync for backward compatibility
 					workflowState.removeWorkflowTagId(id);
 				}
 

--- a/packages/frontend/editor-ui/src/features/shared/tags/tags.store.ts
+++ b/packages/frontend/editor-ui/src/features/shared/tags/tags.store.ts
@@ -5,7 +5,6 @@ import { defineStore } from 'pinia';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { computed, ref } from 'vue';
 import { hasPermission } from '@/app/utils/rbac/permissions';
-import { injectWorkflowState } from '@/app/composables/useWorkflowState';
 import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
@@ -30,7 +29,6 @@ const createTagsStore = (id: typeof STORES.TAGS | typeof STORES.ANNOTATION_TAGS)
 
 			const rootStore = useRootStore();
 			const workflowsStore = useWorkflowsStore();
-			const workflowState = injectWorkflowState();
 
 			// Computed
 
@@ -134,9 +132,6 @@ const createTagsStore = (id: typeof STORES.TAGS | typeof STORES.ANNOTATION_TAGS)
 					const workflowDocumentId = createWorkflowDocumentId(workflowsStore.workflowId);
 					const workflowDocumentStore = useWorkflowDocumentStore(workflowDocumentId);
 					workflowDocumentStore.removeTag(id);
-
-					// Keep workflowState in sync for backward compatibility
-					workflowState.removeWorkflowTagId(id);
 				}
 
 				return deleted;

--- a/packages/frontend/editor-ui/src/features/shared/tags/tags.store.ts
+++ b/packages/frontend/editor-ui/src/features/shared/tags/tags.store.ts
@@ -128,10 +128,12 @@ const createTagsStore = (id: typeof STORES.TAGS | typeof STORES.ANNOTATION_TAGS)
 				if (deleted) {
 					deleteTag(id);
 
-					// Update workflowDocumentStore (source of truth)
-					const workflowDocumentId = createWorkflowDocumentId(workflowsStore.workflowId);
-					const workflowDocumentStore = useWorkflowDocumentStore(workflowDocumentId);
-					workflowDocumentStore.removeTag(id);
+					// Update workflowDocumentStore (source of truth) if a workflow is active
+					if (workflowsStore.workflowId) {
+						const workflowDocumentId = createWorkflowDocumentId(workflowsStore.workflowId);
+						const workflowDocumentStore = useWorkflowDocumentStore(workflowDocumentId);
+						workflowDocumentStore.removeTag(id);
+					}
 				}
 
 				return deleted;

--- a/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.test.ts
@@ -1,4 +1,5 @@
 import { createComponentRenderer } from '@/__tests__/render';
+import { flushPromises } from '@vue/test-utils';
 import SetupWorkflowCredentialsButton from './SetupWorkflowCredentialsButton.vue';
 import { createTestingPinia } from '@pinia/testing';
 import { mockedStore } from '@/__tests__/utils';
@@ -116,7 +117,7 @@ describe('SetupWorkflowCredentialsButton', () => {
 		expect(uiStore.openModal).not.toHaveBeenCalled();
 	});
 
-	it('calls isReadyToRunTemplateId with the correct template ID', () => {
+	it('calls isReadyToRunTemplateId with the correct template ID', async () => {
 		const templateWorkflow = {
 			...EMPTY_WORKFLOW,
 			meta: { templateId: 'ready-to-run-ai-workflow-v5', templateCredsSetupCompleted: false },
@@ -126,8 +127,10 @@ describe('SetupWorkflowCredentialsButton', () => {
 		workflowsStore.getNodes.mockReturnValue([]);
 
 		mockGetVariant.mockReturnValue(TEMPLATE_SETUP_EXPERIENCE.variant);
+		mockRouteQuery.mockReturnValue({ templateId: 'ready-to-run-ai-workflow-v5' });
 
 		renderComponent();
+		await flushPromises();
 
 		expect(readyToRunStore.isReadyToRunTemplateId).toHaveBeenCalledWith(
 			'ready-to-run-ai-workflow-v5',
@@ -150,7 +153,7 @@ describe('SetupWorkflowCredentialsButton', () => {
 			],
 		};
 
-		it('opens modal when all conditions are met', () => {
+		it('opens modal when all conditions are met', async () => {
 			workflowsStore.workflow = workflowWithUnfilledCredentials;
 			workflowsStore.getNodes.mockReturnValue(workflowWithUnfilledCredentials.nodes as never);
 			mockDoesNodeHaveAllCredentialsFilled.mockReturnValue(false);
@@ -159,6 +162,7 @@ describe('SetupWorkflowCredentialsButton', () => {
 			mockRouteQuery.mockReturnValue({ templateId: '123' });
 
 			renderComponent();
+			await flushPromises();
 
 			expect(uiStore.openModal).toHaveBeenCalledWith(SETUP_CREDENTIALS_MODAL_KEY);
 		});

--- a/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, onBeforeUnmount, onMounted, watch } from 'vue';
+import { computed, nextTick, onBeforeUnmount, onMounted, watch } from 'vue';
 import { useI18n } from '@n8n/i18n';
 import { SETUP_CREDENTIALS_MODAL_KEY, TEMPLATE_SETUP_EXPERIENCE } from '@/app/constants';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
@@ -76,7 +76,11 @@ onBeforeUnmount(() => {
 	uiStore.closeModal(SETUP_CREDENTIALS_MODAL_KEY);
 });
 
-onMounted(() => {
+onMounted(async () => {
+	// Wait for all reactive updates to settle before checking conditions
+	// This ensures workflow.meta.templateId is available after initialization
+	await nextTick();
+
 	const templateId = workflowsStore.workflow?.meta?.templateId;
 	const isReadyToRunWorkflow = readyToRunStore.isReadyToRunTemplateId(templateId);
 


### PR DESCRIPTION
## Summary

This pull request improves the handling and typing of workflow tags in the main header components and tests, and introduces a new store constant for workflow documents. The most important changes focus on making the `tags` prop in `WorkflowDetails` and related components strictly a `readonly string[]`, ensuring better type safety and consistency throughout the codebase. The workflow tags are now sourced from the workflow document store, and the tests have been updated to reflect these changes.

**Type and Prop Improvements:**
- Changed the `tags` prop in `WorkflowDetails.vue` and `ActionsDropdownMenu.vue` to use `readonly string[]` instead of the previous, less strict type, and updated all usages accordingly. [[1]](diffhunk://#diff-b5088e218e48601bfab4966fbdec63319cbe26139a54314548518f3095508e83L55-R55) [[2]](diffhunk://#diff-53e384161ee5cc0982c24aac5a5a3fcc0cfc9bfc11b1063e2a47f85c0e74c4acL52-R52)
- Updated the `hasChanged` and `workflowTagIds` logic in `WorkflowDetails.vue` to work with the new `readonly string[]` type, simplifying the tag ID extraction. [[1]](diffhunk://#diff-b5088e218e48601bfab4966fbdec63319cbe26139a54314548518f3095508e83L94-R94) [[2]](diffhunk://#diff-b5088e218e48601bfab4966fbdec63319cbe26139a54314548518f3095508e83L119-R119)

**Component Logic Updates:**
- In `MainHeader.vue`, now injects and uses the `WorkflowDocumentStoreKey` to get the workflow tags, ensuring the tags reflect the current workflow document state. [[1]](diffhunk://#diff-97aaffc73b9f3d4bdd4590bbc1dc99444206c85f383ac02eab50be857a636b5eL19-R23) [[2]](diffhunk://#diff-97aaffc73b9f3d4bdd4590bbc1dc99444206c85f383ac02eab50be857a636b5eR76-R77) [[3]](diffhunk://#diff-97aaffc73b9f3d4bdd4590bbc1dc99444206c85f383ac02eab50be857a636b5eL284-R286)

**Testing Improvements:**
- Refactored `WorkflowDetails.test.ts` to use a new `defaultProps` object with the correct `readonly string[]` type for tags, and updated all test cases to use this object for consistency and type safety. ([packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.test.tsR153-R164](diffhunk://#diff-e430746bcaefa02e0a47c1177d16b5e92cfb24118ba564135136819038bf3163R153-R164) and all subsequent Ffb1b9d5 references)

**Store Constant Addition:**
- Added a new `WORKFLOW_DOCUMENTS` entry to the `STORES` constants for future workflow document store usage.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2181/store-workflow-editable-documents-by-id-on-the-canvas


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
