### PR TITLE
fix: Gmail node crashes when non-string value passed to message/sendTo fields

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,3 +175,4 @@ When implementing features:
 - Always reference the Linear ticket in the PR description,
   use `https://linear.app/n8n/issue/[TICKET-ID]`
 - always link to the github issue if mentioned in the linear ticket.
+

--- a/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
@@ -396,13 +396,16 @@ export function prepareQuery(
 
 export function prepareEmailsInput(
 	this: IExecuteFunctions | ILoadOptionsFunctions,
-	input: string,
+	input: unknown,
 	fieldName: string,
 	itemIndex: number,
 ) {
 	let emails = '';
 
-	input.split(',').forEach((entry) => {
+	// Coerce non-string values (e.g. numbers from expressions) to string
+	const inputStr = String(input);
+
+	inputStr.split(',').forEach((entry) => {
 		const email = entry.trim();
 
 		if (email.indexOf('@') === -1) {
@@ -429,7 +432,9 @@ export function prepareEmailBody(
 	instanceId?: string,
 ) {
 	const emailType = this.getNodeParameter('emailType', itemIndex) as string;
-	let message = (this.getNodeParameter('message', itemIndex, '') as string).trim();
+	// Coerce non-string values (e.g. numbers from expressions) to string before calling .trim()
+	const rawMessage = this.getNodeParameter('message', itemIndex, '');
+	let message = String(rawMessage === null || rawMessage === undefined ? '' : rawMessage).trim();
 
 	if (appendAttribution) {
 		const attributionText = 'This email was sent automatically with ';

--- a/packages/nodes-base/nodes/Google/Gmail/test/v2/utils.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/v2/utils.test.ts
@@ -5,7 +5,7 @@ import type { IExecuteFunctions, INode } from 'n8n-workflow';
 import type { IEmail } from '@utils/sendAndWait/interfaces';
 
 import * as GenericFunctions from '../../GenericFunctions';
-import { parseRawEmail, prepareTimestamp } from '../../GenericFunctions';
+import { parseRawEmail, prepareEmailBody, prepareEmailsInput, prepareTimestamp } from '../../GenericFunctions';
 import { addThreadHeadersToEmail } from '../../v2/utils/draft';
 
 const node: INode = {
@@ -130,6 +130,86 @@ describe('parseRawEmail', () => {
 
 		// ASSERT
 		expect(typeof json.date).toBe('string');
+	});
+});
+
+describe('prepareEmailsInput', () => {
+	const executionFunctions = mock<IExecuteFunctions>({
+		getNode: jest.fn(() => mock<INode>()),
+	});
+
+	it('should handle a plain string email address', () => {
+		const result = prepareEmailsInput.call(
+			executionFunctions,
+			'test@example.com',
+			'To',
+			0,
+		);
+		expect(result).toContain('test@example.com');
+	});
+
+	it('should coerce a number to string and throw invalid email error', () => {
+		// A number like 42 does not contain '@', so it should throw
+		expect(() =>
+			prepareEmailsInput.call(executionFunctions, 42, 'To', 0),
+		).toThrow('Invalid email address');
+	});
+
+	it('should coerce a number that happens to contain @ (via toString) gracefully', () => {
+		// Even a non-string value that becomes a valid email string should work
+		const result = prepareEmailsInput.call(
+			executionFunctions,
+			'user@domain.com',
+			'To',
+			0,
+		);
+		expect(result).toContain('user@domain.com');
+	});
+});
+
+describe('prepareEmailBody', () => {
+	it('should coerce a numeric message value to string without throwing', () => {
+		const executionFunctions = mock<IExecuteFunctions>({
+			getNode: jest.fn(() => mock<INode>()),
+			getNodeParameter: jest.fn((paramName: string) => {
+				if (paramName === 'emailType') return 'text';
+				if (paramName === 'message') return 42; // numeric value from expression
+				return '';
+			}),
+		});
+
+		const result = prepareEmailBody.call(executionFunctions, 0);
+		expect(result.body).toBe('42');
+		expect(result.htmlBody).toBe('');
+	});
+
+	it('should coerce null message value to empty string', () => {
+		const executionFunctions = mock<IExecuteFunctions>({
+			getNode: jest.fn(() => mock<INode>()),
+			getNodeParameter: jest.fn((paramName: string) => {
+				if (paramName === 'emailType') return 'text';
+				if (paramName === 'message') return null;
+				return '';
+			}),
+		});
+
+		const result = prepareEmailBody.call(executionFunctions, 0);
+		expect(result.body).toBe('');
+		expect(result.htmlBody).toBe('');
+	});
+
+	it('should handle a normal string message', () => {
+		const executionFunctions = mock<IExecuteFunctions>({
+			getNode: jest.fn(() => mock<INode>()),
+			getNodeParameter: jest.fn((paramName: string) => {
+				if (paramName === 'emailType') return 'text';
+				if (paramName === 'message') return 'Hello World';
+				return '';
+			}),
+		});
+
+		const result = prepareEmailBody.call(executionFunctions, 0);
+		expect(result.body).toBe('Hello World');
 	});
 });
 


### PR DESCRIPTION
## Summary

The Gmail node was crashing with `this.getNodeParameter(...).trim is not a function` when an expression in the **Message** (or any email address field) resolved to a non-string type — for example a number from pinned-data like `$json.code`.

Root cause: two helper functions in `GenericFunctions.ts` assumed their inputs were always strings:

1. **`prepareEmailBody`** — called `.trim()` directly on the raw return value of `getNodeParameter('message', ...)`. If the expression result was a number (or other non-string), this threw a `TypeError`.
2. **`prepareEmailsInput`** — accepted `input: string` but was called without prior coercion. Passing a non-string caused `.split(',')` to fail in the same way.

**Fix:**
- `prepareEmailBody`: coerce the message to a string with `String(rawMessage)` before calling `.trim()`.
- `prepareEmailsInput`: change parameter type from `string` to `unknown` and coerce with `String(input)` before calling `.split(',')`.

No behavioural change for users who pass normal string values. Non-string values are now safely converted, so e.g. a numeric body `42` is sent as the string `"42"` instead of crashing.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/NODE-4122
- https://github.com/n8n-io/n8n/issues/22614

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if urgent fix that needs to be backported)
