### PR TITLE
fix(core): Skip onboarding screen for SAML users with IdP-provided names

### DIFF
--- a/packages/cli/src/modules/sso-saml/saml.service.ee.ts
+++ b/packages/cli/src/modules/sso-saml/saml.service.ee.ts
@@ -254,7 +254,7 @@ export class SamlService {
 					return {
 						authenticatedUser: newUser,
 						attributes,
-						onboardingRequired: true,
+						onboardingRequired: !newUser.firstName || !newUser.lastName,
 					};
 				}
 			}


### PR DESCRIPTION
## Summary

Fixes IAM-311: Users logging in via SAML SSO with just-in-time provisioning should no longer see the "Finish account setup" screen if their name is already provided by the SAML identity provider.

Previously, the onboarding screen was always shown for new JIT-provisioned users. Now it applies the same conditional check used for existing users—only showing onboarding when firstName or lastName is missing from the IdP.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-311/saml-sso-direct-login-without-setup-screen

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)