### PR TITLE
feat(editor): Implement read-only mode for external secrets connections

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -3058,6 +3058,8 @@
 	"settings.secretsProviderConnections.modal.providerType": "External secrets provider",
 	"settings.secretsProviderConnections.modal.providerType.placeholder": "External secrets provider",
 	"settings.secretsProviderConnections.modal.saving": "Saving...",
+	"settings.secretsProviderConnections.modal.readOnly.notice.admin": "This vault is managed at the instance level. To make changes, go to External Secrets in Settings.",
+	"settings.secretsProviderConnections.modal.readOnly.notice.noPermission": "This vault is managed at the instance level. Contact your instance admin to make changes.",
 	"settings.secretsProviderConnections.modal.unsavedChanges.title": "Close without saving?",
 	"settings.secretsProviderConnections.modal.unsavedChanges.text": "You have unsaved changes. Are you sure you want to close?",
 	"settings.secretsProviderConnections.modal.testConnection.success.serviceEnabled": "Service enabled, {count} secrets available on {providerName}.",

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectExternalSecrets.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectExternalSecrets.vue
@@ -115,7 +115,7 @@ const emptyStateConfig = computed(() => {
 });
 
 const sortedConnections = computed(() =>
-	[...projectSecretConnections.value].sort((a, b) => b.secretsCount - a.secretsCount),
+	[...projectSecretConnections.value].sort((a, b) => a.name.localeCompare(b.name)),
 );
 
 const filteredConnections = computed(() => {

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionModal.ee.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionModal.ee.test.ts
@@ -68,6 +68,7 @@ const mockConnectionModal = {
 	canDelete: { value: true },
 	canShareGlobally: { value: true },
 	isScopedMode: { value: false },
+	isReadOnly: { value: false },
 	projectIds: { value: [] as string[] },
 	sharedWithProjects: { value: [] as ProjectSharingData[] },
 	selectProviderType: vi.fn(),
@@ -178,6 +179,7 @@ describe('SecretsProviderConnectionModal', () => {
 		mockConnectionModal.connectionProjects.value = [];
 		mockConnectionModal.isSharedGlobally.value = false;
 		mockConnectionModal.isScopedMode.value = false;
+		mockConnectionModal.isReadOnly.value = false;
 	});
 
 	it('should load connection data', async () => {
@@ -536,6 +538,69 @@ describe('SecretsProviderConnectionModal', () => {
 
 			// Verify setScopeState was called with empty array and true for global sharing
 			expect(mockConnectionModal.setScopeState).toHaveBeenCalledWith([], true);
+		});
+	});
+
+	describe('read-only mode for global connections', () => {
+		it('should hide the save button when isReadOnly is true', async () => {
+			mockConnectionModal.isReadOnly.value = true;
+
+			const { container } = renderComponent({
+				props: {
+					modalName: SECRETS_PROVIDER_CONNECTION_MODAL_KEY,
+					data: {
+						providerKey: 'test-123',
+						providerTypes: mockProviderTypes,
+					},
+				},
+			});
+
+			await nextTick();
+
+			const saveButton = container.querySelector(
+				'[data-test-id="secrets-provider-connection-save-button"]',
+			);
+			expect(saveButton).not.toBeInTheDocument();
+		});
+
+		it('should hide the delete button when isReadOnly is true', async () => {
+			mockConnectionModal.isReadOnly.value = true;
+
+			const { container } = renderComponent({
+				props: {
+					modalName: SECRETS_PROVIDER_CONNECTION_MODAL_KEY,
+					data: {
+						providerKey: 'test-123',
+						providerTypes: mockProviderTypes,
+					},
+				},
+			});
+
+			await nextTick();
+
+			const deleteButton = container.querySelector(
+				'[data-test-id="secrets-provider-delete-button"]',
+			);
+			expect(deleteButton).not.toBeInTheDocument();
+		});
+
+		it('should show read-only notice when isReadOnly is true', async () => {
+			mockConnectionModal.isReadOnly.value = true;
+
+			const { container } = renderComponent({
+				props: {
+					modalName: SECRETS_PROVIDER_CONNECTION_MODAL_KEY,
+					data: {
+						providerKey: 'test-123',
+						providerTypes: mockProviderTypes,
+					},
+				},
+			});
+
+			await nextTick();
+
+			const notice = container.querySelector('[data-test-id="secrets-provider-read-only-notice"]');
+			expect(notice).toBeInTheDocument();
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionModal.ee.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionModal.ee.vue
@@ -275,7 +275,7 @@ onMounted(async () => {
 						</N8nText>
 					</div>
 				</div>
-				<div :class="$style.actions">
+				<div v-if="!modal.isReadOnly.value" :class="$style.actions">
 					<N8nTooltip placement="left">
 						<N8nIconButton
 							v-if="modal.isEditMode.value && modal.canDelete.value"
@@ -322,6 +322,19 @@ onMounted(async () => {
 						<!-- Connection Tab Content -->
 						<div v-if="ACTIVE_TAB === 'connection'" :class="$style.mainContent">
 							<div>
+								<N8nNotice
+									v-if="modal.isReadOnly.value"
+									class="mb-l"
+									data-test-id="secrets-provider-read-only-notice"
+									:content="
+										i18n.baseText(
+											modal.canShareGlobally.value
+												? 'settings.secretsProviderConnections.modal.readOnly.notice.admin'
+												: 'settings.secretsProviderConnections.modal.readOnly.notice.noPermission',
+										)
+									"
+								/>
+
 								<!-- Connection State Callouts -->
 								<N8nCallout
 									v-if="modal.connection.connectionState.value === 'connected'"
@@ -367,87 +380,93 @@ onMounted(async () => {
 									:details="modal.connection.connectionError.value"
 								/>
 
-								<!-- Provider Name Input -->
-								<div class="mb-l">
-									<N8nInputLabel
-										:label="
-											i18n.baseText('settings.secretsProviderConnections.modal.connectionName')
-										"
-									/>
-									<N8nInput
-										data-test-id="provider-name"
-										:model-value="modal.connectionName.value"
-										:readonly="modal.isEditMode.value"
-										:disabled="modal.isEditMode.value"
-										aria-required="true"
-										placeholder="myVault"
-										@update:model-value="handleConnectionNameUpdate"
-										@blur="handleConnectionNameBlur"
-									/>
-									<N8nText
-										v-if="
-											modal.connectionNameError.value &&
-											modal.connectionNameBlurred.value &&
-											!modal.isEditMode.value
-										"
-										size="small"
-										color="danger"
-										:class="$style.headerHint"
-									>
-										{{ modal.connectionNameError.value }}
-									</N8nText>
-									<N8nText
-										v-else-if="!modal.isEditMode.value"
-										size="small"
-										color="text-light"
-										:class="$style.headerHint"
-									>
-										{{
-											i18n.baseText('settings.secretsProviderConnections.modal.connectionName.hint')
-										}}
-									</N8nText>
-								</div>
-
-								<!-- Provider Type Selector -->
-								<div class="mb-l">
-									<N8nInputLabel
-										:label="i18n.baseText('settings.secretsProviderConnections.modal.providerType')"
-									/>
-									<N8nSelect
-										data-test-id="provider-type-select"
-										:model-value="modal.selectedProviderType.value?.type"
-										:disabled="modal.isEditMode.value"
-										@update:model-value="handleProviderTypeChange"
-									>
-										<N8nOption
-											v-for="option in modal.providerTypeOptions.value"
-											:key="option.value"
-											:label="option.label"
-											:value="option.value"
+								<fieldset :disabled="modal.isReadOnly.value">
+									<!-- Provider Name Input -->
+									<div class="mb-l">
+										<N8nInputLabel
+											:label="
+												i18n.baseText('settings.secretsProviderConnections.modal.connectionName')
+											"
 										/>
-									</N8nSelect>
-								</div>
+										<N8nInput
+											data-test-id="provider-name"
+											:model-value="modal.connectionName.value"
+											:readonly="modal.isEditMode.value"
+											:disabled="modal.isEditMode.value"
+											aria-required="true"
+											placeholder="myVault"
+											@update:model-value="handleConnectionNameUpdate"
+											@blur="handleConnectionNameBlur"
+										/>
+										<N8nText
+											v-if="
+												modal.connectionNameError.value &&
+												modal.connectionNameBlurred.value &&
+												!modal.isEditMode.value
+											"
+											size="small"
+											color="danger"
+											:class="$style.headerHint"
+										>
+											{{ modal.connectionNameError.value }}
+										</N8nText>
+										<N8nText
+											v-else-if="!modal.isEditMode.value"
+											size="small"
+											color="text-light"
+											:class="$style.headerHint"
+										>
+											{{
+												i18n.baseText(
+													'settings.secretsProviderConnections.modal.connectionName.hint',
+												)
+											}}
+										</N8nText>
+									</div>
 
-								<!-- Dynamic Fields -->
-								<form
-									v-for="property in modal.selectedProviderType.value?.properties"
-									v-show="modal.shouldDisplayProperty(property)"
-									:key="property.name"
-									autocomplete="off"
-									@submit.prevent
-								>
-									<N8nNotice v-if="property.type === 'notice'" :content="property.displayName" />
-									<ParameterInputExpanded
-										v-else
-										:ref="(el) => modal.setParameterValidationState(property.name, el)"
-										class="mb-l"
-										:parameter="property"
-										:value="modal.connectionSettings.value[property.name]"
-										:label="LABEL_SIZE"
-										event-source="secrets-provider-connection"
-										@update="handleSettingChange"
-									/>
-								</form>
+									<!-- Provider Type Selector -->
+									<div class="mb-l">
+										<N8nInputLabel
+											:label="
+												i18n.baseText('settings.secretsProviderConnections.modal.providerType')
+											"
+										/>
+										<N8nSelect
+											data-test-id="provider-type-select"
+											:model-value="modal.selectedProviderType.value?.type"
+											:disabled="modal.isEditMode.value"
+											@update:model-value="handleProviderTypeChange"
+										>
+											<N8nOption
+												v-for="option in modal.providerTypeOptions.value"
+												:key="option.value"
+												:label="option.label"
+												:value="option.value"
+											/>
+										</N8nSelect>
+									</div>
+
+									<!-- Dynamic Fields -->
+									<form
+										v-for="property in modal.selectedProviderType.value?.properties"
+										v-show="modal.shouldDisplayProperty(property)"
+										:key="property.name"
+										autocomplete="off"
+										@submit.prevent
+									>
+										<N8nNotice v-if="property.type === 'notice'" :content="property.displayName" />
+										<ParameterInputExpanded
+											v-else
+											:ref="(el) => modal.setParameterValidationState(property.name, el)"
+											class="mb-l"
+											:parameter="property"
+											:value="modal.connectionSettings.value[property.name]"
+											:label="LABEL_SIZE"
+											event-source="secrets-provider-connection"
+											@update="handleSettingChange"
+										/>
+									</form>
+								</fieldset>
 							</div>
 						</div>
 

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useConnectionModal.ee.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useConnectionModal.ee.ts
@@ -493,6 +493,10 @@ export function useConnectionModal(options: UseConnectionModalOptions) {
 
 	const isScopedMode = computed(() => !!options.projectId);
 
+	const isReadOnly = computed(
+		() => isScopedMode.value && isSharedGlobally.value && isEditMode.value,
+	);
+
 	return {
 		// State refs
 		providerSecretsCount,
@@ -515,6 +519,7 @@ export function useConnectionModal(options: UseConnectionModalOptions) {
 		canDelete,
 		canShareGlobally,
 		isScopedMode,
+		isReadOnly,
 		setScopeState,
 
 		// Computed


### PR DESCRIPTION
## Summary

- Added read-only message in the UI for external secrets managed at the instance level.
- Updated sorting of project secret connections to be alphabetical by name.
- Enhanced the connection modal to conditionally hide save and delete buttons based on read-only status.
- Introduced computed property to determine read-only state based on scoped mode and global update permission.

Instance admin:
<img width="973" height="373" alt="Screenshot 2026-03-02 at 16 09 56" src="https://github.com/user-attachments/assets/bad892ee-d296-4aca-9cf3-422bfdbd63a9" />

Project admin:
<img width="964" height="353" alt="Screenshot 2026-03-02 at 16 19 06" src="https://github.com/user-attachments/assets/9d04aae9-57db-4f42-a76a-c991f5b2af72" />

## Related Linear tickets, Github issues, and Community forum posts

Closes [LIGO-317](https://linear.app/n8n/issue/LIGO-317/project-settings-page-prevent-editing-of-global-connections) 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
