### PR TITLE
feat(editor): UX improvements for external secret providers

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2957,6 +2957,8 @@
 	"settings.secretsProviderConnections.modal.saving": "Saving...",
 	"settings.secretsProviderConnections.modal.unsavedChanges.title": "Close without saving?",
 	"settings.secretsProviderConnections.modal.unsavedChanges.text": "You have unsaved changes. Are you sure you want to close?",
+	"settings.secretsProviderConnections.modal.testConnection.success.title": "Connection successful",
+	"settings.secretsProviderConnections.modal.testConnection.success.description": "Successfully connected to {providerName}",
 	"settings.secretsProviderConnections.modal.testConnection.success.serviceEnabled": "Service enabled, {count} secrets available on {providerName}.",
 	"settings.secretsProviderConnections.modal.testConnection.success.reference": "Reference secrets in credentials using expression:",
 	"settings.secretsProviderConnections.modal.testConnection.error": "Connection unsuccessful, please check your {providerName} settings",

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2977,6 +2977,8 @@
 	"settings.secretsProviderConnections.delete.confirmationLabel": "Type \"{name}\" to confirm.",
 	"settings.secretsProviderConnections.delete.success": "Secret store \"{name}\" deleted successfully",
 	"settings.secretsProviderConnections.delete.error": "Failed to delete secret store",
+	"settings.secretsProviderConnections.badge.tooltip.project": "This secrets store is shared with {projectName}.",
+	"settings.secretsProviderConnections.badge.tooltip.global": "This secrets store is available to all projects and users of this instance.",
 	"settings.sourceControl.title": "Environments",
 	"settings.sourceControl.actionBox.title": "Available on the Enterprise plan",
 	"settings.sourceControl.actionBox.description": "Use multiple instances for different environments (dev, prod, etc.), deploying between them via a Git repository.",

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2974,6 +2974,7 @@
 	"settings.secretsProviderConnections.delete.impact.oneCredential": "1 credential",
 	"settings.secretsProviderConnections.delete.impact.credentials": "{count} credentials",
 	"settings.secretsProviderConnections.delete.impact.description": "will stop working",
+	"settings.secretsProviderConnections.delete.description.noImpact": "Deleting this vault will remove it. This action can't be undone. No secrets were imported from it, and no credentials will be affected.",
 	"settings.secretsProviderConnections.delete.confirmationLabel": "Type \"{name}\" to confirm.",
 	"settings.secretsProviderConnections.delete.success": "Secret store \"{name}\" deleted successfully",
 	"settings.secretsProviderConnections.delete.error": "Failed to delete secret store",

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectExternalSecrets.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectExternalSecrets.vue
@@ -255,7 +255,6 @@ async function fetchProjectSecretProviders() {
 	) {
 		return;
 	}
