### PR TITLE
fix(editor): Fix wrong content displayed while quickly navigating projects and folders

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useLatestFetch.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useLatestFetch.test.ts
@@ -1,0 +1,37 @@
+import { useLatestFetch } from './useLatestFetch';
+
+describe('useLatestFetch', () => {
+	it('should return isCurrent as true for a single call', () => {
+		const { next } = useLatestFetch();
+		const isCurrent = next();
+		expect(isCurrent()).toBe(true);
+	});
+
+	it('should invalidate first call when a second call is made', () => {
+		const { next } = useLatestFetch();
+		const isCurrentFirst = next();
+		const isCurrentSecond = next();
+		expect(isCurrentFirst()).toBe(false);
+		expect(isCurrentSecond()).toBe(true);
+	});
+
+	it('should allow sequential calls to both be current at their check time', () => {
+		const { next } = useLatestFetch();
+		const isCurrentFirst = next();
+		expect(isCurrentFirst()).toBe(true);
+
+		const isCurrentSecond = next();
+		expect(isCurrentSecond()).toBe(true);
+		// First is no longer current after second call
+		expect(isCurrentFirst()).toBe(false);
+	});
+
+	it('should only keep the last checker current when calling next() multiple times', () => {
+		const { next } = useLatestFetch();
+		const checkers = [next(), next(), next(), next()];
+		expect(checkers[0]()).toBe(false);
+		expect(checkers[1]()).toBe(false);
+		expect(checkers[2]()).toBe(false);
+		expect(checkers[3]()).toBe(true);
+	});
+});

--- a/packages/frontend/editor-ui/src/app/composables/useLatestFetch.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useLatestFetch.ts
@@ -1,0 +1,10 @@
+export function useLatestFetch() {
+	let generation = 0;
+
+	function next(): () => boolean {
+		const thisGeneration = ++generation;
+		return () => thisGeneration === generation;
+	}
+
+	return { next };
+}

--- a/packages/frontend/editor-ui/src/app/views/WorkflowsView.vue
+++ b/packages/frontend/editor-ui/src/app/views/WorkflowsView.vue
@@ -11,6 +11,7 @@ import WorkflowTagsDropdown from '@/features/shared/tags/components/WorkflowTags
 import { useAutoScrollOnDrag } from '@/app/composables/useAutoScrollOnDrag';
 import { useDebounce } from '@/app/composables/useDebounce';
 import { useDocumentTitle } from '@/app/composables/useDocumentTitle';
+import { useLatestFetch } from '@/app/composables/useLatestFetch';
 import type { DragTarget, DropTarget, FolderListItem } from '@/features/core/folders/folders.types';
 import { useFolders } from '@/features/core/folders/composables/useFolders';
 import { useMessage } from '@/app/composables/useMessage';
@@ -143,6 +144,7 @@ const readyToRunStore = useReadyToRunStore();
 const documentTitle = useDocumentTitle();
 const { callDebounced } = useDebounce();
 const projectPages = useProjectPages();
