### PR TITLE
fix(core): Increase timeout for workflow execution tests

### DIFF
--- a/packages/@n8n/node-cli/src/commands/new/index.test.ts
+++ b/packages/@n8n/node-cli/src/commands/new/index.test.ts
@@ -155,69 +155,73 @@ describe('new command', () => {
 		}
 	});
 
-	tmpdirTest('creates new node project with custom template', async ({ tmpdir }) => {
-		MockPrompt.setup([
-			{
-				question: 'What kind of node are you building?',
-				answer: 'declarative',
-			},
-			{
-				question: 'What template do you want to use?',
-				answer: 'custom',
-			},
-			{
-				question: "What's the base URL of the API?",
-				answer: 'https://api.custom-service.com',
-			},
-			{
-				question: 'What type of authentication does your API use?',
-				answer: 'apiKey',
-			},
-		]);
+	tmpdirTest(
+		'creates new node project with custom template',
+		async ({ tmpdir }) => {
+			MockPrompt.setup([
+				{
+					question: 'What kind of node are you building?',
+					answer: 'declarative',
+				},
+				{
+					question: 'What template do you want to use?',
+					answer: 'custom',
+				},
+				{
+					question: "What's the base URL of the API?",
+					answer: 'https://api.custom-service.com',
+				},
+				{
+					question: 'What type of authentication does your API use?',
+					answer: 'apiKey',
+				},
+			]);
 
-		mockExecSync([
-			{ command: 'git config --get user.name', result: 'Custom User\n' },
-			{ command: 'git config --get user.email', result: 'custom@test.com\n' },
-		]);
+			mockExecSync([
+				{ command: 'git config --get user.name', result: 'Custom User\n' },
+				{ command: 'git config --get user.email', result: 'custom@test.com\n' },
+			]);
 
-		mockSpawn([
-			{
-				command: 'git',
-				args: ['init', '-b', 'main'],
-				options: { exitCode: 0 },
-			},
-		]);
+			mockSpawn([
+				{
+					command: 'git',
+					args: ['init', '-b', 'main'],
+					options: { exitCode: 0 },
+				},
+			]);
 
-		await CommandTester.run('new n8n-nodes-custom-api --skip-install');
+			await CommandTester.run('new n8n-nodes-custom-api --skip-install');
 
-		expect(MockPrompt).toHaveAskedAllQuestions();
+			expect(MockPrompt).toHaveAskedAllQuestions();
 
-		const projectName = 'n8n-nodes-custom-api';
-		expect(tmpdir).toHaveFile(projectName);
+			const projectName = 'n8n-nodes-custom-api';
+			expect(tmpdir).toHaveFile(projectName);
 
-		await expect(tmpdir).toHaveFileContaining(
-			`${projectName}/package.json`,
-			'"name": "n8n-nodes-custom-api"',
-		);
-		await expect(tmpdir).toHaveFileContaining(
-			`${projectName}/package.json`,
-			'"name": "Custom User"',
-		);
-		await expect(tmpdir).toHaveFileContaining(
-			`${projectName}/package.json`,
-			'"email": "custom@test.com"',
-		);
+			await expect(tmpdir).toHaveFileContaining(
+				`${projectName}/package.json`,
+				'"name": "n8n-nodes-custom-api"',
+			);
+			await expect(tmpdir).toHaveFileContaining(
+				`${projectName}/package.json`,
+				'"name": "Custom User"',
+			);
+			await expect(tmpdir).toHaveFileContaining(
+				`${projectName}/package.json`,
+				'"email": "custom@test.com"',
+			);
 
-		await expect(tmpdir).toHaveFileContaining(
-			`${projectName}/nodes/CustomApi/CustomApi.node.ts`,
-			'implements INodeType',
-		);
+			await expect(tmpdir).toHaveFileContaining(
+				`${projectName}/nodes/CustomApi/CustomApi.node.ts`,
+				'implements INodeType',
+			);
 
-		await expect(tmpdir).toHaveFileContaining(
-			`${projectName}/credentials/CustomApiApi.credentials.ts`,
-			'implements ICredentialType',
-		);
-	});
+			await expect(tmpdir).toHaveFileContaining(
+				`${projectName}/credentials/CustomApiApi.credentials.ts`,
+				'implements ICredentialType',
+			);
+		},
+		15_000,
+	);
 
 	test('handles prompt cancellation gracefully', async () => {
 		MockPrompt.setup([

--- a/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
@@ -546,6 +546,8 @@ describe('WorkflowExecute', () => {
 		const nodeTypes = Helpers.NodeTypes(Helpers.getNodeTypes(tests));
 
 		for (const testData of tests) {
+			// These tests execute real Code node sandboxes with retries, which can
+			// exceed the default 5s timeout on slow CI runners
 			test(testData.description, async () => {
 				const workflowInstance = new Workflow({
 					id: 'test',
@@ -602,7 +604,7 @@ describe('WorkflowExecute', () => {
 				expect(result.data.executionData!.runtimeData!.source).toEqual('manual');
 				expect(typeof result.data.executionData!.runtimeData!.establishedAt).toBe('number');
 				expect(result.data.executionData!.runtimeData!.establishedAt).toBeGreaterThan(0);
-			});
+			}, 15_000);
 		}
 	});
 


### PR DESCRIPTION
## Summary
- Increases the Jest timeout for `run test workflows` tests from the default 5s to 15s
- The `retry_and_continue_on_error` test executes ~46 Code node sandbox instances with retries, which intermittently exceeds the 5s default on slow CI runners

## Root cause
The workflow test JSON exercises 31 nodes (15 Reset Count + 16 Retry/Continue Code nodes) with `retryOnFail: true` and `waitBetweenTries: 10ms`. Each Code node creates a `JavaScriptSandbox` VM context. The cumulative sandbox creation + execution time is ~3.5s locally (cold) and can exceed 5s on shared CI runners under load.

## Test plan
- [x] Verified test passes locally with new timeout
- [x] Linting passes (biome pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)