### PR TITLE
test: Add Kafka load testing framework with CI

### DIFF
--- a/.github/workflows/test-e2e-infrastructure-reusable.yml
+++ b/.github/workflows/test-e2e-infrastructure-reusable.yml
@@ -21,4 +21,5 @@ jobs:
       test-command: pnpm --filter=n8n-playwright test:infrastructure
       shards: 1
       workers: 1
+      timeout-minutes: 60
     secrets: inherit

--- a/.github/workflows/test-e2e-infrastructure-reusable.yml
+++ b/.github/workflows/test-e2e-infrastructure-reusable.yml
@@ -8,6 +8,8 @@ on:
       - 'packages/testing/playwright/tests/infrastructure/**'
       - 'packages/testing/playwright/utils/kafka-*'
       - 'packages/testing/playwright/utils/throughput-*'
+      - 'packages/testing/playwright/utils/performance-helper.ts'
+      - 'packages/testing/playwright/reporters/benchmark-summary-reporter.ts'
       - 'packages/testing/containers/services/**'
       - '.github/workflows/test-e2e-infrastructure-reusable.yml'
 

--- a/.github/workflows/test-e2e-infrastructure-reusable.yml
+++ b/.github/workflows/test-e2e-infrastructure-reusable.yml
@@ -1,0 +1,21 @@
+name: 'Test: E2E Infrastructure'
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'packages/testing/playwright/tests/infrastructure/**'
+      - 'packages/testing/playwright/utils/kafka-*'
+      - 'packages/testing/playwright/utils/throughput-*'
+      - 'packages/testing/containers/services/**'
+      - '.github/workflows/test-e2e-infrastructure-reusable.yml'
+
+jobs:
+  build-and-test-infrastructure:
+    uses: ./.github/workflows/test-e2e-reusable.yml
+    with:
+      test-mode: docker-build
+      test-command: pnpm --filter=n8n-playwright test:infrastructure
+      shards: 1
+    secrets: inherit

--- a/.github/workflows/test-e2e-infrastructure-reusable.yml
+++ b/.github/workflows/test-e2e-infrastructure-reusable.yml
@@ -18,4 +18,5 @@ jobs:
       test-mode: docker-build
       test-command: pnpm --filter=n8n-playwright test:infrastructure
       shards: 1
+      workers: 1
     secrets: inherit

--- a/.github/workflows/test-e2e-reusable.yml
+++ b/.github/workflows/test-e2e-reusable.yml
@@ -42,6 +42,11 @@ on:
         required: false
         default: false
         type: boolean
+      timeout-minutes:
+        description: 'Job timeout in minutes'
+        required: false
+        default: 30
+        type: number
       upload-failure-artifacts:
         description: 'Upload test failure artifacts (screenshots, traces, videos). Enable for community PRs without Currents access.'
         required: false
@@ -113,7 +118,7 @@ jobs:
     needs: matrix
     if: ${{ !cancelled() }}
     runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || inputs.runner }}
-    timeout-minutes: 30
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
       packages: read
       contents: read

--- a/packages/testing/containers/services/kafka.ts
+++ b/packages/testing/containers/services/kafka.ts
@@ -115,6 +115,54 @@ export class KafkaHelper {
 		});
 	}
 
