### PR TITLE
ci: Pass secrets to post-release actions

### DIFF
--- a/.github/workflows/release-publish-post-release.yml
+++ b/.github/workflows/release-publish-post-release.yml
@@ -29,16 +29,18 @@ jobs:
     name: Push new release to channel
     if: inputs.release_type != 'rc'
     uses: ./.github/workflows/release-push-to-channel.yml
+    secrets: inherit
     with:
       version: ${{ inputs.version }}
       release-channel: ${{ inputs.track }}
 
   promote-previous-beta-to-stable:
     name: Promote previous beta to stable
-    uses: ./.github/workflows/release-push-to-channel.yml
     if: |
       inputs.release_type != 'rc' &&
       inputs.bump == 'minor'
+    uses: ./.github/workflows/release-push-to-channel.yml
+    secrets: inherit
     with:
       version: ${{ inputs.new_stable_version }}
       release-channel: stable


### PR DESCRIPTION
## Summary

Post-release fails currently as secrets are not passed through workflow calls. This PR fixes that.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
