### PR TITLE
fix(core): Fix markdown rendering issue at streamed Chat hub responses

### DIFF
--- a/packages/@n8n/chat-hub/src/parser.test.ts
+++ b/packages/@n8n/chat-hub/src/parser.test.ts
@@ -132,6 +132,14 @@ describe(appendChunkToParsedMessageItems, () => {
 		expect(result).toEqual([{ type: 'text', content: 'hello world' }]);
 	});
 
+	it('should preserve whitespace-only chunks like newlines', () => {
+		let items: ChatMessageContentChunk[] = [];
+		items = appendChunkToParsedMessageItems(items, '## Hi');
+		items = appendChunkToParsedMessageItems(items, '\n\n');
+		items = appendChunkToParsedMessageItems(items, 'Thanks');
+		expect(items).toEqual([{ type: 'text', content: '## Hi\n\nThanks' }]);
+	});
+
 	describe('with-buttons JSON parsing', () => {
 		it('should parse valid with-buttons JSON', () => {
 			const json = JSON.stringify({
@@ -415,9 +423,10 @@ describe(appendChunkToParsedMessageItems, () => {
 </command:artifact-edit>`;
 
 		const result = appendChunkToParsedMessageItems([], content);
-		expect(result).toHaveLength(2);
+		expect(result).toHaveLength(3);
 		expect(result[0].type).toBe('artifact-create');
-		expect(result[1].type).toBe('artifact-edit');
+		expect(result[1]).toEqual({ type: 'text', content: '\n' });
+		expect(result[2].type).toBe('artifact-edit');
 	});
 
 	it('should handle streaming scenario with text before command', () => {

--- a/packages/@n8n/chat-hub/src/parser.ts
+++ b/packages/@n8n/chat-hub/src/parser.ts
@@ -115,8 +115,8 @@ export function appendChunkToParsedMessageItems(
 }
 
 function addTextToResult(result: ChatMessageContentChunk[], textContent: string): void {
-	// Skip empty or whitespace-only text
-	if (textContent.trim() === '') {
+	// Skip empty text (but preserve whitespace like newlines, which are meaningful in markdown)
+	if (textContent === '') {
 		return;
 	}
 


### PR DESCRIPTION
## Summary

Recent refactoring / support for artifacts broke chunked markdown rendering, as we accidentally started trimming newlines from messages, which are meaningful in markdown.

Just trimming empty strings is the correct behavior.

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C09JFRUU7GC/p1770400797701459

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
