### PR TITLE
fix(editor): Remove white separator from Button (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectCreateResource.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectCreateResource.vue
@@ -47,8 +47,7 @@ defineExpose({
 .buttonGroup {
 	display: inline-flex;
 
-	:global(> .button) {		
-
+	:global(> .button) {
 		&:not(:first-child) {
 			border-radius: 0;
 		}

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectCreateResource.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectCreateResource.vue
@@ -47,8 +47,7 @@ defineExpose({
 .buttonGroup {
 	display: inline-flex;
 
-	:global(> .button) {
-		border-right: 1px solid var(--button--color--text, var(--button--color--text--primary));
+	:global(> .button) {		
 
 		&:not(:first-child) {
 			border-radius: 0;


### PR DESCRIPTION
## Summary
Removes deliberate white border from button dropdown as per https://www.notion.so/n8n/30c5b6e0c94f800d9af8f8552564999f?v=30c5b6e0c94f802aa2aa000cb2c3e7a5&source=copy_link

FYI Was visually hidden but since we changed `box-shadow` props on `<Button />` it's now visible.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
