### PR TITLE
feat(core): Expose externalSecretsStore to filter credentials by external secret provider key

### DIFF
--- a/packages/@n8n/api-types/src/dto/credentials/__tests__/credentials-get-many-request.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/__tests__/credentials-get-many-request.dto.test.ts
@@ -15,6 +15,7 @@ describe('CredentialsGetManyRequestQuery', () => {
 			{ field: 'includeScopes', value: 'false' },
 			{ field: 'includeData', value: 'true' },
 			{ field: 'includeData', value: 'false' },
+			{ field: 'externalSecretsStore', value: 'testProviderKey' },
 		])('with $field set to $value', ({ field, value }) => {
 			const data = { [field]: value };
 
@@ -43,6 +44,9 @@ describe('CredentialsGetManyRequestQuery', () => {
 			{ field: 'includeData', value: true },
 			{ field: 'includeData', value: false },
 			{ field: 'includeData', value: 'invalid' },
+			{ field: 'externalSecretsStore', value: true },
+			{ field: 'externalSecretsStore', value: false },
+			{ field: 'externalSecretsStore', value: 123 },
 		])('with invalid value $value for $field', ({ field, value }) => {
 			const data = { [field]: value };
 

--- a/packages/@n8n/api-types/src/dto/credentials/credentials-get-many-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/credentials-get-many-request.dto.ts
@@ -1,4 +1,5 @@
 import z from 'zod';
+
 import { booleanFromString } from '../../schemas/boolean-from-string';
 import { Z } from '../../zod-class';
 

--- a/packages/@n8n/api-types/src/dto/credentials/credentials-get-many-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/credentials-get-many-request.dto.ts
@@ -1,3 +1,4 @@
+import z from 'zod';
 import { booleanFromString } from '../../schemas/boolean-from-string';
 import { Z } from '../../zod-class';
 
@@ -26,4 +27,10 @@ export class CredentialsGetManyRequestQuery extends Z.class({
 	 * Defaults to false.
 	 */
 	includeGlobal: booleanFromString.optional().default('false'),
+
+	/**
+	 * Filters credentials to only include those that are using a specific external secrets provider.
+	 * The value should be the `providerKey` of the external secrets store.
+	 */
+	externalSecretsStore: z.string().optional(),
 }) {}

--- a/packages/cli/src/credentials/__tests__/credentials.service.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.service.test.ts
@@ -10,7 +10,12 @@ import type {
 import { GLOBAL_OWNER_ROLE, GLOBAL_MEMBER_ROLE } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 import { CREDENTIAL_ERRORS, CredentialDataError, Credentials, type ErrorReporter } from 'n8n-core';
-import { CREDENTIAL_EMPTY_VALUE, type ICredentialType } from 'n8n-workflow';
+import {
+	CREDENTIAL_EMPTY_VALUE,
+	ICredentialDataDecryptedObject,
+	ICredentialsDecrypted,
+	type ICredentialType,
+} from 'n8n-workflow';
 
 import { CREDENTIAL_BLANKING_VALUE } from '@/constants';
 import type { CredentialTypes } from '@/credential-types';
@@ -23,6 +28,7 @@ import type { CredentialsTester } from '@/services/credentials-tester.service';
 import type { OwnershipService } from '@/services/ownership.service';
 import type { ProjectService } from '@/services/project.service.ee';
 import type { RoleService } from '@/services/role.service';
+import assert from 'assert';
 
 describe('CredentialsService', () => {
 	const credType = mock<ICredentialType>({
@@ -1131,6 +1137,66 @@ describe('CredentialsService', () => {
 				// ASSERT
 				expect(credentialsRepository.findAllGlobalCredentials).not.toHaveBeenCalled();
 				expect(result).toHaveLength(1);
+			});
+		});
+
+		describe.only('with externalSecretsStore', () => {
+			const createCredentialWithEncryptedData = (id: string, apiKey: string) =>
+				mock<CredentialsEntity>({
+					id,
+					data: service.createEncryptedData({ ...regularCredential, data: { apiKey } }).data,
+				});
+
+			it('should filter credentials by external secrets store using dot notation', async () => {
+				// ARRANGE
+				const credentialWithExternalSecret1 = createCredentialWithEncryptedData(
+					'cred-with-external-secret-1',
+					'{{ $secrets.myProvider.apiKey }}',
+				);
+				const credentialWithExternalSecret2 = createCredentialWithEncryptedData(
+					'cred-with-external-secret-2',
+					'{{ $secrets.anotherProvider.apiKey }}',
+				);
+				credentialsRepository.findMany.mockResolvedValue([
+					regularCredential,
+					credentialWithExternalSecret1,
+					credentialWithExternalSecret2,
+				]);
+
+				// ACT
+				const result = await service.getMany(memberUser, {
+					externalSecretsStore: 'myProvider',
+				});
+
+				// ASSERT
+				expect(result).toHaveLength(1);
+				expect(result[0].id).toBe(credentialWithExternalSecret1.id);
+			});
+
+			it('should filter credentials by external secrets store using square bracket notation', async () => {
+				// ARRANGE
+				const credentialWithExternalSecret1 = createCredentialWithEncryptedData(
+					'cred-with-external-secret-1',
+					'{{ $secrets["myProvider"]["apiKey"] }}',
+				);
+				const credentialWithExternalSecret2 = createCredentialWithEncryptedData(
+					'cred-with-external-secret-2',
+					'{{ $secrets["anotherProvider"]["apiKey"] }}',
+				);
+				credentialsRepository.findMany.mockResolvedValue([
+					regularCredential,
+					credentialWithExternalSecret1,
+					credentialWithExternalSecret2,
+				]);
+
+				// ACT
+				const result = await service.getMany(memberUser, {
+					externalSecretsStore: 'myProvider',
+				});
+
+				// ASSERT
+				expect(result).toHaveLength(1);
+				expect(result[0].id).toBe(credentialWithExternalSecret1.id);
 			});
 		});
 	});

--- a/packages/cli/src/credentials/__tests__/credentials.service.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.service.test.ts
@@ -1134,7 +1134,7 @@ describe('CredentialsService', () => {
 			});
 		});
 
-		describe.only('with externalSecretsStore', () => {
+		describe('with externalSecretsStore', () => {
 			const createCredentialWithEncryptedData = (id: string, apiKey: string) =>
 				mock<CredentialsEntity>({
 					id,

--- a/packages/cli/src/credentials/__tests__/credentials.service.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.service.test.ts
@@ -10,12 +10,7 @@ import type {
 import { GLOBAL_OWNER_ROLE, GLOBAL_MEMBER_ROLE } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 import { CREDENTIAL_ERRORS, CredentialDataError, Credentials, type ErrorReporter } from 'n8n-core';
-import {
-	CREDENTIAL_EMPTY_VALUE,
-	ICredentialDataDecryptedObject,
-	ICredentialsDecrypted,
-	type ICredentialType,
-} from 'n8n-workflow';
+import { CREDENTIAL_EMPTY_VALUE, type ICredentialType } from 'n8n-workflow';
 
 import { CREDENTIAL_BLANKING_VALUE } from '@/constants';
 import type { CredentialTypes } from '@/credential-types';
@@ -28,7 +23,6 @@ import type { CredentialsTester } from '@/services/credentials-tester.service';
 import type { OwnershipService } from '@/services/ownership.service';
 import type { ProjectService } from '@/services/project.service.ee';
 import type { RoleService } from '@/services/role.service';
-import assert from 'assert';
 
 describe('CredentialsService', () => {
 	const credType = mock<ICredentialType>({

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -74,6 +74,7 @@ export class CredentialsController {
 			includeData: query.includeData,
 			onlySharedWithMe: query.onlySharedWithMe,
 			includeGlobal: query.includeGlobal,
+			externalSecretsStore: query.externalSecretsStore,
 		});
 		credentials.forEach((c) => {
 			// @ts-expect-error: This is to emulate the old behavior of removing the shared

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -50,6 +50,7 @@ import { OwnershipService } from '@/services/ownership.service';
 import { ProjectService } from '@/services/project.service.ee';
 import { RoleService } from '@/services/role.service';
 import { validateOAuthUrl } from '@/oauth/validate-oauth-url';
+import { getAllKeyPaths } from '@/utils';
 
 import { CredentialsFinderService } from './credentials-finder.service';
 import { validateExternalSecretsPermissions } from './validation';
@@ -103,6 +104,7 @@ export class CredentialsService {
 			includeData: true;
 			onlySharedWithMe?: boolean;
 			includeGlobal?: boolean;
+			externalSecretsStore?: string;
 		},
 	): Promise<Array<ICredentialsDecrypted<ICredentialDataDecryptedObject>>>;
 	async getMany(
@@ -113,6 +115,7 @@ export class CredentialsService {
 			includeData?: boolean;
 			onlySharedWithMe?: boolean;
 			includeGlobal?: boolean;
+			externalSecretsStore?: string;
 		},
 	): Promise<CredentialsEntity[]>;
 	async getMany(
@@ -123,12 +126,14 @@ export class CredentialsService {
 			includeData = false,
 			onlySharedWithMe = false,
 			includeGlobal = false,
+			externalSecretsStore,
 		}: {
 			listQueryOptions?: ListQuery.Options & { includeData?: boolean };
 			includeScopes?: boolean;
 			includeData?: boolean;
 			onlySharedWithMe?: boolean;
 			includeGlobal?: boolean;
+			externalSecretsStore?: string;
 		} = {},
 	): Promise<Array<ICredentialsDecrypted<ICredentialDataDecryptedObject>> | CredentialsEntity[]> {
 		const returnAll = hasGlobalScope(user, 'credential:list');
@@ -155,6 +160,10 @@ export class CredentialsService {
 			);
 		}
 
+		if (externalSecretsStore) {
+			credentials = this.filterByExternalSecretsStore(credentials, externalSecretsStore);
+		}
+
 		return await this.enrichCredentials(
 			credentials,
 			user,
@@ -164,6 +173,35 @@ export class CredentialsService {
 			listQueryOptions,
 			onlySharedWithMe,
 		);
+	}
+
+	private filterByExternalSecretsStore(
+		credentials: CredentialsEntity[],
+		externalSecretsStore: string,
+	): CredentialsEntity[] {
+		// matches either dot notation ($secrets.providerKey) or square bracket notation ($secrets['providerKey'])
+		const providerRegex = /\$secrets(?:\.([A-Za-z0-9_-]+)|\[['"]([^'"]+)['"]\])/g;
+		credentials = credentials.filter((credential) => {
+			const decryptedData = this.decrypt(credential, true);
+			const matchingSecretPaths = getAllKeyPaths(decryptedData, '', [], (value) => {
+				if (!value.includes('$secrets')) {
+					return false;
+				}
+
+				let match: RegExpExecArray | null;
+				while ((match = providerRegex.exec(value)) !== null) {
+					const providerKey = match[1] ?? match[2];
+					if (providerKey === externalSecretsStore) {
+						return true;
+					}
+				}
+
+				return false;
+			});
+
+			return matchingSecretPaths.length > 0;
+		});
+		return credentials;
 	}
 
 	private applyOnlySharedWithMeFilter(


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Exposes optional query parameter `externalSecretsStore` to allow filtering credentials by a provider key.

## Related Linear tickets, Github issues, and Community forum posts
Closes [LIGO-191](https://linear.app/n8n/issue/LIGO-191/be-filter-credentials-for-expressions-that-use-a-secret-provider)
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
