### PR TITLE
refactor(editor): Normalize  usedCredentials in workflow document state (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowPublishModal.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowPublishModal.vue
@@ -1,5 +1,13 @@
 <script setup lang="ts">
-import { computed, ref, h, onMounted, onBeforeUnmount, useTemplateRef } from 'vue';
+import {
+	computed,
+	ref,
+	h,
+	onMounted,
+	onBeforeUnmount,
+	useTemplateRef,
+	type DeepReadonly,
+} from 'vue';
 import type { VNode } from 'vue';
 import Modal from '@/app/components/Modal.vue';
 import { WORKFLOW_PUBLISH_MODAL_KEY } from '@/app/constants';
@@ -111,7 +119,7 @@ onBeforeUnmount(() => {
 });
 
 function findManagedOpenAiCredentialId(
-	usedCredentials: Record<string, IUsedCredential>,
+	usedCredentials: DeepReadonly<Record<string, IUsedCredential>>,
 ): string | undefined {
 	return Object.keys(usedCredentials).find((credentialId) => {
 		const credential = credentialsStore.state.credentials[credentialId];

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowPublishModal.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowPublishModal.vue
@@ -136,7 +136,7 @@ function hasActiveNodeUsingCredential(nodes: INodeUi[], credentialId: string): b
  *
  */
 const shouldShowFreeAiCreditsWarning = computed((): boolean => {
-	const usedCredentials = workflowsStore?.usedCredentials;
+	const usedCredentials = workflowDocumentStore.value?.usedCredentials;
 	if (!usedCredentials) return false;
 
 	const managedOpenAiCredentialId = findManagedOpenAiCredentialId(usedCredentials);

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -2788,7 +2788,7 @@ export function useCanvasOperations() {
 			) {
 				nodeSaveData.credentials = filterAllowedCredentials(
 					nodeSaveData.credentials,
-					workflowsStore.usedCredentials,
+					workflowDocumentStore?.usedCredentials ?? {},
 				);
 			}
 

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -113,7 +113,7 @@ import {
 	isCommunityPackageName,
 	isHitlToolType,
 } from 'n8n-workflow';
-import { computed, nextTick, ref } from 'vue';
+import { computed, nextTick, ref, type DeepReadonly } from 'vue';
 import { useUniqueNodeName } from '@/app/composables/useUniqueNodeName';
 import { injectWorkflowState } from '@/app/composables/useWorkflowState';
 import { isPresent, tryToParseNumber } from '@/app/utils/typesUtils';
@@ -2805,7 +2805,7 @@ export function useCanvasOperations() {
 
 	function filterAllowedCredentials(
 		credentials: INodeCredentials,
-		usedCredentials: Record<string, IUsedCredential>,
+		usedCredentials: DeepReadonly<Record<string, IUsedCredential>>,
 	): INodeCredentials {
 		return Object.fromEntries(
 			Object.entries(credentials).filter(([, credential]) => {

--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.test.ts
@@ -21,6 +21,18 @@ import type { IUsedCredential } from '@/features/credentials/credentials.types';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { injectWorkflowState, useWorkflowState } from './useWorkflowState';
 
+const mockDocumentStoreUsedCredentials: Record<string, IUsedCredential> = {};
+
+vi.mock('@/app/stores/workflowDocument.store', async () => {
+	const actual = await vi.importActual('@/app/stores/workflowDocument.store');
+	return {
+		...actual,
+		useWorkflowDocumentStore: vi.fn(() => ({
+			usedCredentials: mockDocumentStoreUsedCredentials,
+		})),
+	};
+});
+
 vi.mock('@/app/composables/useWorkflowState', async () => {
 	const actual = await vi.importActual('@/app/composables/useWorkflowState');
 	return {
@@ -36,6 +48,10 @@ describe('useNodeHelpers()', () => {
 
 	afterEach(() => {
 		vi.clearAllMocks();
+		// Clear mock document store state
+		for (const key of Object.keys(mockDocumentStoreUsedCredentials)) {
+			delete mockDocumentStoreUsedCredentials[key];
+		}
 	});
 
 	describe('initialization', () => {
@@ -241,9 +257,10 @@ describe('useNodeHelpers()', () => {
 			mockedStore(useSettingsStore).isEnterpriseFeatureEnabled = createMockEnterpriseSettings({
 				[EnterpriseEditionFeature.Sharing]: false,
 			});
-			mockedStore(useWorkflowsStore).usedCredentials = {
+			mockedStore(useWorkflowsStore).workflowId = 'test-workflow';
+			Object.assign(mockDocumentStoreUsedCredentials, {
 				[credentialWithoutAccess.id]: credentialWithoutAccess,
-			};
+			});
 
 			const result = getForeignCredentialsIfSharingEnabled({
 				[credentialWithoutAccess.id]: {
@@ -285,10 +302,11 @@ describe('useNodeHelpers()', () => {
 			mockedStore(useSettingsStore).isEnterpriseFeatureEnabled = createMockEnterpriseSettings({
 				[EnterpriseEditionFeature.Sharing]: true,
 			});
-			mockedStore(useWorkflowsStore).usedCredentials = {
+			mockedStore(useWorkflowsStore).workflowId = 'test-workflow';
+			Object.assign(mockDocumentStoreUsedCredentials, {
 				[credentialWithAccess1.id]: credentialWithAccess1,
 				[credentialWithAccess2.id]: credentialWithAccess2,
-			};
+			});
 
 			const result = getForeignCredentialsIfSharingEnabled({
 				[credentialWithAccess1.id]: {
@@ -323,10 +341,11 @@ describe('useNodeHelpers()', () => {
 			mockedStore(useSettingsStore).isEnterpriseFeatureEnabled = createMockEnterpriseSettings({
 				[EnterpriseEditionFeature.Sharing]: true,
 			});
-			mockedStore(useWorkflowsStore).usedCredentials = {
+			mockedStore(useWorkflowsStore).workflowId = 'test-workflow';
+			Object.assign(mockDocumentStoreUsedCredentials, {
 				[credentialWithAccess.id]: credentialWithAccess,
 				[credentialWithoutAccess.id]: credentialWithoutAccess,
-			};
+			});
 
 			const result = getForeignCredentialsIfSharingEnabled({
 				[credentialWithAccess.id]: {

--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
@@ -426,7 +426,7 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 		nodeType?: INodeTypeDescription,
 	): INodeIssues | null {
 		const localNodeType = nodeType ?? nodeTypesStore.getNodeType(node.type, node.typeVersion);
-		const credentialDocStore = workflowsStore.workflowId
+		const workflowDocumentStore = workflowsStore.workflowId
 			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
 			: undefined;
 		if (node.disabled) {
@@ -467,7 +467,9 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 			// Prevents HTTP Request node from being unusable if a sharee does not have direct
 			// access to a credential
 			const isCredentialUsedInWorkflow =
-				credentialDocStore?.usedCredentials?.[node.credentials?.[nodeCredentialType]?.id as string];
+				workflowDocumentStore?.usedCredentials?.[
+					node.credentials?.[nodeCredentialType]?.id as string
+				];
 
 			if (
 				selectedCredsDoNotExist(node, nodeCredentialType, stored) &&
@@ -551,7 +553,7 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 
 				if (nameMatches.length === 0) {
 					const isCredentialUsedInWorkflow =
-						credentialDocStore?.usedCredentials?.[selectedCredentials.id as string];
+						workflowDocumentStore?.usedCredentials?.[selectedCredentials.id as string];
 
 					if (
 						!isCredentialUsedInWorkflow &&

--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
@@ -156,7 +156,10 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 			return [];
 		}
 
-		const usedCredentials = workflowsStore.usedCredentials;
+		const workflowDocumentStore = workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined;
+		const usedCredentials = workflowDocumentStore?.usedCredentials ?? {};
 
 		return Object.values(credentials)
 			.map(({ id }) => id)
@@ -423,6 +426,9 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 		nodeType?: INodeTypeDescription,
 	): INodeIssues | null {
 		const localNodeType = nodeType ?? nodeTypesStore.getNodeType(node.type, node.typeVersion);
+		const credentialDocStore = workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined;
 		if (node.disabled) {
 			// Node is disabled
 			return null;
@@ -461,7 +467,7 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 			// Prevents HTTP Request node from being unusable if a sharee does not have direct
 			// access to a credential
 			const isCredentialUsedInWorkflow =
-				workflowsStore.usedCredentials?.[node.credentials?.[nodeCredentialType]?.id as string];
+				credentialDocStore?.usedCredentials?.[node.credentials?.[nodeCredentialType]?.id as string];
 
 			if (
 				selectedCredsDoNotExist(node, nodeCredentialType, stored) &&
@@ -545,7 +551,7 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 
 				if (nameMatches.length === 0) {
 					const isCredentialUsedInWorkflow =
-						workflowsStore.usedCredentials?.[selectedCredentials.id as string];
+						credentialDocStore?.usedCredentials?.[selectedCredentials.id as string];
 
 					if (
 						!isCredentialUsedInWorkflow &&

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
@@ -249,7 +249,6 @@ describe('useWorkflowHelpers', () => {
 			const setWorkflowIdSpy = vi.spyOn(workflowState, 'setWorkflowId');
 			const setWorkflowNameSpy = vi.spyOn(workflowState, 'setWorkflowName');
 			const setWorkflowVersionDataSpy = vi.spyOn(workflowsStore, 'setWorkflowVersionData');
-			const setUsedCredentialsSpy = vi.spyOn(workflowsStore, 'setUsedCredentials');
 			const setWorkflowSharedWithSpy = vi.spyOn(workflowsEEStore, 'setWorkflowSharedWith');
 			const upsertTagsSpy = vi.spyOn(tagsStore, 'upsertTags');
 
@@ -266,7 +265,6 @@ describe('useWorkflowHelpers', () => {
 				name: null,
 				description: null,
 			});
-			expect(setUsedCredentialsSpy).toHaveBeenCalledWith([]);
 			expect(setWorkflowSharedWithSpy).toHaveBeenCalledWith({
 				workflowId: '1',
 				sharedWithProjects: [],
@@ -287,12 +285,10 @@ describe('useWorkflowHelpers', () => {
 				scopes: [],
 				tags: [],
 			});
-			const setUsedCredentialsSpy = vi.spyOn(workflowsStore, 'setUsedCredentials');
 			const setWorkflowSharedWithSpy = vi.spyOn(workflowsEEStore, 'setWorkflowSharedWith');
 
 			await initState(workflowData);
 
-			expect(setUsedCredentialsSpy).not.toHaveBeenCalled();
 			expect(setWorkflowSharedWithSpy).not.toHaveBeenCalled();
 		});
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
@@ -1004,10 +1004,6 @@ export function useWorkflowHelpers() {
 			}
 		}
 
-		if (workflowData.usedCredentials) {
-			workflowsStore.setUsedCredentials(workflowData.usedCredentials);
-		}
-
 		if (workflowData.sharedWithProjects) {
 			workflowsEEStore.setWorkflowSharedWith({
 				workflowId: workflowData.id,
@@ -1041,6 +1037,7 @@ export function useWorkflowHelpers() {
 			workflowDocumentStore.setChecksum(workflowData.checksum);
 		}
 		workflowDocumentStore.setIsArchived(workflowData.isArchived);
+		workflowDocumentStore.setUsedCredentials(workflowData.usedCredentials ?? []);
 		workflowDocumentStore.setMeta(workflowData.meta);
 		workflowDocumentStore.setScopes(workflowData.scopes ?? []);
 		tagsStore.upsertTags(tags);

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
@@ -12,6 +12,7 @@ import { useWorkflowDocumentSettings } from './workflowDocument/useWorkflowDocum
 import { useWorkflowDocumentTags } from './workflowDocument/useWorkflowDocumentTags';
 import { useWorkflowDocumentIsArchived } from './workflowDocument/useWorkflowDocumentIsArchived';
 import { useWorkflowDocumentTimestamps } from './workflowDocument/useWorkflowDocumentTimestamps';
+import { useWorkflowDocumentUsedCredentials } from './workflowDocument/useWorkflowDocumentUsedCredentials';
 
 export {
 	getPinDataSize,
@@ -63,6 +64,7 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 		const workflowDocumentScopes = useWorkflowDocumentScopes();
 		const workflowDocumentTimestamps = useWorkflowDocumentTimestamps();
 		const workflowDocumentSettings = useWorkflowDocumentSettings();
+		const workflowDocumentUsedCredentials = useWorkflowDocumentUsedCredentials();
 
 		return {
 			workflowId,
@@ -77,6 +79,7 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 			...workflowDocumentPinData,
 			...workflowDocumentScopes,
 			...workflowDocumentTimestamps,
+			...workflowDocumentUsedCredentials,
 		};
 	})();
 }

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentUsedCredentials.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentUsedCredentials.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+import { useWorkflowDocumentUsedCredentials } from './useWorkflowDocumentUsedCredentials';
+import type { IUsedCredential } from '@/features/credentials/credentials.types';
+
+function createUsedCredentials() {
+	return useWorkflowDocumentUsedCredentials();
+}
+
+function createCredential(overrides: Partial<IUsedCredential> = {}): IUsedCredential {
+	return {
+		id: '1',
+		name: 'Test Credential',
+		credentialType: 'testApi',
+		currentUserHasAccess: true,
+		...overrides,
+	};
+}
+
+describe('useWorkflowDocumentUsedCredentials', () => {
+	describe('initial state', () => {
+		it('should start with empty record', () => {
+			const { usedCredentials } = createUsedCredentials();
+			expect(usedCredentials.value).toEqual({});
+		});
+	});
+
+	describe('setUsedCredentials', () => {
+		it('should convert array to record keyed by id and fire event hook', () => {
+			const { usedCredentials, setUsedCredentials, onUsedCredentialsChange } =
+				createUsedCredentials();
+			const hookSpy = vi.fn();
+			onUsedCredentialsChange(hookSpy);
+
+			const cred1 = createCredential({ id: '1', name: 'Cred 1' });
+			const cred2 = createCredential({ id: '2', name: 'Cred 2' });
+			setUsedCredentials([cred1, cred2]);
+
+			expect(usedCredentials.value).toEqual({ '1': cred1, '2': cred2 });
+			expect(hookSpy).toHaveBeenCalledWith({
+				action: 'update',
+				payload: { usedCredentials: { '1': cred1, '2': cred2 } },
+			});
+		});
+
+		it('should replace existing value', () => {
+			const { usedCredentials, setUsedCredentials } = createUsedCredentials();
+			setUsedCredentials([createCredential({ id: '1' })]);
+
+			const newCred = createCredential({ id: '2', name: 'New' });
+			setUsedCredentials([newCred]);
+
+			expect(usedCredentials.value).toEqual({ '2': newCred });
+		});
+
+		it('should handle empty array', () => {
+			const { usedCredentials, setUsedCredentials } = createUsedCredentials();
+			setUsedCredentials([createCredential({ id: '1' })]);
+
+			setUsedCredentials([]);
+
+			expect(usedCredentials.value).toEqual({});
+		});
+
+		it('should fire event hook on every call', () => {
+			const { setUsedCredentials, onUsedCredentialsChange } = createUsedCredentials();
+			const hookSpy = vi.fn();
+			onUsedCredentialsChange(hookSpy);
+
+			setUsedCredentials([createCredential({ id: '1' })]);
+			setUsedCredentials([]);
+
+			expect(hookSpy).toHaveBeenCalledTimes(2);
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentUsedCredentials.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentUsedCredentials.ts
@@ -1,4 +1,4 @@
-import { ref, shallowReadonly } from 'vue';
+import { ref, readonly } from 'vue';
 import { createEventHook } from '@vueuse/core';
 import { CHANGE_ACTION } from './types';
 import type { ChangeAction, ChangeEvent } from './types';
@@ -32,7 +32,7 @@ export function useWorkflowDocumentUsedCredentials() {
 	}
 
 	return {
-		usedCredentials: shallowReadonly(usedCredentials),
+		usedCredentials: readonly(usedCredentials),
 		setUsedCredentials,
 		onUsedCredentialsChange: onUsedCredentialsChange.on,
 	};

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentUsedCredentials.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentUsedCredentials.ts
@@ -1,0 +1,39 @@
+import { ref, shallowReadonly } from 'vue';
+import { createEventHook } from '@vueuse/core';
+import { CHANGE_ACTION } from './types';
+import type { ChangeAction, ChangeEvent } from './types';
+import type { IUsedCredential } from '@/features/credentials/credentials.types';
+
+export type UsedCredentialsPayload = {
+	usedCredentials: Record<string, IUsedCredential>;
+};
+
+export type UsedCredentialsChangeEvent = ChangeEvent<UsedCredentialsPayload>;
+
+export function useWorkflowDocumentUsedCredentials() {
+	const usedCredentials = ref<Record<string, IUsedCredential>>({});
+
+	const onUsedCredentialsChange = createEventHook<UsedCredentialsChangeEvent>();
+
+	function applyUsedCredentials(
+		value: Record<string, IUsedCredential>,
+		action: ChangeAction = CHANGE_ACTION.UPDATE,
+	) {
+		usedCredentials.value = value;
+		void onUsedCredentialsChange.trigger({ action, payload: { usedCredentials: value } });
+	}
+
+	function setUsedCredentials(data: IUsedCredential[]) {
+		const record = data.reduce<Record<string, IUsedCredential>>((accu, credential) => {
+			accu[credential.id] = credential;
+			return accu;
+		}, {});
+		applyUsedCredentials(record);
+	}
+
+	return {
+		usedCredentials: shallowReadonly(usedCredentials),
+		setUsedCredentials,
+		onUsedCredentialsChange: onUsedCredentialsChange.on,
+	};
+}

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -22,7 +22,6 @@ import type {
 	IExecutionsListResponse,
 	IExecutionFlattedResponse,
 } from '@/features/execution/executions/executions.types';
-import type { IUsedCredential } from '@/features/credentials/credentials.types';
 import type { IWorkflowTemplateNode } from '@n8n/rest-api-client/api/templates';
 import type { WorkflowDataCreate, WorkflowDataUpdate } from '@n8n/rest-api-client/api/workflows';
 import { defineStore } from 'pinia';
@@ -135,7 +134,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 	);
 
 	const versionData = ref<WorkflowVersionData | null>(null);
-	const usedCredentials = ref<Record<string, IUsedCredential>>({});
 
 	const currentWorkflowExecutions = ref<ExecutionSummary[]>([]);
 	const workflowExecutionData = ref<IExecutionResponse | null>(null);
@@ -639,14 +637,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 
 	function resetWorkflow() {
 		workflow.value = createEmptyWorkflow();
-	}
-
-	function setUsedCredentials(data: IUsedCredential[]) {
-		workflow.value.usedCredentials = data;
-		usedCredentials.value = data.reduce<{ [name: string]: IUsedCredential }>((accu, credential) => {
-			accu[credential.id] = credential;
-			return accu;
-		}, {});
 	}
 
 	function setWorkflowActiveVersion(version: WorkflowHistory | null) {
@@ -1687,7 +1677,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 	return {
 		workflow,
 		versionData,
-		usedCredentials,
 		currentWorkflowExecutions,
 		workflowExecutionData,
 		workflowExecutionPairedItemMappings,
@@ -1751,7 +1740,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		getActivationError,
 		resetWorkflow,
 		addNodeExecutionStartedData,
-		setUsedCredentials,
 		setWorkflowActiveVersion,
 		setWorkflowVersionData,
 		replaceInvalidWorkflowCredentials,

--- a/packages/frontend/editor-ui/src/features/credentials/credentials.store.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/credentials.store.ts
@@ -26,7 +26,7 @@ import type {
 	NodeParameterValueType,
 } from 'n8n-workflow';
 import { defineStore } from 'pinia';
-import { computed, ref } from 'vue';
+import { computed, ref, type DeepReadonly } from 'vue';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useSettingsStore } from '@/app/stores/settings.store';
@@ -192,7 +192,13 @@ export const useCredentialsStore = defineStore(STORES.CREDENTIALS, () => {
 	});
 
 	const getCredentialOwnerName = computed(() => {
-		return (credential: ICredentialsResponse | IUsedCredential | undefined): string => {
+		return (
+			credential:
+				| ICredentialsResponse
+				| IUsedCredential
+				| DeepReadonly<IUsedCredential>
+				| undefined,
+		): string => {
 			const { name, email } = splitName(credential?.homeProject?.name ?? '');
 
 			return name

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
@@ -68,6 +68,10 @@ import { N8nBlockUi, N8nIcon, N8nNotice, N8nText } from '@n8n/design-system';
 import { useRoute } from 'vue-router';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { injectWorkflowState } from '@/app/composables/useWorkflowState';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { ProjectTypes } from '@/features/collaboration/projects/projects.types';
 
 const props = withDefaults(
@@ -126,6 +130,11 @@ const ndvStore = useNDVStore();
 const workflowsStore = useWorkflowsStore();
 const workflowsListStore = useWorkflowsListStore();
 const workflowState = injectWorkflowState();
+const workflowDocumentStore = computed(() =>
+	workflowsStore.workflowId
+		? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+		: undefined,
+);
 const credentialsStore = useCredentialsStore();
 const historyStore = useHistoryStore();
 
@@ -280,7 +289,7 @@ const isCommunityNode = computed(() => !!node.value && isCommunityPackageName(no
 const packageName = computed(() => node.value?.type.split('.')[0] ?? '');
 
 const usedCredentials = computed(() =>
-	Object.values(workflowsStore.usedCredentials).filter((credential) =>
+	Object.values(workflowDocumentStore.value?.usedCredentials ?? {}).filter((credential) =>
 		Object.values(node.value?.credentials || []).find(
 			(nodeCredential) => nodeCredential.id === credential.id,
 		),


### PR DESCRIPTION
Move usedCredentials from workflows.store into a workflowDocument composable following the apply/public pattern. Migrate all consumers to read from the document store instead of the legacy workflows store.

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/CAT-2368
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
