### PR TITLE
fix(oidc): Correct user provisioning logic in transaction handling

### DIFF
--- a/packages/cli/src/modules/sso-oidc/oidc.service.ee.ts
+++ b/packages/cli/src/modules/sso-oidc/oidc.service.ee.ts
@@ -306,7 +306,7 @@ export class OidcService {
 			return foundUser;
 		}
 
-		return await this.userRepository.manager.transaction(async (trx) => {
+		const newUser = await this.userRepository.manager.transaction(async (trx) => {
 			const { user } = await this.userRepository.createUserWithProject(
 				{
 					firstName: userInfo.given_name,
@@ -327,10 +327,11 @@ export class OidcService {
 				}),
 			);
 
-			await this.applySsoProvisioning(user, claims);
-
 			return user;
 		});
+		await this.applySsoProvisioning(newUser, claims);
+
+		return newUser;
 	}
 
 	private async applySsoProvisioning(user: User, claims: any) {


### PR DESCRIPTION
## Summary

Moving applySsoProvisioning call outside of the database transaction when creating a new OIDC user.
The provisioning service likely makes additional database operations that shouldn't be part of the user creation transaction. Running it inside the transaction could cause issues with transaction management, deadlocks, or rollback problems.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
