### PR TITLE
fix: prioritize WEBHOOK_URL over N8N_EDITOR_BASE_URL for webhook URL …

### DIFF
--- a/packages/frontend/@n8n/stores/src/useRootStore.ts
+++ b/packages/frontend/@n8n/stores/src/useRootStore.ts
@@ -80,25 +80,25 @@ export const useRootStore = defineStore(STORES.ROOT, () => {
 
 	const formUrl = computed(() => `${state.value.urlBaseWebhook}${state.value.endpointForm}`);
 
-	const formTestUrl = computed(() => `${state.value.urlBaseEditor}${state.value.endpointFormTest}`);
+	const formTestUrl = computed(() => `${state.value.urlBaseWebhook}${state.value.endpointFormTest}`);
 
 	const formWaitingUrl = computed(
-		() => `${state.value.urlBaseEditor}${state.value.endpointFormWaiting}`,
+		() => `${state.value.urlBaseWebhook}${state.value.endpointFormWaiting}`,
 	);
 
 	const webhookUrl = computed(() => `${state.value.urlBaseWebhook}${state.value.endpointWebhook}`);
 
 	const webhookTestUrl = computed(
-		() => `${state.value.urlBaseEditor}${state.value.endpointWebhookTest}`,
+		() => `${state.value.urlBaseWebhook}${state.value.endpointWebhookTest}`,
 	);
 
 	const webhookWaitingUrl = computed(
-		() => `${state.value.urlBaseEditor}${state.value.endpointWebhookWaiting}`,
+		() => `${state.value.urlBaseWebhook}${state.value.endpointWebhookWaiting}`,
 	);
 
 	const mcpUrl = computed(() => `${state.value.urlBaseWebhook}${state.value.endpointMcp}`);
 
-	const mcpTestUrl = computed(() => `${state.value.urlBaseEditor}${state.value.endpointMcpTest}`);
+	const mcpTestUrl = computed(() => `${state.value.urlBaseWebhook}${state.value.endpointMcpTest}`);
 
 	const pushRef = computed(() => state.value.pushRef);
 


### PR DESCRIPTION
## Summary
Fixes #26385

When both `WEBHOOK_URL` and `N8N_EDITOR_BASE_URL` are set to distinct URLs, test webhook URLs in the editor UI incorrectly use `N8N_EDITOR_BASE_URL` instead of `WEBHOOK_URL`.

## Changes
Changed 5 computed URL properties in `packages/frontend/@n8n/stores/src/useRootStore.ts` from `urlBaseEditor` → `urlBaseWebhook`:
- `formTestUrl`, `formWaitingUrl`, `webhookTestUrl`, `webhookWaitingUrl`, `mcpTestUrl`

## How to Test
1. Set `WEBHOOK_URL=https://webhooks.example.com` and `N8N_EDITOR_BASE_URL=https://editor.example.com`
2. Start n8n, create a workflow with a Webhook node
3. Both TEST and PRODUCTION URLs should now use `webhooks.example.com`
