### PR TITLE
feat: Migrate external secrets settings to entity-based storage (no-changelog)

### DIFF
--- a/packages/@n8n/db/src/migrations/common/1771500000000-MigrateExternalSecretsToEntityStorage.ts
+++ b/packages/@n8n/db/src/migrations/common/1771500000000-MigrateExternalSecretsToEntityStorage.ts
@@ -70,6 +70,11 @@ export class MigrateExternalSecretsToEntityStorage1771500000000 implements Irrev
 		for (const providerName of providerNames) {
 			const providerData = allSettings[providerName];
 
+			if (!providerData.connected) {
+				logger.info(`[${migrationName}] Provider "${providerName}" is not connected, skipping`);
+				continue;
+			}
+
 			const existing: Array<{ providerKey: string }> = await runQuery(
 				`SELECT ${providerKeyCol} FROM ${connectionTable} WHERE ${providerKeyCol} = :providerKey;`,
 				{ providerKey: providerName },

--- a/packages/@n8n/db/src/migrations/common/1771500000000-MigrateExternalSecretsToEntityStorage.ts
+++ b/packages/@n8n/db/src/migrations/common/1771500000000-MigrateExternalSecretsToEntityStorage.ts
@@ -70,7 +70,6 @@ export class MigrateExternalSecretsToEntityStorage1771500000000 implements Irrev
 		for (const providerName of providerNames) {
 			const providerData = allSettings[providerName];
 
-			// Idempotency check: skip if provider already exists
 			const existing: Array<{ providerKey: string }> = await runQuery(
 				`SELECT ${providerKeyCol} FROM ${connectionTable} WHERE ${providerKeyCol} = :providerKey;`,
 				{ providerKey: providerName },
@@ -83,12 +82,8 @@ export class MigrateExternalSecretsToEntityStorage1771500000000 implements Irrev
 				continue;
 			}
 
-			// Re-encrypt just the settings object for the new entity
 			const encryptedSettings = this.cipher.encrypt(providerData.settings ?? {});
 
-			// Insert row: providerKey = type = providerName (per ticket spec)
-			// isEnabled, createdAt, updatedAt have DB defaults and are omitted
-			// No project_secrets_provider_access rows = global provider
 			await runQuery(
 				`INSERT INTO ${connectionTable} (${providerKeyCol}, ${typeCol}, ${encryptedSettingsCol}) VALUES (:providerKey, :type, :encryptedSettings);`,
 				{

--- a/packages/@n8n/db/src/migrations/common/1771500000000-MigrateExternalSecretsToEntityStorage.ts
+++ b/packages/@n8n/db/src/migrations/common/1771500000000-MigrateExternalSecretsToEntityStorage.ts
@@ -26,85 +26,97 @@ const EXTERNAL_SECRETS_DB_KEY = 'feature.externalSecrets';
 export class MigrateExternalSecretsToEntityStorage1771500000000 implements IrreversibleMigration {
 	private readonly cipher = Container.get(Cipher);
 
-	async up({ escape, runQuery, logger, migrationName }: MigrationContext) {
+	async up(context: MigrationContext) {
+		const allSettings = await this.readSettings(context);
+		if (!allSettings) return;
+
+		const providerNames = Object.keys(allSettings);
+		if (providerNames.length === 0) {
+			context.logger.info(
+				`[${context.migrationName}] External secrets settings blob is empty, skipping`,
+			);
+			return;
+		}
+
+		for (const providerName of providerNames) {
+			await this.migrateProvider(context, providerName, allSettings[providerName]);
+		}
+
+		context.logger.info(
+			`[${context.migrationName}] Migration complete. Old settings row preserved in settings table.`,
+		);
+	}
+
+	private async readSettings({
+		escape,
+		runQuery,
+		logger,
+		migrationName,
+	}: MigrationContext): Promise<ExternalSecretsSettings | undefined> {
 		const settingsTable = escape.tableName('settings');
 		const keyCol = escape.columnName('key');
 		const valueCol = escape.columnName('value');
 
-		// Step 1: Read the encrypted settings blob
 		const rows: Array<{ value: string }> = await runQuery(
 			`SELECT ${valueCol} FROM ${settingsTable} WHERE ${keyCol} = '${EXTERNAL_SECRETS_DB_KEY}';`,
 		);
 
 		if (rows.length === 0) {
 			logger.info(`[${migrationName}] No external secrets settings found, skipping`);
-			return;
+			return undefined;
 		}
 
-		const [row] = rows;
-
-		// Step 2: Decrypt the blob
-		let allSettings: ExternalSecretsSettings;
 		try {
-			const decrypted = this.cipher.decrypt(row.value);
-			allSettings = jsonParse<ExternalSecretsSettings>(decrypted);
-		} catch (e) {
+			const decrypted = this.cipher.decrypt(rows[0].value);
+			return jsonParse<ExternalSecretsSettings>(decrypted);
+		} catch {
 			logger.error(
 				`[${migrationName}] Failed to decrypt external secrets settings, skipping migration`,
 			);
+			return undefined;
+		}
+	}
+
+	private async migrateProvider(
+		{ escape, runQuery, logger, migrationName }: MigrationContext,
+		providerName: string,
+		providerData: ProviderData,
+	) {
+		if (!providerData.connected) {
+			logger.info(`[${migrationName}] Provider "${providerName}" is not connected, skipping`);
 			return;
 		}
 
-		const providerNames = Object.keys(allSettings);
-		if (providerNames.length === 0) {
-			logger.info(`[${migrationName}] External secrets settings blob is empty, skipping`);
-			return;
-		}
-
-		// Step 3: Insert each provider into secrets_provider_connection
 		const connectionTable = escape.tableName('secrets_provider_connection');
 		const providerKeyCol = escape.columnName('providerKey');
 		const typeCol = escape.columnName('type');
 		const encryptedSettingsCol = escape.columnName('encryptedSettings');
 
-		for (const providerName of providerNames) {
-			const providerData = allSettings[providerName];
+		const existing: Array<{ providerKey: string }> = await runQuery(
+			`SELECT ${providerKeyCol} FROM ${connectionTable} WHERE ${providerKeyCol} = :providerKey;`,
+			{ providerKey: providerName },
+		);
 
-			if (!providerData.connected) {
-				logger.info(`[${migrationName}] Provider "${providerName}" is not connected, skipping`);
-				continue;
-			}
-
-			const existing: Array<{ providerKey: string }> = await runQuery(
-				`SELECT ${providerKeyCol} FROM ${connectionTable} WHERE ${providerKeyCol} = :providerKey;`,
-				{ providerKey: providerName },
-			);
-
-			if (existing.length > 0) {
-				logger.info(
-					`[${migrationName}] Provider "${providerName}" already exists in secrets_provider_connection, skipping`,
-				);
-				continue;
-			}
-
-			const encryptedSettings = this.cipher.encrypt(providerData.settings ?? {});
-
-			await runQuery(
-				`INSERT INTO ${connectionTable} (${providerKeyCol}, ${typeCol}, ${encryptedSettingsCol}) VALUES (:providerKey, :type, :encryptedSettings);`,
-				{
-					providerKey: providerName,
-					type: providerName,
-					encryptedSettings,
-				},
-			);
-
+		if (existing.length > 0) {
 			logger.info(
-				`[${migrationName}] Migrated provider "${providerName}" to secrets_provider_connection`,
+				`[${migrationName}] Provider "${providerName}" already exists in secrets_provider_connection, skipping`,
 			);
+			return;
 		}
 
+		const encryptedSettings = this.cipher.encrypt(providerData.settings ?? {});
+
+		await runQuery(
+			`INSERT INTO ${connectionTable} (${providerKeyCol}, ${typeCol}, ${encryptedSettingsCol}) VALUES (:providerKey, :type, :encryptedSettings);`,
+			{
+				providerKey: providerName,
+				type: providerName,
+				encryptedSettings,
+			},
+		);
+
 		logger.info(
-			`[${migrationName}] Migration complete. Old settings row preserved in settings table.`,
+			`[${migrationName}] Migrated provider "${providerName}" to secrets_provider_connection`,
 		);
 	}
 }

--- a/packages/@n8n/db/src/migrations/common/1771500000000-MigrateExternalSecretsToEntityStorage.ts
+++ b/packages/@n8n/db/src/migrations/common/1771500000000-MigrateExternalSecretsToEntityStorage.ts
@@ -1,0 +1,110 @@
+import { Container } from '@n8n/di';
+import { Cipher } from 'n8n-core';
+import { jsonParse } from 'n8n-workflow';
+
+import type { IrreversibleMigration, MigrationContext } from '../migration-types';
+
+interface ProviderData {
+	connected: boolean;
+	connectedAt: string | Date | null;
+	settings: Record<string, unknown>;
+}
+
+interface ExternalSecretsSettings {
+	[providerName: string]: ProviderData;
+}
+
+const EXTERNAL_SECRETS_DB_KEY = 'feature.externalSecrets';
+
+/**
+ * Migrates external secrets provider settings from a single encrypted JSON blob
+ * in the `settings` table to individual entity rows in the `secrets_provider_connection` table.
+ *
+ * Existing providers are migrated as global providers (no project access rows).
+ * The old settings row is preserved for backward compatibility.
+ */
+export class MigrateExternalSecretsToEntityStorage1771500000000 implements IrreversibleMigration {
+	private readonly cipher = Container.get(Cipher);
+
+	async up({ escape, runQuery, logger, migrationName }: MigrationContext) {
+		const settingsTable = escape.tableName('settings');
+		const keyCol = escape.columnName('key');
+		const valueCol = escape.columnName('value');
+
+		// Step 1: Read the encrypted settings blob
+		const rows: Array<{ value: string }> = await runQuery(
+			`SELECT ${valueCol} FROM ${settingsTable} WHERE ${keyCol} = '${EXTERNAL_SECRETS_DB_KEY}';`,
+		);
+
+		if (rows.length === 0) {
+			logger.info(`[${migrationName}] No external secrets settings found, skipping`);
+			return;
+		}
+
+		const [row] = rows;
+
+		// Step 2: Decrypt the blob
+		let allSettings: ExternalSecretsSettings;
+		try {
+			const decrypted = this.cipher.decrypt(row.value);
+			allSettings = jsonParse<ExternalSecretsSettings>(decrypted);
+		} catch (e) {
+			logger.error(
+				`[${migrationName}] Failed to decrypt external secrets settings, skipping migration`,
+			);
+			return;
+		}
+
+		const providerNames = Object.keys(allSettings);
+		if (providerNames.length === 0) {
+			logger.info(`[${migrationName}] External secrets settings blob is empty, skipping`);
+			return;
+		}
+
+		// Step 3: Insert each provider into secrets_provider_connection
+		const connectionTable = escape.tableName('secrets_provider_connection');
+		const providerKeyCol = escape.columnName('providerKey');
+		const typeCol = escape.columnName('type');
+		const encryptedSettingsCol = escape.columnName('encryptedSettings');
+
+		for (const providerName of providerNames) {
+			const providerData = allSettings[providerName];
+
+			// Idempotency check: skip if provider already exists
+			const existing: Array<{ providerKey: string }> = await runQuery(
+				`SELECT ${providerKeyCol} FROM ${connectionTable} WHERE ${providerKeyCol} = :providerKey;`,
+				{ providerKey: providerName },
+			);
+
+			if (existing.length > 0) {
+				logger.info(
+					`[${migrationName}] Provider "${providerName}" already exists in secrets_provider_connection, skipping`,
+				);
+				continue;
+			}
+
+			// Re-encrypt just the settings object for the new entity
+			const encryptedSettings = this.cipher.encrypt(providerData.settings ?? {});
+
+			// Insert row: providerKey = type = providerName (per ticket spec)
+			// isEnabled, createdAt, updatedAt have DB defaults and are omitted
+			// No project_secrets_provider_access rows = global provider
+			await runQuery(
+				`INSERT INTO ${connectionTable} (${providerKeyCol}, ${typeCol}, ${encryptedSettingsCol}) VALUES (:providerKey, :type, :encryptedSettings);`,
+				{
+					providerKey: providerName,
+					type: providerName,
+					encryptedSettings,
+				},
+			);
+
+			logger.info(
+				`[${migrationName}] Migrated provider "${providerName}" to secrets_provider_connection`,
+			);
+		}
+
+		logger.info(
+			`[${migrationName}] Migration complete. Old settings row preserved in settings table.`,
+		);
+	}
+}

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -145,6 +145,7 @@ import { CreateChatHubToolsTable1770000000000 } from '../common/1770000000000-Cr
 import { ExpandProviderIdColumnLength1770000000000 } from '../common/1770000000000-ExpandProviderIdColumnLength';
 import { CreateWorkflowBuilderSessionTable1770220686000 } from '../common/1770220686000-CreateWorkflowBuilderSessionTable';
 import { AddScalingFieldsToTestRun1771417407753 } from '../common/1771417407753-AddScalingFieldsToTestRun';
+import { MigrateExternalSecretsToEntityStorage1771500000000 } from '../common/1771500000000-MigrateExternalSecretsToEntityStorage';
 import type { Migration } from '../migration-types';
 
 export const postgresMigrations: Migration[] = [
@@ -295,4 +296,5 @@ export const postgresMigrations: Migration[] = [
 	ExpandProviderIdColumnLength1770000000000,
 	CreateWorkflowBuilderSessionTable1770220686000,
 	AddScalingFieldsToTestRun1771417407753,
+	MigrateExternalSecretsToEntityStorage1771500000000,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -139,6 +139,7 @@ import { CreateChatHubToolsTable1770000000000 } from '../common/1770000000000-Cr
 import { ExpandProviderIdColumnLength1770000000000 } from '../common/1770000000000-ExpandProviderIdColumnLength';
 import { CreateWorkflowBuilderSessionTable1770220686000 } from '../common/1770220686000-CreateWorkflowBuilderSessionTable';
 import { AddScalingFieldsToTestRun1771417407753 } from '../common/1771417407753-AddScalingFieldsToTestRun';
+import { MigrateExternalSecretsToEntityStorage1771500000000 } from '../common/1771500000000-MigrateExternalSecretsToEntityStorage';
 import type { Migration } from '../migration-types';
 
 const sqliteMigrations: Migration[] = [
@@ -283,6 +284,7 @@ const sqliteMigrations: Migration[] = [
 	ExpandProviderIdColumnLength1770000000000,
 	CreateWorkflowBuilderSessionTable1770220686000,
 	AddScalingFieldsToTestRun1771417407753,
+	MigrateExternalSecretsToEntityStorage1771500000000,
 ];
 
 export { sqliteMigrations };

--- a/packages/cli/test/migration/1771500000000-migrate-external-secrets-to-entity-storage.test.ts
+++ b/packages/cli/test/migration/1771500000000-migrate-external-secrets-to-entity-storage.test.ts
@@ -1,0 +1,265 @@
+import {
+	createTestMigrationContext,
+	initDbUpToMigration,
+	runSingleMigration,
+	type TestMigrationContext,
+} from '@n8n/backend-test-utils';
+import { DbConnection } from '@n8n/db';
+import { Container } from '@n8n/di';
+import { DataSource } from '@n8n/typeorm';
+import { Cipher } from 'n8n-core';
+
+const MIGRATION_NAME = 'MigrateExternalSecretsToEntityStorage1771500000000';
+const EXTERNAL_SECRETS_DB_KEY = 'feature.externalSecrets';
+
+describe('MigrateExternalSecretsToEntityStorage Migration', () => {
+	let dataSource: DataSource;
+	let cipher: Cipher;
+
+	beforeAll(async () => {
+		const dbConnection = Container.get(DbConnection);
+		await dbConnection.init();
+		dataSource = Container.get(DataSource);
+		cipher = Container.get(Cipher);
+	});
+
+	beforeEach(async () => {
+		const context = createTestMigrationContext(dataSource);
+		await context.queryRunner.clearDatabase();
+		await context.queryRunner.release();
+		await initDbUpToMigration(MIGRATION_NAME);
+	});
+
+	afterAll(async () => {
+		const dbConnection = Container.get(DbConnection);
+		await dbConnection.close();
+	});
+
+	async function insertSettingsBlob(context: TestMigrationContext, value: string): Promise<void> {
+		const tableName = context.escape.tableName('settings');
+		const keyCol = context.escape.columnName('key');
+		const valueCol = context.escape.columnName('value');
+		const loadOnStartupCol = context.escape.columnName('loadOnStartup');
+
+		await context.runQuery(
+			`INSERT INTO ${tableName} (${keyCol}, ${valueCol}, ${loadOnStartupCol}) VALUES (:key, :value, :loadOnStartup)`,
+			{ key: EXTERNAL_SECRETS_DB_KEY, value, loadOnStartup: true },
+		);
+	}
+
+	async function getProviderConnections(
+		context: TestMigrationContext,
+	): Promise<Array<{ providerKey: string; type: string; encryptedSettings: string }>> {
+		const tableName = context.escape.tableName('secrets_provider_connection');
+		const providerKeyCol = context.escape.columnName('providerKey');
+		const typeCol = context.escape.columnName('type');
+		const encryptedSettingsCol = context.escape.columnName('encryptedSettings');
+
+		return await context.runQuery(
+			`SELECT ${providerKeyCol} AS "providerKey", ${typeCol} AS "type", ${encryptedSettingsCol} AS "encryptedSettings" FROM ${tableName}`,
+		);
+	}
+
+	async function insertProviderConnection(
+		context: TestMigrationContext,
+		providerKey: string,
+		type: string,
+		encryptedSettings: string,
+	): Promise<void> {
+		const tableName = context.escape.tableName('secrets_provider_connection');
+		const providerKeyCol = context.escape.columnName('providerKey');
+		const typeCol = context.escape.columnName('type');
+		const encryptedSettingsCol = context.escape.columnName('encryptedSettings');
+
+		await context.runQuery(
+			`INSERT INTO ${tableName} (${providerKeyCol}, ${typeCol}, ${encryptedSettingsCol}) VALUES (:providerKey, :type, :encryptedSettings)`,
+			{ providerKey, type, encryptedSettings },
+		);
+	}
+
+	describe('up migration', () => {
+		it('should skip when no external secrets settings exist', async () => {
+			const context = createTestMigrationContext(dataSource);
+			await context.queryRunner.release();
+
+			await runSingleMigration(MIGRATION_NAME);
+			dataSource = Container.get(DataSource);
+
+			const postContext = createTestMigrationContext(dataSource);
+			const connections = await getProviderConnections(postContext);
+			expect(connections).toHaveLength(0);
+			await postContext.queryRunner.release();
+		});
+
+		it('should migrate connected providers to secrets_provider_connection', async () => {
+			const context = createTestMigrationContext(dataSource);
+
+			const settings = {
+				awsSecretsManager: {
+					connected: true,
+					connectedAt: '2024-01-01T00:00:00.000Z',
+					settings: { region: 'us-east-1', accessKeyId: 'AKIA...' },
+				},
+				gcpSecretsManager: {
+					connected: true,
+					connectedAt: '2024-02-01T00:00:00.000Z',
+					settings: { projectId: 'my-project' },
+				},
+			};
+
+			const encrypted = cipher.encrypt(JSON.stringify(settings));
+			await insertSettingsBlob(context, encrypted);
+			await context.queryRunner.release();
+
+			await runSingleMigration(MIGRATION_NAME);
+			dataSource = Container.get(DataSource);
+
+			const postContext = createTestMigrationContext(dataSource);
+			const connections = await getProviderConnections(postContext);
+
+			expect(connections).toHaveLength(2);
+
+			const aws = connections.find((c) => c.providerKey === 'awsSecretsManager');
+			expect(aws).toBeDefined();
+			expect(aws!.type).toBe('awsSecretsManager');
+			const awsDecrypted = JSON.parse(cipher.decrypt(aws!.encryptedSettings));
+			expect(awsDecrypted).toEqual({ region: 'us-east-1', accessKeyId: 'AKIA...' });
+
+			const gcp = connections.find((c) => c.providerKey === 'gcpSecretsManager');
+			expect(gcp).toBeDefined();
+			expect(gcp!.type).toBe('gcpSecretsManager');
+			const gcpDecrypted = JSON.parse(cipher.decrypt(gcp!.encryptedSettings));
+			expect(gcpDecrypted).toEqual({ projectId: 'my-project' });
+
+			await postContext.queryRunner.release();
+		});
+
+		it('should skip disconnected providers', async () => {
+			const context = createTestMigrationContext(dataSource);
+
+			const settings = {
+				awsSecretsManager: {
+					connected: true,
+					connectedAt: '2024-01-01T00:00:00.000Z',
+					settings: { region: 'us-east-1' },
+				},
+				gcpSecretsManager: {
+					connected: false,
+					connectedAt: null,
+					settings: { projectId: 'my-project' },
+				},
+			};
+
+			const encrypted = cipher.encrypt(JSON.stringify(settings));
+			await insertSettingsBlob(context, encrypted);
+			await context.queryRunner.release();
+
+			await runSingleMigration(MIGRATION_NAME);
+			dataSource = Container.get(DataSource);
+
+			const postContext = createTestMigrationContext(dataSource);
+			const connections = await getProviderConnections(postContext);
+
+			expect(connections).toHaveLength(1);
+			expect(connections[0].providerKey).toBe('awsSecretsManager');
+
+			await postContext.queryRunner.release();
+		});
+
+		it('should skip providers that already exist in secrets_provider_connection', async () => {
+			const context = createTestMigrationContext(dataSource);
+
+			const existingEncryptedSettings = cipher.encrypt({ region: 'eu-west-1' });
+			await insertProviderConnection(
+				context,
+				'awsSecretsManager',
+				'awsSecretsManager',
+				existingEncryptedSettings,
+			);
+
+			const settings = {
+				awsSecretsManager: {
+					connected: true,
+					connectedAt: '2024-01-01T00:00:00.000Z',
+					settings: { region: 'us-east-1' },
+				},
+			};
+
+			const encrypted = cipher.encrypt(JSON.stringify(settings));
+			await insertSettingsBlob(context, encrypted);
+			await context.queryRunner.release();
+
+			await runSingleMigration(MIGRATION_NAME);
+			dataSource = Container.get(DataSource);
+
+			const postContext = createTestMigrationContext(dataSource);
+			const connections = await getProviderConnections(postContext);
+
+			expect(connections).toHaveLength(1);
+			// Should still have the original settings, not the migrated ones
+			const decrypted = JSON.parse(cipher.decrypt(connections[0].encryptedSettings));
+			expect(decrypted).toEqual({ region: 'eu-west-1' });
+
+			await postContext.queryRunner.release();
+		});
+
+		it('should skip when settings blob is empty', async () => {
+			const context = createTestMigrationContext(dataSource);
+
+			const encrypted = cipher.encrypt(JSON.stringify({}));
+			await insertSettingsBlob(context, encrypted);
+			await context.queryRunner.release();
+
+			await runSingleMigration(MIGRATION_NAME);
+			dataSource = Container.get(DataSource);
+
+			const postContext = createTestMigrationContext(dataSource);
+			const connections = await getProviderConnections(postContext);
+			expect(connections).toHaveLength(0);
+			await postContext.queryRunner.release();
+		});
+
+		it('should skip when settings blob cannot be decrypted', async () => {
+			const context = createTestMigrationContext(dataSource);
+
+			await insertSettingsBlob(context, 'not-valid-encrypted-data');
+			await context.queryRunner.release();
+
+			await runSingleMigration(MIGRATION_NAME);
+			dataSource = Container.get(DataSource);
+
+			const postContext = createTestMigrationContext(dataSource);
+			const connections = await getProviderConnections(postContext);
+			expect(connections).toHaveLength(0);
+			await postContext.queryRunner.release();
+		});
+
+		it('should handle providers with null settings', async () => {
+			const context = createTestMigrationContext(dataSource);
+
+			const settings = {
+				awsSecretsManager: {
+					connected: true,
+					connectedAt: '2024-01-01T00:00:00.000Z',
+					settings: null as unknown as Record<string, unknown>,
+				},
+			};
+
+			const encrypted = cipher.encrypt(JSON.stringify(settings));
+			await insertSettingsBlob(context, encrypted);
+			await context.queryRunner.release();
+
+			await runSingleMigration(MIGRATION_NAME);
+			dataSource = Container.get(DataSource);
+
+			const postContext = createTestMigrationContext(dataSource);
+			const connections = await getProviderConnections(postContext);
+
+			expect(connections).toHaveLength(1);
+			const decrypted = JSON.parse(cipher.decrypt(connections[0].encryptedSettings));
+			expect(decrypted).toEqual({});
+
+			await postContext.queryRunner.release();
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds a database migration that transfers existing external secrets provider settings from the legacy encrypted JSON blob stored in the `settings` table (`feature.externalSecrets`) to the new `secrets_provider_connection` table used by entity-based storage.


**How to test:**
1. Set `N8N_ENV_FEAT_EXTERNAL_SECRETS_MULTIPLE_CONNECTIONS` to true
1. Start n8n with an existing database that has external secrets configured (blob present in `settings` table under `feature.externalSecrets`)
2. Run migrations, verify providers appear in `secrets_provider_connection`
3. Confirm external secrets continue to work after migration



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-112

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)