### PR TITLE
fixes/25165

### DIFF
--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -140,6 +140,8 @@ describe('Execution Lifecycle Hooks', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 		workflowData.settings = {};
+		// Default: DB update succeeds (execution is not already in a terminal state)
+		executionRepository.updateExistingExecution.mockResolvedValue(true);
 		successfulRun.data = createRunExecutionData({
 			resultData: {
 				runData: {},
@@ -954,14 +956,35 @@ describe('Execution Lifecycle Hooks', () => {
 
 				await lifecycleHooks.runHook('workflowExecuteAfter', [successfulRunWithMetadata, {}]);
 
-				// Worker should save execution data but not metadata
+				// Worker should save execution data but not metadata, with requireNotCanceled guard
 				expect(executionRepository.updateExistingExecution).toHaveBeenCalledWith(
 					executionId,
 					expect.objectContaining({
 						finished: true,
 						status: 'success',
 					}),
+					{ requireNotCanceled: true },
 				);
+			});
+
+			it('should not overwrite a cancelled execution status with success', async () => {
+				// Simulate the race condition: main already wrote 'canceled' to DB while
+				// the worker was still running. updateExistingExecution returns false because
+				// the requireNotCanceled condition is not met.
+				executionRepository.updateExistingExecution.mockResolvedValueOnce(false);
+
+				const lifecycleHooks = createHooks('trigger');
+
+				await lifecycleHooks.runHook('workflowExecuteAfter', [successfulRun, {}]);
+
+				// The guard condition was passed to the DB call
+				expect(executionRepository.updateExistingExecution).toHaveBeenCalledWith(
+					executionId,
+					expect.any(Object),
+					{ requireNotCanceled: true },
+				);
+				// Should bail out after the first failed update - no retry-success write
+				expect(executionRepository.updateExistingExecution).toHaveBeenCalledTimes(1);
 			});
 		});
 	});

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -508,13 +508,35 @@ function hookFunctionsSaveWorker(
 				fullExecutionData.data.pushRef = pushRef;
 			}
 
