### PR TITLE
feat(core): Add env var configuration, CLI commands, and public API for source control

### DIFF
--- a/packages/@n8n/permissions/src/__tests__/types.test.ts
+++ b/packages/@n8n/permissions/src/__tests__/types.test.ts
@@ -18,6 +18,8 @@ describe('ApiKeyScope', () => {
 			'project:update',
 			'securityAudit:generate',
 			'sourceControl:pull',
+			'sourceControl:push',
+			'sourceControl:manage',
 			'tag:create',
 			'tag:delete',
 			'tag:list',

--- a/packages/@n8n/permissions/src/constants.ee.ts
+++ b/packages/@n8n/permissions/src/constants.ee.ts
@@ -68,7 +68,7 @@ export const API_KEY_RESOURCES = {
 	user: ['read', 'list', 'create', 'changeRole', 'delete', 'enforceMfa'] as const,
 	execution: ['delete', 'read', 'retry', 'list', 'get'] as const,
 	credential: ['create', 'update', 'move', 'delete', 'list'] as const,
-	sourceControl: ['pull'] as const,
+	sourceControl: ['pull', 'push', 'manage'] as const,
 	workflowTags: ['update', 'list'] as const,
 	executionTags: ['update', 'list'] as const,
 	dataTable: ['create', 'read', 'update', 'delete', 'list'] as const,

--- a/packages/@n8n/permissions/src/public-api-permissions.ee.ts
+++ b/packages/@n8n/permissions/src/public-api-permissions.ee.ts
@@ -14,6 +14,8 @@ export const OWNER_API_KEY_SCOPES: ApiKeyScope[] = [
 	'user:delete',
 	'user:enforceMfa',
 	'sourceControl:pull',
+	'sourceControl:push',
+	'sourceControl:manage',
 	'securityAudit:generate',
 	'project:create',
 	'project:update',

--- a/packages/cli/src/commands/sourcecontrol/pull.ts
+++ b/packages/cli/src/commands/sourcecontrol/pull.ts
@@ -1,0 +1,57 @@
+import { Command } from '@n8n/decorators';
+import { Container } from '@n8n/di';
+import { z } from 'zod';
+
+import { BaseCommand } from '../base-command';
+
+import { isSourceControlLicensed } from '@/modules/source-control.ee/source-control-helper.ee';
+import { SourceControlPreferencesService } from '@/modules/source-control.ee/source-control-preferences.service.ee';
+import { SourceControlService } from '@/modules/source-control.ee/source-control.service.ee';
+import { OwnershipService } from '@/services/ownership.service';
+
+const flagsSchema = z.object({
+	force: z.boolean().describe('Force pull, overwriting local changes').default(false),
+});
+
+@Command({
+	name: 'sourcecontrol:pull',
+	description: 'Pull workflows and credentials from the connected git repository',
+	examples: ['', '--force'],
+	flagsSchema,
+})
+export class SourceControlPullCommand extends BaseCommand<z.infer<typeof flagsSchema>> {
+	async run() {
+		if (!isSourceControlLicensed()) {
+			this.logger.error('Source control feature is not licensed');
+			return;
+		}
+
+		const preferencesService = Container.get(SourceControlPreferencesService);
+		if (!preferencesService.isSourceControlConnected()) {
+			this.logger.error('Source control is not connected to a repository');
+			return;
+		}
+
+		const owner = await Container.get(OwnershipService).getInstanceOwner();
+		const sourceControlService = Container.get(SourceControlService);
+
+		this.logger.info('Pulling from source control...');
+
+		const result = await sourceControlService.pullWorkfolder(owner, {
+			force: this.flags.force,
+			autoPublish: 'none',
+		});
+
+		if (result.statusCode === 409) {
+			this.logger.warn('Conflicts detected. Use --force to override.');
+			return;
+		}
+
+		this.logger.info(`Pull completed successfully. ${result.statusResult.length} files processed.`);
+	}
+
+	async catch(error: Error) {
+		this.logger.error('Error pulling from source control');
+		this.logger.error(error.message);
+	}
+}

--- a/packages/cli/src/commands/sourcecontrol/push.ts
+++ b/packages/cli/src/commands/sourcecontrol/push.ts
@@ -1,0 +1,68 @@
+import { Command } from '@n8n/decorators';
+import { Container } from '@n8n/di';
+import { z } from 'zod';
+
+import { BaseCommand } from '../base-command';
+
+import { isSourceControlLicensed } from '@/modules/source-control.ee/source-control-helper.ee';
+import { SourceControlPreferencesService } from '@/modules/source-control.ee/source-control-preferences.service.ee';
+import { SourceControlService } from '@/modules/source-control.ee/source-control.service.ee';
+import { OwnershipService } from '@/services/ownership.service';
+
+const flagsSchema = z.object({
+	message: z.string().alias('m').describe('Commit message').default('Update from CLI'),
+	force: z.boolean().describe('Force push, ignoring conflicts').default(false),
+});
+
+@Command({
+	name: 'sourcecontrol:push',
+	description: 'Push workflows and credentials to the connected git repository',
+	examples: ['--message="Deploy production"', '-m "Update workflows" --force'],
+	flagsSchema,
+})
+export class SourceControlPushCommand extends BaseCommand<z.infer<typeof flagsSchema>> {
+	async run() {
+		if (!isSourceControlLicensed()) {
+			this.logger.error('Source control feature is not licensed');
+			return;
+		}
+
+		const preferencesService = Container.get(SourceControlPreferencesService);
+		if (!preferencesService.isSourceControlConnected()) {
+			this.logger.error('Source control is not connected to a repository');
+			return;
+		}
+
+		if (preferencesService.isBranchReadOnly()) {
+			this.logger.error('Cannot push to a read-only branch');
+			return;
+		}
+
+		const owner = await Container.get(OwnershipService).getInstanceOwner();
+		const sourceControlService = Container.get(SourceControlService);
+
+		this.logger.info('Pushing to source control...');
+
+		const result = await sourceControlService.pushWorkfolder(owner, {
+			commitMessage: this.flags.message,
+			force: this.flags.force,
+			fileNames: [],
+		});
+
+		if (result.statusCode === 409) {
+			this.logger.warn('Conflicts detected. Use --force to override.');
+			return;
+		}
+
+		this.logger.info(`Push completed successfully. ${result.statusResult.length} files pushed.`);
+
+		if (result.pushResult?.update?.hash?.to) {
+			this.logger.info(`Commit: ${result.pushResult.update.hash.to}`);
+		}
+	}
+
+	async catch(error: Error) {
+		this.logger.error('Error pushing to source control');
+		this.logger.error(error.message);
+	}
+}

--- a/packages/cli/src/commands/sourcecontrol/status.ts
+++ b/packages/cli/src/commands/sourcecontrol/status.ts
@@ -1,0 +1,88 @@
+import { Command } from '@n8n/decorators';
+import { Container } from '@n8n/di';
+import { z } from 'zod';
+
+import { BaseCommand } from '../base-command';
+
+import { isSourceControlLicensed } from '@/modules/source-control.ee/source-control-helper.ee';
+import { SourceControlPreferencesService } from '@/modules/source-control.ee/source-control-preferences.service.ee';
+import { SourceControlService } from '@/modules/source-control.ee/source-control.service.ee';
+import type { SourceControlledFile } from '@n8n/api-types';
+
+import { SourceControlGetStatus } from '@/modules/source-control.ee/types/source-control-get-status';
+import { OwnershipService } from '@/services/ownership.service';
+
+const directionSchema = z.enum(['push', 'pull']);
+
+const flagsSchema = z.object({
+	direction: directionSchema.describe('Direction to check status for').default('push'),
+	verbose: z.boolean().describe('Show detailed file list').default(false),
+});
+
+@Command({
+	name: 'sourcecontrol:status',
+	description: 'Show source control status',
+	examples: ['', '--direction=pull', '--verbose'],
+	flagsSchema,
+})
+export class SourceControlStatusCommand extends BaseCommand<z.infer<typeof flagsSchema>> {
+	async run() {
+		if (!isSourceControlLicensed()) {
+			this.logger.error('Source control feature is not licensed');
+			return;
+		}
+
+		const preferencesService = Container.get(SourceControlPreferencesService);
+		if (!preferencesService.isSourceControlConnected()) {
+			this.logger.error('Source control is not connected to a repository');
+			return;
+		}
+
+		const owner = await Container.get(OwnershipService).getInstanceOwner();
+		const sourceControlService = Container.get(SourceControlService);
+
+		// Always request non-verbose mode from the service (verbose flag controls CLI output formatting)
+		const statusResult = await sourceControlService.getStatus(
+			owner,
+			new SourceControlGetStatus({
+				direction: this.flags.direction,
+				verbose: false,
+				preferLocalVersion: this.flags.direction === 'push',
+			}),
+		);
+
+		// getStatus with verbose=false always returns an array
+		const result: SourceControlledFile[] = Array.isArray(statusResult) ? statusResult : [];
+
+		const preferences = preferencesService.getPreferences();
+		this.logger.info(`Repository: ${preferences.repositoryUrl}`);
+		this.logger.info(`Branch: ${preferences.branchName}`);
+		this.logger.info(`Direction: ${this.flags.direction}`);
+		this.logger.info(`Total changed files: ${result.length}`);
+
+		if (result.length === 0) {
+			this.logger.info('Everything is up to date.');
+			return;
+		}
+
+		if (this.flags.verbose) {
+			for (const file of result) {
+				const conflict = file.conflict ? ' [CONFLICT]' : '';
+				this.logger.info(`  [${file.status}] ${file.type}: ${file.name ?? file.id}${conflict}`);
+			}
+		} else {
+			const grouped: Record<string, number> = {};
+			for (const file of result) {
+				grouped[file.status] = (grouped[file.status] ?? 0) + 1;
+			}
+			for (const [status, count] of Object.entries(grouped)) {
+				this.logger.info(`  ${status}: ${count}`);
+			}
+		}
+	}
+
+	async catch(error: Error) {
+		this.logger.error('Error checking source control status');
+		this.logger.error(error.message);
+	}
+}

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-preferences.service.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-preferences.service.ee.test.ts
@@ -16,6 +16,11 @@ import type { SourceControlPreferences } from '../types/source-control-preferenc
 jest.unmock('node:fs');
 jest.unmock('node:fs/promises');
 
+const mockParsePrivateKey = jest.fn();
+jest.mock('sshpk', () => ({
+	parsePrivateKey: mockParsePrivateKey,
+}));
+
 describe('SourceControlPreferencesService', () => {
 	const instanceSettings = mock<InstanceSettings>({ n8nFolder: '' });
 	const mockCipher = mock<Cipher>();
@@ -434,6 +439,88 @@ describe('SourceControlPreferencesService', () => {
 			);
 
 			await expect(testService.resetKnownHosts()).resolves.toBeUndefined();
+		});
+	});
+
+	describe('saveKeyPairFromEnv', () => {
+		beforeEach(() => {
+			mockParsePrivateKey.mockReset();
+			mockParsePrivateKey.mockReturnValue({
+				comment: '',
+				toPublic: jest.fn().mockReturnValue({
+					comment: '',
+					toString: jest.fn().mockReturnValue('ssh-ed25519 AAAA... n8n deploy key'),
+				}),
+				toString: jest
+					.fn()
+					.mockReturnValue(
+						'-----BEGIN OPENSSH PRIVATE KEY-----\nformatted\n-----END OPENSSH PRIVATE KEY-----',
+					),
+			});
+		});
+
+		it('should encrypt and store a valid SSH private key', async () => {
+			const testKey =
+				'-----BEGIN OPENSSH PRIVATE KEY-----\ntest-key-data\n-----END OPENSSH PRIVATE KEY-----';
+
+			mockCipher.encrypt.mockReturnValue('encrypted-value');
+			mockSettingsRepository.save.mockResolvedValue(undefined as any);
+
+			await service.saveKeyPairFromEnv(testKey);
+
+			expect(mockParsePrivateKey).toHaveBeenCalled();
+			expect(mockSettingsRepository.save).toHaveBeenCalledWith(
+				expect.objectContaining({
+					key: 'features.sourceControl.sshKeys',
+				}),
+			);
+		});
+
+		it('should normalize CRLF line endings before parsing', async () => {
+			const testKeyWithCRLF =
+				'-----BEGIN OPENSSH PRIVATE KEY-----\r\ntest\r\n-----END OPENSSH PRIVATE KEY-----';
+
+			mockCipher.encrypt.mockReturnValue('encrypted-value');
+			mockSettingsRepository.save.mockResolvedValue(undefined as any);
+
+			await service.saveKeyPairFromEnv(testKeyWithCRLF);
+
+			const calledWith = mockParsePrivateKey.mock.calls[0][0] as string;
+			expect(calledWith).not.toContain('\r');
+		});
+
+		it('should trim whitespace from the key', async () => {
+			const testKeyWithSpaces =
+				'  -----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----  ';
+
+			mockCipher.encrypt.mockReturnValue('encrypted-value');
+			mockSettingsRepository.save.mockResolvedValue(undefined as any);
+
+			await service.saveKeyPairFromEnv(testKeyWithSpaces);
+
+			const calledWith = mockParsePrivateKey.mock.calls[0][0] as string;
+			expect(calledWith).toBe(testKeyWithSpaces.trim());
+		});
+
+		it('should throw descriptive error when key parsing fails', async () => {
+			mockParsePrivateKey.mockImplementation(() => {
+				throw new Error('Invalid key format');
+			});
+
+			await expect(service.saveKeyPairFromEnv('invalid-key')).rejects.toThrow(
+				'Failed to parse SSH private key from environment variable',
+			);
+		});
+
+		it('should throw when database save fails', async () => {
+			mockCipher.encrypt.mockReturnValue('encrypted-value');
+			mockSettingsRepository.save.mockRejectedValue(new Error('DB error'));
+
+			await expect(
+				service.saveKeyPairFromEnv(
+					'-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----',
+				),
+			).rejects.toThrow('Failed to save SSH key pair from environment variable');
 		});
 	});
 });

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control.controller.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control.controller.ee.test.ts
@@ -25,6 +25,7 @@ describe('SourceControlController', () => {
 			pullWorkfolder: jest.fn().mockResolvedValue({ statusCode: 200 }),
 			getStatus: jest.fn().mockResolvedValue([]),
 			setGitUserDetails: jest.fn(),
+			autoConfigureFromEnv: jest.fn().mockResolvedValue(undefined),
 		} as unknown as SourceControlService;
 
 		sourceControlPreferencesService = mock<SourceControlPreferencesService>();
@@ -203,6 +204,32 @@ describe('SourceControlController', () => {
 			const getPreferencesRoute = controllerMetadata.routes.get('getPreferences');
 			expect(getPreferencesRoute).toBeDefined();
 			expect(getPreferencesRoute?.skipAuth).toBe(false);
+		});
+	});
+
+	describe('autoConfigure', () => {
+		it('should call autoConfigureFromEnv and return preferences', async () => {
+			const mockPreferences = {
+				branchName: 'main',
+				repositoryUrl: 'git@github.com:test/repo.git',
+				connected: true,
+			};
+			(sourceControlPreferencesService.getPreferences as jest.Mock).mockReturnValue(
+				mockPreferences,
+			);
+
+			const result = await controller.autoConfigure();
+
+			expect(sourceControlService.autoConfigureFromEnv).toHaveBeenCalled();
+			expect(result).toEqual(mockPreferences);
+		});
+
+		it('should throw BadRequestError when autoConfigureFromEnv fails', async () => {
+			(sourceControlService.autoConfigureFromEnv as jest.Mock).mockRejectedValueOnce(
+				new Error('Configuration failed'),
+			);
+
+			await expect(controller.autoConfigure()).rejects.toThrow('Configuration failed');
 		});
 	});
 });

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control.service.test.ts
@@ -1,4 +1,5 @@
 import type { SourceControlledFile } from '@n8n/api-types';
