### PR TITLE
feat(editor): Add reload action to secret provider connections (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/rest-api-client/src/api/secretsProvider.ee.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/api/secretsProvider.ee.ts
@@ -1,4 +1,5 @@
 import type {
+	ReloadSecretProviderConnectionResponse,
 	SecretProviderConnection,
 	SecretProviderTypeResponse,
 	TestSecretProviderConnectionResponse,
@@ -64,6 +65,17 @@ export const testSecretProviderConnection = async (
 		context,
 		'POST',
 		`/secret-providers/connections/${providerKey}/test`,
+	);
+};
+
+export const reloadSecretProviderConnection = async (
+	context: IRestApiContext,
+	providerKey: string,
+): Promise<ReloadSecretProviderConnectionResponse> => {
+	return await makeRestApiRequest(
+		context,
+		'POST',
+		`/secret-providers/connections/${providerKey}/reload`,
 	);
 };
 

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionCard.ee.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionCard.ee.vue
@@ -35,6 +35,7 @@ const props = defineProps<{
 const emit = defineEmits<{
 	edit: [providerKey: string];
 	share: [providerKey: string];
+	reload: [providerKey: string];
 	delete: [providerKey: string];
 }>();
 
@@ -101,6 +102,13 @@ const actionDropdownOptions = computed(() => {
 		});
 	}
 
+	if (provider.value.state !== 'error') {
+		options.push({
+			label: i18n.baseText('settings.externalSecrets.card.actionDropdown.reload'),
+			value: 'reload',
+		});
+	}
+
 	if (canDelete.value) {
 		options.push({
 			label: i18n.baseText('generic.delete'),
@@ -116,6 +124,8 @@ function onAction(action: string) {
 		emit('edit', provider.value.name);
 	} else if (action === 'share') {
 		emit('share', provider.value.name);
+	} else if (action === 'reload') {
+		emit('reload', provider.value.name);
 	} else if (action === 'delete') {
 		emit('delete', provider.value.name);
 	}

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionCard.ee.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionCard.ee.vue
@@ -102,7 +102,7 @@ const actionDropdownOptions = computed(() => {
 		});
 	}
 
-	if (provider.value.state !== 'error') {
+	if (provider.value.state === 'connected') {
 		options.push({
 			label: i18n.baseText('settings.externalSecrets.card.actionDropdown.reload'),
 			value: 'reload',

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionCard.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionCard.test.ts
@@ -196,4 +196,30 @@ describe('SecretsProviderConnectionCard', () => {
 		expect(getByTestId('secrets-provider-action-toggle')).toBeInTheDocument();
 		expect(screen.queryAllByTestId('action-edit').length).toBe(0);
 	});
+
+	it('should show reload action when provider is connected', () => {
+		const providerTypeInfo = MOCK_PROVIDER_TYPES.find((t) => t.type === mockProvider.type);
+
+		renderComponent({
+			pinia,
+			props: { provider: mockProvider, providerTypeInfo, canUpdate: true },
+		});
+
+		expect(screen.getByTestId('action-reload')).toBeInTheDocument();
+	});
+
+	it('should not show reload action when provider is in error state', () => {
+		const errorProvider: SecretProviderConnection = {
+			...mockProvider,
+			state: 'error',
+		};
+		const providerTypeInfo = MOCK_PROVIDER_TYPES.find((t) => t.type === mockProvider.type);
+
+		renderComponent({
+			pinia,
+			props: { provider: errorProvider, providerTypeInfo, canUpdate: true },
+		});
+
+		expect(screen.queryByTestId('action-reload')).not.toBeInTheDocument();
+	});
 });

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useSecretsProvidersList.ee.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useSecretsProvidersList.ee.test.ts
@@ -12,6 +12,7 @@ import { SETTINGS_STORE_DEFAULT_STATE } from '@/__tests__/utils';
 vi.mock('@n8n/rest-api-client', () => ({
 	getSecretProviderTypes: vi.fn(),
 	getSecretProviderConnections: vi.fn(),
+	getSecretProviderConnectionByKey: vi.fn(),
 }));
 
 describe('useSecretsProvidersList', () => {
@@ -165,6 +166,92 @@ describe('useSecretsProvidersList', () => {
 
 			expect(isLoading.value).toBe(false);
 			expect(activeProviders.value).toEqual([]);
+		});
+	});
+
+	describe('fetchConnection', () => {
+		const mockConnections: SecretProviderConnection[] = [
+			{
+				id: '1',
+				name: 'aws-prod',
+				type: 'awsSecretsManager',
+				state: 'connected',
+				isEnabled: true,
+				projects: [],
+				settings: {},
+				secretsCount: 5,
+				secrets: [],
+				createdAt: '2024-01-20T10:00:00Z',
+				updatedAt: '2024-01-20T10:00:00Z',
+			},
+			{
+				id: '2',
+				name: 'gcp-staging',
+				type: 'gcpSecretsManager',
+				state: 'connected',
+				isEnabled: true,
+				projects: [],
+				settings: {},
+				secretsCount: 3,
+				secrets: [],
+				createdAt: '2024-01-22T10:00:00Z',
+				updatedAt: '2024-01-22T10:00:00Z',
+			},
+		];
+
+		it('should update existing connection in activeConnections', async () => {
+			vi.spyOn(rbacStore, 'hasScope').mockReturnValue(true);
+			vi.mocked(secretsProviderApi.getSecretProviderConnections).mockResolvedValue(mockConnections);
+
+			const updatedConnection: SecretProviderConnection = {
+				...mockConnections[0],
+				secretsCount: 10,
+				state: 'connected',
+			};
+			vi.mocked(secretsProviderApi.getSecretProviderConnectionByKey).mockResolvedValue(
+				updatedConnection,
+			);
+
+			const { fetchActiveConnections, fetchConnection, activeProviders } =
+				useSecretsProvidersList();
+
+			await fetchActiveConnections();
+			expect(activeProviders.value.find((p) => p.name === 'aws-prod')?.secretsCount).toBe(5);
+
+			await fetchConnection('aws-prod');
+			expect(secretsProviderApi.getSecretProviderConnectionByKey).toHaveBeenCalledTimes(1);
+			expect(activeProviders.value.find((p) => p.name === 'aws-prod')?.secretsCount).toBe(10);
+		});
+
+		it('should not modify activeConnections when provider key is not found', async () => {
+			vi.spyOn(rbacStore, 'hasScope').mockReturnValue(true);
+			vi.mocked(secretsProviderApi.getSecretProviderConnections).mockResolvedValue(mockConnections);
+
+			const newConnection: SecretProviderConnection = {
+				id: '3',
+				name: 'unknown-provider',
+				type: 'vault',
+				state: 'connected',
+				isEnabled: true,
+				projects: [],
+				settings: {},
+				secretsCount: 1,
+				secrets: [],
+				createdAt: '2024-01-25T10:00:00Z',
+				updatedAt: '2024-01-25T10:00:00Z',
+			};
+			vi.mocked(secretsProviderApi.getSecretProviderConnectionByKey).mockResolvedValue(
+				newConnection,
+			);
+
+			const { fetchActiveConnections, fetchConnection, activeProviders } =
+				useSecretsProvidersList();
+
+			await fetchActiveConnections();
+			expect(activeProviders.value).toHaveLength(2);
+
+			await fetchConnection('unknown-provider');
+			expect(activeProviders.value).toHaveLength(2);
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useSecretsProvidersList.ee.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useSecretsProvidersList.ee.test.ts
@@ -248,10 +248,10 @@ describe('useSecretsProvidersList', () => {
 				useSecretsProvidersList();
 
 			await fetchActiveConnections();
-			expect(activeProviders.value).toHaveLength(2);
+			const providersBefore = activeProviders.value.map((p) => ({ ...p }));
 
 			await fetchConnection('unknown-provider');
-			expect(activeProviders.value).toHaveLength(2);
+			expect(activeProviders.value).toEqual(providersBefore);
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useSecretsProvidersList.ee.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useSecretsProvidersList.ee.ts
@@ -49,6 +49,18 @@ export function useSecretsProvidersList() {
 		}
 	}
 
+	async function fetchConnection(providerKey: string) {
+		const connection = await secretsProviderApi.getSecretProviderConnectionByKey(
+			rootStore.restApiContext,
+			providerKey,
+		);
+
+		const index = activeConnections.value.findIndex((c) => c.name === providerKey);
+		if (index !== -1) {
+			activeConnections.value[index] = connection;
+		}
+	}
+
 	const isLoading = computed(
 		() => isLoadingProviderTypes.value || isLoadingActiveConnections.value,
 	);
@@ -66,6 +78,7 @@ export function useSecretsProvidersList() {
 		fetchProviderTypes,
 		activeProviders,
 		fetchActiveConnections,
+		fetchConnection,
 		canCreate,
 		canUpdate,
 		isLoading,

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/views/SettingsSecretsProviders.ee.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/views/SettingsSecretsProviders.ee.vue
@@ -93,7 +93,7 @@ async function handleReload(providerKey: string) {
 			}),
 			type: 'success',
 		});
-		await secretsProviders.fetchActiveConnections();
+		await secretsProviders.fetchConnection(providerKey);
 	} catch (error) {
 		toast.showError(error, i18n.baseText('error'));
 	}

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/views/SettingsSecretsProviders.ee.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/views/SettingsSecretsProviders.ee.vue
@@ -25,10 +25,13 @@ import {
 } from '@/app/constants/modals';
 import { I18nT } from 'vue-i18n';
 import type { SecretProviderConnection } from '@n8n/api-types';
+import { reloadSecretProviderConnection } from '@n8n/rest-api-client';
+import { useRootStore } from '@n8n/stores/useRootStore';
 
 const i18n = useI18n();
 const secretsProviders = useSecretsProvidersList();
 const projectsStore = useProjectsStore();
+const rootStore = useRootStore();
 const toast = useToast();
 const documentTitle = useDocumentTitle();
 const pageRedirectionHelper = usePageRedirectionHelper();
@@ -78,6 +81,22 @@ function handleEdit(providerKey: string) {
 
 function handleShare(providerKey: string) {
 	openConnectionModal(providerKey, 'sharing');
+}
+
+async function handleReload(providerKey: string) {
+	try {
+		await reloadSecretProviderConnection(rootStore.restApiContext, providerKey);
+		toast.showMessage({
+			title: i18n.baseText('settings.externalSecrets.card.reload.success.title'),
+			message: i18n.baseText('settings.externalSecrets.card.reload.success.description', {
+				interpolate: { provider: providerKey },
+			}),
+			type: 'success',
+		});
+		await secretsProviders.fetchActiveConnections();
+	} catch (error) {
+		toast.showError(error, i18n.baseText('error'));
+	}
 }
 
 function handleDelete(providerKey: string) {
@@ -183,6 +202,7 @@ function goToUpgrade() {
 					@click="handleCardClick(provider.name)"
 					@edit="handleEdit"
 					@share="handleShare"
+					@reload="handleReload"
 					@delete="handleDelete"
 				/>
 			</div>

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/views/SettingsSecretsProviders.ee.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/views/SettingsSecretsProviders.ee.vue
@@ -85,7 +85,11 @@ function handleShare(providerKey: string) {
 
 async function handleReload(providerKey: string) {
 	try {
-		await reloadSecretProviderConnection(rootStore.restApiContext, providerKey);
+		const result = await reloadSecretProviderConnection(rootStore.restApiContext, providerKey);
+		if (!result.success) {
+			toast.showError(new Error('Reload failed'), i18n.baseText('error'));
+			return;
+		}
 		toast.showMessage({
 			title: i18n.baseText('settings.externalSecrets.card.reload.success.title'),
 			message: i18n.baseText('settings.externalSecrets.card.reload.success.description', {

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/views/SettingsSecretsProviders.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/views/SettingsSecretsProviders.test.ts
@@ -1,5 +1,6 @@
 import { createTestingPinia } from '@pinia/testing';
 import merge from 'lodash/merge';
+import userEvent from '@testing-library/user-event';
 import { EnterpriseEditionFeature } from '@/app/constants';
 import { STORES } from '@n8n/stores';
 import { SETTINGS_STORE_DEFAULT_STATE } from '@/__tests__/utils';
@@ -9,9 +10,19 @@ import { useSettingsStore } from '@/app/stores/settings.store';
 import { setupServer } from '@/__tests__/server';
 import { computed, ref } from 'vue';
 import type { SecretProviderConnection } from '@n8n/api-types';
+import * as restApiClient from '@n8n/rest-api-client';
+
+vi.mock('@n8n/rest-api-client', async (importOriginal) => {
+	const original = await importOriginal<typeof restApiClient>();
+	return {
+		...original,
+		reloadSecretProviderConnection: vi.fn(),
+	};
+});
 
 const mockFetchProviders = vi.fn();
 const mockFetchActiveConnections = vi.fn();
+const mockFetchConnection = vi.fn();
 const mockIsEnterpriseEnabled = ref(false);
 const mockProviders = ref([]);
 const mockActiveProviders = ref([] as SecretProviderConnection[]);
@@ -23,6 +34,7 @@ vi.mock('../composables/useSecretsProvidersList.ee', () => ({
 		activeProviders: computed(() => mockActiveProviders.value),
 		fetchProviderTypes: mockFetchProviders,
 		fetchActiveConnections: mockFetchActiveConnections,
+		fetchConnection: mockFetchConnection,
 		canCreate: computed(() => true),
 		canUpdate: computed(() => true),
 		isLoading: computed(() => mockIsLoading.value),
@@ -45,6 +57,7 @@ describe('SettingsSecretsProviders', () => {
 	beforeEach(async () => {
 		mockFetchProviders.mockResolvedValue(undefined);
 		mockFetchActiveConnections.mockResolvedValue(undefined);
+		mockFetchConnection.mockResolvedValue(undefined);
 		mockIsEnterpriseEnabled.value = false;
 		mockProviders.value = [];
 		mockActiveProviders.value = [];
@@ -224,5 +237,72 @@ describe('SettingsSecretsProviders', () => {
 		expect(licensedContent).toBeInTheDocument();
 		// Should show empty state within the licensed content
 		expect(getByTestId('secrets-provider-connections-empty-state')).toBeInTheDocument();
+	});
+
+	describe('handleReload', () => {
+		const activeProviders: SecretProviderConnection[] = [
+			{
+				id: '1',
+				name: 'aws-prod',
+				type: 'awsSecretsManager',
+				state: 'connected',
+				isEnabled: true,
+				projects: [],
+				settings: {},
+				secretsCount: 5,
+				secrets: [],
+				createdAt: '2024-01-20T10:00:00Z',
+				updatedAt: '2024-01-20T10:00:00Z',
+			},
+		];
+
+		it('should call reloadSecretProviderConnection and fetchConnection on success', async () => {
+			settingsStore.settings.enterprise[EnterpriseEditionFeature.ExternalSecrets] = true;
+			mockIsEnterpriseEnabled.value = true;
+			mockIsLoading.value = false;
+			mockActiveProviders.value = activeProviders;
+
+			vi.mocked(restApiClient.reloadSecretProviderConnection).mockResolvedValue({
+				success: true,
+			});
+
+			const { getByTestId } = renderComponent({ pinia });
+
+			// Click the action toggle to open the dropdown, then click reload
+			await userEvent.click(getByTestId('action-reload'));
+
+			await vi.waitFor(() => {
+				expect(restApiClient.reloadSecretProviderConnection).toHaveBeenCalledWith(
+					expect.anything(),
+					'aws-prod',
+				);
+			});
+
+			expect(mockFetchConnection).toHaveBeenCalledWith('aws-prod');
+		});
+
+		it('should show error toast when reload fails', async () => {
+			settingsStore.settings.enterprise[EnterpriseEditionFeature.ExternalSecrets] = true;
+			mockIsEnterpriseEnabled.value = true;
+			mockIsLoading.value = false;
+			mockActiveProviders.value = activeProviders;
+
+			vi.mocked(restApiClient.reloadSecretProviderConnection).mockRejectedValue(
+				new Error('Reload failed'),
+			);
+
+			const { getByTestId } = renderComponent({ pinia });
+
+			await userEvent.click(getByTestId('action-reload'));
+
+			await vi.waitFor(() => {
+				expect(restApiClient.reloadSecretProviderConnection).toHaveBeenCalledWith(
+					expect.anything(),
+					'aws-prod',
+				);
+			});
+
+			expect(mockFetchConnection).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/views/SettingsSecretsProviders.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/views/SettingsSecretsProviders.test.ts
@@ -281,6 +281,30 @@ describe('SettingsSecretsProviders', () => {
 			expect(mockFetchConnection).toHaveBeenCalledWith('aws-prod');
 		});
 
+		it('should show error toast when reload returns success false', async () => {
+			settingsStore.settings.enterprise[EnterpriseEditionFeature.ExternalSecrets] = true;
+			mockIsEnterpriseEnabled.value = true;
+			mockIsLoading.value = false;
+			mockActiveProviders.value = activeProviders;
+
+			vi.mocked(restApiClient.reloadSecretProviderConnection).mockResolvedValue({
+				success: false,
+			});
+
+			const { getByTestId } = renderComponent({ pinia });
+
+			await userEvent.click(getByTestId('action-reload'));
+
+			await vi.waitFor(() => {
+				expect(restApiClient.reloadSecretProviderConnection).toHaveBeenCalledWith(
+					expect.anything(),
+					'aws-prod',
+				);
+			});
+
+			expect(mockFetchConnection).not.toHaveBeenCalled();
+		});
+
 		it('should show error toast when reload fails', async () => {
 			settingsStore.settings.enterprise[EnterpriseEditionFeature.ExternalSecrets] = true;
 			mockIsEnterpriseEnabled.value = true;


### PR DESCRIPTION
## Summary

Add a reload action to secret provider connections in the Secrets Providers settings page.

<img width="867" height="593" alt="image" src="https://github.com/user-attachments/assets/9bb53cb0-78f9-4203-866d-04cb6dac3e07" />

### Testing

1. Make sure `N8N_ENV_FEAT_EXTERNAL_SECRETS_MULTIPLE_CONNECTIONS` is enabled
2. Create connection with valid details
3. In your secret provider (e.g. Hashicorp) add or remove secrets
4. Use the reload button of your connection -> You should see the secrets count being updated
     

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-228

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [ ] Docs updated or follow-up ticket created
- [x] Tests included
- [ ] PR Labeled with \`release/backport\` (if the PR is an urgent fix that needs to be backported)