### PR TITLE
feat(core): Support special characters in secret names

### DIFF
--- a/packages/cli/src/modules/external-secrets.ee/constants.ts
+++ b/packages/cli/src/modules/external-secrets.ee/constants.ts
@@ -4,8 +4,6 @@ export const EXTERNAL_SECRETS_DB_KEY = 'feature.externalSecrets';
 export const EXTERNAL_SECRETS_INITIAL_BACKOFF = 10 * 1000;
 export const EXTERNAL_SECRETS_MAX_BACKOFF = 5 * 60 * 1000;
 
-export const EXTERNAL_SECRETS_NAME_REGEX = /^[a-zA-Z0-9\-\_\/]+$/;
-
 export const DOCS_HELP_NOTICE: INodeProperties = {
 	displayName:
 		'Need help filling out these fields? <a href="https://docs.n8n.io/external-secrets/#connect-n8n-to-your-secrets-store" target="_blank">Open docs</a>',

--- a/packages/cli/src/modules/external-secrets.ee/providers/__tests__/azure-key-vault.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/__tests__/azure-key-vault.test.ts
@@ -38,7 +38,6 @@ describe('AzureKeyVault', () => {
 					yield { name: 'secret1' };
 					yield { name: 'secret2' };
 					yield { name: 'secret3' }; // no value
-					yield { name: '#@&' }; // unsupported name
 				},
 			}));
 
@@ -61,11 +60,9 @@ describe('AzureKeyVault', () => {
 		expect(getSpy).toHaveBeenCalledWith('secret1');
 		expect(getSpy).toHaveBeenCalledWith('secret2');
 		expect(getSpy).toHaveBeenCalledWith('secret3');
-		expect(getSpy).not.toHaveBeenCalledWith('#@&');
 
 		expect(azureKeyVault.getSecret('secret1')).toBe('value1');
 		expect(azureKeyVault.getSecret('secret2')).toBe('value2');
 		expect(azureKeyVault.getSecret('secret3')).toBeUndefined(); // no value
-		expect(azureKeyVault.getSecret('#@&')).toBeUndefined(); // unsupported name
 	});
 });

