### PR TITLE
test: Janitor tsx shortcut, docs cleanup, dead code removal

### DIFF
--- a/packages/testing/playwright/.janitor-baseline.json
+++ b/packages/testing/playwright/.janitor-baseline.json
@@ -1,7 +1,7 @@
 {
 	"version": 1,
-	"generated": "2026-02-02T19:07:20.088Z",
-	"totalViolations": 571,
+	"generated": "2026-02-24T22:17:42.106Z",
+	"totalViolations": 552,
 	"violations": {
 		"pages/AIAssistantPage.ts": [
 			{
@@ -33,18 +33,6 @@
 				"line": 9,
 				"message": "ChatHubChatPage: Ambiguous page - add a container (for scoped components) or a navigation method (for top-level pages)",
 				"hash": "e4eaeac24146"
-			},
-			{
-				"rule": "dead-code",
-				"line": 117,
-				"message": "Unused method: ChatHubChatPage.clickNextAlternativeButtonAt()",
-				"hash": "fda92980d389"
-			},
-			{
-				"rule": "dead-code",
-				"line": 136,
-				"message": "Unused method: ChatHubChatPage.getAttachButton()",
-				"hash": "ac2bd8e54358"
 			}
 		],
 		"pages/ChatHubPersonalAgentsPage.ts": [
@@ -56,19 +44,13 @@
 			},
 			{
 				"rule": "deduplication",
-				"line": 8,
-				"message": "Duplicate locator: this.page.getByTestId(\"agentEditorModal-modal\") in pages scope",
-				"hash": "9c085627d33a"
-			},
-			{
-				"rule": "deduplication",
-				"line": 24,
+				"line": 22,
 				"message": "Duplicate locator: this.page.getByTestId(\"chat-agent-card\") in pages scope",
 				"hash": "93472d766ead"
 			},
 			{
 				"rule": "deduplication",
-				"line": 28,
+				"line": 26,
 				"message": "Duplicate locator: this.page.getByTestId(\"chat-agent-card\") in pages scope",
 				"hash": "93472d766ead"
 			}
@@ -668,37 +650,55 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 677,
+				"line": 669,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 713,
+				"line": 705,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 717,
+				"line": 709,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 722,
+				"line": 714,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 727,
+				"line": 719,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 731,
+				"line": 723,
+				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "5244a408a8df"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 734,
+				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "5244a408a8df"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 738,
+				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "5244a408a8df"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 738,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
@@ -710,25 +710,19 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 746,
+				"line": 748,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 746,
+				"line": 776,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 750,
-				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "5244a408a8df"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 756,
+				"line": 780,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
@@ -746,37 +740,37 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 792,
+				"line": 793,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 796,
+				"line": 799,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 801,
+				"line": 803,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 807,
-				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "5244a408a8df"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 811,
+				"line": 803,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
 				"line": 811,
+				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "5244a408a8df"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 815,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
@@ -788,39 +782,15 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 823,
+				"line": 851,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 827,
+				"line": 855,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 859,
-				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "5244a408a8df"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 863,
-				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "5244a408a8df"
-			},
-			{
-				"rule": "dead-code",
-				"line": 424,
-				"message": "Unused method: NodeDetailsViewPage.getParameterInputContainer()",
-				"hash": "fcd6fe5c28c8"
-			},
-			{
-				"rule": "dead-code",
-				"line": 655,
-				"message": "Unused method: NodeDetailsViewPage.searchInputData()",
-				"hash": "c4d72de4f9fd"
 			}
 		],
 		"pages/NotificationsPage.ts": [
@@ -863,14 +833,6 @@
 				"hash": "f334f4d128a2"
 			}
 		],
-		"pages/SettingsPersonalPage.ts": [
-			{
-				"rule": "scope-lockdown",
-				"line": 8,
-				"message": "SettingsPersonalPage: Ambiguous page - add a container (for scoped components) or a navigation method (for top-level pages)",
-				"hash": "ea35206b3713"
-			}
-		],
 		"pages/SettingsUsersPage.ts": [
 			{
 				"rule": "scope-lockdown",
@@ -885,14 +847,6 @@
 				"line": 3,
 				"message": "SidebarPage: Ambiguous page - add a container (for scoped components) or a navigation method (for top-level pages)",
 				"hash": "6a6e1341c8f5"
-			}
-		],
-		"pages/SignInPage.ts": [
-			{
-				"rule": "scope-lockdown",
-				"line": 5,
-				"message": "SignInPage: Ambiguous page - add a container (for scoped components) or a navigation method (for top-level pages)",
-				"hash": "1cc558fbab29"
 			}
 		],
 		"pages/SourceControlPullModal.ts": [
@@ -953,20 +907,6 @@
 				"line": 3,
 				"message": "VersionsPage: Ambiguous page - add a container (for scoped components) or a navigation method (for top-level pages)",
 				"hash": "06f7a26b38d8"
-			}
-		],
-		"pages/WorkerViewPage.ts": [
-			{
-				"rule": "scope-lockdown",
-				"line": 3,
-				"message": "WorkerViewPage: Ambiguous page - add a container (for scoped components) or a navigation method (for top-level pages)",
-				"hash": "d235aee41517"
-			},
-			{
-				"rule": "deduplication",
-				"line": 13,
-				"message": "Duplicate locator: this.page.getByTestId(\"menu-item\") in pages scope",
-				"hash": "d2fda13bfcbe"
 			}
 		],
 		"pages/WorkflowActivationModal.ts": [
@@ -1212,7 +1152,7 @@
 		"tests/e2e/ai/assistant-basic.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 162,
+				"line": 166,
 				"message": "Chained locator call in test: n8n.aiAssistant .getNewAssistantSessionModal() .getByRole...",
 				"hash": "8a89adbe00d9"
 			}
@@ -1220,25 +1160,25 @@
 		"tests/e2e/ai/assistant-credential-help.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 29,
-				"message": "Chained locator call in test: n8n.aiAssistant.getCredentialEditAssistantButton().locato...",
-				"hash": "3ea859fe5518"
+				"line": 34,
+				"message": "Chained locator call in test: n8n.aiAssistant .getCredentialEditAssistantButton() .loca...",
+				"hash": "2544eec958d1"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 54,
-				"message": "Chained locator call in test: n8n.aiAssistant.getCredentialEditAssistantButton().locato...",
-				"hash": "3ea859fe5518"
+				"line": 61,
+				"message": "Chained locator call in test: n8n.aiAssistant .getCredentialEditAssistantButton() .loca...",
+				"hash": "2544eec958d1"
 			},
 			{
 				"rule": "api-purity",
-				"line": 75,
+				"line": 84,
 				"message": "Raw API call detected: fetch(",
 				"hash": "b52df352569e"
 			},
 			{
 				"rule": "api-purity",
-				"line": 118,
+				"line": 126,
 				"message": "Raw API call detected: fetch(",
 				"hash": "b52df352569e"
 			}
@@ -1252,31 +1192,31 @@
 			},
 			{
 				"rule": "selector-purity",
-				"line": 83,
+				"line": 87,
 				"message": "Direct page locator call: n8n.page.getByTestId('add-connection-button')",
 				"hash": "e87a57e25440"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 112,
+				"line": 116,
 				"message": "Chained locator call in test: n8n.ndv.getParameterInput('description').locator('textarea')",
 				"hash": "00a4addafb63"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 138,
+				"line": 142,
 				"message": "Direct page locator call: n8n.page.getByTestId('canvas-chat').getByText('Approve')",
 				"hash": "158ef58d883a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 138,
+				"line": 142,
 				"message": "Chained locator call in test: n8n.page.getByTestId('canvas-chat').getByText('Approve')",
 				"hash": "9717a7a385c3"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 138,
+				"line": 142,
 				"message": "Direct page locator call: n8n.page.getByTestId('canvas-chat')",
 				"hash": "0810223b0675"
 			}
@@ -1284,55 +1224,55 @@
 		"tests/e2e/ai/langchain-memory.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 88,
+				"line": 92,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Define below' }).cl...",
 				"hash": "39e5d44a50a7"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 88,
+				"line": 92,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Define below' })",
 				"hash": "5c42d41d0397"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 89,
+				"line": 93,
 				"message": "Chained locator call in test: n8n.ndv.getParameterInput('sessionKey').locator('input')",
 				"hash": "4860c40ad30b"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 103,
+				"line": 107,
 				"message": "Chained locator call in test: n8n.ndv.getAiOutputModeToggle().locator('[role=\"radio\"]')",
 				"hash": "712bf333eaaf"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 111,
+				"line": 115,
 				"message": "Chained locator call in test: n8n.ndv.getOutputPanel().getByTestId('node-error-message')",
 				"hash": "9436eb5e9511"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 114,
+				"line": 118,
 				"message": "Chained locator call in test: n8n.ndv.getOutputPanel().getByTestId('node-error-message')",
 				"hash": "9436eb5e9511"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 165,
+				"line": 169,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Define below' }).cl...",
 				"hash": "39e5d44a50a7"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 165,
+				"line": 169,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Define below' })",
 				"hash": "5c42d41d0397"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 166,
+				"line": 170,
 				"message": "Chained locator call in test: n8n.ndv.getParameterInput('text').locator('textarea')",
 				"hash": "986a0637e45b"
 			}
@@ -1340,27 +1280,27 @@
 		"tests/e2e/ai/langchain-vectorstores.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 83,
-				"message": "Chained locator call in test: n8n.canvas.getManualChatModal().locator('main')",
-				"hash": "5dd065409d52"
+				"line": 87,
+				"message": "Chained locator call in test: n8n.canvas.getManualChatModal().getByTestId('canvas-chat-...",
+				"hash": "0651461e8fda"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 89,
-				"message": "Chained locator call in test: n8n.canvas.getManualChatModal().locator('main')",
-				"hash": "5dd065409d52"
+				"line": 93,
+				"message": "Chained locator call in test: n8n.canvas.getManualChatModal().getByTestId('canvas-chat-...",
+				"hash": "0651461e8fda"
 			}
 		],
 		"tests/e2e/ai/workflow-builder.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 77,
