### PR TITLE
feat(Chat Node): Return chat message instead of input data if Chat is not waiting for user input

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/Chat.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/Chat.node.ts
@@ -41,8 +41,8 @@ export class Chat implements INodeType {
 		icon: 'fa:comments',
 		iconColor: 'black',
 		group: ['input'],
-		version: [1, 1.1, 1.2],
-		defaultVersion: 1.2,
+		version: [1, 1.1, 1.2, 1.3],
+		defaultVersion: 1.3,
 		description: 'Send a message into the chat',
 		defaults: {
 			name: 'Chat',
@@ -221,6 +221,9 @@ export class Chat implements INodeType {
 		}
 
 		if (!waitForReply) {
+			// return original message instead of input data
+			if (nodeVersion >= 1.3) return [[data]];
+
 			const inputData = context.getInputData();
 			return [inputData];
 		}

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/Chat.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/Chat.node.test.ts
@@ -280,6 +280,34 @@ describe('Test Chat Node', () => {
 			expect(memory.chatHistory.addUserMessage).toHaveBeenCalledWith('user message');
 		});
 
+		it('v1.3 should return [[data]] (original message) instead of input data when not waiting for reply', async () => {
+			const chatNode = mock<INode>({
+				name: 'Chat',
+				type: CHAT_NODE_TYPE,
+				parameters: {},
+				typeVersion: 1.3,
+			});
+			const message = { json: { chatInput: 'user message' } };
+			const differentInputData = [{ json: { chatInput: 'other input' } }];
+			mockExecuteFunctions.getInputData.mockReturnValue(differentInputData);
+			mockExecuteFunctions.getNode.mockReturnValue(chatNode);
+			mockExecuteFunctions.getNodeParameter.mockImplementation((parameterName) => {
+				switch (parameterName) {
+					case 'operation':
+						return 'send';
+					case 'options':
+						return { memoryConnection: false };
+					default:
+						return undefined;
+				}
+			});
+
+			const result = await chat.onMessage(mockExecuteFunctions, message);
+
+			expect(result).toEqual([[message]]);
+			expect(result).not.toEqual([differentInputData]);
+		});
+
 		it('v1.2 should return output data directly without nesting into `data` field (except `approved`)', async () => {
 			const chatNode = mock<INode>({
 				name: 'Chat',

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/Chat.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/Chat.node.test.ts
@@ -305,7 +305,6 @@ describe('Test Chat Node', () => {
 			const result = await chat.onMessage(mockExecuteFunctions, message);
 
 			expect(result).toEqual([[message]]);
-			expect(result).not.toEqual([differentInputData]);
 		});
 
 		it('v1.2 should return output data directly without nesting into `data` field (except `approved`)', async () => {

--- a/packages/cli/src/chat/__tests__/utils.test.ts
+++ b/packages/cli/src/chat/__tests__/utils.test.ts
@@ -8,7 +8,12 @@ import {
 	SEND_AND_WAIT_OPERATION,
 } from 'n8n-workflow';
 
-import { getMessage, getLastNodeExecuted, shouldResumeImmediately } from '../utils';
+import {
+	getMessage,
+	getLastNodeExecuted,
+	getLastNodeMessage,
+	shouldResumeImmediately,
+} from '../utils';
 
 // helpers --------------------------------------------------------
 const createMockExecution = (
@@ -490,5 +495,49 @@ describe('shouldResumeImmediately', () => {
 		});
 		const result = shouldResumeImmediately(node);
 		expect(result).toBe(true);
+	});
+});
+
+describe('getLastNodeMessage', () => {
+	it('should return empty string when node type is not CHAT_NODE_TYPE', () => {
+		const execution = createMockExecution();
+		const node = createMockNode({ type: 'some-other-node-type' });
+		const result = getLastNodeMessage(execution, node);
+		expect(result).toBe('');
+	});
+
+	it('should return the message when node is CHAT_NODE_TYPE and execution has sendMessage', () => {
+		const execution = createMockExecution();
+		const node = createMockNode({ type: CHAT_NODE_TYPE });
+		const result = getLastNodeMessage(execution, node);
+		expect(result).toBe('Test message');
+	});
+
+	it('should return empty string when node is CHAT_NODE_TYPE but sendMessage is missing', () => {
+		const execution = createMockExecution({}, { json: { data: 'test' } });
+		const node = createMockNode({ type: CHAT_NODE_TYPE });
+		const result = getLastNodeMessage(execution, node);
+		expect(result).toBe('');
+	});
+
+	it('should return empty string when run data for the node is missing', () => {
+		const execution = createMockExecution({
+			data: {
+				resultData: {
+					lastNodeExecuted: 'TestNode',
+					runData: {},
+				},
+			},
+		});
+		const node = createMockNode({ type: CHAT_NODE_TYPE });
+		const result = getLastNodeMessage(execution, node);
+		expect(result).toBe('');
+	});
+
+	it('should return empty string when main output is missing', () => {
+		const execution = createMockExecution({}, undefined, [{ data: {} }]);
+		const node = createMockNode({ type: CHAT_NODE_TYPE });
+		const result = getLastNodeMessage(execution, node);
+		expect(result).toBe('');
 	});
 });

--- a/packages/cli/src/chat/chat-service.ts
+++ b/packages/cli/src/chat/chat-service.ts
@@ -20,7 +20,12 @@ import {
 	type ChatRequest,
 	Session,
 } from './chat-service.types';
-import { getLastNodeExecuted, getMessage, shouldResumeImmediately } from './utils';
+import {
+	getLastNodeExecuted,
+	getLastNodeMessage,
+	getMessage,
+	shouldResumeImmediately,
+} from './utils';
 
 const CHECK_FOR_RESPONSE_INTERVAL = 3000;
 const DRAIN_TIMEOUT = 50;
@@ -150,7 +155,7 @@ export class ChatService {
 			session.connection.send(N8N_CONTINUE);
 			const data: ChatMessage = {
 				action: 'sendMessage',
-				chatInput: '',
+				chatInput: getLastNodeMessage(execution, lastNode),
 				sessionId: session.sessionId,
 			};
 			await this.resumeExecution(session.executionId, data, sessionKey);

--- a/packages/cli/src/chat/utils.ts
+++ b/packages/cli/src/chat/utils.ts
@@ -70,3 +70,12 @@ export function shouldResumeImmediately(lastNode: INode) {
 
 	return false;
 }
+
+export function getLastNodeMessage(execution: IExecutionResponse, lastNode: INode) {
+	if (lastNode.type !== CHAT_NODE_TYPE) return '';
+
+	const message =
+		execution.data?.resultData?.runData?.[lastNode.name]?.[0]?.data?.main?.[0]?.[0]?.sendMessage;
+
+	return (message as string) ?? '';
+}


### PR DESCRIPTION
## Summary

Added new node version 1.3 - if node is not waiting, a message will be returned instead of input data as in earlier versions

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-4041/the-respond-to-chat-output-seems-to-be-wrong
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
