### PR TITLE
feat(MCP Client Node): Add session handling to MCP client

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClient/__test__/McpClient.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClient/__test__/McpClient.node.test.ts
@@ -33,6 +33,10 @@ describe('McpClient', () => {
 		});
 		executeFunctions.getInputData.mockReturnValue([{ json: {} }]);
 		getAuthHeaders.mockResolvedValue({ headers: {} });
+		// Mock transport to return undefined sessionId (no real MCP session in tests)
+		(client as unknown as { transport: { sessionId: undefined } }).transport = {
+			sessionId: undefined,
+		};
 		connectMcpClient.mockResolvedValue({
 			ok: true,
 			result: client,
@@ -52,7 +56,10 @@ describe('McpClient', () => {
 		expect(result).toEqual([
 			[
 				{
-					json: { content: [{ type: 'text', text: 'Weather in Berlin is sunny' }] },
+					json: {
+						content: [{ type: 'text', text: 'Weather in Berlin is sunny' }],
+						sessionId: undefined,
+					},
 					pairedItem: { item: 0 },
 				},
 			],
@@ -83,7 +90,10 @@ describe('McpClient', () => {
 		expect(result).toEqual([
 			[
 				{
-					json: { content: [{ type: 'text', text: 'Weather in Berlin is sunny' }] },
+					json: {
+						content: [{ type: 'text', text: 'Weather in Berlin is sunny' }],
+						sessionId: undefined,
+					},
 					pairedItem: { item: 0 },
 				},
 			],
@@ -108,7 +118,10 @@ describe('McpClient', () => {
 		expect(result).toEqual([
 			[
 				{
-					json: { content: [{ type: 'text', text: { answer: 'Weather in Berlin is sunny' } }] },
+					json: {
+						content: [{ type: 'text', text: { answer: 'Weather in Berlin is sunny' } }],
+						sessionId: undefined,
+					},
 					pairedItem: { item: 0 },
 				},
 			],
@@ -144,7 +157,7 @@ describe('McpClient', () => {
 		expect(result).toEqual([
 			[
 				{
-					json: {},
+					json: { sessionId: undefined },
 					binary: {
 						data_0: {
 							mimeType: 'image/jpeg',
@@ -187,6 +200,7 @@ describe('McpClient', () => {
 							{ type: 'image', data: 'abcdef', mimeType: 'image/jpeg' },
 							{ type: 'audio', data: 'ghijkl', mimeType: 'audio/mpeg' },
 						],
+						sessionId: undefined,
 					},
 					pairedItem: { item: 0 },
 				},

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
@@ -1,16 +1,18 @@
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
+import type { JSONSchema7 } from 'json-schema';
+import pick from 'lodash/pick';
 import { StructuredToolkit } from 'n8n-core';
-import {
-	type IDataObject,
-	type IExecuteFunctions,
-	type INodeExecutionData,
-	NodeConnectionTypes,
-	NodeOperationError,
-	type INodeType,
-	type INodeTypeDescription,
-	type ISupplyDataFunctions,
-	type SupplyData,
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeType,
+	INodeTypeDescription,
+	ISupplyDataFunctions,
+	SupplyData,
 } from 'n8n-workflow';
+import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 
 import { logWrapper } from '@utils/logWrapper';
 import { getConnectionHintNoticeField } from '@utils/sharedFields';
@@ -27,8 +29,81 @@ import {
 	mapToNodeOperationError,
 	tryRefreshOAuth2Token,
 } from '../shared/utils';
-import type { JSONSchema7 } from 'json-schema';
-import pick from 'lodash/pick';
+
+const SESSION_KEY_PREFIX = 'mcp_session_';
+
+/** The MCP SDK exposes sessionId on transport but not in the Client type */
+function getTransportSessionId(client: Client): string | undefined {
+	return (client as { transport?: { sessionId?: string } }).transport?.sessionId;
+}
+
+function isSessionNotFoundError(error: { type: string; error: Error }): boolean {
+	return (
+		error.type === 'connection' && error.error.message?.toLowerCase().includes('session not found')
+	);
+}
+
+/**
+ * Manages MCP session persistence for Streamable HTTP transport.
+ * Sessions are stored in workflow static data keyed by endpoint URL.
+ */
+class SessionStore {
+	constructor(
+		private staticData: IDataObject,
+		private endpointUrl: string,
+	) {}
+
+	private get key(): string {
+		return `${SESSION_KEY_PREFIX}${this.endpointUrl}`;
+	}
+
+	get(): string | undefined {
+		return this.staticData[this.key] as string | undefined;
+	}
+
+	set(sessionId: string): void {
+		this.staticData[this.key] = sessionId;
+	}
+
+	clear(): void {
+		delete this.staticData[this.key];
+	}
+}
+
+/**
+ * Connect to MCP with optional session recovery for Streamable HTTP.
+ * Session auto-persistence only applies to node version >= 1.3.
+ */
+async function connectWithSessionRecovery(
+	ctx: IExecuteFunctions,
+	config: ReturnType<typeof getNodeConfig>,
+	sessionStore: SessionStore | null,
+	explicitSessionId: string,
+): Promise<{ client: Client; mcpTools: ReturnType<typeof getSelectedTools> }> {
+	const sessionId = explicitSessionId || sessionStore?.get();
+
+	let result = await connectAndGetTools(ctx, config, sessionId);
+
+	// Retry without session if stored session is stale (only for auto-persisted sessions)
+	if (result.error && isSessionNotFoundError(result.error) && sessionStore && !explicitSessionId) {
+		sessionStore.clear();
+		result = await connectAndGetTools(ctx, config, undefined);
+	}
+
+	if (result.error || !result.client) {
+		throw new NodeOperationError(ctx.getNode(), result.error?.error ?? 'Failed to connect');
+	}
+
+	// Persist session for future connections
+	if (sessionStore) {
+		const newSessionId = getTransportSessionId(result.client);
+		if (newSessionId) {
+			sessionStore.set(newSessionId);
+		}
+	}
+
+	return { client: result.client, mcpTools: result.mcpTools };
+}
 
 /**
  * Get node parameters for MCP client configuration
@@ -79,10 +154,14 @@ function getNodeConfig(
 
 /**
  * Connect to MCP server and get filtered tools
+ * @param ctx - n8n execution context
+ * @param config - MCP client configuration
+ * @param sessionId - Optional MCP session ID for resuming a previous session (Streamable HTTP only)
  */
 async function connectAndGetTools(
 	ctx: ISupplyDataFunctions | IExecuteFunctions,
 	config: ReturnType<typeof getNodeConfig>,
+	sessionId?: string,
 ) {
 	const node = ctx.getNode();
 	const { headers } = await getAuthHeaders(ctx, config.authentication);
@@ -95,10 +174,11 @@ async function connectAndGetTools(
 		version: node.typeVersion,
 		onUnauthorized: async (headers) =>
 			await tryRefreshOAuth2Token(ctx, config.authentication, headers),
+		sessionId,
 	});
 
 	if (!client.ok) {
-		return { client, mcpTools: null, error: client.error };
+		return { client: null, mcpTools: null, error: client.error };
 	}
 
 	const allTools = await getAllTools(client.result);
@@ -121,7 +201,7 @@ export class McpClientTool implements INodeType {
 			dark: 'file:../mcp.dark.svg',
 		},
 		group: ['output'],
-		version: [1, 1.1, 1.2],
+		version: [1, 1.1, 1.2, 1.3],
 		description: 'Connect tools from an MCP Server',
 		defaults: {
 			name: 'MCP Client',
@@ -327,6 +407,20 @@ export class McpClientTool implements INodeType {
 				default: {},
 				options: [
 					{
+						displayName: 'Session ID',
+						name: 'sessionId',
+						type: 'string',
+						default: '',
+						description:
+							'Optional MCP session ID to resume a previous session. If not provided, sessions are automatically persisted for Streamable HTTP.',
+						displayOptions: {
+							show: {
+								'@version': [{ _cnd: { gte: 1.3 } }],
+								'/serverTransport': ['httpStreamable'],
+							},
+						},
+					},
+					{
 						displayName: 'Timeout',
 						name: 'timeout',
 						type: 'number',
@@ -360,7 +454,12 @@ export class McpClientTool implements INodeType {
 
 		if (error) {
 			this.logger.error('McpClientTool: Failed to connect to MCP Server', { error });
-			return setError(mapToNodeOperationError(node, error));
+			return setError(
+				mapToNodeOperationError(
+					node,
+					error ?? { type: 'connection', error: new Error('Failed to connect') },
+				),
+			);
 		}
 
 		this.logger.debug('McpClientTool: Successfully connected to MCP Server');
@@ -400,16 +499,26 @@ export class McpClientTool implements INodeType {
 		const node = this.getNode();
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
+		const staticData = this.getWorkflowStaticData('node') ?? {};
+		const supportsSessionPersistence =
+			node.typeVersion >= 1.3 && this.getNodeParameter('serverTransport', 0) === 'httpStreamable';
 
 		for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
 			const item = items[itemIndex];
 			const config = getNodeConfig(this, itemIndex);
+			const explicitSessionId = supportsSessionPersistence
+				? (this.getNodeParameter('options.sessionId', itemIndex, '') as string)
+				: '';
+			const sessionStore = supportsSessionPersistence
+				? new SessionStore(staticData, config.endpointUrl)
+				: null;
 
-			const { client, mcpTools, error } = await connectAndGetTools(this, config);
-
-			if (error) {
-				throw new NodeOperationError(node, error.error, { itemIndex });
-			}
+			const { client, mcpTools } = await connectWithSessionRecovery(
+				this,
+				config,
+				sessionStore,
+				explicitSessionId,
+			);
 
 			if (!mcpTools?.length) {
 				throw new NodeOperationError(node, 'MCP Server returned no tools', { itemIndex });
@@ -456,6 +565,8 @@ export class McpClientTool implements INodeType {
 					});
 				}
 			}
+
+			await client.close();
 		}
 
 		return [returnData];

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/utils.ts
@@ -95,6 +95,16 @@ export function mapToNodeOperationError(
 	}
 }
 
+/**
+ * Connect to MCP server and return the connected client
+ * @param headers - Optional headers to include in the connection request
+ * @param serverTransport - The transport method to use (SSE or Streamable HTTP)
+ * @param endpointUrl - The MCP server endpoint URL
+ * @param name - The name of the client
+ * @param version - The version of the client
+ * @param onUnauthorized - Optional handler to refresh authentication on 401 errors
+ * @param sessionId - Optional MCP session ID for resuming a previous session (Streamable HTTP only)
+ */
 export async function connectMcpClient({
 	headers,
 	serverTransport,
@@ -102,6 +112,7 @@ export async function connectMcpClient({
 	name,
 	version,
 	onUnauthorized,
+	sessionId,
 }: {
 	serverTransport: McpServerTransport;
 	endpointUrl: string;
@@ -109,6 +120,7 @@ export async function connectMcpClient({
 	name: string;
 	version: number;
 	onUnauthorized?: OnUnauthorizedHandler;
+	sessionId?: string;
 }): Promise<Result<Client, ConnectMcpClientError>> {
 	const endpoint = normalizeAndValidateUrl(endpointUrl);
 
@@ -123,6 +135,7 @@ export async function connectMcpClient({
 			const transport = new StreamableHTTPClientTransport(endpoint.result, {
 				requestInit: { headers },
 				fetch: proxyFetch,
+				sessionId,
 			});
 			await client.connect(transport);
 			return createResultOk(client);
@@ -137,6 +150,7 @@ export async function connectMcpClient({
 						endpointUrl,
 						name,
 						version,
+						sessionId,
 					});
 				}
 			}


### PR DESCRIPTION
## Summary

- Store the `sessionId` returned by the MCP server and send it on the next requests (within the same chat session)
- Return `sessionId` from the node so the user can capture it
- Add `sessionId` under options, so users can resume a session

⚠️ I tested this with Playwright MCP, as was reported, but it seems that server aggressively deletes the sessions, even before we call `client.close()`. So on the 2nd MCP call we get a session not found error.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4274/community-issue-agentv3-mcp-tools-open-new-http-streamable-session-per

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