+const { next: nextFetch } = useLatestFetch();
 const {
 	showRecommendedTemplatesInline,
 	emptyStateHeading: emptyListHeading,
@@ -587,7 +589,7 @@ const initialize = async () => {
 	await setFiltersFromQueryString();
 
 	currentFolderId.value = route.params.folderId as string | null;
-	const [resourcesPage] = await Promise.all([
+	await Promise.all([
 		fetchWorkflows(),
 		workflowsListStore.fetchActiveWorkflows(),
 		usageStore.getLicenseInfo(),
@@ -597,8 +599,6 @@ const initialize = async () => {
 		),
 	]);
 	breadcrumbsLoading.value = false;
-	workflowsAndFolders.value = resourcesPage;
-	loading.value = false;
 };
 
 /**
@@ -608,6 +608,8 @@ const initialize = async () => {
  * - Path to the current folder (if not cached)
  */
 const fetchWorkflows = async () => {
+	const isCurrent = nextFetch();
+
 	// We debounce here so that fast enough fetches don't trigger
 	// the placeholder graphics for a few milliseconds, which would cause a flicker
 	const delayedLoading = debounce(() => {
@@ -649,6 +651,8 @@ const fetchWorkflows = async () => {
 			projectPages.isSharedSubPage,
 		);
 
+		if (!isCurrent()) return [];
+
 		foldersStore.cacheFolders(
 			fetchedResources
 				.filter((resource) => resource.resource === 'folder')
@@ -673,15 +677,18 @@ const fetchWorkflows = async () => {
 
 		return fetchedResources;
 	} catch (error) {
+		if (!isCurrent()) return [];
 		toast.showError(error, i18n.baseText('workflows.list.error.fetching'));
 		// redirect to the project page if the folder is not found
 		void router.push({ name: VIEWS.PROJECTS_FOLDERS, params: { projectId: routeProjectId } });
 		return [];
 	} finally {
 		delayedLoading.cancel();
-		loading.value = false;
-		if (breadcrumbsLoading.value) {
-			breadcrumbsLoading.value = false;
+		if (isCurrent()) {
+			loading.value = false;
+			if (breadcrumbsLoading.value) {
+				breadcrumbsLoading.value = false;
+			}
 		}
 	}
 };

--- a/packages/frontend/editor-ui/src/features/credentials/views/CredentialsView.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/views/CredentialsView.vue
@@ -6,7 +6,6 @@ import type { BaseFilters, Resource } from '@/Interface';
 import type { ICredentialTypeMap } from '../credentials.types';
 import ProjectHeader from '@/features/collaboration/projects/components/ProjectHeader.vue';
 import { useDocumentTitle } from '@/app/composables/useDocumentTitle';
-import { useLatestFetch } from '@/app/composables/useLatestFetch';
 import { useProjectPages } from '@/features/collaboration/projects/composables/useProjectPages';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { CREDENTIAL_EDIT_MODAL_KEY, CREDENTIAL_SELECT_MODAL_KEY } from '../credentials.constants';
@@ -52,7 +51,6 @@ const router = useRouter();
 const telemetry = useTelemetry();
 const i18n = useI18n();
 const overview = useProjectPages();
-const { next: nextFetch } = useLatestFetch();
 
 type Filters = BaseFilters & { type?: string[]; setupNeeded?: boolean };
 const updateFilter = (state: Filters) => {
@@ -192,7 +190,6 @@ const maybeEditCredential = async () => {
 };
 
 const initialize = async () => {
-	const isCurrent = nextFetch();
 	loading.value = true;
 	const isVarsEnabled =
 		useSettingsStore().isEnterpriseFeatureEnabled[EnterpriseEditionFeature.Variables];
@@ -223,7 +220,6 @@ const initialize = async () => {
 	];
 
 	await Promise.all(loadPromises);
-	if (!isCurrent()) return;
 	maybeCreateCredential();
 	await maybeEditCredential();
 	loading.value = false;

--- a/packages/frontend/editor-ui/src/features/credentials/views/CredentialsView.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/views/CredentialsView.vue
@@ -6,6 +6,7 @@ import type { BaseFilters, Resource } from '@/Interface';
 import type { ICredentialTypeMap } from '../credentials.types';
 import ProjectHeader from '@/features/collaboration/projects/components/ProjectHeader.vue';
 import { useDocumentTitle } from '@/app/composables/useDocumentTitle';
+import { useLatestFetch } from '@/app/composables/useLatestFetch';
 import { useProjectPages } from '@/features/collaboration/projects/composables/useProjectPages';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { CREDENTIAL_EDIT_MODAL_KEY, CREDENTIAL_SELECT_MODAL_KEY } from '../credentials.constants';
@@ -51,6 +52,7 @@ const router = useRouter();
 const telemetry = useTelemetry();
 const i18n = useI18n();
 const overview = useProjectPages();
+const { next: nextFetch } = useLatestFetch();
 
 type Filters = BaseFilters & { type?: string[]; setupNeeded?: boolean };
 const updateFilter = (state: Filters) => {
@@ -190,6 +192,7 @@ const maybeEditCredential = async () => {
 };
 
 const initialize = async () => {
+	const isCurrent = nextFetch();
 	loading.value = true;
 	const isVarsEnabled =
 		useSettingsStore().isEnterpriseFeatureEnabled[EnterpriseEditionFeature.Variables];
@@ -220,6 +223,7 @@ const initialize = async () => {
 	];
 
 	await Promise.all(loadPromises);
+	if (!isCurrent()) return;
 	maybeCreateCredential();
 	await maybeEditCredential();
 	loading.value = false;


### PR DESCRIPTION
## Summary

If having slow internet connection and the user navigates rapidly between projects/directories it's possible for the responses to come out of order and to end up with incorrect content displayed. Added a mechanism to make sure we're loading only the latest response if there are multiple

It's possible to observe the issue locally using chrome extension like requestly and add artificial delay on API calls

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4705/navigating-back-and-forth-between-folders-and-projects-quickly-might


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
