### PR TITLE
feat(core): Add SSRF protection config

### DIFF
--- a/packages/@n8n/config/src/configs/__tests__/ssrf-protection.config.test.ts
+++ b/packages/@n8n/config/src/configs/__tests__/ssrf-protection.config.test.ts
@@ -1,0 +1,153 @@
+import { Container } from '@n8n/di';
+
+import { SsrfProtectionConfig, SSRF_DEFAULT_BLOCKED_IP_RANGES } from '../ssrf-protection.config';
+
+describe('SsrfProtectionConfig', () => {
+	beforeEach(() => {
+		Container.reset();
+		jest.clearAllMocks();
+	});
+
+	const originalEnv = process.env;
+	afterEach(() => {
+		process.env = originalEnv;
+	});
+
+	describe('defaults', () => {
+		test('enabled is false', () => {
+			process.env = {};
+			expect(Container.get(SsrfProtectionConfig).enabled).toBe(false);
+		});
+
+		test('resolvedBlockedIpRanges expands to default ranges', () => {
+			process.env = {};
+			const config = Container.get(SsrfProtectionConfig);
+			expect(config.resolvedBlockedIpRanges).toEqual(SSRF_DEFAULT_BLOCKED_IP_RANGES);
+		});
+
+		test('allowedIpRanges is empty array', () => {
+			process.env = {};
+			expect(Container.get(SsrfProtectionConfig).allowedIpRanges).toEqual([]);
+		});
+
+		test('allowedHostnames is empty array', () => {
+			process.env = {};
+			expect(Container.get(SsrfProtectionConfig).allowedHostnames).toEqual([]);
+		});
+
+		test('dnsCacheMaxTtlSeconds is 300', () => {
+			process.env = {};
+			expect(Container.get(SsrfProtectionConfig).dnsCacheMaxTtlSeconds).toBe(300);
+		});
+
+		test('dnsCacheMaxSize is 1048576', () => {
+			process.env = {};
+			expect(Container.get(SsrfProtectionConfig).dnsCacheMaxSize).toBe(1048576);
+		});
+	});
+
+	describe('N8N_SSRF_PROTECTION_ENABLED', () => {
+		test('sets enabled to true', () => {
+			process.env = { N8N_SSRF_PROTECTION_ENABLED: 'true' };
+			expect(Container.get(SsrfProtectionConfig).enabled).toBe(true);
+		});
+
+		test('sets enabled to false', () => {
+			process.env = { N8N_SSRF_PROTECTION_ENABLED: 'false' };
+			expect(Container.get(SsrfProtectionConfig).enabled).toBe(false);
+		});
+	});
+
+	describe('N8N_SSRF_BLOCKED_IP_RANGES', () => {
+		test('expands "default" to default ranges', () => {
+			process.env = { N8N_SSRF_BLOCKED_IP_RANGES: 'default' };
+			const config = Container.get(SsrfProtectionConfig);
+			expect(config.resolvedBlockedIpRanges).toEqual(SSRF_DEFAULT_BLOCKED_IP_RANGES);
+		});
+
+		test('parses custom comma-separated CIDRs', () => {
+			process.env = { N8N_SSRF_BLOCKED_IP_RANGES: '10.0.0.0/8,192.168.0.0/16' };
+			const config = Container.get(SsrfProtectionConfig);
+			expect(config.resolvedBlockedIpRanges).toEqual(['10.0.0.0/8', '192.168.0.0/16']);
+		});
+
+		test('trims whitespace in custom CIDRs', () => {
+			process.env = { N8N_SSRF_BLOCKED_IP_RANGES: ' 10.0.0.0/8 , 192.168.0.0/16 ' };
+			const config = Container.get(SsrfProtectionConfig);
+			expect(config.resolvedBlockedIpRanges).toEqual(['10.0.0.0/8', '192.168.0.0/16']);
+		});
+
+		test('filters empty entries', () => {
+			process.env = { N8N_SSRF_BLOCKED_IP_RANGES: '10.0.0.0/8,,192.168.0.0/16' };
+			const config = Container.get(SsrfProtectionConfig);
+			expect(config.resolvedBlockedIpRanges).toEqual(['10.0.0.0/8', '192.168.0.0/16']);
+		});
+
+		test('handles a single CIDR', () => {
+			process.env = { N8N_SSRF_BLOCKED_IP_RANGES: '10.0.0.0/8' };
+			expect(Container.get(SsrfProtectionConfig).resolvedBlockedIpRanges).toEqual(['10.0.0.0/8']);
+		});
+	});
+
+	describe('N8N_SSRF_ALLOWED_IP_RANGES', () => {
+		test('parses comma-separated CIDRs', () => {
+			process.env = { N8N_SSRF_ALLOWED_IP_RANGES: '10.5.0.0/24,10.6.0.0/24' };
+			expect(Container.get(SsrfProtectionConfig).allowedIpRanges).toEqual([
+				'10.5.0.0/24',
+				'10.6.0.0/24',
+			]);
+		});
+
+		test('is empty when env var is empty string', () => {
+			process.env = { N8N_SSRF_ALLOWED_IP_RANGES: '' };
+			expect(Container.get(SsrfProtectionConfig).allowedIpRanges).toEqual([]);
+		});
+	});
+
+	describe('N8N_SSRF_ALLOWED_HOSTNAMES', () => {
+		test('parses comma-separated patterns', () => {
+			process.env = { N8N_SSRF_ALLOWED_HOSTNAMES: '*.n8n.internal,api.example.com' };
+			expect(Container.get(SsrfProtectionConfig).allowedHostnames).toEqual([
+				'*.n8n.internal',
+				'api.example.com',
+			]);
+		});
+
+		test('is empty when env var is empty string', () => {
+			process.env = { N8N_SSRF_ALLOWED_HOSTNAMES: '' };
+			expect(Container.get(SsrfProtectionConfig).allowedHostnames).toEqual([]);
+		});
+	});
+
+	describe('numeric fields', () => {
+		test('overrides dnsCacheMaxTtlSeconds from env', () => {
+			process.env = { N8N_SSRF_DNS_CACHE_MAX_TTL_SECONDS: '600' };
+			expect(Container.get(SsrfProtectionConfig).dnsCacheMaxTtlSeconds).toBe(600);
+		});
+
+		test('overrides dnsCacheMaxSize from env', () => {
+			process.env = { N8N_SSRF_DNS_CACHE_MAX_SIZE: '2097152' };
+			expect(Container.get(SsrfProtectionConfig).dnsCacheMaxSize).toBe(2097152);
+		});
+
+		test('falls back to default for invalid dnsCacheMaxTtlSeconds', () => {
+			const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+			process.env = { N8N_SSRF_DNS_CACHE_MAX_TTL_SECONDS: 'notanumber' };
+			expect(Container.get(SsrfProtectionConfig).dnsCacheMaxTtlSeconds).toBe(300);
+			expect(consoleWarnSpy).toHaveBeenCalled();
+
+			consoleWarnSpy.mockRestore();
+		});
+
+		test('falls back to default for invalid dnsCacheMaxSize', () => {
+			const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+			process.env = { N8N_SSRF_DNS_CACHE_MAX_SIZE: 'invalid' };
+			expect(Container.get(SsrfProtectionConfig).dnsCacheMaxSize).toBe(1048576);
+			expect(consoleWarnSpy).toHaveBeenCalled();
+
+			consoleWarnSpy.mockRestore();
+		});
+	});
+});

