### PR TITLE
fix(Google Nodes): Fix mimeType handling when uploading binary data from filesystem

### DIFF
--- a/packages/nodes-base/nodes/Google/CloudStorage/ObjectDescription.ts
+++ b/packages/nodes-base/nodes/Google/CloudStorage/ObjectDescription.ts
@@ -162,7 +162,7 @@ export const objectOperations: INodeProperties[] = [
 									if (binaryData.id) {
 										content = await this.helpers.getBinaryStream(binaryData.id);
 										const binaryMetadata = await this.helpers.getBinaryMetadata(binaryData.id);
-										contentType = binaryMetadata.mimeType ?? 'application/octet-stream';
+										contentType = binaryData.mimeType ?? binaryMetadata.mimeType ?? 'application/octet-stream';
 										contentLength = binaryMetadata.fileSize;
 									} else {
 										content = Buffer.from(binaryData.data, BINARY_ENCODING);

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/utils.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/utils.test.ts
@@ -1,4 +1,8 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+import { Readable } from 'stream';
+
 import {
+	getItemBinaryData,
 	prepareQueryString,
 	setFileProperties,
 	setUpdateCommonParams,
@@ -121,5 +125,133 @@ describe('test GoogleDriveV2, setUpdateCommonParams', () => {
 			keepRevisionForever: true,
 			ocrLanguage: 'en',
 		});
+	});
+});
+
+describe('test GoogleDriveV2, getItemBinaryData', () => {
+	let mockExecuteFunctions: jest.Mocked<IExecuteFunctions>;
+
+	beforeEach(() => {
+		mockExecuteFunctions = {
+			getNode: jest.fn().mockReturnValue({ name: 'Google Drive' }),
+			helpers: {
+				assertBinaryData: jest.fn(),
+				getBinaryStream: jest.fn(),
+				getBinaryMetadata: jest.fn(),
+			},
+		} as unknown as jest.Mocked<IExecuteFunctions>;
+	});
+
+	it('should use binaryData.mimeType when data is stored in-memory (no binaryData.id)', async () => {
+		const binaryData = {
+			data: Buffer.from('file content').toString('base64'),
+			mimeType: 'application/pdf',
+			fileName: 'document.pdf',
+		};
+
+		(mockExecuteFunctions.helpers.assertBinaryData as jest.Mock).mockReturnValue(binaryData);
+
+		const result = await getItemBinaryData.call(mockExecuteFunctions, 'data', 0);
+
+		expect(result.mimeType).toBe('application/pdf');
+		expect(result.originalFilename).toBe('document.pdf');
+		// Should not call getBinaryStream or getBinaryMetadata for in-memory data
+		expect(mockExecuteFunctions.helpers.getBinaryStream).not.toHaveBeenCalled();
+		expect(mockExecuteFunctions.helpers.getBinaryMetadata).not.toHaveBeenCalled();
+	});
+
+	it('should use binaryData.mimeType when data is in filesystem mode (binaryData.id exists)', async () => {
+		const mockStream = new Readable({ read() {} });
+		const binaryData = {
+			id: 'file-binary-id-123',
+			mimeType: 'image/jpeg',
+			fileName: 'photo.jpg',
+		};
+		const metadata = {
+			fileSize: 102400,
+			fileName: 'photo.jpg',
+			mimeType: 'application/octet-stream', // filesystem-detected mimeType differs from user-set
+		};
+
+		(mockExecuteFunctions.helpers.assertBinaryData as jest.Mock).mockReturnValue(binaryData);
+		(mockExecuteFunctions.helpers.getBinaryStream as jest.Mock).mockResolvedValue(mockStream);
+		(mockExecuteFunctions.helpers.getBinaryMetadata as jest.Mock).mockResolvedValue(metadata);
+
+		const result = await getItemBinaryData.call(mockExecuteFunctions, 'data', 0);
+
+		// Should use binaryData.mimeType (user-set), NOT metadata.mimeType (filesystem-detected)
+		expect(result.mimeType).toBe('image/jpeg');
+		expect(result.contentLength).toBe(102400);
+		expect(result.originalFilename).toBe('photo.jpg');
+	});
+
+	it('should use binaryData.mimeType over filesystem metadata mimeType in filesystem mode', async () => {
+		const mockStream = new Readable({ read() {} });
+		const binaryData = {
+			id: 'file-binary-id-456',
+			mimeType: 'text/csv',
+			fileName: 'data.csv',
+		};
+		const metadata = {
+			fileSize: 2048,
+			fileName: 'data.csv',
+			// filesystem auto-detected a different type
+			mimeType: 'text/plain',
+		};
+
+		(mockExecuteFunctions.helpers.assertBinaryData as jest.Mock).mockReturnValue(binaryData);
+		(mockExecuteFunctions.helpers.getBinaryStream as jest.Mock).mockResolvedValue(mockStream);
+		(mockExecuteFunctions.helpers.getBinaryMetadata as jest.Mock).mockResolvedValue(metadata);
+
+		const result = await getItemBinaryData.call(mockExecuteFunctions, 'data', 0);
+
+		// binaryData.mimeType wins — this is the fix for the bug
+		expect(result.mimeType).toBe('text/csv');
+	});
+
+	it('should throw NodeOperationError when inputDataFieldName is empty', async () => {
+		await expect(getItemBinaryData.call(mockExecuteFunctions, '', 0)).rejects.toThrow(
+			'The name of the input field containing the binary file data must be set',
+		);
+	});
+
+	it('should return fileContent as Buffer for in-memory binary data', async () => {
+		const rawContent = 'hello world';
+		const binaryData = {
+			data: Buffer.from(rawContent).toString('base64'),
+			mimeType: 'text/plain',
+			fileName: 'hello.txt',
+		};
+
+		(mockExecuteFunctions.helpers.assertBinaryData as jest.Mock).mockReturnValue(binaryData);
+
+		const result = await getItemBinaryData.call(mockExecuteFunctions, 'data', 0);
+
+		expect(Buffer.isBuffer(result.fileContent)).toBe(true);
+		expect((result.fileContent as Buffer).toString()).toBe(rawContent);
+		expect(result.contentLength).toBe(Buffer.from(rawContent).length);
+	});
+
+	it('should return fileContent as stream for filesystem binary data', async () => {
+		const mockStream = new Readable({ read() {} });
+		const binaryData = {
+			id: 'file-binary-id-789',
+			mimeType: 'application/zip',
+			fileName: 'archive.zip',
+		};
+		const metadata = {
+			fileSize: 1048576,
+			fileName: 'archive.zip',
+			mimeType: 'application/zip',
+		};
+
+		(mockExecuteFunctions.helpers.assertBinaryData as jest.Mock).mockReturnValue(binaryData);
+		(mockExecuteFunctions.helpers.getBinaryStream as jest.Mock).mockResolvedValue(mockStream);
+		(mockExecuteFunctions.helpers.getBinaryMetadata as jest.Mock).mockResolvedValue(metadata);
+
+		const result = await getItemBinaryData.call(mockExecuteFunctions, 'data', 0);
+
+		expect(result.fileContent).toBe(mockStream);
+		expect(result.contentLength).toBe(1048576);
 	});
 });

