### PR TITLE
fix(Send Email Node): Only set inline disposition for attachments referenced in HTML body

### DIFF
--- a/packages/nodes-base/nodes/EmailSend/test/v2/send.operation.test.ts
+++ b/packages/nodes-base/nodes/EmailSend/test/v2/send.operation.test.ts
@@ -58,7 +58,9 @@ describe('Test EmailSendV2, send operation', () => {
 				.mockReturnValueOnce('Test Subject')
 				.mockReturnValueOnce('html')
 				.mockReturnValueOnce({ attachments: 'file1, file2, file3', appendAttribution: false })
-				.mockReturnValueOnce('<p>Test HTML</p>');
+				.mockReturnValueOnce(
+					'<img src="cid:file1"><img src="cid:file2"><img src="cid:file3"><p>Test HTML</p>',
+				);
 
 			(mockExecuteFunctions.helpers.assertBinaryData as jest.Mock).mockImplementation(
 				(itemIndex: number, propertyName: string) => {
@@ -112,7 +114,7 @@ describe('Test EmailSendV2, send operation', () => {
 				.mockReturnValueOnce('Test Subject')
 				.mockReturnValueOnce('html')
 				.mockReturnValueOnce({ attachments: 'file1,file2', appendAttribution: false })
-				.mockReturnValueOnce('<p>Test HTML</p>');
+				.mockReturnValueOnce('<img src="cid:file1"><img src="cid:file2"><p>Test HTML</p>');
 
 			(mockExecuteFunctions.helpers.assertBinaryData as jest.Mock).mockImplementation(
 				(itemIndex: number, propertyName: string) => {
@@ -165,7 +167,7 @@ describe('Test EmailSendV2, send operation', () => {
 				.mockReturnValueOnce('Test Subject')
 				.mockReturnValueOnce('html')
 				.mockReturnValueOnce({ attachments: '  file1  ,  file2  ', appendAttribution: false })
-				.mockReturnValueOnce('<p>Test HTML</p>');
+				.mockReturnValueOnce('<img src="cid:file1"><img src="cid:file2"><p>Test HTML</p>');
 
 			(mockExecuteFunctions.helpers.assertBinaryData as jest.Mock).mockImplementation(
 				(itemIndex: number, propertyName: string) => {
@@ -221,7 +223,7 @@ describe('Test EmailSendV2, send operation', () => {
 				.mockReturnValueOnce('Test Subject')
 				.mockReturnValueOnce('html')
 				.mockReturnValueOnce({ attachments: 'singleFile', appendAttribution: false })
-				.mockReturnValueOnce('<p>Test HTML</p>');
+				.mockReturnValueOnce('<img src="cid:singleFile"><p>Test HTML</p>');
 
 			(mockExecuteFunctions.helpers.assertBinaryData as jest.Mock).mockImplementation(
 				(itemIndex: number, propertyName: string) => {
@@ -273,7 +275,7 @@ describe('Test EmailSendV2, send operation', () => {
 				.mockReturnValueOnce('Test Subject')
 				.mockReturnValueOnce('html')
 				.mockReturnValueOnce({ attachments: 'file1, file2', appendAttribution: false })
-				.mockReturnValueOnce('<p>Test HTML</p>');
+				.mockReturnValueOnce('<img src="cid:file1"><img src="cid:file2"><p>Test HTML</p>');
 
 			(mockExecuteFunctions.helpers.assertBinaryData as jest.Mock).mockImplementation(
 				(itemIndex: number, propertyName: string) => {
@@ -380,7 +382,7 @@ describe('Test EmailSendV2, send operation', () => {
 
 			expect(transporter.sendMail).toHaveBeenCalledWith(
 				expect.objectContaining({
-					attachments: [expect.objectContaining({ filename: 'file1.txt', cid: binaryDataObject })],
+					attachments: [expect.objectContaining({ filename: 'file1.txt' })],
 				}),
 			);
 		});
@@ -480,6 +482,239 @@ describe('Test EmailSendV2, send operation', () => {
 					attachments: expect.anything(),
 				}),
 			);
+		});
+	});
+
+	describe('inline attachment cid disposition', () => {
+		it('should NOT set cid on attachment when HTML body does not reference it', async () => {
+			const items = [
+				{
+					json: { data: 'test' },
+					binary: {
+						attachment: {
+							data: 'data1',
+							mimeType: 'application/pdf',
+							fileName: 'document.pdf',
+						} as IBinaryData,
+					} as Record<string, IBinaryData>,
+				},
+			];
+
+			mockExecuteFunctions.getInputData.mockReturnValue(items);
+			mockExecuteFunctions.getNode.mockReturnValue({ typeVersion: 2.0 } as any);
+			mockExecuteFunctions.getInstanceId.mockReturnValue('instanceId');
+			mockExecuteFunctions.getCredentials.mockResolvedValue({
+				host: 'smtp.example.com',
+				port: 587,
+			});
+
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('from@example.com')
+				.mockReturnValueOnce('to@example.com')
+				.mockReturnValueOnce('Test Subject')
+				.mockReturnValueOnce('html')
+				.mockReturnValueOnce({ attachments: 'attachment', appendAttribution: false })
+				// HTML body does NOT reference the attachment via cid
+				.mockReturnValueOnce('<p>Please find the document attached.</p>');
+
+			(mockExecuteFunctions.helpers.assertBinaryData as jest.Mock).mockImplementation(
+				(itemIndex: number, propertyName: string) => {
+					return items[itemIndex].binary![propertyName];
+				},
+			);
+
+			(mockExecuteFunctions.helpers.getBinaryDataBuffer as jest.Mock).mockImplementation(
+				async (itemIndex: number, propertyName: string) => {
+					return Buffer.from(items[itemIndex].binary![propertyName].data);
+				},
+			);
+
+			transporter.sendMail.mockResolvedValue({ messageId: 'test-id' });
+
+			await sendOperation.execute.call(mockExecuteFunctions);
+
+			// The attachment should NOT have cid set — it's a regular attachment, not inline
+			expect(transporter.sendMail).toHaveBeenCalledWith(
+				expect.objectContaining({
+					attachments: [
+						expect.objectContaining({ filename: 'document.pdf' }),
+					],
+				}),
+			);
+			const callArgs = transporter.sendMail.mock.calls[0][0];
+			expect(callArgs.attachments[0]).not.toHaveProperty('cid');
+		});
+
+		it('should set cid on attachment when HTML body references it via cid:', async () => {
+			const items = [
+				{
+					json: { data: 'test' },
+					binary: {
+						logo: {
+							data: 'imagedata',
+							mimeType: 'image/png',
+							fileName: 'logo.png',
+						} as IBinaryData,
+					} as Record<string, IBinaryData>,
+				},
+			];
+
+			mockExecuteFunctions.getInputData.mockReturnValue(items);
+			mockExecuteFunctions.getNode.mockReturnValue({ typeVersion: 2.0 } as any);
+			mockExecuteFunctions.getInstanceId.mockReturnValue('instanceId');
+			mockExecuteFunctions.getCredentials.mockResolvedValue({
+				host: 'smtp.example.com',
+				port: 587,
+			});
+
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('from@example.com')
+				.mockReturnValueOnce('to@example.com')
+				.mockReturnValueOnce('Test Subject')
+				.mockReturnValueOnce('html')
+				.mockReturnValueOnce({ attachments: 'logo', appendAttribution: false })
+				// HTML body DOES reference the attachment via cid:logo
+				.mockReturnValueOnce('<p>Hello</p><img src="cid:logo" />');
+
+			(mockExecuteFunctions.helpers.assertBinaryData as jest.Mock).mockImplementation(
+				(itemIndex: number, propertyName: string) => {
+					return items[itemIndex].binary![propertyName];
+				},
+			);
+
+			(mockExecuteFunctions.helpers.getBinaryDataBuffer as jest.Mock).mockImplementation(
+				async (itemIndex: number, propertyName: string) => {
+					return Buffer.from(items[itemIndex].binary![propertyName].data);
+				},
+			);
+
+			transporter.sendMail.mockResolvedValue({ messageId: 'test-id' });
+
+			await sendOperation.execute.call(mockExecuteFunctions);
+
+			// The attachment SHOULD have cid set — it's referenced inline in the HTML
+			expect(transporter.sendMail).toHaveBeenCalledWith(
+				expect.objectContaining({
+					attachments: [expect.objectContaining({ filename: 'logo.png', cid: 'logo' })],
+				}),
+			);
+		});
+
+		it('should set cid only on attachments referenced in the HTML body (mixed case)', async () => {
+			const items = [
+				{
+					json: { data: 'test' },
+					binary: {
+						inlineImage: {
+							data: 'imagedata',
+							mimeType: 'image/png',
+							fileName: 'banner.png',
+						} as IBinaryData,
+						regularAttachment: {
+							data: 'pdfdata',
+							mimeType: 'application/pdf',
+							fileName: 'report.pdf',
+						} as IBinaryData,
+					} as Record<string, IBinaryData>,
+				},
+			];
+
+			mockExecuteFunctions.getInputData.mockReturnValue(items);
+			mockExecuteFunctions.getNode.mockReturnValue({ typeVersion: 2.0 } as any);
+			mockExecuteFunctions.getInstanceId.mockReturnValue('instanceId');
+			mockExecuteFunctions.getCredentials.mockResolvedValue({
+				host: 'smtp.example.com',
+				port: 587,
+			});
+
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('from@example.com')
+				.mockReturnValueOnce('to@example.com')
+				.mockReturnValueOnce('Test Subject')
+				.mockReturnValueOnce('html')
+				.mockReturnValueOnce({
+					attachments: 'inlineImage, regularAttachment',
+					appendAttribution: false,
+				})
+				// HTML references inlineImage but NOT regularAttachment
+				.mockReturnValueOnce('<img src="cid:inlineImage"><p>See the attached report.</p>');
+
+			(mockExecuteFunctions.helpers.assertBinaryData as jest.Mock).mockImplementation(
+				(itemIndex: number, propertyName: string) => {
+					return items[itemIndex].binary![propertyName];
+				},
+			);
+
+			(mockExecuteFunctions.helpers.getBinaryDataBuffer as jest.Mock).mockImplementation(
+				async (itemIndex: number, propertyName: string) => {
+					return Buffer.from(items[itemIndex].binary![propertyName].data);
+				},
+			);
+
+			transporter.sendMail.mockResolvedValue({ messageId: 'test-id' });
+
+			await sendOperation.execute.call(mockExecuteFunctions);
+
+			const callArgs = transporter.sendMail.mock.calls[0][0];
+
+			// inlineImage should have cid set (referenced in HTML)
+			expect(callArgs.attachments[0]).toMatchObject({ filename: 'banner.png', cid: 'inlineImage' });
+
+			// regularAttachment should NOT have cid set (not referenced in HTML)
+			expect(callArgs.attachments[1]).toMatchObject({ filename: 'report.pdf' });
+			expect(callArgs.attachments[1]).not.toHaveProperty('cid');
+		});
+
+		it('should not set cid on attachments when email format is text (no HTML body)', async () => {
+			const items = [
+				{
+					json: { data: 'test' },
+					binary: {
+						attachment: {
+							data: 'data1',
+							mimeType: 'application/pdf',
+							fileName: 'document.pdf',
+						} as IBinaryData,
+					} as Record<string, IBinaryData>,
+				},
+			];
+
+			mockExecuteFunctions.getInputData.mockReturnValue(items);
+			mockExecuteFunctions.getNode.mockReturnValue({ typeVersion: 2.0 } as any);
+			mockExecuteFunctions.getInstanceId.mockReturnValue('instanceId');
+			mockExecuteFunctions.getCredentials.mockResolvedValue({
+				host: 'smtp.example.com',
+				port: 587,
+			});
+
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('from@example.com')
+				.mockReturnValueOnce('to@example.com')
+				.mockReturnValueOnce('Test Subject')
+				.mockReturnValueOnce('text') // text format — no HTML body
+				.mockReturnValueOnce({ attachments: 'attachment', appendAttribution: false })
+				.mockReturnValueOnce('Please find the document attached.'); // plain text
+
+			(mockExecuteFunctions.helpers.assertBinaryData as jest.Mock).mockImplementation(
+				(itemIndex: number, propertyName: string) => {
+					return items[itemIndex].binary![propertyName];
+				},
+			);
+
+			(mockExecuteFunctions.helpers.getBinaryDataBuffer as jest.Mock).mockImplementation(
+				async (itemIndex: number, propertyName: string) => {
+					return Buffer.from(items[itemIndex].binary![propertyName].data);
+				},
+			);
+
+			transporter.sendMail.mockResolvedValue({ messageId: 'test-id' });
+
+			await sendOperation.execute.call(mockExecuteFunctions);
+
+			const callArgs = transporter.sendMail.mock.calls[0][0];
+
+			// In text-format email, no inline embedding possible — no cid should be set
+			expect(callArgs.attachments[0]).not.toHaveProperty('cid');
 		});
 	});
 });

--- a/packages/nodes-base/nodes/EmailSend/v2/send.operation.ts
+++ b/packages/nodes-base/nodes/EmailSend/v2/send.operation.ts
@@ -237,14 +237,22 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 			if (options.attachments && item.binary) {
 				const attachments = [];
 				const attachmentProperties = prepareBinariesDataList(options.attachments);
+				const htmlBody = typeof mailOptions.html === 'string' ? mailOptions.html : '';
 
 				for (const propertyName of attachmentProperties) {
 					const binaryData = this.helpers.assertBinaryData(itemIndex, propertyName);
-					attachments.push({
+					const attachment: { [key: string]: string | Buffer } = {
 						filename: binaryData.fileName || 'unknown',
 						content: await this.helpers.getBinaryDataBuffer(itemIndex, propertyName),
-						cid: propertyName,
-					});
+					};
+
+					// Only mark as inline (set cid) if the HTML body references this attachment
+					// via cid:propertyName. Otherwise, send as a regular attachment.
+					if (htmlBody.includes(`cid:${propertyName}`)) {
+						attachment.cid = propertyName;
+					}
+
+					attachments.push(attachment);
 				}
 
 				if (attachments.length) {


### PR DESCRIPTION
## Summary

Fixes #24333 — Send Email node always marks images as inline attachments.

## Problem

In the Send Email node v2, every attachment is unconditionally given a `cid` (Content-ID) property:

```ts
attachments.push({
    filename: binaryData.fileName || 'unknown',
    content: await this.helpers.getBinaryDataBuffer(itemIndex, propertyName),
    cid: propertyName, // ← always set
});
```

When nodemailer sees `cid` on an attachment, it sets `Content-Disposition: inline`, causing email clients like Microsoft Outlook and OWA to hide the attachment from the attachments list. The images appear embedded in the body (or not at all if not referenced).

**This is a v2 regression** — the v1 Send Email node never set `cid` on attachments.

## Fix

Auto-detect whether an attachment should be inline or regular:

```ts
// Only mark as inline (set cid) if the HTML body references this attachment
if (htmlBody.includes(`cid:${propertyName}`)) {
    attachment.cid = propertyName;
}
```

- If the HTML body references the attachment via `cid:<propertyName>` (e.g., `<img src="cid:image_1">`), it is marked as inline
- Otherwise, it is sent as a regular attachment with proper `Content-Disposition: attachment`

## Backward Compatibility

✅ **Fully backward-compatible:**
- Users who embed images with `<img src="cid:image_1">` continue to work exactly as before
- Users who just attach files now get correct attachment disposition
- No new options or UI changes needed — the fix is automatic