### PR TITLE
chore: Make playwright-janitor private

### DIFF
--- a/packages/testing/janitor/package.json
+++ b/packages/testing/janitor/package.json
@@ -1,5 +1,6 @@
 {
-	"name": "@n8n/playwright-janitor",
+  "name": "@n8n/playwright-janitor",
+  "private": true,
 	"version": "0.1.0",
 	"description": "Static analysis and architecture enforcement for Playwright test suites",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary

We don't want to push this into npm as this is just internal. Mark private so pnpm won't pick it up.

## Related Linear tickets, Github issues, and Community forum posts



## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
