### PR TITLE
fix(editor): Style regressions on Button

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.vue
@@ -209,7 +209,7 @@ const handleClick = (event: MouseEvent) => {
 		--button--height: 2.25rem;
 		--button--padding: 0 var(--spacing--sm);
 		--button--radius: var(--radius--xs);
-		--button--font-size: var(--font-size--md);
+		--button--font-size: var(--font-size--sm);
 	}
 
 	&.xlarge {

--- a/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.vue
@@ -339,6 +339,10 @@ const handleClick = (event: MouseEvent) => {
 	&.iconOnly {
 		width: var(--button--height);
 		padding: 0;
+
+		> * {
+			width: var(--button--height);
+		}
 	}
 }
 

--- a/packages/frontend/editor-ui/src/app/components/DuplicateWorkflowDialog.vue
+++ b/packages/frontend/editor-ui/src/app/components/DuplicateWorkflowDialog.vue
@@ -192,17 +192,15 @@ onMounted(async () => {
 		<template #footer="{ close }">
 			<div :class="$style.footer">
 				<N8nButton
-					:loading="isSaving"
-					:label="i18n.baseText('duplicateWorkflowDialog.save')"
-					float="right"
-					@click="save"
-				/>
-				<N8nButton
 					variant="subtle"
 					:disabled="isSaving"
 					:label="i18n.baseText('duplicateWorkflowDialog.cancel')"
-					float="right"
 					@click="close"
+				/>
+				<N8nButton
+					:loading="isSaving"
+					:label="i18n.baseText('duplicateWorkflowDialog.save')"
+					@click="save"
 				/>
 			</div>
 		</template>
@@ -217,6 +215,8 @@ onMounted(async () => {
 }
 
 .footer {
+	display: flex;
+	justify-content: flex-end;
 	> * {
 		margin-left: var(--spacing--3xs);
 	}

--- a/packages/frontend/editor-ui/src/app/components/ImportWorkflowUrlModal.vue
+++ b/packages/frontend/editor-ui/src/app/components/ImportWorkflowUrlModal.vue
@@ -90,9 +90,9 @@ const focusInput = async () => {
 	visibility: hidden;
 }
 .footer {
-	> * {
-		margin-left: var(--spacing--3xs);
-	}
+	display: flex;
+	justify-content: flex-end;
+	gap: var(--spacing--2xs);
 }
 .noScrollbar {
 	overflow: hidden;

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -2022,7 +2022,7 @@ onBeforeUnmount(() => {
 				<template v-if="containsChatTriggerNodes">
 					<CanvasChatButton
 						v-if="isLogsPanelOpen"
-						variant="ghost"
+						variant="subtle"
 						:label="i18n.baseText('chat.hide')"
 						:class="$style.chatButton"
 						@click="logsStore.toggleOpen(false)"
@@ -2033,7 +2033,7 @@ onBeforeUnmount(() => {
 						:shortcut="{ keys: ['c'] }"
 					>
 						<CanvasChatButton
-							:variant="isRunWorkflowButtonVisible ? 'outline' : 'solid'"
+							:variant="isRunWorkflowButtonVisible ? 'subtle' : 'solid'"
 							:label="i18n.baseText('chat.open')"
 							:class="$style.chatButton"
 							@click="onOpenChat"

--- a/packages/frontend/editor-ui/src/features/core/auth/views/MfaView.vue
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/MfaView.vue
@@ -239,7 +239,7 @@ onMounted(() => {
 					</N8nText>
 				</div>
 			</div>
-			<div>
+			<div :class="$style.footer">
 				<N8nButton
 					float="right"
 					:loading="verifyingMfaCode"
@@ -282,6 +282,12 @@ body {
 
 .formContainer {
 	padding-bottom: var(--spacing--xl);
+}
+
+.footer {
+	display: flex;
+	justify-content: space-between;
+	gap: var(--spacing--2xs);
 }
 
 .headerContainer {

--- a/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsUpgradeModal.vue
+++ b/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsUpgradeModal.vue
@@ -40,7 +40,7 @@ const perks = computed(() =>
 			</ul>
 		</div>
 		<template #footer>
-			<div>
+			<div class="insight-modal-button-container">
 				<N8nButton variant="subtle" @click="model = false">
 					{{ i18n.baseText('insights.upgradeModal.button.dismiss') }}
 				</N8nButton>
@@ -66,5 +66,10 @@ const perks = computed(() =>
 		align-items: center;
 		gap: var(--spacing--2xs);
 	}
+}
+.insight-modal-button-container {
+	display: flex;
+	justify-content: flex-end;
+	gap: var(--spacing--2xs);
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/components/CommunityPackageManageConfirmModal.vue
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/components/CommunityPackageManageConfirmModal.vue
@@ -268,22 +268,22 @@ onMounted(async () => {
 			/>
 		</template>
 		<template #footer>
-			<N8nButton
-				variant="subtle"
-				:label="i18n.baseText('settings.communityNodes.confirmModal.cancel')"
-				size="large"
-				float="left"
-				data-test-id="close-button"
-				@click="onClick"
-			/>
-			<N8nButton
-				:loading="loading"
-				:disabled="loading"
-				:label="loading ? getModalContent.buttonLoadingLabel : getModalContent.buttonLabel"
-				size="large"
-				float="right"
-				@click="onConfirmButtonClick"
-			/>
+			<div :class="$style.footerContainer">
+				<N8nButton
+					variant="subtle"
+					:label="i18n.baseText('settings.communityNodes.confirmModal.cancel')"
+					size="large"
+					data-test-id="close-button"
+					@click="onClick"
+				/>
+				<N8nButton
+					:loading="loading"
+					:disabled="loading"
+					:label="loading ? getModalContent.buttonLoadingLabel : getModalContent.buttonLabel"
+					size="large"
+					@click="onConfirmButtonClick"
+				/>
+			</div>
 		</template>
 	</Modal>
 </template>
@@ -293,6 +293,12 @@ onMounted(async () => {
 	display: flex;
 	margin: var(--spacing--sm) 0;
 	flex-direction: column;
+}
+
+.footerContainer {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
 }
 
 .descriptionIcon {

--- a/packages/frontend/editor-ui/src/features/settings/sso/components/SSOLogin.vue
+++ b/packages/frontend/editor-ui/src/features/settings/sso/components/SSOLogin.vue
@@ -40,10 +40,15 @@ const onSSOLogin = async () => {
 
 <style lang="scss" module>
 .ssoLogin {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
 	text-align: center;
 }
 
 .divider {
+	width: 100%;
 	position: relative;
 	text-transform: uppercase;
 

--- a/packages/frontend/editor-ui/src/features/settings/usage/components/CommunityPlusEnrollmentModal.vue
+++ b/packages/frontend/editor-ui/src/features/settings/usage/components/CommunityPlusEnrollmentModal.vue
@@ -193,8 +193,4 @@ const confirm = async () => {
 	justify-content: space-between;
 	align-items: center;
 }
-
-.skip {
-	padding: 0;
-}
 </style>

--- a/packages/frontend/editor-ui/src/features/settings/usage/views/SettingsUsageAndPlan.vue
+++ b/packages/frontend/editor-ui/src/features/settings/usage/views/SettingsUsageAndPlan.vue
@@ -332,12 +332,14 @@ const openCommunityRegisterModal = () => {
 					/>
 				</template>
 				<template #footer>
-					<N8nButton variant="subtle" @click="onActivationCancel">
-						{{ locale.baseText('settings.usageAndPlan.dialog.activation.cancel') }}
-					</N8nButton>
-					<N8nButton :disabled="!activationKey" @click="() => onLicenseActivation()">
-						{{ locale.baseText('settings.usageAndPlan.dialog.activation.activate') }}
-					</N8nButton>
+					<div :class="$style.dialogButtonsContainer">
+						<N8nButton variant="subtle" @click="onActivationCancel">
+							{{ locale.baseText('settings.usageAndPlan.dialog.activation.cancel') }}
+						</N8nButton>
+						<N8nButton :disabled="!activationKey" @click="() => onLicenseActivation()">
+							{{ locale.baseText('settings.usageAndPlan.dialog.activation.activate') }}
+						</N8nButton>
+					</div>
 				</template>
 			</ElDialog>
 
@@ -445,6 +447,11 @@ div[class*='info'] > span > span:last-child {
 	display: flex;
 	align-items: center;
 	margin: 0 0 0 var(--spacing--2xs);
+}
+
+.dialogButtonsContainer {
+	display: flex;
+	justify-content: flex-end;
 }
 </style>
 

--- a/packages/frontend/editor-ui/src/features/shared/tags/components/TagsManager/NoTagsView.vue
+++ b/packages/frontend/editor-ui/src/features/shared/tags/components/TagsManager/NoTagsView.vue
@@ -23,7 +23,7 @@ const i18n = useI18n();
 	<div :class="$style.container">
 		<ElCol class="notags" :span="16">
 			<div class="icon">🗄️</div>
-			<div>
+			<div :class="$style.content">
 				<div class="mb-s">
 					<N8nHeading size="large">
 						{{ i18n.baseText(titleLocaleKey) }}
@@ -32,12 +32,12 @@ const i18n = useI18n();
 				<div class="description">
 					{{ i18n.baseText(descriptionLocaleKey) }}
 				</div>
+				<N8nButton
+					:label="i18n.baseText(`${createLocaleKey}`)"
+					size="large"
+					@click="$emit('enableCreate')"
+				/>
 			</div>
-			<N8nButton
-				:label="i18n.baseText(`${createLocaleKey}`)"
-				size="large"
-				@click="$emit('enableCreate')"
-			/>
 		</ElCol>
 	</div>
 </template>
@@ -50,6 +50,16 @@ $--footer-spacing: 45px;
 	justify-content: center;
 	align-items: center;
 	margin-top: $--footer-spacing;
+}
+
+.content {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+
+	> button {
+		margin-top: var(--spacing--md);
+	}
 }
 </style>
 

--- a/packages/frontend/editor-ui/src/features/shared/tags/components/TagsManager/TagsManager.vue
+++ b/packages/frontend/editor-ui/src/features/shared/tags/components/TagsManager/TagsManager.vue
@@ -181,7 +181,12 @@ function onEnter() {
 			</ElRow>
 		</template>
 		<template #footer="{ close }">
-			<N8nButton :label="i18n.baseText('tagsManager.done')" float="right" @click="close" />
+			<N8nButton
+				variant="subtle"
+				:label="i18n.baseText('tagsManager.done')"
+				style="margin-left: auto"
+				@click="close"
+			/>
 		</template>
 	</Modal>
 </template>

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/CanvasRunWorkflowButton.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/CanvasRunWorkflowButton.vue
@@ -90,6 +90,7 @@ function getNodeTypeByName(name: string): INodeTypeDescription | null {
 				variant="solid"
 				:class="$style.button"
 				:loading="executing"
+				:iconOnly="executing"
 				:disabled="disabled"
 				:size="size ?? 'large'"
 				icon="flask-conical"

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/__snapshots__/CanvasRunWorkflowButton.test.ts.snap
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/__snapshots__/CanvasRunWorkflowButton.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`CanvasRunWorkflowButton > should render correctly 1`] = `
-"<div class="component"><span class="" data-state="closed" data-grace-area-trigger=""><n8n-button-stub variant="solid" class="button" loading="false" disabled="false" size="large" icon="flask-conical" data-test-id="execute-workflow-button"><span class="buttonContent">Execute workflow <!--v-if--></span></n8n-button-stub></span>
+"<div class="component"><span class="" data-state="closed" data-grace-area-trigger=""><n8n-button-stub variant="solid" class="button" loading="false" icononly="false" disabled="false" size="large" icon="flask-conical" data-test-id="execute-workflow-button"><span class="buttonContent">Execute workflow <!--v-if--></span></n8n-button-stub></span>
   <!--v-if-->
   <!--v-if-->
 </div>"


### PR DESCRIPTION
## Summary
Fixes style issues found in beta release flagged on #25898 that weren't fixed on https://github.com/n8n-io/n8n/pull/25846

| Before | After |
|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/a2aea4c4-ec74-4cbc-8779-067d67c77483" width="960px" alt="image" /> | <img src="https://github.com/user-attachments/assets/9dfd0731-ce0e-4e7b-b181-3c1e3549f5f7" width="960px" alt="CleanShot 2026-02-18 at 10 13 26@2x" /> 
| <img width="892" height="604" alt="image" src="https://github.com/user-attachments/assets/b6ec74c7-5394-492b-8e95-eb745227818e" /> | <img width="880" height="530" alt="CleanShot 2026-02-18 at 10 12 26@2x" src="https://github.com/user-attachments/assets/e6840504-d073-42bf-bbda-ebec1a4b710d" />
| <img width="456" height="133" alt="image" src="https://github.com/user-attachments/assets/a855fb30-33e3-40d6-ad2a-c8e51f5b23af" /> | <img width="270" height="154" alt="CleanShot 2026-02-18 at 10 12 01@2x" src="https://github.com/user-attachments/assets/0e7177f7-8450-4a54-af0a-73645835536e" />
| <img width="593" height="387" alt="image" src="https://github.com/user-attachments/assets/3d54ed5f-bf75-4963-8955-2efdc442c79e" /> | <img width="1040" height="644" alt="CleanShot 2026-02-18 at 10 11 06@2x" src="https://github.com/user-attachments/assets/08dec5dc-d93d-47c6-8c0a-026d9d1f4fb3" />
| <img width="574" height="274" alt="image" src="https://github.com/user-attachments/assets/cccd8263-1633-45c2-92bd-7c54d22a3fc3" /> | <img width="998" height="436" alt="CleanShot 2026-02-18 at 10 10 01@2x" src="https://github.com/user-attachments/assets/a103b3b6-9d22-4b1b-bd84-646723b24c03" />

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/IAM-297/community-issue-n8nbutton-refactor-regression
https://linear.app/n8n/issue/DS-464/buttons-layout-in-duplicate-workflow-modal

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
