### PR TITLE
feat(core): Add N8N_RECOVERY_MODE where executions are disabled

### DIFF
--- a/packages/@n8n/api-types/src/dto/owner/__tests__/dismiss-banner-request.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/owner/__tests__/dismiss-banner-request.dto.test.ts
@@ -85,6 +85,7 @@ describe('DismissBannerRequestDto', () => {
 	describe('Exhaustive banner name check', () => {
 		test('should have all static banner names defined', () => {
 			const expectedBanners = [
+				'RECOVERY_MODE',
 				'V1',
 				'TRIAL_OVER',
 				'TRIAL',

--- a/packages/@n8n/api-types/src/frontend-settings.ts
+++ b/packages/@n8n/api-types/src/frontend-settings.ts
@@ -153,6 +153,7 @@ export interface FrontendSettings {
 	logLevel: LogLevel;
 	hiringBannerEnabled: boolean;
 	previewMode: boolean;
+	recoveryMode?: boolean;
 	templates: {
 		enabled: boolean;
 		host: string;

--- a/packages/@n8n/api-types/src/schemas/banner-name.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/banner-name.schema.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 export const staticBannerNameSchema = z.enum([
+	'RECOVERY_MODE',
 	'V1',
 	'TRIAL_OVER',
 	'TRIAL',

--- a/packages/@n8n/config/src/configs/workflows.config.ts
+++ b/packages/@n8n/config/src/configs/workflows.config.ts
@@ -19,6 +19,10 @@ export class WorkflowsConfig {
 	@Env('N8N_WORKFLOW_ACTIVATION_BATCH_SIZE')
 	activationBatchSize: number = 1;
 
+	/** Whether to start in recovery mode, skipping workflow activation and trigger registration. */
+	@Env('N8N_RECOVERY_MODE')
+	recoveryMode: boolean = false;
+
 	/** Whether to enable workflow dependency indexing. */
 	@Env('N8N_WORKFLOWS_INDEXING_ENABLED')
 	indexingEnabled: boolean = true;

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -179,6 +179,7 @@ describe('GlobalConfig', () => {
 			defaultName: 'My workflow',
 			callerPolicyDefaultOption: 'workflowsFromSameOwner',
 			activationBatchSize: 1,
+			recoveryMode: false,
 			indexingEnabled: true,
 			useWorkflowPublicationService: false,
 		},

--- a/packages/cli/src/active-workflow-manager.ts
+++ b/packages/cli/src/active-workflow-manager.ts
@@ -106,7 +106,11 @@ export class ActiveWorkflowManager {
 			'Active workflow manager expects instance role to be set',
 		);
 
-		await this.addActiveWorkflows('init');
+		if (this.workflowsConfig.recoveryMode) {
+			this.logger.warn('Recovery mode enabled. Skipping activation of active workflows.');
+		} else {
+			await this.addActiveWorkflows('init');
+		}
 
 		await this.externalHooks.run('activeWorkflows.initialized');
 	}
@@ -467,6 +471,13 @@ export class ActiveWorkflowManager {
 	 * only on instance init or (in multi-main setup) on leadership change.
 	 */
 	async addActiveWorkflows(activationMode: 'init' | 'leadershipChange') {
+		if (this.workflowsConfig.recoveryMode) {
+			this.logger.info(
+				`Recovery mode enabled. Skipping workflow activation for mode "${activationMode}".`,
+			);
+			return;
+		}
+
 		if (this.isActivationInProgress) {
 			this.logger.debug(`Skipping activation - already in progress for mode: ${activationMode}`);
 			return;
@@ -1015,6 +1026,8 @@ export class ActiveWorkflowManager {
 	 * Whether this instance may add webhooks to the `webhook_entity` table.
 	 */
 	shouldAddWebhooks(activationMode: WorkflowActivateMode) {
+		if (this.workflowsConfig.recoveryMode) return false;
+
 		// Always try to populate the webhook entity table as well as register the webhooks
 		// to prevent issues with users upgrading from a version < 1.15, where the webhook entity
 		// was cleared on shutdown to anything past 1.28.0, where we stopped populating it on init,
@@ -1031,6 +1044,8 @@ export class ActiveWorkflowManager {
 	 * triggers and pollers in memory, to ensure they are not duplicated.
 	 */
 	shouldAddTriggersAndPollers() {
+		if (this.workflowsConfig.recoveryMode) return false;
+
 		return this.instanceSettings.isLeader;
 	}
 }

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -323,8 +323,13 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 		Container.get(ExecutionsPruningService).init();
 		Container.get(WorkflowHistoryCompactionService).init();
 
-		if (this.globalConfig.executions.mode === 'regular') {
+		if (
+			this.globalConfig.executions.mode === 'regular' &&
+			!this.globalConfig.workflows.recoveryMode
+		) {
 			await this.runEnqueuedExecutions();
+		} else if (this.globalConfig.executions.mode === 'regular') {
+			this.logger.warn('Recovery mode enabled. Skipping enqueued execution recovery.');
 		}
 
 		// Start to get active workflows and run their triggers

--- a/packages/cli/src/services/__tests__/frontend.service.test.ts
+++ b/packages/cli/src/services/__tests__/frontend.service.test.ts
@@ -198,6 +198,7 @@ describe('FrontendService', () => {
 	beforeEach(() => {
 		originalEnv = process.env;
 		jest.clearAllMocks();
+		globalConfig.workflows.recoveryMode = false;
 	});
 
 	afterEach(() => {
@@ -214,6 +215,15 @@ describe('FrontendService', () => {
 					settingsMode: 'authenticated',
 				}),
 			);
+		});
+
+		it('should expose recovery mode from config', async () => {
+			globalConfig.workflows.recoveryMode = true;
+
+			const { service } = createMockService();
+			const settings = await service.getSettings();
+
+			expect(settings.recoveryMode).toBe(true);
 		});
 	});
 

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -177,6 +177,7 @@ export class FrontendService {
 			isDocker: this.instanceSettings.isDocker,
 			databaseType: this.globalConfig.database.type,
 			previewMode: process.env.N8N_PREVIEW_MODE === 'true',
+			recoveryMode: this.globalConfig.workflows.recoveryMode,
 			endpointForm: this.globalConfig.endpoints.form,
 			endpointFormTest: this.globalConfig.endpoints.formTest,
 			endpointFormWaiting: this.globalConfig.endpoints.formWaiting,

--- a/packages/cli/src/webhooks/__tests__/live-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/live-webhooks.test.ts
@@ -1,4 +1,5 @@
 import { mockLogger } from '@n8n/backend-test-utils';
+import type { WorkflowsConfig } from '@n8n/config';
 import type { WebhookEntity, WorkflowEntity, WorkflowHistory, WorkflowRepository } from '@n8n/db';
 import type { Response } from 'express';
 import { mock } from 'jest-mock-extended';
@@ -29,6 +30,7 @@ describe('LiveWebhooks', () => {
 	const webhookService = mock<WebhookService>();
 	const nodeTypes = mock<NodeTypes>();
 	const workflowStaticDataService = mock<WorkflowStaticDataService>();
+	const workflowsConfig = mock<WorkflowsConfig>({ recoveryMode: false });
 
 	let liveWebhooks: LiveWebhooks;
 
@@ -40,6 +42,7 @@ describe('LiveWebhooks', () => {
 			webhookService,
 			workflowRepository,
 			workflowStaticDataService,
+			workflowsConfig,
 		);
 
 		// Mock WorkflowExecuteAdditionalData.getBase to avoid DI issues

--- a/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
@@ -52,6 +52,7 @@ describe('TestWebhooks', () => {
 		mock(),
 		mock(),
 		webhookService,
+		mock(),
 	);
 
 	beforeAll(() => {

--- a/packages/cli/src/webhooks/live-webhooks.ts
+++ b/packages/cli/src/webhooks/live-webhooks.ts
@@ -16,6 +16,7 @@ import type {
 } from './webhook.types';
 
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { ServiceUnavailableError } from '@/errors/response-errors/service-unavailable.error';
 import { WebhookNotFoundError } from '@/errors/response-errors/webhook-not-found.error';
 import { NodeTypes } from '@/node-types';
 import * as WebhookHelpers from '@/webhooks/webhook-helpers';
@@ -197,10 +198,7 @@ export class LiveWebhooks implements IWebhookManager {
 			this.logger.info(
 				`Recovery mode enabled. Ignoring webhook "${httpMethod}" for path "${path}"`,
 			);
-			throw new WebhookNotFoundError(
-				{ path, httpMethod, webhookMethods: [] },
-				{ hint: 'production' },
-			);
+			throw new ServiceUnavailableError('Recovery mode is enabled. Live webhooks are disabled.');
 		}
 
 		const webhook = await this.webhookService.findWebhook(httpMethod, path);

--- a/packages/cli/src/webhooks/test-webhooks.ts
+++ b/packages/cli/src/webhooks/test-webhooks.ts
@@ -76,7 +76,7 @@ export class TestWebhooks implements IWebhookManager {
 		let path = removeTrailingSlash(request.params.path);
 
 		if (this.workflowsConfig.recoveryMode) {
-			throw new WebhookNotFoundError({ path, httpMethod, webhookMethods: [] });
+			throw new ServiceUnavailableError('Recovery mode is enabled. Test webhooks are disabled.');
 		}
 
 		request.params = {} as WebhookRequest['params'];

--- a/packages/cli/src/webhooks/test-webhooks.ts
+++ b/packages/cli/src/webhooks/test-webhooks.ts
@@ -1,4 +1,5 @@
 import { TEST_WEBHOOK_TIMEOUT } from '@/constants';
+import { WorkflowsConfig } from '@n8n/config';
 import { OnPubSubEvent } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import type express from 'express';
@@ -24,6 +25,7 @@ import type {
 } from './webhook.types';
 
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { ServiceUnavailableError } from '@/errors/response-errors/service-unavailable.error';
 import { WebhookNotFoundError } from '@/errors/response-errors/webhook-not-found.error';
 import { SingleWebhookTriggerError } from '@/errors/single-webhook-trigger.error';
 import { WorkflowMissingIdError } from '@/errors/workflow-missing-id.error';
@@ -56,6 +58,7 @@ export class TestWebhooks implements IWebhookManager {
 		private readonly instanceSettings: InstanceSettings,
 		private readonly publisher: Publisher,
 		private readonly webhookService: WebhookService,
+		private readonly workflowsConfig: WorkflowsConfig,
 	) {}
 
 	private timeouts: { [webhookKey: string]: NodeJS.Timeout } = {};
@@ -71,6 +74,10 @@ export class TestWebhooks implements IWebhookManager {
 		const httpMethod = request.method;
 
 		let path = removeTrailingSlash(request.params.path);
+
+		if (this.workflowsConfig.recoveryMode) {
+			throw new WebhookNotFoundError({ path, httpMethod, webhookMethods: [] });
+		}
 
 		request.params = {} as WebhookRequest['params'];
 
@@ -232,6 +239,8 @@ export class TestWebhooks implements IWebhookManager {
 	}
 
 	async getWebhookMethods(rawPath: string) {
+		if (this.workflowsConfig.recoveryMode) return [];
+
 		const path = removeTrailingSlash(rawPath);
 		const webhooks = await this.getWebhooksFromPath(path);
 
@@ -243,6 +252,8 @@ export class TestWebhooks implements IWebhookManager {
 	}
 
 	async findAccessControlOptions(path: string, httpMethod: IHttpRequestMethods) {
+		if (this.workflowsConfig.recoveryMode) return;
+
 		const allKeys = await this.registrations.getAllKeys();
 
 		const webhookKey = allKeys.find((key) => key.includes(path) && key.startsWith(httpMethod));
@@ -282,6 +293,10 @@ export class TestWebhooks implements IWebhookManager {
 		chatSessionId?: string;
 		workflowIsActive?: boolean;
 	}) {
+		if (this.workflowsConfig.recoveryMode) {
+			throw new ServiceUnavailableError('Recovery mode is enabled. Test webhooks are disabled.');
+		}
+
 		const {
 			userId,
 			workflowEntity,

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -26,6 +26,7 @@ import {
 } from 'n8n-workflow';
 
 import { EventService } from '@/events/event.service';
+import { ServiceUnavailableError } from '@/errors/response-errors/service-unavailable.error';
 import { ExecutionPersistence } from '@/executions/execution-persistence';
 import { FailedRunFactory } from '@/executions/failed-run-factory';
 import { SubworkflowPolicyChecker } from '@/executions/pre-execution-checks';
@@ -104,6 +105,12 @@ export class WorkflowExecutionService {
 		user: User,
 		pushRef?: string,
 	): Promise<{ executionId: string } | { waitingForWebhook: boolean }> {
+		if (this.globalConfig.workflows?.recoveryMode) {
+			throw new ServiceUnavailableError(
+				'Recovery mode is enabled. Manual workflow executions are disabled.',
+			);
+		}
+
 		// Check whether this workflow is active.
 		const workflowIsActive = await this.workflowRepository.isActive(payload.workflowData.id);
 

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -366,6 +366,7 @@
 	"banners.confirmEmail.toast.error.heading": "Problem sending confirmation email",
 	"banners.confirmEmail.toast.error.message": "Please try again later.",
 	"banners.nonProductionLicense.message": "This n8n instance is not licensed for production purposes.",
+	"banners.recoveryMode.message": "N8N_RECOVERY_MODE is enabled, all workflow executions are stopped.",
 	"banners.trial.message.days": "1 day left in your n8n trial | {count} days left in your n8n trial",
 	"banners.trial.message.hours": "1 hour left in your n8n trial | {count} hours left in your n8n trial",
 	"banners.trial.message.minutes": "1 minute left in your n8n trial | {count} minutes left in your n8n trial",

--- a/packages/frontend/editor-ui/src/app/init.ts
+++ b/packages/frontend/editor-ui/src/app/init.ts
@@ -146,6 +146,10 @@ export async function initializeAuthenticatedFeatures(
 		bannersStore.pushBannerToStack('NON_PRODUCTION_LICENSE');
 	}
 
+	if (settingsStore.settings.recoveryMode) {
+		bannersStore.pushBannerToStack('RECOVERY_MODE');
+	}
+
 	if (
 		settingsStore.settings.banners &&
 		!settingsStore.settings.banners.dismissed.includes('V1') &&

--- a/packages/frontend/editor-ui/src/features/shared/banners/components/BannerStack.vue
+++ b/packages/frontend/editor-ui/src/features/shared/banners/components/BannerStack.vue
@@ -2,6 +2,7 @@
 import type { BannerName } from '@n8n/api-types';
 import { useBannersStore } from '@/features/shared/banners/banners.store';
 import NonProductionLicenseBanner from './banners/NonProductionLicenseBanner.vue';
+import RecoveryModeBanner from './banners/RecoveryModeBanner.vue';
 import TrialOverBanner from './banners/TrialOverBanner.vue';
 import TrialBanner from './banners/TrialBanner.vue';
 import V1Banner from './banners/V1Banner.vue';
@@ -17,6 +18,7 @@ import type { N8nBanners } from '../banners.types';
 // When registering a new banner, please consult this document to determine it's priority:
 // https://www.notion.so/n8n/Banner-stack-60948c4167c743718fde80d6745258d5
 export const N8N_BANNERS: N8nBanners = {
+	RECOVERY_MODE: { priority: Number.MAX_SAFE_INTEGER, component: RecoveryModeBanner as Component },
 	V1: { priority: 350, component: V1Banner as Component },
 	WORKFLOW_AUTO_DEACTIVATED: {
 		priority: 340,

--- a/packages/frontend/editor-ui/src/features/shared/banners/components/banners/RecoveryModeBanner.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/banners/components/banners/RecoveryModeBanner.test.ts
@@ -1,0 +1,46 @@
+import { createComponentRenderer } from '@/__tests__/render';
+import { SETTINGS_STORE_DEFAULT_STATE } from '@/__tests__/utils';
+import { STORES } from '@n8n/stores';
+import { createTestingPinia } from '@pinia/testing';
+import BannerStack from '../BannerStack.vue';
+import RecoveryModeBanner from './RecoveryModeBanner.vue';
+import { createPinia, setActivePinia } from 'pinia';
+import merge from 'lodash/merge';
+
+const renderComponent = createComponentRenderer(RecoveryModeBanner);
+const renderBannerStack = createComponentRenderer(BannerStack);
+
+describe('RecoveryModeBanner', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia());
+	});
+
+	it('should render recovery mode message as a non-dismissible banner', () => {
+		const { getByTestId, container, queryByTestId } = renderComponent();
+
+		expect(getByTestId('banners-RECOVERY_MODE')).toBeInTheDocument();
+		expect(container.textContent).toContain('N8N_RECOVERY_MODE');
+		expect(queryByTestId('banner-RECOVERY_MODE-close')).not.toBeInTheDocument();
+	});
+
+	it('should render recovery mode banner above all other static banners and keep it non-dismissible', () => {
+		const { getByTestId, queryByTestId } = renderBannerStack({
+			pinia: createTestingPinia({
+				initialState: {
+					[STORES.SETTINGS]: {
+						settings: merge({}, SETTINGS_STORE_DEFAULT_STATE.settings),
+					},
+					[STORES.BANNERS]: {
+						bannerStack: ['V1', 'RECOVERY_MODE', 'TRIAL_OVER'],
+						dynamicBanners: [],
+						dynamicBannersMap: {},
+					},
+				},
+			}),
+		});
+
+		expect(getByTestId('banners-RECOVERY_MODE')).toBeInTheDocument();
+		expect(queryByTestId('banners-V1')).not.toBeInTheDocument();
+		expect(queryByTestId('banner-RECOVERY_MODE-close')).not.toBeInTheDocument();
+	});
+});

--- a/packages/frontend/editor-ui/src/features/shared/banners/components/banners/RecoveryModeBanner.vue
+++ b/packages/frontend/editor-ui/src/features/shared/banners/components/banners/RecoveryModeBanner.vue
@@ -1,0 +1,12 @@
+<script lang="ts" setup>
+import BaseBanner from './BaseBanner.vue';
+import { i18n as locale } from '@n8n/i18n';
+</script>
+
+<template>
+	<BaseBanner name="RECOVERY_MODE" theme="warning" custom-icon="info" :dismissible="false">
+		<template #mainContent>
+			<span>{{ locale.baseText('banners.recoveryMode.message') }}</span>
+		</template>
+	</BaseBanner>
+</template>


### PR DESCRIPTION
## Summary

Adds a new environment variable called N8N_RECOVERY_MODE which disables workflow executions.
This can be useful in a few different cases, such as a workflow in crashloop, some node connections crashing on initialization, or simply to validate the state of an instance without having workflows running.

Enabling the variable adds a banner at the top of the editor mentioning that all executions are stopped.


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
