### PR TITLE
fixes/22112-ai-agent-v3-redis-chat

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/runAgent.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/runAgent.ts
@@ -86,10 +86,18 @@ export async function runAgent(
 				metadata: buildResponseMetadata(response, itemIndex),
 			};
 		}
-		// Save conversation to memory including any tool call context
+		// Save conversation to memory. Only persist tool call traces when returnIntermediateSteps
+		// is true. This matches V2 AgentExecutor behavior where only the final output was saved.
 		if (memory && input && result?.output) {
 			const previousCount = response?.metadata?.previousRequests?.length;
-			await saveToMemory(input, result.output, memory, steps, previousCount);
+			await saveToMemory(
+				input,
+				result.output,
+				memory,
+				steps,
+				previousCount,
+				options.returnIntermediateSteps === true,
+			);
 		}
 
 		if (options.returnIntermediateSteps && steps.length > 0) {
@@ -107,10 +115,18 @@ export async function runAgent(
 		});
 
 		if ('returnValues' in modelResponse) {
-			// Save conversation to memory including any tool call context
+			// Save conversation to memory. Only persist tool call traces when returnIntermediateSteps
+			// is true. This matches V2 AgentExecutor behavior where only the final output was saved.
 			if (memory && input && modelResponse.returnValues.output) {
 				const previousCount = response?.metadata?.previousRequests?.length;
-				await saveToMemory(input, modelResponse.returnValues.output, memory, steps, previousCount);
+				await saveToMemory(
+					input,
+					modelResponse.returnValues.output,
+					memory,
+					steps,
+					previousCount,
+					options.returnIntermediateSteps === true,
+				);
 			}
 			// Include intermediate steps if requested
 			const result = { ...modelResponse.returnValues };

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/runAgent.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/runAgent.test.ts
@@ -1,5 +1,6 @@
 import type { RequestResponseMetadata } from '@utils/agent-execution';
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
+import type { BaseChatMemory } from '@langchain/classic/memory';
 import { mock } from 'jest-mock-extended';
 import type { AgentRunnableSequence } from '@langchain/classic/agents';
 import type { Tool } from '@langchain/classic/tools';
@@ -260,6 +261,175 @@ describe('runAgent - iteration count tracking', () => {
 		expect(result).toHaveProperty('output');
 		expect(result).not.toHaveProperty('actions');
 		expect(result).not.toHaveProperty('metadata');
+	});
+});
+
+describe('runAgent - memory persistence respects returnIntermediateSteps', () => {
+	it('should pass saveToolSteps=false to saveToMemory when returnIntermediateSteps is false', async () => {
+		const mockInvoke = jest.fn().mockResolvedValue({
+			returnValues: { output: 'Final answer' },
+		});
+		const mockExecutor = mock<AgentRunnableSequence>({
+			withConfig: jest.fn().mockReturnValue({ invoke: mockInvoke }),
+		});
+		const mockModel = mock<BaseChatModel>();
+		const mockMemory = mock<BaseChatMemory>();
+
+		const steps: agentExecution.ToolCallData[] = [
+			{
+				action: {
+					tool: 'date_time',
+					toolInput: {},
+					log: 'Getting date',
+					toolCallId: 'call-1',
+					type: 'tool_call',
+				},
+				observation: '2024-01-01',
+			},
+		];
+
+		const itemContext: ItemContext = {
+			itemIndex: 0,
+			input: 'What is today?',
+			steps,
+			tools: [],
+			prompt: mock(),
+			options: {
+				maxIterations: 10,
+				returnIntermediateSteps: false,
+			},
+			outputParser: undefined,
+		};
+
+		jest.spyOn(agentExecution, 'loadMemory').mockResolvedValue([]);
+		const saveToMemorySpy = jest.spyOn(agentExecution, 'saveToMemory').mockResolvedValue();
+		mockContext.getExecutionCancelSignal.mockReturnValue(new AbortController().signal);
+
+		await runAgent(mockContext, mockExecutor, itemContext, mockModel, mockMemory);
+
+		// saveToolSteps (6th argument) should be false
+		expect(saveToMemorySpy).toHaveBeenCalledWith(
+			'What is today?',
+			'Final answer',
+			mockMemory,
+			steps,
+			undefined,
+			false,
+		);
+	});
+
+	it('should pass saveToolSteps=true to saveToMemory when returnIntermediateSteps is true', async () => {
+		const mockInvoke = jest.fn().mockResolvedValue({
+			returnValues: { output: 'Final answer with steps' },
+		});
+		const mockExecutor = mock<AgentRunnableSequence>({
+			withConfig: jest.fn().mockReturnValue({ invoke: mockInvoke }),
+		});
+		const mockModel = mock<BaseChatModel>();
+		const mockMemory = mock<BaseChatMemory>();
+
+		const steps: agentExecution.ToolCallData[] = [
+			{
+				action: {
+					tool: 'calculator',
+					toolInput: { expression: '2+2' },
+					log: 'Calculating',
+					toolCallId: 'call-1',
+					type: 'tool_call',
+				},
+				observation: '4',
+			},
+		];
+
+		const itemContext: ItemContext = {
+			itemIndex: 0,
+			input: 'Calculate 2+2',
+			steps,
+			tools: [],
+			prompt: mock(),
+			options: {
+				maxIterations: 10,
+				returnIntermediateSteps: true,
+			},
+			outputParser: undefined,
+		};
+
+		jest.spyOn(agentExecution, 'loadMemory').mockResolvedValue([]);
+		const saveToMemorySpy = jest.spyOn(agentExecution, 'saveToMemory').mockResolvedValue();
+		mockContext.getExecutionCancelSignal.mockReturnValue(new AbortController().signal);
+
+		await runAgent(mockContext, mockExecutor, itemContext, mockModel, mockMemory);
+
+		// saveToolSteps (6th argument) should be true
+		expect(saveToMemorySpy).toHaveBeenCalledWith(
+			'Calculate 2+2',
+			'Final answer with steps',
+			mockMemory,
+			steps,
+			undefined,
+			true,
+		);
+	});
+
+	it('should pass saveToolSteps=false in streaming mode when returnIntermediateSteps is false', async () => {
+		const mockEventStream = (async function* () {})();
+		const mockStreamEvents = jest.fn().mockReturnValue(mockEventStream);
+		const mockExecutor = mock<AgentRunnableSequence>({
+			withConfig: jest.fn().mockReturnValue({ streamEvents: mockStreamEvents }),
+		});
+		const mockModel = mock<BaseChatModel>();
+		const mockMemory = mock<BaseChatMemory>();
+
+		const steps: agentExecution.ToolCallData[] = [
+			{
+				action: {
+					tool: 'search',
+					toolInput: { query: 'test' },
+					log: 'Searching',
+					toolCallId: 'call-1',
+					type: 'tool_call',
+				},
+				observation: 'Found results',
+			},
+		];
+
+		const itemContext: ItemContext = {
+			itemIndex: 0,
+			input: 'Search for test',
+			steps,
+			tools: [],
+			prompt: mock(),
+			options: {
+				maxIterations: 10,
+				returnIntermediateSteps: false,
+				enableStreaming: true,
+			},
+			outputParser: undefined,
+		};
+
+		const streamingContext = mock<IExecuteFunctions>({
+			getNode: jest.fn().mockReturnValue({ ...mockNode, typeVersion: 2.1 }),
+			isStreaming: jest.fn().mockReturnValue(true),
+			getExecutionCancelSignal: jest.fn().mockReturnValue(new AbortController().signal),
+		});
+
+		jest.spyOn(agentExecution, 'loadMemory').mockResolvedValue([]);
+		jest.spyOn(agentExecution, 'processEventStream').mockResolvedValue({
+			output: 'Streamed answer',
+		});
+		const saveToMemorySpy = jest.spyOn(agentExecution, 'saveToMemory').mockResolvedValue();
+
+		await runAgent(streamingContext, mockExecutor, itemContext, mockModel, mockMemory);
+
+		// saveToolSteps (6th argument) should be false in streaming mode too
+		expect(saveToMemorySpy).toHaveBeenCalledWith(
+			'Search for test',
+			'Streamed answer',
+			mockMemory,
+			steps,
+			undefined,
+			false,
+		);
 	});
 });
 

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/options.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/options.ts
@@ -25,7 +25,8 @@ export const commonOptions: INodeProperties[] = [
 		name: 'returnIntermediateSteps',
 		type: 'boolean',
 		default: false,
-		description: 'Whether or not the output should include intermediate steps the agent took',
+		description:
+			'Whether or not the output should include intermediate steps the agent took. When enabled, tool call traces are also persisted in chat memory. When disabled, only the final assistant response is saved to memory.',
 	},
 	{
 		displayName: 'Automatically Passthrough Binary Images',

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/memoryManagement.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/memoryManagement.ts
@@ -224,21 +224,31 @@ export async function loadMemory(
 /**
  * Saves a conversation turn (user input + agent output) to memory.
  * Uses LangChain-native message types (AIMessage with tool_calls, ToolMessage)
- * when tools are involved, preserving semantic structure for LLMs.
+ * when tools are involved and saveToolSteps is true, preserving semantic structure for LLMs.
+ *
+ * When saveToolSteps is false (default), only the user input and final assistant response
+ * are persisted, matching V2 AgentExecutor behavior where only the final output was saved
+ * via saveContext(). This prevents tool outputs from polluting chat history in memory
+ * backends like Redis.
  *
  * @param input - The user input/prompt
  * @param output - The agent's output/response
  * @param memory - The memory instance to save to
  * @param steps - Optional tool call data to save as proper message sequence
  * @param previousStepsCount - Number of steps from previous turns (to filter out duplicates)
+ * @param saveToolSteps - Whether to persist tool call traces in memory (default: false).
+ *   When false, only user input and final assistant response are saved regardless of steps.
  *
  * @example
  * ```typescript
  * // Simple conversation (no tools)
  * await saveToMemory('What is 2+2?', 'The answer is 4', memory);
  *
- * // With tool calls (saves full message sequence)
+ * // With tool calls but saveToolSteps=false (default): only saves input + final output
  * await saveToMemory('Calculate 2+2', 'The answer is 4', memory, steps, 0);
+ *
+ * // With tool calls and saveToolSteps=true: saves full message sequence
+ * await saveToMemory('Calculate 2+2', 'The answer is 4', memory, steps, 0, true);
  * ```
  */
 export async function saveToMemory(
@@ -247,6 +257,7 @@ export async function saveToMemory(
 	memory?: BaseChatMemory,
 	steps?: ToolCallData[],
 	previousStepsCount?: number,
+	saveToolSteps: boolean = false,
 ): Promise<void> {
 	if (!output || !memory) {
 		return;
@@ -254,6 +265,15 @@ export async function saveToMemory(
 
 	// No tool calls: use simple saveContext (backwards compatible)
 	if (!steps || steps.length === 0) {
+		await memory.saveContext({ input }, { output });
+		return;
+	}
+
+	// When saveToolSteps is false, only save the final conversation pair
+	// (user input + assistant output). This matches V2 AgentExecutor behavior where
+	// LangChain only persisted the final output, preventing tool outputs from polluting
+	// chat history in memory backends like Redis.
+	if (!saveToolSteps) {
 		await memory.saveContext({ input }, { output });
 		return;
 	}

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/memoryManagement.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/memoryManagement.test.ts
@@ -363,7 +363,7 @@ describe('memoryManagement', () => {
 		});
 	});
 
-	describe('saveToMemory with steps (message-based storage)', () => {
+	describe('saveToMemory with steps and saveToolSteps=false (default)', () => {
 		let mockChatHistory: any;
 
 		beforeEach(() => {
@@ -378,7 +378,7 @@ describe('memoryManagement', () => {
 			jest.restoreAllMocks();
 		});
 
-		it('should use message-based storage when steps are provided and addMessages is available', async () => {
+		it('should only save final output when saveToolSteps is false (default)', async () => {
 			const aiMessage = new AIMessage({
 				content: 'Let me calculate',
 				tool_calls: [
@@ -400,22 +400,19 @@ describe('memoryManagement', () => {
 				},
 			];
 
+			// Default saveToolSteps=false: should NOT save tool messages to memory
 			await saveToMemory('Calculate 2+2', 'The answer is 4', mockMemory, steps);
 
-			expect(mockChatHistory.addMessages).toHaveBeenCalledTimes(1);
-			const savedMessages = mockChatHistory.addMessages.mock.calls[0][0];
-
-			expect(savedMessages).toHaveLength(4);
-			expect(savedMessages[0]).toBeInstanceOf(HumanMessage);
-			expect(savedMessages[0].content).toBe('Calculate 2+2');
-			expect(savedMessages[1]).toBe(aiMessage);
-			expect(savedMessages[2]).toBeInstanceOf(ToolMessage);
-			expect(savedMessages[3]).toBeInstanceOf(AIMessage);
-			expect(savedMessages[3].content).toBe('The answer is 4');
+			// Should use simple saveContext, NOT addMessages
+			expect(mockMemory.saveContext).toHaveBeenCalledWith(
+				{ input: 'Calculate 2+2' },
+				{ output: 'The answer is 4' },
+			);
+			expect(mockChatHistory.addMessages).not.toHaveBeenCalled();
 		});
 
-		it('should fall back to string format when addMessages is not available', async () => {
-			// Create a chat history object without addMessages method
+		it('should not include [Used tools:] prefix when saveToolSteps is false', async () => {
+			// Even when addMessages is NOT available, saveToolSteps=false should prevent tool pollution
 			mockMemory.chatHistory = {} as any;
 
 			const steps: ToolCallData[] = [
@@ -433,6 +430,133 @@ describe('memoryManagement', () => {
 
 			await saveToMemory('Calculate 2+2', 'The answer is 4', mockMemory, steps);
 
+			// Should only save the final output, no [Used tools:] prefix
+			expect(mockMemory.saveContext).toHaveBeenCalledWith(
+				{ input: 'Calculate 2+2' },
+				{ output: 'The answer is 4' },
+			);
+		});
+
+		it('should not save tool traces for multiple tools when saveToolSteps is false', async () => {
+			const steps: ToolCallData[] = [
+				{
+					action: {
+						tool: 'date_time',
+						toolInput: {},
+						log: 'Getting date',
+						toolCallId: 'call-1',
+						type: 'tool_call',
+					},
+					observation: '2024-01-01',
+				},
+				{
+					action: {
+						tool: 'report_list',
+						toolInput: { filter: 'active' },
+						log: 'Getting reports',
+						toolCallId: 'call-2',
+						type: 'tool_call',
+					},
+					observation: '{"reports": [{"id": 1, "name": "Q1"}]}',
+				},
+				{
+					action: {
+						tool: 'report_rows',
+						toolInput: { reportId: 1 },
+						log: 'Getting rows',
+						toolCallId: 'call-3',
+						type: 'tool_call',
+					},
+					observation: '{"rows": [{"a": 1}, {"a": 2}]}',
+				},
+			];
+
+			await saveToMemory(
+				'Get me the Q1 report data',
+				'Here is the Q1 report data for 2024.',
+				mockMemory,
+				steps,
+			);
+
+			// Only final output saved, no tool traces
+			expect(mockMemory.saveContext).toHaveBeenCalledWith(
+				{ input: 'Get me the Q1 report data' },
+				{ output: 'Here is the Q1 report data for 2024.' },
+			);
+			expect(mockChatHistory.addMessages).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('saveToMemory with steps and saveToolSteps=true', () => {
+		let mockChatHistory: any;
+
+		beforeEach(() => {
+			jest.spyOn(console, 'log').mockImplementation();
+			mockChatHistory = {
+				addMessages: jest.fn().mockResolvedValue(undefined),
+			};
+			mockMemory.chatHistory = mockChatHistory;
+		});
+
+		afterEach(() => {
+			jest.restoreAllMocks();
+		});
+
+		it('should use message-based storage when saveToolSteps is true and addMessages is available', async () => {
+			const aiMessage = new AIMessage({
+				content: 'Let me calculate',
+				tool_calls: [
+					{ id: 'call-123', name: 'calculator', args: { expression: '2+2' }, type: 'tool_call' },
+				],
+			});
+
+			const steps: ToolCallData[] = [
+				{
+					action: {
+						tool: 'calculator',
+						toolInput: { expression: '2+2' },
+						log: 'Calc',
+						messageLog: [aiMessage],
+						toolCallId: 'call-123',
+						type: 'tool_call',
+					},
+					observation: '4',
+				},
+			];
+
+			await saveToMemory('Calculate 2+2', 'The answer is 4', mockMemory, steps, undefined, true);
+
+			expect(mockChatHistory.addMessages).toHaveBeenCalledTimes(1);
+			const savedMessages = mockChatHistory.addMessages.mock.calls[0][0];
+
+			expect(savedMessages).toHaveLength(4);
+			expect(savedMessages[0]).toBeInstanceOf(HumanMessage);
+			expect(savedMessages[0].content).toBe('Calculate 2+2');
+			expect(savedMessages[1]).toBe(aiMessage);
+			expect(savedMessages[2]).toBeInstanceOf(ToolMessage);
+			expect(savedMessages[3]).toBeInstanceOf(AIMessage);
+			expect(savedMessages[3].content).toBe('The answer is 4');
+		});
+
+		it('should fall back to string format when saveToolSteps is true but addMessages is not available', async () => {
+			// Create a chat history object without addMessages method
+			mockMemory.chatHistory = {} as any;
+
+			const steps: ToolCallData[] = [
+				{
+					action: {
+						tool: 'calculator',
+						toolInput: { expression: '2+2' },
+						log: 'Calc',
+						toolCallId: 'call-123',
+						type: 'tool_call',
+					},
+					observation: '4',
+				},
+			];
+
+			await saveToMemory('Calculate 2+2', 'The answer is 4', mockMemory, steps, undefined, true);
+
 			expect(mockMemory.saveContext).toHaveBeenCalledWith(
 				{ input: 'Calculate 2+2' },
 				{
@@ -443,7 +567,7 @@ describe('memoryManagement', () => {
 		});
 
 		it('should use saveContext when steps array is empty', async () => {
-			await saveToMemory('Simple question', 'Simple answer', mockMemory, []);
+			await saveToMemory('Simple question', 'Simple answer', mockMemory, [], undefined, true);
 
 			expect(mockMemory.saveContext).toHaveBeenCalledWith(
 				{ input: 'Simple question' },
@@ -483,7 +607,7 @@ describe('memoryManagement', () => {
 			];
 
 			// All steps are from previous turns (previousStepsCount = 1)
-			await saveToMemory('New question', 'New answer', mockMemory, steps, 1);
+			await saveToMemory('New question', 'New answer', mockMemory, steps, 1, true);
 
 			expect(mockMemory.saveContext).toHaveBeenCalledWith(
 				{ input: 'New question' },


### PR DESCRIPTION
## Summary

Root Cause
V2 (correct): Uses LangChain's AgentExecutor which internally calls memory.saveContext({ input }, { output }) with only the final output string. Tool call traces are never persisted to memory.

V3 (broken): Manually manages memory via saveToMemory() in [runAgent.ts](vscode-webview://1p8iial8l117g576fjtmhaf7o6blocc58e6mq261pvn7dmoshq3s/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/runAgent.ts). This function always saves the full tool call sequence (AIMessage with tool_calls + ToolMessage pairs) to memory via chatHistory.addMessages(), regardless of the returnIntermediateSteps setting. The flag only controlled the node's OUTPUT data, not memory persistence. In the fallback path (memory without addMessages support), it generated [Used tools: Tool: X, Input: {...}, Result: {...}] output — the exact format users reported seeing in Redis.

Fixes #22112 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
