### PR TITLE
fix: Handle collaboration push old format

### DIFF
--- a/packages/cli/src/collaboration/__tests__/collaboration.state.test.ts
+++ b/packages/cli/src/collaboration/__tests__/collaboration.state.test.ts
@@ -119,5 +119,32 @@ describe('CollaborationState', () => {
 				userId: 'user1',
 			});
 		});
+
+		it('should gracefully ignore old cache format and clean it up', async () => {
+			// Arrange
+			const now = new Date().toISOString();
+
+			mockCacheService.getHash.mockResolvedValueOnce({
+				'old-user-uuid': '2026-02-26T21:23:36.318Z',
+				newClientId: `new-user-uuid|${now}`,
+			});
+
+			// Act
+			const users = await collaborationState.getCollaborators(workflowId);
+
+			// Assert
+			expect(users).toEqual([
+				{
+					clientId: 'newClientId',
+					lastSeen: now,
+					userId: 'new-user-uuid',
+				},
+			]);
+
+			expect(mockCacheService.deleteFromHash).toHaveBeenCalledWith(
+				'collaboration:workflow',
+				'old-user-uuid',
+			);
+		});
 	});
 });

--- a/packages/cli/src/collaboration/collaboration.service.ts
+++ b/packages/cli/src/collaboration/collaboration.service.ts
@@ -1,6 +1,7 @@
 import type { PushPayload } from '@n8n/api-types';
 import type { User } from '@n8n/db';
 import { UserRepository } from '@n8n/db';
+import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
 import { ErrorReporter } from 'n8n-core';
 import type { Workflow } from 'n8n-workflow';
@@ -29,6 +30,7 @@ import { AccessService } from '@/services/access.service';
 @Service()
 export class CollaborationService {
 	constructor(
+		private readonly logger: Logger,
 		private readonly errorReporter: ErrorReporter,
 		private readonly push: Push,
 		private readonly state: CollaborationState,
@@ -41,6 +43,13 @@ export class CollaborationService {
 			try {
 				await this.handleUserMessage(event.userId, event.pushRef, event.msg);
 			} catch (error) {
+				if (this.isTransientError(error)) {
+					this.logger.debug('Transient infrastructure error in collaboration service', {
+						error,
+					});
+					return;
+				}
+
 				this.errorReporter.error(
 					new UnexpectedError('Error handling CollaborationService push message', {
 						extra: {
@@ -53,6 +62,15 @@ export class CollaborationService {
 				);
 			}
 		});
+	}
+
+	private isTransientError(error: unknown): error is NodeJS.ErrnoException {
+		return (
+			error instanceof Error &&
+			'code' in error &&
+			typeof error.code === 'string' &&
+			['ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND', 'ECONNRESET'].includes(error.code)
+		);
 	}
 
 	async handleUserMessage(userId: User['id'], clientId: string, msg: unknown) {

--- a/packages/cli/src/collaboration/collaboration.state.ts
+++ b/packages/cli/src/collaboration/collaboration.state.ts
@@ -63,7 +63,7 @@ export class CollaborationState {
 			return [];
 		}
 
-		const { valid, invalid } = this.cacheHashToCollaborators(cacheValue);
+		const { valid, invalid } = this.parseCacheHashToCollaborators(cacheValue);
 		const [expired, stillActive] = this.splitToExpiredAndStillActive(valid);
 
 		const toRemove = [...expired, ...invalid];
@@ -114,7 +114,7 @@ export class CollaborationState {
 		);
 	}
 
-	private cacheHashToCollaborators(workflowCacheEntry: WorkflowCacheHash): {
+	private parseCacheHashToCollaborators(workflowCacheEntry: WorkflowCacheHash): {
 		valid: CacheEntry[];
 		invalid: CacheEntry[];
 	} {

--- a/packages/cli/src/collaboration/collaboration.state.ts
+++ b/packages/cli/src/collaboration/collaboration.state.ts
@@ -63,11 +63,12 @@ export class CollaborationState {
 			return [];
 		}
 
-		const activeCollaborators = this.cacheHashToCollaborators(cacheValue);
-		const [expired, stillActive] = this.splitToExpiredAndStillActive(activeCollaborators);
+		const { valid, invalid } = this.cacheHashToCollaborators(cacheValue);
+		const [expired, stillActive] = this.splitToExpiredAndStillActive(valid);
 
-		if (expired.length > 0) {
-			void this.removeExpiredCollaborators(workflowId, expired);
+		const toRemove = [...expired, ...invalid];
+		if (toRemove.length > 0) {
+			void this.removeExpiredCollaborators(workflowId, toRemove);
 		}
 
 		// Deduplicate by userId - keep the most recent entry for each user
@@ -113,15 +114,36 @@ export class CollaborationState {
 		);
 	}
 
-	private cacheHashToCollaborators(workflowCacheEntry: WorkflowCacheHash): CacheEntry[] {
-		return Object.entries(workflowCacheEntry).map(([clientId, value]) => {
-			const [userId, lastSeen] = value.split('|');
-			return {
-				userId,
-				lastSeen,
-				clientId,
-			};
-		});
+	private cacheHashToCollaborators(workflowCacheEntry: WorkflowCacheHash): {
+		valid: CacheEntry[];
+		invalid: CacheEntry[];
+	} {
+		const valid: CacheEntry[] = [];
+		const invalid: CacheEntry[] = [];
+
+		for (const [clientId, value] of Object.entries(workflowCacheEntry)) {
+			const parts = value.split('|');
+
+			// Handle old format (pre-tab-scoped collaboration) where value was just a timestamp
+			// Old: { "userId": "2026-02-26T21:23:36.318Z" }
+			// New: { "clientId": "userId|2026-02-26T21:23:36.318Z" }
+			if (parts.length === 1) {
+				invalid.push({
+					clientId,
+					userId: '', // Not needed for deletion
+					lastSeen: value,
+				});
+			} else {
+				const [userId, lastSeen] = parts;
+				valid.push({
+					userId,
+					lastSeen,
+					clientId,
+				});
+			}
+		}
+
+		return { valid, invalid };
 	}
 
 	private hasSessionExpired(lastSeenString: Iso8601DateTimeString) {


### PR DESCRIPTION
## Summary

https://github.com/n8n-io/n8n/pull/25646 switched to a new format for collaboration. While write locks are set per user with a TTL and we introduced a fallback for parsing the old format, we forgot to handle the case with the old format for collaborators list, which doesn't have an official TTL (only custom logic with heartbeats, see below). This PR adds a handler for the old format, as well as introduces a special handling for transient errors.

### How sessions are expired

With the current implementation (of more than 17 months ago):
    - `lastSeen` of each collaborator is set on workflow open and is updated every 5 minutes (`workflowOpened` is sent)
    - anyone not sending a `workflowOpened` event for >15 minutes gets removed when a new collaborator joins or an old one leaves (inside `getCollaborators` method).
    - problem: if the tab continues to be open, while the server was restarted, it'll try to send `workflowOpened` again and it will fail if format changed)

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-4888](https://linear.app/n8n/issue/ADO-4888/bug-collaborationservice-errors-on-workflowopened-message-from-210)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
