### PR TITLE
chore: Make codemirror-lang-html run as part of unit tests

### DIFF
--- a/packages/@n8n/codemirror-lang-html/package.json
+++ b/packages/@n8n/codemirror-lang-html/package.json
@@ -4,6 +4,7 @@
   "description": "HTML + n8n expression language support for CodeMirror 6",
   "scripts": {
     "test": "vitest run",
+    "test:unit": "vitest run",
     "build": "cm-buildhelper src/html.ts",
     "grammar:build": "lezer-generator src/grammar/html.grammar -o src/grammar/parser && rollup -c src/grammar/rollup.config.js",
     "grammar:build-debug": "lezer-generator src/grammar/html.grammar --names -o src/grammar/parser && rollup -c src/grammar/rollup.config.js",


### PR DESCRIPTION
## Summary

For some reason this package was never part of the unit test suite, added package.json entry.

## Related Linear tickets, Github issues, and Community forum posts

Following up on https://github.com/n8n-io/n8n/pull/25694#discussion_r2799424794


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
