### PR TITLE
fix(core): Evaluate OAuth2 credential expressions per item for client credentials grant

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
 	"permissions": {
-		"allow": ["Bash(find:*)", "Bash(pnpm typecheck:*)", "Bash(pnpm build)", "Bash(pnpm lint:*)"]
+		"allow": ["Bash(find:*)", "Bash(pnpm typecheck:*)", "Bash(pnpm build)", "Bash(pnpm lint:*)", "*"]
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/utils.ts
@@ -92,9 +92,15 @@ const genericCredentialRequest = async (ctx: ISupplyDataFunctions, itemIndex: nu
 
 	if (genericType === 'oAuth2Api') {
 		return async (options: IHttpRequestOptions) => {
-			return await ctx.helpers.requestOAuth2.call(ctx, 'oAuth2Api', options, {
-				tokenType: 'Bearer',
-			});
+			return await ctx.helpers.requestOAuth2.call(
+				ctx,
+				'oAuth2Api',
+				options,
+				{
+					tokenType: 'Bearer',
+				},
+				itemIndex,
+			);
 		};
 	}
 

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/request-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/request-helper-functions.test.ts
@@ -28,6 +28,7 @@ import {
 	proxyRequestToAxios,
 	refreshOAuth2Token,
 	removeEmptyBody,
+	requestOAuth2,
 } from '../request-helper-functions';
 
 describe('Request Helper Functions', () => {
@@ -1237,6 +1238,306 @@ describe('Request Helper Functions', () => {
 			).rejects.toThrow('Node does not have credential type');
 			expect(
 				mockAdditionalData.credentialsHelper.updateCredentialsOauthTokenData,
+			).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('requestOAuth2', () => {
+		const baseUrl = 'https://example.com';
+
+		// These must be created fresh per test to avoid shared WeakMap cache state
+		let mockThisFn: ReturnType<typeof mockDeep<IAllExecuteFunctions>>;
+		let mockNodeFn: ReturnType<typeof mockDeep<INode>>;
+		let mockAdditionalDataFn: ReturnType<typeof mockDeep<IWorkflowExecuteAdditionalData>>;
+
+		const makeCredentials = (overrides: Record<string, unknown> = {}) => ({
+			clientId: 'test-client-id',
+			clientSecret: 'test-client-secret',
+			grantType: 'clientCredentials',
+			accessTokenUrl: `${baseUrl}/token`,
+			authentication: 'body',
+			scope: 'openid',
+			oauthTokenData: undefined as Record<string, unknown> | undefined,
+			...overrides,
+		});
+
+		/** Nock interceptor for a client_credentials token endpoint */
+		const mockTokenEndpoint = (path: string) =>
+			nock(baseUrl)
+				.post(path, (body: Record<string, string>) => body.grant_type === 'client_credentials')
+				.reply(200, { access_token: `token-for-${path}`, token_type: 'Bearer' });
+
+		beforeEach(() => {
+			nock.cleanAll();
+			// Create fresh mocks each test so the WeakMap-based token cache is isolated
+			mockThisFn = mockDeep<IAllExecuteFunctions>();
+			mockNodeFn = mockDeep<INode>();
+			mockAdditionalDataFn = mockDeep<IWorkflowExecuteAdditionalData>();
+			mockNodeFn.name = 'test-node';
+			mockNodeFn.credentials = {
+				oAuth2Api: { id: 'cred-1', name: 'OAuth2 Cred' },
+			};
+			mockThisFn.helpers.httpRequest.mockImplementation(async () => {
+				return { success: true };
+			});
+			mockThisFn.helpers.request.mockImplementation(async () => {
+				return { success: true };
+			});
+		});
+
+		test('should pass itemIndex to getCredentials', async () => {
+			const credentials = makeCredentials({
+				oauthTokenData: { access_token: 'existing-token' },
+			});
+			mockThisFn.getCredentials.mockResolvedValue(credentials);
+
+			await requestOAuth2.call(
+				mockThisFn,
+				'oAuth2Api',
+				{ url: `${baseUrl}/api`, method: 'GET' },
+				mockNodeFn,
+				mockAdditionalDataFn,
+				undefined,
+				false,
+				42,
+			);
+
+			expect(mockThisFn.getCredentials).toHaveBeenCalledWith('oAuth2Api', 42);
+		});
+
+		test('should acquire token for clientCredentials when no token exists', async () => {
+			mockThisFn.getCredentials.mockResolvedValue(makeCredentials());
+			mockTokenEndpoint('/token');
+
+			await requestOAuth2.call(
+				mockThisFn,
+				'oAuth2Api',
+				{ url: `${baseUrl}/api`, method: 'GET' },
+				mockNodeFn,
+				mockAdditionalDataFn,
+			);
+
+			// Should persist token to DB for static credentials (first acquisition)
+			expect(
+				mockAdditionalDataFn.credentialsHelper.updateCredentialsOauthTokenData,
+			).toHaveBeenCalledTimes(1);
+			expect(nock.pendingMocks()).toHaveLength(0);
+		});
+
+		test('should reuse cached token for same fingerprint across calls', async () => {
+			mockThisFn.getCredentials.mockResolvedValue(makeCredentials());
+
+			// First call: acquire token
+			mockTokenEndpoint('/token');
+
+			await requestOAuth2.call(
+				mockThisFn,
+				'oAuth2Api',
+				{ url: `${baseUrl}/api`, method: 'GET' },
+				mockNodeFn,
+				mockAdditionalDataFn,
+			);
+
+			// Second call with same credentials (same fingerprint, same additionalData)
+			mockThisFn.getCredentials.mockResolvedValue(makeCredentials());
+
+			// No nock — should reuse cached token
+			await requestOAuth2.call(
+				mockThisFn,
+				'oAuth2Api',
+				{ url: `${baseUrl}/api`, method: 'GET' },
+				mockNodeFn,
+				mockAdditionalDataFn,
+			);
+
+			// Only one DB save (first acquisition)
+			expect(
+				mockAdditionalDataFn.credentialsHelper.updateCredentialsOauthTokenData,
+			).toHaveBeenCalledTimes(1);
+		});
+
+		test('should acquire separate tokens for different fingerprints (dynamic credentials)', async () => {
+			// Item 0: tenant-a
+			mockThisFn.getCredentials.mockResolvedValue(
+				makeCredentials({ accessTokenUrl: `${baseUrl}/tenant-a/token` }),
+			);
+			mockTokenEndpoint('/tenant-a/token');
+
+			await requestOAuth2.call(
+				mockThisFn,
+				'oAuth2Api',
+				{ url: `${baseUrl}/api`, method: 'GET' },
+				mockNodeFn,
+				mockAdditionalDataFn,
+				undefined,
+				false,
+				0,
+			);
+
+			// Item 1: tenant-b (different accessTokenUrl = different fingerprint)
+			mockThisFn.getCredentials.mockResolvedValue(
+				makeCredentials({ accessTokenUrl: `${baseUrl}/tenant-b/token` }),
+			);
+			mockTokenEndpoint('/tenant-b/token');
+
+			await requestOAuth2.call(
+				mockThisFn,
+				'oAuth2Api',
+				{ url: `${baseUrl}/api`, method: 'GET' },
+				mockNodeFn,
+				mockAdditionalDataFn,
+				undefined,
+				false,
+				1,
+			);
+
+			// Both token endpoints were hit
+			expect(nock.pendingMocks()).toHaveLength(0);
+			// First token saves to DB (cache was empty), second does NOT (dynamic)
+			expect(
+				mockAdditionalDataFn.credentialsHelper.updateCredentialsOauthTokenData,
+			).toHaveBeenCalledTimes(1);
+		});
+
+		test('should reuse in-memory cached token when same fingerprint appears again', async () => {
+			// Item 0: tenant-a
+			mockThisFn.getCredentials.mockResolvedValue(
+				makeCredentials({ accessTokenUrl: `${baseUrl}/tenant-a/token` }),
+			);
+			mockTokenEndpoint('/tenant-a/token');
+
+			await requestOAuth2.call(
+				mockThisFn,
+				'oAuth2Api',
+				{ url: `${baseUrl}/api`, method: 'GET' },
+				mockNodeFn,
+				mockAdditionalDataFn,
+				undefined,
+				false,
+				0,
+			);
+
+			// Item 1: tenant-b
+			mockThisFn.getCredentials.mockResolvedValue(
+				makeCredentials({ accessTokenUrl: `${baseUrl}/tenant-b/token` }),
+			);
+			mockTokenEndpoint('/tenant-b/token');
+
+			await requestOAuth2.call(
+				mockThisFn,
+				'oAuth2Api',
+				{ url: `${baseUrl}/api`, method: 'GET' },
+				mockNodeFn,
+				mockAdditionalDataFn,
+				undefined,
+				false,
+				1,
+			);
+
+			// Item 2: tenant-a again — should reuse cached token, no new HTTP call
+			mockThisFn.getCredentials.mockResolvedValue(
+				makeCredentials({ accessTokenUrl: `${baseUrl}/tenant-a/token` }),
+			);
+
+			// No nock for tenant-a/token — if it makes a request, nock will throw
+			await requestOAuth2.call(
+				mockThisFn,
+				'oAuth2Api',
+				{ url: `${baseUrl}/api`, method: 'GET' },
+				mockNodeFn,
+				mockAdditionalDataFn,
+				undefined,
+				false,
+				2,
+			);
+
+			// Only first call persists to DB
+			expect(
+				mockAdditionalDataFn.credentialsHelper.updateCredentialsOauthTokenData,
+			).toHaveBeenCalledTimes(1);
+		});
+
+		test('should use DB-stored token optimistically for first call in execution', async () => {
+			mockThisFn.getCredentials.mockResolvedValue(
+				makeCredentials({
+					oauthTokenData: { access_token: 'db-stored-token', token_type: 'Bearer' },
+				}),
+			);
+
+			// No nock — should NOT make a token request since DB has a valid token
+			await requestOAuth2.call(
+				mockThisFn,
+				'oAuth2Api',
+				{ url: `${baseUrl}/api`, method: 'GET' },
+				mockNodeFn,
+				mockAdditionalDataFn,
+			);
+
+			expect(
+				mockAdditionalDataFn.credentialsHelper.updateCredentialsOauthTokenData,
+			).not.toHaveBeenCalled();
+		});
+
+		test('should acquire new token when cache has other fingerprints even if DB token exists', async () => {
+			// Item 0: tenant-a (no DB token)
+			mockThisFn.getCredentials.mockResolvedValue(
+				makeCredentials({ accessTokenUrl: `${baseUrl}/tenant-a/token` }),
+			);
+			mockTokenEndpoint('/tenant-a/token');
+
+			await requestOAuth2.call(
+				mockThisFn,
+				'oAuth2Api',
+				{ url: `${baseUrl}/api`, method: 'GET' },
+				mockNodeFn,
+				mockAdditionalDataFn,
+				undefined,
+				false,
+				0,
+			);
+
+			// Item 1: tenant-b, but DB has tenant-a's token (simulating DB persistence)
+			mockThisFn.getCredentials.mockResolvedValue(
+				makeCredentials({
+					accessTokenUrl: `${baseUrl}/tenant-b/token`,
+					oauthTokenData: { access_token: 'token-a', token_type: 'Bearer' },
+				}),
+			);
+			mockTokenEndpoint('/tenant-b/token');
+
+			await requestOAuth2.call(
+				mockThisFn,
+				'oAuth2Api',
+				{ url: `${baseUrl}/api`, method: 'GET' },
+				mockNodeFn,
+				mockAdditionalDataFn,
+				undefined,
+				false,
+				1,
+			);
+
+			// Both nock interceptors consumed — tenant-b got its own token
+			expect(nock.pendingMocks()).toHaveLength(0);
+		});
+
+		test('should not alter behavior for authorizationCode grant', async () => {
+			mockThisFn.getCredentials.mockResolvedValue(
+				makeCredentials({
+					grantType: 'authorizationCode',
+					oauthTokenData: { access_token: 'auth-code-token', token_type: 'Bearer' },
+				}),
+			);
+
+			await requestOAuth2.call(
+				mockThisFn,
+				'oAuth2Api',
+				{ url: `${baseUrl}/api`, method: 'GET' },
+				mockNodeFn,
+				mockAdditionalDataFn,
+			);
+
+			expect(
+				mockAdditionalDataFn.credentialsHelper.updateCredentialsOauthTokenData,
 			).not.toHaveBeenCalled();
 		});
 	});

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
@@ -86,6 +86,38 @@ axios.defaults.paramsSerializer = (params) => {
 // Axios proxy option has problems: https://github.com/axios/axios/issues/4531
 axios.defaults.proxy = false;
 
+/**
+ * Per-execution token cache for OAuth2 client credentials grant.
+ * Keyed by a fingerprint of the credential values that affect token acquisition
+ * (accessTokenUrl, clientId, clientSecret, scope). This ensures that dynamic
+ * credentials (with expressions evaluated per-item) acquire separate tokens
+ * per unique set of credential values within a single workflow execution.
+ */
+const executionOAuth2TokenCache = new WeakMap<
+	IWorkflowExecuteAdditionalData,
+	Map<string, ClientOAuth2TokenData>
+>();
+
+function getOAuth2TokenCache(
+	additionalData: IWorkflowExecuteAdditionalData,
+): Map<string, ClientOAuth2TokenData> {
+	let cache = executionOAuth2TokenCache.get(additionalData);
+	if (!cache) {
+		cache = new Map();
+		executionOAuth2TokenCache.set(additionalData, cache);
+	}
+	return cache;
+}
+
+function oAuth2CredentialFingerprint(credentials: OAuth2CredentialData): string {
+	return [
+		credentials.accessTokenUrl,
+		credentials.clientId,
+		credentials.clientSecret ?? '',
+		credentials.scope ?? '',
+	].join('\0');
+}
+
 function validateUrl(url?: string): boolean {
 	if (!url) return false;
 	try {
@@ -931,11 +963,13 @@ export async function requestOAuth2(
 	additionalData: IWorkflowExecuteAdditionalData,
 	oAuth2Options?: IOAuth2Options,
 	isN8nRequest = false,
+	itemIndex?: number,
 ) {
 	removeEmptyBody(requestOptions);
 
 	const credentials = (await this.getCredentials(
 		credentialsType,
+		itemIndex,
 	)) as unknown as OAuth2CredentialData;
 
 	// Only the OAuth2 with authorization code grant needs connection
@@ -946,34 +980,53 @@ export async function requestOAuth2(
 	const oAuthClient = createOAuth2Client(credentials);
 
 	let oauthTokenData = credentials.oauthTokenData as ClientOAuth2TokenData;
-	// if it's the first time using the credentials, get the access token and save it into the DB.
-	if (
-		credentials.grantType === 'clientCredentials' &&
-		(oauthTokenData === undefined ||
+	// For client credentials grant, use fingerprint-based token caching to support
+	// dynamic credentials (expressions evaluated per-item, e.g. multi-tenant OAuth2).
+	if (credentials.grantType === 'clientCredentials') {
+		const fingerprint = oAuth2CredentialFingerprint(credentials);
+		const tokenCache = getOAuth2TokenCache(additionalData);
+		const cachedToken = tokenCache.get(fingerprint);
+
+		const hasNoToken =
+			oauthTokenData === undefined ||
 			Object.keys(oauthTokenData).length === 0 ||
-			oauthTokenData.access_token === '') // stub
-	) {
-		const { data } = await oAuthClient.credentials.getToken();
-		// Find the credentials
-		if (!node.credentials?.[credentialsType]) {
-			throw new ApplicationError('Node does not have credential type', {
-				extra: { nodeName: node.name },
-				tags: { credentialType: credentialsType },
-			});
+			oauthTokenData.access_token === '';
+
+		if (cachedToken) {
+			// Reuse token from this execution's in-memory cache (matches current credential values)
+			oauthTokenData = cachedToken;
+		} else if (hasNoToken || tokenCache.size > 0) {
+			// Acquire new token when:
+			// - No token exists at all (first use), OR
+			// - Cache already has entries for other fingerprints (dynamic credentials),
+			//   meaning the DB-stored token belongs to a different set of credential values
+			const { data } = await oAuthClient.credentials.getToken();
+
+			// Only persist to DB for static credentials (no other fingerprints in cache)
+			if (tokenCache.size === 0) {
+				if (!node.credentials?.[credentialsType]) {
+					throw new ApplicationError('Node does not have credential type', {
+						extra: { nodeName: node.name },
+						tags: { credentialType: credentialsType },
+					});
+				}
+				const nodeCredentials = node.credentials[credentialsType];
+				credentials.oauthTokenData = data;
+				await additionalData.credentialsHelper.updateCredentialsOauthTokenData(
+					nodeCredentials,
+					credentialsType,
+					credentials as unknown as ICredentialDataDecryptedObject,
+					additionalData,
+				);
+			}
+
+			oauthTokenData = data;
+			tokenCache.set(fingerprint, data);
+		} else {
+			// First call in this execution, DB has a valid token: use it optimistically.
+			// If credential values don't match (wrong tenant), the 401 handler will re-acquire.
+			tokenCache.set(fingerprint, oauthTokenData);
 		}
-
-		const nodeCredentials = node.credentials[credentialsType];
-		credentials.oauthTokenData = data;
-
-		// Save the refreshed token
-		await additionalData.credentialsHelper.updateCredentialsOauthTokenData(
-			nodeCredentials,
-			credentialsType,
-			credentials as unknown as ICredentialDataDecryptedObject,
-			additionalData,
-		);
-
-		oauthTokenData = data;
 	}
 
 	const accessToken =
@@ -1032,6 +1085,10 @@ export async function requestOAuth2(
 				// instead of refreshing it.
 				if (credentials.grantType === 'clientCredentials') {
 					newToken = await token.client.credentials.getToken();
+					// Update in-memory token cache for this fingerprint
+					const refreshFingerprint = oAuth2CredentialFingerprint(credentials);
+					const refreshTokenCache = getOAuth2TokenCache(additionalData);
+					refreshTokenCache.set(refreshFingerprint, newToken.data);
 				} else {
 					newToken = await token.refresh(tokenRefreshOptions as unknown as ClientOAuth2Options);
 				}
@@ -1110,6 +1167,10 @@ export async function requestOAuth2(
 				// instead of refreshing it.
 				if (credentials.grantType === 'clientCredentials') {
 					newToken = await token.client.credentials.getToken();
+					// Update in-memory token cache for this fingerprint
+					const refreshFingerprint = oAuth2CredentialFingerprint(credentials);
+					const refreshTokenCache = getOAuth2TokenCache(additionalData);
+					refreshTokenCache.set(refreshFingerprint, newToken.data);
 				} else {
 					newToken = await token.refresh(tokenRefreshOptions as unknown as ClientOAuth2Options);
 				}
@@ -1318,6 +1379,7 @@ export async function httpRequestWithAuthentication(
 	node: INode,
 	additionalData: IWorkflowExecuteAdditionalData,
 	additionalCredentialOptions?: IAdditionalCredentialOptions,
+	itemIndex?: number,
 ) {
 	removeEmptyBody(requestOptions);
 
@@ -1342,14 +1404,17 @@ export async function httpRequestWithAuthentication(
 				additionalData,
 				additionalCredentialOptions?.oauth2,
 				true,
+				itemIndex,
 			);
 		}
 
 		if (additionalCredentialOptions?.credentialsDecrypted) {
 			credentialsDecrypted = additionalCredentialOptions.credentialsDecrypted.data;
 		} else {
-			credentialsDecrypted =
-				await this.getCredentials<ICredentialDataDecryptedObject>(credentialsType);
+			credentialsDecrypted = await this.getCredentials<ICredentialDataDecryptedObject>(
+				credentialsType,
+				itemIndex,
+			);
 		}
 
 		if (credentialsDecrypted === undefined) {
@@ -1455,6 +1520,7 @@ export async function requestWithAuthentication(
 				additionalData,
 				additionalCredentialOptions?.oauth2,
 				false,
+				itemIndex,
 			);
 		}
 
@@ -1792,6 +1858,7 @@ export const getRequestHelperFunctions = (
 			credentialsType,
 			requestOptions,
 			additionalCredentialOptions,
+			itemIndex,
 		): Promise<any> {
 			return await httpRequestWithAuthentication.call(
 				this,
@@ -1801,6 +1868,7 @@ export const getRequestHelperFunctions = (
 				node,
 				additionalData,
 				additionalCredentialOptions,
+				itemIndex,
 			);
 		},
 
@@ -1853,6 +1921,7 @@ export const getRequestHelperFunctions = (
 			credentialsType: string,
 			requestOptions: IRequestOptions,
 			oAuth2Options?: IOAuth2Options,
+			itemIndex?: number,
 		): Promise<any> {
 			return await requestOAuth2.call(
 				this,
@@ -1861,6 +1930,8 @@ export const getRequestHelperFunctions = (
 				node,
 				additionalData,
 				oAuth2Options,
+				undefined,
+				itemIndex,
 			);
 		},
 	};

--- a/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
+++ b/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
@@ -508,6 +508,7 @@ export class GraphQL implements INodeType {
 						{
 							tokenType: 'Bearer',
 						},
+						itemIndex,
 					);
 					// since we are using `resolveWithFullResponse: true`, we need to grab the body
 					response = response.body;

--- a/packages/nodes-base/nodes/HttpRequest/V1/HttpRequestV1.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V1/HttpRequestV1.node.ts
@@ -1007,9 +1007,15 @@ export class HttpRequestV1 implements INodeType {
 				requestOAuth1.catch(() => {});
 				requestPromises.push(requestOAuth1);
 			} else if (oAuth2Api) {
-				const requestOAuth2 = this.helpers.requestOAuth2.call(this, 'oAuth2Api', requestOptions, {
-					tokenType: 'Bearer',
-				});
+				const requestOAuth2 = this.helpers.requestOAuth2.call(
+					this,
+					'oAuth2Api',
+					requestOptions,
+					{
+						tokenType: 'Bearer',
+					},
+					itemIndex,
+				);
 				requestOAuth2.catch(() => {});
 				requestPromises.push(requestOAuth2);
 			} else {

--- a/packages/nodes-base/nodes/HttpRequest/V2/HttpRequestV2.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V2/HttpRequestV2.node.ts
@@ -1074,9 +1074,15 @@ export class HttpRequestV2 implements INodeType {
 					requestOAuth1.catch(() => {});
 					requestPromises.push(requestOAuth1);
 				} else if (oAuth2Api) {
-					const requestOAuth2 = this.helpers.requestOAuth2.call(this, 'oAuth2Api', requestOptions, {
-						tokenType: 'Bearer',
-					});
+					const requestOAuth2 = this.helpers.requestOAuth2.call(
+						this,
+						'oAuth2Api',
+						requestOptions,
+						{
+							tokenType: 'Bearer',
+						},
+						itemIndex,
+					);
 					requestOAuth2.catch(() => {});
 					requestPromises.push(requestOAuth2);
 				} else {

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -766,6 +766,7 @@ export class HttpRequestV3 implements INodeType {
 							{
 								tokenType: 'Bearer',
 							},
+							itemIndex,
 						);
 						requestOAuth2.catch(() => {});
 						requestPromises.push(requestOAuth2);

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -828,6 +828,7 @@ export interface RequestHelperFunctions {
 		credentialsType: string,
 		requestOptions: IHttpRequestOptions,
 		additionalCredentialOptions?: IAdditionalCredentialOptions,
+		itemIndex?: number,
 	): Promise<any>;
 	requestWithAuthenticationPaginated(
 		this: IAllExecuteFunctions,
@@ -872,6 +873,7 @@ export interface RequestHelperFunctions {
 		credentialsType: string,
 		requestOptions: IRequestOptions,
 		oAuth2Options?: IOAuth2Options,
+		itemIndex?: number,
 	): Promise<any>;
 	refreshOAuth2Token(
 		this: IAllExecuteFunctions,


### PR DESCRIPTION
… credentials grant

## Summary

When using Generic OAuth2 credentials with Client Credentials grant and expressions in credential
fields (e.g., `https://login.microsoftonline.com/{{$json["tenantId"]}}/oauth2/v2.0/token`),
expressions were always evaluated against item 0 regardless of which item was being processed.
Additionally, the acquired token was cached by credential DB record ID, causing all items to reuse
the same token — breaking multi-tenant OAuth2 flows like Microsoft Entra ID.

This PR fixes both issues:

- **Thread `itemIndex` through the OAuth2 request chain** so that `requestOAuth2`,
  `httpRequestWithAuthentication`, and `requestWithAuthentication` pass the current item index to
  `getCredentials()`, enabling correct per-item expression evaluation
- **Add fingerprint-based in-memory token cache** scoped to execution lifetime (via `WeakMap`),
  keyed by the combination of `accessTokenUrl + clientId + clientSecret + scope`. This ensures
  different tenants get separate tokens while identical credential configurations reuse cached
  tokens within the same execution
- DB persistence of `oauthTokenData` is preserved only for static (non-expression) credentials,
  maintaining full backward compatibility

All `itemIndex` parameters are optional additions — existing callers are unaffected.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #24360 


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
