### PR TITLE
fix(editor): Stop hijacking search shortcut for layouts without search

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/layouts/ResourcesListLayout.vue
+++ b/packages/frontend/editor-ui/src/app/components/layouts/ResourcesListLayout.vue
@@ -310,6 +310,7 @@ onBeforeUnmount(() => {
 
 //methods
 const captureSearchHotKey = (e: KeyboardEvent) => {
+	if (!props.uiConfig.searchEnabled) return;
 	if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
 		e.preventDefault();
 		focusSearchInput();


### PR DESCRIPTION
## Summary
Prevent ResourceListLayout from hijacking `cmd+f` shortcut if search is not enabled.

## Related Linear tickets, Github issues, and Community forum posts
Fixes ADO-4859


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