--- a/packages/nodes-base/nodes/Google/Drive/v1/GoogleDriveV1.node.ts
+++ b/packages/nodes-base/nodes/Google/Drive/v1/GoogleDriveV1.node.ts
@@ -2443,7 +2443,7 @@ export class GoogleDriveV1 implements INodeType {
 								const metadata = await this.helpers.getBinaryMetadata(binaryData.id);
 								contentLength = metadata.fileSize;
 								originalFilename = metadata.fileName;
-								if (metadata.mimeType) mimeType = binaryData.mimeType;
+								mimeType = binaryData.mimeType;
 							} else {
 								fileContent = Buffer.from(binaryData.data, BINARY_ENCODING);
 								contentLength = fileContent.length;

--- a/packages/nodes-base/nodes/Google/Drive/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Google/Drive/v2/helpers/utils.ts
@@ -44,7 +44,7 @@ export async function getItemBinaryData(
 		const metadata = await this.helpers.getBinaryMetadata(binaryData.id);
 		contentLength = metadata.fileSize;
 		originalFilename = metadata.fileName;
-		if (metadata.mimeType) mimeType = binaryData.mimeType;
+		mimeType = binaryData.mimeType;
 	} else {
 		fileContent = Buffer.from(binaryData.data, BINARY_ENCODING);
 		contentLength = fileContent.length;


### PR DESCRIPTION
## Summary

Fixes incorrect mimeType handling when uploading binary data stored in filesystem mode across three Google nodes.

## Problem

When binary data is stored in filesystem mode (`binaryData.id` exists), multiple Google nodes had broken mimeType handling:

### Google Drive v1 & v2
The line:
```ts
if (metadata.mimeType) mimeType = binaryData.mimeType;
```
Had two bugs:
1. **Logic error**: The condition checks `metadata.mimeType` (auto-detected from filesystem) but assigns `binaryData.mimeType` (user-set) — making the condition pointless
2. **Undefined mimeType (v2 only)**: When `metadata.mimeType` is falsy, `mimeType` is never assigned, resulting in `undefined` being returned to the caller

### Google Cloud Storage
```ts
contentType = binaryMetadata.mimeType ?? 'application/octet-stream';
```
Ignores the user-set `binaryData.mimeType` entirely, only using the auto-detected type from filesystem metadata. This is the same class of bug as #24355.

## Fix

- **Google Drive v1 & v2**: Always assign `binaryData.mimeType` unconditionally (consistent with the `else` branch when data is in-memory)
- **Google Cloud Storage**: Prefer `binaryData.mimeType` over `binaryMetadata.mimeType`, falling back to `'application/octet-stream'`

The correct pattern (already used by HTTP Request node and YouTube channel banner upload) is to always prefer the user-set MIME type from the binary data property.

## Related

- Same class of bug as #24355 (YouTube Upload node mimeType)
- Affects Google Drive and Google Cloud Storage nodes