### PR TITLE
fix: Resize column providerId in table auth_identity

### DIFF
--- a/packages/@n8n/db/src/entities/auth-identity.ts
+++ b/packages/@n8n/db/src/entities/auth-identity.ts
@@ -16,7 +16,7 @@ export class AuthIdentity extends WithTimestamps {
 	)
 	user: User;
 
-	@PrimaryColumn()
+	@PrimaryColumn({ length: 255 })
 	providerId: string;
 
 	@PrimaryColumn()

--- a/packages/@n8n/db/src/migrations/common/1770000000000-ExpandProviderIdColumnLength.ts
+++ b/packages/@n8n/db/src/migrations/common/1770000000000-ExpandProviderIdColumnLength.ts
@@ -1,0 +1,14 @@
+import type { IrreversibleMigration, MigrationContext } from '../migration-types';
+
+export class ExpandProviderIdColumnLength1770000000000 implements IrreversibleMigration {
+	async up({ isPostgres, escape, queryRunner }: MigrationContext) {
+		if (isPostgres) {
+			const table = escape.tableName('auth_identity');
+			const column = escape.columnName('providerId');
+			await queryRunner.query(
+				`ALTER TABLE ${table} ALTER COLUMN ${column} TYPE VARCHAR(255);`,
+			);
+		}
+		// SQLite doesn't enforce VARCHAR lengths, so no action needed
+	}
+}

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -141,6 +141,7 @@ import { CreateSecretsProviderConnectionTables1769433700000 } from '../common/17
 import { CreateWorkflowPublishedVersionTable1769698710000 } from '../common/1769698710000-CreateWorkflowPublishedVersionTable';
 import { ExpandSubjectIDColumnLength1769784356000 } from '../common/1769784356000-ExpandSubjectIDColumnLength';
 import { AddWorkflowUnpublishScopeToCustomRoles1769900001000 } from '../common/1769900001000-AddWorkflowUnpublishScopeToCustomRoles';
+import { ExpandProviderIdColumnLength1770000000000 } from '../common/1770000000000-ExpandProviderIdColumnLength';
 import type { Migration } from '../migration-types';
 
 export const postgresMigrations: Migration[] = [
@@ -287,4 +288,5 @@ export const postgresMigrations: Migration[] = [
 	CreateWorkflowPublishedVersionTable1769698710000,
 	ExpandSubjectIDColumnLength1769784356000,
 	AddWorkflowUnpublishScopeToCustomRoles1769900001000,
+	ExpandProviderIdColumnLength1770000000000,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -135,6 +135,7 @@ import { CreateSecretsProviderConnectionTables1769433700000 } from '../common/17
 import { CreateWorkflowPublishedVersionTable1769698710000 } from '../common/1769698710000-CreateWorkflowPublishedVersionTable';
 import { ExpandSubjectIDColumnLength1769784356000 } from '../common/1769784356000-ExpandSubjectIDColumnLength';
 import { AddWorkflowUnpublishScopeToCustomRoles1769900001000 } from '../common/1769900001000-AddWorkflowUnpublishScopeToCustomRoles';
+import { ExpandProviderIdColumnLength1770000000000 } from '../common/1770000000000-ExpandProviderIdColumnLength';
 import type { Migration } from '../migration-types';
 
 const sqliteMigrations: Migration[] = [
@@ -275,6 +276,7 @@ const sqliteMigrations: Migration[] = [
 	CreateWorkflowPublishedVersionTable1769698710000,
 	ExpandSubjectIDColumnLength1769784356000,
 	AddWorkflowUnpublishScopeToCustomRoles1769900001000,
+	ExpandProviderIdColumnLength1770000000000,
 ];
 
 export { sqliteMigrations };


### PR DESCRIPTION
## Summary

This PR fixes the SSO login. Currently, logging-in with SSO does not work because the `providerId` column is too small. 

Every time I tried to login via SSO, n8n shows the following error:

```
{"code":0,"message":"value too long for type character varying(64)"}
```

After some back-and-forth with Claude Opus, the issue was found in the database structure of the `auth_identity` table. I manually increased the size of the column `providerId`, which resulted in the SSO login working immediately.

The code was generated by GitHub Copilot with Claude Opus 4.6 using opencode, it looks OK to me.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
