### PR TITLE
fix(editor): Add filter by accessible projects in folders query (no-changelog)

### DIFF
--- a/packages/@n8n/db/src/repositories/workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow.repository.ts
@@ -173,7 +173,7 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 	private buildBaseUnionQuery(
 		workflowIds: string[],
 		options: ListQuery.Options = {},
-		accessibleProjectIds: string[] = [],
+		accessibleProjectIds?: string[],
 	) {
 		// Common fields for both folders and workflows
 		const commonFields = {
@@ -224,12 +224,18 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 			.addSelect('NULL', 'description') // Add NULL for description in folders
 			.addSelect("'folder'", 'resource');
 
-		if (accessibleProjectIds.length > 0) {
-			foldersQuery.andWhere('folder.projectId IN (:...accessibleProjectIds)', {
-				accessibleProjectIds,
-			});
-		} else {
-			foldersQuery.andWhere('1 = 0');
+		// Restrict folders to only those in projects the user has access to.
+		// Without this, folders from other users' projects leak into the count/list
+		// and prevent the empty-state screen from showing for users with no accessible content.
+		// When undefined (admin users), no filtering is applied — they can see all folders.
+		if (accessibleProjectIds !== undefined) {
+			if (accessibleProjectIds.length > 0) {
+				foldersQuery.andWhere('folder.projectId IN (:...accessibleProjectIds)', {
+					accessibleProjectIds,
+				});
+			} else {
+				foldersQuery.andWhere('1 = 0');
+			}
 		}
 
 		const workflowsQuery = this.getManyQuery(workflowIds, workflowQueryParameters).addSelect(
@@ -256,7 +262,7 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 	async getWorkflowsAndFoldersUnion(
 		workflowIds: string[],
 		options: ListQuery.Options = {},
-		accessibleProjectIds: string[] = [],
+		accessibleProjectIds?: string[],
 	) {
 		const { baseQuery, sortByColumn, sortByDirection } = this.buildBaseUnionQuery(
 			workflowIds,
@@ -343,7 +349,7 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 	async getWorkflowsAndFoldersCount(
 		workflowIds: string[],
 		options: ListQuery.Options = {},
-		accessibleProjectIds: string[] = [],
+		accessibleProjectIds?: string[],
 	) {
 		const { skip, take, ...baseQueryParameters } = options;
 
@@ -365,7 +371,7 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 	async getWorkflowsAndFoldersWithCount(
 		workflowIds: string[],
 		options: ListQuery.Options = {},
-		accessibleProjectIds: string[] = [],
+		accessibleProjectIds?: string[],
 	) {
 		if (
 			options.filter?.parentFolderId &&

--- a/packages/@n8n/db/src/repositories/workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow.repository.ts
@@ -170,7 +170,11 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 		return totalWorkflowCount ?? 0;
 	}
 
-	private buildBaseUnionQuery(workflowIds: string[], options: ListQuery.Options = {}) {
+	private buildBaseUnionQuery(
+		workflowIds: string[],
+		options: ListQuery.Options = {},
+		accessibleProjectIds: string[] = [],
+	) {
 		// Common fields for both folders and workflows
 		const commonFields = {
 			updatedAt: true,
@@ -220,6 +224,14 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 			.addSelect('NULL', 'description') // Add NULL for description in folders
 			.addSelect("'folder'", 'resource');
 
+		if (accessibleProjectIds.length > 0) {
+			foldersQuery.andWhere('folder.projectId IN (:...accessibleProjectIds)', {
+				accessibleProjectIds,
+			});
+		} else {
+			foldersQuery.andWhere('1 = 0');
+		}
+
 		const workflowsQuery = this.getManyQuery(workflowIds, workflowQueryParameters).addSelect(
 			"'workflow'",
 			'resource',
@@ -241,10 +253,15 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 		};
 	}
 
-	async getWorkflowsAndFoldersUnion(workflowIds: string[], options: ListQuery.Options = {}) {
+	async getWorkflowsAndFoldersUnion(
+		workflowIds: string[],
+		options: ListQuery.Options = {},
+		accessibleProjectIds: string[] = [],
+	) {
 		const { baseQuery, sortByColumn, sortByDirection } = this.buildBaseUnionQuery(
 			workflowIds,
 			options,
+			accessibleProjectIds,
 		);
 
 		const query = this.buildUnionQuery(baseQuery, {
@@ -323,10 +340,18 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 		return results.map(({ name_lower, ...rest }) => rest);
 	}
 
-	async getWorkflowsAndFoldersCount(workflowIds: string[], options: ListQuery.Options = {}) {
+	async getWorkflowsAndFoldersCount(
+		workflowIds: string[],
+		options: ListQuery.Options = {},
+		accessibleProjectIds: string[] = [],
+	) {
 		const { skip, take, ...baseQueryParameters } = options;
 
-		const { baseQuery } = this.buildBaseUnionQuery(workflowIds, baseQueryParameters);
+		const { baseQuery } = this.buildBaseUnionQuery(
+			workflowIds,
+			baseQueryParameters,
+			accessibleProjectIds,
+		);
 
 		const response = await baseQuery
 			.select(`COUNT(DISTINCT ${baseQuery.escape('RESULT')}.${baseQuery.escape('id')})`, 'count')
@@ -337,7 +362,11 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 		return Number(response?.count) || 0;
 	}
 
-	async getWorkflowsAndFoldersWithCount(workflowIds: string[], options: ListQuery.Options = {}) {
+	async getWorkflowsAndFoldersWithCount(
+		workflowIds: string[],
+		options: ListQuery.Options = {},
+		accessibleProjectIds: string[] = [],
+	) {
 		if (
 			options.filter?.parentFolderId &&
 			typeof options.filter?.parentFolderId === 'string' &&
@@ -356,8 +385,8 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 		}
 
 		const [workflowsAndFolders, count] = await Promise.all([
-			this.getWorkflowsAndFoldersUnion(workflowIds, options),
-			this.getWorkflowsAndFoldersCount(workflowIds, options),
+			this.getWorkflowsAndFoldersUnion(workflowIds, options, accessibleProjectIds),
+			this.getWorkflowsAndFoldersCount(workflowIds, options, accessibleProjectIds),
 		]);
 
 		const isArchived =

--- a/packages/cli/src/workflows/__tests__/workflow.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow.service.test.ts
@@ -13,6 +13,9 @@ import type { WebhookService } from '@/webhooks/webhook.service';
 import type { WorkflowSharingService } from '@/workflows/workflow-sharing.service';
 import { WorkflowService } from '@/workflows/workflow.service';
 
+const memberRole = mock({ scopes: [] as Array<{ slug: Scope }> });
+const adminRole = mock({ scopes: [mock({ slug: 'project:read' as Scope })] });
+
 describe('WorkflowService', () => {
 	describe('getMany()', () => {
 		let workflowService: WorkflowService;
@@ -125,7 +128,7 @@ describe('WorkflowService', () => {
 		});
 
 		test('should pass accessible project IDs when includeFolders is true and no projectId filter', async () => {
-			const user = mock<User>({ id: 'user-1' });
+			const user = mock<User>({ id: 'user-1', role: memberRole });
 			const projectIds = ['project-1', 'project-2'];
 			projectRelationRepositoryMock.findAllByUser.mockResolvedValue(
 				projectIds.map((projectId) => mock({ projectId })),
@@ -148,7 +151,7 @@ describe('WorkflowService', () => {
 		});
 
 		test('should use projectId directly as accessible project ID when projectId filter is set', async () => {
-			const user = mock<User>({ id: 'user-1' });
+			const user = mock<User>({ id: 'user-1', role: memberRole });
 			projectRepositoryMock.findOneBy.mockResolvedValue(mock<Project>({ type: 'team' }));
 			workflowSharingServiceMock.getSharedWorkflowIds.mockResolvedValue(['wf-1']);
 			workflowRepositoryMock.getWorkflowsAndFoldersWithCount.mockResolvedValue([[], 0]);
@@ -169,7 +172,7 @@ describe('WorkflowService', () => {
 		});
 
 		test('should pass empty accessible project IDs for user with no project relations', async () => {
-			const user = mock<User>({ id: 'user-1' });
+			const user = mock<User>({ id: 'user-1', role: memberRole });
 			projectRelationRepositoryMock.findAllByUser.mockResolvedValue([]);
 			workflowRepositoryMock.getWorkflowsAndFoldersWithCount.mockResolvedValue([[], 0]);
 
@@ -198,6 +201,25 @@ describe('WorkflowService', () => {
 			);
 
 			expect(projectRelationRepositoryMock.findAllByUser).not.toHaveBeenCalled();
+		});
+
+		test('should skip folder filtering for admin users with global project:read scope', async () => {
+			const user = mock<User>({ id: 'admin-1', role: adminRole });
+			workflowRepositoryMock.getWorkflowsAndFoldersWithCount.mockResolvedValue([[], 0]);
+
+			await workflowService.getMany(
+				user,
+				undefined, // options
+				undefined, // includeScopes
+				true, // includeFolders
+			);
+
+			expect(projectRelationRepositoryMock.findAllByUser).not.toHaveBeenCalled();
+			expect(workflowRepositoryMock.getWorkflowsAndFoldersWithCount).toHaveBeenCalledWith(
+				[],
+				undefined,
+				undefined,
+			);
 		});
 	});
 });

--- a/packages/cli/src/workflows/__tests__/workflow.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow.service.test.ts
@@ -1,4 +1,10 @@
-import type { User } from '@n8n/db';
+import type {
+	User,
+	Project,
+	ProjectRelationRepository,
+	ProjectRepository,
+	WorkflowRepository,
+} from '@n8n/db';
 import type { Scope } from '@n8n/permissions';
 import type { MockProxy } from 'jest-mock-extended';
 import { mock } from 'jest-mock-extended';
@@ -11,12 +17,16 @@ describe('WorkflowService', () => {
 	describe('getMany()', () => {
 		let workflowService: WorkflowService;
 		let workflowSharingServiceMock: MockProxy<WorkflowSharingService>;
-		let workflowRepositoryMock: MockProxy<{ getManyAndCount: jest.Mock }>;
+		let workflowRepositoryMock: MockProxy<WorkflowRepository>;
+		let projectRelationRepositoryMock: MockProxy<ProjectRelationRepository>;
+		let projectRepositoryMock: MockProxy<ProjectRepository>;
 		let webhookServiceMock: MockProxy<WebhookService>;
 
 		beforeEach(() => {
 			workflowSharingServiceMock = mock<WorkflowSharingService>();
-			workflowRepositoryMock = mock();
+			workflowRepositoryMock = mock<WorkflowRepository>();
+			projectRelationRepositoryMock = mock<ProjectRelationRepository>();
+			projectRepositoryMock = mock<ProjectRepository>();
 			workflowRepositoryMock.getManyAndCount.mockResolvedValue({ workflows: [], count: 0 });
 			workflowSharingServiceMock.getSharedWorkflowIds.mockResolvedValue([]);
 			webhookServiceMock = mock<WebhookService>();
@@ -45,7 +55,8 @@ describe('WorkflowService', () => {
 				mock(), // nodeTypes
 				webhookServiceMock, // webhookService
 				mock(), // licenseState
-				mock(), // projectRepository
+				projectRepositoryMock, // projectRepository
+				projectRelationRepositoryMock, // projectRelationRepository
 			);
 		});
 
@@ -111,6 +122,82 @@ describe('WorkflowService', () => {
 			expect(workflowSharingServiceMock.getSharedWorkflowIds).toHaveBeenCalledWith(user, {
 				scopes: executeScope,
 			});
+		});
+
+		test('should pass accessible project IDs when includeFolders is true and no projectId filter', async () => {
+			const user = mock<User>({ id: 'user-1' });
+			const projectIds = ['project-1', 'project-2'];
+			projectRelationRepositoryMock.findAllByUser.mockResolvedValue(
+				projectIds.map((projectId) => mock({ projectId })),
+			);
+			workflowRepositoryMock.getWorkflowsAndFoldersWithCount.mockResolvedValue([[], 0]);
+
+			await workflowService.getMany(
+				user,
+				undefined, // options
+				undefined, // includeScopes
+				true, // includeFolders
+			);
+
+			expect(projectRelationRepositoryMock.findAllByUser).toHaveBeenCalledWith('user-1');
+			expect(workflowRepositoryMock.getWorkflowsAndFoldersWithCount).toHaveBeenCalledWith(
+				[],
+				undefined,
+				projectIds,
+			);
+		});
+
+		test('should use projectId directly as accessible project ID when projectId filter is set', async () => {
+			const user = mock<User>({ id: 'user-1' });
+			projectRepositoryMock.findOneBy.mockResolvedValue(mock<Project>({ type: 'team' }));
+			workflowSharingServiceMock.getSharedWorkflowIds.mockResolvedValue(['wf-1']);
+			workflowRepositoryMock.getWorkflowsAndFoldersWithCount.mockResolvedValue([[], 0]);
+
+			await workflowService.getMany(
+				user,
+				{ filter: { projectId: 'some-project' } }, // options with projectId
+				undefined, // includeScopes
+				true, // includeFolders
+			);
+
+			expect(projectRelationRepositoryMock.findAllByUser).not.toHaveBeenCalled();
+			expect(workflowRepositoryMock.getWorkflowsAndFoldersWithCount).toHaveBeenCalledWith(
+				['wf-1'],
+				{ filter: { projectId: 'some-project' } },
+				['some-project'],
+			);
+		});
+
+		test('should pass empty accessible project IDs for user with no project relations', async () => {
+			const user = mock<User>({ id: 'user-1' });
+			projectRelationRepositoryMock.findAllByUser.mockResolvedValue([]);
+			workflowRepositoryMock.getWorkflowsAndFoldersWithCount.mockResolvedValue([[], 0]);
+
+			await workflowService.getMany(
+				user,
+				undefined, // options
+				undefined, // includeScopes
+				true, // includeFolders
+			);
+
+			expect(workflowRepositoryMock.getWorkflowsAndFoldersWithCount).toHaveBeenCalledWith(
+				[],
+				undefined,
+				[],
+			);
+		});
+
+		test('should not query accessible project IDs when includeFolders is false', async () => {
+			const user = mock<User>({ id: 'user-1' });
+
+			await workflowService.getMany(
+				user,
+				undefined, // options
+				undefined, // includeScopes
+				false, // includeFolders
+			);
+
+			expect(projectRelationRepositoryMock.findAllByUser).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -142,9 +142,13 @@ export class WorkflowService {
 		}
 
 		if (includeFolders) {
+			// Restrict folders to projects the user has access to.
+			// Admins with global project:read scope can see all folders, so no filtering needed.
 			const accessibleProjectIds = options?.filter?.projectId
 				? [options.filter.projectId as string]
-				: (await this.projectRelationRepository.findAllByUser(user.id)).map((r) => r.projectId);
+				: hasGlobalScope(user, 'project:read')
+					? undefined
+					: (await this.projectRelationRepository.findAllByUser(user.id)).map((r) => r.projectId);
 
 			[workflowsAndFolders, count] = await this.workflowRepository.getWorkflowsAndFoldersWithCount(
 				sharedWorkflowIds,

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -17,6 +17,7 @@ import {
 	WorkflowRepository,
 	WorkflowPublishHistoryRepository,
 	ProjectRepository,
+	ProjectRelationRepository,
 } from '@n8n/db';
 import { Container, Service } from '@n8n/di';
 import type { Scope } from '@n8n/permissions';
@@ -94,6 +95,7 @@ export class WorkflowService {
 		private readonly webhookService: WebhookService,
 		private readonly licenseState: LicenseState,
 		private readonly projectRepository: ProjectRepository,
+		private readonly projectRelationRepository: ProjectRelationRepository,
 	) {}
 
 	async getMany(
@@ -140,9 +142,14 @@ export class WorkflowService {
 		}
 
 		if (includeFolders) {
+			const accessibleProjectIds = options?.filter?.projectId
+				? [options.filter.projectId as string]
+				: (await this.projectRelationRepository.findAllByUser(user.id)).map((r) => r.projectId);
+
 			[workflowsAndFolders, count] = await this.workflowRepository.getWorkflowsAndFoldersWithCount(
 				sharedWorkflowIds,
 				options,
+				accessibleProjectIds,
 			);
 
 			workflows = workflowsAndFolders.filter((wf) => wf.resource === 'workflow');

--- a/packages/cli/test/integration/workflows/workflow.service.test.ts
+++ b/packages/cli/test/integration/workflows/workflow.service.test.ts
@@ -14,6 +14,7 @@ import {
 	WorkflowPublishHistoryRepository,
 	WorkflowRepository,
 	ProjectRepository,
+	ProjectRelationRepository,
 } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
@@ -81,6 +82,7 @@ beforeAll(async () => {
 		webhookServiceMock,
 		mock(), // licenseState
 		Container.get(ProjectRepository), // projectRepository
+		Container.get(ProjectRelationRepository), // projectRelationRepository
 	);
 });
 


### PR DESCRIPTION
## Summary

The `/rest/workflows` was returning the number of folders when `includeFolders` is passed as true without apply filter by accessible projects only 

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4769/new-users-invited-to-an-instance-that-has-workflow-but-none-of-them


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
