### PR TITLE
fix(editor): Fix relative url error in websocket connection

### DIFF
--- a/packages/frontend/editor-ui/src/app/push-connection/useWebSocketClient.ts
+++ b/packages/frontend/editor-ui/src/app/push-connection/useWebSocketClient.ts
@@ -15,6 +15,15 @@ export const WebSocketState = {
 	CLOSED: 3,
 };
 
+export const convertRelativeWebSocketUrl = (url: string): string => {
+	if (url.startsWith('ws://') || url.startsWith('wss://')) {
+		return url;
+	}
+	const socketUrl = new URL(url, window.location.href);
+	socketUrl.protocol = socketUrl.protocol === 'https:' ? 'wss:' : 'ws:';
+	return socketUrl.toString();
+};
+
 /**
  * Creates a WebSocket connection to the server. Uses reconnection logic
  * to reconnect if the connection is lost.
@@ -74,7 +83,8 @@ export const useWebSocketClient = <T>(options: UseWebSocketClientOptions<T>) => 
 		// Ensure we disconnect any existing connection
 		disconnect();
 
-		socket.value = new WebSocket(options.url);
+		const webSocketUrl = convertRelativeWebSocketUrl(options.url);
+		socket.value = new WebSocket(webSocketUrl);
 		socket.value.addEventListener('open', onConnected);
 		socket.value.addEventListener('message', onMessage);
 		socket.value.addEventListener('error', onError);


### PR DESCRIPTION
## Summary
Fix an issue where the WebSocket connection fails in old browsers when a relative URL is provided.
Refactor the connection logic to construct a fully qualified absolute URL based on the current `window.location.href`.
- Use the `URL` API to resolve the relative path against the current window origin.
- Automatically handle protocol switching (`http` -> `ws`, `https` -> `wss`).

## Issue
The `useWebSocketClient` hook was initializing the connection using `new WebSocket(options.url)`, where `options.url` is a relative path (e.g., `/rest/push?...`).

The [WebSocket standard](https://html.spec.whatwg.org/multipage/web-sockets.html#dom-websocket) requires an absolute URL including the scheme (`ws://` or `wss://`). Using a relative path causes a `SyntaxError` in old browsers preventing the frontend from setting up WebSocket connections.

[Support for relative paths in different browsers](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/WebSocket)

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
