### PR TITLE
test: Add external secrets provider connection tests

### DIFF
--- a/packages/testing/playwright/helpers/NavigationHelper.ts
+++ b/packages/testing/playwright/helpers/NavigationHelper.ts
@@ -1,5 +1,7 @@
 import type { Page } from '@playwright/test';
 
+import { SecretsProviderSettingsPage } from '../pages/SecretsProviderSettingsPage';
+
 /**
  * NavigationHelper provides centralized navigation methods for all n8n routes.
  * Handles both project-specific and global routes with proper URL construction.
@@ -13,7 +15,11 @@ import type { Page } from '@playwright/test';
  * - Executions: /home/executions or /projects/{projectId}/executions
  */
 export class NavigationHelper {
-	constructor(private page: Page) {}
+	private readonly secretsProviderSettings: SecretsProviderSettingsPage;
+
+	constructor(private page: Page) {
+		this.secretsProviderSettings = new SecretsProviderSettingsPage(page);
+	}
 
 	/**
 	 * Navigate to the home dashboard
@@ -231,5 +237,13 @@ export class NavigationHelper {
 	 */
 	async toChatHubWorkflowAgents() {
 		await this.page.goto('/home/chat/workflow-agents');
+	}
+
+	/**
+	 * Navigate to external secrets settings page
+	 * URL: /settings/external-secrets
+	 */
+	async toExternalSecrets(): Promise<void> {
+		await this.secretsProviderSettings.goto();
 	}
 }

--- a/packages/testing/playwright/pages/ProjectSettingsPage.ts
+++ b/packages/testing/playwright/pages/ProjectSettingsPage.ts
@@ -1,3 +1,4 @@
+import type { Locator } from '@playwright/test';
 import { expect } from '@playwright/test';
 
 import { BasePage } from './BasePage';
@@ -110,4 +111,20 @@ export class ProjectSettingsPage extends BasePage {
 	async selectFirstEmoji() {
 		await this.page.getByTestId('icon-picker-emoji').first().click();
 	}
+
+	getExternalSecretsSection(): Locator {
+		return this.page.getByTestId('external-secrets-section');
+	}
+
+	/**
+	 * The data table listing project-scoped secret provider connections.
+	 */
+	getExternalSecretsTable(): Locator {
+		return this.page.getByTestId('external-secrets-table');
+	}
+
+	getExternalSecretsTableRow(name: string): Locator {
+		return this.getExternalSecretsTable().getByText(name);
+	}
+
 }

--- a/packages/testing/playwright/pages/SecretsProviderSettingsPage.ts
+++ b/packages/testing/playwright/pages/SecretsProviderSettingsPage.ts
@@ -1,0 +1,79 @@
+import type { Locator } from '@playwright/test';
+
+import { BasePage } from './BasePage';
+
+/**
+ * Page object for /settings/external-secrets
+ * Wraps the SettingsSecretsProviders.ee.vue view.
+ */
+export class SecretsProviderSettingsPage extends BasePage {
+	async goto(): Promise<void> {
+		await this.page.goto('/settings/external-secrets');
+	}
+
+	/** The licensed content container (visible when enterprise feature is enabled) */
+	getLicensedContent(): Locator {
+		return this.page.getByTestId('secrets-provider-connections-content-licensed');
+	}
+
+	/** The empty state action box (visible when no providers are configured) */
+	getEmptyState(): Locator {
+		return this.page.getByTestId('secrets-provider-connections-empty-state');
+	}
+
+	async clickEmptyStateAddButton(): Promise<void> {
+		await this.getEmptyState().getByRole('button').click();
+	}
+
+	/** Returns the provider name label for the given connection name. */
+	getProviderNameCard(name: string): Locator {
+		return this.page.getByTestId('secrets-provider-name').filter({ hasText: name });
+	}
+
+	/** Loading skeleton shown while providers are being fetched */
+	getLoadingIndicator(): Locator {
+		return this.page.getByTestId('secrets-providers-loading');
+	}
+
+	/** Returns the global badge scoped to the card for the given provider name. */
+	getProviderCardGlobalBadge(name: string): Locator {
+		return this.getCardContainer(name).getByTestId('secrets-provider-global-badge');
+	}
+
+	/** Returns the project badge scoped to the card for the given provider name. */
+	getProviderCardProjectBadge(name: string): Locator {
+		return this.getCardContainer(name).getByTestId('secrets-provider-project-badge');
+	}
+
+	/** Returns the action toggle (3-dot menu) for a specific provider card. */
+	getProviderCardActionToggle(name: string): Locator {
+		return this.getCardContainer(name).getByTestId('secrets-provider-action-toggle');
+	}
+
+	/**
+	 * Selects an action from the dropdown menu of a specific provider card.
+	 * @param name - The provider connection name
+	 * @param action - The action label to click (e.g. 'Edit', 'Delete', 'Share')
+	 */
+	async selectCardAction(name: string, action: string): Promise<void> {
+		await this.getProviderCardActionToggle(name).click();
+		await this.page.getByRole('menuitem', { name: action }).click();
+	}
+
+	async waitForProvidersLoaded(): Promise<void> {
+		await this.getLicensedContent().waitFor({ state: 'visible' });
+		await this.getLoadingIndicator().waitFor({ state: 'hidden' });
+	}
+
+	/**
+	 * Returns the N8nCard element wrapping a provider card for a given name.
+	 * Used internally to scope sub-element lookups to the right card.
+	 */
+	private getCardContainer(name: string): Locator {
+		return this.page
+			.getByTestId('secrets-provider-name')
+			.filter({ hasText: name })
+			.locator('xpath=ancestor::*[contains(@class,"card") or @role="article"]')
+			.first();
+	}
+}

