### PR TITLE
fix(editor): Switch to using shift+P shortcut for publishing

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
@@ -320,7 +320,7 @@ const versionMenuActions = computed<Array<ActionDropdownItem<VERSION_ACTIONS>>>(
 		{
 			id: VERSION_ACTIONS.PUBLISH,
 			label: i18n.baseText('workflows.publish'),
-			shortcut: { keys: ['P'] },
+			shortcut: { shiftKey: true, keys: ['P'] },
 			disabled: shouldDisablePublishButton.value,
 		},
 	];
@@ -452,7 +452,7 @@ const onDropdownMenuSelect = async (action: VERSION_ACTIONS) => {
 };
 
 useKeybindings({
-	p: {
+	shift_p: {
 		disabled: () => shouldDisablePublishButton.value,
 		run: async () => {
 			await onPublishButtonClick();


### PR DESCRIPTION
## Summary

`P` shortcut was already reserved for pinning data, so we decided to switch to using `Shift+P` for publishing.

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-4815](https://linear.app/n8n/issue/ADO-4815/the-new-publish-keyboard-shortcut-p-overwrites-the-existing-pinned)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
