### PR TITLE
fix(HTTP Request Node): Use original URL on first pagination request

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/request-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/request-helper-functions.test.ts
@@ -5,6 +5,7 @@ import type { Agent as HttpsAgent } from 'https';
 import { mock, mockDeep } from 'jest-mock-extended';
 import type {
 	IAllExecuteFunctions,
+	IExecuteFunctions,
 	IHttpRequestMethods,
 	IHttpRequestOptions,
 	INode,
@@ -22,6 +23,7 @@ import {
 	applyPaginationRequestData,
 	convertN8nRequestToAxios,
 	createFormDataObject,
+	getRequestHelperFunctions,
 	httpRequest,
 	invokeAxios,
 	parseRequestObject,
@@ -1238,6 +1240,121 @@ describe('Request Helper Functions', () => {
 			expect(
 				mockAdditionalData.credentialsHelper.updateCredentialsOauthTokenData,
 			).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('requestWithAuthenticationPaginated', () => {
+		test('should use original URL on first request when pagination uses Next URL mode', async () => {
+			const mockGetParameterValue = jest.fn();
+
+			const workflow = {
+				expression: {
+					getParameterValue: mockGetParameterValue,
+				},
+			} as unknown as Workflow;
+
+			const node = {
+				name: 'HTTP Request',
+				typeVersion: 4.1,
+			} as unknown as INode;
+
+			const additionalData = mock<IWorkflowExecuteAdditionalData>();
+
+			const { requestWithAuthenticationPaginated } = getRequestHelperFunctions(
+				workflow,
+				node,
+				additionalData,
+			);
+
+			// Simulate expression resolution using $response from additionalKeys
+			mockGetParameterValue.mockImplementation(
+				(
+					parameterValue: unknown,
+					_runExecData: unknown,
+					_runIndex: unknown,
+					_itemIndex: unknown,
+					_nodeName: unknown,
+					_connInputData: unknown,
+					_mode: unknown,
+					additionalKeys: Record<string, any>,
+				) => {
+					if (typeof parameterValue === 'object' && parameterValue !== null) {
+						// Resolving the pagination request object — resolve expression fields
+						const result: Record<string, unknown> = {};
+						for (const [key, value] of Object.entries(parameterValue as Record<string, unknown>)) {
+							if (typeof value === 'string' && value.startsWith('=')) {
+								if (key === 'url') {
+									result[key] = additionalKeys?.$response?.headers?.['next-url'] ?? '';
+								}
+							} else {
+								result[key] = value;
+							}
+						}
+						return result;
+					}
+
+					if (typeof parameterValue === 'string') {
+						// Resolving the continue expression — continue if next-url header exists
+						return !!additionalKeys?.$response?.headers?.['next-url'];
+					}
+
+					return parameterValue;
+				},
+			);
+
+			const mockRequest = jest.fn();
+			// First response: includes next-url header pointing to page 2
+			mockRequest.mockResolvedValueOnce({
+				statusCode: 200,
+				headers: {
+					'content-type': 'application/json',
+					'next-url': 'https://example.com/page2',
+				},
+				body: { data: 'page1' },
+			});
+			// Second response: no next-url header, pagination stops
+			mockRequest.mockResolvedValueOnce({
+				statusCode: 200,
+				headers: { 'content-type': 'application/json' },
+				body: { data: 'page2' },
+			});
+
+			const executeFunctions = {
+				helpers: {
+					request: mockRequest,
+				},
+			} as unknown as IExecuteFunctions;
+
+			const requestOptions: IRequestOptions = {
+				uri: 'https://example.com/api',
+				method: 'GET',
+			};
+
+			const paginationOptions: PaginationOptions = {
+				continue: '={{ !!$response.headers["next-url"] }}',
+				request: {
+					url: '={{ $response.headers["next-url"] }}',
+				},
+				requestInterval: 0,
+				maxRequests: 10,
+			};
+
+			const result = await requestWithAuthenticationPaginated.call(
+				executeFunctions,
+				requestOptions,
+				0,
+				paginationOptions,
+			);
+
+			expect(mockRequest).toHaveBeenCalledTimes(2);
+
+			// First request should use the original URL, not the resolved Next URL expression
+			expect(mockRequest.mock.calls[0][0].uri).toBe('https://example.com/api');
+
+			// Second request should use the Next URL extracted from the first response
+			expect(mockRequest.mock.calls[1][0].uri).toBe('https://example.com/page2');
+
+			expect(result).toHaveLength(2);
 		});
 	});
 });

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
@@ -1621,6 +1621,13 @@ export const getRequestHelperFunctions = (
 				false,
 			) as object as PaginationOptions['request'];
 
+			// On the first request, use the node's configured URL instead of the Next URL
+			// expression. The Next URL is meant to extract a URL from a response, which
+			// doesn't exist yet on the first iteration (e.g. $response is empty).
+			if (additionalKeys.$pageCount === 0 && paginationOptions.request.url) {
+				delete paginateRequestData.url;
+			}
+
 			const tempRequestOptions = applyPaginationRequestData(requestOptions, paginateRequestData);
 
 			if (!validateUrl(tempRequestOptions.uri as string)) {


### PR DESCRIPTION
## Summary
In the HTTP Request node's `responseContainsNextURL` pagination mode, the Next URL expression is resolved and applied on the very first request, even though `$response` is empty at that point. This means the first request's URL is determined by the Next URL expression instead of the node's main URL field. Because `$response` has no data on the first iteration, users are forced to add a fallback in every Next URL expression to avoid invalid URL errors:

```js
{{ $response.headers["next-url"] || "https://api.example.com/original-endpoint" }}
```
This workaround is required on every workflow that uses `responseContainsNextURL` pagination, and it means duplicating the base URL inside the Next URL expression. It's error-prone (the fallback URL can drift out of sync with the actual URL field) and unintuitive since the UI description for Next URL refers to `$response` variables implying it's evaluated after a response exists.

### Why existing tests didn't catch this
The workflow.pagination.json test fixture contains responseContainsNextURL nodes with expressions like ={{ $response.headers["next-url"] }} and no fallbac, but this file is not referenced by any test runner. It's an unused fixture. There are no tests that actually exercise the responseContainsNextURL pagination code path, so the bug was never caught.

### The fix
The first request now uses the node's configured URL field. The Next URL expression is only applied from the second request onward, which matches the semantic intent, "Next URL" extracts a URL from a response that doesn't exist yet on the first iteration. The `|| fallback` workaround is no longer needed.

### Known related issue: query param duplication

`applyPaginationRequestData` uses `lodash.merge` to combine the original request options with the pagination overrides on every iteration. This means original query parameters (e.g. `api-version`) are merged into subsequent requests even when the Next URL already contains them as query parameters. This causes duplicate parameter errors on APIs like Microsoft Graph REST endpoints. This is pre-existing behaviour and not addressed in this PR.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Link to Linear ticket or GitHub issue if applicable -->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)