### PR TITLE
Fixed  API are not reflected in open editor

### DIFF
--- a/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
@@ -9,6 +9,7 @@ import type express from 'express';
 import { v4 as uuid } from 'uuid';
 import { z } from 'zod';
 
+import { CollaborationService } from '@/collaboration/collaboration.service';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { EventService } from '@/events/event.service';
 import { ExternalHooks } from '@/external-hooks';
@@ -314,6 +315,9 @@ export = {
 						publishIfActive: true,
 					},
 				);
+
+				// Broadcast workflow update to all connected clients viewing this workflow
+				await Container.get(CollaborationService).broadcastWorkflowUpdate(id, req.user.id);
 
 				return res.json(updatedWorkflow);
 			} catch (error) {

--- a/packages/cli/test/integration/public-api/workflows.test.ts
+++ b/packages/cli/test/integration/public-api/workflows.test.ts
@@ -31,12 +31,14 @@ import type { SuperAgentTest } from '../shared/types';
 import * as utils from '../shared/utils/';
 
 import { ActiveWorkflowManager } from '@/active-workflow-manager';
+import { CollaborationService } from '@/collaboration/collaboration.service';
 import { STARTING_NODES } from '@/constants';
 import { ExecutionService } from '@/executions/execution.service';
 import { ProjectService } from '@/services/project.service.ee';
 import { Telemetry } from '@/telemetry';
 
 mockInstance(Telemetry);
+const collaborationService = mockInstance(CollaborationService);
 
 let ownerPersonalProject: Project;
 let owner: User;
@@ -119,6 +121,9 @@ beforeEach(async () => {
 	authMemberAgent = testServer.publicApiAgentFor(member);
 
 	globalConfig.tags.disabled = false;
+
+	// Reset mocks to track calls in each test
+	collaborationService.broadcastWorkflowUpdate.mockClear();
 });
 
 afterEach(async () => {
@@ -1506,6 +1511,126 @@ describe('PUT /workflows/:id', () => {
 		expect(sharedWorkflow?.workflow.updatedAt.getTime()).toBeGreaterThan(
 			workflow.updatedAt.getTime(),
 		);
+	});
+
+	test('should broadcast workflow update to connected clients', async () => {
+		/**
+		 * REGRESSION TEST for GitHub issue #25482
+		 *
+		 * Bug: When a workflow is updated via the public API (PUT /api/v1/workflows/:id),
+		 * the changes (especially node notes/version metadata) are not reflected in open
+		 * editors until manual refresh, even though websocket push is active.
+		 *
+		 * Root cause: The public API workflow update handler did not call
+		 * collaborationService.broadcastWorkflowUpdate(), while the internal REST API
+		 * (PATCH /rest/workflows/:workflowId) did.
+		 *
+		 * This test verifies that:
+		 * 1. Updating a workflow via public API triggers broadcastWorkflowUpdate
+		 * 2. The broadcast includes the correct workflow ID and user ID
+		 * 3. This enables connected clients to receive push notifications and refresh
+		 *
+		 * Without the fix, this test FAILS because broadcastWorkflowUpdate is never called.
+		 */
+		const workflow = await createWorkflowWithHistory({}, member);
+
+		// Update workflow with node notes (simulating version metadata use case)
+		const payload = {
+			name: 'name updated with broadcast',
+			nodes: [
+				{
+					id: 'uuid-1234',
+					parameters: {},
+					name: 'Start',
+					type: 'n8n-nodes-base.manualTrigger',
+					typeVersion: 1,
+					position: [240, 300],
+					notes: '📌 Version 1.0.1\n📅 Modified: 2026-02-11\n🔒 Hash: abc123',
+				},
+			],
+			connections: {},
+			staticData: '{"id":1}',
+			settings: {
+				saveExecutionProgress: false,
+				saveManualExecutions: false,
+				saveDataErrorExecution: 'all',
+				saveDataSuccessExecution: 'all',
+				executionTimeout: 3600,
+				timezone: 'America/New_York',
+			},
+		};
+
+		// Verify broadcast was NOT called before the update
+		expect(collaborationService.broadcastWorkflowUpdate).not.toHaveBeenCalled();
+
+		const response = await authMemberAgent.put(`/workflows/${workflow.id}`).send(payload);
+
+		expect(response.statusCode).toBe(200);
+
+		// CRITICAL ASSERTION: Verify that broadcastWorkflowUpdate was called
+		// This is the core of the regression - without the fix, this fails
+		expect(collaborationService.broadcastWorkflowUpdate).toHaveBeenCalledTimes(1);
+		expect(collaborationService.broadcastWorkflowUpdate).toHaveBeenCalledWith(
+			workflow.id,
+			member.id,
+		);
+
+		// Verify the workflow was actually updated
+		expect(response.body.nodes[0].notes).toContain('Version 1.0.1');
+	});
+
+	test('should broadcast even when only node notes are updated', async () => {
+		/**
+		 * REGRESSION TEST - Specific scenario from bug report
+		 *
+		 * Users reported that updating ONLY node notes (version metadata) via API
+		 * did not trigger editor refresh. This test ensures that even minimal
+		 * changes to node properties trigger the broadcast.
+		 */
+		const workflow = await createWorkflowWithHistory(
+			{
+				nodes: [
+					{
+						id: 'node-1',
+						parameters: {},
+						name: 'Start',
+						type: 'n8n-nodes-base.manualTrigger',
+						typeVersion: 1,
+						position: [240, 300],
+						notes: 'Version 1.0.0',
+					},
+				],
+				connections: {},
+			},
+			member,
+		);
+
+		// Update ONLY the node notes (no structural changes)
+		const payload = {
+			name: workflow.name,
+			nodes: [
+				{
+					id: 'node-1',
+					parameters: {},
+					name: 'Start',
+					type: 'n8n-nodes-base.manualTrigger',
+					typeVersion: 1,
+					position: [240, 300],
+					notes: 'Version 1.0.1\nModified: 2026-02-11',
+				},
+			],
+			connections: {},
+		};
+
+		collaborationService.broadcastWorkflowUpdate.mockClear();
+
+		const response = await authMemberAgent.put(`/workflows/${workflow.id}`).send(payload);
+
+		expect(response.statusCode).toBe(200);
+
+		// Even for note-only updates, broadcast must be called
+		expect(collaborationService.broadcastWorkflowUpdate).toHaveBeenCalledTimes(1);
+		expect(response.body.nodes[0].notes).toContain('Version 1.0.1');
 	});
 
 	test('should update active version if workflow is published', async () => {

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/index.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/index.ts
@@ -16,3 +16,4 @@ export * from './workflowActivated';
 export * from './workflowAutoDeactivated';
 export * from './workflowDeactivated';
 export * from './workflowFailedToActivate';
+export * from './workflowUpdated';

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowUpdated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowUpdated.ts
@@ -1,0 +1,35 @@
+import type { WorkflowUpdated } from '@n8n/api-types/push/workflow';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
+import { useUIStore } from '@/app/stores/ui.store';
+import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
+
+/**
+ * Handler for workflowUpdated push event.
+ * This is triggered when a workflow is updated externally (e.g., via API)
+ * while the workflow editor is open.
+ */
+export async function workflowUpdated({ data }: WorkflowUpdated) {
+	const { initializeWorkspace } = useCanvasOperations();
+	const workflowsStore = useWorkflowsStore();
+	const workflowsListStore = useWorkflowsListStore();
+	const uiStore = useUIStore();
+
+	const { workflowId } = data;
+
+	// Only update if this is the workflow currently being viewed
+	const workflowIsBeingViewed = workflowsStore.workflowId === workflowId;
+	if (!workflowIsBeingViewed) {
+		return;
+	}
+
+	// Only update workflow if there are no unsaved changes
+	// to avoid overwriting user's work
+	if (!uiStore.stateIsDirty) {
+		const updatedWorkflow = await workflowsListStore.fetchWorkflow(workflowId);
+		if (!updatedWorkflow.checksum) {
+			throw new Error('Failed to fetch workflow');
+		}
+		await initializeWorkspace(updatedWorkflow);
+	}
+}

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/usePushConnection.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/usePushConnection.ts
@@ -21,6 +21,7 @@ import {
 	workflowActivated,
 	workflowDeactivated,
 	workflowAutoDeactivated,
+	workflowUpdated,
 } from '@/app/composables/usePushConnection/handlers';
 import { injectWorkflowState, type WorkflowState } from '@/app/composables/useWorkflowState';
 import { createEventQueue } from '@n8n/utils/event-queue';
@@ -94,6 +95,8 @@ export function usePushConnection({
 				return await workflowDeactivated(event);
 			case 'workflowAutoDeactivated':
 				return await workflowAutoDeactivated(event);
+			case 'workflowUpdated':
+				return await workflowUpdated(event);
 			case 'updateBuilderCredits':
 				return await builderCreditsUpdated(event);
 		}


### PR DESCRIPTION
## Summary

This PR fixes a bug where workflow updates made via the public API (PUT /api/v1/workflows/:id) were not reflected in open editors until manual browser refresh, even with active WebSocket connections.

Root cause: The public API workflow update handler was missing the broadcastWorkflowUpdate() call that the internal REST API (PATCH /rest/workflows/:workflowId) includes. Both endpoints use the same WorkflowService.update() method, but the broadcast happens after the service call returns.

Changes made:
Backend:
Added CollaborationService.broadcastWorkflowUpdate() call to the public API workflow update handler
Added regression tests that verify the broadcast is triggered

Frontend:
Created workflowUpdated push event handler that fetches and applies workflow updates
Registered the handler in the push connection event processor
Handler respects unsaved changes and only updates the currently viewed workflow

Testing:
Open a workflow in the editor
Update the workflow via public API (e.g., modify node notes)
Verify the editor reflects changes without manual refresh
The fix ensures parity between public API and internal REST API behavior for real-time collaboration features.
Related Linear tickets, Github issues, and Community forum posts

Fixes #25482

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
