### PR TITLE
feat: Improve quick connect frontend implementation

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -4572,6 +4572,7 @@
 	"communityNodeInfo.downloads": "{downloads}",
 	"communityNodeInfo.publishedBy": "{publisherName}",
 	"communityNodeInfo.quickConnect": "Quick connect",
+	"communityNodeInfo.quickConnect.tooltip": "This service allows for easy sign in or sign up directly through n8n",
 	"communityNodeInfo.contact.admin": "Please contact an administrator to install this community node:",
 	"credentialsAppSelection.installToConnect": "Install this node to connect",
 	"credentialsAppSelection.askAdminToInstall": "Ask your admin to install this node",

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
@@ -915,6 +915,7 @@ async function onQuickConnectSignIn(credentialTypeName: string) {
 	display: flex;
 	flex-direction: row;
 	align-items: center;
+	flex-wrap: wrap;
 	gap: var(--spacing--2xs);
 	margin-top: var(--spacing--4xs);
 

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeInfo.vue
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeInfo.vue
@@ -163,12 +163,15 @@ onMounted(async () => {
 				</N8nText>
 			</div>
 
-			<div v-if="quickConnect">
-				<N8nIcon :class="$style.tooltipIcon" icon="quick-connect" />
-				<N8nText color="text-light" size="xsmall" bold data-test-id="quick-connect-tag">
-					{{ i18n.baseText('communityNodeInfo.quickConnect') }}
-				</N8nText>
-			</div>
+			<N8nTooltip v-if="quickConnect" placement="top">
+				<template #content>{{ i18n.baseText('communityNodeInfo.quickConnect.tooltip') }}</template>
+				<div>
+					<N8nIcon :class="$style.tooltipIcon" icon="quick-connect" />
+					<N8nText color="text-light" size="xsmall" bold data-test-id="quick-connect-tag">
+						{{ i18n.baseText('communityNodeInfo.quickConnect') }}
+					</N8nText>
+				</div>
+			</N8nTooltip>
 		</div>
 
 		<QuickConnectBanner v-if="quickConnect" :text="quickConnect?.text" />


### PR DESCRIPTION
## Summary

Fixes:
- Add [tooltip](https://www.figma.com/design/lHMYg2A8rBOklIrpA1XQ9x/Quick-Connect-Shaping?node-id=53-3689&m=dev) for the "Quick connect" tag/label in community node preview
- the text "or setup manually" right to the "Quick connect" button in the node view should overflow to next line if the node panel is too small
- quick connect for pinecone registers a "message handler" every time it is clicked. When you click on "Quick connect to pinecone" and close the popup, then click on "quick connect" again and connect to Pinecone - 2 credentials will be created
- When clicking "Cancel" in quick connect there will be an error message. We should not show anything, user's know themself that they have cancelled the connect flow

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4480/design-review-follow-ups


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