+				"line": 81,
 				"message": "Direct page locator call: n8n.page.getByRole('button', { name: 'Execute and refine' })",
 				"hash": "ba2cdfe0e07b"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 111,
+				"line": 115,
 				"message": "Direct page locator call: n8n.page.getByText('Task aborted')",
 				"hash": "beba4221d694"
 			}
@@ -1368,13 +1308,13 @@
 		"tests/e2e/app-config/security-notifications.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 180,
+				"line": 184,
 				"message": "Chained locator call in test: versionCard.locator('.el-tag--danger').getByText('Securit...",
 				"hash": "41e0381dfdf0"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 180,
+				"line": 184,
 				"message": "Chained locator call in test: versionCard.locator('.el-tag--danger')",
 				"hash": "60a61866e32a"
 			}
@@ -1382,19 +1322,19 @@
 		"tests/e2e/building-blocks/node-details-configuration.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 56,
+				"line": 60,
 				"message": "Chained locator call in test: n8n.ndv.getAssignmentName('assignments', 0).getByRole('te...",
 				"hash": "fa1cc41275f1"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 70,
+				"line": 74,
 				"message": "Chained locator call in test: n8n.ndv.getAssignmentCollectionContainer('assignments').g...",
 				"hash": "f36b5d7ebe58"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 85,
+				"line": 89,
 				"message": "Chained locator call in test: n8n.ndv.getAssignmentCollectionContainer('assignments').g...",
 				"hash": "f36b5d7ebe58"
 			}
@@ -1402,37 +1342,37 @@
 		"tests/e2e/chat-hub/chat-hub-attachment.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 57,
+				"line": 61,
 				"message": "Chained locator call in test: newPage.locator('img')",
 				"hash": "787461cb35dd"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 58,
+				"line": 62,
 				"message": "Chained locator call in test: newPage.locator('img')",
 				"hash": "787461cb35dd"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 59,
+				"line": 63,
 				"message": "Chained locator call in test: newPage.locator('img')",
 				"hash": "787461cb35dd"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 38,
+				"line": 42,
 				"message": "Direct page instantiation: new ChatHubChatPage(n8n.page)",
 				"hash": "4c6c3053ee95"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 64,
+				"line": 68,
 				"message": "Direct page instantiation: new ChatHubChatPage(n8n.page)",
 				"hash": "4c6c3053ee95"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 80,
+				"line": 84,
 				"message": "Direct page instantiation: new ChatHubChatPage(n8n.page)",
 				"hash": "4c6c3053ee95"
 			}
@@ -1440,25 +1380,25 @@
 		"tests/e2e/chat-hub/chat-hub-basic.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 30,
+				"line": 34,
 				"message": "Direct page locator call: n8n.page.getByTestId('editCredential-modal')",
 				"hash": "2786a49972b3"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 9,
+				"line": 13,
 				"message": "Direct page instantiation: new ChatHubChatPage(n8n.page)",
 				"hash": "4c6c3053ee95"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 29,
+				"line": 33,
 				"message": "Direct page instantiation: new ChatHubChatPage(n8n.page)",
 				"hash": "4c6c3053ee95"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 56,
+				"line": 60,
 				"message": "Direct page instantiation: new ChatHubChatPage(n8n.page)",
 				"hash": "4c6c3053ee95"
 			}
@@ -1466,43 +1406,43 @@
 		"tests/e2e/chat-hub/chat-hub-personal-agent.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 88,
+				"line": 92,
 				"message": "Direct page locator call: n8n.page.getByRole('dialog').getByText('Delete', { exact:...",
 				"hash": "5fd52ad894c3"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 88,
+				"line": 92,
 				"message": "Direct page locator call: n8n.page.getByRole('dialog').getByText('Delete', { exact:...",
 				"hash": "5fd52ad894c3"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 88,
+				"line": 92,
 				"message": "Chained locator call in test: n8n.page.getByRole('dialog').getByText('Delete', { exact:...",
 				"hash": "41d47e05bb02"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 88,
+				"line": 92,
 				"message": "Direct page locator call: n8n.page.getByRole('dialog')",
 				"hash": "68deb7ade2bb"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 12,
+				"line": 16,
 				"message": "Direct page instantiation: new ChatHubChatPage(n8n.page)",
 				"hash": "4c6c3053ee95"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 43,
+				"line": 47,
 				"message": "Direct page instantiation: new ChatHubPersonalAgentsPage(n8n.page)",
 				"hash": "e85eb6a08ae6"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 44,
+				"line": 48,
 				"message": "Direct page instantiation: new ChatHubChatPage(n8n.page)",
 				"hash": "4c6c3053ee95"
 			}
@@ -1510,67 +1450,19 @@
 		"tests/e2e/credentials/crud.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 68,
-				"message": "Chained locator call in test: n8n.canvas.credentialModal .getModal() .getByTestId('node...",
-				"hash": "d3010be3a81f"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 68,
-				"message": "Chained locator call in test: n8n.canvas.credentialModal .getModal() .getByTestId('node...",
-				"hash": "d3010be3a81f"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 74,
-				"message": "Chained locator call in test: n8n.canvas.credentialModal .getModal() .getByTestId('node...",
-				"hash": "d3010be3a81f"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 74,
-				"message": "Chained locator call in test: n8n.canvas.credentialModal .getModal() .getByTestId('node...",
-				"hash": "d3010be3a81f"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 130,
-				"message": "Chained locator call in test: n8n.canvas.credentialModal .getModal() .getByTestId('node...",
-				"hash": "d3010be3a81f"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 130,
-				"message": "Chained locator call in test: n8n.canvas.credentialModal .getModal() .getByTestId('node...",
-				"hash": "d3010be3a81f"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 320,
-				"message": "Chained locator call in test: n8n.canvas.credentialModal .getModal() .getByTestId('node...",
-				"hash": "d3010be3a81f"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 320,
-				"message": "Chained locator call in test: n8n.canvas.credentialModal .getModal() .getByTestId('node...",
-				"hash": "d3010be3a81f"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 353,
+				"line": 347,
 				"message": "Direct page locator call: n8n.page.locator('.el-overlay').first()",
 				"hash": "6e0141ec89e6"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 353,
+				"line": 347,
 				"message": "Direct page locator call: n8n.page.locator('.el-overlay')",
 				"hash": "4668d190d0af"
 			},
 			{
 				"rule": "api-purity",
-				"line": 302,
+				"line": 300,
 				"message": "Raw API call detected: fetch(",
 				"hash": "b52df352569e"
 			}
@@ -1578,55 +1470,55 @@
 		"tests/e2e/credentials/global.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 35,
+				"line": 39,
 				"message": "Chained locator call in test: n8n.credentials.credentialModal.getVisibleDropdown().getB...",
 				"hash": "5ffd78437b38"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 44,
+				"line": 48,
 				"message": "Chained locator call in test: n8n.credentials.cards .getCredential('Global HTTP Header ...",
 				"hash": "05e7dd651e5e"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 61,
+				"line": 65,
 				"message": "Chained locator call in test: n8n.credentials.cards .getCredential('Global HTTP Header ...",
 				"hash": "05e7dd651e5e"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 91,
+				"line": 95,
 				"message": "Chained locator call in test: dropdown.getByText('Global HTTP Header Cred')",
 				"hash": "4a7662ea3718"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 94,
+				"line": 98,
 				"message": "Chained locator call in test: dropdown.getByText('Global HTTP Header Cred')",
 				"hash": "4a7662ea3718"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 121,
+				"line": 125,
 				"message": "Chained locator call in test: n8n.credentials.credentialModal .getModal() .getByTestId(...",
 				"hash": "ea4ed603d27a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 128,
+				"line": 132,
 				"message": "Chained locator call in test: n8n.credentials.credentialModal .getModal() .getByTestId(...",
 				"hash": "ea4ed603d27a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 128,
+				"line": 132,
 				"message": "Chained locator call in test: n8n.credentials.credentialModal .getModal() .getByTestId(...",
 				"hash": "ea4ed603d27a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 141,
+				"line": 145,
 				"message": "Chained locator call in test: n8n.credentials.cards .getCredential('Global HTTP Header ...",
 				"hash": "05e7dd651e5e"
 			}
@@ -1634,43 +1526,43 @@
 		"tests/e2e/node-creator/categories.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 19,
+				"line": 23,
 				"message": "Chained locator call in test: n8n.canvas.nodeCreator.getCategoryItem('Triggers').locato...",
 				"hash": "7bf32888198a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 24,
+				"line": 28,
 				"message": "Chained locator call in test: n8n.canvas.nodeCreator.getCategoryItem('Actions').locator...",
 				"hash": "408e6ab6e61d"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 30,
+				"line": 34,
 				"message": "Chained locator call in test: n8n.canvas.nodeCreator.getCategoryItem('Actions').locator...",
 				"hash": "408e6ab6e61d"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 45,
+				"line": 49,
 				"message": "Chained locator call in test: n8n.canvas.nodeCreator.getCategoryItem('Actions').locator...",
 				"hash": "408e6ab6e61d"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 51,
+				"line": 55,
 				"message": "Chained locator call in test: n8n.canvas.nodeCreator.getCategoryItem('Actions').locator...",
 				"hash": "408e6ab6e61d"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 56,
+				"line": 60,
 				"message": "Chained locator call in test: n8n.canvas.nodeCreator.getCategoryItem('Triggers').locato...",
 				"hash": "7bf32888198a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 62,
+				"line": 66,
 				"message": "Chained locator call in test: n8n.canvas.nodeCreator.getCategoryItem('Triggers').locato...",
 				"hash": "7bf32888198a"
 			}
