### PR TITLE
Add Google IAP (Identity-Aware Proxy) credential type

### DIFF
--- a/packages/nodes-base/credentials/GoogleIapApi.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleIapApi.credentials.ts
@@ -1,0 +1,177 @@
+import type { AxiosRequestConfig } from 'axios';
+import axios from 'axios';
+import jwt from 'jsonwebtoken';
+import moment from 'moment-timezone';
+import type {
+	ICredentialDataDecryptedObject,
+	ICredentialType,
+	IHttpRequestOptions,
+	INodeProperties,
+	Icon,
+} from 'n8n-workflow';
+
+export class GoogleIapApi implements ICredentialType {
+	name = 'googleIapApi';
+
+	displayName = 'Google IAP (Identity-Aware Proxy) API';
+
+	documentationUrl = 'google/service-account';
+
+	icon: Icon = 'file:icons/Google.svg';
+
+	httpRequestNode = {
+		name: 'Google IAP',
+		docsUrl: 'https://cloud.google.com/iap/docs/authentication-howto',
+		apiBaseUrlPlaceholder: 'https://your-iap-protected-app.example.com/',
+	};
+
+	properties: INodeProperties[] = [
+		{
+			displayName: 'Service Account Email',
+			name: 'email',
+			type: 'string',
+			placeholder: 'name@project.iam.gserviceaccount.com',
+			default: '',
+			description: 'The Google Service account email',
+			required: true,
+		},
+		{
+			displayName: 'Private Key',
+			name: 'privateKey',
+			type: 'string',
+			default: '',
+			placeholder:
+				'-----BEGIN PRIVATE KEY-----\nXIYEvQIBADANBg<...>0IhA7TMoGYPQc=\n-----END PRIVATE KEY-----\n',
+			description: 'Enter the private key',
+			required: true,
+			typeOptions: {
+				password: true,
+			},
+		},
+		{
+			displayName: 'Private Key ID',
+			name: 'privateKeyId',
+			type: 'string',
+			default: '',
+			placeholder: 'key-id-from-json-file',
+			description: 'The private_key_id',
+			required: false,
+		},
+		{
+			displayName: 'IAP Client ID',
+			name: 'iapClientId',
+			type: 'string',
+			default: '',
+			placeholder: 'xxxxx.apps.googleusercontent.com',
+			description: 'The OAuth 2.0 Client ID from your IAP-protected application.',
+			required: true,
+		},
+		{
+			displayName: 'Impersonate User (Domain-Wide Delegation)',
+			name: 'impersonate',
+			type: 'boolean',
+			default: false,
+			description:
+				'Enable to impersonate a user via domain-wide delegation. This only works if domain-wide delegation is configured for your service account.',
+		},
+		{
+			displayName: 'Delegated User Email',
+			name: 'delegatedEmail',
+			type: 'string',
+			default: '',
+			required: true,
+			displayOptions: {
+				show: {
+					impersonate: [true],
+				},
+			},
+			description:
+				'The email address of the user for which the application is requesting delegated access',
+		},
+	];
+
+	async authenticate(
+		credentials: ICredentialDataDecryptedObject,
+		requestOptions: IHttpRequestOptions,
+	): Promise<IHttpRequestOptions> {
+		const privateKey = (credentials.privateKey as string).replace(/\\n/g, '\n').trim();
+		const email = (credentials.email as string).trim();
+		const iapClientId = (credentials.iapClientId as string).trim();
+		const privateKeyId = credentials.privateKeyId
+			? (credentials.privateKeyId as string).trim()
+			: undefined;
+
+		const impersonate = Boolean(credentials.impersonate);
+		const delegatedEmailRaw = (credentials.delegatedEmail as string | undefined)?.trim();
+		const subject = impersonate && delegatedEmailRaw ? delegatedEmailRaw : email;
+
+		const now = moment().unix();
+
+		// Create JWT assertion for IAP token exchange
+		const signOptions: jwt.SignOptions = {
+			algorithm: 'RS256',
+		};
+
+		if (privateKeyId) {
+			signOptions.keyid = privateKeyId;
+		}
+
+		const assertion = jwt.sign(
+			{
+				iss: email,
+				sub: subject,
+				aud: 'https://oauth2.googleapis.com/token',
+				iat: now - 10, // Clock skew handling: set iat 10 seconds in the past
+				exp: now + 3600,
+				target_audience: iapClientId,
+			},
+			privateKey,
+			signOptions,
+		);
+
+		// Exchange JWT for IAP ID token
+		const axiosRequestConfig: AxiosRequestConfig = {
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+			method: 'POST',
+			data: new URLSearchParams({
+				grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+				assertion,
+			}),
+			url: 'https://oauth2.googleapis.com/token',
+		};
+
+		let result;
+		try {
+			result = await axios(axiosRequestConfig);
+		} catch (err: unknown) {
+			const axiosError = err as {
+				response?: { status?: number; data?: { error_description?: string; error?: string } };
+				message?: string;
+			};
+			const status = axiosError?.response?.status;
+			const data = axiosError?.response?.data;
+			throw new Error(
+				`Google IAP token exchange failed${status ? ` (HTTP ${status})` : ''}: ` +
+					`${data?.error_description ?? data?.error ?? axiosError?.message ?? 'Unknown error'}`,
+			);
+		}
+
+		// Validate id_token response
+		const idToken = result?.data?.id_token;
+		if (typeof idToken !== 'string' || idToken.length === 0) {
+			throw new Error(
+				`Google IAP token exchange response missing id_token. Got: ${JSON.stringify(result?.data)}`,
+			);
+		}
+
+		return {
+			...requestOptions,
+			headers: {
+				...requestOptions.headers,
+				Authorization: `Bearer ${idToken}`,
+			},
+		};
+	}
+}

