### PR TITLE
refactor(editor): Move enforce MFA toggle from Users to Security settings page

### DIFF
--- a/packages/frontend/editor-ui/src/app/router.test.ts
+++ b/packages/frontend/editor-ui/src/app/router.test.ts
@@ -33,11 +33,6 @@ describe('router', () => {
 	beforeEach(() => {
 		settingsStore = useSettingsStore();
 		const usersStore = useUsersStore();
-		// Enable PERSONAL_SECURITY_SETTINGS so /settings/security route's custom middleware passes
-		settingsStore.settings.envFeatureFlags = {
-			...settingsStore.settings.envFeatureFlags,
-			N8N_ENV_FEAT_PERSONAL_SECURITY_SETTINGS: 'true',
-		};
 		initializeAuthenticatedFeaturesSpy.mockImplementation(async () => {
 			await usersStore.initialize();
 		});

--- a/packages/frontend/editor-ui/src/app/router.ts
+++ b/packages/frontend/editor-ui/src/app/router.ts
@@ -605,12 +605,8 @@ export const routes: RouteRecordRaw[] = [
 				name: VIEWS.SECURITY_SETTINGS,
 				component: SecuritySettingsView,
 				meta: {
-					middleware: ['authenticated', 'custom', 'rbac'],
+					middleware: ['authenticated', 'rbac'],
 					middlewareOptions: {
-						custom: () => {
-							const { check } = useEnvFeatureFlag();
-							return check.value('PERSONAL_SECURITY_SETTINGS');
-						},
 						rbac: {
 							scope: ['securitySettings:manage'],
 						},

--- a/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.test.ts
@@ -63,6 +63,12 @@ describe('SecuritySettings', () => {
 		settingsStore.isMFAEnforced = false;
 		settingsStore.isEnterpriseFeatureEnabled[EnterpriseEditionFeature.EnforceMFA] = true;
 		usersStore.updateEnforceMfa = vi.fn().mockResolvedValue(undefined);
+
+		// Enable PERSONAL_SECURITY_SETTINGS env feature flag for Personal Space section
+		settingsStore.settings.envFeatureFlags = {
+			...settingsStore.settings.envFeatureFlags,
+			N8N_ENV_FEAT_PERSONAL_SECURITY_SETTINGS: 'true',
+		};
 	});
 
 	it('should render security heading and personal space section', async () => {
@@ -267,6 +273,22 @@ describe('SecuritySettings', () => {
 		});
 
 		expect(getByTestId('security-sharing-count')).toHaveTextContent('Existing shares');
+	});
+
+	it('should hide personal space section when PERSONAL_SECURITY_SETTINGS flag is disabled', async () => {
+		settingsStore.settings.envFeatureFlags = {
+			...settingsStore.settings.envFeatureFlags,
+			N8N_ENV_FEAT_PERSONAL_SECURITY_SETTINGS: 'false',
+		};
+
+		const { getByText, queryByText, getByTestId } = renderView();
+
+		await waitFor(() => {
+			expect(getByTestId('enable-force-mfa')).toBeInTheDocument();
+		});
+
+		expect(getByText('Security')).toBeInTheDocument();
+		expect(queryByText('Personal Space')).not.toBeInTheDocument();
 	});
 
 	it('should render the enforce MFA toggle', async () => {

--- a/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.test.ts
@@ -2,8 +2,11 @@ import { createTestingPinia } from '@pinia/testing';
 import { waitFor } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import { createComponentRenderer } from '@/__tests__/render';
+import { mockedStore } from '@/__tests__/utils';
 import SecuritySettings from './SecuritySettings.vue';
-import { MODAL_CONFIRM } from '@/app/constants/modals';
+import { EnterpriseEditionFeature, MODAL_CONFIRM } from '@/app/constants';
+import { useSettingsStore } from '@/app/stores/settings.store';
+import { useUsersStore } from '@/features/settings/users/users.store';
 
 const getSecuritySettings = vi.fn();
 const updateSecuritySettings = vi.fn();
@@ -28,8 +31,14 @@ vi.mock('@n8n/stores/useRootStore', () => ({
 	useRootStore: () => ({ restApiContext: {} }),
 }));
 
+vi.mock('@/app/composables/usePageRedirectionHelper', () => ({
+	usePageRedirectionHelper: () => ({ goToUpgrade: vi.fn() }),
+}));
+
+const pinia = createTestingPinia();
+
 const renderView = createComponentRenderer(SecuritySettings, {
-	pinia: createTestingPinia(),
+	pinia,
 });
 
 describe('SecuritySettings', () => {
@@ -41,9 +50,19 @@ describe('SecuritySettings', () => {
 		sharedPersonalCredentialsCount: 5,
 	};
 
+	let settingsStore: ReturnType<typeof mockedStore<typeof useSettingsStore>>;
+	let usersStore: ReturnType<typeof mockedStore<typeof useUsersStore>>;
+
 	beforeEach(() => {
 		vi.clearAllMocks();
 		getSecuritySettings.mockResolvedValue(defaultSettings);
+
+		settingsStore = mockedStore(useSettingsStore);
+		usersStore = mockedStore(useUsersStore);
+
+		settingsStore.isMFAEnforced = false;
+		settingsStore.isEnterpriseFeatureEnabled[EnterpriseEditionFeature.EnforceMFA] = true;
+		usersStore.updateEnforceMfa = vi.fn().mockResolvedValue(undefined);
 	});
 
 	it('should render security heading and personal space section', async () => {
@@ -248,5 +267,76 @@ describe('SecuritySettings', () => {
 		});
 
 		expect(getByTestId('security-sharing-count')).toHaveTextContent('Existing shares');
+	});
+
+	it('should render the enforce MFA toggle', async () => {
+		const { getByTestId } = renderView();
+
+		await waitFor(() => {
+			expect(getByTestId('enable-force-mfa')).toBeInTheDocument();
+		});
+	});
+
+	it('should turn enforcing MFA on', async () => {
+		const { getByTestId } = renderView();
+
+		await waitFor(() => {
+			expect(getByTestId('enable-force-mfa')).toBeInTheDocument();
+		});
+
+		const actionSwitch = getByTestId('enable-force-mfa');
+		await userEvent.click(actionSwitch);
+
+		expect(usersStore.updateEnforceMfa).toHaveBeenCalledWith(true);
+	});
+
+	it('should turn enforcing MFA off', async () => {
+		settingsStore.isMFAEnforced = true;
+		const { getByTestId } = renderView();
+
+		await waitFor(() => {
+			expect(getByTestId('enable-force-mfa')).toBeInTheDocument();
+		});
+
+		const actionSwitch = getByTestId('enable-force-mfa');
+		await userEvent.click(actionSwitch);
+
+		expect(usersStore.updateEnforceMfa).toHaveBeenCalledWith(false);
+	});
+
+	it('should show success toast when enabling MFA enforcement', async () => {
+		const { getByTestId } = renderView();
+
+		await waitFor(() => {
+			expect(getByTestId('enable-force-mfa')).toBeInTheDocument();
+		});
+
+		const actionSwitch = getByTestId('enable-force-mfa');
+		await userEvent.click(actionSwitch);
+
+		await waitFor(() => {
+			expect(showToast).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: 'success',
+				}),
+			);
+		});
+	});
+
+	it('should show error toast when MFA enforcement update fails', async () => {
+		usersStore.updateEnforceMfa = vi.fn().mockRejectedValue(new Error('MFA update failed'));
+
+		const { getByTestId } = renderView();
+
+		await waitFor(() => {
+			expect(getByTestId('enable-force-mfa')).toBeInTheDocument();
+		});
+
+		const actionSwitch = getByTestId('enable-force-mfa');
+		await userEvent.click(actionSwitch);
+
+		await waitFor(() => {
+			expect(showError).toHaveBeenCalledWith(expect.any(Error), expect.any(String));
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.vue
+++ b/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.vue
@@ -2,19 +2,55 @@
 import { computed, useCssModule } from 'vue';
 import { useAsyncState } from '@vueuse/core';
 import { ElSwitch } from 'element-plus';
-import { N8nHeading, N8nText } from '@n8n/design-system';
+import { I18nT } from 'vue-i18n';
+import { N8nBadge, N8nHeading, N8nText, N8nTooltip } from '@n8n/design-system';
 import { useI18n, type BaseTextKey } from '@n8n/i18n';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useToast } from '@/app/composables/useToast';
 import * as securitySettingsApi from '@n8n/rest-api-client/api/security-settings';
 import { useMessage } from '@/app/composables/useMessage';
-import { MODAL_CONFIRM } from '@/app/constants/modals';
+import { EnterpriseEditionFeature, MODAL_CONFIRM } from '@/app/constants';
+import EnterpriseEdition from '@/app/components/EnterpriseEdition.ee.vue';
+import { useSettingsStore } from '@/app/stores/settings.store';
+import { useUsersStore } from '@/features/settings/users/users.store';
+import { usePageRedirectionHelper } from '@/app/composables/usePageRedirectionHelper';
 
 const $style = useCssModule();
 const rootStore = useRootStore();
+const settingsStore = useSettingsStore();
+const usersStore = useUsersStore();
 const i18n = useI18n();
 const { showToast, showError } = useToast();
 const message = useMessage();
+const pageRedirectionHelper = usePageRedirectionHelper();
+
+const tooltipKey = 'settings.personal.mfa.enforce.unlicensed_tooltip';
+
+const isEnforceMFAEnabled = computed(
+	() => settingsStore.isEnterpriseFeatureEnabled[EnterpriseEditionFeature.EnforceMFA],
+);
+
+async function onUpdateMfaEnforced(value: string | number | boolean) {
+	const boolValue = typeof value === 'boolean' ? value : Boolean(value);
+	try {
+		await usersStore.updateEnforceMfa(boolValue);
+		showToast({
+			type: 'success',
+			title: boolValue
+				? i18n.baseText('settings.personal.mfa.enforce.enabled.title')
+				: i18n.baseText('settings.personal.mfa.enforce.disabled.title'),
+			message: boolValue
+				? i18n.baseText('settings.personal.mfa.enforce.enabled.message')
+				: i18n.baseText('settings.personal.mfa.enforce.disabled.message'),
+		});
+	} catch (error) {
+		showError(error, i18n.baseText('settings.personal.mfa.enforce.error'));
+	}
+}
+
+function goToUpgrade() {
+	void pageRedirectionHelper.goToUpgrade('settings-users', 'upgrade-users');
+}
 
 const { state, isLoading } = useAsyncState(async () => {
 	const settings = await securitySettingsApi.getSecuritySettings(rootStore.restApiContext);
@@ -117,6 +153,54 @@ const sharingCountText = computed(() => {
 		<N8nHeading tag="h1" size="2xlarge" class="mb-xl">
 			{{ i18n.baseText('settings.security') }}
 		</N8nHeading>
+
+		<N8nHeading tag="h2" size="large" class="mb-l">
+			{{ i18n.baseText('settings.personal.mfa.enforce.title') }}
+		</N8nHeading>
+
+		<div :class="$style.settingsSection">
+			<div :class="$style.settingsContainer">
+				<div :class="$style.settingsContainerInfo">
+					<N8nText :bold="true"
+						>{{ i18n.baseText('settings.personal.mfa.enforce.title') }}
+						<N8nBadge v-if="!isEnforceMFAEnabled" class="ml-4xs">{{
+							i18n.baseText('generic.upgrade')
+						}}</N8nBadge>
+					</N8nText>
+					<N8nText size="small" color="text-light">{{
+						i18n.baseText('settings.personal.mfa.enforce.message')
+					}}</N8nText>
+				</div>
+				<div :class="$style.settingsContainerAction">
+					<EnterpriseEdition :features="[EnterpriseEditionFeature.EnforceMFA]">
+						<ElSwitch
+							:model-value="settingsStore.isMFAEnforced"
+							size="large"
+							data-test-id="enable-force-mfa"
+							@update:model-value="onUpdateMfaEnforced"
+						/>
+						<template #fallback>
+							<N8nTooltip>
+								<ElSwitch
+									:model-value="settingsStore.isMFAEnforced"
+									size="large"
+									:disabled="true"
+								/>
+								<template #content>
+									<I18nT :keypath="tooltipKey" tag="span" scope="global">
+										<template #action>
+											<a @click="goToUpgrade">
+												{{ i18n.baseText('settings.personal.mfa.enforce.unlicensed_tooltip.link') }}
+											</a>
+										</template>
+									</I18nT>
+								</template>
+							</N8nTooltip>
+						</template>
+					</EnterpriseEdition>
+				</div>
+			</div>
+		</div>
 
 		<N8nHeading tag="h2" size="large" class="mb-l">
 			{{ i18n.baseText('settings.security.personalSpace.title') }}

--- a/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.vue
+++ b/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.vue
@@ -11,6 +11,7 @@ import * as securitySettingsApi from '@n8n/rest-api-client/api/security-settings
 import { useMessage } from '@/app/composables/useMessage';
 import { EnterpriseEditionFeature, MODAL_CONFIRM } from '@/app/constants';
 import EnterpriseEdition from '@/app/components/EnterpriseEdition.ee.vue';
+import EnvFeatureFlag from '@/features/shared/envFeatureFlag/EnvFeatureFlag.vue';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import { usePageRedirectionHelper } from '@/app/composables/usePageRedirectionHelper';
@@ -202,73 +203,75 @@ const sharingCountText = computed(() => {
 			</div>
 		</div>
 
-		<N8nHeading tag="h2" size="large" class="mb-l">
-			{{ i18n.baseText('settings.security.personalSpace.title') }}
-		</N8nHeading>
+		<EnvFeatureFlag name="PERSONAL_SECURITY_SETTINGS">
+			<N8nHeading tag="h2" size="large" class="mb-l">
+				{{ i18n.baseText('settings.security.personalSpace.title') }}
+			</N8nHeading>
 
-		<div :class="$style.settingsSection">
-			<div :class="$style.settingsContainer">
-				<div :class="$style.settingsContainerInfo">
-					<N8nText :bold="true">
-						{{ i18n.baseText('settings.security.personalSpace.sharing.title') }}
+			<div :class="$style.settingsSection">
+				<div :class="$style.settingsContainer">
+					<div :class="$style.settingsContainerInfo">
+						<N8nText :bold="true">
+							{{ i18n.baseText('settings.security.personalSpace.sharing.title') }}
+						</N8nText>
+						<N8nText size="small" color="text-light">
+							{{ i18n.baseText('settings.security.personalSpace.sharing.description') }}
+						</N8nText>
+					</div>
+					<div :class="$style.settingsContainerAction">
+						<ElSwitch
+							v-model="personalSpaceSharing"
+							:loading="isLoading"
+							size="large"
+							data-test-id="security-personal-space-sharing-toggle"
+						/>
+					</div>
+				</div>
+				<div :class="$style.settingsCountRow" data-test-id="security-sharing-count">
+					<N8nText size="small">
+						{{ i18n.baseText('settings.security.personalSpace.sharing.existingCount.label') }}
 					</N8nText>
 					<N8nText size="small" color="text-light">
-						{{ i18n.baseText('settings.security.personalSpace.sharing.description') }}
+						{{ sharingCountText }}
 					</N8nText>
 				</div>
-				<div :class="$style.settingsContainerAction">
-					<ElSwitch
-						v-model="personalSpaceSharing"
-						:loading="isLoading"
-						size="large"
-						data-test-id="security-personal-space-sharing-toggle"
-					/>
-				</div>
 			</div>
-			<div :class="$style.settingsCountRow" data-test-id="security-sharing-count">
-				<N8nText size="small">
-					{{ i18n.baseText('settings.security.personalSpace.sharing.existingCount.label') }}
-				</N8nText>
-				<N8nText size="small" color="text-light">
-					{{ sharingCountText }}
-				</N8nText>
-			</div>
-		</div>
 
-		<div :class="$style.settingsSection">
-			<div :class="$style.settingsContainer">
-				<div :class="$style.settingsContainerInfo">
-					<N8nText :bold="true">
-						{{ i18n.baseText('settings.security.personalSpace.publishing.title') }}
+			<div :class="$style.settingsSection">
+				<div :class="$style.settingsContainer">
+					<div :class="$style.settingsContainerInfo">
+						<N8nText :bold="true">
+							{{ i18n.baseText('settings.security.personalSpace.publishing.title') }}
+						</N8nText>
+						<N8nText size="small" color="text-light">
+							{{ i18n.baseText('settings.security.personalSpace.publishing.description') }}
+						</N8nText>
+					</div>
+					<div :class="$style.settingsContainerAction">
+						<ElSwitch
+							v-model="personalSpacePublishing"
+							:loading="isLoading"
+							size="large"
+							data-test-id="security-personal-space-publishing-toggle"
+						/>
+					</div>
+				</div>
+				<div :class="$style.settingsCountRow" data-test-id="security-publishing-count">
+					<N8nText size="small">
+						{{ i18n.baseText('settings.security.personalSpace.publishing.existingCount.label') }}
 					</N8nText>
 					<N8nText size="small" color="text-light">
-						{{ i18n.baseText('settings.security.personalSpace.publishing.description') }}
+						{{
+							i18n.baseText('settings.security.personalSpace.publishing.existingCount.value', {
+								interpolate: {
+									count: String(state?.publishedPersonalWorkflowsCount ?? 0),
+								},
+							})
+						}}
 					</N8nText>
 				</div>
-				<div :class="$style.settingsContainerAction">
-					<ElSwitch
-						v-model="personalSpacePublishing"
-						:loading="isLoading"
-						size="large"
-						data-test-id="security-personal-space-publishing-toggle"
-					/>
-				</div>
 			</div>
-			<div :class="$style.settingsCountRow" data-test-id="security-publishing-count">
-				<N8nText size="small">
-					{{ i18n.baseText('settings.security.personalSpace.publishing.existingCount.label') }}
-				</N8nText>
-				<N8nText size="small" color="text-light">
-					{{
-						i18n.baseText('settings.security.personalSpace.publishing.existingCount.value', {
-							interpolate: {
-								count: String(state?.publishedPersonalWorkflowsCount ?? 0),
-							},
-						})
-					}}
-				</N8nText>
-			</div>
-		</div>
+		</EnvFeatureFlag>
 	</div>
 </template>
 

--- a/packages/frontend/editor-ui/src/features/settings/users/views/SettingsUsersView.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/users/views/SettingsUsersView.test.ts
@@ -160,16 +160,12 @@ describe('SettingsUsersView', () => {
 			.mockResolvedValue({ link: 'https://example.com/reset/123' });
 		usersStore.updateOtherUserSettings = vi.fn().mockResolvedValue(undefined);
 		usersStore.updateGlobalRole = vi.fn().mockResolvedValue(undefined);
-		usersStore.updateEnforceMfa = vi.fn().mockResolvedValue(undefined);
 		usersStore.generateInviteLink = vi
 			.fn()
 			.mockResolvedValue({ link: 'https://example.com/signup?token=generated-token' });
 
 		settingsStore.isSmtpSetup = true;
-		settingsStore.isMFAEnforced = false;
-		settingsStore.settings.enterprise = {
-			mfaEnforcement: true,
-		} as FrontendSettings['enterprise'];
+		settingsStore.settings.enterprise = {} as FrontendSettings['enterprise'];
 		settingsStore.settings.enterprise[EnterpriseEditionFeature.AdvancedPermissions] = true;
 		ssoStore.isSamlLoginEnabled = false;
 	});
@@ -179,42 +175,6 @@ describe('SettingsUsersView', () => {
 		// Reset mock implementation to default (feature flag disabled)
 		mockIsVariantEnabled.mockReset();
 		mockIsVariantEnabled.mockReturnValue(false);
-	});
-
-	it('should turn enforcing mfa on', async () => {
-		const { getByTestId } = renderComponent();
-
-		const actionSwitch = getByTestId('enable-force-mfa');
-		expect(actionSwitch).toBeInTheDocument();
-
-		await userEvent.click(actionSwitch);
-
-		expect(usersStore.updateEnforceMfa).toHaveBeenCalledWith(true);
-	});
-
-	it('should turn enforcing mfa off', async () => {
-		settingsStore.isMFAEnforced = true;
-		const { getByTestId } = renderComponent();
-
-		const actionSwitch = getByTestId('enable-force-mfa');
-		expect(actionSwitch).toBeInTheDocument();
-
-		await userEvent.click(actionSwitch);
-
-		expect(usersStore.updateEnforceMfa).toHaveBeenCalledWith(false);
-	});
-
-	it('should handle MFA enforcement error', async () => {
-		usersStore.updateEnforceMfa = vi.fn().mockRejectedValue(new Error('MFA update failed'));
-
-		const { getByTestId } = renderComponent();
-
-		const actionSwitch = getByTestId('enable-force-mfa');
-		await userEvent.click(actionSwitch);
-
-		await waitFor(() => {
-			expect(mockToast.showError).toHaveBeenCalledWith(expect.any(Error), expect.any(String));
-		});
 	});
 
 	it('should handle missing user settings in SSO actions', async () => {
@@ -1102,33 +1062,6 @@ describe('SettingsUsersView', () => {
 				filter: {
 					fullText: '',
 				},
-			});
-		});
-
-		it('should handle MFA enforcement with partial success', async () => {
-			let callCount = 0;
-			usersStore.updateEnforceMfa = vi.fn().mockImplementation(async () => {
-				callCount++;
-				if (callCount === 1) {
-					throw Error('First attempt failed');
-				}
-				return await Promise.resolve();
-			});
-
-			const { getByTestId } = renderComponent();
-
-			const actionSwitch = getByTestId('enable-force-mfa');
-			await userEvent.click(actionSwitch);
-
-			await waitFor(() => {
-				expect(mockToast.showError).toHaveBeenCalledWith(expect.any(Error), expect.any(String));
-			});
-
-			// Try again
-			await userEvent.click(actionSwitch);
-
-			await waitFor(() => {
-				expect(usersStore.updateEnforceMfa).toHaveBeenCalledTimes(2);
 			});
 		});
 

--- a/packages/frontend/editor-ui/src/features/settings/users/views/SettingsUsersView.vue
+++ b/packages/frontend/editor-ui/src/features/settings/users/views/SettingsUsersView.vue
@@ -17,7 +17,6 @@ import {
 	MODAL_CONFIRM,
 } from '@/app/constants';
 import { DELETE_USER_MODAL_KEY, INVITE_USER_MODAL_KEY } from '../users.constants';
-import EnterpriseEdition from '@/app/components/EnterpriseEdition.ee.vue';
 import type { InvitableRoleName } from '../users.types';
 import type { IUser } from '@n8n/rest-api-client/api/users';
 import { useToast } from '@/app/composables/useToast';
@@ -33,13 +32,11 @@ import { usePageRedirectionHelper } from '@/app/composables/usePageRedirectionHe
 import SettingsUsersTable from '../components/SettingsUsersTable.vue';
 import { I18nT } from 'vue-i18n';
 import { useUserRoleProvisioningStore } from '@/features/settings/sso/provisioning/composables/userRoleProvisioning.store';
-import { ElSwitch } from 'element-plus';
 import N8nAlert from '@n8n/design-system/components/N8nAlert/Alert.vue';
 import { usePostHog } from '@/app/stores/posthog.store';
 import { TAMPER_PROOF_INVITE_LINKS } from '@/app/constants/experiments';
 import {
 	N8nActionBox,
-	N8nBadge,
 	N8nButton,
 	N8nHeading,
 	N8nIcon,
@@ -64,8 +61,6 @@ const pageRedirectionHelper = usePageRedirectionHelper();
 const userRoleProvisioningStore = useUserRoleProvisioningStore();
 const postHog = usePostHog();
 
-const tooltipKey = 'settings.personal.mfa.enforce.unlicensed_tooltip';
-
 const i18n = useI18n();
 
 const search = ref('');
@@ -79,9 +74,6 @@ const usersTableState = ref<TableOptions>({
 	],
 });
 const showUMSetupWarning = computed(() => hasPermission(['defaultUser']));
-const isEnforceMFAEnabled = computed(
-	() => settingsStore.isEnterpriseFeatureEnabled[EnterpriseEditionFeature.EnforceMFA],
-);
 
 const isInstanceRoleProvisioningEnabled = computed(
 	() => userRoleProvisioningStore.provisioningConfig?.scopesProvisionInstanceRole || false,
@@ -437,24 +429,6 @@ const onSearch = (value: string) => {
 	search.value = value;
 	void debouncedUpdateUsersTableData();
 };
-
-async function onUpdateMfaEnforced(value: string | number | boolean) {
-	const boolValue = typeof value === 'boolean' ? value : Boolean(value);
-	try {
-		await usersStore.updateEnforceMfa(boolValue);
-		showToast({
-			type: 'success',
-			title: boolValue
-				? i18n.baseText('settings.personal.mfa.enforce.enabled.title')
-				: i18n.baseText('settings.personal.mfa.enforce.disabled.title'),
-			message: boolValue
-				? i18n.baseText('settings.personal.mfa.enforce.enabled.message')
-				: i18n.baseText('settings.personal.mfa.enforce.disabled.message'),
-		});
-	} catch (error) {
-		showError(error, i18n.baseText('settings.personal.mfa.enforce.error'));
-	}
-}
 </script>
 
 <template>
@@ -497,43 +471,6 @@ async function onUpdateMfaEnforced(value: string | number | boolean) {
 				</template>
 			</I18nT>
 		</N8nNotice>
-		<div :class="$style.settingsContainer">
-			<div :class="$style.settingsContainerInfo">
-				<N8nText :bold="true"
-					>{{ i18n.baseText('settings.personal.mfa.enforce.title') }}
-					<N8nBadge v-if="!isEnforceMFAEnabled" class="ml-4xs">{{
-						i18n.baseText('generic.upgrade')
-					}}</N8nBadge>
-				</N8nText>
-				<N8nText size="small" color="text-light">{{
-					i18n.baseText('settings.personal.mfa.enforce.message')
-				}}</N8nText>
-			</div>
-			<div :class="$style.settingsContainerAction">
-				<EnterpriseEdition :features="[EnterpriseEditionFeature.EnforceMFA]">
-					<ElSwitch
-						:model-value="settingsStore.isMFAEnforced"
-						size="large"
-						data-test-id="enable-force-mfa"
-						@update:model-value="onUpdateMfaEnforced"
-					/>
-					<template #fallback>
-						<N8nTooltip>
-							<ElSwitch :model-value="settingsStore.isMFAEnforced" size="large" :disabled="true" />
-							<template #content>
-								<I18nT :keypath="tooltipKey" tag="span" scope="global">
-									<template #action>
-										<a @click="goToUpgrade">
-											{{ i18n.baseText('settings.personal.mfa.enforce.unlicensed_tooltip.link') }}
-										</a>
-									</template>
-								</I18nT>
-							</template>
-						</N8nTooltip>
-					</template>
-				</EnterpriseEdition>
-			</div>
-		</div>
 		<div v-if="isInstanceRoleProvisioningEnabled" :class="$style.container">
 			<N8nAlert
 				type="info"
@@ -612,35 +549,6 @@ async function onUpdateMfaEnforced(value: string | number | boolean) {
 
 .setupInfoContainer {
 	max-width: 728px;
-}
-
-.settingsContainer {
-	display: flex;
-	align-items: center;
-	padding-left: var(--spacing--sm);
-	margin-bottom: var(--spacing--lg);
-	justify-content: space-between;
-	flex-shrink: 0;
-
-	border-radius: 4px;
-	border: 1px solid var(--Colors-Foreground---color--foreground, #d9dee8);
-}
-
-.settingsContainerInfo {
-	display: flex;
-	padding: 8px 0;
-	flex-direction: column;
-	justify-content: center;
-	align-items: flex-start;
-	gap: 1px;
-}
-
-.settingsContainerAction {
-	display: flex;
-	padding: 20px 16px 20px 248px;
-	justify-content: flex-end;
-	align-items: center;
-	flex-shrink: 0;
 }
 
 .container {


### PR DESCRIPTION
## Summary

Moves the admin-level “Enforce MFA” toggle from the Users settings page (/settings/users) to the Security settings page (/settings/security). Per-user MFA configuration remains in Personal Settings.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/IAM-130

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
