### PR TITLE
fix(editor): Skip false credential warnings for non-admin users

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.test.ts
@@ -19,6 +19,7 @@ import { faker } from '@faker-js/faker';
 import type { INodeUi } from '@/Interface';
 import type { IUsedCredential } from '@/features/credentials/credentials.types';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
+import { useCredentialsStore } from '@/features/credentials/credentials.store';
 import { injectWorkflowState, useWorkflowState } from './useWorkflowState';
 
 vi.mock('@/app/composables/useWorkflowState', async () => {
@@ -697,6 +698,132 @@ describe('useNodeHelpers()', () => {
 			const hints = getNodeHints(workflow, node, nodeType);
 
 			expect(hints).toHaveLength(1);
+		});
+	});
+
+	describe('getNodeCredentialIssues()', () => {
+		const credentialId = faker.string.alphanumeric(16);
+		const credentialName = 'Postgres_ADI_client_EE';
+		const credentialTypeName = 'postgres';
+
+		const nodeTypeWithCredentials: INodeTypeDescription = {
+			displayName: 'Postgres',
+			name: 'n8n-nodes-base.postgres',
+			group: ['transform'],
+			version: [1],
+			description: 'Postgres node',
+			defaults: { name: 'Postgres' },
+			inputs: [NodeConnectionTypes.Main],
+			outputs: [NodeConnectionTypes.Main],
+			credentials: [
+				{
+					name: credentialTypeName,
+					required: true,
+				},
+			],
+			properties: [],
+		};
+
+		const nodeWithCredentials: INodeUi = {
+			id: faker.string.uuid(),
+			name: 'Postgres',
+			type: 'n8n-nodes-base.postgres',
+			typeVersion: 1,
+			position: [0, 0],
+			parameters: {},
+			credentials: {
+				[credentialTypeName]: {
+					id: credentialId,
+					name: credentialName,
+				},
+			},
+		};
+
+		it('should not report credential issues when credential is in usedCredentials but not in credential store', () => {
+			// Simulates a non-admin (member) user who owns the credential but
+			// the credential is not in the frontend credential store due to
+			// project-scoped filtering. The backend-populated usedCredentials
+			// should suppress the false warning.
+			const { getNodeCredentialIssues } = useNodeHelpers();
+
+			mockedStore(useNodeTypesStore).getNodeType = vi
+				.fn()
+				.mockReturnValue(nodeTypeWithCredentials);
+
+			// Credential store returns empty (not accessible via project-scoped filter)
+			const credentialsStore = mockedStore(useCredentialsStore);
+			credentialsStore.getCredentialsByType = vi.fn().mockReturnValue([]);
+			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
+				name: credentialTypeName,
+				displayName: 'Postgres',
+			});
+
+			// But the credential IS present in workflowsStore.usedCredentials
+			// (populated from the backend GET /workflows/:id response)
+			const usedCredential: IUsedCredential = {
+				id: credentialId,
+				name: credentialName,
+				credentialType: credentialTypeName,
+				currentUserHasAccess: true,
+			};
+			mockedStore(useWorkflowsStore).usedCredentials = {
+				[credentialId]: usedCredential,
+			};
+
+			const result = getNodeCredentialIssues(nodeWithCredentials);
+			expect(result).toBeNull();
+		});
+
+		it('should report credential issues when credential is neither in credential store nor in usedCredentials', () => {
+			// When a credential truly does not exist (not in store and not in
+			// usedCredentials), the warning should still be shown.
+			const { getNodeCredentialIssues } = useNodeHelpers();
+
+			mockedStore(useNodeTypesStore).getNodeType = vi
+				.fn()
+				.mockReturnValue(nodeTypeWithCredentials);
+
+			const credentialsStore = mockedStore(useCredentialsStore);
+			credentialsStore.getCredentialsByType = vi.fn().mockReturnValue([]);
+			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
+				name: credentialTypeName,
+				displayName: 'Postgres',
+			});
+
+			// usedCredentials is empty — credential is genuinely missing
+			mockedStore(useWorkflowsStore).usedCredentials = {};
+
+			const result = getNodeCredentialIssues(nodeWithCredentials);
+			expect(result).not.toBeNull();
+			expect(result?.credentials).toBeDefined();
+			expect(result?.credentials?.[credentialTypeName]).toBeDefined();
+		});
+
+		it('should not report credential issues when credential is found in credential store by ID', () => {
+			// Normal case: admin or user who has the credential in their store
+			const { getNodeCredentialIssues } = useNodeHelpers();
+
+			mockedStore(useNodeTypesStore).getNodeType = vi
+				.fn()
+				.mockReturnValue(nodeTypeWithCredentials);
+
+			const credentialsStore = mockedStore(useCredentialsStore);
+			credentialsStore.getCredentialsByType = vi.fn().mockReturnValue([
+				{
+					id: credentialId,
+					name: credentialName,
+					type: credentialTypeName,
+				},
+			]);
+			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
+				name: credentialTypeName,
+				displayName: 'Postgres',
+			});
+
+			mockedStore(useWorkflowsStore).usedCredentials = {};
+
+			const result = getNodeCredentialIssues(nodeWithCredentials);
+			expect(result).toBeNull();
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
@@ -528,6 +528,15 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 					if (idMatch) {
 						continue;
 					}
