### PR TITLE
feat: Set default header auth domains in the UI for new credentials

### DIFF
--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -382,9 +382,18 @@ onMounted(async () => {
 				!credentialData.value.hasOwnProperty(property.name) &&
 				!credentialType.value.__overwrittenProperties?.includes(property.name)
 			) {
+				// For new httpHeaderAuth credentials, default allowedHttpRequestDomains to 'none'
+				let defaultValue = property.default as CredentialInformation;
+				if (
+					props.mode === 'new' &&
+					credentialTypeName.value === 'httpHeaderAuth' &&
+					property.name === 'allowedHttpRequestDomains'
+				) {
+					defaultValue = 'none';
+				}
 				credentialData.value = {
 					...credentialData.value,
-					[property.name]: property.default as CredentialInformation,
+					[property.name]: defaultValue,
 				};
 			}
 		}
@@ -1160,9 +1169,18 @@ function resetCredentialData(): void {
 	}
 	for (const property of credentialType.value.properties) {
 		if (!credentialType.value.__overwrittenProperties?.includes(property.name)) {
+			// For new httpHeaderAuth credentials, default allowedHttpRequestDomains to 'none'
+			let defaultValue = property.default as CredentialInformation;
+			if (
+				props.mode === 'new' &&
+				credentialTypeName.value === 'httpHeaderAuth' &&
+				property.name === 'allowedHttpRequestDomains'
+			) {
+				defaultValue = 'none';
+			}
 			credentialData.value = {
 				...credentialData.value,
-				[property.name]: property.default as CredentialInformation,
+				[property.name]: defaultValue,
 			};
 		}
 	}


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR changes default values for *new* header auth credentials to have *no* allowed domains by default. This is done within the VUE component as opposed to the back-end as currently default values are not stored within the DB, so changing the default value on the credential definition will break the existing header auth credentials.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->

IAM-255

<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

[Screencast from 10-02-26 07:53:23.webm](https://github.com/user-attachments/assets/761f7639-e545-4408-9955-26f765a216f1)


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
