### PR TITLE
refactor(core): Make SecretsProvider.connect() return Result instead of relying on side effects

### DIFF
--- a/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-manager.ee.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-manager.ee.test.ts
@@ -460,7 +460,25 @@ describe('ExternalSecretsManager', () => {
 			});
 		});
 
-		it('should return tested state for non-connected provider', async () => {
+		it('should return connected state on successful test', async () => {
+			const dummyProvider = new DummyProvider();
+			jest.spyOn(dummyProvider, 'test').mockResolvedValue([true]);
+
+			mockProviderLifecycle.initialize.mockResolvedValue({
+				success: true,
+				provider: dummyProvider,
+			});
+			mockProviderLifecycle.connect.mockResolvedValue({ success: true });
+
+			const result = await manager.testProviderSettings('dummy', { key: 'value' });
+
+			expect(result).toEqual({
+				success: true,
+				testState: 'connected',
+			});
+		});
+
+		it('should return tested state for non-connected provider (legacy)', async () => {
 			const dummyProvider = new DummyProvider();
 			jest.spyOn(dummyProvider, 'test').mockResolvedValue([true]);
 
@@ -475,7 +493,7 @@ describe('ExternalSecretsManager', () => {
 				settings: {},
 			});
 
-			const result = await manager.testProviderSettings('dummy', { key: 'value' });
+			const result = await manager.testProviderSettingsLegacy('dummy', { key: 'value' });
 
 			expect(result).toEqual({
 				success: true,
@@ -495,6 +513,7 @@ describe('ExternalSecretsManager', () => {
 			expect(result).toEqual({
 				success: false,
 				testState: 'error',
+				error: 'Init failed',
 			});
 		});
 

--- a/packages/cli/src/modules/external-secrets.ee/external-secrets.service.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets.service.ee.ts
@@ -126,7 +126,7 @@ export class ExternalSecretsService {
 		const providerAndSettings = this.externalSecretsManager.getProviderWithSettings(providerName);
 		const { settings } = providerAndSettings;
 		const newData = this.unredact(data, settings.settings);
-		return await this.externalSecretsManager.testProviderSettings(providerName, newData);
+		return await this.externalSecretsManager.testProviderSettingsLegacy(providerName, newData);
 	}
 
 	async updateProvider(providerName: string) {


### PR DESCRIPTION
## Summary
- Make `connect` return a result
- Have the old endpoint behave as is
- For the new endpoint remove the `tested` logic
- Remove state history as this is unused

Partially done with claude-code

## Related Linear tickets, Github issues, and Community forum posts
Closes LIGO-187

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
