### PR TITLE
test: Add contract test for n8n node vs public API coverage

### DIFF
--- a/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
+++ b/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
@@ -1,0 +1,197 @@
+{
+	"$comment": "Coverage manifest: n8n node vs n8n public API. When a new endpoint is added to the OpenAPI spec, add it here with status covered/gap/excluded. See test/N8n.api-coverage.test.ts.",
+	"endpoints": {
+		"POST /audit": {
+			"status": "covered",
+			"nodeOperation": "audit:generate"
+		},
+		"GET /credentials": {
+			"status": "gap"
+		},
+		"POST /credentials": {
+			"status": "covered",
+			"nodeOperation": "credential:create"
+		},
+		"PATCH /credentials/{id}": {
+			"status": "gap"
+		},
+		"DELETE /credentials/{id}": {
+			"status": "covered",
+			"nodeOperation": "credential:delete"
+		},
+		"GET /credentials/schema/{credentialTypeName}": {
+			"status": "covered",
+			"nodeOperation": "credential:getSchema"
+		},
+		"PUT /credentials/{id}/transfer": {
+			"status": "gap"
+		},
+		"GET /executions": {
+			"status": "covered",
+			"nodeOperation": "execution:getAll"
+		},
+		"GET /executions/{id}": {
+			"status": "covered",
+			"nodeOperation": "execution:get"
+		},
+		"DELETE /executions/{id}": {
+			"status": "covered",
+			"nodeOperation": "execution:delete"
+		},
+		"POST /executions/{id}/retry": {
+			"status": "gap"
+		},
+		"POST /executions/{id}/stop": {
+			"status": "gap"
+		},
+		"POST /executions/stop": {
+			"status": "gap"
+		},
+		"GET /executions/{id}/tags": {
+			"status": "gap"
+		},
+		"PUT /executions/{id}/tags": {
+			"status": "gap"
+		},
+		"POST /tags": {
+			"status": "gap"
+		},
+		"GET /tags": {
+			"status": "gap"
+		},
+		"GET /tags/{id}": {
+			"status": "gap"
+		},
+		"DELETE /tags/{id}": {
+			"status": "gap"
+		},
+		"PUT /tags/{id}": {
+			"status": "gap"
+		},
+		"POST /workflows": {
+			"status": "covered",
+			"nodeOperation": "workflow:create"
+		},
+		"GET /workflows": {
+			"status": "covered",
+			"nodeOperation": "workflow:getAll"
+		},
+		"GET /workflows/{id}": {
+			"status": "covered",
+			"nodeOperation": "workflow:get"
+		},
+		"DELETE /workflows/{id}": {
+			"status": "covered",
+			"nodeOperation": "workflow:delete"
+		},
+		"PUT /workflows/{id}": {
+			"status": "covered",
+			"nodeOperation": "workflow:update"
+		},
+		"GET /workflows/{id}/{versionId}": {
+			"status": "covered",
+			"nodeOperation": "workflow:getVersion"
+		},
+		"POST /workflows/{id}/activate": {
+			"status": "covered",
+			"nodeOperation": "workflow:activate"
+		},
+		"POST /workflows/{id}/deactivate": {
+			"status": "covered",
+			"nodeOperation": "workflow:deactivate"
+		},
+		"PUT /workflows/{id}/transfer": {
+			"status": "gap"
+		},
+		"GET /workflows/{id}/tags": {
+			"status": "gap"
+		},
+		"PUT /workflows/{id}/tags": {
+			"status": "gap"
+		},
+		"GET /users": {
+			"status": "gap"
+		},
+		"POST /users": {
+			"status": "gap"
+		},
+		"GET /users/{id}": {
+			"status": "gap"
+		},
+		"DELETE /users/{id}": {
+			"status": "gap"
+		},
+		"PATCH /users/{id}/role": {
+			"status": "gap"
+		},
+		"POST /source-control/pull": {
+			"status": "gap"
+		},
+		"POST /variables": {
+			"status": "gap"
+		},
+		"GET /variables": {
+			"status": "gap"
+		},
+		"DELETE /variables/{id}": {
+			"status": "gap"
+		},
+		"PUT /variables/{id}": {
+			"status": "gap"
+		},
+		"GET /data-tables": {
+			"status": "gap"
+		},
+		"POST /data-tables": {
+			"status": "gap"
+		},
+		"GET /data-tables/{dataTableId}": {
+			"status": "gap"
+		},
+		"PATCH /data-tables/{dataTableId}": {
+			"status": "gap"
+		},
+		"DELETE /data-tables/{dataTableId}": {
+			"status": "gap"
+		},
+		"GET /data-tables/{dataTableId}/rows": {
+			"status": "gap"
+		},
+		"POST /data-tables/{dataTableId}/rows": {
+			"status": "gap"
+		},
+		"PATCH /data-tables/{dataTableId}/rows/update": {
+			"status": "gap"
+		},
+		"POST /data-tables/{dataTableId}/rows/upsert": {
+			"status": "gap"
+		},
+		"DELETE /data-tables/{dataTableId}/rows/delete": {
+			"status": "gap"
+		},
+		"POST /projects": {
+			"status": "gap"
+		},
+		"GET /projects": {
+			"status": "gap"
+		},
+		"DELETE /projects/{projectId}": {
+			"status": "gap"
+		},
+		"PUT /projects/{projectId}": {
+			"status": "gap"
+		},
+		"GET /projects/{projectId}/users": {
+			"status": "gap"
+		},
+		"POST /projects/{projectId}/users": {
+			"status": "gap"
+		},
+		"DELETE /projects/{projectId}/users/{userId}": {
+			"status": "gap"
+		},
+		"PATCH /projects/{projectId}/users/{userId}": {
+			"status": "gap"
+		}
+	}
+}

