### PR TITLE
fix(Snowflake Node): Disable logging for Snowflake-SDK to prevent folder creation issue

### DIFF
--- a/packages/nodes-base/nodes/Snowflake/Snowflake.node.ts
+++ b/packages/nodes-base/nodes/Snowflake/Snowflake.node.ts
@@ -171,6 +171,11 @@ export class Snowflake implements INodeType {
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const credentials = await this.getCredentials<SnowflakeCredential>('snowflake');
+		// Disable logging - https://docs.snowflake.com/en/developer-guide/node-js/nodejs-driver-logs#configure-the-default-logging-behavior
+		snowflake.configure({
+			logFilePath: 'STDOUT',
+			logLevel: 'OFF',
+		});
 
 		const connectionOptions = getConnectionOptions(credentials);
 		const connection = snowflake.createConnection(connectionOptions);


### PR DESCRIPTION
## Summary
The Snowflake SDK creates a folder to log to file which can cause errors in some environments, This PR disables that and turns off logging as it has a limited audience until we move to adding Node Level logging in the UI.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-4414/disable-logging-in-snowflake


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
