### PR TITLE
Fixes/25633

### DIFF
--- a/packages/cli/src/__tests__/active-executions.test.ts
+++ b/packages/cli/src/__tests__/active-executions.test.ts
@@ -14,6 +14,7 @@ import type {
 import {
 	createEmptyRunExecutionData,
 	ManualExecutionCancelledError,
+	StalledExecutionCancelledError,
 	sleep,
 	SystemShutdownExecutionCancelledError,
 } from 'n8n-workflow';
@@ -356,6 +357,35 @@ describe('ActiveExecutions', () => {
 				expect.any(ManualExecutionCancelledError),
 			);
 			expect(workflowExecution.cancel).not.toHaveBeenCalled();
+		});
+
+		test('Should cancel stalled executions and remove them from active executions', async () => {
+			activeExecutions.stopExecution(
+				executionId,
+				new StalledExecutionCancelledError(executionId),
+			);
+
+			expect(responsePromise.reject).toHaveBeenCalledWith(
+				expect.any(StalledExecutionCancelledError),
+			);
+			expect(workflowExecution.cancel).toHaveBeenCalledTimes(1);
+			await expect(postExecutePromise).rejects.toThrow(StalledExecutionCancelledError);
+
+			// Execution should be removed from active executions after .finally() runs
+			await new Promise(setImmediate);
+			expect(activeExecutions.getActiveExecutions()).toHaveLength(0);
+		});
+
+		test('Should do nothing for unknown execution IDs', () => {
+			expect(() => {
+				activeExecutions.stopExecution(
+					'non-existent-id',
+					new StalledExecutionCancelledError('non-existent-id'),
+				);
+			}).not.toThrow();
+
+			// Original execution should still be tracked
+			expect(activeExecutions.getActiveExecutions()).toHaveLength(1);
 		});
 	});
 

--- a/packages/cli/src/scaling/__tests__/scaling.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/scaling.service.test.ts
@@ -5,7 +5,11 @@ import { Container } from '@n8n/di';
 import * as BullModule from 'bull';
 import { mock } from 'jest-mock-extended';
 import { InstanceSettings } from 'n8n-core';
-import { ApplicationError, ManualExecutionCancelledError } from 'n8n-workflow';
+import {
+	ApplicationError,
+	ManualExecutionCancelledError,
+	StalledExecutionCancelledError,
+} from 'n8n-workflow';
 
 import type { ActiveExecutions } from '@/active-executions';
 
@@ -456,6 +460,93 @@ describe('ScalingService', () => {
 			await scalingService.recoverFromQueue();
 
 			expect(executionRepository.markAsCrashed).not.toHaveBeenCalled();
+		});
+
+		it('should stop active executions tracked in memory when recovering dangling executions', async () => {
+			const activeExecutions = mock<ActiveExecutions>();
+			activeExecutions.has.mockImplementation((id: string) => id === '123');
+
+			scalingService = new ScalingService(
+				mockLogger(),
+				mock(),
+				activeExecutions,
+				jobProcessor,
+				globalConfig,
+				executionRepository,
+				instanceSettings,
+				mock(),
+			);
+			await scalingService.setupQueue();
+
+			executionRepository.getInProgressExecutionIds.mockResolvedValue(['123']);
+			queue.getJobs.mockResolvedValue([]);
+
+			await scalingService.recoverFromQueue();
+
+			expect(executionRepository.markAsCrashed).toHaveBeenCalledWith(['123']);
+			expect(activeExecutions.stopExecution).toHaveBeenCalledWith(
+				'123',
+				expect.any(StalledExecutionCancelledError),
+			);
+		});
+
+		it('should not call stopExecution for dangling executions not tracked in memory', async () => {
+			const activeExecutions = mock<ActiveExecutions>();
+			activeExecutions.has.mockReturnValue(false);
+
+			scalingService = new ScalingService(
+				mockLogger(),
+				mock(),
+				activeExecutions,
+				jobProcessor,
+				globalConfig,
+				executionRepository,
+				instanceSettings,
+				mock(),
+			);
+			await scalingService.setupQueue();
+
+			executionRepository.getInProgressExecutionIds.mockResolvedValue(['123']);
+			queue.getJobs.mockResolvedValue([]);
+
+			await scalingService.recoverFromQueue();
+
+			expect(executionRepository.markAsCrashed).toHaveBeenCalledWith(['123']);
+			expect(activeExecutions.stopExecution).not.toHaveBeenCalled();
+		});
+
+		it('should stop multiple active executions when recovering multiple dangling executions', async () => {
+			const activeExecutions = mock<ActiveExecutions>();
+			activeExecutions.has.mockReturnValue(true);
+
+			scalingService = new ScalingService(
+				mockLogger(),
+				mock(),
+				activeExecutions,
+				jobProcessor,
+				globalConfig,
+				executionRepository,
+				instanceSettings,
+				mock(),
+			);
+			await scalingService.setupQueue();
+
+			executionRepository.getInProgressExecutionIds.mockResolvedValue(['exec-1', 'exec-2', 'exec-3']);
+			queue.getJobs.mockResolvedValue([mock<Job>({ data: { executionId: 'exec-2' } })]);
+
+			await scalingService.recoverFromQueue();
+
+			// exec-2 is still in the queue, so only exec-1 and exec-3 should be recovered
+			expect(executionRepository.markAsCrashed).toHaveBeenCalledWith(['exec-1', 'exec-3']);
+			expect(activeExecutions.stopExecution).toHaveBeenCalledTimes(2);
+			expect(activeExecutions.stopExecution).toHaveBeenCalledWith(
+				'exec-1',
+				expect.any(StalledExecutionCancelledError),
+			);
+			expect(activeExecutions.stopExecution).toHaveBeenCalledWith(
+				'exec-3',
+				expect.any(StalledExecutionCancelledError),
+			);
 		});
 	});
 });

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -12,6 +12,7 @@ import {
 	ensureError,
 	UnexpectedError,
 	ManualExecutionCancelledError,
+	StalledExecutionCancelledError,
 } from 'n8n-workflow';
 import type { IExecuteResponsePromiseData } from 'n8n-workflow';
 import assert, { strict } from 'node:assert';
