### PR TITLE
feat(editor): Implement partial execution from the Setup panel (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -4291,6 +4291,7 @@
 	"setupPanel.credentialLabel": "Credential",
 	"setupPanel.usedInNodes": "Used in {count} nodes",
 	"setupPanel.everythingConfigured.message": "All credentials have been configured",
+	"setupPanel.trigger.credential.note": "Add a credential to listen for events.",
 	"becomeCreator.text": "Share your workflows with other users, unlock perks, and become a featured template creator!",
 	"becomeCreator.buttonText": "Become a creator",
 	"becomeCreator.closeButtonTitle": "Close",

--- a/packages/frontend/editor-ui/src/app/components/FocusPanel.vue
+++ b/packages/frontend/editor-ui/src/app/components/FocusPanel.vue
@@ -692,6 +692,7 @@ function onRenameNode(value: string) {
 				display: flex;
 				height: 100%;
 				width: 100%;
+				align-items: normal;
 				font-size: var(--font-size--2xs);
 
 				:global(.cm-editor) {

--- a/packages/frontend/editor-ui/src/app/components/NodeExecuteButton.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/NodeExecuteButton.test.ts
@@ -7,7 +7,11 @@ import { createComponentRenderer } from '@/__tests__/render';
 import { type MockedStore, mockedStore, getTooltip } from '@/__tests__/utils';
 import { mockNode, mockNodeTypeDescription } from '@/__tests__/mocks';
 import { nodeViewEventBus } from '@/app/event-bus';
-import { AI_TRANSFORM_NODE_TYPE, AI_TRANSFORM_CODE_GENERATED_FOR_PROMPT } from 'n8n-workflow';
+import {
+	AI_TRANSFORM_NODE_TYPE,
+	AI_TRANSFORM_CODE_GENERATED_FOR_PROMPT,
+	AI_TRANSFORM_JS_CODE,
+} from 'n8n-workflow';
 import {
 	CHAT_TRIGGER_NODE_TYPE,
 	FORM_TRIGGER_NODE_TYPE,
@@ -380,6 +384,7 @@ describe('NodeExecuteButton', () => {
 				name: 'test',
 				value: 'Test',
 			}));
+		const updateNodePropertiesSpy = vi.spyOn(workflowState, 'updateNodeProperties');
 		const node = mockNode({
 			name: 'test-node',
 			type: AI_TRANSFORM_NODE_TYPE,
@@ -390,20 +395,21 @@ describe('NodeExecuteButton', () => {
 		});
 		workflowsStore.getNodeByName.mockReturnValue(node);
 
-		const { getByRole, emitted } = renderComponent();
+		const { getByRole } = renderComponent();
 
 		await userEvent.click(getByRole('button'));
 
 		expect(generateCodeForAiTransformSpy).toHaveBeenCalledTimes(1);
 		expect(toast.showMessage).toHaveBeenCalledTimes(1);
-		expect(emitted().valueChanged).toEqual([
-			[{ name: 'test', value: 'Test' }],
-			[
-				{
-					name: `parameters.${AI_TRANSFORM_CODE_GENERATED_FOR_PROMPT}`,
-					value: 'Test instructions',
-				},
-			],
-		]);
+		expect(updateNodePropertiesSpy).toHaveBeenCalledWith({
+			name: 'test-node',
+			properties: {
+				parameters: expect.objectContaining({
+					instructions: 'Test instructions',
+					[AI_TRANSFORM_JS_CODE]: 'Test',
+					[AI_TRANSFORM_CODE_GENERATED_FOR_PROMPT]: 'Test instructions',
+				}),
+			},
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/components/NodeExecuteButton.vue
+++ b/packages/frontend/editor-ui/src/app/components/NodeExecuteButton.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { ref, computed } from 'vue';
 import { useI18n } from '@n8n/i18n';
-import type { ButtonSize } from '@/Interface';
+import type { ButtonSize, IUpdateInformation } from '@/Interface';
 import type { ButtonType } from '@n8n/design-system';
 import { type IconName } from '@n8n/design-system/components/N8nIcon/icons';
 import { N8nButton, N8nTooltip } from '@n8n/design-system';
@@ -43,6 +43,7 @@ const props = withDefaults(
 const emit = defineEmits<{
 	stopExecution: [];
 	execute: [];
+	valueChanged: [value: IUpdateInformation];
 }>();
 
 const slots = defineSlots<{ persistentTooltipContent?: {} }>();
@@ -72,6 +73,7 @@ const {
 	telemetrySource: props.telemetrySource,
 	executionMode: computed(() => props.executionMode),
 	source: 'RunData.ExecuteNodeButton',
+	onCodeGenerated: (update) => emit('valueChanged', update),
 });
 
 const lastPopupCountUpdate = ref(0);
@@ -96,7 +98,7 @@ const buttonLabel = computed(() => {
 
 const buttonIcon = computed((): IconName | undefined => {
 	if (props.icon) return props.icon;
-	if (props.hideIcon && nodeButtonIcon.value === 'flask-conical') return undefined;
+	if (props.hideIcon) return undefined;
 	return nodeButtonIcon.value;
 });
 

--- a/packages/frontend/editor-ui/src/app/components/NodeExecuteButton.vue
+++ b/packages/frontend/editor-ui/src/app/components/NodeExecuteButton.vue
@@ -1,40 +1,14 @@
 <script lang="ts" setup>
 import { ref, computed } from 'vue';
-import {
-	WEBHOOK_NODE_TYPE,
-	MANUAL_TRIGGER_NODE_TYPE,
-	MODAL_CONFIRM,
-	FORM_TRIGGER_NODE_TYPE,
-	CHAT_TRIGGER_NODE_TYPE,
-	FROM_AI_PARAMETERS_MODAL_KEY,
-} from '@/app/constants';
-import {
-	AI_TRANSFORM_CODE_GENERATED_FOR_PROMPT,
-	AI_TRANSFORM_JS_CODE,
-	AI_TRANSFORM_NODE_TYPE,
-	type INodeTypeDescription,
-} from 'n8n-workflow';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
-import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
-import { useMessage } from '@/app/composables/useMessage';
-import { useToast } from '@/app/composables/useToast';
-import { useExternalHooks } from '@/app/composables/useExternalHooks';
-import { nodeViewEventBus } from '@/app/event-bus';
-import { usePinnedData } from '@/app/composables/usePinnedData';
-import { useRunWorkflow } from '@/app/composables/useRunWorkflow';
-import { useRouter } from 'vue-router';
 import { useI18n } from '@n8n/i18n';
-import { useTelemetry } from '@/app/composables/useTelemetry';
-import type { ButtonSize, IUpdateInformation } from '@/Interface';
-import { generateCodeForAiTransform } from '@/features/ndv/parameters/utils/buttonParameter.utils';
-import { needsAgentInput } from '@/app/utils/nodes/nodeTransforms';
-import { useUIStore } from '@/app/stores/ui.store';
+import type { ButtonSize } from '@/Interface';
 import type { ButtonType } from '@n8n/design-system';
 import { type IconName } from '@n8n/design-system/components/N8nIcon/icons';
-
 import { N8nButton, N8nTooltip } from '@n8n/design-system';
-import { injectWorkflowState } from '@/app/composables/useWorkflowState';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { useNodeExecution } from '@/app/composables/useNodeExecution';
+
 const NODE_TEST_STEP_POPUP_COUNT_KEY = 'N8N_NODE_TEST_STEP_POPUP_COUNT';
 const MAX_POPUP_COUNT = 10;
 const POPUP_UPDATE_DELAY = 3000;
@@ -69,7 +43,6 @@ const props = withDefaults(
 const emit = defineEmits<{
 	stopExecution: [];
 	execute: [];
-	valueChanged: [value: IUpdateInformation];
 }>();
 
 const slots = defineSlots<{ persistentTooltipContent?: {} }>();
@@ -78,118 +51,53 @@ defineOptions({
 	inheritAttrs: false,
 });
 
-const lastPopupCountUpdate = ref(0);
-const codeGenerationInProgress = ref(false);
-
-const router = useRouter();
-const { runWorkflow, stopCurrentExecution } = useRunWorkflow({ router });
-
-const workflowsStore = useWorkflowsStore();
-const workflowState = injectWorkflowState();
-const externalHooks = useExternalHooks();
-const toast = useToast();
-const ndvStore = useNDVStore();
-const nodeTypesStore = useNodeTypesStore();
 const i18n = useI18n();
-const message = useMessage();
-const telemetry = useTelemetry();
-const uiStore = useUIStore();
+const workflowsStore = useWorkflowsStore();
+const ndvStore = useNDVStore();
 
 const node = computed(() => workflowsStore.getNodeByName(props.nodeName));
-const pinnedData = usePinnedData(node);
 
-const nodeType = computed((): INodeTypeDescription | null => {
-	return node.value ? nodeTypesStore.getNodeType(node.value.type, node.value.typeVersion) : null;
+const {
+	isExecuting,
+	isListening,
+	isListeningForWorkflowEvents,
+	buttonLabel: nodeButtonLabel,
+	buttonIcon: nodeButtonIcon,
+	disabledReason,
+	isTriggerNode,
+	hasIssues,
+	shouldGenerateCode,
+	execute,
+} = useNodeExecution(node, {
+	telemetrySource: props.telemetrySource,
+	executionMode: computed(() => props.executionMode),
+	source: 'RunData.ExecuteNodeButton',
 });
 
-const isNodeRunning = computed(() => {
-	if (!workflowsStore.isWorkflowRunning || codeGenerationInProgress.value) return false;
-	const triggeredNode = workflowsStore.executedNode;
-	return (
-		workflowState.executingNode.isNodeExecuting(node.value?.name ?? '') ||
-		triggeredNode === node.value?.name
-	);
-});
-
-const isTriggerNode = computed(() => {
-	return node.value ? nodeTypesStore.isTriggerNode(node.value.type) : false;
-});
-
-const isManualTriggerNode = computed(() =>
-	nodeType.value ? nodeType.value.name === MANUAL_TRIGGER_NODE_TYPE : false,
-);
-
-const isChatNode = computed(() =>
-	nodeType.value ? nodeType.value.name === CHAT_TRIGGER_NODE_TYPE : false,
-);
-
-const isChatChild = computed(() => workflowsStore.checkIfNodeHasChatParent(props.nodeName));
-
-const isFormTriggerNode = computed(() =>
-	nodeType.value ? nodeType.value.name === FORM_TRIGGER_NODE_TYPE : false,
-);
-
-const isPollingTypeNode = computed(() => !!nodeType.value?.polling);
-
-const isScheduleTrigger = computed(() => !!nodeType.value?.group.includes('schedule'));
-
-const isWebhookNode = computed(() =>
-	nodeType.value ? nodeType.value.name === WEBHOOK_NODE_TYPE : false,
-);
-
-const isListeningForEvents = computed(() => {
-	const waitingOnWebhook = workflowsStore.executionWaitingForWebhook;
-	const executedNode = workflowsStore.executedNode;
-
-	return (
-		!!node.value &&
-		!node.value.disabled &&
-		isTriggerNode.value &&
-		waitingOnWebhook &&
-		(!executedNode || executedNode === props.nodeName)
-	);
-});
-
-const isListeningForWorkflowEvents = computed(() => {
-	return (
-		isNodeRunning.value &&
-		isTriggerNode.value &&
-		!isScheduleTrigger.value &&
-		!isManualTriggerNode.value
-	);
-});
-
-const hasIssues = computed(() =>
-	Boolean(node.value?.issues && (node.value.issues.parameters || node.value.issues.credentials)),
-);
+const lastPopupCountUpdate = ref(0);
 
 const disabledHint = computed(() => {
-	if (isListeningForEvents.value) {
-		return '';
-	}
-
-	if (codeGenerationInProgress.value) {
-		return i18n.baseText('ndv.execute.generatingCode');
-	}
-
-	if (node?.value?.disabled) {
-		return i18n.baseText('ndv.execute.nodeIsDisabled');
-	}
-
+	// NDV-specific: when the button's node is a trigger with issues
+	// and the active NDV node is a different node, show "fix previous"
 	if (isTriggerNode.value && hasIssues.value) {
 		const activeNode = ndvStore.activeNode;
 		if (activeNode && activeNode.name !== props.nodeName) {
 			return i18n.baseText('ndv.execute.fixPrevious');
 		}
-
-		return i18n.baseText('ndv.execute.requiredFieldsMissing');
 	}
+	return disabledReason.value;
+});
 
-	if (workflowsStore.isWorkflowRunning && !isNodeRunning.value) {
-		return i18n.baseText('ndv.execute.workflowAlreadyRunning');
-	}
+const buttonLabel = computed(() => {
+	if (props.hideLabel) return '';
+	if (props.label && !isListening.value && !isListeningForWorkflowEvents.value) return props.label;
+	return nodeButtonLabel.value;
+});
 
-	return '';
+const buttonIcon = computed((): IconName | undefined => {
+	if (props.icon) return props.icon;
+	if (props.hideIcon && nodeButtonIcon.value === 'flask-conical') return undefined;
+	return nodeButtonIcon.value;
 });
 
 const tooltipText = computed(() => {
@@ -197,84 +105,11 @@ const tooltipText = computed(() => {
 		return i18n.baseText('ndv.execute.generateCodeAndTestNode.description');
 	}
 	if (disabledHint.value) return disabledHint.value;
-	if (props.tooltip && !isLoading.value && testStepButtonPopupCount() < MAX_POPUP_COUNT) {
+	if (props.tooltip && !isExecuting.value && testStepButtonPopupCount() < MAX_POPUP_COUNT) {
 		return props.tooltip;
 	}
 	return '';
 });
-
-const buttonLabel = computed(() => {
-	if (props.hideLabel) {
-		return '';
-	}
-
-	if (isListeningForEvents.value || isListeningForWorkflowEvents.value) {
-		return i18n.baseText('ndv.execute.stopListening');
-	}
-
-	if (props.label) {
-		return props.label;
-	}
-
-	if (isChatNode.value) {
-		return i18n.baseText('ndv.execute.testChat');
-	}
-
-	if (isWebhookNode.value) {
-		return i18n.baseText('ndv.execute.listenForTestEvent');
-	}
-
-	if (isFormTriggerNode.value) {
-		return i18n.baseText('ndv.execute.testStep');
-	}
-
-	if (isPollingTypeNode.value || nodeType.value?.mockManualExecution) {
-		return i18n.baseText('ndv.execute.fetchEvent');
-	}
-
-	return i18n.baseText('ndv.execute.testNode');
-});
-
-const isLoading = computed(
-	() =>
-		codeGenerationInProgress.value ||
-		(isNodeRunning.value && !isListeningForEvents.value && !isListeningForWorkflowEvents.value),
-);
-
-const buttonIcon = computed((): IconName | undefined => {
-	if (props.icon) return props.icon;
-	if (shouldGenerateCode.value) return 'terminal';
-	if (!isListeningForEvents.value && !props.hideIcon) return 'flask-conical';
-	return undefined;
-});
-
-const shouldGenerateCode = computed(() => {
-	if (node.value?.type !== AI_TRANSFORM_NODE_TYPE) {
-		return false;
-	}
-	if (!node.value?.parameters?.instructions) {
-		return false;
-	}
-	if (!node.value?.parameters?.jsCode) {
-		return true;
-	}
-	if (
-		node.value?.parameters[AI_TRANSFORM_CODE_GENERATED_FOR_PROMPT] &&
-		(node.value?.parameters?.instructions as string).trim() !==
-			(node.value?.parameters?.[AI_TRANSFORM_CODE_GENERATED_FOR_PROMPT] as string).trim()
-	) {
-		return true;
-	}
-	return false;
-});
-
-async function stopWaitingForWebhook() {
-	try {
-		await workflowsStore.removeTestWebhook(workflowsStore.workflowId);
-	} catch (error) {
-		toast.showError(error, 'Error stopping webhook');
-	}
-}
 
 function testStepButtonPopupCount() {
 	return Number(localStorage.getItem(NODE_TEST_STEP_POPUP_COUNT_KEY));
@@ -293,107 +128,9 @@ function onMouseOver() {
 }
 
 async function onClick() {
-	if (shouldGenerateCode.value) {
-		// Generate code if user hasn't clicked 'Generate Code' button
-		// and update parameters
-		codeGenerationInProgress.value = true;
-		try {
-			toast.showMessage({
-				title: i18n.baseText('ndv.execute.generateCode.title'),
-				message: i18n.baseText('ndv.execute.generateCode.message', {
-					interpolate: { nodeName: node.value?.name as string },
-				}),
-				type: 'success',
-			});
-			const prompt = node.value?.parameters?.instructions as string;
-			const updateInformation = await generateCodeForAiTransform(
-				prompt,
-				`parameters.${AI_TRANSFORM_JS_CODE}`,
-				5,
-			);
-			if (!updateInformation) return;
-
-			emit('valueChanged', updateInformation);
-
-			emit('valueChanged', {
-				name: `parameters.${AI_TRANSFORM_CODE_GENERATED_FOR_PROMPT}`,
-				value: prompt,
-			});
-
-			useTelemetry().trackAiTransform('generationFinished', {
-				prompt,
-				code: updateInformation.value,
-			});
-		} catch (error) {
-			useTelemetry().trackAiTransform('generationFinished', {
-				prompt,
-				code: '',
-				hasError: true,
-			});
-			toast.showMessage({
-				type: 'error',
-				title: i18n.baseText('codeNodeEditor.askAi.generationFailed'),
-				message: error.message,
-			});
-		}
-		codeGenerationInProgress.value = false;
-	}
-
-	if (isChatNode.value || (isChatChild.value && ndvStore.isInputPanelEmpty)) {
-		ndvStore.unsetActiveNodeName();
-		workflowsStore.chatPartialExecutionDestinationNode = props.nodeName;
-		nodeViewEventBus.emit('openChat');
-	} else if (isListeningForEvents.value) {
-		await stopWaitingForWebhook();
-	} else if (isListeningForWorkflowEvents.value) {
-		await stopCurrentExecution();
-		emit('stopExecution');
-	} else {
-		let shouldUnpinAndExecute = false;
-		if (pinnedData.hasData.value) {
-			const confirmResult = await message.confirm(
-				i18n.baseText('ndv.pinData.unpinAndExecute.description'),
-				i18n.baseText('ndv.pinData.unpinAndExecute.title'),
-				{
-					confirmButtonText: i18n.baseText('ndv.pinData.unpinAndExecute.confirm'),
-					cancelButtonText: i18n.baseText('ndv.pinData.unpinAndExecute.cancel'),
-				},
-			);
-			shouldUnpinAndExecute = confirmResult === MODAL_CONFIRM;
-
-			if (shouldUnpinAndExecute && node.value) {
-				pinnedData.unsetData('unpin-and-execute-modal');
-			}
-		}
-
-		if (!pinnedData.hasData.value || shouldUnpinAndExecute) {
-			if (node.value && needsAgentInput(node.value)) {
-				uiStore.openModalWithData({
-					name: FROM_AI_PARAMETERS_MODAL_KEY,
-					data: {
-						nodeName: props.nodeName,
-					},
-				});
-			} else {
-				const telemetryPayload = {
-					node_type: nodeType.value ? nodeType.value.name : null,
-					workflow_id: workflowsStore.workflowId,
-					source: props.telemetrySource,
-					push_ref: ndvStore.pushRef,
-				};
-
-				telemetry.track('User clicked execute node button', telemetryPayload);
-				await externalHooks.run('nodeExecuteButton.onClick', telemetryPayload);
-
-				await runWorkflow({
-					destinationNode: { nodeName: props.nodeName, mode: props.executionMode },
-					source: 'RunData.ExecuteNodeButton',
-				});
-
-				emit('execute');
-			}
-		}
-	}
+	const result = await execute();
+	if (result === 'executed') emit('execute');
+	if (result === 'stopped-execution') emit('stopExecution');
 }
 </script>
 
@@ -410,8 +147,8 @@ async function onClick() {
 		</template>
 		<N8nButton
 			v-bind="$attrs"
-			:loading="isLoading && showLoadingSpinner"
-			:disabled="disabled || !!disabledHint || (isLoading && !showLoadingSpinner)"
+			:loading="isExecuting && showLoadingSpinner"
+			:disabled="disabled || !!disabledHint || (isExecuting && !showLoadingSpinner)"
 			:label="buttonLabel"
 			:type="type"
 			:size="size"

--- a/packages/frontend/editor-ui/src/app/composables/useNodeExecution.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeExecution.test.ts
@@ -772,6 +772,35 @@ describe('useNodeExecution', () => {
 			expect(result).toBe('executed');
 		});
 
+		it('should call onCodeGenerated callback when code is generated', async () => {
+			vi.mocked(generateCodeForAiTransform).mockResolvedValue({
+				name: `parameters.${AI_TRANSFORM_JS_CODE}`,
+				value: 'return items;',
+			});
+			vi.spyOn(workflowState, 'updateNodeProperties').mockImplementation(() => {});
+			const onCodeGenerated = vi.fn();
+			const node = ref(
+				createTestNode({
+					name: 'AI Transform',
+					type: AI_TRANSFORM_NODE_TYPE,
+					parameters: { instructions: 'do something' },
+				}),
+			);
+
+			const { execute } = useNodeExecution(node, { onCodeGenerated });
+			await execute();
+
+			expect(onCodeGenerated).toHaveBeenCalledTimes(2);
+			expect(onCodeGenerated).toHaveBeenCalledWith({
+				name: `parameters.${AI_TRANSFORM_JS_CODE}`,
+				value: 'return items;',
+			});
+			expect(onCodeGenerated).toHaveBeenCalledWith({
+				name: `parameters.${AI_TRANSFORM_CODE_GENERATED_FOR_PROMPT}`,
+				value: 'do something',
+			});
+		});
+
 		it('should return cancelled when code generation fails', async () => {
 			vi.mocked(generateCodeForAiTransform).mockResolvedValue(undefined as never);
 			const node = ref(

--- a/packages/frontend/editor-ui/src/app/composables/useNodeExecution.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeExecution.test.ts
@@ -1,0 +1,820 @@
+import { ref } from 'vue';
+import { setActivePinia } from 'pinia';
+import { createTestingPinia } from '@pinia/testing';
+import type router from 'vue-router';
+import {
+	AI_TRANSFORM_NODE_TYPE,
+	AI_TRANSFORM_CODE_GENERATED_FOR_PROMPT,
+	AI_TRANSFORM_JS_CODE,
+} from 'n8n-workflow';
+import type { INodeTypeDescription } from 'n8n-workflow';
+
+import { useNodeExecution } from '@/app/composables/useNodeExecution';
+import {
+	injectWorkflowState,
+	useWorkflowState,
+	type WorkflowState,
+} from '@/app/composables/useWorkflowState';
+import { useUIStore } from '@/app/stores/ui.store';
+import { nodeViewEventBus } from '@/app/event-bus';
+import { needsAgentInput } from '@/app/utils/nodes/nodeTransforms';
+import { generateCodeForAiTransform } from '@/features/ndv/parameters/utils/buttonParameter.utils';
+import type { INodeUi } from '@/Interface';
+import {
+	WEBHOOK_NODE_TYPE,
+	MANUAL_TRIGGER_NODE_TYPE,
+	FORM_TRIGGER_NODE_TYPE,
+	CHAT_TRIGGER_NODE_TYPE,
+	MODAL_CONFIRM,
+	FROM_AI_PARAMETERS_MODAL_KEY,
+} from '@/app/constants';
+
+const {
+	mockWorkflowsStore,
+	mockNodeTypesStore,
+	mockNdvStore,
+	mockRunWorkflow,
+	mockPinnedData,
+	mockMessage,
+} = vi.hoisted(() => ({
+	mockWorkflowsStore: {
+		isWorkflowRunning: false,
+		executedNode: undefined as string | undefined,
+		executionWaitingForWebhook: false,
+		workflowId: '123',
+		chatPartialExecutionDestinationNode: undefined as string | undefined,
+		checkIfNodeHasChatParent: vi.fn(),
+		getNodeByName: vi.fn(),
+		removeTestWebhook: vi.fn(),
+	},
+	mockNodeTypesStore: {
+		getNodeType: vi.fn(),
+		isTriggerNode: vi.fn(),
+	},
+	mockNdvStore: {
+		activeNode: null as INodeUi | null,
+		isInputPanelEmpty: false,
+		pushRef: 'push-ref-123',
+		unsetActiveNodeName: vi.fn(),
+	},
+	mockRunWorkflow: {
+		runWorkflow: vi.fn(),
+		stopCurrentExecution: vi.fn(),
+	},
+	mockPinnedData: {
+		hasData: { value: false },
+		unsetData: vi.fn(),
+	},
+	mockMessage: {
+		confirm: vi.fn(),
+	},
+}));
+
+vi.mock('vue-router', async (importOriginal) => {
+	const { RouterLink } = await importOriginal<typeof router>();
+	return {
+		RouterLink,
+		useRouter: vi.fn().mockReturnValue({ push: vi.fn() }),
+		useRoute: vi.fn(),
+	};
+});
+
+vi.mock('@/app/stores/workflows.store', () => ({
+	useWorkflowsStore: vi.fn().mockReturnValue(mockWorkflowsStore),
+}));
+
+vi.mock('@/app/stores/nodeTypes.store', () => ({
+	useNodeTypesStore: vi.fn().mockReturnValue(mockNodeTypesStore),
+}));
+
+vi.mock('@/features/ndv/shared/ndv.store', () => ({
+	useNDVStore: vi.fn().mockReturnValue(mockNdvStore),
+}));
+
+vi.mock('@/app/stores/ui.store', () => ({
+	useUIStore: vi.fn().mockReturnValue({
+		openModalWithData: vi.fn(),
+	}),
+}));
+
+vi.mock('@/app/composables/useRunWorkflow', () => ({
+	useRunWorkflow: vi.fn().mockReturnValue(mockRunWorkflow),
+}));
+
+vi.mock('@/app/composables/usePinnedData', () => ({
+	usePinnedData: vi.fn().mockReturnValue(mockPinnedData),
+}));
+
+vi.mock('@/app/composables/useMessage', () => ({
+	useMessage: vi.fn().mockReturnValue(mockMessage),
+}));
+
+vi.mock('@/app/composables/useTelemetry', () => ({
+	useTelemetry: vi.fn().mockReturnValue({
+		track: vi.fn(),
+		trackAiTransform: vi.fn(),
+	}),
+}));
+
+vi.mock('@n8n/i18n', () => ({
+	i18n: { baseText: vi.fn().mockImplementation((key: string) => key) },
+	useI18n: vi.fn().mockReturnValue({
+		baseText: vi.fn().mockImplementation((key: string) => key),
+	}),
+}));
+
+vi.mock('@/app/composables/useToast', () => ({
+	useToast: vi.fn().mockReturnValue({
+		showMessage: vi.fn(),
+		showError: vi.fn(),
+	}),
+}));
+
+vi.mock('@/app/composables/useExternalHooks', () => ({
+	useExternalHooks: vi.fn().mockReturnValue({
+		run: vi.fn(),
+	}),
+}));
+
+vi.mock('@/app/composables/useWorkflowState', async () => {
+	const actual = await vi.importActual('@/app/composables/useWorkflowState');
+	return {
+		...actual,
+		injectWorkflowState: vi.fn(),
+	};
+});
+
+vi.mock('@/app/utils/nodes/nodeTransforms', () => ({
+	needsAgentInput: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('@/features/ndv/parameters/utils/buttonParameter.utils', () => ({
+	generateCodeForAiTransform: vi.fn(),
+}));
+
+vi.mock('@/app/event-bus', () => ({
+	nodeViewEventBus: { emit: vi.fn() },
+}));
+
+function createTestNode(overrides: Partial<INodeUi> = {}): INodeUi {
+	return {
+		id: 'test-id',
+		name: 'Test Node',
+		type: 'n8n-nodes-base.set',
+		typeVersion: 1,
+		position: [0, 0],
+		parameters: {},
+		...overrides,
+	} as INodeUi;
+}
+
+let workflowState: WorkflowState;
+let uiStore: ReturnType<typeof useUIStore>;
+
+describe('useNodeExecution', () => {
+	beforeEach(() => {
+		const pinia = createTestingPinia({ stubActions: false });
+		setActivePinia(pinia);
+
+		workflowState = vi.mocked(useWorkflowState());
+		vi.mocked(injectWorkflowState).mockReturnValue(workflowState);
+
+		uiStore = useUIStore();
+
+		// Reset store properties to defaults
+		mockWorkflowsStore.isWorkflowRunning = false;
+		mockWorkflowsStore.executedNode = undefined;
+		mockWorkflowsStore.executionWaitingForWebhook = false;
+		mockWorkflowsStore.chatPartialExecutionDestinationNode = undefined;
+		mockWorkflowsStore.checkIfNodeHasChatParent.mockReturnValue(false);
+		mockWorkflowsStore.removeTestWebhook.mockReset();
+		mockWorkflowsStore.getNodeByName.mockReset();
+
+		mockNodeTypesStore.getNodeType.mockReturnValue(null);
+		mockNodeTypesStore.isTriggerNode.mockReturnValue(false);
+
+		mockNdvStore.activeNode = null;
+		mockNdvStore.isInputPanelEmpty = false;
+		mockNdvStore.unsetActiveNodeName.mockReset();
+
+		mockRunWorkflow.runWorkflow.mockReset();
+		mockRunWorkflow.stopCurrentExecution.mockReset();
+
+		mockPinnedData.hasData.value = false;
+		mockPinnedData.unsetData.mockReset();
+
+		mockMessage.confirm.mockReset();
+
+		vi.mocked(needsAgentInput).mockReturnValue(false);
+		vi.mocked(generateCodeForAiTransform).mockReset();
+	});
+
+	describe('isTriggerNode', () => {
+		it('should return true when the node is a trigger node', () => {
+			mockNodeTypesStore.isTriggerNode.mockReturnValue(true);
+			const node = ref(createTestNode({ type: WEBHOOK_NODE_TYPE }));
+
+			const { isTriggerNode } = useNodeExecution(node);
+
+			expect(isTriggerNode.value).toBe(true);
+			expect(mockNodeTypesStore.isTriggerNode).toHaveBeenCalledWith(WEBHOOK_NODE_TYPE);
+		});
+
+		it('should return false when the node is not a trigger node', () => {
+			const node = ref(createTestNode());
+
+			const { isTriggerNode } = useNodeExecution(node);
+
+			expect(isTriggerNode.value).toBe(false);
+		});
+
+		it('should return false when node is null', () => {
+			const node = ref<INodeUi | null>(null);
+
+			const { isTriggerNode } = useNodeExecution(node);
+
+			expect(isTriggerNode.value).toBe(false);
+		});
+	});
+
+	describe('hasIssues', () => {
+		it('should return true when node has parameter issues', () => {
+			const node = ref(
+				createTestNode({
+					issues: { parameters: { param1: ['error'] } },
+				}),
+			);
+
+			const { hasIssues } = useNodeExecution(node);
+
+			expect(hasIssues.value).toBe(true);
+		});
+
+		it('should return true when node has credential issues', () => {
+			const node = ref(
+				createTestNode({
+					issues: { credentials: { cred1: ['error'] } },
+				}),
+			);
+
+			const { hasIssues } = useNodeExecution(node);
+
+			expect(hasIssues.value).toBe(true);
+		});
+
+		it('should return false when node has no issues', () => {
+			const node = ref(createTestNode());
+
+			const { hasIssues } = useNodeExecution(node);
+
+			expect(hasIssues.value).toBe(false);
+		});
+	});
+
+	describe('isListening', () => {
+		it('should return true when trigger node is waiting for webhook', () => {
+			mockNodeTypesStore.isTriggerNode.mockReturnValue(true);
+			mockWorkflowsStore.executionWaitingForWebhook = true;
+			const node = ref(createTestNode({ disabled: false }));
+
+			const { isListening } = useNodeExecution(node);
+
+			expect(isListening.value).toBe(true);
+		});
+
+		it('should return false when node is disabled', () => {
+			mockNodeTypesStore.isTriggerNode.mockReturnValue(true);
+			mockWorkflowsStore.executionWaitingForWebhook = true;
+			const node = ref(createTestNode({ disabled: true }));
+
+			const { isListening } = useNodeExecution(node);
+
+			expect(isListening.value).toBe(false);
+		});
+
+		it('should return false when not a trigger node', () => {
+			mockWorkflowsStore.executionWaitingForWebhook = true;
+			const node = ref(createTestNode());
+
+			const { isListening } = useNodeExecution(node);
+
+			expect(isListening.value).toBe(false);
+		});
+
+		it('should return false when not waiting for webhook', () => {
+			mockNodeTypesStore.isTriggerNode.mockReturnValue(true);
+			const node = ref(createTestNode());
+
+			const { isListening } = useNodeExecution(node);
+
+			expect(isListening.value).toBe(false);
+		});
+
+		it('should return false when executed node is a different node', () => {
+			mockNodeTypesStore.isTriggerNode.mockReturnValue(true);
+			mockWorkflowsStore.executionWaitingForWebhook = true;
+			mockWorkflowsStore.executedNode = 'Other Node';
+			const node = ref(createTestNode({ name: 'Test Node' }));
+
+			const { isListening } = useNodeExecution(node);
+
+			expect(isListening.value).toBe(false);
+		});
+	});
+
+	describe('isListeningForWorkflowEvents', () => {
+		it('should return true when running trigger node that is not schedule or manual', () => {
+			mockNodeTypesStore.isTriggerNode.mockReturnValue(true);
+			mockNodeTypesStore.getNodeType.mockReturnValue({
+				name: WEBHOOK_NODE_TYPE,
+				group: ['trigger'],
+			} as INodeTypeDescription);
+			mockWorkflowsStore.isWorkflowRunning = true;
+			mockWorkflowsStore.executedNode = 'Test Node';
+			const node = ref(createTestNode({ name: 'Test Node' }));
+
+			const { isListeningForWorkflowEvents } = useNodeExecution(node);
+
+			expect(isListeningForWorkflowEvents.value).toBe(true);
+		});
+
+		it('should return false for schedule trigger nodes', () => {
+			mockNodeTypesStore.isTriggerNode.mockReturnValue(true);
+			mockNodeTypesStore.getNodeType.mockReturnValue({
+				name: 'n8n-nodes-base.scheduleTrigger',
+				group: ['schedule'],
+			} as INodeTypeDescription);
+			mockWorkflowsStore.isWorkflowRunning = true;
+			mockWorkflowsStore.executedNode = 'Test Node';
+			const node = ref(createTestNode({ name: 'Test Node' }));
+
+			const { isListeningForWorkflowEvents } = useNodeExecution(node);
+
+			expect(isListeningForWorkflowEvents.value).toBe(false);
+		});
+
+		it('should return false for manual trigger nodes', () => {
+			mockNodeTypesStore.isTriggerNode.mockReturnValue(true);
+			mockNodeTypesStore.getNodeType.mockReturnValue({
+				name: MANUAL_TRIGGER_NODE_TYPE,
+				group: ['trigger'],
+			} as INodeTypeDescription);
+			mockWorkflowsStore.isWorkflowRunning = true;
+			mockWorkflowsStore.executedNode = 'Test Node';
+			const node = ref(createTestNode({ name: 'Test Node' }));
+
+			const { isListeningForWorkflowEvents } = useNodeExecution(node);
+
+			expect(isListeningForWorkflowEvents.value).toBe(false);
+		});
+	});
+
+	describe('isExecuting', () => {
+		it('should return true when node is running and not listening', () => {
+			mockWorkflowsStore.isWorkflowRunning = true;
+			mockWorkflowsStore.executedNode = 'Test Node';
+			const node = ref(createTestNode({ name: 'Test Node' }));
+
+			const { isExecuting } = useNodeExecution(node);
+
+			expect(isExecuting.value).toBe(true);
+		});
+
+		it('should return false when workflow is not running', () => {
+			const node = ref(createTestNode());
+
+			const { isExecuting } = useNodeExecution(node);
+
+			expect(isExecuting.value).toBe(false);
+		});
+	});
+
+	describe('disabledReason', () => {
+		it('should return empty string when listening', () => {
+			mockNodeTypesStore.isTriggerNode.mockReturnValue(true);
+			mockWorkflowsStore.executionWaitingForWebhook = true;
+			const node = ref(createTestNode({ disabled: false }));
+
+			const { disabledReason } = useNodeExecution(node);
+
+			expect(disabledReason.value).toBe('');
+		});
+
+		it('should return disabled message when node is disabled', () => {
+			const node = ref(createTestNode({ disabled: true }));
+
+			const { disabledReason } = useNodeExecution(node);
+
+			expect(disabledReason.value).toBe('ndv.execute.nodeIsDisabled');
+		});
+
+		it('should return missing fields message for trigger node with issues', () => {
+			mockNodeTypesStore.isTriggerNode.mockReturnValue(true);
+			const node = ref(
+				createTestNode({
+					issues: { parameters: { param1: ['error'] } },
+				}),
+			);
+
+			const { disabledReason } = useNodeExecution(node);
+
+			expect(disabledReason.value).toBe('ndv.execute.requiredFieldsMissing');
+		});
+
+		it('should return workflow running message when another node is executing', () => {
+			mockWorkflowsStore.isWorkflowRunning = true;
+			mockWorkflowsStore.executedNode = 'Other Node';
+			const node = ref(createTestNode({ name: 'Test Node' }));
+
+			const { disabledReason } = useNodeExecution(node);
+
+			expect(disabledReason.value).toBe('ndv.execute.workflowAlreadyRunning');
+		});
+
+		it('should return empty string when no disabled condition applies', () => {
+			const node = ref(createTestNode());
+
+			const { disabledReason } = useNodeExecution(node);
+
+			expect(disabledReason.value).toBe('');
+		});
+	});
+
+	describe('buttonLabel', () => {
+		it('should return stopListening when isListening', () => {
+			mockNodeTypesStore.isTriggerNode.mockReturnValue(true);
+			mockWorkflowsStore.executionWaitingForWebhook = true;
+			const node = ref(createTestNode({ disabled: false }));
+
+			const { buttonLabel } = useNodeExecution(node);
+
+			expect(buttonLabel.value).toBe('ndv.execute.stopListening');
+		});
+
+		it('should return testChat for chat trigger node', () => {
+			mockNodeTypesStore.getNodeType.mockReturnValue({
+				name: CHAT_TRIGGER_NODE_TYPE,
+				group: ['trigger'],
+			} as INodeTypeDescription);
+			const node = ref(createTestNode({ type: CHAT_TRIGGER_NODE_TYPE }));
+
+			const { buttonLabel } = useNodeExecution(node);
+
+			expect(buttonLabel.value).toBe('ndv.execute.testChat');
+		});
+
+		it('should return listenForTestEvent for webhook node', () => {
+			mockNodeTypesStore.getNodeType.mockReturnValue({
+				name: WEBHOOK_NODE_TYPE,
+				group: ['trigger'],
+			} as INodeTypeDescription);
+			const node = ref(createTestNode({ type: WEBHOOK_NODE_TYPE }));
+
+			const { buttonLabel } = useNodeExecution(node);
+
+			expect(buttonLabel.value).toBe('ndv.execute.listenForTestEvent');
+		});
+
+		it('should return testStep for form trigger node', () => {
+			mockNodeTypesStore.getNodeType.mockReturnValue({
+				name: FORM_TRIGGER_NODE_TYPE,
+				group: ['trigger'],
+			} as INodeTypeDescription);
+			const node = ref(createTestNode({ type: FORM_TRIGGER_NODE_TYPE }));
+
+			const { buttonLabel } = useNodeExecution(node);
+
+			expect(buttonLabel.value).toBe('ndv.execute.testStep');
+		});
+
+		it('should return fetchEvent for polling type node', () => {
+			mockNodeTypesStore.getNodeType.mockReturnValue({
+				name: 'n8n-nodes-base.emailReadImap',
+				group: ['trigger'],
+				polling: true,
+			} as unknown as INodeTypeDescription);
+			const node = ref(createTestNode());
+
+			const { buttonLabel } = useNodeExecution(node);
+
+			expect(buttonLabel.value).toBe('ndv.execute.fetchEvent');
+		});
+
+		it('should return fetchEvent for mockManualExecution node', () => {
+			mockNodeTypesStore.getNodeType.mockReturnValue({
+				name: 'n8n-nodes-base.someNode',
+				group: [],
+				mockManualExecution: true,
+			} as unknown as INodeTypeDescription);
+			const node = ref(createTestNode());
+
+			const { buttonLabel } = useNodeExecution(node);
+
+			expect(buttonLabel.value).toBe('ndv.execute.fetchEvent');
+		});
+
+		it('should return testNode as default', () => {
+			mockNodeTypesStore.getNodeType.mockReturnValue({
+				name: 'n8n-nodes-base.set',
+				group: [] as string[],
+			} as INodeTypeDescription);
+			const node = ref(createTestNode());
+
+			const { buttonLabel } = useNodeExecution(node);
+
+			expect(buttonLabel.value).toBe('ndv.execute.testNode');
+		});
+	});
+
+	describe('buttonIcon', () => {
+		it('should return flask-conical when not listening', () => {
+			const node = ref(createTestNode());
+
+			const { buttonIcon } = useNodeExecution(node);
+
+			expect(buttonIcon.value).toBe('flask-conical');
+		});
+
+		it('should return undefined when listening', () => {
+			mockNodeTypesStore.isTriggerNode.mockReturnValue(true);
+			mockWorkflowsStore.executionWaitingForWebhook = true;
+			const node = ref(createTestNode({ disabled: false }));
+
+			const { buttonIcon } = useNodeExecution(node);
+
+			expect(buttonIcon.value).toBeUndefined();
+		});
+
+		it('should return terminal when should generate code', () => {
+			const node = ref(
+				createTestNode({
+					type: AI_TRANSFORM_NODE_TYPE,
+					parameters: { instructions: 'do something' },
+				}),
+			);
+
+			const { buttonIcon } = useNodeExecution(node);
+
+			expect(buttonIcon.value).toBe('terminal');
+		});
+	});
+
+	describe('shouldGenerateCode', () => {
+		it('should return false for non-AI transform nodes', () => {
+			const node = ref(createTestNode());
+
+			const { shouldGenerateCode } = useNodeExecution(node);
+
+			expect(shouldGenerateCode.value).toBe(false);
+		});
+
+		it('should return false when AI transform has no instructions', () => {
+			const node = ref(
+				createTestNode({
+					type: AI_TRANSFORM_NODE_TYPE,
+					parameters: {},
+				}),
+			);
+
+			const { shouldGenerateCode } = useNodeExecution(node);
+
+			expect(shouldGenerateCode.value).toBe(false);
+		});
+
+		it('should return true when AI transform has instructions but no code', () => {
+			const node = ref(
+				createTestNode({
+					type: AI_TRANSFORM_NODE_TYPE,
+					parameters: { instructions: 'do something' },
+				}),
+			);
+
+			const { shouldGenerateCode } = useNodeExecution(node);
+
+			expect(shouldGenerateCode.value).toBe(true);
+		});
+
+		it('should return false when AI transform has matching prompt and code', () => {
+			const node = ref(
+				createTestNode({
+					type: AI_TRANSFORM_NODE_TYPE,
+					parameters: {
+						instructions: 'do something',
+						[AI_TRANSFORM_JS_CODE]: 'return items;',
+						[AI_TRANSFORM_CODE_GENERATED_FOR_PROMPT]: 'do something',
+					},
+				}),
+			);
+
+			const { shouldGenerateCode } = useNodeExecution(node);
+
+			expect(shouldGenerateCode.value).toBe(false);
+		});
+
+		it('should return true when AI transform instructions differ from generated prompt', () => {
+			const node = ref(
+				createTestNode({
+					type: AI_TRANSFORM_NODE_TYPE,
+					parameters: {
+						instructions: 'do something new',
+						[AI_TRANSFORM_JS_CODE]: 'return items;',
+						[AI_TRANSFORM_CODE_GENERATED_FOR_PROMPT]: 'do something old',
+					},
+				}),
+			);
+
+			const { shouldGenerateCode } = useNodeExecution(node);
+
+			expect(shouldGenerateCode.value).toBe(true);
+		});
+	});
+
+	describe('execute', () => {
+		it('should return noop when node is null', async () => {
+			const node = ref<INodeUi | null>(null);
+
+			const { execute } = useNodeExecution(node);
+			const result = await execute();
+
+			expect(result).toBe('noop');
+		});
+
+		it('should open chat for chat trigger nodes', async () => {
+			mockNodeTypesStore.getNodeType.mockReturnValue({
+				name: CHAT_TRIGGER_NODE_TYPE,
+				group: ['trigger'],
+			} as INodeTypeDescription);
+			const node = ref(createTestNode({ name: 'Chat Node', type: CHAT_TRIGGER_NODE_TYPE }));
+
+			const { execute } = useNodeExecution(node);
+			const result = await execute();
+
+			expect(result).toBe('opened-chat');
+			expect(mockNdvStore.unsetActiveNodeName).toHaveBeenCalled();
+			expect(nodeViewEventBus.emit).toHaveBeenCalledWith('openChat');
+			expect(mockWorkflowsStore.chatPartialExecutionDestinationNode).toBe('Chat Node');
+		});
+
+		it('should open chat for chat child nodes when input panel is empty', async () => {
+			mockWorkflowsStore.checkIfNodeHasChatParent.mockReturnValue(true);
+			mockNdvStore.isInputPanelEmpty = true;
+			const node = ref(createTestNode({ name: 'Child Node' }));
+
+			const { execute } = useNodeExecution(node);
+			const result = await execute();
+
+			expect(result).toBe('opened-chat');
+		});
+
+		it('should stop webhook when listening', async () => {
+			mockNodeTypesStore.isTriggerNode.mockReturnValue(true);
+			mockWorkflowsStore.executionWaitingForWebhook = true;
+			const node = ref(createTestNode({ disabled: false }));
+
+			const { execute } = useNodeExecution(node);
+			const result = await execute();
+
+			expect(result).toBe('stopped-webhook');
+			expect(mockWorkflowsStore.removeTestWebhook).toHaveBeenCalledWith('123');
+		});
+
+		it('should stop execution when listening for workflow events', async () => {
+			mockNodeTypesStore.isTriggerNode.mockReturnValue(true);
+			mockNodeTypesStore.getNodeType.mockReturnValue({
+				name: WEBHOOK_NODE_TYPE,
+				group: ['trigger'],
+			} as INodeTypeDescription);
+			mockWorkflowsStore.isWorkflowRunning = true;
+			mockWorkflowsStore.executedNode = 'Test Node';
+			const node = ref(createTestNode({ name: 'Test Node' }));
+
+			const { execute } = useNodeExecution(node);
+			const result = await execute();
+
+			expect(result).toBe('stopped-execution');
+			expect(mockRunWorkflow.stopCurrentExecution).toHaveBeenCalled();
+		});
+
+		it('should open modal for nodes needing agent input', async () => {
+			vi.mocked(needsAgentInput).mockReturnValue(true);
+			const node = ref(createTestNode({ name: 'Agent Node' }));
+
+			const { execute } = useNodeExecution(node);
+			const result = await execute();
+
+			expect(result).toBe('opened-modal');
+			expect(uiStore.openModalWithData).toHaveBeenCalledWith({
+				name: FROM_AI_PARAMETERS_MODAL_KEY,
+				data: { nodeName: 'Agent Node' },
+			});
+		});
+
+		it('should run workflow for normal execution', async () => {
+			const node = ref(createTestNode({ name: 'Set Node' }));
+
+			const { execute } = useNodeExecution(node, {
+				telemetrySource: 'ndv',
+				executionMode: 'inclusive',
+				source: 'RunData.ExecuteNodeButton',
+			});
+			const result = await execute();
+
+			expect(result).toBe('executed');
+			expect(mockRunWorkflow.runWorkflow).toHaveBeenCalledWith({
+				destinationNode: { nodeName: 'Set Node', mode: 'inclusive' },
+				source: 'RunData.ExecuteNodeButton',
+			});
+		});
+
+		it('should handle pinned data with confirm dialog', async () => {
+			mockPinnedData.hasData.value = true;
+			mockMessage.confirm.mockResolvedValue(MODAL_CONFIRM);
+			const node = ref(createTestNode({ name: 'Set Node' }));
+
+			const { execute } = useNodeExecution(node);
+			const result = await execute();
+
+			expect(mockMessage.confirm).toHaveBeenCalled();
+			expect(mockPinnedData.unsetData).toHaveBeenCalledWith('unpin-and-execute-modal');
+			expect(result).toBe('executed');
+		});
+
+		it('should return cancelled when pinned data confirm is dismissed', async () => {
+			mockPinnedData.hasData.value = true;
+			mockMessage.confirm.mockResolvedValue('cancel');
+			const node = ref(createTestNode({ name: 'Set Node' }));
+
+			const { execute } = useNodeExecution(node);
+			const result = await execute();
+
+			expect(result).toBe('cancelled');
+		});
+
+		it('should generate code before executing AI transform node', async () => {
+			vi.mocked(generateCodeForAiTransform).mockResolvedValue({
+				name: `parameters.${AI_TRANSFORM_JS_CODE}`,
+				value: 'return items;',
+			});
+			vi.spyOn(workflowState, 'updateNodeProperties').mockImplementation(() => {});
+			const node = ref(
+				createTestNode({
+					name: 'AI Transform',
+					type: AI_TRANSFORM_NODE_TYPE,
+					parameters: { instructions: 'do something' },
+				}),
+			);
+
+			const { execute } = useNodeExecution(node);
+			const result = await execute();
+
+			expect(generateCodeForAiTransform).toHaveBeenCalled();
+			expect(workflowState.updateNodeProperties).toHaveBeenCalled();
+			expect(result).toBe('executed');
+		});
+
+		it('should return cancelled when code generation fails', async () => {
+			vi.mocked(generateCodeForAiTransform).mockResolvedValue(undefined as never);
+			const node = ref(
+				createTestNode({
+					name: 'AI Transform',
+					type: AI_TRANSFORM_NODE_TYPE,
+					parameters: { instructions: 'do something' },
+				}),
+			);
+
+			const { execute } = useNodeExecution(node);
+			const result = await execute();
+
+			expect(result).toBe('cancelled');
+		});
+	});
+
+	describe('stopExecution', () => {
+		it('should stop webhook when listening', async () => {
+			mockNodeTypesStore.isTriggerNode.mockReturnValue(true);
+			mockWorkflowsStore.executionWaitingForWebhook = true;
+			const node = ref(createTestNode({ disabled: false }));
+
+			const { stopExecution } = useNodeExecution(node);
+			await stopExecution();
+
+			expect(mockWorkflowsStore.removeTestWebhook).toHaveBeenCalledWith('123');
+		});
+
+		it('should stop current execution when listening for workflow events', async () => {
+			mockNodeTypesStore.isTriggerNode.mockReturnValue(true);
+			mockNodeTypesStore.getNodeType.mockReturnValue({
+				name: WEBHOOK_NODE_TYPE,
+				group: ['trigger'],
+			} as INodeTypeDescription);
+			mockWorkflowsStore.isWorkflowRunning = true;
+			mockWorkflowsStore.executedNode = 'Test Node';
+			const node = ref(createTestNode({ name: 'Test Node' }));
+
+			const { stopExecution } = useNodeExecution(node);
+			await stopExecution();
+
+			expect(mockRunWorkflow.stopCurrentExecution).toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/app/composables/useNodeExecution.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeExecution.ts
@@ -9,7 +9,7 @@ import {
 	AI_TRANSFORM_NODE_TYPE,
 } from 'n8n-workflow';
 
-import type { INodeUi } from '@/Interface';
+import type { INodeUi, IUpdateInformation } from '@/Interface';
 
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
@@ -51,6 +51,7 @@ export type UseNodeExecutionOptions = {
 	telemetrySource?: string;
 	executionMode?: MaybeRef<'inclusive' | 'exclusive'>;
 	source?: string;
+	onCodeGenerated?: (update: IUpdateInformation) => void;
 };
 
 export type NodeExecutionState = {
@@ -297,6 +298,15 @@ export function useNodeExecution(
 						[AI_TRANSFORM_CODE_GENERATED_FOR_PROMPT]: prompt,
 					},
 				},
+			});
+
+			options.onCodeGenerated?.({
+				name: `parameters.${AI_TRANSFORM_JS_CODE}`,
+				value: updateInformation.value,
+			});
+			options.onCodeGenerated?.({
+				name: `parameters.${AI_TRANSFORM_CODE_GENERATED_FOR_PROMPT}`,
+				value: prompt,
 			});
 
 			telemetry.trackAiTransform('generationFinished', {

--- a/packages/frontend/editor-ui/src/app/composables/useNodeExecution.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeExecution.ts
@@ -38,6 +38,21 @@ import {
 	FROM_AI_PARAMETERS_MODAL_KEY,
 } from '@/app/constants';
 
+export type ExecuteAction =
+	| 'executed'
+	| 'stopped-webhook'
+	| 'stopped-execution'
+	| 'opened-chat'
+	| 'opened-modal'
+	| 'cancelled'
+	| 'noop';
+
+export type UseNodeExecutionOptions = {
+	telemetrySource?: string;
+	executionMode?: MaybeRef<'inclusive' | 'exclusive'>;
+	source?: string;
+};
+
 export type NodeExecutionState = {
 	isExecuting: ComputedRef<boolean>;
 	isListening: ComputedRef<boolean>;
@@ -46,25 +61,31 @@ export type NodeExecutionState = {
 	buttonIcon: ComputedRef<IconName | undefined>;
 	disabledReason: ComputedRef<string>;
 	isTriggerNode: ComputedRef<boolean>;
+	hasIssues: ComputedRef<boolean>;
+	shouldGenerateCode: ComputedRef<boolean>;
 };
 
 export type NodeExecutionActions = {
-	execute: () => Promise<void>;
+	execute: () => Promise<ExecuteAction>;
 	stopExecution: () => Promise<void>;
 };
 
-// TODO: This duplicates a lot of logic from `NodeExecuteButton` component
-// we need to update the component to use this composable
-
 /**
  * Composable that provides node execution state and actions.
- * @param node - The node to execute (can be a ref or INodeUi object)
- * @param telemetrySource - Source identifier for telemetry tracking
+ * Used by both NodeExecuteButton component and SetupPanel.
+ * @param node - The node to execute (can be a ref, computed, or raw value; may be null/undefined)
+ * @param options - Configuration options for execution behavior
  */
 export function useNodeExecution(
-	node: MaybeRef<INodeUi>,
-	telemetrySource = 'setupPanel',
+	node: MaybeRef<INodeUi | null | undefined>,
+	options: UseNodeExecutionOptions = {},
 ): NodeExecutionState & NodeExecutionActions {
+	const {
+		telemetrySource = 'setupPanel',
+		executionMode = 'inclusive',
+		source = 'SetupPanel.ExecuteNodeButton',
+	} = options;
+
 	const router = useRouter();
 	const i18n = useI18n();
 	const telemetry = useTelemetry();
@@ -82,7 +103,7 @@ export function useNodeExecution(
 
 	const codeGenerationInProgress = ref(false);
 
-	const nodeRef = computed(() => toValue(node));
+	const nodeRef = computed(() => toValue(node) ?? null);
 
 	const pinnedData = usePinnedData(nodeRef);
 
@@ -300,15 +321,15 @@ export function useNodeExecution(
 		return true;
 	}
 
-	async function execute(): Promise<void> {
-		if (!nodeRef.value) return;
+	async function execute(): Promise<ExecuteAction> {
+		if (!nodeRef.value) return 'noop';
 
 		const nodeName = nodeRef.value.name;
 
 		// AI Transform code generation
 		if (shouldGenerateCode.value) {
 			const success = await handleCodeGeneration();
-			if (!success) return;
+			if (!success) return 'cancelled';
 		}
 
 		// Chat nodes
@@ -316,19 +337,19 @@ export function useNodeExecution(
 			ndvStore.unsetActiveNodeName();
 			workflowsStore.chatPartialExecutionDestinationNode = nodeName;
 			nodeViewEventBus.emit('openChat');
-			return;
+			return 'opened-chat';
 		}
 
 		// Stop webhook listening
 		if (isListening.value) {
 			await stopWaitingForWebhook();
-			return;
+			return 'stopped-webhook';
 		}
 
 		// Stop workflow execution
 		if (isListeningForWorkflowEvents.value) {
 			await stopCurrentExecution();
-			return;
+			return 'stopped-execution';
 		}
 
 		// Handle pinned data
@@ -358,7 +379,7 @@ export function useNodeExecution(
 						nodeName,
 					},
 				});
-				return;
+				return 'opened-modal';
 			}
 
 			// Normal execution
@@ -373,10 +394,14 @@ export function useNodeExecution(
 			await externalHooks.run('nodeExecuteButton.onClick', telemetryPayload);
 
 			await runWorkflow({
-				destinationNode: { nodeName, mode: 'inclusive' },
-				source: 'SetupPanel.ExecuteNodeButton',
+				destinationNode: { nodeName, mode: toValue(executionMode) },
+				source,
 			});
+
+			return 'executed';
 		}
+
+		return 'cancelled';
 	}
 
 	async function stopExecution(): Promise<void> {
@@ -395,6 +420,8 @@ export function useNodeExecution(
 		buttonIcon,
 		disabledReason,
 		isTriggerNode,
+		hasIssues,
+		shouldGenerateCode,
 		execute,
 		stopExecution,
 	};

--- a/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.test.ts
+++ b/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.test.ts
@@ -383,7 +383,7 @@ describe('NodeSetupCard', () => {
 			const testButton = getByTestId('node-setup-card-test-button');
 			await userEvent.click(testButton);
 
-			expect(mockExecute).toHaveBeenCalledOnce();
+			expect(mockExecute).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.test.ts
+++ b/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.test.ts
@@ -9,6 +9,29 @@ import NodeSetupCard from './NodeSetupCard.vue';
 import type { NodeSetupState } from '../setupPanel.types';
 import type { INodeUi } from '@/Interface';
 
+const { mockExecute } = vi.hoisted(() => ({
+	mockExecute: vi.fn(),
+}));
+
+vi.mock('@/app/composables/useNodeExecution', async () => {
+	const { ref } = await import('vue');
+	return {
+		useNodeExecution: vi.fn(() => ({
+			isExecuting: ref(false),
+			isListening: ref(false),
+			isListeningForWorkflowEvents: ref(false),
+			buttonLabel: ref('Test node'),
+			buttonIcon: ref('flask-conical'),
+			disabledReason: ref(''),
+			isTriggerNode: ref(false),
+			hasIssues: ref(false),
+			shouldGenerateCode: ref(false),
+			execute: mockExecute,
+			stopExecution: vi.fn(),
+		})),
+	};
+});
+
 vi.mock('@/features/credentials/components/CredentialPicker/CredentialPicker.vue', () => ({
 	default: {
 		template:
@@ -42,6 +65,7 @@ const createState = (overrides: Partial<NodeSetupState> = {}): NodeSetupState =>
 			},
 		],
 		isComplete: false,
+		isTrigger: true,
 		...overrides,
 	};
 };
@@ -50,6 +74,7 @@ describe('NodeSetupCard', () => {
 	let nodeTypesStore: ReturnType<typeof mockedStore<typeof useNodeTypesStore>>;
 
 	beforeEach(() => {
+		mockExecute.mockClear();
 		createTestingPinia();
 		nodeTypesStore = mockedStore(useNodeTypesStore);
 		nodeTypesStore.getNodeType = vi.fn().mockReturnValue(
@@ -160,6 +185,47 @@ describe('NodeSetupCard', () => {
 
 			expect(queryByTestId('node-setup-card-shared-nodes-hint')).not.toBeInTheDocument();
 		});
+
+		it('should apply no-content class when there are no credential requirements', () => {
+			const { getByTestId } = renderComponent({
+				props: {
+					state: createState({ credentialRequirements: [], isTrigger: true }),
+					expanded: true,
+				},
+			});
+
+			expect(getByTestId('node-setup-card').className).toMatch(/no-content/);
+		});
+
+		it('should not apply no-content class when there are credential requirements', () => {
+			const { getByTestId } = renderComponent({
+				props: { state: createState(), expanded: true },
+			});
+
+			expect(getByTestId('node-setup-card').className).not.toMatch(/no-content/);
+		});
+
+		it('should show footer for non-complete trigger nodes', () => {
+			const { getByTestId } = renderComponent({
+				props: {
+					state: createState({ isTrigger: true, isComplete: false }),
+					expanded: true,
+				},
+			});
+
+			expect(getByTestId('node-setup-card-test-button')).toBeInTheDocument();
+		});
+
+		it('should not show footer for non-trigger non-complete nodes', () => {
+			const { queryByTestId } = renderComponent({
+				props: {
+					state: createState({ isTrigger: false, isComplete: false }),
+					expanded: true,
+				},
+			});
+
+			expect(queryByTestId('node-setup-card-test-button')).not.toBeInTheDocument();
+		});
 	});
 
 	describe('expand/collapse', () => {
@@ -232,20 +298,39 @@ describe('NodeSetupCard', () => {
 	});
 
 	describe('test button', () => {
-		it('should render test button when expanded', () => {
+		it('should render test button for trigger nodes when expanded', () => {
 			const { getByTestId } = renderComponent({
-				props: { state: createState(), expanded: true },
+				props: { state: createState({ isTrigger: true }), expanded: true },
 			});
 
 			expect(getByTestId('node-setup-card-test-button')).toBeInTheDocument();
 		});
 
-		it('should disable test button when state is not complete', () => {
+		it('should not render test button for non-trigger nodes', () => {
+			const { queryByTestId } = renderComponent({
+				props: { state: createState({ isTrigger: false }), expanded: true },
+			});
+
+			expect(queryByTestId('node-setup-card-test-button')).not.toBeInTheDocument();
+		});
+
+		it('should disable test button when node has issues', () => {
+			const state = createState({ isTrigger: true });
+			state.node.issues = { credentials: { openAiApi: ['Missing credential'] } };
+
 			const { getByTestId } = renderComponent({
-				props: { state: createState({ isComplete: false }), expanded: true },
+				props: { state, expanded: true },
 			});
 
 			expect(getByTestId('node-setup-card-test-button')).toBeDisabled();
+		});
+
+		it('should enable test button when node has no issues', () => {
+			const { getByTestId } = renderComponent({
+				props: { state: createState({ isTrigger: true }), expanded: true },
+			});
+
+			expect(getByTestId('node-setup-card-test-button')).not.toBeDisabled();
 		});
 	});
 
@@ -285,12 +370,12 @@ describe('NodeSetupCard', () => {
 		});
 	});
 
-	describe('test node event', () => {
-		it('should emit testNode when test button is clicked', async () => {
-			const state = createState({ isComplete: true });
+	describe('test node execution', () => {
+		it('should call execute when test button is clicked', async () => {
+			const state = createState({ isComplete: true, isTrigger: true });
 
 			// Mount collapsed with isComplete: true, then expand via header click
-			const { getByTestId, emitted } = renderComponent({
+			const { getByTestId } = renderComponent({
 				props: { state, expanded: false },
 			});
 			await userEvent.click(getByTestId('node-setup-card-header'));
@@ -298,7 +383,7 @@ describe('NodeSetupCard', () => {
 			const testButton = getByTestId('node-setup-card-test-button');
 			await userEvent.click(testButton);
 
-			expect(emitted('testNode')).toHaveLength(1);
+			expect(mockExecute).toHaveBeenCalledOnce();
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.test.ts
+++ b/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.test.ts
@@ -9,22 +9,27 @@ import NodeSetupCard from './NodeSetupCard.vue';
 import type { NodeSetupState } from '../setupPanel.types';
 import type { INodeUi } from '@/Interface';
 
-const { mockExecute } = vi.hoisted(() => ({
+const { mockExecute, mockComposableState } = vi.hoisted(() => ({
 	mockExecute: vi.fn(),
+	mockComposableState: {
+		isExecuting: false,
+		hasIssues: false,
+		disabledReason: '',
+	},
 }));
 
 vi.mock('@/app/composables/useNodeExecution', async () => {
-	const { ref } = await import('vue');
+	const { ref, computed } = await import('vue');
 	return {
 		useNodeExecution: vi.fn(() => ({
-			isExecuting: ref(false),
+			isExecuting: computed(() => mockComposableState.isExecuting),
 			isListening: ref(false),
 			isListeningForWorkflowEvents: ref(false),
 			buttonLabel: ref('Test node'),
 			buttonIcon: ref('flask-conical'),
-			disabledReason: ref(''),
+			disabledReason: computed(() => mockComposableState.disabledReason),
 			isTriggerNode: ref(false),
-			hasIssues: ref(false),
+			hasIssues: computed(() => mockComposableState.hasIssues),
 			shouldGenerateCode: ref(false),
 			execute: mockExecute,
 			stopExecution: vi.fn(),
@@ -75,6 +80,9 @@ describe('NodeSetupCard', () => {
 
 	beforeEach(() => {
 		mockExecute.mockClear();
+		mockComposableState.isExecuting = false;
+		mockComposableState.hasIssues = false;
+		mockComposableState.disabledReason = '';
 		createTestingPinia();
 		nodeTypesStore = mockedStore(useNodeTypesStore);
 		nodeTypesStore.getNodeType = vi.fn().mockReturnValue(
@@ -315,17 +323,26 @@ describe('NodeSetupCard', () => {
 		});
 
 		it('should disable test button when node has issues', () => {
-			const state = createState({ isTrigger: true });
-			state.node.issues = { credentials: { openAiApi: ['Missing credential'] } };
+			mockComposableState.hasIssues = true;
 
 			const { getByTestId } = renderComponent({
-				props: { state, expanded: true },
+				props: { state: createState({ isTrigger: true }), expanded: true },
 			});
 
 			expect(getByTestId('node-setup-card-test-button')).toBeDisabled();
 		});
 
-		it('should enable test button when node has no issues', () => {
+		it('should disable test button when node is executing', () => {
+			mockComposableState.isExecuting = true;
+
+			const { getByTestId } = renderComponent({
+				props: { state: createState({ isTrigger: true }), expanded: true },
+			});
+
+			expect(getByTestId('node-setup-card-test-button')).toBeDisabled();
+		});
+
+		it('should enable test button when node has no issues and is not executing', () => {
 			const { getByTestId } = renderComponent({
 				props: { state: createState({ isTrigger: true }), expanded: true },
 			});

--- a/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.vue
+++ b/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.vue
@@ -26,31 +26,22 @@ const i18n = useI18n();
 const nodeTypesStore = useNodeTypesStore();
 
 const nodeRef = computed(() => props.state.node);
-const { isExecuting, buttonLabel, buttonIcon, disabledReason, execute } = useNodeExecution(nodeRef);
+const { isExecuting, buttonLabel, buttonIcon, disabledReason, hasIssues, execute } =
+	useNodeExecution(nodeRef);
 
 const nodeType = computed(() =>
 	nodeTypesStore.getNodeType(props.state.node.type, props.state.node.typeVersion),
 );
 
-const isLoading = computed(() => isExecuting.value);
-
-const hasNodeIssues = computed(() => {
-	const node = props.state.node;
-	return Boolean(
-		node.issues &&
-			(Object.keys(node.issues.credentials ?? {}).length > 0 ||
-				Object.keys(node.issues.parameters ?? {}).length > 0),
-	);
-});
-
-// For triggers: button is disabled if node has issues or there's a disabledReason
-// The button should be enabled once issues are resolved, even before execution completes
-const isButtonDisabled = computed(() => hasNodeIssues.value || !!disabledReason.value);
+// For triggers: button is disabled if node has issues, is executing, or there's a disabledReason
+const isButtonDisabled = computed(
+	() => isExecuting.value || hasIssues.value || !!disabledReason.value,
+);
 
 const showFooter = computed(() => props.state.isTrigger || props.state.isComplete);
 
 const tooltipText = computed(() => {
-	if (hasNodeIssues.value) {
+	if (hasIssues.value) {
 		return i18n.baseText('ndv.execute.requiredFieldsMissing');
 	}
 	return disabledReason.value;
@@ -174,7 +165,7 @@ onMounted(() => {
 						data-test-id="node-setup-card-test-button"
 						:label="buttonLabel"
 						:disabled="isButtonDisabled"
-						:loading="isLoading"
+						:loading="isExecuting"
 						:icon="buttonIcon"
 						size="small"
 						@click="onTestClick"

--- a/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.vue
+++ b/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue';
 import { useI18n } from '@n8n/i18n';
-import { N8nButton, N8nIcon, N8nText } from '@n8n/design-system';
+import { N8nButton, N8nIcon, N8nText, N8nTooltip } from '@n8n/design-system';
 
 import NodeIcon from '@/app/components/NodeIcon.vue';
 import CredentialPicker from '@/features/credentials/components/CredentialPicker/CredentialPicker.vue';

--- a/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.vue
+++ b/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.vue
@@ -47,6 +47,8 @@ const hasNodeIssues = computed(() => {
 // The button should be enabled once issues are resolved, even before execution completes
 const isButtonDisabled = computed(() => hasNodeIssues.value || !!disabledReason.value);
 
+const showFooter = computed(() => props.state.isTrigger || props.state.isComplete);
+
 const tooltipText = computed(() => {
 	if (hasNodeIssues.value) {
 		return i18n.baseText('ndv.execute.requiredFieldsMissing');
@@ -109,7 +111,10 @@ onMounted(() => {
 		</header>
 
 		<template v-if="expanded">
-			<div v-if="state.credentialRequirements.length" :class="$style.content">
+			<div
+				v-if="state.credentialRequirements.length"
+				:class="{ [$style.content]: true, ['pb-s']: !showFooter }"
+			>
 				<div
 					v-for="requirement in state.credentialRequirements"
 					:key="requirement.credentialType"
@@ -132,7 +137,7 @@ onMounted(() => {
 				</div>
 			</div>
 
-			<footer v-if="state.isTrigger || state.isComplete" :class="$style.footer">
+			<footer v-if="showFooter" :class="$style.footer">
 				<div v-if="state.isComplete" :class="$style['footer-complete-check']">
 					<N8nIcon icon="check" :class="$style['complete-icon']" size="large" />
 					<N8nText size="medium" color="success">

--- a/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.vue
+++ b/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.vue
@@ -74,6 +74,27 @@ const onTestClick = async () => {
 	await execute();
 };
 
+function collectNodeTypesFromRequirements(
+	requirements: Array<{ nodesWithSameCredential: string[] }>,
+) {
+	const types = new Set<string>();
+
+	for (const req of requirements) {
+		for (const nodeName of req.nodesWithSameCredential) {
+			const node = workflowsStore.getNodeByName(nodeName);
+			if (node) types.add(node.type);
+		}
+	}
+
+	return types;
+}
+
+function countRelatedNodes(requirements: Array<{ nodesWithSameCredential: string[] }>) {
+	let count = 0;
+	for (const req of requirements) count += req.nodesWithSameCredential.length;
+	return count;
+}
+
 watch(
 	() => props.state.isComplete,
 	(isComplete) => {
@@ -81,25 +102,12 @@ watch(
 			expanded.value = false;
 
 			if (hadManualInteraction.value) {
-				const nodeTypes = new Set<string>();
-				for (const req of props.state.credentialRequirements) {
-					for (const nodeName of req.nodesWithSameCredential) {
-						const node = workflowsStore.getNodeByName(nodeName);
-						if (node) {
-							nodeTypes.add(node.type);
-						}
-					}
-				}
-
 				telemetry.track('User completed setup step', {
 					template_id: workflowsStore.workflow.meta?.templateId,
 					workflow_id: workflowsStore.workflowId,
 					type: props.state.isTrigger ? 'trigger' : 'credential',
-					nodes: Array.from(nodeTypes),
-					related_nodes_count: props.state.credentialRequirements.reduce(
-						(count, req) => count + req.nodesWithSameCredential.length,
-						0,
-					),
+					nodes: Array.from(collectNodeTypesFromRequirements(props.state.credentialRequirements)),
+					related_nodes_count: countRelatedNodes(props.state.credentialRequirements),
 				});
 				hadManualInteraction.value = false;
 			}

--- a/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.vue
+++ b/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.vue
@@ -103,11 +103,12 @@ onMounted(() => {
 			/>
 			<NodeIcon v-else :node-type="nodeType" :size="16" />
 			<span :class="$style['node-name']">{{ props.state.node.name }}</span>
-			<N8nIcon
-				:class="$style.chevron"
-				:icon="expanded ? 'chevron-up' : 'chevron-down'"
-				size="small"
-			/>
+			<N8nTooltip v-if="state.isTrigger">
+				<template #content>
+					{{ i18n.baseText('nodeCreator.nodeItem.triggerIconTitle') }}
+				</template>
+				<N8nIcon :class="$style.chevron" icon="zap" size="small" />
+			</N8nTooltip>
 		</header>
 
 		<template v-if="expanded">

--- a/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.vue
+++ b/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.vue
@@ -125,7 +125,7 @@ onMounted(() => {
 			</N8nTooltip>
 			<N8nIcon
 				:class="[$style['header-icon'], $style['chevron']]"
-				icon="chevrons-down-up"
+				:icon="expanded ? 'chevrons-down-up' : 'chevrons-up-down'"
 				size="medium"
 				color="text-light"
 			/>

--- a/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.vue
+++ b/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.vue
@@ -9,6 +9,7 @@ import SetupCredentialLabel from './SetupCredentialLabel.vue';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 
 import type { NodeSetupState } from '../setupPanel.types';
+import { useNodeExecution } from '../composables/useNodeExecution';
 
 const props = defineProps<{
 	state: NodeSetupState;
@@ -19,15 +20,29 @@ const expanded = defineModel<boolean>('expanded', { default: false });
 const emit = defineEmits<{
 	credentialSelected: [payload: { credentialType: string; credentialId: string }];
 	credentialDeselected: [credentialType: string];
-	testNode: [];
 }>();
 
 const i18n = useI18n();
 const nodeTypesStore = useNodeTypesStore();
 
+// Use node execution composable
+const nodeRef = computed(() => props.state.node);
+const { isExecuting, isListening, buttonLabel, buttonIcon, disabledReason, execute } =
+	useNodeExecution(nodeRef);
+
 const nodeType = computed(() =>
 	nodeTypesStore.getNodeType(props.state.node.type, props.state.node.typeVersion),
 );
+
+const isLoading = computed(() => isExecuting.value || isListening.value);
+const isButtonDisabled = computed(() => !props.state.isComplete || !!disabledReason.value);
+
+const tooltipText = computed(() => {
+	if (!props.state.isComplete) {
+		return i18n.baseText('ndv.execute.requiredFieldsMissing');
+	}
+	return disabledReason.value;
+});
 
 const onHeaderClick = () => {
 	expanded.value = !expanded.value;
@@ -41,8 +56,8 @@ const onCredentialDeselected = (credentialType: string) => {
 	emit('credentialDeselected', credentialType);
 };
 
-const onTestClick = () => {
-	emit('testNode');
+const onTestClick = async () => {
+	await execute();
 };
 
 watch(
@@ -114,14 +129,17 @@ onMounted(() => {
 						{{ i18n.baseText('generic.complete') }}
 					</N8nText>
 				</div>
-				<N8nButton
-					data-test-id="node-setup-card-test-button"
-					:label="i18n.baseText('node.testStep')"
-					:disabled="!state.isComplete"
-					icon="flask-conical"
-					size="small"
-					@click="onTestClick"
-				/>
+				<N8nTooltip :disabled="!tooltipText" placement="top">
+					<template #content>{{ tooltipText }}</template>
+					<N8nButton
+						:label="buttonLabel"
+						:disabled="isButtonDisabled"
+						:loading="isLoading"
+						:icon="buttonIcon"
+						size="small"
+						@click="onTestClick"
+					/>
+				</N8nTooltip>
 			</footer>
 		</template>
 	</div>

--- a/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.vue
+++ b/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.vue
@@ -25,16 +25,14 @@ const emit = defineEmits<{
 const i18n = useI18n();
 const nodeTypesStore = useNodeTypesStore();
 
-// Use node execution composable
 const nodeRef = computed(() => props.state.node);
-const { isExecuting, isListening, buttonLabel, buttonIcon, disabledReason, execute } =
-	useNodeExecution(nodeRef);
+const { isExecuting, buttonLabel, buttonIcon, disabledReason, execute } = useNodeExecution(nodeRef);
 
 const nodeType = computed(() =>
 	nodeTypesStore.getNodeType(props.state.node.type, props.state.node.typeVersion),
 );
 
-const isLoading = computed(() => isExecuting.value || isListening.value);
+const isLoading = computed(() => isExecuting.value);
 const isButtonDisabled = computed(() => !props.state.isComplete || !!disabledReason.value);
 
 const tooltipText = computed(() => {

--- a/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.vue
+++ b/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.vue
@@ -171,6 +171,7 @@ onMounted(() => {
 				<N8nTooltip v-if="state.isTrigger" :disabled="!tooltipText" placement="top">
 					<template #content>{{ tooltipText }}</template>
 					<N8nButton
+						data-test-id="node-setup-card-test-button"
 						:label="buttonLabel"
 						:disabled="isButtonDisabled"
 						:loading="isLoading"

--- a/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.vue
+++ b/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.vue
@@ -9,7 +9,7 @@ import SetupCredentialLabel from './SetupCredentialLabel.vue';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 
 import type { NodeSetupState } from '../setupPanel.types';
-import { useNodeExecution } from '../composables/useNodeExecution';
+import { useNodeExecution } from '@/app/composables/useNodeExecution';
 
 const props = defineProps<{
 	state: NodeSetupState;

--- a/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.vue
+++ b/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.vue
@@ -33,10 +33,22 @@ const nodeType = computed(() =>
 );
 
 const isLoading = computed(() => isExecuting.value);
-const isButtonDisabled = computed(() => !props.state.isComplete || !!disabledReason.value);
+
+const hasNodeIssues = computed(() => {
+	const node = props.state.node;
+	return Boolean(
+		node.issues &&
+			(Object.keys(node.issues.credentials ?? {}).length > 0 ||
+				Object.keys(node.issues.parameters ?? {}).length > 0),
+	);
+});
+
+// For triggers: button is disabled if node has issues or there's a disabledReason
+// The button should be enabled once issues are resolved, even before execution completes
+const isButtonDisabled = computed(() => hasNodeIssues.value || !!disabledReason.value);
 
 const tooltipText = computed(() => {
-	if (!props.state.isComplete) {
+	if (hasNodeIssues.value) {
 		return i18n.baseText('ndv.execute.requiredFieldsMissing');
 	}
 	return disabledReason.value;
@@ -97,7 +109,7 @@ onMounted(() => {
 		</header>
 
 		<template v-if="expanded">
-			<div :class="$style.content">
+			<div v-if="state.credentialRequirements.length" :class="$style.content">
 				<div
 					v-for="requirement in state.credentialRequirements"
 					:key="requirement.credentialType"
@@ -120,14 +132,14 @@ onMounted(() => {
 				</div>
 			</div>
 
-			<footer :class="$style.footer">
+			<footer v-if="state.isTrigger || state.isComplete" :class="$style.footer">
 				<div v-if="state.isComplete" :class="$style['footer-complete-check']">
 					<N8nIcon icon="check" :class="$style['complete-icon']" size="large" />
 					<N8nText size="medium" color="success">
 						{{ i18n.baseText('generic.complete') }}
 					</N8nText>
 				</div>
-				<N8nTooltip :disabled="!tooltipText" placement="top">
+				<N8nTooltip v-if="state.isTrigger" :disabled="!tooltipText" placement="top">
 					<template #content>{{ tooltipText }}</template>
 					<N8nButton
 						:label="buttonLabel"

--- a/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.vue
+++ b/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.vue
@@ -91,7 +91,14 @@ onMounted(() => {
 <template>
 	<div
 		data-test-id="node-setup-card"
-		:class="[$style.card, { [$style.collapsed]: !expanded, [$style.completed]: state.isComplete }]"
+		:class="[
+			$style.card,
+			{
+				[$style.collapsed]: !expanded,
+				[$style.completed]: state.isComplete,
+				[$style['no-content']]: !state.credentialRequirements.length,
+			},
+		]"
 	>
 		<header data-test-id="node-setup-card-header" :class="$style.header" @click="onHeaderClick">
 			<N8nIcon
@@ -102,13 +109,26 @@ onMounted(() => {
 				size="medium"
 			/>
 			<NodeIcon v-else :node-type="nodeType" :size="16" />
-			<span :class="$style['node-name']">{{ props.state.node.name }}</span>
+			<N8nText :class="$style['node-name']" size="medium" color="text-dark">
+				{{ props.state.node.name }}
+			</N8nText>
 			<N8nTooltip v-if="state.isTrigger">
 				<template #content>
 					{{ i18n.baseText('nodeCreator.nodeItem.triggerIconTitle') }}
 				</template>
-				<N8nIcon :class="$style.chevron" icon="zap" size="small" />
+				<N8nIcon
+					:class="[$style['header-icon'], $style['trigger']]"
+					icon="zap"
+					size="small"
+					color="text-light"
+				/>
 			</N8nTooltip>
+			<N8nIcon
+				:class="[$style['header-icon'], $style['chevron']]"
+				icon="chevrons-down-up"
+				size="medium"
+				color="text-light"
+			/>
 		</header>
 
 		<template v-if="expanded">
@@ -116,6 +136,9 @@ onMounted(() => {
 				v-if="state.credentialRequirements.length"
 				:class="{ [$style.content]: true, ['pb-s']: !showFooter }"
 			>
+				<N8nText v-if="state.isTrigger" size="medium" color="text-light" class="mb-3xs">
+					{{ i18n.baseText('setupPanel.trigger.credential.note') }}
+				</N8nText>
 				<div
 					v-for="requirement in state.credentialRequirements"
 					:key="requirement.credentialType"
@@ -166,10 +189,27 @@ onMounted(() => {
 	width: 100%;
 	display: flex;
 	flex-direction: column;
-	gap: var(--spacing--sm);
+	gap: var(--spacing--2xs);
 	background-color: var(--color--background--light-2);
 	border: var(--border);
 	border-radius: var(--radius);
+
+	.header-icon {
+		&.chevron {
+			display: none;
+		}
+	}
+
+	&:hover {
+		.header-icon {
+			&.chevron {
+				display: block;
+			}
+			&.trigger {
+				display: none;
+			}
+		}
+	}
 }
 
 .header {
@@ -182,21 +222,19 @@ onMounted(() => {
 	.card:not(.collapsed) & {
 		margin-bottom: var(--spacing--sm);
 	}
+
+	.card.no-content & {
+		margin-bottom: 0;
+	}
 }
 
 .node-name {
 	flex: 1;
-	font-size: var(--font-size--sm);
 	font-weight: var(--font-weight--medium);
-	color: var(--color--text);
 }
 
 .complete-icon {
 	color: var(--color--success);
-}
-
-.chevron {
-	color: var(--color--text--tint-1);
 }
 
 .content {
@@ -219,7 +257,7 @@ onMounted(() => {
 .footer {
 	display: flex;
 	justify-content: flex-end;
-	padding: 0 var(--spacing--sm) var(--spacing--sm);
+	padding: var(--spacing--sm);
 }
 
 .footer-complete-check {

--- a/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.vue
+++ b/packages/frontend/editor-ui/src/features/setupPanel/components/NodeSetupCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, watch } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import { useI18n } from '@n8n/i18n';
 import { N8nButton, N8nIcon, N8nText } from '@n8n/design-system';
 
@@ -7,9 +7,11 @@ import NodeIcon from '@/app/components/NodeIcon.vue';
 import CredentialPicker from '@/features/credentials/components/CredentialPicker/CredentialPicker.vue';
 import SetupCredentialLabel from './SetupCredentialLabel.vue';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
 
 import type { NodeSetupState } from '../setupPanel.types';
 import { useNodeExecution } from '@/app/composables/useNodeExecution';
+import { useTelemetry } from '@/app/composables/useTelemetry';
 
 const props = defineProps<{
 	state: NodeSetupState;
@@ -23,7 +25,9 @@ const emit = defineEmits<{
 }>();
 
 const i18n = useI18n();
+const telemetry = useTelemetry();
 const nodeTypesStore = useNodeTypesStore();
+const workflowsStore = useWorkflowsStore();
 
 const nodeRef = computed(() => props.state.node);
 const { isExecuting, buttonLabel, buttonIcon, disabledReason, hasIssues, execute } =
@@ -51,15 +55,22 @@ const onHeaderClick = () => {
 	expanded.value = !expanded.value;
 };
 
+// Tracks whether the user directly interacted with this card (credential select/deselect or test click).
+// Used to avoid firing telemetry for cards that were auto-completed via credential auto-assignment.
+const hadManualInteraction = ref(false);
+
 const onCredentialSelected = (credentialType: string, credentialId: string) => {
+	hadManualInteraction.value = true;
 	emit('credentialSelected', { credentialType, credentialId });
 };
 
 const onCredentialDeselected = (credentialType: string) => {
+	hadManualInteraction.value = true;
 	emit('credentialDeselected', credentialType);
 };
 
 const onTestClick = async () => {
+	hadManualInteraction.value = true;
 	await execute();
 };
 
@@ -68,6 +79,30 @@ watch(
 	(isComplete) => {
 		if (isComplete) {
 			expanded.value = false;
+
+			if (hadManualInteraction.value) {
+				const nodeTypes = new Set<string>();
+				for (const req of props.state.credentialRequirements) {
+					for (const nodeName of req.nodesWithSameCredential) {
+						const node = workflowsStore.getNodeByName(nodeName);
+						if (node) {
+							nodeTypes.add(node.type);
+						}
+					}
+				}
+
+				telemetry.track('User completed setup step', {
+					template_id: workflowsStore.workflow.meta?.templateId,
+					workflow_id: workflowsStore.workflowId,
+					type: props.state.isTrigger ? 'trigger' : 'credential',
+					nodes: Array.from(nodeTypes),
+					related_nodes_count: props.state.credentialRequirements.reduce(
+						(count, req) => count + req.nodesWithSameCredential.length,
+						0,
+					),
+				});
+				hadManualInteraction.value = false;
+			}
 		}
 	},
 );

--- a/packages/frontend/editor-ui/src/features/setupPanel/components/SetupPanelCards.test.ts
+++ b/packages/frontend/editor-ui/src/features/setupPanel/components/SetupPanelCards.test.ts
@@ -31,10 +31,9 @@ vi.mock('./NodeSetupCard.vue', () => ({
 			'<span data-test-id="node-name">{{ state.node.name }}</span>' +
 			"<button data-test-id=\"select-credential-btn\" @click=\"$emit('credentialSelected', { credentialType: 'openAiApi', credentialId: 'cred-123' })\">Select</button>" +
 			'<button data-test-id="deselect-credential-btn" @click="$emit(\'credentialDeselected\', \'openAiApi\')">Deselect</button>' +
-			'<button data-test-id="test-node-btn" @click="$emit(\'testNode\')">Test</button>' +
 			'</div>',
 		props: ['state'],
-		emits: ['credentialSelected', 'credentialDeselected', 'testNode'],
+		emits: ['credentialSelected', 'credentialDeselected'],
 	},
 }));
 
@@ -59,6 +58,7 @@ const createState = (overrides: Partial<NodeSetupState> = {}): NodeSetupState =>
 			},
 		],
 		isComplete: false,
+		isTrigger: true,
 		...overrides,
 	};
 };

--- a/packages/frontend/editor-ui/src/features/setupPanel/components/SetupPanelCards.vue
+++ b/packages/frontend/editor-ui/src/features/setupPanel/components/SetupPanelCards.vue
@@ -17,10 +17,6 @@ const onCredentialSelected = (
 const onCredentialDeselected = (nodeName: string, credentialType: string) => {
 	unsetCredential(nodeName, credentialType);
 };
-
-const onTestNode = (_nodeName: string) => {
-	// TODO: Implement node execution
-};
 </script>
 
 <template>
@@ -52,7 +48,6 @@ const onTestNode = (_nodeName: string) => {
 				:state="state"
 				@credential-selected="onCredentialSelected(state.node.name, $event)"
 				@credential-deselected="onCredentialDeselected(state.node.name, $event)"
-				@test-node="onTestNode(state.node.name)"
 			/>
 			<div
 				v-if="isAllComplete"

--- a/packages/frontend/editor-ui/src/features/setupPanel/components/SetupPanelCards.vue
+++ b/packages/frontend/editor-ui/src/features/setupPanel/components/SetupPanelCards.vue
@@ -1,11 +1,25 @@
 <script setup lang="ts">
+import { watch } from 'vue';
 import { useWorkflowSetupState } from '@/features/setupPanel/composables/useWorkflowSetupState';
 import NodeSetupCard from './NodeSetupCard.vue';
 import { N8nIcon, N8nText } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useTelemetry } from '@/app/composables/useTelemetry';
 
 const i18n = useI18n();
+const telemetry = useTelemetry();
+const workflowsStore = useWorkflowsStore();
 const { nodeSetupStates, isAllComplete, setCredential, unsetCredential } = useWorkflowSetupState();
+
+watch(isAllComplete, (allComplete) => {
+	if (allComplete) {
+		telemetry.track('User completed all setup steps', {
+			template_id: workflowsStore.workflow.meta?.templateId,
+			workflow_id: workflowsStore.workflowId,
+		});
+	}
+});
 
 const onCredentialSelected = (
 	nodeName: string,

--- a/packages/frontend/editor-ui/src/features/setupPanel/components/SetupPanelCards.vue
+++ b/packages/frontend/editor-ui/src/features/setupPanel/components/SetupPanelCards.vue
@@ -43,9 +43,10 @@ const onCredentialDeselected = (nodeName: string, credentialType: string) => {
 		</div>
 		<div v-else :class="$style['card-list']" data-test-id="setup-cards-list">
 			<NodeSetupCard
-				v-for="state in nodeSetupStates"
+				v-for="(state, index) in nodeSetupStates"
 				:key="state.node.id"
 				:state="state"
+				:expanded="index === 0"
 				@credential-selected="onCredentialSelected(state.node.name, $event)"
 				@credential-deselected="onCredentialDeselected(state.node.name, $event)"
 			/>

--- a/packages/frontend/editor-ui/src/features/setupPanel/composables/useNodeExecution.ts
+++ b/packages/frontend/editor-ui/src/features/setupPanel/composables/useNodeExecution.ts
@@ -1,0 +1,401 @@
+import { computed, ref, toValue, type ComputedRef, type MaybeRef } from 'vue';
+import { useRouter } from 'vue-router';
+import { useI18n } from '@n8n/i18n';
+import type { IconName } from '@n8n/design-system/components/N8nIcon/icons';
+
+import {
+	AI_TRANSFORM_CODE_GENERATED_FOR_PROMPT,
+	AI_TRANSFORM_JS_CODE,
+	AI_TRANSFORM_NODE_TYPE,
+} from 'n8n-workflow';
+
+import type { INodeUi } from '@/Interface';
+
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
+import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { useUIStore } from '@/app/stores/ui.store';
+
+import { useRunWorkflow } from '@/app/composables/useRunWorkflow';
+import { usePinnedData } from '@/app/composables/usePinnedData';
+import { useMessage } from '@/app/composables/useMessage';
+import { useTelemetry } from '@/app/composables/useTelemetry';
+import { useToast } from '@/app/composables/useToast';
+import { useExternalHooks } from '@/app/composables/useExternalHooks';
+import { injectWorkflowState } from '@/app/composables/useWorkflowState';
+
+import { needsAgentInput } from '@/app/utils/nodes/nodeTransforms';
+import { generateCodeForAiTransform } from '@/features/ndv/parameters/utils/buttonParameter.utils';
+
+import { nodeViewEventBus } from '@/app/event-bus';
+
+import {
+	WEBHOOK_NODE_TYPE,
+	MANUAL_TRIGGER_NODE_TYPE,
+	FORM_TRIGGER_NODE_TYPE,
+	CHAT_TRIGGER_NODE_TYPE,
+	MODAL_CONFIRM,
+	FROM_AI_PARAMETERS_MODAL_KEY,
+} from '@/app/constants';
+
+export type NodeExecutionState = {
+	isExecuting: ComputedRef<boolean>;
+	isListening: ComputedRef<boolean>;
+	isListeningForWorkflowEvents: ComputedRef<boolean>;
+	buttonLabel: ComputedRef<string>;
+	buttonIcon: ComputedRef<IconName | undefined>;
+	disabledReason: ComputedRef<string>;
+	isTriggerNode: ComputedRef<boolean>;
+};
+
+export type NodeExecutionActions = {
+	execute: () => Promise<void>;
+	stopExecution: () => Promise<void>;
+};
+
+// TODO: This duplicates a lot of logic from `NodeExecuteButton` component
+// we need to update the component to use this composable
+
+/**
+ * Composable that provides node execution state and actions.
+ * @param node - The node to execute (can be a ref or INodeUi object)
+ * @param telemetrySource - Source identifier for telemetry tracking
+ */
+export function useNodeExecution(
+	node: MaybeRef<INodeUi>,
+	telemetrySource = 'setupPanel',
+): NodeExecutionState & NodeExecutionActions {
+	const router = useRouter();
+	const i18n = useI18n();
+	const telemetry = useTelemetry();
+	const toast = useToast();
+	const message = useMessage();
+	const externalHooks = useExternalHooks();
+
+	const workflowsStore = useWorkflowsStore();
+	const nodeTypesStore = useNodeTypesStore();
+	const ndvStore = useNDVStore();
+	const uiStore = useUIStore();
+	const workflowState = injectWorkflowState();
+
+	const { runWorkflow, stopCurrentExecution } = useRunWorkflow({ router });
+
+	const codeGenerationInProgress = ref(false);
+
+	const nodeRef = computed(() => toValue(node));
+
+	const pinnedData = usePinnedData(nodeRef);
+
+	const nodeType = computed(() =>
+		nodeRef.value
+			? nodeTypesStore.getNodeType(nodeRef.value.type, nodeRef.value.typeVersion)
+			: null,
+	);
+
+	const isTriggerNode = computed(() =>
+		nodeRef.value ? nodeTypesStore.isTriggerNode(nodeRef.value.type) : false,
+	);
+
+	const isManualTriggerNode = computed(() => nodeType.value?.name === MANUAL_TRIGGER_NODE_TYPE);
+
+	const isChatNode = computed(() => nodeType.value?.name === CHAT_TRIGGER_NODE_TYPE);
+
+	const isChatChild = computed(() =>
+		nodeRef.value ? workflowsStore.checkIfNodeHasChatParent(nodeRef.value.name) : false,
+	);
+
+	const isFormTriggerNode = computed(() => nodeType.value?.name === FORM_TRIGGER_NODE_TYPE);
+
+	const isPollingTypeNode = computed(() => !!nodeType.value?.polling);
+
+	const isScheduleTrigger = computed(() => !!nodeType.value?.group.includes('schedule'));
+
+	const isWebhookNode = computed(() => nodeType.value?.name === WEBHOOK_NODE_TYPE);
+
+	const isNodeRunning = computed(() => {
+		if (!workflowsStore.isWorkflowRunning || codeGenerationInProgress.value) return false;
+		const triggeredNode = workflowsStore.executedNode;
+		return (
+			workflowState.executingNode.isNodeExecuting(nodeRef.value?.name ?? '') ||
+			triggeredNode === nodeRef.value?.name
+		);
+	});
+
+	const isListening = computed(() => {
+		const waitingOnWebhook = workflowsStore.executionWaitingForWebhook;
+		const executedNode = workflowsStore.executedNode;
+
+		return (
+			!!nodeRef.value &&
+			!nodeRef.value.disabled &&
+			isTriggerNode.value &&
+			waitingOnWebhook &&
+			(!executedNode || executedNode === nodeRef.value.name)
+		);
+	});
+
+	const isListeningForWorkflowEvents = computed(
+		() =>
+			isNodeRunning.value &&
+			isTriggerNode.value &&
+			!isScheduleTrigger.value &&
+			!isManualTriggerNode.value,
+	);
+
+	const isExecuting = computed(
+		() =>
+			codeGenerationInProgress.value ||
+			(isNodeRunning.value && !isListening.value && !isListeningForWorkflowEvents.value),
+	);
+
+	const hasIssues = computed(() =>
+		Boolean(
+			nodeRef.value?.issues &&
+				(nodeRef.value.issues.parameters || nodeRef.value.issues.credentials),
+		),
+	);
+
+	const disabledReason = computed(() => {
+		if (isListening.value) {
+			return '';
+		}
+
+		if (codeGenerationInProgress.value) {
+			return i18n.baseText('ndv.execute.generatingCode');
+		}
+
+		if (nodeRef.value?.disabled) {
+			return i18n.baseText('ndv.execute.nodeIsDisabled');
+		}
+
+		if (isTriggerNode.value && hasIssues.value) {
+			return i18n.baseText('ndv.execute.requiredFieldsMissing');
+		}
+
+		if (workflowsStore.isWorkflowRunning && !isNodeRunning.value) {
+			return i18n.baseText('ndv.execute.workflowAlreadyRunning');
+		}
+
+		return '';
+	});
+
+	const buttonLabel = computed(() => {
+		if (isListening.value || isListeningForWorkflowEvents.value) {
+			return i18n.baseText('ndv.execute.stopListening');
+		}
+
+		if (shouldGenerateCode.value) {
+			return i18n.baseText('ndv.execute.generateCodeAndTestNode.description');
+		}
+
+		if (isChatNode.value) {
+			return i18n.baseText('ndv.execute.testChat');
+		}
+
+		if (isWebhookNode.value) {
+			return i18n.baseText('ndv.execute.listenForTestEvent');
+		}
+
+		if (isFormTriggerNode.value) {
+			return i18n.baseText('ndv.execute.testStep');
+		}
+
+		if (isPollingTypeNode.value || nodeType.value?.mockManualExecution) {
+			return i18n.baseText('ndv.execute.fetchEvent');
+		}
+
+		return i18n.baseText('ndv.execute.testNode');
+	});
+
+	const buttonIcon = computed((): IconName | undefined => {
+		if (shouldGenerateCode.value) return 'terminal';
+		if (!isListening.value) return 'flask-conical';
+		return undefined;
+	});
+
+	const shouldGenerateCode = computed(() => {
+		if (nodeRef.value?.type !== AI_TRANSFORM_NODE_TYPE) {
+			return false;
+		}
+		if (!nodeRef.value?.parameters?.instructions) {
+			return false;
+		}
+		if (!nodeRef.value?.parameters?.jsCode) {
+			return true;
+		}
+		if (
+			nodeRef.value?.parameters[AI_TRANSFORM_CODE_GENERATED_FOR_PROMPT] &&
+			(nodeRef.value?.parameters?.instructions as string).trim() !==
+				(nodeRef.value?.parameters?.[AI_TRANSFORM_CODE_GENERATED_FOR_PROMPT] as string).trim()
+		) {
+			return true;
+		}
+		return false;
+	});
+
+	async function stopWaitingForWebhook() {
+		try {
+			await workflowsStore.removeTestWebhook(workflowsStore.workflowId);
+		} catch (error) {
+			toast.showError(error, 'Error stopping webhook');
+		}
+	}
+
+	async function handleCodeGeneration(): Promise<boolean> {
+		if (!shouldGenerateCode.value || !nodeRef.value) return true;
+
+		codeGenerationInProgress.value = true;
+		try {
+			toast.showMessage({
+				title: i18n.baseText('ndv.execute.generateCode.title'),
+				message: i18n.baseText('ndv.execute.generateCode.message', {
+					interpolate: { nodeName: nodeRef.value.name },
+				}),
+				type: 'success',
+			});
+
+			const prompt = nodeRef.value.parameters?.instructions as string;
+			const updateInformation = await generateCodeForAiTransform(
+				prompt,
+				`parameters.${AI_TRANSFORM_JS_CODE}`,
+				5,
+			);
+
+			if (!updateInformation) {
+				codeGenerationInProgress.value = false;
+				return false;
+			}
+
+			// Update node with generated code
+			workflowState.updateNodeProperties({
+				name: nodeRef.value.name,
+				properties: {
+					parameters: {
+						...nodeRef.value.parameters,
+						[AI_TRANSFORM_JS_CODE]: updateInformation.value,
+						[AI_TRANSFORM_CODE_GENERATED_FOR_PROMPT]: prompt,
+					},
+				},
+			});
+
+			telemetry.trackAiTransform('generationFinished', {
+				prompt,
+				code: updateInformation.value,
+			});
+		} catch (error) {
+			telemetry.trackAiTransform('generationFinished', {
+				prompt: nodeRef.value?.parameters?.instructions as string,
+				code: '',
+				hasError: true,
+			});
+			toast.showMessage({
+				type: 'error',
+				title: i18n.baseText('codeNodeEditor.askAi.generationFailed'),
+				message: (error as Error).message,
+			});
+			codeGenerationInProgress.value = false;
+			return false;
+		}
+		codeGenerationInProgress.value = false;
+		return true;
+	}
+
+	async function execute(): Promise<void> {
+		if (!nodeRef.value) return;
+
+		const nodeName = nodeRef.value.name;
+
+		// AI Transform code generation
+		if (shouldGenerateCode.value) {
+			const success = await handleCodeGeneration();
+			if (!success) return;
+		}
+
+		// Chat nodes
+		if (isChatNode.value || (isChatChild.value && ndvStore.isInputPanelEmpty)) {
+			ndvStore.unsetActiveNodeName();
+			workflowsStore.chatPartialExecutionDestinationNode = nodeName;
+			nodeViewEventBus.emit('openChat');
+			return;
+		}
+
+		// Stop webhook listening
+		if (isListening.value) {
+			await stopWaitingForWebhook();
+			return;
+		}
+
+		// Stop workflow execution
+		if (isListeningForWorkflowEvents.value) {
+			await stopCurrentExecution();
+			return;
+		}
+
+		// Handle pinned data
+		let shouldUnpinAndExecute = false;
+		if (pinnedData.hasData.value) {
+			const confirmResult = await message.confirm(
+				i18n.baseText('ndv.pinData.unpinAndExecute.description'),
+				i18n.baseText('ndv.pinData.unpinAndExecute.title'),
+				{
+					confirmButtonText: i18n.baseText('ndv.pinData.unpinAndExecute.confirm'),
+					cancelButtonText: i18n.baseText('ndv.pinData.unpinAndExecute.cancel'),
+				},
+			);
+			shouldUnpinAndExecute = confirmResult === MODAL_CONFIRM;
+
+			if (shouldUnpinAndExecute) {
+				pinnedData.unsetData('unpin-and-execute-modal');
+			}
+		}
+
+		if (!pinnedData.hasData.value || shouldUnpinAndExecute) {
+			// Handle nodes that need agent input
+			if (needsAgentInput(nodeRef.value)) {
+				uiStore.openModalWithData({
+					name: FROM_AI_PARAMETERS_MODAL_KEY,
+					data: {
+						nodeName,
+					},
+				});
+				return;
+			}
+
+			// Normal execution
+			const telemetryPayload = {
+				node_type: nodeType.value ? nodeType.value.name : null,
+				workflow_id: workflowsStore.workflowId,
+				source: telemetrySource,
+				push_ref: ndvStore.pushRef,
+			};
+
+			telemetry.track('User clicked execute node button', telemetryPayload);
+			await externalHooks.run('nodeExecuteButton.onClick', telemetryPayload);
+
+			await runWorkflow({
+				destinationNode: { nodeName, mode: 'inclusive' },
+				source: 'SetupPanel.ExecuteNodeButton',
+			});
+		}
+	}
+
+	async function stopExecution(): Promise<void> {
+		if (isListening.value) {
+			await stopWaitingForWebhook();
+		} else if (isListeningForWorkflowEvents.value) {
+			await stopCurrentExecution();
+		}
+	}
+
+	return {
+		isExecuting,
+		isListening,
+		isListeningForWorkflowEvents,
+		buttonLabel,
+		buttonIcon,
+		disabledReason,
+		isTriggerNode,
+		execute,
+		stopExecution,
+	};
+}

--- a/packages/frontend/editor-ui/src/features/setupPanel/composables/useWorkflowSetupState.test.ts
+++ b/packages/frontend/editor-ui/src/features/setupPanel/composables/useWorkflowSetupState.test.ts
@@ -76,6 +76,8 @@ describe('useWorkflowSetupState', () => {
 		// Default: getters return no-op functions
 		credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue(undefined);
 		credentialsStore.getCredentialById = vi.fn().mockReturnValue(undefined);
+		nodeTypesStore.isTriggerNode = vi.fn().mockReturnValue(false);
+		workflowsStore.getWorkflowResultDataByNodeName = vi.fn().mockReturnValue(null);
 
 		mockGetNodeTypeDisplayableCredentials.mockReturnValue([]);
 		mockUpdateNodeProperties.mockReset();

--- a/packages/frontend/editor-ui/src/features/setupPanel/composables/useWorkflowSetupState.test.ts
+++ b/packages/frontend/editor-ui/src/features/setupPanel/composables/useWorkflowSetupState.test.ts
@@ -65,12 +65,13 @@ const createNode = (overrides: Partial<INodeUi> = {}): INodeUi =>
 describe('useWorkflowSetupState', () => {
 	let workflowsStore: ReturnType<typeof mockedStore<typeof useWorkflowsStore>>;
 	let credentialsStore: ReturnType<typeof mockedStore<typeof useCredentialsStore>>;
+	let nodeTypesStore: ReturnType<typeof mockedStore<typeof useNodeTypesStore>>;
 
 	beforeEach(() => {
 		createTestingPinia();
 		workflowsStore = mockedStore(useWorkflowsStore);
 		credentialsStore = mockedStore(useCredentialsStore);
-		mockedStore(useNodeTypesStore);
+		nodeTypesStore = mockedStore(useNodeTypesStore);
 
 		// Default: getters return no-op functions
 		credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue(undefined);
@@ -338,6 +339,150 @@ describe('useWorkflowSetupState', () => {
 			const { nodeSetupStates } = useWorkflowSetupState();
 
 			expect(nodeSetupStates.value[0].isComplete).toBe(false);
+		});
+	});
+
+	describe('trigger nodes', () => {
+		it('should include trigger nodes even without credential requirements', () => {
+			const triggerNode = createNode({ name: 'WebhookTrigger', type: 'n8n-nodes-base.webhook' });
+			workflowsStore.allNodes = [triggerNode];
+			nodeTypesStore.isTriggerNode = vi.fn().mockReturnValue(true);
+			mockGetNodeTypeDisplayableCredentials.mockReturnValue([]);
+			workflowsStore.getWorkflowResultDataByNodeName = vi.fn().mockReturnValue(null);
+
+			const { nodeSetupStates } = useWorkflowSetupState();
+
+			expect(nodeSetupStates.value).toHaveLength(1);
+			expect(nodeSetupStates.value[0].node.name).toBe('WebhookTrigger');
+			expect(nodeSetupStates.value[0].credentialRequirements).toHaveLength(0);
+		});
+
+		it('should set isTrigger flag to true for trigger nodes', () => {
+			const triggerNode = createNode({ name: 'Trigger', type: 'n8n-nodes-base.trigger' });
+			workflowsStore.allNodes = [triggerNode];
+			nodeTypesStore.isTriggerNode = vi.fn().mockReturnValue(true);
+			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'testApi' }]);
+			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({ displayName: 'Test' });
+
+			const { nodeSetupStates } = useWorkflowSetupState();
+
+			expect(nodeSetupStates.value[0].isTrigger).toBe(true);
+		});
+
+		it('should set isTrigger flag to false for non-trigger nodes', () => {
+			const node = createNode({ name: 'Regular' });
+			workflowsStore.allNodes = [node];
+			nodeTypesStore.isTriggerNode = vi.fn().mockReturnValue(false);
+			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'testApi' }]);
+			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({ displayName: 'Test' });
+
+			const { nodeSetupStates } = useWorkflowSetupState();
+
+			expect(nodeSetupStates.value[0].isTrigger).toBe(false);
+		});
+
+		it('should sort trigger nodes before non-trigger nodes', () => {
+			const regularNode = createNode({
+				name: 'Regular',
+				type: 'n8n-nodes-base.regular',
+				position: [0, 0],
+			});
+			const triggerNode = createNode({
+				name: 'Trigger',
+				type: 'n8n-nodes-base.trigger',
+				position: [100, 0],
+			});
+			workflowsStore.allNodes = [regularNode, triggerNode];
+			nodeTypesStore.isTriggerNode = vi.fn((type: string) => type === 'n8n-nodes-base.trigger');
+			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'testApi' }]);
+
+			const { nodeSetupStates } = useWorkflowSetupState();
+
+			expect(nodeSetupStates.value[0].node.name).toBe('Trigger');
+			expect(nodeSetupStates.value[1].node.name).toBe('Regular');
+		});
+
+		it('should mark trigger as incomplete when credentials configured but no execution data', () => {
+			const triggerNode = createNode({
+				name: 'Trigger',
+				type: 'n8n-nodes-base.trigger',
+				credentials: { triggerApi: { id: 'cred-1', name: 'My Cred' } },
+			});
+			workflowsStore.allNodes = [triggerNode];
+			nodeTypesStore.isTriggerNode = vi.fn().mockReturnValue(true);
+			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'triggerApi' }]);
+			credentialsStore.getCredentialTypeByName = vi
+				.fn()
+				.mockReturnValue({ displayName: 'Trigger API' });
+			workflowsStore.getWorkflowResultDataByNodeName = vi.fn().mockReturnValue(null);
+
+			const { nodeSetupStates } = useWorkflowSetupState();
+
+			expect(nodeSetupStates.value[0].isComplete).toBe(false);
+		});
+
+		it('should mark trigger as complete when credentials configured and execution succeeded', () => {
+			const triggerNode = createNode({
+				name: 'Trigger',
+				type: 'n8n-nodes-base.trigger',
+				credentials: { triggerApi: { id: 'cred-1', name: 'My Cred' } },
+			});
+			workflowsStore.allNodes = [triggerNode];
+			nodeTypesStore.isTriggerNode = vi.fn().mockReturnValue(true);
+			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'triggerApi' }]);
+			credentialsStore.getCredentialTypeByName = vi
+				.fn()
+				.mockReturnValue({ displayName: 'Trigger API' });
+			workflowsStore.getWorkflowResultDataByNodeName = vi.fn().mockReturnValue([{ data: {} }]);
+
+			const { nodeSetupStates } = useWorkflowSetupState();
+
+			expect(nodeSetupStates.value[0].isComplete).toBe(true);
+		});
+
+		it('should mark trigger as incomplete when execution data exists but credentials missing', () => {
+			const triggerNode = createNode({ name: 'Trigger', type: 'n8n-nodes-base.trigger' });
+			workflowsStore.allNodes = [triggerNode];
+			nodeTypesStore.isTriggerNode = vi.fn().mockReturnValue(true);
+			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'triggerApi' }]);
+			credentialsStore.getCredentialTypeByName = vi
+				.fn()
+				.mockReturnValue({ displayName: 'Trigger API' });
+			workflowsStore.getWorkflowResultDataByNodeName = vi.fn().mockReturnValue([{ data: {} }]);
+
+			const { nodeSetupStates } = useWorkflowSetupState();
+
+			expect(nodeSetupStates.value[0].isComplete).toBe(false);
+		});
+
+		it('should mark trigger without credentials as incomplete when no execution data', () => {
+			const triggerNode = createNode({
+				name: 'ManualTrigger',
+				type: 'n8n-nodes-base.manualTrigger',
+			});
+			workflowsStore.allNodes = [triggerNode];
+			nodeTypesStore.isTriggerNode = vi.fn().mockReturnValue(true);
+			mockGetNodeTypeDisplayableCredentials.mockReturnValue([]);
+			workflowsStore.getWorkflowResultDataByNodeName = vi.fn().mockReturnValue(null);
+
+			const { nodeSetupStates } = useWorkflowSetupState();
+
+			expect(nodeSetupStates.value[0].isComplete).toBe(false);
+		});
+
+		it('should mark trigger without credentials as complete after successful execution', () => {
+			const triggerNode = createNode({
+				name: 'ManualTrigger',
+				type: 'n8n-nodes-base.manualTrigger',
+			});
+			workflowsStore.allNodes = [triggerNode];
+			nodeTypesStore.isTriggerNode = vi.fn().mockReturnValue(true);
+			mockGetNodeTypeDisplayableCredentials.mockReturnValue([]);
+			workflowsStore.getWorkflowResultDataByNodeName = vi.fn().mockReturnValue([{ data: {} }]);
+
+			const { nodeSetupStates } = useWorkflowSetupState();
+
+			expect(nodeSetupStates.value[0].isComplete).toBe(true);
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/setupPanel/composables/useWorkflowSetupState.ts
+++ b/packages/frontend/editor-ui/src/features/setupPanel/composables/useWorkflowSetupState.ts
@@ -11,11 +11,7 @@ import { injectWorkflowState } from '@/app/composables/useWorkflowState';
 import { useToast } from '@/app/composables/useToast';
 import { useI18n } from '@n8n/i18n';
 
-import {
-	getNodeCredentialTypes,
-	buildCredentialRequirement,
-	isNodeSetupComplete,
-} from '../setupPanel.utils';
+import { getNodeCredentialTypes, buildNodeSetupState } from '../setupPanel.utils';
 
 /**
  * Composable that manages workflow setup state for credential configuration.
@@ -89,33 +85,18 @@ export const useWorkflowSetupState = (nodes?: Ref<INodeUi[]>) => {
 	 * Node setup states - one entry per node that requires setup.
 	 * This data is used by cards component.
 	 */
-	const nodeSetupStates = computed<NodeSetupState[]>(() => {
-		return nodesRequiringSetup.value.map(({ node, credentialTypes, isTrigger }) => {
-			const credentialRequirements = credentialTypes.map((credType) =>
-				buildCredentialRequirement(
-					node,
-					credType,
-					getCredentialDisplayName,
-					credentialTypeToNodeNames.value,
-				),
-			);
-
-			const credentialsConfigured = isNodeSetupComplete(credentialRequirements);
-
-			// For triggers: complete only after successful execution
-			// For regular nodes: complete when credentials are configured
-			const isComplete = isTrigger
-				? credentialsConfigured && hasTriggerExecutedSuccessfully(node.name)
-				: credentialsConfigured;
-
-			return {
+	const nodeSetupStates = computed<NodeSetupState[]>(() =>
+		nodesRequiringSetup.value.map(({ node, credentialTypes, isTrigger }) =>
+			buildNodeSetupState(
 				node,
-				credentialRequirements,
-				isComplete,
+				credentialTypes,
+				getCredentialDisplayName,
+				credentialTypeToNodeNames.value,
 				isTrigger,
-			};
-		});
-	});
+				hasTriggerExecutedSuccessfully(node.name),
+			),
+		),
+	);
 
 	const totalCredentialsMissing = computed(() => {
 		return nodeSetupStates.value.reduce((total, state) => {

--- a/packages/frontend/editor-ui/src/features/setupPanel/composables/useWorkflowSetupState.ts
+++ b/packages/frontend/editor-ui/src/features/setupPanel/composables/useWorkflowSetupState.ts
@@ -1,5 +1,4 @@
 import { computed, type Ref } from 'vue';
-import sortBy from 'lodash/sortBy';
 
 import type { INodeUi } from '@/Interface';
 import type { NodeSetupState } from '../setupPanel.types';
@@ -12,7 +11,11 @@ import { injectWorkflowState } from '@/app/composables/useWorkflowState';
 import { useToast } from '@/app/composables/useToast';
 import { useI18n } from '@n8n/i18n';
 
-import { getNodeCredentialTypes, buildNodeSetupState } from '../setupPanel.utils';
+import {
+	getNodeCredentialTypes,
+	buildCredentialRequirement,
+	isNodeSetupComplete,
+} from '../setupPanel.utils';
 
 /**
  * Composable that manages workflow setup state for credential configuration.
@@ -36,19 +39,36 @@ export const useWorkflowSetupState = (nodes?: Ref<INodeUi[]>) => {
 		return credentialTypeInfo?.displayName ?? credentialType;
 	};
 
+	const isTriggerNode = (node: INodeUi): boolean => {
+		return nodeTypesStore.isTriggerNode(node.type);
+	};
+
+	const hasTriggerExecutedSuccessfully = (nodeName: string): boolean => {
+		const runData = workflowsStore.getWorkflowResultDataByNodeName(nodeName);
+		return runData !== null && runData.length > 0;
+	};
+
 	/**
-	 * Get nodes that require credentials, sorted by X position (left to right).
+	 * Get nodes that require setup:
+	 * - Nodes with credential requirements
+	 * - Trigger nodes (regardless of credentials)
+	 * Sorted with triggers first, then by X position.
 	 */
-	const nodesRequiringCredentials = computed(() => {
-		const nodesWithCredentials = sourceNodes.value
+	const nodesRequiringSetup = computed(() => {
+		const nodesForSetup = sourceNodes.value
 			.filter((node) => !node.disabled)
 			.map((node) => ({
 				node,
 				credentialTypes: getNodeCredentialTypes(nodeTypesStore, node),
+				isTrigger: isTriggerNode(node),
 			}))
-			.filter(({ credentialTypes }) => credentialTypes.length > 0);
+			.filter(({ credentialTypes, isTrigger }) => credentialTypes.length > 0 || isTrigger);
 
-		return sortBy(nodesWithCredentials, ({ node }) => node.position[0]);
+		return nodesForSetup.sort((a, b) => {
+			if (a.isTrigger && !b.isTrigger) return -1;
+			if (!a.isTrigger && b.isTrigger) return 1;
+			return a.node.position[0] - b.node.position[0];
+		});
 	});
 
 	/**
@@ -56,7 +76,7 @@ export const useWorkflowSetupState = (nodes?: Ref<INodeUi[]>) => {
 	 */
 	const credentialTypeToNodeNames = computed(() => {
 		const map = new Map<string, string[]>();
-		for (const { node, credentialTypes } of nodesRequiringCredentials.value) {
+		for (const { node, credentialTypes } of nodesRequiringSetup.value) {
 			for (const credType of credentialTypes) {
 				const existing = map.get(credType) ?? [];
 				existing.push(node.name);
@@ -67,19 +87,36 @@ export const useWorkflowSetupState = (nodes?: Ref<INodeUi[]>) => {
 	});
 
 	/**
-	 * Node setup states - one entry per node that requires credentials.
+	 * Node setup states - one entry per node that requires setup.
 	 * This data is used by cards component.
 	 */
-	const nodeSetupStates = computed<NodeSetupState[]>(() =>
-		nodesRequiringCredentials.value.map(({ node, credentialTypes }) =>
-			buildNodeSetupState(
+	const nodeSetupStates = computed<NodeSetupState[]>(() => {
+		return nodesRequiringSetup.value.map(({ node, credentialTypes, isTrigger }) => {
+			const credentialRequirements = credentialTypes.map((credType) =>
+				buildCredentialRequirement(
+					node,
+					credType,
+					getCredentialDisplayName,
+					credentialTypeToNodeNames.value,
+				),
+			);
+
+			const credentialsConfigured = isNodeSetupComplete(credentialRequirements);
+
+			// For triggers: complete only after successful execution
+			// For regular nodes: complete when credentials are configured
+			const isComplete = isTrigger
+				? credentialsConfigured && hasTriggerExecutedSuccessfully(node.name)
+				: credentialsConfigured;
+
+			return {
 				node,
-				credentialTypes,
-				getCredentialDisplayName,
-				credentialTypeToNodeNames.value,
-			),
-		),
-	);
+				credentialRequirements,
+				isComplete,
+				isTrigger,
+			};
+		});
+	});
 
 	const totalCredentialsMissing = computed(() => {
 		return nodeSetupStates.value.reduce((total, state) => {

--- a/packages/frontend/editor-ui/src/features/setupPanel/composables/useWorkflowSetupState.ts
+++ b/packages/frontend/editor-ui/src/features/setupPanel/composables/useWorkflowSetupState.ts
@@ -64,9 +64,10 @@ export const useWorkflowSetupState = (nodes?: Ref<INodeUi[]>) => {
 			}))
 			.filter(({ credentialTypes, isTrigger }) => credentialTypes.length > 0 || isTrigger);
 
-		return nodesForSetup.sort((a, b) => {
-			Number(b.isTrigger) - Number(a.isTrigger) || a.node.position[0] - b.node.position[0]
-		});
+		return nodesForSetup.sort(
+			(a, b) =>
+				Number(b.isTrigger) - Number(a.isTrigger) || a.node.position[0] - b.node.position[0],
+		);
 	});
 
 	/**

--- a/packages/frontend/editor-ui/src/features/setupPanel/composables/useWorkflowSetupState.ts
+++ b/packages/frontend/editor-ui/src/features/setupPanel/composables/useWorkflowSetupState.ts
@@ -65,9 +65,7 @@ export const useWorkflowSetupState = (nodes?: Ref<INodeUi[]>) => {
 			.filter(({ credentialTypes, isTrigger }) => credentialTypes.length > 0 || isTrigger);
 
 		return nodesForSetup.sort((a, b) => {
-			if (a.isTrigger && !b.isTrigger) return -1;
-			if (!a.isTrigger && b.isTrigger) return 1;
-			return a.node.position[0] - b.node.position[0];
+			Number(b.isTrigger) - Number(a.isTrigger) || a.node.position[0] - b.node.position[0]
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/setupPanel/setupPanel.types.ts
+++ b/packages/frontend/editor-ui/src/features/setupPanel/setupPanel.types.ts
@@ -13,4 +13,5 @@ export interface NodeSetupState {
 	node: INodeUi;
 	credentialRequirements: NodeCredentialRequirement[];
 	isComplete: boolean;
+	isTrigger: boolean;
 }

--- a/packages/frontend/editor-ui/src/features/setupPanel/setupPanel.utils.ts
+++ b/packages/frontend/editor-ui/src/features/setupPanel/setupPanel.utils.ts
@@ -78,14 +78,25 @@ export function buildNodeSetupState(
 	credentialTypes: string[],
 	getCredentialDisplayName: (type: string) => string,
 	credentialTypeToNodeNames: Map<string, string[]>,
+	isTrigger = false,
+	hasTriggerExecuted = false,
 ): NodeSetupState {
 	const credentialRequirements = credentialTypes.map((credType) =>
 		buildCredentialRequirement(node, credType, getCredentialDisplayName, credentialTypeToNodeNames),
 	);
 
+	const credentialsConfigured = isNodeSetupComplete(credentialRequirements);
+
+	// For triggers: complete only after successful execution
+	// For regular nodes: complete when credentials are configured
+	const isComplete = isTrigger
+		? credentialsConfigured && hasTriggerExecuted
+		: credentialsConfigured;
+
 	return {
 		node,
 		credentialRequirements,
-		isComplete: isNodeSetupComplete(credentialRequirements),
+		isComplete,
+		isTrigger,
 	};
 }

--- a/packages/frontend/editor-ui/src/features/setupPanel/setupPanel.utils.ts
+++ b/packages/frontend/editor-ui/src/features/setupPanel/setupPanel.utils.ts
@@ -50,7 +50,7 @@ export function buildCredentialRequirement(
 
 	const credentialIssues = node.issues?.credentials ?? {};
 	const issues = credentialIssues[credentialType];
-	const issueMessages = issues ? (Array.isArray(issues) ? issues : [issues]) : [];
+	const issueMessages = [issues ?? []].flat();
 
 	return {
 		credentialType,


### PR DESCRIPTION
## Summary
Adding `Execute step` action to the setup panel for trigger nodes. This allows users to quickly get the first event in straight from the setup panel.
- The biggest change is moving partial execution logic from the `NodeExecuteButton` into a shared composable, `useNodeExecution`.

<img width="509" height="380" alt="image" src="https://github.com/user-attachments/assets/315e6a43-feb8-486a-b6f7-38e5c91a43d2" />

## Related Linear tickets, Github issues, and Community forum posts
Closes ADO-4751
Closes ADO-4784
Closes ADO-4752
Closes ADO-4785

## How to test
See [this linear comment](https://linear.app/n8n/issue/ADO-4751/implement-usenodeexecution-composable#comment-73946bfc).

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
