### PR TITLE
fix(editor): Fix incorrect shortcut resolution for letter keys on non-QWERTY

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useKeybindings.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useKeybindings.ts
@@ -180,21 +180,31 @@ export const useKeybindings = (
 		};
 	}
 
+	// Resolution strategy:
+	// 1. Prefer `byKey` (event.key) so shortcuts follow the logical character
+	//    produced by the active keyboard layout (works correctly for QWERTY,
+	//    Dvorak, and most non-ANSI layouts).
+	// 2. For letter keys (KeyA–KeyZ), do NOT fall back to `byCode` (physical key
+	//    position). Falling back to `byCode` can remap one letter to another on
+	//    alternative layouts (e.g. Colemak), causing unintended matches such as
+	//    CMD+R triggering the CMD+S handler.
+	// 3. Use `byLayout` (Keyboard Layout Map API) as a layout-aware fallback
+	//    when available. This helps in cases where `event.key` is unreliable
+	//    (e.g. certain macOS modifier combinations or dead keys).
+	// 4. For non-letter keys (arrows, function keys, etc.), allow `byCode` as a
+	//    last resort to ensure consistent physical-key behavior across layouts.
 	function onKeyDown(event: KeyboardEvent) {
 		if (ignoreKeyPresses.value || isDisabled.value) return;
 
 		const { byKey, byCode, byLayout } = toShortcutString(event);
 
-		// Prefer `byKey` over `byCode` so that:
-		// - ANSI layouts work correctly
-		// - Dvorak works correctly
-		// - Non-ansi layouts work correctly
-		// Fall back to `byLayout` (Keyboard Layout Map API) for layouts like
-		// Colemak where macOS Alt+key produces dead keys
-		const handler =
-			normalizedKeymap.value[byKey] ??
-			normalizedKeymap.value[byCode] ??
-			(byLayout ? normalizedKeymap.value[byLayout] : undefined);
+		const isLetterKey = typeof event.code === 'string' && event.code.startsWith('Key'); // KeyA..KeyZ
+
+		const handlerFromKey = normalizedKeymap.value[byKey];
+		const handlerFromLayout = byLayout ? normalizedKeymap.value[byLayout] : undefined;
+		const handlerFromCode = !isLetterKey ? normalizedKeymap.value[byCode] : undefined;
+
+		const handler = handlerFromKey ?? handlerFromLayout ?? handlerFromCode;
 		const run =
 			typeof handler === 'function' ? handler : handler?.disabled() ? undefined : handler?.run;
 

--- a/packages/frontend/editor-ui/src/app/composables/useKeybindings.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useKeybindings.ts
@@ -183,26 +183,34 @@ export const useKeybindings = (
 	// Resolution strategy:
 	// 1. Prefer `byKey` (event.key) so shortcuts follow the logical character
 	//    produced by the active keyboard layout (works correctly for QWERTY,
-	//    Dvorak, and most non-ANSI layouts).
-	// 2. For letter keys (KeyA–KeyZ), do NOT fall back to `byCode` (physical key
-	//    position). Falling back to `byCode` can remap one letter to another on
-	//    alternative layouts (e.g. Colemak), causing unintended matches such as
-	//    CMD+R triggering the CMD+S handler.
-	// 3. Use `byLayout` (Keyboard Layout Map API) as a layout-aware fallback
-	//    when available. This helps in cases where `event.key` is unreliable
-	//    (e.g. certain macOS modifier combinations or dead keys).
-	// 4. For non-letter keys (arrows, function keys, etc.), allow `byCode` as a
+	//    Colemak/Dvorak, and most layouts).
+	// 2. Use `byLayout` (Keyboard Layout Map API) as a layout-aware fallback when
+	//    available. This helps in cases where `event.key` is unreliable (e.g.
+	//    certain macOS modifier combinations or dead keys).
+	// 3. Avoid falling back to `byCode` (physical key position) for letter keys
+	//    when the active layout produces Latin letters (a–z). Physical fallback
+	//    can remap one letter to another on alternative layouts (e.g. Colemak),
+	//    causing unintended matches such as CMD+R triggering a CMD+S handler.
+	// 4. For non-Latin layouts (Hebrew, Russian, etc.), allow `byCode` fallback for
+	//    Ctrl/Cmd-modified letter shortcuts so common shortcuts like Ctrl/Cmd+C
+	//    still work even when the key produces a non-Latin character.
+	// 5. For non-letter keys (arrows, function keys, etc.), allow `byCode` as a
 	//    last resort to ensure consistent physical-key behavior across layouts.
 	function onKeyDown(event: KeyboardEvent) {
 		if (ignoreKeyPresses.value || isDisabled.value) return;
 
 		const { byKey, byCode, byLayout } = toShortcutString(event);
 
-		const isLetterKey = typeof event.code === 'string' && event.code.startsWith('Key'); // KeyA..KeyZ
+		const isLetterKey = event.code.startsWith('Key'); // KeyA..KeyZ
+		const isLatinLetter = /^[a-z]$/i.test(event.key);
+		const isNonLatinLetter = /^\p{L}$/u.test(event.key) && !isLatinLetter;
+		const ctrlOrCmd = isCtrlKeyPressed(event);
+
+		const useCodeFallback = !isLetterKey || (ctrlOrCmd && isNonLatinLetter);
 
 		const handlerFromKey = normalizedKeymap.value[byKey];
 		const handlerFromLayout = byLayout ? normalizedKeymap.value[byLayout] : undefined;
-		const handlerFromCode = !isLetterKey ? normalizedKeymap.value[byCode] : undefined;
+		const handlerFromCode = useCodeFallback ? normalizedKeymap.value[byCode] : undefined;
 
 		const handler = handlerFromKey ?? handlerFromLayout ?? handlerFromCode;
 		const run =


### PR DESCRIPTION
## Summary

Fix incorrect shortcut resolution for letter keys on non-QWERTY layouts (e.g. Colemak).

Previously, we fell back to `event.code` (physical key position) when resolving shortcuts. For letter keys (`KeyA`-`KeyZ`), this could remap one letter to another and trigger unintended handlers (e.g. Colemak `CMD+R` being interpreted as `CMD+S` and opening the Name version modal).

We now:
- Resolve shortcuts logically via `event.key` (`byKey`)
- Use the Keyboard Layout Map API (`byLayout`) as a fallback when available
- Skip `byCode` fallback for letter keys
- Keep `byCode` only as a last resort for non-letter keys (arrows, function keys, etc.)

### How to test

1. QWERTY (default layout)
- Open a workflow
- `CMD+S` → Name version modal is opened
- `CMD+R` → Browser refresh
- Other letter shortcuts behave as before

2. Colemak (macOS)
- Switch to Colemak in system keyboard settings
- Open a workflow
- `CMD+S` (`CMD+D` on QWERTY) → Name version modal is opened
- `CMD+R` (`CMD+S` on QWERTY) → Browser refresh
- `CMD+P` (`CMD+R` on QWERTY) → Nothing happens
- Other letter shortcuts follow the layout correctly

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-4836](https://linear.app/n8n/issue/ADO-4836/cmdr-maps-incorrectly-to-cmds-when-using-colemak-layout)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
