### PR TITLE
fix(core): Normalize Gemini tool schemas before binding tools

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleGemini/LmChatGoogleGemini.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleGemini/LmChatGoogleGemini.node.ts
@@ -12,6 +12,7 @@ import type {
 import { getConnectionHintNoticeField } from '@utils/sharedFields';
 
 import { getAdditionalOptions } from '../gemini-common/additional-options';
+import { wrapGeminiBindTools } from '../gemini-common/normalizeGeminiToolSchema';
 import { makeN8nLlmFailedAttemptHandler, N8nLlmTracing } from '@n8n/ai-utilities';
 
 function errorDescriptionMapper(error: NodeError) {
@@ -146,18 +147,20 @@ export class LmChatGoogleGemini implements INodeType {
 			null,
 		) as SafetySetting[];
 
-		const model = new ChatGoogleGenerativeAI({
-			apiKey: credentials.apiKey as string,
-			baseUrl: credentials.host as string,
-			model: modelName,
-			topK: options.topK,
-			topP: options.topP,
-			temperature: options.temperature,
-			maxOutputTokens: options.maxOutputTokens,
-			safetySettings,
-			callbacks: [new N8nLlmTracing(this, { errorDescriptionMapper })],
-			onFailedAttempt: makeN8nLlmFailedAttemptHandler(this),
-		});
+		const model = wrapGeminiBindTools(
+			new ChatGoogleGenerativeAI({
+				apiKey: credentials.apiKey as string,
+				baseUrl: credentials.host as string,
+				model: modelName,
+				topK: options.topK,
+				topP: options.topP,
+				temperature: options.temperature,
+				maxOutputTokens: options.maxOutputTokens,
+				safetySettings,
+				callbacks: [new N8nLlmTracing(this, { errorDescriptionMapper })],
+				onFailedAttempt: makeN8nLlmFailedAttemptHandler(this),
+			}),
+		);
 
 		return {
 			response: model,

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/LmChatGoogleVertex.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/LmChatGoogleVertex.node.ts
@@ -18,6 +18,7 @@ import { getConnectionHintNoticeField } from '@utils/sharedFields';
 
 import { makeErrorFromStatus } from './error-handling';
 import { getAdditionalOptions } from '../gemini-common/additional-options';
+import { wrapGeminiBindTools } from '../gemini-common/normalizeGeminiToolSchema';
 import { makeN8nLlmFailedAttemptHandler, N8nLlmTracing } from '@n8n/ai-utilities';
 
 export class LmChatGoogleVertex implements INodeType {
@@ -201,7 +202,7 @@ export class LmChatGoogleVertex implements INodeType {
 				modelConfig.thinkingBudget = options.thinkingBudget;
 			}
 
-			const model = new ChatVertexAI(modelConfig);
+			const model = wrapGeminiBindTools(new ChatVertexAI(modelConfig));
 
 			return {
 				response: model,

--- a/packages/@n8n/nodes-langchain/nodes/llms/gemini-common/normalizeGeminiToolSchema.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/gemini-common/normalizeGeminiToolSchema.test.ts
@@ -1,0 +1,143 @@
+import { normalizeGeminiToolSchema, wrapGeminiBindTools } from './normalizeGeminiToolSchema';
+
+describe('normalizeGeminiToolSchema', () => {
+	it('should normalize nullable type arrays recursively', () => {
+		const schema = {
+			type: 'object',
+			additionalProperties: false,
+			properties: {
+				value: {
+					type: ['string', 'null'],
+					additionalProperties: false,
+				},
+			},
+		};
+
+		const normalized = normalizeGeminiToolSchema(schema, 'my_tool') as {
+			properties: { value: { type: string; nullable: boolean; additionalProperties?: unknown } };
+			additionalProperties?: unknown;
+		};
+
+		expect(normalized.additionalProperties).toBeUndefined();
+		expect(normalized.properties.value.type).toBe('string');
+		expect(normalized.properties.value.nullable).toBe(true);
+		expect(normalized.properties.value.additionalProperties).toBeUndefined();
+	});
+
+	it('should throw a descriptive error for anyOf', () => {
+		const schema = {
+			type: 'object',
+			properties: {
+				value: {
+					anyOf: [{ type: 'string' }, { type: 'number' }],
+				},
+			},
+		};
+
+		expect(() => normalizeGeminiToolSchema(schema, 'my_tool')).toThrow(/my_tool/);
+		expect(() => normalizeGeminiToolSchema(schema, 'my_tool')).toThrow(/anyOf is not supported/);
+	});
+
+	it('should throw a descriptive error for unsupported multi-type union', () => {
+		const schema = {
+			type: 'object',
+			properties: {
+				value: {
+					type: ['string', 'number', 'null'],
+				},
+			},
+		};
+
+		expect(() => normalizeGeminiToolSchema(schema, 'my_tool')).toThrow(/unsupported type union/);
+	});
+});
+
+describe('wrapGeminiBindTools', () => {
+	it('should normalize schema tools before calling bindTools', () => {
+		const originalBindTools = jest.fn().mockReturnValue('bound');
+		const model = {
+			bindTools: originalBindTools as (tools: unknown[], kwargs?: unknown) => unknown,
+		};
+		const wrappedModel = wrapGeminiBindTools(model);
+		const tools = [
+			{
+				name: 'weather_tool',
+				schema: {
+					type: 'object',
+					properties: {
+						value: { type: ['number', 'null'] },
+					},
+				},
+			},
+		];
+
+		wrappedModel.bindTools?.(tools, { tool_choice: 'auto' });
+
+		expect(originalBindTools).toHaveBeenCalledTimes(1);
+		const calledTools = originalBindTools.mock.calls[0][0] as Array<{
+			schema: { properties: { value: { type: string; nullable: boolean } } };
+		}>;
+
+		expect(calledTools[0].schema.properties.value.type).toBe('number');
+		expect(calledTools[0].schema.properties.value.nullable).toBe(true);
+		expect(tools[0].schema.properties.value.type).toEqual(['number', 'null']);
+	});
+
+	it('should normalize function declarations before calling bindTools', () => {
+		const originalBindTools = jest.fn().mockReturnValue('bound');
+		const model = {
+			bindTools: originalBindTools as (tools: unknown[], kwargs?: unknown) => unknown,
+		};
+		const wrappedModel = wrapGeminiBindTools(model);
+		const tools = [
+			{
+				functionDeclarations: [
+					{
+						name: 'my_tool',
+						parameters: {
+							type: 'object',
+							properties: {
+								value: { type: ['string', 'null'] },
+							},
+						},
+					},
+				],
+			},
+		];
+
+		wrappedModel.bindTools?.(tools);
+
+		const calledTools = originalBindTools.mock.calls[0][0] as Array<{
+			functionDeclarations: Array<{
+				parameters: { properties: { value: { type: string; nullable: boolean } } };
+			}>;
+		}>;
+
+		expect(calledTools[0].functionDeclarations[0].parameters.properties.value.type).toBe('string');
+		expect(calledTools[0].functionDeclarations[0].parameters.properties.value.nullable).toBe(true);
+	});
+
+	it('should throw before binding unsupported union schemas', () => {
+		const originalBindTools = jest.fn().mockReturnValue('bound');
+		const wrappedModel = wrapGeminiBindTools({
+			bindTools: originalBindTools as (tools: unknown[], kwargs?: unknown) => unknown,
+		});
+
+		expect(() =>
+			wrappedModel.bindTools?.([
+				{
+					name: 'bad_tool',
+					schema: {
+						type: 'object',
+						properties: {
+							value: {
+								oneOf: [{ type: 'string' }, { type: 'number' }],
+							},
+						},
+					},
+				},
+			]),
+		).toThrow(/oneOf is not supported/);
+		expect(originalBindTools).not.toHaveBeenCalled();
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/llms/gemini-common/normalizeGeminiToolSchema.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/gemini-common/normalizeGeminiToolSchema.ts
@@ -1,0 +1,166 @@
+import { toJsonSchema } from '@langchain/core/utils/json_schema';
+import { isInteropZodSchema } from '@langchain/core/utils/types';
+
+type JsonObject = Record<string, unknown>;
+
+type NormalizedType = {
+	type: string;
+	nullable: boolean;
+};
+
+function isJsonObject(value: unknown): value is JsonObject {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function toolSchemaError(toolName: string, path: string, reason: string): Error {
+	return new Error(
+		[
+			`Google Gemini does not support this tool schema for "${toolName}".`,
+			`Path: ${path}.`,
+			`Reason: ${reason}.`,
+			'Use a flat object schema with optional fields instead of unions (anyOf/oneOf or multi-type arrays).',
+		].join(' '),
+	);
+}
+
+function normalizeTypeArray(typeValues: unknown[], toolName: string, path: string): NormalizedType {
+	if (typeValues.length === 0) {
+		throw toolSchemaError(toolName, path, 'empty type array');
+	}
+
+	if (!typeValues.every((value) => typeof value === 'string')) {
+		throw toolSchemaError(toolName, path, 'type array contains non-string values');
+	}
+
+	const uniqueTypes = Array.from(new Set(typeValues as string[]));
+	const nonNullTypes = uniqueTypes.filter((type) => type !== 'null');
+	const hasNull = uniqueTypes.includes('null');
+
+	if (nonNullTypes.length === 1) {
+		return {
+			type: nonNullTypes[0],
+			nullable: hasNull,
+		};
+	}
+
+	throw toolSchemaError(toolName, path, `unsupported type union ${JSON.stringify(uniqueTypes)}`);
+}
+
+function normalizeGeminiSchemaInternal(schema: unknown, toolName: string, path: string): unknown {
+	if (Array.isArray(schema)) {
+		return schema.map((item, index) =>
+			normalizeGeminiSchemaInternal(item, toolName, `${path}[${index}]`),
+		);
+	}
+
+	if (!isJsonObject(schema)) {
+		return schema;
+	}
+
+	const normalizedSchema: JsonObject = {};
+	let nullableFromType = false;
+
+	for (const [key, value] of Object.entries(schema)) {
+		const currentPath = `${path}.${key}`;
+
+		if (key === 'additionalProperties' || key === '$schema' || key === 'strict') {
+			continue;
+		}
+
+		if (key === 'anyOf' || key === 'oneOf') {
+			throw toolSchemaError(toolName, currentPath, `${key} is not supported`);
+		}
+
+		if (key === 'type' && Array.isArray(value)) {
+			const normalizedType = normalizeTypeArray(value, toolName, currentPath);
+			normalizedSchema.type = normalizedType.type;
+			nullableFromType = normalizedType.nullable;
+			continue;
+		}
+
+		normalizedSchema[key] = normalizeGeminiSchemaInternal(value, toolName, currentPath);
+	}
+
+	if (nullableFromType) {
+		normalizedSchema.nullable = true;
+	}
+
+	return normalizedSchema;
+}
+
+function normalizeTool(inputTool: unknown): unknown {
+	if (!isJsonObject(inputTool)) {
+		return inputTool;
+	}
+
+	if (Array.isArray(inputTool.functionDeclarations)) {
+		return {
+			...inputTool,
+			functionDeclarations: inputTool.functionDeclarations.map((functionDeclaration, index) => {
+				if (!isJsonObject(functionDeclaration)) {
+					return functionDeclaration;
+				}
+
+				const toolName =
+					typeof functionDeclaration.name === 'string'
+						? functionDeclaration.name
+						: `functionDeclaration[${index}]`;
+
+				if (
+					!('parameters' in functionDeclaration) ||
+					functionDeclaration.parameters === undefined
+				) {
+					return functionDeclaration;
+				}
+
+				return {
+					...functionDeclaration,
+					parameters: normalizeGeminiSchemaInternal(
+						functionDeclaration.parameters,
+						toolName,
+						`${toolName}.parameters`,
+					),
+				};
+			}),
+		};
+	}
+
+	if (
+		typeof inputTool.name === 'string' &&
+		'schema' in inputTool &&
+		inputTool.schema !== undefined
+	) {
+		const toolSchema = isInteropZodSchema(inputTool.schema)
+			? toJsonSchema(inputTool.schema)
+			: inputTool.schema;
+
+		return {
+			...inputTool,
+			schema: normalizeGeminiSchemaInternal(toolSchema, inputTool.name, `${inputTool.name}.schema`),
+		};
+	}
+
+	return inputTool;
+}
+
+export function wrapGeminiBindTools<T extends { bindTools?: unknown }>(model: T): T {
+	if (typeof model.bindTools !== 'function') {
+		return model;
+	}
+
+	const originalBindTools = model.bindTools.bind(model) as (
+		tools: unknown[],
+		kwargs?: unknown,
+	) => unknown;
+
+	model.bindTools = ((tools: unknown[], kwargs?: unknown) => {
+		const normalizedTools = tools.map((tool) => normalizeTool(tool));
+		return originalBindTools(normalizedTools, kwargs);
+	}) as T['bindTools'];
+
+	return model;
+}
+
+export function normalizeGeminiToolSchema(schema: unknown, toolName: string): unknown {
+	return normalizeGeminiSchemaInternal(schema, toolName, `${toolName}.schema`);
+}


### PR DESCRIPTION
## Summary

### Reason for change
Gemini rejects tool schemas containing JSON Schema unions such as `type: ["string", "null"]` and compositional keywords (`anyOf` / `oneOf`) in MCP tool declarations. This caused Gemini model executions to fail when MCP Client Tool was connected.

### Review focus
- The new Gemini schema normalizer behavior for `schema` and `functionDeclarations[].parameters`
- Safety of wrapping `bindTools` for both Google Gemini and Vertex chat models
- Error behavior for unsupported schema constructs (explicit early failure)

### Executed validation
- `pnpm build > build.log 2>&1` (repo root)
- `pnpm test nodes/llms/gemini-common/normalizeGeminiToolSchema.test.ts` (packages/@n8n/nodes-langchain)
- `pnpm test nodes/llms/LmChatGoogleVertex/test/LmChatGoogleVertex.test.ts` (packages/@n8n/nodes-langchain)
- `pnpm lint` (packages/@n8n/nodes-langchain)
- `pnpm typecheck` (packages/@n8n/nodes-langchain)

### Open questions / unresolved items
- Current implementation intentionally rejects `anyOf` / `oneOf` and multi-type unions except nullable unions. If broader Gemini schema support is needed, a follow-up should define deterministic conversion rules.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/GHC-2086
- fixes #15553

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
