### PR TITLE
fix(Microsoft Teams Node): Block Teams link preview service from triggering sendAndWait approvals

### DIFF
--- a/packages/nodes-base/utils/sendAndWait/test/util.test.ts
+++ b/packages/nodes-base/utils/sendAndWait/test/util.test.ts
@@ -503,6 +503,34 @@ describe('Send and Wait utils tests', () => {
 			expect(send).toHaveBeenCalledWith('');
 			expect(result).toEqual({ noWebhookResponse: true });
 		});
+
+		it('should return noWebhookResponse if user-agent is Microsoft Teams link preview service (SkypeSpaces)', async () => {
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				method: 'GET',
+				headers: {
+					'user-agent': 'SkypeSpaces/1.0a$*+',
+				},
+				query: { approved: 'true' },
+			} as any);
+
+			const send = jest.fn();
+
+			mockWebhookFunctions.getResponseObject.mockReturnValue({
+				send,
+			} as any);
+
+			mockWebhookFunctions.getNodeParameter.mockImplementation((parameterName: string) => {
+				const params: { [key: string]: any } = {
+					responseType: 'approval',
+				};
+				return params[parameterName];
+			});
+
+			const result = await sendAndWaitWebhook.call(mockWebhookFunctions);
+
+			expect(send).toHaveBeenCalledWith('');
+			expect(result).toEqual({ noWebhookResponse: true });
+		});
 	});
 });
 

--- a/packages/nodes-base/utils/sendAndWait/utils.ts
+++ b/packages/nodes-base/utils/sendAndWait/utils.ts
@@ -349,7 +349,13 @@ export async function sendAndWaitWebhook(this: IWebhookFunctions) {
 		| 'freeText'
 		| 'customForm';
 
-	if (responseType === 'approval' && isbot(req.headers['user-agent'])) {
+	if (
+		responseType === 'approval' &&
+		(isbot(req.headers['user-agent']) ||
+			// Microsoft Teams link preview service (SkypeSpaces) automatically fetches
+			// URLs in chat messages for rich previews, which would trigger the approval
+			req.headers['user-agent']?.includes('SkypeSpaces'))
+	) {
 		res.send('');
 		return { noWebhookResponse: true };
 	}


### PR DESCRIPTION
## Summary

Microsoft Teams' link preview service automatically fetches URLs in chat messages, which was randomly resuming approval workflows without user interaction. Extended the bot detection to block these requests.

## Related Linear tickets, Github issues, and Community forum posts
Fixes https://github.com/n8n-io/n8n/issues/25311
https://linear.app/n8n/issue/NODE-4389/community-issue-teams-send-and-wait-for-response-auto-approves-without

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
