### PR TITLE
Fixed PR24073

### DIFF
--- a/packages/@n8n/client-oauth2/src/code-flow.ts
+++ b/packages/@n8n/client-oauth2/src/code-flow.ts
@@ -101,7 +101,11 @@ export class CodeFlow {
 		// `client_id`: REQUIRED, if the client is not authenticating with the
 		// authorization server as described in Section 3.2.1.
 		// Reference: https://tools.ietf.org/html/rfc6749#section-3.2.1
-		if (options.clientSecret) {
+		// When authentication is 'body', credentials must be in the body, not headers
+		if (options.authentication === 'body') {
+			// Client credentials will be added to body via options.body merge in getRequestOptions
+			// Don't add Authorization header when using body authentication
+		} else if (options.clientSecret) {
 			headers.Authorization = auth(options.clientId, options.clientSecret);
 		} else {
 			body.client_id = options.clientId;

--- a/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
+++ b/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
@@ -8,6 +8,7 @@ import { OAuth2CredentialController } from '@/controllers/oauth/oauth2-credentia
 import type { OAuthRequest } from '@/requests';
 import { OauthService } from '@/oauth/oauth.service';
 import { ExternalHooks } from '@/external-hooks';
+import { OAuthProviderQuirksService } from '@/oauth/oauth-provider-quirks.service';
 
 jest.mock('axios');
 jest.mock('@n8n/client-oauth2');
@@ -16,6 +17,7 @@ jest.mock('pkce-challenge');
 describe('OAuth2CredentialController', () => {
 	const oauthService = mockInstance(OauthService);
 	const externalHooks = mockInstance(ExternalHooks);
+	const providerQuirksService = mockInstance(OAuthProviderQuirksService);
 
 	mockInstance(Logger);
 
@@ -708,6 +710,440 @@ describe('OAuth2CredentialController', () => {
 				'Token exchange failed',
 				undefined,
 			);
+		});
+
+		it('should extract error_description from HighLevel API error response', async () => {
+			const { ClientOAuth2 } = await import('@n8n/client-oauth2');
+			const errorBody = {
+				error: 'invalid_grant',
+				error_description: 'The authorization code has expired or is invalid',
+			};
+			const mockError = new Error('Invalid grant') as Error & { body: unknown; code: string };
+			mockError.body = errorBody;
+			mockError.code = 'EAUTH';
+			const mockGetToken = jest.fn().mockRejectedValue(mockError);
+			jest.mocked(ClientOAuth2).mockImplementation(
+				() =>
+					({
+						code: {
+							getToken: mockGetToken,
+						},
+					}) as any,
+			);
+
+			const mockResolvedCredential = mock<CredentialsEntity>({
+				id: '1',
+				type: 'highLevelOAuth2Api',
+			});
+			const mockState = {
+				token: 'token',
+				cid: '1',
+				userId: '123',
+				origin: 'static-credential' as const,
+				createdAt: timestamp,
+				data: 'encrypted-data',
+			};
+			oauthService.resolveCredential.mockResolvedValueOnce([
+				mockResolvedCredential,
+				{ csrfSecret: 'csrf-secret' },
+				{
+					clientId: 'client_id',
+					clientSecret: 'client_secret',
+					authUrl: 'https://marketplace.leadconnectorhq.com/oauth/chooselocation',
+					accessTokenUrl: 'https://services.leadconnectorhq.com/oauth/token',
+					scope: 'contacts.readonly contacts.write',
+					grantType: 'authorizationCode',
+					authentication: 'body',
+				},
+				mockState,
+			]);
+			oauthService.getBaseUrl.mockReturnValue('http://localhost:5678/rest/oauth2-credential');
+			externalHooks.run.mockResolvedValue(undefined);
+
+			const req = mock<OAuthRequest.OAuth2Credential.Callback>({
+				query: {
+					code: 'expired_code',
+					state: validState,
+				},
+				originalUrl: '/oauth2-credential/callback?code=expired_code&state=state',
+			});
+
+			await controller.handleCallback(req, res);
+
+			expect(oauthService.renderCallbackError).toHaveBeenCalledWith(
+				res,
+				'Invalid grant',
+				'The authorization code has expired or is invalid',
+			);
+		});
+
+		it('should extract error field from API error response when error_description is missing', async () => {
+			const { ClientOAuth2 } = await import('@n8n/client-oauth2');
+			const errorBody = {
+				error: 'invalid_client',
+			};
+			const mockError = new Error('Invalid client') as Error & { body: unknown; code: string };
+			mockError.body = errorBody;
+			mockError.code = 'EAUTH';
+			const mockGetToken = jest.fn().mockRejectedValue(mockError);
+			jest.mocked(ClientOAuth2).mockImplementation(
+				() =>
+					({
+						code: {
+							getToken: mockGetToken,
+						},
+					}) as any,
+			);
+
+			const mockResolvedCredential = mock<CredentialsEntity>({
+				id: '1',
+				type: 'highLevelOAuth2Api',
+			});
+			const mockState = {
+				token: 'token',
+				cid: '1',
+				userId: '123',
+				origin: 'static-credential' as const,
+				createdAt: timestamp,
+				data: 'encrypted-data',
+			};
+			oauthService.resolveCredential.mockResolvedValueOnce([
+				mockResolvedCredential,
+				{ csrfSecret: 'csrf-secret' },
+				{
+					clientId: 'client_id',
+					clientSecret: 'client_secret',
+					authUrl: 'https://marketplace.leadconnectorhq.com/oauth/chooselocation',
+					accessTokenUrl: 'https://services.leadconnectorhq.com/oauth/token',
+					scope: 'contacts.readonly',
+					grantType: 'authorizationCode',
+					authentication: 'body',
+				},
+				mockState,
+			]);
+			oauthService.getBaseUrl.mockReturnValue('http://localhost:5678/rest/oauth2-credential');
+			externalHooks.run.mockResolvedValue(undefined);
+
+			const req = mock<OAuthRequest.OAuth2Credential.Callback>({
+				query: {
+					code: 'auth_code',
+					state: validState,
+				},
+				originalUrl: '/oauth2-credential/callback?code=auth_code&state=state',
+			});
+
+			await controller.handleCallback(req, res);
+
+			expect(oauthService.renderCallbackError).toHaveBeenCalledWith(
+				res,
+				'Invalid client',
+				'invalid_client',
+			);
+		});
+
+		it('should include full error body when error_description and error are missing', async () => {
+			const { ClientOAuth2 } = await import('@n8n/client-oauth2');
+			const errorBody = {
+				message: 'Unexpected error occurred',
+				details: 'Some additional details',
+			};
+			const mockError = new Error('HTTP status 400') as Error & { body: unknown; code: string };
+			mockError.body = errorBody;
+			mockError.code = 'ESTATUS';
+			const mockGetToken = jest.fn().mockRejectedValue(mockError);
+			jest.mocked(ClientOAuth2).mockImplementation(
+				() =>
+					({
+						code: {
+							getToken: mockGetToken,
+						},
+					}) as any,
+			);
+
+			const mockResolvedCredential = mock<CredentialsEntity>({
+				id: '1',
+				type: 'highLevelOAuth2Api',
+			});
+			const mockState = {
+				token: 'token',
+				cid: '1',
+				userId: '123',
+				origin: 'static-credential' as const,
+				createdAt: timestamp,
+				data: 'encrypted-data',
+			};
+			oauthService.resolveCredential.mockResolvedValueOnce([
+				mockResolvedCredential,
+				{ csrfSecret: 'csrf-secret' },
+				{
+					clientId: 'client_id',
+					clientSecret: 'client_secret',
+					authUrl: 'https://marketplace.leadconnectorhq.com/oauth/chooselocation',
+					accessTokenUrl: 'https://services.leadconnectorhq.com/oauth/token',
+					scope: 'contacts.readonly',
+					grantType: 'authorizationCode',
+					authentication: 'body',
+				},
+				mockState,
+			]);
+			oauthService.getBaseUrl.mockReturnValue('http://localhost:5678/rest/oauth2-credential');
+			externalHooks.run.mockResolvedValue(undefined);
+
+			const req = mock<OAuthRequest.OAuth2Credential.Callback>({
+				query: {
+					code: 'auth_code',
+					state: validState,
+				},
+				originalUrl: '/oauth2-credential/callback?code=auth_code&state=state',
+			});
+
+			await controller.handleCallback(req, res);
+
+			expect(oauthService.renderCallbackError).toHaveBeenCalledWith(
+				res,
+				'HTTP status 400',
+				expect.stringContaining('Unexpected error occurred'),
+			);
+		});
+
+		describe('HighLevel OAuth2 specific handling', () => {
+			it('should include redirect_uri in token exchange body for HighLevel', async () => {
+				const { ClientOAuth2 } = await import('@n8n/client-oauth2');
+				const mockGetToken = jest.fn().mockResolvedValue({
+					data: { access_token: 'token', refresh_token: 'refresh' },
+				});
+				jest.mocked(ClientOAuth2).mockImplementation(
+					() =>
+						({
+							code: {
+								getToken: mockGetToken,
+							},
+						}) as any,
+				);
+
+				const mockResolvedCredential = mock<CredentialsEntity>({
+					id: '1',
+					type: 'highLevelOAuth2Api',
+				});
+				const mockState = {
+					token: 'token',
+					cid: '1',
+					userId: '123',
+					origin: 'static-credential' as const,
+					createdAt: timestamp,
+					data: 'encrypted-data',
+				};
+				oauthService.resolveCredential.mockResolvedValueOnce([
+					mockResolvedCredential,
+					{ csrfSecret: 'csrf-secret' },
+					{
+						clientId: 'highlevel_client_id',
+						clientSecret: 'highlevel_secret',
+						authUrl: 'https://marketplace.leadconnectorhq.com/oauth/chooselocation',
+						accessTokenUrl: 'https://services.leadconnectorhq.com/oauth/token',
+						scope: 'contacts.readonly contacts.write',
+						grantType: 'authorizationCode',
+						authentication: 'body',
+					},
+					mockState,
+				]);
+				oauthService.getBaseUrl.mockReturnValue('http://localhost:5678/rest/oauth2-credential');
+				externalHooks.run.mockResolvedValue(undefined);
+				providerQuirksService.getQuirks.mockReturnValue({
+					alwaysIncludeRedirectUri: true,
+				});
+
+				const req = mock<OAuthRequest.OAuth2Credential.Callback>({
+					query: {
+						code: 'auth_code',
+						state: validState,
+					},
+					originalUrl: '/oauth2-credential/callback?code=auth_code&state=state',
+				});
+
+				await controller.handleCallback(req, res);
+
+				// Verify redirect_uri is included in the token exchange options
+				expect(mockGetToken).toHaveBeenCalledWith(
+					expect.stringContaining('code=auth_code'),
+					expect.objectContaining({
+						body: expect.objectContaining({
+							redirect_uri: 'http://localhost:5678/rest/oauth2-credential/callback',
+							client_id: 'highlevel_client_id',
+							client_secret: 'highlevel_secret',
+						}),
+					}),
+				);
+			});
+
+			it('should classify HighLevel invalid_client error correctly', async () => {
+				const { ClientOAuth2 } = await import('@n8n/client-oauth2');
+				const errorBody = {
+					error: 'invalid_client',
+					error_description: 'Client authentication failed',
+				};
+				const mockError = new Error('Invalid client') as Error & { body: unknown; code: string };
+				mockError.body = errorBody;
+				mockError.code = 'EAUTH';
+				const mockGetToken = jest.fn().mockRejectedValue(mockError);
+				jest.mocked(ClientOAuth2).mockImplementation(
+					() =>
+						({
+							code: {
+								getToken: mockGetToken,
+							},
+						}) as any,
+				);
+
+				const mockResolvedCredential = mock<CredentialsEntity>({
+					id: '1',
+					type: 'highLevelOAuth2Api',
+				});
+				const mockState = {
+					token: 'token',
+					cid: '1',
+					userId: '123',
+					origin: 'static-credential' as const,
+					createdAt: timestamp,
+					data: 'encrypted-data',
+				};
+				oauthService.resolveCredential.mockResolvedValueOnce([
+					mockResolvedCredential,
+					{ csrfSecret: 'csrf-secret' },
+					{
+						clientId: 'client_id',
+						clientSecret: 'client_secret',
+						authUrl: 'https://marketplace.leadconnectorhq.com/oauth/chooselocation',
+						accessTokenUrl: 'https://services.leadconnectorhq.com/oauth/token',
+						scope: 'contacts.readonly',
+						grantType: 'authorizationCode',
+						authentication: 'body',
+					},
+					mockState,
+				]);
+				oauthService.getBaseUrl.mockReturnValue('http://localhost:5678/rest/oauth2-credential');
+				externalHooks.run.mockResolvedValue(undefined);
+				providerQuirksService.getQuirks.mockReturnValue({
+					alwaysIncludeRedirectUri: true,
+					classifyError: (body: unknown) => {
+						if (
+							typeof body === 'object' &&
+							body !== null &&
+							'error' in body &&
+							body.error === 'invalid_client'
+						) {
+							return {
+								type: 'invalid_client' as any,
+								userMessage:
+									'Invalid client credentials. Please verify your Client ID and Client Secret in the HighLevel app settings.',
+								technicalDetails: 'error_description' in body ? String(body.error_description) : undefined,
+							};
+						}
+						return null;
+					},
+				});
+				providerQuirksService.classifyError.mockReturnValue({
+					type: 'invalid_client' as any,
+					userMessage:
+						'Invalid client credentials. Please verify your Client ID and Client Secret in the HighLevel app settings.',
+					technicalDetails: 'Client authentication failed',
+				});
+
+				const req = mock<OAuthRequest.OAuth2Credential.Callback>({
+					query: {
+						code: 'auth_code',
+						state: validState,
+					},
+					originalUrl: '/oauth2-credential/callback?code=auth_code&state=state',
+				});
+
+				await controller.handleCallback(req, res);
+
+				expect(providerQuirksService.classifyError).toHaveBeenCalledWith(
+					'highLevelOAuth2Api',
+					errorBody,
+					undefined,
+				);
+				expect(oauthService.renderCallbackError).toHaveBeenCalledWith(
+					res,
+					'Invalid client credentials. Please verify your Client ID and Client Secret in the HighLevel app settings.',
+					'Client authentication failed',
+				);
+			});
+
+			it('should classify HighLevel redirect_uri mismatch error correctly', async () => {
+				const { ClientOAuth2 } = await import('@n8n/client-oauth2');
+				const errorBody = {
+					error: 'invalid_grant',
+					error_description: 'The redirect URI does not match',
+				};
+				const mockError = new Error('Invalid grant') as Error & { body: unknown; code: string };
+				mockError.body = errorBody;
+				mockError.code = 'EAUTH';
+				const mockGetToken = jest.fn().mockRejectedValue(mockError);
+				jest.mocked(ClientOAuth2).mockImplementation(
+					() =>
+						({
+							code: {
+								getToken: mockGetToken,
+							},
+						}) as any,
+				);
+
+				const mockResolvedCredential = mock<CredentialsEntity>({
+					id: '1',
+					type: 'highLevelOAuth2Api',
+				});
+				const mockState = {
+					token: 'token',
+					cid: '1',
+					userId: '123',
+					origin: 'static-credential' as const,
+					createdAt: timestamp,
+					data: 'encrypted-data',
+				};
+				oauthService.resolveCredential.mockResolvedValueOnce([
+					mockResolvedCredential,
+					{ csrfSecret: 'csrf-secret' },
+					{
+						clientId: 'client_id',
+						clientSecret: 'client_secret',
+						authUrl: 'https://marketplace.leadconnectorhq.com/oauth/chooselocation',
+						accessTokenUrl: 'https://services.leadconnectorhq.com/oauth/token',
+						scope: 'contacts.readonly',
+						grantType: 'authorizationCode',
+						authentication: 'body',
+					},
+					mockState,
+				]);
+				oauthService.getBaseUrl.mockReturnValue('http://localhost:5678/rest/oauth2-credential');
+				externalHooks.run.mockResolvedValue(undefined);
+				providerQuirksService.getQuirks.mockReturnValue({
+					alwaysIncludeRedirectUri: true,
+				});
+				providerQuirksService.classifyError.mockReturnValue({
+					type: 'redirect_uri_mismatch' as any,
+					userMessage:
+						'Redirect URI mismatch. The redirect URI used in the token exchange must exactly match the one used in the authorization request.',
+					technicalDetails: 'The redirect URI does not match',
+				});
+
+				const req = mock<OAuthRequest.OAuth2Credential.Callback>({
+					query: {
+						code: 'auth_code',
+						state: validState,
+					},
+					originalUrl: '/oauth2-credential/callback?code=auth_code&state=state',
+				});
+
+				await controller.handleCallback(req, res);
+
+				expect(oauthService.renderCallbackError).toHaveBeenCalledWith(
+					res,
+					'Redirect URI mismatch. The redirect URI used in the token exchange must exactly match the one used in the authorization request.',
+					'The redirect URI does not match',
+				);
+			});
 		});
 	});
 });

