### PR TITLE
chore(editor): Expose credential:unshare to custom project roles

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2351,6 +2351,8 @@
 	"projectRoles.credential:create.tooltip": "Create new credentials",
 	"projectRoles.credential:share": "Share",
 	"projectRoles.credential:share.tooltip": "Share credentials with other projects or users",
+	"projectRoles.credential:unshare": "Unshare",
+	"projectRoles.credential:unshare.tooltip": "Remove credential sharing with other projects or users",
 	"projectRoles.credential:move": "Transfer",
 	"projectRoles.credential:move.tooltip": "Move credentials to another project",
 	"projectRoles.credential:delete": "Delete",

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/RoleHoverPopover.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/RoleHoverPopover.test.ts
@@ -92,7 +92,7 @@ describe('RoleHoverPopover', () => {
 		it('should display permission count', () => {
 			const { getByText } = renderComponent();
 
-			expect(getByText('3/32 permissions')).toBeInTheDocument();
+			expect(getByText('3/33 permissions')).toBeInTheDocument();
 		});
 
 		it('should display role description when available', () => {

--- a/packages/frontend/editor-ui/src/features/project-roles/projectRoleScopes.ts
+++ b/packages/frontend/editor-ui/src/features/project-roles/projectRoleScopes.ts
@@ -18,7 +18,7 @@ const UI_OPERATIONS = {
 	project: ['read', 'update', 'delete'],
 	folder: ['read', 'update', 'create', 'move', 'delete'],
 	workflow: ['read', 'update', 'create', 'publish', 'unpublish', 'move', 'delete'],
-	credential: ['read', 'update', 'create', 'share', 'move', 'delete'],
+	credential: ['read', 'update', 'create', 'share', 'unshare', 'move', 'delete'],
 	sourceControl: ['push'],
 	dataTable: ['read', 'readRow', 'update', 'writeRow', 'create', 'delete'],
 	projectVariable: ['read', 'update', 'create', 'delete'],


### PR DESCRIPTION
## Summary

This exposes the new unshare scope for custom project roles.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/IAM-274/split-share-and-unshare-scope

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
