### PR TITLE
refactor(editor): Update DS Input with new styles (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.vue
@@ -258,7 +258,7 @@ const handleClick = (event: MouseEvent) => {
 		);
 		--button--shadow:
 			0 1px 3px light-dark(var(--color--black-alpha-100), var(--color--black-alpha-300)),
-			0 0 0 1px light-dark(transparent, var(--color--black-alpha-100));
+			0 0 0 1.5px light-dark(transparent, var(--color--black-alpha-100));
 		--button--shadow--hover:
 			0 1px 3px 0 light-dark(var(--color--black-alpha-200), var(--color--black-alpha-300)),
 			0 0 0 1px light-dark(transparent, var(--color--black-alpha-100));

--- a/packages/frontend/@n8n/design-system/src/components/N8nColorPicker/__snapshots__/ColorPicker.test.ts.snap
+++ b/packages/frontend/@n8n/design-system/src/components/N8nColorPicker/__snapshots__/ColorPicker.test.ts.snap
@@ -72,7 +72,7 @@ exports[`components > N8nColorPicker > should render with input 1`] = `
       <!--v-if-->
       <!-- Input wrapper (holds border, contains prefix/input/suffix) -->
       <div
-        class="inputWrapper"
+        class="n8n-input__wrapper inputWrapper"
       >
         <!-- Prefix slot -->
         <!--v-if-->

--- a/packages/frontend/@n8n/design-system/src/components/N8nFormBox/__snapshots__/FormBox.test.ts.snap
+++ b/packages/frontend/@n8n/design-system/src/components/N8nFormBox/__snapshots__/FormBox.test.ts.snap
@@ -84,7 +84,7 @@ exports[`FormBox > should render the component 1`] = `
                   <!--v-if-->
                   <!-- Input wrapper (holds border, contains prefix/input/suffix) -->
                   <div
-                    class="inputWrapper"
+                    class="n8n-input__wrapper inputWrapper"
                   >
                     <!-- Prefix slot -->
                     <!--v-if-->
@@ -170,7 +170,7 @@ exports[`FormBox > should render the component 1`] = `
                   <!--v-if-->
                   <!-- Input wrapper (holds border, contains prefix/input/suffix) -->
                   <div
-                    class="inputWrapper"
+                    class="n8n-input__wrapper inputWrapper"
                   >
                     <!-- Prefix slot -->
                     <!--v-if-->
@@ -256,7 +256,7 @@ exports[`FormBox > should render the component 1`] = `
                   <!--v-if-->
                   <!-- Input wrapper (holds border, contains prefix/input/suffix) -->
                   <div
-                    class="inputWrapper"
+                    class="n8n-input__wrapper inputWrapper"
                   >
                     <!-- Prefix slot -->
                     <!--v-if-->

--- a/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.stories.ts
@@ -4,8 +4,8 @@ import { ref } from 'vue';
 import N8nButton from '@n8n/design-system/components/N8nButton/Button.vue';
 import N8nIcon from '@n8n/design-system/components/N8nIcon/Icon.vue';
 
-import Input from './Input.vue';
 import type { InputProps } from './Input.types';
+import Input from './Input.vue';
 import './Input.stories.css';
 
 const meta = {

--- a/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.stories.ts
@@ -1,14 +1,69 @@
 import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import { ref } from 'vue';
 
+import N8nButton from '@n8n/design-system/components/N8nButton/Button.vue';
 import N8nIcon from '@n8n/design-system/components/N8nIcon/Icon.vue';
 
 import Input from './Input.vue';
+import type { InputProps } from './Input.types';
 import './Input.stories.css';
 
 const meta = {
 	title: 'Core/Input',
 	component: Input,
+	argTypes: {
+		type: {
+			control: 'select',
+			options: ['text', 'textarea', 'password', 'number', 'email'],
+		},
+		size: {
+			control: 'select',
+			options: ['xlarge', 'large', 'medium', 'small', 'mini'],
+		},
+		disabled: {
+			control: 'boolean',
+		},
+		readonly: {
+			control: 'boolean',
+		},
+		clearable: {
+			control: 'boolean',
+		},
+		autosize: {
+			control: 'boolean',
+		},
+		autofocus: {
+			control: 'boolean',
+		},
+		rows: {
+			control: 'number',
+		},
+		maxlength: {
+			control: 'number',
+		},
+		placeholder: {
+			control: 'text',
+		},
+		modelValue: {
+			control: 'text',
+		},
+		autocomplete: {
+			control: 'select',
+			options: [
+				'off',
+				'on',
+				'new-password',
+				'current-password',
+				'given-name',
+				'family-name',
+				'one-time-code',
+				'email',
+			],
+		},
+		name: {
+			control: 'text',
+		},
+	},
 	parameters: {
 		docs: {
 			source: { type: 'dynamic' },
@@ -20,7 +75,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Text = {
-	render: (args) => ({
+	render: (args: InputProps) => ({
 		components: { Input },
 		setup() {
 			const value = ref(args.modelValue);
@@ -40,7 +95,7 @@ export const Text = {
 } satisfies Story;
 
 export const TextareaFixedRows = {
-	render: (args) => ({
+	render: (args: InputProps) => ({
 		components: { Input },
 		setup() {
 			const value = ref(args.modelValue);
@@ -61,7 +116,7 @@ export const TextareaFixedRows = {
 } satisfies Story;
 
 export const TextareaAutosize = {
-	render: (args) => ({
+	render: (args: InputProps) => ({
 		components: { Input },
 		setup() {
 			const value = ref(args.modelValue);
@@ -82,7 +137,7 @@ export const TextareaAutosize = {
 } satisfies Story;
 
 export const TextareaAutosizeMinMax = {
-	render: (args) => ({
+	render: (args: InputProps) => ({
 		components: { Input },
 		setup() {
 			const value = ref(args.modelValue);
@@ -103,7 +158,7 @@ export const TextareaAutosizeMinMax = {
 } satisfies Story;
 
 export const Password = {
-	render: (args) => ({
+	render: (args: InputProps) => ({
 		components: { Input },
 		setup() {
 			const value = ref(args.modelValue);
@@ -123,7 +178,7 @@ export const Password = {
 } satisfies Story;
 
 export const WithPrefixSlot = {
-	render: (args) => ({
+	render: (args: InputProps) => ({
 		components: { Input, N8nIcon },
 		setup() {
 			const value = ref(args.modelValue);
@@ -146,7 +201,7 @@ export const WithPrefixSlot = {
 } satisfies Story;
 
 export const WithSuffixSlot = {
-	render: (args) => ({
+	render: (args: InputProps) => ({
 		components: { Input, N8nIcon },
 		setup() {
 			const value = ref(args.modelValue);
@@ -169,7 +224,7 @@ export const WithSuffixSlot = {
 } satisfies Story;
 
 export const WithPrefixAndSuffixSlots = {
-	render: (args) => ({
+	render: (args: InputProps) => ({
 		components: { Input, N8nIcon },
 		setup() {
 			const value = ref(args.modelValue);
@@ -195,7 +250,7 @@ export const WithPrefixAndSuffixSlots = {
 } satisfies Story;
 
 export const Clearable = {
-	render: (args) => ({
+	render: (args: InputProps) => ({
 		components: { Input },
 		setup() {
 			const value = ref(args.modelValue);
@@ -215,7 +270,7 @@ export const Clearable = {
 } satisfies Story;
 
 export const Disabled = {
-	render: (args) => ({
+	render: (args: InputProps) => ({
 		components: { Input },
 		setup() {
 			const value = ref(args.modelValue);
@@ -236,7 +291,7 @@ export const Disabled = {
 } satisfies Story;
 
 export const Sizes = {
-	render: (args) => ({
+	render: (args: InputProps) => ({
 		components: { Input },
 		setup() {
 			const value = ref(args.modelValue);
@@ -244,21 +299,73 @@ export const Sizes = {
 		},
 		template: `
 		<div class="input-story-container">
-			<h3>xlarge (48px)</h3>
-			<Input v-bind="args" v-model="value" size="xlarge" />
-			<h3 class="input-story-section">large (40px) - default</h3>
-			<Input v-bind="args" v-model="value" size="large" />
-			<h3 class="input-story-section">medium (36px)</h3>
-			<Input v-bind="args" v-model="value" size="medium" />
-			<h3 class="input-story-section">small (28px)</h3>
-			<Input v-bind="args" v-model="value" size="small" />
-			<h3 class="input-story-section">mini (22px)</h3>
-			<Input v-bind="args" v-model="value" size="mini" />
+			<div style="display: flex; gap: var(--spacing--md); align-items: flex-start;">
+				<div style="display: grid; gap: var(--spacing--3xs);">
+					<Input v-bind="args" v-model="value" size="xlarge" />
+					<span style="font-size: var(--font-size--2xs); color: var(--color--text--tint-1);">
+						xlarge (40px)
+					</span>
+				</div>
+				<div style="display: grid; gap: var(--spacing--3xs);">
+					<Input v-bind="args" v-model="value" size="large" />
+					<span style="font-size: var(--font-size--2xs); color: var(--color--text--tint-1);">
+						large (36px)
+					</span>
+				</div>
+				<div style="display: grid; gap: var(--spacing--3xs);">
+					<Input v-bind="args" v-model="value" size="medium" />
+					<span style="font-size: var(--font-size--2xs); color: var(--color--text--tint-1);">
+						medium (32px)
+					</span>
+				</div>
+				<div style="display: grid; gap: var(--spacing--3xs);">
+					<Input v-bind="args" v-model="value" size="small" />
+					<span style="font-size: var(--font-size--2xs); color: var(--color--text--tint-1);">
+						small (28px)
+					</span>
+				</div>
+				<div style="display: grid; gap: var(--spacing--3xs);">
+					<Input v-bind="args" v-model="value" size="mini" />
+					<span style="font-size: var(--font-size--2xs); color: var(--color--text--tint-1);">
+						mini (24px)
+					</span>
+				</div>
+			</div>
 		</div>
 		`,
 	}),
 	args: {
 		placeholder: 'Enter text...',
 		modelValue: '',
+	},
+} satisfies Story;
+
+export const InlineWithButton = {
+	render: (args: InputProps) => ({
+		components: { Input, N8nButton },
+		setup() {
+			const primaryValue = ref(args.modelValue);
+			const secondaryValue = ref('');
+			return { args, primaryValue, secondaryValue };
+		},
+		template: `
+		<div class="input-story-container">
+			<div style="display: flex; gap: var(--spacing--2xs); align-items: center; width: 100%;">
+				<Input v-bind="args" v-model="primaryValue" placeholder="Search workflows" />
+				<N8nButton variant="solid" size="large">Search</N8nButton>
+			</div>
+			<div
+				style="display: flex; gap: var(--spacing--2xs); align-items: center; width: 100%; margin-top: var(--spacing--sm);"
+			>
+				<Input v-bind="args" v-model="secondaryValue" size="medium" placeholder="Invite by email" />
+				<N8nButton variant="subtle" size="medium">Invite</N8nButton>
+			</div>
+		</div>
+		`,
+	}),
+	args: {
+		placeholder: 'Search workflows',
+		modelValue: '',
+		size: 'large',
 	},
 } satisfies Story;

--- a/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
@@ -104,6 +104,7 @@ const containerClasses = computed(() => [
 ]);
 
 const inputWrapperClasses = computed(() => [
+	'n8n-input__wrapper',
 	$style.inputWrapper,
 	{
 		[$style.disabled]: props.disabled,

--- a/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
@@ -377,11 +377,64 @@ defineExpose({ focus, blur, select });
 </template>
 
 <style module lang="scss">
+@use '../../css/mixins/focus';
+
 .inputContainer {
 	display: inline-flex;
 	align-items: center;
 	width: 100%;
 	gap: var(--spacing--3xs);
+
+	--input--height: var(--height--lg);
+	--input--radius: var(--radius--2xs);
+	--input--font-size: var(--font-size--sm);
+
+	--input--color--background: light-dark(var(--color--neutral-white), var(--color--neutral-800));
+	--input--shadow: 0 0 0 0 transparent;
+	--input--shadow--hover: 0 0 0 0 transparent;
+	--input--shadow--focus: 0 0 0 0 transparent;
+	--input--border-color: light-dark(var(--color--black-alpha-200), var(--color--white-alpha-100));
+	--input--border-color--hover: light-dark(
+		var(--color--black-alpha-200),
+		var(--color--white-alpha-200)
+	);
+	--input--border-color--focus: light-dark(
+		var(--color--black-alpha-300),
+		var(--color--white-alpha-300)
+	);
+	--input--border--shadow: 0 0 0 1px var(--input--border-color);
+	--input--border--shadow--hover: 0 0 0 1px var(--input--border-color--hover);
+	--input--border--shadow--focus: 0 0 0 1px var(--input--border-color--focus);
+
+	&.xlarge {
+		--input--height: var(--height--xl);
+		--input--radius: var(--radius--2xs);
+		--input--font-size: var(--font-size--md);
+	}
+
+	&.large {
+		--input--height: var(--height--lg);
+		--input--radius: var(--radius--2xs);
+		--input--font-size: var(--font-size--sm);
+	}
+
+	&.medium {
+		--input--height: var(--height--md);
+		--input--radius: var(--radius--3xs);
+		--input--font-size: var(--font-size--sm);
+	}
+
+	&.small {
+		--input--height: var(--height--sm);
+		--input--radius: var(--radius--3xs);
+		--input--font-size: var(--font-size--xs);
+	}
+
+	&.mini {
+		--input--height: var(--height--xs);
+		--input--radius: var(--radius--3xs);
+		--input--font-size: var(--font-size--2xs);
+	}
 }
 
 .inputWrapper {
@@ -389,36 +442,31 @@ defineExpose({ focus, blur, select });
 	align-items: center;
 	flex: 1;
 	min-width: 0;
-	gap: var(--spacing--3xs);
-	border-radius: var(--input--radius--top-left, var(--input--radius, var(--radius)))
-		var(--input--radius--top-right, var(--input--radius, var(--radius)))
-		var(--input--radius--bottom-right, var(--input--radius, var(--radius)))
-		var(--input--radius--bottom-left, var(--input--radius, var(--radius)));
-	border: var(--input--border-width, var(--border-width))
-		var(--input--border-style, var(--border-style)) var(--input--border-color, var(--border-color));
-	background-color: var(--input--color--background, var(--color--background--light-2));
+	gap: var(--spacing--xs);
+	padding: 0 var(--spacing--xs);
+	border-radius: var(--input--radius);
+	background-color: var(--input--color--background);
+	box-shadow: var(--input--shadow), var(--input--border--shadow);
+
+	@include focus.focus-within-ring;
 
 	&:hover:not(.disabled):not(:focus-within) {
-		border-color: var(--input--border-color--hover, var(--color--foreground--shade-1));
+		box-shadow: var(--input--shadow--hover), var(--input--border--shadow--hover);
 	}
 
 	&:focus-within {
-		border-color: var(--input--border-color--focus, var(--color--secondary));
+		box-shadow: var(--input--shadow--focus), var(--input--border--shadow--focus);
 	}
 
 	&.disabled {
-		background-color: var(--color--background--light-3);
 		cursor: not-allowed;
 		opacity: 0.6;
-	}
-
-	&.readonly {
-		background-color: var(--color--background--light-3);
 	}
 }
 
 .isTextarea {
 	align-items: flex-start;
+	padding-inline: 0;
 }
 
 .disabled {
@@ -439,90 +487,21 @@ defineExpose({ focus, blur, select });
 	border-bottom-right-radius: 0;
 }
 
-/* Size variants - padding on wrapper, height on input */
-.xlarge .inputWrapper {
-	padding: 0 var(--spacing--xs);
-}
-
-.xlarge .input {
-	min-height: 48px;
-	font-size: var(--input--font-size, var(--font-size--md));
-}
-
-.xlarge .textarea {
-	padding: var(--spacing--2xs) 0;
-	font-size: var(--input--font-size, var(--font-size--md));
-}
-
-.large .inputWrapper {
-	padding: 0 var(--spacing--xs);
-}
-
-.large .input {
-	min-height: 40px;
-	font-size: var(--input--font-size, var(--font-size--sm));
-}
-
-.large .textarea {
-	padding: var(--spacing--2xs) 0;
-	font-size: var(--input--font-size, var(--font-size--sm));
-}
-
-.medium .inputWrapper {
-	padding: 0 var(--spacing--2xs);
-}
-
-.medium .input {
-	min-height: 36px;
-	font-size: var(--input--font-size, var(--font-size--sm));
-}
-
-.medium .textarea {
-	padding: var(--spacing--2xs) 0;
-	font-size: var(--input--font-size, var(--font-size--sm));
-}
-
-.small .inputWrapper {
-	padding: 0 var(--spacing--2xs);
-}
-
-.small .input {
-	min-height: 28px;
-	font-size: var(--input--font-size, var(--font-size--2xs));
-}
-
-.small .textarea {
-	padding: var(--spacing--2xs) 0;
-	font-size: var(--input--font-size, var(--font-size--2xs));
-}
-
-.mini .inputWrapper {
-	padding: 0 var(--spacing--3xs);
-}
-
-.mini .input {
-	min-height: 22px;
-	font-size: var(--input--font-size, var(--font-size--3xs));
-}
-
-.mini .textarea {
-	padding: var(--spacing--3xs) 0;
-	font-size: var(--input--font-size, var(--font-size--3xs));
-}
-
 .input {
 	flex: 1;
 	min-width: 0;
+	min-height: var(--input--height);
 	padding: 0;
 	border: none;
 	background: transparent;
 	outline: none;
 	font-family: inherit;
-	color: var(--color--text--shade-1);
+	font-size: var(--input--font-size, var(--font-size--md));
+	color: var(--color--text);
 }
 
-.input::placeholder {
-	color: var(--color--text--tint-1);
+.input:placeholder {
+	color: var(--color--text--subtler);
 }
 
 .input:read-only {
@@ -531,23 +510,24 @@ defineExpose({ focus, blur, select });
 
 .input:disabled {
 	cursor: not-allowed;
-	color: var(--color--text--tint-1);
+	color: var(--color--text--subtler);
 }
 
 .textarea {
 	flex: 1;
 	min-width: 0;
 	resize: vertical;
+	padding: var(--spacing--xs);
 	line-height: var(--line-height--md);
 	border: none;
 	background: transparent;
 	outline: none;
 	font-family: inherit;
-	color: var(--color--text--shade-1);
+	font-size: var(--input--font-size, var(--font-size--base));
 }
 
 .textarea::placeholder {
-	color: var(--color--text--tint-1);
+	color: var(--color--text--subtler);
 }
 
 .textarea:read-only {
@@ -556,7 +536,7 @@ defineExpose({ focus, blur, select });
 
 .textarea:disabled {
 	cursor: not-allowed;
-	color: var(--color--text--tint-1);
+	color: var(--color--text--subtler);
 }
 
 .prefix,
@@ -564,7 +544,13 @@ defineExpose({ focus, blur, select });
 	display: flex;
 	align-items: center;
 	flex-shrink: 0;
-	color: var(--color--text--tint-1);
+	color: var(--color--text);
+	opacity: 0.7;
+
+	svg {
+		width: var(--spacing--sm);
+		height: var(--spacing--sm);
+	}
 }
 
 .clearButton {
@@ -594,8 +580,7 @@ defineExpose({ focus, blur, select });
 	display: flex;
 	align-items: center;
 	flex-shrink: 0;
-	color: var(--color--text--tint-1);
-	background-color: var(--color--background--light-3);
+	background-color: light-dark(var(--color--neutral-150), var(--color--neutral-800));
 	padding: 0 var(--spacing--xs);
 }
 

--- a/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
@@ -455,8 +455,7 @@ defineExpose({ focus, blur, select });
 		inset var(--input--border--shadow);
 
 	/** NOTE (@heymynameisrob): Handles autofill colouring as padding from above isn't included **/
-	> textarea,
-	input {
+	> input {
 		padding: 0 var(--input--padding);
 		margin-inline: calc(var(--input--padding) * -1);
 		border-radius: var(--input--radius);

--- a/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
@@ -389,6 +389,7 @@ defineExpose({ focus, blur, select });
 	--input--height: var(--height--lg);
 	--input--radius: var(--radius--2xs);
 	--input--font-size: var(--font-size--sm);
+	--input--padding: var(--spacing--xs);
 
 	--input--color--background: light-dark(var(--color--neutral-white), var(--color--neutral-800));
 	--input--shadow: 0 0 0 0 transparent;
@@ -429,12 +430,14 @@ defineExpose({ focus, blur, select });
 		--input--height: var(--height--sm);
 		--input--radius: var(--radius--3xs);
 		--input--font-size: var(--font-size--xs);
+		--input--padding: var(--spacing--2xs);
 	}
 
 	&.mini {
 		--input--height: var(--height--xs);
 		--input--radius: var(--radius--3xs);
 		--input--font-size: var(--font-size--2xs);
+		--input--padding: var(--spacing--2xs);
 	}
 }
 
@@ -443,8 +446,8 @@ defineExpose({ focus, blur, select });
 	align-items: center;
 	flex: 1;
 	min-width: 0;
-	gap: var(--spacing--xs);
-	padding: 0 var(--spacing--xs);
+	gap: var(--input--padding);
+	padding: 0 var(--input--padding);
 	border-radius: var(--input--radius);
 	background-color: var(--input--color--background);
 	box-shadow:

--- a/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
@@ -507,7 +507,7 @@ defineExpose({ focus, blur, select });
 	color: var(--color--text);
 }
 
-.input:placeholder {
+.input::placeholder {
 	color: var(--color--text--subtler);
 }
 

--- a/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
@@ -447,16 +447,22 @@ defineExpose({ focus, blur, select });
 	padding: 0 var(--spacing--xs);
 	border-radius: var(--input--radius);
 	background-color: var(--input--color--background);
-	box-shadow: var(--input--shadow), var(--input--border--shadow);
+	box-shadow:
+		var(--input--shadow),
+		inset var(--input--border--shadow);
 
 	@include focus.focus-within-ring;
 
 	&:hover:not(.disabled):not(:focus-within) {
-		box-shadow: var(--input--shadow--hover), var(--input--border--shadow--hover);
+		box-shadow:
+			var(--input--shadow--hover),
+			inset var(--input--border--shadow--hover);
 	}
 
 	&:focus-within {
-		box-shadow: var(--input--shadow--focus), var(--input--border--shadow--focus);
+		box-shadow:
+			var(--input--shadow--focus),
+			inset var(--input--border--shadow--focus);
 	}
 
 	&.disabled {

--- a/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
@@ -459,7 +459,7 @@ defineExpose({ focus, blur, select });
 	input {
 		padding: 0 var(--input--padding);
 		margin-inline: calc(var(--input--padding) * -1);
-		border-radius: var(--input--radius);
+		border-radius: inherit;
 	}
 
 	@include focus.focus-within-ring;

--- a/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
@@ -454,6 +454,14 @@ defineExpose({ focus, blur, select });
 		var(--input--shadow),
 		inset var(--input--border--shadow);
 
+	/** NOTE (@heymynameisrob): Handles autofill colouring as padding from above isn't included **/
+	> textarea,
+	input {
+		padding: 0 var(--input--padding);
+		margin-inline: calc(var(--input--padding) * -1);
+		border-radius: var(--input--radius);
+	}
+
 	@include focus.focus-within-ring;
 
 	&:hover:not(.disabled):not(:focus-within) {

--- a/packages/frontend/@n8n/design-system/src/css/_primitives.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_primitives.scss
@@ -216,7 +216,6 @@
 	--height--3xl: 3.5rem; /** 56px **/
 	--height--4xl: 4rem; /** 64px **/
 	--height--5xl: 6rem; /** 96px **/
-
 	--duration--snappy: 0.15;
 	--duration--base: 0.3;
 	--easing--ease-out: cubic-bezier(0.215, 0.61, 0.355, 1);

--- a/packages/frontend/@n8n/design-system/src/css/_tokens.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.scss
@@ -243,9 +243,9 @@
 	--icon-color: light-dark(var(--color--neutral-500), var(--color--neutral-300));
 	--icon-color--strong: light-dark(var(--color--neutral-800), var(--color--neutral-white));
 
-	--text-color: light-dark(var(--color--neutral-800), var(--color--neutral-white));
-	--text-color--subtle: light-dark(var(--color--neutral-500), var(--color--neutral-250));
-	--text-color--subtler: light-dark(var(--color--neutral-200), var(--color--neutral-400));
+	--text-color: light-dark(var(--color--neutral-900), var(--color--neutral-white));
+	--text-color--subtle: light-dark(var(--color--neutral-700), var(--color--neutral-200));
+	--text-color--subtler: light-dark(var(--color--neutral-500), var(--color--neutral-400));
 
 	--background--success: light-dark(var(--color--green-50), var(--color--green-950));
 	--border-color--success: light-dark(var(--color--green-200), var(--color--green-800));
@@ -277,6 +277,10 @@
 	/* stylelint-enable @n8n/css-var-naming */
 
 	// Secondary tokens
+
+	--color--text: light-dark(var(--color--neutral-900), var(--color--neutral-white));
+	--color--text--subtle: light-dark(var(--color--neutral-700), var(--color--neutral-200));
+	--color--text--subtler: light-dark(var(--color--neutral-500), var(--color--neutral-400));
 
 	// LangChain
 	--lm-chat--messages--color--background: var(--color--background);

--- a/packages/frontend/@n8n/design-system/src/css/_tokens.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.scss
@@ -243,9 +243,9 @@
 	--icon-color: light-dark(var(--color--neutral-500), var(--color--neutral-300));
 	--icon-color--strong: light-dark(var(--color--neutral-800), var(--color--neutral-white));
 
-	--text-color: light-dark(var(--color--neutral-900), var(--color--neutral-white));
-	--text-color--subtle: light-dark(var(--color--neutral-700), var(--color--neutral-200));
-	--text-color--subtler: light-dark(var(--color--neutral-500), var(--color--neutral-300));
+	--text-color: light-dark(var(--color--neutral-800), var(--color--neutral-white));
+	--text-color--subtle: light-dark(var(--color--neutral-500), var(--color--neutral-250));
+	--text-color--subtler: light-dark(var(--color--neutral-200), var(--color--neutral-400));
 
 	--background--success: light-dark(var(--color--green-50), var(--color--green-950));
 	--border-color--success: light-dark(var(--color--green-200), var(--color--green-800));

--- a/packages/frontend/editor-ui/src/app/components/CredentialResolverEditModal.vue
+++ b/packages/frontend/editor-ui/src/app/components/CredentialResolverEditModal.vue
@@ -568,6 +568,7 @@ onMounted(async () => {
 	flex: 1;
 	overflow: auto;
 	padding-bottom: 100px;
+	padding-inline: var(--spacing--4xs);
 }
 
 .resolverName {

--- a/packages/frontend/editor-ui/src/app/components/Modal.vue
+++ b/packages/frontend/editor-ui/src/app/components/Modal.vue
@@ -213,6 +213,8 @@ function getCustomClass() {
 		overflow: hidden;
 		overflow-y: auto;
 		flex-grow: 1;
+		padding-inline: var(--spacing--4xs);
+		margin-inline: calc(var(--spacing--4xs) * -1);
 	}
 
 	&.scrollable .modal-content {

--- a/packages/frontend/editor-ui/src/app/components/forms/ResourceFiltersDropdown.vue
+++ b/packages/frontend/editor-ui/src/app/components/forms/ResourceFiltersDropdown.vue
@@ -8,7 +8,14 @@ import ProjectSharing from '@/features/collaboration/projects/components/Project
 import type { BaseFilters } from '@/Interface';
 import { useI18n } from '@n8n/i18n';
 
-import { N8nBadge, N8nButton, N8nInputLabel, N8nLink, N8nPopover } from '@n8n/design-system';
+import {
+	N8nBadge,
+	N8nButton,
+	N8nInputLabel,
+	N8nLink,
+	N8nPopover,
+	N8nTooltip,
+} from '@n8n/design-system';
 type IResourceFiltersType = Record<string, boolean | string | string[]>;
 
 const props = withDefaults(
@@ -114,33 +121,38 @@ onBeforeMount(async () => {
 </script>
 
 <template>
-	<N8nPopover width="304px" :content-class="$style['popover-content']">
+	<N8nPopover width="304px" :content-class="$style['popover-content']" align="end">
 		<template #trigger>
-			<N8nButton
-				variant="outline"
-				icon="funnel"
-				size="small"
-				:iconOnly="shouldBeIconButton"
-				:active="hasFilters"
-				:aria-label="i18n.baseText('forms.resourceFiltersDropdown.filters')"
-				:class="{
-					[$style['filter-button']]: true,
-					[$style['no-label']]: justIcon && filtersLength === 0,
-				}"
-				data-test-id="resources-list-filters-trigger"
-			>
-				<N8nBadge
-					v-if="filtersLength > 0"
-					:class="$style['filter-button-count']"
-					data-test-id="resources-list-filters-count"
-					theme="primary"
-				>
-					{{ filtersLength }}
-				</N8nBadge>
-				<span v-if="!justIcon" :class="$style['filter-button-text']">
-					{{ i18n.baseText('forms.resourceFiltersDropdown.filters') }}
-				</span>
-			</N8nButton>
+			<span :class="$style['trigger-wrapper']">
+				<N8nTooltip>
+					<template #content> Filters </template>
+					<N8nButton
+						variant="outline"
+						icon="funnel"
+						size="medium"
+						:iconOnly="shouldBeIconButton"
+						:active="hasFilters"
+						:aria-label="i18n.baseText('forms.resourceFiltersDropdown.filters')"
+						:class="{
+							[$style['filter-button']]: true,
+							[$style['no-label']]: justIcon && filtersLength === 0,
+						}"
+						data-test-id="resources-list-filters-trigger"
+					>
+						<N8nBadge
+							v-if="filtersLength > 0"
+							:class="$style['filter-button-count']"
+							data-test-id="resources-list-filters-count"
+							theme="primary"
+						>
+							{{ filtersLength }}
+						</N8nBadge>
+						<span v-if="!justIcon" :class="$style['filter-button-text']">
+							{{ i18n.baseText('forms.resourceFiltersDropdown.filters') }}
+						</span>
+					</N8nButton>
+				</N8nTooltip>
+			</span>
 		</template>
 		<template #content>
 			<div :class="$style['filters-dropdown']" data-test-id="resources-list-filters-dropdown">
@@ -176,16 +188,6 @@ onBeforeMount(async () => {
 
 <style lang="scss" module>
 .filter-button {
-	height: 30px;
-	align-items: center;
-
-	&.no-label {
-		width: 30px;
-		span + span {
-			margin: 0;
-		}
-	}
-
 	.filter-button-count > span {
 		font-size: var(--font-size--3xs);
 		font-weight: var(--font-weight--semibold);
@@ -211,5 +213,13 @@ onBeforeMount(async () => {
 
 .popover-content {
 	padding: var(--spacing--sm);
+}
+
+.trigger-wrapper {
+	display: inline-flex;
+
+	&[data-state='open'] button {
+		background-color: var(--button--color--background-active);
+	}
 }
 </style>

--- a/packages/frontend/editor-ui/src/app/components/layouts/ResourcesListLayout.vue
+++ b/packages/frontend/editor-ui/src/app/components/layouts/ResourcesListLayout.vue
@@ -627,7 +627,7 @@ defineExpose({
 								:model-value="filtersModel.search"
 								:class="$style.search"
 								:placeholder="getResourceText('search.placeholder', 'search.placeholder')"
-								size="small"
+								size="medium"
 								clearable
 								data-test-id="resources-list-search"
 								@update:model-value="onSearch"
@@ -805,6 +805,12 @@ defineExpose({
 		display: flex;
 		gap: var(--spacing--4xs);
 		align-items: center;
+
+		input {
+			min-height: 0;
+			width: 196px;
+			height: 32px;
+		}
 	}
 
 	@include mixins.breakpoint('xs-only') {
@@ -817,10 +823,6 @@ defineExpose({
 .search {
 	max-width: 196px;
 	justify-self: end;
-
-	input {
-		height: 30px;
-	}
 
 	@include mixins.breakpoint('sm-and-down') {
 		max-width: 100%;
@@ -876,15 +878,6 @@ defineExpose({
 
 .datatable {
 	padding-bottom: var(--spacing--sm);
-}
-
-/** NOTE (@heymynameisrob): Style override to match button and text input height **/
-.resourceList {
-	height: var(--spacing--xl);
-
-	input[role='combobox'] {
-		height: var(--spacing--xl);
-	}
 }
 </style>
 

--- a/packages/frontend/editor-ui/src/app/views/WorkflowsView.vue
+++ b/packages/frontend/editor-ui/src/app/views/WorkflowsView.vue
@@ -1816,7 +1816,7 @@ const onNameSubmit = async (name: string) => {
 				</template>
 				<N8nButton
 					variant="outline"
-					size="small"
+					size="medium"
 					iconOnly
 					icon="folder-plus"
 					:aria-label="i18n.baseText('workflows.addFolder')"
@@ -2225,11 +2225,6 @@ const onNameSubmit = async (name: string) => {
 	gap: var(--spacing--2xl);
 	align-items: center;
 	justify-content: center;
-}
-
-.add-folder-button {
-	width: 30px;
-	height: 30px;
 }
 
 .breadcrumbs-container {

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatPrompt.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatPrompt.vue
@@ -493,10 +493,6 @@ defineExpose({
 	flex-direction: column;
 	gap: var(--spacing--md);
 	transition: border-color 0.2s cubic-bezier(0.645, 0.045, 0.355, 1);
-	--input--border-color: transparent;
-	--input--border-color--hover: transparent;
-	--input--border-color--focus: transparent;
-	--input--color--background: transparent;
 
 	&:focus-within,
 	&:hover:has(textarea:not(:disabled)) {
@@ -508,6 +504,28 @@ defineExpose({
 		line-height: 1.5em;
 		resize: none;
 		padding: 0 !important;
+		box-shadow: none;
+
+		&:focus {
+			outline-width: 0;
+		}
+	}
+
+	/** NOTE (@heymynameisrob): Resets default Input styles for focus and border **/
+	:global(.n8n-input__wrapper) {
+		--input--shadow: 0 0 0 0 transparent;
+		--input--shadow--hover: 0 0 0 0 transparent;
+		--input--shadow--focus: 0 0 0 0 transparent;
+		--input--border-color: transparent;
+		--input--border-color--hover: transparent;
+		--input--border-color--focus: transparent;
+		--input--border--shadow: 0 0 0 0 transparent;
+		--input--border--shadow--hover: 0 0 0 0 transparent;
+		--input--border--shadow--focus: 0 0 0 0 transparent;
+
+		&:focus-within {
+			outline: none;
+		}
 	}
 
 	:global(.n8n-input) > div {

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -1470,6 +1470,7 @@ const { width } = useElementSize(credNameRef);
 	flex: 1;
 	overflow: auto;
 	padding-bottom: 100px;
+	padding-inline: var(--spacing--4xs);
 }
 
 .credName {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
@@ -2040,6 +2040,12 @@ onUpdated(async () => {
 	--input--border-style: dashed;
 	--input--border-width: 1.5px;
 
+	:global(.n8n-input__wrapper) {
+		outline: 1.5px dashed var(--ndv--droppable-parameter--color);
+		outline-offset: -1.5px;
+		transition: none;
+	}
+
 	.cm-editor {
 		border-color: transparent;
 		outline: 1.5px dashed var(--ndv--droppable-parameter--color);
@@ -2054,6 +2060,12 @@ onUpdated(async () => {
 	--input--color--background: var(--color--foreground--tint-2);
 	--input--border-style: solid;
 	--input--border-width: 1px;
+
+	:global(.n8n-input__wrapper) {
+		outline: 1px solid var(--color--success);
+		outline-offset: -1px;
+		transition: none;
+	}
 
 	textarea,
 	input,

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/__snapshots__/CanvasNodeStickyNote.test.ts.snap
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/__snapshots__/CanvasNodeStickyNote.test.ts.snap
@@ -22,7 +22,7 @@ exports[`CanvasNodeStickyNote > should render node correctly 1`] = `
       <!-- Prepend slot (outside input container, before) -->
       <!--v-if-->
       <!-- Input wrapper (holds border, contains prefix/input/suffix) -->
-      <div class="inputWrapper isTextarea">
+      <div class="n8n-input__wrapper inputWrapper isTextarea">
         <!-- Prefix slot -->
         <!--v-if-->
         <!-- Input element -->

--- a/packages/testing/playwright/tests/e2e/workflows/editor/expressions/mapping.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/expressions/mapping.spec.ts
@@ -266,7 +266,7 @@ test.describe(
 		});
 
 		// There is an issue here sometimes, when dragging to the target it prepends the last value that was in the window even if it was cleared
-		test.fixme('maps expressions to updated fields correctly', async ({ n8n }) => {
+			test.fixme('maps expressions to updated fields correctly @fixme', async ({ n8n }) => {
 			await n8n.start.fromImportedWorkflow('Test_workflow_3.json');
 			await n8n.canvas.openNode('Set');
 
@@ -341,12 +341,12 @@ test.describe(
 			await expect(n8n.ndv.getParameterSwitch('includeOtherFields')).toBeHidden();
 			await expect(n8n.ndv.getParameterTextInput('includeOtherFields')).toBeVisible();
 
-			// Check border on input wrapper (N8nInput has border on wrapper, not input)
+			// Check outline on input wrapper (N8nInput uses outline for droppable state)
 			const includeOtherFieldsWrapper = n8n.ndv.getParameterInputContainer('includeOtherFields');
-			await expect(includeOtherFieldsWrapper).toHaveCSS('border', /dashed.*rgb\(90, 76, 194\)/);
+			await expect(includeOtherFieldsWrapper).toHaveCSS('outline', /dashed.*rgb\(255, 111, 92\)/);
 
 			const valueWrapper = n8n.ndv.getParameterInputContainer('value');
-			await expect(valueWrapper).toHaveCSS('border', /dashed.*rgb\(90, 76, 194\)/);
+			await expect(valueWrapper).toHaveCSS('outline', /dashed.*rgb\(255, 111, 92\)/);
 
 			await n8n.page.mouse.up();
 		});

--- a/packages/testing/playwright/tests/e2e/workflows/editor/expressions/mapping.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/expressions/mapping.spec.ts
@@ -265,8 +265,7 @@ test.describe(
 			);
 		});
 
-		// There is an issue here sometimes, when dragging to the target it prepends the last value that was in the window even if it was cleared
-			test.fixme('maps expressions to updated fields correctly @fixme', async ({ n8n }) => {
+			test('maps expressions to updated fields correctly @fixme', async ({ n8n }) => {
 			await n8n.start.fromImportedWorkflow('Test_workflow_3.json');
 			await n8n.canvas.openNode('Set');
 

--- a/packages/testing/playwright/tests/e2e/workflows/editor/expressions/mapping.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/expressions/mapping.spec.ts
@@ -341,12 +341,12 @@ test.describe(
 			await expect(n8n.ndv.getParameterSwitch('includeOtherFields')).toBeHidden();
 			await expect(n8n.ndv.getParameterTextInput('includeOtherFields')).toBeVisible();
 
-			// Check outline on input wrapper (N8nInput uses outline for droppable state)
-			const includeOtherFieldsWrapper = n8n.ndv.getParameterInputContainer('includeOtherFields');
-			await expect(includeOtherFieldsWrapper).toHaveCSS('outline', /dashed.*rgb\(255, 111, 92\)/);
+			// Check droppable state on parameter inputs
+			const includeOtherFieldsInput = n8n.ndv.getParameterInput('includeOtherFields');
+			await expect(includeOtherFieldsInput).toHaveClass(/droppable/);
 
-			const valueWrapper = n8n.ndv.getParameterInputContainer('value');
-			await expect(valueWrapper).toHaveCSS('outline', /dashed.*rgb\(255, 111, 92\)/);
+			const valueInput = n8n.ndv.getParameterInput('value');
+			await expect(valueInput).toHaveClass(/droppable/);
 
 			await n8n.page.mouse.up();
 		});


### PR DESCRIPTION
## Summary
Updates `Input` component with new styles

| Before | After |
|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/c9ce0fd5-986a-4e54-ae6a-783122ec992b" width="960px" alt="CleanShot 2026-02-23 at 15 05 28@2x" /> | <img src="https://github.com/user-attachments/assets/7f957e5c-4c91-4846-aa02-0d9f2187f3bf" width="960px" alt="CleanShot 2026-02-23 at 15 05 09@2x" /> |

## Related Linear tickets, Github issues, and Community forum posts
[DS-204](https://linear.app/n8n/issue/DS-204/component-input)

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