--- a/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
+++ b/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
@@ -12,6 +12,8 @@ import { OauthService, OauthVersion, skipAuthOnOAuthCallback } from '@/oauth/oau
 import { Logger } from '@n8n/backend-common';
 import { ExternalHooks } from '@/external-hooks';
 import type { ICredentialDataDecryptedObject } from 'n8n-workflow';
+import { OAuthProviderQuirksService } from '@/oauth/oauth-provider-quirks.service';
+import type { ClientOAuth2RequestObject } from '@n8n/client-oauth2';
 
 @RestController('/oauth2-credential')
 export class OAuth2CredentialController {
@@ -19,6 +21,7 @@ export class OAuth2CredentialController {
 		private readonly oauthService: OauthService,
 		private readonly logger: Logger,
 		private readonly externalHooks: ExternalHooks,
+		private readonly providerQuirksService: OAuthProviderQuirksService,
 	) {}
 
 	/** Get Authorization url */
@@ -37,6 +40,8 @@ export class OAuth2CredentialController {
 	/** Verify and store app code. Generate access tokens and store for respective credential */
 	@Get('/callback', { usesTemplates: true, skipAuth: skipAuthOnOAuthCallback })
 	async handleCallback(req: OAuthRequest.OAuth2Credential.Callback, res: Response) {
+		let credential: Awaited<ReturnType<typeof this.oauthService.resolveCredential>>[0] | undefined;
+		
 		try {
 			const { code, state: encodedState } = req.query;
 			if (!code || !encodedState) {
@@ -47,8 +52,9 @@ export class OAuth2CredentialController {
 				);
 			}
 
-			const [credential, decryptedDataOriginal, oauthCredentials, state] =
-				await this.oauthService.resolveCredential<OAuth2CredentialData>(req);
+			const resolvedCredential = await this.oauthService.resolveCredential<OAuth2CredentialData>(req);
+			credential = resolvedCredential[0];
+			const [, decryptedDataOriginal, oauthCredentials, state] = resolvedCredential;
 
 			let options: Partial<ClientOAuth2Options> = {};
 
@@ -74,6 +80,30 @@ export class OAuth2CredentialController {
 			const oAuthObj = new ClientOAuth2(oAuthOptions);
 
 			const queryParameters = req.originalUrl.split('?').splice(1, 1).join('');
+
+			// Log token exchange attempt for debugging
+			this.logger.debug('Attempting OAuth2 token exchange', {
+				credentialId: credential.id,
+				credentialType: credential.type,
+				accessTokenUrl: oAuthOptions.accessTokenUri,
+				redirectUri: oAuthOptions.redirectUri,
+				authentication: oauthCredentials.authentication,
+			});
+
+			// Apply provider-specific quirks before token exchange
+			const quirks = this.providerQuirksService.getQuirks(credential.type);
+			
+			// Ensure redirect_uri is included in body for providers that require it (like HighLevel)
+			// This is critical for body authentication where redirect_uri must match exactly
+			if (quirks?.alwaysIncludeRedirectUri && oAuthOptions.redirectUri) {
+				options = {
+					...options,
+					body: {
+						...(options.body ?? {}),
+						redirect_uri: oAuthOptions.redirectUri,
+					},
+				};
+			}
 
 			const oauthToken = await oAuthObj.code.getToken(
 				`${oAuthOptions.redirectUri as string}?${queryParameters}`,
@@ -125,11 +155,35 @@ export class OAuth2CredentialController {
 			}
 		} catch (e) {
 			const error = ensureError(e);
-			return this.oauthService.renderCallbackError(
-				res,
-				error.message,
-				'body' in error ? jsonStringify(error.body) : undefined,
+			const errorBody = 'body' in error ? error.body : undefined;
+			const statusCode = 'status' in error ? error.status : undefined;
+
+			// Classify error using provider-specific logic
+			const credentialType = credential?.type ?? 'unknown';
+			const classification = this.providerQuirksService.classifyError(
+				credentialType,
+				errorBody,
+				statusCode,
 			);
+
+			// Log detailed error information for debugging
+			this.logger.error('OAuth2 callback failed', {
+				credentialId: credential?.id,
+				credentialType: credentialType,
+				errorType: classification.type,
+				errorMessage: error.message,
+				errorCode: 'code' in error ? error.code : undefined,
+				errorBody: errorBody,
+				errorStack: error.stack,
+				statusCode,
+			});
+
+			// Use classified error message for user-facing error
+			const userMessage = classification.userMessage || error.message;
+			const technicalDetails = classification.technicalDetails || 
+				(errorBody ? jsonStringify(errorBody) : undefined);
+
+			return this.oauthService.renderCallbackError(res, userMessage, technicalDetails);
 		}
 	}
 

--- a/packages/cli/src/oauth/oauth-provider-quirks.service.ts
+++ b/packages/cli/src/oauth/oauth-provider-quirks.service.ts
@@ -1,0 +1,250 @@
+import type { ClientOAuth2Options, ClientOAuth2RequestObject } from '@n8n/client-oauth2';
+import type { OAuth2CredentialData } from '@n8n/client-oauth2';
+import { Logger } from '@n8n/backend-common';
+import { Service } from '@n8n/di';
+
+export enum OAuth2ErrorType {
+	INVALID_CLIENT = 'invalid_client',
+	INVALID_CODE = 'invalid_grant',
+	REDIRECT_URI_MISMATCH = 'redirect_uri_mismatch',
+	SCOPE_MISMATCH = 'invalid_scope',
+	PROVIDER_SPECIFIC = 'provider_specific',
+	UNKNOWN = 'unknown',
+}
+
+export interface OAuth2ErrorClassification {
+	type: OAuth2ErrorType;
+	userMessage: string;
+	technicalDetails?: string;
+}
+
+export interface OAuth2ProviderQuirks {
+	/**
+	 * Whether this provider requires redirect_uri in token exchange request
+	 * even when using body authentication
+	 */
+	requiresRedirectUriInTokenExchange?: boolean;
+
+	/**
+	 * Whether to include redirect_uri even if authentication is 'body'
+	 */
+	alwaysIncludeRedirectUri?: boolean;
+
+	/**
+	 * Custom headers to add to token exchange request
+	 */
+	customHeaders?: Record<string, string>;
+
+	/**
+	 * Transform the token exchange request body
+	 */
+	transformTokenExchangeBody?: (
+		body: Record<string, unknown>,
+		options: ClientOAuth2Options,
+	) => Record<string, unknown>;
+
+	/**
+	 * Classify OAuth errors from this provider
+	 */
+	classifyError?: (errorBody: unknown, statusCode?: number) => OAuth2ErrorClassification | null;
+}
+
+@Service()
+export class OAuthProviderQuirksService {
+	private readonly quirks: Map<string, OAuth2ProviderQuirks> = new Map();
+
+	constructor(private readonly logger: Logger) {
+		this.registerHighLevelQuirks();
+	}
+
+	private registerHighLevelQuirks(): void {
+		this.quirks.set('highLevelOAuth2Api', {
+			requiresRedirectUriInTokenExchange: true,
+			alwaysIncludeRedirectUri: true,
+			classifyError: (errorBody: unknown, statusCode?: number): OAuth2ErrorClassification | null => {
+				if (typeof errorBody !== 'object' || errorBody === null) {
+					return null;
+				}
+
+				const body = errorBody as Record<string, unknown>;
+				const error = body.error as string | undefined;
+				const errorDescription = body.error_description as string | undefined;
+
+				if (error === 'invalid_client') {
+					return {
+						type: OAuth2ErrorType.INVALID_CLIENT,
+						userMessage:
+							'Invalid client credentials. Please verify your Client ID and Client Secret in the HighLevel app settings.',
+						technicalDetails: errorDescription,
+					};
+				}
+
+				if (error === 'invalid_grant') {
+					// Check if it's a redirect URI mismatch
+					if (
+						errorDescription?.toLowerCase().includes('redirect') ||
+						errorDescription?.toLowerCase().includes('uri')
+					) {
+						return {
+							type: OAuth2ErrorType.REDIRECT_URI_MISMATCH,
+							userMessage:
+								'Redirect URI mismatch. The redirect URI used in the token exchange must exactly match the one used in the authorization request.',
+							technicalDetails: errorDescription,
+						};
+					}
+
+					return {
+						type: OAuth2ErrorType.INVALID_CODE,
+						userMessage:
+							'Invalid or expired authorization code. Please try connecting your HighLevel credentials again.',
+						technicalDetails: errorDescription,
+					};
+				}
+
+				if (error === 'invalid_scope') {
+					return {
+						type: OAuth2ErrorType.SCOPE_MISMATCH,
+						userMessage:
+							'Invalid scopes. Please verify that the requested scopes are enabled in your HighLevel app settings.',
+						technicalDetails: errorDescription,
+					};
+				}
+
+				if (error) {
+					return {
+						type: OAuth2ErrorType.PROVIDER_SPECIFIC,
+						userMessage: errorDescription || `HighLevel API error: ${error}`,
+						technicalDetails: errorDescription || String(error),
+					};
+				}
+
+				return null;
+			},
+		});
+	}
+
+	getQuirks(credentialType: string): OAuth2ProviderQuirks | undefined {
+		return this.quirks.get(credentialType);
+	}
+
+	/**
+	 * Apply provider-specific quirks to token exchange request
+	 */
+	applyTokenExchangeQuirks(
+		credentialType: string,
+		requestOptions: ClientOAuth2RequestObject,
+		oAuthOptions: ClientOAuth2Options,
+	): ClientOAuth2RequestObject {
+		const quirks = this.getQuirks(credentialType);
+		if (!quirks) {
+			return requestOptions;
+		}
+
+		const modifiedOptions = { ...requestOptions };
+
+		// Apply custom headers
+		if (quirks.customHeaders) {
+			modifiedOptions.headers = {
+				...modifiedOptions.headers,
+				...quirks.customHeaders,
+			};
+		}
+
+		// Transform body if needed
+		if (quirks.transformTokenExchangeBody && modifiedOptions.body) {
+			modifiedOptions.body = quirks.transformTokenExchangeBody(
+				modifiedOptions.body,
+				oAuthOptions,
+			);
+		}
+
+		// Ensure redirect_uri is included if required
+		if (
+			quirks.alwaysIncludeRedirectUri &&
+			oAuthOptions.redirectUri &&
+			modifiedOptions.body &&
+			!modifiedOptions.body.redirect_uri
+		) {
+			modifiedOptions.body = {
+				...modifiedOptions.body,
+				redirect_uri: oAuthOptions.redirectUri,
+			};
+		}
+
+		return modifiedOptions;
+	}
+
+	/**
+	 * Classify an OAuth error based on provider-specific logic
+	 */
+	classifyError(
+		credentialType: string,
+		errorBody: unknown,
+		statusCode?: number,
+	): OAuth2ErrorClassification {
+		const quirks = this.getQuirks(credentialType);
+
+		if (quirks?.classifyError) {
+			const classification = quirks.classifyError(errorBody, statusCode);
+			if (classification) {
+				return classification;
+			}
+		}
+
+		// Fallback to generic classification
+		return this.classifyGenericError(errorBody, statusCode);
+	}
+
+	private classifyGenericError(
+		errorBody: unknown,
+		statusCode?: number,
+	): OAuth2ErrorClassification {
+		if (typeof errorBody === 'object' && errorBody !== null) {
+			const body = errorBody as Record<string, unknown>;
+			const error = body.error as string | undefined;
+			const errorDescription = body.error_description as string | undefined;
+
+			if (error === 'invalid_client') {
+				return {
+					type: OAuth2ErrorType.INVALID_CLIENT,
+					userMessage: 'Invalid client credentials.',
+					technicalDetails: errorDescription,
+				};
+			}
+
+			if (error === 'invalid_grant') {
+				return {
+					type: OAuth2ErrorType.INVALID_CODE,
+					userMessage: 'Invalid or expired authorization code.',
+					technicalDetails: errorDescription,
+				};
+			}
+
+			if (error === 'invalid_scope') {
+				return {
+					type: OAuth2ErrorType.SCOPE_MISMATCH,
+					userMessage: 'Invalid scopes requested.',
+					technicalDetails: errorDescription,
+				};
+			}
+
+			if (error) {
+				return {
+					type: OAuth2ErrorType.PROVIDER_SPECIFIC,
+					userMessage: errorDescription || `OAuth error: ${error}`,
+					technicalDetails: errorDescription || String(error),
+				};
+			}
+		}
+
+		return {
+			type: OAuth2ErrorType.UNKNOWN,
+			userMessage: statusCode === 401
+				? 'Authentication failed. Please check your credentials.'
+				: statusCode === 400
+					? 'Invalid request. Please verify your OAuth configuration.'
+					: 'An error occurred during OAuth authentication.',
+			technicalDetails: typeof errorBody === 'string' ? errorBody : JSON.stringify(errorBody),
+		};
+	}
+}


### PR DESCRIPTION
## Summary

Root cause
HighLevel OAuth2 requires redirect_uri in the token exchange request body even when using body authentication. The generic OAuth2 flow didn't include it, causing token exchange to fail.
Implementation
1. Provider-aware OAuth handling
Created OAuthProviderQuirksService to centralize provider-specific quirks
Registered HighLevel-specific requirements:
alwaysIncludeRedirectUri: true — ensures redirect_uri is in the token exchange body
Error classification for HighLevel-specific errors

2. Fixed token exchange request
Updated code-flow.ts to respect authentication: 'body' and avoid adding Authorization header
Controller ensures redirect_uri is included in the body for HighLevel before token exchange
Preserves exact redirect_uri matching required by HighLevel

3. Error classification
Added OAuth2ErrorType enum for structured error types
HighLevel-specific error classification:
invalid_client → user-friendly message about verifying credentials
invalid_grant with redirect URI mention → redirect URI mismatch message
invalid_scope → scope verification message
Falls back to generic classification for other providers

4. Centralized provider quirks
OAuthProviderQuirksService is extensible
Easy to add quirks for other providers
No hardcoded logic in the controller

5. Tests
Test for HighLevel token exchange with redirect_uri in body
Test for invalid_client error classification
Test for redirect URI mismatch error classification
All tests verify correct request shape and error mapping
## Related Linear tickets, Github issues, and Community forum posts

FIxed PR#24073   https://github.com/n8n-io/n8n/issues/24073


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
