### PR TITLE
feat(core): Emit audit event when execution data is revealed

### DIFF
--- a/packages/cli/src/eventbus/event-message-classes/event-message-audit.ts
+++ b/packages/cli/src/eventbus/event-message-classes/event-message-audit.ts
@@ -1,5 +1,5 @@
 import { EventMessageTypeNames } from 'n8n-workflow';
-import type { JsonObject, JsonValue } from 'n8n-workflow';
+import type { JsonObject, JsonValue, WorkflowSettings } from 'n8n-workflow';
 
 import type { EventNamesAuditType } from '.';
 import { AbstractEventMessage, isEventMessageOptionsWithType } from './abstract-event-message';
@@ -28,6 +28,10 @@ export interface EventPayloadAudit extends AbstractEventPayload {
 	settingsChanged?: Record<string, { from: JsonValue; to: JsonValue }>;
 	variableId?: string;
 	variableKey?: string;
+	executionId?: string;
+	ipAddress?: string;
+	userAgent?: string;
+	redactionPolicy?: WorkflowSettings.RedactionPolicy;
 }
 
 export interface EventMessageAuditOptions extends AbstractEventMessageOptions {

--- a/packages/cli/src/eventbus/event-message-classes/index.ts
+++ b/packages/cli/src/eventbus/event-message-classes/index.ts
@@ -104,6 +104,7 @@ export const eventNamesAudit = [
 	'n8n.audit.personal-sharing-restricted.disabled',
 	'n8n.audit.2fa-enforcement.enabled',
 	'n8n.audit.2fa-enforcement.disabled',
+	'n8n.audit.execution.data.revealed',
 ] as const;
 
 export type EventNamesWorkflowType = (typeof eventNamesWorkflow)[number];

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -463,7 +463,7 @@ export type RelayEventMap = {
 	};
 
 	'execution-data-revealed': {
-		userId: string;
+		user: UserLike;
 		executionId: string;
 		workflowId: string;
 		ipAddress: string;

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -8,6 +8,7 @@ import type {
 	IWorkflowExecutionDataProcess,
 	JsonValue,
 	WorkflowExecuteMode,
+	WorkflowSettings,
 } from 'n8n-workflow';
 
 import type { ConcurrencyQueueType } from '@/concurrency/concurrency-control.service';
@@ -459,6 +460,15 @@ export type RelayEventMap = {
 		user: UserLike;
 		executionIds: string[];
 		deleteBefore?: Date;
+	};
+
+	'execution-data-revealed': {
+		userId: string;
+		executionId: string;
+		workflowId: string;
+		ipAddress: string;
+		userAgent: string;
+		redactionPolicy: WorkflowSettings.RedactionPolicy;
 	};
 
 	// #endregion

--- a/packages/cli/src/events/relays/log-streaming.event-relay.ts
+++ b/packages/cli/src/events/relays/log-streaming.event-relay.ts
@@ -744,6 +744,7 @@ export class LogStreamingEventRelay extends EventRelay {
 		});
 	}
 
