### PR TITLE
fix(OpenAI Node): Prevent empty text config in Responses API requests

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/common.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/common.ts
@@ -137,7 +137,11 @@ export const prepareAdditionalResponsesParams = (options: ModelOptions) => {
 			textConfig.format = removeEmptyProperties(textConfig.format);
 		}
 
-		body.text = textConfig;
+		const cleanedTextConfig =
+			removeEmptyProperties<OpenAIClient.Responses.ResponseTextConfig>(textConfig);
+		if (!isObjectEmpty(cleanedTextConfig)) {
+			body.text = cleanedTextConfig;
+		}
 	}
 
 	if (options.reasoningEffort) {

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/test/common.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/test/common.test.ts
@@ -208,6 +208,20 @@ describe('prepareAdditionalResponsesParams', () => {
 		expect(text).toEqual({ text: { verbosity: 'high', format: { type: 'text' } } });
 	});
 
+	it('does not include text config when textOptions.type is empty', () => {
+		const body = prepareAdditionalResponsesParams({
+			textFormat: { textOptions: { type: '', verbosity: undefined } },
+		} as unknown as IDataObject);
+		expect(body).not.toHaveProperty('text');
+	});
+
+	it('does not include text config when textOptions result in empty object', () => {
+		const body = prepareAdditionalResponsesParams({
+			textFormat: { textOptions: { type: '' } },
+		} as unknown as IDataObject);
+		expect(body).not.toHaveProperty('text');
+	});
+
 	it('sets reasoning effort', () => {
 		const body = prepareAdditionalResponsesParams({
 			reasoningEffort: 'low',

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/test/v2/actions/text/responses.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/test/v2/actions/text/responses.test.ts
@@ -960,6 +960,61 @@ describe('OpenAI Responses Helper Functions', () => {
 			});
 		});
 
+		it('should not include text config when textOptions.type is empty', async () => {
+			const executeFunctions = createExecuteFunctionsMock({});
+			const options = {
+				model: 'gpt-4',
+				messages: [
+					{
+						role: 'user',
+						type: 'text',
+						content: 'Hello',
+					},
+				],
+				options: {
+					textFormat: {
+						textOptions: {
+							type: '',
+							verbosity: undefined,
+						},
+					},
+				},
+				builtInTools: undefined,
+				tools: undefined,
+			};
+
+			const result = await createRequest.call(executeFunctions, 0, options);
+
+			expect(result).not.toHaveProperty('text');
+		});
+
+		it('should not include text config when textOptions result in empty object', async () => {
+			const executeFunctions = createExecuteFunctionsMock({});
+			const options = {
+				model: 'gpt-4',
+				messages: [
+					{
+						role: 'user',
+						type: 'text',
+						content: 'Hello',
+					},
+				],
+				options: {
+					textFormat: {
+						textOptions: {
+							type: '',
+						},
+					},
+				},
+				builtInTools: undefined,
+				tools: undefined,
+			};
+
+			const result = await createRequest.call(executeFunctions, 0, options);
+
+			expect(result).not.toHaveProperty('text');
+		});
+
 		it('should handle built-in tools - web search', async () => {
 			const executeFunctions = createExecuteFunctionsMock({});
 			const options = {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v2/actions/text/helpers/responses.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v2/actions/text/helpers/responses.ts
@@ -197,7 +197,11 @@ export async function createRequest(
 			textConfig.format = removeEmptyProperties(textConfig.format);
 		}
 
-		body.text = textConfig;
+		const cleanedTextConfig =
+			removeEmptyProperties<OpenAIClient.Responses.ResponseTextConfig>(textConfig);
+		if (!isObjectEmpty(cleanedTextConfig)) {
+			body.text = cleanedTextConfig;
+		}
 	}
 
 	if (builtInTools) {


### PR DESCRIPTION
## Summary

When the Responses API text format options have no type selected (the default empty value), the code was including an empty `text: {}` object in the API request body. Strict OpenAI-compatible backends (e.g. LM Studio) reject this with:

```
{"error": {"message": "Required", "type": "invalid_request_error", "param": "text.format", "code": "missing_required_parameter"}}
```

This fix applies `removeEmptyProperties` to the `textConfig` object and only includes it in the request body when it contains meaningful content.

The fix is applied in both code paths that build Responses API requests:
- `responses.ts` (OpenAI Node v2 `createRequest`)
- `common.ts` (LmChatOpenAi sub-node `prepareAdditionalResponsesParams`)

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/issues/24492

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

