### PR TITLE
ci: Upgrade default nodejs setup to 24.x from 22.x

### DIFF
--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -7,9 +7,9 @@ description: 'Configures Node.js with pnpm, installs Aikido SafeChain for supply
 
 inputs:
   node-version:
-    description: 'Node.js version to use. Uses latest 22.x by default.'
+    description: 'Node.js version to use. Uses latest 24.x by default.'
     required: false
-    default: '22.x'
+    default: '24.x'
   enable-docker-cache:
     description: 'Whether to set up Blacksmith Buildx for Docker layer caching (Blacksmith runners only).'
     required: false


### PR DESCRIPTION
## Summary

Default setup-nodejs to use 24.x as [it's the current active release](https://nodejs.org/en/about/previous-releases). This will enable us to also utilize [trusted publishers](https://docs.npmjs.com/trusted-publishers) in CI.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
