### PR TITLE
fix(editor): Load i18n locales in production builds

### DIFF
--- a/packages/frontend/editor-ui/src/app/dev/i18nHmr.test.ts
+++ b/packages/frontend/editor-ui/src/app/dev/i18nHmr.test.ts
@@ -18,8 +18,9 @@ describe('i18nHmr production locale loading', () => {
 		const ifHotPosition = ifHotMatch!.index!;
 		const beforeIfHot = i18nHmrSource.slice(0, ifHotPosition);
 
+		// Both checks must verify the pre-if(hot) section to ensure production builds work
 		const hasStaticLocaleImport =
-			/import\s+\w+\s+from\s+['"]@n8n\/i18n\/locales\/\w+\.json['"]/.test(i18nHmrSource);
+			/import\s+\w+\s+from\s+['"]@n8n\/i18n\/locales\/\w+\.json['"]/.test(beforeIfHot);
 		const hasUpdateCallBeforeIfHot = /updateLocaleMessages\s*\(/.test(beforeIfHot);
 
 		expect(hasStaticLocaleImport).toBe(true);

--- a/packages/frontend/editor-ui/src/app/dev/i18nHmr.test.ts
+++ b/packages/frontend/editor-ui/src/app/dev/i18nHmr.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import i18nHmrSource from './i18nHmr.ts?raw';
+
+/**
+ * Tests for i18nHmr production locale loading.
+ *
+ * Bug: import.meta.glob inside if(hot) only works in dev mode.
+ * Rolldown (production bundler) does not transform import.meta.glob,
+ * so locales added per i18n docs won't load in production builds.
+ *
+ * Fix: Static imports outside if(hot) block ensure locales are bundled.
+ */
+describe('i18nHmr production locale loading', () => {
+	it('should have static locale imports outside if(hot) block', () => {
+		const ifHotMatch = i18nHmrSource.match(/if\s*\(\s*hot\s*\)/);
+		expect(ifHotMatch).toBeDefined();
+
+		const ifHotPosition = ifHotMatch!.index!;
+		const beforeIfHot = i18nHmrSource.slice(0, ifHotPosition);
+
+		const hasStaticLocaleImport =
+			/import\s+\w+\s+from\s+['"]@n8n\/i18n\/locales\/\w+\.json['"]/.test(i18nHmrSource);
+		const hasUpdateCallBeforeIfHot = /updateLocaleMessages\s*\(/.test(beforeIfHot);
+
+		expect(hasStaticLocaleImport).toBe(true);
+		expect(hasUpdateCallBeforeIfHot).toBe(true);
+	});
+});

--- a/packages/frontend/editor-ui/src/app/dev/i18nHmr.ts
+++ b/packages/frontend/editor-ui/src/app/dev/i18nHmr.ts
@@ -8,13 +8,12 @@ import enMessages from '@n8n/i18n/locales/en.json';
 const hot = import.meta.hot;
 const DEFAULT_LOCALE = 'en';
 
-const staticLocales: Record<string, LocaleMessages> = {
-	en: enMessages as unknown as LocaleMessages,
-};
-
-for (const [locale, messages] of Object.entries(staticLocales)) {
-	if (messages) updateLocaleMessages(locale, messages);
+// Adds numberFormats property required by LocaleMessages type
+function toLocaleMessages(json: typeof enMessages): LocaleMessages {
+	return { ...json, numberFormats: {} };
 }
+
+updateLocaleMessages('en', toLocaleMessages(enMessages));
 
 if (hot) {
 	// Eagerly import locale JSONs so this module becomes their HMR owner

--- a/packages/frontend/editor-ui/src/app/dev/i18nHmr.ts
+++ b/packages/frontend/editor-ui/src/app/dev/i18nHmr.ts
@@ -2,8 +2,19 @@ import { i18n, i18nInstance, setLanguage, updateLocaleMessages } from '@n8n/i18n
 import type { LocaleMessages } from '@n8n/i18n/types';
 import { locale as designLocale } from '@n8n/design-system';
 
+// Static import required - import.meta.glob is not transformed by Rolldown in production
+import enMessages from '@n8n/i18n/locales/en.json';
+
 const hot = import.meta.hot;
 const DEFAULT_LOCALE = 'en';
+
+const staticLocales: Record<string, LocaleMessages> = {
+	en: enMessages as unknown as LocaleMessages,
+};
+
+for (const [locale, messages] of Object.entries(staticLocales)) {
+	if (messages) updateLocaleMessages(locale, messages);
+}
 
 if (hot) {
 	// Eagerly import locale JSONs so this module becomes their HMR owner


### PR DESCRIPTION
## Summary

Fixes i18n locale loading in production builds. Currently, `import.meta.glob` inside `if (hot)` block only runs in development mode. Rolldown (production bundler) does not transform `import.meta.glob`, so any locales added following the [i18n documentation](https://github.com/n8n-io/n8n/blob/master/packages/frontend/%40n8n/i18n/docs/README.md) won't load in production builds.

**The fix:** Use static imports outside `if(hot)` block to ensure locales are bundled and loaded in production.

## Related Linear tickets, Github issues, and Community forum posts

N/A - Community contribution

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.

## Test plan

- [x] Unit test verifies static locale loading exists outside HMR block
- [x] `pnpm build` produces bundle with locale content
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes