### PR TITLE
fix(editor): Make Chat hub text prompt scrollable

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
@@ -343,7 +343,7 @@ defineExpose({ focus, blur, select });
 				:maxlength="maxlength"
 				:autocomplete="autocomplete"
 				:name="name"
-				:style="autosize ? { ...textareaStyles, resize: 'none', overflow: 'hidden' } : undefined"
+				:style="autosize ? { ...textareaStyles, resize: 'none', overflow: 'auto' } : undefined"
 				v-bind="inputAttrs"
 				@input="onInput"
 				@blur="onBlur"


### PR DESCRIPTION
## Summary

Chat hub's text prompt wasn't scrollable with long inputs.
Allow the content to scroll with long text.


https://github.com/user-attachments/assets/d36f8174-b16c-4051-b0bd-6dce4e7cd96a

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-145/chat-window-is-not-scrollable-with-a-lot-of-pasted-text

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
