### PR TITLE
fix(core): Gracefully handle OpenAI 429 quota errors in AI workflow builder

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/test/workflow-builder-agent.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/test/workflow-builder-agent.test.ts
@@ -5,7 +5,7 @@ import { GraphRecursionError } from '@langchain/langgraph';
 import type { Logger } from '@n8n/backend-common';
 import { mock } from 'jest-mock-extended';
 import type { INodeTypeDescription } from 'n8n-workflow';
-import { ApplicationError } from 'n8n-workflow';
+import { ApplicationError, OperationalError } from 'n8n-workflow';
 
 jest.mock('@/tools/add-node.tool', () => ({
 	createAddNodeTool: jest.fn().mockReturnValue({ tool: { name: 'add_node' } }),
@@ -281,6 +281,49 @@ describe('WorkflowBuilderAgent', () => {
 				const generator = agent.chat(mockPayload);
 				await generator.next();
 			}).rejects.toThrow(unknownError);
+		});
+
+		it('should wrap 429 quota errors in OperationalError', async () => {
+			const quotaError = Object.assign(
+				new Error('You exceeded your current quota, please check your plan and billing details.'),
+				{ status: 429 },
+			);
+
+			mockCreateStreamProcessor.mockImplementation(() => {
+				// eslint-disable-next-line require-yield
+				return (async function* () {
+					throw quotaError;
+				})();
+			});
+
+			await expect(async () => {
+				const generator = agent.chat(mockPayload);
+				await generator.next();
+			}).rejects.toThrow(OperationalError);
+		});
+
+		it('should set level to warning on OperationalError from 429 quota error', async () => {
+			const quotaError = Object.assign(new Error('You exceeded your current quota'), {
+				status: 429,
+			});
+
+			mockCreateStreamProcessor.mockImplementation(() => {
+				// eslint-disable-next-line require-yield
+				return (async function* () {
+					throw quotaError;
+				})();
+			});
+
+			let thrownError: unknown;
+			try {
+				const generator = agent.chat(mockPayload);
+				await generator.next();
+				fail('Expected an error to be thrown');
+			} catch (error) {
+				thrownError = error;
+			}
+			expect(thrownError).toBeInstanceOf(OperationalError);
+			expect((thrownError as OperationalError).level).toBe('warning');
 		});
 	});
 

--- a/packages/@n8n/ai-workflow-builder.ee/src/utils/error-sanitizer.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/utils/error-sanitizer.ts
@@ -7,11 +7,7 @@ export function sanitizeLlmErrorMessage(error: unknown): string {
 	const statusCode = extractStatusCode(error);
 	const rawMessage = error instanceof Error ? error.message : String(error);
 
-	if (containsHtml(rawMessage)) {
-		return buildUserFriendlyMessage(statusCode);
-	}
-
-	if (rawMessage.length > 500) {
+	if (statusCode === 429 || containsHtml(rawMessage) || rawMessage.length > 500) {
 		return buildUserFriendlyMessage(statusCode);
 	}
 

--- a/packages/@n8n/ai-workflow-builder.ee/src/utils/test/error-sanitizer.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/utils/test/error-sanitizer.test.ts
@@ -54,6 +54,19 @@ describe('sanitizeLlmErrorMessage', () => {
 			expect(result).toContain('Rate limit');
 		});
 
+		it('should return user-friendly message for 429 with short non-HTML message', () => {
+			const error = Object.assign(
+				new Error('You exceeded your current quota, please check your plan and billing details.'),
+				{ status: 429 },
+			);
+
+			const result = sanitizeLlmErrorMessage(error);
+
+			expect(result).toContain('Rate limit');
+			expect(result).not.toContain('quota');
+			expect(result).not.toContain('billing');
+		});
+
 		it('should return service unavailable message for 502', () => {
 			const error = Object.assign(new Error('<html>Bad Gateway</html>'), { status: 502 });
 

--- a/packages/@n8n/ai-workflow-builder.ee/src/workflow-builder-agent.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/workflow-builder-agent.ts
@@ -10,6 +10,7 @@ import type { SelectedNodeContext } from '@n8n/api-types';
 import type { Logger } from '@n8n/backend-common';
 import {
 	ApplicationError,
+	OperationalError,
 	type INodeTypeDescription,
 	type IRunExecutionData,
 	type ITelemetryTrackProperties,
@@ -27,6 +28,7 @@ import { SessionManagerService } from './session-manager.service';
 import type { ResourceLocatorCallback } from './types/callbacks';
 import type { HITLInterruptValue, PlanOutput } from './types/planning';
 import type { SimpleWorkflow } from './types/workflow';
+import { sanitizeLlmErrorMessage } from './utils/error-sanitizer';
 import { createStreamProcessor, type StreamEvent } from './utils/stream-processor';
 import type { WorkflowState } from './workflow-state';
 
@@ -423,6 +425,12 @@ export class WorkflowBuilderAgent {
 			throw new ValidationError(invalidRequestErrorMessage);
 		}
 
+		if (this.isLlmQuotaOrRateLimitError(error)) {
+			throw new OperationalError(sanitizeLlmErrorMessage(error), {
+				cause: error instanceof Error ? error : undefined,
+			});
+		}
+
 		throw error;
 	}
 
@@ -503,6 +511,15 @@ export class WorkflowBuilderAgent {
 			'status' in error &&
 			error.status === 401
 		);
+	}
+
+	/**
+	 * Checks if the error is a 429 rate-limit / quota-exceeded error from the LLM provider.
+	 * These are transient provider-side issues that users cannot act on, so we wrap them
+	 * in OperationalError (level: warning) to prevent them from reaching Sentry.
+	 */
+	private isLlmQuotaOrRateLimitError(error: unknown): boolean {
+		return !!error && typeof error === 'object' && 'status' in error && error.status === 429;
 	}
 
 	private getInvalidRequestError(error: unknown): string | undefined {


### PR DESCRIPTION
## Summary
- Wrap OpenAI 429 (quota exceeded / rate limit) errors in `OperationalError` so they are suppressed by Sentry's `beforeSend` filter, reducing noise from transient provider-side issues
- Always sanitize 429 error messages to show a user-friendly "Rate limit exceeded" message instead of raw OpenAI billing text that confuses users who don't manage their own API keys

## Review pointers

The fix follows the same pattern already used for user-workflow nodes in `openAiFailedAttemptHandler` (`nodes-langchain`). `OperationalError` defaults to `level: 'warning'` → `shouldReport: false` → Sentry drops it.

Related: https://linear.app/n8n/issue/AI-2035
