### PR TITLE
fix(Google Gemini Node): Fix broken thinking budget selector

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/gemini-common/additional-options.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/gemini-common/additional-options.ts
@@ -93,9 +93,9 @@ export function getAdditionalOptions({
 		baseOptions.options?.push({
 			displayName: 'Thinking Budget',
 			name: 'thinkingBudget',
-			default: undefined,
+			default: -1,
 			description:
-				'Controls reasoning tokens for thinking models. Set to 0 to disable automatic thinking. Set to -1 for dynamic thinking. Leave empty for auto mode.',
+				'Controls reasoning tokens for thinking models. Set to 0 to disable automatic thinking. Set to -1 for dynamic thinking (default).',
 			type: 'number',
 			typeOptions: {
 				minValue: -1,

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/text/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/text/message.operation.ts
@@ -307,9 +307,9 @@ const properties: INodeProperties[] = [
 				displayName: 'Thinking Budget',
 				name: 'thinkingBudget',
 				type: 'number',
-				default: undefined,
+				default: -1,
 				description:
-					'Controls reasoning tokens for thinking models. Set to 0 to disable automatic thinking. Set to -1 for dynamic thinking. Leave empty for auto mode.',
+					'Controls reasoning tokens for thinking models. Set to 0 to disable automatic thinking. Set to -1 for dynamic thinking (default).',
 				typeOptions: {
 					minValue: -1,
 					numberPrecision: 0,


### PR DESCRIPTION
## Summary

The "Thinking Budget" option in Google Vertex Chat Model and Google Gemini nodes silently fails to appear when selected from the Options collection dropdown. The dropdown closes but no input field is added.

**Root cause:** `default: undefined` on the `thinkingBudget` parameter causes the frontend's `setParameterValue()` to treat the value as a deletion signal (via `unset()`), immediately removing the parameter after the user selects it.

**Fix:** Change `default: undefined` to `default: -1` (dynamic thinking) in both affected node definitions. This allows the option to be properly added and configured. The description is also updated to reflect the new default.

Affected nodes:
- Google Vertex Chat Model (LangChain) — via `additional-options.ts`
- Google Gemini (standalone) — via `message.operation.ts`

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-2072
- Fixes #25509