### PR TITLE
ci: Skip e2e tests on private repository

### DIFF
--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -90,7 +90,7 @@ jobs:
   e2e-tests:
     name: E2E Tests
     needs: install-and-build
-    if: needs.install-and-build.outputs.non_python_changed == 'true'
+    if: needs.install-and-build.outputs.non_python_changed == 'true' && github.repository == 'n8n-io/n8n'
     uses: ./.github/workflows/test-e2e-ci-reusable.yml
     with:
       branch: ${{ needs.install-and-build.outputs.commit_sha }}
@@ -126,7 +126,7 @@ jobs:
             needs.unit-test.result == 'skipped' ||
             needs.typecheck.result == 'skipped' ||
             needs.lint.result == 'skipped' ||
-            needs.e2e-tests.result == 'skipped'
+            (needs.e2e-tests.result == 'skipped' && github.repository == 'n8n-io/n8n')
           )) ||
           (needs.install-and-build.outputs.workflows_changed == 'true' &&
             needs.security-checks.result == 'skipped')


### PR DESCRIPTION
The e2e workflow pushes to `ghcr.io/n8n-io/runners` but the private repo's token [lacks write access](https://github.com/n8n-io/n8n-private/actions/runs/21756650573/job/62769128851) and linking it would expose security images. Since we run e2e anyway on merge, let's skip it on the private side.