--- a/packages/@n8n/config/src/configs/__tests__/ssrf-protection.config.test.ts
+++ b/packages/@n8n/config/src/configs/__tests__/ssrf-protection.config.test.ts
@@ -19,10 +19,10 @@ describe('SsrfProtectionConfig', () => {
 			expect(Container.get(SsrfProtectionConfig).enabled).toBe(false);
 		});
 
-		test('resolvedBlockedIpRanges expands to default ranges', () => {
+		test('blockedIpRanges defaults to default ranges', () => {
 			process.env = {};
 			const config = Container.get(SsrfProtectionConfig);
-			expect(config.resolvedBlockedIpRanges).toEqual(SSRF_DEFAULT_BLOCKED_IP_RANGES);
+			expect(config.blockedIpRanges).toEqual(SSRF_DEFAULT_BLOCKED_IP_RANGES);
 		});
 
 		test('allowedIpRanges is empty array', () => {
@@ -62,30 +62,42 @@ describe('SsrfProtectionConfig', () => {
 		test('expands "default" to default ranges', () => {
 			process.env = { N8N_SSRF_BLOCKED_IP_RANGES: 'default' };
 			const config = Container.get(SsrfProtectionConfig);
-			expect(config.resolvedBlockedIpRanges).toEqual(SSRF_DEFAULT_BLOCKED_IP_RANGES);
+			expect(config.blockedIpRanges).toEqual(SSRF_DEFAULT_BLOCKED_IP_RANGES);
+		});
+
+		test('expands "default" and appends custom ranges', () => {
+			process.env = { N8N_SSRF_BLOCKED_IP_RANGES: 'default,100.0.0.0/8' };
+			const config = Container.get(SsrfProtectionConfig);
+			expect(config.blockedIpRanges).toEqual([...SSRF_DEFAULT_BLOCKED_IP_RANGES, '100.0.0.0/8']);
+		});
+
+		test('matches "default" case-insensitively', () => {
+			process.env = { N8N_SSRF_BLOCKED_IP_RANGES: 'DEFAULT,100.0.0.0/8' };
+			const config = Container.get(SsrfProtectionConfig);
+			expect(config.blockedIpRanges).toEqual([...SSRF_DEFAULT_BLOCKED_IP_RANGES, '100.0.0.0/8']);
 		});
 
 		test('parses custom comma-separated CIDRs', () => {
 			process.env = { N8N_SSRF_BLOCKED_IP_RANGES: '10.0.0.0/8,192.168.0.0/16' };
 			const config = Container.get(SsrfProtectionConfig);
-			expect(config.resolvedBlockedIpRanges).toEqual(['10.0.0.0/8', '192.168.0.0/16']);
+			expect(config.blockedIpRanges).toEqual(['10.0.0.0/8', '192.168.0.0/16']);
 		});
 
 		test('trims whitespace in custom CIDRs', () => {
 			process.env = { N8N_SSRF_BLOCKED_IP_RANGES: ' 10.0.0.0/8 , 192.168.0.0/16 ' };
 			const config = Container.get(SsrfProtectionConfig);
-			expect(config.resolvedBlockedIpRanges).toEqual(['10.0.0.0/8', '192.168.0.0/16']);
+			expect(config.blockedIpRanges).toEqual(['10.0.0.0/8', '192.168.0.0/16']);
 		});
 
 		test('filters empty entries', () => {
 			process.env = { N8N_SSRF_BLOCKED_IP_RANGES: '10.0.0.0/8,,192.168.0.0/16' };
 			const config = Container.get(SsrfProtectionConfig);
-			expect(config.resolvedBlockedIpRanges).toEqual(['10.0.0.0/8', '192.168.0.0/16']);
+			expect(config.blockedIpRanges).toEqual(['10.0.0.0/8', '192.168.0.0/16']);
 		});
 
 		test('handles a single CIDR', () => {
 			process.env = { N8N_SSRF_BLOCKED_IP_RANGES: '10.0.0.0/8' };
-			expect(Container.get(SsrfProtectionConfig).resolvedBlockedIpRanges).toEqual(['10.0.0.0/8']);
+			expect(Container.get(SsrfProtectionConfig).blockedIpRanges).toEqual(['10.0.0.0/8']);
 		});
 	});
 
@@ -134,6 +146,16 @@ describe('SsrfProtectionConfig', () => {
 			const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
 
 			process.env = { N8N_SSRF_DNS_CACHE_MAX_TTL_SECONDS: 'notanumber' };
+			expect(Container.get(SsrfProtectionConfig).dnsCacheMaxTtlSeconds).toBe(300);
+			expect(consoleWarnSpy).toHaveBeenCalled();
+
+			consoleWarnSpy.mockRestore();
+		});
+
+		test('falls back to default for non-positive dnsCacheMaxTtlSeconds', () => {
+			const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+			process.env = { N8N_SSRF_DNS_CACHE_MAX_TTL_SECONDS: '0' };
 			expect(Container.get(SsrfProtectionConfig).dnsCacheMaxTtlSeconds).toBe(300);
 			expect(consoleWarnSpy).toHaveBeenCalled();
 

--- a/packages/@n8n/config/src/configs/ssrf-protection.config.ts
+++ b/packages/@n8n/config/src/configs/ssrf-protection.config.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 import { CommaSeparatedStringArray } from '../custom-types';
 import { Config, Env } from '../decorators';
 
@@ -28,6 +30,25 @@ export const SSRF_DEFAULT_BLOCKED_IP_RANGES: readonly string[] = Object.freeze([
 	'203.0.113.0/24',
 ]);
 
+/**
+ * Parses comma-separated blocked ranges, expands `default` (case-insensitive)
+ * to the built-in blocked ranges, and removes duplicates while preserving order.
+ */
+const blockedIpRangesSchema = z.string().transform((input) => {
+	const values = input
+		.split(',')
+		.map((value) => value.trim())
+		.filter((value) => value.length > 0);
+
+	const expanded = values.flatMap((value) =>
+		value.toLowerCase() === 'default' ? SSRF_DEFAULT_BLOCKED_IP_RANGES : value,
+	);
+
+	return [...new Set(expanded)];
+});
+
+const positiveNumberSchema = z.coerce.number().gt(0);
+
 @Config
 export class SsrfProtectionConfig {
 	/** Whether SSRF protection is enabled for nodes making HTTP requests to user-controllable targets. */
@@ -35,11 +56,12 @@ export class SsrfProtectionConfig {
 	enabled: boolean = false;
 
 	/**
-	 * Comma-separated CIDR ranges to block, or 'default' for the standard set.
-	 * Use `resolvedBlockedIpRanges` at runtime instead of reading this directly.
+	 * Comma-separated CIDR ranges to block.
+	 * Use `default` to include the standard set, optionally with custom ranges
+	 * (for example: `default,100.0.0.0/8`).
 	 */
-	@Env('N8N_SSRF_BLOCKED_IP_RANGES')
-	blockedIpRanges: string = 'default';
+	@Env('N8N_SSRF_BLOCKED_IP_RANGES', blockedIpRangesSchema)
+	blockedIpRanges: string[] = [...SSRF_DEFAULT_BLOCKED_IP_RANGES];
 
 	/** Comma-separated CIDR ranges to allow (takes precedence over the block list). */
 	@Env('N8N_SSRF_ALLOWED_IP_RANGES')
@@ -50,25 +72,10 @@ export class SsrfProtectionConfig {
 	allowedHostnames: CommaSeparatedStringArray<string> = [];
 
 	/** Maximum DNS cache TTL in seconds. Default: 300. */
-	@Env('N8N_SSRF_DNS_CACHE_MAX_TTL_SECONDS')
+	@Env('N8N_SSRF_DNS_CACHE_MAX_TTL_SECONDS', positiveNumberSchema)
 	dnsCacheMaxTtlSeconds: number = 300;
 
 	/** Maximum DNS cache size in bytes (LRU eviction). Default: 1 MB. */
 	@Env('N8N_SSRF_DNS_CACHE_MAX_SIZE')
 	dnsCacheMaxSize: number = 1024 * 1024;
-
-	/** Resolved list of blocked IP ranges after 'default' expansion. */
-	resolvedBlockedIpRanges: readonly string[] = [];
-
-	sanitize() {
-		if (this.blockedIpRanges === 'default') {
-			this.resolvedBlockedIpRanges = SSRF_DEFAULT_BLOCKED_IP_RANGES;
-			return;
-		}
-
-		this.resolvedBlockedIpRanges = this.blockedIpRanges
-			.split(',')
-			.map((s) => s.trim())
-			.filter((s) => s.length > 0);
-	}
 }

--- a/packages/@n8n/config/src/configs/ssrf-protection.config.ts
+++ b/packages/@n8n/config/src/configs/ssrf-protection.config.ts
@@ -33,8 +33,12 @@ export const SSRF_DEFAULT_BLOCKED_IP_RANGES: readonly string[] = Object.freeze([
 /**
  * Parses comma-separated blocked ranges, expands `default` (case-insensitive)
  * to the built-in blocked ranges, and removes duplicates while preserving order.
+ *
+ * @example
+ * parseBlockedIpRanges('default,100.0.0.0/8')
+ * // returns [...SSRF_DEFAULT_BLOCKED_IP_RANGES, '100.0.0.0/8']
  */
-const blockedIpRangesSchema = z.string().transform((input) => {
+const parseBlockedIpRanges = (input: string): string[] => {
 	const values = input
 		.split(',')
 		.map((value) => value.trim())
@@ -45,7 +49,9 @@ const blockedIpRangesSchema = z.string().transform((input) => {
 	);
 
 	return [...new Set(expanded)];
-});
+};
+
+const blockedIpRangesSchema = z.string().transform(parseBlockedIpRanges);
 
 const positiveNumberSchema = z.coerce.number().gt(0);
 

--- a/packages/@n8n/config/src/configs/ssrf-protection.config.ts
+++ b/packages/@n8n/config/src/configs/ssrf-protection.config.ts
@@ -5,7 +5,7 @@ import { Config, Env } from '../decorators';
  * Default blocked IP ranges applied when N8N_SSRF_BLOCKED_IP_RANGES is 'default'.
  * Covers RFC 1918, loopback, link-local, IPv6 unique local, and reserved/special ranges.
  */
-export const SSRF_DEFAULT_BLOCKED_IP_RANGES: readonly string[] = [
+export const SSRF_DEFAULT_BLOCKED_IP_RANGES: readonly string[] = Object.freeze([
 	// RFC 1918 private ranges
 	'10.0.0.0/8',
 	'172.16.0.0/12',
@@ -26,7 +26,7 @@ export const SSRF_DEFAULT_BLOCKED_IP_RANGES: readonly string[] = [
 	'198.18.0.0/15',
 	'198.51.100.0/24',
 	'203.0.113.0/24',
-] as const;
+]);
 
 @Config
 export class SsrfProtectionConfig {
@@ -63,11 +63,12 @@ export class SsrfProtectionConfig {
 	sanitize() {
 		if (this.blockedIpRanges === 'default') {
 			this.resolvedBlockedIpRanges = SSRF_DEFAULT_BLOCKED_IP_RANGES;
-		} else {
-			this.resolvedBlockedIpRanges = this.blockedIpRanges
-				.split(',')
-				.map((s) => s.trim())
-				.filter((s) => s.length > 0);
+			return;
 		}
+
+		this.resolvedBlockedIpRanges = this.blockedIpRanges
+			.split(',')
+			.map((s) => s.trim())
+			.filter((s) => s.length > 0);
 	}
 }

--- a/packages/@n8n/config/src/configs/ssrf-protection.config.ts
+++ b/packages/@n8n/config/src/configs/ssrf-protection.config.ts
@@ -1,0 +1,73 @@
+import { CommaSeparatedStringArray } from '../custom-types';
+import { Config, Env } from '../decorators';
+
+/**
+ * Default blocked IP ranges applied when N8N_SSRF_BLOCKED_IP_RANGES is 'default'.
+ * Covers RFC 1918, loopback, link-local, IPv6 unique local, and reserved/special ranges.
+ */
+export const SSRF_DEFAULT_BLOCKED_IP_RANGES: readonly string[] = [
+	// RFC 1918 private ranges
+	'10.0.0.0/8',
+	'172.16.0.0/12',
+	'192.168.0.0/16',
+	// Loopback
+	'127.0.0.0/8',
+	'::1',
+	// Link-local
+	'169.254.0.0/16',
+	'fe80::/10',
+	// IPv6 unique local
+	'fc00::/7',
+	'fd00::/8',
+	// Reserved/special purpose
+	'0.0.0.0/8',
+	'192.0.0.0/24',
+	'192.0.2.0/24',
+	'198.18.0.0/15',
+	'198.51.100.0/24',
+	'203.0.113.0/24',
+] as const;
+
+@Config
+export class SsrfProtectionConfig {
+	/** Whether SSRF protection is enabled for nodes making HTTP requests to user-controllable targets. */
+	@Env('N8N_SSRF_PROTECTION_ENABLED')
+	enabled: boolean = false;
+
+	/**
+	 * Comma-separated CIDR ranges to block, or 'default' for the standard set.
+	 * Use `resolvedBlockedIpRanges` at runtime instead of reading this directly.
+	 */
+	@Env('N8N_SSRF_BLOCKED_IP_RANGES')
+	blockedIpRanges: string = 'default';
+
+	/** Comma-separated CIDR ranges to allow (takes precedence over the block list). */
+	@Env('N8N_SSRF_ALLOWED_IP_RANGES')
+	allowedIpRanges: CommaSeparatedStringArray<string> = [];
+
+	/** Comma-separated hostname patterns to allow. Supports wildcards: *.n8n.internal */
+	@Env('N8N_SSRF_ALLOWED_HOSTNAMES')
+	allowedHostnames: CommaSeparatedStringArray<string> = [];
+
+	/** Maximum DNS cache TTL in seconds. Default: 300. */
+	@Env('N8N_SSRF_DNS_CACHE_MAX_TTL_SECONDS')
+	dnsCacheMaxTtlSeconds: number = 300;
+
+	/** Maximum DNS cache size in bytes (LRU eviction). Default: 1 MB. */
+	@Env('N8N_SSRF_DNS_CACHE_MAX_SIZE')
+	dnsCacheMaxSize: number = 1024 * 1024;
+
+	/** Resolved list of blocked IP ranges after 'default' expansion. */
+	resolvedBlockedIpRanges: readonly string[] = [];
+
+	sanitize() {
+		if (this.blockedIpRanges === 'default') {
+			this.resolvedBlockedIpRanges = SSRF_DEFAULT_BLOCKED_IP_RANGES;
+		} else {
+			this.resolvedBlockedIpRanges = this.blockedIpRanges
+				.split(',')
+				.map((s) => s.trim())
+				.filter((s) => s.length > 0);
+		}
+	}
+}

--- a/packages/@n8n/config/src/index.ts
+++ b/packages/@n8n/config/src/index.ts
@@ -31,6 +31,7 @@ import { ScalingModeConfig } from './configs/scaling-mode.config';
 import { SecurityConfig } from './configs/security.config';
 import { SentryConfig } from './configs/sentry.config';
 import { SsoConfig } from './configs/sso.config';
+import { SsrfProtectionConfig } from './configs/ssrf-protection.config';
 import { TagsConfig } from './configs/tags.config';
 import { TemplatesConfig } from './configs/templates.config';
 import { UserManagementConfig } from './configs/user-management.config';
@@ -48,6 +49,10 @@ export { sampleRateSchema } from './configs/sentry.config';
 export type { TaskRunnerMode } from './configs/runners.config';
 export { TaskRunnersConfig } from './configs/runners.config';
 export { SecurityConfig } from './configs/security.config';
+export {
+	SsrfProtectionConfig,
+	SSRF_DEFAULT_BLOCKED_IP_RANGES,
+} from './configs/ssrf-protection.config';
 export { ExecutionsConfig } from './configs/executions.config';
 export { LOG_SCOPES } from './configs/logging.config';
 export type { LogScope } from './configs/logging.config';
@@ -186,6 +191,9 @@ export class GlobalConfig {
 
 	@Nested
 	sso: SsoConfig;
+
+	@Nested
+	ssrfProtection: SsrfProtectionConfig;
 
 	/** Default locale for the UI. */
 	@Env('N8N_DEFAULT_LOCALE')

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -6,7 +6,7 @@ import path from 'node:path';
 
 import type { UserManagementConfig } from '../src/configs/user-management.config';
 import type { DatabaseConfig } from '../src/index';
-import { GlobalConfig } from '../src/index';
+import { GlobalConfig, SSRF_DEFAULT_BLOCKED_IP_RANGES } from '../src/index';
 
 jest.mock('fs');
 const mockFs = mock<typeof fs>();
@@ -25,7 +25,7 @@ describe('GlobalConfig', () => {
 		process.env = originalEnv;
 	});
 
-	const defaultConfig: GlobalConfig = {
+	const defaultConfig = {
 		path: '/',
 		host: 'localhost',
 		port: 5678,
@@ -411,11 +411,19 @@ describe('GlobalConfig', () => {
 				scopesProjectsRolesClaimName: 'n8n_projects',
 			},
 		},
+		ssrfProtection: {
+			enabled: false,
+			blockedIpRanges: 'default',
+			allowedIpRanges: [],
+			allowedHostnames: [],
+			dnsCacheMaxTtlSeconds: 300,
+			dnsCacheMaxSize: 1024 * 1024,
+			resolvedBlockedIpRanges: [...SSRF_DEFAULT_BLOCKED_IP_RANGES],
+		},
 		redis: {
 			prefix: 'n8n',
 		},
 		externalFrontendHooksUrls: '',
-		// @ts-expect-error structuredClone ignores properties defined as a getter
 		ai: {
 			enabled: false,
 			persistBuilderSessions: false,

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -4,7 +4,6 @@ import { mock } from 'jest-mock-extended';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-import type { UserManagementConfig } from '../src/configs/user-management.config';
 import type { DatabaseConfig } from '../src/index';
 import { GlobalConfig, SSRF_DEFAULT_BLOCKED_IP_RANGES } from '../src/index';
 
@@ -13,6 +12,21 @@ const mockFs = mock<typeof fs>();
 fs.readFileSync = mockFs.readFileSync;
 
 const consoleWarnMock = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+// Ignore the sanitize function from the GlobalConfig nested types
+type ConfigShape<T> = T extends ReadonlyArray<infer U>
+	? Array<ConfigShape<U>>
+	: T extends object
+		? {
+				[K in keyof T as K extends 'sanitize'
+					? never
+					: T[K] extends (...args: unknown[]) => unknown
+						? never
+						: K]: ConfigShape<T[K]>;
+			}
+		: T;
+
+type GlobalConfigShape = ConfigShape<GlobalConfig>;
 
 describe('GlobalConfig', () => {
 	beforeEach(() => {
@@ -135,7 +149,7 @@ describe('GlobalConfig', () => {
 					'project-shared': '',
 				},
 			},
-		} as UserManagementConfig,
+		},
 		eventBus: {
 			checkUnsentInterval: 0,
 			crashRecoveryMode: 'extensive',
@@ -424,6 +438,7 @@ describe('GlobalConfig', () => {
 			prefix: 'n8n',
 		},
 		externalFrontendHooksUrls: '',
+		// @ts-expect-error structuredClone ignores properties defined as a getter
 		ai: {
 			enabled: false,
 			persistBuilderSessions: false,
@@ -439,7 +454,7 @@ describe('GlobalConfig', () => {
 			trimmingTimeWindowDays: 2,
 			trimOnStartUp: false,
 		},
-	};
+	} satisfies GlobalConfigShape;
 
 	it('should use all default values when no env variables are defined', () => {
 		process.env = {};

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -427,12 +427,11 @@ describe('GlobalConfig', () => {
 		},
 		ssrfProtection: {
 			enabled: false,
-			blockedIpRanges: 'default',
+			blockedIpRanges: [...SSRF_DEFAULT_BLOCKED_IP_RANGES],
 			allowedIpRanges: [],
 			allowedHostnames: [],
 			dnsCacheMaxTtlSeconds: 300,
 			dnsCacheMaxSize: 1024 * 1024,
-			resolvedBlockedIpRanges: [...SSRF_DEFAULT_BLOCKED_IP_RANGES],
 		},
 		redis: {
 			prefix: 'n8n',


### PR DESCRIPTION
## Summary

- Add `SsrfProtectionConfig` to `@n8n/config` and wire it into `GlobalConfig` as `ssrfProtection`.
- Add SSRF env-backed settings, including default blocked ranges, allow lists, DNS cache TTL, and DNS cache size.
- Export `SsrfProtectionConfig` and `SSRF_DEFAULT_BLOCKED_IP_RANGES` from the config package index.
- Add unit tests covering defaults, env parsing, numeric overrides, and fallback behavior for invalid numeric values.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/CAT-2383

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
