### PR TITLE
feat(editor): Normalize `isArchived` field in workflow document state (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.vue
@@ -75,6 +75,7 @@ const workflow = computed(() => workflowsStore.workflow);
 const workflowId = injectStrict(WorkflowIdKey);
 const workflowDocumentStore = inject(WorkflowDocumentStoreKey, null);
 const workflowTags = computed(() => workflowDocumentStore?.value?.tags ?? []);
+const workflowIsArchived = computed(() => workflowDocumentStore?.value?.isArchived ?? false);
 const onWorkflowPage = computed(() => !!(route.meta.nodeView || route.meta.keepWorkflowAlive));
 
 const isEnterprise = computed(
@@ -289,7 +290,7 @@ async function onWorkflowDeactivated() {
 					:tags="workflowTags"
 					:name="workflow.name"
 					:current-folder="parentFolderForBreadcrumbs"
-					:is-archived="workflow.isArchived"
+					:is-archived="workflowIsArchived"
 					:description="workflow.description"
 					@workflow:deactivated="onWorkflowDeactivated"
 				/>

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
@@ -970,7 +970,6 @@ export function useWorkflowHelpers() {
 	async function initState(workflowData: IWorkflowDb, overrideWorkflowState?: WorkflowState) {
 		const ws = overrideWorkflowState ?? workflowState;
 		workflowsListStore.addWorkflow(workflowData);
-		workflowsStore.setIsArchived(workflowData.isArchived);
 		workflowsStore.setDescription(workflowData.description);
 		ws.setWorkflowId(workflowData.id);
 		ws.setWorkflowName({
@@ -1041,6 +1040,7 @@ export function useWorkflowHelpers() {
 		if (workflowData.checksum) {
 			workflowDocumentStore.setChecksum(workflowData.checksum);
 		}
+		workflowDocumentStore.setIsArchived(workflowData.isArchived);
 		workflowDocumentStore.setMeta(workflowData.meta);
 		workflowDocumentStore.setScopes(workflowData.scopes ?? []);
 		tagsStore.upsertTags(tags);

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
@@ -86,7 +86,7 @@ export function useWorkflowSaving({
 		if (
 			!uiStore.stateIsDirty ||
 			workflowDocumentStore?.isArchived ||
-			!getResourcePermissions(workflowsStore.workflow.scopes).workflow.update
+			!getResourcePermissions(workflowDocumentStore?.scopes ?? []).workflow.update
 		) {
 			next();
 			return;

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
@@ -79,13 +79,14 @@ export function useWorkflowSaving({
 			cancel?: () => Promise<void>;
 		} = {},
 	) {
-		const workflowDocumentStore = useWorkflowDocumentStore(
-			createWorkflowDocumentId(workflowsStore.workflowId),
-		);
+		const workflowDocumentStore = workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined;
+
 		if (
 			!uiStore.stateIsDirty ||
-			workflowsStore.workflow.isArchived ||
-			!getResourcePermissions(workflowDocumentStore.scopes).workflow.update
+			workflowDocumentStore?.isArchived ||
+			!getResourcePermissions(workflowsStore.workflow.scopes).workflow.update
 		) {
 			next();
 			return;

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
@@ -10,6 +10,7 @@ import { useWorkflowDocumentPinData } from './workflowDocument/useWorkflowDocume
 import { useWorkflowDocumentScopes } from './workflowDocument/useWorkflowDocumentScopes';
 import { useWorkflowDocumentSettings } from './workflowDocument/useWorkflowDocumentSettings';
 import { useWorkflowDocumentTags } from './workflowDocument/useWorkflowDocumentTags';
+import { useWorkflowDocumentIsArchived } from './workflowDocument/useWorkflowDocumentIsArchived';
 import { useWorkflowDocumentTimestamps } from './workflowDocument/useWorkflowDocumentTimestamps';
 
 export {
@@ -57,6 +58,7 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 		const workflowDocumentChecksum = useWorkflowDocumentChecksum();
 		const workflowDocumentMeta = useWorkflowDocumentMeta();
 		const workflowDocumentTags = useWorkflowDocumentTags();
+		const workflowDocumentIsArchived = useWorkflowDocumentIsArchived();
 		const workflowDocumentPinData = useWorkflowDocumentPinData();
 		const workflowDocumentScopes = useWorkflowDocumentScopes();
 		const workflowDocumentTimestamps = useWorkflowDocumentTimestamps();
@@ -68,6 +70,7 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 			...workflowDocumentActive,
 			...workflowDocumentHomeProject,
 			...workflowDocumentChecksum,
+			...workflowDocumentIsArchived,
 			...workflowDocumentMeta,
 			...workflowDocumentSettings,
 			...workflowDocumentTags,

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentIsArchived.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentIsArchived.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { useWorkflowDocumentIsArchived } from './useWorkflowDocumentIsArchived';
+
+function createIsArchived() {
+	return useWorkflowDocumentIsArchived();
+}
+
+describe('useWorkflowDocumentIsArchived', () => {
+	describe('initial state', () => {
+		it('should start with false', () => {
+			const { isArchived } = createIsArchived();
+			expect(isArchived.value).toBe(false);
+		});
+	});
+
+	describe('setIsArchived', () => {
+		it('should set isArchived and fire event hook', () => {
+			const { isArchived, setIsArchived, onIsArchivedChange } = createIsArchived();
+			const hookSpy = vi.fn();
+			onIsArchivedChange(hookSpy);
+
+			setIsArchived(true);
+
+			expect(isArchived.value).toBe(true);
+			expect(hookSpy).toHaveBeenCalledWith({
+				action: 'update',
+				payload: { isArchived: true },
+			});
+		});
+
+		it('should replace existing value', () => {
+			const { isArchived, setIsArchived } = createIsArchived();
+			setIsArchived(true);
+
+			setIsArchived(false);
+
+			expect(isArchived.value).toBe(false);
+		});
+
+		it('should fire event hook on every call', () => {
+			const { setIsArchived, onIsArchivedChange } = createIsArchived();
+			const hookSpy = vi.fn();
+			onIsArchivedChange(hookSpy);
+
+			setIsArchived(true);
+			setIsArchived(false);
+
+			expect(hookSpy).toHaveBeenCalledTimes(2);
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentIsArchived.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentIsArchived.ts
@@ -1,0 +1,31 @@
+import { ref, readonly } from 'vue';
+import { createEventHook } from '@vueuse/core';
+import { CHANGE_ACTION } from './types';
+import type { ChangeAction, ChangeEvent } from './types';
+
+export type IsArchivedPayload = {
+	isArchived: boolean;
+};
+
+export type IsArchivedChangeEvent = ChangeEvent<IsArchivedPayload>;
+
+export function useWorkflowDocumentIsArchived() {
+	const isArchived = ref<boolean>(false);
+
+	const onIsArchivedChange = createEventHook<IsArchivedChangeEvent>();
+
+	function applyIsArchived(value: boolean, action: ChangeAction = CHANGE_ACTION.UPDATE) {
+		isArchived.value = value;
+		void onIsArchivedChange.trigger({ action, payload: { isArchived: value } });
+	}
+
+	function setIsArchived(value: boolean) {
+		applyIsArchived(value);
+	}
+
+	return {
+		isArchived: readonly(isArchived),
+		setIsArchived,
+		onIsArchivedChange: onIsArchivedChange.on,
+	};
+}

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.test.ts
@@ -2227,6 +2227,7 @@ describe('useWorkflowsStore', () => {
 			workflowsListStore.addWorkflow(testWorkflow);
 
 			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
+			workflowDocumentStore.setScopes(testWorkflow.scopes ?? []);
 
 			// Verify the mock is set up correctly
 			expect(workflowsStore.workflow.scopes).toContain('workflow:update');

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.test.ts
@@ -1341,9 +1341,11 @@ describe('useWorkflowsStore', () => {
 				'1': { active: true, isArchived: false, versionId } as IWorkflowDb,
 			};
 			workflowsStore.workflow.active = true;
-			workflowsStore.workflow.isArchived = false;
 			workflowsStore.workflow.id = workflowId;
 			workflowsStore.workflow.versionId = versionId;
+
+			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
+			workflowDocumentStore.setIsArchived(false);
 
 			const makeRestApiRequestSpy = vi
 				.spyOn(apiUtils, 'makeRestApiRequest')
@@ -1357,7 +1359,7 @@ describe('useWorkflowsStore', () => {
 			expect(workflowsListStore.workflowsById['1'].active).toBe(false);
 			expect(workflowsListStore.workflowsById['1'].isArchived).toBe(true);
 			expect(workflowsListStore.workflowsById['1'].versionId).toBe(updatedVersionId);
-			expect(workflowsStore.workflow.isArchived).toBe(true);
+			expect(workflowDocumentStore.isArchived).toBe(true);
 			expect(workflowsStore.workflow.versionId).toBe(updatedVersionId);
 			expect(makeRestApiRequestSpy).toHaveBeenCalledWith(
 				expect.objectContaining({
@@ -1380,9 +1382,11 @@ describe('useWorkflowsStore', () => {
 			workflowsListStore.workflowsById = {
 				'1': { active: true, isArchived: false, versionId } as IWorkflowDb,
 			};
-			workflowsStore.workflow.isArchived = false;
 			workflowsStore.workflow.id = workflowId;
 			workflowsStore.workflow.versionId = versionId;
+
+			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
+			workflowDocumentStore.setIsArchived(false);
 
 			const makeRestApiRequestSpy = vi
 				.spyOn(apiUtils, 'makeRestApiRequest')
@@ -1416,9 +1420,11 @@ describe('useWorkflowsStore', () => {
 				'1': { active: false, isArchived: true, versionId } as IWorkflowDb,
 			};
 			workflowsStore.workflow.active = false;
-			workflowsStore.workflow.isArchived = true;
 			workflowsStore.workflow.id = workflowId;
 			workflowsStore.workflow.versionId = versionId;
+
+			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
+			workflowDocumentStore.setIsArchived(true);
 
 			const makeRestApiRequestSpy = vi
 				.spyOn(apiUtils, 'makeRestApiRequest')
@@ -1432,7 +1438,7 @@ describe('useWorkflowsStore', () => {
 			expect(workflowsListStore.workflowsById['1'].active).toBe(false);
 			expect(workflowsListStore.workflowsById['1'].isArchived).toBe(false);
 			expect(workflowsListStore.workflowsById['1'].versionId).toBe(updatedVersionId);
-			expect(workflowsStore.workflow.isArchived).toBe(false);
+			expect(workflowDocumentStore.isArchived).toBe(false);
 			expect(workflowsStore.workflow.versionId).toBe(updatedVersionId);
 			expect(makeRestApiRequestSpy).toHaveBeenCalledWith(
 				expect.objectContaining({
@@ -2210,8 +2216,9 @@ describe('useWorkflowsStore', () => {
 				status: 'success',
 			});
 
+			const workflowId = 'workflow-123';
 			const testWorkflow = createTestWorkflow({
-				id: 'workflow-123',
+				id: workflowId,
 				scopes: ['workflow:update'],
 			});
 
@@ -2219,14 +2226,12 @@ describe('useWorkflowsStore', () => {
 			// Add workflow to workflowsById to simulate it being loaded from backend
 			workflowsListStore.addWorkflow(testWorkflow);
 
-			const workflowDocumentStore = useWorkflowDocumentStore(
-				createWorkflowDocumentId(testWorkflow.id),
-			);
-			workflowDocumentStore.setScopes(testWorkflow.scopes ?? []);
+			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
 
-			expect(workflowDocumentStore.scopes).toContain('workflow:update');
+			// Verify the mock is set up correctly
+			expect(workflowsStore.workflow.scopes).toContain('workflow:update');
 			expect(workflowsStore.workflow.id).toBe('workflow-123');
-			expect(workflowsStore.workflow.isArchived).toBe(false);
+			expect(workflowDocumentStore.isArchived).toBe(false);
 
 			vi.mocked(workflowsApi).getLastSuccessfulExecution.mockResolvedValue(mockExecution);
 
@@ -2326,11 +2331,15 @@ describe('useWorkflowsStore', () => {
 		});
 
 		it('should not fetch when workflow is archived', async () => {
+			const workflowId = 'workflow-123';
 			workflowsStore.workflow = createTestWorkflow({
-				id: 'workflow-123',
+				id: workflowId,
 				scopes: ['workflow:update'],
-				isArchived: true,
 			});
+			workflowsListStore.addWorkflow(workflowsStore.workflow);
+
+			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
+			workflowDocumentStore.setIsArchived(true);
 
 			await workflowsStore.fetchLastSuccessfulExecution();
 

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -605,12 +605,17 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		const workflowPermissions = getResourcePermissions(workflowDocumentStore?.scopes).workflow;
 
 		try {
+			const wfId = workflow.value.id;
+			const workflowDocumentStore = wfId
+				? useWorkflowDocumentStore(createWorkflowDocumentId(wfId))
+				: undefined;
+
 			if (
 				isNewWorkflow.value ||
 				sourceControlStore.preferences.branchReadOnly ||
 				uiStore.isReadOnlyView ||
 				!workflowPermissions.update ||
-				workflow.value.isArchived
+				workflowDocumentStore?.isArchived
 			) {
 				return;
 			}
@@ -742,13 +747,13 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		setWorkflowInactive(id);
 
 		if (id === workflow.value.id) {
-			setIsArchived(true);
 			setWorkflowVersionData({
 				versionId: updatedWorkflow.versionId,
 				name: versionData.value?.name ?? null,
 				description: versionData.value?.description ?? null,
 			});
 			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(id));
+			workflowDocumentStore.setIsArchived(true);
 			workflowDocumentStore.setChecksum(updatedWorkflow.checksum!);
 		}
 	}
@@ -757,7 +762,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		const updatedWorkflow = await workflowsListStore.unarchiveWorkflowInList(id);
 
 		if (id === workflow.value.id) {
-			setIsArchived(false);
 			setWorkflowVersionData({
 				versionId: updatedWorkflow.versionId,
 				name: versionData.value?.name ?? null,
@@ -765,6 +769,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			});
 
 			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(id));
+			workflowDocumentStore.setIsArchived(false);
 			workflowDocumentStore.setChecksum(updatedWorkflow.checksum!);
 		}
 	}
@@ -783,10 +788,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 
 	function setWorkflowInactive(targetWorkflowId: string) {
 		workflowsListStore.setWorkflowInactiveInCache(targetWorkflowId);
-	}
-
-	function setIsArchived(isArchived: boolean) {
-		workflow.value.isArchived = isArchived;
 	}
 
 	function setDescription(description: string | undefined | null) {
@@ -1759,7 +1760,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		unarchiveWorkflow,
 		setWorkflowActive,
 		setWorkflowInactive,
-		setIsArchived,
 		setDescription,
 		getDuplicateCurrentWorkflowName,
 		setWorkflowExecutionRunData,

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
@@ -253,7 +253,7 @@ const { isSubNodeType } = useNodeType({
 	node,
 });
 
-const isArchivedWorkflow = computed(() => workflowsStore.workflow.isArchived);
+const isArchivedWorkflow = computed(() => workflowDocumentStore?.value?.isArchived ?? false);
 const isReadOnlyRoute = computed(() => route.meta.readOnlyCanvas === true);
 const isWaitNodeWaiting = computed(() => {
 	return (

--- a/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useNodeCommands.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useNodeCommands.test.ts
@@ -10,6 +10,10 @@ import type { INodeTypeDescription } from 'n8n-workflow';
 import { getResourcePermissions } from '@n8n/permissions';
 import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
 import { canvasEventBus } from '@/features/workflows/canvas/canvas.eventBus';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 
 const mockEditableWorkflow = {
 	value: {
@@ -81,7 +85,7 @@ describe('useNodeCommands', () => {
 	});
 
 	beforeEach(() => {
-		setActivePinia(createTestingPinia());
+		setActivePinia(createTestingPinia({ stubActions: false }));
 
 		mockGetResourcePermissions = vi.mocked(getResourcePermissions);
 		const canvasOps = useCanvasOperations();
@@ -173,9 +177,8 @@ describe('useNodeCommands', () => {
 		});
 
 		it('should not include add node command when workflow is archived', () => {
-			Object.defineProperty(mockWorkflowsStore, 'workflow', {
-				value: { isArchived: true, scopes: [] },
-			});
+			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId('123'));
+			workflowDocumentStore.setIsArchived(true);
 
 			const { commands } = useNodeCommands({
 				lastQuery: ref(''),

--- a/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useNodeCommands.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useNodeCommands.ts
@@ -48,12 +48,7 @@ export function useNodeCommands(options: {
 	const isReadOnly = computed(
 		() => sourceControlStore.preferences.branchReadOnly || collaborationStore.shouldBeReadOnly,
 	);
-	const isArchived = computed(() => {
-		const wfId = workflowsStore.workflowId;
-		if (!wfId) return false;
-		const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(wfId));
-		return workflowDocumentStore.isArchived;
-	});
+	const isArchived = computed(() => workflowDocumentStore.value.isArchived);
 
 	const workflowPermissions = computed(
 		() => getResourcePermissions(workflowDocumentStore.value.scopes).workflow,

--- a/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useNodeCommands.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useNodeCommands.ts
@@ -48,7 +48,12 @@ export function useNodeCommands(options: {
 	const isReadOnly = computed(
 		() => sourceControlStore.preferences.branchReadOnly || collaborationStore.shouldBeReadOnly,
 	);
-	const isArchived = computed(() => workflowsStore.workflow.isArchived);
+	const isArchived = computed(() => {
+		const wfId = workflowsStore.workflowId;
+		if (!wfId) return false;
+		const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(wfId));
+		return workflowDocumentStore.isArchived;
+	});
 
 	const workflowPermissions = computed(
 		() => getResourcePermissions(workflowDocumentStore.value.scopes).workflow,

--- a/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useWorkflowCommands.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useWorkflowCommands.test.ts
@@ -289,7 +289,7 @@ describe('useWorkflowCommands', () => {
 		});
 
 		it('should not show publish/unpublish commands when workflow is archived', () => {
-			mockWorkflowsStore.workflow.isArchived = true;
+			mockWorkflowDocumentStore.setIsArchived(true);
 
 			const { commands } = useWorkflowCommands();
 			const publishCommand = commands.value.find((cmd) => cmd.id === 'publish-workflow');
@@ -394,7 +394,7 @@ describe('useWorkflowCommands', () => {
 
 	describe('lifecycle commands', () => {
 		it('should show archive command when workflow is not archived', () => {
-			mockWorkflowsStore.workflow.isArchived = false;
+			mockWorkflowDocumentStore.setIsArchived(false);
 
 			const { commands } = useWorkflowCommands();
 			const archiveCommand = commands.value.find((cmd) => cmd.id === 'archive-workflow');
@@ -405,7 +405,7 @@ describe('useWorkflowCommands', () => {
 		});
 
 		it('should show unarchive and delete commands when workflow is archived', () => {
-			mockWorkflowsStore.workflow.isArchived = true;
+			mockWorkflowDocumentStore.setIsArchived(true);
 
 			const { commands } = useWorkflowCommands();
 			const archiveCommand = commands.value.find((cmd) => cmd.id === 'archive-workflow');
@@ -438,7 +438,7 @@ describe('useWorkflowCommands', () => {
 		});
 
 		it('should handle unarchive workflow', async () => {
-			mockWorkflowsStore.workflow.isArchived = true;
+			mockWorkflowDocumentStore.setIsArchived(true);
 
 			const { commands } = useWorkflowCommands();
 			const unarchiveCommand = commands.value.find((cmd) => cmd.id === 'unarchive-workflow');
@@ -449,7 +449,7 @@ describe('useWorkflowCommands', () => {
 		});
 
 		it('should handle delete workflow', async () => {
-			mockWorkflowsStore.workflow.isArchived = true;
+			mockWorkflowDocumentStore.setIsArchived(true);
 
 			const { commands } = useWorkflowCommands();
 			const deleteCommand = commands.value.find((cmd) => cmd.id === 'delete-workflow');

--- a/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useWorkflowCommands.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useWorkflowCommands.ts
@@ -77,12 +77,7 @@ export function useWorkflowCommands(): CommandGroup {
 	const isReadOnly = computed(
 		() => sourceControlStore.preferences.branchReadOnly || collaborationStore.shouldBeReadOnly,
 	);
-	const isArchived = computed(() => {
-		const wfId = workflowsStore.workflowId;
-		if (!wfId) return false;
-		const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(wfId));
-		return workflowDocumentStore.isArchived;
-	});
+	const isArchived = computed(() => workflowDocumentStore.value.isArchived);
 
 	const workflowPermissions = computed(
 		() => getResourcePermissions(workflowDocumentStore.value.scopes).workflow,

--- a/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useWorkflowCommands.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useWorkflowCommands.ts
@@ -77,7 +77,12 @@ export function useWorkflowCommands(): CommandGroup {
 	const isReadOnly = computed(
 		() => sourceControlStore.preferences.branchReadOnly || collaborationStore.shouldBeReadOnly,
 	);
-	const isArchived = computed(() => workflowsStore.workflow.isArchived);
+	const isArchived = computed(() => {
+		const wfId = workflowsStore.workflowId;
+		if (!wfId) return false;
+		const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(wfId));
+		return workflowDocumentStore.isArchived;
+	});
 
 	const workflowPermissions = computed(
 		() => getResourcePermissions(workflowDocumentStore.value.scopes).workflow,

--- a/packages/frontend/editor-ui/src/features/shared/contextMenu/composables/useContextMenuItems.ts
+++ b/packages/frontend/editor-ui/src/features/shared/contextMenu/composables/useContextMenuItems.ts
@@ -68,7 +68,7 @@ export function useContextMenuItems(targetNodeIds: ComputedRef<string[]>): Compu
 			sourceControlStore.preferences.branchReadOnly ||
 			uiStore.isReadOnlyView ||
 			!workflowPermissions.value.update ||
-			(documentStore?.value?.isArchived ?? false) ||
+			(workflowDocumentStore?.value?.isArchived ?? false) ||
 			collaborationStore.shouldBeReadOnly,
 	);
 

--- a/packages/frontend/editor-ui/src/features/shared/contextMenu/composables/useContextMenuItems.ts
+++ b/packages/frontend/editor-ui/src/features/shared/contextMenu/composables/useContextMenuItems.ts
@@ -68,7 +68,7 @@ export function useContextMenuItems(targetNodeIds: ComputedRef<string[]>): Compu
 			sourceControlStore.preferences.branchReadOnly ||
 			uiStore.isReadOnlyView ||
 			!workflowPermissions.value.update ||
-			workflowsStore.workflow.isArchived ||
+			(documentStore?.value?.isArchived ?? false) ||
 			collaborationStore.shouldBeReadOnly,
 	);
 


### PR DESCRIPTION
## Summary

This pull request refactors how the "archived" state of a workflow is managed and accessed throughout the frontend codebase. The main change is moving the `isArchived` property from the global `workflowsStore` to the more granular `workflowDocumentStore`, which improves state encapsulation and consistency. As a result, all references and logic checks for whether a workflow is archived now use the document store, and related test and helper code has been updated accordingly.

**Workflow State Management Refactor**

* The `isArchived` property is now managed in `workflowDocumentStore` instead of `workflowsStore`. All logic and UI checks (e.g., in components, composables, and command bar logic) have been updated to reference `workflowDocumentStore.isArchived` rather than `workflowsStore.workflow.isArchived`. [[1]](diffhunk://#diff-97aaffc73b9f3d4bdd4590bbc1dc99444206c85f383ac02eab50be857a636b5eR78) [[2]](diffhunk://#diff-97aaffc73b9f3d4bdd4590bbc1dc99444206c85f383ac02eab50be857a636b5eL293-R294) [[3]](diffhunk://#diff-67fea899fd80dbaa3a37f4a46baf44a4e465bb59de6aad3e5bf975b3b20955b5L256-R256) [[4]](diffhunk://#diff-2d88866bfe4c44ba4c90aedbebaa1f5047fb3fafb2e7755e4f844a469702fcf3L43-R52) [[5]](diffhunk://#diff-d2e84e3b8a6e85411ce55abae103e6063c49ef6e725d4b95b28f535760ad03ddL72-R81)

* The workflow document store gains a new composable, `useWorkflowDocumentIsArchived`, which encapsulates the archived state and provides methods and event hooks for updating and reacting to changes. Associated unit tests for this composable have been added for reliability. [[1]](diffhunk://#diff-6b8f84de4dac5b49836cb575a2bfc6bdc949f9283a1dc2af763fe8e8c4fe1078R12) [[2]](diffhunk://#diff-6b8f84de4dac5b49836cb575a2bfc6bdc949f9283a1dc2af763fe8e8c4fe1078R60) [[3]](diffhunk://#diff-6b8f84de4dac5b49836cb575a2bfc6bdc949f9283a1dc2af763fe8e8c4fe1078R71) [[4]](diffhunk://#diff-a6547aecada3622be00641dc514ab54925425669f2790d5aee504f9bc4787e7fR1-R31) [[5]](diffhunk://#diff-9ee4f904fc15aac9ddb5819f8c4050f0404e01a7b878fcb5cc8da2132c9b90aeR1-R51)

**Store and Helper Updates**

* The workflow initialization logic now sets the archived state in `workflowDocumentStore` instead of `workflowsStore`, and the setter for `isArchived` has been removed from `workflowsStore`. [[1]](diffhunk://#diff-8fb9478ace4e8e530ab78331a576d3fff420afa30f05c6de7c4786dbae9dc3fbL973) [[2]](diffhunk://#diff-8fb9478ace4e8e530ab78331a576d3fff420afa30f05c6de7c4786dbae9dc3fbR1044) [[3]](diffhunk://#diff-60961aa352d313a6bb585e173f0a0424946c93b11fd447cb4942bdc7278fc4a0L785-L788) [[4]](diffhunk://#diff-60961aa352d313a6bb585e173f0a0424946c93b11fd447cb4942bdc7278fc4a0L1759)

* Workflow archiving and unarchiving actions now update the archived state via `workflowDocumentStore.setIsArchived()`, ensuring the document store remains the single source of truth. [[1]](diffhunk://#diff-60961aa352d313a6bb585e173f0a0424946c93b11fd447cb4942bdc7278fc4a0L742-R753) [[2]](diffhunk://#diff-60961aa352d313a6bb585e173f0a0424946c93b11fd447cb4942bdc7278fc4a0L757-R769)

**Test Refactor**

* All affected tests now use `workflowDocumentStore.isArchived` for assertions, and setup logic has been updated to set the archived state in the document store. This ensures tests reflect the new state management approach. [[1]](diffhunk://#diff-204361196cc0bc2099a34540938aad40a09b0d6a8dc3cded2f181c6310551be8L1344-R1349) [[2]](diffhunk://#diff-204361196cc0bc2099a34540938aad40a09b0d6a8dc3cded2f181c6310551be8L1360-R1362) [[3]](diffhunk://#diff-204361196cc0bc2099a34540938aad40a09b0d6a8dc3cded2f181c6310551be8L1383-R1390) [[4]](diffhunk://#diff-204361196cc0bc2099a34540938aad40a09b0d6a8dc3cded2f181c6310551be8L1419-R1428) [[5]](diffhunk://#diff-204361196cc0bc2099a34540938aad40a09b0d6a8dc3cded2f181c6310551be8L1435-R1441) [[6]](diffhunk://#diff-204361196cc0bc2099a34540938aad40a09b0d6a8dc3cded2f181c6310551be8R2219-R2234) [[7]](diffhunk://#diff-204361196cc0bc2099a34540938aad40a09b0d6a8dc3cded2f181c6310551be8R2324-R2332)

**Component and Feature Updates**

* UI components and features (such as command bars and run data views) now consistently use the archived state from `workflowDocumentStore`, improving reliability and maintainability of workflow status displays and logic. [[1]](diffhunk://#diff-2d88866bfe4c44ba4c90aedbebaa1f5047fb3fafb2e7755e4f844a469702fcf3R13-R16) [[2]](diffhunk://#diff-d2e84e3b8a6e85411ce55abae103e6063c49ef6e725d4b95b28f535760ad03ddR27-R30)

This refactor centralizes workflow archived state management, reduces duplication, and improves code clarity and maintainability.

## Related Linear tickets, Github issues, and Community forum posts

cat-2356-normalize-isarchived-field-in-workflow-document-state


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
