### PR TITLE
ci: Use repository context for GHCR image names

### DIFF
--- a/.github/scripts/cleanup-ghcr-images.mjs
+++ b/.github/scripts/cleanup-ghcr-images.mjs
@@ -16,8 +16,9 @@ import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
 
 const execAsync = promisify(exec);
-const ORG = 'n8n-io';
-const PACKAGES = ['n8n', 'runners'];
+const ORG = process.env.GHCR_ORG || 'n8n-io';
+const REPO = process.env.GHCR_REPO || 'n8n';
+const PACKAGES = [REPO, 'runners'];
 const [mode, rawValue] = process.argv.slice(2);
 
 if (!['--tag', '--pr', '--stale'].includes(mode) || !rawValue) {

--- a/.github/workflows/test-e2e-ci-reusable.yml
+++ b/.github/workflows/test-e2e-ci-reusable.yml
@@ -10,7 +10,7 @@ on:
         default: ''
 
 env:
-  DOCKER_IMAGE: ghcr.io/n8n-io/n8n:pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
+  DOCKER_IMAGE: ghcr.io/${{ github.repository }}:pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
 
 jobs:
   prepare:
@@ -43,9 +43,9 @@ jobs:
           enable-docker-cache: true
         env:
           INCLUDE_TEST_CONTROLLER: 'true'
-          IMAGE_BASE_NAME: ghcr.io/n8n-io/n8n
+          IMAGE_BASE_NAME: ghcr.io/${{ github.repository }}
           IMAGE_TAG: pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
-          RUNNERS_IMAGE_BASE_NAME: ghcr.io/n8n-io/runners
+          RUNNERS_IMAGE_BASE_NAME: ghcr.io/${{ github.repository_owner }}/runners
 
       - name: Generate shard matrix
         id: generate-matrix
@@ -59,7 +59,7 @@ jobs:
     with:
       branch: ${{ inputs.branch }}
       test-mode: docker-pull
-      docker-image: ghcr.io/n8n-io/n8n:pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
+      docker-image: ghcr.io/${{ github.repository }}:pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
       test-command: pnpm --filter=n8n-playwright test:container:sqlite:e2e tests/e2e/building-blocks/workflow-entry-points.spec.ts
       shards: 1
       runner: blacksmith-2vcpu-ubuntu-2204
@@ -77,7 +77,7 @@ jobs:
     with:
       branch: ${{ inputs.branch }}
       test-mode: docker-pull
-      docker-image: ghcr.io/n8n-io/n8n:pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
+      docker-image: ghcr.io/${{ github.repository }}:pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
       test-command: pnpm --filter=n8n-playwright test:container:multi-main:e2e
       shards: 16
       runner: blacksmith-2vcpu-ubuntu-2204
@@ -120,6 +120,8 @@ jobs:
       - name: Delete images from GHCR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_ORG: ${{ github.repository_owner }}
+          GHCR_REPO: ${{ github.event.repository.name }}
         run: |
           if [ -n "${{ github.event.pull_request.number }}" ]; then
             echo "PR context: cleaning all images for PR ${{ github.event.pull_request.number }}"

--- a/.github/workflows/util-cleanup-pr-images.yml
+++ b/.github/workflows/util-cleanup-pr-images.yml
@@ -22,4 +22,6 @@ jobs:
       - name: Delete stale PR images
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_ORG: ${{ github.repository_owner }}
+          GHCR_REPO: ${{ github.event.repository.name }}
         run: node .github/scripts/cleanup-ghcr-images.mjs --stale 7


### PR DESCRIPTION
## Summary

Updates workflows to use the repository context when defining GHCR image names. This allows the workflows to correctly identify and clean up images when running in forked repositories, as well as accommodate different repository names or organizations. It also adds GHCR_ORG and GHCR_REPO environment variables to the cleanup script so that it can be run on forked repositories.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
