### PR TITLE
feat: Implement promotion banner for non community nodes

### DIFF
--- a/packages/frontend/editor-ui/src/features/credentials/quickConnect/composables/useQuickConnect.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/quickConnect/composables/useQuickConnect.test.ts
@@ -348,193 +348,196 @@ describe('useQuickConnect()', () => {
 					);
 				});
 
-				describe('pinecone quick connect', () => {
-					const pineconeOption: QuickConnectOption = {
-						packageName: '@n8n/n8n-nodes-langchain',
-						credentialType: 'pineconeApi',
-						text: 'Pinecone',
-						quickConnectType: 'pinecone',
-						serviceName: 'Pinecone',
-						config: {
-							integrationId: 'test-integration-id',
-						},
-					};
-
-					beforeEach(() => {
-						settingsStore.moduleSettings['quick-connect'] = {
-							options: [pineconeOption],
-						};
-					});
-
-					it('creates credential with API key from Pinecone popup', async () => {
-						const mockPopup = {
-							open: vi.fn(),
-						};
-						mockPineconeConnectPopup.mockImplementation(({ onConnect }) => {
-							// Simulate user connecting and providing API key
-							setTimeout(() => onConnect({ key: 'test-api-key-123' }), 0);
-							return mockPopup;
-						});
-
-						mockGetCredentialTypeByName.mockReturnValue({
-							name: 'pineconeApi',
-							displayName: 'Pinecone API',
-							properties: [],
-						});
-
-						const mockCredential = {
-							id: 'cred-123',
-							name: 'Pinecone API',
-							type: 'pineconeApi',
-							data: {
-								apiKey: 'test-api-key-123',
-								allowedHttpRequestDomains: 'none',
+				describe.each(['@n8n/n8n-nodes-langchain', '@n8n/n8n-nodes-langchain.pinecone'])(
+					'pinecone quick connect with packageName configured as "%s"',
+					(packageName) => {
+						const pineconeOption: QuickConnectOption = {
+							packageName,
+							credentialType: 'pineconeApi',
+							text: 'Pinecone',
+							quickConnectType: 'pinecone',
+							serviceName: 'Pinecone',
+							config: {
+								integrationId: 'test-integration-id',
 							},
-							createdAt: new Date().toISOString(),
-							updatedAt: new Date().toISOString(),
-							isManaged: false,
 						};
-						mockCreateNewCredential.mockResolvedValue(mockCredential);
 
-						const { connect } = useQuickConnect();
-						const result = await connect({
-							credentialTypeName: 'pineconeApi',
-							nodeType: '@n8n/n8n-nodes-langchain.pinecone',
-							source: 'node',
+						beforeEach(() => {
+							settingsStore.moduleSettings['quick-connect'] = {
+								options: [pineconeOption],
+							};
 						});
 
-						expect(mockPineconeConnectPopup).toHaveBeenCalledWith({
-							onConnect: expect.any(Function),
-							onCancel: expect.any(Function),
-							integrationId: 'test-integration-id',
-						});
-						expect(mockPopup.open).toHaveBeenCalled();
-						expect(mockCreateNewCredential).toHaveBeenCalledWith(
-							{
-								id: '',
+						it('creates credential with API key from Pinecone popup', async () => {
+							const mockPopup = {
+								open: vi.fn(),
+							};
+							mockPineconeConnectPopup.mockImplementation(({ onConnect }) => {
+								// Simulate user connecting and providing API key
+								setTimeout(() => onConnect({ key: 'test-api-key-123' }), 0);
+								return mockPopup;
+							});
+
+							mockGetCredentialTypeByName.mockReturnValue({
+								name: 'pineconeApi',
+								displayName: 'Pinecone API',
+								properties: [],
+							});
+
+							const mockCredential = {
+								id: 'cred-123',
 								name: 'Pinecone API',
 								type: 'pineconeApi',
 								data: {
 									apiKey: 'test-api-key-123',
 									allowedHttpRequestDomains: 'none',
 								},
-							},
-							'project-123',
-						);
-						expect(result).toEqual(mockCredential);
-					});
+								createdAt: new Date().toISOString(),
+								updatedAt: new Date().toISOString(),
+								isManaged: false,
+							};
+							mockCreateNewCredential.mockResolvedValue(mockCredential);
 
-					it('returns null when credential type is not found', async () => {
-						mockGetCredentialTypeByName.mockReturnValue(null);
+							const { connect } = useQuickConnect();
+							const result = await connect({
+								credentialTypeName: 'pineconeApi',
+								nodeType: '@n8n/n8n-nodes-langchain.pinecone',
+								source: 'node',
+							});
 
-						const { connect } = useQuickConnect();
-						const result = await connect({
-							credentialTypeName: 'pineconeApi',
-							nodeType: '@n8n/n8n-nodes-langchain.pinecone',
-							source: 'node',
+							expect(mockPineconeConnectPopup).toHaveBeenCalledWith({
+								onConnect: expect.any(Function),
+								onCancel: expect.any(Function),
+								integrationId: 'test-integration-id',
+							});
+							expect(mockPopup.open).toHaveBeenCalled();
+							expect(mockCreateNewCredential).toHaveBeenCalledWith(
+								{
+									id: '',
+									name: 'Pinecone API',
+									type: 'pineconeApi',
+									data: {
+										apiKey: 'test-api-key-123',
+										allowedHttpRequestDomains: 'none',
+									},
+								},
+								'project-123',
+							);
+							expect(result).toEqual(mockCredential);
 						});
 
-						expect(result).toBeNull();
-						expect(mockPineconeConnectPopup).not.toHaveBeenCalled();
-					});
+						it('returns null when credential type is not found', async () => {
+							mockGetCredentialTypeByName.mockReturnValue(null);
 
-					it('shows error toast when Pinecone connection is cancelled', async () => {
-						const mockPopup = {
-							open: vi.fn(),
-						};
-						mockPineconeConnectPopup.mockImplementation(({ onCancel }) => {
-							// Simulate user cancelling the connection
-							setTimeout(() => onCancel(), 0);
-							return mockPopup;
+							const { connect } = useQuickConnect();
+							const result = await connect({
+								credentialTypeName: 'pineconeApi',
+								nodeType: '@n8n/n8n-nodes-langchain.pinecone',
+								source: 'node',
+							});
+
+							expect(result).toBeNull();
+							expect(mockPineconeConnectPopup).not.toHaveBeenCalled();
 						});
 
-						mockGetCredentialTypeByName.mockReturnValue({
-							name: 'pineconeApi',
-							displayName: 'Pinecone API',
-							properties: [],
+						it('shows error toast when Pinecone connection is cancelled', async () => {
+							const mockPopup = {
+								open: vi.fn(),
+							};
+							mockPineconeConnectPopup.mockImplementation(({ onCancel }) => {
+								// Simulate user cancelling the connection
+								setTimeout(() => onCancel(), 0);
+								return mockPopup;
+							});
+
+							mockGetCredentialTypeByName.mockReturnValue({
+								name: 'pineconeApi',
+								displayName: 'Pinecone API',
+								properties: [],
+							});
+
+							const { connect } = useQuickConnect();
+							const result = await connect({
+								credentialTypeName: 'pineconeApi',
+								nodeType: '@n8n/n8n-nodes-langchain.pinecone',
+								source: 'node',
+							});
+
+							expect(result).toBeNull();
+							expect(mockToastShowError).toHaveBeenCalledWith(
+								undefined,
+								'credentialEdit.credentialEdit.showError.createCredential.title',
+							);
 						});
 
-						const { connect } = useQuickConnect();
-						const result = await connect({
-							credentialTypeName: 'pineconeApi',
-							nodeType: '@n8n/n8n-nodes-langchain.pinecone',
-							source: 'node',
+						it('shows error toast when credential creation fails', async () => {
+							const mockPopup = {
+								open: vi.fn(),
+							};
+							mockPineconeConnectPopup.mockImplementation(({ onConnect }) => {
+								setTimeout(() => onConnect({ key: 'test-api-key-123' }), 0);
+								return mockPopup;
+							});
+
+							mockGetCredentialTypeByName.mockReturnValue({
+								name: 'pineconeApi',
+								displayName: 'Pinecone API',
+								properties: [],
+							});
+
+							const error = new Error('Failed to create credential');
+							mockCreateNewCredential.mockRejectedValue(error);
+
+							const { connect } = useQuickConnect();
+							const result = await connect({
+								credentialTypeName: 'pineconeApi',
+								nodeType: '@n8n/n8n-nodes-langchain.pinecone',
+								source: 'node',
+							});
+
+							expect(result).toBeNull();
+							expect(mockToastShowError).toHaveBeenCalledWith(
+								error,
+								'credentialEdit.credentialEdit.showError.createCredential.title',
+							);
 						});
 
-						expect(result).toBeNull();
-						expect(mockToastShowError).toHaveBeenCalledWith(
-							undefined,
-							'credentialEdit.credentialEdit.showError.createCredential.title',
-						);
-					});
+						it('throws error for unsupported quick connect type', async () => {
+							const unsupportedOption: QuickConnectOption = {
+								packageName: 'test-package',
+								credentialType: 'testApi',
+								text: 'Test',
+								quickConnectType: 'unsupported-type',
+								serviceName: 'Test Service',
+							};
 
-					it('shows error toast when credential creation fails', async () => {
-						const mockPopup = {
-							open: vi.fn(),
-						};
-						mockPineconeConnectPopup.mockImplementation(({ onConnect }) => {
-							setTimeout(() => onConnect({ key: 'test-api-key-123' }), 0);
-							return mockPopup;
+							settingsStore.moduleSettings['quick-connect'] = {
+								options: [unsupportedOption],
+							};
+
+							mockGetCredentialTypeByName.mockReturnValue({
+								name: 'testApi',
+								displayName: 'Test API',
+								properties: [],
+							});
+
+							const { connect } = useQuickConnect();
+							const result = await connect({
+								credentialTypeName: 'testApi',
+								nodeType: 'test-package.testNode',
+								source: 'node',
+							});
+
+							expect(result).toBeNull();
+							expect(mockToastShowError).toHaveBeenCalledWith(
+								expect.objectContaining({
+									message: 'Quick connect for type unsupported-type is not implemented',
+								}),
+								'credentialEdit.credentialEdit.showError.createCredential.title',
+							);
 						});
-
-						mockGetCredentialTypeByName.mockReturnValue({
-							name: 'pineconeApi',
-							displayName: 'Pinecone API',
-							properties: [],
-						});
-
-						const error = new Error('Failed to create credential');
-						mockCreateNewCredential.mockRejectedValue(error);
-
-						const { connect } = useQuickConnect();
-						const result = await connect({
-							credentialTypeName: 'pineconeApi',
-							nodeType: '@n8n/n8n-nodes-langchain.pinecone',
-							source: 'node',
-						});
-
-						expect(result).toBeNull();
-						expect(mockToastShowError).toHaveBeenCalledWith(
-							error,
-							'credentialEdit.credentialEdit.showError.createCredential.title',
-						);
-					});
-
-					it('throws error for unsupported quick connect type', async () => {
-						const unsupportedOption: QuickConnectOption = {
-							packageName: 'test-package',
-							credentialType: 'testApi',
-							text: 'Test',
-							quickConnectType: 'unsupported-type',
-							serviceName: 'Test Service',
-						};
-
-						settingsStore.moduleSettings['quick-connect'] = {
-							options: [unsupportedOption],
-						};
-
-						mockGetCredentialTypeByName.mockReturnValue({
-							name: 'testApi',
-							displayName: 'Test API',
-							properties: [],
-						});
-
-						const { connect } = useQuickConnect();
-						const result = await connect({
-							credentialTypeName: 'testApi',
-							nodeType: 'test-package.testNode',
-							source: 'node',
-						});
-
-						expect(result).toBeNull();
-						expect(mockToastShowError).toHaveBeenCalledWith(
-							expect.objectContaining({
-								message: 'Quick connect for type unsupported-type is not implemented',
-							}),
-							'credentialEdit.credentialEdit.showError.createCredential.title',
-						);
-					});
-				});
+					},
+				);
 			});
 		});
 	});

--- a/packages/frontend/editor-ui/src/features/credentials/quickConnect/composables/useQuickConnect.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/quickConnect/composables/useQuickConnect.ts
@@ -68,7 +68,7 @@ export function useQuickConnect() {
 		const option = optionsByCredentialType.value.get(credentialType);
 		if (!option) return undefined;
 		const pkg = nodeType.split('.')[0];
-		return option.packageName === pkg ? option : undefined;
+		return option.packageName.split('.')[0] === pkg ? option : undefined;
 	}
 
 	function getQuickConnectOptionByPackageName(packageName: string): QuickConnectOption | undefined {

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Modes/ActionsMode.vue
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Modes/ActionsMode.vue
@@ -34,6 +34,8 @@ import { isNodePreviewKey } from '../../nodeCreator.utils';
 import CommunityNodeInfo from '@/features/settings/communityNodes/components/nodeCreator/CommunityNodeInfo.vue';
 import CommunityNodeFooter from '@/features/settings/communityNodes/components/nodeCreator/CommunityNodeFooter.vue';
 import { useCalloutHelpers } from '@/app/composables/useCalloutHelpers';
+import { useQuickConnect } from '@/features/credentials/quickConnect/composables/useQuickConnect';
+import QuickConnectBanner from '@/features/credentials/quickConnect/components/QuickConnectBanner.vue';
 
 import { N8nCallout, N8nInfoTip } from '@n8n/design-system';
 const emit = defineEmits<{
@@ -102,6 +104,16 @@ const rootView = computed(() => useViewStacks().activeViewStack.rootView);
 const communityNodeDetails = computed(() => useViewStacks().activeViewStack?.communityNodeDetails);
 
 const placeholderTriggerActions = getPlaceholderTriggerActions(subcategory.value || '');
+
+const { getQuickConnectOptionByPackageName } = useQuickConnect();
+const quickConnect = computed(() => {
+	const items = useViewStacks().activeViewStack.items;
+	if (!communityNodeDetails.value && items?.length) {
+		return getQuickConnectOptionByPackageName(items[0].key);
+	}
+
+	return null;
+});
 
 const hasNoTriggerActions = computed(
 	() =>
@@ -260,6 +272,9 @@ const callouts = computed<INodeCreateElement[]>(() => []);
 		<ItemsRenderer :elements="callouts" :class="$style.items" @selected="onSelected" />
 
 		<CommunityNodeInfo v-if="communityNodeDetails" />
+		<div :class="$style.banner" v-if="quickConnect">
+			<QuickConnectBanner :text="quickConnect.text" />
+		</div>
 		<OrderSwitcher v-if="rootView" :root-view="rootView">
 			<template v-if="shouldShowTriggers" #triggers>
 				<!-- Triggers Category -->
@@ -404,5 +419,9 @@ const callouts = computed<INodeCreateElement[]>(() => []);
 	color: var(--color--text);
 	line-height: var(--line-height--md);
 	z-index: 1;
+}
+.banner {
+	margin: var(--spacing--sm);
+	margin-top: 0;
 }
 </style>


### PR DESCRIPTION
## Summary

Implements promotion banners for non-community nodes

<img width="399" height="369" alt="Bildschirmfoto 2026-02-19 um 15 46 23" src="https://github.com/user-attachments/assets/8b36afb4-dca6-4bba-a911-8f70e34972a8" />


## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/NODE-4469/add-quick-connect-banner-for-non-community-nodes

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
