### PR TITLE
fix(Postgres Node): Detect silent data persistence failures in batch executions

### DIFF
--- a/packages/nodes-base/nodes/Postgres/test/v2/persistenceValidation.test.ts
+++ b/packages/nodes-base/nodes/Postgres/test/v2/persistenceValidation.test.ts
@@ -1,0 +1,335 @@
+import { mock } from 'jest-mock-extended';
+import type { IDataObject, IExecuteFunctions, INode } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+import pgPromise from 'pg-promise';
+
+import type { PgpDatabase, QueryWithValues } from '../../v2/helpers/interfaces';
+import { configureQueryRunner, validateReturningResults } from '../../v2/helpers/utils';
+
+const node: INode = {
+	id: '1',
+	name: 'Postgres node',
+	typeVersion: 2.6,
+	type: 'n8n-nodes-base.postgres',
+	position: [60, 760],
+	parameters: {
+		operation: 'insert',
+	},
+};
+
+const createMockDb = (multiReturnData: IDataObject[][]) => {
+	return {
+		async any() {
+			return [];
+		},
+		async multi() {
+			return multiReturnData;
+		},
+		async tx(callback: (t: unknown) => Promise<unknown>) {
+			return callback({
+				async any() {
+					return [];
+				},
+				async multi() {
+					return multiReturnData.length > 0 ? [multiReturnData[0]] : [[]];
+				},
+			});
+		},
+		async task(callback: (t: unknown) => Promise<unknown>) {
+			let callIndex = 0;
+			return callback({
+				async any() {
+					return [];
+				},
+				async multi() {
+					const result = multiReturnData[callIndex] ?? [];
+					callIndex++;
+					return [result];
+				},
+			});
+		},
+	} as unknown as PgpDatabase;
+};
+
+describe('validateReturningResults', () => {
+	it('should return null when no queries have hasReturning', () => {
+		const queries: QueryWithValues[] = [
+			{ query: 'DELETE FROM test WHERE id=1', values: [] },
+		];
+		const results: unknown[][] = [[]];
+
+		expect(validateReturningResults(node, queries, results)).toBeNull();
+	});
+
+	it('should return null when all RETURNING queries got data back', () => {
+		const queries: QueryWithValues[] = [
+			{ query: 'INSERT INTO test(id) VALUES(1) RETURNING *', values: [], hasReturning: true },
+			{ query: 'INSERT INTO test(id) VALUES(2) RETURNING *', values: [], hasReturning: true },
+		];
+		const results: unknown[][] = [[{ id: 1 }], [{ id: 2 }]];
+
+		expect(validateReturningResults(node, queries, results)).toBeNull();
+	});
+
+	it('should return error when ALL RETURNING queries got empty results', () => {
+		const queries: QueryWithValues[] = [
+			{ query: 'INSERT INTO test(id) VALUES(1) RETURNING *', values: [], hasReturning: true },
+			{ query: 'INSERT INTO test(id) VALUES(2) RETURNING *', values: [], hasReturning: true },
+			{ query: 'INSERT INTO test(id) VALUES(3) RETURNING *', values: [], hasReturning: true },
+		];
+		const results: unknown[][] = [[], [], []];
+
+		const error = validateReturningResults(node, queries, results);
+		expect(error).toBeInstanceOf(NodeOperationError);
+		expect(error?.message).toContain('None of the 3 executed queries returned data');
+	});
+
+	it('should return null when SOME RETURNING queries got data (partial success)', () => {
+		const queries: QueryWithValues[] = [
+			{ query: 'INSERT INTO test(id) VALUES(1) RETURNING *', values: [], hasReturning: true },
+			{ query: 'INSERT INTO test(id) VALUES(2) RETURNING *', values: [], hasReturning: true },
+		];
+		// First query succeeded, second returned empty (e.g. ON CONFLICT scenario)
+		const results: unknown[][] = [[{ id: 1 }], []];
+
+		expect(validateReturningResults(node, queries, results)).toBeNull();
+	});
+
+	it('should return error when results are truncated (fewer results than queries)', () => {
+		const queries: QueryWithValues[] = [
+			{ query: 'INSERT INTO test(id) VALUES(1) RETURNING *', values: [], hasReturning: true },
+			{ query: 'INSERT INTO test(id) VALUES(2) RETURNING *', values: [], hasReturning: true },
+			{ query: 'INSERT INTO test(id) VALUES(3) RETURNING *', values: [], hasReturning: true },
+		];
+		// Only one empty result returned - response was truncated
+		const results: unknown[][] = [[]];
+
+		const error = validateReturningResults(node, queries, results);
+		expect(error).toBeInstanceOf(NodeOperationError);
+		expect(error?.message).toContain('None of the 3 executed queries returned data');
+	});
+
+	it('should skip validation for mixed queries (some with hasReturning, some without)', () => {
+		const queries: QueryWithValues[] = [
+			{ query: 'INSERT INTO test(id) VALUES(1) RETURNING *', values: [], hasReturning: true },
+			{ query: 'DELETE FROM test WHERE id=99', values: [] }, // no hasReturning
+		];
+		const results: unknown[][] = [[{ id: 1 }], []];
+
+		expect(validateReturningResults(node, queries, results)).toBeNull();
+	});
+
+	it('should handle large batch (17000 items) with all empty results', () => {
+		const queries: QueryWithValues[] = Array.from({ length: 17000 }, (_, i) => ({
+			query: `INSERT INTO test(id) VALUES(${i}) RETURNING *`,
+			values: [] as IDataObject[],
+			hasReturning: true,
+		}));
+		const results: unknown[][] = new Array(17000).fill([]);
+
+		const error = validateReturningResults(node, queries, results);
+		expect(error).toBeInstanceOf(NodeOperationError);
+		expect(error?.message).toContain('None of the 17000 executed queries returned data');
+	});
+});
+
+describe('configureQueryRunner - persistence validation', () => {
+	describe('single mode (default)', () => {
+		it('should throw when queries with hasReturning return no data', async () => {
+			const pgp = pgPromise();
+			const db = createMockDb([[], [], []]);
+
+			const thisArg = mock<IExecuteFunctions>();
+			const runQueries = configureQueryRunner.call(thisArg, node, false, pgp, db);
+
+			const queries: QueryWithValues[] = [
+				{ query: 'INSERT INTO test(id) VALUES(1) RETURNING *', values: [], hasReturning: true },
+				{ query: 'INSERT INTO test(id) VALUES(2) RETURNING *', values: [], hasReturning: true },
+				{ query: 'INSERT INTO test(id) VALUES(3) RETURNING *', values: [], hasReturning: true },
+			];
+
+			await expect(
+				runQueries(queries, { nodeVersion: 2.6, operation: 'insert' }),
+			).rejects.toThrow(
+				'None of the 3 executed queries returned data despite having a RETURNING clause',
+			);
+		});
+
+		it('should return error item with continueOnFail when RETURNING returns no data', async () => {
+			const pgp = pgPromise();
+			const db = createMockDb([[], []]);
+
+			const thisArg = mock<IExecuteFunctions>();
+			// continueOnFail = true
+			const runQueries = configureQueryRunner.call(thisArg, node, true, pgp, db);
+
+			const queries: QueryWithValues[] = [
+				{ query: 'INSERT INTO test(id) VALUES(1) RETURNING *', values: [], hasReturning: true },
+				{ query: 'INSERT INTO test(id) VALUES(2) RETURNING *', values: [], hasReturning: true },
+			];
+
+			const result = await runQueries(queries, { nodeVersion: 2.6, operation: 'insert' });
+
+			expect(result).toHaveLength(1);
+			expect(result[0].json).toHaveProperty('message');
+			expect((result[0].json as IDataObject).message).toContain(
+				'None of the 2 executed queries returned data',
+			);
+		});
+
+		it('should return success:true when queries WITHOUT hasReturning return no data (backward compat)', async () => {
+			const pgp = pgPromise();
+			const db = createMockDb([[], []]);
+
+			const thisArg = mock<IExecuteFunctions>();
+			const runQueries = configureQueryRunner.call(thisArg, node, false, pgp, db);
+
+			// Queries without hasReturning - existing behavior preserved
+			const queries: QueryWithValues[] = [
+				{ query: 'DELETE FROM test WHERE id=1', values: [] },
+				{ query: 'DELETE FROM test WHERE id=2', values: [] },
+			];
+
+			const result = await runQueries(queries, { nodeVersion: 2.6, operation: 'deleteTable' });
+
+			expect(result).toEqual([
+				{ json: { success: true }, pairedItem: [{ item: 0 }, { item: 1 }] },
+			]);
+		});
+
+		it('should process results normally when RETURNING queries get data back', async () => {
+			const pgp = pgPromise();
+			const db = createMockDb([[{ id: 1, name: 'a' }], [{ id: 2, name: 'b' }]]);
+
+			const thisArg = mock<IExecuteFunctions>();
+			thisArg.helpers.constructExecutionMetaData.mockImplementation((items, meta) =>
+				items.map((item) => ({ ...item, pairedItem: meta.itemData })),
+			);
+			const runQueries = configureQueryRunner.call(thisArg, node, false, pgp, db);
+
+			const queries: QueryWithValues[] = [
+				{ query: 'INSERT INTO test(id, name) VALUES(1, \'a\') RETURNING *', values: [], hasReturning: true },
+				{ query: 'INSERT INTO test(id, name) VALUES(2, \'b\') RETURNING *', values: [], hasReturning: true },
+			];
+
+			const result = await runQueries(queries, { nodeVersion: 2.6, operation: 'insert' });
+
+			expect(result).toHaveLength(2);
+			expect(result[0].json).toEqual({ id: 1, name: 'a' });
+			expect(result[1].json).toEqual({ id: 2, name: 'b' });
+		});
+
+		it('should simulate large batch (17000 items) empty RETURNING failure', async () => {
+			const pgp = pgPromise();
+			const emptyResults = new Array(17000).fill([]);
+			const db = createMockDb(emptyResults);
+
+			const thisArg = mock<IExecuteFunctions>();
+			const runQueries = configureQueryRunner.call(thisArg, node, false, pgp, db);
+
+			const queries: QueryWithValues[] = Array.from({ length: 17000 }, (_, i) => ({
+				query: `INSERT INTO test(id) VALUES(${i}) RETURNING *`,
+				values: [] as IDataObject[],
+				hasReturning: true,
+			}));
+
+			await expect(
+				runQueries(queries, { nodeVersion: 2.6, operation: 'insert' }),
+			).rejects.toThrow(
+				'None of the 17000 executed queries returned data despite having a RETURNING clause',
+			);
+		});
+	});
+
+	describe('transaction mode', () => {
+		it('should throw when a query with hasReturning returns no data', async () => {
+			const pgp = pgPromise();
+			const db = createMockDb([[]]);
+
+			const thisArg = mock<IExecuteFunctions>();
+			const runQueries = configureQueryRunner.call(thisArg, node, false, pgp, db);
+
+			const queries: QueryWithValues[] = [
+				{ query: 'INSERT INTO test(id) VALUES(1) RETURNING *', values: [], hasReturning: true },
+			];
+
+			await expect(
+				runQueries(queries, {
+					nodeVersion: 2.6,
+					queryBatching: 'transaction',
+					operation: 'insert',
+				}),
+			).rejects.toThrow('RETURNING clause');
+		});
+
+		it('should return error item with continueOnFail in transaction mode', async () => {
+			const pgp = pgPromise();
+			const db = createMockDb([[]]);
+
+			const thisArg = mock<IExecuteFunctions>();
+			const runQueries = configureQueryRunner.call(thisArg, node, true, pgp, db);
+
+			const queries: QueryWithValues[] = [
+				{ query: 'INSERT INTO test(id) VALUES(1) RETURNING *', values: [], hasReturning: true },
+			];
+
+			const result = await runQueries(queries, {
+				nodeVersion: 2.6,
+				queryBatching: 'transaction',
+				operation: 'insert',
+			});
+
+			expect(result).toHaveLength(1);
+			expect(result[0].json).toHaveProperty('error');
+		});
+	});
+
+	describe('independently mode', () => {
+		it('should throw when a query with hasReturning returns no data', async () => {
+			const pgp = pgPromise();
+			const db = createMockDb([[]]);
+
+			const thisArg = mock<IExecuteFunctions>();
+			const runQueries = configureQueryRunner.call(thisArg, node, false, pgp, db);
+
+			const queries: QueryWithValues[] = [
+				{ query: 'INSERT INTO test(id) VALUES(1) RETURNING *', values: [], hasReturning: true },
+			];
+
+			await expect(
+				runQueries(queries, {
+					nodeVersion: 2.6,
+					queryBatching: 'independently',
+					operation: 'insert',
+				}),
+			).rejects.toThrow('RETURNING clause');
+		});
+
+		it('should report per-item failures with continueOnFail in independently mode', async () => {
+			const pgp = pgPromise();
+			// Both queries return empty
+			const db = createMockDb([[], []]);
+
+			const thisArg = mock<IExecuteFunctions>();
+			const runQueries = configureQueryRunner.call(thisArg, node, true, pgp, db);
+
+			const queries: QueryWithValues[] = [
+				{ query: 'INSERT INTO test(id) VALUES(1) RETURNING *', values: [], hasReturning: true },
+				{ query: 'INSERT INTO test(id) VALUES(2) RETURNING *', values: [], hasReturning: true },
+			];
+
+			const result = await runQueries(queries, {
+				nodeVersion: 2.6,
+				queryBatching: 'independently',
+				operation: 'insert',
+			});
+
+			// Each failed query produces its own error item
+			expect(result).toHaveLength(2);
+			expect(result[0].json).toHaveProperty('error');
+			expect(result[1].json).toHaveProperty('error');
+			expect(result[0].pairedItem).toEqual({ item: 0 });
+			expect(result[1].pairedItem).toEqual({ item: 1 });
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/insert.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/insert.operation.ts
@@ -250,7 +250,9 @@ export async function execute(
 
 			[query, values] = addReturning(query, outputColumns, values);
 
-			queries.push({ query, values });
+			// Mark queries that should return data so the runner can detect persistence failures.
+			// Skip for ON CONFLICT DO NOTHING since empty results are expected on conflict.
+			queries.push({ query, values, hasReturning: !options.skipOnConflict });
 		} catch (e) {
 			if (this.continueOnFail()) {
 				const error = e instanceof Error ? e : String(e);

--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/update.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/update.operation.ts
@@ -354,7 +354,7 @@ export async function execute(
 
 			[query, values] = addReturning(query, outputColumns, values);
 
-			queries.push({ query, values });
+			queries.push({ query, values, hasReturning: true });
 		} catch (e) {
 			if (this.continueOnFail()) {
 				const error = e instanceof Error ? e : String(e);

--- a/packages/nodes-base/nodes/Postgres/v2/helpers/interfaces.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/helpers/interfaces.ts
@@ -7,7 +7,13 @@ export type QueryMode = 'single' | 'transaction' | 'independently';
 
 export type QueryValue = string | number | IDataObject | string[];
 export type QueryValues = QueryValue[];
-export type QueryWithValues = { query: string; values?: QueryValues; options?: IFormattingOptions };
+export type QueryWithValues = {
+	query: string;
+	values?: QueryValues;
+	options?: IFormattingOptions;
+	/** When true, indicates the query has a RETURNING clause and MUST return row data on success */
+	hasReturning?: boolean;
+};
 
 export type WhereClause = { column: string; condition: string; value: string | number };
 export type SortRule = { column: string; direction: string };

--- a/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
@@ -67,6 +67,52 @@ export function prepareErrorItem(error: IDataObject | NodeOperationError | Error
 	} as INodeExecutionData;
 }
 
+/**
+ * Validates that queries with a RETURNING clause actually returned data.
+ * If all such queries returned empty results, it indicates a persistence failure
+ * (e.g., connection pooler interrupted the batch, connection dropped mid-execution).
+ * Returns a NodeOperationError if validation fails, or null if results are valid.
+ */
+export function validateReturningResults(
+	node: INode,
+	queries: QueryWithValues[],
+	results: unknown[][],
+): NodeOperationError | null {
+	const queriesExpectingResults = queries.filter((q) => q.hasReturning);
+	if (queriesExpectingResults.length === 0) return null;
+
+	let emptyCount = 0;
+
+	// Check results that were returned
+	for (let i = 0; i < results.length; i++) {
+		if (queries[i]?.hasReturning && (!Array.isArray(results[i]) || results[i].length === 0)) {
+			emptyCount++;
+		}
+	}
+
+	// Count queries beyond the returned results (truncated response)
+	for (let i = results.length; i < queries.length; i++) {
+		if (queries[i]?.hasReturning) {
+			emptyCount++;
+		}
+	}
+
+	if (emptyCount > 0 && emptyCount === queriesExpectingResults.length) {
+		return new NodeOperationError(
+			node,
+			`None of the ${queriesExpectingResults.length} executed queries returned data despite having a RETURNING clause. The data may not have been persisted to the database.`,
+			{
+				description:
+					'This can happen when a connection pooler (e.g., pgBouncer, Supavisor) interrupts ' +
+					'a large batch execution, or when the connection is dropped mid-query. Verify the data ' +
+					'in your database and consider using "independently" or "transaction" query batching mode.',
+			},
+		);
+	}
+
+	return null;
+}
+
 export function parsePostgresError(
 	node: INode,
 	error: any,
@@ -252,7 +298,24 @@ export function configureQueryRunner(
 
 		if (queryBatching === 'single') {
 			try {
-				returnData = (await db.multi(pgp.helpers.concat(queries)))
+				const multiResults = await db.multi(pgp.helpers.concat(queries));
+
+				// Validate that queries with RETURNING actually produced data.
+				// If all RETURNING queries got empty results, data was likely not persisted.
+				const persistenceError = validateReturningResults(node, queries, multiResults);
+				if (persistenceError) {
+					if (!continueOnFail) throw persistenceError;
+					return [
+						{
+							json: {
+								message: persistenceError.message,
+								error: { ...persistenceError },
+							},
+						},
+					];
+				}
+
+				returnData = multiResults
 					.map((result, i) => {
 						return this.helpers.constructExecutionMetaData(wrapData(result as IDataObject[]), {
 							itemData: { item: i },
@@ -275,6 +338,18 @@ export function configureQueryRunner(
 					}
 				}
 			} catch (err) {
+				// Preserve NodeOperationError (e.g. from persistence validation) without re-wrapping
+				if (err instanceof NodeOperationError) {
+					if (!continueOnFail) throw err;
+					return [
+						{
+							json: {
+								message: err.message,
+								error: { ...err },
+							},
+						},
+					];
+				}
 				const error = parsePostgresError(node, err, queries);
 				if (!continueOnFail) throw error;
 
@@ -305,6 +380,13 @@ export function configureQueryRunner(
 						}
 
 						if (!transactionResults.length) {
+							if (queries[i].hasReturning) {
+								throw new NodeOperationError(
+									node,
+									'Query returned no data despite RETURNING clause. The data may not have been persisted.',
+									{ itemIndex: i },
+								);
+							}
 							if ((options?.nodeVersion as number) < 2.3) {
 								transactionResults = emptyReturnData;
 							} else {
@@ -319,7 +401,10 @@ export function configureQueryRunner(
 
 						result.push(...executionData);
 					} catch (err) {
-						const error = parsePostgresError(node, err, queries, i);
+						const error =
+							err instanceof NodeOperationError
+								? err
+								: parsePostgresError(node, err, queries, i);
 						if (!continueOnFail) throw error;
 						result.push(prepareErrorItem(error, i));
 						return result;
@@ -345,6 +430,13 @@ export function configureQueryRunner(
 						}
 
 						if (!transactionResults.length) {
+							if (queries[i].hasReturning) {
+								throw new NodeOperationError(
+									node,
+									'Query returned no data despite RETURNING clause. The data may not have been persisted.',
+									{ itemIndex: i },
+								);
+							}
 							if ((options?.nodeVersion as number) < 2.3) {
 								transactionResults = emptyReturnData;
 							} else {
@@ -359,7 +451,10 @@ export function configureQueryRunner(
 
 						result.push(...executionData);
 					} catch (err) {
-						const error = parsePostgresError(node, err, queries, i);
+						const error =
+							err instanceof NodeOperationError
+								? err
+								: parsePostgresError(node, err, queries, i);
 						if (!continueOnFail) throw error;
 						result.push(prepareErrorItem(error, i));
 					}


### PR DESCRIPTION
…s in Supabase

## Summary

The Postgres node reports successful execution for INSERT/UPDATE queries on large datasets (17,000+ records) while the data is not actually persisted to the database. This happens because the query runner returns `{ success: true }` when `db.multi()` produces empty result sets for queries that include a `RETURNING` clause -- a clear sign that the writes did not go through.

The root cause is in `configureQueryRunner` (single, transaction, and independently modes). When all result sets come back empty for write queries with `RETURNING`, the code falls through to a generic success fallback instead of raising an error. This is especially problematic with connection poolers like Supavisor/pgBouncer that can silently drop or truncate large multi-statement queries.

**What this PR does:**

- Adds a `hasReturning` flag to `QueryWithValues` so write operations can signal that a query must return row data on success.
- Adds `validateReturningResults()` in `utils.ts` that checks whether all RETURNING queries got empty results and returns a `NodeOperationError` if so.
- Applies validation in all three query batching modes (single, transaction, independently).
- Sets the flag in INSERT (skipped for `ON CONFLICT DO NOTHING` where empty results are expected) and UPDATE operations.
- Preserves backward compatibility: queries without the flag behave exactly as before.

**Files changed:**

| File | Change |
|------|--------|
| `v2/helpers/interfaces.ts` | Add optional `hasReturning` to `QueryWithValues` |
| `v2/helpers/utils.ts` | Add `validateReturningResults()`, apply it in all 3 execution modes, fix catch block to preserve `NodeOperationError` |
| `v2/actions/database/insert.operation.ts` | Set `hasReturning` on queries (respects `skipOnConflict`) |
| `v2/actions/database/update.operation.ts` | Set `hasReturning: true` on queries |

**How to test:**

1. Run the new test suite: `pnpm jest nodes/Postgres/test/v2/persistenceValidation.test.ts`
2. Set up a Supabase Postgres instance and run a workflow that inserts 17,000+ rows via the Postgres node in single batching mode. Before this fix, the node returns one `{ success: true }` item with no error. After this fix, if data is not persisted, the node throws an error describing the persistence failure.

## Related Linear tickets, Github issues, and Community forum posts

Fixes https://github.com/n8n-io/n8n/issues/25408


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