+					// If the credential is not in the user's credential store,
+					// check if it is confirmed to be used by this workflow via
+					// the backend-populated usedCredentials. This prevents false
+					// "do not exist" warnings for non-admin users whose credential
+					// store may not include all accessible credentials due to
+					// project-scoped filtering or initialization timing.
+					if (workflowsStore.usedCredentials?.[selectedCredentials.id]) {
+						continue;
+					}
 				}
 
 				const nameMatches = userCredentials.filter(
@@ -1084,6 +1093,7 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 		updateNodesExecutionIssues,
 		updateNodesParameterIssues,
 		updateNodeInputIssues,
+		getNodeCredentialIssues,
 		updateNodeCredentialIssuesByName,
 		updateNodeCredentialIssues,
 		updateNodeParameterIssuesByName,


### PR DESCRIPTION
## Summary

Non-admin (`global:member`) users see false "Credentials with name X do not exist" warnings on workflow nodes, even though the credentials are valid and executions succeed. This is a UI-only issue in `getNodeCredentialIssues()` in `useNodeHelpers.ts`.

### Root cause

1. `getNodeCredentialIssues()` looks up the node's credential by ID in the user's credential store (`credentialsStore.getCredentialsByType()`).
2. The credential store is populated by `fetchAllCredentialsForWorkflow()`, which calls `GET /credentials/for-workflow`. The backend returns an **intersection** of credentials the user can access AND credentials the workflow's project can access.
3. For non-admin users, this intersection can exclude credentials the user owns but that aren't shared with the workflow's project scope — so the ID lookup fails.
4. The existing fallback checks `hasPermission(['rbac'], { rbac: { scope: 'credential:read' } })`, which only considers **global** scopes. Since `credential:read` is only granted to `global:owner` and `global:admin` roles, this always returns `false` for members.
5. The other fallback (`workflowsStore.usedCredentials`) is checked too late — only after the name-matching path also fails.

### Fix

Check `workflowsStore.usedCredentials` early in the flow, right after the credential store ID lookup fails (line 531). Since `usedCredentials` is populated from the backend `GET /workflows/:id` response (which fetches credentials by ID directly from the DB, bypassing user access checks), it reliably confirms the credential exists and is used by the workflow.

This is a minimal, safe change — it adds an early exit before the name-matching fallback path, using data the backend has already validated.

### How to test

1. Set up an n8n instance with Enterprise features (credential sharing, projects)
2. Create a workflow with a Postgres (or any) node using a credential owned by the project
3. Log in as a `global:member` user who has access to the workflow
4. Before fix: the node shows "Credentials with name X do not exist" warning
5. After fix: no warning is shown

## Related Linear tickets, Github issues, and Community forum posts

Fixes https://github.com/n8n-io/n8n/issues/26054

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.