### PR TITLE
chore: Remove api-types zod re-export (no-changelog)  

### DIFF
--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -1,4 +1,3 @@
-export { z } from 'zod';
 export { Z, type ZodClass } from './zod-class';
 export type * from './datetime';
 export * from './dto';

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chat.types.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chat.types.ts
@@ -10,9 +10,9 @@ import {
 	chatHubConversationModelSchema,
 	type ChatModelDto,
 	agentIconOrEmojiSchema,
-	z,
 } from '@n8n/api-types';
 import type { IBinaryData, INode } from 'n8n-workflow';
+import { z } from 'zod';
 import { isLlmProviderModel } from './chat.utils';
 
 export interface UserMessage {


### PR DESCRIPTION
## Summary

Remove accidental `export { z } from 'zod'` re-export from `@n8n/api-types`.
This re-export was introduced in #25393 but is unnecessary — consumers should
import `z` directly from `zod`. The only usage (in `chat.types.ts`) is updated
to import from `zod` directly.
## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
