### PR TITLE
fix(MySQL Node): Route parameter validation errors to error output

### DIFF
--- a/packages/nodes-base/nodes/MySql/v2/actions/database/executeQuery.operation.ts
+++ b/packages/nodes-base/nodes/MySql/v2/actions/database/executeQuery.operation.ts
@@ -47,10 +47,15 @@ export async function execute(
 	runQueries: QueryRunner,
 	nodeOptions: IDataObject,
 ): Promise<INodeExecutionData[]> {
-	let returnData: INodeExecutionData[] = [];
 	const items = replaceEmptyStringsByNulls(inputItems, nodeOptions.replaceEmptyStrings as boolean);
 
+	const errorItems: INodeExecutionData[] = [];
 	const queries: QueryWithValues[] = [];
+	// Track which original item index each query corresponds to.
+	// runQueries uses the query array index for pairedItem, so we need this
+	// to remap results back to the correct input items when some items are
+	// filtered out due to preparation errors.
+	const queryToItemIndex: number[] = [];
 
 	for (let i = 0; i < items.length; i++) {
 		try {
@@ -91,11 +96,12 @@ export async function execute(
 			}
 
 			queries.push(preparedQuery);
+			queryToItemIndex.push(i);
 		} catch (error) {
 			if (!this.continueOnFail()) {
-				throw error;
+				throw new NodeOperationError(this.getNode(), error as Error, { itemIndex: i });
 			}
-			returnData.push({
+			errorItems.push({
 				json: { message: (error as Error).message, error: { ...(error as Error) } },
 				pairedItem: { item: i },
 			});
@@ -103,10 +109,30 @@ export async function execute(
 	}
 
 	if (queries.length === 0) {
-		return returnData;
+		return errorItems;
 	}
 
-	returnData = await runQueries(queries);
+	const queryResults = await runQueries(queries);
 
-	return returnData;
+	// runQueries assigns pairedItem using the query array index (0..n-1). When
+	// some items failed during preparation and were excluded from `queries`,
+	// those indices no longer match the original input item indices. Remap
+	// single-object pairedItem references back to the correct original index.
+	const remappedResults = queryResults.map((result) => {
+		const pairedItem = result.pairedItem;
+		if (
+			pairedItem !== undefined &&
+			typeof pairedItem === 'object' &&
+			!Array.isArray(pairedItem) &&
+			pairedItem.item !== undefined
+		) {
+			const originalIndex = queryToItemIndex[pairedItem.item];
+			if (originalIndex !== undefined) {
+				return { ...result, pairedItem: { item: originalIndex } };
+			}
+		}
+		return result;
+	});
+
+	return [...errorItems, ...remappedResults];
 }

--- a/packages/nodes-base/nodes/MySql/v2/actions/database/executeQuery.operation.ts
+++ b/packages/nodes-base/nodes/MySql/v2/actions/database/executeQuery.operation.ts
@@ -98,11 +98,15 @@ export async function execute(
 			queries.push(preparedQuery);
 			queryToItemIndex.push(i);
 		} catch (error) {
+			const nodeError =
+				error instanceof NodeOperationError
+					? error
+					: new NodeOperationError(this.getNode(), error as Error, { itemIndex: i });
 			if (!this.continueOnFail()) {
-				throw new NodeOperationError(this.getNode(), error as Error, { itemIndex: i });
+				throw nodeError;
 			}
 			errorItems.push({
-				json: { message: (error as Error).message, error: { ...(error as Error) } },
+				json: { message: nodeError.message, error: { ...nodeError } },
 				pairedItem: { item: i },
 			});
 		}
@@ -114,23 +118,39 @@ export async function execute(
 
 	const queryResults = await runQueries(queries);
 
-	// runQueries assigns pairedItem using the query array index (0..n-1). When
-	// some items failed during preparation and were excluded from `queries`,
-	// those indices no longer match the original input item indices. Remap
-	// single-object pairedItem references back to the correct original index.
+	// runQueries assigns pairedItem using query array indices (0..n-1). When
+	// some items fail during preparation and are excluded from `queries`, those
+	// indices no longer match original input item indices. Remap both object and
+	// array pairedItem references back to original indices.
 	const remappedResults = queryResults.map((result) => {
 		const pairedItem = result.pairedItem;
+		if (pairedItem === undefined) {
+			return result;
+		}
+
+		if (Array.isArray(pairedItem)) {
+			const remappedPairedItems = pairedItem.map((entry) => {
+				const originalIndex = queryToItemIndex[entry.item];
+				if (originalIndex === undefined) {
+					return entry;
+				}
+
+				return { ...entry, item: originalIndex };
+			});
+
+			return { ...result, pairedItem: remappedPairedItems };
+		}
+
 		if (
-			pairedItem !== undefined &&
 			typeof pairedItem === 'object' &&
-			!Array.isArray(pairedItem) &&
 			pairedItem.item !== undefined
 		) {
 			const originalIndex = queryToItemIndex[pairedItem.item];
 			if (originalIndex !== undefined) {
-				return { ...result, pairedItem: { item: originalIndex } };
+				return { ...result, pairedItem: { ...pairedItem, item: originalIndex } };
 			}
 		}
+
 		return result;
 	});
 

--- a/packages/nodes-base/nodes/MySql/v2/actions/database/executeQuery.operation.ts
+++ b/packages/nodes-base/nodes/MySql/v2/actions/database/executeQuery.operation.ts
@@ -53,43 +53,57 @@ export async function execute(
 	const queries: QueryWithValues[] = [];
 
 	for (let i = 0; i < items.length; i++) {
-		let rawQuery = this.getNodeParameter('query', i) as string;
+		try {
+			let rawQuery = this.getNodeParameter('query', i) as string;
 
-		for (const resolvable of getResolvables(rawQuery)) {
-			rawQuery = rawQuery.replace(resolvable, this.evaluateExpression(resolvable, i) as string);
-		}
+			for (const resolvable of getResolvables(rawQuery)) {
+				rawQuery = rawQuery.replace(resolvable, this.evaluateExpression(resolvable, i) as string);
+			}
 
-		const options = this.getNodeParameter('options', i, {});
+			const options = this.getNodeParameter('options', i, {});
 
-		const nodeVersion = Number(nodeOptions.nodeVersion);
+			const nodeVersion = Number(nodeOptions.nodeVersion);
 
-		let values;
-		let queryReplacement = options.queryReplacement || [];
+			let values;
+			let queryReplacement = options.queryReplacement || [];
 
-		if (typeof queryReplacement === 'string') {
-			queryReplacement = queryReplacement.split(',').map((entry) => entry.trim());
-		}
+			if (typeof queryReplacement === 'string') {
+				queryReplacement = queryReplacement.split(',').map((entry) => entry.trim());
+			}
 
-		if (Array.isArray(queryReplacement)) {
-			values = queryReplacement as IDataObject[];
-		} else {
-			throw new NodeOperationError(
-				this.getNode(),
-				'Query Replacement must be a string of comma-separated values, or an array of values',
-				{ itemIndex: i },
-			);
-		}
+			if (Array.isArray(queryReplacement)) {
+				values = queryReplacement as IDataObject[];
+			} else {
+				throw new NodeOperationError(
+					this.getNode(),
+					'Query Replacement must be a string of comma-separated values, or an array of values',
+					{ itemIndex: i },
+				);
+			}
 
-		const preparedQuery = prepareQueryAndReplacements(rawQuery, nodeVersion, values);
+			const preparedQuery = prepareQueryAndReplacements(rawQuery, nodeVersion, values);
 
-		if ((nodeOptions.nodeVersion as number) >= 2.3) {
-			const parsedNumbers = preparedQuery.values.map((value) => {
-				return Number(value) ? Number(value) : value;
+			if ((nodeOptions.nodeVersion as number) >= 2.3) {
+				const parsedNumbers = preparedQuery.values.map((value) => {
+					return Number(value) ? Number(value) : value;
+				});
+				preparedQuery.values = parsedNumbers;
+			}
+
+			queries.push(preparedQuery);
+		} catch (error) {
+			if (!this.continueOnFail()) {
+				throw error;
+			}
+			returnData.push({
+				json: { message: (error as Error).message, error: { ...(error as Error) } },
+				pairedItem: { item: i },
 			});
-			preparedQuery.values = parsedNumbers;
 		}
+	}
 
-		queries.push(preparedQuery);
+	if (queries.length === 0) {
+		return returnData;
 	}
 
 	returnData = await runQueries(queries);


### PR DESCRIPTION
## Summary

Fix parameter validation errors being sent to the success output instead of the error output when "On Error" is set to "Continue (using error output)".

## Problem

When a query references `$1` but no query parameters are provided, `prepareQueryAndReplacements` throws an error. This error occurs during query preparation in `executeQuery.execute()`, before the queries reach `runQueries()` — which is where `continueOnFail()` error handling lives. The uncaught error bubbles up through the router and appears on the success output.

## Fix

Wrap the per-item query preparation loop in a try/catch that checks `this.continueOnFail()`. When enabled, errors are returned as error items with proper `pairedItem` metadata for correct item mapping. When disabled, errors are re-thrown as before.

If all items fail during preparation, the function returns early with the error items without calling `runQueries`.

## Related

Fixes #25008