### PR TITLE
Fixes/24871

### DIFF
--- a/packages/cli/src/__tests__/active-workflow-manager.test.ts
+++ b/packages/cli/src/__tests__/active-workflow-manager.test.ts
@@ -18,6 +18,8 @@ import { ActiveWorkflowManager } from '@/active-workflow-manager';
 import type { EventService } from '@/events/event.service';
 import type { ExecutionService } from '@/executions/execution.service';
 import type { NodeTypes } from '@/node-types';
+import type { Push } from '@/push';
+import type { Publisher } from '@/scaling/pubsub/publisher.service';
 import type { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
 import type { WorkflowStaticDataService } from '@/workflows/workflow-static-data.service';
 
@@ -369,6 +371,93 @@ describe('ActiveWorkflowManager', () => {
 				);
 				expect(executeErrorWorkflowSpy).toHaveBeenCalledWith(executionError, workflowData, mode);
 			});
+		});
+	});
+
+	describe('handleAddWebhooksTriggersAndPollers', () => {
+		const push = mock<Push>();
+		const publisher = mock<Publisher>();
+		const activationErrorsService = mock<ActivationErrorsService>();
+
+		beforeEach(() => {
+			jest.clearAllMocks();
+			activeWorkflowManager = new ActiveWorkflowManager(
+				mockLogger(),
+				mock(),
+				mock(),
+				mock(),
+				mock(),
+				nodeTypes,
+				mock(),
+				workflowRepository,
+				activationErrorsService,
+				mock(),
+				mock(),
+				mock(),
+				mock(),
+				instanceSettings,
+				publisher,
+				mock(),
+				push,
+				mock(),
+				mock(),
+			);
+		});
+
+		test('should deactivate workflow when shouldDeactivateOnActivationError returns true', async () => {
+			jest.spyOn(activeWorkflowManager, 'add').mockRejectedValue(new Error('Plugin not found'));
+			jest
+				.spyOn(activeWorkflowManager as never, 'shouldDeactivateOnActivationError')
+				.mockResolvedValue(true as never);
+
+			await activeWorkflowManager.handleAddWebhooksTriggersAndPollers({
+				workflowId: 'wf-1',
+				activeVersionId: 'v1',
+			});
+
+			expect(workflowRepository.update).toHaveBeenCalledWith('wf-1', {
+				active: false,
+				activeVersionId: null,
+			});
+			expect(activationErrorsService.register).not.toHaveBeenCalled();
+			expect(push.broadcast).toHaveBeenCalledWith(
+				expect.objectContaining({ type: 'workflowFailedToActivate' }),
+			);
+		});
+
+		test('should keep workflow published when shouldDeactivateOnActivationError returns false', async () => {
+			jest.spyOn(activeWorkflowManager, 'add').mockRejectedValue(new Error('Plugin not found'));
+			jest
+				.spyOn(activeWorkflowManager as never, 'shouldDeactivateOnActivationError')
+				.mockResolvedValue(false as never);
+
+			await activeWorkflowManager.handleAddWebhooksTriggersAndPollers({
+				workflowId: 'wf-1',
+				activeVersionId: 'v1',
+			});
+
+			expect(workflowRepository.update).not.toHaveBeenCalled();
+			expect(activationErrorsService.register).toHaveBeenCalledWith('wf-1', 'Plugin not found');
+			expect(push.broadcast).toHaveBeenCalledWith(
+				expect.objectContaining({ type: 'workflowFailedToActivate' }),
+			);
+		});
+
+		test('should broadcast activation on success', async () => {
+			jest.spyOn(activeWorkflowManager, 'add').mockResolvedValue({
+				triggersAndPollers: true,
+				webhooks: true,
+			});
+
+			await activeWorkflowManager.handleAddWebhooksTriggersAndPollers({
+				workflowId: 'wf-1',
+				activeVersionId: 'v1',
+			});
+
+			expect(workflowRepository.update).not.toHaveBeenCalled();
+			expect(push.broadcast).toHaveBeenCalledWith(
+				expect.objectContaining({ type: 'workflowActivated' }),
+			);
 		});
 	});
 });

