### PR TITLE
ci: Fix Docker image cleanup and simplify CI image tagging

### DIFF
--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -21,6 +21,7 @@ jobs:
     outputs:
       ci: ${{ fromJSON(steps.ci-filter.outputs.results).ci == true }}
       unit: ${{ fromJSON(steps.ci-filter.outputs.results).unit == true }}
+      e2e: ${{ fromJSON(steps.ci-filter.outputs.results).e2e == true }}
       workflows: ${{ fromJSON(steps.ci-filter.outputs.results).workflows == true }}
       db: ${{ fromJSON(steps.ci-filter.outputs.results).db == true }}
       commit_sha: ${{ steps.commit-sha.outputs.sha }}
@@ -49,6 +50,11 @@ jobs:
               !packages/@n8n/task-runner-python/**
               !packages/testing/playwright/**
               !.github/**
+            e2e:
+              .github/workflows/test-e2e-*.yml
+              .github/scripts/cleanup-ghcr-images.mjs
+              packages/testing/playwright/**
+              packages/testing/containers/**
             workflows: .github/**
             db:
               packages/cli/src/databases/**
@@ -111,7 +117,7 @@ jobs:
   e2e-tests:
     name: E2E Tests
     needs: install-and-build
-    if: needs.install-and-build.outputs.ci == 'true' && github.repository == 'n8n-io/n8n'
+    if: (needs.install-and-build.outputs.ci == 'true' || needs.install-and-build.outputs.e2e == 'true') && github.repository == 'n8n-io/n8n'
     uses: ./.github/workflows/test-e2e-ci-reusable.yml
     with:
       branch: ${{ needs.install-and-build.outputs.commit_sha }}

--- a/.github/workflows/test-e2e-ci-reusable.yml
+++ b/.github/workflows/test-e2e-ci-reusable.yml
@@ -10,7 +10,7 @@ on:
         default: ''
 
 env:
-  DOCKER_IMAGE: ghcr.io/${{ github.repository }}:pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
+  DOCKER_IMAGE: ghcr.io/${{ github.repository }}:ci-${{ github.run_id }}
 
 jobs:
   prepare:
@@ -44,7 +44,7 @@ jobs:
         env:
           INCLUDE_TEST_CONTROLLER: 'true'
           IMAGE_BASE_NAME: ghcr.io/${{ github.repository }}
-          IMAGE_TAG: pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
+          IMAGE_TAG: ci-${{ github.run_id }}
           RUNNERS_IMAGE_BASE_NAME: ghcr.io/${{ github.repository_owner }}/runners
 
       - name: Generate shard matrix
@@ -59,7 +59,7 @@ jobs:
     with:
       branch: ${{ inputs.branch }}
       test-mode: docker-pull
-      docker-image: ghcr.io/${{ github.repository }}:pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
+      docker-image: ghcr.io/${{ github.repository }}:ci-${{ github.run_id }}
       test-command: pnpm --filter=n8n-playwright test:container:sqlite:e2e tests/e2e/building-blocks/workflow-entry-points.spec.ts
       shards: 1
       runner: blacksmith-2vcpu-ubuntu-2204
@@ -77,7 +77,7 @@ jobs:
     with:
       branch: ${{ inputs.branch }}
       test-mode: docker-pull
-      docker-image: ghcr.io/${{ github.repository }}:pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
+      docker-image: ghcr.io/${{ github.repository }}:ci-${{ github.run_id }}
       test-command: pnpm --filter=n8n-playwright test:container:multi-main:e2e
       shards: 16
       runner: blacksmith-2vcpu-ubuntu-2204
@@ -101,9 +101,10 @@ jobs:
       workers: '1'
       upload-failure-artifacts: true
 
-  # Cleanup ephemeral Docker image from GHCR and local cache after tests complete
-  cleanup-docker:
-    name: 'Cleanup Docker Image'
+  # Cleanup ephemeral Docker image from GHCR after tests complete
+  # Local runner cleanup is handled by each test shard in test-e2e-reusable.yml
+  cleanup-ghcr:
+    name: 'Cleanup GHCR Image'
     needs: [prepare, multi-main-e2e, sqlite-sanity]
     if: ${{ !failure() && !cancelled() && !github.event.pull_request.head.repo.fork }}
     runs-on: blacksmith-2vcpu-ubuntu-2204
@@ -117,24 +118,10 @@ jobs:
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
 
-      - name: Cleanup local Docker cache
-        run: |
-          echo "Removing PR images from local cache..."
-          docker rmi ghcr.io/n8n-io/n8n:pr-${{ github.event.pull_request.number }}-${{ github.run_id }} || true
-          docker rmi ghcr.io/n8n-io/runners:pr-${{ github.event.pull_request.number }}-${{ github.run_id }} || true
-          docker system prune -f || true
-
       - name: Delete images from GHCR
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GHCR_ORG: ${{ github.repository_owner }}
           GHCR_REPO: ${{ github.event.repository.name }}
-        run: |
-          if [ -n "${{ github.event.pull_request.number }}" ]; then
-            echo "PR context: cleaning all images for PR ${{ github.event.pull_request.number }}"
-            node .github/scripts/cleanup-ghcr-images.mjs --pr ${{ github.event.pull_request.number }}
-          else
-            echo "Merge queue context: cleaning image pr--${{ github.run_id }}"
-            node .github/scripts/cleanup-ghcr-images.mjs --tag pr--${{ github.run_id }}
-          fi
+        run: node .github/scripts/cleanup-ghcr-images.mjs --tag ci-${{ github.run_id }}

--- a/.github/workflows/test-e2e-reusable.yml
+++ b/.github/workflows/test-e2e-reusable.yml
@@ -175,6 +175,13 @@ jobs:
             packages/testing/playwright/playwright-report/
           retention-days: 7
 
+      - name: Cleanup cached CI images
+        if: ${{ inputs.test-mode == 'docker-pull' }}
+        continue-on-error: true
+        run: |
+          docker images --format '{{.Repository}}:{{.Tag}}' | grep -E 'ghcr\.io/n8n-io/(n8n|runners):(ci|pr)-' | xargs -r docker rmi || true
+          docker system prune -f || true
+
       - name: Cancel Currents run if workflow is cancelled
         if: ${{ cancelled() }}
         env:

--- a/.github/workflows/util-cleanup-pr-images.yml
+++ b/.github/workflows/util-cleanup-pr-images.yml
@@ -1,13 +1,13 @@
-name: 'Util: Cleanup PR Docker Images'
+name: 'Util: Cleanup CI Docker Images'
 
 on:
   schedule:
-    # Weekly cleanup: Sunday at 3 AM UTC
-    - cron: '0 3 * * 0'
+    # Daily cleanup at 3 AM UTC
+    - cron: '0 3 * * *'
 
 jobs:
   cleanup:
-    name: 'Delete stale PR images'
+    name: 'Delete stale CI images'
     runs-on: ubuntu-slim
     permissions:
       packages: write
@@ -19,9 +19,9 @@ jobs:
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
 
-      - name: Delete stale PR images
+      - name: Delete stale CI images
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GHCR_ORG: ${{ github.repository_owner }}
           GHCR_REPO: ${{ github.event.repository.name }}
-        run: node .github/scripts/cleanup-ghcr-images.mjs --stale 7
+        run: node .github/scripts/cleanup-ghcr-images.mjs --stale 1


### PR DESCRIPTION
## Summary
- Replace `pr-{number}-{runId}` image tagging with `ci-{runId}` for consistency across PR and merge queue contexts (eliminates the `pr--{runId}` double-dash issue)
- Move Docker cache cleanup from a separate cleanup job to each test shard, where images actually accumulate on Blacksmith runners
- Simplify GHCR cleanup to a single `--tag` call (no more PR vs merge queue branching logic)
- Add dedicated `e2e` CI filter so workflow/infrastructure changes trigger E2E tests without running unit/typecheck/lint
- Change GHCR orphan cleanup from weekly (`--stale 7`) to daily (`--stale 1`)
- Remove `--pr` mode from cleanup script (no longer needed with simplified tagging)

## Test plan
- [ ] Verify E2E tests trigger on this PR (workflow files changed, `e2e` filter should match)
- [ ] Verify Docker images are tagged as `ci-{runId}` in GHCR
- [ ] Verify shard cleanup step runs after successful tests
- [ ] Verify GHCR cleanup job deletes the `ci-{runId}` image after tests pass
- [ ] Verify no "No such image" errors in cleanup logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)