### PR TITLE
fix(core): Escape curly braces in LangChain prompt templates to prevent parsing errors

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/processItem.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/processItem.ts
@@ -26,8 +26,13 @@ export async function processItem(
 		systemPromptTemplate?: string;
 	};
 
+	const escapedTemplate = (options.systemPromptTemplate ?? SYSTEM_PROMPT_TEMPLATE).replace(
+		/[{}]/g,
+		(match) => match + match,
+	);
+
 	const systemPromptTemplate = SystemMessagePromptTemplate.fromTemplate(
-		`${options.systemPromptTemplate ?? SYSTEM_PROMPT_TEMPLATE}
+		`${escapedTemplate}
 {format_instructions}`,
 	);
 

--- a/packages/@n8n/nodes-langchain/nodes/chains/SentimentAnalysis/SentimentAnalysis.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/SentimentAnalysis/SentimentAnalysis.node.ts
@@ -217,8 +217,12 @@ export class SentimentAnalysis implements INodeType {
 						? OutputFixingParser.fromLLM(llm, structuredParser)
 						: structuredParser;
 
+					const escapedTemplate = (options.systemPromptTemplate ?? DEFAULT_SYSTEM_PROMPT_TEMPLATE)
+						.replace(/[{}]/g, (match) => match + match)
+						.replaceAll('{{categories}}', '{categories}');
+
 					const systemPromptTemplate = SystemMessagePromptTemplate.fromTemplate(
-						`${options.systemPromptTemplate ?? DEFAULT_SYSTEM_PROMPT_TEMPLATE}
+						`${escapedTemplate}
 				{format_instructions}`,
 					);
 
@@ -357,8 +361,12 @@ export class SentimentAnalysis implements INodeType {
 						? OutputFixingParser.fromLLM(llm, structuredParser)
 						: structuredParser;
 
+					const escapedTemplate = (options.systemPromptTemplate ?? DEFAULT_SYSTEM_PROMPT_TEMPLATE)
+						.replace(/[{}]/g, (match) => match + match)
+						.replaceAll('{{categories}}', '{categories}');
+
 					const systemPromptTemplate = SystemMessagePromptTemplate.fromTemplate(
-						`${options.systemPromptTemplate ?? DEFAULT_SYSTEM_PROMPT_TEMPLATE}
+						`${escapedTemplate}
 			{format_instructions}`,
 					);
 

--- a/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/processItem.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/processItem.ts
@@ -36,8 +36,12 @@ export async function processItem(
 		itemIndex,
 		SYSTEM_PROMPT_TEMPLATE,
 	) as string;
+	const escapedTemplate = (systemPromptTemplateOpt ?? SYSTEM_PROMPT_TEMPLATE)
+		.replace(/[{}]/g, (match) => match + match)
+		.replaceAll('{{categories}}', '{categories}');
+
 	const systemPromptTemplate = SystemMessagePromptTemplate.fromTemplate(
-		`${systemPromptTemplateOpt ?? SYSTEM_PROMPT_TEMPLATE}
+		`${escapedTemplate}
 	{format_instructions}
 	${multiClassPrompt}
 	${fallbackPrompt}`,


### PR DESCRIPTION
## Summary

Escape literal curly braces in user-provided system prompt templates before passing them to LangChain's `SystemMessagePromptTemplate.fromTemplate()`. Without this, any `{` or `}` in the prompt (e.g. JSON examples) is interpreted as a template variable delimiter, causing a crash.

Applies the same escaping pattern already used by ChainLLM (`promptUtils.ts`) to:
- **Information Extractor** node
- **Text Classifier** node
- **Sentiment Analysis** node (both batch and sequential code paths)

Code-controlled template variables (`{format_instructions}`, `{categories}`) are appended after escaping, so they remain functional.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-2018/community-issue-information-extractor-node-failing-if-query-or-system
- Fixes #25566