### PR TITLE
ci: Pin Trivy binary version to fix yanked release

### DIFF
--- a/.github/workflows/security-trivy-scan-callable.yml
+++ b/.github/workflows/security-trivy-scan-callable.yml
@@ -51,6 +51,7 @@ jobs:
         id: trivy_scan
         with:
           image-ref: ${{ inputs.image_ref }}
+          version: 'v0.69.2'
           format: 'json'
           output: 'trivy-results.json'
           severity: 'CRITICAL,HIGH,MEDIUM,LOW'
@@ -102,7 +103,11 @@ jobs:
             echo ""
           } >> "$GITHUB_STEP_SUMMARY"
 
-          if [ "${{ steps.process_results.outputs.vulnerabilities_found }}" == "false" ]; then
+          if [ ! -s trivy-results.json ]; then
+            {
+              echo "⚠️ **Scan did not produce results.** Check the 'Run Trivy vulnerability scanner' step for errors."
+            } >> "$GITHUB_STEP_SUMMARY"
+          elif [ "${{ steps.process_results.outputs.vulnerabilities_found }}" == "false" ]; then
             {
               echo "✅ **No vulnerabilities found!**"
             } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Trivy `v0.69.1` was [yanked from GitHub](https://github.com/aquasecurity/trivy-action/issues/512), breaking `trivy-action@0.34.1`'s default binary install. This caused the security scan step to fail silently during the release publish workflow.

**Changes:**
- Pin Trivy binary to `v0.69.2` (the current available release) to fix the install failure
- Add a guard in the `if: always()` summary step to handle missing `trivy-results.json` gracefully, instead of crashing with a `jq` file-not-found error

## Related Linear tickets, Github issues, and Community forum posts

Upstream issue: https://github.com/aquasecurity/trivy-action/issues/512
Failed run: https://github.com/n8n-io/n8n/actions/runs/22580306877/job/65416508398

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)