### PR TITLE
fix(editor): Show conflicts modal for autosave (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/stores/workflowAutosave.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowAutosave.store.ts
@@ -16,6 +16,7 @@ export const useWorkflowAutosaveStore = defineStore('workflowAutosave', () => {
 	const retryDelay = ref(RETRY_START_DELAY);
 	const isRetrying = ref(false);
 	const lastError = ref<string | null>(null);
+	const conflictModalShown = ref(false);
 
 	function setAutoSaveState(state: AutoSaveState) {
 		autoSaveState.value = state;
@@ -42,11 +43,16 @@ export const useWorkflowAutosaveStore = defineStore('workflowAutosave', () => {
 		lastError.value = error;
 	}
 
+	function setConflictModalShown(value: boolean) {
+		conflictModalShown.value = value;
+	}
+
 	function resetRetry() {
 		retryCount.value = 0;
 		retryDelay.value = RETRY_START_DELAY;
 		isRetrying.value = false;
 		lastError.value = null;
+		conflictModalShown.value = false;
 	}
 
 	function reset() {
@@ -62,12 +68,14 @@ export const useWorkflowAutosaveStore = defineStore('workflowAutosave', () => {
 		retryDelay,
 		isRetrying,
 		lastError,
+		conflictModalShown,
 		setAutoSaveState,
 		setPendingAutoSave,
 		incrementRetry,
 		getRetryDelay,
 		setRetrying,
 		setLastError,
+		setConflictModalShown,
 		resetRetry,
 		reset,
 	};


### PR DESCRIPTION
## Summary

When the backoff mechanism was introduced, the conflict check was moved to run after the autosave error check, which caused the conflicts modal to stop appearing. This PR moves the conflict check back to the correct place.

<img height="200" alt="image" src="https://github.com/user-attachments/assets/591567a5-30cf-41e4-a505-18da3e16dc42" />

Additionally, when a user clicks Cancel, they should be able to continue exploring the workflow without the modal popping up again. To support this, I introduced a state variable to track whether the modal has already been shown.

At the same time, we don’t want users to miss the fact that autosave is no longer working, so autosave error toasts will continue to be shown, using the existing backoff mechanism.

### How to test

- Open a workflow in two different tabs
- Edit workflow in one tab (I usually just drag the position of a node)
- Go to the other tab and edit workflow
- See the conflicts modal

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-4774](https://linear.app/n8n/issue/ADO-4774/bug-conflicts-modal-is-not-shown-anymore)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
