### PR TITLE
fix(Webhook Node): Redact auth credential headers from Webhook execution output

### DIFF
--- a/packages/nodes-base/nodes/Webhook/Webhook.node.ts
+++ b/packages/nodes-base/nodes/Webhook/Webhook.node.ts
@@ -32,8 +32,10 @@ import { WebhookAuthorizationError } from './error';
 import {
 	checkResponseModeConfiguration,
 	configuredOutputs,
+	getAuthHeadersToRedact,
 	handleFormData,
 	isIpAllowed,
+	redactHeaders,
 	setupOutputConnection,
 	validateWebhookAuthentication,
 } from './utils';
@@ -245,6 +247,9 @@ export class Webhook extends Node {
 			}
 			throw error;
 		}
+
+		const headersToRedact = await getAuthHeadersToRedact(context, this.authPropertyName);
+		redactHeaders(req.headers, headersToRedact);
 
 		const prepareOutput = setupOutputConnection(context, requestMethod, {
 			jwtPayload: validationData,

--- a/packages/nodes-base/nodes/Webhook/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Webhook/test/utils.test.ts
@@ -1,3 +1,4 @@
+import { mock } from 'jest-mock-extended';
 import jwt from 'jsonwebtoken';
 import {
 	ApplicationError,
@@ -15,14 +16,15 @@ import {
 	configuredOutputs,
 	generateBasicAuthToken,
 	generateFormPostBasicAuthToken,
+	getAuthHeadersToRedact,
 	getResponseCode,
 	getResponseData,
 	handleFormData,
 	isIpAllowed,
+	redactHeaders,
 	setupOutputConnection,
 	validateWebhookAuthentication,
 } from '../utils';
-import { mock } from 'jest-mock-extended';
 
 jest.mock('jsonwebtoken', () => ({
 	verify: jest.fn(),
@@ -818,5 +820,102 @@ describe('Auth token generation', () => {
 			expect(token1).not.toBe(token2);
 			expect(token1).not.toBe(token3);
 		});
+	});
+});
+
+describe('redactHeaders', () => {
+	it('should do nothing when headersToRedact is empty', () => {
+		const headers: Record<string, unknown> = {
+			authorization: 'Bearer secret-token',
+			'content-type': 'application/json',
+		};
+		redactHeaders(headers, new Set());
+		expect(headers.authorization).toBe('Bearer secret-token');
+		expect(headers['content-type']).toBe('application/json');
+	});
+
+	it('should redact matching headers', () => {
+		const headers: Record<string, unknown> = {
+			authorization: 'Bearer secret-token',
+			'content-type': 'application/json',
+		};
+		redactHeaders(headers, new Set(['authorization']));
+		expect(headers.authorization).toBe('**hidden**');
+		expect(headers['content-type']).toBe('application/json');
+	});
+
+	it('should handle case-insensitive matching', () => {
+		const headers: Record<string, unknown> = {
+			Authorization: 'Bearer secret-token',
+		};
+		redactHeaders(headers, new Set(['authorization']));
+		expect(headers.Authorization).toBe('**hidden**');
+	});
+
+	it('should redact multiple headers', () => {
+		const headers: Record<string, unknown> = {
+			authorization: 'Basic base64string',
+			'x-auth-token': 'some-token',
+			'content-type': 'application/json',
+		};
+		redactHeaders(headers, new Set(['authorization', 'x-auth-token']));
+		expect(headers.authorization).toBe('**hidden**');
+		expect(headers['x-auth-token']).toBe('**hidden**');
+		expect(headers['content-type']).toBe('application/json');
+	});
+});
+
+describe('getAuthHeadersToRedact', () => {
+	it('should return empty set for authentication "none"', async () => {
+		const ctx: Partial<IWebhookFunctions> = {
+			getNodeParameter: jest.fn().mockReturnValue('none'),
+		};
+		const result = await getAuthHeadersToRedact(ctx as IWebhookFunctions, 'authentication');
+		expect(result.size).toBe(0);
+	});
+
+	it('should return authorization and x-auth-token for basicAuth', async () => {
+		const ctx: Partial<IWebhookFunctions> = {
+			getNodeParameter: jest.fn().mockReturnValue('basicAuth'),
+		};
+		const result = await getAuthHeadersToRedact(ctx as IWebhookFunctions, 'authentication');
+		expect(result).toEqual(new Set(['authorization', 'x-auth-token']));
+	});
+
+	it('should return authorization for bearerAuth', async () => {
+		const ctx: Partial<IWebhookFunctions> = {
+			getNodeParameter: jest.fn().mockReturnValue('bearerAuth'),
+		};
+		const result = await getAuthHeadersToRedact(ctx as IWebhookFunctions, 'authentication');
+		expect(result).toEqual(new Set(['authorization']));
+	});
+
+	it('should return authorization for jwtAuth', async () => {
+		const ctx: Partial<IWebhookFunctions> = {
+			getNodeParameter: jest.fn().mockReturnValue('jwtAuth'),
+		};
+		const result = await getAuthHeadersToRedact(ctx as IWebhookFunctions, 'authentication');
+		expect(result).toEqual(new Set(['authorization']));
+	});
+
+	it('should return custom header name for headerAuth', async () => {
+		const ctx: Partial<IWebhookFunctions> = {
+			getNodeParameter: jest.fn().mockReturnValue('headerAuth'),
+			getCredentials: jest.fn().mockResolvedValue({
+				name: 'X-My-Secret',
+				value: 'secret-value',
+			}),
+		};
+		const result = await getAuthHeadersToRedact(ctx as IWebhookFunctions, 'authentication');
+		expect(result).toEqual(new Set(['x-my-secret']));
+	});
+
+	it('should return empty set for headerAuth when credentials cannot be fetched', async () => {
+		const ctx: Partial<IWebhookFunctions> = {
+			getNodeParameter: jest.fn().mockReturnValue('headerAuth'),
+			getCredentials: jest.fn().mockRejectedValue(new Error('no credentials')),
+		};
+		const result = await getAuthHeadersToRedact(ctx as IWebhookFunctions, 'authentication');
+		expect(result.size).toBe(0);
 	});
 });

--- a/packages/nodes-base/nodes/Webhook/utils.ts
+++ b/packages/nodes-base/nodes/Webhook/utils.ts
@@ -2,13 +2,14 @@ import basicAuth from 'basic-auth';
 import { rm } from 'fs/promises';
 import jwt from 'jsonwebtoken';
 import { WorkflowConfigurationError } from 'n8n-workflow';
-import type {
-	IWebhookFunctions,
-	INodeExecutionData,
-	IDataObject,
-	ICredentialDataDecryptedObject,
-	MultiPartFormData,
-	INode,
+import {
+	REDACTED,
+	type IWebhookFunctions,
+	type INodeExecutionData,
+	type IDataObject,
+	type ICredentialDataDecryptedObject,
+	type MultiPartFormData,
+	type INode,
 } from 'n8n-workflow';
 import * as a from 'node:assert';
 import { createHmac, timingSafeEqual } from 'node:crypto';
@@ -451,4 +452,45 @@ export function generateBasicAuthToken(
 		.digest('hex');
 
 	return token;
+}
+
+export async function getAuthHeadersToRedact(
+	ctx: IWebhookFunctions,
+	authPropertyName: string,
+): Promise<Set<string>> {
+	const authentication = ctx.getNodeParameter(authPropertyName) as string;
+
+	switch (authentication) {
+		case 'basicAuth':
+			return new Set(['authorization', 'x-auth-token']);
+		case 'bearerAuth':
+			return new Set(['authorization']);
+		case 'jwtAuth':
+			return new Set(['authorization']);
+		case 'headerAuth': {
+			let credentials: ICredentialDataDecryptedObject | undefined;
+			try {
+				credentials = await ctx.getCredentials<ICredentialDataDecryptedObject>('httpHeaderAuth');
+			} catch {}
+			if (credentials?.name) {
+				return new Set([(credentials.name as string).toLowerCase()]);
+			}
+			return new Set();
+		}
+		default:
+			return new Set();
+	}
+}
+
+export function redactHeaders(
+	headers: Record<string, unknown>,
+	headersToRedact: Set<string>,
+): void {
+	if (headersToRedact.size === 0) return;
+
+	for (const headerName of Object.keys(headers)) {
+		if (headersToRedact.has(headerName.toLowerCase())) {
+			headers[headerName] = REDACTED;
+		}
+	}
 }

--- a/packages/workflow/src/constants.ts
+++ b/packages/workflow/src/constants.ts
@@ -138,3 +138,6 @@ export const BINARY_IN_JSON_PROPERTY = '_files';
 
 export const BINARY_MODE_SEPARATE = 'separate';
 export const BINARY_MODE_COMBINED = 'combined';
+
+/** Replacement value for redacted sensitive data in execution output. */
+export const REDACTED = '**hidden**';


### PR DESCRIPTION
## Summary
- When a Webhook node has authentication configured (Basic/Bearer/Header/JWT Auth), the auth headers in incoming requests were exposed in plain text in execution output data
- After auth validation succeeds, auth-related headers are now replaced with `**hidden**` before output is constructed
- Extracts `REDACTED` constant to `n8n-workflow` for shared use

### Screenshots
Before:
<img width="1794" height="1218" alt="image" src="https://github.com/user-attachments/assets/e2cabf2d-142b-4378-a0df-e04730d4930c" />

After:
<img width="2032" height="1266" alt="image" src="https://github.com/user-attachments/assets/a5ed316b-81a6-461c-a938-2b28b3cd271e" />

It's the same when opening a node in the execution, the **hidden** value is shown the same way

We use the same **hidden** redacted value as for the http request node 

## Related ticket
https://linear.app/n8n/issue/IAM-278

## Review / Merge checklist
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)