--- a/packages/nodes-base/nodes/N8n/test/N8n.api-coverage.test.ts
+++ b/packages/nodes-base/nodes/N8n/test/N8n.api-coverage.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Contract test: n8n node vs n8n public API coverage.
+ *
+ * Reads the OpenAPI spec and compares it against the manifest in
+ * n8n-api-coverage.json. Fails if any new endpoint is not registered
+ * in the manifest, or if the manifest has stale entries.
+ *
+ * When this test fails because a new endpoint was added to the spec:
+ * 1. Open packages/nodes-base/nodes/N8n/n8n-api-coverage.json
+ * 2. Add an entry for each new endpoint with status "covered", "gap", or "excluded"
+ *    - "covered" = implemented in the n8n node
+ *    - "gap" = known gap, should eventually be implemented
+ *    - "excluded" = intentionally not supported (requires a "reason" field)
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const OPENAPI_SPEC_PATH = path.resolve(
+	__dirname,
+	'../../../../../packages/cli/src/public-api/v1/openapi.yml',
+);
+
+const MANIFEST_PATH = path.resolve(__dirname, '../n8n-api-coverage.json');
+
+const MANIFEST_RELATIVE = 'packages/nodes-base/nodes/N8n/n8n-api-coverage.json';
+
+const HTTP_METHODS = new Set(['get', 'post', 'put', 'patch', 'delete', 'head', 'options']);
+
+// Matches path entries in openapi.yml: "  /some/path:\n    $ref: './relative/file.yml'"
+const PATH_REF_PATTERN = /^ {2}(\/\S+):\s*\n\s+\$ref:\s*'([^']+)'/gm;
+
+// Matches top-level HTTP method keys in path YAML files (no indentation)
+const METHOD_PATTERN = /^(get|post|put|patch|delete|head|options):/gm;
+
+interface ManifestEntry {
+	status: 'covered' | 'gap' | 'excluded';
+	nodeOperation?: string;
+	reason?: string;
+}
+
+interface Manifest {
+	endpoints: Record<string, ManifestEntry>;
+}
+
+function extractEndpointsFromSpec(): string[] {
+	if (!fs.existsSync(OPENAPI_SPEC_PATH)) {
+		throw new Error(
+			`OpenAPI spec not found at: ${OPENAPI_SPEC_PATH}\nCheck the path resolution in ${__filename}`,
+		);
+	}
+
+	const specDir = path.dirname(OPENAPI_SPEC_PATH);
+	const specContent = fs.readFileSync(OPENAPI_SPEC_PATH, 'utf-8');
+	const endpoints: string[] = [];
+
+	let match;
+	while ((match = PATH_REF_PATTERN.exec(specContent)) !== null) {
+		const apiPath = match[1];
+		const refFile = match[2];
+		const refPath = path.resolve(specDir, refFile);
+		const refContent = fs.readFileSync(refPath, 'utf-8');
+
+		let methodMatch;
+		while ((methodMatch = METHOD_PATTERN.exec(refContent)) !== null) {
+			const method = methodMatch[1];
+			if (HTTP_METHODS.has(method)) {
+				endpoints.push(`${method.toUpperCase()} ${apiPath}`);
+			}
+		}
+	}
+
+	return endpoints.sort();
+}
+
+function loadManifest(): Manifest {
+	return JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf-8')) as Manifest;
+}
+
+describe('n8n node API coverage', () => {
+	let specEndpoints: string[];
+	let manifest: Manifest;
+
+	beforeAll(() => {
+		specEndpoints = extractEndpointsFromSpec();
+		manifest = loadManifest();
+	});
+
+	it('every spec endpoint is tracked in the manifest', () => {
+		const manifestKeys = new Set(Object.keys(manifest.endpoints));
+		const unregistered = specEndpoints.filter((ep) => !manifestKeys.has(ep));
+
+		const example = JSON.stringify({ status: 'gap' }, null, 2);
+
+		expect(
+			unregistered,
+			[
+				`API endpoint(s) in the spec are not in the manifest.`,
+				`Add each to: ${MANIFEST_RELATIVE}`,
+				``,
+				`Missing:`,
+				...unregistered.map((ep) => `  - ${ep}`),
+				``,
+				`Example entry:`,
+				`  "${unregistered[0] ?? 'METHOD /path'}": ${example}`,
+			].join('\n'),
+		).toEqual([]);
+	});
+
+	it('no stale manifest entries for removed endpoints', () => {
+		const specSet = new Set(specEndpoints);
+		const stale = Object.keys(manifest.endpoints).filter((key) => !specSet.has(key));
+
+		expect(
+			stale,
+			[
+				`Manifest entry(ies) reference endpoints no longer in the spec.`,
+				`Remove from: ${MANIFEST_RELATIVE}`,
+				``,
+				`Stale:`,
+				...stale.map((ep) => `  - ${ep}`),
+			].join('\n'),
+		).toEqual([]);
+	});
+
+	it('excluded entries have a reason', () => {
+		const missing = Object.entries(manifest.endpoints)
+			.filter(([, entry]) => entry.status === 'excluded' && !entry.reason)
+			.map(([key]) => key);
+
+		expect(
+			missing,
+			[
+				`"excluded" entry(ies) missing required "reason" field.`,
+				`Fix in: ${MANIFEST_RELATIVE}`,
+				``,
+				...missing.map((ep) => `  - ${ep}`),
+			].join('\n'),
+		).toEqual([]);
+	});
+});

