### PR TITLE
chore(core): Update ChatHub agents table schema for file knowledge

### DIFF
--- a/packages/@n8n/api-types/src/chat-hub.ts
+++ b/packages/@n8n/api-types/src/chat-hub.ts
@@ -32,6 +32,14 @@ export const chatHubLLMProviderSchema = z.enum([
 ]);
 export type ChatHubLLMProvider = z.infer<typeof chatHubLLMProviderSchema>;
 
+export interface ChatHubAgentKnowledgeItem {
+	id: string;
+	type: 'embedding';
+	provider: ChatHubLLMProvider;
+	fileName: string;
+	mimeType: string;
+}
+
 /**
  * Schema for icon or emoji representation
  */
@@ -465,6 +473,7 @@ export interface ChatHubAgentDto {
 	credentialId: string | null;
 	provider: ChatHubLLMProvider;
 	model: string;
+	files: ChatHubAgentKnowledgeItem[];
 	toolIds: string[];
 	createdAt: string;
 	updatedAt: string;

--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -47,6 +47,7 @@ export {
 	type ChatHubConversationResponse,
 	type ChatHubConversationsResponse,
 	type ChatHubAgentDto,
+	type ChatHubAgentKnowledgeItem,
 	ChatHubCreateAgentRequest,
 	ChatHubUpdateAgentRequest,
 	type AgentIconOrEmoji,

--- a/packages/@n8n/db/src/migrations/common/1771500000002-AddFilesColumnToChatHubAgents.ts
+++ b/packages/@n8n/db/src/migrations/common/1771500000002-AddFilesColumnToChatHubAgents.ts
@@ -1,0 +1,13 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+const table = 'chat_hub_agents';
+
+export class AddFilesColumnToChatHubAgents1771500000002 implements ReversibleMigration {
+	async up({ schemaBuilder: { addColumns, column } }: MigrationContext) {
+		await addColumns(table, [column('files').json.notNull.default("'[]'")]);
+	}
+
+	async down({ schemaBuilder: { dropColumns } }: MigrationContext) {
+		await dropColumns(table, ['files']);
+	}
+}

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -147,6 +147,7 @@ import { CreateWorkflowBuilderSessionTable1770220686000 } from '../common/177022
 import { AddScalingFieldsToTestRun1771417407753 } from '../common/1771417407753-AddScalingFieldsToTestRun';
 import { MigrateExternalSecretsToEntityStorage1771500000000 } from '../common/1771500000000-MigrateExternalSecretsToEntityStorage';
 import { AddUnshareScopeToCustomRoles1771500000001 } from '../common/1771500000001-AddUnshareScopeToCustomRoles';
+import { AddFilesColumnToChatHubAgents1771500000002 } from '../common/1771500000002-AddFilesColumnToChatHubAgents';
 import type { Migration } from '../migration-types';
 
 export const postgresMigrations: Migration[] = [
@@ -299,4 +300,5 @@ export const postgresMigrations: Migration[] = [
 	AddScalingFieldsToTestRun1771417407753,
 	MigrateExternalSecretsToEntityStorage1771500000000,
 	AddUnshareScopeToCustomRoles1771500000001,
+	AddFilesColumnToChatHubAgents1771500000002,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -141,6 +141,7 @@ import { CreateWorkflowBuilderSessionTable1770220686000 } from '../common/177022
 import { AddScalingFieldsToTestRun1771417407753 } from '../common/1771417407753-AddScalingFieldsToTestRun';
 import { MigrateExternalSecretsToEntityStorage1771500000000 } from '../common/1771500000000-MigrateExternalSecretsToEntityStorage';
 import { AddUnshareScopeToCustomRoles1771500000001 } from '../common/1771500000001-AddUnshareScopeToCustomRoles';
+import { AddFilesColumnToChatHubAgents1771500000002 } from '../common/1771500000002-AddFilesColumnToChatHubAgents';
 import type { Migration } from '../migration-types';
 
 const sqliteMigrations: Migration[] = [
@@ -287,6 +288,7 @@ const sqliteMigrations: Migration[] = [
 	AddScalingFieldsToTestRun1771417407753,
 	MigrateExternalSecretsToEntityStorage1771500000000,
 	AddUnshareScopeToCustomRoles1771500000001,
+	AddFilesColumnToChatHubAgents1771500000002,
 ];
 
 export { sqliteMigrations };

--- a/packages/cli/src/modules/chat-hub/chat-hub-agent.entity.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-agent.entity.ts
@@ -1,4 +1,8 @@
-import { ChatHubLLMProvider, AgentIconOrEmoji } from '@n8n/api-types';
+import type {
+	ChatHubLLMProvider,
+	AgentIconOrEmoji,
+	ChatHubAgentKnowledgeItem,
+} from '@n8n/api-types';
 import { User, CredentialsEntity, JsonColumn, WithTimestamps } from '@n8n/db';
 import {
 	Column,
@@ -25,6 +29,7 @@ export interface IChatHubAgent {
 	credentialId: string | null;
 	provider: ChatHubLLMProvider;
 	model: string;
+	files: ChatHubAgentKnowledgeItem[];
 }
 
 @Entity({ name: 'chat_hub_agents' })
@@ -104,4 +109,11 @@ export class ChatHubAgent extends WithTimestamps {
 		inverseJoinColumn: { name: 'toolId', referencedColumnName: 'id' },
 	})
 	tools?: Relation<ChatHubTool[]>;
+
+	/**
+	 * The files attached to the agent.
+	 * Can be active files with binary data or embedded PDFs (embeddings only).
+	 */
+	@JsonColumn({ default: '[]' })
+	files: ChatHubAgentKnowledgeItem[];
 }

--- a/packages/cli/src/modules/chat-hub/chat-hub-agent.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-agent.service.ts
@@ -155,6 +155,7 @@ export class ChatHubAgentService {
 			provider: agent.provider,
 			model: agent.model,
 			toolIds,
+			files: [],
 			createdAt: agent.createdAt.toISOString(),
 			updatedAt: agent.updatedAt.toISOString(),
 		};


### PR DESCRIPTION
## Summary

This PR adds `files` column to `chat_hub_agents` table for the agent's file knowledge feature.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/CHA-100/feature-file-knowledge


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
