### PR TITLE
feat(editor): Add clickable assignee count on project roles page

### DIFF
--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -93,6 +93,7 @@ export { createHeartbeatMessage, heartbeatMessageSchema } from './push/heartbeat
 export type { SendWorkerStatusMessage } from './push/worker';
 
 export type { BannerName } from './schemas/banner-name.schema';
+export type { RoleAssigneeDto } from './schemas/role-assignee.schema';
 export { ViewableMimeTypes } from './schemas/binary-data.schema';
 export { passwordSchema } from './schemas/password.schema';
 export {

--- a/packages/@n8n/api-types/src/schemas/role-assignee.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/role-assignee.schema.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const roleAssigneeSchema = z.object({
+	userId: z.string(),
+	email: z.string(),
+	firstName: z.string(),
+	lastName: z.string(),
+	projectId: z.string(),
+	projectName: z.string(),
+});
+
+export type RoleAssigneeDto = z.infer<typeof roleAssigneeSchema>;

--- a/packages/@n8n/db/src/repositories/project-relation.repository.ts
+++ b/packages/@n8n/db/src/repositories/project-relation.repository.ts
@@ -76,6 +76,30 @@ export class ProjectRelationRepository extends Repository<ProjectRelation> {
 		return [...new Set(rows.map((r) => r.userId))];
 	}
 
+	/** Returns users assigned to a specific role, along with which project they're in */
+	async findUsersByRoleSlug(roleSlug: string) {
+		return await this.createQueryBuilder('pr')
+			.innerJoin('pr.user', 'user')
+			.innerJoin('pr.project', 'project')
+			.select([
+				'user.id AS "userId"',
+				'user.email AS "email"',
+				'user.firstName AS "firstName"',
+				'user.lastName AS "lastName"',
+				'project.id AS "projectId"',
+				'project.name AS "projectName"',
+			])
+			.where('pr.role = :roleSlug', { roleSlug })
+			.getRawMany<{
+				userId: string;
+				email: string;
+				firstName: string;
+				lastName: string;
+				projectId: string;
+				projectName: string;
+			}>();
+	}
+
 	async findAllByUser(userId: string) {
 		return await this.find({
 			where: {

--- a/packages/cli/src/controllers/role.controller.ts
+++ b/packages/cli/src/controllers/role.controller.ts
@@ -1,4 +1,10 @@
-import { CreateRoleDto, RoleGetQueryDto, RoleListQueryDto, UpdateRoleDto } from '@n8n/api-types';
+import {
+	CreateRoleDto,
+	RoleGetQueryDto,
+	RoleListQueryDto,
+	UpdateRoleDto,
+	type RoleAssigneeDto,
+} from '@n8n/api-types';
 import { LICENSE_FEATURES } from '@n8n/constants';
 import { AuthenticatedRequest } from '@n8n/db';
 import {
@@ -34,6 +40,16 @@ export class RoleController {
 			credential: allRoles.filter((r) => r.roleType === 'credential'),
 			workflow: allRoles.filter((r) => r.roleType === 'workflow'),
 		};
+	}
+
+	@Get('/:slug/users')
+	@GlobalScope('role:manage')
+	async getRoleAssignees(
+		_req: AuthenticatedRequest,
+		_res: Response,
+		@Param('slug') slug: string,
+	): Promise<RoleAssigneeDto[]> {
+		return await this.roleService.getUsersForRole(slug);
 	}
 
 	@Get('/:slug')

--- a/packages/cli/src/services/__tests__/role.service.rolesWithScope.test.ts
+++ b/packages/cli/src/services/__tests__/role.service.rolesWithScope.test.ts
@@ -1,6 +1,6 @@
 import type { LicenseState } from '@n8n/backend-common';
 import { mockInstance } from '@n8n/backend-test-utils';
-import { RoleRepository, ScopeRepository } from '@n8n/db';
+import { ProjectRelationRepository, RoleRepository, ScopeRepository } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 
 import { RoleCacheService } from '@/services/role-cache.service';
@@ -14,10 +14,12 @@ describe('RoleService.rolesWithScope', () => {
 	const roleCacheService = mockInstance(RoleCacheService);
 	const logger = mockInstance(Logger);
 
+	const projectRelationRepository = mockInstance(ProjectRelationRepository);
 	const roleService = new RoleService(
 		licenseState,
 		roleRepository,
 		scopeRepository,
+		projectRelationRepository,
 		roleCacheService,
 		logger,
 	);

--- a/packages/cli/src/services/role.service.ts
+++ b/packages/cli/src/services/role.service.ts
@@ -8,6 +8,7 @@ import {
 	ListQueryDb,
 	ScopesField,
 	ProjectRelation,
+	ProjectRelationRepository,
 	RoleRepository,
 	Role,
 	Scope as DBScope,
@@ -45,6 +46,7 @@ export class RoleService {
 		private readonly license: LicenseState,
 		private readonly roleRepository: RoleRepository,
 		private readonly scopeRepository: ScopeRepository,
+		private readonly projectRelationRepository: ProjectRelationRepository,
 		private readonly roleCacheService: RoleCacheService,
 		private readonly logger: Logger,
 	) {}
@@ -82,6 +84,17 @@ export class RoleService {
 			return this.dbRoleToRoleDTO(role, usedByUsers);
 		}
 		throw new NotFoundError('Role not found');
+	}
+
+	async getUsersForRole(slug: string) {
+		const role = await this.roleRepository.findBySlug(slug);
+		if (!role) {
+			throw new NotFoundError('Role not found');
+		}
+		if (role.roleType !== 'project') {
+			return [];
+		}
+		return await this.projectRelationRepository.findUsersByRoleSlug(slug);
 	}
 
 	async removeCustomRole(slug: string) {

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2363,6 +2363,8 @@
 	"projectRoles.sourceControl.table.type": "Type",
 	"projectRoles.sourceControl.table.assignedTo": "Assigned to",
 	"projectRoles.sourceControl.table.lastEdited": "Last edited",
+	"projectRoles.assignees.title": "Assigned users",
+	"projectRoles.assignees.noAssignees": "No users assigned to this role",
 	"projectRoles.backToRoleList": "Back to role list",
 	"projectRoles.newRole": "New Role",
 	"projectRoles.addRole": "Add role",

--- a/packages/frontend/@n8n/rest-api-client/src/api/roles.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/api/roles.ts
@@ -1,4 +1,4 @@
-import type { CreateRoleDto, UpdateRoleDto } from '@n8n/api-types';
+import type { CreateRoleDto, RoleAssigneeDto, UpdateRoleDto } from '@n8n/api-types';
 import type { AllRolesMap, Role } from '@n8n/permissions';
 
 import type { IRestApiContext } from '../types';
@@ -32,4 +32,11 @@ export const updateProjectRole = async (
 
 export const deleteProjectRole = async (context: IRestApiContext, slug: string): Promise<Role> => {
 	return await makeRestApiRequest(context, 'DELETE', `/roles/${slug}`);
+};
+
+export const getRoleAssignees = async (
+	context: IRestApiContext,
+	slug: string,
+): Promise<RoleAssigneeDto[]> => {
+	return await makeRestApiRequest(context, 'GET', `/roles/${encodeURIComponent(slug)}/users`);
 };

--- a/packages/frontend/editor-ui/src/app/stores/roles.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/roles.store.ts
@@ -8,7 +8,7 @@ import { defineStore } from 'pinia';
 import { ref, computed } from 'vue';
 import * as rolesApi from '@n8n/rest-api-client/api/roles';
 import { useRootStore } from '@n8n/stores/useRootStore';
-import type { CreateRoleDto, UpdateRoleDto } from '@n8n/api-types';
+import type { CreateRoleDto, RoleAssigneeDto, UpdateRoleDto } from '@n8n/api-types';
 import { useSettingsStore } from './settings.store';
 
 export const useRolesStore = defineStore('roles', () => {
@@ -68,6 +68,10 @@ export const useRolesStore = defineStore('roles', () => {
 		return await rolesApi.deleteProjectRole(rootStore.restApiContext, slug);
 	};
 
+	const fetchRoleAssignees = async (slug: string): Promise<RoleAssigneeDto[]> => {
+		return await rolesApi.getRoleAssignees(rootStore.restApiContext, slug);
+	};
+
 	const updateProjectRole = async (slug: string, body: UpdateRoleDto): Promise<Role> => {
 		return await rolesApi.updateProjectRole(rootStore.restApiContext, slug, body);
 	};
@@ -82,5 +86,6 @@ export const useRolesStore = defineStore('roles', () => {
 		fetchRoleBySlug,
 		updateProjectRole,
 		deleteProjectRole,
+		fetchRoleAssignees,
 	};
 });

--- a/packages/frontend/editor-ui/src/features/project-roles/ProjectRolesView.vue
+++ b/packages/frontend/editor-ui/src/features/project-roles/ProjectRolesView.vue
@@ -24,6 +24,8 @@ import dateformat from 'dateformat';
 import { onMounted, ref, useCssModule } from 'vue';
 import { useRouter } from 'vue-router';
 
+import RoleAssigneesPopover from './RoleAssigneesPopover.vue';
+
 const { showError, showMessage } = useToast();
 
 const rolesStore = useRolesStore();
@@ -58,7 +60,6 @@ const headers = ref<Array<TableHeader<Role>>>([
 		key: 'usedByUsers',
 		disableSort: true,
 		align: 'end',
-		value: (item: Role) => item.usedByUsers ?? 0,
 		width: 75,
 		resize: false,
 	},
@@ -261,6 +262,9 @@ function addRole() {
 					<template v-else>
 						<N8nIcon icon="user-pen" /> {{ i18n.baseText('projectRoles.literal.custom') }}</template
 					>
+				</template>
+				<template #[`item.usedByUsers`]="{ item }">
+					<RoleAssigneesPopover :role-slug="item.slug" :count="item.usedByUsers ?? 0" />
 				</template>
 				<template #[`item.actions`]="{ item }">
 					<N8nActionToggle

--- a/packages/frontend/editor-ui/src/features/project-roles/RoleAssigneesPopover.vue
+++ b/packages/frontend/editor-ui/src/features/project-roles/RoleAssigneesPopover.vue
@@ -1,0 +1,141 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { N8nPopover, N8nText, N8nLoading, N8nUserInfo } from '@n8n/design-system';
+import { useI18n } from '@n8n/i18n';
+import type { RoleAssigneeDto } from '@n8n/api-types';
+import { useRolesStore } from '@/app/stores/roles.store';
+
+const props = defineProps<{
+	roleSlug: string;
+	count: number;
+}>();
+
+const i18n = useI18n();
+const rolesStore = useRolesStore();
+
+const isOpen = ref(false);
+const isLoading = ref(false);
+const assignees = ref<RoleAssigneeDto[]>([]);
+
+const groupedByProject = computed(() => {
+	const groups = new Map<string, { projectName: string; users: RoleAssigneeDto[] }>();
+	for (const assignee of assignees.value) {
+		const existing = groups.get(assignee.projectId);
+		if (existing) {
+			existing.users.push(assignee);
+		} else {
+			groups.set(assignee.projectId, {
+				projectName: assignee.projectName,
+				users: [assignee],
+			});
+		}
+	}
+	return [...groups.values()];
+});
+
+async function handleOpenChange(open: boolean) {
+	isOpen.value = open;
+	if (open && assignees.value.length === 0 && props.count > 0) {
+		isLoading.value = true;
+		try {
+			assignees.value = await rolesStore.fetchRoleAssignees(props.roleSlug);
+		} finally {
+			isLoading.value = false;
+		}
+	}
+}
+
+function handleTriggerClick(event: MouseEvent) {
+	if (props.count === 0) return;
+	event.stopPropagation();
+	void handleOpenChange(!isOpen.value);
+}
+</script>
+
+<template>
+	<N8nPopover
+		:open="isOpen"
+		width="320px"
+		max-height="400px"
+		:suppress-auto-focus="true"
+		@update:open="handleOpenChange"
+	>
+		<template #trigger>
+			<N8nText
+				:class="{ [$style.clickableCount]: count > 0 }"
+				data-test-id="role-assignees-count"
+				@click="handleTriggerClick"
+			>
+				{{ count }}
+			</N8nText>
+		</template>
+		<template #content>
+			<div :class="$style.container">
+				<N8nText :class="$style.title" :bold="true" size="small">
+					{{ i18n.baseText('projectRoles.assignees.title') }}
+				</N8nText>
+				<N8nLoading v-if="isLoading" :rows="3" />
+				<template v-else-if="groupedByProject.length > 0">
+					<div
+						v-for="group in groupedByProject"
+						:key="group.projectName"
+						:class="$style.projectGroup"
+					>
+						<N8nText :class="$style.projectName" size="small" color="text-light">
+							{{ group.projectName }}
+						</N8nText>
+						<div v-for="user in group.users" :key="user.userId" :class="$style.userRow">
+							<N8nUserInfo
+								:first-name="user.firstName"
+								:last-name="user.lastName"
+								:email="user.email"
+							/>
+						</div>
+					</div>
+				</template>
+				<N8nText v-else size="small" color="text-light">
+					{{ i18n.baseText('projectRoles.assignees.noAssignees') }}
+				</N8nText>
+			</div>
+		</template>
+	</N8nPopover>
+</template>
+
+<style lang="css" module>
+.container {
+	padding: var(--spacing--xs);
+}
+
+.title {
+	display: block;
+	margin-bottom: var(--spacing--2xs);
+}
+
+.clickableCount {
+	cursor: pointer;
+	text-decoration: underline;
+	text-decoration-style: dotted;
+	text-underline-offset: 2px;
+}
+
+.clickableCount:hover {
+	color: var(--color--primary);
+}
+
+.projectGroup {
+	margin-bottom: var(--spacing--xs);
+}
+
+.projectGroup:last-child {
+	margin-bottom: 0;
+}
+
+.projectName {
+	display: block;
+	margin-bottom: var(--spacing--4xs);
+}
+
+.userRow {
+	padding: var(--spacing--4xs) 0;
+}
+</style>


### PR DESCRIPTION
## Summary
- Add a clickable "Assigned to" count on the Project Roles settings page that opens a popover showing which users have that role, grouped by project
- New `GET /roles/:slug/users` backend endpoint protected by `role:manage` scope (Owner/Admin only)
- New `RoleAssigneesPopover` Vue component using the design system's `N8nPopover` with lazy-loading

## Related Linear ticket
https://linear.app/n8n/issue/IAM-224

## Review / Merge checklist
- [ ] PR title and target branch are correct
- [ ] Tests are passing
- [ ] Manual test: Navigate to `/settings/project-roles`, click an "Assigned to" count > 0, verify popover shows users grouped by project
- [ ] Manual test: Clicking elsewhere on the row still navigates to role detail page
- [ ] Manual test: Count of 0 is not clickable


🤖 Generated with [Claude Code](https://claude.com/claude-code)