+	async publishBatch(
+		topic: string,
+		messages: Array<{ value: string | object; key?: string }>,
+		options: { batchSize?: number } = {},
+	): Promise<void> {
+		if (!this.producer) {
+			this.producer = this.kafka.producer();
+			await this.producer.connect();
+		}
+
+		const { batchSize = 1000 } = options;
+		const kafkaMessages = messages.map((m) => ({
+			key: m.key,
+			value: typeof m.value === 'string' ? m.value : JSON.stringify(m.value),
+		}));
+
+		for (let i = 0; i < kafkaMessages.length; i += batchSize) {
+			const chunk = kafkaMessages.slice(i, i + batchSize);
+			await this.producer.send({ topic, messages: chunk });
+		}
+	}
+
+	async getConsumerGroupLag(
+		groupId: string,
+		topic: string,
+	): Promise<{ totalLag: number; partitions: Array<{ partition: number; lag: number }> }> {
+		const admin = this.kafka.admin();
+		try {
+			await admin.connect();
+			const offsets = await admin.fetchOffsets({ groupId, topics: [topic] });
+			const topicOffsets = await admin.fetchTopicOffsets(topic);
+
+			let totalLag = 0;
+			const partitions = topicOffsets.map((tp) => {
+				const consumerPartition = offsets
+					.find((o) => o.topic === topic)
+					?.partitions.find((p) => p.partition === tp.partition);
+				const lag = parseInt(tp.high, 10) - parseInt(consumerPartition?.offset ?? '0', 10);
+				totalLag += lag;
+				return { partition: tp.partition, lag };
+			});
+
+			return { totalLag, partitions };
+		} finally {
+			await admin.disconnect();
+		}
+	}
+
 	async consume(
 		topic: string,
 		options: {

--- a/packages/testing/containers/services/postgres-exporter.ts
+++ b/packages/testing/containers/services/postgres-exporter.ts
@@ -1,0 +1,68 @@
+import { GenericContainer, Wait } from 'testcontainers';
+import type { StartedNetwork } from 'testcontainers';
+
+import { TEST_CONTAINER_IMAGES } from '../test-containers';
+import type { PostgresResult } from './postgres';
+import type { Service, ServiceResult, StartContext } from './types';
+
+const HOSTNAME = 'postgres-exporter';
+const EXPORTER_PORT = 9187;
+
+export interface PostgresExporterMeta {
+	host: string;
+	port: number;
+}
+
+export type PostgresExporterResult = ServiceResult<PostgresExporterMeta>;
+
+export const postgresExporter: Service<PostgresExporterResult> = {
+	description: 'Postgres Exporter',
+	dependsOn: ['postgres'],
+
+	shouldStart(ctx: StartContext): boolean {
+		// Auto-start when both postgres and victoriaMetrics are in use
+		const services = ctx.config.services ?? [];
+		return ctx.usePostgres && services.includes('victoriaMetrics');
+	},
+
+	async start(
+		network: StartedNetwork,
+		projectName: string,
+		_options?: unknown,
+		ctx?: StartContext,
+	): Promise<PostgresExporterResult> {
+		const pgResult = ctx?.serviceResults.postgres as PostgresResult | undefined;
+		if (!pgResult) {
+			throw new Error('Postgres service must start before postgres-exporter');
+		}
+
+		const { username, password, database } = pgResult.meta;
+		const dsn = `postgresql://${username}:${password}@postgres:5432/${database}?sslmode=disable`;
+
+		const container = await new GenericContainer(TEST_CONTAINER_IMAGES.postgresExporter)
+			.withName(`${projectName}-${HOSTNAME}`)
+			.withNetwork(network)
+			.withNetworkAliases(HOSTNAME)
+			.withLabels({
+				'com.docker.compose.project': projectName,
+				'com.docker.compose.service': HOSTNAME,
+			})
+			.withEnvironment({
+				DATA_SOURCE_NAME: dsn,
+			})
+			.withExposedPorts(EXPORTER_PORT)
+			.withWaitStrategy(
+				Wait.forHttp('/metrics', EXPORTER_PORT).forStatusCode(200).withStartupTimeout(30000),
+			)
+			.withReuse()
+			.start();
+
+		return {
+			container,
+			meta: {
+				host: HOSTNAME,
+				port: EXPORTER_PORT,
+			},
+		};
+	},
+};

--- a/packages/testing/containers/services/postgres-exporter.ts
+++ b/packages/testing/containers/services/postgres-exporter.ts
@@ -6,7 +6,7 @@ import type { PostgresResult } from './postgres';
 import type { Service, ServiceResult, StartContext } from './types';
 
 const HOSTNAME = 'postgres-exporter';
-const EXPORTER_PORT = 9187;
+export const EXPORTER_PORT = 9187;
 
 export interface PostgresExporterMeta {
 	host: string;

--- a/packages/testing/containers/services/postgres.ts
+++ b/packages/testing/containers/services/postgres.ts
@@ -2,7 +2,7 @@ import { PostgreSqlContainer } from '@testcontainers/postgresql';
 import type { StartedNetwork } from 'testcontainers';
 
 import { TEST_CONTAINER_IMAGES } from '../test-containers';
-import type { Service, ServiceResult } from './types';
+import type { PostgresProfile, Service, ServiceResult, StartContext } from './types';
 
 const HOSTNAME = 'postgres';
 
@@ -14,12 +14,59 @@ export interface PostgresMeta {
 
 export type PostgresResult = ServiceResult<PostgresMeta>;
 
+const POSTGRES_PROFILES: Record<string, Record<string, string>> = {
+	fast: {
+		fsync: 'off',
+		synchronous_commit: 'off',
+		full_page_writes: 'off',
+	},
+	production: {
+		fsync: 'on',
+		synchronous_commit: 'on',
+		full_page_writes: 'on',
+		shared_buffers: '256MB',
+		work_mem: '16MB',
+		max_connections: '100',
+	},
+};
+
+function resolvePostgresFlags(profile: PostgresProfile): Record<string, string> {
+	if (typeof profile === 'string') {
+		return POSTGRES_PROFILES[profile] ?? POSTGRES_PROFILES.fast;
+	}
+	return profile;
+}
+
+function buildCommand(flags: Record<string, string>): string[] {
+	const args = ['postgres'];
+	for (const [key, value] of Object.entries(flags)) {
+		args.push('-c', `${key}=${value}`);
+	}
+	return args;
+}
+
+export interface PostgresConfig {
+	profile: PostgresProfile;
+}
+
 export const postgres: Service<PostgresResult> = {
 	description: 'PostgreSQL database',
 	shouldStart: (ctx) => ctx.usePostgres,
 
-	async start(network: StartedNetwork, projectName: string): Promise<PostgresResult> {
-		const container = await new PostgreSqlContainer(TEST_CONTAINER_IMAGES.postgres)
+	getOptions(ctx: StartContext): PostgresConfig {
+		return { profile: ctx.config.postgresProfile ?? 'fast' };
+	},
+
+	async start(
+		network: StartedNetwork,
+		projectName: string,
+		options?: unknown,
+	): Promise<PostgresResult> {
+		const { profile = 'fast' } = (options as PostgresConfig) ?? {};
+		const flags = resolvePostgresFlags(profile);
+		const useTmpFs = profile === 'fast';
+
+		let builder = new PostgreSqlContainer(TEST_CONTAINER_IMAGES.postgres)
 			.withNetwork(network)
 			.withNetworkAliases(HOSTNAME)
 			.withDatabase('n8n_db')
@@ -32,18 +79,14 @@ export const postgres: Service<PostgresResult> = {
 			})
 			.withName(`${projectName}-${HOSTNAME}`)
 			.withAddedCapabilities('NET_ADMIN') // Allows us to drop IP tables and block traffic
-			.withTmpFs({ '/var/lib/postgresql': 'rw' })
-			.withCommand([
-				'postgres',
-				'-c',
-				'fsync=off',
-				'-c',
-				'synchronous_commit=off',
-				'-c',
-				'full_page_writes=off',
-			])
-			.withReuse()
-			.start();
+			.withCommand(buildCommand(flags))
+			.withReuse();
+
+		if (useTmpFs) {
+			builder = builder.withTmpFs({ '/var/lib/postgresql': 'rw' });
+		}
+
+		const container = await builder.start();
 
 		return {
 			container,

--- a/packages/testing/containers/services/registry.ts
+++ b/packages/testing/containers/services/registry.ts
@@ -10,6 +10,7 @@ import { mysqlService } from './mysql';
 import { ngrok } from './ngrok';
 import { createObservabilityHelper } from './observability';
 import { postgres } from './postgres';
+import { postgresExporter } from './postgres-exporter';
 import { proxy, createProxyHelper } from './proxy';
 import { redis } from './redis';
 import { taskRunner } from './task-runner';
@@ -39,6 +40,7 @@ export const services: Record<ServiceName, Service<ServiceResult>> = {
 	mysql: mysqlService,
 	localstack,
 	kent,
+	postgresExporter,
 };
 
 export const helperFactories: Partial<HelperFactories> = {

--- a/packages/testing/containers/services/types.ts
+++ b/packages/testing/containers/services/types.ts
@@ -61,10 +61,19 @@ export interface StartContext {
 	baseUrl?: string;
 }
 
+/**
+ * Postgres performance profiles. Controls durability vs speed trade-offs.
+ * - `fast`: Disables fsync/WAL for maximum speed. Default for CI/dev.
+ * - `production`: Enables fsync/WAL for realistic durability overhead.
+ * - Custom `Record<string, string>`: Arbitrary `-c key=value` flags passed to postgres.
+ */
+export type PostgresProfile = 'fast' | 'production' | Record<string, string>;
+
 export interface StackConfig {
 	mains?: number;
 	workers?: number;
 	postgres?: boolean;
+	postgresProfile?: PostgresProfile;
 	env?: Record<string, string>;
 	projectName?: string;
 	resourceQuota?: { memory?: number; cpu?: number };

--- a/packages/testing/containers/services/types.ts
+++ b/packages/testing/containers/services/types.ts
@@ -22,6 +22,7 @@ export const SERVICE_NAMES = [
 	'mysql',
 	'localstack',
 	'kent',
+	'postgresExporter',
 ] as const;
 
 export type ServiceName = (typeof SERVICE_NAMES)[number];

--- a/packages/testing/containers/services/victoria-metrics.ts
+++ b/packages/testing/containers/services/victoria-metrics.ts
@@ -84,6 +84,17 @@ export const victoriaMetrics: Service<VictoriaMetricsResult> = {
 			});
 		}
 
+		// Add postgres-exporter scrape target when it will be started
+		const services = ctx.config.services ?? [];
+		if (ctx.usePostgres && services.includes('victoriaMetrics')) {
+			scrapeTargets.push({
+				job: 'postgres',
+				instance: 'postgres',
+				host: 'postgres-exporter',
+				port: 9187,
+			});
+		}
+
 		return { scrapeTargets };
 	},
 

--- a/packages/testing/containers/services/victoria-metrics.ts
+++ b/packages/testing/containers/services/victoria-metrics.ts
@@ -2,6 +2,7 @@ import type { StartedNetwork } from 'testcontainers';
 import { GenericContainer, Wait } from 'testcontainers';
 
 import { TEST_CONTAINER_IMAGES } from '../test-containers';
+import { EXPORTER_PORT } from './postgres-exporter';
 import type { HelperContext, Service, ServiceResult, StartContext } from './types';
 
 const VICTORIA_METRICS_HTTP_PORT = 8428;
@@ -91,7 +92,7 @@ export const victoriaMetrics: Service<VictoriaMetricsResult> = {
 				job: 'postgres',
 				instance: 'postgres',
 				host: 'postgres-exporter',
-				port: 9187,
+				port: EXPORTER_PORT,
 			});
 		}
 

--- a/packages/testing/containers/test-containers.ts
+++ b/packages/testing/containers/test-containers.ts
@@ -41,6 +41,7 @@ const DEFAULT_IMAGES = {
 	kafka: 'confluentinc/cp-kafka:8.0.3',
 	mysql: 'mysql:9.6.0',
 	localstack: 'localstack/localstack:4.13.1',
+	postgresExporter: 'prometheuscommunity/postgres-exporter:v0.17.1',
 } as const;
 
 /** Convert camelCase to SCREAMING_SNAKE_CASE for env var names */
@@ -117,4 +118,5 @@ export const TEST_CONTAINER_IMAGES = {
 	mysql: getImage('mysql'),
 	ngrok: getImage('ngrok'),
 	localstack: getImage('localstack'),
+	postgresExporter: getImage('postgresExporter'),
 } as const;

--- a/packages/testing/playwright/playwright.config.ts
+++ b/packages/testing/playwright/playwright.config.ts
@@ -116,6 +116,12 @@ export default defineConfig<CurrentsFixtures, CurrentsWorkerFixtures>({
 				['json', { outputFile: 'test-results.json' }],
 				...(process.env.CURRENTS_RECORD_KEY ? [currentsReporter(currentsConfig)] : []),
 				['./reporters/metrics-reporter.ts'],
+				['./reporters/benchmark-summary-reporter.ts'],
 			]
-		: [['html'], ['./reporters/metrics-reporter.ts'], ['list']],
+		: [
+				['html'],
+				['./reporters/metrics-reporter.ts'],
+				['./reporters/benchmark-summary-reporter.ts'],
+				['list'],
+			],
 });

--- a/packages/testing/playwright/reporters/benchmark-summary-reporter.ts
+++ b/packages/testing/playwright/reporters/benchmark-summary-reporter.ts
@@ -1,0 +1,134 @@
+import type { Reporter, TestCase, TestResult } from '@playwright/test/reporter';
+
+interface BenchmarkRow {
+	trigger: string;
+	scenario: string;
+	metrics: Map<string, number>;
+}
+
+interface Column {
+	header: string;
+	suffixes: string[];
+	format: (value: number) => string;
+}
+
+const COLUMNS: Column[] = [
+	{
+		header: 'exec/s',
+		suffixes: ['throughput', 'exec-per-sec'],
+		format: (v) => v.toFixed(1),
+	},
+	{
+		header: 'actions/s',
+		suffixes: ['actions-per-sec'],
+		format: (v) => v.toFixed(1),
+	},
+	{ header: 'p50', suffixes: ['duration-p50'], format: (v) => `${v.toFixed(0)}ms` },
+	{ header: 'p95', suffixes: ['duration-p95'], format: (v) => `${v.toFixed(0)}ms` },
+	{ header: 'p99', suffixes: ['duration-p99'], format: (v) => `${v.toFixed(0)}ms` },
+	{
+		header: 'Heap Δ MB',
+		suffixes: ['memory-delta'],
+		format: (v) => `${v >= 0 ? '+' : ''}${v.toFixed(1)}`,
+	},
+];
+
+function extractTrigger(filePath: string): string {
+	// e.g. tests/infrastructure/kafka-load/foo.spec.ts → kafka
+	const match = filePath.match(/tests\/(?:infrastructure|performance)\/([^/]+)/);
+	if (!match) return 'unknown';
+	return match[1].replace(/-load$/, '');
+}
+
+function extractMetricSuffix(metricName: string, scenario: string): string | null {
+	if (metricName.startsWith(`${scenario}-`)) {
+		return metricName.slice(scenario.length + 1);
+	}
+	return null;
+}
+
+class BenchmarkSummaryReporter implements Reporter {
+	private rows: BenchmarkRow[] = [];
+
+	onTestEnd(test: TestCase, result: TestResult): void {
+		const metricAttachments = result.attachments.filter((a) => a.name.startsWith('metric:'));
+		if (metricAttachments.length === 0) return;
+
+		const scenario = test.title;
+		const filePath = test.location.file;
+		const trigger = extractTrigger(filePath);
+		const metrics = new Map<string, number>();
+
+		for (const attachment of metricAttachments) {
+			const fullName = attachment.name.replace('metric:', '');
+			const suffix = extractMetricSuffix(fullName, scenario);
+			if (suffix) {
+				try {
+					const data = JSON.parse(attachment.body?.toString() ?? '');
+					metrics.set(suffix, data.value);
+				} catch {
+					// skip malformed
+				}
+			}
+		}
+
+		if (metrics.size > 0) {
+			this.rows.push({ trigger, scenario, metrics });
+		}
+	}
+
+	onEnd(): void {
+		if (this.rows.length === 0) return;
+
+		this.rows.sort(
+			(a, b) => a.trigger.localeCompare(b.trigger) || a.scenario.localeCompare(b.scenario),
+		);
+
+		const triggerWidth = Math.max(7, ...this.rows.map((r) => r.trigger.length));
+		const scenarioWidth = Math.max(8, ...this.rows.map((r) => r.scenario.length));
+		const colWidths = COLUMNS.map((col) => {
+			const values = this.rows.map((r) => this.resolveColumn(r, col));
+			return Math.max(col.header.length, ...values.map((v) => v.length));
+		});
+
+		const pad = (s: string, w: number) => s.padStart(w);
+		const padLeft = (s: string, w: number) => s.padEnd(w);
+
+		const headerParts = [
+			padLeft('Trigger', triggerWidth),
+			padLeft('Scenario', scenarioWidth),
+			...COLUMNS.map((col, i) => pad(col.header, colWidths[i])),
+		];
+
+		const separator = headerParts.map((h) => '─'.repeat(h.length));
+
+		console.log('\n');
+		console.log('Benchmark Summary');
+		console.log('═'.repeat(headerParts.join(' │ ').length + 4));
+		console.log(`│ ${headerParts.join(' │ ')} │`);
+		console.log(`├─${separator.join('─┼─')}─┤`);
+
+		for (const row of this.rows) {
+			const parts = [
+				padLeft(row.trigger, triggerWidth),
+				padLeft(row.scenario, scenarioWidth),
+				...COLUMNS.map((col, i) => pad(this.resolveColumn(row, col), colWidths[i])),
+			];
+			console.log(`│ ${parts.join(' │ ')} │`);
+		}
+
+		console.log(`└─${separator.map((s) => s).join('─┴─')}─┘`);
+		console.log('');
+	}
+
+	private resolveColumn(row: BenchmarkRow, col: Column): string {
+		for (const suffix of col.suffixes) {
+			const value = row.metrics.get(suffix);
+			if (value !== undefined) return col.format(value);
+		}
+		return '—';
+	}
+}
+
+// eslint-disable-next-line import-x/no-default-export
+export default BenchmarkSummaryReporter;

--- a/packages/testing/playwright/reporters/benchmark-summary-reporter.ts
+++ b/packages/testing/playwright/reporters/benchmark-summary-reporter.ts
@@ -1,6 +1,5 @@
-import { appendFileSync } from 'fs';
-
 import type { Reporter, TestCase, TestResult } from '@playwright/test/reporter';
+import { appendFileSync } from 'fs';
 
 interface BenchmarkRow {
 	trigger: string;

--- a/packages/testing/playwright/reporters/benchmark-summary-reporter.ts
+++ b/packages/testing/playwright/reporters/benchmark-summary-reporter.ts
@@ -4,6 +4,7 @@ import type { Reporter, TestCase, TestResult } from '@playwright/test/reporter';
 
 interface BenchmarkRow {
 	trigger: string;
+	suite: string;
 	scenario: string;
 	metrics: Map<string, number>;
 }
@@ -42,6 +43,14 @@ function extractTrigger(filePath: string): string {
 	return match[1].replace(/-load$/, '');
 }
 
+function extractSuite(filePath: string): string {
+	// e.g. kafka-load.spec.ts → load, trigger-throughput.spec.ts → throughput
+	const filename = filePath.split('/').pop() ?? '';
+	if (filename.includes('throughput')) return 'throughput';
+	if (filename.includes('load')) return 'load';
+	return 'other';
+}
+
 function extractMetricSuffix(metricName: string, scenario: string): string | null {
 	if (metricName.startsWith(`${scenario}-`)) {
 		return metricName.slice(scenario.length + 1);
@@ -59,6 +68,7 @@ class BenchmarkSummaryReporter implements Reporter {
 		const scenario = test.title;
 		const filePath = test.location.file;
 		const trigger = extractTrigger(filePath);
+		const suite = extractSuite(filePath);
 		const metrics = new Map<string, number>();
 
 		for (const attachment of metricAttachments) {
@@ -75,7 +85,7 @@ class BenchmarkSummaryReporter implements Reporter {
 		}
 
 		if (metrics.size > 0) {
-			this.rows.push({ trigger, scenario, metrics });
+			this.rows.push({ trigger, suite, scenario, metrics });
 		}
 	}
 
@@ -83,10 +93,14 @@ class BenchmarkSummaryReporter implements Reporter {
 		if (this.rows.length === 0) return;
 
 		this.rows.sort(
-			(a, b) => a.trigger.localeCompare(b.trigger) || a.scenario.localeCompare(b.scenario),
+			(a, b) =>
+				a.trigger.localeCompare(b.trigger) ||
+				a.suite.localeCompare(b.suite) ||
+				a.scenario.localeCompare(b.scenario),
 		);
 
 		const triggerWidth = Math.max(7, ...this.rows.map((r) => r.trigger.length));
+		const suiteWidth = Math.max(5, ...this.rows.map((r) => r.suite.length));
 		const scenarioWidth = Math.max(8, ...this.rows.map((r) => r.scenario.length));
 		const colWidths = COLUMNS.map((col) => {
 			const values = this.rows.map((r) => this.resolveColumn(r, col));
@@ -98,6 +112,7 @@ class BenchmarkSummaryReporter implements Reporter {
 
 		const headerParts = [
 			padLeft('Trigger', triggerWidth),
+			padLeft('Suite', suiteWidth),
 			padLeft('Scenario', scenarioWidth),
 			...COLUMNS.map((col, i) => pad(col.header, colWidths[i])),
 		];
@@ -113,6 +128,7 @@ class BenchmarkSummaryReporter implements Reporter {
 		for (const row of this.rows) {
 			const parts = [
 				padLeft(row.trigger, triggerWidth),
+				padLeft(row.suite, suiteWidth),
 				padLeft(row.scenario, scenarioWidth),
 				...COLUMNS.map((col, i) => pad(this.resolveColumn(row, col), colWidths[i])),
 			];
@@ -129,7 +145,7 @@ class BenchmarkSummaryReporter implements Reporter {
 		const summaryPath = process.env.GITHUB_STEP_SUMMARY;
 		if (!summaryPath) return;
 
-		const headers = ['Trigger', 'Scenario', ...COLUMNS.map((c) => c.header)];
+		const headers = ['Trigger', 'Suite', 'Scenario', ...COLUMNS.map((c) => c.header)];
 		const lines: string[] = [
 			'## Benchmark Summary',
 			'',
@@ -140,6 +156,7 @@ class BenchmarkSummaryReporter implements Reporter {
 		for (const row of this.rows) {
 			const cells = [
 				row.trigger,
+				row.suite,
 				row.scenario,
 				...COLUMNS.map((col) => this.resolveColumn(row, col)),
 			];

--- a/packages/testing/playwright/reporters/benchmark-summary-reporter.ts
+++ b/packages/testing/playwright/reporters/benchmark-summary-reporter.ts
@@ -1,3 +1,5 @@
+import { appendFileSync } from 'fs';
+
 import type { Reporter, TestCase, TestResult } from '@playwright/test/reporter';
 
 interface BenchmarkRow {
@@ -119,6 +121,33 @@ class BenchmarkSummaryReporter implements Reporter {
 
 		console.log(`└─${separator.map((s) => s).join('─┴─')}─┘`);
 		console.log('');
+
+		this.writeGitHubSummary();
+	}
+
+	private writeGitHubSummary(): void {
+		const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+		if (!summaryPath) return;
+
+		const headers = ['Trigger', 'Scenario', ...COLUMNS.map((c) => c.header)];
+		const lines: string[] = [
+			'## Benchmark Summary',
+			'',
+			`| ${headers.join(' | ')} |`,
+			`| ${headers.map((h) => '---'.padEnd(h.length, '-')).join(' | ')} |`,
+		];
+
+		for (const row of this.rows) {
+			const cells = [
+				row.trigger,
+				row.scenario,
+				...COLUMNS.map((col) => this.resolveColumn(row, col)),
+			];
+			lines.push(`| ${cells.join(' | ')} |`);
+		}
+
+		lines.push('');
+		appendFileSync(summaryPath, lines.join('\n'));
 	}
 
 	private resolveColumn(row: BenchmarkRow, col: Column): string {

--- a/packages/testing/playwright/reporters/benchmark-summary-reporter.ts
+++ b/packages/testing/playwright/reporters/benchmark-summary-reporter.ts
@@ -102,12 +102,12 @@ class BenchmarkSummaryReporter implements Reporter {
 		});
 
 		const pad = (s: string, w: number) => s.padStart(w);
-		const padLeft = (s: string, w: number) => s.padEnd(w);
+		const padRight = (s: string, w: number) => s.padEnd(w);
 
 		const headerParts = [
-			padLeft('Trigger', triggerWidth),
-			padLeft('Suite', suiteWidth),
-			padLeft('Scenario', scenarioWidth),
+			padRight('Trigger', triggerWidth),
+			padRight('Suite', suiteWidth),
+			padRight('Scenario', scenarioWidth),
 			...COLUMNS.map((col, i) => pad(col.header, colWidths[i])),
 		];
 
@@ -121,9 +121,9 @@ class BenchmarkSummaryReporter implements Reporter {
 
 		for (const row of this.rows) {
 			const parts = [
-				padLeft(row.trigger, triggerWidth),
-				padLeft(row.suite, suiteWidth),
-				padLeft(row.scenario, scenarioWidth),
+				padRight(row.trigger, triggerWidth),
+				padRight(row.suite, suiteWidth),
+				padRight(row.scenario, scenarioWidth),
 				...COLUMNS.map((col, i) => pad(this.resolveColumn(row, col), colWidths[i])),
 			];
 			console.log(`│ ${parts.join(' │ ')} │`);

--- a/packages/testing/playwright/reporters/benchmark-summary-reporter.ts
+++ b/packages/testing/playwright/reporters/benchmark-summary-reporter.ts
@@ -29,11 +29,6 @@ const COLUMNS: Column[] = [
 	{ header: 'p50', suffixes: ['duration-p50'], format: (v) => `${v.toFixed(0)}ms` },
 	{ header: 'p95', suffixes: ['duration-p95'], format: (v) => `${v.toFixed(0)}ms` },
 	{ header: 'p99', suffixes: ['duration-p99'], format: (v) => `${v.toFixed(0)}ms` },
-	{
-		header: 'Heap Δ MB',
-		suffixes: ['memory-delta'],
-		format: (v) => `${v >= 0 ? '+' : ''}${v.toFixed(1)}`,
-	},
 ];
 
 function extractTrigger(filePath: string): string {

--- a/packages/testing/playwright/tests/infrastructure/kafka-load/README.md
+++ b/packages/testing/playwright/tests/infrastructure/kafka-load/README.md
@@ -1,0 +1,67 @@
+# Kafka Load & Throughput Benchmarks
+
+Two benchmark suites that measure n8n's Kafka trigger performance under different conditions.
+
+## Suites
+
+### Load (`kafka-load.spec.ts`)
+
+**Question: "Can n8n keep up with incoming Kafka traffic?"**
+
+Measures per-execution latency (p50/p95/p99) and completion rate under realistic load patterns. Uses consumer group lag polling to track individual message consumption.
+
+| Scenario | What it tests |
+|----------|---------------|
+| `10-nodes-1KB-10mps` | Baseline — sustain a modest steady stream |
+| `30-nodes-10KB-100mps` | Scale pressure — larger workflows + heavier payloads at 10x rate |
+| `60-nodes-1KB-preload-10k` | Burst capacity — drain a backlog with no pacing |
+| `10-nodes-100KB-10mps` | Payload weight — does message size affect latency or memory? |
+
+### Throughput (`trigger-throughput.spec.ts`)
+
+**Question: "What's the throughput ceiling and what degrades it?"**
+
+Measures sustained exec/s and actions/s via VictoriaMetrics counters. Preloads all messages before activating the workflow to measure maximum drain rate.
+
+| Scenario | What it tests |
+|----------|---------------|
+| `1-node-1KB-1k` | Pure trigger overhead — minimal workflow |
+| `10/30/60-nodes-1KB-5k` | Node count scaling curve — where does throughput cliff? |
+| `10-nodes-1KB-10kb-out-5k` | DB write pressure (moderate) — 10KB output per node |
+| `10-nodes-1KB-100kb-out-5k` | DB write pressure (heavy) — 100KB output per node |
+
+## Running
+
+```bash
+# Build docker image first
+pnpm build:docker
+
+# All infrastructure tests
+pnpm --filter=n8n-playwright test:infrastructure
+
+# Single scenario
+pnpm --filter=n8n-playwright test:infrastructure --grep "10-nodes-1KB-10mps"
+
+# Custom message count (throughput tests only)
+BENCHMARK_MESSAGES=50000 pnpm --filter=n8n-playwright test:infrastructure
+```
+
+## Results
+
+A benchmark summary table prints at the end of every run and appears in the GitHub Actions job summary:
+
+```
+│ Trigger │ Suite      │ Scenario                 │ exec/s │ actions/s │  p50 │  p95 │  p99 │ Heap Δ MB │
+├─────────┼────────────┼──────────────────────────┼────────┼───────────┼──────┼──────┼──────┼───────────┤
+│ kafka   │ load       │ 10-nodes-1KB-10mps       │   90.6 │         — │  3ms │  5ms │ 13ms │    +171.7 │
+│ kafka   │ throughput │ 10-nodes-1KB-5k          │  142.8 │    1427.6 │    — │    — │    — │    +268.5 │
+```
+
+- **exec/s**: Workflow executions per second
+- **actions/s**: Total node executions per second (exec/s * node count)
+- **p50/p95/p99**: Per-execution duration percentiles (load suite only)
+- **Heap Δ MB**: Heap memory change during the test
+
+## Architecture
+
+Both suites share the same container stack: Kafka + Postgres + VictoriaMetrics + Vector. Tests run sequentially (1 worker) to avoid resource contention. Each test creates unique topics and credentials via `nanoid()` for logical isolation.

--- a/packages/testing/playwright/tests/infrastructure/kafka-load/README.md
+++ b/packages/testing/playwright/tests/infrastructure/kafka-load/README.md
@@ -27,6 +27,7 @@ Measures sustained exec/s and actions/s via VictoriaMetrics counters. Preloads a
 |----------|---------------|
 | `1-node-1KB-1k` | Pure trigger overhead — minimal workflow |
 | `10/30/60-nodes-1KB-5k` | Node count scaling curve — where does throughput cliff? |
+| `10-nodes-100KB-noop-5k` | Large input, noop output — isolates input deserialization cost |
 | `10-nodes-1KB-10kb-out-5k` | DB write pressure (moderate) — 10KB output per node |
 | `10-nodes-1KB-100kb-out-5k` | DB write pressure (heavy) — 100KB output per node |
 

--- a/packages/testing/playwright/tests/infrastructure/kafka-load/README.md
+++ b/packages/testing/playwright/tests/infrastructure/kafka-load/README.md
@@ -15,13 +15,13 @@ Measures per-execution latency (p50/p95/p99) and completion rate under realistic
 | `10-nodes-1KB-10mps` | Baseline — sustain a modest steady stream |
 | `30-nodes-10KB-100mps` | Scale pressure — larger workflows + heavier payloads at 10x rate |
 | `60-nodes-1KB-preload-10k` | Burst capacity — drain a backlog with no pacing |
-| `10-nodes-100KB-10mps` | Payload weight — does message size affect latency or memory? |
+| `10-nodes-100KB-10mps` | Payload weight — does message size affect latency? |
 
 ### Throughput (`trigger-throughput.spec.ts`)
 
 **Question: "What's the throughput ceiling and what degrades it?"**
 
-Measures sustained exec/s and actions/s via VictoriaMetrics counters. Preloads all messages before activating the workflow to measure maximum drain rate.
+Measures sustained exec/s and actions/s via VictoriaMetrics counters. Preloads all messages before activating the workflow to measure maximum drain rate. Collects Postgres and event loop diagnostics after each run.
 
 | Scenario | What it tests |
 |----------|---------------|
@@ -51,17 +51,20 @@ BENCHMARK_MESSAGES=50000 pnpm --filter=n8n-playwright test:infrastructure
 A benchmark summary table prints at the end of every run and appears in the GitHub Actions job summary:
 
 ```
-│ Trigger │ Suite      │ Scenario                 │ exec/s │ actions/s │  p50 │  p95 │  p99 │ Heap Δ MB │
-├─────────┼────────────┼──────────────────────────┼────────┼───────────┼──────┼──────┼──────┼───────────┤
-│ kafka   │ load       │ 10-nodes-1KB-10mps       │   90.6 │         — │  3ms │  5ms │ 13ms │    +171.7 │
-│ kafka   │ throughput │ 10-nodes-1KB-5k          │  142.8 │    1427.6 │    — │    — │    — │    +268.5 │
+│ Trigger │ Suite      │ Scenario                 │ exec/s │ actions/s │   p50 │   p95 │   p99 │
+├─────────┼────────────┼──────────────────────────┼────────┼───────────┼───────┼───────┼───────┤
+│ kafka   │ load       │ 10-nodes-1KB-10mps       │   90.6 │         — │   3ms │   5ms │  13ms │
+│ kafka   │ throughput │ 10-nodes-1KB-5k          │  142.8 │    1427.6 │     — │     — │     — │
 ```
 
 - **exec/s**: Workflow executions per second
-- **actions/s**: Total node executions per second (exec/s * node count)
+- **actions/s**: Total node executions per second (exec/s × node count)
 - **p50/p95/p99**: Per-execution duration percentiles (load suite only)
-- **Heap Δ MB**: Heap memory change during the test
+
+Throughput tests also log Postgres diagnostics (tx/s, rows inserted/s, active connections) and Node.js event loop lag to the console for bottleneck analysis.
 
 ## Architecture
 
-Both suites share the same container stack: Kafka + Postgres + VictoriaMetrics + Vector. Tests run sequentially (1 worker) to avoid resource contention. Each test creates unique topics and credentials via `nanoid()` for logical isolation.
+Both suites share the same container stack: n8n + Kafka + Postgres + postgres-exporter + VictoriaMetrics + Vector. Tests run sequentially (1 worker) to avoid resource contention. Each test creates unique topics and credentials via `nanoid()` for logical isolation.
+
+Currently all tests run in **direct mode** (single n8n process). The container infrastructure supports queue mode with workers — see `capability.workers` in the fixtures.

--- a/packages/testing/playwright/tests/infrastructure/kafka-load/kafka-load.spec.ts
+++ b/packages/testing/playwright/tests/infrastructure/kafka-load/kafka-load.spec.ts
@@ -5,12 +5,11 @@ import {
 	publishAtRate,
 	preloadQueue,
 	waitForExecutions,
-	collectMemoryMetrics,
 	attachLoadTestResults,
 	type PayloadSize,
 } from '../../../utils/kafka-load-helper';
 import { buildKafkaTriggeredWorkflow } from '../../../utils/kafka-workflow-builder';
-import { attachMetric } from '../../../utils/performance-helper';
+import { attachMetric, collectMemorySnapshot } from '../../../utils/performance-helper';
 
 // Resource profile: override via env for different hardware profiles
 const RESOURCE_MEMORY = parseFloat(process.env.KAFKA_LOAD_MEMORY ?? '2');
@@ -117,14 +116,15 @@ test.describe(
 					nodeCount: scenario.nodeCount,
 				});
 
-				const { workflowId, createdWorkflow } =
-					// eslint-disable-next-line @typescript-eslint/no-explicit-any
-					await api.workflows.createWorkflowFromDefinition(workflowDef as any, {
+				const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition(
+					workflowDef,
+					{
 						makeUnique: true,
-					});
+					},
+				);
 
 				// Baseline memory
-				const memBefore = await collectMemoryMetrics(obs.metrics);
+				const memBefore = await collectMemorySnapshot(obs.metrics);
 				console.log(
 					`[LOAD] Baseline: heap=${memBefore.heapUsedMB.toFixed(1)}MB rss=${memBefore.rssMB.toFixed(1)}MB`,
 				);
@@ -172,7 +172,7 @@ test.describe(
 				});
 
 				// Final memory
-				const memAfter = await collectMemoryMetrics(obs.metrics);
+				const memAfter = await collectMemorySnapshot(obs.metrics);
 
 				// Attach results
 				await attachLoadTestResults(testInfo, scenario.name, metrics, memAfter);

--- a/packages/testing/playwright/tests/infrastructure/kafka-load/kafka-load.spec.ts
+++ b/packages/testing/playwright/tests/infrastructure/kafka-load/kafka-load.spec.ts
@@ -123,6 +123,7 @@ test.describe(
 
 				let expectedExecutions: number;
 
+				// eslint-disable-next-line playwright/no-conditional-in-test
 				if (scenario.loadType === 'preloaded') {
 					// Preloaded: publish all messages before activating
 					const publishResult = await preloadQueue(kafka, topic, {

--- a/packages/testing/playwright/tests/infrastructure/kafka-load/kafka-load.spec.ts
+++ b/packages/testing/playwright/tests/infrastructure/kafka-load/kafka-load.spec.ts
@@ -68,9 +68,9 @@ const SCENARIOS: LoadScenario[] = [
 	},
 	// Large messages stress test
 	{
-		name: '10-nodes-1MB-10mps',
+		name: '10-nodes-100KB-10mps',
 		nodeCount: 10,
-		payloadSize: '1MB',
+		payloadSize: '100KB',
 		loadType: 'steady',
 		ratePerSecond: 10,
 		durationSeconds: 30,

--- a/packages/testing/playwright/tests/infrastructure/kafka-load/kafka-load.spec.ts
+++ b/packages/testing/playwright/tests/infrastructure/kafka-load/kafka-load.spec.ts
@@ -1,0 +1,210 @@
+import { nanoid } from 'nanoid';
+
+import { test, expect } from '../../../fixtures/base';
+import {
+	publishAtRate,
+	preloadQueue,
+	waitForExecutions,
+	collectMemoryMetrics,
+	attachLoadTestResults,
+	type PayloadSize,
+} from '../../../utils/kafka-load-helper';
+import { buildKafkaTriggeredWorkflow } from '../../../utils/kafka-workflow-builder';
+import { attachMetric } from '../../../utils/performance-helper';
+
+// Resource profile: override via env for different hardware profiles
+const RESOURCE_MEMORY = parseFloat(process.env.KAFKA_LOAD_MEMORY ?? '2');
+const RESOURCE_CPU = parseFloat(process.env.KAFKA_LOAD_CPU ?? '2');
+
+test.use({
+	capability: {
+		services: ['kafka', 'victoriaLogs', 'victoriaMetrics', 'vector'],
+		postgres: true,
+		resourceQuota: { memory: RESOURCE_MEMORY, cpu: RESOURCE_CPU },
+	},
+});
+
+interface LoadScenario {
+	name: string;
+	nodeCount: number;
+	payloadSize: PayloadSize;
+	loadType: 'steady' | 'preloaded';
+	ratePerSecond?: number;
+	durationSeconds?: number;
+	messageCount?: number;
+	partitions?: number;
+	timeoutMs: number;
+}
+
+const SCENARIOS: LoadScenario[] = [
+	// Baseline: small workflow, small messages, low rate
+	{
+		name: '10-nodes-1KB-10mps',
+		nodeCount: 10,
+		payloadSize: '1KB',
+		loadType: 'steady',
+		ratePerSecond: 10,
+		durationSeconds: 30,
+		timeoutMs: 120_000,
+	},
+	// Medium workflow, medium messages, higher rate
+	{
+		name: '30-nodes-10KB-100mps',
+		nodeCount: 30,
+		payloadSize: '10KB',
+		loadType: 'steady',
+		ratePerSecond: 100,
+		durationSeconds: 30,
+		timeoutMs: 300_000,
+	},
+	// Large workflow, small messages, burst from preloaded queue
+	{
+		name: '60-nodes-1KB-preload-10k',
+		nodeCount: 60,
+		payloadSize: '1KB',
+		loadType: 'preloaded',
+		messageCount: 10_000,
+		partitions: 3,
+		timeoutMs: 600_000,
+	},
+	// Large messages stress test
+	{
+		name: '10-nodes-1MB-10mps',
+		nodeCount: 10,
+		payloadSize: '1MB',
+		loadType: 'steady',
+		ratePerSecond: 10,
+		durationSeconds: 30,
+		timeoutMs: 300_000,
+	},
+];
+
+test.describe(
+	'Kafka Load Tests @mode:postgres @capability:kafka @capability:observability @kafka-load',
+	{
+		annotation: [{ type: 'owner', description: 'Catalysts' }],
+	},
+	() => {
+		for (const scenario of SCENARIOS) {
+			test(`${scenario.name}`, async ({ api, services }, testInfo) => {
+				test.setTimeout(scenario.timeoutMs + 120_000);
+
+				const kafka = services.kafka;
+				const obs = services.observability;
+				const topic = `load-${scenario.name}-${nanoid()}`;
+				const groupId = `load-group-${nanoid()}`;
+
+				// Setup: create topic and credential
+				await kafka.createTopic(topic, scenario.partitions ?? 1);
+
+				const credential = await api.credentials.createCredential({
+					name: `Kafka Load ${nanoid()}`,
+					type: 'kafka',
+					data: {
+						brokers: 'kafka:9092',
+						clientId: `load-${nanoid()}`,
+						ssl: false,
+						authentication: false,
+					},
+				});
+
+				// Build and create workflow
+				const workflowDef = buildKafkaTriggeredWorkflow({
+					topic,
+					groupId,
+					credentialId: credential.id,
+					credentialName: credential.name,
+					nodeCount: scenario.nodeCount,
+				});
+
+				const { workflowId, createdWorkflow } =
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+					await api.workflows.createWorkflowFromDefinition(workflowDef as any, {
+						makeUnique: true,
+					});
+
+				// Baseline memory
+				const memBefore = await collectMemoryMetrics(obs.metrics);
+				console.log(
+					`[LOAD] Baseline: heap=${memBefore.heapUsedMB.toFixed(1)}MB rss=${memBefore.rssMB.toFixed(1)}MB`,
+				);
+
+				let expectedExecutions: number;
+
+				if (scenario.loadType === 'preloaded') {
+					// Preloaded: publish all messages before activating
+					const publishResult = await preloadQueue(kafka, topic, {
+						messageCount: scenario.messageCount!,
+						payloadSize: scenario.payloadSize,
+					});
+					console.log(
+						`[LOAD] Preloaded ${publishResult.totalPublished} messages in ${publishResult.publishDurationMs}ms`,
+					);
+					expectedExecutions = scenario.messageCount!;
+
+					await api.workflows.activate(workflowId, createdWorkflow.versionId!);
+					await kafka.waitForConsumerGroup(groupId, { timeoutMs: 30_000 });
+				} else {
+					// Steady: activate first, then publish at rate
+					await api.workflows.activate(workflowId, createdWorkflow.versionId!);
+					await kafka.waitForConsumerGroup(groupId, { timeoutMs: 30_000 });
+
+					const publishResult = await publishAtRate(kafka, topic, {
+						ratePerSecond: scenario.ratePerSecond!,
+						durationSeconds: scenario.durationSeconds!,
+						payloadSize: scenario.payloadSize,
+					});
+					console.log(
+						`[LOAD] Published ${publishResult.totalPublished} messages in ${publishResult.actualDurationMs}ms`,
+					);
+					expectedExecutions = publishResult.totalPublished;
+				}
+
+				// Wait for executions
+				console.log(
+					`[LOAD] Waiting for ${expectedExecutions} executions (timeout: ${scenario.timeoutMs}ms)`,
+				);
+				const metrics = await waitForExecutions(api.workflows, workflowId, kafka, {
+					expectedCount: expectedExecutions,
+					groupId,
+					topic,
+					timeoutMs: scenario.timeoutMs,
+				});
+
+				// Final memory
+				const memAfter = await collectMemoryMetrics(obs.metrics);
+
+				// Attach results
+				await attachLoadTestResults(testInfo, scenario.name, metrics, memAfter);
+				await attachMetric(
+					testInfo,
+					`${scenario.name}-memory-delta`,
+					memAfter.heapUsedMB - memBefore.heapUsedMB,
+					'MB',
+				);
+
+				// Summary
+				console.log(
+					`[LOAD RESULT] ${scenario.name}\n` +
+						`  Resources: ${RESOURCE_MEMORY}GB RAM, ${RESOURCE_CPU} CPU\n` +
+						`  Completed: ${metrics.totalCompleted}/${expectedExecutions}\n` +
+						`  Errors: ${metrics.totalErrors}\n` +
+						`  Throughput: ${metrics.throughputPerSecond.toFixed(2)} exec/s\n` +
+						`  Duration avg: ${metrics.avgDurationMs.toFixed(0)}ms | ` +
+						`p50: ${metrics.p50DurationMs.toFixed(0)}ms | ` +
+						`p95: ${metrics.p95DurationMs.toFixed(0)}ms | ` +
+						`p99: ${metrics.p99DurationMs.toFixed(0)}ms\n` +
+						`  Memory: heap=${memAfter.heapUsedMB.toFixed(1)}MB rss=${memAfter.rssMB.toFixed(1)}MB ` +
+						`delta=${(memAfter.heapUsedMB - memBefore.heapUsedMB).toFixed(1)}MB`,
+				);
+
+				// Soft assertions - at least some executions should complete
+				expect(metrics.totalCompleted).toBeGreaterThan(0);
+				expect(metrics.totalCompleted).toBeGreaterThanOrEqual(Math.floor(expectedExecutions * 0.5));
+
+				// Cleanup
+				await api.workflows.deactivate(workflowId);
+			});
+		}
+	},
+);

--- a/packages/testing/playwright/tests/infrastructure/kafka-load/kafka-load.spec.ts
+++ b/packages/testing/playwright/tests/infrastructure/kafka-load/kafka-load.spec.ts
@@ -9,7 +9,6 @@ import {
 	type PayloadSize,
 } from '../../../utils/kafka-load-helper';
 import { buildKafkaTriggeredWorkflow } from '../../../utils/kafka-workflow-builder';
-import { attachMetric, collectMemorySnapshot } from '../../../utils/performance-helper';
 
 // Resource profile: override via env for different hardware profiles
 const RESOURCE_MEMORY = parseFloat(process.env.KAFKA_LOAD_MEMORY ?? '2');
@@ -89,7 +88,6 @@ test.describe(
 				test.setTimeout(scenario.timeoutMs + 120_000);
 
 				const kafka = services.kafka;
-				const obs = services.observability;
 				const topic = `load-${scenario.name}-${nanoid()}`;
 				const groupId = `load-group-${nanoid()}`;
 
@@ -121,12 +119,6 @@ test.describe(
 					{
 						makeUnique: true,
 					},
-				);
-
-				// Baseline memory
-				const memBefore = await collectMemorySnapshot(obs.metrics);
-				console.log(
-					`[LOAD] Baseline: heap=${memBefore.heapUsedMB.toFixed(1)}MB rss=${memBefore.rssMB.toFixed(1)}MB`,
 				);
 
 				let expectedExecutions: number;
@@ -171,17 +163,8 @@ test.describe(
 					timeoutMs: scenario.timeoutMs,
 				});
 
-				// Final memory
-				const memAfter = await collectMemorySnapshot(obs.metrics);
-
 				// Attach results
-				await attachLoadTestResults(testInfo, scenario.name, metrics, memAfter);
-				await attachMetric(
-					testInfo,
-					`${scenario.name}-memory-delta`,
-					memAfter.heapUsedMB - memBefore.heapUsedMB,
-					'MB',
-				);
+				await attachLoadTestResults(testInfo, scenario.name, metrics);
 
 				// Summary
 				console.log(
@@ -193,9 +176,7 @@ test.describe(
 						`  Duration avg: ${metrics.avgDurationMs.toFixed(0)}ms | ` +
 						`p50: ${metrics.p50DurationMs.toFixed(0)}ms | ` +
 						`p95: ${metrics.p95DurationMs.toFixed(0)}ms | ` +
-						`p99: ${metrics.p99DurationMs.toFixed(0)}ms\n` +
-						`  Memory: heap=${memAfter.heapUsedMB.toFixed(1)}MB rss=${memAfter.rssMB.toFixed(1)}MB ` +
-						`delta=${(memAfter.heapUsedMB - memBefore.heapUsedMB).toFixed(1)}MB`,
+						`p99: ${metrics.p99DurationMs.toFixed(0)}ms`,
 				);
 
 				// Soft assertions - at least some executions should complete

--- a/packages/testing/playwright/tests/infrastructure/kafka-load/kafka-load.spec.ts
+++ b/packages/testing/playwright/tests/infrastructure/kafka-load/kafka-load.spec.ts
@@ -180,7 +180,10 @@ test.describe(
 						`p99: ${metrics.p99DurationMs.toFixed(0)}ms`,
 				);
 
-				// Soft assertions - at least some executions should complete
+				// Lenient threshold (50%) — load tests use steady-rate publishing where
+				// the system may still be draining when the timeout expires.
+				// Throughput tests use a stricter 95% threshold since all messages
+				// are preloaded and the test waits for the counter to reach the target.
 				expect(metrics.totalCompleted).toBeGreaterThan(0);
 				expect(metrics.totalCompleted).toBeGreaterThanOrEqual(Math.floor(expectedExecutions * 0.5));
 

--- a/packages/testing/playwright/tests/infrastructure/kafka-load/trigger-throughput.spec.ts
+++ b/packages/testing/playwright/tests/infrastructure/kafka-load/trigger-throughput.spec.ts
@@ -1,19 +1,18 @@
 import { nanoid } from 'nanoid';
 
-import { test, expect } from '../../fixtures/base';
+import { test, expect } from '../../../fixtures/base';
 import { BASE_PERFORMANCE_PLANS } from 'n8n-containers/performance-plans';
-import { preloadQueue, type PayloadSize } from '../../utils/kafka-load-helper';
+import { preloadQueue, type PayloadSize } from '../../../utils/kafka-load-helper';
 import {
 	buildKafkaTriggeredWorkflow,
 	type NodeOutputSize,
-} from '../../utils/kafka-workflow-builder';
-import { attachMetric } from '../../utils/performance-helper';
+} from '../../../utils/kafka-workflow-builder';
+import { attachMetric, collectMemorySnapshot } from '../../../utils/performance-helper';
 import {
 	waitForThroughput,
 	getBaselineCounter,
-	collectMemoryFromMetrics,
 	attachThroughputResults,
-} from '../../utils/throughput-helper';
+} from '../../../utils/throughput-helper';
 
 const plan = BASE_PERFORMANCE_PLANS.enterprise;
 const MESSAGE_COUNT = parseInt(process.env.BENCHMARK_MESSAGES ?? '0', 10);
@@ -41,7 +40,7 @@ interface ThroughputScenario {
 
 const SCENARIOS: ThroughputScenario[] = [
 	{
-		name: 'kafka-1node-1k',
+		name: 'kafka-1-node-1KB-1k',
 		nodeCount: 1,
 		messageCount: 1_000,
 		payloadSize: '1KB',
@@ -50,7 +49,7 @@ const SCENARIOS: ThroughputScenario[] = [
 		timeoutMs: 120_000,
 	},
 	{
-		name: 'kafka-10nodes-5k',
+		name: 'kafka-10-nodes-1KB-5k',
 		nodeCount: 10,
 		messageCount: 5_000,
 		payloadSize: '1KB',
@@ -59,7 +58,7 @@ const SCENARIOS: ThroughputScenario[] = [
 		timeoutMs: 300_000,
 	},
 	{
-		name: 'kafka-30nodes-5k',
+		name: 'kafka-30-nodes-1KB-5k',
 		nodeCount: 30,
 		messageCount: 5_000,
 		payloadSize: '1KB',
@@ -68,7 +67,7 @@ const SCENARIOS: ThroughputScenario[] = [
 		timeoutMs: 300_000,
 	},
 	{
-		name: 'kafka-60nodes-5k',
+		name: 'kafka-60-nodes-1KB-5k',
 		nodeCount: 60,
 		messageCount: 5_000,
 		payloadSize: '1KB',
@@ -77,7 +76,7 @@ const SCENARIOS: ThroughputScenario[] = [
 		timeoutMs: 600_000,
 	},
 	{
-		name: 'kafka-10nodes-10kb-5k',
+		name: 'kafka-10-nodes-1KB-10kb-out-5k',
 		nodeCount: 10,
 		messageCount: 5_000,
 		payloadSize: '1KB',
@@ -86,7 +85,7 @@ const SCENARIOS: ThroughputScenario[] = [
 		timeoutMs: 300_000,
 	},
 	{
-		name: 'kafka-10nodes-100kb-5k',
+		name: 'kafka-10-nodes-1KB-100kb-out-5k',
 		nodeCount: 10,
 		messageCount: 5_000,
 		payloadSize: '1KB',
@@ -138,11 +137,12 @@ test.describe(
 					nodeOutputSize: scenario.nodeOutputSize,
 				});
 
-				const { workflowId, createdWorkflow } =
-					// eslint-disable-next-line @typescript-eslint/no-explicit-any
-					await api.workflows.createWorkflowFromDefinition(workflowDef as any, {
+				const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition(
+					workflowDef,
+					{
 						makeUnique: true,
-					});
+					},
+				);
 
 				// 4. Preload queue
 				const publishResult = await preloadQueue(kafka, topic, {
@@ -164,7 +164,7 @@ test.describe(
 				const baselineCounter = await getBaselineCounter(obs.metrics);
 
 				// 6. Collect baseline memory
-				const memBefore = await collectMemoryFromMetrics(obs.metrics);
+				const memBefore = await collectMemorySnapshot(obs.metrics);
 
 				// 7. Activate workflow and wait for consumer group
 				await api.workflows.activate(workflowId, createdWorkflow.versionId!);
@@ -183,7 +183,7 @@ test.describe(
 				});
 
 				// 9. Collect final memory
-				const memAfter = await collectMemoryFromMetrics(obs.metrics);
+				const memAfter = await collectMemorySnapshot(obs.metrics);
 
 				// 10. Attach results
 				await attachThroughputResults(testInfo, scenario.name, result, memAfter);

--- a/packages/testing/playwright/tests/infrastructure/kafka-load/trigger-throughput.spec.ts
+++ b/packages/testing/playwright/tests/infrastructure/kafka-load/trigger-throughput.spec.ts
@@ -76,6 +76,15 @@ const SCENARIOS: ThroughputScenario[] = [
 		timeoutMs: 600_000,
 	},
 	{
+		name: '10-nodes-100KB-noop-5k',
+		nodeCount: 10,
+		messageCount: 5_000,
+		payloadSize: '100KB',
+		nodeOutputSize: 'noop',
+		partitions: 3,
+		timeoutMs: 300_000,
+	},
+	{
 		name: '10-nodes-1KB-10kb-out-5k',
 		nodeCount: 10,
 		messageCount: 5_000,

--- a/packages/testing/playwright/tests/infrastructure/kafka-load/trigger-throughput.spec.ts
+++ b/packages/testing/playwright/tests/infrastructure/kafka-load/trigger-throughput.spec.ts
@@ -40,7 +40,7 @@ interface ThroughputScenario {
 
 const SCENARIOS: ThroughputScenario[] = [
 	{
-		name: 'kafka-1-node-1KB-1k',
+		name: '1-node-1KB-1k',
 		nodeCount: 1,
 		messageCount: 1_000,
 		payloadSize: '1KB',
@@ -49,7 +49,7 @@ const SCENARIOS: ThroughputScenario[] = [
 		timeoutMs: 120_000,
 	},
 	{
-		name: 'kafka-10-nodes-1KB-5k',
+		name: '10-nodes-1KB-5k',
 		nodeCount: 10,
 		messageCount: 5_000,
 		payloadSize: '1KB',
@@ -58,7 +58,7 @@ const SCENARIOS: ThroughputScenario[] = [
 		timeoutMs: 300_000,
 	},
 	{
-		name: 'kafka-30-nodes-1KB-5k',
+		name: '30-nodes-1KB-5k',
 		nodeCount: 30,
 		messageCount: 5_000,
 		payloadSize: '1KB',
@@ -67,7 +67,7 @@ const SCENARIOS: ThroughputScenario[] = [
 		timeoutMs: 300_000,
 	},
 	{
-		name: 'kafka-60-nodes-1KB-5k',
+		name: '60-nodes-1KB-5k',
 		nodeCount: 60,
 		messageCount: 5_000,
 		payloadSize: '1KB',
@@ -76,7 +76,7 @@ const SCENARIOS: ThroughputScenario[] = [
 		timeoutMs: 600_000,
 	},
 	{
-		name: 'kafka-10-nodes-1KB-10kb-out-5k',
+		name: '10-nodes-1KB-10kb-out-5k',
 		nodeCount: 10,
 		messageCount: 5_000,
 		payloadSize: '1KB',
@@ -85,7 +85,7 @@ const SCENARIOS: ThroughputScenario[] = [
 		timeoutMs: 300_000,
 	},
 	{
-		name: 'kafka-10-nodes-1KB-100kb-out-5k',
+		name: '10-nodes-1KB-100kb-out-5k',
 		nodeCount: 10,
 		messageCount: 5_000,
 		payloadSize: '1KB',

--- a/packages/testing/playwright/tests/infrastructure/kafka-load/trigger-throughput.spec.ts
+++ b/packages/testing/playwright/tests/infrastructure/kafka-load/trigger-throughput.spec.ts
@@ -1,7 +1,8 @@
+import type { MetricsHelper } from 'n8n-containers';
+import { BASE_PERFORMANCE_PLANS } from 'n8n-containers/performance-plans';
 import { nanoid } from 'nanoid';
 
 import { test, expect } from '../../../fixtures/base';
-import { BASE_PERFORMANCE_PLANS } from 'n8n-containers/performance-plans';
 import { preloadQueue, type PayloadSize } from '../../../utils/kafka-load-helper';
 import {
 	buildKafkaTriggeredWorkflow,
@@ -94,6 +95,36 @@ const SCENARIOS: ThroughputScenario[] = [
 	},
 ];
 
+async function collectDiagnostics(metrics: MetricsHelper, durationMs: number) {
+	const fmt = (v: number | undefined, unit = '') =>
+		v !== undefined ? `${v.toFixed(2)}${unit}` : 'N/A';
+
+	// Use the test duration (with padding) as the rate window so we capture
+	// the full burst rather than just the tail end after completion.
+	const windowSecs = Math.ceil(durationMs / 1000) + 30;
+	const window = `${windowSecs}s`;
+
+	// Try both with and without _total suffix — varies by exporter version
+	const [eventLoopLag, pgTxA, pgTxB, pgInsA, pgInsB, pgActive] = await Promise.all([
+		metrics.query('n8n_nodejs_eventloop_lag_seconds').catch(() => []),
+		metrics.query(`rate(pg_stat_database_xact_commit_total[${window}])`).catch(() => []),
+		metrics.query(`rate(pg_stat_database_xact_commit[${window}])`).catch(() => []),
+		metrics.query(`rate(pg_stat_database_tup_inserted_total[${window}])`).catch(() => []),
+		metrics.query(`rate(pg_stat_database_tup_inserted[${window}])`).catch(() => []),
+		metrics.query('pg_stat_activity_count').catch(() => []),
+	]);
+
+	const pgTxRate = pgTxA.length > 0 ? pgTxA : pgTxB;
+	const pgInsertRate = pgInsA.length > 0 ? pgInsA : pgInsB;
+
+	return {
+		eventLoopLag: fmt(eventLoopLag[0]?.value, 's'),
+		pgTxRate: fmt(pgTxRate[0]?.value, ' tx/s'),
+		pgInsertRate: fmt(pgInsertRate[0]?.value, ' rows/s'),
+		pgActiveConnections: fmt(pgActive[0]?.value),
+	};
+}
+
 test.describe(
 	'Trigger Throughput Benchmarks @capability:kafka @capability:observability @mode:postgres',
 	{
@@ -167,6 +198,7 @@ test.describe(
 				await kafka.waitForConsumerGroup(groupId, { timeoutMs: 30_000 });
 
 				// 8. Wait for throughput
+				// eslint-disable-next-line playwright/no-conditional-in-test
 				const nodeLabel = scenario.nodeOutputSize === 'noop' ? 'noop' : scenario.nodeOutputSize;
 				console.log(
 					`[BENCH] Draining ${messageCount} messages through ${scenario.nodeCount}-node (${nodeLabel}) workflow (timeout: ${scenario.timeoutMs}ms)`,
@@ -181,7 +213,17 @@ test.describe(
 				// 9. Attach results
 				await attachThroughputResults(testInfo, scenario.name, result);
 
-				// 10. Summary
+				// 10. Diagnostics — query PG and event loop metrics
+				const diagnostics = await collectDiagnostics(obs.metrics, result.durationMs);
+				console.log(
+					`[DIAGNOSTICS] ${scenario.name}\n` +
+						`  Event Loop Lag: ${diagnostics.eventLoopLag}\n` +
+						`  PG Transactions/s: ${diagnostics.pgTxRate}\n` +
+						`  PG Rows Inserted/s: ${diagnostics.pgInsertRate}\n` +
+						`  PG Active Connections: ${diagnostics.pgActiveConnections}`,
+				);
+
+				// 11. Summary
 				console.log(
 					`[BENCH RESULT] ${scenario.name}\n` +
 						`  Plan: enterprise (${plan.memory}GB RAM, ${plan.cpu} CPU)\n` +

--- a/packages/testing/playwright/tests/infrastructure/kafka-load/trigger-throughput.spec.ts
+++ b/packages/testing/playwright/tests/infrastructure/kafka-load/trigger-throughput.spec.ts
@@ -7,7 +7,6 @@ import {
 	buildKafkaTriggeredWorkflow,
 	type NodeOutputSize,
 } from '../../../utils/kafka-workflow-builder';
-import { attachMetric, collectMemorySnapshot } from '../../../utils/performance-helper';
 import {
 	waitForThroughput,
 	getBaselineCounter,
@@ -163,10 +162,7 @@ test.describe(
 				});
 				const baselineCounter = await getBaselineCounter(obs.metrics);
 
-				// 6. Collect baseline memory
-				const memBefore = await collectMemorySnapshot(obs.metrics);
-
-				// 7. Activate workflow and wait for consumer group
+				// 6. Activate workflow and wait for consumer group
 				await api.workflows.activate(workflowId, createdWorkflow.versionId!);
 				await kafka.waitForConsumerGroup(groupId, { timeoutMs: 30_000 });
 
@@ -182,19 +178,10 @@ test.describe(
 					baselineValue: baselineCounter,
 				});
 
-				// 9. Collect final memory
-				const memAfter = await collectMemorySnapshot(obs.metrics);
+				// 9. Attach results
+				await attachThroughputResults(testInfo, scenario.name, result);
 
-				// 10. Attach results
-				await attachThroughputResults(testInfo, scenario.name, result, memAfter);
-				await attachMetric(
-					testInfo,
-					`${scenario.name}-memory-delta`,
-					memAfter.heapUsedMB - memBefore.heapUsedMB,
-					'MB',
-				);
-
-				// 11. Summary
+				// 10. Summary
 				console.log(
 					`[BENCH RESULT] ${scenario.name}\n` +
 						`  Plan: enterprise (${plan.memory}GB RAM, ${plan.cpu} CPU)\n` +
@@ -202,16 +189,14 @@ test.describe(
 						`  Completed: ${result.totalCompleted}/${messageCount}\n` +
 						`  Throughput: ${result.avgExecPerSec.toFixed(1)} exec/s | ${result.actionsPerSec.toFixed(1)} actions/s\n` +
 						`  Peak: ${result.peakExecPerSec.toFixed(1)} exec/s | ${result.peakActionsPerSec.toFixed(1)} actions/s\n` +
-						`  Duration: ${(result.durationMs / 1000).toFixed(1)}s\n` +
-						`  Memory: heap=${memAfter.heapUsedMB.toFixed(1)}MB rss=${memAfter.rssMB.toFixed(1)}MB ` +
-						`delta=${(memAfter.heapUsedMB - memBefore.heapUsedMB).toFixed(1)}MB`,
+						`  Duration: ${(result.durationMs / 1000).toFixed(1)}s`,
 				);
 
-				// 12. Assertions
+				// 11. Assertions
 				expect(result.totalCompleted).toBeGreaterThan(0);
 				expect(result.totalCompleted).toBeGreaterThanOrEqual(Math.floor(messageCount * 0.95));
 
-				// 13. Cleanup
+				// 12. Cleanup
 				await api.workflows.deactivate(workflowId);
 			});
 		}

--- a/packages/testing/playwright/tests/performance/trigger-throughput.spec.ts
+++ b/packages/testing/playwright/tests/performance/trigger-throughput.spec.ts
@@ -1,0 +1,191 @@
+import { nanoid } from 'nanoid';
+
+import { test, expect } from '../../fixtures/base';
+import { BASE_PERFORMANCE_PLANS } from 'n8n-containers/performance-plans';
+import { preloadQueue, type PayloadSize } from '../../utils/kafka-load-helper';
+import { buildKafkaTriggeredWorkflow } from '../../utils/kafka-workflow-builder';
+import { attachMetric } from '../../utils/performance-helper';
+import {
+	waitForThroughput,
+	getBaselineCounter,
+	collectMemoryFromMetrics,
+	attachThroughputResults,
+} from '../../utils/throughput-helper';
+
+const plan = BASE_PERFORMANCE_PLANS.enterprise;
+const MESSAGE_COUNT = parseInt(process.env.BENCHMARK_MESSAGES ?? '0', 10);
+
+test.use({
+	capability: {
+		services: ['kafka', 'victoriaLogs', 'victoriaMetrics', 'vector'],
+		postgres: true,
+		resourceQuota: { memory: plan.memory, cpu: plan.cpu },
+		env: {
+			N8N_METRICS_INCLUDE_MESSAGE_EVENT_BUS_METRICS: 'true',
+		},
+	},
+});
+
+interface ThroughputScenario {
+	name: string;
+	nodeCount: number;
+	messageCount: number;
+	payloadSize: PayloadSize;
+	partitions: number;
+	timeoutMs: number;
+}
+
+const SCENARIOS: ThroughputScenario[] = [
+	{
+		name: 'kafka-1node-1k',
+		nodeCount: 1,
+		messageCount: 1_000,
+		payloadSize: '1KB',
+		partitions: 3,
+		timeoutMs: 120_000,
+	},
+	{
+		name: 'kafka-10nodes-5k',
+		nodeCount: 10,
+		messageCount: 5_000,
+		payloadSize: '1KB',
+		partitions: 3,
+		timeoutMs: 300_000,
+	},
+	{
+		name: 'kafka-30nodes-5k',
+		nodeCount: 30,
+		messageCount: 5_000,
+		payloadSize: '1KB',
+		partitions: 3,
+		timeoutMs: 300_000,
+	},
+	{
+		name: 'kafka-60nodes-5k',
+		nodeCount: 60,
+		messageCount: 5_000,
+		payloadSize: '1KB',
+		partitions: 3,
+		timeoutMs: 600_000,
+	},
+];
+
+test.describe(
+	'Trigger Throughput Benchmarks @capability:kafka @capability:observability @mode:postgres',
+	{
+		annotation: [{ type: 'owner', description: 'Catalysts' }],
+	},
+	() => {
+		for (const scenario of SCENARIOS) {
+			const messageCount = MESSAGE_COUNT || scenario.messageCount;
+
+			test(`${scenario.name}`, async ({ api, services }, testInfo) => {
+				test.setTimeout(scenario.timeoutMs + 120_000);
+
+				const kafka = services.kafka;
+				const obs = services.observability;
+				const topic = `bench-${scenario.name}-${nanoid()}`;
+				const groupId = `bench-group-${nanoid()}`;
+
+				// 1. Create topic
+				await kafka.createTopic(topic, scenario.partitions);
+
+				// 2. Create credential
+				const credential = await api.credentials.createCredential({
+					name: `Kafka Bench ${nanoid()}`,
+					type: 'kafka',
+					data: {
+						brokers: 'kafka:9092',
+						clientId: `bench-${nanoid()}`,
+						ssl: false,
+						authentication: false,
+					},
+				});
+
+				// 3. Build and create workflow
+				const workflowDef = buildKafkaTriggeredWorkflow({
+					topic,
+					groupId,
+					credentialId: credential.id,
+					credentialName: credential.name,
+					nodeCount: scenario.nodeCount,
+				});
+
+				const { workflowId, createdWorkflow } =
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+					await api.workflows.createWorkflowFromDefinition(workflowDef as any, {
+						makeUnique: true,
+					});
+
+				// 4. Preload queue
+				const publishResult = await preloadQueue(kafka, topic, {
+					messageCount,
+					payloadSize: scenario.payloadSize,
+				});
+				console.log(
+					`[BENCH] Preloaded ${publishResult.totalPublished} messages in ${publishResult.publishDurationMs}ms`,
+				);
+
+				// 5. Wait for VictoriaMetrics to be scraping n8n, then record baseline
+				// We check for a default metric (always present) rather than the success counter
+				// which only appears after the first workflow completes.
+				await obs.metrics.waitForMetric('n8n_version_info', {
+					timeoutMs: 30_000,
+					intervalMs: 2000,
+					predicate: (results) => results.length > 0,
+				});
+				const baselineCounter = await getBaselineCounter(obs.metrics);
+
+				// 6. Collect baseline memory
+				const memBefore = await collectMemoryFromMetrics(obs.metrics);
+
+				// 7. Activate workflow and wait for consumer group
+				await api.workflows.activate(workflowId, createdWorkflow.versionId!);
+				await kafka.waitForConsumerGroup(groupId, { timeoutMs: 30_000 });
+
+				// 8. Wait for throughput
+				console.log(
+					`[BENCH] Draining ${messageCount} messages through ${scenario.nodeCount}-node workflow (timeout: ${scenario.timeoutMs}ms)`,
+				);
+				const result = await waitForThroughput(obs.metrics, {
+					expectedCount: messageCount,
+					nodeCount: scenario.nodeCount,
+					timeoutMs: scenario.timeoutMs,
+					baselineValue: baselineCounter,
+				});
+
+				// 9. Collect final memory
+				const memAfter = await collectMemoryFromMetrics(obs.metrics);
+
+				// 10. Attach results
+				await attachThroughputResults(testInfo, scenario.name, result, memAfter);
+				await attachMetric(
+					testInfo,
+					`${scenario.name}-memory-delta`,
+					memAfter.heapUsedMB - memBefore.heapUsedMB,
+					'MB',
+				);
+
+				// 11. Summary
+				console.log(
+					`[BENCH RESULT] ${scenario.name}\n` +
+						`  Plan: enterprise (${plan.memory}GB RAM, ${plan.cpu} CPU)\n` +
+						`  Nodes: ${scenario.nodeCount} | Messages: ${messageCount}\n` +
+						`  Completed: ${result.totalCompleted}/${messageCount}\n` +
+						`  Throughput: ${result.avgExecPerSec.toFixed(1)} exec/s | ${result.actionsPerSec.toFixed(1)} actions/s\n` +
+						`  Peak: ${result.peakExecPerSec.toFixed(1)} exec/s | ${result.peakActionsPerSec.toFixed(1)} actions/s\n` +
+						`  Duration: ${(result.durationMs / 1000).toFixed(1)}s\n` +
+						`  Memory: heap=${memAfter.heapUsedMB.toFixed(1)}MB rss=${memAfter.rssMB.toFixed(1)}MB ` +
+						`delta=${(memAfter.heapUsedMB - memBefore.heapUsedMB).toFixed(1)}MB`,
+				);
+
+				// 12. Assertions
+				expect(result.totalCompleted).toBeGreaterThan(0);
+				expect(result.totalCompleted).toBeGreaterThanOrEqual(Math.floor(messageCount * 0.95));
+
+				// 13. Cleanup
+				await api.workflows.deactivate(workflowId);
+			});
+		}
+	},
+);

--- a/packages/testing/playwright/tests/performance/trigger-throughput.spec.ts
+++ b/packages/testing/playwright/tests/performance/trigger-throughput.spec.ts
@@ -3,7 +3,10 @@ import { nanoid } from 'nanoid';
 import { test, expect } from '../../fixtures/base';
 import { BASE_PERFORMANCE_PLANS } from 'n8n-containers/performance-plans';
 import { preloadQueue, type PayloadSize } from '../../utils/kafka-load-helper';
-import { buildKafkaTriggeredWorkflow } from '../../utils/kafka-workflow-builder';
+import {
+	buildKafkaTriggeredWorkflow,
+	type NodeOutputSize,
+} from '../../utils/kafka-workflow-builder';
 import { attachMetric } from '../../utils/performance-helper';
 import {
 	waitForThroughput,
@@ -31,6 +34,7 @@ interface ThroughputScenario {
 	nodeCount: number;
 	messageCount: number;
 	payloadSize: PayloadSize;
+	nodeOutputSize: NodeOutputSize;
 	partitions: number;
 	timeoutMs: number;
 }
@@ -41,6 +45,7 @@ const SCENARIOS: ThroughputScenario[] = [
 		nodeCount: 1,
 		messageCount: 1_000,
 		payloadSize: '1KB',
+		nodeOutputSize: 'noop',
 		partitions: 3,
 		timeoutMs: 120_000,
 	},
@@ -49,6 +54,7 @@ const SCENARIOS: ThroughputScenario[] = [
 		nodeCount: 10,
 		messageCount: 5_000,
 		payloadSize: '1KB',
+		nodeOutputSize: 'noop',
 		partitions: 3,
 		timeoutMs: 300_000,
 	},
@@ -57,6 +63,7 @@ const SCENARIOS: ThroughputScenario[] = [
 		nodeCount: 30,
 		messageCount: 5_000,
 		payloadSize: '1KB',
+		nodeOutputSize: 'noop',
 		partitions: 3,
 		timeoutMs: 300_000,
 	},
@@ -65,6 +72,25 @@ const SCENARIOS: ThroughputScenario[] = [
 		nodeCount: 60,
 		messageCount: 5_000,
 		payloadSize: '1KB',
+		nodeOutputSize: 'noop',
+		partitions: 3,
+		timeoutMs: 600_000,
+	},
+	{
+		name: 'kafka-10nodes-10kb-5k',
+		nodeCount: 10,
+		messageCount: 5_000,
+		payloadSize: '1KB',
+		nodeOutputSize: '10KB',
+		partitions: 3,
+		timeoutMs: 300_000,
+	},
+	{
+		name: 'kafka-10nodes-100kb-5k',
+		nodeCount: 10,
+		messageCount: 5_000,
+		payloadSize: '1KB',
+		nodeOutputSize: '100KB',
 		partitions: 3,
 		timeoutMs: 600_000,
 	},
@@ -109,6 +135,7 @@ test.describe(
 					credentialId: credential.id,
 					credentialName: credential.name,
 					nodeCount: scenario.nodeCount,
+					nodeOutputSize: scenario.nodeOutputSize,
 				});
 
 				const { workflowId, createdWorkflow } =
@@ -144,8 +171,9 @@ test.describe(
 				await kafka.waitForConsumerGroup(groupId, { timeoutMs: 30_000 });
 
 				// 8. Wait for throughput
+				const nodeLabel = scenario.nodeOutputSize === 'noop' ? 'noop' : scenario.nodeOutputSize;
 				console.log(
-					`[BENCH] Draining ${messageCount} messages through ${scenario.nodeCount}-node workflow (timeout: ${scenario.timeoutMs}ms)`,
+					`[BENCH] Draining ${messageCount} messages through ${scenario.nodeCount}-node (${nodeLabel}) workflow (timeout: ${scenario.timeoutMs}ms)`,
 				);
 				const result = await waitForThroughput(obs.metrics, {
 					expectedCount: messageCount,
@@ -170,7 +198,7 @@ test.describe(
 				console.log(
 					`[BENCH RESULT] ${scenario.name}\n` +
 						`  Plan: enterprise (${plan.memory}GB RAM, ${plan.cpu} CPU)\n` +
-						`  Nodes: ${scenario.nodeCount} | Messages: ${messageCount}\n` +
+						`  Nodes: ${scenario.nodeCount} (${nodeLabel}) | Messages: ${messageCount}\n` +
 						`  Completed: ${result.totalCompleted}/${messageCount}\n` +
 						`  Throughput: ${result.avgExecPerSec.toFixed(1)} exec/s | ${result.actionsPerSec.toFixed(1)} actions/s\n` +
 						`  Peak: ${result.peakExecPerSec.toFixed(1)} exec/s | ${result.peakActionsPerSec.toFixed(1)} actions/s\n` +

--- a/packages/testing/playwright/utils/kafka-load-helper.ts
+++ b/packages/testing/playwright/utils/kafka-load-helper.ts
@@ -139,8 +139,10 @@ export async function waitForExecutions(
 				const durations = await sampleExecutionDurations(workflowApi, workflowId);
 				return buildMetrics(expectedCount, 0, durationMs, durations);
 			}
-		} catch (err) {
-			console.log(`[LOAD] Lag check error: ${err instanceof Error ? err.message : String(err)}`);
+		} catch (error) {
+			console.log(
+				`[LOAD] Lag check error: ${error instanceof Error ? error.message : String(error)}`,
+			);
 		}
 
 		await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));

--- a/packages/testing/playwright/utils/kafka-load-helper.ts
+++ b/packages/testing/playwright/utils/kafka-load-helper.ts
@@ -123,26 +123,29 @@ export async function waitForExecutions(
 	let lastLag = -1;
 
 	while (Date.now() < deadline) {
+		let lagInfo;
 		try {
-			const lagInfo = await kafkaHelper.getConsumerGroupLag(groupId, topic);
-
-			if (lagInfo.totalLag !== lastLag) {
-				const consumed = expectedCount - lagInfo.totalLag;
-				console.log(`[LOAD] Consumed: ${consumed}/${expectedCount} (lag=${lagInfo.totalLag})`);
-				lastLag = lagInfo.totalLag;
-			}
-
-			if (lagInfo.totalLag === 0) {
-				// All messages consumed - wait briefly for last execution to finish
-				await new Promise((resolve) => setTimeout(resolve, 3000));
-				const durationMs = Date.now() - startTime;
-				const durations = await sampleExecutionDurations(workflowApi, workflowId);
-				return buildMetrics(expectedCount, 0, durationMs, durations);
-			}
+			lagInfo = await kafkaHelper.getConsumerGroupLag(groupId, topic);
 		} catch (error) {
 			console.log(
 				`[LOAD] Lag check error: ${error instanceof Error ? error.message : String(error)}`,
 			);
+			await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+			continue;
+		}
+
+		if (lagInfo.totalLag !== lastLag) {
+			const consumed = expectedCount - lagInfo.totalLag;
+			console.log(`[LOAD] Consumed: ${consumed}/${expectedCount} (lag=${lagInfo.totalLag})`);
+			lastLag = lagInfo.totalLag;
+		}
+
+		if (lagInfo.totalLag === 0) {
+			// All messages consumed - wait briefly for last execution to finish
+			await new Promise((resolve) => setTimeout(resolve, 3000));
+			const durationMs = Date.now() - startTime;
+			const durations = await sampleExecutionDurations(workflowApi, workflowId);
+			return buildMetrics(expectedCount, 0, durationMs, durations);
 		}
 
 		await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));

--- a/packages/testing/playwright/utils/kafka-load-helper.ts
+++ b/packages/testing/playwright/utils/kafka-load-helper.ts
@@ -203,7 +203,6 @@ export async function attachLoadTestResults(
 	testInfo: TestInfo,
 	label: string,
 	metrics: ExecutionMetrics,
-	memory: { heapUsedMB: number; rssMB: number },
 ): Promise<void> {
 	await attachMetric(testInfo, `${label}-executions-completed`, metrics.totalCompleted, 'count');
 	await attachMetric(testInfo, `${label}-executions-errors`, metrics.totalErrors, 'count');
@@ -212,7 +211,5 @@ export async function attachLoadTestResults(
 	await attachMetric(testInfo, `${label}-duration-p50`, metrics.p50DurationMs, 'ms');
 	await attachMetric(testInfo, `${label}-duration-p95`, metrics.p95DurationMs, 'ms');
 	await attachMetric(testInfo, `${label}-duration-p99`, metrics.p99DurationMs, 'ms');
-	await attachMetric(testInfo, `${label}-memory-heap`, memory.heapUsedMB, 'MB');
-	await attachMetric(testInfo, `${label}-memory-rss`, memory.rssMB, 'MB');
 	await attachMetric(testInfo, `${label}-total-duration`, metrics.durationMs, 'ms');
 }

--- a/packages/testing/playwright/utils/kafka-load-helper.ts
+++ b/packages/testing/playwright/utils/kafka-load-helper.ts
@@ -18,7 +18,7 @@ import type { WorkflowApiHelper } from '../services/workflow-api-helper';
 export const PAYLOAD_PROFILES = {
 	'1KB': 1024,
 	'10KB': 10240,
-	'1MB': 1048576,
+	'100KB': 102400,
 } as const;
 
 export type PayloadSize = keyof typeof PAYLOAD_PROFILES;

--- a/packages/testing/playwright/utils/kafka-load-helper.ts
+++ b/packages/testing/playwright/utils/kafka-load-helper.ts
@@ -73,8 +73,12 @@ export async function preloadQueue(
 		value: { ...payload, index: i },
 	}));
 
+	// Scale batch size down for large payloads to stay under Kafka's message.max.bytes
+	const payloadBytes = PAYLOAD_PROFILES[payloadSize];
+	const batchSize = payloadBytes >= 10240 ? 5 : 1000;
+
 	const startTime = Date.now();
-	await kafka.publishBatch(topic, messages, { batchSize: 1000 });
+	await kafka.publishBatch(topic, messages, { batchSize });
 
 	return { totalPublished: messageCount, publishDurationMs: Date.now() - startTime };
 }

--- a/packages/testing/playwright/utils/kafka-load-helper.ts
+++ b/packages/testing/playwright/utils/kafka-load-helper.ts
@@ -1,8 +1,17 @@
+/**
+ * Kafka load test helpers — consumer-group-lag completion tracking.
+ *
+ * Use this approach when you need per-message tracking and duration statistics
+ * from the REST API. Better for load tests measuring individual execution performance.
+ *
+ * For sustained throughput measurement with per-interval sampling, use
+ * `throughput-helper.ts` instead.
+ */
 import type { TestInfo } from '@playwright/test';
-import type { KafkaHelper, MetricsHelper } from 'n8n-containers';
+import type { KafkaHelper } from 'n8n-containers';
 
-import type { WorkflowApiHelper } from '../services/workflow-api-helper';
 import { attachMetric } from './performance-helper';
+import type { WorkflowApiHelper } from '../services/workflow-api-helper';
 
 // --- Payload sizes ---
 
@@ -186,41 +195,6 @@ function buildMetrics(
 		p95DurationMs: percentile(durations, 95),
 		p99DurationMs: percentile(durations, 99),
 	};
-}
-
-// --- Memory collection ---
-
-const HEAP_USED_QUERY = 'n8n_nodejs_heap_size_used_bytes / 1024 / 1024';
-const RSS_QUERY = 'n8n_process_resident_memory_bytes / 1024 / 1024';
-
-/**
- * Waits for VictoriaMetrics to have scraped at least one data point,
- * then returns the current memory metrics.
- */
-export async function collectMemoryMetrics(
-	metrics: MetricsHelper,
-	options: { waitForScrape?: boolean } = {},
-): Promise<{ heapUsedMB: number; rssMB: number }> {
-	if (options.waitForScrape) {
-		// Wait up to 15s for VictoriaMetrics to have a real scrape
-		await metrics.waitForMetric(HEAP_USED_QUERY, {
-			timeoutMs: 15_000,
-			intervalMs: 2000,
-			predicate: (results) => results.length > 0 && results[0].value > 0,
-		});
-	}
-	try {
-		const [heapResult, rssResult] = await Promise.all([
-			metrics.query(HEAP_USED_QUERY),
-			metrics.query(RSS_QUERY),
-		]);
-		return {
-			heapUsedMB: heapResult[0]?.value ?? 0,
-			rssMB: rssResult[0]?.value ?? 0,
-		};
-	} catch {
-		return { heapUsedMB: 0, rssMB: 0 };
-	}
 }
 
 // --- Result reporting ---

--- a/packages/testing/playwright/utils/kafka-load-helper.ts
+++ b/packages/testing/playwright/utils/kafka-load-helper.ts
@@ -1,0 +1,244 @@
+import type { TestInfo } from '@playwright/test';
+import type { KafkaHelper, MetricsHelper } from 'n8n-containers';
+
+import type { WorkflowApiHelper } from '../services/workflow-api-helper';
+import { attachMetric } from './performance-helper';
+
+// --- Payload sizes ---
+
+export const PAYLOAD_PROFILES = {
+	'1KB': 1024,
+	'10KB': 10240,
+	'1MB': 1048576,
+} as const;
+
+export type PayloadSize = keyof typeof PAYLOAD_PROFILES;
+
+export function generatePayload(sizeBytes: number): object {
+	const base = { timestamp: Date.now(), index: 0, data: '' };
+	const baseSize = JSON.stringify(base).length;
+	const paddingSize = Math.max(0, sizeBytes - baseSize);
+	return { ...base, data: 'x'.repeat(paddingSize) };
+}
+
+// --- Publishing ---
+
+export async function publishAtRate(
+	kafka: KafkaHelper,
+	topic: string,
+	options: {
+		ratePerSecond: number;
+		durationSeconds: number;
+		payloadSize: PayloadSize;
+	},
+): Promise<{ totalPublished: number; actualDurationMs: number }> {
+	const { ratePerSecond, durationSeconds, payloadSize } = options;
+	const payload = generatePayload(PAYLOAD_PROFILES[payloadSize]);
+	const intervalMs = 1000 / ratePerSecond;
+	const totalMessages = ratePerSecond * durationSeconds;
+	const startTime = Date.now();
+
+	for (let i = 0; i < totalMessages; i++) {
+		const targetTime = startTime + i * intervalMs;
+		const now = Date.now();
+		if (now < targetTime) {
+			await new Promise((resolve) => setTimeout(resolve, targetTime - now));
+		}
+		await kafka.publish(topic, { ...payload, index: i });
+	}
+
+	return { totalPublished: totalMessages, actualDurationMs: Date.now() - startTime };
+}
+
+export async function preloadQueue(
+	kafka: KafkaHelper,
+	topic: string,
+	options: {
+		messageCount: number;
+		payloadSize: PayloadSize;
+	},
+): Promise<{ totalPublished: number; publishDurationMs: number }> {
+	const { messageCount, payloadSize } = options;
+	const payload = generatePayload(PAYLOAD_PROFILES[payloadSize]);
+	const messages = Array.from({ length: messageCount }, (_, i) => ({
+		value: { ...payload, index: i },
+	}));
+
+	const startTime = Date.now();
+	await kafka.publishBatch(topic, messages, { batchSize: 1000 });
+
+	return { totalPublished: messageCount, publishDurationMs: Date.now() - startTime };
+}
+
+// --- Execution metrics ---
+
+export interface ExecutionMetrics {
+	totalCompleted: number;
+	totalErrors: number;
+	durationMs: number;
+	throughputPerSecond: number;
+	executionDurations: number[];
+	avgDurationMs: number;
+	p50DurationMs: number;
+	p95DurationMs: number;
+	p99DurationMs: number;
+}
+
+function percentile(sorted: number[], p: number): number {
+	if (sorted.length === 0) return 0;
+	const index = Math.ceil((p / 100) * sorted.length) - 1;
+	return sorted[Math.max(0, index)];
+}
+
+/**
+ * Waits for all Kafka messages to be consumed by polling consumer group lag.
+ * When lag reaches 0, all messages have been consumed and executions triggered.
+ * Uses REST API sample for duration statistics.
+ */
+export async function waitForExecutions(
+	workflowApi: WorkflowApiHelper,
+	workflowId: string,
+	kafkaHelper: KafkaHelper,
+	options: {
+		expectedCount: number;
+		groupId: string;
+		topic: string;
+		timeoutMs: number;
+		pollIntervalMs?: number;
+	},
+): Promise<ExecutionMetrics> {
+	const { expectedCount, groupId, topic, timeoutMs, pollIntervalMs = 2000 } = options;
+
+	const startTime = Date.now();
+	const deadline = startTime + timeoutMs;
+	let lastLag = -1;
+
+	while (Date.now() < deadline) {
+		try {
+			const lagInfo = await kafkaHelper.getConsumerGroupLag(groupId, topic);
+
+			if (lagInfo.totalLag !== lastLag) {
+				const consumed = expectedCount - lagInfo.totalLag;
+				console.log(`[LOAD] Consumed: ${consumed}/${expectedCount} (lag=${lagInfo.totalLag})`);
+				lastLag = lagInfo.totalLag;
+			}
+
+			if (lagInfo.totalLag === 0) {
+				// All messages consumed - wait briefly for last execution to finish
+				await new Promise((resolve) => setTimeout(resolve, 3000));
+				const durationMs = Date.now() - startTime;
+				const durations = await sampleExecutionDurations(workflowApi, workflowId);
+				return buildMetrics(expectedCount, 0, durationMs, durations);
+			}
+		} catch (err) {
+			console.log(`[LOAD] Lag check error: ${err instanceof Error ? err.message : String(err)}`);
+		}
+
+		await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+	}
+
+	// Timeout - return partial results
+	const durationMs = Date.now() - startTime;
+	let consumed = 0;
+	try {
+		const lagInfo = await kafkaHelper.getConsumerGroupLag(groupId, topic);
+		consumed = expectedCount - lagInfo.totalLag;
+	} catch {
+		// Fall back to REST API count
+		const executions = await workflowApi.getExecutions(workflowId, 100);
+		consumed = executions.length;
+	}
+	const durations = await sampleExecutionDurations(workflowApi, workflowId);
+	return buildMetrics(consumed, 0, durationMs, durations);
+}
+
+/**
+ * Fetches a sample of recent executions to calculate duration statistics.
+ * The REST API has a page size limit, but a sample of 100 is sufficient for percentiles.
+ */
+async function sampleExecutionDurations(
+	workflowApi: WorkflowApiHelper,
+	workflowId: string,
+): Promise<number[]> {
+	const executions = await workflowApi.getExecutions(workflowId, 100);
+	return executions
+		.filter((e) => e.startedAt && e.stoppedAt)
+		.map((e) => new Date(e.stoppedAt!).getTime() - new Date(e.startedAt!).getTime())
+		.sort((a, b) => a - b);
+}
+
+function buildMetrics(
+	successCount: number,
+	errorCount: number,
+	durationMs: number,
+	durations: number[],
+): ExecutionMetrics {
+	const totalCompleted = successCount + errorCount;
+	return {
+		totalCompleted,
+		totalErrors: errorCount,
+		durationMs,
+		throughputPerSecond: durationMs > 0 ? (totalCompleted / durationMs) * 1000 : 0,
+		executionDurations: durations,
+		avgDurationMs:
+			durations.length > 0 ? durations.reduce((a, b) => a + b, 0) / durations.length : 0,
+		p50DurationMs: percentile(durations, 50),
+		p95DurationMs: percentile(durations, 95),
+		p99DurationMs: percentile(durations, 99),
+	};
+}
+
+// --- Memory collection ---
+
+const HEAP_USED_QUERY = 'n8n_nodejs_heap_size_used_bytes / 1024 / 1024';
+const RSS_QUERY = 'n8n_process_resident_memory_bytes / 1024 / 1024';
+
+/**
+ * Waits for VictoriaMetrics to have scraped at least one data point,
+ * then returns the current memory metrics.
+ */
+export async function collectMemoryMetrics(
+	metrics: MetricsHelper,
+	options: { waitForScrape?: boolean } = {},
+): Promise<{ heapUsedMB: number; rssMB: number }> {
+	if (options.waitForScrape) {
+		// Wait up to 15s for VictoriaMetrics to have a real scrape
+		await metrics.waitForMetric(HEAP_USED_QUERY, {
+			timeoutMs: 15_000,
+			intervalMs: 2000,
+			predicate: (results) => results.length > 0 && results[0].value > 0,
+		});
+	}
+	try {
+		const [heapResult, rssResult] = await Promise.all([
+			metrics.query(HEAP_USED_QUERY),
+			metrics.query(RSS_QUERY),
+		]);
+		return {
+			heapUsedMB: heapResult[0]?.value ?? 0,
+			rssMB: rssResult[0]?.value ?? 0,
+		};
+	} catch {
+		return { heapUsedMB: 0, rssMB: 0 };
+	}
+}
+
+// --- Result reporting ---
+
+export async function attachLoadTestResults(
+	testInfo: TestInfo,
+	label: string,
+	metrics: ExecutionMetrics,
+	memory: { heapUsedMB: number; rssMB: number },
+): Promise<void> {
+	await attachMetric(testInfo, `${label}-executions-completed`, metrics.totalCompleted, 'count');
+	await attachMetric(testInfo, `${label}-executions-errors`, metrics.totalErrors, 'count');
+	await attachMetric(testInfo, `${label}-throughput`, metrics.throughputPerSecond, 'exec/s');
+	await attachMetric(testInfo, `${label}-duration-avg`, metrics.avgDurationMs, 'ms');
+	await attachMetric(testInfo, `${label}-duration-p50`, metrics.p50DurationMs, 'ms');
+	await attachMetric(testInfo, `${label}-duration-p95`, metrics.p95DurationMs, 'ms');
+	await attachMetric(testInfo, `${label}-duration-p99`, metrics.p99DurationMs, 'ms');
+	await attachMetric(testInfo, `${label}-memory-heap`, memory.heapUsedMB, 'MB');
+	await attachMetric(testInfo, `${label}-memory-rss`, memory.rssMB, 'MB');
+	await attachMetric(testInfo, `${label}-total-duration`, metrics.durationMs, 'ms');
+}

--- a/packages/testing/playwright/utils/kafka-workflow-builder.ts
+++ b/packages/testing/playwright/utils/kafka-workflow-builder.ts
@@ -1,3 +1,6 @@
+import type { IConnections, INode, IWorkflowBase } from 'n8n-workflow';
+import { NodeConnectionTypes } from 'n8n-workflow';
+
 /**
  * Node output modes for controlling execution data volume per node.
  * - `noop`: NoOp nodes — minimal output, tests pure engine overhead.
@@ -47,7 +50,7 @@ function buildCodeNodeParams(size: Exclude<NodeOutputSize, 'noop'>) {
  *   This tests realistic DB write pressure since n8n stores all node outputs
  *   as a single accumulated blob per execution.
  */
-export function buildKafkaTriggeredWorkflow(options: KafkaWorkflowOptions) {
+export function buildKafkaTriggeredWorkflow(options: KafkaWorkflowOptions): Partial<IWorkflowBase> {
 	const {
 		topic,
 		groupId,
@@ -57,11 +60,8 @@ export function buildKafkaTriggeredWorkflow(options: KafkaWorkflowOptions) {
 		nodeOutputSize = 'noop',
 	} = options;
 
-	const nodes: Array<Record<string, unknown>> = [];
-	const connections: Record<
-		string,
-		{ main: Array<Array<{ node: string; type: string; index: number }>> }
-	> = {};
+	const nodes: INode[] = [];
+	const connections: IConnections = {};
 
 	nodes.push({
 		id: 'trigger',
@@ -105,11 +105,12 @@ export function buildKafkaTriggeredWorkflow(options: KafkaWorkflowOptions) {
 				type: 'n8n-nodes-base.noOp',
 				typeVersion: 1,
 				position: [i * 200, 0] as [number, number],
+				parameters: {},
 			});
 		}
 
 		connections[previousNodeName] = {
-			main: [[{ node: nodeName, type: 'main', index: 0 }]],
+			[NodeConnectionTypes.Main]: [[{ node: nodeName, type: NodeConnectionTypes.Main, index: 0 }]],
 		};
 		previousNodeName = nodeName;
 	}

--- a/packages/testing/playwright/utils/kafka-workflow-builder.ts
+++ b/packages/testing/playwright/utils/kafka-workflow-builder.ts
@@ -1,18 +1,61 @@
+/**
+ * Node output modes for controlling execution data volume per node.
+ * - `noop`: NoOp nodes — minimal output, tests pure engine overhead.
+ * - `10KB` / `100KB` / `1MB`: Code nodes that generate random data at that size.
+ *   Tests realistic DB write pressure since execution data accumulates per node.
+ */
+export type NodeOutputSize = 'noop' | '10KB' | '100KB' | '1MB';
+
 interface KafkaWorkflowOptions {
 	topic: string;
 	groupId: string;
 	credentialId: string;
 	credentialName: string;
 	nodeCount: number;
+	nodeOutputSize?: NodeOutputSize;
+}
+
+const OUTPUT_SIZE_BYTES: Record<Exclude<NodeOutputSize, 'noop'>, number> = {
+	'10KB': 10_000,
+	'100KB': 100_000,
+	'1MB': 1_000_000,
+};
+
+function buildCodeNodeParams(size: Exclude<NodeOutputSize, 'noop'>) {
+	const bytes = OUTPUT_SIZE_BYTES[size];
+	// Generate a deterministic padding string to avoid runtime randomness overhead.
+	// The Code node outputs the incoming item plus a `payload` field of the target size.
+	const code = [
+		`const size = ${bytes};`,
+		`const pad = 'x'.repeat(size);`,
+		`return $input.all().map(item => ({`,
+		`  json: { ...item.json, payload: pad }`,
+		`}));`,
+	].join('\n');
+
+	return {
+		jsCode: code,
+		mode: 'runOnceForAllItems',
+	};
 }
 
 /**
- * Generates a workflow definition with a KafkaTrigger followed by N chained NoOp nodes.
- * Each node in the chain writes execution state to DB, so this tests engine overhead
- * at different workflow depths without node-specific processing cost.
+ * Generates a workflow with a KafkaTrigger followed by N chained nodes.
+ * Node type depends on `nodeOutputSize`:
+ * - `noop` (default): NoOp nodes with minimal output — tests pure engine overhead.
+ * - `10KB`/`100KB`/`1MB`: Code nodes that pad each item with data at that size.
+ *   This tests realistic DB write pressure since n8n stores all node outputs
+ *   as a single accumulated blob per execution.
  */
 export function buildKafkaTriggeredWorkflow(options: KafkaWorkflowOptions) {
-	const { topic, groupId, credentialId, credentialName, nodeCount } = options;
+	const {
+		topic,
+		groupId,
+		credentialId,
+		credentialName,
+		nodeCount,
+		nodeOutputSize = 'noop',
+	} = options;
 
 	const nodes: Array<Record<string, unknown>> = [];
 	const connections: Record<
@@ -40,17 +83,30 @@ export function buildKafkaTriggeredWorkflow(options: KafkaWorkflowOptions) {
 		},
 	});
 
+	const useCodeNode = nodeOutputSize !== 'noop';
 	let previousNodeName = 'Kafka Trigger';
-	for (let i = 1; i <= nodeCount; i++) {
-		const nodeName = `NoOp ${i}`;
 
-		nodes.push({
-			id: String(i + 1),
-			name: nodeName,
-			type: 'n8n-nodes-base.noOp',
-			typeVersion: 1,
-			position: [i * 200, 0] as [number, number],
-		});
+	for (let i = 1; i <= nodeCount; i++) {
+		const nodeName = useCodeNode ? `Code ${i}` : `NoOp ${i}`;
+
+		if (useCodeNode) {
+			nodes.push({
+				id: String(i + 1),
+				name: nodeName,
+				type: 'n8n-nodes-base.code',
+				typeVersion: 2,
+				position: [i * 200, 0] as [number, number],
+				parameters: buildCodeNodeParams(nodeOutputSize),
+			});
+		} else {
+			nodes.push({
+				id: String(i + 1),
+				name: nodeName,
+				type: 'n8n-nodes-base.noOp',
+				typeVersion: 1,
+				position: [i * 200, 0] as [number, number],
+			});
+		}
 
 		connections[previousNodeName] = {
 			main: [[{ node: nodeName, type: 'main', index: 0 }]],
@@ -58,8 +114,9 @@ export function buildKafkaTriggeredWorkflow(options: KafkaWorkflowOptions) {
 		previousNodeName = nodeName;
 	}
 
+	const label = useCodeNode ? `${nodeOutputSize}/node` : 'noop';
 	return {
-		name: `Kafka Load Test (${nodeCount} nodes)`,
+		name: `Kafka Load Test (${nodeCount} nodes, ${label})`,
 		nodes,
 		connections,
 		active: false,

--- a/packages/testing/playwright/utils/kafka-workflow-builder.ts
+++ b/packages/testing/playwright/utils/kafka-workflow-builder.ts
@@ -30,10 +30,10 @@ function buildCodeNodeParams(size: Exclude<NodeOutputSize, 'noop'>) {
 	// The Code node outputs the incoming item plus a `payload` field of the target size.
 	const code = [
 		`const size = ${bytes};`,
-		`const pad = 'x'.repeat(size);`,
-		`return $input.all().map(item => ({`,
-		`  json: { ...item.json, payload: pad }`,
-		`}));`,
+		"const pad = 'x'.repeat(size);",
+		'return $input.all().map(item => ({',
+		'  json: { ...item.json, payload: pad }',
+		'}));',
 	].join('\n');
 
 	return {

--- a/packages/testing/playwright/utils/kafka-workflow-builder.ts
+++ b/packages/testing/playwright/utils/kafka-workflow-builder.ts
@@ -1,0 +1,67 @@
+interface KafkaWorkflowOptions {
+	topic: string;
+	groupId: string;
+	credentialId: string;
+	credentialName: string;
+	nodeCount: number;
+}
+
+/**
+ * Generates a workflow definition with a KafkaTrigger followed by N chained NoOp nodes.
+ * Each node in the chain writes execution state to DB, so this tests engine overhead
+ * at different workflow depths without node-specific processing cost.
+ */
+export function buildKafkaTriggeredWorkflow(options: KafkaWorkflowOptions) {
+	const { topic, groupId, credentialId, credentialName, nodeCount } = options;
+
+	const nodes: Array<Record<string, unknown>> = [];
+	const connections: Record<
+		string,
+		{ main: Array<Array<{ node: string; type: string; index: number }>> }
+	> = {};
+
+	nodes.push({
+		id: 'trigger',
+		name: 'Kafka Trigger',
+		type: 'n8n-nodes-base.kafkaTrigger',
+		typeVersion: 1.1,
+		position: [0, 0] as [number, number],
+		parameters: {
+			topic,
+			groupId,
+			options: {
+				fromBeginning: true,
+				jsonParseMessage: true,
+				parallelProcessing: false,
+			},
+		},
+		credentials: {
+			kafka: { id: credentialId, name: credentialName },
+		},
+	});
+
+	let previousNodeName = 'Kafka Trigger';
+	for (let i = 1; i <= nodeCount; i++) {
+		const nodeName = `NoOp ${i}`;
+
+		nodes.push({
+			id: String(i + 1),
+			name: nodeName,
+			type: 'n8n-nodes-base.noOp',
+			typeVersion: 1,
+			position: [i * 200, 0] as [number, number],
+		});
+
+		connections[previousNodeName] = {
+			main: [[{ node: nodeName, type: 'main', index: 0 }]],
+		};
+		previousNodeName = nodeName;
+	}
+
+	return {
+		name: `Kafka Load Test (${nodeCount} nodes)`,
+		nodes,
+		connections,
+		active: false,
+	};
+}

--- a/packages/testing/playwright/utils/performance-helper.ts
+++ b/packages/testing/playwright/utils/performance-helper.ts
@@ -30,6 +30,35 @@ export async function getAllPerformanceMetrics(page: Page) {
 	});
 }
 
+/**
+ * Queries VictoriaMetrics for current heap and RSS memory of the n8n process.
+ * Optionally waits for at least one scrape before reading.
+ */
+export async function collectMemorySnapshot(
+	metrics: MetricsHelper,
+	options: { waitForScrape?: boolean } = {},
+): Promise<{ heapUsedMB: number; rssMB: number }> {
+	if (options.waitForScrape) {
+		await metrics.waitForMetric(HEAP_USED_QUERY, {
+			timeoutMs: 15_000,
+			intervalMs: 2000,
+			predicate: (results) => results.length > 0 && results[0].value > 0,
+		});
+	}
+	try {
+		const [heapResult, rssResult] = await Promise.all([
+			metrics.query(HEAP_USED_QUERY),
+			metrics.query(RSS_QUERY),
+		]);
+		return {
+			heapUsedMB: heapResult[0]?.value ?? 0,
+			rssMB: rssResult[0]?.value ?? 0,
+		};
+	} catch {
+		return { heapUsedMB: 0, rssMB: 0 };
+	}
+}
+
 /** Attach a performance metric for collection by the metrics reporter */
 export async function attachMetric(
 	testInfo: TestInfo,

--- a/packages/testing/playwright/utils/throughput-helper.ts
+++ b/packages/testing/playwright/utils/throughput-helper.ts
@@ -1,0 +1,211 @@
+import type { TestInfo } from '@playwright/test';
+import type { MetricsHelper } from 'n8n-containers';
+
+import { attachMetric } from './performance-helper';
+
+// --- Types ---
+
+export interface ThroughputSample {
+	timestamp: number;
+	completed: number;
+	delta: number;
+}
+
+export interface ThroughputResult {
+	totalCompleted: number;
+	durationMs: number;
+	avgExecPerSec: number;
+	peakExecPerSec: number;
+	actionsPerSec: number;
+	peakActionsPerSec: number;
+	samples: ThroughputSample[];
+}
+
+export interface MemorySnapshot {
+	heapUsedMB: number;
+	rssMB: number;
+}
+
+// --- PromQL queries ---
+
+const WORKFLOW_SUCCESS_QUERY = 'n8n_workflow_success_total';
+const QUEUE_COMPLETED_QUERY = 'n8n_scaling_mode_queue_jobs_completed';
+const HEAP_USED_QUERY = 'n8n_nodejs_heap_size_used_bytes / 1024 / 1024';
+const RSS_QUERY = 'n8n_process_resident_memory_bytes / 1024 / 1024';
+
+// --- Throughput measurement ---
+
+/**
+ * Polls VictoriaMetrics for a completion counter until it reaches the expected count.
+ * Records samples at each poll interval to calculate throughput.
+ *
+ * The metricQuery parameter allows switching between single-main
+ * (`n8n_workflow_success_total`) and queue mode (`n8n_scaling_mode_queue_jobs_completed`).
+ * For continuous generation tests, set expectedCount to Infinity and use timeoutMs as the run duration.
+ */
+export async function waitForThroughput(
+	metrics: MetricsHelper,
+	options: {
+		expectedCount: number;
+		nodeCount: number;
+		timeoutMs: number;
+		pollIntervalMs?: number;
+		metricQuery?: string;
+		baselineValue?: number;
+	},
+): Promise<ThroughputResult> {
+	const {
+		expectedCount,
+		nodeCount,
+		timeoutMs,
+		pollIntervalMs = 5000,
+		metricQuery = WORKFLOW_SUCCESS_QUERY,
+		baselineValue = 0,
+	} = options;
+
+	const samples: ThroughputSample[] = [];
+	const startTime = Date.now();
+	const deadline = startTime + timeoutMs;
+	let lastValue = baselineValue;
+
+	while (Date.now() < deadline) {
+		await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+
+		try {
+			const results = await metrics.query(metricQuery);
+			const current = results.length > 0 ? results[0].value : 0;
+			const completed = current - baselineValue;
+			const delta = current - lastValue;
+
+			samples.push({
+				timestamp: Date.now(),
+				completed,
+				delta,
+			});
+
+			if (delta !== 0) {
+				console.log(`[THROUGHPUT] Completed: ${completed}/${expectedCount} (+${delta})`);
+			}
+
+			lastValue = current;
+
+			if (completed >= expectedCount) {
+				break;
+			}
+		} catch (err) {
+			console.log(`[THROUGHPUT] Query error: ${err instanceof Error ? err.message : String(err)}`);
+		}
+	}
+
+	return calculateThroughput(samples, nodeCount, startTime);
+}
+
+/**
+ * Reads the current value of the workflow success counter from VictoriaMetrics.
+ * Returns 0 if the metric hasn't been scraped yet.
+ */
+export async function getBaselineCounter(
+	metrics: MetricsHelper,
+	metricQuery: string = WORKFLOW_SUCCESS_QUERY,
+): Promise<number> {
+	try {
+		const results = await metrics.query(metricQuery);
+		return results.length > 0 ? results[0].value : 0;
+	} catch {
+		return 0;
+	}
+}
+
+function calculateThroughput(
+	samples: ThroughputSample[],
+	nodeCount: number,
+	_startTime: number,
+): ThroughputResult {
+	if (samples.length === 0) {
+		return {
+			totalCompleted: 0,
+			durationMs: 0,
+			avgExecPerSec: 0,
+			peakExecPerSec: 0,
+			actionsPerSec: 0,
+			peakActionsPerSec: 0,
+			samples: [],
+		};
+	}
+
+	// Duration measures from first completion observed to last completion.
+	// This excludes VictoriaMetrics scrape lag before executions start appearing.
+	const firstActive = samples.find((s) => s.delta > 0);
+	const lastSample = samples[samples.length - 1];
+	const totalCompleted = lastSample.completed;
+	const durationMs = firstActive
+		? lastSample.timestamp - firstActive.timestamp
+		: lastSample.timestamp - _startTime;
+
+	// Per-interval rates (delta / interval seconds)
+	const intervalRates: number[] = [];
+	for (let i = 0; i < samples.length; i++) {
+		const intervalMs =
+			i === 0 ? samples[0].timestamp - _startTime : samples[i].timestamp - samples[i - 1].timestamp;
+		if (intervalMs > 0 && samples[i].delta > 0) {
+			intervalRates.push((samples[i].delta / intervalMs) * 1000);
+		}
+	}
+
+	const avgExecPerSec = durationMs > 0 ? (totalCompleted / durationMs) * 1000 : 0;
+	const peakExecPerSec = intervalRates.length > 0 ? Math.max(...intervalRates) : 0;
+
+	return {
+		totalCompleted,
+		durationMs,
+		avgExecPerSec,
+		peakExecPerSec,
+		actionsPerSec: avgExecPerSec * nodeCount,
+		peakActionsPerSec: peakExecPerSec * nodeCount,
+		samples,
+	};
+}
+
+// --- Memory collection ---
+
+export async function collectMemoryFromMetrics(metrics: MetricsHelper): Promise<MemorySnapshot> {
+	try {
+		const [heapResult, rssResult] = await Promise.all([
+			metrics.query(HEAP_USED_QUERY),
+			metrics.query(RSS_QUERY),
+		]);
+		return {
+			heapUsedMB: heapResult[0]?.value ?? 0,
+			rssMB: rssResult[0]?.value ?? 0,
+		};
+	} catch {
+		return { heapUsedMB: 0, rssMB: 0 };
+	}
+}
+
+// --- Result reporting ---
+
+export async function attachThroughputResults(
+	testInfo: TestInfo,
+	label: string,
+	result: ThroughputResult,
+	memory: MemorySnapshot,
+): Promise<void> {
+	await attachMetric(testInfo, `${label}-exec-per-sec`, result.avgExecPerSec, 'exec/s');
+	await attachMetric(testInfo, `${label}-actions-per-sec`, result.actionsPerSec, 'actions/s');
+	await attachMetric(testInfo, `${label}-peak-exec-per-sec`, result.peakExecPerSec, 'exec/s');
+	await attachMetric(
+		testInfo,
+		`${label}-peak-actions-per-sec`,
+		result.peakActionsPerSec,
+		'actions/s',
+	);
+	await attachMetric(testInfo, `${label}-total-completed`, result.totalCompleted, 'count');
+	await attachMetric(testInfo, `${label}-duration`, result.durationMs, 'ms');
+	await attachMetric(testInfo, `${label}-memory-heap`, memory.heapUsedMB, 'MB');
+	await attachMetric(testInfo, `${label}-memory-rss`, memory.rssMB, 'MB');
+}
+
+// --- Exported constants for queue mode switching ---
+
+export { WORKFLOW_SUCCESS_QUERY, QUEUE_COMPLETED_QUERY };

--- a/packages/testing/playwright/utils/throughput-helper.ts
+++ b/packages/testing/playwright/utils/throughput-helper.ts
@@ -123,7 +123,7 @@ export async function getBaselineCounter(
 function calculateThroughput(
 	samples: ThroughputSample[],
 	nodeCount: number,
-	_startTime: number,
+	startTime: number,
 ): ThroughputResult {
 	if (samples.length === 0) {
 		return {
@@ -144,13 +144,13 @@ function calculateThroughput(
 	const totalCompleted = lastSample.completed;
 	const durationMs = firstActive
 		? lastSample.timestamp - firstActive.timestamp
-		: lastSample.timestamp - _startTime;
+		: lastSample.timestamp - startTime;
 
 	// Per-interval rates (delta / interval seconds)
 	const intervalRates: number[] = [];
 	for (let i = 0; i < samples.length; i++) {
 		const intervalMs =
-			i === 0 ? samples[0].timestamp - _startTime : samples[i].timestamp - samples[i - 1].timestamp;
+			i === 0 ? samples[0].timestamp - startTime : samples[i].timestamp - samples[i - 1].timestamp;
 		if (intervalMs > 0 && samples[i].delta > 0) {
 			intervalRates.push((samples[i].delta / intervalMs) * 1000);
 		}

--- a/packages/testing/playwright/utils/throughput-helper.ts
+++ b/packages/testing/playwright/utils/throughput-helper.ts
@@ -30,11 +30,6 @@ export interface ThroughputResult {
 	samples: ThroughputSample[];
 }
 
-export interface MemorySnapshot {
-	heapUsedMB: number;
-	rssMB: number;
-}
-
 // --- PromQL queries ---
 
 const WORKFLOW_SUCCESS_QUERY = 'n8n_workflow_success_total';
@@ -179,7 +174,6 @@ export async function attachThroughputResults(
 	testInfo: TestInfo,
 	label: string,
 	result: ThroughputResult,
-	memory: MemorySnapshot,
 ): Promise<void> {
 	await attachMetric(testInfo, `${label}-exec-per-sec`, result.avgExecPerSec, 'exec/s');
 	await attachMetric(testInfo, `${label}-actions-per-sec`, result.actionsPerSec, 'actions/s');
@@ -192,8 +186,6 @@ export async function attachThroughputResults(
 	);
 	await attachMetric(testInfo, `${label}-total-completed`, result.totalCompleted, 'count');
 	await attachMetric(testInfo, `${label}-duration`, result.durationMs, 'ms');
-	await attachMetric(testInfo, `${label}-memory-heap`, memory.heapUsedMB, 'MB');
-	await attachMetric(testInfo, `${label}-memory-rss`, memory.rssMB, 'MB');
 }
 
 // --- Exported constants for queue mode switching ---

--- a/packages/testing/playwright/utils/throughput-helper.ts
+++ b/packages/testing/playwright/utils/throughput-helper.ts
@@ -1,3 +1,12 @@
+/**
+ * Throughput benchmark helpers — VictoriaMetrics counter-based completion tracking.
+ *
+ * Use this approach when you need sustained throughput measurement with per-interval
+ * sampling. Better for benchmarks measuring aggregate throughput over time.
+ *
+ * For per-message tracking via consumer group lag with REST API duration statistics,
+ * use `kafka-load-helper.ts` instead.
+ */
 import type { TestInfo } from '@playwright/test';
 import type { MetricsHelper } from 'n8n-containers';
 
@@ -30,8 +39,6 @@ export interface MemorySnapshot {
 
 const WORKFLOW_SUCCESS_QUERY = 'n8n_workflow_success_total';
 const QUEUE_COMPLETED_QUERY = 'n8n_scaling_mode_queue_jobs_completed';
-const HEAP_USED_QUERY = 'n8n_nodejs_heap_size_used_bytes / 1024 / 1024';
-const RSS_QUERY = 'n8n_process_resident_memory_bytes / 1024 / 1024';
 
 // --- Throughput measurement ---
 
@@ -164,23 +171,6 @@ function calculateThroughput(
 		peakActionsPerSec: peakExecPerSec * nodeCount,
 		samples,
 	};
-}
-
-// --- Memory collection ---
-
-export async function collectMemoryFromMetrics(metrics: MetricsHelper): Promise<MemorySnapshot> {
-	try {
-		const [heapResult, rssResult] = await Promise.all([
-			metrics.query(HEAP_USED_QUERY),
-			metrics.query(RSS_QUERY),
-		]);
-		return {
-			heapUsedMB: heapResult[0]?.value ?? 0,
-			rssMB: rssResult[0]?.value ?? 0,
-		};
-	} catch {
-		return { heapUsedMB: 0, rssMB: 0 };
-	}
 }
 
 // --- Result reporting ---

--- a/packages/testing/playwright/utils/throughput-helper.ts
+++ b/packages/testing/playwright/utils/throughput-helper.ts
@@ -94,8 +94,10 @@ export async function waitForThroughput(
 			if (completed >= expectedCount) {
 				break;
 			}
-		} catch (err) {
-			console.log(`[THROUGHPUT] Query error: ${err instanceof Error ? err.message : String(err)}`);
+		} catch (error) {
+			console.log(
+				`[THROUGHPUT] Query error: ${error instanceof Error ? error.message : String(error)}`,
+			);
 		}
 	}
 


### PR DESCRIPTION
## Summary

Adds a Kafka load testing and trigger throughput benchmarking framework for measuring n8n's performance under sustained message processing workloads, with a consolidated benchmark summary reporter for results visibility.

### Benchmark Suites

- **Load tests** (`kafka-load.spec.ts`) — 4 scenarios measuring per-execution latency (p50/p95/p99) and completion rate under steady-state and burst patterns
- **Throughput tests** (`trigger-throughput.spec.ts`) — 6 scenarios measuring sustained exec/s and actions/s via VictoriaMetrics counters, with Postgres and event loop diagnostics

### Infrastructure

- Kafka batch publishing + consumer group lag monitoring
- postgres-exporter for DB metrics visibility (tx/s, rows inserted/s, active connections)
- Configurable Postgres profiles (fast/production)
- Throughput tests query PG diagnostics after each run using duration-aware rate() windows

### Benchmark Summary Reporter

- Custom Playwright reporter collecting `metric:*` attachments into a consolidated table
- Columns: Trigger, Suite, Scenario, exec/s, actions/s, p50, p95, p99
- Writes to GitHub Actions job summary in CI
- Trigger-agnostic design — works for future webhook/MQTT/RabbitMQ benchmarks

### DX & CI

- Shared helpers with doc comments explaining completion-tracking strategies
- Properly typed workflow builder — no `as any` casts
- All lint and typecheck clean
- New CI workflow for infrastructure tests

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (only suppressed `no-conditional-in-test` for scenario branching)
- [x] All 10 scenarios pass locally with correct metrics
- [x] Benchmark summary table renders in console and GitHub Actions
- [x] PG diagnostics return valid data (tx/s, rows/s, active connections)
- [ ] Trigger infrastructure CI workflow to validate end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)