### PR TITLE
Fixes/25566

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/processItem.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/processItem.ts
@@ -4,6 +4,7 @@ import { ChatPromptTemplate, SystemMessagePromptTemplate } from '@langchain/core
 import type { OutputFixingParser } from '@langchain/classic/output_parsers';
 import { NodeOperationError, type IExecuteFunctions } from 'n8n-workflow';
 
+import { escapeLangChainTemplateVars } from '@utils/promptEscaping';
 import { getTracingConfig } from '@utils/tracing';
 
 import { SYSTEM_PROMPT_TEMPLATE } from './constants';
@@ -26,8 +27,13 @@ export async function processItem(
 		systemPromptTemplate?: string;
 	};
 
+	// Escape curly braces in user-provided prompt to prevent LangChain from
+	// interpreting JSON-like structures as template variables
+	const escapedPrompt = escapeLangChainTemplateVars(
+		options.systemPromptTemplate ?? SYSTEM_PROMPT_TEMPLATE,
+	);
 	const systemPromptTemplate = SystemMessagePromptTemplate.fromTemplate(
-		`${options.systemPromptTemplate ?? SYSTEM_PROMPT_TEMPLATE}
+		`${escapedPrompt}
 {format_instructions}`,
 	);
 

--- a/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/test/processItem.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/test/processItem.test.ts
@@ -116,6 +116,85 @@ describe('processItem', () => {
 		expect(result).toEqual({ name: 'John', age: 30 });
 	});
 
+	it('should handle system prompt containing JSON-like structures', async () => {
+		// This test reproduces the bug from https://github.com/n8n-io/n8n/issues/25566
+		// Before the fix, JSON-like content in the system prompt caused LangChain's
+		// template parser to interpret curly braces as template variables, crashing
+		// before any LLM call was made.
+		const jsonPrompt =
+			'Extract fields matching this schema: {"name": "string", "age": "number"}. Only extract relevant info.';
+		const mockExecuteFunctions = {
+			getNodeParameter: (param: string) => {
+				if (param === 'text') return 'John is 30 years old';
+				if (param === 'options') return { systemPromptTemplate: jsonPrompt };
+				return undefined;
+			},
+			getNode: () => ({ typeVersion: 1.1 }),
+		};
+
+		const llm = new FakeLLM({ response: formatFakeLlmResponse({ name: 'John', age: 30 }) });
+		const parser = OutputFixingParser.fromLLM(
+			llm,
+			StructuredOutputParser.fromZodSchema(makeZodSchemaFromAttributes(mockPersonAttributes)),
+		);
+
+		const result = await processItem(mockExecuteFunctions as any, 0, llm, parser);
+
+		expect(result).toEqual({ name: 'John', age: 30 });
+	});
+
+	it('should handle system prompt with nested JSON example', async () => {
+		const nestedJsonPrompt = `You are an extraction algorithm.
+Extract data following this example output:
+{
+  "person": {
+    "name": "Jane",
+    "contacts": [{"type": "email", "value": "jane@example.com"}]
+  }
+}
+Only extract what is relevant.`;
+		const mockExecuteFunctions = {
+			getNodeParameter: (param: string) => {
+				if (param === 'text') return 'John is 30 years old';
+				if (param === 'options') return { systemPromptTemplate: nestedJsonPrompt };
+				return undefined;
+			},
+			getNode: () => ({ typeVersion: 1.1 }),
+		};
+
+		const llm = new FakeLLM({ response: formatFakeLlmResponse({ name: 'John', age: 30 }) });
+		const parser = OutputFixingParser.fromLLM(
+			llm,
+			StructuredOutputParser.fromZodSchema(makeZodSchemaFromAttributes(mockPersonAttributes)),
+		);
+
+		const result = await processItem(mockExecuteFunctions as any, 0, llm, parser);
+
+		expect(result).toEqual({ name: 'John', age: 30 });
+	});
+
+	it('should handle system prompt with curly braces in plain text', async () => {
+		const bracesPrompt = 'Use curly braces like {this} for emphasis. Extract the data.';
+		const mockExecuteFunctions = {
+			getNodeParameter: (param: string) => {
+				if (param === 'text') return 'John is 30 years old';
+				if (param === 'options') return { systemPromptTemplate: bracesPrompt };
+				return undefined;
+			},
+			getNode: () => ({ typeVersion: 1.1 }),
+		};
+
+		const llm = new FakeLLM({ response: formatFakeLlmResponse({ name: 'John', age: 30 }) });
+		const parser = OutputFixingParser.fromLLM(
+			llm,
+			StructuredOutputParser.fromZodSchema(makeZodSchemaFromAttributes(mockPersonAttributes)),
+		);
+
+		const result = await processItem(mockExecuteFunctions as any, 0, llm, parser);
+
+		expect(result).toEqual({ name: 'John', age: 30 });
+	});
+
 	it('should handle retries when LLM returns invalid data', async () => {
 		const mockExecuteFunctions = {
 			getNodeParameter: (param: string) => {

--- a/packages/@n8n/nodes-langchain/nodes/chains/SentimentAnalysis/SentimentAnalysis.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/SentimentAnalysis/SentimentAnalysis.node.ts
@@ -13,6 +13,7 @@ import type {
 } from 'n8n-workflow';
 import { z } from 'zod';
 
+import { escapeLangChainTemplateVars } from '@utils/promptEscaping';
 import { getBatchingOptionFields } from '@utils/sharedFields';
 import { getTracingConfig } from '@utils/tracing';
 
@@ -212,8 +213,15 @@ export class SentimentAnalysis implements INodeType {
 						? OutputFixingParser.fromLLM(llm, structuredParser)
 						: structuredParser;
 
+					// Escape curly braces in user-provided prompt to prevent LangChain from
+					// interpreting JSON-like structures as template variables.
+					// Preserve {categories} since the default prompt uses it as a template variable.
+					const escapedPrompt = escapeLangChainTemplateVars(
+						options.systemPromptTemplate ?? DEFAULT_SYSTEM_PROMPT_TEMPLATE,
+						['categories'],
+					);
 					const systemPromptTemplate = SystemMessagePromptTemplate.fromTemplate(
-						`${options.systemPromptTemplate ?? DEFAULT_SYSTEM_PROMPT_TEMPLATE}
+						`${escapedPrompt}
 				{format_instructions}`,
 					);
 
