### PR TITLE
fix: Clicking a node keeps adding to context

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
@@ -454,7 +454,7 @@ function onNodeDragStop(event: NodeDragEvent) {
 
 function onNodeClick({ event, node }: NodeMouseEvent) {
 	if (chatPanelStore.isOpen && focusedNodesStore.isFeatureEnabled) {
-		focusedNodesStore.confirmNodes([node.id], 'canvas_selection');
+		focusedNodesStore.setUnconfirmedFromCanvasSelection([node.id]);
 	}
 
 	emit('click:node', node.id, getProjectedPosition(event));


### PR DESCRIPTION
## Summary

When clicking different nodes, each click adds the node to the active context

Selecting one node shows a toast that it was added to context; selecting a second node shows the same, and both nodes remain in context.

The desired behaviour is that selected node(s) appear as a 'suggestion tag' at the bottom of the textarea. User need to click the suggestion to convert it to a real context tag. If there are existing context tags, the new ones are added to the existing set

## Related Linear tickets, Github issues, and Community forum posts

[AI-2102](https://linear.app/n8n/issue/AI-2102/clicking-a-node-keeps-adding-to-context)


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