-
 	isLoadingSecretProviders.value = true;
 	try {
 		projectSecretProviders.value = await projectsStore.getProjectSecretProviders(
@@ -285,10 +284,8 @@ function openConnectionModal(
 			providerTypes: secretsProviders.providerTypes.value,
 			existingProviderNames: existingNames,
 			projectId: projectsStore.currentProjectId,
-			onClose: async (saved?: boolean) => {
-				if (saved) {
-					await fetchProjectSecretProviders();
-				}
+			onClose: async () => {
+				await fetchProjectSecretProviders();
 			},
 		},
 	});
@@ -310,12 +307,22 @@ watch(secretsSearch, () => {
 	currentPage.value = 0;
 });
 
+// Fetch project secret providers when currentProjectId is available
+watch(
+	() => projectsStore.currentProjectId,
+	async (newProjectId) => {
+		if (newProjectId && showExternalSecretsSection.value) {
+			await fetchProjectSecretProviders();
+		}
+	},
+	{ immediate: true },
+);
+
 onMounted(async () => {
 	if (!showExternalSecretsSection.value) return;
 	await Promise.all([
 		secretsProviders.fetchProviderTypes(),
 		secretsProviders.fetchActiveConnections(),
-		fetchProjectSecretProviders(),
 	]);
 });
 
@@ -482,7 +489,7 @@ defineExpose({
 	background-color: var(--color--background--light-3);
 	position: relative;
 
-	&:not(:has(+ .groupHeaderRow))::before {
+	&:not(:last-child):not(:has(+ .groupHeaderRow))::before {
 		content: '';
 		position: absolute;
 		bottom: 0;

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/DeleteSecretsProviderModal.ee.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/DeleteSecretsProviderModal.ee.test.ts
@@ -17,6 +17,17 @@ vi.mock('@n8n/rest-api-client', async () => {
 	};
 });
 
+const mockCredentials = [
+	{
+		id: '1',
+		name: 'cred1',
+		type: 'test',
+		createdAt: '2021-05-05T00:00:00Z',
+		updatedAt: '2021-05-05T00:00:00Z',
+		isManaged: false,
+	},
+];
+
 const renderComponent = createComponentRenderer(DeleteSecretsProviderModal, {
 	global: {
 		stubs: {
@@ -38,11 +49,11 @@ describe('DeleteSecretsProviderModal', () => {
 	beforeEach(() => {
 		pinia = createTestingPinia();
 		vi.clearAllMocks();
-		vi.mocked(credentialsApi.getAllCredentials).mockResolvedValue([]);
+		vi.mocked(credentialsApi.getAllCredentials).mockResolvedValue(mockCredentials);
 	});
 
-	it('should render modal with correct content', () => {
-		const { getByText } = renderComponent({
+	it('should render modal with correct content', async () => {
+		const { findByTestId, getByText } = renderComponent({
 			pinia,
 			props: {
 				modalName: DELETE_SECRETS_PROVIDER_MODAL_KEY,
@@ -53,12 +64,15 @@ describe('DeleteSecretsProviderModal', () => {
 				},
 			},
 		});
+
+		// Wait for confirmation input to appear (indicates credentials are loaded)
+		await findByTestId('delete-confirmation-input');
 
 		expect(getByText(/aws-prod/)).toBeInTheDocument();
 	});
 
-	it('should disable delete button when confirmation text does not match', () => {
-		const { getByTestId } = renderComponent({
+	it('should disable delete button when confirmation text does not match', async () => {
+		const { getByTestId, findByTestId } = renderComponent({
 			pinia,
 			props: {
 				modalName: DELETE_SECRETS_PROVIDER_MODAL_KEY,
@@ -69,13 +83,16 @@ describe('DeleteSecretsProviderModal', () => {
 				},
 			},
 		});
+
+		// Wait for confirmation input to appear (indicates credentials are loaded)
+		await findByTestId('delete-confirmation-input');
 
 		const deleteButton = getByTestId('confirm-delete-button');
 		expect(deleteButton).toBeDisabled();
 	});
 
 	it('should enable delete button when confirmation text matches provider name', async () => {
-		const { getByTestId } = renderComponent({
+		const { getByTestId, findByTestId } = renderComponent({
 			pinia,
 			props: {
 				modalName: DELETE_SECRETS_PROVIDER_MODAL_KEY,
@@ -87,7 +104,8 @@ describe('DeleteSecretsProviderModal', () => {
 			},
 		});
 
-		const input = getByTestId('delete-confirmation-input');
+		// Wait for confirmation input to appear (indicates credentials are loaded)
+		const input = await findByTestId('delete-confirmation-input');
 		const deleteButton = getByTestId('confirm-delete-button');
 
 		await userEvent.type(input, 'aws-prod');
@@ -100,7 +118,7 @@ describe('DeleteSecretsProviderModal', () => {
 		const rootStore = useRootStore();
 		vi.mocked(secretsProviderApi.deleteSecretProviderConnection).mockResolvedValue();
 
-		const { getByTestId } = renderComponent({
+		const { getByTestId, findByTestId } = renderComponent({
 			pinia,
 			props: {
 				modalName: DELETE_SECRETS_PROVIDER_MODAL_KEY,
@@ -113,7 +131,8 @@ describe('DeleteSecretsProviderModal', () => {
 			},
 		});
 
-		const input = getByTestId('delete-confirmation-input');
+		// Wait for confirmation input to appear (indicates credentials are loaded)
+		const input = await findByTestId('delete-confirmation-input');
 		await userEvent.type(input, 'aws-prod');
 
 		const deleteButton = getByTestId('confirm-delete-button');
@@ -126,27 +145,7 @@ describe('DeleteSecretsProviderModal', () => {
 		expect(onConfirm).toHaveBeenCalled();
 	});
 
-	it('should fetch credentials count on mount', async () => {
-		const mockCredentials = [
-			{
-				id: '1',
-				name: 'cred1',
-				type: 'test',
-				createdAt: '2021-05-05T00:00:00Z',
-				updatedAt: '2021-05-05T00:00:00Z',
-				isManaged: false,
-			},
-			{
-				id: '2',
-				name: 'cred2',
-				type: 'test',
-				createdAt: '2021-05-05T00:00:00Z',
-				updatedAt: '2021-05-05T00:00:00Z',
-				isManaged: false,
-			},
-		];
-		vi.mocked(credentialsApi.getAllCredentials).mockResolvedValue(mockCredentials);
-
+	it('should fetch credentials count on mount', () => {
 		renderComponent({
 			pinia,
 			props: {

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/DeleteSecretsProviderModal.ee.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/DeleteSecretsProviderModal.ee.vue
@@ -34,7 +34,11 @@ const isDeleting = ref(false);
 const credentialsCount = ref(0);
 const isLoadingCredentials = ref(true);
 
-const deleteEnabled = computed(() => confirmationText.value === props.data.providerName);
+const shouldShowConfirmation = computed(() => credentialsCount.value > 0);
+
+const deleteEnabled = computed(
+	() => !shouldShowConfirmation.value || confirmationText.value === props.data.providerName,
+);
 
 const credentialsPageUrl = computed(() => ({
 	name: VIEWS.CREDENTIALS,
@@ -124,7 +128,7 @@ function onCancel() {
 		width="540px"
 	>
 		<template #content>
-			<div :class="$style.content">
+			<div v-if="shouldShowConfirmation" :class="$style.content">
 				<N8nText size="medium" color="text-base">
 					{{
 						i18n.baseText('settings.secretsProviderConnections.delete.description', {
@@ -168,6 +172,11 @@ function onCancel() {
 						/>
 					</N8nInputLabel>
 				</div>
+			</div>
+			<div v-else :class="$style.content">
+				<N8nText size="medium" color="text-base">
+					{{ i18n.baseText('settings.secretsProviderConnections.delete.description.noImpact') }}
+				</N8nText>
 			</div>
 		</template>
 

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionModal.ee.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionModal.ee.test.ts
@@ -118,7 +118,6 @@ const mockProjectsStore = {
 	teamProjects: mockProjects,
 	fetchProject: vi.fn(),
 	getAvailableProjects: vi.fn(),
-	getAllProjects: vi.fn(),
 };
 
 vi.mock('@/features/collaboration/projects/projects.store', () => ({

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionModal.ee.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionModal.ee.vue
@@ -176,15 +176,12 @@ async function handleBeforeClose() {
 	return true;
 }
 
-// Lifecycle
 onMounted(async () => {
 	if (providerTypes.value.length === 0) return;
 
 	if (modal.isEditMode.value) {
 		await Promise.all([modal.loadConnection()]);
 	}
-
-	await projectsStore.getAllProjects();
 });
 
 const nameRef = useTemplateRef('nameRef');
@@ -196,10 +193,11 @@ const { width } = useElementSize(nameRef);
 		v-if="providerTypes.length"
 		:id="`${SECRETS_PROVIDER_CONNECTION_MODAL_KEY}-modal`"
 		:custom-class="$style.secretsProviderConnectionModal"
-		width="812px"
 		:event-bus="eventBus"
 		:name="SECRETS_PROVIDER_CONNECTION_MODAL_KEY"
 		:before-close="handleBeforeClose"
+		width="70%"
+		height="80%"
 	>
 		<template #header>
 			<div :class="$style.header">

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useConnectionModal.ee.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useConnectionModal.ee.test.ts
@@ -16,6 +16,7 @@ const mockConnection = {
 
 const mockHasScope = vi.fn((_scope?: string) => true);
 const mockShowError = vi.fn();
+const mockShowMessage = vi.fn();
 
 vi.mock('./useSecretsProviderConnection.ee', () => ({
 	useSecretsProviderConnection: () => mockConnection,
@@ -30,6 +31,7 @@ vi.mock('@/app/stores/rbac.store', () => ({
 vi.mock('@/app/composables/useToast', () => ({
 	useToast: vi.fn(() => ({
 		showError: mockShowError,
+		showMessage: mockShowMessage,
 	})),
 }));
 
@@ -71,6 +73,12 @@ describe('useConnectionModal', () => {
 		mockHasScope.mockReturnValue(true);
 		mockProjectsStore.projects = [];
 		mockProjectsStore.myProjects = [];
+		mockConnection.connectionState.value = 'initializing';
+		mockConnection.testConnection.mockImplementation(async () => {
+			mockConnection.connectionState.value = 'connected';
+		});
+		mockShowError.mockClear();
+		mockShowMessage.mockClear();
 	});
 
 	describe('initialization', () => {
@@ -545,7 +553,6 @@ describe('useConnectionModal', () => {
 				settings: {},
 				secretsCount: 5,
 			});
-			mockConnection.connectionState.value = 'connected';
 
 			selectProviderType('awsSecretsManager');
 			connectionName.value = 'new-connection';

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useConnectionModal.ee.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useConnectionModal.ee.ts
@@ -290,6 +290,37 @@ export function useConnectionModal(options: UseConnectionModalOptions) {
 		initializeSettings(provider);
 	}
 
+	/**
+	 * Tests connection and shows appropriate toast feedback
+	 * Does not throw - connection save is considered successful even if test fails
+	 */
+	async function testAndShowFeedback(key: string): Promise<void> {
+		await connection.testConnection(key);
+
+		if (connection.connectionState.value === 'connected') {
+			toast.showMessage({
+				title: i18n.baseText(
+					'settings.secretsProviderConnections.modal.testConnection.success.title',
+				),
+				message: i18n.baseText(
+					'settings.secretsProviderConnections.modal.testConnection.success.description',
+					{
+						interpolate: { providerName: connectionName.value },
+					},
+				),
+				type: 'success',
+			});
+		} else {
+			toast.showError(
+				new Error(i18n.baseText('generic.error')),
+				i18n.baseText('generic.error'),
+				i18n.baseText(
+					'settings.secretsProviderConnections.modal.testConnection.error.serviceDisabled',
+				),
+			);
+		}
+	}
+
 	async function loadConnection() {
 		if (!providerKey.value) return;
 
@@ -345,19 +376,9 @@ export function useConnectionModal(options: UseConnectionModalOptions) {
 		originalProjectIds.value = [...projectIds.value];
 		originalIsSharedGlobally.value = isSharedGlobally.value;
 
-		// Test connection automatically
+		// Test connection automatically after creation
 		if (providerKey.value) {
-			await connection.testConnection(providerKey.value);
-			if (connection.connectionState.value !== 'connected') {
-				toast.showError(
-					new Error(i18n.baseText('generic.error')),
-					i18n.baseText('generic.error'),
-					i18n.baseText(
-						'settings.secretsProviderConnections.modal.testConnection.error.serviceDisabled',
-					),
-				);
-				return false;
-			}
+			await testAndShowFeedback(providerKey.value);
 		}
 
 		return true;
@@ -376,6 +397,8 @@ export function useConnectionModal(options: UseConnectionModalOptions) {
 			projectIds: scopeProjectIds,
 		};
 
+		const hasSettingsChanges = settingsUpdated.value;
+
 		const { secretsCount, projects } = await connection.updateConnection(
 			providerKey.value,
 			updateData,
@@ -390,8 +413,10 @@ export function useConnectionModal(options: UseConnectionModalOptions) {
 		isSharedGlobally.value = projects.length === 0;
 		originalIsSharedGlobally.value = projects.length === 0;
 
-		// Test connection automatically
-		await connection.testConnection(providerKey.value);
+		// Test connection only if settings changed (not just scope/sharing)
+		if (hasSettingsChanges && providerKey.value) {
+			await testAndShowFeedback(providerKey.value);
+		}
 
 		return true;
 	}

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useConnectionModal.ee.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useConnectionModal.ee.ts
@@ -242,7 +242,11 @@ export function useConnectionModal(options: UseConnectionModalOptions) {
 		if (!hasPermission) return false;
 
 		return (
+			// check if connection settings are filled
 			requiredFieldsFilled.value &&
+			// check if scope is set, either by project or globally
+			(projectIds.value.length > 0 || isSharedGlobally.value) &&
+			// check if there are unsaved changes
 			(settingsUpdated.value || scopeUpdated.value || !isEditMode.value)
 		);
 	});

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/views/SettingsSecretsProviders.ee.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/views/SettingsSecretsProviders.ee.vue
@@ -24,7 +24,7 @@ import {
 	DELETE_SECRETS_PROVIDER_MODAL_KEY,
 } from '@/app/constants/modals';
 import { I18nT } from 'vue-i18n';
-import { SecretProviderConnection } from '@n8n/api-types';
+import type { SecretProviderConnection } from '@n8n/api-types';
 
 const i18n = useI18n();
 const secretsProviders = useSecretsProvidersList();
@@ -66,6 +66,10 @@ function openConnectionModal(
 			},
 		},
 	});
+}
+
+function handleCardClick(providerKey: string) {
+	openConnectionModal(providerKey, 'connection');
 }
 
 function handleEdit(providerKey: string) {
@@ -176,6 +180,7 @@ function goToUpgrade() {
 					:provider-type-info="getProviderTypeInfo(provider.type)"
 					:project="getProjectForProvider(provider)"
 					:can-update="secretsProviders.canUpdate.value"
+					@click="handleCardClick(provider.name)"
 					@edit="handleEdit"
 					@share="handleShare"
 					@delete="handleDelete"


### PR DESCRIPTION
## Summary

**Secret Store Connection card in list view**
Gets project name and project icon to display badge
Requires parent component to fetch projects

<img width="280" height="319" alt="Screenshot 2026-02-12 at 13 43 46" src="https://github.com/user-attachments/assets/0d61f4cb-a750-4bdb-92f5-b16dd01ab08b" />


**Sharing tab in connection modal**
Disable the save button when the connection is not explicitly shared globally or with a project

<img width="777" height="312" alt="Screenshot 2026-02-12 at 13 43 57" src="https://github.com/user-attachments/assets/e3c02478-0a46-416e-85aa-d361405d2398" />

**Delete external secret store connection**
Added a new confirmation message for deleting vaults with no impact.

Enhanced the ProjectExternalSecrets component to fetch and display secret providers with their credentials count.

Updated the DeleteSecretsProviderModal to conditionally show confirmation based on credentials presence and improved the rendering logic in tests for better clarity.

<img width="745" height="358" alt="Screenshot 2026-02-12 at 13 44 11" src="https://github.com/user-attachments/assets/9f31c793-b436-4a13-8a4b-0eebf10b654c" />


**Connection modal**
Added success and error toast messages for connection testing in the secrets provider modal. Updated the connection handling logic to provide user feedback based on the connection state. Improved the localization for success messages in the English locale.

<img width="420" height="153" alt="Screenshot 2026-02-12 at 13 45 26" src="https://github.com/user-attachments/assets/c90e3638-1f91-4383-8e7d-3aadb4d751f9" />

**Project External Secrets**

Fetch project secret providers after currentProjectId is available
Fetch secret provider connections after closing the connection modal
Fix border of secret row last child

## Related Linear tickets, Github issues, and Community forum posts

Closes [LIGO-211](https://linear.app/n8n/issue/LIGO-211/fe-ux-improvements-external-secret-providers)


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
