### PR TITLE
feat: Refactor nodes using ChatOpenAI

### DIFF
--- a/packages/@n8n/ai-utilities/src/suppliers/supplyModel.ts
+++ b/packages/@n8n/ai-utilities/src/suppliers/supplyModel.ts
@@ -54,6 +54,7 @@ function getOpenAiModel(ctx: ISupplyDataFunctions, model: OpenAiModel) {
 		presencePenalty: model.presencePenalty,
 		stopSequences: model.stopSequences,
 		maxRetries: model.maxRetries,
+		timeout: model.timeout,
 		modelKwargs: model.additionalParams,
 		verbosity: model.verbosity,
 		streaming: model.streaming,

--- a/packages/@n8n/ai-utilities/src/types/openai.ts
+++ b/packages/@n8n/ai-utilities/src/types/openai.ts
@@ -8,7 +8,7 @@ export interface OpenAIModelOptions {
 	/** Model name to use */
 	model: string;
 	/**
-	 * API key to use when making requests to OpenAI.
+	 * API key to use when making requests.
 	 */
 	apiKey: string;
 	/**
@@ -45,7 +45,7 @@ export interface OpenAIModelOptions {
 	topLogprobs?: number;
 	/**
 	 * Whether the model supports the `strict` argument when passing in tools.
-	 * If `undefined` the `strict` argument will not be passed to OpenAI.
+	 * If `undefined` the `strict` argument will not be passed to the API.
 	 */
 	supportsStrictToolCalling?: boolean;
 
@@ -56,7 +56,6 @@ export interface OpenAIModelOptions {
 
 	/**
 	 * Should be set to `true` in tenancies with Zero Data Retention
-	 * @see https://platform.openai.com/docs/guides/your-data
 	 *
 	 * @default false
 	 */
@@ -69,9 +68,8 @@ export interface OpenAIModelOptions {
 	service_tier?: 'auto' | 'default' | 'flex' | 'scale' | 'priority' | null;
 
 	/**
-	 * Used by OpenAI to cache responses for similar requests to optimize your cache
+	 * Used to cache responses for similar requests to optimize cache
 	 * hit rates. Replaces the `user` field.
-	 * [Learn more](https://platform.openai.com/docs/guides/prompt-caching).
 	 */
 	promptCacheKey?: string;
 
@@ -98,7 +96,7 @@ export interface OpenAIModelOptions {
 	n?: number;
 	/** Dictionary used to adjust the probability of specific tokens being generated */
 	logitBias?: Record<string, number>;
-	/** Unique string identifier representing your end-user, which can help OpenAI to monitor and detect abuse. */
+	/** Unique string identifier representing your end-user, which can help monitor and detect abuse. */
 	user?: string;
 	/** Whether to stream the results or not. Enabling disables tokenUsage reporting */
 	streaming?: boolean;
@@ -118,7 +116,7 @@ export interface OpenAIModelOptions {
 	/** List of stop words to use when generating */
 	stopSequences?: string[];
 	/**
-	 * Timeout to use when making requests to OpenAI.
+	 * Timeout to use when making requests.
 	 */
 	timeout?: number;
 	/**

--- a/packages/@n8n/ai-utilities/src/types/openai.ts
+++ b/packages/@n8n/ai-utilities/src/types/openai.ts
@@ -108,10 +108,7 @@ export interface OpenAIModelOptions {
 	 */
 	streamUsage?: boolean;
 
-	/** Holds any additional parameters that are valid to pass to {@link
-	 * https://platform.openai.com/docs/api-reference/completions/create |
-	 * `openai.createCompletion`} that are not explicitly specified on this interface
-	 */
+	/** Additional provider-specific parameters to pass to the model. That will be supplied in body of the request. */
 	additionalParams?: Record<string, unknown>;
 	/**
 	 * List of stop words to use when generating

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatLemonade/LmChatLemonade.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatLemonade/LmChatLemonade.node.ts
@@ -1,5 +1,5 @@
-import { ChatOpenAI, type ClientOptions } from '@langchain/openai';
-import { getProxyAgent, makeN8nLlmFailedAttemptHandler, N8nLlmTracing } from '@n8n/ai-utilities';
+import { type ClientOptions } from '@langchain/openai';
+import { getProxyAgent, supplyModel } from '@n8n/ai-utilities';
 import {
 	NodeConnectionTypes,
 	type INodeType,
@@ -12,7 +12,7 @@ import type { LemonadeApiCredentialsType } from '../../../credentials/LemonadeAp
 
 import { getConnectionHintNoticeField } from '@utils/sharedFields';
 
-import { lemonadeModel, lemonadeOptions, lemonadeDescription } from '../LMLemonade/description';
+import { lemonadeDescription, lemonadeModel, lemonadeOptions } from '../LMLemonade/description';
 
 export class LmChatLemonade implements INodeType {
 	description: INodeTypeDescription = {
@@ -104,17 +104,17 @@ export class LmChatLemonade implements INodeType {
 			dispatcher: getProxyAgent(configuration.baseURL ?? '', {}),
 		};
 
-		const model = new ChatOpenAI({
+		return supplyModel(this, {
+			type: 'openai',
+			baseUrl: credentials.baseUrl,
 			apiKey: credentials.apiKey || 'lemonade-placeholder-key',
 			model: modelName,
-			...processedOptions,
-			configuration,
-			callbacks: [new N8nLlmTracing(this)],
-			onFailedAttempt: makeN8nLlmFailedAttemptHandler(this),
+			temperature: processedOptions.temperature,
+			topP: processedOptions.topP,
+			frequencyPenalty: processedOptions.frequencyPenalty,
+			presencePenalty: processedOptions.presencePenalty,
+			maxTokens: processedOptions.maxTokens,
+			stop: processedOptions.stop,
 		});
-
-		return {
-			response: model,
-		};
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
@@ -1,5 +1,5 @@
-import { ChatOpenAI, type ChatOpenAIFields, type ClientOptions } from '@langchain/openai';
-import pick from 'lodash/pick';
+import { supplyModel } from '@n8n/ai-utilities';
+import type { ProviderTool } from '@n8n/ai-utilities';
 import {
 	NodeConnectionTypes,
 	type INodeProperties,
@@ -14,7 +14,6 @@ import { checkDomainRestrictions } from '@utils/checkDomainRestrictions';
 import { getConnectionHintNoticeField } from '@utils/sharedFields';
 
 import { openAiFailedAttemptHandler } from '../../vendors/OpenAi/helpers/error-handling';
-import { makeN8nLlmFailedAttemptHandler, N8nLlmTracing, getProxyAgent } from '@n8n/ai-utilities';
 import { formatBuiltInTools, prepareAdditionalResponsesParams } from './common';
 import { searchModels } from './methods/loadModels';
 import type { ModelOptions } from './types';
@@ -742,94 +741,79 @@ export class LmChatOpenAi implements INodeType {
 
 		const { openAiDefaultHeaders: defaultHeaders } = Container.get(AiConfig);
 
-		const configuration: ClientOptions = {
-			defaultHeaders,
-		};
-
+		// Determine base URL
+		let baseUrl = 'https://api.openai.com/v1';
 		if (options.baseURL) {
 			checkDomainRestrictions(this, credentials, options.baseURL);
-			configuration.baseURL = options.baseURL;
+			baseUrl = options.baseURL;
 		} else if (credentials.url) {
-			configuration.baseURL = credentials.url as string;
+			baseUrl = credentials.url as string;
 		}
 
-		const timeout = options.timeout;
-		configuration.fetchOptions = {
-			dispatcher: getProxyAgent(configuration.baseURL ?? 'https://api.openai.com/v1', {
-				headersTimeout: timeout,
-				bodyTimeout: timeout,
-			}),
-		};
+		// Prepare default headers
+		const headers: Record<string, string> = { ...defaultHeaders };
 		if (
 			credentials.header &&
 			typeof credentials.headerName === 'string' &&
 			credentials.headerName &&
 			typeof credentials.headerValue === 'string'
 		) {
-			configuration.defaultHeaders = {
-				...configuration.defaultHeaders,
-				[credentials.headerName]: credentials.headerValue,
-			};
+			headers[credentials.headerName] = credentials.headerValue;
 		}
 
-		// Extra options to send to OpenAI, that are not directly supported by LangChain
-		const modelKwargs: Record<string, unknown> = {};
+		// Extra options to send to OpenAI
+		const additionalParams: Record<string, unknown> = {};
 		if (responsesApiEnabled) {
 			const kwargs = prepareAdditionalResponsesParams(options);
-			Object.assign(modelKwargs, kwargs);
+			Object.assign(additionalParams, kwargs);
 		} else {
-			if (options.responseFormat) modelKwargs.response_format = { type: options.responseFormat };
+			if (options.responseFormat)
+				additionalParams.response_format = { type: options.responseFormat };
 			if (options.reasoningEffort && ['low', 'medium', 'high'].includes(options.reasoningEffort)) {
-				modelKwargs.reasoning_effort = options.reasoningEffort;
+				additionalParams.reasoning_effort = options.reasoningEffort;
 			}
 		}
 
-		const includedOptions = pick(options, [
-			'frequencyPenalty',
-			'maxTokens',
-			'presencePenalty',
-			'temperature',
-			'topP',
-			'baseURL',
-		]);
-
-		const fields: ChatOpenAIFields = {
-			apiKey: credentials.apiKey as string,
-			model: modelName,
-			...includedOptions,
-			timeout,
-			maxRetries: options.maxRetries ?? 2,
-			configuration,
-			callbacks: [new N8nLlmTracing(this)],
-			modelKwargs,
-			onFailedAttempt: makeN8nLlmFailedAttemptHandler(this, openAiFailedAttemptHandler),
-			// Set to false to ensure compatibility with OpenAI-compatible backends (LM Studio, vLLM, etc.)
-			// that reject strict: null in tool definitions
-			supportsStrictToolCalling: false,
-		};
-
-		// by default ChatOpenAI can switch to responses API automatically, so force it only on 1.3 and above to keep backwards compatibility
-		if (responsesApiEnabled) {
-			fields.useResponsesApi = true;
-		}
-
-		const model = new ChatOpenAI(fields);
-
+		// Prepare provider tools (built-in tools)
+		let providerTools: ProviderTool[] | undefined;
 		if (responsesApiEnabled) {
 			const tools = formatBuiltInTools(
 				this.getNodeParameter('builtInTools', itemIndex, {}) as IDataObject,
 			);
-			// pass tools to the model metadata, ToolAgent will use it to create agent configuration
 			if (tools.length) {
-				model.metadata = {
-					...model.metadata,
-					tools,
-				};
+				providerTools = tools;
 			}
 		}
 
-		return {
-			response: model,
-		};
+		// Handle reasoning effort for reasoning models
+		const reasoning =
+			options.reasoningEffort && ['low', 'medium', 'high'].includes(options.reasoningEffort)
+				? { effort: options.reasoningEffort }
+				: undefined;
+
+		return supplyModel(this, {
+			type: 'openai',
+			baseUrl,
+			apiKey: credentials.apiKey as string,
+			model: modelName,
+			defaultHeaders: headers,
+			useResponsesApi: responsesApiEnabled ? true : undefined,
+			temperature: options.temperature,
+			topP: options.topP,
+			frequencyPenalty: options.frequencyPenalty,
+			presencePenalty: options.presencePenalty,
+			maxTokens: options.maxTokens,
+			timeout: options.timeout,
+			maxRetries: options.maxRetries ?? 2,
+			supportsStrictToolCalling: false,
+			additionalParams: Object.keys(additionalParams).length > 0 ? additionalParams : undefined,
+			providerTools,
+			reasoning,
+			topLogprobs: options.topLogprobs,
+			verbosity: options.verbosity,
+			service_tier: options.serviceTier,
+			promptCacheKey: options.promptCacheKey,
+			onFailedAttempt: openAiFailedAttemptHandler,
+		});
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
@@ -810,7 +810,6 @@ export class LmChatOpenAi implements INodeType {
 			providerTools,
 			reasoning,
 			topLogprobs: options.topLogprobs,
-			verbosity: options.verbosity,
 			service_tier: options.serviceTier,
 			promptCacheKey: options.promptCacheKey,
 			onFailedAttempt: openAiFailedAttemptHandler,

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/common.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/common.ts
@@ -1,5 +1,5 @@
 import type { OpenAIClient } from '@langchain/openai';
-import type { ChatOpenAIToolType } from '@langchain/openai/dist/utils/tools';
+import type { ProviderTool } from '@n8n/ai-utilities';
 import get from 'lodash/get';
 import isObject from 'lodash/isObject';
 import { isObjectEmpty, jsonParse } from 'n8n-workflow';
@@ -28,7 +28,7 @@ const toArray = (str: string) =>
 		.filter(Boolean);
 
 export const formatBuiltInTools = (builtInTools: BuiltInTools) => {
-	const tools: ChatOpenAIToolType[] = [];
+	const tools: ProviderTool[] = [];
 	if (builtInTools) {
 		const webSearchOptions = get(builtInTools, 'webSearch');
 		if (webSearchOptions) {
@@ -49,18 +49,24 @@ export const formatBuiltInTools = (builtInTools: BuiltInTools) => {
 			}
 
 			tools.push({
-				type: 'web_search',
-				search_context_size: get(webSearchOptions, 'searchContextSize', 'medium'),
-				user_location: userLocation,
-				...(allowedDomains && { filters: { allowed_domains: allowedDomains } }),
+				type: 'provider',
+				name: 'web_search',
+				args: {
+					search_context_size: get(webSearchOptions, 'searchContextSize', 'medium'),
+					user_location: userLocation,
+					...(allowedDomains && { filters: { allowed_domains: allowedDomains } }),
+				},
 			});
 		}
 
 		if (builtInTools.codeInterpreter) {
 			tools.push({
-				type: 'code_interpreter',
-				container: {
-					type: 'auto',
+				type: 'provider',
+				name: 'code_interpreter',
+				args: {
+					container: {
+						type: 'auto',
+					},
 				},
 			});
 		}
@@ -69,14 +75,17 @@ export const formatBuiltInTools = (builtInTools: BuiltInTools) => {
 			const vectorStoreIds = get(builtInTools.fileSearch, 'vectorStoreIds', '[]');
 			const filters = get(builtInTools.fileSearch, 'filters', '{}');
 			tools.push({
-				type: 'file_search',
-				vector_store_ids: jsonParse(vectorStoreIds, {
-					errorMessage: 'Failed to parse vector store IDs',
-				}),
-				filters: filters
-					? jsonParse(filters, { errorMessage: 'Failed to parse filters' })
-					: undefined,
-				max_num_results: get(builtInTools.fileSearch, 'maxResults') as number,
+				type: 'provider',
+				name: 'file_search',
+				args: {
+					vector_store_ids: jsonParse(vectorStoreIds, {
+						errorMessage: 'Failed to parse vector store IDs',
+					}),
+					filters: filters
+						? jsonParse(filters, { errorMessage: 'Failed to parse filters' })
+						: undefined,
+					max_num_results: get(builtInTools.fileSearch, 'maxResults') as number,
+				},
 			});
 		}
 	}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/test/common.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/test/common.test.ts
@@ -1,6 +1,7 @@
 import type { IDataObject } from 'n8n-workflow';
 
 import { formatBuiltInTools, prepareAdditionalResponsesParams } from '../common';
+import type { ProviderTool } from '@n8n/ai-utilities';
 
 describe('formatBuiltInTools', () => {
 	it('returns empty array when no built-in tools provided', () => {
@@ -19,19 +20,24 @@ describe('formatBuiltInTools', () => {
 			},
 		} as unknown as IDataObject);
 
-		expect(tools).toEqual([
+		const expected: ProviderTool[] = [
 			{
-				type: 'web_search',
-				search_context_size: 'high',
-				user_location: {
-					type: 'approximate',
-					country: 'US',
-					city: 'NYC',
-					region: 'NY',
+				type: 'provider',
+				name: 'web_search',
+				args: {
+					search_context_size: 'high',
+					user_location: {
+						type: 'approximate',
+						country: 'US',
+						city: 'NYC',
+						region: 'NY',
+					},
+					filters: { allowed_domains: ['example.com', 'sub.domain.org', 'another.net'] },
 				},
-				filters: { allowed_domains: ['example.com', 'sub.domain.org', 'another.net'] },
 			},
-		]);
+		];
+
+		expect(tools).toEqual(expected);
 	});
 
 	it.each([
@@ -65,18 +71,27 @@ describe('formatBuiltInTools', () => {
 				},
 			} as unknown as IDataObject);
 
-			const commonData = {
-				type: 'web_search',
-				search_context_size: 'high',
-				filters: { allowed_domains: ['example.com', 'sub.domain.org', 'another.net'] },
+			const commonData: ProviderTool = {
+				type: 'provider',
+				name: 'web_search',
+				args: {
+					search_context_size: 'high',
+					filters: { allowed_domains: ['example.com', 'sub.domain.org', 'another.net'] },
+				},
 			};
 			if (hasUserLocation) {
 				expect(tools).toEqual([
-					expect.objectContaining({ ...commonData, user_location: expect.anything() }),
+					expect.objectContaining({
+						...commonData,
+						args: { ...commonData.args, user_location: expect.anything() },
+					}),
 				]);
 			} else {
 				expect(tools).toEqual([
-					expect.objectContaining({ ...commonData, user_location: undefined }),
+					expect.objectContaining({
+						...commonData,
+						args: { ...commonData.args, user_location: undefined },
+					}),
 				]);
 			}
 		},
@@ -86,8 +101,11 @@ describe('formatBuiltInTools', () => {
 		const tools = formatBuiltInTools({ codeInterpreter: true } as unknown as IDataObject);
 		expect(tools).toEqual([
 			{
-				type: 'code_interpreter',
-				container: { type: 'auto' },
+				type: 'provider',
+				name: 'code_interpreter',
+				args: {
+					container: { type: 'auto' },
+				},
 			},
 		]);
 	});
@@ -103,10 +121,13 @@ describe('formatBuiltInTools', () => {
 
 		expect(tools).toEqual([
 			{
-				type: 'file_search',
-				vector_store_ids: ['vs1', 'vs2'],
-				filters: { file_types: ['pdf'], tags: ['t1'] },
-				max_num_results: 50,
+				type: 'provider',
+				name: 'file_search',
+				args: {
+					vector_store_ids: ['vs1', 'vs2'],
+					filters: { file_types: ['pdf'], tags: ['t1'] },
+					max_num_results: 50,
+				},
 			},
 		]);
 	});
@@ -117,10 +138,13 @@ describe('formatBuiltInTools', () => {
 		} as unknown as IDataObject);
 		expect(tools).toEqual([
 			{
-				type: 'file_search',
-				vector_store_ids: ['only'],
-				filters: undefined,
-				max_num_results: 3,
+				type: 'provider',
+				name: 'file_search',
+				args: {
+					vector_store_ids: ['only'],
+					filters: undefined,
+					max_num_results: 3,
+				},
 			},
 		]);
 	});

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/types.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/types.ts
@@ -33,6 +33,7 @@ export type ModelOptions = {
 	safetyIdentifier?: string;
 	serviceTier?: 'auto' | 'flex' | 'default' | 'priority';
 	topLogprobs?: number;
+	verbosity?: 'low' | 'medium' | 'high';
 	textFormat?: {
 		textOptions?: TextOptions;
 	};

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.ts
@@ -1,5 +1,4 @@
-import { ChatOpenAI, type ClientOptions } from '@langchain/openai';
-import { getProxyAgent, makeN8nLlmFailedAttemptHandler, N8nLlmTracing } from '@n8n/ai-utilities';
+import { supplyModel } from '@n8n/ai-utilities';
 import {
 	NodeConnectionTypes,
 	type INodeType,
@@ -223,35 +222,22 @@ export class LmChatOpenRouter implements INodeType {
 			responseFormat?: 'text' | 'json_object';
 		};
 
-		const timeout = options.timeout;
-		const configuration: ClientOptions = {
-			baseURL: credentials.url,
-			fetchOptions: {
-				dispatcher: getProxyAgent(credentials.url, {
-					headersTimeout: timeout,
-					bodyTimeout: timeout,
-				}),
-			},
-		};
-
-		const model = new ChatOpenAI({
+		return supplyModel(this, {
+			type: 'openai',
+			baseUrl: credentials.url,
 			apiKey: credentials.apiKey,
 			model: modelName,
-			...options,
-			timeout,
-			maxRetries: options.maxRetries ?? 2,
-			configuration,
-			callbacks: [new N8nLlmTracing(this)],
-			modelKwargs: options.responseFormat
-				? {
-						response_format: { type: options.responseFormat },
-					}
+			temperature: options.temperature,
+			topP: options.topP,
+			frequencyPenalty: options.frequencyPenalty,
+			presencePenalty: options.presencePenalty,
+			maxTokens: options.maxTokens,
+			additionalParams: options.responseFormat
+				? { response_format: { type: options.responseFormat } }
 				: undefined,
-			onFailedAttempt: makeN8nLlmFailedAttemptHandler(this, openAiFailedAttemptHandler),
+			onFailedAttempt: openAiFailedAttemptHandler,
+			timeout: options.timeout,
+			maxRetries: options.maxRetries ?? 2,
 		});
-
-		return {
-			response: model,
-		};
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatVercelAiGateway/LmChatVercelAiGateway.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatVercelAiGateway/LmChatVercelAiGateway.node.ts
@@ -1,5 +1,4 @@
-import { ChatOpenAI, type ClientOptions } from '@langchain/openai';
-import { getProxyAgent, makeN8nLlmFailedAttemptHandler, N8nLlmTracing } from '@n8n/ai-utilities';
+import { supplyModel } from '@n8n/ai-utilities';
 import {
 	NodeConnectionTypes,
 	type INodeType,
@@ -222,35 +221,22 @@ export class LmChatVercelAiGateway implements INodeType {
 			responseFormat?: 'text' | 'json_object';
 		};
 
-		const timeout = options.timeout;
-		const configuration: ClientOptions = {
-			baseURL: credentials.url,
-			fetchOptions: {
-				dispatcher: getProxyAgent(credentials.url, {
-					headersTimeout: timeout,
-					bodyTimeout: timeout,
-				}),
-			},
-		};
-
-		const model = new ChatOpenAI({
+		return supplyModel(this, {
+			type: 'openai',
+			baseUrl: credentials.url,
 			apiKey: credentials.apiKey,
 			model: modelName,
-			...options,
-			timeout,
-			maxRetries: options.maxRetries ?? 2,
-			configuration,
-			callbacks: [new N8nLlmTracing(this)],
-			modelKwargs: options.responseFormat
-				? {
-						response_format: { type: options.responseFormat },
-					}
+			temperature: options.temperature,
+			topP: options.topP,
+			frequencyPenalty: options.frequencyPenalty,
+			presencePenalty: options.presencePenalty,
+			maxTokens: options.maxTokens,
+			additionalParams: options.responseFormat
+				? { response_format: { type: options.responseFormat } }
 				: undefined,
-			onFailedAttempt: makeN8nLlmFailedAttemptHandler(this, openAiFailedAttemptHandler),
+			onFailedAttempt: openAiFailedAttemptHandler,
+			timeout: options.timeout,
+			maxRetries: options.maxRetries ?? 2,
 		});
-
-		return {
-			response: model,
-		};
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatXAiGrok/LmChatXAiGrok.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatXAiGrok/LmChatXAiGrok.node.ts
@@ -233,9 +233,10 @@ export class LmChatXAiGrok implements INodeType {
 			frequencyPenalty: options.frequencyPenalty,
 			presencePenalty: options.presencePenalty,
 			maxTokens: options.maxTokens,
-			additionalParams: options.responseFormat
-				? { response_format: { type: options.responseFormat } }
-				: undefined,
+			additionalParams: {
+				stream_options: undefined,
+				...(options.responseFormat ? { response_format: { type: options.responseFormat } } : {}),
+			},
 			onFailedAttempt: openAiFailedAttemptHandler,
 			timeout: options.timeout,
 			maxRetries: options.maxRetries ?? 2,

--- a/packages/@n8n/nodes-langchain/nodes/llms/test/LmChatOpenAi.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/test/LmChatOpenAi.test.ts
@@ -120,7 +120,9 @@ describe('LmChatOpenAi', () => {
 					configuration: {
 						baseURL: 'https://api.openai.com/v1',
 						defaultHeaders,
-						fetchOptions: expect.any(Object),
+						fetchOptions: {
+							dispatcher: expect.any(Object),
+						},
 					},
 					callbacks: expect.arrayContaining([expect.any(Object)]),
 					modelKwargs: undefined,
@@ -155,7 +157,9 @@ describe('LmChatOpenAi', () => {
 					configuration: {
 						baseURL: 'https://api.openai.com/v1',
 						defaultHeaders,
-						fetchOptions: expect.any(Object),
+						fetchOptions: {
+							dispatcher: expect.any(Object),
+						},
 					},
 					callbacks: expect.arrayContaining([expect.any(Object)]),
 					modelKwargs: undefined,

--- a/packages/@n8n/nodes-langchain/nodes/llms/test/LmChatOpenAi.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/test/LmChatOpenAi.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable n8n-nodes-base/node-filename-against-convention */
 /* eslint-disable @typescript-eslint/unbound-method */
 import { ChatOpenAI } from '@langchain/openai';
+import type { ProviderTool } from '@n8n/ai-utilities';
 import { makeN8nLlmFailedAttemptHandler, N8nLlmTracing, getProxyAgent } from '@n8n/ai-utilities';
 import { AiConfig } from '@n8n/config';
 import { Container } from '@n8n/di';
@@ -11,7 +12,12 @@ import * as common from '../LMChatOpenAi/common';
 import { LmChatOpenAi } from '../LMChatOpenAi/LmChatOpenAi.node';
 
 jest.mock('@langchain/openai');
-jest.mock('@n8n/ai-utilities');
+jest.mock('@n8n/ai-utilities', () => ({
+	...jest.requireActual('@n8n/ai-utilities'),
+	N8nLlmTracing: jest.fn(),
+	makeN8nLlmFailedAttemptHandler: jest.fn(),
+	getProxyAgent: jest.fn(),
+}));
 jest.mock('../LMChatOpenAi/common');
 
 const MockedChatOpenAI = jest.mocked(ChatOpenAI);
@@ -112,13 +118,12 @@ describe('LmChatOpenAi', () => {
 					model: 'gpt-4o-mini',
 					maxRetries: 2,
 					configuration: {
+						baseURL: 'https://api.openai.com/v1',
 						defaultHeaders,
-						fetchOptions: {
-							dispatcher: {},
-						},
+						fetchOptions: expect.any(Object),
 					},
 					callbacks: expect.arrayContaining([expect.any(Object)]),
-					modelKwargs: {},
+					modelKwargs: undefined,
 					onFailedAttempt: expect.any(Function),
 				}),
 			);
@@ -148,13 +153,12 @@ describe('LmChatOpenAi', () => {
 					model: 'gpt-4o-mini',
 					maxRetries: 2,
 					configuration: {
+						baseURL: 'https://api.openai.com/v1',
 						defaultHeaders,
-						fetchOptions: {
-							dispatcher: {},
-						},
+						fetchOptions: expect.any(Object),
 					},
 					callbacks: expect.arrayContaining([expect.any(Object)]),
-					modelKwargs: {},
+					modelKwargs: undefined,
 					onFailedAttempt: expect.any(Function),
 				}),
 			);
@@ -181,18 +185,17 @@ describe('LmChatOpenAi', () => {
 				expect.objectContaining({
 					apiKey: 'test-api-key',
 					model: 'gpt-4o-mini',
-					baseURL: customBaseURL,
 					timeout: 30000,
 					maxRetries: 5,
 					configuration: {
 						baseURL: customBaseURL,
 						fetchOptions: {
-							dispatcher: {},
+							dispatcher: expect.any(Object),
 						},
 						defaultHeaders,
 					},
 					callbacks: expect.arrayContaining([expect.any(Object)]),
-					modelKwargs: {},
+					modelKwargs: undefined,
 					onFailedAttempt: expect.any(Function),
 				}),
 			);
@@ -223,12 +226,12 @@ describe('LmChatOpenAi', () => {
 					configuration: {
 						baseURL: customURL,
 						fetchOptions: {
-							dispatcher: {},
+							dispatcher: expect.any(Object),
 						},
 						defaultHeaders,
 					},
 					callbacks: expect.arrayContaining([expect.any(Object)]),
-					modelKwargs: {},
+					modelKwargs: undefined,
 					onFailedAttempt: expect.any(Function),
 				}),
 			);
@@ -258,16 +261,17 @@ describe('LmChatOpenAi', () => {
 					model: 'gpt-4o-mini',
 					maxRetries: 2,
 					configuration: {
+						baseURL: 'https://api.openai.com/v1',
 						defaultHeaders: {
 							...defaultHeaders,
 							'X-Custom-Header': 'custom-value',
 						},
 						fetchOptions: {
-							dispatcher: {},
+							dispatcher: expect.any(Object),
 						},
 					},
 					callbacks: expect.arrayContaining([expect.any(Object)]),
-					modelKwargs: {},
+					modelKwargs: undefined,
 					onFailedAttempt: expect.any(Function),
 				}),
 			);
@@ -307,9 +311,10 @@ describe('LmChatOpenAi', () => {
 					timeout: 45000,
 					maxRetries: 3,
 					configuration: {
+						baseURL: 'https://api.openai.com/v1',
 						defaultHeaders,
 						fetchOptions: {
-							dispatcher: {},
+							dispatcher: expect.any(Object),
 						},
 					},
 					callbacks: expect.arrayContaining([expect.any(Object)]),
@@ -339,39 +344,8 @@ describe('LmChatOpenAi', () => {
 			expect(MockedChatOpenAI).toHaveBeenCalledWith(
 				expect.objectContaining({
 					model: 'gpt-4o-mini',
-					modelKwargs: {}, // Should not include invalid reasoning_effort
+					modelKwargs: undefined, // Should not include invalid reasoning_effort
 				}),
-			);
-		});
-
-		it('should create N8nLlmTracing callback', async () => {
-			const mockContext = setupMockContext();
-
-			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
-				if (paramName === 'model.value') return 'gpt-4o-mini';
-				if (paramName === 'options') return {};
-				return undefined;
-			});
-
-			await lmChatOpenAi.supplyData.call(mockContext, 0);
-
-			expect(MockedN8nLlmTracing).toHaveBeenCalledWith(mockContext);
-		});
-
-		it('should create failed attempt handler', async () => {
-			const mockContext = setupMockContext();
-
-			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
-				if (paramName === 'model.value') return 'gpt-4o-mini';
-				if (paramName === 'options') return {};
-				return undefined;
-			});
-
-			await lmChatOpenAi.supplyData.call(mockContext, 0);
-
-			expect(mockedMakeN8nLlmFailedAttemptHandler).toHaveBeenCalledWith(
-				mockContext,
-				expect.any(Function), // openAiFailedAttemptHandler
 			);
 		});
 
@@ -438,7 +412,7 @@ describe('LmChatOpenAi', () => {
 					configuration: {
 						baseURL: optionsBaseURL,
 						fetchOptions: {
-							dispatcher: {},
+							dispatcher: expect.any(Object),
 						},
 						defaultHeaders,
 					},
@@ -568,10 +542,16 @@ describe('LmChatOpenAi', () => {
 				codeInterpreter: true,
 			};
 
-			const mockTools = [
+			const mockTools: ProviderTool[] = [
 				{
-					customTools: true,
+					type: 'provider',
+					name: 'web_search',
+					args: {
+						search_context_size: 'high',
+						allowed_domains: 'google.com, wikipedia.org',
+					},
 				},
+				{ type: 'provider', name: 'no_args' },
 			];
 
 			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
@@ -591,7 +571,13 @@ describe('LmChatOpenAi', () => {
 			const instance: unknown = MockedChatOpenAI.mock.instances[0];
 			expect(instance).toBeDefined();
 			expect((instance as { metadata?: { tools?: unknown } }).metadata).toBeDefined();
-			expect((instance as { metadata?: { tools?: unknown } }).metadata?.tools).toEqual(mockTools);
+			expect((instance as { metadata?: { tools?: unknown } }).metadata?.tools).toEqual([
+				{
+					type: 'web_search',
+					search_context_size: 'high',
+					allowed_domains: 'google.com, wikipedia.org',
+				},
+			]);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

This PR migrates several LLM nodes to use the new model adapter pattern.
The changes affect:

- LMChatOpenAi
- LmChatDeepSeek
- LmChatXAiGrok
- LmChatOpenRouter
- LmChatVercelAiGateway
- LmChatLemonade

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4376/migrate-some-nodes-to-use-new-adapters

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)