### PR TITLE
fix(core): Always serve /healthz on task broker regardless of N8N_ENDPOINT_HEALTH

### DIFF
--- a/packages/cli/src/task-runners/task-broker/__tests__/task-broker-server.test.ts
+++ b/packages/cli/src/task-runners/task-broker/__tests__/task-broker-server.test.ts
@@ -1,6 +1,7 @@
 import type { GlobalConfig } from '@n8n/config';
 import { mock } from 'jest-mock-extended';
 import { ServerResponse } from 'node:http';
+import request from 'supertest';
 import type WebSocket from 'ws';
 
 import type { TaskBrokerAuthController } from '@/task-runners/task-broker/auth/task-broker-auth.controller';
@@ -8,6 +9,32 @@ import { TaskBrokerServer } from '@/task-runners/task-broker/task-broker-server'
 import type { TaskBrokerServerInitRequest } from '@/task-runners/task-broker/task-broker-types';
 
 describe('TaskBrokerServer', () => {
+	describe('GET /healthz', () => {
+		it('should return 200 regardless of N8N_ENDPOINT_HEALTH', async () => {
+			// Simulate the case where N8N_ENDPOINT_HEALTH is set to 'health'
+			// (required on platforms like Cloud Run that reserve /healthz).
+			// The task broker is internal and must always expose /healthz so
+			// that the task-runner-launcher can reach it.
+			const server = new TaskBrokerServer(
+				mock(),
+				mock<GlobalConfig>({
+					taskRunners: { path: '/runners', authToken: 'token' },
+					endpoints: { health: '/health' },
+					sentry: { backendDsn: '' },
+				}),
+				mock<TaskBrokerAuthController>(),
+				mock(),
+			);
+
+			// @ts-expect-error Private method
+			server.setupCommonMiddlewares();
+			// @ts-expect-error Private method
+			server.configureRoutes();
+
+			await request(server.app).get('/healthz').expect(200, { status: 'ok' });
+		});
+	});
+
 	describe('handleUpgradeRequest', () => {
 		it('should close WebSocket when response status code is > 200', () => {
 			const ws = mock<WebSocket>();

--- a/packages/cli/src/task-runners/task-broker/task-broker-server.ts
+++ b/packages/cli/src/task-runners/task-broker/task-broker-server.ts
@@ -170,8 +170,14 @@ export class TaskBrokerServer {
 			send(async (req) => await this.authController.createGrantToken(req)),
 		);
 
-		const healthPath = this.globalConfig.endpoints.health;
-		this.app.get(healthPath, (_, res) => {
+		// The task broker is an internal server (not publicly accessible) used
+		// exclusively by the task-runner-launcher. Its health endpoint must always
+		// be /healthz, independent of N8N_ENDPOINT_HEALTH, which is intended for
+		// external-facing servers. Platforms such as Cloud Run reserve /healthz at
+		// the ingress level, so users set N8N_ENDPOINT_HEALTH=health to avoid
+		// conflicts on the public URL — but that restriction does not apply to
+		// internal container-to-container traffic on the broker port.
+		this.app.get('/healthz', (_, res) => {
 			res.send({ status: 'ok' });
 		});
 	}


### PR DESCRIPTION
## Summary

This is a regression introduced by #25729, which made the health endpoint configurable across all servers including the task broker. The `task-runner-launcher` binary, however, hardcodes `/healthz` for the broker readiness check. When users set `N8N_ENDPOINT_HEALTH=health` — required on platforms such as Google Cloud Run that reserve `/healthz` at the ingress — the broker began serving health at `/health` while the launcher kept checking `/healthz`, receiving 404 and waiting forever. Code nodes would time out after 60 seconds.

The task broker runs on an internal port (5679) that is never publicly exposed, so `N8N_ENDPOINT_HEALTH` should not affect it. This fix hardcodes `/healthz` on the task broker, decoupling it from the external health endpoint configuration.

**Root cause:**
- Broker uses `globalConfig.endpoints.health`: [task-broker-server.ts#L173–L174](https://github.com/n8n-io/n8n/blob/master/packages/cli/src/task-runners/task-broker/task-broker-server.ts#L173-L174)
- Launcher hardcodes `/healthz`: [check_until_broker_ready.go#L12](https://github.com/n8n-io/task-runner-launcher/blob/main/internal/http/check_until_broker_ready.go#L12)

Closes #25958

## Testing

Added a unit test to `task-broker-server.test.ts` that verifies `/healthz` returns 200 even when `N8N_ENDPOINT_HEALTH` is overridden (e.g. `endpoints: { health: '/health' }` in `GlobalConfig`).

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
