### PR TITLE
Fix/tools agent enable stream runnable 23851

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/createAgentSequence.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/createAgentSequence.ts
@@ -26,16 +26,22 @@ export function createAgentSequence(
 	model: BaseChatModel,
 	tools: Array<DynamicStructuredTool | Tool>,
 	prompt: ChatPromptTemplate,
-	_options: { maxIterations?: number; returnIntermediateSteps?: boolean },
+	_options: {
+		enableStreaming?: boolean;
+		maxIterations?: number;
+		returnIntermediateSteps?: boolean;
+	},
 	outputParser?: N8nOutputParser,
 	memory?: BaseChatMemory,
 	fallbackModel?: BaseChatModel | null,
 ) {
+	const streamRunnable = _options.enableStreaming === true;
+
 	const agent = createToolCallingAgent({
 		llm: model,
 		tools: getAllTools(model, tools),
 		prompt,
-		streamRunnable: false,
+		streamRunnable,
 	});
 
 	let fallbackAgent: AgentRunnableSequence | undefined;
@@ -44,7 +50,7 @@ export function createAgentSequence(
 			llm: fallbackModel,
 			tools: getAllTools(fallbackModel, tools),
 			prompt,
-			streamRunnable: false,
+			streamRunnable,
 		});
 	}
 	const runnableAgent = RunnableSequence.from([
@@ -54,7 +60,7 @@ export function createAgentSequence(
 	]) as AgentRunnableSequence;
 
 	runnableAgent.singleAction = true;
-	runnableAgent.streamRunnable = false;
+	runnableAgent.streamRunnable = streamRunnable;
 
 	return runnableAgent;
 }

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/createAgentSequence.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/createAgentSequence.test.ts
@@ -61,6 +61,27 @@ describe('createAgentSequence', () => {
 		expect(result.streamRunnable).toBe(false);
 	});
 
+	it('should enable streamRunnable when enableStreaming is true', () => {
+		const mockAgent = mock<any>();
+		const mockRunnableSequence = mock<any>();
+		const mockStepsParser = jest.fn();
+
+		(createToolCallingAgent as jest.Mock).mockReturnValue(mockAgent);
+		(RunnableSequence.from as jest.Mock).mockReturnValue(mockRunnableSequence);
+		jest.spyOn(commonHelpers, 'getAgentStepsParser').mockReturnValue(mockStepsParser);
+
+		const options = { enableStreaming: true, maxIterations: 10, returnIntermediateSteps: false };
+		const result = createAgentSequence(mockModel, [mockTool], mockPrompt, options);
+
+		expect(createToolCallingAgent).toHaveBeenCalledWith({
+			llm: mockModel,
+			tools: [mockTool],
+			prompt: mockPrompt,
+			streamRunnable: true,
+		});
+		expect(result.streamRunnable).toBe(true);
+	});
+
 	it('should create agent sequence with fallback model', () => {
 		const mockFallbackModel = mock<BaseChatModel>();
 		const mockAgent = mock<any>();
@@ -111,6 +132,47 @@ describe('createAgentSequence', () => {
 		]);
 	});
 
+	it('should pass streamRunnable=true to fallback agent when enableStreaming is true', () => {
+		const mockFallbackModel = mock<BaseChatModel>();
+		const mockAgent = mock<any>();
+		const mockFallbackAgent = mock<any>();
+		const mockAgentWithFallback = mock<any>();
+		const mockRunnableSequence = mock<any>();
+		const mockStepsParser = jest.fn();
+
+		mockAgent.withFallbacks = jest.fn().mockReturnValue(mockAgentWithFallback);
+
+		(createToolCallingAgent as jest.Mock)
+			.mockReturnValueOnce(mockAgent)
+			.mockReturnValueOnce(mockFallbackAgent);
+		(RunnableSequence.from as jest.Mock).mockReturnValue(mockRunnableSequence);
+		jest.spyOn(commonHelpers, 'getAgentStepsParser').mockReturnValue(mockStepsParser);
+
+		const options = { enableStreaming: true, maxIterations: 10, returnIntermediateSteps: false };
+		createAgentSequence(
+			mockModel,
+			[mockTool],
+			mockPrompt,
+			options,
+			undefined,
+			undefined,
+			mockFallbackModel,
+		);
+
+		expect(createToolCallingAgent).toHaveBeenNthCalledWith(1, {
+			llm: mockModel,
+			tools: [mockTool],
+			prompt: mockPrompt,
+			streamRunnable: true,
+		});
+		expect(createToolCallingAgent).toHaveBeenNthCalledWith(2, {
+			llm: mockFallbackModel,
+			tools: [mockTool],
+			prompt: mockPrompt,
+			streamRunnable: true,
+		});
+	});
+
 	it('should pass output parser to getAgentStepsParser', () => {
 		const mockAgent = mock<any>();
 		const mockRunnableSequence = mock<any>();
@@ -143,7 +205,7 @@ describe('createAgentSequence', () => {
 		expect(commonHelpers.getAgentStepsParser).toHaveBeenCalledWith(undefined, mockMemory);
 	});
 
-	it('should set streamRunnable to false for agents', () => {
+	it('should set streamRunnable to false for agents by default', () => {
 		const mockAgent = mock<any>();
 		const mockRunnableSequence = mock<any>();
 		const mockStepsParser = jest.fn();


### PR DESCRIPTION
Summary
This PR fixes streaming propagation in Tools Agent V3 for LangChain agents.

When an AI Agent is configured with enableStreaming: true, createAgentSequence still hardcoded streamRunnable: false for:

primary tool-calling agent
fallback tool-calling agent
resulting runnable sequence
That could force non-streaming model invocation even when streaming is explicitly enabled, and can trigger provider-side long-request errors (for example Anthropic-compatible endpoints requiring streaming for long operations).

What changed
Updated createAgentSequence to read enableStreaming from options and propagate it to:
createToolCallingAgent(..., streamRunnable)
fallback createToolCallingAgent(..., streamRunnable)
runnableAgent.streamRunnable
Default behavior remains unchanged when enableStreaming is not set (false).

How to test
Run unit tests for the helper:
pnpm --filter @n8n/n8n-nodes-langchain test -- nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/createAgentSequence.test.ts
Verify new assertions:
default options keep streamRunnable: false
enableStreaming: true sets streamRunnable: true for primary agent
enableStreaming: true sets streamRunnable: true for fallback agent
resulting runnable sequence has streamRunnable: true when enabled
Related Linear tickets, Github issues, and Community forum posts
Fixes #23851 https://github.com/n8n-io/n8n/issues/23851

Review / Merge checklist
 PR title and summary are descriptive. (
 Docs updated or follow-up ticket created.
Not required for this internal runtime fix (no user-facing docs change expected).
 Tests included.
 PR labeled with release/backport (only if maintainers decide this should be backported as urgent).