### PR TITLE
fix(editor): Re-layout all nodes on structural changes in AI builder

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
@@ -318,16 +318,13 @@ export function useWorkflowUpdate() {
 	}
 
 	/**
-	 * Tidy up new node positions
+	 * Tidy up node positions. When nodeIdsFilter is provided, only those nodes
+	 * are laid out. When omitted, all nodes are laid out (full re-layout).
 	 */
-	function tidyUpNewNodes(nodeIds: string[]): void {
-		if (nodeIds.length === 0) {
-			return;
-		}
-
+	function tidyUpNodes(nodeIdsFilter?: string[]): void {
 		canvasEventBus.emit('tidyUp', {
 			source: 'builder-update',
-			nodeIdsFilter: nodeIds,
+			nodeIdsFilter,
 			trackEvents: false,
 			trackHistory: true,
 			trackBulk: false,
@@ -366,9 +363,10 @@ export function useWorkflowUpdate() {
 
 			builderStore.setBuilderMadeEdits(true);
 
-			// Combine newly added node IDs with any additional IDs from previous messages
-			const allNodeIdsToTidyUp = [...newNodeIds, ...(options?.nodeIdsToTidyUp ?? [])];
-			tidyUpNewNodes(allNodeIdsToTidyUp);
+			const hasStructuralChanges = nodesToAdd.length > 0 || nodesToRemove.length > 0;
+			if (hasStructuralChanges) {
+				tidyUpNodes();
+			}
 
 			return { success: true, newNodeIds };
 		} catch (error) {


### PR DESCRIPTION
## Summary

When the AI builder sends follow-up updates (e.g. "this is failing, fix it"), nodes get added/removed but only **new** nodes were laid out, existing nodes stayed in stale positions, causing overlapping. 

`tidyUpNewNodes` always filtered to just new node IDs, so `Canvas.vue` ran `layout('selection')` on only those nodes.

**Fix:** Detect structural changes (adds or removes) and trigger a full re-layout (`tidyUpNodes()` without a filter), so `Canvas.vue` runs `layout('all')` and we properly arrange every node...

https://linear.app/n8n/issue/AI-2045