### PR TITLE
feat(nodes-langchain): Add Azure custom headers

### DIFF
--- a/packages/@n8n/nodes-langchain/credentials/AzureOpenAiApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/AzureOpenAiApi.credentials.ts
@@ -37,6 +37,22 @@ export class AzureOpenAiApi implements ICredentialType {
 			default: undefined,
 			placeholder: 'https://westeurope.api.cognitive.microsoft.com',
 		},
+		{
+			displayName: 'Custom HTTP Header Name',
+			name: 'customHttpHeader',
+			type: 'string',
+			default: '',
+			placeholder: 'X-Custom-Header',
+			description: 'A custom headers, e.g. a api-gateway header for authentication',
+		},
+		{
+			displayName: 'Custom HTTP Header Value',
+			name: 'customHttpHeaderValue',
+			type: 'string',
+			typeOptions: { password: true }, // Passwort-Typ für Sicherheit
+			default: '',
+			description: 'A value/string for the custom header',
+		},
 	];
 
 	authenticate: IAuthenticateGeneric = {
@@ -44,6 +60,8 @@ export class AzureOpenAiApi implements ICredentialType {
 		properties: {
 			headers: {
 				'api-key': '={{$credentials.apiKey}}',
+				// Hier nutzen wir die neue n8n Syntax, um dynamische Header-Namen zu setzen
+				'={{$credentials.customHttpHeader}}': '={{$credentials.customHttpHeaderValue}}',
 			},
 		},
 	};

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/LmChatAzureOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/LmChatAzureOpenAi.node.ts
@@ -84,18 +84,27 @@ export class LmChatAzureOpenAi implements INodeType {
 
 			// Set up Authentication based on selection and get configuration
 			let modelConfig: AzureOpenAIApiKeyModelConfig | AzureOpenAIOAuth2ModelConfig;
+			const credentialName =
+				authenticationMethod === AuthenticationType.ApiKey
+					? 'azureOpenAiApi'
+					: 'azureEntraCognitiveServicesOAuth2Api';
 			switch (authenticationMethod) {
 				case AuthenticationType.ApiKey:
-					modelConfig = await setupApiKeyAuthentication.call(this, 'azureOpenAiApi');
+					modelConfig = await setupApiKeyAuthentication.call(this, credentialName);
 					break;
 				case AuthenticationType.EntraOAuth2:
-					modelConfig = await setupOAuth2Authentication.call(
-						this,
-						'azureEntraCognitiveServicesOAuth2Api',
-					);
+					modelConfig = await setupOAuth2Authentication.call(this, credentialName);
 					break;
 				default:
 					throw new NodeOperationError(this.getNode(), 'Invalid authentication method');
+			}
+
+			// set custom http header in case given in credential set
+			const credentials = await this.getCredentials(credentialName);
+			if (credentials.customHttpHeader && credentials.customHttpHeaderValue) {
+				modelConfig.customHeaders = {
+					[credentials.customHttpHeader as string]: credentials.customHttpHeaderValue as string,
+				};
 			}
 
 			this.logger.info(`Instantiating AzureChatOpenAI model with deployment: ${modelName}`);
@@ -112,6 +121,7 @@ export class LmChatAzureOpenAi implements INodeType {
 				maxRetries: options.maxRetries ?? 2,
 				callbacks: [new N8nLlmTracing(this)],
 				configuration: {
+					defaultHeaders: modelConfig.customHeaders,
 					fetchOptions: {
 						dispatcher: getProxyAgent(undefined, {
 							headersTimeout: timeout,

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/types.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/types.ts
@@ -40,6 +40,8 @@ export interface AzureOpenAIBaseModelConfig {
 	azureOpenAIApiInstanceName: string;
 	azureOpenAIApiVersion: string;
 	azureOpenAIEndpoint?: string;
+	// we allow a custom transport-header objekt - e.g. to pass an API GW
+	customHeaders?: Record<string, string>;
 }
 
 /**


### PR DESCRIPTION
- Adds customHttpHeader to Azure credentials
- Implements defaultHeaders in LmChatAzureOpenAi node
- Supports e.g. Azure API Management, requiring specific header
- Support any other required http header

## Summary

This PR adds support for custom HTTP headers to the Azure OpenAI Chat node.

Currently, the Azure OpenAI nodes are limited to standard authentication. However, many enterprise environments use Azure API Management (APIM) or other API Gateways as a proxy. These gateways often require specific headers, such as Ocp-Apim-Subscription-Key or custom tracking IDs, to authorize and route requests.

**Changes**:

- Added a customHttpHeader field to the azureOpenAiApi and azureEntraCognitiveServicesOAuth2Api credentials.
- Updated the LmChatAzureOpenAi node to include these headers in the request metadata.
- Ensured flexibility by allowing any key-value pair as a header.

**🧪 How to test?**

1. Create a new Azure OpenAI Chat Model node.
2. Open/Create Azure OpenAI API credentials.
3. Add a custom header (e.g., Ocp-Apim-Subscription-Key : your-key-here).
4. Connect the node to a Chain or Agent and execute.
5. Verify (via a proxy tool or gateway logs) that the header is correctly transmitted in the HTTP request.

**📝 Notes for Reviewers**
The implementation uses defaultHeaders in the LangChain model configuration, which is the standard way to inject persistent headers into the underlying OpenAI client.

This is a non-breaking change; if no custom headers are provided, the node behaves exactly as before.

<img width="789" height="524" alt="image" src="https://github.com/user-attachments/assets/e06581d4-22db-4e99-ac21-e49dd3db170f" />

## Related Linear tickets, Github issues, and Community forum posts

[GHC-5649](https://linear.app/n8n/issue/GHC-5649)
https://github.com/n8n-io/n8n/issues/22358

resolves #22358 

## Review / Merge checklist

- [x ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
