### PR TITLE
fix(core): Add mergeAskBuild to builder request DTO feature flags

### DIFF
--- a/packages/@n8n/api-types/src/dto/ai/ai-build-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/ai/ai-build-request.dto.ts
@@ -106,6 +106,7 @@ export class AiBuilderChatRequestDto extends Z.class({
 				codeBuilder: z.boolean().optional(),
 				pinData: z.boolean().optional(),
 				planMode: z.boolean().optional(),
+				mergeAskBuild: z.boolean().optional(),
 			})
 			.optional(),
 		mode: z.enum(['build', 'plan']).optional(),


### PR DESCRIPTION
## Summary

The Zod validation schema in `AiBuilderChatRequestDto` was missing the `mergeAskBuild` field. Since Zod strips unknown properties by default, the flag was silently removed from incoming requests before reaching the workflow builder agent. This prevented the triage agent routing (`mergeAskBuild === true` check in `workflow-builder-agent.ts`) from ever activating on the backend, even when the frontend correctly sent the flag.

The fix adds `mergeAskBuild: z.boolean().optional()` to the `featureFlags` schema in the DTO.