### PR TITLE
chore(core): Introduce redaction marker for items

### DIFF
--- a/packages/cli/test/integration/execution-redaction.test.ts
+++ b/packages/cli/test/integration/execution-redaction.test.ts
@@ -112,13 +112,13 @@ function parseResponseData(responseBody: { data: { data: string } }): IRunExecut
 	return parse(responseBody.data.data) as IRunExecutionData;
 }
 
-function assertRedacted(data: IRunExecutionData) {
+function assertRedacted(data: IRunExecutionData, expectedReason = 'workflow_redaction_policy') {
 	const items = data.resultData.runData['Test Node'][0].data!.main[0]!;
 	expect(items.length).toBeGreaterThan(0);
 	for (const item of items) {
 		expect(item.json).toEqual({});
 		expect(item.binary).toBeUndefined();
-		expect(item.redaction).toEqual({ redacted: true });
+		expect(item.redaction).toEqual({ redacted: true, reason: expectedReason });
 	}
 }
 
@@ -296,7 +296,7 @@ describe('GET /executions/:id — Execution Redaction', () => {
 				.query({ redactExecutionData: 'true' })
 				.expect(200);
 
-			assertRedacted(parseResponseData(response.body));
+			assertRedacted(parseResponseData(response.body), 'user_requested');
 		});
 	});
 

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1368,10 +1368,16 @@ export type ChatNodeMessageWithButtons = {
 
 export type ChatNodeMessage = ChatNodeMessageWithButtons | string;
 
+export interface INodeExecutionRedactionInfo {
+	redacted: true;
+	reason: string;
+}
+
 export interface INodeExecutionData {
 	[key: string]:
 		| IDataObject
 		| IBinaryKeyData
+		| INodeExecutionRedactionInfo
 		| IPairedItemData
 		| IPairedItemData[]
 		| NodeApiError
@@ -1387,6 +1393,12 @@ export interface INodeExecutionData {
 		subExecution: RelatedExecution;
 	};
 	evaluationData?: Record<string, GenericValue>;
+	/**
+	 * Redaction marker. Present when this item's data has been redacted.
+	 * Check `redaction.redacted` to determine if data was stripped,
+	 * and `redaction.reason` for why (e.g. "workflow_redaction_policy").
+	 */
+	redaction?: INodeExecutionRedactionInfo;
 	/**
 	 * Use this key to send a message to the chat.
 	 *


### PR DESCRIPTION
## Summary

This introduces a redaction marker for items in an execution. These can be used later by the FE.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/IAM-179/implement-execution-data-transformation

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
