### PR TITLE
fix(Azure OpenAI Node): Disable Responses API to fix GPT-5.2 connection error

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/LmChatAzureOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/LmChatAzureOpenAi.node.ts
@@ -102,6 +102,10 @@ export class LmChatAzureOpenAi implements INodeType {
 
 			const timeout = options.timeout;
 			const model = new AzureChatOpenAI({
+				// Force completions API — Azure's SDK doesn't rewrite the /responses path,
+				// so the Responses API hits an invalid endpoint and causes a connection error.
+				// See: https://github.com/langchain-ai/langchainjs/issues/9038
+				useResponsesApi: false,
 				// Model name is required so logs are correct
 				// Also ensures internal logic (like mapping "maxTokens" to "maxCompletionTokens") is correct
 				model: modelName,


### PR DESCRIPTION
## Summary

GPT-5.2 (and other newer models) trigger LangChain's automatic Responses API switch, which sends requests to `/responses`. However, Azure's OpenAI SDK only rewrites URLs for a hardcoded set of paths (`/chat/completions`, `/embeddings`, etc.) — `/responses` is not in that set. This causes the request to hit an invalid Azure endpoint, resulting in a connection error.

This fix explicitly sets `useResponsesApi: false` on the `AzureChatOpenAI` constructor, forcing all requests through the completions API path that Azure correctly handles.

This is a known upstream issue: https://github.com/langchain-ai/langchainjs/issues/9038

## Why this fix is safe

`useResponsesApi: false` forces `AzureChatOpenAI` to always use the `/chat/completions` path, which Azure's SDK knows how to rewrite into the correct deployment-based URL. GPT-5.2 works fine via the completions API... the Responses API is just a newer alternative path that Azure's SDK doesn't handle yet.

The regular OpenAI Chat Model node (`LmChatOpenAi`) only enables the Responses API when the user explicitly opts in (v1.3+, `responsesApiEnabled` parameter). The Azure node has no such opt-in yet, the only thing triggering it is LangChain's auto-detection in `_useResponsesApi()`, which checks for built-in tools, custom tools, or responses-only kwargs. That auto-detection is what breaks on Azure.

## Caveats

This blocks **all** Responses API features for the Azure node: built-in tools (web search, file search, code interpreter), conversation IDs, prompt caching keys, service tier selection, etc. **However, none of these features are wired up in the Azure node today, so there is no feature regression.**

## Full fix

The root cause is upstream -> the `openai` SDK's `AzureOpenAI` client only rewrites URLs for a hardcoded set of paths, and `/responses` is not one of them. Azure's Responses API requires a different URL format (`/openai/v1/responses` with model in body) vs the legacy `/openai/deployments/{name}/...` pattern.

So the full fix would be to fix it upstream in `openai` SDK / LangChain, adding `/responses` to Azure's rewritten paths ([langchainjs#9038](https://github.com/langchain-ai/langchainjs/issues/9038)). Once that is done, add a `responsesApiEnabled` toggle to the Azure node (similar to the OpenAI node's v1.3 parameter) so users can opt in to the Responses API and its features

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2063