### PR TITLE
fix(HTTP Request Node): Allow body to be sent with DELETE requests

### DIFF
--- a/packages/nodes-base/nodes/HttpRequest/V1/HttpRequestV1.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V1/HttpRequestV1.node.ts
@@ -918,7 +918,7 @@ export class HttpRequestV1 implements INodeType {
 			}
 
 			// Change the way data get send in case a different content-type than JSON got selected
-			if (['PATCH', 'POST', 'PUT'].includes(requestMethod)) {
+			if (['PATCH', 'POST', 'PUT', 'DELETE'].includes(requestMethod)) {
 				if (options.bodyContentType === 'multipart-form-data') {
 					requestOptions.formData = requestOptions.body;
 					delete requestOptions.body;
@@ -937,7 +937,7 @@ export class HttpRequestV1 implements INodeType {
 					if (requestOptions.headers === undefined) {
 						requestOptions.headers = {};
 					}
-					if (['POST', 'PUT', 'PATCH'].includes(requestMethod)) {
+					if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(requestMethod)) {
 						requestOptions.headers['Content-Type'] = 'application/json';
 					}
 				}

--- a/packages/nodes-base/nodes/HttpRequest/V2/HttpRequestV2.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V2/HttpRequestV2.node.ts
@@ -979,7 +979,7 @@ export class HttpRequestV2 implements INodeType {
 			}
 
 			// Change the way data get send in case a different content-type than JSON got selected
-			if (['PATCH', 'POST', 'PUT'].includes(requestMethod)) {
+			if (['PATCH', 'POST', 'PUT', 'DELETE'].includes(requestMethod)) {
 				if (options.bodyContentType === 'multipart-form-data') {
 					requestOptions.formData = requestOptions.body;
 					delete requestOptions.body;
@@ -998,7 +998,7 @@ export class HttpRequestV2 implements INodeType {
 					if (requestOptions.headers === undefined) {
 						requestOptions.headers = {};
 					}
-					if (['POST', 'PUT', 'PATCH'].includes(requestMethod)) {
+					if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(requestMethod)) {
 						requestOptions.headers['Content-Type'] = 'application/json';
 					}
 				}

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -464,7 +464,7 @@ export class HttpRequestV3 implements INodeType {
 				}
 
 				// Change the way data get send in case a different content-type than JSON got selected
-				if (sendBody && ['PATCH', 'POST', 'PUT', 'GET'].includes(requestMethod)) {
+				if (sendBody && ['PATCH', 'POST', 'PUT', 'GET', 'DELETE'].includes(requestMethod)) {
 					if (bodyContentType === 'multipart-form-data') {
 						requestOptions.formData = requestOptions.body as IDataObject;
 						delete requestOptions.body;

--- a/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequest.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequest.test.ts
@@ -148,6 +148,16 @@ describe('Test HTTP Request Node', () => {
 			deletedOn: '2023-02-09T05:37:31.720Z',
 		});
 
+		//DELETE with body
+		nock(baseUrl)
+			.delete('/todos/delete', {
+				ids: [1, 2, 3],
+			})
+			.reply(200, {
+				deleted: [1, 2, 3],
+				count: 3,
+			});
+
 		// Pagination - GET
 		nock(baseUrl)
 			.persist()

--- a/packages/nodes-base/nodes/HttpRequest/test/node/workflow.deleteWithBody.json
+++ b/packages/nodes-base/nodes/HttpRequest/test/node/workflow.deleteWithBody.json
@@ -1,0 +1,59 @@
+{
+	"name": "http request test",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "12433cfb-74d9-4bf1-9afd-0ab9afc9ef19",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [820, 360]
+		},
+		{
+			"parameters": {
+				"method": "DELETE",
+				"url": "https://dummyjson.com/todos/delete",
+				"sendBody": true,
+				"specifyBody": "json",
+				"jsonBody": "{\"ids\":[1,2,3]}",
+				"options": {}
+			},
+			"id": "a1b2c3d4-5678-9abc-def0-123456789abc",
+			"name": "HTTP Request",
+			"type": "n8n-nodes-base.httpRequest",
+			"typeVersion": 3,
+			"position": [1140, 200]
+		}
+	],
+	"pinData": {
+		"HTTP Request": [
+			{
+				"json": {
+					"deleted": [1, 2, 3],
+					"count": 3
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "HTTP Request",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {},
+	"versionId": "d4e5f6a7-8901-2345-6789-abcdef012345",
+	"id": "108",
+	"meta": {
+		"instanceId": "36203ea1ce3cef713fa25999bd9874ae26b9e4c2c3a90a365f2882a154d031d0"
+	},
+	"tags": []
+}


### PR DESCRIPTION
## Summary

The HTTP Request node UI allows configuring a body for DELETE requests, but the execution code silently drops it because `DELETE` is missing from the hardcoded method arrays that gate body processing.

This adds `DELETE` to those arrays in all three node versions (V1, V2, V3), so that body content (JSON, form-urlencoded, multipart-form-data, raw, binary) is transmitted correctly — matching the behavior of POST, PUT, and PATCH.

The HTTP specification (RFC 9110) does not prohibit bodies on DELETE requests, and many APIs (e.g., Elasticsearch bulk delete) require them.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #26044

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- No docs change needed — the UI already showed body options for DELETE; this fix makes the backend match the existing UI behavior. -->
- [x] Tests included.


🤖 Generated with [Claude Code](https://claude.com/claude-code)