### PR TITLE
feat(GitHub Trigger): Add organization webhook support

### DIFF
--- a/packages/nodes-base/nodes/Github/GithubTrigger.node.ts
+++ b/packages/nodes-base/nodes/Github/GithubTrigger.node.ts
@@ -12,7 +12,7 @@ import { NodeConnectionTypes, NodeApiError, NodeOperationError } from 'n8n-workf
 
 import { githubApiRequest } from './GenericFunctions';
 import { verifySignature } from './GithubTriggerHelpers';
-import { getRepositories, getUsers } from './SearchFunctions';
+import { getOrganizations, getRepositories, getUsers } from './SearchFunctions';
 
 export class GithubTrigger implements INodeType {
 	description: INodeTypeDescription = {
@@ -22,8 +22,9 @@ export class GithubTrigger implements INodeType {
 		group: ['trigger'],
 		version: 1,
 		subtitle:
-			'={{$parameter["owner"] + "/" + $parameter["repository"] + ": " + $parameter["events"].join(", ")}}',
-		description: 'Starts the workflow when Github events occur',
+			'={{$parameter["scope"] === "organization" ? $parameter["organization"] + " (org)" : $parameter["owner"] + "/" + $parameter["repository"]}}: {{$parameter["events"].join(", ")}}',
+		description:
+			'Starts the workflow when Github events occur in a repository or organization',
 		defaults: {
 			name: 'Github Trigger',
 		},
@@ -66,6 +67,86 @@ export class GithubTrigger implements INodeType {
 				default: '',
 			},
 			{
+				displayName: 'Source',
+				name: 'scope',
+				type: 'options',
+				options: [
+					{
+						name: 'Repository',
+						value: 'repository',
+						description: 'Receive events from a specific repository',
+					},
+					{
+						name: 'Organization',
+						value: 'organization',
+						description:
+							'Receive events from all repositories in an organization (issues, PRs, etc.)',
+					},
+				],
+				default: 'repository',
+				description: 'Whether to listen to a single repository or the entire organization',
+			},
+			{
+				displayName: 'Organization',
+				name: 'organization',
+				type: 'resourceLocator',
+				default: { mode: 'list', value: '' },
+				required: true,
+				displayOptions: {
+					show: {
+						scope: ['organization'],
+					},
+				},
+				modes: [
+					{
+						displayName: 'Organization',
+						name: 'list',
+						type: 'list',
+						placeholder: 'Select an organization...',
+						typeOptions: {
+							searchListMethod: 'getOrganizations',
+							searchable: true,
+							searchFilterRequired: true,
+						},
+					},
+					{
+						displayName: 'Link',
+						name: 'url',
+						type: 'string',
+						placeholder: 'e.g. https://github.com/n8n-io',
+						extractValue: {
+							type: 'regex',
+							regex: 'https:\\/\\/(?:[^/]+)\\/([-_0-9a-zA-Z]+)',
+						},
+						validation: [
+							{
+								type: 'regex',
+								properties: {
+									regex: 'https:\\/\\/([^/]+)\\/([-_0-9a-zA-Z]+)(?:.*)',
+									errorMessage: 'Not a valid Github organization URL',
+								},
+							},
+						],
+					},
+					{
+						displayName: 'By Name',
+						name: 'name',
+						type: 'string',
+						placeholder: 'e.g. n8n-io',
+						validation: [
+							{
+								type: 'regex',
+								properties: {
+									regex: '[-_a-zA-Z0-9]+',
+									errorMessage: 'Not a valid Github Organization Name',
+								},
+							},
+						],
+						url: '=https://github.com/{{$value}}',
+					},
+				],
+			},
+			{
 				displayName: 'Authentication',
 				name: 'authentication',
 				type: 'options',
@@ -87,6 +168,11 @@ export class GithubTrigger implements INodeType {
 				type: 'resourceLocator',
 				default: { mode: 'list', value: '' },
 				required: true,
+				displayOptions: {
+					show: {
+						scope: ['repository'],
+					},
+				},
 				modes: [
 					{
 						displayName: 'Repository Owner',
@@ -142,6 +228,11 @@ export class GithubTrigger implements INodeType {
 				type: 'resourceLocator',
 				default: { mode: 'list', value: '' },
 				required: true,
+				displayOptions: {
+					show: {
+						scope: ['repository'],
+					},
+				},
 				modes: [
 					{
 						displayName: 'Repository Name',
@@ -466,12 +557,12 @@ export class GithubTrigger implements INodeType {
 					return false;
 				}
 
-				// Webhook got created before so check if it still exists
-				const owner = this.getNodeParameter('owner', '', { extractValue: true }) as string;
-				const repository = this.getNodeParameter('repository', '', {
-					extractValue: true,
-				}) as string;
-				const endpoint = `/repos/${owner}/${repository}/hooks/${webhookData.webhookId}`;
+				// Use stored scope and identifiers from creation (user may have changed the dropdown)
+				const scope = (webhookData.webhookScope as string) ?? this.getNodeParameter('scope', '');
+				const endpoint =
+					scope === 'organization'
+						? `/orgs/${webhookData.webhookOrg ?? this.getNodeParameter('organization', '', { extractValue: true })}/hooks/${webhookData.webhookId}`
+						: `/repos/${webhookData.webhookOwner ?? this.getNodeParameter('owner', '', { extractValue: true })}/${webhookData.webhookRepo ?? this.getNodeParameter('repository', '', { extractValue: true })}/hooks/${webhookData.webhookId}`;
 
 				try {
 					await githubApiRequest.call(this, 'GET', endpoint, {});
@@ -480,6 +571,10 @@ export class GithubTrigger implements INodeType {
 						// Webhook does not exist
 						delete webhookData.webhookId;
 						delete webhookData.webhookEvents;
+						delete webhookData.webhookScope;
+						delete webhookData.webhookOrg;
+						delete webhookData.webhookOwner;
+						delete webhookData.webhookRepo;
 
 						return false;
 					}
@@ -500,14 +595,14 @@ export class GithubTrigger implements INodeType {
 					);
 				}
 
-				const owner = this.getNodeParameter('owner', '', { extractValue: true }) as string;
-				const repository = this.getNodeParameter('repository', '', {
-					extractValue: true,
-				}) as string;
+				const scope = this.getNodeParameter('scope', '') as string;
 				const events = this.getNodeParameter('events', []);
-
-				const endpoint = `/repos/${owner}/${repository}/hooks`;
 				const options = this.getNodeParameter('options') as { insecureSSL: boolean };
+
+				const endpoint =
+					scope === 'organization'
+						? `/orgs/${this.getNodeParameter('organization', '', { extractValue: true })}/hooks`
+						: `/repos/${this.getNodeParameter('owner', '', { extractValue: true })}/${this.getNodeParameter('repository', '', { extractValue: true })}/hooks`;
 
 				// Generate a secure random secret for webhook signature verification
 				const webhookSecret = randomBytes(32).toString('hex');
@@ -544,6 +639,25 @@ export class GithubTrigger implements INodeType {
 									// create it again simply save the webhook-id
 									webhookData.webhookId = webhook.id as string;
 									webhookData.webhookEvents = webhook.events as string[];
+									webhookData.webhookScope = scope;
+									if (scope === 'organization') {
+										webhookData.webhookOrg = this.getNodeParameter(
+											'organization',
+											'',
+											{ extractValue: true },
+										);
+									} else {
+										webhookData.webhookOwner = this.getNodeParameter(
+											'owner',
+											'',
+											{ extractValue: true },
+										);
+										webhookData.webhookRepo = this.getNodeParameter(
+											'repository',
+											'',
+											{ extractValue: true },
+										);
+									}
 									// Legacy webhook without secret on GitHub's side - not setting webhookData.webhookSecret
 									// so signature verification is skipped. To enable it, deactivate and reactivate the workflow.
 									return true;
@@ -559,11 +673,13 @@ export class GithubTrigger implements INodeType {
 					}
 
 					if (error.httpCode === '404') {
-						throw new NodeOperationError(
-							this.getNode(),
-							'Check that the repository exists and that you have permission to create the webhooks this node requires',
-							{ level: 'warning' },
-						);
+						const message =
+							scope === 'organization'
+								? 'Check that the organization exists and that you have owner privileges to create org webhooks'
+								: 'Check that the repository exists and that you have permission to create the webhooks this node requires';
+						throw new NodeOperationError(this.getNode(), message, {
+							level: 'warning',
+						});
 					}
 
 					throw error;
@@ -579,6 +695,19 @@ export class GithubTrigger implements INodeType {
 				webhookData.webhookId = responseData.id as string;
 				webhookData.webhookEvents = responseData.events as string[];
 				webhookData.webhookSecret = webhookSecret;
+				webhookData.webhookScope = scope;
+				if (scope === 'organization') {
+					webhookData.webhookOrg = this.getNodeParameter('organization', '', {
+						extractValue: true,
+					});
+				} else {
+					webhookData.webhookOwner = this.getNodeParameter('owner', '', {
+						extractValue: true,
+					});
+					webhookData.webhookRepo = this.getNodeParameter('repository', '', {
+						extractValue: true,
+					});
+				}
 
 				return true;
 			},
@@ -586,11 +715,12 @@ export class GithubTrigger implements INodeType {
 				const webhookData = this.getWorkflowStaticData('node');
 
 				if (webhookData.webhookId !== undefined) {
-					const owner = this.getNodeParameter('owner', '', { extractValue: true }) as string;
-					const repository = this.getNodeParameter('repository', '', {
-						extractValue: true,
-					}) as string;
-					const endpoint = `/repos/${owner}/${repository}/hooks/${webhookData.webhookId}`;
+					// Use stored scope and identifiers from creation (user may have changed the dropdown)
+					const scope = (webhookData.webhookScope as string) ?? this.getNodeParameter('scope', '');
+					const endpoint =
+						scope === 'organization'
+							? `/orgs/${webhookData.webhookOrg ?? this.getNodeParameter('organization', '', { extractValue: true })}/hooks/${webhookData.webhookId}`
+							: `/repos/${webhookData.webhookOwner ?? this.getNodeParameter('owner', '', { extractValue: true })}/${webhookData.webhookRepo ?? this.getNodeParameter('repository', '', { extractValue: true })}/hooks/${webhookData.webhookId}`;
 					const body = {};
 
 					try {
@@ -604,6 +734,10 @@ export class GithubTrigger implements INodeType {
 					delete webhookData.webhookId;
 					delete webhookData.webhookEvents;
 					delete webhookData.webhookSecret;
+					delete webhookData.webhookScope;
+					delete webhookData.webhookOrg;
+					delete webhookData.webhookOwner;
+					delete webhookData.webhookRepo;
 				}
 
 				return true;
@@ -615,6 +749,7 @@ export class GithubTrigger implements INodeType {
 		listSearch: {
 			getUsers,
 			getRepositories,
+			getOrganizations,
 		},
 	};
 

--- a/packages/nodes-base/nodes/Github/SearchFunctions.ts
+++ b/packages/nodes-base/nodes/Github/SearchFunctions.ts
@@ -30,6 +30,44 @@ type RefItem = {
 	ref: string;
 };
 
+type OrganizationSearchItem = {
+	login: string;
+	html_url: string;
+};
+
+export async function getOrganizations(
+	this: ILoadOptionsFunctions,
+	filter?: string,
+	paginationToken?: string,
+): Promise<INodeListSearchResult> {
+	const page = paginationToken ? +paginationToken : 1;
+	const per_page = 100;
+
+	const responseData: OrganizationSearchItem[] = await githubApiRequest.call(
+		this,
+		'GET',
+		'/user/orgs',
+		{},
+		{ page, per_page },
+	);
+
+	let results: INodeListSearchItems[] = responseData.map((item: OrganizationSearchItem) => ({
+		name: item.login,
+		value: item.login,
+		url: item.html_url,
+	}));
+
+	if (filter) {
+		results = results.filter((org) =>
+			org.name.toLowerCase().includes(filter.toLowerCase()),
+		);
+	}
+
+	const nextPaginationToken =
+		responseData.length === per_page ? page + 1 : undefined;
+	return { results, paginationToken: nextPaginationToken };
+}
+
 export async function getUsers(
 	this: ILoadOptionsFunctions,
 	filter?: string,

--- a/packages/nodes-base/nodes/Github/__tests__/SearchFunctions.test.ts
+++ b/packages/nodes-base/nodes/Github/__tests__/SearchFunctions.test.ts
@@ -1,9 +1,18 @@
 import type { ILoadOptionsFunctions } from 'n8n-workflow';
 
-import { getUsers, getRepositories, getWorkflows, getRefs } from '../SearchFunctions';
+import {
+	getOrganizations,
+	getUsers,
+	getRepositories,
+	getWorkflows,
+	getRefs,
+} from '../SearchFunctions';
 
 const mockLoadOptionsFunctions = {
-	getNodeParameter: jest.fn(),
+	getNodeParameter: jest.fn().mockImplementation((name: string) => {
+		if (name === 'authentication') return 'accessToken';
+		return undefined;
+	}),
 	getCredentials: jest.fn().mockResolvedValue({
 		server: 'https://api.github.com',
 	}),
@@ -109,6 +118,55 @@ describe('Search Functions', () => {
 					qs: expect.objectContaining({ page: 3 }),
 				}),
 			);
+		});
+	});
+
+	describe('getOrganizations', () => {
+		it('should fetch organizations', async () => {
+			const responseData = [
+				{ login: 'org-1', html_url: 'https://github.com/org-1' },
+				{ login: 'org-2', html_url: 'https://github.com/org-2' },
+			];
+
+			(mockLoadOptionsFunctions.helpers.requestWithAuthentication as jest.Mock).mockResolvedValue(
+				responseData,
+			);
+
+			const result = await getOrganizations.call(mockLoadOptionsFunctions);
+
+			expect(result).toEqual({
+				results: [
+					{ name: 'org-1', value: 'org-1', url: 'https://github.com/org-1' },
+					{ name: 'org-2', value: 'org-2', url: 'https://github.com/org-2' },
+				],
+				paginationToken: undefined,
+			});
+
+			expect(mockLoadOptionsFunctions.helpers.requestWithAuthentication).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.objectContaining({
+					method: 'GET',
+					uri: expect.stringContaining('/user/orgs'),
+					qs: expect.objectContaining({ page: 1 }),
+				}),
+			);
+		});
+
+		it('should filter organizations when filter is provided', async () => {
+			const responseData = [
+				{ login: 'n8n-io', html_url: 'https://github.com/n8n-io' },
+				{ login: 'other-org', html_url: 'https://github.com/other-org' },
+			];
+
+			(mockLoadOptionsFunctions.helpers.requestWithAuthentication as jest.Mock).mockResolvedValue(
+				responseData,
+			);
+
+			const result = await getOrganizations.call(mockLoadOptionsFunctions, 'n8n');
+
+			expect(result.results).toEqual([
+				{ name: 'n8n-io', value: 'n8n-io', url: 'https://github.com/n8n-io' },
+			]);
 		});
 	});
 

--- a/packages/nodes-base/nodes/Github/__tests__/UrlPatterns.test.ts
+++ b/packages/nodes-base/nodes/Github/__tests__/UrlPatterns.test.ts
@@ -82,6 +82,24 @@ describe('GitHub Node URL Pattern Tests', () => {
 		return new RegExp(validation?.properties?.regex ?? '');
 	};
 
+	const getTriggerOrganizationUrlMode = () => {
+		const orgParam = githubTriggerNode.description.properties.find(
+			(prop) => prop.name === 'organization',
+		);
+		return orgParam?.modes?.find((mode) => mode.name === 'url');
+	};
+
+	const getTriggerOrganizationExtractRegex = () => {
+		const mode = getTriggerOrganizationUrlMode();
+		return new RegExp(mode?.extractValue?.regex ?? '');
+	};
+
+	const getTriggerOrganizationValidationRegex = () => {
+		const mode = getTriggerOrganizationUrlMode();
+		const validation = mode?.validation?.[0] as ValidationRule;
+		return new RegExp(validation?.properties?.regex ?? '');
+	};
+
 	beforeEach(() => {
 		githubNode = new Github();
 		githubTriggerNode = new GithubTrigger();
@@ -219,6 +237,41 @@ describe('GitHub Node URL Pattern Tests', () => {
 				const validationRegex = getTriggerRepositoryValidationRegex();
 				const url = 'https://github.company.com/my-org/my-repo';
 				expect(validationRegex.test(url)).toBe(true);
+			});
+		});
+
+		describe('Organization URL Pattern', () => {
+			it('should extract organization from github.com URL', () => {
+				const regex = getTriggerOrganizationExtractRegex();
+				const url = 'https://github.com/n8n-io';
+				const match = url.match(regex);
+				expect(match?.[1]).toBe('n8n-io');
+			});
+
+			it('should extract organization from custom GitHub URL', () => {
+				const regex = getTriggerOrganizationExtractRegex();
+				const url = 'https://github.company.com/acme-corp';
+				const match = url.match(regex);
+				expect(match?.[1]).toBe('acme-corp');
+			});
+
+			it('should validate github.com organization URL', () => {
+				const validationRegex = getTriggerOrganizationValidationRegex();
+				const url = 'https://github.com/n8n-io';
+				expect(validationRegex.test(url)).toBe(true);
+			});
+
+			it('should validate custom GitHub organization URL', () => {
+				const validationRegex = getTriggerOrganizationValidationRegex();
+				const url = 'https://github.company.com/acme-corp';
+				expect(validationRegex.test(url)).toBe(true);
+			});
+
+			it('should reject invalid organization URLs', () => {
+				const validationRegex = getTriggerOrganizationValidationRegex();
+				expect(validationRegex.test('not-a-url')).toBe(false);
+				expect(validationRegex.test('http://github.com/user')).toBe(false);
+				expect(validationRegex.test('https://')).toBe(false);
 			});
 		});
 	});

--- a/packages/nodes-base/nodes/Github/__tests__/node/GithubTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Github/__tests__/node/GithubTrigger.node.test.ts
@@ -17,8 +17,10 @@ describe('GithubTrigger Node', () => {
 			mockThis = {
 				getWorkflowStaticData: () => webhookData,
 				getNodeParameter: jest.fn().mockImplementation((name: string) => {
+					if (name === 'scope') return 'repository';
 					if (name === 'owner') return 'some-owner';
 					if (name === 'repository') return 'some-repo';
+					return undefined;
 				}),
 			};
 		});
@@ -33,6 +35,29 @@ describe('GithubTrigger Node', () => {
 			expect(webhookData.webhookId).toBeUndefined();
 			expect(webhookData.webhookEvents).toBeUndefined();
 		});
+
+		it('should use org endpoint when webhookScope is organization', async () => {
+			webhookData.webhookScope = 'organization';
+			webhookData.webhookOrg = 'my-org';
+			mockThis.getNodeParameter = jest.fn().mockImplementation((name: string) => {
+				if (name === 'scope') return 'organization';
+				if (name === 'organization') return 'my-org';
+				return undefined;
+			});
+
+			const apiRequestSpy = jest
+				.spyOn(GenericFunctions, 'githubApiRequest')
+				.mockResolvedValueOnce({});
+
+			const trigger = new GithubTrigger();
+			await trigger.webhookMethods.default.checkExists.call(mockThis);
+
+			expect(apiRequestSpy).toHaveBeenCalledWith(
+				'GET',
+				'/orgs/my-org/hooks/123456',
+				{},
+			);
+		});
 	});
 
 	describe('create webhook method', () => {
@@ -44,10 +69,12 @@ describe('GithubTrigger Node', () => {
 			mockThis = {
 				getNodeWebhookUrl: () => 'https://example.com/webhook',
 				getNodeParameter: jest.fn().mockImplementation((name: string) => {
+					if (name === 'scope') return 'repository';
 					if (name === 'owner') return 'some-owner';
 					if (name === 'repository') return 'some-repo';
 					if (name === 'events') return ['push'];
 					if (name === 'options') return { insecureSSL: false };
+					return undefined;
 				}),
 				getWorkflowStaticData: () => webhookData,
 				getNode: () => ({}),
@@ -124,6 +151,63 @@ describe('GithubTrigger Node', () => {
 				/Check that the repository exists/,
 			);
 		});
+
+		it('should use org endpoint when scope is organization', async () => {
+			mockThis.getNodeParameter = jest.fn().mockImplementation((name: string) => {
+				if (name === 'scope') return 'organization';
+				if (name === 'organization') return 'my-org';
+				if (name === 'events') return ['issues', 'pull_request'];
+				if (name === 'options') return { insecureSSL: false };
+				return undefined;
+			});
+
+			const createdWebhook = { id: '999', active: true };
+			const apiRequestSpy = jest
+				.spyOn(GenericFunctions, 'githubApiRequest')
+				.mockResolvedValueOnce(createdWebhook);
+
+			const trigger = new GithubTrigger();
+			await trigger.webhookMethods.default.create.call(mockThis);
+
+			expect(apiRequestSpy).toHaveBeenCalledWith(
+				'POST',
+				'/orgs/my-org/hooks',
+				expect.objectContaining({
+					name: 'web',
+					events: ['issues', 'pull_request'],
+					active: true,
+					config: expect.objectContaining({
+						content_type: 'json',
+						secret: expect.any(String),
+					}),
+				}),
+			);
+			expect(webhookData.webhookId).toBe('999');
+			expect(webhookData.webhookScope).toBe('organization');
+			expect(webhookData.webhookOrg).toBe('my-org');
+		});
+
+		it('should throw org-specific message when org is not found (404)', async () => {
+			mockThis.getNodeParameter = jest.fn().mockImplementation((name: string) => {
+				if (name === 'scope') return 'organization';
+				if (name === 'organization') return 'nonexistent-org';
+				if (name === 'events') return ['issues'];
+				if (name === 'options') return { insecureSSL: false };
+				return undefined;
+			});
+
+			jest.spyOn(GenericFunctions, 'githubApiRequest').mockRejectedValue({ httpCode: '404' });
+
+			const trigger = new GithubTrigger();
+
+			await expect(trigger.webhookMethods.default.create.call(mockThis)).rejects.toThrow(
+				NodeOperationError,
+			);
+
+			await expect(trigger.webhookMethods.default.create.call(mockThis)).rejects.toThrow(
+				/Check that the organization exists/,
+			);
+		});
 	});
 
 	describe('delete webhook method', () => {
@@ -140,8 +224,10 @@ describe('GithubTrigger Node', () => {
 			mockThis = {
 				getWorkflowStaticData: () => webhookData,
 				getNodeParameter: jest.fn().mockImplementation((name: string) => {
+					if (name === 'scope') return 'repository';
 					if (name === 'owner') return 'some-owner';
 					if (name === 'repository') return 'some-repo';
+					return undefined;
 				}),
 			};
 		});
@@ -156,6 +242,45 @@ describe('GithubTrigger Node', () => {
 			expect(webhookData.webhookId).toBeUndefined();
 			expect(webhookData.webhookEvents).toBeUndefined();
 			expect(webhookData.webhookSecret).toBeUndefined();
+		});
+
+		it('should use org endpoint when webhookScope is organization', async () => {
+			webhookData.webhookScope = 'organization';
+			webhookData.webhookOrg = 'my-org';
+
+			const apiRequestSpy = jest
+				.spyOn(GenericFunctions, 'githubApiRequest')
+				.mockResolvedValueOnce({});
+
+			const trigger = new GithubTrigger();
+			await trigger.webhookMethods.default.delete.call(mockThis);
+
+			expect(apiRequestSpy).toHaveBeenCalledWith(
+				'DELETE',
+				'/orgs/my-org/hooks/123456',
+				{},
+			);
+			expect(webhookData.webhookId).toBeUndefined();
+			expect(webhookData.webhookScope).toBeUndefined();
+			expect(webhookData.webhookOrg).toBeUndefined();
+		});
+	});
+
+	describe('node description', () => {
+		it('should have scope and organization parameters when scope is organization', () => {
+			const trigger = new GithubTrigger();
+			const scopeParam = trigger.description.properties.find((p) => p.name === 'scope');
+			const orgParam = trigger.description.properties.find((p) => p.name === 'organization');
+
+			expect(scopeParam).toBeDefined();
+			expect(scopeParam?.options).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ value: 'repository' }),
+					expect.objectContaining({ value: 'organization' }),
+				]),
+			);
+			expect(orgParam).toBeDefined();
+			expect(orgParam?.displayOptions?.show).toEqual({ scope: ['organization'] });
 		});
 	});
 


### PR DESCRIPTION
## Summary

Add support for **organization-level webhooks** in the GitHub Trigger node. Users can receive events from all repositories in an organization (issues, PRs, etc.) with a single webhook instead of configuring one per repository.

### What's New

**Source Option**
- New **Source** parameter with two options: **Repository** (default) or **Organization**
- **Repository**: Existing behavior – receive events from a single repository
- **Organization**: Receive events from all repositories in the selected organization

**Organization Selector**
- Organization resource locator with three modes:
  - **List**: Search and select from organizations the user belongs to (via `GET /user/orgs`)
  - **Link**: Paste organization URL (e.g. `https://github.com/n8n-io`)
  - **By Name**: Enter organization name (e.g. `n8n-io`)

**Webhook Lifecycle**
- Uses GitHub organization webhooks API (`POST /orgs/{org}/hooks`) when scope is Organization
- Stores `webhookScope`, `webhookOrg`, `webhookOwner`, `webhookRepo` in workflow static data so check/delete work correctly after reactivation

**Permissions**
- **Repository**: Admin access to the repository (unchanged)
- **Organization**: Organization owner privileges, or OAuth token with `admin:org_hook` scope

### How to Test

1. Add a GitHub Trigger node to a workflow
2. Set **Source** to **Organization**
3. Select an organization you have owner access to
4. Choose events (e.g. Issues, Pull Request)
5. Activate the workflow and verify the org webhook is created.
6. Trigger an event (e.g. open an issue) in any repo in the org and confirm the workflow runs

### Files Changed

- `GithubTrigger.node.ts` – scope parameter, organization selector, org webhook handling
- `SearchFunctions.ts` – `getOrganizations` for org list search
- `GithubTrigger.node.test.ts` – tests for org webhook create, checkExists, delete
- `SearchFunctions.test.ts` – tests for `getOrganizations`
- `UrlPatterns.test.ts` – organization URL pattern tests

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
