### PR TITLE
fix(core): Disable inline SBOM to prevent malformed Docker image layers

### DIFF
--- a/.github/scripts/docker/docker-config.test.mjs
+++ b/.github/scripts/docker/docker-config.test.mjs
@@ -1,0 +1,138 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import BuildContext from './docker-config.mjs';
+
+describe('BuildContext', () => {
+	let ctx;
+
+	beforeEach(() => {
+		delete process.env.GITHUB_OUTPUT;
+		ctx = new BuildContext();
+	});
+
+	describe('determine()', () => {
+		it('should use version and releaseType when both are provided', () => {
+			const result = ctx.determine({ version: '1.2.3', releaseType: 'stable' });
+			assert.equal(result.version, '1.2.3');
+			assert.equal(result.release_type, 'stable');
+			assert.equal(result.push_to_docker, true);
+		});
+
+		it('should configure nightly for schedule events', () => {
+			const result = ctx.determine({ event: 'schedule' });
+			assert.equal(result.version, 'nightly');
+			assert.equal(result.release_type, 'nightly');
+			assert.equal(result.push_to_docker, true);
+			assert.deepEqual(result.platforms, ['linux/amd64', 'linux/arm64']);
+		});
+
+		it('should configure PR builds as single-platform dev', () => {
+			const result = ctx.determine({ event: 'pull_request', pr: '42' });
+			assert.equal(result.version, 'pr-42');
+			assert.equal(result.release_type, 'dev');
+			assert.deepEqual(result.platforms, ['linux/amd64']);
+		});
+
+		it('should configure workflow_dispatch as single-platform branch', () => {
+			const result = ctx.determine({ event: 'workflow_dispatch', branch: 'feat/my-branch' });
+			assert.equal(result.version, 'branch-feat-my-branch');
+			assert.equal(result.release_type, 'branch');
+			assert.deepEqual(result.platforms, ['linux/amd64']);
+		});
+
+		it('should configure push to master as dev', () => {
+			const result = ctx.determine({ event: 'push', branch: 'master' });
+			assert.equal(result.version, 'dev');
+			assert.equal(result.release_type, 'dev');
+			assert.equal(result.push_to_docker, true);
+		});
+
+		it('should configure push to non-master branch', () => {
+			const result = ctx.determine({ event: 'push', branch: 'feature/test' });
+			assert.equal(result.version, 'branch-feature-test');
+			assert.equal(result.release_type, 'branch');
+			assert.deepEqual(result.platforms, ['linux/amd64']);
+		});
+
+		it('should configure workflow_call with version', () => {
+			const result = ctx.determine({ event: 'workflow_call', version: '2.0.0' });
+			assert.equal(result.version, '2.0.0');
+			assert.equal(result.release_type, 'stable');
+			assert.equal(result.push_to_docker, true);
+		});
+
+		it('should throw for workflow_call without version', () => {
+			assert.throws(
+				() => ctx.determine({ event: 'workflow_call' }),
+				(err) => {
+					assert.match(err.message, /Version required/);
+					return true;
+				},
+			);
+		});
+
+		it('should throw for unknown events', () => {
+			assert.throws(
+				() => ctx.determine({ event: 'unknown_event' }),
+				(err) => {
+					assert.match(err.message, /Unknown event/);
+					return true;
+				},
+			);
+		});
+
+		it('should respect pushEnabled override', () => {
+			const result = ctx.determine({ event: 'schedule', pushEnabled: false });
+			assert.equal(result.push_enabled, false);
+		});
+
+		it('should default push_enabled to push_to_ghcr', () => {
+			const result = ctx.determine({ event: 'schedule' });
+			assert.equal(result.push_enabled, result.push_to_ghcr);
+		});
+	});
+
+	describe('sanitizeBranch()', () => {
+		it('should lowercase and replace special characters', () => {
+			assert.equal(ctx.sanitizeBranch('Feature/MY-Branch'), 'feature-my-branch');
+		});
+
+		it('should remove leading dots and dashes', () => {
+			assert.equal(ctx.sanitizeBranch('.hidden-branch'), 'hidden-branch');
+			assert.equal(ctx.sanitizeBranch('-bad-start'), 'bad-start');
+		});
+
+		it('should remove trailing dots and dashes', () => {
+			assert.equal(ctx.sanitizeBranch('branch-name.'), 'branch-name');
+			assert.equal(ctx.sanitizeBranch('branch-name-'), 'branch-name');
+		});
+
+		it('should truncate to 128 characters', () => {
+			const longBranch = 'a'.repeat(200);
+			assert.equal(ctx.sanitizeBranch(longBranch).length, 128);
+		});
+
+		it('should return unknown for falsy input', () => {
+			assert.equal(ctx.sanitizeBranch(''), 'unknown');
+			assert.equal(ctx.sanitizeBranch(null), 'unknown');
+			assert.equal(ctx.sanitizeBranch(undefined), 'unknown');
+		});
+	});
+
+	describe('buildMatrix()', () => {
+		it('should build matrix for dual-platform', () => {
+			const matrix = ctx.buildMatrix(['linux/amd64', 'linux/arm64']);
+			assert.deepEqual(matrix.platform, ['amd64', 'arm64']);
+			assert.equal(matrix.include.length, 2);
+			assert.equal(matrix.include[0].runner, 'blacksmith-4vcpu-ubuntu-2204');
+			assert.equal(matrix.include[1].runner, 'blacksmith-4vcpu-ubuntu-2204-arm');
+		});
+
+		it('should build matrix for single-platform', () => {
+			const matrix = ctx.buildMatrix(['linux/amd64']);
+			assert.deepEqual(matrix.platform, ['amd64']);
+			assert.equal(matrix.include.length, 1);
+			assert.equal(matrix.include[0].docker_platform, 'linux/amd64');
+		});
+	});
+});

