### PR TITLE
chore(core): Add redaction policy to workflow setting

### DIFF
--- a/packages/@n8n/api-types/src/dto/workflows/__tests__/create-workflow.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/__tests__/create-workflow.dto.test.ts
@@ -32,6 +32,15 @@ describe('CreateWorkflowDto', () => {
 				},
 			},
 			{
+				name: 'with redactionPolicy setting',
+				request: {
+					name: 'Redacted Workflow',
+					nodes: [],
+					connections: {},
+					settings: { redactionPolicy: 'non-manual' },
+				},
+			},
+			{
 				name: 'with tags as objects (backward compatibility)',
 				request: {
 					name: 'Tagged Workflow',

--- a/packages/@n8n/api-types/src/dto/workflows/__tests__/create-workflow.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/__tests__/create-workflow.dto.test.ts
@@ -32,7 +32,25 @@ describe('CreateWorkflowDto', () => {
 				},
 			},
 			{
-				name: 'with redactionPolicy setting',
+				name: 'with redactionPolicy none',
+				request: {
+					name: 'Redacted Workflow',
+					nodes: [],
+					connections: {},
+					settings: { redactionPolicy: 'none' },
+				},
+			},
+			{
+				name: 'with redactionPolicy all',
+				request: {
+					name: 'Redacted Workflow',
+					nodes: [],
+					connections: {},
+					settings: { redactionPolicy: 'all' },
+				},
+			},
+			{
+				name: 'with redactionPolicy non-manual',
 				request: {
 					name: 'Redacted Workflow',
 					nodes: [],

--- a/packages/@n8n/api-types/src/dto/workflows/__tests__/update-workflow.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/__tests__/update-workflow.dto.test.ts
@@ -32,6 +32,12 @@ describe('UpdateWorkflowDto', () => {
 				},
 			},
 			{
+				name: 'update redactionPolicy setting',
+				request: {
+					settings: { redactionPolicy: 'all' },
+				},
+			},
+			{
 				name: 'update multiple fields',
 				request: {
 					name: 'Updated Workflow',

--- a/packages/@n8n/api-types/src/dto/workflows/__tests__/update-workflow.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/__tests__/update-workflow.dto.test.ts
@@ -32,9 +32,21 @@ describe('UpdateWorkflowDto', () => {
 				},
 			},
 			{
-				name: 'update redactionPolicy setting',
+				name: 'update redactionPolicy to none',
+				request: {
+					settings: { redactionPolicy: 'none' },
+				},
+			},
+			{
+				name: 'update redactionPolicy to all',
 				request: {
 					settings: { redactionPolicy: 'all' },
+				},
+			},
+			{
+				name: 'update redactionPolicy to non-manual',
+				request: {
+					settings: { redactionPolicy: 'non-manual' },
 				},
 			},
 			{

--- a/packages/core/src/execution-engine/execution-context.ts
+++ b/packages/core/src/execution-engine/execution-context.ts
@@ -129,6 +129,10 @@ export const establishExecutionContext = async (
 		version: 1,
 		establishedAt: Date.now(),
 		source: mode,
+		redaction: {
+			version: 1,
+			policy: workflow.settings?.redactionPolicy ?? 'none',
+		},
 	};
 
 	if (runExecutionData.parentExecution) {

--- a/packages/workflow/src/execution-context.ts
+++ b/packages/workflow/src/execution-context.ts
@@ -45,6 +45,19 @@ const WorkflowExecuteModeSchema = z.union([
 
 export type WorkflowExecuteModeValues = z.infer<typeof WorkflowExecuteModeSchema>;
 
+const RedactionPolicySchema = z.union([
+	z.literal('none'),
+	z.literal('all'),
+	z.literal('non-manual'),
+]);
+
+const RedactionSettingSchemaV1 = z.object({
+	version: z.literal(1),
+	policy: RedactionPolicySchema,
+});
+
+export type IRedactionSettingV1 = z.output<typeof RedactionSettingSchemaV1>;
+
 const ExecutionContextSchemaV1 = z.object({
 	version: z.literal(1),
 	/**
@@ -82,6 +95,13 @@ const ExecutionContextSchemaV1 = z.object({
 		description:
 			'Encrypted credential context for dynamic credential resolution Always encrypted when stored, decrypted on-demand by credential resolver @see ICredentialContext for decrypted structure',
 	}),
+
+	/**
+	 * Redaction setting captured at execution time.
+	 * Persisted so the correct redaction policy is applied when reading execution data,
+	 * regardless of any subsequent changes to the workflow setting.
+	 */
+	redaction: RedactionSettingSchemaV1.optional(),
 });
 
 export type IExecutionContextV1 = z.output<typeof ExecutionContextSchemaV1>;

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2937,6 +2937,7 @@ export type WorkflowActivateMode =
 export namespace WorkflowSettings {
 	export type CallerPolicy = 'any' | 'none' | 'workflowsFromAList' | 'workflowsFromSameOwner';
 	export type SaveDataExecution = 'DEFAULT' | 'all' | 'none';
+	export type RedactionPolicy = 'none' | 'all' | 'non-manual';
 }
 
 export type WorkflowSettingsBinaryMode = typeof BINARY_MODE_SEPARATE | typeof BINARY_MODE_COMBINED;
@@ -2957,6 +2958,7 @@ export interface IWorkflowSettings {
 	timeSavedMode?: 'fixed' | 'dynamic';
 	availableInMCP?: boolean;
 	credentialResolverId?: string;
+	redactionPolicy?: WorkflowSettings.RedactionPolicy;
 }
 
 export interface WorkflowFEMeta {


### PR DESCRIPTION
## Summary

- Add `redactionPolicy` field (`'none' | 'all' | 'non-manual'`) to `IWorkflowSettings` for per-workflow execution data redaction control
- Capture the active redaction policy in the execution context (`IExecutionContext`) at execution time, ensuring the correct policy is applied when reading execution data regardless of later setting changes
- Add versioned `RedactionSettingV1` schema to execution context with Zod validation

## Changes

### Workflow Settings (`packages/workflow/src/interfaces.ts`)
- Add `WorkflowSettings.RedactionPolicy` type
- Add optional `redactionPolicy` field to `IWorkflowSettings`

### Execution Context Schema (`packages/workflow/src/execution-context.ts`)
- Add `RedactionPolicySchema`, `RedactionSettingSchemaV1` Zod schemas
- Add optional `redaction` field to `ExecutionContextSchemaV1`
- Export `IRedactionSettingV1` type

### Execution Context Establishment (`packages/core/src/execution-engine/execution-context.ts`)
- Read `workflow.settings?.redactionPolicy` and set `redaction: { version: 1, policy }` on fresh context (defaults to `'none'`)
- Sub-workflows use their own redaction policy via existing spread order

### Tests
- **DTO unit tests**: All 3 policy values validated in `CreateWorkflowDto` and `UpdateWorkflowDto`
- **Execution context unit tests**: 5 new tests covering default policy, explicit values, sub-workflow override, and webhook resume preservation
- **Integration tests**: 2 new tests in `workflows.controller.test.ts` verifying `redactionPolicy` persists to DB on create and update

## Test plan

- [x] DTO unit tests pass (60/60)
- [x] Execution context unit tests pass (28/28)
- [x] Integration tests pass (179/179)
- [x] TypeScript typecheck passes

## Related tickets

https://linear.app/n8n/issue/IAM-174
https://linear.app/n8n/issue/IAM-206

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
