### PR TITLE
feat: Hide workflow edit conflict error in Sentry (no-changelog)

### DIFF
--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -1029,9 +1029,8 @@ export class WorkflowService {
 		const currentChecksum = await calculateWorkflowChecksum(dbWorkflow);
 
 		if (expectedChecksum !== currentChecksum) {
-			throw new BadRequestError(
+			throw new ConflictError(
 				'Your most recent changes may be lost, because someone else just updated this workflow. Open this workflow in a new tab to see those new updates.',
-				100,
 			);
 		}
 	}

--- a/packages/cli/test/integration/workflows/workflows.controller.ee.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.ee.test.ts
@@ -1341,8 +1341,8 @@ describe('PATCH /workflows/:workflowId', () => {
 				.patch(`/workflows/${id}`)
 				.send({ nodes: [], versionId: ownerVersionId, expectedChecksum: ownerChecksum });
 
-			expect(updateAttemptResponse.status).toBe(400);
-			expect(updateAttemptResponse.body.code).toBe(100);
+			expect(updateAttemptResponse.status).toBe(409);
+			expect(updateAttemptResponse.body.code).toBe(409);
 		});
 
 		it('should block member updating workflow nodes on interim update by owner', async () => {
@@ -1379,8 +1379,8 @@ describe('PATCH /workflows/:workflowId', () => {
 				.patch(`/workflows/${id}`)
 				.send({ nodes: [], versionId: memberVersionId, expectedChecksum: memberChecksum });
 
-			expect(updateAttemptResponse.status).toBe(400);
-			expect(updateAttemptResponse.body.code).toBe(100);
+			expect(updateAttemptResponse.status).toBe(409);
+			expect(updateAttemptResponse.body.code).toBe(409);
 		});
 
 		it('should block owner activation on interim activation by member', async () => {
@@ -1410,8 +1410,8 @@ describe('PATCH /workflows/:workflowId', () => {
 				expectedChecksum: ownerChecksum,
 			});
 
-			expect(activationAttemptResponse.status).toBe(400);
-			expect(activationAttemptResponse.body.code).toBe(100);
+			expect(activationAttemptResponse.status).toBe(409);
+			expect(activationAttemptResponse.body.code).toBe(409);
 		});
 
 		it('should block member activation on interim activation by owner', async () => {
@@ -1450,8 +1450,8 @@ describe('PATCH /workflows/:workflowId', () => {
 				expectedChecksum: memberChecksum,
 			});
 
-			expect(updateAttemptResponse.status).toBe(400);
-			expect(updateAttemptResponse.body.code).toBe(100);
+			expect(updateAttemptResponse.status).toBe(409);
+			expect(updateAttemptResponse.body.code).toBe(409);
 		});
 
 		it('should block member updating workflow settings on interim update by owner', async () => {
@@ -1483,8 +1483,8 @@ describe('PATCH /workflows/:workflowId', () => {
 				expectedChecksum: memberChecksum,
 			});
 
-			expect(updateAttemptResponse.status).toBe(400);
-			expect(updateAttemptResponse.body.code).toBe(100);
+			expect(updateAttemptResponse.status).toBe(409);
+			expect(updateAttemptResponse.body.code).toBe(409);
 		});
 
 		it('should block member updating workflow name on interim update by owner', async () => {
@@ -1516,8 +1516,8 @@ describe('PATCH /workflows/:workflowId', () => {
 				expectedChecksum: memberChecksum,
 			});
 
-			expect(updateAttemptResponse.status).toBe(400);
-			expect(updateAttemptResponse.body.code).toBe(100);
+			expect(updateAttemptResponse.status).toBe(409);
+			expect(updateAttemptResponse.body.code).toBe(409);
 		});
 	});
 

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -4167,8 +4167,8 @@ describe('POST /workflows/:workflowId/deactivate', () => {
 			.post(`/workflows/${workflow.id}/deactivate`)
 			.send({ expectedChecksum: outdatedChecksum });
 
-		expect(response.statusCode).toBe(400);
-		expect(response.body.code).toBe(100);
+		expect(response.statusCode).toBe(409);
+		expect(response.body.code).toBe(409);
 	});
 
 	test('should allow deactivation when expectedChecksum matches', async () => {
@@ -4416,8 +4416,8 @@ describe('POST /workflows/:workflowId/archive', () => {
 			.post(`/workflows/${workflow.id}/archive`)
 			.send({ expectedChecksum: outdatedChecksum });
 
-		expect(response.statusCode).toBe(400);
-		expect(response.body.code).toBe(100);
+		expect(response.statusCode).toBe(409);
+		expect(response.body.code).toBe(409);
 	});
 
 	test('should allow archive when expectedChecksum matches', async () => {

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
@@ -252,7 +252,7 @@ export function useWorkflowSaving({
 
 				uiStore.removeActiveAction('workflowSaving');
 
-				if (error.errorCode === 100) {
+				if (error.errorCode === 409) {
 					telemetry.track('User attempted to save locked workflow', {
 						workflowId: currentWorkflow,
 						sharing_role: getWorkflowProjectRole(currentWorkflow),

--- a/packages/frontend/editor-ui/src/app/plugins/sentry.ts
+++ b/packages/frontend/editor-ui/src/app/plugins/sentry.ts
@@ -9,6 +9,7 @@ const ignoredErrors = [
 	{ instanceof: ResponseError, message: /ECONNREFUSED/ },
 	{ instanceof: ResponseError, message: "Can't connect to n8n." },
 	{ instanceof: ResponseError, message: 'Unauthorized' },
+	{ instanceof: ResponseError, message: /Your most recent changes may be lost/ },
 	{ instanceof: RangeError, message: /Position \d+ is out of range for changeset of length \d+/ },
 	{ instanceof: RangeError, message: /Invalid change range \d+ to \d+/ },
 	{ instanceof: RangeError, message: /Selection points outside of document$/ },


### PR DESCRIPTION
## Summary

- Switch from `BadRequestError` with status 400 and code 100 to `ConflictError` (409) for workflow edit conflicts
- Hide this error from Sentry

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-4848](https://linear.app/n8n/issue/ADO-4848/responseerror-your-most-recent-changes-may-be-lost-because-someone)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
