### PR TITLE
feat(core): Filter secrets provider autocomplete to connected vaults only

### DIFF
--- a/packages/@n8n/db/src/repositories/__tests__/secrets-provider-connection.repository.ee.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/secrets-provider-connection.repository.ee.test.ts
@@ -3,6 +3,8 @@ import { Container } from '@n8n/di';
 import { SecretsProviderConnection } from '../../entities';
 import { mockEntityManager } from '../../utils/test-utils/mock-entity-manager';
 import { SecretsProviderConnectionRepository } from '../secrets-provider-connection.repository.ee';
+import { mock } from 'jest-mock-extended';
+import { random } from 'lodash';
 
 describe('SecretsProviderConnectionRepository', () => {
 	const entityManager = mockEntityManager(SecretsProviderConnection);
@@ -13,27 +15,22 @@ describe('SecretsProviderConnectionRepository', () => {
 	});
 
 	describe('findAll', () => {
+		const createMockConnection = (
+			overrides: Partial<SecretsProviderConnection> = {},
+		): SecretsProviderConnection => {
+			return mock<SecretsProviderConnection>({
+				id: random(1, Number.MAX_SAFE_INTEGER),
+				providerKey: 'myVault',
+				type: 'vault',
+				encryptedSettings: '',
+				isEnabled: false,
+				projectAccess: [],
+				...overrides,
+			});
+		};
+
 		it('should return all secrets provider connections', async () => {
-			const mockConnections = [
-				{
-					providerKey: 'awsSecretsManager',
-					type: 'awsSecretsManager',
-					encryptedSettings: '{}',
-					isEnabled: true,
-					projectAccess: [],
-					createdAt: new Date(),
-					updatedAt: new Date(),
-				},
-				{
-					providerKey: 'vault',
-					type: 'vault',
-					encryptedSettings: '{}',
-					isEnabled: false,
-					projectAccess: [],
-					createdAt: new Date(),
-					updatedAt: new Date(),
-				},
-			];
+			const mockConnections = [createMockConnection(), createMockConnection()];
 
 			entityManager.find.mockResolvedValueOnce(mockConnections);
 

--- a/packages/@n8n/db/src/repositories/__tests__/secrets-provider-connection.repository.ee.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/secrets-provider-connection.repository.ee.test.ts
@@ -1,10 +1,10 @@
 import { Container } from '@n8n/di';
+import { mock } from 'jest-mock-extended';
+import random from 'lodash/random';
 
 import { SecretsProviderConnection } from '../../entities';
 import { mockEntityManager } from '../../utils/test-utils/mock-entity-manager';
 import { SecretsProviderConnectionRepository } from '../secrets-provider-connection.repository.ee';
-import { mock } from 'jest-mock-extended';
-import { random } from 'lodash';
 
 describe('SecretsProviderConnectionRepository', () => {
 	const entityManager = mockEntityManager(SecretsProviderConnection);

--- a/packages/@n8n/db/src/repositories/secrets-provider-connection.repository.ee.ts
+++ b/packages/@n8n/db/src/repositories/secrets-provider-connection.repository.ee.ts
@@ -28,19 +28,23 @@ export class SecretsProviderConnectionRepository extends Repository<SecretsProvi
 	 * Retrieves global connections, i.e., connections that are not assigned to any project.
 	 * A global connection has no associated entries in its projectAccess relation.
 	 *
-	 * @param typeFilter - (Optional) Limits results to connections of the specified provider type.
+	 * @param filters - (Optional) Filters to apply to the query.
+	 * @param filters.providerKeys - (Optional) Limits results to connections of the specified provider keys.
 	 * @returns Promise resolving to all matching SecretsProviderConnection entities.
 	 */
-	async findGlobalConnections({
-		providerKeys,
-	}: { providerKeys?: Array<SecretsProviderConnection['providerKey']> } = {}): Promise<
-		SecretsProviderConnection[]
-	> {
+	async findGlobalConnections(
+		filters: { providerKeys?: Array<SecretsProviderConnection['providerKey']> } = {},
+	): Promise<SecretsProviderConnection[]> {
+		const { providerKeys } = filters;
+		if (providerKeys && providerKeys.length === 0) {
+			return [];
+		}
+
 		const connectionQuery = this.createQueryBuilder('connection')
 			.leftJoin('connection.projectAccess', 'access')
 			.where('access.secretsProviderConnectionId IS NULL');
 
-		if (providerKeys && providerKeys.length > 0) {
+		if (providerKeys) {
 			connectionQuery.andWhere('connection.providerKey IN (:...providerKeys)', { providerKeys });
 		}
 
@@ -55,19 +59,25 @@ export class SecretsProviderConnectionRepository extends Repository<SecretsProvi
 	 * not global connections (i.e., those without any project restriction).
 	 *
 	 * @param projectId - The ID of the project to filter on.
-	 * @param type - (Optional) The provider type to filter connections by.
+	 * @param filters - (Optional) Filters to apply to the query.
+	 * @param filters.providerKeys - (Optional) Limits results to connections of the specified provider keys.
 	 * @returns Promise resolving to all matching SecretsProviderConnection entities.
 	 */
 	async findByProjectId(
 		projectId: string,
-		{ providerKeys }: { providerKeys?: Array<SecretsProviderConnection['providerKey']> } = {},
+		filters: { providerKeys?: Array<SecretsProviderConnection['providerKey']> } = {},
 	): Promise<SecretsProviderConnection[]> {
+		const { providerKeys } = filters;
+		if (providerKeys && providerKeys.length === 0) {
+			return [];
+		}
+
 		const connectionQuery = this.createQueryBuilder('connection')
 			.innerJoinAndSelect('connection.projectAccess', 'projectAccess')
 			.leftJoinAndSelect('projectAccess.project', 'project')
 			.where('projectAccess.projectId = :projectId', { projectId });
 
-		if (providerKeys && providerKeys.length > 0) {
+		if (providerKeys) {
 			connectionQuery.andWhere('connection.providerKey IN (:...providerKeys)', { providerKeys });
 		}
 

--- a/packages/@n8n/db/src/repositories/secrets-provider-connection.repository.ee.ts
+++ b/packages/@n8n/db/src/repositories/secrets-provider-connection.repository.ee.ts
@@ -32,16 +32,16 @@ export class SecretsProviderConnectionRepository extends Repository<SecretsProvi
 	 * @returns Promise resolving to all matching SecretsProviderConnection entities.
 	 */
 	async findGlobalConnections({
-		types,
-	}: { types?: Array<SecretsProviderConnection['type']> } = {}): Promise<
+		providerKeys,
+	}: { providerKeys?: Array<SecretsProviderConnection['providerKey']> } = {}): Promise<
 		SecretsProviderConnection[]
 	> {
 		const connectionQuery = this.createQueryBuilder('connection')
 			.leftJoin('connection.projectAccess', 'access')
 			.where('access.secretsProviderConnectionId IS NULL');
 
-		if (types && types.length > 0) {
-			connectionQuery.andWhere('connection.type IN (:...types)', { types });
+		if (providerKeys && providerKeys.length > 0) {
+			connectionQuery.andWhere('connection.providerKey IN (:...providerKeys)', { providerKeys });
 		}
 
 		return await connectionQuery.getMany();
@@ -60,15 +60,15 @@ export class SecretsProviderConnectionRepository extends Repository<SecretsProvi
 	 */
 	async findByProjectId(
 		projectId: string,
-		{ types }: { types?: Array<SecretsProviderConnection['type']> } = {},
+		{ providerKeys }: { providerKeys?: Array<SecretsProviderConnection['providerKey']> } = {},
 	): Promise<SecretsProviderConnection[]> {
 		const connectionQuery = this.createQueryBuilder('connection')
 			.innerJoinAndSelect('connection.projectAccess', 'projectAccess')
 			.leftJoinAndSelect('projectAccess.project', 'project')
 			.where('projectAccess.projectId = :projectId', { projectId });
 
-		if (types && types.length > 0) {
-			connectionQuery.andWhere('connection.type IN (:...types)', { types });
+		if (providerKeys && providerKeys.length > 0) {
+			connectionQuery.andWhere('connection.providerKey IN (:...providerKeys)', { providerKeys });
 		}
 
 		return await connectionQuery.getMany();

--- a/packages/@n8n/db/src/repositories/secrets-provider-connection.repository.ee.ts
+++ b/packages/@n8n/db/src/repositories/secrets-provider-connection.repository.ee.ts
@@ -25,21 +25,51 @@ export class SecretsProviderConnectionRepository extends Repository<SecretsProvi
 	}
 
 	/**
-	 * Find all global connections (connections with no project access entries)
+	 * Retrieves global connections, i.e., connections that are not assigned to any project.
+	 * A global connection has no associated entries in its projectAccess relation.
+	 *
+	 * @param typeFilter - (Optional) Limits results to connections of the specified provider type.
+	 * @returns Promise resolving to all matching SecretsProviderConnection entities.
 	 */
-	async findGlobalConnections(): Promise<SecretsProviderConnection[]> {
-		return await this.createQueryBuilder('connection')
+	async findGlobalConnections({
+		types,
+	}: { types?: SecretsProviderConnection['type'][] } = {}): Promise<SecretsProviderConnection[]> {
+		const connectionQuery = await this.createQueryBuilder('connection')
 			.leftJoin('connection.projectAccess', 'access')
-			.where('access.secretsProviderConnectionId IS NULL')
-			.getMany();
+			.where('access.secretsProviderConnectionId IS NULL');
+
+		if (types && types.length > 0) {
+			connectionQuery.andWhere('connection.type IN (:...types)', { types });
+		}
+
+		return await connectionQuery.getMany();
 	}
 
-	async findByProjectId(projectId: string): Promise<SecretsProviderConnection[]> {
-		return await this.createQueryBuilder('connection')
+	/**
+	 * Finds all secrets provider connections assigned to a given project.
+	 * Optionally filters connections by provider type.
+	 *
+	 * This returns only those connections explicitly linked to the project,
+	 * not global connections (i.e., those without any project restriction).
+	 *
+	 * @param projectId - The ID of the project to filter on.
+	 * @param type - (Optional) The provider type to filter connections by.
+	 * @returns Promise resolving to all matching SecretsProviderConnection entities.
+	 */
+	async findByProjectId(
+		projectId: string,
+		{ types }: { types?: SecretsProviderConnection['type'][] } = {},
+	): Promise<SecretsProviderConnection[]> {
+		const connectionQuery = await this.createQueryBuilder('connection')
 			.innerJoinAndSelect('connection.projectAccess', 'projectAccess')
 			.leftJoinAndSelect('projectAccess.project', 'project')
-			.where('projectAccess.projectId = :projectId', { projectId })
-			.getMany();
+			.where('projectAccess.projectId = :projectId', { projectId });
+
+		if (types && types.length > 0) {
+			connectionQuery.andWhere('connection.type IN (:...types)', { types });
+		}
+
+		return await connectionQuery.getMany();
 	}
 
 	/**

--- a/packages/@n8n/db/src/repositories/secrets-provider-connection.repository.ee.ts
+++ b/packages/@n8n/db/src/repositories/secrets-provider-connection.repository.ee.ts
@@ -33,8 +33,10 @@ export class SecretsProviderConnectionRepository extends Repository<SecretsProvi
 	 */
 	async findGlobalConnections({
 		types,
-	}: { types?: SecretsProviderConnection['type'][] } = {}): Promise<SecretsProviderConnection[]> {
-		const connectionQuery = await this.createQueryBuilder('connection')
+	}: { types?: Array<SecretsProviderConnection['type']> } = {}): Promise<
+		SecretsProviderConnection[]
+	> {
+		const connectionQuery = this.createQueryBuilder('connection')
 			.leftJoin('connection.projectAccess', 'access')
 			.where('access.secretsProviderConnectionId IS NULL');
 
@@ -58,9 +60,9 @@ export class SecretsProviderConnectionRepository extends Repository<SecretsProvi
 	 */
 	async findByProjectId(
 		projectId: string,
-		{ types }: { types?: SecretsProviderConnection['type'][] } = {},
+		{ types }: { types?: Array<SecretsProviderConnection['type']> } = {},
 	): Promise<SecretsProviderConnection[]> {
-		const connectionQuery = await this.createQueryBuilder('connection')
+		const connectionQuery = this.createQueryBuilder('connection')
 			.innerJoinAndSelect('connection.projectAccess', 'projectAccess')
 			.leftJoinAndSelect('projectAccess.project', 'project')
 			.where('projectAccess.projectId = :projectId', { projectId });

--- a/packages/@n8n/db/src/repositories/secrets-provider-connection.repository.ee.ts
+++ b/packages/@n8n/db/src/repositories/secrets-provider-connection.repository.ee.ts
@@ -53,7 +53,7 @@ export class SecretsProviderConnectionRepository extends Repository<SecretsProvi
 
 	/**
 	 * Finds all secrets provider connections assigned to a given project.
-	 * Optionally filters connections by provider type.
+	 * Optionally filters connections by provider keys.
 	 *
 	 * This returns only those connections explicitly linked to the project,
 	 * not global connections (i.e., those without any project restriction).

--- a/packages/cli/src/modules/external-secrets.ee/__tests__/provider-registry.service.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/provider-registry.service.test.ts
@@ -119,12 +119,41 @@ describe('ProviderRegistry', () => {
 
 			const result = registry.getConnected();
 
-			expect(result).toHaveLength(1);
-			expect(result[0]).toBe(dummyProvider);
+			expect(result.size).toBe(1);
+			expect(result.get('dummy')).toBe(dummyProvider);
 		});
 
 		it('should return empty array when no providers are connected', () => {
+			registry.add('dummy', dummyProvider);
+			registry.add('another', anotherProvider);
+
 			const result = registry.getConnected();
+
+			expect(result.size).toBe(0);
+		});
+	});
+
+	describe('getConnectedNames', () => {
+		it('should return all connected provider names', async () => {
+			await dummyProvider.init({ connected: true, connectedAt: new Date(), settings: {} });
+			await dummyProvider.connect();
+
+			await anotherProvider.init({ connected: true, connectedAt: new Date(), settings: {} });
+			anotherProvider.setState('error', new Error('Test error'));
+
+			registry.add('dummy', dummyProvider);
+			registry.add('another', anotherProvider);
+
+			const result = registry.getConnectedNames();
+
+			expect(result).toEqual(['dummy']);
+		});
+
+		it('should return empty array when no providers are connected', () => {
+			registry.add('dummy', dummyProvider);
+			registry.add('another', anotherProvider);
+
+			const result = registry.getConnectedNames();
 
 			expect(result).toEqual([]);
 		});

--- a/packages/cli/src/modules/external-secrets.ee/__tests__/secrets-providers-connections.service.ee.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/secrets-providers-connections.service.ee.test.ts
@@ -14,12 +14,14 @@ import type { ExternalSecretsManager } from '@/modules/external-secrets.ee/exter
 import type { RedactionService } from '@/modules/external-secrets.ee/redaction.service.ee';
 import { SecretsProvidersConnectionsService } from '@/modules/external-secrets.ee/secrets-providers-connections.service.ee';
 import type { SecretsProvider } from '@/modules/external-secrets.ee/types';
+import { ExternalSecretsProviderRegistry } from '../provider-registry.service';
 
 describe('SecretsProvidersConnectionsService', () => {
 	const mockRepository = mock<SecretsProviderConnectionRepository>();
 	const mockProjectAccessRepository = mock<ProjectSecretsProviderAccessRepository>();
 	const mockExternalSecretsManager = mock<ExternalSecretsManager>();
 	const mockRedactionService = mock<RedactionService>();
+	const mockProviderRegistryService = mock<ExternalSecretsProviderRegistry>();
 	const mockEventService = mock<EventService>();
 	const mockCipher = {
 		encrypt: jest.fn((data: IDataObject) => JSON.stringify(data)),
@@ -30,6 +32,7 @@ describe('SecretsProvidersConnectionsService', () => {
 		mockLogger(),
 		mockRepository,
 		mockProjectAccessRepository,
+		mockProviderRegistryService,
 		mockCipher as any,
 		mockExternalSecretsManager,
 		mockRedactionService,

--- a/packages/cli/src/modules/external-secrets.ee/__tests__/secrets-providers-connections.service.ee.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/secrets-providers-connections.service.ee.test.ts
@@ -1,4 +1,3 @@
-import type { IDataObject, INodeProperties } from 'n8n-workflow';
 import { mockLogger } from '@n8n/backend-test-utils';
 import type {
 	ProjectSecretsProviderAccessRepository,
@@ -6,15 +5,16 @@ import type {
 	SecretsProviderConnectionRepository,
 } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
+import type { IDataObject, INodeProperties } from 'n8n-workflow';
 
 import { CREDENTIAL_BLANKING_VALUE } from '@/constants';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import type { EventService } from '@/events/event.service';
 import type { ExternalSecretsManager } from '@/modules/external-secrets.ee/external-secrets-manager.ee';
+import type { ExternalSecretsProviderRegistry } from '@/modules/external-secrets.ee/provider-registry.service';
 import type { RedactionService } from '@/modules/external-secrets.ee/redaction.service.ee';
 import { SecretsProvidersConnectionsService } from '@/modules/external-secrets.ee/secrets-providers-connections.service.ee';
 import type { SecretsProvider } from '@/modules/external-secrets.ee/types';
-import type { ExternalSecretsProviderRegistry } from '@/modules/external-secrets.ee/provider-registry.service';
 
 describe('SecretsProvidersConnectionsService', () => {
 	const mockRepository = mock<SecretsProviderConnectionRepository>();

--- a/packages/cli/src/modules/external-secrets.ee/__tests__/secrets-providers-connections.service.ee.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/secrets-providers-connections.service.ee.test.ts
@@ -14,14 +14,14 @@ import type { ExternalSecretsManager } from '@/modules/external-secrets.ee/exter
 import type { RedactionService } from '@/modules/external-secrets.ee/redaction.service.ee';
 import { SecretsProvidersConnectionsService } from '@/modules/external-secrets.ee/secrets-providers-connections.service.ee';
 import type { SecretsProvider } from '@/modules/external-secrets.ee/types';
-import { ExternalSecretsProviderRegistry } from '../provider-registry.service';
+import type { ExternalSecretsProviderRegistry } from '@/modules/external-secrets.ee/provider-registry.service';
 
 describe('SecretsProvidersConnectionsService', () => {
 	const mockRepository = mock<SecretsProviderConnectionRepository>();
 	const mockProjectAccessRepository = mock<ProjectSecretsProviderAccessRepository>();
 	const mockExternalSecretsManager = mock<ExternalSecretsManager>();
 	const mockRedactionService = mock<RedactionService>();
-	const mockProviderRegistryService = mock<ExternalSecretsProviderRegistry>();
+	const mockProviderRegistry = mock<ExternalSecretsProviderRegistry>();
 	const mockEventService = mock<EventService>();
 	const mockCipher = {
 		encrypt: jest.fn((data: IDataObject) => JSON.stringify(data)),
@@ -32,7 +32,7 @@ describe('SecretsProvidersConnectionsService', () => {
 		mockLogger(),
 		mockRepository,
 		mockProjectAccessRepository,
-		mockProviderRegistryService,
+		mockProviderRegistry,
 		mockCipher as any,
 		mockExternalSecretsManager,
 		mockRedactionService,

--- a/packages/cli/src/modules/external-secrets.ee/provider-registry.service.ts
+++ b/packages/cli/src/modules/external-secrets.ee/provider-registry.service.ts
@@ -30,8 +30,18 @@ export class ExternalSecretsProviderRegistry {
 		return new Map(this.providers);
 	}
 
-	getConnected(): SecretsProvider[] {
-		return Array.from(this.providers.values()).filter((p) => p.state === 'connected');
+	getConnected(): Map<string, SecretsProvider> {
+		const result = new Map<string, SecretsProvider>();
+		for (const [name, provider] of this.providers) {
+			if (provider.state === 'connected') {
+				result.set(name, provider);
+			}
+		}
+		return result;
+	}
+
+	getConnectedNames(): string[] {
+		return Array.from(this.getConnected().keys());
 	}
 
 	getNames(): string[] {

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.service.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.service.ee.ts
@@ -24,6 +24,7 @@ import type { ProjectSummary } from '@/events/maps/relay.event-map';
 import { ExternalSecretsManager } from '@/modules/external-secrets.ee/external-secrets-manager.ee';
 import { RedactionService } from '@/modules/external-secrets.ee/redaction.service.ee';
 import { SecretsProvidersResponses } from '@/modules/external-secrets.ee/secrets-providers.responses.ee';
+import { ExternalSecretsProviderRegistry } from './provider-registry.service';
 
 @Service()
 export class SecretsProvidersConnectionsService {
@@ -31,6 +32,7 @@ export class SecretsProvidersConnectionsService {
 		private readonly logger: Logger,
 		private readonly repository: SecretsProviderConnectionRepository,
 		private readonly projectAccessRepository: ProjectSecretsProviderAccessRepository,
+		private readonly providerRegistry: ExternalSecretsProviderRegistry,
 		private readonly cipher: Cipher,
 		private readonly externalSecretsManager: ExternalSecretsManager,
 		private readonly redactionService: RedactionService,
@@ -179,11 +181,21 @@ export class SecretsProvidersConnectionsService {
 	}
 
 	async getGlobalCompletions(): Promise<SecretsProviderConnection[]> {
-		return await this.repository.findGlobalConnections();
+		const connectedProviders = this.providerRegistry.getConnected();
+		const connectedProviderNames = connectedProviders.map((provider) => provider.name);
+		const connections = await this.repository.findGlobalConnections({
+			types: connectedProviderNames,
+		});
+		return connections;
 	}
 
 	async getProjectCompletions(projectId: string): Promise<SecretsProviderConnection[]> {
-		return await this.repository.findByProjectId(projectId);
+		const connectedProviders = this.providerRegistry.getConnected();
+		const connectedProviderNames = connectedProviders.map((provider) => provider.name);
+		const connections = await this.repository.findByProjectId(projectId, {
+			types: connectedProviderNames,
+		});
+		return connections;
 	}
 
 	async listConnectionsForProject(projectId: string): Promise<SecretsProviderConnection[]> {

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.service.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.service.ee.ts
@@ -182,21 +182,19 @@ export class SecretsProvidersConnectionsService {
 	}
 
 	async getGlobalCompletions(): Promise<SecretsProviderConnection[]> {
-		const connectedProviders = this.providerRegistry.getConnected();
-		const connectedProviderNames = connectedProviders.map((provider) => provider.name);
-		const connections = await this.repository.findGlobalConnections({
-			types: connectedProviderNames,
+		const connectedProviderKeys = this.providerRegistry.getConnectedNames();
+
+		return await this.repository.findGlobalConnections({
+			providerKeys: connectedProviderKeys,
 		});
-		return connections;
 	}
 
 	async getProjectCompletions(projectId: string): Promise<SecretsProviderConnection[]> {
-		const connectedProviders = this.providerRegistry.getConnected();
-		const connectedProviderNames = connectedProviders.map((provider) => provider.name);
-		const connections = await this.repository.findByProjectId(projectId, {
-			types: connectedProviderNames,
+		const connectedProviderKeys = this.providerRegistry.getConnectedNames();
+
+		return await this.repository.findByProjectId(projectId, {
+			providerKeys: connectedProviderKeys,
 		});
-		return connections;
 	}
 
 	async listConnectionsForProject(projectId: string): Promise<SecretsProviderConnection[]> {

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.service.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.service.ee.ts
@@ -15,8 +15,8 @@ import {
 import { Service } from '@n8n/di';
 import { Cipher } from 'n8n-core';
 import type { IDataObject } from 'n8n-workflow';
-
 import { jsonParse } from 'n8n-workflow';
+
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { EventService } from '@/events/event.service';
@@ -24,6 +24,7 @@ import type { ProjectSummary } from '@/events/maps/relay.event-map';
 import { ExternalSecretsManager } from '@/modules/external-secrets.ee/external-secrets-manager.ee';
 import { RedactionService } from '@/modules/external-secrets.ee/redaction.service.ee';
 import { SecretsProvidersResponses } from '@/modules/external-secrets.ee/secrets-providers.responses.ee';
+
 import { ExternalSecretsProviderRegistry } from './provider-registry.service';
 
 @Service()

--- a/packages/cli/test/integration/database/repositories/secrets-provider-connection.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/secrets-provider-connection.repository.test.ts
@@ -82,7 +82,7 @@ describe('SecretsProviderConnectionRepository', () => {
 			]);
 		});
 
-		it('filters by types when provided', async () => {
+		it('filters by provider keys when provided', async () => {
 			await Promise.all([
 				createConnection('globalAws', 'awsSecretsManager'),
 				createConnection('globalVault', 'hashicorpVault'),
@@ -90,7 +90,7 @@ describe('SecretsProviderConnectionRepository', () => {
 			]);
 
 			const connections = await connectionRepository.findGlobalConnections({
-				types: ['awsSecretsManager', 'hashicorpVault'],
+				providerKeys: ['globalAws', 'globalVault'],
 			});
 
 			expect(connections).toHaveLength(2);
@@ -127,7 +127,7 @@ describe('SecretsProviderConnectionRepository', () => {
 			]);
 		});
 
-		it('filters by types when provided', async () => {
+		it('filters by provider keys when provided', async () => {
 			await Promise.all([
 				createConnection('projAws', 'awsSecretsManager', [project1.id]),
 				createConnection('projVault', 'hashicorpVault', [project1.id]),
@@ -135,7 +135,7 @@ describe('SecretsProviderConnectionRepository', () => {
 			]);
 
 			const connections = await connectionRepository.findByProjectId(project1.id, {
-				types: ['awsSecretsManager', 'gcpSecretsManager'],
+				providerKeys: ['projAws', 'projGcp'],
 			});
 
 			expect(connections).toHaveLength(2);

--- a/packages/cli/test/integration/database/repositories/secrets-provider-connection.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/secrets-provider-connection.repository.test.ts
@@ -1,0 +1,156 @@
+import { LicenseState } from '@n8n/backend-common';
+import { createTeamProject, testDb } from '@n8n/backend-test-utils';
+import type { Project } from '@n8n/db';
+import {
+	ProjectSecretsProviderAccessRepository,
+	SecretsProviderConnectionRepository,
+} from '@n8n/db';
+import { Container } from '@n8n/di';
+import { mock } from 'jest-mock-extended';
+import { Cipher } from 'n8n-core';
+
+describe('SecretsProviderConnectionRepository', () => {
+	let connectionRepository: SecretsProviderConnectionRepository;
+	let projectAccessRepository: ProjectSecretsProviderAccessRepository;
+
+	let project1: Project;
+	let project2: Project;
+
+	beforeAll(async () => {
+		const licenseMock = mock<LicenseState>();
+		licenseMock.isLicensed.mockReturnValue(true);
+		Container.set(LicenseState, licenseMock);
+
+		await testDb.init();
+
+		connectionRepository = Container.get(SecretsProviderConnectionRepository);
+		projectAccessRepository = Container.get(ProjectSecretsProviderAccessRepository);
+
+		project1 = await createTeamProject('Project 1');
+		project2 = await createTeamProject('Project 2');
+	});
+
+	beforeEach(async () => {
+		await testDb.truncate(['SecretsProviderConnection', 'ProjectSecretsProviderAccess']);
+	});
+
+	afterAll(async () => {
+		await testDb.terminate();
+	});
+
+	async function createConnection(providerKey: string, type: string, projectIds: string[] = []) {
+		const cipher = Container.get(Cipher);
+		const encryptedSettings = cipher.encrypt({});
+
+		const connection = await connectionRepository.save(
+			connectionRepository.create({
+				providerKey,
+				type,
+				encryptedSettings,
+				isEnabled: true,
+			}),
+		);
+
+		if (projectIds.length > 0) {
+			await projectAccessRepository.save(
+				projectIds.map((projectId) =>
+					projectAccessRepository.create({
+						secretsProviderConnectionId: connection.id,
+						projectId,
+					}),
+				),
+			);
+		}
+
+		return connection;
+	}
+
+	describe('findGlobalConnections', () => {
+		it('returns only connections without project access', async () => {
+			await Promise.all([
+				createConnection('global1', 'awsSecretsManager'),
+				createConnection('global2', 'hashicorpVault'),
+				createConnection('project1', 'awsSecretsManager', [project1.id]),
+			]);
+
+			const connections = await connectionRepository.findGlobalConnections();
+
+			expect(connections).toHaveLength(2);
+			expect(connections.map((connection) => connection.providerKey).sort()).toEqual([
+				'global1',
+				'global2',
+			]);
+		});
+
+		it('filters by types when provided', async () => {
+			await Promise.all([
+				createConnection('globalAws', 'awsSecretsManager'),
+				createConnection('globalVault', 'hashicorpVault'),
+				createConnection('globalGcp', 'gcpSecretsManager'),
+			]);
+
+			const connections = await connectionRepository.findGlobalConnections({
+				types: ['awsSecretsManager', 'hashicorpVault'],
+			});
+
+			expect(connections).toHaveLength(2);
+			expect(connections.map((connection) => connection.providerKey).sort()).toEqual([
+				'globalAws',
+				'globalVault',
+			]);
+		});
+
+		it('returns empty array when no global connections exist', async () => {
+			await createConnection('projectOnly', 'awsSecretsManager', [project1.id]);
+
+			const connections = await connectionRepository.findGlobalConnections();
+
+			expect(connections).toEqual([]);
+		});
+	});
+
+	describe('findByProjectId', () => {
+		it('returns only connections assigned to the project', async () => {
+			await Promise.all([
+				createConnection('global', 'awsSecretsManager'),
+				createConnection('proj1A', 'awsSecretsManager', [project1.id]),
+				createConnection('proj1B', 'hashicorpVault', [project1.id]),
+				createConnection('proj2A', 'gcpSecretsManager', [project2.id]),
+			]);
+
+			const connections = await connectionRepository.findByProjectId(project1.id);
+
+			expect(connections).toHaveLength(2);
+			expect(connections.map((connection) => connection.providerKey).sort()).toEqual([
+				'proj1A',
+				'proj1B',
+			]);
+		});
+
+		it('filters by types when provided', async () => {
+			await Promise.all([
+				createConnection('projAws', 'awsSecretsManager', [project1.id]),
+				createConnection('projVault', 'hashicorpVault', [project1.id]),
+				createConnection('projGcp', 'gcpSecretsManager', [project1.id]),
+			]);
+
+			const connections = await connectionRepository.findByProjectId(project1.id, {
+				types: ['awsSecretsManager', 'gcpSecretsManager'],
+			});
+
+			expect(connections).toHaveLength(2);
+			expect(connections.map((connection) => connection.providerKey).sort()).toEqual([
+				'projAws',
+				'projGcp',
+			]);
+		});
+
+		it('returns empty array when no connections exist for project', async () => {
+			await createConnection('otherProject', 'awsSecretsManager', [project2.id]);
+
+			const connections = await connectionRepository.findByProjectId(project1.id);
+
+			expect(connections).toEqual([]);
+		});
+	});
+});

--- a/packages/cli/test/integration/database/repositories/secrets-provider-connection.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/secrets-provider-connection.repository.test.ts
@@ -107,6 +107,20 @@ describe('SecretsProviderConnectionRepository', () => {
 
 			expect(connections).toEqual([]);
 		});
+
+		it('returns empty array when providerKeys filter is an empty array', async () => {
+			await Promise.all([
+				createConnection('globalAws', 'awsSecretsManager'),
+				createConnection('globalVault', 'hashicorpVault'),
+				createConnection('globalGcp', 'gcpSecretsManager'),
+			]);
+
+			const connections = await connectionRepository.findGlobalConnections({
+				providerKeys: [],
+			});
+
+			expect(connections).toEqual([]);
+		});
 	});
 
 	describe('findByProjectId', () => {
@@ -149,6 +163,20 @@ describe('SecretsProviderConnectionRepository', () => {
 			await createConnection('otherProject', 'awsSecretsManager', [project2.id]);
 
 			const connections = await connectionRepository.findByProjectId(project1.id);
+
+			expect(connections).toEqual([]);
+		});
+
+		it('returns empty array when providerKeys filter is an empty array', async () => {
+			await Promise.all([
+				createConnection('projAws', 'awsSecretsManager', [project1.id]),
+				createConnection('projVault', 'hashicorpVault', [project1.id]),
+				createConnection('projGcp', 'gcpSecretsManager', [project1.id]),
+			]);
+
+			const connections = await connectionRepository.findByProjectId(project1.id, {
+				providerKeys: [],
+			});
 
 			expect(connections).toEqual([]);
 		});


### PR DESCRIPTION
## Summary

Improves the user experience when selecting secrets provider connections by filtering autocomplete suggestions to only show connections from providers that are successfully connected - hiding unsuccessfully connected providers from the list.

Previously, the autocomplete would show all connections regardless of whether their provider was connected, which could confuse users by showing options that couldn't actually be used.

**Changes:**
- Repository methods now accept optional `types` filter parameter
- Service uses provider registry to get list of connected providers  
- Autocomplete results are filtered to only connected provider types
- Added integration tests for the new filtering behavior

**Testing:**
1. Set up multiple secrets provider connections (e.g., AWS, HashiCorp Vault)
    a. Make sure at least one connection is not connected (e.g. use fake access token)
2. Open a credential or node that uses secrets
3. Type to trigger autocomplete for secrets provider selection
4. Verify only connections from connected providers appear in suggestions
5. Fix the invalid provider (use a correct token to successfully connect)
6. Verify that this connection now appear in autocomplete

Note: You can test this for global and project based secrets provider connections

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-235

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)