--- a/packages/cli/src/active-workflow-manager.ts
+++ b/packages/cli/src/active-workflow-manager.ts
@@ -10,7 +10,7 @@ import { WorkflowsConfig } from '@n8n/config';
 import type { WorkflowEntity, IWorkflowDb } from '@n8n/db';
 import { WorkflowRepository } from '@n8n/db';
 import { OnLeaderStepdown, OnLeaderTakeover, OnPubSubEvent, OnShutdown } from '@n8n/decorators';
-import { Service } from '@n8n/di';
+import { Container, Service } from '@n8n/di';
 import chunk from 'lodash/chunk';
 import {
 	ActiveWorkflows,
@@ -759,7 +759,20 @@ export class ActiveWorkflowManager {
 			const error = ensureError(e);
 			const { message } = error;
 
-			await this.workflowRepository.update(workflowId, { active: false, activeVersionId: null });
+			const shouldDeactivate = await this.shouldDeactivateOnActivationError();
+
+			if (shouldDeactivate) {
+				await this.workflowRepository.update(workflowId, {
+					active: false,
+					activeVersionId: null,
+				});
+			} else {
+				this.logger.warn(
+					`Workflow ${workflowId} failed to activate but will remain published (N8N_DEACTIVATE_WORKFLOWS_ON_PLUGIN_ERROR=false)`,
+					{ workflowId, errorMessage: message },
+				);
+				await this.activationErrorsService.register(workflowId, message);
+			}
 
 			this.push.broadcast({
 				type: 'workflowFailedToActivate',
@@ -771,6 +784,32 @@ export class ActiveWorkflowManager {
 				payload: { workflowId, errorMessage: message },
 			}); // instruct followers to show activation error in UI
 		}
+	}
+
+	/**
+	 * Whether to deactivate a workflow when activation fails in the pub/sub handler.
+	 * Checks if community packages have missing packages and if the config allows
+	 * deactivation on plugin errors. When missing packages are detected and
+	 * deactivation is disabled (default), workflows remain published to prevent
+	 * mass unpublishing caused by transient plugin load failures.
+	 */
+	private async shouldDeactivateOnActivationError(): Promise<boolean> {
+		const { CommunityPackagesService } = await import(
+			'@/modules/community-packages/community-packages.service'
+		);
+		const { CommunityPackagesConfig } = await import(
+			'@/modules/community-packages/community-packages.config'
+		);
+
+		const communityPackagesConfig = Container.get(CommunityPackagesConfig);
+
+		if (communityPackagesConfig.deactivateOnPluginError) return true;
+
+		const communityPackagesService = Container.get(CommunityPackagesService);
+
+		if (communityPackagesService.hasMissingPackages) return false;
+
+		return true;
 	}
 
 	/**

--- a/packages/cli/src/modules/community-packages/__tests__/community-packages.service.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/community-packages.service.test.ts
@@ -326,6 +326,42 @@ describe('CommunityPackagesService', () => {
 		});
 	});
 
+	describe('isNodeFromMissingPackage()', () => {
+		test('should return false when no packages are missing', () => {
+			setMissingPackages([]);
+			expect(communityPackagesService.isNodeFromMissingPackage('n8n-nodes-test.MyNode')).toBe(
+				false,
+			);
+		});
+
+		test('should return true when node belongs to a missing package', () => {
+			setMissingPackages(['n8n-nodes-test@0.1.0']);
+			expect(communityPackagesService.isNodeFromMissingPackage('n8n-nodes-test.MyNode')).toBe(
+				true,
+			);
+		});
+
+		test('should return false when node does not belong to any missing package', () => {
+			setMissingPackages(['n8n-nodes-test@0.1.0']);
+			expect(
+				communityPackagesService.isNodeFromMissingPackage('n8n-nodes-other.MyNode'),
+			).toBe(false);
+		});
+
+		test('should handle multiple missing packages', () => {
+			setMissingPackages(['n8n-nodes-a@0.1.0', 'n8n-nodes-b@0.2.0']);
+			expect(communityPackagesService.isNodeFromMissingPackage('n8n-nodes-a.NodeOne')).toBe(
+				true,
+			);
+			expect(communityPackagesService.isNodeFromMissingPackage('n8n-nodes-b.NodeTwo')).toBe(
+				true,
+			);
+			expect(communityPackagesService.isNodeFromMissingPackage('n8n-nodes-c.NodeThree')).toBe(
+				false,
+			);
+		});
+	});
+
 	const setMissingPackages = (missingPackages: string[]) => {
 		Object.assign(communityPackagesService, { missingPackages });
 	};

--- a/packages/cli/src/modules/community-packages/community-packages.config.ts
+++ b/packages/cli/src/modules/community-packages/community-packages.config.ts
@@ -25,4 +25,12 @@ export class CommunityPackagesConfig {
 	/** Whether to load community packages */
 	@Env('N8N_COMMUNITY_PACKAGES_PREVENT_LOADING')
 	preventLoading: boolean = false;
+
+	/**
+	 * Whether to deactivate workflows when a community package fails to load.
+	 * When false (default), workflows remain published even if the plugin they
+	 * depend on fails to load, avoiding mass unpublishing in production.
+	 */
+	@Env('N8N_DEACTIVATE_WORKFLOWS_ON_PLUGIN_ERROR')
+	deactivateOnPluginError: boolean = false;
 }

