### PR TITLE
feat(Mortorhead Node): Hide deprecated Motorhead memory node from UI

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryMotorhead/MemoryMotorhead.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryMotorhead/MemoryMotorhead.node.ts
@@ -19,6 +19,7 @@ export class MemoryMotorhead implements INodeType {
 		name: 'memoryMotorhead',
 		icon: 'fa:file-export',
 		iconColor: 'black',
+		hidden: true,
 		group: ['transform'],
 		version: [1, 1.1, 1.2, 1.3],
 		description: 'Use Motorhead Memory',
@@ -52,6 +53,13 @@ export class MemoryMotorhead implements INodeType {
 		],
 		properties: [
 			getConnectionHintNoticeField([NodeConnectionTypes.AiAgent]),
+			{
+				displayName:
+					'The Motorhead project is no longer maintained. This node is deprecated and will be removed in a future version.',
+				name: 'deprecationNotice',
+				type: 'notice',
+				default: '',
+			},
 			{
 				displayName: 'Session ID',
 				name: 'sessionId',


### PR DESCRIPTION
The Motorhead project is no longer maintained, so hide the node from the node selector to avoid misleading users. Existing workflows using this node will continue to work. A deprecation notice is shown to users who still have it in their workflows.

https://linear.app/n8n/issue/AI-2008/we-suggest-motorhead-memory-as-one-of-our-main-options-even-though-its