+	@Redactable()
 	private executionDataRevealed({
 		user,
 		executionId,

--- a/packages/cli/src/events/relays/log-streaming.event-relay.ts
+++ b/packages/cli/src/events/relays/log-streaming.event-relay.ts
@@ -745,7 +745,7 @@ export class LogStreamingEventRelay extends EventRelay {
 	}
 
 	private executionDataRevealed({
-		userId,
+		user,
 		executionId,
 		workflowId,
 		ipAddress,
@@ -754,7 +754,7 @@ export class LogStreamingEventRelay extends EventRelay {
 	}: RelayEventMap['execution-data-revealed']) {
 		void this.eventBus.sendAuditEvent({
 			eventName: 'n8n.audit.execution.data.revealed',
-			payload: { userId, executionId, workflowId, ipAddress, userAgent, redactionPolicy },
+			payload: { ...user, executionId, workflowId, ipAddress, userAgent, redactionPolicy },
 		});
 	}
 

--- a/packages/cli/src/events/relays/log-streaming.event-relay.ts
+++ b/packages/cli/src/events/relays/log-streaming.event-relay.ts
@@ -82,6 +82,7 @@ export class LogStreamingEventRelay extends EventRelay {
 			'execution-started-during-bootup': (event) => this.executionStartedDuringBootup(event),
 			'execution-cancelled': (event) => this.executionCancelled(event),
 			'execution-deleted': (event) => this.executionDeleted(event),
+			'execution-data-revealed': (event) => this.executionDataRevealed(event),
 			'ai-messages-retrieved-from-memory': (event) => this.aiMessagesRetrievedFromMemory(event),
 			'ai-message-added-to-memory': (event) => this.aiMessageAddedToMemory(event),
 			'ai-output-parsed': (event) => this.aiOutputParsed(event),
@@ -740,6 +741,20 @@ export class LogStreamingEventRelay extends EventRelay {
 				executionIds,
 				...(deleteBefore && { deleteBefore: deleteBefore.toISOString() }),
 			},
+		});
+	}
+
+	private executionDataRevealed({
+		userId,
+		executionId,
+		workflowId,
+		ipAddress,
+		userAgent,
+		redactionPolicy,
+	}: RelayEventMap['execution-data-revealed']) {
+		void this.eventBus.sendAuditEvent({
+			eventName: 'n8n.audit.execution.data.revealed',
+			payload: { userId, executionId, workflowId, ipAddress, userAgent, redactionPolicy },
 		});
 	}
 

--- a/packages/cli/src/executions/execution-redaction.ts
+++ b/packages/cli/src/executions/execution-redaction.ts
@@ -3,6 +3,8 @@ import type { IExecutionDb, User } from '@n8n/db';
 
 export type ExecutionRedactionOptions = {
 	user: User;
+	ipAddress?: string;
+	userAgent?: string;
 } & Pick<ExecutionRedactionQueryDto, 'redactExecutionData'>;
 
 export interface ExecutionRedaction {

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -152,7 +152,7 @@ export class ExecutionService {
 				user: req.user,
 				redactExecutionData,
 				ipAddress: req.ip ?? '',
-				userAgent: (req.headers['user-agent'] as string) ?? '',
+				userAgent: req.headers['user-agent'] ?? '',
 			},
 		);
 

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -151,6 +151,8 @@ export class ExecutionService {
 			{
 				user: req.user,
 				redactExecutionData,
+				ipAddress: req.ip ?? '',
+				userAgent: (req.headers['user-agent'] as string) ?? '',
 			},
 		);
 

--- a/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
+++ b/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
@@ -317,7 +317,7 @@ describe('ExecutionRedactionService', () => {
 			await service.processExecution(execution, options);
 
 			expect(eventService.emit).toHaveBeenCalledWith('execution-data-revealed', {
-				userId: mockUser.id,
+				user: mockUser,
 				executionId: execution.id,
 				workflowId: execution.workflowId,
 				ipAddress: '1.2.3.4',

--- a/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
+++ b/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
@@ -9,9 +9,11 @@ import type {
 	WorkflowExecuteMode,
 } from 'n8n-workflow';
 import { ExpressionError, NodeApiError, NodeOperationError } from 'n8n-workflow';
+import { mock } from 'jest-mock-extended';
 
 import type { ExecutionRedactionOptions } from '@/executions/execution-redaction';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { EventService } from '@/events/event.service';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
 import { ExecutionRedactionService } from '../execution-redaction.service';
@@ -19,6 +21,7 @@ import { ExecutionRedactionService } from '../execution-redaction.service';
 describe('ExecutionRedactionService', () => {
 	const logger = mockInstance(Logger);
 	const workflowFinderService = mockInstance(WorkflowFinderService);
+	const eventService = mock<EventService>();
 	let service: ExecutionRedactionService;
 
 	const mockUser = {
@@ -31,7 +34,7 @@ describe('ExecutionRedactionService', () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks();
-		service = new ExecutionRedactionService(logger, workflowFinderService);
+		service = new ExecutionRedactionService(logger, workflowFinderService, eventService);
 		// Default: user lacks execution:reveal scope → canReveal: false
 		workflowFinderService.findWorkflowForUser.mockResolvedValue(null);
 	});
@@ -298,6 +301,42 @@ describe('ExecutionRedactionService', () => {
 			};
 
 			await expect(service.processExecution(execution, options)).rejects.toThrow(ForbiddenError);
+		});
+
+		it('should emit execution-data-revealed when user is allowed to reveal', async () => {
+			workflowFinderService.findWorkflowForUser.mockResolvedValue({ id: 'workflow-123' } as never);
+
+			const execution = createMockExecution({ policy: 'all', mode: 'trigger', withRunData: true });
+			const options: ExecutionRedactionOptions = {
+				user: mockUser,
+				redactExecutionData: false,
+				ipAddress: '1.2.3.4',
+				userAgent: 'TestAgent/1.0',
+			};
+
+			await service.processExecution(execution, options);
+
+			expect(eventService.emit).toHaveBeenCalledWith('execution-data-revealed', {
+				userId: mockUser.id,
+				executionId: execution.id,
+				workflowId: execution.workflowId,
+				ipAddress: '1.2.3.4',
+				userAgent: 'TestAgent/1.0',
+				redactionPolicy: 'all',
+			});
+		});
+
+		it('should not emit execution-data-revealed when user is forbidden', async () => {
+			// workflowFinderService returns null (default in beforeEach) → no permission
+			const execution = createMockExecution({ policy: 'all', mode: 'trigger' });
+			const options: ExecutionRedactionOptions = {
+				user: mockUser,
+				redactExecutionData: false,
+			};
+
+			await expect(service.processExecution(execution, options)).rejects.toThrow(ForbiddenError);
+
+			expect(eventService.emit).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
+++ b/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
@@ -13,7 +13,7 @@ import { mock } from 'jest-mock-extended';
 
 import type { ExecutionRedactionOptions } from '@/executions/execution-redaction';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
-import { EventService } from '@/events/event.service';
+import type { EventService } from '@/events/event.service';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
 import { ExecutionRedactionService } from '../execution-redaction.service';

--- a/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
+++ b/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
@@ -15,6 +15,7 @@ import {
 	WorkflowSettings,
 } from 'n8n-workflow';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { EventService } from '@/events/event.service';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
 const MANUAL_MODES: ReadonlySet<WorkflowExecuteMode> = new Set(['manual']);
@@ -28,6 +29,7 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 	constructor(
 		private readonly logger: Logger,
 		private readonly workflowFinderService: WorkflowFinderService,
+		private readonly eventService: EventService,
 	) {}
 
 	/**
@@ -60,6 +62,14 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 			const allowed =
 				this.policyAllowsReveal(execution) || (await this.canUserReveal(options.user, execution));
 			if (allowed) {
+				this.eventService.emit('execution-data-revealed', {
+					userId: options.user.id,
+					executionId: execution.id,
+					workflowId: execution.workflowId,
+					ipAddress: options.ipAddress ?? '',
+					userAgent: options.userAgent ?? '',
+					redactionPolicy: this.resolvePolicy(execution),
+				});
 				return execution;
 			} else {
 				throw new ForbiddenError();

--- a/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
+++ b/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
@@ -63,7 +63,7 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 				this.policyAllowsReveal(execution) || (await this.canUserReveal(options.user, execution));
 			if (allowed) {
 				this.eventService.emit('execution-data-revealed', {
-					userId: options.user.id,
+					user: options.user,
 					executionId: execution.id,
 					workflowId: execution.workflowId,
 					ipAddress: options.ipAddress ?? '',


### PR DESCRIPTION
## Summary

Implements audit event emission for the `n8n.audit.execution.data.revealed` event, completing the audit trail for the execution data reveal feature.

**What changed:**

- Added `'n8n.audit.execution.data.revealed'` to the `eventNamesAudit` array and four new optional fields (`executionId`, `ipAddress`, `userAgent`, `redactionPolicy`) to `EventPayloadAudit` — the eventbus audit layer
- Added `'execution-data-revealed'` entry to `RelayEventMap` with fully typed, required fields: `userId`, `executionId`, `workflowId`, `ipAddress`, `userAgent`, `redactionPolicy`
- Injected `EventService` into `ExecutionRedactionService` and emits `'execution-data-revealed'` in the `redactExecutionData === false && allowed` branch — the exact point where unredacted data is returned to the caller. The event is not emitted when the request is denied (`ForbiddenError`)
- Extended `ExecutionRedactionOptions` with optional `ipAddress` and `userAgent` fields; updated `ExecutionService.findOne()` to forward `req.ip` and `req.headers['user-agent']` into the options
- Added `executionDataRevealed` relay handler in `LogStreamingEventRelay` to bridge the relay event to `sendAuditEvent('n8n.audit.execution.data.revealed', ...)`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-189
https://linear.app/n8n/issue/IAM-188

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)