### PR TITLE
chore(core): Remove feature flag for personal space policies

### DIFF
--- a/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.test.ts
@@ -64,12 +64,6 @@ describe('SecuritySettings', () => {
 		settingsStore.isEnterpriseFeatureEnabled[EnterpriseEditionFeature.EnforceMFA] = true;
 		settingsStore.isEnterpriseFeatureEnabled[EnterpriseEditionFeature.PersonalSpacePolicy] = true;
 		usersStore.updateEnforceMfa = vi.fn().mockResolvedValue(undefined);
-
-		// Enable PERSONAL_SECURITY_SETTINGS env feature flag for Personal Space section
-		settingsStore.settings.envFeatureFlags = {
-			...settingsStore.settings.envFeatureFlags,
-			N8N_ENV_FEAT_PERSONAL_SECURITY_SETTINGS: 'true',
-		};
 	});
 
 	it('should render security heading and personal space section', async () => {
@@ -274,22 +268,6 @@ describe('SecuritySettings', () => {
 		});
 
 		expect(getByTestId('security-sharing-count')).toHaveTextContent('Existing shares');
-	});
-
-	it('should hide personal space section when PERSONAL_SECURITY_SETTINGS flag is disabled', async () => {
-		settingsStore.settings.envFeatureFlags = {
-			...settingsStore.settings.envFeatureFlags,
-			N8N_ENV_FEAT_PERSONAL_SECURITY_SETTINGS: 'false',
-		};
-
-		const { getByText, queryByText, getByTestId } = renderView();
-
-		await waitFor(() => {
-			expect(getByTestId('enable-force-mfa')).toBeInTheDocument();
-		});
-
-		expect(getByText('Security')).toBeInTheDocument();
-		expect(queryByText('Personal Space')).not.toBeInTheDocument();
 	});
 
 	it('should render the enforce MFA toggle', async () => {

--- a/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.vue
+++ b/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.vue
@@ -11,7 +11,6 @@ import * as securitySettingsApi from '@n8n/rest-api-client/api/security-settings
 import { useMessage } from '@/app/composables/useMessage';
 import { EnterpriseEditionFeature, MODAL_CONFIRM } from '@/app/constants';
 import EnterpriseEdition from '@/app/components/EnterpriseEdition.ee.vue';
-import EnvFeatureFlag from '@/features/shared/envFeatureFlag/EnvFeatureFlag.vue';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import { usePageRedirectionHelper } from '@/app/composables/usePageRedirectionHelper';
@@ -208,127 +207,125 @@ const sharingCountText = computed(() => {
 			</div>
 		</div>
 
-		<EnvFeatureFlag name="PERSONAL_SECURITY_SETTINGS">
-			<N8nHeading tag="h2" size="large" class="mb-l">
-				{{ i18n.baseText('settings.security.personalSpace.title') }}
-			</N8nHeading>
+		<N8nHeading tag="h2" size="large" class="mb-l">
+			{{ i18n.baseText('settings.security.personalSpace.title') }}
+		</N8nHeading>
 
-			<div :class="$style.settingsSection">
-				<div :class="$style.settingsContainer">
-					<div :class="$style.settingsContainerInfo">
-						<N8nText :bold="true"
-							>{{ i18n.baseText('settings.security.personalSpace.sharing.title') }}
-							<N8nBadge v-if="!isPersonalSpacePolicyLicensed" class="ml-4xs">{{
-								i18n.baseText('generic.upgrade')
-							}}</N8nBadge>
-						</N8nText>
-						<N8nText size="small" color="text-light">
-							{{ i18n.baseText('settings.security.personalSpace.sharing.description') }}
-						</N8nText>
-					</div>
-					<div :class="$style.settingsContainerAction">
-						<EnterpriseEdition :features="[EnterpriseEditionFeature.PersonalSpacePolicy]">
-							<ElSwitch
-								v-model="personalSpaceSharing"
-								:loading="isLoading"
-								size="large"
-								data-test-id="security-personal-space-sharing-toggle"
-							/>
-							<template #fallback>
-								<N8nTooltip>
-									<ElSwitch
-										:model-value="false"
-										size="large"
-										:disabled="true"
-										data-test-id="security-personal-space-sharing-toggle"
-									/>
-									<template #content>
-										<I18nT :keypath="personalSpaceTooltipKey" tag="span" scope="global">
-											<template #action>
-												<a @click="goToUpgrade">
-													{{
-														i18n.baseText('settings.security.personalSpace.unlicensed_tooltip.link')
-													}}
-												</a>
-											</template>
-										</I18nT>
-									</template>
-								</N8nTooltip>
-							</template>
-						</EnterpriseEdition>
-					</div>
-				</div>
-				<div :class="$style.settingsCountRow" data-test-id="security-sharing-count">
-					<N8nText size="small">
-						{{ i18n.baseText('settings.security.personalSpace.sharing.existingCount.label') }}
+		<div :class="$style.settingsSection">
+			<div :class="$style.settingsContainer">
+				<div :class="$style.settingsContainerInfo">
+					<N8nText :bold="true"
+						>{{ i18n.baseText('settings.security.personalSpace.sharing.title') }}
+						<N8nBadge v-if="!isPersonalSpacePolicyLicensed" class="ml-4xs">{{
+							i18n.baseText('generic.upgrade')
+						}}</N8nBadge>
 					</N8nText>
 					<N8nText size="small" color="text-light">
-						{{ sharingCountText }}
+						{{ i18n.baseText('settings.security.personalSpace.sharing.description') }}
 					</N8nText>
 				</div>
-			</div>
-
-			<div :class="$style.settingsSection">
-				<div :class="$style.settingsContainer">
-					<div :class="$style.settingsContainerInfo">
-						<N8nText :bold="true"
-							>{{ i18n.baseText('settings.security.personalSpace.publishing.title') }}
-							<N8nBadge v-if="!isPersonalSpacePolicyLicensed" class="ml-4xs">{{
-								i18n.baseText('generic.upgrade')
-							}}</N8nBadge>
-						</N8nText>
-						<N8nText size="small" color="text-light">
-							{{ i18n.baseText('settings.security.personalSpace.publishing.description') }}
-						</N8nText>
-					</div>
-					<div :class="$style.settingsContainerAction">
-						<EnterpriseEdition :features="[EnterpriseEditionFeature.PersonalSpacePolicy]">
-							<ElSwitch
-								v-model="personalSpacePublishing"
-								:loading="isLoading"
-								size="large"
-								data-test-id="security-personal-space-publishing-toggle"
-							/>
-							<template #fallback>
-								<N8nTooltip>
-									<ElSwitch
-										:model-value="false"
-										size="large"
-										:disabled="true"
-										data-test-id="security-personal-space-publishing-toggle"
-									/>
-									<template #content>
-										<I18nT :keypath="personalSpaceTooltipKey" tag="span" scope="global">
-											<template #action>
-												<a @click="goToUpgrade">
-													{{
-														i18n.baseText('settings.security.personalSpace.unlicensed_tooltip.link')
-													}}
-												</a>
-											</template>
-										</I18nT>
-									</template>
-								</N8nTooltip>
-							</template>
-						</EnterpriseEdition>
-					</div>
+				<div :class="$style.settingsContainerAction">
+					<EnterpriseEdition :features="[EnterpriseEditionFeature.PersonalSpacePolicy]">
+						<ElSwitch
+							v-model="personalSpaceSharing"
+							:loading="isLoading"
+							size="large"
+							data-test-id="security-personal-space-sharing-toggle"
+						/>
+						<template #fallback>
+							<N8nTooltip>
+								<ElSwitch
+									:model-value="false"
+									size="large"
+									:disabled="true"
+									data-test-id="security-personal-space-sharing-toggle"
+								/>
+								<template #content>
+									<I18nT :keypath="personalSpaceTooltipKey" tag="span" scope="global">
+										<template #action>
+											<a @click="goToUpgrade">
+												{{
+													i18n.baseText('settings.security.personalSpace.unlicensed_tooltip.link')
+												}}
+											</a>
+										</template>
+									</I18nT>
+								</template>
+							</N8nTooltip>
+						</template>
+					</EnterpriseEdition>
 				</div>
-				<div :class="$style.settingsCountRow" data-test-id="security-publishing-count">
-					<N8nText size="small">
-						{{ i18n.baseText('settings.security.personalSpace.publishing.existingCount.label') }}
+			</div>
+			<div :class="$style.settingsCountRow" data-test-id="security-sharing-count">
+				<N8nText size="small">
+					{{ i18n.baseText('settings.security.personalSpace.sharing.existingCount.label') }}
+				</N8nText>
+				<N8nText size="small" color="text-light">
+					{{ sharingCountText }}
+				</N8nText>
+			</div>
+		</div>
+
+		<div :class="$style.settingsSection">
+			<div :class="$style.settingsContainer">
+				<div :class="$style.settingsContainerInfo">
+					<N8nText :bold="true"
+						>{{ i18n.baseText('settings.security.personalSpace.publishing.title') }}
+						<N8nBadge v-if="!isPersonalSpacePolicyLicensed" class="ml-4xs">{{
+							i18n.baseText('generic.upgrade')
+						}}</N8nBadge>
 					</N8nText>
 					<N8nText size="small" color="text-light">
-						{{
-							i18n.baseText('settings.security.personalSpace.publishing.existingCount.value', {
-								interpolate: {
-									count: String(state?.publishedPersonalWorkflowsCount ?? 0),
-								},
-							})
-						}}
+						{{ i18n.baseText('settings.security.personalSpace.publishing.description') }}
 					</N8nText>
 				</div>
+				<div :class="$style.settingsContainerAction">
+					<EnterpriseEdition :features="[EnterpriseEditionFeature.PersonalSpacePolicy]">
+						<ElSwitch
+							v-model="personalSpacePublishing"
+							:loading="isLoading"
+							size="large"
+							data-test-id="security-personal-space-publishing-toggle"
+						/>
+						<template #fallback>
+							<N8nTooltip>
+								<ElSwitch
+									:model-value="false"
+									size="large"
+									:disabled="true"
+									data-test-id="security-personal-space-publishing-toggle"
+								/>
+								<template #content>
+									<I18nT :keypath="personalSpaceTooltipKey" tag="span" scope="global">
+										<template #action>
+											<a @click="goToUpgrade">
+												{{
+													i18n.baseText('settings.security.personalSpace.unlicensed_tooltip.link')
+												}}
+											</a>
+										</template>
+									</I18nT>
+								</template>
+							</N8nTooltip>
+						</template>
+					</EnterpriseEdition>
+				</div>
 			</div>
-		</EnvFeatureFlag>
+			<div :class="$style.settingsCountRow" data-test-id="security-publishing-count">
+				<N8nText size="small">
+					{{ i18n.baseText('settings.security.personalSpace.publishing.existingCount.label') }}
+				</N8nText>
+				<N8nText size="small" color="text-light">
+					{{
+						i18n.baseText('settings.security.personalSpace.publishing.existingCount.value', {
+							interpolate: {
+								count: String(state?.publishedPersonalWorkflowsCount ?? 0),
+							},
+						})
+					}}
+				</N8nText>
+			</div>
+		</div>
 	</div>
 </template>
 


### PR DESCRIPTION
## Summary

This removes the feature flag for personal space policies and make the feature generally available. The license feature gate stays in place.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/IAM-247/remove-feature-flag

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
