### PR TITLE
fix(GitLab & GitHub Triggers): Prevent duplicate webhooks on workflow re-publish

### DIFF
--- a/packages/nodes-base/nodes/Github/GithubTrigger.node.ts
+++ b/packages/nodes-base/nodes/Github/GithubTrigger.node.ts
@@ -509,6 +509,45 @@ export class GithubTrigger implements INodeType {
 				const endpoint = `/repos/${owner}/${repository}/hooks`;
 				const options = this.getNodeParameter('options') as { insecureSSL: boolean };
 
+				const webhookData = this.getWorkflowStaticData('node');
+
+				// Check for existing webhooks first to prevent duplicates
+				// See: https://github.com/n8n-io/n8n/issues/25381
+				let existingWebhooks;
+				try {
+					existingWebhooks = await githubApiRequest.call(this, 'GET', endpoint, {});
+				} catch (error) {
+					if (error.httpCode === '404') {
+						throw new NodeOperationError(
+							this.getNode(),
+							'Check that the repository exists and that you have permission to create the webhooks this node requires',
+							{ level: 'warning' },
+						);
+					}
+					throw error;
+				}
+
+				// Check if a webhook with the same URL already exists
+				for (const webhook of existingWebhooks as IDataObject[]) {
+					if ((webhook.config! as IDataObject).url! === webhookUrl) {
+						// Webhook with same URL found
+						if (JSON.stringify(webhook.events) === JSON.stringify(events)) {
+							// Same events, reuse existing webhook
+							webhookData.webhookId = webhook.id as string;
+							webhookData.webhookEvents = webhook.events as string[];
+							// Legacy webhook without secret - signature verification skipped
+							return true;
+						} else {
+							// Different events, throw error
+							throw new NodeOperationError(
+								this.getNode(),
+								'A webhook with the identical URL but different events exists already. Please delete it manually on Github!',
+								{ level: 'warning' },
+							);
+						}
+					}
+				}
+
 				// Generate a secure random secret for webhook signature verification
 				const webhookSecret = randomBytes(32).toString('hex');
 
@@ -524,40 +563,10 @@ export class GithubTrigger implements INodeType {
 					active: true,
 				};
 
-				const webhookData = this.getWorkflowStaticData('node');
-
 				let responseData;
 				try {
 					responseData = await githubApiRequest.call(this, 'POST', endpoint, body);
 				} catch (error) {
-					if (error.httpCode === '422') {
-						// Webhook exists already
-
-						// Get the data of the already registered webhook
-						responseData = await githubApiRequest.call(this, 'GET', endpoint, body);
-
-						for (const webhook of responseData as IDataObject[]) {
-							if ((webhook.config! as IDataObject).url! === webhookUrl) {
-								// Webhook got found
-								if (JSON.stringify(webhook.events) === JSON.stringify(events)) {
-									// Webhook with same events exists already so no need to
-									// create it again simply save the webhook-id
-									webhookData.webhookId = webhook.id as string;
-									webhookData.webhookEvents = webhook.events as string[];
-									// Legacy webhook without secret on GitHub's side - not setting webhookData.webhookSecret
-									// so signature verification is skipped. To enable it, deactivate and reactivate the workflow.
-									return true;
-								}
-							}
-						}
-
-						throw new NodeOperationError(
-							this.getNode(),
-							'A webhook with the identical URL probably exists already. Please delete it manually on Github!',
-							{ level: 'warning' },
-						);
-					}
-
 					if (error.httpCode === '404') {
 						throw new NodeOperationError(
 							this.getNode(),

--- a/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
+++ b/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
@@ -240,17 +240,35 @@ export class GitlabTrigger implements INodeType {
 
 				const endpoint = `/projects/${path}/hooks`;
 
-				const body = {
-					url: webhookUrl,
-					...events,
-					enable_ssl_verification: false,
-				};
-
-				let responseData;
+				// Check if a webhook with the same URL already exists to avoid duplicates
+				// See: https://github.com/n8n-io/n8n/issues/25381
+				let existingWebhooks;
 				try {
-					responseData = await gitlabApiRequest.call(this, 'POST', endpoint, body);
+					existingWebhooks = await gitlabApiRequest.call(this, 'GET', endpoint, {});
 				} catch (error) {
 					throw new NodeApiError(this.getNode(), error as JsonObject);
+				}
+
+				const existingWebhook = existingWebhooks?.find(
+					(hook: { url: string }) => hook.url === webhookUrl,
+				);
+
+				let responseData;
+				if (existingWebhook?.id) {
+					// Webhook already exists, use the existing one
+					responseData = existingWebhook;
+				} else {
+					const body = {
+						url: webhookUrl,
+						...events,
+						enable_ssl_verification: false,
+					};
+
+					try {
+						responseData = await gitlabApiRequest.call(this, 'POST', endpoint, body);
+					} catch (error) {
+						throw new NodeApiError(this.getNode(), error as JsonObject);
+					}
 				}
 
 				if (responseData.id === undefined) {


### PR DESCRIPTION
## Summary

Fixes #25381 - Webhook duplicates on each publish for GitLab and GitHub

## Bug Description

When a workflow with GitLab or GitHub triggers was published multiple times, a new webhook was registered each time with the same URL, causing duplicate workflow executions.

## Changes

### GitLab Trigger
- Query existing webhooks via GET /projects/{id}/hooks before creating
- Check if webhook with matching URL already exists  
- Use existing webhook ID if found, otherwise create new

### GitHub Trigger  
- Query existing webhooks via GET /repos/{owner}/{repo}/hooks before creating
- Check if webhook with matching URL already exists
- Reuse existing webhook if events match
- Clear error if webhook exists with different events

## Testing

- [x] GitLab: Verified webhook lookup and reuse logic
- [x] GitHub: Verified webhook lookup and reuse logic
- [x] Both: Proper error handling for permission issues

## Related Issue

Fixes #25381