### PR TITLE
docs: Update error message when community nodes fail to install

### DIFF
--- a/packages/cli/src/modules/community-packages/__tests__/npm-utils.test.ts
+++ b/packages/cli/src/modules/community-packages/__tests__/npm-utils.test.ts
@@ -348,7 +348,9 @@ describe('verifyIntegrity', () => {
 		mockAsyncExec.mockRejectedValue(new Error('CLI command failed'));
 
 		await expect(verifyIntegrity(packageName, version, registryUrl, integrity)).rejects.toThrow(
-			new UnexpectedError('Checksum verification failed'),
+			new UnexpectedError(
+				'Checksum verification failed. Try restarting n8n and attempting the installation again.',
+			),
 		);
 	});
 
@@ -422,7 +424,9 @@ describe('verifyIntegrity', () => {
 			});
 
 			await expect(verifyIntegrity(packageName, version, registryUrl, integrity)).rejects.toThrow(
-				new UnexpectedError('Checksum verification failed'),
+				new UnexpectedError(
+					'Checksum verification failed. Try restarting n8n and attempting the installation again.',
+				),
 			);
 
 			expect(mockAsyncExec).toHaveBeenCalledTimes(1);
@@ -499,7 +503,9 @@ describe('verifyIntegrity', () => {
 			mockAsyncExec.mockRejectedValue(new Error('Some other error'));
 
 			await expect(verifyIntegrity(packageName, version, registryUrl, integrity)).rejects.toThrow(
-				new UnexpectedError('Checksum verification failed'),
+				new UnexpectedError(
+					'Checksum verification failed. Try restarting n8n and attempting the installation again.',
+				),
 			);
 
 			expect(mockAsyncExec).toHaveBeenCalledTimes(1);

--- a/packages/cli/src/modules/community-packages/npm-utils.ts
+++ b/packages/cli/src/modules/community-packages/npm-utils.ts
@@ -114,7 +114,9 @@ export async function verifyIntegrity(
 
 		const integrity = metadata?.data?.dist?.integrity;
 		if (integrity !== expectedIntegrity) {
-			throw new UnexpectedError('Checksum verification failed. Package integrity does not match.');
+			throw new UnexpectedError(
+				'Checksum verification failed. Package integrity does not match. Try restarting n8n and attempting the installation again.',
+			);
 		}
 		return;
 	} catch (error) {
@@ -133,7 +135,7 @@ export async function verifyIntegrity(
 			const integrity = jsonParse(stdout);
 			if (integrity !== expectedIntegrity) {
 				throw new UnexpectedError(
-					'Checksum verification failed. Package integrity does not match.',
+					'Checksum verification failed. Package integrity does not match. Try restarting n8n and attempting the installation again.',
 				);
 			}
 			return;
@@ -143,7 +145,9 @@ export async function verifyIntegrity(
 					'Checksum verification failed. Please check your network connection and try again.',
 				);
 			}
-			throw new UnexpectedError('Checksum verification failed');
+			throw new UnexpectedError(
+				'Checksum verification failed. Try restarting n8n and attempting the installation again.',
+			);
 		}
 	}
 }


### PR DESCRIPTION
## Summary
This PR updates the text for when a community node fails to install, Most of the time this is caused by the cache after we release new node versions. Restarting an instance is currently the best option to correct this.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
