### PR TITLE
fix(Ollama Node): Respect timeout configuration for API requests

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LMOllama/LmOllama.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMOllama/LmOllama.node.ts
@@ -12,6 +12,7 @@ import {
 	makeN8nLlmFailedAttemptHandler,
 	N8nLlmTracing,
 	getConnectionHintNoticeField,
+	proxyFetch,
 } from '@n8n/ai-utilities';
 
 export class LmOllama implements INodeType {
@@ -64,6 +65,9 @@ export class LmOllama implements INodeType {
 				}
 			: undefined;
 
+		const fetchWithTimeout = async (input: RequestInfo | URL, init?: RequestInit) =>
+			await proxyFetch(input, init, {});
+
 		const model = new Ollama({
 			baseUrl: credentials.baseUrl as string,
 			model: modelName,
@@ -71,6 +75,7 @@ export class LmOllama implements INodeType {
 			callbacks: [new N8nLlmTracing(this)],
 			onFailedAttempt: makeN8nLlmFailedAttemptHandler(this),
 			headers,
+			fetch: fetchWithTimeout,
 		});
 
 		return {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Ollama/Ollama.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Ollama/Ollama.node.test.ts
@@ -115,6 +115,39 @@ describe('Ollama Node', () => {
 			]);
 		});
 
+		it('should pass timeout option to API request', async () => {
+			executeFunctionsMock.getNodeParameter.mockImplementation((parameter: string) => {
+				switch (parameter) {
+					case 'modelId':
+						return 'llama3.2:latest';
+					case 'messages.values':
+						return [{ role: 'user', content: 'Hello' }];
+					case 'simplify':
+						return true;
+					case 'options':
+						return { timeout: 600000 };
+					default:
+						return undefined;
+				}
+			});
+			executeFunctionsMock.getNodeInputs.mockReturnValue([{ type: 'main' }]);
+			getConnectedToolsMock.mockResolvedValue([]);
+			apiRequestMock.mockResolvedValue({
+				model: 'llama3.2:latest',
+				created_at: '2023-10-01T10:00:00Z',
+				message: { role: 'assistant', content: 'Hello!' },
+				done: true,
+			} as OllamaChatResponse);
+
+			await text.message.execute.call(executeFunctionsMock, 0);
+
+			const callArgs = apiRequestMock.mock.calls[0];
+			expect(callArgs[2]).toMatchObject({
+				body: expect.any(Object),
+				option: { timeout: 600000 },
+			});
+		});
+
 		it('should handle tool calls correctly', async () => {
 			const mockTool = {
 				name: 'calculator',
@@ -674,6 +707,46 @@ describe('Ollama Node', () => {
 						temperature: 0.1,
 					},
 				},
+			});
+		});
+
+		it('should pass timeout option for image analysis API request', async () => {
+			executeFunctionsMock.getNodeParameter.mockImplementation((parameter: string) => {
+				switch (parameter) {
+					case 'modelId':
+						return 'llava:latest';
+					case 'inputType':
+						return 'binary';
+					case 'binaryPropertyName':
+						return 'data';
+					case 'text':
+						return 'Describe this image';
+					case 'simplify':
+						return true;
+					case 'options':
+						return { timeout: 600000 };
+					default:
+						return undefined;
+				}
+			});
+
+			executeFunctionsMock.helpers.getBinaryDataBuffer.mockResolvedValue(Buffer.from('test image'));
+			apiRequestMock.mockResolvedValue({
+				model: 'llava:latest',
+				created_at: '2023-10-01T10:00:00Z',
+				message: {
+					role: 'assistant',
+					content: 'A sample image.',
+				},
+				done: true,
+			} as OllamaChatResponse);
+
+			await image.analyze.execute.call(executeFunctionsMock, 0);
+
+			const callArgs = apiRequestMock.mock.calls[0];
+			expect(callArgs[2]).toMatchObject({
+				body: expect.any(Object),
+				option: { timeout: 600000 },
 			});
 		});
 	});

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Ollama/Ollama.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Ollama/Ollama.node.test.ts
@@ -118,6 +118,39 @@ describe('Ollama Node', () => {
 			]);
 		});
 
