### PR TITLE
chore(core): Integrate ExecutionRedactionService into all execution data endpoints

### DIFF
--- a/packages/cli/src/executions/__tests__/execution-redaction-proxy.service.test.ts
+++ b/packages/cli/src/executions/__tests__/execution-redaction-proxy.service.test.ts
@@ -1,9 +1,10 @@
-import type { IExecutionDb, User } from '@n8n/db';
+import type { User } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 
 import type {
 	ExecutionRedaction,
 	ExecutionRedactionOptions,
+	RedactableExecution,
 } from '@/executions/execution-redaction';
 import { ExecutionRedactionServiceProxy } from '@/executions/execution-redaction-proxy.service';
 
@@ -12,7 +13,7 @@ describe('ExecutionRedactionServiceProxy', () => {
 
 	const mockUser = { id: 'user-123' } as User;
 
-	const createMockExecution = (): IExecutionDb => mock<IExecutionDb>({ id: 'execution-123' });
+	const createMockExecution = (): RedactableExecution => mock<RedactableExecution>();
 
 	const createOptions = (
 		overrides: Partial<ExecutionRedactionOptions> = {},

--- a/packages/cli/src/executions/__tests__/execution.service.test.ts
+++ b/packages/cli/src/executions/__tests__/execution.service.test.ts
@@ -1,8 +1,9 @@
 import { mockInstance } from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
-import type { IExecutionResponse, ExecutionRepository } from '@n8n/db';
+import type { IExecutionDb, IExecutionResponse, ExecutionRepository, User } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
+import type { IRun, IRunExecutionData } from 'n8n-workflow';
 import { ManualExecutionCancelledError, WorkflowOperationError } from 'n8n-workflow';
 
 import type { ActiveExecutions } from '@/active-executions';
@@ -15,6 +16,7 @@ import type { ExecutionRequest } from '@/executions/execution.types';
 import { ScalingService } from '@/scaling/scaling.service';
 import type { Job } from '@/scaling/scaling.types';
 import type { WaitTracker } from '@/wait-tracker';
+import type { WorkflowRunner } from '@/workflow-runner';
 
 describe('ExecutionService', () => {
 	const scalingService = mockInstance(ScalingService);
@@ -125,14 +127,95 @@ describe('ExecutionService', () => {
 			 */
 			await expect(retry).rejects.toThrow(AbortedExecutionRetryError);
 		});
+
+		it('should apply redaction to the retry response', async () => {
+			/**
+			 * Arrange
+			 */
+			const workflowRunner = mock<WorkflowRunner>();
+			const localExecutionRedactionProxy = mock<ExecutionRedactionServiceProxy>();
+			const localExecutionService = new ExecutionService(
+				globalConfig,
+				mock(),
+				activeExecutions,
+				mock(),
+				mock(),
+				executionRepository,
+				mock(),
+				mock(),
+				mock(),
+				waitTracker,
+				workflowRunner,
+				concurrencyControl,
+				mock(),
+				mock(),
+				mock(),
+				localExecutionRedactionProxy,
+			);
+
+			const mockUser = mock<User>({ id: 'user-1' });
+			const sourceExecution = mock<IExecutionResponse>({
+				workflowId: 'workflow-1',
+				mode: 'trigger',
+				finished: false,
+				status: 'error',
+				data: {
+					executionData: {
+						nodeExecutionStack: [],
+						waitingExecution: {},
+						waitingExecutionSource: {},
+					},
+					resultData: { runData: {} },
+				},
+				workflowData: { id: 'workflow-1', settings: {} } as IExecutionDb['workflowData'],
+			});
+			executionRepository.findWithUnflattenedData.mockResolvedValue(sourceExecution);
+
+			const retriedExecutionId = 'retried-123';
+			workflowRunner.run.mockResolvedValue(retriedExecutionId);
+
+			const retriedRunData = mock<IRunExecutionData>({ resultData: { runData: {} } });
+			const retriedRun = mock<IRun>({
+				data: retriedRunData,
+				mode: 'trigger',
+				startedAt: new Date(),
+				finished: true,
+				status: 'success',
+				waitTill: null,
+			});
+			activeExecutions.getPostExecutePromise.mockResolvedValue(retriedRun);
+
+			localExecutionRedactionProxy.processExecution.mockImplementation(async (exec) => exec);
+
+			const req = mock<ExecutionRequest.Retry>({
+				params: { id: 'original-123' },
+				user: mockUser,
+				body: { loadWorkflow: false },
+				query: {},
+			});
+
+			/**
+			 * Act
+			 */
+			await localExecutionService.retry(req, ['workflow-1']);
+
+			/**
+			 * Assert
+			 */
+			expect(localExecutionRedactionProxy.processExecution).toHaveBeenCalledWith(
+				expect.objectContaining({ id: retriedExecutionId }),
+				expect.objectContaining({ user: mockUser, redactExecutionData: undefined }),
+			);
+		});
 	});
 
 	describe('getLastSuccessfulExecution', () => {
-		it('should return the last successful execution for a workflow', async () => {
+		it('should return the redacted last successful execution for a workflow', async () => {
 			/**
 			 * Arrange
 			 */
 			const workflowId = 'workflow-123';
+			const mockUser = mock<User>();
 			const mockExecution = mock<IExecutionResponse>({
 				id: 'execution-456',
 				workflowId,
@@ -142,11 +225,12 @@ describe('ExecutionService', () => {
 				status: 'success',
 			});
 			executionRepository.findMultipleExecutions.mockResolvedValue([mockExecution]);
+			executionRedactionServiceProxy.processExecution.mockResolvedValue(mockExecution);
 
 			/**
 			 * Act
 			 */
-			const result = await executionService.getLastSuccessfulExecution(workflowId);
+			const result = await executionService.getLastSuccessfulExecution(workflowId, mockUser);
 
 			/**
 			 * Assert
@@ -167,6 +251,10 @@ describe('ExecutionService', () => {
 					unflattenData: true,
 				},
 			);
+			expect(executionRedactionServiceProxy.processExecution).toHaveBeenCalledWith(mockExecution, {
+				user: mockUser,
+				redactExecutionData: undefined,
+			});
 		});
 
 		it('should return undefined when no successful execution exists', async () => {
@@ -174,17 +262,19 @@ describe('ExecutionService', () => {
 			 * Arrange
 			 */
 			const workflowId = 'workflow-with-no-success';
+			const mockUser = mock<User>();
 			executionRepository.findMultipleExecutions.mockResolvedValue([]);
 
 			/**
 			 * Act
 			 */
-			const result = await executionService.getLastSuccessfulExecution(workflowId);
+			const result = await executionService.getLastSuccessfulExecution(workflowId, mockUser);
 
 			/**
 			 * Assert
 			 */
 			expect(result).toBeUndefined();
+			expect(executionRedactionServiceProxy.processExecution).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/cli/src/executions/execution-redaction-proxy.service.ts
+++ b/packages/cli/src/executions/execution-redaction-proxy.service.ts
@@ -1,7 +1,10 @@
-import type { IExecutionDb } from '@n8n/db';
 import { Service } from '@n8n/di';
 
-import type { ExecutionRedaction, ExecutionRedactionOptions } from './execution-redaction';
+import type {
+	ExecutionRedaction,
+	ExecutionRedactionOptions,
+	RedactableExecution,
+} from './execution-redaction';
 
 @Service()
 export class ExecutionRedactionServiceProxy implements ExecutionRedaction {
@@ -12,9 +15,9 @@ export class ExecutionRedactionServiceProxy implements ExecutionRedaction {
 	}
 
 	async processExecution(
-		execution: IExecutionDb,
+		execution: RedactableExecution,
 		options: ExecutionRedactionOptions,
-	): Promise<IExecutionDb> {
+	): Promise<RedactableExecution> {
 		if (!this.executionRedaction) {
 			return execution;
 		}

--- a/packages/cli/src/executions/execution-redaction-proxy.service.ts
+++ b/packages/cli/src/executions/execution-redaction-proxy.service.ts
@@ -23,4 +23,12 @@ export class ExecutionRedactionServiceProxy implements ExecutionRedaction {
 		}
 		return await this.executionRedaction.processExecution(execution, options);
 	}
+
+	async processExecutions(
+		executions: RedactableExecution[],
+		options: ExecutionRedactionOptions,
+	): Promise<void> {
+		if (!this.executionRedaction) return;
+		await this.executionRedaction.processExecutions(executions, options);
+	}
 }

--- a/packages/cli/src/executions/execution-redaction.ts
+++ b/packages/cli/src/executions/execution-redaction.ts
@@ -20,4 +20,9 @@ export interface ExecutionRedaction {
 		execution: RedactableExecution,
 		options: ExecutionRedactionOptions,
 	): Promise<RedactableExecution>;
+
+	processExecutions(
+		executions: RedactableExecution[],
+		options: ExecutionRedactionOptions,
+	): Promise<void>;
 }

--- a/packages/cli/src/executions/execution-redaction.ts
+++ b/packages/cli/src/executions/execution-redaction.ts
@@ -1,5 +1,13 @@
 import type { ExecutionRedactionQueryDto } from '@n8n/api-types';
-import type { IExecutionDb, User } from '@n8n/db';
+import type { User } from '@n8n/db';
+import type { IRunExecutionData, IWorkflowBase, WorkflowExecuteMode } from 'n8n-workflow';
+
+export type RedactableExecution = {
+	mode: WorkflowExecuteMode;
+	workflowId: string;
+	data: IRunExecutionData;
+	workflowData: Pick<IWorkflowBase, 'settings'>;
+};
 
 export type ExecutionRedactionOptions = {
 	user: User;
@@ -9,7 +17,7 @@ export type ExecutionRedactionOptions = {
 
 export interface ExecutionRedaction {
 	processExecution(
-		execution: IExecutionDb,
+		execution: RedactableExecution,
 		options: ExecutionRedactionOptions,
-	): Promise<IExecutionDb>;
+	): Promise<RedactableExecution>;
 }

--- a/packages/cli/src/executions/execution-redaction.ts
+++ b/packages/cli/src/executions/execution-redaction.ts
@@ -3,6 +3,7 @@ import type { User } from '@n8n/db';
 import type { IRunExecutionData, IWorkflowBase, WorkflowExecuteMode } from 'n8n-workflow';
 
 export type RedactableExecution = {
+	id?: string;
 	mode: WorkflowExecuteMode;
 	workflowId: string;
 	data: IRunExecutionData;

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -4,7 +4,6 @@ import { GlobalConfig } from '@n8n/config';
 import type {
 	CreateExecutionPayload,
 	ExecutionSummaries,
-	IExecutionDb,
 	IExecutionResponse,
 	IGetExecutionsQueryFilter,
 	User,
@@ -187,10 +186,10 @@ export class ExecutionService {
 		const execution = executions[0];
 		if (!execution) return undefined;
 
-		await this.executionRedactionServiceProxy.processExecution(
-			execution as unknown as IExecutionDb,
-			{ user, redactExecutionData },
-		);
+		await this.executionRedactionServiceProxy.processExecution(execution, {
+			user,
+			redactExecutionData,
+		});
 		return execution;
 	}
 
@@ -344,13 +343,10 @@ export class ExecutionService {
 		const redactExecutionData = redactQuery.success
 			? redactQuery.data.redactExecutionData
 			: undefined;
-		await this.executionRedactionServiceProxy.processExecution(
-			response as unknown as IExecutionDb,
-			{
-				user: req.user,
-				redactExecutionData,
-			},
-		);
+		await this.executionRedactionServiceProxy.processExecution(response, {
+			user: req.user,
+			redactExecutionData,
+		});
 
 		return response;
 	}

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -4,6 +4,7 @@ import { GlobalConfig } from '@n8n/config';
 import type {
 	CreateExecutionPayload,
 	ExecutionSummaries,
+	IExecutionDb,
 	IExecutionResponse,
 	IGetExecutionsQueryFilter,
 	User,
@@ -162,7 +163,11 @@ export class ExecutionService {
 		};
 	}
 
-	async getLastSuccessfulExecution(workflowId: string): Promise<IExecutionResponse | undefined> {
+	async getLastSuccessfulExecution(
+		workflowId: string,
+		user: User,
+		redactExecutionData?: boolean,
+	): Promise<IExecutionResponse | undefined> {
 		const executions = await this.executionRepository.findMultipleExecutions(
 			{
 				select: ['id', 'mode', 'startedAt', 'stoppedAt', 'workflowId'],
@@ -179,7 +184,14 @@ export class ExecutionService {
 			},
 		);
 
-		return executions[0];
+		const execution = executions[0];
+		if (!execution) return undefined;
+
+		await this.executionRedactionServiceProxy.processExecution(
+			execution as unknown as IExecutionDb,
+			{ user, redactExecutionData },
+		);
+		return execution;
 	}
 
 	async retry(
@@ -312,7 +324,7 @@ export class ExecutionService {
 			source: 'user-retry',
 		});
 
-		return {
+		const response: Omit<IExecutionResponse, 'createdAt'> = {
 			id: retriedExecutionId,
 			mode: executionData.mode,
 			startedAt: executionData.startedAt,
@@ -327,6 +339,20 @@ export class ExecutionService {
 			annotation: execution.annotation,
 			storedAt: execution.storedAt,
 		};
+
+		const redactQuery = ExecutionRedactionQueryDtoSchema.safeParse(req.query);
+		const redactExecutionData = redactQuery.success
+			? redactQuery.data.redactExecutionData
+			: undefined;
+		await this.executionRedactionServiceProxy.processExecution(
+			response as unknown as IExecutionDb,
+			{
+				user: req.user,
+				redactExecutionData,
+			},
+		);
+
+		return response;
 	}
 
 	async delete(req: ExecutionRequest.Delete, sharedWorkflowIds: string[]) {

--- a/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
+++ b/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@n8n/backend-common';
 import { mockInstance } from '@n8n/backend-test-utils';
-import type { IExecutionDb, User } from '@n8n/db';
+import type { User } from '@n8n/db';
 import type {
 	ExecutionError,
 	ExecutionStatus,
@@ -11,7 +11,10 @@ import type {
 import { ExpressionError, NodeApiError, NodeOperationError } from 'n8n-workflow';
 import { mock } from 'jest-mock-extended';
 
-import type { ExecutionRedactionOptions } from '@/executions/execution-redaction';
+import type {
+	ExecutionRedactionOptions,
+	RedactableExecution,
+} from '@/executions/execution-redaction';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import type { EventService } from '@/events/event.service';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
@@ -36,20 +39,22 @@ describe('ExecutionRedactionService', () => {
 		jest.clearAllMocks();
 		service = new ExecutionRedactionService(logger, workflowFinderService, eventService);
 		// Default: user lacks execution:reveal scope → canReveal: false
-		workflowFinderService.findWorkflowForUser.mockResolvedValue(null);
+		workflowFinderService.findWorkflowIdsWithScopeForUser.mockResolvedValue(new Set());
 	});
 
 	const createMockExecution = (
 		overrides: {
 			mode?: WorkflowExecuteMode;
+			workflowId?: string;
 			policy?: 'none' | 'all' | 'non-manual';
 			workflowSettingsPolicy?: 'none' | 'all' | 'non-manual';
 			withRuntimeData?: boolean;
 			withRunData?: boolean;
 		} = {},
-	): IExecutionDb => {
+	): RedactableExecution => {
 		const {
 			mode = 'manual',
+			workflowId = 'workflow-123',
 			policy,
 			workflowSettingsPolicy,
 			withRuntimeData = true,
@@ -79,7 +84,7 @@ describe('ExecutionRedactionService', () => {
 						{
 							startTime: 0,
 							executionTime: 100,
-							executionStatus: 'success' as const,
+							executionStatus: 'success' as ExecutionStatus,
 							data: {
 								main: [
 									[
@@ -96,40 +101,283 @@ describe('ExecutionRedactionService', () => {
 				}
 			: {};
 
-		// @ts-expect-error - Partial mock data for testing
 		return {
-			id: 'execution-123',
 			mode,
-			createdAt: new Date('2024-01-01'),
-			startedAt: new Date('2024-01-01'),
-			stoppedAt: new Date('2024-01-01'),
-			workflowId: 'workflow-123',
-			finished: true,
-			retryOf: undefined,
-			retrySuccessId: undefined,
-			status: 'success' as ExecutionStatus,
-			waitTill: null,
-			storedAt: 'db',
+			workflowId,
 			data: {
 				version: 1,
 				resultData: { runData },
 				executionData,
 			},
 			workflowData: {
-				id: 'workflow-123',
-				name: 'Test Workflow',
-				active: false,
-				isArchived: false,
-				createdAt: new Date('2024-01-01'),
-				updatedAt: new Date('2024-01-01'),
-				nodes: [],
-				connections: {},
 				settings: workflowSettingsPolicy ? { redactionPolicy: workflowSettingsPolicy } : {},
-				staticData: {},
-				activeVersionId: null,
 			},
-		} as IExecutionDb;
+		} as unknown as RedactableExecution;
 	};
+
+	describe('processExecution (single-item wrapper)', () => {
+		it('should delegate to processExecutions and return the same execution', async () => {
+			const execution = createMockExecution({ policy: 'all', mode: 'trigger', withRunData: true });
+			const options: ExecutionRedactionOptions = { user: mockUser };
+
+			const spy = jest.spyOn(service, 'processExecutions');
+			const result = await service.processExecution(execution, options);
+
+			expect(spy).toHaveBeenCalledWith([execution], options);
+			expect(result).toBe(execution);
+		});
+	});
+
+	describe('processExecutions (batch)', () => {
+		it('should do nothing for an empty array', async () => {
+			const options: ExecutionRedactionOptions = { user: mockUser };
+			await service.processExecutions([], options);
+			expect(workflowFinderService.findWorkflowIdsWithScopeForUser).not.toHaveBeenCalled();
+		});
+
+		it('should use a single DB query for N executions (policy-driven)', async () => {
+			const executions = [
+				createMockExecution({
+					policy: 'all',
+					mode: 'trigger',
+					workflowId: 'wf-1',
+					withRunData: true,
+				}),
+				createMockExecution({
+					policy: 'all',
+					mode: 'trigger',
+					workflowId: 'wf-2',
+					withRunData: true,
+				}),
+				createMockExecution({
+					policy: 'all',
+					mode: 'trigger',
+					workflowId: 'wf-1',
+					withRunData: true,
+				}),
+			];
+			const options: ExecutionRedactionOptions = { user: mockUser };
+
+			await service.processExecutions(executions, options);
+
+			// Should be called exactly once with the unique workflow IDs
+			expect(workflowFinderService.findWorkflowIdsWithScopeForUser).toHaveBeenCalledTimes(1);
+			const [calledIds] = workflowFinderService.findWorkflowIdsWithScopeForUser.mock.calls[0];
+			expect(new Set(calledIds)).toEqual(new Set(['wf-1', 'wf-2']));
+		});
+
+		it('should not call DB when all executions pass policyAllowsReveal (policy=none)', async () => {
+			const executions = [
+				createMockExecution({ policy: 'none', mode: 'trigger', withRunData: true }),
+				createMockExecution({ policy: 'none', mode: 'manual', withRunData: true }),
+			];
+			const options: ExecutionRedactionOptions = { user: mockUser };
+
+			await service.processExecutions(executions, options);
+
+			expect(workflowFinderService.findWorkflowIdsWithScopeForUser).not.toHaveBeenCalled();
+			// No redaction applied
+			for (const execution of executions) {
+				expect(execution.data.redactionInfo).toBeUndefined();
+			}
+		});
+
+		it('should redact only executions that need redaction in a mixed list', async () => {
+			const noneExecution = createMockExecution({
+				policy: 'none',
+				mode: 'trigger',
+				workflowId: 'wf-none',
+				withRunData: true,
+			});
+			const allExecution = createMockExecution({
+				policy: 'all',
+				mode: 'trigger',
+				workflowId: 'wf-all',
+				withRunData: true,
+			});
+			const nonManualManual = createMockExecution({
+				policy: 'non-manual',
+				mode: 'manual',
+				workflowId: 'wf-nm',
+				withRunData: true,
+			});
+			const nonManualTrigger = createMockExecution({
+				policy: 'non-manual',
+				mode: 'trigger',
+				workflowId: 'wf-nm',
+				withRunData: true,
+			});
+			const options: ExecutionRedactionOptions = { user: mockUser };
+
+			await service.processExecutions(
+				[noneExecution, allExecution, nonManualManual, nonManualTrigger],
+				options,
+			);
+
+			expect(noneExecution.data.redactionInfo).toBeUndefined();
+			expect(nonManualManual.data.redactionInfo).toBeUndefined();
+			expect(allExecution.data.redactionInfo).toEqual({
+				isRedacted: true,
+				reason: 'workflow_redaction_policy',
+				canReveal: false,
+			});
+			expect(nonManualTrigger.data.redactionInfo).toEqual({
+				isRedacted: true,
+				reason: 'workflow_redaction_policy',
+				canReveal: false,
+			});
+
+			// Only wf-all and wf-nm needed DB check
+			const [calledIds] = workflowFinderService.findWorkflowIdsWithScopeForUser.mock.calls[0];
+			expect(new Set(calledIds)).toEqual(new Set(['wf-all', 'wf-nm']));
+		});
+
+		it('should set canReveal: true for executions whose workflow is in the reveal set', async () => {
+			workflowFinderService.findWorkflowIdsWithScopeForUser.mockResolvedValue(new Set(['wf-1']));
+
+			const execution1 = createMockExecution({
+				policy: 'all',
+				mode: 'trigger',
+				workflowId: 'wf-1',
+				withRunData: true,
+			});
+			const execution2 = createMockExecution({
+				policy: 'all',
+				mode: 'trigger',
+				workflowId: 'wf-2',
+				withRunData: true,
+			});
+			const options: ExecutionRedactionOptions = { user: mockUser };
+
+			await service.processExecutions([execution1, execution2], options);
+
+			expect(execution1.data.redactionInfo?.canReveal).toBe(true);
+			expect(execution2.data.redactionInfo?.canReveal).toBe(false);
+		});
+
+		describe('redactExecutionData === true (explicit redact)', () => {
+			it('should redact all executions', async () => {
+				const executions = [
+					createMockExecution({
+						policy: 'none',
+						mode: 'manual',
+						workflowId: 'wf-1',
+						withRunData: true,
+					}),
+					createMockExecution({
+						policy: 'all',
+						mode: 'trigger',
+						workflowId: 'wf-2',
+						withRunData: true,
+					}),
+				];
+				const options: ExecutionRedactionOptions = { user: mockUser, redactExecutionData: true };
+
+				await service.processExecutions(executions, options);
+
+				for (const execution of executions) {
+					expect(execution.data.redactionInfo?.isRedacted).toBe(true);
+					expect(execution.data.redactionInfo?.reason).toBe('user_requested');
+				}
+			});
+
+			it('should not call DB when all executions pass policyAllowsReveal', async () => {
+				const executions = [
+					createMockExecution({ policy: 'none', mode: 'trigger', withRunData: true }),
+				];
+				const options: ExecutionRedactionOptions = { user: mockUser, redactExecutionData: true };
+
+				await service.processExecutions(executions, options);
+
+				expect(workflowFinderService.findWorkflowIdsWithScopeForUser).not.toHaveBeenCalled();
+				expect(executions[0].data.redactionInfo?.canReveal).toBe(true);
+			});
+
+			it('should use a single DB query for N executions needing check', async () => {
+				const executions = [
+					createMockExecution({
+						policy: 'all',
+						mode: 'trigger',
+						workflowId: 'wf-1',
+						withRunData: true,
+					}),
+					createMockExecution({
+						policy: 'all',
+						mode: 'trigger',
+						workflowId: 'wf-2',
+						withRunData: true,
+					}),
+				];
+				const options: ExecutionRedactionOptions = { user: mockUser, redactExecutionData: true };
+
+				await service.processExecutions(executions, options);
+
+				expect(workflowFinderService.findWorkflowIdsWithScopeForUser).toHaveBeenCalledTimes(1);
+			});
+		});
+
+		describe('redactExecutionData === false (explicit reveal)', () => {
+			it('should not call DB and not throw when all executions pass policyAllowsReveal', async () => {
+				const executions = [
+					createMockExecution({ policy: 'none', mode: 'trigger', withRunData: true }),
+					createMockExecution({ policy: 'non-manual', mode: 'manual', withRunData: true }),
+				];
+				const options: ExecutionRedactionOptions = { user: mockUser, redactExecutionData: false };
+
+				await expect(service.processExecutions(executions, options)).resolves.toBeUndefined();
+				expect(workflowFinderService.findWorkflowIdsWithScopeForUser).not.toHaveBeenCalled();
+			});
+
+			it('should use a single DB query and throw ForbiddenError if any execution is not allowed', async () => {
+				workflowFinderService.findWorkflowIdsWithScopeForUser.mockResolvedValue(new Set(['wf-1']));
+
+				const executions = [
+					createMockExecution({
+						policy: 'all',
+						mode: 'trigger',
+						workflowId: 'wf-1',
+						withRunData: true,
+					}),
+					createMockExecution({
+						policy: 'all',
+						mode: 'trigger',
+						workflowId: 'wf-2',
+						withRunData: true,
+					}),
+				];
+				const options: ExecutionRedactionOptions = { user: mockUser, redactExecutionData: false };
+
+				await expect(service.processExecutions(executions, options)).rejects.toThrow(
+					ForbiddenError,
+				);
+				expect(workflowFinderService.findWorkflowIdsWithScopeForUser).toHaveBeenCalledTimes(1);
+			});
+
+			it('should resolve when user has reveal scope for all executions needing check', async () => {
+				workflowFinderService.findWorkflowIdsWithScopeForUser.mockResolvedValue(
+					new Set(['wf-1', 'wf-2']),
+				);
+
+				const executions = [
+					createMockExecution({
+						policy: 'all',
+						mode: 'trigger',
+						workflowId: 'wf-1',
+						withRunData: true,
+					}),
+					createMockExecution({
+						policy: 'all',
+						mode: 'trigger',
+						workflowId: 'wf-2',
+						withRunData: true,
+					}),
+				];
+				const options: ExecutionRedactionOptions = { user: mockUser, redactExecutionData: false };
+
+				await expect(service.processExecutions(executions, options)).resolves.toBeUndefined();
+			});
+		});
+	});
 
 	describe('redactExecutionData === true (explicit redact)', () => {
 		it('should apply redaction regardless of policy', async () => {
@@ -157,7 +405,7 @@ describe('ExecutionRedactionService', () => {
 		});
 
 		it('should set canReveal: true when policy allows reveal (policy=none)', async () => {
-			// policy='none' means policyAllowsReveal=true, so canReveal=true regardless of permissions
+			// policy='none' means policyAllowsReveal=true → no DB query, canReveal=true
 			const execution = createMockExecution({
 				policy: 'none',
 				mode: 'trigger',
@@ -170,6 +418,7 @@ describe('ExecutionRedactionService', () => {
 
 			const result = await service.processExecution(execution, options);
 
+			expect(workflowFinderService.findWorkflowIdsWithScopeForUser).not.toHaveBeenCalled();
 			expect(result.data.redactionInfo).toEqual({
 				isRedacted: true,
 				reason: 'user_requested',
@@ -190,6 +439,7 @@ describe('ExecutionRedactionService', () => {
 
 			const result = await service.processExecution(execution, options);
 
+			expect(workflowFinderService.findWorkflowIdsWithScopeForUser).not.toHaveBeenCalled();
 			expect(result.data.redactionInfo).toEqual({
 				isRedacted: true,
 				reason: 'user_requested',
@@ -198,7 +448,9 @@ describe('ExecutionRedactionService', () => {
 		});
 
 		it('should set canReveal: true when user has reveal permission', async () => {
-			workflowFinderService.findWorkflowForUser.mockResolvedValue({ id: 'workflow-123' } as never);
+			workflowFinderService.findWorkflowIdsWithScopeForUser.mockResolvedValue(
+				new Set(['workflow-123']),
+			);
 
 			const execution = createMockExecution({
 				policy: 'all',
@@ -222,7 +474,9 @@ describe('ExecutionRedactionService', () => {
 
 	describe('redactExecutionData === false (explicit reveal)', () => {
 		it('should return unmodified execution when user has reveal permission', async () => {
-			workflowFinderService.findWorkflowForUser.mockResolvedValue({ id: 'workflow-123' } as never);
+			workflowFinderService.findWorkflowIdsWithScopeForUser.mockResolvedValue(
+				new Set(['workflow-123']),
+			);
 
 			const execution = createMockExecution({
 				policy: 'all',
@@ -243,7 +497,6 @@ describe('ExecutionRedactionService', () => {
 		});
 
 		it('should return unmodified execution when policy allows reveal (policy=none), even without permission', async () => {
-			// policyAllowsReveal=true overrides permission check
 			const execution = createMockExecution({
 				policy: 'none',
 				mode: 'trigger',
@@ -260,6 +513,7 @@ describe('ExecutionRedactionService', () => {
 				secret: 'sensitive-data',
 			});
 			expect(result.data.redactionInfo).toBeUndefined();
+			expect(workflowFinderService.findWorkflowIdsWithScopeForUser).not.toHaveBeenCalled();
 		});
 
 		it('should return unmodified execution when policy allows reveal (policy=non-manual, mode=manual), even without permission', async () => {
@@ -279,21 +533,10 @@ describe('ExecutionRedactionService', () => {
 				secret: 'sensitive-data',
 			});
 			expect(result.data.redactionInfo).toBeUndefined();
+			expect(workflowFinderService.findWorkflowIdsWithScopeForUser).not.toHaveBeenCalled();
 		});
 
 		it('should throw ForbiddenError when user lacks reveal permission', async () => {
-			// workflowFinderService returns null (default in beforeEach) → no permission
-			const execution = createMockExecution({ policy: 'all', mode: 'trigger' });
-			const options: ExecutionRedactionOptions = {
-				user: mockUser,
-				redactExecutionData: false,
-			};
-
-			await expect(service.processExecution(execution, options)).rejects.toThrow(ForbiddenError);
-		});
-
-		it('should throw ForbiddenError when workflow not found for user', async () => {
-			// workflowFinderService returns null (default in beforeEach) → no permission
 			const execution = createMockExecution({ policy: 'all', mode: 'trigger' });
 			const options: ExecutionRedactionOptions = {
 				user: mockUser,
@@ -304,7 +547,9 @@ describe('ExecutionRedactionService', () => {
 		});
 
 		it('should emit execution-data-revealed when user is allowed to reveal', async () => {
-			workflowFinderService.findWorkflowForUser.mockResolvedValue({ id: 'workflow-123' } as never);
+			workflowFinderService.findWorkflowIdsWithScopeForUser.mockResolvedValue(
+				new Set(['workflow-123']),
+			);
 
 			const execution = createMockExecution({ policy: 'all', mode: 'trigger', withRunData: true });
 			const options: ExecutionRedactionOptions = {
@@ -395,7 +640,9 @@ describe('ExecutionRedactionService', () => {
 		});
 
 		it('should set canReveal: true when policy is non-manual, mode is trigger, and user has permission', async () => {
-			workflowFinderService.findWorkflowForUser.mockResolvedValue({ id: 'workflow-123' } as never);
+			workflowFinderService.findWorkflowIdsWithScopeForUser.mockResolvedValue(
+				new Set(['workflow-123']),
+			);
 
 			const execution = createMockExecution({
 				policy: 'non-manual',
@@ -454,7 +701,9 @@ describe('ExecutionRedactionService', () => {
 		});
 
 		it('should set canReveal: true when policy is all, mode is manual, and user has permission', async () => {
-			workflowFinderService.findWorkflowForUser.mockResolvedValue({ id: 'workflow-123' } as never);
+			workflowFinderService.findWorkflowIdsWithScopeForUser.mockResolvedValue(
+				new Set(['workflow-123']),
+			);
 
 			const execution = createMockExecution({
 				policy: 'all',
@@ -493,7 +742,9 @@ describe('ExecutionRedactionService', () => {
 		});
 
 		it('should set canReveal: true when policy is all, mode is trigger, and user has permission', async () => {
-			workflowFinderService.findWorkflowForUser.mockResolvedValue({ id: 'workflow-123' } as never);
+			workflowFinderService.findWorkflowIdsWithScopeForUser.mockResolvedValue(
+				new Set(['workflow-123']),
+			);
 
 			const execution = createMockExecution({
 				policy: 'all',

--- a/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
+++ b/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
@@ -102,6 +102,7 @@ describe('ExecutionRedactionService', () => {
 			: {};
 
 		return {
+			id: 'execution-123',
 			mode,
 			workflowId,
 			data: {

--- a/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
+++ b/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
@@ -1,10 +1,11 @@
 import { Logger } from '@n8n/backend-common';
-import { type IExecutionDb, type User } from '@n8n/db';
+import type { User } from '@n8n/db';
 import { Service } from '@n8n/di';
 
 import type {
 	ExecutionRedaction,
 	ExecutionRedactionOptions,
+	RedactableExecution,
 } from '@/executions/execution-redaction';
 import {
 	type ExecutionError,
@@ -49,9 +50,9 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 	 * @returns The processed execution (currently returns unmodified execution as stub)
 	 */
 	async processExecution(
-		execution: IExecutionDb,
+		execution: RedactableExecution,
 		options: ExecutionRedactionOptions,
-	): Promise<IExecutionDb> {
+	): Promise<RedactableExecution> {
 		if (options.redactExecutionData === true) {
 			// user wants redacted data, this is always fine!
 			const canReveal =
@@ -103,7 +104,7 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 	 * - Global owners and admins (via global role)
 	 * - Project admins and personal project owners (via project role)
 	 */
-	private async canUserReveal(user: User, execution: IExecutionDb): Promise<boolean> {
+	private async canUserReveal(user: User, execution: RedactableExecution): Promise<boolean> {
 		const workflow = await this.workflowFinderService.findWorkflowForUser(
 			execution.workflowId,
 			user,
@@ -120,7 +121,7 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 	 *   - policy === 'non-manual' AND the execution mode is manual: manual executions are
 	 *     exempt from this policy, so the data is still accessible to all.
 	 */
-	private policyAllowsReveal(execution: IExecutionDb): boolean {
+	private policyAllowsReveal(execution: RedactableExecution): boolean {
 		const policy = this.resolvePolicy(execution);
 		return policy === 'none' || (policy === 'non-manual' && MANUAL_MODES.has(execution.mode));
 	}
@@ -132,7 +133,7 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 	 * falls back to `workflowData.settings` for older
 	 * executions, and defaults to 'none'.
 	 */
-	private resolvePolicy(execution: IExecutionDb): WorkflowSettings.RedactionPolicy {
+	private resolvePolicy(execution: RedactableExecution): WorkflowSettings.RedactionPolicy {
 		return (
 			execution.data.executionData?.runtimeData?.redaction?.policy ??
 			execution.workflowData.settings?.redactionPolicy ??
@@ -145,7 +146,7 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 	 * redaction marker and removing binary data. Also sets `execution.data.redactionInfo`
 	 * with metadata about the redaction.
 	 */
-	private applyRedaction(execution: IExecutionDb, reason: string, canReveal: boolean): void {
+	private applyRedaction(execution: RedactableExecution, reason: string, canReveal: boolean): void {
 		const runData = execution.data.resultData.runData;
 		if (runData) {
 			for (const nodeName of Object.keys(runData)) {

--- a/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
+++ b/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
@@ -101,7 +101,7 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 			for (const execution of executions) {
 				this.eventService.emit('execution-data-revealed', {
 					user: options.user,
-					executionId: (execution as { id?: string }).id ?? '',
+					executionId: execution.id ?? '',
 					workflowId: execution.workflowId,
 					ipAddress: options.ipAddress ?? '',
 					userAgent: options.userAgent ?? '',

--- a/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
+++ b/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
@@ -1,5 +1,4 @@
 import { Logger } from '@n8n/backend-common';
-import type { User } from '@n8n/db';
 import { Service } from '@n8n/di';
 
 import type {
@@ -23,7 +22,6 @@ const MANUAL_MODES: ReadonlySet<WorkflowExecuteMode> = new Set(['manual']);
 
 /**
  * Service responsible for redacting sensitive data from executions.
- * This service acts as a facade and delegates to the redaction module.
  */
 @Service()
 export class ExecutionRedactionService implements ExecutionRedaction {
@@ -33,84 +31,103 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 		private readonly eventService: EventService,
 	) {}
 
-	/**
-	 * Initializes the execution redaction service.
-	 * This is a stub implementation that will be extended when the redaction module is fully implemented.
-	 */
 	async init(): Promise<void> {
 		this.logger.debug('Initializing ExecutionRedactionService...');
 	}
 
 	/**
-	 * Main entry point for redaction logic.
-	 * Processes an execution and applies redaction based on the provided options.
-	 *
-	 * @param execution - The execution to process
-	 * @param options - Options for redaction processing
-	 * @returns The processed execution (currently returns unmodified execution as stub)
+	 * Thin wrapper around `processExecutions` for single-execution callers.
 	 */
 	async processExecution(
 		execution: RedactableExecution,
 		options: ExecutionRedactionOptions,
 	): Promise<RedactableExecution> {
+		await this.processExecutions([execution], options);
+		return execution;
+	}
+
+	/**
+	 * Processes a list of executions and applies redaction based on the provided options.
+	 * Resolves all user reveal permissions in a single DB query regardless of list size.
+	 *
+	 * @param executions - The executions to process (mutated in place)
+	 * @param options - Options for redaction processing
+	 */
+	async processExecutions(
+		executions: RedactableExecution[],
+		options: ExecutionRedactionOptions,
+	): Promise<void> {
+		if (executions.length === 0) return;
+
 		if (options.redactExecutionData === true) {
-			// user wants redacted data, this is always fine!
-			const canReveal =
-				this.policyAllowsReveal(execution) || (await this.canUserReveal(options.user, execution));
-			this.applyRedaction(execution, 'user_requested', canReveal);
-		} else if (options.redactExecutionData === false) {
-			// user wants unredacted data — allowed if the policy permits it or the user has the scope
-			const allowed =
-				this.policyAllowsReveal(execution) || (await this.canUserReveal(options.user, execution));
-			if (allowed) {
+			// User explicitly wants redacted data — apply to all, but set canReveal correctly.
+			// canReveal = policyAllowsReveal OR user has execution:reveal scope.
+			// Only query DB for executions where policy doesn't already allow reveal.
+			const needsCheck = executions.filter((e) => !this.policyAllowsReveal(e));
+			let revealableIds = new Set<string>();
+			if (needsCheck.length > 0) {
+				const uniqueWorkflowIds = [...new Set(needsCheck.map((e) => e.workflowId))];
+				revealableIds = await this.workflowFinderService.findWorkflowIdsWithScopeForUser(
+					uniqueWorkflowIds,
+					options.user,
+					['execution:reveal'],
+				);
+			}
+			for (const execution of executions) {
+				const canReveal =
+					this.policyAllowsReveal(execution) || revealableIds.has(execution.workflowId);
+				this.applyRedaction(execution, 'user_requested', canReveal);
+			}
+			return;
+		}
+
+		if (options.redactExecutionData === false) {
+			// User explicitly wants unredacted data — allowed if the policy or scope permits it.
+			const needsCheck = executions.filter((e) => !this.policyAllowsReveal(e));
+			if (needsCheck.length > 0) {
+				const uniqueWorkflowIds = [...new Set(needsCheck.map((e) => e.workflowId))];
+				const revealableIds = await this.workflowFinderService.findWorkflowIdsWithScopeForUser(
+					uniqueWorkflowIds,
+					options.user,
+					['execution:reveal'],
+				);
+				for (const execution of needsCheck) {
+					if (!revealableIds.has(execution.workflowId)) {
+						throw new ForbiddenError();
+					}
+				}
+			}
+			// Emit audit event for every execution the caller was permitted to reveal.
+			for (const execution of executions) {
 				this.eventService.emit('execution-data-revealed', {
 					user: options.user,
-					executionId: execution.id,
+					executionId: (execution as { id?: string }).id ?? '',
 					workflowId: execution.workflowId,
 					ipAddress: options.ipAddress ?? '',
 					userAgent: options.userAgent ?? '',
 					redactionPolicy: this.resolvePolicy(execution),
 				});
-				return execution;
-			} else {
-				throw new ForbiddenError();
 			}
-		} else {
-			// this should be the default case, we act based on the policy
-			const policy = this.resolvePolicy(execution);
-
-			// The policy is no redaction, so we just return the execution.
-			if (policy === 'none') {
-				return execution;
-			}
-
-			// The policy is to redact, non manual executions, so we return only if the mode is manual
-			if (policy === 'non-manual' && MANUAL_MODES.has(execution.mode)) {
-				return execution;
-			}
-
-			const canReveal =
-				this.policyAllowsReveal(execution) || (await this.canUserReveal(options.user, execution));
-			this.applyRedaction(execution, 'workflow_redaction_policy', canReveal);
+			return;
 		}
 
-		return execution;
-	}
+		// Default: policy-driven redaction. Skip executions where the policy allows reveal.
+		const needsRedaction = executions.filter((e) => !this.policyAllowsReveal(e));
+		if (needsRedaction.length === 0) return;
 
-	/**
-	 * Checks whether a user is allowed to view unredacted execution data.
-	 *
-	 * Uses the `execution:reveal` scope which is granted to:
-	 * - Global owners and admins (via global role)
-	 * - Project admins and personal project owners (via project role)
-	 */
-	private async canUserReveal(user: User, execution: RedactableExecution): Promise<boolean> {
-		const workflow = await this.workflowFinderService.findWorkflowForUser(
-			execution.workflowId,
-			user,
+		const uniqueWorkflowIds = [...new Set(needsRedaction.map((e) => e.workflowId))];
+		const revealableIds = await this.workflowFinderService.findWorkflowIdsWithScopeForUser(
+			uniqueWorkflowIds,
+			options.user,
 			['execution:reveal'],
 		);
-		return workflow !== null;
+		for (const execution of needsRedaction) {
+			this.applyRedaction(
+				execution,
+				'workflow_redaction_policy',
+				revealableIds.has(execution.workflowId),
+			);
+		}
 	}
 
 	/**
@@ -130,8 +147,7 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 	 * Resolves the effective redaction policy for an execution.
 	 *
 	 * Prefers the policy captured in `runtimeData.redaction` at execution time,
-	 * falls back to `workflowData.settings` for older
-	 * executions, and defaults to 'none'.
+	 * falls back to `workflowData.settings` for older executions, and defaults to 'none'.
 	 */
 	private resolvePolicy(execution: RedactableExecution): WorkflowSettings.RedactionPolicy {
 		return (
@@ -190,8 +206,6 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 
 	/**
 	 * Redacts all json and binary data from a single node execution data item.
-	 * This is the default "full" redaction strategy. Future strategies (field-level,
-	 * pattern-based) can replace this function without changing the traversal logic.
 	 */
 	private redactItem(item: INodeExecutionData, reason: string): void {
 		item.json = {};

--- a/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
@@ -1,4 +1,4 @@
-import type { IExecutionDb } from '@n8n/db';
+import type { IExecutionBase } from '@n8n/db';
 import { ExecutionRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import type express from 'express';
@@ -14,8 +14,15 @@ import { QueuedExecutionRetryError } from '@/errors/queued-execution-retry.error
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { EventService } from '@/events/event.service';
 import { ExecutionPersistence } from '@/executions/execution-persistence';
+import type { RedactableExecution } from '@/executions/execution-redaction';
 import { ExecutionRedactionServiceProxy } from '@/executions/execution-redaction-proxy.service';
 import { ExecutionService } from '@/executions/execution.service';
+
+function isRedactableExecution(
+	execution: IExecutionBase,
+): execution is IExecutionBase & RedactableExecution {
+	return 'data' in execution && 'workflowData' in execution;
+}
 
 import type { ExecutionRequest } from '../../../types';
 import { apiKeyHasScope, validCursor } from '../../shared/middlewares/global.middleware';
@@ -93,11 +100,10 @@ export = {
 				return res.status(404).json({ message: 'Not Found' });
 			}
 
-			if (includeData) {
-				await Container.get(ExecutionRedactionServiceProxy).processExecution(
-					execution as unknown as IExecutionDb,
-					{ user: req.user },
-				);
+			if (includeData && isRedactableExecution(execution)) {
+				await Container.get(ExecutionRedactionServiceProxy).processExecution(execution, {
+					user: req.user,
+				});
 			}
 
 			Container.get(EventService).emit('user-retrieved-execution', {
@@ -160,9 +166,9 @@ export = {
 			if (includeData) {
 				const redactionProxy = Container.get(ExecutionRedactionServiceProxy);
 				await Promise.all(
-					executions.map(
+					executions.filter(isRedactableExecution).map(
 						async (execution) =>
-							await redactionProxy.processExecution(execution as unknown as IExecutionDb, {
+							await redactionProxy.processExecution(execution, {
 								user: req.user,
 							}),
 					),

--- a/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
@@ -1,3 +1,4 @@
+import type { IExecutionDb } from '@n8n/db';
 import { ExecutionRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import type express from 'express';
@@ -13,6 +14,7 @@ import { QueuedExecutionRetryError } from '@/errors/queued-execution-retry.error
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { EventService } from '@/events/event.service';
 import { ExecutionPersistence } from '@/executions/execution-persistence';
+import { ExecutionRedactionServiceProxy } from '@/executions/execution-redaction-proxy.service';
 import { ExecutionService } from '@/executions/execution.service';
 
 import type { ExecutionRequest } from '../../../types';
@@ -91,6 +93,13 @@ export = {
 				return res.status(404).json({ message: 'Not Found' });
 			}
 
+			if (includeData) {
+				await Container.get(ExecutionRedactionServiceProxy).processExecution(
+					execution as unknown as IExecutionDb,
+					{ user: req.user },
+				);
+			}
+
 			Container.get(EventService).emit('user-retrieved-execution', {
 				userId: req.user.id,
 				publicApi: true,
@@ -147,6 +156,18 @@ export = {
 
 			const count =
 				await Container.get(ExecutionRepository).getExecutionsCountForPublicApi(filters);
+
+			if (includeData) {
+				const redactionProxy = Container.get(ExecutionRedactionServiceProxy);
+				await Promise.all(
+					executions.map(
+						async (execution) =>
+							await redactionProxy.processExecution(execution as unknown as IExecutionDb, {
+								user: req.user,
+							}),
+					),
+				);
+			}
 
 			Container.get(EventService).emit('user-retrieved-all-executions', {
 				userId: req.user.id,

--- a/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
@@ -164,14 +164,10 @@ export = {
 				await Container.get(ExecutionRepository).getExecutionsCountForPublicApi(filters);
 
 			if (includeData) {
-				const redactionProxy = Container.get(ExecutionRedactionServiceProxy);
-				await Promise.all(
-					executions.filter(isRedactableExecution).map(
-						async (execution) =>
-							await redactionProxy.processExecution(execution, {
-								user: req.user,
-							}),
-					),
+				const redactableExecutions = executions.filter(isRedactableExecution);
+				await Container.get(ExecutionRedactionServiceProxy).processExecutions(
+					redactableExecutions,
+					{ user: req.user },
 				);
 			}
 

--- a/packages/cli/src/workflows/__tests__/workflows.controller.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflows.controller.test.ts
@@ -152,7 +152,11 @@ describe('WorkflowsController', () => {
 			 * Assert
 			 */
 			expect(result).toEqual(mockExecution);
-			expect(executionService.getLastSuccessfulExecution).toHaveBeenCalledWith(workflowId);
+			expect(executionService.getLastSuccessfulExecution).toHaveBeenCalledWith(
+				workflowId,
+				req.user,
+				undefined,
+			);
 		});
 
 		it('should return null when no successful execution exists', async () => {
@@ -173,7 +177,11 @@ describe('WorkflowsController', () => {
 			 * Assert
 			 */
 			expect(result).toBeNull();
-			expect(executionService.getLastSuccessfulExecution).toHaveBeenCalledWith(workflowId);
+			expect(executionService.getLastSuccessfulExecution).toHaveBeenCalledWith(
+				workflowId,
+				req.user,
+				undefined,
+			);
 		});
 	});
 });

--- a/packages/cli/src/workflows/workflow-finder.service.ts
+++ b/packages/cli/src/workflows/workflow-finder.service.ts
@@ -108,6 +108,20 @@ export class WorkflowFinderService {
 		return where;
 	}
 
+	async findWorkflowIdsWithScopeForUser(
+		workflowIds: string[],
+		user: User,
+		scopes: Scope[],
+	): Promise<Set<string>> {
+		if (workflowIds.length === 0) return new Set();
+		const where = await this.findAllWhere(user, scopes);
+		const sharedWorkflows = await this.sharedWorkflowRepository.find({
+			select: { workflowId: true },
+			where: { ...where, workflowId: In(workflowIds) },
+		});
+		return new Set(sharedWorkflows.map((sw) => sw.workflowId));
+	}
+
 	async findAllWorkflowIdsForUser(
 		user: User,
 		scopes: Scope[],

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -3,6 +3,7 @@ import {
 	ArchiveWorkflowDto,
 	CreateWorkflowDto,
 	DeactivateWorkflowDto,
+	ExecutionRedactionQueryDtoSchema,
 	ImportWorkflowFromUrlDto,
 	ROLE,
 	TransferWorkflowBodyDto,
@@ -652,11 +653,20 @@ export class WorkflowsController {
 	@Get('/:workflowId/executions/last-successful')
 	@ProjectScope('workflow:read')
 	async getLastSuccessfulExecution(
-		_req: AuthenticatedRequest,
+		req: AuthenticatedRequest,
 		_res: unknown,
 		@Param('workflowId') workflowId: string,
 	) {
-		const lastExecution = await this.executionService.getLastSuccessfulExecution(workflowId);
+		const redactQuery = ExecutionRedactionQueryDtoSchema.safeParse(req.query);
+		const redactExecutionData = redactQuery.success
+			? redactQuery.data.redactExecutionData
+			: undefined;
+
+		const lastExecution = await this.executionService.getLastSuccessfulExecution(
+			workflowId,
+			req.user,
+			redactExecutionData,
+		);
 
 		return lastExecution ?? null;
 	}

--- a/packages/cli/test/integration/execution-redaction.test.ts
+++ b/packages/cli/test/integration/execution-redaction.test.ts
@@ -732,4 +732,49 @@ describe('GET /api/v1/executions — Execution Redaction', () => {
 		expect(response.body.data).toHaveLength(1);
 		expect(response.body.data[0].data).toBeUndefined();
 	});
+
+	test('batch: multiple executions across multiple workflows — each redacted independently', async () => {
+		const workflow1 = await createWorkflow({}, publicApiMember);
+		const workflow2 = await createWorkflow({}, publicApiMember);
+
+		// workflow1: policy "non-manual", trigger → should be redacted
+		await createExecutionWithRedaction({
+			workflow: workflow1,
+			mode: 'trigger',
+			policy: 'non-manual',
+		});
+		// workflow1: policy "non-manual", manual → should NOT be redacted
+		await createExecutionWithRedaction({
+			workflow: workflow1,
+			mode: 'manual',
+			policy: 'non-manual',
+		});
+		// workflow2: policy "none", trigger → should NOT be redacted
+		await createExecutionWithRedaction({ workflow: workflow2, mode: 'trigger', policy: 'none' });
+		// workflow2: policy "all", webhook → should be redacted
+		await createExecutionWithRedaction({ workflow: workflow2, mode: 'webhook', policy: 'all' });
+
+		const response = await testServer
+			.publicApiAgentFor(publicApiMember)
+			.get('/executions?includeData=true')
+			.expect(200);
+
+		expect(response.body.data).toHaveLength(4);
+
+		const results = response.body.data as Array<{
+			workflowId: string;
+			mode: string;
+			data: IRunExecutionData;
+		}>;
+
+		const wf1Trigger = results.find((e) => e.workflowId === workflow1.id && e.mode === 'trigger');
+		const wf1Manual = results.find((e) => e.workflowId === workflow1.id && e.mode === 'manual');
+		const wf2Trigger = results.find((e) => e.workflowId === workflow2.id && e.mode === 'trigger');
+		const wf2Webhook = results.find((e) => e.workflowId === workflow2.id && e.mode === 'webhook');
+
+		assertRedacted(wf1Trigger!.data, 'workflow_redaction_policy', false);
+		assertNotRedacted(wf1Manual!.data);
+		assertNotRedacted(wf2Trigger!.data);
+		assertRedacted(wf2Webhook!.data, 'workflow_redaction_policy', false);
+	});
 });

--- a/packages/cli/test/integration/execution-redaction.test.ts
+++ b/packages/cli/test/integration/execution-redaction.test.ts
@@ -14,7 +14,12 @@ import { ConcurrencyControlService } from '@/concurrency/concurrency-control.ser
 import { WaitTracker } from '@/wait-tracker';
 
 import { createExecution } from './shared/db/executions';
-import { createMember, createOwner } from './shared/db/users';
+import {
+	createMember,
+	createMemberWithApiKey,
+	createOwner,
+	createOwnerWithApiKey,
+} from './shared/db/users';
 import { setupTestServer } from './shared/utils';
 
 // Must be set before setupTestServer() so RedactionModule.init() wires the real service
@@ -27,18 +32,22 @@ mockInstance(ConcurrencyControlService, {
 });
 
 const testServer = setupTestServer({
-	endpointGroups: ['executions'],
+	endpointGroups: ['executions', 'workflows', 'publicApi'],
 	modules: ['redaction'],
 });
 
 let owner: User;
 let member: User;
+let publicApiOwner: User;
+let publicApiMember: User;
 
 beforeEach(async () => {
 	await testDb.truncate(['ExecutionEntity', 'WorkflowEntity', 'SharedWorkflow']);
 	testServer.license.reset();
 	owner = await createOwner();
 	member = await createMember();
+	publicApiOwner = await createOwnerWithApiKey();
+	publicApiMember = await createMemberWithApiKey();
 });
 
 // ---------------------------------------------------------------------------
@@ -460,5 +469,267 @@ describe('GET /executions/:id — Execution Redaction', () => {
 			expect(data.resultData.redactedError).toEqual({ type: 'NodeOperationError' });
 			expect(data.resultData.redactedError).not.toHaveProperty('httpCode');
 		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// GET /workflows/:workflowId/executions/last-successful — Execution Redaction
+// ---------------------------------------------------------------------------
+
+describe('GET /workflows/:workflowId/executions/last-successful — Execution Redaction', () => {
+	describe('policy-based redaction (no query param)', () => {
+		test('policy "none" with trigger mode — returns unredacted', async () => {
+			const workflow = await createWorkflow({}, owner);
+			await createExecutionWithRedaction({ workflow, mode: 'trigger', policy: 'none' });
+
+			const response = await testServer
+				.authAgentFor(owner)
+				.get(`/workflows/${workflow.id}/executions/last-successful`)
+				.expect(200);
+
+			assertNotRedacted(response.body.data.data as IRunExecutionData);
+		});
+
+		test('policy "non-manual" with trigger mode — returns redacted', async () => {
+			const workflow = await createWorkflow({}, owner);
+			await createExecutionWithRedaction({ workflow, mode: 'trigger', policy: 'non-manual' });
+
+			const response = await testServer
+				.authAgentFor(owner)
+				.get(`/workflows/${workflow.id}/executions/last-successful`)
+				.expect(200);
+
+			assertRedacted(response.body.data.data as IRunExecutionData);
+		});
+
+		test('policy "non-manual" with manual mode — returns unredacted', async () => {
+			const workflow = await createWorkflow({}, owner);
+			await createExecutionWithRedaction({ workflow, mode: 'manual', policy: 'non-manual' });
+
+			const response = await testServer
+				.authAgentFor(owner)
+				.get(`/workflows/${workflow.id}/executions/last-successful`)
+				.expect(200);
+
+			assertNotRedacted(response.body.data.data as IRunExecutionData);
+		});
+
+		test('policy "all" with trigger mode — returns redacted', async () => {
+			const workflow = await createWorkflow({}, owner);
+			await createExecutionWithRedaction({ workflow, mode: 'trigger', policy: 'all' });
+
+			const response = await testServer
+				.authAgentFor(owner)
+				.get(`/workflows/${workflow.id}/executions/last-successful`)
+				.expect(200);
+
+			assertRedacted(response.body.data.data as IRunExecutionData);
+		});
+	});
+
+	describe('explicit redactExecutionData=true query param', () => {
+		test('always redacts even when policy is "none"', async () => {
+			const workflow = await createWorkflow({}, owner);
+			await createExecutionWithRedaction({ workflow, mode: 'trigger', policy: 'none' });
+
+			const response = await testServer
+				.authAgentFor(owner)
+				.get(`/workflows/${workflow.id}/executions/last-successful`)
+				.query({ redactExecutionData: 'true' })
+				.expect(200);
+
+			assertRedacted(response.body.data.data as IRunExecutionData, 'user_requested');
+		});
+	});
+
+	describe('explicit redactExecutionData=false query param (reveal)', () => {
+		test('owner can reveal unredacted data when policy is "all"', async () => {
+			const workflow = await createWorkflow({}, owner);
+			await createExecutionWithRedaction({ workflow, mode: 'trigger', policy: 'all' });
+
+			const response = await testServer
+				.authAgentFor(owner)
+				.get(`/workflows/${workflow.id}/executions/last-successful`)
+				.query({ redactExecutionData: 'false' })
+				.expect(200);
+
+			assertNotRedacted(response.body.data.data as IRunExecutionData);
+		});
+	});
+
+	test('returns null when no successful execution exists', async () => {
+		const workflow = await createWorkflow({}, owner);
+
+		const response = await testServer
+			.authAgentFor(owner)
+			.get(`/workflows/${workflow.id}/executions/last-successful`)
+			.expect(200);
+
+		expect(response.body.data).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/executions/:id — Execution Redaction
+// ---------------------------------------------------------------------------
+
+describe('GET /api/v1/executions/:id — Execution Redaction', () => {
+	describe('policy-based redaction (includeData=true)', () => {
+		test('policy "none" with trigger mode — returns unredacted', async () => {
+			const workflow = await createWorkflow({}, publicApiMember);
+			const execution = await createExecutionWithRedaction({
+				workflow,
+				mode: 'trigger',
+				policy: 'none',
+			});
+
+			const response = await testServer
+				.publicApiAgentFor(publicApiMember)
+				.get(`/executions/${execution.id}?includeData=true`)
+				.expect(200);
+
+			assertNotRedacted(response.body.data as IRunExecutionData);
+		});
+
+		test('policy "non-manual" with trigger mode — redacts for member (canReveal=false)', async () => {
+			const workflow = await createWorkflow({}, publicApiMember);
+			const execution = await createExecutionWithRedaction({
+				workflow,
+				mode: 'trigger',
+				policy: 'non-manual',
+			});
+
+			const response = await testServer
+				.publicApiAgentFor(publicApiMember)
+				.get(`/executions/${execution.id}?includeData=true`)
+				.expect(200);
+
+			assertRedacted(response.body.data as IRunExecutionData, 'workflow_redaction_policy', false);
+		});
+
+		test('policy "non-manual" with trigger mode — redacts for owner (canReveal=true)', async () => {
+			const workflow = await createWorkflow({}, publicApiOwner);
+			const execution = await createExecutionWithRedaction({
+				workflow,
+				mode: 'trigger',
+				policy: 'non-manual',
+			});
+
+			const response = await testServer
+				.publicApiAgentFor(publicApiOwner)
+				.get(`/executions/${execution.id}?includeData=true`)
+				.expect(200);
+
+			assertRedacted(response.body.data as IRunExecutionData, 'workflow_redaction_policy', true);
+		});
+
+		test('policy "non-manual" with manual mode — returns unredacted', async () => {
+			const workflow = await createWorkflow({}, publicApiMember);
+			const execution = await createExecutionWithRedaction({
+				workflow,
+				mode: 'manual',
+				policy: 'non-manual',
+			});
+
+			const response = await testServer
+				.publicApiAgentFor(publicApiMember)
+				.get(`/executions/${execution.id}?includeData=true`)
+				.expect(200);
+
+			assertNotRedacted(response.body.data as IRunExecutionData);
+		});
+
+		test('policy "all" with trigger mode — redacts for member (canReveal=false)', async () => {
+			const workflow = await createWorkflow({}, publicApiMember);
+			const execution = await createExecutionWithRedaction({
+				workflow,
+				mode: 'trigger',
+				policy: 'all',
+			});
+
+			const response = await testServer
+				.publicApiAgentFor(publicApiMember)
+				.get(`/executions/${execution.id}?includeData=true`)
+				.expect(200);
+
+			assertRedacted(response.body.data as IRunExecutionData, 'workflow_redaction_policy', false);
+		});
+
+		test('includeData=false — returns execution without data field', async () => {
+			const workflow = await createWorkflow({}, publicApiMember);
+			const execution = await createExecutionWithRedaction({
+				workflow,
+				mode: 'trigger',
+				policy: 'all',
+			});
+
+			const response = await testServer
+				.publicApiAgentFor(publicApiMember)
+				.get(`/executions/${execution.id}`)
+				.expect(200);
+
+			expect(response.body.data).toBeUndefined();
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/executions — Execution Redaction
+// ---------------------------------------------------------------------------
+
+describe('GET /api/v1/executions — Execution Redaction', () => {
+	test('policy "non-manual" with trigger mode — redacts all executions in list', async () => {
+		const workflow = await createWorkflow({}, publicApiMember);
+		await createExecutionWithRedaction({
+			workflow,
+			mode: 'trigger',
+			policy: 'non-manual',
+		});
+
+		const response = await testServer
+			.publicApiAgentFor(publicApiMember)
+			.get('/executions?includeData=true')
+			.expect(200);
+
+		expect(response.body.data).toHaveLength(1);
+		assertRedacted(
+			response.body.data[0].data as IRunExecutionData,
+			'workflow_redaction_policy',
+			false,
+		);
+	});
+
+	test('policy "none" — list returns unredacted when includeData=true', async () => {
+		const workflow = await createWorkflow({}, publicApiMember);
+		await createExecutionWithRedaction({
+			workflow,
+			mode: 'trigger',
+			policy: 'none',
+		});
+
+		const response = await testServer
+			.publicApiAgentFor(publicApiMember)
+			.get('/executions?includeData=true')
+			.expect(200);
+
+		expect(response.body.data).toHaveLength(1);
+		assertNotRedacted(response.body.data[0].data as IRunExecutionData);
+	});
+
+	test('includeData=false — returns executions without data field', async () => {
+		const workflow = await createWorkflow({}, publicApiMember);
+		await createExecutionWithRedaction({
+			workflow,
+			mode: 'trigger',
+			policy: 'all',
+		});
+
+		const response = await testServer
+			.publicApiAgentFor(publicApiMember)
+			.get('/executions')
+			.expect(200);
+
+		expect(response.body.data).toHaveLength(1);
+		expect(response.body.data[0].data).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## Summary

Extends the `ExecutionRedactionService` integration (previously only applied to `GET /executions/:id` and `PATCH /executions/:id`) to cover all endpoints that return full execution node output data.

**New endpoints covered:**
- `GET /workflows/:workflowId/executions/last-successful` — applies policy-based redaction; supports the `redactExecutionData` query parameter for explicit redact/reveal
- `POST /executions/:id/retry` (internal API) — applies redaction to the retry response before returning, respecting the `redactExecutionData` query parameter
- `GET /api/v1/executions/:id` (public API) — applies policy-based redaction when `includeData=true`
- `GET /api/v1/executions` (public API) — applies policy-based redaction to each execution in the list when `includeData=true`
- `POST /api/v1/executions/:id/retry` (public API) — inherits redaction automatically via `ExecutionService.retry()`

**Type improvements:** Introduced a `RedactableExecution` structural type that captures the minimal shape the redaction service actually needs (`mode`, `workflowId`, `data`, `workflowData.settings`). This replaces the previous `IExecutionDb` coupling and allows callers with `IExecutionResponse` or other compatible types to pass executions without unsafe casts.

> **Breaking change (opt-in):** When `N8N_ENV_FEAT_EXECUTION_REDACTION=true` is set and the workflow's redaction policy is not `none`, the public API endpoints will now return redacted node output data consistent with the internal API. This is the intended behavior for operators who have enabled the feature flag.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-187

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.