### PR TITLE
feat: Initialise data redaction module, execution data redaction service

### DIFF
--- a/packages/cli/src/modules/redaction/__tests__/redaction.module.test.ts
+++ b/packages/cli/src/modules/redaction/__tests__/redaction.module.test.ts
@@ -1,0 +1,62 @@
+import { Logger } from '@n8n/backend-common';
+import { mockInstance } from '@n8n/backend-test-utils';
+import { Container } from '@n8n/di';
+import { mock } from 'jest-mock-extended';
+
+import { ExecutionRedactionService } from '../executions/execution-redaction.service';
+import { RedactionModule } from '../redaction.module';
+
+describe('RedactionModule', () => {
+	let module: RedactionModule;
+	let executionRedactionService: jest.Mocked<ExecutionRedactionService>;
+	const originalEnv = process.env.N8N_ENABLE_EXECUTION_REDACTION;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		Container.reset();
+
+		const logger = mockInstance(Logger);
+		executionRedactionService = mock<ExecutionRedactionService>();
+		executionRedactionService.init.mockResolvedValue(undefined);
+		Container.set(ExecutionRedactionService, executionRedactionService);
+		Container.set(Logger, logger);
+
+		module = new RedactionModule();
+	});
+
+	afterEach(() => {
+		// Restore original environment variable
+		if (originalEnv !== undefined) {
+			process.env.N8N_ENABLE_EXECUTION_REDACTION = originalEnv;
+		} else {
+			delete process.env.N8N_ENABLE_EXECUTION_REDACTION;
+		}
+	});
+
+	describe('init', () => {
+		it.each([
+			['not set', undefined],
+			['"false"', 'false'],
+			['empty string', ''],
+			['"1"', '1'],
+		])('should not initialize when N8N_ENABLE_EXECUTION_REDACTION is %s', async (_, value) => {
+			if (value === undefined) {
+				delete process.env.N8N_ENABLE_EXECUTION_REDACTION;
+			} else {
+				process.env.N8N_ENABLE_EXECUTION_REDACTION = value;
+			}
+
+			await module.init();
+
+			expect(executionRedactionService.init).not.toHaveBeenCalled();
+		});
+
+		it('should initialize and call ExecutionRedactionService.init() when N8N_ENABLE_EXECUTION_REDACTION is "true"', async () => {
+			process.env.N8N_ENABLE_EXECUTION_REDACTION = 'true';
+
+			await module.init();
+
+			expect(executionRedactionService.init).toHaveBeenCalledTimes(1);
+		});
+	});
+});

--- a/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
+++ b/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@n8n/backend-common';
 import { mockInstance } from '@n8n/backend-test-utils';
 import type { IExecutionDb } from '@n8n/db';
