### PR TITLE
feat(core): Enable workflow dependency indexing by default

### DIFF
--- a/packages/@n8n/config/src/configs/workflows.config.ts
+++ b/packages/@n8n/config/src/configs/workflows.config.ts
@@ -19,11 +19,9 @@ export class WorkflowsConfig {
 	@Env('N8N_WORKFLOW_ACTIVATION_BATCH_SIZE')
 	activationBatchSize: number = 1;
 
-	/** Whether to enable workflow dependency indexing.
-	 * NOTE: this feature is still under development.
-	 */
+	/** Whether to enable workflow dependency indexing. */
 	@Env('N8N_WORKFLOWS_INDEXING_ENABLED')
-	indexingEnabled: boolean = false;
+	indexingEnabled: boolean = true;
 
 	/** Whether to use workflow publication service.
 	 * NOTE: this feature is still under development.

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -179,7 +179,7 @@ describe('GlobalConfig', () => {
 			defaultName: 'My workflow',
 			callerPolicyDefaultOption: 'workflowsFromSameOwner',
 			activationBatchSize: 1,
-			indexingEnabled: false,
+			indexingEnabled: true,
 			useWorkflowPublicationService: false,
 		},
 		endpoints: {


### PR DESCRIPTION
## Summary

Enable workflow dependency indexing by default.

It's been running on internal for a day with no incident, and it seems to be behaving correctly.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2292

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
