### PR TITLE
feat(editor): Forward rich message types from SDK instead of flattening to text

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/responder.prompt.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/prompts/agents/responder.prompt.ts
@@ -188,8 +188,9 @@ export function buildRecursionErrorNoWorkflowGuidance(): string[] {
 /** Guidance for other (non-recursion) errors */
 export function buildGeneralErrorGuidance(): string {
 	return (
-		'Apologize and explain that a technical error occurred. ' +
-		'Ask if they would like to try again or approach the problem differently.'
+		'Apologize briefly and explain that something went wrong while building the workflow. ' +
+		'Do NOT use the phrase "technical error". ' +
+		'Suggest the user try again, and offer to help approach the problem differently if the issue persists.'
 	);
 }
 

--- a/packages/@n8n/ai-workflow-builder.ee/src/types/streaming.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/types/streaming.ts
@@ -7,6 +7,7 @@ export interface AgentMessageChunk {
 	role: 'assistant';
 	type: 'message';
 	text: string;
+	codeSnippet?: string;
 }
 
 /**
@@ -85,6 +86,27 @@ export interface MessagesCompactedChunk {
 }
 
 /**
+ * Summary chunk for structured summary messages from the SDK
+ */
+export interface SummaryChunk {
+	role: 'assistant';
+	type: 'summary';
+	title: string;
+	content: string;
+}
+
+/**
+ * Agent suggestion chunk for structured suggestion messages from the SDK
+ */
+export interface AgentSuggestionChunk {
+	role: 'assistant';
+	type: 'agent-suggestion';
+	title: string;
+	text: string;
+	suggestionId?: string;
+}
+
+/**
  * Union type for all stream chunks
  */
 export type StreamChunk =
@@ -96,7 +118,9 @@ export type StreamChunk =
 	| QuestionsChunk
 	| PlanChunk
 	| CodeDiffChunk
-	| MessagesCompactedChunk;
+	| MessagesCompactedChunk
+	| SummaryChunk
+	| AgentSuggestionChunk;
 
 /**
  * Stream output containing messages

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/TextMessage.vue
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/TextMessage.vue
@@ -268,13 +268,6 @@ async function onCopyButtonClick(content: string, e: MouseEvent) {
 		display: none;
 	}
 
-	// Add top padding to strong elements only when there's content before them
-	:not(:first-child) > strong:first-child,
-	* + strong {
-		display: inline-block;
-		padding-top: var(--spacing--md);
-	}
-
 	h1,
 	h2,
 	h3 {


### PR DESCRIPTION
## Summary

Forward `summary`, `agent-suggestion`, and `codeSnippet` message types from the assistant SDK as structured chunks instead of degrading them to plain markdown text. The UI components (`BlockMessage.vue`, `TextMessage.vue`) already support rendering these rich types. This change wires them through the builder message pipeline.

**Backend:**
- Added `SummaryChunk` and `AgentSuggestionChunk` types to `streaming.ts`
- Added `codeSnippet` field to `AgentMessageChunk`
- `AssistantHandler.mapSdkMessage()` now forwards rich types instead of flattening `summary` → `**title**\n\ncontent` and `agent-suggestion` → `**title**\n\ntext`

**Frontend:**
- `processSingleMessage()` and `mapAssistantMessageToUI()` now handle `summary` → `SummaryBlock`, `agent-suggestion` → `SummaryBlock`, and `codeSnippet` on text messages
- `getThinkingState()` recognizes `type === 'block'` as a response that clears thinking state

## Related Linear tickets
https://linear.app/n8n/issue/AI-2037