### PR TITLE
ci: set explicit least-privilege permissions for core CI workflows

### DIFF
--- a/.github/workflows/ci-check-eligibility-reusable.yml
+++ b/.github/workflows/ci-check-eligibility-reusable.yml
@@ -50,6 +50,9 @@ on:
         description: "Outputs 'true' if all eligibility checks pass, otherwise 'false'."
         value: ${{ jobs.evaluate_conditions.outputs.run_decision }}
 
+permissions:
+  contents: read
+
 jobs:
   evaluate_conditions:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -8,6 +8,9 @@ on:
     paths-ignore:
       - packages/@n8n/task-runner-python/**
 
+permissions:
+  contents: read
+
 jobs:
   build-github:
     name: Build for Github Cache

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   merge_group:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- add explicit top-level workflow permissions (`contents: read`) to these core CI workflows:
  - `.github/workflows/ci-pull-requests.yml`
  - `.github/workflows/ci-master.yml`
  - `.github/workflows/ci-check-eligibility-reusable.yml`

## Why
These workflows currently rely on repository-default token scope. Declaring explicit least-privilege permissions reduces blast radius in the event of CI supply-chain compromise while preserving existing behavior.

## Validation
- `rg -n "^permissions:|^\s+contents:\s" .github/workflows/ci-pull-requests.yml .github/workflows/ci-master.yml .github/workflows/ci-check-eligibility-reusable.yml`
