### PR TITLE
fix(Gmail Node): Fix GetMany messages query string pollution with non-API parameters

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
@@ -366,8 +366,8 @@ export function prepareQuery(
 		} else {
 			qs.q = `is:${qs.readStatus}`;
 		}
-		delete qs.readStatus;
 	}
+	delete qs.readStatus;
 
 	if (qs.receivedAfter) {
 		qs.q = prepareTimestamp(

--- a/packages/nodes-base/nodes/Google/Gmail/test/v2/GmailV2.node.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/v2/GmailV2.node.test.ts
@@ -29,8 +29,6 @@ describe('Test Gmail Node v2', () => {
 					labelIds: 'CHAT',
 					q: 'test from:Test Sender after:1734393600 before:1735171200',
 					readStatus: 'both',
-					dataPropertyAttachmentsPrefixName: 'attachment_',
-					downloadAttachments: 'true',
 					maxResults: '2',
 				})
 				.reply(200, { messages });
@@ -49,8 +47,6 @@ describe('Test Gmail Node v2', () => {
 					labelIds: 'CHAT',
 					q: 'test from:Test Sender after:1734393600 before:1735171200',
 					readStatus: 'both',
-					dataPropertyAttachmentsPrefixName: 'attachment_',
-					downloadAttachments: 'true',
 					maxResults: '2',
 					format: 'raw',
 				})
@@ -65,8 +61,6 @@ describe('Test Gmail Node v2', () => {
 					labelIds: 'CHAT',
 					q: 'test from:Test Sender after:1734393600 before:1735171200',
 					readStatus: 'both',
-					dataPropertyAttachmentsPrefixName: 'attachment_',
-					downloadAttachments: 'true',
 					maxResults: '2',
 					format: 'raw',
 				})

--- a/packages/nodes-base/nodes/Google/Gmail/test/v2/GmailV2.node.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/v2/GmailV2.node.test.ts
@@ -28,7 +28,6 @@ describe('Test Gmail Node v2', () => {
 					includeSpamTrash: 'true',
 					labelIds: 'CHAT',
 					q: 'test from:Test Sender after:1734393600 before:1735171200',
-					readStatus: 'both',
 					maxResults: '2',
 				})
 				.reply(200, { messages });
@@ -46,7 +45,6 @@ describe('Test Gmail Node v2', () => {
 					includeSpamTrash: 'true',
 					labelIds: 'CHAT',
 					q: 'test from:Test Sender after:1734393600 before:1735171200',
-					readStatus: 'both',
 					maxResults: '2',
 					format: 'raw',
 				})
@@ -60,7 +58,6 @@ describe('Test Gmail Node v2', () => {
 					includeSpamTrash: 'true',
 					labelIds: 'CHAT',
 					q: 'test from:Test Sender after:1734393600 before:1735171200',
-					readStatus: 'both',
 					maxResults: '2',
 					format: 'raw',
 				})

--- a/packages/nodes-base/nodes/Google/Gmail/v2/GmailV2.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/GmailV2.node.ts
@@ -377,7 +377,7 @@ export class GmailV2 implements INodeType {
 						const options = this.getNodeParameter('options', i, {});
 						const filters = this.getNodeParameter('filters', i, {});
 						const qs: IDataObject = {};
-						Object.assign(qs, prepareQuery.call(this, filters, i), options, i);
+						Object.assign(qs, prepareQuery.call(this, filters, i));
 
 						if (returnAll) {
 							responseData = await googleApiRequestAllItems.call(


### PR DESCRIPTION
## Summary

Fix the Gmail node's `getAll` messages operation incorrectly merging `options` and the loop index `i` into the API query string via `Object.assign`.

**Before:**
```typescript
Object.assign(qs, prepareQuery.call(this, filters, i), options, i);
```

**After:**
```typescript
Object.assign(qs, prepareQuery.call(this, filters, i));
```

The `options` object contains internal n8n parameters (`dataPropertyAttachmentsPrefixName`, `downloadAttachments`) that are not Gmail API query parameters. Merging them into `qs` pollutes the query string sent to the Gmail API. The trailing `i` (loop index number) was also incorrectly passed as a source to `Object.assign`.

This caused failures when the Gmail node was used as a tool via the MCP Server Trigger, as the polluted query string led to faulty API requests. The thread `getAll` operation (line 729) already uses the correct pattern without `options` and `i`.

The `options` object is still properly accessed later in the function (line 427) for `dataPropertyAttachmentsPrefixName` — it just should not be merged into the API query string.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-2082