### PR TITLE
feat(ai-builder): Implement workflow execution in evaluations (no-changelog)

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/cli.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/cli.test.ts
@@ -27,6 +27,7 @@ const mockCreateConsoleLifecycle = jest.fn();
 const mockCreateLLMJudgeEvaluator = jest.fn();
 const mockCreateProgrammaticEvaluator = jest.fn();
 const mockCreatePairwiseEvaluator = jest.fn();
+const mockCreateExecutionEvaluator = jest.fn();
 const mockSendWebhookNotification = jest.fn();
 
 // Mock all external modules
@@ -42,6 +43,7 @@ jest.mock('../cli/argument-parser', () => ({
 jest.mock('../support/environment', () => ({
 	setupTestEnvironment: (): unknown => mockSetupTestEnvironment(),
 	createAgent: (...args: unknown[]): unknown => mockCreateAgent(...args),
+	resolveNodesBasePath: (): string => '/mock/nodes-base',
 }));
 
 jest.mock('../langsmith/types', () => ({
@@ -89,6 +91,7 @@ jest.mock('../index', () => ({
 		mockCreateProgrammaticEvaluator(...args),
 	createPairwiseEvaluator: (...args: unknown[]): unknown => mockCreatePairwiseEvaluator(...args),
 	createSimilarityEvaluator: () => ({ name: 'similarity', evaluate: jest.fn() }),
+	createExecutionEvaluator: (...args: unknown[]): unknown => mockCreateExecutionEvaluator(...args),
 }));
 
 /** Helper to create a minimal valid workflow for tests */
@@ -191,6 +194,7 @@ describe('CLI', () => {
 		mockCreateLLMJudgeEvaluator.mockReturnValue({ name: 'llm-judge', evaluate: jest.fn() });
 		mockCreateProgrammaticEvaluator.mockReturnValue({ name: 'programmatic', evaluate: jest.fn() });
 		mockCreatePairwiseEvaluator.mockReturnValue({ name: 'pairwise', evaluate: jest.fn() });
+		mockCreateExecutionEvaluator.mockReturnValue({ name: 'execution', evaluate: jest.fn() });
 	});
 
 	afterEach(() => {

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/execution/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/execution/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Execution evaluator for the v2 evaluation harness.
+ *
+ * Executes generated workflows with pin data to verify they run without errors.
+ * Service nodes use pin data (skipping real API calls); utility nodes execute
+ * using their real compiled dist implementations.
+ */
+
+import type { SimpleWorkflow } from '@/types/workflow';
+
+import type { EvaluationContext, Evaluator, Feedback } from '../../harness/harness-types';
+import { executeWorkflowWithPinData } from '../../support/workflow-executor';
+
+/**
+ * Create an execution evaluator that runs the workflow with pin data.
+ *
+ * Node implementations are loaded lazily from the compiled dist/ files in
+ * nodes-base and nodes-langchain — no DI or package-loading setup required.
+ */
+export function createExecutionEvaluator(): Evaluator<EvaluationContext> {
+	return {
+		name: 'execution',
+
+		async evaluate(workflow: SimpleWorkflow, ctx: EvaluationContext): Promise<Feedback[]> {
+			const pinData = ctx.pinData ?? {};
+
+			const result = await executeWorkflowWithPinData(workflow, pinData);
+
+			return [
+				{
+					evaluator: 'execution',
+					metric: 'executionSuccess',
+					score: result.success ? 1 : 0,
+					kind: 'score',
+					comment: result.success
+						? `Workflow executed successfully (${result.executedNodes.length} nodes)`
+						: `Execution failed: ${result.error}${result.errorNode ? ` (at node: ${result.errorNode})` : ''}`,
+				},
+			];
+		},
+	};
+}

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/index.ts
@@ -15,3 +15,4 @@ export {
 	createSimilarityEvaluator,
 	type SimilarityEvaluatorOptions,
 } from './similarity';
+export { createExecutionEvaluator } from './execution';

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/harness-types.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/harness/harness-types.ts
@@ -1,4 +1,5 @@
 import type { Client as LangsmithClient } from 'langsmith/client';
+import type { IPinData } from 'n8n-workflow';
 import type pLimit from 'p-limit';
 
 import type { EvalLogger } from './logger';
@@ -38,6 +39,8 @@ export interface EvaluationContext {
 	 * Populated from GenerationResult when available.
 	 */
 	generatedCode?: string;
+	/** Pin data for service nodes (used by execution evaluator) */
+	pinData?: IPinData;
 }
 
 /** Context attached to an individual test case (prompt is provided separately). */
@@ -137,6 +140,8 @@ export interface RunConfigBase {
 	lifecycle?: Partial<EvaluationLifecycle>;
 	/** Logger for all output (use `createQuietLifecycle()` to suppress output in tests) */
 	logger: EvalLogger;
+	/** Optional pin data generator. When provided, generates mock data for service nodes after workflow generation. */
+	pinDataGenerator?: (workflow: SimpleWorkflow) => Promise<IPinData>;
 }
 
 export interface LocalRunConfig extends RunConfigBase {

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/index.ts
@@ -45,6 +45,7 @@ export {
 	createProgrammaticEvaluator,
 	createPairwiseEvaluator,
 	createSimilarityEvaluator,
+	createExecutionEvaluator,
 	type PairwiseEvaluatorOptions,
 	type SimilarityEvaluatorOptions,
 } from './evaluators';

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/support/environment.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/support/environment.ts
@@ -207,7 +207,7 @@ export function resolveBuiltinNodeDefinitionDirs(): string[] {
 }
 
 /** Walk up from startDir to find the monorepo root (contains pnpm-workspace.yaml). */
-function findRepoRoot(startDir: string): string | undefined {
+export function findRepoRoot(startDir: string): string | undefined {
 	let dir = startDir;
 	while (dir !== path.dirname(dir)) {
 		if (fs.existsSync(path.join(dir, 'pnpm-workspace.yaml'))) {
@@ -216,6 +216,17 @@ function findRepoRoot(startDir: string): string | undefined {
 		dir = path.dirname(dir);
 	}
 	return undefined;
+}
+
+/**
+ * Resolve the path to packages/nodes-base/nodes/ for __schema__ resolution.
+ * Returns undefined if the path doesn't exist (e.g. running outside the monorepo).
+ */
+export function resolveNodesBasePath(): string | undefined {
+	const repoRoot = findRepoRoot(__dirname);
+	if (!repoRoot) return undefined;
+	const p = path.join(repoRoot, 'packages', 'nodes-base', 'nodes');
+	return fs.existsSync(p) ? p : undefined;
 }
 
 /**

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/support/pin-data-generator.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/support/pin-data-generator.test.ts
@@ -1,0 +1,414 @@
+import type { INode, INodeTypeDescription } from 'n8n-workflow';
+
+import type { SimpleWorkflow } from '../../src/types/workflow';
+import {
+	identifyPinDataNodes,
+	buildSchemaContexts,
+	workflowToMermaid,
+	generateEvalPinData,
+} from './pin-data-generator';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeNode(overrides: Partial<INode> & { name: string; type: string }): INode {
+	return {
+		name: overrides.name,
+		type: overrides.type,
+		typeVersion: overrides.typeVersion ?? 1,
+		position: overrides.position ?? [0, 0],
+		parameters: overrides.parameters ?? {},
+		id: overrides.id ?? overrides.name,
+		...(overrides.disabled !== undefined ? { disabled: overrides.disabled } : {}),
+	} as INode;
+}
+
+function makeNodeType(
+	name: string,
+	opts?: { credentials?: Array<{ name: string }> },
+): INodeTypeDescription {
+	return {
+		displayName: name,
+		name,
+		group: ['transform'],
+		version: 1,
+		description: '',
+		defaults: { name },
+		inputs: ['main'],
+		outputs: ['main'],
+		properties: [],
+		...(opts?.credentials ? { credentials: opts.credentials } : {}),
+	} as unknown as INodeTypeDescription;
+}
+
+// ---------------------------------------------------------------------------
+// identifyPinDataNodes
+// ---------------------------------------------------------------------------
+
+describe('identifyPinDataNodes', () => {
+	const nodeTypes: INodeTypeDescription[] = [
+		makeNodeType('n8n-nodes-base.slack', { credentials: [{ name: 'slackApi' }] }),
+		makeNodeType('n8n-nodes-base.gmail', { credentials: [{ name: 'gmailOAuth2' }] }),
+		makeNodeType('n8n-nodes-base.set'),
+		makeNodeType('n8n-nodes-base.if'),
+		makeNodeType('n8n-nodes-base.httpRequest'),
+		makeNodeType('n8n-nodes-base.webhook'),
+	];
+
+	it('should include service nodes with credentials', () => {
+		const workflow: SimpleWorkflow = {
+			name: 'Test',
+			nodes: [makeNode({ name: 'Slack', type: 'n8n-nodes-base.slack' })],
+			connections: {},
+		};
+
+		const result = identifyPinDataNodes(workflow, nodeTypes);
+		expect(result).toHaveLength(1);
+		expect(result[0].name).toBe('Slack');
+	});
+
+	it('should exclude utility nodes from deny-list', () => {
+		const workflow: SimpleWorkflow = {
+			name: 'Test',
+			nodes: [
+				makeNode({ name: 'Set', type: 'n8n-nodes-base.set' }),
+				makeNode({ name: 'If', type: 'n8n-nodes-base.if' }),
+				makeNode({ name: 'Code', type: 'n8n-nodes-base.code' }),
+			],
+			connections: {},
+		};
+
+		const result = identifyPinDataNodes(workflow, nodeTypes);
+		expect(result).toHaveLength(0);
+	});
+
+	it('should include HTTP Request and Webhook nodes even without credentials', () => {
+		const workflow: SimpleWorkflow = {
+			name: 'Test',
+			nodes: [
+				makeNode({ name: 'HTTP', type: 'n8n-nodes-base.httpRequest' }),
+				makeNode({ name: 'Hook', type: 'n8n-nodes-base.webhook' }),
+			],
+			connections: {},
+		};
+
+		const result = identifyPinDataNodes(workflow, nodeTypes);
+		expect(result).toHaveLength(2);
+	});
+
+	it('should skip disabled nodes', () => {
+		const workflow: SimpleWorkflow = {
+			name: 'Test',
+			nodes: [makeNode({ name: 'Slack', type: 'n8n-nodes-base.slack', disabled: true })],
+			connections: {},
+		};
+
+		const result = identifyPinDataNodes(workflow, nodeTypes);
+		expect(result).toHaveLength(0);
+	});
+
+	it('should handle mixed utility and service nodes', () => {
+		const workflow: SimpleWorkflow = {
+			name: 'Test',
+			nodes: [
+				makeNode({ name: 'Trigger', type: 'n8n-nodes-base.manualTrigger' }),
+				makeNode({ name: 'Slack', type: 'n8n-nodes-base.slack' }),
+				makeNode({ name: 'Set', type: 'n8n-nodes-base.set' }),
+				makeNode({ name: 'Gmail', type: 'n8n-nodes-base.gmail' }),
+			],
+			connections: {},
+		};
+
+		const result = identifyPinDataNodes(workflow, nodeTypes);
+		expect(result).toHaveLength(2);
+		expect(result.map((n) => n.name)).toEqual(['Slack', 'Gmail']);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// buildSchemaContexts
+// ---------------------------------------------------------------------------
+
+describe('buildSchemaContexts', () => {
+	it('should extract resource and operation from node parameters', () => {
+		const nodes: INode[] = [
+			makeNode({
+				name: 'Slack',
+				type: 'n8n-nodes-base.slack',
+				typeVersion: 2,
+				parameters: { resource: 'message', operation: 'send' },
+			}),
+		];
+
+		const contexts = buildSchemaContexts(nodes);
+		expect(contexts).toHaveLength(1);
+		expect(contexts[0]).toMatchObject({
+			nodeName: 'Slack',
+			nodeType: 'n8n-nodes-base.slack',
+			typeVersion: 2,
+			resource: 'message',
+			operation: 'send',
+		});
+	});
+
+	it('should handle nodes without resource/operation', () => {
+		const nodes: INode[] = [
+			makeNode({
+				name: 'HTTP',
+				type: 'n8n-nodes-base.httpRequest',
+				parameters: { url: 'https://example.com' },
+			}),
+		];
+
+		const contexts = buildSchemaContexts(nodes);
+		expect(contexts[0].resource).toBeUndefined();
+		expect(contexts[0].operation).toBeUndefined();
+	});
+
+	it('should not include schema when nodesBasePath is not provided', () => {
+		const nodes: INode[] = [
+			makeNode({
+				name: 'Slack',
+				type: 'n8n-nodes-base.slack',
+				parameters: { resource: 'message', operation: 'send' },
+			}),
+		];
+
+		const contexts = buildSchemaContexts(nodes);
+		expect(contexts[0].schema).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// workflowToMermaid
+// ---------------------------------------------------------------------------
+
+describe('workflowToMermaid', () => {
+	it('should generate mermaid flowchart for a simple workflow', () => {
+		const workflow: SimpleWorkflow = {
+			name: 'Test',
+			nodes: [
+				makeNode({ name: 'Trigger', type: 'n8n-nodes-base.manualTrigger' }),
+				makeNode({ name: 'Slack', type: 'n8n-nodes-base.slack', typeVersion: 2 }),
+			],
+			connections: {
+				Trigger: {
+					main: [[{ node: 'Slack', type: 'main', index: 0 }]],
+				},
+			},
+		};
+
+		const mermaid = workflowToMermaid(workflow);
+		expect(mermaid).toContain('flowchart LR');
+		expect(mermaid).toContain('Trigger');
+		expect(mermaid).toContain('Slack');
+		expect(mermaid).toContain('-->');
+	});
+
+	it('should include resource and operation in labels', () => {
+		const workflow: SimpleWorkflow = {
+			name: 'Test',
+			nodes: [
+				makeNode({
+					name: 'Slack',
+					type: 'n8n-nodes-base.slack',
+					typeVersion: 2,
+					parameters: { resource: 'message', operation: 'send' },
+				}),
+			],
+			connections: {},
+		};
+
+		const mermaid = workflowToMermaid(workflow);
+		expect(mermaid).toContain('resource:message');
+		expect(mermaid).toContain('op:send');
+	});
+
+	it('should handle empty connections', () => {
+		const workflow: SimpleWorkflow = {
+			name: 'Test',
+			nodes: [makeNode({ name: 'Trigger', type: 'n8n-nodes-base.manualTrigger' })],
+			connections: {},
+		};
+
+		const mermaid = workflowToMermaid(workflow);
+		expect(mermaid).toContain('flowchart LR');
+		expect(mermaid).not.toContain('-->');
+	});
+
+	it('should handle multi-output connections', () => {
+		const workflow: SimpleWorkflow = {
+			name: 'Test',
+			nodes: [
+				makeNode({ name: 'If', type: 'n8n-nodes-base.if' }),
+				makeNode({ name: 'True', type: 'n8n-nodes-base.set' }),
+				makeNode({ name: 'False', type: 'n8n-nodes-base.set' }),
+			],
+			connections: {
+				If: {
+					main: [
+						[{ node: 'True', type: 'main', index: 0 }],
+						[{ node: 'False', type: 'main', index: 0 }],
+					],
+				},
+			},
+		};
+
+		const mermaid = workflowToMermaid(workflow);
+		// Should have two connection lines
+		const arrowCount = (mermaid.match(/-->/g) ?? []).length;
+		expect(arrowCount).toBe(2);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// generateEvalPinData (with mocked LLM)
+// ---------------------------------------------------------------------------
+
+describe('generateEvalPinData', () => {
+	const nodeTypes: INodeTypeDescription[] = [
+		makeNodeType('n8n-nodes-base.slack', { credentials: [{ name: 'slackApi' }] }),
+		makeNodeType('n8n-nodes-base.linear', { credentials: [{ name: 'linearApi' }] }),
+		makeNodeType('n8n-nodes-base.set'),
+	];
+
+	function createMockLLM(responseContent: string) {
+		return {
+			invoke: jest.fn().mockResolvedValue({ content: responseContent }),
+		} as never;
+	}
+
+	it('should return pin data for service nodes', async () => {
+		const workflow: SimpleWorkflow = {
+			name: 'Test',
+			nodes: [
+				makeNode({ name: 'Linear', type: 'n8n-nodes-base.linear' }),
+				makeNode({ name: 'Set', type: 'n8n-nodes-base.set' }),
+				makeNode({ name: 'Slack', type: 'n8n-nodes-base.slack' }),
+			],
+			connections: {},
+		};
+
+		const llmResponse = JSON.stringify({
+			Linear: [{ json: { id: 'issue-123', title: 'Test Issue' } }],
+			Slack: [{ json: { ok: true, channel: 'C123' } }],
+		});
+
+		const result = await generateEvalPinData(workflow, {
+			llm: createMockLLM(llmResponse),
+			nodeTypes,
+		});
+
+		expect(Object.keys(result)).toEqual(['Linear', 'Slack']);
+		expect(result.Linear).toHaveLength(1);
+		expect(result.Slack).toHaveLength(1);
+	});
+
+	it('should return empty object when no service nodes exist', async () => {
+		const workflow: SimpleWorkflow = {
+			name: 'Test',
+			nodes: [makeNode({ name: 'Set', type: 'n8n-nodes-base.set' })],
+			connections: {},
+		};
+
+		const llm = createMockLLM('{}');
+
+		const result = await generateEvalPinData(workflow, { llm, nodeTypes });
+
+		expect(result).toEqual({});
+		// LLM should not be called
+		expect((llm as unknown as { invoke: jest.Mock }).invoke).not.toHaveBeenCalled();
+	});
+
+	it('should handle markdown-fenced JSON response', async () => {
+		const workflow: SimpleWorkflow = {
+			name: 'Test',
+			nodes: [makeNode({ name: 'Slack', type: 'n8n-nodes-base.slack' })],
+			connections: {},
+		};
+
+		const llmResponse = '```json\n{"Slack": [{"json": {"ok": true}}]}\n```';
+
+		const result = await generateEvalPinData(workflow, {
+			llm: createMockLLM(llmResponse),
+			nodeTypes,
+		});
+
+		expect(result.Slack).toHaveLength(1);
+	});
+
+	it('should wrap raw objects in { json: ... } format', async () => {
+		const workflow: SimpleWorkflow = {
+			name: 'Test',
+			nodes: [makeNode({ name: 'Slack', type: 'n8n-nodes-base.slack' })],
+			connections: {},
+		};
+
+		// LLM returns items without the { json: ... } wrapper
+		const llmResponse = JSON.stringify({
+			Slack: [{ ok: true, channel: 'C123' }],
+		});
+
+		const result = await generateEvalPinData(workflow, {
+			llm: createMockLLM(llmResponse),
+			nodeTypes,
+		});
+
+		expect(result.Slack).toHaveLength(1);
+		expect(result.Slack[0]).toHaveProperty('json');
+	});
+
+	it('should return empty object on LLM failure', async () => {
+		const workflow: SimpleWorkflow = {
+			name: 'Test',
+			nodes: [makeNode({ name: 'Slack', type: 'n8n-nodes-base.slack' })],
+			connections: {},
+		};
+
+		const llm = {
+			invoke: jest.fn().mockRejectedValue(new Error('LLM error')),
+		} as never;
+
+		const result = await generateEvalPinData(workflow, { llm, nodeTypes });
+		expect(result).toEqual({});
+	});
+
+	it('should return empty object on invalid JSON response', async () => {
+		const workflow: SimpleWorkflow = {
+			name: 'Test',
+			nodes: [makeNode({ name: 'Slack', type: 'n8n-nodes-base.slack' })],
+			connections: {},
+		};
+
+		const result = await generateEvalPinData(workflow, {
+			llm: createMockLLM('not valid json at all'),
+			nodeTypes,
+		});
+
+		expect(result).toEqual({});
+	});
+
+	it('should skip nodes not present in LLM response', async () => {
+		const workflow: SimpleWorkflow = {
+			name: 'Test',
+			nodes: [
+				makeNode({ name: 'Slack', type: 'n8n-nodes-base.slack' }),
+				makeNode({ name: 'Linear', type: 'n8n-nodes-base.linear' }),
+			],
+			connections: {},
+		};
+
+		// LLM only returns data for Slack, not Linear
+		const llmResponse = JSON.stringify({
+			Slack: [{ json: { ok: true } }],
+		});
+
+		const result = await generateEvalPinData(workflow, {
+			llm: createMockLLM(llmResponse),
+			nodeTypes,
+		});
+
+		expect(Object.keys(result)).toEqual(['Slack']);
+	});
+});

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/support/pin-data-generator.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/support/pin-data-generator.test.ts
@@ -1,12 +1,12 @@
 import type { INode, INodeTypeDescription } from 'n8n-workflow';
 
-import type { SimpleWorkflow } from '../../src/types/workflow';
 import {
 	identifyPinDataNodes,
 	buildSchemaContexts,
 	workflowToMermaid,
 	generateEvalPinData,
 } from './pin-data-generator';
+import type { SimpleWorkflow } from '../../src/types/workflow';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/support/pin-data-generator.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/support/pin-data-generator.ts
@@ -9,7 +9,6 @@
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import { existsSync, readFileSync, readdirSync } from 'fs';
-import { join } from 'path';
 import {
 	jsonParse,
 	type IDataObject,
@@ -17,6 +16,7 @@ import {
 	type INodeTypeDescription,
 	type IPinData,
 } from 'n8n-workflow';
+import { join } from 'path';
 
 import type { SimpleWorkflow } from '../../src/types/workflow';
 import type { EvalLogger } from '../harness/logger';

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/support/pin-data-generator.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/support/pin-data-generator.ts
@@ -1,0 +1,503 @@
+/**
+ * LLM-based pin data generator for evaluations.
+ *
+ * Generates realistic mock output data for service nodes in a workflow
+ * via a single LLM call, ensuring cross-node data consistency.
+ * Works with both the code-based and multi-agent builder outputs.
+ */
+
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
+import { HumanMessage, SystemMessage } from '@langchain/core/messages';
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import {
+	jsonParse,
+	type IDataObject,
+	type INode,
+	type INodeTypeDescription,
+	type IPinData,
+} from 'n8n-workflow';
+
+import type { SimpleWorkflow } from '../../src/types/workflow';
+import type { EvalLogger } from '../harness/logger';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PinDataGeneratorOptions {
+	/** LLM to use for generating mock data */
+	llm: BaseChatModel;
+	/** Loaded node type descriptions (from env.parsedNodeTypes) */
+	nodeTypes: INodeTypeDescription[];
+	/** Path to packages/nodes-base/nodes/ for __schema__ resolution */
+	nodesBasePath?: string;
+	/** Logger for verbose output */
+	logger?: EvalLogger;
+}
+
+interface NodeSchemaContext {
+	nodeName: string;
+	nodeType: string;
+	typeVersion: number;
+	resource?: string;
+	operation?: string;
+	schema?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Utility node deny-list
+// ---------------------------------------------------------------------------
+
+/** Node types that don't call external APIs and don't need pin data. */
+const UTILITY_NODE_TYPES = new Set([
+	'n8n-nodes-base.set',
+	'n8n-nodes-base.if',
+	'n8n-nodes-base.switch',
+	'n8n-nodes-base.merge',
+	'n8n-nodes-base.code',
+	'n8n-nodes-base.splitInBatches',
+	'n8n-nodes-base.noOp',
+	'n8n-nodes-base.stickyNote',
+	'n8n-nodes-base.manualTrigger',
+	'n8n-nodes-base.scheduleTrigger',
+	'n8n-nodes-base.cronTrigger',
+	'n8n-nodes-base.executeWorkflowTrigger',
+	'n8n-nodes-base.errorTrigger',
+	'n8n-nodes-base.start',
+	'n8n-nodes-base.functionItem',
+	'n8n-nodes-base.function',
+	'n8n-nodes-base.itemLists',
+	'n8n-nodes-base.filter',
+	'n8n-nodes-base.removeDuplicates',
+	'n8n-nodes-base.sort',
+	'n8n-nodes-base.limit',
+	'n8n-nodes-base.aggregate',
+	'n8n-nodes-base.summarize',
+	'n8n-nodes-base.splitOut',
+	'n8n-nodes-base.dateTime',
+	'n8n-nodes-base.crypto',
+	'n8n-nodes-base.xml',
+	'n8n-nodes-base.html',
+	'n8n-nodes-base.markdown',
+	'n8n-nodes-base.compareDatasets',
+	'n8n-nodes-base.respondToWebhook',
+	'n8n-nodes-base.wait',
+	'n8n-nodes-base.executeCommand',
+	'n8n-nodes-base.convertToFile',
+	'n8n-nodes-base.extractFromFile',
+	'n8n-nodes-base.renameKeys',
+]);
+
+// ---------------------------------------------------------------------------
+// Node identification
+// ---------------------------------------------------------------------------
+
+/**
+ * Identify which nodes in a workflow need pin data.
+ * In eval context, we pin all service/API nodes since none have real credentials.
+ */
+export function identifyPinDataNodes(
+	workflow: SimpleWorkflow,
+	nodeTypes: INodeTypeDescription[],
+): INode[] {
+	const nodeTypeMap = new Map(nodeTypes.map((nt) => [nt.name, nt]));
+
+	return workflow.nodes.filter((node) => {
+		// Skip disabled nodes
+		if (node.disabled) return false;
+
+		// Skip utility nodes by deny-list
+		if (UTILITY_NODE_TYPES.has(node.type)) return false;
+
+		// Check if the node type definition has credentials (→ it's a service node)
+		const typeDesc = nodeTypeMap.get(node.type);
+		if (typeDesc?.credentials && typeDesc.credentials.length > 0) return true;
+
+		// Also include HTTP Request and Webhook nodes (may not have credentials defined)
+		if (node.type === 'n8n-nodes-base.httpRequest' || node.type === 'n8n-nodes-base.webhook') {
+			return true;
+		}
+
+		return false;
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Schema resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a map from node type name (e.g., "n8n-nodes-base.linear") to the
+ * directory containing its __schema__ folder by scanning .node.ts files.
+ * Cached per nodesBasePath.
+ */
+const schemaMapCache = new Map<string, Map<string, string>>();
+
+function buildSchemaMap(nodesBasePath: string): Map<string, string> {
+	const cached = schemaMapCache.get(nodesBasePath);
+	if (cached) return cached;
+
+	const result = new Map<string, string>();
+
+	function scanDir(dir: string) {
+		try {
+			for (const entry of readdirSync(dir, { withFileTypes: true })) {
+				if (!entry.isDirectory()) continue;
+
+				const entryPath = join(dir, entry.name);
+				const schemaDir = join(entryPath, '__schema__');
+
+				if (existsSync(schemaDir)) {
+					// Find .node.ts/.node.js files to extract the node type name
+					const nodeFiles = readdirSync(entryPath).filter(
+						(f) => f.endsWith('.node.ts') || f.endsWith('.node.js'),
+					);
+					for (const nodeFile of nodeFiles) {
+						try {
+							const content = readFileSync(join(entryPath, nodeFile), 'utf-8');
+							const nameMatch = content.match(/name:\s*['"]([^'"]+)['"]/);
+							if (nameMatch) {
+								result.set(`n8n-nodes-base.${nameMatch[1]}`, entryPath);
+							}
+						} catch {
+							// Skip files that can't be read
+						}
+					}
+				}
+
+				// Recurse into subdirectories (e.g., Aws/S3, Google/Gmail)
+				scanDir(entryPath);
+			}
+		} catch {
+			// Directory doesn't exist or can't be read
+		}
+	}
+
+	scanDir(nodesBasePath);
+	schemaMapCache.set(nodesBasePath, result);
+	return result;
+}
+
+/**
+ * Normalize a version number to a semver-like string for directory matching.
+ * 1 → "1.0.0", 1.1 → "1.1.0", 2 → "2.0.0"
+ */
+function normalizeVersion(version: number): string {
+	const str = String(version);
+	const parts = str.split('.');
+	while (parts.length < 3) parts.push('0');
+	return parts.join('.');
+}
+
+/**
+ * Resolve the __schema__ JSON Schema for a node's output, if available.
+ */
+export function resolveSchemaForNode(
+	nodeType: string,
+	typeVersion: number,
+	resource: string | undefined,
+	operation: string | undefined,
+	nodesBasePath: string,
+): Record<string, unknown> | undefined {
+	const schemaMap = buildSchemaMap(nodesBasePath);
+	const nodeDir = schemaMap.get(nodeType);
+	if (!nodeDir) return undefined;
+
+	const schemaBaseDir = join(nodeDir, '__schema__');
+	if (!existsSync(schemaBaseDir)) return undefined;
+
+	const versionStr = normalizeVersion(typeVersion);
+
+	// Try exact version first, then fall back to available versions
+	const versionDirs = [
+		`v${versionStr}`,
+		...readdirSync(schemaBaseDir)
+			.filter((d) => d.startsWith('v'))
+			.sort()
+			.reverse(),
+	];
+
+	for (const vDir of [...new Set(versionDirs)]) {
+		const versionPath = join(schemaBaseDir, vDir);
+		if (!existsSync(versionPath)) continue;
+
+		// Build path with resource and operation
+		const parts = [versionPath, resource, operation ? `${operation}.json` : undefined].filter(
+			Boolean,
+		) as string[];
+
+		const schemaFile = join(...parts);
+		if (existsSync(schemaFile)) {
+			try {
+				return JSON.parse(readFileSync(schemaFile, 'utf-8')) as Record<string, unknown>;
+			} catch {
+				return undefined;
+			}
+		}
+	}
+
+	return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Schema context building
+// ---------------------------------------------------------------------------
+
+/**
+ * Build schema context for all pin-data-eligible nodes.
+ */
+export function buildSchemaContexts(nodes: INode[], nodesBasePath?: string): NodeSchemaContext[] {
+	return nodes.map((node) => {
+		const params = node.parameters as Record<string, unknown> | undefined;
+		const resource = typeof params?.resource === 'string' ? params.resource : undefined;
+		const operation = typeof params?.operation === 'string' ? params.operation : undefined;
+
+		let schema: Record<string, unknown> | undefined;
+		if (nodesBasePath) {
+			schema = resolveSchemaForNode(
+				node.type,
+				node.typeVersion,
+				resource,
+				operation,
+				nodesBasePath,
+			);
+		}
+
+		return {
+			nodeName: node.name,
+			nodeType: node.type,
+			typeVersion: node.typeVersion,
+			resource,
+			operation,
+			schema,
+		};
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Mermaid diagram generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a workflow's nodes and connections to a mermaid flowchart string.
+ * Includes node type, version, resource, and operation info in labels.
+ */
+export function workflowToMermaid(workflow: SimpleWorkflow): string {
+	const lines: string[] = ['flowchart LR'];
+
+	// Build a map for safe mermaid IDs
+	const nodeIdMap = new Map<string, string>();
+	workflow.nodes.forEach((node, i) => {
+		nodeIdMap.set(node.name, `n${i}`);
+	});
+
+	// Add node declarations with labels
+	for (const node of workflow.nodes) {
+		const id = nodeIdMap.get(node.name)!;
+		const params = node.parameters as Record<string, unknown> | undefined;
+		const resource = typeof params?.resource === 'string' ? params.resource : undefined;
+		const operation = typeof params?.operation === 'string' ? params.operation : undefined;
+
+		const shortType = node.type.split('.').pop() ?? node.type;
+		let label = `${node.name} (${shortType} v${node.typeVersion}`;
+		if (resource) label += `, resource:${resource}`;
+		if (operation) label += `, op:${operation}`;
+		label += ')';
+
+		lines.push(`  ${id}["${label}"]`);
+	}
+
+	// Add connections
+	const { connections } = workflow;
+	for (const [sourceName, nodeConns] of Object.entries(connections)) {
+		const sourceId = nodeIdMap.get(sourceName);
+		if (!sourceId) continue;
+
+		for (const [, outputConnections] of Object.entries(nodeConns)) {
+			if (!Array.isArray(outputConnections)) continue;
+
+			for (const outputGroup of outputConnections) {
+				if (!Array.isArray(outputGroup)) continue;
+
+				for (const conn of outputGroup) {
+					if (!conn?.node) continue;
+					const targetId = nodeIdMap.get(conn.node);
+					if (targetId) {
+						lines.push(`  ${sourceId} --> ${targetId}`);
+					}
+				}
+			}
+		}
+	}
+
+	return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// LLM prompt construction
+// ---------------------------------------------------------------------------
+
+const SYSTEM_PROMPT = `You are a test data generator for n8n workflow automation. Generate realistic mock API response data for service nodes in a workflow.
+
+RULES:
+1. Data must be consistent across nodes. If node A creates an entity with id "abc-123", downstream nodes referencing that entity must use "abc-123".
+2. Generate 1-2 items per node.
+3. When a JSON Schema is provided, follow its structure exactly.
+4. When no schema is provided, generate a realistic response based on the node type, resource, and operation.
+5. Use realistic but clearly fake values (e.g., "jane@example.com", "proj_abc123", "2024-01-15T10:30:00Z").
+6. Return ONLY a valid JSON object, no explanation or markdown fencing.`;
+
+function buildUserPrompt(workflow: SimpleWorkflow, contexts: NodeSchemaContext[]): string {
+	const mermaid = workflowToMermaid(workflow);
+
+	const sections: string[] = [
+		'Generate mock output data for service nodes in this workflow.',
+		'',
+		'## Workflow Graph',
+		'',
+		'```mermaid',
+		mermaid,
+		'```',
+		'',
+		'## Nodes Requiring Mock Data',
+	];
+
+	for (const ctx of contexts) {
+		sections.push('');
+		sections.push(`### ${ctx.nodeName} (${ctx.nodeType} v${ctx.typeVersion})`);
+		if (ctx.resource || ctx.operation) {
+			const parts: string[] = [];
+			if (ctx.resource) parts.push(`Resource: ${ctx.resource}`);
+			if (ctx.operation) parts.push(`Operation: ${ctx.operation}`);
+			sections.push(`- ${parts.join(' | ')}`);
+		}
+		if (ctx.schema) {
+			const schemaStr = JSON.stringify(ctx.schema, null, 2);
+			// Truncate very large schemas to keep prompt manageable
+			const truncated = schemaStr.length > 3000 ? schemaStr.slice(0, 3000) + '\n...' : schemaStr;
+			sections.push('- Output JSON Schema:');
+			sections.push('```json');
+			sections.push(truncated);
+			sections.push('```');
+		} else {
+			sections.push('(no schema available — generate based on API knowledge)');
+		}
+	}
+
+	sections.push('');
+	sections.push('## Expected Output Format');
+	sections.push('');
+	sections.push(
+		'Return a JSON object where each key is the exact node name and the value is an array of items, each wrapped in a "json" key:',
+	);
+	sections.push('');
+	sections.push('```json');
+	sections.push('{');
+	for (let i = 0; i < Math.min(contexts.length, 2); i++) {
+		const ctx = contexts[i];
+		const comma = i < Math.min(contexts.length, 2) - 1 ? ',' : '';
+		sections.push(`  "${ctx.nodeName}": [{ "json": { ... } }]${comma}`);
+	}
+	if (contexts.length > 2) {
+		sections.push('  ...');
+	}
+	sections.push('}');
+	sections.push('```');
+
+	return sections.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Response parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the LLM response into IPinData format.
+ * Handles both `{ "json": {...} }` wrapped and unwrapped items.
+ */
+function parsePinDataResponse(responseText: string, expectedNodes: string[]): IPinData {
+	// Strip markdown code fences if present
+	let cleaned = responseText.trim();
+	if (cleaned.startsWith('```')) {
+		cleaned = cleaned.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '');
+	}
+
+	const parsed = jsonParse<Record<string, unknown>>(cleaned);
+	const pinData: IPinData = {};
+
+	for (const nodeName of expectedNodes) {
+		const nodeData = parsed[nodeName];
+		if (!Array.isArray(nodeData) || nodeData.length === 0) continue;
+
+		pinData[nodeName] = nodeData.map((item: unknown) => {
+			if (typeof item === 'object' && item !== null && 'json' in item) {
+				return item as { json: IDataObject };
+			}
+			// Wrap raw objects in { json: ... }
+			return { json: (item ?? {}) as IDataObject };
+		});
+	}
+
+	return pinData;
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate pin data for all service nodes in a workflow using an LLM.
+ * Produces consistent cross-node mock data in a single LLM call.
+ *
+ * @returns IPinData map (node name → execution data items). Returns {} on failure.
+ */
+export async function generateEvalPinData(
+	workflow: SimpleWorkflow,
+	options: PinDataGeneratorOptions,
+): Promise<IPinData> {
+	const { llm, nodeTypes, nodesBasePath, logger } = options;
+
+	// 1. Identify which nodes need pin data
+	const eligibleNodes = identifyPinDataNodes(workflow, nodeTypes);
+	if (eligibleNodes.length === 0) {
+		logger?.verbose('  Pin data: no service nodes found, skipping');
+		return {};
+	}
+
+	logger?.verbose(`  Pin data: generating for ${eligibleNodes.length} node(s)`);
+
+	// 2. Build schema contexts (with optional __schema__ enrichment)
+	const contexts = buildSchemaContexts(eligibleNodes, nodesBasePath);
+	const schemasFound = contexts.filter((c) => c.schema).length;
+	if (schemasFound > 0) {
+		logger?.verbose(`  Pin data: found __schema__ for ${schemasFound}/${contexts.length} node(s)`);
+	}
+
+	// 3. Build prompt and call LLM
+	const userPrompt = buildUserPrompt(workflow, contexts);
+	const expectedNodeNames = contexts.map((c) => c.nodeName);
+
+	try {
+		const response = await llm.invoke([
+			new SystemMessage(SYSTEM_PROMPT),
+			new HumanMessage(userPrompt),
+		]);
+
+		const responseText =
+			typeof response.content === 'string' ? response.content : JSON.stringify(response.content);
+
+		const pinData = parsePinDataResponse(responseText, expectedNodeNames);
+
+		const generatedCount = Object.keys(pinData).length;
+		logger?.verbose(
+			`  Pin data: generated for ${generatedCount}/${expectedNodeNames.length} node(s)`,
+		);
+
+		return pinData;
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		logger?.warn(`  Pin data generation failed: ${message}`);
+		return {};
+	}
+}

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/support/workflow-executor.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/support/workflow-executor.test.ts
@@ -1,0 +1,99 @@
+import type { INode, IPinData } from 'n8n-workflow';
+
+import type { SimpleWorkflow } from '../../src/types/workflow';
+import { executeWorkflowWithPinData } from './workflow-executor';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock('./environment', () => ({
+	findRepoRoot: jest.fn(() => '/mock/repo/root'),
+}));
+
+jest.mock('@n8n/di', () => ({
+	Container: {
+		set: jest.fn(),
+		get: jest.fn(() => ({})),
+	},
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSimpleWorkflow(nodes?: INode[]): SimpleWorkflow {
+	return {
+		name: 'Test Workflow',
+		nodes: nodes ?? [
+			{
+				name: 'Trigger',
+				type: 'n8n-nodes-base.manualTrigger',
+				typeVersion: 1,
+				position: [0, 0] as [number, number],
+				parameters: {},
+				id: 'trigger-1',
+			} as INode,
+		],
+		connections: {},
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('executeWorkflowWithPinData', () => {
+	describe('error handling — no monorepo root', () => {
+		beforeEach(() => {
+			const envModule = require('./environment') as { findRepoRoot: jest.Mock };
+			envModule.findRepoRoot.mockReturnValue(undefined);
+		});
+
+		it('should return success=false when monorepo root cannot be found', async () => {
+			const workflow = makeSimpleWorkflow();
+			const pinData: IPinData = {};
+
+			const result = await executeWorkflowWithPinData(workflow, pinData);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Cannot find monorepo root');
+			expect(result.executedNodes).toEqual([]);
+		});
+
+		it('should always return a non-negative durationMs', async () => {
+			const result = await executeWorkflowWithPinData(makeSimpleWorkflow(), {});
+
+			expect(typeof result.durationMs).toBe('number');
+			expect(result.durationMs).toBeGreaterThanOrEqual(0);
+		});
+	});
+});
+
+describe('ExecutionResult shape', () => {
+	it('should include success, durationMs, and executedNodes', () => {
+		const result = {
+			success: true,
+			durationMs: 100,
+			executedNodes: ['Trigger', 'Set'],
+		};
+
+		expect(result).toHaveProperty('success');
+		expect(result).toHaveProperty('durationMs');
+		expect(result).toHaveProperty('executedNodes');
+	});
+
+	it('should support optional error and errorNode fields', () => {
+		const result = {
+			success: false,
+			error: 'Something went wrong',
+			errorNode: 'HTTP Request',
+			durationMs: 50,
+			executedNodes: ['Trigger'],
+		};
+
+		expect(result.success).toBe(false);
+		expect(result.error).toBe('Something went wrong');
+		expect(result.errorNode).toBe('HTTP Request');
+	});
+});

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/support/workflow-executor.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/support/workflow-executor.test.ts
@@ -1,7 +1,8 @@
 import type { INode, IPinData } from 'n8n-workflow';
 
-import type { SimpleWorkflow } from '../../src/types/workflow';
+import { findRepoRoot } from './environment';
 import { executeWorkflowWithPinData } from './workflow-executor';
+import type { SimpleWorkflow } from '../../src/types/workflow';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -46,8 +47,7 @@ function makeSimpleWorkflow(nodes?: INode[]): SimpleWorkflow {
 describe('executeWorkflowWithPinData', () => {
 	describe('error handling — no monorepo root', () => {
 		beforeEach(() => {
-			const envModule = require('./environment') as { findRepoRoot: jest.Mock };
-			envModule.findRepoRoot.mockReturnValue(undefined);
+			jest.mocked(findRepoRoot).mockReturnValue(undefined);
 		});
 
 		it('should return success=false when monorepo root cannot be found', async () => {

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/support/workflow-executor.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/support/workflow-executor.ts
@@ -28,8 +28,8 @@ import type {
 import { createDeferredPromise, createRunExecutionData, NodeHelpers, Workflow } from 'n8n-workflow';
 import path from 'path';
 
-import type { SimpleWorkflow } from '../../src/types/workflow';
 import { findRepoRoot } from './environment';
+import type { SimpleWorkflow } from '../../src/types/workflow';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -96,9 +96,9 @@ class DistNodeTypes implements INodeTypes {
 	getByNameAndVersion(type: string, version?: number): INodeType {
 		const loaded = this.loadNode(type);
 		if ('nodeVersions' in loaded) {
-			return NodeHelpers.getVersionedNodeType(loaded as IVersionedNodeType, version);
+			return NodeHelpers.getVersionedNodeType(loaded, version);
 		}
-		return loaded as INodeType;
+		return loaded;
 	}
 
 	getKnownTypes() {
@@ -220,9 +220,9 @@ async function resolveImports(): Promise<ResolvedImports> {
 	]);
 
 	resolvedImports = {
-		WorkflowExecute: weModule.WorkflowExecute as unknown as ResolvedImports['WorkflowExecute'],
+		WorkflowExecute: weModule.WorkflowExecute as ResolvedImports['WorkflowExecute'],
 		ExecutionLifecycleHooks:
-			hookModule.ExecutionLifecycleHooks as unknown as ResolvedImports['ExecutionLifecycleHooks'],
+			hookModule.ExecutionLifecycleHooks as ResolvedImports['ExecutionLifecycleHooks'],
 		nodeTypes,
 	};
 
@@ -340,7 +340,7 @@ export async function executeWorkflowWithPinData(
 
 		return {
 			success: !hasError && result.status === 'success',
-			error: hasError ? ((resultError as Error)?.message ?? String(resultError)) : undefined,
+			error: hasError ? ((resultError as Error)?.message ?? resultError) : undefined,
 			errorNode: hasError ? findErrorNode(result) : undefined,
 			durationMs: Date.now() - startTime,
 			executedNodes,

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/support/workflow-executor.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/support/workflow-executor.ts
@@ -1,0 +1,371 @@
+/**
+ * Lightweight workflow executor for evaluations.
+ *
+ * Executes a SimpleWorkflow with pin data using the n8n execution engine.
+ * Service/API nodes use pin data (skipping real API calls). Utility nodes
+ * (Set, If, Code, etc.) actually execute using their compiled dist
+ * implementations, validating the workflow structure end-to-end.
+ *
+ * Node implementations are loaded directly from the compiled dist/ files in
+ * nodes-base and nodes-langchain, bypassing the DI-based loader infrastructure
+ * and its TypeScript path-alias issues.
+ *
+ * Uses path-based resolution to import WorkflowExecute and
+ * ExecutionLifecycleHooks from @n8n/core dist without adding it as a package
+ * dependency, following the NodeTestHarness pattern.
+ */
+
+import type {
+	IExecuteFunctions,
+	IPinData,
+	IRun,
+	INodeType,
+	INodeTypeDescription,
+	INodeTypes,
+	IVersionedNodeType,
+	IWorkflowExecuteAdditionalData,
+} from 'n8n-workflow';
+import { createDeferredPromise, createRunExecutionData, NodeHelpers, Workflow } from 'n8n-workflow';
+import path from 'path';
+
+import type { SimpleWorkflow } from '../../src/types/workflow';
+import { findRepoRoot } from './environment';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ExecutionResult {
+	success: boolean;
+	error?: string;
+	/** Node that caused the error, if identifiable */
+	errorNode?: string;
+	/** Total execution duration in ms */
+	durationMs: number;
+	/** Which nodes actually executed (in order) */
+	executedNodes: string[];
+}
+
+// ---------------------------------------------------------------------------
+// DistNodeTypes
+//
+// Implements INodeTypes by loading compiled node classes directly from the
+// dist/ directories of nodes-base and nodes-langchain packages.
+//
+// - Reads dist/known/nodes.json for the lazy-load index (no actual loading yet)
+// - On getByName/getByNameAndVersion: require()s the compiled .js file and
+//   instantiates the class on demand
+// - Unknown types fall back to a passthrough; service nodes never reach
+//   execute() because the engine short-circuits on pin data
+//
+// No DI container, no TypeScript source files, no path alias issues.
+// ---------------------------------------------------------------------------
+
+interface KnownNodeEntry {
+	className: string;
+	sourcePath: string;
+	packageDir: string;
+}
+
+class DistNodeTypes implements INodeTypes {
+	private readonly knownNodes: Map<string, KnownNodeEntry>;
+
+	private readonly cache = new Map<string, INodeType | IVersionedNodeType>();
+
+	constructor(
+		packages: Array<{
+			packagePrefix: string;
+			packageDir: string;
+			knownNodes: Record<string, { className: string; sourcePath: string }>;
+		}>,
+	) {
+		this.knownNodes = new Map();
+		for (const { packagePrefix, packageDir, knownNodes } of packages) {
+			for (const [shortName, info] of Object.entries(knownNodes)) {
+				// Workflow nodes use the full type name: "n8n-nodes-base.set"
+				// The known.nodes JSON uses just the short name: "set"
+				this.knownNodes.set(`${packagePrefix}.${shortName}`, { ...info, packageDir });
+			}
+		}
+	}
+
+	getByName(type: string): INodeType | IVersionedNodeType {
+		return this.loadNode(type);
+	}
+
+	getByNameAndVersion(type: string, version?: number): INodeType {
+		const loaded = this.loadNode(type);
+		if ('nodeVersions' in loaded) {
+			return NodeHelpers.getVersionedNodeType(loaded as IVersionedNodeType, version);
+		}
+		return loaded as INodeType;
+	}
+
+	getKnownTypes() {
+		return {};
+	}
+
+	private loadNode(type: string): INodeType | IVersionedNodeType {
+		const cached = this.cache.get(type);
+		if (cached) return cached;
+
+		const known = this.knownNodes.get(type);
+		if (!known) {
+			// Unknown type — return a passthrough so the engine doesn't crash.
+			// Service nodes never reach execute() because pin data intercepts them first.
+			return {
+				description: {
+					displayName: type,
+					name: type,
+					group: ['transform'],
+					version: 1,
+					description: '',
+					defaults: { name: type },
+					inputs: ['main'],
+					outputs: ['main'],
+					properties: [],
+				} as unknown as INodeTypeDescription,
+				async execute(this: IExecuteFunctions) {
+					return [this.getInputData()];
+				},
+			};
+		}
+
+		// Load from compiled dist JS file — no path aliases, no DI
+		const filePath = path.join(known.packageDir, known.sourcePath);
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		const mod = require(filePath) as Record<string, new () => INodeType | IVersionedNodeType>;
+		const NodeClass = mod[known.className];
+		const instance = new NodeClass();
+		this.cache.set(type, instance);
+		return instance;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Lazy singleton for WorkflowExecute + ExecutionLifecycleHooks + DistNodeTypes
+// ---------------------------------------------------------------------------
+
+let resolvedImports: ResolvedImports | undefined;
+
+interface ResolvedImports {
+	WorkflowExecute: new (
+		additionalData: IWorkflowExecuteAdditionalData,
+		mode: string,
+		runExecutionData: unknown,
+	) => { processRunExecutionData: (workflow: Workflow) => Promise<IRun> };
+	ExecutionLifecycleHooks: new (
+		mode: string,
+		executionId: string,
+		workflowData: unknown,
+	) => {
+		addHandler: (event: string, handler: (...args: unknown[]) => void) => void;
+	};
+	nodeTypes: DistNodeTypes;
+}
+
+function getPaths(): { corePath: string; nodesBasePath: string; langchainPath: string } {
+	const repoRoot = findRepoRoot(__dirname);
+	if (!repoRoot) {
+		throw new Error('Cannot find monorepo root — workflow execution requires the n8n monorepo');
+	}
+	return {
+		corePath: path.join(repoRoot, 'packages', 'core'),
+		nodesBasePath: path.join(repoRoot, 'packages', 'nodes-base'),
+		langchainPath: path.join(repoRoot, 'packages', '@n8n', 'nodes-langchain'),
+	};
+}
+
+async function resolveImports(): Promise<ResolvedImports> {
+	if (resolvedImports) return resolvedImports;
+
+	const { corePath, nodesBasePath, langchainPath } = getPaths();
+	const distPath = path.join(corePath, 'dist', 'execution-engine');
+
+	// Import WorkflowExecute and ExecutionLifecycleHooks from compiled dist
+	const weModule = (await import(path.join(distPath, 'workflow-execute.js'))) as Record<
+		string,
+		unknown
+	>;
+	const hookModule = (await import(path.join(distPath, 'execution-lifecycle-hooks.js'))) as Record<
+		string,
+		unknown
+	>;
+
+	// Load the lazy-load index from each package's dist/known/nodes.json.
+	// These JSON files are built during `pnpm build` and map short node names
+	// to their compiled .js entry points.
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	const nodesBaseKnown = require(path.join(nodesBasePath, 'dist', 'known', 'nodes.json')) as Record<
+		string,
+		{ className: string; sourcePath: string }
+	>;
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	const langchainKnown = require(path.join(langchainPath, 'dist', 'known', 'nodes.json')) as Record<
+		string,
+		{ className: string; sourcePath: string }
+	>;
+
+	const nodeTypes = new DistNodeTypes([
+		{
+			packagePrefix: 'n8n-nodes-base',
+			packageDir: nodesBasePath,
+			knownNodes: nodesBaseKnown,
+		},
+		{
+			packagePrefix: '@n8n/n8n-nodes-langchain',
+			packageDir: langchainPath,
+			knownNodes: langchainKnown,
+		},
+	]);
+
+	resolvedImports = {
+		WorkflowExecute: weModule.WorkflowExecute as unknown as ResolvedImports['WorkflowExecute'],
+		ExecutionLifecycleHooks:
+			hookModule.ExecutionLifecycleHooks as unknown as ResolvedImports['ExecutionLifecycleHooks'],
+		nodeTypes,
+	};
+
+	return resolvedImports;
+}
+
+// ---------------------------------------------------------------------------
+// Proxy-based additionalData stub
+//
+// WorkflowExecute calls various methods on additionalData at runtime.
+// Rather than importing jest-mock-extended (which requires the Jest runtime),
+// we use a Proxy that returns a no-op function for any property access and
+// allows specific values to be injected via the `overrides` map.
+// ---------------------------------------------------------------------------
+
+function makeAdditionalDataStub(
+	overrides: Record<string, unknown>,
+): IWorkflowExecuteAdditionalData {
+	return new Proxy({} as IWorkflowExecuteAdditionalData, {
+		get(_target, prop: string) {
+			if (prop in overrides) return overrides[prop];
+			return () => undefined;
+		},
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Main execution function
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a workflow with pin data and return the result.
+ *
+ * Service/API nodes use pin data (skipping real API calls). Utility nodes
+ * (Set, If, Code, etc.) execute normally using their compiled dist
+ * implementations, validating the workflow structure end-to-end.
+ *
+ * @param workflow - The workflow to execute
+ * @param pinData  - Pin data for service/API nodes
+ */
+export async function executeWorkflowWithPinData(
+	workflow: SimpleWorkflow,
+	pinData: IPinData,
+): Promise<ExecutionResult> {
+	const startTime = Date.now();
+	const executedNodes: string[] = [];
+
+	try {
+		const imports = await resolveImports();
+
+		// Create Workflow instance with real node implementations
+		const workflowInstance = new Workflow({
+			id: 'eval-execution',
+			nodes: workflow.nodes,
+			connections: workflow.connections,
+			nodeTypes: imports.nodeTypes,
+			active: false,
+		});
+
+		// Find start node
+		const startNode = workflowInstance.getStartNode();
+		if (!startNode) {
+			return {
+				success: false,
+				error: 'No start node found in workflow',
+				durationMs: Date.now() - startTime,
+				executedNodes: [],
+			};
+		}
+
+		// Set up execution lifecycle hooks
+		const hooks = new imports.ExecutionLifecycleHooks('trigger', '1', {} as never);
+		hooks.addHandler('nodeExecuteAfter', (nodeName: unknown) => {
+			if (typeof nodeName === 'string') {
+				executedNodes.push(nodeName);
+			}
+		});
+
+		const waitPromise = createDeferredPromise<IRun>();
+		hooks.addHandler('workflowExecuteAfter', (fullRunData: unknown) => {
+			waitPromise.resolve(fullRunData as IRun);
+		});
+
+		// Set up additional data with a Proxy stub so WorkflowExecute can safely call
+		// any method on it without hitting "Cannot read properties of undefined".
+		// WorkflowExecute reads `hooks` at runtime — it's not on the TS type, so we
+		// inject it via the proxy's known-values map.
+		const additionalData = makeAdditionalDataStub({ executionId: '1', hooks });
+
+		// Create execution data with pin data in resultData
+		const runExecutionData = createRunExecutionData({
+			executionData: {
+				nodeExecutionStack: [
+					{
+						node: startNode,
+						data: { main: [[{ json: {} }]] },
+						source: null,
+					},
+				],
+			},
+			resultData: {
+				pinData,
+			},
+		});
+
+		// Execute the workflow
+		const workflowExecute = new imports.WorkflowExecute(additionalData, 'manual', runExecutionData);
+		await workflowExecute.processRunExecutionData(workflowInstance);
+
+		const result = await waitPromise.promise;
+
+		// Check result for errors
+		const resultError = result.data?.resultData?.error;
+		const hasError = !!resultError;
+
+		return {
+			success: !hasError && result.status === 'success',
+			error: hasError ? ((resultError as Error)?.message ?? String(resultError)) : undefined,
+			errorNode: hasError ? findErrorNode(result) : undefined,
+			durationMs: Date.now() - startTime,
+			executedNodes,
+		};
+	} catch (error) {
+		return {
+			success: false,
+			error: error instanceof Error ? error.message : String(error),
+			durationMs: Date.now() - startTime,
+			executedNodes,
+		};
+	}
+}
+
+/**
+ * Find the node that caused an execution error from run data.
+ */
+function findErrorNode(run: IRun): string | undefined {
+	const { runData } = run.data.resultData;
+	for (const [nodeName, nodeRuns] of Object.entries(runData)) {
+		for (const nodeRun of nodeRuns) {
+			if (nodeRun.error) {
+				return nodeName;
+			}
+		}
+	}
+	return undefined;
+}

--- a/packages/@n8n/ai-workflow-builder.ee/src/code-builder/handlers/test/agent-iteration-handler.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/code-builder/handlers/test/agent-iteration-handler.test.ts
@@ -44,7 +44,7 @@ describe('AgentIterationHandler', () => {
 				});
 
 				// Exhaust the generator
-				// eslint-disable-next-line @typescript-eslint/no-unused-vars
+
 				for await (const _chunk of generator) {
 					// consume chunks
 				}


### PR DESCRIPTION
## Summary

Add an execution-based evaluator to the AI Workflow Builder evaluation harness. After the AI generates a workflow, the system:

1. Identifies service/API nodes that need mock data (nodes with credentials, HTTP Request, Webhook)
2. Generates realistic mock pin data for those nodes via a single LLM call, using Mermaid workflow diagrams and optional `__schema__` JSON Schemas for structural accuracy
3. Executes the workflow with the generated pin data — service nodes return pinned data while utility nodes (Set, If, Merge, etc.) run their real implementations
4. Reports success/failure as an `executionSuccess` metric

The workflow executor bypasses the DI container by loading compiled node implementations directly from `dist/known/nodes.json`, making it self-contained for the evaluation context.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-1977

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)