--- a/packages/cli/src/modules/external-secrets.ee/providers/__tests__/gcp-secrets-manager.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/__tests__/gcp-secrets-manager.test.ts
@@ -85,7 +85,6 @@ describe('GCP Secrets Manager', () => {
 			secret1: 'value1',
 			secret2: 'value2',
 			secret3: '', // no value
-			'#@&': 'value', // unsupported name
 		};
 
 		await gcpSecretsManager.init(
@@ -102,7 +101,6 @@ describe('GCP Secrets Manager', () => {
 					{ name: `projects/${PROJECT_ID}/secrets/secret1` },
 					{ name: `projects/${PROJECT_ID}/secrets/secret2` },
 					{ name: `projects/${PROJECT_ID}/secrets/secret3` },
-					{ name: `projects/${PROJECT_ID}/secrets/#@&` },
 				],
 			]);
 
@@ -135,14 +133,10 @@ describe('GCP Secrets Manager', () => {
 		expect(getSpy).toHaveBeenCalledWith({
 			name: `projects/${PROJECT_ID}/secrets/secret3/versions/latest`,
 		});
-		expect(getSpy).not.toHaveBeenCalledWith({
-			name: `projects/${PROJECT_ID}/secrets/#@&/versions/latest`,
-		});
 
 		expect(gcpSecretsManager.getSecret('secret1')).toBe('value1');
 		expect(gcpSecretsManager.getSecret('secret2')).toBe('value2');
 		expect(gcpSecretsManager.getSecret('secret3')).toBeUndefined(); // no value
-		expect(gcpSecretsManager.getSecret('#@&')).toBeUndefined(); // unsupported name
 	});
 
 	it('should throw a generic error when accessing secret versions', async () => {
@@ -155,7 +149,6 @@ describe('GCP Secrets Manager', () => {
 			secret1: 'value1',
 			secret2: 'value2',
 			secret3: '', // no value
-			'#@&': 'value', // unsupported name
 		};
 
 		await gcpSecretsManager.init(
@@ -172,7 +165,6 @@ describe('GCP Secrets Manager', () => {
 					{ name: `projects/${PROJECT_ID}/secrets/secret1` },
 					{ name: `projects/${PROJECT_ID}/secrets/secret2` },
 					{ name: `projects/${PROJECT_ID}/secrets/secret3` },
-					{ name: `projects/${PROJECT_ID}/secrets/#@&` },
 				],
 			]);
 
@@ -210,7 +202,6 @@ describe('GCP Secrets Manager', () => {
 			secret1: 'value1',
 			secret2: 'value2',
 			secret3: '', // no value
-			'#@&': 'value', // unsupported name
 		};
 
 		await gcpSecretsManager.init(
@@ -227,7 +218,6 @@ describe('GCP Secrets Manager', () => {
 					{ name: `projects/${PROJECT_ID}/secrets/secret1` },
 					{ name: `projects/${PROJECT_ID}/secrets/secret2` },
 					{ name: `projects/${PROJECT_ID}/secrets/secret3` },
-					{ name: `projects/${PROJECT_ID}/secrets/#@&` },
 				],
 			]);
 
@@ -264,14 +254,10 @@ describe('GCP Secrets Manager', () => {
 		expect(getSpy).toHaveBeenCalledWith({
 			name: `projects/${PROJECT_ID}/secrets/secret3/versions/latest`,
 		});
-		expect(getSpy).not.toHaveBeenCalledWith({
-			name: `projects/${PROJECT_ID}/secrets/#@&/versions/latest`,
-		});
 
 		expect(gcpSecretsManager.getSecret('secret1')).toBeUndefined(); // error case
 		expect(gcpSecretsManager.getSecret('secret2')).toBe('value2');
 		expect(gcpSecretsManager.getSecret('secret3')).toBeUndefined(); // no value
-		expect(gcpSecretsManager.getSecret('#@&')).toBeUndefined(); // unsupported name
 	});
 
 	it('should handle errors when accessing secret versions (PERMISSION_DENIED)', async () => {
@@ -284,7 +270,6 @@ describe('GCP Secrets Manager', () => {
 			secret1: 'value1',
 			secret2: 'value2',
 			secret3: '', // no value
-			'#@&': 'value', // unsupported name
 		};
 
 		await gcpSecretsManager.init(
@@ -301,7 +286,6 @@ describe('GCP Secrets Manager', () => {
 					{ name: `projects/${PROJECT_ID}/secrets/secret1` },
 					{ name: `projects/${PROJECT_ID}/secrets/secret2` },
 					{ name: `projects/${PROJECT_ID}/secrets/secret3` },
-					{ name: `projects/${PROJECT_ID}/secrets/#@&` },
 				],
 			]);
 
@@ -338,14 +322,10 @@ describe('GCP Secrets Manager', () => {
 		expect(getSpy).toHaveBeenCalledWith({
 			name: `projects/${PROJECT_ID}/secrets/secret3/versions/latest`,
 		});
-		expect(getSpy).not.toHaveBeenCalledWith({
-			name: `projects/${PROJECT_ID}/secrets/#@&/versions/latest`,
-		});
 
 		expect(gcpSecretsManager.getSecret('secret1')).toBeUndefined(); // error case
 		expect(gcpSecretsManager.getSecret('secret2')).toBe('value2');
 		expect(gcpSecretsManager.getSecret('secret3')).toBeUndefined(); // no value
-		expect(gcpSecretsManager.getSecret('#@&')).toBeUndefined(); // unsupported name
 	});
 
 	it('should handle errors when accessing secret versions (UNAVAILABLE)', async () => {
@@ -358,7 +338,6 @@ describe('GCP Secrets Manager', () => {
 			secret1: 'value1',
 			secret2: 'value2',
 			secret3: '', // no value
-			'#@&': 'value', // unsupported name
 		};
 
 		await gcpSecretsManager.init(
@@ -375,7 +354,6 @@ describe('GCP Secrets Manager', () => {
 					{ name: `projects/${PROJECT_ID}/secrets/secret1` },
 					{ name: `projects/${PROJECT_ID}/secrets/secret2` },
 					{ name: `projects/${PROJECT_ID}/secrets/secret3` },
-					{ name: `projects/${PROJECT_ID}/secrets/#@&` },
 				],
 			]);
 
@@ -412,13 +390,9 @@ describe('GCP Secrets Manager', () => {
 		expect(getSpy).toHaveBeenCalledWith({
 			name: `projects/${PROJECT_ID}/secrets/secret3/versions/latest`,
 		});
-		expect(getSpy).not.toHaveBeenCalledWith({
-			name: `projects/${PROJECT_ID}/secrets/#@&/versions/latest`,
-		});
 
 		expect(gcpSecretsManager.getSecret('secret1')).toBeUndefined(); // error case
 		expect(gcpSecretsManager.getSecret('secret2')).toBe('value2');
 		expect(gcpSecretsManager.getSecret('secret3')).toBeUndefined(); // no value
-		expect(gcpSecretsManager.getSecret('#@&')).toBeUndefined(); // unsupported name
 	});
 });

--- a/packages/cli/src/modules/external-secrets.ee/providers/aws-secrets-manager.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/aws-secrets-manager.ts
@@ -3,7 +3,7 @@ import { Logger } from '@n8n/backend-common';
 import { Container } from '@n8n/di';
 import type { INodeProperties } from 'n8n-workflow';
 
-import { DOCS_HELP_NOTICE, EXTERNAL_SECRETS_NAME_REGEX } from '../constants';
+import { DOCS_HELP_NOTICE } from '../constants';
 import { UnknownAuthTypeError } from '../errors/unknown-auth-type.error';
 import { SecretsProvider } from '../types';
 import type { SecretsProviderSettings } from '../types';
@@ -148,7 +148,7 @@ export class AwsSecretsManager extends SecretsProvider {
 	async update() {
 		const secrets = await this.fetchAllSecrets();
 
-		const supportedSecrets = secrets.filter((s) => EXTERNAL_SECRETS_NAME_REGEX.test(s.secretName));
+		const supportedSecrets = secrets;
 
 		this.cachedSecrets = Object.fromEntries(
 			supportedSecrets.map((s) => [s.secretName, s.secretValue]),

--- a/packages/cli/src/modules/external-secrets.ee/providers/azure-key-vault/azure-key-vault.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/azure-key-vault/azure-key-vault.ts
@@ -4,7 +4,7 @@ import { Container } from '@n8n/di';
 import type { INodeProperties } from 'n8n-workflow';
 
 import type { AzureKeyVaultContext } from './types';
-import { DOCS_HELP_NOTICE, EXTERNAL_SECRETS_NAME_REGEX } from '../../constants';
+import { DOCS_HELP_NOTICE } from '../../constants';
 import { SecretsProvider } from '../../types';
 
 export class AzureKeyVault extends SecretsProvider {
@@ -108,12 +108,10 @@ export class AzureKeyVault extends SecretsProvider {
 			secretNames.push(secret.name);
 		}
 
-		const promises = secretNames
-			.filter((name) => EXTERNAL_SECRETS_NAME_REGEX.test(name))
-			.map(async (name) => {
-				const { value } = await this.client.getSecret(name);
-				return { name, value };
-			});
+		const promises = secretNames.map(async (name) => {
+			const { value } = await this.client.getSecret(name);
+			return { name, value };
+		});
 
 		const secrets = await Promise.all(promises);
 

--- a/packages/cli/src/modules/external-secrets.ee/providers/gcp-secrets-manager/gcp-secrets-manager.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/gcp-secrets-manager/gcp-secrets-manager.ts
@@ -8,7 +8,7 @@ import type {
 	GcpSecretAccountKey,
 	RawGcpSecretAccountKey,
 } from './types';
-import { DOCS_HELP_NOTICE, EXTERNAL_SECRETS_NAME_REGEX } from '../../constants';
+import { DOCS_HELP_NOTICE } from '../../constants';
 import { SecretsProvider } from '../../types';
 
 export class GcpSecretsManager extends SecretsProvider {
@@ -82,7 +82,7 @@ export class GcpSecretsManager extends SecretsProvider {
 		});
 
 		const secretNames = rawSecretNames.reduce<string[]>((acc, cur) => {
-			if (!cur.name || !EXTERNAL_SECRETS_NAME_REGEX.test(cur.name)) return acc;
+			if (!cur.name) return acc;
 
 			const secretName = cur.name.split('/').pop();
 

--- a/packages/cli/src/modules/external-secrets.ee/providers/infisical.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/infisical.ts
@@ -1,7 +1,6 @@
 import type InfisicalClient from 'infisical-node';
 import { UnexpectedError, type IDataObject, type INodeProperties } from 'n8n-workflow';
 
-import { EXTERNAL_SECRETS_NAME_REGEX } from '../constants';
 import { SecretsProvider } from '../types';
 import type { SecretsProviderSettings } from '../types';
 
@@ -145,7 +144,7 @@ export class InfisicalProvider extends SecretsProvider {
 	}
 
 	getSecretNames(): string[] {
-		return Object.keys(this.cachedSecrets).filter((k) => EXTERNAL_SECRETS_NAME_REGEX.test(k));
+		return Object.keys(this.cachedSecrets);
 	}
 
 	hasSecret(name: string): boolean {

--- a/packages/cli/src/modules/external-secrets.ee/providers/vault.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/vault.ts
@@ -4,7 +4,7 @@ import type { AxiosInstance, AxiosResponse } from 'axios';
 import axios from 'axios';
 import type { IDataObject, INodeProperties } from 'n8n-workflow';
 
-import { DOCS_HELP_NOTICE, EXTERNAL_SECRETS_NAME_REGEX } from '../constants';
+import { DOCS_HELP_NOTICE } from '../constants';
 import { ExternalSecretsConfig } from '../external-secrets.config';
 import type { SecretsProviderSettings } from '../types';
 import { SecretsProvider } from '../types';
@@ -526,15 +526,9 @@ export class VaultProvider extends SecretsProvider {
 
 	getSecretNames(): string[] {
 		const getKeys = ([k, v]: [string, IDataObject]): string[] => {
-			if (!EXTERNAL_SECRETS_NAME_REGEX.test(k)) {
-				return [];
-			}
 			if (typeof v === 'object') {
 				const keys: string[] = [];
 				for (const key of Object.keys(v)) {
-					if (!EXTERNAL_SECRETS_NAME_REGEX.test(key)) {
-						continue;
-					}
 					const value = v[key];
 					if (typeof value === 'object' && value !== null) {
 						keys.push(...getKeys([key, value as IDataObject]).map((ok) => `${k}.${ok}`));

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-completions.controller.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-completions.controller.ee.ts
@@ -1,7 +1,7 @@
 import type { SecretCompletionsResponse } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import type { AuthenticatedRequest } from '@n8n/db';
-import { Get, GlobalScope, Middleware, Param, RestController } from '@n8n/decorators';
+import { Get, GlobalScope, Middleware, Param, ProjectScope, RestController } from '@n8n/decorators';
 import type { NextFunction, Request, Response } from 'express';
 
 import { ExternalSecretsConfig } from './external-secrets.config';
@@ -52,6 +52,7 @@ export class SecretProvidersCompletionsController {
 
 	@Get('/secrets/global')
 	@GlobalScope('externalSecret:list')
+	@ProjectScope('externalSecret:list')
 	async listGlobalSecrets(): Promise<SecretCompletionsResponse> {
 		this.logger.debug('Listing global secrets');
 		const connections = await this.connectionsService.getGlobalCompletions();
@@ -60,6 +61,7 @@ export class SecretProvidersCompletionsController {
 
 	@Get('/secrets/project/:projectId')
 	@GlobalScope('externalSecret:list')
+	@ProjectScope('externalSecret:list')
 	async listProjectSecrets(
 		_req: AuthenticatedRequest,
 		_res: Response,

--- a/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/completions/datatype.completions.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/completions/datatype.completions.ts
@@ -54,6 +54,7 @@ import {
 	isCredentialsModalOpen,
 	isPseudoParam,
 	isSplitInBatchesAbsent,
+	isValidJavascriptIdentifier,
 	longestCommonPrefix,
 	prefixMatch,
 	resolveAutocompleteExpression,
@@ -1245,7 +1246,6 @@ export const secretOptions = (base: string) => {
 			return [];
 		}
 		return Object.entries(resolved).map(([secret, value]) => {
-			const needsBracketAccess = /\//.test(secret);
 			const option = createCompletionOption({
 				name: secret,
 				doc: {
@@ -1257,7 +1257,7 @@ export const secretOptions = (base: string) => {
 			});
 
 			// Override the apply handler for keys that need bracket access
-			if (needsBracketAccess) {
+			if (!isValidJavascriptIdentifier(secret)) {
 				option.apply = applyBracketAccessCompletion;
 			}
 

--- a/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/completions/utils.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/completions/utils.ts
@@ -138,6 +138,22 @@ export const isAllowedInDotNotation = (str: string) => {
 	return !DOT_NOTATION_BANNED_CHARS.test(str);
 };
 
+/**
+ * Whether is a string is a valid identifier to be used in dot notation.
+ * Allow-list alternative to the blocked-list approach in isAllowedInDotNotation.
+ * Rules:
+ * - Must start with a letter, underscore, or dollar sign.
+ * - Followed by zero or more letters, numbers, underscores, or dollar signs.
+ * - Nothing else allowed after that.
+ *
+ * Link to the spec: https://tc39.es/ecma262/#prod-IdentifierStart
+ */
+export const isValidJavascriptIdentifier = (str: string) => {
+	const VALID_IDENTIFIER = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/;
+
+	return VALID_IDENTIFIER.test(str);
+};
+
 // ----------------------------------
 //      resolution-based utils
 // ----------------------------------


### PR DESCRIPTION
## Summary

Demo video: https://www.loom.com/share/fd2ef3c6824c4850a8642f341e0df254

Since we can switch to bracket access instead of dot notation for secret names that don't fulfill the Ecmascript identifier spec (https://github.com/n8n-io/n8n/commit/488a929ea6772b7fd1f4971b0d3055ee1f52c30a), we don't need to have this restriction on the backend anymore.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-257/fe-add-support-for-more-special-characters-in-secret-names-in-secret


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
