### PR TITLE
feat(core): Old external secrets endpoint keeps returning only known provider keys (no-changelog)

### DIFF
--- a/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
@@ -168,6 +168,10 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 		return this.secretsCache.getAllSecretNames();
 	}
 
+	getSecretsForOldExternalSecretsApi(): Record<string, string[]> {
+		return this.secretsCache.getSecretsForVaultNamesBeforeProjectScopedRelease();
+	}
+
 	// ========================================
 	// Public API - Settings
 	// ========================================

--- a/packages/cli/src/modules/external-secrets.ee/external-secrets.controller.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets.controller.ee.ts
@@ -88,6 +88,6 @@ export class ExternalSecretsController {
 	@Get('/secrets')
 	@GlobalScope('externalSecret:list')
 	getSecretNames() {
-		return this.secretsService.getAllSecrets();
+		return this.secretsService.getGlobalSecrets();
 	}
 }

--- a/packages/cli/src/modules/external-secrets.ee/external-secrets.service.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets.service.ee.ts
@@ -67,6 +67,10 @@ export class ExternalSecretsService {
 		return this.externalSecretsManager.getAllSecretNames();
 	}
 
+	getGlobalSecrets(): Record<string, string[]> {
+		return this.externalSecretsManager.getSecretsForOldExternalSecretsApi();
+	}
+
 	async testProviderSettings(providerName: string, data: IDataObject) {
 		const providerAndSettings = this.externalSecretsManager.getProviderWithSettings(providerName);
 		const { settings } = providerAndSettings;

--- a/packages/cli/src/modules/external-secrets.ee/secrets-cache.service.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-cache.service.ts
@@ -87,4 +87,30 @@ export class ExternalSecretsSecretsCache {
 
 		return result;
 	}
+
+	/**
+	 * Before we implemented project-scoped external secrets,
+	 * there was a hardcoded list of 5 supported provider names.
+	 * This method is only intended for the old GET /rest/external-secrets/secrets
+	 * to be backwards-compatible, by not including project-scoped secrets.
+	 */
+	getSecretsForVaultNamesBeforeProjectScopedRelease(): Record<string, string[]> {
+		const providers = this.registry.getAll();
+		const result: Record<string, string[]> = {};
+		const setOfPreviouslySupportedProviderNames = new Set([
+			'vault',
+			'awsSecretsManager',
+			'gcpSecretsManager',
+			'infisical',
+			'azureKeyVault',
+		]);
+
+		for (const [name, provider] of providers.entries()) {
+			if (setOfPreviouslySupportedProviderNames.has(name)) {
+				result[name] = provider.getSecretNames();
+			}
+		}
+
+		return result;
+	}
 }

--- a/packages/cli/test/integration/external-secrets/external-secrets.api.test.ts
+++ b/packages/cli/test/integration/external-secrets/external-secrets.api.test.ts
@@ -456,7 +456,7 @@ describe('GET /external-secrets/secrets', () => {
 		});
 		mockProvidersInstance.setProviders({
 			vault: vaultProvider,
-			newProvider: newProvider,
+			newProvider,
 		});
 
 		await setExternalSecretsSettings({


### PR DESCRIPTION
## Summary

While there is a new endpoint to fetch global secrets with our new feature flag: https://github.com/n8n-io/n8n/pull/25728

I think we'd do ourselves a favor to ensure that the old endpoint doesn't return any providers that it didn't used to return in the past.

This PR limits the providers that can be returned from the `GET /rest/external-secrets/secrets` to the 5 hardcoded ones that were supported in the past.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-219/febe-autocompletion-bug-project-scoped-vaults-are-listed-under-global


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
