### PR TITLE
fix(core): Disallow editing AI messages on Chat hub

### DIFF
--- a/packages/cli/src/modules/chat-hub/chat-hub.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.service.ts
@@ -534,15 +534,7 @@ export class ChatHubService {
 				const messageToEdit = await this.getChatMessage(session.id, editId, [], trx);
 
 				if (messageToEdit.type === 'ai') {
-					if (model.provider === 'n8n') {
-						throw new BadRequestError(
-							'Editing AI messages with n8n workflow agents is not supported',
-						);
-					}
-
-					// AI edits just change the original message without revisioning or response generation
-					await this.messageRepository.updateChatMessage(editId, { content: payload.message }, trx);
-					return { workflow: null, combinedAttachments: [] };
+					throw new BadRequestError('Editing AI messages is not supported');
 				}
 
 				if (messageToEdit.type === 'human') {

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chat.utils.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chat.utils.ts
@@ -453,7 +453,7 @@ export function createFakeAgent(
 }
 
 export const isEditable = (message: ChatMessage): boolean => {
-	return message.status === 'success' && !(message.provider === 'n8n' && message.type === 'ai');
+	return message.status === 'success' && message.type !== 'ai';
 };
 
 export const isRegenerable = (message: ChatMessage): boolean => {


### PR DESCRIPTION
## Summary

Removes the ability to edit AI messages from Chat hub:
- **UI**: The edit button no longer appears on AI messages in message actions
- **Backend**: The editMessage endpoint rejects all AI message edits with an error response

This ensures AI messages cannot be modified, while user messages remain editable.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-129

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)