### PR TITLE
fix: Assignments control buttons top padding fix

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/AssignmentCollection/Assignment.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/AssignmentCollection/Assignment.vue
@@ -297,11 +297,11 @@ const onValueDrop = async (droppedExpression: string) => {
 	color: var(--icon--color);
 }
 .extraTopPadding {
-	top: calc(20px + var(--spacing--lg));
+	top: calc(20px + var(--spacing--sm));
 }
 
 .defaultTopPadding {
-	top: var(--spacing--lg);
+	top: var(--spacing--sm);
 }
 
 .status {


### PR DESCRIPTION
## Summary

Fixed the assignment control buttons to resolve an issue where the delete button could not be clicked

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-4401/ux-bug-delete-icon-cannot-be-clicked-in-fields-to-set-in-ndv-for-a
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
