### PR TITLE
Fixes/24919

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
@@ -760,5 +760,28 @@ describe('useWorkflowSaving', () => {
 
 			expect(autosaveStore.autoSaveState).toBe(AutoSaveState.Idle);
 		});
+
+		it('should not schedule autosave on read-only routes (e.g. execution preview)', () => {
+			const autosaveStore = useWorkflowAutosaveStore();
+			autosaveStore.reset();
+
+			const mockRouter = {
+				resolve: vi.fn(),
+				currentRoute: {
+					value: {
+						name: VIEWS.EXECUTION_PREVIEW,
+						params: {},
+						query: {},
+						meta: { readOnlyCanvas: true },
+					},
+				},
+			};
+
+			const { autoSaveWorkflow } = useWorkflowSaving({ router: mockRouter as never });
+
+			autoSaveWorkflow();
+
+			expect(autosaveStore.autoSaveState).toBe(AutoSaveState.Idle);
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
@@ -536,6 +536,11 @@ export function useWorkflowSaving({
 	);
 
 	const scheduleAutoSave = () => {
+		// Don't schedule if on a read-only route (e.g. execution preview)
+		if (router.currentRoute.value.meta?.readOnlyCanvas) {
+			return;
+		}
+
 		// Don't schedule if a save is already in progress - the finally block
 		// will reschedule if there are pending changes
 		if (autosaveStore.autoSaveState === AutoSaveState.InProgress) {

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -329,6 +329,7 @@ const isNDVV2 = computed(() => true);
 const isCanvasReadOnly = computed(() => {
 	return (
 		isDemoRoute.value ||
+		isReadOnlyRoute.value ||
 		isReadOnlyEnvironment.value ||
 		collaborationStore.shouldBeReadOnly ||
 		!(workflowPermissions.value.update ?? projectPermissions.value.workflow.update) ||
@@ -1947,8 +1948,8 @@ watch(
 	() => uiStore.dirtyStateSetCount,
 	(dirtyStateSetCount) => {
 		if (dirtyStateSetCount > 0) {
-			// Skip write access and auto-save in demo mode
-			if (isDemoRoute.value) return;
+			// Skip write access and auto-save in demo mode or read-only routes (e.g. execution preview)
+			if (isDemoRoute.value || isReadOnlyRoute.value) return;
 
 			collaborationStore.requestWriteAccess();
 

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
@@ -290,6 +290,8 @@ const hasOutputConnection = computed(() => {
 });
 
 const valueChanged = (parameterData: IUpdateInformation) => {
+	if (props.readOnly) return;
+
 	let newValue: NodeParameterValue;
 
 	if (parameterData.hasOwnProperty('value')) {


### PR DESCRIPTION
## Summary

Viewing a Code node in the Executions UI triggered repeated "Problem saving workflow" errors because the Node Detail View was not in read-only mode during execution preview. Parameter changes from the Code node editor propagated through valueChanged -> setNodeParameters -> markStateDirty -> autoSaveWorkflow, causing save attempts against a workflow that was only being viewed.

The fix applies defense-in-depth across three layers:

NodeView.vue - Add isReadOnlyRoute to the isCanvasReadOnly computed, which feeds the readOnly prop to NDV. Also guard the dirtyStateSetCount watcher to skip write-access requests and auto-save on read-only routes.
NodeSettings.vue - Early-return from valueChanged() when readOnly prop is true, preventing parameter mutations from reaching the store.
useWorkflowSaving.ts - Skip scheduleAutoSave() when the current route has readOnlyCanvas meta set, preventing save attempts on execution preview and other read-only routes.
The route metadata readOnlyCanvas was already correctly set for execution preview via EDITABLE_CANVAS_VIEWS, but isCanvasReadOnly was not consuming it.

How to test:

Create a workflow with a Code node and execute it
Go to Executions, open the completed execution
Click on the Code node to open the NDV
Confirm no save errors appear in the toast notifications
Confirm the NDV is in read-only mode (parameters not editable)


## Related Linear tickets, Github issues, and Community forum posts

Fixes #24919




## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
