### PR TITLE
fix(FTP Node): Use POSIX rename for SFTP move to prevent incomplete file transfers

### DIFF
--- a/packages/nodes-base/nodes/Ftp/Ftp.node.json
+++ b/packages/nodes-base/nodes/Ftp/Ftp.node.json
@@ -15,7 +15,7 @@
 			}
 		]
 	},
-	"alias": ["SFTP", "FTP", "Binary", "File", "Transfer"],
+	"alias": ["SFTP", "FTP", "Binary", "File", "Transfer", "Move", "Rename"],
 	"subcategories": {
 		"Core Nodes": ["Files", "Helpers"]
 	}

--- a/packages/nodes-base/nodes/Ftp/Ftp.node.ts
+++ b/packages/nodes-base/nodes/Ftp/Ftp.node.ts
@@ -22,6 +22,8 @@ import { file as tmpFile } from 'tmp-promise';
 
 import { formatPrivateKey, generatePairedItemData } from '@utils/utilities';
 
+import { sftpRenameWithPosixFallback } from './utils';
+
 interface ReturnFtpItem {
 	type: string;
 	name: string;
@@ -717,7 +719,7 @@ export class Ftp implements INodeType {
 								await recursivelyCreateSftpDirs(sftp!, newPath);
 							}
 
-							await sftp!.rename(oldPath, newPath);
+							await sftpRenameWithPosixFallback(sftp!, oldPath, newPath);
 							const executionData = this.helpers.constructExecutionMetaData(
 								[{ json: { success: true } }],
 								{ itemData: { item: i } },

--- a/packages/nodes-base/nodes/Ftp/__test__/Ftp.node.test.ts
+++ b/packages/nodes-base/nodes/Ftp/__test__/Ftp.node.test.ts
@@ -149,4 +149,82 @@ describe('Ftp', () => {
 			}),
 		);
 	});
