### PR TITLE
fix(ai-workflow-builder): Add string composition examples to expression reference

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/code-builder/prompts/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/code-builder/prompts/index.ts
@@ -41,7 +41,15 @@ const EXPRESSION_REFERENCE = `Available variables inside \`expr('{{{{ ... }}}}')
 - \`$execution.id\` — unique execution ID
 - \`$execution.mode\` — 'test' or 'production'
 - \`$workflow.id\` — workflow ID
-- \`$workflow.name\` — workflow name`;
+- \`$workflow.name\` — workflow name
+
+String composition — variables MUST always be inside \`{{{{ }}}}\`, never outside as JS variables:
+
+- \`expr('Hello {{{{ $json.name }}}}, welcome!')\` — variable embedded in text
+- \`expr('Report for {{{{ $now.toFormat("MMMM d, yyyy") }}}} - {{{{ $json.title }}}}')\` — multiple variables with method call
+- \`expr('{{{{ $json.firstName }}}} {{{{ $json.lastName }}}}')\` — combining multiple fields
+- \`expr('Total: {{{{ $json.items.length }}}} items, updated {{{{ $now.toISO() }}}}')\` — expressions with method calls
+- \`expr('Status: {{{{ $json.count > 0 ? "active" : "empty" }}}}')\` — inline ternary`;
 
 /**
  * Additional SDK functions not covered by main workflow patterns
@@ -750,6 +758,8 @@ Rules:
 - Expressions: use \`expr()\` for any \`{{{{ }}}}\` syntax  — always use single or double quotes, NOT backtick template literals
   - e.g. \`expr('Hello {{{{ $json.name }}}}')\` or \`expr("{{{{ $('Node').item.json.field }}}}")\`
 	- For multiline expressions, use string concatenation: \`expr('Line 1\\n' + 'Line 2 {{{{ $json.value }}}}')\`
+  - WRONG: \`expr('Daily Digest - ' + $now.toFormat('MMMM d') + '\\n' + $json.output)\` — $now and $json are outside {{{{ }}}}
+  - CORRECT: \`expr('Daily Digest - {{{{ $now.toFormat("MMMM d") }}}}\\n{{{{ $json.output }}}}')\` — variables inside {{{{ }}}}
 - Placeholders: use \`placeholder('hint')\` directly as the parameter value, not inside \`expr()\`, objects, or arrays, etc.
 - Every node MUST have an \`output\` property with sample data — following nodes depend on it for expressions
 - String quoting: When a string value contains an apostrophe, use double quotes for that string.


### PR DESCRIPTION
## Summary

- Adds string composition examples to the `EXPRESSION_REFERENCE` section of the code builder prompt, showing how to embed expression variables inside `{{ }}` delimiters when composing longer strings
- Adds a WRONG/CORRECT example pair to the step 5 expression rules, explicitly warning against using `$now`/`$json` as JS variables outside `{{ }}`

This prevents the code builder LLM from falling back to JavaScript string concatenation patterns (e.g. `'text ' + $json.field`) when it should keep variables inside `{{ }}` delimiters (e.g. `'text {{ $json.field }}'`).

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)