### PR TITLE
fix(core): Forward activationMode in multi-main webhook/trigger setup

### DIFF
--- a/.github/workflows/test-e2e-reusable.yml
+++ b/.github/workflows/test-e2e-reusable.yml
@@ -138,7 +138,7 @@ jobs:
           # docker-build: build app + docker image locally
           # docker-pull: no build needed, image is pre-built
           # local: build app for local server
-          build-command: ${{ inputs.test-mode == 'docker-build' && 'pnpm build:docker' || (inputs.test-mode == 'local' && 'pnpm build' || '') }}
+          build-command: ${{ inputs.test-mode == 'docker-build' && 'pnpm build:docker' || (inputs.test-mode == 'local' && 'pnpm build' || 'pnpm build --filter n8n-playwright') }}
           enable-docker-cache: ${{ inputs.test-mode == 'docker-build' }}
         env:
           INCLUDE_TEST_CONTROLLER: ${{ inputs.test-mode == 'docker-build' && 'true' || '' }}

--- a/.github/workflows/test-e2e-reusable.yml
+++ b/.github/workflows/test-e2e-reusable.yml
@@ -138,7 +138,7 @@ jobs:
           # docker-build: build app + docker image locally
           # docker-pull: no build needed, image is pre-built
           # local: build app for local server
-          build-command: ${{ inputs.test-mode == 'docker-build' && 'pnpm build:docker' || (inputs.test-mode == 'local' && 'pnpm build' || 'pnpm build --filter n8n-playwright') }}
+          build-command: ${{ inputs.test-mode == 'docker-build' && 'pnpm build:docker' || 'pnpm build' }}
           enable-docker-cache: ${{ inputs.test-mode == 'docker-build' }}
         env:
           INCLUDE_TEST_CONTROLLER: ${{ inputs.test-mode == 'docker-build' && 'true' || '' }}

