### PR TITLE
feat: Add connection state to secret stores response (no-changelog)

### DIFF
--- a/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-manager.ee.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-manager.ee.test.ts
@@ -13,7 +13,7 @@ import type { ExternalSecretsProviderRegistry } from '../provider-registry.servi
 import type { ExternalSecretsRetryManager } from '../retry-manager.service';
 import type { ExternalSecretsSecretsCache } from '../secrets-cache.service';
 import type { ExternalSecretsSettingsStore } from '../settings-store.service';
-import type { ExternalSecretsSettings } from '../types';
+import type { ExternalSecretsSettings, SecretsProvider } from '../types';
 
 describe('ExternalSecretsManager', () => {
 	jest.useFakeTimers();
@@ -191,6 +191,32 @@ describe('ExternalSecretsManager', () => {
 
 			expect(result).toBe(dummyProvider);
 			expect(mockProviderRegistry.get).toHaveBeenCalledWith('dummy');
+		});
+	});
+
+	describe('getProviderProperties', () => {
+		it('should return property schema for the given provider type', () => {
+			const getProviderSpy = jest.spyOn(mockProvidersFactory, 'getProvider');
+
+			const result = manager.getProviderProperties('dummy');
+
+			expect(Array.isArray(result)).toBe(true);
+			expect(result).toHaveLength(3);
+			expect(result.map((p) => p.name)).toEqual(['username', 'other', 'password']);
+			expect(getProviderSpy).toHaveBeenCalledWith('dummy');
+			getProviderSpy.mockRestore();
+		});
+
+		it('should throw if provider type does not exist', () => {
+			const getProviderSpy = jest
+				.spyOn(mockProvidersFactory, 'getProvider')
+				.mockReturnValue(undefined as unknown as { new (): SecretsProvider });
+
+			expect(() => manager.getProviderProperties('nonexistentType')).toThrowError(
+				'Provider type "nonexistentType" not found',
+			);
+
+			getProviderSpy.mockRestore();
 		});
 	});
 