@@ -1678,73 +1570,73 @@
 		"tests/e2e/nodes/community-nodes.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 79,
+				"line": 83,
 				"message": "Direct page locator call: n8n.page.getByTestId('credentials-label').click()",
 				"hash": "b487b1272454"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 79,
+				"line": 83,
 				"message": "Direct page locator call: n8n.page.getByTestId('credentials-label')",
 				"hash": "c57d3abbea50"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 80,
+				"line": 84,
 				"message": "Direct page locator call: n8n.page.getByTestId('node-credentials-select-item-new')....",
 				"hash": "b9824deca284"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 80,
+				"line": 84,
 				"message": "Direct page locator call: n8n.page.getByTestId('node-credentials-select-item-new')",
 				"hash": "ba4a66294bfb"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 82,
+				"line": 86,
 				"message": "Direct page locator call: n8n.page.getByTestId('editCredential-modal')",
 				"hash": "2786a49972b3"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 94,
+				"line": 98,
 				"message": "Direct page locator call: n8n.page.getByTestId('credentials-label').click()",
 				"hash": "b487b1272454"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 94,
+				"line": 98,
 				"message": "Direct page locator call: n8n.page.getByTestId('credentials-label')",
 				"hash": "c57d3abbea50"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 95,
+				"line": 99,
 				"message": "Direct page locator call: n8n.page.getByTestId('node-credentials-select-item-new')....",
 				"hash": "b9824deca284"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 95,
+				"line": 99,
 				"message": "Direct page locator call: n8n.page.getByTestId('node-credentials-select-item-new')",
 				"hash": "ba4a66294bfb"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 97,
+				"line": 101,
 				"message": "Direct page locator call: n8n.page.getByTestId('editCredential-modal')",
 				"hash": "2786a49972b3"
 			},
 			{
 				"rule": "api-purity",
-				"line": 15,
+				"line": 19,
 				"message": "Raw API call detected: fetch(",
 				"hash": "b52df352569e"
 			},
 			{
 				"rule": "api-purity",
-				"line": 30,
+				"line": 34,
 				"message": "Raw API call detected: fetch(",
 				"hash": "b52df352569e"
 			}
@@ -1752,87 +1644,75 @@
 		"tests/e2e/nodes/form-trigger-node.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 59,
+				"line": 63,
 				"message": "Direct page locator call: n8n.page.getByRole('button', { name: 'Add Field Option' }...",
 				"hash": "c3629563dd24"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 59,
+				"line": 63,
 				"message": "Direct page locator call: n8n.page.getByRole('button', { name: 'Add Field Option' })",
 				"hash": "69e3d4b550e1"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 102,
+				"line": 106,
 				"message": "Direct page locator call: n8n.page.locator('text=/form-test\\\\/[a-f0-9-]+/')",
 				"hash": "ccdce08746cc"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 111,
+				"line": 115,
 				"message": "Chained locator call in test: formPage.getByLabel('What is your first name?')",
 				"hash": "1223d29492d9"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 112,
-				"message": "Chained locator call in test: formPage.getByRole('button', { name: 'Submit' })",
-				"hash": "e4d7841ebb40"
-			},
-			{
-				"rule": "selector-purity",
 				"line": 116,
-				"message": "Chained locator call in test: formPage.getByLabel('What is your last name?')",
-				"hash": "cfc3f214f389"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 117,
 				"message": "Chained locator call in test: formPage.getByRole('button', { name: 'Submit' })",
 				"hash": "e4d7841ebb40"
 			},
 			{
 				"rule": "selector-purity",
 				"line": 120,
+				"message": "Chained locator call in test: formPage.getByLabel('What is your last name?')",
+				"hash": "cfc3f214f389"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 121,
+				"message": "Chained locator call in test: formPage.getByRole('button', { name: 'Submit' })",
+				"hash": "e4d7841ebb40"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 124,
 				"message": "Chained locator call in test: formPage.getByText('Your response has been recorded')",
 				"hash": "0e9a9b561cfa"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 193,
+				"line": 197,
 				"message": "Direct page locator call: n8n.page.locator('text=/form-test\\\\/[a-f0-9-]+/')",
 				"hash": "ccdce08746cc"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 202,
+				"line": 206,
 				"message": "Chained locator call in test: formPage.getByRole('button', { name: 'Submit' })",
 				"hash": "e4d7841ebb40"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 203,
+				"line": 207,
 				"message": "Chained locator call in test: formPage.getByText('This worked')",
 				"hash": "a0552602d3c9"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 307,
+				"line": 311,
 				"message": "Direct page locator call: n8n.page.locator('text=/form-test\\\\/[a-f0-9-]+/')",
 				"hash": "ccdce08746cc"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 316,
-				"message": "Chained locator call in test: formPage.getByRole('button', { name: 'Submit' })",
-				"hash": "e4d7841ebb40"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 317,
-				"message": "Chained locator call in test: formPage.getByText('Step 2')",
-				"hash": "94ffa2350779"
 			},
 			{
 				"rule": "selector-purity",
@@ -1843,6 +1723,18 @@
 			{
 				"rule": "selector-purity",
 				"line": 321,
+				"message": "Chained locator call in test: formPage.getByText('Step 2')",
+				"hash": "94ffa2350779"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 324,
+				"message": "Chained locator call in test: formPage.getByRole('button', { name: 'Submit' })",
+				"hash": "e4d7841ebb40"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 325,
 				"message": "Chained locator call in test: formPage.getByText('This worked')",
 				"hash": "a0552602d3c9"
 			}
@@ -1850,19 +1742,19 @@
 		"tests/e2e/nodes/if-node.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 21,
+				"line": 25,
 				"message": "Chained locator call in test: n8n.ndv.getFilterConditionLeft(FILTER_PARAM_NAME, 0).loca...",
 				"hash": "c3fc875effa7"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 22,
+				"line": 26,
 				"message": "Chained locator call in test: n8n.ndv.getFilterConditionLeft(FILTER_PARAM_NAME, 1).loca...",
 				"hash": "5f2f690a0a6a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 29,
+				"line": 33,
 				"message": "Chained locator call in test: n8n.ndv.getFilterConditionLeft(FILTER_PARAM_NAME, 0).loca...",
 				"hash": "c3fc875effa7"
 			}
@@ -1870,13 +1762,13 @@
 		"tests/e2e/nodes/webhook.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 66,
+				"line": 70,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Response Code' }).c...",
 				"hash": "4ec8fd179f0d"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 66,
+				"line": 70,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Response Code' })",
 				"hash": "3f5a68018809"
 			}
@@ -1884,31 +1776,31 @@
 		"tests/e2e/projects/folders-basic.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 151,
+				"line": 155,
 				"message": "Chained locator call in test: n8n.modal.container.getByText(errorMessage, { exact: fals...",
 				"hash": "493ced26c9ed"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 155,
+				"line": 159,
 				"message": "Chained locator call in test: n8n.modal.container.getByText(emptyErrorMessage)",
 				"hash": "1a0616eac3d8"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 158,
+				"line": 162,
 				"message": "Chained locator call in test: n8n.modal.container.getByText(tooLongErrorMessage)",
 				"hash": "d7e82d2a75eb"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 161,
+				"line": 165,
 				"message": "Chained locator call in test: n8n.modal.container.getByText(dotsErrorMessage)",
 				"hash": "bbb98f3cbb44"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 177,
+				"line": 181,
 				"message": "Chained locator call in test: n8n.notifications .getNotificationByTitleOrContent(FOLDER...",
 				"hash": "ef7efad8acb2"
 			}
@@ -1916,73 +1808,73 @@
 		"tests/e2e/projects/project-settings.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 60,
+				"line": 64,
 				"message": "Direct page locator call: n8n.page.getByText('Project Updated Project Name saved su...",
 				"hash": "5c8bb96d8da1"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 80,
+				"line": 84,
 				"message": "Chained locator call in test: table.getByText('User')",
 				"hash": "35eb3e7e10a1"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 81,
+				"line": 85,
 				"message": "Chained locator call in test: table.getByText('Role')",
 				"hash": "598e22980502"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 84,
+				"line": 88,
 				"message": "Chained locator call in test: table.locator('tbody tr')",
 				"hash": "fdc278cf27e4"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 89,
+				"line": 93,
 				"message": "Chained locator call in test: ownerRow.getByTestId('project-member-role-dropdown')",
 				"hash": "c69f7e1bd77a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 105,
+				"line": 109,
 				"message": "Direct page locator call: n8n.page.locator('tbody tr').first()",
 				"hash": "c57a14994e07"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 105,
+				"line": 109,
 				"message": "Direct page locator call: n8n.page.locator('tbody tr')",
 				"hash": "48de3852588f"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 106,
+				"line": 110,
 				"message": "Chained locator call in test: currentUserRow.getByTestId('project-member-role-dropdown')",
 				"hash": "f1e1476c1fc9"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 109,
+				"line": 113,
 				"message": "Chained locator call in test: currentUserRow.getByText('Admin')",
 				"hash": "1927ce34d19a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 176,
+				"line": 180,
 				"message": "Direct page locator call: n8n.page.getByText('Danger zone')",
 				"hash": "58fee023d77a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 178,
+				"line": 182,
 				"message": "Direct page locator call: n8n.page.getByText( 'When deleting a project, you can als...",
 				"hash": "f2d055ed66a9"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 204,
+				"line": 208,
 				"message": "Direct page locator call: n8n.page.getByText('Project Persisted Project Name saved ...",
 				"hash": "0f573d3d200b"
 			}
@@ -1990,37 +1882,37 @@
 		"tests/e2e/projects/projects-move-resources.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 102,
+				"line": 106,
 				"message": "Chained locator call in test: n8n.resourceMoveModal.getProjectSelectCredential().locato...",
 				"hash": "e8eff63d49af"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 103,
+				"line": 107,
 				"message": "Direct page locator call: n8n.page.getByRole('option')",
 				"hash": "c58b0877f9a1"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 119,