--- a/packages/cli/src/active-workflow-manager.ts
+++ b/packages/cli/src/active-workflow-manager.ts
@@ -610,7 +610,7 @@ export class ActiveWorkflowManager {
 
 			void this.publisher.publishCommand({
 				command: 'add-webhooks-triggers-and-pollers',
-				payload: { workflowId, activeVersionId: dbWorkflow.activeVersionId },
+				payload: { workflowId, activeVersionId: dbWorkflow.activeVersionId, activationMode },
 			});
 
 			return added;
@@ -743,9 +743,10 @@ export class ActiveWorkflowManager {
 	async handleAddWebhooksTriggersAndPollers({
 		workflowId,
 		activeVersionId,
+		activationMode,
 	}: PubSubCommandMap['add-webhooks-triggers-and-pollers']) {
 		try {
-			await this.add(workflowId, 'activate', undefined, {
+			await this.add(workflowId, activationMode, undefined, {
 				shouldPublish: false, // prevent leader from re-publishing message
 			});
 

--- a/packages/cli/src/scaling/pubsub/__tests__/pubsub.registry.test.ts
+++ b/packages/cli/src/scaling/pubsub/__tests__/pubsub.registry.test.ts
@@ -131,9 +131,17 @@ describe('PubSubRegistry', () => {
 		);
 		pubSubRegistry.init();
 
-		pubsubEventBus.emit('add-webhooks-triggers-and-pollers', { workflowId, activeVersionId });
+		pubsubEventBus.emit('add-webhooks-triggers-and-pollers', {
+			workflowId,
+			activeVersionId,
+			activationMode: 'activate',
+		});
 		expect(onLeaderInstanceSpy).toHaveBeenCalledTimes(1);
-		expect(onLeaderInstanceSpy).toHaveBeenCalledWith({ workflowId, activeVersionId });
+		expect(onLeaderInstanceSpy).toHaveBeenCalledWith({
+			workflowId,
+			activeVersionId,
+			activationMode: 'activate',
+		});
 
 		pubsubEventBus.emit('restart-event-bus');
 		expect(onFollowerInstanceSpy).not.toHaveBeenCalled();
@@ -153,7 +161,11 @@ describe('PubSubRegistry', () => {
 		);
 		followerPubSubRegistry.init();
 
-		pubsubEventBus.emit('add-webhooks-triggers-and-pollers', { workflowId, activeVersionId });
+		pubsubEventBus.emit('add-webhooks-triggers-and-pollers', {
+			workflowId,
+			activeVersionId,
+			activationMode: 'activate',
+		});
 		expect(onLeaderInstanceSpy).not.toHaveBeenCalled();
 
 		pubsubEventBus.emit('restart-event-bus');
@@ -177,9 +189,17 @@ describe('PubSubRegistry', () => {
 		);
 		pubSubRegistry.init();
 
-		pubsubEventBus.emit('add-webhooks-triggers-and-pollers', { workflowId, activeVersionId });
+		pubsubEventBus.emit('add-webhooks-triggers-and-pollers', {
+			workflowId,
+			activeVersionId,
+			activationMode: 'activate',
+		});
 		expect(onLeaderInstanceSpy).toHaveBeenCalledTimes(1);
-		expect(onLeaderInstanceSpy).toHaveBeenCalledWith({ workflowId, activeVersionId });
+		expect(onLeaderInstanceSpy).toHaveBeenCalledWith({
+			workflowId,
+			activeVersionId,
+			activationMode: 'activate',
+		});
 	});
 
 	it('should handle dynamic role changes at runtime', () => {
@@ -197,19 +217,35 @@ describe('PubSubRegistry', () => {
 		pubSubRegistry.init();
 
 		// Initially as follower, event should be ignored
-		pubsubEventBus.emit('add-webhooks-triggers-and-pollers', { workflowId, activeVersionId });
+		pubsubEventBus.emit('add-webhooks-triggers-and-pollers', {
+			workflowId,
+			activeVersionId,
+			activationMode: 'activate',
+		});
 		expect(onLeaderInstanceSpy).not.toHaveBeenCalled();
 
 		// Change role to leader
 		instanceSettings.instanceRole = 'leader';
-		pubsubEventBus.emit('add-webhooks-triggers-and-pollers', { workflowId, activeVersionId });
+		pubsubEventBus.emit('add-webhooks-triggers-and-pollers', {
+			workflowId,
+			activeVersionId,
+			activationMode: 'activate',
+		});
 		expect(onLeaderInstanceSpy).toHaveBeenCalledTimes(1);
-		expect(onLeaderInstanceSpy).toHaveBeenCalledWith({ workflowId, activeVersionId });
+		expect(onLeaderInstanceSpy).toHaveBeenCalledWith({
+			workflowId,
+			activeVersionId,
+			activationMode: 'activate',
+		});
 
 		// Change back to follower
 		onLeaderInstanceSpy.mockClear();
 		instanceSettings.instanceRole = 'follower';
-		pubsubEventBus.emit('add-webhooks-triggers-and-pollers', { workflowId, activeVersionId });
+		pubsubEventBus.emit('add-webhooks-triggers-and-pollers', {
+			workflowId,
+			activeVersionId,
+			activationMode: 'activate',
+		});
 		expect(onLeaderInstanceSpy).not.toHaveBeenCalled();
 	});
 

--- a/packages/cli/src/scaling/pubsub/pubsub.event-map.ts
+++ b/packages/cli/src/scaling/pubsub/pubsub.event-map.ts
@@ -1,5 +1,5 @@
 import type { ChatHubMessageStatus, PushMessage, WorkerStatus } from '@n8n/api-types';
-import type { IWorkflowBase } from 'n8n-workflow';
+import type { IWorkflowBase, WorkflowActivateMode } from 'n8n-workflow';
 
 export type PubSubCommandMap = {
 	// #region Lifecycle
@@ -61,6 +61,7 @@ export type PubSubCommandMap = {
 	'add-webhooks-triggers-and-pollers': {
 		workflowId: string;
 		activeVersionId: string;
+		activationMode: WorkflowActivateMode;
 	};
 
 	'remove-triggers-and-pollers': {

--- a/packages/testing/playwright/package.json
+++ b/packages/testing/playwright/package.json
@@ -36,6 +36,7 @@
     "@n8n/api-types": "workspace:*",
     "@n8n/playwright-janitor": "workspace:*",
     "@n8n/constants": "workspace:*",
+    "@n8n/workflow-sdk": "workspace:*",
     "@n8n/permissions": "workspace:*",
     "@n8n/db": "workspace:*",
     "@playwright/cli": "catalog:e2e",

--- a/packages/testing/playwright/services/workflow-api-helper.ts
+++ b/packages/testing/playwright/services/workflow-api-helper.ts
@@ -82,6 +82,26 @@ export class WorkflowApiHelper {
 		}
 	}
 
+	async update(
+		workflowId: string,
+		versionId: string,
+		data: Partial<IWorkflowBase>,
+	): Promise<IWorkflowBase> {
+		const response = await this.api.request.patch(`/rest/workflows/${workflowId}`, {
+			data: {
+				...data,
+				versionId,
+			},
+		});
+
+		if (!response.ok()) {
+			throw new TestError(`Failed to update workflow: ${await response.text()}`);
+		}
+
+		const result = await response.json();
+		return result.data ?? result;
+	}
+
 	async deactivate(workflowId: string) {
 		const response = await this.api.request.post(`/rest/workflows/${workflowId}/deactivate`);
 

--- a/packages/testing/playwright/tests/e2e/nodes/n8n-trigger-multi-main.spec.ts
+++ b/packages/testing/playwright/tests/e2e/nodes/n8n-trigger-multi-main.spec.ts
@@ -1,0 +1,77 @@
+import { workflow, trigger, node } from '@n8n/workflow-sdk';
+import type { INode, IWorkflowBase } from 'n8n-workflow';
+import { nanoid } from 'nanoid';
+
+import { test, expect } from '../../../fixtures/base';
+
+type TriggerEventType = 'activate' | 'update';
+
+const makeN8nTriggerWorkflow = (events: TriggerEventType[]) => {
+	const n8nTrigger = trigger({
+		type: 'n8n-nodes-base.n8nTrigger',
+		version: 1,
+		config: {
+			name: 'n8n Trigger',
+			parameters: { events },
+		},
+	});
+
+	const noOp = node({
+		type: 'n8n-nodes-base.noOp',
+		version: 1,
+		config: {
+			name: 'NoOp',
+		},
+	});
+
+	return workflow(nanoid(), `n8n Trigger Test ${nanoid()}`).add(n8nTrigger.to(noOp));
+};
+
+test.describe(
+	'n8n Trigger node in multi-main mode',
+	{
+		annotation: [{ type: 'owner', description: 'Catalysts' }],
+	},
+	() => {
+		test('should fire "activate" event when workflow is published @mode:multi-main', async ({
+			api,
+		}) => {
+			const wf = makeN8nTriggerWorkflow(['activate']);
+			const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition(
+				wf.toJSON() as IWorkflowBase,
+			);
+
+			// First activation — activationMode = 'activate'
+			await api.workflows.activate(workflowId, createdWorkflow.versionId!);
+
+			const execution = await api.workflows.waitForExecution(workflowId, 15_000, 'trigger');
+			expect(execution.status).toBe('success');
+		});
+
+		test('should fire "update" event when active workflow is re-published @mode:multi-main', async ({
+			api,
+		}) => {
+			const wf = makeN8nTriggerWorkflow(['update']);
+			const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition(
+				wf.toJSON() as IWorkflowBase,
+			);
+
+			// First activation — activationMode = 'activate', trigger should NOT fire
+			await api.workflows.activate(workflowId, createdWorkflow.versionId!);
+
+			// Update the workflow nodes to create a new version (simulates editing)
+			const updatedNodes = wf.add(
+				node({ type: 'n8n-nodes-base.noOp', version: 1, config: { name: 'NoOp2' } }),
+			);
+			const updatedWorkflow = await api.workflows.update(workflowId, createdWorkflow.versionId!, {
+				nodes: updatedNodes.toJSON().nodes as INode[],
+			});
+
+			// Re-activation with new version — activationMode = 'update', trigger should fire
+			await api.workflows.activate(workflowId, updatedWorkflow.versionId!);
+
+			const execution = await api.workflows.waitForExecution(workflowId, 15_000, 'trigger');
+			expect(execution.status).toBe('success');
+		});
+	},
+);

--- a/packages/testing/playwright/tests/e2e/nodes/n8n-trigger.spec.ts
+++ b/packages/testing/playwright/tests/e2e/nodes/n8n-trigger.spec.ts
@@ -28,14 +28,12 @@ const makeN8nTriggerWorkflow = (events: TriggerEventType[]) => {
 };
 
 test.describe(
-	'n8n Trigger node in multi-main mode',
+	'n8n Trigger node',
 	{
 		annotation: [{ type: 'owner', description: 'Catalysts' }],
 	},
 	() => {
-		test('should fire "activate" event when workflow is published @mode:multi-main', async ({
-			api,
-		}) => {
+		test('should fire "activate" event when workflow is published', async ({ api }) => {
 			const wf = makeN8nTriggerWorkflow(['activate']);
 			const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition(
 				wf.toJSON() as IWorkflowBase,
@@ -48,9 +46,7 @@ test.describe(
 			expect(execution.status).toBe('success');
 		});
 
-		test('should fire "update" event when active workflow is re-published @mode:multi-main', async ({
-			api,
-		}) => {
+		test('should fire "update" event when active workflow is re-published', async ({ api }) => {
 			const wf = makeN8nTriggerWorkflow(['update']);
 			const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition(
 				wf.toJSON() as IWorkflowBase,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -749,7 +749,7 @@ importers:
         version: 4.0.7
       axios:
         specifier: 1.13.5
-        version: 1.13.5
+        version: 1.13.5(debug@4.4.3)
       dotenv:
         specifier: 17.2.3
         version: 17.2.3
@@ -784,7 +784,7 @@ importers:
     dependencies:
       axios:
         specifier: 1.13.5
-        version: 1.13.5
+        version: 1.13.5(debug@4.4.3)
     devDependencies:
       '@n8n/typescript-config':
         specifier: workspace:*
@@ -1648,7 +1648,7 @@ importers:
         version: link:../eslint-plugin-community-nodes
       axios:
         specifier: 1.13.5
-        version: 1.13.5
+        version: 1.13.5(debug@4.4.3)
       eslint:
         specifier: 'catalog:'
         version: 9.29.0(jiti@2.6.1)
@@ -1926,7 +1926,7 @@ importers:
         version: 1.11.0
       axios:
         specifier: 1.13.5
-        version: 1.13.5
+        version: 1.13.5(debug@4.4.3)
       bcryptjs:
         specifier: 2.4.3
         version: 2.4.3
@@ -2284,7 +2284,7 @@ importers:
         version: 10.36.0
       axios:
         specifier: 1.13.5
-        version: 1.13.5
+        version: 1.13.5(debug@4.4.3)
       callsites:
         specifier: 'catalog:'
         version: 3.1.0
@@ -2757,7 +2757,7 @@ importers:
         version: link:../../../@n8n/utils
       axios:
         specifier: 1.13.5
-        version: 1.13.5
+        version: 1.13.5(debug@4.4.3)
       flatted:
         specifier: 'catalog:'
         version: 3.2.7
@@ -3072,7 +3072,7 @@ importers:
         version: 1.1.4
       axios:
         specifier: 1.13.5
-        version: 1.13.5
+        version: 1.13.5(debug@4.4.3)
       bowser:
         specifier: 2.11.0
         version: 2.11.0
@@ -3755,6 +3755,9 @@ importers:
       '@n8n/playwright-janitor':
         specifier: workspace:*
         version: link:../janitor
+      '@n8n/workflow-sdk':
+        specifier: workspace:*
+        version: link:../../@n8n/workflow-sdk
       '@playwright/cli':
         specifier: catalog:e2e
         version: 0.1.0
@@ -23662,7 +23665,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 3.8.4
       '@microsoft/agents-activity': 1.1.0-alpha.85
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -25008,7 +25011,7 @@ snapshots:
 
   '@rudderstack/rudder-sdk-node@3.0.0':
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       axios-retry: 4.5.0(axios@1.13.5)
       component-type: 2.0.0
       join-component: 1.1.0
@@ -28092,20 +28095,12 @@ snapshots:
 
   axios-retry@4.5.0(axios@1.13.5):
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       is-retry-allowed: 2.2.0
-
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11(debug@4.4.1)
-      form-data: 4.0.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
 
   axios@1.13.5(debug@4.4.3):
     dependencies:
-      follow-redirects: 1.15.11(debug@4.4.3)
+      follow-redirects: 1.15.11(debug@4.4.1)
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -30890,10 +30885,6 @@ snapshots:
     optionalDependencies:
       debug: 4.4.1(supports-color@8.1.1)
 
-  follow-redirects@1.15.11(debug@4.4.3):
-    optionalDependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
@@ -31607,7 +31598,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.13.5)
+      retry-axios: 2.6.0(axios@1.13.5(debug@4.4.3))
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -31692,7 +31683,7 @@ snapshots:
 
   infisical-node@1.3.0:
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       dotenv: 16.6.1
       tweetnacl: 1.0.3
       tweetnacl-util: 0.15.1
@@ -35393,7 +35384,7 @@ snapshots:
 
   posthog-node@3.2.1:
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       rusha: 0.8.14
     transitivePeerDependencies:
       - debug
@@ -36090,9 +36081,9 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
-  retry-axios@2.6.0(axios@1.13.5):
+  retry-axios@2.6.0(axios@1.13.5(debug@4.4.3)):
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
 
   retry-request@7.0.2(encoding@0.1.13):
     dependencies:
@@ -36708,7 +36699,7 @@ snapshots:
       asn1.js: 5.4.1
       asn1.js-rfc2560: 5.0.1(asn1.js@5.4.1)
       asn1.js-rfc5280: 3.0.0
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       big-integer: 1.6.52
       bignumber.js: 9.1.2
       binascii: 0.0.2


### PR DESCRIPTION
## Summary

In multi-main deployments, when the n8n Trigger node's "Active Workflow Updated" event is configured, it fails to fire because follower instances were always using 'activate' mode instead of the actual activation mode (e.g., 'update'). This fix forwards the `activationMode` through the pub/sub command so followers can correctly distinguish between initial activation and workflow updates.

Changes include:
- Forward `activationMode` in the `add-webhooks-triggers-and-pollers` pub/sub command payload
- Update handler to use the forwarded `activationMode` instead of hardcoded 'activate'
- Add workflow update helper method to the Playwright API service
- Add E2E tests to verify multi-main trigger behavior for both 'activate' and 'update' modes

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2310

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [ ] Docs updated or follow-up ticket created
- [x] Tests included
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)