### PR TITLE
fix(core): Allow expressions in OAuth URLs during validation (fix #26131)

### DIFF
--- a/packages/cli/src/credentials/__tests__/credentials.service.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.service.test.ts
@@ -1934,6 +1934,81 @@ describe('CredentialsService', () => {
 				await service.prepareUpdateData(ownerUser, payload, existingCredential);
 			});
 		});
+
+		describe('validateOAuthCredentialUrls during prepareUpdateData', () => {
+			beforeEach(() => {
+				jest.spyOn(service, 'decrypt').mockReturnValue({});
+				credentialsRepository.create.mockImplementation((data) => ({ ...data }) as any);
+			});
+
+			it('should allow valid http/https URLs', async () => {
+				credentialsHelper.getCredentialsProperties.mockReturnValue([]);
+				credentialTypes.getParentTypes.mockReturnValue(['oAuth2Api']);
+				const payload = {
+					name: 'Test Credential',
+					type: 'mcpOAuth2Api',
+					data: {
+						authUrl: 'https://example.com/auth',
+						accessTokenUrl: 'http://example.com/token',
+					},
+					projectId: 'project-1',
+				};
+				const existingCredential = mockExistingCredential({
+					name: 'Test Credential',
+					type: 'mcpOAuth2Api',
+					data: {},
+					projectId: 'project-1',
+				});
+				await expect(
+					service.prepareUpdateData(ownerUser, payload, existingCredential),
+				).resolves.toBeDefined();
+			});
+
+			it('should throw BadRequestError for invalid URLs', async () => {
+				credentialsHelper.getCredentialsProperties.mockReturnValue([]);
+				credentialTypes.getParentTypes.mockReturnValue(['oAuth2Api']);
+				const payload = {
+					name: 'Test Credential',
+					type: 'mcpOAuth2Api',
+					data: {
+						authUrl: 'not-a-url',
+					},
+					projectId: 'project-1',
+				};
+				const existingCredential = mockExistingCredential({
+					name: 'Test Credential',
+					type: 'mcpOAuth2Api',
+					data: {},
+					projectId: 'project-1',
+				});
+				await expect(
+					service.prepareUpdateData(ownerUser, payload, existingCredential),
+				).rejects.toThrow('OAuth url is not a valid URL.');
+			});
+
+			it('should skip validation for expressions (starting with "=")', async () => {
+				credentialsHelper.getCredentialsProperties.mockReturnValue([]);
+				credentialTypes.getParentTypes.mockReturnValue(['oAuth2Api']);
+				const payload = {
+					name: 'Test Credential',
+					type: 'mcpOAuth2Api',
+					data: {
+						authUrl: '={{ $vars.mcp_auth }}',
+						accessTokenUrl: '={{ $vars.token_url }}',
+					},
+					projectId: 'project-1',
+				};
+				const existingCredential = mockExistingCredential({
+					name: 'Test Credential',
+					type: 'mcpOAuth2Api',
+					data: {},
+					projectId: 'project-1',
+				});
+				await expect(
+					service.prepareUpdateData(ownerUser, payload, existingCredential),
+				).resolves.toBeDefined();
+			});
+		});
 	});
 
 	describe('checkCredentialData', () => {
@@ -2157,6 +2232,39 @@ describe('CredentialsService', () => {
 			expect(() => service.checkCredentialData('apiCredential', data, ownerUser)).toThrow(
 				'The field "apiKey" is mandatory for credentials of type "apiCredential"',
 			);
+		});
+
+		describe('validateOAuthCredentialUrls', () => {
+			it('should allow valid http/https URLs', () => {
+				credentialsHelper.getCredentialsProperties.mockReturnValue([]);
+				credentialTypes.getParentTypes.mockReturnValue(['oAuth2Api']);
+				const data = {
+					authUrl: 'https://example.com/auth',
+					accessTokenUrl: 'http://example.com/token',
+				};
+				expect(() => service.checkCredentialData('mcpOAuth2Api', data, ownerUser)).not.toThrow();
+			});
+
+			it('should throw BadRequestError for invalid URLs', () => {
+				credentialsHelper.getCredentialsProperties.mockReturnValue([]);
+				credentialTypes.getParentTypes.mockReturnValue(['oAuth2Api']);
+				const data = {
+					authUrl: 'not-a-url',
+				};
+				expect(() => service.checkCredentialData('mcpOAuth2Api', data, ownerUser)).toThrow(
+					'OAuth url is not a valid URL.',
+				);
+			});
+
+			it('should skip validation for expressions (starting with "=")', () => {
+				credentialsHelper.getCredentialsProperties.mockReturnValue([]);
+				credentialTypes.getParentTypes.mockReturnValue(['oAuth2Api']);
+				const data = {
+					authUrl: '={{ $vars.mcp_auth }}',
+					accessTokenUrl: '={{ $vars.token_url }}',
+				};
+				expect(() => service.checkCredentialData('mcpOAuth2Api', data, ownerUser)).not.toThrow();
+			});
 		});
 	});
 });

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -1044,7 +1044,7 @@ export class CredentialsService {
 			const oauthUrlFields = ['authUrl', 'accessTokenUrl', 'serverUrl'] as const;
 			for (const field of oauthUrlFields) {
 				const value = data[field];
-				if (typeof value === 'string' && value.trim() !== '') {
+				if (typeof value === 'string' && value.trim() !== '' && value.trim().charAt(0) !== '=') {
 					validateOAuthUrl(value);
 				}
 			}
@@ -1053,7 +1053,7 @@ export class CredentialsService {
 			const oauthUrlFields = ['authUrl', 'requestTokenUrl', 'accessTokenUrl'] as const;
 			for (const field of oauthUrlFields) {
 				const value = data[field];
-				if (typeof value === 'string' && value.trim() !== '') {
+				if (typeof value === 'string' && value.trim() !== '' && value.trim().charAt(0) !== '=') {
 					validateOAuthUrl(value);
 				}
 			}


### PR DESCRIPTION
## Summary

### The Issue
Incorrectly validating OAuth URLs that contained expressions (like ={{ $vars.my_url }}). It expected a standard HTTP link and threw an error before the expression could be evaluated.

### The Fix
Updated the URL validation logic so that if the URL string starts with an =  (indicating an expression), it skips the strict URL format check.

### Testing
Added new unit tests to ensure valid URLs still pass, invalid URLs are still blocked, and URLs with expressions are successfully allowed. Tests pass.

Issue [26131](https://github.com/n8n-io/n8n/issues/26131)

fixes #26131

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
