### PR TITLE
feat(editor): Update store logic for fetching global external secrets

### DIFF
--- a/packages/frontend/@n8n/rest-api-client/src/api/externalSecrets.ee.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/api/externalSecrets.ee.ts
@@ -12,6 +12,15 @@ export const getExternalSecrets = async (
 /**
  * @beta still under development
  */
+export const getGlobalExternalSecrets = async (
+	context: IRestApiContext,
+): Promise<Record<string, string[]>> => {
+	return await makeRestApiRequest(context, 'GET', '/secret-providers/completions/secrets/global');
+};
+
+/**
+ * @beta still under development
+ */
 export const getProjectExternalSecrets = async (
 	context: IRestApiContext,
 	projectId: string,

--- a/packages/frontend/editor-ui/src/features/integrations/externalSecrets.ee/externalSecrets.ee.store.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/externalSecrets.ee/externalSecrets.ee.store.ts
@@ -102,8 +102,10 @@ export const useExternalSecretsStore = defineStore('externalSecrets', () => {
 	async function fetchGlobalSecrets() {
 		if (rbacStore.hasScope('externalSecret:list')) {
 			try {
-				state.secrets = await externalSecretsApi.getExternalSecrets(rootStore.restApiContext);
-			} catch (error) {
+				state.secrets = checkDevFeatureFlag.value('EXTERNAL_SECRETS_FOR_PROJECTS')
+					? await externalSecretsApi.getGlobalExternalSecrets(rootStore.restApiContext)
+					: await externalSecretsApi.getExternalSecrets(rootStore.restApiContext);
+			} catch {
 				state.secrets = {};
 			}
 		}


### PR DESCRIPTION
## Summary

Uses new endpoint to fetch global external secrets.
This is needed to split the autocompletion view between **project** external secrets and **global** external secrets.

<img width="593" height="258" alt="Screenshot 2026-02-13 at 09 28 05" src="https://github.com/user-attachments/assets/6427f645-f4d1-4528-9696-d4afd7414ff9" />



## Related Linear tickets, Github issues, and Community forum posts

Fixes [LIGO-219](https://linear.app/n8n/issue/LIGO-219/febe-autocompletion-bug-project-scoped-vaults-are-listed-under-global)


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