+
+	describe('SFTP rename (move) operation', () => {
+		let posixRename: jest.Mock;
+		let rename: jest.Mock;
+		let connect: jest.Mock;
+		let end: jest.Mock;
+
+		beforeEach(() => {
+			posixRename = jest.fn();
+			rename = jest.fn();
+			connect = jest.fn();
+			end = jest.fn();
+
+			jest.spyOn(sftpModule, 'default').mockImplementation(
+				() =>
+					({
+						connect,
+						posixRename,
+						rename,
+						end,
+					}) as unknown as sftp,
+			);
+
+			executeFunctions.getCredentials.mockResolvedValue({
+				host: 'test.com',
+				port: 22,
+				username: 'test',
+				password: 'test',
+			});
+
+			executeFunctions.getNodeParameter.mockImplementation((parameterName, _idx, defaultValue) => {
+				switch (parameterName) {
+					case 'operation':
+						return 'rename';
+					case 'protocol':
+						return 'sftp';
+					case 'options.timeout':
+						return 10000;
+					case 'oldPath':
+						return '/source/file.txt';
+					case 'newPath':
+						return '/target/file.txt';
+					case 'options':
+						return {};
+					default:
+						return defaultValue;
+				}
+			});
+		});
+
+		it('should use posixRename when the server supports the extension', async () => {
+			posixRename.mockResolvedValue('OK');
+
+			await new Ftp().execute.call(executeFunctions);
+
+			expect(posixRename).toHaveBeenCalledWith('/source/file.txt', '/target/file.txt');
+			expect(rename).not.toHaveBeenCalled();
+		});
+
+		it('should fall back to rename when posixRename extension is not supported', async () => {
+			posixRename.mockRejectedValue(new Error('Server does not support this extended request'));
+			rename.mockResolvedValue('OK');
+
+			await new Ftp().execute.call(executeFunctions);
+
+			expect(posixRename).toHaveBeenCalledWith('/source/file.txt', '/target/file.txt');
+			expect(rename).toHaveBeenCalledWith('/source/file.txt', '/target/file.txt');
+		});
+
+		it('should propagate posixRename errors that are not about extension support', async () => {
+			posixRename.mockRejectedValue(new Error('Permission denied'));
+
+			await expect(new Ftp().execute.call(executeFunctions)).rejects.toThrow('Permission denied');
+
+			expect(posixRename).toHaveBeenCalledWith('/source/file.txt', '/target/file.txt');
+			expect(rename).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/packages/nodes-base/nodes/Ftp/__test__/utils.test.ts
+++ b/packages/nodes-base/nodes/Ftp/__test__/utils.test.ts
@@ -1,0 +1,79 @@
+import type sftp from 'ssh2-sftp-client';
+
+import { sftpRenameWithPosixFallback } from '../utils';
+
+describe('sftpRenameWithPosixFallback', () => {
+	let posixRename: jest.Mock;
+	let rename: jest.Mock;
+	let sftpClient: sftp;
+
+	beforeEach(() => {
+		posixRename = jest.fn();
+		rename = jest.fn();
+		sftpClient = { posixRename, rename } as unknown as sftp;
+	});
+
+	it('should use posixRename when the server supports the extension', async () => {
+		posixRename.mockResolvedValue('OK');
+
+		await sftpRenameWithPosixFallback(sftpClient, '/src/file.txt', '/dst/file.txt');
+
+		expect(posixRename).toHaveBeenCalledWith('/src/file.txt', '/dst/file.txt');
+		expect(rename).not.toHaveBeenCalled();
+	});
+
+	it('should fall back to rename when posixRename extension is not supported', async () => {
+		posixRename.mockRejectedValue(new Error('Server does not support this extended request'));
+		rename.mockResolvedValue('OK');
+
+		await sftpRenameWithPosixFallback(sftpClient, '/src/file.txt', '/dst/file.txt');
+
+		expect(posixRename).toHaveBeenCalledWith('/src/file.txt', '/dst/file.txt');
+		expect(rename).toHaveBeenCalledWith('/src/file.txt', '/dst/file.txt');
+	});
+
+	it('should propagate posixRename errors that are not about extension support', async () => {
+		posixRename.mockRejectedValue(new Error('Permission denied'));
+
+		await expect(
+			sftpRenameWithPosixFallback(sftpClient, '/src/file.txt', '/dst/file.txt'),
+		).rejects.toThrow('Permission denied');
+
+		expect(posixRename).toHaveBeenCalledWith('/src/file.txt', '/dst/file.txt');
+		expect(rename).not.toHaveBeenCalled();
+	});
+
+	it('should propagate non-Error exceptions from posixRename', async () => {
+		posixRename.mockRejectedValue('unexpected string error');
+
+		await expect(
+			sftpRenameWithPosixFallback(sftpClient, '/src/file.txt', '/dst/file.txt'),
+		).rejects.toBe('unexpected string error');
+
+		expect(rename).not.toHaveBeenCalled();
+	});
+
+	it('should propagate errors from the fallback rename call', async () => {
+		posixRename.mockRejectedValue(new Error('Server does not support this extended request'));
+		rename.mockRejectedValue(new Error('No such file'));
+
+		await expect(
+			sftpRenameWithPosixFallback(sftpClient, '/src/file.txt', '/dst/file.txt'),
+		).rejects.toThrow('No such file');
+	});
+
+	it('should handle paths with special characters', async () => {
+		posixRename.mockResolvedValue('OK');
+
+		await sftpRenameWithPosixFallback(
+			sftpClient,
+			'/path/with spaces/file (1).txt',
+			'/target/path/new name.txt',
+		);
+
+		expect(posixRename).toHaveBeenCalledWith(
+			'/path/with spaces/file (1).txt',
+			'/target/path/new name.txt',
+		);
+	});
+});

--- a/packages/nodes-base/nodes/Ftp/utils.ts
+++ b/packages/nodes-base/nodes/Ftp/utils.ts
@@ -1,0 +1,26 @@
+import type sftpClient from 'ssh2-sftp-client';
+
+/**
+ * Attempt POSIX rename first (atomic, uses posix-rename@openssh.com extension),
+ * then fall back to basic SFTP v3 rename if the extension is not available.
+ *
+ * POSIX rename provides reliable atomic semantics that work correctly on servers
+ * like Synology NAS, whereas the basic SFTP v3 SSH_FXP_RENAME can leave behind
+ * temporary files on certain server implementations.
+ */
+export async function sftpRenameWithPosixFallback(
+	sftp: sftpClient,
+	oldPath: string,
+	newPath: string,
+): Promise<void> {
+	try {
+		await sftp.posixRename(oldPath, newPath);
+	} catch (posixError) {
+		const message = posixError instanceof Error ? posixError.message : String(posixError);
+		if (message.includes('does not support this extended request')) {
+			await sftp.rename(oldPath, newPath);
+		} else {
+			throw posixError;
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a regression where the SFTP MOVE (rename) operation leaves behind temporary
files with short/random names on certain SFTP servers (notably Synology NAS),
while reporting success. The final destination filename is never created and the
original file is not properly moved.

The root cause is that the SFTP rename operation uses the basic SFTP v3
`SSH_FXP_RENAME` command, which has non-POSIX semantics. Certain SFTP server
implementations handle this command by internally staging through temporary files,
and the finalization step can silently fail.

This PR changes the SFTP rename to prefer `posixRename()` (the
`posix-rename@openssh.com` SSH extension), which provides atomic POSIX rename
semantics. If the server does not support the extension, it falls back to the
basic `rename()` call, preserving backward compatibility.

- Extract `sftpRenameWithPosixFallback()` helper into `utils.ts`
- Try `posixRename()` first for atomic semantics
- Fall back to `rename()` only when the server lacks extension support
- Propagate actual operation errors (permission denied, no such file, etc.)

## Related Linear tickets, Github issues, and Community forum posts

Fixes #24381


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
