### PR TITLE
fix(core): Don't show setup in demo mode

### DIFF
--- a/packages/cli/src/services/__tests__/frontend.service.test.ts
+++ b/packages/cli/src/services/__tests__/frontend.service.test.ts
@@ -284,8 +284,12 @@ describe('FrontendService', () => {
 			process.env.N8N_PREVIEW_MODE = 'true';
 
 			const { service } = createMockService();
-			const settings = await service.getPublicSettings(false);
+			const publicSettings = await service.getPublicSettings(false);
 
+			expect(publicSettings.previewMode).toBe(true);
+			expect(publicSettings.userManagement.showSetupOnFirstLoad).toBe(false);
+
+			const settings = await service.getSettings();
 			expect(settings.previewMode).toBe(true);
 			expect(settings.userManagement.showSetupOnFirstLoad).toBe(false);
 		});

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -150,6 +150,13 @@ export class FrontendService {
 		return envFeatureFlags;
 	}
 
+	private async getShowSetupOnFirstLoad() {
+		const previewMode = process.env.N8N_PREVIEW_MODE === 'true';
+		const hasInstanceOwner = await this.ownershipService.hasInstanceOwner();
+		// In preview mode, skip the setup redirect to allow accessing demo routes
+		return previewMode ? false : !hasInstanceOwner;
+	}
+
 	private async initSettings() {
 		const instanceBaseUrl = this.urlService.getInstanceBaseUrl();
 		const restEndpoint = this.globalConfig.endpoints.rest;
@@ -173,7 +180,6 @@ export class FrontendService {
 		}
 
 		const previewMode = process.env.N8N_PREVIEW_MODE === 'true';
-		const hasInstanceOwner = await this.ownershipService.hasInstanceOwner();
 
 		this.settings = {
 			settingsMode: 'authenticated',
@@ -240,8 +246,7 @@ export class FrontendService {
 			defaultLocale: this.globalConfig.defaultLocale,
 			userManagement: {
 				quota: this.license.getUsersLimit(),
-				// In preview mode, skip the setup redirect to allow accessing demo routes
-				showSetupOnFirstLoad: !previewMode && !hasInstanceOwner,
+				showSetupOnFirstLoad: await this.getShowSetupOnFirstLoad(),
 				smtpSetup: this.mailer.isEmailSetUp,
 				authenticationMethod: getCurrentAuthenticationMethod(),
 			},
@@ -395,7 +400,6 @@ export class FrontendService {
 	}
 
 	async getSettings(): Promise<FrontendSettings> {
-		console.log('getSettings');
 		if (!this.settings) {
 			await this.initSettings();
 		}
@@ -413,7 +417,7 @@ export class FrontendService {
 		Object.assign(this.settings.userManagement, {
 			quota: this.license.getUsersLimit(),
 			authenticationMethod: getCurrentAuthenticationMethod(),
-			showSetupOnFirstLoad: !(await this.ownershipService.hasInstanceOwner()),
+			showSetupOnFirstLoad: await this.getShowSetupOnFirstLoad(),
 		});
 
 		let dismissedBanners: string[] = [];
@@ -560,7 +564,6 @@ export class FrontendService {
 			mfa,
 			communityNodesEnabled,
 		} = await this.getSettings();
-
 		const publicSettings: PublicFrontendSettings = {
 			settingsMode: 'public',
 			defaultLocale,

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -172,12 +172,15 @@ export class FrontendService {
 			telemetrySettings.config = { key, url, proxy, sourceConfig };
 		}
 
+		const previewMode = process.env.N8N_PREVIEW_MODE === 'true';
+		const hasInstanceOwner = await this.ownershipService.hasInstanceOwner();
+
 		this.settings = {
 			settingsMode: 'authenticated',
 			inE2ETests,
 			isDocker: this.instanceSettings.isDocker,
 			databaseType: this.globalConfig.database.type,
-			previewMode: process.env.N8N_PREVIEW_MODE === 'true',
+			previewMode,
 			endpointForm: this.globalConfig.endpoints.form,
 			endpointFormTest: this.globalConfig.endpoints.formTest,
 			endpointFormWaiting: this.globalConfig.endpoints.formWaiting,
@@ -237,7 +240,8 @@ export class FrontendService {
 			defaultLocale: this.globalConfig.defaultLocale,
 			userManagement: {
 				quota: this.license.getUsersLimit(),
-				showSetupOnFirstLoad: !(await this.ownershipService.hasInstanceOwner()),
+				// In preview mode, skip the setup redirect to allow accessing demo routes
+				showSetupOnFirstLoad: !previewMode && !hasInstanceOwner,
 				smtpSetup: this.mailer.isEmailSetUp,
 				authenticationMethod: getCurrentAuthenticationMethod(),
 			},
@@ -391,6 +395,7 @@ export class FrontendService {
 	}
 
 	async getSettings(): Promise<FrontendSettings> {
+		console.log('getSettings');
 		if (!this.settings) {
 			await this.initSettings();
 		}
@@ -561,8 +566,7 @@ export class FrontendService {
 			defaultLocale,
 			userManagement: {
 				authenticationMethod,
-				// In preview mode, skip the setup redirect to allow accessing demo routes
-				showSetupOnFirstLoad: previewMode ? false : showSetupOnFirstLoad,
+				showSetupOnFirstLoad,
 				smtpSetup,
 			},
 			sso: {


### PR DESCRIPTION
## Summary

This PR fixes issue when sometimes in demo mode n8n returned `showSetupOnFirstLoad: true`

Testing:
- copy `hooks` directory locally from [here](https://github.com/n8n-io/n8n-argo-apps/tree/main/apps/n8n-preview-service/chart/files/hooks)
- Set those envs
```
EXTERNAL_HOOK_FILES=path/to/hooks/directory
N8N_PREVIEW_MODE=true
NODE_ENV=production
N8N_USER_MANAGEMENT_JWT_SECRET=secret
```
- open http://localhost:5678/workflows/demo

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
