### PR TITLE
chore(core): Add preview notice to AI node SDK and CLI prompts

### DIFF
--- a/packages/@n8n/ai-node-sdk/README.md
+++ b/packages/@n8n/ai-node-sdk/README.md
@@ -1,5 +1,7 @@
 # @n8n/ai-node-sdk
 
+> ℹ️ **Preview:** This package is currently in preview. The API is not stable and may change. AI Nodes are not being accepted for verification at this time.
+
 Public SDK for building AI nodes in n8n. This package provides a simplified API for creating chat model and memory nodes without LangChain dependencies.
 
 ## Installation in node packages

--- a/packages/@n8n/ai-node-sdk/README.md
+++ b/packages/@n8n/ai-node-sdk/README.md
@@ -1,6 +1,6 @@
 # @n8n/ai-node-sdk
 
-> ℹ️ **Preview:** This package is currently in preview. The API is not stable and may change. AI Nodes are not being accepted for verification at this time.
+> **Preview:** This package is in preview. The API may change without notice. AI nodes are not yet accepted for verification.
 
 Public SDK for building AI nodes in n8n. This package provides a simplified API for creating chat model and memory nodes without LangChain dependencies.
 

--- a/packages/@n8n/node-cli/src/commands/new/prompts.ts
+++ b/packages/@n8n/node-cli/src/commands/new/prompts.ts
@@ -58,12 +58,12 @@ export const programmaticNodeTypePrompt = async () =>
 					hint: 'Standard programmatic node',
 				},
 				{
-					label: 'Chat Model',
+					label: 'Chat Model (preview)',
 					value: 'chatModel',
 					hint: 'AI chat model node',
 				},
 				{
-					label: 'Chat Memory',
+					label: 'Chat Memory (preview)',
 					value: 'chatMemory',
 					hint: 'AI chat memory node',
 				},


### PR DESCRIPTION
## Summary

- Added preview notice to `@n8n/ai-node-sdk` README clarifying the API may change and AI nodes are not yet accepted for verification
- Added `(preview)` label to Chat Model and Chat Memory options in the `n8n-node new` CLI selector

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4482

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)