### PR TITLE
refactor(core): Extract and reuse containsExpression string utility

### DIFF
--- a/packages/cli/src/__tests__/utils.test.ts
+++ b/packages/cli/src/__tests__/utils.test.ts
@@ -6,6 +6,7 @@ import {
 	getAllKeyPaths,
 	isWorkflowIdValid,
 	setMicrosoftObservabilityDefaults,
+	containsExpression,
 } from '../utils';
 
 describe('shouldAssignExecuteMethod', () => {
@@ -329,5 +330,53 @@ describe('setMicrosoftObservabilityDefaults', () => {
 
 		expect(process.env.ENABLE_OBSERVABILITY).toBe('custom-value');
 		expect(process.env.ENABLE_A365_OBSERVABILITY_EXPORTER).toBe('true');
+	});
+});
+
+describe('containsExpression', () => {
+	it('returns true for a simple expression with {{...}}', () => {
+		expect(containsExpression('={{value}}')).toBe(true);
+	});
+
+	it('returns true when {{...}} appears later in the string', () => {
+		expect(containsExpression('=hello {{world}}')).toBe(true);
+	});
+
+	it('returns true when there is content inside the braces (including spaces)', () => {
+		expect(containsExpression('={{ value }}')).toBe(true);
+	});
+
+	it('returns true when there is trailing content after the }}', () => {
+		expect(containsExpression('={{value}} + 1')).toBe(true);
+	});
+
+	it('returns false when the string does not start with "="', () => {
+		expect(containsExpression('hello {{world}}')).toBe(false);
+	});
+
+	it('returns false when the string starts with "=" but has no {{...}}', () => {
+		expect(containsExpression('=hello world')).toBe(false);
+	});
+
+	it('returns false for empty placeholder {{}}', () => {
+		expect(containsExpression('={{}}')).toBe(false);
+	});
+
+	it('returns false when the string uses single braces {..} instead of double {{..}}', () => {
+		expect(containsExpression('={value}')).toBe(false);
+	});
+
+	it('returns false when the braces are incomplete', () => {
+		expect(containsExpression('={{value}')).toBe(false);
+		expect(containsExpression('={value}}')).toBe(false);
+		expect(containsExpression('={{value')).toBe(false);
+	});
+
+	it('returns true when there are multiple placeholders and at least one matches', () => {
+		expect(containsExpression('=x {{a}} y {{b}}')).toBe(true);
+	});
+
+	it('returns false when the string is empty', () => {
+		expect(containsExpression('')).toBe(false);
 	});
 });

--- a/packages/cli/src/modules/external-secrets.ee/__tests__/redaction.service.ee.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/redaction.service.ee.test.ts
@@ -1,6 +1,8 @@
 import type { INodeProperties } from 'n8n-workflow';
-import { RedactionService } from '../redaction.service.ee';
+
 import { CREDENTIAL_BLANKING_VALUE } from '@/constants';
+
+import { RedactionService } from '../redaction.service.ee';
 
 function createProperty(name: string, isPassword = false): INodeProperties {
 	return {
@@ -45,7 +47,23 @@ describe('RedactionService', () => {
 			});
 		});
 