--- a/packages/nodes-base/nodes/N8n/test/N8n.api-coverage.test.ts
+++ b/packages/nodes-base/nodes/N8n/test/N8n.api-coverage.test.ts
@@ -74,7 +74,11 @@ function extractEndpointsFromSpec(): string[] {
 }
 
 function loadManifest(): Manifest {
-	return JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf-8')) as Manifest;
+	try {
+		return JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf-8')) as Manifest;
+	} catch (error) {
+		throw new Error('Failed to parse ' + MANIFEST_RELATIVE + ': ' + String(error));
+	}
 }
 
 describe('n8n node API coverage', () => {
@@ -95,13 +99,13 @@ describe('n8n node API coverage', () => {
 		expect(
 			unregistered,
 			[
-				`API endpoint(s) in the spec are not in the manifest.`,
-				`Add each to: ${MANIFEST_RELATIVE}`,
-				``,
-				`Missing:`,
-				...unregistered.map((ep) => `  - ${ep}`),
-				``,
-				`Example entry:`,
+				'API endpoint(s) in the spec are not in the manifest.',
+				'Add each to: ' + MANIFEST_RELATIVE,
+				'',
+				'Missing:',
+				...unregistered.map((ep) => '  - ' + ep),
+				'',
+				'Example entry:',
 				`  "${unregistered[0] ?? 'METHOD /path'}": ${example}`,
 			].join('\n'),
 		).toEqual([]);
@@ -114,11 +118,11 @@ describe('n8n node API coverage', () => {
 		expect(
 			stale,
 			[
-				`Manifest entry(ies) reference endpoints no longer in the spec.`,
-				`Remove from: ${MANIFEST_RELATIVE}`,
-				``,
-				`Stale:`,
-				...stale.map((ep) => `  - ${ep}`),
+				'Manifest entry(ies) reference endpoints no longer in the spec.',
+				'Remove from: ' + MANIFEST_RELATIVE,
+				'',
+				'Stale:',
+				...stale.map((ep) => '  - ' + ep),
 			].join('\n'),
 		).toEqual([]);
 	});
@@ -131,10 +135,10 @@ describe('n8n node API coverage', () => {
 		expect(
 			missing,
 			[
-				`"excluded" entry(ies) missing required "reason" field.`,
-				`Fix in: ${MANIFEST_RELATIVE}`,
-				``,
-				...missing.map((ep) => `  - ${ep}`),
+				'"excluded" entry(ies) missing required "reason" field.',
+				'Fix in: ' + MANIFEST_RELATIVE,
+				'',
+				...missing.map((ep) => '  - ' + ep),
 			].join('\n'),
 		).toEqual([]);
 	});


### PR DESCRIPTION
## Summary
- Adds a manifest-based contract test that ensures the n8n node (`packages/nodes-base/nodes/N8n/`) stays in sync with the public API OpenAPI spec (`packages/cli/src/public-api/v1/`)
- When a new endpoint is added to the spec, CI fails until the endpoint is classified in `n8n-api-coverage.json` as `covered`, `gap`, or `excluded`
- Also catches stale manifest entries when endpoints are removed from the spec

## Context

Currently 15 of 59 API endpoints are covered by the node. The remaining 44 are baselined as `gap` so the test passes from day one while catching all future drift.

## Test plan
- [x] All 3 test cases pass: tracked endpoints, stale detection, excluded reason validation
- [x] Verified failure output when an endpoint is missing from the manifest
- [x] Verified failure output when a stale entry exists in the manifest
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)