### PR TITLE
fix: Prevent node mention popup when typing email addresses

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useNodeMention.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useNodeMention.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setActivePinia } from 'pinia';
+import { createTestingPinia } from '@pinia/testing';
+
+import { useNodeMention } from './useNodeMention';
+import { useFocusedNodesStore } from '../focusedNodes.store';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import type { INodeUi } from '@/Interface';
+
+vi.mock('@/app/stores/posthog.store', () => ({
+	usePostHog: () => ({
+		isVariantEnabled: vi.fn().mockReturnValue(false),
+	}),
+}));
+
+vi.mock('@/app/composables/useTelemetry', () => ({
+	useTelemetry: () => ({ track: vi.fn() }),
+}));
+
+vi.mock('@/features/ndv/shared/ndv.store', () => ({
+	useNDVStore: () => ({ activeNode: null }),
+}));
+
+function createMockInput(value = '', selectionStart: number | null = null): HTMLInputElement {
+	const input = document.createElement('input');
+	input.value = value;
+	Object.defineProperty(input, 'selectionStart', {
+		get: () => selectionStart ?? value.length,
+		configurable: true,
+	});
+	input.setSelectionRange = vi.fn();
+	input.dispatchEvent = vi.fn();
+	return input;
+}
+
+function createMockInputEvent(): InputEvent {
+	return new InputEvent('input', { bubbles: true });
+}
+
+const mockNodes: INodeUi[] = [
+	{
+		id: 'node-1',
+		name: 'HTTP Request',
+		type: 'n8n-nodes-base.httpRequest',
+		typeVersion: 1,
+		position: [0, 0],
+		parameters: {},
+	},
+	{
+		id: 'node-2',
+		name: 'Set',
+		type: 'n8n-nodes-base.set',
+		typeVersion: 1,
+		position: [200, 0],
+		parameters: {},
+	},
+];
+
+describe('useNodeMention', () => {
+	let workflowsStore: ReturnType<typeof useWorkflowsStore>;
+	let focusedNodesStore: ReturnType<typeof useFocusedNodesStore>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		setActivePinia(
+			createTestingPinia({
+				createSpy: vi.fn,
+				stubActions: false,
+			}),
+		);
+
+		workflowsStore = useWorkflowsStore();
+		focusedNodesStore = useFocusedNodesStore();
+
+		// @ts-expect-error -- mock readonly property
+		workflowsStore.allNodes = mockNodes;
+	});
+
+	describe('handleInput - @ trigger conditions', () => {
+		it('should open dropdown when @ is typed at start of input', () => {
+			const { handleInput, showDropdown } = useNodeMention();
+			const input = createMockInput('@', 1);
+
+			handleInput(createMockInputEvent(), input);
+
+			expect(showDropdown.value).toBe(true);
+		});
+
+		it('should open dropdown when @ is preceded by a space', () => {
+			const { handleInput, showDropdown } = useNodeMention();
+			const input = createMockInput('hello @', 7);
+
+			handleInput(createMockInputEvent(), input);
+
+			expect(showDropdown.value).toBe(true);
+		});
+
+		it('should not open dropdown when @ is part of an email address', () => {
+			const { handleInput, showDropdown } = useNodeMention();
+			const input = createMockInput('user@', 5);
+
+			handleInput(createMockInputEvent(), input);
+
+			expect(showDropdown.value).toBe(false);
+		});
+
+		it('should not open dropdown when @ is preceded by a letter', () => {
+			const { handleInput, showDropdown } = useNodeMention();
+			const input = createMockInput('test@', 5);
+
+			handleInput(createMockInputEvent(), input);
+
+			expect(showDropdown.value).toBe(false);
+		});
+
+		it('should not open dropdown when @ is preceded by a number', () => {
+			const { handleInput, showDropdown } = useNodeMention();
+			const input = createMockInput('abc123@', 7);
+
+			handleInput(createMockInputEvent(), input);
+
+			expect(showDropdown.value).toBe(false);
+		});
+
+		it('should open dropdown when @ is preceded by a tab character', () => {
+			const { handleInput, showDropdown } = useNodeMention();
+			const input = createMockInput('\t@', 2);
+
+			handleInput(createMockInputEvent(), input);
+
+			expect(showDropdown.value).toBe(true);
+		});
+	});
+
+	describe('handleKeyDown - Escape', () => {
+		it('should close dropdown without removing query text on Escape', () => {
+			const { handleInput, handleKeyDown, showDropdown } = useNodeMention();
+
+			const openInput = createMockInput('@', 1);
+			handleInput(createMockInputEvent(), openInput);
+			expect(showDropdown.value).toBe(true);
+
+			const escapeEvent = new KeyboardEvent('keydown', {
+				key: 'Escape',
+				cancelable: true,
+			});
+			const preventDefaultSpy = vi.spyOn(escapeEvent, 'preventDefault');
+
+			const handled = handleKeyDown(escapeEvent);
+
+			expect(handled).toBe(true);
+			expect(showDropdown.value).toBe(false);
+			expect(preventDefaultSpy).toHaveBeenCalled();
+			// Input value should remain unchanged (no removeQueryFromInput)
+			// eslint-disable-next-line @typescript-eslint/unbound-method
+			expect(openInput.dispatchEvent).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('selectNode', () => {
+		it('should confirm the selected node and close dropdown', () => {
+			const { handleInput, selectNode, showDropdown } = useNodeMention();
+
+			const input = createMockInput('@', 1);
+			handleInput(createMockInputEvent(), input);
+			expect(showDropdown.value).toBe(true);
+
+			selectNode(mockNodes[0]);
+
+			expect(showDropdown.value).toBe(false);
+			expect(focusedNodesStore.confirmedNodeIds).toContain('node-1');
+		});
+	});
+
+	describe('filteredNodes', () => {
+		it('should exclude already confirmed nodes', () => {
+			focusedNodesStore.confirmNodes(['node-1'], 'mention');
+
+			const { filteredNodes } = useNodeMention();
+			const nodeIds = filteredNodes.value.map((n) => n.id);
+
+			expect(nodeIds).not.toContain('node-1');
+			expect(nodeIds).toContain('node-2');
+		});
+
+		it('should filter by search query', () => {
+			const { handleInput, filteredNodes } = useNodeMention();
+
+			const openInput = createMockInput('@', 1);
+			handleInput(createMockInputEvent(), openInput);
+
+			const searchInput = createMockInput('@HTTP', 5);
+			handleInput(createMockInputEvent(), searchInput);
+
+			expect(filteredNodes.value.length).toBe(1);
+			expect(filteredNodes.value[0].name).toBe('HTTP Request');
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useNodeMention.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useNodeMention.ts
@@ -130,8 +130,11 @@ export function useNodeMention(options: UseNodeMentionOptions = {}): UseNodeMent
 		if (!showDropdown.value) {
 			const charBeforeCursor = value.charAt(cursorPosition - 1);
 			if (charBeforeCursor === '@') {
-				openDropdown(inputElement);
-				mentionStartIndex.value = cursorPosition - 1;
+				const charBeforeAt = cursorPosition >= 2 ? value.charAt(cursorPosition - 2) : '';
+				if (!charBeforeAt || /\s/.test(charBeforeAt)) {
+					openDropdown(inputElement);
+					mentionStartIndex.value = cursorPosition - 1;
+				}
 				return;
 			}
 		} else {
@@ -177,7 +180,7 @@ export function useNodeMention(options: UseNodeMentionOptions = {}): UseNodeMent
 
 			case 'Escape':
 				event.preventDefault();
-				closeDropdown(filteredNodes.value.length === 0);
+				closeDropdown();
 				return true;
 
 			case 'Tab':


### PR DESCRIPTION
## Summary

![Kapture 2026-02-17 at 08 54 15](https://github.com/user-attachments/assets/d6348998-6f68-4dd9-b544-f15004dd2bf6)

Fixes [AI-2058](https://linear.app/n8n/issue/AI-2058)

The `@` node mention dropdown was triggering on any `@` character typed in the AI builder chat input, including when typing email addresses (e.g. `eugene@n8n.io`). Additionally, pressing Escape to dismiss the popup would destructively delete the `@` and subsequent characters.

**Changes:**
- Only activate the mention dropdown when `@` is preceded by whitespace or is at the start of input — skip it when `@` follows a word character (as in email addresses)
- Make Escape non-destructive: closing the dropdown now always preserves the typed text
