### PR TITLE
revert: Make n8n-workflow a peer dependency in ai-utilities

### DIFF
--- a/packages/@n8n/ai-utilities/package.json
+++ b/packages/@n8n/ai-utilities/package.json
@@ -49,13 +49,11 @@
     "langchain": "catalog:",
     "@n8n/config": "workspace:*",
     "@n8n/typescript-config": "workspace:*",
+    "n8n-workflow": "workspace:*",
     "tmp-promise": "3.0.3",
     "js-tiktoken": "catalog:",
     "https-proxy-agent": "catalog:",
     "proxy-from-env": "^1.1.0",
     "undici": "^6.21.0"
-  },
-  "peerDependencies": {
-    "n8n-workflow": "*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -547,7 +547,7 @@ importers:
         specifier: 'catalog:'
         version: 1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(zod-to-json-schema@3.23.3(zod@3.25.67))
       n8n-workflow:
-        specifier: '*'
+        specifier: workspace:*
         version: link:../../workflow
       proxy-from-env:
         specifier: ^1.1.0


### PR DESCRIPTION
## Summary

Reverts #26404. Moving `n8n-workflow` from `dependencies` to `peerDependencies` in `@n8n/ai-utilities` broke the monorepo build — peer deps aren't automatically resolved for the package itself during build, so `ai-utilities` can no longer find `n8n-workflow`.

The proper fix needs `n8n-workflow` in both `devDependencies` (for monorepo build) and `peerDependencies` (for npm consumers). Will follow up with a corrected PR.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4532

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
