### PR TITLE
fix(editor): Mark workflow state dirty after settings save

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/WorkflowSettings.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowSettings.test.ts
@@ -13,6 +13,7 @@ import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
+import { useUIStore } from '@/app/stores/ui.store';
 import * as restApiClient from '@n8n/rest-api-client';
 import { mock } from 'vitest-mock-extended';
 import { BINARY_MODE_COMBINED } from 'n8n-workflow';
@@ -52,6 +53,7 @@ let workflowsStore: MockedStore<typeof useWorkflowsStore>;
 let workflowsListStore: MockedStore<typeof useWorkflowsListStore>;
 let settingsStore: MockedStore<typeof useSettingsStore>;
 let sourceControlStore: MockedStore<typeof useSourceControlStore>;
+let uiStore: MockedStore<typeof useUIStore>;
 let pinia: ReturnType<typeof createTestingPinia>;
 
 let searchWorkflowsSpy: MockInstance<(typeof workflowsListStore)['searchWorkflows']>;
@@ -74,6 +76,7 @@ describe('WorkflowSettingsVue', () => {
 		workflowsListStore = mockedStore(useWorkflowsListStore);
 		settingsStore = mockedStore(useSettingsStore);
 		sourceControlStore = mockedStore(useSourceControlStore);
+		uiStore = mockedStore(useUIStore);
 
 		settingsStore.settings = mock<FrontendSettings>({
 			enterprise: {},
@@ -717,6 +720,28 @@ describe('WorkflowSettingsVue', () => {
 			const dropdownContainer = getByTestId('workflow-settings-credential-resolver');
 			const input = dropdownContainer.querySelector('input');
 			expect(input).toBeDisabled();
+		});
+	});
+
+	describe('Dirty State', () => {
+		it('should mark state as dirty after saving workflow settings', async () => {
+			workflowsStore.workflowSettings = {
+				executionOrder: 'v1',
+			};
+
+			const { getByTestId, getByRole } = createComponent({ pinia });
+			await nextTick();
+
+			const dropdownItems = await getDropdownItems(getByTestId('error-workflow'));
+
+			// Select the test workflow (second option)
+			await userEvent.click(dropdownItems[1]);
+
+			await userEvent.click(getByRole('button', { name: 'Save' }));
+
+			await waitFor(() => {
+				expect(uiStore.markStateDirty).toHaveBeenCalled();
+			});
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowState.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowState.ts
@@ -127,6 +127,7 @@ export function useWorkflowState() {
 
 	function setWorkflowSettings(workflowSettings: IWorkflowSettings) {
 		ws.private.setWorkflowSettings(workflowSettings);
+		uiStore.markStateDirty();
 	}
 
 	function setWorkflowTagIds(tags: string[]) {


### PR DESCRIPTION
# Pull Request: Fix Workflow Settings Not Activating Save/Publish Buttons

## Summary

This PR fixes a bug where changing workflow settings via the Settings modal does not activate the Save/Publish buttons in the main toolbar, preventing users from publishing workflows with updated settings.

**Issue:** [#25359](https://github.com/n8n-io/n8n/issues/25359)

### The Problem

When a user:
1. Opens a workflow in the Editor
2. Clicks the three-dot menu (⋯) next to the workflow name
3. Clicks "Settings" to open the Workflow Settings modal
4. Changes any setting (e.g., Error Workflow)
5. Clicks "Save" in the modal

The settings are saved to the backend, but the Save/Publish buttons in the main toolbar remain disabled because the workflow is not marked as "dirty" (having unsaved changes). Users cannot publish the workflow with the new settings unless they also make a visual change like dragging a node.

### The Fix

Added a call to `uiStore.markStateDirty()` in the `setWorkflowSettings` function in `useWorkflowState.ts`. This ensures that when workflow settings are updated, the UI state is properly marked as dirty, enabling the Save/Publish buttons.

---

## Changes

### Files Modified

1. **`packages/frontend/editor-ui/src/app/composables/useWorkflowState.ts`**
   - Added `uiStore.markStateDirty()` call after updating workflow settings

2. **`packages/frontend/editor-ui/src/app/components/WorkflowSettings.test.ts`**
   - Added test case to verify that `markStateDirty` is called after saving workflow settings

---

## Test Plan

- [x] Unit test added to verify `markStateDirty` is called
- [ ] Manual testing:
  1. Open any workflow in the Editor
  2. Click the three-dot menu (⋯) next to the workflow name
  3. Click "Settings" to open Workflow Settings modal
  4. Change any setting (e.g., select an Error Workflow)
  5. Click "Save" in the modal
  6. **Expected:** Save/Publish buttons in toolbar become active/enabled
  7. **Expected:** Success toast message appears

---

## Technical Details

### Root Cause

The `setWorkflowSettings()` function in `useWorkflowState.ts` was only calling `ws.private.setWorkflowSettings(workflowSettings)` without marking the UI state as dirty. Other similar functions in the codebase (like `setWorkflowName`, `removeAllConnections`, etc.) already properly call `uiStore.markStateDirty()` when making changes.

### Solution Pattern

This fix follows the existing pattern used throughout the codebase:
- `setWorkflowName` (line 64-65) calls `markStateDirty` when `setStateDirty` is true
- `removeAllConnections` (line 76-77) calls `markStateDirty` when appropriate
- Node parameter changes trigger `markStateDirty` in multiple places

---

## Checklist

- [x] Code follows project style guidelines
- [x] Pre-commit hooks pass (biome)
- [x] Unit tests added
- [x] No TypeScript errors
- [x] Changes are focused on single fix
- [x] Commit message follows conventional commits format

---

## Related Links

- **Issue:** https://github.com/n8n-io/n8n/issues/25359
- **Branch:** `fix/workflow-settings-dirty-state-clean`
- **Fork:** https://github.com/saakshigupta2002/n8n
