### PR TITLE
feat(core): Add `workflow-version-updated` event to log streaming

### DIFF
--- a/packages/cli/src/eventbus/event-message-classes/event-message-audit.ts
+++ b/packages/cli/src/eventbus/event-message-classes/event-message-audit.ts
@@ -21,6 +21,7 @@ export interface EventPayloadAudit extends AbstractEventPayload {
 	workflowId?: string;
 	workflowName?: string;
 	activeVersionId?: string | null;
+	deactivatedVersionId?: string | null;
 	versionId?: string;
 	versionName?: string | null;
 	versionDescription?: string | null;

--- a/packages/cli/src/eventbus/event-message-classes/event-message-audit.ts
+++ b/packages/cli/src/eventbus/event-message-classes/event-message-audit.ts
@@ -21,6 +21,9 @@ export interface EventPayloadAudit extends AbstractEventPayload {
 	workflowId?: string;
 	workflowName?: string;
 	activeVersionId?: string | null;
+	versionId?: string;
+	versionName?: string | null;
+	versionDescription?: string | null;
 	settingsChanged?: Record<string, { from: JsonValue; to: JsonValue }>;
 	variableId?: string;
 	variableKey?: string;

--- a/packages/cli/src/eventbus/event-message-classes/index.ts
+++ b/packages/cli/src/eventbus/event-message-classes/index.ts
@@ -87,6 +87,7 @@ export const eventNamesAudit = [
 	'n8n.audit.workflow.unarchived',
 	'n8n.audit.workflow.activated',
 	'n8n.audit.workflow.deactivated',
+	'n8n.audit.workflow.version.updated',
 	'n8n.audit.variable.created',
 	'n8n.audit.variable.updated',
 	'n8n.audit.variable.deleted',

--- a/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
@@ -181,6 +181,41 @@ describe('LogStreamingEventRelay', () => {
 			});
 		});
 
+		it('should log on `workflow-version-updated` event', () => {
+			const event: RelayEventMap['workflow-version-updated'] = {
+				user: {
+					id: '789',
+					email: 'john@n8n.io',
+					firstName: 'John',
+					lastName: 'Doe',
+					role: { slug: 'admin' },
+				},
+				workflowId: 'wf-version-123',
+				workflowName: 'Version Test Workflow',
+				versionId: 'v-001',
+				versionName: 'Production Release',
+				versionDescription: 'Initial production release with all features',
+			};
+
+			eventService.emit('workflow-version-updated', event);
+
+			expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
+				eventName: 'n8n.audit.workflow.version.updated',
+				payload: {
+					userId: '789',
+					_email: 'john@n8n.io',
+					_firstName: 'John',
+					_lastName: 'Doe',
+					globalRole: 'admin',
+					workflowId: 'wf-version-123',
+					workflowName: 'Version Test Workflow',
+					versionId: 'v-001',
+					versionName: 'Production Release',
+					versionDescription: 'Initial production release with all features',
+				},
+			});
+		});
+
 		it('should log on `workflow-deleted` event', () => {
 			const event: RelayEventMap['workflow-deleted'] = {
 				user: {

--- a/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
@@ -158,9 +158,10 @@ describe('LogStreamingEventRelay', () => {
 				workflow: mock<IWorkflowDb>({
 					id: 'wf789',
 					name: 'Deactivated Workflow',
-					activeVersionId: 'version-xyz-789',
+					activeVersionId: null,
 				}),
 				publicApi: false,
+				deactivatedVersionId: 'version-xyz-789',
 			};
 
 			eventService.emit('workflow-deactivated', event);
@@ -175,7 +176,7 @@ describe('LogStreamingEventRelay', () => {
 					globalRole: 'user',
 					workflowId: 'wf789',
 					workflowName: 'Deactivated Workflow',
-					activeVersionId: 'version-xyz-789',
+					deactivatedVersionId: 'version-xyz-789',
 				},
 			});
 		});

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -112,6 +112,7 @@ export type RelayEventMap = {
 		workflowId: string;
 		workflow: IWorkflowDb;
 		publicApi: boolean;
+		deactivatedVersionId: string | null;
 	};
 
 	'workflow-pre-execute': {

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -149,6 +149,15 @@ export type RelayEventMap = {
 			| 'chat';
 	};
 
+	'workflow-version-updated': {
+		user: UserLike;
+		workflowId: string;
+		workflowName: string;
+		versionId: string;
+		versionName?: string | null;
+		versionDescription?: string | null;
+	};
+
 	// #endregion
 
 	// #region Node

--- a/packages/cli/src/events/relays/log-streaming.event-relay.ts
+++ b/packages/cli/src/events/relays/log-streaming.event-relay.ts
@@ -34,6 +34,7 @@ export class LogStreamingEventRelay extends EventRelay {
 			'workflow-activated': (event) => this.workflowActivated(event),
 			'workflow-deactivated': (event) => this.workflowDeactivated(event),
 			'workflow-saved': (event) => this.workflowSaved(event),
+			'workflow-version-updated': (event) => this.workflowVersionUpdated(event),
 			'workflow-pre-execute': (event) => this.workflowPreExecute(event),
 			'workflow-post-execute': (event) => this.workflowPostExecute(event),
 			'workflow-executed': (event) => this.workflowExecuted(event),
@@ -170,6 +171,28 @@ export class LogStreamingEventRelay extends EventRelay {
 				workflowId: workflow.id,
 				workflowName: workflow.name,
 				...(settingsChanged && { settingsChanged }),
+			},
+		});
+	}
+
+	@Redactable()
+	private workflowVersionUpdated({
+		user,
+		workflowId,
+		workflowName,
+		versionId,
+		versionName,
+		versionDescription,
+	}: RelayEventMap['workflow-version-updated']) {
+		void this.eventBus.sendAuditEvent({
+			eventName: 'n8n.audit.workflow.version.updated',
+			payload: {
+				...user,
+				workflowId,
+				workflowName,
+				versionId,
+				...(versionName !== undefined && { versionName }),
+				...(versionDescription !== undefined && { versionDescription }),
 			},
 		});
 	}

--- a/packages/cli/src/events/relays/log-streaming.event-relay.ts
+++ b/packages/cli/src/events/relays/log-streaming.event-relay.ts
@@ -150,6 +150,7 @@ export class LogStreamingEventRelay extends EventRelay {
 		user,
 		workflowId,
 		workflow,
+		deactivatedVersionId,
 	}: RelayEventMap['workflow-deactivated']) {
 		void this.eventBus.sendAuditEvent({
 			eventName: 'n8n.audit.workflow.deactivated',
@@ -157,7 +158,7 @@ export class LogStreamingEventRelay extends EventRelay {
 				...user,
 				workflowId,
 				workflowName: workflow.name,
-				activeVersionId: workflow.activeVersionId,
+				deactivatedVersionId,
 			},
 		});
 	}

