### PR TITLE
fix(api): correct workflowId type in execution OpenAPI schema

### DIFF
--- a/packages/cli/src/public-api/v1/handlers/executions/spec/schemas/execution.yml
+++ b/packages/cli/src/public-api/v1/handlers/executions/spec/schemas/execution.yml
@@ -39,8 +39,8 @@ properties:
     nullable: true
     description: The time at which the execution stopped. Will only be null for executions that still have the status 'running'.
   workflowId:
-    type: number
-    example: '1000'
+    type: string
+    example: '2tUt1wbLX592XDdX'
   waitTill:
     type: string
     nullable: true


### PR DESCRIPTION
## Summary

Fix the `workflowId` type in the execution schema from `number` to `string`.

## Problem

The OpenAPI spec at `execution.yml` defines `workflowId` as `type: number` with example `'1000'`, but n8n returns alphanumeric string workflow IDs (e.g., `2tUt1wbLX592XDdX`). This causes issues for API consumers generating typed clients.

The same field is correctly typed as `string` in other schema locations (`sharedWorkflow.workflowId`, `workflowVersion.workflowId`).

## Fix

Change `type: number` to `type: string` and update the example to match actual n8n output.

## Related

Fixes #24122