### PR TITLE
feat(editor): Add text search to IconPicker

### DIFF
--- a/packages/frontend/@n8n/design-system/package.json
+++ b/packages/frontend/@n8n/design-system/package.json
@@ -54,7 +54,7 @@
     "@tanstack/vue-table": "^8.21.2",
     "clsx": "^2.1.1",
     "element-plus": "catalog:frontend",
-    "emojibase-data": "^15.3.2",
+    "emojibase-data": "^17.0.0",
     "is-emoji-supported": "^0.0.5",
     "lodash": "catalog:",
     "markdown-it": "^13.0.2",

--- a/packages/frontend/@n8n/design-system/package.json
+++ b/packages/frontend/@n8n/design-system/package.json
@@ -54,6 +54,7 @@
     "@tanstack/vue-table": "^8.21.2",
     "clsx": "^2.1.1",
     "element-plus": "catalog:frontend",
+    "emojibase-data": "^15.3.2",
     "is-emoji-supported": "^0.0.5",
     "lodash": "catalog:",
     "markdown-it": "^13.0.2",

--- a/packages/frontend/@n8n/design-system/src/components/N8nIconPicker/IconPicker.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nIconPicker/IconPicker.test.ts
@@ -224,24 +224,32 @@ describe('IconPicker', () => {
 		const emojis = queryAllByTestId('icon-picker-emoji');
 		const emojiTexts = emojis.map((e) => e.textContent);
 		expect(emojiTexts).toMatchInlineSnapshot(`
-				[
-				  "😁",
-				  "😃",
-				  "😄",
-				  "😅",
-				  "😆",
-				  "😈",
-				  "😊",
-				  "😋",
-				  "😍",
-				  "😙",
-				  "😸",
-				  "😺",
-				  "😻",
-				  "😼",
-				  "🙂",
-				]
-			`);
+			[
+			  "😀",
+			  "😁",
+			  "😃",
+			  "😄",
+			  "😅",
+			  "😆",
+			  "😇",
+			  "😈",
+			  "😊",
+			  "😋",
+			  "😍",
+			  "😎",
+			  "😙",
+			  "😬",
+			  "😸",
+			  "😺",
+			  "😻",
+			  "😼",
+			  "🙂",
+			  "🙃",
+			  "🤩",
+			  "🥰",
+			  "🥲",
+			]
+		`);
 	});
 
 	it('selects random icon from search results when random button is clicked', async () => {

--- a/packages/frontend/@n8n/design-system/src/components/N8nIconPicker/IconPicker.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nIconPicker/IconPicker.test.ts
@@ -185,4 +185,92 @@ describe('IconPicker', () => {
 			value: '😀',
 		});
 	});
+
+	it('shows combined results with both icons and emojis during search', async () => {
+		const { getByTestId, findAllByTestId, queryAllByTestId, queryByTestId } = render(IconPicker, {
+			props: {
+				modelValue: { type: 'icon', value: 'smile' },
+				buttonTooltip: 'Select an icon',
+			},
+			global: {
+				plugins: [router],
+				components,
+				stubs: ['N8nIcon', 'N8nButton'],
+			},
+		});
+
+		await fireEvent.click(getByTestId('icon-picker-button'));
+		const searchInput = getByTestId('icon-picker-search');
+
+		// Search for "smile" which matches both icon name and emoji labels
+		await fireEvent.update(searchInput, 'smile');
+
+		// Wait for emoji metadata to load and emojis to appear
+		await findAllByTestId('icon-picker-emoji');
+
+		// Tabs should be hidden during search
+		expect(queryByTestId('icon-picker-tabs')).not.toBeInTheDocument();
+
+		// Verify specific icons matching "smile"
+		const icons = queryAllByTestId('icon-picker-icon');
+		const iconNames = icons.map((icon) => icon.getAttribute('icon'));
+		expect(iconNames).toMatchInlineSnapshot(`
+				[
+				  "smile",
+				]
+			`);
+
+		// Verify emojis with "smile" in their label/tags are present
+		const emojis = queryAllByTestId('icon-picker-emoji');
+		const emojiTexts = emojis.map((e) => e.textContent);
+		expect(emojiTexts).toMatchInlineSnapshot(`
+				[
+				  "😁",
+				  "😃",
+				  "😄",
+				  "😅",
+				  "😆",
+				  "😈",
+				  "😊",
+				  "😋",
+				  "😍",
+				  "😙",
+				  "😸",
+				  "😺",
+				  "😻",
+				  "😼",
+				  "🙂",
+				]
+			`);
+	});
+
+	it('selects random icon from search results when random button is clicked', async () => {
+		const { getByTestId, getByRole, emitted, findAllByTestId } = render(IconPicker, {
+			props: {
+				modelValue: { type: 'icon', value: 'smile' },
+				buttonTooltip: 'Select an icon',
+			},
+			global: {
+				plugins: [router],
+				components,
+				stubs: ['N8nIcon'],
+			},
+		});
+
+		await fireEvent.click(getByTestId('icon-picker-button'));
+
+		const searchInput = getByTestId('icon-picker-search');
+
+		// Search for "smile" which matches both icon name and emoji labels
+		await fireEvent.update(searchInput, 'donut');
+
+		// Wait for emoji metadata to load and emojis to appear
+		await findAllByTestId('icon-picker-emoji');
+
+		const randomButton = getByRole('button', { name: 'Random' });
+		await fireEvent.click(randomButton);
+
+		expect(emitted('update:modelValue')).toHaveLength(1);
+		expect(emitted('update:modelValue')[0]).toEqual([{ type: 'emoji', value: '🍩' }]);
+	});
 });

--- a/packages/frontend/@n8n/design-system/src/components/N8nIconPicker/IconPicker.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nIconPicker/IconPicker.vue
@@ -87,8 +87,6 @@ const filteredEmojis = computed(() => {
 		return emojis.value;
 	}
 
-	void loadEmojiMetadataMap();
-
 	const query = searchQuery.value.toLowerCase();
 	return emojis.value.filter((emoji) => {
 		const metadata = emojiMetadataMap.value?.get(emoji);
@@ -207,6 +205,7 @@ async function loadEmojiMetadataMap() {
 					:clearable="true"
 					size="small"
 					data-test-id="icon-picker-search"
+					@input="loadEmojiMetadataMap"
 				>
 					<template #prefix>
 						<N8nIcon icon="search" :size="16" />

--- a/packages/frontend/@n8n/design-system/src/locale/lang/en.ts
+++ b/packages/frontend/@n8n/design-system/src/locale/lang/en.ts
@@ -81,6 +81,7 @@ export default {
 	'iconPicker.tabs.icons': 'Icons',
 	'iconPicker.tabs.emojis': 'Emojis',
 	'iconPicker.search.placeholder': 'Search...',
+	'iconPicker.random': 'Random',
 	'selectableList.addDefault': '+ Add a',
 	'auth.changePassword.passwordsMustMatchError': 'Passwords must match',
 	'tableControlsButton.display': 'Display',

--- a/packages/frontend/@n8n/design-system/src/locale/lang/en.ts
+++ b/packages/frontend/@n8n/design-system/src/locale/lang/en.ts
@@ -80,6 +80,7 @@ export default {
 	'iconPicker.button.defaultToolTip': 'Choose icon',
 	'iconPicker.tabs.icons': 'Icons',
 	'iconPicker.tabs.emojis': 'Emojis',
+	'iconPicker.search.placeholder': 'Search...',
 	'selectableList.addDefault': '+ Add a',
 	'auth.changePassword.passwordsMustMatchError': 'Passwords must match',
 	'tableControlsButton.display': 'Display',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2482,8 +2482,8 @@ importers:
         specifier: catalog:frontend
         version: 2.4.3(patch_hash=3bc4ea0a42ad52c6bbc3d06c12c2963d55b57d6b5b8d436e46e7fd8ff8c10661)(vue@3.5.26(typescript@5.9.2))
       emojibase-data:
-        specifier: ^15.3.2
-        version: 15.3.2(emojibase@17.0.0)
+        specifier: ^17.0.0
+        version: 17.0.0(emojibase@17.0.0)
       is-emoji-supported:
         specifier: ^0.0.5
         version: 0.0.5
@@ -11745,8 +11745,8 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
-  emojibase-data@15.3.2:
-    resolution: {integrity: sha512-TpDyTDDTdqWIJixV5sTA6OQ0P0JfIIeK2tFRR3q56G9LK65ylAZ7z3KyBXokpvTTJ+mLUXQXbLNyVkjvnTLE+A==}
+  emojibase-data@17.0.0:
+    resolution: {integrity: sha512-Yvgb5AWoHViHV/gq1qr5ZAarcBip+B27/ZLRsUJkbgAEaLlZ/fof9g882LTpmEpyhBNEC0m2SEmItljHsTygjA==}
     peerDependencies:
       emojibase: '*'
 
@@ -29599,7 +29599,7 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
-  emojibase-data@15.3.2(emojibase@17.0.0):
+  emojibase-data@17.0.0(emojibase@17.0.0):
     dependencies:
       emojibase: 17.0.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2481,6 +2481,9 @@ importers:
       element-plus:
         specifier: catalog:frontend
         version: 2.4.3(patch_hash=3bc4ea0a42ad52c6bbc3d06c12c2963d55b57d6b5b8d436e46e7fd8ff8c10661)(vue@3.5.26(typescript@5.9.2))
+      emojibase-data:
+        specifier: ^15.3.2
+        version: 15.3.2(emojibase@17.0.0)
       is-emoji-supported:
         specifier: ^0.0.5
         version: 0.0.5
@@ -11741,6 +11744,15 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  emojibase-data@15.3.2:
+    resolution: {integrity: sha512-TpDyTDDTdqWIJixV5sTA6OQ0P0JfIIeK2tFRR3q56G9LK65ylAZ7z3KyBXokpvTTJ+mLUXQXbLNyVkjvnTLE+A==}
+    peerDependencies:
+      emojibase: '*'
+
+  emojibase@17.0.0:
+    resolution: {integrity: sha512-bXdpf4HPY3p41zK5swVKZdC/VynsMZ4LoLxdYDE+GucqkFwzcM1GVc4ODfYAlwoKaf2U2oNNUoOO78N96ovpBA==}
+    engines: {node: '>=18.12.0'}
 
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
@@ -29586,6 +29598,12 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  emojibase-data@15.3.2(emojibase@17.0.0):
+    dependencies:
+      emojibase: 17.0.0
+
+  emojibase@17.0.0: {}
 
   empathic@2.0.0: {}
 


### PR DESCRIPTION
## Summary

This PR implements text search and random select button in IconPicker to make it easier for users to find and choose one. The reason for random selection button is being able to visually distinguish agents is sometimes enough.

The text search is implemented with emojibase (MIT) and the data is lazily loaded when search keyword is typed.

The picker is currently used for project icon and ChatHub workflow & personal agent icon/emoji.

<img width="512" height="219" alt="Screenshot 2026-02-05 at 12 06 13" src="https://github.com/user-attachments/assets/56ee1269-2931-401e-9443-08cc5dfbc196" />


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
