### PR TITLE
fix: Initialize Demo layout (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
@@ -85,16 +85,18 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 		}
 	}
 
-	const workflowId = computed(() => {
-		const name = route.params.name;
-		return (Array.isArray(name) ? name[0] : name) ?? '';
-	});
-
 	const isNewWorkflowRoute = computed(() => route.query.new === 'true');
 	const isDemoRoute = computed(() => route.name === VIEWS.DEMO);
 	const isTemplateRoute = computed(() => route.name === VIEWS.TEMPLATE_IMPORT);
 	const isOnboardingRoute = computed(() => route.name === VIEWS.WORKFLOW_ONBOARDING);
 	const isDebugRoute = computed(() => route.name === VIEWS.EXECUTION_DEBUG);
+
+	const workflowId = computed(() => {
+		if (isDemoRoute.value) return 'demo';
+
+		const name = route.params.name;
+		return (Array.isArray(name) ? name[0] : name) ?? '';
+	});
 
 	async function loadCredentials() {
 		let options: { workflowId: string } | { projectId: string };

--- a/packages/frontend/editor-ui/src/app/layouts/DemoLayout.test.ts
+++ b/packages/frontend/editor-ui/src/app/layouts/DemoLayout.test.ts
@@ -1,7 +1,55 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createComponentRenderer } from '@/__tests__/render';
 import DemoLayout from './DemoLayout.vue';
+import { computed, ref, shallowRef } from 'vue';
 import { createTestingPinia } from '@pinia/testing';
