### PR TITLE
fix(editor): Route error/credential help messages to builder in merged Ask+Build view

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -296,6 +296,8 @@
 	"aiAssistant.builder.canvasPrompt.startManually.title": "Start manually",
 	"aiAssistant.builder.canvasPrompt.startManually.subTitle": "Add the first node",
 	"aiAssistant.builder.canvasPrompt.buildWithAI": "Build with AI",
+	"aiAssistant.builder.credentialHelpMessage": "How do I set up the credentials for {credentialName}?",
+	"aiAssistant.builder.errorHelpMessage": "I'm getting an error on the \"{nodeName}\" node: {errorMessage}",
 	"aiAssistant.builder.streamAbortedMessage": "Task aborted",
 	"aiAssistant.builder.executeMessage.description": "Complete these steps before executing your workflow",
 	"aiAssistant.builder.executeMessage.noIssues": "Your workflow is ready to be executed",

--- a/packages/frontend/editor-ui/src/app/components/MainSidebarHeader.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainSidebarHeader.test.ts
@@ -71,15 +71,6 @@ describe('MainSidebarHeader', () => {
 		},
 	);
 
-	it('should render beta icon when not collapsed and isBeta is true', () => {
-		const { queryByTestId } = createComponentRenderer(MainSidebarHeader, {
-			pinia,
-			props: { isCollapsed: false, isBeta: true },
-		})();
-
-		expect(queryByTestId('beta-icon') !== null).toBe(true);
-	});
-
 	it('renders the logo link only when not collapsed', async () => {
 		const { container, rerender } = createComponentRenderer(MainSidebarHeader, {
 			pinia,

--- a/packages/frontend/editor-ui/src/app/components/MainSidebarHeader.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainSidebarHeader.vue
@@ -18,11 +18,8 @@ import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/
 import KeyboardShortcutTooltip from '@/app/components/KeyboardShortcutTooltip.vue';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useGlobalEntityCreation } from '@/app/composables/useGlobalEntityCreation';
-import BetaTag from '@n8n/design-system/components/BetaTag/BetaTag.vue';
-
 defineProps<{
 	isCollapsed: boolean;
-	isBeta?: boolean;
 	hideCreate?: boolean;
 }>();
 
@@ -74,7 +71,6 @@ const {
 				:collapsed="isCollapsed"
 				:release-channel="settingsStore.settings.releaseChannel"
 			>
-				<BetaTag v-if="isBeta" :class="$style.beta" data-test-id="beta-icon" />
 				<N8nTooltip
 					v-if="sourceControlStore.preferences.branchReadOnly && !isCollapsed"
 					placement="bottom"
@@ -226,11 +222,6 @@ const {
 
 .logo {
 	margin-right: auto;
-}
-
-.beta {
-	margin-top: 2px;
-	margin-left: var(--spacing--3xs);
 }
 
 .readOnlyEnvironmentIcon {

--- a/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.ts
@@ -295,8 +295,9 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 
 	async function initCredHelp(credType: ICredentialType) {
 		const hasExistingSession = !!currentSessionId.value;
-		const credentialName = credType.displayName;
-		const question = `How do I set up the credentials for ${credentialName}?`;
+		const question = locale.baseText('aiAssistant.builder.credentialHelpMessage', {
+			interpolate: { credentialName: credType.displayName },
+		});
 
 		await initSupportChat(question, credType);
 

--- a/packages/frontend/editor-ui/src/features/ai/assistant/chatPanel.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/chatPanel.store.ts
@@ -163,6 +163,13 @@ export const useChatPanelStore = defineStore(STORES.CHAT_PANEL, () => {
 	 * Opens assistant with credential help context
 	 */
 	async function openWithCredHelp(credentialType: ICredentialType) {
+		if (isMergeAskBuildEnabled.value) {
+			const question = `How do I set up the credentials for ${credentialType.displayName}?`;
+			await open({ mode: 'builder' });
+			const builderStore = useBuilderStore();
+			await builderStore.sendChatMessage({ text: question });
+			return;
+		}
 		const assistantStore = useAssistantStore();
 		await assistantStore.initCredHelp(credentialType);
 		await open({ mode: 'assistant' });
@@ -172,6 +179,13 @@ export const useChatPanelStore = defineStore(STORES.CHAT_PANEL, () => {
 	 * Opens assistant with error helper context
 	 */
 	async function openWithErrorHelper(context: ChatRequest.ErrorContext) {
+		if (isMergeAskBuildEnabled.value) {
+			const errorText = `I'm getting an error on the "${context.node.name}" node: ${context.error.message}`;
+			await open({ mode: 'builder' });
+			const builderStore = useBuilderStore();
+			await builderStore.sendChatMessage({ text: errorText });
+			return;
+		}
 		const assistantStore = useAssistantStore();
 		await assistantStore.initErrorHelper(context);
 		await open({ mode: 'assistant' });

--- a/packages/frontend/editor-ui/src/features/ai/assistant/chatPanel.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/chatPanel.store.ts
@@ -13,6 +13,7 @@ import { useSettingsStore } from '@/app/stores/settings.store';
 import { useEnvFeatureFlag } from '@/features/shared/envFeatureFlag/useEnvFeatureFlag';
 import type { ICredentialType } from 'n8n-workflow';
 import type { ChatRequest } from './assistant.types';
+import { useI18n } from '@n8n/i18n';
 
 export const MAX_CHAT_WIDTH = 425;
 export const MIN_CHAT_WIDTH = 380;
@@ -35,6 +36,7 @@ export const useChatPanelStore = defineStore(STORES.CHAT_PANEL, () => {
 	const chatPanelStateStore = useChatPanelStateStore();
 	const settingsStore = useSettingsStore();
 	const { check } = useEnvFeatureFlag();
+	const locale = useI18n();
 
 	const isMergeAskBuildEnabled = computed(
 		() =>
@@ -164,7 +166,9 @@ export const useChatPanelStore = defineStore(STORES.CHAT_PANEL, () => {
 	 */
 	async function openWithCredHelp(credentialType: ICredentialType) {
 		if (isMergeAskBuildEnabled.value) {
-			const question = `How do I set up the credentials for ${credentialType.displayName}?`;
+			const question = locale.baseText('aiAssistant.builder.credentialHelpMessage', {
+				interpolate: { credentialName: credentialType.displayName },
+			});
 			await open({ mode: 'builder' });
 			const builderStore = useBuilderStore();
 			await builderStore.sendChatMessage({ text: question });
@@ -180,7 +184,9 @@ export const useChatPanelStore = defineStore(STORES.CHAT_PANEL, () => {
 	 */
 	async function openWithErrorHelper(context: ChatRequest.ErrorContext) {
 		if (isMergeAskBuildEnabled.value) {
-			const errorText = `I'm getting an error on the "${context.node.name}" node: ${context.error.message}`;
+			const errorText = locale.baseText('aiAssistant.builder.errorHelpMessage', {
+				interpolate: { nodeName: context.node.name, errorMessage: context.error.message },
+			});
 			await open({ mode: 'builder' });
 			const builderStore = useBuilderStore();
 			await builderStore.sendChatMessage({ text: errorText });

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatSidebar.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatSidebar.vue
@@ -77,7 +77,6 @@ const onLogout = () => {
 	>
 		<MainSidebarHeader
 			hide-create
-			is-beta
 			:is-collapsed="isCollapsed"
 			@collapse="toggleCollapse"
 			@open-command-bar="openCommandBar"


### PR DESCRIPTION
## Summary

When `MERGE_ASK_BUILD` feature flag is enabled, clicking "Ask n8n AI" inside a NDV (from error panels or credential help) doesn't work after generating a workflow with the builder:

- **Case 1**: "Ask n8n AI" triggered the "Start new session" modal, but after pressing "Start new session", nothing happened.
- **Case 2**: "Ask n8n AI" did nothing at all — not even the modal showed up.

Both cases funnel through `openWithErrorHelper()` / `openWithCredHelp()` in `chatPanel.store.ts`, which were always routing messages to `assistantStore`. With `MERGE_ASK_BUILD` enabled, `resolveMode` redirects the panel to builder mode, but since `AskAssistantBuild.vue` reads from `builderStore.chatMessages`, the messages were invisible.

The fix makes both functions check `isMergeAskBuildEnabled` and route messages through `builderStore.sendChatMessage()` instead, so they appear in the builder chat panel the user actually sees.


... also RIP beta tag...

## Related ticket

https://linear.app/n8n/issue/AI-2064