### PR TITLE
fix(core): Avoid fetching workflows unpaginated if `getWorkflows` API is used with projectId

### DIFF
--- a/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
@@ -198,13 +198,12 @@ export = {
 					const workflows = await Container.get(WorkflowFinderService).findAllWorkflowsForUser(
 						req.user,
 						['workflow:read'],
+						undefined,
+						projectId,
+						true,
 					);
 
-					const workflowIds = workflows
-						.filter((workflow) => workflow.projectId === projectId)
-						.map((workflow) => workflow.id);
-
-					where.id = In(workflowIds);
+					where.id = In(workflows.map(({ id }) => id));
 				}
 			} else {
 				const options: { workflowIds?: string[] } = {};
@@ -218,15 +217,14 @@ export = {
 				let workflows = await Container.get(WorkflowFinderService).findAllWorkflowsForUser(
 					req.user,
 					['workflow:read'],
+					undefined,
+					projectId,
+					true,
 				);
 
 				if (options.workflowIds) {
 					const workflowIds = options.workflowIds;
 					workflows = workflows.filter((wf) => workflowIds.includes(wf.id));
-				}
-
-				if (projectId) {
-					workflows = workflows.filter((w) => w.projectId === projectId);
 				}
 
 				if (!workflows.length) {

--- a/packages/cli/src/workflows/workflow-finder.service.ts
+++ b/packages/cli/src/workflows/workflow-finder.service.ts
@@ -62,13 +62,7 @@ export class WorkflowFinderService {
 		return sharedWorkflow.workflow;
 	}
 
-	async findAllWorkflowsForUser(
-		user: User,
-		scopes: Scope[],
-		folderId?: string,
-		projectId?: string,
-		returnIds = false,
-	) {
+	private async findAllWhere(user: User, scopes: Scope[], folderId?: string, projectId?: string) {
 		let where: FindOptionsWhere<SharedWorkflow> = {};
 
 		if (folderId) {
@@ -111,14 +105,31 @@ export class WorkflowFinderService {
 			};
 		}
 
-		if (returnIds) {
-			const sharedWorkflows = await this.sharedWorkflowRepository.find({
-				select: { workflowId: true, projectId: true },
-				where,
-			});
+		return where;
+	}
 
-			return sharedWorkflows.map(({ workflowId: id, projectId }) => ({ id, projectId }));
-		}
+	async findAllWorkflowIdsForUser(
+		user: User,
+		scopes: Scope[],
+		folderId?: string,
+		projectId?: string,
+	) {
+		const where = await this.findAllWhere(user, scopes, folderId, projectId);
+		const sharedWorkflows = await this.sharedWorkflowRepository.find({
+			select: { workflowId: true, projectId: true },
+			where,
+		});
+
+		return sharedWorkflows.map(({ workflowId }) => workflowId);
+	}
+
+	async findAllWorkflowsForUser(
+		user: User,
+		scopes: Scope[],
+		folderId?: string,
+		projectId?: string,
+	) {
+		const where = await this.findAllWhere(user, scopes, folderId, projectId);
 
 		const sharedWorkflows = await this.sharedWorkflowRepository.find({
 			where,

--- a/packages/cli/src/workflows/workflow-finder.service.ts
+++ b/packages/cli/src/workflows/workflow-finder.service.ts
@@ -3,7 +3,7 @@ import { SharedWorkflowRepository, FolderRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { hasGlobalScope, type Scope } from '@n8n/permissions';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
-import type { EntityManager, FindOptionsWhere } from '@n8n/typeorm';
+import type { EntityManager, FindManyOptions, FindOptionsWhere } from '@n8n/typeorm';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In } from '@n8n/typeorm';
 
@@ -67,6 +67,7 @@ export class WorkflowFinderService {
 		scopes: Scope[],
 		folderId?: string,
 		projectId?: string,
+		returnIds = false,
 	) {
 		let where: FindOptionsWhere<SharedWorkflow> = {};
 
@@ -101,6 +102,22 @@ export class WorkflowFinderService {
 					},
 				},
 			};
+		} else if (projectId) {
+			where = {
+				...where,
+				project: {
+					id: projectId,
+				},
+			};
+		}
+
+		if (returnIds) {
+			const sharedWorkflows = await this.sharedWorkflowRepository.find({
+				select: { workflowId: true, projectId: true },
+				where,
+			});
+
+			return sharedWorkflows.map(({ workflowId: id, projectId }) => ({ id, projectId }));
 		}
 
 		const sharedWorkflows = await this.sharedWorkflowRepository.find({

--- a/packages/cli/src/workflows/workflow-finder.service.ts
+++ b/packages/cli/src/workflows/workflow-finder.service.ts
@@ -3,7 +3,7 @@ import { SharedWorkflowRepository, FolderRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { hasGlobalScope, type Scope } from '@n8n/permissions';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
-import type { EntityManager, FindManyOptions, FindOptionsWhere } from '@n8n/typeorm';
+import type { EntityManager, FindOptionsWhere } from '@n8n/typeorm';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In } from '@n8n/typeorm';
 

--- a/packages/cli/test/integration/folder/folder.controller.test.ts
+++ b/packages/cli/test/integration/folder/folder.controller.test.ts
@@ -507,7 +507,7 @@ describe('GET /projects/:projectId/folders/:folderId/credentials', () => {
 						},
 					],
 				},
-				owner,
+				project,
 			);
 		}
 


### PR DESCRIPTION
## Summary

Also fix a latent bug in `WorkflowFinderService.findAllWorkflowsForUser`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4602


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
