### PR TITLE
feat(core): Explicit fail on production executions with failing dynamic

### DIFF
--- a/packages/cli/src/__tests__/credentials-helper.test.ts
+++ b/packages/cli/src/__tests__/credentials-helper.test.ts
@@ -738,7 +738,7 @@ describe('CredentialsHelper', () => {
 			expect(result).not.toEqual({ apiKey: 'static-key' });
 		});
 
-		test('should skip resolution when executionContext is missing', async () => {
+		test('should skip resolution when executionContext is missing (manual mode)', async () => {
 			dynamicCredentialProxy.setResolverProvider(mockCredentialResolutionProvider);
 			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue({
 				data: { apiKey: 'resolved' },
@@ -785,7 +785,7 @@ describe('CredentialsHelper', () => {
 			expect(result).toEqual(dynamicData);
 		});
 
-		test('should skip resolution when credentials context is missing', async () => {
+		test('should skip resolution when credentials context is missing (manual mode)', async () => {
 			dynamicCredentialProxy.setResolverProvider(mockCredentialResolutionProvider);
 			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue({
 				data: { apiKey: 'resolved' },
@@ -811,7 +811,7 @@ describe('CredentialsHelper', () => {
 				true,
 			);
 
-			// Resolution should not happen when credentials context is missing
+			// Resolution should not happen when credentials context is missing in manual mode
 			expect(mockCredentialResolutionProvider.resolveIfNeeded).not.toHaveBeenCalled();
 			// Should return static decrypted data
 			expect(result).toEqual({ apiKey: 'static-key' });
@@ -842,6 +842,85 @@ describe('CredentialsHelper', () => {
 
 			expect(mockCredentialResolutionProvider.resolveIfNeeded).not.toHaveBeenCalled();
 			expect(result).toEqual({ apiKey: 'static-key' });
+		});
+
+		test('should throw when dynamic credential cannot be resolved in non-manual mode (no execution context)', async () => {
+			dynamicCredentialProxy.setResolverProvider(mockCredentialResolutionProvider);
+
+			const { CredentialResolutionError } = await import(
+				'@/modules/dynamic-credentials.ee/errors/credential-resolution.error'
+			);
+
+			const resolvableCredentialEntity = {
+				...mockCredentialEntity,
+				isResolvable: true,
+				resolverId: 'resolver-123',
+			} as CredentialsEntity;
+
+			credentialsRepository.findOneByOrFail.mockResolvedValue(resolvableCredentialEntity);
+			mockCredentialResolutionProvider.resolveIfNeeded.mockRejectedValue(
+				new CredentialResolutionError(
+					'Cannot resolve dynamic credentials without execution context for "Test Credentials"',
+				),
+			);
+
+			await expect(
+				credentialsHelper.getDecrypted(
+					{ ...mockAdditionalData, executionContext: undefined },
+					nodeCredentials,
+					credentialType,
+					'webhook',
+					undefined,
+					true,
+				),
+			).rejects.toThrow(CredentialResolutionError);
+
+			expect(mockCredentialResolutionProvider.resolveIfNeeded).toHaveBeenCalledTimes(1);
+		});
+
+		test('should throw when dynamic credential cannot be resolved in non-manual mode (no credentials in context)', async () => {
+			dynamicCredentialProxy.setResolverProvider(mockCredentialResolutionProvider);
+
+			const { CredentialResolutionError } = await import(
+				'@/modules/dynamic-credentials.ee/errors/credential-resolution.error'
+			);
+
+			const resolvableCredentialEntity = {
+				...mockCredentialEntity,
+				isResolvable: true,
+				resolverId: 'resolver-123',
+			} as CredentialsEntity;
+
+			credentialsRepository.findOneByOrFail.mockResolvedValue(resolvableCredentialEntity);
+			mockCredentialResolutionProvider.resolveIfNeeded.mockRejectedValue(
+				new CredentialResolutionError(
+					'Cannot resolve dynamic credentials without execution context for "Test Credentials"',
+				),
+			);
+
+			const additionalDataWithEmptyContext = {
+				...mockAdditionalData,
+				executionContext: {
+					version: 1 as const,
+					establishedAt: Date.now(),
+					source: 'webhook' as const,
+					// credentials is undefined
+				},
+			};
+
+			await expect(
+				credentialsHelper.getDecrypted(
+					additionalDataWithEmptyContext,
+					nodeCredentials,
+					credentialType,
+					'webhook',
+					undefined,
+					true,
+				),
+			).rejects.toThrow(CredentialResolutionError);
+
+			// Verify static credentials were NOT used as a fallback
+			expect(mockCredentialResolutionProvider.resolveIfNeeded).toHaveBeenCalledTimes(1);
 		});
 
 		test('should handle missing workflowSettings gracefully', async () => {

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/identifier-interface.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/identifier-interface.ts
@@ -1,9 +1,17 @@
 import type { ICredentialContext } from 'n8n-workflow';
 
+import { CredentialResolutionError } from '../../errors/credential-resolution.error';
+
 /**
- * Error thrown when token identifier validation or resolution fails
+ * Error thrown when token identifier validation or resolution fails.
+ * Extends CredentialResolutionError so it propagates correctly through the resolution pipeline.
  */
-export class IdentifierValidationError extends Error {}
+export class IdentifierValidationError extends CredentialResolutionError {
+	constructor(message: string, options?: ErrorOptions) {
+		super(message, options);
+		this.name = 'IdentifierValidationError';
+	}
+}
 
 /**
  * Interface for resolving unique identifiers from credential contexts

--- a/packages/cli/src/modules/dynamic-credentials.ee/errors/credential-resolver-not-configured.error.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/errors/credential-resolver-not-configured.error.ts
@@ -1,0 +1,12 @@
+import { CredentialResolutionError } from './credential-resolution.error';
+
+/**
+ * Thrown when a credential is marked as resolvable but has no resolver configured
+ * (neither on the credential itself nor on the workflow settings).
+ */
+export class CredentialResolverNotConfiguredError extends CredentialResolutionError {
+	constructor(credentialName: string) {
+		super(`No resolver configured for dynamic credential "${credentialName}"`);
+		this.name = 'CredentialResolverNotConfiguredError';
+	}
+}

--- a/packages/cli/src/modules/dynamic-credentials.ee/errors/credential-resolver-not-found.error.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/errors/credential-resolver-not-found.error.ts
@@ -1,7 +1,21 @@
 import { UserError } from 'n8n-workflow';
 
+import { CredentialResolutionError } from './credential-resolution.error';
+
+/** Thrown by the resolver CRUD API when a resolver with the given ID does not exist. */
 export class DynamicCredentialResolverNotFoundError extends UserError {
 	constructor(resolverId: string) {
 		super(`Credential resolver with ID "${resolverId}" does not exist.`);
+	}
+}
+
+/**
+ * Thrown during execution when the resolver referenced by a credential or workflow setting
+ * cannot be found (entity deleted from DB or resolver type no longer registered).
+ */
+export class CredentialResolverNotFoundError extends CredentialResolutionError {
+	constructor(credentialName: string, resolverId: string) {
+		super(`Resolver "${resolverId}" not found for credential "${credentialName}"`);
+		this.name = 'CredentialResolverNotFoundError';
 	}
 }

--- a/packages/cli/src/modules/dynamic-credentials.ee/errors/missing-execution-context.error.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/errors/missing-execution-context.error.ts
@@ -1,0 +1,12 @@
+import { CredentialResolutionError } from './credential-resolution.error';
+
+/**
+ * Thrown when dynamic credential resolution is attempted but no execution context
+ * (or no credentials field within it) is available.
+ */
+export class MissingExecutionContextError extends CredentialResolutionError {
+	constructor(credentialName: string) {
+		super(`Cannot resolve dynamic credentials without execution context for "${credentialName}"`);
+		this.name = 'MissingExecutionContextError';
+	}
+}

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential.service.test.ts
@@ -344,7 +344,9 @@ describe('DynamicCredentialService', () => {
 						additionalData.executionContext,
 						undefined,
 					),
-				).rejects.toThrow('Failed to resolve dynamic credentials for "Test Credential"');
+				).rejects.toThrow(
+					'Failed to resolve dynamic credentials for "Test Credential": Resolution failed',
+				);
 
 				expect(mockLogger.debug).toHaveBeenCalledWith(
 					'Dynamic credential resolution failed',

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential.service.test.ts
@@ -1,4 +1,5 @@
 import type { Logger } from '@n8n/backend-common';
+import type { AuthenticatedRequest } from '@n8n/db';
 import { CredentialResolverDataNotFoundError, type ICredentialResolver } from '@n8n/decorators';
 import type { Response } from 'express';
 import type { Cipher } from 'n8n-core';
@@ -19,10 +20,13 @@ import type { DynamicCredentialResolver } from '../../database/entities/credenti
 import type { DynamicCredentialResolverRepository } from '../../database/repositories/credential-resolver.repository';
 import type { DynamicCredentialsConfig } from '../../dynamic-credentials.config';
 import { CredentialResolutionError } from '../../errors/credential-resolution.error';
+import { CredentialResolverNotConfiguredError } from '../../errors/credential-resolver-not-configured.error';
+import { CredentialResolverNotFoundError } from '../../errors/credential-resolver-not-found.error';
+import { MissingExecutionContextError } from '../../errors/missing-execution-context.error';
+import { IdentifierValidationError } from '../../credential-resolvers/identifiers/identifier-interface';
 import type { DynamicCredentialResolverRegistry } from '../credential-resolver-registry.service';
 import { DynamicCredentialService } from '../dynamic-credential.service';
 import type { ResolverConfigExpressionService } from '../resolver-config-expression.service';
-import type { AuthenticatedRequest } from '@n8n/db';
 
 describe('DynamicCredentialService', () => {
 	let service: DynamicCredentialService;
@@ -243,7 +247,7 @@ describe('DynamicCredentialService', () => {
 
 				await expect(
 					service.resolveIfNeeded(credentialsEntity, staticData, undefined),
-				).rejects.toThrow(CredentialResolutionError);
+				).rejects.toThrow(CredentialResolverNotFoundError);
 
 				await expect(
 					service.resolveIfNeeded(credentialsEntity, staticData, undefined),
@@ -267,7 +271,7 @@ describe('DynamicCredentialService', () => {
 						additionalData.executionContext,
 						undefined,
 					),
-				).rejects.toThrow(CredentialResolutionError);
+				).rejects.toThrow(CredentialResolverNotConfiguredError);
 			});
 
 			it('credential has no resolver ID', async () => {
@@ -278,7 +282,7 @@ describe('DynamicCredentialService', () => {
 
 				await expect(
 					service.resolveIfNeeded(credentialsEntity, staticData, undefined),
-				).rejects.toThrow(CredentialResolutionError);
+				).rejects.toThrow(CredentialResolverNotConfiguredError);
 			});
 
 			it('resolver instance is not found in registry', async () => {
@@ -290,7 +294,7 @@ describe('DynamicCredentialService', () => {
 
 				await expect(
 					service.resolveIfNeeded(credentialsEntity, staticData, undefined),
-				).rejects.toThrow(CredentialResolutionError);
+				).rejects.toThrow(CredentialResolverNotFoundError);
 			});
 
 			it('execution context is missing', async () => {
@@ -303,7 +307,7 @@ describe('DynamicCredentialService', () => {
 
 				await expect(
 					service.resolveIfNeeded(credentialsEntity, staticData, undefined),
-				).rejects.toThrow(CredentialResolutionError);
+				).rejects.toThrow(MissingExecutionContextError);
 
 				await expect(
 					service.resolveIfNeeded(credentialsEntity, staticData, undefined),
@@ -344,14 +348,14 @@ describe('DynamicCredentialService', () => {
 						additionalData.executionContext,
 						undefined,
 					),
-				).rejects.toThrow(
-					'Failed to resolve dynamic credentials for "Test Credential": Resolution failed',
-				);
+					// Internal error message must NOT be exposed to the user
+				).rejects.toThrow('Failed to resolve dynamic credentials for "Test Credential"');
 
 				expect(mockLogger.debug).toHaveBeenCalledWith(
 					'Dynamic credential resolution failed',
 					expect.objectContaining({
 						credentialId: 'cred-123',
+						error: 'Resolution failed',
 					}),
 				);
 			});
@@ -387,7 +391,7 @@ describe('DynamicCredentialService', () => {
 			it('resolver throws CredentialResolverDataNotFoundError', async () => {
 				const credentialsEntity = createMockCredentialsMetadata();
 				const resolverEntity = createMockResolverEntity();
-				const mockResolver = createMockResolver(false, true); // Throws DataNotFoundError
+				const mockResolver = createMockResolver(false, true); // Throws CredentialResolverDataNotFoundError
 				const executionContext = createMockExecutionContext('encrypted-credentials');
 				const credentialContext = createMockCredentialContext();
 				const additionalData = createMockAdditionalData('exec-123', {}, executionContext);
@@ -405,7 +409,42 @@ describe('DynamicCredentialService', () => {
 						additionalData.executionContext,
 						undefined,
 					),
-				).rejects.toThrow(CredentialResolutionError);
+				).rejects.toThrow(
+					'Failed to resolve dynamic credentials for "Test Credential": No data found available for the requested credential and context combination.',
+				);
+			});
+
+			it('resolver throws IdentifierValidationError', async () => {
+				const credentialsEntity = createMockCredentialsMetadata();
+				const resolverEntity = createMockResolverEntity();
+				const executionContext = createMockExecutionContext('encrypted-credentials');
+				const credentialContext = createMockCredentialContext();
+				const additionalData = createMockAdditionalData('exec-123', {}, executionContext);
+				const mockResolver: jest.Mocked<ICredentialResolver> = {
+					metadata: { name: 'test-resolver-1.0', description: 'Test resolver' },
+					getSecret: jest
+						.fn()
+						.mockRejectedValue(new IdentifierValidationError('Token is not active')),
+					setSecret: jest.fn(),
+					validateOptions: jest.fn(),
+				};
+
+				mockResolverRepository.findOneBy.mockResolvedValue(resolverEntity);
+				mockResolverRegistry.getResolverByTypename.mockReturnValue(mockResolver);
+				mockCipher.decrypt
+					.mockReturnValueOnce(JSON.stringify(credentialContext))
+					.mockReturnValueOnce(JSON.stringify({ prefix: 'test' }));
+
+				await expect(
+					service.resolveIfNeeded(
+						credentialsEntity,
+						staticData,
+						additionalData.executionContext,
+						undefined,
+					),
+				).rejects.toThrow(
+					'Failed to resolve dynamic credentials for "Test Credential": Token is not active',
+				);
 			});
 		});
 

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential.service.ts
@@ -181,8 +181,9 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 			error: error instanceof Error ? error.message : String(error),
 		});
 
+		const causeMessage = error instanceof Error ? `: ${error.message}` : '';
 		throw new CredentialResolutionError(
-			`Failed to resolve dynamic credentials for "${credentialsResolveMetadata.name}"`,
+			`Failed to resolve dynamic credentials for "${credentialsResolveMetadata.name}"${causeMessage}`,
 			{ cause: error },
 		);
 	}

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential.service.ts
@@ -1,4 +1,6 @@
 import { Logger } from '@n8n/backend-common';
+import { AuthenticatedRequest } from '@n8n/db';
+import { CredentialResolverError } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import { NextFunction, Response } from 'express';
 import { Cipher } from 'n8n-core';
@@ -23,7 +25,9 @@ import type {
 import { DynamicCredentialResolverRepository } from '../database/repositories/credential-resolver.repository';
 import { DynamicCredentialsConfig } from '../dynamic-credentials.config';
 import { CredentialResolutionError } from '../errors/credential-resolution.error';
-import { AuthenticatedRequest } from '@n8n/db';
+import { CredentialResolverNotConfiguredError } from '../errors/credential-resolver-not-configured.error';
+import { CredentialResolverNotFoundError } from '../errors/credential-resolver-not-found.error';
+import { MissingExecutionContextError } from '../errors/missing-execution-context.error';
 
 /**
  * Service for resolving credentials dynamically via configured resolvers.
@@ -69,7 +73,7 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 		}
 
 		if (!resolverId) {
-			return this.handleMissingResolver(credentialsResolveMetadata, resolverId);
+			return this.handleResolverNotConfigured(credentialsResolveMetadata);
 		}
 
 		// Load resolver configuration
@@ -78,14 +82,14 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 		});
 
 		if (!resolverEntity) {
-			return this.handleMissingResolver(credentialsResolveMetadata, resolverId);
+			return this.handleResolverNotFound(credentialsResolveMetadata, resolverId);
 		}
 
 		// Get resolver instance from registry
 		const resolver = this.resolverRegistry.getResolverByTypename(resolverEntity.type);
 
 		if (!resolver) {
-			return this.handleMissingResolver(credentialsResolveMetadata, resolverId);
+			return this.handleResolverNotFound(credentialsResolveMetadata, resolverId);
 		}
 
 		// Build credential context from execution context
@@ -165,8 +169,11 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 	}
 
 	/**
-	 * Handles resolution errors by always throwing.
-	 * Dynamic credentials must resolve successfully — no silent fallback to static data.
+	 * Throws when resolution fails inside getSecret().
+	 * - CredentialResolutionError subtypes (e.g. IdentifierValidationError)
+	 *   → rethrown with credential name prepended to the message
+	 * - CredentialResolverDataNotFoundError → rethrown with credential name prepended to the message
+	 * - Anything else → generic CredentialResolutionError (no internal detail surfaced)
 	 */
 	private handleResolutionError(
 		credentialsResolveMetadata: CredentialResolveMetadata,
@@ -181,20 +188,44 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 			error: error instanceof Error ? error.message : String(error),
 		});
 
-		const causeMessage = error instanceof Error ? `: ${error.message}` : '';
+		// Known errors from both the CLI and resolver SDK layers.
+		// User-facing, safe to propagate details.
+		if (error instanceof CredentialResolutionError || error instanceof CredentialResolverError) {
+			throw new CredentialResolutionError(
+				`Failed to resolve dynamic credentials for "${credentialsResolveMetadata.name}": ${error.message}`,
+				{ cause: error },
+			);
+		}
+
+		// Internal errors (network, crypto, DB, config validation) must not leak details to the user.
 		throw new CredentialResolutionError(
-			`Failed to resolve dynamic credentials for "${credentialsResolveMetadata.name}"${causeMessage}`,
+			`Failed to resolve dynamic credentials for "${credentialsResolveMetadata.name}"`,
 			{ cause: error },
 		);
 	}
 
 	/**
-	 * Handles missing resolver by always throwing.
-	 * Dynamic credentials must have a valid resolver — no silent fallback to static data.
+	 * Throws when the credential is resolvable but no resolver ID is configured
+	 * on the credential or the workflow settings.
 	 */
-	private handleMissingResolver(
+	private handleResolverNotConfigured(
 		credentialsResolveMetadata: CredentialResolveMetadata,
-		resolverId?: string,
+	): never {
+		this.logger.debug('No resolver configured for dynamic credential', {
+			credentialId: credentialsResolveMetadata.id,
+			credentialName: credentialsResolveMetadata.name,
+		});
+
+		throw new CredentialResolverNotConfiguredError(credentialsResolveMetadata.name);
+	}
+
+	/**
+	 * Throws when a resolver ID is set but the entity no longer exists in the DB
+	 * or the resolver type is not registered.
+	 */
+	private handleResolverNotFound(
+		credentialsResolveMetadata: CredentialResolveMetadata,
+		resolverId: string,
 	): never {
 		this.logger.debug('Resolver not found for dynamic credential', {
 			credentialId: credentialsResolveMetadata.id,
@@ -203,14 +234,11 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 			resolverSource: credentialsResolveMetadata.resolverId ? 'credential' : 'workflow',
 		});
 
-		throw new CredentialResolutionError(
-			`Resolver "${resolverId ?? 'unknown'}" not found for credential "${credentialsResolveMetadata.name}"`,
-		);
+		throw new CredentialResolverNotFoundError(credentialsResolveMetadata.name, resolverId);
 	}
 
 	/**
-	 * Handles missing execution context by always throwing.
-	 * Dynamic credentials require an execution context — no silent fallback to static data.
+	 * Throws when no execution context (or credentials field within it) is available.
 	 */
 	private handleMissingContext(credentialsResolveMetadata: CredentialResolveMetadata): never {
 		this.logger.debug('No execution context available for dynamic credential', {
@@ -218,9 +246,7 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 			credentialName: credentialsResolveMetadata.name,
 		});
 
-		throw new CredentialResolutionError(
-			`Cannot resolve dynamic credentials without execution context for "${credentialsResolveMetadata.name}"`,
-		);
+		throw new MissingExecutionContextError(credentialsResolveMetadata.name);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

- dynamic-credential.service.ts: Appended the inner error's message to CredentialResolutionError, so the UI now shows the actual cause (e.g. Failed to resolve dynamic credentials for "X": Token has expired) instead of a generic message.
- dynamic-credential.service.test.ts: Updated the matching test to assert the full message including the cause.


Screenshot when a dynamic credentials resolution occur:
<img width="2572" height="1330" alt="image" src="https://github.com/user-attachments/assets/92878be4-915d-45ce-b464-c9e70486a0d1" />

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/IAM-353/explicit-fail-on-production-executions-with-failing-dynamic-credential

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
