### PR TITLE
chore(editor): Align beta icon on sidebar better

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/MainSidebarHeader.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainSidebarHeader.vue
@@ -229,7 +229,7 @@ const {
 }
 
 .beta {
-	margin-top: var(--spacing--3xs);
+	margin-top: 2px;
 	margin-left: var(--spacing--3xs);
 }
 


### PR DESCRIPTION
## Summary

<img width="211" height="70" alt="image" src="https://github.com/user-attachments/assets/2c2fd3d8-45c8-4ea1-98c3-7cb4edcce84f" />

The alignment of the beta icon was a bit off visually. It can't simply be centered vertically, as the SVG icon next to it is a bit unbalanced. Design had it be higher than the n8n text but it looked off to some. This at least makes it look visually more correct, this component might change in the future (on chat hub where this icon is currently only shown).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-137/bug-chat-hub-nav-bar-icon-beta-tag-misaligned

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