@@ -352,8 +360,13 @@ export class SentimentAnalysis implements INodeType {
 						? OutputFixingParser.fromLLM(llm, structuredParser)
 						: structuredParser;
 
+					// Escape curly braces in user-provided prompt (same as batch path above)
+					const escapedPrompt = escapeLangChainTemplateVars(
+						options.systemPromptTemplate ?? DEFAULT_SYSTEM_PROMPT_TEMPLATE,
+						['categories'],
+					);
 					const systemPromptTemplate = SystemMessagePromptTemplate.fromTemplate(
-						`${options.systemPromptTemplate ?? DEFAULT_SYSTEM_PROMPT_TEMPLATE}
+						`${escapedPrompt}
 			{format_instructions}`,
 					);
 

--- a/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/processItem.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/processItem.ts
@@ -4,6 +4,7 @@ import { ChatPromptTemplate, SystemMessagePromptTemplate } from '@langchain/core
 import type { OutputFixingParser, StructuredOutputParser } from '@langchain/classic/output_parsers';
 import { NodeOperationError, type IExecuteFunctions, type INodeExecutionData } from 'n8n-workflow';
 
+import { escapeLangChainTemplateVars } from '@utils/promptEscaping';
 import { getTracingConfig } from '@utils/tracing';
 
 import { SYSTEM_PROMPT_TEMPLATE } from './constants';
@@ -36,8 +37,15 @@ export async function processItem(
 		itemIndex,
 		SYSTEM_PROMPT_TEMPLATE,
 	) as string;
+	// Escape curly braces in user-provided prompt to prevent LangChain from
+	// interpreting JSON-like structures as template variables.
+	// Preserve {categories} since the default prompt uses it as a template variable.
+	const escapedPrompt = escapeLangChainTemplateVars(
+		systemPromptTemplateOpt ?? SYSTEM_PROMPT_TEMPLATE,
+		['categories'],
+	);
 	const systemPromptTemplate = SystemMessagePromptTemplate.fromTemplate(
-		`${systemPromptTemplateOpt ?? SYSTEM_PROMPT_TEMPLATE}
+		`${escapedPrompt}
 	{format_instructions}
 	${multiClassPrompt}
 	${fallbackPrompt}`,

--- a/packages/@n8n/nodes-langchain/utils/promptEscaping.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/promptEscaping.test.ts
@@ -1,0 +1,89 @@
+import { escapeLangChainTemplateVars } from './promptEscaping';
+
+describe('escapeLangChainTemplateVars', () => {
+	it('should return text unchanged when no curly braces present', () => {
+		expect(escapeLangChainTemplateVars('Hello world')).toBe('Hello world');
+	});
+
+	it('should escape single curly braces', () => {
+		expect(escapeLangChainTemplateVars('a { b } c')).toBe('a {{ b }} c');
+	});
+
+	it('should escape JSON-like structures in prompts', () => {
+		const input = 'Return data as {"name": "John", "age": 30}';
+		const expected = 'Return data as {{"name": "John", "age": 30}}';
+		expect(escapeLangChainTemplateVars(input)).toBe(expected);
+	});
+
+	it('should escape nested JSON structures', () => {
+		const input = '{"user": {"name": "John", "address": {"city": "NYC"}}}';
+		const expected = '{{"user": {{"name": "John", "address": {{"city": "NYC"}}}}}}';
+		expect(escapeLangChainTemplateVars(input)).toBe(expected);
+	});
+
+	it('should escape JSON arrays with objects', () => {
+		const input = 'Format: [{"key": "value"}, {"key2": "value2"}]';
+		const expected = 'Format: [{{"key": "value"}}, {{"key2": "value2"}}]';
+		expect(escapeLangChainTemplateVars(input)).toBe(expected);
+	});
+
+	it('should preserve specified template variables', () => {
+		const input = 'Categories: {categories}. Return as {"result": true}';
+		const expected = 'Categories: {categories}. Return as {{"result": true}}';
+		expect(escapeLangChainTemplateVars(input, ['categories'])).toBe(expected);
+	});
+
+	it('should preserve multiple template variables', () => {
+		const input = '{categories} and {format_instructions} but not {"json": true}';
+		const expected = '{categories} and {format_instructions} but not {{"json": true}}';
+		expect(escapeLangChainTemplateVars(input, ['categories', 'format_instructions'])).toBe(
+			expected,
+		);
+	});
+
+	it('should not affect already-escaped braces', () => {
+		// If text already has {{ }}, they get doubled again: {{{{ }}}}
+		// This is consistent behavior - the function always escapes all braces
+		const input = '{{already_escaped}}';
+		const expected = '{{{{already_escaped}}}}';
+		expect(escapeLangChainTemplateVars(input)).toBe(expected);
+	});
+
+	it('should handle empty string', () => {
+		expect(escapeLangChainTemplateVars('')).toBe('');
+	});
+
+	it('should handle prompt with JSON schema example', () => {
+		const input = `Extract data following this schema:
+{
+  "type": "object",
+  "properties": {
+    "name": {"type": "string"},
+    "age": {"type": "number"}
+  }
+}`;
+		const result = escapeLangChainTemplateVars(input);
+		// All braces should be doubled
+		expect(result).not.toContain('{"type"');
+		expect(result).toContain('{{"type"');
+		expect(result).toContain('{{"type": "string"}}');
+	});
+
+	it('should handle a realistic Information Extractor prompt with JSON', () => {
+		const input = `You are an expert extraction algorithm.
+Extract the following fields from the text.
+Return JSON matching this example: {"name": "string", "age": "number", "address": {"street": "string", "city": "string"}}
+If you do not know a value, omit it.`;
+		const result = escapeLangChainTemplateVars(input);
+		// The JSON example should be fully escaped
+		expect(result).toContain('{{"name": "string", "age": "number", "address": {{"street": "string", "city": "string"}}}}');
+		// No unescaped single braces should remain
+		expect(result.replace(/\{\{/g, '').replace(/\}\}/g, '')).not.toMatch(/[{}]/);
+	});
+
+	it('should preserve template variable even when adjacent to JSON', () => {
+		const input = '{categories}: {"example": "value"}';
+		const expected = '{categories}: {{"example": "value"}}';
+		expect(escapeLangChainTemplateVars(input, ['categories'])).toBe(expected);
+	});
+});

--- a/packages/@n8n/nodes-langchain/utils/promptEscaping.ts
+++ b/packages/@n8n/nodes-langchain/utils/promptEscaping.ts
@@ -1,0 +1,31 @@
+/**
+ * Escapes curly braces in user-provided text to prevent LangChain's template
+ * parser from interpreting them as template variables.
+ *
+ * LangChain's `fromTemplate()` uses f-string syntax where `{variable}` denotes
+ * a template variable. When user text contains JSON-like structures
+ * (e.g. `{"name": "John"}`), the parser misinterprets the braces as variable
+ * references, causing runtime errors.
+ *
+ * This function doubles all curly braces (`{` → `{{`, `}` → `}}`), which is
+ * LangChain's escape syntax for literal braces. It optionally preserves
+ * specific template variable names that should remain interpolatable.
+ *
+ * @param text - The user-provided text that may contain curly braces
+ * @param preserveVariables - Template variable names to keep unescaped (e.g. `['categories']`)
+ * @returns The text with curly braces escaped, except for preserved variables
+ */
+export function escapeLangChainTemplateVars(
+	text: string,
+	preserveVariables: string[] = [],
+): string {
+	// Escape all curly braces by doubling them
+	let escaped = text.replace(/\{/g, '{{').replace(/\}/g, '}}');
+
+	// Restore any preserved template variables
+	for (const varName of preserveVariables) {
+		escaped = escaped.replaceAll(`{{${varName}}}`, `{${varName}}`);
+	}
+
+	return escaped;
+}


### PR DESCRIPTION
## Summary

Fixes a bug where AI nodes (Information Extractor, Text Classifier, Sentiment Analysis) crash at runtime when the user's system prompt contains JSON-like structures (e.g. {"name": "string"}).

The root cause is that user-provided prompt text is string-concatenated directly into LangChain's template string before fromTemplate() is called. LangChain's f-string parser treats every {...} pattern as a template variable, so JSON braces in user prompts cause an InputFormatError before any LLM call is made.

The fix introduces a shared utility (escapeLangChainTemplateVars) that escapes curly braces in user-provided text by doubling them ({ to {{), which is LangChain's syntax for literal braces. Each node call-site specifies which template variables (e.g. {categories}) should be preserved. This is the same approach already used in the ChainLLM node at promptUtils.ts:64-66.

Changed files:

utils/promptEscaping.ts — new shared escape utility
InformationExtractor/processItem.ts — escape user prompt before fromTemplate()
TextClassifier/processItem.ts — escape user prompt, preserve {categories}
SentimentAnalysis/SentimentAnalysis.node.ts — escape in both batch and sequential paths
Test files:

utils/promptEscaping.test.ts — 11 unit tests covering JSON, nested objects, preserved variables, edge cases
InformationExtractor/test/processItem.test.ts — 3 regression tests with JSON-containing prompts

## Related Linear tickets, Github issues, and Community forum posts

Fixes #25566


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
