### PR TITLE
fix(editor): Skip credential auto-assignment when node displayOptions don't match

### DIFF
--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -729,8 +729,16 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			}
 
 			// Check if this node type supports the credential type
-			const supportsCredential = nodeType.credentials.some((cred) => cred.name === data.type);
-			if (!supportsCredential) {
+			// and if the credential is actually active given the node's current parameters
+			const credentialDescription = nodeType.credentials.find((cred) => cred.name === data.type);
+			if (!credentialDescription) {
+				return;
+			}
+
+			if (
+				credentialDescription.displayOptions &&
+				!nodeHelpers.displayParameter(node.parameters, credentialDescription, '', node)
+			) {
 				return;
 			}
 


### PR DESCRIPTION
## Summary

When selecting a credential (e.g. Header Auth) in the HTTP Request node, the system incorrectly auto-assigns it to other nodes that **support** the same credential type, even if those nodes don't have the credential **active** based on their current parameters.

For example, the Webhook node type supports `httpHeaderAuth`, but only when its `authentication` parameter is set to `'headerAuth'`. With default parameters (`authentication: 'none'`), the credential should not be auto-assigned. The toast "Added this credential to 1 other node(s)" appeared incorrectly.

**Root cause:** `assignCredentialToMatchingNodes` only checked if the node type *supports* the credential via `.some()`, without checking `displayOptions` against the node's current parameters.

**Fix:** Use `.find()` to get the credential description, then check `credentialDescription.displayOptions` against the node's parameters using the existing `nodeHelpers.displayParameter()` function. This matches the pattern already used in:
- `useNodeCredentialOptions.ts` (NDV credential display)
- `useNodeHelpers.ts` (credential issue checking)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4786

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.