### PR TITLE
fix(editor): Resolve credential modal expressions without workflow co…

### DIFF
--- a/packages/frontend/editor-ui/src/features/shared/editors/composables/useExpressionEditor.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/composables/useExpressionEditor.ts
@@ -32,6 +32,7 @@ import { highlighter } from '../plugins/codemirror/resolvableHighlighter';
 import { closeCursorInfoBox } from '../plugins/codemirror/tooltips/InfoBoxTooltip';
 import type { Html, Plaintext, RawSegment, Resolvable, Segment } from '@/app/types/expressions';
 import { getExpressionErrorMessage, getResolvableState } from '@/app/utils/expressions';
+import { isCredentialsModalOpen } from '../plugins/codemirror/completions/utils';
 import { closeCompletion, completionStatus } from '@codemirror/autocomplete';
 import {
 	Compartment,
@@ -354,7 +355,10 @@ export const useExpressionEditor = ({
 					...expressionLocalResolveContext.value,
 					additionalKeys: toValue(additionalData),
 				});
-			} else if (!ndvStore.activeNode && toValue(targetNodeParameterContext) === undefined) {
+			} else if (
+				isCredentialsModalOpen() ||
+				(!ndvStore.activeNode && toValue(targetNodeParameterContext) === undefined)
+			) {
 				// e.g. credential modal
 				result.resolved = Expression.resolveWithoutWorkflow(resolvable, toValue(additionalData));
 			} else {


### PR DESCRIPTION
…ntext

## Summary

When the credentials modal is opened from the NDV (which sets an active node), expressions like $secrets were incorrectly resolved using the workflow context instead of resolveWithoutWorkflow. This happened because the condition only checked for the absence of an active node, which is never true when the modal is opened from the NDV.

Add an explicit isCredentialsModalOpen() check so credential expressions always use resolveWithoutWorkflow, regardless of whether an active node exists.

<img width="525" height="364" alt="Screenshot 2026-02-24 at 14 38 23" src="https://github.com/user-attachments/assets/eb9d788e-87f9-4ae4-b20a-d34d505eb326" />


## Related Linear tickets, Github issues, and Community forum posts

Fixes [LIGO-241](https://linear.app/n8n/issue/LIGO-241/fe-bug-bash-secrets-that-are-resolved-show-as-red)


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
