### PR TITLE
fix(editor): Truncate long version names in workflow history

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryContent.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryContent.vue
@@ -205,6 +205,7 @@ $descriptionBoxMaxWidth: 330px;
 }
 
 .mainLine {
+	display: block;
 	@include mixins.utils-ellipsis;
 	cursor: default;
 }


### PR DESCRIPTION
## Summary

Before: 
<img height="200" alt="image" src="https://github.com/user-attachments/assets/950eba4e-5664-4d1f-8bf0-f44d8ea2ce51" />

After:
<img height="200" alt="image" src="https://github.com/user-attachments/assets/d87b6130-377e-4a2a-82d8-5fa654506551" />

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-4773](https://linear.app/n8n/issue/ADO-4773/bug-long-wf-history-version-names-are-not-truncated)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
