### PR TITLE
chore(core): Implement redaction logic in redaction module

### DIFF
--- a/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
+++ b/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
@@ -1,14 +1,22 @@
 import { Logger } from '@n8n/backend-common';
 import { mockInstance } from '@n8n/backend-test-utils';
 import type { IExecutionDb, User } from '@n8n/db';
-import type { ExecutionStatus, WorkflowExecuteMode } from 'n8n-workflow';
+import { SharedWorkflowRepository } from '@n8n/db';
+import type { ExecutionStatus, IRunExecutionData, WorkflowExecuteMode } from 'n8n-workflow';
 
 import type { ExecutionRedactionOptions } from '@/executions/execution-redaction';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { userHasScopes } from '@/permissions.ee/check-access';
 
 import { ExecutionRedactionService } from '../execution-redaction.service';
 
+jest.mock('@/permissions.ee/check-access');
+
+const mockedUserHasScopes = jest.mocked(userHasScopes);
+
 describe('ExecutionRedactionService', () => {
 	const logger = mockInstance(Logger);
+	const sharedWorkflowRepository = mockInstance(SharedWorkflowRepository);
 	let service: ExecutionRedactionService;
 
 	const mockUser = {
@@ -20,66 +28,131 @@ describe('ExecutionRedactionService', () => {
 	} as unknown as User;
 
 	beforeEach(() => {
-		service = new ExecutionRedactionService(logger);
+		jest.clearAllMocks();
+		service = new ExecutionRedactionService(logger, sharedWorkflowRepository);
 	});
 
-	describe('processExecution', () => {
-		const createMockExecution = (): IExecutionDb => {
-			// @ts-expect-error - Partial mock data for testing
-			return {
-				id: 'execution-123',
-				mode: 'manual' as WorkflowExecuteMode,
-				createdAt: new Date('2024-01-01'),
-				startedAt: new Date('2024-01-01'),
-				stoppedAt: new Date('2024-01-01'),
-				workflowId: 'workflow-123',
-				finished: true,
-				retryOf: undefined,
-				retrySuccessId: undefined,
-				status: 'success' as ExecutionStatus,
-				waitTill: null,
-				storedAt: 'db',
-				data: {
-					version: 1,
-					resultData: {
-						runData: {},
-					},
-					executionData: {
-						contextData: {},
-						nodeExecutionStack: [],
-						metadata: {},
-						waitingExecution: {},
-						waitingExecutionSource: null,
-					},
-				},
-				workflowData: {
-					id: 'workflow-123',
-					name: 'Test Workflow',
-					active: false,
-					isArchived: false,
-					createdAt: new Date('2024-01-01'),
-					updatedAt: new Date('2024-01-01'),
-					nodes: [],
-					connections: {},
-					settings: {},
-					staticData: {},
-					activeVersionId: null,
-				},
-			} as IExecutionDb;
+	const createMockExecution = (
+		overrides: {
+			mode?: WorkflowExecuteMode;
+			policy?: 'none' | 'all' | 'non-manual';
+			workflowSettingsPolicy?: 'none' | 'all' | 'non-manual';
+			withRuntimeData?: boolean;
+			withRunData?: boolean;
+		} = {},
+	): IExecutionDb => {
+		const {
+			mode = 'manual',
+			policy,
+			workflowSettingsPolicy,
+			withRuntimeData = true,
+			withRunData = false,
+		} = overrides;
+
+		const executionData: IRunExecutionData['executionData'] = {
+			contextData: {},
+			nodeExecutionStack: [],
+			metadata: {},
+			waitingExecution: {},
+			waitingExecutionSource: null,
 		};
 
-		it('should return unmodified execution when redactExecutionData is undefined', async () => {
-			const execution = createMockExecution();
-			const options: ExecutionRedactionOptions = { user: mockUser };
+		if (withRuntimeData && policy !== undefined) {
+			executionData.runtimeData = {
+				version: 1 as const,
+				establishedAt: Date.now(),
+				source: mode,
+				redaction: { version: 1 as const, policy },
+			};
+		}
+
+		const runData = withRunData
+			? {
+					TestNode: [
+						{
+							startTime: 0,
+							executionTime: 100,
+							executionStatus: 'success' as const,
+							data: {
+								main: [
+									[
+										{
+											json: { secret: 'sensitive-data' },
+											binary: { file: { mimeType: 'text/plain', data: 'abc' } },
+										},
+									],
+								],
+							},
+							source: [],
+						},
+					],
+				}
+			: {};
+
+		// @ts-expect-error - Partial mock data for testing
+		return {
+			id: 'execution-123',
+			mode,
+			createdAt: new Date('2024-01-01'),
+			startedAt: new Date('2024-01-01'),
+			stoppedAt: new Date('2024-01-01'),
+			workflowId: 'workflow-123',
+			finished: true,
+			retryOf: undefined,
+			retrySuccessId: undefined,
+			status: 'success' as ExecutionStatus,
+			waitTill: null,
+			storedAt: 'db',
+			data: {
+				version: 1,
+				resultData: { runData },
+				executionData,
+			},
+			workflowData: {
+				id: 'workflow-123',
+				name: 'Test Workflow',
+				active: false,
+				isArchived: false,
+				createdAt: new Date('2024-01-01'),
+				updatedAt: new Date('2024-01-01'),
+				nodes: [],
+				connections: {},
+				settings: workflowSettingsPolicy ? { redactionPolicy: workflowSettingsPolicy } : {},
+				staticData: {},
+				activeVersionId: null,
+			},
+		} as IExecutionDb;
+	};
+
+	describe('redactExecutionData === true (explicit redact)', () => {
+		it('should apply redaction regardless of policy', async () => {
+			const execution = createMockExecution({
+				policy: 'none',
+				withRunData: true,
+			});
+			const options: ExecutionRedactionOptions = {
+				user: mockUser,
+				redactExecutionData: true,
+			};
 
 			const result = await service.processExecution(execution, options);
 
-			expect(result).toBe(execution);
-			expect(result).toEqual(execution);
+			const item = result.data.resultData.runData.TestNode[0].data!.main[0]![0];
+			expect(item.json).toEqual({});
+			expect(item.binary).toBeUndefined();
+			expect(item.redaction).toEqual({ redacted: true });
 		});
+	});
 
-		it('should return unmodified execution when redactExecutionData is false', async () => {
-			const execution = createMockExecution();
+	describe('redactExecutionData === false (explicit reveal)', () => {
+		it('should return unmodified execution when user has reveal permission', async () => {
+			sharedWorkflowRepository.findBy.mockResolvedValue([{ projectId: 'project-1' } as never]);
+			mockedUserHasScopes.mockResolvedValue(true);
+
+			const execution = createMockExecution({
+				policy: 'all',
+				withRunData: true,
+			});
 			const options: ExecutionRedactionOptions = {
 				user: mockUser,
 				redactExecutionData: false,
@@ -87,68 +160,212 @@ describe('ExecutionRedactionService', () => {
 
 			const result = await service.processExecution(execution, options);
 
-			expect(result).toBe(execution);
-			expect(result).toEqual(execution);
+			expect(result.data.resultData.runData.TestNode[0].data!.main[0]![0].json).toEqual({
+				secret: 'sensitive-data',
+			});
 		});
 
-		it('should return unmodified execution when redactExecutionData is true (stub behavior)', async () => {
-			const execution = createMockExecution();
+		it('should throw ForbiddenError when user lacks reveal permission', async () => {
+			sharedWorkflowRepository.findBy.mockResolvedValue([{ projectId: 'project-1' } as never]);
+			mockedUserHasScopes.mockResolvedValue(false);
+
+			const execution = createMockExecution({ policy: 'all' });
 			const options: ExecutionRedactionOptions = {
 				user: mockUser,
-				redactExecutionData: true,
+				redactExecutionData: false,
 			};
+
+			await expect(service.processExecution(execution, options)).rejects.toThrow(ForbiddenError);
+		});
+
+		it('should throw ForbiddenError when no shared workflows exist', async () => {
+			sharedWorkflowRepository.findBy.mockResolvedValue([]);
+
+			const execution = createMockExecution({ policy: 'all' });
+			const options: ExecutionRedactionOptions = {
+				user: mockUser,
+				redactExecutionData: false,
+			};
+
+			await expect(service.processExecution(execution, options)).rejects.toThrow(ForbiddenError);
+		});
+	});
+
+	describe('redactExecutionData === undefined (policy-based)', () => {
+		it('should return unmodified when policy is none', async () => {
+			const execution = createMockExecution({
+				policy: 'none',
+				mode: 'trigger',
+				withRunData: true,
+			});
+			const options: ExecutionRedactionOptions = { user: mockUser };
 
 			const result = await service.processExecution(execution, options);
 
-			// Stub implementation should return unmodified execution
-			expect(result).toBe(execution);
-			expect(result).toEqual(execution);
+			expect(result.data.resultData.runData.TestNode[0].data!.main[0]![0].json).toEqual({
+				secret: 'sensitive-data',
+			});
 		});
 
-		it('should log debug message when processing execution', async () => {
-			const execution = createMockExecution();
-			const options: ExecutionRedactionOptions = {
-				user: mockUser,
-				redactExecutionData: true,
-			};
+		it('should return unmodified when policy is non-manual and mode is manual', async () => {
+			const execution = createMockExecution({
+				policy: 'non-manual',
+				mode: 'manual',
+				withRunData: true,
+			});
+			const options: ExecutionRedactionOptions = { user: mockUser };
 
-			await service.processExecution(execution, options);
+			const result = await service.processExecution(execution, options);
 
-			expect(logger.debug).toHaveBeenCalledWith('Processing execution for redaction', {
-				executionId: execution.id,
-				redactExecutionData: true,
+			expect(result.data.resultData.runData.TestNode[0].data!.main[0]![0].json).toEqual({
+				secret: 'sensitive-data',
+			});
+		});
+
+		it('should redact when policy is non-manual and mode is trigger', async () => {
+			const execution = createMockExecution({
+				policy: 'non-manual',
+				mode: 'trigger',
+				withRunData: true,
+			});
+			const options: ExecutionRedactionOptions = { user: mockUser };
+
+			const result = await service.processExecution(execution, options);
+
+			const item = result.data.resultData.runData.TestNode[0].data!.main[0]![0];
+			expect(item.json).toEqual({});
+			expect(item.binary).toBeUndefined();
+			expect(item.redaction).toEqual({ redacted: true });
+		});
+
+		it('should redact when policy is non-manual and mode is webhook', async () => {
+			const execution = createMockExecution({
+				policy: 'non-manual',
+				mode: 'webhook',
+				withRunData: true,
+			});
+			const options: ExecutionRedactionOptions = { user: mockUser };
+
+			const result = await service.processExecution(execution, options);
+
+			const item = result.data.resultData.runData.TestNode[0].data!.main[0]![0];
+			expect(item.json).toEqual({});
+			expect(item.redaction).toEqual({ redacted: true });
+		});
+
+		it('should redact when policy is all and mode is manual', async () => {
+			const execution = createMockExecution({
+				policy: 'all',
+				mode: 'manual',
+				withRunData: true,
+			});
+			const options: ExecutionRedactionOptions = { user: mockUser };
+
+			const result = await service.processExecution(execution, options);
+
+			const item = result.data.resultData.runData.TestNode[0].data!.main[0]![0];
+			expect(item.json).toEqual({});
+			expect(item.redaction).toEqual({ redacted: true });
+		});
+
+		it('should redact when policy is all and mode is trigger', async () => {
+			const execution = createMockExecution({
+				policy: 'all',
+				mode: 'trigger',
+				withRunData: true,
+			});
+			const options: ExecutionRedactionOptions = { user: mockUser };
+
+			const result = await service.processExecution(execution, options);
+
+			const item = result.data.resultData.runData.TestNode[0].data!.main[0]![0];
+			expect(item.json).toEqual({});
+			expect(item.redaction).toEqual({ redacted: true });
+		});
+
+		it('should default to none when runtimeData and workflow settings are missing', async () => {
+			const execution = createMockExecution({
+				withRuntimeData: false,
+				mode: 'trigger',
+				withRunData: true,
+			});
+			const options: ExecutionRedactionOptions = { user: mockUser };
+
+			const result = await service.processExecution(execution, options);
+
+			expect(result.data.resultData.runData.TestNode[0].data!.main[0]![0].json).toEqual({
+				secret: 'sensitive-data',
+			});
+		});
+
+		it('should fall back to workflow settings when runtimeData is missing', async () => {
+			const execution = createMockExecution({
+				withRuntimeData: false,
+				workflowSettingsPolicy: 'all',
+				mode: 'trigger',
+				withRunData: true,
+			});
+			const options: ExecutionRedactionOptions = { user: mockUser };
+
+			const result = await service.processExecution(execution, options);
+
+			const item = result.data.resultData.runData.TestNode[0].data!.main[0]![0];
+			expect(item.json).toEqual({});
+			expect(item.redaction).toEqual({ redacted: true });
+		});
+	});
+
+	describe('resolvePolicy precedence', () => {
+		it('should prefer runtimeData policy over workflow settings', async () => {
+			const execution = createMockExecution({
+				policy: 'none',
+				workflowSettingsPolicy: 'all',
+				mode: 'trigger',
+				withRunData: true,
+			});
+			const options: ExecutionRedactionOptions = { user: mockUser };
+
+			const result = await service.processExecution(execution, options);
+
+			// runtimeData says 'none', so no redaction despite workflow settings saying 'all'
+			expect(result.data.resultData.runData.TestNode[0].data!.main[0]![0].json).toEqual({
+				secret: 'sensitive-data',
 			});
 		});
 	});
 
-	describe('canUserReveal', () => {
-		it('should return false (stub behavior)', async () => {
-			const userId = 'user-123';
-			const executionId = 'execution-123';
-
-			const result = await service.canUserReveal(userId, executionId);
-
-			expect(result).toBe(false);
-		});
-
-		it('should log debug message when checking reveal permissions', async () => {
-			const userId = 'user-123';
-			const executionId = 'execution-123';
-
-			await service.canUserReveal(userId, executionId);
-
-			expect(logger.debug).toHaveBeenCalledWith('Checking reveal permissions', {
-				userId,
-				executionId,
+	describe('applyRedaction behavior', () => {
+		it('should handle empty runData gracefully', async () => {
+			const execution = createMockExecution({
+				policy: 'all',
+				mode: 'trigger',
+				withRunData: false,
 			});
+			const options: ExecutionRedactionOptions = { user: mockUser };
+
+			const result = await service.processExecution(execution, options);
+
+			expect(result).toBe(execution);
 		});
 
-		it('should return false for different user and execution combinations', async () => {
-			const result1 = await service.canUserReveal('user-1', 'execution-1');
-			const result2 = await service.canUserReveal('user-2', 'execution-2');
+		it('should redact inputOverride data', async () => {
+			const execution = createMockExecution({
+				policy: 'all',
+				mode: 'trigger',
+				withRunData: true,
+			});
+			// Add inputOverride to the task data
+			execution.data.resultData.runData.TestNode[0].inputOverride = {
+				main: [[{ json: { override: 'secret' }, binary: { f: { mimeType: 'x', data: 'y' } } }]],
+			};
+			const options: ExecutionRedactionOptions = { user: mockUser };
 
-			expect(result1).toBe(false);
-			expect(result2).toBe(false);
+			const result = await service.processExecution(execution, options);
+
+			const overrideItem = result.data.resultData.runData.TestNode[0].inputOverride!.main[0]![0];
+			expect(overrideItem.json).toEqual({});
+			expect(overrideItem.binary).toBeUndefined();
+			expect(overrideItem.redaction).toEqual({ redacted: true });
 		});
 	});
 });

--- a/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
+++ b/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
@@ -1,11 +1,21 @@
 import { Logger } from '@n8n/backend-common';
-import type { IExecutionDb } from '@n8n/db';
+import { type IExecutionDb, SharedWorkflowRepository, type User } from '@n8n/db';
 import { Service } from '@n8n/di';
 
 import type {
 	ExecutionRedaction,
 	ExecutionRedactionOptions,
 } from '@/executions/execution-redaction';
+import {
+	INodeExecutionData,
+	ITaskDataConnections,
+	WorkflowExecuteMode,
+	WorkflowSettings,
+} from 'n8n-workflow';
+import { userHasScopes } from '@/permissions.ee/check-access';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+
+const MANUAL_MODES: ReadonlySet<WorkflowExecuteMode> = new Set(['manual']);
 
 /**
  * Service responsible for redacting sensitive data from executions.
@@ -13,7 +23,10 @@ import type {
  */
 @Service()
 export class ExecutionRedactionService implements ExecutionRedaction {
-	constructor(private readonly logger: Logger) {}
+	constructor(
+		private readonly logger: Logger,
+		private readonly sharedWorkflowRepository: SharedWorkflowRepository,
+	) {}
 
 	/**
 	 * Initializes the execution redaction service.
@@ -35,30 +48,120 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 		execution: IExecutionDb,
 		options: ExecutionRedactionOptions,
 	): Promise<IExecutionDb> {
-		this.logger.debug('Processing execution for redaction', {
-			executionId: execution.id,
-			redactExecutionData: options.redactExecutionData,
-		});
+		if (options.redactExecutionData === true) {
+			// user wants redacted data, this is always fine!
+			this.applyRedaction(execution);
+		} else if (options.redactExecutionData === false) {
+			// user wants unredacted data, lets see if they have the permissions to do so
+			const allowed = await this.canUserReveal(options.user, execution);
+			if (allowed) {
+				return execution;
+			} else {
+				throw new ForbiddenError();
+			}
+		} else {
+			// this should be the default case, we act based on the policy
+			const policy = this.resolvePolicy(execution);
 
-		// Stub implementation: return unmodified execution
+			// The policy is no redaction, so we just return the execution.
+			if (policy === 'none') {
+				return execution;
+			}
+
+			// The policy is to redact, non manual executions, so we return only if the mode is manual
+			if (policy === 'non-manual' && MANUAL_MODES.has(execution.mode)) {
+				return execution;
+			}
+
+			this.applyRedaction(execution);
+		}
+
 		return execution;
 	}
 
 	/**
-	 * Checks whether a user has permission to reveal redacted data in an execution.
+	 * Checks whether a user is allowed to view unredacted execution data.
 	 *
-	 * @param userId - The ID of the user requesting access
-	 * @param executionId - The ID of the execution to check
-	 * @returns `true` if the user can reveal redacted data, `false` otherwise
-	 *          (currently returns `false` as stub)
+	 * Uses the `execution:reveal` scope which is granted to:
+	 * - Global owners and admins (via global role)
+	 * - Project admins and personal project owners (via project role)
+	 *
+	 * The check finds all projects containing the workflow and verifies
+	 * the user has the scope either globally or in one of those projects.
 	 */
-	async canUserReveal(userId: string, executionId: string): Promise<boolean> {
-		this.logger.debug('Checking reveal permissions', {
-			userId,
-			executionId,
+	private async canUserReveal(user: User, execution: IExecutionDb): Promise<boolean> {
+		const sharedWorkflows = await this.sharedWorkflowRepository.findBy({
+			workflowId: execution.workflowId,
 		});
 
-		// Stub implementation: return false (no reveal permission)
+		for (const sw of sharedWorkflows) {
+			if (await userHasScopes(user, ['execution:reveal'], false, { projectId: sw.projectId })) {
+				return true;
+			}
+		}
+
 		return false;
+	}
+
+	/**
+	 * Resolves the effective redaction policy for an execution.
+	 *
+	 * Prefers the policy captured in `runtimeData.redaction` at execution time,
+	 * falls back to `workflowData.settings` for older
+	 * executions, and defaults to 'none'.
+	 */
+	private resolvePolicy(execution: IExecutionDb): WorkflowSettings.RedactionPolicy {
+		return (
+			execution.data.executionData?.runtimeData?.redaction?.policy ??
+			execution.workflowData.settings?.redactionPolicy ??
+			'none'
+		);
+	}
+
+	/**
+	 * Mutates execution data in place, replacing all node output json with a
+	 * redaction marker and removing binary data.
+	 */
+	private applyRedaction(execution: IExecutionDb): void {
+		const runData = execution.data.resultData.runData;
+		if (!runData) return;
+
+		for (const nodeName of Object.keys(runData)) {
+			for (const taskData of runData[nodeName]) {
+				if (taskData.data) {
+					this.redactConnections(taskData.data);
+				}
+				if (taskData.inputOverride) {
+					this.redactConnections(taskData.inputOverride);
+				}
+			}
+		}
+	}
+
+	/** Walks an ITaskDataConnections structure and redacts every data item in place. */
+	private redactConnections(connections: ITaskDataConnections): void {
+		for (const connectionType of Object.keys(connections)) {
+			const outputs = connections[connectionType];
+			for (const items of outputs) {
+				if (items) {
+					for (const item of items) {
+						this.redactItem(item);
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Redacts all json and binary data from a single node execution data item.
+	 * This is the default "full" redaction strategy. Future strategies (field-level,
+	 * pattern-based) can replace this function without changing the traversal logic.
+	 */
+	private redactItem(item: INodeExecutionData): void {
+		item.json = {};
+		delete item.binary;
+		item.redaction = {
+			redacted: true,
+		};
 	}
 }

--- a/packages/cli/test/integration/execution-redaction.test.ts
+++ b/packages/cli/test/integration/execution-redaction.test.ts
@@ -1,0 +1,376 @@
+import {
+	createTeamProject,
+	linkUserToProject,
+	createWorkflow,
+	testDb,
+	mockInstance,
+} from '@n8n/backend-test-utils';
+import type { User } from '@n8n/db';
+import { stringify } from 'flatted';
+import type { IRunExecutionData, IWorkflowBase, WorkflowExecuteMode } from 'n8n-workflow';
+import { createRunExecutionData } from 'n8n-workflow';
+
+import { ConcurrencyControlService } from '@/concurrency/concurrency-control.service';
+import { WaitTracker } from '@/wait-tracker';
+
+import { createExecution } from './shared/db/executions';
+import { createMember, createOwner } from './shared/db/users';
+import { setupTestServer } from './shared/utils';
+
+// Must be set before setupTestServer() so RedactionModule.init() wires the real service
+process.env.N8N_ENV_FEAT_EXECUTION_REDACTION = 'true';
+
+mockInstance(WaitTracker);
+mockInstance(ConcurrencyControlService, {
+	// @ts-expect-error Private property
+	isEnabled: false,
+});
+
+const testServer = setupTestServer({
+	endpointGroups: ['executions'],
+	modules: ['redaction'],
+});
+
+let owner: User;
+let member: User;
+
+beforeEach(async () => {
+	await testDb.truncate(['ExecutionEntity', 'WorkflowEntity', 'SharedWorkflow']);
+	testServer.license.reset();
+	owner = await createOwner();
+	member = await createMember();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SENSITIVE_JSON = { secret: 'sensitive-value', apiKey: 'sk-1234' };
+
+const BINARY_DATA = {
+	data: 'base64data',
+	mimeType: 'text/plain',
+	fileName: 'secret.txt',
+};
+
+function buildRunExecutionData(opts: {
+	policy?: 'none' | 'non-manual' | 'all';
+	mode?: WorkflowExecuteMode;
+}): IRunExecutionData {
+	return createRunExecutionData({
+		resultData: {
+			runData: {
+				'Test Node': [
+					{
+						startTime: 0,
+						executionIndex: 0,
+						executionTime: 0,
+						executionStatus: 'success',
+						source: [],
+						data: {
+							main: [
+								[
+									{
+										json: { ...SENSITIVE_JSON },
+										binary: { file: { ...BINARY_DATA } },
+									},
+								],
+							],
+						},
+					},
+				],
+			},
+		},
+		executionData: opts.policy
+			? {
+					runtimeData: {
+						version: 1 as const,
+						establishedAt: Date.now(),
+						source: opts.mode ?? 'trigger',
+						redaction: { version: 1 as const, policy: opts.policy },
+					},
+				}
+			: undefined,
+	});
+}
+
+async function createExecutionWithRedaction(opts: {
+	workflow: IWorkflowBase;
+	mode?: WorkflowExecuteMode;
+	policy?: 'none' | 'non-manual' | 'all';
+}) {
+	const runData = buildRunExecutionData({ policy: opts.policy, mode: opts.mode });
+	return await createExecution(
+		{ data: stringify(runData), mode: opts.mode ?? 'trigger' },
+		opts.workflow,
+	);
+}
+
+function parseResponseData(responseBody: { data: { data: string } }): IRunExecutionData {
+	// The response data field is flatted-stringified
+	const { parse } = require('flatted');
+	return parse(responseBody.data.data) as IRunExecutionData;
+}
+
+function assertRedacted(data: IRunExecutionData) {
+	const items = data.resultData.runData['Test Node'][0].data!.main[0]!;
+	expect(items.length).toBeGreaterThan(0);
+	for (const item of items) {
+		expect(item.json).toEqual({});
+		expect(item.binary).toBeUndefined();
+		expect(item.redaction).toEqual({ redacted: true });
+	}
+}
+
+function assertNotRedacted(data: IRunExecutionData) {
+	const items = data.resultData.runData['Test Node'][0].data!.main[0]!;
+	expect(items.length).toBeGreaterThan(0);
+	for (const item of items) {
+		expect(item.json).toEqual(expect.objectContaining({ secret: 'sensitive-value' }));
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GET /executions/:id — Execution Redaction', () => {
+	describe('policy-based redaction (no query param)', () => {
+		test('policy "none" with trigger mode — returns unredacted', async () => {
+			const workflow = await createWorkflow({}, owner);
+			const execution = await createExecutionWithRedaction({
+				workflow,
+				mode: 'trigger',
+				policy: 'none',
+			});
+
+			const response = await testServer
+				.authAgentFor(owner)
+				.get(`/executions/${execution.id}`)
+				.expect(200);
+
+			assertNotRedacted(parseResponseData(response.body));
+		});
+
+		test('policy "none" with manual mode — returns unredacted', async () => {
+			const workflow = await createWorkflow({}, owner);
+			const execution = await createExecutionWithRedaction({
+				workflow,
+				mode: 'manual',
+				policy: 'none',
+			});
+
+			const response = await testServer
+				.authAgentFor(owner)
+				.get(`/executions/${execution.id}`)
+				.expect(200);
+
+			assertNotRedacted(parseResponseData(response.body));
+		});
+
+		test('policy "non-manual" with manual mode — returns unredacted', async () => {
+			const workflow = await createWorkflow({}, owner);
+			const execution = await createExecutionWithRedaction({
+				workflow,
+				mode: 'manual',
+				policy: 'non-manual',
+			});
+
+			const response = await testServer
+				.authAgentFor(owner)
+				.get(`/executions/${execution.id}`)
+				.expect(200);
+
+			assertNotRedacted(parseResponseData(response.body));
+		});
+
+		test('policy "non-manual" with trigger mode — returns redacted', async () => {
+			const workflow = await createWorkflow({}, owner);
+			const execution = await createExecutionWithRedaction({
+				workflow,
+				mode: 'trigger',
+				policy: 'non-manual',
+			});
+
+			const response = await testServer
+				.authAgentFor(owner)
+				.get(`/executions/${execution.id}`)
+				.expect(200);
+
+			assertRedacted(parseResponseData(response.body));
+		});
+
+		test('policy "non-manual" with webhook mode — returns redacted', async () => {
+			const workflow = await createWorkflow({}, owner);
+			const execution = await createExecutionWithRedaction({
+				workflow,
+				mode: 'webhook',
+				policy: 'non-manual',
+			});
+
+			const response = await testServer
+				.authAgentFor(owner)
+				.get(`/executions/${execution.id}`)
+				.expect(200);
+
+			assertRedacted(parseResponseData(response.body));
+		});
+
+		test('policy "all" with manual mode — returns redacted', async () => {
+			const workflow = await createWorkflow({}, owner);
+			const execution = await createExecutionWithRedaction({
+				workflow,
+				mode: 'manual',
+				policy: 'all',
+			});
+
+			const response = await testServer
+				.authAgentFor(owner)
+				.get(`/executions/${execution.id}`)
+				.expect(200);
+
+			assertRedacted(parseResponseData(response.body));
+		});
+
+		test('policy "all" with trigger mode — returns redacted', async () => {
+			const workflow = await createWorkflow({}, owner);
+			const execution = await createExecutionWithRedaction({
+				workflow,
+				mode: 'trigger',
+				policy: 'all',
+			});
+
+			const response = await testServer
+				.authAgentFor(owner)
+				.get(`/executions/${execution.id}`)
+				.expect(200);
+
+			assertRedacted(parseResponseData(response.body));
+		});
+
+		test('no runtimeData and no workflow settings — defaults to "none", returns unredacted', async () => {
+			const workflow = await createWorkflow({}, owner);
+			// No policy passed → no runtimeData.redaction
+			const execution = await createExecutionWithRedaction({
+				workflow,
+				mode: 'trigger',
+			});
+
+			const response = await testServer
+				.authAgentFor(owner)
+				.get(`/executions/${execution.id}`)
+				.expect(200);
+
+			assertNotRedacted(parseResponseData(response.body));
+		});
+
+		test('no runtimeData but workflow settings has policy "all" — falls back to settings, returns redacted', async () => {
+			const workflow = await createWorkflow({ settings: { redactionPolicy: 'all' } }, owner);
+			// No runtimeData.redaction → falls back to workflowData.settings.redactionPolicy
+			const execution = await createExecutionWithRedaction({
+				workflow,
+				mode: 'trigger',
+			});
+
+			const response = await testServer
+				.authAgentFor(owner)
+				.get(`/executions/${execution.id}`)
+				.expect(200);
+
+			assertRedacted(parseResponseData(response.body));
+		});
+	});
+
+	describe('explicit redactExecutionData=true query param', () => {
+		test('always redacts even when policy is "none"', async () => {
+			const workflow = await createWorkflow({}, owner);
+			const execution = await createExecutionWithRedaction({
+				workflow,
+				mode: 'trigger',
+				policy: 'none',
+			});
+
+			const response = await testServer
+				.authAgentFor(owner)
+				.get(`/executions/${execution.id}`)
+				.query({ redactExecutionData: 'true' })
+				.expect(200);
+
+			assertRedacted(parseResponseData(response.body));
+		});
+	});
+
+	describe('explicit redactExecutionData=false query param (reveal)', () => {
+		test('owner can reveal unredacted data', async () => {
+			const workflow = await createWorkflow({}, owner);
+			const execution = await createExecutionWithRedaction({
+				workflow,
+				mode: 'trigger',
+				policy: 'all',
+			});
+
+			const response = await testServer
+				.authAgentFor(owner)
+				.get(`/executions/${execution.id}`)
+				.query({ redactExecutionData: 'false' })
+				.expect(200);
+
+			assertNotRedacted(parseResponseData(response.body));
+		});
+
+		test('project editor without execution:reveal scope gets 403', async () => {
+			testServer.license.enable('feat:sharing');
+
+			const teamProject = await createTeamProject();
+			await linkUserToProject(member, teamProject, 'project:editor');
+
+			const workflow = await createWorkflow({}, teamProject);
+			const execution = await createExecutionWithRedaction({
+				workflow,
+				mode: 'trigger',
+				policy: 'all',
+			});
+
+			await testServer
+				.authAgentFor(member)
+				.get(`/executions/${execution.id}`)
+				.query({ redactExecutionData: 'false' })
+				.expect(403);
+		});
+	});
+
+	describe('policy fallback precedence', () => {
+		test('runtimeData policy takes precedence over workflowData.settings', async () => {
+			// Workflow settings say "all" but runtimeData says "none"
+			const workflow = await createWorkflow({ settings: { redactionPolicy: 'all' } }, owner);
+			const execution = await createExecutionWithRedaction({
+				workflow,
+				mode: 'trigger',
+				policy: 'none', // runtimeData wins
+			});
+
+			const response = await testServer
+				.authAgentFor(owner)
+				.get(`/executions/${execution.id}`)
+				.expect(200);
+
+			assertNotRedacted(parseResponseData(response.body));
+		});
+
+		test('falls back to workflowData.settings when runtimeData is missing', async () => {
+			const workflow = await createWorkflow({ settings: { redactionPolicy: 'all' } }, owner);
+			// No policy → no runtimeData.redaction → falls back to settings
+			const execution = await createExecutionWithRedaction({
+				workflow,
+				mode: 'trigger',
+			});
+
+			const response = await testServer
+				.authAgentFor(owner)
+				.get(`/executions/${execution.id}`)
+				.expect(200);
+
+			assertRedacted(parseResponseData(response.body));
+		});
+	});
+});

--- a/packages/cli/test/integration/shared/types.ts
+++ b/packages/cli/test/integration/shared/types.ts
@@ -58,6 +58,7 @@ type ModuleName =
 	| 'dynamic-credentials'
 	| 'log-streaming'
 	| 'ldap'
+	| 'redaction'
 	| 'source-control';
 
 export interface SetupProps {


### PR DESCRIPTION
## Summary

Implement execution data redaction logic in `ExecutionRedactionService`, replacing the previous stub.

The `processExecution` method handles three cases based on the `redactExecutionData` query parameter:

1. **`true`** — Always redact (user explicitly requests redacted view)
2. **`false`** — User explicitly requests unredacted data; if policies allow it, we send unredacted data, otherwise checks `execution:reveal` scope via `canUserReveal`. Returns unmodified if allowed, throws `ForbiddenError` otherwise
3. **`undefined`** (default) — Evaluates the workflow's redaction policy:
   - `none` → return unmodified
   - `non-manual` → return unmodified only for manual executions, redact otherwise
   - `all` → always redact

Policy is resolved from `runtimeData.redaction.policy` (captured at execution time), falling back to `workflowData.settings.redactionPolicy`, defaulting to `none`.

`canUserReveal` checks the `execution:reveal` scope against all projects the workflow is shared with.

`applyRedaction` mutates execution data in place — replaces node output JSON with `{}`, removes binary data, and sets a `{ redacted: true }` marker on each item.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-178/if-data-redaction-is-enabled-on-a-workflow-production-execution-data
https://linear.app/n8n/issue/IAM-182/implement-redactexecutiondatatrue-support
https://linear.app/n8n/issue/IAM-186/implement-redactexecutiondataundefined-behavior
https://linear.app/n8n/issue/IAM-184/implement-redactexecutiondatafalse-logic

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)