### PR TITLE
ci: Pass secrets to release-create-pr on workflow_call

### DIFF
--- a/.github/workflows/release-create-minor-pr.yml
+++ b/.github/workflows/release-create-minor-pr.yml
@@ -9,6 +9,7 @@ jobs:
   create-release-pr:
     name: Create release PR
     uses: ./.github/workflows/release-create-pr.yml
+    secrets: inherit
     with:
       base-branch: master
       release-type: minor


### PR DESCRIPTION
## Summary

Secrets aren't auto-injected to workflow calls (https://github.com/n8n-io/n8n/actions/runs/22579154754/job/65406148731#step:2:17)

This change pushes them with the workflow call.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