+				"line": 123,
 				"message": "Chained locator call in test: n8n.resourceMoveModal.getProjectSelectCredential().locato...",
 				"hash": "e8eff63d49af"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 120,
+				"line": 124,
 				"message": "Direct page locator call: n8n.page.getByRole('option')",
 				"hash": "c58b0877f9a1"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 136,
+				"line": 140,
 				"message": "Chained locator call in test: n8n.resourceMoveModal.getProjectSelectCredential().locato...",
 				"hash": "e8eff63d49af"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 137,
+				"line": 141,
 				"message": "Direct page locator call: n8n.page.getByRole('option')",
 				"hash": "c58b0877f9a1"
 			}
@@ -2028,49 +1920,49 @@
 		"tests/e2e/projects/projects.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 85,
+				"line": 89,
 				"message": "Chained locator call in test: n8n.workflows.cards.getWorkflow('My workflow').getByText(...",
 				"hash": "c5bffdc35ac3"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 161,
+				"line": 165,
 				"message": "Direct page locator call: subn8n.page.getByRole('heading', { name: 'My Sub-Workflow...",
 				"hash": "788ef93cfb62"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 161,
+				"line": 165,
 				"message": "Chained locator call in test: subn8n.page.getByRole('heading', { name: 'My Sub-Workflow...",
 				"hash": "9e664e14b0a8"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 166,
+				"line": 170,
 				"message": "Direct page locator call: subn8n.page.getByRole('heading', { name: 'Notion account' })",
 				"hash": "43671aca120d"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 166,
+				"line": 170,
 				"message": "Chained locator call in test: subn8n.page.getByRole('heading', { name: 'Notion account' })",
 				"hash": "c98e5c7b276b"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 206,
+				"line": 210,
 				"message": "Chained locator call in test: n8n.projectSettings.getIconPickerButton().locator('svg')",
 				"hash": "4342f0cc13b8"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 243,
+				"line": 247,
 				"message": "Direct page locator call: n8n.page.locator('body').click()",
 				"hash": "4484dbdcd879"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 243,
+				"line": 247,
 				"message": "Direct page locator call: n8n.page.locator('body')",
 				"hash": "6667df4502c4"
 			}
@@ -2078,25 +1970,25 @@
 		"tests/e2e/regression/ADO-2372-prevent-clipping-params.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 62,
+				"line": 66,
 				"message": "Chained locator call in test: editor.locator('.cm-line')",
 				"hash": "1ac80885fc71"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 63,
+				"line": 67,
 				"message": "Chained locator call in test: editor.locator('.cm-line')",
 				"hash": "1ac80885fc71"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 64,
+				"line": 68,
 				"message": "Chained locator call in test: editor.locator('.cm-line')",
 				"hash": "1ac80885fc71"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 65,
+				"line": 69,
 				"message": "Chained locator call in test: editor.locator('.cm-line')",
 				"hash": "1ac80885fc71"
 			}
@@ -2104,25 +1996,25 @@
 		"tests/e2e/regression/AI-1401-sub-nodes-input-panel.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 19,
+				"line": 23,
 				"message": "Chained locator call in test: n8n.ndv.inputPanel.get().locator('[data-test-id*=\"input-s...",
 				"hash": "396dc4f1d5af"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 22,
+				"line": 26,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Edit Fields' })",
 				"hash": "c6c4cc5bf6c4"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 23,
+				"line": 27,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Manual Trigger' })",
 				"hash": "503597d4ef3e"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 24,
+				"line": 28,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'No Operation, do no...",
 				"hash": "7a16d85129d2"
 			}
@@ -2130,13 +2022,13 @@
 		"tests/e2e/regression/SUG-121-fields-reset-after-closing-ndv.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 21,
+				"line": 25,
 				"message": "Chained locator call in test: n8n.ndv.getParameterByLabel('JavaScript').getByRole('text...",
 				"hash": "f8105d6d3a8d"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 24,
+				"line": 28,
 				"message": "Chained locator call in test: n8n.ndv.getParameterByLabel('JavaScript').getByRole('text...",
 				"hash": "f8105d6d3a8d"
 			}
@@ -2144,55 +2036,55 @@
 		"tests/e2e/settings/environments/source-control.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 52,
+				"line": 56,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'main' })",
 				"hash": "8e36dd6e7c35"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 71,
+				"line": 75,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'main' })",
 				"hash": "8e36dd6e7c35"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 72,
+				"line": 76,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'development' })",
 				"hash": "4157d0d852a3"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 73,
+				"line": 77,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'staging' })",
 				"hash": "5ea1e1189ae1"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 74,
+				"line": 78,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'production' })",
 				"hash": "13bbd087b456"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 75,
+				"line": 79,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'development' }).cli...",
 				"hash": "2d47edbe9c6a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 75,
+				"line": 79,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'development' })",
 				"hash": "4157d0d852a3"
 			},
 			{
 				"rule": "api-purity",
-				"line": 79,
+				"line": 83,
 				"message": "Raw API call detected: request.get(",
 				"hash": "5128d500e46f"
 			},
 			{
 				"rule": "api-purity",
-				"line": 88,
+				"line": 92,
 				"message": "Raw API call detected: request.get(",
 				"hash": "5128d500e46f"
 			}
@@ -2200,25 +2092,25 @@
 		"tests/e2e/sharing/access-control.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 73,
+				"line": 79,
 				"message": "Chained locator call in test: adminN8n.credentials.credentialModal.getVisibleDropdown()...",
 				"hash": "466547047099"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 134,
+				"line": 140,
 				"message": "Chained locator call in test: credentialDropdown.getByText(testCredName)",
 				"hash": "88f241af5012"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 135,
+				"line": 141,
 				"message": "Chained locator call in test: credentialDropdown.getByText(devCredName)",
 				"hash": "7c1126e1a52a"
 			},
 			{
 				"rule": "api-purity",
-				"line": 99,
+				"line": 105,
 				"message": "Raw API call detected: request.get(",
 				"hash": "5128d500e46f"
 			}
@@ -2226,55 +2118,55 @@
 		"tests/e2e/sharing/credential-visibility.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 48,
+				"line": 52,
 				"message": "Chained locator call in test: credentialDropdown.getByText(testCredName)",
 				"hash": "88f241af5012"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 49,
+				"line": 53,
 				"message": "Chained locator call in test: credentialDropdown.getByText(personalCredName)",
 				"hash": "8a03b8f32fa8"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 50,
+				"line": 54,
 				"message": "Chained locator call in test: credentialDropdown.getByText(devCredName)",
 				"hash": "7c1126e1a52a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 92,
+				"line": 96,
 				"message": "Chained locator call in test: credentialDropdown.getByText(ownerCredName)",
 				"hash": "7b09c1090b15"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 93,
+				"line": 97,
 				"message": "Chained locator call in test: credentialDropdown.getByText(memberCredName)",
 				"hash": "241866f0d4df"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 150,
+				"line": 154,
 				"message": "Chained locator call in test: credentialDropdown.getByText(memberCredName)",
 				"hash": "241866f0d4df"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 151,
+				"line": 155,
 				"message": "Chained locator call in test: credentialDropdown.getByText(ownerCredName)",
 				"hash": "7b09c1090b15"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 205,
+				"line": 209,
 				"message": "Chained locator call in test: n8n.ndv.getVisiblePopper().locator('li')",
 				"hash": "eb4832404c9b"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 235,
+				"line": 239,
 				"message": "Chained locator call in test: n8n.ndv.getVisiblePopper().locator('li')",
 				"hash": "eb4832404c9b"
 			}
@@ -2282,7 +2174,7 @@
 		"tests/e2e/source-control/pull.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 90,
+				"line": 94,
 				"message": "Chained locator call in test: n8n.canvas.tagsManagerModal.getTable().getByText('pull-te...",
 				"hash": "9cd079655a6b"
 			}
@@ -2290,55 +2182,55 @@
 		"tests/e2e/workflows/checklist/production-checklist.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 63,
+				"line": 67,
 				"message": "Direct page locator call: n8n.page.getByTestId('workflow-settings-dialog')",
 				"hash": "6dff31c05187"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 64,
+				"line": 68,
 				"message": "Direct page locator call: n8n.page.getByTestId('workflow-settings-error-workflow')",
 				"hash": "e86d143e5094"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 79,
+				"line": 83,
 				"message": "Direct page locator call: n8n.page.getByTestId('workflow-settings-dialog')",
 				"hash": "6dff31c05187"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 91,
+				"line": 95,
 				"message": "Chained locator call in test: n8n.canvas.getProductionChecklistActionItem().first().get...",
 				"hash": "b99bf85bffb8"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 94,
+				"line": 98,
 				"message": "Direct page locator call: n8n.page.locator('body').click({ position: { x: 0, y: 0 } })",
 				"hash": "82ea0a8120b9"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 94,
+				"line": 98,
 				"message": "Direct page locator call: n8n.page.locator('body')",
 				"hash": "6667df4502c4"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 132,
+				"line": 136,
 				"message": "Direct page locator call: n8n.page.getByTestId('workflow-settings-dialog')",
 				"hash": "6dff31c05187"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 138,
+				"line": 142,
 				"message": "Chained locator call in test: n8n.canvas .getProductionChecklistActionItem() .first() ....",
 				"hash": "049e1b469b18"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 155,
+				"line": 159,
 				"message": "Direct page locator call: n8n.page.locator('.el-message-box')",
 				"hash": "a41c304c373a"
 			}
@@ -2346,133 +2238,133 @@
 		"tests/e2e/workflows/demo-diff.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 116,
+				"line": 120,
 				"message": "Direct page locator call: n8n.page.getByText('Waiting for workflow data...')",
 				"hash": "b6b8ed64d974"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 123,
