### PR TITLE
refactor(editor): Stop writing sharedWithProjects to workflowsStore.workflow (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/stores/workflows.ee.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.ee.store.ts
@@ -4,7 +4,6 @@ import { STORES } from '@n8n/stores';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { defineStore } from 'pinia';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { i18n } from '@n8n/i18n';
 import type { ProjectSharingData } from '@/features/collaboration/projects/projects.types';
@@ -36,14 +35,9 @@ export const useWorkflowsEEStore = defineStore(STORES.WORKFLOWS_EE, () => {
 		workflowId: string;
 		sharedWithProjects: ProjectSharingData[];
 	}) => {
-		const workflowsStore = useWorkflowsStore();
 		workflowsListStore.updateWorkflowInCache(payload.workflowId, {
 			sharedWithProjects: payload.sharedWithProjects,
 		});
-		workflowsStore.workflow = {
-			...workflowsStore.workflow,
-			sharedWithProjects: payload.sharedWithProjects,
-		};
 	};
 
 	const saveWorkflowSharedWith = async (payload: {


### PR DESCRIPTION
## Summary

The EE store's `setWorkflowSharedWith` was redundantly writing `sharedWithProjects` to both the list cache (`workflowsListStore`) and `workflowsStore.workflow`. Nothing reads `sharedWithProjects` from `workflowsStore.workflow` — all consumers read from the list cache or API response data directly.

This removes the write to `workflowsStore.workflow`, keeping only the list cache update. This eliminates a split-brain risk where the same data was maintained in two places.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2363

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)