### PR TITLE
ci: Remove unnecessary release note ping from release pipeline

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -129,17 +129,6 @@ jobs:
       release_tag_ref: 'n8n@${{ needs.publish-to-npm.outputs.release }}'
     secrets: inherit
 
-  trigger-release-note:
-    name: Trigger a release note
-    needs: [publish-to-npm, create-github-release]
-    if: |
-      github.event.pull_request.merged == true &&
-      !contains(needs.publish-to-npm.outputs.release, '-rc.')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger a release note
-        run: curl -u docsWorkflows:${{ secrets.N8N_WEBHOOK_DOCS_PASSWORD }} --request GET 'https://internal.users.n8n.cloud/webhook/trigger-release-note' --header 'Content-Type:application/json' --data '{"version":"${{ needs.publish-to-npm.outputs.release }}"}'
-
   merge-release-tag-to-master:
     name: Merge release tag to master
     needs: [publish-to-npm, create-github-release]


### PR DESCRIPTION
## Summary

This ping was not used for anything anymore as it's automated now.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2418/remove-trigger-release-note-from-release-pipeline

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
