### PR TITLE
fix(core): Render newlines on Chat hub messages without requiring hard breaks

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatHubMarkdownOptions.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useChatHubMarkdownOptions.ts
@@ -23,6 +23,7 @@ export function useChatHubMarkdownOptions(
 	const codeBlockContents = ref<Map<string, string>>();
 
 	const options = {
+		breaks: true,
 		highlight(str: string, lang: string) {
 			if (!lang) {
 				return ''; // use external default escaping


### PR DESCRIPTION
## Summary

<img width="414" height="480" alt="image" src="https://github.com/user-attachments/assets/5c6999a7-183e-4b46-b25b-6fc7e02c1e46" />

Make chat hub render newlines on messages withtour requiring a hard break (two trailing spaces). This makes Respond to Chat nodes more intuitive to use, as this requirement of hard breaks was difficult to discover, and AI models might also not do this and just use a newline without trailing spaces.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-136/respond-to-chat-node-line-breaks-only-works-if-previous-line-has-two

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
