### PR TITLE
fix(ai-builder): Fix chat fade, keyboard   shortcuts, node tidy-up, and feedback styling

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
@@ -741,19 +741,6 @@ defineExpose({
 	code {
 		text-wrap: wrap;
 	}
-
-	// Add a gradient fade at the bottom of the messages area
-	&::after {
-		content: '';
-		position: absolute;
-		bottom: 0;
-		left: 0;
-		right: var(--spacing--xs);
-		height: var(--spacing--md);
-		background: linear-gradient(to bottom, transparent 0%, var(--color--background--light-2) 100%);
-		pointer-events: none;
-		z-index: 1;
-	}
 }
 
 .placeholder {
@@ -845,10 +832,7 @@ defineExpose({
 .feedbackWrapper {
 	display: flex;
 	justify-content: start;
-	padding: 0 var(--spacing--2xs) var(--spacing--2xs) var(--spacing--2xs);
-	border-left: var(--border);
-	border-right: var(--border);
-	background-color: var(--color--background--light-2);
+	padding: var(--spacing--2xs);
 }
 
 .inputHeaderWrapper {

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
@@ -651,9 +651,9 @@ defineExpose({
 					</div>
 				</template>
 			</div>
-		</div>
-		<div v-if="showFooterRating" :class="$style.feedbackWrapper" data-test-id="footer-rating">
-			<MessageRating minimal @feedback="onRateMessage" />
+			<div v-if="showFooterRating" :class="$style.feedbackWrapper" data-test-id="footer-rating">
+				<MessageRating minimal @feedback="onRateMessage" />
+			</div>
 		</div>
 		<div
 			v-if="$slots.inputHeader && (showBottomInput || showSuggestions)"
@@ -707,7 +707,6 @@ defineExpose({
 	position: relative;
 	display: grid;
 	grid-template-rows: auto 1fr auto;
-	background-color: var(--color--background--light-2);
 }
 
 .header {
@@ -770,7 +769,7 @@ defineExpose({
 
 .messagesContent {
 	padding: var(--spacing--xs);
-	padding-bottom: var(--spacing--lg);
+	padding-bottom: var(--spacing--3xl);
 
 	// Override p line-height from reset.scss (1.8) to use chat standard (1.5)
 	:global(p) {
@@ -830,9 +829,19 @@ defineExpose({
 }
 
 .feedbackWrapper {
+	position: absolute;
+	bottom: 0;
+	left: 0;
 	display: flex;
 	justify-content: start;
 	padding: var(--spacing--2xs);
+	z-index: 1;
+
+	&:has([data-feedback-expanded]) {
+		right: 0;
+		padding-top: 0;
+		background-color: var(--color--background--light-2);
+	}
 }
 
 .inputHeaderWrapper {
@@ -841,7 +850,7 @@ defineExpose({
 	width: 100%;
 	border-left: var(--border);
 	border-right: var(--border);
-	background-color: transparent;
+	background-color: var(--color--background--light-2);
 
 	> :first-child {
 		width: 90%;
@@ -850,7 +859,7 @@ defineExpose({
 
 .inputWrapper {
 	padding: var(--spacing--4xs) var(--spacing--2xs) var(--spacing--xs);
-	background-color: transparent;
+	background-color: var(--color--background--light-2);
 	width: 100%;
 	position: relative;
 	border-left: var(--border);

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/__snapshots__/AskAssistantChat.test.ts.snap
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/__snapshots__/AskAssistantChat.test.ts.snap
@@ -76,8 +76,8 @@ exports[`AskAssistantChat > limits maximum input length when maxCharacterLength 
         </div>
         
       </div>
+      <!--v-if-->
     </div>
-    <!--v-if-->
     <!--v-if-->
     <div
       class="inputWrapper"
@@ -320,8 +320,8 @@ exports[`AskAssistantChat > renders chat with messages correctly 1`] = `
           
         </div>
       </div>
+      <!--v-if-->
     </div>
-    <!--v-if-->
     <!--v-if-->
     <div
       class="inputWrapper"
@@ -421,8 +421,8 @@ exports[`AskAssistantChat > renders default placeholder chat correctly 1`] = `
         </div>
         
       </div>
+      <!--v-if-->
     </div>
-    <!--v-if-->
     <!--v-if-->
     <div
       class="inputWrapper"
@@ -574,8 +574,8 @@ exports[`AskAssistantChat > renders end of session chat correctly 1`] = `
           
         </div>
       </div>
+      <!--v-if-->
     </div>
-    <!--v-if-->
     <!--v-if-->
     <div
       class="inputWrapper disabledInput"
@@ -708,8 +708,8 @@ exports[`AskAssistantChat > renders error message correctly with retry button 1`
           
         </div>
       </div>
+      <!--v-if-->
     </div>
-    <!--v-if-->
     <!--v-if-->
     <div
       class="inputWrapper"
@@ -842,8 +842,8 @@ exports[`AskAssistantChat > renders message with code snippet 1`] = `
           
         </div>
       </div>
+      <!--v-if-->
     </div>
-    <!--v-if-->
     <!--v-if-->
     <div
       class="inputWrapper"
@@ -976,8 +976,8 @@ exports[`AskAssistantChat > renders streaming chat correctly 1`] = `
           
         </div>
       </div>
+      <!--v-if-->
     </div>
-    <!--v-if-->
     <!--v-if-->
     <div
       class="inputWrapper"

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/MessageRating.vue
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/MessageRating.vue
@@ -199,6 +199,7 @@ function onCancelFeedback() {
 
 	.feedbackContainer {
 		gap: var(--spacing--3xs);
+		padding-top: var(--spacing--2xs);
 	}
 
 	.feedbackInput {

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/MessageRating.vue
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/MessageRating.vue
@@ -63,7 +63,10 @@ function onCancelFeedback() {
 </script>
 
 <template>
-	<div :class="[$style.rating, { [$style.minimal]: minimal }]">
+	<div
+		:class="[$style.rating, { [$style.minimal]: minimal }]"
+		:data-feedback-expanded="showFeedbackArea || undefined"
+	>
 		<div v-if="showRatingButtons" :class="$style.buttons">
 			<template v-if="!minimal">
 				<N8nButton
@@ -185,10 +188,16 @@ function onCancelFeedback() {
 
 /* Minimal style specific */
 .minimal {
-	margin-top: var(--spacing--5xs);
+	margin-top: 0;
+	gap: 0;
 
 	.buttons {
 		gap: var(--spacing--5xs);
+		border: var(--border);
+		border-radius: var(--radius--lg);
+		padding: var(--spacing--4xs);
+		background-color: var(--color--background--light-2);
+		width: fit-content;
 	}
 
 	.ratingButton {
@@ -199,7 +208,6 @@ function onCancelFeedback() {
 
 	.feedbackContainer {
 		gap: var(--spacing--3xs);
-		padding-top: var(--spacing--2xs);
 	}
 
 	.feedbackInput {

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.test.ts
@@ -716,7 +716,7 @@ describe('useWorkflowUpdate', () => {
 				});
 			});
 
-			it('should not emit tidyUp event when there are no structural changes', async () => {
+			it('should emit tidyUp event even when there are no structural changes', async () => {
 				const existingNode = createTestNode({
 					id: 'node-1',
 					name: 'HTTP Request',
@@ -749,7 +749,13 @@ describe('useWorkflowUpdate', () => {
 					connections: {},
 				});
 
-				expect(canvasEventBusEmitMock).not.toHaveBeenCalled();
+				expect(canvasEventBusEmitMock).toHaveBeenCalledWith('tidyUp', {
+					source: 'builder-update',
+					nodeIdsFilter: undefined,
+					trackEvents: false,
+					trackHistory: true,
+					trackBulk: false,
+				});
 			});
 		});
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
@@ -385,10 +385,7 @@ export function useWorkflowUpdate() {
 
 			builderStore.setBuilderMadeEdits(true);
 
-			const hasStructuralChanges = nodesToAdd.length > 0 || nodesToRemove.length > 0;
-			if (hasStructuralChanges) {
-				tidyUpNodes();
-			}
+			tidyUpNodes();
 
 			return { success: true, newNodeIds };
 		} catch (error) {

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/AskAssistantBuild.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/AskAssistantBuild.vue
@@ -425,11 +425,12 @@ watch(
 
 		// Tidy up all nodes and zoom to fit after generation completes
 		if (accumulatedNodeIdsToTidyUp.value.length > 0) {
+			accumulatedNodeIdsToTidyUp.value = [];
 			await nextTick();
 			canvasEventBus.emit('tidyUp', {
 				source: 'builder-update',
 				trackEvents: false,
-				trackHistory: true,
+				trackHistory: false,
 				trackBulk: false,
 			});
 			await nextTick();

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/AskAssistantBuild.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/AskAssistantBuild.vue
@@ -423,8 +423,15 @@ watch(
 			builderStore.initialGeneration = false;
 		}
 
-		// Zoom to fit all nodes after generation completes
+		// Tidy up all nodes and zoom to fit after generation completes
 		if (accumulatedNodeIdsToTidyUp.value.length > 0) {
+			await nextTick();
+			canvasEventBus.emit('tidyUp', {
+				source: 'builder-update',
+				trackEvents: false,
+				trackHistory: true,
+				trackBulk: false,
+			});
 			await nextTick();
 			canvasEventBus.emit('fitView');
 		}

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
@@ -921,7 +921,7 @@ function onFilesDropped(files: File[]) {
 		left: 0;
 		width: 100%;
 		padding-block: var(--spacing--md);
-		background: linear-gradient(transparent 0%, var(--color--background--light-2) 30%);
+		background: var(--color--background--light-2);
 	}
 }
 

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
@@ -65,7 +65,6 @@ import { useExperimentalNdvStore } from '../experimental/experimentalNdv.store';
 import { type ContextMenuAction } from '@/features/shared/contextMenu/composables/useContextMenuItems';
 import { useFocusedNodesStore } from '@/features/ai/assistant/focusedNodes.store';
 import { useChatPanelStore } from '@/features/ai/assistant/chatPanel.store';
-import { useChatPanelStateStore } from '@/features/ai/assistant/chatPanelState.store';
 import { useSetupPanelStore } from '@/features/setupPanel/setupPanel.store';
 
 const $style = useCssModule();
@@ -164,7 +163,6 @@ const { isMobileDevice, controlKeyCode } = useDeviceSupport();
 const experimentalNdvStore = useExperimentalNdvStore();
 const focusedNodesStore = useFocusedNodesStore();
 const chatPanelStore = useChatPanelStore();
-const chatPanelStateStore = useChatPanelStateStore();
 const setupPanelStore = useSetupPanelStore();
 
 const isExperimentalNdvActive = computed(() => experimentalNdvStore.isActive(viewport.value.zoom));
@@ -448,7 +446,6 @@ function onNodeDragStop(event: NodeDragEvent) {
 function onNodeClick({ event, node }: NodeMouseEvent) {
 	if (chatPanelStore.isOpen && focusedNodesStore.isFeatureEnabled) {
 		focusedNodesStore.confirmNodes([node.id], 'canvas_selection');
-		chatPanelStateStore.focusRequested++;
 	}
 
 	emit('click:node', node.id, getProjectedPosition(event));


### PR DESCRIPTION
## Summary

- Remove gradient fade from chat messages area and prompt container background (AI-2097)
- Stop stealing focus to chat input when clicking canvas nodes, so keyboard shortcuts (copy/paste/delete) work while WFB is open (AI-2100)
- Run tidy-up on every workflow update and add final tidy-up when streaming ends so nodes stay arranged during generation (AI-2101)
- Remove full-width background/borders from feedback icons wrapper and add top padding to expanded feedback form

Addresses: https://linear.app/n8n/issue/AI-2101/bug-tidy-up-of-nodes-after-wfb-finishes-not-working-correctly
Addresses: https://linear.app/n8n/issue/AI-2100/bug-copypaste-keyboard-shortcuts-in-general-captured-by-wfb
Addresses: https://linear.app/n8n/issue/AI-2097/bug-wfb-chat-remove-fade-as-hard-borders-make-it-un-necessary

## Screenshots
<img width="804" height="1460" alt="image" src="https://github.com/user-attachments/assets/80f68070-c4f3-4bb0-8e6a-76357d5e824c" />
<img width="800" height="458" alt="image" src="https://github.com/user-attachments/assets/0fab12f4-c143-455d-b7a9-90535d9f2f00" />
<img width="800" height="738" alt="image" src="https://github.com/user-attachments/assets/3748ba04-3e92-4499-9710-6dab53443ae0" />

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
