### PR TITLE
refactor(core): Replace `zod-class` with minimal implementation

### DIFF
--- a/packages/@n8n/api-types/package.json
+++ b/packages/@n8n/api-types/package.json
@@ -29,7 +29,6 @@
     "n8n-workflow": "workspace:*",
     "xss": "catalog:",
     "zod": "catalog:",
-    "zod-class": "0.0.16",
     "@n8n/permissions": "workspace:*"
   }
 }

--- a/packages/@n8n/api-types/src/chat-hub.ts
+++ b/packages/@n8n/api-types/src/chat-hub.ts
@@ -7,7 +7,8 @@ import {
 	INodeSchema,
 } from 'n8n-workflow';
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from './zod-class';
 
 /**
  * Supported AI model providers

--- a/packages/@n8n/api-types/src/dto/ai/ai-apply-suggestion-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/ai/ai-apply-suggestion-request.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class AiApplySuggestionRequestDto extends Z.class({
 	sessionId: z.string(),

--- a/packages/@n8n/api-types/src/dto/ai/ai-ask-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/ai/ai-ask-request.dto.ts
@@ -1,6 +1,7 @@
 import type { AiAssistantSDK, SchemaType } from '@n8n_io/ai-assistant-sdk';
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 // Note: This is copied from the sdk, since this type is not exported
 type Schema = {

--- a/packages/@n8n/api-types/src/dto/ai/ai-build-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/ai/ai-build-request.dto.ts
@@ -1,6 +1,7 @@
 import type { IRunExecutionData, IWorkflowBase, NodeExecutionSchema } from 'n8n-workflow';
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export interface ExpressionValue {
 	expression: string;

--- a/packages/@n8n/api-types/src/dto/ai/ai-chat-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/ai/ai-chat-request.dto.ts
@@ -1,6 +1,7 @@
 import type { AiAssistantSDK } from '@n8n_io/ai-assistant-sdk';
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class AiChatRequestDto
 	extends Z.class({

--- a/packages/@n8n/api-types/src/dto/ai/ai-free-credits-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/ai/ai-free-credits-request.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class AiFreeCreditsRequestDto extends Z.class({
 	projectId: z.string().min(1).optional(),

--- a/packages/@n8n/api-types/src/dto/ai/ai-session-retrieval-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/ai/ai-session-retrieval-request.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class AiSessionRetrievalRequestDto extends Z.class({
 	workflowId: z.string().optional(),

--- a/packages/@n8n/api-types/src/dto/ai/ai-truncate-messages-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/ai/ai-truncate-messages-request.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class AiTruncateMessagesRequestDto extends Z.class({
 	workflowId: z.string(),

--- a/packages/@n8n/api-types/src/dto/ai/ai-usage-settings-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/ai/ai-usage-settings-request.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class AiUsageSettingsRequestDto extends Z.class({
 	allowSendingParameterValues: z.boolean(),

--- a/packages/@n8n/api-types/src/dto/api-keys/update-api-key-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/api-keys/update-api-key-request.dto.ts
@@ -1,8 +1,8 @@
 import xss from 'xss';
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
 import { scopesSchema } from '../../schemas/scopes.schema';
+import { Z } from '../../zod-class';
 
 const xssCheck = (value: string) =>
 	value ===

--- a/packages/@n8n/api-types/src/dto/auth/login-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/auth/login-request.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class LoginRequestDto extends Z.class({
 	/*

--- a/packages/@n8n/api-types/src/dto/auth/resolve-signup-token-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/auth/resolve-signup-token-query.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 // Support both legacy format (inviterId + inviteeId) and new JWT format (token)
 // All fields are optional at the schema level, but validation ensures either token OR (inviterId AND inviteeId) are provided

--- a/packages/@n8n/api-types/src/dto/binary-data/binary-data-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/binary-data/binary-data-query.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class BinaryDataQueryDto extends Z.class({
 	id: z

--- a/packages/@n8n/api-types/src/dto/binary-data/binary-data-signed-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/binary-data/binary-data-signed-query.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class BinaryDataSignedQueryDto extends Z.class({
 	token: z.string().regex(/^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/, {

--- a/packages/@n8n/api-types/src/dto/credential-resolver/create-credential-resolver.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credential-resolver/create-credential-resolver.dto.ts
@@ -1,10 +1,9 @@
-import { Z } from 'zod-class';
-
 import {
 	credentialResolverNameSchema,
 	credentialResolverConfigSchema,
 	credentialResolverTypeNameSchema,
 } from '../../schemas/credential-resolver.schema';
+import { Z } from '../../zod-class';
 
 export class CreateCredentialResolverDto extends Z.class({
 	name: credentialResolverNameSchema,

--- a/packages/@n8n/api-types/src/dto/credential-resolver/update-credential-resolver.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credential-resolver/update-credential-resolver.dto.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
 import {
 	credentialResolverNameSchema,
 	credentialResolverConfigSchema,
 	credentialResolverTypeNameSchema,
 } from '../../schemas/credential-resolver.schema';
+import { Z } from '../../zod-class';
 
 export class UpdateCredentialResolverDto extends Z.class({
 	type: credentialResolverTypeNameSchema.optional(),

--- a/packages/@n8n/api-types/src/dto/credentials/create-credential.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/create-credential.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class CreateCredentialDto extends Z.class({
 	name: z.string().min(1).max(128),

--- a/packages/@n8n/api-types/src/dto/credentials/credentials-get-many-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/credentials-get-many-request.dto.ts
@@ -1,6 +1,5 @@
-import { Z } from 'zod-class';
-
 import { booleanFromString } from '../../schemas/boolean-from-string';
+import { Z } from '../../zod-class';
 
 export class CredentialsGetManyRequestQuery extends Z.class({
 	/**

--- a/packages/@n8n/api-types/src/dto/credentials/credentials-get-one-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/credentials-get-one-request.dto.ts
@@ -1,6 +1,5 @@
-import { Z } from 'zod-class';
-
 import { booleanFromString } from '../../schemas/boolean-from-string';
+import { Z } from '../../zod-class';
 
 export class CredentialsGetOneRequestQuery extends Z.class({
 	/**

--- a/packages/@n8n/api-types/src/dto/credentials/generate-credential-name.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/generate-credential-name.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class GenerateCredentialNameRequestQuery extends Z.class({
 	name: z.string().optional(),

--- a/packages/@n8n/api-types/src/dto/data-table/add-data-table-column.dto.ts
+++ b/packages/@n8n/api-types/src/dto/data-table/add-data-table-column.dto.ts
@@ -1,5 +1,4 @@
-import { Z } from 'zod-class';
-
 import { dataTableCreateColumnSchema } from '../../schemas/data-table.schema';
+import { Z } from '../../zod-class';
 
 export class AddDataTableColumnDto extends Z.class(dataTableCreateColumnSchema.shape) {}

--- a/packages/@n8n/api-types/src/dto/data-table/add-data-table-rows.dto.ts
+++ b/packages/@n8n/api-types/src/dto/data-table/add-data-table-rows.dto.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
 import {
 	dataTableColumnNameSchema,
 	dataTableColumnValueSchema,
 	insertRowReturnType,
 } from '../../schemas/data-table.schema';
+import { Z } from '../../zod-class';
 
 export class AddDataTableRowsDto extends Z.class({
 	data: z.array(z.record(dataTableColumnNameSchema, dataTableColumnValueSchema)),

--- a/packages/@n8n/api-types/src/dto/data-table/create-data-table-column.dto.ts
+++ b/packages/@n8n/api-types/src/dto/data-table/create-data-table-column.dto.ts
@@ -1,9 +1,8 @@
-import { Z } from 'zod-class';
-
 import {
 	dataTableColumnNameSchema,
 	dataTableColumnTypeSchema,
 } from '../../schemas/data-table.schema';
+import { Z } from '../../zod-class';
 
 export class CreateDataTableColumnDto extends Z.class({
 	name: dataTableColumnNameSchema,

--- a/packages/@n8n/api-types/src/dto/data-table/create-data-table.dto.ts
+++ b/packages/@n8n/api-types/src/dto/data-table/create-data-table.dto.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
 import { CreateDataTableColumnDto } from './create-data-table-column.dto';
 import { dataTableNameSchema } from '../../schemas/data-table.schema';
+import { Z } from '../../zod-class';
 
 export class CreateDataTableDto extends Z.class({
 	name: dataTableNameSchema,
-	columns: z.array(CreateDataTableColumnDto),
+	columns: z.array(CreateDataTableColumnDto.schema),
 	fileId: z.string().optional(),
 	hasHeaders: z.boolean().optional(),
 }) {}

--- a/packages/@n8n/api-types/src/dto/data-table/delete-data-table-rows.dto.ts
+++ b/packages/@n8n/api-types/src/dto/data-table/delete-data-table-rows.dto.ts
@@ -1,8 +1,8 @@
 import { jsonParse } from 'n8n-workflow';
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
 import { dataTableFilterSchema } from '../../schemas/data-table-filter.schema';
+import { Z } from '../../zod-class';
 
 const dataTableFilterQueryValidator = z.string().transform((val, ctx) => {
 	if (!val) {

--- a/packages/@n8n/api-types/src/dto/data-table/list-data-table-content-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/data-table/list-data-table-content-query.dto.ts
@@ -1,9 +1,9 @@
 import { jsonParse } from 'n8n-workflow';
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
 import { dataTableFilterSchema } from '../../schemas/data-table-filter.schema';
 import { dataTableColumnNameSchema } from '../../schemas/data-table.schema';
+import { Z } from '../../zod-class';
 import { paginationSchema, publicApiPaginationSchema } from '../pagination/pagination.dto';
 
 const filterValidator = z

--- a/packages/@n8n/api-types/src/dto/data-table/list-data-table-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/data-table/list-data-table-query.dto.ts
@@ -1,7 +1,7 @@
 import { jsonParse } from 'n8n-workflow';
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
+import { Z } from '../../zod-class';
 import { paginationSchema, publicApiPaginationSchema } from '../pagination/pagination.dto';
 
 const VALID_SORT_OPTIONS = [

--- a/packages/@n8n/api-types/src/dto/data-table/move-data-table-column.dto.ts
+++ b/packages/@n8n/api-types/src/dto/data-table/move-data-table-column.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class MoveDataTableColumnDto extends Z.class({
 	targetIndex: z.number().int().nonnegative(),

--- a/packages/@n8n/api-types/src/dto/data-table/rename-data-table-column.dto.ts
+++ b/packages/@n8n/api-types/src/dto/data-table/rename-data-table-column.dto.ts
@@ -1,6 +1,5 @@
-import { Z } from 'zod-class';
-
 import { dataTableColumnNameSchema } from '../../schemas/data-table.schema';
+import { Z } from '../../zod-class';
 
 export class RenameDataTableColumnDto extends Z.class({
 	name: dataTableColumnNameSchema,

--- a/packages/@n8n/api-types/src/dto/data-table/update-data-table-row.dto.ts
+++ b/packages/@n8n/api-types/src/dto/data-table/update-data-table-row.dto.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
 import { dataTableFilterSchema } from '../../schemas/data-table-filter.schema';
 import {
 	dataTableColumnNameSchema,
 	dataTableColumnValueSchema,
 } from '../../schemas/data-table.schema';
+import { Z } from '../../zod-class';
 
 const updateFilterSchema = dataTableFilterSchema.refine((filter) => filter.filters.length > 0, {
 	message: 'filter must not be empty',

--- a/packages/@n8n/api-types/src/dto/data-table/update-data-table.dto.ts
+++ b/packages/@n8n/api-types/src/dto/data-table/update-data-table.dto.ts
@@ -1,6 +1,5 @@
-import { Z } from 'zod-class';
-
 import { dataTableNameSchema } from '../../schemas/data-table.schema';
+import { Z } from '../../zod-class';
 
 export class UpdateDataTableDto extends Z.class({
 	name: dataTableNameSchema,

--- a/packages/@n8n/api-types/src/dto/data-table/upsert-data-table-row.dto.ts
+++ b/packages/@n8n/api-types/src/dto/data-table/upsert-data-table-row.dto.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
 import { dataTableFilterSchema } from '../../schemas/data-table-filter.schema';
 import {
 	dataTableColumnNameSchema,
 	dataTableColumnValueSchema,
 } from '../../schemas/data-table.schema';
+import { Z } from '../../zod-class';
 
 const upsertFilterSchema = dataTableFilterSchema.refine((filter) => filter.filters.length > 0, {
 	message: 'filter must not be empty',

--- a/packages/@n8n/api-types/src/dto/dynamic-node-parameters/base-dynamic-parameters-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/dynamic-node-parameters/base-dynamic-parameters-request.dto.ts
@@ -1,8 +1,8 @@
 import type { INodeCredentials, INodeParameters, INodeTypeNameVersion } from 'n8n-workflow';
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
 import { nodeVersionSchema } from '../../schemas/node-version.schema';
+import { Z } from '../../zod-class';
 
 export class BaseDynamicParametersRequestDto extends Z.class({
 	path: z.string(),

--- a/packages/@n8n/api-types/src/dto/folders/create-folder.dto.ts
+++ b/packages/@n8n/api-types/src/dto/folders/create-folder.dto.ts
@@ -1,6 +1,5 @@
-import { Z } from 'zod-class';
-
 import { folderNameSchema, folderIdSchema } from '../../schemas/folder.schema';
+import { Z } from '../../zod-class';
 
 export class CreateFolderDto extends Z.class({
 	name: folderNameSchema,

--- a/packages/@n8n/api-types/src/dto/folders/delete-folder.dto.ts
+++ b/packages/@n8n/api-types/src/dto/folders/delete-folder.dto.ts
@@ -1,6 +1,5 @@
-import { Z } from 'zod-class';
-
 import { folderIdSchema } from '../../schemas/folder.schema';
+import { Z } from '../../zod-class';
 
 export class DeleteFolderDto extends Z.class({
 	transferToFolderId: folderIdSchema.optional(),

--- a/packages/@n8n/api-types/src/dto/folders/list-folder-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/folders/list-folder-query.dto.ts
@@ -1,6 +1,7 @@
 import { jsonParse } from 'n8n-workflow';
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 const VALID_SELECT_FIELDS = [
 	'id',

--- a/packages/@n8n/api-types/src/dto/folders/transfer-folder.dto.ts
+++ b/packages/@n8n/api-types/src/dto/folders/transfer-folder.dto.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
 import { folderIdSchema } from '../../schemas/folder.schema';
+import { Z } from '../../zod-class';
 
 export class TransferFolderBodyDto extends Z.class({
 	destinationProjectId: z.string(),

--- a/packages/@n8n/api-types/src/dto/folders/update-folder.dto.ts
+++ b/packages/@n8n/api-types/src/dto/folders/update-folder.dto.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
 import { folderNameSchema, folderIdSchema } from '../../schemas/folder.schema';
+import { Z } from '../../zod-class';
+
 export class UpdateFolderDto extends Z.class({
 	name: folderNameSchema.optional(),
 	tagIds: z.array(z.string().max(24)).optional(),

--- a/packages/@n8n/api-types/src/dto/insights/date-filter.dto.ts
+++ b/packages/@n8n/api-types/src/dto/insights/date-filter.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class InsightsDateFilterDto extends Z.class({
 	startDate: z.coerce.date().optional(),

--- a/packages/@n8n/api-types/src/dto/insights/list-workflow-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/insights/list-workflow-query.dto.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
+import { Z } from '../../zod-class';
 import { createTakeValidator, paginationSchema } from '../pagination/pagination.dto';
 
 export const MAX_ITEMS_PER_PAGE = 100;

--- a/packages/@n8n/api-types/src/dto/invitation/accept-invitation-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/invitation/accept-invitation-request.dto.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
 import { passwordSchema } from '../../schemas/password.schema';
+import { Z } from '../../zod-class';
 
 // Support both legacy format (inviterId) and new JWT format (token)
 // All fields are optional at the schema level, but validation ensures either token OR inviterId is provided

--- a/packages/@n8n/api-types/src/dto/license/community-registered-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/license/community-registered-request.dto.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class CommunityRegisteredRequestDto extends Z.class({ email: z.string().email() }) {}

--- a/packages/@n8n/api-types/src/dto/log-streaming/delete-destination-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/log-streaming/delete-destination-query.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class DeleteDestinationQueryDto extends Z.class({
 	id: z.string().min(1),

--- a/packages/@n8n/api-types/src/dto/log-streaming/get-destination-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/log-streaming/get-destination-query.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class GetDestinationQueryDto extends Z.class({
 	id: z.string().min(1).optional(),

--- a/packages/@n8n/api-types/src/dto/log-streaming/test-destination-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/log-streaming/test-destination-query.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class TestDestinationQueryDto extends Z.class({
 	id: z.string().min(1),

--- a/packages/@n8n/api-types/src/dto/node-types/get-node-types-by-identifier.dto.ts
+++ b/packages/@n8n/api-types/src/dto/node-types/get-node-types-by-identifier.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 /**
  * Schema for node type identifier in the format "name@version"

--- a/packages/@n8n/api-types/src/dto/oauth/oauth-client.dto.ts
+++ b/packages/@n8n/api-types/src/dto/oauth/oauth-client.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 /**
  * DTO for OAuth client response (excludes sensitive data like clientSecret)

--- a/packages/@n8n/api-types/src/dto/oidc/config.dto.ts
+++ b/packages/@n8n/api-types/src/dto/oidc/config.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class OidcConfigDto extends Z.class({
 	clientId: z.string().min(1),

--- a/packages/@n8n/api-types/src/dto/owner/dismiss-banner-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/owner/dismiss-banner-request.dto.ts
@@ -1,6 +1,5 @@
-import { Z } from 'zod-class';
-
 import { bannerNameSchema } from '../../schemas/banner-name.schema';
+import { Z } from '../../zod-class';
 
 export class DismissBannerRequestDto extends Z.class({
 	banner: bannerNameSchema.optional(),

--- a/packages/@n8n/api-types/src/dto/owner/owner-setup-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/owner/owner-setup-request.dto.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
 import { passwordSchema } from '../../schemas/password.schema';
+import { Z } from '../../zod-class';
 
 export class OwnerSetupRequestDto extends Z.class({
 	email: z.string().email(),

--- a/packages/@n8n/api-types/src/dto/pagination/pagination.dto.ts
+++ b/packages/@n8n/api-types/src/dto/pagination/pagination.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export const MAX_ITEMS_PER_PAGE = 250;
 

--- a/packages/@n8n/api-types/src/dto/password-reset/change-password-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/password-reset/change-password-request.dto.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
 import { passwordResetTokenSchema } from '../../schemas/password-reset-token.schema';
 import { passwordSchema } from '../../schemas/password.schema';
+import { Z } from '../../zod-class';
 
 export class ChangePasswordRequestDto extends Z.class({
 	token: passwordResetTokenSchema,

--- a/packages/@n8n/api-types/src/dto/password-reset/forgot-password-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/password-reset/forgot-password-request.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class ForgotPasswordRequestDto extends Z.class({
 	email: z.string().email().max(255),

--- a/packages/@n8n/api-types/src/dto/password-reset/resolve-password-token-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/password-reset/resolve-password-token-query.dto.ts
@@ -1,6 +1,5 @@
-import { Z } from 'zod-class';
-
 import { passwordResetTokenSchema } from '../../schemas/password-reset-token.schema';
+import { Z } from '../../zod-class';
 
 export class ResolvePasswordTokenQueryDto extends Z.class({
 	token: passwordResetTokenSchema,

--- a/packages/@n8n/api-types/src/dto/project/add-users-to-project.dto.ts
+++ b/packages/@n8n/api-types/src/dto/project/add-users-to-project.dto.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
 import { projectRelationSchema } from '../../schemas/project.schema';
+import { Z } from '../../zod-class';
 
 export class AddUsersToProjectDto extends Z.class({
 	relations: z.array(projectRelationSchema).min(1),

--- a/packages/@n8n/api-types/src/dto/project/change-user-role-in-project.dto.ts
+++ b/packages/@n8n/api-types/src/dto/project/change-user-role-in-project.dto.ts
@@ -1,5 +1,6 @@
 import { assignableProjectRoleSchema } from '@n8n/permissions';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class ChangeUserRoleInProject extends Z.class({
 	role: assignableProjectRoleSchema,

--- a/packages/@n8n/api-types/src/dto/project/create-project.dto.ts
+++ b/packages/@n8n/api-types/src/dto/project/create-project.dto.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
 import { projectIconSchema, projectNameSchema } from '../../schemas/project.schema';
+import { Z } from '../../zod-class';
 
 export class CreateProjectDto extends Z.class({
 	name: projectNameSchema,

--- a/packages/@n8n/api-types/src/dto/project/delete-project.dto.ts
+++ b/packages/@n8n/api-types/src/dto/project/delete-project.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class DeleteProjectDto extends Z.class({
 	transferId: z.string().optional(),

--- a/packages/@n8n/api-types/src/dto/project/update-project.dto.ts
+++ b/packages/@n8n/api-types/src/dto/project/update-project.dto.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
 import {
 	projectDescriptionSchema,
@@ -7,6 +6,7 @@ import {
 	projectNameSchema,
 	projectRelationSchema,
 } from '../../schemas/project.schema';
+import { Z } from '../../zod-class';
 
 const updateProjectShape = {
 	name: projectNameSchema.optional(),

--- a/packages/@n8n/api-types/src/dto/provisioning/config.dto.ts
+++ b/packages/@n8n/api-types/src/dto/provisioning/config.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class ProvisioningConfigDto extends Z.class({
 	scopesProvisionInstanceRole: z.boolean(),

--- a/packages/@n8n/api-types/src/dto/roles/create-role.dto.ts
+++ b/packages/@n8n/api-types/src/dto/roles/create-role.dto.ts
@@ -1,6 +1,7 @@
 import { scopeSchema } from '@n8n/permissions';
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class CreateRoleDto extends Z.class({
 	displayName: z.string().min(2).max(100),

--- a/packages/@n8n/api-types/src/dto/roles/role-get-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/roles/role-get-query.dto.ts
@@ -1,6 +1,5 @@
-import { Z } from 'zod-class';
-
 import { booleanFromString } from '../../schemas/boolean-from-string';
+import { Z } from '../../zod-class';
 
 /**
  * Query DTO for retrieving a single role with optional usage count

--- a/packages/@n8n/api-types/src/dto/roles/role-list-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/roles/role-list-query.dto.ts
@@ -1,6 +1,5 @@
-import { Z } from 'zod-class';
-
 import { booleanFromString } from '../../schemas/boolean-from-string';
+import { Z } from '../../zod-class';
 
 /**
  * Query DTO for listing roles with optional usage count

--- a/packages/@n8n/api-types/src/dto/roles/update-role.dto.ts
+++ b/packages/@n8n/api-types/src/dto/roles/update-role.dto.ts
@@ -1,6 +1,7 @@
 import { scopeSchema } from '@n8n/permissions';
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class UpdateRoleDto extends Z.class({
 	displayName: z.string().min(2).max(100).optional(),

--- a/packages/@n8n/api-types/src/dto/saml/saml-acs.dto.ts
+++ b/packages/@n8n/api-types/src/dto/saml/saml-acs.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class SamlAcsDto extends Z.class({
 	RelayState: z.string().optional(),

--- a/packages/@n8n/api-types/src/dto/saml/saml-preferences.dto.ts
+++ b/packages/@n8n/api-types/src/dto/saml/saml-preferences.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 const SamlLoginBindingSchema = z.enum(['redirect', 'post']);
 
@@ -29,7 +30,7 @@ export class SamlPreferencesAttributeMapping extends Z.class({
 
 export class SamlPreferences extends Z.class({
 	/** Mapping of SAML attributes to user fields. */
