### PR TITLE
fix(editor): Skip welcome screen when agent is pre-selected

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
@@ -129,6 +129,11 @@ const showWelcomeScreen = computed<boolean | undefined>(() => {
 		return false; // return false early to make UI ready fast
 	}
 
+	// Skip welcome screen if an agent is pre-selected via query params
+	if (route.query.workflowId || route.query.agentId) {
+		return false;
+	}
+
 	if (!chatStore.sessionsReady) {
 		return undefined; // not known yet
 	}


### PR DESCRIPTION
## Summary

Prevent the welcome screen from being displayed on Chat hub when a user with no chat history clicks on a workflow or personal agent. When navigating to `/home/chat?workflowId=xxx` or `/home/chat?agentId=xxx`, the chat interface is now shown directly with the selected agent, instead of the welcome screen.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-131

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [ ] Docs updated or follow-up ticket created
- [ ] Tests included