### PR TITLE
chore(core): External secrets - remove delete connection response

### DIFF
--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.controller.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-connections.controller.ee.ts
@@ -111,12 +111,13 @@ export class SecretProvidersConnectionsController {
 	@GlobalScope('externalSecretsProvider:delete')
 	async deleteConnection(
 		req: AuthenticatedRequest,
-		_res: Response,
+		res: Response,
 		@Param('providerKey') providerKey: string,
-	): Promise<SecretsProvidersResponses.PublicConnection> {
+	) {
 		this.logger.debug('Deleting connection', { providerKey });
-		const connection = await this.connectionsService.deleteConnection(providerKey, req.user.id);
-		return this.connectionsService.toPublicConnection(connection);
+		await this.connectionsService.deleteConnection(providerKey, req.user.id);
+		res.status(204).send();
+		return;
 	}
 
 	@Get('/')

--- a/packages/cli/src/modules/external-secrets.ee/secrets-providers-project.controller.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/secrets-providers-project.controller.ee.ts
@@ -123,16 +123,13 @@ export class SecretProvidersProjectController {
 	@ProjectScope('externalSecretsProvider:delete')
 	async deleteConnection(
 		_req: AuthenticatedRequest,
-		_res: Response,
+		res: Response,
 		@Param('projectId') projectId: string,
 		@Param('providerKey') providerKey: string,
-	): Promise<SecretsProvidersResponses.PublicConnection> {
+	) {
 		this.logger.debug('Deleting connection for project', { projectId, providerKey });
-		const connection = await this.connectionsService.deleteConnectionForProject(
-			providerKey,
-			projectId,
-		);
-		return this.connectionsService.toPublicConnection(connection);
+		await this.connectionsService.deleteConnectionForProject(providerKey, projectId);
+		res.status(204).send();
 	}
 
 	@Post('/:projectId/connections/:providerKey/test')

--- a/packages/cli/test/integration/external-secrets/secret-providers-connections.api.test.ts
+++ b/packages/cli/test/integration/external-secrets/secret-providers-connections.api.test.ts
@@ -536,16 +536,8 @@ describe('Secret Providers Connections API', () => {
 			expect(listResponseString).not.toContain('AKIAIOSFODNN7EXAMPLE');
 			expect(listResponseString).not.toContain('very-secret-session-token');
 
-			// DELETE endpoint should include redacted settings in response
-			const deleteResponse = await ownerAgent
-				.delete('/secret-providers/connections/securityTest')
-				.expect(200);
-
-			expect(deleteResponse.body.data).toHaveProperty('settings');
-			const deleteResponseString = JSON.stringify(deleteResponse.body.data.settings);
-			expect(deleteResponseString).toContain('__n8n_BLANK_VALUE_');
-			expect(deleteResponseString).not.toContain('AKIAIOSFODNN7EXAMPLE');
-			expect(deleteResponseString).not.toContain('very-secret-session-token');
+			// DELETE endpoint should return 204 with no body
+			await ownerAgent.delete('/secret-providers/connections/securityTest').expect(204);
 		});
 	});
 
@@ -679,10 +671,9 @@ describe('Secret Providers Connections API', () => {
 				const providerKey = `deleteAuth${role.charAt(0).toUpperCase() + role.slice(1)}Test`;
 				const response = await agents[role]
 					.delete(`/secret-providers/connections/${providerKey}`)
-					.expect(allowed ? 200 : 403);
+					.expect(allowed ? 204 : 403);
 
 				if (allowed) {
-					expect(response.body.data.name).toBe(providerKey);
 					await ownerAgent.get(`/secret-providers/connections/${providerKey}`).expect(404);
 				} else {
 					expect(response.body.message).toBe(FORBIDDEN_MESSAGE);

--- a/packages/cli/test/integration/external-secrets/secret-providers-connections.api.test.ts
+++ b/packages/cli/test/integration/external-secrets/secret-providers-connections.api.test.ts
@@ -355,12 +355,7 @@ describe('Secret Providers Connections API', () => {
 			).findOneByOrFail({ providerKey: 'deleteTest' });
 			const connectionId = savedConnection.id;
 
-			const response = await ownerAgent
-				.delete('/secret-providers/connections/deleteTest')
-				.expect(200);
-
-			expect(response.body.data.name).toBe('deleteTest');
-			expect(response.body.data.projects).toHaveLength(2);
+			await ownerAgent.delete('/secret-providers/connections/deleteTest').expect(204);
 
 			// Verify deletion via GET
 			await ownerAgent.get('/secret-providers/connections/deleteTest').expect(404);

--- a/packages/cli/test/integration/external-secrets/secret-providers-project.api.test.ts
+++ b/packages/cli/test/integration/external-secrets/secret-providers-project.api.test.ts
@@ -549,11 +549,9 @@ describe('Secret Providers Project API', () => {
 		test('should delete a connection belonging to the project', async () => {
 			const connectionId = await createProviderConnection('del-conn', [teamProject1.id]);
 
-			const response = await ownerAgent
+			await ownerAgent
 				.delete(`/secret-providers/projects/${teamProject1.id}/connections/del-conn`)
-				.expect(200);
-
-			expect(response.body.data.name).toBe('del-conn');
+				.expect(204);
 
 			// Verify it's actually gone from the DB
 			const found = await connectionRepository.findOneBy({ id: connectionId });
@@ -596,7 +594,7 @@ describe('Secret Providers Project API', () => {
 
 					const response = await agents[role]
 						.delete(`/secret-providers/projects/${teamProject1.id}/connections/auth-del-${role}`)
-						.expect(allowed ? 200 : 403);
+						.expect(allowed ? 204 : 403);
 
 					if (!allowed) {
 						expect(response.body.message).toBe(FORBIDDEN_MESSAGE);


### PR DESCRIPTION
- **chore(core): External Secrets - Remove delete connection response**
## Summary
Remove delete connection response

## Related Linear tickets, Github issues, and Community forum 
Closes LIGO-197

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