--- a/packages/nodes-base/credentials/test/GoogleIapApi.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/GoogleIapApi.credentials.test.ts
@@ -1,0 +1,251 @@
+import { generateKeyPairSync, createPublicKey, createVerify } from 'crypto';
+
+import type { IHttpRequestOptions } from 'n8n-workflow';
+
+import { GoogleIapApi } from '../GoogleIapApi.credentials';
+
+// Generate RSA key pair dynamically for testing
+const { privateKey: TEST_PRIVATE_KEY, publicKey: TEST_PUBLIC_KEY } = generateKeyPairSync('rsa', {
+	modulusLength: 2048,
+	privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+	publicKeyEncoding: { type: 'spki', format: 'pem' },
+});
+
+// Mock axios with proper default export structure
+jest.mock('axios', () => {
+	const mockFn = jest.fn();
+	return {
+		__esModule: true,
+		default: mockFn,
+	};
+});
+
+import axios from 'axios';
+
+const mockAxios = axios as jest.MockedFunction<typeof axios>;
+
+// Helper to extract and parse JWT from request data
+function extractJwtFromRequest(requestData: string): {
+	header: Record<string, unknown>;
+	payload: Record<string, unknown>;
+	signature: string;
+	raw: string;
+} {
+	const params = new URLSearchParams(requestData);
+	const assertion = params.get('assertion');
+	if (!assertion) throw new Error('No assertion found in request data');
+
+	const parts = assertion.split('.');
+	if (parts.length !== 3) throw new Error('Invalid JWT format');
+
+	return {
+		header: JSON.parse(Buffer.from(parts[0], 'base64url').toString()),
+		payload: JSON.parse(Buffer.from(parts[1], 'base64url').toString()),
+		signature: parts[2],
+		raw: assertion,
+	};
+}
+
+// Helper to verify JWT signature
+function verifyJwtSignature(jwt: string, publicKey: string): boolean {
+	const parts = jwt.split('.');
+	const signedContent = `${parts[0]}.${parts[1]}`;
+	const signature = Buffer.from(parts[2], 'base64url');
+
+	const verify = createVerify('RSA-SHA256');
+	verify.update(signedContent);
+	return verify.verify(createPublicKey(publicKey), signature);
+}
+
+describe('GoogleIapApi', () => {
+	let googleIapApi: GoogleIapApi;
+
+	beforeEach(() => {
+		googleIapApi = new GoogleIapApi();
+		jest.clearAllMocks();
+	});
+
+	describe('credential properties', () => {
+		it('should have correct name and displayName', () => {
+			expect(googleIapApi.name).toBe('googleIapApi');
+			expect(googleIapApi.displayName).toBe('Google IAP (Identity-Aware Proxy) API');
+		});
+
+		it('should have required properties', () => {
+			const propertyNames = googleIapApi.properties.map((p) => p.name);
+			expect(propertyNames).toContain('email');
+			expect(propertyNames).toContain('privateKey');
+			expect(propertyNames).toContain('iapClientId');
+		});
+	});
+
+	describe('authenticate', () => {
+		const baseCredentials = {
+			email: 'test-sa@project.iam.gserviceaccount.com',
+			privateKey: TEST_PRIVATE_KEY,
+			iapClientId: '123456789.apps.googleusercontent.com',
+		};
+
+		const baseRequestOptions: IHttpRequestOptions = {
+			url: 'https://my-iap-protected-app.com/api',
+			method: 'GET',
+		};
+
+		it('should exchange JWT for IAP token and add Authorization header', async () => {
+			mockAxios.mockResolvedValueOnce({
+				data: { id_token: 'mock-iap-id-token' },
+			});
+
+			const result = await googleIapApi.authenticate(baseCredentials, baseRequestOptions);
+
+			expect(mockAxios).toHaveBeenCalledTimes(1);
+			expect(result.headers).toHaveProperty('Authorization', 'Bearer mock-iap-id-token');
+		});
+
+		it('should preserve existing headers', async () => {
+			mockAxios.mockResolvedValueOnce({
+				data: { id_token: 'mock-iap-id-token' },
+			});
+
+			const requestWithHeaders: IHttpRequestOptions = {
+				...baseRequestOptions,
+				headers: { 'X-Custom-Header': 'custom-value' },
+			};
+
+			const result = await googleIapApi.authenticate(baseCredentials, requestWithHeaders);
+
+			expect(result.headers).toHaveProperty('X-Custom-Header', 'custom-value');
+			expect(result.headers).toHaveProperty('Authorization', 'Bearer mock-iap-id-token');
+		});
+
+		it('should use delegated email when impersonating', async () => {
+			mockAxios.mockResolvedValueOnce({
+				data: { id_token: 'mock-iap-id-token' },
+			});
+
+			const credentialsWithDelegation = {
+				...baseCredentials,
+				impersonate: true,
+				delegatedEmail: 'user@example.com',
+			};
+
+			await googleIapApi.authenticate(credentialsWithDelegation, baseRequestOptions);
+
+			// Extract JWT using URLSearchParams (more robust than regex)
+			const axiosCall = mockAxios.mock.calls[0][0] as unknown as { data: string };
+			const jwt = extractJwtFromRequest(axiosCall.data);
+
+			// Verify the JWT contains the delegated email as 'sub'
+			expect(jwt.payload.sub).toBe('user@example.com');
+			expect(jwt.payload.iss).toBe('test-sa@project.iam.gserviceaccount.com');
+			expect(jwt.payload.target_audience).toBe('123456789.apps.googleusercontent.com');
+
+			// Verify JWT signature is valid
+			expect(verifyJwtSignature(jwt.raw, TEST_PUBLIC_KEY)).toBe(true);
+		});
+
+		it('should use service account email as sub when not impersonating', async () => {
+			mockAxios.mockResolvedValueOnce({
+				data: { id_token: 'mock-iap-id-token' },
+			});
+
+			// No delegatedEmail set
+			await googleIapApi.authenticate(baseCredentials, baseRequestOptions);
+
+			const axiosCall = mockAxios.mock.calls[0][0] as unknown as { data: string };
+			const jwt = extractJwtFromRequest(axiosCall.data);
+
+			// When not impersonating, sub should equal iss (service account email)
+			expect(jwt.payload.sub).toBe('test-sa@project.iam.gserviceaccount.com');
+			expect(jwt.payload.iss).toBe('test-sa@project.iam.gserviceaccount.com');
+		});
+
+		it('should include target_audience in JWT for IAP authentication', async () => {
+			mockAxios.mockResolvedValueOnce({
+				data: { id_token: 'mock-iap-id-token' },
+			});
+
+			await googleIapApi.authenticate(baseCredentials, baseRequestOptions);
+
+			const axiosCall = mockAxios.mock.calls[0][0] as unknown as { data: string };
+			const params = new URLSearchParams(axiosCall.data);
+
+			// Verify grant_type is correct for JWT bearer
+			expect(params.get('grant_type')).toBe('urn:ietf:params:oauth:grant-type:jwt-bearer');
+
+			// Extract and verify JWT payload
+			const jwt = extractJwtFromRequest(axiosCall.data);
+
+			// IAP uses target_audience instead of scope
+			expect(jwt.payload.target_audience).toBe('123456789.apps.googleusercontent.com');
+			expect(jwt.payload).not.toHaveProperty('scope');
+
+			// Verify JWT signature
+			expect(verifyJwtSignature(jwt.raw, TEST_PUBLIC_KEY)).toBe(true);
+		});
+
+		it('should throw error when Google OAuth returns an error', async () => {
+			const axiosError = {
+				response: {
+					status: 400,
+					data: {
+						error: 'invalid_grant',
+						error_description: 'Invalid JWT Signature.',
+					},
+				},
+				message: 'Request failed with status code 400',
+			};
+			mockAxios.mockRejectedValueOnce(axiosError);
+
+			await expect(googleIapApi.authenticate(baseCredentials, baseRequestOptions)).rejects.toThrow(
+				'Google IAP token exchange failed (HTTP 400): Invalid JWT Signature.',
+			);
+		});
+
+		it('should throw error when response is missing id_token', async () => {
+			mockAxios.mockResolvedValueOnce({
+				data: { access_token: 'wrong-token-type' },
+			});
+
+			await expect(googleIapApi.authenticate(baseCredentials, baseRequestOptions)).rejects.toThrow(
+				'Google IAP token exchange response missing id_token',
+			);
+		});
+
+		it('should not use delegated email when impersonate is false', async () => {
+			mockAxios.mockResolvedValueOnce({
+				data: { id_token: 'mock-iap-id-token' },
+			});
+
+			const credentialsWithDelegationButNotEnabled = {
+				...baseCredentials,
+				impersonate: false,
+				delegatedEmail: 'user@example.com',
+			};
+
+			await googleIapApi.authenticate(credentialsWithDelegationButNotEnabled, baseRequestOptions);
+
+			const axiosCall = mockAxios.mock.calls[0][0] as unknown as { data: string };
+			const jwt = extractJwtFromRequest(axiosCall.data);
+
+			// When impersonate is false, sub should be service account email even if delegatedEmail is set
+			expect(jwt.payload.sub).toBe('test-sa@project.iam.gserviceaccount.com');
+		});
+
+		it('should include clock skew adjustment in JWT iat', async () => {
+			mockAxios.mockResolvedValueOnce({
+				data: { id_token: 'mock-iap-id-token' },
+			});
+
+			await googleIapApi.authenticate(baseCredentials, baseRequestOptions);
+
+			const axiosCall = mockAxios.mock.calls[0][0] as unknown as { data: string };
+			const jwt = extractJwtFromRequest(axiosCall.data);
+
+			// iat should be set to approximately now - 10 seconds
+			const now = Math.floor(Date.now() / 1000);
+			expect(jwt.payload.iat).toBeLessThanOrEqual(now);
+			expect(jwt.payload.iat).toBeGreaterThan(now - 30); // Allow some test execution time
+		});
+	});
+});

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -139,6 +139,7 @@
       "dist/credentials/GoogleAdsOAuth2Api.credentials.js",
       "dist/credentials/GoogleAnalyticsOAuth2Api.credentials.js",
       "dist/credentials/GoogleApi.credentials.js",
