### PR TITLE
test: Harden janitor TCR and clean up test architecture (no-changelog)

### DIFF
--- a/packages/testing/janitor/src/cli/help.ts
+++ b/packages/testing/janitor/src/cli/help.ts
@@ -104,7 +104,7 @@ Options:
   --message=<msg>         Commit message
   --target-branch=<name>  Branch to diff against
   --max-diff-lines=<n>    Skip if diff exceeds N lines
-  --test-command=<cmd>    Test command (files appended)
+  --test-command=<cmd>    Test command (files appended). Must match allowlist if configured
   --json, --verbose
 
 Example: playwright-janitor tcr --execute -m="Fix bug"

--- a/packages/testing/janitor/src/config.ts
+++ b/packages/testing/janitor/src/config.ts
@@ -83,6 +83,8 @@ export interface JanitorConfig {
 		testCommand: string;
 		/** Number of Playwright workers. Always appended to test command. @default 1 */
 		workerCount?: number;
+		/** Allowlist of permitted test commands. When set, --test-command must match. */
+		allowedTestCommands?: string[];
 	};
 }
 

--- a/packages/testing/janitor/src/index.ts
+++ b/packages/testing/janitor/src/index.ts
@@ -132,6 +132,12 @@ export {
 } from './core/tcr-executor.js';
 
 export {
+	resolveTestCommand,
+	buildTestCommand,
+	type ResolvedCommand,
+} from './utils/test-command.js';
+
+export {
 	diffFileMethods,
 	formatDiffConsole,
 	formatDiffJSON,

--- a/packages/testing/janitor/src/utils/test-command.test.ts
+++ b/packages/testing/janitor/src/utils/test-command.test.ts
@@ -18,20 +18,20 @@ describe('test-command', () => {
 	});
 
 	describe('resolveTestCommand', () => {
-		it('appends default workers to override command', () => {
+		it('returns structured command with override', () => {
 			vi.mocked(config.hasConfig).mockReturnValue(false);
 			const result = resolveTestCommand('custom test command');
-			expect(result).toBe('custom test command --workers=1');
+			expect(result).toEqual({ bin: 'custom', args: ['test', 'command', '--workers=1'] });
 		});
 
-		it('appends default workers to config command', () => {
+		it('returns structured command from config', () => {
 			vi.mocked(config.hasConfig).mockReturnValue(true);
 			vi.mocked(config.getConfig).mockReturnValue({
 				tcr: { testCommand: 'pnpm test' },
 			} as ReturnType<typeof config.getConfig>);
 
 			const result = resolveTestCommand();
-			expect(result).toBe('pnpm test --workers=1');
+			expect(result).toEqual({ bin: 'pnpm', args: ['test', '--workers=1'] });
 		});
 
 		it('uses custom worker count from config', () => {
@@ -41,7 +41,7 @@ describe('test-command', () => {
 			} as ReturnType<typeof config.getConfig>);
 
 			const result = resolveTestCommand();
-			expect(result).toBe('pnpm test --workers=4');
+			expect(result).toEqual({ bin: 'pnpm', args: ['test', '--workers=4'] });
 		});
 
 		it('uses config worker count with override command', () => {
@@ -51,14 +51,14 @@ describe('test-command', () => {
 			} as ReturnType<typeof config.getConfig>);
 
 			const result = resolveTestCommand('pnpm test:container');
-			expect(result).toBe('pnpm test:container --workers=2');
+			expect(result).toEqual({ bin: 'pnpm', args: ['test:container', '--workers=2'] });
 		});
 
 		it('returns default when no override and no config', () => {
 			vi.mocked(config.hasConfig).mockReturnValue(false);
 
 			const result = resolveTestCommand();
-			expect(result).toBe('npx playwright test --workers=1');
+			expect(result).toEqual({ bin: 'npx', args: ['playwright', 'test', '--workers=1'] });
 		});
 
 		it('returns default when config exists but no testCommand', () => {
@@ -68,7 +68,7 @@ describe('test-command', () => {
 			} as ReturnType<typeof config.getConfig>);
 
 			const result = resolveTestCommand();
-			expect(result).toBe('npx playwright test --workers=1');
+			expect(result).toEqual({ bin: 'npx', args: ['playwright', 'test', '--workers=1'] });
 		});
 
 		it('returns default when config exists but no tcr section', () => {
@@ -76,7 +76,16 @@ describe('test-command', () => {
 			vi.mocked(config.getConfig).mockReturnValue({} as ReturnType<typeof config.getConfig>);
 
 			const result = resolveTestCommand();
-			expect(result).toBe('npx playwright test --workers=1');
+			expect(result).toEqual({ bin: 'npx', args: ['playwright', 'test', '--workers=1'] });
+		});
+
+		it('throws on empty command', () => {
+			vi.mocked(config.hasConfig).mockReturnValue(true);
+			vi.mocked(config.getConfig).mockReturnValue({
+				tcr: { testCommand: '   ' },
+			} as ReturnType<typeof config.getConfig>);
+
+			expect(() => resolveTestCommand()).toThrow('Test command cannot be empty');
 		});
 	});
 
@@ -87,22 +96,104 @@ describe('test-command', () => {
 
 		it('builds command with test files', () => {
 			const result = buildTestCommand(['test1.spec.ts', 'test2.spec.ts']);
-			expect(result).toBe('npx playwright test --workers=1 test1.spec.ts test2.spec.ts');
+			expect(result).toEqual({
+				bin: 'npx',
+				args: ['playwright', 'test', '--workers=1', 'test1.spec.ts', 'test2.spec.ts'],
+			});
 		});
 
 		it('uses override command with workers appended', () => {
 			const result = buildTestCommand(['test.spec.ts'], 'pnpm test');
-			expect(result).toBe('pnpm test --workers=1 test.spec.ts');
+			expect(result).toEqual({
+				bin: 'pnpm',
+				args: ['test', '--workers=1', 'test.spec.ts'],
+			});
 		});
 
 		it('handles empty file list', () => {
 			const result = buildTestCommand([]);
-			expect(result).toBe('npx playwright test --workers=1 ');
+			expect(result).toEqual({
+				bin: 'npx',
+				args: ['playwright', 'test', '--workers=1'],
+			});
 		});
 
 		it('handles single file', () => {
 			const result = buildTestCommand(['single.spec.ts']);
-			expect(result).toBe('npx playwright test --workers=1 single.spec.ts');
+			expect(result).toEqual({
+				bin: 'npx',
+				args: ['playwright', 'test', '--workers=1', 'single.spec.ts'],
+			});
+		});
+	});
+
+	describe('allowlist', () => {
+		it('accepts command in allowlist', () => {
+			vi.mocked(config.hasConfig).mockReturnValue(true);
+			vi.mocked(config.getConfig).mockReturnValue({
+				tcr: {
+					testCommand: 'pnpm test:local',
+					allowedTestCommands: ['pnpm test:local', 'pnpm test:container'],
+				},
+			} as ReturnType<typeof config.getConfig>);
+
+			const result = resolveTestCommand();
+			expect(result.bin).toBe('pnpm');
+		});
+
+		it('accepts override command in allowlist', () => {
+			vi.mocked(config.hasConfig).mockReturnValue(true);
+			vi.mocked(config.getConfig).mockReturnValue({
+				tcr: {
+					testCommand: 'pnpm test:local',
+					allowedTestCommands: ['pnpm test:local', 'pnpm test:container'],
+				},
+			} as ReturnType<typeof config.getConfig>);
+
+			const result = resolveTestCommand('pnpm test:container');
+			expect(result.bin).toBe('pnpm');
+		});
+
+		it('rejects command not in allowlist', () => {
+			vi.mocked(config.hasConfig).mockReturnValue(true);
+			vi.mocked(config.getConfig).mockReturnValue({
+				tcr: {
+					testCommand: 'pnpm test:local',
+					allowedTestCommands: ['pnpm test:local'],
+				},
+			} as ReturnType<typeof config.getConfig>);
+
+			expect(() => resolveTestCommand('true')).toThrow('not in the allowlist');
+		});
+
+		it('rejects shell injection attempts', () => {
+			vi.mocked(config.hasConfig).mockReturnValue(true);
+			vi.mocked(config.getConfig).mockReturnValue({
+				tcr: {
+					testCommand: 'pnpm test:local',
+					allowedTestCommands: ['pnpm test:local'],
+				},
+			} as ReturnType<typeof config.getConfig>);
+
+			expect(() => resolveTestCommand('pnpm test:local || true')).toThrow('not in the allowlist');
+			expect(() => resolveTestCommand('pnpm test:local ; exit 0')).toThrow('not in the allowlist');
+		});
+
+		it('allows any command when no allowlist configured', () => {
+			vi.mocked(config.hasConfig).mockReturnValue(true);
+			vi.mocked(config.getConfig).mockReturnValue({
+				tcr: { testCommand: 'pnpm test:local' },
+			} as ReturnType<typeof config.getConfig>);
+
+			const result = resolveTestCommand('anything-goes');
+			expect(result.bin).toBe('anything-goes');
+		});
+
+		it('allows any command when no config loaded', () => {
+			vi.mocked(config.hasConfig).mockReturnValue(false);
+
+			const result = resolveTestCommand('custom-command');
+			expect(result.bin).toBe('custom-command');
 		});
 	});
 });

--- a/packages/testing/janitor/src/utils/test-command.ts
+++ b/packages/testing/janitor/src/utils/test-command.ts
@@ -10,12 +10,25 @@ import { getConfig, hasConfig } from '../config.js';
 const DEFAULT_TEST_COMMAND = 'npx playwright test';
 const DEFAULT_WORKERS = 1;
 
+export interface ResolvedCommand {
+	bin: string;
+	args: string[];
+}
+
 function getWorkerCount(): number {
 	if (hasConfig()) {
 		const config = getConfig();
 		return config.tcr?.workerCount ?? DEFAULT_WORKERS;
 	}
 	return DEFAULT_WORKERS;
+}
+
+function getAllowedTestCommands(): string[] | undefined {
+	if (hasConfig()) {
+		const config = getConfig();
+		return config.tcr?.allowedTestCommands;
+	}
+	return undefined;
 }
 
 function getBaseCommand(override?: string): string {
@@ -33,14 +46,36 @@ function getBaseCommand(override?: string): string {
 	return DEFAULT_TEST_COMMAND;
 }
 
-export function resolveTestCommand(override?: string): string {
-	const baseCommand = getBaseCommand(override);
-	const workers = getWorkerCount();
-	return `${baseCommand} --workers=${workers}`;
+function parseCommand(command: string): ResolvedCommand {
+	const parts = command.split(/\s+/).filter(Boolean);
+	if (parts.length === 0) {
+		throw new Error('Test command cannot be empty');
+	}
+	return { bin: parts[0], args: parts.slice(1) };
 }
 
-export function buildTestCommand(testFiles: string[], override?: string): string {
-	const baseCommand = resolveTestCommand(override);
-	const fileArgs = testFiles.join(' ');
-	return `${baseCommand} ${fileArgs}`;
+function validateAgainstAllowlist(command: string): void {
+	const allowedCommands = getAllowedTestCommands();
+	if (!allowedCommands) return;
+
+	if (!allowedCommands.includes(command)) {
+		throw new Error(
+			`Test command "${command}" is not in the allowlist. Allowed commands: ${allowedCommands.join(', ')}`,
+		);
+	}
+}
+
+export function resolveTestCommand(override?: string): ResolvedCommand {
+	const baseCommand = getBaseCommand(override);
+	validateAgainstAllowlist(baseCommand);
+	const workers = getWorkerCount();
+	const parsed = parseCommand(baseCommand);
+	parsed.args.push(`--workers=${workers}`);
+	return parsed;
+}
+
+export function buildTestCommand(testFiles: string[], override?: string): ResolvedCommand {
+	const resolved = resolveTestCommand(override);
+	resolved.args.push(...testFiles);
+	return resolved;
 }

--- a/packages/testing/playwright/janitor.config.mjs
+++ b/packages/testing/playwright/janitor.config.mjs
@@ -81,5 +81,9 @@ export default defineConfig({
 	tcr: {
 		testCommand: 'pnpm test:local',
 		workerCount: 1,
+		allowedTestCommands: [
+			'pnpm test:local',
+			'pnpm test:container:sqlite',
+		],
 	},
 });

--- a/packages/testing/playwright/pages/ChatHubChatPage.ts
+++ b/packages/testing/playwright/pages/ChatHubChatPage.ts
@@ -83,10 +83,6 @@ export class ChatHubChatPage extends BasePage {
 		return this.getChatMessages().nth(index).getByTestId('chat-message-prev-alternative');
 	}
 
-	getNextAlternativeButtonAt(index: number): Locator {
-		return this.getChatMessages().nth(index).getByTestId('chat-message-next-alternative');
-	}
-
 	async clickEditButtonAt(index: number): Promise<void> {
 		await this.hoverMessageActionsAt(index);
 		const editButton = this.getEditButtonAt(index);
@@ -114,15 +110,6 @@ export class ChatHubChatPage extends BasePage {
 		await prevButton.click({ force: true });
 	}
 
-	async clickNextAlternativeButtonAt(index: number): Promise<void> {
-		await this.hoverMessageActionsAt(index);
-		const nextButton = this.getNextAlternativeButtonAt(index);
-		// Wait for streaming to complete - the button is disabled during streaming
-		await nextButton.waitFor({ state: 'visible' });
-		await expect(nextButton).toBeEnabled();
-		await nextButton.click({ force: true });
-	}
-
 	/**
 	 * Hovers over the message content area to reveal hidden action buttons.
 	 * The action buttons are hidden by CSS until the content area is hovered.
@@ -133,9 +120,6 @@ export class ChatHubChatPage extends BasePage {
 		await message.getByTestId('chat-message-actions').waitFor({ state: 'visible' });
 	}
 
-	getAttachButton(): Locator {
-		return this.page.getByRole('button', { name: /attach/i });
-	}
 	getFileInput(): Locator {
 		return this.page.locator('input[type="file"]');
 	}

--- a/packages/testing/playwright/pages/NodeDetailsViewPage.ts
+++ b/packages/testing/playwright/pages/NodeDetailsViewPage.ts
@@ -652,14 +652,6 @@ export class NodeDetailsViewPage extends BasePage {
 		await searchInput.fill(searchTerm);
 	}
 
-	async searchInputData(searchTerm: string) {
-		// Focus the search input to expand it (it has opacity:0 when collapsed)
-		const searchInput = this.inputPanel.getSearchInput();
-		await searchInput.focus();
-		// Wait for the search input to become visible after focus triggers expansion
-		await searchInput.waitFor({ state: 'visible' });
-		await searchInput.fill(searchTerm);
-	}
 	/**
 	 * Type multiple values into the first available text parameter field
 	 * Useful for testing multiple parameter changes

--- a/packages/testing/playwright/pages/SettingsUsersPage.ts
+++ b/packages/testing/playwright/pages/SettingsUsersPage.ts
@@ -25,11 +25,6 @@ export class SettingsUsersPage extends BasePage {
 		await searchInput.fill(email);
 	}
 
-	async clickTransferUser(email: string) {
-		await this.openActions(email);
-		await this.page.getByTestId('action-transfer').click();
-	}
-
 	async transferData(emailOrName: string) {
 		await this.page
 			.getByRole('radio', {

--- a/packages/testing/playwright/pages/TemplateCredentialSetupPage.ts
+++ b/packages/testing/playwright/pages/TemplateCredentialSetupPage.ts
@@ -41,12 +41,6 @@ export class TemplateCredentialSetupPage extends BasePage {
 		return this.page.getByTestId('setup-workflow-credentials-modal');
 	}
 
-	getSetupCredentialModalCloseButton(): Locator {
-		return this.page
-			.getByTestId('setup-workflow-credentials-modal')
-			.getByRole('button', { name: 'Close this dialog' });
-	}
-
 	getSetupCredentialModalSteps(): Locator {
 		return this.page
 			.getByTestId('setup-workflow-credentials-modal')
@@ -73,10 +67,5 @@ export class TemplateCredentialSetupPage extends BasePage {
 		const messageBox = this.getMessageBox();
 		await messageBox.waitFor({ state: 'visible' });
 		await messageBox.locator('.btn--cancel').click();
-	}
-
-	async closeSetupCredentialModal(): Promise<void> {
-		await this.getSetupCredentialModalCloseButton().click();
-		await this.getCanvasCredentialModal().waitFor({ state: 'hidden' });
 	}
 }

--- a/packages/testing/playwright/pages/WorkflowSharingModal.ts
+++ b/packages/testing/playwright/pages/WorkflowSharingModal.ts
@@ -9,10 +9,6 @@ export class WorkflowSharingModal extends BasePage {
 		return this.page.getByTestId('project-sharing-select').filter({ visible: true });
 	}
 
-	getVisibleDropdown() {
-		return this.page.locator('.el-select-dropdown:visible');
-	}
-
 	async addUser(emailOrName: string) {
 		await this.clickByTestId('project-sharing-select');
 		// Try to find by email or name (personal projects now show "Personal space" instead of email)

--- a/packages/testing/playwright/services/api-helper.ts
+++ b/packages/testing/playwright/services/api-helper.ts
@@ -11,6 +11,7 @@ import {
 } from '../config/test-users';
 import { TestError } from '../Types';
 import { CredentialApiHelper } from './credential-api-helper';
+import { ExternalSecretsApiHelper } from './external-secrets-api-helper';
 import { McpApiHelper } from './mcp-api-helper';
 import { ProjectApiHelper } from './project-api-helper';
 import { PublicApiHelper } from './public-api-helper';
@@ -50,6 +51,7 @@ export class ApiHelpers {
 	projects: ProjectApiHelper;
 	credentials: CredentialApiHelper;
 	variables: VariablesApiHelper;
+	externalSecrets: ExternalSecretsApiHelper;
 	users: UserApiHelper;
 	tags: TagApiHelper;
 	roles: RoleApiHelper;
@@ -65,6 +67,7 @@ export class ApiHelpers {
 		this.projects = new ProjectApiHelper(this);
 		this.credentials = new CredentialApiHelper(this);
 		this.variables = new VariablesApiHelper(this);
+		this.externalSecrets = new ExternalSecretsApiHelper(this);
 		this.users = new UserApiHelper(this);
 		this.tags = new TagApiHelper(this);
 		this.roles = new RoleApiHelper(this);

--- a/packages/testing/playwright/services/api-helper.ts
+++ b/packages/testing/playwright/services/api-helper.ts
@@ -268,24 +268,6 @@ export class ApiHelpers {
 	}
 
 	/**
-	 * Create an API helper for a specific base URL.
-	 * Useful for multi-main testing where you want to send requests
-	 * directly to a specific main instance (bypassing the load balancer).
-	 *
-	 * @param baseUrl - The base URL to use (e.g., from n8nContainer.mainUrls[0])
-	 * @returns A new ApiHelpers instance configured for the specified URL
-	 */
-	static async createForUrl(baseUrl: string): Promise<ApiHelpers> {
-		const context = await request.newContext({ baseURL: baseUrl });
-		return new ApiHelpers(context);
-	}
-
-	async get(path: string, params?: URLSearchParams) {
-		const response = await this.request.get(path, { params });
-		const { data } = await response.json();
-		return data;
-	}
-	/**
 	 * Check if n8n is healthy
 	 * @returns True if n8n is healthy, false otherwise
 	 */
@@ -397,26 +379,6 @@ export class ApiHelpers {
 	}
 
 	// ===== MCP API KEY METHODS =====
-
-	/**
-	 * Get or create MCP API key for the authenticated user.
-	 * If the user already has an API key, returns the existing one (redacted).
-	 * If not, creates a new one and returns the full key.
-	 *
-	 * @returns The MCP API key data including the key itself
-	 */
-	async getMcpApiKey(): Promise<{ id: string; apiKey: string; userId: string }> {
-		const response = await this.request.get('/rest/mcp/api-key');
-
-		if (!response.ok()) {
-			throw new TestError(
-				`Failed to get MCP API key: ${response.status()} ${await response.text()}`,
-			);
-		}
-
-		const result = await response.json();
-		return result.data ?? result;
-	}
 
 	/**
 	 * Rotate the MCP API key for the authenticated user.

--- a/packages/testing/playwright/services/external-secrets-api-helper.ts
+++ b/packages/testing/playwright/services/external-secrets-api-helper.ts
@@ -1,0 +1,105 @@
+import type { ApiHelpers } from './api-helper';
+import { TestError } from '../Types';
+
+interface ExternalSecretsProviderSettings {
+	region: string;
+	authMethod: string;
+	accessKeyId: string;
+	secretAccessKey: string;
+}
+
+interface SecretProviderConnectionDto {
+	providerKey: string;
+	type: string;
+	projectIds?: string[];
+	settings: ExternalSecretsProviderSettings;
+}
+
+export class ExternalSecretsApiHelper {
+	constructor(private api: ApiHelpers) {}
+
+	async getSecrets(providerName: string): Promise<string[]> {
+		const response = await this.api.request.get('/rest/external-secrets/secrets');
+
+		if (!response.ok()) {
+			throw new TestError(`Failed to get secrets: ${await response.text()}`);
+		}
+
+		const { data } = await response.json();
+		return data[providerName] ?? [];
+	}
+
+	async saveProviderSettings(
+		providerName: string,
+		settings: ExternalSecretsProviderSettings,
+	): Promise<void> {
+		const response = await this.api.request.post(
+			`/rest/external-secrets/providers/${providerName}`,
+			{ data: settings },
+		);
+
+		if (!response.ok()) {
+			throw new TestError(`Failed to save provider settings: ${await response.text()}`);
+		}
+	}
+
+	async testProvider(
+		providerName: string,
+		settings: ExternalSecretsProviderSettings,
+	): Promise<void> {
+		const response = await this.api.request.post(
+			`/rest/external-secrets/providers/${providerName}/test`,
+			{ data: settings },
+		);
+
+		if (!response.ok()) {
+			throw new TestError(`Failed to test provider: ${await response.text()}`);
+		}
+	}
+
+	async connectProvider(providerName: string): Promise<void> {
+		const response = await this.api.request.post(
+			`/rest/external-secrets/providers/${providerName}/connect`,
+			{ data: { connected: true } },
+		);
+
+		if (!response.ok()) {
+			throw new TestError(`Failed to connect provider: ${await response.text()}`);
+		}
+	}
+
+	async updateProvider(providerName: string): Promise<void> {
+		const response = await this.api.request.post(
+			`/rest/external-secrets/providers/${providerName}/update`,
+		);
+
+		if (!response.ok()) {
+			throw new TestError(`Failed to update provider: ${await response.text()}`);
+		}
+	}
+
+	async createConnection(
+		connection: SecretProviderConnectionDto,
+	): Promise<Record<string, unknown>> {
+		const response = await this.api.request.post('/rest/secret-providers/connections', {
+			data: connection,
+		});
+
+		if (!response.ok()) {
+			throw new TestError(`Failed to create connection: ${await response.text()}`);
+		}
+
+		const result = await response.json();
+		return result.data ?? result;
+	}
+
+	async deleteConnection(providerKey: string): Promise<void> {
+		const response = await this.api.request.delete(
+			`/rest/secret-providers/connections/${providerKey}`,
+		);
+
+		if (!response.ok()) {
+			throw new TestError(`Failed to delete connection: ${await response.text()}`);
+		}
+	}
+}

--- a/packages/testing/playwright/tests/e2e/settings/external-secrets/aws-secrets-manager.spec.ts
+++ b/packages/testing/playwright/tests/e2e/settings/external-secrets/aws-secrets-manager.spec.ts
@@ -1,59 +1,45 @@
 import { expect, test } from '../../../../fixtures/base';
-import type { n8nPage } from '../../../../pages/n8nPage';
 
 test.use({ capability: 'external-secrets' });
 test.setTimeout(180_000);
 
-test.describe('AWS Secrets Manager with LocalStack @capability:external-secrets @licensed', {
-	annotation: [
-		{ type: 'owner', description: 'Lifecycle & Governance' },
-	],
-}, () => {
-	const PROVIDER_NAME = 'awsSecretsManager';
-	const PROVIDER_BASE_URL = `/rest/external-secrets/providers/${PROVIDER_NAME}`;
-	const PROVIDER_SETTINGS = {
-		region: 'us-east-1',
-		authMethod: 'iamUser',
-		accessKeyId: 'test',
-		secretAccessKey: 'test',
-	};
+test.describe(
+	'AWS Secrets Manager with LocalStack @capability:external-secrets @licensed',
+	{
+		annotation: [{ type: 'owner', description: 'Lifecycle & Governance' }],
+	},
+	() => {
+		const PROVIDER_NAME = 'awsSecretsManager';
+		const PROVIDER_SETTINGS = {
+			region: 'us-east-1',
+			authMethod: 'iamUser',
+			accessKeyId: 'test',
+			secretAccessKey: 'test',
+		};
 
-	async function getSecrets(n8n: n8nPage): Promise<string[]> {
-		const response = await n8n.api.request.get('/rest/external-secrets/secrets');
-		const { data } = await response.json();
-		return data[PROVIDER_NAME] ?? [];
-	}
-
-	test.beforeEach(async ({ n8n, services }) => {
-		await services.localstack.secretsManager.clear();
-		await n8n.api.enableFeature('externalSecrets');
-	});
-
-	test('can configure, connect, and sync secrets from LocalStack', async ({ n8n, services }) => {
-		const { secretsManager } = services.localstack;
-
-		await secretsManager.createSecret('api-key', 'secret-123');
-
-		const settingsResponse = await n8n.api.request.post(PROVIDER_BASE_URL, {
-			data: PROVIDER_SETTINGS,
+		test.beforeEach(async ({ n8n, services }) => {
+			await services.localstack.secretsManager.clear();
+			await n8n.api.enableFeature('externalSecrets');
 		});
-		expect(settingsResponse.ok()).toBeTruthy();
 
-		const testResponse = await n8n.api.request.post(`${PROVIDER_BASE_URL}/test`, {
-			data: PROVIDER_SETTINGS,
+		test('can configure, connect, and sync secrets from LocalStack', async ({ n8n, services }) => {
+			const { secretsManager } = services.localstack;
+
+			await secretsManager.createSecret('api-key', 'secret-123');
+
+			await n8n.api.externalSecrets.saveProviderSettings(PROVIDER_NAME, PROVIDER_SETTINGS);
+			await n8n.api.externalSecrets.testProvider(PROVIDER_NAME, PROVIDER_SETTINGS);
+			await n8n.api.externalSecrets.connectProvider(PROVIDER_NAME);
+			await n8n.api.externalSecrets.updateProvider(PROVIDER_NAME);
+
+			expect(await n8n.api.externalSecrets.getSecrets(PROVIDER_NAME)).toContain('api-key');
+
+			await secretsManager.createSecret('new-secret', 'value-2');
+			await n8n.api.externalSecrets.updateProvider(PROVIDER_NAME);
+
+			const secrets = await n8n.api.externalSecrets.getSecrets(PROVIDER_NAME);
+			expect(secrets).toContain('api-key');
+			expect(secrets).toContain('new-secret');
 		});
-		expect(testResponse.ok()).toBeTruthy();
-
-		await n8n.api.request.post(`${PROVIDER_BASE_URL}/connect`, { data: { connected: true } });
-		await n8n.api.request.post(`${PROVIDER_BASE_URL}/update`);
-
-		expect(await getSecrets(n8n)).toContain('api-key');
-
-		await secretsManager.createSecret('new-secret', 'value-2');
-		await n8n.api.request.post(`${PROVIDER_BASE_URL}/update`);
-
-		const secrets = await getSecrets(n8n);
-		expect(secrets).toContain('api-key');
-		expect(secrets).toContain('new-secret');
-	});
-});
+	},
+);

--- a/packages/testing/playwright/tests/e2e/settings/external-secrets/secret-providers-connections.spec.ts
+++ b/packages/testing/playwright/tests/e2e/settings/external-secrets/secret-providers-connections.spec.ts
@@ -5,51 +5,51 @@ test.use({ capability: 'external-secrets' });
 // LocalStack can take time to start up
 test.setTimeout(180_000);
 
-test.describe('Secret Providers Connections with LocalStack @capability:external-secrets @licensed', {
-	annotation: [
-		{ type: 'owner', description: 'Lifecycle & Governance' },
-	],
-}, () => {
-	const PROVIDER_KEY = 'aws-localstack-e2e';
-	const PROVIDER_TYPE = 'awsSecretsManager';
+test.describe(
+	'Secret Providers Connections with LocalStack @capability:external-secrets @licensed',
+	{
+		annotation: [{ type: 'owner', description: 'Lifecycle & Governance' }],
+	},
+	() => {
+		const PROVIDER_KEY = 'aws-localstack-e2e';
+		const PROVIDER_TYPE = 'awsSecretsManager';
 
-	test.beforeEach(async ({ n8n, services }) => {
-		// N8N_ENV_FEAT_EXTERNAL_SECRETS_FOR_PROJECTS is set at container startup
-		// via the external-secrets capability config
+		test.beforeEach(async ({ n8n, services }) => {
+			// N8N_ENV_FEAT_EXTERNAL_SECRETS_FOR_PROJECTS is set at container startup
+			// via the external-secrets capability config
 
-		// Enable the external secrets license feature
-		await n8n.api.enableFeature('externalSecrets');
+			// Enable the external secrets license feature
+			await n8n.api.enableFeature('externalSecrets');
 
-		// Clear any existing secrets from previous tests
-		await services.localstack.secretsManager.clear();
-	});
+			// Clear any existing secrets from previous tests
+			await services.localstack.secretsManager.clear();
+		});
 
-	test.afterEach(async ({ n8n }) => {
-		// Clean up: delete the test connection if it exists
-		try {
-			await n8n.api.request.delete(`/rest/secret-providers/connections/${PROVIDER_KEY}`);
-		} catch {
-			// Ignore errors if connection doesn't exist
-		}
-	});
+		test.afterEach(async ({ n8n }) => {
+			// Clean up: delete the test connection if it exists
+			try {
+				await n8n.api.externalSecrets.deleteConnection(PROVIDER_KEY);
+			} catch {
+				// Ignore errors if connection doesn't exist
+			}
+		});
 
-	test('can create a connection pointing to LocalStack', async ({ n8n, services }) => {
-		// Arrange: Seed secrets in LocalStack
-		await services.localstack.secretsManager.createSecret('e2e-api-key', 'secret-123');
-		await services.localstack.secretsManager.createSecret(
-			'e2e-db-credentials',
-			JSON.stringify({ username: 'admin', password: 'hunter2' }),
-		);
+		test('can create a connection pointing to LocalStack', async ({ n8n, services }) => {
+			// Arrange: Seed secrets in LocalStack
+			await services.localstack.secretsManager.createSecret('e2e-api-key', 'secret-123');
+			await services.localstack.secretsManager.createSecret(
+				'e2e-db-credentials',
+				JSON.stringify({ username: 'admin', password: 'hunter2' }),
+			);
 
-		// Verify secrets exist in LocalStack
-		const secrets = await services.localstack.secretsManager.listSecrets();
-		expect(secrets).toContain('e2e-api-key');
-		expect(secrets).toContain('e2e-db-credentials');
+			// Verify secrets exist in LocalStack
+			const secrets = await services.localstack.secretsManager.listSecrets();
+			expect(secrets).toContain('e2e-api-key');
+			expect(secrets).toContain('e2e-db-credentials');
 
-		// Act: Create a connection with settings that would work with LocalStack
-		// (n8n container has AWS_ENDPOINT_URL set to point to LocalStack)
-		const createResponse = await n8n.api.request.post('/rest/secret-providers/connections', {
-			data: {
+			// Act: Create a connection with settings that would work with LocalStack
+			// (n8n container has AWS_ENDPOINT_URL set to point to LocalStack)
+			const created = await n8n.api.externalSecrets.createConnection({
 				providerKey: PROVIDER_KEY,
 				type: PROVIDER_TYPE,
 				projectIds: [],
@@ -59,15 +59,13 @@ test.describe('Secret Providers Connections with LocalStack @capability:external
 					accessKeyId: 'test',
 					secretAccessKey: 'test',
 				},
-			},
+			});
+
+			// Assert: Connection created successfully
+			expect(created.name).toBe(PROVIDER_KEY);
+			expect(created.type).toBe(PROVIDER_TYPE);
+
+			// TODO - this test should verify that the secrets are loaded - but that functionality is not there yet
 		});
-
-		// Assert: Connection created successfully
-		expect(createResponse.ok()).toBeTruthy();
-		const created = await createResponse.json();
-		expect(created.data.name).toBe(PROVIDER_KEY);
-		expect(created.data.type).toBe(PROVIDER_TYPE);
-
-		// TODO - this test should verify that the secrets are loaded - but that functionality is not there yet
-	});
-});
+	},
+);


### PR DESCRIPTION
## Summary

Hardens the janitor's TCR workflow against command injection and cleans up Playwright test architecture violations.

**TCR hardening:**
- Replace `execSync(string)` with `execFileSync(bin, args)` to prevent shell operator chaining (`|| true`, `; exit 0`)
- Add `allowedTestCommands` config option — when set, `--test-command` must match the allowlist
- Early command validation in `run()` with clear `test-command-rejected` failure step
- Fail-closed baseline validation — git failures now block commits instead of silently passing
- Return structured `ResolvedCommand` type (`{ bin, args }`) instead of raw command strings

**Test architecture cleanup:**
- Extract `external-secrets-api-helper.ts` from `api-helper.ts` to fix api-purity violations
- Remove dead code from page objects (`ChatHubChatPage`, `NodeDetailsViewPage`, `SettingsUsersPage`, `TemplateCredentialSetupPage`, `WorkflowSharingModal`)

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to #24869

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)