-				"message": "Direct page locator call: n8n.page.getByText('Waiting for workflow data...')",
-				"hash": "b6b8ed64d974"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 141,
+				"line": 127,
 				"message": "Direct page locator call: n8n.page.getByText('Waiting for workflow data...')",
 				"hash": "b6b8ed64d974"
 			},
 			{
 				"rule": "selector-purity",
 				"line": 145,
+				"message": "Direct page locator call: n8n.page.getByText('Waiting for workflow data...')",
+				"hash": "b6b8ed64d974"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 149,
 				"message": "Direct page locator call: n8n.page.getByRole('heading', { name: /Test Workflow/, ex...",
 				"hash": "27a3f117a93a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 149,
+				"line": 153,
 				"message": "Direct page locator call: n8n.page.getByRole('button', { name: /Changes/ })",
 				"hash": "1daa8f688214"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 156,
+				"line": 160,
 				"message": "Direct page locator call: n8n.page.getByText('Waiting for workflow data...')",
 				"hash": "b6b8ed64d974"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 173,
+				"line": 177,
 				"message": "Direct page locator call: n8n.page.getByText('Waiting for workflow data...')",
 				"hash": "b6b8ed64d974"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 176,
+				"line": 180,
 				"message": "Direct page locator call: n8n.page.getByRole('heading', { name: 'Test Workflow - Af...",
 				"hash": "284153f6d798"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 183,
+				"line": 187,
 				"message": "Direct page locator call: n8n.page.getByText('Waiting for workflow data...')",
 				"hash": "b6b8ed64d974"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 200,
+				"line": 204,
 				"message": "Direct page locator call: n8n.page.getByText('Waiting for workflow data...')",
 				"hash": "b6b8ed64d974"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 203,
+				"line": 207,
 				"message": "Direct page locator call: n8n.page.getByRole('heading', { name: 'Test Workflow - Be...",
 				"hash": "dd7b576b2982"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 210,
-				"message": "Direct page locator call: n8n.page.getByText('Waiting for workflow data...')",
-				"hash": "b6b8ed64d974"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 229,
+				"line": 214,
 				"message": "Direct page locator call: n8n.page.getByText('Waiting for workflow data...')",
 				"hash": "b6b8ed64d974"
 			},
 			{
 				"rule": "selector-purity",
 				"line": 233,
+				"message": "Direct page locator call: n8n.page.getByText('Waiting for workflow data...')",
+				"hash": "b6b8ed64d974"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 237,
 				"message": "Direct page locator call: n8n.page.getByRole('heading', { name: /Test Workflow/, ex...",
 				"hash": "27a3f117a93a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 237,
+				"line": 241,
 				"message": "Direct page locator call: n8n.page.getByRole('button', { name: /Changes/ })",
 				"hash": "1daa8f688214"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 244,
+				"line": 248,
 				"message": "Direct page locator call: n8n.page.getByText('Waiting for workflow data...')",
 				"hash": "b6b8ed64d974"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 252,
+				"line": 256,
 				"message": "Direct page locator call: n8n.page.getByText('Waiting for workflow data...')",
 				"hash": "b6b8ed64d974"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 259,
+				"line": 263,
 				"message": "Direct page locator call: n8n.page.getByText('Waiting for workflow data...')",
 				"hash": "b6b8ed64d974"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 273,
+				"line": 277,
 				"message": "Direct page locator call: n8n.page.getByText('Waiting for workflow data...')",
 				"hash": "b6b8ed64d974"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 278,
+				"line": 282,
 				"message": "Direct page locator call: n8n.page.locator('body')",
 				"hash": "6667df4502c4"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 283,
+				"line": 287,
 				"message": "Direct page locator call: n8n.page.locator('body')",
 				"hash": "6667df4502c4"
 			},
 			{
 				"rule": "duplicate-logic",
-				"line": 113,
+				"line": 117,
 				"message": "Duplicate test logic: \"shows waiting state initially\" has identical structure to tests/e2e/ai/workflow-builder.spec.ts:\"should show Build with AI button on empty canvas\"",
 				"hash": "6cf55be1ebdb"
 			}
@@ -2480,13 +2372,13 @@
 		"tests/e2e/workflows/editor/canvas/canvas-nodes.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 24,
+				"line": 28,
 				"message": "Direct page locator call: n8n.page.getByText('Add Routing Rule').click()",
 				"hash": "bb9ccdaa6e0f"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 24,
+				"line": 28,
 				"message": "Direct page locator call: n8n.page.getByText('Add Routing Rule')",
 				"hash": "f13800d70ddd"
 			}
@@ -2494,19 +2386,19 @@
 		"tests/e2e/workflows/editor/canvas/canvas-zoom.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 218,
+				"line": 222,
 				"message": "Chained locator call in test: n8n.canvas.nodeByName('n8n').getByTestId('overflow-node-b...",
 				"hash": "3d500494797e"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 219,
+				"line": 223,
 				"message": "Direct page locator call: n8n.page.getByTestId('context-menu-item-open').click()",
 				"hash": "803edc6e2d15"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 219,
+				"line": 223,
 				"message": "Direct page locator call: n8n.page.getByTestId('context-menu-item-open')",
 				"hash": "049003f6550b"
 			}
@@ -2514,37 +2406,37 @@
 		"tests/e2e/workflows/editor/code/code-node.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 24,
+				"line": 28,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Run Once for Each I...",
 				"hash": "354ddeafe76a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 24,
+				"line": 28,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Run Once for Each I...",
 				"hash": "354ddeafe76a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 31,
+				"line": 35,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Run Once for All It...",
 				"hash": "03087d1206ad"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 31,
+				"line": 35,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Run Once for All It...",
 				"hash": "03087d1206ad"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 46,
+				"line": 50,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Run Once for Each I...",
 				"hash": "354ddeafe76a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 46,
+				"line": 50,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Run Once for Each I...",
 				"hash": "354ddeafe76a"
 			}
@@ -2552,19 +2444,19 @@
 		"tests/e2e/workflows/editor/execution/execution.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 145,
+				"line": 149,
 				"message": "Direct page locator call: n8n.page.getByTestId('copy-input').click()",
 				"hash": "20e9bf63ae83"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 145,
+				"line": 149,
 				"message": "Direct page locator call: n8n.page.getByTestId('copy-input')",
 				"hash": "dd5c167f4482"
 			},
 			{
 				"rule": "api-purity",
-				"line": 149,
+				"line": 153,
 				"message": "Raw API call detected: request.get(",
 				"hash": "5128d500e46f"
 			}
@@ -2572,7 +2464,7 @@
 		"tests/e2e/workflows/editor/execution/inject-previous.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 55,
+				"line": 59,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.get().locator('[contenteditable=\"true...",
 				"hash": "cae3335d44be"
 			}
@@ -2580,13 +2472,13 @@
 		"tests/e2e/workflows/editor/execution/logs.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 249,
+				"line": 253,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel .getDataContainer() .locator('a')",
 				"hash": "6a673016ebff"
 			},
 			{
 				"rule": "api-purity",
-				"line": 259,
+				"line": 263,
 				"message": "Raw API call detected: request.get(",
 				"hash": "5128d500e46f"
 			}
@@ -2594,7 +2486,7 @@
 		"tests/e2e/workflows/editor/expressions/inline.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 51,
+				"line": 55,
 				"message": "Chained locator call in test: n8n.ndv.getParameterInput('value').getByRole('textbox')",
 				"hash": "e6c73a21e494"
 			}
@@ -2602,31 +2494,31 @@
 		"tests/e2e/workflows/editor/expressions/mapping.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 56,
+				"line": 60,
 				"message": "Chained locator call in test: n8n.ndv.inputPanel.get().getByText(expectedJsonText)",
 				"hash": "9865414150f3"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 102,
+				"line": 106,
 				"message": "Chained locator call in test: n8n.ndv.inputPanel.get().getByText('Schedule Trigger')",
 				"hash": "2043cf03c7a7"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 113,
+				"line": 117,
 				"message": "Chained locator call in test: schemaItem.locator('span')",
 				"hash": "dae1f9ee44ac"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 154,
+				"line": 158,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'String' }).click()",
 				"hash": "c3130f54285b"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 154,
+				"line": 158,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'String' })",
 				"hash": "6351fa2e946a"
 			}
@@ -2634,19 +2526,19 @@
 		"tests/e2e/workflows/editor/expressions/transformation.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 15,
+				"line": 19,
 				"message": "Chained locator call in test: assignmentValue.locator('text=Expression')",
 				"hash": "398682465503"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 110,
+				"line": 114,
 				"message": "Chained locator call in test: n8n.ndv.getOutputDataContainer().locator('[class*=value_]')",
 				"hash": "78a1c969575d"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 130,
+				"line": 134,
 				"message": "Chained locator call in test: n8n.ndv.getOutputDataContainer().locator('[class*=value_]')",
 				"hash": "78a1c969575d"
 			}
@@ -2654,109 +2546,109 @@
 		"tests/e2e/workflows/editor/ndv/io-filter.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 28,
+				"line": 32,
 				"message": "Chained locator call in test: pagination.locator('li')",
 				"hash": "5a7163c291f8"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 29,
