### PR TITLE
chore: Bump task-runner-launcher to 1.4.3

### DIFF
--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -82,7 +82,7 @@ RUN uv pip install . && rm -rf /app/task-runner-python/src
 # ==============================================================================
 FROM alpine:3.22 AS launcher-downloader
 ARG TARGETPLATFORM
-ARG LAUNCHER_VERSION=1.4.2
+ARG LAUNCHER_VERSION=1.4.3
 
 RUN set -e; \
     case "$TARGETPLATFORM" in \

--- a/docker/images/runners/Dockerfile.distroless
+++ b/docker/images/runners/Dockerfile.distroless
@@ -99,7 +99,7 @@ RUN uv pip install . && rm -rf /app/task-runner-python/src
 # ==============================================================================
 FROM debian:bookworm-slim AS launcher-downloader
 ARG TARGETPLATFORM
-ARG LAUNCHER_VERSION=1.4.2
+ARG LAUNCHER_VERSION=1.4.3
 
 RUN set -e; \
     apt-get update && apt-get install -y --no-install-recommends wget ca-certificates && \


### PR DESCRIPTION
## Summary
- Bumps task-runner-launcher from 1.4.2 to 1.4.3 in both Alpine and distroless Dockerfiles
- Release contains a Go version update to 1.25.7 (no functional changes)
- https://github.com/n8n-io/task-runner-launcher/releases/tag/1.4.3

## Test plan
- [x] Docker build succeeds for both Alpine and distroless variants
- [x] SHA256 checksum validation passes during build

🤖 Generated with [Claude Code](https://claude.com/claude-code)