### PR TITLE
feat(nodes-langchain): Add Avian Chat Model node

### DIFF
--- a/packages/@n8n/nodes-langchain/credentials/AvianApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/AvianApi.credentials.ts
@@ -1,0 +1,47 @@
+import type {
+	IAuthenticateGeneric,
+	ICredentialTestRequest,
+	ICredentialType,
+	INodeProperties,
+} from 'n8n-workflow';
+
+export class AvianApi implements ICredentialType {
+	name = 'avianApi';
+
+	displayName = 'Avian';
+
+	documentationUrl = 'avian';
+
+	properties: INodeProperties[] = [
+		{
+			displayName: 'API Key',
+			name: 'apiKey',
+			type: 'string',
+			typeOptions: { password: true },
+			required: true,
+			default: '',
+		},
+		{
+			displayName: 'Base URL',
+			name: 'url',
+			type: 'hidden',
+			default: 'https://api.avian.io/v1',
+		},
+	];
+
+	authenticate: IAuthenticateGeneric = {
+		type: 'generic',
+		properties: {
+			headers: {
+				Authorization: '=Bearer {{$credentials.apiKey}}',
+			},
+		},
+	};
+
+	test: ICredentialTestRequest = {
+		request: {
+			baseURL: '={{ $credentials.url }}',
+			url: '/models',
+		},
+	};
+}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAvian/LmChatAvian.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAvian/LmChatAvian.node.ts
@@ -1,0 +1,258 @@
+import { ChatOpenAI, type ClientOptions } from '@langchain/openai';
+import { getProxyAgent, makeN8nLlmFailedAttemptHandler, N8nLlmTracing } from '@n8n/ai-utilities';
+import {
+	NodeConnectionTypes,
+	type INodeType,
+	type INodeTypeDescription,
+	type ISupplyDataFunctions,
+	type SupplyData,
+} from 'n8n-workflow';
+
+import { getConnectionHintNoticeField } from '@utils/sharedFields';
+
+import type { OpenAICompatibleCredential } from '../../../types/types';
+import { openAiFailedAttemptHandler } from '../../vendors/OpenAi/helpers/error-handling';
+
+export class LmChatAvian implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Avian Chat Model',
+
+		name: 'lmChatAvian',
+		icon: 'file:avian.svg',
+		group: ['transform'],
+		version: [1],
+		description: 'For advanced usage with an AI chain',
+		defaults: {
+			name: 'Avian Chat Model',
+		},
+		codex: {
+			categories: ['AI'],
+			subcategories: {
+				AI: ['Language Models', 'Root Nodes'],
+				'Language Models': ['Chat Models (Recommended)'],
+			},
+			resources: {
+				primaryDocumentation: [
+					{
+						url: 'https://docs.n8n.io/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatavian/',
+					},
+				],
+			},
+		},
+
+		inputs: [],
+
+		outputs: [NodeConnectionTypes.AiLanguageModel],
+		outputNames: ['Model'],
+		credentials: [
+			{
+				name: 'avianApi',
+				required: true,
+			},
+		],
+		requestDefaults: {
+			ignoreHttpStatusErrors: true,
+			baseURL: '={{ $credentials?.url }}',
+		},
+		properties: [
+			getConnectionHintNoticeField([NodeConnectionTypes.AiChain, NodeConnectionTypes.AiAgent]),
+			{
+				displayName:
+					'If using JSON response format, you must include word "json" in the prompt in your chain or agent. Also, make sure to select latest models released post November 2023.',
+				name: 'notice',
+				type: 'notice',
+				default: '',
+				displayOptions: {
+					show: {
+						'/options.responseFormat': ['json_object'],
+					},
+				},
+			},
+			{
+				displayName: 'Model',
+				name: 'model',
+				type: 'options',
+				description:
+					'The model which will generate the completion. <a href="https://avian.io/models">Learn more</a>.',
+				typeOptions: {
+					loadOptions: {
+						routing: {
+							request: {
+								method: 'GET',
+								url: '/models',
+							},
+							output: {
+								postReceive: [
+									{
+										type: 'rootProperty',
+										properties: {
+											property: 'data',
+										},
+									},
+									{
+										type: 'setKeyValue',
+										properties: {
+											name: '={{$responseItem.id}}',
+											value: '={{$responseItem.id}}',
+										},
+									},
+									{
+										type: 'sort',
+										properties: {
+											key: 'name',
+										},
+									},
+								],
+							},
+						},
+					},
+				},
+				routing: {
+					send: {
+						type: 'body',
+						property: 'model',
+					},
+				},
+				default: 'deepseek/deepseek-v3.2',
+			},
+			{
+				displayName: 'Options',
+				name: 'options',
+				placeholder: 'Add Option',
+				description: 'Additional options to add',
+				type: 'collection',
+				default: {},
+				options: [
+					{
+						displayName: 'Frequency Penalty',
+						name: 'frequencyPenalty',
+						default: 0,
+						typeOptions: { maxValue: 2, minValue: -2, numberPrecision: 1 },
+						description:
+							"Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim",
+						type: 'number',
+					},
+					{
+						displayName: 'Maximum Number of Tokens',
+						name: 'maxTokens',
+						default: -1,
+						description:
+							'The maximum number of tokens to generate in the completion. Most models have a context length of 2048 tokens (except for the newest models, which support 32,768).',
+						type: 'number',
+						typeOptions: {
+							maxValue: 32768,
+						},
+					},
+					{
+						displayName: 'Response Format',
+						name: 'responseFormat',
+						default: 'text',
+						type: 'options',
+						options: [
+							{
+								name: 'Text',
+								value: 'text',
+								description: 'Regular text response',
+							},
+							{
+								name: 'JSON',
+								value: 'json_object',
+								description:
+									'Enables JSON mode, which should guarantee the message the model generates is valid JSON',
+							},
+						],
+					},
+					{
+						displayName: 'Presence Penalty',
+						name: 'presencePenalty',
+						default: 0,
+						typeOptions: { maxValue: 2, minValue: -2, numberPrecision: 1 },
+						description:
+							"Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics",
+						type: 'number',
+					},
+					{
+						displayName: 'Sampling Temperature',
+						name: 'temperature',
+						default: 0.7,
+						typeOptions: { maxValue: 2, minValue: 0, numberPrecision: 1 },
+						description:
+							'Controls randomness: Lowering results in less random completions. As the temperature approaches zero, the model will become deterministic and repetitive.',
+						type: 'number',
+					},
+					{
+						displayName: 'Timeout',
+						name: 'timeout',
+						default: 360000,
+						description: 'Maximum amount of time a request is allowed to take in milliseconds',
+						type: 'number',
+					},
+					{
+						displayName: 'Max Retries',
+						name: 'maxRetries',
+						default: 2,
+						description: 'Maximum number of retries to attempt',
+						type: 'number',
+					},
+					{
+						displayName: 'Top P',
+						name: 'topP',
+						default: 1,
+						typeOptions: { maxValue: 1, minValue: 0, numberPrecision: 1 },
+						description:
+							'Controls diversity via nucleus sampling: 0.5 means half of all likelihood-weighted options are considered. We generally recommend altering this or temperature but not both.',
+						type: 'number',
+					},
+				],
+			},
+		],
+	};
+
+	async supplyData(this: ISupplyDataFunctions, itemIndex: number): Promise<SupplyData> {
+		const credentials = await this.getCredentials<OpenAICompatibleCredential>('avianApi');
+
+		const modelName = this.getNodeParameter('model', itemIndex) as string;
+
+		const options = this.getNodeParameter('options', itemIndex, {}) as {
+			frequencyPenalty?: number;
+			maxTokens?: number;
+			maxRetries: number;
+			timeout: number;
+			presencePenalty?: number;
+			temperature?: number;
+			topP?: number;
+			responseFormat?: 'text' | 'json_object';
+		};
+
+		const timeout = options.timeout;
+		const configuration: ClientOptions = {
+			baseURL: credentials.url,
+			fetchOptions: {
+				dispatcher: getProxyAgent(credentials.url, {
+					headersTimeout: timeout,
+					bodyTimeout: timeout,
+				}),
+			},
+		};
+
+		const model = new ChatOpenAI({
+			apiKey: credentials.apiKey,
+			model: modelName,
+			...options,
+			timeout,
+			maxRetries: options.maxRetries ?? 2,
+			configuration,
+			callbacks: [new N8nLlmTracing(this)],
+			modelKwargs: options.responseFormat
+				? {
+						response_format: { type: options.responseFormat },
+					}
+				: undefined,
+			onFailedAttempt: makeN8nLlmFailedAttemptHandler(this, openAiFailedAttemptHandler),
+		});
+
+		return {
+			response: model,
+		};
+	}
+}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAvian/avian.svg
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAvian/avian.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#6366f1"/>
+      <stop offset="100%" style="stop-color:#4f46e5"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#bg)"/>
+  <path d="M44 20c-2 0-4.5 1-6 3-1.5-1-3.5-1.5-5.5-1-4 1-6.5 4.5-6.5 8.5 0 .5 0 1 .1 1.5C22 32.5 18.5 34 16 37c-1.5 1.8-2 4-1.5 6 .5 2.5 2.5 4 5 4h22c4.5 0 8.5-3 10-7 1-3 .5-6.5-1-9.5-1.5-2.8-3.5-5-5.5-6.5-.3-2-1-4-1-4zm-4 6a2 2 0 1 1 0 4 2 2 0 0 1 0-4z" fill="white"/>
+</svg>

