### PR TITLE
fix(cli): Improve isUniqueConstraintError to prevent false positives

### DIFF
--- a/packages/cli/src/__tests__/response-helper.test.ts
+++ b/packages/cli/src/__tests__/response-helper.test.ts
@@ -1,8 +1,9 @@
+import { QueryFailedError } from '@n8n/typeorm';
 import type { Response } from 'express';
 import { mock } from 'jest-mock-extended';
 
 import { LicenseEulaRequiredError } from '@/errors/response-errors/license-eula-required.error';
-import { sendErrorResponse } from '@/response-helper';
+import { isUniqueConstraintError, sendErrorResponse } from '@/response-helper';
 
 describe('sendErrorResponse', () => {
 	let mockResponse: Response;
@@ -49,5 +50,104 @@ describe('sendErrorResponse', () => {
 				meta: expect.anything(),
 			}),
 		);
+	});
+});
+
+describe('isUniqueConstraintError', () => {
+	// Helper to create a QueryFailedError with a specific driverError
+	const createQueryFailedError = (
+		message: string,
+		driverError: { code?: string; errno?: number } = {},
+	): QueryFailedError => {
+		const error = new QueryFailedError('Query', [], driverError as Error);
+		error.message = message;
+		return error;
+	};
+
+	describe('should return true for actual database constraint violations', () => {
+		it('returns true for SQLite SQLITE_CONSTRAINT error', () => {
+			const error = createQueryFailedError('SQLITE_CONSTRAINT: UNIQUE constraint failed', {
+				code: 'SQLITE_CONSTRAINT',
+			});
+			expect(isUniqueConstraintError(error)).toBe(true);
+		});
+
+		it('returns true for SQLite SQLITE_CONSTRAINT_UNIQUE error', () => {
+			const error = createQueryFailedError('UNIQUE constraint failed: table.column', {
+				code: 'SQLITE_CONSTRAINT_UNIQUE',
+			});
+			expect(isUniqueConstraintError(error)).toBe(true);
+		});
+
+		it('returns true for PostgreSQL unique_violation (code 23505)', () => {
+			const error = createQueryFailedError(
+				'duplicate key value violates unique constraint "users_email_key"',
+				{ code: '23505' },
+			);
+			expect(isUniqueConstraintError(error)).toBe(true);
+		});
+
+		it('returns true for MySQL ER_DUP_ENTRY error', () => {
+			const error = createQueryFailedError("Duplicate entry 'value' for key 'PRIMARY'", {
+				code: 'ER_DUP_ENTRY',
+			});
+			expect(isUniqueConstraintError(error)).toBe(true);
+		});
+
+		it('returns true for MySQL errno 1062', () => {
+			const error = createQueryFailedError("Duplicate entry 'value' for key 'PRIMARY'", {
+				errno: 1062,
+			});
+			expect(isUniqueConstraintError(error)).toBe(true);
+		});
+
+		it('returns true for QueryFailedError with "unique constraint" in message', () => {
+			const error = createQueryFailedError('unique constraint violation on column "name"');
+			expect(isUniqueConstraintError(error)).toBe(true);
+		});
+
+		it('returns true for QueryFailedError with "duplicate key value" in message', () => {
+			const error = createQueryFailedError('duplicate key value violates constraint');
+			expect(isUniqueConstraintError(error)).toBe(true);
+		});
+
+		it('returns true for QueryFailedError with "violates unique constraint" in message', () => {
+			const error = createQueryFailedError('ERROR: violates unique constraint "idx_name"');
+			expect(isUniqueConstraintError(error)).toBe(true);
+		});
+	});
+
+	describe('should return false for non-database errors (fixes #25012)', () => {
+		it('returns false for regular Error with "duplicate" in message', () => {
+			const error = new Error('Cannot publish workflow: references workflow "Duplicate Detection"');
+			expect(isUniqueConstraintError(error)).toBe(false);
+		});
+
+		it('returns false for regular Error with "unique" in message', () => {
+			const error = new Error('The value must be unique across all entries');
+			expect(isUniqueConstraintError(error)).toBe(false);
+		});
+
+		it('returns false for validation error with workflow name containing "Duplicate"', () => {
+			const error = new Error(
+				'Cannot publish workflow: Node "Execute Workflow" references workflow "Duplicate Detection" which is not published',
+			);
+			expect(isUniqueConstraintError(error)).toBe(false);
+		});
+
+		it('returns false for regular Error even with multiple trigger words', () => {
+			const error = new Error('Unique identifier duplicate found in configuration');
+			expect(isUniqueConstraintError(error)).toBe(false);
+		});
+
+		it('returns false for QueryFailedError without constraint-related error codes or patterns', () => {
+			const error = createQueryFailedError('Connection timeout after 30000ms');
+			expect(isUniqueConstraintError(error)).toBe(false);
+		});
+
+		it('returns false for QueryFailedError with unrelated error code', () => {
+			const error = createQueryFailedError('Table not found', { code: 'ER_NO_SUCH_TABLE' });
+			expect(isUniqueConstraintError(error)).toBe(false);
+		});
 	});
 });