--- a/packages/cli/src/workflows/workflow-history/__tests__/workflow-history.service.test.ts
+++ b/packages/cli/src/workflows/workflow-history/__tests__/workflow-history.service.test.ts
@@ -3,6 +3,7 @@ import { User, WorkflowHistoryRepository } from '@n8n/db';
 import type { UpdateResult } from '@n8n/typeorm';
 import { mockClear } from 'jest-mock-extended';
 
+import { EventService } from '@/events/event.service';
 import { SharedWorkflowNotFoundError } from '@/errors/shared-workflow-not-found.error';
 import { WorkflowHistoryVersionNotFoundError } from '@/errors/workflow-history-version-not-found.error';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
@@ -12,10 +13,12 @@ import { getWorkflow, getWorkflowHistory } from '@test-integration/workflow';
 const workflowHistoryRepository = mockInstance(WorkflowHistoryRepository);
 const logger = mockLogger();
 const workflowFinderService = mockInstance(WorkflowFinderService);
+const eventService = mockInstance(EventService);
 const workflowHistoryService = new WorkflowHistoryService(
 	logger,
 	workflowHistoryRepository,
 	workflowFinderService,
+	eventService,
 );
 const testUser = Object.assign(new User(), {
 	id: '1234',

--- a/packages/cli/src/workflows/workflow-history/workflow-history.service.ts
+++ b/packages/cli/src/workflows/workflow-history/workflow-history.service.ts
@@ -168,7 +168,7 @@ export class WorkflowHistoryService {
 
 		await this.updateVersion(workflowId, versionId, updateData);
 
-		if (updateData.name || updateData.description) {
+		if (updateData.name !== undefined || updateData.description !== undefined) {
 			this.eventService.emit('workflow-version-updated', {
 				user: {
 					id: user.id,

--- a/packages/cli/src/workflows/workflow-history/workflow-history.service.ts
+++ b/packages/cli/src/workflows/workflow-history/workflow-history.service.ts
@@ -14,6 +14,7 @@ import { WorkflowFinderService } from '../workflow-finder.service';
 
 import { SharedWorkflowNotFoundError } from '@/errors/shared-workflow-not-found.error';
 import { WorkflowHistoryVersionNotFoundError } from '@/errors/workflow-history-version-not-found.error';
+import { EventService } from '@/events/event.service';
 
 @Service()
 export class WorkflowHistoryService {
@@ -21,6 +22,7 @@ export class WorkflowHistoryService {
 		private readonly logger: Logger,
 		private readonly workflowHistoryRepository: WorkflowHistoryRepository,
 		private readonly workflowFinderService: WorkflowFinderService,
+		private readonly eventService: EventService,
 	) {}
 
 	async getList(
@@ -165,6 +167,23 @@ export class WorkflowHistoryService {
 		}
 
 		await this.updateVersion(workflowId, versionId, updateData);
+
+		if (updateData.name || updateData.description) {
+			this.eventService.emit('workflow-version-updated', {
+				user: {
+					id: user.id,
+					email: user.email,
+					firstName: user.firstName,
+					lastName: user.lastName,
+					role: user.role,
+				},
+				workflowId: workflow.id,
+				workflowName: workflow.name,
+				versionId,
+				versionName: updateData.name,
+				versionDescription: updateData.description,
+			});
+		}
 	}
 
 	/**

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -627,7 +627,6 @@ export class WorkflowService {
 		if (previousActiveVersionId) {
 			await this.activeWorkflowManager.remove(workflowId);
 
-			assert(previousActiveVersionId !== null);
 			this.eventService.emit('workflow-deactivated', {
 				user,
 				workflowId,

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -3835,6 +3835,139 @@ describe('POST /workflows/:workflowId/activate', () => {
 		});
 	});
 
+	test('should emit only activation event when activating inactive workflow', async () => {
+		const workflow = await createWorkflowWithHistory({}, owner);
+		const emitSpy = jest.spyOn(eventService, 'emit');
+
+		await authOwnerAgent
+			.post(`/workflows/${workflow.id}/activate`)
+			.send({ versionId: workflow.versionId });
+
+		expect(emitSpy).toHaveBeenCalledWith(
+			'workflow-activated',
+			expect.objectContaining({
+				workflowId: workflow.id,
+				workflow: expect.objectContaining({
+					activeVersionId: workflow.versionId,
+				}),
+			}),
+		);
+
+		expect(emitSpy).not.toHaveBeenCalledWith('workflow-deactivated', expect.anything());
+	});
+
+	test('should emit both deactivation and activation events when updating active workflow', async () => {
+		const workflow = await createActiveWorkflow({}, owner);
+		const oldVersionId = workflow.activeVersionId!;
+		const newVersionId = uuid();
+		await createWorkflowHistoryItem(workflow.id, { versionId: newVersionId });
+
+		const emitSpy = jest.spyOn(eventService, 'emit');
+
+		await authOwnerAgent
+			.post(`/workflows/${workflow.id}/activate`)
+			.send({ versionId: newVersionId });
+
+		// Should emit deactivation event for the old version FIRST
+		expect(emitSpy).toHaveBeenCalledWith(
+			'workflow-deactivated',
+			expect.objectContaining({
+				workflowId: workflow.id,
+				deactivatedVersionId: oldVersionId,
+			}),
+		);
+
+		// Should emit activation event for the new version AFTER
+		expect(emitSpy).toHaveBeenCalledWith(
+			'workflow-activated',
+			expect.objectContaining({
+				workflowId: workflow.id,
+				workflow: expect.objectContaining({
+					activeVersionId: newVersionId,
+				}),
+			}),
+		);
+
+		const deactivationCallIndex = emitSpy.mock.calls.findIndex(
+			(call) => call[0] === 'workflow-deactivated',
+		);
+		const activationCallIndex = emitSpy.mock.calls.findIndex(
+			(call) => call[0] === 'workflow-activated',
+		);
+		expect(deactivationCallIndex).toBeLessThan(activationCallIndex);
+	});
+
+	test('should emit only deactivation event when activation fails on active workflow', async () => {
+		const workflow = await createActiveWorkflow({}, owner);
+		const oldVersionId = workflow.activeVersionId!;
+		const newVersionId = uuid();
+		await createWorkflowHistoryItem(workflow.id, { versionId: newVersionId });
+
+		// Mock activeWorkflowManager.add to fail
+		const addSpy = jest
+			.spyOn(activeWorkflowManagerLike, 'add')
+			.mockRejectedValueOnce(new Error('Failed to add workflow'));
+
+		const emitSpy = jest.spyOn(eventService, 'emit');
+
+		const response = await authOwnerAgent
+			.post(`/workflows/${workflow.id}/activate`)
+			.send({ versionId: newVersionId });
+
+		expect(response.statusCode).toBe(400);
+
+		// Should emit deactivation event for the old version
+		expect(emitSpy).toHaveBeenCalledWith(
+			'workflow-deactivated',
+			expect.objectContaining({
+				workflowId: workflow.id,
+				deactivatedVersionId: oldVersionId,
+			}),
+		);
+
+		// Should NOT emit activation event (activation failed)
+		expect(emitSpy).not.toHaveBeenCalledWith('workflow-activated', expect.anything());
+
+		// Verify workflow is deactivated in database
+		const updatedWorkflow = await workflowRepository.findOne({
+			where: { id: workflow.id },
+		});
+		expect(updatedWorkflow?.active).toBe(false);
+		expect(updatedWorkflow?.activeVersionId).toBeNull();
+
+		addSpy.mockRestore();
+	});
+
+	test('should emit no events when activation fails on inactive workflow', async () => {
+		const workflow = await createWorkflowWithHistory({}, owner);
+
+		// Mock activeWorkflowManager.add to fail
+		const addSpy = jest
+			.spyOn(activeWorkflowManagerLike, 'add')
+			.mockRejectedValueOnce(new Error('Failed to add workflow'));
+
+		const emitSpy = jest.spyOn(eventService, 'emit');
+
+		const response = await authOwnerAgent
+			.post(`/workflows/${workflow.id}/activate`)
+			.send({ versionId: workflow.versionId });
+
+		expect(response.statusCode).toBe(400);
+
+		// Should NOT emit any workflow events
+		expect(emitSpy).not.toHaveBeenCalledWith('workflow-activated', expect.anything());
+		expect(emitSpy).not.toHaveBeenCalledWith('workflow-deactivated', expect.anything());
+
+		// Verify workflow remains inactive
+		const updatedWorkflow = await workflowRepository.findOne({
+			where: { id: workflow.id },
+		});
+		expect(updatedWorkflow?.active).toBe(false);
+		expect(updatedWorkflow?.activeVersionId).toBeNull();
+
+		addSpy.mockRestore();
+	});
+
 	test('should not activate an archived workflow', async () => {
 		const workflow = await createWorkflowWithHistory({ isArchived: true }, owner);
 


### PR DESCRIPTION
## Summary

- Add new `workflow-version-updated` event to log streaming that will be relayed on "Name version" action
- Fix `workflow-deactivated` event
    - It was sent with `activeVersionId` which is aways `null` - instead, we're now sending `deactivatedVersionId`
- Fix bug with not sending a deactivated event when activating a new version + sending the activated event before knowing activation went on successfully.

### How to test
- Pul the latest changes, checkout this branch and run `git rebase ado-4732-frontend-add-name-version-actions` (I want to merge it to master, that's why it's not initially based off of the frontend branch, but it's the only way to test it properly)
- Prepare a webhook link (e.g. [here](https://webhook.site/#!/view/db8b9d1b-a19f-433a-a00c-4c6f56a4da67))
- Go to your instance. Click `Settings` -> `Log Streaming`.
- Add a new destination of type `Webhook` and paste your URL (leave the `POST` method). Save and activate.
- Go to a workflow page, click `Cmd + S` and save a new version.
- See a new event (`n8n.audit.workflow.version.updated`) on the webhook page.

To see "deactivated" event, unpublish a published workflow.

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-4734](https://linear.app/n8n/issue/ADO-4734/add-version-updated-event-to-log-streaming)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
