### PR TITLE
test: Refine unit test descriptions for clarity and determinism

### DIFF
--- a/packages/@n8n/backend-common/src/utils/__tests__/is-object-literal.test.ts
+++ b/packages/@n8n/backend-common/src/utils/__tests__/is-object-literal.test.ts
@@ -13,7 +13,7 @@ describe('isObjectLiteral', () => {
 		['string', 'string', false],
 		['boolean', true, false],
 		['undefined', undefined, false],
-		['Date object', new Date(), false],
+		['Date object', new Date('2020-01-01'), false],
 		['RegExp object', new RegExp(''), false],
 		['Map object', new Map(), false],
 		['Set object', new Set(), false],
@@ -25,7 +25,7 @@ describe('isObjectLiteral', () => {
 		['Buffer', Buffer.from('test'), false],
 		['Serialized Buffer', Buffer.from('test').toJSON(), true],
 		['Promise', new Promise(() => {}), false],
-	])('should return %s for %s', (_, input, expected) => {
+	])('isObjectLiteral(%s)', (_, input, expected) => {
 		expect(isObjectLiteral(input)).toBe(expected);
 	});
 

--- a/packages/frontend/editor-ui/src/app/utils/objectUtils.test.ts
+++ b/packages/frontend/editor-ui/src/app/utils/objectUtils.test.ts
@@ -6,10 +6,15 @@ import {
 	omitKey,
 } from '@/app/utils/objectUtils';
 
-const testData = [1, '', true, null, undefined, new Date(), () => {}].map((value) => [
-	value,
-	typeof value,
-]);
+const testData: Array<[string, unknown]> = [
+	['a number', 1],
+	['an empty string', ''],
+	['a boolean', true],
+	['null', null],
+	['undefined', undefined],
+	['a Date object', new Date('2020-01-01')],
+	['a function', () => {}],
+];
 
 describe('objectUtils', () => {
 	describe('isObjectOrArray', () => {
@@ -21,7 +26,7 @@ describe('objectUtils', () => {
 			assert(isObjectOrArray([]));
 		});
 
-		test.each(testData)('should return false for %j (type %s)', (value) => {
+		test.each(testData)('should return false for %s', (_, value) => {
 			assert(!isObjectOrArray(value));
 		});
 	});
@@ -35,7 +40,7 @@ describe('objectUtils', () => {
 			assert(!isObject([]));
 		});
 
-		test.each(testData)('should return false for %j (type %s)', (value) => {
+		test.each(testData)('should return false for %s', (_, value) => {
 			assert(!isObject(value));
 		});
 	});


### PR DESCRIPTION
## Summary

The reason for the rename is tracking tools such as Codecov treat each test as a new test since it has a unique name. So our test count in Codecov has inflated to over 37k, and it's impossible to use it to find actual test data/failures historicallly

- Replaces `new Date()` with `new Date('2020-01-01')` in test data to avoid non-deterministic snapshot output
- Improves parameterized test names to describe what's being tested rather than raw values (e.g., `isObjectLiteral(Date object)` instead of `should return %s for %s`)
- Restructures `objectUtils` test data array for readability with explicit labels

## Test plan
- [x] Existing tests pass with updated descriptions
- [ ] Verify test output reads clearly in CI logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)