### PR TITLE
feat(editor): Update styles and Secrets Provider connection components

### DIFF
--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/DeleteSecretsProviderModal.ee.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/DeleteSecretsProviderModal.ee.vue
@@ -182,11 +182,11 @@ function onCancel() {
 
 		<template #footer>
 			<div :class="$style.footer">
-				<N8nButton type="secondary" @click="onCancel">
+				<N8nButton variant="subtle" @click="onCancel">
 					{{ i18n.baseText('generic.cancel') }}
 				</N8nButton>
 				<N8nButton
-					type="danger"
+					variant="destructive"
 					:disabled="!deleteEnabled"
 					:loading="isDeleting"
 					data-test-id="confirm-delete-button"

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionCard.ee.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionCard.ee.vue
@@ -123,7 +123,7 @@ function onAction(action: string) {
 </script>
 
 <template>
-	<N8nCard :class="$style.card" hoverable>
+	<N8nCard :class="$style.card">
 		<template v-if="providerTypeInfo" #prepend>
 			<SecretsProviderImage
 				:class="$style.providerImage"
@@ -214,6 +214,12 @@ function onAction(action: string) {
 .card {
 	--card--padding: var(--spacing--2xs);
 	padding-left: var(--spacing--sm);
+	transition: box-shadow 0.3s ease;
+	cursor: pointer;
+
+	&:hover {
+		box-shadow: var(--shadow--card-hover);
+	}
 }
 
 .providerImage {

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionCard.ee.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionCard.ee.vue
@@ -235,7 +235,8 @@ function onAction(action: string) {
 	padding: var(--spacing--4xs) var(--spacing--2xs);
 	background-color: var(--color--background--light-3);
 	border-color: var(--color--foreground);
-	height: 23px;
+	height: var(--spacing--lg);
+	cursor: pointer;
 
 	& > span {
 		display: flex;

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionModal.ee.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionModal.ee.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, onMounted, ref, useTemplateRef } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { useI18n } from '@n8n/i18n';
 import { useMessage } from '@/app/composables/useMessage';
 import { createEventBus } from '@n8n/utils/event-bus';
@@ -32,7 +32,6 @@ import {
 	N8nTooltip,
 	type IMenuItem,
 } from '@n8n/design-system';
-import { useElementSize } from '@vueuse/core';
 import ProjectSharing from '@/features/collaboration/projects/components/ProjectSharing.vue';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import type { ProjectSharingData } from '@/features/collaboration/projects/projects.types';
@@ -197,9 +196,6 @@ onMounted(async () => {
 		await Promise.all([modal.loadConnection()]);
 	}
 });
-
-const nameRef = useTemplateRef('nameRef');
-const { width } = useElementSize(nameRef);
 </script>
 
 <template>
@@ -223,17 +219,24 @@ const { width } = useElementSize(nameRef);
 							:class="$style.headerIcon"
 						/><N8nIcon v-else icon="vault" width="24" height="24" />
 					</div>
-					<div ref="nameRef" :class="$style.name">
-						<div :class="$style.nameRow">
-							<N8nText size="large">
-								{{
-									modal.selectedProviderType.value?.displayName ??
-									i18n.baseText(
-										'settings.secretsProviderConnections.modal.providerType.placeholder',
-									)
-								}}
-							</N8nText>
-						</div>
+					<div :class="$style.name">
+						<N8nText
+							v-if="modal.providerKey.value"
+							size="large"
+							:class="$style.providerName"
+							:title="modal.providerKey.value"
+						>
+							{{ modal.providerKey.value }}
+						</N8nText>
+						<N8nText
+							:size="modal.providerKey.value ? 'small' : 'large'"
+							:color="modal.providerKey.value ? 'text-light' : 'text-base'"
+						>
+							{{
+								modal.selectedProviderType.value?.displayName ??
+								i18n.baseText('settings.secretsProviderConnections.modal.providerType.placeholder')
+							}}
+						</N8nText>
 					</div>
 				</div>
 				<div :class="$style.actions">
@@ -461,8 +464,8 @@ const { width } = useElementSize(nameRef);
 .secretsProviderConnectionModal {
 	--dialog--max-width: 1200px;
 	--dialog--close--spacing--top: 31px;
-	--dialog--min-height: 600px;
-	--dialog--max-height: 600px;
+	min-height: var(--dialog--min-height);
+	max-height: var(--dialog--max-height);
 
 	:global(.el-dialog__header) {
 		padding-bottom: 0;
@@ -484,6 +487,7 @@ const { width } = useElementSize(nameRef);
 .icon {
 	width: 1.5rem;
 	height: 1.5rem;
+	min-width: 1.5rem;
 	display: flex;
 	align-items: center;
 	margin-right: var(--spacing--xs);
@@ -491,16 +495,14 @@ const { width } = useElementSize(nameRef);
 
 .name {
 	display: flex;
-	width: 100%;
 	flex-direction: column;
-	gap: var(--spacing--4xs);
+	min-width: 0;
 }
 
-.nameRow {
-	display: flex;
-	align-items: center;
-	gap: var(--spacing--2xs);
-	min-height: var(--spacing--md);
+.providerName {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .headerHint {
@@ -539,6 +541,7 @@ const { width } = useElementSize(nameRef);
 	align-items: center;
 	flex-direction: row;
 	flex-grow: 1;
+	min-width: 0;
 	margin-bottom: var(--spacing--lg);
 }
 

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionModal.ee.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionModal.ee.vue
@@ -348,7 +348,6 @@ onMounted(async () => {
 									<N8nInput
 										data-test-id="provider-name"
 										:model-value="modal.connectionName.value"
-										:max-width="width - 10"
 										:readonly="modal.isEditMode.value"
 										:disabled="modal.isEditMode.value"
 										aria-required="true"


### PR DESCRIPTION
## Summary

Sets modal height correctly (`--dialog--max-height` and `--dialog--min-height`)
Show vault name in header row
Handles long vault names
DeleteSecretsProviderModal: fixes button styles to use new component variants

## Screenshots

<img width="1027" height="682" alt="Screenshot 2026-02-17 at 16 04 25" src="https://github.com/user-attachments/assets/0607938e-0740-4971-800b-769f6ee85586" />

## Related Linear tickets, Github issues, and Community forum posts

Closes [LIGO-250](https://linear.app/n8n/issue/LIGO-250/fe-style-fixes-for-connection-list-and-modal)
Closes [LIGO-251](https://linear.app/n8n/issue/LIGO-251/fe-both-cancel-and-delete-button-for-deleting-external-secret-are)


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
