### PR TITLE
fix(gmail): Handle non-string expression values in message and email fields

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
@@ -396,13 +396,16 @@ export function prepareQuery(
 
 export function prepareEmailsInput(
 	this: IExecuteFunctions | ILoadOptionsFunctions,
-	input: string,
+	input: unknown,
 	fieldName: string,
 	itemIndex: number,
 ) {
 	let emails = '';
 
-	input.split(',').forEach((entry) => {
+	// Convert non-string values (e.g. numbers from expressions) to strings
+	const inputStr = String(input);
+
+	inputStr.split(',').forEach((entry) => {
 		const email = entry.trim();
 
 		if (email.indexOf('@') === -1) {
@@ -429,7 +432,8 @@ export function prepareEmailBody(
 	instanceId?: string,
 ) {
 	const emailType = this.getNodeParameter('emailType', itemIndex) as string;
-	let message = (this.getNodeParameter('message', itemIndex, '') as string).trim();
+	// Convert non-string values (e.g. numbers from expressions) to strings before calling .trim()
+	let message = String(this.getNodeParameter('message', itemIndex, '')).trim();
 
 	if (appendAttribution) {
 		const attributionText = 'This email was sent automatically with ';

--- a/packages/nodes-base/nodes/Google/Gmail/test/v2/utils.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/v2/utils.test.ts
@@ -5,7 +5,12 @@ import type { IExecuteFunctions, INode } from 'n8n-workflow';
 import type { IEmail } from '@utils/sendAndWait/interfaces';
 
 import * as GenericFunctions from '../../GenericFunctions';
-import { parseRawEmail, prepareTimestamp } from '../../GenericFunctions';
+import {
+	parseRawEmail,
+	prepareEmailBody,
+	prepareEmailsInput,
+	prepareTimestamp,
+} from '../../GenericFunctions';
 import { addThreadHeadersToEmail } from '../../v2/utils/draft';
 
 const node: INode = {
@@ -130,6 +135,119 @@ describe('parseRawEmail', () => {
 
 		// ASSERT
 		expect(typeof json.date).toBe('string');
+	});
+});
+
+describe('prepareEmailsInput', () => {
+	it('should handle a string email address correctly', () => {
+		const executionFunctions = mock<IExecuteFunctions>({
+			getNode: () => node,
+		});
+
+		const result = prepareEmailsInput.call(
+			executionFunctions,
+			'test@example.com',
+			'To',
+			0,
+		);
+
+		expect(result).toContain('test@example.com');
+	});
+
+	it('should convert a number to string and throw for invalid email (no @)', () => {
+		// A number like 1 becomes "1" which has no @, so it should throw
+		const executionFunctions = mock<IExecuteFunctions>({
+			getNode: () => node,
+		});
+
+		expect(() =>
+			prepareEmailsInput.call(executionFunctions, 1 as unknown as string, 'To', 0),
+		).toThrow('Invalid email address');
+	});
+
+	it('should not throw when given a valid email string even if it came from an expression returning a string', () => {
+		const executionFunctions = mock<IExecuteFunctions>({
+			getNode: () => node,
+		});
+
+		const result = prepareEmailsInput.call(
+			executionFunctions,
+			'user@example.com',
+			'To',
+			0,
+		);
+
+		expect(result).toBe('<user@example.com>, ');
+	});
+
+	it('should handle multiple comma-separated email addresses', () => {
+		const executionFunctions = mock<IExecuteFunctions>({
+			getNode: () => node,
+		});
+
+		const result = prepareEmailsInput.call(
+			executionFunctions,
+			'a@example.com, b@example.com',
+			'To',
+			0,
+		);
+
+		expect(result).toContain('a@example.com');
+		expect(result).toContain('b@example.com');
+	});
+});
+
+describe('prepareEmailBody', () => {
+	it('should handle a non-string message value (number) without throwing', () => {
+		// This simulates the case where an expression returns a number (e.g. $json.code = 1)
+		const executionFunctions = mock<IExecuteFunctions>({
+			getNode: () => node,
+			getNodeParameter: (parameterName: string) => {
+				if (parameterName === 'emailType') return 'text';
+				if (parameterName === 'message') return 42; // number, not a string
+				return '';
+			},
+		});
+
+		let result: ReturnType<typeof prepareEmailBody>;
+		expect(() => {
+			result = prepareEmailBody.call(executionFunctions, 0);
+		}).not.toThrow();
+
+		expect(result!.body).toBe('42');
+	});
+
+	it('should handle a string message value correctly', () => {
+		const executionFunctions = mock<IExecuteFunctions>({
+			getNode: () => node,
+			getNodeParameter: (parameterName: string) => {
+				if (parameterName === 'emailType') return 'text';
+				if (parameterName === 'message') return 'Hello World';
+				return '';
+			},
+		});
+
+		const result = prepareEmailBody.call(executionFunctions, 0);
+
+		expect(result.body).toBe('Hello World');
+	});
+
+	it('should handle an object/null message value without throwing', () => {
+		const executionFunctions = mock<IExecuteFunctions>({
+			getNode: () => node,
+			getNodeParameter: (parameterName: string) => {
+				if (parameterName === 'emailType') return 'text';
+				if (parameterName === 'message') return null;
+				return '';
+			},
+		});
+
+		let result: ReturnType<typeof prepareEmailBody>;
+		expect(() => {
+			result = prepareEmailBody.call(executionFunctions, 0);
+		}).not.toThrow();
+
+		expect(result!.body).toBe('null');
 	});
 });
 


### PR DESCRIPTION
## Summary

This PR fixes a bug in the Gmail node where using an expression that evaluates to a non-string value (e.g., a number like `$json.code`) in the **Message**, **To**, **CC**, **BCC**, or **Reply-To** fields caused a cryptic runtime error:

```
this.getNodeParameter(...).trim is not a function (item 0)
```

### Root Cause

The functions `prepareEmailBody` and `prepareEmailsInput` in `GenericFunctions.ts` called `.trim()` and `.split(',')` directly on the return value of `this.getNodeParameter(...)`. When an expression resolves to a non-string type (e.g., a number, boolean, or object), these string methods don't exist on the value, causing the error.

### Fix

Both functions now wrap the parameter value with `String(...)` before calling any string methods, which safely coerces any type to a string — matching the natural expectation that any value piped via an expression should be stringified.

### How to test

1. Create a workflow with a **Manual Trigger** node, pin data with a numeric field (e.g. `{ "code": 1 }`).
2. Connect to a **Gmail** node with `message` set to an expression that resolves to the number: `={{ $json.code }}`.
3. Before the fix: execution fails with `trim is not a function`.
4. After the fix: execution succeeds and the number is sent as `"1"` in the email body.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4122
fixes https://github.com/n8n-io/n8n/issues/22614

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
