### PR TITLE
chore: Disable flaky tests on codemirror-lang-sql

### DIFF
--- a/packages/@n8n/codemirror-lang-sql/package.json
+++ b/packages/@n8n/codemirror-lang-sql/package.json
@@ -4,11 +4,9 @@
   "description": "SQL + n8n expression language support for CodeMirror 6",
   "scripts": {
     "clean": "rimraf dist .turbo",
-    "test": "jest",
     "generate:sql:grammar": "lezer-generator --typeScript --output src/grammar.sql.ts src/sql.grammar",
     "generate": "pnpm generate:sql:grammar && pnpm format",
     "build": "tsc -p tsconfig.build.json",
-    "test:unit": "jest",
     "lint": "eslint . --quiet",
     "lint:fix": "eslint . --fix",
     "format": "biome format --write src test",


### PR DESCRIPTION
## Summary

Based on discussion, disable flaky codemirror fork tests in 1.x.

No code changes to the completion logic is going to be backported anyway so no changes will happen to the package.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2405/disable-codemirror-sql-unit-tests-in-1x

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
