### PR TITLE
chore: Add more claude permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,6 @@
 {
 	"permissions": {
 		"allow": [
-			"Bash(find:*)",
 			"Bash(git log:*)",
 			"Bash(git show:*)",
 			"Bash(grep:*)",
@@ -12,7 +11,7 @@
 			"Bash(pnpm typecheck:*)",
 			"Bash(popd)",
 			"Bash(pushd:*)",
-			"Bash(tee:*)"
+			"Bash(tee:*.log)"
 		]
 	}
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,18 @@
 {
 	"permissions": {
-		"allow": ["Bash(find:*)", "Bash(pnpm typecheck:*)", "Bash(pnpm build)", "Bash(pnpm lint:*)"]
+		"allow": [
+			"Bash(find:*)",
+			"Bash(git log:*)",
+			"Bash(git show:*)",
+			"Bash(grep:*)",
+			"Bash(ls:*)",
+			"Bash(pnpm build)",
+			"Bash(pnpm lint:*)",
+			"Bash(pnpm test:*)",
+			"Bash(pnpm typecheck:*)",
+			"Bash(popd)",
+			"Bash(pushd:*)",
+			"Bash(tee:*)"
+		]
 	}
 }


### PR DESCRIPTION
## Summary

Expands the allowed commands in .claude/settings.json to improve Claude Code's capabilities when working in the n8n
  repository.

Added permissions:
- Git commands: git log, git show - for viewing commit history and changes
- File operations: grep, ls - for searching and listing files
- Testing: pnpm test:* - for running test suites
- Directory navigation: pushd, popd - for managing directory stack
- Utilities: tee - for output redirection

The permissions list has also been reorganized alphabetically for better maintainability.


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
