### PR TITLE
fix(editor): Check specific unpublish permission for unpublish button

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.test.ts
@@ -77,6 +77,7 @@ const defaultWorkflowProps = {
 		update: true,
 		delete: true,
 		publish: true,
+		unpublish: true,
 	},
 };
 
@@ -601,6 +602,33 @@ describe('WorkflowHeaderDraftPublishActions', () => {
 			workflowsStore.workflow.activeVersion = null;
 			const { container } = renderComponent();
 			expect(container).toBeInTheDocument();
+		});
+
+		it('should be disabled when user lacks workflow:unpublish permission', async () => {
+			setupEnabledPublishButton({
+				workflow: {
+					...workflowsStore.workflow,
+					activeVersion: createMockActiveVersion('active-version-1'),
+				},
+			});
+
+			const { getByTestId } = renderComponent({
+				props: {
+					...defaultWorkflowProps,
+					workflowPermissions: {
+						...defaultWorkflowProps.workflowPermissions,
+						unpublish: false,
+					},
+				},
+			});
+
+			const versionMenuButton = getByTestId('version-menu-button');
+			await userEvent.click(versionMenuButton);
+
+			// The unpublish menu item should be disabled
+			const unpublishItem = getByTestId('version-menu-item-unpublish');
+			expect(unpublishItem).toBeInTheDocument();
+			expect(unpublishItem.closest('.el-dropdown-menu__item')).toHaveClass('is-disabled');
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
@@ -122,6 +122,7 @@ const workflowPublishState = computed((): WorkflowPublishState => {
 const collaborationReadOnly = computed(() => collaborationStore.shouldBeReadOnly);
 const hasUpdatePermission = computed(() => props.workflowPermissions.update);
 const hasPublishPermission = computed(() => props.workflowPermissions.publish);
+const hasUnpublishPermission = computed(() => props.workflowPermissions.unpublish);
 
 const isPersonalSpace = computed(() => projectStore.currentProject?.type === ProjectTypes.Personal);
 
@@ -337,7 +338,7 @@ const versionMenuActions = computed<Array<ActionDropdownItem<VERSION_ACTIONS>>>(
 	actions.push({
 		id: VERSION_ACTIONS.UNPUBLISH,
 		label: i18n.baseText('workflows.unpublish'),
-		disabled: !activeVersion.value || collaborationReadOnly.value || !hasPublishPermission.value,
+		disabled: !activeVersion.value || collaborationReadOnly.value || !hasUnpublishPermission.value,
 		divided: true,
 		shortcut: { metaKey: true, keys: ['U'] },
 	});


### PR DESCRIPTION

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
Change the permission check for the unpublish action in the workflow editor publish menu.
Before: checked the `publish` scope to disable the unpublish button
Now: check the `unpublish` scope to disable the unpublish button

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/IAM-251/test-prod-readiness-of-personal-space-policies

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
