### PR TITLE
fix(webhook): return 401 instead of 403 for invalid basic auth

### DIFF
--- a/packages/nodes-base/nodes/Webhook/utils.ts
+++ b/packages/nodes-base/nodes/Webhook/utils.ts
@@ -276,7 +276,7 @@ export async function validateWebhookAuthentication(
 			providedAuth.pass !== expectedAuth.password
 		) {
 			// Provided authentication data is wrong
-			throw new WebhookAuthorizationError(403);
+			throw new WebhookAuthorizationError(401);
 		}
 	} else if (authentication === 'bearerAuth') {
 		let expectedAuth: ICredentialDataDecryptedObject | undefined;


### PR DESCRIPTION
## Summary
This PR corrects the incorrect RFC 7235 for standard basic auth workflows.
Changes return status to 401 from 403 for incorrect passwords in webhooks.
The below image shows the corrected response status with header WWW-Authenticate
<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
<img width="926" height="302" alt="image" src="https://github.com/user-attachments/assets/a9cf57fb-5034-46c6-bed6-c73f230688bf" />

## Related Linear tickets, Github issues, and Community forum posts
solves #26365
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
