### PR TITLE
ci: Parallelize NPM publish and Docker builds in release pipeline

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -8,21 +8,6 @@ on:
       - 'release/*'
 
 jobs:
-  build-arm64:
-    runs-on: blacksmith-4vcpu-ubuntu-2204-arm
-    if: github.event.pull_request.merged == true
-    env:
-      NODE_OPTIONS: --max-old-space-size=6144
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Setup and Build ARM64
-        uses: ./.github/actions/setup-nodejs
-        env:
-          N8N_FAIL_ON_POPULARITY_FETCH_ERROR: true
-
   determine-version-info:
     name: Determine publishing track
     runs-on: ubuntu-latest
@@ -102,7 +87,7 @@ jobs:
 
   publish-to-docker-hub:
     name: Publish to DockerHub
-    needs: [determine-version-info, publish-to-npm, build-arm64]
+    needs: [determine-version-info]
     uses: ./.github/workflows/docker-build-push.yml
     with:
       n8n_version: ${{ needs.determine-version-info.outputs.version }}


### PR DESCRIPTION
## Summary
- Remove redundant `build-arm64` pre-build job from `release-publish.yml` — it built without the `RELEASE` env var so its Turbo cache couldn't help Docker ARM builds, resulting in ARM being built twice
- Decouple Docker publish from NPM publish — Docker builds from source, not from NPM, so they can run in parallel
- `create-github-release` still gates on both NPM and Docker completing successfully

## Before
```
build-arm64 (7m, wasted) ─────────────────┐
determine-version (1m) → npm (14m) ────────┤→ docker arm64 (24m) → manifest → release
```

## After
```
determine-version (1m) → npm (14m) ────────────────────────────────┐
                       → docker amd64 (10m) ───────────────────────┤→ release
                       → docker arm64 (24m) → manifest (2m) ───────┘
```

- ~14 min wall clock improvement per release
- ~7 min saved compute (no duplicate ARM build)
- Cleaner retry semantics — if Docker fails, retry just Docker without re-running NPM

## Test plan
- [ ] Verify workflow YAML is valid (actionlint passes in pre-commit)
- [ ] Confirm on next release that NPM and Docker jobs start in parallel after `determine-version-info`
- [ ] Confirm `create-github-release` waits for both NPM and Docker before proceeding


🤖 Generated with [Claude Code](https://claude.com/claude-code)