### PR TITLE
feat(Webhook node): return "method" in "INodeExecutionData"

### DIFF
--- a/packages/nodes-base/nodes/Webhook/Webhook.node.ts
+++ b/packages/nodes-base/nodes/Webhook/Webhook.node.ts
@@ -266,6 +266,7 @@ export class Webhook extends Node {
 
 		const response: INodeExecutionData = {
 			json: {
+				method: requestMethod,
 				headers: req.headers,
 				params: req.params,
 				query: req.query,
@@ -326,6 +327,7 @@ export class Webhook extends Node {
 
 			const returnItem: INodeExecutionData = {
 				json: {
+					method: req.method,
 					headers: req.headers,
 					params: req.params,
 					query: req.query,


### PR DESCRIPTION
## Summary

This PR adds the HTTP `method` (GET, POST, PUT, etc.) to the JSON output of the Webhook node.

**Why is this needed?**
Previously, when a user enabled "Allow Multiple HTTP Methods," it was difficult to determine which method was used to call the webhook. This change provides the method as a top-level property in the output JSON, making it easier to use in subsequent `If` or `Switch` nodes to branch workflow logic based on the request type.

**Changes:**

* Modified the `webhook` method to include the `method` property in the standard JSON output.
* Modified the `handleBinaryData` method to include the `method` property when the request contains binary data.

**How to test:**

1. Create a new workflow with a **Webhook** node.
2. In the node settings, toggle **Allow Multiple HTTP Methods** and select `GET`, `POST`, and `DELETE`.
3. Trigger the **Test URL** using a tool like Postman or cURL:
* `curl -X POST https://your-n8n-instance/webhook-test/path`


4. Verify that the output JSON now includes a `"method": "POST"` field.
5. Repeat with other methods to ensure they are captured correctly.

## Related Linear tickets, Github issues, and Community forum posts

Resolves: N/A (Feature enhancement)

## Review / Merge checklist

* [x] PR title and summary are descriptive.
* [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
* [ ] Tests included.
* [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
