### PR TITLE
fix(AI Agent Node): Fix orphaned tool messages in AI Agent memory after buffer window slides

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
@@ -16,6 +16,7 @@ import { jsonParse, NodeOperationError, sleep } from 'n8n-workflow';
 import type { IExecuteFunctions, INodeExecutionData, ISupplyDataFunctions } from 'n8n-workflow';
 import assert from 'node:assert';
 
+import { loadMemory } from '@utils/agent-execution';
 import { getPromptInputByType } from '@utils/helpers';
 import {
 	getOptionalOutputParser,
@@ -294,12 +295,7 @@ export async function toolsAgentExecute(
 				this.getNode().typeVersion >= 2.1
 			) {
 				// Get chat history respecting the context window length configured in memory
-				let chatHistory;
-				if (memory) {
-					// Load memory variables to respect context window length
-					const memoryVariables = await memory.loadMemoryVariables({});
-					chatHistory = memoryVariables['chat_history'];
-				}
+				const chatHistory = memory ? await loadMemory(memory, model) : undefined;
 				const eventStream = executor.streamEvents(
 					{
 						...invokeParams,

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/memoryManagement.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/memoryManagement.ts
@@ -152,20 +152,29 @@ export function buildToolContext(steps: ToolCallData[]): string {
  * @returns Cleaned array with orphaned messages removed from the start
  */
 function cleanupOrphanedMessages(chatHistory: BaseMessage[]): BaseMessage[] {
-	// Remove orphaned ToolMessages at the start
-	while (chatHistory.length > 0 && chatHistory[0] instanceof ToolMessage) {
-		chatHistory.shift();
-	}
+	let changed = true;
+	while (changed && chatHistory.length > 0) {
+		changed = false;
 
-	// Remove AIMessages with tool_calls if they don't have following ToolMessages
-	const firstMessage = chatHistory[0];
-	const hasOrphanedAIMessage =
-		firstMessage instanceof AIMessage &&
-		(firstMessage.tool_calls?.length ?? 0) > 0 &&
-		!(chatHistory[1] instanceof ToolMessage);
+		// Remove orphaned ToolMessages at the start
+		while (chatHistory.length > 0 && chatHistory[0] instanceof ToolMessage) {
+			chatHistory.shift();
+			changed = true;
+		}
 
-	if (hasOrphanedAIMessage) {
-		chatHistory.shift();
+		// Remove AIMessages with tool_calls if they don't have following ToolMessages
+		if (chatHistory.length > 0) {
+			const firstMessage = chatHistory[0];
+			const hasOrphanedAIMessage =
+				firstMessage instanceof AIMessage &&
+				(firstMessage.tool_calls?.length ?? 0) > 0 &&
+				!(chatHistory[1] instanceof ToolMessage);
+
+			if (hasOrphanedAIMessage) {
+				chatHistory.shift();
+				changed = true;
+			}
+		}
 	}
 
 	return chatHistory;


### PR DESCRIPTION
## Summary

When `BufferWindowMemory` trims chat history (e.g. with `k=5`), it naively slices messages assuming simple Human/AI pairs. With tool calls, a single turn is 4+ messages (`HumanMessage → AIMessage(tool_calls) → ToolMessage → AIMessage(final)`), so the slice can cut mid-sequence creating orphaned messages. OpenAI and other LLMs reject requests with orphaned `ToolMessage` without a preceding `AIMessage(tool_calls)`.

This PR fixes two bugs:

1. **V2 streaming path bypassed cleanup entirely**, it called `memory.loadMemoryVariables({})` directly instead of using the `loadMemory()` helper that includes `cleanupOrphanedMessages()`. Now uses `loadMemory()` like V3.
2. **`cleanupOrphanedMessages()` was incomplete**, it only handled a single orphaned message at the start. Now loops until all orphans are removed, handling chains like `ToolMsg → AIMsg(tool_calls) → HumanMsg` where removing the ToolMessage reveals an orphaned AIMessage underneath.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-2075
- Fixes https://github.com/n8n-io/n8n/issues/24772