### PR TITLE
fix(core): Don't include last human message twice on Chat hub message regeneration

### DIFF
--- a/packages/cli/src/modules/chat-hub/__tests__/chat-hub.service.integration.test.ts
+++ b/packages/cli/src/modules/chat-hub/__tests__/chat-hub.service.integration.test.ts
@@ -9,6 +9,7 @@ import { InstanceSettings, BinaryDataService, Cipher } from 'n8n-core';
 import {
 	CHAT_TRIGGER_NODE_TYPE,
 	CHAT_NODE_TYPE,
+	MEMORY_MANAGER_NODE_TYPE,
 	createRunExecutionData,
 	NodeOperationError,
 	type INode,
@@ -1200,6 +1201,176 @@ describe('chatHub', () => {
 				) as [ChatHubExecutionEnd, string[]] | undefined;
 				expect(endEvent).toBeDefined();
 				expect(endEvent![0].data.sessionId).toBe(sessionId);
+			});
+		});
+
+		describe('regenerateAIMessage', () => {
+			let anthropicCredential: CredentialsEntity;
+			let sessionId: string;
+			let messageId: string;
+
+			let spyExecute: jest.SpyInstance<
+				ReturnType<WorkflowExecutionService['executeChatWorkflow']>,
+				Parameters<WorkflowExecutionService['executeChatWorkflow']>
+			>;
+			let finishRun = (_: IRun) => {};
+
+			beforeEach(async () => {
+				jest.spyOn(instanceSettings, 'isMultiMain', 'get').mockReturnValue(false);
+				jest.spyOn(settingsRepository, 'findByKey').mockResolvedValue(null);
+
+				spyExecute = jest.spyOn(Container.get(WorkflowExecutionService), 'executeChatWorkflow');
+
+				jest
+					.spyOn(Container.get(ActiveExecutions), 'getPostExecutePromise')
+					// eslint-disable-next-line @typescript-eslint/promise-function-async
+					.mockImplementation(() => {
+						return new Promise((r) => {
+							finishRun = r;
+						});
+					});
+
+				anthropicCredential = await saveCredential(
+					{
+						name: 'Test Anthropic Credential',
+						type: 'anthropicApi',
+						data: { apiKey: 'test-api-key' },
+					},
+					{ user: member, role: 'credential:owner' },
+				);
+
+				sessionId = crypto.randomUUID();
+				messageId = crypto.randomUUID();
+			});
+
+			it('should not include the last human message in restored memory history', async () => {
+				// Step 1: Send a human message and get an AI response
+				spyExecute.mockImplementationOnce(async (_user, workflowData, executionData, stream) => {
+					const executionId = await executionPersistence.create({
+						finished: false,
+						mode: 'chat',
+						status: 'running',
+						workflowId: workflowData.id,
+						data: executionData,
+						workflowData,
+					});
+
+					setTimeout(() => stream!.write('{"type":"begin","metadata":{}}\n'));
+					setTimeout(() =>
+						stream!.write('{"type":"item","content":"AI response","metadata":{}}\n'),
+					);
+					setTimeout(() => stream!.write('{"type":"end","metadata":{}}\n'));
+					setTimeout(() => stream!.end());
+					setTimeout(async () => {
+						await executionRepository.updateExistingExecution(executionId, { status: 'success' });
+					});
+					setTimeout(() => finishRun({} as IRun));
+
+					return { executionId };
+				});
+
+				// Title generation mock — needed because sendHumanMessage triggers it for new sessions
+				spyExecute.mockRejectedValueOnce(Error());
+
+				await chatHubService.sendHumanMessage(
+					member,
+					{
+						userId: member.id,
+						sessionId,
+						messageId,
+						message: 'Hello',
+						model: { provider: 'anthropic', model: 'claude-3-5-sonnet-20241022' },
+						credentials: {
+							anthropicApi: { id: anthropicCredential.id, name: anthropicCredential.name },
+						},
+						previousMessageId: null,
+						attachments: [],
+					},
+					{
+						authToken: 'authtoken',
+						method: 'POST',
+						endpoint: '/api/chat/message',
+					},
+				);
+
+				// Wait for the AI response to be persisted
+				const messages = await retryUntil(async () => {
+					const messages = await messagesRepository.getManyBySessionId(sessionId);
+					expect(messages.length).toBeGreaterThanOrEqual(2);
+					expect(messages[1]?.status).toBe('success');
+					return messages;
+				});
+
+				const aiMessageId = messages[1].id;
+
+				// Step 2: Regenerate the AI message — capture the workflow
+				let capturedWorkflowData: IWorkflowBase | undefined;
+				spyExecute.mockImplementationOnce(async (_user, workflowData, executionData, stream) => {
+					capturedWorkflowData = workflowData;
+
+					const executionId = await executionPersistence.create({
+						finished: false,
+						mode: 'chat',
+						status: 'running',
+						workflowId: workflowData.id,
+						data: executionData,
+						workflowData,
+					});
+
+					setTimeout(() => stream!.write('{"type":"begin","metadata":{}}\n'));
+					setTimeout(() =>
+						stream!.write('{"type":"item","content":"Regenerated","metadata":{}}\n'),
+					);
+					setTimeout(() => stream!.write('{"type":"end","metadata":{}}\n'));
+					setTimeout(() => stream!.end());
+					setTimeout(async () => {
+						await executionRepository.updateExistingExecution(executionId, { status: 'success' });
+					});
+					setTimeout(() => finishRun({} as IRun));
+
+					return { executionId };
+				});
+
+				await chatHubService.regenerateAIMessage(
+					member,
+					{
+						userId: member.id,
+						sessionId,
+						retryId: aiMessageId,
+						model: { provider: 'anthropic', model: 'claude-3-5-sonnet-20241022' },
+						credentials: {
+							anthropicApi: { id: anthropicCredential.id, name: anthropicCredential.name },
+						},
+					},
+					{
+						authToken: 'authtoken',
+						method: 'POST',
+						endpoint: '/api/chat/message',
+					},
+				);
+
+				await retryUntil(async () => {
+					expect(capturedWorkflowData).toBeDefined();
+				});
+
+				// Verify the "Restore Chat Memory" node does NOT contain the human message
+				// The human message is already replayed via the chat trigger input,
+				// so including it in memory would cause the agent to see it twice
+				const restoreMemoryNode = capturedWorkflowData!.nodes.find(
+					(n) => n.type === MEMORY_MANAGER_NODE_TYPE && n.name === 'Restore Chat Memory',
+				);
+				expect(restoreMemoryNode).toBeDefined();
+
+				const messageValues = (
+					restoreMemoryNode!.parameters as {
+						messages: { messageValues: Array<{ type: string; message: string }> };
+					}
+				).messages.messageValues;
+
+				// Memory should be empty — the human message "Hello" should NOT be in the history
+				// because it's sent as the current chat input, not as part of memory restoration
+				const userMessages = messageValues.filter((m) => m.type === 'user');
+				expect(userMessages).toHaveLength(0);
 			});
 		});
 

