### PR TITLE
fix(Miro Node): remove required constraint from scope field in OAuth2 credentials

### DIFF
--- a/packages/nodes-base/credentials/MiroOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MiroOAuth2Api.credentials.ts
@@ -43,7 +43,6 @@ export class MiroOAuth2Api implements ICredentialType {
 			name: 'scope',
 			type: 'hidden',
 			default: '',
-			required: true,
 		},
 		{
 			displayName: 'Auth URI Query Parameters',


### PR DESCRIPTION
## Summary

Remove `required: true` from the `scope` field in `MiroOAuth2Api.credentials.ts`.

## Problem

When users try to connect their Miro account, they get a validation error:

> The field "scope" is mandatory for credentials of type "miroOAuth2Api"

This happens because the scope field is marked `required: true` with a `default: ''` — the empty string fails the required check.

## Fix

Remove `required: true` from the scope property. Miro scopes are configured in the Miro app settings (developer portal), not passed in the OAuth authorization URL, so this field should not be required.

## Related

Fixes #24295