+import type { Logger } from '@n8n/backend-common';
 import { isContainedWithin } from '@n8n/backend-common';
 import { GLOBAL_ADMIN_ROLE, GLOBAL_MEMBER_ROLE, User, type WorkflowEntity } from '@n8n/db';
 import { Container } from '@n8n/di';
@@ -10,11 +11,13 @@ import { SourceControlPreferencesService } from '@/modules/source-control.ee/sou
 import { SourceControlService } from '@/modules/source-control.ee/source-control.service.ee';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import type { EventService } from '@/events/event.service';
+import type { OwnershipService } from '@/services/ownership.service';
 import type { SourceControlExportService } from '../source-control-export.service.ee';
 import type { SourceControlGitService } from '../source-control-git.service.ee';
 import type { SourceControlImportService } from '../source-control-import.service.ee';
 import type { SourceControlScopedService } from '../source-control-scoped.service';
 import { sourceControlFoldersExistCheck } from '../source-control-helper.ee';
+import type { SourceControlConfig } from '../source-control.config';
 import type { ExportResult } from '../types/export-result';
 
 // Mock the status service to avoid complex dependency issues
@@ -45,8 +48,9 @@ describe('SourceControlService', () => {
 	const sourceControlScopedService = mock<SourceControlScopedService>();
 	const gitService = mock<SourceControlGitService>();
 	const eventService = mock<EventService>();
+	const mockLogger = mock<Logger>();
 	const sourceControlService = new SourceControlService(
-		mock(), // logger
+		mockLogger,
 		gitService,
 		preferencesService,
 		sourceControlExportService,
@@ -1148,6 +1152,220 @@ describe('SourceControlService', () => {
 
 			// ACT & ASSERT
 			await expect(sourceControlService.sanityCheck()).resolves.toBeUndefined();
+		});
+	});
+
+	describe('autoConfigureFromEnv', () => {
+		const mockOwner = Object.assign(new User(), { id: 'owner-id', role: GLOBAL_ADMIN_ROLE });
+		const mockOwnershipService = mock<OwnershipService>();
+
+		let mockConfig: SourceControlConfig;
+
+		beforeEach(() => {
+			mockConfig = {
+				repositoryUrl: 'git@github.com:test/repo.git',
+				branch: 'main',
+				branchReadOnly: false,
+				connectionType: 'ssh' as const,
+				sshKey: '-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----',
+				autoPullOnStartup: false,
+				failOnPullError: false,
+				defaultKeyPairType: 'ed25519' as const,
+			};
+
+			mockOwnershipService.getInstanceOwner.mockResolvedValue(mockOwner);
+
+			jest.spyOn(Container, 'get').mockImplementation((token: unknown) => {
+				const name = typeof token === 'function' ? token.name : String(token);
+				if (name === 'SourceControlConfig') return mockConfig;
+				if (name === 'OwnershipService') return mockOwnershipService;
+				return Container.get(token as any);
+			});
+
+			preferencesService.setPreferences = jest.fn().mockResolvedValue({});
+			preferencesService.saveKeyPairFromEnv = jest.fn().mockResolvedValue(undefined);
+			preferencesService.isSourceControlConnected = jest.fn().mockReturnValue(false);
+			preferencesService.getPreferences = jest.fn().mockReturnValue({
+				repositoryUrl: 'git@github.com:test/repo.git',
+				branchName: 'main',
+				branchReadOnly: false,
+				connectionType: 'ssh',
+				connected: false,
+			});
+		});
+
+		afterEach(() => {
+			jest.restoreAllMocks();
+		});
+
+		it('should return early when no repo URL is configured', async () => {
+			mockConfig.repositoryUrl = '';
+
+			await sourceControlService.autoConfigureFromEnv();
+
+			expect(preferencesService.setPreferences).not.toHaveBeenCalled();
+		});
+
+		it('should skip config but pull when already connected and autoPull=true', async () => {
+			preferencesService.isSourceControlConnected = jest.fn().mockReturnValue(true);
+			mockConfig.autoPullOnStartup = true;
+
+			jest.spyOn(sourceControlService, 'pullWorkfolder').mockResolvedValue({
+				statusCode: 200,
+				statusResult: [],
+			});
+
+			await sourceControlService.autoConfigureFromEnv();
+
+			expect(preferencesService.setPreferences).not.toHaveBeenCalled();
+			expect(sourceControlService.pullWorkfolder).toHaveBeenCalledWith(mockOwner, {
+				force: true,
+				autoPublish: 'none',
+			});
+		});
+
+		it('should skip all when already connected and autoPull=false', async () => {
+			preferencesService.isSourceControlConnected = jest.fn().mockReturnValue(true);
+			mockConfig.autoPullOnStartup = false;
+
+			jest.spyOn(sourceControlService, 'pullWorkfolder');
+
+			await sourceControlService.autoConfigureFromEnv();
+
+			expect(preferencesService.setPreferences).not.toHaveBeenCalled();
+			expect(sourceControlService.pullWorkfolder).not.toHaveBeenCalled();
+		});
+
+		it('should import SSH key, set prefs, and init repo when not connected with SSH', async () => {
+			jest
+				.spyOn(sourceControlService, 'initializeRepository')
+				.mockResolvedValue({ branches: ['main'], currentBranch: 'main' });
+
+			await sourceControlService.autoConfigureFromEnv();
+
+			expect(preferencesService.saveKeyPairFromEnv).toHaveBeenCalledWith(mockConfig.sshKey);
+			expect(preferencesService.setPreferences).toHaveBeenCalledWith(
+				expect.objectContaining({
+					repositoryUrl: 'git@github.com:test/repo.git',
+					branchName: 'main',
+					connectionType: 'ssh',
+				}),
+				true,
+				false,
+			);
+			expect(sourceControlService.initializeRepository).toHaveBeenCalled();
+		});
+
+		it('should skip SSH key import when connection type is HTTPS', async () => {
+			mockConfig.connectionType = 'https';
+			mockConfig.repositoryUrl = 'https://github.com/test/repo.git';
+			jest
+				.spyOn(sourceControlService, 'initializeRepository')
+				.mockResolvedValue({ branches: ['main'], currentBranch: 'main' });
+
+			await sourceControlService.autoConfigureFromEnv();
+
+			expect(preferencesService.saveKeyPairFromEnv).not.toHaveBeenCalled();
+		});
+
+		it('should skip SSH key import when sshKey is empty', async () => {
+			mockConfig.sshKey = '';
+			jest
+				.spyOn(sourceControlService, 'initializeRepository')
+				.mockResolvedValue({ branches: ['main'], currentBranch: 'main' });
+
+			await sourceControlService.autoConfigureFromEnv();
+
+			expect(preferencesService.saveKeyPairFromEnv).not.toHaveBeenCalled();
+		});
+
+		it('should disconnect and throw when initializeRepository fails', async () => {
+			jest
+				.spyOn(sourceControlService, 'initializeRepository')
+				.mockRejectedValue(new Error('Git init failed'));
+			jest.spyOn(sourceControlService, 'disconnect').mockResolvedValue({} as any);
+
+			await expect(sourceControlService.autoConfigureFromEnv()).rejects.toThrow(
+				'Failed to auto-connect source control from environment variables',
+			);
+
+			expect(sourceControlService.disconnect).toHaveBeenCalledWith({ keepKeyPair: true });
+		});
+
+		it('should pull after successful connect when autoPull=true', async () => {
+			mockConfig.autoPullOnStartup = true;
+			jest
+				.spyOn(sourceControlService, 'initializeRepository')
+				.mockResolvedValue({ branches: ['main'], currentBranch: 'main' });
+			jest.spyOn(sourceControlService, 'pullWorkfolder').mockResolvedValue({
+				statusCode: 200,
+				statusResult: [],
+			});
+
+			await sourceControlService.autoConfigureFromEnv();
+
+			expect(sourceControlService.initializeRepository).toHaveBeenCalled();
+			expect(sourceControlService.pullWorkfolder).toHaveBeenCalledWith(mockOwner, {
+				force: true,
+				autoPublish: 'none',
+			});
+		});
+
+		it('should not pull after connect when autoPull=false', async () => {
+			mockConfig.autoPullOnStartup = false;
+			jest
+				.spyOn(sourceControlService, 'initializeRepository')
+				.mockResolvedValue({ branches: ['main'], currentBranch: 'main' });
+			jest.spyOn(sourceControlService, 'pullWorkfolder');
+
+			await sourceControlService.autoConfigureFromEnv();
+
+			expect(sourceControlService.pullWorkfolder).not.toHaveBeenCalled();
+		});
+
+		it('should use SOURCE_CONTROL_DEFAULT_BRANCH when branch is empty', async () => {
+			mockConfig.branch = '';
+			jest
+				.spyOn(sourceControlService, 'initializeRepository')
+				.mockResolvedValue({ branches: ['main'], currentBranch: 'main' });
+
+			await sourceControlService.autoConfigureFromEnv();
+
+			expect(preferencesService.setPreferences).toHaveBeenCalledWith(
+				expect.objectContaining({ branchName: 'main' }),
+				true,
+				false,
+			);
+		});
+
+		it('should throw UnexpectedError when pull fails and failOnError=true', async () => {
+			preferencesService.isSourceControlConnected = jest.fn().mockReturnValue(true);
+			mockConfig.autoPullOnStartup = true;
+			mockConfig.failOnPullError = true;
+
+			jest
+				.spyOn(sourceControlService, 'pullWorkfolder')
+				.mockRejectedValue(new Error('Pull failed'));
+
+			await expect(sourceControlService.autoConfigureFromEnv()).rejects.toThrow(
+				'Auto-pull from source control failed: Pull failed',
+			);
+		});
+
+		it('should warn but not throw when pull fails and failOnError=false', async () => {
+			preferencesService.isSourceControlConnected = jest.fn().mockReturnValue(true);
+			mockConfig.autoPullOnStartup = true;
+			mockConfig.failOnPullError = false;
+
+			jest
+				.spyOn(sourceControlService, 'pullWorkfolder')
+				.mockRejectedValue(new Error('Pull failed'));
+
+			await expect(sourceControlService.autoConfigureFromEnv()).resolves.toBeUndefined();
+
+			expect(mockLogger.warn).toHaveBeenCalledWith(
+				'Auto-pull from source control failed: Pull failed',
+			);
 		});
 	});
 });

