### PR TITLE
fix(YouTube Node): Use binary data mimeType for uploads

### DIFF
--- a/packages/nodes-base/nodes/Google/YouTube/YouTube.node.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/YouTube.node.ts
@@ -847,7 +847,7 @@ export class YouTube implements INodeType {
 							fileContent = await this.helpers.getBinaryStream(binaryData.id, UPLOAD_CHUNK_SIZE);
 							const metadata = await this.helpers.getBinaryMetadata(binaryData.id);
 							contentLength = metadata.fileSize;
-							mimeType = metadata.mimeType ?? binaryData.mimeType;
+							mimeType = binaryData.mimeType;
 						} else {
 							const buffer = Buffer.from(binaryData.data, BINARY_ENCODING);
 							fileContent = Readable.from(buffer);


### PR DESCRIPTION
Fixes #24355

The YouTube Upload node was preferring `metadata.mimeType` (from filesystem storage) over `binaryData.mimeType` when streaming uploads. When an upstream node overrides the mimeType after binary data is stored, the filesystem metadata retains the original auto-detected value while `binaryData.mimeType` reflects the override. This caused the wrong MIME type (e.g., `application/mp4` instead of `video/mp4`) to be sent to the YouTube API.

This change uses `binaryData.mimeType` consistently, which is the authoritative value visible in the n8n UI.

*This PR was created with the assistance of Claude Opus 4.6 by Anthropic. Happy to make any adjustments!*