### PR TITLE
fix: Address issue with resolving EKS Pod Identity Credentials

### DIFF
--- a/packages/nodes-base/credentials/common/aws/system-credentials-utils.test.ts
+++ b/packages/nodes-base/credentials/common/aws/system-credentials-utils.test.ts
@@ -412,7 +412,7 @@ describe('system-credentials-utils', () => {
 				expect.objectContaining({
 					headers: {
 						'User-Agent': 'n8n-aws-credential',
-						Authorization: 'Bearer test-auth-token',
+						Authorization: 'test-auth-token',
 					},
 				}),
 			);
@@ -491,7 +491,7 @@ describe('system-credentials-utils', () => {
 				expect.objectContaining({
 					headers: {
 						'User-Agent': 'n8n-aws-credential',
-						Authorization: 'Bearer file-based-token',
+						Authorization: 'file-based-token',
 					},
 				}),
 			);
@@ -531,7 +531,7 @@ describe('system-credentials-utils', () => {
 				expect.objectContaining({
 					headers: {
 						'User-Agent': 'n8n-aws-credential',
-						Authorization: 'Bearer file-token-with-whitespace',
+						Authorization: 'file-token-with-whitespace',
 					},
 				}),
 			);
@@ -577,7 +577,7 @@ describe('system-credentials-utils', () => {
 				expect.objectContaining({
 					headers: {
 						'User-Agent': 'n8n-aws-credential',
-						Authorization: 'Bearer fallback-direct-token',
+						Authorization: 'fallback-direct-token',
 					},
 				}),
 			);
@@ -618,7 +618,7 @@ describe('system-credentials-utils', () => {
 				expect.objectContaining({
 					headers: {
 						'User-Agent': 'n8n-aws-credential',
-						Authorization: 'Bearer file-token-has-priority',
+						Authorization: 'file-token-has-priority',
 					},
 				}),
 			);
@@ -657,7 +657,7 @@ describe('system-credentials-utils', () => {
 				expect.objectContaining({
 					headers: {
 						'User-Agent': 'n8n-aws-credential',
-						Authorization: 'Bearer direct-token',
+						Authorization: 'direct-token',
 					},
 				}),
 			);

--- a/packages/nodes-base/credentials/common/aws/system-credentials-utils.ts
+++ b/packages/nodes-base/credentials/common/aws/system-credentials-utils.ts
@@ -206,6 +206,10 @@ async function getContainerMetadataCredentials() {
  * it includes the Authorization header as required by AWS for Pod Identity credential endpoints.
  * The file-based token takes precedence over the direct token, following AWS SDK behavior.
  *
+ * Unlike when retrieving AWS Credentials from Container Metadata for ECS/Fargate, the Authorization
+ * header should NOT include a 'Bearer ' prefix as the EKS Pod Identity Agent uses the header value
+ * directly when making the AssumeRoleForPodIdentity API call.
+ *
  * @returns Promise resolving to credentials object or null if not running with EKS Pod Identity
  *
  * @see {@link https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html EKS Pod Identities}
@@ -239,7 +243,7 @@ async function getPodIdentityCredentials() {
 		};
 
 		if (authToken) {
-			headers.Authorization = `Bearer ${authToken}`;
+			headers.Authorization = `${authToken}`;
 		}
 
 		const response = await fetch(fullUri, {


### PR DESCRIPTION
## Summary
This PR is to fix the non-working EKS Pod Identity credentials resolver when using the system credentials option with AWS Credentials.

#21584 introduced support for the `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` required for EKS Pod Identity Authentication. There is an existing bug which predates #21584 which erroneously adds 'Bearer ' as a prefix to the Authorization header. When the EKS Pod Identity Agent makes the AssumeRoleForPodIdentity API call, it expects to find just the token in the Authorization header and passes the value of the header direct to the API as the ServiceAccountToken part of the request.

When a 'Bearer ' prefix is added to the Authorization header, this is also passed to the API call and results in the following error:

`Error fetching credentials: Service account token cannot be parsed: token is malformed: could not base64 decode header: illegal base64 data at input byte 6`

This PR removes the Bearer prefix from the Authorization header when making a call to resolve Pod Identity credentials only. The Bearer prefix is still present when resolving credentials from container metadata for ECS/Fargate.

## Related links
[EKS Pod Identity Usage of the header](https://github.com/aws/eks-pod-identity-agent/blob/2134e9093c2577e2560b96881a997eb9e18d6a25/pkg/handlers/eks_credential_handler.go#L78)

## Related Linear tickets, Github issues, and Community forum posts

fixes #23584

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)