### PR TITLE
fix: Devcontainer build failures from hardened base image (no-changelog)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,15 @@
-FROM n8nio/base:24
+ARG NODE_VERSION=24
 
-RUN apk add --no-cache --update openssh sudo shadow bash
+FROM node:${NODE_VERSION}-alpine
+
+ARG NODE_VERSION
+
+RUN apk add --no-cache \
+    openssh sudo shadow bash libc-utils \
+    git openssl graphicsmagick tini tzdata ca-certificates libc6-compat
 RUN echo node ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/node && chmod 0440 /etc/sudoers.d/node
 RUN mkdir /workspaces && chown node:node /workspaces
-RUN npm install -g pnpm
+RUN corepack enable
 
 USER node
 RUN mkdir -p ~/.pnpm-store && pnpm config set store-dir ~/.pnpm-store --global


### PR DESCRIPTION
## Summary
- Switch devcontainer base from `n8nio/base:24` to `node:24-alpine` — the production base image removes `apk-tools`, making package installation impossible
- Replace `npm install -g pnpm` with `corepack enable` — pnpm version is managed by `packageManager` in `package.json` via the existing `postCreateCommand`
- Add `libc-utils` for `getconf`, required by VS Code server's `check-requirements.sh`
- Add all OS dependencies from the base image (`openssl`, `tini`, `tzdata`, `ca-certificates`, etc.) to maintain parity

## Test plan
- [x] `docker build -f .devcontainer/Dockerfile .devcontainer/` builds successfully
- [ ] Open devcontainer via VS Code and verify it starts without errors
- [ ] Run `pnpm install` and `pnpm build` inside the container

Related: https://linear.app/n8n/issue/CAT-2506

🤖 Generated with [Claude Code](https://claude.com/claude-code)