### PR TITLE
fix: Admin should be able to install community nodes

### DIFF
--- a/packages/frontend/editor-ui/src/experiments/credentialsAppSelection/components/AppInstallModal.vue
+++ b/packages/frontend/editor-ui/src/experiments/credentialsAppSelection/components/AppInstallModal.vue
@@ -32,7 +32,7 @@ const usersStore = useUsersStore();
 const nodeTypesStore = useNodeTypesStore();
 const { installNode, loading } = useInstallNode();
 
-const isOwner = computed(() => usersStore.isInstanceOwner);
+const isAdmin = computed(() => usersStore.isAdmin);
 
 // Fetched data from API (like CommunityNodeInfo does)
 const publisherName = ref<string | undefined>(undefined);
@@ -134,7 +134,7 @@ const nodeTypeForIcon = computed((): SimplifiedNodeType | null => {
 });
 
 const handleInstall = async () => {
-	if (!props.appEntry?.packageName || !isOwner.value) return;
+	if (!props.appEntry?.packageName || !isAdmin.value) return;
 
 	const result = await installNode({
 		type: 'verified',
@@ -263,14 +263,14 @@ watch(
 					</a>
 				</div>
 
-				<ContactAdministratorToInstall v-if="!isOwner" />
+				<ContactAdministratorToInstall v-if="!isAdmin" />
 			</div>
 		</template>
 
 		<template #footer>
 			<div :class="$style.footer">
 				<N8nButton
-					v-if="isOwner"
+					v-if="isAdmin"
 					:label="i18n.baseText('communityNodeDetails.install')"
 					icon="download"
 					:loading="loading"

--- a/packages/frontend/editor-ui/src/experiments/credentialsAppSelection/components/AppInstallModal.vue
+++ b/packages/frontend/editor-ui/src/experiments/credentialsAppSelection/components/AppInstallModal.vue
@@ -32,7 +32,7 @@ const usersStore = useUsersStore();
 const nodeTypesStore = useNodeTypesStore();
 const { installNode, loading } = useInstallNode();
 
-const isAdmin = computed(() => usersStore.isAdmin);
+const isAdminOrOwner = computed(() => usersStore.isAdmin || usersStore.isInstanceOwner);
 
 // Fetched data from API (like CommunityNodeInfo does)
 const publisherName = ref<string | undefined>(undefined);
@@ -134,7 +134,7 @@ const nodeTypeForIcon = computed((): SimplifiedNodeType | null => {
 });
 
 const handleInstall = async () => {
-	if (!props.appEntry?.packageName || !isAdmin.value) return;
+	if (!props.appEntry?.packageName || !isAdminOrOwner.value) return;
 
 	const result = await installNode({
 		type: 'verified',
@@ -263,14 +263,14 @@ watch(
 					</a>
 				</div>
 
-				<ContactAdministratorToInstall v-if="!isAdmin" />
+				<ContactAdministratorToInstall v-if="!isAdminOrOwner" />
 			</div>
 		</template>
 
 		<template #footer>
 			<div :class="$style.footer">
 				<N8nButton
-					v-if="isAdmin"
+					v-if="isAdminOrOwner"
 					:label="i18n.baseText('communityNodeDetails.install')"
 					icon="download"
 					:loading="loading"

--- a/packages/frontend/editor-ui/src/experiments/credentialsAppSelection/components/AppInstallModal.vue
+++ b/packages/frontend/editor-ui/src/experiments/credentialsAppSelection/components/AppInstallModal.vue
@@ -32,7 +32,7 @@ const usersStore = useUsersStore();
 const nodeTypesStore = useNodeTypesStore();
 const { installNode, loading } = useInstallNode();
 
-const isAdminOrOwner = computed(() => usersStore.isAdmin || usersStore.isInstanceOwner);
+const isAdminOrOwner = computed(() => usersStore.isAdminOrOwner);
 
 // Fetched data from API (like CommunityNodeInfo does)
 const publisherName = ref<string | undefined>(undefined);

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsInvalidNodeWarning.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsInvalidNodeWarning.test.ts
@@ -68,8 +68,23 @@ describe('NodeSettingsInvalidNodeWarning', () => {
 			expect(getByTestId('install-community-node-button')).toBeInTheDocument();
 		});
 
+		it('should show install button when user is instance owner (not admin)', async () => {
+			mockUseUsersStore.isAdmin = false;
+			mockUseUsersStore.isInstanceOwner = true;
+			const node = mockNode({ name: 'Test Node', type: 'n8n-nodes-test.testNode' });
+			const { getByTestId } = renderComponent(NodeSettingsInvalidNodeWarning, {
+				props: {
+					node,
+				},
+				pinia,
+			});
+
+			expect(getByTestId('install-community-node-button')).toBeInTheDocument();
+		});
+
 		it('should show ContactAdministratorToInstall when user is not owner', async () => {
 			mockUseUsersStore.isAdmin = false;
+			mockUseUsersStore.isInstanceOwner = false;
 			const node = mockNode({ name: 'Test Node', type: 'n8n-nodes-test.testNode' });
 			const { getByText } = renderComponent(NodeSettingsInvalidNodeWarning, {
 				props: {

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsInvalidNodeWarning.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsInvalidNodeWarning.test.ts
@@ -55,21 +55,12 @@ describe('NodeSettingsInvalidNodeWarning', () => {
 	});
 
 	describe('Owner permissions', () => {
-		it('should show install button when user is admin', async () => {
-			mockUseUsersStore.isAdmin = true;
-			const node = mockNode({ name: 'Test Node', type: 'n8n-nodes-test.testNode' });
-			const { getByTestId } = renderComponent(NodeSettingsInvalidNodeWarning, {
-				props: {
-					node,
-				},
-				pinia,
-			});
-
-			expect(getByTestId('install-community-node-button')).toBeInTheDocument();
-		});
-
-		it('should show install button when user is instance owner', async () => {
-			mockUseUsersStore.isInstanceOwner = true;
+		it.each([
+			{ isAdmin: true, isInstanceOwner: false, label: 'admin' },
+			{ isAdmin: false, isInstanceOwner: true, label: 'instance owner' },
+		])('should show install button when user is $label', ({ isAdmin, isInstanceOwner }) => {
+			mockUseUsersStore.isAdmin = isAdmin;
+			mockUseUsersStore.isInstanceOwner = isInstanceOwner;
 			const node = mockNode({ name: 'Test Node', type: 'n8n-nodes-test.testNode' });
 			const { getByTestId } = renderComponent(NodeSettingsInvalidNodeWarning, {
 				props: {

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsInvalidNodeWarning.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsInvalidNodeWarning.test.ts
@@ -56,7 +56,7 @@ describe('NodeSettingsInvalidNodeWarning', () => {
 
 	describe('Owner permissions', () => {
 		it('should show install button when user is owner', async () => {
-			mockUseUsersStore.isInstanceOwner = true;
+			mockUseUsersStore.isAdmin = true;
 			const node = mockNode({ name: 'Test Node', type: 'n8n-nodes-test.testNode' });
 			const { getByTestId } = renderComponent(NodeSettingsInvalidNodeWarning, {
 				props: {
@@ -69,7 +69,7 @@ describe('NodeSettingsInvalidNodeWarning', () => {
 		});
 
 		it('should show ContactAdministratorToInstall when user is not owner', async () => {
-			mockUseUsersStore.isInstanceOwner = false;
+			mockUseUsersStore.isAdmin = false;
 			const node = mockNode({ name: 'Test Node', type: 'n8n-nodes-test.testNode' });
 			const { getByText } = renderComponent(NodeSettingsInvalidNodeWarning, {
 				props: {
@@ -86,7 +86,7 @@ describe('NodeSettingsInvalidNodeWarning', () => {
 
 	describe('View Details button', () => {
 		it('should open node creator when node is verified community node', async () => {
-			mockUseUsersStore.isInstanceOwner = true;
+			mockUseUsersStore.isAdmin = true;
 			mockUseNodeTypesStore.communityNodeType = () =>
 				({
 					isOfficialNode: true,
@@ -109,7 +109,7 @@ describe('NodeSettingsInvalidNodeWarning', () => {
 		});
 
 		it('should open NPM page when node is not verified community node', async () => {
-			mockUseUsersStore.isInstanceOwner = true;
+			mockUseUsersStore.isAdmin = true;
 			mockUseNodeTypesStore.communityNodeType = () =>
 				({
 					isOfficialNode: false,
@@ -135,7 +135,7 @@ describe('NodeSettingsInvalidNodeWarning', () => {
 
 	describe('Install button logic', () => {
 		it('should call installNode directly for verified community node', async () => {
-			mockUseUsersStore.isInstanceOwner = true;
+			mockUseUsersStore.isAdmin = true;
 			mockUseNodeTypesStore.communityNodeType = () =>
 				({
 					isOfficialNode: true,
@@ -165,7 +165,7 @@ describe('NodeSettingsInvalidNodeWarning', () => {
 		});
 
 		it('should call installNode without preview token directly for verified community node', async () => {
-			mockUseUsersStore.isInstanceOwner = true;
+			mockUseUsersStore.isAdmin = true;
 			mockUseNodeTypesStore.communityNodeType = () =>
 				({
 					isOfficialNode: true,
@@ -195,7 +195,7 @@ describe('NodeSettingsInvalidNodeWarning', () => {
 		});
 
 		it('should open modal for non-verified community node', async () => {
-			mockUseUsersStore.isInstanceOwner = true;
+			mockUseUsersStore.isAdmin = true;
 			mockUseNodeTypesStore.communityNodeType = () =>
 				({
 					isOfficialNode: false,
@@ -228,7 +228,7 @@ describe('NodeSettingsInvalidNodeWarning', () => {
 
 	describe('Node installation watcher', () => {
 		it('should call unsetActiveNodeName when node is defined', async () => {
-			mockUseUsersStore.isInstanceOwner = true;
+			mockUseUsersStore.isAdmin = true;
 			mockUseNodeTypesStore.communityNodeType = () =>
 				({
 					isOfficialNode: true,
@@ -260,7 +260,7 @@ describe('NodeSettingsInvalidNodeWarning', () => {
 		});
 
 		it('should not call unsetActiveNodeName when node is not defined', () => {
-			mockUseUsersStore.isInstanceOwner = true;
+			mockUseUsersStore.isAdmin = true;
 			mockUseNodeTypesStore.communityNodeType = () =>
 				({
 					isOfficialNode: true,
@@ -282,7 +282,7 @@ describe('NodeSettingsInvalidNodeWarning', () => {
 
 	describe('Non-community nodes', () => {
 		it('should show custom node documentation link for non-community nodes', () => {
-			mockUseUsersStore.isInstanceOwner = true;
+			mockUseUsersStore.isAdmin = true;
 			const node = mockNode({ name: 'Custom Node', type: 'custom-node' });
 
 			const { getByText } = renderComponent(NodeSettingsInvalidNodeWarning, {

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsInvalidNodeWarning.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsInvalidNodeWarning.test.ts
@@ -55,7 +55,7 @@ describe('NodeSettingsInvalidNodeWarning', () => {
 	});
 
 	describe('Owner permissions', () => {
-		it('should show install button when user is owner', async () => {
+		it('should show install button when user is admin', async () => {
 			mockUseUsersStore.isAdmin = true;
 			const node = mockNode({ name: 'Test Node', type: 'n8n-nodes-test.testNode' });
 			const { getByTestId } = renderComponent(NodeSettingsInvalidNodeWarning, {
@@ -68,8 +68,7 @@ describe('NodeSettingsInvalidNodeWarning', () => {
 			expect(getByTestId('install-community-node-button')).toBeInTheDocument();
 		});
 
-		it('should show install button when user is instance owner (not admin)', async () => {
-			mockUseUsersStore.isAdmin = false;
+		it('should show install button when user is instance owner', async () => {
 			mockUseUsersStore.isInstanceOwner = true;
 			const node = mockNode({ name: 'Test Node', type: 'n8n-nodes-test.testNode' });
 			const { getByTestId } = renderComponent(NodeSettingsInvalidNodeWarning, {
@@ -82,7 +81,7 @@ describe('NodeSettingsInvalidNodeWarning', () => {
 			expect(getByTestId('install-community-node-button')).toBeInTheDocument();
 		});
 
-		it('should show ContactAdministratorToInstall when user is not owner', async () => {
+		it('should show ContactAdministratorToInstall when user is not owner or admin', async () => {
 			mockUseUsersStore.isAdmin = false;
 			mockUseUsersStore.isInstanceOwner = false;
 			const node = mockNode({ name: 'Test Node', type: 'n8n-nodes-test.testNode' });

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsInvalidNodeWarning.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsInvalidNodeWarning.vue
@@ -35,7 +35,7 @@ const isVerifiedCommunityNode = computed(
 		nodeTypesStore.communityNodeType(node.type)?.isOfficialNode,
 );
 const npmPackage = computed(() => removePreviewToken(node.type.split('.')[0]));
-const isAdminOrOwner = computed(() => usersStore.isAdmin || usersStore.isInstanceOwner);
+const isAdminOrOwner = computed(() => usersStore.isAdminOrOwner);
 const { getQuickConnectOptionByPackageName } = useQuickConnect();
 const quickConnect = computed(() => getQuickConnectOptionByPackageName(npmPackage.value));
 

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsInvalidNodeWarning.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsInvalidNodeWarning.vue
@@ -35,7 +35,7 @@ const isVerifiedCommunityNode = computed(
 		nodeTypesStore.communityNodeType(node.type)?.isOfficialNode,
 );
 const npmPackage = computed(() => removePreviewToken(node.type.split('.')[0]));
-const isOwner = computed(() => usersStore.isInstanceOwner);
+const isAdmin = computed(() => usersStore.isAdmin);
 const { getQuickConnectOptionByPackageName } = useQuickConnect();
 const quickConnect = computed(() => getQuickConnectOptionByPackageName(npmPackage.value));
 
@@ -114,10 +114,10 @@ watch(isNodeDefined, () => {
 					<N8nText size="medium" bold>{{ npmPackage }}</N8nText>
 				</template>
 			</I18nT>
-			<div v-if="isOwner" :class="$style.communityNodeActionsContainer">
+			<div v-if="isAdmin" :class="$style.communityNodeActionsContainer">
 				<N8nButton
 					variant="solid"
-					v-if="isOwner"
+					v-if="isAdmin"
 					icon="hard-drive-download"
 					data-test-id="install-community-node-button"
 					:loading="loading"

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsInvalidNodeWarning.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsInvalidNodeWarning.vue
@@ -35,7 +35,7 @@ const isVerifiedCommunityNode = computed(
 		nodeTypesStore.communityNodeType(node.type)?.isOfficialNode,
 );
 const npmPackage = computed(() => removePreviewToken(node.type.split('.')[0]));
-const isAdmin = computed(() => usersStore.isAdmin);
+const isAdminOrOwner = computed(() => usersStore.isAdmin || usersStore.isInstanceOwner);
 const { getQuickConnectOptionByPackageName } = useQuickConnect();
 const quickConnect = computed(() => getQuickConnectOptionByPackageName(npmPackage.value));
 
@@ -114,10 +114,10 @@ watch(isNodeDefined, () => {
 					<N8nText size="medium" bold>{{ npmPackage }}</N8nText>
 				</template>
 			</I18nT>
-			<div v-if="isAdmin" :class="$style.communityNodeActionsContainer">
+			<div v-if="isAdminOrOwner" :class="$style.communityNodeActionsContainer">
 				<N8nButton
 					variant="solid"
-					v-if="isAdmin"
+					v-if="isAdminOrOwner"
 					icon="hard-drive-download"
 					data-test-id="install-community-node-button"
 					:loading="loading"

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeDetails.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeDetails.test.ts
@@ -37,7 +37,7 @@ const showError = vi.fn();
 const removeNodeFromMergedNodes = vi.fn();
 
 const usersStore = {
-	isInstanceOwner: true,
+	isAdminOrOwner: true,
 };
 
 vi.mock('@/features/credentials/credentials.store', () => ({
@@ -211,7 +211,7 @@ describe('CommunityNodeDetails', () => {
 	});
 
 	it('should not render install button if not instance owner', async () => {
-		usersStore.isInstanceOwner = false;
+		usersStore.isAdminOrOwner = false;
 
 		const wrapper = renderComponent({ pinia });
 

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeDetails.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeDetails.test.ts
@@ -37,7 +37,7 @@ const showError = vi.fn();
 const removeNodeFromMergedNodes = vi.fn();
 
 const usersStore = {
-	isAdmin: true,
+	isInstanceOwner: true,
 };
 
 vi.mock('@/features/credentials/credentials.store', () => ({
@@ -211,7 +211,7 @@ describe('CommunityNodeDetails', () => {
 	});
 
 	it('should not render install button if not instance owner', async () => {
-		usersStore.isAdmin = false;
+		usersStore.isInstanceOwner = false;
 
 		const wrapper = renderComponent({ pinia });
 

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeDetails.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeDetails.test.ts
@@ -37,7 +37,7 @@ const showError = vi.fn();
 const removeNodeFromMergedNodes = vi.fn();
 
 const usersStore = {
-	isInstanceOwner: true,
+	isAdmin: true,
 };
 
 vi.mock('@/features/credentials/credentials.store', () => ({
@@ -211,7 +211,7 @@ describe('CommunityNodeDetails', () => {
 	});
 
 	it('should not render install button if not instance owner', async () => {
-		usersStore.isInstanceOwner = false;
+		usersStore.isAdmin = false;
 
 		const wrapper = renderComponent({ pinia });
 

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeDetails.vue
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeDetails.vue
@@ -34,7 +34,7 @@ const quickConnect = computed(() => {
 const nodeCreatorStore = useNodeCreatorStore();
 const { installNode, loading } = useInstallNode();
 
-const isOwner = computed(() => useUsersStore().isInstanceOwner);
+const isAdminOrOwner = computed(() => useUsersStore().isAdminOrOwner);
 
 const updateViewStack = (key: string) => {
 	const installedNodeKey = removePreviewToken(key);
@@ -71,7 +71,11 @@ const updateStoresAndViewStack = (key: string) => {
 };
 
 const onInstall = async () => {
-	if (isOwner.value && activeViewStack.communityNodeDetails && !communityNodeDetails?.installed) {
+	if (
+		isAdminOrOwner.value &&
+		activeViewStack.communityNodeDetails &&
+		!communityNodeDetails?.installed
+	) {
 		const { key, packageName } = activeViewStack.communityNodeDetails;
 		const result = await installNode({
 			type: 'verified',
@@ -123,7 +127,7 @@ const onInstall = async () => {
 				</div>
 
 				<N8nButton
-					v-if="isOwner && !communityNodeDetails.installed"
+					v-if="isAdminOrOwner && !communityNodeDetails.installed"
 					:loading="loading"
 					:disabled="loading"
 					:label="i18n.baseText('communityNodeDetails.install')"

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeInfo.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeInfo.test.ts
@@ -40,7 +40,7 @@ vi.mock('@/app/stores/nodeTypes.store', () => ({
 
 vi.mock('@/features/settings/users/users.store', () => ({
 	useUsersStore: vi.fn(() => ({
-		isInstanceOwner: true,
+		isAdmin: true,
 	})),
 }));
 

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeInfo.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeInfo.test.ts
@@ -41,6 +41,7 @@ vi.mock('@/app/stores/nodeTypes.store', () => ({
 vi.mock('@/features/settings/users/users.store', () => ({
 	useUsersStore: vi.fn(() => ({
 		isAdmin: true,
+		isAdminOrOwner: true,
 		isInstanceOwner: false,
 	})),
 }));

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeInfo.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeInfo.test.ts
@@ -41,6 +41,7 @@ vi.mock('@/app/stores/nodeTypes.store', () => ({
 vi.mock('@/features/settings/users/users.store', () => ({
 	useUsersStore: vi.fn(() => ({
 		isAdmin: true,
+		isInstanceOwner: false,
 	})),
 }));
 

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeInfo.vue
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeInfo.vue
@@ -37,7 +37,7 @@ const quickConnect = computed(() => {
 
 const nodeTypesStore = useNodeTypesStore();
 
-const isOwner = computed(() => useUsersStore().isInstanceOwner);
+const isAdmin = computed(() => useUsersStore().isAdmin);
 
 const formatNumber = (number: number) => {
 	if (!number) return null;
@@ -175,7 +175,7 @@ onMounted(async () => {
 		</div>
 
 		<QuickConnectBanner v-if="quickConnect" :text="quickConnect?.text" />
-		<ContactAdministratorToInstall v-if="!isOwner && !communityNodeDetails?.installed" />
+		<ContactAdministratorToInstall v-if="!isAdmin && !communityNodeDetails?.installed" />
 	</div>
 </template>
 

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeInfo.vue
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeInfo.vue
@@ -37,7 +37,8 @@ const quickConnect = computed(() => {
 
 const nodeTypesStore = useNodeTypesStore();
 
-const isAdmin = computed(() => useUsersStore().isAdmin);
+const usersStore = useUsersStore();
+const isAdminOrOwner = computed(() => usersStore.isAdmin || usersStore.isInstanceOwner);
 
 const formatNumber = (number: number) => {
 	if (!number) return null;
@@ -175,7 +176,7 @@ onMounted(async () => {
 		</div>
 
 		<QuickConnectBanner v-if="quickConnect" :text="quickConnect?.text" />
-		<ContactAdministratorToInstall v-if="!isAdmin && !communityNodeDetails?.installed" />
+		<ContactAdministratorToInstall v-if="!isAdminOrOwner && !communityNodeDetails?.installed" />
 	</div>
 </template>
 

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeInfo.vue
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeInfo.vue
@@ -38,7 +38,7 @@ const quickConnect = computed(() => {
 const nodeTypesStore = useNodeTypesStore();
 
 const usersStore = useUsersStore();
-const isAdminOrOwner = computed(() => usersStore.isAdmin || usersStore.isInstanceOwner);
+const isAdminOrOwner = computed(() => usersStore.isAdminOrOwner);
 
 const formatNumber = (number: number) => {
 	if (!number) return null;

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeInstallHint.vue
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeInstallHint.vue
@@ -7,13 +7,13 @@ export interface Props {
 	hint: string;
 }
 
-const isOwner = computed(() => useUsersStore().isInstanceOwner);
+const isAdminOrOwner = computed(() => useUsersStore().isAdminOrOwner);
 
 defineProps<Props>();
 </script>
 
 <template>
-	<div v-if="isOwner" :class="$style.container">
+	<div v-if="isAdminOrOwner" :class="$style.container">
 		<N8nIcon color="text-light" icon="info" size="large" />
 		<N8nText color="text-base" size="medium"> {{ hint }} </N8nText>
 	</div>

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/composables/useInstallNode.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/composables/useInstallNode.test.ts
@@ -90,9 +90,12 @@ beforeEach(() => {
 		value: true,
 		writable: true,
 	});
-
 	Object.defineProperty(usersStore, 'isInstanceOwner', {
 		value: false,
+		writable: true,
+	});
+	Object.defineProperty(usersStore, 'isAdminOrOwner', {
+		value: true,
 		writable: true,
 	});
 
@@ -146,6 +149,10 @@ describe('useInstallNode', () => {
 				value: false,
 				writable: true,
 			});
+			Object.defineProperty(usersStore, 'isAdminOrOwner', {
+				value: false,
+				writable: true,
+			});
 			const { installNode } = useInstallNode();
 
 			const result = await installNode({
@@ -156,7 +163,7 @@ describe('useInstallNode', () => {
 
 			expect(result.success).toBe(false);
 			expect(result.error).toBeInstanceOf(Error);
-			expect(result.error?.message).toBe('User is not an owner');
+			expect(result.error?.message).toBe('User is not an owner or admin');
 			expect(showError).toHaveBeenCalledWith(
 				expect.any(Error),
 				'settings.communityNodes.messages.install.error',
@@ -173,6 +180,10 @@ describe('useInstallNode', () => {
 			});
 			Object.defineProperty(usersStore, 'isInstanceOwner', {
 				value: isInstanceOwner,
+				writable: true,
+			});
+			Object.defineProperty(usersStore, 'isAdminOrOwner', {
+				value: isAdmin || isInstanceOwner,
 				writable: true,
 			});
 			const { installNode } = useInstallNode();

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/composables/useInstallNode.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/composables/useInstallNode.test.ts
@@ -91,6 +91,11 @@ beforeEach(() => {
 		writable: true,
 	});
 
+	Object.defineProperty(usersStore, 'isInstanceOwner', {
+		value: false,
+		writable: true,
+	});
+
 	vi.mocked(communityNodesStore.installPackage).mockResolvedValue(undefined);
 	vi.mocked(nodeTypesStore.getNodeTypes).mockResolvedValue(undefined);
 	vi.mocked(nodeTypesStore.fetchCommunityNodePreviews).mockResolvedValue(undefined);
@@ -137,6 +142,10 @@ describe('useInstallNode', () => {
 				value: false,
 				writable: true,
 			});
+			Object.defineProperty(usersStore, 'isInstanceOwner', {
+				value: false,
+				writable: true,
+			});
 			const { installNode } = useInstallNode();
 
 			const result = await installNode({
@@ -151,6 +160,31 @@ describe('useInstallNode', () => {
 			expect(showError).toHaveBeenCalledWith(
 				expect.any(Error),
 				'settings.communityNodes.messages.install.error',
+			);
+		});
+
+		it('should install node when user is instance owner (not admin)', async () => {
+			Object.defineProperty(usersStore, 'isAdmin', {
+				value: false,
+				writable: true,
+			});
+			Object.defineProperty(usersStore, 'isInstanceOwner', {
+				value: true,
+				writable: true,
+			});
+			const { installNode } = useInstallNode();
+
+			const result = await installNode({
+				type: 'verified',
+				packageName: 'test-package',
+				nodeType: 'test-node',
+			});
+
+			expect(result.success).toBe(true);
+			expect(communityNodesStore.installPackage).toHaveBeenCalledWith(
+				'test-package',
+				true,
+				'1.0.0',
 			);
 		});
 

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/composables/useInstallNode.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/composables/useInstallNode.test.ts
@@ -86,7 +86,7 @@ beforeEach(() => {
 
 	vi.mocked(useToast).mockReturnValue(toast);
 
-	Object.defineProperty(usersStore, 'isInstanceOwner', {
+	Object.defineProperty(usersStore, 'isAdmin', {
 		value: true,
 		writable: true,
 	});
@@ -133,7 +133,7 @@ beforeEach(() => {
 describe('useInstallNode', () => {
 	describe('installNode', () => {
 		it('should return error when user is not an owner', async () => {
-			Object.defineProperty(usersStore, 'isInstanceOwner', {
+			Object.defineProperty(usersStore, 'isAdmin', {
 				value: false,
 				writable: true,
 			});

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/composables/useInstallNode.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/composables/useInstallNode.test.ts
@@ -137,7 +137,7 @@ beforeEach(() => {
 
 describe('useInstallNode', () => {
 	describe('installNode', () => {
-		it('should return error when user is not an owner', async () => {
+		it('should return error when user is not an owner or admin', async () => {
 			Object.defineProperty(usersStore, 'isAdmin', {
 				value: false,
 				writable: true,
@@ -163,13 +163,16 @@ describe('useInstallNode', () => {
 			);
 		});
 
-		it('should install node when user is instance owner (not admin)', async () => {
+		it.each([
+			{ isAdmin: true, isInstanceOwner: false, label: 'admin' },
+			{ isAdmin: false, isInstanceOwner: true, label: 'instance owner' },
+		])('should allow installing when user is $label', async ({ isAdmin, isInstanceOwner }) => {
 			Object.defineProperty(usersStore, 'isAdmin', {
-				value: false,
+				value: isAdmin,
 				writable: true,
 			});
 			Object.defineProperty(usersStore, 'isInstanceOwner', {
-				value: true,
+				value: isInstanceOwner,
 				writable: true,
 			});
 			const { installNode } = useInstallNode();

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/composables/useInstallNode.ts
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/composables/useInstallNode.ts
@@ -2,7 +2,7 @@ import { useCommunityNodesStore } from '../communityNodes.store';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
-import { computed, nextTick, ref } from 'vue';
+import { nextTick, ref } from 'vue';
 import { i18n } from '@n8n/i18n';
 import { useToast } from '@/app/composables/useToast';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/composables/useInstallNode.ts
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/composables/useInstallNode.ts
@@ -39,7 +39,7 @@ export function useInstallNode() {
 	const nodeTypesStore = useNodeTypesStore();
 	const credentialsStore = useCredentialsStore();
 	const workflowsStore = useWorkflowsStore();
-	const isOwner = computed(() => useUsersStore().isInstanceOwner);
+	const isAdmin = computed(() => useUsersStore().isAdmin);
 	const loading = ref(false);
 	const toast = useToast();
 	const canvasOperations = useCanvasOperations();
@@ -56,7 +56,7 @@ export function useInstallNode() {
 	};
 
 	const installNode = async (props: InstallNodeProps): Promise<InstallNodeResult> => {
-		if (!isOwner.value) {
+		if (!isAdmin.value) {
 			const error = new Error('User is not an owner');
 			toast.showError(error, i18n.baseText('settings.communityNodes.messages.install.error'));
 			return { success: false, error };

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/composables/useInstallNode.ts
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/composables/useInstallNode.ts
@@ -58,7 +58,7 @@ export function useInstallNode() {
 
 	const installNode = async (props: InstallNodeProps): Promise<InstallNodeResult> => {
 		if (!canInstallNodes.value) {
-			const error = new Error('User is not an owner');
+			const error = new Error('User is not an owner or an admin');
 			toast.showError(error, i18n.baseText('settings.communityNodes.messages.install.error'));
 			return { success: false, error };
 		}

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/composables/useInstallNode.ts
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/composables/useInstallNode.ts
@@ -39,7 +39,8 @@ export function useInstallNode() {
 	const nodeTypesStore = useNodeTypesStore();
 	const credentialsStore = useCredentialsStore();
 	const workflowsStore = useWorkflowsStore();
-	const isAdmin = computed(() => useUsersStore().isAdmin);
+	const userStore = useUsersStore();
+	const canInstallNodes = computed(() => userStore.isAdmin || userStore.isInstanceOwner);
 	const loading = ref(false);
 	const toast = useToast();
 	const canvasOperations = useCanvasOperations();
@@ -56,7 +57,7 @@ export function useInstallNode() {
 	};
 
 	const installNode = async (props: InstallNodeProps): Promise<InstallNodeResult> => {
-		if (!isAdmin.value) {
+		if (!canInstallNodes.value) {
 			const error = new Error('User is not an owner');
 			toast.showError(error, i18n.baseText('settings.communityNodes.messages.install.error'));
 			return { success: false, error };

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/composables/useInstallNode.ts
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/composables/useInstallNode.ts
@@ -40,7 +40,6 @@ export function useInstallNode() {
 	const credentialsStore = useCredentialsStore();
 	const workflowsStore = useWorkflowsStore();
 	const userStore = useUsersStore();
-	const canInstallNodes = computed(() => userStore.isAdmin || userStore.isInstanceOwner);
 	const loading = ref(false);
 	const toast = useToast();
 	const canvasOperations = useCanvasOperations();
@@ -57,8 +56,8 @@ export function useInstallNode() {
 	};
 
 	const installNode = async (props: InstallNodeProps): Promise<InstallNodeResult> => {
-		if (!canInstallNodes.value) {
-			const error = new Error('User is not an owner');
+		if (!userStore.isAdminOrOwner) {
+			const error = new Error('User is not an owner or admin');
 			toast.showError(error, i18n.baseText('settings.communityNodes.messages.install.error'));
 			return { success: false, error };
 		}

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/composables/useInstalledCommunityPackage.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/composables/useInstalledCommunityPackage.test.ts
@@ -74,7 +74,7 @@ describe('useInstalledCommunityPackage', () => {
 
 		it('should compute isUpdateCheckAvailable correctly when user is instance owner and node is community', () => {
 			const usersStore = mockedStore(useUsersStore);
-			usersStore.isInstanceOwner = true;
+			usersStore.isAdminOrOwner = true;
 			mockIsCommunityPackageName.mockReturnValue(true);
 
 			const { isUpdateCheckAvailable } = useInstalledCommunityPackage(
@@ -86,7 +86,7 @@ describe('useInstalledCommunityPackage', () => {
 
 		it('should compute isUpdateCheckAvailable as false when user is not instance owner', () => {
 			const usersStore = mockedStore(useUsersStore);
-			usersStore.isInstanceOwner = false;
+			usersStore.isAdminOrOwner = false;
 			mockIsCommunityPackageName.mockReturnValue(true);
 
 			const { isUpdateCheckAvailable } = useInstalledCommunityPackage(
@@ -98,7 +98,7 @@ describe('useInstalledCommunityPackage', () => {
 
 		it('should compute isUpdateCheckAvailable as false when node is not community', () => {
 			const usersStore = mockedStore(useUsersStore);
-			usersStore.isInstanceOwner = true;
+			usersStore.isAdminOrOwner = true;
 			mockIsCommunityPackageName.mockReturnValue(false);
 
 			const { isUpdateCheckAvailable } = useInstalledCommunityPackage('n8n-nodes-base.HttpRequest');

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/composables/useInstalledCommunityPackage.ts
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/composables/useInstalledCommunityPackage.ts
@@ -51,7 +51,7 @@ export function useInstalledCommunityPackage(nodeTypeName?: MaybeRefOrGetter<str
 	const isUpdateCheckAvailable = computed(() => {
 		return (
 			isCommunityNode.value &&
-			usersStore.isInstanceOwner &&
+			usersStore.isAdminOrOwner &&
 			!installedPackage.value?.unverifiedUpdate
 		);
 	});

--- a/packages/frontend/editor-ui/src/features/settings/users/users.store.ts
+++ b/packages/frontend/editor-ui/src/features/settings/users/users.store.ts
@@ -73,6 +73,8 @@ export const useUsersStore = defineStore(STORES.USERS, () => {
 
 	const isAdmin = computed(() => _isAdmin(currentUser.value));
 
+	const isAdminOrOwner = computed(() => isInstanceOwner.value || isAdmin.value);
+
 	const mfaEnabled = computed(() => currentUser.value?.mfaEnabled ?? false);
 
 	const globalRoleName = computed(() => currentUser.value?.role ?? 'default');
@@ -459,6 +461,7 @@ export const useUsersStore = defineStore(STORES.USERS, () => {
 		isDefaultUser,
 		isInstanceOwner,
 		isAdmin,
+		isAdminOrOwner,
 		mfaEnabled,
 		globalRoleName,
 		personalizedNodeTypes,

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Modes/ActionsMode.vue
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Modes/ActionsMode.vue
@@ -44,7 +44,7 @@ const emit = defineEmits<{
 const telemetry = useTelemetry();
 const i18n = useI18n();
 
-const { userActivated, isInstanceOwner } = useUsersStore();
+const usersStore = useUsersStore();
 const { popViewStack, updateCurrentViewStack } = useViewStacks();
 const { registerKeyHook } = useKeyboardNavigation();
 const {
@@ -327,7 +327,7 @@ const callouts = computed<INodeCreateElement[]>(() => []);
 					@selected="onSelected"
 				>
 					<N8nCallout
-						v-if="!userActivated && isTriggerRootView"
+						v-if="!usersStore.userActivated && isTriggerRootView"
 						theme="info"
 						iconless
 						slim
@@ -371,7 +371,7 @@ const callouts = computed<INodeCreateElement[]>(() => []);
 			v-if="communityNodeDetails"
 			:class="$style.communityNodeFooter"
 			:package-name="communityNodeDetails.packageName"
-			:show-manage="communityNodeDetails.installed && isInstanceOwner"
+			:show-manage="communityNodeDetails.installed && usersStore.isAdminOrOwner"
 		/>
 	</div>
 </template>


### PR DESCRIPTION
## Summary

Fixes a bug that prevented instance admin from installing community packages. The admin role already had the permissions (scope) to install packages but it was not reflected in the UI

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4258/community-issue-cant-install-community-node-as-admin
Fixes #24797

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
