### PR TITLE
fix(Youtube Node): include Content-Type header in resumable video upload PUT request

### DIFF
--- a/packages/nodes-base/nodes/Google/YouTube/YouTube.node.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/YouTube.node.ts
@@ -909,6 +909,7 @@ export class YouTube implements INodeType {
 									headers: {
 										'Content-Length': chunk.length,
 										'Content-Range': `bytes ${offset}-${nextOffset - 1}/${contentLength}`,
+										'Content-Type': mimeType,
 									},
 									body: chunk,
 								});

--- a/packages/nodes-base/nodes/Google/YouTube/__test__/node/video.upload.test.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/__test__/node/video.upload.test.ts
@@ -108,7 +108,11 @@ describe('Test YouTube, video => upload', () => {
 
 		expect(httpRequestMock).toHaveBeenCalledWith({
 			body: expect.any(Object),
-			headers: { 'Content-Length': 2097152, 'Content-Range': 'bytes 0-2097151/2097152' },
+			headers: {
+				'Content-Length': 2097152,
+				'Content-Range': 'bytes 0-2097151/2097152',
+				'Content-Type': 'video/mp4',
+			},
 			method: 'PUT',
 			url: 'https://www.youtube.com/watch?v=1234',
 		});


### PR DESCRIPTION
## Summary

This PR fixes an issue in the YouTube node where resumable video uploads were missing the Content-Type header in the PUT request.

While the initial resumable upload session (POST /upload/youtube/v3/videos) was created successfully, the subsequent chunk upload requests did not include the MIME Content-type . This could lead to uploads appearing successful in execution logs while failing silently / behaving inconsistently on YouTube’s side.

Changes
- Adds the Content-Type header to the resumable PUT upload request, using the MIME type derived from the binary data.
- Extends the existing unit test to assert that the Content-Type header is present, preventing regressions.

How to test
1.  Run the existing unit test: 

     ```bash
      pnpm test packages/nodes-base/nodes/Google/YouTube/__test__/node/video.upload.test.ts
     ```
3.  Verify that the test asserts the presence of the Content-Type header in the PUT request.
4.  (Optional) Upload a video via the YouTube node using resumable upload and confirm successful persistence on YouTube.



fixes: #24355


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
