### PR TITLE
chore(editor): Fix node click keeping adding to context

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/WorkflowSettings.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowSettings.test.ts
@@ -1,4 +1,5 @@
 import { nextTick, reactive } from 'vue';
+import { flushPromises } from '@vue/test-utils';
 import { createTestingPinia } from '@pinia/testing';
 import type { MockInstance } from 'vitest';
 import { waitFor, within } from '@testing-library/vue';
@@ -740,12 +741,11 @@ describe('WorkflowSettingsVue', () => {
 			// so we verify the save behavior when the value is already empty.
 			workflowDocumentStore.setSettings({ credentialResolverId: '' });
 
-			const { getByTestId, getByRole } = createComponent({ pinia });
-			await nextTick();
-
-			await waitFor(() => {
-				expect(getByTestId('workflow-settings-credential-resolver-create-new')).toBeInTheDocument();
-			});
+			const { getByRole } = createComponent({ pinia });
+			// flushPromises drains the full microtask queue, ensuring onMounted's
+			// Promise.all (loadCredentialResolvers, loadWorkflows, etc.) fully resolves
+			// and workflowSettings.value is initialized before we click Save.
+			await flushPromises();
 
 			await userEvent.click(getByRole('button', { name: 'Save' }));
 


### PR DESCRIPTION
## Summary

### Fix: Flaky test in WorkflowSettings (no-changelog)

The test `should save with empty credentialResolverId when resolver is cleared` was intermittently failing with `TypeError: Cannot read properties of undefined (reading '0')` because it asserted on `updateWorkflow.mock.calls[0]` before the save was guaranteed to have been called.

**Root cause:** The test used `waitFor(() => getByTestId(...).toBeInTheDocument())` to wait for component readiness, but the element renders immediately on first paint — before `onMounted`'s `await Promise.all([...])` finishes initialising `workflowSettings.value`. When `saveSettings` ran with uninitialised state, `executionTimeout` was `undefined`, which evaluated to `0` via the HMS conversion, triggering an early `return` that never reached `updateWorkflow`.

**Fix:** Replaced the racy `waitFor` with `await flushPromises()` from `@vue/test-utils`, which drains the full microtask queue and guarantees `onMounted` has fully completed before clicking Save.

## Related Linear tickets, Github issues, and Community forum posts

<!-- https://linear.app/n8n/issue/ -->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)