### PR TITLE
feat(core): Add tracing to workflow indexing

### DIFF
--- a/packages/cli/src/modules/workflow-index/__tests__/workflow-index.service.test.ts
+++ b/packages/cli/src/modules/workflow-index/__tests__/workflow-index.service.test.ts
@@ -21,7 +21,6 @@ describe('WorkflowIndexService', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
 
-		// Make startSpan execute the callback directly
 		mockTracing.startSpan.mockImplementation(
 			async (_opts, cb) => await cb({ setStatus: jest.fn() }),
 		);

--- a/packages/cli/src/modules/workflow-index/__tests__/workflow-index.service.test.ts
+++ b/packages/cli/src/modules/workflow-index/__tests__/workflow-index.service.test.ts
@@ -3,11 +3,14 @@
 import { Logger } from '@n8n/backend-common';
 import { mockInstance } from '@n8n/backend-test-utils';
 import { WorkflowDependencyRepository, WorkflowEntity, WorkflowRepository } from '@n8n/db';
+import { mock } from 'jest-mock-extended';
+import type { Span } from 'n8n-core';
 import { ErrorReporter, Tracing } from 'n8n-core';
 import type { INode, IWorkflowBase } from 'n8n-workflow';
 
-import { WorkflowIndexService } from '../workflow-index.service';
 import { EventService } from '@/events/event.service';
+
+import { WorkflowIndexService } from '../workflow-index.service';
 
 describe('WorkflowIndexService', () => {
 	let service: WorkflowIndexService;
@@ -21,9 +24,7 @@ describe('WorkflowIndexService', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
 
-		mockTracing.startSpan.mockImplementation(
-			async (_opts, cb) => await cb({ setStatus: jest.fn() }),
-		);
+		mockTracing.startSpan.mockImplementation(async (_opts, spanCb) => await spanCb(mock<Span>()));
 
 		service = new WorkflowIndexService(
 			mockWorkflowDependencyRepository,

--- a/packages/cli/src/modules/workflow-index/__tests__/workflow-index.service.test.ts
+++ b/packages/cli/src/modules/workflow-index/__tests__/workflow-index.service.test.ts
@@ -3,7 +3,7 @@
 import { Logger } from '@n8n/backend-common';
 import { mockInstance } from '@n8n/backend-test-utils';
 import { WorkflowDependencyRepository, WorkflowEntity, WorkflowRepository } from '@n8n/db';
-import { ErrorReporter } from 'n8n-core';
+import { ErrorReporter, Tracing } from 'n8n-core';
 import type { INode, IWorkflowBase } from 'n8n-workflow';
 
 import { WorkflowIndexService } from '../workflow-index.service';
@@ -16,9 +16,15 @@ describe('WorkflowIndexService', () => {
 	const mockLogger = mockInstance(Logger);
 	const mockErrorReporter = mockInstance(ErrorReporter);
 	const mockEventService = mockInstance(EventService);
+	const mockTracing = mockInstance(Tracing);
 
 	beforeEach(() => {
 		jest.resetAllMocks();
+
+		// Make startSpan execute the callback directly
+		mockTracing.startSpan.mockImplementation(
+			async (_opts, cb) => await cb({ setStatus: jest.fn() }),
+		);
 
 		service = new WorkflowIndexService(
 			mockWorkflowDependencyRepository,
@@ -26,6 +32,7 @@ describe('WorkflowIndexService', () => {
 			mockEventService,
 			mockLogger,
 			mockErrorReporter,
+			mockTracing,
 		);
 	});
 
@@ -519,6 +526,7 @@ describe('WorkflowIndexService', () => {
 				mockEventService,
 				mockLogger,
 				mockErrorReporter,
+				mockTracing,
 				batchSize,
 			);
 

--- a/packages/cli/test/integration/workflows/workflow-index.test.ts
+++ b/packages/cli/test/integration/workflows/workflow-index.test.ts
@@ -9,7 +9,7 @@ import type { IWorkflowDb } from '@n8n/db';
 import { WorkflowDependencyRepository, WorkflowRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { retryUntil } from '@test-integration/retry-until';
-import { ErrorReporter } from 'n8n-core';
+import { ErrorReporter, Tracing } from 'n8n-core';
 import { v4 as uuid } from 'uuid';
 
 import { createOwner } from '../shared/db/users';
@@ -37,6 +37,7 @@ beforeAll(async () => {
 		eventService,
 		Container.get(Logger),
 		Container.get(ErrorReporter),
+		Container.get(Tracing),
 	);
 
 	// Initialize the service to register event listeners

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export * from './nodes-loader';
 export * from './utils';
 export * from './http-proxy';
 export { WorkflowHasIssuesError } from './errors/workflow-has-issues.error';
+export * from './observability';
 
 export type * from './interfaces';
 export * from './node-execute-functions';

--- a/packages/core/src/observability/tracing/tracing.ts
+++ b/packages/core/src/observability/tracing/tracing.ts
@@ -5,7 +5,7 @@ import type {
 	SpanAttributes as SentrySpanAttributes,
 } from '@sentry/core';
 import type Sentry from '@sentry/node';
-import type { INode, Workflow } from 'n8n-workflow';
+import type { INode, IWorkflowBase } from 'n8n-workflow';
 
 import { NoopTracing } from './noop-tracing';
 
@@ -69,13 +69,16 @@ export class Tracing {
 		this.tracer = tracing;
 	}
 
-	/** Start a span and execute the callback with the span */
+	/**
+	 * Start a span and execute the callback with the span. If the `spanCb` throws,
+	 * the span will be marked automatically as errored.
+	 */
 	async startSpan<T>(options: StartSpanOpts, spanCb: (span: Span) => Promise<T>): Promise<T> {
 		return await this.tracer.startSpan(options, spanCb);
 	}
 
 	/** Pick common attributes for a workflow */
-	pickWorkflowAttributes(workflow: Workflow): SpanAttributes {
+	pickWorkflowAttributes(workflow: Partial<Pick<IWorkflowBase, 'id' | 'name'>>): SpanAttributes {
 		return {
 			[this.commonAttrs.workflow.id]: workflow.id,
 			[this.commonAttrs.workflow.name]: workflow.name,
@@ -83,7 +86,9 @@ export class Tracing {
 	}
 
 	/** Pick common attributes for a node */
-	pickNodeAttributes(node: INode): SpanAttributes {
+	pickNodeAttributes(
+		node: Partial<Pick<INode, 'id' | 'name' | 'type' | 'typeVersion'>>,
+	): SpanAttributes {
 		return {
 			[this.commonAttrs.node.id]: node.id,
 			[this.commonAttrs.node.name]: node.name,


### PR DESCRIPTION
## Summary

Instrument WorkflowIndexService with OpenTelemetry-style tracing spans for build, update, and remove operations. Three main operations are now traced:
- Full index builds with draft and published workflow counts
- Individual workflow index updates with dependency type tracking  
- Removal of dependencies for deleted workflows

Also relax Tracing helper parameter types to accept partial workflow/node objects, and export the observability module from n8n-core for external consumers.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2273

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] Tests included and passing (14 tests)
- [ ] Docs updated (observability already documented)