### PR TITLE
fix(editor-ui): Update class binding for global option in SecretsProv…

### DIFF
--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionModal.ee.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionModal.ee.vue
@@ -487,7 +487,9 @@ onMounted(async () => {
 											:key="option.value || 'global'"
 											:value="option.value"
 											:label="option.label"
-											:class="{ [$style.globalOption]: option.value === '' }"
+											:class="{
+												[$style.globalOption]: option.value === '' && scopeOptions.length > 1,
+											}"
 										>
 											<div :class="$style.optionContent">
 												<N8nText v-if="option.icon?.type === 'emoji'" :class="$style.menuItemEmoji">


### PR DESCRIPTION
## Summary

Adjusted the class logic to make sure global option is styled correctly when it is the only option.

Background: When Global is the only option (because there are no applicable projects), no visual separator and extra margin is needed, hence no extra class needed.

## Related Linear tickets, Github issues, and Community forum posts

Closes [LIGO-249](https://linear.app/n8n/issue/LIGO-249/project-scope-fe-rework-ux-of-scope-selection-dropdown) 


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
