### PR TITLE
feat(Kafka Trigger Node): Refactoring and fixes (backport 1.x)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.test.ts
@@ -53,6 +53,7 @@ function createMockContext(overrides?: Partial<ISupplyDataFunctions>): ISupplyDa
 		getTimezone: jest.fn(),
 		getWorkflow: jest.fn(),
 		getWorkflowStaticData: jest.fn(),
+		getWorkflowSettings: jest.fn(() => ({})),
 		logger: {
 			debug: jest.fn(),
 			error: jest.fn(),

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -337,7 +337,7 @@ export class WorkflowRunner {
 					if (workflowExecution.isCanceled) {
 						fullRunData.finished = false;
 					}
-					fullRunData.status = this.activeExecutions.getStatus(executionId);
+
 					this.activeExecutions.resolveExecutionResponsePromise(executionId);
 					this.activeExecutions.finalizeExecution(executionId, fullRunData);
 				})

--- a/packages/core/src/execution-engine/node-execution-context/node-execution-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/node-execution-context.ts
@@ -163,6 +163,15 @@ export abstract class NodeExecutionContext implements Omit<FunctionsBase, 'getCr
 	}
 
 	@Memoized
+	get workflowSettings() {
+		return Object.freeze(structuredClone(this.workflow.settings));
+	}
+
+	getWorkflowSettings() {
+		return this.workflowSettings;
+	}
+
+	@Memoized
 	get nodeType() {
 		const { type, typeVersion } = this.node;
 		return this.workflow.nodeTypes.getByNameAndVersion(type, typeVersion);

--- a/packages/nodes-base/nodes/Kafka/KafkaTrigger.node.ts
+++ b/packages/nodes-base/nodes/Kafka/KafkaTrigger.node.ts
@@ -1,15 +1,30 @@
-import { SchemaRegistry } from '@kafkajs/confluent-schema-registry';
-import type { KafkaConfig, SASLOptions } from 'kafkajs';
-import { Kafka as apacheKafka, logLevel } from 'kafkajs';
+import type { EachBatchPayload } from 'kafkajs';
+import { Kafka as apacheKafka } from 'kafkajs';
 import type {
 	ITriggerFunctions,
-	IDataObject,
 	INodeType,
 	INodeTypeDescription,
 	ITriggerResponse,
-	IRun,
 } from 'n8n-workflow';
-import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
+import {
+	ensureError,
+	NodeConnectionTypes,
+	NodeOperationError,
+	TriggerCloseError,
+} from 'n8n-workflow';
+
+import {
+	type KafkaTriggerOptions,
+	connectEventListeners,
+	disconnectEventListeners,
+	setSchemaRegistry,
+	configureMessageParser,
+	createConfig,
+	createConsumerConfig,
+	configureDataEmitter,
+	getAutoCommitSettings,
+	runWithHeartbeat,
+} from './utils';
 
 export class KafkaTrigger implements INodeType {
 	description: INodeTypeDescription = {
@@ -17,7 +32,7 @@ export class KafkaTrigger implements INodeType {
 		name: 'kafkaTrigger',
 		icon: { light: 'file:kafka.svg', dark: 'file:kafka.dark.svg' },
 		group: ['trigger'],
-		version: [1, 1.1],
+		version: [1, 1.1, 1.2, 1.3],
 		description: 'Consume messages from a Kafka topic',
 		defaults: {
 			name: 'Kafka Trigger',
@@ -48,6 +63,88 @@ export class KafkaTrigger implements INodeType {
 				required: true,
 				placeholder: 'n8n-kafka',
 				description: 'ID of the consumer group',
+			},
+			{
+				displayName: 'Resolve Offset',
+				name: 'resolveOffset',
+				type: 'options',
+				default: 'onCompletion',
+				description:
+					'Select on which condition the offsets should be resolved. In the manual mode, when execution started by clicking on Execute Workflow or Execute Step button, offsets are always resolved immediately after message received.',
+				options: [
+					{
+						name: 'On Execution Completion',
+						value: 'onCompletion',
+						description: 'Resolve offset after execution completion regardless of the status',
+					},
+					{
+						name: 'On Execution Success',
+						value: 'onSuccess',
+						description: 'Resolve offset only if execution status equals success',
+					},
+					{
+						name: 'On Allowed Execution Statuses',
+						value: 'onStatus',
+						description: 'Resolve offset only if execution status in the list of selected statuses',
+					},
+					{
+						name: 'Immediately',
+						value: 'immediately',
+						description:
+							'Resolve offset immediately after message received. This option is not recommended as it can cause messages loss.',
+					},
+				],
+				displayOptions: {
+					show: {
+						'@version': [{ _cnd: { gte: 1.3 } }],
+					},
+				},
+			},
+			{
+				displayName: 'Allowed Statuses',
+				name: 'allowedStatuses',
+				type: 'multiOptions',
+				default: ['success'],
+				options: [
+					{
+						name: 'Canceled',
+						value: 'canceled',
+					},
+					{
+						name: 'Crashed',
+						value: 'crashed',
+					},
+					{
+						name: 'Error',
+						value: 'error',
+					},
+					{
+						name: 'New',
+						value: 'new',
+					},
+					{
+						name: 'Running',
+						value: 'running',
+					},
+					{
+						name: 'Success',
+						value: 'success',
+					},
+					{
+						name: 'Unknown',
+						value: 'unknown',
+					},
+					{
+						name: 'Waiting',
+						value: 'waiting',
+					},
+				],
+				displayOptions: {
+					show: {
+						'@version': [{ _cnd: { gte: 1.3 } }],
+						resolveOffset: ['onStatus'],
+					},
+				},
 			},
 			{
 				displayName: 'Use Schema Registry',
@@ -82,7 +179,7 @@ export class KafkaTrigger implements INodeType {
 						name: 'allowAutoTopicCreation',
 						type: 'boolean',
 						default: false,
-						description: 'Whether to allow sending message to a previously non exisiting topic',
+						description: 'Whether to allow sending message to a previously non-existing topic',
 					},
 					{
 						displayName: 'Auto Commit Threshold',
@@ -102,12 +199,67 @@ export class KafkaTrigger implements INodeType {
 						hint: 'Value in milliseconds',
 					},
 					{
+						displayName: 'Batch Size',
+						name: 'batchSize',
+						type: 'number',
+						default: 1,
+						description:
+							'Number of messages to process in each batch, when set to 1, message-by-message processing is enabled',
+					},
+					{
+						displayName: 'Each Batch Auto Resolve',
+						name: 'eachBatchAutoResolve',
+						type: 'boolean',
+						default: false,
+						description: 'Whether to auto resolve offsets for each batch',
+						displayOptions: {
+							show: {
+								'@version': [{ _cnd: { gte: 1.3 } }],
+							},
+						},
+					},
+					{
+						displayName: 'Fetch Max Bytes',
+						name: 'fetchMaxBytes',
+						type: 'number',
+						default: 1048576,
+						description:
+							'Maximum amount of data the server should return for a fetch request. In bytes. Default is 1MB. Higher values allow fetching more messages at once.',
+					},
+					{
+						displayName: 'Fetch Min Bytes',
+						name: 'fetchMinBytes',
+						type: 'number',
+						default: 1,
+						description:
+							'Minimum amount of data the server should return for a fetch request. In bytes. Server will wait up to fetchMaxWaitTime for this amount to accumulate.',
+					},
+					{
+						displayName: 'Heartbeat Interval',
+						name: 'heartbeatInterval',
+						type: 'number',
+						default: 10000,
+						description:
+							'Controls how often the consumer sends heartbeats to the broker to indicate it is still alive. Must be lower than Session Timeout. Recommended value is approximately one third of the Session Timeout (for example: 10s heartbeat with 30s session timeout).',
+						hint: 'Value in milliseconds',
+						displayOptions: {
+							show: {
+								'@version': [{ _cnd: { gte: 1.3 } }],
+							},
+						},
+					},
+					{
 						displayName: 'Heartbeat Interval',
 						name: 'heartbeatInterval',
 						type: 'number',
 						default: 3000,
 						description: "Heartbeats are used to ensure that the consumer's session stays active",
 						hint: 'The value must be set lower than Session Timeout',
+						displayOptions: {
+							hide: {
+								'@version': [{ _cnd: { gte: 1.3 } }],
+							},
+						},
 					},
 					{
 						displayName: 'Max Number of Requests',
@@ -132,17 +284,39 @@ export class KafkaTrigger implements INodeType {
 						description: 'Whether to try to parse the message to an object',
 					},
 					{
+						displayName: 'Keep Message as Binary Data',
+						name: 'keepBinaryData',
+						type: 'boolean',
+						default: false,
+						displayOptions: {
+							show: {
+								'@version': [{ _cnd: { gte: 1.2 } }],
+							},
+						},
+						description:
+							'Whether to keep message value as binary data for downstream processing (e.g., Avro deserialization)',
+					},
+					{
 						displayName: 'Parallel Processing',
 						name: 'parallelProcessing',
 						type: 'boolean',
 						default: true,
+						description:
+							'Whether to process messages in parallel resolving offsets independently or in order resolving offsets after execution completion. In the manual mode, when execution started by clicking on Execute Workflow or Execute Step button, messages are processed in parallel resolving offsets immediately.',
 						displayOptions: {
-							hide: {
-								'@version': [1],
+							show: {
+								'@version': [1.1, 1.2],
 							},
 						},
+					},
+					{
+						displayName: 'Partitions Consumed Concurrently',
+						name: 'partitionsConsumedConcurrently',
+						type: 'number',
+						default: 0,
 						description:
-							'Whether to process messages in parallel or by keeping the message in order',
+							'Number of Kafka partitions to process in parallel. Controls how many partitions are processed concurrently by the consumer.',
+						hint: 'Set to 0 to process all partitions sequentially',
 					},
 					{
 						displayName: 'Only Message',
@@ -164,11 +338,39 @@ export class KafkaTrigger implements INodeType {
 						description: 'Whether to return the headers received from Kafka',
 					},
 					{
+						displayName: 'Rebalance Timeout',
+						name: 'rebalanceTimeout',
+						type: 'number',
+						default: 600000,
+						description: 'The maximum time allowed for a consumer to join the group',
+					},
+					{
+						displayName: 'Retry Delay on Error',
+						name: 'errorRetryDelay',
+						type: 'number',
+						default: 5000,
+						description:
+							'Delay in milliseconds before retrying after a failed offset resolution. This prevents rapid retry loops that could overwhelm the Kafka broker.',
+						hint: 'Value in milliseconds',
+						typeOptions: {
+							minValue: 1000,
+						},
+						displayOptions: {
+							show: {
+								'@version': [{ _cnd: { gte: 1.3 } }],
+							},
+							hide: {
+								'/resolveOffset': ['immediately'],
+							},
+						},
+					},
+					{
 						displayName: 'Session Timeout',
 						name: 'sessionTimeout',
 						type: 'number',
 						default: 30000,
-						description: 'The time to await a response in ms',
+						description:
+							'Timeout in milliseconds used to detect failures. Has to be higher than Heartbeat Interval. During the workflow execution heartbeat will be sent periodically to keep the session alive with configured Heartbeat Interval.',
 						hint: 'Value in milliseconds',
 					},
 				],
@@ -177,121 +379,115 @@ export class KafkaTrigger implements INodeType {
 	};
 
 	async trigger(this: ITriggerFunctions): Promise<ITriggerResponse> {
-		const topic = this.getNodeParameter('topic') as string;
+		const nodeVersion = this.getNode().typeVersion;
 
-		const groupId = this.getNodeParameter('groupId') as string;
-
-		const credentials = await this.getCredentials('kafka');
-
-		const brokers = ((credentials.brokers as string) ?? '').split(',').map((item) => item.trim());
-
-		const clientId = credentials.clientId as string;
-
-		const ssl = credentials.ssl as boolean;
-
-		const options = this.getNodeParameter('options', {}) as IDataObject;
-
-		options.nodeVersion = this.getNode().typeVersion;
-
-		const config: KafkaConfig = {
-			clientId,
-			brokers,
-			ssl,
-			logLevel: logLevel.ERROR,
-		};
-
-		if (credentials.authentication === true) {
-			if (!(credentials.username && credentials.password)) {
-				throw new NodeOperationError(
-					this.getNode(),
-					'Username and password are required for authentication',
-				);
-			}
-			config.sasl = {
-				username: credentials.username as string,
-				password: credentials.password as string,
-				mechanism: credentials.saslMechanism as string,
-			} as SASLOptions;
-		}
-
-		const maxInFlightRequests = (
-			this.getNodeParameter('options.maxInFlightRequests', null) === 0
-				? null
-				: this.getNodeParameter('options.maxInFlightRequests', null)
-		) as number;
-
-		const parallelProcessing = options.parallelProcessing as boolean;
-
-		const useSchemaRegistry = this.getNodeParameter('useSchemaRegistry', 0) as boolean;
-
-		const schemaRegistryUrl = this.getNodeParameter('schemaRegistryUrl', 0) as string;
-
+		const config = await createConfig(this);
 		const kafka = new apacheKafka(config);
-		const consumer = kafka.consumer({
-			groupId,
-			maxInFlightRequests,
-			sessionTimeout: this.getNodeParameter('options.sessionTimeout', 30000) as number,
-			heartbeatInterval: this.getNodeParameter('options.heartbeatInterval', 3000) as number,
-		});
+		const registry = setSchemaRegistry(this);
 
-		// The "closeFunction" function gets called by n8n whenever
-		// the workflow gets deactivated and can so clean up.
-		async function closeFunction() {
-			await consumer.disconnect();
+		const options = this.getNodeParameter('options', {}) as KafkaTriggerOptions;
+		if (options.keepBinaryData && nodeVersion < 1.2) {
+			options.keepBinaryData = undefined;
 		}
+
+		const consumerConfig = createConsumerConfig(this, options, nodeVersion);
+		const consumer = kafka.consumer(consumerConfig);
+
+		const processMessage = configureMessageParser(
+			options,
+			this.logger,
+			registry,
+			this.helpers.prepareBinaryData,
+		);
+
+		const topic = this.getNodeParameter('topic') as string;
+		const batchSize = options.batchSize ?? 1;
+		const partitionsConsumedConcurrently = options.partitionsConsumedConcurrently || undefined;
+
+		const dataEmitter = configureDataEmitter(this, options, nodeVersion);
 
 		const startConsumer = async () => {
-			await consumer.connect();
+			try {
+				await consumer.connect();
 
-			await consumer.subscribe({ topic, fromBeginning: options.fromBeginning ? true : false });
-			await consumer.run({
-				autoCommitInterval: (options.autoCommitInterval as number) || null,
-				autoCommitThreshold: (options.autoCommitThreshold as number) || null,
-				eachMessage: async ({ topic: messageTopic, message }) => {
-					let data: IDataObject = {};
-					let value = message.value?.toString() as string;
+				await consumer.subscribe({ topic, fromBeginning: options.fromBeginning ? true : false });
 
-					if (options.jsonParseMessage) {
-						try {
-							value = JSON.parse(value);
-						} catch (error) {}
-					}
+				await consumer.run({
+					partitionsConsumedConcurrently,
+					...getAutoCommitSettings(options),
+					eachBatch: async ({
+						batch,
+						resolveOffset,
+						heartbeat,
+						isStale,
+						isRunning,
+						commitOffsetsIfNecessary,
+					}: EachBatchPayload) => {
+						// avoid throwing error in the callback, as it leads to consumer stop, disconnect and crash
+						const messages = batch.messages;
+						const messageTopic = batch.topic;
 
-					if (useSchemaRegistry) {
-						try {
-							const registry = new SchemaRegistry({ host: schemaRegistryUrl });
-							value = await registry.decode(message.value as Buffer);
-						} catch (error) {}
-					}
+						for (let i = 0; i < messages.length; i += batchSize) {
+							// stop if consumer stopped or partition revoked
+							if (!isRunning() || isStale()) {
+								this.logger.debug('Batch processing interrupted due to rebalance or consumer stop');
+								break;
+							}
 
-					if (options.returnHeaders && message.headers) {
-						data.headers = Object.fromEntries(
-							Object.entries(message.headers).map(([headerKey, headerValue]) => [
-								headerKey,
-								headerValue?.toString('utf8') ?? '',
-							]),
-						);
-					}
+							const chunk = messages.slice(i, Math.min(i + batchSize, messages.length));
 
-					data.message = value;
-					data.topic = messageTopic;
+							let processedData;
+							try {
+								processedData = await Promise.all(
+									chunk.map(async (message) => await processMessage(message, messageTopic)),
+								);
+							} catch (err) {
+								this.logger.error('Chunk processing failed, skipping commit for this chunk', err);
+								await heartbeat();
+								break;
+							}
 
-					if (options.onlyMessage) {
-						//@ts-ignore
-						data = value;
-					}
-					let responsePromise = undefined;
-					if (!parallelProcessing && (options.nodeVersion as number) > 1) {
-						responsePromise = this.helpers.createDeferredPromise<IRun>();
-						this.emit([this.helpers.returnJsonArray([data])], undefined, responsePromise);
-					} else {
-						this.emit([this.helpers.returnJsonArray([data])]);
-					}
-					if (responsePromise) {
-						await responsePromise.promise;
-					}
-				},
-			});
+							const result = await runWithHeartbeat(
+								dataEmitter(processedData),
+								heartbeat,
+								consumerConfig.heartbeatInterval,
+							);
+
+							if (!result.success) {
+								this.logger.warn('runWithHeartbeat failed, skipping commit for this chunk');
+								await heartbeat();
+								break;
+							}
+
+							const lastMessage = chunk[chunk.length - 1];
+							if (lastMessage) {
+								resolveOffset(lastMessage.offset);
+								await commitOffsetsIfNecessary();
+							}
+
+							await heartbeat();
+						}
+					},
+				});
+			} catch (error) {
+				this.logger.error('Failed to start Kafka consumer', { error });
+				throw new NodeOperationError(this.getNode(), error);
+			}
+		};
+
+		const listeners = connectEventListeners(consumer, this.logger);
+
+		const closeFunction = async () => {
+			try {
+				disconnectEventListeners(listeners);
+				await consumer.stop();
+				await consumer.disconnect();
+			} catch (error) {
+				throw new TriggerCloseError(this.getNode(), {
+					cause: ensureError(error),
+					level: 'warning',
+				});
+			}
 		};
 
 		if (this.getMode() !== 'manual') {

--- a/packages/nodes-base/nodes/Kafka/test/KafkaTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Kafka/test/KafkaTrigger.node.test.ts
@@ -1,513 +1,2016 @@
-import type { EachBatchPayload } from 'kafkajs';
-import { Kafka as apacheKafka } from 'kafkajs';
-import type {
-	ITriggerFunctions,
-	INodeType,
-	INodeTypeDescription,
-	ITriggerResponse,
-} from 'n8n-workflow';
+import { SchemaRegistry } from '@kafkajs/confluent-schema-registry';
+import { mock } from 'jest-mock-extended';
 import {
-	ensureError,
-	NodeConnectionTypes,
-	NodeOperationError,
-	TriggerCloseError,
-} from 'n8n-workflow';
+	Kafka,
+	logLevel,
+	type Consumer,
+	type ConsumerRunConfig,
+	type EachBatchHandler,
+	type EachMessageHandler,
+	type IHeaders,
+	type KafkaMessage,
+	type RecordBatchEntry,
+} from 'kafkajs';
+import { NodeOperationError, type IRun } from 'n8n-workflow';
 
-import {
-	type KafkaTriggerOptions,
-	connectEventListeners,
-	disconnectEventListeners,
-	setSchemaRegistry,
-	configureMessageParser,
-	createConfig,
-	createConsumerConfig,
-	configureDataEmitter,
-	getAutoCommitSettings,
-	runWithHeartbeat,
-} from './utils';
+import { testTriggerNode } from '@test/nodes/TriggerHelpers';
 
-export class KafkaTrigger implements INodeType {
-	description: INodeTypeDescription = {
-		displayName: 'Kafka Trigger',
-		name: 'kafkaTrigger',
-		icon: { light: 'file:kafka.svg', dark: 'file:kafka.dark.svg' },
-		group: ['trigger'],
-		version: [1, 1.1, 1.2, 1.3],
-		description: 'Consume messages from a Kafka topic',
-		defaults: {
-			name: 'Kafka Trigger',
-		},
-		inputs: [],
-		outputs: [NodeConnectionTypes.Main],
-		credentials: [
-			{
-				name: 'kafka',
-				required: true,
-			},
-		],
-		properties: [
-			{
-				displayName: 'Topic',
-				name: 'topic',
-				type: 'string',
-				default: '',
-				required: true,
-				placeholder: 'topic-name',
-				description: 'Name of the queue of topic to consume from',
-			},
-			{
-				displayName: 'Group ID',
-				name: 'groupId',
-				type: 'string',
-				default: '',
-				required: true,
-				placeholder: 'n8n-kafka',
-				description: 'ID of the consumer group',
-			},
-			{
-				displayName: 'Resolve Offset',
-				name: 'resolveOffset',
-				type: 'options',
-				default: 'onCompletion',
-				description:
-					'Select on which condition the offsets should be resolved. In the manual mode, when execution started by clicking on Execute Workflow or Execute Step button, offsets are always resolved immediately after message received.',
-				options: [
-					{
-						name: 'On Execution Completion',
-						value: 'onCompletion',
-						description: 'Resolve offset after execution completion regardless of the status',
-					},
-					{
-						name: 'On Execution Success',
-						value: 'onSuccess',
-						description: 'Resolve offset only if execution status equals success',
-					},
-					{
-						name: 'On Allowed Execution Statuses',
-						value: 'onStatus',
-						description: 'Resolve offset only if execution status in the list of selected statuses',
-					},
-					{
-						name: 'Immediately',
-						value: 'immediately',
-						description:
-							'Resolve offset immediately after message received. This option is not recommended as it can cause messages loss.',
-					},
-				],
-				displayOptions: {
-					show: {
-						'@version': [{ _cnd: { gte: 1.3 } }],
-					},
-				},
-			},
-			{
-				displayName: 'Allowed Statuses',
-				name: 'allowedStatuses',
-				type: 'multiOptions',
-				default: ['success'],
-				options: [
-					{
-						name: 'Canceled',
-						value: 'canceled',
-					},
-					{
-						name: 'Crashed',
-						value: 'crashed',
-					},
-					{
-						name: 'Error',
-						value: 'error',
-					},
-					{
-						name: 'New',
-						value: 'new',
-					},
-					{
-						name: 'Running',
-						value: 'running',
-					},
-					{
-						name: 'Success',
-						value: 'success',
-					},
-					{
-						name: 'Unknown',
-						value: 'unknown',
-					},
-					{
-						name: 'Waiting',
-						value: 'waiting',
-					},
-				],
-				displayOptions: {
-					show: {
-						'@version': [{ _cnd: { gte: 1.3 } }],
-						resolveOffset: ['onStatus'],
-					},
-				},
-			},
-			{
-				displayName: 'Use Schema Registry',
-				name: 'useSchemaRegistry',
-				type: 'boolean',
-				default: false,
-				description: 'Whether to use Confluent Schema Registry',
-			},
-			{
-				displayName: 'Schema Registry URL',
-				name: 'schemaRegistryUrl',
-				type: 'string',
-				required: true,
-				displayOptions: {
-					show: {
-						useSchemaRegistry: [true],
-					},
-				},
-				placeholder: 'https://schema-registry-domain:8081',
-				default: '',
-				description: 'URL of the schema registry',
-			},
-			{
-				displayName: 'Options',
-				name: 'options',
-				type: 'collection',
-				default: {},
-				placeholder: 'Add option',
-				options: [
-					{
-						displayName: 'Allow Topic Creation',
-						name: 'allowAutoTopicCreation',
-						type: 'boolean',
-						default: false,
-						description: 'Whether to allow sending message to a previously non-existing topic',
-					},
-					{
-						displayName: 'Auto Commit Threshold',
-						name: 'autoCommitThreshold',
-						type: 'number',
-						default: 0,
-						description:
-							'The consumer will commit offsets after resolving a given number of messages',
-					},
-					{
-						displayName: 'Auto Commit Interval',
-						name: 'autoCommitInterval',
-						type: 'number',
-						default: 0,
-						description:
-							'The consumer will commit offsets after a given period, for example, five seconds',
-						hint: 'Value in milliseconds',
-					},
-					{
-						displayName: 'Batch Size',
-						name: 'batchSize',
-						type: 'number',
-						default: 1,
-						description:
-							'Number of messages to process in each batch, when set to 1, message-by-message processing is enabled',
-					},
-					{
-						displayName: 'Each Batch Auto Resolve',
-						name: 'eachBatchAutoResolve',
-						type: 'boolean',
-						default: false,
-						description: 'Whether to auto resolve offsets for each batch',
-						displayOptions: {
-							show: {
-								'@version': [{ _cnd: { gte: 1.3 } }],
-							},
-						},
-					},
-					{
-						displayName: 'Fetch Max Bytes',
-						name: 'fetchMaxBytes',
-						type: 'number',
-						default: 1048576,
-						description:
-							'Maximum amount of data the server should return for a fetch request. In bytes. Default is 1MB. Higher values allow fetching more messages at once.',
-					},
-					{
-						displayName: 'Fetch Min Bytes',
-						name: 'fetchMinBytes',
-						type: 'number',
-						default: 1,
-						description:
-							'Minimum amount of data the server should return for a fetch request. In bytes. Server will wait up to fetchMaxWaitTime for this amount to accumulate.',
-					},
-					{
-						displayName: 'Heartbeat Interval',
-						name: 'heartbeatInterval',
-						type: 'number',
-						default: 10000,
-						description:
-							'Controls how often the consumer sends heartbeats to the broker to indicate it is still alive. Must be lower than Session Timeout. Recommended value is approximately one third of the Session Timeout (for example: 10s heartbeat with 30s session timeout).',
-						hint: 'Value in milliseconds',
-						displayOptions: {
-							show: {
-								'@version': [{ _cnd: { gte: 1.3 } }],
-							},
-						},
-					},
-					{
-						displayName: 'Heartbeat Interval',
-						name: 'heartbeatInterval',
-						type: 'number',
-						default: 3000,
-						description: "Heartbeats are used to ensure that the consumer's session stays active",
-						hint: 'The value must be set lower than Session Timeout',
-						displayOptions: {
-							hide: {
-								'@version': [{ _cnd: { gte: 1.3 } }],
-							},
-						},
-					},
-					{
-						displayName: 'Max Number of Requests',
-						name: 'maxInFlightRequests',
-						type: 'number',
-						default: 1,
-						description:
-							'The maximum number of unacknowledged requests the client will send on a single connection',
-					},
-					{
-						displayName: 'Read Messages From Beginning',
-						name: 'fromBeginning',
-						type: 'boolean',
-						default: true,
-						description: 'Whether to read message from beginning',
-					},
-					{
-						displayName: 'JSON Parse Message',
-						name: 'jsonParseMessage',
-						type: 'boolean',
-						default: false,
-						description: 'Whether to try to parse the message to an object',
-					},
-					{
-						displayName: 'Keep Message as Binary Data',
-						name: 'keepBinaryData',
-						type: 'boolean',
-						default: false,
-						displayOptions: {
-							show: {
-								'@version': [{ _cnd: { gte: 1.2 } }],
-							},
-						},
-						description:
-							'Whether to keep message value as binary data for downstream processing (e.g., Avro deserialization)',
-					},
-					{
-						displayName: 'Parallel Processing',
-						name: 'parallelProcessing',
-						type: 'boolean',
-						default: true,
-						description:
-							'Whether to process messages in parallel resolving offsets independently or in order resolving offsets after execution completion. In the manual mode, when execution started by clicking on Execute Workflow or Execute Step button, messages are processed in parallel resolving offsets immediately.',
-						displayOptions: {
-							show: {
-								'@version': [1.1, 1.2],
-							},
-						},
-					},
-					{
-						displayName: 'Partitions Consumed Concurrently',
-						name: 'partitionsConsumedConcurrently',
-						type: 'number',
-						default: 0,
-						description:
-							'Number of Kafka partitions to process in parallel. Controls how many partitions are processed concurrently by the consumer.',
-						hint: 'Set to 0 to process all partitions sequentially',
-					},
-					{
-						displayName: 'Only Message',
-						name: 'onlyMessage',
-						type: 'boolean',
-						displayOptions: {
-							show: {
-								jsonParseMessage: [true],
-							},
-						},
-						default: false,
-						description: 'Whether to return only the message property',
-					},
-					{
-						displayName: 'Return Headers',
-						name: 'returnHeaders',
-						type: 'boolean',
-						default: false,
-						description: 'Whether to return the headers received from Kafka',
-					},
-					{
-						displayName: 'Rebalance Timeout',
-						name: 'rebalanceTimeout',
-						type: 'number',
-						default: 600000,
-						description: 'The maximum time allowed for a consumer to join the group',
-					},
-					{
-						displayName: 'Retry Delay on Error',
-						name: 'errorRetryDelay',
-						type: 'number',
-						default: 5000,
-						description:
-							'Delay in milliseconds before retrying after a failed offset resolution. This prevents rapid retry loops that could overwhelm the Kafka broker.',
-						hint: 'Value in milliseconds',
-						typeOptions: {
-							minValue: 1000,
-						},
-						displayOptions: {
-							show: {
-								'@version': [{ _cnd: { gte: 1.3 } }],
-							},
-							hide: {
-								'/resolveOffset': ['immediately'],
-							},
-						},
-					},
-					{
-						displayName: 'Session Timeout',
-						name: 'sessionTimeout',
-						type: 'number',
-						default: 30000,
-						description:
-							'Timeout in milliseconds used to detect failures. Has to be higher than Heartbeat Interval. During the workflow execution heartbeat will be sent periodically to keep the session alive with configured Heartbeat Interval.',
-						hint: 'Value in milliseconds',
-					},
-				],
-			},
-		],
+import { KafkaTrigger } from '../KafkaTrigger.node';
+
+jest.mock('kafkajs');
+jest.mock('@kafkajs/confluent-schema-registry');
+jest.mock('n8n-workflow', () => {
+	const actual = jest.requireActual('n8n-workflow');
+	return {
+		...actual,
+		sleep: jest.fn().mockResolvedValue(undefined),
 	};
+});
 
-	async trigger(this: ITriggerFunctions): Promise<ITriggerResponse> {
-		const nodeVersion = this.getNode().typeVersion;
+describe('KafkaTrigger Node', () => {
+	let mockKafka: jest.Mocked<Kafka>;
+	let mockRegistry: jest.Mocked<SchemaRegistry>;
+	let mockConsumerConnect: jest.Mock;
+	let mockConsumerSubscribe: jest.Mock;
+	let mockConsumerRun: jest.Mock;
+	let mockConsumerDisconnect: jest.Mock;
+	let mockConsumerCreate: jest.Mock;
+	let mockRegistryDecode: jest.Mock;
+	let publishMessage: (message: Partial<KafkaMessage>) => Promise<void>;
 
-		const config = await createConfig(this);
-		const kafka = new apacheKafka(config);
-		const registry = setSchemaRegistry(this);
-
-		const options = this.getNodeParameter('options', {}) as KafkaTriggerOptions;
-		if (options.keepBinaryData && nodeVersion < 1.2) {
-			options.keepBinaryData = undefined;
-		}
-
-		const consumerConfig = createConsumerConfig(this, options, nodeVersion);
-		const consumer = kafka.consumer(consumerConfig);
-
-		const processMessage = configureMessageParser(
-			options,
-			this.logger,
-			registry,
-			this.helpers.prepareBinaryData,
+	beforeEach(() => {
+		const mockEachMessageHolder = {
+			handler: jest.fn(async () => {}) as jest.Mocked<EachMessageHandler>,
+		};
+		const mockEachBatchHolder = {
+			handler: jest.fn(async () => {}) as jest.Mocked<EachBatchHandler>,
+		};
+		mockConsumerConnect = jest.fn();
+		mockConsumerSubscribe = jest.fn();
+		mockConsumerRun = jest.fn(({ eachMessage, eachBatch }: ConsumerRunConfig) => {
+			if (eachMessage) {
+				mockEachMessageHolder.handler = eachMessage;
+			}
+			if (eachBatch) {
+				mockEachBatchHolder.handler = eachBatch;
+			}
+		});
+		mockConsumerDisconnect = jest.fn();
+		mockConsumerCreate = jest.fn(() =>
+			mock<Consumer>({
+				connect: mockConsumerConnect,
+				subscribe: mockConsumerSubscribe,
+				run: mockConsumerRun,
+				disconnect: mockConsumerDisconnect,
+				on: jest.fn(() => jest.fn()),
+				events: {
+					CONNECT: 'consumer.connect',
+					GROUP_JOIN: 'consumer.group_join',
+					REQUEST_TIMEOUT: 'consumer.network.request_timeout',
+					RECEIVED_UNSUBSCRIBED_TOPICS: 'consumer.received_unsubscribed_topics',
+					STOP: 'consumer.stop',
+					DISCONNECT: 'consumer.disconnect',
+					COMMIT_OFFSETS: 'consumer.commit_offsets',
+					REBALANCING: 'consumer.rebalancing',
+					CRASH: 'consumer.crash',
+				},
+			}),
 		);
 
-		const topic = this.getNodeParameter('topic') as string;
-		const batchSize = options.batchSize ?? 1;
-		const partitionsConsumedConcurrently = options.partitionsConsumedConcurrently || undefined;
+		// Helper to publish a single message using eachBatch (since we now always use eachBatch)
+		publishMessage = async (message: Partial<KafkaMessage>) => {
+			await mockEachBatchHolder.handler({
+				batch: {
+					topic: 'test-topic',
+					partition: 0,
+					highWatermark: '100',
+					messages: [
+						{
+							attributes: 1,
+							key: Buffer.from('messageKey'),
+							offset: '0',
+							timestamp: new Date().toISOString(),
+							value: Buffer.from('message'),
+							headers: {} as IHeaders,
+							...message,
+						},
+					] as RecordBatchEntry[],
+					isEmpty: () => false,
+					firstOffset: () => '0',
+					lastOffset: () => '0',
+					offsetLag: () => '0',
+					offsetLagLow: () => '0',
+				},
+				resolveOffset: jest.fn(),
+				heartbeat: jest.fn(),
+				commitOffsetsIfNecessary: jest.fn(),
+				uncommittedOffsets: jest.fn(),
+				isRunning: jest.fn(() => true),
+				isStale: jest.fn(() => false),
+				pause: jest.fn(),
+			});
+		};
 
-		const dataEmitter = configureDataEmitter(this, options, nodeVersion);
+		const publishBatch = async (messages: Array<Partial<KafkaMessage>>) => {
+			await mockEachBatchHolder.handler({
+				batch: {
+					topic: 'test-topic',
+					partition: 0,
+					highWatermark: '100',
+					messages: messages.map((msg, index) => ({
+						attributes: 1,
+						key: Buffer.from('messageKey'),
+						offset: String(index),
+						timestamp: new Date().toISOString(),
+						value: Buffer.from('message'),
+						headers: {} as IHeaders,
+						...msg,
+					})) as RecordBatchEntry[],
+					isEmpty: () => false,
+					firstOffset: () => '0',
+					lastOffset: () => String(messages.length - 1),
+					offsetLag: () => '0',
+					offsetLagLow: () => '0',
+				},
+				resolveOffset: jest.fn(),
+				heartbeat: jest.fn(),
+				commitOffsetsIfNecessary: jest.fn(),
+				uncommittedOffsets: jest.fn(),
+				isRunning: jest.fn(() => true),
+				isStale: jest.fn(() => false),
+				pause: jest.fn(),
+			});
+		};
 
-		const startConsumer = async () => {
-			try {
-				await consumer.connect();
+		// Expose publishBatch for tests that need it
+		(global as any).publishBatch = publishBatch;
 
-				await consumer.subscribe({ topic, fromBeginning: options.fromBeginning ? true : false });
+		mockKafka = mock<Kafka>({
+			consumer: mockConsumerCreate,
+		});
 
-				await consumer.run({
-					partitionsConsumedConcurrently,
-					...getAutoCommitSettings(options),
-					eachBatch: async ({
-						batch,
-						resolveOffset,
-						heartbeat,
-						isStale,
-						isRunning,
-						commitOffsetsIfNecessary,
-					}: EachBatchPayload) => {
-						// avoid throwing error in the callback, as it leads to consumer stop, disconnect and crash
-						const messages = batch.messages;
-						const messageTopic = batch.topic;
+		mockRegistryDecode = jest.fn().mockResolvedValue({ data: 'decoded-data' });
+		mockRegistry = mock<SchemaRegistry>({
+			decode: mockRegistryDecode,
+		});
 
-						for (let i = 0; i < messages.length; i += batchSize) {
-							// stop if consumer stopped or partition revoked
-							if (!isRunning() || isStale()) {
-								this.logger.debug('Batch processing interrupted due to rebalance or consumer stop');
-								break;
-							}
+		(Kafka as jest.Mock).mockReturnValue(mockKafka);
+		(SchemaRegistry as jest.Mock).mockReturnValue(mockRegistry);
+	});
 
-							const chunk = messages.slice(i, Math.min(i + batchSize, messages.length));
-
-							let processedData;
-							try {
-								processedData = await Promise.all(
-									chunk.map(async (message) => await processMessage(message, messageTopic)),
-								);
-							} catch (err) {
-								this.logger.error('Chunk processing failed, skipping commit for this chunk', err);
-								await heartbeat();
-								break;
-							}
-
-							const result = await runWithHeartbeat(
-								dataEmitter(processedData),
-								heartbeat,
-								consumerConfig.heartbeatInterval,
-							);
-
-							if (!result.success) {
-								this.logger.warn('runWithHeartbeat failed, skipping commit for this chunk');
-								await heartbeat();
-								break;
-							}
-
-							const lastMessage = chunk[chunk.length - 1];
-							if (lastMessage) {
-								resolveOffset(lastMessage.offset);
-								await commitOffsetsIfNecessary();
-							}
-
-							await heartbeat();
-						}
+	it('should connect to Kafka and subscribe to topic', async () => {
+		const { close, emit } = await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				typeVersion: 1,
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+					options: {
+						fromBeginning: true,
+						parallelProcessing: true,
 					},
-				});
-			} catch (error) {
-				this.logger.error('Failed to start Kafka consumer', { error });
-				throw new NodeOperationError(this.getNode(), error);
-			}
-		};
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
 
-		const listeners = connectEventListeners(consumer, this.logger);
+		expect(Kafka).toHaveBeenCalledWith({
+			clientId: 'n8n-kafka',
+			brokers: ['localhost:9092'],
+			ssl: false,
+			logLevel: logLevel.ERROR,
+		});
 
-		const closeFunction = async () => {
-			try {
-				disconnectEventListeners(listeners);
-				await consumer.stop();
-				await consumer.disconnect();
-			} catch (error) {
-				throw new TriggerCloseError(this.getNode(), {
-					cause: ensureError(error),
-					level: 'warning',
-				});
-			}
-		};
+		expect(mockConsumerCreate).toHaveBeenCalledWith({
+			groupId: 'test-group',
+			maxInFlightRequests: null,
+			sessionTimeout: 30000,
+			heartbeatInterval: 3000,
+			rebalanceTimeout: 600000,
+		});
 
-		if (this.getMode() !== 'manual') {
-			await startConsumer();
-			return { closeFunction };
-		} else {
-			// The "manualTriggerFunction" function gets called by n8n
-			// when a user is in the workflow editor and starts the
-			// workflow manually. So the function has to make sure that
-			// the emit() gets called with similar data like when it
-			// would trigger by itself so that the user knows what data
-			// to expect.
-			async function manualTriggerFunction() {
-				await startConsumer();
-			}
+		expect(mockConsumerConnect).toHaveBeenCalled();
+		expect(mockConsumerSubscribe).toHaveBeenCalledWith({
+			topic: 'test-topic',
+			fromBeginning: true,
+		});
+		expect(mockConsumerRun).toHaveBeenCalled();
 
-			return {
-				closeFunction,
-				manualTriggerFunction,
-			};
-		}
-	}
-}
+		await publishMessage({
+			value: Buffer.from('message'),
+		});
+		expect(emit).toHaveBeenCalledWith([[{ json: { message: 'message', topic: 'test-topic' } }]]);
+
+		await close();
+		expect(mockConsumerDisconnect).toHaveBeenCalled();
+	});
+
+	it('should handle authentication when credentials are provided', async () => {
+		await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: true,
+				authentication: true,
+				username: 'test-user',
+				password: 'test-password',
+				saslMechanism: 'plain',
+			},
+		});
+
+		expect(Kafka).toHaveBeenCalledWith({
+			clientId: 'n8n-kafka',
+			brokers: ['localhost:9092'],
+			ssl: true,
+			logLevel: logLevel.ERROR,
+			sasl: {
+				username: 'test-user',
+				password: 'test-password',
+				mechanism: 'plain',
+			},
+		});
+	});
+
+	it('should throw an error if authentication is enabled but credentials are missing', async () => {
+		await expect(
+			testTriggerNode(KafkaTrigger, {
+				mode: 'trigger',
+				node: {
+					parameters: {
+						topic: 'test-topic',
+						groupId: 'test-group',
+					},
+				},
+				credential: {
+					brokers: 'localhost:9092',
+					clientId: 'n8n-kafka',
+					ssl: false,
+					authentication: true,
+				},
+			}),
+		).rejects.toThrow(NodeOperationError);
+	});
+
+	it('should use schema registry when enabled', async () => {
+		const { emit } = await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: true,
+					schemaRegistryUrl: 'http://localhost:8081',
+					options: { parallelProcessing: true },
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		await publishMessage({
+			value: Buffer.from('test-message'),
+			headers: { 'content-type': Buffer.from('application/json') },
+		});
+
+		expect(SchemaRegistry).toHaveBeenCalledWith({
+			host: 'http://localhost:8081',
+		});
+		expect(mockRegistryDecode).toHaveBeenCalledWith(Buffer.from('test-message'));
+		expect(emit).toHaveBeenCalledWith([
+			[
+				{
+					json: {
+						message: { data: 'decoded-data' },
+						topic: 'test-topic',
+					},
+				},
+			],
+		]);
+	});
+
+	it('should parse JSON message when jsonParseMessage is true', async () => {
+		const { emit } = await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+					options: {
+						jsonParseMessage: true,
+						parallelProcessing: true,
+						onlyMessage: true,
+					},
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		const jsonData = { foo: 'bar' };
+
+		await publishMessage({
+			value: Buffer.from(JSON.stringify(jsonData)),
+		});
+
+		expect(emit).toHaveBeenCalledWith([[{ json: jsonData }]]);
+	});
+
+	it('should include headers when returnHeaders is true', async () => {
+		const { emit } = await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				typeVersion: 1,
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+					options: {
+						returnHeaders: true,
+					},
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		await publishMessage({
+			value: Buffer.from('test-message'),
+			headers: {
+				'content-type': Buffer.from('application/json'),
+				'correlation-id': '123456',
+				'with-array-value': ['1', '2', '3'],
+				empty: undefined,
+			},
+		});
+
+		expect(emit).toHaveBeenCalledWith([
+			[
+				{
+					json: {
+						message: 'test-message',
+						topic: 'test-topic',
+						headers: {
+							'content-type': 'application/json',
+							'correlation-id': '123456',
+							'with-array-value': '1,2,3',
+							empty: '',
+						},
+					},
+				},
+			],
+		]);
+	});
+
+	it('should handle manual trigger mode', async () => {
+		const { emit, manualTriggerFunction } = await testTriggerNode(KafkaTrigger, {
+			mode: 'manual',
+			node: {
+				typeVersion: 1,
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+					options: {
+						parallelProcessing: true,
+					},
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		await manualTriggerFunction?.();
+
+		expect(mockConsumerConnect).toHaveBeenCalledTimes(1);
+		expect(mockConsumerSubscribe).toHaveBeenCalledTimes(1);
+		expect(mockConsumerRun).toHaveBeenCalledTimes(1);
+
+		expect(emit).not.toHaveBeenCalled();
+
+		await publishMessage({ value: Buffer.from('test') });
+
+		expect(emit).toHaveBeenCalledWith([[{ json: { message: 'test', topic: 'test-topic' } }]]);
+	});
+
+	it('should use immediate emit in manual mode even when resolveOffset is onCompletion (v1.3)', async () => {
+		const { emit, manualTriggerFunction } = await testTriggerNode(KafkaTrigger, {
+			mode: 'manual',
+			node: {
+				typeVersion: 1.3,
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+					resolveOffset: 'onCompletion',
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		await manualTriggerFunction?.();
+
+		await publishMessage({ value: Buffer.from('test-message') });
+
+		expect(emit).toHaveBeenCalledWith([
+			[{ json: { message: 'test-message', topic: 'test-topic' } }],
+		]);
+		expect(emit.mock.calls[0][2]).toBeUndefined();
+	});
+
+	it('should use immediate emit in manual mode even when parallelProcessing is false (v1.1)', async () => {
+		const { emit, manualTriggerFunction } = await testTriggerNode(KafkaTrigger, {
+			mode: 'manual',
+			node: {
+				typeVersion: 1.1,
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+					options: {
+						parallelProcessing: false,
+					},
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		await manualTriggerFunction?.();
+
+		await publishMessage({ value: Buffer.from('test-message') });
+
+		expect(emit).toHaveBeenCalledWith([
+			[{ json: { message: 'test-message', topic: 'test-topic' } }],
+		]);
+		expect(emit.mock.calls[0][2]).toBeUndefined();
+	});
+
+	it('should handle sequential processing when parallelProcessing is false', async () => {
+		const { emit } = await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				typeVersion: 1.1,
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+					options: {
+						parallelProcessing: false,
+					},
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		const publishPromise = publishMessage({
+			value: Buffer.from('test-message'),
+		});
+
+		// Wait for the async message handler to execute
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(emit).toHaveBeenCalled();
+
+		const deferredPromise = emit.mock.calls[0][2];
+		expect(deferredPromise).toBeDefined();
+
+		deferredPromise?.resolve(mock());
+		await publishPromise;
+	});
+
+	it('should keep binary data when keepBinaryData is enabled in v1.2', async () => {
+		const messageBuffer = Buffer.from('binary-avro-data');
+
+		const { emit } = await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				typeVersion: 1.2,
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+					options: {
+						keepBinaryData: true,
+						parallelProcessing: true,
+					},
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		await publishMessage({
+			value: messageBuffer,
+		});
+
+		// Verify that emit was called with binary data structure
+		expect(emit).toHaveBeenCalled();
+		const emittedData = emit.mock.calls[0][0][0][0]; // [callIndex][argumentIndex][arrayIndex][itemIndex]
+
+		// Check the structure has both json and binary properties
+		expect(emittedData).toHaveProperty('json');
+		expect(emittedData).toHaveProperty('binary');
+		// Message is converted to string for the json field
+		expect(emittedData.json.message).toBe('binary-avro-data');
+		expect(emittedData.json.topic).toBe('test-topic');
+		// Raw buffer is preserved in binary data for downstream processing
+		expect(emittedData.binary).toHaveProperty('data');
+	});
+
+	it('should not keep binary data in v1.0 and v1.1 even if option is set', async () => {
+		const { emit } = await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				typeVersion: 1.1,
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+					options: {
+						keepBinaryData: true,
+						parallelProcessing: true,
+					},
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		await publishMessage({
+			value: Buffer.from('test-message'),
+		});
+
+		// Should emit as string, not binary data
+		expect(emit).toHaveBeenCalledWith([
+			[
+				{
+					json: {
+						message: 'test-message',
+						topic: 'test-topic',
+					},
+				},
+			],
+		]);
+	});
+
+	it('should convert to string when keepBinaryData is false in v1.2', async () => {
+		const { emit } = await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				typeVersion: 1.2,
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+					options: {
+						keepBinaryData: false,
+						parallelProcessing: true,
+					},
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		await publishMessage({
+			value: Buffer.from('test-message'),
+		});
+
+		expect(emit).toHaveBeenCalledWith([
+			[
+				{
+					json: {
+						message: 'test-message',
+						topic: 'test-topic',
+					},
+				},
+			],
+		]);
+	});
+
+	it('should parse JSON and keep binary data when both options are enabled', async () => {
+		const jsonData = { foo: 'bar', nested: { value: 123 } };
+		const messageBuffer = Buffer.from(JSON.stringify(jsonData));
+
+		const { emit } = await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				typeVersion: 1.2,
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+					options: {
+						keepBinaryData: true,
+						jsonParseMessage: true,
+						parallelProcessing: true,
+					},
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		await publishMessage({
+			value: messageBuffer,
+		});
+
+		expect(emit).toHaveBeenCalled();
+		const emittedData = emit.mock.calls[0][0][0][0];
+
+		// Should have parsed JSON in the message field
+		expect(emittedData.json.message).toEqual(jsonData);
+		expect(emittedData.json.topic).toBe('test-topic');
+		// Should also have binary data attached
+		expect(emittedData.binary).toHaveProperty('data');
+	});
+
+	it('should decode with schema registry and keep binary data when both are enabled', async () => {
+		const messageBuffer = Buffer.from('avro-encoded-data');
+		const decodedData = { userId: 123, userName: 'test-user' };
+		mockRegistryDecode.mockResolvedValue(decodedData);
+
+		const { emit } = await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				typeVersion: 1.2,
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: true,
+					schemaRegistryUrl: 'http://localhost:8081',
+					options: {
+						keepBinaryData: true,
+						parallelProcessing: true,
+					},
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		await publishMessage({
+			value: messageBuffer,
+		});
+
+		// Should call schema registry decode
+		expect(mockRegistryDecode).toHaveBeenCalledWith(messageBuffer);
+
+		expect(emit).toHaveBeenCalled();
+		const emittedData = emit.mock.calls[0][0][0][0];
+
+		// Should have decoded data in the message field
+		expect(emittedData.json.message).toEqual(decodedData);
+		expect(emittedData.json.topic).toBe('test-topic');
+		// Should also have binary data attached
+		expect(emittedData.binary).toHaveProperty('data');
+	});
+
+	it('should work with keepBinaryData and onlyMessage together', async () => {
+		const jsonData = { result: 'success', data: [1, 2, 3] };
+		const messageBuffer = Buffer.from(JSON.stringify(jsonData));
+
+		const { emit } = await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				typeVersion: 1.2,
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+					options: {
+						keepBinaryData: true,
+						jsonParseMessage: true,
+						onlyMessage: true,
+						parallelProcessing: true,
+					},
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		await publishMessage({
+			value: messageBuffer,
+		});
+
+		expect(emit).toHaveBeenCalled();
+		const emittedData = emit.mock.calls[0][0][0][0];
+
+		// onlyMessage should return just the parsed JSON (not wrapped in message/topic)
+		expect(emittedData.json).toEqual(jsonData);
+		// Should still have binary data attached
+		expect(emittedData.binary).toHaveProperty('data');
+	});
+
+	it('should keep binary data with returnHeaders enabled', async () => {
+		const messageBuffer = Buffer.from('test-data');
+
+		const { emit } = await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				typeVersion: 1.2,
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+					options: {
+						keepBinaryData: true,
+						returnHeaders: true,
+						parallelProcessing: true,
+					},
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		await publishMessage({
+			value: messageBuffer,
+			headers: {
+				'content-type': Buffer.from('application/octet-stream'),
+				'message-id': Buffer.from('msg-123'),
+			},
+		});
+
+		expect(emit).toHaveBeenCalled();
+		const emittedData = emit.mock.calls[0][0][0][0];
+
+		// Should have message and headers (message converted to string)
+		expect(emittedData.json.message).toBe('test-data');
+		expect(emittedData.json.topic).toBe('test-topic');
+		expect(emittedData.json.headers).toEqual({
+			'content-type': 'application/octet-stream',
+			'message-id': 'msg-123',
+		});
+		// Raw buffer is preserved in binary data for downstream processing
+		expect(emittedData.binary).toHaveProperty('data');
+	});
+
+	it('should use custom rebalanceTimeout when provided', async () => {
+		await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				typeVersion: 1,
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+					options: {
+						rebalanceTimeout: 300000,
+						sessionTimeout: 20000,
+						heartbeatInterval: 2000,
+					},
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		expect(mockConsumerCreate).toHaveBeenCalledWith({
+			groupId: 'test-group',
+			maxInFlightRequests: null,
+			sessionTimeout: 20000,
+			heartbeatInterval: 2000,
+			rebalanceTimeout: 300000,
+		});
+	});
+
+	it('should register event listeners on consumer', async () => {
+		const mockOn = jest.fn(() => jest.fn());
+		mockConsumerCreate.mockReturnValueOnce(
+			mock<Consumer>({
+				connect: mockConsumerConnect,
+				subscribe: mockConsumerSubscribe,
+				run: mockConsumerRun,
+				disconnect: mockConsumerDisconnect,
+				on: mockOn,
+				events: {
+					CONNECT: 'consumer.connect',
+					GROUP_JOIN: 'consumer.group_join',
+					REQUEST_TIMEOUT: 'consumer.network.request_timeout',
+					RECEIVED_UNSUBSCRIBED_TOPICS: 'consumer.received_unsubscribed_topics',
+					STOP: 'consumer.stop',
+					DISCONNECT: 'consumer.disconnect',
+					COMMIT_OFFSETS: 'consumer.commit_offsets',
+					REBALANCING: 'consumer.rebalancing',
+					CRASH: 'consumer.crash',
+				},
+			}),
+		);
+
+		await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		// Verify all event listeners are registered
+		expect(mockOn).toHaveBeenCalledTimes(9);
+		expect(mockOn).toHaveBeenCalledWith('consumer.connect', expect.any(Function));
+		expect(mockOn).toHaveBeenCalledWith('consumer.group_join', expect.any(Function));
+		expect(mockOn).toHaveBeenCalledWith('consumer.network.request_timeout', expect.any(Function));
+		expect(mockOn).toHaveBeenCalledWith(
+			'consumer.received_unsubscribed_topics',
+			expect.any(Function),
+		);
+		expect(mockOn).toHaveBeenCalledWith('consumer.stop', expect.any(Function));
+		expect(mockOn).toHaveBeenCalledWith('consumer.disconnect', expect.any(Function));
+		expect(mockOn).toHaveBeenCalledWith('consumer.commit_offsets', expect.any(Function));
+		expect(mockOn).toHaveBeenCalledWith('consumer.rebalancing', expect.any(Function));
+		expect(mockOn).toHaveBeenCalledWith('consumer.crash', expect.any(Function));
+	});
+
+	it('should clean up event listeners on close', async () => {
+		const mockRemoveListener1 = jest.fn();
+		const mockRemoveListener2 = jest.fn();
+		const mockRemoveListener3 = jest.fn();
+		const mockRemoveListener4 = jest.fn();
+		const mockRemoveListener5 = jest.fn();
+		const mockRemoveListener6 = jest.fn();
+		const mockRemoveListener7 = jest.fn();
+		const mockRemoveListener8 = jest.fn();
+		const mockRemoveListener9 = jest.fn();
+
+		const mockOn = jest
+			.fn()
+			.mockReturnValueOnce(mockRemoveListener1)
+			.mockReturnValueOnce(mockRemoveListener2)
+			.mockReturnValueOnce(mockRemoveListener3)
+			.mockReturnValueOnce(mockRemoveListener4)
+			.mockReturnValueOnce(mockRemoveListener5)
+			.mockReturnValueOnce(mockRemoveListener6)
+			.mockReturnValueOnce(mockRemoveListener7)
+			.mockReturnValueOnce(mockRemoveListener8)
+			.mockReturnValueOnce(mockRemoveListener9);
+
+		const mockConsumerStop = jest.fn();
+
+		mockConsumerCreate.mockReturnValueOnce(
+			mock<Consumer>({
+				connect: mockConsumerConnect,
+				subscribe: mockConsumerSubscribe,
+				run: mockConsumerRun,
+				disconnect: mockConsumerDisconnect,
+				stop: mockConsumerStop,
+				on: mockOn,
+				events: {
+					CONNECT: 'consumer.connect',
+					GROUP_JOIN: 'consumer.group_join',
+					REQUEST_TIMEOUT: 'consumer.network.request_timeout',
+					RECEIVED_UNSUBSCRIBED_TOPICS: 'consumer.received_unsubscribed_topics',
+					STOP: 'consumer.stop',
+					DISCONNECT: 'consumer.disconnect',
+					COMMIT_OFFSETS: 'consumer.commit_offsets',
+					REBALANCING: 'consumer.rebalancing',
+					CRASH: 'consumer.crash',
+				},
+			}),
+		);
+
+		const { close } = await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		await close();
+
+		// Verify all event listener removal functions were called
+		expect(mockRemoveListener1).toHaveBeenCalled();
+		expect(mockRemoveListener2).toHaveBeenCalled();
+		expect(mockRemoveListener3).toHaveBeenCalled();
+		expect(mockRemoveListener4).toHaveBeenCalled();
+		expect(mockRemoveListener5).toHaveBeenCalled();
+		expect(mockRemoveListener6).toHaveBeenCalled();
+		expect(mockRemoveListener7).toHaveBeenCalled();
+		expect(mockRemoveListener8).toHaveBeenCalled();
+		expect(mockRemoveListener9).toHaveBeenCalled();
+
+		// Verify consumer was stopped and disconnected
+		expect(mockConsumerStop).toHaveBeenCalled();
+		expect(mockConsumerDisconnect).toHaveBeenCalled();
+	});
+
+	it('should use default values for consumer config when options are not provided', async () => {
+		await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				typeVersion: 1,
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		expect(mockConsumerCreate).toHaveBeenCalledWith({
+			groupId: 'test-group',
+			maxInFlightRequests: null,
+			sessionTimeout: 30000,
+			heartbeatInterval: 3000,
+			rebalanceTimeout: 600000,
+		});
+	});
+
+	it('should handle batch processing when batchSize > 1', async () => {
+		const { emit } = await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+					options: {
+						batchSize: 3,
+						parallelProcessing: true,
+					},
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		const publishBatch = (global as any).publishBatch;
+		await publishBatch([
+			{ value: Buffer.from('message1') },
+			{ value: Buffer.from('message2') },
+			{ value: Buffer.from('message3') },
+		]);
+
+		expect(emit).toHaveBeenCalledWith([
+			[
+				{ json: { message: 'message1', topic: 'test-topic' } },
+				{ json: { message: 'message2', topic: 'test-topic' } },
+				{ json: { message: 'message3', topic: 'test-topic' } },
+			],
+		]);
+	});
+
+	it('should process messages in chunks when batch has more messages than batchSize', async () => {
+		const { emit } = await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+					options: {
+						batchSize: 2,
+						parallelProcessing: true,
+					},
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		const publishBatch = (global as any).publishBatch;
+		await publishBatch([
+			{ value: Buffer.from('message1') },
+			{ value: Buffer.from('message2') },
+			{ value: Buffer.from('message3') },
+			{ value: Buffer.from('message4') },
+			{ value: Buffer.from('message5') },
+		]);
+
+		// Should be called 3 times: [msg1, msg2], [msg3, msg4], [msg5]
+		expect(emit).toHaveBeenCalledTimes(3);
+		expect(emit).toHaveBeenNthCalledWith(1, [
+			[
+				{ json: { message: 'message1', topic: 'test-topic' } },
+				{ json: { message: 'message2', topic: 'test-topic' } },
+			],
+		]);
+		expect(emit).toHaveBeenNthCalledWith(2, [
+			[
+				{ json: { message: 'message3', topic: 'test-topic' } },
+				{ json: { message: 'message4', topic: 'test-topic' } },
+			],
+		]);
+		expect(emit).toHaveBeenNthCalledWith(3, [
+			[{ json: { message: 'message5', topic: 'test-topic' } }],
+		]);
+	});
+
+	it('should use fetchMaxBytes and fetchMinBytes when provided', async () => {
+		await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				typeVersion: 1,
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+					options: {
+						fetchMaxBytes: 2097152,
+						fetchMinBytes: 1024,
+					},
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		expect(mockConsumerCreate).toHaveBeenCalledWith({
+			groupId: 'test-group',
+			maxInFlightRequests: null,
+			sessionTimeout: 30000,
+			heartbeatInterval: 3000,
+			rebalanceTimeout: 600000,
+			maxBytesPerPartition: 2097152,
+			minBytes: 1024,
+		});
+	});
+
+	it('should use partitionsConsumedConcurrently when provided', async () => {
+		await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+					options: {
+						partitionsConsumedConcurrently: 5,
+					},
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		expect(mockConsumerRun).toHaveBeenCalledWith(
+			expect.objectContaining({
+				partitionsConsumedConcurrently: 5,
+			}),
+		);
+	});
+
+	it('should handle batch processing with sequential processing', async () => {
+		const { emit } = await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				typeVersion: 1.1,
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+					options: {
+						batchSize: 2,
+						parallelProcessing: false,
+					},
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		const publishBatch = (global as any).publishBatch;
+		const publishPromise = publishBatch([
+			{ value: Buffer.from('message1') },
+			{ value: Buffer.from('message2') },
+		]);
+
+		// Wait for the async batch handler to execute
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(emit).toHaveBeenCalled();
+
+		const deferredPromise = emit.mock.calls[0][2];
+		expect(deferredPromise).toBeDefined();
+
+		deferredPromise?.resolve(mock());
+		await publishPromise;
+	});
+
+	it('should handle batch processing with JSON parsing', async () => {
+		const { emit } = await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+					options: {
+						batchSize: 2,
+						jsonParseMessage: true,
+						parallelProcessing: true,
+					},
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		const publishBatch = (global as any).publishBatch;
+		await publishBatch([
+			{ value: Buffer.from(JSON.stringify({ id: 1, name: 'test1' })) },
+			{ value: Buffer.from(JSON.stringify({ id: 2, name: 'test2' })) },
+		]);
+
+		expect(emit).toHaveBeenCalledWith([
+			[
+				{ json: { message: { id: 1, name: 'test1' }, topic: 'test-topic' } },
+				{ json: { message: { id: 2, name: 'test2' }, topic: 'test-topic' } },
+			],
+		]);
+	});
+
+	it('should handle batch processing with headers', async () => {
+		const { emit } = await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				typeVersion: 1,
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+					options: {
+						batchSize: 2,
+						returnHeaders: true,
+						parallelProcessing: true,
+					},
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		const publishBatch = (global as any).publishBatch;
+		await publishBatch([
+			{
+				value: Buffer.from('message1'),
+				headers: { 'content-type': Buffer.from('application/json') },
+			},
+			{
+				value: Buffer.from('message2'),
+				headers: { 'content-type': Buffer.from('text/plain') },
+			},
+		]);
+
+		expect(emit).toHaveBeenCalledWith([
+			[
+				{
+					json: {
+						message: 'message1',
+						topic: 'test-topic',
+						headers: { 'content-type': 'application/json' },
+					},
+				},
+				{
+					json: {
+						message: 'message2',
+						topic: 'test-topic',
+						headers: { 'content-type': 'text/plain' },
+					},
+				},
+			],
+		]);
+	});
+
+	it('should keep binary data in batch processing when keepBinaryData is enabled in v1.2', async () => {
+		const { emit } = await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				typeVersion: 1.2,
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+					options: {
+						batchSize: 2,
+						keepBinaryData: true,
+						parallelProcessing: true,
+					},
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		const publishBatch = (global as any).publishBatch;
+		await publishBatch([
+			{ value: Buffer.from('binary-data-1') },
+			{ value: Buffer.from('binary-data-2') },
+		]);
+
+		expect(emit).toHaveBeenCalled();
+		const emittedData = emit.mock.calls[0][0][0];
+
+		// Both messages should have binary data
+		expect(emittedData[0]).toHaveProperty('json');
+		expect(emittedData[0]).toHaveProperty('binary');
+		expect(emittedData[0].json.message).toBe('binary-data-1');
+		expect(emittedData[0].binary).toHaveProperty('data');
+
+		expect(emittedData[1]).toHaveProperty('json');
+		expect(emittedData[1]).toHaveProperty('binary');
+		expect(emittedData[1].json.message).toBe('binary-data-2');
+		expect(emittedData[1].binary).toHaveProperty('data');
+	});
+
+	describe('version 1.3', () => {
+		it('should use default sessionTimeout and heartbeatInterval', async () => {
+			await testTriggerNode(KafkaTrigger, {
+				mode: 'trigger',
+				node: {
+					typeVersion: 1.3,
+					parameters: {
+						topic: 'test-topic',
+						groupId: 'test-group',
+						useSchemaRegistry: false,
+						resolveOffset: 'immediately',
+					},
+				},
+				credential: {
+					brokers: 'localhost:9092',
+					clientId: 'n8n-kafka',
+					ssl: false,
+					authentication: false,
+				},
+			});
+
+			expect(mockConsumerCreate).toHaveBeenCalledWith({
+				groupId: 'test-group',
+				maxInFlightRequests: null,
+				sessionTimeout: 30000,
+				heartbeatInterval: 10000,
+				rebalanceTimeout: 600000,
+			});
+		});
+
+		it('should use resolveOffset "immediately" and emit without waiting', async () => {
+			const { emit } = await testTriggerNode(KafkaTrigger, {
+				mode: 'trigger',
+				node: {
+					typeVersion: 1.3,
+					parameters: {
+						topic: 'test-topic',
+						groupId: 'test-group',
+						useSchemaRegistry: false,
+						resolveOffset: 'immediately',
+					},
+				},
+				credential: {
+					brokers: 'localhost:9092',
+					clientId: 'n8n-kafka',
+					ssl: false,
+					authentication: false,
+				},
+			});
+
+			await publishMessage({ value: Buffer.from('test-message') });
+
+			expect(emit).toHaveBeenCalledWith([
+				[{ json: { message: 'test-message', topic: 'test-topic' } }],
+			]);
+			expect(emit.mock.calls[0][2]).toBeUndefined();
+		});
+
+		it('should use resolveOffset "onCompletion" and wait for execution', async () => {
+			const { emit } = await testTriggerNode(KafkaTrigger, {
+				mode: 'trigger',
+				node: {
+					typeVersion: 1.3,
+					parameters: {
+						topic: 'test-topic',
+						groupId: 'test-group',
+						useSchemaRegistry: false,
+						resolveOffset: 'onCompletion',
+					},
+				},
+				credential: {
+					brokers: 'localhost:9092',
+					clientId: 'n8n-kafka',
+					ssl: false,
+					authentication: false,
+				},
+			});
+
+			const publishPromise = publishMessage({ value: Buffer.from('test-message') });
+			await new Promise((resolve) => setImmediate(resolve));
+
+			expect(emit).toHaveBeenCalled();
+			const deferredPromise = emit.mock.calls[0][2];
+			expect(deferredPromise).toBeDefined();
+
+			deferredPromise?.resolve(mock());
+			await publishPromise;
+		});
+
+		it('should use resolveOffset "onSuccess" and wait for successful execution', async () => {
+			const { emit } = await testTriggerNode(KafkaTrigger, {
+				mode: 'trigger',
+				node: {
+					typeVersion: 1.3,
+					parameters: {
+						topic: 'test-topic',
+						groupId: 'test-group',
+						useSchemaRegistry: false,
+						resolveOffset: 'onSuccess',
+					},
+				},
+				credential: {
+					brokers: 'localhost:9092',
+					clientId: 'n8n-kafka',
+					ssl: false,
+					authentication: false,
+				},
+			});
+
+			const publishPromise = publishMessage({ value: Buffer.from('test-message') });
+			await new Promise((resolve) => setImmediate(resolve));
+
+			expect(emit).toHaveBeenCalled();
+			const deferredPromise = emit.mock.calls[0][2];
+			expect(deferredPromise).toBeDefined();
+
+			deferredPromise?.resolve(mock<IRun>({ status: 'success' }));
+			await publishPromise;
+		});
+
+		it('should return success false when resolveOffset is "onSuccess" and execution fails', async () => {
+			const { emit } = await testTriggerNode(KafkaTrigger, {
+				mode: 'trigger',
+				node: {
+					typeVersion: 1.3,
+					parameters: {
+						topic: 'test-topic',
+						groupId: 'test-group',
+						useSchemaRegistry: false,
+						resolveOffset: 'onSuccess',
+					},
+				},
+				credential: {
+					brokers: 'localhost:9092',
+					clientId: 'n8n-kafka',
+					ssl: false,
+					authentication: false,
+				},
+			});
+
+			const publishPromise = publishMessage({ value: Buffer.from('test-message') });
+			await new Promise((resolve) => setImmediate(resolve));
+
+			expect(emit).toHaveBeenCalled();
+			const deferredPromise = emit.mock.calls[0][2];
+			expect(deferredPromise).toBeDefined();
+
+			deferredPromise?.resolve(mock<IRun>({ status: 'error' }));
+			// The emitter catches the error, logs it, and returns { success: false }
+			// instead of throwing, so the promise resolves (not rejects)
+			await publishPromise;
+		});
+
+		it('should use sessionTimeout and heartbeatInterval options when provided', async () => {
+			await testTriggerNode(KafkaTrigger, {
+				mode: 'trigger',
+				node: {
+					typeVersion: 1.3,
+					parameters: {
+						topic: 'test-topic',
+						groupId: 'test-group',
+						useSchemaRegistry: false,
+						resolveOffset: 'immediately',
+						options: {
+							sessionTimeout: 20000,
+							heartbeatInterval: 2000,
+						},
+					},
+				},
+				credential: {
+					brokers: 'localhost:9092',
+					clientId: 'n8n-kafka',
+					ssl: false,
+					authentication: false,
+				},
+			});
+
+			expect(mockConsumerCreate).toHaveBeenCalledWith({
+				groupId: 'test-group',
+				maxInFlightRequests: null,
+				sessionTimeout: 20000,
+				heartbeatInterval: 2000,
+				rebalanceTimeout: 600000,
+			});
+		});
+
+		it('should use resolveOffset "onStatus" and resolve when status matches allowed statuses', async () => {
+			const { emit } = await testTriggerNode(KafkaTrigger, {
+				mode: 'trigger',
+				node: {
+					typeVersion: 1.3,
+					parameters: {
+						topic: 'test-topic',
+						groupId: 'test-group',
+						useSchemaRegistry: false,
+						resolveOffset: 'onStatus',
+						allowedStatuses: ['success', 'error'],
+					},
+				},
+				credential: {
+					brokers: 'localhost:9092',
+					clientId: 'n8n-kafka',
+					ssl: false,
+					authentication: false,
+				},
+			});
+
+			const publishPromise = publishMessage({ value: Buffer.from('test-message') });
+			await new Promise((resolve) => setImmediate(resolve));
+
+			expect(emit).toHaveBeenCalled();
+			const deferredPromise = emit.mock.calls[0][2];
+			expect(deferredPromise).toBeDefined();
+
+			// Should resolve successfully when status is in allowedStatuses
+			deferredPromise?.resolve(mock<IRun>({ status: 'error' }));
+			await publishPromise;
+		});
+
+		it('should use resolveOffset "onStatus" and fail when status does not match allowed statuses', async () => {
+			const { emit } = await testTriggerNode(KafkaTrigger, {
+				mode: 'trigger',
+				node: {
+					typeVersion: 1.3,
+					parameters: {
+						topic: 'test-topic',
+						groupId: 'test-group',
+						useSchemaRegistry: false,
+						resolveOffset: 'onStatus',
+						allowedStatuses: ['success'],
+					},
+				},
+				credential: {
+					brokers: 'localhost:9092',
+					clientId: 'n8n-kafka',
+					ssl: false,
+					authentication: false,
+				},
+			});
+
+			const publishPromise = publishMessage({ value: Buffer.from('test-message') });
+			await new Promise((resolve) => setImmediate(resolve));
+
+			expect(emit).toHaveBeenCalled();
+			const deferredPromise = emit.mock.calls[0][2];
+			expect(deferredPromise).toBeDefined();
+
+			// Should fail when status is not in allowedStatuses
+			deferredPromise?.resolve(mock<IRun>({ status: 'error' }));
+			// The emitter catches the error, logs it, and returns { success: false }
+			await publishPromise;
+		});
+
+		it('should throw error when resolveOffset is "onStatus" but no statuses are selected', async () => {
+			await expect(
+				testTriggerNode(KafkaTrigger, {
+					mode: 'trigger',
+					node: {
+						typeVersion: 1.3,
+						parameters: {
+							topic: 'test-topic',
+							groupId: 'test-group',
+							useSchemaRegistry: false,
+							resolveOffset: 'onStatus',
+							allowedStatuses: [],
+						},
+					},
+					credential: {
+						brokers: 'localhost:9092',
+						clientId: 'n8n-kafka',
+						ssl: false,
+						authentication: false,
+					},
+				}),
+			).rejects.toThrow(NodeOperationError);
+		});
+
+		it('should stop processing batch when isRunning returns false (consumer stopping)', async () => {
+			let eachBatchHandler: EachBatchHandler | undefined;
+			mockConsumerRun.mockImplementation(({ eachBatch }: ConsumerRunConfig) => {
+				if (eachBatch) {
+					eachBatchHandler = eachBatch;
+				}
+			});
+
+			const { emit } = await testTriggerNode(KafkaTrigger, {
+				mode: 'trigger',
+				node: {
+					typeVersion: 1.3,
+					parameters: {
+						topic: 'test-topic',
+						groupId: 'test-group',
+						useSchemaRegistry: false,
+						resolveOffset: 'immediately',
+						options: {
+							batchSize: 1,
+						},
+					},
+				},
+				credential: {
+					brokers: 'localhost:9092',
+					clientId: 'n8n-kafka',
+					ssl: false,
+					authentication: false,
+				},
+			});
+
+			const mockResolveOffset = jest.fn();
+			const mockHeartbeat = jest.fn();
+
+			// Simulate consumer stopping after first message
+			let messageCount = 0;
+			const mockIsRunning = jest.fn(() => {
+				messageCount++;
+				return messageCount <= 1; // Returns true for first message, false after
+			});
+
+			await eachBatchHandler!({
+				batch: {
+					topic: 'test-topic',
+					partition: 0,
+					highWatermark: '100',
+					messages: [
+						{
+							attributes: 1,
+							key: Buffer.from('key1'),
+							offset: '0',
+							timestamp: new Date().toISOString(),
+							value: Buffer.from('message1'),
+							headers: {},
+						},
+						{
+							attributes: 1,
+							key: Buffer.from('key2'),
+							offset: '1',
+							timestamp: new Date().toISOString(),
+							value: Buffer.from('message2'),
+							headers: {},
+						},
+						{
+							attributes: 1,
+							key: Buffer.from('key3'),
+							offset: '2',
+							timestamp: new Date().toISOString(),
+							value: Buffer.from('message3'),
+							headers: {},
+						},
+					] as RecordBatchEntry[],
+					isEmpty: () => false,
+					firstOffset: () => '0',
+					lastOffset: () => '2',
+					offsetLag: () => '0',
+					offsetLagLow: () => '0',
+				},
+				resolveOffset: mockResolveOffset,
+				heartbeat: mockHeartbeat,
+				commitOffsetsIfNecessary: jest.fn(),
+				uncommittedOffsets: jest.fn(),
+				isRunning: mockIsRunning,
+				isStale: jest.fn(() => false),
+				pause: jest.fn(),
+			});
+
+			// Should only process first message before isRunning returns false
+			expect(emit).toHaveBeenCalledTimes(1);
+			expect(mockResolveOffset).toHaveBeenCalledTimes(1);
+			expect(mockResolveOffset).toHaveBeenCalledWith('0');
+		});
+
+		it('should stop processing batch when isStale returns true (partition revoked)', async () => {
+			let eachBatchHandler: EachBatchHandler | undefined;
+			mockConsumerRun.mockImplementation(({ eachBatch }: ConsumerRunConfig) => {
+				if (eachBatch) {
+					eachBatchHandler = eachBatch;
+				}
+			});
+
+			const { emit } = await testTriggerNode(KafkaTrigger, {
+				mode: 'trigger',
+				node: {
+					typeVersion: 1.3,
+					parameters: {
+						topic: 'test-topic',
+						groupId: 'test-group',
+						useSchemaRegistry: false,
+						resolveOffset: 'immediately',
+						options: {
+							batchSize: 1,
+						},
+					},
+				},
+				credential: {
+					brokers: 'localhost:9092',
+					clientId: 'n8n-kafka',
+					ssl: false,
+					authentication: false,
+				},
+			});
+
+			const mockResolveOffset = jest.fn();
+			const mockHeartbeat = jest.fn();
+
+			// Simulate partition becoming stale after first message (rebalance occurred)
+			let messageCount = 0;
+			const mockIsStale = jest.fn(() => {
+				messageCount++;
+				return messageCount > 1; // Returns false for first message, true after
+			});
+
+			await eachBatchHandler!({
+				batch: {
+					topic: 'test-topic',
+					partition: 0,
+					highWatermark: '100',
+					messages: [
+						{
+							attributes: 1,
+							key: Buffer.from('key1'),
+							offset: '0',
+							timestamp: new Date().toISOString(),
+							value: Buffer.from('message1'),
+							headers: {},
+						},
+						{
+							attributes: 1,
+							key: Buffer.from('key2'),
+							offset: '1',
+							timestamp: new Date().toISOString(),
+							value: Buffer.from('message2'),
+							headers: {},
+						},
+						{
+							attributes: 1,
+							key: Buffer.from('key3'),
+							offset: '2',
+							timestamp: new Date().toISOString(),
+							value: Buffer.from('message3'),
+							headers: {},
+						},
+					] as RecordBatchEntry[],
+					isEmpty: () => false,
+					firstOffset: () => '0',
+					lastOffset: () => '2',
+					offsetLag: () => '0',
+					offsetLagLow: () => '0',
+				},
+				resolveOffset: mockResolveOffset,
+				heartbeat: mockHeartbeat,
+				commitOffsetsIfNecessary: jest.fn(),
+				uncommittedOffsets: jest.fn(),
+				isRunning: jest.fn(() => true),
+				isStale: mockIsStale,
+				pause: jest.fn(),
+			});
+
+			// Should only process first message before isStale returns true
+			expect(emit).toHaveBeenCalledTimes(1);
+			expect(mockResolveOffset).toHaveBeenCalledTimes(1);
+			expect(mockResolveOffset).toHaveBeenCalledWith('0');
+		});
+
+		it('should use default auto commit settings (autoCommit true, eachBatchAutoResolve false)', async () => {
+			await testTriggerNode(KafkaTrigger, {
+				mode: 'trigger',
+				node: {
+					typeVersion: 1.3,
+					parameters: {
+						topic: 'test-topic',
+						groupId: 'test-group',
+						useSchemaRegistry: false,
+						resolveOffset: 'onSuccess',
+					},
+				},
+				credential: {
+					brokers: 'localhost:9092',
+					clientId: 'n8n-kafka',
+					ssl: false,
+					authentication: false,
+				},
+			});
+
+			expect(mockConsumerRun).toHaveBeenCalledWith(
+				expect.objectContaining({
+					autoCommit: true,
+					eachBatchAutoResolve: false,
+				}),
+			);
+		});
+
+		it('should enable eachBatchAutoResolve when option is set', async () => {
+			await testTriggerNode(KafkaTrigger, {
+				mode: 'trigger',
+				node: {
+					typeVersion: 1.3,
+					parameters: {
+						topic: 'test-topic',
+						groupId: 'test-group',
+						useSchemaRegistry: false,
+						resolveOffset: 'onCompletion',
+						options: {
+							eachBatchAutoResolve: true,
+						},
+					},
+				},
+				credential: {
+					brokers: 'localhost:9092',
+					clientId: 'n8n-kafka',
+					ssl: false,
+					authentication: false,
+				},
+			});
+
+			expect(mockConsumerRun).toHaveBeenCalledWith(
+				expect.objectContaining({
+					autoCommit: true,
+					eachBatchAutoResolve: true,
+				}),
+			);
+		});
+
+		it('should use default auto commit settings with onStatus resolveOffset', async () => {
+			await testTriggerNode(KafkaTrigger, {
+				mode: 'trigger',
+				node: {
+					typeVersion: 1.3,
+					parameters: {
+						topic: 'test-topic',
+						groupId: 'test-group',
+						useSchemaRegistry: false,
+						resolveOffset: 'onStatus',
+						allowedStatuses: ['success'],
+					},
+				},
+				credential: {
+					brokers: 'localhost:9092',
+					clientId: 'n8n-kafka',
+					ssl: false,
+					authentication: false,
+				},
+			});
+
+			expect(mockConsumerRun).toHaveBeenCalledWith(
+				expect.objectContaining({
+					autoCommit: true,
+					eachBatchAutoResolve: false,
+				}),
+			);
+		});
+
+		it('should use default auto commit settings with immediately resolveOffset', async () => {
+			await testTriggerNode(KafkaTrigger, {
+				mode: 'trigger',
+				node: {
+					typeVersion: 1.3,
+					parameters: {
+						topic: 'test-topic',
+						groupId: 'test-group',
+						useSchemaRegistry: false,
+						resolveOffset: 'immediately',
+					},
+				},
+				credential: {
+					brokers: 'localhost:9092',
+					clientId: 'n8n-kafka',
+					ssl: false,
+					authentication: false,
+				},
+			});
+
+			expect(mockConsumerRun).toHaveBeenCalledWith(
+				expect.objectContaining({
+					autoCommit: true,
+					eachBatchAutoResolve: false,
+				}),
+			);
+		});
+
+		it('should process all messages when isRunning and isStale return normal values', async () => {
+			let eachBatchHandler: EachBatchHandler | undefined;
+			mockConsumerRun.mockImplementation(({ eachBatch }: ConsumerRunConfig) => {
+				if (eachBatch) {
+					eachBatchHandler = eachBatch;
+				}
+			});
+
+			const { emit } = await testTriggerNode(KafkaTrigger, {
+				mode: 'trigger',
+				node: {
+					typeVersion: 1.3,
+					parameters: {
+						topic: 'test-topic',
+						groupId: 'test-group',
+						useSchemaRegistry: false,
+						resolveOffset: 'immediately',
+						options: {
+							batchSize: 1,
+						},
+					},
+				},
+				credential: {
+					brokers: 'localhost:9092',
+					clientId: 'n8n-kafka',
+					ssl: false,
+					authentication: false,
+				},
+			});
+
+			const mockResolveOffset = jest.fn();
+			const mockHeartbeat = jest.fn();
+
+			await eachBatchHandler!({
+				batch: {
+					topic: 'test-topic',
+					partition: 0,
+					highWatermark: '100',
+					messages: [
+						{
+							attributes: 1,
+							key: Buffer.from('key1'),
+							offset: '0',
+							timestamp: new Date().toISOString(),
+							value: Buffer.from('message1'),
+							headers: {},
+						},
+						{
+							attributes: 1,
+							key: Buffer.from('key2'),
+							offset: '1',
+							timestamp: new Date().toISOString(),
+							value: Buffer.from('message2'),
+							headers: {},
+						},
+						{
+							attributes: 1,
+							key: Buffer.from('key3'),
+							offset: '2',
+							timestamp: new Date().toISOString(),
+							value: Buffer.from('message3'),
+							headers: {},
+						},
+					] as RecordBatchEntry[],
+					isEmpty: () => false,
+					firstOffset: () => '0',
+					lastOffset: () => '2',
+					offsetLag: () => '0',
+					offsetLagLow: () => '0',
+				},
+				resolveOffset: mockResolveOffset,
+				heartbeat: mockHeartbeat,
+				commitOffsetsIfNecessary: jest.fn(),
+				uncommittedOffsets: jest.fn(),
+				isRunning: jest.fn(() => true),
+				isStale: jest.fn(() => false),
+				pause: jest.fn(),
+			});
+
+			// Should process all 3 messages
+			expect(emit).toHaveBeenCalledTimes(3);
+			expect(mockResolveOffset).toHaveBeenCalledTimes(3);
+			expect(mockResolveOffset).toHaveBeenNthCalledWith(1, '0');
+			expect(mockResolveOffset).toHaveBeenNthCalledWith(2, '1');
+			expect(mockResolveOffset).toHaveBeenNthCalledWith(3, '2');
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Kafka/test/KafkaTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Kafka/test/KafkaTrigger.node.test.ts
@@ -1,379 +1,513 @@
-import { SchemaRegistry } from '@kafkajs/confluent-schema-registry';
-import { mock } from 'jest-mock-extended';
+import type { EachBatchPayload } from 'kafkajs';
+import { Kafka as apacheKafka } from 'kafkajs';
+import type {
+	ITriggerFunctions,
+	INodeType,
+	INodeTypeDescription,
+	ITriggerResponse,
+} from 'n8n-workflow';
 import {
-	Kafka,
-	logLevel,
-	type Consumer,
-	type ConsumerRunConfig,
-	type EachMessageHandler,
-	type IHeaders,
-	type KafkaMessage,
-	type RecordBatchEntry,
-} from 'kafkajs';
-import { NodeOperationError } from 'n8n-workflow';
+	ensureError,
+	NodeConnectionTypes,
+	NodeOperationError,
+	TriggerCloseError,
+} from 'n8n-workflow';
 
-import { testTriggerNode } from '@test/nodes/TriggerHelpers';
+import {
+	type KafkaTriggerOptions,
+	connectEventListeners,
+	disconnectEventListeners,
+	setSchemaRegistry,
+	configureMessageParser,
+	createConfig,
+	createConsumerConfig,
+	configureDataEmitter,
+	getAutoCommitSettings,
+	runWithHeartbeat,
+} from './utils';
 
-import { KafkaTrigger } from '../KafkaTrigger.node';
-
-jest.mock('kafkajs');
-jest.mock('@kafkajs/confluent-schema-registry');
-
-describe('KafkaTrigger Node', () => {
-	let mockKafka: jest.Mocked<Kafka>;
-	let mockRegistry: jest.Mocked<SchemaRegistry>;
-	let mockConsumerConnect: jest.Mock;
-	let mockConsumerSubscribe: jest.Mock;
-	let mockConsumerRun: jest.Mock;
-	let mockConsumerDisconnect: jest.Mock;
-	let mockConsumerCreate: jest.Mock;
-	let mockRegistryDecode: jest.Mock;
-	let publishMessage: (message: Partial<KafkaMessage>) => Promise<void>;
-
-	beforeEach(() => {
-		let mockEachMessage: jest.Mocked<EachMessageHandler> = jest.fn(async () => {});
-		mockConsumerConnect = jest.fn();
-		mockConsumerSubscribe = jest.fn();
-		mockConsumerRun = jest.fn(({ eachMessage }: ConsumerRunConfig) => {
-			if (eachMessage) {
-				mockEachMessage = eachMessage;
-			}
-		});
-		mockConsumerDisconnect = jest.fn();
-		mockConsumerCreate = jest.fn(() =>
-			mock<Consumer>({
-				connect: mockConsumerConnect,
-				subscribe: mockConsumerSubscribe,
-				run: mockConsumerRun,
-				disconnect: mockConsumerDisconnect,
-			}),
-		);
-
-		publishMessage = async (message: Partial<KafkaMessage>) => {
-			await mockEachMessage({
-				message: {
-					attributes: 1,
-					key: Buffer.from('messageKey'),
-					offset: '0',
-					timestamp: new Date().toISOString(),
-					value: Buffer.from('message'),
-					headers: {} as IHeaders,
-					...message,
-				} as RecordBatchEntry,
-				partition: 0,
-				topic: 'test-topic',
-				heartbeat: jest.fn(),
-				pause: jest.fn(),
-			});
-		};
-
-		mockKafka = mock<Kafka>({
-			consumer: mockConsumerCreate,
-		});
-
-		mockRegistryDecode = jest.fn().mockResolvedValue({ data: 'decoded-data' });
-		mockRegistry = mock<SchemaRegistry>({
-			decode: mockRegistryDecode,
-		});
-
-		(Kafka as jest.Mock).mockReturnValue(mockKafka);
-		(SchemaRegistry as jest.Mock).mockReturnValue(mockRegistry);
-	});
-
-	it('should connect to Kafka and subscribe to topic', async () => {
-		const { close, emit } = await testTriggerNode(KafkaTrigger, {
-			mode: 'trigger',
-			node: {
-				parameters: {
-					topic: 'test-topic',
-					groupId: 'test-group',
-					useSchemaRegistry: false,
-					options: {
-						fromBeginning: true,
-						parallelProcessing: true,
+export class KafkaTrigger implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Kafka Trigger',
+		name: 'kafkaTrigger',
+		icon: { light: 'file:kafka.svg', dark: 'file:kafka.dark.svg' },
+		group: ['trigger'],
+		version: [1, 1.1, 1.2, 1.3],
+		description: 'Consume messages from a Kafka topic',
+		defaults: {
+			name: 'Kafka Trigger',
+		},
+		inputs: [],
+		outputs: [NodeConnectionTypes.Main],
+		credentials: [
+			{
+				name: 'kafka',
+				required: true,
+			},
+		],
+		properties: [
+			{
+				displayName: 'Topic',
+				name: 'topic',
+				type: 'string',
+				default: '',
+				required: true,
+				placeholder: 'topic-name',
+				description: 'Name of the queue of topic to consume from',
+			},
+			{
+				displayName: 'Group ID',
+				name: 'groupId',
+				type: 'string',
+				default: '',
+				required: true,
+				placeholder: 'n8n-kafka',
+				description: 'ID of the consumer group',
+			},
+			{
+				displayName: 'Resolve Offset',
+				name: 'resolveOffset',
+				type: 'options',
+				default: 'onCompletion',
+				description:
+					'Select on which condition the offsets should be resolved. In the manual mode, when execution started by clicking on Execute Workflow or Execute Step button, offsets are always resolved immediately after message received.',
+				options: [
+					{
+						name: 'On Execution Completion',
+						value: 'onCompletion',
+						description: 'Resolve offset after execution completion regardless of the status',
+					},
+					{
+						name: 'On Execution Success',
+						value: 'onSuccess',
+						description: 'Resolve offset only if execution status equals success',
+					},
+					{
+						name: 'On Allowed Execution Statuses',
+						value: 'onStatus',
+						description: 'Resolve offset only if execution status in the list of selected statuses',
+					},
+					{
+						name: 'Immediately',
+						value: 'immediately',
+						description:
+							'Resolve offset immediately after message received. This option is not recommended as it can cause messages loss.',
+					},
+				],
+				displayOptions: {
+					show: {
+						'@version': [{ _cnd: { gte: 1.3 } }],
 					},
 				},
 			},
-			credential: {
-				brokers: 'localhost:9092',
-				clientId: 'n8n-kafka',
-				ssl: false,
-				authentication: false,
-			},
-		});
-
-		expect(Kafka).toHaveBeenCalledWith({
-			clientId: 'n8n-kafka',
-			brokers: ['localhost:9092'],
-			ssl: false,
-			logLevel: logLevel.ERROR,
-		});
-
-		expect(mockConsumerCreate).toHaveBeenCalledWith({
-			groupId: 'test-group',
-			maxInFlightRequests: null,
-			sessionTimeout: 30000,
-			heartbeatInterval: 3000,
-		});
-
-		expect(mockConsumerConnect).toHaveBeenCalled();
-		expect(mockConsumerSubscribe).toHaveBeenCalledWith({
-			topic: 'test-topic',
-			fromBeginning: true,
-		});
-		expect(mockConsumerRun).toHaveBeenCalled();
-
-		await publishMessage({
-			value: Buffer.from('message'),
-		});
-		expect(emit).toHaveBeenCalledWith([[{ json: { message: 'message', topic: 'test-topic' } }]]);
-
-		await close();
-		expect(mockConsumerDisconnect).toHaveBeenCalled();
-	});
-
-	it('should handle authentication when credentials are provided', async () => {
-		await testTriggerNode(KafkaTrigger, {
-			mode: 'trigger',
-			node: {
-				parameters: {
-					topic: 'test-topic',
-					groupId: 'test-group',
-					useSchemaRegistry: false,
-				},
-			},
-			credential: {
-				brokers: 'localhost:9092',
-				clientId: 'n8n-kafka',
-				ssl: true,
-				authentication: true,
-				username: 'test-user',
-				password: 'test-password',
-				saslMechanism: 'plain',
-			},
-		});
-
-		expect(Kafka).toHaveBeenCalledWith({
-			clientId: 'n8n-kafka',
-			brokers: ['localhost:9092'],
-			ssl: true,
-			logLevel: logLevel.ERROR,
-			sasl: {
-				username: 'test-user',
-				password: 'test-password',
-				mechanism: 'plain',
-			},
-		});
-	});
-
-	it('should throw an error if authentication is enabled but credentials are missing', async () => {
-		await expect(
-			testTriggerNode(KafkaTrigger, {
-				mode: 'trigger',
-				node: {
-					parameters: {
-						topic: 'test-topic',
-						groupId: 'test-group',
+			{
+				displayName: 'Allowed Statuses',
+				name: 'allowedStatuses',
+				type: 'multiOptions',
+				default: ['success'],
+				options: [
+					{
+						name: 'Canceled',
+						value: 'canceled',
 					},
-				},
-				credential: {
-					brokers: 'localhost:9092',
-					clientId: 'n8n-kafka',
-					ssl: false,
-					authentication: true,
-				},
-			}),
-		).rejects.toThrow(NodeOperationError);
-	});
-
-	it('should use schema registry when enabled', async () => {
-		const { emit } = await testTriggerNode(KafkaTrigger, {
-			mode: 'trigger',
-			node: {
-				parameters: {
-					topic: 'test-topic',
-					groupId: 'test-group',
-					useSchemaRegistry: true,
-					schemaRegistryUrl: 'http://localhost:8081',
-					options: { parallelProcessing: true },
-				},
-			},
-			credential: {
-				brokers: 'localhost:9092',
-				clientId: 'n8n-kafka',
-				ssl: false,
-				authentication: false,
-			},
-		});
-
-		await publishMessage({
-			value: Buffer.from('test-message'),
-			headers: { 'content-type': Buffer.from('application/json') },
-		});
-
-		expect(SchemaRegistry).toHaveBeenCalledWith({
-			host: 'http://localhost:8081',
-		});
-		expect(mockRegistryDecode).toHaveBeenCalledWith(Buffer.from('test-message'));
-		expect(emit).toHaveBeenCalledWith([
-			[
-				{
-					json: {
-						message: { data: 'decoded-data' },
-						topic: 'test-topic',
+					{
+						name: 'Crashed',
+						value: 'crashed',
 					},
-				},
-			],
-		]);
-	});
-
-	it('should parse JSON message when jsonParseMessage is true', async () => {
-		const { emit } = await testTriggerNode(KafkaTrigger, {
-			mode: 'trigger',
-			node: {
-				parameters: {
-					topic: 'test-topic',
-					groupId: 'test-group',
-					useSchemaRegistry: false,
-					options: {
-						jsonParseMessage: true,
-						parallelProcessing: true,
-						onlyMessage: true,
+					{
+						name: 'Error',
+						value: 'error',
+					},
+					{
+						name: 'New',
+						value: 'new',
+					},
+					{
+						name: 'Running',
+						value: 'running',
+					},
+					{
+						name: 'Success',
+						value: 'success',
+					},
+					{
+						name: 'Unknown',
+						value: 'unknown',
+					},
+					{
+						name: 'Waiting',
+						value: 'waiting',
+					},
+				],
+				displayOptions: {
+					show: {
+						'@version': [{ _cnd: { gte: 1.3 } }],
+						resolveOffset: ['onStatus'],
 					},
 				},
 			},
-			credential: {
-				brokers: 'localhost:9092',
-				clientId: 'n8n-kafka',
-				ssl: false,
-				authentication: false,
+			{
+				displayName: 'Use Schema Registry',
+				name: 'useSchemaRegistry',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to use Confluent Schema Registry',
 			},
-		});
-
-		const jsonData = { foo: 'bar' };
-
-		await publishMessage({
-			value: Buffer.from(JSON.stringify(jsonData)),
-		});
-
-		expect(emit).toHaveBeenCalledWith([[{ json: jsonData }]]);
-	});
-
-	it('should include headers when returnHeaders is true', async () => {
-		const { emit } = await testTriggerNode(KafkaTrigger, {
-			mode: 'trigger',
-			node: {
-				typeVersion: 1,
-				parameters: {
-					topic: 'test-topic',
-					groupId: 'test-group',
-					useSchemaRegistry: false,
-					options: {
-						returnHeaders: true,
+			{
+				displayName: 'Schema Registry URL',
+				name: 'schemaRegistryUrl',
+				type: 'string',
+				required: true,
+				displayOptions: {
+					show: {
+						useSchemaRegistry: [true],
 					},
 				},
+				placeholder: 'https://schema-registry-domain:8081',
+				default: '',
+				description: 'URL of the schema registry',
 			},
-			credential: {
-				brokers: 'localhost:9092',
-				clientId: 'n8n-kafka',
-				ssl: false,
-				authentication: false,
-			},
-		});
-
-		await publishMessage({
-			value: Buffer.from('test-message'),
-			headers: {
-				'content-type': Buffer.from('application/json'),
-				'correlation-id': '123456',
-				'with-array-value': ['1', '2', '3'],
-				empty: undefined,
-			},
-		});
-
-		expect(emit).toHaveBeenCalledWith([
-			[
-				{
-					json: {
-						message: 'test-message',
-						topic: 'test-topic',
-						headers: {
-							'content-type': 'application/json',
-							'correlation-id': '123456',
-							'with-array-value': '1,2,3',
-							empty: '',
+			{
+				displayName: 'Options',
+				name: 'options',
+				type: 'collection',
+				default: {},
+				placeholder: 'Add option',
+				options: [
+					{
+						displayName: 'Allow Topic Creation',
+						name: 'allowAutoTopicCreation',
+						type: 'boolean',
+						default: false,
+						description: 'Whether to allow sending message to a previously non-existing topic',
+					},
+					{
+						displayName: 'Auto Commit Threshold',
+						name: 'autoCommitThreshold',
+						type: 'number',
+						default: 0,
+						description:
+							'The consumer will commit offsets after resolving a given number of messages',
+					},
+					{
+						displayName: 'Auto Commit Interval',
+						name: 'autoCommitInterval',
+						type: 'number',
+						default: 0,
+						description:
+							'The consumer will commit offsets after a given period, for example, five seconds',
+						hint: 'Value in milliseconds',
+					},
+					{
+						displayName: 'Batch Size',
+						name: 'batchSize',
+						type: 'number',
+						default: 1,
+						description:
+							'Number of messages to process in each batch, when set to 1, message-by-message processing is enabled',
+					},
+					{
+						displayName: 'Each Batch Auto Resolve',
+						name: 'eachBatchAutoResolve',
+						type: 'boolean',
+						default: false,
+						description: 'Whether to auto resolve offsets for each batch',
+						displayOptions: {
+							show: {
+								'@version': [{ _cnd: { gte: 1.3 } }],
+							},
 						},
 					},
-				},
-			],
-		]);
-	});
-
-	it('should handle manual trigger mode', async () => {
-		const { emit, manualTriggerFunction } = await testTriggerNode(KafkaTrigger, {
-			mode: 'manual',
-			node: {
-				parameters: {
-					topic: 'test-topic',
-					groupId: 'test-group',
-					useSchemaRegistry: false,
-					options: {
-						parallelProcessing: true,
+					{
+						displayName: 'Fetch Max Bytes',
+						name: 'fetchMaxBytes',
+						type: 'number',
+						default: 1048576,
+						description:
+							'Maximum amount of data the server should return for a fetch request. In bytes. Default is 1MB. Higher values allow fetching more messages at once.',
 					},
-				},
-			},
-			credential: {
-				brokers: 'localhost:9092',
-				clientId: 'n8n-kafka',
-				ssl: false,
-				authentication: false,
-			},
-		});
-
-		await manualTriggerFunction?.();
-
-		expect(mockConsumerConnect).toHaveBeenCalledTimes(1);
-		expect(mockConsumerSubscribe).toHaveBeenCalledTimes(1);
-		expect(mockConsumerRun).toHaveBeenCalledTimes(1);
-
-		expect(emit).not.toHaveBeenCalled();
-
-		await publishMessage({ value: Buffer.from('test') });
-
-		expect(emit).toHaveBeenCalledWith([[{ json: { message: 'test', topic: 'test-topic' } }]]);
-	});
-
-	it('should handle sequential processing when parallelProcessing is false', async () => {
-		const { emit } = await testTriggerNode(KafkaTrigger, {
-			mode: 'trigger',
-			node: {
-				parameters: {
-					topic: 'test-topic',
-					groupId: 'test-group',
-					useSchemaRegistry: false,
-					options: {
-						parallelProcessing: false,
+					{
+						displayName: 'Fetch Min Bytes',
+						name: 'fetchMinBytes',
+						type: 'number',
+						default: 1,
+						description:
+							'Minimum amount of data the server should return for a fetch request. In bytes. Server will wait up to fetchMaxWaitTime for this amount to accumulate.',
 					},
-				},
+					{
+						displayName: 'Heartbeat Interval',
+						name: 'heartbeatInterval',
+						type: 'number',
+						default: 10000,
+						description:
+							'Controls how often the consumer sends heartbeats to the broker to indicate it is still alive. Must be lower than Session Timeout. Recommended value is approximately one third of the Session Timeout (for example: 10s heartbeat with 30s session timeout).',
+						hint: 'Value in milliseconds',
+						displayOptions: {
+							show: {
+								'@version': [{ _cnd: { gte: 1.3 } }],
+							},
+						},
+					},
+					{
+						displayName: 'Heartbeat Interval',
+						name: 'heartbeatInterval',
+						type: 'number',
+						default: 3000,
+						description: "Heartbeats are used to ensure that the consumer's session stays active",
+						hint: 'The value must be set lower than Session Timeout',
+						displayOptions: {
+							hide: {
+								'@version': [{ _cnd: { gte: 1.3 } }],
+							},
+						},
+					},
+					{
+						displayName: 'Max Number of Requests',
+						name: 'maxInFlightRequests',
+						type: 'number',
+						default: 1,
+						description:
+							'The maximum number of unacknowledged requests the client will send on a single connection',
+					},
+					{
+						displayName: 'Read Messages From Beginning',
+						name: 'fromBeginning',
+						type: 'boolean',
+						default: true,
+						description: 'Whether to read message from beginning',
+					},
+					{
+						displayName: 'JSON Parse Message',
+						name: 'jsonParseMessage',
+						type: 'boolean',
+						default: false,
+						description: 'Whether to try to parse the message to an object',
+					},
+					{
+						displayName: 'Keep Message as Binary Data',
+						name: 'keepBinaryData',
+						type: 'boolean',
+						default: false,
+						displayOptions: {
+							show: {
+								'@version': [{ _cnd: { gte: 1.2 } }],
+							},
+						},
+						description:
+							'Whether to keep message value as binary data for downstream processing (e.g., Avro deserialization)',
+					},
+					{
+						displayName: 'Parallel Processing',
+						name: 'parallelProcessing',
+						type: 'boolean',
+						default: true,
+						description:
+							'Whether to process messages in parallel resolving offsets independently or in order resolving offsets after execution completion. In the manual mode, when execution started by clicking on Execute Workflow or Execute Step button, messages are processed in parallel resolving offsets immediately.',
+						displayOptions: {
+							show: {
+								'@version': [1.1, 1.2],
+							},
+						},
+					},
+					{
+						displayName: 'Partitions Consumed Concurrently',
+						name: 'partitionsConsumedConcurrently',
+						type: 'number',
+						default: 0,
+						description:
+							'Number of Kafka partitions to process in parallel. Controls how many partitions are processed concurrently by the consumer.',
+						hint: 'Set to 0 to process all partitions sequentially',
+					},
+					{
+						displayName: 'Only Message',
+						name: 'onlyMessage',
+						type: 'boolean',
+						displayOptions: {
+							show: {
+								jsonParseMessage: [true],
+							},
+						},
+						default: false,
+						description: 'Whether to return only the message property',
+					},
+					{
+						displayName: 'Return Headers',
+						name: 'returnHeaders',
+						type: 'boolean',
+						default: false,
+						description: 'Whether to return the headers received from Kafka',
+					},
+					{
+						displayName: 'Rebalance Timeout',
+						name: 'rebalanceTimeout',
+						type: 'number',
+						default: 600000,
+						description: 'The maximum time allowed for a consumer to join the group',
+					},
+					{
+						displayName: 'Retry Delay on Error',
+						name: 'errorRetryDelay',
+						type: 'number',
+						default: 5000,
+						description:
+							'Delay in milliseconds before retrying after a failed offset resolution. This prevents rapid retry loops that could overwhelm the Kafka broker.',
+						hint: 'Value in milliseconds',
+						typeOptions: {
+							minValue: 1000,
+						},
+						displayOptions: {
+							show: {
+								'@version': [{ _cnd: { gte: 1.3 } }],
+							},
+							hide: {
+								'/resolveOffset': ['immediately'],
+							},
+						},
+					},
+					{
+						displayName: 'Session Timeout',
+						name: 'sessionTimeout',
+						type: 'number',
+						default: 30000,
+						description:
+							'Timeout in milliseconds used to detect failures. Has to be higher than Heartbeat Interval. During the workflow execution heartbeat will be sent periodically to keep the session alive with configured Heartbeat Interval.',
+						hint: 'Value in milliseconds',
+					},
+				],
 			},
-			credential: {
-				brokers: 'localhost:9092',
-				clientId: 'n8n-kafka',
-				ssl: false,
-				authentication: false,
-			},
-		});
+		],
+	};
 
-		const publishPromise = publishMessage({
-			value: Buffer.from('test-message'),
-		});
+	async trigger(this: ITriggerFunctions): Promise<ITriggerResponse> {
+		const nodeVersion = this.getNode().typeVersion;
 
-		expect(emit).toHaveBeenCalled();
+		const config = await createConfig(this);
+		const kafka = new apacheKafka(config);
+		const registry = setSchemaRegistry(this);
 
-		const deferredPromise = emit.mock.calls[0][2];
-		expect(deferredPromise).toBeDefined();
+		const options = this.getNodeParameter('options', {}) as KafkaTriggerOptions;
+		if (options.keepBinaryData && nodeVersion < 1.2) {
+			options.keepBinaryData = undefined;
+		}
 
-		deferredPromise?.resolve(mock());
-		await publishPromise;
-	});
-});
+		const consumerConfig = createConsumerConfig(this, options, nodeVersion);
+		const consumer = kafka.consumer(consumerConfig);
+
+		const processMessage = configureMessageParser(
+			options,
+			this.logger,
+			registry,
+			this.helpers.prepareBinaryData,
+		);
+
+		const topic = this.getNodeParameter('topic') as string;
+		const batchSize = options.batchSize ?? 1;
+		const partitionsConsumedConcurrently = options.partitionsConsumedConcurrently || undefined;
+
+		const dataEmitter = configureDataEmitter(this, options, nodeVersion);
+
+		const startConsumer = async () => {
+			try {
+				await consumer.connect();
+
+				await consumer.subscribe({ topic, fromBeginning: options.fromBeginning ? true : false });
+
+				await consumer.run({
+					partitionsConsumedConcurrently,
+					...getAutoCommitSettings(options),
+					eachBatch: async ({
+						batch,
+						resolveOffset,
+						heartbeat,
+						isStale,
+						isRunning,
+						commitOffsetsIfNecessary,
+					}: EachBatchPayload) => {
+						// avoid throwing error in the callback, as it leads to consumer stop, disconnect and crash
+						const messages = batch.messages;
+						const messageTopic = batch.topic;
+
+						for (let i = 0; i < messages.length; i += batchSize) {
+							// stop if consumer stopped or partition revoked
+							if (!isRunning() || isStale()) {
+								this.logger.debug('Batch processing interrupted due to rebalance or consumer stop');
+								break;
+							}
+
+							const chunk = messages.slice(i, Math.min(i + batchSize, messages.length));
+
+							let processedData;
+							try {
+								processedData = await Promise.all(
+									chunk.map(async (message) => await processMessage(message, messageTopic)),
+								);
+							} catch (err) {
+								this.logger.error('Chunk processing failed, skipping commit for this chunk', err);
+								await heartbeat();
+								break;
+							}
+
+							const result = await runWithHeartbeat(
+								dataEmitter(processedData),
+								heartbeat,
+								consumerConfig.heartbeatInterval,
+							);
+
+							if (!result.success) {
+								this.logger.warn('runWithHeartbeat failed, skipping commit for this chunk');
+								await heartbeat();
+								break;
+							}
+
+							const lastMessage = chunk[chunk.length - 1];
+							if (lastMessage) {
+								resolveOffset(lastMessage.offset);
+								await commitOffsetsIfNecessary();
+							}
+
+							await heartbeat();
+						}
+					},
+				});
+			} catch (error) {
+				this.logger.error('Failed to start Kafka consumer', { error });
+				throw new NodeOperationError(this.getNode(), error);
+			}
+		};
+
+		const listeners = connectEventListeners(consumer, this.logger);
+
+		const closeFunction = async () => {
+			try {
+				disconnectEventListeners(listeners);
+				await consumer.stop();
+				await consumer.disconnect();
+			} catch (error) {
+				throw new TriggerCloseError(this.getNode(), {
+					cause: ensureError(error),
+					level: 'warning',
+				});
+			}
+		};
+
+		if (this.getMode() !== 'manual') {
+			await startConsumer();
+			return { closeFunction };
+		} else {
+			// The "manualTriggerFunction" function gets called by n8n
+			// when a user is in the workflow editor and starts the
+			// workflow manually. So the function has to make sure that
+			// the emit() gets called with similar data like when it
+			// would trigger by itself so that the user knows what data
+			// to expect.
+			async function manualTriggerFunction() {
+				await startConsumer();
+			}
+
+			return {
+				closeFunction,
+				manualTriggerFunction,
+			};
+		}
+	}
+}

--- a/packages/nodes-base/nodes/Kafka/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Kafka/test/utils.test.ts
@@ -1,0 +1,575 @@
+import { mock } from 'jest-mock-extended';
+import type { ITriggerFunctions, IRun, INode, Logger, IDeferredPromise } from 'n8n-workflow';
+import { NodeOperationError, sleep } from 'n8n-workflow';
+
+import { getAutoCommitSettings, configureDataEmitter, type KafkaTriggerOptions } from '../utils';
+
+jest.mock('n8n-workflow', () => {
+	const actual = jest.requireActual('n8n-workflow');
+	return {
+		...actual,
+		sleep: jest.fn().mockResolvedValue(undefined),
+	};
+});
+
+const mockedSleep = jest.mocked(sleep);
+
+describe('Kafka Utils', () => {
+	describe('getAutoCommitSettings', () => {
+		it('should return autoCommit true and eachBatchAutoResolve false for version 1.1', () => {
+			const options: KafkaTriggerOptions = {};
+			const result = getAutoCommitSettings(options);
+
+			expect(result).toEqual({
+				autoCommit: true,
+				eachBatchAutoResolve: false,
+				autoCommitInterval: undefined,
+				autoCommitThreshold: undefined,
+			});
+		});
+
+		it('should return eachBatchAutoResolve true when option is set', () => {
+			const options: KafkaTriggerOptions = {
+				eachBatchAutoResolve: true,
+			};
+			const result = getAutoCommitSettings(options);
+
+			expect(result).toEqual({
+				autoCommit: true,
+				eachBatchAutoResolve: true,
+				autoCommitInterval: undefined,
+				autoCommitThreshold: undefined,
+			});
+		});
+
+		it('should return eachBatchAutoResolve false when option is explicitly false', () => {
+			const options: KafkaTriggerOptions = {
+				eachBatchAutoResolve: false,
+			};
+			const result = getAutoCommitSettings(options);
+
+			expect(result).toEqual({
+				autoCommit: true,
+				eachBatchAutoResolve: false,
+				autoCommitInterval: undefined,
+				autoCommitThreshold: undefined,
+			});
+		});
+
+		it('should pass through autoCommitInterval when provided', () => {
+			const options: KafkaTriggerOptions = {
+				autoCommitInterval: 5000,
+			};
+			const result = getAutoCommitSettings(options);
+
+			expect(result).toEqual({
+				autoCommit: true,
+				eachBatchAutoResolve: false,
+				autoCommitInterval: 5000,
+				autoCommitThreshold: undefined,
+			});
+		});
+
+		it('should pass through autoCommitThreshold when provided', () => {
+			const options: KafkaTriggerOptions = {
+				autoCommitThreshold: 100,
+			};
+			const result = getAutoCommitSettings(options);
+
+			expect(result).toEqual({
+				autoCommit: true,
+				eachBatchAutoResolve: false,
+				autoCommitInterval: undefined,
+				autoCommitThreshold: 100,
+			});
+		});
+
+		it('should pass through both autoCommit options when provided', () => {
+			const options: KafkaTriggerOptions = {
+				autoCommitInterval: 5000,
+				autoCommitThreshold: 100,
+			};
+			const result = getAutoCommitSettings(options);
+
+			expect(result).toEqual({
+				autoCommit: true,
+				eachBatchAutoResolve: false,
+				autoCommitInterval: 5000,
+				autoCommitThreshold: 100,
+			});
+		});
+
+		it('should combine eachBatchAutoResolve with autoCommit options', () => {
+			const options: KafkaTriggerOptions = {
+				eachBatchAutoResolve: true,
+				autoCommitInterval: 5000,
+				autoCommitThreshold: 100,
+			};
+			const result = getAutoCommitSettings(options);
+
+			expect(result).toEqual({
+				autoCommit: true,
+				eachBatchAutoResolve: true,
+				autoCommitInterval: 5000,
+				autoCommitThreshold: 100,
+			});
+		});
+	});
+
+	describe('configureDataEmitter', () => {
+		const mockNode: INode = {
+			id: 'test-node-id',
+			name: 'Test Kafka Trigger',
+			type: 'n8n-nodes-base.kafkaTrigger',
+			typeVersion: 1.3,
+			position: [0, 0],
+			parameters: {},
+		};
+
+		interface TestDeferredPromise<T> extends IDeferredPromise<T> {
+			resolveWith: (value: T) => void;
+			rejectWith: (error: Error) => void;
+		}
+
+		const createDeferredPromise = <T>(): TestDeferredPromise<T> => {
+			let resolveFunc: (value: T) => void;
+			let rejectFunc: (error: Error) => void;
+			const promise = new Promise<T>((res, rej) => {
+				resolveFunc = res;
+				rejectFunc = rej;
+			});
+			return {
+				promise,
+				resolve: () => {},
+				reject: () => {},
+				resolveWith: (value: T) => resolveFunc(value),
+				rejectWith: (error: Error) => rejectFunc(error),
+			};
+		};
+
+		const createMockContext = (
+			params: Record<string, unknown> = {},
+			mode: 'manual' | 'trigger' = 'trigger',
+			deferredPromise?: TestDeferredPromise<IRun>,
+		) => {
+			const ctx = mock<ITriggerFunctions>();
+			const mockLogger = mock<Logger>();
+
+			ctx.getNodeParameter.mockImplementation(
+				(name: string, fallback?: unknown) => (params[name] ?? fallback) as never,
+			);
+			ctx.getMode.mockReturnValue(mode);
+			ctx.getNode.mockReturnValue(mockNode);
+			ctx.logger = mockLogger;
+			ctx.getWorkflowSettings.mockReturnValue({ executionTimeout: 3600 });
+
+			// Mock helpers.createDeferredPromise
+			if (deferredPromise) {
+				ctx.helpers = {
+					...ctx.helpers,
+					createDeferredPromise: jest.fn().mockReturnValue(deferredPromise),
+				} as unknown as ITriggerFunctions['helpers'];
+			}
+
+			return ctx;
+		};
+
+		beforeEach(() => {
+			jest.clearAllMocks();
+			jest.useFakeTimers();
+		});
+
+		afterEach(() => {
+			jest.useRealTimers();
+		});
+
+		describe('immediate emit mode', () => {
+			it('should emit immediately in manual mode regardless of resolveOffset setting', async () => {
+				const ctx = createMockContext({ resolveOffset: 'onCompletion' }, 'manual');
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const result = await emitter(testData);
+
+				expect(ctx.emit).toHaveBeenCalledWith([testData]);
+				expect(result).toEqual({ success: true });
+			});
+
+			it('should emit immediately for version 1 (resolveOffset mode is "immediately")', async () => {
+				const ctx = createMockContext({}, 'trigger');
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1);
+				const testData = [{ json: { message: 'test' } }];
+
+				const result = await emitter(testData);
+
+				expect(ctx.emit).toHaveBeenCalledWith([testData]);
+				expect(result).toEqual({ success: true });
+			});
+
+			it('should emit immediately for version 1.1 with parallelProcessing enabled', async () => {
+				const ctx = createMockContext({}, 'trigger');
+				const options: KafkaTriggerOptions = { parallelProcessing: true };
+
+				const emitter = configureDataEmitter(ctx, options, 1.1);
+				const testData = [{ json: { message: 'test' } }];
+
+				const result = await emitter(testData);
+
+				expect(ctx.emit).toHaveBeenCalledWith([testData]);
+				expect(result).toEqual({ success: true });
+			});
+
+			it('should emit immediately when resolveOffset is explicitly set to "immediately"', async () => {
+				const ctx = createMockContext({ resolveOffset: 'immediately' }, 'trigger');
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const result = await emitter(testData);
+
+				expect(ctx.emit).toHaveBeenCalledWith([testData]);
+				expect(result).toEqual({ success: true });
+			});
+		});
+
+		describe('deferred emit mode - onCompletion', () => {
+			it('should wait for execution completion and return success', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext(
+					{ resolveOffset: 'onCompletion' },
+					'trigger',
+					deferredPromise,
+				);
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const resultPromise = emitter(testData);
+
+				// Simulate successful execution completion
+				deferredPromise.resolveWith({ status: 'success' } as unknown as IRun);
+
+				const result = await resultPromise;
+
+				expect(ctx.emit).toHaveBeenCalledWith([testData], undefined, deferredPromise);
+				expect(result).toEqual({ success: true });
+			});
+
+			it('should return success for any status in onCompletion mode', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext(
+					{ resolveOffset: 'onCompletion' },
+					'trigger',
+					deferredPromise,
+				);
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const resultPromise = emitter(testData);
+
+				// Simulate failed execution - should still succeed in onCompletion mode
+				deferredPromise.resolveWith({ status: 'error' } as unknown as IRun);
+
+				const result = await resultPromise;
+
+				expect(result).toEqual({ success: true });
+			});
+
+			it('should use version 1.1 onCompletion mode when parallelProcessing is false', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext({}, 'trigger', deferredPromise);
+				const options: KafkaTriggerOptions = { parallelProcessing: false };
+
+				const emitter = configureDataEmitter(ctx, options, 1.1);
+				const testData = [{ json: { message: 'test' } }];
+
+				const resultPromise = emitter(testData);
+
+				deferredPromise.resolveWith({ status: 'success' } as unknown as IRun);
+
+				const result = await resultPromise;
+
+				expect(ctx.emit).toHaveBeenCalledWith([testData], undefined, deferredPromise);
+				expect(result).toEqual({ success: true });
+			});
+		});
+
+		describe('deferred emit mode - onSuccess', () => {
+			it('should return success when execution status is "success"', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext({ resolveOffset: 'onSuccess' }, 'trigger', deferredPromise);
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const resultPromise = emitter(testData);
+
+				deferredPromise.resolveWith({ status: 'success' } as unknown as IRun);
+
+				const result = await resultPromise;
+
+				expect(result).toEqual({ success: true });
+			});
+
+			it('should return failure and sleep when execution status is not "success"', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext({ resolveOffset: 'onSuccess' }, 'trigger', deferredPromise);
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const resultPromise = emitter(testData);
+
+				deferredPromise.resolveWith({ status: 'error' } as unknown as IRun);
+
+				const result = await resultPromise;
+
+				expect(mockedSleep).toHaveBeenCalledWith(5000); // DEFAULT_ERROR_RETRY_DELAY_MS
+				expect(ctx.logger.error).toHaveBeenCalled();
+				expect(result).toEqual({ success: false });
+			});
+
+			it('should use custom errorRetryDelay when provided', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext({ resolveOffset: 'onSuccess' }, 'trigger', deferredPromise);
+				const options: KafkaTriggerOptions = { errorRetryDelay: 10000 };
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const resultPromise = emitter(testData);
+
+				deferredPromise.resolveWith({ status: 'error' } as unknown as IRun);
+
+				await resultPromise;
+
+				expect(mockedSleep).toHaveBeenCalledWith(10000);
+			});
+		});
+
+		describe('deferred emit mode - onStatus', () => {
+			it('should throw error when no statuses are selected', () => {
+				const ctx = createMockContext(
+					{ resolveOffset: 'onStatus', allowedStatuses: [] },
+					'trigger',
+				);
+				const options: KafkaTriggerOptions = {};
+
+				expect(() => configureDataEmitter(ctx, options, 1.3)).toThrow(NodeOperationError);
+			});
+
+			it('should return success when execution status matches allowed statuses', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext(
+					{ resolveOffset: 'onStatus', allowedStatuses: ['success', 'warning'] },
+					'trigger',
+					deferredPromise,
+				);
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const resultPromise = emitter(testData);
+
+				deferredPromise.resolveWith({ status: 'warning' } as unknown as IRun);
+
+				const result = await resultPromise;
+
+				expect(result).toEqual({ success: true });
+			});
+
+			it('should return failure when execution status does not match allowed statuses', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext(
+					{ resolveOffset: 'onStatus', allowedStatuses: ['success'] },
+					'trigger',
+					deferredPromise,
+				);
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const resultPromise = emitter(testData);
+
+				deferredPromise.resolveWith({ status: 'error' } as unknown as IRun);
+
+				const result = await resultPromise;
+
+				expect(mockedSleep).toHaveBeenCalled();
+				expect(result).toEqual({ success: false });
+			});
+		});
+
+		describe('timeout handling', () => {
+			it('should timeout and return failure when execution takes too long', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext(
+					{ resolveOffset: 'onCompletion' },
+					'trigger',
+					deferredPromise,
+				);
+				ctx.getWorkflowSettings.mockReturnValue({ executionTimeout: 1 }); // 1 second timeout
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const resultPromise = emitter(testData);
+
+				// Advance timers past the timeout
+				jest.advanceTimersByTime(1001);
+
+				const result = await resultPromise;
+
+				expect(mockedSleep).toHaveBeenCalled();
+				expect(ctx.logger.error).toHaveBeenCalled();
+				expect(result).toEqual({ success: false });
+			});
+
+			it('should use default timeout of 3600 seconds when not configured', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext(
+					{ resolveOffset: 'onCompletion' },
+					'trigger',
+					deferredPromise,
+				);
+				ctx.getWorkflowSettings.mockReturnValue({}); // No timeout configured
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const resultPromise = emitter(testData);
+
+				// Resolve before timeout
+				deferredPromise.resolveWith({ status: 'success' } as unknown as IRun);
+
+				const result = await resultPromise;
+
+				expect(result).toEqual({ success: true });
+			});
+
+			it('should clear timeout when execution completes before timeout', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext(
+					{ resolveOffset: 'onCompletion' },
+					'trigger',
+					deferredPromise,
+				);
+				ctx.getWorkflowSettings.mockReturnValue({ executionTimeout: 10 });
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const resultPromise = emitter(testData);
+
+				// Resolve quickly
+				deferredPromise.resolveWith({ status: 'success' } as unknown as IRun);
+
+				const result = await resultPromise;
+
+				// Advance timers past what would have been the timeout
+				jest.advanceTimersByTime(15000);
+
+				// Should not have logged any timeout error
+				expect(result).toEqual({ success: true });
+			});
+		});
+
+		describe('error handling', () => {
+			it('should handle promise rejection and return failure', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext(
+					{ resolveOffset: 'onCompletion' },
+					'trigger',
+					deferredPromise,
+				);
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const resultPromise = emitter(testData);
+
+				deferredPromise.rejectWith(new Error('Execution failed'));
+
+				const result = await resultPromise;
+
+				expect(mockedSleep).toHaveBeenCalledWith(5000);
+				expect(ctx.logger.error).toHaveBeenCalledWith('Execution failed', expect.any(Object));
+				expect(result).toEqual({ success: false });
+			});
+
+			it('should handle non-Error objects in catch block', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext(
+					{ resolveOffset: 'onCompletion' },
+					'trigger',
+					deferredPromise,
+				);
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const resultPromise = emitter(testData);
+
+				// Reject with a string instead of Error
+				deferredPromise.rejectWith('String error' as unknown as Error);
+
+				const result = await resultPromise;
+
+				expect(mockedSleep).toHaveBeenCalled();
+				expect(result).toEqual({ success: false });
+			});
+		});
+
+		describe('data emission', () => {
+			it('should emit data array wrapped in another array', async () => {
+				const ctx = createMockContext({}, 'manual');
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test1' } }, { json: { message: 'test2' } }];
+
+				await emitter(testData);
+
+				expect(ctx.emit).toHaveBeenCalledWith([testData]);
+			});
+
+			it('should pass deferred promise to emit in deferred mode', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext(
+					{ resolveOffset: 'onCompletion' },
+					'trigger',
+					deferredPromise,
+				);
+				const options: KafkaTriggerOptions = {};
+
+				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const testData = [{ json: { message: 'test' } }];
+
+				const resultPromise = emitter(testData);
+
+				deferredPromise.resolveWith({ status: 'success' } as unknown as IRun);
+
+				await resultPromise;
+
+				expect(ctx.emit).toHaveBeenCalledWith([testData], undefined, deferredPromise);
+			});
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Kafka/utils.ts
+++ b/packages/nodes-base/nodes/Kafka/utils.ts
@@ -1,0 +1,442 @@
+import type {
+	Consumer,
+	RemoveInstrumentationEventListener,
+	KafkaMessage,
+	KafkaConfig,
+	SASLOptions,
+	ConsumerConfig,
+} from 'kafkajs';
+import { logLevel } from 'kafkajs';
+import { SchemaRegistry } from '@kafkajs/confluent-schema-registry';
+import type {
+	Logger,
+	ITriggerFunctions,
+	IDataObject,
+	IRun,
+	IBinaryKeyData,
+	INodeExecutionData,
+} from 'n8n-workflow';
+
+import { ensureError, jsonParse, NodeOperationError, sleep } from 'n8n-workflow';
+
+// Default delay in milliseconds before retrying after a failed offset resolution.
+// This prevents rapid retry loops that could overwhelm the Kafka broker
+const DEFAULT_ERROR_RETRY_DELAY_MS = 5000;
+
+export interface KafkaTriggerOptions {
+	allowAutoTopicCreation?: boolean;
+	autoCommitThreshold?: number;
+	autoCommitInterval?: number;
+	batchSize?: number;
+	eachBatchAutoResolve?: boolean;
+	errorRetryDelay?: number;
+	fetchMaxBytes?: number;
+	fetchMinBytes?: number;
+	heartbeatInterval?: number;
+	maxInFlightRequests?: number;
+	fromBeginning?: boolean;
+	jsonParseMessage?: boolean;
+	keepBinaryData?: boolean;
+	parallelProcessing?: boolean;
+	partitionsConsumedConcurrently?: number;
+	onlyMessage?: boolean;
+	returnHeaders?: boolean;
+	rebalanceTimeout?: number;
+	sessionTimeout?: number;
+}
+
+interface KafkaCredentials {
+	clientId: string;
+	brokers: string;
+	ssl: boolean;
+	authentication: boolean;
+	username?: string;
+	password?: string;
+	saslMechanism?: 'plain' | 'scram-sha-256' | 'scram-sha-512';
+}
+
+type ResolveOffsetMode = 'immediately' | 'onCompletion' | 'onSuccess' | 'onStatus';
+
+/**
+ * Creates Kafka client configuration from n8n credentials
+ * @param ctx - The trigger function context
+ * @returns Kafka configuration object with authentication settings
+ */
+export async function createConfig(ctx: ITriggerFunctions) {
+	const credentials = (await ctx.getCredentials('kafka')) as KafkaCredentials;
+	const clientId = credentials.clientId;
+	const brokers = (credentials.brokers ?? '').split(',').map((item) => item.trim());
+	const ssl = credentials.ssl;
+
+	const config: KafkaConfig = {
+		clientId,
+		brokers,
+		ssl,
+		logLevel: logLevel.ERROR,
+	};
+
+	if (credentials.authentication) {
+		if (!(credentials.username && credentials.password)) {
+			throw new NodeOperationError(
+				ctx.getNode(),
+				'Username and password are required for authentication',
+			);
+		}
+		config.sasl = {
+			username: credentials.username as string,
+			password: credentials.password as string,
+			mechanism: credentials.saslMechanism as string,
+		} as SASLOptions;
+	}
+
+	return config;
+}
+
+/**
+ * Creates Kafka consumer configuration with session timeout and heartbeat settings
+ * @param ctx - The trigger function context
+ * @param options - Kafka trigger options from node parameters
+ * @param nodeVersion - The version of the Kafka trigger node
+ * @returns Consumer configuration object
+ */
+export function createConsumerConfig(
+	ctx: ITriggerFunctions,
+	options: KafkaTriggerOptions,
+	nodeVersion: number,
+) {
+	const groupId = ctx.getNodeParameter('groupId') as string;
+	const maxInFlightRequests = (
+		ctx.getNodeParameter('options.maxInFlightRequests', null) === 0
+			? null
+			: ctx.getNodeParameter('options.maxInFlightRequests', null)
+	) as number;
+
+	const sessionTimeout = options.sessionTimeout ?? 30000;
+	let heartbeatInterval: number;
+	if (nodeVersion < 1.3) {
+		heartbeatInterval = options.heartbeatInterval ?? 3000;
+	} else {
+		heartbeatInterval = options.heartbeatInterval ?? 10000;
+	}
+
+	const rebalanceTimeout = options.rebalanceTimeout ?? 600000;
+	const maxBytesPerPartition = options.fetchMaxBytes;
+	const minBytes = options.fetchMinBytes;
+
+	const consumerConfig: ConsumerConfig = {
+		groupId,
+		maxInFlightRequests,
+		sessionTimeout,
+		heartbeatInterval,
+		rebalanceTimeout,
+	};
+
+	if (maxBytesPerPartition !== undefined) {
+		consumerConfig.maxBytesPerPartition = maxBytesPerPartition;
+	}
+
+	if (minBytes !== undefined) {
+		consumerConfig.minBytes = minBytes;
+	}
+
+	return consumerConfig;
+}
+
+/**
+ * Configures a message parser function that processes Kafka messages based on node options
+ * @param options - Kafka trigger options for parsing behavior
+ * @param logger - Logger instance for warnings
+ * @param registry - Optional schema registry for message decoding
+ * @param prepareBinaryData - Helper function to prepare binary data
+ * @returns Async function that parses Kafka messages into n8n execution data
+ */
+export function configureMessageParser(
+	options: KafkaTriggerOptions,
+	logger: Logger,
+	registry: SchemaRegistry | undefined,
+	prepareBinaryData: ITriggerFunctions['helpers']['prepareBinaryData'],
+) {
+	return async (message: KafkaMessage, messageTopic: string): Promise<INodeExecutionData> => {
+		let data: IDataObject = {};
+		let value = message.value?.toString() as string;
+		const binary: IBinaryKeyData = {};
+
+		if (options.jsonParseMessage) {
+			try {
+				value = jsonParse(value);
+			} catch (error) {
+				logger.warn('Could not parse message to JSON, returning as string', { error });
+			}
+		}
+
+		if (registry) {
+			try {
+				value = await registry.decode(message.value as Buffer);
+			} catch (error) {
+				logger.warn('Could not decode message with Schema Registry, returning original message', {
+					error,
+				});
+			}
+		}
+
+		// Preserve raw binary data for downstream processing (only in v1.2+)
+		if (options.keepBinaryData && message.value) {
+			const binaryData = await prepareBinaryData(
+				message.value as Buffer,
+				'message',
+				'application/octet-stream',
+			);
+			binary.data = binaryData;
+		}
+
+		if (options.returnHeaders && message.headers) {
+			data.headers = Object.fromEntries(
+				Object.entries(message.headers).map(([headerKey, headerValue]) => [
+					headerKey,
+					headerValue?.toString('utf8') ?? '',
+				]),
+			);
+		}
+
+		data.message = value;
+		data.topic = messageTopic;
+
+		if (options.onlyMessage) {
+			data = value as unknown as IDataObject;
+		}
+
+		if (options.keepBinaryData && Object.keys(binary).length) {
+			return { json: data, binary };
+		}
+
+		return { json: data };
+	};
+}
+
+/**
+ * Attaches event listeners to the Kafka consumer for monitoring and logging
+ * @param consumer - The Kafka consumer instance
+ * @param logger - Logger instance for event logging
+ * @returns Array of listener removal functions
+ */
+export function connectEventListeners(consumer: Consumer, logger: Logger) {
+	const onConnected = consumer.on(consumer.events.CONNECT, () => {
+		logger.debug('Kafka consumer connected');
+	});
+	const onGroupJoin = consumer.on(consumer.events.GROUP_JOIN, () => {
+		logger.debug('Consumer has joined the group');
+	});
+	const onRequestTimeout = consumer.on(consumer.events.REQUEST_TIMEOUT, () => {
+		logger.error('Consumer request timed out');
+	});
+	const onUnsubscribedtopicsReceived = consumer.on(
+		consumer.events.RECEIVED_UNSUBSCRIBED_TOPICS,
+		() => {
+			logger.warn('Consumer received messages for unsubscribed topics');
+		},
+	);
+	const onStop = consumer.on(consumer.events.STOP, async (error) => {
+		logger.error('Consumer has stopped', { error });
+	});
+	const onDisconnect = consumer.on(consumer.events.DISCONNECT, async (error) => {
+		logger.error('Consumer has disconnected', { error });
+	});
+	const onCommitOffsets = consumer.on(consumer.events.COMMIT_OFFSETS, () => {
+		logger.debug('Consumer offsets committed!');
+	});
+	const onRebalancing = consumer.on(consumer.events.REBALANCING, (payload) => {
+		logger.debug('Consumer is rebalancing', { payload });
+	});
+	const onCrash = consumer.on(consumer.events.CRASH, async (error) => {
+		logger.error('Consumer has crashed', { error });
+	});
+
+	return [
+		onConnected,
+		onGroupJoin,
+		onRequestTimeout,
+		onUnsubscribedtopicsReceived,
+		onStop,
+		onDisconnect,
+		onCommitOffsets,
+		onRebalancing,
+		onCrash,
+	];
+}
+
+/**
+ * Removes all event listeners from the Kafka consumer
+ * @param listeners - Array of listener removal functions
+ */
+export function disconnectEventListeners(
+	listeners: Array<RemoveInstrumentationEventListener<'consumer.connect'>>,
+) {
+	listeners.forEach((listener) => listener());
+}
+
+/**
+ * Initializes Confluent Schema Registry if enabled in node parameters
+ * @param ctx - The trigger function context
+ * @returns Schema registry instance or undefined if not configured
+ */
+export function setSchemaRegistry(ctx: ITriggerFunctions) {
+	const useSchemaRegistry = ctx.getNodeParameter('useSchemaRegistry', 0) as boolean;
+
+	if (useSchemaRegistry) {
+		try {
+			const schemaRegistryUrl = ctx.getNodeParameter('schemaRegistryUrl', 0) as string;
+			return new SchemaRegistry({ host: schemaRegistryUrl });
+		} catch (error) {
+			ctx.logger.warn('Could not connect to Schema Registry', { error });
+		}
+	}
+
+	return undefined;
+}
+
+/**
+ * Determines the offset resolution mode based on node version and configuration
+ * @param ctx - The trigger function context
+ * @param options - Kafka trigger options
+ * @param nodeVersion - The version of the Kafka trigger node
+ * @returns The offset resolution mode
+ */
+function getResolveOffsetMode(
+	ctx: ITriggerFunctions,
+	options: KafkaTriggerOptions,
+	nodeVersion: number,
+): ResolveOffsetMode {
+	if (nodeVersion === 1) return 'immediately';
+
+	if (nodeVersion === 1.1) {
+		if (options.parallelProcessing) return 'immediately';
+		return 'onCompletion';
+	}
+	return ctx.getNodeParameter('resolveOffset', 'immediately') as ResolveOffsetMode;
+}
+
+/**
+ * Configures a data emitter function that handles workflow execution and offset resolution
+ * @param ctx - The trigger function context
+ * @param options - Kafka trigger options
+ * @param nodeVersion - The version of the Kafka trigger node
+ * @returns Async function that emits data and waits for execution completion based on resolve mode
+ */
+export function configureDataEmitter(
+	ctx: ITriggerFunctions,
+	options: KafkaTriggerOptions,
+	nodeVersion: number,
+) {
+	const resolveOffsetMode = getResolveOffsetMode(ctx, options, nodeVersion);
+
+	// For manual mode, always use immediate emit (no donePromise)
+	if (ctx.getMode() === 'manual' || resolveOffsetMode === 'immediately') {
+		return async (dataArray: INodeExecutionData[]) => {
+			ctx.emit([dataArray]);
+			return { success: true };
+		};
+	}
+
+	const executionTimeoutInSeconds = ctx.getWorkflowSettings().executionTimeout ?? 3600;
+	const errorRetryDelay = options.errorRetryDelay ?? DEFAULT_ERROR_RETRY_DELAY_MS;
+
+	const allowedStatuses: string[] = [];
+	if (resolveOffsetMode === 'onSuccess') {
+		allowedStatuses.push('success');
+	} else if (resolveOffsetMode === 'onStatus') {
+		const selectedStatuses = ctx.getNodeParameter('allowedStatuses', []) as string[];
+
+		if (Array.isArray(selectedStatuses) && selectedStatuses.length) {
+			allowedStatuses.push(...selectedStatuses);
+		} else {
+			throw new NodeOperationError(
+				ctx.getNode(),
+				'At least one execution status must be selected to resolve offsets on selected statuses.',
+			);
+		}
+	}
+
+	return async (dataArray: INodeExecutionData[]) => {
+		let timeoutId: NodeJS.Timeout | undefined;
+		try {
+			const responsePromise = ctx.helpers.createDeferredPromise<IRun>();
+			ctx.emit([dataArray], undefined, responsePromise);
+
+			const timeoutPromise = new Promise<IRun>((_, reject) => {
+				timeoutId = setTimeout(() => {
+					reject(
+						new NodeOperationError(
+							ctx.getNode(),
+							`Execution took longer than the configured workflow timeout of ${executionTimeoutInSeconds} seconds to complete, offsets not resolved.`,
+						),
+					);
+				}, executionTimeoutInSeconds * 1000);
+			});
+
+			const run = await Promise.race([responsePromise.promise, timeoutPromise]);
+
+			if (resolveOffsetMode !== 'onCompletion' && !allowedStatuses.includes(run.status)) {
+				throw new NodeOperationError(
+					ctx.getNode(),
+					'Execution status is not allowed for resolving offsets, current status: ' + run.status,
+				);
+			}
+
+			return { success: true };
+		} catch (e) {
+			await sleep(errorRetryDelay);
+			const error = ensureError(e);
+			ctx.logger.error(error.message, { error });
+			return { success: false };
+		} finally {
+			if (timeoutId) clearTimeout(timeoutId);
+		}
+	};
+}
+
+/**
+ * Determines auto-commit settings based on node's optons
+ * @param options - Kafka trigger options
+ * @returns Object with auto-commit configuration
+ */
+export function getAutoCommitSettings(options: KafkaTriggerOptions) {
+	const eachBatchAutoResolve = options.eachBatchAutoResolve ?? false;
+
+	const autoCommitInterval = options.autoCommitInterval ?? undefined;
+	const autoCommitThreshold = options.autoCommitThreshold ?? undefined;
+
+	return {
+		autoCommit: true,
+		eachBatchAutoResolve,
+		autoCommitInterval,
+		autoCommitThreshold,
+	};
+}
+
+/**
+ * Runs a task while periodically invoking a heartbeat function
+ * at specified intervals to prevent session timeout
+ * @param task - The promise to execute
+ * @param heartbeat - The heartbeat function to call periodically
+ * @param intervalMs - The interval in milliseconds between heartbeat calls (default: 3000)
+ * @returns The result of the task promise
+ */
+export async function runWithHeartbeat<T>(
+	task: Promise<T>,
+	heartbeat: () => Promise<void>,
+	intervalMs = 3000,
+) {
+	let timer;
+
+	try {
+		timer = setInterval(async () => {
+			try {
+				await heartbeat();
+			} catch (error) {}
+		}, intervalMs);
+
+		return await task;
+	} finally {
+		clearInterval(timer);
+	}
+}

--- a/packages/nodes-base/test/nodes/TriggerHelpers.ts
+++ b/packages/nodes-base/test/nodes/TriggerHelpers.ts
@@ -107,12 +107,19 @@ export async function testTriggerNode(
 	const triggerFunctions = mock<ITriggerFunctions>({
 		helpers,
 		emit,
+		logger: mock({
+			debug: jest.fn(),
+			info: jest.fn(),
+			warn: jest.fn(),
+			error: jest.fn(),
+		}),
 		getTimezone: () => timezone,
 		getNode: () => node,
 		getCredentials: async <T extends object = ICredentialDataDecryptedObject>() =>
 			(options.credential ?? {}) as T,
 		getMode: () => options.mode ?? 'trigger',
 		getWorkflowStaticData: () => options.workflowStaticData ?? {},
+		getWorkflowSettings: () => ({}),
 		getNodeParameter: (parameterName, fallback) => get(node.parameters, parameterName) ?? fallback,
 	});
 

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -925,6 +925,7 @@ export interface FunctionsBase {
 	getExecutionId(): string;
 	getNode(): INode;
 	getWorkflow(): IWorkflowMetadata;
+	getWorkflowSettings(): IWorkflowSettings;
 	getWorkflowStaticData(type: string): IDataObject;
 	getTimezone(): string;
 	getRestApiUrl(): string;


### PR DESCRIPTION
# Description
Backport of #25088 to `1.x`.

# Original description

## Summary

Refactoring and fixes for Kafka trigger node, base for v1.3
- fix: Check for `isRunning` and `isStale` to prevent issues during processing in a rebalance.
- fix: `runWithHeartbeat` added to periodically send a heartbeat during long-running executions to prevent session timeouts.
- fix: Manual/test executions will no longer wait for `donePromise`.
- fix: improvements for parameters descriptions

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-4238/kafka-enable-more-control-over-commit-timing-improve-ui-timeout
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
