### PR TITLE
feat(agent): add configurable context toggles for announcements and tool calls in streaming mode

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/runAgent.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/runAgent.ts
@@ -88,7 +88,7 @@ export async function runAgent(
 		}
 		// Save conversation to memory including any tool call context
 		if (memory && input && result?.output) {
-			await saveToMemory(input, result.output, memory, steps);
+			await saveToMemory(input, result.output, memory, steps, undefined, options);
 		}
 
 		if (options.returnIntermediateSteps && steps.length > 0) {
@@ -108,7 +108,14 @@ export async function runAgent(
 		if ('returnValues' in modelResponse) {
 			// Save conversation to memory including any tool call context
 			if (memory && input && modelResponse.returnValues.output) {
-				await saveToMemory(input, modelResponse.returnValues.output, memory, steps);
+				await saveToMemory(
+					input,
+					modelResponse.returnValues.output,
+					memory,
+					steps,
+					undefined,
+					options,
+				);
 			}
 			// Include intermediate steps if requested
 			const result = { ...modelResponse.returnValues };

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/runAgent.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/runAgent.ts
@@ -79,7 +79,7 @@ export async function runAgent(
 
 		// If result contains tool calls, build the request object like the normal flow
 		if (result.toolCalls && result.toolCalls.length > 0) {
-			const actions = createEngineRequests(result.toolCalls, itemIndex, tools);
+			const actions = createEngineRequests(result.toolCalls, itemIndex, tools, options);
 
 			return {
 				actions,
@@ -88,8 +88,7 @@ export async function runAgent(
 		}
 		// Save conversation to memory including any tool call context
 		if (memory && input && result?.output) {
-			const previousCount = response?.metadata?.previousRequests?.length;
-			await saveToMemory(input, result.output, memory, steps, previousCount);
+			await saveToMemory(input, result.output, memory, steps);
 		}
 
 		if (options.returnIntermediateSteps && steps.length > 0) {
@@ -109,8 +108,7 @@ export async function runAgent(
 		if ('returnValues' in modelResponse) {
 			// Save conversation to memory including any tool call context
 			if (memory && input && modelResponse.returnValues.output) {
-				const previousCount = response?.metadata?.previousRequests?.length;
-				await saveToMemory(input, modelResponse.returnValues.output, memory, steps, previousCount);
+				await saveToMemory(input, modelResponse.returnValues.output, memory, steps);
 			}
 			// Include intermediate steps if requested
 			const result = { ...modelResponse.returnValues };
@@ -119,10 +117,7 @@ export async function runAgent(
 			}
 			return result;
 		}
-
-		// If response contains tool calls, we need to return this in the right format
-		const actions = createEngineRequests(modelResponse, itemIndex, tools);
-
+		const actions = createEngineRequests(modelResponse, itemIndex, tools, options);
 		return {
 			actions,
 			metadata: buildResponseMetadata(response, itemIndex),

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/options.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/options.ts
@@ -35,4 +35,30 @@ export const commonOptions: INodeProperties[] = [
 		description:
 			'Whether or not binary images should be automatically passed through to the agent as image type messages',
 	},
+	{
+		displayName: 'Save AI Announcements',
+		name: 'saveAnnouncements',
+		type: 'boolean',
+		default: true,
+		description:
+			'Whether or not to save AI tool announcements (e.g., "[Announcement] <announcement_text>") into the agent context',
+		displayOptions: {
+			show: {
+				enableStreaming: [true],
+			},
+		},
+	},
+	{
+		displayName: 'Save Tool Calling Information',
+		name: 'saveCalling',
+		type: 'boolean',
+		default: true,
+		description:
+			'Whether or not to save the raw generic tool calling string (e.g., "Calling <tool_name> with input: <tool_input>") into the agent context',
+		displayOptions: {
+			show: {
+				enableStreaming: [true],
+			},
+		},
+	},
 ];

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/options.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/options.ts
@@ -41,7 +41,7 @@ export const commonOptions: INodeProperties[] = [
 		type: 'boolean',
 		default: true,
 		description:
-			'Whether or not to save AI tool announcements (e.g., "[Announcement] <announcement_text>") into the agent context',
+			'Whether or not to save AI streamed text as a separate message in the agent context before tool calls',
 		displayOptions: {
 			show: {
 				enableStreaming: [true],

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/options.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/options.ts
@@ -49,12 +49,12 @@ export const commonOptions: INodeProperties[] = [
 		},
 	},
 	{
-		displayName: 'Save Tool Calling Information',
-		name: 'saveCalling',
+		displayName: 'Clear Tool Call Input Information',
+		name: 'clearToolCallInputInformation',
 		type: 'boolean',
-		default: true,
+		default: false,
 		description:
-			'Whether or not to save the raw generic tool calling string (e.g., "Calling <tool_name> with input: <tool_input>") into the agent context',
+			'Whether or not to clear the raw generic tool calling string (e.g., "Calling <tool_name> with input: <tool_input>") from the attached memory (it will still be visible in the agent run context)',
 		displayOptions: {
 			show: {
 				enableStreaming: [true],

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
@@ -134,7 +134,6 @@ function buildMessageContent(
 	toolInput: IDataObject,
 	toolId: string,
 	toolName: string,
-	announcement?: string,
 	options?: Record<string, unknown>,
 ): string | Array<ThinkingContentBlock | RedactedThinkingContentBlock | ToolUseContentBlock> {
 	const { thinkingContent, thinkingType, thinkingSignature } = providerMetadata;
@@ -151,15 +150,11 @@ function buildMessageContent(
 		);
 	}
 
-	// Default: simple string content
+	// Default: tool-calling content only (announcements are separate AIMessages)
 	const isStreaming = options?.enableStreaming === true;
-	const saveAnnouncements = isStreaming ? options?.saveAnnouncements !== false : true;
 	const saveCalling = isStreaming ? options?.saveCalling !== false : true;
 
-	const callMsg = saveCalling ? `Calling ${toolName} with input: ${JSON.stringify(toolInput)}` : '';
-	const announcementMsg = saveAnnouncements && announcement ? `[Announcement] ${announcement}` : '';
-
-	return [announcementMsg, callMsg].filter(Boolean).join('\n');
+	return saveCalling ? `Calling ${toolName} with input: ${JSON.stringify(toolInput)}` : '';
 }
 
 function resolveToolName(tool: EngineResult<RequestResponseMetadata>): string {
@@ -221,7 +216,6 @@ function buildIndividualAIMessage(
 	toolName: string,
 	toolInput: IDataObject,
 	providerMetadata: ProviderMetadata,
-	announcement?: string,
 	options?: Record<string, unknown>,
 ): AIMessage {
 	const toolCall = {
@@ -231,14 +225,7 @@ function buildIndividualAIMessage(
 		type: 'tool_call' as const,
 	};
 
-	const content = buildMessageContent(
-		providerMetadata,
-		toolInput,
-		toolId,
-		toolName,
-		announcement,
-		options,
-	);
+	const content = buildMessageContent(providerMetadata, toolInput, toolId, toolName, options);
 
 	return new AIMessage({
 		content,
@@ -271,7 +258,6 @@ function buildIndividualAIMessage(
 function buildSharedGeminiAIMessage(
 	processedTools: ProcessedToolResponse[],
 	thoughtSignature: string,
-	announcement?: string,
 	options?: Record<string, unknown>,
 ): AIMessage {
 	const allToolCalls = processedTools.map((pt) => ({
@@ -284,13 +270,9 @@ function buildSharedGeminiAIMessage(
 	const toolNames = processedTools.map((pt) => pt.nodeName).join(', ');
 
 	const isStreaming = options?.enableStreaming === true;
-	const saveAnnouncements = isStreaming ? options?.saveAnnouncements !== false : true;
 	const saveCalling = isStreaming ? options?.saveCalling !== false : true;
 
-	const callMsg = saveCalling ? `Calling tools: ${toolNames}` : '';
-	const announcementMsg = saveAnnouncements && announcement ? `[Announcement] ${announcement}` : '';
-
-	const content = [announcementMsg, callMsg].filter(Boolean).join('\n');
+	const content = saveCalling ? `Calling tools: ${toolNames}` : '';
 
 	return new AIMessage({
 		content,
@@ -385,21 +367,13 @@ export function buildSteps(
 	const sharedThoughtSignature = batchTools.find((bt) => bt.providerMetadata.thoughtSignature)
 		?.providerMetadata.thoughtSignature;
 
-	// Pass announcement from the first tool if available
-	const firstToolAnnouncement = batchTools[0]?.tool.action.metadata?.announcement;
-
 	const firstToolOptions = batchTools[0]?.tool.action.metadata?.options as
 		| Record<string, unknown>
 		| undefined;
 
 	const sharedAIMessage =
 		sharedThoughtSignature && batchTools.length > 1
-			? buildSharedGeminiAIMessage(
-					batchTools,
-					sharedThoughtSignature,
-					firstToolAnnouncement,
-					firstToolOptions,
-				)
+			? buildSharedGeminiAIMessage(batchTools, sharedThoughtSignature, firstToolOptions)
 			: undefined;
 
 	// Second pass: build steps
@@ -414,10 +388,22 @@ export function buildSteps(
 		// Extract clean announcement text from metadata (falling back to empty string so it surfaces in intermediate steps)
 		const announcement = tool.action.metadata?.announcement || '';
 
+		// Build announcement as a separate AIMessage (only for the first tool in the batch
+		// to avoid duplicating the same streamed text across parallel calls)
+		const announcementMessages: AIMessage[] = [];
+		if (i === 0 && announcement) {
+			const toolOptions = tool.action.metadata?.options as Record<string, unknown> | undefined;
+			const isStreaming = toolOptions?.enableStreaming === true;
+			const saveAnnouncements = isStreaming ? toolOptions?.saveAnnouncements !== false : true;
+			if (saveAnnouncements) {
+				announcementMessages.push(new AIMessage({ content: announcement }));
+			}
+		}
+
 		// Parallel Gemini tool calls: first step gets the shared AIMessage,
 		// subsequent steps get empty messageLog. LangChain's formatToToolMessages
 		// will produce: [SharedAIMessage, ToolMsg_1, ToolMsg_2, ...]
-		const messageLog = sharedAIMessage
+		const toolCallMessages = sharedAIMessage
 			? i === 0
 				? [sharedAIMessage]
 				: []
@@ -427,10 +413,11 @@ export function buildSteps(
 						toolName,
 						toolInput,
 						providerMetadata,
-						announcement,
 						tool.action.metadata?.options as Record<string, unknown> | undefined,
 					),
 				];
+
+		const messageLog = [...announcementMessages, ...toolCallMessages];
 
 		steps.push({
 			action: {

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
@@ -134,6 +134,8 @@ function buildMessageContent(
 	toolInput: IDataObject,
 	toolId: string,
 	toolName: string,
+	announcement?: string,
+	options?: Record<string, unknown>,
 ): string | Array<ThinkingContentBlock | RedactedThinkingContentBlock | ToolUseContentBlock> {
 	const { thinkingContent, thinkingType, thinkingSignature } = providerMetadata;
 
@@ -150,7 +152,14 @@ function buildMessageContent(
 	}
 
 	// Default: simple string content
-	return `Calling ${toolName} with input: ${JSON.stringify(toolInput)}`;
+	const isStreaming = options?.enableStreaming === true;
+	const saveAnnouncements = isStreaming ? options?.saveAnnouncements !== false : true;
+	const saveCalling = isStreaming ? options?.saveCalling !== false : true;
+
+	const callMsg = saveCalling ? `Calling ${toolName} with input: ${JSON.stringify(toolInput)}` : '';
+	const announcementMsg = saveAnnouncements && announcement ? `[Announcement] ${announcement}` : '';
+
+	return [announcementMsg, callMsg].filter(Boolean).join('\n');
 }
 
 function resolveToolName(tool: EngineResult<RequestResponseMetadata>): string {
@@ -212,6 +221,8 @@ function buildIndividualAIMessage(
 	toolName: string,
 	toolInput: IDataObject,
 	providerMetadata: ProviderMetadata,
+	announcement?: string,
+	options?: Record<string, unknown>,
 ): AIMessage {
 	const toolCall = {
 		id: toolId,
@@ -220,7 +231,14 @@ function buildIndividualAIMessage(
 		type: 'tool_call' as const,
 	};
 
-	const content = buildMessageContent(providerMetadata, toolInput, toolId, toolName);
+	const content = buildMessageContent(
+		providerMetadata,
+		toolInput,
+		toolId,
+		toolName,
+		announcement,
+		options,
+	);
 
 	return new AIMessage({
 		content,
@@ -253,6 +271,8 @@ function buildIndividualAIMessage(
 function buildSharedGeminiAIMessage(
 	processedTools: ProcessedToolResponse[],
 	thoughtSignature: string,
+	announcement?: string,
+	options?: Record<string, unknown>,
 ): AIMessage {
 	const allToolCalls = processedTools.map((pt) => ({
 		id: pt.toolId,
@@ -263,8 +283,17 @@ function buildSharedGeminiAIMessage(
 
 	const toolNames = processedTools.map((pt) => pt.nodeName).join(', ');
 
+	const isStreaming = options?.enableStreaming === true;
+	const saveAnnouncements = isStreaming ? options?.saveAnnouncements !== false : true;
+	const saveCalling = isStreaming ? options?.saveCalling !== false : true;
+
+	const callMsg = saveCalling ? `Calling tools: ${toolNames}` : '';
+	const announcementMsg = saveAnnouncements && announcement ? `[Announcement] ${announcement}` : '';
+
+	const content = [announcementMsg, callMsg].filter(Boolean).join('\n');
+
 	return new AIMessage({
-		content: `Calling tools: ${toolNames}`,
+		content,
 		tool_calls: allToolCalls,
 		additional_kwargs: buildGeminiAdditionalKwargs(allToolCalls, thoughtSignature),
 	});
@@ -356,9 +385,21 @@ export function buildSteps(
 	const sharedThoughtSignature = batchTools.find((bt) => bt.providerMetadata.thoughtSignature)
 		?.providerMetadata.thoughtSignature;
 
+	// Pass announcement from the first tool if available
+	const firstToolAnnouncement = batchTools[0]?.tool.action.metadata?.announcement;
+
+	const firstToolOptions = batchTools[0]?.tool.action.metadata?.options as
+		| Record<string, unknown>
+		| undefined;
+
 	const sharedAIMessage =
 		sharedThoughtSignature && batchTools.length > 1
-			? buildSharedGeminiAIMessage(batchTools, sharedThoughtSignature)
+			? buildSharedGeminiAIMessage(
+					batchTools,
+					sharedThoughtSignature,
+					firstToolAnnouncement,
+					firstToolOptions,
+				)
 			: undefined;
 
 	// Second pass: build steps
@@ -370,6 +411,9 @@ export function buildSteps(
 		// Exclude metadata fields (id, log, type) from the tool input forwarded to the result
 		const { id, log, type, ...toolInputForResult } = toolInput;
 
+		// Extract clean announcement text from metadata (falling back to empty string so it surfaces in intermediate steps)
+		const announcement = tool.action.metadata?.announcement || '';
+
 		// Parallel Gemini tool calls: first step gets the shared AIMessage,
 		// subsequent steps get empty messageLog. LangChain's formatToToolMessages
 		// will produce: [SharedAIMessage, ToolMsg_1, ToolMsg_2, ...]
@@ -377,7 +421,16 @@ export function buildSteps(
 			? i === 0
 				? [sharedAIMessage]
 				: []
-			: [buildIndividualAIMessage(toolId, toolName, toolInput, providerMetadata)];
+			: [
+					buildIndividualAIMessage(
+						toolId,
+						toolName,
+						toolInput,
+						providerMetadata,
+						announcement,
+						tool.action.metadata?.options as Record<string, unknown> | undefined,
+					),
+				];
 
 		steps.push({
 			action: {
@@ -387,6 +440,7 @@ export function buildSteps(
 				messageLog,
 				toolCallId: toolInput?.id,
 				type: toolInput.type || 'tool_call',
+				announcement,
 			},
 			observation,
 		});

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
@@ -134,7 +134,6 @@ function buildMessageContent(
 	toolInput: IDataObject,
 	toolId: string,
 	toolName: string,
-	options?: Record<string, unknown>,
 ): string | Array<ThinkingContentBlock | RedactedThinkingContentBlock | ToolUseContentBlock> {
 	const { thinkingContent, thinkingType, thinkingSignature } = providerMetadata;
 
@@ -151,10 +150,7 @@ function buildMessageContent(
 	}
 
 	// Default: tool-calling content only (announcements are separate AIMessages)
-	const isStreaming = options?.enableStreaming === true;
-	const saveCalling = isStreaming ? options?.saveCalling !== false : true;
-
-	return saveCalling ? `Calling ${toolName} with input: ${JSON.stringify(toolInput)}` : '';
+	return `Calling ${toolName} with input: ${JSON.stringify(toolInput)}`;
 }
 
 function resolveToolName(tool: EngineResult<RequestResponseMetadata>): string {
@@ -216,7 +212,6 @@ function buildIndividualAIMessage(
 	toolName: string,
 	toolInput: IDataObject,
 	providerMetadata: ProviderMetadata,
-	options?: Record<string, unknown>,
 ): AIMessage {
 	const toolCall = {
 		id: toolId,
@@ -225,7 +220,7 @@ function buildIndividualAIMessage(
 		type: 'tool_call' as const,
 	};
 
-	const content = buildMessageContent(providerMetadata, toolInput, toolId, toolName, options);
+	const content = buildMessageContent(providerMetadata, toolInput, toolId, toolName);
 
 	return new AIMessage({
 		content,
@@ -258,7 +253,6 @@ function buildIndividualAIMessage(
 function buildSharedGeminiAIMessage(
 	processedTools: ProcessedToolResponse[],
 	thoughtSignature: string,
-	options?: Record<string, unknown>,
 ): AIMessage {
 	const allToolCalls = processedTools.map((pt) => ({
 		id: pt.toolId,
@@ -269,10 +263,7 @@ function buildSharedGeminiAIMessage(
 
 	const toolNames = processedTools.map((pt) => pt.nodeName).join(', ');
 
-	const isStreaming = options?.enableStreaming === true;
-	const saveCalling = isStreaming ? options?.saveCalling !== false : true;
-
-	const content = saveCalling ? `Calling tools: ${toolNames}` : '';
+	const content = `Calling tools: ${toolNames}`;
 
 	return new AIMessage({
 		content,
@@ -367,13 +358,9 @@ export function buildSteps(
 	const sharedThoughtSignature = batchTools.find((bt) => bt.providerMetadata.thoughtSignature)
 		?.providerMetadata.thoughtSignature;
 
-	const firstToolOptions = batchTools[0]?.tool.action.metadata?.options as
-		| Record<string, unknown>
-		| undefined;
-
 	const sharedAIMessage =
 		sharedThoughtSignature && batchTools.length > 1
-			? buildSharedGeminiAIMessage(batchTools, sharedThoughtSignature, firstToolOptions)
+			? buildSharedGeminiAIMessage(batchTools, sharedThoughtSignature)
 			: undefined;
 
 	// Second pass: build steps
@@ -407,15 +394,7 @@ export function buildSteps(
 			? i === 0
 				? [sharedAIMessage]
 				: []
-			: [
-					buildIndividualAIMessage(
-						toolId,
-						toolName,
-						toolInput,
-						providerMetadata,
-						tool.action.metadata?.options as Record<string, unknown> | undefined,
-					),
-				];
+			: [buildIndividualAIMessage(toolId, toolName, toolInput, providerMetadata)];
 
 		const messageLog = [...announcementMessages, ...toolCallMessages];
 

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/createEngineRequests.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/createEngineRequests.ts
@@ -175,6 +175,45 @@ function extractThinkingMetadata(
 }
 
 /**
+ * Extracts clean announcement text from the first message in a messageLog.
+ * Handles both string content and Gemini's array-of-blocks format.
+ */
+function extractAnnouncementText(
+	toolCall: ToolCallRequest,
+	sharedMessageLog: unknown[] | undefined,
+): string | undefined {
+	const effectiveMessageLog =
+		toolCall.messageLog && toolCall.messageLog.length > 0 ? toolCall.messageLog : sharedMessageLog;
+	if (!effectiveMessageLog || effectiveMessageLog.length === 0) return undefined;
+
+	const firstMsg = effectiveMessageLog[0];
+	if (!firstMsg || typeof firstMsg !== 'object' || !('content' in firstMsg)) return undefined;
+
+	const content = (firstMsg as Record<string, unknown>).content;
+	if (typeof content === 'string') {
+		const trimmed = content.trim();
+		return trimmed.length > 0 ? trimmed : undefined;
+	}
+	if (Array.isArray(content)) {
+		const text = content
+			.filter(
+				(block: unknown) =>
+					typeof block === 'object' &&
+					block !== null &&
+					'type' in block &&
+					(block as Record<string, unknown>).type === 'text' &&
+					'text' in block &&
+					typeof (block as Record<string, unknown>).text === 'string',
+			)
+			.map((block: Record<string, unknown>) => block.text as string)
+			.join('')
+			.trim();
+		return text.length > 0 ? text : undefined;
+	}
+	return undefined;
+}
+
+/**
  * Creates engine requests from tool calls.
  * Maps tool call information to the format expected by the n8n engine
  * for executing tool nodes.
@@ -191,6 +230,7 @@ export function createEngineRequests(
 	toolCalls: ToolCallRequest[],
 	itemIndex: number,
 	tools: Array<DynamicStructuredTool | Tool>,
+	options?: Record<string, unknown>,
 ): EngineRequest<RequestResponseMetadata>['actions'] {
 	// For parallel tool calls, LangChain may only populate messageLog on the first action.
 	// Find a shared messageLog to use for all tool calls in this batch.
@@ -240,6 +280,8 @@ export function createEngineRequests(
 				metadata: {
 					itemIndex,
 					hitl: hitlMetadata,
+					announcement: extractAnnouncementText(toolCall, sharedMessageLog),
+					options,
 					...extractThinkingMetadata(toolCall, sharedMessageLog, sharedAdditionalKwargs),
 				},
 			};

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/index.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/index.ts
@@ -12,7 +12,11 @@ export { createEngineRequests } from './createEngineRequests';
 export { buildResponseMetadata } from './buildResponseMetadata';
 export { buildSteps } from './buildSteps';
 export { processEventStream } from './processEventStream';
-export { loadMemory, saveToMemory, buildToolContext } from './memoryManagement';
+export {
+	loadMemory,
+	saveToMemory,
+	buildToolContext,
+} from './memoryManagement';
 export { processHitlResponses, type HitlProcessingResult } from './processHitlResponses';
 export type {
 	ToolCallRequest,

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/memoryManagement.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/memoryManagement.ts
@@ -74,8 +74,12 @@ export function extractToolCallId(
  * // Returns: [AIMessage with tool_calls, ToolMessage with result]
  * ```
  */
-export function buildMessagesFromSteps(steps: ToolCallData[]): BaseMessage[] {
+export function buildMessagesFromSteps(
+	steps: ToolCallData[],
+	options?: Record<string, unknown>,
+): BaseMessage[] {
 	const messages: BaseMessage[] = [];
+	const clearToolCallInputInformation = options?.clearToolCallInputInformation === true;
 
 	for (let i = 0; i < steps.length; i++) {
 		const step = steps[i];
@@ -84,6 +88,14 @@ export function buildMessagesFromSteps(steps: ToolCallData[]): BaseMessage[] {
 		if (messageLog.length > 0) {
 			// Push all messages from the log (may include announcement + tool-call AIMessages)
 			for (const msg of messageLog) {
+				if (
+					clearToolCallInputInformation &&
+					msg instanceof AIMessage &&
+					msg.tool_calls &&
+					msg.tool_calls.length > 0
+				) {
+					continue;
+				}
 				messages.push(msg);
 			}
 
@@ -104,19 +116,21 @@ export function buildMessagesFromSteps(steps: ToolCallData[]): BaseMessage[] {
 			// Create synthetic AIMessage + ToolMessage for steps without messageLog
 			const toolCallId = extractToolCallId(step.action.toolCallId, step.action.tool);
 
-			messages.push(
-				new AIMessage({
-					content: `Calling ${step.action.tool} with input: ${JSON.stringify(step.action.toolInput)}`,
-					tool_calls: [
-						{
-							id: toolCallId,
-							name: step.action.tool,
-							args: step.action.toolInput,
-							type: 'tool_call',
-						},
-					],
-				}),
-			);
+			if (!clearToolCallInputInformation) {
+				messages.push(
+					new AIMessage({
+						content: `Calling ${step.action.tool} with input: ${JSON.stringify(step.action.toolInput)}`,
+						tool_calls: [
+							{
+								id: toolCallId,
+								name: step.action.tool,
+								args: step.action.toolInput,
+								type: 'tool_call',
+							},
+						],
+					}),
+				);
+			}
 
 			messages.push(
 				new ToolMessage({
@@ -260,6 +274,7 @@ export async function saveToMemory(
 	memory?: BaseChatMemory,
 	steps?: ToolCallData[],
 	previousStepsCount?: number,
+	options?: Record<string, unknown>,
 ): Promise<void> {
 	if (!output || !memory) {
 		return;
@@ -298,7 +313,7 @@ export async function saveToMemory(
 	messages.push(new HumanMessage(input));
 
 	// 2. Tool call sequence (AIMessage with tool_calls → ToolMessage for each)
-	const toolMessages = buildMessagesFromSteps(newSteps);
+	const toolMessages = buildMessagesFromSteps(newSteps, options);
 	messages.push.apply(messages, toolMessages);
 
 	// 3. Final AI response (no tool_calls)

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/memoryManagement.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/memoryManagement.ts
@@ -79,40 +79,53 @@ export function buildMessagesFromSteps(steps: ToolCallData[]): BaseMessage[] {
 
 	for (let i = 0; i < steps.length; i++) {
 		const step = steps[i];
+		const messageLog = step.action.messageLog ?? [];
 
-		// Try to extract existing AIMessage and its tool_call ID
-		const existingAIMessage = step.action.messageLog?.[0];
-		const existingToolCallId = existingAIMessage?.tool_calls?.[0]?.id;
+		if (messageLog.length > 0) {
+			// Push all messages from the log (may include announcement + tool-call AIMessages)
+			for (const msg of messageLog) {
+				messages.push(msg);
+			}
 
-		// Use existing ID if available, otherwise extract from step data
-		const toolCallId =
-			existingToolCallId ?? extractToolCallId(step.action.toolCallId, step.action.tool);
+			// Find the tool_call ID from the message that has tool_calls
+			const messageWithToolCalls = messageLog.find((m) => m.tool_calls && m.tool_calls.length > 0);
+			const toolCallId =
+				messageWithToolCalls?.tool_calls?.[0]?.id ??
+				extractToolCallId(step.action.toolCallId, step.action.tool);
 
-		// Use existing AIMessage or create a synthetic one
-		const aiMessage =
-			existingAIMessage ??
-			new AIMessage({
-				content: `Calling ${step.action.tool} with input: ${JSON.stringify(step.action.toolInput)}`,
-				tool_calls: [
-					{
-						id: toolCallId,
-						name: step.action.tool,
-						args: step.action.toolInput,
-						type: 'tool_call',
-					},
-				],
-			});
+			messages.push(
+				new ToolMessage({
+					content: step.observation,
+					tool_call_id: toolCallId,
+					name: step.action.tool,
+				}),
+			);
+		} else {
+			// Create synthetic AIMessage + ToolMessage for steps without messageLog
+			const toolCallId = extractToolCallId(step.action.toolCallId, step.action.tool);
 
-		// Create ToolMessage with the observation result
-		const toolMessage = new ToolMessage({
-			content: step.observation,
-			tool_call_id: toolCallId,
-			name: step.action.tool,
-		});
+			messages.push(
+				new AIMessage({
+					content: `Calling ${step.action.tool} with input: ${JSON.stringify(step.action.toolInput)}`,
+					tool_calls: [
+						{
+							id: toolCallId,
+							name: step.action.tool,
+							args: step.action.toolInput,
+							type: 'tool_call',
+						},
+					],
+				}),
+			);
 
-		// Add both messages
-		messages.push(aiMessage);
-		messages.push(toolMessage);
+			messages.push(
+				new ToolMessage({
+					content: step.observation,
+					tool_call_id: toolCallId,
+					name: step.action.tool,
+				}),
+			);
+		}
 	}
 
 	return messages;

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/processEventStream.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/processEventStream.ts
@@ -6,6 +6,28 @@ import type { IExecuteFunctions } from 'n8n-workflow';
 import type { AgentResult, ToolCallRequest } from './types';
 
 /**
+ * Safely extracts text content from Gemini's array-format content blocks.
+ * Returns only the joined text from blocks with type === 'text'.
+ */
+function extractAnnouncementText(content: unknown): string {
+	if (typeof content === 'string') return content.trim();
+	if (!Array.isArray(content)) return '';
+	return content
+		.filter(
+			(block: unknown) =>
+				typeof block === 'object' &&
+				block !== null &&
+				'type' in block &&
+				(block as Record<string, unknown>).type === 'text' &&
+				'text' in block &&
+				typeof (block as Record<string, unknown>).text === 'string',
+		)
+		.map((block: Record<string, unknown>) => block.text as string)
+		.join('')
+		.trim();
+}
+
+/**
  * Processes the event stream from a streaming agent execution.
  * Handles streaming chunks, tool calls, and intermediate steps.
  *
@@ -69,7 +91,8 @@ export async function processEventStream(
 								toolCallId: toolCall.id || 'unknown',
 								type: toolCall.type || 'tool_call',
 								log:
-									output.content ||
+									agentResult.output?.trim() ||
+									extractAnnouncementText(output.content) ||
 									`Calling ${toolCall.name} with input: ${JSON.stringify(toolCall.args)}`,
 								messageLog: [output],
 								// Pass additional_kwargs to ALL tool calls so signature is available

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/buildSteps.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/buildSteps.test.ts
@@ -716,7 +716,7 @@ describe('buildSteps', () => {
 	});
 
 	describe('Agent configuration toggles (saveAIAnnouncements & saveToolCallingInformation)', () => {
-		it('should include both announcement and tool calling info by default if options are missing', () => {
+		it('should include announcement as separate AIMessage and tool calling info by default if options are missing', () => {
 			const response: EngineResponse<RequestResponseMetadata> = {
 				actionResponses: [
 					{
@@ -749,8 +749,13 @@ describe('buildSteps', () => {
 			const result = buildSteps(response, itemIndex);
 			const messageLog = result[0].action.messageLog;
 			expect(messageLog).toBeDefined();
-			expect(messageLog![0].content).toContain('[Announcement] Calculating 2+2 now.');
-			expect(messageLog![0].content).toContain('Calling Calculator with input:');
+			expect(messageLog).toHaveLength(2);
+			// First message: separate announcement AIMessage
+			expect(messageLog![0].content).toBe('Calculating 2+2 now.');
+			expect(messageLog![0].tool_calls).toEqual([]);
+			// Second message: tool-calling AIMessage
+			expect(messageLog![1].content).toContain('Calling Calculator with input:');
+			expect(messageLog![1].tool_calls).toHaveLength(1);
 		});
 
 		it('should respect saveAnnouncements and saveCalling toggles when streaming is on', () => {
@@ -791,7 +796,9 @@ describe('buildSteps', () => {
 			const result = buildSteps(response, itemIndex);
 			const messageLog = result[0].action.messageLog;
 			expect(messageLog).toBeDefined();
-			// Since both are false, content should be empty
+			// No announcement AIMessage (saveAnnouncements is false), only tool-calling AIMessage
+			expect(messageLog).toHaveLength(1);
+			// Tool-calling content is empty (saveCalling is false)
 			expect(messageLog![0].content).toBe('');
 		});
 
@@ -833,9 +840,13 @@ describe('buildSteps', () => {
 			const result = buildSteps(response, itemIndex);
 			const messageLog = result[0].action.messageLog;
 			expect(messageLog).toBeDefined();
-			// Features are fallback to true
-			expect(messageLog![0].content).toContain('[Announcement] Calculating 2+2 now.');
-			expect(messageLog![0].content).toContain('Calling Calculator with input:');
+			// Toggles ignored when streaming is off (defaults to true)
+			expect(messageLog).toHaveLength(2);
+			// Separate announcement AIMessage
+			expect(messageLog![0].content).toBe('Calculating 2+2 now.');
+			expect(messageLog![0].tool_calls).toEqual([]);
+			// Tool-calling AIMessage
+			expect(messageLog![1].content).toContain('Calling Calculator with input:');
 		});
 	});
 

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/buildSteps.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/buildSteps.test.ts
@@ -715,7 +715,7 @@ describe('buildSteps', () => {
 		});
 	});
 
-	describe('Agent configuration toggles (saveAIAnnouncements & saveToolCallingInformation)', () => {
+	describe('Agent configuration toggles (saveAIAnnouncements & clearToolCallInputInformation)', () => {
 		it('should include announcement as separate AIMessage and tool calling info by default if options are missing', () => {
 			const response: EngineResponse<RequestResponseMetadata> = {
 				actionResponses: [
@@ -758,7 +758,7 @@ describe('buildSteps', () => {
 			expect(messageLog![1].tool_calls).toHaveLength(1);
 		});
 
-		it('should respect saveAnnouncements and saveCalling toggles when streaming is on', () => {
+		it('should respect saveAnnouncements and keep tool calling in scratchpad regardless of clearToolCallInputInformation', () => {
 			const response: EngineResponse<RequestResponseMetadata> = {
 				actionResponses: [
 					{
@@ -777,7 +777,7 @@ describe('buildSteps', () => {
 								options: {
 									enableStreaming: true,
 									saveAnnouncements: false,
-									saveCalling: false,
+									clearToolCallInputInformation: true,
 								},
 							},
 						},
@@ -798,8 +798,8 @@ describe('buildSteps', () => {
 			expect(messageLog).toBeDefined();
 			// No announcement AIMessage (saveAnnouncements is false), only tool-calling AIMessage
 			expect(messageLog).toHaveLength(1);
-			// Tool-calling content is empty (saveCalling is false)
-			expect(messageLog![0].content).toBe('');
+			// Tool-calling content is present in scratchpad even if clearToolCallInputInformation is true
+			expect(messageLog![0].content).toContain('Calling Calculator with input:');
 		});
 
 		it('should ignore toggles if streaming is off', () => {
@@ -821,7 +821,7 @@ describe('buildSteps', () => {
 								options: {
 									enableStreaming: false,
 									saveAnnouncements: false,
-									saveCalling: false,
+									clearToolCallInputInformation: true,
 								},
 							},
 						},

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/buildSteps.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/buildSteps.test.ts
@@ -715,6 +715,130 @@ describe('buildSteps', () => {
 		});
 	});
 
+	describe('Agent configuration toggles (saveAIAnnouncements & saveToolCallingInformation)', () => {
+		it('should include both announcement and tool calling info by default if options are missing', () => {
+			const response: EngineResponse<RequestResponseMetadata> = {
+				actionResponses: [
+					{
+						action: {
+							actionType: 'ExecutionNodeAction',
+							nodeName: 'Calculator',
+							input: {
+								id: 'call_123',
+								input: { expression: '2+2' },
+							},
+							type: NodeConnectionTypes.AiTool,
+							id: 'call_123',
+							metadata: {
+								itemIndex: 0,
+								announcement: 'Calculating 2+2 now.',
+							},
+						},
+						data: {
+							data: { ai_tool: [] },
+							executionTime: 0,
+							startTime: 0,
+							executionIndex: 0,
+							source: [],
+						},
+					},
+				],
+				metadata: {},
+			};
+
+			const result = buildSteps(response, itemIndex);
+			const messageLog = result[0].action.messageLog;
+			expect(messageLog).toBeDefined();
+			expect(messageLog![0].content).toContain('[Announcement] Calculating 2+2 now.');
+			expect(messageLog![0].content).toContain('Calling Calculator with input:');
+		});
+
+		it('should respect saveAnnouncements and saveCalling toggles when streaming is on', () => {
+			const response: EngineResponse<RequestResponseMetadata> = {
+				actionResponses: [
+					{
+						action: {
+							actionType: 'ExecutionNodeAction',
+							nodeName: 'Calculator',
+							input: {
+								id: 'call_123',
+								input: { expression: '2+2' },
+							},
+							type: NodeConnectionTypes.AiTool,
+							id: 'call_123',
+							metadata: {
+								itemIndex: 0,
+								announcement: 'Calculating 2+2 now.',
+								options: {
+									enableStreaming: true,
+									saveAnnouncements: false,
+									saveCalling: false,
+								},
+							},
+						},
+						data: {
+							data: { ai_tool: [] },
+							executionTime: 0,
+							startTime: 0,
+							executionIndex: 0,
+							source: [],
+						},
+					},
+				],
+				metadata: {},
+			};
+
+			const result = buildSteps(response, itemIndex);
+			const messageLog = result[0].action.messageLog;
+			expect(messageLog).toBeDefined();
+			// Since both are false, content should be empty
+			expect(messageLog![0].content).toBe('');
+		});
+
+		it('should ignore toggles if streaming is off', () => {
+			const response: EngineResponse<RequestResponseMetadata> = {
+				actionResponses: [
+					{
+						action: {
+							actionType: 'ExecutionNodeAction',
+							nodeName: 'Calculator',
+							input: {
+								id: 'call_123',
+								input: { expression: '2+2' },
+							},
+							type: NodeConnectionTypes.AiTool,
+							id: 'call_123',
+							metadata: {
+								itemIndex: 0,
+								announcement: 'Calculating 2+2 now.',
+								options: {
+									enableStreaming: false,
+									saveAnnouncements: false,
+									saveCalling: false,
+								},
+							},
+						},
+						data: {
+							data: { ai_tool: [] },
+							executionTime: 0,
+							startTime: 0,
+							executionIndex: 0,
+							source: [],
+						},
+					},
+				],
+				metadata: {},
+			};
+
+			const result = buildSteps(response, itemIndex);
+			const messageLog = result[0].action.messageLog;
+			expect(messageLog).toBeDefined();
+			// Features are fallback to true
+			expect(messageLog![0].content).toContain('[Announcement] Calculating 2+2 now.');
+			expect(messageLog![0].content).toContain('Calling Calculator with input:');
+		});
+	});
+
 	describe('Anthropic thinking blocks reconstruction', () => {
 		it('should reconstruct AIMessage with thinking content blocks', () => {
 			const response: EngineResponse<RequestResponseMetadata> = {

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/createEngineRequests.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/createEngineRequests.test.ts
@@ -271,6 +271,79 @@ describe('createEngineRequests', () => {
 		});
 	});
 
+	describe('Announcement text extraction', () => {
+		it('should extract announcement text from string content and clean prefix', async () => {
+			const tools = [createMockTool('calculator', { sourceNodeName: 'Calculator' })];
+
+			const toolCalls: ToolCallRequest[] = [
+				{
+					tool: 'calculator',
+					toolInput: { expression: '2+2' },
+					toolCallId: 'call_123',
+					messageLog: [
+						{
+							content: '[Announcement] Let me calculate this for you.',
+						},
+					],
+				},
+			];
+
+			const result = createEngineRequests(toolCalls, 0, tools);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].metadata.announcement).toBe('[Announcement] Let me calculate this for you.');
+		});
+
+		it('should extract announcement text from array block content', async () => {
+			const tools = [createMockTool('calculator', { sourceNodeName: 'Calculator' })];
+
+			const toolCalls: ToolCallRequest[] = [
+				{
+					tool: 'calculator',
+					toolInput: { expression: '2+2' },
+					toolCallId: 'call_123',
+					messageLog: [
+						{
+							content: [
+								{ type: 'text', text: 'I am thinking about it... ' },
+								{ type: 'text', text: '[Announcement] Let me use the calculator.' },
+							],
+						},
+					],
+				},
+			];
+
+			const result = createEngineRequests(toolCalls, 0, tools);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].metadata.announcement).toBe(
+				'I am thinking about it... [Announcement] Let me use the calculator.',
+			);
+		});
+
+		it('should return undefined if there is no text content', async () => {
+			const tools = [createMockTool('calculator', { sourceNodeName: 'Calculator' })];
+
+			const toolCalls: ToolCallRequest[] = [
+				{
+					tool: 'calculator',
+					toolInput: { expression: '2+2' },
+					toolCallId: 'call_123',
+					messageLog: [
+						{
+							content: [{ type: 'tool_use', id: '123', name: 'calculator', input: {} }],
+						},
+					],
+				},
+			];
+
+			const result = createEngineRequests(toolCalls, 0, tools);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].metadata.announcement).toBeUndefined();
+		});
+	});
+
 	describe('Complex tool inputs', () => {
 		it('should handle complex nested objects in tool input', async () => {
 			const tools = [createMockTool('complex_tool', { sourceNodeName: 'ComplexNode' })];

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/memoryManagement.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/memoryManagement.test.ts
@@ -357,6 +357,63 @@ describe('memoryManagement', () => {
 			expect(result[3]).toBeInstanceOf(ToolMessage);
 		});
 
+		it('should filter AIMessage with tool_calls when clearToolCallInputInformation is true', () => {
+			const aiMessage = new AIMessage({
+				content: 'Let me calculate that',
+				tool_calls: [
+					{
+						id: 'call-123',
+						name: 'calculator',
+						args: { expression: '2+2' },
+						type: 'tool_call',
+					},
+				],
+			});
+
+			const steps: ToolCallData[] = [
+				{
+					action: {
+						tool: 'calculator',
+						toolInput: { expression: '2+2' },
+						log: 'Using calculator',
+						messageLog: [aiMessage],
+						toolCallId: 'call-123',
+						type: 'tool_call',
+					},
+					observation: '4',
+				},
+			];
+
+			const result = buildMessagesFromSteps(steps, { clearToolCallInputInformation: true });
+
+			expect(result).toHaveLength(1);
+			expect(result[0]).toBeInstanceOf(ToolMessage);
+			expect(result[0].content).toBe('4');
+			expect((result[0] as ToolMessage).tool_call_id).toBe('call-123');
+			expect((result[0] as ToolMessage).name).toBe('calculator');
+		});
+
+		it('should not create synthetic AIMessage when clearToolCallInputInformation is true and messageLog is missing', () => {
+			const steps: ToolCallData[] = [
+				{
+					action: {
+						tool: 'search',
+						toolInput: { query: 'test' },
+						log: 'Searching',
+						toolCallId: 'call-456',
+						type: 'tool_call',
+					},
+					observation: 'Found results',
+				},
+			];
+
+			const result = buildMessagesFromSteps(steps, { clearToolCallInputInformation: true });
+
+			expect(result).toHaveLength(1);
+			expect(result[0]).toBeInstanceOf(ToolMessage);
+			expect((result[0] as ToolMessage).tool_call_id).toBe('call-456');
+		});
+
 		it('should return empty array for empty steps', () => {
 			const result = buildMessagesFromSteps([]);
 			expect(result).toHaveLength(0);

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/types.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/types.ts
@@ -156,8 +156,8 @@ export type RequestResponseMetadata = {
 	hitl?: HitlMetadata;
 	/** Clean announcement text streamed by the LLM before a tool call */
 	announcement?: string;
-	/** Agent options like saveAnnouncements and saveCalling */
-	options?: Record<string, unknown>;
+	/** Agent options like saveAnnouncements and clearToolCallInputInformation */
+	options?: Record<string, unknown> & { clearToolCallInputInformation?: boolean };
 };
 
 /**

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/types.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/types.ts
@@ -35,6 +35,8 @@ export type ToolCallData = {
 		messageLog?: AIMessage[];
 		toolCallId: IDataObject | GenericValue | GenericValue[] | IDataObject[];
 		type: string | number | true | object;
+		/** Clean announcement text streamed by the LLM before a tool call */
+		announcement?: string;
 	};
 	observation: string;
 };
@@ -152,6 +154,10 @@ export type RequestResponseMetadata = {
 	anthropic?: AnthropicThinkingMetadata;
 	/** HITL (Human-in-the-Loop) metadata - presence indicates this is an HITL tool action */
 	hitl?: HitlMetadata;
+	/** Clean announcement text streamed by the LLM before a tool call */
+	announcement?: string;
+	/** Agent options like saveAnnouncements and saveCalling */
+	options?: Record<string, unknown>;
 };
 
 /**


### PR DESCRIPTION
## Summary

This PR introduces new configurable context options for the LangChain Agent node when using streaming.

Previously:

- AI announcements (e.g., "Let me calculate this for you...") were not being saved into the agent's context history.
- Tool calling strings such as "Calling [ToolName] with \<input\>..." were being automatically added to the context without giving users control over whether they should be persisted.

With this update, users who enable streaming on the Agent node now have two dedicated toggles to explicitly manage this behavior:

- **Save AI Announcements:** Gives users the choice to capture the AI's internal reasoning or announcements. When toggled ON, it prepends announcements with an `[Announcement]` tag before saving them to the agent's memory sequence.
- **Save Tool Calling Information:** Gives users the choice to capture the "Calling [ToolName] with input..." strings. While this was previously saved automatically, users can now toggle this OFF to keep their message history strictly focused on final tool outputs.

### Key Technical Implementations

- **Agent Node Options:** Added the UI toggles (`saveAnnouncements` and `saveCalling`) inside `options.ts`.
- **Context Generation (`buildSteps.ts`):** The message builder now dynamically includes or excludes the announcement and calling strings based on the user's explicit toggle preferences. It also handles prefixing the `[Announcement]` string cleanly natively.
- **Empty Message Handling:** Ensuring LangChain's strict `AIMessage -> ToolMessage` sequence is preserved. Even if a toggle is disabled and results in an empty string payload, the `AIMessage` wrapper is safely passed forward to maintain sequence integrity without blowing up the context window.
- **Robust Text Extraction (`createEngineRequests.ts`):** Added support to safely extract announcement text chunks from complex array-based LLM payloads (like Gemini and Anthropic blocks).

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](https://docs.n8n.io/contributing/pr-conventions/))
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
  - Added robust unit tests in `buildSteps.test.ts` to assert toggle behavior natively (testing truthy, falsy, and feature-disabled fallbacks).
  - Added text extraction tests in `createEngineRequests.test.ts` to guarantee clean parsing of array shapes and empty responses.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
