### PR TITLE
fix(editor): Fix grid alignment on Safari 18.6

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.vue
@@ -134,6 +134,7 @@ const handleClick = (event: MouseEvent) => {
 	user-select: none;
 	width: fit-content;
 	display: grid;
+	align-items: center;
 	font-weight: var(--font-weight--medium);
 	line-height: 1;
 	cursor: pointer;


### PR DESCRIPTION
## Summary
Fixes broken `display:grid;` alignment by adding `align-items:center;` as Safari 18.6 doesn't do this by default like Chrome or Firefox.

## Related Linear tickets, Github issues, and Community forum posts

[N8N-9720](https://linear.app/n8n/issue/N8N-9720/incorrect-icontext-alignment-in-new-button-components-in-safari)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