-				"message": "Chained locator call in test: n8n.ndv.outputPanel.getDataContainer().locator('mark')",
-				"hash": "fc731709a0e9"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 38,
+				"line": 33,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.getDataContainer().locator('mark')",
 				"hash": "fc731709a0e9"
 			},
 			{
 				"rule": "selector-purity",
 				"line": 42,
+				"message": "Chained locator call in test: n8n.ndv.outputPanel.getDataContainer().locator('mark')",
+				"hash": "fc731709a0e9"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 46,
 				"message": "Chained locator call in test: pagination.locator('li')",
 				"hash": "5a7163c291f8"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 62,
+				"line": 66,
 				"message": "Chained locator call in test: n8n.ndv.inputPanel.get().getByTestId('ndv-data-pagination')",
 				"hash": "1a869dd91e67"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 64,
+				"line": 68,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.get().getByTestId('ndv-data-pagination')",
 				"hash": "58e725977612"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 68,
+				"line": 72,
 				"message": "Chained locator call in test: getInputPagination().locator('li')",
 				"hash": "5aa75994ab8d"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 70,
+				"line": 74,
 				"message": "Chained locator call in test: getOutputPagination().locator('li')",
 				"hash": "d452a5950767"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 77,
-				"message": "Chained locator call in test: getOutputPagination().locator('li')",
-				"hash": "d452a5950767"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 84,
+				"line": 81,
 				"message": "Chained locator call in test: getOutputPagination().locator('li')",
 				"hash": "d452a5950767"
 			},
 			{
 				"rule": "selector-purity",
 				"line": 88,
-				"message": "Chained locator call in test: getInputPagination().locator('li')",
-				"hash": "5aa75994ab8d"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 90,
 				"message": "Chained locator call in test: getOutputPagination().locator('li')",
 				"hash": "d452a5950767"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 100,
+				"line": 92,
 				"message": "Chained locator call in test: getInputPagination().locator('li')",
 				"hash": "5aa75994ab8d"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 102,
+				"line": 94,
 				"message": "Chained locator call in test: getOutputPagination().locator('li')",
 				"hash": "d452a5950767"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 107,
+				"line": 104,
 				"message": "Chained locator call in test: getInputPagination().locator('li')",
 				"hash": "5aa75994ab8d"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 114,
+				"line": 106,
+				"message": "Chained locator call in test: getOutputPagination().locator('li')",
+				"hash": "d452a5950767"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 111,
 				"message": "Chained locator call in test: getInputPagination().locator('li')",
 				"hash": "5aa75994ab8d"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 120,
+				"line": 118,
 				"message": "Chained locator call in test: getInputPagination().locator('li')",
 				"hash": "5aa75994ab8d"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 122,
+				"line": 124,
+				"message": "Chained locator call in test: getInputPagination().locator('li')",
+				"hash": "5aa75994ab8d"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 126,
 				"message": "Chained locator call in test: getOutputPagination().locator('li')",
 				"hash": "d452a5950767"
 			}
@@ -2764,25 +2656,25 @@
 		"tests/e2e/workflows/editor/ndv/ndv-core.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 116,
+				"line": 120,
 				"message": "Chained locator call in test: n8n.ndv.getContainer().getByText('Webhook URLs').locator(...",
 				"hash": "15c9e3d9aeba"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 116,
+				"line": 120,
 				"message": "Chained locator call in test: n8n.ndv.getContainer().getByText('Webhook URLs')",
 				"hash": "9026e28e4f47"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 171,
+				"line": 175,
 				"message": "Chained locator call in test: n8n.ndv.getParameterInput('jsCode').locator('.cm-content')",
 				"hash": "b09a3f3d56fc"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 202,
+				"line": 206,
 				"message": "Chained locator call in test: n8n.ndv.getParameterInput('jsCode').locator('.cm-content')",
 				"hash": "b09a3f3d56fc"
 			}
@@ -2790,49 +2682,49 @@
 		"tests/e2e/workflows/editor/ndv/ndv-data-display.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 59,
+				"line": 63,
 				"message": "Chained locator call in test: objectValueItem.locator('.toggle')",
 				"hash": "45d8699925c6"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 78,
+				"line": 82,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.get().getByText('5 items')",
 				"hash": "beef6d951ce8"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 94,
+				"line": 98,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.get().getByText('26 items')",
 				"hash": "f1b1cc3c04b4"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 116,
+				"line": 120,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.getTableRow(1).locator('mark')",
 				"hash": "6212a0d5e5bc"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 131,
+				"line": 135,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.get().locator('[class*=\"active\"]')",
 				"hash": "ddd992a3778f"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 143,
+				"line": 147,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.getTableRow(1).locator('mark')",
 				"hash": "6212a0d5e5bc"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 147,
+				"line": 151,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.getDataContainer().locator('.json-data')",
 				"hash": "8c80e9607f84"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 250,
+				"line": 254,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel .get() .getByText('To search field va...",
 				"hash": "6bd1281071a1"
 			}
@@ -2840,13 +2732,13 @@
 		"tests/e2e/workflows/editor/ndv/ndv-parameters.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 115,
+				"line": 119,
 				"message": "Chained locator call in test: n8n.ndv.getResourceLocatorInput('documentId').locator('in...",
 				"hash": "a10387b2b4a5"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 173,
+				"line": 177,
 				"message": "Chained locator call in test: n8n.ndv.getAssignmentValue('assignments').getByText('Expr...",
 				"hash": "25491e82dd43"
 			}
@@ -2854,91 +2746,91 @@
 		"tests/e2e/workflows/editor/ndv/paired-item.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 91,
+				"line": 95,
 				"message": "Direct page locator call: n8n.page.locator('[data-test-id=\"hovering-item\"]')",
 				"hash": "170e68f7b7b7"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 97,
+				"line": 101,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Set1' }).click()",
 				"hash": "7363e0425bfb"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 97,
+				"line": 101,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Set1' })",
 				"hash": "7e6cc145ca37"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 101,
+				"line": 105,
 				"message": "Chained locator call in test: n8n.ndv.inputPanel.getTable().locator('text=1000')",
 				"hash": "d54ea49f3e0f"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 102,
+				"line": 106,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.get().locator('[data-test-id=\"hoverin...",
 				"hash": "6e9d8666bad6"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 109,
+				"line": 113,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Sort' }).click()",
 				"hash": "dab3a0c3f01f"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 109,
+				"line": 113,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Sort' })",
 				"hash": "57ea397df648"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 113,
+				"line": 117,
 				"message": "Chained locator call in test: n8n.ndv.inputPanel.getTable().locator('text=1111')",
 				"hash": "20de742a14d7"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 114,
+				"line": 118,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.get().locator('[data-test-id=\"hoverin...",
 				"hash": "6e9d8666bad6"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 193,
+				"line": 197,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.get().getByText('False Branch (2 item...",
 				"hash": "4ed4184926d5"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 217,
+				"line": 221,
 				"message": "Chained locator call in test: n8n.ndv.inputPanel.get().getByText('True Branch')",
 				"hash": "cc551456a986"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 224,
+				"line": 228,
 				"message": "Chained locator call in test: n8n.ndv.inputPanel.get().locator('[data-test-id=\"hovering...",
 				"hash": "8d39d87925b5"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 229,
+				"line": 233,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.get().locator('[data-test-id=\"hoverin...",
 				"hash": "6e9d8666bad6"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 233,
+				"line": 237,
 				"message": "Chained locator call in test: n8n.ndv.inputPanel.get().getByText('False Branch')",
 				"hash": "dee1bac10eac"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 244,
+				"line": 248,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.get().locator('[data-test-id=\"hoverin...",
 				"hash": "6e9d8666bad6"
 			}
@@ -2946,19 +2838,19 @@
 		"tests/e2e/workflows/editor/ndv/pinning.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 77,
+				"line": 81,
 				"message": "Chained locator call in test: runDataHeader.getByRole('button', { name: 'Edit Output' })",
 				"hash": "aa1904651d9c"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 171,
+				"line": 175,
 				"message": "Chained locator call in test: n8n.ndv.getAssignmentValue('assignments').getByText('Expr...",
 				"hash": "25491e82dd43"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 180,
+				"line": 184,
 				"message": "Chained locator call in test: n8n.ndv.getParameterInputHint().getByText(expectedOutput)",
 				"hash": "393fc24d0bf4"
 			}
@@ -2966,45 +2858,27 @@
 		"tests/e2e/workflows/editor/ndv/resource-locator.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 77,
+				"line": 91,
 				"message": "Direct page locator call: n8n.page.locator('.el-message-box').locator('button:has-t...",
 				"hash": "066ea6c93563"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 77,
+				"line": 91,
 				"message": "Chained locator call in test: n8n.page.locator('.el-message-box').locator('button:has-t...",
 				"hash": "6dae6a423842"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 77,
+				"line": 91,
 				"message": "Direct page locator call: n8n.page.locator('.el-message-box')",
 				"hash": "a41c304c373a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 106,
+				"line": 120,
 				"message": "Chained locator call in test: n8n.ndv.getResourceLocatorInput('sheetName').locator('inp...",
 				"hash": "8c2440762013"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 115,
-				"message": "Direct page locator call: n8n.page.getByTestId('rlc-item').first()",
-				"hash": "4466b60c399e"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 115,
-				"message": "Direct page locator call: n8n.page.getByTestId('rlc-item')",
-				"hash": "84df99d6a586"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 118,
-				"message": "Chained locator call in test: visiblePopper.getByTestId('rlc-item')",
-				"hash": "50584e5d1477"
 			},
 			{
 				"rule": "selector-purity",
@@ -3021,6 +2895,24 @@
 			{
 				"rule": "selector-purity",
 				"line": 132,
+				"message": "Chained locator call in test: visiblePopper.getByTestId('rlc-item')",
+				"hash": "50584e5d1477"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 143,
+				"message": "Direct page locator call: n8n.page.getByTestId('rlc-item').first()",
+				"hash": "4466b60c399e"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 143,
+				"message": "Direct page locator call: n8n.page.getByTestId('rlc-item')",
+				"hash": "84df99d6a586"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 146,
 				"message": "Chained locator call in test: visiblePopperAfter.getByTestId('rlc-item')",
 				"hash": "160fc14cc93a"
 			}
@@ -3028,7 +2920,7 @@
 		"tests/e2e/workflows/editor/ndv/schema-preview.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 11,
+				"line": 15,
 				"message": "Chained locator call in test: n8n.ndv.inputPanel.get().getByText('No input data')",
 				"hash": "89dc9850c2d6"
 			}
@@ -3036,19 +2928,19 @@
 		"tests/e2e/workflows/editor/subworkflows/debugging.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 38,
+				"line": 42,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.getTbodyCell(0, 0).locator('a')",
 				"hash": "11bb70e5e4f9"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 81,
+				"line": 85,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.getTbodyCell(0, 0).locator('a')",
 				"hash": "11bb70e5e4f9"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 95,
+				"line": 99,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.getTbodyCell(0, 0).locator('a')",
 				"hash": "11bb70e5e4f9"
 			}
@@ -3056,25 +2948,25 @@
 		"tests/e2e/workflows/editor/subworkflows/workflow-selector.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 58,
+				"line": 62,
 				"message": "Chained locator call in test: n8n.ndv.getResourceLocatorInput('workflowId').locator('in...",
 				"hash": "d4ee6d0058ed"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 64,
+				"line": 68,
 				"message": "Chained locator call in test: n8n.ndv.getResourceLocatorInput('workflowId').locator('a')",
 				"hash": "1cadf974d1a1"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 73,
+				"line": 77,
 				"message": "Chained locator call in test: n8n.ndv.getResourceLocatorModeSelector('workflowId').loca...",
 				"hash": "b893416c36ed"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 87,
+				"line": 91,
 				"message": "Chained locator call in test: addResourceItem.getByText(/Create a/)",
 				"hash": "f7f77ebf40c7"
 			}
