### PR TITLE
test: Fix janitor dead-code false positives and CI impact analysis path resolution (no-changelog)

### DIFF
--- a/packages/testing/janitor/src/rules/dead-code.rule.test.ts
+++ b/packages/testing/janitor/src/rules/dead-code.rule.test.ts
@@ -157,6 +157,160 @@ page.publicMethod();
 		expect(violations).toHaveLength(0);
 	});
 
+	test('allows method used via indirect property chain (text fallback)', ({
+		project,
+		createFile,
+	}) => {
+		const file = createFile(
+			'/services/MyHelper.ts',
+			`
+export class MyHelper {
+	async archive() {}
+	async reallyUnused() {}
+}
+`,
+		);
+
+		// No direct import of MyHelper — usage is through a property chain
+		// that ts-morph cannot trace (e.g. Playwright fixtures)
+		createFile(
+			'/tests/fixtures.ts',
+			`
+const thing = getFixture();
+await thing.api.helpers.archive();
+`,
+		);
+
+		createFile(
+			'/tests/test.spec.ts',
+			`
+import { MyHelper } from '../services/MyHelper';
+const h = new MyHelper();
+`,
+		);
+
+		const violations = rule.analyze(project, [file]);
+
+		// archive() should NOT be flagged — text fallback finds '.archive('
+		// reallyUnused() SHOULD be flagged — no text match anywhere
+		expect(violations).toHaveLength(1);
+		expect(violations[0].message).toContain('reallyUnused');
+	});
+
+	test('allows property used via indirect access (text fallback)', ({ project, createFile }) => {
+		const file = createFile(
+			'/pages/TestPage.ts',
+			`
+export class TestPage {
+	container = 'div';
+	deadProp = 'unused';
+}
+`,
+		);
+
+		// Property accessed via chain, no direct import
+		createFile(
+			'/tests/test.spec.ts',
+			`
+const n8n = getFixture();
+n8n.page.container.click();
+`,
+		);
+
+		createFile(
+			'/other/consumer.ts',
+			`
+import { TestPage } from '../pages/TestPage';
+const p = new TestPage();
+`,
+		);
+
+		const violations = rule.analyze(project, [file]);
+
+		expect(violations).toHaveLength(1);
+		expect(violations[0].message).toContain('deadProp');
+	});
+
+	test('text fallback does not match partial member names', ({ project, createFile }) => {
+		const file = createFile(
+			'/services/Helper.ts',
+			`
+export class Helper {
+	async save() {}
+}
+`,
+		);
+
+		// 'saveAll' contains 'save' but is a different member — should not match
+		createFile(
+			'/tests/test.spec.ts',
+			`
+import { Helper } from '../services/Helper';
+const h = new Helper();
+thing.saveAll();
+`,
+		);
+
+		const violations = rule.analyze(project, [file]);
+
+		expect(violations).toHaveLength(1);
+		expect(violations[0].message).toContain('save');
+	});
+
+	test('text fallback matches assignment and comma patterns', ({ project, createFile }) => {
+		const file = createFile(
+			'/services/Helper.ts',
+			`
+export class Helper {
+	async usedViaAssignment() {}
+	async usedInArray() {}
+}
+`,
+		);
+
+		// Patterns that [.(] would miss but \b catches
+		createFile(
+			'/tests/test.spec.ts',
+			`
+import { Helper } from '../services/Helper';
+const h = new Helper();
+const x = obj.usedViaAssignment;
+const arr = [obj.usedInArray, other];
+`,
+		);
+
+		const violations = rule.analyze(project, [file]);
+
+		expect(violations).toHaveLength(0);
+	});
+
+	test('text fallback escapes regex special characters in member names', ({
+		project,
+		createFile,
+	}) => {
+		const file = createFile(
+			'/services/Helper.ts',
+			`
+export class Helper {
+	async $reset() {}
+}
+`,
+		);
+
+		createFile(
+			'/tests/test.spec.ts',
+			`
+import { Helper } from '../services/Helper';
+const h = new Helper();
+thing.$reset();
+`,
+		);
+
+		const violations = rule.analyze(project, [file]);
+
+		expect(violations).toHaveLength(0);
+	});
+
 	test('provides correct fix data', ({ project, createFile }) => {
 		const file = createFile(
 			'/pages/TestPage.ts',

--- a/packages/testing/janitor/src/rules/dead-code.rule.ts
+++ b/packages/testing/janitor/src/rules/dead-code.rule.ts
@@ -37,18 +37,18 @@ export class DeadCodeRule extends BaseRule {
 		];
 	}
 
-	analyze(_project: Project, files: SourceFile[]): Violation[] {
+	analyze(project: Project, files: SourceFile[]): Violation[] {
 		const violations: Violation[] = [];
 
 		for (const file of files) {
-			const fileViolations = this.analyzeFile(file);
+			const fileViolations = this.analyzeFile(project, file);
 			violations.push(...fileViolations);
 		}
 
 		return violations;
 	}
 
-	private analyzeFile(file: SourceFile): Violation[] {
+	private analyzeFile(project: Project, file: SourceFile): Violation[] {
 		const violations: Violation[] = [];
 
 		for (const classDecl of file.getClasses()) {
@@ -62,8 +62,8 @@ export class DeadCodeRule extends BaseRule {
 			}
 
 			// Check individual members
-			violations.push(...this.checkUnusedMethods(file, classDecl, className));
-			violations.push(...this.checkUnusedProperties(file, classDecl, className));
+			violations.push(...this.checkUnusedMethods(project, file, classDecl, className));
+			violations.push(...this.checkUnusedProperties(project, file, classDecl, className));
 		}
 
 		return violations;
@@ -86,6 +86,7 @@ export class DeadCodeRule extends BaseRule {
 	}
 
 	private checkUnusedMethods(
+		project: Project,
 		file: SourceFile,
 		classDecl: ReturnType<SourceFile['getClasses']>[0],
 		className: string,
@@ -96,7 +97,10 @@ export class DeadCodeRule extends BaseRule {
 			if (method.hasModifier(SyntaxKind.PrivateKeyword)) continue;
 
 			const methodName = method.getName();
-			if (!this.hasExternalReferences(file, method)) {
+			if (
+				!this.hasExternalReferences(file, method) &&
+				!this.hasTextUsage(project, file, methodName)
+			) {
 				violations.push(
 					this.createViolation(
 						file,
@@ -115,6 +119,7 @@ export class DeadCodeRule extends BaseRule {
 	}
 
 	private checkUnusedProperties(
+		project: Project,
 		file: SourceFile,
 		classDecl: ReturnType<SourceFile['getClasses']>[0],
 		className: string,
@@ -125,7 +130,7 @@ export class DeadCodeRule extends BaseRule {
 			if (this.isPrivateOrProtected(prop)) continue;
 
 			const propName = prop.getName();
-			if (!this.hasExternalReferences(file, prop)) {
+			if (!this.hasExternalReferences(file, prop) && !this.hasTextUsage(project, file, propName)) {
 				violations.push(
 					this.createViolation(
 						file,
@@ -149,6 +154,23 @@ export class DeadCodeRule extends BaseRule {
 		return (
 			prop.hasModifier(SyntaxKind.PrivateKeyword) || prop.hasModifier(SyntaxKind.ProtectedKeyword)
 		);
+	}
+
+	/**
+	 * Text-based fallback for when ts-morph can't trace references through
+	 * complex generics (e.g. Playwright fixture type chains).
+	 * Searches all project files for `.memberName` followed by a non-word char.
+	 */
+	private hasTextUsage(project: Project, sourceFile: SourceFile, memberName: string): boolean {
+		const escaped = memberName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+		const pattern = new RegExp(`\\.${escaped}\\b`);
+		for (const file of project.getSourceFiles()) {
+			if (file === sourceFile) continue;
+			if (pattern.test(file.getFullText())) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private hasExternalReferences(

--- a/packages/testing/playwright/scripts/distribute-tests.mjs
+++ b/packages/testing/playwright/scripts/distribute-tests.mjs
@@ -19,7 +19,9 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PLAYWRIGHT_DIR = path.resolve(__dirname, '..');
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..', '..');
 const JANITOR_CLI = path.resolve(__dirname, '..', '..', 'janitor', 'dist', 'cli.js');
+const PLAYWRIGHT_PREFIX = path.relative(REPO_ROOT, PLAYWRIGHT_DIR) + path.sep;
 const CONTAINER_STARTUP_TIME = 22_500; // 22.5s average per fixture
 
 const CAPABILITY_IMAGES = {
@@ -47,7 +49,15 @@ function getRequiredImages(capabilities) {
 function getOrchestration(numShards, options = {}) {
 	const cliArgs = ['orchestrate', `--shards=${numShards}`];
 	if (options.impact) cliArgs.push('--impact');
-	if (options.files) cliArgs.push(`--files=${options.files}`);
+	if (options.files) {
+		// Normalize repo-root-relative paths to playwright-root-relative
+		// git diff gives 'packages/testing/playwright/foo.ts', janitor expects 'foo.ts'
+		const normalized = options.files
+			.split(',')
+			.map((f) => (f.startsWith(PLAYWRIGHT_PREFIX) ? f.slice(PLAYWRIGHT_PREFIX.length) : f))
+			.join(',');
+		cliArgs.push(`--files=${normalized}`);
+	}
 	const output = execFileSync('node', [JANITOR_CLI, ...cliArgs], {
 		cwd: PLAYWRIGHT_DIR,
 		encoding: 'utf-8',

--- a/packages/testing/playwright/services/dynamic-credential-api-helper.ts
+++ b/packages/testing/playwright/services/dynamic-credential-api-helper.ts
@@ -66,13 +66,6 @@ export class DynamicCredentialApiHelper {
 		return result.data ?? result;
 	}
 
-	async deleteResolver(id: string): Promise<void> {
-		const response = await this.api.request.delete(`/rest/credential-resolvers/${id}`);
-		if (!response.ok()) {
-			throw new TestError(`Failed to delete credential resolver: ${await response.text()}`);
-		}
-	}
-
 	// ===== Execution status =====
 
 	/**
@@ -193,32 +186,4 @@ export class DynamicCredentialApiHelper {
 	}
 
 	// ===== Revoke =====
-
-	/**
-	 * DELETE /rest/credentials/:credentialId/revoke?resolverId=:resolverId
-	 *
-	 * Revokes stored credential data for the current user identity.
-	 */
-	async revokeCredential(
-		credentialId: string,
-		resolverId: string,
-		options?: { bearerToken?: string; endpointToken?: string },
-	): Promise<void> {
-		const headers: Record<string, string> = {};
-		if (options?.bearerToken) {
-			headers['Authorization'] = `Bearer ${options.bearerToken}`;
-		}
-		if (options?.endpointToken) {
-			headers['X-Authorization'] = options.endpointToken;
-		}
-
-		const response = await this.api.request.delete(
-			`/rest/credentials/${credentialId}/revoke?resolverId=${encodeURIComponent(resolverId)}`,
-			{ headers },
-		);
-
-		if (response.status() !== 204 && !response.ok()) {
-			throw new TestError(`Failed to revoke credential: ${await response.text()}`);
-		}
-	}
 }

--- a/packages/testing/playwright/services/workflow-api-helper.ts
+++ b/packages/testing/playwright/services/workflow-api-helper.ts
@@ -110,14 +110,6 @@ export class WorkflowApiHelper {
 		}
 	}
 
-	async archive(workflowId: string) {
-		const response = await this.api.request.post(`/rest/workflows/${workflowId}/archive`);
-
-		if (!response.ok()) {
-			throw new TestError(`Failed to archive workflow: ${await response.text()}`);
-		}
-	}
-
 	async delete(workflowId: string) {
 		const response = await this.api.request.delete(`/rest/workflows/${workflowId}`);
 

--- a/packages/testing/playwright/services/workflow-api-helper.ts
+++ b/packages/testing/playwright/services/workflow-api-helper.ts
@@ -110,6 +110,14 @@ export class WorkflowApiHelper {
 		}
 	}
 
+	async archive(workflowId: string) {
+		const response = await this.api.request.post(`/rest/workflows/${workflowId}/archive`);
+
+		if (!response.ok()) {
+			throw new TestError(`Failed to archive workflow: ${await response.text()}`);
+		}
+	}
+
 	async delete(workflowId: string) {
 		const response = await this.api.request.delete(`/rest/workflows/${workflowId}`);
 


### PR DESCRIPTION
## Summary

- Remove 2 genuinely unused methods from `DynamicCredentialApiHelper` (`deleteResolver`, `revokeCredential`)
- Fix path doubling in CI impact analysis — `distribute-tests.mjs` now strips the `packages/testing/playwright/` prefix from repo-root-relative git paths before passing to the janitor
- Fix janitor dead-code rule false positives — add text-based fallback (`hasTextUsage`) for when ts-morph can't trace references through Playwright's fixture type chains (e.g. `n8n.api.workflows.archive()`)

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)