### PR TITLE
ci: Add suppress_output option to Claude task runner (no-changelog)

### DIFF
--- a/.github/workflows/util-claude-task.yml
+++ b/.github/workflows/util-claude-task.yml
@@ -26,6 +26,11 @@ on:
         required: false
         type: number
         default: 50
+      suppress_output:
+        description: 'Suppress console output and job summary (use for security-sensitive tasks)'
+        required: false
+        type: boolean
+        default: false
       ref:
         description: 'Git ref (branch/tag/SHA) to check out and work on'
         required: false
@@ -121,7 +126,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.generate_token.outputs.token }}
           prompt: ${{ env.CLAUDE_PROMPT }}
-          show_full_output: true
+          show_full_output: ${{ inputs.suppress_output != true }}
           settings: |
             {
               "permissions": {
@@ -161,11 +166,16 @@ jobs:
           INPUT_TASK: ${{ inputs.task }}
           CLAUDE_OUTCOME: ${{ steps.claude.outcome }}
           CLAUDE_SESSION_ID: ${{ steps.claude.outputs.session_id }}
+          SUPPRESS_OUTPUT: ${{ inputs.suppress_output }}
         run: |
           {
             echo "## Claude Task Runner Summary"
             echo ""
-            echo "**Task:** $INPUT_TASK"
+            if [ "$SUPPRESS_OUTPUT" = "true" ]; then
+              echo "**Task:** _(suppressed — security-sensitive)_"
+            else
+              echo "**Task:** $INPUT_TASK"
+            fi
             echo "**Branch:** ${BRANCH_NAME:-N/A}"
             echo "**Claude outcome:** $CLAUDE_OUTCOME"
             if [ -n "$CLAUDE_SESSION_ID" ]; then

--- a/.github/workflows/util-claude-task.yml
+++ b/.github/workflows/util-claude-task.yml
@@ -27,7 +27,7 @@ on:
         type: number
         default: 50
       suppress_output:
-        description: 'Suppress console output and job summary (use for security-sensitive tasks)'
+        description: 'Suppress console output and job summary'
         required: false
         type: boolean
         default: false
@@ -172,7 +172,7 @@ jobs:
             echo "## Claude Task Runner Summary"
             echo ""
             if [ "$SUPPRESS_OUTPUT" = "true" ]; then
-              echo "**Task:** _(suppressed — security-sensitive)_"
+              echo "**Task:** _(output suppressed)_"
             else
               echo "**Task:** $INPUT_TASK"
             fi


### PR DESCRIPTION
## Summary

Adds a `suppress_output` boolean input to the Claude task runner workflow that prevents task/ticket information from appearing in GitHub Actions logs.

When `suppress_output=true`:
- Claude's full conversation output is hidden from step logs (`show_full_output` set to false)
- The task description in the job summary is replaced with `_(output suppressed)_`

**Usage:**
```bash
gh workflow run util-claude-task.yml \
  -f task="Triage CAT-1234..." \
  -f suppress_output=true
```

**Note:** `workflow_dispatch` inputs are always visible in the GitHub UI regardless of this flag. For full redaction, pass only a Linear ticket ID and let Claude fetch details via MCP.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)