### PR TITLE
fix(core): Project external secrets are not autocompleted (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
@@ -194,9 +194,9 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 			if (settingsStore.isEnterpriseFeatureEnabled[EnterpriseEditionFeature.ExternalSecrets]) {
 				promises.push(externalSecretsStore.fetchGlobalSecrets());
 				const shouldFetchProjectSecrets =
-					route?.params?.projectId !== projectsStore.personalProject?.id;
-				if (shouldFetchProjectSecrets && typeof route?.params?.projectId === 'string') {
-					promises.push(externalSecretsStore.fetchProjectSecrets(route.params.projectId));
+					projectsStore.currentProjectId !== projectsStore.personalProject?.id;
+				if (shouldFetchProjectSecrets && typeof projectsStore.currentProjectId === 'string') {
+					promises.push(externalSecretsStore.fetchProjectSecrets(projectsStore.currentProjectId));
 				}
 			}
 


### PR DESCRIPTION
## Summary

Since the `projectId` from `route.params` was undefined, the project-scoped secrets were not fetched when opening a workflow, resulting in the external secret data for autocompletion for credential creation not being available
## Related Linear tickets, Github issues, and Community forum posts

## Related issues

https://linear.app/n8n/issue/LIGO-218/fe-fix-project-scoped-autocompletions-no-longer-available-when


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
