### PR TITLE
ci: Update claude-code-action to latest v1 and suppress output

### DIFF
--- a/.github/scripts/claude-task/prepare-claude-prompt.mjs
+++ b/.github/scripts/claude-task/prepare-claude-prompt.mjs
@@ -66,4 +66,3 @@ When running lint/typecheck, suppress verbose output:
 const delimiter = `CLAUDE_PROMPT_DELIM_${randomUUID().replace(/-/g, '')}`;
 appendFileSync(envFile, `CLAUDE_PROMPT<<${delimiter}\n${prompt}\n${delimiter}\n`);
 
-console.log(`Prompt written to GITHUB_ENV (${prompt.length} chars)`);

--- a/.github/scripts/claude-task/resume-callback.mjs
+++ b/.github/scripts/claude-task/resume-callback.mjs
@@ -48,8 +48,6 @@ try {
 		body: payload,
 	});
 
-	console.log(`Callback sent: ${response.status} ${response.statusText}`);
-
 	if (!response.ok) {
 		const body = await response.text();
 		console.error(`Callback failed: ${body}`);

--- a/.github/workflows/util-claude-task.yml
+++ b/.github/workflows/util-claude-task.yml
@@ -121,12 +121,13 @@ jobs:
       - name: Run Claude
         id: claude
         continue-on-error: true
-        uses: anthropics/claude-code-action@1b8ee3b94104046d71fde52ec3557651ad8c0d71 # v1
+        uses: anthropics/claude-code-action@d668cc452deb931732f24c6b1bbf24d97bc0c586 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.generate_token.outputs.token }}
           prompt: ${{ env.CLAUDE_PROMPT }}
           show_full_output: ${{ inputs.suppress_output != true }}
+          display_report: false
           settings: |
             {
               "permissions": {
@@ -163,19 +164,11 @@ jobs:
       - name: Summary
         if: always()
         env:
-          INPUT_TASK: ${{ inputs.task }}
           CLAUDE_OUTCOME: ${{ steps.claude.outcome }}
           CLAUDE_SESSION_ID: ${{ steps.claude.outputs.session_id }}
-          SUPPRESS_OUTPUT: ${{ inputs.suppress_output }}
         run: |
           {
-            echo "## Claude Task Runner Summary"
-            echo ""
-            if [ "$SUPPRESS_OUTPUT" = "true" ]; then
-              echo "**Task:** _(output suppressed)_"
-            else
-              echo "**Task:** $INPUT_TASK"
-            fi
+            echo "## Claude Task Runner"
             echo "**Branch:** ${BRANCH_NAME:-N/A}"
             echo "**Claude outcome:** $CLAUDE_OUTCOME"
             if [ -n "$CLAUDE_SESSION_ID" ]; then

--- a/.github/workflows/util-claude.yml
+++ b/.github/workflows/util-claude.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude PR Action
-        uses: anthropics/claude-code-action@de8e0b9c42c6cb58e904c857f164aa072244c1ac # beta
+        uses: anthropics/claude-code-action@d668cc452deb931732f24c6b1bbf24d97bc0c586 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Or use OAuth token instead:


### PR DESCRIPTION
## Summary
- Pin both claude workflows (`util-claude-task.yml`, `util-claude.yml`) to latest `claude-code-action` v1 SHA
- Add `display_report: false` to task runner to prevent Claude-authored content in Step Summary
- Remove `console.log` from `prepare-claude-prompt.mjs` and `resume-callback.mjs` to prevent log leakage
- Simplify Summary step to metadata only (branch, outcome, session ID)

## Test plan
- [ ] Trigger task runner via workflow_dispatch and verify no task content appears in logs or summary
- [ ] Verify `@claude` mention on a PR still works with updated action version

🤖 Generated with [Claude Code](https://claude.com/claude-code)