@@ -3082,19 +2974,19 @@
 		"tests/e2e/workflows/editor/tags.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 59,
+				"line": 63,
 				"message": "Chained locator call in test: n8n.canvas.tagsManagerModal.getTable().getByText(tag1)",
 				"hash": "f31292c4e171"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 64,
+				"line": 68,
 				"message": "Chained locator call in test: n8n.canvas.tagsManagerModal.getTable().getByText(tag2)",
 				"hash": "20fbe08893cc"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 209,
+				"line": 213,
 				"message": "Chained locator call in test: n8n.canvas.getVisibleDropdown().locator('li')",
 				"hash": "4febc57392da"
 			}
@@ -3102,7 +2994,7 @@
 		"tests/e2e/workflows/editor/workflow-actions/archive.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 36,
+				"line": 40,
 				"message": "Chained locator call in test: n8n.workflowSettingsModal.getArchiveMenuItem().locator('..')",
 				"hash": "ec8d53703e0b"
 			}
@@ -3110,57 +3002,27 @@
 		"tests/e2e/workflows/editor/workflow-actions/settings.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 28,
+				"line": 32,
 				"message": "Direct page locator call: n8n.page.getByRole('option').count()",
 				"hash": "43ba2cdb87a8"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 28,
+				"line": 32,
 				"message": "Direct page locator call: n8n.page.getByRole('option')",
 				"hash": "c58b0877f9a1"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 30,
+				"line": 34,
 				"message": "Direct page locator call: n8n.page.getByRole('option').last().click()",
 				"hash": "4dcd8e905b3c"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 30,
+				"line": 34,
 				"message": "Direct page locator call: n8n.page.getByRole('option').last()",
 				"hash": "a8b0a552c436"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 30,
-				"message": "Direct page locator call: n8n.page.getByRole('option')",
-				"hash": "c58b0877f9a1"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 33,
-				"message": "Direct page locator call: n8n.page.getByRole('option').first()",
-				"hash": "f8c4aff6a0b3"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 33,
-				"message": "Direct page locator call: n8n.page.getByRole('option')",
-				"hash": "c58b0877f9a1"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 34,
-				"message": "Direct page locator call: n8n.page.getByRole('option').nth(1).click()",
-				"hash": "5a25d5a68877"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 34,
-				"message": "Direct page locator call: n8n.page.getByRole('option').nth(1)",
-				"hash": "0e8a6f4130fa"
 			},
 			{
 				"rule": "selector-purity",
@@ -3171,20 +3033,26 @@
 			{
 				"rule": "selector-purity",
 				"line": 37,
+				"message": "Direct page locator call: n8n.page.getByRole('option').first()",
+				"hash": "f8c4aff6a0b3"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 37,
 				"message": "Direct page locator call: n8n.page.getByRole('option')",
 				"hash": "c58b0877f9a1"
 			},
 			{
 				"rule": "selector-purity",
 				"line": 38,
-				"message": "Direct page locator call: n8n.page.getByRole('option').last().click()",
-				"hash": "4dcd8e905b3c"
+				"message": "Direct page locator call: n8n.page.getByRole('option').nth(1).click()",
+				"hash": "5a25d5a68877"
 			},
 			{
 				"rule": "selector-purity",
 				"line": 38,
-				"message": "Direct page locator call: n8n.page.getByRole('option').last()",
-				"hash": "a8b0a552c436"
+				"message": "Direct page locator call: n8n.page.getByRole('option').nth(1)",
+				"hash": "0e8a6f4130fa"
 			},
 			{
 				"rule": "selector-purity",
@@ -3263,30 +3131,48 @@
 				"line": 50,
 				"message": "Direct page locator call: n8n.page.getByRole('option')",
 				"hash": "c58b0877f9a1"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 53,
+				"message": "Direct page locator call: n8n.page.getByRole('option')",
+				"hash": "c58b0877f9a1"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 54,
+				"message": "Direct page locator call: n8n.page.getByRole('option').last().click()",
+				"hash": "4dcd8e905b3c"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 54,
+				"message": "Direct page locator call: n8n.page.getByRole('option').last()",
+				"hash": "a8b0a552c436"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 54,
+				"message": "Direct page locator call: n8n.page.getByRole('option')",
+				"hash": "c58b0877f9a1"
 			}
 		],
 		"tests/e2e/workflows/executions/list.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 45,
+				"line": 48,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Success' }).click()",
 				"hash": "fbad8571f166"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 45,
+				"line": 48,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Success' })",
 				"hash": "75835fe42ab8"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 189,
-				"message": "Chained locator call in test: iframe.locator('body')",
-				"hash": "44c6c75041a8"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 230,
+				"line": 192,
 				"message": "Chained locator call in test: iframe.locator('body')",
 				"hash": "44c6c75041a8"
 			},
@@ -3328,51 +3214,39 @@
 			},
 			{
 				"rule": "selector-purity",
-				"line": 312,
+				"line": 251,
+				"message": "Chained locator call in test: iframe.locator('body')",
+				"hash": "44c6c75041a8"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 270,
 				"message": "Direct page locator call: n8n.page.getByTestId('workflow-execution-no-trigger-conte...",
 				"hash": "407bd53b3360"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 314,
+				"line": 272,
 				"message": "Direct page locator call: n8n.page.getByRole('button', { name: 'Add first step' })....",
 				"hash": "90ae792f4909"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 314,
+				"line": 272,
 				"message": "Direct page locator call: n8n.page.getByRole('button', { name: 'Add first step' })",
 				"hash": "ae0e7537f378"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 320,
+				"line": 278,
 				"message": "Direct page locator call: n8n.page.getByTestId('workflow-execution-no-content')",
 				"hash": "36b71f3e9617"
-			},
-			{
-				"rule": "api-purity",
-				"line": 265,
-				"message": "Raw API call detected: request.post(",
-				"hash": "fc24119a27f0"
-			},
-			{
-				"rule": "api-purity",
-				"line": 283,
-				"message": "Raw API call detected: request.get(",
-				"hash": "5128d500e46f"
-			},
-			{
-				"rule": "api-purity",
-				"line": 291,
-				"message": "Raw API call detected: request.get(",
-				"hash": "5128d500e46f"
 			}
 		],
 		"tests/e2e/workflows/templates/templates.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 242,
+				"line": 246,
 				"message": "Chained locator call in test: n8n.templates.getDescription().locator('img')",
 				"hash": "5f06d991a2b6"
 			}
