### PR TITLE
fix(Notion Node): Skip fetching children of unsupported block types

### DIFF
--- a/packages/nodes-base/nodes/Notion/shared/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Notion/shared/GenericFunctions.ts
@@ -122,7 +122,7 @@ export async function notionApiRequestGetBlockChildrens(
 	for (const block of blocks) {
 		responseData.push(block);
 
-		if (block.type === 'child_page') continue;
+		if (block.type === 'child_page' || block.type === 'unsupported') continue;
 
 		if (block.has_children) {
 			let childrens = await notionApiRequestAllItems.call(

--- a/packages/nodes-base/nodes/Notion/test/node/v2/block/getAll.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/block/getAll.test.ts
@@ -205,6 +205,28 @@ const API_RESPONSE = {
 				],
 			},
 		},
+		{
+			object: 'block',
+			id: 'aabbccdd-1234-5678-9012-abcdef123456',
+			parent: {
+				type: 'block_id',
+				block_id: '90e03468-f8aa-4576-95da-02ccad963040',
+			},
+			created_time: '2024-12-13T03:40:00.000Z',
+			last_edited_time: '2024-12-13T06:15:00.000Z',
+			created_by: {
+				object: 'user',
+				id: 'f215e49c-4677-40c0-9adc-87440d341324',
+			},
+			last_edited_by: {
+				object: 'user',
+				id: '88f72c1a-07ed-4bae-9fa0-231365d813d9',
+			},
+			has_children: true,
+			archived: false,
+			in_trash: false,
+			type: 'unsupported',
+		},
 	],
 	has_more: false,
 };

--- a/packages/nodes-base/nodes/Notion/test/node/v2/block/getAll.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/block/getAll.test.ts
@@ -231,6 +231,122 @@ const API_RESPONSE = {
 	has_more: false,
 };
 
