### PR TITLE
fix: Initialize Vue Router for stories (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/storybook/.storybook/preview.ts
+++ b/packages/frontend/@n8n/storybook/.storybook/preview.ts
@@ -4,6 +4,7 @@ import ElementPlus from 'element-plus';
 // @ts-expect-error no types
 import lang from 'element-plus/dist/locale/en.mjs';
 import { createPinia } from 'pinia';
+import { createMemoryHistory, createRouter } from 'vue-router';
 
 import { N8nPlugin } from '@n8n/design-system';
 import { i18nInstance } from '@n8n/i18n';
@@ -16,6 +17,12 @@ setup((app) => {
 	const pinia = createPinia();
 	app.use(pinia);
 	app.use(i18nInstance);
+
+	const router = createRouter({
+		history: createMemoryHistory(),
+		routes: [{ path: '/:catchAll(.*)', component: { template: '' } }],
+	});
+	app.use(router);
 
 	app.use(ElementPlus, {
 		locale: lang,

--- a/packages/frontend/@n8n/storybook/package.json
+++ b/packages/frontend/@n8n/storybook/package.json
@@ -17,6 +17,7 @@
     "@n8n/utils": "workspace:*",
     "pinia": "catalog:frontend",
     "vue": "catalog:frontend",
+    "vue-router": "catalog:frontend",
     "vue-tsc": "catalog:frontend"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2951,6 +2951,9 @@ importers:
       vue:
         specifier: catalog:frontend
         version: 3.5.26(typescript@5.9.2)
+      vue-router:
+        specifier: catalog:frontend
+        version: 4.5.0(vue@3.5.26(typescript@5.9.2))
       vue-tsc:
         specifier: ^2.2.8
         version: 2.2.8(patch_hash=e2aee939ccac8a57fe449bfd92bedd8117841579526217bc39aca26c6b8c317f)(typescript@5.9.2)


### PR DESCRIPTION
## Summary

Add Vue Router initialization to Storybook preview to support breadcrumbs component which requires router context for navigation features.

## Related Linear tickets, Github issues, and Community forum posts

N/A


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
