### PR TITLE
fix(store): improve WebSocket client ID on tab reload and duplication

### DIFF
--- a/packages/frontend/@n8n/stores/src/__tests__/useRootStore.test.ts
+++ b/packages/frontend/@n8n/stores/src/__tests__/useRootStore.test.ts
@@ -1,0 +1,134 @@
+import { randomString } from 'n8n-workflow';
+import { createPinia, setActivePinia } from 'pinia';
+
+import { useRootStore } from '../useRootStore';
+
+vi.mock('n8n-workflow', () => ({
+	randomString: vi.fn(() => 'DEFAULTMOCK'),
+	setGlobalState: vi.fn(),
+}));
+
+vi.mock('../metaTagConfig', () => ({
+	getConfigFromMetaTag: vi.fn(() => null),
+}));
+
+function mockNavigationType(type: 'navigate' | 'reload' | 'back_forward' | 'prerender') {
+	vi.spyOn(performance, 'getEntriesByType').mockReturnValue([
+		{ type } as unknown as PerformanceEntry,
+	]);
+}
+
+describe('useRootStore - pushRef', () => {
+	beforeEach(() => {
+		sessionStorage.clear();
+		vi.mocked(randomString).mockReturnValue('NEWRANDOMID');
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('should generate a new pushRef on initial navigation', () => {
+		mockNavigationType('navigate');
+		setActivePinia(createPinia());
+
+		const store = useRootStore();
+
+		expect(store.pushRef).toBe('newrandomid');
+		expect(randomString).toHaveBeenCalledWith(10);
+	});
+
+	it('should store the generated pushRef in sessionStorage', () => {
+		mockNavigationType('navigate');
+		setActivePinia(createPinia());
+
+		useRootStore();
+
+		expect(sessionStorage.getItem('n8n-client-id')).toBe('newrandomid');
+	});
+
+	it('should reuse the existing pushRef from sessionStorage on page reload', () => {
+		sessionStorage.setItem('n8n-client-id', 'existing-push-ref');
+		mockNavigationType('reload');
+		setActivePinia(createPinia());
+
+		const store = useRootStore();
+
+		expect(store.pushRef).toBe('existing-push-ref');
+		expect(randomString).not.toHaveBeenCalled();
+	});
+
+	it('should generate a new pushRef when tab is duplicated (cloned sessionStorage)', () => {
+		sessionStorage.setItem('n8n-client-id', 'original-tab-id');
+		mockNavigationType('navigate');
+		setActivePinia(createPinia());
+
+		const store = useRootStore();
+
+		expect(store.pushRef).toBe('newrandomid');
+		expect(store.pushRef).not.toBe('original-tab-id');
+		expect(randomString).toHaveBeenCalledWith(10);
+	});
+
+	it('should generate a new pushRef on reload if sessionStorage is empty', () => {
+		mockNavigationType('reload');
+		setActivePinia(createPinia());
+
+		const store = useRootStore();
+
+		expect(store.pushRef).toBe('newrandomid');
+		expect(randomString).toHaveBeenCalledWith(10);
+	});
+
+	it('should produce a lowercase pushRef', () => {
+		vi.mocked(randomString).mockReturnValue('UPPER_Case_123');
+		mockNavigationType('navigate');
+		setActivePinia(createPinia());
+
+		const store = useRootStore();
+
+		expect(store.pushRef).toBe('upper_case_123');
+	});
+
+	it('should overwrite sessionStorage when generating a new pushRef on tab duplication', () => {
+		sessionStorage.setItem('n8n-client-id', 'old-cloned-id');
+		mockNavigationType('navigate');
+		setActivePinia(createPinia());
+
+		useRootStore();
+
+		expect(sessionStorage.getItem('n8n-client-id')).toBe('newrandomid');
+	});
+
+	it('should generate different pushRefs for duplicated tabs', () => {
+		let callCount = 0;
+		vi.mocked(randomString).mockImplementation(() => {
+			callCount++;
+			return `RANDOM${callCount}`;
+		});
+
+		mockNavigationType('navigate');
+
+		setActivePinia(createPinia());
+		const firstPushRef = useRootStore().pushRef;
+
+		// Simulates a duplicated tab: same sessionStorage, fresh JS context, 'navigate' type
+		setActivePinia(createPinia());
+		const secondPushRef = useRootStore().pushRef;
+
+		expect(firstPushRef).toBe('random1');
+		expect(secondPushRef).toBe('random2');
+		expect(firstPushRef).not.toBe(secondPushRef);
+	});
+
+	it('should handle missing navigation timing entry gracefully', () => {
+		vi.spyOn(performance, 'getEntriesByType').mockReturnValue([]);
+		sessionStorage.setItem('n8n-client-id', 'stale-id');
+		setActivePinia(createPinia());
+
+		const store = useRootStore();
+
+		expect(store.pushRef).toBe('newrandomid');
+		expect(randomString).toHaveBeenCalledWith(10);
+	});
+});

--- a/packages/frontend/@n8n/stores/src/useRootStore.ts
+++ b/packages/frontend/@n8n/stores/src/useRootStore.ts
@@ -35,13 +35,26 @@ export type RootStoreState = {
 };
 
 export const useRootStore = defineStore(STORES.ROOT, () => {
-	// Generate or retrieve client ID from sessionStorage
+	/**
+	 * Returns a unique client ID for this tab. On page reload, reuses the
+	 * existing ID so in-flight execution push messages keep arriving. On tab
+	 * duplication (or any other fresh navigation) a new ID is generated to
+	 * prevent two tabs from sharing the same WebSocket pushRef.
+	 */
 	const getClientId = (): string => {
 		const storageKey = 'n8n-client-id';
-		const existingId = sessionStorage.getItem(storageKey);
-		if (existingId) {
-			return existingId;
+
+		const navEntry = performance.getEntriesByType('navigation')[0] as
+			| PerformanceNavigationTiming
+			| undefined;
+
+		if (navEntry?.type === 'reload') {
+			const existingId = sessionStorage.getItem(storageKey);
+			if (existingId) {
+				return existingId;
+			}
 		}
+
 		const newId = randomString(10).toLowerCase();
 		sessionStorage.setItem(storageKey, newId);
 		return newId;


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
## Problem

1. Each browser tab needs a unique `clientId` to maintain its own WebSocket
   connection with the n8n backend, so execution push messages are routed to
   the correct tab.
2. Tab duplication copies `sessionStorage`, meaning the duplicated tab inherits
   the same `n8n-client-id` as the original. Both tabs then share one
   `clientId`, causing push messages to be misrouted between them.
3. Page reload must reuse the existing `clientId`, otherwise in-flight
   execution messages from the backend — already addressed to the old ID —
   are lost.
4. The old code unconditionally reused the stored ID, making it impossible to
   tell a reload (reuse needed) from a duplication (new ID needed).

## Fix

Detect navigation type using
`performance.getEntriesByType('navigation')[0].type`:

- `"reload"` → reuse the stored ID (keeps push messages alive)
- anything else → generate a new ID (breaks the shared-ID problem on
  duplication)

## Result

| Scenario       | Before              | After       |
| -------------- | ------------------- | ----------- |
| First visit    | New ID ✅           | New ID ✅   |
| Page reload    | Reuse ID ✅         | Reuse ID ✅ |
| Tab duplication | Reuse ID (conflict) ❌ | New ID ✅ |


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
https://github.com/n8n-io/n8n/issues/26369
fixes #<26369>

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
