### PR TITLE
feat: Pass focused nodes context to planner agent

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/agents/planner.agent.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/agents/planner.agent.ts
@@ -94,6 +94,7 @@ export interface PlannerNodeInput {
 	workflowJSON: SimpleWorkflow;
 	planPrevious?: PlanOutput | null;
 	planFeedback?: string | null;
+	selectedNodesContext?: string;
 }
 
 export interface PlannerNodeResult {
@@ -143,6 +144,7 @@ export async function invokePlannerNode(
 		workflowJSON: input.workflowJSON,
 		planPrevious: input.planPrevious,
 		planFeedback: input.planFeedback,
+		selectedNodesContext: input.selectedNodesContext,
 	});
 	const contextMessage = createContextMessage([contextContent]);
 

--- a/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/planner.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/planner.prompt.ts
@@ -77,6 +77,7 @@ export interface PlannerContextOptions {
 	workflowJSON: SimpleWorkflow;
 	planPrevious?: PlanOutput | null;
 	planFeedback?: string | null;
+	selectedNodesContext?: string;
 }
 
 /**
@@ -85,7 +86,14 @@ export interface PlannerContextOptions {
  * feedback from a previous modify cycle.
  */
 export function buildPlannerContext(options: PlannerContextOptions): string {
-	const { userRequest, discoveryContext, workflowJSON, planPrevious, planFeedback } = options;
+	const {
+		userRequest,
+		discoveryContext,
+		workflowJSON,
+		planPrevious,
+		planFeedback,
+		selectedNodesContext,
+	} = options;
 
 	const discoveredNodesList = discoveryContext.nodesFound
 		.map((node) => `- ${node.nodeName} v${node.version}: ${node.reasoning}`)
@@ -101,6 +109,7 @@ export function buildPlannerContext(options: PlannerContextOptions): string {
 
 	return prompt()
 		.section('user_request', userRequest)
+		.sectionIf(selectedNodesContext, 'selected_nodes', () => selectedNodesContext!)
 		.sectionIf(
 			discoveryContext.nodesFound.length > 0,
 			'discovery_context_suggested_nodes',

--- a/packages/@n8n/ai-workflow-builder.ee/src/subgraphs/discovery.subgraph.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/subgraphs/discovery.subgraph.ts
@@ -186,6 +186,12 @@ export const DiscoverySubgraphState = Annotation.Root({
 		default: () => ({}),
 	}),
 
+	// Selected nodes context for planner (built from workflowContext.selectedNodes)
+	selectedNodesContext: Annotation<string>({
+		reducer: (x, y) => y ?? x,
+		default: () => '',
+	}),
+
 	// Retry count for when LLM fails to use tool calls properly
 	toolCallRetryCount: Annotation<number>({
 		reducer: (x, y) => y ?? x,
@@ -353,6 +359,7 @@ export class DiscoverySubgraph extends BaseSubgraph<
 				workflowJSON: state.workflowJSON,
 				planPrevious: state.planPrevious,
 				planFeedback: state.planFeedback,
+				selectedNodesContext: state.selectedNodesContext,
 			},
 			runnableConfig,
 		);
@@ -685,6 +692,7 @@ export class DiscoverySubgraph extends BaseSubgraph<
 			planDecision: null,
 			planFeedback: parentState.planFeedback ?? null,
 			planPrevious: parentState.planPrevious ?? null,
+			selectedNodesContext: selectedNodesSummary ?? '',
 			messages: [contextMessage], // Context already in messages
 			cachedTemplates: parentState.cachedTemplates,
 		};


### PR DESCRIPTION
## Summary

When users select/focus nodes on the canvas and enter plan mode, the planner agent had no awareness of which nodes were selected. This meant deictic references like "fix this node", "add error handling after this", or "modify it" were not resolved — the planner didn't know what "this" referred to.

The focused nodes context was already collected on the frontend and used by both the discovery and builder agents, but was never passed to the planner. This PR threads the selected nodes summary through the discovery subgraph state into the planner's context prompt, so it can resolve these references correctly.

### Changes
- Added `selectedNodesContext` field to `DiscoverySubgraphState`
- Populated it in `transformInput()` from the existing `buildSelectedNodesSummary` utility
- Threaded it through `plannerNode()` → `invokePlannerNode()` → `buildPlannerContext()`
- Added a `selected_nodes` section to the planner prompt (via `sectionIf`) so the planner sees which nodes the user has focused

Uses the lightweight summary (node names + issue status) rather than the full `buildSelectedNodesContextBlock` used by the builder, since the planner generates plain-language plans and already receives workflow structure via a mermaid diagram.
<img width="394" height="477" alt="Screenshot 2026-02-11 at 14 10 23" src="https://github.com/user-attachments/assets/e4d29eb9-3e48-4c55-a1bd-a65f32f553f5" />


