### PR TITLE
fix(core): Handle unencoded percent signs in Content-Disposition filenames

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/parse-incoming-message.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/parse-incoming-message.test.ts
@@ -146,6 +146,16 @@ describe('parseContentDisposition', () => {
 			expected: { type: 'attachment', filename: 'test.txt' },
 			description: 'should handle multiple parameters',
 		},
+		{
+			input: 'attachment; filename="my_scan_144dpi_75%.pdf"',
+			expected: { type: 'attachment', filename: 'my_scan_144dpi_75%.pdf' },
+			description: 'should handle filename with unencoded percent sign',
+		},
+		{
+			input: 'attachment; filename="report_100%_done.xlsx"',
+			expected: { type: 'attachment', filename: 'report_100%_done.xlsx' },
+			description: 'should handle filename with percent sign followed by non-hex chars',
+		},
 	];
 
 	test.each(testCases)('$description', ({ input, expected }) => {
@@ -246,6 +256,21 @@ describe('parseIncomingMessage', () => {
 
 		expect(message.contentDisposition).toEqual({
 			filename: 'screenshot (1).png',
+			type: 'attachment',
+		});
+	});
+
+	it('parses content-disposition with unencoded percent in filename', () => {
+		const message = mock<IncomingMessage>({
+			headers: {
+				'content-type': undefined,
+				'content-disposition': 'attachment; filename="my_scan_144dpi_75%.pdf"',
+			},
+		});
+		parseIncomingMessage(message);
+
+		expect(message.contentDisposition).toEqual({
+			filename: 'my_scan_144dpi_75%.pdf',
 			type: 'attachment',
 		});
 	});

--- a/packages/core/src/execution-engine/node-execution-context/utils/parse-incoming-message.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/parse-incoming-message.ts
@@ -1,10 +1,26 @@
 import type { IncomingMessage } from 'http';
 
+/**
+ * Safely decodes a URI component, returning the original value if decoding fails
+ * (e.g. when the value contains a literal '%' that is not part of a percent-encoded sequence)
+ */
+function safeDecodeURIComponent(value: string): string {
+	try {
+		return decodeURIComponent(value);
+	} catch {
+		return value;
+	}
+}
+
+/**
+ * Parses header parameters (e.g. from Content-Type or Content-Disposition) into a key-value object
+ * @returns {Record<string, string>} Parsed parameter key-value pairs with trimmed, lowercased keys
+ */
 function parseHeaderParameters(parameters: string[]): Record<string, string> {
 	return parameters.reduce(
 		(acc, param) => {
 			const [key, value] = param.split('=');
-			let decodedValue = decodeURIComponent(value).trim();
+			let decodedValue = safeDecodeURIComponent(value).trim();
 			if (decodedValue.startsWith('"') && decodedValue.endsWith('"')) {
 				decodedValue = decodedValue.slice(1, -1);
 			}


### PR DESCRIPTION
## Summary

Wrap `decodeURIComponent` in a try-catch within `parseHeaderParameters` so that filenames containing literal `%` characters (e.g. `my_scan_144dpi_75%.pdf`) no longer throw a `URIError: URI malformed` error. When decoding fails, the original value is returned as-is.

## Related Linear tickets, Github issues, and Community forum posts

Fixes https://github.com/n8n-io/n8n/issues/26031

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)