### PR TITLE
chore(API): Add DTOs for credential endpoints

### DIFF
--- a/packages/@n8n/api-types/src/dto/credentials/__tests__/credentials-for-workflow-query.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/__tests__/credentials-for-workflow-query.dto.test.ts
@@ -1,0 +1,65 @@
+import { CredentialsForWorkflowQueryDto } from '../credentials-for-workflow-query.dto';
+
+describe('CredentialsForWorkflowQueryDto', () => {
+	describe('Valid requests', () => {
+		test.each([
+			{
+				name: 'with workflowId',
+				request: {
+					workflowId: 'workflow-123',
+				},
+			},
+			{
+				name: 'with projectId',
+				request: {
+					projectId: 'project-123',
+				},
+			},
+			{
+				name: 'with both workflowId and projectId',
+				request: {
+					workflowId: 'workflow-123',
+					projectId: 'project-123',
+				},
+			},
+		])('should validate $name', ({ request }) => {
+			const result = CredentialsForWorkflowQueryDto.safeParse(request);
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe('Invalid requests', () => {
+		test.each([
+			{
+				name: 'missing both workflowId and projectId',
+				request: {},
+			},
+			{
+				name: 'empty object with undefined values',
+				request: {
+					workflowId: undefined,
+					projectId: undefined,
+				},
+			},
+		])('should fail validation for $name', ({ request }) => {
+			const result = CredentialsForWorkflowQueryDto.safeParse(request);
+			expect(result.success).toBe(false);
+		});
+
+		test('should fail validation when workflowId is not a string', () => {
+			const result = CredentialsForWorkflowQueryDto.safeParse({
+				workflowId: 123,
+			});
+			expect(result.success).toBe(false);
+			expect(result.error?.issues[0].path).toEqual(['workflowId']);
+		});
+
+		test('should fail validation when projectId is not a string', () => {
+			const result = CredentialsForWorkflowQueryDto.safeParse({
+				projectId: 123,
+			});
+			expect(result.success).toBe(false);
+			expect(result.error?.issues[0].path).toEqual(['projectId']);
+		});
+	});
+});

--- a/packages/@n8n/api-types/src/dto/credentials/__tests__/share-credentials-body.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/__tests__/share-credentials-body.dto.test.ts
@@ -1,0 +1,68 @@
+import { ShareCredentialsBodyDto } from '../share-credentials-body.dto';
+
+describe('ShareCredentialsBodyDto', () => {
+	describe('Valid requests', () => {
+		test.each([
+			{
+				name: 'with project IDs',
+				request: {
+					shareWithIds: ['project-1', 'project-2'],
+				},
+			},
+			{
+				name: 'with empty array',
+				request: {
+					shareWithIds: [],
+				},
+			},
+			{
+				name: 'with single project ID',
+				request: {
+					shareWithIds: ['project-123'],
+				},
+			},
+		])('should validate $name', ({ request }) => {
+			const result = ShareCredentialsBodyDto.safeParse(request);
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe('Invalid requests', () => {
+		test.each([
+			{
+				name: 'missing shareWithIds',
+				request: {},
+				expectedErrorPath: ['shareWithIds'],
+			},
+			{
+				name: 'shareWithIds is not an array',
+				request: {
+					shareWithIds: 'project-123',
+				},
+				expectedErrorPath: ['shareWithIds'],
+			},
+			{
+				name: 'shareWithIds contains non-string',
+				request: {
+					shareWithIds: ['project-1', 123],
+				},
+				expectedErrorPath: ['shareWithIds', 1],
+			},
+			{
+				name: 'shareWithIds is null',
+				request: {
+					shareWithIds: null,
+				},
+				expectedErrorPath: ['shareWithIds'],
+			},
+		])('should fail validation for $name', ({ request, expectedErrorPath }) => {
+			const result = ShareCredentialsBodyDto.safeParse(request);
+
+			expect(result.success).toBe(false);
+
+			if (expectedErrorPath) {
+				expect(result.error?.issues[0].path).toEqual(expectedErrorPath);
+			}
+		});
+	});
+});

--- a/packages/@n8n/api-types/src/dto/credentials/__tests__/test-credentials-body.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/__tests__/test-credentials-body.dto.test.ts
@@ -14,6 +14,15 @@ describe('TestCredentialsBodyDto', () => {
 				},
 			},
 			{
+				name: 'with minimal credentials without name',
+				request: {
+					credentials: {
+						id: 'cred-123',
+						type: 'apiKey',
+					},
+				},
+			},
+			{
 				name: 'with data',
 				request: {
 					credentials: {
@@ -145,16 +154,6 @@ describe('TestCredentialsBodyDto', () => {
 					},
 				},
 				expectedErrorPath: ['credentials', 'id'],
-			},
-			{
-				name: 'credentials missing name',
-				request: {
-					credentials: {
-						id: 'cred-123',
-						type: 'apiKey',
-					},
-				},
-				expectedErrorPath: ['credentials', 'name'],
 			},
 			{
 				name: 'credentials missing type',

--- a/packages/@n8n/api-types/src/dto/credentials/__tests__/test-credentials-body.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/__tests__/test-credentials-body.dto.test.ts
@@ -1,0 +1,256 @@
+import { TestCredentialsBodyDto } from '../test-credentials-body.dto';
+
+describe('TestCredentialsBodyDto', () => {
+	describe('Valid requests', () => {
+		test.each([
+			{
+				name: 'with minimal credentials',
+				request: {
+					credentials: {
+						id: 'cred-123',
+						name: 'Test Credentials',
+						type: 'apiKey',
+					},
+				},
+			},
+			{
+				name: 'with data',
+				request: {
+					credentials: {
+						id: 'cred-123',
+						name: 'Test Credentials',
+						type: 'apiKey',
+						data: { apiKey: 'secret-key' },
+					},
+				},
+			},
+			{
+				name: 'with homeProject',
+				request: {
+					credentials: {
+						id: 'cred-123',
+						name: 'Test Credentials',
+						type: 'apiKey',
+						homeProject: {
+							id: 'proj-123',
+							name: 'My Project',
+							icon: { type: 'emoji', value: '🚀' },
+							type: 'personal',
+							createdAt: '2024-01-01T00:00:00Z',
+							updatedAt: '2024-01-01T00:00:00Z',
+						},
+					},
+				},
+			},
+			{
+				name: 'with null project name and icon',
+				request: {
+					credentials: {
+						id: 'cred-123',
+						name: 'Test Credentials',
+						type: 'apiKey',
+						homeProject: {
+							id: 'proj-123',
+							name: null,
+							icon: null,
+							type: 'team',
+							createdAt: '2024-01-01T00:00:00Z',
+							updatedAt: '2024-01-01T00:00:00Z',
+						},
+					},
+				},
+			},
+			{
+				name: 'with sharedWithProjects',
+				request: {
+					credentials: {
+						id: 'cred-123',
+						name: 'Test Credentials',
+						type: 'apiKey',
+						sharedWithProjects: [
+							{
+								id: 'proj-1',
+								name: 'Project 1',
+								icon: { type: 'icon', value: 'folder' },
+								type: 'team',
+								createdAt: '2024-01-01T00:00:00Z',
+								updatedAt: '2024-01-01T00:00:00Z',
+							},
+						],
+					},
+				},
+			},
+			{
+				name: 'with isGlobal and isResolvable',
+				request: {
+					credentials: {
+						id: 'cred-123',
+						name: 'Test Credentials',
+						type: 'apiKey',
+						isGlobal: true,
+						isResolvable: false,
+					},
+				},
+			},
+			{
+				name: 'with all fields',
+				request: {
+					credentials: {
+						id: 'cred-123',
+						name: 'Full Credentials',
+						type: 'oauth2',
+						data: { accessToken: 'token', refreshToken: 'refresh' },
+						homeProject: {
+							id: 'proj-home',
+							name: 'Home Project',
+							icon: { type: 'emoji', value: '🏠' },
+							type: 'personal',
+							createdAt: '2024-01-01T00:00:00Z',
+							updatedAt: '2024-01-02T00:00:00Z',
+						},
+						sharedWithProjects: [
+							{
+								id: 'proj-shared',
+								name: 'Shared Project',
+								icon: null,
+								type: 'public',
+								createdAt: '2024-01-01T00:00:00Z',
+								updatedAt: '2024-01-01T00:00:00Z',
+							},
+						],
+						isGlobal: false,
+						isResolvable: true,
+					},
+				},
+			},
+		])('should validate $name', ({ request }) => {
+			const result = TestCredentialsBodyDto.safeParse(request);
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe('Invalid requests', () => {
+		test.each([
+			{
+				name: 'missing credentials',
+				request: {},
+				expectedErrorPath: ['credentials'],
+			},
+			{
+				name: 'credentials missing id',
+				request: {
+					credentials: {
+						name: 'Test',
+						type: 'apiKey',
+					},
+				},
+				expectedErrorPath: ['credentials', 'id'],
+			},
+			{
+				name: 'credentials missing name',
+				request: {
+					credentials: {
+						id: 'cred-123',
+						type: 'apiKey',
+					},
+				},
+				expectedErrorPath: ['credentials', 'name'],
+			},
+			{
+				name: 'credentials missing type',
+				request: {
+					credentials: {
+						id: 'cred-123',
+						name: 'Test',
+					},
+				},
+				expectedErrorPath: ['credentials', 'type'],
+			},
+			{
+				name: 'invalid homeProject structure',
+				request: {
+					credentials: {
+						id: 'cred-123',
+						name: 'Test',
+						type: 'apiKey',
+						homeProject: {
+							id: 'proj-123',
+							// missing required fields
+						},
+					},
+				},
+				expectedErrorPath: ['credentials', 'homeProject', 'name'],
+			},
+			{
+				name: 'invalid project type',
+				request: {
+					credentials: {
+						id: 'cred-123',
+						name: 'Test',
+						type: 'apiKey',
+						homeProject: {
+							id: 'proj-123',
+							name: 'Project',
+							icon: null,
+							type: 'invalid',
+							createdAt: '2024-01-01T00:00:00Z',
+							updatedAt: '2024-01-01T00:00:00Z',
+						},
+					},
+				},
+				expectedErrorPath: ['credentials', 'homeProject', 'type'],
+			},
+			{
+				name: 'invalid icon type',
+				request: {
+					credentials: {
+						id: 'cred-123',
+						name: 'Test',
+						type: 'apiKey',
+						homeProject: {
+							id: 'proj-123',
+							name: 'Project',
+							icon: { type: 'image', value: 'url' },
+							type: 'personal',
+							createdAt: '2024-01-01T00:00:00Z',
+							updatedAt: '2024-01-01T00:00:00Z',
+						},
+					},
+				},
+				expectedErrorPath: ['credentials', 'homeProject', 'icon', 'type'],
+			},
+			{
+				name: 'invalid sharedWithProjects item',
+				request: {
+					credentials: {
+						id: 'cred-123',
+						name: 'Test',
+						type: 'apiKey',
+						sharedWithProjects: [{ id: 'invalid' }],
+					},
+				},
+				expectedErrorPath: ['credentials', 'sharedWithProjects', 0, 'name'],
+			},
+			{
+				name: 'isGlobal not a boolean',
+				request: {
+					credentials: {
+						id: 'cred-123',
+						name: 'Test',
+						type: 'apiKey',
+						isGlobal: 'true',
+					},
+				},
+				expectedErrorPath: ['credentials', 'isGlobal'],
+			},
+		])('should fail validation for $name', ({ request, expectedErrorPath }) => {
+			const result = TestCredentialsBodyDto.safeParse(request);
+
+			expect(result.success).toBe(false);
+
+			if (expectedErrorPath) {
+				expect(result.error?.issues[0].path).toEqual(expectedErrorPath);
+			}
+		});
+	});
+});

--- a/packages/@n8n/api-types/src/dto/credentials/__tests__/test-credentials-body.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/__tests__/test-credentials-body.dto.test.ts
@@ -14,15 +14,6 @@ describe('TestCredentialsBodyDto', () => {
 				},
 			},
 			{
-				name: 'with minimal credentials without name',
-				request: {
-					credentials: {
-						id: 'cred-123',
-						type: 'apiKey',
-					},
-				},
-			},
-			{
 				name: 'with data',
 				request: {
 					credentials: {
@@ -154,6 +145,16 @@ describe('TestCredentialsBodyDto', () => {
 					},
 				},
 				expectedErrorPath: ['credentials', 'id'],
+			},
+			{
+				name: 'credentials missing name',
+				request: {
+					credentials: {
+						id: 'cred-123',
+						type: 'apiKey',
+					},
+				},
+				expectedErrorPath: ['credentials', 'name'],
 			},
 			{
 				name: 'credentials missing type',

--- a/packages/@n8n/api-types/src/dto/credentials/__tests__/transfer-credential-body.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/__tests__/transfer-credential-body.dto.test.ts
@@ -1,0 +1,55 @@
+import { TransferCredentialBodyDto } from '../transfer-credential-body.dto';
+
+describe('TransferCredentialBodyDto', () => {
+	describe('Valid requests', () => {
+		test.each([
+			{
+				name: 'with destinationProjectId',
+				request: {
+					destinationProjectId: 'project-123',
+				},
+			},
+			{
+				name: 'with uuid-style projectId',
+				request: {
+					destinationProjectId: '550e8400-e29b-41d4-a716-446655440000',
+				},
+			},
+		])('should validate $name', ({ request }) => {
+			const result = TransferCredentialBodyDto.safeParse(request);
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe('Invalid requests', () => {
+		test.each([
+			{
+				name: 'missing destinationProjectId',
+				request: {},
+				expectedErrorPath: ['destinationProjectId'],
+			},
+			{
+				name: 'destinationProjectId is not a string',
+				request: {
+					destinationProjectId: 123,
+				},
+				expectedErrorPath: ['destinationProjectId'],
+			},
+			{
+				name: 'destinationProjectId is null',
+				request: {
+					destinationProjectId: null,
+				},
+				expectedErrorPath: ['destinationProjectId'],
+			},
+		])('should fail validation for $name', ({ request, expectedErrorPath }) => {
+			const result = TransferCredentialBodyDto.safeParse(request);
+
+			expect(result.success).toBe(false);
+
+			if (expectedErrorPath) {
+				expect(result.error?.issues[0].path).toEqual(expectedErrorPath);
+			}
+		});
+	});
+});

--- a/packages/@n8n/api-types/src/dto/credentials/__tests__/update-credential.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/__tests__/update-credential.dto.test.ts
@@ -1,0 +1,128 @@
+import { UpdateCredentialDto } from '../update-credential.dto';
+
+describe('UpdateCredentialDto', () => {
+	describe('Valid requests', () => {
+		test.each([
+			{
+				name: 'with name only',
+				request: {
+					name: 'New Credential Name',
+				},
+			},
+			{
+				name: 'with data only',
+				request: {
+					data: { apiKey: 'new-key' },
+				},
+			},
+			{
+				name: 'with isGlobal only',
+				request: {
+					isGlobal: true,
+				},
+			},
+			{
+				name: 'with isResolvable only',
+				request: {
+					isResolvable: false,
+				},
+			},
+			{
+				name: 'with all fields',
+				request: {
+					name: 'Updated Credential',
+					type: 'apiKey',
+					data: { apiKey: 'value', secret: 'secret' },
+					isGlobal: true,
+					isResolvable: true,
+				},
+			},
+			{
+				name: 'with empty object',
+				request: {},
+			},
+		])('should validate $name', ({ request }) => {
+			const result = UpdateCredentialDto.safeParse(request);
+			expect(result.success).toBe(true);
+		});
+
+		test('should not strip out properties from the data object', () => {
+			const result = UpdateCredentialDto.safeParse({
+				data: {
+					apiKey: '123',
+					customProperty: 'customValue',
+				},
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.data).toEqual({
+				data: {
+					apiKey: '123',
+					customProperty: 'customValue',
+				},
+			});
+		});
+	});
+
+	describe('Invalid requests', () => {
+		test.each([
+			{
+				name: 'empty name',
+				request: {
+					name: '',
+				},
+				expectedErrorPath: ['name'],
+			},
+			{
+				name: 'name too long',
+				request: {
+					name: 'a'.repeat(129),
+				},
+				expectedErrorPath: ['name'],
+			},
+			{
+				name: 'empty type',
+				request: {
+					type: '',
+				},
+				expectedErrorPath: ['type'],
+			},
+			{
+				name: 'type too long',
+				request: {
+					type: 'a'.repeat(129),
+				},
+				expectedErrorPath: ['type'],
+			},
+			{
+				name: 'invalid data type',
+				request: {
+					data: 'invalid',
+				},
+				expectedErrorPath: ['data'],
+			},
+			{
+				name: 'isGlobal not a boolean',
+				request: {
+					isGlobal: 'true',
+				},
+				expectedErrorPath: ['isGlobal'],
+			},
+			{
+				name: 'isResolvable not a boolean',
+				request: {
+					isResolvable: 1,
+				},
+				expectedErrorPath: ['isResolvable'],
+			},
+		])('should fail validation for $name', ({ request, expectedErrorPath }) => {
+			const result = UpdateCredentialDto.safeParse(request);
+
+			expect(result.success).toBe(false);
+
+			if (expectedErrorPath) {
+				expect(result.error?.issues[0].path).toEqual(expectedErrorPath);
+			}
+		});
+	});
+});

--- a/packages/@n8n/api-types/src/dto/credentials/credentials-for-workflow-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/credentials-for-workflow-query.dto.ts
@@ -1,24 +1,19 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
-export class CredentialsForWorkflowQueryDto extends Z.class({
-	workflowId: z.string().optional(),
-	projectId: z.string().optional(),
-}) {
-	static override safeParse(
-		data: unknown,
-	): z.SafeParseReturnType<
-		{ workflowId?: string; projectId?: string },
-		{ workflowId?: string; projectId?: string }
-	> {
-		const schema = z
-			.object({
-				workflowId: z.string().optional(),
-				projectId: z.string().optional(),
-			})
-			.refine((d) => d.workflowId !== undefined || d.projectId !== undefined, {
-				message: 'Either workflowId or projectId must be provided',
-			});
-		return schema.safeParse(data);
+const credentialsForWorkflowQuerySchema = z
+	.object({
+		workflowId: z.string().optional(),
+		projectId: z.string().optional(),
+	})
+	.refine((data) => data.workflowId !== undefined || data.projectId !== undefined, {
+		message: 'Either workflowId or projectId must be provided',
+	});
+
+export class CredentialsForWorkflowQueryDto {
+	workflowId?: string;
+	projectId?: string;
+
+	static safeParse(data: unknown) {
+		return credentialsForWorkflowQuerySchema.safeParse(data);
 	}
 }

--- a/packages/@n8n/api-types/src/dto/credentials/credentials-for-workflow-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/credentials-for-workflow-query.dto.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod';
 
+// Note: This DTO uses a different pattern than others (manual class + static safeParse)
+// because Z.class doesn't support .refine() validation. The refine ensures at least
+// one of workflowId or projectId is provided.
 const credentialsForWorkflowQuerySchema = z
 	.object({
 		workflowId: z.string().optional(),

--- a/packages/@n8n/api-types/src/dto/credentials/credentials-for-workflow-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/credentials-for-workflow-query.dto.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+import { Z } from 'zod-class';
+
+export class CredentialsForWorkflowQueryDto extends Z.class({
+	workflowId: z.string().optional(),
+	projectId: z.string().optional(),
+}) {
+	static override safeParse(
+		data: unknown,
+	): z.SafeParseReturnType<
+		{ workflowId?: string; projectId?: string },
+		{ workflowId?: string; projectId?: string }
+	> {
+		const schema = z
+			.object({
+				workflowId: z.string().optional(),
+				projectId: z.string().optional(),
+			})
+			.refine((d) => d.workflowId !== undefined || d.projectId !== undefined, {
+				message: 'Either workflowId or projectId must be provided',
+			});
+		return schema.safeParse(data);
+	}
+}

--- a/packages/@n8n/api-types/src/dto/credentials/share-credentials-body.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/share-credentials-body.dto.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+import { Z } from 'zod-class';
+
+export class ShareCredentialsBodyDto extends Z.class({
+	shareWithIds: z.array(z.string()),
+}) {}

--- a/packages/@n8n/api-types/src/dto/credentials/share-credentials-body.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/share-credentials-body.dto.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+import { Z } from '../../zod-class';
 
 export class ShareCredentialsBodyDto extends Z.class({
 	shareWithIds: z.array(z.string()),

--- a/packages/@n8n/api-types/src/dto/credentials/share-credentials-body.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/share-credentials-body.dto.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+
 import { Z } from '../../zod-class';
 
 export class ShareCredentialsBodyDto extends Z.class({

--- a/packages/@n8n/api-types/src/dto/credentials/test-credentials-body.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/test-credentials-body.dto.ts
@@ -19,7 +19,7 @@ const projectSharingDataSchema = z.object({
 
 const credentialsDecryptedSchema = z.object({
 	id: z.string(),
-	name: z.string(),
+	name: z.string().optional(),
 	type: z.string(),
 	data: z.record(z.string(), z.any()).optional(),
 	homeProject: projectSharingDataSchema.optional(),

--- a/packages/@n8n/api-types/src/dto/credentials/test-credentials-body.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/test-credentials-body.dto.ts
@@ -21,7 +21,7 @@ const credentialsDecryptedSchema = z.object({
 	id: z.string(),
 	name: z.string(),
 	type: z.string(),
-	data: z.record(z.string(), z.unknown()).optional(),
+	data: z.record(z.string(), z.any()).optional(),
 	homeProject: projectSharingDataSchema.optional(),
 	sharedWithProjects: z.array(projectSharingDataSchema).optional(),
 	isGlobal: z.boolean().optional(),

--- a/packages/@n8n/api-types/src/dto/credentials/test-credentials-body.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/test-credentials-body.dto.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+import { Z } from 'zod-class';
+
+const projectIconSchema = z
+	.object({
+		type: z.enum(['emoji', 'icon']),
+		value: z.string(),
+	})
+	.nullable();
+
+const projectSharingDataSchema = z.object({
+	id: z.string(),
+	name: z.string().nullable(),
+	icon: projectIconSchema,
+	type: z.enum(['personal', 'team', 'public']),
+	createdAt: z.string(),
+	updatedAt: z.string(),
+});
+
+const credentialsDecryptedSchema = z.object({
+	id: z.string(),
+	name: z.string(),
+	type: z.string(),
+	data: z.record(z.string(), z.unknown()).optional(),
+	homeProject: projectSharingDataSchema.optional(),
+	sharedWithProjects: z.array(projectSharingDataSchema).optional(),
+	isGlobal: z.boolean().optional(),
+	isResolvable: z.boolean().optional(),
+});
+
+export class TestCredentialsBodyDto extends Z.class({
+	credentials: credentialsDecryptedSchema,
+}) {}

--- a/packages/@n8n/api-types/src/dto/credentials/test-credentials-body.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/test-credentials-body.dto.ts
@@ -21,7 +21,7 @@ const credentialsDecryptedSchema = z.object({
 	id: z.string(),
 	name: z.string(),
 	type: z.string(),
-	data: z.record(z.string(), z.any()).optional(),
+	data: z.record(z.string(), z.unknown()).optional(),
 	homeProject: projectSharingDataSchema.optional(),
 	sharedWithProjects: z.array(projectSharingDataSchema).optional(),
 	isGlobal: z.boolean().optional(),

--- a/packages/@n8n/api-types/src/dto/credentials/test-credentials-body.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/test-credentials-body.dto.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+import { Z } from '../../zod-class';
 
 const projectIconSchema = z
 	.object({

--- a/packages/@n8n/api-types/src/dto/credentials/test-credentials-body.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/test-credentials-body.dto.ts
@@ -19,7 +19,7 @@ const projectSharingDataSchema = z.object({
 
 const credentialsDecryptedSchema = z.object({
 	id: z.string(),
-	name: z.string().optional(),
+	name: z.string(),
 	type: z.string(),
 	data: z.record(z.string(), z.any()).optional(),
 	homeProject: projectSharingDataSchema.optional(),

--- a/packages/@n8n/api-types/src/dto/credentials/test-credentials-body.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/test-credentials-body.dto.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+
 import { Z } from '../../zod-class';
 
 const projectIconSchema = z

--- a/packages/@n8n/api-types/src/dto/credentials/transfer-credential-body.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/transfer-credential-body.dto.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+import { Z } from 'zod-class';
+
+export class TransferCredentialBodyDto extends Z.class({
+	destinationProjectId: z.string(),
+}) {}

--- a/packages/@n8n/api-types/src/dto/credentials/transfer-credential-body.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/transfer-credential-body.dto.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+
 import { Z } from '../../zod-class';
 
 export class TransferCredentialBodyDto extends Z.class({

--- a/packages/@n8n/api-types/src/dto/credentials/transfer-credential-body.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/transfer-credential-body.dto.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+import { Z } from '../../zod-class';
 
 export class TransferCredentialBodyDto extends Z.class({
 	destinationProjectId: z.string(),

--- a/packages/@n8n/api-types/src/dto/credentials/update-credential.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/update-credential.dto.ts
@@ -4,7 +4,7 @@ import { Z } from 'zod-class';
 export class UpdateCredentialDto extends Z.class({
 	name: z.string().min(1).max(128).optional(),
 	type: z.string().min(1).max(128).optional(),
-	data: z.record(z.string(), z.unknown()).optional(),
+	data: z.record(z.string(), z.any()).optional(),
 	isGlobal: z.boolean().optional(),
 	isResolvable: z.boolean().optional(),
 }) {}

--- a/packages/@n8n/api-types/src/dto/credentials/update-credential.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/update-credential.dto.ts
@@ -4,7 +4,7 @@ import { Z } from 'zod-class';
 export class UpdateCredentialDto extends Z.class({
 	name: z.string().min(1).max(128).optional(),
 	type: z.string().min(1).max(128).optional(),
-	data: z.record(z.string(), z.any()).optional(),
+	data: z.record(z.string(), z.unknown()).optional(),
 	isGlobal: z.boolean().optional(),
 	isResolvable: z.boolean().optional(),
 }) {}

--- a/packages/@n8n/api-types/src/dto/credentials/update-credential.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/update-credential.dto.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+import { Z } from 'zod-class';
+
+export class UpdateCredentialDto extends Z.class({
+	name: z.string().min(1).max(128).optional(),
+	type: z.string().min(1).max(128).optional(),
+	data: z.record(z.string(), z.unknown()).optional(),
+	isGlobal: z.boolean().optional(),
+	isResolvable: z.boolean().optional(),
+}) {}

--- a/packages/@n8n/api-types/src/dto/credentials/update-credential.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/update-credential.dto.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+import { Z } from '../../zod-class';
 
 export class UpdateCredentialDto extends Z.class({
 	name: z.string().min(1).max(128).optional(),

--- a/packages/@n8n/api-types/src/dto/credentials/update-credential.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/update-credential.dto.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+
 import { Z } from '../../zod-class';
 
 export class UpdateCredentialDto extends Z.class({

--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -71,6 +71,7 @@ export { CredentialsGetOneRequestQuery } from './credentials/credentials-get-one
 export { CredentialsGetManyRequestQuery } from './credentials/credentials-get-many-request.dto';
 export { GenerateCredentialNameRequestQuery } from './credentials/generate-credential-name.dto';
 export { TransferCredentialBodyDto } from './credentials/transfer-credential-body.dto';
+export { ShareCredentialsBodyDto } from './credentials/share-credentials-body.dto';
 
 export { CreateWorkflowDto } from './workflows/create-workflow.dto';
 export { UpdateWorkflowDto } from './workflows/update-workflow.dto';

--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -70,6 +70,7 @@ export { UpdateVariableRequestDto } from './variables/update-variable-request.dt
 export { CredentialsGetOneRequestQuery } from './credentials/credentials-get-one-request.dto';
 export { CredentialsGetManyRequestQuery } from './credentials/credentials-get-many-request.dto';
 export { GenerateCredentialNameRequestQuery } from './credentials/generate-credential-name.dto';
+export { TransferCredentialBodyDto } from './credentials/transfer-credential-body.dto';
 
 export { CreateWorkflowDto } from './workflows/create-workflow.dto';
 export { UpdateWorkflowDto } from './workflows/update-workflow.dto';

--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -72,6 +72,7 @@ export { CredentialsGetManyRequestQuery } from './credentials/credentials-get-ma
 export { GenerateCredentialNameRequestQuery } from './credentials/generate-credential-name.dto';
 export { TransferCredentialBodyDto } from './credentials/transfer-credential-body.dto';
 export { ShareCredentialsBodyDto } from './credentials/share-credentials-body.dto';
+export { CredentialsForWorkflowQueryDto } from './credentials/credentials-for-workflow-query.dto';
 
 export { CreateWorkflowDto } from './workflows/create-workflow.dto';
 export { UpdateWorkflowDto } from './workflows/update-workflow.dto';

--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -73,6 +73,7 @@ export { GenerateCredentialNameRequestQuery } from './credentials/generate-crede
 export { TransferCredentialBodyDto } from './credentials/transfer-credential-body.dto';
 export { ShareCredentialsBodyDto } from './credentials/share-credentials-body.dto';
 export { CredentialsForWorkflowQueryDto } from './credentials/credentials-for-workflow-query.dto';
+export { UpdateCredentialDto } from './credentials/update-credential.dto';
 
 export { CreateWorkflowDto } from './workflows/create-workflow.dto';
 export { UpdateWorkflowDto } from './workflows/update-workflow.dto';

--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -74,6 +74,7 @@ export { TransferCredentialBodyDto } from './credentials/transfer-credential-bod
 export { ShareCredentialsBodyDto } from './credentials/share-credentials-body.dto';
 export { CredentialsForWorkflowQueryDto } from './credentials/credentials-for-workflow-query.dto';
 export { UpdateCredentialDto } from './credentials/update-credential.dto';
+export { TestCredentialsBodyDto } from './credentials/test-credentials-body.dto';
 
 export { CreateWorkflowDto } from './workflows/create-workflow.dto';
 export { UpdateWorkflowDto } from './workflows/update-workflow.dto';

--- a/packages/cli/src/credentials/__tests__/credentials.controller.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.controller.test.ts
@@ -194,9 +194,9 @@ describe('CredentialsController', () => {
 			credentialsFinderService.findCredentialForUser.mockResolvedValue(existingCredential);
 
 			// ACT
-			await expect(credentialsController.updateCredentials(ownerReq)).rejects.toThrowError(
-				'You are not licensed for sharing credentials',
-			);
+			await expect(
+				credentialsController.updateCredentials(ownerReq, res, ownerReq.body),
+			).rejects.toThrowError('You are not licensed for sharing credentials');
 
 			// ASSERT
 			expect(credentialsService.update).not.toHaveBeenCalled();
@@ -225,7 +225,7 @@ describe('CredentialsController', () => {
 			});
 
 			// ACT
-			await credentialsController.updateCredentials(ownerReq);
+			await credentialsController.updateCredentials(ownerReq, res, ownerReq.body);
 
 			// ASSERT
 			expect(credentialsService.update).toHaveBeenCalledWith(
@@ -268,7 +268,7 @@ describe('CredentialsController', () => {
 			});
 
 			// ACT
-			await credentialsController.updateCredentials(ownerReq);
+			await credentialsController.updateCredentials(ownerReq, res, ownerReq.body);
 
 			// ASSERT
 			expect(credentialsService.update).toHaveBeenCalledWith(
@@ -297,9 +297,9 @@ describe('CredentialsController', () => {
 			credentialsFinderService.findCredentialForUser.mockResolvedValue(existingCredential);
 
 			// ACT
-			await expect(credentialsController.updateCredentials(memberReq)).rejects.toThrowError(
-				'You do not have permission to change global sharing for credentials',
-			);
+			await expect(
+				credentialsController.updateCredentials(memberReq, res, memberReq.body),
+			).rejects.toThrowError('You do not have permission to change global sharing for credentials');
 
 			// ASSERT
 			expect(credentialsService.update).not.toHaveBeenCalled();
@@ -326,9 +326,9 @@ describe('CredentialsController', () => {
 			});
 
 			// ACT
-			await expect(credentialsController.updateCredentials(memberReq)).rejects.toThrowError(
-				'You do not have permission to change global sharing for credentials',
-			);
+			await expect(
+				credentialsController.updateCredentials(memberReq, res, memberReq.body),
+			).rejects.toThrowError('You do not have permission to change global sharing for credentials');
 
 			// ASSERT
 			expect(credentialsService.update).not.toHaveBeenCalled();
@@ -354,7 +354,7 @@ describe('CredentialsController', () => {
 			});
 
 			// ACT
-			await credentialsController.updateCredentials(ownerReq);
+			await credentialsController.updateCredentials(ownerReq, res, ownerReq.body);
 
 			// ASSERT
 			// Should not include isGlobal in update when not provided
@@ -403,7 +403,7 @@ describe('CredentialsController', () => {
 			});
 
 			// ACT
-			await credentialsController.updateCredentials(ownerReq);
+			await credentialsController.updateCredentials(ownerReq, res, ownerReq.body);
 
 			// ASSERT
 			expect(credentialsService.update).toHaveBeenCalledWith(
@@ -450,7 +450,7 @@ describe('CredentialsController', () => {
 			});
 
 			// ACT
-			await credentialsController.updateCredentials(ownerReq);
+			await credentialsController.updateCredentials(ownerReq, res, ownerReq.body);
 
 			// ASSERT
 			expect(credentialsService.update).toHaveBeenCalledWith(

--- a/packages/cli/src/credentials/__tests__/credentials.controller.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.controller.test.ts
@@ -483,9 +483,9 @@ describe('CredentialsController', () => {
 			// Mock setup: existing credential already has a secret expression
 			jest.mocked(credentialsService.decrypt).mockReturnValue({ apiKey: '$secrets.oldKey' });
 
-			await expect(credentialsController.updateCredentials(memberReq)).rejects.toThrow(
-				'Lacking permissions to reference external secrets in credentials',
-			);
+			await expect(
+				credentialsController.updateCredentials(memberReq, undefined, memberReq.body),
+			).rejects.toThrow('Lacking permissions to reference external secrets in credentials');
 			expect(validateExternalSecretsPermissionsSpy).toHaveBeenCalledWith({
 				user: memberReq.user,
 				projectId: existingCredential.shared[0].projectId,
@@ -513,9 +513,9 @@ describe('CredentialsController', () => {
 			credentialsFinderService.findCredentialForUser.mockResolvedValue(existingCredential);
 			jest.mocked(credentialsService.decrypt).mockReturnValue({ apiKey: 'regular-key' });
 
-			await expect(credentialsController.updateCredentials(memberReq)).rejects.toThrow(
-				'Lacking permissions to reference external secrets in credentials',
-			);
+			await expect(
+				credentialsController.updateCredentials(memberReq, undefined, memberReq.body),
+			).rejects.toThrow('Lacking permissions to reference external secrets in credentials');
 			expect(validateExternalSecretsPermissionsSpy).toHaveBeenCalledWith({
 				user: memberReq.user,
 				projectId: existingCredential.shared[0].projectId,

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -34,7 +34,7 @@ import { hasGlobalScope, PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In } from '@n8n/typeorm';
 import { deepCopy } from 'n8n-workflow';
-import type { ICredentialDataDecryptedObject, ICredentialsDecrypted } from 'n8n-workflow';
+import type { ICredentialDataDecryptedObject } from 'n8n-workflow';
 
 import { CredentialsFinderService } from './credentials-finder.service';
 import { CredentialsService } from './credentials.service';
@@ -96,19 +96,11 @@ export class CredentialsController {
 		_res: unknown,
 		@Query query: CredentialsForWorkflowQueryDto,
 	) {
-		// Use type guards to narrow the union type safely
-		if (query.workflowId !== undefined) {
-			return await this.credentialsService.getCredentialsAUserCanUseInAWorkflow(req.user, {
-				workflowId: query.workflowId,
-			});
-		}
-		if (query.projectId !== undefined) {
-			return await this.credentialsService.getCredentialsAUserCanUseInAWorkflow(req.user, {
-				projectId: query.projectId,
-			});
-		}
-		// Should never reach here due to DTO validation
-		throw new BadRequestError('Either workflowId or projectId must be provided');
+		// The DTO's .refine() validation guarantees at least one of workflowId or projectId is present
+		return await this.credentialsService.getCredentialsAUserCanUseInAWorkflow(
+			req.user,
+			query as { workflowId: string } | { projectId: string },
+		);
 	}
 
 	@Get('/new')
@@ -171,8 +163,6 @@ export class CredentialsController {
 		}
 
 		const mergedCredentials = deepCopy(credentials);
-		// Ensure name is always set, falling back to stored credential's name
-		mergedCredentials.name = credentials.name ?? storedCredential.name;
 		const decryptedData = this.credentialsService.decrypt(storedCredential, true);
 
 		// When a sharee (or project viewer) opens a credential, the fields and the
@@ -183,7 +173,7 @@ export class CredentialsController {
 			req.user,
 			storedCredential,
 			decryptedData,
-			mergedCredentials as ICredentialsDecrypted,
+			mergedCredentials,
 		);
 
 		if (mergedCredentials.data) {
@@ -193,10 +183,7 @@ export class CredentialsController {
 			);
 		}
 
-		return await this.credentialsService.test(
-			req.user.id,
-			mergedCredentials as ICredentialsDecrypted,
-		);
+		return await this.credentialsService.test(req.user.id, mergedCredentials);
 	}
 
 	@Post('/')

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -6,6 +6,7 @@ import {
 	GenerateCredentialNameRequestQuery,
 	ShareCredentialsBodyDto,
 	TransferCredentialBodyDto,
+	UpdateCredentialDto,
 } from '@n8n/api-types';
 import { LicenseState, Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
@@ -207,9 +208,12 @@ export class CredentialsController {
 
 	@Patch('/:credentialId')
 	@ProjectScope('credential:update')
-	async updateCredentials(req: CredentialRequest.Update) {
+	async updateCredentials(
+		req: CredentialRequest.Update,
+		_res: unknown,
+		@Body payload: UpdateCredentialDto,
+	) {
 		const {
-			body,
 			user,
 			params: { credentialId },
 		} = req;
@@ -235,11 +239,11 @@ export class CredentialsController {
 		}
 
 		// We never want to allow users to change the oauthTokenData
-		delete body.data?.oauthTokenData;
+		delete payload.data?.oauthTokenData;
 
 		const preparedCredentialData = await this.credentialsService.prepareUpdateData(
 			req.user,
-			req.body,
+			payload,
 			credential,
 		);
 		const newCredentialData = this.credentialsService.createEncryptedData({
@@ -250,7 +254,7 @@ export class CredentialsController {
 		});
 
 		// Update isGlobal if provided in the payload and user has permission
-		const isGlobal = body.isGlobal;
+		const isGlobal = payload.isGlobal;
 		if (isGlobal !== undefined && isGlobal !== credential.isGlobal) {
 			if (!this.licenseState.isSharingLicensed()) {
 				throw new ForbiddenError('You are not licensed for sharing credentials');
@@ -265,7 +269,7 @@ export class CredentialsController {
 			newCredentialData.isGlobal = isGlobal;
 		}
 
-		newCredentialData.isResolvable = body.isResolvable ?? credential.isResolvable;
+		newCredentialData.isResolvable = payload.isResolvable ?? credential.isResolvable;
 		const responseData = await this.credentialsService.update(credentialId, newCredentialData);
 
 		if (responseData === null) {

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -1,5 +1,6 @@
 import {
 	CreateCredentialDto,
+	CredentialsForWorkflowQueryDto,
 	CredentialsGetManyRequestQuery,
 	CredentialsGetOneRequestQuery,
 	GenerateCredentialNameRequestQuery,
@@ -32,7 +33,6 @@ import { hasGlobalScope, PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
 import { In } from '@n8n/typeorm';
 import { deepCopy } from 'n8n-workflow';
 import type { ICredentialDataDecryptedObject } from 'n8n-workflow';
-import { z } from 'zod';
 
 import { CredentialsFinderService } from './credentials-finder.service';
 import { CredentialsService } from './credentials.service';
@@ -89,11 +89,12 @@ export class CredentialsController {
 	}
 
 	@Get('/for-workflow')
-	async getProjectCredentials(req: CredentialRequest.ForWorkflow) {
-		const options = z
-			.union([z.object({ workflowId: z.string() }), z.object({ projectId: z.string() })])
-			.parse(req.query);
-		return await this.credentialsService.getCredentialsAUserCanUseInAWorkflow(req.user, options);
+	async getProjectCredentials(
+		req: CredentialRequest.ForWorkflow,
+		_res: unknown,
+		@Query query: CredentialsForWorkflowQueryDto,
+	) {
+		return await this.credentialsService.getCredentialsAUserCanUseInAWorkflow(req.user, query);
 	}
 
 	@Get('/new')

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -3,6 +3,7 @@ import {
 	CredentialsGetManyRequestQuery,
 	CredentialsGetOneRequestQuery,
 	GenerateCredentialNameRequestQuery,
+	ShareCredentialsBodyDto,
 	TransferCredentialBodyDto,
 } from '@n8n/api-types';
 import { LicenseState, Logger } from '@n8n/backend-common';
@@ -321,16 +322,13 @@ export class CredentialsController {
 
 	@Licensed('feat:sharing')
 	@Put('/:credentialId/share')
-	async shareCredentials(req: CredentialRequest.Share) {
+	async shareCredentials(
+		req: CredentialRequest.Share,
+		_res: unknown,
+		@Body payload: ShareCredentialsBodyDto,
+	) {
 		const { credentialId } = req.params;
-		const { shareWithIds } = req.body;
-
-		if (
-			!Array.isArray(shareWithIds) ||
-			!shareWithIds.every((userId) => typeof userId === 'string')
-		) {
-			throw new BadRequestError('Bad request');
-		}
+		const { shareWithIds } = payload;
 
 		const credential = await this.credentialsFinderService.findCredentialForUser(
 			credentialId,

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -96,7 +96,11 @@ export class CredentialsController {
 		_res: unknown,
 		@Query query: CredentialsForWorkflowQueryDto,
 	) {
-		return await this.credentialsService.getCredentialsAUserCanUseInAWorkflow(req.user, query);
+		// The DTO's refine validation ensures at least one is present
+		return await this.credentialsService.getCredentialsAUserCanUseInAWorkflow(
+			req.user,
+			query as { workflowId: string } | { projectId: string },
+		);
 	}
 
 	@Get('/new')

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -34,7 +34,7 @@ import { hasGlobalScope, PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In } from '@n8n/typeorm';
 import { deepCopy } from 'n8n-workflow';
-import type { ICredentialDataDecryptedObject } from 'n8n-workflow';
+import type { ICredentialDataDecryptedObject, ICredentialsDecrypted } from 'n8n-workflow';
 
 import { CredentialsFinderService } from './credentials-finder.service';
 import { CredentialsService } from './credentials.service';
@@ -164,6 +164,8 @@ export class CredentialsController {
 		}
 
 		const mergedCredentials = deepCopy(credentials);
+		// Ensure name is always set, falling back to stored credential's name
+		mergedCredentials.name = credentials.name ?? storedCredential.name;
 		const decryptedData = this.credentialsService.decrypt(storedCredential, true);
 
 		// When a sharee (or project viewer) opens a credential, the fields and the
@@ -174,7 +176,7 @@ export class CredentialsController {
 			req.user,
 			storedCredential,
 			decryptedData,
-			mergedCredentials,
+			mergedCredentials as ICredentialsDecrypted,
 		);
 
 		if (mergedCredentials.data) {
@@ -184,7 +186,10 @@ export class CredentialsController {
 			);
 		}
 
-		return await this.credentialsService.test(req.user.id, mergedCredentials);
+		return await this.credentialsService.test(
+			req.user.id,
+			mergedCredentials as ICredentialsDecrypted,
+		);
 	}
 
 	@Post('/')

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -5,6 +5,7 @@ import {
 	CredentialsGetOneRequestQuery,
 	GenerateCredentialNameRequestQuery,
 	ShareCredentialsBodyDto,
+	TestCredentialsBodyDto,
 	TransferCredentialBodyDto,
 	UpdateCredentialDto,
 } from '@n8n/api-types';
@@ -140,8 +141,12 @@ export class CredentialsController {
 
 	// TODO: Write at least test cases for the failure paths.
 	@Post('/test')
-	async testCredentials(req: CredentialRequest.Test) {
-		const { credentials } = req.body;
+	async testCredentials(
+		req: CredentialRequest.Test,
+		_res: unknown,
+		@Body payload: TestCredentialsBodyDto,
+	) {
+		const { credentials } = payload;
 
 		const storedCredential = await this.credentialsFinderService.findCredentialForUser(
 			credentials.id,

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -96,7 +96,8 @@ export class CredentialsController {
 		_res: unknown,
 		@Query query: CredentialsForWorkflowQueryDto,
 	) {
-		// The DTO's refine validation ensures at least one is present
+		// Type cast required because DTO properties are optional at the type level,
+		// but the DTO's .refine() validation ensures at least one is present at runtime
 		return await this.credentialsService.getCredentialsAUserCanUseInAWorkflow(
 			req.user,
 			query as { workflowId: string } | { projectId: string },

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -96,12 +96,19 @@ export class CredentialsController {
 		_res: unknown,
 		@Query query: CredentialsForWorkflowQueryDto,
 	) {
-		// Type cast required because DTO properties are optional at the type level,
-		// but the DTO's .refine() validation ensures at least one is present at runtime
-		return await this.credentialsService.getCredentialsAUserCanUseInAWorkflow(
-			req.user,
-			query as { workflowId: string } | { projectId: string },
-		);
+		// Use type guards to narrow the union type safely
+		if (query.workflowId !== undefined) {
+			return await this.credentialsService.getCredentialsAUserCanUseInAWorkflow(req.user, {
+				workflowId: query.workflowId,
+			});
+		}
+		if (query.projectId !== undefined) {
+			return await this.credentialsService.getCredentialsAUserCanUseInAWorkflow(req.user, {
+				projectId: query.projectId,
+			});
+		}
+		// Should never reach here due to DTO validation
+		throw new BadRequestError('Either workflowId or projectId must be provided');
 	}
 
 	@Get('/new')

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -3,6 +3,7 @@ import {
 	CredentialsGetManyRequestQuery,
 	CredentialsGetOneRequestQuery,
 	GenerateCredentialNameRequestQuery,
+	TransferCredentialBodyDto,
 } from '@n8n/api-types';
 import { LicenseState, Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
@@ -413,13 +414,15 @@ export class CredentialsController {
 
 	@Put('/:credentialId/transfer')
 	@ProjectScope('credential:move')
-	async transfer(req: CredentialRequest.Transfer) {
-		const body = z.object({ destinationProjectId: z.string() }).parse(req.body);
-
+	async transfer(
+		req: CredentialRequest.Transfer,
+		_res: unknown,
+		@Body payload: TransferCredentialBodyDto,
+	) {
 		return await this.enterpriseCredentialsService.transferOne(
 			req.user,
 			req.params.credentialId,
-			body.destinationProjectId,
+			payload.destinationProjectId,
 		);
 	}
 }

--- a/packages/cli/test/integration/credentials/credentials.api.test.ts
+++ b/packages/cli/test/integration/credentials/credentials.api.test.ts
@@ -1808,6 +1808,7 @@ describe('POST /credentials/test', () => {
 		const response = await authOwnerAgent.post('/credentials/test').send({
 			credentials: {
 				id: savedCredential.id,
+				name: savedCredential.name,
 				type: savedCredential.type,
 				data: credential.data,
 			},
@@ -1837,6 +1838,7 @@ describe('POST /credentials/test', () => {
 		const response = await authOwnerAgent.post('/credentials/test').send({
 			credentials: {
 				id: savedCredential.id,
+				name: savedCredential.name,
 				type: savedCredential.type,
 				data: {
 					accessToken: CREDENTIAL_BLANKING_VALUE,

--- a/packages/cli/test/integration/credentials/credentials.api.test.ts
+++ b/packages/cli/test/integration/credentials/credentials.api.test.ts
@@ -1817,6 +1817,7 @@ describe('POST /credentials/test', () => {
 		expect(mockCredentialsTester.testCredentials.mock.calls[0][1]).toBe(savedCredential.type);
 		expect(mockCredentialsTester.testCredentials.mock.calls[0][2]).toEqual({
 			id: savedCredential.id,
+			name: savedCredential.name,
 			type: savedCredential.type,
 			data: credential.data,
 		});
@@ -1847,6 +1848,7 @@ describe('POST /credentials/test', () => {
 		expect(mockCredentialsTester.testCredentials.mock.calls[0][1]).toBe(savedCredential.type);
 		expect(mockCredentialsTester.testCredentials.mock.calls[0][2]).toEqual({
 			id: savedCredential.id,
+			name: savedCredential.name,
 			type: savedCredential.type,
 			data: credential.data,
 		});


### PR DESCRIPTION
## Summary

Add Data Transfer Objects (DTOs) for credential-related API endpoints to improve code organization and type safety. Replaces inline Zod validation in the controller with dedicated DTO classes in `@n8n/api-types`, providing better reusability across the codebase.

**Changes include:**
- 5 new DTOs: `CredentialsForWorkflowQueryDto`, `ShareCredentialsBodyDto`, `TestCredentialsBodyDto`, `TransferCredentialBodyDto`, `UpdateCredentialDto`
- 572 lines of comprehensive test coverage for all DTOs
- Improved type safety by using `z.unknown()` instead of `z.any()` where possible (there are some exceptions).
- Controller methods updated to use `@Body` and `@Query` decorators
- All existing tests pass (96/96)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-614

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] Tests included (572 lines of test coverage across 5 DTOs)
- [x] Type safety validated (`pnpm typecheck` passes)
- [x] All tests passing (96 tests)