@@ -539,6 +540,19 @@ export class ScalingService {
 		}
 
 		await this.executionRepository.markAsCrashed(danglingIds);
+
+		// Clean up in-memory active executions that are still tracked on this main
+		// process. Without this, the `job.finished()` call in `enqueueExecution`
+		// hangs indefinitely, leaking the execution in the `activeExecutions` map
+		// and blocking shutdown.
+		for (const executionId of danglingIds) {
+			if (this.activeExecutions.has(executionId)) {
+				this.activeExecutions.stopExecution(
+					executionId,
+					new StalledExecutionCancelledError(executionId),
+				);
+			}
+		}
 
 		this.logger.info('Completed queue recovery check, recovered dangling executions', {
 			danglingIds,

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -434,6 +434,14 @@ export class WorkflowRunner {
 				try {
 					await job.finished();
 				} catch (error) {
+					// If this execution was already recovered (e.g. by queue recovery
+					// calling stopExecution), skip error processing to avoid overwriting
+					// the `crashed` status in the DB with a duplicate `error` save.
+					if (!this.activeExecutions.has(executionId)) {
+						this.scalingService.popJobResult(executionId);
+						return reject(error);
+					}
+
 					if (
 						error instanceof Error &&
 						typeof error.message === 'string' &&
@@ -463,6 +471,15 @@ export class WorkflowRunner {
 					this.scalingService.popJobResult(executionId);
 
 					return reject(error);
+				}
+
+				// If this execution was already recovered (e.g. by queue recovery
+				// calling stopExecution while job.finished() was pending), skip
+				// finalization and lifecycle hooks to avoid overwriting the `crashed`
+				// status in the DB.
+				if (!this.activeExecutions.has(executionId)) {
+					this.scalingService.popJobResult(executionId);
+					return resolve(undefined as unknown as IRun);
 				}
 
 				const jobResult = this.scalingService.popJobResult(executionId);

--- a/packages/workflow/src/errors/execution-cancelled.error.ts
+++ b/packages/workflow/src/errors/execution-cancelled.error.ts
@@ -1,6 +1,6 @@
 import { ExecutionBaseError } from './abstract/execution-base.error';
 
-export type CancellationReason = 'manual' | 'timeout' | 'shutdown';
+export type CancellationReason = 'manual' | 'timeout' | 'shutdown' | 'stalled';
 
 export abstract class ExecutionCancelledError extends ExecutionBaseError {
 	readonly reason: CancellationReason;
@@ -33,5 +33,13 @@ export class SystemShutdownExecutionCancelledError extends ExecutionCancelledErr
 	constructor(executionId: string) {
 		super(executionId, 'shutdown');
 		this.message = 'The execution was cancelled because the system is shutting down';
+	}
+}
+
+export class StalledExecutionCancelledError extends ExecutionCancelledError {
+	constructor(executionId: string) {
+		super(executionId, 'stalled');
+		this.message =
+			'The execution was cancelled because it was detected as stalled by queue recovery';
 	}
 }

--- a/packages/workflow/src/errors/index.ts
+++ b/packages/workflow/src/errors/index.ts
@@ -7,6 +7,7 @@ export { ExpressionError } from './expression.error';
 export {
 	ExecutionCancelledError,
 	ManualExecutionCancelledError,
+	StalledExecutionCancelledError,
 	SystemShutdownExecutionCancelledError,
 	TimeoutExecutionCancelledError,
 	type CancellationReason,


### PR DESCRIPTION
## Summary


Fix stalled/non-terminating executions in scaling mode with unlimited concurrency.

When running in scaling mode (executionMode: queue) with concurrency: -1, executions could hang indefinitely or fail to terminate. The root cause is a gap between database-level recovery and in-memory state cleanup:

recoverFromQueue() detects executions that are in the DB but missing from the Bull queue and marks them as crashed in Postgres — but never cleans up the corresponding in-memory ActiveExecutions entry on the main process.
The job.finished() call in enqueueExecution() hangs forever for these orphaned jobs (Bull's maxStalledCount: 0 means stalled jobs are never detected), so finalizeExecution() is never called.
Over time, stuck executions accumulate in memory, blocking shutdown and leaking resources — with no error message.

The fix:
scaling.service.ts: After markAsCrashed(), call activeExecutions.stopExecution() for each dangling execution still tracked in memory. This cancels the hanging PCancelable, rejects the postExecutePromise, and removes the entry from the map.
workflow-runner.ts: Add guards in enqueueExecution() so that if job.finished() resolves or throws after queue recovery already cleaned up the execution, we skip lifecycle hooks and error processing to avoid overwriting the crashed status in the DB.
execution-cancelled.error.ts: Add StalledExecutionCancelledError (reason: 'stalled') to distinguish queue-recovery cancellations from manual/timeout/shutdown ones in logs and telemetry.



## Related Linear tickets, Github issues, and Community forum posts

Fixes #25633

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
