### PR TITLE
Fix Custom Cron Expression Hint

### DIFF
--- a/packages/nodes-base/nodes/Schedule/ScheduleTrigger.node.ts
+++ b/packages/nodes-base/nodes/Schedule/ScheduleTrigger.node.ts
@@ -415,7 +415,7 @@ export class ScheduleTrigger implements INodeType {
 										field: ['cronExpression'],
 									},
 								},
-								hint: 'Format: [Second] [Minute] [Hour] [Day of Month] [Month] [Day of Week]',
+								hint: 'Format: [Minute] [Hour] [Day of Month] [Month] [Day of Week]',
 							},
 						],
 					},


### PR DESCRIPTION
## Summary

This PR fixes the hint of the "Expression" field shown when you enter a "Custom (Cron)" trigger interval in the Schedule Trigger node.

Cron expressions don't allow specifying seconds. See e.g. https://crontab.guru/.

## Related Linear tickets, Github issues, and Community forum posts

None


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