--- a/packages/cli/src/modules/source-control.ee/source-control-preferences.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-preferences.service.ee.ts
@@ -11,6 +11,7 @@ import * as path from 'path';
 
 import {
 	SOURCE_CONTROL_GIT_FOLDER,
+	SOURCE_CONTROL_GIT_KEY_COMMENT,
 	SOURCE_CONTROL_PREFERENCES_DB_KEY,
 	SOURCE_CONTROL_SSH_FOLDER,
 	SOURCE_CONTROL_SSH_KEY_NAME,
@@ -228,6 +229,49 @@ export class SourceControlPreferencesService {
 		}
 
 		return this.getPreferences();
+	}
+
+	/**
+	 * Import an SSH private key from an environment variable and store it encrypted in the database.
+	 * Derives the public key from the private key using sshpk.
+	 */
+	async saveKeyPairFromEnv(privateKeyRaw: string): Promise<void> {
+		const sshpk = await import('sshpk');
+		const normalizedKey = privateKeyRaw.replace(/\r\n/g, '\n').replace(/\r/g, '\n').trim();
+
+		let sshPrivateKey: string;
+		let sshPublicKey: string;
+
+		try {
+			const parsedKey = sshpk.parsePrivateKey(normalizedKey, 'auto');
+			parsedKey.comment = SOURCE_CONTROL_GIT_KEY_COMMENT;
+
+			const publicKey = parsedKey.toPublic();
+			publicKey.comment = SOURCE_CONTROL_GIT_KEY_COMMENT;
+
+			sshPrivateKey = parsedKey.toString('ssh-private');
+			sshPublicKey = publicKey.toString('ssh');
+		} catch (error) {
+			throw new UnexpectedError(
+				'Failed to parse SSH private key from environment variable. Ensure it is a valid OpenSSH or PEM-formatted private key.',
+				{ cause: error },
+			);
+		}
+
+		try {
+			await this.settingsRepository.save({
+				key: 'features.sourceControl.sshKeys',
+				value: JSON.stringify({
+					encryptedPrivateKey: this.cipher.encrypt(sshPrivateKey),
+					publicKey: sshPublicKey,
+				}),
+				loadOnStartup: true,
+			});
+		} catch (error) {
+			throw new UnexpectedError('Failed to save SSH key pair from environment variable', {
+				cause: error,
+			});
+		}
 	}
 
 	isBranchReadOnly(): boolean {

--- a/packages/cli/src/modules/source-control.ee/source-control.config.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control.config.ts
@@ -1,8 +1,43 @@
 import { Config, Env } from '@n8n/config';
+import { z } from 'zod';
+
+const connectionTypeSchema = z.enum(['ssh', 'https']);
 
 @Config
 export class SourceControlConfig {
 	/** Default SSH key type to use when generating SSH keys. */
 	@Env('N8N_SOURCECONTROL_DEFAULT_SSH_KEY_TYPE')
 	defaultKeyPairType: 'ed25519' | 'rsa' = 'ed25519';
+
+	/** Git repository URL for auto-configuration (e.g. git@github.com:org/repo.git). */
+	@Env('N8N_SOURCECONTROL_REPO_URL')
+	repositoryUrl: string = '';
+
+	/** Branch name to use. Only applied during auto-configuration. */
+	@Env('N8N_SOURCECONTROL_BRANCH')
+	branch: string = 'main';
+
+	/** Whether the branch is read-only (pull only, no push). */
+	@Env('N8N_SOURCECONTROL_BRANCH_READ_ONLY')
+	branchReadOnly: boolean = false;
+
+	/**
+	 * SSH private key for git authentication.
+	 * Supports the `_FILE` suffix pattern (e.g. N8N_SOURCECONTROL_SSH_KEY_FILE=/run/secrets/key)
+	 * for Docker/Kubernetes secrets.
+	 */
+	@Env('N8N_SOURCECONTROL_SSH_KEY')
+	sshKey: string = '';
+
+	/** Connection type: 'ssh' or 'https'. */
+	@Env('N8N_SOURCECONTROL_CONNECTION_TYPE', connectionTypeSchema)
+	connectionType: 'ssh' | 'https' = 'ssh';
+
+	/** Whether to automatically pull from git on startup after connecting. */
+	@Env('N8N_SOURCECONTROL_AUTO_PULL_ON_STARTUP')
+	autoPullOnStartup: boolean = false;
+
+	/** Whether to fail startup if auto-pull encounters an error. */
+	@Env('N8N_SOURCECONTROL_FAIL_ON_PULL_ERROR')
+	failOnPullError: boolean = false;
 }

--- a/packages/cli/src/modules/source-control.ee/source-control.controller.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control.controller.ee.ts
@@ -151,6 +151,17 @@ export class SourceControlController {
 		}
 	}
 
