### PR TITLE
test: Normalize page object navigation methods to goto

### DIFF
--- a/packages/testing/playwright/composables/MfaComposer.ts
+++ b/packages/testing/playwright/composables/MfaComposer.ts
@@ -14,7 +14,7 @@ export class MfaComposer {
 	 */
 	async enableMfa(email: string, password: string, mfaSecret: string): Promise<void> {
 		await this.n8n.signIn.loginWithEmailAndPassword(email, password, true);
-		await this.n8n.settingsPersonal.goToPersonalSettings();
+		await this.n8n.settingsPersonal.goto();
 
 		await this.n8n.settingsPersonal.clickEnableMfa();
 

--- a/packages/testing/playwright/pages/SettingsPersonalPage.ts
+++ b/packages/testing/playwright/pages/SettingsPersonalPage.ts
@@ -10,7 +10,7 @@ export class SettingsPersonalPage extends BasePage {
 		return this.page.getByTestId('menu-item');
 	}
 
-	async goToSettings() {
+	async gotoSettings() {
 		await this.page.goto('/settings');
 	}
 
@@ -18,7 +18,7 @@ export class SettingsPersonalPage extends BasePage {
 		return this.page.getByTestId('current-user-role');
 	}
 
-	async goToPersonalSettings(): Promise<void> {
+	async goto(): Promise<void> {
 		await this.page.goto('/settings/personal');
 	}
 
@@ -65,7 +65,7 @@ export class SettingsPersonalPage extends BasePage {
 	 * @param lastName - The new last name
 	 */
 	async updateFirstAndLastName(firstName: string, lastName: string): Promise<void> {
-		await this.goToPersonalSettings();
+		await this.goto();
 		await this.fillPersonalData(firstName, lastName);
 		await this.saveSettings();
 	}
@@ -98,7 +98,7 @@ export class SettingsPersonalPage extends BasePage {
 	 * Navigate to personal settings and initiate MFA disable workflow
 	 */
 	async triggerDisableMfa(): Promise<void> {
-		await this.goToPersonalSettings();
+		await this.goto();
 		await this.clickDisableMfa();
 	}
 

--- a/packages/testing/playwright/pages/SignInPage.ts
+++ b/packages/testing/playwright/pages/SignInPage.ts
@@ -19,7 +19,7 @@ export class SignInPage extends BasePage {
 		return this.page.getByRole('button', { name: /continue with sso/i });
 	}
 
-	async goToSignIn(): Promise<void> {
+	async goto(): Promise<void> {
 		await this.page.goto('/signin');
 	}
 
@@ -46,7 +46,7 @@ export class SignInPage extends BasePage {
 		password: string,
 		waitForWorkflow = false,
 	): Promise<void> {
-		await this.goToSignIn();
+		await this.goto();
 		await this.fillEmail(email);
 		await this.fillPassword(password);
 		await this.clickSubmit();

--- a/packages/testing/playwright/pages/TemplateCredentialSetupPage.ts
+++ b/packages/testing/playwright/pages/TemplateCredentialSetupPage.ts
@@ -5,6 +5,7 @@ import { CredentialModal } from './components/CredentialModal';
 
 export class TemplateCredentialSetupPage extends BasePage {
 	readonly credentialModal = new CredentialModal(this.page.getByTestId('editCredential-modal'));
+
 	getTitle(titleText: string): Locator {
 		return this.page.getByRole('heading', { name: titleText, level: 1 });
 	}

--- a/packages/testing/playwright/pages/WorkerViewPage.ts
+++ b/packages/testing/playwright/pages/WorkerViewPage.ts
@@ -13,7 +13,7 @@ export class WorkerViewPage extends BasePage {
 		return this.page.getByTestId('menu-item').getByText('Workers', { exact: true });
 	}
 
-	async visitWorkerView() {
+	async goto() {
 		await this.page.goto('/settings/workers');
 	}
 }

--- a/packages/testing/playwright/tests/e2e/auth/admin-smoke.spec.ts
+++ b/packages/testing/playwright/tests/e2e/auth/admin-smoke.spec.ts
@@ -1,19 +1,21 @@
 import { test, expect } from '../../../fixtures/base';
 
-test.describe('Admin user', {
-	annotation: [
-		{ type: 'owner', description: 'Identity & Access' },
-	],
-}, () => {
-	test('should see same Settings sub menu items as instance owner', async ({ n8n }) => {
-		await n8n.api.setupTest('signin-only', 'owner');
-		await n8n.settingsPersonal.goToSettings();
+test.describe(
+	'Admin user',
+	{
+		annotation: [{ type: 'owner', description: 'Identity & Access' }],
+	},
+	() => {
+		test('should see same Settings sub menu items as instance owner', async ({ n8n }) => {
+			await n8n.api.setupTest('signin-only', 'owner');
+			await n8n.settingsPersonal.gotoSettings();
 
-		const ownerMenuItems = await n8n.settingsPersonal.getMenuItems().count();
+			const ownerMenuItems = await n8n.settingsPersonal.getMenuItems().count();
 
-		await n8n.api.setupTest('signin-only', 'admin');
-		await n8n.settingsPersonal.goToSettings();
+			await n8n.api.setupTest('signin-only', 'admin');
+			await n8n.settingsPersonal.gotoSettings();
 
-		await expect(n8n.settingsPersonal.getMenuItems()).toHaveCount(ownerMenuItems);
-	});
-});
+			await expect(n8n.settingsPersonal.getMenuItems()).toHaveCount(ownerMenuItems);
+		});
+	},
+);

--- a/packages/testing/playwright/tests/e2e/auth/signin.spec.ts
+++ b/packages/testing/playwright/tests/e2e/auth/signin.spec.ts
@@ -1,21 +1,23 @@
 import { INSTANCE_OWNER_CREDENTIALS } from '../../../config/test-users';
 import { test, expect } from '../../../fixtures/base';
 
-test.describe('Sign In', {
-	annotation: [
-		{ type: 'owner', description: 'Identity & Access' },
-	],
-}, () => {
-	test('should login and logout @auth:none', async ({ n8n }) => {
-		await n8n.goHome();
+test.describe(
+	'Sign In',
+	{
+		annotation: [{ type: 'owner', description: 'Identity & Access' }],
+	},
+	() => {
+		test('should login and logout @auth:none', async ({ n8n }) => {
+			await n8n.goHome();
 
-		await n8n.signIn.goToSignIn();
+			await n8n.signIn.goto();
 
-		await n8n.signIn.loginWithEmailAndPassword(
-			INSTANCE_OWNER_CREDENTIALS.email,
-			INSTANCE_OWNER_CREDENTIALS.password,
-		);
+			await n8n.signIn.loginWithEmailAndPassword(
+				INSTANCE_OWNER_CREDENTIALS.email,
+				INSTANCE_OWNER_CREDENTIALS.password,
+			);
 
-		await expect(n8n.sideBar.getSettings()).toBeVisible();
-	});
-});
+			await expect(n8n.sideBar.getSettings()).toBeVisible();
+		});
+	},
+);

--- a/packages/testing/playwright/tests/e2e/settings/personal/personal.spec.ts
+++ b/packages/testing/playwright/tests/e2e/settings/personal/personal.spec.ts
@@ -24,36 +24,38 @@ const VALID_NAMES = [
 	['Милорад', 'Филиповић'],
 ];
 
-test.describe('Personal Settings', {
-	annotation: [
-		{ type: 'owner', description: 'Identity & Access' },
-	],
-}, () => {
-	test('should allow to change first and last name', async ({ n8n }) => {
-		await n8n.settingsPersonal.goToPersonalSettings();
+test.describe(
+	'Personal Settings',
+	{
+		annotation: [{ type: 'owner', description: 'Identity & Access' }],
+	},
+	() => {
+		test('should allow to change first and last name', async ({ n8n }) => {
+			await n8n.settingsPersonal.goto();
 
-		for (const name of VALID_NAMES) {
-			await n8n.settingsPersonal.fillPersonalData(name[0], name[1]);
-			await n8n.settingsPersonal.saveSettings();
+			for (const name of VALID_NAMES) {
+				await n8n.settingsPersonal.fillPersonalData(name[0], name[1]);
+				await n8n.settingsPersonal.saveSettings();
 
-			await expect(
-				n8n.notifications.getNotificationByTitleOrContent('Personal details updated'),
-			).toBeVisible();
-			await n8n.notifications.closeNotificationByText('Personal details updated');
-		}
-	});
+				await expect(
+					n8n.notifications.getNotificationByTitleOrContent('Personal details updated'),
+				).toBeVisible();
+				await n8n.notifications.closeNotificationByText('Personal details updated');
+			}
+		});
 
-	test('should not allow malicious values for personal data', async ({ n8n }) => {
-		await n8n.settingsPersonal.goToPersonalSettings();
+		test('should not allow malicious values for personal data', async ({ n8n }) => {
+			await n8n.settingsPersonal.goto();
 
-		for (const name of INVALID_NAMES) {
-			await n8n.settingsPersonal.fillPersonalData(name, name);
-			await n8n.settingsPersonal.saveSettings();
+			for (const name of INVALID_NAMES) {
+				await n8n.settingsPersonal.fillPersonalData(name, name);
+				await n8n.settingsPersonal.saveSettings();
 
-			await expect(
-				n8n.notifications.getNotificationByTitleOrContent('Problem updating your details'),
-			).toBeVisible();
-			await n8n.notifications.closeNotificationByText('Problem updating your details');
-		}
-	});
-});
+				await expect(
+					n8n.notifications.getNotificationByTitleOrContent('Problem updating your details'),
+				).toBeVisible();
+				await n8n.notifications.closeNotificationByText('Problem updating your details');
+			}
+		});
+	},
+);

--- a/packages/testing/playwright/tests/e2e/settings/personal/two-factor-authentication.spec.ts
+++ b/packages/testing/playwright/tests/e2e/settings/personal/two-factor-authentication.spec.ts
@@ -18,93 +18,95 @@ const NOTIFICATIONS = {
 const { email, password, mfaSecret, mfaRecoveryCodes } = INSTANCE_OWNER_CREDENTIALS;
 const RECOVERY_CODE = mfaRecoveryCodes![0];
 
-test.describe('Two-factor authentication @auth:none @db:reset', {
-	annotation: [
-		{ type: 'owner', description: 'Identity & Access' },
-	],
-}, () => {
-	test.describe.configure({ mode: 'serial' });
+test.describe(
+	'Two-factor authentication @auth:none @db:reset',
+	{
+		annotation: [{ type: 'owner', description: 'Identity & Access' }],
+	},
+	() => {
+		test.describe.configure({ mode: 'serial' });
 
-	test('Should be able to login with MFA code', async ({ n8n }) => {
-		await n8n.mfaComposer.enableMfa(email, password, mfaSecret!);
-		await n8n.sideBar.signOutFromWorkflows();
+		test('Should be able to login with MFA code', async ({ n8n }) => {
+			await n8n.mfaComposer.enableMfa(email, password, mfaSecret!);
+			await n8n.sideBar.signOutFromWorkflows();
 
-		await n8n.mfaComposer.loginWithMfaCode(email, password, mfaSecret!);
+			await n8n.mfaComposer.loginWithMfaCode(email, password, mfaSecret!);
 
-		await expect(n8n.page).toHaveURL(/workflows/);
-	});
+			await expect(n8n.page).toHaveURL(/workflows/);
+		});
 
-	test('Should be able to login with MFA recovery code', async ({ n8n }) => {
-		await n8n.mfaComposer.enableMfa(email, password, mfaSecret!);
-		await n8n.sideBar.signOutFromWorkflows();
+		test('Should be able to login with MFA recovery code', async ({ n8n }) => {
+			await n8n.mfaComposer.enableMfa(email, password, mfaSecret!);
+			await n8n.sideBar.signOutFromWorkflows();
 
-		await n8n.mfaComposer.loginWithMfaRecoveryCode(email, password, RECOVERY_CODE);
+			await n8n.mfaComposer.loginWithMfaRecoveryCode(email, password, RECOVERY_CODE);
 
-		await expect(n8n.page).toHaveURL(/workflows/);
-	});
+			await expect(n8n.page).toHaveURL(/workflows/);
+		});
 
-	test('Should be able to disable MFA in account with MFA code', async ({ n8n }) => {
-		await n8n.mfaComposer.enableMfa(email, password, mfaSecret!);
-		await n8n.sideBar.signOutFromWorkflows();
+		test('Should be able to disable MFA in account with MFA code', async ({ n8n }) => {
+			await n8n.mfaComposer.enableMfa(email, password, mfaSecret!);
+			await n8n.sideBar.signOutFromWorkflows();
 
-		await n8n.mfaComposer.loginWithMfaCode(email, password, mfaSecret!);
+			await n8n.mfaComposer.loginWithMfaCode(email, password, mfaSecret!);
 
-		const disableToken = authenticator.generate(mfaSecret!);
-		await n8n.settingsPersonal.triggerDisableMfa();
-		await n8n.settingsPersonal.fillMfaCodeAndSave(disableToken);
+			const disableToken = authenticator.generate(mfaSecret!);
+			await n8n.settingsPersonal.triggerDisableMfa();
+			await n8n.settingsPersonal.fillMfaCodeAndSave(disableToken);
 
-		await expect(n8n.settingsPersonal.getEnableMfaButton()).toBeVisible();
-	});
+			await expect(n8n.settingsPersonal.getEnableMfaButton()).toBeVisible();
+		});
 
-	test('Should prompt for MFA code when email changes', async ({ n8n }) => {
-		await n8n.mfaComposer.enableMfa(email, password, mfaSecret!);
+		test('Should prompt for MFA code when email changes', async ({ n8n }) => {
+			await n8n.mfaComposer.enableMfa(email, password, mfaSecret!);
 
-		await n8n.settingsPersonal.goToPersonalSettings();
-		await n8n.settingsPersonal.fillEmail(TEST_DATA.NEW_EMAIL);
-		await n8n.settingsPersonal.pressEnterOnEmail();
+			await n8n.settingsPersonal.goto();
+			await n8n.settingsPersonal.fillEmail(TEST_DATA.NEW_EMAIL);
+			await n8n.settingsPersonal.pressEnterOnEmail();
 
-		const mfaCode = authenticator.generate(mfaSecret!);
-		await n8n.settingsPersonal.fillMfaCodeAndSave(mfaCode);
+			const mfaCode = authenticator.generate(mfaSecret!);
+			await n8n.settingsPersonal.fillMfaCodeAndSave(mfaCode);
 
-		await expect(
-			n8n.notifications.getNotificationByTitleOrContent(NOTIFICATIONS.PERSONAL_DETAILS_UPDATED),
-		).toBeVisible();
-	});
+			await expect(
+				n8n.notifications.getNotificationByTitleOrContent(NOTIFICATIONS.PERSONAL_DETAILS_UPDATED),
+			).toBeVisible();
+		});
 
-	test('Should prompt for MFA recovery code when email changes', async ({ n8n }) => {
-		await n8n.mfaComposer.enableMfa(email, password, mfaSecret!);
+		test('Should prompt for MFA recovery code when email changes', async ({ n8n }) => {
+			await n8n.mfaComposer.enableMfa(email, password, mfaSecret!);
 
-		await n8n.settingsPersonal.goToPersonalSettings();
-		await n8n.settingsPersonal.fillEmail(TEST_DATA.NEW_EMAIL);
-		await n8n.settingsPersonal.pressEnterOnEmail();
+			await n8n.settingsPersonal.goto();
+			await n8n.settingsPersonal.fillEmail(TEST_DATA.NEW_EMAIL);
+			await n8n.settingsPersonal.pressEnterOnEmail();
 
-		await expect(n8n.settingsPersonal.getMfaCodeOrRecoveryCodeInput()).toBeVisible();
-	});
+			await expect(n8n.settingsPersonal.getMfaCodeOrRecoveryCodeInput()).toBeVisible();
+		});
 
-	test('Should not prompt for MFA code or recovery code when first name or last name changes', async ({
-		n8n,
-	}) => {
-		await n8n.mfaComposer.enableMfa(email, password, mfaSecret!);
+		test('Should not prompt for MFA code or recovery code when first name or last name changes', async ({
+			n8n,
+		}) => {
+			await n8n.mfaComposer.enableMfa(email, password, mfaSecret!);
 
-		await n8n.settingsPersonal.updateFirstAndLastName(
-			TEST_DATA.NEW_FIRST_NAME,
-			TEST_DATA.NEW_LAST_NAME,
-		);
+			await n8n.settingsPersonal.updateFirstAndLastName(
+				TEST_DATA.NEW_FIRST_NAME,
+				TEST_DATA.NEW_LAST_NAME,
+			);
 
-		await expect(
-			n8n.notifications.getNotificationByTitleOrContent(NOTIFICATIONS.PERSONAL_DETAILS_UPDATED),
-		).toBeVisible();
-	});
+			await expect(
+				n8n.notifications.getNotificationByTitleOrContent(NOTIFICATIONS.PERSONAL_DETAILS_UPDATED),
+			).toBeVisible();
+		});
 
-	test('Should be able to disable MFA in account with recovery code', async ({ n8n }) => {
-		await n8n.mfaComposer.enableMfa(email, password, mfaSecret!);
-		await n8n.sideBar.signOutFromWorkflows();
+		test('Should be able to disable MFA in account with recovery code', async ({ n8n }) => {
+			await n8n.mfaComposer.enableMfa(email, password, mfaSecret!);
+			await n8n.sideBar.signOutFromWorkflows();
 
-		await n8n.mfaComposer.loginWithMfaCode(email, password, mfaSecret!);
+			await n8n.mfaComposer.loginWithMfaCode(email, password, mfaSecret!);
 
-		await n8n.settingsPersonal.triggerDisableMfa();
-		await n8n.settingsPersonal.fillMfaCodeAndSave(RECOVERY_CODE);
+			await n8n.settingsPersonal.triggerDisableMfa();
+			await n8n.settingsPersonal.fillMfaCodeAndSave(RECOVERY_CODE);
 
-		await expect(n8n.settingsPersonal.getEnableMfaButton()).toBeVisible();
-	});
-});
+			await expect(n8n.settingsPersonal.getEnableMfaButton()).toBeVisible();
+		});
+	},
+);

--- a/packages/testing/playwright/tests/e2e/settings/workers/workers.spec.ts
+++ b/packages/testing/playwright/tests/e2e/settings/workers/workers.spec.ts
@@ -2,27 +2,29 @@ import { test, expect } from '../../../../fixtures/base';
 
 test.describe
 	.serial('Worker View', () => {
-		test.describe('unlicensed', {
-	annotation: [
-		{ type: 'owner', description: 'Catalysts' },
-	],
-}, () => {
-			test.beforeEach(async ({ n8n }) => {
-				await n8n.api.disableFeature('workerView');
-				await n8n.api.disableFeature('workerView');
-				await n8n.api.setQueueMode(false);
-			});
+		test.describe(
+			'unlicensed',
+			{
+				annotation: [{ type: 'owner', description: 'Catalysts' }],
+			},
+			() => {
+				test.beforeEach(async ({ n8n }) => {
+					await n8n.api.disableFeature('workerView');
+					await n8n.api.disableFeature('workerView');
+					await n8n.api.setQueueMode(false);
+				});
 
-			test('should not show up in the menu sidebar', async ({ n8n }) => {
-				await n8n.workerView.visitWorkerView();
-				await expect(n8n.workerView.getWorkerMenuItem()).toBeHidden();
-			});
+				test('should not show up in the menu sidebar', async ({ n8n }) => {
+					await n8n.workerView.goto();
+					await expect(n8n.workerView.getWorkerMenuItem()).toBeHidden();
+				});
 
-			test('should show action box', async ({ n8n }) => {
-				await n8n.workerView.visitWorkerView();
-				await expect(n8n.workerView.getWorkerViewUnlicensed()).toBeVisible();
-			});
-		});
+				test('should show action box', async ({ n8n }) => {
+					await n8n.workerView.goto();
+					await expect(n8n.workerView.getWorkerViewUnlicensed()).toBeVisible();
+				});
+			},
+		);
 
 		test.describe('licensed', () => {
 			test.beforeEach(async ({ n8n }) => {
@@ -32,12 +34,12 @@ test.describe
 
 			test('should show up in the menu sidebar', async ({ n8n }) => {
 				await n8n.goHome();
-				await n8n.workerView.visitWorkerView();
+				await n8n.workerView.goto();
 				await expect(n8n.workerView.getWorkerMenuItem()).toBeVisible();
 			});
 
 			test('should show worker list view', async ({ n8n }) => {
-				await n8n.workerView.visitWorkerView();
+				await n8n.workerView.goto();
 				await expect(n8n.workerView.getWorkerViewLicensed()).toBeVisible();
 			});
 		});


### PR DESCRIPTION
## Summary

Normalizes inconsistent navigation method names across Playwright page objects to use a consistent `goto()` convention.

**Before:** Page objects had ad-hoc navigation names (`goToSignIn()`, `visitWorkerView()`, `goToPersonalSettings()`, `goToSettings()`)
**After:** All renamed to `goto()` / `gotoSettings()`, matching existing conventions (`DemoPage.goto()`, `SettingsSsoPage.goto()`)

### Changes
- `SignInPage.goToSignIn()` → `goto()`
- `SettingsPersonalPage.goToPersonalSettings()` → `goto()`
- `SettingsPersonalPage.goToSettings()` → `gotoSettings()`
- `WorkerViewPage.visitWorkerView()` → `goto()`
- Updated all callers (tests + MfaComposer)

Committed via janitor TCR (test && commit || revert) — all 6 affected test files passed before the commit landed.

## Related Linear tickets, Github issues, and Community forum posts

Internal test architecture cleanup (no-changelog).

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)