### PR TITLE
feat: Allow skipping foreignkey constraint disablement for imports

### DIFF
--- a/packages/cli/src/commands/import/__tests__/entities.test.ts
+++ b/packages/cli/src/commands/import/__tests__/entities.test.ts
@@ -141,6 +141,33 @@ describe('ImportEntitiesCommand', () => {
 			);
 		});
 
+		it('should skip disabling foreign key constraints when skipDisableForeignKeyConstraints flag is true', async () => {
+			const command = new ImportEntitiesCommand();
+			// @ts-expect-error Protected property
+			command.flags = {
+				inputDir: './outputs',
+				truncateTables: false,
+				skipDisableForeignKeyConstraints: true,
+			};
+			// @ts-expect-error Protected property
+			command.logger = {
+				info: jest.fn(),
+				error: jest.fn(),
+			};
+
+			mockImportService.importEntities.mockResolvedValue(undefined);
+
+			await command.run();
+
+			expect(mockImportService.importEntities).toHaveBeenCalledWith(
+				'./outputs',
+				false,
+				undefined,
+				false,
+				true,
+			);
+		});
+
 		it('should handle service errors gracefully', async () => {
 			const command = new ImportEntitiesCommand();
 			// @ts-expect-error Protected property

--- a/packages/cli/src/commands/import/__tests__/entities.test.ts
+++ b/packages/cli/src/commands/import/__tests__/entities.test.ts
@@ -36,6 +36,7 @@ describe('ImportEntitiesCommand', () => {
 				false,
 				undefined,
 				false,
+				false,
 			);
 		});
 
@@ -60,6 +61,7 @@ describe('ImportEntitiesCommand', () => {
 				'/custom/path',
 				false,
 				undefined,
+				false,
 				false,
 			);
 		});
@@ -87,6 +89,7 @@ describe('ImportEntitiesCommand', () => {
 				true,
 				undefined,
 				false,
+				false,
 			);
 		});
 
@@ -111,6 +114,7 @@ describe('ImportEntitiesCommand', () => {
 				'./outputs',
 				false,
 				'key.txt',
+				false,
 				false,
 			);
 		});
@@ -138,6 +142,7 @@ describe('ImportEntitiesCommand', () => {
 				false,
 				undefined,
 				true,
+				false,
 			);
 		});
 
@@ -191,6 +196,7 @@ describe('ImportEntitiesCommand', () => {
 				false,
 				undefined,
 				false,
+				false,
 			);
 		});
 
@@ -216,6 +222,7 @@ describe('ImportEntitiesCommand', () => {
 				'./outputs',
 				true,
 				undefined,
+				false,
 				false,
 			);
 		});

--- a/packages/cli/src/commands/import/__tests__/entities.test.ts
+++ b/packages/cli/src/commands/import/__tests__/entities.test.ts
@@ -146,13 +146,13 @@ describe('ImportEntitiesCommand', () => {
 			);
 		});
 
