### PR TITLE
fix(editor): Fetch tags when returning published wf version

### DIFF
--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -705,9 +705,11 @@ export class WorkflowService {
 		}
 
 		// Fetch workflow again with workflowPublishHistory after activation to include the new entry
+		const tagsDisabled = this.globalConfig.tags.disabled;
 		const updatedWorkflow = await this.workflowRepository.findOne({
 			where: { id: workflowId },
 			relations: {
+				tags: !tagsDisabled,
 				activeVersion: {
 					workflowPublishHistory: true,
 				},


### PR DESCRIPTION
## Summary
Fixes a bug where workflow tags were being removed when publishing a workflow.

Root cause: The activateWorkflow method was not including tags in the relations when fetching the updated workflow after activation, causing the response to return tags: undefined which overwrote the frontend's cached tags.

Fix: Include tags in the relations query
<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/ADO-4847/community-issue-bug-workflow-tags-are-removed-when-publishing-a
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
