### PR TITLE
fixes/24716-jira-trigger-node

### DIFF
--- a/packages/nodes-base/nodes/Jira/JiraJqlValidator.ts
+++ b/packages/nodes-base/nodes/Jira/JiraJqlValidator.ts
@@ -1,0 +1,74 @@
+import type { IExecuteFunctions, IHookFunctions, IWebhookFunctions } from 'n8n-workflow';
+import { jiraSoftwareCloudApiRequest } from './GenericFunctions';
+import type { JiraWebhookPayload } from './JiraWebhookValidator';
+
+/**
+ * Validates if an issue matches a JQL filter by querying Jira API
+ * This ensures JQL filters are enforced at runtime, not just during webhook registration
+ */
+export async function validateIssueAgainstJql(
+	context: IWebhookFunctions | IExecuteFunctions | IHookFunctions,
+	issueKey: string,
+	jqlFilter: string,
+): Promise<boolean> {
+	if (!jqlFilter || jqlFilter.trim() === '') {
+		// No filter means all issues pass
+		return true;
+	}
+
+	try {
+		// Construct a JQL query that checks if the specific issue matches the filter
+		// We combine the user's JQL with an issue key filter
+		const combinedJql = `key = ${issueKey} AND (${jqlFilter})`;
+
+		// Query Jira to see if the issue matches
+		const response = await jiraSoftwareCloudApiRequest.call(
+			context,
+			'/api/2/search',
+			'GET',
+			{},
+			{
+				jql: combinedJql,
+				maxResults: 1,
+				fields: 'key', // We only need to know if it exists
+			},
+		);
+
+		// If the search returns the issue, it matches the filter
+		return response.total > 0;
+	} catch (error) {
+		// If there's an error querying Jira (e.g., invalid JQL), log it and allow the event
+		// This prevents JQL syntax errors from blocking all webhooks
+		context.logger.warn(
+			`Failed to validate issue ${issueKey} against JQL filter: ${error.message}`,
+			{
+				jqlFilter,
+				error: error.message,
+			},
+		);
+		return true;
+	}
+}
+
+/**
+ * Extracts the issue key from a webhook payload
+ */
+export function extractIssueKey(payload: JiraWebhookPayload): string | null {
+	return payload.issue?.key || null;
+}
+
+/**
+ * Checks if the webhook event is issue-related and should be filtered by JQL
+ */
+export function isIssueRelatedEvent(webhookEvent: string): boolean {
+	const issueEvents = [
+		'jira:issue_created',
+		'jira:issue_updated',
+		'jira:issue_deleted',
+		'comment_created',
+		'comment_updated',
+		'comment_deleted',
+	];
+
+	return issueEvents.includes(webhookEvent);
+}

--- a/packages/nodes-base/nodes/Jira/JiraTrigger.node.ts
+++ b/packages/nodes-base/nodes/Jira/JiraTrigger.node.ts
@@ -17,6 +17,18 @@ import {
 	jiraSoftwareCloudApiRequest,
 } from './GenericFunctions';
 import type { JiraWebhook } from './types';
