### PR TITLE
fix(core): Prevent SSO enforcement bypass via self-service settings API

### DIFF
--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -47,6 +47,7 @@ export { SamlToggleDto } from './saml/saml-toggle.dto';
 export { PasswordUpdateRequestDto } from './user/password-update-request.dto';
 export { RoleChangeRequestDto } from './user/role-change-request.dto';
 export { SettingsUpdateRequestDto } from './user/settings-update-request.dto';
+export { UserSelfSettingsUpdateRequestDto } from './user/user-self-settings-update-request.dto';
 export { UserUpdateRequestDto } from './user/user-update-request.dto';
 
 export { CommunityRegisteredRequestDto } from './license/community-registered-request.dto';

--- a/packages/@n8n/api-types/src/dto/user/__tests__/user-self-settings-update-request.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/user/__tests__/user-self-settings-update-request.dto.test.ts
@@ -1,0 +1,132 @@
+import { UserSelfSettingsUpdateRequestDto } from '../user-self-settings-update-request.dto';
+
+describe('UserSelfSettingsUpdateRequestDto', () => {
+	describe('valid payloads', () => {
+		it('should pass validation with empty object', () => {
+			const data = {};
+
+			const result = UserSelfSettingsUpdateRequestDto.safeParse(data);
+
+			expect(result.success).toBe(true);
+		});
+
+		it('should pass validation with easyAIWorkflowOnboarded', () => {
+			const data = {
+				easyAIWorkflowOnboarded: true,
+			};
+
+			const result = UserSelfSettingsUpdateRequestDto.safeParse(data);
+
+			expect(result.success).toBe(true);
+		});
+
+		it('should pass validation with dismissedCallouts', () => {
+			const data = {
+				dismissedCallouts: {
+					'some-callout': true,
+					'another-callout': false,
+				},
+			};
+
+			const result = UserSelfSettingsUpdateRequestDto.safeParse(data);
+
+			expect(result.success).toBe(true);
+		});
+
+		it('should pass validation with all allowed fields', () => {
+			const data = {
+				easyAIWorkflowOnboarded: false,
+				dismissedCallouts: { 'test-callout': true },
+			};
+
+			const result = UserSelfSettingsUpdateRequestDto.safeParse(data);
+
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe('invalid payloads', () => {
+		it('should fail validation with invalid easyAIWorkflowOnboarded type', () => {
+			const data = {
+				easyAIWorkflowOnboarded: 'invalid',
+			};
+
+			const result = UserSelfSettingsUpdateRequestDto.safeParse(data);
+
+			expect(result.success).toBe(false);
+			expect(result.error?.issues[0].path[0]).toBe('easyAIWorkflowOnboarded');
+			expect(result.error?.issues[0].message).toBe('Expected boolean, received string');
+		});
+
+		it('should fail validation with invalid dismissedCallouts type', () => {
+			const data = {
+				dismissedCallouts: 'invalid',
+			};
+
+			const result = UserSelfSettingsUpdateRequestDto.safeParse(data);
+
+			expect(result.success).toBe(false);
+			expect(result.error?.issues[0].path[0]).toBe('dismissedCallouts');
+		});
+
+		it('should fail validation with invalid dismissedCallouts value type', () => {
+			const data = {
+				dismissedCallouts: {
+					'some-callout': 'not-a-boolean',
+				},
+			};
+
+			const result = UserSelfSettingsUpdateRequestDto.safeParse(data);
+
+			expect(result.success).toBe(false);
+			expect(result.error?.issues[0].path).toEqual(['dismissedCallouts', 'some-callout']);
+		});
+	});
+
+	describe('security: restricted fields should be stripped', () => {
+		it('should strip allowSSOManualLogin from payload', () => {
+			const data = {
+				easyAIWorkflowOnboarded: true,
+				allowSSOManualLogin: true,
+			};
+
+			const result = UserSelfSettingsUpdateRequestDto.safeParse(data);
+
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data).not.toHaveProperty('allowSSOManualLogin');
+				expect(result.data.easyAIWorkflowOnboarded).toBe(true);
+			}
+		});
+
+		it('should strip userActivated from payload (backend-only field)', () => {
+			const data = {
+				easyAIWorkflowOnboarded: true,
+				userActivated: true,
+			};
+
+			const result = UserSelfSettingsUpdateRequestDto.safeParse(data);
+
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data).not.toHaveProperty('userActivated');
+				expect(result.data.easyAIWorkflowOnboarded).toBe(true);
+			}
+		});
+
+		it('should strip unknown fields from payload', () => {
+			const data = {
+				easyAIWorkflowOnboarded: true,
+				someUnknownField: 'value',
+			};
+
+			const result = UserSelfSettingsUpdateRequestDto.safeParse(data);
+
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data).not.toHaveProperty('someUnknownField');
+				expect(result.data.easyAIWorkflowOnboarded).toBe(true);
+			}
+		});
+	});
+});

