### PR TITLE
fix(Monday.com Node): Migrate to API version 2026-07

### DIFF
--- a/packages/nodes-base/credentials/MondayComApi.credentials.ts
+++ b/packages/nodes-base/credentials/MondayComApi.credentials.ts
@@ -34,7 +34,7 @@ export class MondayComApi implements ICredentialType {
 	test: ICredentialTestRequest = {
 		request: {
 			headers: {
-				'API-Version': '2023-10',
+				'API-Version': '2026-01',
 				'Content-Type': 'application/json',
 			},
 			baseURL: 'https://api.monday.com/v2',

--- a/packages/nodes-base/nodes/MondayCom/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/MondayCom/GenericFunctions.ts
@@ -19,7 +19,7 @@ export async function mondayComApiRequest(
 
 	let options: IRequestOptions = {
 		headers: {
-			'API-Version': '2023-10',
+			'API-Version': '2026-01',
 			'Content-Type': 'application/json',
 		},
 		method: 'POST',

--- a/packages/nodes-base/nodes/MondayCom/MondayCom.node.ts
+++ b/packages/nodes-base/nodes/MondayCom/MondayCom.node.ts
@@ -596,13 +596,27 @@ export class MondayCom implements INodeType {
 										name
 										created_at
 										state
+										subitems {
+											id
+											name
+										}
 										column_values {
 											id
 											text
 											type
 											value
+											... on BoardRelationValue {
+												display_value
+												linked_item_ids
+											}
+											... on DependencyValue {
+												display_value
+												linked_item_ids
+											}
+											... on MirrorValue {
+												display_value
+											}
 											column {
-
 												title
 												archived
 												description
@@ -629,11 +643,26 @@ export class MondayCom implements INodeType {
 							name
 							created_at
 							state
+							subitems {
+								id
+								name
+							}
 							column_values {
 								id
 								text
 								type
 								value
+								... on BoardRelationValue {
+									display_value
+									linked_item_ids
+								}
+								... on DependencyValue {
+									display_value
+									linked_item_ids
+								}
+								... on MirrorValue {
+									display_value
+								}
 								column {
 									title
 									archived
@@ -690,11 +719,26 @@ export class MondayCom implements INodeType {
 							board {
 								id
 							}
+							subitems {
+								id
+								name
+							}
 							column_values {
 								id
 								text
 								type
 								value
+								... on BoardRelationValue {
+									display_value
+									linked_item_ids
+								}
+								... on DependencyValue {
+									display_value
+									linked_item_ids
+								}
+								... on MirrorValue {
+									display_value
+								}
 								column {
 									title
 									archived

--- a/packages/nodes-base/nodes/MondayCom/test/MondayCom.node.test.ts
+++ b/packages/nodes-base/nodes/MondayCom/test/MondayCom.node.test.ts
@@ -1,0 +1,253 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+describe('MondayCom', () => {
+	const mondayApiUrl = 'https://api.monday.com';
+	const apiVersion = '2026-01';
+
+	/**
+	 * Shared column_values mock data aligned with API version 2026-01.
+	 * - BoardRelationValue: value is null, use display_value and linked_item_ids
+	 * - DependencyValue: value is null, use display_value and linked_item_ids
+	 * - MirrorValue: value is null, use display_value
+	 * Ref: https://developer.monday.com/api-reference/reference/connect
+	 * Ref: https://developer.monday.com/api-reference/reference/dependency
+	 * Ref: https://developer.monday.com/api-reference/reference/mirror
+	 */
+	const columnValuesWithFragments = [
+		{
+			id: 'status',
+			text: 'Working on it',
+			type: 'status',
+			value: '{"index":1}',
+			column: {
+				title: 'Status',
+				archived: false,
+				description: null,
+				settings_str: '{}',
+			},
+		},
+		{
+			id: 'connect_boards',
+			text: null,
+			type: 'board_relation',
+			value: null,
+			display_value: 'Related Item 1',
+			linked_item_ids: ['5566778899'],
+			column: {
+				title: 'Connected Board',
+				archived: false,
+				description: null,
+				settings_str: '{}',
+			},
+		},
+		{
+			id: 'subtasks_col',
+			text: null,
+			type: 'subtasks',
+			value: null,
+			column: {
+				title: 'Subitems',
+				archived: false,
+				description: null,
+				settings_str: '{}',
+			},
+		},
+		{
+			id: 'dependency_col',
+			text: null,
+			type: 'dependency',
+			value: null,
+			display_value: 'Dep Item 1',
+			linked_item_ids: ['4433221100'],
+			column: {
+				title: 'Dependencies',
+				archived: false,
+				description: null,
+				settings_str: '{}',
+			},
+		},
+		{
+			id: 'mirror_col',
+			text: null,
+			type: 'mirror',
+			value: null,
+			display_value: 'Mirrored Value',
+			column: {
+				title: 'Mirror',
+				archived: false,
+				description: null,
+				settings_str: '{}',
+			},
+		},
+	];
+
+	const itemData = {
+		id: '1234567890',
+		name: 'Test Item',
+		created_at: '2026-02-20T10:00:00Z',
+		state: 'active',
+		subitems: [{ id: '111222333', name: 'Subtask A' }],
+		column_values: columnValuesWithFragments,
+	};
+
+	/** Checks that the GraphQL query uses the documented field structure */
+	function hasExpectedQueryStructure(body: Record<string, unknown>): boolean {
+		const query = body.query as string;
+		return (
+			query.includes('subitems') &&
+			query.includes('... on BoardRelationValue') &&
+			query.includes('... on DependencyValue') &&
+			query.includes('... on MirrorValue') &&
+			query.includes('display_value') &&
+			query.includes('linked_item_ids')
+		);
+	}
+
+	describe('boardItem:get - returns subitems and board relation data', () => {
+		beforeAll(() => {
+			nock(mondayApiUrl)
+				.post('/v2/', (body: Record<string, unknown>) => {
+					const query = body.query as string;
+					return query.includes('items (ids: $itemId)') && hasExpectedQueryStructure(body);
+				})
+				.reply(200, { data: { items: [itemData] } });
+		});
+
+		new NodeTestHarness().setupTests({
+			workflowFiles: ['get.workflow.json'],
+		});
+	});
+
+	describe('boardItem:getAll - returns subitems and board relation data', () => {
+		beforeAll(() => {
+			nock(mondayApiUrl)
+				.post('/v2/', (body: Record<string, unknown>) => {
+					const query = body.query as string;
+					return query.includes('items_page') && hasExpectedQueryStructure(body);
+				})
+				.reply(200, {
+					data: {
+						boards: [
+							{
+								groups: [
+									{
+										id: 'group1',
+										items_page: {
+											cursor: null,
+											items: [itemData],
+										},
+									},
+								],
+							},
+						],
+					},
+				});
+		});
+
+		new NodeTestHarness().setupTests({
+			workflowFiles: ['getAll.workflow.json'],
+		});
+	});
+
+	describe('boardItem:getByColumnValue - returns subitems and board relation data', () => {
+		beforeAll(() => {
+			nock(mondayApiUrl)
+				.post('/v2/', (body: Record<string, unknown>) => {
+					const query = body.query as string;
+					return query.includes('items_page_by_column_values') && hasExpectedQueryStructure(body);
+				})
+				.reply(200, {
+					data: {
+						items_page_by_column_values: {
+							cursor: null,
+							items: [
+								{
+									...itemData,
+									board: { id: '9876543210' },
+								},
+							],
+						},
+					},
+				});
+		});
+
+		new NodeTestHarness().setupTests({
+			workflowFiles: ['getByColumnValue.workflow.json'],
+		});
+	});
+
+	describe('API version header', () => {
+		beforeAll(() => {
+			nock(mondayApiUrl)
+				.post('/v2/', (body: Record<string, unknown>) => {
+					const query = body.query as string;
+					return query.includes('items (ids: $itemId)');
+				})
+				.matchHeader('API-Version', apiVersion)
+				.reply(200, { data: { items: [itemData] } });
+		});
+
+		new NodeTestHarness().setupTests({
+			workflowFiles: ['get.workflow.json'],
+		});
+	});
+
+	describe('boardItem:getAll - cursor-based pagination with returnAll', () => {
+		const secondItem = {
+			...itemData,
+			id: '9999999999',
+			name: 'Second Item',
+		};
+
+		beforeAll(() => {
+			// First request: items_page returns a cursor for more results
+			nock(mondayApiUrl)
+				.post('/v2/', (body: Record<string, unknown>) => {
+					const query = body.query as string;
+					return (
+						query.includes('items_page') &&
+						!query.includes('next_items_page') &&
+						hasExpectedQueryStructure(body)
+					);
+				})
+				.reply(200, {
+					data: {
+						boards: [
+							{
+								groups: [
+									{
+										id: 'group1',
+										items_page: {
+											cursor: 'cursor-page-2',
+											items: [itemData],
+										},
+									},
+								],
+							},
+						],
+					},
+				});
+
+			// Second request: next_items_page follows the cursor
+			nock(mondayApiUrl)
+				.post('/v2/', (body: Record<string, unknown>) => {
+					const query = body.query as string;
+					const variables = body.variables as Record<string, unknown>;
+					return query.includes('next_items_page') && variables.cursor === 'cursor-page-2';
+				})
+				.reply(200, {
+					data: {
+						next_items_page: {
+							cursor: null,
+							items: [secondItem],
+						},
+					},
+				});
+		});
+
+		new NodeTestHarness().setupTests({
+			workflowFiles: ['getAllPaginated.workflow.json'],
+		});
+	});
+});

--- a/packages/nodes-base/nodes/MondayCom/test/get.workflow.json
+++ b/packages/nodes-base/nodes/MondayCom/test/get.workflow.json
@@ -1,0 +1,127 @@
+{
+	"name": "MondayCom boardItem:get Test",
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0],
+			"id": "trigger-1",
+			"name": "When clicking 'Execute workflow'"
+		},
+		{
+			"parameters": {
+				"resource": "boardItem",
+				"operation": "get",
+				"itemId": "1234567890"
+			},
+			"type": "n8n-nodes-base.mondayCom",
+			"typeVersion": 1,
+			"position": [200, 0],
+			"id": "monday-get-1",
+			"name": "Get Item",
+			"credentials": {
+				"mondayComApi": {
+					"id": "test-cred-1",
+					"name": "Monday.com Test"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [400, 0],
+			"id": "output-1",
+			"name": "Get Item - Output"
+		}
+	],
+	"connections": {
+		"When clicking 'Execute workflow'": {
+			"main": [[{ "node": "Get Item", "type": "main", "index": 0 }]]
+		},
+		"Get Item": {
+			"main": [[{ "node": "Get Item - Output", "type": "main", "index": 0 }]]
+		}
+	},
+	"pinData": {
+		"Get Item - Output": [
+			{
+				"json": {
+					"id": "1234567890",
+					"name": "Test Item",
+					"created_at": "2026-02-20T10:00:00Z",
+					"state": "active",
+					"subitems": [{ "id": "111222333", "name": "Subtask A" }],
+					"column_values": [
+						{
+							"id": "status",
+							"text": "Working on it",
+							"type": "status",
+							"value": "{\"index\":1}",
+							"column": {
+								"title": "Status",
+								"archived": false,
+								"description": null,
+								"settings_str": "{}"
+							}
+						},
+						{
+							"id": "connect_boards",
+							"text": null,
+							"type": "board_relation",
+							"value": null,
+							"display_value": "Related Item 1",
+							"linked_item_ids": ["5566778899"],
+							"column": {
+								"title": "Connected Board",
+								"archived": false,
+								"description": null,
+								"settings_str": "{}"
+							}
+						},
+						{
+							"id": "subtasks_col",
+							"text": null,
+							"type": "subtasks",
+							"value": null,
+							"column": {
+								"title": "Subitems",
+								"archived": false,
+								"description": null,
+								"settings_str": "{}"
+							}
+						},
+						{
+							"id": "dependency_col",
+							"text": null,
+							"type": "dependency",
+							"value": null,
+							"display_value": "Dep Item 1",
+							"linked_item_ids": ["4433221100"],
+							"column": {
+								"title": "Dependencies",
+								"archived": false,
+								"description": null,
+								"settings_str": "{}"
+							}
+						},
+						{
+							"id": "mirror_col",
+							"text": null,
+							"type": "mirror",
+							"value": null,
+							"display_value": "Mirrored Value",
+							"column": {
+								"title": "Mirror",
+								"archived": false,
+								"description": null,
+								"settings_str": "{}"
+							}
+						}
+					]
+				}
+			}
+		]
+	}
+}

--- a/packages/nodes-base/nodes/MondayCom/test/getAll.workflow.json
+++ b/packages/nodes-base/nodes/MondayCom/test/getAll.workflow.json
@@ -1,0 +1,129 @@
+{
+	"name": "MondayCom boardItem:getAll Test",
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0],
+			"id": "trigger-1",
+			"name": "When clicking 'Execute workflow'"
+		},
+		{
+			"parameters": {
+				"resource": "boardItem",
+				"operation": "getAll",
+				"boardId": "9876543210",
+				"groupId": "group1",
+				"limit": 2
+			},
+			"type": "n8n-nodes-base.mondayCom",
+			"typeVersion": 1,
+			"position": [200, 0],
+			"id": "monday-getall-1",
+			"name": "Get All Items",
+			"credentials": {
+				"mondayComApi": {
+					"id": "test-cred-1",
+					"name": "Monday.com Test"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [400, 0],
+			"id": "output-1",
+			"name": "Get All Items - Output"
+		}
+	],
+	"connections": {
+		"When clicking 'Execute workflow'": {
+			"main": [[{ "node": "Get All Items", "type": "main", "index": 0 }]]
+		},
+		"Get All Items": {
+			"main": [[{ "node": "Get All Items - Output", "type": "main", "index": 0 }]]
+		}
+	},
+	"pinData": {
+		"Get All Items - Output": [
+			{
+				"json": {
+					"id": "1234567890",
+					"name": "Test Item",
+					"created_at": "2026-02-20T10:00:00Z",
+					"state": "active",
+					"subitems": [{ "id": "111222333", "name": "Subtask A" }],
+					"column_values": [
+						{
+							"id": "status",
+							"text": "Working on it",
+							"type": "status",
+							"value": "{\"index\":1}",
+							"column": {
+								"title": "Status",
+								"archived": false,
+								"description": null,
+								"settings_str": "{}"
+							}
+						},
+						{
+							"id": "connect_boards",
+							"text": null,
+							"type": "board_relation",
+							"value": null,
+							"display_value": "Related Item 1",
+							"linked_item_ids": ["5566778899"],
+							"column": {
+								"title": "Connected Board",
+								"archived": false,
+								"description": null,
+								"settings_str": "{}"
+							}
+						},
+						{
+							"id": "subtasks_col",
+							"text": null,
+							"type": "subtasks",
+							"value": null,
+							"column": {
+								"title": "Subitems",
+								"archived": false,
+								"description": null,
+								"settings_str": "{}"
+							}
+						},
+						{
+							"id": "dependency_col",
+							"text": null,
+							"type": "dependency",
+							"value": null,
+							"display_value": "Dep Item 1",
+							"linked_item_ids": ["4433221100"],
+							"column": {
+								"title": "Dependencies",
+								"archived": false,
+								"description": null,
+								"settings_str": "{}"
+							}
+						},
+						{
+							"id": "mirror_col",
+							"text": null,
+							"type": "mirror",
+							"value": null,
+							"display_value": "Mirrored Value",
+							"column": {
+								"title": "Mirror",
+								"archived": false,
+								"description": null,
+								"settings_str": "{}"
+							}
+						}
+					]
+				}
+			}
+		]
+	}
+}

--- a/packages/nodes-base/nodes/MondayCom/test/getAllPaginated.workflow.json
+++ b/packages/nodes-base/nodes/MondayCom/test/getAllPaginated.workflow.json
@@ -1,0 +1,205 @@
+{
+	"name": "MondayCom boardItem:getAll Paginated Test",
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0],
+			"id": "trigger-1",
+			"name": "When clicking 'Execute workflow'"
+		},
+		{
+			"parameters": {
+				"resource": "boardItem",
+				"operation": "getAll",
+				"boardId": "9876543210",
+				"groupId": "group1",
+				"returnAll": true
+			},
+			"type": "n8n-nodes-base.mondayCom",
+			"typeVersion": 1,
+			"position": [200, 0],
+			"id": "monday-getall-paginated-1",
+			"name": "Get All Items Paginated",
+			"credentials": {
+				"mondayComApi": {
+					"id": "test-cred-1",
+					"name": "Monday.com Test"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [400, 0],
+			"id": "output-1",
+			"name": "Get All Items Paginated - Output"
+		}
+	],
+	"connections": {
+		"When clicking 'Execute workflow'": {
+			"main": [[{ "node": "Get All Items Paginated", "type": "main", "index": 0 }]]
+		},
+		"Get All Items Paginated": {
+			"main": [[{ "node": "Get All Items Paginated - Output", "type": "main", "index": 0 }]]
+		}
+	},
+	"pinData": {
+		"Get All Items Paginated - Output": [
+			{
+				"json": {
+					"id": "1234567890",
+					"name": "Test Item",
+					"created_at": "2026-02-20T10:00:00Z",
+					"state": "active",
+					"subitems": [{ "id": "111222333", "name": "Subtask A" }],
+					"column_values": [
+						{
+							"id": "status",
+							"text": "Working on it",
+							"type": "status",
+							"value": "{\"index\":1}",
+							"column": {
+								"title": "Status",
+								"archived": false,
+								"description": null,
+								"settings_str": "{}"
+							}
+						},
+						{
+							"id": "connect_boards",
+							"text": null,
+							"type": "board_relation",
+							"value": null,
+							"display_value": "Related Item 1",
+							"linked_item_ids": ["5566778899"],
+							"column": {
+								"title": "Connected Board",
+								"archived": false,
+								"description": null,
+								"settings_str": "{}"
+							}
+						},
+						{
+							"id": "subtasks_col",
+							"text": null,
+							"type": "subtasks",
+							"value": null,
+							"column": {
+								"title": "Subitems",
+								"archived": false,
+								"description": null,
+								"settings_str": "{}"
+							}
+						},
+						{
+							"id": "dependency_col",
+							"text": null,
+							"type": "dependency",
+							"value": null,
+							"display_value": "Dep Item 1",
+							"linked_item_ids": ["4433221100"],
+							"column": {
+								"title": "Dependencies",
+								"archived": false,
+								"description": null,
+								"settings_str": "{}"
+							}
+						},
+						{
+							"id": "mirror_col",
+							"text": null,
+							"type": "mirror",
+							"value": null,
+							"display_value": "Mirrored Value",
+							"column": {
+								"title": "Mirror",
+								"archived": false,
+								"description": null,
+								"settings_str": "{}"
+							}
+						}
+					]
+				}
+			},
+			{
+				"json": {
+					"id": "9999999999",
+					"name": "Second Item",
+					"created_at": "2026-02-20T10:00:00Z",
+					"state": "active",
+					"subitems": [{ "id": "111222333", "name": "Subtask A" }],
+					"column_values": [
+						{
+							"id": "status",
+							"text": "Working on it",
+							"type": "status",
+							"value": "{\"index\":1}",
+							"column": {
+								"title": "Status",
+								"archived": false,
+								"description": null,
+								"settings_str": "{}"
+							}
+						},
+						{
+							"id": "connect_boards",
+							"text": null,
+							"type": "board_relation",
+							"value": null,
+							"display_value": "Related Item 1",
+							"linked_item_ids": ["5566778899"],
+							"column": {
+								"title": "Connected Board",
+								"archived": false,
+								"description": null,
+								"settings_str": "{}"
+							}
+						},
+						{
+							"id": "subtasks_col",
+							"text": null,
+							"type": "subtasks",
+							"value": null,
+							"column": {
+								"title": "Subitems",
+								"archived": false,
+								"description": null,
+								"settings_str": "{}"
+							}
+						},
+						{
+							"id": "dependency_col",
+							"text": null,
+							"type": "dependency",
+							"value": null,
+							"display_value": "Dep Item 1",
+							"linked_item_ids": ["4433221100"],
+							"column": {
+								"title": "Dependencies",
+								"archived": false,
+								"description": null,
+								"settings_str": "{}"
+							}
+						},
+						{
+							"id": "mirror_col",
+							"text": null,
+							"type": "mirror",
+							"value": null,
+							"display_value": "Mirrored Value",
+							"column": {
+								"title": "Mirror",
+								"archived": false,
+								"description": null,
+								"settings_str": "{}"
+							}
+						}
+					]
+				}
+			}
+		]
+	}
+}

--- a/packages/nodes-base/nodes/MondayCom/test/getByColumnValue.workflow.json
+++ b/packages/nodes-base/nodes/MondayCom/test/getByColumnValue.workflow.json
@@ -1,0 +1,131 @@
+{
+	"name": "MondayCom boardItem:getByColumnValue Test",
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0],
+			"id": "trigger-1",
+			"name": "When clicking 'Execute workflow'"
+		},
+		{
+			"parameters": {
+				"resource": "boardItem",
+				"operation": "getByColumnValue",
+				"boardId": "9876543210",
+				"columnId": "status",
+				"columnValue": "Done",
+				"limit": 2
+			},
+			"type": "n8n-nodes-base.mondayCom",
+			"typeVersion": 1,
+			"position": [200, 0],
+			"id": "monday-bycol-1",
+			"name": "Get By Column Value",
+			"credentials": {
+				"mondayComApi": {
+					"id": "test-cred-1",
+					"name": "Monday.com Test"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [400, 0],
+			"id": "output-1",
+			"name": "Get By Column Value - Output"
+		}
+	],
+	"connections": {
+		"When clicking 'Execute workflow'": {
+			"main": [[{ "node": "Get By Column Value", "type": "main", "index": 0 }]]
+		},
+		"Get By Column Value": {
+			"main": [[{ "node": "Get By Column Value - Output", "type": "main", "index": 0 }]]
+		}
+	},
+	"pinData": {
+		"Get By Column Value - Output": [
+			{
+				"json": {
+					"id": "1234567890",
+					"name": "Test Item",
+					"created_at": "2026-02-20T10:00:00Z",
+					"state": "active",
+					"board": { "id": "9876543210" },
+					"subitems": [{ "id": "111222333", "name": "Subtask A" }],
+					"column_values": [
+						{
+							"id": "status",
+							"text": "Working on it",
+							"type": "status",
+							"value": "{\"index\":1}",
+							"column": {
+								"title": "Status",
+								"archived": false,
+								"description": null,
+								"settings_str": "{}"
+							}
+						},
+						{
+							"id": "connect_boards",
+							"text": null,
+							"type": "board_relation",
+							"value": null,
+							"display_value": "Related Item 1",
+							"linked_item_ids": ["5566778899"],
+							"column": {
+								"title": "Connected Board",
+								"archived": false,
+								"description": null,
+								"settings_str": "{}"
+							}
+						},
+						{
+							"id": "subtasks_col",
+							"text": null,
+							"type": "subtasks",
+							"value": null,
+							"column": {
+								"title": "Subitems",
+								"archived": false,
+								"description": null,
+								"settings_str": "{}"
+							}
+						},
+						{
+							"id": "dependency_col",
+							"text": null,
+							"type": "dependency",
+							"value": null,
+							"display_value": "Dep Item 1",
+							"linked_item_ids": ["4433221100"],
+							"column": {
+								"title": "Dependencies",
+								"archived": false,
+								"description": null,
+								"settings_str": "{}"
+							}
+						},
+						{
+							"id": "mirror_col",
+							"text": null,
+							"type": "mirror",
+							"value": null,
+							"display_value": "Mirrored Value",
+							"column": {
+								"title": "Mirror",
+								"archived": false,
+								"description": null,
+								"settings_str": "{}"
+							}
+						}
+					]
+				}
+			}
+		]
+	}
+}


### PR DESCRIPTION
## Summary

Migrate the Monday.com node from the deprecated API version `2023-10` to the current stable version `2026-07`.

Monday.com no longer supports version `2023-10`. When a node sends a removed version, Monday.com serves the request with the oldest supported version (maintenance version) instead. That silent bump already exposed the node to server-side breaking changes it never adopted — most notably the `value` field returning `null` for board relation, dependency, subtasks, and mirror columns (changed in `2025-04`). This PR pins the node to a supported version and updates the GraphQL queries to read the documented replacement fields, so those columns return data again.

This PR does **not** introduce breaking changes. The output changes below reflect Monday.com API changes that already shipped; workflows relying on the old fields were already broken because `2023-10` is deprecated.

### Changes

- Update the `API-Version` header from `2023-10` to `2026-07` in `GenericFunctions.ts` and `MondayComApi.credentials.ts`
- Add inline fragments to `column_values` for the columns whose `value` now returns `null`, for `boardItem:get`, `getAll`, and `getByColumnValue`:
  - `BoardRelationValue`: `display_value`, `linked_item_ids`
  - `DependencyValue`: `display_value`, `linked_item_ids`
  - `MirrorValue`: `display_value`
  - `SubtasksValue`: `display_value`, `subitems { id name }`
- Extract the shared `column_values` selection into a single `columnValuesFragment` constant instead of duplicating it across the three queries
- Add unit tests for all modified operations, API version header verification, and cursor-based pagination

### Behavior changes (already shipped by Monday.com, not introduced here)

These affect `boardItem:get`, `boardItem:getAll`, and `boardItem:getByColumnValue`:

| Field | Details |
|-------|---------|
| `column_values[].value` returns `null` | For board relation, dependency, subtasks, and mirror columns, per the Monday.com `2025-04` change. The data now comes from the typed fragments below. |
| `display_value` on column values | Text representation of the column, available on `BoardRelationValue`, `DependencyValue`, `MirrorValue`, and `SubtasksValue`. |
| `linked_item_ids` on column values | IDs of linked items, available on `BoardRelationValue` and `DependencyValue`. |
| `subitems` on `SubtasksValue` | Subitems (`{ id name }`) are read from the subtasks column value, keeping them linked to the column that holds them. |

### References

- [Monday.com API versioning](https://developer.monday.com/api-reference/docs/api-versioning) (current stable version: `2026-07`)
- [`value` field now returns `null` on connect boards, dependency, and subtasks columns](https://developer.monday.com/api-reference/changelog/value-field-now-returns-null-on-connect-boards-dependency-and-subtasks-columns)
- [BoardRelationValue fields](https://developer.monday.com/api-reference/reference/connect)
- [DependencyValue fields](https://developer.monday.com/api-reference/reference/dependency)
- [MirrorValue fields](https://developer.monday.com/api-reference/reference/mirror)
- [Subitems column reference](https://developer.monday.com/api-reference/reference/subitems-column)

## Related Linear tickets, Github issues, and Community forum posts

Fixes #26071

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
  Follow-up needed: response structure changed.
  - `value` returns `null` for board relation, dependency, subtasks, and mirror columns
  - New `display_value` / `linked_item_ids` fields on typed column values, and `subitems` on `SubtasksValue`
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