+import {
+	validateEventType,
+	validateWebhookPayload,
+	generateEventId,
+	getGlobalDeduplicator,
+	type JiraWebhookPayload,
+} from './JiraWebhookValidator';
+import {
+	validateIssueAgainstJql,
+	extractIssueKey,
+	isIssueRelatedEvent,
+} from './JiraJqlValidator';
 
 export class JiraTrigger implements INodeType {
 	description: INodeTypeDescription = {
@@ -551,6 +563,91 @@ export class JiraTrigger implements INodeType {
 		const bodyData = this.getBodyData();
 		const queryData = this.getQueryData() as IDataObject;
 		const response = this.getResponseObject();
+
+		// Validate webhook payload structure
+		if (!validateWebhookPayload(bodyData)) {
+			response.status(400).json({
+				message: 'Invalid webhook payload: missing required fields',
+			});
+			return {
+				noWebhookResponse: true,
+			};
+		}
+
+		const payload = bodyData as unknown as JiraWebhookPayload;
+
+		// Get configured events for validation
+		const configuredEvents = this.getNodeParameter('events') as string[];
+
+		// Validate that the incoming event matches configured event types
+		const eventValidation = validateEventType(payload, configuredEvents);
+		if (!eventValidation.isValid) {
+			// Silently ignore events that don't match configured types
+			// This prevents wrong event types from triggering the workflow
+			this.logger.debug(
+				`Jira webhook event rejected: ${eventValidation.reason}`,
+				{
+					webhookEvent: payload.webhookEvent,
+					configuredEvents,
+				},
+			);
+
+			response.status(200).json({ message: 'Event type not configured for this trigger' });
+			return {
+				noWebhookResponse: true,
+			};
+		}
+
+		// Check for duplicate events
+		const eventId = generateEventId(payload);
+		const deduplicator = getGlobalDeduplicator();
+
+		if (deduplicator.isDuplicate(eventId)) {
+			this.logger.debug(
+				`Jira webhook duplicate event detected and ignored: ${eventId}`,
+				{
+					webhookEvent: payload.webhookEvent,
+					issueId: payload.issue?.id,
+					timestamp: payload.timestamp,
+				},
+			);
+
+			response.status(200).json({ message: 'Duplicate event ignored' });
+			return {
+				noWebhookResponse: true,
+			};
+		}
+
+		// Mark this event as processed
+		deduplicator.markProcessed(eventId);
+
+		// Validate JQL filter for issue-related events
+		const additionalFields = this.getNodeParameter('additionalFields') as IDataObject;
+		const jqlFilter = additionalFields.filter as string | undefined;
+
+		if (jqlFilter && payload.webhookEvent && isIssueRelatedEvent(payload.webhookEvent)) {
+			const issueKey = extractIssueKey(payload);
+
+			if (issueKey) {
+				const matchesFilter = await validateIssueAgainstJql(this, issueKey, jqlFilter);
+
+				if (!matchesFilter) {
+					this.logger.debug(
+						`Jira webhook event rejected: issue does not match JQL filter`,
+						{
+							issueKey,
+							jqlFilter,
+							webhookEvent: payload.webhookEvent,
+						},
+					);
+
+					response.status(200).json({ message: 'Issue does not match JQL filter' });
+					return {
+						noWebhookResponse: true,
+					};
+				}
+			}
+		}
 
 		let authenticateWebhook = false;
 

--- a/packages/nodes-base/nodes/Jira/JiraWebhookValidator.ts
+++ b/packages/nodes-base/nodes/Jira/JiraWebhookValidator.ts
@@ -1,0 +1,216 @@
+import type { IDataObject } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+
+/**
+ * Validates and processes Jira webhook events to ensure correct filtering
+ * and prevent duplicate executions
+ */
+
+export interface JiraWebhookPayload {
+	webhookEvent?: string;
+	issue_event_type_name?: string;
+	timestamp?: number;
+	issue?: {
+		id?: string;
+		key?: string;
+		fields?: {
+			project?: {
+				key?: string;
+				id?: string;
+			};
+		};
+	};
+	[key: string]: unknown;
+}
+
+export interface ValidationResult {
+	isValid: boolean;
+	reason?: string;
+}
+
+/**
+ * Validates that the incoming webhook event matches the configured event types
+ */
+export function validateEventType(
+	payload: JiraWebhookPayload,
+	configuredEvents: string[],
+): ValidationResult {
+	const webhookEvent = payload.webhookEvent;
+	const issueEventType = payload.issue_event_type_name;
+
+	if (!webhookEvent) {
+		return {
+			isValid: false,
+			reason: 'Missing webhookEvent field in payload',
+		};
+	}
+
+	// Check if the webhook event matches any configured event
+	const eventMatches = configuredEvents.some((configuredEvent) => {
+		// Handle wildcard
+		if (configuredEvent === '*') {
+			return true;
+		}
+
+		// Direct match
+		if (webhookEvent === configuredEvent) {
+			return true;
+		}
+
+		// For issue events, also check issue_event_type_name
+		// Some Jira versions use different field names
+		if (issueEventType && configuredEvent.includes(issueEventType)) {
+			return true;
+		}
+
+		return false;
+	});
+
+	if (!eventMatches) {
+		return {
+			isValid: false,
+			reason: `Event type '${webhookEvent}' does not match configured events: ${configuredEvents.join(', ')}`,
+		};
+	}
+
+	return { isValid: true };
+}
+
+/**
+ * Extracts project information from the webhook payload
+ */
+export function extractProjectInfo(payload: JiraWebhookPayload): {
+	projectKey?: string;
+	projectId?: string;
+} {
+	const projectKey = payload.issue?.fields?.project?.key;
+	const projectId = payload.issue?.fields?.project?.id;
+
+	return { projectKey, projectId };
+}
+
+/**
+ * Generates a unique identifier for a webhook event to prevent duplicate processing
+ * Uses a combination of webhook event type, issue ID, and timestamp
+ */
+export function generateEventId(payload: JiraWebhookPayload): string {
+	const webhookEvent = payload.webhookEvent || 'unknown';
+	const issueId = payload.issue?.id || payload.issue?.key || 'no-issue';
+	const timestamp = payload.timestamp || Date.now();
+
+	return `${webhookEvent}:${issueId}:${timestamp}`;
+}
+
+/**
+ * Validates the complete webhook payload structure
+ */
+export function validateWebhookPayload(payload: unknown): payload is JiraWebhookPayload {
+	if (!payload || typeof payload !== 'object') {
+		return false;
+	}
+
+	const data = payload as IDataObject;
+
+	// Must have webhookEvent field
+	if (!data.webhookEvent || typeof data.webhookEvent !== 'string') {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Checks if an event has already been processed based on a simple time-based deduplication
+ * This prevents the same event from being processed multiple times within a short window
+ */
+export class EventDeduplicator {
+	private processedEvents: Map<string, number> = new Map();
+	private readonly cleanupInterval: NodeJS.Timeout;
+	private readonly eventTTL: number;
+
+	constructor(eventTTLMs: number = 60000) {
+		// Default 60 seconds
+		this.eventTTL = eventTTLMs;
+
+		// Clean up old events every 30 seconds
+		this.cleanupInterval = setInterval(() => {
+			this.cleanup();
+		}, 30000);
+	}
+
+	/**
+	 * Check if an event has been processed recently
+	 */
+	isDuplicate(eventId: string): boolean {
+		const lastProcessed = this.processedEvents.get(eventId);
+		if (!lastProcessed) {
+			return false;
+		}
+
+		const now = Date.now();
+		const age = now - lastProcessed;
+
+		// If the event was processed within the TTL window, it's a duplicate
+		return age < this.eventTTL;
+	}
+
+	/**
+	 * Mark an event as processed
+	 */
+	markProcessed(eventId: string): void {
+		this.processedEvents.set(eventId, Date.now());
+	}
+
+	/**
+	 * Remove old events from the cache
+	 */
+	private cleanup(): void {
+		const now = Date.now();
+		const keysToDelete: string[] = [];
+
+		for (const [eventId, timestamp] of this.processedEvents.entries()) {
+			if (now - timestamp > this.eventTTL) {
+				keysToDelete.push(eventId);
+			}
+		}
+
+		for (const key of keysToDelete) {
+			this.processedEvents.delete(key);
+		}
+	}
+
+	/**
+	 * Clear all processed events (useful for testing)
+	 */
+	clear(): void {
+		this.processedEvents.clear();
+	}
+
+	/**
+	 * Cleanup resources
+	 */
+	destroy(): void {
+		clearInterval(this.cleanupInterval);
+		this.processedEvents.clear();
+	}
+}
+
+// Global deduplicator instance shared across all Jira Trigger nodes
+let globalDeduplicator: EventDeduplicator | null = null;
+
+export function getGlobalDeduplicator(): EventDeduplicator {
+	if (!globalDeduplicator) {
+		globalDeduplicator = new EventDeduplicator();
+	}
+	return globalDeduplicator;
+}
+
+/**
+ * Reset the global deduplicator (useful for testing)
+ */
+export function resetGlobalDeduplicator(): void {
+	if (globalDeduplicator) {
+		globalDeduplicator.destroy();
+		globalDeduplicator = null;
+	}
+}

--- a/packages/nodes-base/nodes/Jira/__test__/JiraTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Jira/__test__/JiraTrigger.node.test.ts
@@ -9,8 +9,14 @@ import type {
 import { testWebhookTriggerNode } from '@test/nodes/TriggerHelpers';
 
 import { JiraTrigger } from '../JiraTrigger.node';
+import { resetGlobalDeduplicator } from '../JiraWebhookValidator';
 
 describe('JiraTrigger', () => {
+	afterEach(() => {
+		// Reset deduplicator between tests
+		resetGlobalDeduplicator();
+	});
+
 	describe('Webhook lifecycle', () => {
 		let staticData: IDataObject;
 
@@ -255,6 +261,289 @@ describe('JiraTrigger', () => {
 			};
 			const { responseData } = await testWebhookTriggerNode(JiraTrigger, {
 				bodyData: event,
+				node: {
+					parameters: {
+						events: ['jira:issue_created'],
+					},
+				},
+			});
+
+			expect(responseData).toEqual({ workflowData: [[{ json: event }]] });
+		});
+
+		test('should reject issue_created event when configured for issue_updated', async () => {
+			const event = {
+				timestamp: 1743524005044,
+				webhookEvent: 'jira:issue_created',
+				issue_event_type_name: 'issue_created',
+				issue: {
+					id: '10018',
+					key: 'TEST-19',
+				},
+			};
+
+			const { responseData } = await testWebhookTriggerNode(JiraTrigger, {
+				bodyData: event,
+				node: {
+					parameters: {
+						events: ['jira:issue_updated'],
+					},
+				},
+			});
+
+			// Should not trigger workflow
+			expect(responseData).toEqual({ noWebhookResponse: true });
+		});
+
+		test('should reject issue_updated event when configured for issue_created', async () => {
+			const event = {
+				timestamp: 1743524005044,
+				webhookEvent: 'jira:issue_updated',
+				issue_event_type_name: 'issue_updated',
+				issue: {
+					id: '10018',
+					key: 'TEST-19',
+				},
+			};
+
+			const { responseData } = await testWebhookTriggerNode(JiraTrigger, {
+				bodyData: event,
+				node: {
+					parameters: {
+						events: ['jira:issue_created'],
+					},
+				},
+			});
+
+			// Should not trigger workflow
+			expect(responseData).toEqual({ noWebhookResponse: true });
+		});
+
+		test('should prevent duplicate executions for the same event', async () => {
+			const event = {
+				timestamp: 1743524005044,
+				webhookEvent: 'jira:issue_created',
+				issue_event_type_name: 'issue_created',
+				issue: {
+					id: '10018',
+					key: 'TEST-19',
+				},
+			};
+
+			// First execution should succeed
+			const { responseData: firstResponse } = await testWebhookTriggerNode(JiraTrigger, {
+				bodyData: event,
+				node: {
+					parameters: {
+						events: ['jira:issue_created'],
+					},
+				},
+			});
+
+			expect(firstResponse).toEqual({ workflowData: [[{ json: event }]] });
+
+			// Second execution with same event should be rejected as duplicate
+			const { responseData: secondResponse } = await testWebhookTriggerNode(JiraTrigger, {
+				bodyData: event,
+				node: {
+					parameters: {
+						events: ['jira:issue_created'],
+					},
+				},
+			});
+
+			expect(secondResponse).toEqual({ noWebhookResponse: true });
+		});
+
+		test('should allow different events even with same issue ID', async () => {
+			const createdEvent = {
+				timestamp: 1743524005044,
+				webhookEvent: 'jira:issue_created',
+				issue_event_type_name: 'issue_created',
+				issue: {
+					id: '10018',
+					key: 'TEST-19',
+				},
+			};
+
+			const updatedEvent = {
+				timestamp: 1743524005045,
+				webhookEvent: 'jira:issue_updated',
+				issue_event_type_name: 'issue_updated',
+				issue: {
+					id: '10018',
+					key: 'TEST-19',
+				},
+			};
+
+			// First event (created)
+			const { responseData: firstResponse } = await testWebhookTriggerNode(JiraTrigger, {
+				bodyData: createdEvent,
+				node: {
+					parameters: {
+						events: ['jira:issue_created', 'jira:issue_updated'],
+					},
+				},
+			});
+
+			expect(firstResponse).toEqual({ workflowData: [[{ json: createdEvent }]] });
+
+			// Second event (updated) - should be allowed because it's a different event type
+			const { responseData: secondResponse } = await testWebhookTriggerNode(JiraTrigger, {
+				bodyData: updatedEvent,
+				node: {
+					parameters: {
+						events: ['jira:issue_created', 'jira:issue_updated'],
+					},
+				},
+			});
+
+			expect(secondResponse).toEqual({ workflowData: [[{ json: updatedEvent }]] });
+		});
+
+		test('should reject events with missing webhookEvent field', async () => {
+			const invalidEvent = {
+				timestamp: 1743524005044,
+				issue: {
+					id: '10018',
+					key: 'TEST-19',
+				},
+			};
+
+			const { responseData } = await testWebhookTriggerNode(JiraTrigger, {
+				bodyData: invalidEvent,
+				node: {
+					parameters: {
+						events: ['jira:issue_created'],
+					},
+				},
+			});
+
+			expect(responseData).toEqual({ noWebhookResponse: true });
+		});
+
+		test('should accept wildcard event configuration', async () => {
+			const event = {
+				timestamp: 1743524005044,
+				webhookEvent: 'jira:issue_created',
+				issue_event_type_name: 'issue_created',
+				issue: {
+					id: '10018',
+					key: 'TEST-19',
+				},
+			};
+
+			const { responseData } = await testWebhookTriggerNode(JiraTrigger, {
+				bodyData: event,
+				node: {
+					parameters: {
+						events: ['*'],
+					},
+				},
+			});
+
+			expect(responseData).toEqual({ workflowData: [[{ json: event }]] });
+		});
+
+		test('should reject event when JQL filter does not match', async () => {
+			const event = {
+				timestamp: 1743524005044,
+				webhookEvent: 'jira:issue_updated',
+				issue_event_type_name: 'issue_updated',
+				issue: {
+					id: '10018',
+					key: 'TEST-19',
+					fields: {
+						project: {
+							key: 'TEST',
+							id: '10000',
+						},
+					},
+				},
+			};
+
+			// Mock the JQL validation to return no matches
+			const { responseData } = await testWebhookTriggerNode(JiraTrigger, {
+				bodyData: event,
+				node: {
+					parameters: {
+						events: ['jira:issue_updated'],
+						additionalFields: {
+							filter: 'project = DIFFERENT',
+						},
+					},
+				},
+				helpers: {
+					requestWithAuthentication: jest.fn().mockResolvedValue({
+						total: 0, // No matches
+						issues: [],
+					}),
+				},
+			});
+
+			expect(responseData).toEqual({ noWebhookResponse: true });
+		});
+
+		test('should accept event when JQL filter matches', async () => {
+			const event = {
+				timestamp: 1743524005044,
+				webhookEvent: 'jira:issue_updated',
+				issue_event_type_name: 'issue_updated',
+				issue: {
+					id: '10018',
+					key: 'TEST-19',
+					fields: {
+						project: {
+							key: 'TEST',
+							id: '10000',
+						},
+					},
+				},
+			};
+
+			// Mock the JQL validation to return a match
+			const { responseData } = await testWebhookTriggerNode(JiraTrigger, {
+				bodyData: event,
+				node: {
+					parameters: {
+						events: ['jira:issue_updated'],
+						additionalFields: {
+							filter: 'project = TEST',
+						},
+					},
+				},
+				helpers: {
+					requestWithAuthentication: jest.fn().mockResolvedValue({
+						total: 1, // Match found
+						issues: [{ key: 'TEST-19' }],
+					}),
+				},
+			});
+
+			expect(responseData).toEqual({ workflowData: [[{ json: event }]] });
+		});
+
+		test('should not apply JQL filter to non-issue events', async () => {
+			const event = {
+				timestamp: 1743524005044,
+				webhookEvent: 'project_created',
+				project: {
+					id: '10000',
+					key: 'TEST',
+				},
+			};
+
+			// Even with a JQL filter configured, project events should pass through
+			const { responseData } = await testWebhookTriggerNode(JiraTrigger, {
+				bodyData: event,
+				node: {
+					parameters: {
+						events: ['project_created'],
+						additionalFields: {
+							filter: 'project = DIFFERENT',
+						},
+					},
+				},
 			});
 
 			expect(responseData).toEqual({ workflowData: [[{ json: event }]] });


### PR DESCRIPTION
## Summary

This PR fixes critical production bugs in the Jira Trigger node that were causing:

Wrong event types triggering workflows (e.g., issue_created firing issue_updated workflows)
JQL filters being completely ignored at runtime
The same Jira event triggering 5-10 duplicate workflow executions
Severe cost impact in production environments where executions are billed
What Changed
The fix implements a comprehensive validation pipeline in the webhook handler:

Event Type Validation - Strictly validates incoming webhook events match configured event types
Deduplication - Prevents the same event from triggering multiple executions using time-based caching (60s TTL)
Runtime JQL Enforcement - Validates issues against JQL filters by querying Jira API at execution time
Payload Validation - Rejects malformed webhook payloads early
Implementation Details
New Files:

JiraWebhookValidator.ts - Event validation, payload validation, and deduplication logic
JiraJqlValidator.ts - Runtime JQL filter validation against Jira API
Modified Files:

JiraTrigger.node.ts - Enhanced webhook method with validation pipeline
JiraTrigger.node.test.ts - Added 10 comprehensive test cases

Fixes #24716 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
