### PR TITLE
chore: Disable publishing on n8n-node-dev

### DIFF
--- a/packages/node-dev/README.md
+++ b/packages/node-dev/README.md
@@ -1,5 +1,9 @@
 ![n8n.io - Workflow Automation](https://user-images.githubusercontent.com/65276001/173571060-9f2f6d7b-bac0-43b6-bdb2-001da9694058.png)
 
+# ⚠️ Deprecated
+
+> **This package is deprecated and no more updates will be published to npm**
+
 # n8n-node-dev
 
 Currently very simple and not very sophisticated CLI which makes it easier

--- a/packages/node-dev/package.json
+++ b/packages/node-dev/package.json
@@ -2,6 +2,7 @@
   "name": "n8n-node-dev",
   "version": "2.9.0",
   "description": "CLI to simplify n8n credentials/node development",
+  "private": true,
   "main": "dist/src/index",
   "types": "dist/src/index.d.ts",
   "oclif": {


### PR DESCRIPTION
## Summary

Mark package as private to prevent publishing new versions via pnpm.

Add small deprecation notice to readme to instruct monorepo users to consider applying changes to said package.

Let's not remove it altogether just yet before gathering data on any possible usecases.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2290/move-n8n-node-dev-package-under-n8n-npm-org

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
