### PR TITLE
feat(nodes-base): add salesforce client credentials support

### DIFF
--- a/packages/nodes-base/credentials/SalesforceClientCredentialsApi.credentials.ts
+++ b/packages/nodes-base/credentials/SalesforceClientCredentialsApi.credentials.ts
@@ -1,0 +1,84 @@
+import type { AxiosRequestConfig } from 'axios';
+import axios from 'axios';
+import type {
+	ICredentialDataDecryptedObject,
+	ICredentialTestRequest,
+	ICredentialType,
+	IHttpRequestOptions,
+	INodeProperties,
+} from 'n8n-workflow';
+
+export class SalesforceClientCredentialsApi implements ICredentialType {
+	name = 'salesforceClientCredentialsApi';
+
+	displayName = 'Salesforce Client Credentials API';
+
+	documentationUrl = 'salesforce';
+
+	properties: INodeProperties[] = [
+		{
+			displayName: 'Salesforce Url',
+			name: 'url',
+			type: 'string',
+			default: '',
+			required: true,
+			description: 'Salesforce instance URL, e.g. https://mydomain.my.salesforce.com',
+		},
+		{
+			displayName: 'Client ID',
+			name: 'clientId',
+			type: 'string',
+			default: '',
+			required: true,
+			description: 'Consumer Key from Salesforce Connected App',
+		},
+		{
+			displayName: 'Client Secret',
+			name: 'clientSecret',
+			type: 'string',
+			typeOptions: {
+				password: true,
+			},
+			default: '',
+			required: true,
+			description: 'Consumer Secret from Salesforce Connected App',
+		},
+	];
+
+	async authenticate(
+		credentials: ICredentialDataDecryptedObject,
+		requestOptions: IHttpRequestOptions,
+	): Promise<IHttpRequestOptions> {
+		const axiosRequestConfig: AxiosRequestConfig = {
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+			method: 'POST',
+			data: new URLSearchParams({
+				grant_type: 'client_credentials',
+				client_id: credentials.clientId as string,
+				client_secret: credentials.clientSecret as string,
+			}).toString(),
+			url: `${credentials.url as string}/services/oauth2/token`,
+			responseType: 'json',
+		};
+		const result = await axios(axiosRequestConfig);
+		const { access_token } = result.data as { access_token: string };
+
+		return {
+			...requestOptions,
+			headers: {
+				...requestOptions.headers,
+				Authorization: `Bearer ${access_token}`,
+			},
+		};
+	}
+
+	test: ICredentialTestRequest = {
+		request: {
+			baseURL: '={{$credentials?.url}}',
+			url: '/services/oauth2/userinfo',
+			method: 'GET',
+		},
+	};
+}

--- a/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
@@ -82,6 +82,27 @@ async function getAccessToken(
 	return await this.helpers.request(options);
 }
 
