### PR TITLE
ci: Remove secrets.NPM_TOKEN access in preparation for OIDC

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -644,7 +644,7 @@ cosign verify-attestation --type openvex \
 
 | Category            | Secrets                                                     |
 |---------------------|-------------------------------------------------------------|
-| Package Publishing  | `NPM_TOKEN`, `DOCKER_USERNAME`, `DOCKER_PASSWORD`           |
+| Package Publishing  | `DOCKER_USERNAME`, `DOCKER_PASSWORD`           |
 | Notifications       | `SLACK_WEBHOOK_URL`, `QBOT_SLACK_TOKEN`                     |
 | Code Quality        | `CODECOV_TOKEN`, `CHROMATIC_PROJECT_TOKEN`, `CURRENTS_RECORD_KEY` |
 | Error Tracking      | `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_*_PROJECT`       |

--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -644,7 +644,7 @@ cosign verify-attestation --type openvex \
 
 | Category            | Secrets                                                     |
 |---------------------|-------------------------------------------------------------|
-| Package Publishing  | `DOCKER_USERNAME`, `DOCKER_PASSWORD`           |
+| Package Publishing  | `NPM_TOKEN`, `DOCKER_USERNAME`, `DOCKER_PASSWORD`           |
 | Notifications       | `SLACK_WEBHOOK_URL`, `QBOT_SLACK_TOKEN`                     |
 | Code Quality        | `CODECOV_TOKEN`, `CHROMATIC_PROJECT_TOKEN`, `CURRENTS_RECORD_KEY` |
 | Error Tracking      | `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_*_PROJECT`       |

--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -14,12 +14,10 @@ inputs:
     description: 'Whether to set up Blacksmith Buildx for Docker layer caching (Blacksmith runners only).'
     required: false
     default: 'false'
-    type: boolean
   build-command:
     description: 'Command to execute for building the project or an optional command. Leave empty to skip build step.'
     required: false
     default: 'pnpm build'
-    type: string
 
 runs:
   using: 'composite'

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -28,6 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true
     timeout-minutes: 20
+    environment: npm
     permissions:
       id-token: write
     env:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -64,7 +64,6 @@ jobs:
 
       - name: Pre publishing changes
         run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
           node .github/scripts/trim-fe-packageJson.js
           node .github/scripts/ensure-provenance-fields.mjs
           cp README.md packages/cli/README.md

--- a/.github/workflows/release-push-to-channel.yml
+++ b/.github/workflows/release-push-to-channel.yml
@@ -57,12 +57,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: validate-inputs
     timeout-minutes: 5
+    permissions:
+      id-token: write
     steps:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
-
-      - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
 
       - name: Add beta/next tags to NPM
         if: needs.validate-inputs.outputs.release_channel == 'beta'

--- a/.github/workflows/release-push-to-channel.yml
+++ b/.github/workflows/release-push-to-channel.yml
@@ -64,6 +64,9 @@ jobs:
         with:
           node-version: 22.x
 
+      # Remove after https://github.com/npm/cli/issues/8547 gets resolved
+      - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+
       - name: Add beta/next tags to NPM
         if: needs.validate-inputs.outputs.release_channel == 'beta'
         run: |

--- a/.github/workflows/release-standalone-package.yml
+++ b/.github/workflows/release-standalone-package.yml
@@ -15,6 +15,7 @@ on:
           - '@n8n/eslint-plugin-community-nodes'
           - '@n8n/node-cli'
           - '@n8n/scan-community-package'
+# All packages listed above require OIDC enabled in NPM. https://docs.npmjs.com/trusted-publishers
 
 concurrency:
   group: release-package-${{ github.event.inputs.package }}

--- a/.github/workflows/release-standalone-package.yml
+++ b/.github/workflows/release-standalone-package.yml
@@ -50,11 +50,9 @@ jobs:
 
       - name: Pre publishing changes
         run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
           node .github/scripts/ensure-provenance-fields.mjs
 
       - name: Publish package
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           PACKAGE: ${{ github.event.inputs.package }}
         run: pnpm --filter "$PACKAGE" publish --access public --no-git-checks --publish-branch master

--- a/.github/workflows/release-standalone-package.yml
+++ b/.github/workflows/release-standalone-package.yml
@@ -29,6 +29,7 @@ jobs:
     name: Publish to NPM
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    environment: npm
     permissions:
       id-token: write
     env:


### PR DESCRIPTION
## Summary

Remove usage of secrets.NPM_TOKEN as we prepare to move into using OIDC and [Trusted Publishing](https://docs.npmjs.com/trusted-publishers)

Changes to `setup-nodejs` were just an actionlint fix.

## Related Linear tickets, Github issues, and Community forum posts

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
