### PR TITLE
ci: Automatically mark releases at latest or pre-release

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -125,8 +125,8 @@ jobs:
         with:
           commit: ${{github.event.pull_request.base.ref}}
           tag: 'n8n@${{ needs.determine-version-info.outputs.version }}'
-          prerelease: ${{ startsWith(needs.determine-version-info.outputs.version, '2.') }}
-          makeLatest: false
+          prerelease: ${{ needs.determine-version-info.outputs.track == 'beta' }}
+          makeLatest: ${{ needs.determine-version-info.outputs.track == 'stable' }}
           body: ${{github.event.pull_request.body}}
 
   move-track-tag:


### PR DESCRIPTION
## Summary

Instead of having to do the release modification manually after the release process, mark the releases accordingly in the action that creates the release.

- If release is a stable release, mark it as Latest
- If release is a beta release, mark it as pre-release
- If a release is anything else, it's neither of these.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2158 

Though here less is more. No need to add steps when we can just do the right thing from the get-go

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
