### PR TITLE
fix(EmbeddingsOpenAi Node): Fix Dimensions and Encoding Format options not appearing in embedding ndoes

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsAzureOpenAi/EmbeddingsAzureOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsAzureOpenAi/EmbeddingsAzureOpenAi.node.ts
@@ -89,7 +89,7 @@ export class EmbeddingsAzureOpenAi implements INodeType {
 					{
 						displayName: 'Dimensions',
 						name: 'dimensions',
-						default: undefined,
+						default: 1536,
 						description:
 							'The number of dimensions the resulting output embeddings should have. Only supported in text-embedding-3 and later models.',
 						type: 'options',

--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsOpenAI/EmbeddingsOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsOpenAI/EmbeddingsOpenAi.node.ts
@@ -145,7 +145,7 @@ export class EmbeddingsOpenAi implements INodeType {
 					{
 						displayName: 'Dimensions',
 						name: 'dimensions',
-						default: undefined,
+						default: 1536,
 						description:
 							'The number of dimensions the resulting output embeddings should have. Only supported in text-embedding-3 and later models.',
 						type: 'options',
@@ -212,7 +212,7 @@ export class EmbeddingsOpenAi implements INodeType {
 						name: 'encodingFormat',
 						type: 'options',
 						description: 'The format to return the embeddings in',
-						default: undefined,
+						default: 'float',
 						options: [
 							{
 								name: 'Float',


### PR DESCRIPTION
## Summary

Fixes the "Dimensions" option (and "Encoding Format") not appearing when selected from the "Add Option" dropdown in the Embeddings OpenAI and Embeddings Azure OpenAI nodes.

**Root cause:** Both fields were defined with `default: undefined` inside a `collection` parameter. When the user selects an option, the UI calls `deepCopy(option.default)` which yields `undefined`, and then `NodeSettings.vue` filters out `undefined` values during parameter persistence (`nodeParameters[key] !== undefined`). 

This means the key is never saved to the node's parameters, so `Object.keys(props.values)` in the collection component never includes the field... the dropdown closes but nothing renders.

**Fix:** Replace `default: undefined` with concrete default values:
- **Dimensions**: `default: 1536` (native output dimension of `text-embedding-3-small`)
- **Encoding Format**: `default: 'float'` (standard OpenAI default)