### PR TITLE
fix(editor): Do not send health checks in preview (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useBackendStatus.spec.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useBackendStatus.spec.ts
@@ -92,4 +92,22 @@ describe('useBackendStatus', () => {
 
 		expect(mockStopHeartbeat).toHaveBeenCalled();
 	});
+
+	it('should skip health checks in preview mode', async () => {
+		settingsStore.setSettings(
+			merge({}, defaultSettings, {
+				previewMode: true,
+				endpointHealth: '/internal/health',
+			}),
+		);
+
+		const wrapper = createWrapper();
+
+		await vi.waitFor(() => {
+			expect(mockFetch).not.toHaveBeenCalled();
+			expect(mockStartHeartbeat).not.toHaveBeenCalled();
+		});
+
+		wrapper.unmount();
+	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/useBackendStatus.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useBackendStatus.ts
@@ -59,6 +59,10 @@ export function useBackendStatus() {
 	});
 
 	onMounted(() => {
+		if (settingsStore.isPreviewMode) {
+			return;
+		}
+
 		// Initial health check and start polling
 		void updateOnlineStatus();
 		startHeartbeat();


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-4895](https://linear.app/n8n/issue/ADO-4895/bug-health-checks-shouldnt-be-sent-on-the-preview-instance)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
