### PR TITLE
fix(core): Harden form webhook against Content-Type confusion

### DIFF
--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -1003,6 +1003,27 @@ async function parseRequestBody(
 	}
 
 	const { contentType } = req;
+
+	// CVE-2026-21858: Form trigger POST requests MUST use multipart/form-data.
+	// Reject early to prevent Content-Type confusion attacks where an attacker
+	// sends JSON with a crafted "files" object to trigger arbitrary file reads.
+	const isFormTriggerNode = [FORM_TRIGGER_NODE_TYPE, FORM_NODE_TYPE].includes(
+		workflowStartNode.type,
+	);
+	const isWaitFormNode =
+		workflowStartNode.type === WAIT_NODE_TYPE &&
+		workflowStartNode.parameters?.resume === 'form';
+
+	if (
+		(isFormTriggerNode || isWaitFormNode) &&
+		req.method === 'POST' &&
+		contentType !== 'multipart/form-data'
+	) {
+		throw new OperationalError(
+			'Form submissions require multipart/form-data content type',
+		);
+	}
+
 	if (contentType === 'multipart/form-data') {
 		req.body = await parseFormData(req);
 	} else {

--- a/packages/core/src/execution-engine/node-execution-context/utils/binary-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/binary-helper-functions.ts
@@ -24,6 +24,7 @@ import {
 	BINARY_MODE_SEPARATE,
 	sanitizeFilename,
 } from 'n8n-workflow';
+import { tmpdir } from 'node:os';
 import path from 'path';
 import type { Readable } from 'stream';
 import { URL } from 'url';
@@ -197,6 +198,15 @@ export async function copyBinaryFile(
 	fileName: string,
 	mimeType?: string,
 ): Promise<IBinaryData> {
+	// Validate filePath is within the OS temp directory to prevent arbitrary file reads (CVE-2026-21858)
+	const resolvedPath = path.resolve(filePath);
+	const tempDir = tmpdir();
+	if (!resolvedPath.startsWith(tempDir + path.sep) && resolvedPath !== tempDir) {
+		throw new UnexpectedError(
+			`File path must be within the temp directory. Resolved: ${resolvedPath}`,
+		);
+	}
+
 	let fileExtension: string | undefined;
 	if (!mimeType) {
 		// If no mime type is given figure it out

--- a/packages/nodes-base/nodes/Form/utils/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils/utils.ts
@@ -21,7 +21,6 @@ import {
 	tryToParseUrl,
 	BINARY_MODE_COMBINED,
 } from 'n8n-workflow';
-import * as a from 'node:assert';
 import sanitize from 'sanitize-html';
 
 import { getResolvables } from '../../../utils/utilities';
@@ -409,7 +408,12 @@ export async function prepareFormReturnItem(
 	useWorkflowTimezone: boolean = false,
 ) {
 	const req = context.getRequestObject() as MultiPartFormData.Request;
-	a.ok(req.contentType === 'multipart/form-data', 'Expected multipart/form-data');
+	if (req.contentType !== 'multipart/form-data') {
+		throw new NodeOperationError(
+			context.getNode(),
+			'Form submissions must use multipart/form-data content type',
+		);
+	}
 	const bodyData = (context.getBodyData().data as IDataObject) ?? {};
 	const files = (context.getBodyData().files as IDataObject) ?? {};
 	const { binaryMode } = context.getWorkflowSettings();


### PR DESCRIPTION
## Summary

Defense-in-depth against arbitrary file read via Content-Type confusion in form webhook handlers (CVE-2026-21858).

- **Reject non-multipart POST requests** to form trigger endpoints early in `parseRequestBody`, preventing attackers from sending JSON with a crafted `files` object to trigger arbitrary file reads
- **Add temp-dir path validation** in `copyBinaryFile` to ensure file paths are within the OS temp directory before copying
- **Replace weak `node:assert` check** in `prepareFormReturnItem` with an explicit `NodeOperationError` for proper error handling when content type is not `multipart/form-data`

## Related Linear tickets, Github issues, and Community forum posts

CVE-2026-21858

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)