### PR TITLE
fix: Enable external secrets multi-connection to vault 

### DIFF
--- a/packages/@n8n/api-types/src/frontend-settings.ts
+++ b/packages/@n8n/api-types/src/frontend-settings.ts
@@ -268,6 +268,16 @@ export type FrontendModuleSettings = {
 	'quick-connect'?: {
 		options: QuickConnectOption[];
 	};
+
+	/**
+	 * Client settings for external secrets module.
+	 */
+	'external-secrets'?: {
+		/** Whether multiple connections per vault type are enabled. */
+		multipleConnections: boolean;
+		/** Whether project-scoped external secrets are enabled. */
+		forProjects: boolean;
+	};
 };
 
 export type N8nEnvFeatFlagValue = boolean | string | number | undefined;

--- a/packages/cli/src/modules/external-secrets.ee/external-secrets.module.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets.module.ts
@@ -22,6 +22,16 @@ export class ExternalSecretsModule implements ModuleInterface {
 		externalSecretsProxy.setManager(externalSecretsManager);
 	}
 
+	async settings() {
+		const { ExternalSecretsConfig } = await import('./external-secrets.config');
+		const config = Container.get(ExternalSecretsConfig);
+
+		return {
+			multipleConnections: config.externalSecretsMultipleConnections,
+			forProjects: config.externalSecretsForProjects,
+		};
+	}
+
 	@OnShutdown()
 	async shutdown() {
 		const { ExternalSecretsManager } = await import('./external-secrets-manager.ee');

--- a/packages/frontend/editor-ui/src/__tests__/server/endpoints/module.ts
+++ b/packages/frontend/editor-ui/src/__tests__/server/endpoints/module.ts
@@ -2,6 +2,6 @@ import type { Server } from 'miragejs';
 
 export function routesForModuleSettings(server: Server) {
 	server.get('/rest/module-settings', () => {
-		return {};
+		return { data: {} };
 	});
 }

--- a/packages/frontend/editor-ui/src/app/router.ts
+++ b/packages/frontend/editor-ui/src/app/router.ts
@@ -23,7 +23,6 @@ import { MfaRequiredError } from '@n8n/rest-api-client';
 import { useRecentResources } from '@/features/shared/commandBar/composables/useRecentResources';
 import { usePostHog } from '@/app/stores/posthog.store';
 import { TEMPLATE_SETUP_EXPERIENCE } from '@/app/constants/experiments';
-import { useEnvFeatureFlag } from '@/features/shared/envFeatureFlag/useEnvFeatureFlag';
 import { useDynamicCredentials } from '@/features/resolvers/composables/useDynamicCredentials';
 
 const ChangePasswordView = async () =>
@@ -76,12 +75,10 @@ const SamlOnboarding = async () => await import('@/features/settings/sso/views/S
 const SettingsSourceControl = async () =>
 	await import('@/features/integrations/sourceControl.ee/views/SettingsSourceControl.vue');
 const SettingsExternalSecrets = async () => {
-	const { check } = useEnvFeatureFlag();
+	const settingsStore = useSettingsStore();
+	const moduleConfig = settingsStore.moduleSettings['external-secrets'];
 
-	if (
-		check.value('EXTERNAL_SECRETS_FOR_PROJECTS') ||
-		check.value('EXTERNAL_SECRETS_MULTIPLE_CONNECTIONS')
-	) {
+	if (moduleConfig?.multipleConnections || moduleConfig?.forProjects) {
 		return await import(
 			'@/features/integrations/secretsProviders.ee/views/SettingsSecretsProviders.ee.vue'
 		);

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectExternalSecrets.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectExternalSecrets.test.ts
@@ -124,10 +124,13 @@ vi.mock('@/app/composables/useToast', () => ({
 	})),
 }));
 
-vi.mock('@/features/shared/envFeatureFlag/useEnvFeatureFlag', () => ({
-	useEnvFeatureFlag: vi.fn(() => ({
-		check: {
-			value: vi.fn((flag: string) => flag === 'EXTERNAL_SECRETS_FOR_PROJECTS'),
+vi.mock('@/app/stores/settings.store', () => ({
+	useSettingsStore: vi.fn(() => ({
+		moduleSettings: {
+			'external-secrets': {
+				multipleConnections: true,
+				forProjects: true,
+			},
 		},
 	})),
 }));
@@ -444,14 +447,15 @@ describe('ProjectExternalSecrets', () => {
 		});
 
 		it('should not fetch data when feature is disabled', async () => {
-			const { useEnvFeatureFlag } = await import(
-				'@/features/shared/envFeatureFlag/useEnvFeatureFlag'
-			);
-			vi.mocked(useEnvFeatureFlag).mockReturnValue({
-				check: {
-					value: vi.fn(() => false),
+			const { useSettingsStore } = await import('@/app/stores/settings.store');
+			vi.mocked(useSettingsStore).mockReturnValue({
+				moduleSettings: {
+					'external-secrets': {
+						multipleConnections: true,
+						forProjects: false,
+					},
 				},
-			} as unknown as ReturnType<typeof useEnvFeatureFlag>);
+			} as unknown as ReturnType<typeof useSettingsStore>);
 
 			const fetchSpy = vi.spyOn(projectsStore, 'getProjectSecretProviders');
 

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectExternalSecrets.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectExternalSecrets.vue
@@ -7,7 +7,7 @@ import { useSecretsProvidersList } from '@/features/integrations/secretsProvider
 import type { SecretProviderConnection } from '@n8n/api-types';
 import { useUIStore } from '@/app/stores/ui.store';
 import { SECRETS_PROVIDER_CONNECTION_MODAL_KEY, VIEWS } from '@/app/constants';
-import { useEnvFeatureFlag } from '@/features/shared/envFeatureFlag/useEnvFeatureFlag';
+import { useSettingsStore } from '@/app/stores/settings.store';
 import { useRouter } from 'vue-router';
 
 import {
@@ -30,9 +30,9 @@ const router = useRouter();
 const projectsStore = useProjectsStore();
 const uiStore = useUIStore();
 const rbacStore = useRBACStore();
+const settingsStore = useSettingsStore();
 const secretsProviders = useSecretsProvidersList();
 const secretsProviderConnection = useSecretsProviderConnection();
-const envFeatureFlag = useEnvFeatureFlag();
 
 interface ConnectionRow {
 	id: string;
@@ -50,8 +50,8 @@ const expandedConnections = ref<Set<string>>(new Set());
 const currentPage = ref(0);
 const itemsPerPage = ref(5);
 
-const isFeatureEnabled = computed(() =>
-	envFeatureFlag.check.value('EXTERNAL_SECRETS_FOR_PROJECTS'),
+const isFeatureEnabled = computed(
+	() => settingsStore.moduleSettings['external-secrets']?.forProjects ?? false,
 );
 
 // Permissions

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionCard.ee.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionCard.ee.vue
@@ -18,12 +18,13 @@ import ProjectIcon from '@/features/collaboration/projects/components/ProjectIco
 import { splitName } from '@/features/collaboration/projects/projects.utils';
 import type { ProjectListItem } from '@/features/collaboration/projects/projects.types';
 import { isIconOrEmoji, type IconOrEmoji } from '@n8n/design-system/components/N8nIconPicker/types';
-import { useEnvFeatureFlag } from '@/features/shared/envFeatureFlag/useEnvFeatureFlag';
+import { useSettingsStore } from '@/app/stores/settings.store';
 
 const i18n = useI18n();
 const rbacStore = useRBACStore();
-const { check: checkDevFeatureFlag } = useEnvFeatureFlag();
-const isProjectScopedSecretsEnabled = checkDevFeatureFlag.value('EXTERNAL_SECRETS_FOR_PROJECTS');
+const settingsStore = useSettingsStore();
+const isProjectScopedSecretsEnabled =
+	settingsStore.moduleSettings['external-secrets']?.forProjects ?? false;
 
 const props = defineProps<{
 	provider: SecretProviderConnection;

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionModal.ee.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionModal.ee.test.ts
@@ -125,14 +125,6 @@ vi.mock('@/features/collaboration/projects/projects.store', () => ({
 	useProjectsStore: vi.fn(() => mockProjectsStore),
 }));
 
-vi.mock('@/features/shared/envFeatureFlag/useEnvFeatureFlag', () => ({
-	useEnvFeatureFlag: vi.fn(() => ({
-		check: {
-			value: vi.fn((flag: string) => flag === 'EXTERNAL_SECRETS_FOR_PROJECTS'),
-		},
-	})),
-}));
-
 const initialState = {
 	[STORES.UI]: {
 		modalsById: {
@@ -141,6 +133,14 @@ const initialState = {
 			},
 		},
 		modalStack: [SECRETS_PROVIDER_CONNECTION_MODAL_KEY],
+	},
+	[STORES.SETTINGS]: {
+		moduleSettings: {
+			'external-secrets': {
+				multipleConnections: true,
+				forProjects: true,
+			},
+		},
 	},
 };
 

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionModal.ee.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionModal.ee.vue
@@ -36,7 +36,7 @@ import ProjectSharing from '@/features/collaboration/projects/components/Project
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import type { ProjectSharingData } from '@/features/collaboration/projects/projects.types';
 import { useUIStore } from '@/app/stores/ui.store';
-import { useEnvFeatureFlag } from '@/features/shared/envFeatureFlag/useEnvFeatureFlag';
+import { useSettingsStore } from '@/app/stores/settings.store';
 import Banner from '@/app/components/Banner.vue';
 
 // Props
@@ -65,7 +65,7 @@ const { confirm } = useMessage();
 const eventBus = createEventBus();
 const projectsStore = useProjectsStore();
 const uiStore = useUIStore();
-const { check: checkDevFeatureFlag } = useEnvFeatureFlag();
+const settingsStore = useSettingsStore();
 
 // Constants
 const LABEL_SIZE: IParameterLabel = { size: 'medium' };
@@ -85,7 +85,8 @@ const modal = useConnectionModal({
 });
 
 const tabNavigationEnabled =
-	checkDevFeatureFlag.value('EXTERNAL_SECRETS_FOR_PROJECTS') && modal.canShareGlobally.value;
+	(settingsStore.moduleSettings['external-secrets']?.forProjects ?? false) &&
+	modal.canShareGlobally.value;
 
 const ACTIVE_TAB = computed({
 	get: () => (tabNavigationEnabled ? internalActiveTab.value : 'connection'),

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useConnectionModal.ee.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useConnectionModal.ee.ts
@@ -10,7 +10,7 @@ import type { Scope } from '@n8n/permissions';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import type { ProjectSharingData } from '@/features/collaboration/projects/projects.types';
 import { isComponentPublicInstance } from '@/app/utils/typeGuards';
-import { useEnvFeatureFlag } from '@/features/shared/envFeatureFlag/useEnvFeatureFlag';
+import { useSettingsStore } from '@/app/stores/settings.store';
 
 export type ConnectionProjectSummary = { id: string; name: string };
 
@@ -39,7 +39,7 @@ export function useConnectionModal(options: UseConnectionModalOptions) {
 	const rbacStore = useRBACStore();
 	const toast = useToast();
 	const projectsStore = useProjectsStore();
-	const { check: checkDevFeatureFlag } = useEnvFeatureFlag();
+	const settingsStore = useSettingsStore();
 
 	// State
 	const providerKey = ref<string | undefined>(options.providerKey?.value);
@@ -157,7 +157,7 @@ export function useConnectionModal(options: UseConnectionModalOptions) {
 			value: type.type,
 		}));
 
-		if (checkDevFeatureFlag.value('EXTERNAL_SECRETS_MULTIPLE_CONNECTIONS')) {
+		if (settingsStore.moduleSettings['external-secrets']?.multipleConnections) {
 			// infisical has been deprecated for a long time.
 			// In order to be able to fully remove the code for it
 			// we are no longer showing users the option to create connections to infisical.

--- a/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/completions/datatype.completions.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/completions/datatype.completions.ts
@@ -65,7 +65,7 @@ import {
 import { javascriptLanguage } from '@codemirror/lang-javascript';
 import { isPairedItemIntermediateNodesError } from '@/app/utils/expressions';
 import type { TargetNodeParameterContext } from '@/Interface';
-import { useEnvFeatureFlag } from '@/features/shared/envFeatureFlag/useEnvFeatureFlag';
+import { useSettingsStore } from '@/app/stores/settings.store';
 
 /**
  * Resolution-based completions offered according to datatype.
@@ -1270,7 +1270,7 @@ export const secretOptions = (base: string) => {
 
 export const secretProvidersOptions = () => {
 	const externalSecretsStore = useExternalSecretsStore();
-	const { check } = useEnvFeatureFlag();
+	const settingsStore = useSettingsStore();
 
 	const externalSecretProviderToOption = (provider: string, section?: 'global' | 'project') => {
 		const doc: DocMetadata = {
@@ -1280,8 +1280,6 @@ export const secretProvidersOptions = () => {
 			docURL: i18n.baseText('settings.externalSecrets.docs'),
 		};
 		if (section) {
-			// group will be undefined if project secret development feature flag is disabled
-			// TODO: make group param mandatory once feature flag is removed
 			doc.section = section;
 			doc.description = i18n.baseText(
 				`codeNodeEditor.completer.$secrets.group.${section}.description`,
@@ -1294,7 +1292,8 @@ export const secretProvidersOptions = () => {
 		});
 	};
 
-	const projectSecretsEnabled = check.value('EXTERNAL_SECRETS_FOR_PROJECTS');
+	const projectSecretsEnabled =
+		settingsStore.moduleSettings['external-secrets']?.forProjects ?? false;
 	if (!projectSecretsEnabled) {
 		return Object.keys(externalSecretsStore.secretsAsObject).map((provider) =>
 			externalSecretProviderToOption(provider),


### PR DESCRIPTION
## Summary

Replaces `useEnvFeatureFlag` checks (`EXTERNAL_SECRETS_FOR_PROJECTS`, `EXTERNAL_SECRETS_MULTIPLE_CONNECTIONS`) with backend-driven module settings exposed via `settingsStore.moduleSettings['external-secrets']`.


## How to test

**env vars**
- `N8N_ENV_FEAT_EXTERNAL_SECRETS_FOR_PROJECTS`
- `N8N_ENV_FEAT_EXTERNAL_SECRETS_MULTIPLE_CONNECTIONS`

### Without env vars  

1. Start n8n without any of the environment variable listed above set
2. Check that multi-connection is enabled by default  

- The new external external settings page should be displayed by default
- You should be able to create a new connection
- You should be able to use connection secrets in credentials

### With  `N8N_ENV_FEAT_EXTERNAL_SECRETS_MULTIPLE_CONNECTIONS` set to `false`


1. Start n8n with `N8N_ENV_FEAT_EXTERNAL_SECRETS_MULTIPLE_CONNECTIONS` set to `false`
2. Check that multi-connection is disabled

- You should see the old external settings page (with the five static providers and the "set up" button)
- You should still be able to use secrets in credentials

### With  `N8N_ENV_FEAT_EXTERNAL_SECRETS_FOR_PROJECTS` set to `true`


1. Start n8n with `N8N_ENV_FEAT_EXTERNAL_SECRETS_FOR_PROJECTS` set to `false`
2. Check that project-scope feature is enabled

- You should be able to share external secrets with project and see the external secrets section in the project settings tab

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-280

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)