### PR TITLE
fix: Skip non-existent tables during entity export

### DIFF
--- a/packages/cli/src/services/export.service.ts
+++ b/packages/cli/src/services/export.service.ts
@@ -148,6 +148,20 @@ export class ExportService {
 
 			this.logger.info(`\n📊 Processing table: ${tableName} (${entityName})`);
 
+			// Check if table exists before trying to export it
+			try {
+				// Test if the table exists by querying it
+				await this.dataSource.query(
+					`SELECT 1 FROM ${this.dataSource.driver.escape(tableName)} LIMIT 1`,
+				);
+			} catch (error) {
+				this.logger.info(
+					`   ⚠️  Table ${tableName} not found or not accessible, skipping...`,
+					{ error },
+				);
+				continue;
+			}
+
 			// Clear existing files for this entity
 			await this.clearExistingEntityFiles(outputDir, entityName);
 


### PR DESCRIPTION
This PR fixes the issue where `n8n export:entities` would fail when the `secrets_provider_connection` table doesn't exist (e.g., when no secrets provider is configured).

The fix adds a table existence check before attempting to export data from each table, following the same pattern as the existing migrations table export logic.

When a table doesn't exist or is not accessible, the export process will now skip the table instead of failing with an error.

This ensures that the export command works correctly even when optional tables are not present in the database.

Related issue: #25345