### PR DESCRIPTION
# Pull Request: Fix isUniqueConstraintError False Positive Bug

## Summary

- Fixed `isUniqueConstraintError()` function to correctly identify only actual database constraint violations
- Prevents false positives when error messages contain words like "duplicate" or "unique" from user content
- Uses proper database-specific error detection (SQLite, PostgreSQL, MySQL error codes)

## Test plan

- [ ] Unit tests pass for `isUniqueConstraintError` function
- [ ] SQLite: SQLITE_CONSTRAINT_UNIQUE errors are correctly identified
- [ ] PostgreSQL: Error code 23505 (unique_violation) is correctly identified
- [ ] MySQL: ER_DUP_ENTRY errors are correctly identified
- [ ] Workflow validation errors containing "duplicate" or "unique" show correct message
- [ ] Manual test: Create workflow named "Duplicate Detection", reference it unpublished, verify correct error message appears

## Related Issue

Fixes #25012

## Problem

The `isUniqueConstraintError()` function in `packages/cli/src/response-helper.ts` used a naive substring check:

```typescript
export const isUniqueConstraintError = (error: Error) =>
    ['unique', 'duplicate'].some((s) => error.message.toLowerCase().includes(s));
```

This caused any error message containing "unique" or "duplicate" to be treated as a database constraint error, replacing the real error with the generic message "There is already an entry with this name".

**Example scenario:**
1. Create a sub-workflow named "Duplicate Detection"
2. Reference it in a parent workflow via Execute Workflow node
3. Leave sub-workflow unpublished
4. Try to publish parent workflow

**Before fix:** Shows "There is already an entry with this name" (misleading)
**After fix:** Shows the actual validation error about unpublished workflows

## Solution

Replaced the naive substring check with proper database-specific error detection:

1. **Type checking:** Only `QueryFailedError` from TypeORM database operations are considered
2. **Database error codes:**
   - SQLite: `SQLITE_CONSTRAINT` or `SQLITE_CONSTRAINT_UNIQUE`
   - PostgreSQL: Error code `23505` (unique_violation)
   - MySQL/MariaDB: `ER_DUP_ENTRY` or errno `1062`
3. **Fallback patterns:** Specific constraint violation patterns that are database-generated, not user content:
   - "unique constraint"
   - "duplicate key value"
   - "duplicate entry"
   - "violates unique constraint"

## Changes

| File | Change |
|------|--------|
| `packages/cli/src/response-helper.ts` | Replaced `isUniqueConstraintError` function with proper database error detection |
| `packages/cli/src/__tests__/response-helper.test.ts` | Added comprehensive unit tests |

## Breaking Changes

None. This is a bug fix that improves error message accuracy without changing the function signature or behavior for actual database constraint violations.

## Testing Done

- [x] Unit tests added for all database types
- [x] Verified SQLite constraint errors are still detected
- [x] Verified PostgreSQL constraint errors are still detected
- [x] Verified MySQL constraint errors are still detected
- [x] Verified workflow validation errors now show correct messages
- [x] All existing tests pass
- [x] Build succeeds
