### PR TITLE
fix(core, nodes-base): Fix OAuth2 token refresh for Microsoft Teams (403 + httpRequest path)

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
@@ -1102,14 +1102,18 @@ export async function requestOAuth2(
 			if (
 				requestOptions.resolveWithFullResponse === true &&
 				requestOptions.simple === false &&
-				response.statusCode === tokenExpiredStatusCode
+				(response.statusCode === tokenExpiredStatusCode ||
+					(tokenExpiredStatusCode !== 401 && response.statusCode === 401))
 			) {
 				throw response;
 			}
 			return response;
 		})
 		.catch(async (error: IResponseError) => {
-			if (error.statusCode === tokenExpiredStatusCode) {
+			if (
+				error.statusCode === tokenExpiredStatusCode ||
+				(tokenExpiredStatusCode !== 401 && error.statusCode === 401)
+			) {
 				// Token is probably not valid anymore. So try refresh it.
 				const tokenRefreshOptions: IDataObject = {};
 				if (oAuth2Options?.includeCredentialsOnRefreshOnBody) {

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
@@ -1024,9 +1024,13 @@ export async function requestOAuth2(
 	}
 	if (isN8nRequest) {
 		return await this.helpers.httpRequest(newRequestOptions).catch(async (error: AxiosError) => {
-			if (error.response?.status === 401) {
+			const tokenExpiredStatus = oAuth2Options?.tokenExpiredStatusCode ?? 401;
+			if (
+				error.response?.status === tokenExpiredStatus ||
+				(tokenExpiredStatus !== 401 && error.response?.status === 401)
+			) {
 				this.logger.debug(
-					`OAuth2 token for "${credentialsType}" used by node "${node.name}" expired. Should revalidate.`,
+					`OAuth2 token for "${credentialsType}" used by node "${node.name}" expired (status: ${error.response?.status}). Should revalidate.`,
 				);
 				const tokenRefreshOptions: IDataObject = {};
 				if (oAuth2Options?.includeCredentialsOnRefreshOnBody) {

--- a/packages/nodes-base/nodes/HttpRequest/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/HttpRequest/GenericFunctions.ts
@@ -179,6 +179,9 @@ export const getOAuth2AdditionalParameters = (nodeCredentialType: string) => {
 		microsoftAzureMonitorOAuth2Api: {
 			tokenExpiredStatusCode: 403,
 		},
+		microsoftTeamsOAuth2Api: {
+			tokenExpiredStatusCode: 403,
+		},
 		microsoftDynamicsOAuth2Api: {
 			property: 'id_token',
 		},


### PR DESCRIPTION
## Summary

Three bugs prevent n8n from automatically refreshing expired Microsoft Teams OAuth2 tokens:

1. **Missing `tokenExpiredStatusCode` for Teams credentials** — Microsoft Graph API returns HTTP 403 (not 401) when tokens expire, but `microsoftTeamsOAuth2Api` didn't configure this, so n8n never recognised the response as a token expiry.

2. **`httpRequest` code path ignores `tokenExpiredStatusCode`** — The newer `httpRequest` path in `requestOAuth2` (used by "Predefined Credential Type" HTTP Request nodes) hardcodes `error.response?.status === 401`, completely ignoring the `tokenExpiredStatusCode` option from `oAuth2Options`.

3. **Legacy `request` code path doesn't fall back to 401** — When `tokenExpiredStatusCode` is set to 403, the legacy `request()` path ONLY checks for 403. If Microsoft returns 401 instead (which it does for some endpoints/scenarios), the refresh is skipped. Both code paths need to check for both the configured status code AND 401 as a fallback.

Microsoft Graph API returns **both** 401 and 403 for expired tokens depending on the endpoint and scenario. Without these fixes, token refresh only triggers if the status code exactly matches a single hardcoded value.

## Changes

### Commit 1: `packages/nodes-base/nodes/HttpRequest/GenericFunctions.ts`
Adds `tokenExpiredStatusCode: 403` to `microsoftTeamsOAuth2Api` in `getOAuth2AdditionalParameters`, matching the existing pattern used by `microsoftAzureMonitorOAuth2Api` (added in #12645).

### Commit 2: `packages/core/.../request-helper-functions.ts` (httpRequest path)
Changes the `httpRequest` path in `requestOAuth2` to read `tokenExpiredStatusCode` from `oAuth2Options` (defaulting to 401) instead of hardcoding 401. Also checks for 401 as a fallback when a custom status code is configured.

### Commit 3: `packages/core/.../request-helper-functions.ts` (legacy request path)
Applies the same fallback logic to the legacy `request()` path — both the `.then()` handler (for `resolveWithFullResponse` responses) and the `.catch()` handler now check for both the configured `tokenExpiredStatusCode` AND 401.

**The pattern applied to both code paths:**
```typescript
// Before (only matches one status code):
if (error.statusCode === tokenExpiredStatusCode) {

// After (matches configured code + 401 fallback):
if (
    error.statusCode === tokenExpiredStatusCode ||
    (tokenExpiredStatusCode !== 401 && error.statusCode === 401)
) {
```

## Why both code paths matter

n8n's `requestOAuth2` function has two code paths:

| Path | Used when | Token expiry check |
|------|-----------|-------------------|
| `this.helpers.httpRequest()` | `isN8nRequest=true` (Predefined Credential Type) | Was hardcoded to 401 only |
| `this.helpers.request()` | `isN8nRequest=false` (Generic Credential Type, some native nodes) | Only checked `tokenExpiredStatusCode`, no 401 fallback |

In practice, Microsoft Teams nodes can hit either path depending on the node configuration. Microsoft returns both 401 (`InvalidAuthenticationToken`) and 403 (`Forbidden`) for expired tokens. Both paths now handle both status codes.

## Related Issues

- Fixes #18517 — OAuth2 API client credentials do not refresh on 403
- Fixes #17450 — OAuth2 Client Credentials does not refresh token after expiry (403 error)
- Related to #22893 — n8n not refreshing OAuth tokens
- Related community reports:
  - [Bug in MS Teams Credential Refreshing](https://community.n8n.io/t/bug-in-ms-teams-credential-refreshing/248863)
  - [MS Teams Node 403 / "No authorization information present"](https://community.n8n.io/t/microsoft-teams-node-403-no-authorization-information-present-on-the-request-error/139912)
  - [Feature Request: Add HTTP 403 support for OAuth2 token refresh](https://community.n8n.io/t/feature-request-add-http-403-support-for-oauth2-token-refresh-in-generic-oauth2api-credential/179197)

## Test plan

- Verified on a self-hosted n8n 2.8.3 instance with 32+ active workflows using Microsoft Teams OAuth2 credentials
- Before patch: workflows intermittently fail with 403 or 401 `InvalidAuthenticationToken` errors after ~1 hour when the access token expires; token refresh never triggers
- After patch: n8n detects both 403 and 401 as token expiry on both code paths, refreshes the token, and retries the request