### PR TITLE
fix(core): Handle tool wrapper nodes without supplyData in queue mode MCP Trigger

### DIFF
--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -527,7 +527,13 @@ export class JobProcessor {
 
 				const result = await nodeType.execute.call(context as unknown as IExecuteFunctions);
 
-				return result?.[0]?.flatMap((item: INodeExecutionData) => item.json);
+				const response = result?.[0]?.flatMap((item: INodeExecutionData) => item.json);
+
+				context.addOutputData(NodeConnectionTypes.AiTool, 0, [
+					[{ json: { response } as INodeExecutionData['json'] }],
+				]);
+
+				return response;
 			}
 
 			throw new UnexpectedError(

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -13,6 +13,7 @@ import type { Tool } from '@langchain/core/tools';
 import type {
 	ExecutionStatus,
 	IExecuteData,
+	IExecuteFunctions,
 	IExecuteResponsePromiseData,
 	INodeExecutionData,
 	IRun,
@@ -442,8 +443,10 @@ export class JobProcessor {
 
 	/**
 	 * Invoke a tool directly for MCP Trigger in queue mode.
-	 * This method creates a SupplyDataContext, calls supplyData to get the Tool,
-	 * and invokes it directly instead of running a full workflow execution.
+	 * For nodes with supplyData (e.g. native langchain tool nodes), creates a
+	 * SupplyDataContext, calls supplyData to get the Tool, and invokes it.
+	 * For tool wrapper nodes without supplyData (e.g. httpRequestTool), calls
+	 * execute directly — mirroring the fallback in get-input-connection-data.ts.
 	 */
 	private async invokeTool(
 		workflow: Workflow,
@@ -462,9 +465,6 @@ export class JobProcessor {
 
 		// Get the node type
 		const nodeType = this.nodeTypes.getByNameAndVersion(toolNode.type, toolNode.typeVersion);
-		if (!nodeType.supplyData) {
-			throw new UnexpectedError(`Tool node "${sourceNodeName}" does not have supplyData method`);
-		}
 
 		// Validate toolArgs is a proper object (not null/array) before using as input data
 		const validatedToolArgs =
@@ -509,16 +509,30 @@ export class JobProcessor {
 		);
 
 		try {
-			const supplyDataResult = await nodeType.supplyData.call(context, 0);
-			const tool = supplyDataResult.response as Tool;
+			if (nodeType.supplyData) {
+				const supplyDataResult = await nodeType.supplyData.call(context, 0);
+				const tool = supplyDataResult.response as Tool;
 
-			if (!tool || typeof tool.invoke !== 'function') {
-				throw new UnexpectedError(`Tool node "${sourceNodeName}" did not return a valid Tool`);
+				if (!tool || typeof tool.invoke !== 'function') {
+					throw new UnexpectedError(`Tool node "${sourceNodeName}" did not return a valid Tool`);
+				}
+
+				return await tool.invoke(validatedToolArgs);
 			}
 
-			const result = await tool.invoke(validatedToolArgs);
+			if (nodeType.execute && nodeType.description.outputs.includes(NodeConnectionTypes.AiTool)) {
+				context.addInputData(NodeConnectionTypes.AiTool, [
+					[{ json: validatedToolArgs as INodeExecutionData['json'] }],
+				]);
 
-			return result;
+				const result = await nodeType.execute.call(context as unknown as IExecuteFunctions);
+
+				return result?.[0]?.flatMap((item: INodeExecutionData) => item.json);
+			}
+
+			throw new UnexpectedError(
+				`Tool node "${sourceNodeName}" does not have supplyData or execute method`,
+			);
 		} finally {
 			for (const closeFunction of closeFunctions) {
 				try {


### PR DESCRIPTION
## Summary

In queue mode, the invike tool method only supported tool nodes with a native `supplyData` method (e.g. `@n8n/n8n-nodes-langchain.toolHttpRequest`). 

Tool wrapper nodes like`httpRequestTool` and `dataTableTool`, which are normalr nodes marked `usableAsTool` that get their description modified at runtime via `convertNodeToAiTool()` don't have `supplyData`. They use their `execute` method instead.

This adds a path in `invokeTool()` that calls `execute` directly for these nodes when `supplyData` is not available but the node has `AiTool` output, mirroring the existing behavior in `get-input-connection-data.ts`.

**How to test:** Set up an MCP Server Trigger with an HTTP Request Tool node in queue mode. Tool calls should now succeed instead of failing with "does not have supplyData method".

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2074