### PR TITLE
fix: improve accessibility of chat send button

### DIFF
--- a/packages/frontend/@n8n/chat/src/components/Input.vue
+++ b/packages/frontend/@n8n/chat/src/components/Input.vue
@@ -352,8 +352,13 @@ function adjustTextAreaHeight() {
 				>
 					<IconPaperclip height="24" width="24" />
 				</button>
-				<button :disabled="isSubmitDisabled" class="chat-input-send-button" @click="onSubmit">
-					<IconSend height="24" width="24" />
+				<button
+				type="submit"
+				:disabled="isSubmitDisabled"
+				class="chat-input-send-button"
+				@click="onSubmit"
+				aria-label="Send message">
+				<IconSend height="24" width="24" aria-hidden="true" focusable="false" />
 				</button>
 			</div>
 		</div>


### PR DESCRIPTION
## Improve accessibility of chatbot send button (WCAG compliant)
### Description
Due to the European Accessibility Act (EAA), digital services are required to comply with WCAG accessibility guidelines. To support these requirements, I updated the icon-only Send Message button by adding an accessible name, as it was flagged as an accessibility issue by multiple automated checkers.
### Changes
Added aria-label="Send message" to provide a proper accessible name for screen readers and marked the decorative send icon as hidden with aria-hidden="true" and focusable="false".
### Result
Screen readers can now correctly announce the button as “Send message,” improving keyboard and assistive technology support in line with WCAG 4.1.2 (Name, Role, Value).