### PR TITLE
fix(core): add 'default' to available binary data modes

### DIFF
--- a/packages/core/src/binary-data/binary-data.config.ts
+++ b/packages/core/src/binary-data/binary-data.config.ts
@@ -21,7 +21,12 @@ const dbMaxFileSizeSchema = z.coerce
 @Config
 export class BinaryDataConfig {
 	/** Available modes of binary data storage, as comma separated strings. */
-	availableModes: z.infer<typeof availableModesSchema> = ['filesystem', 's3', 'database'];
+	availableModes: z.infer<typeof availableModesSchema> = [
+		'default',
+		'filesystem',
+		's3',
+		'database',
+	];
 
 	/** Storage mode for binary data. Defaults to 'filesystem' in regular mode, 'database' in scaling mode. */
 	@Env('N8N_DEFAULT_BINARY_DATA_MODE', binaryDataModesSchema)


### PR DESCRIPTION
This PR resolves a configuration mismatch where the N8N_DEFAULT_BINARY_DATA_MODE environment variable would fail validation when set to default. While the official documentation lists default as a valid value, it was missing from the internal allowed modes schema in the codebase.

Changes:

Added 'default' to the BINARY_DATA_MODES constant.

Updated the availableModes array in the BinaryDataConfig class to include 'default'.

Rebuilt the core package to ensure the compiled JavaScript reflects these changes.

How to test:

Set the environment variable: N8N_DEFAULT_BINARY_DATA_MODE=default.

Start the n8n instance.

Result: The application should now start successfully without a "Validation Error" regarding binary data modes.

(Optional) Inspect packages/core/dist/binary-data/binary-data.config.js to see the updated availableModes array.

Related Linear tickets, Github issues, and Community forum posts
fixes #25747

Review / Merge checklist
[x] PR title and summary are descriptive.

[x] [Docs updated](https://github.com/n8n-io/n8n-docs) (Documentation was already correct; this PR aligns the code to match it).

[x] Tests included (Manually verified via local build and environment variable injection).
<img width="647" height="51" alt="Pic 1 terminal" src="https://github.com/user-attachments/assets/5bb44ff2-d511-45ae-807b-24a674783c3e" />
<img width="579" height="191" alt="pic 2 code" src="https://github.com/user-attachments/assets/259b7cc8-9e5d-44f2-87f4-064c498b64f6" />