--- a/packages/@n8n/nodes-langchain/package.json
+++ b/packages/@n8n/nodes-langchain/package.json
@@ -45,6 +45,7 @@
     "n8nNodesApiVersion": 1,
     "credentials": [
       "dist/credentials/AnthropicApi.credentials.js",
+      "dist/credentials/AvianApi.credentials.js",
       "dist/credentials/AzureAiSearchApi.credentials.js",
       "dist/credentials/AzureOpenAiApi.credentials.js",
       "dist/credentials/AzureEntraCognitiveServicesOAuth2Api.credentials.js",
@@ -106,6 +107,7 @@
       "dist/nodes/embeddings/EmbeddingsOllama/EmbeddingsOllama.node.js",
       "dist/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.js",
       "dist/nodes/llms/LmChatAzureOpenAi/LmChatAzureOpenAi.node.js",
+      "dist/nodes/llms/LmChatAvian/LmChatAvian.node.js",
       "dist/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.js",
       "dist/nodes/llms/LmChatCohere/LmChatCohere.node.js",
       "dist/nodes/llms/LmChatDeepSeek/LmChatDeepSeek.node.js",


### PR DESCRIPTION
## Summary
- Adds [Avian](https://avian.io) as a new AI model provider node in n8n
- Avian provides an OpenAI-compatible API (chat completions, streaming, function calling) with access to frontier models at competitive pricing
- Available models include DeepSeek V3.2 (164K context, $0.26/$0.38 per M tokens), Kimi K2.5 (131K context), GLM-5, and Minimax M2.5 (1M context)

## Changes
- **Credential**: `AvianApi.credentials.ts` — Bearer token auth against `https://api.avian.io/v1`, with `/models` endpoint test
- **Node**: `LmChatAvian.node.ts` — OpenAI-compatible chat model node using `@langchain/openai` `ChatOpenAI`, with dynamic model loading via `/models` endpoint, full options (temperature, top_p, frequency/presence penalty, max tokens, response format, timeout, retries)
- **Icon**: `avian.svg` — Brand icon for the node
- **Registration**: Added credential and node entries to `package.json`

Follows the exact same pattern as the DeepSeek, xAI Grok, and OpenRouter nodes.

## Test plan
- [ ] Credential test: Verify API key validation via `/models` endpoint
- [ ] Model loading: Confirm dynamic model list populates from Avian API
- [ ] Chat completion: Test basic text generation with DeepSeek V3.2
- [ ] Streaming: Verify streaming responses work in AI chains
- [ ] Function calling: Test tool use in AI agent workflows
- [ ] JSON mode: Verify `response_format: json_object` works correctly
- [ ] Error handling: Confirm failed attempts are handled by `openAiFailedAttemptHandler`

cc @OlegIvaniv @Cadiac — would appreciate your review as maintainers of the existing AI model nodes