### PR TITLE
fix (DateTime Node) : Handle timezone conversion when parsing dates with fromFormat

### DIFF
--- a/packages/nodes-base/nodes/DateTime/V2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/DateTime/V2/GenericFunctions.ts
@@ -47,8 +47,10 @@ export function parseDate(
 				parsedDate = DateTime.fromISO(moment(date).toISOString());
 			}
 		}
-
-		parsedDate = parsedDate.setZone(timezone || 'Etc/UTC');
+		// When parsing user-provided formats (e.g. AM/PM), preserve wall-clock time
+		parsedDate = options.fromFormat
+			? parsedDate.setZone(timezone || 'Etc/UTC', { keepLocalTime: true })
+			: parsedDate.setZone(timezone || 'Etc/UTC');
 
 		if (parsedDate.invalidReason === 'unparsable') {
 			throw new NodeOperationError(this.getNode(), 'Invalid date format');

--- a/packages/nodes-base/nodes/DateTime/test/node/DateTime.extract.test.ts
+++ b/packages/nodes-base/nodes/DateTime/test/node/DateTime.extract.test.ts
@@ -1,0 +1,23 @@
+import { parseDate } from '../../V2/GenericFunctions';
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+const mockExecuteFunctions = {
+	getNode: jest.fn(),
+} as unknown as IExecuteFunctions;
+
+describe('parseDate AM/PM handling', () => {
+	it('should be deterministic across timezones', () => {
+		const utc = parseDate.call(mockExecuteFunctions, '2026-02-09 3:00 PM', {
+			fromFormat: 'yyyy-MM-dd h:mm a',
+			timezone: 'UTC',
+		});
+
+		const ny = parseDate.call(mockExecuteFunctions, '2026-02-09 3:00 PM', {
+			fromFormat: 'yyyy-MM-dd h:mm a',
+			timezone: 'America/New_York',
+		});
+
+		expect(utc.hour).toBe(15);
+		expect(ny.hour).toBe(15);
+	});
+});


### PR DESCRIPTION
## Summary
Fixes incorrect timezone conversion when parsing dates using fromFormat in parseDate.

Previously, dates parsed with DateTime.fromFormat were converted to the target timezone, unintentionally changing the clock time (e.g. 15:00 → 20:30). This resulted in double / unintended timezone shifts , which **failed EXTRACT PART from DateTime**.

This PR preserves the original local time for fromFormat inputs by applying setZone(..., { keepLocalTime: true }), while keeping existing behavior unchanged for timestamps and ISO strings.

## How to test
1. Run the unit test:
``` bash 
 pnpm test packages/nodes-base/nodes/DateTime/test/node/DateTime.extract.test.ts
```
2. Parse an ISO string or timestamp and verify timezone conversion still occurs as expected.
Existing DateTime tests continue to pass.
3. (optional) Parse a date using DateTime node to Extract Hour using fromFormat with a timezone (e.g. 3:00 PM, America/New_York) and verify the clock time remains 3:00 PM.


fixes #25496


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
