### PR TITLE
ci: Add Workflow script test runner to CI

### DIFF
--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "test": "node --test --experimental-test-module-mocks ./*.test.mjs"
+  },
   "dependencies": {
     "cacheable-lookup": "6.1.0",
     "conventional-changelog": "^4.0.0",

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -23,6 +23,7 @@ jobs:
       unit: ${{ fromJSON(steps.ci-filter.outputs.results).unit == true }}
       e2e: ${{ fromJSON(steps.ci-filter.outputs.results).e2e == true }}
       workflows: ${{ fromJSON(steps.ci-filter.outputs.results).workflows == true }}
+      workflow_scripts: ${{ fromJSON(steps.ci-filter.outputs.results)['workflow-scripts'] == true }}
       db: ${{ fromJSON(steps.ci-filter.outputs.results).db == true }}
       design_system: ${{ fromJSON(steps.ci-filter.outputs.results)['design-system'] == true }}
       performance: ${{ fromJSON(steps.ci-filter.outputs.results).performance == true }}
@@ -58,6 +59,7 @@ jobs:
               packages/testing/playwright/**
               packages/testing/containers/**
             workflows: .github/**
+            workflow-scripts: .github/scripts/**
             design-system:
               packages/frontend/@n8n/design-system/**
               packages/frontend/@n8n/chat/**
@@ -160,6 +162,15 @@ jobs:
       ref: ${{ needs.install-and-build.outputs.commit_sha }}
     secrets: inherit
 
+  workflow-scripts:
+    name: Workflow scripts
+    needs: install-and-build
+    if: needs.install-and-build.outputs.workflow_scripts == 'true'
+    uses: ./.github/workflows/test-workflow-scripts-reusable.yml
+    with:
+      ref: ${{ needs.install-and-build.outputs.commit_sha }}
+    secrets: inherit
+
   chromatic:
     name: Chromatic
     needs: install-and-build
@@ -173,7 +184,19 @@ jobs:
   # PRs cannot be merged unless this job passes.
   required-checks:
     name: Required Checks
-    needs: [install-and-build, unit-test, typecheck, lint, e2e-tests, db-tests, performance, security-checks, chromatic]
+    needs:
+      [
+        install-and-build,
+        unit-test,
+        typecheck,
+        lint,
+        e2e-tests,
+        db-tests,
+        performance,
+        security-checks,
+        workflow-scripts,
+        chromatic,
+      ]
     if: always()
     runs-on: ubuntu-slim
     steps:

--- a/.github/workflows/test-workflow-scripts-reusable.yml
+++ b/.github/workflows/test-workflow-scripts-reusable.yml
@@ -1,0 +1,37 @@
+name: 'Test: Workflow scripts'
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: GitHub ref to lint.
+        required: false
+        type: string
+        default: ''
+      nodeVersion:
+        description: Version of node to use.
+        required: false
+        type: string
+        default: 24.13.1
+
+env:
+  NODE_OPTIONS: --max-old-space-size=7168
+
+jobs:
+  workflow-script-tests:
+    name: Run tests for workflow scripts
+    runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-slim' || 'blacksmith-4vcpu-ubuntu-2204' }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-nodejs
+        with:
+          build-command: ''
+          install-command: npm install --prefix=.github/scripts --no-package-lock
+
+      - name: Run tests
+        id: run-tests
+        run: npm test --prefix=.github/scripts


### PR DESCRIPTION
## Summary

As we are building more of our workflows into `mjs` scripts, and building a lot of tests around them, I think it would be beneficial to introduce a CI step to ensure those tests run green when changes are made.

@shortstacked I'd appriciate if you checked I used the CI filter action correctly here.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
