### PR TITLE
fix(editor): Fix `What's new` callout position (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/css/_global.scss
+++ b/packages/frontend/editor-ui/src/app/css/_global.scss
@@ -178,6 +178,7 @@
 	&.whats-new-notification {
 		bottom: var(--spacing--xs) !important;
 		left: var(--spacing--sm) !important;
+		margin-bottom: 0;
 		width: 300px;
 		padding: var(--spacing--xs);
 		border: var(--border);


### PR DESCRIPTION
## Summary
Before:

<img width="746" height="986" alt="image" src="https://github.com/user-attachments/assets/cc249504-9f64-48c9-9327-3f926fc9e29d" />

After:
<img width="744" height="989" alt="image" src="https://github.com/user-attachments/assets/2d7fbd2d-8e9f-43b8-a0b5-038d824245eb" />

## Related Linear tickets, Github issues, and Community forum posts
Fixes ADO-4790


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
