### PR TITLE
chore: Remove cats from code ownership of node-popularity.json

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,1 @@
 packages/@n8n/db/src/migrations/ @n8n-io/migrations-review
-
-# Node popularity data updates
-packages/frontend/editor-ui/data/node-popularity.json @n8n-io/catalysts

--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -479,7 +479,6 @@ Team ownership mappings in `CODEOWNERS`:
 | Path Pattern                                                 | Team                       |
 |--------------------------------------------------------------|----------------------------|
 | `packages/@n8n/db/src/migrations/`                           | @n8n-io/migrations-review  |
-| `packages/frontend/editor-ui/data/node-popularity.json`      | @n8n-io/catalysts          |
 
 ---
 

--- a/.github/workflows/util-update-node-popularity.yml
+++ b/.github/workflows/util-update-node-popularity.yml
@@ -59,6 +59,6 @@ jobs:
           branch: update-node-popularity
           base: master
           delete-branch: true
-          team-reviewers: '@n8n-io/catalysts'
+          reviewers: Matsuuu
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>

--- a/.github/workflows/util-update-node-popularity.yml
+++ b/.github/workflows/util-update-node-popularity.yml
@@ -30,7 +30,7 @@ jobs:
           N8N_FAIL_ON_POPULARITY_FETCH_ERROR: 'false' # Don't fail if API is down
 
       - name: Format generated file
-        run: pnpm format packages/frontend/editor-ui/data/node-popularity.json
+        run: pnpm biome format --write packages/frontend/editor-ui/data/node-popularity.json
 
       - name: Check for changes
         id: check-changes

--- a/.github/workflows/util-update-node-popularity.yml
+++ b/.github/workflows/util-update-node-popularity.yml
@@ -59,5 +59,6 @@ jobs:
           branch: update-node-popularity
           base: master
           delete-branch: true
+          team-reviewers: '@n8n-io/catalysts'
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>


### PR DESCRIPTION
## Summary

Instead of relying on code ownership, make the automated task assign @n8n-io/catalysts as the reviewer of the PR. This reduces unnecessary PR review requests created by manual modification of said file.

## Related Linear tickets, Github issues, and Community forum posts

Prevents unnecessary spam like https://github.com/n8n-io/n8n/pull/25351

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