--- a/packages/cli/src/modules/chat-hub/chat-hub.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.service.ts
@@ -700,7 +700,7 @@ export class ChatHubService {
 
 				const lastHumanMessageIndex = history.indexOf(lastHumanMessage);
 				if (lastHumanMessageIndex !== -1) {
-					history.splice(lastHumanMessageIndex + 1);
+					history.splice(lastHumanMessageIndex);
 				}
 
 				const retryOfMessageId = messageToRetry.retryOfMessageId ?? messageToRetry.id;

--- a/packages/testing/playwright/expectations/chat-hub/1770382922975-unknown-host-POST-_v1_messages-806f7911.json
+++ b/packages/testing/playwright/expectations/chat-hub/1770382922975-unknown-host-POST-_v1_messages-806f7911.json
@@ -56,11 +56,11 @@
 		}
 	},
 	"id": "1770382922975-unknown-host-POST-_v1_messages-806f7911.json",
-	"priority": 0,
+	"priority": 1,
 	"timeToLive": {
 		"unlimited": true
 	},
 	"times": {
-		"unlimited": true
+		"remainingTimes": 1
 	}
 }

--- a/packages/testing/playwright/expectations/chat-hub/1770382922976-unknown-host-POST-_v1_messages-202bcf80.json
+++ b/packages/testing/playwright/expectations/chat-hub/1770382922976-unknown-host-POST-_v1_messages-202bcf80.json
@@ -16,15 +16,11 @@
 					{
 						"role": "user",
 						"content": "Hi"
-					},
-					{
-						"role": "user",
-						"content": "Hi"
 					}
 				],
 				"system": "You are a helpful assistant.\n\n__e2e_system_prompt_placeholder__"
 			},
-			"rawBytes": "eyJtb2RlbCI6ImNsYXVkZS1vcHVzLTQtNiIsInN0cmVhbSI6dHJ1ZSwibWF4X3Rva2VucyI6ODE5MiwidGhpbmtpbmciOnsidHlwZSI6ImRpc2FibGVkIn0sIm1lc3NhZ2VzIjpbeyJyb2xlIjoidXNlciIsImNvbnRlbnQiOiJIaSJ9LHsicm9sZSI6InVzZXIiLCJjb250ZW50IjoiSGkifV0sInN5c3RlbSI6IllvdSBhcmUgYSBoZWxwZnVsIGFzc2lzdGFudC5cblxuX19lMmVfc3lzdGVtX3Byb21wdF9wbGFjZWhvbGRlcl9fIn0="
+			"rawBytes": "eyJtb2RlbCI6ImNsYXVkZS1vcHVzLTQtNiIsInN0cmVhbSI6dHJ1ZSwibWF4X3Rva2VucyI6ODE5MiwidGhpbmtpbmciOnsidHlwZSI6ImRpc2FibGVkIn0sIm1lc3NhZ2VzIjpbeyJyb2xlIjoidXNlciIsImNvbnRlbnQiOiJIaSJ9XSwic3lzdGVtIjoiWW91IGFyZSBhIGhlbHBmdWwgYXNzaXN0YW50LlxuXG5fX2UyZV9zeXN0ZW1fcHJvbXB0X3BsYWNlaG9sZGVyX18ifQ=="
 		}
 	},
 	"httpResponse": {
@@ -59,7 +55,7 @@
 			"contentType": "text/event-stream; charset=utf-8"
 		}
 	},
-	"id": "1770382922976-unknown-host-POST-_v1_messages-eb3a8d37.json",
+	"id": "1770382922976-unknown-host-POST-_v1_messages-202bcf80.json",
 	"priority": 0,
 	"timeToLive": {
 		"unlimited": true


### PR DESCRIPTION
## Summary

When user regenerated messages on Chat hub we accidentally included the last human message both oh the chat history and as a new human message triggering that turn.

Instead don't include the human message on the history, as it gets replayed which inserts it into the memory again.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-83/bug-duplicate-user-message-sent-on-regeneration

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
