### PR TITLE
fix(editor): Fix spacing between workflow history (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryListItem.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryListItem.vue
@@ -217,6 +217,7 @@ onMounted(() => {
 				[$style.selected]: props.isSelected,
 				[$style.actionsVisible]: actionsVisible,
 				[$style.grouped]: props.isGrouped,
+				[$style.firstItem]: props.index === 0,
 			}"
 			@click="onItemClick"
 		>
@@ -302,12 +303,12 @@ $authorMaxWidth: 130px;
 
 	margin-top: var(--spacing--lg);
 
-	&:first-child {
+	&.firstItem {
 		margin-top: 0;
 	}
 
 	// Line segment in the gap above this item (not for first item)
-	&:not(:first-child):not(.grouped)::before {
+	&:not(.firstItem):not(.grouped)::before {
 		@include timeline-gap-line;
 	}
 


### PR DESCRIPTION
## Summary
Before:
<img width="321" height="213" alt="image" src="https://github.com/user-attachments/assets/da36d0df-1a53-4cf4-9629-57c98d4c5462" />

After:
<img width="324" height="267" alt="image" src="https://github.com/user-attachments/assets/49e6fd19-8dde-4a1e-868f-6b242c3b5b2e" />


## Related Linear tickets, Github issues, and Community forum posts
Fixes ADO-4826


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