--- a/.github/scripts/docker/docker-tags.test.mjs
+++ b/.github/scripts/docker/docker-tags.test.mjs
@@ -1,0 +1,109 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import TagGenerator from './docker-tags.mjs';
+
+describe('TagGenerator', () => {
+	let gen;
+
+	beforeEach(() => {
+		delete process.env.GITHUB_OUTPUT;
+		delete process.env.GITHUB_REPOSITORY_OWNER;
+		delete process.env.DOCKER_USERNAME;
+		gen = new TagGenerator();
+	});
+
+	describe('generate()', () => {
+		it('should generate GHCR tag for n8n image', () => {
+			const tags = gen.generate({ image: 'n8n', version: '1.0.0' });
+			assert.deepEqual(tags.ghcr, ['ghcr.io/n8n-io/n8n:1.0.0']);
+			assert.deepEqual(tags.docker, []);
+			assert.deepEqual(tags.all, ['ghcr.io/n8n-io/n8n:1.0.0']);
+		});
+
+		it('should generate GHCR tag with platform suffix', () => {
+			const tags = gen.generate({ image: 'n8n', version: '1.0.0', platform: 'linux/amd64' });
+			assert.deepEqual(tags.ghcr, ['ghcr.io/n8n-io/n8n:1.0.0-amd64']);
+		});
+
+		it('should generate both GHCR and Docker Hub tags when includeDockerHub is true', () => {
+			const tags = gen.generate({ image: 'n8n', version: '1.0.0', includeDockerHub: true });
+			assert.deepEqual(tags.ghcr, ['ghcr.io/n8n-io/n8n:1.0.0']);
+			assert.deepEqual(tags.docker, ['n8nio/n8n:1.0.0']);
+			assert.equal(tags.all.length, 2);
+		});
+
+		it('should handle runners-distroless by using runners image name with suffix', () => {
+			const tags = gen.generate({ image: 'runners-distroless', version: '1.0.0' });
+			assert.deepEqual(tags.ghcr, ['ghcr.io/n8n-io/runners:1.0.0-distroless']);
+		});
+
+		it('should handle runners image without distroless suffix', () => {
+			const tags = gen.generate({ image: 'runners', version: '1.0.0' });
+			assert.deepEqual(tags.ghcr, ['ghcr.io/n8n-io/runners:1.0.0']);
+		});
+
+		it('should combine platform and distroless suffixes', () => {
+			const tags = gen.generate({
+				image: 'runners-distroless',
+				version: '2.0.0',
+				platform: 'linux/arm64',
+			});
+			assert.deepEqual(tags.ghcr, ['ghcr.io/n8n-io/runners:2.0.0-distroless-arm64']);
+		});
+
+		it('should handle nightly version', () => {
+			const tags = gen.generate({ image: 'n8n', version: 'nightly' });
+			assert.deepEqual(tags.ghcr, ['ghcr.io/n8n-io/n8n:nightly']);
+		});
+
+		it('should handle dev version', () => {
+			const tags = gen.generate({ image: 'n8n', version: 'dev', platform: 'linux/amd64' });
+			assert.deepEqual(tags.ghcr, ['ghcr.io/n8n-io/n8n:dev-amd64']);
+		});
+	});
+
+	describe('generateAll()', () => {
+		it('should generate tags for all three image types', () => {
+			const results = gen.generateAll({ version: '1.0.0' });
+			assert.ok('n8n' in results);
+			assert.ok('runners' in results);
+			assert.ok('runners_distroless' in results);
+		});
+
+		it('should generate correct tags for each image', () => {
+			const results = gen.generateAll({ version: '1.0.0', platform: 'linux/amd64' });
+			assert.deepEqual(results.n8n.ghcr, ['ghcr.io/n8n-io/n8n:1.0.0-amd64']);
+			assert.deepEqual(results.runners.ghcr, ['ghcr.io/n8n-io/runners:1.0.0-amd64']);
+			assert.deepEqual(results.runners_distroless.ghcr, [
+				'ghcr.io/n8n-io/runners:1.0.0-distroless-amd64',
+			]);
+		});
+
+		it('should include Docker Hub tags when requested', () => {
+			const results = gen.generateAll({
+				version: '1.0.0',
+				includeDockerHub: true,
+			});
+			assert.equal(results.n8n.docker.length, 1);
+			assert.equal(results.runners.docker.length, 1);
+			assert.equal(results.runners_distroless.docker.length, 1);
+		});
+	});
+
+	describe('defaults', () => {
+		it('should use n8n-io as default github owner', () => {
+			assert.equal(gen.githubOwner, 'n8n-io');
+		});
+
+		it('should use n8nio as default docker username', () => {
+			assert.equal(gen.dockerUsername, 'n8nio');
+		});
+
+		it('should respect GITHUB_REPOSITORY_OWNER env var', () => {
+			process.env.GITHUB_REPOSITORY_OWNER = 'custom-org';
+			const customGen = new TagGenerator();
+			assert.equal(customGen.githubOwner, 'custom-org');
+			delete process.env.GITHUB_REPOSITORY_OWNER;
+		});
+	});
+});

