### PR TITLE
fix(editor): Apply missing focus mixin styles

### DIFF
--- a/packages/frontend/@n8n/design-system/src/css/_tokens.new.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.new.scss
@@ -49,9 +49,6 @@
 	--border-color--inverse: var(--color--neutral-700);
 	--text-color--inverse: var(--color--neutral-100);
 	--icon-color--inverse: var(--color--neutral-100);
-
-	--focus--border-width: 2px;
-	--focus--border-color: light-dark(var(--color--neutral-900), var(--color--neutral-100));
 }
 
 :root {

--- a/packages/frontend/@n8n/design-system/src/css/_tokens.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.scss
@@ -395,6 +395,10 @@
 	--button--border-color--highlight-fill--disabled: transparent;
 	--button--color--background--highlight-fill--disabled: var(--color--background);
 
+	// Focus
+	--focus--border-width: 2px;
+	--focus--border-color: light-dark(var(--color--neutral-900), var(--color--neutral-100));
+
 	// Button success, warning, danger
 	--button--color--text--success: var(--color--neutral-white);
 	--button--color--text--success--disabled: var(--color--white-alpha-800);

--- a/packages/frontend/@n8n/design-system/src/css/_tokens.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.scss
@@ -397,7 +397,7 @@
 
 	// Focus
 	--focus--border-width: 1px;
-	--focus--border-color: light-dark(var(--color--secondary), var(--color--secondary--tint-1));
+	--focus--border-color: var(--color--secondary);
 
 	// Button success, warning, danger
 	--button--color--text--success: var(--color--neutral-white);

--- a/packages/frontend/@n8n/design-system/src/css/_tokens.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.scss
@@ -396,8 +396,8 @@
 	--button--color--background--highlight-fill--disabled: var(--color--background);
 
 	// Focus
-	--focus--border-width: 2px;
-	--focus--border-color: light-dark(var(--color--neutral-900), var(--color--neutral-100));
+	--focus--border-width: 1px;
+	--focus--border-color: light-dark(var(--color--secondary), var(--color--secondary--tint-1));
 
 	// Button success, warning, danger
 	--button--color--text--success: var(--color--neutral-white);


### PR DESCRIPTION
## Summary
Move focus tokens to `_tokens.scss` so we can use them in the editor. Living in `_tokens.new.scss` only makes them available in Storybook (confusingly). This was causing some elements to have an invisible focus state.

## Related Linear tickets, Github issues, and Community forum posts
[DS-465](https://linear.app/n8n/issue/DS-465/focus-styles-were-not-applied-to-some-elements)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
