### PR TITLE
feat(core): Add telemetry tracking for external secrets connections (no-changelog)

### DIFF
--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -511,7 +511,7 @@ describe('TelemetryEventRelay', () => {
 				provider_key: 'provider-key-123',
 				vault_type: 'gcp',
 				scope: 'global',
-				project_count: 0,
+				project_ids: [],
 			});
 		});
 
@@ -533,7 +533,7 @@ describe('TelemetryEventRelay', () => {
 				provider_key: 'provider-key-123',
 				vault_type: 'gcp',
 				scope: 'project',
-				project_count: 2,
+				project_ids: ['project1', 'project2'],
 			});
 		});
 
@@ -552,7 +552,7 @@ describe('TelemetryEventRelay', () => {
 				provider_key: 'provider-key-123',
 				vault_type: 'aws',
 				scope: 'global',
-				project_count: 0,
+				project_ids: [],
 			});
 		});
 
@@ -571,7 +571,7 @@ describe('TelemetryEventRelay', () => {
 				provider_key: 'provider-key-123',
 				vault_type: 'aws',
 				scope: 'project',
-				project_count: 1,
+				project_ids: ['project1'],
 			});
 		});
 
@@ -590,7 +590,7 @@ describe('TelemetryEventRelay', () => {
 				provider_key: 'provider-key-123',
 				vault_type: 'vault',
 				scope: 'global',
-				project_count: 0,
+				project_ids: [],
 			});
 		});
 