@@ -3454,7 +3328,7 @@
 		"tests/e2e/app-config/nps-survey.spec.ts": [
 			{
 				"rule": "api-purity",
-				"line": 46,
+				"line": 50,
 				"message": "Raw API call detected: fetch(",
 				"hash": "b52df352569e"
 			}
@@ -3462,7 +3336,7 @@
 		"tests/e2e/auth/password-reset.spec.ts": [
 			{
 				"rule": "api-purity",
-				"line": 7,
+				"line": 11,
 				"message": "Raw API call detected: request.post(",
 				"hash": "fc24119a27f0"
 			}
@@ -3470,7 +3344,7 @@
 		"tests/e2e/building-blocks/workflow-entry-points.spec.ts": [
 			{
 				"rule": "api-purity",
-				"line": 35,
+				"line": 39,
 				"message": "Raw API call detected: request.post(",
 				"hash": "fc24119a27f0"
 			}
@@ -3478,13 +3352,13 @@
 		"tests/e2e/capabilities/proxy-server.spec.ts": [
 			{
 				"rule": "api-purity",
-				"line": 23,
+				"line": 27,
 				"message": "Raw API call detected: fetch(",
 				"hash": "b52df352569e"
 			},
 			{
 				"rule": "api-purity",
-				"line": 60,
+				"line": 64,
 				"message": "Raw API call detected: fetch(",
 				"hash": "b52df352569e"
 			}
@@ -3492,7 +3366,7 @@
 		"tests/e2e/sharing/workflow-sharing.spec.ts": [
 			{
 				"rule": "api-purity",
-				"line": 118,
+				"line": 122,
 				"message": "Raw API call detected: request.get(",
 				"hash": "5128d500e46f"
 			}
@@ -3500,27 +3374,35 @@
 		"tests/e2e/workflows/editor/subworkflows/subworkflow-version-resolution.spec.ts": [
 			{
 				"rule": "api-purity",
-				"line": 60,
+				"line": 64,
 				"message": "Raw API call detected: request.patch(",
 				"hash": "8b1d786219ad"
 			},
 			{
 				"rule": "api-purity",
-				"line": 112,
+				"line": 116,
 				"message": "Raw API call detected: request.post(",
 				"hash": "fc24119a27f0"
 			},
 			{
 				"rule": "api-purity",
-				"line": 141,
+				"line": 145,
 				"message": "Raw API call detected: request.patch(",
 				"hash": "8b1d786219ad"
 			},
 			{
 				"rule": "api-purity",
-				"line": 294,
+				"line": 298,
 				"message": "Raw API call detected: request.patch(",
 				"hash": "8b1d786219ad"
+			}
+		],
+		"pages/WorkerViewPage.ts": [
+			{
+				"rule": "deduplication",
+				"line": 13,
+				"message": "Duplicate locator: this.page.getByTestId(\"menu-item\") in pages scope",
+				"hash": "d2fda13bfcbe"
 			}
 		],
 		"workflows/Test_workflow_5.json": [
@@ -3558,7 +3440,7 @@
 		"tests/e2e/workflows/editor/canvas/actions.spec.ts": [
 			{
 				"rule": "duplicate-logic",
-				"line": 62,
+				"line": 66,
 				"message": "Duplicate test logic: \"should add disconnected node if nothing is selected\" has identical structure to tests/e2e/building-blocks/canvas-actions.spec.ts:\"should add disconnected node when nothing selected\"",
 				"hash": "5cda70c65afc"
 			}
@@ -3566,7 +3448,7 @@
 		"tests/e2e/chat-hub/chat-hub-chat-user.spec.ts": [
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 24,
+				"line": 28,
 				"message": "Direct page instantiation: new ChatHubChatPage(n8n.page)",
 				"hash": "4c6c3053ee95"
 			}
@@ -3574,25 +3456,25 @@
 		"tests/e2e/chat-hub/chat-hub-settings.spec.ts": [
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 10,
+				"line": 14,
 				"message": "Direct page instantiation: new ChatHubSettingsPage(n8n.page)",
 				"hash": "03642a3feb2b"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 35,
+				"line": 39,
 				"message": "Direct page instantiation: new ChatHubChatPage(memberN8n.page)",
 				"hash": "397d824f0d69"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 57,
+				"line": 61,
 				"message": "Direct page instantiation: new ChatHubSettingsPage(n8n.page)",
 				"hash": "03642a3feb2b"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 94,
+				"line": 98,
 				"message": "Direct page instantiation: new ChatHubChatPage(memberN8n.page)",
 				"hash": "397d824f0d69"
 			}
@@ -3600,7 +3482,7 @@
 		"tests/e2e/chat-hub/chat-hub-tools.spec.ts": [
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 12,
+				"line": 16,
 				"message": "Direct page instantiation: new ChatHubChatPage(n8n.page)",
 				"hash": "4c6c3053ee95"
 			}
@@ -3608,55 +3490,55 @@
 		"tests/e2e/chat-hub/chat-hub-workflow-agent.spec.ts": [
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 12,
+				"line": 16,
 				"message": "Direct page instantiation: new ChatHubWorkflowAgentsPage(n8n.page)",
 				"hash": "c9be1b5d1bc9"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 13,
+				"line": 17,
 				"message": "Direct page instantiation: new ChatHubChatPage(n8n.page)",
 				"hash": "4c6c3053ee95"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 31,
+				"line": 35,
 				"message": "Direct page instantiation: new CanvasPage(tab1)",
 				"hash": "57ca97b38297"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 32,
+				"line": 36,
 				"message": "Direct page instantiation: new NodeDetailsViewPage(tab1)",
 				"hash": "b2f3d965950b"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 54,
+				"line": 58,
 				"message": "Direct page instantiation: new CanvasPage(tab2)",
 				"hash": "0bd465646efa"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 55,
+				"line": 59,
 				"message": "Direct page instantiation: new NodeDetailsViewPage(tab2)",
 				"hash": "e3b9a2a545fd"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 80,
+				"line": 84,
 				"message": "Direct page instantiation: new ChatHubWorkflowAgentsPage(n8n.page)",
 				"hash": "c9be1b5d1bc9"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 85,
+				"line": 89,
 				"message": "Direct page instantiation: new ChatHubWorkflowAgentsPage(memberN8n.page)",
 				"hash": "13e61175005b"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 103,
+				"line": 107,
 				"message": "Direct page instantiation: new ChatHubChatPage(memberN8n.page)",
 				"hash": "397d824f0d69"
 			}

--- a/packages/testing/playwright/CONTRIBUTING.md
+++ b/packages/testing/playwright/CONTRIBUTING.md
@@ -508,6 +508,7 @@ Before submitting your PR, ensure:
 - [ ] Constants used for repeated strings
 - [ ] Dynamic data includes timestamps to avoid conflicts
 - [ ] Methods are small and focused on one responsibility
+- [ ] Janitor passes on changed files (`pnpm janitor --file=<your-file>`)
 
 ---
 

--- a/packages/testing/playwright/composables/TemplatesComposer.ts
+++ b/packages/testing/playwright/composables/TemplatesComposer.ts
@@ -45,18 +45,6 @@ export class TemplatesComposer {
 	}
 
 	/**
-	 * Fill in dummy credentials for an app and handle confirmation dialog
-	 * @param appName - The name of the app
-	 */
-	async fillDummyCredentialForAppWithConfirm(
-		appName: string,
-		{ fields }: { fields: Record<string, string> } = { fields: {} },
-	): Promise<void> {
-		await this.fillDummyCredentialForApp(appName, { fields });
-		await this.n8n.templateCredentialSetup.dismissMessageBox();
-	}
-
-	/**
 	 * Fill in dummy credentials for an OAuth app.
 	 * OAuth credentials have no Save button — clicking Connect implicitly saves.
 	 * @param appName - The name of the app (e.g. 'X (Formerly Twitter)')

--- a/packages/testing/playwright/janitor.config.mjs
+++ b/packages/testing/playwright/janitor.config.mjs
@@ -22,8 +22,8 @@ export default defineConfig({
 		helpers: [
 			'helpers/**/*.ts',
 			'utils/**/*.ts',
-			'config/**/*.ts', // TODO: Move TestRequirements to helpers/
-			'tests/**/fixtures.ts', // TODO: Consolidate colocated fixtures
+			'config/**/*.ts',
+			'tests/**/fixtures.ts',
 		],
 		factories: ['test-data/**/*.ts', 'factories/**/*.ts'],
 		testData: ['workflows/**/*'],

--- a/packages/testing/playwright/package.json
+++ b/packages/testing/playwright/package.json
@@ -28,8 +28,8 @@
     "lint": "eslint . --quiet",
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit",
-    "janitor": "playwright-janitor",
-    "janitor:fix": "playwright-janitor --fix --write"
+    "janitor": "tsx ../janitor/src/cli.ts",
+    "janitor:fix": "tsx ../janitor/src/cli.ts --fix --write"
   },
   "devDependencies": {
     "@currents/playwright": "catalog:e2e",

--- a/packages/testing/playwright/pages/components/ChatHubToolsModal.ts
+++ b/packages/testing/playwright/pages/components/ChatHubToolsModal.ts
@@ -35,11 +35,6 @@ export class ChatHubToolsModal {
 		return this.getParameterInput(parameterName).getByTestId('from-ai-override-button');
 	}
 
-	/** Inline editable tool name in the settings view header */
-	getToolNameInput(): Locator {
-		return this.root.getByTestId('inline-editable-area');
-	}
-
 	/** Close button (X) shown in list view */
 	getCloseButton(): Locator {
 		return this.root.locator('.el-dialog__close').first();

--- a/packages/testing/playwright/pages/components/CredentialModal.ts
+++ b/packages/testing/playwright/pages/components/CredentialModal.ts
@@ -135,16 +135,8 @@ export class CredentialModal extends BaseModal {
 		await this.getNameInput().press('Enter');
 	}
 
-	getAuthMethodSelector() {
-		return this.root.getByTestId('credential-mode-selector');
-	}
-
 	getOAuthRedirectUrl() {
 		return this.root.page().getByTestId('oauth-redirect-url');
-	}
-
-	getAuthTypeRadioButtons() {
-		return this.root.page().locator('label.el-radio');
 	}
 
 	getModeSelector() {


### PR DESCRIPTION
## Summary
- **Eliminate build step for janitor**: Switch from compiled `playwright-janitor` CLI to `tsx ../janitor/src/cli.ts` so janitor runs from source. No more install/build/install dance.
- **Fix stale docs**: Rewrite janitor section in playwright README with correct subcommand-based CLI syntax (was still referencing old `npx tsx scripts/janitor/index.ts` paths). Add "Janitor Blocked My Commit - Now What?" section for when the lefthook is enabled.
- **Remove dead code**: 4 unused methods across 3 files (TCR-verified).
- **Update baseline**: Reflects the 4 removed violations.

## Details

### tsx change
Janitor scripts in `package.json` now use `tsx ../janitor/src/cli.ts` instead of the `playwright-janitor` bin entry. This means janitor works immediately after `pnpm install` with no build step. The published package still uses `dist/cli.js` via the bin entry.

### Dead code removed
| File | Method |
|------|--------|
| `TemplatesComposer.ts` | `fillDummyCredentialForAppWithConfirm()` |
| `ChatHubToolsModal.ts` | `getToolNameInput()` |
| `CredentialModal.ts` | `getAuthMethodSelector()` |
| `CredentialModal.ts` | `getAuthTypeRadioButtons()` |

### Docs updated
- Playwright README janitor section rewritten with correct commands and rule table
- Added "Janitor Blocked My Commit" troubleshooting section with fix examples
- Added janitor check to CONTRIBUTING.md code review checklist
- Removed TODO comments from `janitor.config.mjs`

## Test plan
- [x] `pnpm janitor --list` works via tsx (no build needed)
- [x] `pnpm janitor --rule=dead-code --ignore-baseline` reports 0 violations
- [x] `pnpm --filter=n8n-playwright typecheck` passes
- [x] TCR verified: rules pass, typecheck passes, no affected tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)