### PR TITLE
fix(core): Use actual map key after auto-rename in add() and to()

### DIFF
--- a/packages/@n8n/workflow-sdk/src/merge.test.ts
+++ b/packages/@n8n/workflow-sdk/src/merge.test.ts
@@ -279,5 +279,67 @@ describe('Merge', () => {
 			expect(weatherConns.main[0]![0].node).toBe('Merge Results');
 			expect(weatherConns.main[0]![0].index).toBe(1);
 		});
+
+		it('should handle duplicate node names with workflow-level .to() to merge inputs', () => {
+			const t = trigger({ type: 'n8n-nodes-base.manualTrigger', version: 1, config: {} });
+			const mergeNode = node({
+				type: 'n8n-nodes-base.merge',
+				version: 3,
+				config: { name: 'Combine' },
+			}) as MergeNode;
+			// Both nodes have the same name - second will be auto-renamed to "Process 1"
+			const process1 = node({
+				type: 'n8n-nodes-base.set',
+				version: 3,
+				config: { name: 'Process' },
+			});
+			const process2 = node({
+				type: 'n8n-nodes-base.set',
+				version: 3,
+				config: { name: 'Process' },
+			});
+			const downstream = node({
+				type: 'n8n-nodes-base.set',
+				version: 3,
+				config: { name: 'Downstream' },
+			});
+
+			// Use workflow-level .add()/.to() pattern (not node-instance .to() workaround)
+			const wf = workflow('test-id', 'Test')
+				.add(t.to([process1, process2]))
+				.add(process1)
+				.to(mergeNode.input(0))
+				.add(process2)
+				.to(mergeNode.input(1))
+				.add(mergeNode)
+				.to(downstream);
+
+			const json = wf.toJSON();
+
+			// Should have: trigger, process1 ("Process"), process2 ("Process 1"), merge, downstream
+			expect(json.nodes).toHaveLength(5);
+
+			// Verify auto-rename happened
+			const names = json.nodes.map((n) => n.name).sort();
+			expect(names).toContain('Process');
+			expect(names).toContain('Process 1');
+
+			// "Process" should connect to Combine input 0
+			const process1Conns = json.connections['Process'];
+			expect(process1Conns).toBeDefined();
+			expect(process1Conns.main[0]![0].node).toBe('Combine');
+			expect(process1Conns.main[0]![0].index).toBe(0);
+
+			// "Process 1" (auto-renamed) should connect to Combine input 1
+			const process2Conns = json.connections['Process 1'];
+			expect(process2Conns).toBeDefined();
+			expect(process2Conns.main[0]![0].node).toBe('Combine');
+			expect(process2Conns.main[0]![0].index).toBe(1);
+
+			// Combine should connect to Downstream
+			const mergeConns = json.connections['Combine'];
+			expect(mergeConns).toBeDefined();
+			expect(mergeConns.main[0]![0].node).toBe('Downstream');
+		});
 	});
 });

