### PR TITLE
fix(Clockify Node): Include Task Name in Update Request Body

### DIFF
--- a/packages/nodes-base/nodes/Clockify/Clockify.node.ts
+++ b/packages/nodes-base/nodes/Clockify/Clockify.node.ts
@@ -651,6 +651,20 @@ export class Clockify implements INodeType {
 
 						const body: IDataObject = {};
 
+						// The Clockify API requires the task name in the PUT body.
+						// If the user didn't provide a name, fetch the current task
+						// to preserve the existing name.
+						if (!updateFields.name) {
+							const currentTask = await clockifyApiRequest.call(
+								this,
+								'GET',
+								`/workspaces/${workspaceId}/projects/${projectId}/tasks/${taskId}`,
+								{},
+								qs,
+							);
+							body.name = (currentTask as IDataObject).name;
+						}
+
 						Object.assign(body, updateFields);
 
 						if (body.estimate) {


### PR DESCRIPTION
## Summary

Fix the Clockify task update operation failing with "Task name is required".

## Problem

The Clockify API requires the `name` field in the PUT request body when updating a task. The n8n node includes `name` as an optional update field, but when omitted, the API rejects the request with a 400 error.

## Fix

Before sending the update request, check if the user provided a name. If not, fetch the current task via GET to retrieve the existing name and include it in the request body.

## Related

Fixes #25508