### PR TITLE
feat(editor): Enable adding secret store from project settings page

### DIFF
--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionModal.ee.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionModal.ee.test.ts
@@ -357,6 +357,25 @@ describe('SecretsProviderConnectionModal', () => {
 			mockConnectionModal.isEditMode.value = true;
 		});
 
+		it('should not show sharing tab navigation when user has no global update permission', async () => {
+			mockConnectionModal.canShareGlobally.value = false;
+
+			const { queryByTestId } = renderComponent({
+				props: {
+					modalName: SECRETS_PROVIDER_CONNECTION_MODAL_KEY,
+					data: {
+						activeTab: 'sharing',
+						providerKey: 'test-123',
+						providerTypes: mockProviderTypes,
+					},
+				},
+			});
+
+			await nextTick();
+
+			expect(queryByTestId('sharing-tab')).not.toBeInTheDocument();
+		});
+
 		it('should not fetch projects from store when projects are already in store', async () => {
 			mockConnectionModal.connectionProjects.value = mockProjects.map((p) => ({
 				id: p.id,
@@ -417,6 +436,7 @@ describe('SecretsProviderConnectionModal', () => {
 			mockConnectionModal.projectIds.value = [];
 			mockConnectionModal.isSharedGlobally.value = false;
 			mockConnectionModal.canUpdate.value = true;
+			mockConnectionModal.canShareGlobally.value = true;
 			mockConnectionModal.isEditMode.value = true;
 			mockProjectsStore.projects = mockProjects;
 
@@ -456,6 +476,7 @@ describe('SecretsProviderConnectionModal', () => {
 			mockConnectionModal.projectIds.value = [];
 			mockConnectionModal.isSharedGlobally.value = false;
 			mockConnectionModal.canUpdate.value = true;
+			mockConnectionModal.canShareGlobally.value = true;
 			mockProjectsStore.projects = mockProjects;
 
 			const { queryByTestId } = renderComponent({

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/views/SettingsSecretsProviders.ee.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/views/SettingsSecretsProviders.ee.vue
@@ -40,7 +40,7 @@ const uiStore = useUIStore();
 const hasActiveProviders = computed(() => secretsProviders.activeProviders.value.length > 0);
 
 const sortedProviders = computed(() => {
-	return [...secretsProviders.activeProviders.value].sort((a, b) => b.type.localeCompare(a.type));
+	return [...secretsProviders.activeProviders.value].sort((a, b) => a.name.localeCompare(b.name));
 });
 
 function getProjectForProvider(provider: SecretProviderConnection): ProjectListItem | null {

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/views/SettingsSecretsProviders.ee.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/views/SettingsSecretsProviders.ee.vue
@@ -39,6 +39,10 @@ const uiStore = useUIStore();
 
 const hasActiveProviders = computed(() => secretsProviders.activeProviders.value.length > 0);
 
+const sortedProviders = computed(() => {
+	return [...secretsProviders.activeProviders.value].sort((a, b) => b.type.localeCompare(a.type));
+});
+
 function getProjectForProvider(provider: SecretProviderConnection): ProjectListItem | null {
 	if (!provider || provider.projects.length === 0) return null;
 
@@ -196,7 +200,7 @@ function goToUpgrade() {
 			/>
 			<div v-else>
 				<SecretsProviderConnectionCard
-					v-for="provider in secretsProviders.activeProviders.value"
+					v-for="provider in sortedProviders"
 					:key="provider.name"
 					class="mb-2xs"
 					:provider="provider"


### PR DESCRIPTION
## Summary

- If project permissions allow it, render button to add secret store
- Disable sharing tab on connection modal if permission do not allow to share globally
- Fixes permission checks to use RBAC store

## Screenshot

<img width="1159" height="761" alt="Screenshot 2026-02-23 at 11 27 02" src="https://github.com/user-attachments/assets/88b54695-eff3-4fb9-bac0-0628f3ee6c1d" />

<img width="1161" height="798" alt="Screenshot 2026-02-23 at 11 27 10" src="https://github.com/user-attachments/assets/643faeae-fcb5-48c3-9777-b08f6bd59f7d" />


## Related Linear tickets, Github issues, and Community forum posts

Implements [LIGO-222](https://linear.app/n8n/issue/LIGO-222/project-scope-fe-connect-secret-vault-from-project-settings) 


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
