### PR TITLE
chore(core): Add mode to log streaming events

### DIFF
--- a/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
@@ -367,6 +367,7 @@ describe('LogStreamingEventRelay', () => {
 			const event: RelayEventMap['workflow-pre-execute'] = {
 				executionId: 'exec123',
 				data: workflow,
+				mode: 'trigger',
 			};
 
 			eventService.emit('workflow-pre-execute', event);
@@ -378,6 +379,7 @@ describe('LogStreamingEventRelay', () => {
 					userId: undefined,
 					workflowId: 'wf202',
 					isManual: false,
+					mode: 'trigger',
 					workflowName: 'Test Workflow',
 				},
 			});
@@ -406,6 +408,7 @@ describe('LogStreamingEventRelay', () => {
 					...rest,
 					success: true, // same as finished
 					isManual: true,
+					mode: 'manual',
 					workflowName: 'some-name',
 					workflowId: 'some-id',
 				},
@@ -476,6 +479,7 @@ describe('LogStreamingEventRelay', () => {
 					...rest,
 					success: false, // same as finished
 					isManual: true,
+					mode: 'manual',
 					workflowName: 'some-name',
 					workflowId: 'some-id',
 					lastNodeExecuted: 'some-node',

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -7,6 +7,7 @@ import type {
 	IWorkflowBase,
 	IWorkflowExecutionDataProcess,
 	JsonValue,
+	WorkflowExecuteMode,
 } from 'n8n-workflow';
 
 import type { ConcurrencyQueueType } from '@/concurrency/concurrency-control.service';
@@ -123,6 +124,7 @@ export type RelayEventMap = {
 	'workflow-pre-execute': {
 		executionId: string;
 		data: IWorkflowExecutionDataProcess /* main process */ | IWorkflowBase /* worker */;
+		mode: WorkflowExecuteMode;
 	};
 
 	'workflow-post-execute': {

--- a/packages/cli/src/events/relays/log-streaming.event-relay.ts
+++ b/packages/cli/src/events/relays/log-streaming.event-relay.ts
@@ -209,7 +209,7 @@ export class LogStreamingEventRelay extends EventRelay {
 		});
 	}
 
-	private workflowPreExecute({ data, executionId }: RelayEventMap['workflow-pre-execute']) {
+	private workflowPreExecute({ data, executionId, mode }: RelayEventMap['workflow-pre-execute']) {
 		const payload =
 			'executionData' in data
 				? {
@@ -217,6 +217,7 @@ export class LogStreamingEventRelay extends EventRelay {
 						userId: data.userId,
 						workflowId: data.workflowData.id,
 						isManual: data.executionMode === 'manual',
+						mode,
 						workflowName: data.workflowData.name,
 					}
 				: {
@@ -224,6 +225,7 @@ export class LogStreamingEventRelay extends EventRelay {
 						userId: undefined,
 						workflowId: (data as IWorkflowBase).id,
 						isManual: false,
+						mode,
 						workflowName: (data as IWorkflowBase).name,
 					};
 
@@ -241,6 +243,7 @@ export class LogStreamingEventRelay extends EventRelay {
 			executionId,
 			success: !!runData?.finished, // despite the `success` name, this reports `finished` state
 			isManual: runData?.mode === 'manual',
+			mode: runData?.mode,
 			workflowId: workflow.id,
 			workflowName: workflow.name,
 		};

--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -179,6 +179,7 @@ describe('Execution Lifecycle Hooks', () => {
 				expect(eventService.emit).toHaveBeenCalledWith('workflow-pre-execute', {
 					executionId,
 					data: workflowData,
+					mode: 'manual',
 				});
 			});
 		});

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -133,8 +133,8 @@ type HooksSetupParameters = {
 function hookFunctionsWorkflowEvents(hooks: ExecutionLifecycleHooks, userId?: string) {
 	const eventService = Container.get(EventService);
 	hooks.addHandler('workflowExecuteBefore', function () {
-		const { executionId, workflowData } = this;
-		eventService.emit('workflow-pre-execute', { executionId, data: workflowData });
+		const { executionId, workflowData, mode } = this;
+		eventService.emit('workflow-pre-execute', { executionId, data: workflowData, mode });
 	});
 	hooks.addHandler('workflowExecuteAfter', function (runData) {
 		if (runData.status === 'waiting') return;


### PR DESCRIPTION
## Summary

This adds a mode field to the log streaming events, for workflow-pre-execute event.

<img width="538" height="345" alt="image" src="https://github.com/user-attachments/assets/02fcb9b8-009f-4061-9f53-cad1b912037e" />


## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/IAM-53/add-execution-mode-to-log-streaming-data-payload

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
