### PR TITLE
fix(core): Refine credential access check to discard not actively used credentials

### DIFF
--- a/packages/cli/src/executions/pre-execution-checks/__tests__/credentials-permission-checker.test.ts
+++ b/packages/cli/src/executions/pre-execution-checks/__tests__/credentials-permission-checker.test.ts
@@ -225,6 +225,7 @@ describe('CredentialsPermissionChecker', () => {
 				},
 			} as never);
 
+			// The active credential is accessible, the stale one would not be
 			sharedCredentialsRepository.getFilteredAccessibleCredentials.mockResolvedValue([
 				activeCredentialId,
 			]);
@@ -237,29 +238,6 @@ describe('CredentialsPermissionChecker', () => {
 				[teamProject.id],
 				[activeCredentialId],
 			);
-		});
-
-		it('should not fail on stale credentials that do not exist', async () => {
-			nodeTypes.getByNameAndVersion.mockReturnValue({
-				description: {
-					credentials: [
-						{
-							name: 'httpSslAuth',
-							required: true,
-							displayOptions: { show: { provideSslCertificates: [true] } },
-						},
-					],
-				},
-			} as never);
-
-			// The active credential is accessible, the stale one would not be
-			sharedCredentialsRepository.getFilteredAccessibleCredentials.mockResolvedValue([
-				activeCredentialId,
-			]);
-			credentialsRepository.find.mockResolvedValue([]);
-
-			// This should pass because the stale credential is filtered out
-			await expect(permissionChecker.check(workflowId, [httpRequestNode])).resolves.not.toThrow();
 		});
 
 		it('should fall back to checking all credentials if node type cannot be resolved', async () => {

--- a/packages/cli/src/executions/pre-execution-checks/credentials-permission-checker.ts
+++ b/packages/cli/src/executions/pre-execution-checks/credentials-permission-checker.ts
@@ -3,8 +3,9 @@ import { CredentialsRepository, SharedCredentialsRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { hasGlobalScope } from '@n8n/permissions';
 import type { INode } from 'n8n-workflow';
-import { UserError } from 'n8n-workflow';
+import { displayParameter, UserError } from 'n8n-workflow';
 
+import { NodeTypes } from '@/node-types';
 import { OwnershipService } from '@/services/ownership.service';
 import { ProjectService } from '@/services/project.service.ee';
 
@@ -37,6 +38,7 @@ export class CredentialsPermissionChecker {
 		private readonly credentialsRepository: CredentialsRepository,
 		private readonly ownershipService: OwnershipService,
 		private readonly projectService: ProjectService,
+		private readonly nodeTypes: NodeTypes,
 	) {}
 
 	/**
@@ -99,13 +101,49 @@ export class CredentialsPermissionChecker {
 		return nodes.reduce<{ [credentialId: string]: INode[] }>((map, node) => {
 			if (node.disabled || !node.credentials) return map;
 
-			Object.values(node.credentials).forEach((cred) => {
+			const activeCredTypes = this.getActiveCredentialTypes(node);
+
+			for (const [credType, cred] of Object.entries(node.credentials)) {
 				if (!cred.id) throw new InvalidCredentialError(node);
 
+				// Skip credentials that are not actively used by the node's current configuration
+				if (activeCredTypes !== null && !activeCredTypes.has(credType)) continue;
+
 				map[cred.id] = map[cred.id] ? [...map[cred.id], node] : [node];
-			});
+			}
 
 			return map;
 		}, {});
+	}
+
+	/**
+	 * Determines which credential types are actively used by a node based on its
+	 * current configuration. Returns null if the node type cannot be resolved,
+	 * in which case all credentials should be checked as a safe fallback.
+	 */
+	private getActiveCredentialTypes(node: INode): Set<string> | null {
+		try {
+			const nodeType = this.nodeTypes.getByNameAndVersion(node.type, node.typeVersion);
+			const activeTypes = new Set<string>();
+
+			// Check credentials defined in the node type description with display options
+			for (const credDef of nodeType.description.credentials ?? []) {
+				if (displayParameter(node.parameters, credDef, node, nodeType.description)) {
+					activeTypes.add(credDef.name);
+				}
+			}
+
+			// For nodes using predefined credential type (e.g., HTTP Request node),
+			// the active credential is specified by the nodeCredentialType parameter
+			const { nodeCredentialType } = node.parameters;
+			if (typeof nodeCredentialType === 'string' && nodeCredentialType) {
+				activeTypes.add(nodeCredentialType);
+			}
+
+			return activeTypes;
+		} catch {
+			// If we can't resolve the node type, fall back to checking all credentials
+			return null;
+		}
 	}
 }


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Some nodes (like HTTP Request node) can have multiple credentials set in the `credentials` field (even if only one selected in the UI.
Whenever the user changes credential types, a new credentials key/value is added to the `credentials` object of the node.
Then, when checking on workflow run that workflow project has access to all nodes credentials, the checks fails for old unused credentials of the node that is not used anymore (and could not exist in the db).
This PR changes the check access so that only actively used credentials of a node are actually checked for permission

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/IAM-264/potential-caching-issue-with-nodes-losing-connection-to-credentials


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
