### PR TITLE
fix(editor): Clean up collaboration state when leaving workflow

### DIFF
--- a/packages/frontend/editor-ui/src/features/collaboration/collaboration/collaboration.store.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/collaboration/collaboration.store.ts
@@ -368,6 +368,8 @@ export const useCollaborationStore = defineStore(STORES.COLLABORATION, () => {
 		if (unloadTimeout.value) {
 			clearTimeout(unloadTimeout.value);
 		}
+		currentWriterId.value = null;
+		collaborators.value = [];
 	}
 
 	return {


### PR DESCRIPTION
## Summary

To reproduce, open a workflow that is being edited by another user, and then create a new workflow.
This PR clears the state on collaboration store terminate.

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-4783](https://linear.app/n8n/issue/ADO-4783/another-user-editing-this-workflow-persists-even-on-a-different)


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
