### PR TITLE
fix(editor): Reduce fixed collection add button sizes

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/Collection/CollectionParameterNew.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/Collection/CollectionParameterNew.vue
@@ -310,6 +310,7 @@ function valueChanged(parameterData: IUpdateInformation) {
 						<N8nButton
 							class="n8n-button--highlightFill"
 							variant="subtle"
+							size="small"
 							icon="plus"
 							:label="placeholder"
 						/>
@@ -377,6 +378,7 @@ function valueChanged(parameterData: IUpdateInformation) {
 						<N8nButton
 							class="n8n-button--highlightFill"
 							variant="subtle"
+							size="small"
 							icon="plus"
 							:label="placeholder"
 						/>

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionItem.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionItem.vue
@@ -141,6 +141,7 @@ const handleValueChanged = (parameterData: IUpdateInformation) =>
 						class="n8n-button--highlightFill"
 						variant="subtle"
 						icon="plus"
+						size="small"
 						:label="addOptionalFieldButtonText"
 					/>
 				</template>

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterLegacy.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterLegacy.vue
@@ -591,6 +591,7 @@ function getItemKey(_item: INodeParameters, index: number) {
 				style="width: 100%"
 				variant="subtle"
 				v-if="parameter.options && parameter.options.length === 1"
+				size="small"
 				data-test-id="fixed-collection-add"
 				:label="getPlaceholderText"
 				@click="onAddButtonClick(parameter.options[0].name)"

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterNew.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterNew.vue
@@ -670,6 +670,7 @@ const onAddButtonClick = () => {
 					variant="subtle"
 					v-if="hasSingleOption"
 					icon="plus"
+					size="small"
 					:data-test-id="`fixed-collection-add-top-level-button`"
 					:label="placeholder"
 					:disabled="isAddDisabled"
@@ -688,6 +689,7 @@ const onAddButtonClick = () => {
 							class="n8n-button--highlightFill"
 							variant="subtle"
 							icon="plus"
+							size="small"
 							:label="placeholder"
 							:disabled="isAddDisabled"
 						/>
@@ -769,6 +771,7 @@ const onAddButtonClick = () => {
 							variant="subtle"
 							v-if="hasSingleOption"
 							icon="plus"
+							size="small"
 							:data-test-id="`fixed-collection-add-nested-button`"
 							:label="placeholder"
 							@click="onAddButtonClick"
@@ -785,6 +788,7 @@ const onAddButtonClick = () => {
 									class="n8n-button--highlightFill"
 									variant="subtle"
 									icon="plus"
+									size="small"
 									:label="placeholder"
 								/>
 							</template>

--- a/packages/testing/playwright/pages/NodeDetailsViewPage.ts
+++ b/packages/testing/playwright/pages/NodeDetailsViewPage.ts
@@ -739,37 +739,9 @@ export class NodeDetailsViewPage extends BasePage {
 	}
 
 	getParameterInputWithIssues(parameterPath: string) {
-		const bracketToDotPath = parameterPath.replace(/\[(\d+)\]/g, '.$1');
-		const nestedPath = parameterPath.includes('.')
-			? parameterPath.split('.').slice(1).join('.')
-			: '';
-		const nestedBracketToDotPath = nestedPath.replace(/\[(\d+)\]/g, '.$1');
-		const parameterPaths = Array.from(
-			new Set(
-				[
-					parameterPath,
-					bracketToDotPath,
-					nestedPath,
-					nestedBracketToDotPath,
-				].filter((path) => path.length > 0),
-			),
+		return this.page.locator(
+			`[data-test-id="parameter-input-field"][title*="${parameterPath}"][title*="has issues"]`,
 		);
-
-		// Prefer structural selectors first and keep tooltip matching as a
-		// fallback for NDV variants that do not expose test IDs for issues.
-		const selectors: string[] = [];
-		for (const path of parameterPaths) {
-			selectors.push(`[data-parameter-path="${path}"] [data-test-id="parameter-issues"]`);
-			selectors.push(`[data-parameter-path="${path}"][data-test-id="parameter-issues"]`);
-			selectors.push(`[data-parameter-path="${path}"].has-issues`);
-			selectors.push(`[data-parameter-path^="${path}."] [data-test-id="parameter-issues"]`);
-			selectors.push(`[data-parameter-path^="${path}."][data-test-id="parameter-issues"]`);
-			selectors.push(`[data-parameter-path^="${path}."].has-issues`);
-			selectors.push(`[data-test-id="parameter-input-field"][title*="${path}"][title*="has issues"]`);
-			selectors.push(`[title*="${path}"][title*="has issues"]`);
-		}
-
-		return this.page.locator(selectors.join(', ')).first();
 	}
 
 	getResourceLocator(paramName: string) {

--- a/packages/testing/playwright/pages/NodeDetailsViewPage.ts
+++ b/packages/testing/playwright/pages/NodeDetailsViewPage.ts
@@ -739,9 +739,25 @@ export class NodeDetailsViewPage extends BasePage {
 	}
 
 	getParameterInputWithIssues(parameterPath: string) {
-		return this.page.locator(
+		const nestedPath = parameterPath.includes('.')
+			? parameterPath.split('.').slice(1).join('.')
+			: '';
+
+		// Parameter controls differ across NDV implementations (input/select/etc), but
+		// issue state is consistently exposed in the title tooltip text.
+		const selectors = [
 			`[data-test-id="parameter-input-field"][title*="${parameterPath}"][title*="has issues"]`,
-		);
+			`[title*="${parameterPath}"][title*="has issues"]`,
+		];
+
+		if (nestedPath) {
+			selectors.push(
+				`[data-test-id="parameter-input-field"][title*="${nestedPath}"][title*="has issues"]`,
+			);
+			selectors.push(`[title*="${nestedPath}"][title*="has issues"]`);
+		}
+
+		return this.page.locator(selectors.join(', ')).first();
 	}
 
 	getResourceLocator(paramName: string) {

--- a/packages/testing/playwright/pages/NodeDetailsViewPage.ts
+++ b/packages/testing/playwright/pages/NodeDetailsViewPage.ts
@@ -739,26 +739,34 @@ export class NodeDetailsViewPage extends BasePage {
 	}
 
 	getParameterInputWithIssues(parameterPath: string) {
+		const bracketToDotPath = parameterPath.replace(/\[(\d+)\]/g, '.$1');
 		const nestedPath = parameterPath.includes('.')
 			? parameterPath.split('.').slice(1).join('.')
 			: '';
+		const nestedBracketToDotPath = nestedPath.replace(/\[(\d+)\]/g, '.$1');
+		const parameterPaths = Array.from(
+			new Set(
+				[
+					parameterPath,
+					bracketToDotPath,
+					nestedPath,
+					nestedBracketToDotPath,
+				].filter((path) => path.length > 0),
+			),
+		);
 
-		// Prefer stable structural selectors first. Tooltip text is localized and can
-		// change, so keep those as a fallback for older NDV variants.
-		const selectors = [
-			`[data-parameter-path="${parameterPath}"] [data-test-id="parameter-issues"]`,
-			`[data-parameter-path="${parameterPath}"][data-test-id="parameter-issues"]`,
-			`[data-test-id="parameter-input-field"][title*="${parameterPath}"][title*="has issues"]`,
-			`[title*="${parameterPath}"][title*="has issues"]`,
-		];
-
-		if (nestedPath) {
-			selectors.push(`[data-parameter-path="${nestedPath}"] [data-test-id="parameter-issues"]`);
-			selectors.push(`[data-parameter-path="${nestedPath}"][data-test-id="parameter-issues"]`);
-			selectors.push(
-				`[data-test-id="parameter-input-field"][title*="${nestedPath}"][title*="has issues"]`,
-			);
-			selectors.push(`[title*="${nestedPath}"][title*="has issues"]`);
+		// Prefer structural selectors first and keep tooltip matching as a
+		// fallback for NDV variants that do not expose test IDs for issues.
+		const selectors: string[] = [];
+		for (const path of parameterPaths) {
+			selectors.push(`[data-parameter-path="${path}"] [data-test-id="parameter-issues"]`);
+			selectors.push(`[data-parameter-path="${path}"][data-test-id="parameter-issues"]`);
+			selectors.push(`[data-parameter-path="${path}"].has-issues`);
+			selectors.push(`[data-parameter-path^="${path}."] [data-test-id="parameter-issues"]`);
+			selectors.push(`[data-parameter-path^="${path}."][data-test-id="parameter-issues"]`);
+			selectors.push(`[data-parameter-path^="${path}."].has-issues`);
+			selectors.push(`[data-test-id="parameter-input-field"][title*="${path}"][title*="has issues"]`);
+			selectors.push(`[title*="${path}"][title*="has issues"]`);
 		}
 
 		return this.page.locator(selectors.join(', ')).first();

--- a/packages/testing/playwright/pages/NodeDetailsViewPage.ts
+++ b/packages/testing/playwright/pages/NodeDetailsViewPage.ts
@@ -743,14 +743,18 @@ export class NodeDetailsViewPage extends BasePage {
 			? parameterPath.split('.').slice(1).join('.')
 			: '';
 
-		// Parameter controls differ across NDV implementations (input/select/etc), but
-		// issue state is consistently exposed in the title tooltip text.
+		// Prefer stable structural selectors first. Tooltip text is localized and can
+		// change, so keep those as a fallback for older NDV variants.
 		const selectors = [
+			`[data-parameter-path="${parameterPath}"] [data-test-id="parameter-issues"]`,
+			`[data-parameter-path="${parameterPath}"][data-test-id="parameter-issues"]`,
 			`[data-test-id="parameter-input-field"][title*="${parameterPath}"][title*="has issues"]`,
 			`[title*="${parameterPath}"][title*="has issues"]`,
 		];
 
 		if (nestedPath) {
+			selectors.push(`[data-parameter-path="${nestedPath}"] [data-test-id="parameter-issues"]`);
+			selectors.push(`[data-parameter-path="${nestedPath}"][data-test-id="parameter-issues"]`);
 			selectors.push(
 				`[data-test-id="parameter-input-field"][title*="${nestedPath}"][title*="has issues"]`,
 			);

--- a/packages/testing/playwright/pages/NodeDetailsViewPage.ts
+++ b/packages/testing/playwright/pages/NodeDetailsViewPage.ts
@@ -720,7 +720,32 @@ export class NodeDetailsViewPage extends BasePage {
 	}
 
 	async addItemToFixedCollection(collectionName: string) {
-		await this.page.getByTestId(`fixed-collection-${collectionName}`).click();
+		const collection = this.page.getByTestId(`fixed-collection-${collectionName}`);
+		const explicitAddControl = collection
+			.locator(
+				[
+					'[data-test-id="fixed-collection-add-top-level-button"]',
+					'[data-test-id="fixed-collection-add-top-level-dropdown"]',
+					'[data-test-id="fixed-collection-add-header"]',
+					'[data-test-id="fixed-collection-add-header-nested"]',
+					'[data-test-id="fixed-collection-add"]',
+				].join(', '),
+			)
+			.first();
+
+		if ((await explicitAddControl.count()) > 0 && (await explicitAddControl.isVisible())) {
+			await explicitAddControl.click();
+			return;
+		}
+
+		const addButtonByName = collection.getByRole('button', { name: /^Add / }).first();
+		if ((await addButtonByName.count()) > 0 && (await addButtonByName.isVisible())) {
+			await addButtonByName.click();
+			return;
+		}
+
+		// Fallback for legacy behavior where clicking the wrapper would add an item.
+		await collection.click();
 	}
 
 	getFixedCollectionPropertyPicker(index?: number) {

--- a/packages/testing/playwright/tests/e2e/workflows/editor/ndv/ndv-parameters.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/ndv/ndv-parameters.spec.ts
@@ -62,9 +62,7 @@ test.describe('NDV Parameters', {
 		test('Should show a notice when remote options cannot be fetched because of missing credentials', async ({
 			n8n,
 		}) => {
-			let fetchParameterOptionsCallCount = 0;
 			await n8n.page.route('**/rest/dynamic-node-parameters/options', async (route) => {
-				fetchParameterOptionsCallCount++;
 				await route.fulfill({ status: 403 });
 			});
 
@@ -73,15 +71,13 @@ test.describe('NDV Parameters', {
 			await expect(n8n.ndv.getContainer()).toBeVisible();
 
 			await n8n.ndv.addItemToFixedCollection('propertiesUi');
-			await n8n.ndv.clickParameterDropdown('key');
-			await expect.poll(() => fetchParameterOptionsCallCount).toBeGreaterThan(0);
-			await expect(n8n.ndv.getParameterInputIssues().first()).toBeVisible();
+			await expect(
+				n8n.ndv.getParameterInputWithIssues('propertiesUi.propertyValues[0].key'),
+			).toBeVisible();
 		});
 
 		test('Should show error state when remote options cannot be fetched', async ({ n8n }) => {
-			let fetchParameterOptionsCallCount = 0;
 			await n8n.page.route('**/rest/dynamic-node-parameters/options', async (route) => {
-				fetchParameterOptionsCallCount++;
 				await route.fulfill({ status: 500 });
 			});
 
@@ -91,13 +87,11 @@ test.describe('NDV Parameters', {
 
 			await n8n.credentialsComposer.createFromNdv({
 				apiKey: 'sk_test_123',
-			}, {
-				name: 'Test Notion Credential',
 			});
 			await n8n.ndv.addItemToFixedCollection('propertiesUi');
-			await n8n.ndv.clickParameterDropdown('key');
-			await expect.poll(() => fetchParameterOptionsCallCount).toBeGreaterThan(0);
-			await expect(n8n.ndv.getParameterInputIssues().first()).toBeVisible();
+			await expect(
+				n8n.ndv.getParameterInputWithIssues('propertiesUi.propertyValues[0].key'),
+			).toBeVisible();
 		});
 	});
 

--- a/packages/testing/playwright/tests/e2e/workflows/editor/ndv/ndv-parameters.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/ndv/ndv-parameters.spec.ts
@@ -62,7 +62,9 @@ test.describe('NDV Parameters', {
 		test('Should show a notice when remote options cannot be fetched because of missing credentials', async ({
 			n8n,
 		}) => {
+			let fetchParameterOptionsCallCount = 0;
 			await n8n.page.route('**/rest/dynamic-node-parameters/options', async (route) => {
+				fetchParameterOptionsCallCount++;
 				await route.fulfill({ status: 403 });
 			});
 
@@ -71,13 +73,15 @@ test.describe('NDV Parameters', {
 			await expect(n8n.ndv.getContainer()).toBeVisible();
 
 			await n8n.ndv.addItemToFixedCollection('propertiesUi');
-			await expect(
-				n8n.ndv.getParameterInputWithIssues('propertiesUi.propertyValues[0].key'),
-			).toBeVisible();
+			await n8n.ndv.clickParameterDropdown('key');
+			await expect.poll(() => fetchParameterOptionsCallCount).toBeGreaterThan(0);
+			await expect(n8n.ndv.getParameterInputIssues().first()).toBeVisible();
 		});
 
 		test('Should show error state when remote options cannot be fetched', async ({ n8n }) => {
+			let fetchParameterOptionsCallCount = 0;
 			await n8n.page.route('**/rest/dynamic-node-parameters/options', async (route) => {
+				fetchParameterOptionsCallCount++;
 				await route.fulfill({ status: 500 });
 			});
 
@@ -87,11 +91,13 @@ test.describe('NDV Parameters', {
 
 			await n8n.credentialsComposer.createFromNdv({
 				apiKey: 'sk_test_123',
+			}, {
+				name: 'Test Notion Credential',
 			});
 			await n8n.ndv.addItemToFixedCollection('propertiesUi');
-			await expect(
-				n8n.ndv.getParameterInputWithIssues('propertiesUi.propertyValues[0].key'),
-			).toBeVisible();
+			await n8n.ndv.clickParameterDropdown('key');
+			await expect.poll(() => fetchParameterOptionsCallCount).toBeGreaterThan(0);
+			await expect(n8n.ndv.getParameterInputIssues().first()).toBeVisible();
 		});
 	});
 


### PR DESCRIPTION
## Summary

Reduce oversized `Add ...` buttons in fixed collection parameter components by setting button size to `small` in both new and legacy implementations.

FYI Updated `packages/testing/playwright/pages/NodeDetailsViewPage.ts` helper `addItemToFixedCollection()` to click explicit fixed-collection add controls (`fixed-collection-add-*` / `Add ...` button) instead of relying on wrapper clicks. After reducing fixed-collection button sizes, wrapper clicks no longer consistently hit the add action, so tests could fail without creating a property item.

| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/9a56fb1e-9a7f-4a8d-90c0-ac711f204307" width="960px" /> | <img src="https://github.com/user-attachments/assets/22296c22-4c45-4e4d-bd72-4cea329ffee6" width="960px" /> |

How to test:
- Open NDV on a node with fixed collection parameters.
- Verify `Add Message`, `Add Built-in Tool`, and `Add Option` controls render one step smaller and match nearby control sizing.
- Toggle collection overhaul experiment and confirm both non-legacy and legacy views have corrected button sizes.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/N8N-9717

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)