### PR TITLE
fix(ai-builder): Improve plan mode defaults and   modification awareness (no-changelog)

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/multi-agent-workflow-subgraphs.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/multi-agent-workflow-subgraphs.ts
@@ -404,6 +404,18 @@ export function createMultiAgentWorkflowWithSubgraphs(config: MultiAgentSubgraph
 					clear_error_state: 'clear_error_state',
 					continue: 'supervisor',
 				};
+
+				// In plan mode, skip the supervisor and go directly to discovery
+				// (which contains the planner) when no plan has been generated yet
+				if (
+					state.nextPhase === 'continue' &&
+					featureFlags?.planMode === true &&
+					state.mode === 'plan' &&
+					!state.planOutput
+				) {
+					return 'discovery_subgraph';
+				}
+
 				return routes[state.nextPhase] ?? 'supervisor';
 			})
 			// Route after state modification nodes

--- a/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/planner.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/planner.prompt.ts
@@ -44,7 +44,15 @@ Rules:
 - Do not generate workflow JSON.
 - Do not mention internal n8n node type names in steps — describe what happens in plain language.
 - You may include suggestedNodes in the structured output for the builder, but the step description should be human-readable.
-- If key information is missing, make reasonable assumptions. Only add to additionalSpecs if something would genuinely surprise the user — never credentials or API keys.`;
+- If key information is missing, make reasonable assumptions. Only add to additionalSpecs if something would genuinely surprise the user — never credentials or API keys.
+
+<modification_mode>
+When an existing_workflow_summary is provided, the user is asking to MODIFY an existing workflow — not rebuild it from scratch.
+- Only describe the CHANGES being made, not the entire workflow.
+- The summary should explain what will be modified and why.
+- Steps should only cover the modifications (e.g., "Change the AI model from GPT-4.1-mini to GPT-5-mini"), not re-describe unchanged parts of the workflow.
+- Keep the trigger field as-is from the existing workflow if it isn't changing.
+</modification_mode>`;
 
 const OUTPUT_FORMAT = `Output format:
 - summary: 1–2 sentences describing the workflow outcome in plain language

--- a/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/planner.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/planner.prompt.ts
@@ -7,6 +7,7 @@
 import type { DiscoveryContext } from '@/types/discovery-types';
 import type { PlanOutput } from '@/types/planning';
 import type { SimpleWorkflow } from '@/types/workflow';
+import { mermaidStringify } from '@/tools/utils/mermaid.utils';
 import { formatPlanAsText } from '@/utils/plan-helpers';
 
 import { prompt } from '../builder';
@@ -90,7 +91,13 @@ export function buildPlannerContext(options: PlannerContextOptions): string {
 		.map((node) => `- ${node.nodeName} v${node.version}: ${node.reasoning}`)
 		.join('\n');
 
-	const workflowSummary = workflowJSON.nodes.map((n) => `- ${n.name} (${n.type})`).join('\n');
+	const workflowOverview =
+		workflowJSON.nodes.length > 0
+			? mermaidStringify(
+					{ workflow: workflowJSON },
+					{ includeNodeType: true, includeNodeParameters: true, includeNodeName: true },
+				)
+			: '';
 
 	return prompt()
 		.section('user_request', userRequest)
@@ -99,7 +106,7 @@ export function buildPlannerContext(options: PlannerContextOptions): string {
 			'discovery_context_suggested_nodes',
 			discoveredNodesList,
 		)
-		.sectionIf(workflowJSON.nodes.length > 0, 'existing_workflow_summary', workflowSummary)
+		.sectionIf(workflowJSON.nodes.length > 0, 'existing_workflow', workflowOverview)
 		.sectionIf(planPrevious, 'previous_plan', () => formatPlanAsText(planPrevious!))
 		.sectionIf(planFeedback, 'user_feedback', () => planFeedback!)
 		.build();

--- a/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/planner.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/planner.prompt.ts
@@ -4,10 +4,10 @@
  * Generates a structured workflow plan for user approval (Plan Mode).
  */
 
+import { mermaidStringify } from '@/tools/utils/mermaid.utils';
 import type { DiscoveryContext } from '@/types/discovery-types';
 import type { PlanOutput } from '@/types/planning';
 import type { SimpleWorkflow } from '@/types/workflow';
-import { mermaidStringify } from '@/tools/utils/mermaid.utils';
 import { formatPlanAsText } from '@/utils/plan-helpers';
 
 import { prompt } from '../builder';

--- a/packages/@n8n/ai-workflow-builder.ee/src/subgraphs/builder.subgraph.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/subgraphs/builder.subgraph.ts
@@ -355,6 +355,13 @@ export class BuilderSubgraph extends BaseSubgraph<
 		if (parentState.planOutput) {
 			contextParts.push('=== APPROVED PLAN (FOLLOW THIS) ===');
 			contextParts.push(formatPlanAsText(parentState.planOutput));
+			if (parentState.workflowJSON?.nodes?.length > 0) {
+				contextParts.push(
+					'=== IMPORTANT: EXISTING WORKFLOW ===',
+					'The workflow already has nodes. Use get_workflow_overview first to see what exists.',
+					'Only make the changes described in the plan — do NOT recreate nodes that already exist.',
+				);
+			}
 		} else {
 			// Conversation context (history, original request, previous actions)
 			// Supports UNDERSTANDING_CONTEXT prompt section for investigating issues

--- a/packages/@n8n/ai-workflow-builder.ee/src/subgraphs/builder.subgraph.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/subgraphs/builder.subgraph.ts
@@ -35,6 +35,7 @@ import { createRemoveConnectionTool } from '../tools/remove-connection.tool';
 import { createRemoveNodeTool } from '../tools/remove-node.tool';
 import { createRenameNodeTool } from '../tools/rename-node.tool';
 import { createUpdateNodeParametersTool } from '../tools/update-node-parameters.tool';
+import { mermaidStringify } from '../tools/utils/mermaid.utils';
 import { createValidateConfigurationTool } from '../tools/validate-configuration.tool';
 import { createValidateStructureTool } from '../tools/validate-structure.tool';
 // Types and utilities
@@ -44,7 +45,6 @@ import type { DiscoveryContext } from '../types/discovery-types';
 import { isBaseMessage } from '../types/langchain';
 import type { WorkflowMetadata } from '../types/tools';
 import type { SimpleWorkflow, WorkflowOperation } from '../types/workflow';
-import { mermaidStringify } from '../tools/utils/mermaid.utils';
 import { applySubgraphCacheMarkers } from '../utils/cache-control';
 import {
 	buildConversationContext,

--- a/packages/@n8n/ai-workflow-builder.ee/src/subgraphs/builder.subgraph.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/subgraphs/builder.subgraph.ts
@@ -44,6 +44,7 @@ import type { DiscoveryContext } from '../types/discovery-types';
 import { isBaseMessage } from '../types/langchain';
 import type { WorkflowMetadata } from '../types/tools';
 import type { SimpleWorkflow, WorkflowOperation } from '../types/workflow';
+import { mermaidStringify } from '../tools/utils/mermaid.utils';
 import { applySubgraphCacheMarkers } from '../utils/cache-control';
 import {
 	buildConversationContext,
@@ -356,10 +357,14 @@ export class BuilderSubgraph extends BaseSubgraph<
 			contextParts.push('=== APPROVED PLAN (FOLLOW THIS) ===');
 			contextParts.push(formatPlanAsText(parentState.planOutput));
 			if (parentState.workflowJSON?.nodes?.length > 0) {
+				const overview = mermaidStringify(
+					{ workflow: parentState.workflowJSON },
+					{ includeNodeType: true, includeNodeParameters: true, includeNodeName: true },
+				);
 				contextParts.push(
-					'=== IMPORTANT: EXISTING WORKFLOW ===',
-					'The workflow already has nodes. Use get_workflow_overview first to see what exists.',
-					'Only make the changes described in the plan — do NOT recreate nodes that already exist.',
+					'=== EXISTING WORKFLOW (do NOT recreate these nodes) ===',
+					overview,
+					'Only make the changes described in the plan.',
 				);
 			}
 		} else {

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
@@ -876,17 +876,6 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 
 				chatMessages.value = convertedMessages;
 
-				// Restore builderMode from loaded messages:
-				// If any plan-mode interrupt is present, the user was in plan mode
-				const hasPlanModeMessages = convertedMessages.some(
-					(msg) =>
-						msg.role === 'assistant' &&
-						(isPlanModeQuestionsMessage(msg) || isPlanModePlanMessage(msg)),
-				);
-				if (hasPlanModeMessages) {
-					builderMode.value = 'plan';
-				}
-
 				// Restore lastUserMessageId from the loaded session for telemetry tracking
 				const lastUserMsg = [...convertedMessages]
 					.reverse()
@@ -981,6 +970,21 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 				void fetchBuilderCredits();
 				void loadSessions();
 			}
+		},
+	);
+
+	// Set default builder mode based on canvas state once nodes are loaded.
+	// Watches both workflowId and nodes.length so it fires when:
+	// - A new workflow is opened (workflowId changes, even if nodes stay empty)
+	// - Nodes are loaded after workflow reset (nodes.length changes)
+	// Only applies when the chat is fresh (no messages) so it doesn't interfere
+	// with an active conversation.
+	watch(
+		[() => workflowsStore.workflowId, () => workflowsStore.workflow.nodes.length],
+		([, nodesCount]) => {
+			if (chatMessages.value.length > 0) return;
+			if (!isPlanModeAvailable.value) return;
+			builderMode.value = nodesCount === 0 ? 'plan' : 'build';
 		},
 	);
 

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
@@ -980,7 +980,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 	// Only applies when the chat is fresh (no messages) so it doesn't interfere
 	// with an active conversation.
 	watch(
-		[() => workflowsStore.workflowId, () => workflowsStore.workflow.nodes.length],
+		[() => workflowsStore.workflowId, () => workflowsStore.workflow.nodes?.length ?? 0],
 		([, nodesCount]) => {
 			if (chatMessages.value.length > 0) return;
 			if (!isPlanModeAvailable.value) return;


### PR DESCRIPTION
## Summary

Improves plan mode in the AI workflow builder with four changes:

### Frontend: Default mode based on canvas state
- When the plan mode experiment is enabled, the builder defaults to **plan** mode on an empty canvas and **build** mode when nodes already exist.
- Uses a reactive watcher on `workflowId` + `nodes.length` to handle the timing of workflow loading (nodes are populated after the workflow ID is set).
- Session history no longer overrides the mode — it's determined purely by canvas state.

### Backend: Skip supervisor in plan mode
- When `mode === 'plan'` and no plan exists yet, the `check_state` routing bypasses the supervisor and goes directly to the discovery subgraph (which contains the planner).
- Previously, the supervisor had no knowledge of plan mode and would route simple modifications (e.g., "change model to X") straight to the builder, skipping plan generation entirely.

### Backend: Modification-aware plans
- Added a `<modification_mode>` section to the planner prompt: when an existing workflow is present, the planner now generates a plan describing only the **changes**, not the entire workflow.
- The builder context now includes the existing workflow as a Mermaid diagram alongside the plan, with an instruction to not recreate existing nodes.

### Backend: Mermaid workflow overview in planner/builder context
- Replaced the bare node list (`- NodeName (nodeType)`) in the planner context with a full Mermaid diagram via `mermaidStringify`, showing connections, parameters, and flow.
- Injected the same overview into the builder context when implementing a plan on an existing workflow, eliminating the need for an extra `get_workflow_overview` tool call.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
