### PR TITLE
fix(editor): Fix workflow diff navigation left arrow hover state

### DIFF
--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectExternalSecrets.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectExternalSecrets.vue
@@ -515,6 +515,10 @@ defineExpose({
 	font-size: var(--font-size--2xs);
 	background-color: var(--color--neutral-125);
 	padding: var(--spacing--4xs);
+
+	body[data-theme='dark'] & {
+		background-color: var(--color--background--light-1);
+	}
 }
 
 .connectionLink {

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
@@ -825,7 +825,7 @@ onMounted(async () => {
 							<N8nButton
 								variant="subtle"
 								icon="funnel"
-								style="height: 100%"
+								:class="$style.filterButton"
 								:active="Boolean(filterCount)"
 								data-test-id="source-control-filter-dropdown"
 							>
@@ -1109,6 +1109,11 @@ onMounted(async () => {
 </template>
 
 <style module lang="scss">
+.filterButton {
+	align-self: stretch;
+	height: auto;
+}
+
 .filtersRow {
 	display: flex;
 	align-items: center;

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/WorkflowDiffModal.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/WorkflowDiffModal.vue
@@ -656,13 +656,14 @@ function setSelectedDetailId(
 	align-items: center;
 	justify-content: space-between;
 
-	.navigationButton {
-		height: 34px;
-		width: 34px;
-	}
-
 	.backButton {
 		border: none;
+	}
+}
+
+.navigationButton {
+	&:hover {
+		z-index: 1;
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `z-index: 1` on `:hover` to visually fix the hover state
- Fix button heights

## Screenshots
<img width="250" height="161" alt="Screenshot 2026-02-25 at 15 51 15" src="https://github.com/user-attachments/assets/abbc0206-45c8-4756-80a3-38d29e4d560b" />

<img width="250" height="110" alt="Screenshot 2026-02-25 at 15 50 41" src="https://github.com/user-attachments/assets/ed4ba251-0db4-4d52-b244-96995ad92fc0" />

<img width="250" height="300" alt="Screenshot 2026-02-25 at 15 51 20" src="https://github.com/user-attachments/assets/3c55e08a-20b3-4649-bd7d-8b38a9dbad66" />


## Related Linear tickets, Github issues, and Community forum posts

Fixes [LIGO-146](https://linear.app/n8n/issue/LIGO-146/workflow-diff-navigation-left-arrow-hover-state-inconsistent)


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