+async function getClientCredentialsToken(
+	this: IExecuteFunctions | ILoadOptionsFunctions | IPollFunctions,
+	credentials: IDataObject,
+): Promise<IDataObject> {
+	const options: IRequestOptions = {
+		headers: {
+			'Content-Type': 'application/x-www-form-urlencoded',
+		},
+		method: 'POST',
+		form: {
+			grant_type: 'client_credentials',
+			client_id: credentials.clientId as string,
+			client_secret: credentials.clientSecret as string,
+		},
+		url: `${credentials.url as string}/services/oauth2/token`,
+		json: true,
+	};
+
+	return await this.helpers.request(options);
+}
+
 export async function salesforceApiRequest(
 	this: IExecuteFunctions | ILoadOptionsFunctions | IPollFunctions,
 	method: IHttpRequestMethods,
@@ -114,6 +135,25 @@ export async function salesforceApiRequest(
 			options.headers!.Authorization = `Bearer ${access_token}`;
 			Object.assign(options, option);
 			return await this.helpers.request(options);
+		} else if (authenticationMethod === 'clientCredentials') {
+			// https://help.salesforce.com/s/articleView?id=xcloud.remoteaccess_oauth_client_credentials_flow.htm&type=5
+			const credentialsType = 'salesforceClientCredentialsApi';
+			const credentials = await this.getCredentials(credentialsType);
+			const response = await getClientCredentialsToken.call(this, credentials);
+			const { instance_url, access_token } = response;
+			const options = getOptions.call(
+				this,
+				method,
+				uri || endpoint,
+				body,
+				qs,
+				instance_url as string,
+			);
+			this.logger.debug(
+				`Authentication for "Salesforce" node is using "clientCredentials". Invoking URI ${options.uri}`,
+			);
+			options.headers!.Authorization = `Bearer ${access_token}`;
+			Object.assign(options, option);
 		} else {
 			// https://help.salesforce.com/articleView?id=remoteaccess_oauth_web_server_flow.htm&type=5
 			const credentialsType = 'salesforceOAuth2Api';

--- a/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
@@ -154,6 +154,7 @@ export async function salesforceApiRequest(
 			);
 			options.headers!.Authorization = `Bearer ${access_token}`;
 			Object.assign(options, option);
+			return await this.helpers.request(options);
 		} else {
 			// https://help.salesforce.com/articleView?id=remoteaccess_oauth_web_server_flow.htm&type=5
 			const credentialsType = 'salesforceOAuth2Api';

--- a/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
@@ -40,7 +40,7 @@ function getOptions(
 	return options;
 }
 
-async function getAccessToken(
+async function getJwtToken(
 	this: IExecuteFunctions | ILoadOptionsFunctions | IPollFunctions,
 	credentials: IDataObject,
 ): Promise<IDataObject> {
@@ -103,6 +103,23 @@ async function getClientCredentialsToken(
 	return await this.helpers.request(options);
 }
 
+async function getBearerCredentials(
+	this: IExecuteFunctions | ILoadOptionsFunctions | IPollFunctions,
+	authenticationMethod: string,
+): Promise<IDataObject> {
+	if (authenticationMethod === 'jwt') {
+		// https://help.salesforce.com/articleView?id=remoteaccess_oauth_jwt_flow.htm&type=5
+		const credentialsType = 'salesforceJwtApi';
+		const credentials = await this.getCredentials(credentialsType);
+		return await getJwtToken.call(this, credentials);
+	} else {
+		// https://help.salesforce.com/s/articleView?id=xcloud.remoteaccess_oauth_client_credentials_flow.htm&type=5
+		const credentialsType = 'salesforceClientCredentialsApi';
+		const credentials = await this.getCredentials(credentialsType);
+		return await getClientCredentialsToken.call(this, credentials);
+	}
+}
+
 export async function salesforceApiRequest(
 	this: IExecuteFunctions | ILoadOptionsFunctions | IPollFunctions,
 	method: IHttpRequestMethods,
@@ -115,11 +132,8 @@ export async function salesforceApiRequest(
 ): Promise<any> {
 	const authenticationMethod = this.getNodeParameter('authentication', 0, 'oAuth2') as string;
 	try {
-		if (authenticationMethod === 'jwt') {
-			// https://help.salesforce.com/articleView?id=remoteaccess_oauth_jwt_flow.htm&type=5
-			const credentialsType = 'salesforceJwtApi';
-			const credentials = await this.getCredentials(credentialsType);
-			const response = await getAccessToken.call(this, credentials);
+		if (authenticationMethod === 'jwt' || authenticationMethod === 'clientCredentials') {
+			const response = await getBearerCredentials.call(this, authenticationMethod);
 			const { instance_url, access_token } = response;
 			const options = getOptions.call(
 				this,
@@ -130,27 +144,7 @@ export async function salesforceApiRequest(
 				instance_url as string,
 			);
 			this.logger.debug(
-				`Authentication for "Salesforce" node is using "jwt". Invoking URI ${options.uri}`,
-			);
-			options.headers!.Authorization = `Bearer ${access_token}`;
-			Object.assign(options, option);
-			return await this.helpers.request(options);
-		} else if (authenticationMethod === 'clientCredentials') {
-			// https://help.salesforce.com/s/articleView?id=xcloud.remoteaccess_oauth_client_credentials_flow.htm&type=5
-			const credentialsType = 'salesforceClientCredentialsApi';
-			const credentials = await this.getCredentials(credentialsType);
-			const response = await getClientCredentialsToken.call(this, credentials);
-			const { instance_url, access_token } = response;
-			const options = getOptions.call(
-				this,
-				method,
-				uri || endpoint,
-				body,
-				qs,
-				instance_url as string,
-			);
-			this.logger.debug(
-				`Authentication for "Salesforce" node is using "clientCredentials". Invoking URI ${options.uri}`,
+				`Authentication for "Salesforce" node is using "${authenticationMethod}". Invoking URI ${options.uri}`,
 			);
 			options.headers!.Authorization = `Bearer ${access_token}`;
 			Object.assign(options, option);

--- a/packages/nodes-base/nodes/Salesforce/Salesforce.node.ts
+++ b/packages/nodes-base/nodes/Salesforce/Salesforce.node.ts
@@ -73,6 +73,15 @@ export class Salesforce implements INodeType {
 					},
 				},
 			},
+			{
+				name: 'salesforceClientCredentialsApi',
+				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['clientCredentials'],
+					},
+				},
+			},
 		],
 		properties: [
 			{
@@ -87,6 +96,10 @@ export class Salesforce implements INodeType {
 					{
 						name: 'OAuth2 JWT',
 						value: 'jwt',
+					},
+					{
+						name: 'Client Credentials',
+						value: 'clientCredentials',
 					},
 				],
 				default: 'oAuth2',

--- a/packages/nodes-base/nodes/Salesforce/__test__/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Salesforce/__test__/GenericFunctions.test.ts
@@ -961,4 +961,82 @@ describe('Salesforce -> GenericFunctions', () => {
 			});
 		});
 	});
+
+	describe('salesforceApiRequest - Client Credentials Authentication', () => {
+		let mockExecuteFunctions: jest.Mocked<IExecuteFunctions>;
+		let mockRequest: jest.Mock;
+
+		beforeEach(() => {
+			mockExecuteFunctions = mockDeep<IExecuteFunctions>();
+			mockRequest = jest.fn();
+			mockExecuteFunctions.helpers.request = mockRequest;
+			jest.clearAllMocks();
+
+			// Setup default mocks
+			(mockJwt.sign as jest.Mock).mockReturnValue('mock-jwt-signature');
+			mockExecuteFunctions.getNodeParameter.mockImplementation((param: string) => {
+				if (param === 'authentication') return 'clientCredentials';
+				return undefined;
+			});
+		});
+
+		afterEach(() => {
+			jest.resetAllMocks();
+		});
+
+		it('should authenticate using Client Credentials', async () => {
+			const mockCredentials = {
+				clientId: 'test-client-id',
+				clientSecret: 'test-client-secret',
+				url: 'https://mydomain.my.salesforce.com',
+			};
+			const mockResponse = {
+				access_token: 'mock-access-token',
+				instance_url: 'https://mydomain.my.salesforce.com',
+			};
+
+			mockExecuteFunctions.getCredentials.mockResolvedValue(mockCredentials);
+			mockRequest.mockResolvedValue(mockResponse);
+			mockExecuteFunctions.logger = {
+				debug: jest.fn(),
+			} as any;
+
+			await salesforceApiRequest.call(mockExecuteFunctions, 'GET', '/test-endpoint', {}, {});
+
+			// Verify token exchange request
+			expect(mockRequest).toHaveBeenCalledWith({
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				method: 'POST',
+				form: {
+					grant_type: 'client_credentials',
+					client_id: 'test-client-id',
+					client_secret: 'test-client-secret',
+				},
+				url: 'https://mydomain.my.salesforce.com/services/oauth2/token',
+				json: true,
+			});
+
+			// Verify API request with bearer token
+			const expectedApiOptions = {
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: 'Bearer mock-access-token',
+				},
+				method: 'GET',
+				qs: {},
+				uri: 'https://mydomain.my.salesforce.com/services/data/v59.0/test-endpoint',
+				json: true,
+			};
+
+			// console log the second request
+			console.log('Second request options:', mockRequest.mock.calls[1][0]);
+
+			expect(mockRequest).toHaveBeenCalledWith(expectedApiOptions);
+			expect(mockExecuteFunctions.logger.debug).toHaveBeenCalledWith(
+				'Authentication for "Salesforce" node is using "clientCredentials". Invoking URI https://mydomain.my.salesforce.com/services/data/v59.0/test-endpoint',
+			);
+		});
+	});
 });

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -312,6 +312,7 @@
       "dist/credentials/RocketchatApi.credentials.js",
       "dist/credentials/RundeckApi.credentials.js",
       "dist/credentials/S3.credentials.js",
+      "dist/credentials/SalesforceClientCredentialsApi.credentials.js",
       "dist/credentials/SalesforceJwtApi.credentials.js",
       "dist/credentials/SalesforceOAuth2Api.credentials.js",
       "dist/credentials/SalesmateApi.credentials.js",


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
This Pull Request adds Client-Credentials support for Salesforce nodes. 

<!--
## Related Linear tickets, Github issues, and Community forum posts
-->

<img width="775" height="676" alt="Screenshot 2026-02-16 210342" src="https://github.com/user-attachments/assets/1c14cd15-bd2b-406d-aed5-ef7e9e7742b9" />



I tried to follow the existing codebase’s coding style without making too many changes. However, I think the code should be refactored, as there are several duplications. I can update the PR with a restructured version.

Pull Request for the documentation update: https://github.com/n8n-io/n8n-docs/pull/4243

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
