### PR TITLE
feat(editor): Show execution data in preview

### DIFF
--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -101,7 +101,6 @@ import { useNpsSurveyStore } from '@/app/stores/npsSurvey.store';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
-import { useExecutionDebugging } from '@/features/execution/executions/composables/useExecutionDebugging';
 import { buildExecutionResponseFromSchema } from '@/features/execution/executions/executions.utils';
 import type { ExecutionPreviewNodeSchema } from '@/features/execution/executions/executions.types';
 import { useUsersStore } from '@/features/settings/users/users.store';

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -83,6 +83,7 @@ import type {
 	NodeConnectionType,
 	IDataObject,
 	ExecutionSummary,
+	ExecutionStatus,
 	IConnection,
 	INodeParameters,
 } from 'n8n-workflow';
@@ -100,6 +101,9 @@ import { useNpsSurveyStore } from '@/app/stores/npsSurvey.store';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
+import { useExecutionDebugging } from '@/features/execution/executions/composables/useExecutionDebugging';
+import { buildExecutionResponseFromSchema } from '@/features/execution/executions/executions.utils';
+import type { ExecutionPreviewNodeSchema } from '@/features/execution/executions/executions.types';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import { sourceControlEventBus } from '@/features/integrations/sourceControl.ee/sourceControl.eventBus';
 import { useTagsStore } from '@/features/shared/tags/tags.store';
@@ -1151,6 +1155,45 @@ async function onOpenExecution(executionId: string, nodeId?: string) {
 	});
 }
 
+async function onOpenExecutionPreview(json: {
+	workflow: IWorkflowDb;
+	nodeExecutionSchema: Record<string, ExecutionPreviewNodeSchema>;
+	executionStatus: ExecutionStatus;
+	executionError?: { message: string; description?: string; name?: string; stack?: string };
+	lastNodeExecuted?: string;
+	projectId?: string;
+}) {
+	canvasStore.startLoading();
+
+	const workflow = json.workflow;
+	if (!workflow?.nodes || !workflow?.connections) {
+		canvasStore.stopLoading();
+		throw new Error('Invalid workflow object');
+	}
+
+	if (json.projectId) {
+		await projectsStore.fetchAndSetProject(json.projectId);
+	}
+
+	const data = buildExecutionResponseFromSchema({
+		workflow,
+		nodeExecutionSchema: json.nodeExecutionSchema,
+		executionStatus: json.executionStatus,
+		executionError: json.executionError,
+		lastNodeExecuted: json.lastNodeExecuted,
+	});
+
+	// importWorkflowExact handles resetWorkspace, initializeData, and fitView
+	await importWorkflowExact(json);
+
+	workflowState.setWorkflowExecutionData(data);
+	workflowState.setWorkflowPinData({});
+
+	canvasStore.stopLoading();
+
+	canvasEventBus.emit('open:execution', data);
+}
+
 function onExecutionOpenedWithError(data: IExecutionResponse) {
 	if (!data.finished && data.data?.resultData?.error) {
 		// Check if any node contains an error
@@ -1403,6 +1446,28 @@ async function onPostMessageReceived(messageEvent: MessageEvent) {
 
 				await onOpenExecution(json.executionId, json.nodeId);
 				canOpenNDV.value = json.canOpenNDV ?? true;
+				hideNodeIssues.value = json.hideNodeIssues ?? false;
+				isExecutionPreview.value = true;
+			} catch (e) {
+				if (window.top) {
+					window.top.postMessage(
+						JSON.stringify({
+							command: 'error',
+							message: i18n.baseText('nodeView.showError.openExecution.title'),
+						}),
+						'*',
+					);
+				}
+				toast.showMessage({
+					title: i18n.baseText('nodeView.showError.openExecution.title'),
+					message: (e as Error).message,
+					type: 'error',
+				});
+			}
+		} else if (json && json.command === 'openExecutionPreview') {
+			try {
+				await onOpenExecutionPreview(json);
+				canOpenNDV.value = json.canOpenNDV ?? false;
 				hideNodeIssues.value = json.hideNodeIssues ?? false;
 				isExecutionPreview.value = true;
 			} catch (e) {

--- a/packages/frontend/editor-ui/src/features/execution/executions/executions.types.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/executions.types.ts
@@ -106,3 +106,28 @@ export interface IExecutionDeleteFilter {
 	filters?: ExecutionsQueryFilter;
 	ids?: string[];
 }
+
+export interface ExecutionPreviewSchemaField {
+	name: string;
+	type: 'string' | 'number' | 'boolean' | 'object' | 'array';
+	fields?: ExecutionPreviewSchemaField[];
+	itemSchema?: ExecutionPreviewSchemaField[];
+}
+
+export interface ExecutionPreviewOutputSchema {
+	itemCount?: number;
+	fields: ExecutionPreviewSchemaField[];
+}
+
+export interface ExecutionPreviewNodeSchema {
+	executionStatus: ExecutionStatus;
+	executionTime?: number;
+	error?: {
+		message: string;
+		description?: string;
+		name?: string;
+		stack?: string;
+		node?: { name: string; type: string };
+	};
+	outputSchema?: ExecutionPreviewOutputSchema;
+}


### PR DESCRIPTION
## Summary
Adds a new openExecutionPreview postMessage command that lets a parent window render a workflow canvas with per-node execution status indicators (success/error/canceled) without shipping actual execution output data. 
The utility function buildExecutionResponseFromSchema constructs a synthetic IExecutionResponse from a lightweight schema.


## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-1675/feature-load-workflow-preview-with-execution-data-loaded-and-error


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
