### PR TITLE
fixes/24676-variable-intermittently

### DIFF
--- a/packages/cli/src/environments.ee/variables/__tests__/variables-cache.integration.test.ts
+++ b/packages/cli/src/environments.ee/variables/__tests__/variables-cache.integration.test.ts
@@ -1,0 +1,335 @@
+import { testDb } from '@n8n/backend-test-utils';
+import { VariablesRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+import { mock } from 'jest-mock-extended';
+
+import type { EventService } from '@/events/event.service';
+import { CacheService } from '@/services/cache/cache.service';
+import { ProjectService } from '@/services/project.service.ee';
+import { createVariable } from '@test-integration/db/variables';
+
+import { VariablesService } from '../variables.service.ee';
+import { VariablesCacheHealthService } from '../variables-cache-health.service';
+
+describe('Variables Cache Bug Fix', () => {
+	let variablesService: VariablesService;
+	let variablesRepository: VariablesRepository;
+	let cacheService: CacheService;
+	let healthService: VariablesCacheHealthService;
+	let projectService: ProjectService;
+	let licenseState: { isVariablesLicensed: jest.Mock; getMaxVariables: jest.Mock };
+
+	beforeAll(async () => {
+		await testDb.init();
+	});
+
+	afterAll(async () => {
+		await testDb.terminate();
+	});
+
+	beforeEach(async () => {
+		variablesRepository = Container.get(VariablesRepository);
+		cacheService = Container.get(CacheService);
+		projectService = Container.get(ProjectService);
+
+		licenseState = {
+			isVariablesLicensed: jest.fn().mockReturnValue(true),
+			getMaxVariables: jest.fn().mockReturnValue(-1),
+		};
+
+		variablesService = new VariablesService(
+			cacheService,
+			variablesRepository,
+			mock<EventService>(),
+			licenseState as any,
+			projectService,
+		);
+
+		healthService = new VariablesCacheHealthService(
+			cacheService,
+			variablesRepository,
+			mock(),
+		);
+
+		// Clear cache before each test
+		await cacheService.reset();
+	});
+
+	afterEach(async () => {
+		jest.clearAllMocks();
+		await testDb.truncate(['Variables']);
+		await cacheService.reset();
+	});
+
+	describe('Empty Cache Recovery', () => {
+		test('should recover when cache contains empty array but database has variables', async () => {
+			// ARRANGE - Create variables in database
+			const var1 = await createVariable('VAR1', 'value1');
+			const var2 = await createVariable('VAR2', 'value2');
+
+			// Simulate stale empty cache (the bug scenario)
+			await cacheService.set('variables', []);
+
+			// ACT - Get variables (should detect empty cache and refresh)
+			const variables = await variablesService.getAllCached();
+
+			// ASSERT - Should return variables from database, not empty array
+			expect(variables).toHaveLength(2);
+			expect(variables.map((v) => v.key)).toEqual(expect.arrayContaining(['VAR1', 'VAR2']));
+		});
+
+		test('should not refresh cache when database is also empty', async () => {
+			// ARRANGE - No variables in database
+			await cacheService.set('variables', []);
+
+			const findAllSpy = jest.spyOn(variablesRepository, 'find');
+
+			// ACT
+			const variables = await variablesService.getAllCached();
+
+			// ASSERT - Should return empty array without unnecessary DB query
+			expect(variables).toHaveLength(0);
+			// Should only query DB once to verify it's truly empty
+			expect(findAllSpy).toHaveBeenCalledTimes(1);
+		});
+
+		test('should handle cache miss (undefined) by refreshing from database', async () => {
+			// ARRANGE - Create variables in database
+			await createVariable('VAR1', 'value1');
+			await createVariable('VAR2', 'value2');
+
+			// Cache is empty (undefined) - simulates Redis restart or eviction
+			await cacheService.delete('variables');
+
+			// ACT
+			const variables = await variablesService.getAllCached();
+
+			// ASSERT
+			expect(variables).toHaveLength(2);
+			expect(variables.map((v) => v.key)).toEqual(expect.arrayContaining(['VAR1', 'VAR2']));
+		});
+
+		test('should handle cache returning null by refreshing from database', async () => {
+			// ARRANGE
+			await createVariable('VAR1', 'value1');
+
+			// Simulate cache returning null
+			await cacheService.set('variables', null as any);
+
+			// ACT
+			const variables = await variablesService.getAllCached();
+
+			// ASSERT
+			expect(variables).toHaveLength(1);
+			expect(variables[0].key).toBe('VAR1');
+		});
+	});
+
+	describe('Cache Consistency', () => {
+		test('should use cached variables when cache is valid and non-empty', async () => {
+			// ARRANGE - Create variables and populate cache
+			const var1 = await createVariable('VAR1', 'value1');
+			const var2 = await createVariable('VAR2', 'value2');
+
+			// First call populates cache
+			await variablesService.getAllCached();
+
+			const findAllSpy = jest.spyOn(variablesRepository, 'find');
+
+			// ACT - Second call should use cache
+			const variables = await variablesService.getAllCached();
+
+			// ASSERT
+			expect(variables).toHaveLength(2);
+			// Should not query database again
+			expect(findAllSpy).not.toHaveBeenCalled();
+		});
+
+		test('should refresh cache after variable creation', async () => {
+			// ARRANGE - Start with empty cache
+			await cacheService.set('variables', []);
+
+			// ACT - Create a variable (should update cache)
+			await createVariable('VAR1', 'value1');
+			await variablesService.updateCache();
+
+			// Get from cache
+			const variables = await variablesService.getAllCached();
+
+			// ASSERT
+			expect(variables).toHaveLength(1);
+			expect(variables[0].key).toBe('VAR1');
+		});
+
+		test('should handle concurrent cache access correctly', async () => {
+			// ARRANGE
+			await createVariable('VAR1', 'value1');
+			await createVariable('VAR2', 'value2');
+
+			// Simulate empty cache
+			await cacheService.set('variables', []);
+
+			// ACT - Multiple concurrent requests
+			const [result1, result2, result3] = await Promise.all([
+				variablesService.getAllCached(),
+				variablesService.getAllCached(),
+				variablesService.getAllCached(),
+			]);
+
+			// ASSERT - All should return the same correct data
+			expect(result1).toHaveLength(2);
+			expect(result2).toHaveLength(2);
+			expect(result3).toHaveLength(2);
+		});
+	});
+
+	describe('Health Check Service', () => {
+		test('should detect empty cache with variables in database', async () => {
+			// ARRANGE
+			await createVariable('VAR1', 'value1');
+			await createVariable('VAR2', 'value2');
+
+			// Simulate stale empty cache
+			await cacheService.set('variables', []);
+
+			// ACT
+			const result = await healthService.performHealthCheck();
+
+			// ASSERT
+			expect(result.healthy).toBe(false);
+			expect(result.repaired).toBe(true);
+
+			// Verify cache was repaired
+			const cachedVariables = await cacheService.get<any[]>('variables');
+			expect(cachedVariables).toHaveLength(2);
+		});
+
+		test('should detect cache count mismatch', async () => {
+			// ARRANGE
+			await createVariable('VAR1', 'value1');
+			await createVariable('VAR2', 'value2');
+			await createVariable('VAR3', 'value3');
+
+			// Cache has outdated data (only 2 variables)
+			await cacheService.set('variables', [
+				{ id: '1', key: 'VAR1', value: 'value1' },
+				{ id: '2', key: 'VAR2', value: 'value2' },
+			]);
+
+			// ACT
+			const result = await healthService.performHealthCheck();
+
+			// ASSERT
+			expect(result.healthy).toBe(false);
+			expect(result.repaired).toBe(true);
+
+			// Verify cache was updated
+			const cachedVariables = await cacheService.get<any[]>('variables');
+			expect(cachedVariables).toHaveLength(3);
+		});
+
+		test('should report healthy when cache matches database', async () => {
+			// ARRANGE
+			const var1 = await createVariable('VAR1', 'value1');
+			const var2 = await createVariable('VAR2', 'value2');
+
+			// Populate cache correctly
+			await variablesService.updateCache();
+
+			// ACT
+			const result = await healthService.performHealthCheck();
+
+			// ASSERT
+			expect(result.healthy).toBe(true);
+			expect(result.repaired).toBe(false);
+		});
+
+		test('should handle empty database and empty cache as healthy', async () => {
+			// ARRANGE - No variables in database
+			await cacheService.set('variables', []);
+
+			// ACT
+			const result = await healthService.performHealthCheck();
+
+			// ASSERT
+			expect(result.healthy).toBe(true);
+			expect(result.repaired).toBe(false);
+		});
+	});
+
+	describe('Workflow Execution Scenarios', () => {
+		test('should provide variables to workflow execution even after cache loss', async () => {
+			// ARRANGE - Create variables
+			await createVariable('API_KEY', 'secret-key-123');
+			await createVariable('BASE_URL', 'https://api.example.com');
+
+			// Populate cache initially
+			await variablesService.updateCache();
+
+			// Simulate cache loss (Redis restart)
+			await cacheService.delete('variables');
+
+			// ACT - Workflow execution tries to get variables
+			const variables = await variablesService.getAllCached();
+
+			// ASSERT - Should recover and return variables
+			expect(variables).toHaveLength(2);
+			expect(variables.find((v) => v.key === 'API_KEY')?.value).toBe('secret-key-123');
+			expect(variables.find((v) => v.key === 'BASE_URL')?.value).toBe(
+				'https://api.example.com',
+			);
+		});
+
+		test('should handle worker node startup with empty cache', async () => {
+			// ARRANGE - Variables exist in database
+			await createVariable('WORKER_VAR', 'worker-value');
+
+			// Worker node starts with no cache
+			await cacheService.reset();
+
+			// ACT - Worker tries to execute workflow
+			const variables = await variablesService.getAllCached();
+
+			// ASSERT - Should load from database
+			expect(variables).toHaveLength(1);
+			expect(variables[0].key).toBe('WORKER_VAR');
+		});
+	});
+
+	describe('refreshCache method', () => {
+		test('should force refresh cache from database', async () => {
+			// ARRANGE
+			await createVariable('VAR1', 'value1');
+
+			// Set stale cache
+			await cacheService.set('variables', []);
+
+			// ACT
+			const variables = await variablesService.refreshCache();
+
+			// ASSERT
+			expect(variables).toHaveLength(1);
+			expect(variables[0].key).toBe('VAR1');
+
+			// Verify cache was updated
+			const cachedVariables = await cacheService.get<any[]>('variables');
+			expect(cachedVariables).toHaveLength(1);
+		});
+
+		test('should return fresh data even if cache was valid', async () => {
+			// ARRANGE
+			await createVariable('VAR1', 'value1');
+			await variablesService.updateCache();
+
+			// Add another variable directly to database (bypassing cache)
+			await createVariable('VAR2', 'value2');
+
+			// ACT - Force refresh
+			const variables = await variablesService.refreshCache();
+
+			// ASSERT - Should include the new variable
+			expect(variables).toHaveLength(2);
+			expect(variables.map((v) => v.key)).toEqual(expect.arrayContaining(['VAR1', 'VAR2']));
+		});
+	});
+});

--- a/packages/cli/src/environments.ee/variables/variables-cache-health.service.ts
+++ b/packages/cli/src/environments.ee/variables/variables-cache-health.service.ts
@@ -1,0 +1,110 @@
+import type { Variables } from '@n8n/db';
+import { VariablesRepository } from '@n8n/db';
+import { Service } from '@n8n/di';
+import { Logger } from '@n8n/logging';
+
+import { CacheService } from '@/services/cache/cache.service';
+
+/**
+ * Service to monitor and maintain the health of the variables cache.
+ * Ensures cache consistency between Redis and PostgreSQL in queue mode.
+ */
+@Service()
+export class VariablesCacheHealthService {
+	private healthCheckInterval: NodeJS.Timeout | null = null;
+
+	private readonly HEALTH_CHECK_INTERVAL_MS = 60000; // 1 minute
+
+	constructor(
+		private readonly cacheService: CacheService,
+		private readonly variablesRepository: VariablesRepository,
+		private readonly logger: Logger,
+	) {}
+
+	/**
+	 * Start periodic health checks for the variables cache.
+	 * This helps detect and recover from stale or empty cache states.
+	 */
+	startHealthChecks(): void {
+		if (this.healthCheckInterval) {
+			this.logger.debug('Variables cache health checks already running');
+			return;
+		}
+
+		this.logger.info('Starting variables cache health checks');
+
+		this.healthCheckInterval = setInterval(async () => {
+			try {
+				await this.performHealthCheck();
+			} catch (error) {
+				this.logger.error('Variables cache health check failed', {
+					error: error instanceof Error ? error.message : String(error),
+				});
+			}
+		}, this.HEALTH_CHECK_INTERVAL_MS);
+	}
+
+	/**
+	 * Stop periodic health checks.
+	 */
+	stopHealthChecks(): void {
+		if (this.healthCheckInterval) {
+			clearInterval(this.healthCheckInterval);
+			this.healthCheckInterval = null;
+			this.logger.info('Stopped variables cache health checks');
+		}
+	}
+
+	/**
+	 * Perform a health check on the variables cache.
+	 * Compares cache state with database state and repairs if necessary.
+	 */
+	async performHealthCheck(): Promise<{ healthy: boolean; repaired: boolean }> {
+		const cachedVariables = await this.cacheService.get<Variables[]>('variables');
+		const dbVariables = await this.variablesRepository.find({ relations: ['project'] });
+
+		const cacheCount = cachedVariables?.length ?? 0;
+		const dbCount = dbVariables.length;
+
+		// Check if cache is empty but database has variables
+		if (cacheCount === 0 && dbCount > 0) {
+			this.logger.warn('Variables cache is empty but database has variables - repairing cache', {
+				dbCount,
+			});
+
+			await this.cacheService.set('variables', dbVariables);
+
+			return { healthy: false, repaired: true };
+		}
+
+		// Check if cache count doesn't match database count
+		if (cacheCount !== dbCount) {
+			this.logger.warn('Variables cache count mismatch with database - repairing cache', {
+				cacheCount,
+				dbCount,
+			});
+
+			await this.cacheService.set('variables', dbVariables);
+
+			return { healthy: false, repaired: true };
+		}
+
+		// Cache appears healthy
+		return { healthy: true, repaired: false };
+	}
+
+	/**
+	 * Verify cache integrity and repair if necessary.
+	 * Returns true if cache was healthy or successfully repaired.
+	 */
+	async verifyCacheIntegrity(): Promise<boolean> {
+		const result = await this.performHealthCheck();
+
+		if (!result.healthy && !result.repaired) {
+			this.logger.error('Failed to repair variables cache');
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/packages/cli/src/environments.ee/variables/variables.service.ee.ts
+++ b/packages/cli/src/environments.ee/variables/variables.service.ee.ts
@@ -64,10 +64,36 @@ export class VariablesService {
 	async getAllCached(
 		filters: { globalOnly: boolean } = { globalOnly: false },
 	): Promise<Variables[]> {
-		const variables =
-			(await this.cacheService.get('variables', {
-				refreshFn: async () => await this.findAll(),
-			})) ?? [];
+		const cachedVariables = await this.cacheService.get<Variables[]>('variables', {
+			refreshFn: async () => await this.findAll(),
+		});
+
+		// If cache returns undefined or null, refresh from database
+		// If cache returns an empty array, we need to verify it's actually empty in the DB
+		// This handles the case where Redis cache contains [] but DB has variables
+		let variables: Variables[];
+
+		if (cachedVariables === undefined || cachedVariables === null) {
+			// Cache miss - refresh from database
+			variables = await this.findAll();
+			await this.cacheService.set('variables', variables);
+		} else if (Array.isArray(cachedVariables) && cachedVariables.length === 0) {
+			// Empty array in cache - verify against database to ensure it's truly empty
+			// This prevents stale empty caches from hiding valid variables
+			const dbVariables = await this.findAll();
+
+			if (dbVariables.length > 0) {
+				// Database has variables but cache was empty - refresh cache
+				variables = dbVariables;
+				await this.cacheService.set('variables', variables);
+			} else {
+				// Database is also empty - cache is correct
+				variables = cachedVariables;
+			}
+		} else {
+			// Cache hit with non-empty array
+			variables = cachedVariables;
+		}
 
 		if (filters.globalOnly) {
 			return variables.filter((v) => !v.project);
@@ -89,6 +115,16 @@ export class VariablesService {
 		// TODO: log update cache metric
 		const variables = await this.findAll();
 		await this.cacheService.set('variables', variables);
+	}
+
+	/**
+	 * Force refresh the variables cache from the database.
+	 * This is useful for recovery scenarios where the cache may be stale or empty.
+	 */
+	async refreshCache(): Promise<Variables[]> {
+		const variables = await this.findAll();
+		await this.cacheService.set('variables', variables);
+		return variables;
 	}
 
 	async getAllForUser(

--- a/packages/cli/src/services/cache/__tests__/cache.service.test.ts
+++ b/packages/cli/src/services/cache/__tests__/cache.service.test.ts
@@ -144,6 +144,69 @@ for (const backend of ['memory', 'redis'] as const) {
 
 				await expect(cacheService.get(nonAsciiKey)).resolves.toBe('value');
 			});
+
+			test('should validate cached value and refresh if invalid', async () => {
+				// Set an empty array in cache
+				await cacheService.set('testArray', []);
+
+				// Get with validation that rejects empty arrays
+				const result = await cacheService.get<string[]>('testArray', {
+					validateFn: (value) => Array.isArray(value) && value.length > 0,
+					refreshFn: async () => ['item1', 'item2'],
+				});
+
+				// Should have refreshed and returned new value
+				expect(result).toEqual(['item1', 'item2']);
+
+				// Cache should now contain the refreshed value
+				const cachedValue = await cacheService.get('testArray');
+				expect(cachedValue).toEqual(['item1', 'item2']);
+			});
+
+			test('should use cached value if validation passes', async () => {
+				// Set a non-empty array in cache
+				await cacheService.set('testArray', ['existing1', 'existing2']);
+
+				const refreshFn = jest.fn().mockResolvedValue(['new1', 'new2']);
+
+				// Get with validation that accepts non-empty arrays
+				const result = await cacheService.get<string[]>('testArray', {
+					validateFn: (value) => Array.isArray(value) && value.length > 0,
+					refreshFn,
+				});
+
+				// Should use cached value without calling refreshFn
+				expect(result).toEqual(['existing1', 'existing2']);
+				expect(refreshFn).not.toHaveBeenCalled();
+			});
+
+			test('should fall back to fallback value if validation fails and no refreshFn', async () => {
+				// Set an empty array in cache
+				await cacheService.set('testArray', []);
+
+				// Get with validation but no refreshFn
+				const result = await cacheService.get<string[]>('testArray', {
+					validateFn: (value) => Array.isArray(value) && value.length > 0,
+					fallbackValue: ['fallback1', 'fallback2'],
+				});
+
+				// Should return fallback value
+				expect(result).toEqual(['fallback1', 'fallback2']);
+			});
+
+			test('should handle validation with complex objects', async () => {
+				// Set an object with missing required field
+				await cacheService.set('testObject', { name: 'test' });
+
+				// Get with validation that requires 'value' field
+				const result = await cacheService.get<{ name: string; value: string }>('testObject', {
+					validateFn: (obj) => obj && 'value' in obj,
+					refreshFn: async () => ({ name: 'test', value: 'refreshed' }),
+				});
+
+				// Should have refreshed
+				expect(result).toEqual({ name: 'test', value: 'refreshed' });
+			});
 		});
 
 		describe('delete', () => {

--- a/packages/cli/src/services/cache/cache.service.ts
+++ b/packages/cli/src/services/cache/cache.service.ts
@@ -181,7 +181,12 @@ export class CacheService extends TypedEmitter<CacheEvents> {
 		{
 			fallbackValue,
 			refreshFn,
-		}: { fallbackValue?: T; refreshFn?: (key: string) => Promise<T | undefined> } = {},
+			validateFn,
+		}: {
+			fallbackValue?: T;
+			refreshFn?: (key: string) => Promise<T | undefined>;
+			validateFn?: (value: T) => boolean;
+		} = {},
 	) {
 		if (!this.cache) await this.init();
 
@@ -190,6 +195,23 @@ export class CacheService extends TypedEmitter<CacheEvents> {
 		const value = await this.cache.store.get<T>(key);
 
 		if (value !== undefined) {
+			// If a validation function is provided, check if the cached value is valid
+			if (validateFn && !validateFn(value)) {
+				this.emit('metrics.cache.miss');
+
+				// Invalid cached value - refresh if possible
+				if (refreshFn) {
+					this.emit('metrics.cache.update');
+
+					const refreshValue = await refreshFn(key);
+					await this.set(key, refreshValue);
+
+					return refreshValue;
+				}
+
+				return fallbackValue;
+			}
+
 			this.emit('metrics.cache.hit');
 
 			return value;

--- a/packages/cli/src/workflow-helpers.ts
+++ b/packages/cli/src/workflow-helpers.ts
@@ -214,8 +214,19 @@ export async function replaceInvalidCredentials<T extends IWorkflowBase>(workflo
 }
 
 export async function getVariables(workflowId?: string, projectId?: string): Promise<IDataObject> {
-	const [variables, project] = await Promise.all([
-		Container.get(VariablesService).getAllCached(),
+	const variablesService = Container.get(VariablesService);
+
+	// Get variables from cache
+	let variables = await variablesService.getAllCached();
+
+	// If cache returns empty array, verify against database
+	// This handles the case where Redis cache is stale
+	if (variables.length === 0) {
+		// Force refresh from database to ensure we have the latest data
+		variables = await variablesService.refreshCache();
+	}
+
+	const [project] = await Promise.all([
 		// If projectId is not provided, try to get it from workflow
 		workflowId && !projectId
 			? Container.get(OwnershipService).getWorkflowProjectCached(workflowId)


### PR DESCRIPTION
## Summary

This PR fixes a critical production bug in queue mode deployments where project variables intermittently disappear from the UI and resolve as `undefined` during workflow execution, causing silent failures.

### The Problem

In n8n deployments with queue mode (Redis + PostgreSQL):
- Variables disappear from the UI after Redis restarts, cache eviction, or memory pressure
- `$vars.MY_VAR` resolves as `undefined` in workflow executions
- Variables still exist in PostgreSQL and are returned by the API
- Creating a new variable temporarily fixes the issue by forcing cache refresh

### Root Cause

The bug occurs because:
1. Redis cache can contain an empty array `[]` for the variables key
2. `CacheService.get()` treats `[]` as a valid cache HIT
3. The refresh function is only triggered when cache returns `undefined`
4. Stale empty caches permanently hide valid variables in the database

### The Solution

This PR implements a multi-layered fix:

1. **Enhanced cache validation** - `getAllCached()` now detects empty cache arrays and verifies against the database before returning
2. **Smart refresh logic** - Only queries the database when cache is empty but DB might have data
3. **Workflow execution fallback** - `getVariables()` forces cache refresh when empty array is returned
4. **Health monitoring** - New `VariablesCacheHealthService` performs periodic cache integrity checks and automatic repair
5. **Extensible validation** - `CacheService.get()` now supports custom `validateFn` for cache value validation


Fixes #24676 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
