### PR TITLE
fix(cli): skip non-existent tables during export:entities

### DIFF
--- a/packages/cli/src/services/__tests__/export.service.test.ts
+++ b/packages/cli/src/services/__tests__/export.service.test.ts
@@ -280,6 +280,56 @@ describe('ExportService', () => {
 
 			await expect(exportService.exportEntities(outputDir)).rejects.toThrow('Permission denied');
 		});
+
+		it('should skip tables that do not exist in the database', async () => {
+			const outputDir = '/test/output';
+
+			// Mock DataSource with entities including one that doesn't exist in DB
+			// @ts-expect-error Accessing private property for testing
+			mockDataSource.entityMetadatas = [
+				{
+					name: 'User',
+					tableName: 'user',
+					columns: [{ databaseName: 'id' }, { databaseName: 'email' }],
+				},
+				{
+					name: 'SecretsProviderConnection',
+					tableName: 'secrets_provider_connection',
+					columns: [{ databaseName: 'id' }, { databaseName: 'providerKey' }],
+				},
+			];
+
+			let queryCount = 0;
+			jest.mocked(mockDataSource.query).mockImplementation(async (query: string) => {
+				queryCount++;
+				// Migrations table doesn't exist
+				if (query.includes('migrations')) {
+					throw new Error('Table not found');
+				}
+				// User table exists and has no data
+				if (query.includes('user') && query.includes('SELECT 1')) {
+					return [{ '1': 1 }];
+				}
+				if (query.includes('user')) {
+					return [];
+				}
+				// secrets_provider_connection table doesn't exist
+				if (query.includes('secrets_provider_connection')) {
+					throw new Error('relation "secrets_provider_connection" does not exist');
+				}
+				return [];
+			});
+			jest.mocked(readdir).mockResolvedValue([]);
+
+			await exportService.exportEntities(outputDir);
+
+			// Should log warning about missing table
+			expect(mockLogger.info).toHaveBeenCalledWith(
+				'   ⚠️  Table secrets_provider_connection does not exist in the database, skipping...',
+			);
+			// Should complete successfully
+			expect(mockLogger.info).toHaveBeenCalledWith('✅ Task completed successfully! \n');
+		});
 	});
 
 	describe('clearExistingEntityFiles', () => {

--- a/packages/cli/src/services/export.service.ts
+++ b/packages/cli/src/services/export.service.ts
@@ -148,13 +148,24 @@ export class ExportService {
 
 			this.logger.info(`\n📊 Processing table: ${tableName} (${entityName})`);
 
-			// Clear existing files for this entity
-			await this.clearExistingEntityFiles(outputDir, entityName);
-
 			// Get column information for this table
 			const columnNames = metadata.columns.map((col) => col.databaseName);
 			const columns = columnNames.map(this.dataSource.driver.escape).join(', ');
 			this.logger.info(`   💭 Columns: ${columnNames.join(', ')}`);
+
+			// Check if the table exists before attempting to export
+			const formattedTableName = this.dataSource.driver.escape(tableName);
+			try {
+				await this.dataSource.query(`SELECT 1 FROM ${formattedTableName} LIMIT 1`);
+			} catch {
+				this.logger.info(
+					`   ⚠️  Table ${tableName} does not exist in the database, skipping...`,
+				);
+				continue;
+			}
+
+			// Clear existing files for this entity
+			await this.clearExistingEntityFiles(outputDir, entityName);
 
 			let offset = 0;
 			let totalEntityCount = 0;
@@ -167,7 +178,6 @@ export class ExportService {
 				 * use raw SQL query to avoid typeorm limitations,
 				 * typeorm repositories do not return joining table entries
 				 */
-				const formattedTableName = this.dataSource.driver.escape(tableName);
 				const pageEntities = await this.dataSource.query(
 					`SELECT ${columns} FROM ${formattedTableName} LIMIT ${pageSize} OFFSET ${offset}`,
 				);


### PR DESCRIPTION
## Summary

Fixes #25345

The `export:entities` command crashes with "relation does not exist" when a table defined in entity metadata doesn't exist in the database. This happens with the `secrets_provider_connection` table which is only created for enterprise mode but is registered in entity metadata.

## Changes

- Add table existence check (`SELECT 1 FROM table LIMIT 1`) before attempting to export each table
- Log a warning message and continue to the next table when a table doesn't exist
- Add test case for missing table handling

This follows the same pattern already used for the migrations table export in the same file, which handles missing tables gracefully.

## Before
```
📊 Processing table: secrets_provider_connection (secretsproviderconnection)
   💭 Columns: updatedAt, createdAt, providerKey, type, encryptedSettings, isEnabled
❌ Error exporting entities. See log messages for details. 
relation "secrets_provider_connection" does not exist 
```

## After
```
📊 Processing table: secrets_provider_connection (secretsproviderconnection)
   💭 Columns: updatedAt, createdAt, providerKey, type, encryptedSettings, isEnabled
   ⚠️  Table secrets_provider_connection does not exist in the database, skipping...
```