### PR TITLE
fix(editor): Fix trigger listening state tooltip layout (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeTooltip.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeTooltip.vue
@@ -14,31 +14,36 @@ const renderOptions = computed(() => render.value.options as CanvasNodeDefaultRe
 </script>
 
 <template>
-	<N8nTooltip
-		placement="top"
-		:show-after="500"
-		:visible="visible"
-		:teleported="false"
-		:content-class="$style.content"
-		:avoid-collisions="false"
-	>
-		<template #content>
-			{{ renderOptions.tooltip }}
-		</template>
-		<div :class="$style.tooltipTrigger" />
-	</N8nTooltip>
+	<div :class="$style.tooltipAnchor">
+		<N8nTooltip
+			placement="top"
+			:show-after="500"
+			:visible="visible"
+			:teleported="false"
+			:content-class="$style.content"
+			:avoid-collisions="false"
+		>
+			<template #content>
+				{{ renderOptions.tooltip }}
+			</template>
+			<span :class="$style.tooltipTrigger" />
+		</N8nTooltip>
+	</div>
 </template>
 
 <style lang="scss" module>
-.tooltipTrigger {
+.tooltipAnchor {
 	position: absolute;
 	top: 0;
 	left: 0;
 	width: 100%;
-	height: 100%;
+	display: flex;
+	justify-content: center;
+	pointer-events: none;
 }
 
 .content {
 	white-space: nowrap;
+	max-width: none;
 }
 </style>


### PR DESCRIPTION
## Summary
**Before**:
<img width="225" height="212" alt="image" src="https://github.com/user-attachments/assets/67144ad0-6f5e-4d06-bb28-59e471bf3d1f" />

**After**:
<img width="230" height="219" alt="image" src="https://github.com/user-attachments/assets/1ef08c1a-d519-44fe-b1df-842f1a4ff148" />


## Related Linear tickets, Github issues, and Community forum posts
Fixes ADO-4863


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