--- a/.github/scripts/docker/get-manifest-digests.mjs
+++ b/.github/scripts/docker/get-manifest-digests.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 /**
  * Extracts manifest digests and image names for SLSA provenance and VEX attestation.
+ * Also validates that image manifests contain only valid tar-based layers
+ * (no malformed attestation blobs that would cause "invalid tar header" on pull).
  *
  * Usage:
  *   N8N_TAG=ghcr.io/n8n-io/n8n:1.0.0 node get-manifest-digests.mjs
@@ -15,7 +17,53 @@
 import { execSync } from 'node:child_process';
 import { appendFileSync } from 'node:fs';
 
-const githubOutput = process.env.GITHUB_OUTPUT || null;
+// Valid OCI/Docker layer media types (all must be tar-based archives)
+export const VALID_LAYER_MEDIA_TYPES = [
+	'application/vnd.oci.image.layer.v1.tar',
+	'application/vnd.oci.image.layer.v1.tar+gzip',
+	'application/vnd.oci.image.layer.v1.tar+zstd',
+	'application/vnd.docker.image.rootfs.diff.tar.gzip',
+	'application/vnd.oci.image.layer.nondistributable.v1.tar',
+	'application/vnd.oci.image.layer.nondistributable.v1.tar+gzip',
+	'application/vnd.oci.image.layer.nondistributable.v1.tar+zstd',
+];
+
+/**
+ * Validates that a parsed manifest contains only valid tar-based layers.
+ * Detects malformed attestation blobs (e.g. SBOM JSON) incorrectly referenced as layers,
+ * which cause "archive/tar: invalid tar header" errors during docker pull.
+ *
+ * @param {object} manifest - Parsed OCI/Docker manifest JSON
+ * @param {string} [imageRef] - Image reference for error messages
+ * @throws {Error} If any layer has a non-tar media type
+ */
+export function validateManifestLayers(manifest, imageRef = 'unknown') {
+	// For OCI index (multi-platform), skip — layers are in child manifests, not at index level
+	if (manifest.manifests) {
+		return;
+	}
+
+	// For single-platform manifests, validate layer media types
+	if (manifest.layers) {
+		for (let i = 0; i < manifest.layers.length; i++) {
+			const layer = manifest.layers[i];
+			const mediaType = layer.mediaType || '';
+
+			if (!VALID_LAYER_MEDIA_TYPES.includes(mediaType)) {
+				throw new Error(
+					`Image ${imageRef}: layer ${i} has non-tar media type "${mediaType}" ` +
+						`(size: ${layer.size} bytes). This would cause "archive/tar: invalid tar header" ` +
+						`on docker pull. Ensure sbom:false is set in the build step.`,
+				);
+			}
+		}
+	}
+}
+
+export function getImageName(imageRef) {
+	if (!imageRef) return '';
+	return imageRef.replace(/:([^:]+)$/, '');
+}
 
 function getDigest(imageRef) {
 	if (!imageRef) return '';
@@ -26,38 +74,58 @@ function getDigest(imageRef) {
 	return `sha256:${hash}`;
 }
 
-function getImageName(imageRef) {
-	if (!imageRef) return '';
-	return imageRef.replace(/:([^:]+)$/, '');
+function fetchAndValidateManifest(imageRef) {
+	if (!imageRef) return;
+	const raw = execSync(`docker buildx imagetools inspect "${imageRef}" --raw`, {
+		encoding: 'utf8',
+	});
+	const manifest = JSON.parse(raw);
+	validateManifestLayers(manifest, imageRef);
+	console.log(`  Validated layers for ${imageRef}`);
 }
 
-function setOutput(name, value) {
+function setOutput(name, value, githubOutput) {
 	if (githubOutput && value) appendFileSync(githubOutput, `${name}=${value}\n`);
 }
 
-const n8nTag = process.env.N8N_TAG || '';
-const runnersTag = process.env.RUNNERS_TAG || '';
-const distrolessTag = process.env.DISTROLESS_TAG || '';
+// CLI entry point
+if (import.meta.url === `file://${process.argv[1]}`) {
+	const githubOutput = process.env.GITHUB_OUTPUT || null;
 
-const results = {
-	n8n: { digest: getDigest(n8nTag), image: getImageName(n8nTag) },
-	runners: { digest: getDigest(runnersTag), image: getImageName(runnersTag) },
-	runners_distroless: { digest: getDigest(distrolessTag), image: getImageName(distrolessTag) },
-};
+	const n8nTag = process.env.N8N_TAG || '';
+	const runnersTag = process.env.RUNNERS_TAG || '';
+	const distrolessTag = process.env.DISTROLESS_TAG || '';
 
-setOutput('n8n_digest', results.n8n.digest);
-setOutput('n8n_image', results.n8n.image);
-setOutput('runners_digest', results.runners.digest);
-setOutput('runners_image', results.runners.image);
-setOutput('runners_distroless_digest', results.runners_distroless.digest);
-setOutput('runners_distroless_image', results.runners_distroless.image);
+	// Validate manifest layers before extracting digests
+	console.log('=== Validating Image Layers ===');
+	fetchAndValidateManifest(n8nTag);
+	fetchAndValidateManifest(runnersTag);
+	fetchAndValidateManifest(distrolessTag);
+	console.log('');
 
-console.log('=== Manifest Digests ===');
-console.log(`n8n: ${results.n8n.digest || 'N/A'}`);
-console.log(`runners: ${results.runners.digest || 'N/A'}`);
-console.log(`runners-distroless: ${results.runners_distroless.digest || 'N/A'}`);
-console.log('');
-console.log('=== Image Names ===');
-console.log(`n8n: ${results.n8n.image || 'N/A'}`);
-console.log(`runners: ${results.runners.image || 'N/A'}`);
-console.log(`runners-distroless: ${results.runners_distroless.image || 'N/A'}`);
+	const results = {
+		n8n: { digest: getDigest(n8nTag), image: getImageName(n8nTag) },
+		runners: { digest: getDigest(runnersTag), image: getImageName(runnersTag) },
+		runners_distroless: {
+			digest: getDigest(distrolessTag),
+			image: getImageName(distrolessTag),
+		},
+	};
+
+	setOutput('n8n_digest', results.n8n.digest, githubOutput);
+	setOutput('n8n_image', results.n8n.image, githubOutput);
+	setOutput('runners_digest', results.runners.digest, githubOutput);
+	setOutput('runners_image', results.runners.image, githubOutput);
+	setOutput('runners_distroless_digest', results.runners_distroless.digest, githubOutput);
+	setOutput('runners_distroless_image', results.runners_distroless.image, githubOutput);
+
+	console.log('=== Manifest Digests ===');
+	console.log(`n8n: ${results.n8n.digest || 'N/A'}`);
+	console.log(`runners: ${results.runners.digest || 'N/A'}`);
+	console.log(`runners-distroless: ${results.runners_distroless.digest || 'N/A'}`);
+	console.log('');
+	console.log('=== Image Names ===');
+	console.log(`n8n: ${results.n8n.image || 'N/A'}`);
+	console.log(`runners: ${results.runners.image || 'N/A'}`);
+	console.log(`runners-distroless: ${results.runners_distroless.image || 'N/A'}`);
+}

--- a/.github/scripts/docker/get-manifest-digests.test.mjs
+++ b/.github/scripts/docker/get-manifest-digests.test.mjs
@@ -1,0 +1,281 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { validateManifestLayers, getImageName, VALID_LAYER_MEDIA_TYPES } from './get-manifest-digests.mjs';
+
+describe('validateManifestLayers', () => {
+	it('should pass for manifest with valid tar+gzip layers', () => {
+		const manifest = {
+			schemaVersion: 2,
+			mediaType: 'application/vnd.oci.image.manifest.v1+json',
+			layers: [
+				{
+					mediaType: 'application/vnd.oci.image.layer.v1.tar+gzip',
+					size: 31457280,
+					digest: 'sha256:abc123',
+				},
+				{
+					mediaType: 'application/vnd.oci.image.layer.v1.tar+gzip',
+					size: 1024000,
+					digest: 'sha256:def456',
+				},
+			],
+		};
+		assert.doesNotThrow(() => validateManifestLayers(manifest, 'test:latest'));
+	});
+
+	it('should pass for manifest with valid Docker-format layers', () => {
+		const manifest = {
+			schemaVersion: 2,
+			layers: [
+				{
+					mediaType: 'application/vnd.docker.image.rootfs.diff.tar.gzip',
+					size: 5000000,
+					digest: 'sha256:aaa111',
+				},
+			],
+		};
+		assert.doesNotThrow(() => validateManifestLayers(manifest));
+	});
+
+	it('should pass for manifest with tar+zstd layers', () => {
+		const manifest = {
+			schemaVersion: 2,
+			layers: [
+				{
+					mediaType: 'application/vnd.oci.image.layer.v1.tar+zstd',
+					size: 2000000,
+					digest: 'sha256:bbb222',
+				},
+			],
+		};
+		assert.doesNotThrow(() => validateManifestLayers(manifest));
+	});
+
+	it('should pass for manifest with uncompressed tar layers', () => {
+		const manifest = {
+			schemaVersion: 2,
+			layers: [
+				{
+					mediaType: 'application/vnd.oci.image.layer.v1.tar',
+					size: 10000000,
+					digest: 'sha256:ccc333',
+				},
+			],
+		};
+		assert.doesNotThrow(() => validateManifestLayers(manifest));
+	});
+
+	it('should throw for layer with SBOM JSON media type (the bug this fix prevents)', () => {
+		const manifest = {
+			schemaVersion: 2,
+			layers: [
+				{
+					mediaType: 'application/vnd.oci.image.layer.v1.tar+gzip',
+					size: 31457280,
+					digest: 'sha256:abc123',
+				},
+				{
+					mediaType: 'application/spdx+json',
+					size: 1890,
+					digest: 'sha256:bc0cdc8ecc2f',
+				},
+			],
+		};
+		assert.throws(
+			() => validateManifestLayers(manifest, 'n8nio/n8n:2.4.0'),
+			(err) => {
+				assert.match(err.message, /non-tar media type/);
+				assert.match(err.message, /spdx\+json/);
+				assert.match(err.message, /invalid tar header/);
+				assert.match(err.message, /n8nio\/n8n:2\.4\.0/);
+				assert.match(err.message, /1890 bytes/);
+				return true;
+			},
+		);
+	});
+
+	it('should throw for layer with generic JSON media type', () => {
+		const manifest = {
+			schemaVersion: 2,
+			layers: [
+				{
+					mediaType: 'application/json',
+					size: 2048,
+					digest: 'sha256:bad000',
+				},
+			],
+		};
+		assert.throws(
+			() => validateManifestLayers(manifest, 'test:latest'),
+			(err) => {
+				assert.match(err.message, /non-tar media type/);
+				assert.match(err.message, /application\/json/);
+				return true;
+			},
+		);
+	});
+
+	it('should throw for layer with empty media type', () => {
+		const manifest = {
+			schemaVersion: 2,
+			layers: [
+				{
+					mediaType: '',
+					size: 1024,
+					digest: 'sha256:empty00',
+				},
+			],
+		};
+		assert.throws(
+			() => validateManifestLayers(manifest),
+			(err) => {
+				assert.match(err.message, /non-tar media type/);
+				return true;
+			},
+		);
+	});
+
+	it('should throw for layer with attestation manifest media type', () => {
+		const manifest = {
+			schemaVersion: 2,
+			layers: [
+				{
+					mediaType: 'application/vnd.in-toto+json',
+					size: 512,
+					digest: 'sha256:attest0',
+				},
+			],
+		};
+		assert.throws(
+			() => validateManifestLayers(manifest),
+			(err) => {
+				assert.match(err.message, /non-tar media type/);
+				return true;
+			},
+		);
+	});
+
+	it('should pass for OCI index (multi-platform) manifests without layers', () => {
+		const manifest = {
+			schemaVersion: 2,
+			mediaType: 'application/vnd.oci.image.index.v1+json',
+			manifests: [
+				{
+					mediaType: 'application/vnd.oci.image.manifest.v1+json',
+					digest: 'sha256:amd64digest',
+					platform: { architecture: 'amd64', os: 'linux' },
+				},
+				{
+					mediaType: 'application/vnd.oci.image.manifest.v1+json',
+					digest: 'sha256:arm64digest',
+					platform: { architecture: 'arm64', os: 'linux' },
+				},
+			],
+		};
+		assert.doesNotThrow(() => validateManifestLayers(manifest));
+	});
+
+	it('should pass for OCI index with attestation manifests (architecture: unknown)', () => {
+		const manifest = {
+			schemaVersion: 2,
+			manifests: [
+				{
+					mediaType: 'application/vnd.oci.image.manifest.v1+json',
+					digest: 'sha256:amd64digest',
+					platform: { architecture: 'amd64', os: 'linux' },
+				},
+				{
+					mediaType: 'application/vnd.oci.image.manifest.v1+json',
+					digest: 'sha256:attestdigest',
+					platform: { architecture: 'unknown', os: 'unknown' },
+				},
+			],
+		};
+		assert.doesNotThrow(() => validateManifestLayers(manifest));
+	});
+
+	it('should pass for manifest with no layers property', () => {
+		const manifest = { schemaVersion: 2 };
+		assert.doesNotThrow(() => validateManifestLayers(manifest));
+	});
+
+	it('should pass for manifest with empty layers array', () => {
+		const manifest = { schemaVersion: 2, layers: [] };
+		assert.doesNotThrow(() => validateManifestLayers(manifest));
+	});
+
+	it('should validate all media types in VALID_LAYER_MEDIA_TYPES pass', () => {
+		for (const mediaType of VALID_LAYER_MEDIA_TYPES) {
+			const manifest = {
+				schemaVersion: 2,
+				layers: [{ mediaType, size: 1000, digest: 'sha256:test' }],
+			};
+			assert.doesNotThrow(
+				() => validateManifestLayers(manifest),
+				`Expected ${mediaType} to be valid`,
+			);
+		}
+	});
+
+	it('should use default imageRef in error message when not provided', () => {
+		const manifest = {
+			schemaVersion: 2,
+			layers: [{ mediaType: 'application/octet-stream', size: 100, digest: 'sha256:x' }],
+		};
+		assert.throws(
+			() => validateManifestLayers(manifest),
+			(err) => {
+				assert.match(err.message, /unknown/);
+				return true;
+			},
+		);
+	});
+
+	it('should detect the first invalid layer among valid ones', () => {
+		const manifest = {
+			schemaVersion: 2,
+			layers: [
+				{
+					mediaType: 'application/vnd.oci.image.layer.v1.tar+gzip',
+					size: 5000000,
+					digest: 'sha256:good1',
+				},
+				{
+					mediaType: 'application/vnd.oci.image.layer.v1.tar+gzip',
+					size: 3000000,
+					digest: 'sha256:good2',
+				},
+				{
+					mediaType: 'application/spdx+json',
+					size: 1890,
+					digest: 'sha256:bad',
+				},
+			],
+		};
+		assert.throws(
+			() => validateManifestLayers(manifest, 'test:v1'),
+			(err) => {
+				assert.match(err.message, /layer 2/);
+				return true;
+			},
+		);
+	});
+});
+
+describe('getImageName', () => {
+	it('should extract image name from full reference', () => {
+		assert.equal(getImageName('ghcr.io/n8n-io/n8n:1.0.0'), 'ghcr.io/n8n-io/n8n');
+	});
+
+	it('should handle reference with port', () => {
+		assert.equal(getImageName('registry:5000/image:tag'), 'registry:5000/image');
+	});
+
+	it('should return empty string for empty input', () => {
+		assert.equal(getImageName(''), '');
+	});
+
+	it('should handle image with no tag', () => {
+		assert.equal(getImageName('ghcr.io/n8n-io/n8n'), 'ghcr.io/n8n-io/n8n');
+	});
+});

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -126,7 +126,7 @@ jobs:
             N8N_RELEASE_TYPE=${{ needs.determine-build-context.outputs.release_type }}
           platforms: ${{ matrix.docker_platform }}
           provenance: false # Disabled - using SLSA L3 generator for isolated provenance
-          sbom: true
+          sbom: false # Disabled - inline SBOM with provenance:false creates malformed attestation layers (invalid tar header on pull). Security scanning is handled by Trivy.
           push: ${{ needs.determine-build-context.outputs.push_enabled == 'true' }}
           tags: ${{ steps.determine-tags.outputs.n8n_tags }}
 
@@ -142,7 +142,7 @@ jobs:
             N8N_RELEASE_TYPE=${{ needs.determine-build-context.outputs.release_type }}
           platforms: ${{ matrix.docker_platform }}
           provenance: false # Disabled - using SLSA L3 generator for isolated provenance
-          sbom: true
+          sbom: false # Disabled - inline SBOM with provenance:false creates malformed attestation layers (invalid tar header on pull). Security scanning is handled by Trivy.
           push: ${{ needs.determine-build-context.outputs.push_enabled == 'true' }}
           tags: ${{ steps.determine-tags.outputs.runners_tags }}
 
@@ -158,9 +158,45 @@ jobs:
             N8N_RELEASE_TYPE=${{ needs.determine-build-context.outputs.release_type }}
           platforms: ${{ matrix.docker_platform }}
           provenance: false # Disabled - using SLSA L3 generator for isolated provenance
-          sbom: true
+          sbom: false # Disabled - inline SBOM with provenance:false creates malformed attestation layers (invalid tar header on pull). Security scanning is handled by Trivy.
           push: ${{ needs.determine-build-context.outputs.push_enabled == 'true' }}
           tags: ${{ steps.determine-tags.outputs.runners_distroless_tags }}
+
+      - name: Validate pushed image layers
+        if: needs.determine-build-context.outputs.push_enabled == 'true'
+        run: |
+          # Verify that all image layers have valid tar media types (no malformed attestation blobs)
+          validate_image() {
+            local TAG=$1
+            local NAME=$2
+            if [[ -z "$TAG" ]]; then return; fi
+
+            echo "Validating $NAME layers: $TAG"
+            MANIFEST=$(docker buildx imagetools inspect "$TAG" --raw 2>/dev/null || echo '{}')
+
+            # For single-platform manifests, check layer media types
+            echo "$MANIFEST" | node -e "
+              const manifest = JSON.parse(require('fs').readFileSync('/dev/stdin', 'utf8'));
+              const layers = manifest.layers || [];
+              for (const [i, layer] of layers.entries()) {
+                const mt = layer.mediaType || '';
+                if (mt && !mt.includes('tar') && !mt.includes('gzip') && !mt.includes('zstd')) {
+                  console.error('ERROR: $NAME layer ' + i + ' has non-tar media type: ' + mt);
+                  process.exit(1);
+                }
+              }
+              console.log('  OK: ' + layers.length + ' layers validated');
+            "
+          }
+
+          FIRST_N8N_TAG=$(echo "${{ steps.determine-tags.outputs.n8n_tags }}" | cut -d',' -f1)
+          FIRST_RUNNERS_TAG=$(echo "${{ steps.determine-tags.outputs.runners_tags }}" | cut -d',' -f1)
+          FIRST_DISTROLESS_TAG=$(echo "${{ steps.determine-tags.outputs.runners_distroless_tags }}" | cut -d',' -f1)
+
+          validate_image "$FIRST_N8N_TAG" "n8n"
+          validate_image "$FIRST_RUNNERS_TAG" "runners"
+          validate_image "$FIRST_DISTROLESS_TAG" "runners-distroless"
+          echo "All image layers validated successfully"
 
   create_multi_arch_manifest:
     name: Create Multi-Arch Manifest

--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -12,8 +12,8 @@ ENV SHELL=/bin/sh
 
 WORKDIR /home/node
 
-COPY ./compiled /usr/local/lib/node_modules/n8n
-COPY docker/images/n8n/docker-entrypoint.sh /
+COPY --link ./compiled /usr/local/lib/node_modules/n8n
+COPY --link docker/images/n8n/docker-entrypoint.sh /
 
 RUN cd /usr/local/lib/node_modules/n8n && \
     npm rebuild sqlite3 && \

--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -116,10 +116,10 @@ ENV NODE_ENV=production \
     SHELL=/bin/sh
 
 # Bring `uv` over from python-runner-builder, to make the image easier to extend
-COPY --from=python-runner-builder /usr/local/bin/uv /usr/local/bin/uv
+COPY --link --from=python-runner-builder /usr/local/bin/uv /usr/local/bin/uv
 
 # Bring node over from node-alpine
-COPY --from=node-alpine /usr/local/bin/node /usr/local/bin/node
+COPY --link --from=node-alpine /usr/local/bin/node /usr/local/bin/node
 
 # libstdc++ is required by Node
 # libc6-compat is required by task-runner-launcher
@@ -127,7 +127,7 @@ RUN apk add --no-cache ca-certificates tini libstdc++ libc6-compat && \
     apk del apk-tools
 
 # Bring corepack and pnpm over, to make the image easier to extend
-COPY --from=node-alpine /usr/local/lib/node_modules/corepack /usr/local/lib/node_modules/corepack
+COPY --link --from=node-alpine /usr/local/lib/node_modules/corepack /usr/local/lib/node_modules/corepack
 RUN ln -s ../lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack && \
 		ln -s ../lib/node_modules/corepack/dist/pnpm.js /usr/local/bin/pnpm
 
@@ -136,10 +136,10 @@ RUN addgroup -g 1000 -S runner \
 
 WORKDIR /home/runner
 
-COPY --from=javascript-runner-builder --chown=root:root /app/task-runner-javascript /opt/runners/task-runner-javascript
-COPY --from=python-runner-builder --chown=root:root /app/task-runner-python /opt/runners/task-runner-python
-COPY --from=launcher-downloader /launcher-bin/* /usr/local/bin/
-COPY --chown=root:root docker/images/runners/n8n-task-runners.json /etc/n8n-task-runners.json
+COPY --link --from=javascript-runner-builder --chown=root:root /app/task-runner-javascript /opt/runners/task-runner-javascript
+COPY --link --from=python-runner-builder --chown=root:root /app/task-runner-python /opt/runners/task-runner-python
+COPY --link --from=launcher-downloader /launcher-bin/* /usr/local/bin/
+COPY --link --chown=root:root docker/images/runners/n8n-task-runners.json /etc/n8n-task-runners.json
 
 USER runner
 

--- a/docker/images/runners/Dockerfile.distroless
+++ b/docker/images/runners/Dockerfile.distroless
@@ -133,27 +133,27 @@ FROM node:${NODE_VERSION}-bookworm-slim AS node-debian
 FROM debian:bookworm-slim AS runtime-prep
 
 # Copy Python runtime
-COPY --from=python-runner-builder /usr/local/bin/python3.13 /runtime/usr/local/bin/python3.13
-COPY --from=python-runner-builder /usr/local/lib/python3.13 /runtime/usr/local/lib/python3.13
-COPY --from=python-runner-builder /usr/local/lib/libpython3.13.so* /runtime/usr/local/lib/
+COPY --link --from=python-runner-builder /usr/local/bin/python3.13 /runtime/usr/local/bin/python3.13
+COPY --link --from=python-runner-builder /usr/local/lib/python3.13 /runtime/usr/local/lib/python3.13
+COPY --link --from=python-runner-builder /usr/local/lib/libpython3.13.so* /runtime/usr/local/lib/
 
 # Copy Python dependencies (architecture-specific directories)
 # The /* glob will match x86_64-linux-gnu or aarch64-linux-gnu
-COPY --from=python-runner-builder /lib/*-linux-gnu* /runtime/lib/
-COPY --from=python-runner-builder /usr/lib/*-linux-gnu* /runtime/usr/lib/
+COPY --link --from=python-runner-builder /lib/*-linux-gnu* /runtime/lib/
+COPY --link --from=python-runner-builder /usr/lib/*-linux-gnu* /runtime/usr/lib/
 
 # Copy Node.js runtime
-COPY --from=node-debian /usr/local/bin/node /runtime/usr/local/bin/node
+COPY --link --from=node-debian /usr/local/bin/node /runtime/usr/local/bin/node
 
 # Copy task runners
-COPY --from=javascript-runner-builder /app/task-runner-javascript /runtime/opt/runners/task-runner-javascript
-COPY --from=python-runner-builder /app/task-runner-python /runtime/opt/runners/task-runner-python
+COPY --link --from=javascript-runner-builder /app/task-runner-javascript /runtime/opt/runners/task-runner-javascript
+COPY --link --from=python-runner-builder /app/task-runner-python /runtime/opt/runners/task-runner-python
 
 # Copy launcher
-COPY --from=launcher-downloader /launcher-bin/* /runtime/usr/local/bin/
+COPY --link --from=launcher-downloader /launcher-bin/* /runtime/usr/local/bin/
 
 # Copy configuration
-COPY docker/images/runners/n8n-task-runners.json /runtime/etc/n8n-task-runners.json
+COPY --link docker/images/runners/n8n-task-runners.json /runtime/etc/n8n-task-runners.json
 
 # Create necessary directories with proper permissions
 RUN mkdir -p /runtime/home/runner && \
@@ -179,7 +179,7 @@ ENV NODE_ENV=production \
     HOME=/home/runner
 
 # Copy everything from the prepared runtime filesystem
-COPY --from=runtime-prep --chown=root:root /runtime/ /
+COPY --link --from=runtime-prep --chown=root:root /runtime/ /
 
 WORKDIR /home/runner
 


### PR DESCRIPTION
## Summary

Docker pulls fail with archive/tar: invalid tar header for all n8n versions > 2.3.0. The ~1.89KB layer bc0cdc8ecc2f is a malformed SBOM attestation blob (JSON) incorrectly referenced as a regular image layer.

Root cause: The sbom: true parameter in useblacksmith/build-push-action, combined with provenance: false, causes the builder to generate SBOM JSON data without a proper OCI attestation manifest wrapper. The raw JSON blob ends up referenced as a regular tar layer. When Docker pulls the image and tries to extract it, the JSON fails tar parsing.

Changes:

.github/workflows/docker-build-push.yml — Set sbom: false for all 3 build steps (n8n, runners, runners-distroless). Added post-build validation step that inspects pushed images and verifies all layer media types are valid tar-based formats. Security scanning remains handled by Trivy.
docker/images/n8n/Dockerfile — Use COPY --link for self-contained, independently verifiable layers immune to builder diff-layer bugs.
docker/images/runners/Dockerfile — Same COPY --link hardening for all runtime-stage COPY instructions.
docker/images/runners/Dockerfile.distroless — Same COPY --link hardening across runtime-prep and distroless runtime stages.
.github/scripts/docker/get-manifest-digests.mjs — Added validateManifestLayers() that checks all image layer media types against a whitelist of valid OCI/Docker tar formats before extracting digests for SLSA provenance, catching malformed attestation blobs early.

Fixes #24347 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
