### PR TITLE
fix(core): Resolve multi-main startup race condition in AuthRolesService

### DIFF
--- a/packages/@n8n/db/src/index.ts
+++ b/packages/@n8n/db/src/index.ts
@@ -38,6 +38,7 @@ export { DbConnection } from './connection/db-connection';
 export { DbConnectionOptions } from './connection/db-connection-options';
 
 export { AuthRolesService } from './services/auth.roles.service';
+export { DbLock, DbLockService } from './services/db-lock.service';
 
 export { In, Like, Not, DataSource } from '@n8n/typeorm';
 export type { FindManyOptions, FindOptionsWhere } from '@n8n/typeorm';

--- a/packages/@n8n/db/src/services/__tests__/db-lock.service.test.ts
+++ b/packages/@n8n/db/src/services/__tests__/db-lock.service.test.ts
@@ -1,0 +1,152 @@
+import type { DatabaseConfig } from '@n8n/config';
+import { QueryFailedError } from '@n8n/typeorm';
+import type { DataSource, EntityManager } from '@n8n/typeorm';
+import { mock } from 'jest-mock-extended';
+import { OperationalError } from 'n8n-workflow';
+
+import { DbLockService } from '../db-lock.service';
+
+describe('DbLockService', () => {
+	const mockTx = mock<EntityManager>();
+	const dataSource = mock<DataSource>();
+	const databaseConfig = mock<DatabaseConfig>();
+
+	const transactionMock = jest.fn<Promise<unknown>, [(tx: EntityManager) => Promise<unknown>]>();
+
+	let service: DbLockService;
+
+	beforeEach(() => {
+		jest.resetAllMocks();
+		transactionMock.mockImplementation(async (fn) => await fn(mockTx));
+		dataSource.manager.transaction = transactionMock as never;
+		mockTx.query.mockResolvedValue([]);
+		service = new DbLockService(dataSource, databaseConfig);
+	});
+
+	describe('withLock', () => {
+		it('should acquire advisory lock and execute fn on Postgres', async () => {
+			databaseConfig.type = 'postgresdb';
+			const fn = jest.fn().mockResolvedValue('result');
+
+			const result = await service.withLock(1001, fn);
+
+			expect(result).toBe('result');
+			expect(mockTx.query).toHaveBeenCalledWith('SELECT pg_advisory_xact_lock($1)', [1001]);
+			expect(fn).toHaveBeenCalledWith(mockTx);
+		});
+
+		it('should skip advisory lock on SQLite and still execute fn', async () => {
+			databaseConfig.type = 'sqlite';
+			const fn = jest.fn().mockResolvedValue('result');
+
+			const result = await service.withLock(1001, fn);
+
+			expect(result).toBe('result');
+			expect(mockTx.query).not.toHaveBeenCalled();
+			expect(fn).toHaveBeenCalledWith(mockTx);
+		});
+
+		it('should set lock_timeout when timeoutMs is provided', async () => {
+			databaseConfig.type = 'postgresdb';
+			const fn = jest.fn().mockResolvedValue('result');
+
+			await service.withLock(1001, fn, { timeoutMs: 5000 });
+
+			expect(mockTx.query).toHaveBeenCalledWith("SET LOCAL lock_timeout = '5000'");
+			expect(mockTx.query).toHaveBeenCalledWith('SELECT pg_advisory_xact_lock($1)', [1001]);
+		});
+
+		it('should not set lock_timeout when timeoutMs is not provided', async () => {
+			databaseConfig.type = 'postgresdb';
+			const fn = jest.fn().mockResolvedValue('result');
+
+			await service.withLock(1001, fn);
+
+			expect(mockTx.query).not.toHaveBeenCalledWith(expect.stringContaining('lock_timeout'));
+			expect(mockTx.query).toHaveBeenCalledWith('SELECT pg_advisory_xact_lock($1)', [1001]);
+		});
+
+		it('should throw OperationalError when lock timeout is exceeded', async () => {
+			databaseConfig.type = 'postgresdb';
+			const fn = jest.fn();
+			const timeoutError = new QueryFailedError(
+				'SELECT pg_advisory_xact_lock($1)',
+				[1001],
+				new Error('canceling statement due to lock timeout'),
+			);
+
+			// First call succeeds (SET LOCAL), second call throws (advisory lock)
+			mockTx.query.mockResolvedValueOnce(undefined).mockRejectedValueOnce(timeoutError);
+
+			await expect(service.withLock(1001, fn, { timeoutMs: 5000 })).rejects.toThrow(
+				OperationalError,
+			);
+			expect(fn).not.toHaveBeenCalled();
+		});
+
+		it('should include timeout details in OperationalError message', async () => {
+			databaseConfig.type = 'postgresdb';
+			const fn = jest.fn();
+			const timeoutError = new QueryFailedError(
+				'SELECT pg_advisory_xact_lock($1)',
+				[1001],
+				new Error('canceling statement due to lock timeout'),
+			);
+
+			mockTx.query.mockResolvedValueOnce(undefined).mockRejectedValueOnce(timeoutError);
+
+			await expect(service.withLock(1001, fn, { timeoutMs: 5000 })).rejects.toThrow(
+				/Timed out waiting for DbLock 1001 after 5000ms/,
+			);
+		});
+
+		it('should propagate non-timeout errors unchanged', async () => {
+			databaseConfig.type = 'postgresdb';
+			const fn = jest.fn();
+			const otherError = new Error('connection lost');
+
+			mockTx.query.mockRejectedValueOnce(otherError);
+
+			await expect(service.withLock(1001, fn)).rejects.toThrow('connection lost');
+			expect(fn).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('tryWithLock', () => {
+		it('should execute fn when lock is acquired', async () => {
+			databaseConfig.type = 'postgresdb';
+			const fn = jest.fn().mockResolvedValue('result');
+			mockTx.query.mockResolvedValueOnce([{ pg_try_advisory_xact_lock: true }]);
+
+			const result = await service.tryWithLock(1001, fn);
+
+			expect(result).toBe('result');
+			expect(mockTx.query).toHaveBeenCalledWith('SELECT pg_try_advisory_xact_lock($1)', [1001]);
+			expect(fn).toHaveBeenCalledWith(mockTx);
+		});
+
+		it('should throw OperationalError when lock is already held', async () => {
+			databaseConfig.type = 'postgresdb';
+			const fn = jest.fn();
+			mockTx.query.mockResolvedValueOnce([{ pg_try_advisory_xact_lock: false }]);
+
+			const error = await service.tryWithLock(1001, fn).catch((e: unknown) => e);
+			expect(error).toBeInstanceOf(OperationalError);
+			expect((error as OperationalError).message).toMatch(
+				/DbLock 1001 is already held by another process/,
+			);
+			expect(fn).not.toHaveBeenCalled();
+		});
+
+		it('should skip advisory lock on SQLite and execute fn', async () => {
+			databaseConfig.type = 'sqlite';
+			const fn = jest.fn().mockResolvedValue('result');
+
+			const result = await service.tryWithLock(1001, fn);
+
+			expect(result).toBe('result');
+			expect(mockTx.query).not.toHaveBeenCalled();
+			expect(fn).toHaveBeenCalledWith(mockTx);
+		});
+	});
+});

--- a/packages/@n8n/db/src/services/db-lock.service.ts
+++ b/packages/@n8n/db/src/services/db-lock.service.ts
@@ -1,0 +1,85 @@
+import { DatabaseConfig } from '@n8n/config';
+import { Service } from '@n8n/di';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
+import { DataSource, QueryFailedError } from '@n8n/typeorm';
+import type { EntityManager } from '@n8n/typeorm';
+import { OperationalError } from 'n8n-workflow';
+
+/**
+ * Centrally managed advisory lock IDs. Every Postgres advisory lock
+ * used in the application MUST be registered here to prevent collisions.
+ */
+export const enum DbLock {
+	AUTH_ROLES_SYNC = 1001,
+	/** Reserved for integration tests — never use in production code */
+	TEST = 9999,
+}
+
+@Service()
+export class DbLockService {
+	constructor(
+		private readonly dataSource: DataSource,
+		private readonly databaseConfig: DatabaseConfig,
+	) {}
+
+	/**
+	 * Execute `fn` inside a database transaction, serialized by a
+	 * Postgres advisory lock. On SQLite the transaction alone provides
+	 * serialization (single-process only).
+	 *
+	 * The lock is automatically released when the transaction commits
+	 * or rolls back. Concurrent callers block until the lock is available.
+	 *
+	 * @param options.timeoutMs - Maximum time in milliseconds to wait for the lock.
+	 *   If not provided, waits indefinitely.
+	 */
+	async withLock<T>(
+		lockId: DbLock,
+		fn: (tx: EntityManager) => Promise<T>,
+		options?: { timeoutMs?: number },
+	): Promise<T> {
+		return await this.dataSource.manager.transaction(async (tx) => {
+			if (this.databaseConfig.type === 'postgresdb') {
+				if (options?.timeoutMs !== undefined) {
+					// SET doesn't support parameterized queries ($1) in Postgres.
+					// Number() coercion is safe here since timeoutMs is typed as number.
+					await tx.query(`SET LOCAL lock_timeout = '${Number(options.timeoutMs)}'`);
+				}
+				try {
+					await tx.query('SELECT pg_advisory_xact_lock($1)', [lockId]);
+				} catch (error) {
+					if (error instanceof QueryFailedError && error.message.includes('lock timeout')) {
+						throw new OperationalError(
+							`Timed out waiting for DbLock ${lockId} after ${options?.timeoutMs}ms`,
+							{ cause: error },
+						);
+					}
+					throw error;
+				}
+			}
+			return await fn(tx);
+		});
+	}
+
+	/**
+	 * Execute `fn` inside a database transaction, but only if the advisory
+	 * lock can be acquired immediately. On SQLite the transaction alone
+	 * provides serialization.
+	 *
+	 * @throws {OperationalError} if the lock is already held by another process
+	 */
+	async tryWithLock<T>(lockId: DbLock, fn: (tx: EntityManager) => Promise<T>): Promise<T> {
+		return await this.dataSource.manager.transaction(async (tx) => {
+			if (this.databaseConfig.type === 'postgresdb') {
+				const result: Array<{ pg_try_advisory_xact_lock: boolean }> = await tx.query(
+					'SELECT pg_try_advisory_xact_lock($1)',
+					[lockId],
+				);
+				if (!result[0].pg_try_advisory_xact_lock) {
+					throw new OperationalError(`DbLock ${lockId} is already held by another process`);
+				}
+			}
+			return await fn(tx);
+		});
+	}
+}

--- a/packages/@n8n/db/src/services/index.ts
+++ b/packages/@n8n/db/src/services/index.ts
@@ -1,1 +1,2 @@
 export { AuthRolesService } from './auth.roles.service';
+export { DbLock, DbLockService } from './db-lock.service';

--- a/packages/cli/src/commands/__tests__/start.test.ts
+++ b/packages/cli/src/commands/__tests__/start.test.ts
@@ -196,7 +196,7 @@ describe('Start - AuthRolesService initialization', () => {
 			expect(authRolesService.init).not.toHaveBeenCalled();
 		});
 
-		it('should NOT initialize AuthRolesService when instanceType is main, multi-main enabled, but NOT leader', async () => {
+		it('should initialize AuthRolesService when instanceType is main, multi-main enabled, but NOT leader (advisory lock serializes)', async () => {
 			setupInstanceSettings('main', true, false);
 			// @ts-expect-error - Accessing protected property for testing
 			start.globalConfig = {
@@ -218,7 +218,7 @@ describe('Start - AuthRolesService initialization', () => {
 
 			await start.init();
 
-			expect(authRolesService.init).not.toHaveBeenCalled();
+			expect(authRolesService.init).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/packages/cli/test/integration/database/services/db-lock.service.test.ts
+++ b/packages/cli/test/integration/database/services/db-lock.service.test.ts
@@ -1,0 +1,141 @@
+import { GlobalConfig } from '@n8n/config';
+import { testDb } from '@n8n/backend-test-utils';
+import { DbLock, DbLockService } from '@n8n/db';
+import { Container } from '@n8n/di';
+import { DataSource } from '@n8n/typeorm';
+import { OperationalError, sleep } from 'n8n-workflow';
+
+let dbLockService: DbLockService;
+let dataSource: DataSource;
+let isPostgres: boolean;
+
+beforeAll(async () => {
+	await testDb.init();
+	dbLockService = Container.get(DbLockService);
+	dataSource = Container.get(DataSource);
+	isPostgres = Container.get(GlobalConfig).database.type === 'postgresdb';
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+describe('DbLockService', () => {
+	describe('withLock', () => {
+		it('should execute the callback inside a transaction', async () => {
+			const result = await dbLockService.withLock(DbLock.TEST, async (tx) => {
+				expect(tx).toBeDefined();
+				expect(tx.queryRunner).toBeDefined();
+				return 'done';
+			});
+
+			expect(result).toBe('done');
+		});
+
+		it('should return the value from the callback', async () => {
+			const result = await dbLockService.withLock(DbLock.TEST, async () => 42);
+			expect(result).toBe(42);
+		});
+
+		it('should roll back the transaction when the callback throws', async () => {
+			await expect(
+				dbLockService.withLock(DbLock.TEST, async () => {
+					throw new Error('rollback me');
+				}),
+			).rejects.toThrow('rollback me');
+		});
+	});
+
+	describe('tryWithLock', () => {
+		it('should execute the callback when no contention', async () => {
+			const result = await dbLockService.tryWithLock(DbLock.TEST, async (tx) => {
+				expect(tx).toBeDefined();
+				return 'acquired';
+			});
+
+			expect(result).toBe('acquired');
+		});
+	});
+
+	describe('advisory lock serialization (Postgres)', () => {
+		it('should serialize concurrent withLock calls', async () => {
+			if (!isPostgres) return;
+
+			const executionOrder: string[] = [];
+
+			// First call: acquires lock, holds it for 200ms
+			const first = dbLockService.withLock(DbLock.TEST, async () => {
+				executionOrder.push('first:start');
+				await sleep(200);
+				executionOrder.push('first:end');
+				return 'first';
+			});
+
+			// Small delay to ensure the first call starts first
+			await sleep(50);
+
+			// Second call: should block until first releases the lock
+			const second = dbLockService.withLock(DbLock.TEST, async () => {
+				executionOrder.push('second:start');
+				return 'second';
+			});
+
+			const results = await Promise.all([first, second]);
+
+			expect(results).toEqual(['first', 'second']);
+			// The second call should only start after the first call ends
+			expect(executionOrder).toEqual(['first:start', 'first:end', 'second:start']);
+		});
+
+		it('should throw OperationalError when withLock times out', async () => {
+			if (!isPostgres) return;
+
+			// Hold the lock in a separate transaction using raw SQL
+			// so we can control when it releases
+			const holdLockPromise = dataSource.manager.transaction(async (tx) => {
+				await tx.query('SELECT pg_advisory_xact_lock($1)', [DbLock.TEST]);
+				// Hold the lock longer than the timeout
+				await sleep(2000);
+			});
+
+			// Wait for the lock to be acquired
+			await sleep(100);
+
+			// Try to acquire with a short timeout — should fail
+			await expect(
+				dbLockService.withLock(DbLock.TEST, async () => 'should not reach', {
+					timeoutMs: 200,
+				}),
+			).rejects.toThrow(OperationalError);
+
+			// Clean up: wait for the lock holder to finish
+			await holdLockPromise;
+		});
+
+		it('should throw OperationalError when tryWithLock cannot acquire', async () => {
+			if (!isPostgres) return;
+
+			let tryResult: unknown;
+
+			await dataSource.manager.transaction(async (tx) => {
+				// Hold the advisory lock inside this transaction
+				await tx.query('SELECT pg_advisory_xact_lock($1)', [DbLock.TEST]);
+
+				// While the lock is held, tryWithLock should fail immediately
+				tryResult = await dbLockService
+					.tryWithLock(DbLock.TEST, async () => 'should not reach')
+					.catch((e: unknown) => e);
+			});
+
+			expect(tryResult).toBeInstanceOf(OperationalError);
+			expect((tryResult as OperationalError).message).toMatch(/already held by another process/);
+		});
+
+		it('tryWithLock should succeed when lock is not held', async () => {
+			if (!isPostgres) return;
+
+			const result = await dbLockService.tryWithLock(DbLock.TEST, async () => 'free');
+			expect(result).toBe('free');
+		});
+	});
+});

--- a/packages/cli/test/integration/database/services/db-lock.service.test.ts
+++ b/packages/cli/test/integration/database/services/db-lock.service.test.ts
@@ -1,22 +1,39 @@
 import { GlobalConfig } from '@n8n/config';
 import { testDb } from '@n8n/backend-test-utils';
-import { DbLock, DbLockService } from '@n8n/db';
+import { DbConnectionOptions, DbLock, DbLockService } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { DataSource } from '@n8n/typeorm';
 import { OperationalError, sleep } from 'n8n-workflow';
 
 let dbLockService: DbLockService;
-let dataSource: DataSource;
 let isPostgres: boolean;
+
+// Separate DataSource with its own connection for holding locks during
+// contention tests. The main DataSource may have poolSize=1 in CI
+// (set by setup-testcontainers.js), so we need an independent connection
+// to hold a lock while the service tries to acquire it on the main pool.
+let holdLockDs: DataSource;
 
 beforeAll(async () => {
 	await testDb.init();
 	dbLockService = Container.get(DbLockService);
-	dataSource = Container.get(DataSource);
-	isPostgres = Container.get(GlobalConfig).database.type === 'postgresdb';
+	const globalConfig = Container.get(GlobalConfig);
+	isPostgres = globalConfig.database.type === 'postgresdb';
+
+	if (isPostgres) {
+		holdLockDs = new DataSource({
+			type: 'postgres',
+			...Container.get(DbConnectionOptions).getPostgresOverrides(),
+			schema: globalConfig.database.postgresdb.schema,
+		});
+		await holdLockDs.initialize();
+	}
 });
 
 afterAll(async () => {
+	if (holdLockDs?.isInitialized) {
+		await holdLockDs.destroy();
+	}
 	await testDb.terminate();
 });
 
@@ -63,18 +80,24 @@ describe('DbLockService', () => {
 
 			const executionOrder: string[] = [];
 
-			// First call: acquires lock, holds it for 200ms
-			const first = dbLockService.withLock(DbLock.TEST, async () => {
+			let lockAcquired!: () => void;
+			const lockAcquiredPromise = new Promise<void>((resolve) => {
+				lockAcquired = resolve;
+			});
+
+			// First call: hold lock on the separate connection
+			const first = holdLockDs.manager.transaction(async (tx) => {
+				await tx.query('SELECT pg_advisory_xact_lock($1)', [DbLock.TEST]);
 				executionOrder.push('first:start');
-				await sleep(200);
+				lockAcquired();
+				await sleep(300);
 				executionOrder.push('first:end');
 				return 'first';
 			});
 
-			// Small delay to ensure the first call starts first
-			await sleep(50);
+			await lockAcquiredPromise;
 
-			// Second call: should block until first releases the lock
+			// Second call via the service: should block until first releases the lock
 			const second = dbLockService.withLock(DbLock.TEST, async () => {
 				executionOrder.push('second:start');
 				return 'second';
@@ -90,14 +113,13 @@ describe('DbLockService', () => {
 		it('should throw OperationalError when withLock times out', async () => {
 			if (!isPostgres) return;
 
-			// Use a promise to signal when the lock is actually held,
-			// instead of a fixed sleep which is racy on CI.
 			let lockAcquired!: () => void;
 			const lockAcquiredPromise = new Promise<void>((resolve) => {
 				lockAcquired = resolve;
 			});
 
-			const holdLockPromise = dataSource.manager.transaction(async (tx) => {
+			// Hold the lock on the separate connection
+			const holdLockPromise = holdLockDs.manager.transaction(async (tx) => {
 				await tx.query('SELECT pg_advisory_xact_lock($1)', [DbLock.TEST]);
 				lockAcquired();
 				await sleep(2000);
@@ -105,29 +127,26 @@ describe('DbLockService', () => {
 
 			await lockAcquiredPromise;
 
-			// Try to acquire with a short timeout — should fail
+			// Try to acquire on the main connection with a short timeout — should fail
 			await expect(
 				dbLockService.withLock(DbLock.TEST, async () => 'should not reach', {
 					timeoutMs: 200,
 				}),
 			).rejects.toThrow(OperationalError);
 
-			// Clean up: wait for the lock holder to finish
 			await holdLockPromise;
 		});
 
 		it('should throw OperationalError when tryWithLock cannot acquire', async () => {
 			if (!isPostgres) return;
 
-			// Hold the lock in a background transaction and signal when acquired.
-			// tryWithLock opens its own transaction (separate connection), so we
-			// must not nest it inside the holding transaction.
 			let lockAcquired!: () => void;
 			const lockAcquiredPromise = new Promise<void>((resolve) => {
 				lockAcquired = resolve;
 			});
 
-			const holdLockPromise = dataSource.manager.transaction(async (tx) => {
+			// Hold the lock on the separate connection
+			const holdLockPromise = holdLockDs.manager.transaction(async (tx) => {
 				await tx.query('SELECT pg_advisory_xact_lock($1)', [DbLock.TEST]);
 				lockAcquired();
 				await sleep(2000);
@@ -135,6 +154,7 @@ describe('DbLockService', () => {
 
 			await lockAcquiredPromise;
 
+			// tryWithLock on the main connection should fail immediately
 			const error = await dbLockService
 				.tryWithLock(DbLock.TEST, async () => 'should not reach')
 				.catch((e: unknown) => e);

--- a/packages/cli/test/integration/database/services/db-lock.service.test.ts
+++ b/packages/cli/test/integration/database/services/db-lock.service.test.ts
@@ -90,16 +90,20 @@ describe('DbLockService', () => {
 		it('should throw OperationalError when withLock times out', async () => {
 			if (!isPostgres) return;
 
-			// Hold the lock in a separate transaction using raw SQL
-			// so we can control when it releases
+			// Use a promise to signal when the lock is actually held,
+			// instead of a fixed sleep which is racy on CI.
+			let lockAcquired!: () => void;
+			const lockAcquiredPromise = new Promise<void>((resolve) => {
+				lockAcquired = resolve;
+			});
+
 			const holdLockPromise = dataSource.manager.transaction(async (tx) => {
 				await tx.query('SELECT pg_advisory_xact_lock($1)', [DbLock.TEST]);
-				// Hold the lock longer than the timeout
+				lockAcquired();
 				await sleep(2000);
 			});
 
-			// Wait for the lock to be acquired
-			await sleep(100);
+			await lockAcquiredPromise;
 
 			// Try to acquire with a short timeout — should fail
 			await expect(
@@ -115,20 +119,30 @@ describe('DbLockService', () => {
 		it('should throw OperationalError when tryWithLock cannot acquire', async () => {
 			if (!isPostgres) return;
 
-			let tryResult: unknown;
-
-			await dataSource.manager.transaction(async (tx) => {
-				// Hold the advisory lock inside this transaction
-				await tx.query('SELECT pg_advisory_xact_lock($1)', [DbLock.TEST]);
-
-				// While the lock is held, tryWithLock should fail immediately
-				tryResult = await dbLockService
-					.tryWithLock(DbLock.TEST, async () => 'should not reach')
-					.catch((e: unknown) => e);
+			// Hold the lock in a background transaction and signal when acquired.
+			// tryWithLock opens its own transaction (separate connection), so we
+			// must not nest it inside the holding transaction.
+			let lockAcquired!: () => void;
+			const lockAcquiredPromise = new Promise<void>((resolve) => {
+				lockAcquired = resolve;
 			});
 
-			expect(tryResult).toBeInstanceOf(OperationalError);
-			expect((tryResult as OperationalError).message).toMatch(/already held by another process/);
+			const holdLockPromise = dataSource.manager.transaction(async (tx) => {
+				await tx.query('SELECT pg_advisory_xact_lock($1)', [DbLock.TEST]);
+				lockAcquired();
+				await sleep(2000);
+			});
+
+			await lockAcquiredPromise;
+
+			const error = await dbLockService
+				.tryWithLock(DbLock.TEST, async () => 'should not reach')
+				.catch((e: unknown) => e);
+
+			expect(error).toBeInstanceOf(OperationalError);
+			expect((error as OperationalError).message).toMatch(/already held by another process/);
+
+			await holdLockPromise;
 		});
 
 		it('tryWithLock should succeed when lock is not held', async () => {


### PR DESCRIPTION
## Summary

Fixes a multi-main startup race condition where concurrent n8n instances running `AuthRolesService.syncScopes()` against the same Postgres database hit duplicate key constraint violations.

- Introduces a centralized `DbLockService` in `@n8n/db` that wraps Postgres advisory locks (`pg_advisory_xact_lock`) inside transactions, with a `DbLock` enum to prevent lock ID collisions
- Supports an optional `timeoutMs` on `withLock` (via `SET LOCAL lock_timeout`) and a non-blocking `tryWithLock` (via `pg_try_advisory_xact_lock`) that fails fast if the lock is already held
- On SQLite, advisory locks are skipped — the transaction alone provides serialization
- Refactors `AuthRolesService.init()` to use `DbLockService.withLock(DbLock.AUTH_ROLES_SYNC, ...)` instead of repository-level calls
- Removes the leader-only guard in `start.ts` — all main instances now call `AuthRolesService.init()`, and the advisory lock serializes them safely
- Lock contention throws `OperationalError` (timeout exceeded or try-lock busy)

## Test plan

- [x] 10 unit tests for `DbLockService` (`withLock` + `tryWithLock`, Postgres/SQLite, timeout, error propagation)
- [x] 8 integration tests against live database (transaction behavior, advisory lock serialization, timeout, try-lock contention)
- [x] 27 existing `AuthRolesService` unit tests updated and passing
- [x] 4 existing `start.ts` unit tests updated (non-leader now calls init)
- [x] Typecheck and lint clean on both `@n8n/db` and `cli` packages

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/IAM-298

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