+	@Post('/auto-configure')
+	@GlobalScope('sourceControl:manage')
+	async autoConfigure(): Promise<SourceControlPreferences> {
+		try {
+			await this.sourceControlService.autoConfigureFromEnv();
+			return this.sourceControlPreferencesService.getPreferences();
+		} catch (error) {
+			throw new BadRequestError((error as { message: string }).message);
+		}
+	}
+
 	@Post('/disconnect')
 	@GlobalScope('sourceControl:manage')
 	async disconnect(req: SourceControlRequest.Disconnect) {

--- a/packages/cli/src/modules/source-control.ee/source-control.module.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control.module.ts
@@ -12,6 +12,8 @@ export class SourceControlModule implements ModuleInterface {
 		await import('./source-control.controller.ee');
 
 		const { SourceControlService } = await import('./source-control.service.ee');
-		await Container.get(SourceControlService).start();
+		const service = Container.get(SourceControlService);
+		await service.start();
+		await service.autoConfigureFromEnv();
 	}
 }

--- a/packages/cli/src/modules/source-control.ee/source-control.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control.service.ee.ts
@@ -6,18 +6,20 @@ import type {
 import { Logger } from '@n8n/backend-common';
 import { type User } from '@n8n/db';
 import { OnPubSubEvent } from '@n8n/decorators';
-import { Service } from '@n8n/di';
+import { Container, Service } from '@n8n/di';
 import { writeFileSync } from 'fs';
 import { UnexpectedError, UserError, jsonParse } from 'n8n-workflow';
 import * as path from 'path';
 import type { PushResult } from 'simple-git';
 
 import {
+	SOURCE_CONTROL_DEFAULT_BRANCH,
 	SOURCE_CONTROL_DEFAULT_EMAIL,
 	SOURCE_CONTROL_DEFAULT_NAME,
 	SOURCE_CONTROL_README,
 	SOURCE_CONTROL_WORKFLOW_EXPORT_FOLDER,
 } from './constants';
+import { SourceControlConfig } from './source-control.config';
 import { SourceControlExportService } from './source-control-export.service.ee';
 import { SourceControlGitService } from './source-control-git.service.ee';
 import {
@@ -45,6 +47,7 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { EventService } from '@/events/event.service';
 import { IWorkflowToImport } from '@/interfaces';
+import { OwnershipService } from '@/services/ownership.service';
 
 @Service()
 export class SourceControlService {
@@ -76,6 +79,107 @@ export class SourceControlService {
 
 	async start(): Promise<void> {
 		await this.refreshServiceState();
+	}
+
+	/**
+	 * Automatically configures and connects source control from environment variables.
+	 * Only runs if:
+	 *  - A repository URL is configured via N8N_SOURCECONTROL_REPO_URL
+	 *  - Source control is not already connected
+	 *
+	 * Optionally pulls from git on startup if N8N_SOURCECONTROL_AUTO_PULL_ON_STARTUP is true.
+	 */
+	async autoConfigureFromEnv(): Promise<void> {
+		const config = Container.get(SourceControlConfig);
+
+		if (!config.repositoryUrl) {
+			return;
+		}
+
+		if (this.sourceControlPreferencesService.isSourceControlConnected()) {
+			this.logger.debug(
+				'Source control is already connected, skipping auto-configuration from env vars',
+			);
+
+			if (config.autoPullOnStartup) {
+				await this.autoPullOnStartup(config.failOnPullError);
+			}
+			return;
+		}
+
+		this.logger.info('Auto-configuring source control from environment variables');
+
+		// Import SSH key from env var if provided
+		if (config.sshKey && config.connectionType === 'ssh') {
+			await this.sourceControlPreferencesService.saveKeyPairFromEnv(config.sshKey);
+			this.logger.debug('SSH key pair imported from environment variable');
+		}
+
+		// Set preferences from env vars
+		const preferences: Partial<SourceControlPreferences> = {
+			repositoryUrl: config.repositoryUrl,
+			branchName: config.branch || SOURCE_CONTROL_DEFAULT_BRANCH,
+			branchReadOnly: config.branchReadOnly,
+			connectionType: config.connectionType,
+		};
+
+		await this.sourceControlPreferencesService.setPreferences(preferences, true, false);
+
+		// Initialize repository (connect)
+		const owner = await Container.get(OwnershipService).getInstanceOwner();
+
+		try {
+			await this.initializeRepository(
+				{
+					...this.sourceControlPreferencesService.getPreferences(),
+					branchName: preferences.branchName || SOURCE_CONTROL_DEFAULT_BRANCH,
+					initRepo: true,
+				},
+				owner,
+			);
+		} catch (error) {
+			this.logger.error(
+				`Failed to auto-connect source control to ${config.repositoryUrl}: ${(error as Error).message}`,
+			);
+			// Clean up partial state
+			await this.disconnect({ keepKeyPair: true });
+			throw new UnexpectedError(
+				'Failed to auto-connect source control from environment variables',
+				{
+					cause: error,
+				},
+			);
+		}
+
+		this.logger.info(
+			`Source control connected to ${config.repositoryUrl} on branch ${preferences.branchName}`,
+		);
+
+		// Auto-pull if enabled
+		if (config.autoPullOnStartup) {
+			await this.autoPullOnStartup(config.failOnPullError);
+		}
+	}
+
+	private async autoPullOnStartup(failOnError: boolean): Promise<void> {
+		this.logger.info('Auto-pulling from source control on startup');
+
+		const owner = await Container.get(OwnershipService).getInstanceOwner();
+
+		try {
+			const result = await this.pullWorkfolder(owner, { force: true, autoPublish: 'none' });
+			this.logger.info(
+				`Auto-pull completed successfully, ${result.statusResult.length} files processed`,
+			);
+		} catch (error) {
+			const message = `Auto-pull from source control failed: ${(error as Error).message}`;
+
+			if (failOnError) {
+				throw new UnexpectedError(message, { cause: error });
+			}
+
+			this.logger.warn(message);
+		}
 	}
 
 	/**

--- a/packages/cli/src/public-api/v1/handlers/source-control/__tests__/source-control.handler.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/source-control/__tests__/source-control.handler.test.ts
@@ -1,0 +1,243 @@
+import type { AuthenticatedRequest } from '@n8n/db';
+import { Container } from '@n8n/di';
+import type express from 'express';
+
+import * as sourceControlHelper from '@/modules/source-control.ee/source-control-helper.ee';
+import { SourceControlPreferencesService } from '@/modules/source-control.ee/source-control-preferences.service.ee';
+import { SourceControlService } from '@/modules/source-control.ee/source-control.service.ee';
+import { EventService } from '@/events/event.service';
+import * as middlewares from '@/public-api/v1/shared/middlewares/global.middleware';
+
+// Mock middleware before requiring handler
+const mockMiddleware = jest.fn(async (_req: unknown, _res: unknown, next: () => void) =>
+	next(),
+) as any;
+jest.spyOn(middlewares, 'apiKeyHasScopeWithGlobalScopeFallback').mockReturnValue(mockMiddleware);
+
+const mockSourceControlPreferencesService = {
+	isSourceControlConnected: jest.fn().mockReturnValue(true),
+};
+const mockSourceControlService = {
+	pushWorkfolder: jest.fn(),
+	setGitUserDetails: jest.fn(),
+	getStatus: jest.fn(),
+	pullWorkfolder: jest.fn(),
+};
+const mockEventService = { emit: jest.fn() };
+
+jest.spyOn(sourceControlHelper, 'isSourceControlLicensed').mockReturnValue(true);
+jest
+	.spyOn(sourceControlHelper, 'getTrackingInformationFromPostPushResult')
+	.mockReturnValue({} as any);
+jest.spyOn(sourceControlHelper, 'getTrackingInformationFromPullResult').mockReturnValue({} as any);
+
+jest.spyOn(Container, 'get').mockImplementation((token: unknown) => {
+	if (token === SourceControlPreferencesService) return mockSourceControlPreferencesService as any;
+	if (token === SourceControlService) return mockSourceControlService as any;
+	if (token === EventService) return mockEventService as any;
+	return {} as any;
+});
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const handler = require('../source-control.handler');
+
+describe('Source Control Public API Handler', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		(sourceControlHelper.isSourceControlLicensed as jest.Mock).mockReturnValue(true);
+		mockSourceControlPreferencesService.isSourceControlConnected.mockReturnValue(true);
+
+		jest.spyOn(Container, 'get').mockImplementation((token: unknown) => {
+			if (token === SourceControlPreferencesService)
+				return mockSourceControlPreferencesService as any;
+			if (token === SourceControlService) return mockSourceControlService as any;
+			if (token === EventService) return mockEventService as any;
+			return {} as any;
+		});
+	});
+
+	const createMockRes = () => {
+		const res = {
+			status: jest.fn().mockReturnThis(),
+			json: jest.fn().mockReturnThis(),
+			send: jest.fn().mockReturnThis(),
+		} as unknown as express.Response;
+		return res;
+	};
+
+	const createMockReq = (overrides: Record<string, unknown> = {}) =>
+		({
+			user: {
+				id: 'user-1',
+				firstName: 'Test',
+				lastName: 'User',
+				email: 'test@example.com',
+			},
+			body: {},
+			query: {},
+			...overrides,
+		}) as unknown as AuthenticatedRequest;
+
+	describe('push', () => {
+		const getPushHandler = () => handler.push[1];
+
+		it('should return 401 when not licensed', async () => {
+			(sourceControlHelper.isSourceControlLicensed as jest.Mock).mockReturnValue(false);
+			const res = createMockRes();
+			const req = createMockReq();
+
+			await getPushHandler()(req, res);
+
+			expect(res.status).toHaveBeenCalledWith(401);
+			expect(res.json).toHaveBeenCalledWith(
+				expect.objectContaining({ message: 'Source Control feature is not licensed' }),
+			);
+		});
+
+		it('should return 400 when not connected', async () => {
+			mockSourceControlPreferencesService.isSourceControlConnected.mockReturnValue(false);
+			const res = createMockRes();
+			const req = createMockReq();
+
+			await getPushHandler()(req, res);
+
+			expect(res.status).toHaveBeenCalledWith(400);
+			expect(res.json).toHaveBeenCalledWith(
+				expect.objectContaining({
+					message: 'Source Control is not connected to a repository',
+				}),
+			);
+		});
+
+		it('should return 200 with files and commit on success', async () => {
+			const mockResult = {
+				statusCode: 200,
+				statusResult: [{ file: 'test.json', status: 'modified' }],
+				pushResult: {
+					update: {
+						hash: { to: 'abc123' },
+						head: { local: 'main' },
+					},
+				},
+			};
+			mockSourceControlService.pushWorkfolder.mockResolvedValue(mockResult);
+			mockSourceControlService.setGitUserDetails.mockResolvedValue(undefined);
+
+			const res = createMockRes();
+			const req = createMockReq({
+				body: { fileNames: [] },
+			});
+
+			await getPushHandler()(req, res);
+
+			expect(res.status).toHaveBeenCalledWith(200);
+			expect(res.json).toHaveBeenCalledWith(
+				expect.objectContaining({
+					files: mockResult.statusResult,
+					commit: expect.objectContaining({ hash: 'abc123' }),
+				}),
+			);
+		});
+
+		it('should return 409 on conflict', async () => {
+			const mockResult = {
+				statusCode: 409,
+				statusResult: [{ file: 'test.json', conflict: true }],
+				pushResult: undefined,
+			};
+			mockSourceControlService.pushWorkfolder.mockResolvedValue(mockResult);
+			mockSourceControlService.setGitUserDetails.mockResolvedValue(undefined);
+
+			const res = createMockRes();
+			const req = createMockReq({
+				body: { fileNames: [] },
+			});
+
+			await getPushHandler()(req, res);
+
+			expect(res.status).toHaveBeenCalledWith(409);
+		});
+
+		it('should return 400 on error', async () => {
+			mockSourceControlService.pushWorkfolder.mockRejectedValue(new Error('Push failed'));
+			mockSourceControlService.setGitUserDetails.mockResolvedValue(undefined);
+
+			const res = createMockRes();
+			const req = createMockReq({
+				body: { fileNames: [] },
+			});
+
+			await getPushHandler()(req, res);
+
+			expect(res.status).toHaveBeenCalledWith(400);
+			expect(res.send).toHaveBeenCalledWith('Push failed');
+		});
+	});
+
+	describe('getStatus', () => {
+		const getStatusHandler = () => handler.getStatus[1];
+
+		it('should return 401 when not licensed', async () => {
+			(sourceControlHelper.isSourceControlLicensed as jest.Mock).mockReturnValue(false);
+			const res = createMockRes();
+			const req = createMockReq();
+
+			await getStatusHandler()(req, res);
+
+			expect(res.status).toHaveBeenCalledWith(401);
+		});
+
+		it('should return 400 when not connected', async () => {
+			mockSourceControlPreferencesService.isSourceControlConnected.mockReturnValue(false);
+			const res = createMockRes();
+			const req = createMockReq();
+
+			await getStatusHandler()(req, res);
+
+			expect(res.status).toHaveBeenCalledWith(400);
+		});
+
+		it('should return 200 with status array', async () => {
+			const mockStatus = [{ file: 'workflow-1.json', type: 'workflow', status: 'modified' }];
+			mockSourceControlService.getStatus.mockResolvedValue(mockStatus);
+
+			const res = createMockRes();
+			const req = createMockReq();
+
+			await getStatusHandler()(req, res);
+
+			expect(res.status).toHaveBeenCalledWith(200);
+			expect(res.json).toHaveBeenCalledWith(mockStatus);
+		});
+
+		it('should pass query params correctly', async () => {
+			mockSourceControlService.getStatus.mockResolvedValue([]);
+
+			const res = createMockRes();
+			const req = createMockReq({
+				query: { direction: 'pull', verbose: 'true', preferLocalVersion: 'false' },
+			});
+
+			await getStatusHandler()(req, res);
+
+			expect(mockSourceControlService.getStatus).toHaveBeenCalledWith(
+				req.user,
+				expect.objectContaining({
+					direction: 'pull',
+				}),
+			);
+		});
+
+		it('should return 400 on error', async () => {
+			mockSourceControlService.getStatus.mockRejectedValue(new Error('Status failed'));
+
+			const res = createMockRes();
+			const req = createMockReq();
+
+			await getStatusHandler()(req, res);
+
+			expect(res.status).toHaveBeenCalledWith(400);
+			expect(res.send).toHaveBeenCalledWith('Status failed');
+		});
+	});
+});

--- a/packages/cli/src/public-api/v1/handlers/source-control/source-control.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/source-control/source-control.handler.ts
@@ -1,16 +1,18 @@
-import { PullWorkFolderRequestDto } from '@n8n/api-types';
+import { PullWorkFolderRequestDto, PushWorkFolderRequestDto } from '@n8n/api-types';
 import type { AuthenticatedRequest } from '@n8n/db';
 import { Container } from '@n8n/di';
 import type express from 'express';
 import type { StatusResult } from 'simple-git';
 
 import {
+	getTrackingInformationFromPostPushResult,
 	getTrackingInformationFromPullResult,
 	isSourceControlLicensed,
 } from '@/modules/source-control.ee/source-control-helper.ee';
 import { SourceControlPreferencesService } from '@/modules/source-control.ee/source-control-preferences.service.ee';
 import { SourceControlService } from '@/modules/source-control.ee/source-control.service.ee';
 import type { ImportResult } from '@/modules/source-control.ee/types/import-result';
+import { SourceControlGetStatus } from '@/modules/source-control.ee/types/source-control-get-status';
 import { EventService } from '@/events/event.service';
 
 import { apiKeyHasScopeWithGlobalScopeFallback } from '../../shared/middlewares/global.middleware';
@@ -47,6 +49,87 @@ export = {
 				} else {
 					return res.status(409).send(result.statusResult);
 				}
+			} catch (error) {
+				return res.status(400).send((error as { message: string }).message);
+			}
+		},
+	],
+
+	push: [
+		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'sourceControl:push' }),
+		async (req: AuthenticatedRequest, res: express.Response): Promise<express.Response> => {
+			const sourceControlPreferencesService = Container.get(SourceControlPreferencesService);
+			if (!isSourceControlLicensed()) {
+				return res
+					.status(401)
+					.json({ status: 'Error', message: 'Source Control feature is not licensed' });
+			}
+			if (!sourceControlPreferencesService.isSourceControlConnected()) {
+				return res
+					.status(400)
+					.json({ status: 'Error', message: 'Source Control is not connected to a repository' });
+			}
+			try {
+				const payload = PushWorkFolderRequestDto.parse(req.body);
+				const sourceControlService = Container.get(SourceControlService);
+
+				await sourceControlService.setGitUserDetails(
+					`${req.user.firstName} ${req.user.lastName}`,
+					req.user.email,
+				);
+
+				const result = await sourceControlService.pushWorkfolder(req.user, payload);
+
+				if (result.statusCode === 200) {
+					Container.get(EventService).emit(
+						'source-control-user-finished-push-ui',
+						getTrackingInformationFromPostPushResult(req.user.id, result.statusResult),
+					);
+					return res.status(200).json({
+						files: result.statusResult,
+						commit: result.pushResult?.update?.hash?.to
+							? {
+									hash: result.pushResult.update.hash.to,
+									message: payload.commitMessage ?? 'Updated Workfolder',
+									branch: result.pushResult.update.head?.local ?? '',
+								}
+							: null,
+					});
+				} else {
+					return res.status(409).json({ files: result.statusResult, commit: null });
+				}
+			} catch (error) {
+				return res.status(400).send((error as { message: string }).message);
+			}
+		},
+	],
+
+	getStatus: [
+		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'sourceControl:pull' }),
+		async (req: AuthenticatedRequest, res: express.Response): Promise<express.Response> => {
+			const sourceControlPreferencesService = Container.get(SourceControlPreferencesService);
+			if (!isSourceControlLicensed()) {
+				return res
+					.status(401)
+					.json({ status: 'Error', message: 'Source Control feature is not licensed' });
+			}
+			if (!sourceControlPreferencesService.isSourceControlConnected()) {
+				return res
+					.status(400)
+					.json({ status: 'Error', message: 'Source Control is not connected to a repository' });
+			}
+			try {
+				const sourceControlService = Container.get(SourceControlService);
+				const query = req.query as Record<string, string>;
+				const result = await sourceControlService.getStatus(
+					req.user,
+					new SourceControlGetStatus({
+						direction: (query.direction as 'push' | 'pull') ?? 'push',
+						verbose: query.verbose ?? 'false',
+						preferLocalVersion: query.preferLocalVersion ?? 'true',
+					}),
+				);
+				return res.status(200).json(result);
 			} catch (error) {
 				return res.status(400).send((error as { message: string }).message);
 			}

--- a/packages/cli/src/public-api/v1/handlers/source-control/spec/paths/sourceControl.push.yml
+++ b/packages/cli/src/public-api/v1/handlers/source-control/spec/paths/sourceControl.push.yml
@@ -1,0 +1,25 @@
+post:
+  x-eov-operation-id: push
+  x-eov-operation-handler: v1/handlers/source-control/source-control.handler
+  tags:
+    - SourceControl
+  summary: Push changes to the remote repository
+  description: Requires the Source Control feature to be licensed and connected to a repository.
+  requestBody:
+    description: Push options
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/push.yml'
+  responses:
+    '200':
+      description: Push result with files and commit info
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/pushResult.yml'
+    '400':
+      $ref: '../../../../shared/spec/responses/badRequest.yml'
+    '409':
+      $ref: '../../../../shared/spec/responses/conflict.yml'

--- a/packages/cli/src/public-api/v1/handlers/source-control/spec/paths/sourceControl.status.yml
+++ b/packages/cli/src/public-api/v1/handlers/source-control/spec/paths/sourceControl.status.yml
@@ -1,0 +1,39 @@
+get:
+  x-eov-operation-id: getStatus
+  x-eov-operation-handler: v1/handlers/source-control/source-control.handler
+  tags:
+    - SourceControl
+  summary: Get source control status
+  description: Returns the list of source-controlled files with their status. Requires the Source Control feature to be licensed and connected to a repository.
+  parameters:
+    - name: direction
+      in: query
+      description: Whether to get status for push or pull
+      required: false
+      schema:
+        type: string
+        enum: [push, pull]
+        default: push
+    - name: verbose
+      in: query
+      description: Whether to include verbose status information
+      required: false
+      schema:
+        type: boolean
+        default: false
+    - name: preferLocalVersion
+      in: query
+      description: Whether to prefer the local version when comparing
+      required: false
+      schema:
+        type: boolean
+        default: true
+  responses:
+    '200':
+      description: Status result
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/statusResult.yml'
+    '400':
+      $ref: '../../../../shared/spec/responses/badRequest.yml'

--- a/packages/cli/src/public-api/v1/handlers/source-control/spec/schemas/push.yml
+++ b/packages/cli/src/public-api/v1/handlers/source-control/spec/schemas/push.yml
@@ -1,0 +1,15 @@
+type: object
+properties:
+  force:
+    type: boolean
+    description: Whether to force push (overwrite conflicts)
+    example: false
+  commitMessage:
+    type: string
+    description: Commit message for the push
+    example: Updated workflows
+  fileNames:
+    type: array
+    description: List of files to push. If empty, all changed files are pushed.
+    items:
+      $ref: './sourceControlledFile.yml'

--- a/packages/cli/src/public-api/v1/handlers/source-control/spec/schemas/pushResult.yml
+++ b/packages/cli/src/public-api/v1/handlers/source-control/spec/schemas/pushResult.yml
@@ -1,0 +1,22 @@
+type: object
+properties:
+  files:
+    type: array
+    items:
+      $ref: './sourceControlledFile.yml'
+  commit:
+    type: object
+    nullable: true
+    properties:
+      hash:
+        type: string
+        description: The commit hash
+        example: abc123def456
+      message:
+        type: string
+        description: The commit message
+        example: Updated workflows
+      branch:
+        type: string
+        description: The branch that was pushed to
+        example: main

--- a/packages/cli/src/public-api/v1/handlers/source-control/spec/schemas/sourceControlledFile.yml
+++ b/packages/cli/src/public-api/v1/handlers/source-control/spec/schemas/sourceControlledFile.yml
@@ -1,0 +1,41 @@
+type: object
+properties:
+  file:
+    type: string
+    description: File path relative to the git folder
+    example: workflow-abc123.json
+  id:
+    type: string
+    description: Resource identifier
+    example: abc123
+  name:
+    type: string
+    description: Resource name
+    example: My Workflow
+  type:
+    type: string
+    enum: [workflow, credential, tags, variables, folders, project, file]
+    description: Type of resource
+    example: workflow
+  status:
+    type: string
+    enum: [created, deleted, modified, renamed, unknown]
+    description: Change status
+    example: modified
+  location:
+    type: string
+    enum: [local, remote, unknown]
+    description: Where the change originates
+    example: local
+  conflict:
+    type: boolean
+    description: Whether this file has a conflict
+    example: false
+  updatedAt:
+    type: string
+    description: ISO 8601 timestamp of last update
+    example: '2024-01-01T00:00:00.000Z'
+  pushed:
+    type: boolean
+    description: Whether this file has been pushed
+    example: true

--- a/packages/cli/src/public-api/v1/handlers/source-control/spec/schemas/statusResult.yml
+++ b/packages/cli/src/public-api/v1/handlers/source-control/spec/schemas/statusResult.yml
@@ -1,0 +1,3 @@
+type: array
+items:
+  $ref: './sourceControlledFile.yml'

--- a/packages/cli/src/public-api/v1/openapi.yml
+++ b/packages/cli/src/public-api/v1/openapi.yml
@@ -82,6 +82,10 @@ paths:
     $ref: './handlers/users/spec/paths/users.id.role.yml'
   /source-control/pull:
     $ref: './handlers/source-control/spec/paths/sourceControl.yml'
+  /source-control/push:
+    $ref: './handlers/source-control/spec/paths/sourceControl.push.yml'
+  /source-control/status:
+    $ref: './handlers/source-control/spec/paths/sourceControl.status.yml'
   /variables:
     $ref: './handlers/variables/spec/paths/variables.yml'
   /variables/{id}:


### PR DESCRIPTION
## Summary

Resolves [Configure Source Control (Git) via Environment Variables, CLI, and API for IaC/GitOps Deployments](https://community.n8n.io/t/configure-source-control-git-via-environment-variables-cli-and-api-for-iac-gitops-deployments/261609/2)

- Add environment variable configuration for source control (`N8N_SOURCE_CONTROL_*` env vars) with auto-connect on startup
- Add CLI commands (`n8n sourcecontrol:push`, `sourcecontrol:pull`, `sourcecontrol:status`) for headless/CI workflows
- Add SSH private key import from env vars (`N8N_SOURCE_CONTROL_SSH_KEY`)
- Add public API endpoints for push (`POST /source-control/push`) and status (`GET /source-control/status`) with OpenAPI specs
- Add `POST /auto-configure` REST endpoint to trigger env-based setup via API
- Add `sourceControl:push` and `sourceControl:manage` API key scopes

## Test plan

- [x] All 287 source control tests pass (unit tests for autoConfigureFromEnv, saveKeyPairFromEnv, controller, public API handler)
- [x] Permissions tests pass (90 tests)
- [x] TypeScript typecheck passes
- [x] ESLint passes
- [x] CI/CD pipeline passes