### PR TITLE
refactor(editor): Migrate workflow `checksum` to document store (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.test.ts
@@ -180,9 +180,9 @@ describe('WorkflowDetails', () => {
 	beforeEach(() => {
 		const docPinia = createTestingPinia({ stubActions: false });
 		setActivePinia(docPinia);
-		const docStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflow.id));
-		docStore.setActiveState({ activeVersionId: null, activeVersion: null });
-		workflowDocumentStoreRef.value = docStore;
+		const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflow.id));
+		workflowDocumentStore.setActiveState({ activeVersionId: null, activeVersion: null });
+		workflowDocumentStoreRef.value = workflowDocumentStore;
 		setActivePinia(pinia);
 
 		uiStore = useUIStore();
@@ -200,7 +200,7 @@ describe('WorkflowDetails', () => {
 		};
 		workflowsStore.isWorkflowSaved = { '1': true, '123': true };
 		workflowsStore.workflowId = workflow.id;
-		workflowsStore.workflowChecksum = 'test-checksum';
+		workflowDocumentStoreRef.value?.setChecksum('test-checksum');
 		projectsStore.currentProject = null;
 		projectsStore.personalProject = { id: 'personal', name: 'Personal' } as Project;
 		collaborationStore.shouldBeReadOnly = false;

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.vue
@@ -244,7 +244,7 @@ async function handleArchiveWorkflow() {
 
 	try {
 		const expectedChecksum =
-			props.id === workflowsStore.workflowId ? workflowsStore.workflowChecksum : undefined;
+			props.id === workflowsStore.workflowId ? workflowDocumentStore?.value?.checksum : undefined;
 		await workflowsStore.archiveWorkflow(props.id, expectedChecksum);
 		workflowDocumentStore?.value?.setActiveState({
 			activeVersionId: null,

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowPublishModal.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowPublishModal.test.ts
@@ -82,8 +82,8 @@ describe('WorkflowPublishModal', () => {
 		workflowsStore = mockedStore(useWorkflowsStore);
 		workflowsListStore = mockedStore(useWorkflowsListStore);
 
-		const docStore = useWorkflowDocumentStore(createWorkflowDocumentId('workflow-1'));
-		docStore.setActiveState({
+		const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId('workflow-1'));
+		workflowDocumentStore.setActiveState({
 			activeVersionId: 'old-version',
 			activeVersion: {
 				versionId: 'old-version',

--- a/packages/frontend/editor-ui/src/app/components/WorkflowProductionChecklist.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowProductionChecklist.test.ts
@@ -160,9 +160,11 @@ describe('WorkflowProductionChecklist', () => {
 
 	beforeEach(() => {
 		setActivePinia(createTestingPinia({ stubActions: false }));
-		const docStore = useWorkflowDocumentStore(createWorkflowDocumentId(mockWorkflow.id));
-		docStore.setActiveState({ activeVersionId: 'v1', activeVersion: null });
-		workflowDocumentStoreRef.value = docStore;
+		const workflowDocumentStore = useWorkflowDocumentStore(
+			createWorkflowDocumentId(mockWorkflow.id),
+		);
+		workflowDocumentStore.setActiveState({ activeVersionId: 'v1', activeVersion: null });
+		workflowDocumentStoreRef.value = workflowDocumentStore;
 
 		router = {
 			push: vi.fn(),

--- a/packages/frontend/editor-ui/src/app/components/WorkflowSettings.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowSettings.vue
@@ -42,6 +42,7 @@ import { useI18n } from '@n8n/i18n';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useDebounce } from '@/app/composables/useDebounce';
 import { injectWorkflowState } from '@/app/composables/useWorkflowState';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useMcp } from '@/features/ai/mcpAccess/composables/useMcp';
 import { useGlobalLinkActions } from '@/app/composables/useGlobalLinkActions';
 import { useNodeCreatorStore } from '@/features/shared/nodeCreator/nodeCreator.store';
@@ -67,6 +68,7 @@ const collaborationStore = useCollaborationStore();
 const workflowsStore = useWorkflowsStore();
 const workflowsListStore = useWorkflowsListStore();
 const workflowState = injectWorkflowState();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const workflowsEEStore = useWorkflowsEEStore();
 const nodeCreatorStore = useNodeCreatorStore();
 const posthogStore = usePostHog();
@@ -501,7 +503,7 @@ const saveSettings = async () => {
 
 	isLoading.value = true;
 	data.versionId = workflowsStore.workflowVersionId;
-	data.expectedChecksum = workflowsStore.workflowChecksum;
+	data.expectedChecksum = workflowDocumentStore?.value?.checksum ?? '';
 
 	try {
 		await workflowsStore.updateWorkflow(String(route.params.name), data);

--- a/packages/frontend/editor-ui/src/app/components/WorkflowSettings.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowSettings.vue
@@ -503,7 +503,7 @@ const saveSettings = async () => {
 
 	isLoading.value = true;
 	data.versionId = workflowsStore.workflowVersionId;
-	data.expectedChecksum = workflowDocumentStore?.value?.checksum ?? '';
+	data.expectedChecksum = workflowDocumentStore?.value?.checksum;
 
 	try {
 		await workflowsStore.updateWorkflow(String(route.params.name), data);

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.ts
@@ -105,7 +105,7 @@ export function useWorkflowActivate() {
 
 		try {
 			const expectedChecksum =
-				workflowId === workflowsStore.workflowId ? workflowsStore.workflowChecksum : undefined;
+				workflowId === workflowsStore.workflowId ? workflowDocumentStore.checksum : undefined;
 
 			const updatedWorkflow = await workflowsStore.publishWorkflow(workflowId, {
 				versionId,
@@ -124,14 +124,14 @@ export function useWorkflowActivate() {
 			});
 
 			if (workflowId === workflowsStore.workflowId) {
-				workflowsStore.setWorkflowVersionData(
-					{
-						versionId: updatedWorkflow.versionId,
-						name: workflowsStore.versionData?.name ?? null,
-						description: workflowsStore.versionData?.description ?? null,
-					},
-					updatedWorkflow.checksum,
-				);
+				workflowsStore.setWorkflowVersionData({
+					versionId: updatedWorkflow.versionId,
+					name: workflowsStore.versionData?.name ?? null,
+					description: workflowsStore.versionData?.description ?? null,
+				});
+				if (updatedWorkflow.checksum) {
+					workflowDocumentStore.setChecksum(updatedWorkflow.checksum);
+				}
 			}
 
 			void useExternalHooks().run('workflow.published', {
@@ -190,7 +190,7 @@ export function useWorkflowActivate() {
 		const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
 		try {
 			const expectedChecksum =
-				workflowId === workflowsStore.workflowId ? workflowsStore.workflowChecksum : undefined;
+				workflowId === workflowsStore.workflowId ? workflowDocumentStore.checksum : undefined;
 
 			await workflowsStore.deactivateWorkflow(workflowId, expectedChecksum);
 			workflowDocumentStore.setActiveState({

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
@@ -268,10 +268,11 @@ describe('useWorkflowHelpers', () => {
 				executionOrder: 'v1',
 				timezone: 'DEFAULT',
 			});
-			expect(setWorkflowVersionDataSpy).toHaveBeenCalledWith(
-				{ versionId: 'v1', name: null, description: null },
-				'checksum',
-			);
+			expect(setWorkflowVersionDataSpy).toHaveBeenCalledWith({
+				versionId: 'v1',
+				name: null,
+				description: null,
+			});
 			expect(setWorkflowMetadataSpy).toHaveBeenCalledWith({});
 			expect(setWorkflowScopesSpy).toHaveBeenCalledWith(['workflow:create']);
 			expect(setUsedCredentialsSpy).toHaveBeenCalledWith([]);

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
@@ -980,14 +980,11 @@ export function useWorkflowHelpers() {
 			setStateDirty: uiStore.stateIsDirty,
 		});
 		ws.setWorkflowSettings(workflowData.settings ?? {});
-		workflowsStore.setWorkflowVersionData(
-			{
-				versionId: workflowData.versionId,
-				name: null,
-				description: null,
-			},
-			workflowData.checksum,
-		);
+		workflowsStore.setWorkflowVersionData({
+			versionId: workflowData.versionId,
+			name: null,
+			description: null,
+		});
 		ws.setWorkflowMetadata(workflowData.meta);
 		ws.setWorkflowScopes(workflowData.scopes);
 
@@ -1036,6 +1033,9 @@ export function useWorkflowHelpers() {
 			activeVersion: workflowData.activeVersion ?? null,
 		});
 		workflowDocumentStore.setPinData(workflowData.pinData ?? {});
+		if (workflowData.checksum) {
+			workflowDocumentStore.setChecksum(workflowData.checksum);
+		}
 		tagsStore.upsertTags(tags);
 
 		return { workflowDocumentStore };

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
@@ -211,7 +211,10 @@ export function useWorkflowSaving({
 				workflowDataRequest.versionId = workflowsStore.workflowVersionId;
 				// Check if AI Builder made edits since last save
 				workflowDataRequest.aiBuilderAssisted = builderStore.getAiBuilderMadeEdits();
-				workflowDataRequest.expectedChecksum = workflowsStore.workflowChecksum;
+				const workflowDocumentStore = useWorkflowDocumentStore(
+					createWorkflowDocumentId(currentWorkflow),
+				);
+				workflowDataRequest.expectedChecksum = workflowDocumentStore.checksum;
 				workflowDataRequest.autosaved = autosaved;
 
 				const workflowData = await workflowsStore.updateWorkflow(
@@ -222,14 +225,11 @@ export function useWorkflowSaving({
 				if (!workflowData.checksum) {
 					throw new Error('Failed to update workflow');
 				}
-				workflowsStore.setWorkflowVersionData(
-					{
-						versionId: workflowData.versionId,
-						name: null,
-						description: null,
-					},
-					workflowData.checksum,
-				);
+				workflowsStore.setWorkflowVersionData({
+					versionId: workflowData.versionId,
+					name: null,
+					description: null,
+				});
 				workflowState.setWorkflowProperty('updatedAt', workflowData.updatedAt);
 
 				// Only mark state clean if no new changes were made during the save
@@ -474,15 +474,15 @@ export function useWorkflowSaving({
 				activeVersionId: workflowData.activeVersionId,
 				activeVersion: workflowData.activeVersion ?? null,
 			});
+			if (workflowData.checksum) {
+				workflowDocumentStore.setChecksum(workflowData.checksum);
+			}
 			workflowState.setWorkflowId(workflowData.id);
-			workflowsStore.setWorkflowVersionData(
-				{
-					versionId: workflowData.versionId,
-					name: null,
-					description: null,
-				},
-				workflowData.checksum,
-			);
+			workflowsStore.setWorkflowVersionData({
+				versionId: workflowData.versionId,
+				name: null,
+				description: null,
+			});
 			workflowState.setWorkflowProperty('updatedAt', workflowData.updatedAt);
 
 			// Only update webhook IDs if we explicitly reset them

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
@@ -3,6 +3,7 @@ import { STORES } from '@n8n/stores';
 import { inject } from 'vue';
 import { WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
 import { useWorkflowDocumentActive } from './workflowDocument/useWorkflowDocumentActive';
+import { useWorkflowDocumentChecksum } from './workflowDocument/useWorkflowDocumentChecksum';
 import { useWorkflowDocumentPinData } from './workflowDocument/useWorkflowDocumentPinData';
 import { useWorkflowDocumentTags } from './workflowDocument/useWorkflowDocumentTags';
 
@@ -47,6 +48,7 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 		const [workflowId, workflowVersion] = id.split('@');
 
 		const workflowDocumentActive = useWorkflowDocumentActive();
+		const workflowDocumentChecksum = useWorkflowDocumentChecksum();
 		const workflowDocumentTags = useWorkflowDocumentTags();
 		const workflowDocumentPinData = useWorkflowDocumentPinData();
 
@@ -54,6 +56,7 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 			workflowId,
 			workflowVersion,
 			...workflowDocumentActive,
+			...workflowDocumentChecksum,
 			...workflowDocumentTags,
 			...workflowDocumentPinData,
 		};

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentChecksum.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentChecksum.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { useWorkflowDocumentChecksum } from './useWorkflowDocumentChecksum';
+
+function createChecksum() {
+	return useWorkflowDocumentChecksum();
+}
+
+describe('useWorkflowDocumentChecksum', () => {
+	describe('initial state', () => {
+		it('should start with empty string', () => {
+			const { checksum } = createChecksum();
+			expect(checksum.value).toBe('');
+		});
+	});
+
+	describe('setChecksum', () => {
+		it('should set checksum and fire event hook', () => {
+			const { checksum, setChecksum, onChecksumChange } = createChecksum();
+			const hookSpy = vi.fn();
+			onChecksumChange(hookSpy);
+
+			setChecksum('abc123');
+
+			expect(checksum.value).toBe('abc123');
+			expect(hookSpy).toHaveBeenCalledWith({
+				action: 'update',
+				payload: { checksum: 'abc123' },
+			});
+		});
+
+		it('should replace existing checksum', () => {
+			const { checksum, setChecksum } = createChecksum();
+			setChecksum('abc123');
+
+			setChecksum('def456');
+
+			expect(checksum.value).toBe('def456');
+		});
+
+		it('should fire event hook on every call', () => {
+			const { setChecksum, onChecksumChange } = createChecksum();
+			const hookSpy = vi.fn();
+			onChecksumChange(hookSpy);
+
+			setChecksum('abc123');
+			setChecksum('def456');
+
+			expect(hookSpy).toHaveBeenCalledTimes(2);
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentChecksum.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentChecksum.ts
@@ -1,0 +1,31 @@
+import { ref, readonly } from 'vue';
+import { createEventHook } from '@vueuse/core';
+import { CHANGE_ACTION } from './types';
+import type { ChangeAction, ChangeEvent } from './types';
+
+export type ChecksumPayload = {
+	checksum: string;
+};
+
+export type ChecksumChangeEvent = ChangeEvent<ChecksumPayload>;
+
+export function useWorkflowDocumentChecksum() {
+	const checksum = ref<string>('');
+
+	const onChecksumChange = createEventHook<ChecksumChangeEvent>();
+
+	function applyChecksum(newChecksum: string, action: ChangeAction = CHANGE_ACTION.UPDATE) {
+		checksum.value = newChecksum;
+		void onChecksumChange.trigger({ action, payload: { checksum: newChecksum } });
+	}
+
+	function setChecksum(newChecksum: string) {
+		applyChecksum(newChecksum);
+	}
+
+	return {
+		checksum: readonly(checksum),
+		setChecksum,
+		onChecksumChange: onChecksumChange.on,
+	};
+}

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -160,8 +160,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 
 	const workflowVersionId = computed(() => workflow.value.versionId);
 
-	const workflowChecksum = ref<string>('');
-
 	const workflowSettings = computed(() => workflow.value.settings ?? { ...defaults.settings });
 
 	// A workflow is new if it hasn't been saved to the backend yet
@@ -638,7 +636,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 
 	function resetWorkflow() {
 		workflow.value = createEmptyWorkflow();
-		workflowChecksum.value = '';
 	}
 
 	function setUsedCredentials(data: IUsedCredential[]) {
@@ -653,12 +650,9 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		workflow.value.activeVersion = deepCopy(version);
 	}
 
-	function setWorkflowVersionData(version: WorkflowVersionData, newChecksum?: string) {
+	function setWorkflowVersionData(version: WorkflowVersionData) {
 		versionData.value = deepCopy(version);
 		workflow.value.versionId = version.versionId;
-		if (newChecksum) {
-			workflowChecksum.value = newChecksum;
-		}
 	}
 
 	// replace invalid credentials in workflow
@@ -751,14 +745,13 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 
 		if (id === workflow.value.id) {
 			setIsArchived(true);
-			setWorkflowVersionData(
-				{
-					versionId: updatedWorkflow.versionId,
-					name: versionData.value?.name ?? null,
-					description: versionData.value?.description ?? null,
-				},
-				updatedWorkflow.checksum,
-			);
+			setWorkflowVersionData({
+				versionId: updatedWorkflow.versionId,
+				name: versionData.value?.name ?? null,
+				description: versionData.value?.description ?? null,
+			});
+			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(id));
+			workflowDocumentStore.setChecksum(updatedWorkflow.checksum!);
 		}
 	}
 
@@ -767,14 +760,13 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 
 		if (id === workflow.value.id) {
 			setIsArchived(false);
-			setWorkflowVersionData(
-				{
-					versionId: updatedWorkflow.versionId,
-					name: versionData.value?.name ?? null,
-					description: versionData.value?.description ?? null,
-				},
-				updatedWorkflow.checksum,
-			);
+			setWorkflowVersionData({
+				versionId: updatedWorkflow.versionId,
+				name: versionData.value?.name ?? null,
+				description: versionData.value?.description ?? null,
+			});
+			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(id));
+			workflowDocumentStore.setChecksum(updatedWorkflow.checksum!);
 		}
 	}
 
@@ -1357,14 +1349,13 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		}
 
 		if (id === workflow.value.id) {
-			setWorkflowVersionData(
-				{
-					versionId: updatedWorkflow.versionId,
-					name: versionData.value?.name ?? null,
-					description: versionData.value?.description ?? null,
-				},
-				updatedWorkflow.checksum,
-			);
+			setWorkflowVersionData({
+				versionId: updatedWorkflow.versionId,
+				name: versionData.value?.name ?? null,
+				description: versionData.value?.description ?? null,
+			});
+			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(id));
+			workflowDocumentStore.setChecksum(updatedWorkflow.checksum);
 		}
 
 		if (
@@ -1408,14 +1399,13 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		setWorkflowInactive(id);
 
 		if (id === workflow.value.id) {
-			setWorkflowVersionData(
-				{
-					versionId: updatedWorkflow.versionId,
-					name: versionData.value?.name ?? null,
-					description: versionData.value?.description ?? null,
-				},
-				updatedWorkflow.checksum,
-			);
+			setWorkflowVersionData({
+				versionId: updatedWorkflow.versionId,
+				name: versionData.value?.name ?? null,
+				description: versionData.value?.description ?? null,
+			});
+			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(id));
+			workflowDocumentStore.setChecksum(updatedWorkflow.checksum);
 		}
 
 		return updatedWorkflow;
@@ -1436,7 +1426,8 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		if (isCurrentWorkflow) {
 			currentSettings = workflow.value.settings ?? ({} as IWorkflowSettings);
 			currentVersionId = workflow.value.versionId;
-			currentChecksum = workflowChecksum.value;
+			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(id));
+			currentChecksum = workflowDocumentStore.checksum;
 		} else {
 			const cached = workflowsListStore.getWorkflowById(id);
 			if (cached && cached.versionId) {
@@ -1483,7 +1474,8 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 
 		if (isCurrentWorkflow) {
 			currentVersionId = workflow.value.versionId;
-			currentChecksum = workflowChecksum.value;
+			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(id));
+			currentChecksum = workflowDocumentStore.checksum;
 		} else {
 			const cached = workflowsListStore.getWorkflowById(id);
 			if (cached?.versionId) {
@@ -1712,7 +1704,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		workflowName,
 		workflowId,
 		workflowVersionId,
-		workflowChecksum,
 		workflowSettings,
 		isNewWorkflow,
 		isWorkflowSaved,


### PR DESCRIPTION
## Summary

This pull request refactors how workflow checksums are managed in the frontend editor UI. The checksum state and logic are moved from the global `workflows.store.ts` to the per-document `workflowDocument.store.ts`, ensuring that each workflow document manages its own checksum. This improves data consistency, modularity, and testability. All usages of the checksum are updated to use the new per-document store, and related tests and components are adjusted accordingly.

**Checksum Management Refactor**

* Introduced a new composable, `useWorkflowDocumentChecksum`, to handle checksum state and events for each workflow document, including associated tests. [[1]](diffhunk://#diff-52232bc77eaff8beaf8af6b6f5a511bbfaa04530133a6329556774a92906097aR1-R31) [[2]](diffhunk://#diff-4292c8e0d38302090742591ef590b5589e98da60b399b99e8560e02d45745c2bR1-R51)
* Integrated `useWorkflowDocumentChecksum` into `workflowDocument.store.ts`, making checksum available as part of the workflow document store API. [[1]](diffhunk://#diff-6b8f84de4dac5b49836cb575a2bfc6bdc949f9283a1dc2af763fe8e8c4fe1078R6) [[2]](diffhunk://#diff-6b8f84de4dac5b49836cb575a2bfc6bdc949f9283a1dc2af763fe8e8c4fe1078R51-R59)

**Removal from Global Store**

* Removed the global `workflowChecksum` state and related logic from `workflows.store.ts`, including updating `setWorkflowVersionData` to no longer accept or set a checksum. [[1]](diffhunk://#diff-60961aa352d313a6bb585e173f0a0424946c93b11fd447cb4942bdc7278fc4a0L163-L164) [[2]](diffhunk://#diff-60961aa352d313a6bb585e173f0a0424946c93b11fd447cb4942bdc7278fc4a0L641) [[3]](diffhunk://#diff-60961aa352d313a6bb585e173f0a0424946c93b11fd447cb4942bdc7278fc4a0L656-L661)

**Checksum Usage Updates**

* Updated all composables (`useWorkflowActivate`, `useWorkflowHelpers`, `useWorkflowSaving`) and components (`WorkflowSettings.vue`, `WorkflowDetails.vue`) to use the checksum from the workflow document store instead of the global store. [[1]](diffhunk://#diff-def9f7a3c8e60311db533c6787c7e9c803b8007b1533c090940398f38bec3115L108-R108) [[2]](diffhunk://#diff-def9f7a3c8e60311db533c6787c7e9c803b8007b1533c090940398f38bec3115L193-R193) [[3]](diffhunk://#diff-8fb9478ace4e8e530ab78331a576d3fff420afa30f05c6de7c4786dbae9dc3fbL983-R987) [[4]](diffhunk://#diff-8fb9478ace4e8e530ab78331a576d3fff420afa30f05c6de7c4786dbae9dc3fbR1036-R1038) [[5]](diffhunk://#diff-cb61698542c4e1905ddfe131f5ab534ce0f63e4e352dc4490122befe5d0f14e8L214-R217) [[6]](diffhunk://#diff-cb61698542c4e1905ddfe131f5ab534ce0f63e4e352dc4490122befe5d0f14e8L225-R232) [[7]](diffhunk://#diff-cb61698542c4e1905ddfe131f5ab534ce0f63e4e352dc4490122befe5d0f14e8R477-R485) [[8]](diffhunk://#diff-c71676b22cf0cfd5fa57bd1049d90b7f2b9b5a3fa9caa4cccf9168da24b36b99L504-R506) [[9]](diffhunk://#diff-b5088e218e48601bfab4966fbdec63319cbe26139a54314548518f3095508e83L247-R247) [[10]](diffhunk://#diff-e430746bcaefa02e0a47c1177d16b5e92cfb24118ba564135136819038bf3163L203-R203)

**Checksum Synchronization**

* Ensured that after workflow actions (archive, publish, deactivate, save), the checksum is updated in the workflow document store, including in store actions and tests. [[1]](diffhunk://#diff-60961aa352d313a6bb585e173f0a0424946c93b11fd447cb4942bdc7278fc4a0L754-R754) [[2]](diffhunk://#diff-60961aa352d313a6bb585e173f0a0424946c93b11fd447cb4942bdc7278fc4a0L770-R769) [[3]](diffhunk://#diff-60961aa352d313a6bb585e173f0a0424946c93b11fd447cb4942bdc7278fc4a0L1360-R1358) [[4]](diffhunk://#diff-e430746bcaefa02e0a47c1177d16b5e92cfb24118ba564135136819038bf3163L183-R185) [[5]](diffhunk://#diff-0e36796c29e25e2269c54504376285daf1132e82c65f2620c8fc60d293abcca7L85-R86) [[6]](diffhunk://#diff-e78bc338cc4765ff49823e081fd024fb6b17eb31152e30387aa191c453098536L163-R167) [[7]](diffhunk://#diff-41478f0a5f6dbfb9c7209a4792c5f097ceaca8c403769d5a2ac4fba68bd2a753L271-R275)

**Component and Test Adjustments**

* Updated all relevant components and tests to reference the checksum from the workflow document store, ensuring consistency and correctness after the refactor. [[1]](diffhunk://#diff-c71676b22cf0cfd5fa57bd1049d90b7f2b9b5a3fa9caa4cccf9168da24b36b99R45) [[2]](diffhunk://#diff-c71676b22cf0cfd5fa57bd1049d90b7f2b9b5a3fa9caa4cccf9168da24b36b99R71)

This refactor centralizes checksum management per workflow document, reducing global state complexity and improving maintainability.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2372/normalize-checksum-field-in-workflow-document-state

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
