### PR TITLE
fix(editor): Remove dark border appearing on publish button hover

### DIFF
--- a/.claude-fix-request
+++ b/.claude-fix-request
@@ -1,0 +1,3 @@
+This branch is ready for Claude Code to fix the issue.
+
+Issue: " + $("Prepare Branch Data").item.json.issueTitle

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
@@ -608,7 +608,7 @@ defineExpose({
 }
 
 .groupButtonLeft:hover {
-	border-right-color: inherit;
+	border-right-color: transparent;
 }
 
 .groupButtonRight {


### PR DESCRIPTION
## Summary

Fixes a visual bug where hovering over the publish label (left part) of the split publish button in the workflow editor header caused an unwanted dark border to appear on the right side of the button.

### Root cause

The hover state styles on the publish button's left section were causing an unintended border/outline to bleed through or overlap with the adjacent dropdown trigger section, creating a visible dark border artifact.

### Fix

Adjusted the hover state styles on the publish split button component to ensure no unwanted border appears when hovering over either section of the button.

## Steps to verify

1. Open the workflow editor
2. Locate the publish button in the header
3. Hover over the publish label on the left part of the button
4. Confirm no dark border appears on the right side of the button
5. Hover over the dropdown arrow on the right part of the button
6. Confirm no visual artifacts appear

## Related Linear tickets, Github issues, and Community forum posts

- Linear: Bug - Publish button shows weird dark border on hover

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)