+		it('should pass timeout option to API request', async () => {
+			executeFunctionsMock.getNodeParameter.mockImplementation((parameter: string) => {
+				switch (parameter) {
+					case 'modelId':
+						return 'llama3.2:latest';
+					case 'messages.values':
+						return [{ role: 'user', content: 'Hello' }];
+					case 'simplify':
+						return true;
+					case 'options':
+						return { timeout: 600000 };
+					default:
+						return undefined;
+				}
+			});
+			executeFunctionsMock.getNodeInputs.mockReturnValue([{ type: 'main' }]);
+			getConnectedToolsMock.mockResolvedValue([]);
+			apiRequestMock.mockResolvedValue({
+				model: 'llama3.2:latest',
+				created_at: '2023-10-01T10:00:00Z',
+				message: { role: 'assistant', content: 'Hello!' },
+				done: true,
+			} as OllamaChatResponse);
+
+			await text.message.execute.call(executeFunctionsMock, 0);
+
+			const callArgs = apiRequestMock.mock.calls[0];
+			expect(callArgs[2]).toMatchObject({
+				body: expect.any(Object),
+				option: { timeout: 600000 },
+			});
+		});
+
 		it('should handle tool calls correctly', async () => {
 			const mockTool = {
 				name: 'calculator',
@@ -675,6 +708,46 @@ describe('Ollama Node', () => {
 						temperature: 0.1,
 					},
 				},
+			});
+		});
+
+		it('should pass timeout option for image analysis API request', async () => {
+			executeFunctionsMock.getNodeParameter.mockImplementation((parameter: string) => {
+				switch (parameter) {
+					case 'modelId':
+						return 'llava:latest';
+					case 'inputType':
+						return 'binary';
+					case 'binaryPropertyName':
+						return 'data';
+					case 'text':
+						return 'Describe this image';
+					case 'simplify':
+						return true;
+					case 'options':
+						return { timeout: 600000 };
+					default:
+						return undefined;
+				}
+			});
+
+			executeFunctionsMock.helpers.getBinaryDataBuffer.mockResolvedValue(Buffer.from('test image'));
+			apiRequestMock.mockResolvedValue({
+				model: 'llava:latest',
+				created_at: '2023-10-01T10:00:00Z',
+				message: {
+					role: 'assistant',
+					content: 'A sample image.',
+				},
+				done: true,
+			} as OllamaChatResponse);
+
+			await image.analyze.execute.call(executeFunctionsMock, 0);
+
+			const callArgs = apiRequestMock.mock.calls[0];
+			expect(callArgs[2]).toMatchObject({
+				body: expect.any(Object),
+				option: { timeout: 600000 },
 			});
 		});
 	});

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Ollama/actions/image/analyze.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Ollama/actions/image/analyze.operation.ts
@@ -87,6 +87,13 @@ const properties: INodeProperties[] = [
 				},
 			},
 			{
+				displayName: 'Timeout',
+				name: 'timeout',
+				default: 60000,
+				description: 'Maximum amount of time a request is allowed to take in milliseconds',
+				type: 'number',
+			},
+			{
 				displayName: 'Temperature',
 				name: 'temperature',
 				type: 'number',
@@ -335,6 +342,7 @@ const properties: INodeProperties[] = [
 
 interface MessageOptions {
 	system?: string;
+	timeout?: number;
 	temperature?: number;
 	top_p?: number;
 	top_k?: number;
@@ -375,6 +383,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 	const text = this.getNodeParameter('text', i, '') as string;
 	const simplify = this.getNodeParameter('simplify', i, true) as boolean;
 	const options = this.getNodeParameter('options', i, {}) as MessageOptions;
+	const timeout = options.timeout;
 
 	let images: string[];
 
@@ -420,6 +429,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 	];
 
 	const processedOptions = { ...options };
+	delete processedOptions.timeout;
 	if (processedOptions.stop && typeof processedOptions.stop === 'string') {
 		processedOptions.stop = processedOptions.stop
 			.split(',')
@@ -436,6 +446,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 
 	const response: OllamaChatResponse = await apiRequest.call(this, 'POST', '/api/chat', {
 		body,
+		option: timeout === undefined ? undefined : { timeout },
 	});
 
 	if (simplify) {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Ollama/actions/image/analyze.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Ollama/actions/image/analyze.operation.ts
@@ -87,6 +87,13 @@ const properties: INodeProperties[] = [
 				},
 			},
 			{
+				displayName: 'Timeout',
+				name: 'timeout',
+				default: 60000,
+				description: 'Maximum amount of time a request is allowed to take in milliseconds',
+				type: 'number',
+			},
+			{
 				displayName: 'Temperature',
 				name: 'temperature',
 				type: 'number',
@@ -343,6 +350,7 @@ const properties: INodeProperties[] = [
 
 interface MessageOptions {
 	system?: string;
+	timeout?: number;
 	temperature?: number;
 	think?: boolean;
 	top_p?: number;
@@ -384,6 +392,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 	const text = this.getNodeParameter('text', i, '') as string;
 	const simplify = this.getNodeParameter('simplify', i, true) as boolean;
 	const { think, ...options } = this.getNodeParameter('options', i, {}) as MessageOptions;
+	const timeout = options.timeout;
 
 	let images: string[];
 
@@ -429,6 +438,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 	];
 
 	const processedOptions = { ...options };
+	delete processedOptions.timeout;
 	if (processedOptions.stop && typeof processedOptions.stop === 'string') {
 		processedOptions.stop = processedOptions.stop
 			.split(',')
@@ -446,6 +456,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 
 	const response: OllamaChatResponse = await apiRequest.call(this, 'POST', '/api/chat', {
 		body,
+		option: timeout === undefined ? undefined : { timeout },
 	});
 
 	if (simplify) {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Ollama/actions/text/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Ollama/actions/text/message.operation.ts
@@ -86,6 +86,13 @@ const properties: INodeProperties[] = [
 				},
 			},
 			{
+				displayName: 'Timeout',
+				name: 'timeout',
+				default: 60000,
+				description: 'Maximum amount of time a request is allowed to take in milliseconds',
+				type: 'number',
+			},
+			{
 				displayName: 'Temperature',
 				name: 'temperature',
 				type: 'number',
@@ -334,6 +341,7 @@ const properties: INodeProperties[] = [
 
 interface MessageOptions {
 	system?: string;
+	timeout?: number;
 	temperature?: number;
 	top_p?: number;
 	top_k?: number;
@@ -373,6 +381,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 	const messages = this.getNodeParameter('messages.values', i, []) as OllamaMessage[];
 	const simplify = this.getNodeParameter('simplify', i, true) as boolean;
 	const options = this.getNodeParameter('options', i, {}) as MessageOptions;
+	const timeout = options.timeout;
 	const { tools, connectedTools } = await getTools.call(this);
 
 	if (options.system) {
@@ -385,6 +394,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 	delete options.system;
 
 	const processedOptions = { ...options };
+	delete processedOptions.timeout;
 	if (processedOptions.stop && typeof processedOptions.stop === 'string') {
 		processedOptions.stop = processedOptions.stop
 			.split(',')
@@ -402,6 +412,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 
 	let response: OllamaChatResponse = await apiRequest.call(this, 'POST', '/api/chat', {
 		body,
+		option: timeout === undefined ? undefined : { timeout },
 	});
 
 	if (tools.length > 0 && response.message.tool_calls && response.message.tool_calls.length > 0) {
@@ -448,6 +459,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 
 		response = await apiRequest.call(this, 'POST', '/api/chat', {
 			body: updatedBody,
+			option: timeout === undefined ? undefined : { timeout },
 		});
 	}
 

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Ollama/actions/text/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Ollama/actions/text/message.operation.ts
@@ -86,6 +86,13 @@ const properties: INodeProperties[] = [
 				},
 			},
 			{
+				displayName: 'Timeout',
+				name: 'timeout',
+				default: 60000,
+				description: 'Maximum amount of time a request is allowed to take in milliseconds',
+				type: 'number',
+			},
+			{
 				displayName: 'Temperature',
 				name: 'temperature',
 				type: 'number',
@@ -342,6 +349,7 @@ const properties: INodeProperties[] = [
 
 interface MessageOptions {
 	system?: string;
+	timeout?: number;
 	temperature?: number;
 	think?: boolean;
 	top_p?: number;
@@ -382,6 +390,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 	const messages = this.getNodeParameter('messages.values', i, []) as OllamaMessage[];
 	const simplify = this.getNodeParameter('simplify', i, true) as boolean;
 	const { think, system, ...options } = this.getNodeParameter('options', i, {}) as MessageOptions;
+	const timeout = options.timeout;
 	const { tools, connectedTools } = await getTools.call(this);
 
 	if (system) {
@@ -392,6 +401,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 	}
 
 	const processedOptions = { ...options };
+	delete processedOptions.timeout;
 	if (processedOptions.stop && typeof processedOptions.stop === 'string') {
 		processedOptions.stop = processedOptions.stop
 			.split(',')
@@ -410,6 +420,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 
 	let response: OllamaChatResponse = await apiRequest.call(this, 'POST', '/api/chat', {
 		body,
+		option: timeout === undefined ? undefined : { timeout },
 	});
 
 	if (response.prompt_eval_count != null || response.eval_count != null) {
@@ -460,6 +471,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 
 		response = await apiRequest.call(this, 'POST', '/api/chat', {
 			body: updatedBody,
+			option: timeout === undefined ? undefined : { timeout },
 		});
 
 		if (response.prompt_eval_count != null || response.eval_count != null) {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Ollama/transport/index.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Ollama/transport/index.ts
@@ -9,7 +9,7 @@ type RequestParameters = {
 	headers?: IDataObject;
 	body?: IDataObject | string;
 	qs?: IDataObject;
-	option?: IDataObject;
+	option?: IDataObject & { timeout?: number };
 };
 
 export async function apiRequest(


### PR DESCRIPTION
Fixes #25360

The Ollama node ignores timeout configuration and always falls back to the axios default timeout of 300 seconds (5 minutes). This causes requests to fail with `timeout of 300000ms exceeded` when model loading or inference takes longer than 5 minutes.

**Root cause:** The Ollama transport function does not pass a `timeout` option to `httpRequestWithAuthentication`, which defaults to `axios.defaults.timeout` (300000ms). The same issue affects the Ollama Model (non-chat) LangChain node, which lacks the `proxyFetch` wrapper added to the Chat Model node in #24292.

**Changes:**
- Add configurable `Timeout` option to the direct Ollama node (text message and image analyze operations)
- Pass timeout through to `httpRequestWithAuthentication` via the transport layer option parameter
- Add `proxyFetch` with timeout support to `LmOllama` (matching the existing `LmChatOllama` pattern from #24292)
- Add unit tests for timeout propagation in both text and image operations