### PR TITLE
fix(Mistral Cloud Chat Model Node): Handle Request objects in proxyFetch

### DIFF
--- a/packages/@n8n/ai-utilities/src/utils/http-proxy-agent.ts
+++ b/packages/@n8n/ai-utilities/src/utils/http-proxy-agent.ts
@@ -77,14 +77,17 @@ export function getProxyAgent(targetUrl?: string, timeoutOptions?: AgentTimeoutO
  * @param timeoutOptions - Optional timeout configuration to override defaults
  */
 export async function proxyFetch(
-	input: string | URL,
+	input: RequestInfo | URL,
 	init?: RequestInit,
 	timeoutOptions?: AgentTimeoutOptions,
 ): Promise<Response> {
+	const targetUrl = input instanceof Request ? input.url : input.toString();
+	const dispatcher = getProxyAgent(targetUrl, timeoutOptions);
+
 	return await fetch(input, {
 		...init,
 		// @ts-expect-error - dispatcher is an undici-specific option not in standard fetch
-		dispatcher: getProxyAgent(input.toString(), timeoutOptions),
+		dispatcher,
 	});
 }
 

--- a/packages/@n8n/ai-utilities/src/utils/httpProxyAgent.test.ts
+++ b/packages/@n8n/ai-utilities/src/utils/httpProxyAgent.test.ts
@@ -317,6 +317,19 @@ describe('proxyFetch', () => {
 				dispatcher: undefined,
 			});
 		});
+
+		it('should handle Request objects', async () => {
+			const request = new Request('https://api.openai.com/v1', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ test: 'data' }),
+			});
+			await proxyFetch(request);
+
+			expect(mockFetch).toHaveBeenCalledWith(request, {
+				dispatcher: undefined,
+			});
+		});
 	});
 
 	describe('with proxy configured', () => {
@@ -361,6 +374,19 @@ describe('proxyFetch', () => {
 
 			expect(ProxyAgent).toHaveBeenCalledWith(expect.objectContaining({ uri: proxyUrl }));
 			expect(mockFetch).toHaveBeenCalledWith(url, {
+				dispatcher: expect.objectContaining({ type: 'ProxyAgent' }),
+			});
+		});
+
+		it('should handle Request objects with proxy', async () => {
+			const proxyUrl = 'https://proxy.example.com:8080';
+			process.env.HTTPS_PROXY = proxyUrl;
+
+			const request = new Request('https://api.openai.com/v1');
+			await proxyFetch(request);
+
+			expect(ProxyAgent).toHaveBeenCalledWith(expect.objectContaining({ uri: proxyUrl }));
+			expect(mockFetch).toHaveBeenCalledWith(request, {
 				dispatcher: expect.objectContaining({ type: 'ProxyAgent' }),
 			});
 		});

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOllama/LmChatOllama.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOllama/LmChatOllama.node.ts
@@ -64,7 +64,7 @@ export class LmChatOllama implements INodeType {
 			: undefined;
 
 		const fetchWithTimeout = async (input: RequestInfo | URL, init?: RequestInit) =>
-			await proxyFetch(input.toString(), init, {});
+			await proxyFetch(input, init, {});
 
 		const model = new ChatOllama({
 			...options,

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatMistralCloud/LmChatMistralCloud.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatMistralCloud/LmChatMistralCloud.node.ts
@@ -188,7 +188,7 @@ export class LmChatMistralCloud implements INodeType {
 		}) as Partial<ChatMistralAIInput>;
 
 		const fetchWithTimeout = async (input: RequestInfo | URL, init?: RequestInit) =>
-			await proxyFetch(input.toString(), init, {});
+			await proxyFetch(input, init, {});
 		const httpClient = new HTTPClient({ fetcher: fetchWithTimeout });
 
 		const model = new ChatMistralAI({


### PR DESCRIPTION
## Summary

Fix a regression causing Mistral Chat Model executions to fail with `Failed to parse URL from [object Request]`.

The issue came from request normalization in our HTTP utility path when an SDK passed a native `Request` object instead of a string URL. In that case, the request could be coerced into `[object Request]`, which then failed URL parsing downstream.

This PR updates request handling so native `Request` inputs are handled correctly and keeps proxy/timeout behavior intact. It also aligns affected LLM integrations to use the shared utility in this safer way.
## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
