### PR TITLE
fix(editor): Hide client secret field in resolver when user info endpoint is selected

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/CredentialResolverEditModal.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/CredentialResolverEditModal.test.ts
@@ -391,38 +391,6 @@ describe('CredentialResolverEditModal', () => {
 				expect(getPropertyNames(capturedProps)).not.toContain('clientSecret');
 			});
 		});
-
-		it('should filter by displayOptions in create mode with default values', async () => {
-			const { capturedProps, component } = createCredentialInputsSpy();
-
-			vi.mocked(restApiClient.getCredentialResolverTypes).mockResolvedValue(mockOAuthResolverTypes);
-
-			renderModal({
-				props: {
-					modalName: CREDENTIAL_RESOLVER_EDIT_MODAL_KEY,
-					data: { onSave: vi.fn() },
-				},
-				pinia,
-				global: { stubs: { Modal: ModalStub, CredentialInputs: component } },
-			});
-
-			// In create mode, no resolver is loaded — wait for types only
-			await vi.waitFor(() => {
-				expect(restApiClient.getCredentialResolverTypes).toHaveBeenCalled();
-			});
-
-			// CredentialInputs won't render until a type is selected.
-			// Simulate selecting the OAuth type by emitting a type change.
-			// The type select is bound to resolverType via v-model, so we need to
-			// find and interact with it. Since the N8nSelect is not stubbed away,
-			// we check that no CredentialInputs rendered yet (no type selected).
-			expect(capturedProps.length).toBe(0);
-
-			// We can't easily select the type via the stubbed UI, but we can verify
-			// that once the validation field defaults kick in, the filtering works.
-			// This is already covered by the edit-mode tests above — the computed
-			// uses the same code path regardless of create vs edit mode.
-		});
 	});
 
 	describe('Error handling', () => {

--- a/packages/frontend/editor-ui/src/app/components/CredentialResolverEditModal.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/CredentialResolverEditModal.test.ts
@@ -7,7 +7,7 @@ import { useToast } from '@/app/composables/useToast';
 import { CREDENTIAL_RESOLVER_EDIT_MODAL_KEY } from '../constants';
 import * as restApiClient from '@n8n/rest-api-client';
 import type { CredentialResolverType } from '@n8n/api-types';
-import { defineComponent, h } from 'vue';
+import { defineComponent, h, watch, toRefs } from 'vue';
 
 vi.mock('@/app/composables/useToast', () => {
 	const showError = vi.fn();
@@ -120,6 +120,41 @@ const mockOAuthResolverTypes: CredentialResolverType[] = [
 	},
 ];
 
+/**
+ * Creates a spy component that replaces CredentialInputs, capturing props on
+ * every render and optionally exposing an `emit('update', ...)` trigger.
+ */
+function createCredentialInputsSpy({ withEmit = false } = {}) {
+	const capturedProps: Array<Record<string, unknown>> = [];
+	let triggerUpdate: ((data: { name: string; value: unknown }) => void) | undefined;
+
+	const component = defineComponent({
+		props: ['credentialProperties', 'credentialData', 'documentationUrl', 'showValidationWarnings'],
+		emits: ['update'],
+		setup(props, { emit }) {
+			if (withEmit) {
+				triggerUpdate = (data) => emit('update', data);
+			}
+			// Capture initial props
+			capturedProps.push({ ...props });
+			// Re-capture on every prop change
+			const refs = toRefs(props);
+			watch(
+				() => Object.values(refs).map((r) => r.value),
+				() => capturedProps.push({ ...props }),
+			);
+			return () => h('div', { 'data-test-id': 'credential-inputs' });
+		},
+	});
+
+	return { capturedProps, component, getTriggerUpdate: () => triggerUpdate };
+}
+
+function getPropertyNames(capturedProps: Array<Record<string, unknown>>) {
+	const lastProps = capturedProps[capturedProps.length - 1];
+	return (lastProps.credentialProperties as Array<{ name: string }>).map((p) => p.name);
+}
+
 const renderModal = createComponentRenderer(CredentialResolverEditModal);
 
 let pinia: ReturnType<typeof createTestingPinia>;
@@ -225,23 +260,11 @@ describe('CredentialResolverEditModal', () => {
 
 	describe('displayOptions filtering', () => {
 		it('should hide clientId and clientSecret when validation is oauth2-userinfo', async () => {
-			const credentialInputsProps: Array<Record<string, unknown>> = [];
-			const CredentialInputsSpy = defineComponent({
-				props: [
-					'credentialProperties',
-					'credentialData',
-					'documentationUrl',
-					'showValidationWarnings',
-				],
-				setup(props) {
-					credentialInputsProps.push({ ...props });
-					return () => h('div', { 'data-test-id': 'credential-inputs' });
-				},
-			});
+			const { capturedProps, component } = createCredentialInputsSpy();
 
 			vi.mocked(restApiClient.getCredentialResolverTypes).mockResolvedValue(mockOAuthResolverTypes);
 
-			const mockResolver = {
+			vi.mocked(restApiClient.getCredentialResolver).mockResolvedValue({
 				id: 'oauth-resolver-id',
 				name: 'OAuth Resolver',
 				type: 'credential-resolver.oauth2-1.0',
@@ -253,9 +276,7 @@ describe('CredentialResolverEditModal', () => {
 				},
 				createdAt: new Date(),
 				updatedAt: new Date(),
-			};
-
-			vi.mocked(restApiClient.getCredentialResolver).mockResolvedValue(mockResolver);
+			});
 
 			renderModal({
 				props: {
@@ -263,23 +284,14 @@ describe('CredentialResolverEditModal', () => {
 					data: { resolverId: 'oauth-resolver-id' },
 				},
 				pinia,
-				global: {
-					stubs: {
-						Modal: ModalStub,
-						CredentialInputs: CredentialInputsSpy,
-					},
-				},
+				global: { stubs: { Modal: ModalStub, CredentialInputs: component } },
 			});
 
 			await vi.waitFor(() => {
-				expect(credentialInputsProps.length).toBeGreaterThan(0);
+				expect(capturedProps.length).toBeGreaterThan(0);
 			});
 
-			const lastProps = credentialInputsProps[credentialInputsProps.length - 1];
-			const propertyNames = (lastProps.credentialProperties as Array<{ name: string }>).map(
-				(p) => p.name,
-			);
-
+			const propertyNames = getPropertyNames(capturedProps);
 			expect(propertyNames).toContain('metadataUri');
 			expect(propertyNames).toContain('validation');
 			expect(propertyNames).toContain('subjectClaim');
@@ -287,109 +299,12 @@ describe('CredentialResolverEditModal', () => {
 			expect(propertyNames).not.toContain('clientSecret');
 		});
 
-		it('should reactively hide clientId and clientSecret when user switches validation to oauth2-userinfo', async () => {
-			const credentialInputsProps: Array<Record<string, unknown>> = [];
-			let triggerUpdate: ((data: { name: string; value: unknown }) => void) | undefined;
-
-			const CredentialInputsSpy = defineComponent({
-				props: [
-					'credentialProperties',
-					'credentialData',
-					'documentationUrl',
-					'showValidationWarnings',
-				],
-				emits: ['update'],
-				setup(props, { emit }) {
-					triggerUpdate = (data) => emit('update', data);
-					credentialInputsProps.push({ ...props });
-					return () => h('div', { 'data-test-id': 'credential-inputs' });
-				},
-				// Re-capture props on update
-				updated() {
-					credentialInputsProps.push({ ...this.$props });
-				},
-			});
-
-			vi.mocked(restApiClient.getCredentialResolverTypes).mockResolvedValue(mockOAuthResolverTypes);
-
-			const mockResolver = {
-				id: 'oauth-resolver-id',
-				name: 'OAuth Resolver',
-				type: 'credential-resolver.oauth2-1.0',
-				config: '{}',
-				decryptedConfig: {
-					metadataUri: 'https://auth.example.com/.well-known/openid-configuration',
-					validation: 'oauth2-introspection',
-					clientId: 'my-client',
-					clientSecret: 'my-secret',
-					subjectClaim: 'sub',
-				},
-				createdAt: new Date(),
-				updatedAt: new Date(),
-			};
-
-			vi.mocked(restApiClient.getCredentialResolver).mockResolvedValue(mockResolver);
-
-			renderModal({
-				props: {
-					modalName: CREDENTIAL_RESOLVER_EDIT_MODAL_KEY,
-					data: { resolverId: 'oauth-resolver-id' },
-				},
-				pinia,
-				global: {
-					stubs: {
-						Modal: ModalStub,
-						CredentialInputs: CredentialInputsSpy,
-					},
-				},
-			});
-
-			// Wait for initial render with introspection — fields should be visible
-			await vi.waitFor(() => {
-				expect(credentialInputsProps.length).toBeGreaterThan(0);
-				expect(triggerUpdate).toBeDefined();
-			});
-
-			let lastProps = credentialInputsProps[credentialInputsProps.length - 1];
-			let propertyNames = (lastProps.credentialProperties as Array<{ name: string }>).map(
-				(p) => p.name,
-			);
-			expect(propertyNames).toContain('clientId');
-			expect(propertyNames).toContain('clientSecret');
-
-			// Simulate user switching validation to oauth2-userinfo
-			const propsCountBefore = credentialInputsProps.length;
-			triggerUpdate!({ name: 'validation', value: 'oauth2-userinfo' });
-
-			await vi.waitFor(() => {
-				expect(credentialInputsProps.length).toBeGreaterThan(propsCountBefore);
-				lastProps = credentialInputsProps[credentialInputsProps.length - 1];
-				propertyNames = (lastProps.credentialProperties as Array<{ name: string }>).map(
-					(p) => p.name,
-				);
-				expect(propertyNames).not.toContain('clientId');
-				expect(propertyNames).not.toContain('clientSecret');
-			});
-		});
-
 		it('should show clientId and clientSecret when validation is oauth2-introspection', async () => {
-			const credentialInputsProps: Array<Record<string, unknown>> = [];
-			const CredentialInputsSpy = defineComponent({
-				props: [
-					'credentialProperties',
-					'credentialData',
-					'documentationUrl',
-					'showValidationWarnings',
-				],
-				setup(props) {
-					credentialInputsProps.push({ ...props });
-					return () => h('div', { 'data-test-id': 'credential-inputs' });
-				},
-			});
+			const { capturedProps, component } = createCredentialInputsSpy();
 
 			vi.mocked(restApiClient.getCredentialResolverTypes).mockResolvedValue(mockOAuthResolverTypes);
 
-			const mockResolver = {
+			vi.mocked(restApiClient.getCredentialResolver).mockResolvedValue({
 				id: 'oauth-resolver-id',
 				name: 'OAuth Resolver',
 				type: 'credential-resolver.oauth2-1.0',
@@ -403,9 +318,7 @@ describe('CredentialResolverEditModal', () => {
 				},
 				createdAt: new Date(),
 				updatedAt: new Date(),
-			};
-
-			vi.mocked(restApiClient.getCredentialResolver).mockResolvedValue(mockResolver);
+			});
 
 			renderModal({
 				props: {
@@ -413,28 +326,102 @@ describe('CredentialResolverEditModal', () => {
 					data: { resolverId: 'oauth-resolver-id' },
 				},
 				pinia,
-				global: {
-					stubs: {
-						Modal: ModalStub,
-						CredentialInputs: CredentialInputsSpy,
-					},
-				},
+				global: { stubs: { Modal: ModalStub, CredentialInputs: component } },
 			});
 
 			await vi.waitFor(() => {
-				expect(credentialInputsProps.length).toBeGreaterThan(0);
+				expect(capturedProps.length).toBeGreaterThan(0);
 			});
 
-			const lastProps = credentialInputsProps[credentialInputsProps.length - 1];
-			const propertyNames = (lastProps.credentialProperties as Array<{ name: string }>).map(
-				(p) => p.name,
-			);
-
+			const propertyNames = getPropertyNames(capturedProps);
 			expect(propertyNames).toContain('metadataUri');
 			expect(propertyNames).toContain('validation');
 			expect(propertyNames).toContain('clientId');
 			expect(propertyNames).toContain('clientSecret');
 			expect(propertyNames).toContain('subjectClaim');
+		});
+
+		it('should reactively hide fields when user switches validation to oauth2-userinfo', async () => {
+			const { capturedProps, component, getTriggerUpdate } = createCredentialInputsSpy({
+				withEmit: true,
+			});
+
+			vi.mocked(restApiClient.getCredentialResolverTypes).mockResolvedValue(mockOAuthResolverTypes);
+
+			vi.mocked(restApiClient.getCredentialResolver).mockResolvedValue({
+				id: 'oauth-resolver-id',
+				name: 'OAuth Resolver',
+				type: 'credential-resolver.oauth2-1.0',
+				config: '{}',
+				decryptedConfig: {
+					metadataUri: 'https://auth.example.com/.well-known/openid-configuration',
+					validation: 'oauth2-introspection',
+					clientId: 'my-client',
+					clientSecret: 'my-secret',
+					subjectClaim: 'sub',
+				},
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			});
+
+			renderModal({
+				props: {
+					modalName: CREDENTIAL_RESOLVER_EDIT_MODAL_KEY,
+					data: { resolverId: 'oauth-resolver-id' },
+				},
+				pinia,
+				global: { stubs: { Modal: ModalStub, CredentialInputs: component } },
+			});
+
+			await vi.waitFor(() => {
+				expect(capturedProps.length).toBeGreaterThan(0);
+				expect(getTriggerUpdate()).toBeDefined();
+			});
+
+			expect(getPropertyNames(capturedProps)).toContain('clientId');
+			expect(getPropertyNames(capturedProps)).toContain('clientSecret');
+
+			// Simulate user switching validation method
+			const propsCountBefore = capturedProps.length;
+			getTriggerUpdate()!({ name: 'validation', value: 'oauth2-userinfo' });
+
+			await vi.waitFor(() => {
+				expect(capturedProps.length).toBeGreaterThan(propsCountBefore);
+				expect(getPropertyNames(capturedProps)).not.toContain('clientId');
+				expect(getPropertyNames(capturedProps)).not.toContain('clientSecret');
+			});
+		});
+
+		it('should filter by displayOptions in create mode with default values', async () => {
+			const { capturedProps, component } = createCredentialInputsSpy();
+
+			vi.mocked(restApiClient.getCredentialResolverTypes).mockResolvedValue(mockOAuthResolverTypes);
+
+			renderModal({
+				props: {
+					modalName: CREDENTIAL_RESOLVER_EDIT_MODAL_KEY,
+					data: { onSave: vi.fn() },
+				},
+				pinia,
+				global: { stubs: { Modal: ModalStub, CredentialInputs: component } },
+			});
+
+			// In create mode, no resolver is loaded — wait for types only
+			await vi.waitFor(() => {
+				expect(restApiClient.getCredentialResolverTypes).toHaveBeenCalled();
+			});
+
+			// CredentialInputs won't render until a type is selected.
+			// Simulate selecting the OAuth type by emitting a type change.
+			// The type select is bound to resolverType via v-model, so we need to
+			// find and interact with it. Since the N8nSelect is not stubbed away,
+			// we check that no CredentialInputs rendered yet (no type selected).
+			expect(capturedProps.length).toBe(0);
+
+			// We can't easily select the type via the stubbed UI, but we can verify
+			// that once the validation field defaults kick in, the filtering works.
+			// This is already covered by the edit-mode tests above — the computed
+			// uses the same code path regardless of create vs edit mode.
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/components/CredentialResolverEditModal.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/CredentialResolverEditModal.test.ts
@@ -7,6 +7,7 @@ import { useToast } from '@/app/composables/useToast';
 import { CREDENTIAL_RESOLVER_EDIT_MODAL_KEY } from '../constants';
 import * as restApiClient from '@n8n/rest-api-client';
 import type { CredentialResolverType } from '@n8n/api-types';
+import { defineComponent, h } from 'vue';
 
 vi.mock('@/app/composables/useToast', () => {
 	const showError = vi.fn();
@@ -61,6 +62,59 @@ const mockResolverTypes: CredentialResolverType[] = [
 				required: true,
 				description: 'Enter your API key',
 				placeholder: 'Enter key',
+			},
+		],
+	},
+];
+
+const mockOAuthResolverTypes: CredentialResolverType[] = [
+	{
+		name: 'credential-resolver.oauth2-1.0',
+		displayName: 'OAuth2 Resolver',
+		description: 'OAuth2 based credential resolver',
+		options: [
+			{
+				displayName: 'Metadata URL',
+				name: 'metadataUri',
+				type: 'string',
+				required: true,
+				default: '',
+			},
+			{
+				displayName: 'Validation Method',
+				name: 'validation',
+				type: 'options',
+				options: [
+					{ name: 'OAuth2 Token Introspection', value: 'oauth2-introspection' },
+					{ name: 'OAuth2 UserInfo Endpoint', value: 'oauth2-userinfo' },
+				],
+				default: 'oauth2-introspection',
+			},
+			{
+				displayName: 'Client ID',
+				name: 'clientId',
+				type: 'string',
+				default: '',
+				displayOptions: {
+					hide: { validation: ['oauth2-userinfo'] },
+					show: { validation: ['oauth2-introspection'] },
+				},
+			},
+			{
+				displayName: 'Client Secret',
+				name: 'clientSecret',
+				type: 'string',
+				default: '',
+				displayOptions: {
+					hide: { validation: ['oauth2-userinfo'] },
+					show: { validation: ['oauth2-introspection'] },
+				},
+			},
+			{
+				displayName: 'Subject Claim',
+				name: 'subjectClaim',
+				type: 'string',
+				default: 'sub',
 			},
 		],
 	},
@@ -166,6 +220,136 @@ describe('CredentialResolverEditModal', () => {
 					'existing-resolver-id',
 				);
 			});
+		});
+	});
+
+	describe('displayOptions filtering', () => {
+		it('should hide clientId and clientSecret when validation is oauth2-userinfo', async () => {
+			const credentialInputsProps: Array<Record<string, unknown>> = [];
+			const CredentialInputsSpy = defineComponent({
+				props: [
+					'credentialProperties',
+					'credentialData',
+					'documentationUrl',
+					'showValidationWarnings',
+				],
+				setup(props) {
+					credentialInputsProps.push({ ...props });
+					return () => h('div', { 'data-test-id': 'credential-inputs' });
+				},
+			});
+
+			vi.mocked(restApiClient.getCredentialResolverTypes).mockResolvedValue(mockOAuthResolverTypes);
+
+			const mockResolver = {
+				id: 'oauth-resolver-id',
+				name: 'OAuth Resolver',
+				type: 'credential-resolver.oauth2-1.0',
+				config: '{}',
+				decryptedConfig: {
+					metadataUri: 'https://auth.example.com/.well-known/openid-configuration',
+					validation: 'oauth2-userinfo',
+					subjectClaim: 'sub',
+				},
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			};
+
+			vi.mocked(restApiClient.getCredentialResolver).mockResolvedValue(mockResolver);
+
+			renderModal({
+				props: {
+					modalName: CREDENTIAL_RESOLVER_EDIT_MODAL_KEY,
+					data: { resolverId: 'oauth-resolver-id' },
+				},
+				pinia,
+				global: {
+					stubs: {
+						Modal: ModalStub,
+						CredentialInputs: CredentialInputsSpy,
+					},
+				},
+			});
+
+			await vi.waitFor(() => {
+				expect(credentialInputsProps.length).toBeGreaterThan(0);
+			});
+
+			const lastProps = credentialInputsProps[credentialInputsProps.length - 1];
+			const propertyNames = (lastProps.credentialProperties as Array<{ name: string }>).map(
+				(p) => p.name,
+			);
+
+			expect(propertyNames).toContain('metadataUri');
+			expect(propertyNames).toContain('validation');
+			expect(propertyNames).toContain('subjectClaim');
+			expect(propertyNames).not.toContain('clientId');
+			expect(propertyNames).not.toContain('clientSecret');
+		});
+
+		it('should show clientId and clientSecret when validation is oauth2-introspection', async () => {
+			const credentialInputsProps: Array<Record<string, unknown>> = [];
+			const CredentialInputsSpy = defineComponent({
+				props: [
+					'credentialProperties',
+					'credentialData',
+					'documentationUrl',
+					'showValidationWarnings',
+				],
+				setup(props) {
+					credentialInputsProps.push({ ...props });
+					return () => h('div', { 'data-test-id': 'credential-inputs' });
+				},
+			});
+
+			vi.mocked(restApiClient.getCredentialResolverTypes).mockResolvedValue(mockOAuthResolverTypes);
+
+			const mockResolver = {
+				id: 'oauth-resolver-id',
+				name: 'OAuth Resolver',
+				type: 'credential-resolver.oauth2-1.0',
+				config: '{}',
+				decryptedConfig: {
+					metadataUri: 'https://auth.example.com/.well-known/openid-configuration',
+					validation: 'oauth2-introspection',
+					clientId: 'my-client',
+					clientSecret: 'my-secret',
+					subjectClaim: 'sub',
+				},
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			};
+
+			vi.mocked(restApiClient.getCredentialResolver).mockResolvedValue(mockResolver);
+
+			renderModal({
+				props: {
+					modalName: CREDENTIAL_RESOLVER_EDIT_MODAL_KEY,
+					data: { resolverId: 'oauth-resolver-id' },
+				},
+				pinia,
+				global: {
+					stubs: {
+						Modal: ModalStub,
+						CredentialInputs: CredentialInputsSpy,
+					},
+				},
+			});
+
+			await vi.waitFor(() => {
+				expect(credentialInputsProps.length).toBeGreaterThan(0);
+			});
+
+			const lastProps = credentialInputsProps[credentialInputsProps.length - 1];
+			const propertyNames = (lastProps.credentialProperties as Array<{ name: string }>).map(
+				(p) => p.name,
+			);
+
+			expect(propertyNames).toContain('metadataUri');
+			expect(propertyNames).toContain('validation');
+			expect(propertyNames).toContain('clientId');
+			expect(propertyNames).toContain('clientSecret');
+			expect(propertyNames).toContain('subjectClaim');
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/components/CredentialResolverEditModal.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/CredentialResolverEditModal.test.ts
@@ -287,6 +287,91 @@ describe('CredentialResolverEditModal', () => {
 			expect(propertyNames).not.toContain('clientSecret');
 		});
 
+		it('should reactively hide clientId and clientSecret when user switches validation to oauth2-userinfo', async () => {
+			const credentialInputsProps: Array<Record<string, unknown>> = [];
+			let triggerUpdate: ((data: { name: string; value: unknown }) => void) | undefined;
+
+			const CredentialInputsSpy = defineComponent({
+				props: [
+					'credentialProperties',
+					'credentialData',
+					'documentationUrl',
+					'showValidationWarnings',
+				],
+				emits: ['update'],
+				setup(props, { emit }) {
+					triggerUpdate = (data) => emit('update', data);
+					credentialInputsProps.push({ ...props });
+					return () => h('div', { 'data-test-id': 'credential-inputs' });
+				},
+				// Re-capture props on update
+				updated() {
+					credentialInputsProps.push({ ...this.$props });
+				},
+			});
+
+			vi.mocked(restApiClient.getCredentialResolverTypes).mockResolvedValue(mockOAuthResolverTypes);
+
+			const mockResolver = {
+				id: 'oauth-resolver-id',
+				name: 'OAuth Resolver',
+				type: 'credential-resolver.oauth2-1.0',
+				config: '{}',
+				decryptedConfig: {
+					metadataUri: 'https://auth.example.com/.well-known/openid-configuration',
+					validation: 'oauth2-introspection',
+					clientId: 'my-client',
+					clientSecret: 'my-secret',
+					subjectClaim: 'sub',
+				},
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			};
+
+			vi.mocked(restApiClient.getCredentialResolver).mockResolvedValue(mockResolver);
+
+			renderModal({
+				props: {
+					modalName: CREDENTIAL_RESOLVER_EDIT_MODAL_KEY,
+					data: { resolverId: 'oauth-resolver-id' },
+				},
+				pinia,
+				global: {
+					stubs: {
+						Modal: ModalStub,
+						CredentialInputs: CredentialInputsSpy,
+					},
+				},
+			});
+
+			// Wait for initial render with introspection — fields should be visible
+			await vi.waitFor(() => {
+				expect(credentialInputsProps.length).toBeGreaterThan(0);
+				expect(triggerUpdate).toBeDefined();
+			});
+
+			let lastProps = credentialInputsProps[credentialInputsProps.length - 1];
+			let propertyNames = (lastProps.credentialProperties as Array<{ name: string }>).map(
+				(p) => p.name,
+			);
+			expect(propertyNames).toContain('clientId');
+			expect(propertyNames).toContain('clientSecret');
+
+			// Simulate user switching validation to oauth2-userinfo
+			const propsCountBefore = credentialInputsProps.length;
+			triggerUpdate!({ name: 'validation', value: 'oauth2-userinfo' });
+
+			await vi.waitFor(() => {
+				expect(credentialInputsProps.length).toBeGreaterThan(propsCountBefore);
+				lastProps = credentialInputsProps[credentialInputsProps.length - 1];
+				propertyNames = (lastProps.credentialProperties as Array<{ name: string }>).map(
+					(p) => p.name,
+				);
+				expect(propertyNames).not.toContain('clientId');
+				expect(propertyNames).not.toContain('clientSecret');
+			});
+		});
+
 		it('should show clientId and clientSecret when validation is oauth2-introspection', async () => {
 			const credentialInputsProps: Array<Record<string, unknown>> = [];
 			const CredentialInputsSpy = defineComponent({

--- a/packages/frontend/editor-ui/src/app/components/CredentialResolverEditModal.vue
+++ b/packages/frontend/editor-ui/src/app/components/CredentialResolverEditModal.vue
@@ -26,10 +26,11 @@ import {
 import { useCredentialResolvers } from '@/features/resolvers/composables/useCredentialResolvers';
 import type {
 	INodeProperties,
+	INodeParameters,
 	ICredentialDataDecryptedObject,
 	CredentialInformation,
 } from 'n8n-workflow';
-import { deepCopy } from 'n8n-workflow';
+import { deepCopy, NodeHelpers } from 'n8n-workflow';
 import type { IUpdateInformation } from '@/Interface';
 import CredentialInputs from '@/features/credentials/components/CredentialEdit/CredentialInputs.vue';
 
@@ -136,8 +137,18 @@ const toNodeProperty = (option: Record<string, unknown>): INodeProperties => {
 const resolverProperties = computed<INodeProperties[]>(() => {
 	if (!selectedType.value?.options) return [];
 
-	// Transform resolver options to INodeProperties format
-	return selectedType.value.options.map(toNodeProperty);
+	// Transform resolver options to INodeProperties format and filter by displayOptions
+	return selectedType.value.options.map(toNodeProperty).filter((property) => {
+		if (property.type === 'hidden') return false;
+		if (!property.displayOptions) return true;
+		return NodeHelpers.displayParameterPath(
+			resolverData.value as INodeParameters,
+			property,
+			'',
+			null,
+			null,
+		);
+	});
 });
 
 const resolverData = computed<ICredentialDataDecryptedObject>(() => {


### PR DESCRIPTION
## Summary

When configuring an OAuth2 credential resolver with the "UserInfo Endpoint" validation method, the `clientId` and `clientSecret` fields are now correctly hidden. The backend already defined `displayOptions` on these fields, but the frontend modal was not evaluating them. This adds `NodeHelpers.displayParameterPath` filtering to `resolverProperties` in `CredentialResolverEditModal.vue`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-142

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)