### PR TITLE
fix: Fix selector-purity violation and E2E impact analysis in CI

### DIFF
--- a/.github/workflows/test-e2e-ci-reusable.yml
+++ b/.github/workflows/test-e2e-ci-reusable.yml
@@ -27,6 +27,7 @@ jobs:
       contents: read
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
+      skip-tests: ${{ steps.generate-matrix.outputs.skip-tests }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -62,7 +63,10 @@ jobs:
 
       - name: Generate shard matrix
         id: generate-matrix
-        run: echo "matrix=$(node packages/testing/playwright/scripts/distribute-tests.mjs --matrix 16 --orchestrate ${{ inputs.playwright-only && format('--impact --base=origin/{0}', github.event.pull_request.base.ref || 'master') || '' }})" >> "$GITHUB_OUTPUT"
+        run: |
+          MATRIX=$(node packages/testing/playwright/scripts/distribute-tests.mjs --matrix 16 --orchestrate ${{ inputs.playwright-only && format('--impact --base=origin/{0}', github.event.pull_request.base.ref || 'master') || '' }})
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          echo "skip-tests=$(node -e "process.stdout.write(JSON.parse(process.argv[1])[0]?.skip === true ? 'true' : 'false')" "$MATRIX")" >> "$GITHUB_OUTPUT"
 
   sqlite-sanity:
     needs: [prepare]
@@ -85,7 +89,7 @@ jobs:
   multi-main-e2e:
     needs: [prepare]
     name: 'Multi-Main: E2E'
-    if: ${{ !github.event.pull_request.head.repo.fork }}
+    if: ${{ !github.event.pull_request.head.repo.fork && needs.prepare.outputs.skip-tests != 'true' }}
     uses: ./.github/workflows/test-e2e-reusable.yml
     with:
       branch: ${{ inputs.branch }}

--- a/.github/workflows/test-e2e-ci-reusable.yml
+++ b/.github/workflows/test-e2e-ci-reusable.yml
@@ -71,8 +71,7 @@ jobs:
         run: |
           ARGS=(--matrix 16 --orchestrate)
           if [[ "${{ inputs.playwright-only }}" == "true" ]]; then
-            ARGS+=(--impact)
-            [[ -n "$CHANGED_FILES" ]] && ARGS+=("--files=$CHANGED_FILES")
+            ARGS+=(--impact "--files=$CHANGED_FILES")
           fi
           MATRIX=$(node packages/testing/playwright/scripts/distribute-tests.mjs "${ARGS[@]}")
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-e2e-ci-reusable.yml
+++ b/.github/workflows/test-e2e-ci-reusable.yml
@@ -57,10 +57,24 @@ jobs:
           BUILD_STATS_WEBHOOK_PASSWORD: ${{ secrets.BUILD_STATS_WEBHOOK_PASSWORD }}
           DOCKER_STATS_WEBHOOK_URL: ${{ secrets.DOCKER_STATS_WEBHOOK_URL }}
 
+      - name: Get changed files for impact analysis
+        if: ${{ inputs.playwright-only }}
+        id: changed-files
+        run: |
+          git fetch --depth=1 origin ${{ github.event.pull_request.base.ref || 'master' }}
+          echo "list=$(git diff --name-only FETCH_HEAD HEAD | tr '\n' ',' | sed 's/,$//')" >> "$GITHUB_OUTPUT"
+
       - name: Generate shard matrix
         id: generate-matrix
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.list }}
         run: |
-          MATRIX=$(node packages/testing/playwright/scripts/distribute-tests.mjs --matrix 16 --orchestrate ${{ inputs.playwright-only && format('--impact --base=origin/{0}', github.event.pull_request.base.ref || 'master') || '' }})
+          ARGS=(--matrix 16 --orchestrate)
+          if [[ "${{ inputs.playwright-only }}" == "true" ]]; then
+            ARGS+=(--impact)
+            [[ -n "$CHANGED_FILES" ]] && ARGS+=("--files=$CHANGED_FILES")
+          fi
+          MATRIX=$(node packages/testing/playwright/scripts/distribute-tests.mjs "${ARGS[@]}")
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
           echo "skip-tests=$(node -e "process.stdout.write(JSON.parse(process.argv[1])[0]?.skip === true ? 'true' : 'false')" "$MATRIX")" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/test-e2e-ci-reusable.yml
+++ b/.github/workflows/test-e2e-ci-reusable.yml
@@ -35,10 +35,6 @@ jobs:
           ref: ${{ inputs.branch || github.ref }}
           fetch-depth: 1
 
