### PR TITLE
fix(DeepL Node): migrate authentication from deprecated query parameter to header-based auth

### DIFF
--- a/packages/nodes-base/credentials/DeepLApi.credentials.ts
+++ b/packages/nodes-base/credentials/DeepLApi.credentials.ts
@@ -41,8 +41,8 @@ export class DeepLApi implements ICredentialType {
 	authenticate: IAuthenticateGeneric = {
 		type: 'generic',
 		properties: {
-			qs: {
-				auth_key: '={{$credentials.apiKey}}',
+			headers: {
+				Authorization: '=DeepL-Auth-Key {{$credentials.apiKey}}',
 			},
 		},
 	};

--- a/packages/nodes-base/credentials/test/DeepLApi.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/DeepLApi.credentials.test.ts
@@ -1,0 +1,49 @@
+import { DeepLApi } from '../DeepLApi.credentials';
+
+describe('DeepLApi Credential', () => {
+	const deepLApi = new DeepLApi();
+
+	it('should have correct properties', () => {
+		expect(deepLApi.name).toBe('deepLApi');
+		expect(deepLApi.displayName).toBe('DeepL API');
+		expect(deepLApi.documentationUrl).toBe('deepl');
+		expect(deepLApi.properties).toHaveLength(2);
+	});
+
+	it('should authenticate via Authorization header', () => {
+		expect(deepLApi.authenticate).toEqual({
+			type: 'generic',
+			properties: {
+				headers: {
+					Authorization: '=DeepL-Auth-Key {{$credentials.apiKey}}',
+				},
+			},
+		});
+	});
+
+	it('should not use query string authentication', () => {
+		const auth = deepLApi.authenticate;
+		if ('properties' in auth) {
+			expect(auth.properties).not.toHaveProperty('qs');
+		}
+	});
+
+	it('should test against /usage endpoint', () => {
+		expect(deepLApi.test.request.url).toBe('/usage');
+	});
+
+	it('should use pro API endpoint for pro plan', () => {
+		expect(deepLApi.test.request.baseURL).toContain('api.deepl.com');
+	});
+
+	it('should support free and pro API plans', () => {
+		const apiPlanProp = deepLApi.properties.find((p) => p.name === 'apiPlan');
+		expect(apiPlanProp).toBeDefined();
+		expect(apiPlanProp?.type).toBe('options');
+		if (apiPlanProp && 'options' in apiPlanProp && Array.isArray(apiPlanProp.options)) {
+			const values = apiPlanProp.options.map((o: { value: string }) => o.value);
+			expect(values).toContain('pro');
+			expect(values).toContain('free');
+		}
+	});
+});


### PR DESCRIPTION
## Summary

DeepL [deprecated the `auth_key` query parameter authentication method](https://developers.deepl.com/docs/resources/breaking-changes-change-notices/november-2025-deprecation-of-legacy-auth-methods) in November 2025. This PR migrates the DeepL credential to use the recommended `Authorization` header with the `DeepL-Auth-Key` scheme.

## Changes

- **`DeepLApi.credentials.ts`**: Changed `authenticate` from query string (`qs.auth_key`) to header-based (`Authorization: DeepL-Auth-Key <key>`)
- **`DeepLApi.credentials.test.ts`**: Added unit tests for credential configuration

## Before

```
GET /v2/translate?auth_key=YOUR_KEY&text=...
```

## After

```
GET /v2/translate
Authorization: DeepL-Auth-Key YOUR_KEY
```

## Related

Fixes #25304