--- a/packages/@n8n/api-types/src/dto/user/user-self-settings-update-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/user/user-self-settings-update-request.dto.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+import { Z } from 'zod-class';
+
+/**
+ * DTO for self-service user settings updates via /me/settings endpoint.
+ * This DTO only includes fields that users should be able to modify themselves.
+ *
+ * Excluded fields:
+ * - `allowSSOManualLogin`: Admin-only, prevents SSO bypass attacks
+ * - `userActivated`: Set by backend when user runs first successful workflow
+ *
+ * For admin operations on user settings, use `SettingsUpdateRequestDto` instead.
+ */
+export class UserSelfSettingsUpdateRequestDto extends Z.class({
+	easyAIWorkflowOnboarded: z.boolean().optional(),
+	dismissedCallouts: z.record(z.string(), z.boolean()).optional(),
+}) {}

--- a/packages/cli/src/controllers/me.controller.ts
+++ b/packages/cli/src/controllers/me.controller.ts
@@ -1,7 +1,7 @@
 import {
 	passwordSchema,
 	PasswordUpdateRequestDto,
-	SettingsUpdateRequestDto,
+	UserSelfSettingsUpdateRequestDto,
 	UserUpdateRequestDto,
 } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
@@ -272,12 +272,14 @@ export class MeController {
 
 	/**
 	 * Update the logged-in user's settings.
+	 * Note: This endpoint uses UserSelfSettingsUpdateRequestDto which excludes admin-only
+	 * fields like allowSSOManualLogin to prevent privilege escalation attacks (SSO bypass).
 	 */
 	@Patch('/settings')
 	async updateCurrentUserSettings(
 		req: AuthenticatedRequest,
 		_: Response,
-		@Body payload: SettingsUpdateRequestDto,
+		@Body payload: UserSelfSettingsUpdateRequestDto,
 	): Promise<User['settings']> {
 		const { id } = req.user;
 

--- a/packages/frontend/@n8n/rest-api-client/src/api/users.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/api/users.ts
@@ -2,6 +2,7 @@ import type {
 	LoginRequestDto,
 	PasswordUpdateRequestDto,
 	SettingsUpdateRequestDto,
+	UserSelfSettingsUpdateRequestDto,
 	UsersListFilterDto,
 	UserUpdateRequestDto,
 	Role,
@@ -169,7 +170,7 @@ export async function updateCurrentUser(
 
 export async function updateCurrentUserSettings(
 	context: IRestApiContext,
-	settings: SettingsUpdateRequestDto,
+	settings: UserSelfSettingsUpdateRequestDto,
 ): Promise<IUserSettings> {
 	return await makeRestApiRequest(context, 'PATCH', '/me/settings', settings);
 }

--- a/packages/frontend/editor-ui/src/features/settings/users/users.store.ts
+++ b/packages/frontend/editor-ui/src/features/settings/users/users.store.ts
@@ -3,6 +3,7 @@ import {
 	type LoginRequestDto,
 	type PasswordUpdateRequestDto,
 	type SettingsUpdateRequestDto,
+	type UserSelfSettingsUpdateRequestDto,
 	type UserUpdateRequestDto,
 	type User,
 	ROLE,
@@ -298,7 +299,7 @@ export const useUsersStore = defineStore(STORES.USERS, () => {
 		});
 	};
 
-	const updateUserSettings = async (settings: SettingsUpdateRequestDto) => {
+	const updateUserSettings = async (settings: UserSelfSettingsUpdateRequestDto) => {
 		const updatedSettings = await usersApi.updateCurrentUserSettings(
 			rootStore.restApiContext,
 			settings,


### PR DESCRIPTION
## Summary

Fix critical security vulnerability (CVSS 8.1) that allowed SSO-authenticated users to bypass SSO enforcement by self-enabling the `allowSSOManualLogin` setting through the `/rest/me/settings` API endpoint.

Introduce `UserSelfSettingsUpdateRequestDto` that excludes admin-only and backend-only fields. The self-service endpoint now only accepts user-controllable settings (easyAIWorkflowOnboarded, dismissedCallouts). Backend-only fields like `userActivated` are also excluded. Added comprehensive integration tests to verify the security fix.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-229

GHSA Reference: https://github.com/n8n-io/n8n/security/advisories/GHSA-vjf3-2gpj-233v

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)