### PR TITLE
fix(ai-builder): Fix CodeBuilder parse failures and think-loop

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/code-builder/code-builder-agent.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/code-builder/code-builder-agent.ts
@@ -644,12 +644,14 @@ export class CodeBuilderAgent {
 		if (state.consecutiveThinkOnlyCalls >= MAX_CONSECUTIVE_THINK_ONLY) {
 			state.consecutiveThinkOnlyCalls = 0;
 			messages.push(
-				new HumanMessage(
-					'You have been reasoning without making changes for several iterations. ' +
+				new HumanMessage({
+					content:
+						'You have been reasoning without making changes for several iterations. ' +
 						'You MUST now either: (1) use batch_str_replace or str_replace to fix the code, ' +
 						'or (2) simplify the workflow by removing the problematic node. ' +
 						'Do NOT call the think tool again until you have made a code change.',
-				),
+					additional_kwargs: { validationMessage: true },
+				}),
 			);
 		}
 

--- a/packages/@n8n/ai-workflow-builder.ee/src/code-builder/code-builder-agent.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/code-builder/code-builder-agent.ts
@@ -11,6 +11,7 @@
 import type { CallbackManagerForChainRun } from '@langchain/core/callbacks/manager';
 import { CallbackManager } from '@langchain/core/callbacks/manager';
 import type { AIMessage, BaseMessage } from '@langchain/core/messages';
+import { HumanMessage } from '@langchain/core/messages';
 import type { StructuredToolInterface } from '@langchain/core/tools';
 import type { Logger } from '@n8n/backend-common';
 import type { WorkflowJSON } from '@n8n/workflow-sdk';
@@ -30,6 +31,7 @@ import {
 	CODE_BUILDER_SEARCH_NODES_TOOL,
 	CODE_BUILDER_THINK_TOOL,
 	MAX_AGENT_ITERATIONS,
+	MAX_CONSECUTIVE_THINK_ONLY,
 	MAX_VALIDATE_ATTEMPTS,
 } from './constants';
 import { AgentIterationHandler } from './handlers/agent-iteration-handler';
@@ -424,6 +426,7 @@ export class CodeBuilderAgent {
 			warningTracker: new WarningTracker(),
 			outputTrace: [],
 			hasUnvalidatedEdits: false,
+			consecutiveThinkOnlyCalls: 0,
 		};
 
 		// Pre-validate existing workflow to discover pre-existing warnings
@@ -631,6 +634,25 @@ export class CodeBuilderAgent {
 			warningTracker: state.warningTracker,
 		});
 
+		// Track consecutive think-only iterations
+		if (dispatchResult.allThinkOnly) {
+			state.consecutiveThinkOnlyCalls++;
+		} else {
+			state.consecutiveThinkOnlyCalls = 0;
+		}
+
+		if (state.consecutiveThinkOnlyCalls >= MAX_CONSECUTIVE_THINK_ONLY) {
+			state.consecutiveThinkOnlyCalls = 0;
+			messages.push(
+				new HumanMessage(
+					'You have been reasoning without making changes for several iterations. ' +
+						'You MUST now either: (1) use batch_str_replace or str_replace to fix the code, ' +
+						'or (2) simplify the workflow by removing the problematic node. ' +
+						'Do NOT call the think tool again until you have made a code change.',
+				),
+			);
+		}
+
 		// Update state from dispatch result
 		if (dispatchResult.hasUnvalidatedEdits !== undefined) {
 			state.hasUnvalidatedEdits = dispatchResult.hasUnvalidatedEdits;
@@ -785,4 +807,6 @@ interface AgenticLoopState {
 	outputTrace: TraceEntry[];
 	/** Whether the agent has made code edits that haven't been followed by validation */
 	hasUnvalidatedEdits: boolean;
+	/** Number of consecutive iterations where the only tool calls were 'think' */
+	consecutiveThinkOnlyCalls: number;
 }

--- a/packages/@n8n/ai-workflow-builder.ee/src/code-builder/constants.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/code-builder/constants.ts
@@ -14,12 +14,15 @@ export const MAX_VALIDATE_ATTEMPTS = 10;
 
 /** Instruction appended to validation/parse error messages with steps to fix */
 export const FIX_VALIDATION_ERRORS_INSTRUCTION = `
-Use the think tool to analyze ALL errors at once, then act:
+Use the think tool to analyze the errors, then use the editor tool to apply fixes:
 1. Which errors are relevant to the last user request? If NONE, stop — do not fix unrelated warnings.
 2. Use search_nodes and get_node_types to look up the correct node schema (if not already fetched)
 3. Use batch_str_replace to fix ALL identified issues atomically in one call (preferred), or use individual str_replace/insert calls
 4. Call validate_workflow ONCE after all fixes are applied
 Do NOT output explanations — just fix the code. Do not add or edit comments.`;
+
+/** Maximum consecutive think-only iterations before forcing an action */
+export const MAX_CONSECUTIVE_THINK_ONLY = 3;
 
 /** Native Anthropic text editor tool configuration */
 export const TEXT_EDITOR_TOOL = {

--- a/packages/@n8n/ai-workflow-builder.ee/src/code-builder/handlers/test/tool-dispatch-handler.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/code-builder/handlers/test/tool-dispatch-handler.test.ts
@@ -993,6 +993,128 @@ describe('ToolDispatchHandler', () => {
 		});
 	});
 
