### PR TITLE
fix(core): Remove --tunnel option after hooks.n8n.cloud shutdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "setup-backend-module": "node scripts/ensure-zx.mjs && zx scripts/backend-module/setup.mjs",
     "start": "run-script-os",
     "start:default": "cd packages/cli/bin && ./n8n",
-    "start:tunnel": "./packages/cli/bin/n8n start --tunnel",
     "start:windows": "cd packages/cli/bin && n8n",
     "test": "JEST_JUNIT_CLASSNAME={filepath} turbo run test",
     "test:ci": "turbo run test --continue --concurrency=1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -105,7 +105,6 @@
     "@n8n/decorators": "workspace:*",
     "@n8n/di": "workspace:*",
     "@n8n/errors": "workspace:*",
-    "@n8n/localtunnel": "3.0.0",
     "@n8n/n8n-nodes-langchain": "workspace:*",
     "@n8n/permissions": "workspace:*",
     "@n8n/task-runner": "workspace:*",

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -300,9 +300,16 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 		}
 
 		if (flags.tunnel) {
+			this.logger.error('');
+			this.logger.error('========================================================');
+			this.logger.error('The --tunnel option is no longer available.');
+			this.logger.error('The tunnel service (hooks.n8n.cloud) has been shut down.');
+			this.logger.error('');
 			this.logger.error(
-				'The --tunnel option is no longer available. The tunnel service (hooks.n8n.cloud) has been shut down. For local development with webhooks, consider using a third-party tunneling service such as ngrok or Cloudflare Tunnel.',
+				'For local development with webhooks, consider using a third-party tunneling service such as ngrok or Cloudflare Tunnel.',
 			);
+			this.logger.error('========================================================');
+			this.logger.error('');
 			process.exit(1);
 		}
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -300,8 +300,8 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 		}
 
 		if (flags.tunnel) {
-			this.log(
-				'\nThe --tunnel option is no longer available. The tunnel service (hooks.n8n.cloud) has been shut down.\nFor local development with webhooks, consider using a third-party tunneling service such as ngrok or Cloudflare Tunnel.',
+			this.logger.error(
+				'The --tunnel option is no longer available. The tunnel service (hooks.n8n.cloud) has been shut down. For local development with webhooks, consider using a third-party tunneling service such as ngrok or Cloudflare Tunnel.',
 			);
 			process.exit(1);
 		}

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -7,7 +7,7 @@ import { Container } from '@n8n/di';
 import glob from 'fast-glob';
 import { createReadStream, createWriteStream, existsSync } from 'fs';
 import { mkdir } from 'fs/promises';
-import { jsonParse, randomString, type IWorkflowExecutionDataProcess } from 'n8n-workflow';
+import { jsonParse, type IWorkflowExecutionDataProcess } from 'n8n-workflow';
 import path from 'path';
 import replaceStream from 'replacestream';
 import { pipeline } from 'stream/promises';
@@ -52,7 +52,7 @@ const flagsSchema = z.object({
 @Command({
 	name: 'start',
 	description: 'Starts n8n. Makes Web-UI available and starts active workflows',
-	examples: ['', '--tunnel', '-o', '--tunnel -o'],
+	examples: ['', '-o'],
 	flagsSchema,
 })
 export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
@@ -300,31 +300,10 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 		}
 
 		if (flags.tunnel) {
-			this.log('\nWaiting for tunnel ...');
-
-			let tunnelSubdomain =
-				process.env.N8N_TUNNEL_SUBDOMAIN ?? this.instanceSettings.tunnelSubdomain ?? '';
-
-			if (tunnelSubdomain === '') {
-				// When no tunnel subdomain did exist yet create a new random one
-				tunnelSubdomain = randomString(24).toLowerCase();
-
-				this.instanceSettings.update({ tunnelSubdomain });
-			}
-
-			const { default: localtunnel } = await import('@n8n/localtunnel');
-			const { port } = this.globalConfig;
-
-			const webhookTunnel = await localtunnel(port, {
-				host: 'https://hooks.n8n.cloud',
-				subdomain: tunnelSubdomain,
-			});
-
-			process.env.WEBHOOK_URL = `${webhookTunnel.url}/`;
-			this.log(`Tunnel URL: ${process.env.WEBHOOK_URL}\n`);
 			this.log(
-				'IMPORTANT! Do not share with anybody as it would give people access to your n8n instance!',
+				'\nThe --tunnel option is no longer available. The tunnel service (hooks.n8n.cloud) has been shut down.\nFor local development with webhooks, consider using a third-party tunneling service such as ngrok or Cloudflare Tunnel.',
 			);
+			process.exit(1);
 		}
 
 		if (this.globalConfig.database.isLegacySqlite) {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -301,14 +301,12 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 
 		if (flags.tunnel) {
 			this.logger.error('');
-			this.logger.error('========================================================');
 			this.logger.error('The --tunnel option is no longer available.');
 			this.logger.error('The tunnel service (hooks.n8n.cloud) has been shut down.');
 			this.logger.error('');
 			this.logger.error(
 				'For local development with webhooks, consider using a third-party tunneling service such as ngrok or Cloudflare Tunnel.',
 			);
-			this.logger.error('========================================================');
 			this.logger.error('');
 			process.exit(1);
 		}

--- a/packages/core/src/instance-settings/instance-settings.ts
+++ b/packages/core/src/instance-settings/instance-settings.ts
@@ -18,9 +18,8 @@ interface ReadOnlySettings {
 	encryptionKey: string;
 }
 
-interface WritableSettings {
-	tunnelSubdomain?: string;
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface WritableSettings {}
 
 type Settings = ReadOnlySettings & WritableSettings;
 
@@ -135,10 +134,6 @@ export class InstanceSettings {
 		return this.settings.encryptionKey;
 	}
 
-	get tunnelSubdomain() {
-		return this.settings.tunnelSubdomain;
-	}
-
 	/**
 	 * Whether this instance is running inside a Docker/Podman/Kubernetes container.
 	 */
@@ -186,7 +181,7 @@ export class InstanceSettings {
 
 			if (!inTest) this.logger.debug(`User settings loaded from: ${this.settingsFile}`);
 
-			const { encryptionKey, tunnelSubdomain } = settings;
+			const { encryptionKey } = settings;
 
 			if (encryptionKeyFromEnv && encryptionKey !== encryptionKeyFromEnv) {
 				throw new ApplicationError(
@@ -194,7 +189,7 @@ export class InstanceSettings {
 				);
 			}
 
-			return { encryptionKey, tunnelSubdomain };
+			return { encryptionKey };
 		}
 
 		if (!encryptionKeyFromEnv) {

--- a/packages/nodes-base/nodes/Github/GithubTrigger.node.ts
+++ b/packages/nodes-base/nodes/Github/GithubTrigger.node.ts
@@ -496,7 +496,7 @@ export class GithubTrigger implements INodeType {
 				if (webhookUrl.includes('//localhost')) {
 					throw new NodeOperationError(
 						this.getNode(),
-						'The Webhook can not work on "localhost". Please, either setup n8n on a custom domain or start with "--tunnel"!',
+						'The Webhook can not work on "localhost". Please set up n8n on a custom domain or use a tunneling service.',
 					);
 				}
 

--- a/packages/nodes-base/nodes/Onfleet/OnfleetTrigger.node.ts
+++ b/packages/nodes-base/nodes/Onfleet/OnfleetTrigger.node.ts
@@ -79,7 +79,7 @@ export class OnfleetTrigger implements INodeType {
 				if (webhookUrl.includes('//localhost')) {
 					throw new NodeOperationError(
 						this.getNode(),
-						'The Webhook can not work on "localhost". Please, either setup n8n on a custom domain or start with "--tunnel"!',
+						'The Webhook can not work on "localhost". Please set up n8n on a custom domain or use a tunneling service.',
 					);
 				}
 				// Webhook name according to the field

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1529,9 +1529,6 @@ importers:
       '@n8n/errors':
         specifier: workspace:*
         version: link:../@n8n/errors
-      '@n8n/localtunnel':
-        specifier: 3.0.0
-        version: 3.0.0
       '@n8n/n8n-nodes-langchain':
         specifier: workspace:*
         version: link:../@n8n/nodes-langchain
@@ -6352,10 +6349,6 @@ packages:
     resolution: {integrity: sha512-AAwRb5vXFcY4L+FvZ7LZusDuZ0vEe0Zm8ohn1FM6/X7A3bj4mqmkAcGRWuvC2JwSygNwHAAmMnAI73vPHeqsHA==}
     engines: {node: '>=18'}
 
-  '@n8n/localtunnel@3.0.0':
-    resolution: {integrity: sha512-0t/AUiZ8Oqo7AqYp2q2qmEC2p2lPP4CEdrGRB0J6nSC7ivOtr0p46Pw739UvUfJMU1bIKvzHIc5M9wCjH5Byjg==}
-    engines: {node: '>=18.0.0'}
-
   '@n8n/tournament@1.0.6':
     resolution: {integrity: sha512-UGSxYXXVuOX0yL6HTLBStKYwLIa0+JmRKiSZSCMcM2s2Wax984KWT6XIA1TR/27i7yYpDk1MY14KsTPnuEp27A==}
     engines: {node: '>=20.15', pnpm: '>=9.5'}
@@ -10864,15 +10857,6 @@ packages:
 
   debug@4.3.5:
     resolution: {integrity: sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  debug@4.3.6:
-    resolution: {integrity: sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -22867,13 +22851,6 @@ snapshots:
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
 
-  '@n8n/localtunnel@3.0.0':
-    dependencies:
-      axios: 1.13.5(debug@4.3.6)
-      debug: 4.3.6
-    transitivePeerDependencies:
-      - supports-color
-
   '@n8n/tournament@1.0.6':
     dependencies:
       '@n8n_io/riot-tmpl': 4.0.1
@@ -26854,25 +26831,9 @@ snapshots:
       axios: 1.13.5(debug@4.4.1)
       is-retry-allowed: 2.2.0
 
-  axios@1.13.5(debug@4.3.6):
-    dependencies:
-      follow-redirects: 1.15.11(debug@4.3.6)
-      form-data: 4.0.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.5(debug@4.4.1):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.1)
-      form-data: 4.0.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
-  axios@1.13.5(debug@4.4.3):
-    dependencies:
-      follow-redirects: 1.15.11(debug@4.4.3)
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -28231,10 +28192,6 @@ snapshots:
       ms: 2.1.2
 
   debug@4.3.5:
-    dependencies:
-      ms: 2.1.2
-
-  debug@4.3.6:
     dependencies:
       ms: 2.1.2
 
@@ -29709,17 +29666,9 @@ snapshots:
 
   fn.name@1.1.0: {}
 
-  follow-redirects@1.15.11(debug@4.3.6):
-    optionalDependencies:
-      debug: 4.3.6
-
   follow-redirects@1.15.11(debug@4.4.1):
     optionalDependencies:
       debug: 4.4.1(supports-color@8.1.1)
-
-  follow-redirects@1.15.11(debug@4.4.3):
-    optionalDependencies:
-      debug: 4.4.3
 
   for-each@0.3.5:
     dependencies:
@@ -30426,7 +30375,7 @@ snapshots:
       '@types/debug': 4.1.12
       '@types/node': 20.19.21
       '@types/tough-cookie': 4.0.5
-      axios: 1.13.5(debug@4.4.3)
+      axios: 1.13.5(debug@4.4.1)
       camelcase: 6.3.0
       debug: 4.4.3
       dotenv: 16.6.1
@@ -30436,7 +30385,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.2
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.13.5)
+      retry-axios: 2.6.0(axios@1.13.5(debug@4.4.3))
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -34850,7 +34799,7 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
-  retry-axios@2.6.0(axios@1.13.5):
+  retry-axios@2.6.0(axios@1.13.5(debug@4.4.3)):
     dependencies:
       axios: 1.13.5(debug@4.4.1)
 


### PR DESCRIPTION
## Summary

The tunnel service hosted at `hooks.n8n.cloud` has been shut down. This PR removes the `--tunnel` CLI option and replaces its logic with a clear error message directing users to third-party tunneling alternatives like ngrok or Cloudflare Tunnel. Also updates webhook error messages in GitHub and Onfleet trigger nodes to remove outdated `--tunnel` suggestions.

<img width="621" height="106" alt="image" src="https://github.com/user-attachments/assets/0b19c931-b24d-421a-aecf-ba60f4b2e487" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2400

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [ ] Docs updated or follow-up ticket created
- [ ] Tests included