### PR TITLE
fix(AWS DynamoDB Node): Use explicit type check for number detection in PutItem

### DIFF
--- a/packages/nodes-base/nodes/Aws/DynamoDB/__test__/utils.test.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/__test__/utils.test.ts
@@ -1,0 +1,35 @@
+import { adjustPutItem } from '../utils';
+
+describe('adjustPutItem', () => {
+	it('keeps regular strings as S', () => {
+		expect(adjustPutItem({ name: 'hello' })).toEqual({
+			name: { S: 'hello' },
+		});
+	});
+
+	it('keeps numeric strings as S', () => {
+		expect(adjustPutItem({ id: '34', executionId: '1234567890' })).toEqual({
+			id: { S: '34' },
+			executionId: { S: '1234567890' },
+		});
+	});
+
+	it('maps numbers to N', () => {
+		expect(adjustPutItem({ count: 42, price: 9.99 })).toEqual({
+			count: { N: '42' },
+			price: { N: '9.99' },
+		});
+	});
+
+	it('maps booleans to BOOL', () => {
+		expect(adjustPutItem({ active: true })).toEqual({
+			active: { BOOL: 'true' },
+		});
+	});
+
+	it('maps objects to M', () => {
+		expect(adjustPutItem({ meta: { key: 'val' } })).toEqual({
+			meta: { M: '[object Object]' },
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Aws/DynamoDB/utils.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/utils.ts
@@ -47,10 +47,10 @@ export function adjustPutItem(putItemUi: PutItemUi) {
 			type = 'BOOL';
 		} else if (typeof value === 'object' && !Array.isArray(value) && value !== null) {
 			type = 'M';
-		} else if (isNaN(Number(value))) {
-			type = 'S';
-		} else {
+		} else if (typeof value === 'number') {
 			type = 'N';
+		} else {
+			type = 'S';
 		}
 
 		adjustedPutItem[attribute] = { [type]: value.toString() };


### PR DESCRIPTION
## Summary

Fixes #25268

The `adjustPutItem` function in the DynamoDB node uses `isNaN(Number(value))` to distinguish between string and number types. This causes string values that happen to be parseable as numbers (e.g. execution IDs like `"34"` or `"1234567890"`) to be incorrectly classified as DynamoDB `N` (Number) type instead of `S` (String) type.

## Changes

**`packages/nodes-base/nodes/Aws/DynamoDB/utils.ts`**
- Replaced the `isNaN(Number(value))` heuristic with an explicit `typeof value === "number"` check
- Only actual JavaScript `number` values are now mapped to DynamoDB `N` type
- All other values (including numeric strings) default to `S` type

**`packages/nodes-base/nodes/Aws/DynamoDB/__test__/utils.test.ts`** (new)
- Added unit tests for `adjustPutItem` covering: regular strings, numeric strings, actual numbers, booleans, and objects

## Related issue(s)

Closes #25268

## Review / Merge checklist

- [x] PR title and description follow [contribution guidelines](https://github.com/n8n-io/n8n/blob/master/.github/CONTRIBUTING.md)
- [x] Tests included
- [x] [PR title matches convention](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md)