-	mapping: SamlPreferencesAttributeMapping.optional(),
+	mapping: SamlPreferencesAttributeMapping.schema.optional(),
 	/** SAML metadata in XML format. */
 	metadata: z.string().optional(),
 	metadataUrl: z.string().optional(),

--- a/packages/@n8n/api-types/src/dto/saml/saml-toggle.dto.ts
+++ b/packages/@n8n/api-types/src/dto/saml/saml-toggle.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class SamlToggleDto extends Z.class({
 	loginEnabled: z.boolean(),

--- a/packages/@n8n/api-types/src/dto/secrets-provider/create-secrets-provider-connection.dto.ts
+++ b/packages/@n8n/api-types/src/dto/secrets-provider/create-secrets-provider-connection.dto.ts
@@ -1,8 +1,8 @@
 import type { IDataObject } from 'n8n-workflow';
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
 import { secretsProviderTypeSchema } from '../../schemas/secrets-provider.schema';
+import { Z } from '../../zod-class';
 
 export class CreateSecretsProviderConnectionDto extends Z.class({
 	providerKey: z

--- a/packages/@n8n/api-types/src/dto/secrets-provider/set-secrets-provider-connection-is-enabled.dto.ts
+++ b/packages/@n8n/api-types/src/dto/secrets-provider/set-secrets-provider-connection-is-enabled.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 /**
  * Enable/disable connection.

--- a/packages/@n8n/api-types/src/dto/secrets-provider/update-secrets-provider-connection.dto.ts
+++ b/packages/@n8n/api-types/src/dto/secrets-provider/update-secrets-provider-connection.dto.ts
@@ -1,8 +1,8 @@
 import type { IDataObject } from 'n8n-workflow';
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
 import { secretsProviderTypeSchema } from '../../schemas/secrets-provider.schema';
+import { Z } from '../../zod-class';
 
 export class UpdateSecretsProviderConnectionDto extends Z.class({
 	type: secretsProviderTypeSchema.optional(),

--- a/packages/@n8n/api-types/src/dto/security-settings/security-settings.dto.ts
+++ b/packages/@n8n/api-types/src/dto/security-settings/security-settings.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class SecuritySettingsDto extends Z.class({
 	personalSpacePublishing: z.boolean(),

--- a/packages/@n8n/api-types/src/dto/source-control/pull-work-folder-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/source-control/pull-work-folder-request.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 const AutoPublishModeSchema = z.enum(['none', 'all', 'published']);
 export const AUTO_PUBLISH_MODE = AutoPublishModeSchema.Values;

--- a/packages/@n8n/api-types/src/dto/source-control/push-work-folder-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/source-control/push-work-folder-request.dto.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
 import { SourceControlledFileSchema } from '../../schemas/source-controlled-file.schema';
+import { Z } from '../../zod-class';
 
 export class PushWorkFolderRequestDto extends Z.class({
 	force: z.boolean().optional(),

--- a/packages/@n8n/api-types/src/dto/tag/create-or-update-tag-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/tag/create-or-update-tag-request.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class CreateOrUpdateTagRequestDto extends Z.class({
 	name: z.string().trim().min(1),

--- a/packages/@n8n/api-types/src/dto/tag/retrieve-tag-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/tag/retrieve-tag-query.dto.ts
@@ -1,6 +1,5 @@
-import { Z } from 'zod-class';
-
 import { booleanFromString } from '../../schemas/boolean-from-string';
+import { Z } from '../../zod-class';
 
 export class RetrieveTagQueryDto extends Z.class({
 	withUsageCount: booleanFromString.optional().default('false'),

--- a/packages/@n8n/api-types/src/dto/user/password-update-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/user/password-update-request.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class PasswordUpdateRequestDto extends Z.class({
 	currentPassword: z.string(),

--- a/packages/@n8n/api-types/src/dto/user/role-change-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/user/role-change-request.dto.ts
@@ -1,5 +1,6 @@
 import { assignableGlobalRoleSchema } from '@n8n/permissions';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class RoleChangeRequestDto extends Z.class({
 	newRoleName: assignableGlobalRoleSchema

--- a/packages/@n8n/api-types/src/dto/user/settings-update-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/user/settings-update-request.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class SettingsUpdateRequestDto extends Z.class({
 	userActivated: z.boolean().optional(),

--- a/packages/@n8n/api-types/src/dto/user/user-self-settings-update-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/user/user-self-settings-update-request.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 /**
  * DTO for self-service user settings updates via /me/settings endpoint.

--- a/packages/@n8n/api-types/src/dto/user/user-update-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/user/user-update-request.dto.ts
@@ -1,6 +1,7 @@
 import xss from 'xss';
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 const xssCheck = (value: string) =>
 	value ===

--- a/packages/@n8n/api-types/src/dto/user/users-list-filter.dto.ts
+++ b/packages/@n8n/api-types/src/dto/user/users-list-filter.dto.ts
@@ -1,7 +1,7 @@
 import { jsonParse } from 'n8n-workflow';
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
+import { Z } from '../../zod-class';
 import { createTakeValidator, paginationSchema } from '../pagination/pagination.dto';
 
 export const USERS_LIST_SORT_OPTIONS = [

--- a/packages/@n8n/api-types/src/dto/variables/base.dto.ts
+++ b/packages/@n8n/api-types/src/dto/variables/base.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export const KEY_NAME_REGEX = /^[A-Za-z0-9_]+$/;
 export const KEY_MAX_LENGTH = 50;

--- a/packages/@n8n/api-types/src/dto/variables/update-variable-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/variables/update-variable-request.dto.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
 import { variableKeySchema, variableTypeSchema, variableValueSchema } from './base.dto';
+import { Z } from '../../zod-class';
 
 export class UpdateVariableRequestDto extends Z.class({
 	key: variableKeySchema.optional(),

--- a/packages/@n8n/api-types/src/dto/variables/variables-list-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/variables/variables-list-request.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class VariableListRequestDto extends Z.class({
 	state: z.literal('empty').optional(),

--- a/packages/@n8n/api-types/src/dto/workflow-history/update-workflow-history-version.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflow-history/update-workflow-history-version.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class UpdateWorkflowHistoryVersionDto extends Z.class({
 	name: z.string().optional().nullable(),

--- a/packages/@n8n/api-types/src/dto/workflow-history/workflow-history-versions-by-ids.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflow-history/workflow-history-versions-by-ids.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class WorkflowHistoryVersionsByIdsDto extends Z.class({
 	versionIds: z.array(z.string()),

--- a/packages/@n8n/api-types/src/dto/workflows/activate-workflow.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/activate-workflow.dto.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
 import {
 	workflowVersionNameSchema,
 	workflowVersionDescriptionSchema,
 } from '../../schemas/workflow-version.schema';
+import { Z } from '../../zod-class';
 
 export class ActivateWorkflowDto extends Z.class({
 	versionId: z.string(),

--- a/packages/@n8n/api-types/src/dto/workflows/archive-workflow.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/archive-workflow.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class ArchiveWorkflowDto extends Z.class({
 	expectedChecksum: z.string().optional(),

--- a/packages/@n8n/api-types/src/dto/workflows/create-workflow.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/create-workflow.dto.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
 import { baseWorkflowShape } from './base-workflow.dto';
+import { Z } from '../../zod-class';
 
 export const workflowIdSchema = z.string();
 

--- a/packages/@n8n/api-types/src/dto/workflows/deactivate-workflow.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/deactivate-workflow.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class DeactivateWorkflowDto extends Z.class({
 	expectedChecksum: z.string().optional(),

--- a/packages/@n8n/api-types/src/dto/workflows/import-workflow-from-url.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/import-workflow-from-url.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class ImportWorkflowFromUrlDto extends Z.class({
 	url: z.string().url(),

--- a/packages/@n8n/api-types/src/dto/workflows/transfer.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/transfer.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
+
+import { Z } from '../../zod-class';
 
 export class TransferWorkflowBodyDto extends Z.class({
 	destinationProjectId: z.string(),

--- a/packages/@n8n/api-types/src/dto/workflows/update-workflow.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/update-workflow.dto.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
 import { baseWorkflowShape } from './base-workflow.dto';
+import { Z } from '../../zod-class';
 
 export class UpdateWorkflowDto extends Z.class(
 	// Make all base fields optional for partial updates

--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -1,3 +1,4 @@
+export { Z, type ZodClass } from './zod-class';
 export type * from './datetime';
 export * from './dto';
 export type * from './push';

--- a/packages/@n8n/api-types/src/zod-class.ts
+++ b/packages/@n8n/api-types/src/zod-class.ts
@@ -5,9 +5,7 @@ export interface ZodClass<T = unknown, Shape extends z.ZodRawShape = z.ZodRawSha
 	schema: z.ZodObject<Shape>;
 	safeParse(data: unknown): z.SafeParseReturnType<unknown, T>;
 	parse(data: unknown): T;
-	extend<U extends z.ZodRawShape>(
-		shape: U,
-	): ZodClass<T & z.objectOutputType<U, z.ZodTypeAny>, Shape & U>;
+	extend<U extends z.ZodRawShape>(shape: U): ZodClass<T & z.infer<z.ZodObject<U>>, Shape & U>;
 }
 
 /**
@@ -31,9 +29,9 @@ export interface ZodClass<T = unknown, Shape extends z.ZodRawShape = z.ZodRawSha
  * ```
  */
 export const Z = {
-	class: <T extends z.ZodRawShape>(shape: T): ZodClass<z.objectOutputType<T, z.ZodTypeAny>, T> => {
+	class: <T extends z.ZodRawShape>(shape: T): ZodClass<z.infer<z.ZodObject<T>>, T> => {
 		const schema = z.object(shape);
-		type Output = z.objectOutputType<T, z.ZodTypeAny>;
+		type Output = z.infer<typeof schema>;
 
 		const DtoClass = class {
 			static schema = schema;

--- a/packages/@n8n/api-types/src/zod-class.ts
+++ b/packages/@n8n/api-types/src/zod-class.ts
@@ -1,0 +1,56 @@
+import { z } from 'zod';
+
+export interface ZodClass<T = unknown, Shape extends z.ZodRawShape = z.ZodRawShape> {
+	new (): T;
+	schema: z.ZodObject<Shape>;
+	safeParse(data: unknown): z.SafeParseReturnType<unknown, T>;
+	parse(data: unknown): T;
+	extend<U extends z.ZodRawShape>(
+		shape: U,
+	): ZodClass<T & z.objectOutputType<U, z.ZodTypeAny>, Shape & U>;
+}
+
+/**
+ * Replacement for: https://www.npmjs.com/package/zod-class
+ *
+ * Creates a class with static `.parse()` and `.safeParse()` methods,
+ * compatible with reflection-based validation in the controller registry.
+ *
+ * Usage is identical to `zod-class`.
+ *
+ * ```ts
+ * export class LoginDto extends Z.class({
+ *   email: z.string().email(),
+ *   password: z.string().min(8),
+ * }) {}
+ *
+ * // Inheritance via extend:
+ * export class ChildDto extends ParentDto.extend({
+ *   additionalField: z.string(),
+ * }) {}
+ * ```
+ */
+export const Z = {
+	class: <T extends z.ZodRawShape>(shape: T): ZodClass<z.objectOutputType<T, z.ZodTypeAny>, T> => {
+		const schema = z.object(shape);
+		type Output = z.objectOutputType<T, z.ZodTypeAny>;
+
+		const DtoClass = class {
+			static schema = schema;
+
+			static safeParse(data: unknown) {
+				return schema.safeParse(data);
+			}
+
+			static parse(data: unknown): Output {
+				return schema.parse(data);
+			}
+
+			static extend<U extends z.ZodRawShape>(additionalShape: U) {
+				return Z.class({ ...shape, ...additionalShape });
+			}
+		};
+
+		return DtoClass as unknown as ZodClass<Output, T>;
+	},
+};

--- a/packages/cli/src/__tests__/controller.registry.test.ts
+++ b/packages/cli/src/__tests__/controller.registry.test.ts
@@ -22,8 +22,8 @@ import { Container } from '@n8n/di';
 import express, { json } from 'express';
 import { mock } from 'jest-mock-extended';
 import { agent as testAgent } from 'supertest';
+import { Z } from '@n8n/api-types';
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
 import type { AuthService } from '@/auth/auth.service';
 import { ControllerRegistry } from '@/controller.registry';

--- a/packages/cli/src/controller.registry.ts
+++ b/packages/cli/src/controller.registry.ts
@@ -15,7 +15,7 @@ import { Router } from 'express';
 import type { Application, Request, Response, RequestHandler } from 'express';
 import { UnexpectedError } from 'n8n-workflow';
 import assert from 'node:assert';
-import type { ZodClass } from 'zod-class';
+import type { ZodClass } from '@n8n/api-types';
 
 import { NotFoundError } from './errors/response-errors/not-found.error';
 import { LastActiveAtService } from './services/last-active-at.service';

--- a/packages/cli/src/modules/chat-hub/chat-hub.models.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.models.service.ts
@@ -40,7 +40,7 @@ export class ChatHubModelsService {
 
 	async getModels(
 		user: User,
-		credentialIds: Record<ChatHubLLMProvider, string | null>,
+		credentialIds: Partial<Record<ChatHubProvider, string | null>>,
 	): Promise<ChatModelsResponse> {
 		const additionalData = await getBase({ userId: user.id });
 		const providers = chatHubProviderSchema.options;

--- a/packages/cli/src/modules/chat-hub/dto/chat-models-request.dto.ts
+++ b/packages/cli/src/modules/chat-hub/dto/chat-models-request.dto.ts
@@ -1,4 +1,3 @@
-import { chatModelsRequestSchema } from '@n8n/api-types';
-import { Z } from 'zod-class';
+import { chatModelsRequestSchema, Z } from '@n8n/api-types';
 
 export class ChatModelsRequestDto extends Z.class(chatModelsRequestSchema.shape) {}

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential-web.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential-web.service.ts
@@ -1,6 +1,6 @@
 import { AuthService } from '@/auth/auth.service';
 import { Service } from '@n8n/di';
-import { Z } from 'zod-class';
+import { Z } from '@n8n/api-types';
 import { z } from 'zod';
 import { ICredentialContext } from 'n8n-workflow';
 import { Request } from 'express';

--- a/packages/cli/src/modules/mcp/dto/approve-consent-request.dto.ts
+++ b/packages/cli/src/modules/mcp/dto/approve-consent-request.dto.ts
@@ -1,5 +1,5 @@
+import { Z } from '@n8n/api-types';
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
 export class ApproveConsentRequestDto extends Z.class({
 	approved: z.boolean(),

--- a/packages/cli/src/modules/mcp/dto/update-mcp-settings.dto.ts
+++ b/packages/cli/src/modules/mcp/dto/update-mcp-settings.dto.ts
@@ -1,5 +1,5 @@
+import { Z } from '@n8n/api-types';
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
 export class UpdateMcpSettingsDto extends Z.class({
 	mcpAccessEnabled: z.boolean(),

--- a/packages/cli/src/modules/mcp/dto/update-workflow-availability.dto.ts
+++ b/packages/cli/src/modules/mcp/dto/update-workflow-availability.dto.ts
@@ -1,5 +1,5 @@
+import { Z } from '@n8n/api-types';
 import { z } from 'zod';
-import { Z } from 'zod-class';
 
 export class UpdateWorkflowAvailabilityDto extends Z.class({
 	availableInMCP: z.boolean(),

--- a/packages/cli/src/services/rate-limit.service.ts
+++ b/packages/cli/src/services/rate-limit.service.ts
@@ -7,7 +7,7 @@ import type { Request, RequestHandler } from 'express';
 import { rateLimit as expressRateLimit } from 'express-rate-limit';
 import assert from 'node:assert';
 import type { ZodTypeAny } from 'zod';
-import type { ZodClass } from 'zod-class';
+import type { ZodClass } from '@n8n/api-types';
 
 const defaultLimits: Required<RateLimiterLimits> = {
 	limit: 5,
@@ -47,7 +47,7 @@ export class RateLimitService {
 		config: BodyKeyedRateLimiterConfig,
 	): RequestHandler {
 		const fieldName = config.field;
-		const bodyFieldSchema = bodyDtoClass.shape[fieldName];
+		const bodyFieldSchema = bodyDtoClass.schema.shape[fieldName];
 		assert(bodyFieldSchema, `Missing field ${fieldName} in DTO schema`);
 
 		return expressRateLimit({

--- a/packages/frontend/editor-ui/src/features/execution/insights/insights.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/insights/insights.store.test.ts
@@ -16,7 +16,7 @@ vi.mock('vue-router', async (importOriginal) => ({
 }));
 vi.mock('@/features/execution/insights/insights.api');
 
-const mockFilter = { dateRange: 'week' as const };
+const mockFilter = { projectId: 'test-project' };
 const mockData = [
 	{
 		date: '2023-01-01',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -617,9 +617,6 @@ importers:
       zod:
         specifier: 3.25.67
         version: 3.25.67
-      zod-class:
-        specifier: 0.0.16
-        version: 0.0.16(zod@3.25.67)
     devDependencies:
       '@n8n/config':
         specifier: workspace:*
@@ -19084,11 +19081,6 @@ packages:
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
-
-  zod-class@0.0.16:
-    resolution: {integrity: sha512-3A1l81VEUOxvSTGoNPsU4fTUY9CKin/HSySnXT3bIc+TJTDGCPbzSPE8W1VvwXqyzHEIWK608eFZja2uew9Ivw==}
-    peerDependencies:
-      zod: 3.25.67
 
   zod-to-json-schema@3.23.3:
     resolution: {integrity: sha512-TYWChTxKQbRJp5ST22o/Irt9KC5nj7CdBKYB/AosCRdj/wxEMvv4NNaj9XVUHDOIp53ZxArGhnw5HMZziPFjog==}
@@ -38709,11 +38701,6 @@ snapshots:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.5.2
-
-  zod-class@0.0.16(zod@3.25.67):
-    dependencies:
-      type-fest: 4.26.1
-      zod: 3.25.67
 
   zod-to-json-schema@3.23.3(zod@3.25.67):
     dependencies:


### PR DESCRIPTION
## Summary

This PR replaces `zod-class` with a minimal implementation, to unblock migrating to Zod 4. v4 brings significant [performance improvements](https://zod.dev/v4#benchmarks), but our dep `zod-class` is incompatible with v4 as it relies on v3 internals, and we only need minimal functionality from this dep for our DTO setup. 

Side note - Two spots used DTO classes directly as Zod types. `zod-class` made DTO classes behave as full Zod schemas via proxy magic. This minimal implementation does not replicate this, instead these two usages now access the `.schema` property explicitly:

- `z.array(CreateDataTableColumnDto)` → `z.array(CreateDataTableColumnDto.schema)`
- `SamlPreferencesAttributeMapping.optional()` →
  `SamlPreferencesAttributeMapping.schema.optional()`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-857

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
