### PR TITLE
fix(design-system): prevent IME Enter from submitting inline and prompt inputs

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nInlineTextEdit/InlineTextEdit.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInlineTextEdit/InlineTextEdit.test.ts
@@ -1,3 +1,4 @@
+import { fireEvent } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 
 import { createComponentRenderer } from '@n8n/design-system/__tests__/render';
@@ -55,6 +56,27 @@ describe('N8nInlineTextEdit', () => {
 		await userEvent.keyboard('{Enter}');
 
 		expect(preview).toHaveTextContent('Test Value');
+	});
+
+	it('should not submit on Enter during IME composition', async () => {
+		const wrapper = renderComponent({
+			props: {
+				modelValue: 'Test Value',
+			},
+		});
+		const preview = wrapper.getByTestId('inline-edit-preview');
+
+		await userEvent.click(preview);
+		const input = wrapper.getByTestId('inline-edit-input');
+
+		await userEvent.clear(input);
+		await userEvent.type(input, '猫');
+		const emittedCountBeforeEnter = wrapper.emitted('update:model-value')?.length ?? 0;
+		await fireEvent.keyDown(input, { key: 'Enter', isComposing: true });
+
+		const emittedCountAfterEnter = wrapper.emitted('update:model-value')?.length ?? 0;
+		expect(emittedCountAfterEnter).toBe(emittedCountBeforeEnter);
+		expect(input).toHaveFocus();
 	});
 
 	it('should display changes to props.modelValue', async () => {

--- a/packages/frontend/@n8n/design-system/src/components/N8nInlineTextEdit/InlineTextEdit.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInlineTextEdit/InlineTextEdit.vue
@@ -30,6 +30,7 @@ const measureSpan = useTemplateRef('measureSpan');
 
 // Internal editing value
 const editingValue = ref(props.modelValue);
+const isComposing = ref(false);
 
 // Content for width calculation
 const displayContent = computed(() => editingValue.value || props.placeholder);
@@ -77,6 +78,28 @@ function onSubmit() {
 
 function onInput(value: string) {
 	editingValue.value = value;
+}
+
+function onCompositionStart() {
+	isComposing.value = true;
+}
+
+function onCompositionEnd() {
+	isComposing.value = false;
+}
+
+function onKeyDown(event: KeyboardEvent) {
+	const isComposingEnter = event.key === 'Enter' && (event.isComposing || isComposing.value);
+	const isLegacyComposingEnter = event.key === 'Enter' && event.keyCode === 229;
+
+	if (!isComposingEnter && !isLegacyComposingEnter) {
+		return;
+	}
+
+	// Prevent EditableRoot submit while the IME is confirming composition.
+	event.preventDefault();
+	event.stopPropagation();
+	event.stopImmediatePropagation();
 }
 
 function onStateChange(state: string) {
@@ -127,7 +150,10 @@ defineExpose({ forceFocus, forceCancel });
 				data-test-id="inline-edit-input"
 				:style="computedInlineStyles"
 				@input="onInput($event.target.value)"
+				@keydown.capture="onKeyDown"
 				@keydown.space.stop
+				@compositionstart="onCompositionStart"
+				@compositionend="onCompositionEnd"
 			/>
 		</EditableArea>
 	</EditableRoot>

--- a/packages/frontend/@n8n/design-system/src/components/N8nPromptInput/N8nPromptInput.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nPromptInput/N8nPromptInput.test.ts
@@ -244,6 +244,22 @@ describe('N8nPromptInput', () => {
 			expect(render.emitted('submit')).toBeTruthy();
 		});
 
+		it('should not emit submit on Enter during IME composition', async () => {
+			const render = renderComponent({
+				props: {
+					modelValue: 'Test message',
+				},
+				global: {
+					stubs: ['N8nCallout', 'N8nScrollArea', 'N8nSendStopButton'],
+				},
+			});
+
+			const textarea = render.container.querySelector('textarea') as HTMLTextAreaElement;
+			await fireEvent.keyDown(textarea, { key: 'Enter', isComposing: true });
+
+			expect(render.emitted('submit')).toBeFalsy();
+		});
+
 		it('should emit submit on Ctrl+Enter', async () => {
 			const render = renderComponent({
 				props: {

--- a/packages/frontend/@n8n/design-system/src/components/N8nPromptInput/N8nPromptInput.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nPromptInput/N8nPromptInput.vue
@@ -269,7 +269,7 @@ async function handleKeyDown(event: KeyboardEvent) {
 	const isPrintableChar = event.key.length === 1 && !hasModifier;
 	const isDeletionKey = event.key === 'Backspace' || event.key === 'Delete';
 	const atMaxLength = characterCount.value >= props.maxLength;
-	const isSubmitKey = event.key === 'Enter' && !event.shiftKey;
+	const isSubmitKey = event.key === 'Enter' && !event.shiftKey && !event.isComposing;
 	const isNewlineKey = event.key === 'Enter' && event.shiftKey;
 
 	// Prevent adding characters if at max length (but allow deletions/navigation)


### PR DESCRIPTION
## Summary

Fixes IME composition handling for Enter key in design-system inputs.

- `N8nPromptInput`: Do not submit when `Enter` is pressed during IME composition (`event.isComposing`).
- `N8nInlineTextEdit`: Do not commit/blur on IME confirm Enter.
  - Added composition state handling (`compositionstart` / `compositionend`).
  - Added capture-phase keydown guard to stop internal editable submit on composing Enter.
- Added regression tests for both components.

### How to test

1. Run:
   - `pnpm --filter @n8n/design-system test src/components/N8nPromptInput/N8nPromptInput.test.ts src/components/N8nInlineTextEdit/InlineTextEdit.test.ts`
2. Manual check:
   - In prompt input, Japanese kana conversion `Enter` should confirm composition only (no submit).
   - In inline edit input (`data-test-id="inline-edit-input"`), Japanese kana conversion `Enter` should not commit or lose focus.

<img width="1130" height="636" alt="CleanShot 2026-02-24 at 23 35 35@2x" src="https://github.com/user-attachments/assets/40efad15-0820-424c-8e50-01eac6cc749f" />


## Related Linear tickets, Github issues, and Community forum posts

- Fixes #26192
- https://github.com/n8n-io/n8n/issues/26192

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
