### PR TITLE
chore(core): Add n8n-workflow to devDependencies in ai-utilities

### DIFF
--- a/packages/@n8n/ai-utilities/package.json
+++ b/packages/@n8n/ai-utilities/package.json
@@ -36,7 +36,8 @@
     "jest-mock-extended": "^3.0.4",
     "@types/mime-types": "catalog:",
     "tsx": "catalog:",
-    "axios": "catalog:"
+    "axios": "catalog:",
+    "n8n-workflow": "workspace:*"
   },
   "dependencies": {
     "zod": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -546,9 +546,6 @@ importers:
       langchain:
         specifier: 'catalog:'
         version: 1.2.3(@langchain/core@1.1.8(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.204.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(openai@6.19.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(zod-to-json-schema@3.23.3(zod@3.25.67))
-      n8n-workflow:
-        specifier: '*'
-        version: link:../../workflow
       proxy-from-env:
         specifier: ^1.1.0
         version: 1.1.0
@@ -577,6 +574,9 @@ importers:
       jest-mock-extended:
         specifier: ^3.0.4
         version: 3.0.4(jest@29.7.0(@types/node@20.19.21)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.17))(@types/node@20.19.21)(typescript@5.9.2)))(typescript@5.9.2)
+      n8n-workflow:
+        specifier: workspace:*
+        version: link:../../workflow
       tsx:
         specifier: 'catalog:'
         version: 4.19.3


### PR DESCRIPTION
## Summary

Fixes the build broken by #26404. That PR moved `n8n-workflow` from `dependencies` to `peerDependencies` in `@n8n/ai-utilities`, but peer deps aren't resolved for the package itself during build, so TypeScript couldn't find `n8n-workflow`.

This adds `n8n-workflow` to `devDependencies` so it's available during the monorepo build, while keeping the `peerDependencies` entry so npm consumers use the host's single instance (no nested copy).

| Context | `devDependencies` | `peerDependencies` | Result |
|---|---|---|---|
| Monorepo build | `workspace:*` resolves to local package | ignored | Build works |
| Published to npm | stripped (not installed) | signals "host must provide" | Single instance |

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4532

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)