### PR TITLE
fix(editor): Fix race condition in credentialResolverId test

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/WorkflowSettings.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowSettings.test.ts
@@ -740,11 +740,11 @@ describe('WorkflowSettingsVue', () => {
 			// so we verify the save behavior when the value is already empty.
 			workflowDocumentStore.setSettings({ credentialResolverId: '' });
 
-			const { getByRole } = createComponent({ pinia });
+			const { getByTestId, getByRole } = createComponent({ pinia });
 			await nextTick();
 
 			await waitFor(() => {
-				expect(workflowsListStore.fetchWorkflow).toHaveBeenCalled();
+				expect(getByTestId('workflow-settings-credential-resolver-create-new')).toBeInTheDocument();
 			});
 
 			await userEvent.click(getByRole('button', { name: 'Save' }));


### PR DESCRIPTION
## Summary

The "should save with empty credentialResolverId" test was clicking Save before
onMounted completed. This caused workflowSettings.executionTimeout to be 0,
triggering an early return in saveSettings. Fixed by waiting for the credential
resolver UI to render before clicking Save.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