--- a/packages/cli/src/modules/community-packages/community-packages.service.ts
+++ b/packages/cli/src/modules/community-packages/community-packages.service.ts
@@ -80,6 +80,18 @@ export class CommunityPackagesService {
 		return this.missingPackages.length > 0;
 	}
 
+	/**
+	 * Check if a node type belongs to a package that failed to load.
+	 * The node type format is "packageName.nodeName", and missingPackages
+	 * entries are "packageName@version".
+	 */
+	isNodeFromMissingPackage(nodeTypeName: string): boolean {
+		if (this.missingPackages.length === 0) return false;
+
+		const missingPackageNames = this.missingPackages.map((entry) => entry.split('@')[0]);
+		return missingPackageNames.some((pkg) => nodeTypeName.startsWith(`${pkg}.`));
+	}
+
 	async findInstalledPackage(packageName: string) {
 		return await this.installedPackageRepository.findOne({
 			where: { packageName },


### PR DESCRIPTION
## Summary

When a community package fails to load during n8n startup (e.g. corrupted install, missing dependency), the activation retry path in multi-main mode triggers handleAddWebhooksTriggersAndPollers, which unconditionally sets active: false on every workflow that depends on that package. This causes mass unpublishing of production workflows due to a transient plugin issue.

This PR makes workflow deactivation on plugin load failure conditional. By default, workflows now remain published when activation fails and missing community packages are detected. Instead of deactivating, the error is logged and registered as an activation error visible in the UI. The previous behavior (automatic deactivation) can be restored by setting N8N_DEACTIVATE_WORKFLOWS_ON_PLUGIN_ERROR=true.

Changes:

Added deactivateOnPluginError config option (N8N_DEACTIVATE_WORKFLOWS_ON_PLUGIN_ERROR, default false) to CommunityPackagesConfig
Modified handleAddWebhooksTriggersAndPollers catch block to check whether deactivation should occur based on the config and whether missing packages exist
Added isNodeFromMissingPackage() helper to CommunityPackagesService for identifying nodes from failed packages
Added tests for the conditional deactivation logic and the new helper method

## Related Linear tickets, Github issues, and Community forum posts

Fixes https://github.com/n8n-io/n8n/issues/24871#issue-3855960535

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
