### PR TITLE
fix(core): Validate GCP service account key on initialization

### DIFF
--- a/packages/cli/src/modules/external-secrets.ee/providers/gcp-secrets-manager/gcp-secrets-manager.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/gcp-secrets-manager/gcp-secrets-manager.ts
@@ -1,7 +1,7 @@
 import type { protos, SecretManagerServiceClient as GcpClient } from '@google-cloud/secret-manager';
 import { Logger } from '@n8n/backend-common';
 import { Container } from '@n8n/di';
-import { ensureError, jsonParse, type INodeProperties } from 'n8n-workflow';
+import { ensureError, jsonParse, UserError, type INodeProperties } from 'n8n-workflow';
 
 import type {
 	GcpSecretsManagerContext,
@@ -156,13 +156,24 @@ export class GcpSecretsManager extends SecretsProvider {
 		return Object.keys(this.cachedSecrets);
 	}
 
-	private parseSecretAccountKey(privateKey: string): GcpSecretAccountKey {
-		const parsed = jsonParse<RawGcpSecretAccountKey>(privateKey, { fallbackValue: {} });
+	private parseSecretAccountKey(serviceAccountKey: string): GcpSecretAccountKey {
+		const secretAccountKey = jsonParse<RawGcpSecretAccountKey>(serviceAccountKey, {
+			fallbackValue: {},
+		});
+		const clientEmail = secretAccountKey.client_email?.trim();
+		const privateKey = secretAccountKey.private_key?.trim();
+		const projectId = secretAccountKey.project_id?.trim();
+
+		if (!clientEmail || !privateKey) {
+			throw new UserError(
+				'Service account key must contain "client_email" and "private_key" fields. Use the downloaded service account JSON key file from Google Cloud Console.',
+			);
+		}
 
 		return {
-			projectId: parsed?.project_id ?? '',
-			clientEmail: parsed?.client_email ?? '',
-			privateKey: parsed?.private_key ?? '',
+			projectId: projectId ?? '',
+			clientEmail,
+			privateKey,
 		};
 	}
 }


### PR DESCRIPTION
## Summary

This PR adds early validation for the GCP service account key when initializing the GCP Secrets Manager provider.

Previously, if the stored service account key was invalid, empty, or malformed, we fell back to `{}` on JSON parse failure. This led to runtime uncaught errors from GCP due to missing `client_email` and `private_key`, which was blocking n8n instance startup.

With this change, the key is validated during initialization and a clear `UserError` is thrown if invalid, allowing other service providers to initialize normally.

## What’s Changed

- Validate that the service account key:
  - Is not empty or whitespace
  - Is valid JSON
  - Contains required fields: `client_email` and `private_key`
- Provide a clear error message referencing the Google Cloud Console service account JSON key file
- Prevent invalid stored GCP keys from blocking instance startup

## Why Only GCP?

GCP is currently the only provider requiring a JSON service account key at initialization. Other providers rely on tokens and do not require JSON parsing during startup.

## Tests

- Added 5 new test cases covering validation scenarios
- Updated existing tests to use a valid service account key helper

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-201

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`release/backport\` (if the PR is an urgent fix that needs to be backported)