### PR TITLE
fix: Fix Chromatic workflow trigger and make failures block merging (no-changelog)

### DIFF
--- a/.github/workflows/test-visual-chromatic.yml
+++ b/.github/workflows/test-visual-chromatic.yml
@@ -25,7 +25,7 @@ jobs:
               - 'packages/frontend/@n8n/design-system/**'
               - 'packages/frontend/@n8n/chat/**'
               - 'packages/frontend/@n8n/storybook/**'
-              - '.github/workflows/test-visual-storybook.yml'
+              - '.github/workflows/test-visual-chromatic.yml'
     outputs:
       has_changes: ${{ steps.changed.outputs.design_system || 'false' }}
 
@@ -55,9 +55,9 @@ jobs:
       - name: Publish to Chromatic
         uses: chromaui/action@1cfa065cbdab28f6ca3afaeb3d761383076a35aa # v11
         id: chromatic_tests
-        continue-on-error: true
         with:
           workingDir: packages/frontend/@n8n/storybook
+          buildScriptName: build
           autoAcceptChanges: 'master'
           skip: 'release/**'
           onlyChanged: true
@@ -65,7 +65,7 @@ jobs:
           exitZeroOnChanges: false
 
       - name: Success comment
-        if: steps.chromatic_tests.outcome == 'success' && github.ref != 'refs/heads/master'
+        if: always() && steps.chromatic_tests.outcome == 'success' && github.ref != 'refs/heads/master'
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -75,7 +75,7 @@ jobs:
             :white_check_mark: No visual regressions found.
 
       - name: Fail comment
-        if: steps.chromatic_tests.outcome != 'success' && github.ref != 'refs/heads/master'
+        if: always() && steps.chromatic_tests.outcome == 'failure' && github.ref != 'refs/heads/master'
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           issue-number: ${{ github.event.pull_request.number }}

--- a/packages/frontend/@n8n/storybook/package.json
+++ b/packages/frontend/@n8n/storybook/package.json
@@ -38,6 +38,7 @@
     "typescript": "catalog:",
     "unplugin-icons": "catalog:frontend",
     "vite": "catalog:",
+    "vite-svg-loader": "catalog:frontend",
     "vitest": "catalog:",
     "vue-tsc": "catalog:frontend"
   },

--- a/packages/frontend/@n8n/storybook/vite.config.ts
+++ b/packages/frontend/@n8n/storybook/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import icons from 'unplugin-icons/vite';
+import svgLoader from 'vite-svg-loader';
 import path from 'path';
 
 // https://vite.dev/config/
@@ -10,6 +11,21 @@ export default defineConfig({
 		icons({
 			compiler: 'vue3',
 			autoInstall: true,
+		}),
+		svgLoader({
+			svgoConfig: {
+				plugins: [
+					{
+						name: 'preset-default',
+						params: {
+							overrides: {
+								cleanupIds: false,
+								removeViewBox: false,
+							},
+						},
+					},
+				],
+			},
 		}),
 	],
 	resolve: {

--- a/packages/frontend/editor-ui/package.json
+++ b/packages/frontend/editor-ui/package.json
@@ -139,7 +139,7 @@
     "vite-plugin-istanbul": "^7.2.0",
     "vite-plugin-node-polyfills": "^0.24.0",
     "vite-plugin-static-copy": "2.2.0",
-    "vite-svg-loader": "5.1.0",
+    "vite-svg-loader": "catalog:frontend",
     "vitest": "catalog:",
     "vitest-mock-extended": "catalog:",
     "vue-tsc": "catalog:frontend",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,6 +242,9 @@ catalogs:
     unplugin-icons:
       specifier: ^0.19.0
       version: 0.19.0
+    vite-svg-loader:
+      specifier: 5.1.0
+      version: 5.1.0
     vue:
       specifier: ^3.5.13
       version: 3.5.26
@@ -2836,6 +2839,9 @@ importers:
       vite:
         specifier: 'catalog:'
         version: rolldown-vite@7.3.1(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass@1.89.2)(terser@5.16.1)(tsx@4.19.3)
+      vite-svg-loader:
+        specifier: catalog:frontend
+        version: 5.1.0(vue@3.5.26(typescript@5.9.2))
       vitest:
         specifier: 'catalog:'
         version: 3.1.3(@types/debug@4.1.12)(@types/node@20.19.21)(jiti@2.6.1)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(sass@1.89.2)(terser@5.16.1)(tsx@4.19.3)
@@ -3189,7 +3195,7 @@ importers:
         specifier: 2.2.0
         version: 2.2.0(rolldown-vite@7.3.1(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass@1.89.2)(terser@5.16.1)(tsx@4.19.3))
       vite-svg-loader:
-        specifier: 5.1.0
+        specifier: catalog:frontend
         version: 5.1.0(vue@3.5.26(typescript@5.9.2))
       vitest:
         specifier: 'catalog:'
@@ -28425,7 +28431,7 @@ snapshots:
       cheerio-select: 2.1.0
       dom-serializer: 2.0.0
       domhandler: 5.0.3
-      domutils: 3.1.0
+      domutils: 3.2.2
       htmlparser2: 8.0.2
       parse5: 7.1.2
       parse5-htmlparser2-tree-adapter: 7.0.0
@@ -28947,7 +28953,7 @@ snapshots:
       boolbase: 1.0.0
       css-what: 6.1.0
       domhandler: 5.0.3
-      domutils: 3.1.0
+      domutils: 3.2.2
       nth-check: 2.1.1
 
   css-to-react-native@3.2.0:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -97,6 +97,7 @@ catalogs:
     highlight.js: 11.8.0
     pinia: ^2.2.4
     unplugin-icons: ^0.19.0
+    vite-svg-loader: 5.1.0
     vue: ^3.5.13
     vue-i18n: ^11.1.2
     vue-markdown-render: ^2.2.1


### PR DESCRIPTION
## Summary

- Fix path filter to watch the correct workflow file (was watching non-existent test-visual-storybook.yml)
- Add buildScriptName to use the correct 'build' script from package.json
- Remove continue-on-error so Chromatic failures block merging
- Add always() to comment conditions so they still post after failures

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2285/fix-chromatic-run-in-ci

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
