### PR TITLE
fix: Only use displayOptions for determining credential required fields for update if the property is defined

### DIFF
--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -950,7 +950,7 @@ export class CredentialsService {
 		const credentialProperties = this.credentialsHelper.getCredentialsProperties(type);
 		for (const property of credentialProperties) {
 			/*
-			 * displyaOpyions is possibly undefined, which causes displayParameter to default `true`, which is expected behaviur for UI
+			 * displayOpyions is possibly undefined, which causes displayParameter to default `true`, which is expected behavior for UI
 			 * however, missing `displayOptions` should not default to true for validation purposes as credentials can be overridden
 			 * without displayOptions being explicitly set on every credential definition
 			 */

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -949,7 +949,16 @@ export class CredentialsService {
 		// check mandatory fields are present
 		const credentialProperties = this.credentialsHelper.getCredentialsProperties(type);
 		for (const property of credentialProperties) {
-			if (property.required && displayParameter(data, property, null, null)) {
+			/*
+			 * displyaOpyions is possibly undefined, which causes displayParameter to default `true`, which is expected behaviur for UI
+			 * however, missing `displayOptions` should not default to true for validation purposes as credentials can be overridden
+			 * without displayOptions being explicitly set on every credential definition
+			 */
+			if (
+				property.required &&
+				property.displayOptions !== undefined &&
+				displayParameter(data, property, null, null)
+			) {
 				// Check if value is present in data, if not, check if default value exists
 				const value = data[property.name];
 				const hasDefault =


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR addresses the fact that `displayOptions` is not always defined on a credential definition, which in turn, means any field that doesn't have that field, cannot be set up for credential overrides that essentially no longer require that field.

## Related Linear tickets, Github issues, and Community forum posts

IAM-271

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
