### PR TITLE
ci: Only run node-popularity in n8n-io/n8n

### DIFF
--- a/.github/workflows/util-update-node-popularity.yml
+++ b/.github/workflows/util-update-node-popularity.yml
@@ -12,6 +12,9 @@ permissions:
 
 jobs:
   update-popularity:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'schedule' && github.repository == 'n8n-io/n8n')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Now that the node popularity update script is up and running, only run it in this repo. Allow workflow_dispatch for testing anywhere, but disable scheduled run on other repos.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
