### PR TITLE
feat(editor): Make it possible to pick Chat hub model by ID even if no models are loaded

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -417,7 +417,7 @@
 	"chatHub.agent.newAgent": "New Agent",
 	"chatHub.agent.unavailableAgent": "Unavailable agent",
 	"chatHub.agent.configureCredentials": "Configure credentials",
-	"chatHub.agent.addModel": "Add model",
+	"chatHub.agent.addModel": "Choose model by ID",
 	"chatHub.agent.credentialsMissing": "Credentials missing",
 	"chatHub.agent.card.menu.edit": "Edit",
 	"chatHub.agent.card.menu.delete": "Delete",

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ModelSelector.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ModelSelector.vue
@@ -97,6 +97,7 @@ const menu = computed(() =>
 		isLoading,
 		i18n,
 		settings: settingStore.moduleSettings?.['chat-hub']?.providers ?? {},
+		credentials,
 	}),
 );
 

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/model-selector.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/model-selector.utils.test.ts
@@ -47,6 +47,7 @@ const buildMenuOptions: BuildMenuItemsOptions = {
 	isLoading: false,
 	i18n: mockI18n,
 	settings: mockSettings.providers,
+	credentials: null,
 };
 
 describe(buildModelSelectorMenuItems, () => {
@@ -228,6 +229,36 @@ describe(buildModelSelectorMenuItems, () => {
 		expect(personalAgentsGroup?.children?.[0].label).toBe('generic.loadingEllipsis');
 		expect(personalAgentsGroup?.children?.[0].disabled).toBe(true);
 		expect(personalAgentsGroup?.children?.[1].label).toBe('chatHub.agent.newAgent');
+	});
+
+	it('should show "+ Add Model" button when provider has no models but has a credential', () => {
+		const agents = createMockModelsResponse({
+			openai: { models: [] },
+		});
+
+		const result = buildModelSelectorMenuItems(agents, {
+			...buildMenuOptions,
+			credentials: { openai: 'cred-123' },
+		});
+
+		const openaiGroup = result.find((item) => item.id === 'openai');
+		expect(openaiGroup).toBeDefined();
+		const addModelItem = openaiGroup?.children?.find((item) => item.id === 'openai::add-model');
+		expect(addModelItem).toBeDefined();
+		expect(addModelItem?.label).toBe('chatHub.agent.addModel');
+	});
+
+	it('should not show "+ Add Model" button when provider has no models and no credential', () => {
+		const agents = createMockModelsResponse({
+			openai: { models: [] },
+		});
+
+		const result = buildModelSelectorMenuItems(agents, buildMenuOptions);
+
+		const openaiGroup = result.find((item) => item.id === 'openai');
+		expect(openaiGroup).toBeDefined();
+		const addModelItem = openaiGroup?.children?.find((item) => item.id === 'openai::add-model');
+		expect(addModelItem).toBeUndefined();
 	});
 
 	it('should show empty state for workflow agents', () => {

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/model-selector.utils.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/model-selector.utils.ts
@@ -35,6 +35,7 @@ export interface BuildMenuItemsOptions {
 	isLoading: boolean;
 	i18n: I18nClass;
 	settings: Partial<Record<ChatHubLLMProvider, ChatProviderSettingsDto>>;
+	credentials: Partial<Record<ChatHubLLMProvider, string | null>> | null;
 }
 
 /**
@@ -217,8 +218,9 @@ function buildWorkflowAgentsMenuItem(
 function buildLlmProviderMenuItem(
 	provider: ChatHubLLMProvider,
 	{ models, error }: ChatModelsResponse[ChatHubLLMProvider],
-	{ settings, i18n, isLoading }: BuildMenuItemsOptions,
+	options: BuildMenuItemsOptions,
 ): MenuItem | null {
+	const { settings, i18n, isLoading, credentials } = options;
 	const providerSettings = settings[provider];
 
 	// Filter out disabled providers from the menu
@@ -282,7 +284,8 @@ function buildLlmProviderMenuItem(
 	const children = [
 		configureMenu,
 		...agentOptions,
-		...(agentOptions.length > 0 && providerSettings?.allowedModels.length === 0
+		...((agentOptions.length > 0 || !!credentials?.[provider]) &&
+		providerSettings?.allowedModels.length === 0
 			? [
 					{
 						id: `${provider}::add-model`,


### PR DESCRIPTION
## Summary

On providers such as Azure when we can't list available models we should still make it possible for users to choose the model to use manually by entering the ID of the model. Our logic was faulty and hid the option even if user had defined credentials if entering those credentials didn't lead to the list being populated.

Now users can configure their Azure credentials, and then manually enter the identifier of the model to use (ie. `gpt-5-mini`) using this menu option and use it.

<img width="522" height="182" alt="image" src="https://github.com/user-attachments/assets/50bfb13e-e1d4-4e61-b594-eb79af6548b6" />

This still isn't the ideal solution as these custom options aren't saved on the backend. For these providers admin can go to Chat settings, find the provider and edit it, adding the desired models manually under "Limit Models" to make them show up for all users of the instance.

<img width="719" height="664" alt="image" src="https://github.com/user-attachments/assets/a9367c0e-d1fb-4619-835d-9333b788cb9c" />

## Related Linear tickets, Github issues, and Community forum posts

cha-123-bug-azure-ai-foundry-microsoft-foundry-doesnt-work-on-chat

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
