### PR TITLE
refactor(editor): Migrate `settings` to normalized workflow document state (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.vue
@@ -257,7 +257,10 @@ function hideGithubButton() {
 }
 
 async function onWorkflowDeactivated() {
-	if (settingsStore.isModuleActive('mcp') && workflow.value.settings?.availableInMCP) {
+	if (
+		settingsStore.isModuleActive('mcp') &&
+		workflowDocumentStore?.value?.settings?.availableInMCP
+	) {
 		try {
 			// Fetch the updated workflow to get the latest settings after backend processing
 			const updatedWorkflow = await workflowsListStore.fetchWorkflow(workflow.value.id);

--- a/packages/frontend/editor-ui/src/app/components/WorkflowSettings.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowSettings.test.ts
@@ -743,6 +743,10 @@ describe('WorkflowSettingsVue', () => {
 			const { getByRole } = createComponent({ pinia });
 			await nextTick();
 
+			await waitFor(() => {
+				expect(workflowsListStore.fetchWorkflow).toHaveBeenCalled();
+			});
+
 			await userEvent.click(getByRole('button', { name: 'Save' }));
 
 			const callArgs = workflowsStore.updateWorkflow.mock.calls[0];

--- a/packages/frontend/editor-ui/src/app/components/WorkflowSettings.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowSettings.test.ts
@@ -16,6 +16,10 @@ import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/
 import * as restApiClient from '@n8n/rest-api-client';
 import { mock } from 'vitest-mock-extended';
 import { BINARY_MODE_COMBINED } from 'n8n-workflow';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 
 const toast = {
 	showMessage: vi.fn(),
@@ -56,6 +60,7 @@ let sourceControlStore: MockedStore<typeof useSourceControlStore>;
 let pinia: ReturnType<typeof createTestingPinia>;
 
 let searchWorkflowsSpy: MockInstance<(typeof workflowsListStore)['searchWorkflows']>;
+let workflowDocumentStore: ReturnType<typeof useWorkflowDocumentStore>;
 
 const createComponent = createComponentRenderer(WorkflowSettingsVue, {
 	global: {
@@ -70,11 +75,19 @@ const createComponent = createComponentRenderer(WorkflowSettingsVue, {
 
 describe('WorkflowSettingsVue', () => {
 	beforeEach(async () => {
-		pinia = createTestingPinia();
+		pinia = createTestingPinia({ stubActions: false });
 		workflowsStore = mockedStore(useWorkflowsStore);
 		workflowsListStore = mockedStore(useWorkflowsListStore);
 		settingsStore = mockedStore(useSettingsStore);
 		sourceControlStore = mockedStore(useSourceControlStore);
+
+		// Mock specific store actions that tests assert on
+		workflowsStore.updateWorkflow = vi.fn();
+		workflowsListStore.fetchWorkflow = vi.fn();
+
+		// Create document store on the main pinia (same one the component uses).
+		// With stubActions: false, setSettings and getSettingsSnapshot work normally.
+		workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId('1'));
 
 		settingsStore.settings = mock<FrontendSettings>({
 			enterprise: {},
@@ -161,9 +174,9 @@ describe('WorkflowSettingsVue', () => {
 		});
 
 		it('should initialize undefined errorWorkflow to DEFAULT', async () => {
-			workflowsStore.workflowSettings = {
+			workflowDocumentStore.setSettings({
 				executionOrder: 'v1',
-			};
+			});
 
 			const { getByTestId, getByRole } = createComponent({ pinia });
 			await nextTick();
@@ -182,10 +195,10 @@ describe('WorkflowSettingsVue', () => {
 		});
 
 		it('should send DEFAULT value for errorWorkflow to backend when set to "No Workflow"', async () => {
-			workflowsStore.workflowSettings = {
+			workflowDocumentStore.setSettings({
 				executionOrder: 'v1',
 				errorWorkflow: 'some-workflow-id',
-			};
+			});
 
 			const { getByTestId, getByRole } = createComponent({ pinia });
 			await nextTick();
@@ -206,9 +219,9 @@ describe('WorkflowSettingsVue', () => {
 		});
 
 		it('should save workflow with errorWorkflow when a specific workflow is selected', async () => {
-			workflowsStore.workflowSettings = {
+			workflowDocumentStore.setSettings({
 				executionOrder: 'v1',
-			};
+			});
 
 			const { getByTestId, getByRole } = createComponent({ pinia });
 			await nextTick();
@@ -310,7 +323,7 @@ describe('WorkflowSettingsVue', () => {
 	);
 
 	it('should save time saved per execution correctly', async () => {
-		workflowsStore.workflowSettings.timeSavedMode = 'fixed';
+		workflowDocumentStore.setSettings({ timeSavedMode: 'fixed' });
 		const { getByTestId, getByRole } = createComponent({ pinia });
 		await nextTick();
 		await waitFor(() => {
@@ -332,8 +345,7 @@ describe('WorkflowSettingsVue', () => {
 	});
 
 	it('should remove time saved per execution setting', async () => {
-		workflowsStore.workflowSettings.timeSavedMode = 'fixed';
-		workflowsStore.workflowSettings.timeSavedPerExecution = 10;
+		workflowDocumentStore.setSettings({ timeSavedMode: 'fixed', timeSavedPerExecution: 10 });
 
 		const { getByTestId, getByRole } = createComponent({ pinia });
 		await nextTick();
@@ -359,7 +371,7 @@ describe('WorkflowSettingsVue', () => {
 	});
 
 	it('should disable save time saved per execution if env is read-only', async () => {
-		workflowsStore.workflowSettings.timeSavedMode = 'fixed';
+		workflowDocumentStore.setSettings({ timeSavedMode: 'fixed' });
 		sourceControlStore.preferences.branchReadOnly = true;
 
 		const { getByTestId } = createComponent({ pinia });
@@ -376,7 +388,7 @@ describe('WorkflowSettingsVue', () => {
 	});
 
 	it('should disable save time saved per execution if user has no permission to update workflow', async () => {
-		workflowsStore.workflowSettings.timeSavedMode = 'fixed';
+		workflowDocumentStore.setSettings({ timeSavedMode: 'fixed' });
 
 		const readOnlyWorkflow = createTestWorkflow({
 			id: '1',
@@ -419,8 +431,7 @@ describe('WorkflowSettingsVue', () => {
 		});
 
 		it('should set binaryMode to separate when selecting v0', async () => {
-			workflowsStore.workflowSettings.executionOrder = 'v1';
-			workflowsStore.workflowSettings.binaryMode = BINARY_MODE_COMBINED;
+			workflowDocumentStore.setSettings({ executionOrder: 'v1', binaryMode: BINARY_MODE_COMBINED });
 
 			const { getByTestId, getByRole } = createComponent({ pinia });
 			await nextTick();
@@ -444,8 +455,7 @@ describe('WorkflowSettingsVue', () => {
 		});
 
 		it('should set binaryMode to separate when selecting v1', async () => {
-			workflowsStore.workflowSettings.executionOrder = 'v0';
-			workflowsStore.workflowSettings.binaryMode = BINARY_MODE_COMBINED;
+			workflowDocumentStore.setSettings({ executionOrder: 'v0', binaryMode: BINARY_MODE_COMBINED });
 
 			const { getByTestId, getByRole } = createComponent({ pinia });
 			await nextTick();
@@ -469,8 +479,7 @@ describe('WorkflowSettingsVue', () => {
 		});
 
 		it('should show binary mode warning toast when binary mode changes', async () => {
-			workflowsStore.workflowSettings.executionOrder = 'v1';
-			workflowsStore.workflowSettings.binaryMode = BINARY_MODE_COMBINED;
+			workflowDocumentStore.setSettings({ executionOrder: 'v1', binaryMode: BINARY_MODE_COMBINED });
 
 			const { getByTestId, getByRole } = createComponent({ pinia });
 			await nextTick();
@@ -494,8 +503,7 @@ describe('WorkflowSettingsVue', () => {
 		});
 
 		it('should not show warning when binary mode does not change', async () => {
-			workflowsStore.workflowSettings.executionOrder = 'v0';
-			workflowsStore.workflowSettings.binaryMode = 'separate';
+			workflowDocumentStore.setSettings({ executionOrder: 'v0', binaryMode: 'separate' });
 
 			const { getByTestId } = createComponent({ pinia });
 			await nextTick();
@@ -513,9 +521,9 @@ describe('WorkflowSettingsVue', () => {
 		});
 
 		it('should default to v1 execution order when not set', async () => {
-			workflowsStore.workflowSettings = {
+			workflowDocumentStore.setSettings({
 				executionOrder: 'v1',
-			};
+			});
 
 			const { getByTestId } = createComponent({ pinia });
 			await nextTick();
@@ -657,7 +665,7 @@ describe('WorkflowSettingsVue', () => {
 		});
 
 		it('should show "Edit" button when an editable resolver is selected', async () => {
-			workflowsStore.workflowSettings.credentialResolverId = 'resolver-1';
+			workflowDocumentStore.setSettings({ credentialResolverId: 'resolver-1' });
 
 			const { getByTestId } = createComponent({ pinia });
 			await nextTick();
@@ -668,7 +676,7 @@ describe('WorkflowSettingsVue', () => {
 		});
 
 		it('should not show "Edit" button when a non-editable resolver is selected', async () => {
-			workflowsStore.workflowSettings.credentialResolverId = 'resolver-n8n';
+			workflowDocumentStore.setSettings({ credentialResolverId: 'resolver-n8n' });
 
 			const { queryByTestId } = createComponent({ pinia });
 			await nextTick();
@@ -730,7 +738,7 @@ describe('WorkflowSettingsVue', () => {
 			// Element Plus clearable sets the model value to '' when the clear icon is clicked.
 			// The clear icon requires CSS hover state which jsdom cannot simulate,
 			// so we verify the save behavior when the value is already empty.
-			workflowsStore.workflowSettings.credentialResolverId = '';
+			workflowDocumentStore.setSettings({ credentialResolverId: '' });
 
 			const { getByRole } = createComponent({ pinia });
 			await nextTick();

--- a/packages/frontend/editor-ui/src/app/components/WorkflowSettings.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowSettings.vue
@@ -26,7 +26,7 @@ import {
 	N8nTooltip,
 } from '@n8n/design-system';
 import type { WorkflowSettings, WorkflowSettingsBinaryMode } from 'n8n-workflow';
-import { deepCopy, BINARY_MODE_COMBINED, BINARY_MODE_SEPARATE } from 'n8n-workflow';
+import { BINARY_MODE_COMBINED, BINARY_MODE_SEPARATE } from 'n8n-workflow';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useWorkflowsEEStore } from '@/app/stores/workflows.ee.store';
@@ -41,8 +41,10 @@ import { getResourcePermissions } from '@n8n/permissions';
 import { useI18n } from '@n8n/i18n';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useDebounce } from '@/app/composables/useDebounce';
-import { injectWorkflowState } from '@/app/composables/useWorkflowState';
-import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { useMcp } from '@/features/ai/mcpAccess/composables/useMcp';
 import { useGlobalLinkActions } from '@/app/composables/useGlobalLinkActions';
 import { useNodeCreatorStore } from '@/features/shared/nodeCreator/nodeCreator.store';
@@ -67,8 +69,11 @@ const sourceControlStore = useSourceControlStore();
 const collaborationStore = useCollaborationStore();
 const workflowsStore = useWorkflowsStore();
 const workflowsListStore = useWorkflowsListStore();
-const workflowState = injectWorkflowState();
-const workflowDocumentStore = injectWorkflowDocumentStore();
+const workflowDocumentStore = computed(() => {
+	const wfId = workflowsStore.workflowId;
+	if (!wfId) return null;
+	return useWorkflowDocumentStore(createWorkflowDocumentId(wfId));
+});
 const workflowsEEStore = useWorkflowsEEStore();
 const nodeCreatorStore = useNodeCreatorStore();
 const posthogStore = usePostHog();
@@ -551,9 +556,10 @@ const saveSettings = async () => {
 		Object.entries(workflowSettings.value).filter(([, value]) => value !== 'DEFAULT'),
 	);
 
-	const oldSettings = deepCopy(workflowsStore.workflowSettings);
+	const oldSettings = (workflowDocumentStore?.value?.getSettingsSnapshot() ??
+		{}) as IWorkflowSettings;
 
-	workflowState.setWorkflowSettings(localWorkflowSettings);
+	workflowDocumentStore?.value?.setSettings(localWorkflowSettings);
 
 	isLoading.value = false;
 
@@ -564,7 +570,7 @@ const saveSettings = async () => {
 
 	closeDialog();
 
-	void externalHooks.run('workflowSettings.saveSettings', { oldSettings });
+	void externalHooks.run('workflowSettings.saveSettings', { oldSettings: { ...oldSettings } });
 	telemetry.track('User updated workflow settings', {
 		workflow_id: workflowsStore.workflowId,
 		// null and undefined values are removed from the object, but we need the keys to be there
@@ -675,7 +681,8 @@ onMounted(async () => {
 		);
 	}
 
-	const workflowSettingsData = deepCopy(workflowsStore.workflowSettings);
+	const workflowSettingsData = (workflowDocumentStore?.value?.getSettingsSnapshot() ??
+		{}) as IWorkflowSettings;
 
 	if (workflowSettingsData.timeSavedMode === undefined) {
 		workflowSettingsData.timeSavedMode = 'fixed';

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
@@ -145,7 +145,7 @@ export async function executionFinished(
 	uiStore.setProcessingExecutionResults(false);
 
 	if (execution.data?.waitTill !== undefined) {
-		handleExecutionFinishedWithWaitTill(options);
+		handleExecutionFinishedWithWaitTill(data.workflowId, options);
 	} else if (execution.status === 'error' || execution.status === 'canceled') {
 		handleExecutionFinishedWithErrorOrCanceled(execution, runExecutionData);
 	} else {
@@ -266,16 +266,19 @@ export function getRunDataExecutedErrorMessage(execution: SimplifiedExecution) {
  * Handle the case when the workflow execution finished with `waitTill`,
  * meaning that it's in a waiting state.
  */
-export function handleExecutionFinishedWithWaitTill(options: {
-	router: ReturnType<typeof useRouter>;
-}) {
+export function handleExecutionFinishedWithWaitTill(
+	workflowId: string,
+	options: {
+		router: ReturnType<typeof useRouter>;
+	},
+) {
 	const workflowsStore = useWorkflowsStore();
 	const settingsStore = useSettingsStore();
 	const workflowSaving = useWorkflowSaving(options);
 	const workflowObject = workflowsStore.workflowObject;
 
-	const workflowDocumentStore = workflowsStore.workflowId
-		? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+	const workflowDocumentStore = workflowId
+		? useWorkflowDocumentStore(createWorkflowDocumentId(workflowId))
 		: undefined;
 	const workflowSettings = workflowDocumentStore?.settings ?? {};
 	const saveManualExecutions =

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
@@ -274,7 +274,10 @@ export function handleExecutionFinishedWithWaitTill(options: {
 	const workflowSaving = useWorkflowSaving(options);
 	const workflowObject = workflowsStore.workflowObject;
 
-	const workflowSettings = workflowsStore.workflowSettings;
+	const workflowDocumentStore = workflowsStore.workflowId
+		? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+		: undefined;
+	const workflowSettings = workflowDocumentStore?.settings ?? {};
 	const saveManualExecutions =
 		workflowSettings.saveManualExecutions ?? settingsStore.saveManualExecutions;
 

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionRecovered.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionRecovered.ts
@@ -36,7 +36,7 @@ export async function executionRecovered(
 	uiStore.setProcessingExecutionResults(false);
 
 	if (execution.data?.waitTill !== undefined) {
-		handleExecutionFinishedWithWaitTill(options);
+		handleExecutionFinishedWithWaitTill(execution.workflowId ?? '', options);
 	} else if (execution.status === 'error' || execution.status === 'canceled') {
 		handleExecutionFinishedWithErrorOrCanceled(execution, runExecutionData);
 	} else {

--- a/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.test.ts
@@ -85,7 +85,6 @@ vi.mock('@/app/stores/workflows.store', () => {
 		incomingConnectionsByNodeName: vi.fn(),
 		outgoingConnectionsByNodeName: vi.fn(),
 		private: {
-			setWorkflowSettings: vi.fn(),
 			setActiveExecutionId: vi.fn((id: string | null | undefined) => {
 				storeState.activeExecutionId = id;
 			}),

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
@@ -248,7 +248,6 @@ describe('useWorkflowHelpers', () => {
 			const addWorkflowSpy = vi.spyOn(workflowsListStore, 'addWorkflow');
 			const setWorkflowIdSpy = vi.spyOn(workflowState, 'setWorkflowId');
 			const setWorkflowNameSpy = vi.spyOn(workflowState, 'setWorkflowName');
-			const setWorkflowSettingsSpy = vi.spyOn(workflowState, 'setWorkflowSettings');
 			const setWorkflowVersionDataSpy = vi.spyOn(workflowsStore, 'setWorkflowVersionData');
 			const setWorkflowScopesSpy = vi.spyOn(workflowState, 'setWorkflowScopes');
 			const setUsedCredentialsSpy = vi.spyOn(workflowsStore, 'setUsedCredentials');
@@ -262,10 +261,6 @@ describe('useWorkflowHelpers', () => {
 			expect(setWorkflowNameSpy).toHaveBeenCalledWith({
 				newName: 'Test Workflow',
 				setStateDirty: false,
-			});
-			expect(setWorkflowSettingsSpy).toHaveBeenCalledWith({
-				executionOrder: 'v1',
-				timezone: 'DEFAULT',
 			});
 			expect(setWorkflowVersionDataSpy).toHaveBeenCalledWith({
 				versionId: 'v1',
@@ -340,9 +335,12 @@ describe('useWorkflowHelpers', () => {
 			const documentId = createWorkflowDocumentId(workflowId);
 			const workflowDocumentStore = useWorkflowDocumentStore(documentId);
 
-			// Note: createTestingPinia() stubs actions by default, so setTags() won't work
+			// Note: createTestingPinia() stubs actions by default, so setTags()/setSettings() won't work
 			Object.defineProperty(workflowDocumentStore, 'tags', {
 				value: tagIds,
+			});
+			vi.mocked(workflowDocumentStore.getSettingsSnapshot).mockReturnValue({
+				executionOrder: 'v1',
 			});
 
 			const { getWorkflowDataToSave } = useWorkflowHelpers();

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
@@ -601,7 +601,7 @@ export function useWorkflowHelpers() {
 			pinData: workflowDocumentStore.getPinDataSnapshot(),
 			connections: workflowConnections,
 			active: workflowDocumentStore.active,
-			settings: workflowsStore.workflow.settings,
+			settings: workflowDocumentStore.settings,
 			tags: [...workflowDocumentStore.tags],
 			versionId: workflowsStore.workflow.versionId,
 			meta: workflowDocumentStore.meta,
@@ -977,7 +977,6 @@ export function useWorkflowHelpers() {
 			newName: workflowData.name,
 			setStateDirty: uiStore.stateIsDirty,
 		});
-		ws.setWorkflowSettings(workflowData.settings ?? {});
 		workflowsStore.setWorkflowVersionData({
 			versionId: workflowData.versionId,
 			name: null,
@@ -1024,11 +1023,18 @@ export function useWorkflowHelpers() {
 		const workflowDocumentStore = useWorkflowDocumentStore(
 			createWorkflowDocumentId(workflowData.id),
 		);
+
+		// Sync document store settings → workflowObject (runtime Workflow instance)
+		workflowDocumentStore.onSettingsChange(({ payload }) => {
+			workflowsStore.workflowObject.setSettings(payload.settings);
+		});
+
 		workflowDocumentStore.setTags(tagIds);
 		workflowDocumentStore.setActiveState({
 			activeVersionId: workflowData.activeVersionId,
 			activeVersion: workflowData.activeVersion ?? null,
 		});
+		workflowDocumentStore.setSettings(workflowData.settings ?? {});
 		workflowDocumentStore.setPinData(workflowData.pinData ?? {});
 		workflowDocumentStore.setCreatedAt(workflowData.createdAt);
 		workflowDocumentStore.setUpdatedAt(workflowData.updatedAt);

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
@@ -1034,9 +1034,7 @@ export function useWorkflowHelpers() {
 			activeVersionId: workflowData.activeVersionId,
 			activeVersion: workflowData.activeVersion ?? null,
 		});
-		workflowDocumentStore.setSettings(
-			workflowData.settings ?? { ...workflowsStore.defaults.settings },
-		);
+		workflowDocumentStore.setSettings(workflowData.settings ?? {});
 		workflowDocumentStore.setPinData(workflowData.pinData ?? {});
 		workflowDocumentStore.setCreatedAt(workflowData.createdAt);
 		workflowDocumentStore.setUpdatedAt(workflowData.updatedAt);

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
@@ -1034,7 +1034,9 @@ export function useWorkflowHelpers() {
 			activeVersionId: workflowData.activeVersionId,
 			activeVersion: workflowData.activeVersion ?? null,
 		});
-		workflowDocumentStore.setSettings(workflowData.settings ?? {});
+		workflowDocumentStore.setSettings(
+			workflowData.settings ?? { ...workflowsStore.defaults.settings },
+		);
 		workflowDocumentStore.setPinData(workflowData.pinData ?? {});
 		workflowDocumentStore.setCreatedAt(workflowData.createdAt);
 		workflowDocumentStore.setUpdatedAt(workflowData.updatedAt);

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
@@ -56,7 +56,6 @@ const mockWorkflowState = {
 	setWorkflowName: vi.fn(),
 	setActive: vi.fn(),
 	setWorkflowId: vi.fn(),
-	setWorkflowSettings: vi.fn(),
 	setNodeValue: vi.fn(),
 };
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowState.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowState.ts
@@ -18,6 +18,7 @@ import { getPairedItemsMapping } from '@/app/utils/pairedItemUtils';
 import {
 	type INodeIssueData,
 	type INodeIssueObjectProperty,
+	type IWorkflowSettings,
 	NodeHelpers,
 	type IDataObject,
 	type INodeParameters,
@@ -28,6 +29,7 @@ import { useRootStore } from '@n8n/stores/useRootStore';
 import { isEmpty } from '@/app/utils/typesUtils';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { clearPopupWindowState } from '@/features/execution/executions/executions.utils';
+import { DEFAULT_SETTINGS } from '@/app/stores/workflowDocument/useWorkflowDocumentSettings';
 import { useDocumentTitle } from './useDocumentTitle';
 import { useWorkflowStateStore } from '@/app/stores/workflowState.store';
 import { isObject } from '@/app/utils/objectUtils';
@@ -137,9 +139,9 @@ export function useWorkflowState() {
 		projectId?: string,
 		parentFolderId?: string,
 	): Promise<INewWorkflowData> {
-		let workflowData = {
+		let workflowData: { name: string; settings: IWorkflowSettings } = {
 			name: '',
-			settings: { ...ws.defaults.settings },
+			settings: { ...DEFAULT_SETTINGS },
 		};
 		try {
 			const data: IDataObject = {
@@ -228,7 +230,7 @@ export function useWorkflowState() {
 		setWorkflowId('');
 		setWorkflowName({ newName: '', setStateDirty: false });
 		// Settings are managed by workflowDocumentStore; reset the runtime Workflow instance directly
-		ws.workflowObject.setSettings({ ...ws.defaults.settings });
+		ws.workflowObject.setSettings({ ...DEFAULT_SETTINGS });
 		// Note: Tags are now managed by workflowDocumentStore, which is disposed during reset
 
 		setActiveExecutionId(undefined);

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowState.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowState.ts
@@ -21,7 +21,6 @@ import {
 	NodeHelpers,
 	type IDataObject,
 	type INodeParameters,
-	type IWorkflowSettings,
 } from 'n8n-workflow';
 import { inject } from 'vue';
 import * as workflowsApi from '@/app/api/workflows';
@@ -123,10 +122,6 @@ export function useWorkflowState() {
 		// Set the workflow ID directly, or empty string if not provided
 		ws.workflow.id = id || '';
 		ws.workflowObject.id = ws.workflow.id;
-	}
-
-	function setWorkflowSettings(workflowSettings: IWorkflowSettings) {
-		ws.private.setWorkflowSettings(workflowSettings);
 	}
 
 	function setWorkflowProperty<K extends keyof IWorkflowDb>(key: K, value: IWorkflowDb[K]) {
@@ -232,7 +227,8 @@ export function useWorkflowState() {
 
 		setWorkflowId('');
 		setWorkflowName({ newName: '', setStateDirty: false });
-		setWorkflowSettings({ ...ws.defaults.settings });
+		// Settings are managed by workflowDocumentStore; reset the runtime Workflow instance directly
+		ws.workflowObject.setSettings({ ...ws.defaults.settings });
 		// Note: Tags are now managed by workflowDocumentStore, which is disposed during reset
 
 		setActiveExecutionId(undefined);
@@ -437,7 +433,6 @@ export function useWorkflowState() {
 		resetAllNodesIssues,
 		setWorkflowId,
 		setWorkflowName,
-		setWorkflowSettings,
 		setWorkflowProperty,
 		setActiveExecutionId,
 		getNewWorkflowDataAndMakeShareable,

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
@@ -7,6 +7,7 @@ import { useWorkflowDocumentHomeProject } from './workflowDocument/useWorkflowDo
 import { useWorkflowDocumentChecksum } from './workflowDocument/useWorkflowDocumentChecksum';
 import { useWorkflowDocumentMeta } from './workflowDocument/useWorkflowDocumentMeta';
 import { useWorkflowDocumentPinData } from './workflowDocument/useWorkflowDocumentPinData';
+import { useWorkflowDocumentSettings } from './workflowDocument/useWorkflowDocumentSettings';
 import { useWorkflowDocumentTags } from './workflowDocument/useWorkflowDocumentTags';
 import { useWorkflowDocumentTimestamps } from './workflowDocument/useWorkflowDocumentTimestamps';
 
@@ -57,6 +58,7 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 		const workflowDocumentTags = useWorkflowDocumentTags();
 		const workflowDocumentPinData = useWorkflowDocumentPinData();
 		const workflowDocumentTimestamps = useWorkflowDocumentTimestamps();
+		const workflowDocumentSettings = useWorkflowDocumentSettings();
 
 		return {
 			workflowId,
@@ -65,6 +67,7 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 			...workflowDocumentHomeProject,
 			...workflowDocumentChecksum,
 			...workflowDocumentMeta,
+			...workflowDocumentSettings,
 			...workflowDocumentTags,
 			...workflowDocumentPinData,
 			...workflowDocumentTimestamps,

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentSettings.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentSettings.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { useWorkflowDocumentSettings } from './useWorkflowDocumentSettings';
+import { useWorkflowDocumentSettings, DEFAULT_SETTINGS } from './useWorkflowDocumentSettings';
 
 function createSettings() {
 	return useWorkflowDocumentSettings();
@@ -7,14 +7,14 @@ function createSettings() {
 
 describe('useWorkflowDocumentSettings', () => {
 	describe('initial state', () => {
-		it('should start with empty settings', () => {
+		it('should start with default settings', () => {
 			const { settings } = createSettings();
-			expect(settings.value).toEqual({});
+			expect(settings.value).toEqual(DEFAULT_SETTINGS);
 		});
 	});
 
 	describe('setSettings', () => {
-		it('should set settings and fire event hook', () => {
+		it('should set settings merged with defaults and fire event hook', () => {
 			const { settings, setSettings, onSettingsChange } = createSettings();
 			const hookSpy = vi.fn();
 			onSettingsChange(hookSpy);
@@ -22,20 +22,21 @@ describe('useWorkflowDocumentSettings', () => {
 			const newSettings = { executionOrder: 'v1' as const, timezone: 'UTC' };
 			setSettings(newSettings);
 
-			expect(settings.value).toEqual(newSettings);
+			const expected = { ...DEFAULT_SETTINGS, ...newSettings };
+			expect(settings.value).toEqual(expected);
 			expect(hookSpy).toHaveBeenCalledWith({
 				action: 'update',
-				payload: { settings: newSettings },
+				payload: { settings: expected },
 			});
 		});
 
-		it('should replace existing settings', () => {
+		it('should always include defaults when replacing settings', () => {
 			const { settings, setSettings } = createSettings();
 			setSettings({ executionOrder: 'v1' });
 
 			setSettings({ timezone: 'UTC' });
 
-			expect(settings.value).toEqual({ timezone: 'UTC' });
+			expect(settings.value).toEqual({ ...DEFAULT_SETTINGS, timezone: 'UTC' });
 		});
 
 		it('should fire event hook on every call', () => {
@@ -59,7 +60,11 @@ describe('useWorkflowDocumentSettings', () => {
 			setSettings({ executionOrder: 'v1', timezone: 'UTC' });
 			mergeSettings({ timezone: 'America/New_York' });
 
-			expect(settings.value).toEqual({ executionOrder: 'v1', timezone: 'America/New_York' });
+			expect(settings.value).toEqual({
+				...DEFAULT_SETTINGS,
+				executionOrder: 'v1',
+				timezone: 'America/New_York',
+			});
 		});
 
 		it('should add new fields without removing existing ones', () => {
@@ -68,7 +73,11 @@ describe('useWorkflowDocumentSettings', () => {
 
 			mergeSettings({ timezone: 'UTC' });
 
-			expect(settings.value).toEqual({ executionOrder: 'v1', timezone: 'UTC' });
+			expect(settings.value).toEqual({
+				...DEFAULT_SETTINGS,
+				executionOrder: 'v1',
+				timezone: 'UTC',
+			});
 		});
 
 		it('should fire event hook with merged settings', () => {
@@ -81,7 +90,7 @@ describe('useWorkflowDocumentSettings', () => {
 
 			expect(hookSpy).toHaveBeenCalledWith({
 				action: 'update',
-				payload: { settings: { executionOrder: 'v1', timezone: 'UTC' } },
+				payload: { settings: { ...DEFAULT_SETTINGS, executionOrder: 'v1', timezone: 'UTC' } },
 			});
 		});
 	});
@@ -94,13 +103,13 @@ describe('useWorkflowDocumentSettings', () => {
 
 			const snapshot = getSettingsSnapshot();
 
-			expect(snapshot).toEqual(original);
+			expect(snapshot).toEqual({ ...DEFAULT_SETTINGS, ...original });
 			expect(snapshot).not.toBe(settings.value);
 		});
 
-		it('should return empty object when no settings set', () => {
+		it('should return default settings when no settings set', () => {
 			const { getSettingsSnapshot } = createSettings();
-			expect(getSettingsSnapshot()).toEqual({});
+			expect(getSettingsSnapshot()).toEqual(DEFAULT_SETTINGS);
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentSettings.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentSettings.test.ts
@@ -50,6 +50,42 @@ describe('useWorkflowDocumentSettings', () => {
 		});
 	});
 
+	describe('mergeSettings', () => {
+		it('should merge partial settings with existing settings', () => {
+			const { settings, setSettings, mergeSettings, onSettingsChange } = createSettings();
+			const hookSpy = vi.fn();
+			onSettingsChange(hookSpy);
+
+			setSettings({ executionOrder: 'v1', timezone: 'UTC' });
+			mergeSettings({ timezone: 'America/New_York' });
+
+			expect(settings.value).toEqual({ executionOrder: 'v1', timezone: 'America/New_York' });
+		});
+
+		it('should add new fields without removing existing ones', () => {
+			const { settings, setSettings, mergeSettings } = createSettings();
+			setSettings({ executionOrder: 'v1' });
+
+			mergeSettings({ timezone: 'UTC' });
+
+			expect(settings.value).toEqual({ executionOrder: 'v1', timezone: 'UTC' });
+		});
+
+		it('should fire event hook with merged settings', () => {
+			const { setSettings, mergeSettings, onSettingsChange } = createSettings();
+			const hookSpy = vi.fn();
+			setSettings({ executionOrder: 'v1' });
+			onSettingsChange(hookSpy);
+
+			mergeSettings({ timezone: 'UTC' });
+
+			expect(hookSpy).toHaveBeenCalledWith({
+				action: 'update',
+				payload: { settings: { executionOrder: 'v1', timezone: 'UTC' } },
+			});
+		});
+	});
+
 	describe('getSettingsSnapshot', () => {
 		it('should return a deep copy of settings', () => {
 			const { settings, setSettings, getSettingsSnapshot } = createSettings();

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentSettings.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentSettings.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { useWorkflowDocumentSettings } from './useWorkflowDocumentSettings';
+
+function createSettings() {
+	return useWorkflowDocumentSettings();
+}
+
+describe('useWorkflowDocumentSettings', () => {
+	describe('initial state', () => {
+		it('should start with empty settings', () => {
+			const { settings } = createSettings();
+			expect(settings.value).toEqual({});
+		});
+	});
+
+	describe('setSettings', () => {
+		it('should set settings and fire event hook', () => {
+			const { settings, setSettings, onSettingsChange } = createSettings();
+			const hookSpy = vi.fn();
+			onSettingsChange(hookSpy);
+
+			const newSettings = { executionOrder: 'v1' as const, timezone: 'UTC' };
+			setSettings(newSettings);
+
+			expect(settings.value).toEqual(newSettings);
+			expect(hookSpy).toHaveBeenCalledWith({
+				action: 'update',
+				payload: { settings: newSettings },
+			});
+		});
+
+		it('should replace existing settings', () => {
+			const { settings, setSettings } = createSettings();
+			setSettings({ executionOrder: 'v1' });
+
+			setSettings({ timezone: 'UTC' });
+
+			expect(settings.value).toEqual({ timezone: 'UTC' });
+		});
+
+		it('should fire event hook on every call', () => {
+			const { setSettings, onSettingsChange } = createSettings();
+			const hookSpy = vi.fn();
+			onSettingsChange(hookSpy);
+
+			setSettings({ executionOrder: 'v1' });
+			setSettings({ timezone: 'UTC' });
+
+			expect(hookSpy).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	describe('getSettingsSnapshot', () => {
+		it('should return a deep copy of settings', () => {
+			const { settings, setSettings, getSettingsSnapshot } = createSettings();
+			const original = { executionOrder: 'v1' as const, timezone: 'UTC' };
+			setSettings(original);
+
+			const snapshot = getSettingsSnapshot();
+
+			expect(snapshot).toEqual(original);
+			expect(snapshot).not.toBe(settings.value);
+		});
+
+		it('should return empty object when no settings set', () => {
+			const { getSettingsSnapshot } = createSettings();
+			expect(getSettingsSnapshot()).toEqual({});
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentSettings.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentSettings.ts
@@ -28,6 +28,10 @@ export function useWorkflowDocumentSettings() {
 		applySettings(newSettings);
 	}
 
+	function mergeSettings(partialSettings: Partial<IWorkflowSettings>) {
+		applySettings({ ...settings.value, ...partialSettings });
+	}
+
 	function getSettingsSnapshot(): IWorkflowSettings {
 		return deepCopy(settings.value);
 	}
@@ -35,6 +39,7 @@ export function useWorkflowDocumentSettings() {
 	return {
 		settings: readonly(settings),
 		setSettings,
+		mergeSettings,
 		getSettingsSnapshot,
 		onSettingsChange: onSettingsChange.on,
 	};

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentSettings.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentSettings.ts
@@ -1,6 +1,6 @@
 import { ref, readonly } from 'vue';
 import { createEventHook } from '@vueuse/core';
-import { deepCopy } from 'n8n-workflow';
+import { BINARY_MODE_SEPARATE, deepCopy } from 'n8n-workflow';
 import type { IWorkflowSettings } from 'n8n-workflow';
 import { CHANGE_ACTION } from './types';
 import type { ChangeAction, ChangeEvent } from './types';
@@ -11,8 +11,13 @@ export type SettingsPayload = {
 
 export type SettingsChangeEvent = ChangeEvent<SettingsPayload>;
 
+export const DEFAULT_SETTINGS = {
+	executionOrder: 'v1',
+	binaryMode: BINARY_MODE_SEPARATE,
+} satisfies IWorkflowSettings;
+
 export function useWorkflowDocumentSettings() {
-	const settings = ref<IWorkflowSettings>({});
+	const settings = ref<IWorkflowSettings>({ ...DEFAULT_SETTINGS });
 
 	const onSettingsChange = createEventHook<SettingsChangeEvent>();
 
@@ -25,7 +30,7 @@ export function useWorkflowDocumentSettings() {
 	}
 
 	function setSettings(newSettings: IWorkflowSettings) {
-		applySettings(newSettings);
+		applySettings({ ...DEFAULT_SETTINGS, ...newSettings });
 	}
 
 	function mergeSettings(partialSettings: Partial<IWorkflowSettings>) {

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentSettings.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentSettings.ts
@@ -1,0 +1,41 @@
+import { ref, readonly } from 'vue';
+import { createEventHook } from '@vueuse/core';
+import { deepCopy } from 'n8n-workflow';
+import type { IWorkflowSettings } from 'n8n-workflow';
+import { CHANGE_ACTION } from './types';
+import type { ChangeAction, ChangeEvent } from './types';
+
+export type SettingsPayload = {
+	settings: IWorkflowSettings;
+};
+
+export type SettingsChangeEvent = ChangeEvent<SettingsPayload>;
+
+export function useWorkflowDocumentSettings() {
+	const settings = ref<IWorkflowSettings>({});
+
+	const onSettingsChange = createEventHook<SettingsChangeEvent>();
+
+	function applySettings(
+		newSettings: IWorkflowSettings,
+		action: ChangeAction = CHANGE_ACTION.UPDATE,
+	) {
+		settings.value = newSettings;
+		void onSettingsChange.trigger({ action, payload: { settings: newSettings } });
+	}
+
+	function setSettings(newSettings: IWorkflowSettings) {
+		applySettings(newSettings);
+	}
+
+	function getSettingsSnapshot(): IWorkflowSettings {
+		return deepCopy(settings.value);
+	}
+
+	return {
+		settings: readonly(settings),
+		setSettings,
+		getSettingsSnapshot,
+		onSettingsChange: onSettingsChange.on,
+	};
+}

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.test.ts
@@ -1458,6 +1458,10 @@ describe('useWorkflowsStore', () => {
 				timezone: 'UTC',
 			};
 
+			// Also populate the document store since updateWorkflowSetting reads from it
+			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId('w1'));
+			workflowDocumentStore.setSettings({ executionOrder: 'v1', timezone: 'UTC' });
+
 			const makeRestApiRequestSpy = vi.spyOn(apiUtils, 'makeRestApiRequest').mockResolvedValue(
 				createTestWorkflow({
 					id: 'w1',
@@ -1489,7 +1493,7 @@ describe('useWorkflowsStore', () => {
 			// Assert returned value and store updates
 			expect(result.versionId).toBe('v1');
 			expect(workflowsStore.workflow.versionId).toBe('v1');
-			expect(workflowsStore.workflow.settings).toEqual({
+			expect(workflowDocumentStore.settings).toEqual({
 				executionOrder: 'v1',
 				timezone: 'UTC',
 				executionTimeout: 10,

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.test.ts
@@ -1495,6 +1495,7 @@ describe('useWorkflowsStore', () => {
 			expect(workflowsStore.workflow.versionId).toBe('v1');
 			expect(workflowDocumentStore.settings).toEqual({
 				executionOrder: 'v1',
+				binaryMode: 'separate',
 				timezone: 'UTC',
 				executionTimeout: 10,
 			});

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -160,8 +160,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 
 	const workflowVersionId = computed(() => workflow.value.versionId);
 
-	const workflowSettings = computed(() => workflow.value.settings ?? { ...defaults.settings });
-
 	// A workflow is new if it hasn't been saved to the backend yet
 	const isNewWorkflow = computed(() => {
 		if (!workflow.value.id) return true;
@@ -584,7 +582,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			connections: copyData ? deepCopy(connections) : connections,
 			active: false,
 			nodeTypes,
-			settings: workflow.value.settings ?? { ...defaults.settings },
+			settings: workflowDocumentStore?.settings ?? { ...defaults.settings },
 			pinData: workflowDocumentStore?.getPinDataSnapshot() ?? {},
 		});
 	}
@@ -821,11 +819,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			workflowExecutionResultDataLastUpdate.value = Date.now();
 			workflowExecutionStartedData.value = undefined;
 		}
-	}
-
-	function setWorkflowSettings(workflowSettings: IWorkflowSettings) {
-		workflow.value.settings = workflowSettings as IWorkflowDb['settings'];
-		workflowObject.value.setSettings(workflowSettings);
 	}
 
 	function setWorkflow(value: IWorkflowDb): void {
@@ -1420,11 +1413,13 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		let currentVersionId = '';
 		let currentChecksum = '';
 		const isCurrentWorkflow = id === workflow.value.id;
+		const workflowDocumentStore = isCurrentWorkflow
+			? useWorkflowDocumentStore(createWorkflowDocumentId(id))
+			: undefined;
 
-		if (isCurrentWorkflow) {
-			currentSettings = workflow.value.settings ?? ({} as IWorkflowSettings);
+		if (isCurrentWorkflow && workflowDocumentStore) {
+			currentSettings = (workflowDocumentStore.settings ?? {}) as IWorkflowSettings;
 			currentVersionId = workflow.value.versionId;
-			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(id));
 			currentChecksum = workflowDocumentStore.checksum;
 		} else {
 			const cached = workflowsListStore.getWorkflowById(id);
@@ -1450,8 +1445,8 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		});
 
 		// Update local store state to reflect the change
-		if (isCurrentWorkflow) {
-			setWorkflowSettings(updated.settings ?? {});
+		if (isCurrentWorkflow && workflowDocumentStore) {
+			workflowDocumentStore.setSettings(updated.settings ?? {});
 		} else if (workflowsListStore.getWorkflowById(id)) {
 			workflowsListStore.updateWorkflowInCache(id, {
 				settings: updated.settings,
@@ -1698,7 +1693,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		workflowName,
 		workflowId,
 		workflowVersionId,
-		workflowSettings,
 		isNewWorkflow,
 		isWorkflowSaved,
 		workflowTriggerNodes,
@@ -1806,7 +1800,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		// This is exposed to ease the refactoring to the injected workflowState composable
 		// Please do not use outside this context
 		private: {
-			setWorkflowSettings,
 			setActiveExecutionId,
 		},
 	};

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -763,6 +763,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 				name: versionData.value?.name ?? null,
 				description: versionData.value?.description ?? null,
 			});
+
 			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(id));
 			workflowDocumentStore.setChecksum(updatedWorkflow.checksum!);
 		}
@@ -834,8 +835,8 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		// Sync settings to the document store so createWorkflowObject reads correct settings
 		const wfId = workflow.value.id;
 		if (wfId) {
-			const docStore = useWorkflowDocumentStore(createWorkflowDocumentId(wfId));
-			docStore.setSettings(workflow.value.settings ?? { ...defaults.settings });
+			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(wfId));
+			workflowDocumentStore.setSettings(workflow.value.settings ?? { ...defaults.settings });
 		}
 
 		workflowObject.value = createWorkflowObject(

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -1418,7 +1418,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			: undefined;
 
 		if (isCurrentWorkflow && workflowDocumentStore) {
-			currentSettings = (workflowDocumentStore.settings ?? {}) as IWorkflowSettings;
+			currentSettings = workflowDocumentStore.settings;
 			currentVersionId = workflow.value.versionId;
 			currentChecksum = workflowDocumentStore.checksum;
 		} else {

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -49,7 +49,6 @@ import {
 	SEND_AND_WAIT_OPERATION,
 	Workflow,
 	TelemetryHelpers,
-	BINARY_MODE_SEPARATE,
 } from 'n8n-workflow';
 import * as workflowUtils from 'n8n-workflow/common';
 
@@ -93,6 +92,7 @@ import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
 } from '@/app/stores/workflowDocument.store';
+import { DEFAULT_SETTINGS } from '@/app/stores/workflowDocument/useWorkflowDocumentSettings';
 
 const defaults: Omit<IWorkflowDb, 'id'> & { settings: NonNullable<IWorkflowDb['settings']> } = {
 	name: '',
@@ -104,10 +104,7 @@ const defaults: Omit<IWorkflowDb, 'id'> & { settings: NonNullable<IWorkflowDb['s
 	updatedAt: -1,
 	connections: {},
 	nodes: [],
-	settings: {
-		executionOrder: 'v1',
-		binaryMode: BINARY_MODE_SEPARATE,
-	},
+	settings: { ...DEFAULT_SETTINGS },
 	tags: [],
 	pinData: {},
 	versionId: '',
@@ -582,7 +579,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			connections: copyData ? deepCopy(connections) : connections,
 			active: false,
 			nodeTypes,
-			settings: workflowDocumentStore?.settings ?? { ...defaults.settings },
+			settings: workflowDocumentStore?.settings ?? { ...DEFAULT_SETTINGS },
 			pinData: workflowDocumentStore?.getPinDataSnapshot() ?? {},
 		});
 	}
@@ -829,14 +826,14 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			...(!value.hasOwnProperty('connections') ? { connections: {} } : {}),
 			...(!value.hasOwnProperty('id') ? { id: '' } : {}),
 			...(!value.hasOwnProperty('nodes') ? { nodes: [] } : {}),
-			...(!value.hasOwnProperty('settings') ? { settings: { ...defaults.settings } } : {}),
+			...(!value.hasOwnProperty('settings') ? { settings: { ...DEFAULT_SETTINGS } } : {}),
 		};
 
 		// Sync settings to the document store so createWorkflowObject reads correct settings
 		const wfId = workflow.value.id;
 		if (wfId) {
 			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(wfId));
-			workflowDocumentStore.setSettings(workflow.value.settings ?? { ...defaults.settings });
+			workflowDocumentStore.setSettings(workflow.value.settings ?? {});
 		}
 
 		workflowObject.value = createWorkflowObject(
@@ -1455,7 +1452,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 
 		// Update local store state to reflect the change
 		if (isCurrentWorkflow && workflowDocumentStore) {
-			workflowDocumentStore.setSettings(updated.settings ?? { ...defaults.settings });
+			workflowDocumentStore.setSettings(updated.settings ?? {});
 		} else if (workflowsListStore.getWorkflowById(id)) {
 			workflowsListStore.updateWorkflowInCache(id, {
 				settings: updated.settings,

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -830,6 +830,14 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			...(!value.hasOwnProperty('nodes') ? { nodes: [] } : {}),
 			...(!value.hasOwnProperty('settings') ? { settings: { ...defaults.settings } } : {}),
 		};
+
+		// Sync settings to the document store so createWorkflowObject reads correct settings
+		const wfId = workflow.value.id;
+		if (wfId) {
+			const docStore = useWorkflowDocumentStore(createWorkflowDocumentId(wfId));
+			docStore.setSettings(workflow.value.settings ?? { ...defaults.settings });
+		}
+
 		workflowObject.value = createWorkflowObject(
 			workflow.value.nodes,
 			workflow.value.connections,

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -1455,7 +1455,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 
 		// Update local store state to reflect the change
 		if (isCurrentWorkflow && workflowDocumentStore) {
-			workflowDocumentStore.setSettings(updated.settings ?? {});
+			workflowDocumentStore.setSettings(updated.settings ?? { ...defaults.settings });
 		} else if (workflowsListStore.getWorkflowById(id)) {
 			workflowsListStore.updateWorkflowInCache(id, {
 				settings: updated.settings,

--- a/packages/frontend/editor-ui/src/features/ai/mcpAccess/mcp.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/mcpAccess/mcp.store.ts
@@ -87,7 +87,7 @@ export const useMCPStore = defineStore(MCP_STORE, () => {
 			});
 			if (settings) {
 				const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(id));
-				workflowDocumentStore.setSettings(settings);
+				workflowDocumentStore.mergeSettings(settings);
 			}
 		}
 		if (workflowsListStore.workflowsById[id]) {

--- a/packages/frontend/editor-ui/src/features/ai/mcpAccess/mcp.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/mcpAccess/mcp.store.ts
@@ -2,6 +2,10 @@ import { defineStore } from 'pinia';
 import { MCP_STORE } from './mcp.constants';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import type { WorkflowListItem } from '@/Interface';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import {
@@ -82,7 +86,8 @@ export const useMCPStore = defineStore(MCP_STORE, () => {
 				description: workflowsStore.versionData?.description ?? null,
 			});
 			if (settings) {
-				workflowsStore.private.setWorkflowSettings(settings);
+				const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(id));
+				workflowDocumentStore.setSettings(settings);
 			}
 		}
 		if (workflowsListStore.workflowsById[id]) {

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
@@ -1,3 +1,4 @@
+import { shallowRef } from 'vue';
 import { describe, it, vi } from 'vitest';
 import { screen } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
@@ -19,6 +20,11 @@ import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import type { FrontendSettings } from '@n8n/api-types';
 import type { ICredentialType, INodeTypeDescription } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
+import { WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 
 const httpNode: INodeUi = {
 	parameters: {
@@ -97,14 +103,25 @@ function createCredential(
 }
 
 describe('NodeCredentials', () => {
+	const pinia = createTestingPinia({ stubActions: false });
+	const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId('1'));
+	const workflowDocumentStoreRef = shallowRef<ReturnType<typeof useWorkflowDocumentStore> | null>(
+		workflowDocumentStore,
+	);
+
 	const defaultRenderOptions: RenderOptions<typeof NodeCredentials> = {
-		pinia: createTestingPinia({ stubActions: false }),
+		pinia,
 		props: {
 			overrideCredType: 'openAiApi',
 			node: httpNode,
 			readonly: false,
 			showAll: false,
 			hideIssues: false,
+		},
+		global: {
+			provide: {
+				[WorkflowDocumentStoreKey as symbol]: workflowDocumentStoreRef,
+			},
 		},
 	};
 
@@ -390,7 +407,7 @@ describe('NodeCredentials', () => {
 
 		it('should show warning when resolvable credential selected but workflow has no resolver', async () => {
 			setupResolvableCredential();
-			workflowsStore.workflowSettings = { executionOrder: 'v1' };
+			workflowDocumentStore.setSettings({ executionOrder: 'v1' });
 
 			renderComponent();
 
@@ -399,10 +416,10 @@ describe('NodeCredentials', () => {
 
 		it('should not show warning when resolvable credential selected and workflow has resolver', async () => {
 			setupResolvableCredential();
-			workflowsStore.workflowSettings = {
+			workflowDocumentStore.setSettings({
 				executionOrder: 'v1',
 				credentialResolverId: 'resolver-123',
-			};
+			});
 
 			renderComponent();
 

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
@@ -53,6 +53,7 @@ import {
 	N8nTooltip,
 } from '@n8n/design-system';
 import { injectWorkflowState } from '@/app/composables/useWorkflowState';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 type Props = {
 	node: INodeUi;
 	overrideCredType?: NodeParameterValueType;
@@ -85,6 +86,7 @@ const uiStore = useUIStore();
 const workflowsStore = useWorkflowsStore();
 const projectsStore = useProjectsStore();
 const workflowState = injectWorkflowState();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const { isEnabled: isDynamicCredentialsEnabled } = useDynamicCredentials();
 
 // Quick connect
@@ -147,7 +149,7 @@ const selected = computed<Record<string, INodeCredentialsDetails>>(
 );
 
 const hasWorkflowResolver = computed(() => {
-	return !!workflowsStore.workflowSettings?.credentialResolverId;
+	return !!workflowDocumentStore?.value?.settings?.credentialResolverId;
 });
 
 function isCredentialResolvable(credentialType: string): boolean {

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsInfoAccordion.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsInfoAccordion.vue
@@ -6,10 +6,10 @@ import { useUIStore } from '@/app/stores/ui.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { WORKFLOW_SETTINGS_MODAL_KEY } from '@/app/constants';
 import type { IWorkflowSettings } from 'n8n-workflow';
-import { deepCopy } from 'n8n-workflow';
 import { useNpsSurveyStore } from '@/app/stores/npsSurvey.store';
 import { useI18n } from '@n8n/i18n';
 import { useWorkflowSaving } from '@/app/composables/useWorkflowSaving';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import type { IconColor } from '@n8n/design-system';
 import { type IAccordionItem } from '@n8n/design-system/components/N8nInfoAccordion/InfoAccordion.vue';
 import { type IconName } from '@n8n/design-system/components/N8nIcon/icons';
@@ -39,6 +39,7 @@ const locale = useI18n();
 const settingsStore = useSettingsStore();
 const uiStore = useUIStore();
 const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const npsSurveyStore = useNpsSurveyStore();
 
 const defaultValues = ref({
@@ -103,7 +104,7 @@ const productionExecutionsStatus = computed(() => {
 		return 'unknown';
 	}
 });
-const workflowSettings = computed(() => deepCopy(workflowsStore.workflowSettings));
+const workflowSettings = computed(() => workflowDocumentStore?.value?.getSettingsSnapshot() ?? {});
 const accordionIcon = computed((): { color: IconColor; icon: IconName } | undefined => {
 	if (
 		!workflowSaveSettings.value.saveTestExecutions ||

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataBinary.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataBinary.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { saveAs } from 'file-saver';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { WORKFLOW_SETTINGS_MODAL_KEY } from '@/app/constants/modals';
 import { ViewableMimeTypes } from '@n8n/api-types';
@@ -17,6 +18,7 @@ const emit = defineEmits<{ preview: [index: number, key: string | number] }>();
 
 const i18n = useI18n();
 const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const uiStore = useUIStore();
 const posthogStore = usePostHog();
 
@@ -28,7 +30,7 @@ const isV2Enabled = computed(() => {
 });
 
 const isLegacyBinaryMode = computed(
-	() => workflowsStore.workflow.settings?.binaryMode !== BINARY_MODE_COMBINED,
+	() => workflowDocumentStore?.value?.settings?.binaryMode !== BINARY_MODE_COMBINED,
 );
 
 function isViewable(index: number, key: string | number): boolean {

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataJson.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataJson.vue
@@ -16,7 +16,7 @@ import TextWithHighlights from './TextWithHighlights.vue';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useElementSize } from '@vueuse/core';
 import { useTelemetryContext } from '@/app/composables/useTelemetryContext';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 
 const LazyRunDataJsonActions = defineAsyncComponent(
 	async () => await import('@/features/ndv/runData/components/RunDataJsonActions.vue'),
@@ -44,11 +44,11 @@ const props = withDefaults(
 );
 
 const ndvStore = useNDVStore();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 
 const externalHooks = useExternalHooks();
 const telemetry = useTelemetry();
 const telemetryContext = useTelemetryContext();
-const workflowsStore = useWorkflowsStore();
 
 const selectedJsonPath = ref(nonExistingJsonPath);
 const draggingPath = ref<null | string>(null);
@@ -75,7 +75,7 @@ const getJsonParameterPath = (path: string) => {
 		nodeName: props.node.name,
 		distanceFromActive: props.distanceFromActive,
 		path: subPath,
-		binaryMode: workflowsStore.workflow.settings?.binaryMode,
+		binaryMode: workflowDocumentStore?.value?.settings?.binaryMode,
 	});
 };
 

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataTable.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataTable.vue
@@ -3,6 +3,7 @@ import { useExternalHooks } from '@/app/composables/useExternalHooks';
 import type { INodeUi, IRunDataDisplayMode, ITableData } from '@/Interface';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { getMappedExpression } from '@/app/utils/mappingUtils';
 import { getPairedItemId } from '@/app/utils/pairedItemUtils';
 import { shorten } from '@/app/utils/typesUtils';
@@ -77,6 +78,7 @@ const fixedColumnWidths = ref<number[] | undefined>();
 
 const ndvStore = useNDVStore();
 const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 
 const i18n = useI18n();
 const telemetry = useTelemetry();
@@ -213,7 +215,7 @@ function getExpression(column: string) {
 		nodeName: props.node.name,
 		distanceFromActive: props.distanceFromActive,
 		path: [column],
-		binaryMode: workflowsStore.workflow.settings?.binaryMode,
+		binaryMode: workflowDocumentStore?.value?.settings?.binaryMode,
 	});
 }
 
@@ -246,7 +248,7 @@ function getCellExpression(path: Array<string | number>, colIndex: number) {
 		nodeName: props.node.name,
 		distanceFromActive: props.distanceFromActive,
 		path: [column, ...path],
-		binaryMode: workflowsStore.workflow.settings?.binaryMode,
+		binaryMode: workflowDocumentStore?.value?.settings?.binaryMode,
 	});
 }
 

--- a/packages/frontend/editor-ui/src/features/ndv/shared/composables/useBinaryDataAccessTooltip.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/composables/useBinaryDataAccessTooltip.ts
@@ -1,17 +1,17 @@
 import { computed } from 'vue';
 import { BINARY_MODE_COMBINED } from 'n8n-workflow';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useI18n } from '@n8n/i18n';
 
 /**
  * Composable for getting the binary data access tooltip based on the workflow's binary mode
  */
 export function useBinaryDataAccessTooltip() {
-	const workflowsStore = useWorkflowsStore();
+	const workflowDocumentStore = injectWorkflowDocumentStore();
 	const i18n = useI18n();
 
 	const binaryDataAccessTooltip = computed(() => {
-		if (workflowsStore.workflow.settings?.binaryMode === BINARY_MODE_COMBINED) {
+		if (workflowDocumentStore?.value?.settings?.binaryMode === BINARY_MODE_COMBINED) {
 			return i18n.baseText('ndv.binaryData.combinedTooltip', {
 				interpolate: {
 					example: "{{ $('Target Node').item.binaryName }}",

--- a/packages/frontend/editor-ui/src/features/shared/editors/components/CodeNodeEditor/CodeNodeEditor.vue
+++ b/packages/frontend/editor-ui/src/features/shared/editors/components/CodeNodeEditor/CodeNodeEditor.vue
@@ -18,7 +18,7 @@ import AskAI from './AskAI/AskAI.vue';
 import { CODE_PLACEHOLDERS } from './constants';
 import { useLinter } from './linter';
 import { useSettingsStore } from '@/app/stores/settings.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { dropInCodeEditor } from '../../plugins/codemirror/dragAndDrop';
 import type { TargetNodeParameterContext } from '@/Interface';
 import { valueToInsert } from './utils';
@@ -66,12 +66,12 @@ const rootStore = useRootStore();
 const i18n = useI18n();
 const telemetry = useTelemetry();
 const settingsStore = useSettingsStore();
-const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 
 const linter = useLinter(
 	() => props.mode,
 	() => (props.language === 'pythonNative' ? 'python' : props.language),
-	() => workflowsStore.workflow.settings?.binaryMode,
+	() => workflowDocumentStore?.value?.settings?.binaryMode,
 );
 const extensions = computed(() => [linter.value]);
 const placeholder = computed(() => CODE_PLACEHOLDERS[props.language]?.[props.mode] ?? '');
@@ -210,7 +210,12 @@ async function onDrop(value: string, event: MouseEvent) {
 	await dropInCodeEditor(
 		toRaw(editor.value),
 		event,
-		valueToInsert(value, props.language, props.mode, workflowsStore.workflow.settings?.binaryMode),
+		valueToInsert(
+			value,
+			props.language,
+			props.mode,
+			workflowDocumentStore?.value?.settings?.binaryMode,
+		),
 	);
 }
 

--- a/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/typescript/client/useTypescript.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/typescript/client/useTypescript.ts
@@ -5,6 +5,7 @@ import { autocompletableNodeNames } from '@/features/shared/editors/plugins/code
 import useEnvironmentsStore from '@/features/settings/environments.ee/environments.store';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { forceParse } from '@/app/utils/forceParse';
 import { executionDataToJson } from '@/app/utils/nodeTypesUtils';
 import { autocompletion } from '@codemirror/autocomplete';
@@ -33,6 +34,7 @@ export function useTypescript(
 	const { getInputDataWithPinned, getSchemaForExecutionData } = useDataSchema();
 	const ndvStore = useNDVStore();
 	const workflowsStore = useWorkflowsStore();
+	const workflowDocumentStore = injectWorkflowDocumentStore();
 	const { debounce } = useDebounce();
 	const activeNodeName = toValue(targetNodeParameterContext)?.nodeName ?? ndvStore.activeNodeName;
 	const worker = ref<Comlink.Remote<LanguageServiceWorker>>();
@@ -57,7 +59,7 @@ export function useTypescript(
 						)
 					: [],
 				mode: toValue(mode),
-				binaryMode: workflowsStore.workflow.settings?.binaryMode,
+				binaryMode: workflowDocumentStore?.value?.settings?.binaryMode,
 			},
 			Comlink.proxy(async (nodeName) => {
 				const node = workflowsStore.getNodeByName(nodeName);


### PR DESCRIPTION
## Summary

This pull request refactors how workflow settings are managed throughout the editor UI by consolidating settings access into the `workflowDocumentStore` instead of directly using `workflowsStore.workflowSettings`. This change improves consistency and reliability, especially in collaborative and multi-document scenarios. The update affects both the main `WorkflowSettings` component and its associated tests, as well as related composables and test utilities.

**Workflow Settings Store Refactor**

* Replaced all direct usage of `workflowsStore.workflowSettings` in `WorkflowSettings.vue` with access via the computed `workflowDocumentStore`, ensuring that settings are always retrieved from and updated in the correct document context. [[1]](diffhunk://#diff-c71676b22cf0cfd5fa57bd1049d90b7f2b9b5a3fa9caa4cccf9168da24b36b99L44-R47) [[2]](diffhunk://#diff-c71676b22cf0cfd5fa57bd1049d90b7f2b9b5a3fa9caa4cccf9168da24b36b99L70-R76) [[3]](diffhunk://#diff-c71676b22cf0cfd5fa57bd1049d90b7f2b9b5a3fa9caa4cccf9168da24b36b99L554-R562) [[4]](diffhunk://#diff-c71676b22cf0cfd5fa57bd1049d90b7f2b9b5a3fa9caa4cccf9168da24b36b99L678-R685)
* Updated the logic for saving and initializing settings in `WorkflowSettings.vue` to use `workflowDocumentStore.getSettingsSnapshot()` and `workflowDocumentStore.setSettings()`, removing dependency on `deepCopy` and eliminating the use of the old workflow state injection. [[1]](diffhunk://#diff-c71676b22cf0cfd5fa57bd1049d90b7f2b9b5a3fa9caa4cccf9168da24b36b99L554-R562) [[2]](diffhunk://#diff-c71676b22cf0cfd5fa57bd1049d90b7f2b9b5a3fa9caa4cccf9168da24b36b99L678-R685)

**Test Suite Updates**

* Refactored all tests in `WorkflowSettings.test.ts` to set and read workflow settings via `workflowDocumentStore.setSettings()` instead of mutating `workflowsStore.workflowSettings`, ensuring tests align with the new store structure. [[1]](diffhunk://#diff-aee69609ace79906b844ee62ccc9d4e08da65f7a92ad924c911b17335960b2a3L164-R179) [[2]](diffhunk://#diff-aee69609ace79906b844ee62ccc9d4e08da65f7a92ad924c911b17335960b2a3L185-R201) [[3]](diffhunk://#diff-aee69609ace79906b844ee62ccc9d4e08da65f7a92ad924c911b17335960b2a3L209-R224) [[4]](diffhunk://#diff-aee69609ace79906b844ee62ccc9d4e08da65f7a92ad924c911b17335960b2a3L313-R326) [[5]](diffhunk://#diff-aee69609ace79906b844ee62ccc9d4e08da65f7a92ad924c911b17335960b2a3L335-R348) [[6]](diffhunk://#diff-aee69609ace79906b844ee62ccc9d4e08da65f7a92ad924c911b17335960b2a3L362-R374) [[7]](diffhunk://#diff-aee69609ace79906b844ee62ccc9d4e08da65f7a92ad924c911b17335960b2a3L379-R391) [[8]](diffhunk://#diff-aee69609ace79906b844ee62ccc9d4e08da65f7a92ad924c911b17335960b2a3L422-R434) [[9]](diffhunk://#diff-aee69609ace79906b844ee62ccc9d4e08da65f7a92ad924c911b17335960b2a3L447-R458) [[10]](diffhunk://#diff-aee69609ace79906b844ee62ccc9d4e08da65f7a92ad924c911b17335960b2a3L472-R482) [[11]](diffhunk://#diff-aee69609ace79906b844ee62ccc9d4e08da65f7a92ad924c911b17335960b2a3L497-R506) [[12]](diffhunk://#diff-aee69609ace79906b844ee62ccc9d4e08da65f7a92ad924c911b17335960b2a3L516-R526) [[13]](diffhunk://#diff-aee69609ace79906b844ee62ccc9d4e08da65f7a92ad924c911b17335960b2a3L660-R668) [[14]](diffhunk://#diff-aee69609ace79906b844ee62ccc9d4e08da65f7a92ad924c911b17335960b2a3L671-R679) [[15]](diffhunk://#diff-aee69609ace79906b844ee62ccc9d4e08da65f7a92ad924c911b17335960b2a3L733-R741)
* Added initialization of `workflowDocumentStore` in tests using the main pinia instance to ensure correct action stubbing and store context.

**Composables and Utilities Cleanup**

* Updated `executionFinished.ts` handler to retrieve workflow settings from `workflowDocumentStore` rather than directly from `workflowsStore`, ensuring settings are always document-specific.
* Removed unused or obsolete methods such as `setWorkflowSettings` from mocks and test spies, reflecting the new workflow settings management approach. [[1]](diffhunk://#diff-f9825c0fcfe80cc1346dd9b9ab031905b7092f647ab401799163364bbd43bd33L88) [[2]](diffhunk://#diff-41478f0a5f6dbfb9c7209a4792c5f097ceaca8c403769d5a2ac4fba68bd2a753L251) [[3]](diffhunk://#diff-41478f0a5f6dbfb9c7209a4792c5f097ceaca8c403769d5a2ac4fba68bd2a753L266-L269)

**Minor Logic and Dependency Updates**

* Cleaned up imports in `WorkflowSettings.vue` to remove unused helpers and update to the new workflow document store methods. [[1]](diffhunk://#diff-c71676b22cf0cfd5fa57bd1049d90b7f2b9b5a3fa9caa4cccf9168da24b36b99L29-R29) [[2]](diffhunk://#diff-c71676b22cf0cfd5fa57bd1049d90b7f2b9b5a3fa9caa4cccf9168da24b36b99L44-R47)
* Improved the robustness of MCP workflow deactivation logic by referencing `workflowDocumentStore` settings instead of the old workflow object.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2361/normalize-settings-field-in-workflow-document-state


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
