### PR TITLE
fix(editor): Position chat welcome message to center with base LLM models

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
@@ -239,6 +239,10 @@ const selectedModel = computed<ChatModelDto | null>(() => {
 	});
 });
 
+const isAgentModel = computed(
+	() => !!selectedModel.value && !isLlmProvider(selectedModel.value.model.provider),
+);
+
 const customAgentId = computed(() =>
 	selectedModel.value?.model.provider === 'custom-agent'
 		? selectedModel.value.model.agentId
@@ -734,6 +738,7 @@ function onFilesDropped(files: File[]) {
 		:class="{
 			[$style.chatLayout]: true,
 			[$style.isNewSession]: isNewSession,
+			[$style.isAgentNewSession]: isNewSession && isAgentModel,
 			[$style.isExistingSession]: !isNewSession,
 			[$style.isMobileDevice]: isMobileDevice,
 			[$style.isDraggingFile]: fileDrop.isDragging.value,
@@ -795,6 +800,7 @@ function onFilesDropped(files: File[]) {
 					<div ref="scrollable" :class="$style.scrollable">
 						<ChatGreetings
 							v-if="isNewSession"
+							:class="{ [$style.greetingsCentered]: !isAgentModel }"
 							:selected-agent="selectedModel"
 							:loading="!chatStore.agentsReady"
 							@select-prompt="handleSelectPrompt"
@@ -968,8 +974,18 @@ function onFilesDropped(files: File[]) {
 
 	.isNewSession & {
 		justify-content: space-between;
+	}
+
+	.isAgentNewSession & {
 		padding-top: var(--spacing--2xl);
 	}
+}
+
+.greetingsCentered {
+	flex: 1;
+	display: flex;
+	justify-content: center;
+	align-items: center;
 }
 
 .header {


### PR DESCRIPTION
## Summary

<img width="1425" height="900" alt="image" src="https://github.com/user-attachments/assets/de6c3d6c-fc81-44fb-90cf-06173f4101af" />

Now that chat suggested prompts are out we (accidentally?) changed the layout also on base LLM chats, positioning the chat greeting to the top. This looks pretty empty, lets position it to the center instead.

Perhaps we'll add suggested prompts for base LLM chats too later, but as we don't have them now lets make this look slightly better.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-154/bug-position-chat-greetings-text-to-the-middle

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
