### PR TITLE
Fixes/24872

### DIFF
--- a/packages/cli/src/__tests__/load-nodes-and-credentials.test.ts
+++ b/packages/cli/src/__tests__/load-nodes-and-credentials.test.ts
@@ -555,7 +555,6 @@ describe('LoadNodesAndCredentials', () => {
 
 			await instance.setupHotReload();
 
-			console.log(subscribe);
 			expect(subscribe).toHaveBeenCalledTimes(2);
 			expect(subscribe).toHaveBeenCalledWith('/some/custom/path', expect.any(Function), {
 				ignore: ['**/node_modules/**/node_modules/**'],
@@ -577,6 +576,69 @@ describe('LoadNodesAndCredentials', () => {
 			expect(mockLoader.reset).toHaveBeenCalled();
 			expect(mockLoader.loadAll).toHaveBeenCalled();
 			expect(postProcessSpy).toHaveBeenCalled();
+		});
+
+		it('should watch scoped custom node packages', async () => {
+			jest.spyOn(instance, 'postProcessLoaders').mockResolvedValue(undefined);
+			const subscribe = jest.mocked(watcher.subscribe);
+
+			// Simulate node_modules with a scoped package
+			(fs.readdir as jest.Mock)
+				.mockResolvedValueOnce([
+					{ name: '@my-scope', isDirectory: () => true, isSymbolicLink: () => false },
+				])
+				.mockResolvedValueOnce([
+					{
+						name: 'n8n-nodes-scoped',
+						isDirectory: () => false,
+						isSymbolicLink: () => true,
+					},
+				]);
+
+			(fs.realpath as jest.Mock).mockResolvedValueOnce('/resolved/scoped-node');
+
+			await instance.setupHotReload();
+
+			expect(subscribe).toHaveBeenCalledTimes(2);
+			expect(subscribe).toHaveBeenCalledWith('/some/custom/path', expect.any(Function), {
+				ignore: ['**/node_modules/**/node_modules/**'],
+			});
+			expect(subscribe).toHaveBeenCalledWith('/resolved/scoped-node', expect.any(Function), {
+				ignore: ['**/node_modules/**/node_modules/**'],
+			});
+		});
+
+		it('should watch both scoped and unscoped packages', async () => {
+			jest.spyOn(instance, 'postProcessLoaders').mockResolvedValue(undefined);
+			const subscribe = jest.mocked(watcher.subscribe);
+
+			// Simulate node_modules with both unscoped and scoped packages
+			(fs.readdir as jest.Mock)
+				.mockResolvedValueOnce([
+					{ name: 'n8n-nodes-unscoped', isDirectory: () => true, isSymbolicLink: () => false },
+					{ name: '@org', isDirectory: () => true, isSymbolicLink: () => false },
+				])
+				.mockResolvedValueOnce([
+					{ name: 'n8n-nodes-scoped', isDirectory: () => true, isSymbolicLink: () => false },
+				]);
+
+			(fs.realpath as jest.Mock)
+				.mockResolvedValueOnce('/resolved/unscoped')
+				.mockResolvedValueOnce('/resolved/scoped');
+
+			await instance.setupHotReload();
+
+			// 1 for the base directory + 2 for the resolved packages
+			expect(subscribe).toHaveBeenCalledTimes(3);
+			expect(subscribe).toHaveBeenCalledWith('/some/custom/path', expect.any(Function), {
+				ignore: ['**/node_modules/**/node_modules/**'],
+			});
+			expect(subscribe).toHaveBeenCalledWith('/resolved/unscoped', expect.any(Function), {
+				ignore: ['**/node_modules/**/node_modules/**'],
+			});
+			expect(subscribe).toHaveBeenCalledWith('/resolved/scoped', expect.any(Function), {
+				ignore: ['**/node_modules/**/node_modules/**'],
+			});
 		});
 	});
 

--- a/packages/cli/src/load-nodes-and-credentials.ts
+++ b/packages/cli/src/load-nodes-and-credentials.ts
@@ -17,6 +17,7 @@ import {
 	UnrecognizedNodeTypeError,
 	ExecutionContextHookRegistry,
 	CUSTOM_NODES_PACKAGE_NAME,
+	resolveCustomNodePackagePaths,
 } from 'n8n-core';
 import type {
 	KnownNodesAndCredentials,
@@ -629,30 +630,13 @@ export class LoadNodesAndCredentials {
 
 			// For lazy loaded packages, we need to watch the dist directory
 			const watchPaths = loader.isLazyLoaded ? [path.join(directory, 'dist')] : [directory];
-			const customNodesRoot = path.join(directory, 'node_modules');
 
 			if (loader.packageName === CUSTOM_NODES_PACKAGE_NAME) {
-				const customNodeEntries = await fsPromises.readdir(customNodesRoot, {
-					withFileTypes: true,
-				});
-
-				// Custom nodes are usually symlinked using npm link. Resolve symlinks to support file watching
-				const realCustomNodesPaths = await Promise.all(
-					customNodeEntries
-						.filter(
-							(entry) =>
-								(entry.isDirectory() || entry.isSymbolicLink()) && !entry.name.startsWith('.'),
-						)
-						.map(
-							async (entry) =>
-								await fsPromises.realpath(path.join(customNodesRoot, entry.name)).catch(() => null),
-						),
-				);
-
-				watchPaths.push.apply(
-					watchPaths,
-					realCustomNodesPaths.filter((path): path is string => !!path),
-				);
+				// Custom nodes are usually symlinked using npm link. Resolve symlinks
+				// to support file watching for both scoped (@scope/pkg) and unscoped packages.
+				const customNodesRoot = path.join(directory, 'node_modules');
+				const resolvedPaths = await resolveCustomNodePackagePaths(customNodesRoot);
+				watchPaths.push(...resolvedPaths);
 			}
 
 			this.logger.debug('Watching node folders for hot reload', {

--- a/packages/core/src/nodes-loader/__tests__/utils.test.ts
+++ b/packages/core/src/nodes-loader/__tests__/utils.test.ts
@@ -1,0 +1,214 @@
+import fsPromises from 'fs/promises';
+import path from 'path';
+
+import { resolveCustomNodePackagePaths } from '../utils';
+
+jest.mock('fs/promises');
+
+const mockReaddir = jest.mocked(fsPromises.readdir);
+const mockRealpath = jest.mocked(fsPromises.realpath);
+
+describe('resolveCustomNodePackagePaths', () => {
+	const nodeModulesDir = '/home/user/.n8n/custom/node_modules';
+
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
+
+	it('should resolve unscoped package paths', async () => {
+		mockReaddir.mockResolvedValueOnce([
+			{ name: 'n8n-nodes-example', isDirectory: () => true, isSymbolicLink: () => false },
+		] as never);
+
+		mockRealpath.mockResolvedValueOnce('/real/path/n8n-nodes-example');
+
+		const result = await resolveCustomNodePackagePaths(nodeModulesDir);
+
+		expect(mockReaddir).toHaveBeenCalledWith(nodeModulesDir, { withFileTypes: true });
+		expect(mockRealpath).toHaveBeenCalledWith(
+			path.join(nodeModulesDir, 'n8n-nodes-example'),
+		);
+		expect(result).toEqual(['/real/path/n8n-nodes-example']);
+	});
+
+	it('should resolve scoped package paths', async () => {
+		mockReaddir
+			// First call: read node_modules root
+			.mockResolvedValueOnce([
+				{ name: '@example-scope', isDirectory: () => true, isSymbolicLink: () => false },
+			] as never)
+			// Second call: read @example-scope/ directory
+			.mockResolvedValueOnce([
+				{
+					name: 'n8n-nodes-example',
+					isDirectory: () => true,
+					isSymbolicLink: () => false,
+				},
+			] as never);
+
+		mockRealpath.mockResolvedValueOnce('/real/path/scoped-example');
+
+		const result = await resolveCustomNodePackagePaths(nodeModulesDir);
+
+		expect(mockReaddir).toHaveBeenCalledTimes(2);
+		expect(mockReaddir).toHaveBeenCalledWith(nodeModulesDir, { withFileTypes: true });
+		expect(mockReaddir).toHaveBeenCalledWith(
+			path.join(nodeModulesDir, '@example-scope'),
+			{ withFileTypes: true },
+		);
+		expect(mockRealpath).toHaveBeenCalledWith(
+			path.join(nodeModulesDir, '@example-scope', 'n8n-nodes-example'),
+		);
+		expect(result).toEqual(['/real/path/scoped-example']);
+	});
+
+	it('should resolve both scoped and unscoped packages together', async () => {
+		mockReaddir
+			.mockResolvedValueOnce([
+				{ name: 'n8n-nodes-unscoped', isDirectory: () => true, isSymbolicLink: () => false },
+				{ name: '@my-scope', isDirectory: () => true, isSymbolicLink: () => false },
+			] as never)
+			.mockResolvedValueOnce([
+				{ name: 'n8n-nodes-scoped', isDirectory: () => true, isSymbolicLink: () => false },
+			] as never);
+
+		mockRealpath
+			.mockResolvedValueOnce('/real/unscoped')
+			.mockResolvedValueOnce('/real/scoped');
+
+		const result = await resolveCustomNodePackagePaths(nodeModulesDir);
+
+		expect(result).toEqual(['/real/unscoped', '/real/scoped']);
+	});
+
+	it('should resolve symlinked packages', async () => {
+		mockReaddir.mockResolvedValueOnce([
+			{ name: 'n8n-nodes-linked', isDirectory: () => false, isSymbolicLink: () => true },
+		] as never);
+
+		mockRealpath.mockResolvedValueOnce('/original/source/n8n-nodes-linked');
+
+		const result = await resolveCustomNodePackagePaths(nodeModulesDir);
+
+		expect(result).toEqual(['/original/source/n8n-nodes-linked']);
+	});
+
+	it('should resolve symlinked scoped packages', async () => {
+		mockReaddir
+			.mockResolvedValueOnce([
+				{ name: '@my-scope', isDirectory: () => true, isSymbolicLink: () => false },
+			] as never)
+			.mockResolvedValueOnce([
+				{ name: 'n8n-nodes-linked', isDirectory: () => false, isSymbolicLink: () => true },
+			] as never);
+
+		mockRealpath.mockResolvedValueOnce('/original/source/n8n-nodes-linked');
+
+		const result = await resolveCustomNodePackagePaths(nodeModulesDir);
+
+		expect(result).toEqual(['/original/source/n8n-nodes-linked']);
+	});
+
+	it('should skip hidden entries', async () => {
+		mockReaddir.mockResolvedValueOnce([
+			{ name: '.hidden', isDirectory: () => true, isSymbolicLink: () => false },
+			{ name: 'n8n-nodes-visible', isDirectory: () => true, isSymbolicLink: () => false },
+		] as never);
+
+		mockRealpath.mockResolvedValueOnce('/real/visible');
+
+		const result = await resolveCustomNodePackagePaths(nodeModulesDir);
+
+		expect(mockRealpath).toHaveBeenCalledTimes(1);
+		expect(result).toEqual(['/real/visible']);
+	});
+
+	it('should skip hidden entries inside scope directories', async () => {
+		mockReaddir
+			.mockResolvedValueOnce([
+				{ name: '@scope', isDirectory: () => true, isSymbolicLink: () => false },
+			] as never)
+			.mockResolvedValueOnce([
+				{ name: '.hidden-pkg', isDirectory: () => true, isSymbolicLink: () => false },
+				{ name: 'n8n-nodes-visible', isDirectory: () => true, isSymbolicLink: () => false },
+			] as never);
+
+		mockRealpath.mockResolvedValueOnce('/real/visible');
+
+		const result = await resolveCustomNodePackagePaths(nodeModulesDir);
+
+		expect(mockRealpath).toHaveBeenCalledTimes(1);
+		expect(result).toEqual(['/real/visible']);
+	});
+
+	it('should handle realpath failures gracefully', async () => {
+		mockReaddir.mockResolvedValueOnce([
+			{ name: 'broken-link', isDirectory: () => false, isSymbolicLink: () => true },
+			{ name: 'working-pkg', isDirectory: () => true, isSymbolicLink: () => false },
+		] as never);
+
+		mockRealpath
+			.mockRejectedValueOnce(new Error('ENOENT'))
+			.mockResolvedValueOnce('/real/working');
+
+		const result = await resolveCustomNodePackagePaths(nodeModulesDir);
+
+		expect(result).toEqual(['/real/working']);
+	});
+
+	it('should return empty array when node_modules directory does not exist', async () => {
+		mockReaddir.mockRejectedValueOnce(new Error('ENOENT'));
+
+		const result = await resolveCustomNodePackagePaths(nodeModulesDir);
+
+		expect(result).toEqual([]);
+	});
+
+	it('should handle scope directory read failures gracefully', async () => {
+		mockReaddir
+			.mockResolvedValueOnce([
+				{ name: '@broken-scope', isDirectory: () => true, isSymbolicLink: () => false },
+				{ name: 'n8n-nodes-ok', isDirectory: () => true, isSymbolicLink: () => false },
+			] as never)
+			.mockRejectedValueOnce(new Error('EACCES'));
+
+		mockRealpath.mockResolvedValueOnce('/real/ok');
+
+		const result = await resolveCustomNodePackagePaths(nodeModulesDir);
+
+		expect(result).toEqual(['/real/ok']);
+	});
+
+	it('should handle multiple packages in a single scope', async () => {
+		mockReaddir
+			.mockResolvedValueOnce([
+				{ name: '@my-org', isDirectory: () => true, isSymbolicLink: () => false },
+			] as never)
+			.mockResolvedValueOnce([
+				{ name: 'n8n-nodes-first', isDirectory: () => true, isSymbolicLink: () => false },
+				{ name: 'n8n-nodes-second', isDirectory: () => true, isSymbolicLink: () => false },
+			] as never);
+
+		mockRealpath
+			.mockResolvedValueOnce('/real/first')
+			.mockResolvedValueOnce('/real/second');
+
+		const result = await resolveCustomNodePackagePaths(nodeModulesDir);
+
+		expect(result).toEqual(['/real/first', '/real/second']);
+	});
+
+	it('should skip files (non-directory, non-symlink) at root level', async () => {
+		mockReaddir.mockResolvedValueOnce([
+			{ name: 'package-lock.json', isDirectory: () => false, isSymbolicLink: () => false },
+			{ name: 'n8n-nodes-real', isDirectory: () => true, isSymbolicLink: () => false },
+		] as never);
+
+		mockRealpath.mockResolvedValueOnce('/real/path');
+
+		const result = await resolveCustomNodePackagePaths(nodeModulesDir);
+
+		expect(mockRealpath).toHaveBeenCalledTimes(1);
+		expect(result).toEqual(['/real/path']);
+	});
+});

--- a/packages/core/src/nodes-loader/index.ts
+++ b/packages/core/src/nodes-loader/index.ts
@@ -2,4 +2,5 @@ export { DirectoryLoader, type Types } from './directory-loader';
 export { CustomDirectoryLoader } from './custom-directory-loader';
 export { PackageDirectoryLoader } from './package-directory-loader';
 export { LazyPackageDirectoryLoader } from './lazy-package-directory-loader';
+export { resolveCustomNodePackagePaths } from './utils';
 export type { n8n } from './types';

--- a/packages/core/src/nodes-loader/utils.ts
+++ b/packages/core/src/nodes-loader/utils.ts
@@ -1,0 +1,50 @@
+import fsPromises from 'fs/promises';
+import path from 'path';
+
+/**
+ * Resolves all custom node package paths in a node_modules directory,
+ * handling both scoped (@scope/pkg) and unscoped (pkg) packages.
+ * Resolves symlinks to their real paths for file watching support.
+ */
+export async function resolveCustomNodePackagePaths(
+	nodeModulesDir: string,
+): Promise<string[]> {
+	let entries;
+	try {
+		entries = await fsPromises.readdir(nodeModulesDir, { withFileTypes: true });
+	} catch {
+		return [];
+	}
+
+	const packagePaths: string[] = [];
+
+	for (const entry of entries) {
+		if (entry.name.startsWith('.')) continue;
+
+		if (entry.name.startsWith('@')) {
+			// Scoped package directory: read its sub-entries to find actual packages
+			const scopeDir = path.join(nodeModulesDir, entry.name);
+			let scopeEntries;
+			try {
+				scopeEntries = await fsPromises.readdir(scopeDir, { withFileTypes: true });
+			} catch {
+				continue;
+			}
+
+			for (const scopeEntry of scopeEntries) {
+				if (scopeEntry.name.startsWith('.')) continue;
+				if (scopeEntry.isDirectory() || scopeEntry.isSymbolicLink()) {
+					packagePaths.push(path.join(scopeDir, scopeEntry.name));
+				}
+			}
+		} else if (entry.isDirectory() || entry.isSymbolicLink()) {
+			packagePaths.push(path.join(nodeModulesDir, entry.name));
+		}
+	}
+
+	const resolvedPaths = await Promise.all(
+		packagePaths.map(async (p) => await fsPromises.realpath(p).catch(() => null)),
+	);
+
+	return resolvedPaths.filter((p): p is string => p !== null);
+}


### PR DESCRIPTION
## Summary
Hot reload for custom community nodes (introduced in #18094) does not work for scoped npm packages (e.g. @example-scope/n8n-nodes-example).

The setupHotReload() method reads first-level entries under node_modules/ and resolves their symlinks for file watching. This works for unscoped packages (node_modules/n8n-nodes-example), but scoped packages are nested one level deeper (node_modules/@scope/n8n-nodes-example). The code was resolving the realpath of the @scope/ directory itself rather than the actual package inside it, so file watchers were never set up for the real source path.

The fix extracts the path resolution logic into a shared utility (resolveCustomNodePackagePaths) that detects scope directories (entries starting with @), descends into them, and resolves the realpaths of the actual packages within. Both scoped and unscoped packages are handled uniformly.

Changes:

packages/core/src/nodes-loader/utils.ts — new utility that resolves custom node package paths including scoped packages, with symlink resolution and error handling
packages/core/src/nodes-loader/index.ts — export the utility from n8n-core
packages/cli/src/load-nodes-and-credentials.ts — replace inline resolution logic in setupHotReload() with the utility
How to test:

Create a community node with a scoped package name (@my-scope/n8n-nodes-test)
Install it as a custom node via npm link or n8n-node dev
Start n8n with N8N_DEV_RELOAD=true pnpm dev
Modify the source code of the scoped node
Verify changes are picked up automatically without restart
Verify unscoped community nodes still hot reload correctly



## Related Linear tickets, Github issues, and Community forum posts


Fixes https://github.com/n8n-io/n8n/issues/24872#issue-3855962280
Related to #18094
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