+	describe('allThinkOnly tracking', () => {
+		async function drainGenerator(
+			gen: AsyncGenerator<StreamOutput, ToolDispatchResult, unknown>,
+		): Promise<ToolDispatchResult> {
+			let result = await gen.next();
+			while (!result.done) {
+				result = await gen.next();
+			}
+			return result.value;
+		}
+
+		it('should return allThinkOnly=true when every tool call is think', async () => {
+			const thinkTool = {
+				name: 'think',
+				invoke: jest.fn().mockResolvedValue('thinking...'),
+			} as unknown as StructuredToolInterface;
+
+			const handler = createHandler(new Map([['think', thinkTool]]));
+
+			const result = await drainGenerator(
+				handler.dispatch({
+					toolCalls: [
+						{ id: 'tc-1', name: 'think', args: { thought: 'hmm' } },
+						{ id: 'tc-2', name: 'think', args: { thought: 'still thinking' } },
+					],
+					messages: [],
+					iteration: 1,
+					warningTracker: new WarningTracker(),
+				}),
+			);
+
+			expect(result.allThinkOnly).toBe(true);
+		});
+
+		it('should return allThinkOnly=true for a single think call', async () => {
+			const thinkTool = {
+				name: 'think',
+				invoke: jest.fn().mockResolvedValue('thinking...'),
+			} as unknown as StructuredToolInterface;
+
+			const handler = createHandler(new Map([['think', thinkTool]]));
+
+			const result = await drainGenerator(
+				handler.dispatch({
+					toolCalls: [{ id: 'tc-1', name: 'think', args: { thought: 'hmm' } }],
+					messages: [],
+					iteration: 1,
+					warningTracker: new WarningTracker(),
+				}),
+			);
+
+			expect(result.allThinkOnly).toBe(true);
+		});
+
+		it('should return allThinkOnly=false when think is mixed with other tools', async () => {
+			const thinkTool = {
+				name: 'think',
+				invoke: jest.fn().mockResolvedValue('thinking...'),
+			} as unknown as StructuredToolInterface;
+			const searchTool = {
+				name: 'search_nodes',
+				invoke: jest.fn().mockResolvedValue('results'),
+			} as unknown as StructuredToolInterface;
+
+			const handler = createHandler(
+				new Map([
+					['think', thinkTool],
+					['search_nodes', searchTool],
+				]),
+			);
+
+			const result = await drainGenerator(
+				handler.dispatch({
+					toolCalls: [
+						{ id: 'tc-1', name: 'think', args: { thought: 'hmm' } },
+						{ id: 'tc-2', name: 'search_nodes', args: { query: 'http' } },
+					],
+					messages: [],
+					iteration: 1,
+					warningTracker: new WarningTracker(),
+				}),
+			);
+
+			expect(result.allThinkOnly).toBe(false);
+		});
+
+		it('should return allThinkOnly=false when no tool calls are think', async () => {
+			const searchTool = {
+				name: 'search_nodes',
+				invoke: jest.fn().mockResolvedValue('results'),
+			} as unknown as StructuredToolInterface;
+
+			const handler = createHandler(new Map([['search_nodes', searchTool]]));
+
+			const result = await drainGenerator(
+				handler.dispatch({
+					toolCalls: [{ id: 'tc-1', name: 'search_nodes', args: { query: 'http' } }],
+					messages: [],
+					iteration: 1,
+					warningTracker: new WarningTracker(),
+				}),
+			);
+
+			expect(result.allThinkOnly).toBe(false);
+		});
+
+		it('should return allThinkOnly=false when tool calls list is empty', async () => {
+			const handler = createHandler(new Map());
+
+			const result = await drainGenerator(
+				handler.dispatch({
+					toolCalls: [],
+					messages: [],
+					iteration: 1,
+					warningTracker: new WarningTracker(),
+				}),
+			);
+
+			expect(result.allThinkOnly).toBe(false);
+		});
+	});
+
 	describe('parseReplacements', () => {
 		it('should pass through a valid array', () => {
 			const input = [{ old_str: 'a', new_str: 'b' }];

--- a/packages/@n8n/ai-workflow-builder.ee/src/code-builder/handlers/tool-dispatch-handler.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/code-builder/handlers/tool-dispatch-handler.ts
@@ -99,6 +99,8 @@ export interface ToolDispatchResult {
 	validatePassedThisIteration: boolean;
 	/** undefined = no edits or validations this iteration */
 	hasUnvalidatedEdits?: boolean;
+	/** true if every tool call in this iteration was 'think' */
+	allThinkOnly: boolean;
 }
 
 /**
@@ -196,6 +198,8 @@ export class ToolDispatchHandler {
 			}
 		}
 
+		const allThinkOnly = toolCalls.length > 0 && toolCalls.every((tc) => tc.name === 'think');
+
 		return {
 			workflow,
 			workflowReady,
@@ -203,6 +207,7 @@ export class ToolDispatchHandler {
 			parseDuration,
 			validatePassedThisIteration,
 			hasUnvalidatedEdits,
+			allThinkOnly,
 		};
 	}
 

--- a/packages/@n8n/ai-workflow-builder.ee/src/code-builder/test/code-builder-agent-think-loop.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/code-builder/test/code-builder-agent-think-loop.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Tests for CodeBuilderAgent think-loop circuit breaker.
+ *
+ * Verifies that when the agent calls only the `think` tool for
+ * MAX_CONSECUTIVE_THINK_ONLY iterations, a HumanMessage is injected
+ * to force it to take an action.
+ */
+
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
+import { AIMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { WorkflowJSON } from '@n8n/workflow-sdk';
+
+import { CodeBuilderAgent } from '../code-builder-agent';
+import { MAX_CONSECUTIVE_THINK_ONLY } from '../constants';
+
+// Mock workflow-sdk to control parse/validate behavior
+jest.mock('@n8n/workflow-sdk', () => ({
+	parseWorkflowCodeToBuilder: jest.fn(),
+	validateWorkflow: jest.fn(),
+	generateWorkflowCode: jest.fn().mockReturnValue('// generated code'),
+}));
+
+// Mock the prompts module to avoid complex prompt building
+jest.mock('../prompts', () => ({
+	buildCodeBuilderPrompt: jest.fn().mockReturnValue({
+		formatMessages: jest.fn().mockResolvedValue([]),
+	}),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { parseWorkflowCodeToBuilder, validateWorkflow } = require('@n8n/workflow-sdk') as {
+	parseWorkflowCodeToBuilder: jest.Mock;
+	validateWorkflow: jest.Mock;
+};
+
+const MOCK_WORKFLOW: WorkflowJSON = {
+	id: 'test-wf-1',
+	name: 'Test Workflow',
+	nodes: [
+		{
+			id: 'node-1',
+			name: 'Manual Trigger',
+			type: 'n8n-nodes-base.manualTrigger',
+			typeVersion: 1.1,
+			position: [240, 300],
+			parameters: {},
+		},
+	],
+	connections: {},
+} as unknown as WorkflowJSON;
+
+function createMockBuilder() {
+	return {
+		regenerateNodeIds: jest.fn(),
+		validate: jest.fn().mockReturnValue({ valid: true, errors: [], warnings: [] }),
+		generatePinData: jest.fn(),
+		toJSON: jest.fn().mockReturnValue(MOCK_WORKFLOW),
+	};
+}
+
+/**
+ * Extract the text content from a message, handling both plain string content
+ * and multi-part content arrays (produced by applySubgraphCacheMarkers).
+ */
+function getTextContent(msg: BaseMessage): string {
+	if (typeof msg.content === 'string') return msg.content;
+	if (Array.isArray(msg.content)) {
+		return msg.content
+			.filter((b): b is { type: 'text'; text: string } => typeof b === 'object' && 'text' in b)
+			.map((b) => b.text)
+			.join('');
+	}
+	return '';
+}
+
+describe('CodeBuilderAgent think-loop circuit breaker', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		parseWorkflowCodeToBuilder.mockReturnValue(createMockBuilder());
+		validateWorkflow.mockReturnValue({ valid: true, errors: [], warnings: [] });
+	});
+
+	it(`should inject a forced-action HumanMessage after ${MAX_CONSECUTIVE_THINK_ONLY} consecutive think-only iterations`, async () => {
+		let callCount = 0;
+
+		// Snapshot messages at each LLM invocation (the array is mutated in-place,
+		// so we must shallow-copy at call time to inspect later)
+		const messageSnapshots: unknown[][] = [];
+
+		// First N calls: return think-only tool calls
+		// Call after injection: return final code response
+		const mockLlm = {
+			bindTools: jest.fn().mockReturnValue({
+				invoke: jest.fn().mockImplementation((messages: unknown[]) => {
+					messageSnapshots.push([...messages]);
+					callCount++;
+
+					if (callCount <= MAX_CONSECUTIVE_THINK_ONLY) {
+						return new AIMessage({
+							content: '',
+							tool_calls: [
+								{
+									name: 'think',
+									args: { thought: `thinking iteration ${callCount}` },
+									id: `tc-think-${callCount}`,
+									type: 'tool_call' as const,
+								},
+							],
+							response_metadata: { usage: { input_tokens: 50, output_tokens: 20 } },
+						});
+					}
+
+					// After forced-action message, return code
+					return new AIMessage({
+						content: '```typescript\nconst workflow = builder.addNode(...);\n```',
+						tool_calls: [],
+						response_metadata: { usage: { input_tokens: 200, output_tokens: 100 } },
+					});
+				}),
+			}),
+		} as unknown as BaseChatModel;
+
+		const agent = new CodeBuilderAgent({
+			llm: mockLlm,
+			nodeTypes: [],
+			enableTextEditor: false,
+		});
+
+		const chunks = [];
+		for await (const chunk of agent.chat(
+			{ id: 'msg-think-loop', message: 'Create a workflow' },
+			'user-1',
+		)) {
+			chunks.push(chunk);
+		}
+
+		// The agent should have completed (produced a workflow)
+		const workflowChunk = chunks.find((c) =>
+			c.messages?.some((m) => 'type' in m && m.type === 'workflow-updated'),
+		);
+		expect(workflowChunk).toBeDefined();
+
+		// The HumanMessage is injected AFTER the 3rd think-only dispatch returns,
+		// so it appears in the messages for the (MAX_CONSECUTIVE_THINK_ONLY + 1)th call.
+		// Verify we had enough invocations.
+		expect(messageSnapshots.length).toBe(MAX_CONSECUTIVE_THINK_ONLY + 1);
+
+		const postThinkSnapshot = messageSnapshots[MAX_CONSECUTIVE_THINK_ONLY] as BaseMessage[];
+
+		// Content may have been transformed to multi-part format by cache markers,
+		// so use the helper to extract text.
+		const forcedActionMessage = postThinkSnapshot.find((m) =>
+			getTextContent(m).includes('You have been reasoning without making changes'),
+		);
+
+		expect(forcedActionMessage).toBeDefined();
+	});
+
+	it('should reset think-only counter when a non-think tool is called', async () => {
+		let callCount = 0;
+		const messageSnapshots: unknown[][] = [];
+
+		const mockLlm = {
+			bindTools: jest.fn().mockReturnValue({
+				invoke: jest.fn().mockImplementation((messages: unknown[]) => {
+					messageSnapshots.push([...messages]);
+					callCount++;
+
+					// First 2 calls: think only (below threshold)
+					if (callCount <= 2) {
+						return new AIMessage({
+							content: '',
+							tool_calls: [
+								{
+									name: 'think',
+									args: { thought: `thinking ${callCount}` },
+									id: `tc-think-${callCount}`,
+									type: 'tool_call' as const,
+								},
+							],
+							response_metadata: { usage: { input_tokens: 50, output_tokens: 20 } },
+						});
+					}
+
+					// 3rd call: search_nodes (resets counter)
+					if (callCount === 3) {
+						return new AIMessage({
+							content: '',
+							tool_calls: [
+								{
+									name: 'search_nodes',
+									args: { query: 'http' },
+									id: 'tc-search-1',
+									type: 'tool_call' as const,
+								},
+							],
+							response_metadata: { usage: { input_tokens: 50, output_tokens: 20 } },
+						});
+					}
+
+					// 4th call: final code response
+					return new AIMessage({
+						content: '```typescript\nconst workflow = builder.addNode(...);\n```',
+						tool_calls: [],
+						response_metadata: { usage: { input_tokens: 200, output_tokens: 100 } },
+					});
+				}),
+			}),
+		} as unknown as BaseChatModel;
+
+		const agent = new CodeBuilderAgent({
+			llm: mockLlm,
+			nodeTypes: [],
+			enableTextEditor: false,
+		});
+
+		const chunks = [];
+		for await (const chunk of agent.chat(
+			{ id: 'msg-reset', message: 'Create a workflow' },
+			'user-1',
+		)) {
+			chunks.push(chunk);
+		}
+
+		// Should have completed successfully
+		const workflowChunk = chunks.find((c) =>
+			c.messages?.some((m) => 'type' in m && m.type === 'workflow-updated'),
+		);
+		expect(workflowChunk).toBeDefined();
+
+		// No forced-action HumanMessage should have been injected because
+		// the search_nodes call reset the counter before reaching the threshold
+		for (const snapshot of messageSnapshots) {
+			const forcedActionMsg = (snapshot as BaseMessage[]).find((m) =>
+				getTextContent(m).includes('You have been reasoning without making changes'),
+			);
+			expect(forcedActionMsg).toBeUndefined();
+		}
+	});
+});

--- a/packages/@n8n/workflow-sdk/src/ast-interpreter/interpreter.test.ts
+++ b/packages/@n8n/workflow-sdk/src/ast-interpreter/interpreter.test.ts
@@ -267,6 +267,16 @@ describe('AST Interpreter', () => {
 			expect(interpretSDKCode('export default 7 % 3;', sdkFunctions)).toBe(1);
 		});
 
+		it('should support string concatenation with +', () => {
+			expect(interpretSDKCode("export default 'hello' + ' world';", sdkFunctions)).toBe(
+				'hello world',
+			);
+			expect(interpretSDKCode("export default 'count: ' + 5;", sdkFunctions)).toBe('count: 5');
+			expect(interpretSDKCode("export default 1 + ' item';", sdkFunctions)).toBe('1 item');
+			// Multi-part concat
+			expect(interpretSDKCode("export default 'a' + 'b' + 'c';", sdkFunctions)).toBe('abc');
+		});
+
 		it('should interpret comparison operators', () => {
 			expect(interpretSDKCode('export default 5 > 3;', sdkFunctions)).toBe(true);
 			expect(interpretSDKCode('export default 5 < 3;', sdkFunctions)).toBe(false);

--- a/packages/@n8n/workflow-sdk/src/ast-interpreter/interpreter.ts
+++ b/packages/@n8n/workflow-sdk/src/ast-interpreter/interpreter.ts
@@ -561,6 +561,9 @@ class SDKInterpreter {
 
 		switch (node.operator) {
 			case '+':
+				if (typeof left === 'string' || typeof right === 'string') {
+					return String(left) + String(right);
+				}
 				return (left as number) + (right as number);
 			case '-':
 				return (left as number) - (right as number);

--- a/packages/@n8n/workflow-sdk/src/workflow-builder.test.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder.test.ts
@@ -265,6 +265,24 @@ describe('Workflow Builder', () => {
 		});
 	});
 
+	describe('.output() / .input() error guidance', () => {
+		it('should throw a clear error when calling .output() on the workflow builder', () => {
+			const t = trigger({ type: 'n8n-nodes-base.webhookTrigger', version: 1, config: {} });
+			const wf = workflow('test-id', 'Test Workflow').add(t);
+			expect(() => (wf as unknown as { output: (n: number) => void }).output(0)).toThrow(
+				'Cannot call .output() on the workflow builder',
+			);
+		});
+
+		it('should throw a clear error when calling .input() on the workflow builder', () => {
+			const t = trigger({ type: 'n8n-nodes-base.webhookTrigger', version: 1, config: {} });
+			const wf = workflow('test-id', 'Test Workflow').add(t);
+			expect(() => (wf as unknown as { input: (n: number) => void }).input(1)).toThrow(
+				'Cannot call .input() on the workflow builder',
+			);
+		});
+	});
+
 	describe('.to()', () => {
 		it('should chain nodes with connections', () => {
 			const t = trigger({ type: 'n8n-nodes-base.webhookTrigger', version: 1, config: {} });

--- a/packages/@n8n/workflow-sdk/src/workflow-builder.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder.ts
@@ -358,6 +358,20 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 		return this;
 	}
 
+	output(): never {
+		throw new Error(
+			'Cannot call .output() on the workflow builder. ' +
+				'Use .output() on a node variable instead: myNode.output(0).to(targetNode)',
+		);
+	}
+
+	input(): never {
+		throw new Error(
+			'Cannot call .input() on the workflow builder. ' +
+				'Use .input() on a node variable instead: myNode.input(1)',
+		);
+	}
+
 	settings(settings: WorkflowSettings): WorkflowBuilder {
 		this._settings = { ...this._settings, ...settings };
 		return this;


### PR DESCRIPTION
## Summary
- Add string concatenation support to AST interpreter (`+` with string operands was silently producing `NaN`, causing cascading parse errors)
- Add `.output()` / `.input()` methods on `WorkflowBuilder` that throw clear error messages guiding the agent to the correct node-level API
- Update validation prompt to explicitly direct agent toward editor tool actions after thinking
- Add think-loop circuit breaker: after 3 consecutive think-only iterations, inject a `HumanMessage` forcing the agent to make a code change

## Related Linear ticket
https://linear.app/n8n/issue/AI-2040

## Test plan
- [x] AST interpreter tests pass (87 tests) — new string concatenation tests included
- [x] WorkflowBuilder tests pass (96 tests) — new `.output()`/`.input()` error tests included
- [x] AI workflow builder tests pass (2097 tests, 126 suites)
- [x] Typecheck passes for both `@n8n/workflow-sdk` and `@n8n/ai-workflow-builder`

🤖 Generated with [Claude Code](https://claude.com/claude-code)