### PR TITLE
fix(gmail-node): coerce message and email address fields to string to prevent trim/split errors

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
@@ -402,7 +402,10 @@ export function prepareEmailsInput(
 ) {
 	let emails = '';
 
-	input.split(',').forEach((entry) => {
+	// Coerce to string to handle cases where an expression returns a non-string value
+	const inputStr = String(input);
+
+	inputStr.split(',').forEach((entry) => {
 		const email = entry.trim();
 
 		if (email.indexOf('@') === -1) {
@@ -429,7 +432,8 @@ export function prepareEmailBody(
 	instanceId?: string,
 ) {
 	const emailType = this.getNodeParameter('emailType', itemIndex) as string;
-	let message = (this.getNodeParameter('message', itemIndex, '') as string).trim();
+	// Coerce to string to handle cases where an expression returns a non-string value (e.g. a number)
+	let message = String(this.getNodeParameter('message', itemIndex, '') ?? '').trim();
 
 	if (appendAttribution) {
 		const attributionText = 'This email was sent automatically with ';

--- a/packages/nodes-base/nodes/Google/Gmail/test/v2/utils.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/v2/utils.test.ts
@@ -5,7 +5,12 @@ import type { IExecuteFunctions, INode } from 'n8n-workflow';
 import type { IEmail } from '@utils/sendAndWait/interfaces';
 
 import * as GenericFunctions from '../../GenericFunctions';
-import { parseRawEmail, prepareTimestamp } from '../../GenericFunctions';
+import {
+	parseRawEmail,
+	prepareEmailBody,
+	prepareEmailsInput,
+	prepareTimestamp,
+} from '../../GenericFunctions';
 import { addThreadHeadersToEmail } from '../../v2/utils/draft';
 
 const node: INode = {
@@ -130,6 +135,107 @@ describe('parseRawEmail', () => {
 
 		// ASSERT
 		expect(typeof json.date).toBe('string');
+	});
+});
+
+describe('prepareEmailsInput', () => {
+	it('should handle a normal string email address', () => {
+		const executionFunctions = mock<IExecuteFunctions>({
+			getNode: jest.fn(() => mock<INode>()),
+		});
+
+		const result = prepareEmailsInput.call(
+			executionFunctions,
+			'test@example.com',
+			'To',
+			0,
+		);
+		expect(result).toBe('<test@example.com>, ');
+	});
+
+	it('should coerce a number to string and process it (will fail validation for non-email)', () => {
+		const executionFunctions = mock<IExecuteFunctions>({
+			getNode: jest.fn(() => mock<INode>()),
+		});
+
+		// A number without "@" should throw an "Invalid email address" error (not "trim is not a function")
+		expect(() =>
+			prepareEmailsInput.call(executionFunctions, 42 as unknown as string, 'To', 0),
+		).toThrow('Invalid email address');
+	});
+
+	it('should coerce a number that looks like an email-containing value', () => {
+		const executionFunctions = mock<IExecuteFunctions>({
+			getNode: jest.fn(() => mock<INode>()),
+		});
+
+		// Ensure String() coercion is applied and does not throw "trim is not a function"
+		expect(() =>
+			prepareEmailsInput.call(executionFunctions, 123 as unknown as string, 'Message', 0),
+		).toThrow('Invalid email address');
+	});
+});
+
+describe('prepareEmailBody', () => {
+	it('should handle a normal string message', () => {
+		const executionFunctions = mock<IExecuteFunctions>({
+			getNode: jest.fn(() => mock<INode>()),
+			getNodeParameter: jest.fn((paramName: string) => {
+				if (paramName === 'emailType') return 'text';
+				if (paramName === 'message') return 'Hello World';
+				return '';
+			}),
+		});
+
+		const result = prepareEmailBody.call(executionFunctions, 0);
+		expect(result.body).toBe('Hello World');
+		expect(result.htmlBody).toBe('');
+	});
+
+	it('should coerce a numeric message to string without throwing "trim is not a function"', () => {
+		const executionFunctions = mock<IExecuteFunctions>({
+			getNode: jest.fn(() => mock<INode>()),
+			getNodeParameter: jest.fn((paramName: string) => {
+				if (paramName === 'emailType') return 'text';
+				if (paramName === 'message') return 42; // numeric value from expression
+				return '';
+			}),
+		});
+
+		// Should not throw - numeric value gets coerced to string "42"
+		const result = prepareEmailBody.call(executionFunctions, 0);
+		expect(result.body).toBe('42');
+		expect(result.htmlBody).toBe('');
+	});
+
+	it('should coerce null/undefined message to empty string', () => {
+		const executionFunctions = mock<IExecuteFunctions>({
+			getNode: jest.fn(() => mock<INode>()),
+			getNodeParameter: jest.fn((paramName: string) => {
+				if (paramName === 'emailType') return 'text';
+				if (paramName === 'message') return null;
+				return '';
+			}),
+		});
+
+		const result = prepareEmailBody.call(executionFunctions, 0);
+		expect(result.body).toBe('');
+		expect(result.htmlBody).toBe('');
+	});
+
+	it('should handle html email type with numeric message', () => {
+		const executionFunctions = mock<IExecuteFunctions>({
+			getNode: jest.fn(() => mock<INode>()),
+			getNodeParameter: jest.fn((paramName: string) => {
+				if (paramName === 'emailType') return 'html';
+				if (paramName === 'message') return 100;
+				return '';
+			}),
+		});
+
+		const result = prepareEmailBody.call(executionFunctions, 0);
+		expect(result.htmlBody).toBe('100');
+		expect(result.body).toBe('');
 	});
 });
 


### PR DESCRIPTION
## Summary

Fixes a bug in the Gmail node where using an expression that returns a **non-string value** (e.g. a number like `1`, `2`, or an object) in the **Message** or **To/CC/BCC/Reply-To** fields would throw a cryptic error:

```
this.getNodeParameter(...).trim is not a function (item 0)
```

The root cause is that JavaScript's `.trim()` and `.split()` methods are string-only. When a user's expression (e.g. `={{ $json.code }}`) evaluates to a number or other non-string primitive, these calls fail at runtime.

### Fix

Two functions in `GenericFunctions.ts` were updated:

1. **`prepareEmailBody`**: The `message` parameter is now coerced to string using `String(... ?? '')` before calling `.trim()`. This ensures numbers, booleans, or null values all work gracefully.

2. **`prepareEmailsInput`**: The `input` parameter is now coerced to string using `String(input)` before calling `.split(',')`. If a non-email value was passed (e.g. a plain number), the existing validation will then throw the correct, user-friendly `"Invalid email address"` error instead of the confusing `trim/split is not a function` error.

### How to test

1. Create a workflow with a Manual Trigger node pinning data like `{ "name": "First item", "code": 1 }`
2. Connect to a Gmail "Send a message" node
3. Set the **Message** field to an expression: `={{ $json.code }}` (returns a number)
4. Before fix: error `this.getNodeParameter(...).trim is not a function`
5. After fix: message is sent successfully with the number converted to string `"1"`

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/NODE-4122
- closes https://github.com/n8n-io/n8n/issues/22614

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
