### PR TITLE
feat(editor): Boost Claude Opus 4.6 priority in chat hub model selector

### DIFF
--- a/packages/cli/src/modules/chat-hub/chat-hub.constants.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.constants.ts
@@ -131,15 +131,19 @@ const MODEL_METADATA_REGISTRY: Partial<
 		},
 		'claude-haiku-4-5-20251001': {
 			inputModalities: ['text', 'image'],
-			priority: 80,
+			priority: 70,
 		},
 		'claude-sonnet-4-5-20250929': {
 			inputModalities: ['text', 'image'],
-			priority: 90,
+			priority: 80,
+		},
+		'claude-opus-4-6': {
+			inputModalities: ['text', 'image'],
+			priority: 100,
 		},
 		'claude-opus-4-5-20251101': {
 			inputModalities: ['text', 'image'],
-			priority: 100,
+			priority: 90,
 		},
 		'claude-opus-4-20250514': {
 			inputModalities: ['text', 'image'],


### PR DESCRIPTION
## Summary

Boost Claude Opus 4.6 to be the new default model to choose from Anthropic on Chat hub.

<img width="492" height="706" alt="image" src="https://github.com/user-attachments/assets/b022d74a-e454-4fac-955b-c60ee9cae619" />

## Related Linear tickets

https://linear.app/n8n/issue/CHA-132