### PR TITLE
feat(core): Allow constrained property assignment in AST interpreter in workflow-sdk

### DIFF
--- a/packages/@n8n/workflow-sdk/src/ast-interpreter/interpreter.test.ts
+++ b/packages/@n8n/workflow-sdk/src/ast-interpreter/interpreter.test.ts
@@ -433,9 +433,34 @@ describe('AST Interpreter', () => {
 			expect(() => interpretSDKCode(code, sdkFunctions)).toThrow(UnsupportedNodeError);
 		});
 
-		it('should reject assignment expressions', () => {
-			const code = 'const x = {}; x.y = 1;';
+		it('should reject bare variable reassignment', () => {
+			const code = 'const x = 1; x = 2;';
 			expect(() => interpretSDKCode(code, sdkFunctions)).toThrow(UnsupportedNodeError);
+		});
+
+		it('should reject compound assignment operators', () => {
+			const code = 'const x = { count: 0 }; x.count += 1;';
+			expect(() => interpretSDKCode(code, sdkFunctions)).toThrow(UnsupportedNodeError);
+		});
+
+		it('should reject assignment to __proto__', () => {
+			const code = 'const x = {}; x.__proto__ = {};';
+			expect(() => interpretSDKCode(code, sdkFunctions)).toThrow(SecurityError);
+		});
+
+		it('should reject assignment to prototype', () => {
+			const code = 'const x = {}; x.prototype = {};';
+			expect(() => interpretSDKCode(code, sdkFunctions)).toThrow(SecurityError);
+		});
+
+		it('should reject assignment to constructor', () => {
+			const code = 'const x = {}; x.constructor = {};';
+			expect(() => interpretSDKCode(code, sdkFunctions)).toThrow(SecurityError);
+		});
+
+		it('should reject assignment with dynamic property', () => {
+			const code = 'const x = {}; const k = "a"; x[k] = 1;';
+			expect(() => interpretSDKCode(code, sdkFunctions)).toThrow(SecurityError);
 		});
 
 		it('should reject named exports', () => {
@@ -446,6 +471,39 @@ describe('AST Interpreter', () => {
 		it('should reject return statements', () => {
 			const code = 'return 42;';
 			expect(() => interpretSDKCode(code, sdkFunctions)).toThrow();
+		});
+	});
+
+	describe('Property assignment', () => {
+		let sdkFunctions: SDKFunctions;
+
+		beforeEach(() => {
+			sdkFunctions = createMockSDKFunctions();
+		});
+
+		it('should allow single-level property assignment', () => {
+			const code = 'const x = { a: 1 }; x.config = { key: "value" }; export default x;';
+			const result = interpretSDKCode(code, sdkFunctions) as Record<string, unknown>;
+			expect(result.config).toEqual({ key: 'value' });
+		});
+
+		it('should allow nested property assignment (e.g. config.subnodes)', () => {
+			const code = `
+				const splitter = textSplitter({ type: 'test', version: 1, config: {} });
+				const docLoader = documentLoader({ type: 'test', version: 1, config: { subnodes: {} } });
+				docLoader.config.subnodes = { textSplitter: splitter };
+				export default docLoader;
+			`;
+			const result = interpretSDKCode(code, sdkFunctions) as {
+				config: { subnodes: { textSplitter: unknown } };
+			};
+			expect(result.config.subnodes.textSplitter).toBeDefined();
+		});
+
+		it('should allow literal key property assignment', () => {
+			const code = 'const x = {}; x["key"] = 42; export default x;';
+			const result = interpretSDKCode(code, sdkFunctions) as Record<string, unknown>;
+			expect(result.key).toBe(42);
 		});
 	});
 
@@ -550,6 +608,33 @@ describe('AST Interpreter', () => {
 				sdkFunctions.node as jest.Mock,
 			);
 			expect(nodeCallArgs.config.subnodes.model).toBeDefined();
+		});
+
+		it('should interpret workflow with subnodes assigned after creation', () => {
+			const code = `
+				const splitter = textSplitter({
+					type: '@n8n/n8n-nodes-langchain.textSplitterTokenSplitter',
+					version: 1,
+					config: { parameters: { chunkSize: 500 } }
+				});
+				const loader = documentLoader({
+					type: '@n8n/n8n-nodes-langchain.documentDefaultDataLoader',
+					version: 1,
+					config: { subnodes: {} }
+				});
+				loader.config.subnodes = { textSplitter: splitter };
+				export default loader;
+			`;
+			// Mock returns { type: 'documentLoader', config: <arg> }
+			// so loader.config is the full arg object passed to documentLoader()
+			const result = interpretSDKCode(code, sdkFunctions) as {
+				type: string;
+				config: { config: { subnodes: { textSplitter: { type: string } } }; subnodes: unknown };
+			};
+			// The assignment sets loader.config.subnodes (a new prop on the arg object)
+			// splitter mock wraps as { type: 'textSplitter', config: <full-arg> }
+			const subnodes = result.config.subnodes as { textSplitter: { type: string } };
+			expect(subnodes.textSplitter.type).toBe('textSplitter');
 		});
 
 		it('should interpret workflow with fromAi', () => {

--- a/packages/@n8n/workflow-sdk/src/ast-interpreter/interpreter.ts
+++ b/packages/@n8n/workflow-sdk/src/ast-interpreter/interpreter.ts
@@ -142,6 +142,8 @@ class SDKInterpreter {
 				return this.visitLogicalExpression(node);
 			case 'ConditionalExpression':
 				return this.visitConditionalExpression(node);
+			case 'AssignmentExpression':
+				return this.visitAssignmentExpression(node);
 			default:
 				throw new UnsupportedNodeError(node.type, node.loc ?? undefined, this.sourceCode);
 		}
@@ -628,6 +630,65 @@ class SDKInterpreter {
 	private visitConditionalExpression(node: ESTree.ConditionalExpression): unknown {
 		const test = this.evaluate(node.test);
 		return test ? this.evaluate(node.consequent) : this.evaluate(node.alternate);
+	}
+
+	/**
+	 * Visit an assignment expression.
+	 * Only allows simple property assignment (obj.prop = value).
+	 */
+	private visitAssignmentExpression(node: ESTree.AssignmentExpression): unknown {
+		if (node.operator !== '=') {
+			throw new UnsupportedNodeError(
+				`Assignment operator '${node.operator}' is not allowed. Only '=' is permitted.`,
+				node.loc ?? undefined,
+				this.sourceCode,
+			);
+		}
+
+		if (node.left.type !== 'MemberExpression') {
+			throw new UnsupportedNodeError(
+				'Only property assignment (e.g., obj.prop = value) is allowed. Variable reassignment is not permitted.',
+				node.loc ?? undefined,
+				this.sourceCode,
+			);
+		}
+
+		validateMemberExpression(node.left, this.sourceCode);
+
+		if (node.left.object.type === 'Super') {
+			throw new UnsupportedNodeError(
+				'super keyword is not supported in SDK code',
+				node.left.object.loc ?? undefined,
+				this.sourceCode,
+			);
+		}
+
+		const obj = this.evaluate(node.left.object);
+
+		if (obj === null || obj === undefined) {
+			throw new InterpreterError(
+				`Cannot assign property on ${String(obj)}`,
+				node.loc ?? undefined,
+				this.sourceCode,
+			);
+		}
+
+		let propName: string | number;
+		if (node.left.property.type === 'Identifier' && !node.left.computed) {
+			propName = node.left.property.name;
+		} else if (node.left.property.type === 'Literal') {
+			propName = node.left.property.value as string | number;
+		} else {
+			throw new UnsupportedNodeError(
+				'Dynamic property assignment',
+				node.left.property.loc ?? undefined,
+				this.sourceCode,
+			);
+		}
+
+		const value = this.evaluate(node.right);
+		(obj as Record<string | number, unknown>)[propName] = value;
+		return value;
 	}
 
 	/**

--- a/packages/@n8n/workflow-sdk/src/ast-interpreter/validators.ts
+++ b/packages/@n8n/workflow-sdk/src/ast-interpreter/validators.ts
@@ -171,6 +171,9 @@ const ALLOWED_NODE_TYPES = new Set([
 	'SpreadElement',
 	'Property',
 
+	// Assignment (constrained to property assignment only)
+	'AssignmentExpression',
+
 	// Operators (for simple expressions like array access)
 	'UnaryExpression',
 	'BinaryExpression',
@@ -196,7 +199,6 @@ const FORBIDDEN_NODE_TYPES: Record<string, string> = {
 	TryStatement: 'Try-catch is not allowed in SDK code',
 	ThrowStatement: 'Throw statements are not allowed in SDK code',
 	WithStatement: 'With statements are not allowed in SDK code',
-	AssignmentExpression: 'Assignments are not allowed. Use const declarations only.',
 	UpdateExpression: 'Update expressions (++, --) are not allowed in SDK code',
 	NewExpression: 'new expressions are not allowed. Use SDK factory functions instead.',
 	ImportDeclaration: 'Import declarations are not allowed in SDK code',


### PR DESCRIPTION
## Summary
- Allow simple property assignment (`obj.prop = value`) in the SDK AST interpreter to support subnode dependency ordering (e.g., `loader.config.subnodes = { textSplitter: splitter }`)
- Only the `=` operator on `MemberExpression` targets is permitted; compound operators (`+=`, `-=`), bare variable reassignment, and dangerous properties (`__proto__`, `prototype`, `constructor`) remain blocked
- Adds 10 new tests covering both allowed patterns and security rejections

## Related Linear ticket
https://linear.app/n8n/issue/AI-2041

## Test plan
- [x] Existing 84 interpreter tests still pass
- [x] 10 new tests pass (3 positive, 7 rejection)
- [x] TypeScript typecheck passes
- [ ] Verify in integration that LLM-generated code with `loader.config.subnodes = { ... }` no longer throws `UnsupportedNodeError`


🤖 Generated with [Claude Code](https://claude.com/claude-code)