### PR TITLE
fix(ai-builder): Fix more evals executions of workflows (no-changelog)

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/support/pin-data-generator.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/support/pin-data-generator.test.ts
@@ -98,6 +98,68 @@ describe('identifyPinDataNodes', () => {
 		expect(result.map((n) => n.name)).toEqual(['Code', 'Exec']);
 	});
 
+	it('should include DataTable nodes', () => {
+		const workflow: SimpleWorkflow = {
+			name: 'Test',
+			nodes: [makeNode({ name: 'Table', type: 'n8n-nodes-base.dataTable' })],
+			connections: {},
+		};
+
+		const result = identifyPinDataNodes(workflow, nodeTypes);
+		expect(result).toHaveLength(1);
+		expect(result[0].name).toBe('Table');
+	});
+
+	it('should include root AI nodes targeted by ai_* connections', () => {
+		const workflow: SimpleWorkflow = {
+			name: 'Test',
+			nodes: [
+				makeNode({ name: 'Chat Trigger', type: '@n8n/n8n-nodes-langchain.chatTrigger' }),
+				makeNode({ name: 'Agent', type: '@n8n/n8n-nodes-langchain.agent' }),
+				makeNode({ name: 'OpenAI', type: '@n8n/n8n-nodes-langchain.lmOpenAi' }),
+				makeNode({ name: 'Tool', type: '@n8n/n8n-nodes-langchain.toolCalculator' }),
+			],
+			connections: {
+				'Chat Trigger': {
+					main: [[{ node: 'Agent', type: 'main', index: 0 }]],
+				},
+				OpenAI: {
+					ai_languageModel: [[{ node: 'Agent', type: 'ai_languageModel', index: 0 }]],
+				},
+				Tool: {
+					ai_tool: [[{ node: 'Agent', type: 'ai_tool', index: 0 }]],
+				},
+			},
+		};
+
+		const result = identifyPinDataNodes(workflow, nodeTypes);
+		const names = result.map((n) => n.name);
+		// Agent is a root AI node (target of ai_* connections) → pinned
+		expect(names).toContain('Agent');
+		// Sub-nodes (OpenAI, Tool) are not pinned — they won't execute
+		// because the root is pinned
+		expect(names).not.toContain('OpenAI');
+		expect(names).not.toContain('Tool');
+	});
+
+	it('should not treat nodes targeted only by main connections as AI roots', () => {
+		const workflow: SimpleWorkflow = {
+			name: 'Test',
+			nodes: [
+				makeNode({ name: 'Trigger', type: 'n8n-nodes-base.manualTrigger' }),
+				makeNode({ name: 'Set', type: 'n8n-nodes-base.set' }),
+			],
+			connections: {
+				Trigger: {
+					main: [[{ node: 'Set', type: 'main', index: 0 }]],
+				},
+			},
+		};
+
+		const result = identifyPinDataNodes(workflow, nodeTypes);
+		expect(result).toHaveLength(0);
+	});
+
 	it('should include HTTP Request and Webhook nodes even without credentials', () => {
 		const workflow: SimpleWorkflow = {
 			name: 'Test',

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/support/pin-data-generator.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/support/pin-data-generator.test.ts
@@ -68,19 +68,34 @@ describe('identifyPinDataNodes', () => {
 		expect(result[0].name).toBe('Slack');
 	});
 
-	it('should exclude utility nodes from deny-list', () => {
+	it('should exclude utility nodes that can run without infrastructure', () => {
 		const workflow: SimpleWorkflow = {
 			name: 'Test',
 			nodes: [
 				makeNode({ name: 'Set', type: 'n8n-nodes-base.set' }),
 				makeNode({ name: 'If', type: 'n8n-nodes-base.if' }),
-				makeNode({ name: 'Code', type: 'n8n-nodes-base.code' }),
+				makeNode({ name: 'Merge', type: 'n8n-nodes-base.merge' }),
 			],
 			connections: {},
 		};
 
 		const result = identifyPinDataNodes(workflow, nodeTypes);
 		expect(result).toHaveLength(0);
+	});
+
+	it('should include Code and ExecuteCommand nodes (require task runner)', () => {
+		const workflow: SimpleWorkflow = {
+			name: 'Test',
+			nodes: [
+				makeNode({ name: 'Code', type: 'n8n-nodes-base.code' }),
+				makeNode({ name: 'Exec', type: 'n8n-nodes-base.executeCommand' }),
+			],
+			connections: {},
+		};
+
+		const result = identifyPinDataNodes(workflow, nodeTypes);
+		expect(result).toHaveLength(2);
+		expect(result.map((n) => n.name)).toEqual(['Code', 'Exec']);
 	});
 
 	it('should include HTTP Request and Webhook nodes even without credentials', () => {

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/support/pin-data-generator.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/support/pin-data-generator.ts
@@ -49,44 +49,14 @@ interface NodeSchemaContext {
 // Utility node deny-list
 // ---------------------------------------------------------------------------
 
-/** Node types that don't call external APIs and don't need pin data. */
-const UTILITY_NODE_TYPES = new Set([
-	'n8n-nodes-base.set',
-	'n8n-nodes-base.if',
-	'n8n-nodes-base.switch',
-	'n8n-nodes-base.merge',
-	'n8n-nodes-base.code',
-	'n8n-nodes-base.splitInBatches',
-	'n8n-nodes-base.noOp',
-	'n8n-nodes-base.stickyNote',
-	'n8n-nodes-base.manualTrigger',
-	'n8n-nodes-base.scheduleTrigger',
-	'n8n-nodes-base.cronTrigger',
-	'n8n-nodes-base.executeWorkflowTrigger',
-	'n8n-nodes-base.errorTrigger',
-	'n8n-nodes-base.start',
-	'n8n-nodes-base.functionItem',
-	'n8n-nodes-base.function',
-	'n8n-nodes-base.itemLists',
-	'n8n-nodes-base.filter',
-	'n8n-nodes-base.removeDuplicates',
-	'n8n-nodes-base.sort',
-	'n8n-nodes-base.limit',
-	'n8n-nodes-base.aggregate',
-	'n8n-nodes-base.summarize',
-	'n8n-nodes-base.splitOut',
-	'n8n-nodes-base.dateTime',
-	'n8n-nodes-base.crypto',
-	'n8n-nodes-base.xml',
-	'n8n-nodes-base.html',
-	'n8n-nodes-base.markdown',
-	'n8n-nodes-base.compareDatasets',
-	'n8n-nodes-base.respondToWebhook',
-	'n8n-nodes-base.wait',
-	'n8n-nodes-base.executeCommand',
-	'n8n-nodes-base.convertToFile',
-	'n8n-nodes-base.extractFromFile',
-	'n8n-nodes-base.renameKeys',
+/**
+ * Nodes that define credentials in their type description but don't actually
+ * call external APIs, so they don't need pin data. All other non-service nodes
+ * are excluded naturally because they have no credentials defined.
+ */
+const NON_SERVICE_NODES_WITH_CREDENTIALS = new Set([
+	'n8n-nodes-base.wait', // optional webhook-resumption auth
+	'n8n-nodes-base.respondToWebhook', // optional JWT signing when responding
 ]);
 
 // ---------------------------------------------------------------------------
@@ -107,15 +77,21 @@ export function identifyPinDataNodes(
 		// Skip disabled nodes
 		if (node.disabled) return false;
 
-		// Skip utility nodes by deny-list
-		if (UTILITY_NODE_TYPES.has(node.type)) return false;
-
 		// Check if the node type definition has credentials (→ it's a service node)
 		const typeDesc = nodeTypeMap.get(node.type);
-		if (typeDesc?.credentials && typeDesc.credentials.length > 0) return true;
+		if (typeDesc?.credentials && typeDesc.credentials.length > 0) {
+			// Exclude nodes that define credentials for local/optional auth, not external APIs
+			return !NON_SERVICE_NODES_WITH_CREDENTIALS.has(node.type);
+		}
 
-		// Also include HTTP Request and Webhook nodes (may not have credentials defined)
-		if (node.type === 'n8n-nodes-base.httpRequest' || node.type === 'n8n-nodes-base.webhook') {
+		// Also include HTTP Request, Webhook, and DataTable nodes.
+		// HTTP/Webhook have optional credentials; DataTable has none but requires
+		// the data-table module which isn't available in the eval context.
+		if (
+			node.type === 'n8n-nodes-base.httpRequest' ||
+			node.type === 'n8n-nodes-base.webhook' ||
+			node.type === 'n8n-nodes-base.dataTable'
+		) {
 			return true;
 		}
 

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/support/pin-data-generator.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/support/pin-data-generator.ts
@@ -64,6 +64,29 @@ const NON_SERVICE_NODES_WITH_CREDENTIALS = new Set([
 // ---------------------------------------------------------------------------
 
 /**
+ * Build a set of node names that are targets of AI-type connections
+ * (ai_languageModel, ai_tool, ai_memory, etc.). These are root AI nodes
+ * (e.g. Agent, Chain) whose sub-nodes can't be individually pinned.
+ * Pinning the root prevents sub-node execution entirely.
+ */
+function findAiRootNodeNames(workflow: SimpleWorkflow): Set<string> {
+	const roots = new Set<string>();
+	for (const nodeConns of Object.values(workflow.connections)) {
+		for (const [connType, outputs] of Object.entries(nodeConns)) {
+			if (!connType.startsWith('ai_')) continue;
+			if (!Array.isArray(outputs)) continue;
+			for (const group of outputs) {
+				if (!Array.isArray(group)) continue;
+				for (const conn of group) {
+					if (conn?.node) roots.add(conn.node);
+				}
+			}
+		}
+	}
+	return roots;
+}
+
+/**
  * Identify which nodes in a workflow need pin data.
  * In eval context, we pin all service/API nodes since none have real credentials.
  */
@@ -72,10 +95,15 @@ export function identifyPinDataNodes(
 	nodeTypes: INodeTypeDescription[],
 ): INode[] {
 	const nodeTypeMap = new Map(nodeTypes.map((nt) => [nt.name, nt]));
+	const aiRootNodes = findAiRootNodeNames(workflow);
 
 	return workflow.nodes.filter((node) => {
 		// Skip disabled nodes
 		if (node.disabled) return false;
+
+		// Pin root AI nodes (Agent, Chain, etc.) — their sub-nodes (tools,
+		// memory, LLMs) can't run without real providers in the eval context.
+		if (aiRootNodes.has(node.name)) return true;
 
 		// Check if the node type definition has credentials (→ it's a service node)
 		const typeDesc = nodeTypeMap.get(node.type);
@@ -84,13 +112,16 @@ export function identifyPinDataNodes(
 			return !NON_SERVICE_NODES_WITH_CREDENTIALS.has(node.type);
 		}
 
-		// Also include HTTP Request, Webhook, and DataTable nodes.
-		// HTTP/Webhook have optional credentials; DataTable has none but requires
-		// the data-table module which isn't available in the eval context.
+		// Nodes that require infrastructure unavailable in the eval context:
+		// - HTTP/Webhook: optional credentials, may call external APIs
+		// - DataTable: requires the data-table module
+		// - Code/ExecuteCommand: require a task runner to execute
 		if (
 			node.type === 'n8n-nodes-base.httpRequest' ||
 			node.type === 'n8n-nodes-base.webhook' ||
-			node.type === 'n8n-nodes-base.dataTable'
+			node.type === 'n8n-nodes-base.dataTable' ||
+			node.type === 'n8n-nodes-base.code' ||
+			node.type === 'n8n-nodes-base.executeCommand'
 		) {
 			return true;
 		}

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/support/workflow-executor.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/support/workflow-executor.ts
@@ -17,6 +17,7 @@
 
 import type {
 	IExecuteFunctions,
+	INode,
 	IPinData,
 	IRun,
 	INodeType,
@@ -241,6 +242,23 @@ function makeAdditionalDataStub(
 }
 
 // ---------------------------------------------------------------------------
+// Start node detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Fallback start-node finder for trigger nodes whose type description
+ * includes 'trigger' in its group (e.g. ChatTrigger, which is webhook-based
+ * and not recognised by Workflow.getStartNode()).
+ */
+export function findTriggerByGroup(nodes: INode[], nodeTypes: INodeTypes): INode | undefined {
+	return nodes.find((currentNode) => {
+		if (currentNode.disabled) return false;
+		const nt = nodeTypes.getByNameAndVersion(currentNode.type, currentNode.typeVersion);
+		return nt.description.group?.includes('trigger');
+	});
+}
+
+// ---------------------------------------------------------------------------
 // Main execution function
 // ---------------------------------------------------------------------------
 
@@ -277,13 +295,7 @@ export async function executeWorkflowWithPinData(
 		// method or those in STARTING_NODE_TYPES. Webhook-based triggers like ChatTrigger
 		// are missed, so fall back to any node whose description group includes 'trigger'.
 		let startNode = workflowInstance.getStartNode();
-		if (!startNode) {
-			startNode = workflow.nodes.find((n) => {
-				if (n.disabled) return false;
-				const nt = imports.nodeTypes.getByNameAndVersion(n.type, n.typeVersion);
-				return nt.description.group?.includes('trigger');
-			});
-		}
+		startNode ??= findTriggerByGroup(workflow.nodes, imports.nodeTypes);
 		if (!startNode) {
 			return {
 				success: false,

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/support/workflow-executor.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/support/workflow-executor.ts
@@ -112,7 +112,6 @@ class DistNodeTypes implements INodeTypes {
 		const known = this.knownNodes.get(type);
 		if (!known) {
 			// Unknown type — return a passthrough so the engine doesn't crash.
-			// Service nodes never reach execute() because pin data intercepts them first.
 			return {
 				description: {
 					displayName: type,
@@ -141,10 +140,6 @@ class DistNodeTypes implements INodeTypes {
 		return instance;
 	}
 }
-
-// ---------------------------------------------------------------------------
-// Lazy singleton for WorkflowExecute + ExecutionLifecycleHooks + DistNodeTypes
-// ---------------------------------------------------------------------------
 
 let resolvedImports: ResolvedImports | undefined;
 
@@ -193,8 +188,6 @@ async function resolveImports(): Promise<ResolvedImports> {
 	>;
 
 	// Load the lazy-load index from each package's dist/known/nodes.json.
-	// These JSON files are built during `pnpm build` and map short node names
-	// to their compiled .js entry points.
 	// eslint-disable-next-line @typescript-eslint/no-require-imports
 	const nodesBaseKnown = require(path.join(nodesBasePath, 'dist', 'known', 'nodes.json')) as Record<
 		string,
@@ -229,15 +222,13 @@ async function resolveImports(): Promise<ResolvedImports> {
 	return resolvedImports;
 }
 
-// ---------------------------------------------------------------------------
-// Proxy-based additionalData stub
-//
-// WorkflowExecute calls various methods on additionalData at runtime.
-// Rather than importing jest-mock-extended (which requires the Jest runtime),
-// we use a Proxy that returns a no-op function for any property access and
-// allows specific values to be injected via the `overrides` map.
-// ---------------------------------------------------------------------------
-
+/*
+ * Proxy-based additionalData stub
+ *
+ * WorkflowExecute calls various methods on additionalData at runtime.
+ * we use a Proxy that returns a no-op function for any property access and
+ * allows specific values to be injected via the `overrides` map.
+ */
 function makeAdditionalDataStub(
 	overrides: Record<string, unknown>,
 ): IWorkflowExecuteAdditionalData {
@@ -258,7 +249,7 @@ function makeAdditionalDataStub(
  *
  * Service/API nodes use pin data (skipping real API calls). Utility nodes
  * (Set, If, Code, etc.) execute normally using their compiled dist
- * implementations, validating the workflow structure end-to-end.
+ * implementations
  *
  * @param workflow - The workflow to execute
  * @param pinData  - Pin data for service/API nodes
@@ -282,8 +273,17 @@ export async function executeWorkflowWithPinData(
 			active: false,
 		});
 
-		// Find start node
-		const startNode = workflowInstance.getStartNode();
+		// Find start node. getStartNode() only recognises nodes with a trigger()/poll()
+		// method or those in STARTING_NODE_TYPES. Webhook-based triggers like ChatTrigger
+		// are missed, so fall back to any node whose description group includes 'trigger'.
+		let startNode = workflowInstance.getStartNode();
+		if (!startNode) {
+			startNode = workflow.nodes.find((n) => {
+				if (n.disabled) return false;
+				const nt = imports.nodeTypes.getByNameAndVersion(n.type, n.typeVersion);
+				return nt.description.group?.includes('trigger');
+			});
+		}
 		if (!startNode) {
 			return {
 				success: false,
@@ -306,13 +306,9 @@ export async function executeWorkflowWithPinData(
 			waitPromise.resolve(fullRunData as IRun);
 		});
 
-		// Set up additional data with a Proxy stub so WorkflowExecute can safely call
-		// any method on it without hitting "Cannot read properties of undefined".
-		// WorkflowExecute reads `hooks` at runtime — it's not on the TS type, so we
-		// inject it via the proxy's known-values map.
+		// Set up additional data with a Proxy stub so WorkflowExecute
 		const additionalData = makeAdditionalDataStub({ executionId: '1', hooks });
 
-		// Create execution data with pin data in resultData
 		const runExecutionData = createRunExecutionData({
 			executionData: {
 				nodeExecutionStack: [
@@ -328,7 +324,6 @@ export async function executeWorkflowWithPinData(
 			},
 		});
 
-		// Execute the workflow
 		const workflowExecute = new imports.WorkflowExecute(additionalData, 'manual', runExecutionData);
 		await workflowExecute.processRunExecutionData(workflowInstance);
 

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/support/workflow-executor.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/support/workflow-executor.ts
@@ -294,8 +294,7 @@ export async function executeWorkflowWithPinData(
 		// Find start node. getStartNode() only recognises nodes with a trigger()/poll()
 		// method or those in STARTING_NODE_TYPES. Webhook-based triggers like ChatTrigger
 		// are missed, so fall back to any node whose description group includes 'trigger'.
-		let startNode = workflowInstance.getStartNode();
-		startNode ??= findTriggerByGroup(workflow.nodes, imports.nodeTypes);
+		const startNode = workflowInstance.getStartNode() ?? findTriggerByGroup(workflow.nodes, imports.nodeTypes);
 		if (!startNode) {
 			return {
 				success: false,


### PR DESCRIPTION
## Summary

Fix several issues preventing the execution evaluator from successfully
running LLM-generated workflows with pin data.

- Removed hard-coded list of nodes to skip and instead create pin data for everything that needs credentials (easier to maintain fewer exceptions from that rule than a full blacklist)
- ChatTrigger not detected as start node (fix start node detection)
- Code/ExecuteCommand nodes crash without task runner (generate pin data for them)
- DataTable nodes crash without data-table module (generate pin data for them)
- AI root nodes need pin data to prevent sub-node execution

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2081

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)