-      - name: Fetch base branch for impact analysis
-        if: ${{ inputs.playwright-only }}
-        run: git fetch origin ${{ github.event.pull_request.base.ref || 'master' }} --depth=1
-
       - name: Login to GHCR
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:

--- a/packages/testing/janitor/src/utils/git-operations.ts
+++ b/packages/testing/janitor/src/utils/git-operations.ts
@@ -78,7 +78,17 @@ export function getChangedFiles(options: GitChangedFilesOptions): string[] {
 
 	try {
 		if (targetBranch) {
-			const output = execFileSync('git', ['diff', '--name-only', `${targetBranch}...HEAD`], {
+			// Fetch the base branch at depth=1 so FETCH_HEAD is available for the diff.
+			// Using FETCH_HEAD with two-dot diff avoids the need for a merge base, which
+			// fails with shallow clones (fatal: no merge base). This matches the approach
+			// used by the ci-filter action across the rest of the repo.
+			const remoteName = targetBranch.startsWith('origin/') ? targetBranch.slice(7) : targetBranch;
+			execFileSync('git', ['fetch', '--depth=1', 'origin', remoteName], {
+				cwd: gitRoot,
+				encoding: 'utf-8',
+				stdio: 'pipe',
+			});
+			const output = execFileSync('git', ['diff', '--name-only', 'FETCH_HEAD', 'HEAD'], {
 				cwd: gitRoot,
 				encoding: 'utf-8',
 			});

--- a/packages/testing/playwright/pages/CanvasPage.ts
+++ b/packages/testing/playwright/pages/CanvasPage.ts
@@ -179,6 +179,10 @@ export class CanvasPage extends BasePage {
 		return this.page.locator('.rename-prompt');
 	}
 
+	getRenameInput(): Locator {
+		return this.getRenamePrompt().locator('input');
+	}
+
 	/**
 	 * Get the names of all pinned nodes on the canvas.
 	 * @returns An array of node names.

--- a/packages/testing/playwright/scripts/distribute-tests.mjs
+++ b/packages/testing/playwright/scripts/distribute-tests.mjs
@@ -46,9 +46,9 @@ function getRequiredImages(capabilities) {
 
 function getOrchestration(numShards, options = {}) {
 	const impactFlag = options.impact ? ' --impact' : '';
-	const baseFlag = options.base ? ` --base=${options.base}` : '';
+	const filesFlag = options.files ? ` --files=${options.files}` : '';
 	const output = execSync(
-		`node ${JANITOR_CLI} orchestrate --shards=${numShards}${impactFlag}${baseFlag}`,
+		`node ${JANITOR_CLI} orchestrate --shards=${numShards}${impactFlag}${filesFlag}`,
 		{ cwd: PLAYWRIGHT_DIR, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'inherit'] },
 	);
 	return JSON.parse(output);
@@ -58,7 +58,7 @@ const args = process.argv.slice(2);
 const matrixMode = args.includes('--matrix');
 const orchestrateMode = args.includes('--orchestrate');
 const impactMode = args.includes('--impact');
-const baseArg = args.find((a) => a.startsWith('--base='))?.slice('--base='.length);
+const filesArg = args.find((a) => a.startsWith('--files='))?.slice('--files='.length) || undefined;
 const shards = parseInt(args.find((a) => !a.startsWith('-')) ?? '');
 
 if (!shards || shards < 1) {
@@ -76,7 +76,7 @@ if (matrixMode) {
 		}));
 		console.log(JSON.stringify(matrix));
 	} else {
-		const result = getOrchestration(shards, { impact: impactMode, base: baseArg });
+		const result = getOrchestration(shards, { impact: impactMode, files: filesArg });
 
 		if (result.shards.length === 0) {
 			console.error('\n⏭️  No specs to run — all filtered out by discovery/impact. Skipping.\n');
@@ -116,7 +116,7 @@ if (matrixMode) {
 		console.error(`Index must be between 0 and ${shards - 1}`);
 		process.exit(1);
 	}
-	const result = getOrchestration(shards, { impact: impactMode, base: baseArg });
+	const result = getOrchestration(shards, { impact: impactMode, files: filesArg });
 	const shard = result.shards[index];
 	if (shard) {
 		console.log(shard.specs.join('\n'));

--- a/packages/testing/playwright/scripts/distribute-tests.mjs
+++ b/packages/testing/playwright/scripts/distribute-tests.mjs
@@ -49,7 +49,7 @@ function getOrchestration(numShards, options = {}) {
 	const baseFlag = options.base ? ` --base=${options.base}` : '';
 	const output = execSync(
 		`node ${JANITOR_CLI} orchestrate --shards=${numShards}${impactFlag}${baseFlag}`,
-		{ cwd: PLAYWRIGHT_DIR, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+		{ cwd: PLAYWRIGHT_DIR, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'inherit'] },
 	);
 	return JSON.parse(output);
 }
@@ -80,7 +80,7 @@ if (matrixMode) {
 
 		if (result.shards.length === 0) {
 			console.error('\n⏭️  No specs to run — all filtered out by discovery/impact. Skipping.\n');
-			console.log(JSON.stringify([{ shard: 1, specs: '', images: '' }]));
+			console.log(JSON.stringify([{ shard: 1, specs: '', images: '', skip: true }]));
 		} else {
 			console.error('\n📊 Shard Distribution:');
 			let maxShardTime = 0;

--- a/packages/testing/playwright/scripts/distribute-tests.mjs
+++ b/packages/testing/playwright/scripts/distribute-tests.mjs
@@ -13,7 +13,7 @@
  *   node distribute-tests.mjs <shards> <index>                 # Specs for a single shard
  */
 
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -45,12 +45,14 @@ function getRequiredImages(capabilities) {
 }
 
 function getOrchestration(numShards, options = {}) {
-	const impactFlag = options.impact ? ' --impact' : '';
-	const filesFlag = options.files ? ` --files=${options.files}` : '';
-	const output = execSync(
-		`node ${JANITOR_CLI} orchestrate --shards=${numShards}${impactFlag}${filesFlag}`,
-		{ cwd: PLAYWRIGHT_DIR, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'inherit'] },
-	);
+	const cliArgs = ['orchestrate', `--shards=${numShards}`];
+	if (options.impact) cliArgs.push('--impact');
+	if (options.files) cliArgs.push(`--files=${options.files}`);
+	const output = execFileSync('node', [JANITOR_CLI, ...cliArgs], {
+		cwd: PLAYWRIGHT_DIR,
+		encoding: 'utf-8',
+		stdio: ['pipe', 'pipe', 'inherit'],
+	});
 	return JSON.parse(output);
 }
 

--- a/packages/testing/playwright/tests/e2e/workflows/editor/canvas/canvas-zoom.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/canvas/canvas-zoom.spec.ts
@@ -163,8 +163,7 @@ test.describe(
 			await n8n.page.keyboard.press('Shift+Space');
 			await n8n.page.keyboard.type('Y');
 
-			const renameInput = n8n.canvas.getRenamePrompt().locator('input');
-			await expect(renameInput).toHaveValue('X: Y');
+			await expect(n8n.canvas.getRenameInput()).toHaveValue('X: Y');
 
 			await n8n.page.keyboard.press('Enter');
 			await expect(n8n.canvas.nodeByName('X: Y')).toBeAttached();


### PR DESCRIPTION
## Summary

What started as a small janitor fix uncovered two bugs in the CI impact analysis pipeline. This PR fixes all three issues:

**1. Selector-purity violation (`canvas-zoom.spec.ts`)**
Moved a chained `.locator('input')` call out of the test and into `CanvasPage` as `getRenameInput()`, fixing the `selector-purity` error caught by the janitor.

**2. Broken `playwright-only` fallback in CI**
When impact analysis found no affected specs, `distribute-tests.mjs` emitted a sentinel matrix entry with empty `specs`, causing Playwright to run all 746 tests on a single shard — far worse than the normal 16-shard run. Fixed by:
- Adding `skip: true` to the no-specs sentinel
- Capturing a `skip-tests` output from the `prepare` job and using it to skip `multi-main-e2e` entirely via `needs` context

**3. Impact analysis silently returning no changed files**
`git diff --name-only origin/master...HEAD` (three-dot) requires a merge base, which fails with `fatal: no merge base` on shallow CI checkouts. The janitor's `getChangedFiles` was catching the exception and returning `[]`, making every `playwright-only` run report no affected specs.

The CI workflow now computes the changed file list itself (fetch + `FETCH_HEAD HEAD` two-dot diff, matching the approach used by `ci-filter` across the rest of the repo) and passes it directly to the janitor via `--files=`. This decouples the janitor from git operations in CI entirely — impact analysis is now pure AST. The janitor's `--base` path is preserved for local use.

## Related Linear tickets, Github issues, and Community forum posts

<!-- https://linear.app/n8n/issue/ -->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created. (internal tooling only)
- [x] Tests included. (all changes verified via TCR and CI)
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)