### PR TITLE
fix(Anthropic Chat Model Node): Add gateway error enrichment and empty model guard

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
@@ -3,6 +3,7 @@ import type { LLMResult } from '@langchain/core/outputs';
 import { getProxyAgent, makeN8nLlmFailedAttemptHandler, N8nLlmTracing } from '@n8n/ai-utilities';
 import {
 	NodeConnectionTypes,
+	NodeOperationError,
 	type INodeProperties,
 	type INodePropertyOptions,
 	type INodeType,
@@ -272,6 +273,12 @@ export class LmChatAnthropic implements INodeType {
 			version >= 1.3
 				? (this.getNodeParameter('model.value', itemIndex) as string)
 				: (this.getNodeParameter('model', itemIndex) as string);
+
+		if (!modelName) {
+			throw new NodeOperationError(this.getNode(), 'No model selected. Please choose a model.', {
+				itemIndex,
+			});
+		}
 
 		const options = this.getNodeParameter('options', itemIndex, {}) as {
 			maxTokensToSample?: number;

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
@@ -149,11 +149,7 @@ export class LmChatAnthropic implements INodeType {
 				displayName: 'Model',
 				name: 'model',
 				type: 'resourceLocator',
-				default: {
-					mode: 'list',
-					value: 'claude-sonnet-4-5-20250929',
-					cachedResultName: 'Claude Sonnet 4.5',
-				},
+				default: { mode: 'list', value: '' },
 				required: true,
 				modes: [
 					{

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
@@ -150,7 +150,11 @@ export class LmChatAnthropic implements INodeType {
 				displayName: 'Model',
 				name: 'model',
 				type: 'resourceLocator',
-				default: { mode: 'list', value: '' },
+				default: {
+					mode: 'list',
+					value: 'claude-sonnet-4-5-20250929',
+					cachedResultName: 'Claude Sonnet 4.5',
+				},
 				required: true,
 				modes: [
 					{
@@ -345,6 +349,22 @@ export class LmChatAnthropic implements INodeType {
 			};
 		}
 
+		const isUsingGateway = baseURL !== 'https://api.anthropic.com';
+		const gatewayErrorHandler = isUsingGateway
+			? (error: unknown) => {
+					const message = error instanceof Error ? error.message : String(error);
+					const isModelError =
+						/model.*not found|not found.*model|invalid model|does not exist/i.test(message);
+					if (isModelError) {
+						throw new NodeOperationError(
+							this.getNode(),
+							`The model "${modelName}" was not found at ${baseURL}. If you're using an AI gateway, select a model that your gateway supports.`,
+							{ itemIndex },
+						);
+					}
+				}
+			: undefined;
+
 		const model = new ChatAnthropic({
 			anthropicApiKey: credentials.apiKey,
 			model: modelName,
@@ -354,7 +374,7 @@ export class LmChatAnthropic implements INodeType {
 			topK: options.topK,
 			topP: options.topP,
 			callbacks: [new N8nLlmTracing(this, { tokensUsageParser })],
-			onFailedAttempt: makeN8nLlmFailedAttemptHandler(this),
+			onFailedAttempt: makeN8nLlmFailedAttemptHandler(this, gatewayErrorHandler),
 			invocationKwargs,
 			clientOptions,
 		});

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
@@ -5,6 +5,7 @@ import { ChatAnthropic } from '@langchain/anthropic';
 import { makeN8nLlmFailedAttemptHandler, N8nLlmTracing, getProxyAgent } from '@n8n/ai-utilities';
 import { createMockExecuteFunction } from 'n8n-nodes-base/test/nodes/Helpers';
 import type { INode, ISupplyDataFunctions } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
 
 import { LmChatAnthropic } from '../LmChatAnthropic.node';
 
@@ -429,6 +430,75 @@ describe('LmChatAnthropic', () => {
 			await lmChatAnthropic.supplyData.call(mockContext, 0);
 
 			expect(mockedMakeN8nLlmFailedAttemptHandler).toHaveBeenCalledWith(mockContext);
+		});
+
+		it('should throw when model is empty (v1.3)', async () => {
+			const mockContext = setupMockContext({ typeVersion: 1.3 });
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return '';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await expect(lmChatAnthropic.supplyData.call(mockContext, 0)).rejects.toThrow(
+				NodeOperationError,
+			);
+			expect(MockedChatAnthropic).not.toHaveBeenCalled();
+		});
+
+		it('should throw when model is empty (v1.2)', async () => {
+			const mockContext = setupMockContext({ typeVersion: 1.2 });
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model') return '';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await expect(lmChatAnthropic.supplyData.call(mockContext, 0)).rejects.toThrow(
+				NodeOperationError,
+			);
+			expect(MockedChatAnthropic).not.toHaveBeenCalled();
+		});
+
+		it('should use gateway-provided model name via custom base URL without hardcoded defaults', async () => {
+			const gatewayURL = 'https://ai-gateway.example.com';
+			const gatewayModel = 'my-org/claude-3-sonnet';
+			const mockContext = setupMockContext({ typeVersion: 1.3 });
+
+			mockContext.getCredentials.mockResolvedValue({
+				apiKey: 'gateway-api-key',
+				url: gatewayURL,
+			});
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return gatewayModel;
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(MockedChatAnthropic).toHaveBeenCalledWith(
+				expect.objectContaining({
+					anthropicApiKey: 'gateway-api-key',
+					model: gatewayModel,
+					anthropicApiUrl: gatewayURL,
+				}),
+			);
+		});
+
+		it('should have no hardcoded default model in v1.3 resource locator', () => {
+			const v13ModelField = lmChatAnthropic.description.properties.find(
+				(p) =>
+					p.name === 'model' &&
+					p.type === 'resourceLocator' &&
+					p.displayOptions?.show?.['@version']?.[0] !== undefined,
+			);
+
+			expect(v13ModelField).toBeDefined();
+			expect(v13ModelField!.default).toEqual({ mode: 'list', value: '' });
 		});
 	});
 

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
@@ -418,7 +418,7 @@ describe('LmChatAnthropic', () => {
 			);
 		});
 
-		it('should create failed attempt handler', async () => {
+		it('should create failed attempt handler without gateway handler for direct API', async () => {
 			const mockContext = setupMockContext();
 
 			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
@@ -429,7 +429,65 @@ describe('LmChatAnthropic', () => {
 
 			await lmChatAnthropic.supplyData.call(mockContext, 0);
 
-			expect(mockedMakeN8nLlmFailedAttemptHandler).toHaveBeenCalledWith(mockContext);
+			expect(mockedMakeN8nLlmFailedAttemptHandler).toHaveBeenCalledWith(mockContext, undefined);
+		});
+
+		it('should create failed attempt handler with gateway handler for custom URL', async () => {
+			const mockContext = setupMockContext();
+
+			mockContext.getCredentials.mockResolvedValue({
+				apiKey: 'test-api-key',
+				url: 'https://ai-gateway.example.com',
+			});
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-20250514';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(mockedMakeN8nLlmFailedAttemptHandler).toHaveBeenCalledWith(
+				mockContext,
+				expect.any(Function),
+			);
+		});
+
+		it('should enrich model-not-found errors with gateway hint when using custom URL', async () => {
+			const gatewayURL = 'https://ai-gateway.example.com';
+			const mockContext = setupMockContext();
+
+			mockContext.getCredentials.mockResolvedValue({
+				apiKey: 'test-api-key',
+				url: gatewayURL,
+			});
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-20250514';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			// Capture the gateway handler passed to makeN8nLlmFailedAttemptHandler
+			let capturedHandler: ((error: unknown) => void) | undefined;
+			mockedMakeN8nLlmFailedAttemptHandler.mockImplementation((_ctx, handler) => {
+				capturedHandler = handler as (error: unknown) => void;
+				return jest.fn();
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(capturedHandler).toBeDefined();
+
+			// Model-not-found error should be enriched
+			expect(() => capturedHandler!(new Error('model not found'))).toThrow(NodeOperationError);
+			expect(() => capturedHandler!(new Error('model not found'))).toThrow(
+				/ai-gateway\.example\.com/,
+			);
+
+			// Non-model errors should pass through without throwing
+			expect(() => capturedHandler!(new Error('rate limit exceeded'))).not.toThrow();
 		});
 
 		it('should throw when model is empty (v1.3)', async () => {
@@ -489,7 +547,7 @@ describe('LmChatAnthropic', () => {
 			);
 		});
 
-		it('should have no hardcoded default model in v1.3 resource locator', () => {
+		it('should have a default model in v1.3 resource locator', () => {
 			const v13ModelField = lmChatAnthropic.description.properties.find(
 				(p) =>
 					p.name === 'model' &&
@@ -498,7 +556,11 @@ describe('LmChatAnthropic', () => {
 			);
 
 			expect(v13ModelField).toBeDefined();
-			expect(v13ModelField!.default).toEqual({ mode: 'list', value: '' });
+			expect(v13ModelField!.default).toEqual({
+				mode: 'list',
+				value: 'claude-sonnet-4-5-20250929',
+				cachedResultName: 'Claude Sonnet 4.5',
+			});
 		});
 	});
 

--- a/packages/@n8n/nodes-langchain/nodes/llms/test/LmChatAnthropic.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/test/LmChatAnthropic.test.ts
@@ -330,7 +330,7 @@ describe('LmChatAnthropic', () => {
 
 			await lmChatAnthropic.supplyData.call(mockContext, 0);
 
-			expect(mockedMakeN8nLlmFailedAttemptHandler).toHaveBeenCalledWith(mockContext);
+			expect(mockedMakeN8nLlmFailedAttemptHandler).toHaveBeenCalledWith(mockContext, undefined);
 		});
 
 		it('should not add custom headers when header toggle is disabled', async () => {


### PR DESCRIPTION
## Summary
- Adds gateway-aware error enrichment: when using a custom base URL (AI gateway), model-not-found errors are caught and re-thrown with a helpful message suggesting the user select a gateway-supported model
- Adds a runtime guard that throws a clear `NodeOperationError` when no model is selected
- Adds tests for gateway error enrichment, empty model validation, and default model verification

## Related Linear Tickets
https://linear.app/n8n/issue/AI-2062