### PR TITLE
chore: Add cubic rule for `workflowDocumentStore` migration (no-changelog)

### DIFF
--- a/cubic.yaml
+++ b/cubic.yaml
@@ -202,6 +202,48 @@ reviews:
         `@n8n/design-system/src/css/_tokens.scss` for an appropriate alternative.
         If one exists, suggest using it. If none exist, ask why the hard-coded
         value is required.
+    - name: Use workflowDocumentStore for Migrated Workflow Fields
+      description: |-
+        We are actively migrating workflow state from `workflowsStore` (Pinia store defined in
+        `packages/frontend/editor-ui/src/app/stores/workflows.store.ts`) to `workflowDocumentStore`
+        (defined in `packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts`).
+
+        The `workflowDocumentStore` is the single source of truth for migrated fields.
+        When new frontend code reads or writes any of the fields listed below, it **must** use
+        `workflowDocumentStore` instead of `workflowsStore.workflow.*` or equivalent accessors.
+
+        **Already-migrated fields (do NOT access via workflowsStore):**
+        - `active`
+        - `activeVersion`
+        - `activeVersionId`
+        - `checksum`
+        - `createdAt`
+        - `homeProject`
+        - `meta`
+        - `pinData`
+        - `settings`
+        - `tags`
+        - `updatedAt`
+
+        **Detection criteria — flag when NEW code in `packages/frontend/` does any of:**
+        1. Reads a migrated field from `workflowsStore.workflow.<field>` (e.g. `workflowsStore.workflow.tags`)
+        2. Reads a migrated field from a destructured `workflow` ref originating from `workflowsStore`
+        3. Writes to a migrated field through `workflowsStore` (e.g. `workflowsStore.workflow.active = true`)
+        4. Calls a `workflowsStore` setter/action that only mutates a migrated field when
+           `workflowDocumentStore` already exposes an equivalent method
+
+        **Do NOT flag:**
+        - Existing unchanged code (only review new or modified lines)
+        - Access to non-migrated fields (e.g. `workflowsStore.workflow.nodes`, `workflowsStore.workflow.connections`)
+        - Backend code — this rule applies only to `packages/frontend/`
+        - Code inside `workflowDocument.store.ts` or its sub-modules (those *are* the source of truth)
+        - Code inside `workflows.store.ts` itself (the migration is still in progress there)
+
+        **Recommendation:**
+        Use `useWorkflowDocumentStore(createWorkflowDocumentId(workflowId))` from
+        `@/app/stores/workflowDocument.store.ts` to access migrated fields.
+
+        This is an active migration. The list of migrated fields will grow over time.
 pr_descriptions:
   generate: false
   instructions: Each PR is supposed to have a limited scope. In your review, focus on changes made in the PR and avoid pointing out problems you found in the code that already existed.


### PR DESCRIPTION
## Summary

This pull request adds a new review guideline to the `cubic.yaml` configuration, specifically focused on the ongoing migration of workflow state management in the frontend codebase. The guideline instructs reviewers to ensure that any new code accesses migrated workflow fields through the `workflowDocumentStore` rather than the legacy `workflowsStore`. This helps maintain consistency and prevents regressions during the migration.

Workflow state migration review rule:

* Added a review rule requiring all new frontend code to use `workflowDocumentStore` for accessing or mutating already-migrated workflow fields, instead of the legacy `workflowsStore`. The rule lists the migrated fields and provides detection criteria for flagging incorrect usage.
* Clarified exceptions, such as unchanged code, non-migrated fields, backend code, and store implementation files, which should not be flagged by this rule.
* Provided a recommended usage pattern for accessing migrated fields via `useWorkflowDocumentStore(createWorkflowDocumentId(workflowId))`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2508/add-cubic-rule-for-enforcing-usage-of-workflow-document-migration


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