+
+vi.mock('vue-router', async (importOriginal) => {
+	const actual = (await importOriginal()) as object;
+	return {
+		...actual,
+		useRoute: () => ({
+			params: {},
+			query: {},
+			meta: {},
+			name: 'demo',
+		}),
+		useRouter: () => ({
+			replace: vi.fn(),
+			push: vi.fn(),
+		}),
+	};
+});
+
+vi.mock('@/app/composables/useWorkflowState', async (importOriginal) => {
+	const actual = (await importOriginal()) as object;
+	return {
+		...actual,
+		useWorkflowState: vi.fn(() => ({
+			getNewWorkflowDataAndMakeShareable: vi.fn(),
+			setWorkflowId: vi.fn(),
+			resetState: vi.fn(),
+		})),
+	};
+});
+
+vi.mock('@/app/composables/useWorkflowInitialization', () => ({
+	useWorkflowInitialization: vi.fn(() => ({
+		isLoading: ref(false),
+		workflowId: computed(() => 'demo'),
+		currentWorkflowDocumentStore: shallowRef(null),
+		initializeData: vi.fn().mockResolvedValue(undefined),
+		initializeWorkflow: vi.fn().mockResolvedValue(undefined),
+		cleanup: vi.fn(),
+	})),
+}));
+
+vi.mock('@/app/composables/usePostMessageHandler', () => ({
+	usePostMessageHandler: vi.fn(() => ({
+		setup: vi.fn(),
+		cleanup: vi.fn(),
+	})),
+}));
 
 const renderComponent = createComponentRenderer(DemoLayout, {
 	global: {
@@ -17,10 +65,14 @@ const renderComponent = createComponentRenderer(DemoLayout, {
 			},
 		},
 	},
-	pinia: createTestingPinia(),
 });
 
 describe('DemoLayout', () => {
+	beforeEach(() => {
+		createTestingPinia();
+		vi.clearAllMocks();
+	});
+
 	it('should render the layout without throwing', () => {
 		expect(() => renderComponent()).not.toThrow();
 	});

--- a/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
@@ -1,41 +1,22 @@
 <script lang="ts" setup>
-import { provide, onBeforeMount, onBeforeUnmount } from 'vue';
+import { provide, computed, onMounted } from 'vue';
 import BaseLayout from './BaseLayout.vue';
 import DemoFooter from '@/features/execution/logs/components/DemoFooter.vue';
-import {
-	WorkflowIdKey,
-	WorkflowStateKey,
-	WorkflowDocumentStoreKey,
-} from '@/app/constants/injectionKeys';
+import { WorkflowIdKey } from '@/app/constants/injectionKeys';
 import { useWorkflowState } from '@/app/composables/useWorkflowState';
 import { useWorkflowInitialization } from '@/app/composables/useWorkflowInitialization';
-import { usePostMessageHandler } from '@/app/composables/usePostMessageHandler';
 
 const workflowState = useWorkflowState();
-provide(WorkflowStateKey, workflowState);
+const { initializeData, initializeWorkflow } = useWorkflowInitialization(workflowState);
 
-const {
-	workflowId,
-	currentWorkflowDocumentStore,
-	cleanup: cleanupInitialization,
-} = useWorkflowInitialization(workflowState);
+const workflowId = computed(() => 'demo');
+
+onMounted(async () => {
+	await initializeData();
+	await initializeWorkflow();
+});
 
 provide(WorkflowIdKey, workflowId);
-provide(WorkflowDocumentStoreKey, currentWorkflowDocumentStore);
-
-const { setup: setupPostMessages, cleanup: cleanupPostMessages } = usePostMessageHandler({
-	workflowState,
-	currentWorkflowDocumentStore,
-});
-
-onBeforeMount(() => {
-	setupPostMessages();
-});
-
-onBeforeUnmount(() => {
-	cleanupPostMessages();
-	cleanupInitialization();
-});
 </script>
 
 <template>

--- a/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
@@ -17,7 +17,6 @@ provide(WorkflowStateKey, workflowState);
 const {
 	workflowId,
 	initializeData,
-	initializeWorkflow,
 	currentWorkflowDocumentStore,
 	cleanup: cleanupInitialization,
 } = useWorkflowInitialization(workflowState);
@@ -36,7 +35,6 @@ onBeforeMount(() => {
 
 onMounted(async () => {
 	await initializeData();
-	await initializeWorkflow();
 });
 
 onBeforeUnmount(() => {

--- a/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
@@ -1,22 +1,48 @@
 <script lang="ts" setup>
-import { provide, computed, onMounted } from 'vue';
+import { provide, onBeforeMount, onBeforeUnmount, onMounted } from 'vue';
 import BaseLayout from './BaseLayout.vue';
 import DemoFooter from '@/features/execution/logs/components/DemoFooter.vue';
-import { WorkflowIdKey } from '@/app/constants/injectionKeys';
+import {
+	WorkflowIdKey,
+	WorkflowStateKey,
+	WorkflowDocumentStoreKey,
+} from '@/app/constants/injectionKeys';
 import { useWorkflowState } from '@/app/composables/useWorkflowState';
 import { useWorkflowInitialization } from '@/app/composables/useWorkflowInitialization';
+import { usePostMessageHandler } from '@/app/composables/usePostMessageHandler';
 
 const workflowState = useWorkflowState();
-const { initializeData, initializeWorkflow } = useWorkflowInitialization(workflowState);
+provide(WorkflowStateKey, workflowState);
 
-const workflowId = computed(() => 'demo');
+const {
+	workflowId,
+	initializeData,
+	initializeWorkflow,
+	currentWorkflowDocumentStore,
+	cleanup: cleanupInitialization,
+} = useWorkflowInitialization(workflowState);
+
+provide(WorkflowIdKey, workflowId);
+provide(WorkflowDocumentStoreKey, currentWorkflowDocumentStore);
+
+const { setup: setupPostMessages, cleanup: cleanupPostMessages } = usePostMessageHandler({
+	workflowState,
+	currentWorkflowDocumentStore,
+});
+
+onBeforeMount(() => {
+	setupPostMessages();
+});
 
 onMounted(async () => {
 	await initializeData();
 	await initializeWorkflow();
 });
 
-provide(WorkflowIdKey, workflowId);
+onBeforeUnmount(() => {
+	cleanupPostMessages();
+	cleanupInitialization();
+});
 </script>
 
 <template>


### PR DESCRIPTION
## Summary

This pull request refines how workflow initialization is handled for demo routes and improves the setup sequence in the `DemoLayout` component. The main focus is on ensuring that demo workflows use a consistent identifier and that initialization logic is properly triggered when the component mounts.

**Workflow initialization improvements:**

* Updated the `workflowId` computation in `useWorkflowInitialization.ts` to return `'demo'` for demo routes, ensuring consistent workflow identification for demos.

**Component lifecycle and initialization sequencing:**

* In `DemoLayout.vue`, added the `onMounted` lifecycle hook to trigger both `initializeData` and `initializeWorkflow` after the component mounts, ensuring all necessary setup steps are performed in the correct order.
* Included `initializeData` and `initializeWorkflow` in the destructuring from `useWorkflowInitialization`, making them available for use in the layout component.
* Added the `onMounted` import to the top of `DemoLayout.vue` to support the new initialization logic.

## Related Linear tickets, Github issues, and Community forum posts

N/A


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
