### PR TITLE
feat(core): Track dynamic credential resolution per node execution in ITaskData

### DIFF
--- a/packages/cli/src/__tests__/credentials-helper.test.ts
+++ b/packages/cli/src/__tests__/credentials-helper.test.ts
@@ -621,7 +621,7 @@ describe('CredentialsHelper', () => {
 			const resolvedData = { apiKey: 'dynamic-key' };
 			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue({
 				data: resolvedData,
-				wasDynamic: true,
+				isDynamic: true,
 			});
 			credentialsRepository.findOneByOrFail.mockResolvedValue(mockCredentialEntity);
 
@@ -655,7 +655,7 @@ describe('CredentialsHelper', () => {
 			dynamicCredentialProxy.setResolverProvider(mockCredentialResolutionProvider);
 			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue({
 				data: { apiKey: 'resolved' },
-				wasDynamic: false,
+				isDynamic: false,
 			});
 
 			await credentialsHelper.getDecrypted(
@@ -676,7 +676,7 @@ describe('CredentialsHelper', () => {
 			dynamicCredentialProxy.setResolverProvider(mockCredentialResolutionProvider);
 			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue({
 				data: { apiKey: 'resolved' },
-				wasDynamic: false,
+				isDynamic: false,
 			});
 
 			await credentialsHelper.getDecrypted(
@@ -724,7 +724,7 @@ describe('CredentialsHelper', () => {
 			const dynamicData = { apiKey: 'dynamic-key', extraField: 'extra-value' };
 			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue({
 				data: dynamicData,
-				wasDynamic: true,
+				isDynamic: true,
 			});
 
 			const result = await credentialsHelper.getDecrypted(
@@ -744,7 +744,7 @@ describe('CredentialsHelper', () => {
 			dynamicCredentialProxy.setResolverProvider(mockCredentialResolutionProvider);
 			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue({
 				data: { apiKey: 'resolved' },
-				wasDynamic: false,
+				isDynamic: false,
 			});
 
 			const additionalDataWithoutContext = {
@@ -769,7 +769,7 @@ describe('CredentialsHelper', () => {
 			dynamicCredentialProxy.setResolverProvider(mockCredentialResolutionProvider);
 			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue({
 				data: { apiKey: 'resolved' },
-				wasDynamic: false,
+				isDynamic: false,
 			});
 
 			const additionalDataWithoutCredentials = {
@@ -801,7 +801,7 @@ describe('CredentialsHelper', () => {
 			dynamicCredentialProxy.setResolverProvider(mockCredentialResolutionProvider);
 			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue({
 				data: { apiKey: 'resolved' },
-				wasDynamic: false,
+				isDynamic: false,
 			});
 
 			const additionalDataWithoutSettings = {

--- a/packages/cli/src/__tests__/credentials-helper.test.ts
+++ b/packages/cli/src/__tests__/credentials-helper.test.ts
@@ -619,7 +619,10 @@ describe('CredentialsHelper', () => {
 			dynamicCredentialProxy.setResolverProvider(mockCredentialResolutionProvider);
 
 			const resolvedData = { apiKey: 'dynamic-key' };
-			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue(resolvedData);
+			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue({
+				data: resolvedData,
+				wasDynamic: true,
+			});
 			credentialsRepository.findOneByOrFail.mockResolvedValue(mockCredentialEntity);
 
 			const result = await credentialsHelper.getDecrypted(
@@ -650,7 +653,10 @@ describe('CredentialsHelper', () => {
 
 		test('should pass executionContext from additionalData to resolver', async () => {
 			dynamicCredentialProxy.setResolverProvider(mockCredentialResolutionProvider);
-			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue({ apiKey: 'resolved' });
+			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue({
+				data: { apiKey: 'resolved' },
+				wasDynamic: false,
+			});
 
 			await credentialsHelper.getDecrypted(
 				mockAdditionalData,
@@ -668,7 +674,10 @@ describe('CredentialsHelper', () => {
 
 		test('should pass workflowSettings from additionalData to resolver', async () => {
 			dynamicCredentialProxy.setResolverProvider(mockCredentialResolutionProvider);
-			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue({ apiKey: 'resolved' });
+			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue({
+				data: { apiKey: 'resolved' },
+				wasDynamic: false,
+			});
 
 			await credentialsHelper.getDecrypted(
 				mockAdditionalData,
@@ -713,7 +722,10 @@ describe('CredentialsHelper', () => {
 			dynamicCredentialProxy.setResolverProvider(mockCredentialResolutionProvider);
 
 			const dynamicData = { apiKey: 'dynamic-key', extraField: 'extra-value' };
-			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue(dynamicData);
+			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue({
+				data: dynamicData,
+				wasDynamic: true,
+			});
 
 			const result = await credentialsHelper.getDecrypted(
 				mockAdditionalData,
@@ -730,7 +742,10 @@ describe('CredentialsHelper', () => {
 
 		test('should skip resolution when executionContext is missing', async () => {
 			dynamicCredentialProxy.setResolverProvider(mockCredentialResolutionProvider);
-			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue({ apiKey: 'resolved' });
+			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue({
+				data: { apiKey: 'resolved' },
+				wasDynamic: false,
+			});
 
 			const additionalDataWithoutContext = {
 				...mockAdditionalData,
@@ -752,7 +767,10 @@ describe('CredentialsHelper', () => {
 
 		test('should skip resolution when credentials context is missing', async () => {
 			dynamicCredentialProxy.setResolverProvider(mockCredentialResolutionProvider);
-			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue({ apiKey: 'resolved' });
+			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue({
+				data: { apiKey: 'resolved' },
+				wasDynamic: false,
+			});
 
 			const additionalDataWithoutCredentials = {
 				...mockAdditionalData,
@@ -781,7 +799,10 @@ describe('CredentialsHelper', () => {
 
 		test('should handle missing workflowSettings gracefully', async () => {
 			dynamicCredentialProxy.setResolverProvider(mockCredentialResolutionProvider);
-			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue({ apiKey: 'resolved' });
+			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue({
+				data: { apiKey: 'resolved' },
+				wasDynamic: false,
+			});
 
 			const additionalDataWithoutSettings = {
 				...mockAdditionalData,

--- a/packages/cli/src/credentials-helper.ts
+++ b/packages/cli/src/credentials-helper.ts
@@ -367,7 +367,7 @@ export class CredentialsHelper extends ICredentialsHelper {
 		 */
 		if (additionalData.executionContext?.credentials !== undefined) {
 			// Resolve dynamic credentials if configured (EE feature)
-			decryptedDataOriginal = await this.dynamicCredentialsProxy.resolveIfNeeded(
+			const resolveResult = await this.dynamicCredentialsProxy.resolveIfNeeded(
 				{
 					id: credentialsEntity.id,
 					name: credentialsEntity.name,
@@ -381,6 +381,10 @@ export class CredentialsHelper extends ICredentialsHelper {
 				additionalData.workflowSettings,
 				canUseExternalSecrets,
 			);
+			decryptedDataOriginal = resolveResult.data;
+			if (resolveResult.wasDynamic) {
+				additionalData.currentNodeUsedDynamicCredentials = true;
+			}
 		}
 
 		if (raw === true) {

--- a/packages/cli/src/credentials-helper.ts
+++ b/packages/cli/src/credentials-helper.ts
@@ -382,7 +382,7 @@ export class CredentialsHelper extends ICredentialsHelper {
 				canUseExternalSecrets,
 			);
 			decryptedDataOriginal = resolveResult.data;
-			if (resolveResult.wasDynamic) {
+			if (resolveResult.isDynamic) {
 				additionalData.currentNodeUsedDynamicCredentials = true;
 			}
 		}

--- a/packages/cli/src/credentials/__tests__/dynamic-credentials-proxy.test.ts
+++ b/packages/cli/src/credentials/__tests__/dynamic-credentials-proxy.test.ts
@@ -7,6 +7,7 @@ import type {
 } from 'n8n-workflow';
 
 import type {
+	CredentialResolutionResult,
 	CredentialResolveMetadata,
 	ICredentialResolutionProvider,
 } from '../credential-resolution-provider.interface';
@@ -53,7 +54,7 @@ describe('DynamicCredentialsProxy', () => {
 		it('should return static data when no provider is set and credential is not resolvable', async () => {
 			const result = await proxy.resolveIfNeeded(credentialMetadata, staticData);
 
-			expect(result).toBe(staticData);
+			expect(result).toEqual({ data: staticData, wasDynamic: false });
 			expect(mockLogger.warn).not.toHaveBeenCalled();
 		});
 
@@ -70,14 +71,17 @@ describe('DynamicCredentialsProxy', () => {
 		});
 
 		it('should delegate to provider when set', async () => {
-			const dynamicData = { token: 'dynamic-token' };
-			mockResolverProvider.resolveIfNeeded.mockResolvedValue(dynamicData);
+			const dynamicResult: CredentialResolutionResult = {
+				data: { token: 'dynamic-token' },
+				wasDynamic: true,
+			};
+			mockResolverProvider.resolveIfNeeded.mockResolvedValue(dynamicResult);
 
 			proxy.setResolverProvider(mockResolverProvider);
 
 			const result = await proxy.resolveIfNeeded(credentialMetadata, staticData);
 
-			expect(result).toBe(dynamicData);
+			expect(result).toBe(dynamicResult);
 			expect(mockResolverProvider.resolveIfNeeded).toHaveBeenCalledWith(
 				credentialMetadata,
 				staticData,
@@ -98,7 +102,10 @@ describe('DynamicCredentialsProxy', () => {
 			};
 			const canUseExternalSecrets = true;
 
-			mockResolverProvider.resolveIfNeeded.mockResolvedValue(staticData);
+			mockResolverProvider.resolveIfNeeded.mockResolvedValue({
+				data: staticData,
+				wasDynamic: false,
+			});
 			proxy.setResolverProvider(mockResolverProvider);
 
 			await proxy.resolveIfNeeded(

--- a/packages/cli/src/credentials/__tests__/dynamic-credentials-proxy.test.ts
+++ b/packages/cli/src/credentials/__tests__/dynamic-credentials-proxy.test.ts
@@ -54,7 +54,7 @@ describe('DynamicCredentialsProxy', () => {
 		it('should return static data when no provider is set and credential is not resolvable', async () => {
 			const result = await proxy.resolveIfNeeded(credentialMetadata, staticData);
 
-			expect(result).toEqual({ data: staticData, wasDynamic: false });
+			expect(result).toEqual({ data: staticData, isDynamic: false });
 			expect(mockLogger.warn).not.toHaveBeenCalled();
 		});
 
@@ -73,7 +73,7 @@ describe('DynamicCredentialsProxy', () => {
 		it('should delegate to provider when set', async () => {
 			const dynamicResult: CredentialResolutionResult = {
 				data: { token: 'dynamic-token' },
-				wasDynamic: true,
+				isDynamic: true,
 			};
 			mockResolverProvider.resolveIfNeeded.mockResolvedValue(dynamicResult);
 
@@ -104,7 +104,7 @@ describe('DynamicCredentialsProxy', () => {
 
 			mockResolverProvider.resolveIfNeeded.mockResolvedValue({
 				data: staticData,
-				wasDynamic: false,
+				isDynamic: false,
 			});
 			proxy.setResolverProvider(mockResolverProvider);
 

--- a/packages/cli/src/credentials/credential-resolution-provider.interface.ts
+++ b/packages/cli/src/credentials/credential-resolution-provider.interface.ts
@@ -14,6 +14,12 @@ export type CredentialResolveMetadata = {
 	isResolvable: boolean;
 };
 
+export type CredentialResolutionResult = {
+	data: ICredentialDataDecryptedObject;
+	/** True only when the credential was actually resolved via a dynamic resolver (not a fallback to static data). */
+	wasDynamic: boolean;
+};
+
 /**
  * Interface for credential resolution providers.
  * Implementations can provide dynamic credential resolution logic.
@@ -27,7 +33,7 @@ export interface ICredentialResolutionProvider {
 	 * @param staticData The decrypted static credential data
 	 * @param additionalData Additional workflow execution data for context and settings
 	 * @param canUseExternalSecrets Whether the credential can use external secrets for expression resolution
-	 * @returns Resolved credential data (either dynamic or static)
+	 * @returns Resolved credential data and a flag indicating whether dynamic resolution occurred
 	 */
 	resolveIfNeeded(
 		credentialsResolveMetadata: CredentialResolveMetadata,
@@ -35,5 +41,5 @@ export interface ICredentialResolutionProvider {
 		executionContext?: IExecutionContext,
 		workflowSettings?: IWorkflowSettings,
 		canUseExternalSecrets?: boolean,
-	): Promise<ICredentialDataDecryptedObject>;
+	): Promise<CredentialResolutionResult>;
 }

--- a/packages/cli/src/credentials/credential-resolution-provider.interface.ts
+++ b/packages/cli/src/credentials/credential-resolution-provider.interface.ts
@@ -17,7 +17,7 @@ export type CredentialResolveMetadata = {
 export type CredentialResolutionResult = {
 	data: ICredentialDataDecryptedObject;
 	/** True only when the credential was actually resolved via a dynamic resolver (not a fallback to static data). */
-	wasDynamic: boolean;
+	isDynamic: boolean;
 };
 
 /**

--- a/packages/cli/src/credentials/dynamic-credentials-proxy.ts
+++ b/packages/cli/src/credentials/dynamic-credentials-proxy.ts
@@ -11,6 +11,7 @@ import type {
 import { toCredentialContext, UnexpectedError } from 'n8n-workflow';
 
 import type {
+	CredentialResolutionResult,
 	CredentialResolveMetadata,
 	ICredentialResolutionProvider,
 } from './credential-resolution-provider.interface';
@@ -42,7 +43,7 @@ export class DynamicCredentialsProxy
 		executionContext?: IExecutionContext,
 		workflowSettings?: IWorkflowSettings,
 		canUseExternalSecrets?: boolean,
-	): Promise<ICredentialDataDecryptedObject> {
+	): Promise<CredentialResolutionResult> {
 		if (!this.resolvingProvider) {
 			if (credentialsResolveMetadata.isResolvable) {
 				this.logger.warn(
@@ -50,7 +51,7 @@ export class DynamicCredentialsProxy
 				);
 				throw new Error('No dynamic credential resolving provider set');
 			}
-			return staticData;
+			return { data: staticData, wasDynamic: false };
 		}
 		return await this.resolvingProvider.resolveIfNeeded(
 			credentialsResolveMetadata,

--- a/packages/cli/src/credentials/dynamic-credentials-proxy.ts
+++ b/packages/cli/src/credentials/dynamic-credentials-proxy.ts
@@ -51,7 +51,7 @@ export class DynamicCredentialsProxy
 				);
 				throw new Error('No dynamic credential resolving provider set');
 			}
-			return { data: staticData, wasDynamic: false };
+			return { data: staticData, isDynamic: false };
 		}
 		return await this.resolvingProvider.resolveIfNeeded(
 			credentialsResolveMetadata,

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -1644,18 +1644,18 @@ describe('TelemetryEventRelay', () => {
 		});
 
 		it('should track successful workflow execution', async () => {
-			const runData = mock<IRun>({
+			const runData = {
 				finished: true,
 				status: 'success',
 				mode: 'manual',
-				data: { resultData: {} },
-			});
+				data: { resultData: { runData: {} } },
+			} as unknown as IRun;
 
 			const event: RelayEventMap['workflow-post-execute'] = {
 				workflow: mockWorkflowBase,
 				executionId: 'execution123',
 				userId: 'user123',
-				runData: runData as unknown as IRun,
+				runData,
 			};
 
 			eventService.emit('workflow-post-execute', event);

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -809,7 +809,9 @@ export class TelemetryEventRelay extends EventRelay {
 			is_manual: false,
 			version_cli: N8N_VERSION,
 			success: false,
-			used_dynamic_credentials: !!runData?.data?.executionData?.runtimeData?.credentials,
+			used_dynamic_credentials: Object.values(runData?.data?.resultData?.runData ?? {}).some(
+				(taskDataList) => taskDataList.some((taskData) => taskData.usedDynamicCredentials),
+			),
 		};
 
 		if (userId) {

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential.service.test.ts
@@ -8,7 +8,10 @@ import type {
 	IExecutionContext,
 } from 'n8n-workflow';
 
-import type { CredentialResolveMetadata } from '@/credentials/credential-resolution-provider.interface';
+import type {
+	CredentialResolutionResult,
+	CredentialResolveMetadata,
+} from '@/credentials/credential-resolution-provider.interface';
 import type { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 import { StaticAuthService } from '@/services/static-auth-service';
 
@@ -215,6 +218,11 @@ describe('DynamicCredentialService', () => {
 			apiKey: 'static-key',
 		};
 
+		const expectStaticResult = (result: CredentialResolutionResult) => {
+			expect(result.data).toBe(staticData);
+			expect(result.wasDynamic).toBe(false);
+		};
+
 		describe('should return static credentials when', () => {
 			it('credential is not resolvable', async () => {
 				const credentialsEntity = createMockCredentialsMetadata({
@@ -223,7 +231,7 @@ describe('DynamicCredentialService', () => {
 
 				const result = await service.resolveIfNeeded(credentialsEntity, staticData, undefined);
 
-				expect(result).toBe(staticData);
+				expectStaticResult(result);
 				expect(mockResolverRepository.findOneBy).not.toHaveBeenCalled();
 			});
 
@@ -236,7 +244,7 @@ describe('DynamicCredentialService', () => {
 
 				const result = await service.resolveIfNeeded(credentialsEntity, staticData, undefined);
 
-				expect(result).toBe(staticData);
+				expectStaticResult(result);
 				expect(mockLogger.debug).toHaveBeenCalledWith(
 					'Resolver not found, falling back to static credentials',
 					expect.objectContaining({
@@ -257,7 +265,7 @@ describe('DynamicCredentialService', () => {
 
 				const result = await service.resolveIfNeeded(credentialsEntity, staticData, undefined);
 
-				expect(result).toBe(staticData);
+				expectStaticResult(result);
 				expect(mockLogger.debug).toHaveBeenCalled();
 			});
 
@@ -273,7 +281,7 @@ describe('DynamicCredentialService', () => {
 
 				const result = await service.resolveIfNeeded(credentialsEntity, staticData, undefined);
 
-				expect(result).toBe(staticData);
+				expectStaticResult(result);
 				expect(mockLogger.debug).toHaveBeenCalledWith(
 					'No execution context available, falling back to static credentials',
 					expect.objectContaining({
@@ -304,7 +312,7 @@ describe('DynamicCredentialService', () => {
 					undefined,
 				);
 
-				expect(result).toBe(staticData);
+				expectStaticResult(result);
 				expect(mockLogger.error).toHaveBeenCalledWith(
 					'Failed to decrypt credential context from execution context',
 					expect.any(Object),
@@ -334,7 +342,7 @@ describe('DynamicCredentialService', () => {
 					undefined,
 				);
 
-				expect(result).toBe(staticData);
+				expectStaticResult(result);
 				expect(mockLogger.debug).toHaveBeenCalledWith(
 					'Dynamic credential resolution failed, falling back to static',
 					expect.objectContaining({
@@ -368,7 +376,7 @@ describe('DynamicCredentialService', () => {
 					undefined,
 				);
 
-				expect(result).toBe(staticData);
+				expectStaticResult(result);
 				expect(mockLogger.debug).toHaveBeenCalledWith(
 					'Dynamic credential resolution failed, falling back to static',
 					expect.objectContaining({
@@ -543,7 +551,8 @@ describe('DynamicCredentialService', () => {
 				);
 
 				// Verify merge: static fields preserved, dynamic fields added/overridden
-				expect(result).toEqual({
+				expect(result.wasDynamic).toBe(true);
+				expect(result.data).toEqual({
 					clientId: 'static-client-id', // From static (preserved)
 					clientSecret: 'static-client-secret', // From static (preserved)
 					token: 'dynamic-token', // From dynamic (overridden)
@@ -664,7 +673,7 @@ describe('DynamicCredentialService', () => {
 					undefined,
 				);
 
-				expect(result).toBe(staticData);
+				expectStaticResult(result);
 				expect(mockCipher.decrypt).not.toHaveBeenCalled();
 			});
 
@@ -688,7 +697,7 @@ describe('DynamicCredentialService', () => {
 					undefined,
 				);
 
-				expect(result).toBe(staticData);
+				expectStaticResult(result);
 				expect(mockLogger.debug).toHaveBeenCalled();
 			});
 
@@ -757,7 +766,8 @@ describe('DynamicCredentialService', () => {
 				expect(mockResolverRepository.findOneBy).toHaveBeenCalledWith({
 					id: 'workflow-resolver-789',
 				});
-				expect(result).toEqual({ token: 'dynamic-token', apiKey: 'dynamic-key' });
+				expect(result.wasDynamic).toBe(true);
+				expect(result.data).toEqual({ token: 'dynamic-token', apiKey: 'dynamic-key' });
 				expect(mockLogger.debug).toHaveBeenCalledWith(
 					'Successfully resolved dynamic credentials',
 					expect.objectContaining({
@@ -800,7 +810,8 @@ describe('DynamicCredentialService', () => {
 				expect(mockResolverRepository.findOneBy).toHaveBeenCalledWith({
 					id: 'credential-resolver-456',
 				});
-				expect(result).toEqual({ token: 'dynamic-token', apiKey: 'dynamic-key' });
+				expect(result.wasDynamic).toBe(true);
+				expect(result.data).toEqual({ token: 'dynamic-token', apiKey: 'dynamic-key' });
 				expect(mockLogger.debug).toHaveBeenCalledWith(
 					'Successfully resolved dynamic credentials',
 					expect.objectContaining({
@@ -832,7 +843,7 @@ describe('DynamicCredentialService', () => {
 					additionalData.workflowSettings,
 				);
 
-				expect(result).toBe(staticData);
+				expectStaticResult(result);
 				expect(mockLogger.debug).toHaveBeenCalledWith(
 					'Resolver not found, falling back to static credentials',
 					expect.objectContaining({

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential.service.test.ts
@@ -220,7 +220,7 @@ describe('DynamicCredentialService', () => {
 
 		const expectStaticResult = (result: CredentialResolutionResult) => {
 			expect(result.data).toBe(staticData);
-			expect(result.wasDynamic).toBe(false);
+			expect(result.isDynamic).toBe(false);
 		};
 
 		describe('should return static credentials when', () => {
@@ -551,7 +551,7 @@ describe('DynamicCredentialService', () => {
 				);
 
 				// Verify merge: static fields preserved, dynamic fields added/overridden
-				expect(result.wasDynamic).toBe(true);
+				expect(result.isDynamic).toBe(true);
 				expect(result.data).toEqual({
 					clientId: 'static-client-id', // From static (preserved)
 					clientSecret: 'static-client-secret', // From static (preserved)
@@ -766,7 +766,7 @@ describe('DynamicCredentialService', () => {
 				expect(mockResolverRepository.findOneBy).toHaveBeenCalledWith({
 					id: 'workflow-resolver-789',
 				});
-				expect(result.wasDynamic).toBe(true);
+				expect(result.isDynamic).toBe(true);
 				expect(result.data).toEqual({ token: 'dynamic-token', apiKey: 'dynamic-key' });
 				expect(mockLogger.debug).toHaveBeenCalledWith(
 					'Successfully resolved dynamic credentials',
@@ -810,7 +810,7 @@ describe('DynamicCredentialService', () => {
 				expect(mockResolverRepository.findOneBy).toHaveBeenCalledWith({
 					id: 'credential-resolver-456',
 				});
-				expect(result.wasDynamic).toBe(true);
+				expect(result.isDynamic).toBe(true);
 				expect(result.data).toEqual({ token: 'dynamic-token', apiKey: 'dynamic-key' });
 				expect(mockLogger.debug).toHaveBeenCalledWith(
 					'Successfully resolved dynamic credentials',

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential.service.ts
@@ -66,7 +66,7 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 
 		// Not resolvable - return static credentials
 		if (!credentialsResolveMetadata.isResolvable) {
-			return { data: staticData, wasDynamic: false };
+			return { data: staticData, isDynamic: false };
 		}
 
 		if (!resolverId) {
@@ -139,7 +139,7 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 			}
 
 			// Adds and override static data with dynamically resolved data
-			return { data: { ...staticData, ...dynamicData }, wasDynamic: true };
+			return { data: { ...staticData, ...dynamicData }, isDynamic: true };
 		} catch (error) {
 			return this.handleResolutionError(credentialsResolveMetadata, staticData, error, resolverId);
 		}
@@ -185,7 +185,7 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 				error: error instanceof Error ? error.message : String(error),
 				isDataNotFound,
 			});
-			return { data: staticData, wasDynamic: false };
+			return { data: staticData, isDynamic: false };
 		}
 
 		this.logger.debug('Dynamic credential resolution failed without fallback', {
@@ -217,7 +217,7 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 				resolverId,
 				resolverSource: credentialsResolveMetadata.resolverId ? 'credential' : 'workflow',
 			});
-			return { data: staticData, wasDynamic: false };
+			return { data: staticData, isDynamic: false };
 		}
 
 		throw new CredentialResolutionError(
@@ -237,7 +237,7 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 				credentialId: credentialsResolveMetadata.id,
 				credentialName: credentialsResolveMetadata.name,
 			});
-			return { data: staticData, wasDynamic: false };
+			return { data: staticData, isDynamic: false };
 		}
 
 		throw new CredentialResolutionError(

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential.service.ts
@@ -17,6 +17,7 @@ import { DynamicCredentialResolverRegistry } from './credential-resolver-registr
 import { ResolverConfigExpressionService } from './resolver-config-expression.service';
 import { extractSharedFields } from './shared-fields';
 import type {
+	CredentialResolutionResult,
 	CredentialResolveMetadata,
 	ICredentialResolutionProvider,
 } from '../../../credentials/credential-resolution-provider.interface';
@@ -58,14 +59,14 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 		executionContext?: IExecutionContext,
 		workflowSettings?: IWorkflowSettings,
 		canUseExternalSecrets?: boolean,
-	): Promise<ICredentialDataDecryptedObject> {
+	): Promise<CredentialResolutionResult> {
 		// Determine which resolver ID to use: credential's own resolver or workflow's fallback
 		const resolverId =
 			credentialsResolveMetadata.resolverId ?? workflowSettings?.credentialResolverId;
 
 		// Not resolvable - return static credentials
 		if (!credentialsResolveMetadata.isResolvable) {
-			return staticData;
+			return { data: staticData, wasDynamic: false };
 		}
 
 		if (!resolverId) {
@@ -138,7 +139,7 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 			}
 
 			// Adds and override static data with dynamically resolved data
-			return { ...staticData, ...dynamicData };
+			return { data: { ...staticData, ...dynamicData }, wasDynamic: true };
 		} catch (error) {
 			return this.handleResolutionError(credentialsResolveMetadata, staticData, error, resolverId);
 		}
@@ -172,7 +173,7 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 		staticData: ICredentialDataDecryptedObject,
 		error: unknown,
 		resolverId: string,
-	): ICredentialDataDecryptedObject {
+	): CredentialResolutionResult {
 		const isDataNotFound = error instanceof CredentialResolverDataNotFoundError;
 
 		if (credentialsResolveMetadata.resolvableAllowFallback) {
@@ -184,7 +185,7 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 				error: error instanceof Error ? error.message : String(error),
 				isDataNotFound,
 			});
-			return staticData;
+			return { data: staticData, wasDynamic: false };
 		}
 
 		this.logger.debug('Dynamic credential resolution failed without fallback', {
@@ -208,7 +209,7 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 		credentialsResolveMetadata: CredentialResolveMetadata,
 		staticData: ICredentialDataDecryptedObject,
 		resolverId?: string,
-	): ICredentialDataDecryptedObject {
+	): CredentialResolutionResult {
 		if (credentialsResolveMetadata.resolvableAllowFallback) {
 			this.logger.debug('Resolver not found, falling back to static credentials', {
 				credentialId: credentialsResolveMetadata.id,
@@ -216,7 +217,7 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 				resolverId,
 				resolverSource: credentialsResolveMetadata.resolverId ? 'credential' : 'workflow',
 			});
-			return staticData;
+			return { data: staticData, wasDynamic: false };
 		}
 
 		throw new CredentialResolutionError(
@@ -230,13 +231,13 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 	private handleMissingContext(
 		credentialsResolveMetadata: CredentialResolveMetadata,
 		staticData: ICredentialDataDecryptedObject,
-	): ICredentialDataDecryptedObject {
+	): CredentialResolutionResult {
 		if (credentialsResolveMetadata.resolvableAllowFallback) {
 			this.logger.debug('No execution context available, falling back to static credentials', {
 				credentialId: credentialsResolveMetadata.id,
 				credentialName: credentialsResolveMetadata.name,
 			});
-			return staticData;
+			return { data: staticData, wasDynamic: false };
 		}
 
 		throw new CredentialResolutionError(

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1509,6 +1509,9 @@ export class WorkflowExecute {
 						this.runExecutionData.executionData!.nodeExecutionStack.shift() as IExecuteData;
 					executionNode = executionData.node;
 
+					// Reset per-node dynamic credential flag before each node execution
+					this.additionalData.currentNodeUsedDynamicCredentials = false;
+
 					const taskStartedData: ITaskStartedData = {
 						startTime: Date.now(),
 						executionIndex: this.additionalData.currentNodeExecutionIndex++,
@@ -1825,6 +1828,8 @@ export class WorkflowExecute {
 						executionTime: Date.now() - taskStartedData.startTime,
 						metadata: executionData.metadata,
 						executionStatus: this.runExecutionData.waitTill ? 'waiting' : 'success',
+						usedDynamicCredentials:
+							this.additionalData.currentNodeUsedDynamicCredentials || undefined,
 					};
 
 					if (executionError !== undefined) {

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2689,6 +2689,8 @@ export interface ITaskData extends ITaskStartedData {
 	inputOverride?: ITaskDataConnections;
 	error?: ExecutionError;
 	metadata?: ITaskMetadata;
+	/** True when at least one credential used by this node was resolved dynamically */
+	usedDynamicCredentials?: boolean;
 }
 
 export interface ISourceData {
@@ -2925,6 +2927,11 @@ export interface IWorkflowExecuteAdditionalData {
 	): Promise<Result<T, E>>;
 	getRunnerStatus?(taskType: string): { available: true } | { available: false; reason?: string };
 	validateCookieAuth?: (cookieValue: string) => Promise<void>;
+	/**
+	 * Mutable flag set to true during a node's execution if any credential was resolved
+	 * dynamically. Reset to false by the execution engine before each node runs.
+	 */
+	currentNodeUsedDynamicCredentials?: boolean;
 }
 
 export type WorkflowActivateMode =


### PR DESCRIPTION
## Summary

Track when a node's credential was resolved dynamically (via the EE dynamic credentials module) by adding an optional `usedDynamicCredentials` flag to `ITaskData`.

### How it works

During workflow execution, `CredentialsHelper.getDecrypted()` calls `DynamicCredentialsProxy.resolveIfNeeded()`, which delegates to `DynamicCredentialService.resolveIfNeeded()`. Previously, that call returned the raw decrypted credential object, making it impossible to tell whether a _real_ dynamic resolution occurred (i.e. `resolver.getSecret()` succeeded) vs. a fallback to static data.

This PR introduces a `{ data, wasDynamic }` result type throughout the resolution chain so the flag can propagate upward cleanly:

1. **`CredentialResolutionResult`** — new return type for `ICredentialResolutionProvider.resolveIfNeeded()` carrying both the data and a `wasDynamic: boolean`. Only the successful `resolver.getSecret()` path in `DynamicCredentialService` sets `wasDynamic: true`; all fallback/non-resolvable paths return `false`.

2. **`additionalData` side-channel** — `IWorkflowExecuteAdditionalData` gets a new optional `currentNodeUsedDynamicCredentials` field. `CredentialsHelper` writes `true` to it when `wasDynamic` is set; `WorkflowExecute` resets it to `false` before each node and reads it when building `ITaskData`.

3. **`ITaskData.usedDynamicCredentials`** — the per-node-run flag stored in execution run data. Absent (i.e. `undefined`) when no dynamic resolution occurred, keeping serialised payloads lean.

### Changes

| Package | File | Change |
|---|---|---|
| `workflow` | `interfaces.ts` | Add `usedDynamicCredentials?` to `ITaskData`; add `currentNodeUsedDynamicCredentials?` to `IWorkflowExecuteAdditionalData` |
| `cli` | `credential-resolution-provider.interface.ts` | Add `CredentialResolutionResult` type; update `resolveIfNeeded()` return type |
| `cli` | `dynamic-credentials-proxy.ts` | Propagate new return type through proxy |
| `cli` | `dynamic-credential.service.ts` | Return `wasDynamic: true` only on successful `getSecret()` |
| `cli` | `credentials-helper.ts` | Capture `wasDynamic`, write to `additionalData` |
| `core` | `workflow-execute.ts` | Reset flag before node; write to `ITaskData` |

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/IAM-308/check-validity-of-dynamic-cred-metrics

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)