### PR TITLE
fix(editor): Enable stop button to abort AI Ask Assistant streaming

### DIFF
--- a/packages/cli/src/controllers/__tests__/ai.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/ai.controller.test.ts
@@ -73,6 +73,69 @@ describe('AiController', () => {
 				InternalServerError,
 			);
 		});
+
+		it('should register a close handler on the response for abort', async () => {
+			aiService.chat.mockResolvedValue(
+				mock<Response>({
+					body: mock({
+						pipeTo: jest.fn().mockResolvedValue(undefined),
+					}),
+				}),
+			);
+
+			await controller.chat(request, response, payload);
+
+			expect(response.on).toHaveBeenCalledWith('close', expect.any(Function));
+		});
+
+		it('should remove close handler after streaming completes', async () => {
+			aiService.chat.mockResolvedValue(
+				mock<Response>({
+					body: mock({
+						pipeTo: jest.fn().mockResolvedValue(undefined),
+					}),
+				}),
+			);
+
+			await controller.chat(request, response, payload);
+
+			expect(response.off).toHaveBeenCalledWith('close', expect.any(Function));
+		});
+
+		it('should silently return when pipeTo throws an AbortError', async () => {
+			const abortError = new DOMException('The operation was aborted', 'AbortError');
+
+			aiService.chat.mockResolvedValue(
+				mock<Response>({
+					body: mock({
+						pipeTo: jest.fn().mockRejectedValue(abortError),
+					}),
+				}),
+			);
+
+			// Should not throw
+			await controller.chat(request, response, payload);
+
+			expect(response.end).not.toHaveBeenCalled();
+		});
+
+		it('should pass abort signal to pipeTo', async () => {
+			const pipeToMock = jest.fn().mockResolvedValue(undefined);
+
+			aiService.chat.mockResolvedValue(
+				mock<Response>({
+					body: mock({
+						pipeTo: pipeToMock,
+					}),
+				}),
+			);
+
+			await controller.chat(request, response, payload);
+
+			expect(pipeToMock).toHaveBeenCalledWith(expect.any(WritableStream), {
+				signal: expect.any(AbortSignal),
+			});
+		});
 	});
 
 	describe('applySuggestion', () => {

--- a/packages/frontend/editor-ui/src/features/ai/assistant/assistant.api.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/assistant.api.ts
@@ -44,6 +44,7 @@ export function chatWithAssistant(
 	onMessageUpdated: (data: ChatRequest.ResponsePayload) => void,
 	onDone: () => void,
 	onError: (e: Error) => void,
+	abortSignal?: AbortSignal,
 ): void {
 	try {
 		const payloadSize = getObjectSizeInKB(payload.payload);
@@ -61,6 +62,8 @@ export function chatWithAssistant(
 		onMessageUpdated,
 		onDone,
 		onError,
+		undefined,
+		abortSignal,
 	);
 }
 

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Chat/AskAssistantChat.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Chat/AskAssistantChat.vue
@@ -95,6 +95,7 @@ defineExpose({
 			:input-placeholder="i18n.baseText('aiAssistant.askMode.inputPlaceholder')"
 			@close="emit('close')"
 			@message="onUserMessage"
+			@stop="assistantStore.abortStreaming"
 			@code-replace="onCodeReplace"
 			@code-undo="undoCodeDiff"
 		>


### PR DESCRIPTION
## Summary

The stop button in Ask mode (AI assistant chat) was non-functional, clicking it had no effect and the generation continued until completion. This was because the entire abort pipeline was missing for Ask mode, while Builder mode had a complete implementation.

This fix replicates the Builder mode's abort pattern

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2065/ai-ask-assistant-generation-cannot-be-stopped