### PR TITLE
ci: Pin Trivy binary version to fix yanked release

### DIFF
--- a/.github/workflows/security-trivy-scan-callable.yml
+++ b/.github/workflows/security-trivy-scan-callable.yml
@@ -50,6 +50,7 @@ jobs:
         id: trivy_scan
         with:
           image-ref: ${{ inputs.image_ref }}
+          version: 'v0.69.2'
           format: 'json'
           output: 'trivy-results.json'
           severity: 'CRITICAL,HIGH,MEDIUM,LOW'
@@ -101,7 +102,11 @@ jobs:
             echo ""
           } >> "$GITHUB_STEP_SUMMARY"
 
-          if [ "${{ steps.process_results.outputs.vulnerabilities_found }}" == "false" ]; then
+          if [ ! -s trivy-results.json ]; then
+            {
+              echo "⚠️ **Scan did not produce results.** Check the 'Run Trivy vulnerability scanner' step for errors."
+            } >> "$GITHUB_STEP_SUMMARY"
+          elif [ "${{ steps.process_results.outputs.vulnerabilities_found }}" == "false" ]; then
             {
               echo "✅ **No vulnerabilities found!**"
             } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

1.x releases are failing due to Trivy not being pinned there.

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/actions/runs/22660954640

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
