### PR TITLE
refactor(editor): Switch MERGE_ASK_BUILD from env feature flag to PH boolean flag

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/multi-agent-workflow-subgraphs.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/multi-agent-workflow-subgraphs.ts
@@ -234,9 +234,7 @@ export function createMultiAgentWorkflowWithSubgraphs(config: MultiAgentSubgraph
 		assistantHandler,
 	} = config;
 
-	const mergeAskBuild =
-		(featureFlags?.mergeAskBuild === true || process.env.N8N_ENV_FEAT_MERGE_ASK_BUILD === 'true') &&
-		!!assistantHandler;
+	const mergeAskBuild = featureFlags?.mergeAskBuild === true && !!assistantHandler;
 	const supervisorAgent = new SupervisorAgent({
 		llm: stageLLMs.supervisor,
 		mergeAskBuild,

--- a/packages/@n8n/ai-workflow-builder.ee/src/test/workflow-builder-agent.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/test/workflow-builder-agent.test.ts
@@ -487,7 +487,7 @@ describe('WorkflowBuilderAgent', () => {
 			const payload: ChatPayload = {
 				id: '123',
 				message: 'Create a simple workflow',
-				featureFlags: { codeBuilder: true },
+				featureFlags: { codeBuilder: true, mergeAskBuild: true },
 			};
 
 			const generator = agent.chat(payload);
@@ -506,11 +506,9 @@ describe('WorkflowBuilderAgent', () => {
 
 	describe('triage agent routing', () => {
 		let triageConfig: WorkflowBuilderAgentConfig;
-		const originalMergeAskBuild = process.env.N8N_ENV_FEAT_MERGE_ASK_BUILD;
 
 		beforeEach(() => {
 			jest.clearAllMocks();
-			process.env.N8N_ENV_FEAT_MERGE_ASK_BUILD = 'true';
 
 			mockGenerateCodeBuilderThreadId.mockReturnValue('test-thread-id');
 			mockLoadCodeBuilderSession.mockResolvedValue({
@@ -523,14 +521,6 @@ describe('WorkflowBuilderAgent', () => {
 				...config,
 				assistantHandler: mock<AssistantHandler>(),
 			};
-		});
-
-		afterEach(() => {
-			if (originalMergeAskBuild !== undefined) {
-				process.env.N8N_ENV_FEAT_MERGE_ASK_BUILD = originalMergeAskBuild;
-			} else {
-				delete process.env.N8N_ENV_FEAT_MERGE_ASK_BUILD;
-			}
 		});
 
 		it('should yield assistant chunks and not call CodeWorkflowBuilder for assistant outcome', async () => {
@@ -551,7 +541,7 @@ describe('WorkflowBuilderAgent', () => {
 			const payload: ChatPayload = {
 				id: '123',
 				message: 'How do credentials work?',
-				featureFlags: { codeBuilder: true },
+				featureFlags: { codeBuilder: true, mergeAskBuild: true },
 			};
 
 			const results: StreamOutput[] = [];
@@ -576,7 +566,7 @@ describe('WorkflowBuilderAgent', () => {
 			const payload: ChatPayload = {
 				id: '123',
 				message: 'Build me a Slack notification workflow',
-				featureFlags: { codeBuilder: true },
+				featureFlags: { codeBuilder: true, mergeAskBuild: true },
 			};
 
 			const results: StreamOutput[] = [];
@@ -601,7 +591,7 @@ describe('WorkflowBuilderAgent', () => {
 			const payload: ChatPayload = {
 				id: '123',
 				message: 'What approach should I take?',
-				featureFlags: { codeBuilder: true },
+				featureFlags: { codeBuilder: true, mergeAskBuild: true },
 			};
 
 			const results: StreamOutput[] = [];
@@ -622,7 +612,7 @@ describe('WorkflowBuilderAgent', () => {
 			const payload: ChatPayload = {
 				id: '123',
 				message: 'Help me',
-				featureFlags: { codeBuilder: true },
+				featureFlags: { codeBuilder: true, mergeAskBuild: true },
 			};
 
 			for await (const _ of triageAgent.chat(payload, 'user-456')) {
@@ -644,7 +634,7 @@ describe('WorkflowBuilderAgent', () => {
 			const payload: ChatPayload = {
 				id: '123',
 				message: 'Help me',
-				featureFlags: { codeBuilder: true },
+				featureFlags: { codeBuilder: true, mergeAskBuild: true },
 			};
 
 			const controller = new AbortController();
@@ -681,7 +671,7 @@ describe('WorkflowBuilderAgent', () => {
 			const payload: ChatPayload = {
 				id: '123',
 				message: 'Build this',
-				featureFlags: { codeBuilder: true },
+				featureFlags: { codeBuilder: true, mergeAskBuild: true },
 				workflowContext: { currentWorkflow: { id: 'wf-1' } },
 			};
 
@@ -714,7 +704,7 @@ describe('WorkflowBuilderAgent', () => {
 			const payload: ChatPayload = {
 				id: '123',
 				message: 'How do credentials work?',
-				featureFlags: { codeBuilder: true },
+				featureFlags: { codeBuilder: true, mergeAskBuild: true },
 				workflowContext: { currentWorkflow: { id: 'wf-1' } },
 			};
 
@@ -751,7 +741,7 @@ describe('WorkflowBuilderAgent', () => {
 			const payload: ChatPayload = {
 				id: '123',
 				message: 'What approach should I take?',
-				featureFlags: { codeBuilder: true },
+				featureFlags: { codeBuilder: true, mergeAskBuild: true },
 				workflowContext: { currentWorkflow: { id: 'wf-1' } },
 			};
 
@@ -785,7 +775,7 @@ describe('WorkflowBuilderAgent', () => {
 			const payload: ChatPayload = {
 				id: '123',
 				message: 'Build a workflow',
-				featureFlags: { codeBuilder: true },
+				featureFlags: { codeBuilder: true, mergeAskBuild: true },
 				workflowContext: { currentWorkflow: { id: 'wf-1' } },
 			};
 
@@ -812,7 +802,7 @@ describe('WorkflowBuilderAgent', () => {
 			const payload: ChatPayload = {
 				id: '123',
 				message: 'Fix the Google Sheets error',
-				featureFlags: { codeBuilder: true },
+				featureFlags: { codeBuilder: true, mergeAskBuild: true },
 				workflowContext: { currentWorkflow: { id: 'wf-1' } },
 			};
 
@@ -847,7 +837,7 @@ describe('WorkflowBuilderAgent', () => {
 			const payload: ChatPayload = {
 				id: '123',
 				message: 'Test',
-				featureFlags: { codeBuilder: true },
+				featureFlags: { codeBuilder: true, mergeAskBuild: true },
 			};
 
 			for await (const _ of triageAgent.chat(payload, 'user-456')) {

--- a/packages/@n8n/ai-workflow-builder.ee/src/workflow-builder-agent.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/workflow-builder-agent.ts
@@ -279,7 +279,7 @@ export class WorkflowBuilderAgent {
 				return;
 			}
 
-			const isMergeAskBuildEnabled = process.env.N8N_ENV_FEAT_MERGE_ASK_BUILD === 'true';
+			const isMergeAskBuildEnabled = payload.featureFlags?.mergeAskBuild === true;
 			if (isMergeAskBuildEnabled && this.assistantHandler) {
 				this.logger?.debug('Routing through triage agent', { userId });
 				yield* this.runTriageAgent(payload, userId, abortSignal);

--- a/packages/frontend/editor-ui/src/app/constants/experiments.ts
+++ b/packages/frontend/editor-ui/src/app/constants/experiments.ts
@@ -55,6 +55,8 @@ export const AI_BUILDER_REVIEW_CHANGES_EXPERIMENT = createExperiment(
 	'075_ai_builder_review_changes',
 );
 
+export const MERGE_ASK_BUILD_EXPERIMENT = createExperiment('076_merge_ask_build');
+
 export const EXECUTION_LOGIC_V2_EXPERIMENT = {
 	name: '062_execution_logic_v2',
 	control: 'control',
@@ -121,4 +123,5 @@ export const EXPERIMENTS_TO_TRACK = [
 	FOCUSED_NODES_EXPERIMENT.name,
 	QUICK_CONNECT_EXPERIMENT.name,
 	AI_BUILDER_REVIEW_CHANGES_EXPERIMENT.name,
+	MERGE_ASK_BUILD_EXPERIMENT.name,
 ];

--- a/packages/frontend/editor-ui/src/features/ai/assistant/assistant.types.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/assistant.types.ts
@@ -128,6 +128,7 @@ export namespace ChatRequest {
 		codeBuilder?: boolean;
 		pinData?: boolean;
 		planMode?: boolean;
+		mergeAskBuild?: boolean;
 	}
 
 	export interface UserChatMessage {

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.utils.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.utils.ts
@@ -9,6 +9,7 @@ import { usePostHog } from '@/app/stores/posthog.store';
 import {
 	AI_BUILDER_TEMPLATE_EXAMPLES_EXPERIMENT,
 	CODE_WORKFLOW_BUILDER_EXPERIMENT,
+	MERGE_ASK_BUILD_EXPERIMENT,
 } from '@/app/constants/experiments';
 import type { IRunExecutionData } from 'n8n-workflow';
 import type { IWorkflowDb } from '@/Interface';
@@ -88,6 +89,7 @@ export async function createBuilderPayload(
 		codeBuilder: isCodeBuilderEnabled,
 		pinData: isPinDataEnabled,
 		planMode: options.isPlanModeEnabled ?? false,
+		mergeAskBuild: posthogStore.isFeatureEnabled(MERGE_ASK_BUILD_EXPERIMENT.name),
 	};
 
 	if (options.nodesForSchema?.length) {

--- a/packages/frontend/editor-ui/src/features/ai/assistant/chatPanel.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/chatPanel.store.ts
@@ -10,7 +10,8 @@ import { useChatPanelStateStore, type ChatPanelMode } from './chatPanelState.sto
 import { useAssistantStore } from './assistant.store';
 import { useBuilderStore } from './builder.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
-import { useEnvFeatureFlag } from '@/features/shared/envFeatureFlag/useEnvFeatureFlag';
+import { usePostHog } from '@/app/stores/posthog.store';
+import { MERGE_ASK_BUILD_EXPERIMENT } from '@/app/constants/experiments';
 import type { ICredentialType } from 'n8n-workflow';
 import type { ChatRequest } from './assistant.types';
 import { useI18n } from '@n8n/i18n';
@@ -35,12 +36,12 @@ export const useChatPanelStore = defineStore(STORES.CHAT_PANEL, () => {
 	const route = useRoute();
 	const chatPanelStateStore = useChatPanelStateStore();
 	const settingsStore = useSettingsStore();
-	const { check } = useEnvFeatureFlag();
+	const posthogStore = usePostHog();
 	const locale = useI18n();
 
 	const isMergeAskBuildEnabled = computed(
 		() =>
-			check.value('MERGE_ASK_BUILD') &&
+			posthogStore.isFeatureEnabled(MERGE_ASK_BUILD_EXPERIMENT.name) &&
 			settingsStore.isAiAssistantEnabled &&
 			useBuilderStore().isAIBuilderEnabled,
 	);

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useAskModeCoachmark.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useAskModeCoachmark.ts
@@ -4,7 +4,8 @@ import { useChatPanelStore } from '@/features/ai/assistant/chatPanel.store';
 import { useBuilderStore } from '@/features/ai/assistant/builder.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useCalloutHelpers } from '@/app/composables/useCalloutHelpers';
-import { useEnvFeatureFlag } from '@/features/shared/envFeatureFlag/useEnvFeatureFlag';
+import { usePostHog } from '@/app/stores/posthog.store';
+import { MERGE_ASK_BUILD_EXPERIMENT } from '@/app/constants/experiments';
 import { BUILDER_ENABLED_VIEWS } from '../constants';
 import type { VIEWS } from '@/app/constants';
 
@@ -19,13 +20,13 @@ export function useAskModeCoachmark() {
 	const settingsStore = useSettingsStore();
 	const route = useRoute();
 	const { isCalloutDismissed, dismissCallout } = useCalloutHelpers();
-	const { check } = useEnvFeatureFlag();
+	const posthogStore = usePostHog();
 
 	const isBuildMode = computed(() => chatPanelStore.isBuilderModeActive);
 
 	const isMergeAskBuildEnabled = computed(
 		() =>
-			check.value('MERGE_ASK_BUILD') &&
+			posthogStore.isFeatureEnabled(MERGE_ASK_BUILD_EXPERIMENT.name) &&
 			settingsStore.isAiAssistantEnabled &&
 			builderStore.isAIBuilderEnabled,
 	);


### PR DESCRIPTION
Replace the N8N_ENV_FEAT_MERGE_ASK_BUILD environment variable with a PostHog boolean feature flag (076_merge_ask_build). The flag is now evaluated client-side via PostHog and passed to the backend through the featureFlags payload.

This is to toggle on and off the feature once release if something goes south