### PR TITLE
fix(editor): Normalize `pinData` field in workflow document state (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -62,6 +62,10 @@ import {
 	useWorkflowState,
 	type WorkflowState,
 } from '@/app/composables/useWorkflowState';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 
 import { useRouter } from 'vue-router';
 import { useTemplatesStore } from '@/features/workflows/templates/templates.store';
@@ -146,6 +150,7 @@ vi.mock('@/app/composables/useWorkflowState', async () => {
 const canPinNodeMock = vi.fn();
 const setDataMock = vi.fn();
 const unsetDataMock = vi.fn();
+const hasDataRef = { value: false };
 const getInputDataWithPinnedMock = vi.fn();
 
 vi.mock('@/app/composables/usePinnedData', () => {
@@ -154,6 +159,7 @@ vi.mock('@/app/composables/usePinnedData', () => {
 			canPinNode: canPinNodeMock,
 			setData: setDataMock,
 			unsetData: unsetDataMock,
+			hasData: hasDataRef,
 		})),
 	};
 });
@@ -1841,6 +1847,7 @@ describe('useCanvasOperations', () => {
 			setDataMock.mockReset();
 			unsetDataMock.mockReset();
 			getInputDataWithPinnedMock.mockReset();
+			hasDataRef.value = false;
 		});
 
 		it('should only pin pinnable nodes when mix of pinnable and non-pinnable nodes are selected', () => {
@@ -1855,7 +1862,7 @@ describe('useCanvasOperations', () => {
 			workflowsStore.getNodesByIds.mockReturnValue(nodes);
 
 			// Initially, none have pinned data
-			workflowsStore.pinDataByNodeName = vi.fn().mockReturnValue(undefined);
+			workflowsStore.workflow.pinData = {};
 
 			let checkIndex = 0;
 			const nodeOrder: string[] = [];
@@ -1893,13 +1900,8 @@ describe('useCanvasOperations', () => {
 			const nodes = [pinnableNode1, nonPinnableNode, pinnableNode2];
 			workflowsStore.getNodesByIds.mockReturnValue(nodes);
 
-			// Set some initial pinned data for pinnable nodes
-			workflowsStore.pinDataByNodeName = vi.fn().mockImplementation((nodeName: string) => {
-				if (nodeName === 'PinnableNode1' || nodeName === 'PinnableNode2') {
-					return [{ json: { pinned: 'data' } }];
-				}
-				return undefined;
-			});
+			// Indicate all pinnable nodes have pinned data
+			hasDataRef.value = true;
 
 			let checkIndex = 0;
 
@@ -1930,7 +1932,7 @@ describe('useCanvasOperations', () => {
 			const nodes = [nonPinnableNode1, nonPinnableNode2];
 			workflowsStore.getNodesByIds.mockReturnValue(nodes);
 
-			workflowsStore.pinDataByNodeName = vi.fn().mockReturnValue(undefined);
+			workflowsStore.workflow.pinData = {};
 			canPinNodeMock.mockReturnValue(false);
 
 			const { toggleNodesPinned } = useCanvasOperations();
@@ -4115,8 +4117,11 @@ describe('useCanvasOperations', () => {
 		});
 
 		it('should clear workflow pin data if execution mode is not manual', async () => {
-			const setWorkflowPinDataSpy = vi.spyOn(workflowState, 'setWorkflowPinData');
 			const workflowsStore = mockedStore(useWorkflowsStore);
+			const workflowDocumentStore = useWorkflowDocumentStore(
+				createWorkflowDocumentId(workflowsStore.workflowId),
+			);
+			const setPinDataSpy = vi.spyOn(workflowDocumentStore, 'setPinData');
 			const { openExecution } = useCanvasOperations();
 
 			const executionId = '123';
@@ -4134,7 +4139,7 @@ describe('useCanvasOperations', () => {
 
 			await openExecution(executionId);
 
-			expect(setWorkflowPinDataSpy).toHaveBeenCalledWith({});
+			expect(setPinDataSpy).toHaveBeenCalledWith({});
 		});
 		it('should show an error notification for failed executions', async () => {
 			const workflowsStore = mockedStore(useWorkflowsStore);

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -1861,9 +1861,6 @@ describe('useCanvasOperations', () => {
 			const nodes = [pinnableNode1, nonPinnableNode, pinnableNode2];
 			workflowsStore.getNodesByIds.mockReturnValue(nodes);
 
-			// Initially, none have pinned data
-			workflowsStore.workflow.pinData = {};
-
 			let checkIndex = 0;
 			const nodeOrder: string[] = [];
 
@@ -1932,7 +1929,6 @@ describe('useCanvasOperations', () => {
 			const nodes = [nonPinnableNode1, nonPinnableNode2];
 			workflowsStore.getNodesByIds.mockReturnValue(nodes);
 
-			workflowsStore.workflow.pinData = {};
 			canPinNodeMock.mockReturnValue(false);
 
 			const { toggleNodesPinned } = useCanvasOperations();

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -138,6 +138,7 @@ import { useClipboard } from '@vueuse/core';
 import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
+	pinDataToExecutionData,
 } from '@/app/stores/workflowDocument.store';
 
 type AddNodeData = Partial<INodeUi> & {
@@ -2764,10 +2765,12 @@ export function useCanvasOperations() {
 			const workflowDocumentStore = workflowsStore.workflowId
 				? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
 				: null;
-			const pinDataForNode = workflowDocumentStore?.pinDataByNodeName(node.name);
+			const pinDataForNode = workflowDocumentStore
+				? pinDataToExecutionData(workflowDocumentStore.pinData)[node.name]
+				: undefined;
 
 			if (pinDataForNode) {
-				data.pinData[node.name] = pinDataForNode;
+				data.pinData[node.name] = pinDataForNode as IPinData[string];
 			}
 
 			if (

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -679,16 +679,15 @@ export function useCanvasOperations() {
 		const nodes = workflowsStore.getNodesByIds(ids);
 
 		// Filter to only pinnable nodes
-		const pinnableNodes = nodes.filter((node) => {
-			const pinnedDataForNode = usePinnedData(node);
-			return pinnedDataForNode.canPinNode(true);
-		});
-		const nextStatePinned = pinnableNodes.some(
-			(node) => !workflowsStore.pinDataByNodeName(node.name),
+		const pinnableNodesWithPinnedData = nodes
+			.map((node) => ({ node, pinnedData: usePinnedData(node) }))
+			.filter(({ pinnedData }) => pinnedData.canPinNode(true));
+
+		const nextStatePinned = pinnableNodesWithPinnedData.some(
+			({ pinnedData }) => !pinnedData.hasData.value,
 		);
 
-		for (const node of pinnableNodes) {
-			const pinnedDataForNode = usePinnedData(node);
+		for (const { node, pinnedData: pinnedDataForNode } of pinnableNodesWithPinnedData) {
 			if (nextStatePinned) {
 				const dataToPin = useDataSchema().getInputDataWithPinned(node);
 				if (dataToPin.length !== 0) {
@@ -2762,7 +2761,10 @@ export function useCanvasOperations() {
 
 		for (const node of nodes) {
 			const nodeSaveData = workflowHelpers.getNodeDataToSave(node);
-			const pinDataForNode = workflowsStore.pinDataByNodeName(node.name);
+			const workflowDocumentStore = workflowsStore.workflowId
+				? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+				: null;
+			const pinDataForNode = workflowDocumentStore?.pinDataByNodeName(node.name);
 
 			if (pinDataForNode) {
 				data.pinData[node.name] = pinDataForNode;
@@ -2899,7 +2901,12 @@ export function useCanvasOperations() {
 		workflowState.setWorkflowExecutionData(data);
 
 		if (!['manual', 'evaluation'].includes(data.mode)) {
-			workflowState.setWorkflowPinData({});
+			if (workflowsStore.workflowId) {
+				const workflowDocumentStore = useWorkflowDocumentStore(
+					createWorkflowDocumentId(workflowsStore.workflowId),
+				);
+				workflowDocumentStore.setPinData({});
+			}
 		}
 
 		if (nodeId) {

--- a/packages/frontend/editor-ui/src/app/composables/useDataSchema.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useDataSchema.ts
@@ -8,6 +8,10 @@ import type {
 	SchemaType,
 } from '@/Interface';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { generatePath, getNodeParentExpression } from '@/app/utils/mappingUtils';
 import { isObject } from '@/app/utils/objectUtils';
 import { isObj } from '@/app/utils/typeGuards';
@@ -206,8 +210,11 @@ export function useDataSchema() {
 	): INodeExecutionData[] {
 		if (!node) return [];
 
-		const { pinDataByNodeName } = useWorkflowsStore();
-		const pinnedData = pinDataByNodeName(node.name);
+		const workflowsStore = useWorkflowsStore();
+		const workflowDocumentStore = workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined;
+		const pinnedData = workflowDocumentStore?.getNodePinData(node.name)?.map((item) => item.json);
 		let inputData = getNodeInputData(node, runIndex, outputIndex);
 
 		if (pinnedData) {

--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
@@ -48,6 +48,10 @@ import { hasPermission } from '@/app/utils/rbac/permissions';
 import { useCanvasStore } from '@/app/stores/canvas.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { injectWorkflowState, type WorkflowState } from './useWorkflowState';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 
 declare namespace HttpRequestNode {
 	namespace V2 {
@@ -187,7 +191,10 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 		workflow: Workflow,
 		ignoreIssues?: string[],
 	): INodeIssues | null {
-		const pinDataNodeNames = Object.keys(workflowsStore.pinnedWorkflowData ?? {});
+		const workflowDocumentStore = workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined;
+		const pinDataNodeNames = Object.keys(workflowDocumentStore?.pinData ?? {});
 
 		let nodeIssues: INodeIssues | null = null;
 		ignoreIssues = ignoreIssues ?? [];

--- a/packages/frontend/editor-ui/src/app/composables/usePinnedData.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePinnedData.test.ts
@@ -5,6 +5,10 @@ import { usePinnedData } from '@/app/composables/usePinnedData';
 import type { INodeUi } from '@/Interface';
 import { HTTP_REQUEST_NODE_TYPE, IF_NODE_TYPE, MAX_PINNED_DATA_SIZE } from '@/app/constants';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { NodeConnectionTypes, STICKY_NODE_TYPE } from 'n8n-workflow';
 import type { NodeConnectionType, INodeTypeDescription } from 'n8n-workflow';
@@ -81,18 +85,23 @@ describe('usePinnedData', () => {
 
 		it('should set data correctly for valid inputs', () => {
 			const workflowsStore = useWorkflowsStore();
+			workflowsStore.workflow.id = 'test-workflow';
 			const node = ref({ name: 'testNode' } as INodeUi);
 			const { setData } = usePinnedData(node);
 			const testData = [{ json: { key: 'value' } }];
 
 			expect(() => setData(testData, 'pin-icon-click')).not.toThrow();
-			expect(workflowsStore.workflow.pinData?.[node.value.name]).toEqual(testData);
+			const workflowDocumentStore = useWorkflowDocumentStore(
+				createWorkflowDocumentId(workflowsStore.workflow.id),
+			);
+			expect(workflowDocumentStore.pinData?.[node.value.name]).toEqual(testData);
 		});
 	});
 
 	describe('unsetData()', () => {
 		it('should unset data correctly', () => {
 			const workflowsStore = useWorkflowsStore();
+			workflowsStore.workflow.id = 'test-workflow';
 			const node = ref({ name: 'testNode' } as INodeUi);
 			const { setData, unsetData } = usePinnedData(node);
 			const testData = [{ json: { key: 'value' } }];
@@ -100,7 +109,10 @@ describe('usePinnedData', () => {
 			setData(testData, 'pin-icon-click');
 			unsetData('context-menu');
 
-			expect(workflowsStore.workflow.pinData?.[node.value.name]).toBeUndefined();
+			const workflowDocumentStore = useWorkflowDocumentStore(
+				createWorkflowDocumentId(workflowsStore.workflow.id),
+			);
+			expect(workflowDocumentStore.pinData?.[node.value.name]).toBeUndefined();
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/composables/usePinnedData.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePinnedData.ts
@@ -10,6 +10,13 @@ import {
 } from '@/app/constants';
 import { stringSizeInBytes, toMegaBytes } from '@/app/utils/typesUtils';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useUIStore } from '@/app/stores/ui.store';
+import {
+	injectWorkflowDocumentStore,
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+	getPinDataSize,
+} from '@/app/stores/workflowDocument.store';
 import type { INodeUi, IRunDataDisplayMode } from '@/Interface';
 import { useExternalHooks } from '@/app/composables/useExternalHooks';
 import { useTelemetry } from '@/app/composables/useTelemetry';
@@ -45,6 +52,12 @@ export function usePinnedData(
 ) {
 	const rootStore = useRootStore();
 	const workflowsStore = useWorkflowsStore();
+	const uiStore = useUIStore();
+	const workflowDocumentStore =
+		injectWorkflowDocumentStore() ??
+		(workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: null);
 	const toast = useToast();
 	const i18n = useI18n();
 	const telemetry = useTelemetry();
@@ -59,7 +72,7 @@ export function usePinnedData(
 
 	const data = computed<IPinData[string] | undefined>(() => {
 		const targetNode = unref(node);
-		return targetNode ? workflowsStore.pinDataByNodeName(targetNode.name) : undefined;
+		return targetNode ? workflowDocumentStore?.pinDataByNodeName(targetNode.name) : undefined;
 	});
 
 	const hasData = computed<boolean>(() => {
@@ -164,11 +177,12 @@ export function usePinnedData(
 
 		if (typeof data === 'object') data = JSON.stringify(data);
 
-		const { pinData: currentPinData, ...workflowObjectWithoutPinData } = workflowObject.value;
+		const { pinData: _pinData, ...workflowObjectWithoutPinData } = workflowObject.value;
+		const currentPinData = (workflowDocumentStore?.pinData ?? {}) as IPinData;
 		const workflowJson = jsonStringify(workflowObjectWithoutPinData, { replaceCircularRefs: true });
 
 		const newPinData = { ...currentPinData, [targetNode.name]: data };
-		const newPinDataSize = workflowsStore.getPinDataSize(newPinData);
+		const newPinDataSize = getPinDataSize(newPinData);
 
 		if (newPinDataSize > getMaxPinnedDataSize()) {
 			toast.showError(
@@ -265,7 +279,18 @@ export function usePinnedData(
 			throw new Error('Data too large');
 		}
 
-		workflowsStore.pinData({ node: targetNode, data: data as INodeExecutionData[] });
+		if (workflowDocumentStore) {
+			const nodeName = targetNode.name;
+			// Update metadata timestamp for existing pinned data
+			if (
+				(workflowDocumentStore.pinData[nodeName] ?? []).length > 0 &&
+				workflowsStore.nodeMetadata[nodeName]
+			) {
+				workflowsStore.nodeMetadata[nodeName].pinnedDataLastUpdatedAt = Date.now();
+			}
+			workflowDocumentStore.pinNodeData(nodeName, data as INodeExecutionData[]);
+			uiStore.markStateDirty();
+		}
 		onSetDataSuccess({ source });
 	}
 
@@ -289,7 +314,13 @@ export function usePinnedData(
 		}
 
 		onUnsetData({ source });
-		workflowsStore.unpinData({ node: targetNode });
+		if (workflowDocumentStore) {
+			workflowDocumentStore.unpinNodeData(targetNode.name);
+			if (workflowsStore.nodeMetadata[targetNode.name]) {
+				workflowsStore.nodeMetadata[targetNode.name].pinnedDataLastRemovedAt = Date.now();
+			}
+			uiStore.markStateDirty();
+		}
 	}
 
 	return {

--- a/packages/frontend/editor-ui/src/app/composables/usePinnedData.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePinnedData.ts
@@ -1,6 +1,6 @@
 import { useToast } from '@/app/composables/useToast';
 import { useI18n } from '@n8n/i18n';
-import type { INodeExecutionData, IPinData, Workflow } from 'n8n-workflow';
+import type { IDataObject, INodeExecutionData, IPinData, Workflow } from 'n8n-workflow';
 import { jsonParse, jsonStringify, NodeConnectionTypes, NodeHelpers } from 'n8n-workflow';
 import {
 	MAX_EXPECTED_REQUEST_SIZE,
@@ -16,6 +16,7 @@ import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
 	getPinDataSize,
+	pinDataToExecutionData,
 } from '@/app/stores/workflowDocument.store';
 import type { INodeUi, IRunDataDisplayMode } from '@/Interface';
 import { useExternalHooks } from '@/app/composables/useExternalHooks';
@@ -70,9 +71,10 @@ export function usePinnedData(
 		node,
 	});
 
-	const data = computed<IPinData[string] | undefined>(() => {
+	const data = computed<IDataObject[] | undefined>(() => {
 		const targetNode = unref(node);
-		return targetNode ? workflowDocumentStore?.pinDataByNodeName(targetNode.name) : undefined;
+		if (!targetNode || !workflowDocumentStore) return undefined;
+		return pinDataToExecutionData(workflowDocumentStore.pinData)[targetNode.name];
 	});
 
 	const hasData = computed<boolean>(() => {

--- a/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.test.ts
@@ -1,0 +1,352 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { shallowRef } from 'vue';
+import { setActivePinia } from 'pinia';
+import { createTestingPinia } from '@pinia/testing';
+import { usePostMessageHandler } from './usePostMessageHandler';
+import type { WorkflowState } from '@/app/composables/useWorkflowState';
+import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
+
+const mockImportWorkflowExact = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock('@/app/composables/useWorkflowImport', () => ({
+	useWorkflowImport: vi.fn(() => ({
+		importWorkflowExact: mockImportWorkflowExact,
+	})),
+}));
+
+const mockResetWorkspace = vi.hoisted(() => vi.fn());
+const mockOpenExecution = vi.hoisted(() => vi.fn().mockResolvedValue(null));
+const mockFitView = vi.hoisted(() => vi.fn());
+vi.mock('@/app/composables/useCanvasOperations', () => ({
+	useCanvasOperations: vi.fn(() => ({
+		resetWorkspace: mockResetWorkspace,
+		openExecution: mockOpenExecution,
+		fitView: mockFitView,
+	})),
+}));
+
+const mockIsProductionExecutionPreview = vi.hoisted(() => ({ value: false }));
+vi.mock('@/app/composables/useNodeHelpers', () => ({
+	useNodeHelpers: vi.fn(() => ({
+		isProductionExecutionPreview: mockIsProductionExecutionPreview,
+		updateNodesInputIssues: vi.fn(),
+		updateNodesCredentialsIssues: vi.fn(),
+	})),
+}));
+
+vi.mock('@/app/composables/useExternalHooks', () => ({
+	useExternalHooks: vi.fn(() => ({
+		run: vi.fn().mockResolvedValue(undefined),
+	})),
+}));
+
+vi.mock('@/app/composables/useTelemetry', () => ({
+	useTelemetry: vi.fn(() => ({
+		track: vi.fn(),
+	})),
+}));
+
+vi.mock('@/app/composables/useToast', () => ({
+	useToast: vi.fn(() => ({
+		showError: vi.fn(),
+		showMessage: vi.fn(),
+	})),
+}));
+
+const mockCanvasEventBusEmit = vi.hoisted(() => vi.fn());
+vi.mock('@/features/workflows/canvas/canvas.eventBus', () => ({
+	canvasEventBus: {
+		emit: mockCanvasEventBusEmit,
+	},
+}));
+
+const mockBuildExecutionResponseFromSchema = vi.hoisted(() =>
+	vi.fn().mockReturnValue({ workflowData: { id: 'w1' } } as unknown as IExecutionResponse),
+);
+vi.mock('@/features/execution/executions/executions.utils', async (importOriginal) => {
+	const actual = (await importOriginal()) as object;
+	return {
+		...actual,
+		buildExecutionResponseFromSchema: mockBuildExecutionResponseFromSchema,
+	};
+});
+
+vi.mock('vue-router', async (importOriginal) => {
+	const actual = (await importOriginal()) as object;
+	return {
+		...actual,
+		useRoute: vi.fn(() => ({ name: 'workflow' })),
+	};
+});
+
+function createMockWorkflowState(): WorkflowState {
+	return {
+		setWorkflowExecutionData: vi.fn(),
+	} as unknown as WorkflowState;
+}
+
+describe('usePostMessageHandler', () => {
+	let workflowState: WorkflowState;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		setActivePinia(createTestingPinia());
+		mockIsProductionExecutionPreview.value = false;
+		workflowState = createMockWorkflowState();
+	});
+
+	afterEach(() => {
+		// Ensure listeners are cleaned up
+	});
+
+	describe('setup and cleanup', () => {
+		it('should add message event listener on setup', () => {
+			const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+			const { setup } = usePostMessageHandler({
+				workflowState,
+				currentWorkflowDocumentStore: shallowRef(null),
+			});
+
+			setup();
+
+			expect(addEventListenerSpy).toHaveBeenCalledWith('message', expect.any(Function));
+		});
+
+		it('should remove message event listener on cleanup', () => {
+			const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+			const { setup, cleanup } = usePostMessageHandler({
+				workflowState,
+				currentWorkflowDocumentStore: shallowRef(null),
+			});
+
+			setup();
+			cleanup();
+
+			expect(removeEventListenerSpy).toHaveBeenCalledWith('message', expect.any(Function));
+		});
+
+		it('should emit n8nReady postMessage on setup', () => {
+			const postMessageSpy = vi.spyOn(window.parent, 'postMessage');
+			const { setup, cleanup } = usePostMessageHandler({
+				workflowState,
+				currentWorkflowDocumentStore: shallowRef(null),
+			});
+
+			setup();
+
+			expect(postMessageSpy).toHaveBeenCalledWith(
+				expect.stringContaining('"command":"n8nReady"'),
+				'*',
+			);
+
+			cleanup();
+		});
+	});
+
+	describe('openWorkflow command', () => {
+		it('should call importWorkflowExact when openWorkflow message is received', async () => {
+			const { setup, cleanup } = usePostMessageHandler({
+				workflowState,
+				currentWorkflowDocumentStore: shallowRef(null),
+			});
+			setup();
+
+			const workflow = { nodes: [], connections: {} };
+			const messageEvent = new MessageEvent('message', {
+				data: JSON.stringify({ command: 'openWorkflow', workflow }),
+			});
+			window.dispatchEvent(messageEvent);
+
+			// Wait for async handler
+			await vi.waitFor(() => {
+				expect(mockImportWorkflowExact).toHaveBeenCalledWith(expect.objectContaining({ workflow }));
+			});
+
+			cleanup();
+		});
+
+		it('should emit tidyUp event when tidyUp is true', async () => {
+			const { setup, cleanup } = usePostMessageHandler({
+				workflowState,
+				currentWorkflowDocumentStore: shallowRef(null),
+			});
+			setup();
+
+			const messageEvent = new MessageEvent('message', {
+				data: JSON.stringify({
+					command: 'openWorkflow',
+					workflow: { nodes: [], connections: {} },
+					tidyUp: true,
+				}),
+			});
+			window.dispatchEvent(messageEvent);
+
+			await vi.waitFor(() => {
+				expect(mockCanvasEventBusEmit).toHaveBeenCalledWith('tidyUp', {
+					source: 'import-workflow-data',
+				});
+			});
+
+			cleanup();
+		});
+	});
+
+	describe('openExecution command', () => {
+		it('should set isProductionExecutionPreview for non-manual executions', async () => {
+			mockOpenExecution.mockResolvedValue({
+				workflowData: { id: 'w1', name: 'Test' },
+				mode: 'trigger',
+				finished: true,
+			});
+
+			const { setup, cleanup } = usePostMessageHandler({
+				workflowState,
+				currentWorkflowDocumentStore: shallowRef(null),
+			});
+			setup();
+
+			const messageEvent = new MessageEvent('message', {
+				data: JSON.stringify({
+					command: 'openExecution',
+					executionId: 'exec-1',
+					executionMode: 'trigger',
+				}),
+			});
+			window.dispatchEvent(messageEvent);
+
+			await vi.waitFor(() => {
+				expect(mockIsProductionExecutionPreview.value).toBe(true);
+			});
+
+			cleanup();
+		});
+
+		it('should not set isProductionExecutionPreview for manual executions', async () => {
+			mockOpenExecution.mockResolvedValue({
+				workflowData: { id: 'w1', name: 'Test' },
+				mode: 'manual',
+				finished: true,
+			});
+
+			const { setup, cleanup } = usePostMessageHandler({
+				workflowState,
+				currentWorkflowDocumentStore: shallowRef(null),
+			});
+			setup();
+
+			const messageEvent = new MessageEvent('message', {
+				data: JSON.stringify({
+					command: 'openExecution',
+					executionId: 'exec-1',
+					executionMode: 'manual',
+				}),
+			});
+			window.dispatchEvent(messageEvent);
+
+			await vi.waitFor(() => {
+				expect(mockOpenExecution).toHaveBeenCalled();
+			});
+
+			expect(mockIsProductionExecutionPreview.value).toBe(false);
+
+			cleanup();
+		});
+	});
+
+	describe('openExecutionPreview command', () => {
+		it('should call importWorkflowExact and set execution data', async () => {
+			const mockSetPinData = vi.fn();
+			const storeRef = shallowRef({ setPinData: mockSetPinData } as never);
+			const mockExecutionData = {
+				workflowData: { id: 'w1' },
+			} as unknown as IExecutionResponse;
+			mockBuildExecutionResponseFromSchema.mockReturnValue(mockExecutionData);
+
+			const { setup, cleanup } = usePostMessageHandler({
+				workflowState,
+				currentWorkflowDocumentStore: storeRef,
+			});
+			setup();
+
+			const messageEvent = new MessageEvent('message', {
+				data: JSON.stringify({
+					command: 'openExecutionPreview',
+					workflow: { nodes: [{ name: 'Node1' }], connections: {} },
+					nodeExecutionSchema: {},
+					executionStatus: 'success',
+				}),
+			});
+			window.dispatchEvent(messageEvent);
+
+			await vi.waitFor(() => {
+				expect(mockImportWorkflowExact).toHaveBeenCalled();
+			});
+
+			expect(workflowState.setWorkflowExecutionData).toHaveBeenCalledWith(mockExecutionData);
+			expect(mockSetPinData).toHaveBeenCalledWith({});
+
+			cleanup();
+		});
+
+		it('should throw if workflow has no nodes', async () => {
+			const { setup, cleanup } = usePostMessageHandler({
+				workflowState,
+				currentWorkflowDocumentStore: shallowRef(null),
+			});
+			setup();
+
+			const messageEvent = new MessageEvent('message', {
+				data: JSON.stringify({
+					command: 'openExecutionPreview',
+					workflow: { connections: {} },
+					nodeExecutionSchema: {},
+					executionStatus: 'success',
+				}),
+			});
+			window.dispatchEvent(messageEvent);
+
+			// The error is caught internally, so we check that importWorkflowExact was not called
+			await vi.waitFor(() => {
+				expect(mockImportWorkflowExact).not.toHaveBeenCalled();
+			});
+
+			cleanup();
+		});
+	});
+
+	describe('message filtering', () => {
+		it('should ignore non-string messages', async () => {
+			const { setup, cleanup } = usePostMessageHandler({
+				workflowState,
+				currentWorkflowDocumentStore: shallowRef(null),
+			});
+			setup();
+
+			const messageEvent = new MessageEvent('message', { data: 123 });
+			window.dispatchEvent(messageEvent);
+
+			// Give async handlers time to run
+			await new Promise((r) => setTimeout(r, 10));
+			expect(mockImportWorkflowExact).not.toHaveBeenCalled();
+
+			cleanup();
+		});
+
+		it('should ignore messages without "command" in data', async () => {
+			const { setup, cleanup } = usePostMessageHandler({
+				workflowState,
+				currentWorkflowDocumentStore: shallowRef(null),
+			});
+			setup();
+
+			const messageEvent = new MessageEvent('message', {
+				data: JSON.stringify({ action: 'something' }),
+			});
+			window.dispatchEvent(messageEvent);
+
+			await new Promise((r) => setTimeout(r, 10));
+			expect(mockImportWorkflowExact).not.toHaveBeenCalled();
+
+			cleanup();
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.ts
@@ -1,0 +1,218 @@
+import { nextTick, type ShallowRef } from 'vue';
+import { useI18n } from '@n8n/i18n';
+import type { ExecutionStatus, ExecutionSummary } from 'n8n-workflow';
+import { useToast } from '@/app/composables/useToast';
+import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
+import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
+import { useExternalHooks } from '@/app/composables/useExternalHooks';
+import { useTelemetry } from '@/app/composables/useTelemetry';
+import { useCanvasStore } from '@/app/stores/canvas.store';
+import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
+import { useExecutionsStore } from '@/features/execution/executions/executions.store';
+import { useRootStore } from '@n8n/stores/useRootStore';
+import { canvasEventBus } from '@/features/workflows/canvas/canvas.eventBus';
+import { buildExecutionResponseFromSchema } from '@/features/execution/executions/executions.utils';
+import type { ExecutionPreviewNodeSchema } from '@/features/execution/executions/executions.types';
+import type { IWorkflowDb } from '@/Interface';
+import type { WorkflowDataUpdate } from '@n8n/rest-api-client/api/workflows';
+import type { WorkflowState } from '@/app/composables/useWorkflowState';
+import type { useWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import { useWorkflowImport } from '@/app/composables/useWorkflowImport';
+
+interface PostMessageHandlerDeps {
+	workflowState: WorkflowState;
+	currentWorkflowDocumentStore: ShallowRef<ReturnType<typeof useWorkflowDocumentStore> | null>;
+}
+
+export function usePostMessageHandler({
+	workflowState,
+	currentWorkflowDocumentStore,
+}: PostMessageHandlerDeps) {
+	const i18n = useI18n();
+	const toast = useToast();
+	const canvasStore = useCanvasStore();
+	const projectsStore = useProjectsStore();
+	const executionsStore = useExecutionsStore();
+	const rootStore = useRootStore();
+	const externalHooks = useExternalHooks();
+	const telemetry = useTelemetry();
+	const nodeHelpers = useNodeHelpers();
+
+	const { resetWorkspace, openExecution, fitView } = useCanvasOperations();
+	const { importWorkflowExact } = useWorkflowImport(currentWorkflowDocumentStore);
+
+	function emitPostMessageReady() {
+		if (window.parent) {
+			window.parent.postMessage(
+				JSON.stringify({ command: 'n8nReady', version: rootStore.versionCli }),
+				'*',
+			);
+		}
+	}
+
+	function reportErrorToParent(message: string) {
+		if (window.top) {
+			window.top.postMessage(JSON.stringify({ command: 'error', message }), '*');
+		}
+	}
+
+	async function handleOpenWorkflow(json: {
+		workflow: WorkflowDataUpdate;
+		projectId?: string;
+		tidyUp?: boolean;
+	}) {
+		if (json.projectId) {
+			await projectsStore.fetchAndSetProject(json.projectId);
+		}
+		await importWorkflowExact(json);
+
+		if (json.tidyUp === true) {
+			canvasEventBus.emit('tidyUp', { source: 'import-workflow-data' });
+		}
+	}
+
+	async function handleOpenExecution(json: {
+		executionId: string;
+		executionMode?: string;
+		nodeId?: string;
+		projectId?: string;
+	}) {
+		if (json.projectId) {
+			await projectsStore.fetchAndSetProject(json.projectId);
+		}
+
+		nodeHelpers.isProductionExecutionPreview.value =
+			json.executionMode !== 'manual' && json.executionMode !== 'evaluation';
+
+		canvasStore.startLoading();
+		resetWorkspace();
+
+		const data = await openExecution(json.executionId, json.nodeId);
+		if (!data) {
+			return;
+		}
+
+		void nextTick(() => {
+			nodeHelpers.updateNodesInputIssues();
+			nodeHelpers.updateNodesCredentialsIssues();
+		});
+
+		canvasStore.stopLoading();
+		fitView();
+
+		canvasEventBus.emit('open:execution', data);
+
+		void externalHooks.run('execution.open', {
+			workflowId: data.workflowData.id,
+			workflowName: data.workflowData.name,
+			executionId: json.executionId,
+		});
+
+		telemetry.track('User opened read-only execution', {
+			workflow_id: data.workflowData.id,
+			execution_mode: data.mode,
+			execution_finished: data.finished,
+		});
+	}
+
+	async function handleOpenExecutionPreview(json: {
+		workflow: IWorkflowDb;
+		nodeExecutionSchema: Record<string, ExecutionPreviewNodeSchema>;
+		executionStatus: ExecutionStatus;
+		executionError?: { message: string; description?: string; name?: string; stack?: string };
+		lastNodeExecuted?: string;
+		projectId?: string;
+	}) {
+		canvasStore.startLoading();
+
+		const workflow = json.workflow;
+		if (!workflow?.nodes || !workflow?.connections) {
+			canvasStore.stopLoading();
+			throw new Error('Invalid workflow object');
+		}
+
+		if (json.projectId) {
+			await projectsStore.fetchAndSetProject(json.projectId);
+		}
+
+		const data = buildExecutionResponseFromSchema({
+			workflow,
+			nodeExecutionSchema: json.nodeExecutionSchema,
+			executionStatus: json.executionStatus,
+			executionError: json.executionError,
+			lastNodeExecuted: json.lastNodeExecuted,
+		});
+
+		await importWorkflowExact(json);
+
+		workflowState.setWorkflowExecutionData(data);
+		currentWorkflowDocumentStore.value?.setPinData({});
+
+		canvasStore.stopLoading();
+
+		canvasEventBus.emit('open:execution', data);
+	}
+
+	async function onPostMessageReceived(messageEvent: MessageEvent) {
+		if (
+			!messageEvent ||
+			typeof messageEvent.data !== 'string' ||
+			!messageEvent.data?.includes?.('"command"')
+		) {
+			return;
+		}
+		try {
+			const json = JSON.parse(messageEvent.data);
+			if (json && json.command === 'openWorkflow') {
+				try {
+					await handleOpenWorkflow(json);
+				} catch (e) {
+					reportErrorToParent(i18n.baseText('openWorkflow.workflowImportError'));
+					toast.showError(e, i18n.baseText('openWorkflow.workflowImportError'));
+				}
+			} else if (json && json.command === 'openExecution') {
+				try {
+					await handleOpenExecution(json);
+				} catch (e) {
+					reportErrorToParent(i18n.baseText('nodeView.showError.openExecution.title'));
+					toast.showMessage({
+						title: i18n.baseText('nodeView.showError.openExecution.title'),
+						message: (e as Error).message,
+						type: 'error',
+					});
+				}
+			} else if (json && json.command === 'openExecutionPreview') {
+				try {
+					await handleOpenExecutionPreview(json);
+				} catch (e) {
+					reportErrorToParent(i18n.baseText('nodeView.showError.openExecution.title'));
+					toast.showMessage({
+						title: i18n.baseText('nodeView.showError.openExecution.title'),
+						message: (e as Error).message,
+						type: 'error',
+					});
+				}
+			} else if (json?.command === 'setActiveExecution') {
+				executionsStore.activeExecution = (await executionsStore.fetchExecution(
+					json.executionId,
+				)) as ExecutionSummary;
+			}
+		} catch {
+			// Ignore parse errors
+		}
+	}
+
+	function setup() {
+		window.addEventListener('message', onPostMessageReceived);
+		emitPostMessageReady();
+	}
+
+	function cleanup() {
+		window.removeEventListener('message', onPostMessageReceived);
+	}
+
+	return {
+		setup,
+		cleanup,
+	};
+}

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
@@ -14,6 +14,10 @@ import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useBuilderStore } from '@/features/ai/assistant/builder.store';
 import {
@@ -336,7 +340,10 @@ export function handleExecutionFinishedWithErrorOrCanceled(
 				const node = workflowObject.getNode(error.context.nodeCause as string);
 
 				if (node) {
-					eventData.is_pinned = !!workflowObject.getPinDataOfNode(node.name);
+					const workflowDocumentStore = workflowsStore.workflowId
+						? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+						: undefined;
+					eventData.is_pinned = !!workflowDocumentStore?.pinData?.[node.name];
 					eventData.mode = node.parameters.mode;
 					eventData.node_type = node.type;
 					eventData.operation = node.parameters.operation;

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
@@ -25,8 +25,7 @@ import {
 	NodeConnectionTypes,
 	WEBHOOK_NODE_TYPE,
 } from 'n8n-workflow';
-import type { AssignmentCollectionValue, IConnections, IPinData } from 'n8n-workflow';
-import { ref } from 'vue';
+import type { AssignmentCollectionValue, IConnections } from 'n8n-workflow';
 import * as apiWebhooks from '@n8n/rest-api-client/api/webhooks';
 import { mockedStore } from '@/__tests__/utils';
 import { SLACK_TRIGGER_NODE_TYPE, SET_NODE_TYPE } from '../constants';
@@ -35,32 +34,10 @@ import {
 	useWorkflowState,
 	type WorkflowState,
 } from '@/app/composables/useWorkflowState';
-
-const mockWorkflowDocumentStorePinData = ref<IPinData>({});
-
-vi.mock('@/app/stores/workflowDocument.store', async () => {
-	const actual = await vi.importActual('@/app/stores/workflowDocument.store');
-	return {
-		...actual,
-		useWorkflowDocumentStore: vi.fn(() => ({
-			get pinData() {
-				return mockWorkflowDocumentStorePinData.value;
-			},
-			setPinData: vi.fn((newPinData: IPinData) => {
-				mockWorkflowDocumentStorePinData.value = newPinData;
-			}),
-			setTags: vi.fn(),
-			addTags: vi.fn(),
-			removeTag: vi.fn(),
-			pinNodeData: vi.fn(),
-			unpinNodeData: vi.fn(),
-			renamePinDataNode: vi.fn(),
-			pinDataByNodeName: vi.fn(),
-			getPinDataSnapshot: vi.fn(() => ({ ...mockWorkflowDocumentStorePinData.value })),
-			getNodePinData: vi.fn((nodeName: string) => mockWorkflowDocumentStorePinData.value[nodeName]),
-		})),
-	};
-});
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 
 vi.mock('@/app/composables/useWorkflowState', async () => {
 	const actual = await vi.importActual('@/app/composables/useWorkflowState');
@@ -93,7 +70,7 @@ describe('useWorkflowHelpers', () => {
 
 	afterEach(() => {
 		vi.clearAllMocks();
-		mockWorkflowDocumentStorePinData.value = {};
+		workflowsStore.workflowId = '';
 	});
 
 	describe('getNodeParametersWithResolvedExpressions', () => {
@@ -1019,9 +996,12 @@ describe('useWorkflowHelpers', () => {
 			const runIndex = 0;
 
 			workflowsStore.workflowId = 'test-workflow';
-			mockWorkflowDocumentStorePinData.value = {
+			const workflowDocumentStore = useWorkflowDocumentStore(
+				createWorkflowDocumentId('test-workflow'),
+			);
+			vi.mocked(workflowDocumentStore.getPinDataSnapshot).mockReturnValue({
 				ParentNode: [{ json: { key: 'value' } }],
-			};
+			});
 
 			const result = executeData({}, parentNodes, currentNode, inputName, runIndex);
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
@@ -25,7 +25,8 @@ import {
 	NodeConnectionTypes,
 	WEBHOOK_NODE_TYPE,
 } from 'n8n-workflow';
-import type { AssignmentCollectionValue, IConnections } from 'n8n-workflow';
+import type { AssignmentCollectionValue, IConnections, IPinData } from 'n8n-workflow';
+import { ref } from 'vue';
 import * as apiWebhooks from '@n8n/rest-api-client/api/webhooks';
 import { mockedStore } from '@/__tests__/utils';
 import { SLACK_TRIGGER_NODE_TYPE, SET_NODE_TYPE } from '../constants';
@@ -34,6 +35,32 @@ import {
 	useWorkflowState,
 	type WorkflowState,
 } from '@/app/composables/useWorkflowState';
+
+const mockWorkflowDocumentStorePinData = ref<IPinData>({});
+
+vi.mock('@/app/stores/workflowDocument.store', async () => {
+	const actual = await vi.importActual('@/app/stores/workflowDocument.store');
+	return {
+		...actual,
+		useWorkflowDocumentStore: vi.fn(() => ({
+			get pinData() {
+				return mockWorkflowDocumentStorePinData.value;
+			},
+			setPinData: vi.fn((newPinData: IPinData) => {
+				mockWorkflowDocumentStorePinData.value = newPinData;
+			}),
+			setTags: vi.fn(),
+			addTags: vi.fn(),
+			removeTag: vi.fn(),
+			pinNodeData: vi.fn(),
+			unpinNodeData: vi.fn(),
+			renamePinDataNode: vi.fn(),
+			pinDataByNodeName: vi.fn(),
+			getPinDataSnapshot: vi.fn(() => ({ ...mockWorkflowDocumentStorePinData.value })),
+			getNodePinData: vi.fn((nodeName: string) => mockWorkflowDocumentStorePinData.value[nodeName]),
+		})),
+	};
+});
 
 vi.mock('@/app/composables/useWorkflowState', async () => {
 	const actual = await vi.importActual('@/app/composables/useWorkflowState');
@@ -66,6 +93,7 @@ describe('useWorkflowHelpers', () => {
 
 	afterEach(() => {
 		vi.clearAllMocks();
+		mockWorkflowDocumentStorePinData.value = {};
 	});
 
 	describe('getNodeParametersWithResolvedExpressions', () => {
@@ -245,7 +273,6 @@ describe('useWorkflowHelpers', () => {
 			const setWorkflowIdSpy = vi.spyOn(workflowState, 'setWorkflowId');
 			const setWorkflowNameSpy = vi.spyOn(workflowState, 'setWorkflowName');
 			const setWorkflowSettingsSpy = vi.spyOn(workflowState, 'setWorkflowSettings');
-			const setWorkflowPinDataSpy = vi.spyOn(workflowState, 'setWorkflowPinData');
 			const setWorkflowVersionDataSpy = vi.spyOn(workflowsStore, 'setWorkflowVersionData');
 			const setWorkflowMetadataSpy = vi.spyOn(workflowState, 'setWorkflowMetadata');
 			const setWorkflowScopesSpy = vi.spyOn(workflowState, 'setWorkflowScopes');
@@ -266,7 +293,6 @@ describe('useWorkflowHelpers', () => {
 				executionOrder: 'v1',
 				timezone: 'DEFAULT',
 			});
-			expect(setWorkflowPinDataSpy).toHaveBeenCalledWith({});
 			expect(setWorkflowVersionDataSpy).toHaveBeenCalledWith(
 				{ versionId: 'v1', name: null, description: null },
 				'checksum',
@@ -992,7 +1018,8 @@ describe('useWorkflowHelpers', () => {
 			const inputName = 'main';
 			const runIndex = 0;
 
-			workflowsStore.pinnedWorkflowData = {
+			workflowsStore.workflowId = 'test-workflow';
+			mockWorkflowDocumentStorePinData.value = {
 				ParentNode: [{ json: { key: 'value' } }],
 			};
 
@@ -1010,7 +1037,6 @@ describe('useWorkflowHelpers', () => {
 			const inputName = 'main';
 			const runIndex = 0;
 
-			workflowsStore.pinnedWorkflowData = undefined;
 			workflowsStore.getWorkflowRunData = {
 				ParentNode: [
 					{
@@ -1050,7 +1076,6 @@ describe('useWorkflowHelpers', () => {
 			const runIndex = 0;
 			const parentRunIndex = 1;
 
-			workflowsStore.pinnedWorkflowData = undefined;
 			workflowsStore.getWorkflowRunData = {
 				ParentNode: [
 					{ data: {} } as never,
@@ -1092,7 +1117,6 @@ describe('useWorkflowHelpers', () => {
 			const inputName = 'main';
 			const runIndex = 0;
 
-			workflowsStore.pinnedWorkflowData = undefined;
 			workflowsStore.getWorkflowRunData = null;
 
 			const result = executeData({}, parentNodes, currentNode, inputName, runIndex);

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowImport.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowImport.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { shallowRef } from 'vue';
+import { setActivePinia } from 'pinia';
+import { createTestingPinia } from '@pinia/testing';
+import { useWorkflowImport } from './useWorkflowImport';
+import type { WorkflowDataUpdate } from '@n8n/rest-api-client/api/workflows';
+import { VIEWS } from '@/app/constants';
+
+const mockResetWorkspace = vi.hoisted(() => vi.fn());
+const mockInitializeWorkspace = vi.hoisted(() =>
+	vi.fn().mockResolvedValue({ workflowDocumentStore: { id: 'mock-store' } }),
+);
+const mockFitView = vi.hoisted(() => vi.fn());
+
+vi.mock('@/app/composables/useCanvasOperations', () => ({
+	useCanvasOperations: vi.fn(() => ({
+		resetWorkspace: mockResetWorkspace,
+		initializeWorkspace: mockInitializeWorkspace,
+		fitView: mockFitView,
+	})),
+}));
+
+const mockRoute = vi.hoisted(() => ({ name: 'workflow' as string }));
+vi.mock('vue-router', async (importOriginal) => {
+	const actual = (await importOriginal()) as object;
+	return {
+		...actual,
+		useRoute: vi.fn(() => mockRoute),
+	};
+});
+
+vi.mock('@/app/utils/nodeViewUtils', () => ({
+	getNodesWithNormalizedPosition: vi.fn((nodes) => nodes),
+}));
+
+describe('useWorkflowImport', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		setActivePinia(createTestingPinia());
+		mockRoute.name = VIEWS.WORKFLOW;
+	});
+
+	const createWorkflowData = (overrides: Partial<WorkflowDataUpdate> = {}): WorkflowDataUpdate =>
+		({
+			id: 'test-workflow',
+			nodes: [{ name: 'Node 1', type: 'n8n-nodes-base.noOp', position: [0, 0] }],
+			connections: {},
+			...overrides,
+		}) as WorkflowDataUpdate;
+
+	it('should throw if workflow has no nodes', async () => {
+		const storeRef = shallowRef(null);
+		const { importWorkflowExact } = useWorkflowImport(storeRef);
+
+		await expect(
+			importWorkflowExact({ workflow: { connections: {} } as WorkflowDataUpdate }),
+		).rejects.toThrow('Invalid workflow object');
+	});
+
+	it('should throw if workflow has no connections', async () => {
+		const storeRef = shallowRef(null);
+		const { importWorkflowExact } = useWorkflowImport(storeRef);
+
+		await expect(
+			importWorkflowExact({ workflow: { nodes: [] } as unknown as WorkflowDataUpdate }),
+		).rejects.toThrow('Invalid workflow object');
+	});
+
+	it('should reset workspace, initialize, and fit view', async () => {
+		const storeRef = shallowRef(null);
+		const { importWorkflowExact } = useWorkflowImport(storeRef);
+
+		await importWorkflowExact({ workflow: createWorkflowData() });
+
+		expect(mockResetWorkspace).toHaveBeenCalledOnce();
+		expect(mockInitializeWorkspace).toHaveBeenCalledOnce();
+		expect(mockFitView).toHaveBeenCalledOnce();
+	});
+
+	it('should call resetWorkspace before initializeWorkspace', async () => {
+		const callOrder: string[] = [];
+		mockResetWorkspace.mockImplementation(() => callOrder.push('reset'));
+		mockInitializeWorkspace.mockImplementation(async () => {
+			callOrder.push('initialize');
+			return { workflowDocumentStore: { id: 'mock-store' } };
+		});
+
+		const storeRef = shallowRef(null);
+		const { importWorkflowExact } = useWorkflowImport(storeRef);
+
+		await importWorkflowExact({ workflow: createWorkflowData() });
+
+		expect(callOrder).toEqual(['reset', 'initialize']);
+	});
+
+	it('should update currentWorkflowDocumentStore with the new store', async () => {
+		const mockStore = { id: 'new-store' };
+		mockInitializeWorkspace.mockResolvedValue({ workflowDocumentStore: mockStore });
+
+		const storeRef = shallowRef(null);
+		const { importWorkflowExact } = useWorkflowImport(storeRef);
+
+		await importWorkflowExact({ workflow: createWorkflowData() });
+
+		expect(storeRef.value).toBe(mockStore);
+	});
+
+	it('should use workflow id from data on non-demo routes', async () => {
+		mockRoute.name = VIEWS.WORKFLOW;
+
+		const storeRef = shallowRef(null);
+		const { importWorkflowExact } = useWorkflowImport(storeRef);
+
+		await importWorkflowExact({ workflow: createWorkflowData({ id: 'my-workflow-id' }) });
+
+		expect(mockInitializeWorkspace).toHaveBeenCalledWith(
+			expect.objectContaining({ id: 'my-workflow-id' }),
+		);
+	});
+
+	it('should use "demo" id on demo routes', async () => {
+		mockRoute.name = VIEWS.DEMO;
+
+		const storeRef = shallowRef(null);
+		const { importWorkflowExact } = useWorkflowImport(storeRef);
+
+		await importWorkflowExact({ workflow: createWorkflowData({ id: 'ignored-id' }) });
+
+		expect(mockInitializeWorkspace).toHaveBeenCalledWith(expect.objectContaining({ id: 'demo' }));
+	});
+});

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowImport.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowImport.ts
@@ -1,0 +1,41 @@
+import { computed, type ShallowRef } from 'vue';
+import { useRoute } from 'vue-router';
+import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
+import { VIEWS } from '@/app/constants';
+import type { INodeUi, IWorkflowDb } from '@/Interface';
+import type { WorkflowDataUpdate } from '@n8n/rest-api-client/api/workflows';
+import { getNodesWithNormalizedPosition } from '@/app/utils/nodeViewUtils';
+import type { useWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+
+export function useWorkflowImport(
+	currentWorkflowDocumentStore: ShallowRef<ReturnType<typeof useWorkflowDocumentStore> | null>,
+) {
+	const route = useRoute();
+	const { resetWorkspace, initializeWorkspace, fitView } = useCanvasOperations();
+
+	const isDemoRoute = computed(() => route.name === VIEWS.DEMO);
+
+	async function importWorkflowExact({
+		workflow: workflowData,
+	}: {
+		workflow: WorkflowDataUpdate;
+	}) {
+		if (!workflowData.nodes || !workflowData.connections) {
+			throw new Error('Invalid workflow object');
+		}
+
+		resetWorkspace();
+
+		const { workflowDocumentStore } = await initializeWorkspace({
+			...workflowData,
+			id: isDemoRoute.value ? 'demo' : workflowData.id,
+			nodes: getNodesWithNormalizedPosition<INodeUi>(workflowData.nodes),
+		} as IWorkflowDb);
+
+		currentWorkflowDocumentStore.value = workflowDocumentStore;
+
+		fitView();
+	}
+
+	return { importWorkflowExact };
+}

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowState.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowState.test.ts
@@ -7,7 +7,7 @@ import {
 	createTestWorkflowExecutionResponse,
 } from '@/__tests__/mocks';
 import type { IWorkflowDb } from '@/Interface';
-import { createRunExecutionData, type IPinData } from 'n8n-workflow';
+import { createRunExecutionData } from 'n8n-workflow';
 
 describe('useWorkflowState', () => {
 	let workflowsStore: ReturnType<typeof useWorkflowsStore>;
@@ -214,31 +214,6 @@ describe('useWorkflowState', () => {
 		it('should throw error if out of bounds', () => {
 			workflowsStore.workflow.nodes = [];
 			expect(() => workflowState.updateNodeAtIndex(0, { name: 'Updated Node' })).toThrowError();
-		});
-	});
-
-	describe('pinned data', () => {
-		it('sets workflow pin data', () => {
-			workflowsStore.workflow.pinData = undefined;
-			const data: IPinData = {
-				TestNode: [{ json: { test: true } }],
-				TestNode1: [{ json: { test: false } }],
-			};
-			workflowState.setWorkflowPinData(data);
-			expect(workflowsStore.workflow.pinData).toEqual(data);
-		});
-
-		it('sets workflow pin data, adding json keys', () => {
-			workflowsStore.workflow.pinData = undefined;
-			const data = {
-				TestNode: [{ test: true }],
-				TestNode1: [{ test: false }],
-			};
-			workflowState.setWorkflowPinData(data as unknown as IPinData);
-			expect(workflowsStore.workflow.pinData).toEqual({
-				TestNode: [{ json: { test: true } }],
-				TestNode1: [{ json: { test: false } }],
-			});
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowState.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowState.ts
@@ -22,12 +22,11 @@ import {
 	type IDataObject,
 	type INodeParameters,
 	type IWorkflowSettings,
-	type IPinData,
 } from 'n8n-workflow';
 import { inject } from 'vue';
 import * as workflowsApi from '@/app/api/workflows';
 import { useRootStore } from '@n8n/stores/useRootStore';
-import { isEmpty, isJsonKeyObject } from '@/app/utils/typesUtils';
+import { isEmpty } from '@/app/utils/typesUtils';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import type { ProjectSharingData } from '@/features/collaboration/projects/projects.types';
 import { clearPopupWindowState } from '@/features/execution/executions/executions.utils';
@@ -40,7 +39,10 @@ import isEqual from 'lodash/isEqual';
 import pick from 'lodash/pick';
 import { createEventBus } from '@n8n/utils/event-bus';
 import type { WorkflowMetadata } from '@n8n/rest-api-client';
-import { dataPinningEventBus } from '../event-bus';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 
 export type WorkflowStateBusEvents = {
 	updateNodeProperties: [WorkflowState, INodeUpdatePropertiesInformation];
@@ -87,7 +89,12 @@ export function useWorkflowState() {
 		}
 
 		if (data.removePinData) {
-			ws.workflow.pinData = {};
+			if (ws.workflow.id) {
+				const workflowDocumentStore = useWorkflowDocumentStore(
+					createWorkflowDocumentId(ws.workflow.id),
+				);
+				workflowDocumentStore.setPinData({});
+			}
 		}
 
 		ws.workflow.nodes.splice(0, ws.workflow.nodes.length);
@@ -217,25 +224,6 @@ export function useWorkflowState() {
 			...ws.workflow.meta,
 			...data,
 		};
-	}
-
-	function setWorkflowPinData(data: IPinData = {}) {
-		const validPinData = Object.keys(data).reduce((accu, nodeName) => {
-			accu[nodeName] = data[nodeName].map((item) => {
-				if (!isJsonKeyObject(item)) {
-					return { json: item };
-				}
-
-				return item;
-			});
-
-			return accu;
-		}, {} as IPinData);
-
-		ws.workflow.pinData = validPinData;
-		ws.workflowObject.setPinData(validPinData);
-
-		dataPinningEventBus.emit('pin-data', validPinData);
 	}
 
 	////
@@ -499,7 +487,6 @@ export function useWorkflowState() {
 		setWorkflowScopes,
 		setWorkflowMetadata,
 		addToWorkflowMetadata,
-		setWorkflowPinData,
 
 		// Execution
 		markExecutionAsStopped,

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
@@ -6,6 +6,10 @@
 import { DEFAULT_NEW_WORKFLOW_NAME } from '@/app/constants';
 import type { INodeUi } from '@/Interface';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useBuilderStore } from '@/features/ai/assistant/builder.store';
@@ -16,7 +20,7 @@ import { canvasEventBus } from '@/features/workflows/canvas/canvas.eventBus';
 import { mapLegacyConnectionsToCanvasConnections } from '@/features/workflows/canvas/canvas.utils';
 import { getAuthTypeForNodeCredential, getMainAuthField } from '@/app/utils/nodeTypesUtils';
 import type { WorkflowDataUpdate } from '@n8n/rest-api-client/api/workflows';
-import { NodeHelpers, type IConnections, type INode } from 'n8n-workflow';
+import { NodeHelpers, type IConnections, type INode, type IPinData } from 'n8n-workflow';
 import isEqual from 'lodash/isEqual';
 
 export interface UpdateWorkflowOptions {
@@ -354,9 +358,12 @@ export function useWorkflowUpdate() {
 			updateWorkflowNameIfNeeded(workflowData.name, options?.isInitialGeneration);
 
 			// Merge pin data from workflow data with existing pin data
-			if (workflowData.pinData) {
-				workflowsStore.setWorkflowPinData({
-					...workflowsStore.workflow.pinData,
+			if (workflowData.pinData && workflowsStore.workflowId) {
+				const workflowDocumentStore = useWorkflowDocumentStore(
+					createWorkflowDocumentId(workflowsStore.workflowId),
+				);
+				workflowDocumentStore.setPinData({
+					...(workflowDocumentStore.pinData as IPinData),
 					...workflowData.pinData,
 				});
 			}

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
@@ -20,7 +20,7 @@ import { canvasEventBus } from '@/features/workflows/canvas/canvas.eventBus';
 import { mapLegacyConnectionsToCanvasConnections } from '@/features/workflows/canvas/canvas.utils';
 import { getAuthTypeForNodeCredential, getMainAuthField } from '@/app/utils/nodeTypesUtils';
 import type { WorkflowDataUpdate } from '@n8n/rest-api-client/api/workflows';
-import { NodeHelpers, type IConnections, type INode, type IPinData } from 'n8n-workflow';
+import { NodeHelpers, type IConnections, type INode } from 'n8n-workflow';
 import isEqual from 'lodash/isEqual';
 
 export interface UpdateWorkflowOptions {
@@ -363,7 +363,7 @@ export function useWorkflowUpdate() {
 					createWorkflowDocumentId(workflowsStore.workflowId),
 				);
 				workflowDocumentStore.setPinData({
-					...(workflowDocumentStore.pinData as IPinData),
+					...workflowDocumentStore.getPinDataSnapshot(),
 					...workflowData.pinData,
 				});
 			}

--- a/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
@@ -1,9 +1,10 @@
 <script lang="ts" setup>
-import { provide, computed } from 'vue';
+import { provide, computed, shallowRef } from 'vue';
 import { useRoute } from 'vue-router';
 import BaseLayout from './BaseLayout.vue';
 import DemoFooter from '@/features/execution/logs/components/DemoFooter.vue';
-import { WorkflowIdKey } from '@/app/constants/injectionKeys';
+import { WorkflowIdKey, WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
+import type { useWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 
 const route = useRoute();
 
@@ -12,7 +13,12 @@ const workflowId = computed(() => {
 	return (Array.isArray(name) ? name[0] : name) as string;
 });
 
+const currentWorkflowDocumentStore = shallowRef<ReturnType<typeof useWorkflowDocumentStore> | null>(
+	null,
+);
+
 provide(WorkflowIdKey, workflowId);
+provide(WorkflowDocumentStoreKey, currentWorkflowDocumentStore);
 </script>
 
 <template>

--- a/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
@@ -1,24 +1,41 @@
 <script lang="ts" setup>
-import { provide, computed, shallowRef } from 'vue';
-import { useRoute } from 'vue-router';
+import { provide, onBeforeMount, onBeforeUnmount } from 'vue';
 import BaseLayout from './BaseLayout.vue';
 import DemoFooter from '@/features/execution/logs/components/DemoFooter.vue';
-import { WorkflowIdKey, WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
-import type { useWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import {
+	WorkflowIdKey,
+	WorkflowStateKey,
+	WorkflowDocumentStoreKey,
+} from '@/app/constants/injectionKeys';
+import { useWorkflowState } from '@/app/composables/useWorkflowState';
+import { useWorkflowInitialization } from '@/app/composables/useWorkflowInitialization';
+import { usePostMessageHandler } from '@/app/composables/usePostMessageHandler';
 
-const route = useRoute();
+const workflowState = useWorkflowState();
+provide(WorkflowStateKey, workflowState);
 
-const workflowId = computed(() => {
-	const name = route.params.name;
-	return (Array.isArray(name) ? name[0] : name) as string;
-});
-
-const currentWorkflowDocumentStore = shallowRef<ReturnType<typeof useWorkflowDocumentStore> | null>(
-	null,
-);
+const {
+	workflowId,
+	currentWorkflowDocumentStore,
+	cleanup: cleanupInitialization,
+} = useWorkflowInitialization(workflowState);
 
 provide(WorkflowIdKey, workflowId);
 provide(WorkflowDocumentStoreKey, currentWorkflowDocumentStore);
+
+const { setup: setupPostMessages, cleanup: cleanupPostMessages } = usePostMessageHandler({
+	workflowState,
+	currentWorkflowDocumentStore,
+});
+
+onBeforeMount(() => {
+	setupPostMessages();
+});
+
+onBeforeUnmount(() => {
+	cleanupPostMessages();
+	cleanupInitialization();
+});
 </script>
 
 <template>

--- a/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.test.ts
+++ b/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createComponentRenderer } from '@/__tests__/render';
 import WorkflowLayout from './WorkflowLayout.vue';
-import { computed, ref } from 'vue';
+import { computed, ref, shallowRef } from 'vue';
 import { createTestingPinia } from '@pinia/testing';
 
 vi.mock('vue-router', async (importOriginal) => {
@@ -45,10 +45,20 @@ vi.mock('@/app/composables/useWorkflowInitialization', () => ({
 	useWorkflowInitialization: vi.fn(() => ({
 		isLoading: ref(false),
 		workflowId: computed(() => 'test-workflow-id'),
+		currentWorkflowDocumentStore: shallowRef(null),
 		isTemplateRoute: computed(() => false),
 		isOnboardingRoute: computed(() => false),
+		isDebugRoute: computed(() => false),
 		initializeData: vi.fn().mockResolvedValue(undefined),
 		initializeWorkflow: vi.fn().mockResolvedValue(undefined),
+		handleDebugModeRoute: vi.fn().mockResolvedValue(undefined),
+		cleanup: vi.fn(),
+	})),
+}));
+
+vi.mock('@/app/composables/usePostMessageHandler', () => ({
+	usePostMessageHandler: vi.fn(() => ({
+		setup: vi.fn(),
 		cleanup: vi.fn(),
 	})),
 }));

--- a/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
@@ -4,6 +4,7 @@ import BaseLayout from './BaseLayout.vue';
 import { useLayoutProps } from '@/app/composables/useLayoutProps';
 import { useWorkflowState } from '@/app/composables/useWorkflowState';
 import { useWorkflowInitialization } from '@/app/composables/useWorkflowInitialization';
+import { usePostMessageHandler } from '@/app/composables/usePostMessageHandler';
 import AskAssistantFloatingButton from '@/features/ai/assistant/components/Chat/AskAssistantFloatingButton.vue';
 import { useAssistantStore } from '@/features/ai/assistant/assistant.store';
 import AppHeader from '@/app/components/app/AppHeader.vue';
@@ -36,7 +37,13 @@ const {
 provide(WorkflowIdKey, workflowId);
 provide(WorkflowDocumentStoreKey, currentWorkflowDocumentStore);
 
+const { setup: setupPostMessages, cleanup: cleanupPostMessages } = usePostMessageHandler({
+	workflowState,
+	currentWorkflowDocumentStore,
+});
+
 onMounted(async () => {
+	setupPostMessages();
 	await initializeData();
 	await initializeWorkflow();
 });
@@ -64,7 +71,10 @@ watch(
 	{ flush: 'post' },
 );
 
-onBeforeUnmount(() => cleanup());
+onBeforeUnmount(() => {
+	cleanupPostMessages();
+	cleanup();
+});
 </script>
 
 <template>

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
@@ -13,7 +13,10 @@ import {
 	type TagAction,
 } from './workflowDocument/useWorkflowDocumentTags';
 
-export { getPinDataSize } from './workflowDocument/useWorkflowDocumentPinData';
+export {
+	getPinDataSize,
+	pinDataToExecutionData,
+} from './workflowDocument/useWorkflowDocumentPinData';
 
 // Pinia internal type - _s is the store registry Map
 type PiniaInternal = ReturnType<typeof getActivePinia> & {
@@ -78,7 +81,6 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 			pinNodeData,
 			unpinNodeData,
 			renamePinDataNode,
-			pinDataByNodeName,
 			getPinDataSnapshot,
 			getNodePinData,
 			handleAction: handlePinDataAction,
@@ -96,7 +98,6 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 			pinNodeData,
 			unpinNodeData,
 			renamePinDataNode,
-			pinDataByNodeName,
 			getPinDataSnapshot,
 			getNodePinData,
 		};

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
@@ -1,7 +1,10 @@
 import { defineStore, getActivePinia, type StoreGeneric } from 'pinia';
 import { STORES } from '@n8n/stores';
 import { ref, readonly, inject } from 'vue';
+import type { INodeExecutionData, IPinData } from 'n8n-workflow';
 import { WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
+import { isJsonKeyObject, stringSizeInBytes } from '@/app/utils/typesUtils';
+import { dataPinningEventBus } from '@/app/event-bus';
 
 // Pinia internal type - _s is the store registry Map
 type PiniaInternal = ReturnType<typeof getActivePinia> & {
@@ -23,13 +26,73 @@ type SetTagsAction = Action<'setTags', { tags: string[] }>;
 type AddTagsAction = Action<'addTags', { tags: string[] }>;
 type RemoveTagAction = Action<'removeTag', { tagId: string }>;
 
-type WorkflowDocumentAction = SetTagsAction | AddTagsAction | RemoveTagAction;
+type SetPinDataAction = Action<'setPinData', { pinData: IPinData }>;
+type PinNodeDataAction = Action<'pinNodeData', { nodeName: string; data: INodeExecutionData[] }>;
+type UnpinNodeDataAction = Action<'unpinNodeData', { nodeName: string }>;
+type RenamePinDataNodeAction = Action<'renamePinDataNode', { oldName: string; newName: string }>;
+
+type WorkflowDocumentAction =
+	| SetTagsAction
+	| AddTagsAction
+	| RemoveTagAction
+	| SetPinDataAction
+	| PinNodeDataAction
+	| UnpinNodeDataAction
+	| RenamePinDataNodeAction;
 
 /**
  * Gets the store ID for a workflow document store.
  */
 export function getWorkflowDocumentStoreId(id: string) {
 	return `${STORES.WORKFLOW_DOCUMENTS}/${id}`;
+}
+
+/**
+ * Normalize an array of node execution data items by stripping runtime properties.
+ * Only keeps json, binary, and pairedItem.
+ */
+function normalizeNodeExecutionData(data: INodeExecutionData[]): INodeExecutionData[] {
+	if (!Array.isArray(data)) {
+		data = [data];
+	}
+
+	return data.map((item) => {
+		if (isJsonKeyObject(item)) {
+			const { json, binary, pairedItem } = item;
+			return {
+				json,
+				...(binary && { binary }),
+				...(pairedItem !== undefined && { pairedItem }),
+			};
+		}
+		return { json: item };
+	}) as INodeExecutionData[];
+}
+
+/**
+ * Normalize pin data by ensuring all items have the json key wrapper.
+ */
+function normalizePinData(data: IPinData): IPinData {
+	return Object.keys(data).reduce<IPinData>((accu, nodeName) => {
+		accu[nodeName] = data[nodeName].map((item) => {
+			if (!isJsonKeyObject(item)) {
+				return { json: item };
+			}
+			return item;
+		});
+		return accu;
+	}, {});
+}
+
+/**
+ * Calculate the byte size of pin data.
+ */
+export function getPinDataSize(
+	pinData: Record<string, string | INodeExecutionData[]> = {},
+): number {
+	return Object.values(pinData).reduce<number>((acc, value) => {
+		return acc + stringSizeInBytes(value);
+	}, 0);
 }
 
 /**
@@ -65,6 +128,44 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 		}
 
 		/**
+		 * Pin Data
+		 */
+
+		const pinData = ref<IPinData>({});
+
+		function setPinData(newPinData: IPinData) {
+			onChange({ name: 'setPinData', payload: { pinData: newPinData } });
+		}
+
+		function pinNodeData(nodeName: string, data: INodeExecutionData[]) {
+			onChange({ name: 'pinNodeData', payload: { nodeName, data } });
+		}
+
+		function unpinNodeData(nodeName: string) {
+			onChange({ name: 'unpinNodeData', payload: { nodeName } });
+		}
+
+		function renamePinDataNode(oldName: string, newName: string) {
+			onChange({ name: 'renamePinDataNode', payload: { oldName, newName } });
+		}
+
+		function pinDataByNodeName(nodeName: string): INodeExecutionData[] | undefined {
+			if (!pinData.value[nodeName]) return undefined;
+
+			return pinData.value[nodeName].map((item) => item.json) as INodeExecutionData[];
+		}
+
+		/** Returns a mutable shallow copy of all pin data, bypassing the readonly wrapper. */
+		function getPinDataSnapshot(): IPinData {
+			return { ...pinData.value };
+		}
+
+		/** Returns pin data for a specific node, bypassing the readonly wrapper. */
+		function getNodePinData(nodeName: string): INodeExecutionData[] | undefined {
+			return pinData.value[nodeName];
+		}
+
+		/**
 		 * Handle actions in a CRDT like manner
 		 */
 
@@ -76,6 +177,45 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 				tags.value = Array.from(uniqueTags);
 			} else if (action.name === 'removeTag') {
 				tags.value = tags.value.filter((tag) => tag !== action.payload.tagId);
+			} else if (action.name === 'setPinData') {
+				const normalized = normalizePinData(action.payload.pinData);
+				pinData.value = normalized;
+				dataPinningEventBus.emit('pin-data', normalized);
+			} else if (action.name === 'pinNodeData') {
+				const storedData = normalizeNodeExecutionData(action.payload.data);
+				pinData.value = { ...pinData.value, [action.payload.nodeName]: storedData };
+				dataPinningEventBus.emit('pin-data', {
+					[action.payload.nodeName]: storedData,
+				});
+			} else if (action.name === 'unpinNodeData') {
+				const { [action.payload.nodeName]: _, ...rest } = pinData.value;
+				pinData.value = rest;
+				dataPinningEventBus.emit('unpin-data', {
+					nodeNames: [action.payload.nodeName],
+				});
+			} else if (action.name === 'renamePinDataNode') {
+				const { oldName, newName } = action.payload;
+				if (pinData.value[oldName]) {
+					const { [oldName]: renamed, ...rest } = pinData.value;
+					pinData.value = { ...rest, [newName]: renamed };
+				}
+				// Update pairedItem sourceOverwrite references to the old node name
+				Object.values(pinData.value)
+					.flatMap((executionData) =>
+						executionData.flatMap((nodeExecution) =>
+							Array.isArray(nodeExecution.pairedItem)
+								? nodeExecution.pairedItem
+								: [nodeExecution.pairedItem],
+						),
+					)
+					.forEach((pairedItem) => {
+						if (
+							typeof pairedItem === 'number' ||
+							pairedItem?.sourceOverwrite?.previousNode !== oldName
+						)
+							return;
+						pairedItem.sourceOverwrite.previousNode = newName;
+					});
 			}
 		}
 
@@ -86,6 +226,14 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 			setTags,
 			addTags,
 			removeTag,
+			pinData: readonly(pinData),
+			setPinData,
+			pinNodeData,
+			unpinNodeData,
+			renamePinDataNode,
+			pinDataByNodeName,
+			getPinDataSnapshot,
+			getNodePinData,
 		};
 	})();
 }

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
@@ -1,8 +1,17 @@
 import { defineStore, getActivePinia, type StoreGeneric } from 'pinia';
 import { STORES } from '@n8n/stores';
-import { ref, readonly, inject } from 'vue';
+import { inject } from 'vue';
 import { WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
-import { useWorkflowDocumentPinData } from './workflowDocument/useWorkflowDocumentPinData';
+import {
+	useWorkflowDocumentPinData,
+	isPinDataAction,
+	type PinDataAction,
+} from './workflowDocument/useWorkflowDocumentPinData';
+import {
+	useWorkflowDocumentTags,
+	isTagAction,
+	type TagAction,
+} from './workflowDocument/useWorkflowDocumentTags';
 
 export { getPinDataSize } from './workflowDocument/useWorkflowDocumentPinData';
 
@@ -20,13 +29,7 @@ export function createWorkflowDocumentId(
 	return `${workflowId}@${version}`;
 }
 
-type Action<N, P> = { name: N; payload: P };
-
-type SetTagsAction = Action<'setTags', { tags: string[] }>;
-type AddTagsAction = Action<'addTags', { tags: string[] }>;
-type RemoveTagAction = Action<'removeTag', { tagId: string }>;
-
-type TagAction = SetTagsAction | AddTagsAction | RemoveTagAction;
+type WorkflowDocumentAction = TagAction | PinDataAction;
 
 /**
  * Gets the store ID for a workflow document store.
@@ -50,26 +53,24 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 		const [workflowId, workflowVersion] = id.split('@');
 
 		/**
-		 * Tags
+		 * Handle all document actions in a CRDT-like manner.
+		 * Single entry point for all mutations, enabling future CRDT sync integration.
 		 */
-
-		const tags = ref<string[]>([]);
-
-		function setTags(newTags: string[]) {
-			onChange({ name: 'setTags', payload: { tags: newTags } });
+		function onChange(action: WorkflowDocumentAction) {
+			if (isTagAction(action)) {
+				handleTagAction(action);
+			} else if (isPinDataAction(action)) {
+				handlePinDataAction(action);
+			}
 		}
 
-		function addTags(newTags: string[]) {
-			onChange({ name: 'addTags', payload: { tags: newTags } });
-		}
-
-		function removeTag(tagId: string) {
-			onChange({ name: 'removeTag', payload: { tagId } });
-		}
-
-		/**
-		 * Pin Data
-		 */
+		const {
+			tags,
+			setTags,
+			addTags,
+			removeTag,
+			handleAction: handleTagAction,
+		} = useWorkflowDocumentTags(onChange);
 
 		const {
 			pinData,
@@ -80,27 +81,13 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 			pinDataByNodeName,
 			getPinDataSnapshot,
 			getNodePinData,
-		} = useWorkflowDocumentPinData();
-
-		/**
-		 * Handle tag actions in a CRDT like manner
-		 */
-
-		function onChange(action: TagAction) {
-			if (action.name === 'setTags') {
-				tags.value = action.payload.tags;
-			} else if (action.name === 'addTags') {
-				const uniqueTags = new Set([...tags.value, ...action.payload.tags]);
-				tags.value = Array.from(uniqueTags);
-			} else if (action.name === 'removeTag') {
-				tags.value = tags.value.filter((tag) => tag !== action.payload.tagId);
-			}
-		}
+			handleAction: handlePinDataAction,
+		} = useWorkflowDocumentPinData(onChange);
 
 		return {
 			workflowId,
 			workflowVersion,
-			tags: readonly(tags),
+			tags,
 			setTags,
 			addTags,
 			removeTag,

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
@@ -1,10 +1,10 @@
 import { defineStore, getActivePinia, type StoreGeneric } from 'pinia';
 import { STORES } from '@n8n/stores';
 import { ref, readonly, inject } from 'vue';
-import type { INodeExecutionData, IPinData } from 'n8n-workflow';
 import { WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
-import { isJsonKeyObject, stringSizeInBytes } from '@/app/utils/typesUtils';
-import { dataPinningEventBus } from '@/app/event-bus';
+import { useWorkflowDocumentPinData } from './workflowDocument/useWorkflowDocumentPinData';
+
+export { getPinDataSize } from './workflowDocument/useWorkflowDocumentPinData';
 
 // Pinia internal type - _s is the store registry Map
 type PiniaInternal = ReturnType<typeof getActivePinia> & {
@@ -26,73 +26,13 @@ type SetTagsAction = Action<'setTags', { tags: string[] }>;
 type AddTagsAction = Action<'addTags', { tags: string[] }>;
 type RemoveTagAction = Action<'removeTag', { tagId: string }>;
 
-type SetPinDataAction = Action<'setPinData', { pinData: IPinData }>;
-type PinNodeDataAction = Action<'pinNodeData', { nodeName: string; data: INodeExecutionData[] }>;
-type UnpinNodeDataAction = Action<'unpinNodeData', { nodeName: string }>;
-type RenamePinDataNodeAction = Action<'renamePinDataNode', { oldName: string; newName: string }>;
-
-type WorkflowDocumentAction =
-	| SetTagsAction
-	| AddTagsAction
-	| RemoveTagAction
-	| SetPinDataAction
-	| PinNodeDataAction
-	| UnpinNodeDataAction
-	| RenamePinDataNodeAction;
+type TagAction = SetTagsAction | AddTagsAction | RemoveTagAction;
 
 /**
  * Gets the store ID for a workflow document store.
  */
 export function getWorkflowDocumentStoreId(id: string) {
 	return `${STORES.WORKFLOW_DOCUMENTS}/${id}`;
-}
-
-/**
- * Normalize an array of node execution data items by stripping runtime properties.
- * Only keeps json, binary, and pairedItem.
- */
-function normalizeNodeExecutionData(data: INodeExecutionData[]): INodeExecutionData[] {
-	if (!Array.isArray(data)) {
-		data = [data];
-	}
-
-	return data.map((item) => {
-		if (isJsonKeyObject(item)) {
-			const { json, binary, pairedItem } = item;
-			return {
-				json,
-				...(binary && { binary }),
-				...(pairedItem !== undefined && { pairedItem }),
-			};
-		}
-		return { json: item };
-	}) as INodeExecutionData[];
-}
-
-/**
- * Normalize pin data by ensuring all items have the json key wrapper.
- */
-function normalizePinData(data: IPinData): IPinData {
-	return Object.keys(data).reduce<IPinData>((accu, nodeName) => {
-		accu[nodeName] = data[nodeName].map((item) => {
-			if (!isJsonKeyObject(item)) {
-				return { json: item };
-			}
-			return item;
-		});
-		return accu;
-	}, {});
-}
-
-/**
- * Calculate the byte size of pin data.
- */
-export function getPinDataSize(
-	pinData: Record<string, string | INodeExecutionData[]> = {},
-): number {
-	return Object.values(pinData).reduce<number>((acc, value) => {
-		return acc + stringSizeInBytes(value);
-	}, 0);
 }
 
 /**
@@ -131,45 +71,22 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 		 * Pin Data
 		 */
 
-		const pinData = ref<IPinData>({});
-
-		function setPinData(newPinData: IPinData) {
-			onChange({ name: 'setPinData', payload: { pinData: newPinData } });
-		}
-
-		function pinNodeData(nodeName: string, data: INodeExecutionData[]) {
-			onChange({ name: 'pinNodeData', payload: { nodeName, data } });
-		}
-
-		function unpinNodeData(nodeName: string) {
-			onChange({ name: 'unpinNodeData', payload: { nodeName } });
-		}
-
-		function renamePinDataNode(oldName: string, newName: string) {
-			onChange({ name: 'renamePinDataNode', payload: { oldName, newName } });
-		}
-
-		function pinDataByNodeName(nodeName: string): INodeExecutionData[] | undefined {
-			if (!pinData.value[nodeName]) return undefined;
-
-			return pinData.value[nodeName].map((item) => item.json) as INodeExecutionData[];
-		}
-
-		/** Returns a mutable shallow copy of all pin data, bypassing the readonly wrapper. */
-		function getPinDataSnapshot(): IPinData {
-			return { ...pinData.value };
-		}
-
-		/** Returns pin data for a specific node, bypassing the readonly wrapper. */
-		function getNodePinData(nodeName: string): INodeExecutionData[] | undefined {
-			return pinData.value[nodeName];
-		}
+		const {
+			pinData,
+			setPinData,
+			pinNodeData,
+			unpinNodeData,
+			renamePinDataNode,
+			pinDataByNodeName,
+			getPinDataSnapshot,
+			getNodePinData,
+		} = useWorkflowDocumentPinData();
 
 		/**
-		 * Handle actions in a CRDT like manner
+		 * Handle tag actions in a CRDT like manner
 		 */
 
-		function onChange(action: WorkflowDocumentAction) {
+		function onChange(action: TagAction) {
 			if (action.name === 'setTags') {
 				tags.value = action.payload.tags;
 			} else if (action.name === 'addTags') {
@@ -177,45 +94,6 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 				tags.value = Array.from(uniqueTags);
 			} else if (action.name === 'removeTag') {
 				tags.value = tags.value.filter((tag) => tag !== action.payload.tagId);
-			} else if (action.name === 'setPinData') {
-				const normalized = normalizePinData(action.payload.pinData);
-				pinData.value = normalized;
-				dataPinningEventBus.emit('pin-data', normalized);
-			} else if (action.name === 'pinNodeData') {
-				const storedData = normalizeNodeExecutionData(action.payload.data);
-				pinData.value = { ...pinData.value, [action.payload.nodeName]: storedData };
-				dataPinningEventBus.emit('pin-data', {
-					[action.payload.nodeName]: storedData,
-				});
-			} else if (action.name === 'unpinNodeData') {
-				const { [action.payload.nodeName]: _, ...rest } = pinData.value;
-				pinData.value = rest;
-				dataPinningEventBus.emit('unpin-data', {
-					nodeNames: [action.payload.nodeName],
-				});
-			} else if (action.name === 'renamePinDataNode') {
-				const { oldName, newName } = action.payload;
-				if (pinData.value[oldName]) {
-					const { [oldName]: renamed, ...rest } = pinData.value;
-					pinData.value = { ...rest, [newName]: renamed };
-				}
-				// Update pairedItem sourceOverwrite references to the old node name
-				Object.values(pinData.value)
-					.flatMap((executionData) =>
-						executionData.flatMap((nodeExecution) =>
-							Array.isArray(nodeExecution.pairedItem)
-								? nodeExecution.pairedItem
-								: [nodeExecution.pairedItem],
-						),
-					)
-					.forEach((pairedItem) => {
-						if (
-							typeof pairedItem === 'number' ||
-							pairedItem?.sourceOverwrite?.previousNode !== oldName
-						)
-							return;
-						pairedItem.sourceOverwrite.previousNode = newName;
-					});
 			}
 		}
 
@@ -226,7 +104,7 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 			setTags,
 			addTags,
 			removeTag,
-			pinData: readonly(pinData),
+			pinData,
 			setPinData,
 			pinNodeData,
 			unpinNodeData,

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentPinData.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentPinData.test.ts
@@ -3,6 +3,7 @@ import type { INodeExecutionData, IPinData } from 'n8n-workflow';
 import {
 	useWorkflowDocumentPinData,
 	getPinDataSize,
+	pinDataToExecutionData,
 	type PinDataAction,
 } from './useWorkflowDocumentPinData';
 import { dataPinningEventBus } from '@/app/event-bus';
@@ -335,20 +336,28 @@ describe('useWorkflowDocumentPinData', () => {
 		});
 	});
 
-	describe('pinDataByNodeName', () => {
-		it('should return undefined for non-existent node', () => {
-			const { pinDataByNodeName } = createPinData();
-
-			expect(pinDataByNodeName('NonExistent')).toBeUndefined();
+	describe('pinDataToExecutionData', () => {
+		it('should return empty object for empty pin data', () => {
+			expect(pinDataToExecutionData({})).toEqual({});
 		});
 
-		it('should return unwrapped json values', () => {
-			const { pinNodeData, pinDataByNodeName } = createPinData();
+		it('should return undefined when indexing a non-existent node', () => {
+			const { pinData } = createPinData();
+
+			expect(pinDataToExecutionData(pinData.value).NonExistent).toBeUndefined();
+		});
+
+		it('should return unwrapped json values for all nodes', () => {
+			const { pinData, pinNodeData } = createPinData();
 			pinNodeData('Node1', [{ json: { key: 'value1' } }, { json: { key: 'value2' } }]);
+			pinNodeData('Node2', [{ json: { key: 'value3' } }]);
 
-			const result = pinDataByNodeName('Node1');
+			const result = pinDataToExecutionData(pinData.value);
 
-			expect(result).toEqual([{ key: 'value1' }, { key: 'value2' }]);
+			expect(result).toEqual({
+				Node1: [{ key: 'value1' }, { key: 'value2' }],
+				Node2: [{ key: 'value3' }],
+			});
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentPinData.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentPinData.test.ts
@@ -1,0 +1,353 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { INodeExecutionData, IPinData } from 'n8n-workflow';
+import { useWorkflowDocumentPinData, getPinDataSize } from './useWorkflowDocumentPinData';
+import { dataPinningEventBus } from '@/app/event-bus';
+
+vi.mock('@/app/event-bus', () => ({
+	dataPinningEventBus: {
+		emit: vi.fn(),
+	},
+}));
+
+describe('useWorkflowDocumentPinData', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('initial state', () => {
+		it('should start with empty pin data', () => {
+			const { pinData } = useWorkflowDocumentPinData();
+			expect(pinData.value).toEqual({});
+		});
+	});
+
+	describe('setPinData', () => {
+		it('should set pin data with json-key objects', () => {
+			const { pinData, setPinData } = useWorkflowDocumentPinData();
+			const data: IPinData = {
+				Node1: [{ json: { key: 'value' } }],
+			};
+
+			setPinData(data);
+
+			expect(pinData.value).toEqual({ Node1: [{ json: { key: 'value' } }] });
+		});
+
+		it('should normalize items without json key wrapper', () => {
+			const { pinData, setPinData } = useWorkflowDocumentPinData();
+			const data = {
+				Node1: [{ key: 'value' } as unknown as INodeExecutionData],
+			};
+
+			setPinData(data);
+
+			expect(pinData.value).toEqual({ Node1: [{ json: { key: 'value' } }] });
+		});
+
+		it('should emit pin-data event', () => {
+			const { setPinData } = useWorkflowDocumentPinData();
+			const data: IPinData = {
+				Node1: [{ json: { key: 'value' } }],
+			};
+
+			setPinData(data);
+
+			expect(dataPinningEventBus.emit).toHaveBeenCalledWith('pin-data', {
+				Node1: [{ json: { key: 'value' } }],
+			});
+		});
+
+		it('should replace existing pin data entirely', () => {
+			const { pinData, setPinData } = useWorkflowDocumentPinData();
+			setPinData({ Node1: [{ json: { a: 1 } }] });
+			setPinData({ Node2: [{ json: { b: 2 } }] });
+
+			expect(pinData.value).toEqual({ Node2: [{ json: { b: 2 } }] });
+			expect(pinData.value).not.toHaveProperty('Node1');
+		});
+	});
+
+	describe('pinNodeData', () => {
+		it('should pin data for a specific node', () => {
+			const { pinData, pinNodeData } = useWorkflowDocumentPinData();
+
+			pinNodeData('Node1', [{ json: { key: 'value' } }]);
+
+			expect(pinData.value).toEqual({ Node1: [{ json: { key: 'value' } }] });
+		});
+
+		it('should normalize data by stripping runtime properties', () => {
+			const { pinData, pinNodeData } = useWorkflowDocumentPinData();
+			const data = [
+				{
+					json: { key: 'value' },
+					binary: { file: { mimeType: 'text/plain', data: 'abc' } },
+					pairedItem: { item: 0 },
+					// runtime properties that should be stripped
+					index: 0,
+					executionIndex: 5,
+				} as unknown as INodeExecutionData,
+			];
+
+			pinNodeData('Node1', data);
+
+			expect(pinData.value.Node1[0]).toEqual({
+				json: { key: 'value' },
+				binary: { file: { mimeType: 'text/plain', data: 'abc' } },
+				pairedItem: { item: 0 },
+			});
+			expect(pinData.value.Node1[0]).not.toHaveProperty('index');
+			expect(pinData.value.Node1[0]).not.toHaveProperty('executionIndex');
+		});
+
+		it('should wrap items without json key in { json: item }', () => {
+			const { pinData, pinNodeData } = useWorkflowDocumentPinData();
+			const data = [{ key: 'value' } as unknown as INodeExecutionData];
+
+			pinNodeData('Node1', data);
+
+			expect(pinData.value).toEqual({
+				Node1: [{ json: { key: 'value' } }],
+			});
+		});
+
+		it('should preserve existing nodes when pinning a new one', () => {
+			const { pinData, pinNodeData } = useWorkflowDocumentPinData();
+			pinNodeData('Node1', [{ json: { a: 1 } }]);
+			pinNodeData('Node2', [{ json: { b: 2 } }]);
+
+			expect(pinData.value).toEqual({
+				Node1: [{ json: { a: 1 } }],
+				Node2: [{ json: { b: 2 } }],
+			});
+		});
+
+		it('should overwrite existing pin data for the same node', () => {
+			const { pinData, pinNodeData } = useWorkflowDocumentPinData();
+			pinNodeData('Node1', [{ json: { a: 1 } }]);
+			pinNodeData('Node1', [{ json: { a: 2 } }]);
+
+			expect(pinData.value).toEqual({ Node1: [{ json: { a: 2 } }] });
+		});
+
+		it('should emit pin-data event with normalized data', () => {
+			const { pinNodeData } = useWorkflowDocumentPinData();
+			pinNodeData('Node1', [{ json: { key: 'value' } }]);
+
+			expect(dataPinningEventBus.emit).toHaveBeenCalledWith('pin-data', {
+				Node1: [{ json: { key: 'value' } }],
+			});
+		});
+
+		it('should handle non-array input by wrapping in array', () => {
+			const { pinData, pinNodeData } = useWorkflowDocumentPinData();
+			const data = { json: { key: 'value' } } as unknown as INodeExecutionData[];
+
+			pinNodeData('Node1', data);
+
+			expect(pinData.value).toEqual({ Node1: [{ json: { key: 'value' } }] });
+		});
+	});
+
+	describe('unpinNodeData', () => {
+		it('should remove pin data for a specific node', () => {
+			const { pinData, pinNodeData, unpinNodeData } = useWorkflowDocumentPinData();
+			pinNodeData('Node1', [{ json: { a: 1 } }]);
+			pinNodeData('Node2', [{ json: { b: 2 } }]);
+
+			unpinNodeData('Node1');
+
+			expect(pinData.value).toEqual({ Node2: [{ json: { b: 2 } }] });
+		});
+
+		it('should emit unpin-data event', () => {
+			const { pinNodeData, unpinNodeData } = useWorkflowDocumentPinData();
+			pinNodeData('Node1', [{ json: { a: 1 } }]);
+			vi.mocked(dataPinningEventBus.emit).mockClear();
+
+			unpinNodeData('Node1');
+
+			expect(dataPinningEventBus.emit).toHaveBeenCalledWith('unpin-data', {
+				nodeNames: ['Node1'],
+			});
+		});
+
+		it('should handle unpinning a non-existent node gracefully', () => {
+			const { pinData, unpinNodeData } = useWorkflowDocumentPinData();
+
+			unpinNodeData('NonExistent');
+
+			expect(pinData.value).toEqual({});
+		});
+	});
+
+	describe('renamePinDataNode', () => {
+		it('should rename a node key in pin data', () => {
+			const { pinData, pinNodeData, renamePinDataNode } = useWorkflowDocumentPinData();
+			pinNodeData('OldName', [{ json: { key: 'value' } }]);
+
+			renamePinDataNode('OldName', 'NewName');
+
+			expect(pinData.value).not.toHaveProperty('OldName');
+			expect(pinData.value).toEqual({ NewName: [{ json: { key: 'value' } }] });
+		});
+
+		it('should not modify pin data if old name does not exist', () => {
+			const { pinData, pinNodeData, renamePinDataNode } = useWorkflowDocumentPinData();
+			pinNodeData('Node1', [{ json: { key: 'value' } }]);
+
+			renamePinDataNode('NonExistent', 'NewName');
+
+			expect(pinData.value).toEqual({ Node1: [{ json: { key: 'value' } }] });
+			expect(pinData.value).not.toHaveProperty('NewName');
+		});
+
+		it('should update pairedItem sourceOverwrite references', () => {
+			const { pinData, setPinData, renamePinDataNode } = useWorkflowDocumentPinData();
+			setPinData({
+				Node2: [
+					{
+						json: { data: 'test' },
+						pairedItem: {
+							item: 0,
+							sourceOverwrite: { previousNode: 'OldName', previousNodeOutput: 0 },
+						},
+					},
+				],
+			});
+
+			renamePinDataNode('OldName', 'NewName');
+
+			const pairedItem = pinData.value.Node2[0].pairedItem as {
+				sourceOverwrite: { previousNode: string };
+			};
+			expect(pairedItem.sourceOverwrite.previousNode).toBe('NewName');
+		});
+
+		it('should update pairedItem array sourceOverwrite references', () => {
+			const { pinData, setPinData, renamePinDataNode } = useWorkflowDocumentPinData();
+			setPinData({
+				Node2: [
+					{
+						json: { data: 'test' },
+						pairedItem: [
+							{
+								item: 0,
+								sourceOverwrite: { previousNode: 'OldName', previousNodeOutput: 0 },
+							},
+							{
+								item: 1,
+								sourceOverwrite: { previousNode: 'OtherNode', previousNodeOutput: 0 },
+							},
+						],
+					},
+				],
+			});
+
+			renamePinDataNode('OldName', 'NewName');
+
+			const pairedItems = pinData.value.Node2[0].pairedItem as Array<{
+				sourceOverwrite: { previousNode: string };
+			}>;
+			expect(pairedItems[0].sourceOverwrite.previousNode).toBe('NewName');
+			expect(pairedItems[1].sourceOverwrite.previousNode).toBe('OtherNode');
+		});
+
+		it('should skip numeric pairedItem values', () => {
+			const { pinData, setPinData, renamePinDataNode } = useWorkflowDocumentPinData();
+			setPinData({
+				Node2: [
+					{
+						json: { data: 'test' },
+						pairedItem: 0,
+					},
+				],
+			});
+
+			expect(() => renamePinDataNode('OldName', 'NewName')).not.toThrow();
+			expect(pinData.value.Node2[0].pairedItem).toBe(0);
+		});
+	});
+
+	describe('pinDataByNodeName', () => {
+		it('should return undefined for non-existent node', () => {
+			const { pinDataByNodeName } = useWorkflowDocumentPinData();
+
+			expect(pinDataByNodeName('NonExistent')).toBeUndefined();
+		});
+
+		it('should return unwrapped json values', () => {
+			const { pinNodeData, pinDataByNodeName } = useWorkflowDocumentPinData();
+			pinNodeData('Node1', [{ json: { key: 'value1' } }, { json: { key: 'value2' } }]);
+
+			const result = pinDataByNodeName('Node1');
+
+			expect(result).toEqual([{ key: 'value1' }, { key: 'value2' }]);
+		});
+	});
+
+	describe('getPinDataSnapshot', () => {
+		it('should return a mutable shallow copy', () => {
+			const { pinData, pinNodeData, getPinDataSnapshot } = useWorkflowDocumentPinData();
+			pinNodeData('Node1', [{ json: { key: 'value' } }]);
+
+			const snapshot = getPinDataSnapshot();
+
+			expect(snapshot).toEqual(pinData.value);
+			// Should be a different object reference
+			snapshot.Node2 = [{ json: { key: 'new' } }];
+			expect(pinData.value).not.toHaveProperty('Node2');
+		});
+	});
+
+	describe('getNodePinData', () => {
+		it('should return undefined for non-existent node', () => {
+			const { getNodePinData } = useWorkflowDocumentPinData();
+
+			expect(getNodePinData('NonExistent')).toBeUndefined();
+		});
+
+		it('should return raw pin data for a node', () => {
+			const { pinNodeData, getNodePinData } = useWorkflowDocumentPinData();
+			pinNodeData('Node1', [{ json: { key: 'value' } }]);
+
+			const result = getNodePinData('Node1');
+
+			expect(result).toEqual([{ json: { key: 'value' } }]);
+		});
+	});
+});
+
+describe('getPinDataSize', () => {
+	it('should return 0 for empty pin data', () => {
+		expect(getPinDataSize({})).toBe(0);
+	});
+
+	it('should return 0 when called without arguments', () => {
+		expect(getPinDataSize()).toBe(0);
+	});
+
+	it('should calculate size for string values', () => {
+		const result = getPinDataSize({ Node1: 'test' });
+		expect(result).toBeGreaterThan(0);
+	});
+
+	it('should calculate size for INodeExecutionData array values', () => {
+		const result = getPinDataSize({
+			Node1: [{ json: { key: 'value' } }] as INodeExecutionData[],
+		});
+		expect(result).toBeGreaterThan(0);
+	});
+
+	it('should sum sizes across all nodes', () => {
+		const singleNode = getPinDataSize({
+			Node1: [{ json: { key: 'value' } }] as INodeExecutionData[],
+		});
+		const twoNodes = getPinDataSize({
+			Node1: [{ json: { key: 'value' } }] as INodeExecutionData[],
+			Node2: [{ json: { key: 'value' } }] as INodeExecutionData[],
+		});
+
+		expect(twoNodes).toBeGreaterThan(singleNode);
+	});
+});

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentPinData.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentPinData.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { INodeExecutionData, IPinData } from 'n8n-workflow';
-import { useWorkflowDocumentPinData, getPinDataSize } from './useWorkflowDocumentPinData';
+import {
+	useWorkflowDocumentPinData,
+	getPinDataSize,
+	type PinDataAction,
+} from './useWorkflowDocumentPinData';
 import { dataPinningEventBus } from '@/app/event-bus';
 
 vi.mock('@/app/event-bus', () => ({
@@ -9,6 +13,20 @@ vi.mock('@/app/event-bus', () => ({
 	},
 }));
 
+/**
+ * Creates the composable wired through a spy onChange.
+ * The spy calls handleAction, simulating the store's unified dispatcher.
+ */
+function createPinData() {
+	const onChangeSpy = vi.fn<(action: PinDataAction) => void>();
+	const composable = useWorkflowDocumentPinData(onChangeSpy);
+
+	// Wire the spy to call handleAction, simulating the store's onChange dispatcher
+	onChangeSpy.mockImplementation(composable.handleAction);
+
+	return { ...composable, onChangeSpy };
+}
+
 describe('useWorkflowDocumentPinData', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -16,14 +34,14 @@ describe('useWorkflowDocumentPinData', () => {
 
 	describe('initial state', () => {
 		it('should start with empty pin data', () => {
-			const { pinData } = useWorkflowDocumentPinData();
+			const { pinData } = createPinData();
 			expect(pinData.value).toEqual({});
 		});
 	});
 
 	describe('setPinData', () => {
 		it('should set pin data with json-key objects', () => {
-			const { pinData, setPinData } = useWorkflowDocumentPinData();
+			const { pinData, setPinData } = createPinData();
 			const data: IPinData = {
 				Node1: [{ json: { key: 'value' } }],
 			};
@@ -33,8 +51,20 @@ describe('useWorkflowDocumentPinData', () => {
 			expect(pinData.value).toEqual({ Node1: [{ json: { key: 'value' } }] });
 		});
 
+		it('should route through onChange', () => {
+			const { setPinData, onChangeSpy } = createPinData();
+			const data: IPinData = { Node1: [{ json: { key: 'value' } }] };
+
+			setPinData(data);
+
+			expect(onChangeSpy).toHaveBeenCalledWith({
+				name: 'setPinData',
+				payload: { pinData: data },
+			});
+		});
+
 		it('should normalize items without json key wrapper', () => {
-			const { pinData, setPinData } = useWorkflowDocumentPinData();
+			const { pinData, setPinData } = createPinData();
 			const data = {
 				Node1: [{ key: 'value' } as unknown as INodeExecutionData],
 			};
@@ -45,7 +75,7 @@ describe('useWorkflowDocumentPinData', () => {
 		});
 
 		it('should emit pin-data event', () => {
-			const { setPinData } = useWorkflowDocumentPinData();
+			const { setPinData } = createPinData();
 			const data: IPinData = {
 				Node1: [{ json: { key: 'value' } }],
 			};
@@ -58,7 +88,7 @@ describe('useWorkflowDocumentPinData', () => {
 		});
 
 		it('should replace existing pin data entirely', () => {
-			const { pinData, setPinData } = useWorkflowDocumentPinData();
+			const { pinData, setPinData } = createPinData();
 			setPinData({ Node1: [{ json: { a: 1 } }] });
 			setPinData({ Node2: [{ json: { b: 2 } }] });
 
@@ -69,15 +99,27 @@ describe('useWorkflowDocumentPinData', () => {
 
 	describe('pinNodeData', () => {
 		it('should pin data for a specific node', () => {
-			const { pinData, pinNodeData } = useWorkflowDocumentPinData();
+			const { pinData, pinNodeData } = createPinData();
 
 			pinNodeData('Node1', [{ json: { key: 'value' } }]);
 
 			expect(pinData.value).toEqual({ Node1: [{ json: { key: 'value' } }] });
 		});
 
+		it('should route through onChange', () => {
+			const { pinNodeData, onChangeSpy } = createPinData();
+			const data = [{ json: { key: 'value' } }];
+
+			pinNodeData('Node1', data);
+
+			expect(onChangeSpy).toHaveBeenCalledWith({
+				name: 'pinNodeData',
+				payload: { nodeName: 'Node1', data },
+			});
+		});
+
 		it('should normalize data by stripping runtime properties', () => {
-			const { pinData, pinNodeData } = useWorkflowDocumentPinData();
+			const { pinData, pinNodeData } = createPinData();
 			const data = [
 				{
 					json: { key: 'value' },
@@ -101,7 +143,7 @@ describe('useWorkflowDocumentPinData', () => {
 		});
 
 		it('should wrap items without json key in { json: item }', () => {
-			const { pinData, pinNodeData } = useWorkflowDocumentPinData();
+			const { pinData, pinNodeData } = createPinData();
 			const data = [{ key: 'value' } as unknown as INodeExecutionData];
 
 			pinNodeData('Node1', data);
@@ -112,7 +154,7 @@ describe('useWorkflowDocumentPinData', () => {
 		});
 
 		it('should preserve existing nodes when pinning a new one', () => {
-			const { pinData, pinNodeData } = useWorkflowDocumentPinData();
+			const { pinData, pinNodeData } = createPinData();
 			pinNodeData('Node1', [{ json: { a: 1 } }]);
 			pinNodeData('Node2', [{ json: { b: 2 } }]);
 
@@ -123,7 +165,7 @@ describe('useWorkflowDocumentPinData', () => {
 		});
 
 		it('should overwrite existing pin data for the same node', () => {
-			const { pinData, pinNodeData } = useWorkflowDocumentPinData();
+			const { pinData, pinNodeData } = createPinData();
 			pinNodeData('Node1', [{ json: { a: 1 } }]);
 			pinNodeData('Node1', [{ json: { a: 2 } }]);
 
@@ -131,7 +173,7 @@ describe('useWorkflowDocumentPinData', () => {
 		});
 
 		it('should emit pin-data event with normalized data', () => {
-			const { pinNodeData } = useWorkflowDocumentPinData();
+			const { pinNodeData } = createPinData();
 			pinNodeData('Node1', [{ json: { key: 'value' } }]);
 
 			expect(dataPinningEventBus.emit).toHaveBeenCalledWith('pin-data', {
@@ -140,7 +182,7 @@ describe('useWorkflowDocumentPinData', () => {
 		});
 
 		it('should handle non-array input by wrapping in array', () => {
-			const { pinData, pinNodeData } = useWorkflowDocumentPinData();
+			const { pinData, pinNodeData } = createPinData();
 			const data = { json: { key: 'value' } } as unknown as INodeExecutionData[];
 
 			pinNodeData('Node1', data);
@@ -151,7 +193,7 @@ describe('useWorkflowDocumentPinData', () => {
 
 	describe('unpinNodeData', () => {
 		it('should remove pin data for a specific node', () => {
-			const { pinData, pinNodeData, unpinNodeData } = useWorkflowDocumentPinData();
+			const { pinData, pinNodeData, unpinNodeData } = createPinData();
 			pinNodeData('Node1', [{ json: { a: 1 } }]);
 			pinNodeData('Node2', [{ json: { b: 2 } }]);
 
@@ -160,8 +202,21 @@ describe('useWorkflowDocumentPinData', () => {
 			expect(pinData.value).toEqual({ Node2: [{ json: { b: 2 } }] });
 		});
 
+		it('should route through onChange', () => {
+			const { pinNodeData, unpinNodeData, onChangeSpy } = createPinData();
+			pinNodeData('Node1', [{ json: { a: 1 } }]);
+			onChangeSpy.mockClear();
+
+			unpinNodeData('Node1');
+
+			expect(onChangeSpy).toHaveBeenCalledWith({
+				name: 'unpinNodeData',
+				payload: { nodeName: 'Node1' },
+			});
+		});
+
 		it('should emit unpin-data event', () => {
-			const { pinNodeData, unpinNodeData } = useWorkflowDocumentPinData();
+			const { pinNodeData, unpinNodeData } = createPinData();
 			pinNodeData('Node1', [{ json: { a: 1 } }]);
 			vi.mocked(dataPinningEventBus.emit).mockClear();
 
@@ -173,7 +228,7 @@ describe('useWorkflowDocumentPinData', () => {
 		});
 
 		it('should handle unpinning a non-existent node gracefully', () => {
-			const { pinData, unpinNodeData } = useWorkflowDocumentPinData();
+			const { pinData, unpinNodeData } = createPinData();
 
 			unpinNodeData('NonExistent');
 
@@ -183,7 +238,7 @@ describe('useWorkflowDocumentPinData', () => {
 
 	describe('renamePinDataNode', () => {
 		it('should rename a node key in pin data', () => {
-			const { pinData, pinNodeData, renamePinDataNode } = useWorkflowDocumentPinData();
+			const { pinData, pinNodeData, renamePinDataNode } = createPinData();
 			pinNodeData('OldName', [{ json: { key: 'value' } }]);
 
 			renamePinDataNode('OldName', 'NewName');
@@ -192,8 +247,19 @@ describe('useWorkflowDocumentPinData', () => {
 			expect(pinData.value).toEqual({ NewName: [{ json: { key: 'value' } }] });
 		});
 
+		it('should route through onChange', () => {
+			const { renamePinDataNode, onChangeSpy } = createPinData();
+
+			renamePinDataNode('OldName', 'NewName');
+
+			expect(onChangeSpy).toHaveBeenCalledWith({
+				name: 'renamePinDataNode',
+				payload: { oldName: 'OldName', newName: 'NewName' },
+			});
+		});
+
 		it('should not modify pin data if old name does not exist', () => {
-			const { pinData, pinNodeData, renamePinDataNode } = useWorkflowDocumentPinData();
+			const { pinData, pinNodeData, renamePinDataNode } = createPinData();
 			pinNodeData('Node1', [{ json: { key: 'value' } }]);
 
 			renamePinDataNode('NonExistent', 'NewName');
@@ -203,7 +269,7 @@ describe('useWorkflowDocumentPinData', () => {
 		});
 
 		it('should update pairedItem sourceOverwrite references', () => {
-			const { pinData, setPinData, renamePinDataNode } = useWorkflowDocumentPinData();
+			const { pinData, setPinData, renamePinDataNode } = createPinData();
 			setPinData({
 				Node2: [
 					{
@@ -225,7 +291,7 @@ describe('useWorkflowDocumentPinData', () => {
 		});
 
 		it('should update pairedItem array sourceOverwrite references', () => {
-			const { pinData, setPinData, renamePinDataNode } = useWorkflowDocumentPinData();
+			const { pinData, setPinData, renamePinDataNode } = createPinData();
 			setPinData({
 				Node2: [
 					{
@@ -246,7 +312,7 @@ describe('useWorkflowDocumentPinData', () => {
 
 			renamePinDataNode('OldName', 'NewName');
 
-			const pairedItems = pinData.value.Node2[0].pairedItem as Array<{
+			const pairedItems = pinData.value.Node2[0].pairedItem as unknown as Array<{
 				sourceOverwrite: { previousNode: string };
 			}>;
 			expect(pairedItems[0].sourceOverwrite.previousNode).toBe('NewName');
@@ -254,7 +320,7 @@ describe('useWorkflowDocumentPinData', () => {
 		});
 
 		it('should skip numeric pairedItem values', () => {
-			const { pinData, setPinData, renamePinDataNode } = useWorkflowDocumentPinData();
+			const { pinData, setPinData, renamePinDataNode } = createPinData();
 			setPinData({
 				Node2: [
 					{
@@ -271,13 +337,13 @@ describe('useWorkflowDocumentPinData', () => {
 
 	describe('pinDataByNodeName', () => {
 		it('should return undefined for non-existent node', () => {
-			const { pinDataByNodeName } = useWorkflowDocumentPinData();
+			const { pinDataByNodeName } = createPinData();
 
 			expect(pinDataByNodeName('NonExistent')).toBeUndefined();
 		});
 
 		it('should return unwrapped json values', () => {
-			const { pinNodeData, pinDataByNodeName } = useWorkflowDocumentPinData();
+			const { pinNodeData, pinDataByNodeName } = createPinData();
 			pinNodeData('Node1', [{ json: { key: 'value1' } }, { json: { key: 'value2' } }]);
 
 			const result = pinDataByNodeName('Node1');
@@ -288,7 +354,7 @@ describe('useWorkflowDocumentPinData', () => {
 
 	describe('getPinDataSnapshot', () => {
 		it('should return a mutable shallow copy', () => {
-			const { pinData, pinNodeData, getPinDataSnapshot } = useWorkflowDocumentPinData();
+			const { pinData, pinNodeData, getPinDataSnapshot } = createPinData();
 			pinNodeData('Node1', [{ json: { key: 'value' } }]);
 
 			const snapshot = getPinDataSnapshot();
@@ -302,13 +368,13 @@ describe('useWorkflowDocumentPinData', () => {
 
 	describe('getNodePinData', () => {
 		it('should return undefined for non-existent node', () => {
-			const { getNodePinData } = useWorkflowDocumentPinData();
+			const { getNodePinData } = createPinData();
 
 			expect(getNodePinData('NonExistent')).toBeUndefined();
 		});
 
 		it('should return raw pin data for a node', () => {
-			const { pinNodeData, getNodePinData } = useWorkflowDocumentPinData();
+			const { pinNodeData, getNodePinData } = createPinData();
 			pinNodeData('Node1', [{ json: { key: 'value' } }]);
 
 			const result = getNodePinData('Node1');

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentPinData.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentPinData.test.ts
@@ -284,7 +284,7 @@ describe('useWorkflowDocumentPinData', () => {
 
 			renamePinDataNode('OldName', 'NewName');
 
-			const pairedItem = pinData.value.Node2[0].pairedItem as {
+			const pairedItem = pinData.value.Node2[0].pairedItem as unknown as {
 				sourceOverwrite: { previousNode: string };
 			};
 			expect(pairedItem.sourceOverwrite.previousNode).toBe('NewName');

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentPinData.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentPinData.ts
@@ -1,0 +1,159 @@
+import { ref, readonly } from 'vue';
+import type { INodeExecutionData, IPinData } from 'n8n-workflow';
+import { isJsonKeyObject, stringSizeInBytes } from '@/app/utils/typesUtils';
+import { dataPinningEventBus } from '@/app/event-bus';
+
+type Action<N, P> = { name: N; payload: P };
+
+type SetPinDataAction = Action<'setPinData', { pinData: IPinData }>;
+type PinNodeDataAction = Action<'pinNodeData', { nodeName: string; data: INodeExecutionData[] }>;
+type UnpinNodeDataAction = Action<'unpinNodeData', { nodeName: string }>;
+type RenamePinDataNodeAction = Action<'renamePinDataNode', { oldName: string; newName: string }>;
+
+export type PinDataAction =
+	| SetPinDataAction
+	| PinNodeDataAction
+	| UnpinNodeDataAction
+	| RenamePinDataNodeAction;
+
+/**
+ * Normalize an array of node execution data items by stripping runtime properties.
+ * Only keeps json, binary, and pairedItem.
+ */
+function normalizeNodeExecutionData(data: INodeExecutionData[]): INodeExecutionData[] {
+	if (!Array.isArray(data)) {
+		data = [data];
+	}
+
+	return data.map((item) => {
+		if (isJsonKeyObject(item)) {
+			const { json, binary, pairedItem } = item;
+			return {
+				json,
+				...(binary && { binary }),
+				...(pairedItem !== undefined && { pairedItem }),
+			};
+		}
+		return { json: item };
+	}) as INodeExecutionData[];
+}
+
+/**
+ * Normalize pin data by ensuring all items have the json key wrapper.
+ */
+function normalizePinData(data: IPinData): IPinData {
+	return Object.keys(data).reduce<IPinData>((accu, nodeName) => {
+		accu[nodeName] = data[nodeName].map((item) => {
+			if (!isJsonKeyObject(item)) {
+				return { json: item };
+			}
+			return item;
+		});
+		return accu;
+	}, {});
+}
+
+/**
+ * Calculate the byte size of pin data.
+ */
+export function getPinDataSize(
+	pinData: Record<string, string | INodeExecutionData[]> = {},
+): number {
+	return Object.values(pinData).reduce<number>((acc, value) => {
+		return acc + stringSizeInBytes(value);
+	}, 0);
+}
+
+/**
+ * Composable that encapsulates all pin data state and actions
+ * for a workflow document store.
+ */
+export function useWorkflowDocumentPinData() {
+	const pinData = ref<IPinData>({});
+
+	function setPinData(newPinData: IPinData) {
+		onChange({ name: 'setPinData', payload: { pinData: newPinData } });
+	}
+
+	function pinNodeData(nodeName: string, data: INodeExecutionData[]) {
+		onChange({ name: 'pinNodeData', payload: { nodeName, data } });
+	}
+
+	function unpinNodeData(nodeName: string) {
+		onChange({ name: 'unpinNodeData', payload: { nodeName } });
+	}
+
+	function renamePinDataNode(oldName: string, newName: string) {
+		onChange({ name: 'renamePinDataNode', payload: { oldName, newName } });
+	}
+
+	function pinDataByNodeName(nodeName: string): INodeExecutionData[] | undefined {
+		if (!pinData.value[nodeName]) return undefined;
+
+		return pinData.value[nodeName].map((item) => item.json) as INodeExecutionData[];
+	}
+
+	/** Returns a mutable shallow copy of all pin data, bypassing the readonly wrapper. */
+	function getPinDataSnapshot(): IPinData {
+		return { ...pinData.value };
+	}
+
+	/** Returns pin data for a specific node, bypassing the readonly wrapper. */
+	function getNodePinData(nodeName: string): INodeExecutionData[] | undefined {
+		return pinData.value[nodeName];
+	}
+
+	function onChange(action: PinDataAction) {
+		if (action.name === 'setPinData') {
+			const normalized = normalizePinData(action.payload.pinData);
+			pinData.value = normalized;
+			dataPinningEventBus.emit('pin-data', normalized);
+		} else if (action.name === 'pinNodeData') {
+			const storedData = normalizeNodeExecutionData(action.payload.data);
+			pinData.value = { ...pinData.value, [action.payload.nodeName]: storedData };
+			dataPinningEventBus.emit('pin-data', {
+				[action.payload.nodeName]: storedData,
+			});
+		} else if (action.name === 'unpinNodeData') {
+			const { [action.payload.nodeName]: _, ...rest } = pinData.value;
+			pinData.value = rest;
+			dataPinningEventBus.emit('unpin-data', {
+				nodeNames: [action.payload.nodeName],
+			});
+		} else if (action.name === 'renamePinDataNode') {
+			const { oldName, newName } = action.payload;
+			if (pinData.value[oldName]) {
+				const { [oldName]: renamed, ...rest } = pinData.value;
+				pinData.value = { ...rest, [newName]: renamed };
+			}
+			// Update pairedItem sourceOverwrite references to the old node name
+			Object.values(pinData.value)
+				.flatMap((executionData) =>
+					executionData.flatMap((nodeExecution) =>
+						Array.isArray(nodeExecution.pairedItem)
+							? nodeExecution.pairedItem
+							: [nodeExecution.pairedItem],
+					),
+				)
+				.forEach((pairedItem) => {
+					if (
+						typeof pairedItem === 'number' ||
+						pairedItem?.sourceOverwrite?.previousNode !== oldName
+					)
+						return;
+					pairedItem.sourceOverwrite.previousNode = newName;
+				});
+		}
+	}
+
+	return {
+		pinData: readonly(pinData),
+		setPinData,
+		pinNodeData,
+		unpinNodeData,
+		renamePinDataNode,
+		pinDataByNodeName,
+		getPinDataSnapshot,
+		getNodePinData,
+	};
+}

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentPinData.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentPinData.ts
@@ -1,5 +1,5 @@
 import { ref, readonly } from 'vue';
-import type { INodeExecutionData, IPinData } from 'n8n-workflow';
+import type { INodeExecutionData, IDataObject, IPinData } from 'n8n-workflow';
 import { isJsonKeyObject, stringSizeInBytes } from '@/app/utils/typesUtils';
 import { dataPinningEventBus } from '@/app/event-bus';
 
@@ -65,6 +65,17 @@ function normalizePinData(data: IPinData): IPinData {
 }
 
 /**
+ * Extract the json values from pin data, producing a map of node names to plain data objects.
+ */
+export function pinDataToExecutionData(
+	pinData: Readonly<Record<string, ReadonlyArray<{ readonly json: IDataObject }>>>,
+): Record<string, IDataObject[]> {
+	return Object.fromEntries(
+		Object.entries(pinData).map(([nodeName, items]) => [nodeName, items.map((item) => item.json)]),
+	);
+}
+
+/**
  * Calculate the byte size of pin data.
  */
 export function getPinDataSize(
@@ -99,12 +110,6 @@ export function useWorkflowDocumentPinData(onChange: (action: PinDataAction) => 
 
 	function renamePinDataNode(oldName: string, newName: string) {
 		onChange({ name: 'renamePinDataNode', payload: { oldName, newName } });
-	}
-
-	function pinDataByNodeName(nodeName: string): INodeExecutionData[] | undefined {
-		if (!pinData.value[nodeName]) return undefined;
-
-		return pinData.value[nodeName].map((item) => item.json) as INodeExecutionData[];
 	}
 
 	/** Returns a mutable shallow copy of all pin data, bypassing the readonly wrapper. */
@@ -170,7 +175,6 @@ export function useWorkflowDocumentPinData(onChange: (action: PinDataAction) => 
 		pinNodeData,
 		unpinNodeData,
 		renamePinDataNode,
-		pinDataByNodeName,
 		getPinDataSnapshot,
 		getNodePinData,
 		handleAction,

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentPinData.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentPinData.ts
@@ -16,6 +16,17 @@ export type PinDataAction =
 	| UnpinNodeDataAction
 	| RenamePinDataNodeAction;
 
+const PIN_DATA_ACTION_NAMES = new Set<string>([
+	'setPinData',
+	'pinNodeData',
+	'unpinNodeData',
+	'renamePinDataNode',
+]);
+
+export function isPinDataAction(action: { name: string }): action is PinDataAction {
+	return PIN_DATA_ACTION_NAMES.has(action.name);
+}
+
 /**
  * Normalize an array of node execution data items by stripping runtime properties.
  * Only keeps json, binary, and pairedItem.
@@ -65,10 +76,13 @@ export function getPinDataSize(
 }
 
 /**
- * Composable that encapsulates all pin data state and actions
+ * Composable that encapsulates pin data state, public API, and mutation logic
  * for a workflow document store.
+ *
+ * Accepts an `onChange` callback that routes actions through the store's
+ * unified dispatcher for CRDT migration readiness.
  */
-export function useWorkflowDocumentPinData() {
+export function useWorkflowDocumentPinData(onChange: (action: PinDataAction) => void) {
 	const pinData = ref<IPinData>({});
 
 	function setPinData(newPinData: IPinData) {
@@ -103,7 +117,11 @@ export function useWorkflowDocumentPinData() {
 		return pinData.value[nodeName];
 	}
 
-	function onChange(action: PinDataAction) {
+	/**
+	 * Apply a pin data action to the state.
+	 * Called by the store's unified onChange dispatcher.
+	 */
+	function handleAction(action: PinDataAction) {
 		if (action.name === 'setPinData') {
 			const normalized = normalizePinData(action.payload.pinData);
 			pinData.value = normalized;
@@ -155,5 +173,6 @@ export function useWorkflowDocumentPinData() {
 		pinDataByNodeName,
 		getPinDataSnapshot,
 		getNodePinData,
+		handleAction,
 	};
 }

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentTags.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentTags.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi } from 'vitest';
+import { useWorkflowDocumentTags, type TagAction } from './useWorkflowDocumentTags';
+
+/**
+ * Creates the composable wired through a spy onChange.
+ * The spy calls handleAction, simulating the store's unified dispatcher.
+ */
+function createTags() {
+	const onChangeSpy = vi.fn<(action: TagAction) => void>();
+	const composable = useWorkflowDocumentTags(onChangeSpy);
+
+	// Wire the spy to call handleAction, simulating the store's onChange dispatcher
+	onChangeSpy.mockImplementation(composable.handleAction);
+
+	return { ...composable, onChangeSpy };
+}
+
+describe('useWorkflowDocumentTags', () => {
+	describe('initial state', () => {
+		it('should start with empty tags', () => {
+			const { tags } = createTags();
+			expect(tags.value).toEqual([]);
+		});
+	});
+
+	describe('setTags', () => {
+		it('should set tags via onChange', () => {
+			const { tags, setTags, onChangeSpy } = createTags();
+
+			setTags(['tag1', 'tag2']);
+
+			expect(onChangeSpy).toHaveBeenCalledWith({
+				name: 'setTags',
+				payload: { tags: ['tag1', 'tag2'] },
+			});
+			expect(tags.value).toEqual(['tag1', 'tag2']);
+		});
+
+		it('should replace existing tags entirely', () => {
+			const { tags, setTags } = createTags();
+			setTags(['tag1']);
+
+			setTags(['tag2', 'tag3']);
+
+			expect(tags.value).toEqual(['tag2', 'tag3']);
+		});
+
+		it('should allow setting empty tags', () => {
+			const { tags, setTags } = createTags();
+			setTags(['tag1']);
+
+			setTags([]);
+
+			expect(tags.value).toEqual([]);
+		});
+	});
+
+	describe('addTags', () => {
+		it('should add tags via onChange', () => {
+			const { tags, addTags, onChangeSpy } = createTags();
+
+			addTags(['tag1', 'tag2']);
+
+			expect(onChangeSpy).toHaveBeenCalledWith({
+				name: 'addTags',
+				payload: { tags: ['tag1', 'tag2'] },
+			});
+			expect(tags.value).toEqual(['tag1', 'tag2']);
+		});
+
+		it('should append to existing tags', () => {
+			const { tags, setTags, addTags } = createTags();
+			setTags(['tag1']);
+
+			addTags(['tag2']);
+
+			expect(tags.value).toEqual(['tag1', 'tag2']);
+		});
+
+		it('should deduplicate tags', () => {
+			const { tags, setTags, addTags } = createTags();
+			setTags(['tag1', 'tag2']);
+
+			addTags(['tag2', 'tag3']);
+
+			expect(tags.value).toEqual(['tag1', 'tag2', 'tag3']);
+		});
+	});
+
+	describe('removeTag', () => {
+		it('should remove a tag via onChange', () => {
+			const { tags, setTags, removeTag, onChangeSpy } = createTags();
+			setTags(['tag1', 'tag2', 'tag3']);
+			onChangeSpy.mockClear();
+
+			removeTag('tag2');
+
+			expect(onChangeSpy).toHaveBeenCalledWith({
+				name: 'removeTag',
+				payload: { tagId: 'tag2' },
+			});
+			expect(tags.value).toEqual(['tag1', 'tag3']);
+		});
+
+		it('should handle removing a non-existent tag gracefully', () => {
+			const { tags, setTags, removeTag } = createTags();
+			setTags(['tag1']);
+
+			removeTag('nonexistent');
+
+			expect(tags.value).toEqual(['tag1']);
+		});
+
+		it('should handle removing from empty tags', () => {
+			const { tags, removeTag } = createTags();
+
+			removeTag('tag1');
+
+			expect(tags.value).toEqual([]);
+		});
+	});
+
+	describe('handleAction', () => {
+		it('should apply setTags action directly', () => {
+			const { tags, handleAction } = createTags();
+
+			handleAction({ name: 'setTags', payload: { tags: ['tag1'] } });
+
+			expect(tags.value).toEqual(['tag1']);
+		});
+
+		it('should apply addTags action directly', () => {
+			const { tags, handleAction } = createTags();
+			handleAction({ name: 'setTags', payload: { tags: ['tag1'] } });
+
+			handleAction({ name: 'addTags', payload: { tags: ['tag2'] } });
+
+			expect(tags.value).toEqual(['tag1', 'tag2']);
+		});
+
+		it('should apply removeTag action directly', () => {
+			const { tags, handleAction } = createTags();
+			handleAction({ name: 'setTags', payload: { tags: ['tag1', 'tag2'] } });
+
+			handleAction({ name: 'removeTag', payload: { tagId: 'tag1' } });
+
+			expect(tags.value).toEqual(['tag2']);
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentTags.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentTags.ts
@@ -1,0 +1,61 @@
+import { ref, readonly } from 'vue';
+
+type Action<N, P> = { name: N; payload: P };
+
+type SetTagsAction = Action<'setTags', { tags: string[] }>;
+type AddTagsAction = Action<'addTags', { tags: string[] }>;
+type RemoveTagAction = Action<'removeTag', { tagId: string }>;
+
+export type TagAction = SetTagsAction | AddTagsAction | RemoveTagAction;
+
+const TAG_ACTION_NAMES = new Set<string>(['setTags', 'addTags', 'removeTag']);
+
+export function isTagAction(action: { name: string }): action is TagAction {
+	return TAG_ACTION_NAMES.has(action.name);
+}
+
+/**
+ * Composable that encapsulates tag state, public API, and mutation logic
+ * for a workflow document store.
+ *
+ * Accepts an `onChange` callback that routes actions through the store's
+ * unified dispatcher for CRDT migration readiness.
+ */
+export function useWorkflowDocumentTags(onChange: (action: TagAction) => void) {
+	const tags = ref<string[]>([]);
+
+	function setTags(newTags: string[]) {
+		onChange({ name: 'setTags', payload: { tags: newTags } });
+	}
+
+	function addTags(newTags: string[]) {
+		onChange({ name: 'addTags', payload: { tags: newTags } });
+	}
+
+	function removeTag(tagId: string) {
+		onChange({ name: 'removeTag', payload: { tagId } });
+	}
+
+	/**
+	 * Apply a tag action to the state.
+	 * Called by the store's unified onChange dispatcher.
+	 */
+	function handleAction(action: TagAction) {
+		if (action.name === 'setTags') {
+			tags.value = action.payload.tags;
+		} else if (action.name === 'addTags') {
+			const uniqueTags = new Set([...tags.value, ...action.payload.tags]);
+			tags.value = Array.from(uniqueTags);
+		} else if (action.name === 'removeTag') {
+			tags.value = tags.value.filter((tag) => tag !== action.payload.tagId);
+		}
+	}
+
+	return {
+		tags: readonly(tags),
+		setTags,
+		addTags,
+		removeTag,
+		handleAction,
+	};
+}

--- a/packages/frontend/editor-ui/src/app/utils/expressions.ts
+++ b/packages/frontend/editor-ui/src/app/utils/expressions.ts
@@ -1,5 +1,9 @@
 import { i18n } from '@n8n/i18n';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import type { ResolvableState } from '@/app/types/expressions';
 import { ExpressionError, ExpressionParser, isExpression, type Result } from 'n8n-workflow';
 
@@ -96,7 +100,11 @@ export const getExpressionErrorMessage = (error: Error, nodeHasRunData = false):
 
 	if (isInvalidPairedItemError(error) || isNoPairedItemError(error)) {
 		const nodeCause = error.context.nodeCause as string;
-		const isPinned = !!useWorkflowsStore().pinDataByNodeName(nodeCause);
+		const workflowsStore = useWorkflowsStore();
+		const workflowDocumentStore = workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined;
+		const isPinned = !!workflowDocumentStore?.pinData?.[nodeCause];
 
 		if (isPinned) {
 			return i18n.baseText('expressionModalInput.pairedItemInvalidPinnedError', {

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -794,6 +794,7 @@ async function importWorkflowExact({ workflow: workflowData }: { workflow: Workf
 
 	const { workflowDocumentStore: newStore } = await initializeWorkspace({
 		...workflowData,
+		id: isDemoRoute.value ? 'demo' : workflowData.id,
 		nodes: getNodesWithNormalizedPosition<INodeUi>(workflowData.nodes),
 	} as IWorkflowDb);
 

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -2,6 +2,7 @@
 import {
 	computed,
 	defineAsyncComponent,
+	inject,
 	nextTick,
 	onActivated,
 	onBeforeMount,
@@ -145,8 +146,7 @@ import { injectWorkflowState } from '@/app/composables/useWorkflowState';
 import { useActivityDetection } from '@/app/composables/useActivityDetection';
 import { useCollaborationStore } from '@/features/collaboration/collaboration/collaboration.store';
 import { injectStrict } from '@/app/utils/injectStrict';
-import { WorkflowIdKey } from '@/app/constants/injectionKeys';
-import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import { WorkflowIdKey, WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
 
 import { N8nCallout, N8nCanvasThinkingPill, N8nCanvasCollaborationPill } from '@n8n/design-system';
 
@@ -214,7 +214,8 @@ const collaborationStore = useCollaborationStore();
 const emptyStateBuilderPromptStore = useEmptyStateBuilderPromptStore();
 const chatPanelStore = useChatPanelStore();
 
-const workflowDocumentStore = injectWorkflowDocumentStore();
+const workflowDocumentStoreRef = inject(WorkflowDocumentStoreKey, null);
+const workflowDocumentStore = computed(() => workflowDocumentStoreRef?.value ?? null);
 const workflowState = injectWorkflowState();
 
 // Initialize activity detection for collaboration
@@ -791,10 +792,14 @@ async function importWorkflowExact({ workflow: workflowData }: { workflow: Workf
 
 	resetWorkspace();
 
-	await initializeWorkspace({
+	const { workflowDocumentStore: newStore } = await initializeWorkspace({
 		...workflowData,
 		nodes: getNodesWithNormalizedPosition<INodeUi>(workflowData.nodes),
 	} as IWorkflowDb);
+
+	if (workflowDocumentStoreRef && newStore) {
+		workflowDocumentStoreRef.value = newStore;
+	}
 
 	fitView();
 }
@@ -1188,7 +1193,7 @@ async function onOpenExecutionPreview(json: {
 	await importWorkflowExact(json);
 
 	workflowState.setWorkflowExecutionData(data);
-	workflowState.setWorkflowPinData({});
+	workflowDocumentStore.value?.setPinData({});
 
 	canvasStore.stopLoading();
 
@@ -1293,7 +1298,7 @@ const isOnlyChatTriggerNodeActive = computed(() => {
 const chatTriggerNodePinnedData = computed(() => {
 	if (!chatTriggerNode.value) return null;
 
-	return workflowDocumentStore?.pinData?.[chatTriggerNode.value.name];
+	return workflowDocumentStore.value?.pinData?.[chatTriggerNode.value.name];
 });
 
 function onOpenChat() {

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -2,7 +2,6 @@
 import {
 	computed,
 	defineAsyncComponent,
-	inject,
 	nextTick,
 	onActivated,
 	onBeforeMount,
@@ -84,17 +83,14 @@ import type {
 	NodeConnectionType,
 	IDataObject,
 	ExecutionSummary,
-	ExecutionStatus,
 	IConnection,
 	INodeParameters,
 } from 'n8n-workflow';
 import { useToast } from '@/app/composables/useToast';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
 import { useEnvironmentsStore } from '@/features/settings/environments.ee/environments.store';
-import { useRootStore } from '@n8n/stores/useRootStore';
 import { historyBus } from '@/app/models/history';
 import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
-import { useExecutionsStore } from '@/features/execution/executions/executions.store';
 import { useCanvasStore } from '@/app/stores/canvas.store';
 import { useMessage } from '@/app/composables/useMessage';
 import { useDocumentTitle } from '@/app/composables/useDocumentTitle';
@@ -102,18 +98,12 @@ import { useNpsSurveyStore } from '@/app/stores/npsSurvey.store';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
-import { buildExecutionResponseFromSchema } from '@/features/execution/executions/executions.utils';
-import type { ExecutionPreviewNodeSchema } from '@/features/execution/executions/executions.types';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import { sourceControlEventBus } from '@/features/integrations/sourceControl.ee/sourceControl.eventBus';
 import { useTagsStore } from '@/features/shared/tags/tags.store';
 import { usePushConnectionStore } from '@/app/stores/pushConnection.store';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
-import {
-	getBounds,
-	getNodesWithNormalizedPosition,
-	getNodeViewTab,
-} from '@/app/utils/nodeViewUtils';
+import { getBounds, getNodeViewTab } from '@/app/utils/nodeViewUtils';
 import CanvasStopCurrentExecutionButton from '@/features/workflows/canvas/components/elements/buttons/CanvasStopCurrentExecutionButton.vue';
 import CanvasStopWaitingForWebhookButton from '@/features/workflows/canvas/components/elements/buttons/CanvasStopWaitingForWebhookButton.vue';
 import { nodeViewEventBus } from '@/app/event-bus';
@@ -146,7 +136,8 @@ import { injectWorkflowState } from '@/app/composables/useWorkflowState';
 import { useActivityDetection } from '@/app/composables/useActivityDetection';
 import { useCollaborationStore } from '@/features/collaboration/collaboration/collaboration.store';
 import { injectStrict } from '@/app/utils/injectStrict';
-import { WorkflowIdKey, WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
+import { WorkflowIdKey } from '@/app/constants/injectionKeys';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 
 import { N8nCallout, N8nCanvasThinkingPill, N8nCanvasCollaborationPill } from '@n8n/design-system';
 
@@ -196,8 +187,6 @@ const sourceControlStore = useSourceControlStore();
 const nodeCreatorStore = useNodeCreatorStore();
 const credentialsStore = useCredentialsStore();
 const environmentsStore = useEnvironmentsStore();
-const rootStore = useRootStore();
-const executionsStore = useExecutionsStore();
 const canvasStore = useCanvasStore();
 const npsSurveyStore = useNpsSurveyStore();
 const projectsStore = useProjectsStore();
@@ -214,8 +203,6 @@ const collaborationStore = useCollaborationStore();
 const emptyStateBuilderPromptStore = useEmptyStateBuilderPromptStore();
 const chatPanelStore = useChatPanelStore();
 
-const workflowDocumentStoreRef = inject(WorkflowDocumentStoreKey, null);
-const workflowDocumentStore = computed(() => workflowDocumentStoreRef?.value ?? null);
 const workflowState = injectWorkflowState();
 
 // Initialize activity detection for collaboration
@@ -261,7 +248,6 @@ const {
 	fetchWorkflowDataFromUrl,
 	resetWorkspace,
 	initializeWorkspace,
-	openExecution,
 	editableWorkflow,
 	editableWorkflowObject,
 	lastClickPosition,
@@ -278,15 +264,10 @@ useKeybindings({
 const canvasRef = useTemplateRef('canvas');
 const isLoading = ref(true);
 const readOnlyNotification = ref<null | { visible: boolean }>(null);
-
-const isProductionExecutionPreview = ref(false);
-const isExecutionPreview = ref(false);
-
-const canOpenNDV = ref(true);
-const hideNodeIssues = ref(false);
 const fallbackNodes = ref<INodeUi[]>([]);
 
 const workflowId = injectStrict(WorkflowIdKey);
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const routeNodeId = computed(() => {
 	const nodeId = route.params.nodeId;
 	return Array.isArray(nodeId) ? nodeId[0] : nodeId;
@@ -785,26 +766,6 @@ function onRevertDeleteConnection({ connection }: { connection: [IConnection, IC
  * Import / Export
  */
 
-async function importWorkflowExact({ workflow: workflowData }: { workflow: WorkflowDataUpdate }) {
-	if (!workflowData.nodes || !workflowData.connections) {
-		throw new Error('Invalid workflow object');
-	}
-
-	resetWorkspace();
-
-	const { workflowDocumentStore: newStore } = await initializeWorkspace({
-		...workflowData,
-		id: isDemoRoute.value ? 'demo' : workflowData.id,
-		nodes: getNodesWithNormalizedPosition<INodeUi>(workflowData.nodes),
-	} as IWorkflowDb);
-
-	if (workflowDocumentStoreRef && newStore) {
-		workflowDocumentStoreRef.value = newStore;
-	}
-
-	fitView();
-}
-
 async function onImportWorkflowDataEvent(data: IDataObject) {
 	const workflowData = data.data as WorkflowDataUpdate;
 	const trackEvents = typeof data.trackEvents === 'boolean' ? data.trackEvents : undefined;
@@ -1130,77 +1091,6 @@ function trackRunWorkflowToNode(node: INodeUi) {
 	void externalHooks.run('nodeView.onRunNode', telemetryPayload);
 }
 
-async function onOpenExecution(executionId: string, nodeId?: string) {
-	canvasStore.startLoading();
-
-	resetWorkspace();
-
-	const data = await openExecution(executionId, nodeId);
-	if (!data) {
-		return;
-	}
-
-	void nextTick(() => {
-		updateNodesIssues();
-	});
-
-	canvasStore.stopLoading();
-	fitView();
-
-	canvasEventBus.emit('open:execution', data);
-
-	void externalHooks.run('execution.open', {
-		workflowId: data.workflowData.id,
-		workflowName: data.workflowData.name,
-		executionId,
-	});
-
-	telemetry.track('User opened read-only execution', {
-		workflow_id: data.workflowData.id,
-		execution_mode: data.mode,
-		execution_finished: data.finished,
-	});
-}
-
-async function onOpenExecutionPreview(json: {
-	workflow: IWorkflowDb;
-	nodeExecutionSchema: Record<string, ExecutionPreviewNodeSchema>;
-	executionStatus: ExecutionStatus;
-	executionError?: { message: string; description?: string; name?: string; stack?: string };
-	lastNodeExecuted?: string;
-	projectId?: string;
-}) {
-	canvasStore.startLoading();
-
-	const workflow = json.workflow;
-	if (!workflow?.nodes || !workflow?.connections) {
-		canvasStore.stopLoading();
-		throw new Error('Invalid workflow object');
-	}
-
-	if (json.projectId) {
-		await projectsStore.fetchAndSetProject(json.projectId);
-	}
-
-	const data = buildExecutionResponseFromSchema({
-		workflow,
-		nodeExecutionSchema: json.nodeExecutionSchema,
-		executionStatus: json.executionStatus,
-		executionError: json.executionError,
-		lastNodeExecuted: json.lastNodeExecuted,
-	});
-
-	// importWorkflowExact handles resetWorkspace, initializeData, and fitView
-	await importWorkflowExact(json);
-
-	workflowState.setWorkflowExecutionData(data);
-	workflowDocumentStore.value?.setPinData({});
-
-	canvasStore.stopLoading();
-
-	canvasEventBus.emit('open:execution', data);
-}
-
 function onExecutionOpenedWithError(data: IExecutionResponse) {
 	if (!data.finished && data.data?.resultData?.error) {
 		// Check if any node contains an error
@@ -1299,7 +1189,7 @@ const isOnlyChatTriggerNodeActive = computed(() => {
 const chatTriggerNodePinnedData = computed(() => {
 	if (!chatTriggerNode.value) return null;
 
-	return workflowDocumentStore.value?.pinData?.[chatTriggerNode.value.name];
+	return workflowDocumentStore?.pinData?.[chatTriggerNode.value.name];
 });
 
 function onOpenChat() {
@@ -1380,125 +1270,6 @@ function addCommandBarEventBindings() {
 
 function removeCommandBarEventBindings() {
 	canvasEventBus.off('create:sticky', onCreateSticky);
-}
-
-/**
- * Post message events
- */
-
-function addPostMessageEventBindings() {
-	window.addEventListener('message', onPostMessageReceived);
-}
-
-function removePostMessageEventBindings() {
-	window.removeEventListener('message', onPostMessageReceived);
-}
-
-function emitPostMessageReady() {
-	if (window.parent) {
-		window.parent.postMessage(
-			JSON.stringify({ command: 'n8nReady', version: rootStore.versionCli }),
-			'*',
-		);
-	}
-}
-
-async function onPostMessageReceived(messageEvent: MessageEvent) {
-	if (
-		!messageEvent ||
-		typeof messageEvent.data !== 'string' ||
-		!messageEvent.data?.includes?.('"command"')
-	) {
-		return;
-	}
-	try {
-		const json = JSON.parse(messageEvent.data);
-		if (json && json.command === 'openWorkflow') {
-			try {
-				// Set the project if provided from the parent window
-				if (json.projectId) {
-					await projectsStore.fetchAndSetProject(json.projectId);
-				}
-				await importWorkflowExact(json);
-				canOpenNDV.value = json.canOpenNDV ?? true;
-				hideNodeIssues.value = json.hideNodeIssues ?? false;
-				isExecutionPreview.value = false;
-
-				// Apply tidy-up if requested
-				if (json.tidyUp === true) {
-					canvasEventBus.emit('tidyUp', { source: 'import-workflow-data' });
-				}
-			} catch (e) {
-				if (window.top) {
-					window.top.postMessage(
-						JSON.stringify({
-							command: 'error',
-							message: i18n.baseText('openWorkflow.workflowImportError'),
-						}),
-						'*',
-					);
-				}
-				toast.showError(e, i18n.baseText('openWorkflow.workflowImportError'));
-			}
-		} else if (json && json.command === 'openExecution') {
-			try {
-				// Set the project if provided from the parent window
-				if (json.projectId) {
-					await projectsStore.fetchAndSetProject(json.projectId);
-				}
-				// If this NodeView is used in preview mode (in iframe) it will not have access to the main app store
-				// so everything it needs has to be sent using post messages and passed down to child components
-				isProductionExecutionPreview.value =
-					json.executionMode !== 'manual' && json.executionMode !== 'evaluation';
-
-				await onOpenExecution(json.executionId, json.nodeId);
-				canOpenNDV.value = json.canOpenNDV ?? true;
-				hideNodeIssues.value = json.hideNodeIssues ?? false;
-				isExecutionPreview.value = true;
-			} catch (e) {
-				if (window.top) {
-					window.top.postMessage(
-						JSON.stringify({
-							command: 'error',
-							message: i18n.baseText('nodeView.showError.openExecution.title'),
-						}),
-						'*',
-					);
-				}
-				toast.showMessage({
-					title: i18n.baseText('nodeView.showError.openExecution.title'),
-					message: (e as Error).message,
-					type: 'error',
-				});
-			}
-		} else if (json && json.command === 'openExecutionPreview') {
-			try {
-				await onOpenExecutionPreview(json);
-				canOpenNDV.value = json.canOpenNDV ?? false;
-				hideNodeIssues.value = json.hideNodeIssues ?? false;
-				isExecutionPreview.value = true;
-			} catch (e) {
-				if (window.top) {
-					window.top.postMessage(
-						JSON.stringify({
-							command: 'error',
-							message: i18n.baseText('nodeView.showError.openExecution.title'),
-						}),
-						'*',
-					);
-				}
-				toast.showMessage({
-					title: i18n.baseText('nodeView.showError.openExecution.title'),
-					message: (e as Error).message,
-					type: 'error',
-				});
-			}
-		} else if (json?.command === 'setActiveExecution') {
-			executionsStore.activeExecution = (await executionsStore.fetchExecution(
-				json.executionId,
-			)) as ExecutionSummary;
-		}
-	} catch (e) {}
 }
 
 /**
@@ -1867,8 +1638,6 @@ onBeforeMount(() => {
 	if (!isDemoRoute.value) {
 		pushConnectionStore.pushConnect();
 	}
-
-	addPostMessageEventBindings();
 });
 
 onMounted(async () => {
@@ -1904,8 +1673,6 @@ onMounted(async () => {
 			}
 		}, 500);
 
-		emitPostMessageReady();
-
 		// Check for pending builder prompt from empty state experiment
 		void handlePendingBuilderPrompt();
 	}
@@ -1935,7 +1702,6 @@ onDeactivated(() => {
 
 onBeforeUnmount(() => {
 	removeSourceControlEventBindings();
-	removePostMessageEventBindings();
 	removeWorkflowSavedEventBindings();
 	removeBeforeUnloadEventBindings();
 	removeImportEventBindings();
@@ -2098,7 +1864,7 @@ onBeforeUnmount(() => {
 					v-if="!isNDVV2"
 					:workflow-object="editableWorkflowObject"
 					:read-only="isCanvasReadOnly"
-					:is-production-execution-preview="isProductionExecutionPreview"
+					:is-production-execution-preview="nodeHelpers.isProductionExecutionPreview.value"
 					:renaming="false"
 					@value-changed="onRenameNode($event.value as string)"
 					@stop-execution="onStopExecution"
@@ -2111,7 +1877,7 @@ onBeforeUnmount(() => {
 					v-if="isNDVV2"
 					:workflow-object="editableWorkflowObject"
 					:read-only="isCanvasReadOnly"
-					:is-production-execution-preview="isProductionExecutionPreview"
+					:is-production-execution-preview="nodeHelpers.isProductionExecutionPreview.value"
 					@rename-node="onRenameNode"
 					@stop-execution="onStopExecution"
 					@switch-selected-node="onSwitchActiveNode"

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -146,6 +146,7 @@ import { useActivityDetection } from '@/app/composables/useActivityDetection';
 import { useCollaborationStore } from '@/features/collaboration/collaboration/collaboration.store';
 import { injectStrict } from '@/app/utils/injectStrict';
 import { WorkflowIdKey } from '@/app/constants/injectionKeys';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 
 import { N8nCallout, N8nCanvasThinkingPill, N8nCanvasCollaborationPill } from '@n8n/design-system';
 
@@ -213,6 +214,7 @@ const collaborationStore = useCollaborationStore();
 const emptyStateBuilderPromptStore = useEmptyStateBuilderPromptStore();
 const chatPanelStore = useChatPanelStore();
 
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const workflowState = injectWorkflowState();
 
 // Initialize activity detection for collaboration
@@ -1291,7 +1293,7 @@ const isOnlyChatTriggerNodeActive = computed(() => {
 const chatTriggerNodePinnedData = computed(() => {
 	if (!chatTriggerNode.value) return null;
 
-	return workflowsStore.pinDataByNodeName(chatTriggerNode.value.name);
+	return workflowDocumentStore?.pinData?.[chatTriggerNode.value.name];
 });
 
 function onOpenChat() {

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
@@ -970,7 +970,11 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 		if (!pinData) return;
 		for (const nodeName of Object.keys(pinData)) {
 			workflowDocumentStore?.unpinNodeData(nodeName);
+			if (workflowsStore.nodeMetadata[nodeName]) {
+				workflowsStore.nodeMetadata[nodeName].pinnedDataLastRemovedAt = Date.now();
+			}
 		}
+		uiStore.markStateDirty();
 	}
 
 	function clearExistingWorkflow() {

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
@@ -13,6 +13,10 @@ import { assert } from '@n8n/utils/assert';
 import { useI18n } from '@n8n/i18n';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { useBuilderMessages } from './composables/useBuilderMessages';
 import {
 	chatWithBuilder,
@@ -959,13 +963,13 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 	}
 
 	function unpinAllNodes() {
-		const pinData = workflowsStore.workflow.pinData;
+		const workflowDocumentStore = workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined;
+		const pinData = workflowDocumentStore?.pinData;
 		if (!pinData) return;
 		for (const nodeName of Object.keys(pinData)) {
-			const node = workflowsStore.getNodeByName(nodeName);
-			if (node) {
-				workflowsStore.unpinData({ node });
-			}
+			workflowDocumentStore?.unpinNodeData(nodeName);
 		}
 	}
 

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useAIAssistantHelpers.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useAIAssistantHelpers.ts
@@ -26,6 +26,10 @@ import {
 } from '@/app/utils/nodeTypesUtils';
 import type { AssistantProcessOptions, ChatRequest } from '../assistant.types';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { useDataSchema } from '@/app/composables/useDataSchema';
 import { AI_ASSISTANT_MAX_CONTENT_LENGTH, VIEWS } from '@/app/constants';
 import { useI18n } from '@n8n/i18n';
@@ -297,6 +301,9 @@ export const useAIAssistantHelpers = () => {
 	 * @returns schemas and list of node names whose schema was derived from pin data
 	 */
 	function getNodesSchemas(nodeNames: string[], excludeValues?: boolean) {
+		const workflowDocumentStore = workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined;
 		const schemas: ChatRequest.NodeExecutionSchema[] = [];
 		const pinnedNodeNames: string[] = [];
 		for (const name of nodeNames) {
@@ -304,7 +311,7 @@ export const useAIAssistantHelpers = () => {
 			if (!node) {
 				continue;
 			}
-			if (workflowsStore.pinDataByNodeName(node.name)) {
+			if (workflowDocumentStore?.pinData?.[node.name]) {
 				pinnedNodeNames.push(node.name);
 			}
 			const { getSchemaForExecutionData, getInputDataWithPinned } = useDataSchema();

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/InputPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/InputPanel.test.ts
@@ -12,7 +12,7 @@ import {
 	type IRunData,
 } from 'n8n-workflow';
 import { setActivePinia } from 'pinia';
-import { mockedStore } from '@/__tests__/utils';
+
 import { useWorkflowState } from '@/app/composables/useWorkflowState';
 
 vi.mock('vue-router', () => {
@@ -61,7 +61,7 @@ const render = (props: Partial<Props> = {}, pinData?: INodeExecutionData[], runD
 	workflowStore.setWorkflow(workflow);
 
 	if (pinData) {
-		mockedStore(useWorkflowsStore).pinDataByNodeName.mockReturnValue(pinData);
+		workflowStore.workflow.pinData = Object.fromEntries(nodes.map((n) => [n.name, pinData]));
 	}
 
 	if (runData) {

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/__snapshots__/InputPanel.test.ts.snap
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/__snapshots__/InputPanel.test.ts.snap
@@ -73,13 +73,14 @@ exports[`InputPanel > should render 1`] = `
         data-test-id="run-data-pane-header"
         data-v-5b5900d0=""
       >
-        <!---->
+        <!--v-if-->
         <!--v-if-->
         <div
           class="n8n-radio-buttons radioGroup"
           data-test-id="ndv-run-data-display-mode"
           data-v-5b5900d0=""
           role="radiogroup"
+          style="display: none;"
         >
           
           <label
@@ -209,7 +210,107 @@ exports[`InputPanel > should render 1`] = `
       data-v-5b5900d0=""
     >
       <!--v-if-->
-      <!---->
+      <div
+        class="center"
+        data-v-5b5900d0=""
+      >
+        
+        <div
+          class="noOutputData"
+        >
+          
+          <article
+            class="empty"
+          >
+            
+            <svg
+              aria-hidden="true"
+              class="n8n-icon"
+              data-icon="arrow-right-to-line"
+              focusable="false"
+              height="20px"
+              role="img"
+              viewBox="0 0 24 24"
+              width="20px"
+            >
+              <path
+                d="M17 12H3m8 6l6-6l-6-6m10-1v14"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+            
+            <h1
+              class="title"
+            >
+              No input data
+            </h1>
+            <p
+              class="description"
+            >
+              
+              <span>
+                
+                
+                
+                
+                <span
+                  class=""
+                  data-grace-area-trigger=""
+                  data-state="closed"
+                >
+                  
+                  
+                  <button
+                    aria-live="polite"
+                    class="button button solid medium"
+                    data-test-id="execute-previous-node"
+                    square="false"
+                    title=""
+                    transparent-background="true"
+                    type="submit"
+                  >
+                    <transition-stub
+                      appear="false"
+                      css="true"
+                      name="n8n-button-fade"
+                      persisted="false"
+                    >
+                      <!--v-if-->
+                    </transition-stub>
+                    <div
+                      class="button-inner"
+                    >
+                      
+                      <!--v-if-->
+                      
+                      <span>
+                        Execute previous nodes
+                      </span>
+                    </div>
+                  </button>
+                  
+                  
+                </span>
+                <!--teleport start-->
+                <!--teleport end-->
+                
+                
+                
+                <br />
+                
+                 to view input data
+              </span>
+              
+            </p>
+          </article>
+          
+        </div>
+        
+      </div>
     </div>
     <!--v-if-->
     <transition-stub

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.test.ts
@@ -20,6 +20,10 @@ import { setActivePinia } from 'pinia';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useSchemaPreviewStore } from '@/features/ndv/runData/schemaPreview.store';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 
 const MOCK_EXECUTION_URL = 'execution.url/123';
 
@@ -1214,7 +1218,13 @@ describe('RunData', () => {
 		ndvStore.setOutputPanelEditModeValue = vi.fn();
 
 		if (pinnedData) {
-			workflowsStore.pinDataByNodeName.mockReturnValue(pinnedData);
+			const testWorkflowId = workflowId ?? 'test-workflow';
+			workflowsStore.workflow.id = testWorkflowId;
+			workflowsStore.workflow.pinData = { 'Test Node': pinnedData };
+			const workflowDocumentStore = useWorkflowDocumentStore(
+				createWorkflowDocumentId(testWorkflowId),
+			);
+			workflowDocumentStore.pinNodeData('Test Node', pinnedData);
 		}
 
 		schemaPreviewStore.getSchemaPreview = vi.fn().mockResolvedValue({});

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.test.ts
@@ -1220,7 +1220,6 @@ describe('RunData', () => {
 		if (pinnedData) {
 			const testWorkflowId = workflowId ?? 'test-workflow';
 			workflowsStore.workflow.id = testWorkflowId;
-			workflowsStore.workflow.pinData = { 'Test Node': pinnedData };
 			const workflowDocumentStore = useWorkflowDocumentStore(
 				createWorkflowDocumentId(testWorkflowId),
 			);

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
@@ -94,6 +94,7 @@ import {
 	N8nTooltip,
 } from '@n8n/design-system';
 import { injectWorkflowState } from '@/app/composables/useWorkflowState';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 
 const LazyRunDataTable = defineAsyncComponent(async () => await import('./RunDataTable.vue'));
 const LazyRunDataJson = defineAsyncComponent(async () => await import('./RunDataJson.vue'));
@@ -226,6 +227,7 @@ const nodeTypesStore = useNodeTypesStore();
 const ndvStore = useNDVStore();
 const workflowsStore = useWorkflowsStore();
 const workflowState = injectWorkflowState();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const sourceControlStore = useSourceControlStore();
 const collaborationStore = useCollaborationStore();
 const rootStore = useRootStore();
@@ -588,7 +590,7 @@ const parentNodeOutputData = computed(() => {
 
 const parentNodePinnedData = computed(() => {
 	const parentNode = props.workflowObject.getParentNodesByDepth(node.value?.name ?? '')[0];
-	return props.workflowObject.pinData?.[parentNode?.name || ''] ?? [];
+	return workflowDocumentStore?.pinData?.[parentNode?.name || ''] ?? [];
 });
 
 const showPinButton = computed(

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.test.ts
@@ -215,10 +215,6 @@ function pinData(node: { name: string }, data: INodeExecutionData[]) {
 		createWorkflowDocumentId(workflowsStore.workflow.id),
 	);
 	workflowDocumentStore.pinNodeData(node.name, data);
-	workflowsStore.workflow.pinData = {
-		...workflowsStore.workflow.pinData,
-		[node.name]: data,
-	};
 }
 
 function mockNodeOutputData(nodeName: string, data: INodeExecutionData[], outputIndex = 0) {

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.test.ts
@@ -18,11 +18,16 @@ import type { IWorkflowDb } from '@/Interface';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { createTestingPinia } from '@pinia/testing';
 import { fireEvent } from '@testing-library/dom';
 import { userEvent } from '@testing-library/user-event';
 import { cleanup, waitFor } from '@testing-library/vue';
-import { computed } from 'vue';
+import { computed, shallowRef } from 'vue';
+import { WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
 import {
 	createResultOk,
 	NodeConnectionTypes,
@@ -147,6 +152,7 @@ async function setupStore() {
 		name: 'Test Workflow',
 		connections: {},
 		active: true,
+		pinData: {} as Record<string, INodeExecutionData[]>,
 		nodes: [
 			mockNode1,
 			mockNode2,
@@ -201,6 +207,18 @@ async function setupStore() {
 	ndvStore.setActiveNodeName('Test Node Name', 'other');
 
 	return pinia;
+}
+
+function pinData(node: { name: string }, data: INodeExecutionData[]) {
+	const workflowsStore = useWorkflowsStore();
+	const workflowDocumentStore = useWorkflowDocumentStore(
+		createWorkflowDocumentId(workflowsStore.workflow.id),
+	);
+	workflowDocumentStore.pinNodeData(node.name, data);
+	workflowsStore.workflow.pinData = {
+		...workflowsStore.workflow.pinData,
+		[node.name]: data,
+	};
 }
 
 function mockNodeOutputData(nodeName: string, data: INodeExecutionData[], outputIndex = 0) {
@@ -271,6 +289,11 @@ describe('VirtualSchema.vue', () => {
 			isRagStarterCalloutVisible: computed(() => false),
 		});
 
+		const workflowsStore = useWorkflowsStore();
+		const workflowDocumentStore = useWorkflowDocumentStore(
+			createWorkflowDocumentId(workflowsStore.workflow.id),
+		);
+
 		renderComponent = createComponentRenderer(VirtualSchema, {
 			global: {
 				stubs: {
@@ -281,6 +304,9 @@ describe('VirtualSchema.vue', () => {
 					N8nCallout: N8nCalloutStub,
 					Notice: NoticeStub,
 					NodeIcon: NodeIconStub,
+				},
+				provide: {
+					[WorkflowDocumentStoreKey as symbol]: shallowRef(workflowDocumentStore),
 				},
 				mocks: {
 					$locale: {
@@ -321,20 +347,14 @@ describe('VirtualSchema.vue', () => {
 	});
 
 	it('renders schema for data', async () => {
-		useWorkflowsStore().pinData({
-			node: mockNode1,
-			data: [
-				{ json: { name: 'John', age: 22, hobbies: ['surfing', 'traveling'] } },
-				{ json: { name: 'Joe', age: 33, hobbies: ['skateboarding', 'gaming'] } },
-			],
-		});
-		useWorkflowsStore().pinData({
-			node: mockNode2,
-			data: [
-				{ json: { name: 'John', age: 22, hobbies: ['surfing', 'traveling'] } },
-				{ json: { name: 'Joe', age: 33, hobbies: ['skateboarding', 'gaming'] } },
-			],
-		});
+		pinData(mockNode1, [
+			{ json: { name: 'John', age: 22, hobbies: ['surfing', 'traveling'] } },
+			{ json: { name: 'Joe', age: 33, hobbies: ['skateboarding', 'gaming'] } },
+		]);
+		pinData(mockNode2, [
+			{ json: { name: 'John', age: 22, hobbies: ['surfing', 'traveling'] } },
+			{ json: { name: 'Joe', age: 33, hobbies: ['skateboarding', 'gaming'] } },
+		]);
 
 		const { getAllByTestId } = renderComponent();
 		await waitFor(() => {
@@ -376,23 +396,20 @@ describe('VirtualSchema.vue', () => {
 	});
 
 	it('renders schema with spaces and dots', async () => {
-		useWorkflowsStore().pinData({
-			node: mockNode1,
-			data: [
-				{
-					json: {
-						'hello world': [
-							{
-								test: {
-									'more to think about': 1,
-								},
-								'test.how': 'ignore',
+		pinData(mockNode1, [
+			{
+				json: {
+					'hello world': [
+						{
+							test: {
+								'more to think about': 1,
 							},
-						],
-					},
+							'test.how': 'ignore',
+						},
+					],
 				},
-			],
-		});
+			},
+		]);
 
 		const { container, getAllByTestId } = renderComponent();
 
@@ -405,10 +422,7 @@ describe('VirtualSchema.vue', () => {
 	});
 
 	it('renders no data to show for data empty objects', async () => {
-		useWorkflowsStore().pinData({
-			node: mockNode1,
-			data: [{ json: {} }, { json: {} }],
-		});
+		pinData(mockNode1, [{ json: {} }, { json: {} }]);
 
 		const { getAllByText } = renderComponent();
 		await waitFor(() =>
@@ -418,10 +432,7 @@ describe('VirtualSchema.vue', () => {
 
 	// this can happen when setting the output to [{}]
 	it('renders empty state to show for empty data', async () => {
-		useWorkflowsStore().pinData({
-			node: mockNode1,
-			data: [{} as INodeExecutionData],
-		});
+		pinData(mockNode1, [{} as INodeExecutionData]);
 
 		const { getAllByText } = renderComponent({ props: { paneType: 'output' } });
 		await waitFor(() =>
@@ -542,10 +553,10 @@ describe('VirtualSchema.vue', () => {
 	test.each([[[{ tx: false }, { tx: false }]], [[{ tx: '' }, { tx: '' }]], [[{ tx: [] }]]])(
 		'renders schema instead of showing no data for %o',
 		async (data) => {
-			useWorkflowsStore().pinData({
-				node: mockNode1,
-				data: data.map((item) => ({ json: item })),
-			});
+			pinData(
+				mockNode1,
+				data.map((item) => ({ json: item })),
+			);
 
 			const { getAllByTestId } = renderComponent();
 			await waitFor(() =>
@@ -555,15 +566,8 @@ describe('VirtualSchema.vue', () => {
 	);
 
 	it('should filter invalid connections', async () => {
-		const { pinData } = useWorkflowsStore();
-		pinData({
-			node: mockNode1,
-			data: [{ json: { tx: 1 } }],
-		});
-		pinData({
-			node: mockNode2,
-			data: [{ json: { tx: 2 } }],
-		});
+		pinData(mockNode1, [{ json: { tx: 1 } }]);
+		pinData(mockNode2, [{ json: { tx: 2 } }]);
 
 		const { getAllByTestId } = renderComponent({
 			props: {
@@ -633,10 +637,7 @@ describe('VirtualSchema.vue', () => {
 		}
 
 		it('should track data pill drag and drop', async () => {
-			useWorkflowsStore().pinData({
-				node: mockNode1,
-				data: [{ json: { name: 'John', age: 22, hobbies: ['surfing', 'traveling'] } }],
-			});
+			pinData(mockNode1, [{ json: { name: 'John', age: 22, hobbies: ['surfing', 'traveling'] } }]);
 			const telemetry = useTelemetry();
 			const trackSpy = vi.spyOn(telemetry, 'track');
 
@@ -716,14 +717,8 @@ describe('VirtualSchema.vue', () => {
 	});
 
 	it('should expand all nodes when searching', async () => {
-		useWorkflowsStore().pinData({
-			node: mockNode1,
-			data: [{ json: { name: 'John' } }],
-		});
-		useWorkflowsStore().pinData({
-			node: mockNode2,
-			data: [{ json: { name: 'John' } }],
-		});
+		pinData(mockNode1, [{ json: { name: 'John' } }]);
+		pinData(mockNode2, [{ json: { name: 'John' } }]);
 
 		const { getAllByTestId, queryAllByTestId, rerender, container } = renderComponent();
 
@@ -746,10 +741,7 @@ describe('VirtualSchema.vue', () => {
 	});
 
 	it('renders preview schema when enabled and available', async () => {
-		useWorkflowsStore().pinData({
-			node: mockNode2,
-			data: [],
-		});
+		pinData(mockNode2, []);
 		const posthogStore = usePostHog();
 		vi.spyOn(posthogStore, 'isVariantEnabled').mockReturnValue(true);
 		const schemaPreviewStore = useSchemaPreviewStore();
@@ -785,10 +777,7 @@ describe('VirtualSchema.vue', () => {
 	});
 
 	it('renders variables and context section', async () => {
-		useWorkflowsStore().pinData({
-			node: mockNode1,
-			data: [],
-		});
+		pinData(mockNode1, []);
 
 		const { getAllByTestId, container } = renderComponent({
 			props: {
@@ -821,10 +810,9 @@ describe('VirtualSchema.vue', () => {
 	});
 
 	it('renders schema for empty objects and arrays', async () => {
-		useWorkflowsStore().pinData({
-			node: mockNode1,
-			data: [{ json: { empty: {}, emptyArray: [], nested: [{ empty: {}, emptyArray: [] }] } }],
-		});
+		pinData(mockNode1, [
+			{ json: { empty: {}, emptyArray: [], nested: [{ empty: {}, emptyArray: [] }] } },
+		]);
 
 		const { container, getAllByTestId } = renderComponent({
 			props: {
@@ -1057,10 +1045,7 @@ describe('VirtualSchema.vue', () => {
 				},
 			};
 
-			useWorkflowsStore().pinData({
-				node: mockNode1,
-				data: [{ json: { actualField: 'actual executed data' } }],
-			});
+			pinData(mockNode1, [{ json: { actualField: 'actual executed data' } }]);
 
 			const { getAllByTestId } = renderComponent({
 				props: {
@@ -1108,10 +1093,7 @@ describe('VirtualSchema.vue', () => {
 
 	describe('execute event emission', () => {
 		it('should emit execute event when schema preview execute link is clicked', async () => {
-			useWorkflowsStore().pinData({
-				node: mockNode2,
-				data: [],
-			});
+			pinData(mockNode2, []);
 
 			const posthogStore = usePostHog();
 			vi.spyOn(posthogStore, 'isVariantEnabled').mockReturnValue(true);
@@ -1196,10 +1178,7 @@ describe('VirtualSchema.vue', () => {
 
 	describe('empty data detection with preview', () => {
 		it('should detect single empty object as empty data', async () => {
-			useWorkflowsStore().pinData({
-				node: mockNode1,
-				data: [{ json: {} }],
-			});
+			pinData(mockNode1, [{ json: {} }]);
 
 			const { getAllByText } = renderComponent({
 				props: {
@@ -1216,10 +1195,7 @@ describe('VirtualSchema.vue', () => {
 		});
 
 		it('should show pinData when available even with preview execution', async () => {
-			useWorkflowsStore().pinData({
-				node: mockNode1,
-				data: [{ json: { pinnedField: 'pinned data' } }],
-			});
+			pinData(mockNode1, [{ json: { pinnedField: 'pinned data' } }]);
 
 			const previewExecutionData = {
 				id: 'preview-123',

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.vue
@@ -21,6 +21,7 @@ import { useCalloutHelpers } from '@/app/composables/useCalloutHelpers';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { executionDataToJson } from '@/app/utils/nodeTypesUtils';
 import {
 	type IRunExecutionData,
@@ -87,6 +88,7 @@ const i18n = useI18n();
 const ndvStore = useNDVStore();
 const nodeTypesStore = useNodeTypesStore();
 const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const schemaPreviewStore = useSchemaPreviewStore();
 const environmentsStore = useEnvironmentsStore();
 const settingsStore = useSettingsStore();
@@ -122,7 +124,8 @@ const toggleNodeExclusiveAndScrollTop = (id: string) => {
 };
 
 const getNodeSchema = async (fullNode: INodeUi, connectedNode: IConnectedNode) => {
-	const pinData = workflowsStore.pinDataByNodeName(connectedNode.name);
+	const rawPinData = workflowDocumentStore?.getNodePinData(connectedNode.name);
+	const pinData = rawPinData ? executionDataToJson(rawPinData) : undefined;
 	const hasPinnedData = pinData ? pinData.length > 0 : false;
 	const isNodeExecuted = hasPinnedData || hasNodeExecuted(connectedNode.name);
 

--- a/packages/frontend/editor-ui/src/features/ndv/shared/ndv.store.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/ndv.store.ts
@@ -21,6 +21,10 @@ import { NodeConnectionTypes } from 'n8n-workflow';
 import { defineStore } from 'pinia';
 import { v4 as uuid } from 'uuid';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { computed, ref } from 'vue';
 import type { TelemetryNdvSource } from '@/app/types/telemetry';
 import { injectWorkflowState } from '@/app/composables/useWorkflowState';
@@ -93,6 +97,11 @@ export const useNDVStore = defineStore(STORES.NDV, () => {
 	const lastSetActiveNodeSource = ref<TelemetryNdvSource>();
 
 	const workflowsStore = useWorkflowsStore();
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
 	const workflowState = injectWorkflowState();
 
 	const activeNode = computed(() => {
@@ -128,7 +137,7 @@ export const useNDVStore = defineStore(STORES.NDV, () => {
 	const ndvInputDataWithPinnedData = computed(() => {
 		const data = ndvInputData.value;
 		return ndvInputNodeName.value
-			? (workflowsStore.pinDataByNodeName(ndvInputNodeName.value) ?? data)
+			? (workflowDocumentStore.value?.pinData?.[ndvInputNodeName.value] ?? data)
 			: data;
 	});
 

--- a/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsView.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsView.vue
@@ -23,6 +23,7 @@ import type { DataPinningDiscoveryEvent } from '@/app/event-bus';
 import { dataPinningEventBus } from '@/app/event-bus';
 import { ndvEventBus } from '@/features/ndv/shared/ndv.eventBus';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useDeviceSupport } from '@n8n/composables/useDeviceSupport';
@@ -69,6 +70,7 @@ const { activeNode } = storeToRefs(ndvStore);
 const pinnedData = usePinnedData(activeNode);
 const nodeTypesStore = useNodeTypesStore();
 const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const deviceSupport = useDeviceSupport();
 const telemetry = useTelemetry();
 const telemetryContext = useTelemetryContext({ view_shown: 'ndv' });
@@ -134,7 +136,7 @@ const parentNodes = computed(() => {
 
 const parentNode = computed<IConnectedNode | undefined>(() => {
 	for (const parent of parentNodes.value) {
-		if (workflowsStore?.pinnedWorkflowData?.[parent.name]) {
+		if (workflowDocumentStore?.pinData?.[parent.name]) {
 			return parent;
 		}
 

--- a/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsViewV2.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsViewV2.vue
@@ -31,6 +31,7 @@ import { useNDVStore } from '../ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { getNodeIconSource } from '@/app/utils/nodeIcon';
 import { useDeviceSupport } from '@n8n/composables/useDeviceSupport';
 import { useI18n } from '@n8n/i18n';
@@ -71,6 +72,7 @@ const pinnedData = usePinnedData(activeNode);
 const nodeTypesStore = useNodeTypesStore();
 const uiStore = useUIStore();
 const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const deviceSupport = useDeviceSupport();
 const telemetry = useTelemetry();
 const telemetryContext = useTelemetryContext({ view_shown: 'ndv' });
@@ -138,7 +140,7 @@ const parentNodes = computed(() => {
 
 const parentNode = computed(() => {
 	for (const parentNodeName of parentNodes.value) {
-		if (workflowsStore?.pinnedWorkflowData?.[parentNodeName]) {
+		if (workflowDocumentStore?.pinData?.[parentNodeName]) {
 			return parentNodeName;
 		}
 

--- a/packages/frontend/editor-ui/src/features/shared/contextMenu/composables/useContextMenuItems.ts
+++ b/packages/frontend/editor-ui/src/features/shared/contextMenu/composables/useContextMenuItems.ts
@@ -8,6 +8,10 @@ import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { useCollaborationStore } from '@/features/collaboration/collaboration/collaboration.store';
 import { useFocusedNodesStore } from '@/features/ai/assistant/focusedNodes.store';
 import { useI18n } from '@n8n/i18n';
@@ -94,7 +98,10 @@ export function useContextMenuItems(targetNodeIds: ComputedRef<string[]>): Compu
 	};
 
 	const hasPinData = (node: INode): boolean => {
-		return !!workflowsStore.pinDataByNodeName(node.name);
+		const workflowDocumentStore = workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined;
+		return !!workflowDocumentStore?.pinData?.[node.name];
 	};
 
 	const isExecutable = (node: INodeUi) => {

--- a/packages/frontend/editor-ui/src/features/shared/editors/components/CodeNodeEditor/completions/jsonField.completions.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/components/CodeNodeEditor/completions/jsonField.completions.ts
@@ -4,7 +4,11 @@ import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { isAllowedInDotNotation } from '@/features/shared/editors/plugins/codemirror/completions/utils';
 import { useI18n } from '@n8n/i18n';
-import type { IPinData, IRunData, IDataObject } from 'n8n-workflow';
+import type { IRunData, IDataObject } from 'n8n-workflow';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 
 function useJsonFieldCompletions() {
 	const i18n = useI18n();
@@ -252,7 +256,11 @@ function useJsonFieldCompletions() {
 			nodeName = quotedNodeName.replace(/^"/, '').replace(/"$/, '');
 		}
 
-		const pinData: IPinData | undefined = useWorkflowsStore().pinnedWorkflowData;
+		const wfStore = useWorkflowsStore();
+		const workflowDocumentStore = wfStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(wfStore.workflowId))
+			: undefined;
+		const pinData = workflowDocumentStore?.getPinDataSnapshot();
 
 		const nodePinData = pinData?.[nodeName];
 

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.ts
@@ -6,6 +6,10 @@
 import { useI18n } from '@n8n/i18n';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import type { Ref } from 'vue';
 import { ref, computed } from 'vue';
 import type {
@@ -75,6 +79,11 @@ export function useCanvasMapping({
 }) {
 	const i18n = useI18n();
 	const workflowsStore = useWorkflowsStore();
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
 	const workflowState = injectWorkflowState();
 	const nodeTypesStore = useNodeTypesStore();
 	const nodeHelpers = useNodeHelpers();
@@ -279,7 +288,7 @@ export function useCanvasMapping({
 
 	const nodePinnedDataById = computed(() =>
 		nodes.value.reduce<Record<string, INodeExecutionData[] | undefined>>((acc, node) => {
-			acc[node.id] = workflowsStore.pinDataByNodeName(node.name);
+			acc[node.id] = workflowDocumentStore.value?.getNodePinData(node.name);
 			return acc;
 		}, {}),
 	);


### PR DESCRIPTION
## Summary

This pull request refactors the handling of pinned node data throughout the workflow editor UI, centralizing pin data management in the `workflowDocumentStore` instead of directly in the `workflowsStore`. The changes update composables, tests, and helpers to use the new store, improving consistency and maintainability for workflow pinning operations.

**Pin Data Management Refactor:**

* All composables (`usePinnedData`, `useCanvasOperations`, `useNodeHelpers`, `useDataSchema`) now retrieve and update pinned node data via `workflowDocumentStore` rather than `workflowsStore`, including logic for pinning, unpinning, and checking pin status. [[1]](diffhunk://#diff-c1dcc048c122b1a00382a21b9511da675d4e1323867546249a74754f53079d9dR55-R60) [[2]](diffhunk://#diff-c1dcc048c122b1a00382a21b9511da675d4e1323867546249a74754f53079d9dL62-R75) [[3]](diffhunk://#diff-c1dcc048c122b1a00382a21b9511da675d4e1323867546249a74754f53079d9dL167-R185) [[4]](diffhunk://#diff-c1dcc048c122b1a00382a21b9511da675d4e1323867546249a74754f53079d9dL268-R293) [[5]](diffhunk://#diff-1487212043d6ef4240e9d67e7109fb1980110a620b187b7528eab3231504301dL682-R690) [[6]](diffhunk://#diff-1487212043d6ef4240e9d67e7109fb1980110a620b187b7528eab3231504301dL2765-R2767) [[7]](diffhunk://#diff-10d3bee4649d947b5e06c369c77a3be95fbd5180dd32c546b53eafad2e019d19R51-R54) [[8]](diffhunk://#diff-10d3bee4649d947b5e06c369c77a3be95fbd5180dd32c546b53eafad2e019d19L190-R197) [[9]](diffhunk://#diff-a268827f066cee5065f76b2e9d8fa1fbe21dedaa1b775f3fc003bd567a231021R11-R14) [[10]](diffhunk://#diff-a268827f066cee5065f76b2e9d8fa1fbe21dedaa1b775f3fc003bd567a231021L209-R217)

* Workflow execution logic now clears pin data using `workflowDocumentStore.setPinData({})` instead of `workflowsStore.setWorkflowPinData({})`. [[1]](diffhunk://#diff-1487212043d6ef4240e9d67e7109fb1980110a620b187b7528eab3231504301dL2902-R2909) [[2]](diffhunk://#diff-7080209d37c752c856492d3e46be950dff64d336f21b9aa7c69d58d598d26e22L4118-R4124) [[3]](diffhunk://#diff-7080209d37c752c856492d3e46be950dff64d336f21b9aa7c69d58d598d26e22L4137-R4142)

**Test Updates:**

* Unit tests for composables and helpers are updated to provide and use `workflowDocumentStore` for pin data setup and assertions, ensuring accurate test coverage of the new pin data flow. [[1]](diffhunk://#diff-7080209d37c752c856492d3e46be950dff64d336f21b9aa7c69d58d598d26e22R65-R68) [[2]](diffhunk://#diff-22c1f74cdef230461b1806afae7fa6410dd79a2d3e7e71a22163b4cc630212b3L19-R26) [[3]](diffhunk://#diff-22c1f74cdef230461b1806afae7fa6410dd79a2d3e7e71a22163b4cc630212b3R50-R65) [[4]](diffhunk://#diff-22c1f74cdef230461b1806afae7fa6410dd79a2d3e7e71a22163b4cc630212b3L291-R308) [[5]](diffhunk://#diff-22c1f74cdef230461b1806afae7fa6410dd79a2d3e7e71a22163b4cc630212b3R466-R470) [[6]](diffhunk://#diff-3c77809aac90700f65a2774d2ee9ed1c98e17d2a299f7a6623237903828afc77R8-R11) [[7]](diffhunk://#diff-3c77809aac90700f65a2774d2ee9ed1c98e17d2a299f7a6623237903828afc77R88-R115)

* Test mocks and assertions are revised to reflect the new pin data access patterns, including resetting pin data and checking pin status via the store. [[1]](diffhunk://#diff-7080209d37c752c856492d3e46be950dff64d336f21b9aa7c69d58d598d26e22R153) [[2]](diffhunk://#diff-7080209d37c752c856492d3e46be950dff64d336f21b9aa7c69d58d598d26e22R162) [[3]](diffhunk://#diff-7080209d37c752c856492d3e46be950dff64d336f21b9aa7c69d58d598d26e22R1850) [[4]](diffhunk://#diff-7080209d37c752c856492d3e46be950dff64d336f21b9aa7c69d58d598d26e22L1858-R1865) [[5]](diffhunk://#diff-7080209d37c752c856492d3e46be950dff64d336f21b9aa7c69d58d598d26e22L1896-R1904) [[6]](diffhunk://#diff-7080209d37c752c856492d3e46be950dff64d336f21b9aa7c69d58d598d26e22L1933-R1935)

**Behavioral Improvements:**

* Pinning/unpinning logic now uses computed properties and store methods for more accurate state tracking, including updating metadata timestamps and marking UI state as dirty when pin data changes. [[1]](diffhunk://#diff-c1dcc048c122b1a00382a21b9511da675d4e1323867546249a74754f53079d9dL268-R293) [[2]](diffhunk://#diff-22c1f74cdef230461b1806afae7fa6410dd79a2d3e7e71a22163b4cc630212b3L291-R308)

* Pin data size checks and error handling are now performed using `getPinDataSize` from the new store, ensuring consistent enforcement of pin data limits.

**Integration Consistency:**

* All relevant imports and dependency injections are updated to use the new pin data store, ensuring that workflow pin data is consistently managed and accessed throughout the UI codebase. [[1]](diffhunk://#diff-7080209d37c752c856492d3e46be950dff64d336f21b9aa7c69d58d598d26e22R65-R68) [[2]](diffhunk://#diff-22c1f74cdef230461b1806afae7fa6410dd79a2d3e7e71a22163b4cc630212b3L19-R26) [[3]](diffhunk://#diff-10d3bee4649d947b5e06c369c77a3be95fbd5180dd32c546b53eafad2e019d19R51-R54) [[4]](diffhunk://#diff-a268827f066cee5065f76b2e9d8fa1fbe21dedaa1b775f3fc003bd567a231021R11-R14) [[5]](diffhunk://#diff-3c77809aac90700f65a2774d2ee9ed1c98e17d2a299f7a6623237903828afc77R8-R11) [[6]](diffhunk://#diff-c1dcc048c122b1a00382a21b9511da675d4e1323867546249a74754f53079d9dR13-R19)

This refactor lays the groundwork for more robust workflow document management and easier future enhancements to pin data functionality.

## Related Linear tickets, Github issues, and Community forum posts

TODO

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
