### PR TITLE
chore: Bigger alert for sharing deactivation

### DIFF
--- a/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.vue
+++ b/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.vue
@@ -355,6 +355,7 @@ const sharingCountText = computed(() => {
 			:description="
 				i18n.baseText('settings.security.personalSpace.sharing.confirmMessage.disable.message')
 			"
+			size="medium"
 			@action="confirmDisableSharing"
 			@cancel="showSharingDialog = false"
 			@update:open="showSharingDialog = $event"


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR increases the alert for the personal space sharing deactivation

## Related Linear tickets, Github issues, and Community forum posts

IAM-248

<img width="1853" height="933" alt="image" src="https://github.com/user-attachments/assets/b12cf5e3-871f-4923-a6db-3dad6876ed63" />

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