--- a/packages/testing/playwright/pages/components/CredentialModal.ts
+++ b/packages/testing/playwright/pages/components/CredentialModal.ts
@@ -47,6 +47,34 @@ export class CredentialModal extends BaseModal {
 		await expect(input).toHaveValue(value);
 	}
 
+	/**
+	 * Switch a credential field to expression mode and fill it with an expression.
+	 *
+	 * Expression mode is activated by clicking the "Expression" radio button that
+	 * appears when hovering over a parameter input.
+	 *
+	 * @example
+	 * await modal.fillExpressionField('value', "{{ $secrets['myVault']['apikey'] }}");
+	 */
+	async fillExpressionField(key: string, expression: string): Promise<void> {
+		const parameterInput = this.root
+			.getByTestId('credential-connection-parameter')
+			.getByTestId(key);
+
+		// Hover to reveal the Fixed / Expression toggle
+		await parameterInput.locator('label').first().hover();
+		await parameterInput.getByTestId('parameter-options-container').waitFor({ state: 'visible' });
+
+		// Click the "Expression" radio option
+		await parameterInput.getByTestId('radio-button-expression').click();
+
+		// After switching modes, the field becomes a CodeMirror editor
+		const cmContent = parameterInput.locator('.cm-content');
+		await cmContent.waitFor({ state: 'visible', timeout: 10_000 });
+		await cmContent.click();
+		await cmContent.fill(expression);
+	}
+
 	async fillAllFields(values: Record<string, string>): Promise<void> {
 		for (const [key, val] of Object.entries(values)) {
 			await this.fillField(key, val);
@@ -55,6 +83,10 @@ export class CredentialModal extends BaseModal {
 
 	getSaveButton(): Locator {
 		return this.root.getByTestId('credential-save-button');
+	}
+
+	getParameterInputHint(): Locator {
+		return this.container.getByTestId('parameter-input-hint');
 	}
 
 	/**

--- a/packages/testing/playwright/pages/components/DeleteSecretsProviderModal.ts
+++ b/packages/testing/playwright/pages/components/DeleteSecretsProviderModal.ts
@@ -1,0 +1,52 @@
+import type { Locator } from '@playwright/test';
+
+import { BaseModal } from './BaseModal';
+
+/**
+ * Page object for the delete secrets provider confirmation modal.
+ * Modal key: DELETE_SECRETS_PROVIDER_MODAL_KEY ("deleteSecretsProvider")
+ * Component: DeleteSecretsProviderModal.ee.vue
+ *
+ * When credentials reference the provider, a confirmation input is required
+ * where the user must type the exact provider name before deletion is enabled.
+ */
+export class DeleteSecretsProviderModal extends BaseModal {
+	get container(): Locator {
+		return this.page.getByTestId('deleteSecretsProvider-modal');
+	}
+
+	async waitForModal(): Promise<void> {
+		await this.container.waitFor({ state: 'visible' });
+	}
+
+	/**
+	 * Only shown when credentials reference this provider.
+	 * The user must type the exact provider name to enable deletion.
+	 */
+	getConfirmationInput(): Locator {
+		return this.container.getByTestId('delete-confirmation-input');
+	}
+
+	/** Required when credentials reference this provider. */
+	async fillConfirmation(providerName: string): Promise<void> {
+		const input = this.getConfirmationInput();
+		await input.waitFor({ state: 'visible' });
+		await input.fill(providerName);
+	}
+
+	getConfirmDeleteButton(): Locator {
+		return this.container.getByTestId('confirm-delete-button');
+	}
+
+	/** Clicks the confirm delete button and waits for the DELETE API response. */
+	async confirmDelete(): Promise<void> {
+		await Promise.all([
+			this.page.waitForResponse(
+				(res) =>
+					res.url().includes('/rest/secret-providers/connections') &&
+					res.request().method() === 'DELETE',
+			),
+			this.getConfirmDeleteButton().click(),
+		]);
+	}
+}

--- a/packages/testing/playwright/pages/components/DeleteSecretsProviderModal.ts
+++ b/packages/testing/playwright/pages/components/DeleteSecretsProviderModal.ts
@@ -40,13 +40,12 @@ export class DeleteSecretsProviderModal extends BaseModal {
 
 	/** Clicks the confirm delete button and waits for the DELETE API response. */
 	async confirmDelete(): Promise<void> {
-		await Promise.all([
-			this.page.waitForResponse(
-				(res) =>
-					res.url().includes('/rest/secret-providers/connections') &&
-					res.request().method() === 'DELETE',
-			),
-			this.getConfirmDeleteButton().click(),
-		]);
+		const responsePromise = this.page.waitForResponse(
+			(res) =>
+				res.url().includes('/rest/secret-providers/connections') &&
+				res.request().method() === 'DELETE',
+		);
+		await this.getConfirmDeleteButton().click();
+		await responsePromise;
 	}
 }

--- a/packages/testing/playwright/pages/components/SecretsProviderConnectionModal.ts
+++ b/packages/testing/playwright/pages/components/SecretsProviderConnectionModal.ts
@@ -56,14 +56,13 @@ export class SecretsProviderConnectionModal extends BaseModal {
 
 	/** Clicks save and waits for the connection API call. After saving, the modal auto-tests the connection. */
 	async save(): Promise<void> {
-		await Promise.all([
-			this.page.waitForResponse(
-				(res) =>
-					res.url().includes('/rest/secret-providers/connections') &&
-					['POST', 'PATCH'].includes(res.request().method()),
-			),
-			this.getSaveButton().click(),
-		]);
+		const responsePromise = this.page.waitForResponse(
+			(res) =>
+				res.url().includes('/rest/secret-providers/connections') &&
+				['POST', 'PATCH'].includes(res.request().method()),
+		);
+		await this.getSaveButton().click();
+		await responsePromise;
 	}
 
 	/** Green callout — visible when the connection test succeeds. */
@@ -87,8 +86,12 @@ export class SecretsProviderConnectionModal extends BaseModal {
 	 * @param optionLabel - The project name or 'Global' to select
 	 */
 	async selectScope(optionLabel: string): Promise<void> {
+		await this.getScopeSelect().waitFor({ state: 'visible' });
 		await this.getScopeSelect().click();
-		await this.page.getByRole('option', { name: optionLabel }).click();
+		const option = this.page.getByRole('option', { name: optionLabel });
+		await option.waitFor({ state: 'visible' });
+		await option.click();
+		await option.waitFor({ state: 'hidden' });
 	}
 
 	async close(): Promise<void> {

--- a/packages/testing/playwright/pages/components/SecretsProviderConnectionModal.ts
+++ b/packages/testing/playwright/pages/components/SecretsProviderConnectionModal.ts
@@ -70,6 +70,10 @@ export class SecretsProviderConnectionModal extends BaseModal {
 		return this.container.getByTestId('connection-success-callout');
 	}
 
+	getErrorBanner(): Locator {
+		return this.container.getByTestId('connection-error-banner');
+	}
+
 	/**
 	 * Switches to the Scope/Sharing tab.
 	 * Only available in edit mode (requires forProjects feature flag + canShareGlobally permission).

--- a/packages/testing/playwright/pages/components/SecretsProviderConnectionModal.ts
+++ b/packages/testing/playwright/pages/components/SecretsProviderConnectionModal.ts
@@ -1,0 +1,104 @@
+import type { Locator } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+import { BaseModal } from './BaseModal';
+
+/**
+ * Page object for the secret provider connection creation/edit modal.
+ * Modal key: SECRETS_PROVIDER_CONNECTION_MODAL_KEY ("secretsProviderConnection")
+ * Component: SecretsProviderConnectionModal.ee.vue
+ *
+ * Used for both create mode (no providerKey) and edit mode (with providerKey).
+ */
+export class SecretsProviderConnectionModal extends BaseModal {
+	get container(): Locator {
+		return this.page.getByRole('dialog');
+	}
+
+	/** Readonly/disabled in edit mode. */
+	getConnectionNameInput(): Locator {
+		return this.container.getByTestId('provider-name');
+	}
+
+	async fillConnectionName(name: string): Promise<void> {
+		const input = this.getConnectionNameInput();
+		await input.waitFor({ state: 'visible' });
+		await input.fill(name);
+		await input.blur();
+	}
+
+	/** Disabled in edit mode. */
+	getProviderTypeSelect(): Locator {
+		return this.container.getByTestId('provider-type-select');
+	}
+
+	async selectProviderType(typeLabel: string): Promise<void> {
+		await this.getProviderTypeSelect().click();
+		await this.page.getByRole('option', { name: typeLabel }).click();
+	}
+
+	/**
+	 * Fills a dynamic provider property field by its parameter name (e.g. 'region', 'accessKeyId').
+	 * Fields are rendered via ParameterInputExpanded as `parameter-input-{name}` test ids.
+	 */
+	async fillProviderField(fieldName: string, value: string): Promise<void> {
+		const field = this.container.getByTestId(`parameter-input-${fieldName}`);
+		const input = field.locator('input, textarea').first();
+		await input.waitFor({ state: 'visible', timeout: 10_000 });
+		await input.fill(value);
+		await expect(input).toHaveValue(value);
+	}
+
+	/** The save/create button in the modal header. */
+	getSaveButton(): Locator {
+		return this.container.getByTestId('secrets-provider-connection-save-button');
+	}
+
+	/** Clicks save and waits for the connection API call. After saving, the modal auto-tests the connection. */
+	async save(): Promise<void> {
+		await Promise.all([
+			this.page.waitForResponse(
+				(res) =>
+					res.url().includes('/rest/secret-providers/connections') &&
+					['POST', 'PATCH'].includes(res.request().method()),
+			),
+			this.getSaveButton().click(),
+		]);
+	}
+
+	/** Green callout — visible when the connection test succeeds. */
+	getSuccessCallout(): Locator {
+		return this.container.getByTestId('connection-success-callout');
+	}
+
+	/**
+	 * Switches to the Scope/Sharing tab.
+	 * Only available in edit mode (requires forProjects feature flag + canShareGlobally permission).
+	 */
+	async switchToScopeTab(): Promise<void> {
+		await this.container.getByTestId('sidebar-item-sharing').click();
+	}
+
+	getScopeSelect(): Locator {
+		return this.container.getByTestId('secrets-provider-scope-select');
+	}
+
+	/**
+	 * @param optionLabel - The project name or 'Global' to select
+	 */
+	async selectScope(optionLabel: string): Promise<void> {
+		await this.getScopeSelect().click();
+		await this.page.getByRole('option', { name: optionLabel }).click();
+	}
+
+	async close(): Promise<void> {
+		const closeBtn = this.container.locator('.el-dialog__close').first();
+		if (await closeBtn.isVisible()) {
+			await closeBtn.click();
+		}
+	}
+
+	async waitForModal(): Promise<void> {
+		await this.container.waitFor({ state: 'visible' });
+	}
+}

--- a/packages/testing/playwright/pages/n8nPage.ts
+++ b/packages/testing/playwright/pages/n8nPage.ts
@@ -6,8 +6,10 @@ import { CanvasPage } from './CanvasPage';
 import { CommunityNodesPage } from './CommunityNodesPage';
 import { BaseModal } from './components/BaseModal';
 import { Breadcrumbs } from './components/Breadcrumbs';
+import { DeleteSecretsProviderModal } from './components/DeleteSecretsProviderModal';
 import { ProjectTabsComponent } from './components/ProjectTabsComponent';
 import { ResourceMoveModal } from './components/ResourceMoveModal';
+import { SecretsProviderConnectionModal } from './components/SecretsProviderConnectionModal';
 import { CredentialsPage } from './CredentialsPage';
 import { DataTableDetails } from './DataTableDetails';
 import { DataTableView } from './DataTableView';
@@ -21,6 +23,7 @@ import { NodeDetailsViewPage } from './NodeDetailsViewPage';
 import { NotificationsPage } from './NotificationsPage';
 import { NpsSurveyPage } from './NpsSurveyPage';
 import { ProjectSettingsPage } from './ProjectSettingsPage';
+import { SecretsProviderSettingsPage } from './SecretsProviderSettingsPage';
 import { SettingsEnvironmentPage } from './SettingsEnvironmentPage';
 import { SettingsLogStreamingPage } from './SettingsLogStreamingPage';
 import { SettingsPersonalPage } from './SettingsPersonalPage';
@@ -96,6 +99,8 @@ export class n8nPage {
 	readonly projectTabs: ProjectTabsComponent;
 
 	readonly settingsEnvironment: SettingsEnvironmentPage;
+	readonly secretsProviderSettings: SecretsProviderSettingsPage;
+
 	// Modals
 	readonly workflowActivationModal: WorkflowActivationModal;
 	readonly workflowCredentialSetupModal: WorkflowCredentialSetupModal;
@@ -106,6 +111,8 @@ export class n8nPage {
 	readonly mfaSetupModal: MfaSetupModal;
 	readonly modal: BaseModal;
 	readonly resourceMoveModal: ResourceMoveModal;
+	readonly secretsProviderConnectionModal: SecretsProviderConnectionModal;
+	readonly deleteSecretsProviderModal: DeleteSecretsProviderModal;
 
 	// Composables
 	readonly workflowComposer: WorkflowComposer;
@@ -159,6 +166,7 @@ export class n8nPage {
 		this.dataTable = new DataTableView(page);
 		this.dataTableDetails = new DataTableDetails(page);
 		this.settingsEnvironment = new SettingsEnvironmentPage(page);
+		this.secretsProviderSettings = new SecretsProviderSettingsPage(page);
 
 		this.settingsUsers = new SettingsUsersPage(page);
 		this.settingsSso = new SettingsSsoPage(page);
@@ -175,6 +183,8 @@ export class n8nPage {
 		this.mfaSetupModal = new MfaSetupModal(page);
 		this.modal = new BaseModal(page);
 		this.resourceMoveModal = new ResourceMoveModal(page);
+		this.secretsProviderConnectionModal = new SecretsProviderConnectionModal(page);
+		this.deleteSecretsProviderModal = new DeleteSecretsProviderModal(page);
 
 		// Composables
 		this.workflowComposer = new WorkflowComposer(this);

--- a/packages/testing/playwright/tests/e2e/settings/external-secrets/secret-providers-connections-ui.spec.ts
+++ b/packages/testing/playwright/tests/e2e/settings/external-secrets/secret-providers-connections-ui.spec.ts
@@ -1,0 +1,184 @@
+import { expect, test } from '../../../../fixtures/base';
+
+test.use({ capability: 'external-secrets' });
+
+// LocalStack can take time to start up, and connection tests add latency
+test.setTimeout(180_000);
+
+// LocalStack test credentials (AWS_ENDPOINT_URL in the n8n container redirects all SDK calls to LocalStack)
+const LOCALSTACK_AWS_SETTINGS = {
+	region: 'us-east-1',
+	authMethod: 'iamUser',
+	accessKeyId: 'test',
+	secretAccessKey: 'test',
+} as const;
+
+test.describe(
+	'Secret Providers Connections UI @capability:external-secrets @licensed',
+	{
+		annotation: [{ type: 'owner', description: 'Lifecycle & Governance' }],
+	},
+	() => {
+		test.beforeEach(async ({ n8n, services }) => {
+			await n8n.api.enableFeature('externalSecrets');
+			await services.localstack.secretsManager.clear();
+		});
+
+		/**
+		 * Creates a global connection via the UI settings page, verifies the success
+		 * callout and global badge, creates a credential referencing a secret from
+		 * the provider, then deletes the connection through the UI delete flow.
+		 */
+		test('should create a global connection via UI and reference it in a credential', async ({
+			n8n,
+			services,
+		}) => {
+			const providerName = 'awsGlobal';
+
+			await services.localstack.secretsManager.createSecret('apikey', 'supersecret');
+
+			await n8n.navigate.toExternalSecrets();
+			await n8n.secretsProviderSettings.waitForProvidersLoaded();
+			await expect(n8n.secretsProviderSettings.getEmptyState()).toBeVisible();
+
+			await n8n.secretsProviderSettings.clickEmptyStateAddButton();
+			await n8n.secretsProviderConnectionModal.waitForModal();
+
+			await n8n.secretsProviderConnectionModal.fillConnectionName(providerName);
+			await n8n.secretsProviderConnectionModal.selectProviderType('AWS Secrets Manager');
+			await n8n.secretsProviderConnectionModal.fillProviderField(
+				'region',
+				LOCALSTACK_AWS_SETTINGS.region,
+			);
+			await n8n.secretsProviderConnectionModal.fillProviderField(
+				'accessKeyId',
+				LOCALSTACK_AWS_SETTINGS.accessKeyId,
+			);
+			await n8n.secretsProviderConnectionModal.fillProviderField(
+				'secretAccessKey',
+				LOCALSTACK_AWS_SETTINGS.secretAccessKey,
+			);
+
+			await n8n.secretsProviderConnectionModal.save();
+			await expect(n8n.secretsProviderConnectionModal.getSuccessCallout()).toBeVisible();
+			await n8n.secretsProviderConnectionModal.close();
+
+			await expect(n8n.secretsProviderSettings.getProviderNameCard(providerName)).toBeVisible();
+			await expect(
+				n8n.secretsProviderSettings.getProviderCardGlobalBadge(providerName),
+			).toBeVisible();
+
+			const credentialName = 'Secret Ref Header Auth';
+			await n8n.navigate.toCredentials();
+			await n8n.credentials.emptyListCreateCredentialButton.click();
+			await n8n.credentials.selectCredentialType('Header Auth');
+			await n8n.credentials.credentialModal.waitForModal();
+			await n8n.credentials.credentialModal.renameCredential(credentialName);
+			// plain text, not expression mode
+			await n8n.credentials.credentialModal.fillField('name', 'Authorization');
+			// expression mode, referencing the external secret
+			await n8n.credentials.credentialModal.fillExpressionField(
+				'value',
+				`{{ $secrets['${providerName}']['apikey'] }}`,
+			);
+			await expect(n8n.credentials.credentialModal.getParameterInputHint()).toContainText(
+				'*********',
+			);
+			await n8n.credentials.credentialModal.getSaveButton().click();
+			await n8n.credentials.credentialModal.close();
+
+			await expect(n8n.credentials.cards.getCredential(credentialName)).toBeVisible();
+
+			await n8n.navigate.toExternalSecrets();
+			await n8n.secretsProviderSettings.waitForProvidersLoaded();
+			await n8n.secretsProviderSettings.selectCardAction(providerName, 'Delete');
+			await n8n.deleteSecretsProviderModal.waitForModal();
+
+			// The credential references this provider, so the user must type the exact provider
+			// name into the confirmation input to enable the delete button.
+			await n8n.deleteSecretsProviderModal.fillConfirmation(providerName);
+			await n8n.deleteSecretsProviderModal.confirmDelete();
+
+			await expect(n8n.secretsProviderSettings.getEmptyState()).toBeVisible();
+			await expect(n8n.secretsProviderSettings.getProviderNameCard(providerName)).toBeHidden();
+		});
+
+		/**
+		 * Creates a global connection via the UI settings page, scopes it to a project
+		 * via the Sharing tab, then verifies the connection appears in the project settings
+		 * and can be referenced from a project credential.
+		 */
+		test('should create a connection, scope it to a project, and use it in a project credential', async ({
+			n8n,
+			services,
+		}) => {
+			const providerName = 'awsGlobalRecovery';
+
+			await services.localstack.secretsManager.createSecret('projectsecret', 'projectvalue');
+
+			const project = await n8n.api.projects.createProject('SecretProject');
+			const projectId = project.id;
+
+			await n8n.navigate.toExternalSecrets();
+			await n8n.secretsProviderSettings.waitForProvidersLoaded();
+			await expect(n8n.secretsProviderSettings.getEmptyState()).toBeVisible();
+
+			await n8n.secretsProviderSettings.clickEmptyStateAddButton();
+			await n8n.secretsProviderConnectionModal.waitForModal();
+
+			await n8n.secretsProviderConnectionModal.fillConnectionName(providerName);
+			await n8n.secretsProviderConnectionModal.selectProviderType('AWS Secrets Manager');
+			await n8n.secretsProviderConnectionModal.fillProviderField(
+				'region',
+				LOCALSTACK_AWS_SETTINGS.region,
+			);
+			await n8n.secretsProviderConnectionModal.fillProviderField(
+				'accessKeyId',
+				LOCALSTACK_AWS_SETTINGS.accessKeyId,
+			);
+			await n8n.secretsProviderConnectionModal.fillProviderField(
+				'secretAccessKey',
+				LOCALSTACK_AWS_SETTINGS.secretAccessKey,
+			);
+
+			await n8n.secretsProviderConnectionModal.save();
+			await expect(n8n.secretsProviderConnectionModal.getSuccessCallout()).toBeVisible();
+
+			await n8n.secretsProviderConnectionModal.switchToScopeTab();
+			await n8n.secretsProviderConnectionModal.selectScope('SecretProject');
+			await n8n.secretsProviderConnectionModal.save();
+			await n8n.secretsProviderConnectionModal.close();
+
+			await expect(n8n.secretsProviderSettings.getProviderNameCard(providerName)).toBeVisible();
+			await expect(
+				n8n.secretsProviderSettings.getProviderCardProjectBadge(providerName),
+			).toBeVisible();
+
+			await n8n.navigate.toProjectSettings(projectId);
+			await expect(n8n.projectSettings.getExternalSecretsSection()).toBeVisible();
+			await expect(n8n.projectSettings.getExternalSecretsTable()).toBeVisible();
+			await expect(n8n.projectSettings.getExternalSecretsTableRow(providerName)).toBeVisible();
+
+			const credentialName = 'Project Secret Ref Header Auth';
+			await n8n.navigate.toCredentials(projectId);
+			await n8n.credentials.emptyListCreateCredentialButton.click();
+			await n8n.credentials.selectCredentialType('Header Auth');
+			await n8n.credentials.credentialModal.waitForModal();
+			await n8n.credentials.credentialModal.renameCredential(credentialName);
+			// plain text, not expression mode
+			await n8n.credentials.credentialModal.fillField('name', 'Authorization');
+			// expression mode, referencing the project-scoped secret
+			await n8n.credentials.credentialModal.fillExpressionField(
+				'value',
+				`{{ $secrets['${providerName}']['projectsecret'] }}`,
+			);
+			await expect(n8n.credentials.credentialModal.getParameterInputHint()).toContainText(
+				'*********',
+			);
+			await n8n.credentials.credentialModal.getSaveButton().click();
+			await n8n.credentials.credentialModal.close();
+
+			await expect(n8n.credentials.cards.getCredential(credentialName)).toBeVisible();
+		});
+	},
+);

--- a/packages/testing/playwright/tests/e2e/settings/external-secrets/secret-providers-connections-ui.spec.ts
+++ b/packages/testing/playwright/tests/e2e/settings/external-secrets/secret-providers-connections-ui.spec.ts
@@ -13,6 +13,8 @@ const LOCALSTACK_AWS_SETTINGS = {
 	secretAccessKey: 'test',
 } as const;
 
+const INVALID_AWS_SETTINGS_REGION = 'us-east/1';
+
 test.describe(
 	'Secret Providers Connections UI @capability:external-secrets @licensed',
 	{
@@ -104,11 +106,11 @@ test.describe(
 		});
 
 		/**
-		 * Creates a global connection via the UI settings page, scopes it to a project
-		 * via the Sharing tab, then verifies the connection appears in the project settings
-		 * and can be referenced from a project credential.
+		 * Creates a global connection via the UI settings page,
+		 * creates a connection with invalid region then saves it and verifies that the error banner is shown.
+		 * Scopes it to a project and verifies that the connection appears in the project settings and can be referenced from a project credential.
 		 */
-		test('should create a connection, scope it to a project, and use it in a project credential', async ({
+		test('should create a connection, recover a wrong setting, scope it to a project, and use it in a project credential', async ({
 			n8n,
 			services,
 		}) => {
@@ -130,7 +132,7 @@ test.describe(
 			await n8n.secretsProviderConnectionModal.selectProviderType('AWS Secrets Manager');
 			await n8n.secretsProviderConnectionModal.fillProviderField(
 				'region',
-				LOCALSTACK_AWS_SETTINGS.region,
+				INVALID_AWS_SETTINGS_REGION,
 			);
 			await n8n.secretsProviderConnectionModal.fillProviderField(
 				'accessKeyId',
@@ -139,6 +141,15 @@ test.describe(
 			await n8n.secretsProviderConnectionModal.fillProviderField(
 				'secretAccessKey',
 				LOCALSTACK_AWS_SETTINGS.secretAccessKey,
+			);
+
+			await n8n.secretsProviderConnectionModal.save();
+			await expect(n8n.secretsProviderConnectionModal.getErrorBanner()).toBeVisible();
+			await expect(n8n.secretsProviderConnectionModal.getSuccessCallout()).toBeHidden();
+
+			await n8n.secretsProviderConnectionModal.fillProviderField(
+				'region',
+				LOCALSTACK_AWS_SETTINGS.region,
 			);
 
 			await n8n.secretsProviderConnectionModal.save();

--- a/packages/testing/playwright/tests/e2e/settings/external-secrets/secret-providers-connections-ui.spec.ts
+++ b/packages/testing/playwright/tests/e2e/settings/external-secrets/secret-providers-connections-ui.spec.ts
@@ -84,7 +84,7 @@ test.describe(
 			await expect(n8n.credentials.credentialModal.getParameterInputHint()).toContainText(
 				'*********',
 			);
-			await n8n.credentials.credentialModal.getSaveButton().click();
+			await n8n.credentials.credentialModal.save();
 			await n8n.credentials.credentialModal.close();
 
 			await expect(n8n.credentials.cards.getCredential(credentialName)).toBeVisible();
@@ -175,7 +175,7 @@ test.describe(
 			await expect(n8n.credentials.credentialModal.getParameterInputHint()).toContainText(
 				'*********',
 			);
-			await n8n.credentials.credentialModal.getSaveButton().click();
+			await n8n.credentials.credentialModal.save();
 			await n8n.credentials.credentialModal.close();
 
 			await expect(n8n.credentials.cards.getCredential(credentialName)).toBeVisible();


### PR DESCRIPTION
## Summary

Covers two flows: creating a global connection and referencing it in a credential with the delete/confirmation flow, and creating a global connection scoped to a project via the sharing tab then using it in a project credential.

Run (with docker built):
```
pnpm --filter=n8n-playwright test:container:sqlite --grep "Secret Providers Connections"
```

## Recording:
https://www.loom.com/share/1b354c8a92c840efb3a9d562702cc4f6

## Related Linear tickets, Github issues, and Community forum posts

Closes [LIGO-204](https://linear.app/n8n/issue/LIGO-204/add-e2e-tests-for-external-secret-providers)

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
