### PR TITLE
ci: Automate calls to release-push-to-channel

### DIFF
--- a/.github/scripts/determine-version-info.test.mjs
+++ b/.github/scripts/determine-version-info.test.mjs
@@ -15,7 +15,7 @@ mock.module('./github-helpers.mjs', {
 		resolveReleaseTagForTrack: (track) => {
 			// Always return deterministic data
 			if (track === 'stable') return { version: '2.9.2' };
-			if (track === 'beta') return { version: '2.10.0' };
+			if (track === 'beta') return { version: '2.10.1' };
 			return { version: '1.123.33' };
 		},
 		writeGithubOutput: () => {}, // no-op in tests
@@ -39,10 +39,10 @@ describe('determine-tracks', () => {
 	});
 
 	it('Allow patch releases on beta', () => {
-		const output = determineTrack('2.10.1');
+		const output = determineTrack('2.10.2');
 
 		assert.equal(output.track, 'beta');
-		assert.equal(output.version, '2.10.1');
+		assert.equal(output.version, '2.10.2');
 		assert.equal(output.bump, 'patch');
 		assert.equal(output.new_stable_version, null);
 		assert.equal(output.release_type, 'stable');
@@ -75,15 +75,15 @@ describe('determine-tracks', () => {
 		assert.equal(output.track, 'beta');
 		assert.equal(output.version, '2.11.0');
 		assert.equal(output.bump, 'minor');
-		assert.equal(output.new_stable_version, '2.10.0');
+		assert.equal(output.new_stable_version, '2.10.1');
 		assert.equal(output.release_type, 'stable');
 	});
 
 	it('Set release_type accordingly on rc releases', () => {
-		const output = determineTrack('2.10.1-rc.1');
+		const output = determineTrack('2.10.2-rc.1');
 
 		assert.equal(output.track, 'beta');
-		assert.equal(output.version, '2.10.1-rc.1');
+		assert.equal(output.version, '2.10.2-rc.1');
 		assert.equal(output.bump, 'patch');
 		assert.equal(output.new_stable_version, null);
 		assert.equal(output.release_type, 'rc');

--- a/.github/workflows/release-publish-post-release.yml
+++ b/.github/workflows/release-publish-post-release.yml
@@ -27,6 +27,7 @@ on:
 jobs:
   push-to-channels:
     runs-on: ubuntu-latest
+    if: inputs.release_type != 'rc'
 
     steps:
       - name: Checkout

--- a/.github/workflows/release-publish-post-release.yml
+++ b/.github/workflows/release-publish-post-release.yml
@@ -1,0 +1,52 @@
+name: 'Release: Publish: Post-release'
+
+on:
+  workflow_call:
+    inputs:
+      track:
+        description: 'Release track acquired from determine-version-info. (e.g. stable, beta)'
+        required: true
+        type: string
+      version:
+        description: 'Release version acquired from determine-version-info. (e.g. 2.9.3, 1.123.23)'
+        required: true
+        type: string
+      bump:
+        description: 'Release bump size acquired from determine-version-info. (e.g. minor, patch)'
+        required: true
+        type: string
+      new_stable_version:
+        description: 'New stable version acquired from determine-version-info. (e.g. 2.9.3, null (on patch releases))'
+        required: true
+        type: string
+      release_type:
+        description: 'Release type acquired from determine-version-info. (stable or rc)'
+        required: true
+        type: string
+
+jobs:
+  push-to-channels:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-nodejs
+        with:
+          build-command: ''
+          install-command: npm install --prefix=.github/scripts --no-package-lock
+
+      - name: Push new release to channel
+        uses: ./.github/workflows/release-push-to-channel.yml
+        with:
+          version: ${{ inputs.version }}
+          release-channel: ${{ inputs.track }}
+
+      - name: Promote previous beta to stable
+        uses: ./.github/workflows/release-push-to-channel.yml
+        if: inputs.bump == 'minor'
+        with:
+          version: ${{ inputs.new_stable_version }}
+          release-channel: stable

--- a/.github/workflows/release-publish-post-release.yml
+++ b/.github/workflows/release-publish-post-release.yml
@@ -25,29 +25,18 @@ on:
         type: string
 
 jobs:
-  push-to-channels:
-    runs-on: ubuntu-latest
+  push-new-release-to-channel:
+    name: Push new release to channel
     if: inputs.release_type != 'rc'
+    uses: ./.github/workflows/release-push-to-channel.yml
+    with:
+      version: ${{ inputs.version }}
+      release-channel: ${{ inputs.track }}
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Setup Node.js
-        uses: ./.github/actions/setup-nodejs
-        with:
-          build-command: ''
-          install-command: npm install --prefix=.github/scripts --no-package-lock
-
-      - name: Push new release to channel
-        uses: ./.github/workflows/release-push-to-channel.yml
-        with:
-          version: ${{ inputs.version }}
-          release-channel: ${{ inputs.track }}
-
-      - name: Promote previous beta to stable
-        uses: ./.github/workflows/release-push-to-channel.yml
-        if: inputs.bump == 'minor'
-        with:
-          version: ${{ inputs.new_stable_version }}
-          release-channel: stable
+  promote-previous-beta-to-stable:
+    name: Promote previous beta to stable
+    uses: ./.github/workflows/release-push-to-channel.yml
+    if: inputs.bump == 'minor'
+    with:
+      version: ${{ inputs.new_stable_version }}
+      release-channel: stable

--- a/.github/workflows/release-publish-post-release.yml
+++ b/.github/workflows/release-publish-post-release.yml
@@ -36,7 +36,9 @@ jobs:
   promote-previous-beta-to-stable:
     name: Promote previous beta to stable
     uses: ./.github/workflows/release-push-to-channel.yml
-    if: inputs.bump == 'minor'
+    if: |
+      inputs.release_type != 'rc' &&
+      inputs.bump == 'minor'
     with:
       version: ${{ inputs.new_stable_version }}
       release-channel: stable

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -214,3 +214,14 @@ jobs:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           message: |
             <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}| Release tag merge to master failed for n8n@${{ needs.determine-version-info.outputs.version }} >
+  post-release:
+    name: Run Post-release actions
+    needs: [determine-version-info, merge-release-tag-to-master]
+    uses: ./.github/workflows/release-publish-post-release.yml
+    with:
+      track: ${{ needs.determine-version-info.outputs.track }}
+      version: ${{ needs.determine-version-info.outputs.version }}
+      bump: ${{ needs.determine-version-info.outputs.bump }}
+      new_stable_version: ${{ needs.determine-version-info.outputs.new_stable_version }}
+      release_type: ${{ needs.determine-version-info.outputs.release_type }}
+    secrets: inherit

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -216,7 +216,7 @@ jobs:
             <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}| Release tag merge to master failed for n8n@${{ needs.determine-version-info.outputs.version }} >
   post-release:
     name: Run Post-release actions
-    needs: [determine-version-info, merge-release-tag-to-master]
+    needs: [determine-version-info, publish-to-npm, create-github-release]
     uses: ./.github/workflows/release-publish-post-release.yml
     with:
       track: ${{ needs.determine-version-info.outputs.track }}

--- a/.github/workflows/release-push-to-channel.yml
+++ b/.github/workflows/release-push-to-channel.yml
@@ -1,6 +1,18 @@
 name: 'Release: Push to Channel'
 
 on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'n8n Release version to push to a channel (e.g., 1.2.3 or 1.2.3-beta.4)'
+        required: true
+        type: string
+
+      release-channel:
+        description: 'Release channel'
+        required: true
+        type: string
+
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/release-push-to-channel.yml
+++ b/.github/workflows/release-push-to-channel.yml
@@ -35,12 +35,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.check_version.outputs.version }}
-      release_channel: ${{ github.event.inputs.release-channel }}
+      release_channel: ${{ inputs.release-channel }}
     steps:
       - name: Check Version Format
         id: check_version
         env:
-          INPUT_VERSION: ${{ github.event.inputs.version }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           input_version="${{ env.INPUT_VERSION }}"
           version_regex='^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$'
@@ -55,8 +55,8 @@ jobs:
 
       - name: Block RC promotion to stable/beta
         env:
-          INPUT_VERSION: ${{ github.event.inputs.version }}
-          CHANNEL: ${{ github.event.inputs.release-channel }}
+          INPUT_VERSION: ${{ inputs.version }}
+          CHANNEL: ${{ inputs.release-channel }}
         run: |
           if [[ "$INPUT_VERSION" == *"-rc."* ]]; then
             echo "::error::RC versions cannot be promoted to '$CHANNEL' channel. Version '$INPUT_VERSION' contains '-rc.'"


### PR DESCRIPTION
## Summary

Automate manual process of calling [release-push-to-channel](https://github.com/n8n-io/n8n/actions/workflows/release-push-to-channel.yml).

On Patch releases only the released version is pushed, on Minor releases the previous beta is also promoted.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2423

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
