### PR TITLE
fix(OpenRouter Chat Model Node): Fix OpenRouter tool calls with empty arguments

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.test.ts
@@ -1,0 +1,326 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
+/* eslint-disable @typescript-eslint/unbound-method */
+import { ChatOpenAI } from '@langchain/openai';
+import { makeN8nLlmFailedAttemptHandler, N8nLlmTracing, getProxyAgent } from '@n8n/ai-utilities';
+import { createMockExecuteFunction } from 'n8n-nodes-base/test/nodes/Helpers';
+import type { INode, ISupplyDataFunctions } from 'n8n-workflow';
+
+import { LmChatOpenRouter } from './LmChatOpenRouter.node';
+
+jest.mock('@langchain/openai');
+jest.mock('@n8n/ai-utilities');
+
+const MockedChatOpenAI = jest.mocked(ChatOpenAI);
+const MockedN8nLlmTracing = jest.mocked(N8nLlmTracing);
+const mockedMakeN8nLlmFailedAttemptHandler = jest.mocked(makeN8nLlmFailedAttemptHandler);
+const mockedGetProxyAgent = jest.mocked(getProxyAgent);
+
+describe('LmChatOpenRouter', () => {
+	let node: LmChatOpenRouter;
+
+	const mockNodeDef: INode = {
+		id: '1',
+		name: 'OpenRouter Chat Model',
+		typeVersion: 1,
+		type: 'n8n-nodes-langchain.lmChatOpenRouter',
+		position: [0, 0],
+		parameters: {},
+	};
+
+	const setupMockContext = (nodeOverrides: Partial<INode> = {}) => {
+		const nodeDef = { ...mockNodeDef, ...nodeOverrides };
+		const ctx = createMockExecuteFunction<ISupplyDataFunctions>(
+			{},
+			nodeDef,
+		) as jest.Mocked<ISupplyDataFunctions>;
+
+		ctx.getCredentials = jest.fn().mockResolvedValue({
+			apiKey: 'test-key',
+			url: 'https://openrouter.ai/api/v1',
+		});
+		ctx.getNode = jest.fn().mockReturnValue(nodeDef);
+		ctx.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+			if (paramName === 'model') return 'anthropic/claude-sonnet-4-20250514';
+			if (paramName === 'options') return {};
+			return undefined;
+		});
+
+		MockedN8nLlmTracing.mockImplementation(() => ({}) as unknown as N8nLlmTracing);
+		mockedMakeN8nLlmFailedAttemptHandler.mockReturnValue(jest.fn());
+		mockedGetProxyAgent.mockReturnValue({} as any);
+		return ctx;
+	};
+
+	beforeEach(() => {
+		node = new LmChatOpenRouter();
+		jest.clearAllMocks();
+	});
+
+	describe('node description', () => {
+		it('should have correct node properties', () => {
+			expect(node.description).toMatchObject({
+				displayName: 'OpenRouter Chat Model',
+				name: 'lmChatOpenRouter',
+				group: ['transform'],
+				version: [1],
+			});
+		});
+
+		it('should require openRouterApi credentials', () => {
+			expect(node.description.credentials).toEqual([{ name: 'openRouterApi', required: true }]);
+		});
+
+		it('should output ai_languageModel', () => {
+			expect(node.description.outputs).toEqual(['ai_languageModel']);
+			expect(node.description.outputNames).toEqual(['Model']);
+		});
+	});
+
+	describe('supplyData', () => {
+		it('should create ChatOpenAI with basic configuration', async () => {
+			const ctx = setupMockContext();
+
+			const result = await node.supplyData.call(ctx, 0);
+
+			expect(ctx.getCredentials).toHaveBeenCalledWith('openRouterApi');
+			expect(MockedChatOpenAI).toHaveBeenCalledWith(
+				expect.objectContaining({
+					apiKey: 'test-key',
+					model: 'anthropic/claude-sonnet-4-20250514',
+					maxRetries: 2,
+					callbacks: expect.arrayContaining([expect.any(Object)]),
+					onFailedAttempt: expect.any(Function),
+				}),
+			);
+			expect(result).toEqual({ response: expect.any(Object) });
+		});
+
+		it('should pass options to ChatOpenAI', async () => {
+			const ctx = setupMockContext();
+			ctx.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model') return 'anthropic/claude-sonnet-4-20250514';
+				if (paramName === 'options')
+					return {
+						temperature: 0.5,
+						maxTokens: 2000,
+						topP: 0.9,
+						frequencyPenalty: 0.3,
+						presencePenalty: 0.2,
+						timeout: 60000,
+						maxRetries: 5,
+					};
+				return undefined;
+			});
+
+			await node.supplyData.call(ctx, 0);
+
+			expect(MockedChatOpenAI).toHaveBeenCalledWith(
+				expect.objectContaining({
+					temperature: 0.5,
+					maxTokens: 2000,
+					topP: 0.9,
+					frequencyPenalty: 0.3,
+					presencePenalty: 0.2,
+					timeout: 60000,
+					maxRetries: 5,
+				}),
+			);
+		});
+
+		it('should set response_format in modelKwargs when responseFormat is provided', async () => {
+			const ctx = setupMockContext();
+			ctx.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model') return 'anthropic/claude-sonnet-4-20250514';
+				if (paramName === 'options') return { responseFormat: 'json_object' };
+				return undefined;
+			});
+
+			await node.supplyData.call(ctx, 0);
+
+			expect(MockedChatOpenAI).toHaveBeenCalledWith(
+				expect.objectContaining({
+					modelKwargs: { response_format: { type: 'json_object' } },
+				}),
+			);
+		});
+
+		it('should not set modelKwargs when no responseFormat', async () => {
+			const ctx = setupMockContext();
+
+			await node.supplyData.call(ctx, 0);
+
+			expect(MockedChatOpenAI).toHaveBeenCalledWith(
+				expect.objectContaining({
+					modelKwargs: undefined,
+				}),
+			);
+		});
+
+		it('should pass a custom fetch wrapper in configuration', async () => {
+			const ctx = setupMockContext();
+
+			await node.supplyData.call(ctx, 0);
+
+			const callArgs = MockedChatOpenAI.mock.calls[0][0];
+			expect(callArgs?.configuration?.fetch).toEqual(expect.any(Function));
+		});
+	});
+
+	describe('fetch wrapper (empty tool call arguments fix)', () => {
+		const origFetch = globalThis.fetch;
+
+		afterEach(() => {
+			globalThis.fetch = origFetch;
+		});
+
+		function jsonResponse(body: unknown): Response {
+			const json = JSON.stringify(body);
+			return new Response(json, {
+				status: 200,
+				headers: { 'content-type': 'application/json' },
+			});
+		}
+
+		/**
+		 * Sets up a mock fetch, calls supplyData to capture it in the wrapper,
+		 * and returns the wrapper function from the ChatOpenAI constructor args.
+		 */
+		async function setupFetchWrapper(mockFetch: jest.Mock): Promise<typeof globalThis.fetch> {
+			globalThis.fetch = mockFetch;
+			const ctx = setupMockContext();
+			await node.supplyData.call(ctx, 0);
+			return MockedChatOpenAI.mock.calls[0][0]?.configuration?.fetch as typeof fetch;
+		}
+
+		it.each<{ input: unknown; expected: string; label: string }>([
+			{ input: '', expected: '{}', label: 'empty string' },
+			{ input: '   ', expected: '{}', label: 'whitespace-only string' },
+			{ input: null, expected: '{}', label: 'null' },
+			{ input: [], expected: '{}', label: 'empty array' },
+			{ input: [1, 2], expected: '{}', label: 'non-empty array' },
+			{ input: {}, expected: '{}', label: 'empty object (stringified)' },
+			{
+				input: { location: 'NYC' },
+				expected: '{"location":"NYC"}',
+				label: 'plain object (stringified)',
+			},
+			{
+				input: '{"location":"NYC"}',
+				expected: '{"location":"NYC"}',
+				label: 'valid JSON string (unchanged)',
+			},
+			{ input: '{}', expected: '{}', label: 'empty JSON object string (unchanged)' },
+		])('should normalize arguments: $label → $expected', async ({ input, expected }) => {
+			const mockFetch = jest.fn().mockResolvedValue(
+				jsonResponse({
+					choices: [
+						{
+							message: {
+								tool_calls: [{ id: 'call_1', function: { name: 'tool', arguments: input } }],
+							},
+						},
+					],
+				}),
+			);
+
+			const wrappedFetch = await setupFetchWrapper(mockFetch);
+			const response = await wrappedFetch('https://openrouter.ai/api/v1/chat/completions');
+			const result = await response.json();
+
+			expect(result.choices[0].message.tool_calls[0].function.arguments).toBe(expected);
+		});
+
+		it('should pass through non-JSON responses untouched', async () => {
+			const textBody = 'plain text response';
+			const mockFetch = jest.fn().mockResolvedValue(
+				new Response(textBody, {
+					status: 200,
+					headers: { 'content-type': 'text/plain' },
+				}),
+			);
+
+			const wrappedFetch = await setupFetchWrapper(mockFetch);
+			const response = await wrappedFetch('https://openrouter.ai/api/v1/chat/completions');
+
+			expect(await response.text()).toBe(textBody);
+		});
+
+		it('should pass through JSON responses without choices', async () => {
+			const body = { models: ['a', 'b'] };
+			const mockFetch = jest.fn().mockResolvedValue(jsonResponse(body));
+
+			const wrappedFetch = await setupFetchWrapper(mockFetch);
+			const response = await wrappedFetch('https://openrouter.ai/api/v1/models');
+
+			expect(await response.json()).toEqual(body);
+		});
+
+		it('should pass through responses without tool_calls', async () => {
+			const body = {
+				choices: [{ message: { role: 'assistant', content: 'Hello!' } }],
+			};
+			const mockFetch = jest.fn().mockResolvedValue(jsonResponse(body));
+
+			const wrappedFetch = await setupFetchWrapper(mockFetch);
+			const response = await wrappedFetch('https://openrouter.ai/api/v1/chat/completions');
+
+			expect(await response.json()).toEqual(body);
+		});
+
+		it('should fix only empty arguments in a mixed set of tool calls', async () => {
+			const mockFetch = jest.fn().mockResolvedValue(
+				jsonResponse({
+					choices: [
+						{
+							message: {
+								tool_calls: [
+									{
+										id: 'call_1',
+										function: { name: 'get_weather', arguments: '{"city":"NYC"}' },
+									},
+									{ id: 'call_2', function: { name: 'get_time', arguments: '' } },
+									{
+										id: 'call_3',
+										function: { name: 'get_date', arguments: '{"format":"iso"}' },
+									},
+								],
+							},
+						},
+					],
+				}),
+			);
+
+			const wrappedFetch = await setupFetchWrapper(mockFetch);
+			const response = await wrappedFetch('https://openrouter.ai/api/v1/chat/completions');
+			const result = await response.json();
+
+			const toolCalls = result.choices[0].message.tool_calls;
+			expect(toolCalls[0].function.arguments).toBe('{"city":"NYC"}');
+			expect(toolCalls[1].function.arguments).toBe('{}');
+			expect(toolCalls[2].function.arguments).toBe('{"format":"iso"}');
+		});
+
+		it('should only carry content-type header on modified responses', async () => {
+			const mockFetch = jest.fn().mockResolvedValue(
+				jsonResponse({
+					choices: [
+						{
+							message: {
+								tool_calls: [{ id: 'call_1', function: { name: 'get_time', arguments: '' } }],
+							},
+						},
+					],
+				}),
+			);
+
+			const wrappedFetch = await setupFetchWrapper(mockFetch);
+			const response = await wrappedFetch('https://openrouter.ai/api/v1/chat/completions');
+
+			expect(response.headers.get('content-type')).toBe('application/json');
+			// Stale metadata headers (content-length, etag, etc.) are not carried over
+			expect(response.headers.get('content-length')).toBeNull();
+		});
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/LmChatOpenRouter.node.ts
@@ -1,5 +1,6 @@
 import { ChatOpenAI, type ClientOptions } from '@langchain/openai';
 import { getProxyAgent, makeN8nLlmFailedAttemptHandler, N8nLlmTracing } from '@n8n/ai-utilities';
+import { getConnectionHintNoticeField } from '@utils/sharedFields';
 import {
 	NodeConnectionTypes,
 	type INodeType,
@@ -8,10 +9,73 @@ import {
 	type SupplyData,
 } from 'n8n-workflow';
 
-import { getConnectionHintNoticeField } from '@utils/sharedFields';
-
 import type { OpenAICompatibleCredential } from '../../../types/types';
 import { openAiFailedAttemptHandler } from '../../vendors/OpenAi/helpers/error-handling';
+
+interface OpenAIToolCall {
+	function?: { arguments?: unknown };
+}
+
+interface OpenAIChoice {
+	message?: { tool_calls?: OpenAIToolCall[] };
+}
+
+function isOpenAIResponseWithChoices(json: unknown): json is { choices: OpenAIChoice[] } {
+	return (
+		typeof json === 'object' &&
+		json !== null &&
+		'choices' in json &&
+		Array.isArray((json as { choices: unknown }).choices)
+	);
+}
+
+/**
+ * Wraps fetch to fix empty tool call arguments in API responses.
+ *
+ * When Anthropic models are accessed through OpenRouter, tool calls for tools
+ * with no parameters return empty string arguments ("") instead of "{}".
+ * LangChain's parseToolCall does JSON.parse("") which throws, breaking the agent.
+ * This wrapper normalizes empty arguments to "{}" before LangChain sees them.
+ */
+function createOpenRouterFetch(baseFetch: typeof globalThis.fetch): typeof globalThis.fetch {
+	return async (input, init) => {
+		const response = await baseFetch(input, init);
+
+		const contentType = response.headers.get('content-type') ?? '';
+		if (!contentType.includes('json')) return response;
+
+		// Clone before reading, since .json() consumes the body. If no
+		// modification is needed we return the clone with the original body intact.
+		const clone = response.clone();
+		const json: unknown = await response.json();
+
+		if (!isOpenAIResponseWithChoices(json)) return clone;
+
+		const isInvalidArgs = (args: unknown): boolean => typeof args !== 'string' || !args.trim();
+
+		const toolCallsToFix = json.choices
+			.flatMap((choice) => choice.message?.tool_calls ?? [])
+			.filter((tc) => tc.function && isInvalidArgs(tc.function.arguments));
+
+		if (toolCallsToFix.length === 0) return clone;
+
+		for (const tc of toolCallsToFix) {
+			if (!tc.function) continue;
+			const { arguments: args } = tc.function;
+			// Preserve already-parsed plain objects by stringifying them.
+			// Arrays and other non-object types are not valid tool args, so default to '{}'.
+			const isPlainObject = typeof args === 'object' && args !== null && !Array.isArray(args);
+			tc.function.arguments = isPlainObject ? JSON.stringify(args) : '{}';
+		}
+
+		const body = JSON.stringify(json);
+		return new Response(body, {
+			status: response.status,
+			statusText: response.statusText,
+			headers: { 'content-type': contentType },
+		});
+	};
+}
 
 export class LmChatOpenRouter implements INodeType {
 	description: INodeTypeDescription = {
@@ -226,6 +290,7 @@ export class LmChatOpenRouter implements INodeType {
 		const timeout = options.timeout;
 		const configuration: ClientOptions = {
 			baseURL: credentials.url,
+			fetch: createOpenRouterFetch(globalThis.fetch),
 			fetchOptions: {
 				dispatcher: getProxyAgent(credentials.url, {
 					headersTimeout: timeout,

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/test/LmChatOpenRouter.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatOpenRouter/test/LmChatOpenRouter.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable n8n-nodes-base/node-filename-against-convention */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
@@ -7,7 +8,7 @@ import { makeN8nLlmFailedAttemptHandler, N8nLlmTracing, getProxyAgent } from '@n
 import { createMockExecuteFunction } from 'n8n-nodes-base/test/nodes/Helpers';
 import type { INode, ISupplyDataFunctions } from 'n8n-workflow';
 
-import { LmChatOpenRouter } from './LmChatOpenRouter.node';
+import { LmChatOpenRouter } from '../LmChatOpenRouter.node';
 
 jest.mock('@langchain/openai');
 jest.mock('@n8n/ai-utilities');


### PR DESCRIPTION
## Summary

When using the **OpenRouter Chat Model** node with Anthropic models and an AI Agent that has a tool with no parameters, executing the tool fails with:

```
Failed to parse tool arguments from chat model response. Text: "[]".
SyntaxError: Unexpected end of JSON input
```

**Root cause:** Anthropic models accessed through OpenRouter's OpenAI-compatible API return empty/invalid `function.arguments` (`""`, `[]`, `null`) instead of `"{}"` for tools with no parameters. LangChain's `parseToolCall` does `JSON.parse("")` which throws, and the tool call ends up in `invalid_tool_calls` instead of `tool_calls`, breaking the agent output parser.

**Fix:** A `fetch` wrapper in the OpenRouter node intercepts API responses and normalizes invalid tool call arguments before LangChain sees them. This approach was chosen because:
- Subclassing `ChatOpenAI` doesn't work — `ChatOpenAI.withConfig()` (called by `bindTools`) hardcodes `new ChatOpenAI(this.fields)`, discarding any subclass
- The wrapper lives in the `configuration` object which is part of the original fields, so it survives all LangChain internal cloning

Normalization rules:
| Input | Output | Reason |
|---|---|---|
| `""`, `"  "`, `null` | `"{}"` | Empty — default to empty object |
| `[]`, `[1,2]` | `"{}"` | Arrays are not valid tool args |
| `{location: "NYC"}` | `'{"location":"NYC"}'` | Plain object — stringify to preserve data |
| `'{"city":"NYC"}'` | `'{"city":"NYC"}'` | Valid JSON string — unchanged |

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2029


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
