### PR TITLE
fix(editor): Custom style for date picker btns (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/css/date-picker.scss
+++ b/packages/frontend/@n8n/design-system/src/css/date-picker.scss
@@ -25,7 +25,7 @@
 		}
 		&:last-child {
 			background: var(--color--orange-400);
-			color: var(--color--foreground--tint-2);
+			color: var(--color--neutral-white);
 
 			&:hover {
 				background-color: var(--color--orange-500);

--- a/packages/frontend/@n8n/design-system/src/css/date-picker.scss
+++ b/packages/frontend/@n8n/design-system/src/css/date-picker.scss
@@ -13,9 +13,26 @@
 
 .el-picker-panel__footer {
 	.el-picker-panel__link-btn {
+		border: 1px;
+		border-radius: var(--radius--sm);
+		color: var(--text--color);
+
+		&:hover {
+			background-color: light-dark(var(--color--neutral-150), var(--color--neutral-800));
+		}
+		&:active {
+			background-color: light-dark(var(--color--neutral-200), var(--color--neutral-700));
+		}
 		&:last-child {
-			background: var(--color--primary);
+			background: var(--color--orange-400);
 			color: var(--color--foreground--tint-2);
+
+			&:hover {
+				background-color: var(--color--orange-500);
+			}
+			&:active {
+				background-color: var(--color--orange-600);
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Adds new styles to `<button />` in old Date Picker as they don't render `<Button />` so don't have the styles.

| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/6d79aeb8-e529-4792-a39d-98fbe628442f" width="960px" alt="Before image" /> | <img src="https://github.com/user-attachments/assets/72d9acd5-2bea-43e3-b2b7-dd71b8f808ed" width="960px" alt="After image" /> |


## Related Linear tickets, Github issues, and Community forum posts
[DS-475](https://linear.app/n8n/issue/DS-475/buttons-in-date-picker-dont-use-new-button-styles)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
