### PR TITLE
chore(core): Add redactionInfo object to execution data responses

### DIFF
--- a/packages/workflow/src/run-execution-data/run-execution-data.ts
+++ b/packages/workflow/src/run-execution-data/run-execution-data.ts
@@ -8,6 +8,8 @@
 import type { IRunExecutionDataV0 } from './run-execution-data.v0';
 import { runExecutionDataV0ToV1, type IRunExecutionDataV1 } from './run-execution-data.v1';
 
+export type { RedactionInfo } from './run-execution-data.v1';
+
 /**
  * All the versions of the interface.
  * !!! Only used at the data access layer to handle records saved under older versions. !!!

--- a/packages/workflow/src/run-execution-data/run-execution-data.v1.ts
+++ b/packages/workflow/src/run-execution-data/run-execution-data.v1.ts
@@ -15,6 +15,12 @@ import type {
 } from '..';
 import type { IRunExecutionDataV0 } from './run-execution-data.v0';
 
+export interface RedactionInfo {
+	isRedacted: boolean;
+	reason: string;
+	canReveal: boolean;
+}
+
 // DIFF: switches startData.destinationNode to a structured object, rather than just the name of the string.
 export interface IRunExecutionDataV1 {
 	version: 1;
@@ -56,6 +62,9 @@ export interface IRunExecutionDataV1 {
 		IWorkflowExecutionDataProcess,
 		'dirtyNodeNames' | 'triggerToStartFrom' | 'userId'
 	>;
+
+	/** Metadata about whether and how this execution's data was redacted. */
+	redactionInfo?: RedactionInfo;
 }
 
 export function runExecutionDataV0ToV1(data: IRunExecutionDataV0): IRunExecutionDataV1 {


### PR DESCRIPTION
## Summary

Adds an optional `redactionInfo` field to `IRunExecutionDataV1` (in `packages/workflow`) that travels with the execution data object itself. When an execution's data is redacted, this field describes the redaction so that callers know whether data was withheld and whether they can request unredacted access.

**New type (`packages/workflow`):**
```typescript
export interface RedactionInfo {
  isRedacted: boolean;
  reason: string;      // 'workflow_redaction_policy' | 'user_requested'
  canReveal: boolean;  // true if the requester is allowed to see unredacted data
}
```

**`canReveal` logic:** A user can reveal unredacted data when either:
- The workflow's redaction policy implicitly allows it (`policy === 'none'`, or `policy === 'non-manual'` and the execution mode is `manual`); **or**
- The user holds the `execution:reveal` scope (global owners/admins, project admins).

This also fixes a gap in the `redactExecutionData=false` (explicit reveal) path: users without the `execution:reveal` scope were previously blocked with a 403 even when the policy would not have redacted the data in the first place.

**Implementation details:**
- `applyRedaction()` in `ExecutionRedactionService` now accepts a `canReveal` parameter and writes `execution.data.redactionInfo`
- A new `policyAllowsReveal()` private method encapsulates the policy-based check
- `canUserReveal()` is simplified to delegate to `WorkflowFinderService.findWorkflowForUser()` with the `execution:reveal` scope
- Non-redacted paths leave `redactionInfo` as `undefined`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-181

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
