### PR TITLE
fix(editor): Show the right state on metadata update (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.vue
@@ -175,7 +175,7 @@ function onTagsBlur() {
 		workflowDocumentStore.value.setTags(tags);
 	}
 	workflowState.setWorkflowTagIds(tags);
-	uiStore.markStateDirty();
+	uiStore.markStateDirty('metadata');
 
 	telemetry.track('User edited workflow tags', {
 		workflow_id: props.id,

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
@@ -99,7 +99,7 @@ const workflowPublishState = computed((): WorkflowPublishState => {
 	const hasBeenPublished = !!workflowsStore.workflow.activeVersion;
 	const hasChanges =
 		workflowsStore.workflow.versionId !== workflowsStore.workflow.activeVersion?.versionId ||
-		uiStore.stateIsDirty;
+		uiStore.hasUnsavedWorkflowChanges;
 
 	// Not published states
 	if (!hasBeenPublished) {

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowState.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowState.ts
@@ -62,7 +62,7 @@ export function useWorkflowState() {
 
 	function setWorkflowName(data: { newName: string; setStateDirty: boolean }) {
 		if (data.setStateDirty) {
-			uiStore.markStateDirty();
+			uiStore.markStateDirty('metadata');
 		}
 		ws.workflow.name = data.newName;
 		ws.workflowObject.name = data.newName;

--- a/packages/frontend/editor-ui/src/app/stores/ui.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/ui.store.test.ts
@@ -1,0 +1,80 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { useUIStore } from '@/app/stores/ui.store';
+
+describe('UI Store', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia());
+	});
+
+	describe('markStateDirty', () => {
+		it('should mark state as dirty and set hasUnsavedWorkflowChanges when type is workflow', () => {
+			const uiStore = useUIStore();
+
+			uiStore.markStateDirty('workflow');
+
+			expect(uiStore.stateIsDirty).toBe(true);
+			expect(uiStore.hasUnsavedWorkflowChanges).toBe(true);
+		});
+
+		it('should mark state as dirty but not set hasUnsavedWorkflowChanges when type is metadata', () => {
+			const uiStore = useUIStore();
+
+			uiStore.markStateDirty('metadata');
+
+			expect(uiStore.stateIsDirty).toBe(true);
+			expect(uiStore.hasUnsavedWorkflowChanges).toBe(false);
+		});
+
+		it('should default to workflow type when no type is provided', () => {
+			const uiStore = useUIStore();
+
+			uiStore.markStateDirty();
+
+			expect(uiStore.stateIsDirty).toBe(true);
+			expect(uiStore.hasUnsavedWorkflowChanges).toBe(true);
+		});
+
+		it('should increment dirtyStateSetCount each time it is called', () => {
+			const uiStore = useUIStore();
+			const initialCount = uiStore.dirtyStateSetCount;
+
+			uiStore.markStateDirty('metadata');
+			expect(uiStore.dirtyStateSetCount).toBe(initialCount + 1);
+
+			uiStore.markStateDirty('workflow');
+			expect(uiStore.dirtyStateSetCount).toBe(initialCount + 2);
+		});
+
+		it('should not override hasUnsavedWorkflowChanges once set to true', () => {
+			const uiStore = useUIStore();
+
+			uiStore.markStateDirty('workflow');
+			expect(uiStore.hasUnsavedWorkflowChanges).toBe(true);
+
+			uiStore.markStateDirty('metadata');
+			expect(uiStore.hasUnsavedWorkflowChanges).toBe(true);
+		});
+	});
+
+	describe('markStateClean', () => {
+		it('should mark state as clean', () => {
+			const uiStore = useUIStore();
+
+			uiStore.markStateDirty('workflow');
+			expect(uiStore.stateIsDirty).toBe(true);
+
+			uiStore.markStateClean();
+			expect(uiStore.stateIsDirty).toBe(false);
+		});
+
+		it('should clear hasUnsavedWorkflowChanges when marking state clean', () => {
+			const uiStore = useUIStore();
+
+			uiStore.markStateDirty('workflow');
+			expect(uiStore.hasUnsavedWorkflowChanges).toBe(true);
+
+			uiStore.markStateClean();
+			expect(uiStore.hasUnsavedWorkflowChanges).toBe(false);
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/app/stores/ui.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/ui.store.ts
@@ -275,6 +275,8 @@ export const useUIStore = defineStore(STORES.UI, () => {
 	});
 	const currentView = ref<string>('');
 	const stateIsDirty = ref<boolean>(false);
+	// This tracks only structural changes without metadata (name or tags)
+	const hasUnsavedWorkflowChanges = ref<boolean>(false);
 	const dirtyStateSetCount = ref<number>(0);
 	const lastSelectedNode = ref<string | null>(null);
 	const nodeViewOffsetPosition = ref<[number, number]>([0, 0]);
@@ -617,13 +619,17 @@ export const useUIStore = defineStore(STORES.UI, () => {
 		processingExecutionResults.value = value;
 	};
 
-	const markStateDirty = () => {
+	const markStateDirty = (type: 'workflow' | 'metadata' = 'workflow') => {
 		dirtyStateSetCount.value++;
 		stateIsDirty.value = true;
+		if (type === 'workflow') {
+			hasUnsavedWorkflowChanges.value = true;
+		}
 	};
 
 	const markStateClean = () => {
 		stateIsDirty.value = false;
+		hasUnsavedWorkflowChanges.value = false;
 	};
 
 	/**
@@ -686,6 +692,7 @@ export const useUIStore = defineStore(STORES.UI, () => {
 		headerHeight,
 		dirtyStateSetCount: computed(() => dirtyStateSetCount.value),
 		stateIsDirty: computed(() => stateIsDirty.value),
+		hasUnsavedWorkflowChanges: computed(() => hasUnsavedWorkflowChanges.value),
 		isBlankRedirect,
 		activeCredentialType,
 		lastSelectedNode,


### PR DESCRIPTION
## Summary

In https://github.com/n8n-io/n8n/pull/25577 we switched to using debounced save for name and tags update which made the publish indicator state show incorrect `hasChanges` state when only workflow metadata changed. This PR fixes that.

To test, go to a workflow which last version is published and update workflow name or tags with a slow connection.

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-4830](https://linear.app/n8n/issue/ADO-4830/bug-publish-state-is-temporarily-has-changes-on-tag-or-name-update)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