-		it('should skip disabling foreign key constraints when skipDisableForeignKeyConstraints flag is true', async () => {
+		it('should skip disabling foreign key constraints when skipTogglingForeignKeyConstraints flag is true', async () => {
 			const command = new ImportEntitiesCommand();
 			// @ts-expect-error Protected property
 			command.flags = {
 				inputDir: './outputs',
 				truncateTables: false,
-				skipDisableForeignKeyConstraints: true,
+				skipTogglingForeignKeyConstraints: true,
 			};
 			// @ts-expect-error Protected property
 			command.logger = {

--- a/packages/cli/src/commands/import/entities.ts
+++ b/packages/cli/src/commands/import/entities.ts
@@ -20,6 +20,10 @@ const flagsSchema = z.object({
 		.boolean()
 		.describe('Skip migration validation checks')
 		.default(false),
+	skipDisableForeignKeyConstraints: z.coerce
+		.boolean()
+		.describe('Skip disabling foreign key constraints')
+		.default(false),
 });
 
 @Command({
@@ -44,6 +48,7 @@ export class ImportEntitiesCommand extends BaseCommand<z.infer<typeof flagsSchem
 		const truncateTables = this.flags.truncateTables;
 		const keyFilePath = this.flags.keyFile ? safeJoinPath(this.flags.keyFile) : undefined;
 		const skipMigrationChecks = this.flags.skipMigrationChecks ?? false;
+		const skipDisableForeignKeyConstraints = this.flags.skipDisableForeignKeyConstraints ?? false;
 
 		this.logger.info('\n⚠️⚠️ This feature is currently under development. ⚠️⚠️');
 		this.logger.info('\n🚀 Starting entity import...');

--- a/packages/cli/src/commands/import/entities.ts
+++ b/packages/cli/src/commands/import/entities.ts
@@ -57,12 +57,16 @@ export class ImportEntitiesCommand extends BaseCommand<z.infer<typeof flagsSchem
 		if (skipMigrationChecks) {
 			this.logger.info('⏭️  Skipping migration checks');
 		}
+		if (skipDisableForeignKeyConstraints) {
+			this.logger.info('⏭️  Skipping disabling foreign key constraints');
+		}
 
 		await Container.get(ImportService).importEntities(
 			inputDir,
 			truncateTables,
 			keyFilePath,
 			skipMigrationChecks,
+			skipDisableForeignKeyConstraints,
 		);
 	}
 

--- a/packages/cli/src/commands/import/entities.ts
+++ b/packages/cli/src/commands/import/entities.ts
@@ -20,7 +20,7 @@ const flagsSchema = z.object({
 		.boolean()
 		.describe('Skip migration validation checks')
 		.default(false),
-	skipDisableForeignKeyConstraints: z.coerce
+	skipTogglingForeignKeyConstraints: z.coerce
 		.boolean()
 		.describe('Skip disabling foreign key constraints')
 		.default(false),
@@ -48,7 +48,7 @@ export class ImportEntitiesCommand extends BaseCommand<z.infer<typeof flagsSchem
 		const truncateTables = this.flags.truncateTables;
 		const keyFilePath = this.flags.keyFile ? safeJoinPath(this.flags.keyFile) : undefined;
 		const skipMigrationChecks = this.flags.skipMigrationChecks ?? false;
-		const skipDisableForeignKeyConstraints = this.flags.skipDisableForeignKeyConstraints ?? false;
+		const skipTogglingForeignKeyConstraints = this.flags.skipTogglingForeignKeyConstraints ?? false;
 
 		this.logger.info('\n⚠️⚠️ This feature is currently under development. ⚠️⚠️');
 		this.logger.info('\n🚀 Starting entity import...');
@@ -57,7 +57,7 @@ export class ImportEntitiesCommand extends BaseCommand<z.infer<typeof flagsSchem
 		if (skipMigrationChecks) {
 			this.logger.info('⏭️  Skipping migration checks');
 		}
-		if (skipDisableForeignKeyConstraints) {
+		if (skipTogglingForeignKeyConstraints) {
 			this.logger.info('⏭️  Skipping disabling foreign key constraints');
 		}
 
@@ -66,7 +66,7 @@ export class ImportEntitiesCommand extends BaseCommand<z.infer<typeof flagsSchem
 			truncateTables,
 			keyFilePath,
 			skipMigrationChecks,
-			skipDisableForeignKeyConstraints,
+			skipTogglingForeignKeyConstraints,
 		);
 	}
 

--- a/packages/cli/src/services/__tests__/import.service.test.ts
+++ b/packages/cli/src/services/__tests__/import.service.test.ts
@@ -559,7 +559,7 @@ describe('ImportService', () => {
 			await importService.enableForeignKeyConstraints(mockEntityManager);
 
 			expect(mockEntityManager.query).toHaveBeenCalledWith(
-				'SET session_replication_role = DEFAULT;',
+				'SET session_replication_role = ORIGIN;',
 			);
 		});
 	});

--- a/packages/cli/src/services/import.service.ts
+++ b/packages/cli/src/services/import.service.ts
@@ -44,8 +44,8 @@ export class ImportService {
 			sqlite: 'PRAGMA defer_foreign_keys = OFF;',
 			'sqlite-pooled': 'PRAGMA defer_foreign_keys = OFF;',
 			'sqlite-memory': 'PRAGMA defer_foreign_keys = OFF;',
-			postgres: 'SET session_replication_role = DEFAULT;',
-			postgresql: 'SET session_replication_role = DEFAULT;',
+			postgres: 'SET session_replication_role = ORIGIN;',
+			postgresql: 'SET session_replication_role = ORIGIN;',
 		},
 	};
 

--- a/packages/cli/src/services/import.service.ts
+++ b/packages/cli/src/services/import.service.ts
@@ -372,6 +372,7 @@ export class ImportService {
 		truncateTables: boolean,
 		keyFilePath?: string,
 		skipMigrationChecks = false,
+		skipDisableForeignKeyConstraints = false,
 	) {
 		validateDbTypeForImportEntities(this.dataSource.options.type);
 
@@ -397,7 +398,9 @@ export class ImportService {
 		}
 
 		await this.dataSource.transaction(async (transactionManager: EntityManager) => {
-			await this.disableForeignKeyConstraints(transactionManager);
+			if (!skipDisableForeignKeyConstraints) {
+				await this.disableForeignKeyConstraints(transactionManager);
+			}
 
 			// Get import metadata after migration validation
 			const importMetadata = await this.getImportMetadata(inputDir);
@@ -434,7 +437,9 @@ export class ImportService {
 				customEncryptionKey,
 			);
 
-			await this.enableForeignKeyConstraints(transactionManager);
+			if (!skipDisableForeignKeyConstraints) {
+				await this.enableForeignKeyConstraints(transactionManager);
+			}
 		});
 
 		// Cleanup decompressed files after import

--- a/packages/cli/src/services/import.service.ts
+++ b/packages/cli/src/services/import.service.ts
@@ -372,7 +372,7 @@ export class ImportService {
 		truncateTables: boolean,
 		keyFilePath?: string,
 		skipMigrationChecks = false,
-		skipDisableForeignKeyConstraints = false,
+		skipTogglingForeignKeyConstraints = false,
 	) {
 		validateDbTypeForImportEntities(this.dataSource.options.type);
 
@@ -398,7 +398,7 @@ export class ImportService {
 		}
 
 		await this.dataSource.transaction(async (transactionManager: EntityManager) => {
-			if (!skipDisableForeignKeyConstraints) {
+			if (!skipTogglingForeignKeyConstraints) {
 				await this.disableForeignKeyConstraints(transactionManager);
 			}
 
@@ -437,7 +437,7 @@ export class ImportService {
 				customEncryptionKey,
 			);
 
-			if (!skipDisableForeignKeyConstraints) {
+			if (!skipTogglingForeignKeyConstraints) {
 				await this.enableForeignKeyConstraints(transactionManager);
 			}
 		});


### PR DESCRIPTION
## Summary

This feature adds a new flag to allow skipping disablement of foreign key constraints on database imports, for the cases where the client does not have enough privileges, e.g. Azure hosted postgres server does not allow SUPERUSER role on clients, which is required to set the session_replication_role parameter.

Also fixes the value for `session_replication_role`, DEFAULT -> ORIGIN.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
