### PR TITLE
feat(core): Don't show infisical as option when creating new secret secret store (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useConnectionModal.ee.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useConnectionModal.ee.test.ts
@@ -4,6 +4,14 @@ import { vi } from 'vitest';
 import type { SecretProviderTypeResponse } from '@n8n/api-types';
 import type { ProjectListItem } from '@/features/collaboration/projects/projects.types';
 
+// Mock feature flag composable
+const { useEnvFeatureFlag } = vi.hoisted(() => ({
+	useEnvFeatureFlag: vi.fn(),
+}));
+vi.mock('@/features/shared/envFeatureFlag/useEnvFeatureFlag', () => ({
+	useEnvFeatureFlag,
+}));
+
 // Mock dependencies
 const mockConnection = {
 	getConnection: vi.fn(),
@@ -79,6 +87,10 @@ describe('useConnectionModal', () => {
 		});
 		mockShowError.mockClear();
 		mockShowMessage.mockClear();
+		// Mock feature flag to return false by default
+		useEnvFeatureFlag.mockReturnValue({
+			check: ref(() => false),
+		});
 	});
 
 	describe('initialization', () => {
@@ -190,6 +202,67 @@ describe('useConnectionModal', () => {
 				projectIds: [],
 			});
 			expect(mockConnection.testConnection).toHaveBeenCalledWith('existing-key');
+		});
+	});
+
+	describe('infisical deprecation', () => {
+		beforeEach(() => {
+			useEnvFeatureFlag.mockReturnValue({
+				check: ref((key: string) => key === 'EXTERNAL_SECRETS_MULTIPLE_CONNECTIONS'),
+			});
+		});
+		it('should not provide option to create new infisical connection if new feature flag is enabled', () => {
+			const providerTypesWithInfisical = ref([
+				...mockProviderTypes,
+				{
+					type: 'infisical',
+					displayName: 'Infisical',
+					icon: 'infisical',
+					properties: [],
+				} as SecretProviderTypeResponse,
+			]);
+
+			const { providerTypeOptions } = useConnectionModal({
+				...defaultOptions,
+				providerTypes: providerTypesWithInfisical,
+			});
+
+			expect(providerTypeOptions.value.find((opt) => opt.value === 'infisical')).toBeUndefined();
+			expect(providerTypeOptions.value.length).toEqual(1);
+			expect(providerTypeOptions.value[0].value).toEqual('awsSecretsManager');
+		});
+
+		it('should still set selectedProviderType to infisical on existing infisical connection', async () => {
+			const providerTypesWithInfisical = ref([
+				...mockProviderTypes,
+				{
+					type: 'infisical',
+					displayName: 'Infisical',
+					icon: 'infisical',
+					properties: [],
+				} as SecretProviderTypeResponse,
+			]);
+
+			// Mock existing infisical connection
+			mockConnection.getConnection.mockResolvedValue({
+				id: 'infisical-id',
+				name: 'infisical-connection',
+				type: 'infisical',
+				settings: {},
+			});
+
+			const options = {
+				...defaultOptions,
+				providerTypes: providerTypesWithInfisical,
+				providerKey: ref('infisical-key'),
+			};
+
+			const { selectedProviderType, providerTypeOptions, loadConnection } =
+				useConnectionModal(options);
+
+			await loadConnection();
+
+			expect(selectedProviderType.value?.type).toBe('infisical');
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useConnectionModal.ee.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useConnectionModal.ee.test.ts
@@ -257,8 +257,7 @@ describe('useConnectionModal', () => {
 				providerKey: ref('infisical-key'),
 			};
 
-			const { selectedProviderType, providerTypeOptions, loadConnection } =
-				useConnectionModal(options);
+			const { selectedProviderType, loadConnection } = useConnectionModal(options);
 
 			await loadConnection();
 


### PR DESCRIPTION
## Summary

With the upcoming release of multiple connections per global provider, we want to no longer provide the option to create connections for the `infisical` provider type.

This PR removes the option from the creation dialog, but still renders the provider type as expected for existing infisical connections.

**How to test**:
- Run `$cli pnpm run dev` without `N8N_ENV_FEAT_EXTERNAL_SECRETS_MULTIPLE_CONNECTIONS` enabled
- Create an infisical connection (no need to use valid credentials, just enter any strings in the required fields)
- Run `$cli N8N_ENV_FEAT_EXTERNAL_SECRETS_MULTIPLE_CONNECTIONS=true pnpm run dev`
- Observe that in the UI, you can no longer create an infisical connection, on your existing one, the infisical type is still displayed as expected.

Existing infisical connection with value correctly displayed (dropdown is disabled):
<img width="990" height="855" alt="image" src="https://github.com/user-attachments/assets/4c71aee1-cf3e-4cc2-8af6-fc4831f2c410" />

Can't select infisical in create modal anymore:
<img width="727" height="622" alt="image" src="https://github.com/user-attachments/assets/ca042d32-7ec1-4ca2-a9d3-1db3fbe54477" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-253/remove-infiscal-from-the-ui


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
