### PR TITLE
refactor(editor): Switch to using refs when injecting the workflow document (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowActivated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowActivated.ts
@@ -17,7 +17,7 @@ export async function workflowActivated({ data }: WorkflowActivated) {
 	const { workflowId, activeVersionId } = data;
 
 	const workflowIsBeingViewed = workflowsStore.workflowId === workflowId;
-	const activeVersionChanged = documentStore?.activeVersionId !== activeVersionId;
+	const activeVersionChanged = documentStore?.value?.activeVersionId !== activeVersionId;
 	if (workflowIsBeingViewed && activeVersionChanged) {
 		// Only update workflow if there are no unsaved changes
 		if (!uiStore.stateIsDirty) {

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowAutoDeactivated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowAutoDeactivated.ts
@@ -26,7 +26,7 @@ export async function workflowAutoDeactivated({ data }: WorkflowAutoDeactivated)
 			// initializeWorkspace calls initState which sets the document store
 			await initializeWorkspace(updatedWorkflow);
 		} else {
-			documentStore?.setActiveState({ activeVersionId: null, activeVersion: null });
+			documentStore?.value?.setActiveState({ activeVersionId: null, activeVersion: null });
 		}
 
 		bannersStore.pushBannerToStack('WORKFLOW_AUTO_DEACTIVATED');

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowDeactivated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowDeactivated.ts
@@ -22,7 +22,7 @@ export async function workflowDeactivated({ data }: WorkflowDeactivated) {
 			// initializeWorkspace calls initState which sets the document store
 			await initializeWorkspace(updatedWorkflow);
 		} else {
-			documentStore?.setActiveState({ activeVersionId: null, activeVersion: null });
+			documentStore?.value?.setActiveState({ activeVersionId: null, activeVersion: null });
 		}
 	}
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowFailedToActivate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowFailedToActivate.ts
@@ -17,7 +17,7 @@ export async function workflowFailedToActivate(
 	}
 
 	workflowsStore.setWorkflowInactive(data.workflowId);
-	documentStore?.setActiveState({ activeVersionId: null, activeVersion: null });
+	documentStore?.value?.setActiveState({ activeVersionId: null, activeVersion: null });
 
 	const toast = useToast();
 	const i18n = useI18n();

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
@@ -156,6 +156,5 @@ export function disposeWorkflowDocumentStore(id: string) {
  * document store but may be called outside of the NodeView tree.
  */
 export function injectWorkflowDocumentStore() {
-	const storeRef = inject(WorkflowDocumentStoreKey, null);
-	return storeRef?.value ?? null;
+	return inject(WorkflowDocumentStoreKey, null);
 }

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -1193,7 +1193,7 @@ const isOnlyChatTriggerNodeActive = computed(() => {
 const chatTriggerNodePinnedData = computed(() => {
 	if (!chatTriggerNode.value) return null;
 
-	return workflowDocumentStore?.pinData?.[chatTriggerNode.value.name];
+	return workflowDocumentStore?.value?.pinData?.[chatTriggerNode.value.name];
 });
 
 function onOpenChat() {

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -1072,7 +1072,7 @@ async function onCopyTestUrl(id: string) {
 }
 
 async function onCopyProductionUrl(id: string) {
-	const isWorkflowActive = workflowDocumentStore?.active ?? false;
+	const isWorkflowActive = workflowDocumentStore?.value?.active ?? false;
 	if (!isWorkflowActive) {
 		toast.showMessage({
 			title: i18n.baseText('nodeWebhooks.showMessage.not.active'),

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/TriggerPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/TriggerPanel.vue
@@ -191,7 +191,7 @@ const isActivelyPolling = computed(() => {
 	return workflowRunning.value && isPollingNode.value && props.nodeName === triggeredNode;
 });
 
-const isWorkflowActive = computed(() => workflowDocumentStore?.active ?? false);
+const isWorkflowActive = computed(() => workflowDocumentStore?.value?.active ?? false);
 
 const listeningTitle = computed(() => {
 	return nodeType.value?.name === FORM_TRIGGER_NODE_TYPE

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
@@ -590,7 +590,7 @@ const parentNodeOutputData = computed(() => {
 
 const parentNodePinnedData = computed(() => {
 	const parentNode = props.workflowObject.getParentNodesByDepth(node.value?.name ?? '')[0];
-	return workflowDocumentStore?.pinData?.[parentNode?.name || ''] ?? [];
+	return workflowDocumentStore?.value?.pinData?.[parentNode?.name || ''] ?? [];
 });
 
 const showPinButton = computed(

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.vue
@@ -124,7 +124,7 @@ const toggleNodeExclusiveAndScrollTop = (id: string) => {
 };
 
 const getNodeSchema = async (fullNode: INodeUi, connectedNode: IConnectedNode) => {
-	const rawPinData = workflowDocumentStore?.getNodePinData(connectedNode.name);
+	const rawPinData = workflowDocumentStore?.value?.getNodePinData(connectedNode.name);
 	const pinData = rawPinData ? executionDataToJson(rawPinData) : undefined;
 	const hasPinnedData = pinData ? pinData.length > 0 : false;
 	const isNodeExecuted = hasPinnedData || hasNodeExecuted(connectedNode.name);

--- a/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsView.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsView.vue
@@ -136,7 +136,7 @@ const parentNodes = computed(() => {
 
 const parentNode = computed<IConnectedNode | undefined>(() => {
 	for (const parent of parentNodes.value) {
-		if (workflowDocumentStore?.pinData?.[parent.name]) {
+		if (workflowDocumentStore?.value?.pinData?.[parent.name]) {
 			return parent;
 		}
 

--- a/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsViewV2.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsViewV2.vue
@@ -140,7 +140,7 @@ const parentNodes = computed(() => {
 
 const parentNode = computed(() => {
 	for (const parentNodeName of parentNodes.value) {
-		if (workflowDocumentStore?.pinData?.[parentNodeName]) {
+		if (workflowDocumentStore?.value?.pinData?.[parentNodeName]) {
 			return parentNodeName;
 		}
 

--- a/packages/frontend/editor-ui/src/features/shared/contextMenu/composables/useContextMenu.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/contextMenu/composables/useContextMenu.test.ts
@@ -7,6 +7,7 @@ import {
 	STICKY_NODE_TYPE,
 } from '@/app/constants';
 import { faker } from '@faker-js/faker';
+import { shallowRef } from 'vue';
 import { createPinia, setActivePinia } from 'pinia';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
 import { useUIStore } from '@/app/stores/ui.store';
@@ -63,7 +64,7 @@ describe('useContextMenu', () => {
 		workflowsStore.workflow.nodes = nodes;
 		workflowsStore.workflow.scopes = ['workflow:update'];
 		documentStore = useWorkflowDocumentStore(createWorkflowDocumentId(testWorkflowId));
-		vi.mocked(injectWorkflowDocumentStore).mockReturnValue(documentStore);
+		vi.mocked(injectWorkflowDocumentStore).mockReturnValue(shallowRef(documentStore));
 		workflowsStore.workflowObject = {
 			nodes,
 			getNode: (_: string) => {

--- a/packages/frontend/editor-ui/src/features/shared/contextMenu/composables/useContextMenuItems.ts
+++ b/packages/frontend/editor-ui/src/features/shared/contextMenu/composables/useContextMenuItems.ts
@@ -252,7 +252,7 @@ export function useContextMenuItems(targetNodeIds: ComputedRef<string[]>): Compu
 
 				if (isWebhookNode(nodes[0])) {
 					const isProductionOnly = PRODUCTION_ONLY_TRIGGER_NODE_TYPES.includes(nodes[0].type);
-					const isWorkflowActive = documentStore?.active ?? false;
+					const isWorkflowActive = documentStore?.value?.active ?? false;
 					if (!isProductionOnly) {
 						copyWebhookActions.push({
 							divided: true,


### PR DESCRIPTION
## Summary

Changed `injectWorkflowDocumentStore()` to return a ref directly instead of unwrapping it, ensuring reactive updates throughout the application. All consuming code is updated to access the store via `.value`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2442

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
- [ ] Docs updated or follow-up ticket created.
- [ ] PR Labeled with `release/backport` (if applicable)