### PR TITLE
fix(editor): Fix alignment if workfow history items (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryListItem.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryListItem.vue
@@ -44,15 +44,6 @@ const usersStore = useUsersStore();
 
 const actionsVisible = ref(false);
 const itemElement = ref<HTMLElement | null>(null);
-const authorElement = ref<InstanceType<typeof N8nText> | null>(null);
-const isAuthorElementTruncated = ref(false);
-
-const checkAuthorTruncation = () => {
-	const el = authorElement.value?.$el;
-	if (el instanceof HTMLElement) {
-		isAuthorElementTruncated.value = el.scrollWidth > el.clientWidth;
-	}
-};
 
 const formattedCreatedAt = computed<string>(() => {
 	const { date, time } = formatTimestamp(props.item.createdAt);
@@ -198,7 +189,6 @@ onMounted(() => {
 		offsetTop: itemElement.value?.offsetTop ?? 0,
 		isSelected: props.isSelected,
 	});
-	checkAuthorTruncation();
 });
 </script>
 <template>
@@ -256,39 +246,19 @@ onMounted(() => {
 							</N8nText>
 						</div>
 						<div :class="$style.metaRow">
-							<N8nTooltip
-								placement="right-end"
-								:disabled="!isAuthorElementTruncated"
-								:show-after="300"
-							>
-								<template #content>{{ props.item.authors }}</template>
-								<N8nText
-									ref="authorElement"
-									size="small"
-									color="text-base"
-									:class="$style.metaItem"
-								>
-									{{ authors.label }},
-								</N8nText>
-							</N8nTooltip>
-							<N8nText tag="time" size="small" color="text-base" :class="$style.metaItem">
+							<N8nText size="small" color="text-base" :class="$style.metaAuthor">
+								{{ authors.label }},
+							</N8nText>
+							<N8nText tag="time" size="small" color="text-base" :class="$style.metaTime">
 								{{ formattedCreatedAt }}
 							</N8nText>
 						</div>
 					</template>
 					<!-- Unnamed version: show author and time on single row -->
 					<div v-else :class="$style.unnamedRow">
-						<N8nTooltip placement="right-end" :disabled="!isAuthorElementTruncated">
-							<template #content>{{ props.item.authors }}</template>
-							<N8nText
-								ref="authorElement"
-								size="small"
-								color="text-base"
-								:class="$style.unnamedAuthor"
-							>
-								{{ authors.label }},
-							</N8nText>
-						</N8nTooltip>
+						<N8nText size="small" color="text-base" :class="$style.unnamedAuthor">
+							{{ authors.label }},
+						</N8nText>
 						<N8nText tag="time" size="small" color="text-base" :class="$style.unnamedTime">
 							{{ formattedCreatedAt }}
 						</N8nText>
@@ -311,6 +281,7 @@ onMounted(() => {
 
 $timelineDotSize: 8px;
 $hoverBackground: var(--color--background--light-1);
+$authorMaxWidth: 130px;
 
 .item {
 	display: flex;
@@ -425,36 +396,48 @@ $hoverBackground: var(--color--background--light-1);
 	align-items: center;
 	gap: var(--spacing--5xs);
 	margin-top: var(--spacing--5xs);
+	min-width: 0;
 }
 
-.metaItem {
-	max-width: 120px;
+.metaAuthor {
+	display: block;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+	max-width: $authorMaxWidth;
+}
+
+.metaTime {
+	white-space: nowrap;
+	flex-shrink: 0;
 }
 
 // Unnamed version styles
 .unnamedRow {
 	display: flex;
 	align-items: center;
+	min-width: 0;
+	gap: var(--spacing--5xs);
 }
 
 .unnamedAuthor {
+	display: block;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	max-width: 110px;
+	max-width: $authorMaxWidth;
 }
 
 .unnamedTime {
-	margin-left: var(--spacing--5xs);
 	white-space: nowrap;
+	flex-shrink: 0;
 }
 
 .actions {
 	display: block;
 	padding: var(--spacing--3xs);
+	flex-shrink: 0;
+	align-self: center;
 }
 
 .publishedBadge {


### PR DESCRIPTION
## Summary

<img width="423" height="252" alt="image" src="https://github.com/user-attachments/assets/9627a319-cc77-45fd-9f4c-745b899cefca" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4767/bug-broken-alignment-on-workflow-history-page


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