-		it('should NOT redact expressions starting with =', () => {
+		it('should NOT redact text starting with ={{', () => {
+			const data = {
+				apiKey: '={{ someExpression }}',
+				password: 'plainValue',
+			};
+
+			const properties = [createProperty('apiKey', true), createProperty('password', true)];
+
+			const result = service.redact(data, properties);
+
+			expect(result).toEqual({
+				apiKey: '={{ someExpression }}',
+				password: CREDENTIAL_BLANKING_VALUE,
+			});
+		});
+
+		it('should redact text starting with =', () => {
 			const data = {
 				apiKey: '=someExpression',
 				password: 'plainValue',
@@ -56,7 +74,7 @@ describe('RedactionService', () => {
 			const result = service.redact(data, properties);
 
 			expect(result).toEqual({
-				apiKey: '=someExpression',
+				apiKey: CREDENTIAL_BLANKING_VALUE,
 				password: CREDENTIAL_BLANKING_VALUE,
 			});
 		});

--- a/packages/cli/src/modules/external-secrets.ee/redaction.service.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/redaction.service.ee.ts
@@ -3,6 +3,7 @@ import type { IDataObject, INodeProperties } from 'n8n-workflow';
 import { deepCopy } from 'n8n-workflow';
 
 import { CREDENTIAL_BLANKING_VALUE } from '@/constants';
+import { containsExpression } from '@/utils';
 
 @Service()
 export class RedactionService {
@@ -51,8 +52,7 @@ export class RedactionService {
 	 * @returns True if value should be redacted
 	 */
 	private shouldRedactValue(value: unknown): boolean {
-		// Only redact string values that are not expressions (starting with '=')
-		return typeof value === 'string' && !value.startsWith('=');
+		return typeof value === 'string' && !containsExpression(value);
 	}
 
 	/**

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-helper.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-helper.ee.test.ts
@@ -12,6 +12,7 @@ import {
 	SOURCE_CONTROL_SSH_FOLDER,
 } from '@/modules/source-control.ee/constants';
 import type { SourceControlPreferencesService } from '@/modules/source-control.ee/source-control-preferences.service.ee';
+
 import {
 	areSameCredentials,
 	generateSshKeyPair,
@@ -25,7 +26,6 @@ import {
 	sanitizeCredentialData,
 	sourceControlFoldersExistCheck,
 } from '../source-control-helper.ee';
-
 import type { StatusExportableCredential } from '../types/exportable-credential';
 import type { SourceControlWorkflowVersionId } from '../types/source-control-workflow-version-id';
 

--- a/packages/cli/src/modules/source-control.ee/source-control-helper.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-helper.ee.ts
@@ -18,6 +18,7 @@ import { readFile as fsReadFile } from 'node:fs/promises';
 import path from 'path';
 
 import { License } from '@/license';
+import { containsExpression } from '@/utils';
 
 import {
 	SOURCE_CONTROL_FOLDERS_EXPORT_FILE,
@@ -37,10 +38,6 @@ import type { KeyPairType } from './types/key-pair-type';
 import type { RemoteResourceOwner, StatusResourceOwner } from './types/resource-owner';
 import type { SourceControlWorkflowVersionId } from './types/source-control-workflow-version-id';
 
-function stringContainsExpression(testString: string): boolean {
-	return /^=.*\{\{.+\}\}/.test(testString);
-}
-
 export function sanitizeCredentialData(
 	data: ICredentialDataDecryptedObject,
 ): ICredentialDataDecryptedObject {
@@ -53,7 +50,7 @@ export function sanitizeCredentialData(
 		} else if (typeof value === 'object') {
 			result[key] = sanitizeCredentialData(value as ICredentialDataDecryptedObject);
 		} else if (typeof value === 'string') {
-			result[key] = stringContainsExpression(value) ? value : '';
+			result[key] = containsExpression(value) ? value : '';
 		}
 
 		// NOTE: number and boolean values are synchable for backward compatibility
@@ -75,7 +72,7 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
  */
 function mergeSingleValue(sanitizedRemoteValue: unknown, localValue: unknown): unknown {
 	if (typeof sanitizedRemoteValue === 'string') {
-		if (stringContainsExpression(sanitizedRemoteValue)) {
+		if (containsExpression(sanitizedRemoteValue)) {
 			return sanitizedRemoteValue;
 		} else if (localValue !== undefined && localValue !== null) {
 			// Local value is preserved if it exists (secret handling)

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -139,3 +139,7 @@ export function setMicrosoftObservabilityDefaults(): void {
 		process.env.ENABLE_A365_OBSERVABILITY_EXPORTER = 'true';
 	}
 }
+
+export function containsExpression(testString: string): boolean {
+	return /^=.*\{\{.+\}\}/.test(testString);
+}


### PR DESCRIPTION
## Summary

Extracts the `containsExpression` string-checking function into a shared utility in `packages/cli/src/utils.ts` and reuses it in two places:

- **`source-control-helper.ee.ts`**: removes the local `stringContainsExpression` function and replaces calls with the shared utility
- **`redaction.service.ee.ts`**: replaces the inline `!value.startsWith('=')` check (which only tested the leading `=`) with `containsExpression`, making the expression-detection logic consistent across both modules

Tests updated to cover the new exported utility.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Link to Linear ticket: https://linear.app/n8n/issue/LIGO-278 -->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)