@@ -613,7 +613,7 @@ describe('TelemetryEventRelay', () => {
 				provider_key: 'provider-key-123',
 				vault_type: 'vault',
 				scope: 'project',
-				project_count: 3,
+				project_ids: ['project1', 'project2', 'project3'],
 			});
 		});
 	});

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -508,7 +508,6 @@ describe('TelemetryEventRelay', () => {
 
 			expect(telemetry.track).toHaveBeenCalledWith('User created external secrets connection', {
 				user_id: 'user123',
-				provider_key: 'provider-key-123',
 				vault_type: 'gcp',
 				scope: 'global',
 				project_ids: [],
@@ -530,7 +529,6 @@ describe('TelemetryEventRelay', () => {
 
 			expect(telemetry.track).toHaveBeenCalledWith('User created external secrets connection', {
 				user_id: 'user123',
-				provider_key: 'provider-key-123',
 				vault_type: 'gcp',
 				scope: 'project',
 				project_ids: ['project1', 'project2'],
@@ -549,7 +547,6 @@ describe('TelemetryEventRelay', () => {
 
 			expect(telemetry.track).toHaveBeenCalledWith('User updated external secrets connection', {
 				user_id: 'user123',
-				provider_key: 'provider-key-123',
 				vault_type: 'aws',
 				scope: 'global',
 				project_ids: [],
@@ -568,7 +565,6 @@ describe('TelemetryEventRelay', () => {
 
 			expect(telemetry.track).toHaveBeenCalledWith('User updated external secrets connection', {
 				user_id: 'user123',
-				provider_key: 'provider-key-123',
 				vault_type: 'aws',
 				scope: 'project',
 				project_ids: ['project1'],
@@ -587,7 +583,6 @@ describe('TelemetryEventRelay', () => {
 
 			expect(telemetry.track).toHaveBeenCalledWith('User deleted external secrets connection', {
 				user_id: 'user123',
-				provider_key: 'provider-key-123',
 				vault_type: 'vault',
 				scope: 'global',
 				project_ids: [],
@@ -610,7 +605,6 @@ describe('TelemetryEventRelay', () => {
 
 			expect(telemetry.track).toHaveBeenCalledWith('User deleted external secrets connection', {
 				user_id: 'user123',
-				provider_key: 'provider-key-123',
 				vault_type: 'vault',
 				scope: 'project',
 				project_ids: ['project1', 'project2', 'project3'],

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -495,6 +495,127 @@ describe('TelemetryEventRelay', () => {
 				vault_type: 'aws',
 			});
 		});
+
+		it('should track on `external-secrets-connection-created` event with global scope', () => {
+			const event: RelayEventMap['external-secrets-connection-created'] = {
+				userId: 'user123',
+				providerKey: 'provider-key-123',
+				vaultType: 'gcp',
+				projects: [],
+			};
+
+			eventService.emit('external-secrets-connection-created', event);
+
+			expect(telemetry.track).toHaveBeenCalledWith('User created external secrets connection', {
+				user_id: 'user123',
+				provider_key: 'provider-key-123',
+				vault_type: 'gcp',
+				scope: 'global',
+				project_count: 0,
+			});
+		});
+
+		it('should track on `external-secrets-connection-created` event with project scope', () => {
+			const event: RelayEventMap['external-secrets-connection-created'] = {
+				userId: 'user123',
+				providerKey: 'provider-key-123',
+				vaultType: 'gcp',
+				projects: [
+					{ id: 'project1', name: 'Project 1' },
+					{ id: 'project2', name: 'Project 2' },
+				],
+			};
+
+			eventService.emit('external-secrets-connection-created', event);
+
+			expect(telemetry.track).toHaveBeenCalledWith('User created external secrets connection', {
+				user_id: 'user123',
+				provider_key: 'provider-key-123',
+				vault_type: 'gcp',
+				scope: 'project',
+				project_count: 2,
+			});
+		});
+
+		it('should track on `external-secrets-connection-updated` event with global scope', () => {
+			const event: RelayEventMap['external-secrets-connection-updated'] = {
+				userId: 'user123',
+				providerKey: 'provider-key-123',
+				vaultType: 'aws',
+				projects: [],
+			};
+
+			eventService.emit('external-secrets-connection-updated', event);
+
+			expect(telemetry.track).toHaveBeenCalledWith('User updated external secrets connection', {
+				user_id: 'user123',
+				provider_key: 'provider-key-123',
+				vault_type: 'aws',
+				scope: 'global',
+				project_count: 0,
+			});
+		});
+
+		it('should track on `external-secrets-connection-updated` event with project scope', () => {
+			const event: RelayEventMap['external-secrets-connection-updated'] = {
+				userId: 'user123',
+				providerKey: 'provider-key-123',
+				vaultType: 'aws',
+				projects: [{ id: 'project1', name: 'Project 1' }],
+			};
+
+			eventService.emit('external-secrets-connection-updated', event);
+
+			expect(telemetry.track).toHaveBeenCalledWith('User updated external secrets connection', {
+				user_id: 'user123',
+				provider_key: 'provider-key-123',
+				vault_type: 'aws',
+				scope: 'project',
+				project_count: 1,
+			});
+		});
+
+		it('should track on `external-secrets-connection-deleted` event with global scope', () => {
+			const event: RelayEventMap['external-secrets-connection-deleted'] = {
+				userId: 'user123',
+				providerKey: 'provider-key-123',
+				vaultType: 'vault',
+				projects: [],
+			};
+
+			eventService.emit('external-secrets-connection-deleted', event);
+
+			expect(telemetry.track).toHaveBeenCalledWith('User deleted external secrets connection', {
+				user_id: 'user123',
+				provider_key: 'provider-key-123',
+				vault_type: 'vault',
+				scope: 'global',
+				project_count: 0,
+			});
+		});
+
+		it('should track on `external-secrets-connection-deleted` event with project scope', () => {
+			const event: RelayEventMap['external-secrets-connection-deleted'] = {
+				userId: 'user123',
+				providerKey: 'provider-key-123',
+				vaultType: 'vault',
+				projects: [
+					{ id: 'project1', name: 'Project 1' },
+					{ id: 'project2', name: 'Project 2' },
+					{ id: 'project3', name: 'Project 3' },
+				],
+			};
+
+			eventService.emit('external-secrets-connection-deleted', event);
+
+			expect(telemetry.track).toHaveBeenCalledWith('User deleted external secrets connection', {
+				user_id: 'user123',
+				provider_key: 'provider-key-123',
+				vault_type: 'vault',
+				scope: 'project',
+				project_count: 3,
+			});
+		});
 	});
 
 	describe('public API events', () => {

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -358,13 +358,11 @@ export class TelemetryEventRelay extends EventRelay {
 
 	private externalSecretsConnectionCreated({
 		userId,
-		providerKey,
 		vaultType,
 		projects,
 	}: RelayEventMap['external-secrets-connection-created']) {
 		this.telemetry.track('User created external secrets connection', {
 			user_id: userId,
-			provider_key: providerKey,
 			vault_type: vaultType,
 			scope: projects.length === 0 ? 'global' : 'project',
 			project_ids: projects.map((project) => project.id),
@@ -373,13 +371,11 @@ export class TelemetryEventRelay extends EventRelay {
 
 	private externalSecretsConnectionUpdated({
 		userId,
-		providerKey,
 		vaultType,
 		projects,
 	}: RelayEventMap['external-secrets-connection-updated']) {
 		this.telemetry.track('User updated external secrets connection', {
 			user_id: userId,
-			provider_key: providerKey,
 			vault_type: vaultType,
 			scope: projects.length === 0 ? 'global' : 'project',
 			project_ids: projects.map((project) => project.id),
@@ -388,13 +384,11 @@ export class TelemetryEventRelay extends EventRelay {
 
 	private externalSecretsConnectionDeleted({
 		userId,
-		providerKey,
 		vaultType,
 		projects,
 	}: RelayEventMap['external-secrets-connection-deleted']) {
 		this.telemetry.track('User deleted external secrets connection', {
 			user_id: userId,
-			provider_key: providerKey,
 			vault_type: vaultType,
 			scope: projects.length === 0 ? 'global' : 'project',
 			project_ids: projects.map((project) => project.id),

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -164,7 +164,6 @@ export class TelemetryEventRelay extends EventRelay {
 		this.telemetry.track('Project settings updated', {
 			user_id: userId,
 			role,
-
 			members: members.map(({ userId: user_id, role }) => ({ user_id, role })),
 			project_id: projectId,
 		});
@@ -368,7 +367,7 @@ export class TelemetryEventRelay extends EventRelay {
 			provider_key: providerKey,
 			vault_type: vaultType,
 			scope: projects.length === 0 ? 'global' : 'project',
-			project_count: projects.length,
+			project_ids: projects.map((project) => project.id),
 		});
 	}
 
@@ -383,7 +382,7 @@ export class TelemetryEventRelay extends EventRelay {
 			provider_key: providerKey,
 			vault_type: vaultType,
 			scope: projects.length === 0 ? 'global' : 'project',
-			project_count: projects.length,
+			project_ids: projects.map((project) => project.id),
 		});
 	}
 
@@ -398,7 +397,7 @@ export class TelemetryEventRelay extends EventRelay {
 			provider_key: providerKey,
 			vault_type: vaultType,
 			scope: projects.length === 0 ? 'global' : 'project',
-			project_count: projects.length,
+			project_ids: projects.map((project) => project.id),
 		});
 	}
 

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -89,6 +89,12 @@ export class TelemetryEventRelay extends EventRelay {
 			'external-secrets-provider-settings-saved': (event) =>
 				this.externalSecretsProviderSettingsSaved(event),
 			'external-secrets-provider-reloaded': (event) => this.externalSecretsProviderReloaded(event),
+			'external-secrets-connection-created': (event) =>
+				this.externalSecretsConnectionCreated(event),
+			'external-secrets-connection-updated': (event) =>
+				this.externalSecretsConnectionUpdated(event),
+			'external-secrets-connection-deleted': (event) =>
+				this.externalSecretsConnectionDeleted(event),
 			'public-api-invoked': (event) => this.publicApiInvoked(event),
 			'public-api-key-created': (event) => this.publicApiKeyCreated(event),
 			'public-api-key-deleted': (event) => this.publicApiKeyDeleted(event),
@@ -348,6 +354,51 @@ export class TelemetryEventRelay extends EventRelay {
 	}: RelayEventMap['external-secrets-provider-reloaded']) {
 		this.telemetry.track('User reloaded external secrets', {
 			vault_type: vaultType,
+		});
+	}
+
+	private externalSecretsConnectionCreated({
+		userId,
+		providerKey,
+		vaultType,
+		projects,
+	}: RelayEventMap['external-secrets-connection-created']) {
+		this.telemetry.track('User created external secrets connection', {
+			user_id: userId,
+			provider_key: providerKey,
+			vault_type: vaultType,
+			scope: projects.length === 0 ? 'global' : 'project',
+			project_count: projects.length,
+		});
+	}
+
+	private externalSecretsConnectionUpdated({
+		userId,
+		providerKey,
+		vaultType,
+		projects,
+	}: RelayEventMap['external-secrets-connection-updated']) {
+		this.telemetry.track('User updated external secrets connection', {
+			user_id: userId,
+			provider_key: providerKey,
+			vault_type: vaultType,
+			scope: projects.length === 0 ? 'global' : 'project',
+			project_count: projects.length,
+		});
+	}
+
+	private externalSecretsConnectionDeleted({
+		userId,
+		providerKey,
+		vaultType,
+		projects,
+	}: RelayEventMap['external-secrets-connection-deleted']) {
+		this.telemetry.track('User deleted external secrets connection', {
+			user_id: userId,
+			provider_key: providerKey,
+			vault_type: vaultType,
+			scope: projects.length === 0 ? 'global' : 'project',
+			project_count: projects.length,
 		});
 	}
 


### PR DESCRIPTION
## Summary

This PR adds telemetry tracking for external secrets connection lifecycle events (create, update, delete). Each event tracks the scope (global or project-level) to help understand how external secrets are being used across the platform.

**What this adds:**
- Telemetry tracking for `external-secrets-connection-created` events
- Telemetry tracking for `external-secrets-connection-updated` events (sharing/unsharing)
- Telemetry tracking for `external-secrets-connection-deleted` events
- Scope detection: `global` (no projects) vs `project` (associated with projects)
- Project IDs tracking to understand sharing patterns

**Properties tracked:**
- `user_id` - Who performed the action
- `vault_type` - Type of secrets provider (gcp, aws, vault, etc.)
- `scope` - `global` or `project` 
- `project_ids` - Number of projects the connection is shared with

**Tests:**
- 6 new test cases covering all three events with both global and project scopes
- All tests passing (79/79)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-203

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`release/backport\` (if the PR is an urgent fix that needs to be backported)