+const NESTED_BLOCKS_PARENT_RESPONSE = {
+	results: [
+		{
+			object: 'block',
+			id: '11110000-1111-1111-1111-111100001111',
+			parent: {
+				type: 'block_id',
+				block_id: 'aabb0000-aabb-0000-aabb-0000aabb0000',
+			},
+			created_time: '2023-11-23T10:42:00.000Z',
+			last_edited_time: '2024-12-13T03:35:00.000Z',
+			created_by: {
+				object: 'user',
+				id: '88f72c1a-07ed-4bae-9fa0-231365d813d9',
+			},
+			last_edited_by: {
+				object: 'user',
+				id: '88f72c1a-07ed-4bae-9fa0-231365d813d9',
+			},
+			has_children: true,
+			archived: false,
+			in_trash: false,
+			type: 'toggle',
+			toggle: {
+				color: 'default',
+				text: [
+					{
+						type: 'text',
+						text: { content: 'Toggle block', link: null },
+						annotations: {
+							bold: false,
+							italic: false,
+							strikethrough: false,
+							underline: false,
+							code: false,
+							color: 'default',
+						},
+						plain_text: 'Toggle block',
+						href: null,
+					},
+				],
+			},
+		},
+		{
+			object: 'block',
+			id: '33330000-3333-3333-3333-333300003333',
+			parent: {
+				type: 'block_id',
+				block_id: 'aabb0000-aabb-0000-aabb-0000aabb0000',
+			},
+			created_time: '2024-12-13T03:40:00.000Z',
+			last_edited_time: '2024-12-13T06:15:00.000Z',
+			created_by: {
+				object: 'user',
+				id: '88f72c1a-07ed-4bae-9fa0-231365d813d9',
+			},
+			last_edited_by: {
+				object: 'user',
+				id: '88f72c1a-07ed-4bae-9fa0-231365d813d9',
+			},
+			has_children: true,
+			archived: false,
+			in_trash: false,
+			type: 'unsupported',
+		},
+	],
+	has_more: false,
+};
+
+const TOGGLE_CHILDREN_RESPONSE = {
+	results: [
+		{
+			object: 'block',
+			id: '22220000-2222-2222-2222-222200002222',
+			parent: {
+				type: 'block_id',
+				block_id: '11110000-1111-1111-1111-111100001111',
+			},
+			created_time: '2023-11-23T10:42:00.000Z',
+			last_edited_time: '2024-12-13T03:35:00.000Z',
+			created_by: {
+				object: 'user',
+				id: '88f72c1a-07ed-4bae-9fa0-231365d813d9',
+			},
+			last_edited_by: {
+				object: 'user',
+				id: '88f72c1a-07ed-4bae-9fa0-231365d813d9',
+			},
+			has_children: false,
+			archived: false,
+			in_trash: false,
+			type: 'paragraph',
+			paragraph: {
+				color: 'default',
+				text: [
+					{
+						type: 'text',
+						text: { content: 'Nested paragraph', link: null },
+						annotations: {
+							bold: false,
+							italic: false,
+							strikethrough: false,
+							underline: false,
+							code: false,
+							color: 'default',
+						},
+						plain_text: 'Nested paragraph',
+						href: null,
+					},
+				],
+			},
+		},
+	],
+	has_more: false,
+};
+
 describe('Test NotionV2, block => getAll', () => {
 	nock('https://api.notion.com')
 		.get('/v1/blocks/90e03468f8aa457695da02ccad963040/children')
@@ -238,5 +354,20 @@ describe('Test NotionV2, block => getAll', () => {
 
 	new NodeTestHarness().setupTests({
 		workflowFiles: ['getAll.workflow.json'],
+	});
+});
+
+describe('Test NotionV2, block => getAll with nested blocks skips unsupported', () => {
+	nock('https://api.notion.com')
+		.get('/v1/blocks/aabb0000aabb0000aabb0000aabb0000/children')
+		.reply(200, NESTED_BLOCKS_PARENT_RESPONSE)
+		// Mock children for the toggle block - this SHOULD be fetched
+		.get('/v1/blocks/11110000-1111-1111-1111-111100001111/children')
+		.reply(200, TOGGLE_CHILDREN_RESPONSE);
+	// No mock for /v1/blocks/33330000-3333-3333-3333-333300003333/children
+	// If the code tries to fetch children of the unsupported block, nock will fail
+
+	new NodeTestHarness().setupTests({
+		workflowFiles: ['getAllNestedBlocks.workflow.json'],
 	});
 });

--- a/packages/nodes-base/nodes/Notion/test/node/v2/block/getAll.workflow.json
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/block/getAll.workflow.json
@@ -147,6 +147,26 @@
 					"root_id": "90e03468f8aa457695da02ccad963040",
 					"content": ""
 				}
+			},
+			{
+				"json": {
+					"object": "block",
+					"parent_id": "90e03468f8aa457695da02ccad963040",
+					"id": "aabbccdd-1234-5678-9012-abcdef123456",
+					"parent": {
+						"type": "block_id",
+						"block_id": "90e03468-f8aa-4576-95da-02ccad963040"
+					},
+					"last_edited_by": {
+						"object": "user",
+						"id": "88f72c1a-07ed-4bae-9fa0-231365d813d9"
+					},
+					"has_children": true,
+					"archived": false,
+					"in_trash": false,
+					"type": "unsupported",
+					"root_id": "90e03468f8aa457695da02ccad963040"
+				}
 			}
 		]
 	},

