### PR TITLE
fix(Gitlab Node): Handle binary data in all modes by converting to base64

### DIFF
--- a/packages/nodes-base/nodes/Gitlab/Gitlab.node.ts
+++ b/packages/nodes-base/nodes/Gitlab/Gitlab.node.ts
@@ -1626,9 +1626,9 @@ export class Gitlab implements INodeType {
 							// Currently internally n8n uses base64 and also GitLab expects it base64 encoded.
 							// If that ever changes the data has to get converted here.
 							const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i);
-							const binaryData = this.helpers.assertBinaryData(i, binaryPropertyName);
-							// TODO: Does this work with filesystem mode
-							body.content = binaryData.data;
+
+							const buffer = await this.helpers.getBinaryDataBuffer(i, binaryPropertyName);
+							body.content = buffer.toString('base64');
 							body.encoding = 'base64';
 						} else {
 							// Is text file


### PR DESCRIPTION
## Summary
Fixes #24809

Binary files uploaded to GitLab via the n8n GitLab node were being corrupted (appearing as \uZm\ with 6B size) because binary data was not properly handled in filesystem mode.

## Changes
This PR applies the same fix that was implemented for the GitHub node in PR #23497:
- Replaced `this.helpers.assertBinaryData()` with `this.helpers.getBinaryDataBuffer()`
- Properly convert the buffer to base64 using `buffer.toString('base64')`

This ensures binary data is correctly handled across all storage modes (memory, filesystem, etc.).

## Related Issues/PRs
- Fixes #24809
- Similar fix for GitHub node: #23497