### PR TITLE
ci: Pin LocalStack Docker image to 4.13.1 (no-changelog)

### DIFF
--- a/packages/testing/containers/test-containers.ts
+++ b/packages/testing/containers/test-containers.ts
@@ -40,7 +40,7 @@ const DEFAULT_IMAGES = {
 	ngrok: 'ngrok/ngrok:alpine',
 	kafka: 'confluentinc/cp-kafka:8.0.3',
 	mysql: 'mysql:9.6.0',
-	localstack: 'localstack/localstack:latest',
+	localstack: 'localstack/localstack:4.13.1',
 } as const;
 
 /** Convert camelCase to SCREAMING_SNAKE_CASE for env var names */


### PR DESCRIPTION
## Summary

Pins the LocalStack Docker image from `:latest` to `4.13.1` (the latest stable release).

The unpinned `:latest` tag was pulling unstable development builds, causing **~48 failures/week** across virtually every branch for both external-secrets E2E tests:
- `secret-providers-connections.spec.ts` — "can create a connection pointing to LocalStack"
- `aws-secrets-manager.spec.ts` — "can configure, connect, and sync secrets from LocalStack"

LocalStack was the **only unpinned image** in `test-containers.ts` — every other service already had a pinned version.

### Verification
- Pulled `localstack/localstack:4.13.1` successfully
- Health check returns `secretsmanager: available` on first attempt
- Secrets Manager create/list operations confirmed working
- Prepull script (`pull-test-images.ts`) will automatically use the pinned version

### Additional context
LocalStack is [moving to require authentication](https://blog.localstack.cloud/the-road-ahead-for-localstack/) for Docker pulls starting March 2026. A follow-up ticket should be created to plan for that transition.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)