### PR TITLE
fix(editor): Center execute workflow button icon on small screens

### DIFF
--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -2090,13 +2090,16 @@ onBeforeUnmount(() => {
 		}
 
 		@include mixins.breakpoint('xs-only') {
-			text-indent: -10000px;
 			width: 42px;
 			height: 42px;
 			padding: 0;
 
 			span {
 				margin: 0;
+			}
+
+			> span + span {
+				display: none;
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- Fixes the "Execute workflow" button icon not being horizontally centered when the button converts to an icon-only square on small screens (xs breakpoint).
  - Replace text-indent: -10000px hack with display: none on the text span
  - Hide the label span via > span + span selector so only the icon remains
  - Ensures the icon is properly centered in the 42px square button on xs breakpoint
  -
Before:
<img width="221" height="181" alt="image" src="https://github.com/user-attachments/assets/26e683f7-d430-44f2-a428-145cd4ba82e4" />

After:
<img width="204" height="176" alt="image" src="https://github.com/user-attachments/assets/e4361ec7-b807-4ebc-b38c-62a4250568d7" />


## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/ADO-4807/bug-icon-not-horizontally-centered-in-execute-workflow-button

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
