### PR TITLE
Fixes/24772

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
@@ -1,4 +1,5 @@
 import type { BaseChatMemory } from '@langchain/community/memory/chat_memory';
+import { AIMessage, ToolMessage } from '@langchain/core/messages';
 import pick from 'lodash/pick';
 import {
 	Node,
@@ -820,7 +821,14 @@ export class ChatTrigger extends Node {
 					| BaseChatMemory
 					| undefined;
 				const messages = ((await memory?.chatHistory.getMessages()) ?? [])
-					.filter((message) => !message?.additional_kwargs?.hideFromUI)
+					.filter((message) => {
+						if (message?.additional_kwargs?.hideFromUI) return false;
+						// Exclude tool call messages from chat history to prevent
+						// raw tool JSON from appearing in the UI on session reload
+						if (message instanceof ToolMessage) return false;
+						if (message instanceof AIMessage && message.tool_calls?.length) return false;
+						return true;
+					})
 					.map((message) => message?.toJSON());
 				return {
 					webhookResponse: { data: messages },

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/memoryManagement.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/memoryManagement.ts
@@ -285,7 +285,12 @@ export async function saveToMemory(
 	messages.push(new HumanMessage(input));
 
 	// 2. Tool call sequence (AIMessage with tool_calls → ToolMessage for each)
+	// Mark tool messages as hidden from UI so they don't appear in chat history
+	// when loading previous sessions
 	const toolMessages = buildMessagesFromSteps(newSteps);
+	for (const msg of toolMessages) {
+		msg.additional_kwargs.hideFromUI = true;
+	}
 	messages.push.apply(messages, toolMessages);
 
 	// 3. Final AI response (no tool_calls)

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/memoryManagement.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/memoryManagement.test.ts
@@ -414,6 +414,42 @@ describe('memoryManagement', () => {
 			expect(savedMessages[3].content).toBe('The answer is 4');
 		});
 
+		it('should mark tool messages with hideFromUI flag', async () => {
+			const aiMessage = new AIMessage({
+				content: 'Let me check',
+				tool_calls: [
+					{ id: 'call-abc', name: 'weather', args: { city: 'NYC' }, type: 'tool_call' },
+				],
+			});
+
+			const steps: ToolCallData[] = [
+				{
+					action: {
+						tool: 'weather',
+						toolInput: { city: 'NYC' },
+						log: 'Weather',
+						messageLog: [aiMessage],
+						toolCallId: 'call-abc',
+						type: 'tool_call',
+					},
+					observation: 'Sunny, 72°F',
+				},
+			];
+
+			await saveToMemory('What is the weather?', 'It is sunny and 72°F.', mockMemory, steps);
+
+			const savedMessages = mockChatHistory.addMessages.mock.calls[0][0];
+
+			// HumanMessage (index 0) and final AIMessage (index 3) should NOT have hideFromUI
+			expect(savedMessages[0].additional_kwargs.hideFromUI).toBeUndefined();
+			expect(savedMessages[3].additional_kwargs.hideFromUI).toBeUndefined();
+
+			// Tool-related messages (AIMessage with tool_calls at index 1, ToolMessage at index 2)
+			// should have hideFromUI set to true
+			expect(savedMessages[1].additional_kwargs.hideFromUI).toBe(true);
+			expect(savedMessages[2].additional_kwargs.hideFromUI).toBe(true);
+		});
+
 		it('should fall back to string format when addMessages is not available', async () => {
 			// Create a chat history object without addMessages method
 			mockMemory.chatHistory = {} as any;

--- a/packages/frontend/@n8n/chat/src/__tests__/plugins/chat.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/plugins/chat.spec.ts
@@ -360,6 +360,65 @@ describe('ChatPlugin', () => {
 			expect(window.localStorage.setItem).not.toHaveBeenCalled();
 		});
 
+		it('should filter out tool call messages from previous session', async () => {
+			const mockSessionId = 'tool-session';
+			const mockMessages: LoadPreviousSessionResponse = {
+				data: [
+					{
+						id: ['langchain_core', 'messages', 'HumanMessage'],
+						kwargs: { content: 'What is the weather?', additional_kwargs: {} },
+						lc: 1,
+						type: 'constructor',
+					},
+					{
+						id: ['langchain_core', 'messages', 'AIMessage'],
+						kwargs: {
+							content: '',
+							additional_kwargs: {
+								tool_calls: [
+									{ id: 'call-123', name: 'weather', args: { city: 'NYC' } },
+								],
+							},
+						},
+						lc: 1,
+						type: 'constructor',
+					},
+					{
+						id: ['langchain_core', 'messages', 'ToolMessage'],
+						kwargs: { content: '{"temp": 72}', additional_kwargs: {} },
+						lc: 1,
+						type: 'constructor',
+					},
+					{
+						id: ['langchain_core', 'messages', 'AIMessage'],
+						kwargs: {
+							content: 'The weather in NYC is 72 degrees.',
+							additional_kwargs: {},
+						},
+						lc: 1,
+						type: 'constructor',
+					},
+				],
+			};
+
+			(window.localStorage.getItem as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+				mockSessionId,
+			);
+			vi.mocked(api.loadPreviousSession).mockResolvedValueOnce(mockMessages);
+
+			await chatStore.loadPreviousSession?.();
+
+			// Should only contain the user message and final AI response
+			expect(chatStore.messages.value).toHaveLength(2);
+			expect(chatStore.messages.value[0]).toMatchObject({
+				text: 'What is the weather?',
+			});
+			expect(chatStore.messages.value[1]).toMatchObject({
+				text: 'The weather in NYC is 72 degrees.',
+				sender: 'bot',
+			});
+		});
+
 		it('should skip loading if loadPreviousSession is false', async () => {
 			mockOptions.loadPreviousSession = false;
 			chatStore = setupChatStore(mockOptions);

--- a/packages/frontend/@n8n/chat/src/plugins/chat.ts
+++ b/packages/frontend/@n8n/chat/src/plugins/chat.ts
@@ -270,11 +270,24 @@ export const ChatPlugin: Plugin<ChatOptions> = {
 
 			const previousMessagesResponse = await api.loadPreviousSession(sessionId, options);
 
-			messages.value = (previousMessagesResponse?.data || []).map((message, index) => ({
-				id: `${index}`,
-				text: message.kwargs.content,
-				sender: message.id.includes('HumanMessage') ? 'user' : 'bot',
-			}));
+			messages.value = (previousMessagesResponse?.data || [])
+				.filter((msg) => {
+					// Exclude tool-related messages from the chat UI
+					if (msg.id.includes('ToolMessage')) return false;
+					if (
+						msg.id.includes('AIMessage') &&
+						Array.isArray(msg.kwargs?.additional_kwargs?.tool_calls) &&
+						msg.kwargs.additional_kwargs.tool_calls.length > 0
+					) {
+						return false;
+					}
+					return true;
+				})
+				.map((message, index) => ({
+					id: `${index}`,
+					text: message.kwargs.content,
+					sender: message.id.includes('HumanMessage') ? 'user' : 'bot',
+				}));
 
 			// Always set currentSessionId to preserve manually set sessionIds
 			currentSessionId.value = sessionId;


### PR DESCRIPTION
## Summary

When using Web Chat with an AI Agent that performs tool calls, the tool call payloads and tool result messages are incorrectly included in the chat history returned by "Load Previous Session". During live chat the user only sees the final AI response (correct), but after refreshing the page the raw tool call JSON appears as regular chat messages, cluttering the conversation.

The root cause is three-fold:

saveToMemory() in memoryManagement.ts saves tool-related messages (AIMessage with tool_calls and ToolMessage) to chat history without marking them as internal, so they are indistinguishable from user-facing messages on reload.

The loadPreviousSession handler in ChatTrigger.node.ts only filters messages with the hideFromUI flag but does not filter by message type, so tool messages pass through to the frontend.

The frontend chat plugin in chat.ts renders every non-HumanMessage as a bot message with no type-based filtering.

Fix (defense-in-depth across 3 layers):

Source (memoryManagement.ts): Mark all tool-related messages with additional_kwargs.hideFromUI = true when saving to memory, so they are tagged at write time.
Backend (ChatTrigger.node.ts): Filter out ToolMessage instances and AIMessage instances with tool_calls in the loadPreviousSession handler. This catches both newly tagged messages and pre-existing untagged messages already stored in databases.
Frontend (chat.ts): Filter the serialized message array by checking the id field for ToolMessage and AIMessage entries with tool_calls in additional_kwargs, as a safeguard regardless of backend version.
How to test:

Create a Web Chat connected to an AI Agent with tools (e.g. calculator, HTTP request)
Connect persistent memory (Postgres, Redis, or Buffer Window)
Enable "Load Previous Session" on the Chat Trigger
Send a message that triggers a tool call
Verify the agent responds normally (tool output hidden)
Refresh the page
Verify the reloaded chat history shows only user messages and final AI responses, with no raw tool call JSON

## Related Linear tickets, Github issues, and Community forum posts

Fixes https://github.com/n8n-io/n8n/issues/24772#issue-3847259003


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