+      "dist/credentials/GoogleIapApi.credentials.js",
       "dist/credentials/GoogleBigQueryOAuth2Api.credentials.js",
       "dist/credentials/GoogleBooksOAuth2Api.credentials.js",
       "dist/credentials/GoogleCalendarOAuth2Api.credentials.js",


### PR DESCRIPTION
## Summary

Adds a new credential type `Google IAP (Identity-Aware Proxy) API` that allows users to authenticate to IAP-protected applications using a Google Service Account.

### Why

Currently, n8n supports Google Service Account authentication for standard OAuth flows, but there's no built-in way to generate IAP (Identity-Aware Proxy) tokens. Users who need to access IAP-protected applications have no native solution since:

1. The Code node cannot access credentials (external task runner limitation)
2. `$secrets` expressions are only available in credential fields, not in Set/Code nodes

This credential type fills that gap by providing IAP token generation where `$secrets` CAN be used (in credential fields).

### How

The implementation follows the existing `GoogleApi.credentials.ts` pattern with key differences for IAP:

- **New field**: `iapClientId` - The OAuth 2.0 Client ID from the IAP-protected application
- **JWT claim**: Uses `target_audience` instead of `scope` 
- **Token response**: Returns `id_token` instead of `access_token`

### How to test

1. Create a Google Service Account with IAP access
2. Get the OAuth 2.0 Client ID from your IAP-protected application (GCP Console > Security > Identity-Aware Proxy)
3. Create a new "Google IAP (Identity-Aware Proxy) API" credential in n8n
4. Use it with an HTTP Request node to access your IAP-protected endpoint

## Related Linear tickets, Github issues, and Community forum posts

N/A - New feature contribution

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.