--- a/packages/@n8n/workflow-sdk/src/types/base.ts
+++ b/packages/@n8n/workflow-sdk/src/types/base.ts
@@ -894,6 +894,7 @@ export interface WorkflowBuilder {
 	>(node: N): WorkflowBuilder;
 
 	to<N extends NodeInstance<string, string, unknown>>(node: N): WorkflowBuilder;
+	to(inputTarget: InputTarget): WorkflowBuilder;
 	to(ifElse: IfElseComposite): WorkflowBuilder;
 	to(switchCase: SwitchCaseComposite): WorkflowBuilder;
 	to<T>(splitInBatches: SplitInBatchesBuilder<T>): WorkflowBuilder;

--- a/packages/@n8n/workflow-sdk/src/workflow-builder.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder.ts
@@ -244,7 +244,7 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 		const regularNode = node as NodeInstance<string, string, unknown>;
 
 		// Regular node or trigger
-		this.addNodeWithSubnodes(this._nodes, regularNode);
+		const actualKey = this.addNodeWithSubnodes(this._nodes, regularNode) ?? regularNode.name;
 
 		// Also add connection target nodes (e.g., onError handlers)
 		// This is important when re-adding a node that already exists but has new connections
@@ -252,7 +252,7 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 
 		// Collect pinData from the node if present
 		this._pinData = this.collectPinData(regularNode);
-		this._currentNode = regularNode.name;
+		this._currentNode = actualKey;
 		this._currentOutput = 0;
 
 		return this;
@@ -268,6 +268,33 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 		// This must come before composite checks since chains have composite-like properties
 		if (isNodeChain(nodeOrComposite)) {
 			return this.handleNodeChain(nodeOrComposite);
+		}
+
+		// Handle InputTarget (e.g., mergeNode.input(1))
+		if (isInputTarget(nodeOrComposite)) {
+			const actualNode = nodeOrComposite.node;
+			const actualKey = this.addNodeWithSubnodes(this._nodes, actualNode) ?? actualNode.name;
+
+			// Connect from current node to the target with the specified input index
+			if (this._currentNode) {
+				const currentGraphNode = this._nodes.get(this._currentNode);
+				if (currentGraphNode) {
+					const mainConns =
+						currentGraphNode.connections.get('main') ?? new Map<number, ConnectionTarget[]>();
+					const outputConns: ConnectionTarget[] = mainConns.get(this._currentOutput) ?? [];
+					outputConns.push({
+						node: actualKey,
+						type: 'main',
+						index: nodeOrComposite.inputIndex,
+					});
+					mainConns.set(this._currentOutput, outputConns);
+					currentGraphNode.connections.set('main', mainConns);
+				}
+			}
+
+			this._currentNode = actualKey;
+			this._currentOutput = 0;
+			return this;
 		}
 
 		// Check for plugin composite handlers
@@ -301,36 +328,9 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 		// Remaining type is a regular NodeInstance.
 		const node = nodeOrComposite as NodeInstance<string, string, unknown>;
 
-		// Check if node already exists in the workflow (cycle connection)
-		const existingNode = this._nodes.has(node.name);
-
-		if (existingNode) {
-			// Node already exists - just add the connection, don't re-add the node
-			if (this._currentNode) {
-				const currentGraphNode = this._nodes.get(this._currentNode);
-				if (currentGraphNode) {
-					const mainConns =
-						currentGraphNode.connections.get('main') ?? new Map<number, ConnectionTarget[]>();
-					const outputConnections: ConnectionTarget[] = mainConns.get(this._currentOutput) ?? [];
-					// Check for duplicate connections
-					const alreadyConnected = outputConnections.some((c) => c.node === node.name);
-					if (!alreadyConnected) {
-						mainConns.set(this._currentOutput, [
-							...outputConnections,
-							{ node: node.name, type: 'main', index: 0 },
-						]);
-						currentGraphNode.connections.set('main', mainConns);
-					}
-				}
-			}
-
-			this._currentNode = node.name;
-			this._currentOutput = 0;
-			return this;
-		}
-
-		// Add the new node and its subnodes
-		this.addNodeWithSubnodes(this._nodes, node);
+		// addNodeWithSubnodes is idempotent: returns existing key for same instance,
+		// generates unique name for name collisions, or adds new node.
+		const actualKey = this.addNodeWithSubnodes(this._nodes, node) ?? node.name;
 
 		// Add connection target nodes (e.g., onError handlers)
 		this.addSingleNodeConnectionTargets(this._nodes, node);
@@ -342,17 +342,21 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 				const mainConns =
 					currentGraphNode.connections.get('main') ?? new Map<number, ConnectionTarget[]>();
 				const outputConnections: ConnectionTarget[] = mainConns.get(this._currentOutput) ?? [];
-				mainConns.set(this._currentOutput, [
-					...outputConnections,
-					{ node: node.name, type: 'main', index: 0 },
-				]);
-				currentGraphNode.connections.set('main', mainConns);
+				// Check for duplicate connections
+				const alreadyConnected = outputConnections.some((c) => c.node === actualKey);
+				if (!alreadyConnected) {
+					mainConns.set(this._currentOutput, [
+						...outputConnections,
+						{ node: actualKey, type: 'main', index: 0 },
+					]);
+					currentGraphNode.connections.set('main', mainConns);
+				}
 			}
 		}
 
 		// Collect pinData from the node if present
 		this._pinData = this.collectPinData(node);
-		this._currentNode = node.name;
+		this._currentNode = actualKey;
 		this._currentOutput = 0;
 
 		return this;


### PR DESCRIPTION
## Summary
- Fix `WorkflowBuilder.add()` and `.to()` to use the actual map key returned by `addNodeWithSubnodes()` instead of `node.name`, which is wrong when a node is auto-renamed due to duplicate names
- Add `InputTarget` handling to workflow-level `to()` method, enabling patterns like `.add(process2).to(mergeNode.input(1))`
- Merge existing/new node paths in `to()` into a single idempotent path using `addNodeWithSubnodes()`

Linear ticket: https://linear.app/n8n/issue/AI-2042

## Test plan
- [x] New test: duplicate-name nodes with `WorkflowBuilder.to()` to merge inputs
- [x] All existing merge tests pass (8/8)
- [x] Full workflow-sdk test suite passes (pre-existing schema validation failures only)
- [x] TypeScript typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)