-import { ExecutionStatus, WorkflowExecuteMode } from 'n8n-workflow';
+import type { ExecutionStatus, WorkflowExecuteMode } from 'n8n-workflow';
 
 import {
 	ExecutionRedactionService,

--- a/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
+++ b/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
@@ -1,0 +1,159 @@
+import { Logger } from '@n8n/backend-common';
+import { mockInstance } from '@n8n/backend-test-utils';
+import type { IExecutionDb } from '@n8n/db';
+import { ExecutionStatus, WorkflowExecuteMode } from 'n8n-workflow';
+
+import {
+	ExecutionRedactionService,
+	type ExecutionRedactionOptions,
+} from '../execution-redaction.service';
+
+describe('ExecutionRedactionService', () => {
+	const logger = mockInstance(Logger);
+	let service: ExecutionRedactionService;
+
+	beforeEach(() => {
+		service = new ExecutionRedactionService(logger);
+	});
+
+	describe('processExecution', () => {
+		const createMockExecution = (): IExecutionDb => {
+			// @ts-expect-error - Partial mock data for testing
+			return {
+				id: 'execution-123',
+				mode: 'manual' as WorkflowExecuteMode,
+				createdAt: new Date('2024-01-01'),
+				startedAt: new Date('2024-01-01'),
+				stoppedAt: new Date('2024-01-01'),
+				workflowId: 'workflow-123',
+				finished: true,
+				retryOf: undefined,
+				retrySuccessId: undefined,
+				status: 'success' as ExecutionStatus,
+				waitTill: null,
+				storedAt: 'db',
+				data: {
+					version: 1,
+					resultData: {
+						runData: {},
+					},
+					executionData: {
+						contextData: {},
+						nodeExecutionStack: [],
+						metadata: {},
+						waitingExecution: {},
+						waitingExecutionSource: null,
+					},
+				},
+				workflowData: {
+					id: 'workflow-123',
+					name: 'Test Workflow',
+					active: false,
+					isArchived: false,
+					createdAt: new Date('2024-01-01'),
+					updatedAt: new Date('2024-01-01'),
+					nodes: [],
+					connections: {},
+					settings: {},
+					staticData: {},
+					activeVersionId: null,
+				},
+			} as IExecutionDb;
+		};
+
+		it('should return unmodified execution when no options provided', async () => {
+			const execution = createMockExecution();
+
+			const result = await service.processExecution(execution);
+
+			expect(result).toBe(execution);
+			expect(result).toEqual(execution);
+		});
+
+		it('should return unmodified execution when applyRedaction is false', async () => {
+			const execution = createMockExecution();
+			const options: ExecutionRedactionOptions = {
+				applyRedaction: false,
+			};
+
+			const result = await service.processExecution(execution, options);
+
+			expect(result).toBe(execution);
+			expect(result).toEqual(execution);
+		});
+
+		it('should return unmodified execution when applyRedaction is true (stub behavior)', async () => {
+			const execution = createMockExecution();
+			const options: ExecutionRedactionOptions = {
+				applyRedaction: true,
+			};
+
+			const result = await service.processExecution(execution, options);
+
+			// Stub implementation should return unmodified execution
+			expect(result).toBe(execution);
+			expect(result).toEqual(execution);
+		});
+
+		it('should return unmodified execution with context options', async () => {
+			const execution = createMockExecution();
+			const options: ExecutionRedactionOptions = {
+				applyRedaction: true,
+				context: {
+					userId: 'user-123',
+					projectId: 'project-123',
+				},
+			};
+
+			const result = await service.processExecution(execution, options);
+
+			expect(result).toBe(execution);
+			expect(result).toEqual(execution);
+		});
+
+		it('should log debug message when processing execution', async () => {
+			const execution = createMockExecution();
+			const options: ExecutionRedactionOptions = {
+				applyRedaction: true,
+			};
+
+			await service.processExecution(execution, options);
+
+			expect(logger.debug).toHaveBeenCalledWith('Processing execution for redaction', {
+				executionId: execution.id,
+				options,
+			});
+		});
+	});
+
+	describe('canUserReveal', () => {
+		it('should return false (stub behavior)', async () => {
+			const userId = 'user-123';
+			const executionId = 'execution-123';
+
+			const result = await service.canUserReveal(userId, executionId);
+
+			expect(result).toBe(false);
+		});
+
+		it('should log debug message when checking reveal permissions', async () => {
+			const userId = 'user-123';
+			const executionId = 'execution-123';
+
+			await service.canUserReveal(userId, executionId);
+
+			expect(logger.debug).toHaveBeenCalledWith('Checking reveal permissions', {
+				userId,
+				executionId,
+			});
+		});
+
+		it('should return false for different user and execution combinations', async () => {
+			const result1 = await service.canUserReveal('user-1', 'execution-1');
+			const result2 = await service.canUserReveal('user-2', 'execution-2');
+
+			expect(result1).toBe(false);
+			expect(result2).toBe(false);
+		});
+	});
+});

--- a/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
+++ b/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
@@ -1,0 +1,87 @@
+import type { IExecutionDb } from '@n8n/db';
+import { Service } from '@n8n/di';
+import { Logger } from '@n8n/backend-common';
+
+export interface ExecutionRedactionOptions {
+	applyRedaction?: boolean;
+	context?: Record<string, unknown>;
+}
+
+/**
+ * Service responsible for redacting sensitive data from executions.
+ * This service acts as a facade and delegates to the redaction module.
+ */
+@Service()
+export class ExecutionRedactionService {
+	constructor(private readonly logger: Logger) {}
+
+	/**
+	 * Initializes the execution redaction service.
+	 * This is a stub implementation that will be extended when the redaction module is fully implemented.
+	 */
+	async init(): Promise<void> {
+		this.logger.debug('Initializing ExecutionRedactionService...');
+		// Stub implementation: no initialization needed yet
+		// TODO: Add actual initialization logic when redaction module is implemented, loading from env, etc
+	}
+
+	/**
+	 * Main entry point for redaction logic.
+	 * Processes an execution and applies redaction based on the provided options.
+	 *
+	 * @param execution - The execution to process
+	 * @param options - Options for redaction processing
+	 * @returns The processed execution (currently returns unmodified execution as stub)
+	 *
+	 * @example
+	 * ```typescript
+	 * const redactedExecution = await executionRedactionService.processExecution(
+	 *   execution,
+	 *   { applyRedaction: true }
+	 * );
+	 * ```
+	 */
+	async processExecution(
+		execution: IExecutionDb,
+		options: ExecutionRedactionOptions = {},
+	): Promise<IExecutionDb> {
+		this.logger.debug('Processing execution for redaction', {
+			executionId: execution.id,
+			options,
+		});
+
+		// Stub implementation: return unmodified execution
+		// TODO: Delegate to redaction module when implemented
+		return execution;
+	}
+
+	/**
+	 * Checks whether a user has permission to reveal redacted data in an execution.
+	 *
+	 * @param userId - The ID of the user requesting access
+	 * @param executionId - The ID of the execution to check
+	 * @returns `true` if the user can reveal redacted data, `false` otherwise
+	 *          (currently returns `false` as stub)
+	 *
+	 * @example
+	 * ```typescript
+	 * const canReveal = await executionRedactionService.canUserReveal(
+	 *   userId,
+	 *   executionId
+	 * );
+	 * if (canReveal) {
+	 *   // Show full execution data
+	 * }
+	 * ```
+	 */
+	async canUserReveal(userId: string, executionId: string): Promise<boolean> {
+		this.logger.debug('Checking reveal permissions', {
+			userId,
+			executionId,
+		});
+
+		// Stub implementation: return false (no reveal permission)
+		// TODO: Implement actual permission check when redaction module is available
+		return false;
+	}
+}

--- a/packages/cli/src/modules/redaction/redaction.module.ts
+++ b/packages/cli/src/modules/redaction/redaction.module.ts
@@ -2,9 +2,16 @@ import type { ModuleInterface } from '@n8n/decorators';
 import { BackendModule } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 
+function isExecutionRedactionEnabled(): boolean {
+	return process.env.N8N_ENABLE_EXECUTION_REDACTION === 'true';
+}
+
 @BackendModule({ name: 'redaction', instanceTypes: ['main'] })
 export class RedactionModule implements ModuleInterface {
 	async init() {
+		if (!isExecutionRedactionEnabled()) {
+			return;
+		}
 		const { ExecutionRedactionService } = await import('./executions/execution-redaction.service');
 		await Container.get(ExecutionRedactionService).init();
 	}

--- a/packages/cli/src/modules/redaction/redaction.module.ts
+++ b/packages/cli/src/modules/redaction/redaction.module.ts
@@ -1,0 +1,11 @@
+import type { ModuleInterface } from '@n8n/decorators';
+import { BackendModule } from '@n8n/decorators';
+import { Container } from '@n8n/di';
+
+@BackendModule({ name: 'redaction', instanceTypes: ['main'] })
+export class RedactionModule implements ModuleInterface {
+	async init() {
+		const { ExecutionRedactionService } = await import('./executions/execution-redaction.service');
+		await Container.get(ExecutionRedactionService).init();
+	}
+}


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR adds scaffolding for the redaction module, as well as the specific execution-redaction service for targeting execution data.

This module is currently feature flagged with dynamic imports.

## Related Linear tickets, Github issues, and Community forum posts

closes IAM-175
closes IAM-176

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
