### PR TITLE
fix: Remove redundant builder-log check causing responder double-answering

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/agents/supervisor.agent.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/agents/supervisor.agent.ts
@@ -14,7 +14,7 @@ import {
 	buildSimplifiedExecutionContext,
 	buildWorkflowSummary,
 } from '../utils/context-builders';
-import { summarizeCoordinationLog } from '../utils/coordination-log';
+import { getCurrentTurnEntries, summarizeCoordinationLog } from '../utils/coordination-log';
 import type { ChatPayload } from '../workflow-builder-agent';
 
 const ROUTING_OPTIONS_WITH_ASSISTANT = ['responder', 'discovery', 'builder', 'assistant'] as const;
@@ -94,9 +94,10 @@ export class SupervisorAgent {
 			contextParts.push('</workflow_summary>');
 		}
 
-		if (context.coordinationLog.length > 0) {
+		const currentTurnLog = getCurrentTurnEntries(context.coordinationLog);
+		if (currentTurnLog.length > 0) {
 			contextParts.push('<completed_phases>');
-			contextParts.push(summarizeCoordinationLog(context.coordinationLog));
+			contextParts.push(summarizeCoordinationLog(currentTurnLog));
 			contextParts.push('</completed_phases>');
 		}
 

--- a/packages/@n8n/ai-workflow-builder.ee/src/multi-agent-workflow-subgraphs.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/multi-agent-workflow-subgraphs.ts
@@ -316,7 +316,7 @@ export function createMultiAgentWorkflowWithSubgraphs(config: MultiAgentSubgraph
 				// (streamed to the frontend via custom events). If the SDK returned
 				// empty text, fall through to the normal responder so it can generate
 				// a meaningful reply instead of silently emitting nothing.
-				if (assistantEntry?.output && !hasBuilderPhaseInLog(state.coordinationLog)) {
+				if (assistantEntry?.output) {
 					logger?.debug('[responder] Forwarding assistant response (no credits consumed)', {
 						outputLength: assistantEntry.output.length,
 						outputPreview: assistantEntry.output.substring(0, 100),

--- a/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/supervisor.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/supervisor.prompt.ts
@@ -29,12 +29,17 @@ const ROUTING_DECISION_TREE_WITH_ASSISTANT = `1. Is user asking a conversational
    Examples: "why is this node failing?", "how do I set up Gmail credentials?", "what does this error mean?", "how does the HTTP Request node work?", "help me debug this"
    Examples with selected nodes: "why is this failing?", "help me fix this error"
 
-3. Is the user asking you to DO something to the workflow (create, modify, configure, set up nodes)? → discovery or builder
+3. Does the message contain BOTH a knowledge question AND an action request? → discovery or builder
+   When the user asks a question AND requests an action in the same message, always prefer the action path.
+   The responder will address the knowledge question when summarizing the build result.
+   Examples: "what are Slack credentials? set them up", "how does OAuth work? add it to this node", "explain webhooks and add one to my workflow"
+
+4. Is the user asking you to DO something to the workflow (create, modify, configure, set up nodes)? → discovery or builder
    IMPORTANT: If the message is an action request (imperative/instructional tone), it goes to discovery or builder, NOT assistant.
    Examples: "set them up", "configure the node", "now add a Slack node", "connect these", "do it"
-   Continue to steps 4-6 to choose between discovery and builder.
+   Continue to steps 5-7 to choose between discovery and builder.
 
-4. Does the request involve NEW or DIFFERENT node types? → discovery
+5. Does the request involve NEW or DIFFERENT node types? → discovery
    Examples:
    - "Build a workflow that..." (new workflow)
    - "Use [ServiceB] instead of [ServiceA]" (replacing node type)
@@ -42,11 +47,11 @@ const ROUTING_DECISION_TREE_WITH_ASSISTANT = `1. Is user asking a conversational
    - "Switch from [ServiceA] to [ServiceB]" (swapping services)
    - "Add something before/after this" (needs discovery to find what to add)
 
-5. Is the request about connecting/disconnecting existing nodes? → builder
+6. Is the request about connecting/disconnecting existing nodes? → builder
    Examples: "Connect node A to node B", "Remove the connection to X"
    Examples with selected nodes: "connect this to X", "disconnect this", "add X before/after this" (after discovery)
 
-6. Is the request about changing VALUES in existing nodes? → builder
+7. Is the request about changing VALUES in existing nodes? → builder
    Examples:
    - "Change the URL to https://..."
    - "Set the timeout to 30 seconds"
@@ -91,6 +96,12 @@ ACTION vs KNOWLEDGE:
 - "Now set them up for this workflow" = ACTION REQUEST = builder (imperative tone = action, not question)
 - "Use [ServiceB] instead of [ServiceA]" = REPLACEMENT = discovery (new node type needed)
 - "Change the [ServiceA] API key" = CONFIGURATION = builder (same node, different value)
+
+MIXED INTENT (question + action in same message):
+- "What are Slack credentials? Set them up" = ACTION (builder) — responder will explain credentials in summary
+- "How does OAuth work? Add it to this node" = ACTION (discovery/builder) — responder covers the explanation
+- "Explain webhooks and add one" = ACTION (discovery) — responder addresses the explanation part
+- When in doubt between assistant and action, prefer action — the responder can always explain
 
 COMMON PATTERNS:
 - Polite wrappers: "Help me set up X" / "Can you configure this?" / "Could you add a node?" = ACTION = discovery or builder (not assistant)

--- a/packages/@n8n/ai-workflow-builder.ee/src/utils/coordination-log.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/utils/coordination-log.ts
@@ -186,6 +186,23 @@ export function getNextPhaseFromLog(log: CoordinationLogEntry[]): RoutingDecisio
 }
 
 /**
+ * Get entries from the current turn only.
+ * A turn ends when the responder completes, so current-turn entries
+ * are those after the last completed responder entry.
+ * This prevents stale entries from previous turns leaking into context.
+ */
+export function getCurrentTurnEntries(log: CoordinationLogEntry[]): CoordinationLogEntry[] {
+	const lastResponderIndex = log.findLastIndex(
+		(entry) => entry.phase === 'responder' && entry.status === 'completed',
+	);
+
+	// No previous responder completion — entire log is the current turn
+	if (lastResponderIndex === -1) return log;
+
+	return log.slice(lastResponderIndex + 1);
+}
+
+/**
  * Build a summary of completed phases for debugging/logging
  */
 export function summarizeCoordinationLog(log: CoordinationLogEntry[]): string {


### PR DESCRIPTION
## Summary

- Fix responder double-answering after assistant in multi-turn `mergeAskBuild` sessions
- Remove redundant `!hasBuilderPhaseInLog(state.coordinationLog)` check from the responder short-circuit condition
- The `lastCompletedPhase === 'assistant'` check already guarantees builder didn't run after assistant in the current turn

### Root Cause

The `coordinationLog` uses an append-only reducer and persists across turns via the checkpointer. After a build turn (Turn 1), builder entries remain in the log. In Turn 2 (ask), `hasBuilderPhaseInLog` returns `true` on stale entries, causing the short-circuit to fail and the responder LLM to generate a second answer.