### PR TITLE
ci: Use inputs. vs github.event.inputs for workflow_call compatibility

### DIFF
--- a/.github/workflows/release-create-pr.yml
+++ b/.github/workflows/release-create-pr.yml
@@ -60,7 +60,7 @@ jobs:
       # poutine: untrusted_checkout_exec
       - name: Switch to base branch
         env:
-          BASE_BRANCH: ${{ github.event.inputs.base-branch }}
+          BASE_BRANCH: ${{ inputs.base-branch }}
         run: git checkout "$BASE_BRANCH"
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -78,14 +78,14 @@ jobs:
         run: |
           echo "NEXT_RELEASE=$(node .github/scripts/bump-versions.mjs)" >> "$GITHUB_ENV"
         env:
-          RELEASE_TYPE: ${{ github.event.inputs.release-type }}
+          RELEASE_TYPE: ${{ inputs.release-type }}
 
       - name: Update Changelog
         run: node .github/scripts/update-changelog.mjs
 
       - name: Push the base branch
         env:
-          BASE_BRANCH: ${{ github.event.inputs.base-branch }}
+          BASE_BRANCH: ${{ inputs.base-branch }}
         run: |
           git push -f origin "refs/remotes/origin/${{ env.BASE_BRANCH }}:refs/heads/release/${{ env.NEXT_RELEASE }}"
 
@@ -114,6 +114,6 @@ jobs:
           branch: 'release-pr/${{ env.NEXT_RELEASE }}'
           commit-message: ':rocket: Release ${{ env.NEXT_RELEASE }}'
           delete-branch: true
-          labels: release,release:${{ github.event.inputs.release-type }}
+          labels: release,release:${{ inputs.release-type }}
           title: ':rocket: Release ${{ env.NEXT_RELEASE }}'
           body: ${{ steps.generate-body.outputs.content }}


### PR DESCRIPTION
## Summary

Workflow calls on https://github.com/n8n-io/n8n/actions/workflows/release-create-minor-pr.yml fail due to inputs being parsed in the old GHA way instead of using the `inputs` object.

Stabilize `release-create-pr.yml` around just `inputs`

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
