### PR TITLE
fix(editor): Restyle corner radii and alignment (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.vue
@@ -148,17 +148,20 @@ const handleClick = (event: MouseEvent) => {
 	--button--color--background-hover: transparent;
 	--button--color--background-active: transparent;
 	--button--color: light-dark(var(--color--neutral-900), var(--color--neutral-100));
-	--button--shadow: none;
-	--button--shadow--hover: none;
-	--button--shadow--active: none;
+	--button--shadow: 0 0 0 0 transparent;
+	--button--shadow--hover: 0 0 0 0 transparent;
+	--button--shadow--active: 0 0 0 0 transparent;
+	--button--border--shadow: 0 0 0 0 transparent;
+	--button--border--shadow--hover: 0 0 0 0 transparent;
+	--button--border--shadow--active: 0 0 0 0 transparent;
 	--button--border-color: transparent;
 	--button--border-color--hover: transparent;
 	--button--border-color--active: transparent;
 
 	background-color: var(--button--color--background);
 	color: var(--button--color);
-	box-shadow: var(--button--shadow);
-	border: 1px solid var(--button--border-color);
+	box-shadow: var(--button--shadow), var(--button--border--shadow);
+	border: none;
 
 	> * {
 		grid-area: 1 / 1;
@@ -166,14 +169,12 @@ const handleClick = (event: MouseEvent) => {
 
 	&:hover {
 		background-color: var(--button--color--background-hover);
-		box-shadow: var(--button--shadow--hover);
-		border-color: var(--button--border-color--hover);
+		box-shadow: var(--button--shadow--hover), var(--button--border--shadow--hover);
 	}
 
 	&:active {
 		background-color: var(--button--color--background-active);
-		box-shadow: var(--button--shadow--active);
-		border-color: var(--button--border-color--active);
+		box-shadow: var(--button--shadow--active), var(--button--border--shadow--active);
 	}
 
 	&:focus {
@@ -187,28 +188,28 @@ const handleClick = (event: MouseEvent) => {
 	&.xsmall {
 		--button--height: 1.5rem;
 		--button--padding: 0 var(--spacing--2xs);
-		--button--radius: var(--radius--2xs);
+		--button--radius: var(--radius--3xs);
 		--button--font-size: var(--font-size--2xs);
 	}
 
 	&.small {
 		--button--height: 1.75rem;
 		--button--padding: 0 var(--spacing--xs);
-		--button--radius: var(--radius--2xs);
+		--button--radius: var(--radius--3xs);
 		--button--font-size: var(--font-size--xs);
 	}
 
 	&.medium {
 		--button--height: 2rem;
 		--button--padding: 0 var(--spacing--xs);
-		--button--radius: var(--radius--xs);
+		--button--radius: var(--radius--3xs);
 		--button--font-size: var(--font-size--sm);
 	}
 
 	&.large {
 		--button--height: 2.25rem;
 		--button--padding: 0 var(--spacing--sm);
-		--button--radius: var(--radius--xs);
+		--button--radius: var(--radius--2xs);
 		--button--font-size: var(--font-size--sm);
 	}
 
@@ -233,6 +234,9 @@ const handleClick = (event: MouseEvent) => {
 		--button--border-color: var(--color--orange-400);
 		--button--border-color--hover: var(--color--orange-500);
 		--button--border-color--active: var(--color--orange-600);
+		--button--border--shadow: 0 0 0 1px var(--button--border-color);
+		--button--border--shadow--hover: 0 0 0 1px var(--button--border-color--hover);
+		--button--border--shadow--active: 0 0 0 1px var(--button--border-color--active);
 	}
 
 	&.subtle {
@@ -246,7 +250,7 @@ const handleClick = (event: MouseEvent) => {
 			var(--color--neutral-600)
 		);
 		--button--shadow:
-			0 1px 2px light-dark(var(--color--black-alpha-100), var(--color--black-alpha-300)),
+			0 1px 3px light-dark(var(--color--black-alpha-100), var(--color--black-alpha-300)),
 			0 0 0 1px light-dark(transparent, var(--color--black-alpha-100));
 		--button--shadow--hover:
 			0 1px 3px 0 light-dark(var(--color--black-alpha-200), var(--color--black-alpha-300)),
@@ -266,6 +270,9 @@ const handleClick = (event: MouseEvent) => {
 			var(--color--black-alpha-300),
 			var(--color--white-alpha-300)
 		);
+		--button--border--shadow: 0 0 0 1px var(--button--border-color);
+		--button--border--shadow--hover: 0 0 0 1px var(--button--border-color--hover);
+		--button--border--shadow--active: 0 0 0 1px var(--button--border-color--active);
 	}
 
 	&.outline {
@@ -290,6 +297,9 @@ const handleClick = (event: MouseEvent) => {
 			var(--color--black-alpha-300),
 			var(--color--white-alpha-300)
 		);
+		--button--border--shadow: 0 0 0 1px var(--button--border-color);
+		--button--border--shadow--hover: 0 0 0 1px var(--button--border-color--hover);
+		--button--border--shadow--active: 0 0 0 1px var(--button--border-color--active);
 	}
 
 	&.ghost {
@@ -303,6 +313,9 @@ const handleClick = (event: MouseEvent) => {
 			var(--color--white-alpha-200)
 		);
 		--button--border-color: transparent;
+		--button--border--shadow: 0 0 0 1px var(--button--border-color);
+		--button--border--shadow--hover: 0 0 0 1px var(--button--border-color);
+		--button--border--shadow--active: 0 0 0 1px var(--button--border-color);
 	}
 
 	&.destructive {
@@ -325,6 +338,9 @@ const handleClick = (event: MouseEvent) => {
 		--button--border-color: light-dark(var(--color--red-500), var(--color--red-600));
 		--button--border-color--hover: light-dark(var(--color--red-600), var(--color--red-500));
 		--button--border-color--active: light-dark(var(--color--red-600), var(--color--red-400));
+		--button--border--shadow: 0 0 0 1px var(--button--border-color);
+		--button--border--shadow--hover: 0 0 0 1px var(--button--border-color--hover);
+		--button--border--shadow--active: 0 0 0 1px var(--button--border-color--active);
 	}
 
 	&.disabled {


### PR DESCRIPTION
## Summary
Match existing components styles more and fix [N8N-9677](https://linear.app/n8n/issue/N8N-9677/icon-button-glyph-shifted-right-05-1-px-in-top-right-actions) whilst we're at it

| Before | After |
|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/075bb9f8-a73c-48dd-bd5e-e36a7eeec532" alt="CleanShot 2026-02-18 at 16 13 27@2x" width="960px" /> | <img src="https://github.com/user-attachments/assets/30a8ed84-026b-44af-aa0f-ec57613148cb" alt="CleanShot 2026-02-18 at 16 13 06@2x" width="960px" /> |
| <img width="324" height="164" alt="CleanShot 2026-02-18 at 16 14 44@2x" src="https://github.com/user-attachments/assets/06986ab5-ff6e-4e74-b3e6-d17fa5d3dd7d" /> | <img width="288" height="132" alt="CleanShot 2026-02-18 at 16 15 06@2x" src="https://github.com/user-attachments/assets/67e72a39-3be4-420a-ab0a-ed574bb62fe2" />


## Related Linear tickets, Github issues, and Community forum posts
[N8N-9677](https://linear.app/n8n/issue/N8N-9677/icon-button-glyph-shifted-right-05-1-px-in-top-right-actions) whilst we're at it

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
