### PR TITLE
fix: Adjust gap behaviour of the execution buttons

### DIFF
--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -2069,6 +2069,7 @@ onBeforeUnmount(() => {
 	display: flex;
 	justify-content: center;
 	align-items: center;
+	gap: var(--spacing--xs);
 	left: 50%;
 	transform: translateX(-50%);
 	bottom: var(--spacing--sm);
@@ -2084,7 +2085,6 @@ onBeforeUnmount(() => {
 		display: flex;
 		justify-content: center;
 		align-items: center;
-		margin-left: 0.625rem;
 
 		&:first-child {
 			margin: 0;


### PR DESCRIPTION
## Summary

https://linear.app/n8n/issue/AI-2012/bug-no-gap-between-execute-and-open-chat-buttons
<img width="610" height="488" alt="Screenshot 2026-02-09 at 15 59 15" src="https://github.com/user-attachments/assets/40f20b1e-b424-43ba-9cf1-81f1a079e975" />