--- a/packages/cli/src/modules/external-secrets.ee/__tests__/secrets-providers-connections.service.ee.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/secrets-providers-connections.service.ee.test.ts
@@ -1,4 +1,4 @@
-import type { IDataObject } from 'n8n-workflow';
+import type { IDataObject, INodeProperties } from 'n8n-workflow';
 import { mockLogger } from '@n8n/backend-test-utils';
 import type {
 	ProjectSecretsProviderAccessRepository,
@@ -45,16 +45,18 @@ describe('SecretsProvidersConnectionsService', () => {
 		it('should map entity to DTO with projects, redacted settings, secretsCount, and secrets', () => {
 			const decryptedSettings = { apiKey: 'secret123', region: 'us-east-1' };
 			const redactedSettings = { apiKey: CREDENTIAL_BLANKING_VALUE, region: 'us-east-1' };
+			const mockProperties: INodeProperties[] = [
+				{
+					name: 'apiKey',
+					type: 'string',
+					displayName: 'API Key',
+					default: '',
+					typeOptions: { password: true },
+				},
+			];
 			const mockProvider = {
-				properties: [
-					{
-						name: 'apiKey',
-						type: 'string',
-						displayName: 'API Key',
-						default: '',
-						typeOptions: { password: true },
-					},
-				],
+				state: 'connected' as const,
+				properties: mockProperties,
 			} as SecretsProvider;
 
 			const connection = {
@@ -70,10 +72,8 @@ describe('SecretsProvidersConnectionsService', () => {
 				updatedAt: new Date('2024-01-02'),
 			} as unknown as SecretsProviderConnection;
 
-			mockExternalSecretsManager.getProviderWithSettings.mockReturnValue({
-				provider: mockProvider,
-				settings: {} as any,
-			});
+			mockExternalSecretsManager.getProviderProperties.mockReturnValue(mockProperties);
+			mockExternalSecretsManager.getProvider.mockReturnValue(mockProvider);
 			mockExternalSecretsManager.getSecretNames.mockReturnValue(['secret-a', 'secret-b']);
 			mockRedactionService.redact.mockReturnValue(redactedSettings);
 
@@ -82,6 +82,7 @@ describe('SecretsProvidersConnectionsService', () => {
 				name: 'my-aws',
 				type: 'awsSecretsManager',
 				secretsCount: 2,
+				state: 'connected',
 				secrets: [{ name: 'secret-a' }, { name: 'secret-b' }],
 				projects: [
 					{ id: 'p1', name: 'Project 1' },
@@ -92,29 +93,29 @@ describe('SecretsProvidersConnectionsService', () => {
 				updatedAt: '2024-01-02T00:00:00.000Z',
 			});
 
-			expect(mockExternalSecretsManager.getProviderWithSettings).toHaveBeenCalledWith(
+			expect(mockExternalSecretsManager.getProviderProperties).toHaveBeenCalledWith(
 				'awsSecretsManager',
 			);
+			expect(mockExternalSecretsManager.getProvider).toHaveBeenCalledWith('my-aws');
 			expect(mockExternalSecretsManager.getSecretNames).toHaveBeenCalledWith('my-aws');
-			expect(mockRedactionService.redact).toHaveBeenCalledWith(
-				decryptedSettings,
-				mockProvider.properties,
-			);
+			expect(mockRedactionService.redact).toHaveBeenCalledWith(decryptedSettings, mockProperties);
 		});
 
 		it('should map entity to DTO without projects and with empty secrets', () => {
 			const decryptedSettings = { token: 'secret-token' };
 			const redactedSettings = { token: CREDENTIAL_BLANKING_VALUE };
+			const mockProperties: INodeProperties[] = [
+				{
+					name: 'token',
+					type: 'string',
+					displayName: 'Token',
+					default: '',
+					typeOptions: { password: true },
+				},
+			];
 			const mockProvider = {
-				properties: [
-					{
-						name: 'token',
-						type: 'string',
-						displayName: 'Token',
-						default: '',
-						typeOptions: { password: true },
-					},
-				],
+				state: 'connected' as const,
+				properties: mockProperties,
 			} as SecretsProvider;
 
 			const connection = {
@@ -127,10 +128,8 @@ describe('SecretsProvidersConnectionsService', () => {
 				updatedAt: new Date('2024-01-02'),
 			} as unknown as SecretsProviderConnection;
 
-			mockExternalSecretsManager.getProviderWithSettings.mockReturnValue({
-				provider: mockProvider,
-				settings: {} as any,
-			});
+			mockExternalSecretsManager.getProviderProperties.mockReturnValue(mockProperties);
+			mockExternalSecretsManager.getProvider.mockReturnValue(mockProvider);
 			mockExternalSecretsManager.getSecretNames.mockReturnValue([]);
 			mockRedactionService.redact.mockReturnValue(redactedSettings);
 
@@ -139,17 +138,23 @@ describe('SecretsProvidersConnectionsService', () => {
 				name: 'my-vault',
 				type: 'vault',
 				secretsCount: 0,
+				state: 'connected',
 				secrets: [],
 				projects: [],
 				settings: redactedSettings,
 				createdAt: '2024-01-01T00:00:00.000Z',
 				updatedAt: '2024-01-02T00:00:00.000Z',
 			});
+
+			expect(mockExternalSecretsManager.getProviderProperties).toHaveBeenCalledWith('vault');
+			expect(mockExternalSecretsManager.getProvider).toHaveBeenCalledWith('my-vault');
 		});
 	});
 
 	describe('toPublicConnectionListItem', () => {
-		it('should map entity to lightweight DTO with secretsCount but without settings or secrets', () => {
+		it('should map entity to lightweight DTO with secretsCount, state, but without settings or secrets', () => {
+			const mockProviderInstance = { state: 'connected' as const } as SecretsProvider;
+			mockExternalSecretsManager.getProvider.mockReturnValue(mockProviderInstance);
 			mockExternalSecretsManager.getSecretNames.mockReturnValue(['secret-a', 'secret-b']);
 
 			const connection = {
@@ -172,6 +177,7 @@ describe('SecretsProvidersConnectionsService', () => {
 				name: 'my-aws',
 				type: 'awsSecretsManager',
 				secretsCount: 2,
+				state: 'connected',
 				projects: [
 					{ id: 'p1', name: 'Project 1' },
 					{ id: 'p2', name: 'Project 2' },
@@ -184,10 +190,31 @@ describe('SecretsProvidersConnectionsService', () => {
 			expect(result).not.toHaveProperty('settings');
 			expect(result).not.toHaveProperty('secrets');
 
-			// Verify no external services were called (no decryption/redaction needed)
+			expect(mockExternalSecretsManager.getProvider).toHaveBeenCalledWith('my-aws');
+			expect(mockExternalSecretsManager.getSecretNames).toHaveBeenCalledWith('my-aws');
+			// No decryption/redaction for list response
 			expect(mockExternalSecretsManager.getProviderWithSettings).not.toHaveBeenCalled();
 			expect(mockRedactionService.redact).not.toHaveBeenCalled();
-			expect(mockExternalSecretsManager.getSecretNames).toHaveBeenCalledWith('my-aws');
+		});
+
+		it('should use state "initializing" when provider instance is not in registry', () => {
+			mockExternalSecretsManager.getProvider.mockReturnValue(undefined);
+			mockExternalSecretsManager.getSecretNames.mockReturnValue([]);
+
+			const connection = {
+				id: 2,
+				providerKey: 'not-synced-yet',
+				type: 'vault',
+				encryptedSettings: '{}',
+				projectAccess: [],
+				createdAt: new Date('2024-01-01'),
+				updatedAt: new Date('2024-01-02'),
+			} as unknown as SecretsProviderConnection;
+
+			const result = service.toPublicConnectionListItem(connection);
+
+			expect(result.state).toBe('initializing');
+			expect(mockExternalSecretsManager.getProvider).toHaveBeenCalledWith('not-synced-yet');
 		});
 	});
 

--- a/packages/cli/src/modules/external-secrets.ee/__tests__/secrets-providers-connections.service.ee.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/secrets-providers-connections.service.ee.test.ts
@@ -149,6 +149,63 @@ describe('SecretsProvidersConnectionsService', () => {
 			expect(mockExternalSecretsManager.getProviderProperties).toHaveBeenCalledWith('vault');
 			expect(mockExternalSecretsManager.getProvider).toHaveBeenCalledWith('my-vault');
 		});
+
+		it('should use state "initializing" when provider instance is not in registry', () => {
+			const mockProperties: INodeProperties[] = [
+				{ name: 'token', type: 'string', displayName: 'Token', default: '' },
+			];
+			const redactedSettings = { token: CREDENTIAL_BLANKING_VALUE };
+
+			mockExternalSecretsManager.getProviderProperties.mockReturnValue(mockProperties);
+			mockExternalSecretsManager.getProvider.mockReturnValue(undefined);
+			mockExternalSecretsManager.getSecretNames.mockReturnValue([]);
+			mockRedactionService.redact.mockReturnValue(redactedSettings);
+
+			const connection = {
+				id: 3,
+				providerKey: 'not-synced-yet',
+				type: 'vault',
+				encryptedSettings: '{}',
+				projectAccess: [],
+				createdAt: new Date('2024-01-01'),
+				updatedAt: new Date('2024-01-02'),
+			} as unknown as SecretsProviderConnection;
+
+			const result = service.toPublicConnection(connection);
+
+			expect(result.state).toBe('initializing');
+			expect(mockExternalSecretsManager.getProvider).toHaveBeenCalledWith('not-synced-yet');
+		});
+
+		it('should pass through state "error" from provider instance', () => {
+			const mockProperties: INodeProperties[] = [
+				{ name: 'key', type: 'string', displayName: 'Key', default: '' },
+			];
+			const redactedSettings = { key: CREDENTIAL_BLANKING_VALUE };
+			const mockProvider = {
+				state: 'error' as const,
+				properties: mockProperties,
+			} as SecretsProvider;
+
+			mockExternalSecretsManager.getProviderProperties.mockReturnValue(mockProperties);
+			mockExternalSecretsManager.getProvider.mockReturnValue(mockProvider);
+			mockExternalSecretsManager.getSecretNames.mockReturnValue([]);
+			mockRedactionService.redact.mockReturnValue(redactedSettings);
+
+			const connection = {
+				id: 4,
+				providerKey: 'failing-vault',
+				type: 'vault',
+				encryptedSettings: '{}',
+				projectAccess: [],
+				createdAt: new Date('2024-01-01'),
+				updatedAt: new Date('2024-01-02'),
+			} as unknown as SecretsProviderConnection;
+
+			const result = service.toPublicConnection(connection);
+
+			expect(result.state).toBe('error');
+		});
 	});
 
 	describe('toPublicConnectionListItem', () => {
@@ -215,6 +272,27 @@ describe('SecretsProvidersConnectionsService', () => {
 
 			expect(result.state).toBe('initializing');
 			expect(mockExternalSecretsManager.getProvider).toHaveBeenCalledWith('not-synced-yet');
+		});
+
+		it('should pass through state "error" from provider instance', () => {
+			const mockProviderInstance = { state: 'error' as const } as SecretsProvider;
+			mockExternalSecretsManager.getProvider.mockReturnValue(mockProviderInstance);
+			mockExternalSecretsManager.getSecretNames.mockReturnValue([]);
+
+			const connection = {
+				id: 3,
+				providerKey: 'failing-connection',
+				type: 'awsSecretsManager',
+				encryptedSettings: '{}',
+				projectAccess: [],
+				createdAt: new Date('2024-01-01'),
+				updatedAt: new Date('2024-01-02'),
+			} as unknown as SecretsProviderConnection;
+
+			const result = service.toPublicConnectionListItem(connection);
+
+			expect(result.state).toBe('error');
+			expect(mockExternalSecretsManager.getProvider).toHaveBeenCalledWith('failing-connection');
 		});
 	});
 

--- a/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
@@ -4,7 +4,7 @@ import { SecretsProviderConnectionRepository } from '@n8n/db';
 import { OnPubSubEvent } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import { Cipher, type IExternalSecretsManager } from 'n8n-core';
-import { jsonParse, UnexpectedError, type IDataObject } from 'n8n-workflow';
+import { jsonParse, UnexpectedError, type IDataObject, type INodeProperties } from 'n8n-workflow';
 
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { EventService } from '@/events/event.service';
@@ -92,6 +92,14 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 
 	getProvider(provider: string): SecretsProvider | undefined {
 		return this.providerRegistry.get(provider);
+	}
+
+	getProviderProperties(providerType: string): INodeProperties[] {
+		const ProviderClass = this.providersFactory.getProvider(providerType);
+		if (!ProviderClass) {
+			throw new NotFoundError(`Provider type "${providerType}" not found`);
+		}
+		return new ProviderClass().properties;
 	}
 
 	hasProvider(provider: string): boolean {

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.service.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.service.ee.ts
@@ -203,12 +203,14 @@ export class SecretsProvidersConnectionsService {
 		connection: SecretsProviderConnection,
 	): SecretsProvidersResponses.ConnectionListItem {
 		const secretNames = this.externalSecretsManager.getSecretNames(connection.providerKey);
+		const connectionInstance = this.externalSecretsManager.getProvider(connection.providerKey);
 
 		return {
 			id: String(connection.id),
 			name: connection.providerKey,
 			type: connection.type as SecretsProviderType,
 			secretsCount: secretNames.length,
+			state: connectionInstance?.state ?? 'initializing',
 			projects: connection.projectAccess.map((access) => ({
 				id: access.project.id,
 				name: access.project.name,
@@ -223,12 +225,14 @@ export class SecretsProvidersConnectionsService {
 		const { provider } = this.externalSecretsManager.getProviderWithSettings(connection.type);
 		const redactedSettings = this.redactionService.redact(decryptedSettings, provider.properties);
 		const secretNames = this.externalSecretsManager.getSecretNames(connection.providerKey);
+		const connectionInstance = this.externalSecretsManager.getProvider(connection.providerKey);
 
 		return {
 			id: String(connection.id),
 			name: connection.providerKey,
 			type: connection.type as SecretsProviderType,
 			secretsCount: secretNames.length,
+			state: connectionInstance?.state ?? 'initializing',
 			secrets: secretNames.map((name) => ({ name })),
 			projects: connection.projectAccess.map((access) => ({
 				id: access.project.id,

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.service.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.service.ee.ts
@@ -222,8 +222,8 @@ export class SecretsProvidersConnectionsService {
 
 	toPublicConnection(connection: SecretsProviderConnection): SecretsProvidersResponses.Connection {
 		const decryptedSettings = this.decryptConnectionSettings(connection.encryptedSettings);
-		const { provider } = this.externalSecretsManager.getProviderWithSettings(connection.type);
-		const redactedSettings = this.redactionService.redact(decryptedSettings, provider.properties);
+		const properties = this.externalSecretsManager.getProviderProperties(connection.type);
+		const redactedSettings = this.redactionService.redact(decryptedSettings, properties);
 		const secretNames = this.externalSecretsManager.getSecretNames(connection.providerKey);
 		const connectionInstance = this.externalSecretsManager.getProvider(connection.providerKey);
 

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.service.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.service.ee.ts
@@ -210,6 +210,8 @@ export class SecretsProvidersConnectionsService {
 			name: connection.providerKey,
 			type: connection.type as SecretsProviderType,
 			secretsCount: secretNames.length,
+			// Provider may not be registered yet in multi-main setups.
+			// When that's the case the default state is 'initializing'.
 			state: connectionInstance?.state ?? 'initializing',
 			projects: connection.projectAccess.map((access) => ({
 				id: access.project.id,
@@ -232,6 +234,8 @@ export class SecretsProvidersConnectionsService {
 			name: connection.providerKey,
 			type: connection.type as SecretsProviderType,
 			secretsCount: secretNames.length,
+			// Provider may not be registered yet in multi-main setups.
+			// When that's the case the default state is 'initializing'.
 			state: connectionInstance?.state ?? 'initializing',
 			secrets: secretNames.map((name) => ({ name })),
 			projects: connection.projectAccess.map((access) => ({

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers.responses.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers.responses.ee.ts
@@ -2,13 +2,10 @@ import type { SecretProviderConnection } from '@n8n/api-types';
 
 export declare namespace SecretsProvidersResponses {
 	// Lightweight type for list responses (no settings, no secrets array)
-	type ConnectionListItem = Omit<
-		SecretProviderConnection,
-		'settings' | 'state' | 'isEnabled' | 'secrets'
-	>;
+	type ConnectionListItem = Omit<SecretProviderConnection, 'settings' | 'isEnabled' | 'secrets'>;
 
 	// Full type for detail responses (includes redacted settings and secrets)
-	type Connection = Omit<SecretProviderConnection, 'state' | 'isEnabled'>;
+	type Connection = Omit<SecretProviderConnection, 'isEnabled'>;
 
 	/** @deprecated: use ConnectionListItem instead **/
 	type StrippedConnection = ConnectionListItem;

--- a/packages/cli/test/integration/external-secrets/secret-providers-connections.api.test.ts
+++ b/packages/cli/test/integration/external-secrets/secret-providers-connections.api.test.ts
@@ -133,6 +133,7 @@ describe('Secret Providers Connections API', () => {
 				name: 'aws-prod',
 				type: 'awsSecretsManager',
 				secretsCount: 2,
+				state: 'connected',
 				secrets: [{ name: 'test1' }, { name: 'test2' }],
 				projects: [],
 				settings: expect.any(Object),
@@ -421,6 +422,7 @@ describe('Secret Providers Connections API', () => {
 					id: expect.any(String),
 					name: expect.any(String),
 					type: expect.any(String),
+					state: expect.any(String),
 					projects: expect.any(Array),
 					createdAt: expect.any(String),
 					updatedAt: expect.any(String),
@@ -468,6 +470,7 @@ describe('Secret Providers Connections API', () => {
 				id: expect.any(String),
 				name: 'get-test',
 				type: 'awsSecretsManager',
+				state: expect.any(String),
 				createdAt: expect.any(String),
 				updatedAt: expect.any(String),
 			});

--- a/packages/cli/test/integration/external-secrets/secret-providers-project.api.test.ts
+++ b/packages/cli/test/integration/external-secrets/secret-providers-project.api.test.ts
@@ -162,6 +162,7 @@ describe('Secret Providers Project API', () => {
 				expect(globalConnection1).toMatchObject({
 					name: 'global-connection1',
 					type: 'dummy',
+					state: 'initializing',
 					projects: [],
 				});
 			});
@@ -214,6 +215,7 @@ describe('Secret Providers Project API', () => {
 					expect(connection1).toMatchObject({
 						name: 'connection1',
 						type: 'dummy',
+						state: 'initializing',
 						projects: [{ id: teamProject1.id, name: teamProject1.name }],
 					});
 				});
@@ -309,6 +311,7 @@ describe('Secret Providers Project API', () => {
 			expect(response.body.data).toMatchObject({
 				name: 'new-conn',
 				type: 'awsSecretsManager',
+				state: 'connected',
 				projects: [{ id: teamProject1.id, name: teamProject1.name }],
 			});
 
@@ -405,6 +408,7 @@ describe('Secret Providers Project API', () => {
 
 			expect(response.body.data).toMatchObject({
 				name: 'my-conn',
+				state: 'initializing',
 				projects: [{ id: teamProject1.id }],
 			});
 		});


### PR DESCRIPTION
## Summary

<img width="793" height="576" alt="image" src="https://github.com/user-attachments/assets/986082e9-07b3-4b1a-8870-83d0646c0262" />

- Added `state` property to the API response
- Implemented `getProviderProperties` method to fetch provider-specific connection information
- No need to change the frontend, there was already support for the state

### Testing:

1. Add connection with valid details -> Should not show any indicator on the screen
2. Add a connection with invalid details -> Should show a `Disconnected` label next to its 

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-240

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [ ] Docs updated or follow-up ticket created
- [x] Tests included (added comprehensive tests for all connection states)
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)