### PR TITLE
fix(Schedule Trigger Node): clear stale recurrence data when schedule changes

### DIFF
--- a/packages/nodes-base/nodes/Schedule/ScheduleTrigger.node.ts
+++ b/packages/nodes-base/nodes/Schedule/ScheduleTrigger.node.ts
@@ -430,7 +430,17 @@ export class ScheduleTrigger implements INodeType {
 		const timezone = this.getTimezone();
 		const staticData = this.getWorkflowStaticData('node') as {
 			recurrenceRules: number[];
+			scheduleHash?: string;
 		};
+
+		// Compute a fingerprint of the current schedule configuration so we can
+		// detect when the user changes the schedule and clear stale recurrence
+		// data that would otherwise permanently prevent the trigger from firing.
+		const currentHash = JSON.stringify(intervals);
+		if (staticData.scheduleHash !== currentHash) {
+			staticData.recurrenceRules = [];
+			staticData.scheduleHash = currentHash;
+		}
 		if (!staticData.recurrenceRules) {
 			staticData.recurrenceRules = [];
 		}

--- a/packages/nodes-base/nodes/Schedule/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Schedule/test/GenericFunctions.test.ts
@@ -201,6 +201,22 @@ describe('recurrenceCheck', () => {
 		const result2 = recurrenceCheck(recurrence, recurrenceRules, 'UTC');
 		expect(result2).toBe(false);
 	});
+
+	it('should trigger on first call when recurrenceRules are cleared (schedule change)', () => {
+		// Simulate stale recurrence data from a previous schedule configuration
+		// being cleared when the schedule is changed — the first call after
+		// clearing should always succeed (lastExecution === undefined).
+		const recurrence: IRecurrenceRule = {
+			activated: true,
+			index: 0,
+			intervalSize: 3,
+			typeInterval: 'hours',
+		};
+		// Fresh recurrence rules (as if cleared after schedule change)
+		const recurrenceRules: number[] = [];
+		const result = recurrenceCheck(recurrence, recurrenceRules, 'UTC');
+		expect(result).toBe(true);
+	});
 });
 
 describe('intervalToRecurrence', () => {


### PR DESCRIPTION
## Summary

Fix the Schedule Trigger permanently dropping valid triggers after a schedule change.

## Problem

When a user changes the schedule interval (e.g., from every 1 hour to every 3 hours), the `recurrenceRules` in the workflow's static data retain the `lastExecution` value from the previous configuration. Since `recurrenceCheck` computes `(intervalSize + lastExecution) % period`, the stale value causes the check to permanently return `false` — the trigger never fires again.

**Reproduction:**
1. Create a workflow with a schedule trigger set to every 1 hour
2. Let it execute at an hour that isn't a multiple of 3 (e.g., 16:00)
3. Change the schedule to every 3 hours
4. The workflow never triggers again because `(3 + 16) % 24 = 19`, which never matches a multiple-of-3 hour

## Fix

Compute a JSON fingerprint of the schedule configuration and store it in static data alongside `recurrenceRules`. When the trigger starts, compare the current configuration hash with the stored one. If they differ (schedule was changed), clear `recurrenceRules` so `recurrenceCheck` treats the next invocation as a fresh start (`lastExecution === undefined → return true`).

## Changes

- **`ScheduleTrigger.node.ts`**: Added schedule hash comparison and stale data clearing
- **`GenericFunctions.test.ts`**: Added test verifying recurrenceCheck succeeds after rules are cleared

## Related

Fixes #23711