### PR TITLE
fix(editor): Hide native scrollbar when custom scrollbar is active

### DIFF
--- a/packages/frontend/@n8n/design-system/src/css/scrollbar.scss
+++ b/packages/frontend/@n8n/design-system/src/css/scrollbar.scss
@@ -17,6 +17,13 @@
 	@include mixins.e(wrap) {
 		overflow: auto;
 		height: 100%;
+
+		@include mixins.m(hidden-default) {
+			scrollbar-width: none;
+			&::-webkit-scrollbar {
+				display: none;
+			}
+		}
 	}
 
 	@include mixins.e(thumb) {


### PR DESCRIPTION
## Summary

Fixes duplicate scrollbars appearing in Element Plus dropdown components (e.g. the "Add new credential" modal, node parameter dropdowns, date pickers).

Before:
<img width="1512" height="982" alt="Before" src="https://github.com/user-attachments/assets/5861dcbf-706b-4180-9111-c9c5ee8e77f9" />

After:
<img width="1512" height="982" alt="After" src="https://github.com/user-attachments/assets/83f20b57-a4c9-486d-b3cb-1a625d0787ff" />



**Root cause:** `@n8n/design-system`'s `scrollbar.scss` overrides Element Plus's scrollbar theme but was missing the `.el-scrollbar__wrap--hidden-default` CSS modifier. Element Plus applies this class via JavaScript expecting CSS to hide the native browser scrollbar — without it, both the native and custom scrollbars appeared simultaneously.

**Fix:** Added the missing 6-line CSS block to `scrollbar.scss` that hides the native scrollbar on all Element Plus scrollable components.

**Affected file:** `packages/frontend/@n8n/design-system/src/css/scrollbar.scss`

**How to test:**
1. Go to Credentials tab → click "Create Credential"
2. Open the app/service dropdown — only one thin scrollbar should appear
3. Also check: node parameter dropdowns, date/time pickers, execution filters

## Related Linear tickets, Github issues, and Community forum posts

Linear ticket : [GHC-6843](https://linear.app/n8n/issue/GHC-6843)
closes #25786

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created — N/A (CSS-only change)
- [ ] Tests included - visual QA is the appropriate verification method for this change
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