--- a/packages/nodes-base/nodes/Notion/test/node/v2/block/getAllNestedBlocks.workflow.json
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/block/getAllNestedBlocks.workflow.json
@@ -1,0 +1,146 @@
+{
+	"name": "tests notion nested blocks",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "4260fdbd-e92f-4712-8114-38b85f8289ea",
+			"name": "When clicking 'Execute workflow'",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [820, 360]
+		},
+		{
+			"parameters": {
+				"resource": "block",
+				"operation": "getAll",
+				"blockId": {
+					"__rl": true,
+					"value": "https://www.notion.so/Block-Test-88188cbb303e4f44847f27d24bd7ad8e?pvs=4#aabb0000aabb0000aabb0000aabb0000",
+					"mode": "url"
+				},
+				"returnAll": true,
+				"fetchNestedBlocks": true
+			},
+			"id": "5ab80e6a-c9c4-4cc5-9332-2fc7a3f8ae24",
+			"name": "Notion",
+			"type": "n8n-nodes-base.notion",
+			"typeVersion": 2.2,
+			"position": [1040, 360],
+			"credentials": {
+				"notionApi": {
+					"id": "CiZXWkDmjiZzpcL1",
+					"name": "Notion account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "a664f506-72a5-4e50-80b4-97ed2e6eb334",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1260, 360]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"object": "block",
+					"parent_id": "aabb0000aabb0000aabb0000aabb0000",
+					"id": "11110000-1111-1111-1111-111100001111",
+					"parent": {
+						"type": "block_id",
+						"block_id": "aabb0000-aabb-0000-aabb-0000aabb0000"
+					},
+					"last_edited_by": {
+						"object": "user",
+						"id": "88f72c1a-07ed-4bae-9fa0-231365d813d9"
+					},
+					"has_children": true,
+					"archived": false,
+					"in_trash": false,
+					"type": "toggle",
+					"root_id": "aabb0000aabb0000aabb0000aabb0000",
+					"content": "Toggle block"
+				}
+			},
+			{
+				"json": {
+					"object": "block",
+					"parent_id": "11110000-1111-1111-1111-111100001111",
+					"id": "22220000-2222-2222-2222-222200002222",
+					"parent": {
+						"type": "block_id",
+						"block_id": "11110000-1111-1111-1111-111100001111"
+					},
+					"last_edited_by": {
+						"object": "user",
+						"id": "88f72c1a-07ed-4bae-9fa0-231365d813d9"
+					},
+					"has_children": false,
+					"archived": false,
+					"in_trash": false,
+					"type": "paragraph",
+					"root_id": "aabb0000aabb0000aabb0000aabb0000",
+					"content": "Nested paragraph"
+				}
+			},
+			{
+				"json": {
+					"object": "block",
+					"parent_id": "aabb0000aabb0000aabb0000aabb0000",
+					"id": "33330000-3333-3333-3333-333300003333",
+					"parent": {
+						"type": "block_id",
+						"block_id": "aabb0000-aabb-0000-aabb-0000aabb0000"
+					},
+					"last_edited_by": {
+						"object": "user",
+						"id": "88f72c1a-07ed-4bae-9fa0-231365d813d9"
+					},
+					"has_children": true,
+					"archived": false,
+					"in_trash": false,
+					"type": "unsupported",
+					"root_id": "aabb0000aabb0000aabb0000aabb0000"
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking 'Execute workflow'": {
+			"main": [
+				[
+					{
+						"node": "Notion",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Notion": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "4fdb1c05-8e94-5064-b7a2-97d4d7935514",
+	"meta": {
+		"templateCredsSetupCompleted": true,
+		"instanceId": "be251a83c052a9862eeac953816fbb1464f89dfbf79d7ac490a8e336a8cc8bfd"
+	},
+	"id": "Ucav6QC99JNMCkd4",
+	"tags": []
+}


### PR DESCRIPTION
## Summary

The Notion API returns meeting transcription blocks as `type: "unsupported"` with
`has_children: true`. When "Fetch Nested Blocks" is enabled in the "Get Many Child Blocks"
action, the node tries to recursively fetch children of all blocks, including unsupported ones.
The API rejects these requests, causing the entire execution to fail.

Add `unsupported` to the skip list alongside `child_page` in `notionApiRequestGetBlockChildrens`,
so these blocks are still included in the output but their children are not recursively fetched.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)