### PR TITLE
feat(editor): Disable v2 migration report via shared target version constant

### DIFF
--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -189,6 +189,8 @@ export type {
 	BreakingChangeVersion,
 } from './schemas/breaking-changes.schema';
 
+export { MIGRATION_REPORT_TARGET_VERSION } from './schemas/breaking-changes.schema';
+
 export type {
 	SecretsProviderType,
 	SecretsProviderState,

--- a/packages/@n8n/api-types/src/schemas/breaking-changes.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/breaking-changes.schema.ts
@@ -9,6 +9,18 @@ export const breakingChangeIssueLevelSchema = z.enum(['info', 'warning', 'error'
 const breakingChangeVersionSchema = z.enum(['v2']);
 export type BreakingChangeVersion = z.infer<typeof breakingChangeVersionSchema>;
 
+/**
+ * The target n8n major version for the migration/breaking-changes report.
+ *
+ * Set this to a version (e.g. 'v2') to enable the migration report on both
+ * frontend (settings sidebar + page) and backend (controller + service).
+ * Set to `null` to disable it entirely on both sides.
+ *
+ * When a new major version is released, update this value and add the
+ * corresponding breaking-change rules on the backend.
+ */
+export const MIGRATION_REPORT_TARGET_VERSION: BreakingChangeVersion | null = null;
+
 // Common schemas
 const recommendationSchema = z.object({
 	action: z.string(),

--- a/packages/cli/src/modules/breaking-changes/breaking-changes.module.ts
+++ b/packages/cli/src/modules/breaking-changes/breaking-changes.module.ts
@@ -1,9 +1,12 @@
 import type { ModuleInterface } from '@n8n/decorators';
 import { BackendModule } from '@n8n/decorators';
+import { MIGRATION_REPORT_TARGET_VERSION } from '@n8n/api-types';
 
 @BackendModule({ name: 'breaking-changes', instanceTypes: ['main'] })
 export class BreakingChangesModule implements ModuleInterface {
 	async init() {
+		if (!MIGRATION_REPORT_TARGET_VERSION) return;
+
 		await import('./breaking-changes.controller');
 	}
 }

--- a/packages/frontend/editor-ui/src/app/composables/useSettingsItems.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useSettingsItems.ts
@@ -7,6 +7,7 @@ import { VIEWS } from '../constants';
 import { useUIStore } from '../stores/ui.store';
 import { useSettingsStore } from '../stores/settings.store';
 import { hasPermission } from '../utils/rbac/permissions';
+import { MIGRATION_REPORT_TARGET_VERSION } from '@n8n/api-types';
 
 export function useSettingsItems() {
 	const router = useRouter();
@@ -144,14 +145,16 @@ export function useSettingsItems() {
 			route: { to: { name: VIEWS.COMMUNITY_NODES } },
 		});
 
-		menuItems.push({
-			id: 'settings-migration-report',
-			icon: 'list-checks',
-			label: i18n.baseText('settings.migrationReport'),
-			position: 'top',
-			available: canUserAccessRouteByName(VIEWS.MIGRATION_REPORT),
-			route: { to: { name: VIEWS.MIGRATION_REPORT } },
-		});
+		if (MIGRATION_REPORT_TARGET_VERSION) {
+			menuItems.push({
+				id: 'settings-migration-report',
+				icon: 'list-checks',
+				label: i18n.baseText('settings.migrationReport'),
+				position: 'top',
+				available: canUserAccessRouteByName(VIEWS.MIGRATION_REPORT),
+				route: { to: { name: VIEWS.MIGRATION_REPORT } },
+			});
+		}
 
 		// Append module-registered settings sidebar items.
 		const moduleItems = uiStore.settingsSidebarItems;

--- a/packages/frontend/editor-ui/src/app/router.ts
+++ b/packages/frontend/editor-ui/src/app/router.ts
@@ -107,6 +107,8 @@ const ResourceCenterSectionView = async () =>
 const SecuritySettingsView = async () =>
 	await import('@/features/settings/security/SecuritySettings.vue');
 
+import { MIGRATION_REPORT_TARGET_VERSION } from '@n8n/api-types';
+
 const MigrationReportView = async () =>
 	await import('@/features/settings/migrationReport/MigrationRules.vue');
 
@@ -555,6 +557,12 @@ export const routes: RouteRecordRaw[] = [
 			{
 				path: 'migration-report',
 				component: RouterView,
+				beforeEnter: () => {
+					if (!MIGRATION_REPORT_TARGET_VERSION) {
+						return { name: VIEWS.HOMEPAGE };
+					}
+					return true;
+				},
 				children: [
 					{
 						path: '',

--- a/packages/frontend/editor-ui/src/features/settings/migrationReport/MigrationRules.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/migrationReport/MigrationRules.test.ts
@@ -121,7 +121,10 @@ describe('MigrationRules', () => {
 			});
 
 			// API called with correct context
-			expect(breakingChangesApi.getReport).toHaveBeenCalledWith(rootStore.restApiContext);
+			expect(breakingChangesApi.getReport).toHaveBeenCalledWith(
+				rootStore.restApiContext,
+				undefined,
+			);
 
 			// Loading skeletons are gone
 			expect(document.querySelectorAll('.el-skeleton').length).toBe(0);
@@ -391,7 +394,10 @@ describe('MigrationRules', () => {
 
 			// API called and data reloaded
 			await waitFor(() => {
-				expect(breakingChangesApi.refreshReport).toHaveBeenCalledWith(rootStore.restApiContext);
+				expect(breakingChangesApi.refreshReport).toHaveBeenCalledWith(
+					rootStore.restApiContext,
+					undefined,
+				);
 				expect(screen.getByText('Updated Rule')).toBeInTheDocument();
 				expect(screen.getByText('10 Workflows')).toBeInTheDocument();
 			});

--- a/packages/frontend/editor-ui/src/features/settings/migrationReport/MigrationRules.vue
+++ b/packages/frontend/editor-ui/src/features/settings/migrationReport/MigrationRules.vue
@@ -17,6 +17,7 @@ import orderBy from 'lodash/orderBy';
 import SeverityTag from './components/SeverityTag.vue';
 import EmptyTab from './components/EmptyTab.vue';
 import { useI18n } from '@n8n/i18n';
+import { MIGRATION_REPORT_TARGET_VERSION } from '@n8n/api-types';
 
 const $style = useCssModule();
 const rootStore = useRootStore();
@@ -25,9 +26,13 @@ const i18n = useI18n();
 const currentTab = ref('workflow-issues');
 const shouldShowRefreshButton = ref(false);
 
+const versionQuery = MIGRATION_REPORT_TARGET_VERSION
+	? { version: MIGRATION_REPORT_TARGET_VERSION }
+	: undefined;
+
 const { state, isLoading, execute } = useAsyncState(async (refresh: boolean = false) => {
 	if (refresh) {
-		const response = await breakingChangesApi.refreshReport(rootStore.restApiContext);
+		const response = await breakingChangesApi.refreshReport(rootStore.restApiContext, versionQuery);
 		// set tab based on available issues
 		if (
 			response.report.workflowResults.length === 0 &&
@@ -39,7 +44,7 @@ const { state, isLoading, execute } = useAsyncState(async (refresh: boolean = fa
 
 		return response;
 	}
-	const response = await breakingChangesApi.getReport(rootStore.restApiContext);
+	const response = await breakingChangesApi.getReport(rootStore.restApiContext, versionQuery);
 	shouldShowRefreshButton.value = response.shouldCache;
 
 	return response;


### PR DESCRIPTION
## Summary

Adds a shared `MIGRATION_REPORT_TARGET_VERSION` constant in `@n8n/api-types` that controls both frontend and backend loading of the breaking-changes/migration report feature.

When set to `null` (current state):
- **Frontend**: The migration report menu item is hidden from settings sidebar, and direct URL navigation redirects to homepage
- **Backend**: The breaking-changes module skips controller/service initialization

To re-enable for a future major version (e.g. v3), update the constant to the target version and add the corresponding breaking-change rules.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-284

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)