### PR TITLE
fix(editor): Improve NDV panel drag handle contrast in dark mode

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/PanelDragButtonV2.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/PanelDragButtonV2.vue
@@ -58,7 +58,7 @@ const onDragStart = () => {
 	align-items: baseline;
 	gap: var(--spacing--3xs);
 	padding: var(--spacing--4xs) var(--spacing--3xs) 0 var(--spacing--3xs);
-	color: var(--color--foreground--shade-1);
+	color: var(--color--foreground--shade-2);
 	border: var(--border);
 	border-bottom: none;
 	border-top-left-radius: var(--radius);


### PR DESCRIPTION
## Summary
Change the NDV panel drag button icon color token in dark mode from `--color--foreground--shade-1` to `--color--foreground--shade-2`.

This improves contrast and makes the handle icons easier to see after the recent color token update.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/DS-461/bug-handle-icons-too-hard-to-see-in-dark-mode-after-color

## Review / Merge checklist
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
