### PR TITLE
feat: Add option to hide credential overwrites

### DIFF
--- a/packages/@n8n/config/src/configs/credentials.config.ts
+++ b/packages/@n8n/config/src/configs/credentials.config.ts
@@ -1,3 +1,4 @@
+import { CommaSeparatedStringArray } from '../custom-types';
 import { Config, Env, Nested } from '../decorators';
 
 @Config
@@ -20,6 +21,15 @@ class CredentialsOverwrite {
 	/** Whether to persist credential overwrites so they survive restarts. */
 	@Env('CREDENTIALS_OVERWRITE_PERSISTENCE')
 	persistence: boolean = false;
+
+	/**
+	 * Comma-separated list of credential types for which overwrites are skipped
+	 * when the credential has been customized (any overwrite field has a user-set
+	 * value differing from the overwrite).
+	 * @example `N8N_SKIP_CREDENTIAL_OVERWRITE=zohoOAuth2Api,salesforceOAuth2Api`
+	 */
+	@Env('N8N_SKIP_CREDENTIAL_OVERWRITE')
+	skipTypes: CommaSeparatedStringArray<string> = [];
 }
 
 @Config

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -103,6 +103,7 @@ describe('GlobalConfig', () => {
 				endpoint: '',
 				endpointAuthToken: '',
 				persistence: false,
+				skipTypes: [],
 			},
 		},
 		userManagement: {

--- a/packages/cli/src/__tests__/credentials-overwrites.test.ts
+++ b/packages/cli/src/__tests__/credentials-overwrites.test.ts
@@ -1,6 +1,6 @@
 import type { Logger } from '@n8n/backend-common';
 import { mockInstance } from '@n8n/backend-test-utils';
-import type { GlobalConfig } from '@n8n/config';
+import type { CommaSeparatedStringArray, GlobalConfig } from '@n8n/config';
 import { SettingsRepository } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 import { Cipher, UnrecognizedCredentialTypeError } from 'n8n-core';
@@ -27,6 +27,8 @@ describe('CredentialsOverwrites', () => {
 			test: { username: 'user' },
 			parent: { password: 'pass' },
 		});
+		globalConfig.credentials.overwrite.skipTypes =
+			[] as unknown as CommaSeparatedStringArray<string>;
 		credentialTypes.recognizes.mockReturnValue(true);
 		credentialTypes.getByName.mockImplementation((credentialType) => {
 			if (credentialType === testCredentialType.name) return testCredentialType;
@@ -109,6 +111,50 @@ describe('CredentialsOverwrites', () => {
 
 			const result = credentialsOverwrites.applyOverwrite('unknownCredential', data);
 			expect(result).toEqual(data);
+		});
+
+		describe('N8N_SKIP_CREDENTIAL_OVERWRITE', () => {
+			beforeEach(() => {
+				globalConfig.credentials.overwrite.skipTypes = [
+					'test',
+				] as unknown as CommaSeparatedStringArray<string>;
+			});
+
+			it('should apply overwrite when all overwrite fields are empty', () => {
+				const result = credentialsOverwrites.applyOverwrite('test', {
+					username: '',
+					password: '',
+				});
+
+				expect(result).toEqual({ username: 'user', password: 'pass' });
+			});
+
+			it('should apply overwrite when overwrite fields match the stored values', () => {
+				// stored values already equal the overwrite values — apply is a no-op but correct path
+				const result = credentialsOverwrites.applyOverwrite('test', {
+					username: 'user',
+					password: 'pass',
+				});
+
+				expect(result).toEqual({ username: 'user', password: 'pass' });
+			});
+
+			it('should skip overwrite when credential has a custom value for an overwrite field', () => {
+				const data = { username: 'custom-user', password: '' };
+
+				const result = credentialsOverwrites.applyOverwrite('test', data);
+
+				expect(result).toEqual(data);
+			});
+
+			it('should not affect types not in the skip list', () => {
+				// 'parent' is not in skipTypes, so its empty fields are still filled
+				credentialTypes.getParentTypes.calledWith('parent').mockReturnValue([]);
+
+				const result = credentialsOverwrites.applyOverwrite('parent', { password: '' });
+
+				expect(result).toEqual({ password: 'pass' });
+			});
 		});
 	});
 

--- a/packages/cli/src/credentials-overwrites.ts
+++ b/packages/cli/src/credentials-overwrites.ts
@@ -143,6 +143,25 @@ export class CredentialsOverwrites {
 			return data;
 		}
 
+		// For skip-list types, don't apply overwrite if the credential has been
+		// customized (any overwrite field has a non-empty value that differs from
+		// the overwrite value). Since overwrites are never persisted to the DB,
+		// any non-empty stored value that differs from the overwrite is user-set.
+		if (this.globalConfig.credentials.overwrite.skipTypes.includes(type)) {
+			const customizedField = Object.keys(overwrites).find((key) => {
+				const storedValue = data[key];
+				return (
+					storedValue !== null &&
+					storedValue !== undefined &&
+					storedValue !== '' &&
+					storedValue !== overwrites[key]
+				);
+			});
+			if (customizedField !== undefined) {
+				return data;
+			}
+		}
+
 		const returnData = deepCopy(data);
 		// Overwrite only if there is currently no data set
 		for (const key of Object.keys(overwrites)) {

--- a/packages/cli/src/credentials-overwrites.ts
+++ b/packages/cli/src/credentials-overwrites.ts
@@ -148,7 +148,7 @@ export class CredentialsOverwrites {
 		// the overwrite value). Since overwrites are never persisted to the DB,
 		// any non-empty stored value that differs from the overwrite is user-set.
 		if (this.globalConfig.credentials.overwrite.skipTypes.includes(type)) {
-			const customizedField = Object.keys(overwrites).find((key) => {
+			const isFieldCustomized = (key: string) => {
 				const storedValue = data[key];
 				return (
 					storedValue !== null &&
@@ -156,8 +156,8 @@ export class CredentialsOverwrites {
 					storedValue !== '' &&
 					storedValue !== overwrites[key]
 				);
-			});
-			if (customizedField !== undefined) {
+			};
+			if (Object.keys(overwrites).some(isFieldCustomized)) {
 				return data;
 			}
 		}

--- a/packages/cli/src/services/__tests__/frontend.service.test.ts
+++ b/packages/cli/src/services/__tests__/frontend.service.test.ts
@@ -3,7 +3,7 @@ import type { GlobalConfig, SecurityConfig } from '@n8n/config';
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
 import type { BinaryDataConfig, InstanceSettings } from 'n8n-core';
-import type { INodeTypeDescription } from 'n8n-workflow';
+import type { ICredentialType, INodeTypeDescription } from 'n8n-workflow';
 
 import type { CredentialTypes } from '@/credential-types';
 import type { CredentialsOverwrites } from '@/credentials-overwrites';
@@ -59,6 +59,9 @@ describe('FrontendService', () => {
 			ldap: { loginEnabled: false },
 			saml: { loginEnabled: false },
 			oidc: { loginEnabled: false },
+		},
+		credentials: {
+			overwrite: { skipTypes: [] },
 		},
 	});
 
@@ -482,6 +485,74 @@ describe('FrontendService', () => {
 				expect.arrayContaining(['n8n-nodes-base.duplicate@1', 'n8n-nodes-base.duplicate@2']),
 			);
 			expect(identifiers).toHaveLength(2);
+		});
+	});
+
+	describe('overwriteCredentialsProperties', () => {
+		afterEach(() => {
+			// Restore globalConfig.credentials to the default so other tests are unaffected
+			(globalConfig as any).credentials = { overwrite: { skipTypes: [] } };
+			loadNodesAndCredentials.types = { credentials: [], nodes: [] };
+		});
+
+		it('should set __skipManagedCreation for types in the skip list', () => {
+			const skipCredential = {
+				name: 'googleSheetsOAuth2Api',
+				displayName: 'Google Sheets OAuth2 API',
+				properties: [],
+			} as ICredentialType;
+			const normalCredential = {
+				name: 'slackOAuth2Api',
+				displayName: 'Slack OAuth2 API',
+				properties: [],
+			} as ICredentialType;
+
+			loadNodesAndCredentials.types = {
+				credentials: [skipCredential, normalCredential],
+				nodes: [],
+			};
+			(globalConfig as any).credentials = {
+				overwrite: { skipTypes: ['googleSheetsOAuth2Api'] },
+			};
+
+			const { service } = createMockService();
+			(service as any).overwriteCredentialsProperties();
+
+			expect(skipCredential.__skipManagedCreation).toBe(true);
+			expect(normalCredential.__skipManagedCreation).toBeUndefined();
+		});
+
+		it('should not set __skipManagedCreation when skip list is empty', () => {
+			const credential = {
+				name: 'googleSheetsOAuth2Api',
+				displayName: 'Google Sheets OAuth2 API',
+				properties: [],
+			} as ICredentialType;
+
+			loadNodesAndCredentials.types = { credentials: [credential], nodes: [] };
+			(globalConfig as any).credentials = { overwrite: { skipTypes: [] } };
+
+			const { service } = createMockService();
+			(service as any).overwriteCredentialsProperties();
+
+			expect(credential.__skipManagedCreation).toBeUndefined();
+		});
+
+		it('should clear stale __skipManagedCreation when type is removed from skip list', () => {
+			const credential = {
+				name: 'googleSheetsOAuth2Api',
+				displayName: 'Google Sheets OAuth2 API',
+				properties: [],
+				__skipManagedCreation: true, // Previously set
+			} as ICredentialType;
+
+			loadNodesAndCredentials.types = { credentials: [credential], nodes: [] };
+			(globalConfig as any).credentials = { overwrite: { skipTypes: [] } };
+
+			const { service } = createMockService();
+			(service as any).overwriteCredentialsProperties();
+
+			expect(credential.__skipManagedCreation).toBeUndefined();
 		});
 	});
 

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -639,9 +639,11 @@ export class FrontendService {
 	private overwriteCredentialsProperties() {
 		const { credentials } = this.loadNodesAndCredentials.types;
 		const credentialsOverwrites = this.credentialsOverwrites.getAll();
+		const { skipTypes } = this.globalConfig.credentials.overwrite;
 		for (const credential of credentials) {
 			// Clear any existing overwritten properties to prevent stale data
 			delete credential.__overwrittenProperties;
+			delete credential.__skipManagedCreation;
 
 			const overwrittenProperties = [];
 			this.credentialTypes
@@ -658,6 +660,12 @@ export class FrontendService {
 
 			if (overwrittenProperties.length) {
 				credential.__overwrittenProperties = uniq(overwrittenProperties);
+			}
+
+			// For skip-list types, prevent managed credential creation in the frontend
+			// (overwrite is conditional on stored data; users should provide their own credentials)
+			if (skipTypes.includes(credential.name)) {
+				credential.__skipManagedCreation = true;
 			}
 		}
 	}

--- a/packages/cli/test/integration/credentials/credentials-overwrites.integration.test.ts
+++ b/packages/cli/test/integration/credentials/credentials-overwrites.integration.test.ts
@@ -36,6 +36,7 @@ describe('CredentialsOverwrites - Integration Tests', () => {
 				persistence: true, // Enable persistence for integration tests
 				endpointAuthToken: 'integration-test-token',
 				endpoint: 'integration-credentials-overwrite',
+				skipTypes: [],
 			},
 		};
 

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, useTemplateRef } from 'vue';
+import { computed, onMounted, ref, useTemplateRef, watch } from 'vue';
 
 import type { IUpdateInformation } from '@/Interface';
 import type { ICredentialsDecryptedResponse, ICredentialsResponse } from '../../credentials.types';
@@ -376,6 +376,18 @@ function setCredentialPropertyDefaults() {
 	}
 }
 
+// For new credentials of skip-list types, default to custom mode (managed creation is disabled).
+// Using { immediate: true } handles both initial load and subsequent type switches.
+watch(
+	credentialType,
+	(newType) => {
+		if (props.mode === 'new' && newType?.__skipManagedCreation) {
+			useCustomOAuth.value = true;
+		}
+	},
+	{ immediate: true },
+);
+
 onMounted(async () => {
 	const modalState = uiStore.modalsById[CREDENTIAL_EDIT_MODAL_KEY];
 	requiredCredentials.value =
@@ -398,9 +410,11 @@ onMounted(async () => {
 
 	setCredentialPropertyDefaults();
 
-	// Detect if existing credential uses custom OAuth (user-provided clientId/clientSecret)
+	// Detect if existing credential uses custom OAuth (user-provided clientId/clientSecret).
+	// Use __overwrittenProperties directly instead of managedOAuthAvailable so that skip-list
+	// types (where managedOAuthAvailable is false) still auto-detect custom credentials.
 	if (
-		managedOAuthAvailable.value &&
+		credentialType.value?.__overwrittenProperties?.includes('clientId') &&
 		credentialData.value.clientId &&
 		credentialData.value.clientSecret
 	) {
@@ -756,6 +770,7 @@ function usesExternalSecrets(data: Record<string, unknown>): boolean {
 
 function hasManagedOAuthCredentials(credType: string) {
 	const type = credentialsStore.getCredentialTypeByName(credType);
+	if (type?.__skipManagedCreation) return false;
 	return (
 		type?.__overwrittenProperties?.includes('clientId') &&
 		type.__overwrittenProperties.includes('clientSecret')

--- a/packages/frontend/editor-ui/src/features/credentials/composables/__tests__/useCredentialOAuth.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/__tests__/useCredentialOAuth.test.ts
@@ -280,6 +280,18 @@ describe('useCredentialOAuth', () => {
 			const { hasManagedOAuthCredentials } = useCredentialOAuth();
 			expect(hasManagedOAuthCredentials('unknownType')).toBe(false);
 		});
+
+		it('should return false when __skipManagedCreation is true', () => {
+			const credentialsStore = mockedStore(useCredentialsStore);
+			credentialsStore.state.credentialTypes.slackOAuth2Api = {
+				...slackOAuth2Api,
+				__overwrittenProperties: ['clientId'],
+				__skipManagedCreation: true,
+			};
+
+			const { hasManagedOAuthCredentials } = useCredentialOAuth();
+			expect(hasManagedOAuthCredentials('slackOAuth2Api')).toBe(false);
+		});
 	});
 
 	describe('authorize', () => {

--- a/packages/frontend/editor-ui/src/features/credentials/composables/useCredentialOAuth.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/useCredentialOAuth.ts
@@ -79,6 +79,10 @@ export function useCredentialOAuth() {
 			return false;
 		}
 
+		if (credentialType.__skipManagedCreation) {
+			return false;
+		}
+
 		const overwrittenProperties = credentialType.__overwrittenProperties ?? [];
 		if (overwrittenProperties.length === 0) {
 			return false;

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -359,6 +359,7 @@ export interface ICredentialType {
 	properties: INodeProperties[];
 	documentationUrl?: string;
 	__overwrittenProperties?: string[];
+	__skipManagedCreation?: boolean;
 	authenticate?: IAuthenticate;
 	preAuthentication?: (
 		this: IHttpRequestHelper,


### PR DESCRIPTION
## Summary
There are times where we might want to deprecate a managed credential on n8n cloud, To handle this and make the transition easier we are adding a new env option that accepts a credential type, If this type is in the overwrites we will keep existing credentials working but won't allow new ones to be created.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
