### PR TITLE
fix(YouTube Node): Prefer binary data mimeType over filesystem metadata mimeType

### DIFF
--- a/packages/nodes-base/nodes/Google/YouTube/YouTube.node.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/YouTube.node.ts
@@ -847,7 +847,7 @@ export class YouTube implements INodeType {
 							fileContent = await this.helpers.getBinaryStream(binaryData.id, UPLOAD_CHUNK_SIZE);
 							const metadata = await this.helpers.getBinaryMetadata(binaryData.id);
 							contentLength = metadata.fileSize;
-							mimeType = metadata.mimeType ?? binaryData.mimeType;
+							mimeType = binaryData.mimeType ?? metadata.mimeType;
 						} else {
 							const buffer = Buffer.from(binaryData.data, BINARY_ENCODING);
 							fileContent = Readable.from(buffer);

--- a/packages/nodes-base/nodes/Google/YouTube/__test__/node/video.upload.test.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/__test__/node/video.upload.test.ts
@@ -48,6 +48,62 @@ describe('Test YouTube, video => upload', () => {
 		jest.clearAllMocks();
 	});
 
+	it('should use binaryData.mimeType over metadata.mimeType when streaming', async () => {
+		const items = [{ json: { data: 'test' } }];
+		mockExecuteFunctions.getInputData.mockReturnValue(items);
+		mockExecuteFunctions.getNodeParameter.mockImplementation((key: string) => {
+			switch (key) {
+				case 'resource':
+					return 'video';
+				case 'operation':
+					return 'upload';
+				case 'title':
+					return 'test';
+				case 'categoryId':
+					return '11';
+				case 'options':
+					return {};
+				case 'binaryProperty':
+					return 'data';
+				default:
+			}
+		});
+
+		// Simulate filesystem binary storage: binaryData has id and mimeType set by user,
+		// but metadata returns a different (incorrect) mimeType from file detection
+		const stream = Readable.from(Buffer.alloc(1024, 'a'));
+		mockExecuteFunctions.helpers = {
+			constructExecutionMetaData: jest.fn(() => []),
+			returnJsonArray: jest.fn(() => []),
+			assertBinaryData: jest.fn(() => ({
+				id: 'filesystem:some-binary-id',
+				mimeType: 'video/mp4',
+				data: 'filesystem',
+			})),
+			getBinaryStream: jest.fn(async () => stream),
+			getBinaryMetadata: jest.fn(async () => ({
+				fileSize: 1024,
+				mimeType: 'application/mp4',
+			})),
+			httpRequest: httpRequestMock,
+		} as any;
+
+		await youTube.execute.call(mockExecuteFunctions);
+
+		expect(genericFunctions.googleApiRequest).toHaveBeenCalledWith(
+			'POST',
+			'/upload/youtube/v3/videos',
+			expect.any(Object),
+			expect.any(Object),
+			undefined,
+			expect.objectContaining({
+				headers: expect.objectContaining({
+					'X-Upload-Content-Type': 'video/mp4',
+				}),
+			}),
+		);
+	});
+
 	it('should create readable from buffer', async () => {
 		const items = [{ json: { data: 'test' } }];
 		mockExecuteFunctions.getInputData.mockReturnValue(items);


### PR DESCRIPTION
## Summary

When uploading videos through the YouTube node with binary data stored in filesystem mode, the node was incorrectly using the auto-detected MIME type from the filesystem metadata (`application/mp4`) instead of the user-specified MIME type from the binary data object (`video/mp4`). This caused YouTube API to reject uploads with "Media type 'application/mp4' is not supported."

The fix swaps the precedence so `binaryData.mimeType` takes priority over `metadata.mimeType`. This matches how the Google Drive v1 and v2 nodes already handle the same case.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #24355

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)