-			// In scaling mode, worker saves execution without metadata
-			// Main process will save metadata after deletion decisions to avoid FK violations
-			await updateExistingExecution({
-				executionId: this.executionId,
-				workflowId: this.workflowData.id,
-				executionData: fullExecutionData,
-			});
+			// In scaling mode, worker saves execution without metadata.
+			// Main process will save metadata after deletion decisions to avoid FK violations.
+			//
+			// Use `requireNotCanceled` so the worker never overwrites a 'canceled' status
+			// that was set by the main instance (e.g. via stopDuringRun).  This prevents a
+			// race condition where the main writes 'canceled' to the DB while the worker is
+			// still running and later overwrites it with 'success'.
+			const updated = await Container.get(ExecutionRepository).updateExistingExecution(
+				this.executionId,
+				fullExecutionData,
+				{ requireNotCanceled: true },
+			);
+
+			if (!updated) {
+				logger.debug(
+					'Worker skipped saving execution result: execution was already cancelled',
+					{
+						executionId: this.executionId,
+						workflowId: this.workflowData.id,
+					},
+				);
+				return;
+			}
+
+			if (fullExecutionData.finished === true && fullExecutionData.retryOf !== undefined) {
+				await Container.get(ExecutionRepository).updateExistingExecution(fullExecutionData.retryOf, {
+					retrySuccessId: this.executionId,
+				});
+			}
 		} finally {
 			workflowStatisticsService.emit('workflowExecutionCompleted', {
 				workflowData: this.workflowData,

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -13,7 +13,7 @@ import {
 	ExecutionRepository,
 	WorkflowRepository,
 } from '@n8n/db';
-import { Service } from '@n8n/di';
+import { Container, Service } from '@n8n/di';
 import { validate as jsonSchemaValidate } from 'jsonschema';
 import type {
 	ExecutionError,
@@ -577,10 +577,20 @@ export class ExecutionService {
 
 	private async stopInScalingMode(execution: IExecutionResponse) {
 		if (this.activeExecutions.has(execution.id)) {
+			// This main instance tracks the execution: cancel the local PCancelable, which
+			// will fire the onCancel handler in workflow-runner.ts and send abort-job to the
+			// worker via the Bull queue.
 			this.activeExecutions.stopExecution(
 				execution.id,
 				new ManualExecutionCancelledError(execution.id),
 			);
+		} else {
+			// The execution is running on a worker but is not tracked by this main instance
+			// (e.g. in a multi-main setup the cancel request arrived at a different main than
+			// the one that enqueued the job).  Send the abort signal directly to the worker
+			// via the queue so it receives the cancellation and stops executing.
+			const { ScalingService } = await import('@/scaling/scaling.service');
+			await Container.get(ScalingService).stopJobByExecutionId(execution.id);
 		}
 
 		if (this.waitTracker.has(execution.id)) {

--- a/packages/cli/src/scaling/__tests__/scaling.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/scaling.service.test.ts
@@ -324,6 +324,50 @@ describe('ScalingService', () => {
 		});
 	});
 
+	describe('stopJobByExecutionId', () => {
+		it('should find and stop the active job for the given execution ID', async () => {
+			await scalingService.setupQueue();
+			const executionId = 'exec-to-cancel';
+			const activeJob = mock<Job>({
+				data: mock<JobData>({ executionId }),
+				isActive: jest.fn().mockResolvedValue(true),
+			});
+			const otherJob = mock<Job>({
+				data: mock<JobData>({ executionId: 'other-exec' }),
+				isActive: jest.fn().mockResolvedValue(true),
+			});
+			queue.getJobs.mockResolvedValue([activeJob, otherJob]);
+
+			const result = await scalingService.stopJobByExecutionId(executionId);
+
+			expect(result).toBe(true);
+			expect(activeJob.progress).toHaveBeenCalledWith({ kind: 'abort-job' });
+			expect(activeJob.discard).toHaveBeenCalled();
+			expect(activeJob.moveToFailed).toHaveBeenCalled();
+			expect(otherJob.progress).not.toHaveBeenCalled();
+		});
+
+		it('should return false when no active job exists for the execution ID', async () => {
+			await scalingService.setupQueue();
+			queue.getJobs.mockResolvedValue([
+				mock<Job>({ data: mock<JobData>({ executionId: 'different-exec' }) }),
+			]);
+
+			const result = await scalingService.stopJobByExecutionId('exec-to-cancel');
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false when the queue has no active jobs at all', async () => {
+			await scalingService.setupQueue();
+			queue.getJobs.mockResolvedValue([]);
+
+			const result = await scalingService.stopJobByExecutionId('exec-to-cancel');
+
+			expect(result).toBe(false);
+		});
+	});
+
 	describe('message handling', () => {
 		it('should handle send-chunk messages', async () => {
 			const activeExecutions = mock<ActiveExecutions>();

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -261,6 +261,27 @@ export class ScalingService {
 		}
 	}
 
+	/**
+	 * Stop a job by its execution ID, without requiring a job reference.
+	 *
+	 * Used when the current main instance does not track the execution locally,
+	 * e.g. in a multi-main setup where the cancel request arrives at a different
+	 * main than the one that enqueued the job. Finds the active or waiting Bull
+	 * job whose `data.executionId` matches and delegates to `stopJob`.
+	 */
+	async stopJobByExecutionId(executionId: string): Promise<boolean> {
+		const activeJobs = await this.findJobsByStatus(['active', 'waiting']);
+		const job = activeJobs.find((j) => j.data.executionId === executionId);
+
+		if (!job) {
+			this.logger.debug('No active job found to stop for execution', { executionId });
+			return false;
+		}
+
+		this.logger.debug('Stopping job by execution ID', { executionId, jobId: job.id });
+		return await this.stopJob(job);
+	}
+
 	getRunningJobsCount() {
 		return this.jobProcessor.getRunningJobIds().length;
 	}


### PR DESCRIPTION
## Summary

This PR fixes a critical issue in queue mode with separate workers where cancelling an execution via the UI or API does not actually stop the workflow running on the worker.

## Related Linear tickets, Github issues, and Community forum posts

Fixes https://github.com/n8n-io/n8n/issues/25165#issue-3885647626


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
