### PR TITLE
fix(Slack Trigger Node): Users or bots to ignore are not actually ignored for `message_changed` event subtype

### DIFF
--- a/packages/nodes-base/nodes/Slack/SlackTrigger.node.ts
+++ b/packages/nodes-base/nodes/Slack/SlackTrigger.node.ts
@@ -370,7 +370,7 @@ export class SlackTrigger implements INodeType {
 		// Check if user should be ignored
 		if (options.userIds) {
 			const userIds = options.userIds as string[];
-			if (userIds.includes(req.body.event.user)) {
+			if (userIds.includes(req.body.event.user ?? req.body.event.message?.user)) {
 				return {};
 			}
 		}

--- a/packages/nodes-base/nodes/Slack/test/SlackTrigger.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/SlackTrigger.test.ts
@@ -369,6 +369,101 @@ describe('SlackTrigger Node', () => {
 		});
 	});
 
+	describe('webhook method - user ignore list', () => {
+		const getMessageEvent = (overrides: Record<string, unknown> = {}) => ({
+			body: {
+				type: 'event_callback',
+				event: {
+					type: 'message',
+					channel: 'C123',
+					text: 'Hello world',
+					...overrides,
+				},
+			},
+		});
+
+		beforeEach(() => {
+			mockWebhookFunctions.getNodeParameter.mockImplementation(
+				(paramName: string, defaultValue?: any) => {
+					switch (paramName) {
+						case 'trigger':
+							return ['message'];
+						case 'watchWorkspace':
+							return false;
+						case 'channelId':
+							return 'C123';
+						case 'downloadFiles':
+							return false;
+						case 'options':
+							return { userIds: ['U_IGNORED'] };
+						default:
+							return defaultValue;
+					}
+				},
+			);
+		});
+
+		it('should ignore event when event.user matches an ignored user', async () => {
+			mockWebhookFunctions.getRequestObject.mockReturnValue(
+				getMessageEvent({ user: 'U_IGNORED' }) as any,
+			);
+
+			const result = await slackTrigger.webhook!.call(mockWebhookFunctions);
+
+			expect(result).toEqual({});
+		});
+
+		it('should ignore event when event.user is undefined but event.message.user matches an ignored user', async () => {
+			mockWebhookFunctions.getRequestObject.mockReturnValue(
+				getMessageEvent({ user: undefined, message: { user: 'U_IGNORED' } }) as any,
+			);
+
+			const result = await slackTrigger.webhook!.call(mockWebhookFunctions);
+
+			expect(result).toEqual({});
+		});
+
+		it('should not ignore event when event.user does not match any ignored user', async () => {
+			mockWebhookFunctions.getRequestObject.mockReturnValue(
+				getMessageEvent({ user: 'U_SOMEONE_ELSE' }) as any,
+			);
+
+			const result = await slackTrigger.webhook!.call(mockWebhookFunctions);
+
+			expect(result.workflowData).toBeDefined();
+		});
+
+		it('should not ignore event when both event.user and event.message.user are absent from the ignore list', async () => {
+			mockWebhookFunctions.getRequestObject.mockReturnValue(
+				getMessageEvent({ user: undefined, message: { user: 'U_SOMEONE_ELSE' } }) as any,
+			);
+
+			const result = await slackTrigger.webhook!.call(mockWebhookFunctions);
+
+			expect(result.workflowData).toBeDefined();
+		});
+
+		it('should not ignore event when neither event.user nor event.message.user exist', async () => {
+			mockWebhookFunctions.getRequestObject.mockReturnValue(
+				getMessageEvent({ user: undefined }) as any,
+			);
+
+			const result = await slackTrigger.webhook!.call(mockWebhookFunctions);
+
+			expect(result.workflowData).toBeDefined();
+		});
+
+		it('should use event.user over event.message.user when both are present', async () => {
+			mockWebhookFunctions.getRequestObject.mockReturnValue(
+				getMessageEvent({ user: 'U_SOMEONE_ELSE', message: { user: 'U_IGNORED' } }) as any,
+			);
+
+			const result = await slackTrigger.webhook!.call(mockWebhookFunctions);
+
+			expect(result.workflowData).toBeDefined();
+		});
+	});
+
 	describe('webhook method - other event scenarios', () => {
 		it('should handle team_join event (no channel extraction needed)', async () => {
 			const mockRequest = {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Slack trigger allows to filter out events caused by specific users/bots, but this option didn't work for `message` event with `message_changed` subtype. This is due to the fact that the payload for this message does not have a top-level `user` field that the filtering logic is using, instead it's nested under `message` field. This PR updates the code to use that field as a fallback

### To test
1. Set up a Slack trigger to listen for new messages
2. Add your user to the list of users to ignore
3. Send a message to the channel that the trigger is listening in
4. Observe that the trigger didn't fire - expected
5. Edit the message you've sent
6. Observe that the trigger **did** fire - bug

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
https://linear.app/n8n/issue/NODE-4534/community-issue-bug-report-slack-trigger-usernames-to-ignore-fails-on
Closes #23782

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
