### PR TITLE
chore(core): Redact sensitive node output fields via configurable strategy pipeline

### DIFF
--- a/packages/cli/src/executions/execution-redaction.ts
+++ b/packages/cli/src/executions/execution-redaction.ts
@@ -2,14 +2,6 @@ import type { ExecutionRedactionQueryDto } from '@n8n/api-types';
 import type { User } from '@n8n/db';
 import type { IRunExecutionData, IWorkflowBase, WorkflowExecuteMode } from 'n8n-workflow';
 
-export type RedactableExecution = {
-	id?: string;
-	mode: WorkflowExecuteMode;
-	workflowId: string;
-	data: IRunExecutionData;
-	workflowData: Pick<IWorkflowBase, 'settings'>;
-};
-
 export type ExecutionRedactionOptions = {
 	user: User;
 	ipAddress?: string;
@@ -27,3 +19,19 @@ export interface ExecutionRedaction {
 		options: ExecutionRedactionOptions,
 	): Promise<void>;
 }
+
+/**
+ * Minimal structural type for execution data that needs redaction processing.
+ * Decouples redaction strategies from `IExecutionDb` so they can be tested
+ * and reused without a full database entity.
+ *
+ * `workflowData.nodes` is required so strategies can look up per-node
+ * `sensitiveOutputFields` declarations from the node type registry.
+ */
+export type RedactableExecution = {
+	id?: string;
+	mode: WorkflowExecuteMode;
+	workflowId: string;
+	data: IRunExecutionData;
+	workflowData: Pick<IWorkflowBase, 'settings' | 'nodes'>;
+};

--- a/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
+++ b/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
@@ -1,14 +1,7 @@
 import { Logger } from '@n8n/backend-common';
 import { mockInstance } from '@n8n/backend-test-utils';
 import type { User } from '@n8n/db';
-import type {
-	ExecutionError,
-	ExecutionStatus,
-	INode,
-	IRunExecutionData,
-	WorkflowExecuteMode,
-} from 'n8n-workflow';
-import { ExpressionError, NodeApiError, NodeOperationError } from 'n8n-workflow';
+import type { IRunExecutionData, WorkflowExecuteMode } from 'n8n-workflow';
 import { mock } from 'jest-mock-extended';
 
 import type {
@@ -20,11 +13,16 @@ import type { EventService } from '@/events/event.service';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
 import { ExecutionRedactionService } from '../execution-redaction.service';
+import { FullItemRedactionStrategy } from '../strategies/full-item-redaction.strategy';
+import { NodeDefinedFieldRedactionStrategy } from '../strategies/node-defined-field-redaction.strategy';
 
 describe('ExecutionRedactionService', () => {
 	const logger = mockInstance(Logger);
 	const workflowFinderService = mockInstance(WorkflowFinderService);
 	const eventService = mock<EventService>();
+	const fullItemRedactionStrategy = mockInstance(FullItemRedactionStrategy);
+	const nodeDefinedFieldRedactionStrategy = mockInstance(NodeDefinedFieldRedactionStrategy);
+
 	let service: ExecutionRedactionService;
 
 	const mockUser = {
@@ -37,19 +35,26 @@ describe('ExecutionRedactionService', () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks();
-		service = new ExecutionRedactionService(logger, workflowFinderService, eventService);
-		// Default: user lacks execution:reveal scope → canReveal: false
+		service = new ExecutionRedactionService(
+			logger,
+			workflowFinderService,
+			eventService,
+			fullItemRedactionStrategy,
+			nodeDefinedFieldRedactionStrategy,
+		);
+		// Default: user lacks execution:reveal scope
 		workflowFinderService.findWorkflowIdsWithScopeForUser.mockResolvedValue(new Set());
+		fullItemRedactionStrategy.apply.mockResolvedValue(undefined);
+		nodeDefinedFieldRedactionStrategy.apply.mockResolvedValue(undefined);
 	});
 
-	const createMockExecution = (
+	const makeExecution = (
 		overrides: {
 			mode?: WorkflowExecuteMode;
 			workflowId?: string;
 			policy?: 'none' | 'all' | 'non-manual';
 			workflowSettingsPolicy?: 'none' | 'all' | 'non-manual';
 			withRuntimeData?: boolean;
-			withRunData?: boolean;
 		} = {},
 	): RedactableExecution => {
 		const {
@@ -58,7 +63,6 @@ describe('ExecutionRedactionService', () => {
 			policy,
 			workflowSettingsPolicy,
 			withRuntimeData = true,
-			withRunData = false,
 		} = overrides;
 
 		const executionData: IRunExecutionData['executionData'] = {
@@ -78,47 +82,25 @@ describe('ExecutionRedactionService', () => {
 			};
 		}
 
-		const runData = withRunData
-			? {
-					TestNode: [
-						{
-							startTime: 0,
-							executionTime: 100,
-							executionStatus: 'success' as ExecutionStatus,
-							data: {
-								main: [
-									[
-										{
-											json: { secret: 'sensitive-data' },
-											binary: { file: { mimeType: 'text/plain', data: 'abc' } },
-										},
-									],
-								],
-							},
-							source: [],
-						},
-					],
-				}
-			: {};
-
 		return {
 			id: 'execution-123',
 			mode,
 			workflowId,
 			data: {
 				version: 1,
-				resultData: { runData },
+				resultData: { runData: {} },
 				executionData,
 			},
 			workflowData: {
 				settings: workflowSettingsPolicy ? { redactionPolicy: workflowSettingsPolicy } : {},
+				nodes: [],
 			},
 		} as unknown as RedactableExecution;
 	};
 
 	describe('processExecution (single-item wrapper)', () => {
-		it('should delegate to processExecutions and return the same execution', async () => {
-			const execution = createMockExecution({ policy: 'all', mode: 'trigger', withRunData: true });
+		it('delegates to processExecutions and returns the same execution', async () => {
+			const execution = makeExecution({ policy: 'all', mode: 'trigger' });
 			const options: ExecutionRedactionOptions = { user: mockUser };
 
 			const spy = jest.spyOn(service, 'processExecutions');
@@ -130,83 +112,51 @@ describe('ExecutionRedactionService', () => {
 	});
 
 	describe('processExecutions (batch)', () => {
-		it('should do nothing for an empty array', async () => {
+		it('does nothing for an empty array', async () => {
 			const options: ExecutionRedactionOptions = { user: mockUser };
 			await service.processExecutions([], options);
 			expect(workflowFinderService.findWorkflowIdsWithScopeForUser).not.toHaveBeenCalled();
 		});
 
-		it('should use a single DB query for N executions (policy-driven)', async () => {
+		it('uses a single DB query for N executions (policy-driven)', async () => {
 			const executions = [
-				createMockExecution({
-					policy: 'all',
-					mode: 'trigger',
-					workflowId: 'wf-1',
-					withRunData: true,
-				}),
-				createMockExecution({
-					policy: 'all',
-					mode: 'trigger',
-					workflowId: 'wf-2',
-					withRunData: true,
-				}),
-				createMockExecution({
-					policy: 'all',
-					mode: 'trigger',
-					workflowId: 'wf-1',
-					withRunData: true,
-				}),
+				makeExecution({ policy: 'all', mode: 'trigger', workflowId: 'wf-1' }),
+				makeExecution({ policy: 'all', mode: 'trigger', workflowId: 'wf-2' }),
+				makeExecution({ policy: 'all', mode: 'trigger', workflowId: 'wf-1' }),
 			];
 			const options: ExecutionRedactionOptions = { user: mockUser };
 
 			await service.processExecutions(executions, options);
 
-			// Should be called exactly once with the unique workflow IDs
 			expect(workflowFinderService.findWorkflowIdsWithScopeForUser).toHaveBeenCalledTimes(1);
 			const [calledIds] = workflowFinderService.findWorkflowIdsWithScopeForUser.mock.calls[0];
 			expect(new Set(calledIds)).toEqual(new Set(['wf-1', 'wf-2']));
 		});
 
-		it('should not call DB when all executions pass policyAllowsReveal (policy=none)', async () => {
+		it('does not call DB when all executions pass policyAllowsReveal (policy=none)', async () => {
 			const executions = [
-				createMockExecution({ policy: 'none', mode: 'trigger', withRunData: true }),
-				createMockExecution({ policy: 'none', mode: 'manual', withRunData: true }),
+				makeExecution({ policy: 'none', mode: 'trigger' }),
+				makeExecution({ policy: 'none', mode: 'manual' }),
 			];
 			const options: ExecutionRedactionOptions = { user: mockUser };
 
 			await service.processExecutions(executions, options);
 
 			expect(workflowFinderService.findWorkflowIdsWithScopeForUser).not.toHaveBeenCalled();
-			// No redaction applied
-			for (const execution of executions) {
-				expect(execution.data.redactionInfo).toBeUndefined();
-			}
 		});
 
-		it('should redact only executions that need redaction in a mixed list', async () => {
-			const noneExecution = createMockExecution({
-				policy: 'none',
-				mode: 'trigger',
-				workflowId: 'wf-none',
-				withRunData: true,
-			});
-			const allExecution = createMockExecution({
-				policy: 'all',
-				mode: 'trigger',
-				workflowId: 'wf-all',
-				withRunData: true,
-			});
-			const nonManualManual = createMockExecution({
+		it('calls FullItemRedactionStrategy only for executions needing redaction in a mixed list', async () => {
+			const noneExecution = makeExecution({ policy: 'none', mode: 'trigger', workflowId: 'wf-none' });
+			const allExecution = makeExecution({ policy: 'all', mode: 'trigger', workflowId: 'wf-all' });
+			const nonManualManual = makeExecution({
 				policy: 'non-manual',
 				mode: 'manual',
 				workflowId: 'wf-nm',
-				withRunData: true,
 			});
-			const nonManualTrigger = createMockExecution({
+			const nonManualTrigger = makeExecution({
 				policy: 'non-manual',
 				mode: 'trigger',
 				workflowId: 'wf-nm',
-				withRunData: true,
 			});
 			const options: ExecutionRedactionOptions = { user: mockUser };
 
@@ -215,352 +165,212 @@ describe('ExecutionRedactionService', () => {
 				options,
 			);
 
-			expect(noneExecution.data.redactionInfo).toBeUndefined();
-			expect(nonManualManual.data.redactionInfo).toBeUndefined();
-			expect(allExecution.data.redactionInfo).toEqual({
-				isRedacted: true,
-				reason: 'workflow_redaction_policy',
-				canReveal: false,
-			});
-			expect(nonManualTrigger.data.redactionInfo).toEqual({
-				isRedacted: true,
-				reason: 'workflow_redaction_policy',
-				canReveal: false,
-			});
-
 			// Only wf-all and wf-nm needed DB check
 			const [calledIds] = workflowFinderService.findWorkflowIdsWithScopeForUser.mock.calls[0];
 			expect(new Set(calledIds)).toEqual(new Set(['wf-all', 'wf-nm']));
+
+			// FullItemRedactionStrategy called only for allExecution and nonManualTrigger
+			expect(fullItemRedactionStrategy.apply).toHaveBeenCalledTimes(2);
+			// NodeDefinedFieldRedactionStrategy called for all 4
+			expect(nodeDefinedFieldRedactionStrategy.apply).toHaveBeenCalledTimes(4);
 		});
 
-		it('should set canReveal: true for executions whose workflow is in the reveal set', async () => {
-			workflowFinderService.findWorkflowIdsWithScopeForUser.mockResolvedValue(new Set(['wf-1']));
+		it('uses a single DB query for N executions when redactExecutionData === true', async () => {
+			const executions = [
+				makeExecution({ policy: 'all', mode: 'trigger', workflowId: 'wf-1' }),
+				makeExecution({ policy: 'all', mode: 'trigger', workflowId: 'wf-2' }),
+			];
+			const options: ExecutionRedactionOptions = { user: mockUser, redactExecutionData: true };
 
-			const execution1 = createMockExecution({
-				policy: 'all',
-				mode: 'trigger',
-				workflowId: 'wf-1',
-				withRunData: true,
-			});
-			const execution2 = createMockExecution({
-				policy: 'all',
-				mode: 'trigger',
-				workflowId: 'wf-2',
-				withRunData: true,
-			});
-			const options: ExecutionRedactionOptions = { user: mockUser };
+			await service.processExecutions(executions, options);
 
-			await service.processExecutions([execution1, execution2], options);
-
-			expect(execution1.data.redactionInfo?.canReveal).toBe(true);
-			expect(execution2.data.redactionInfo?.canReveal).toBe(false);
-		});
-
-		describe('redactExecutionData === true (explicit redact)', () => {
-			it('should redact all executions', async () => {
-				const executions = [
-					createMockExecution({
-						policy: 'none',
-						mode: 'manual',
-						workflowId: 'wf-1',
-						withRunData: true,
-					}),
-					createMockExecution({
-						policy: 'all',
-						mode: 'trigger',
-						workflowId: 'wf-2',
-						withRunData: true,
-					}),
-				];
-				const options: ExecutionRedactionOptions = { user: mockUser, redactExecutionData: true };
-
-				await service.processExecutions(executions, options);
-
-				for (const execution of executions) {
-					expect(execution.data.redactionInfo?.isRedacted).toBe(true);
-					expect(execution.data.redactionInfo?.reason).toBe('user_requested');
-				}
-			});
-
-			it('should not call DB when all executions pass policyAllowsReveal', async () => {
-				const executions = [
-					createMockExecution({ policy: 'none', mode: 'trigger', withRunData: true }),
-				];
-				const options: ExecutionRedactionOptions = { user: mockUser, redactExecutionData: true };
-
-				await service.processExecutions(executions, options);
-
-				expect(workflowFinderService.findWorkflowIdsWithScopeForUser).not.toHaveBeenCalled();
-				expect(executions[0].data.redactionInfo?.canReveal).toBe(true);
-			});
-
-			it('should use a single DB query for N executions needing check', async () => {
-				const executions = [
-					createMockExecution({
-						policy: 'all',
-						mode: 'trigger',
-						workflowId: 'wf-1',
-						withRunData: true,
-					}),
-					createMockExecution({
-						policy: 'all',
-						mode: 'trigger',
-						workflowId: 'wf-2',
-						withRunData: true,
-					}),
-				];
-				const options: ExecutionRedactionOptions = { user: mockUser, redactExecutionData: true };
-
-				await service.processExecutions(executions, options);
-
-				expect(workflowFinderService.findWorkflowIdsWithScopeForUser).toHaveBeenCalledTimes(1);
-			});
-		});
-
-		describe('redactExecutionData === false (explicit reveal)', () => {
-			it('should not call DB and not throw when all executions pass policyAllowsReveal', async () => {
-				const executions = [
-					createMockExecution({ policy: 'none', mode: 'trigger', withRunData: true }),
-					createMockExecution({ policy: 'non-manual', mode: 'manual', withRunData: true }),
-				];
-				const options: ExecutionRedactionOptions = { user: mockUser, redactExecutionData: false };
-
-				await expect(service.processExecutions(executions, options)).resolves.toBeUndefined();
-				expect(workflowFinderService.findWorkflowIdsWithScopeForUser).not.toHaveBeenCalled();
-			});
-
-			it('should use a single DB query and throw ForbiddenError if any execution is not allowed', async () => {
-				workflowFinderService.findWorkflowIdsWithScopeForUser.mockResolvedValue(new Set(['wf-1']));
-
-				const executions = [
-					createMockExecution({
-						policy: 'all',
-						mode: 'trigger',
-						workflowId: 'wf-1',
-						withRunData: true,
-					}),
-					createMockExecution({
-						policy: 'all',
-						mode: 'trigger',
-						workflowId: 'wf-2',
-						withRunData: true,
-					}),
-				];
-				const options: ExecutionRedactionOptions = { user: mockUser, redactExecutionData: false };
-
-				await expect(service.processExecutions(executions, options)).rejects.toThrow(
-					ForbiddenError,
-				);
-				expect(workflowFinderService.findWorkflowIdsWithScopeForUser).toHaveBeenCalledTimes(1);
-			});
-
-			it('should resolve when user has reveal scope for all executions needing check', async () => {
-				workflowFinderService.findWorkflowIdsWithScopeForUser.mockResolvedValue(
-					new Set(['wf-1', 'wf-2']),
-				);
-
-				const executions = [
-					createMockExecution({
-						policy: 'all',
-						mode: 'trigger',
-						workflowId: 'wf-1',
-						withRunData: true,
-					}),
-					createMockExecution({
-						policy: 'all',
-						mode: 'trigger',
-						workflowId: 'wf-2',
-						withRunData: true,
-					}),
-				];
-				const options: ExecutionRedactionOptions = { user: mockUser, redactExecutionData: false };
-
-				await expect(service.processExecutions(executions, options)).resolves.toBeUndefined();
-			});
+			expect(workflowFinderService.findWorkflowIdsWithScopeForUser).toHaveBeenCalledTimes(1);
+			expect(fullItemRedactionStrategy.apply).toHaveBeenCalledTimes(2);
 		});
 	});
 
-	describe('redactExecutionData === true (explicit redact)', () => {
-		it('should apply redaction regardless of policy', async () => {
-			const execution = createMockExecution({
-				policy: 'all',
-				mode: 'trigger',
-				withRunData: true,
-			});
-			const options: ExecutionRedactionOptions = {
-				user: mockUser,
-				redactExecutionData: true,
-			};
-
-			const result = await service.processExecution(execution, options);
-
-			const item = result.data.resultData.runData.TestNode[0].data!.main[0]![0];
-			expect(item.json).toEqual({});
-			expect(item.binary).toBeUndefined();
-			expect(item.redaction).toEqual({ redacted: true, reason: 'user_requested' });
-			expect(result.data.redactionInfo).toEqual({
-				isRedacted: true,
-				reason: 'user_requested',
-				canReveal: false,
-			});
+	describe('FullItemRedactionStrategy inclusion', () => {
+		it('is included when redactExecutionData === true (regardless of policy)', async () => {
+			const execution = makeExecution({ policy: 'none', mode: 'trigger' });
+			await service.processExecution(execution, { user: mockUser, redactExecutionData: true });
+			expect(fullItemRedactionStrategy.apply).toHaveBeenCalledTimes(1);
 		});
 
-		it('should set canReveal: true when policy allows reveal (policy=none)', async () => {
-			// policy='none' means policyAllowsReveal=true → no DB query, canReveal=true
-			const execution = createMockExecution({
-				policy: 'none',
-				mode: 'trigger',
-				withRunData: true,
-			});
-			const options: ExecutionRedactionOptions = {
-				user: mockUser,
-				redactExecutionData: true,
-			};
-
-			const result = await service.processExecution(execution, options);
-
-			expect(workflowFinderService.findWorkflowIdsWithScopeForUser).not.toHaveBeenCalled();
-			expect(result.data.redactionInfo).toEqual({
-				isRedacted: true,
-				reason: 'user_requested',
-				canReveal: true,
-			});
+		it('is included when policy is "all" and mode is manual', async () => {
+			const execution = makeExecution({ policy: 'all', mode: 'manual' });
+			await service.processExecution(execution, { user: mockUser });
+			expect(fullItemRedactionStrategy.apply).toHaveBeenCalledTimes(1);
 		});
 
-		it('should set canReveal: true when policy allows reveal (policy=non-manual, mode=manual)', async () => {
-			const execution = createMockExecution({
-				policy: 'non-manual',
-				mode: 'manual',
-				withRunData: true,
-			});
-			const options: ExecutionRedactionOptions = {
-				user: mockUser,
-				redactExecutionData: true,
-			};
-
-			const result = await service.processExecution(execution, options);
-
-			expect(workflowFinderService.findWorkflowIdsWithScopeForUser).not.toHaveBeenCalled();
-			expect(result.data.redactionInfo).toEqual({
-				isRedacted: true,
-				reason: 'user_requested',
-				canReveal: true,
-			});
+		it('is included when policy is "all" and mode is trigger', async () => {
+			const execution = makeExecution({ policy: 'all', mode: 'trigger' });
+			await service.processExecution(execution, { user: mockUser });
+			expect(fullItemRedactionStrategy.apply).toHaveBeenCalledTimes(1);
 		});
 
-		it('should set canReveal: true when user has reveal permission', async () => {
+		it('is included when policy is "non-manual" and mode is trigger', async () => {
+			const execution = makeExecution({ policy: 'non-manual', mode: 'trigger' });
+			await service.processExecution(execution, { user: mockUser });
+			expect(fullItemRedactionStrategy.apply).toHaveBeenCalledTimes(1);
+		});
+
+		it('is included when policy is "non-manual" and mode is webhook', async () => {
+			const execution = makeExecution({ policy: 'non-manual', mode: 'webhook' });
+			await service.processExecution(execution, { user: mockUser });
+			expect(fullItemRedactionStrategy.apply).toHaveBeenCalledTimes(1);
+		});
+
+		it('is NOT included when policy is "none"', async () => {
+			const execution = makeExecution({ policy: 'none', mode: 'trigger' });
+			await service.processExecution(execution, { user: mockUser });
+			expect(fullItemRedactionStrategy.apply).not.toHaveBeenCalled();
+		});
+
+		it('is NOT included when policy is "non-manual" and mode is manual', async () => {
+			const execution = makeExecution({ policy: 'non-manual', mode: 'manual' });
+			await service.processExecution(execution, { user: mockUser });
+			expect(fullItemRedactionStrategy.apply).not.toHaveBeenCalled();
+		});
+
+		it('is NOT included on reveal path (redactExecutionData === false)', async () => {
 			workflowFinderService.findWorkflowIdsWithScopeForUser.mockResolvedValue(
 				new Set(['workflow-123']),
 			);
-
-			const execution = createMockExecution({
-				policy: 'all',
-				mode: 'trigger',
-				withRunData: true,
-			});
-			const options: ExecutionRedactionOptions = {
-				user: mockUser,
-				redactExecutionData: true,
-			};
-
-			const result = await service.processExecution(execution, options);
-
-			expect(result.data.redactionInfo).toEqual({
-				isRedacted: true,
-				reason: 'user_requested',
-				canReveal: true,
-			});
+			const execution = makeExecution({ policy: 'all', mode: 'trigger' });
+			await service.processExecution(execution, { user: mockUser, redactExecutionData: false });
+			expect(fullItemRedactionStrategy.apply).not.toHaveBeenCalled();
 		});
 	});
 
-	describe('redactExecutionData === false (explicit reveal)', () => {
-		it('should return unmodified execution when user has reveal permission', async () => {
+	describe('NodeDefinedFieldRedactionStrategy inclusion', () => {
+		it('is always included when redacting', async () => {
+			const execution = makeExecution({ policy: 'all', mode: 'trigger' });
+			await service.processExecution(execution, { user: mockUser });
+			expect(nodeDefinedFieldRedactionStrategy.apply).toHaveBeenCalledTimes(1);
+		});
+
+		it('is included even when policy is "none" (no item clearing)', async () => {
+			const execution = makeExecution({ policy: 'none', mode: 'trigger' });
+			await service.processExecution(execution, { user: mockUser });
+			expect(nodeDefinedFieldRedactionStrategy.apply).toHaveBeenCalledTimes(1);
+		});
+
+		it('is included on reveal path (redactExecutionData === false)', async () => {
 			workflowFinderService.findWorkflowIdsWithScopeForUser.mockResolvedValue(
 				new Set(['workflow-123']),
 			);
+			const execution = makeExecution({ policy: 'all', mode: 'trigger' });
+			await service.processExecution(execution, { user: mockUser, redactExecutionData: false });
+			expect(nodeDefinedFieldRedactionStrategy.apply).toHaveBeenCalledTimes(1);
+		});
+	});
 
-			const execution = createMockExecution({
-				policy: 'all',
-				mode: 'trigger',
-				withRunData: true,
+	describe('strategy ordering', () => {
+		it('runs FullItemRedactionStrategy before NodeDefinedFieldRedactionStrategy', async () => {
+			const callOrder: string[] = [];
+			fullItemRedactionStrategy.apply.mockImplementation(async () => {
+				callOrder.push('full');
 			});
-			const options: ExecutionRedactionOptions = {
-				user: mockUser,
-				redactExecutionData: false,
-			};
-
-			const result = await service.processExecution(execution, options);
-
-			expect(result.data.resultData.runData.TestNode[0].data!.main[0]![0].json).toEqual({
-				secret: 'sensitive-data',
+			nodeDefinedFieldRedactionStrategy.apply.mockImplementation(async () => {
+				callOrder.push('node-defined');
 			});
-			expect(result.data.redactionInfo).toBeUndefined();
+
+			const execution = makeExecution({ policy: 'all', mode: 'trigger' });
+			await service.processExecution(execution, { user: mockUser });
+
+			expect(callOrder).toEqual(['full', 'node-defined']);
+		});
+	});
+
+	describe('context passed to strategies', () => {
+		it('passes redactExecutionData from options', async () => {
+			const execution = makeExecution({ policy: 'all', mode: 'trigger' });
+			await service.processExecution(execution, { user: mockUser, redactExecutionData: true });
+
+			const [, context] = fullItemRedactionStrategy.apply.mock.calls[0];
+			expect(context.redactExecutionData).toBe(true);
 		});
 
-		it('should return unmodified execution when policy allows reveal (policy=none), even without permission', async () => {
-			const execution = createMockExecution({
-				policy: 'none',
-				mode: 'trigger',
-				withRunData: true,
-			});
-			const options: ExecutionRedactionOptions = {
-				user: mockUser,
-				redactExecutionData: false,
-			};
-
-			const result = await service.processExecution(execution, options);
-
-			expect(result.data.resultData.runData.TestNode[0].data!.main[0]![0].json).toEqual({
-				secret: 'sensitive-data',
-			});
-			expect(result.data.redactionInfo).toBeUndefined();
-			expect(workflowFinderService.findWorkflowIdsWithScopeForUser).not.toHaveBeenCalled();
-		});
-
-		it('should return unmodified execution when policy allows reveal (policy=non-manual, mode=manual), even without permission', async () => {
-			const execution = createMockExecution({
-				policy: 'non-manual',
-				mode: 'manual',
-				withRunData: true,
-			});
-			const options: ExecutionRedactionOptions = {
-				user: mockUser,
-				redactExecutionData: false,
-			};
-
-			const result = await service.processExecution(execution, options);
-
-			expect(result.data.resultData.runData.TestNode[0].data!.main[0]![0].json).toEqual({
-				secret: 'sensitive-data',
-			});
-			expect(result.data.redactionInfo).toBeUndefined();
-			expect(workflowFinderService.findWorkflowIdsWithScopeForUser).not.toHaveBeenCalled();
-		});
-
-		it('should throw ForbiddenError when user lacks reveal permission', async () => {
-			const execution = createMockExecution({ policy: 'all', mode: 'trigger' });
-			const options: ExecutionRedactionOptions = {
-				user: mockUser,
-				redactExecutionData: false,
-			};
-
-			await expect(service.processExecution(execution, options)).rejects.toThrow(ForbiddenError);
-		});
-
-		it('should emit execution-data-revealed when user is allowed to reveal', async () => {
+		it('passes userCanReveal: true when user has permission', async () => {
 			workflowFinderService.findWorkflowIdsWithScopeForUser.mockResolvedValue(
 				new Set(['workflow-123']),
 			);
+			const execution = makeExecution({ policy: 'all', mode: 'trigger' });
+			await service.processExecution(execution, { user: mockUser });
 
-			const execution = createMockExecution({ policy: 'all', mode: 'trigger', withRunData: true });
-			const options: ExecutionRedactionOptions = {
+			const [, context] = fullItemRedactionStrategy.apply.mock.calls[0];
+			expect(context.userCanReveal).toBe(true);
+		});
+
+		it('passes userCanReveal: false when user lacks permission', async () => {
+			const execution = makeExecution({ policy: 'all', mode: 'trigger' });
+			await service.processExecution(execution, { user: mockUser });
+
+			const [, context] = fullItemRedactionStrategy.apply.mock.calls[0];
+			expect(context.userCanReveal).toBe(false);
+		});
+
+		it('passes userCanReveal: true when policyAllowsReveal (policy=none)', async () => {
+			const execution = makeExecution({ policy: 'none', mode: 'trigger' });
+			await service.processExecution(execution, { user: mockUser });
+
+			const [, context] = nodeDefinedFieldRedactionStrategy.apply.mock.calls[0];
+			expect(context.userCanReveal).toBe(true);
+		});
+
+		it('passes userCanReveal: true when policyAllowsReveal (policy=non-manual, mode=manual)', async () => {
+			const execution = makeExecution({ policy: 'non-manual', mode: 'manual' });
+			await service.processExecution(execution, { user: mockUser });
+
+			const [, context] = nodeDefinedFieldRedactionStrategy.apply.mock.calls[0];
+			expect(context.userCanReveal).toBe(true);
+		});
+	});
+
+	describe('reveal path (redactExecutionData === false)', () => {
+		it('throws ForbiddenError when neither policy nor user allows reveal', async () => {
+			const execution = makeExecution({ policy: 'all', mode: 'trigger' });
+			await expect(
+				service.processExecution(execution, { user: mockUser, redactExecutionData: false }),
+			).rejects.toThrow(ForbiddenError);
+		});
+
+		it('does not throw when policy allows reveal (policy=none)', async () => {
+			const execution = makeExecution({ policy: 'none', mode: 'trigger' });
+			await expect(
+				service.processExecution(execution, { user: mockUser, redactExecutionData: false }),
+			).resolves.toBeDefined();
+		});
+
+		it('does not throw when policy allows reveal (policy=non-manual, mode=manual)', async () => {
+			const execution = makeExecution({ policy: 'non-manual', mode: 'manual' });
+			await expect(
+				service.processExecution(execution, { user: mockUser, redactExecutionData: false }),
+			).resolves.toBeDefined();
+		});
+
+		it('does not throw when user has reveal permission', async () => {
+			workflowFinderService.findWorkflowIdsWithScopeForUser.mockResolvedValue(
+				new Set(['workflow-123']),
+			);
+			const execution = makeExecution({ policy: 'all', mode: 'trigger' });
+			await expect(
+				service.processExecution(execution, { user: mockUser, redactExecutionData: false }),
+			).resolves.toBeDefined();
+		});
+
+		it('emits execution-data-revealed when user is allowed to reveal', async () => {
+			workflowFinderService.findWorkflowIdsWithScopeForUser.mockResolvedValue(
+				new Set(['workflow-123']),
+			);
+			const execution = makeExecution({ policy: 'all', mode: 'trigger' });
+
+			await service.processExecution(execution, {
 				user: mockUser,
 				redactExecutionData: false,
 				ipAddress: '1.2.3.4',
 				userAgent: 'TestAgent/1.0',
-			};
-
-			await service.processExecution(execution, options);
+			});
 
 			expect(eventService.emit).toHaveBeenCalledWith('execution-data-revealed', {
 				user: mockUser,
@@ -572,629 +382,92 @@ describe('ExecutionRedactionService', () => {
 			});
 		});
 
-		it('should not emit execution-data-revealed when user is forbidden', async () => {
-			// workflowFinderService returns null (default in beforeEach) → no permission
-			const execution = createMockExecution({ policy: 'all', mode: 'trigger' });
-			const options: ExecutionRedactionOptions = {
-				user: mockUser,
-				redactExecutionData: false,
-			};
+		it('does not emit execution-data-revealed when user is forbidden', async () => {
+			const execution = makeExecution({ policy: 'all', mode: 'trigger' });
 
-			await expect(service.processExecution(execution, options)).rejects.toThrow(ForbiddenError);
+			await expect(
+				service.processExecution(execution, { user: mockUser, redactExecutionData: false }),
+			).rejects.toThrow(ForbiddenError);
 
 			expect(eventService.emit).not.toHaveBeenCalled();
 		});
-	});
 
-	describe('redactExecutionData === undefined (policy-based)', () => {
-		it('should return unmodified when policy is none', async () => {
-			const execution = createMockExecution({
-				policy: 'none',
-				mode: 'trigger',
-				withRunData: true,
-			});
-			const options: ExecutionRedactionOptions = { user: mockUser };
+		it('does not call DB and does not throw when all executions pass policyAllowsReveal', async () => {
+			const executions = [
+				makeExecution({ policy: 'none', mode: 'trigger' }),
+				makeExecution({ policy: 'non-manual', mode: 'manual' }),
+			];
+			const options: ExecutionRedactionOptions = { user: mockUser, redactExecutionData: false };
 
-			const result = await service.processExecution(execution, options);
-
-			expect(result.data.resultData.runData.TestNode[0].data!.main[0]![0].json).toEqual({
-				secret: 'sensitive-data',
-			});
-			expect(result.data.redactionInfo).toBeUndefined();
+			await expect(service.processExecutions(executions, options)).resolves.toBeUndefined();
+			expect(workflowFinderService.findWorkflowIdsWithScopeForUser).not.toHaveBeenCalled();
 		});
 
-		it('should return unmodified when policy is non-manual and mode is manual', async () => {
-			const execution = createMockExecution({
-				policy: 'non-manual',
-				mode: 'manual',
-				withRunData: true,
-			});
-			const options: ExecutionRedactionOptions = { user: mockUser };
+		it('throws ForbiddenError if any execution in batch is not allowed', async () => {
+			workflowFinderService.findWorkflowIdsWithScopeForUser.mockResolvedValue(new Set(['wf-1']));
 
-			const result = await service.processExecution(execution, options);
+			const executions = [
+				makeExecution({ policy: 'all', mode: 'trigger', workflowId: 'wf-1' }),
+				makeExecution({ policy: 'all', mode: 'trigger', workflowId: 'wf-2' }),
+			];
+			const options: ExecutionRedactionOptions = { user: mockUser, redactExecutionData: false };
 
-			expect(result.data.resultData.runData.TestNode[0].data!.main[0]![0].json).toEqual({
-				secret: 'sensitive-data',
-			});
-			expect(result.data.redactionInfo).toBeUndefined();
-		});
-
-		it('should redact when policy is non-manual and mode is trigger', async () => {
-			const execution = createMockExecution({
-				policy: 'non-manual',
-				mode: 'trigger',
-				withRunData: true,
-			});
-			const options: ExecutionRedactionOptions = { user: mockUser };
-
-			const result = await service.processExecution(execution, options);
-
-			const item = result.data.resultData.runData.TestNode[0].data!.main[0]![0];
-			expect(item.json).toEqual({});
-			expect(item.binary).toBeUndefined();
-			expect(item.redaction).toEqual({ redacted: true, reason: 'workflow_redaction_policy' });
-			expect(result.data.redactionInfo).toEqual({
-				isRedacted: true,
-				reason: 'workflow_redaction_policy',
-				canReveal: false,
-			});
-		});
-
-		it('should set canReveal: true when policy is non-manual, mode is trigger, and user has permission', async () => {
-			workflowFinderService.findWorkflowIdsWithScopeForUser.mockResolvedValue(
-				new Set(['workflow-123']),
-			);
-
-			const execution = createMockExecution({
-				policy: 'non-manual',
-				mode: 'trigger',
-				withRunData: true,
-			});
-			const options: ExecutionRedactionOptions = { user: mockUser };
-
-			const result = await service.processExecution(execution, options);
-
-			expect(result.data.redactionInfo).toEqual({
-				isRedacted: true,
-				reason: 'workflow_redaction_policy',
-				canReveal: true,
-			});
-		});
-
-		it('should redact when policy is non-manual and mode is webhook', async () => {
-			const execution = createMockExecution({
-				policy: 'non-manual',
-				mode: 'webhook',
-				withRunData: true,
-			});
-			const options: ExecutionRedactionOptions = { user: mockUser };
-
-			const result = await service.processExecution(execution, options);
-
-			const item = result.data.resultData.runData.TestNode[0].data!.main[0]![0];
-			expect(item.json).toEqual({});
-			expect(item.redaction).toEqual({ redacted: true, reason: 'workflow_redaction_policy' });
-			expect(result.data.redactionInfo).toEqual({
-				isRedacted: true,
-				reason: 'workflow_redaction_policy',
-				canReveal: false,
-			});
-		});
-
-		it('should redact when policy is all and mode is manual', async () => {
-			const execution = createMockExecution({
-				policy: 'all',
-				mode: 'manual',
-				withRunData: true,
-			});
-			const options: ExecutionRedactionOptions = { user: mockUser };
-
-			const result = await service.processExecution(execution, options);
-
-			const item = result.data.resultData.runData.TestNode[0].data!.main[0]![0];
-			expect(item.json).toEqual({});
-			expect(item.redaction).toEqual({ redacted: true, reason: 'workflow_redaction_policy' });
-			expect(result.data.redactionInfo).toEqual({
-				isRedacted: true,
-				reason: 'workflow_redaction_policy',
-				canReveal: false,
-			});
-		});
-
-		it('should set canReveal: true when policy is all, mode is manual, and user has permission', async () => {
-			workflowFinderService.findWorkflowIdsWithScopeForUser.mockResolvedValue(
-				new Set(['workflow-123']),
-			);
-
-			const execution = createMockExecution({
-				policy: 'all',
-				mode: 'manual',
-				withRunData: true,
-			});
-			const options: ExecutionRedactionOptions = { user: mockUser };
-
-			const result = await service.processExecution(execution, options);
-
-			expect(result.data.redactionInfo).toEqual({
-				isRedacted: true,
-				reason: 'workflow_redaction_policy',
-				canReveal: true,
-			});
-		});
-
-		it('should redact when policy is all and mode is trigger', async () => {
-			const execution = createMockExecution({
-				policy: 'all',
-				mode: 'trigger',
-				withRunData: true,
-			});
-			const options: ExecutionRedactionOptions = { user: mockUser };
-
-			const result = await service.processExecution(execution, options);
-
-			const item = result.data.resultData.runData.TestNode[0].data!.main[0]![0];
-			expect(item.json).toEqual({});
-			expect(item.redaction).toEqual({ redacted: true, reason: 'workflow_redaction_policy' });
-			expect(result.data.redactionInfo).toEqual({
-				isRedacted: true,
-				reason: 'workflow_redaction_policy',
-				canReveal: false,
-			});
-		});
-
-		it('should set canReveal: true when policy is all, mode is trigger, and user has permission', async () => {
-			workflowFinderService.findWorkflowIdsWithScopeForUser.mockResolvedValue(
-				new Set(['workflow-123']),
-			);
-
-			const execution = createMockExecution({
-				policy: 'all',
-				mode: 'trigger',
-				withRunData: true,
-			});
-			const options: ExecutionRedactionOptions = { user: mockUser };
-
-			const result = await service.processExecution(execution, options);
-
-			expect(result.data.redactionInfo).toEqual({
-				isRedacted: true,
-				reason: 'workflow_redaction_policy',
-				canReveal: true,
-			});
-		});
-
-		it('should default to none when runtimeData and workflow settings are missing', async () => {
-			const execution = createMockExecution({
-				withRuntimeData: false,
-				mode: 'trigger',
-				withRunData: true,
-			});
-			const options: ExecutionRedactionOptions = { user: mockUser };
-
-			const result = await service.processExecution(execution, options);
-
-			expect(result.data.resultData.runData.TestNode[0].data!.main[0]![0].json).toEqual({
-				secret: 'sensitive-data',
-			});
-			expect(result.data.redactionInfo).toBeUndefined();
-		});
-
-		it('should fall back to workflow settings when runtimeData is missing', async () => {
-			const execution = createMockExecution({
-				withRuntimeData: false,
-				workflowSettingsPolicy: 'all',
-				mode: 'trigger',
-				withRunData: true,
-			});
-			const options: ExecutionRedactionOptions = { user: mockUser };
-
-			const result = await service.processExecution(execution, options);
-
-			const item = result.data.resultData.runData.TestNode[0].data!.main[0]![0];
-			expect(item.json).toEqual({});
-			expect(item.redaction).toEqual({ redacted: true, reason: 'workflow_redaction_policy' });
-			expect(result.data.redactionInfo).toEqual({
-				isRedacted: true,
-				reason: 'workflow_redaction_policy',
-				canReveal: false,
-			});
+			await expect(service.processExecutions(executions, options)).rejects.toThrow(ForbiddenError);
+			expect(workflowFinderService.findWorkflowIdsWithScopeForUser).toHaveBeenCalledTimes(1);
 		});
 	});
 
-	describe('error redaction', () => {
-		const mockNode = {
-			id: 'node-1',
-			name: 'TestNode',
-			type: 'n8n-nodes-base.httpRequest',
-			typeVersion: 1,
-			position: [0, 0] as [number, number],
-			parameters: {},
-		} as INode;
-
-		describe('item-level error (INodeExecutionData.error)', () => {
-			it('should redact NodeApiError with httpCode and preserve type and httpCode', async () => {
-				const error = new NodeApiError(mockNode, { message: 'Not Found' }, { httpCode: '404' });
-				const execution = createMockExecution({
-					policy: 'all',
-					mode: 'trigger',
-					withRunData: true,
-				});
-				execution.data.resultData.runData.TestNode[0].data!.main[0]![0].error = error;
-				const options: ExecutionRedactionOptions = { user: mockUser };
-
-				const result = await service.processExecution(execution, options);
-
-				const item = result.data.resultData.runData.TestNode[0].data!.main[0]![0];
-				expect(item.error).toBeUndefined();
-				expect(item.redaction?.error).toEqual({ type: 'NodeApiError', httpCode: '404' });
-			});
-
-			it('should preserve httpCode: null when NodeApiError has no http code', async () => {
-				const error = new NodeApiError(mockNode, { message: 'Unknown Error' });
-				const execution = createMockExecution({
-					policy: 'all',
-					mode: 'trigger',
-					withRunData: true,
-				});
-				execution.data.resultData.runData.TestNode[0].data!.main[0]![0].error = error;
-				const options: ExecutionRedactionOptions = { user: mockUser };
-
-				const result = await service.processExecution(execution, options);
-
-				const item = result.data.resultData.runData.TestNode[0].data!.main[0]![0];
-				expect(item.error).toBeUndefined();
-				expect(item.redaction?.error).toEqual({ type: 'NodeApiError', httpCode: null });
-			});
-
-			it('should redact NodeOperationError without httpCode', async () => {
-				const error = new NodeOperationError(mockNode, 'Operation failed');
-				const execution = createMockExecution({
-					policy: 'all',
-					mode: 'trigger',
-					withRunData: true,
-				});
-				execution.data.resultData.runData.TestNode[0].data!.main[0]![0].error = error;
-				const options: ExecutionRedactionOptions = { user: mockUser };
-
-				const result = await service.processExecution(execution, options);
-
-				const item = result.data.resultData.runData.TestNode[0].data!.main[0]![0];
-				expect(item.error).toBeUndefined();
-				expect(item.redaction?.error).toEqual({ type: 'NodeOperationError' });
-				expect(item.redaction?.error).not.toHaveProperty('httpCode');
-			});
-
-			it('should not add error key to redaction when item has no error', async () => {
-				const execution = createMockExecution({
-					policy: 'all',
-					mode: 'trigger',
-					withRunData: true,
-				});
-				// item has no error field
-				const options: ExecutionRedactionOptions = { user: mockUser };
-
-				const result = await service.processExecution(execution, options);
-
-				const item = result.data.resultData.runData.TestNode[0].data!.main[0]![0];
-				expect(item.error).toBeUndefined();
-				expect(item.redaction).toEqual({ redacted: true, reason: 'workflow_redaction_policy' });
-				expect(item.redaction).not.toHaveProperty('error');
-			});
+	describe('DB call optimisation', () => {
+		it('does not call findWorkflowIdsWithScopeForUser when policyAllowsReveal (policy=none)', async () => {
+			const execution = makeExecution({ policy: 'none', mode: 'trigger' });
+			await service.processExecution(execution, { user: mockUser });
+			expect(workflowFinderService.findWorkflowIdsWithScopeForUser).not.toHaveBeenCalled();
 		});
 
-		describe('task-level error (ITaskData.error)', () => {
-			it('should redact NodeApiError on task and preserve type and httpCode', async () => {
-				const error = new NodeApiError(mockNode, { message: 'Server Error' }, { httpCode: '500' });
-				const execution = createMockExecution({
-					policy: 'all',
-					mode: 'trigger',
-					withRunData: true,
-				});
-				execution.data.resultData.runData.TestNode[0].error = error;
-				const options: ExecutionRedactionOptions = { user: mockUser };
-
-				const result = await service.processExecution(execution, options);
-
-				const taskData = result.data.resultData.runData.TestNode[0];
-				expect(taskData.error).toBeUndefined();
-				expect(taskData.redactedError).toEqual({ type: 'NodeApiError', httpCode: '500' });
-			});
-
-			it('should redact ExpressionError on task without httpCode', async () => {
-				const error = new ExpressionError('Expression evaluation failed');
-				const execution = createMockExecution({
-					policy: 'all',
-					mode: 'trigger',
-					withRunData: true,
-				});
-				execution.data.resultData.runData.TestNode[0].error = error;
-				const options: ExecutionRedactionOptions = { user: mockUser };
-
-				const result = await service.processExecution(execution, options);
-
-				const taskData = result.data.resultData.runData.TestNode[0];
-				expect(taskData.error).toBeUndefined();
-				expect(taskData.redactedError).toEqual({ type: 'ExpressionError' });
-				expect(taskData.redactedError).not.toHaveProperty('httpCode');
-			});
-
-			it('should not set redactedError on task when task has no error', async () => {
-				const execution = createMockExecution({
-					policy: 'all',
-					mode: 'trigger',
-					withRunData: true,
-				});
-				const options: ExecutionRedactionOptions = { user: mockUser };
-
-				const result = await service.processExecution(execution, options);
-
-				const taskData = result.data.resultData.runData.TestNode[0];
-				expect(taskData.error).toBeUndefined();
-				expect(taskData.redactedError).toBeUndefined();
-			});
+		it('does not call findWorkflowIdsWithScopeForUser when policyAllowsReveal (policy=non-manual, mode=manual)', async () => {
+			const execution = makeExecution({ policy: 'non-manual', mode: 'manual' });
+			await service.processExecution(execution, { user: mockUser });
+			expect(workflowFinderService.findWorkflowIdsWithScopeForUser).not.toHaveBeenCalled();
 		});
 
-		describe('workflow-level error (resultData.error)', () => {
-			it('should redact resultData.error and preserve type', async () => {
-				const error = new NodeOperationError(mockNode, 'Workflow operation failed');
-				const execution = createMockExecution({
-					policy: 'all',
-					mode: 'trigger',
-					withRunData: false,
-				});
-				execution.data.resultData.error = error;
-				const options: ExecutionRedactionOptions = { user: mockUser };
-
-				const result = await service.processExecution(execution, options);
-
-				expect(result.data.resultData.error).toBeUndefined();
-				expect(result.data.resultData.redactedError).toEqual({ type: 'NodeOperationError' });
-			});
-
-			it('should redact NodeApiError in resultData and preserve httpCode', async () => {
-				const error = new NodeApiError(mockNode, { message: 'Forbidden' }, { httpCode: '403' });
-				const execution = createMockExecution({
-					policy: 'all',
-					mode: 'trigger',
-					withRunData: false,
-				});
-				execution.data.resultData.error = error;
-				const options: ExecutionRedactionOptions = { user: mockUser };
-
-				const result = await service.processExecution(execution, options);
-
-				expect(result.data.resultData.error).toBeUndefined();
-				expect(result.data.resultData.redactedError).toEqual({
-					type: 'NodeApiError',
-					httpCode: '403',
-				});
-			});
-
-			it('should not set redactedError in resultData when no error is present', async () => {
-				const execution = createMockExecution({
-					policy: 'all',
-					mode: 'trigger',
-					withRunData: false,
-				});
-				const options: ExecutionRedactionOptions = { user: mockUser };
-
-				const result = await service.processExecution(execution, options);
-
-				expect(result.data.resultData.error).toBeUndefined();
-				expect(result.data.resultData.redactedError).toBeUndefined();
-			});
-		});
-
-		describe('deserialized plain objects (after DB round-trip)', () => {
-			it('should use error.name for type when error is a deserialized NodeApiError', async () => {
-				const error = {
-					name: 'NodeApiError',
-					message: 'Not Found',
-					timestamp: Date.now(),
-					lineNumber: undefined,
-					description: null,
-					context: {},
-					cause: undefined,
-				} as unknown as ExecutionError;
-
-				const execution = createMockExecution({
-					policy: 'all',
-					mode: 'trigger',
-					withRunData: false,
-				});
-				execution.data.resultData.error = error;
-				const options: ExecutionRedactionOptions = { user: mockUser };
-
-				const result = await service.processExecution(execution, options);
-
-				expect(result.data.resultData.error).toBeUndefined();
-				expect(result.data.resultData.redactedError).toEqual({
-					type: 'NodeApiError',
-					httpCode: null,
-				});
-			});
-
-			it('should use error.name for deserialized NodeOperationError without httpCode', async () => {
-				const error = {
-					name: 'NodeOperationError',
-					message: 'Operation failed',
-					timestamp: Date.now(),
-					lineNumber: undefined,
-					description: null,
-					context: {},
-					cause: undefined,
-				} as unknown as ExecutionError;
-
-				const execution = createMockExecution({
-					policy: 'all',
-					mode: 'trigger',
-					withRunData: false,
-				});
-				execution.data.resultData.error = error;
-				const options: ExecutionRedactionOptions = { user: mockUser };
-
-				const result = await service.processExecution(execution, options);
-
-				expect(result.data.resultData.error).toBeUndefined();
-				expect(result.data.resultData.redactedError).toEqual({ type: 'NodeOperationError' });
-				expect(result.data.resultData.redactedError).not.toHaveProperty('httpCode');
-			});
-
-			it('should use error.name for deserialized ExpressionError without httpCode', async () => {
-				const error = {
-					name: 'ExpressionError',
-					message: 'Expression evaluation failed',
-					timestamp: Date.now(),
-					lineNumber: undefined,
-					description: null,
-					context: {},
-					cause: undefined,
-				} as unknown as ExecutionError;
-
-				const execution = createMockExecution({
-					policy: 'all',
-					mode: 'trigger',
-					withRunData: false,
-				});
-				execution.data.resultData.error = error;
-				const options: ExecutionRedactionOptions = { user: mockUser };
-
-				const result = await service.processExecution(execution, options);
-
-				expect(result.data.resultData.error).toBeUndefined();
-				expect(result.data.resultData.redactedError).toEqual({ type: 'ExpressionError' });
-				expect(result.data.resultData.redactedError).not.toHaveProperty('httpCode');
-			});
-
-			it('should preserve httpCode from spread plain object (pre-DB serialization)', async () => {
-				const liveError = new NodeApiError(mockNode, { message: 'Not Found' }, { httpCode: '404' });
-				const spreadError = { ...liveError } as unknown as ExecutionError;
-
-				const execution = createMockExecution({
-					policy: 'all',
-					mode: 'trigger',
-					withRunData: false,
-				});
-				execution.data.resultData.error = spreadError;
-				const options: ExecutionRedactionOptions = { user: mockUser };
-
-				const result = await service.processExecution(execution, options);
-
-				expect(result.data.resultData.error).toBeUndefined();
-				expect(result.data.resultData.redactedError).toEqual({
-					type: 'NodeApiError',
-					httpCode: '404',
-				});
-			});
+		it('calls findWorkflowIdsWithScopeForUser once when policy does not inherently allow reveal', async () => {
+			const execution = makeExecution({ policy: 'all', mode: 'trigger' });
+			await service.processExecution(execution, { user: mockUser });
+			expect(workflowFinderService.findWorkflowIdsWithScopeForUser).toHaveBeenCalledTimes(1);
+			expect(workflowFinderService.findWorkflowIdsWithScopeForUser).toHaveBeenCalledWith(
+				['workflow-123'],
+				mockUser,
+				['execution:reveal'],
+			);
 		});
 	});
 
-	describe('resolvePolicy precedence', () => {
-		it('should prefer runtimeData policy over workflow settings', async () => {
-			const execution = createMockExecution({
+	describe('policy resolution precedence', () => {
+		it('prefers runtimeData policy over workflow settings (runtime=none overrides settings=all)', async () => {
+			const execution = makeExecution({
 				policy: 'none',
 				workflowSettingsPolicy: 'all',
 				mode: 'trigger',
-				withRunData: true,
 			});
-			const options: ExecutionRedactionOptions = { user: mockUser };
-
-			const result = await service.processExecution(execution, options);
-
-			// runtimeData says 'none', so no redaction despite workflow settings saying 'all'
-			expect(result.data.resultData.runData.TestNode[0].data!.main[0]![0].json).toEqual({
-				secret: 'sensitive-data',
-			});
-			expect(result.data.redactionInfo).toBeUndefined();
-		});
-	});
-
-	describe('applyRedaction behavior', () => {
-		it('should handle empty runData gracefully', async () => {
-			const execution = createMockExecution({
-				policy: 'all',
-				mode: 'trigger',
-				withRunData: false,
-			});
-			const options: ExecutionRedactionOptions = { user: mockUser };
-
-			const result = await service.processExecution(execution, options);
-
-			expect(result).toBe(execution);
+			await service.processExecution(execution, { user: mockUser });
+			// runtimeData policy=none → no item clearing despite workflow settings=all
+			expect(fullItemRedactionStrategy.apply).not.toHaveBeenCalled();
 		});
 
-		it('should redact inputOverride data', async () => {
-			const execution = createMockExecution({
-				policy: 'all',
+		it('falls back to workflow settings when runtimeData is missing', async () => {
+			const execution = makeExecution({
+				withRuntimeData: false,
+				workflowSettingsPolicy: 'all',
 				mode: 'trigger',
-				withRunData: true,
 			});
-			// Add inputOverride to the task data
-			execution.data.resultData.runData.TestNode[0].inputOverride = {
-				main: [[{ json: { override: 'secret' }, binary: { f: { mimeType: 'x', data: 'y' } } }]],
-			};
-			const options: ExecutionRedactionOptions = { user: mockUser };
-
-			const result = await service.processExecution(execution, options);
-
-			const overrideItem = result.data.resultData.runData.TestNode[0].inputOverride!.main[0]![0];
-			expect(overrideItem.json).toEqual({});
-			expect(overrideItem.binary).toBeUndefined();
-			expect(overrideItem.redaction).toEqual({
-				redacted: true,
-				reason: 'workflow_redaction_policy',
-			});
-			expect(result.data.redactionInfo).toEqual({
-				isRedacted: true,
-				reason: 'workflow_redaction_policy',
-				canReveal: false,
-			});
+			await service.processExecution(execution, { user: mockUser });
+			expect(fullItemRedactionStrategy.apply).toHaveBeenCalledTimes(1);
 		});
 
-		it('should handle large executions with 1000+ items efficiently', async () => {
-			const items = Array.from({ length: 1500 }, (_, i) => ({
-				json: { id: i, secret: `sensitive-data-${i}`, nested: { key: `value-${i}` } },
-				binary: { file: { mimeType: 'text/plain', data: `data-${i}` } },
-			}));
-
-			const execution = createMockExecution({
-				policy: 'all',
-				mode: 'trigger',
-				withRunData: false,
-			});
-			execution.data.resultData.runData = {
-				LargeNode: [
-					{
-						startTime: 0,
-						executionIndex: 0,
-						executionTime: 100,
-						executionStatus: 'success' as const,
-						data: { main: [items] },
-						source: [],
-					},
-				],
-			};
-			const options: ExecutionRedactionOptions = { user: mockUser };
-
-			const start = performance.now();
-			const result = await service.processExecution(execution, options);
-			const elapsed = performance.now() - start;
-
-			const redactedItems = result.data.resultData.runData.LargeNode[0].data!.main[0]!;
-			expect(redactedItems).toHaveLength(1500);
-			for (const item of redactedItems) {
-				expect(item.json).toEqual({});
-				expect(item.binary).toBeUndefined();
-				expect(item.redaction).toEqual({ redacted: true, reason: 'workflow_redaction_policy' });
-			}
-
-			// Redaction of 1500 items should complete well under 100ms
-			expect(elapsed).toBeLessThan(100);
-			expect(result.data.redactionInfo).toEqual({
-				isRedacted: true,
-				reason: 'workflow_redaction_policy',
-				canReveal: false,
-			});
+		it('defaults to none when both runtimeData and workflow settings are missing', async () => {
+			const execution = makeExecution({ withRuntimeData: false, mode: 'trigger' });
+			await service.processExecution(execution, { user: mockUser });
+			expect(fullItemRedactionStrategy.apply).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
+++ b/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
@@ -146,7 +146,11 @@ describe('ExecutionRedactionService', () => {
 		});
 
 		it('calls FullItemRedactionStrategy only for executions needing redaction in a mixed list', async () => {
-			const noneExecution = makeExecution({ policy: 'none', mode: 'trigger', workflowId: 'wf-none' });
+			const noneExecution = makeExecution({
+				policy: 'none',
+				mode: 'trigger',
+				workflowId: 'wf-none',
+			});
 			const allExecution = makeExecution({ policy: 'all', mode: 'trigger', workflowId: 'wf-all' });
 			const nonManualManual = makeExecution({
 				policy: 'non-manual',

--- a/packages/cli/src/modules/redaction/executions/execution-redaction.interfaces.ts
+++ b/packages/cli/src/modules/redaction/executions/execution-redaction.interfaces.ts
@@ -1,0 +1,28 @@
+import type { User } from '@n8n/db';
+
+import type { RedactableExecution } from '@/executions/execution-redaction';
+
+/**
+ * Context passed to every redaction strategy by the orchestrator.
+ * The orchestrator resolves `userCanReveal` once (single DB call) and shares
+ * the result so individual strategies never need to perform permission checks.
+ */
+export interface RedactionContext {
+	readonly user: User;
+	readonly redactExecutionData: boolean | undefined;
+	/** Pre-resolved by the orchestrator — true if the user can see unredacted data. */
+	readonly userCanReveal: boolean;
+}
+
+/**
+ * A composable unit of redaction logic.  Strategies are pure data transformers:
+ * they mutate `execution` in place and own any side-effects they need to apply
+ * (e.g. setting `execution.data.redactionInfo`).
+ *
+ * Strategies MUST NOT evaluate policy or check permissions — those decisions
+ * are made by the orchestrator when building the pipeline.
+ */
+export interface IExecutionRedactionStrategy {
+	readonly name: string;
+	apply(execution: RedactableExecution, context: RedactionContext): Promise<void>;
+}

--- a/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
+++ b/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
@@ -1,27 +1,36 @@
 import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
+import { WorkflowExecuteMode, WorkflowSettings } from 'n8n-workflow';
 
 import type {
 	ExecutionRedaction,
 	ExecutionRedactionOptions,
 	RedactableExecution,
 } from '@/executions/execution-redaction';
-import {
-	type ExecutionError,
-	type INodeExecutionData,
-	type IRedactedErrorInfo,
-	type ITaskDataConnections,
-	type WorkflowExecuteMode,
-	WorkflowSettings,
-} from 'n8n-workflow';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { EventService } from '@/events/event.service';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
+import type {
+	IExecutionRedactionStrategy,
+	RedactionContext,
+} from './execution-redaction.interfaces';
+import { FullItemRedactionStrategy } from './strategies/full-item-redaction.strategy';
+import { NodeDefinedFieldRedactionStrategy } from './strategies/node-defined-field-redaction.strategy';
+
 const MANUAL_MODES: ReadonlySet<WorkflowExecuteMode> = new Set(['manual']);
 
 /**
- * Service responsible for redacting sensitive data from executions.
+ * Orchestrates the execution redaction pipeline with batch permission resolution.
+ *
+ * Responsibilities:
+ *   1. Resolve `userCanReveal` with a single DB call for any number of executions.
+ *   2. Build a `RedactionContext` per execution.
+ *   3. Construct the strategy pipeline based on policy and request options.
+ *   4. Run each strategy in order; strategies own all data mutations.
+ *
+ * Policy evaluation and permission checks live here.
+ * Data transformation lives in the strategies.
  */
 @Service()
 export class ExecutionRedactionService implements ExecutionRedaction {
@@ -29,6 +38,8 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 		private readonly logger: Logger,
 		private readonly workflowFinderService: WorkflowFinderService,
 		private readonly eventService: EventService,
+		private readonly fullItemRedactionStrategy: FullItemRedactionStrategy,
+		private readonly nodeDefinedFieldRedactionStrategy: NodeDefinedFieldRedactionStrategy,
 	) {}
 
 	async init(): Promise<void> {
@@ -59,28 +70,6 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 	): Promise<void> {
 		if (executions.length === 0) return;
 
-		if (options.redactExecutionData === true) {
-			// User explicitly wants redacted data — apply to all, but set canReveal correctly.
-			// canReveal = policyAllowsReveal OR user has execution:reveal scope.
-			// Only query DB for executions where policy doesn't already allow reveal.
-			const needsCheck = executions.filter((e) => !this.policyAllowsReveal(e));
-			let revealableIds = new Set<string>();
-			if (needsCheck.length > 0) {
-				const uniqueWorkflowIds = [...new Set(needsCheck.map((e) => e.workflowId))];
-				revealableIds = await this.workflowFinderService.findWorkflowIdsWithScopeForUser(
-					uniqueWorkflowIds,
-					options.user,
-					['execution:reveal'],
-				);
-			}
-			for (const execution of executions) {
-				const canReveal =
-					this.policyAllowsReveal(execution) || revealableIds.has(execution.workflowId);
-				this.applyRedaction(execution, 'user_requested', canReveal);
-			}
-			return;
-		}
-
 		if (options.redactExecutionData === false) {
 			// User explicitly wants unredacted data — allowed if the policy or scope permits it.
 			const needsCheck = executions.filter((e) => !this.policyAllowsReveal(e));
@@ -108,26 +97,76 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 					redactionPolicy: this.resolvePolicy(execution),
 				});
 			}
+			// NodeDefinedFieldRedactionStrategy always runs — node-declared sensitive fields
+			// are never revealable, even on the explicit reveal path.
+			for (const execution of executions) {
+				const context: RedactionContext = {
+					user: options.user,
+					redactExecutionData: false,
+					userCanReveal: true,
+				};
+				await this.nodeDefinedFieldRedactionStrategy.apply(execution, context);
+			}
 			return;
 		}
 
-		// Default: policy-driven redaction. Skip executions where the policy allows reveal.
-		const needsRedaction = executions.filter((e) => !this.policyAllowsReveal(e));
-		if (needsRedaction.length === 0) return;
-
-		const uniqueWorkflowIds = [...new Set(needsRedaction.map((e) => e.workflowId))];
-		const revealableIds = await this.workflowFinderService.findWorkflowIdsWithScopeForUser(
-			uniqueWorkflowIds,
-			options.user,
-			['execution:reveal'],
-		);
-		for (const execution of needsRedaction) {
-			this.applyRedaction(
-				execution,
-				'workflow_redaction_policy',
-				revealableIds.has(execution.workflowId),
+		// Redact path: redactExecutionData === true (explicit) or undefined (policy-driven).
+		// Only query the DB for executions where policy doesn't already allow reveal.
+		const needsCheck = executions.filter((e) => !this.policyAllowsReveal(e));
+		let revealableIds = new Set<string>();
+		if (needsCheck.length > 0) {
+			const uniqueWorkflowIds = [...new Set(needsCheck.map((e) => e.workflowId))];
+			revealableIds = await this.workflowFinderService.findWorkflowIdsWithScopeForUser(
+				uniqueWorkflowIds,
+				options.user,
+				['execution:reveal'],
 			);
 		}
+		for (const execution of executions) {
+			const policyAllowsReveal = this.policyAllowsReveal(execution);
+			const userCanReveal = policyAllowsReveal || revealableIds.has(execution.workflowId);
+			const context: RedactionContext = {
+				user: options.user,
+				redactExecutionData: options.redactExecutionData,
+				userCanReveal,
+			};
+			const pipeline = this.buildPipeline(execution, context, policyAllowsReveal);
+			for (const strategy of pipeline) {
+				await strategy.apply(execution, context);
+			}
+		}
+	}
+
+	/**
+	 * Constructs the ordered strategy pipeline for this execution.
+	 *
+	 * - `FullItemRedactionStrategy` is included when items should be cleared:
+	 *   explicit redact (`redactExecutionData === true`), policy=all, or
+	 *   policy=non-manual on a non-manual execution mode.
+	 * - `NodeDefinedFieldRedactionStrategy` is always appended last — node-declared
+	 *   sensitive fields are never revealable.
+	 */
+	private buildPipeline(
+		execution: RedactableExecution,
+		context: RedactionContext,
+		policyAllowsReveal: boolean,
+	): IExecutionRedactionStrategy[] {
+		const pipeline: IExecutionRedactionStrategy[] = [];
+
+		const policy = this.resolvePolicy(execution);
+		const shouldClearItems =
+			context.redactExecutionData === true ||
+			(!policyAllowsReveal &&
+				(policy === 'all' ||
+					(policy === 'non-manual' && !MANUAL_MODES.has(execution.mode))));
+
+		if (shouldClearItems) {
+			pipeline.push(this.fullItemRedactionStrategy);
+		}
+
+		pipeline.push(this.nodeDefinedFieldRedactionStrategy);
+
+		return pipeline;
 	}
 
 	/**
@@ -155,92 +194,5 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 			execution.workflowData.settings?.redactionPolicy ??
 			'none'
 		);
-	}
-
-	/**
-	 * Mutates execution data in place, replacing all node output json with a
-	 * redaction marker and removing binary data. Also sets `execution.data.redactionInfo`
-	 * with metadata about the redaction.
-	 */
-	private applyRedaction(execution: RedactableExecution, reason: string, canReveal: boolean): void {
-		const runData = execution.data.resultData.runData;
-		if (runData) {
-			for (const nodeName of Object.keys(runData)) {
-				for (const taskData of runData[nodeName]) {
-					if (taskData.data) {
-						this.redactConnections(taskData.data, reason);
-					}
-					if (taskData.inputOverride) {
-						this.redactConnections(taskData.inputOverride, reason);
-					}
-					if (taskData.error) {
-						taskData.redactedError = this.redactError(taskData.error);
-						delete taskData.error;
-					}
-				}
-			}
-		}
-
-		const resultData = execution.data.resultData;
-		if (resultData.error) {
-			resultData.redactedError = this.redactError(resultData.error);
-			delete resultData.error;
-		}
-
-		execution.data.redactionInfo = { isRedacted: true, reason, canReveal };
-	}
-
-	/** Walks an ITaskDataConnections structure and redacts every data item in place. */
-	private redactConnections(connections: ITaskDataConnections, reason: string): void {
-		for (const connectionType of Object.keys(connections)) {
-			const outputs = connections[connectionType];
-			for (const items of outputs) {
-				if (items) {
-					for (const item of items) {
-						this.redactItem(item, reason);
-					}
-				}
-			}
-		}
-	}
-
-	/**
-	 * Redacts all json and binary data from a single node execution data item.
-	 */
-	private redactItem(item: INodeExecutionData, reason: string): void {
-		item.json = {};
-		delete item.binary;
-
-		const redactedError = item.error ? this.redactError(item.error) : undefined;
-		delete item.error;
-
-		item.redaction = {
-			redacted: true,
-			reason,
-			...(redactedError !== undefined && { error: redactedError }),
-		};
-	}
-
-	/**
-	 * Extracts safe, non-PII technical metadata from any execution error for
-	 * inclusion in the redaction marker. Handles both live class instances and
-	 * deserialized plain objects (after DB round-trip via flatted.stringify/parse).
-	 *
-	 * Uses error.name (survives serialization) instead of error.constructor.name
-	 * (returns 'Object' for plain objects) and name-based checks instead of
-	 * instanceof (fails for plain objects).
-	 *
-	 * Preserves: error name (type classification), HTTP status code
-	 * from NodeApiError (numeric code only, null if absent or unknown).
-	 * Omits: message, description, messages[], cause, context, errorResponse
-	 * — all of which may contain PII or sensitive credential data.
-	 */
-	private redactError(error: ExecutionError): IRedactedErrorInfo {
-		const result: IRedactedErrorInfo = { type: error.name };
-		if (error.name === 'NodeApiError') {
-			result.httpCode =
-				('httpCode' in error ? (error as { httpCode: string | null }).httpCode : null) ?? null;
-		}
-		return result;
 	}
 }

--- a/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
+++ b/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
@@ -59,7 +59,8 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 
 	/**
 	 * Processes a list of executions and applies redaction based on the provided options.
-	 * Resolves all user reveal permissions in a single DB query regardless of list size.
+	 * A single DB query resolves reveal permissions for any number of executions on both
+	 * the redact and reveal paths.
 	 *
 	 * @param executions - The executions to process (mutated in place)
 	 * @param options - Options for redaction processing
@@ -70,48 +71,8 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 	): Promise<void> {
 		if (executions.length === 0) return;
 
-		if (options.redactExecutionData === false) {
-			// User explicitly wants unredacted data — allowed if the policy or scope permits it.
-			const needsCheck = executions.filter((e) => !this.policyAllowsReveal(e));
-			if (needsCheck.length > 0) {
-				const uniqueWorkflowIds = [...new Set(needsCheck.map((e) => e.workflowId))];
-				const revealableIds = await this.workflowFinderService.findWorkflowIdsWithScopeForUser(
-					uniqueWorkflowIds,
-					options.user,
-					['execution:reveal'],
-				);
-				for (const execution of needsCheck) {
-					if (!revealableIds.has(execution.workflowId)) {
-						throw new ForbiddenError();
-					}
-				}
-			}
-			// Emit audit event for every execution the caller was permitted to reveal.
-			for (const execution of executions) {
-				this.eventService.emit('execution-data-revealed', {
-					user: options.user,
-					executionId: execution.id ?? '',
-					workflowId: execution.workflowId,
-					ipAddress: options.ipAddress ?? '',
-					userAgent: options.userAgent ?? '',
-					redactionPolicy: this.resolvePolicy(execution),
-				});
-			}
-			// NodeDefinedFieldRedactionStrategy always runs — node-declared sensitive fields
-			// are never revealable, even on the explicit reveal path.
-			for (const execution of executions) {
-				const context: RedactionContext = {
-					user: options.user,
-					redactExecutionData: false,
-					userCanReveal: true,
-				};
-				await this.nodeDefinedFieldRedactionStrategy.apply(execution, context);
-			}
-			return;
-		}
-
-		// Redact path: redactExecutionData === true (explicit) or undefined (policy-driven).
-		// Only query the DB for executions where policy doesn't already allow reveal.
+		// Single DB call shared by both the reveal and redact paths.
+		// Only executions where policy doesn't already grant access need a scope check.
 		const needsCheck = executions.filter((e) => !this.policyAllowsReveal(e));
 		let revealableIds = new Set<string>();
 		if (needsCheck.length > 0) {
@@ -122,6 +83,19 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 				['execution:reveal'],
 			);
 		}
+
+		// Reveal path: validate all permissions atomically before any processing.
+		if (options.redactExecutionData === false) {
+			for (const execution of needsCheck) {
+				if (!revealableIds.has(execution.workflowId)) {
+					throw new ForbiddenError();
+				}
+			}
+		}
+
+		// Unified pipeline execution. buildPipeline excludes FullItemRedactionStrategy on the
+		// reveal path (redactExecutionData === false). NodeDefinedFieldRedactionStrategy
+		// always runs — node-declared sensitive fields are never revealable.
 		for (const execution of executions) {
 			const policyAllowsReveal = this.policyAllowsReveal(execution);
 			const userCanReveal = policyAllowsReveal || revealableIds.has(execution.workflowId);
@@ -135,6 +109,20 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 				await strategy.apply(execution, context);
 			}
 		}
+
+		// Emit audit events after all executions have been successfully processed.
+		if (options.redactExecutionData === false) {
+			for (const execution of executions) {
+				this.eventService.emit('execution-data-revealed', {
+					user: options.user,
+					executionId: execution.id ?? '',
+					workflowId: execution.workflowId,
+					ipAddress: options.ipAddress ?? '',
+					userAgent: options.userAgent ?? '',
+					redactionPolicy: this.resolvePolicy(execution),
+				});
+			}
+		}
 	}
 
 	/**
@@ -143,6 +131,7 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 	 * - `FullItemRedactionStrategy` is included when items should be cleared:
 	 *   explicit redact (`redactExecutionData === true`), policy=all, or
 	 *   policy=non-manual on a non-manual execution mode.
+	 *   It is never included on the reveal path (`redactExecutionData === false`).
 	 * - `NodeDefinedFieldRedactionStrategy` is always appended last — node-declared
 	 *   sensitive fields are never revealable.
 	 */
@@ -155,10 +144,10 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 
 		const policy = this.resolvePolicy(execution);
 		const shouldClearItems =
-			context.redactExecutionData === true ||
-			(!policyAllowsReveal &&
-				(policy === 'all' ||
-					(policy === 'non-manual' && !MANUAL_MODES.has(execution.mode))));
+			context.redactExecutionData !== false &&
+			(context.redactExecutionData === true ||
+				(!policyAllowsReveal &&
+					(policy === 'all' || (policy === 'non-manual' && !MANUAL_MODES.has(execution.mode)))));
 
 		if (shouldClearItems) {
 			pipeline.push(this.fullItemRedactionStrategy);

--- a/packages/cli/src/modules/redaction/executions/strategies/__tests__/full-item-redaction.strategy.test.ts
+++ b/packages/cli/src/modules/redaction/executions/strategies/__tests__/full-item-redaction.strategy.test.ts
@@ -1,0 +1,243 @@
+import type { IRunExecutionData } from 'n8n-workflow';
+
+import type { RedactableExecution } from '@/executions/execution-redaction';
+import type { RedactionContext } from '../../execution-redaction.interfaces';
+import { FullItemRedactionStrategy } from '../full-item-redaction.strategy';
+
+const makeContext = (overrides: Partial<RedactionContext> = {}): RedactionContext => ({
+	user: { id: 'user-1' } as RedactionContext['user'],
+	redactExecutionData: undefined,
+	userCanReveal: false,
+	...overrides,
+});
+
+const makeExecution = (runData: IRunExecutionData['resultData']['runData']): RedactableExecution =>
+	({
+		mode: 'manual',
+		workflowId: 'wf-1',
+		data: {
+			version: 1,
+			resultData: { runData },
+			executionData: {
+				contextData: {},
+				nodeExecutionStack: [],
+				metadata: {},
+				waitingExecution: {},
+				waitingExecutionSource: null,
+			},
+		},
+		workflowData: { settings: {}, nodes: [] },
+	}) as unknown as RedactableExecution;
+
+describe('FullItemRedactionStrategy', () => {
+	let strategy: FullItemRedactionStrategy;
+
+	beforeEach(() => {
+		strategy = new FullItemRedactionStrategy();
+	});
+
+	it('has name "full-item-redaction"', () => {
+		expect(strategy.name).toBe('full-item-redaction');
+	});
+
+	describe('item clearing', () => {
+		it('clears json and binary and sets redaction marker on each item', async () => {
+			const execution = makeExecution({
+				NodeA: [
+					{
+						startTime: 0,
+						executionTime: 0,
+						executionStatus: 'success',
+						source: [],
+						data: {
+							main: [
+								[
+									{
+										json: { secret: 'sensitive' },
+										binary: { file: { mimeType: 'text/plain', data: 'abc' } },
+									},
+								],
+							],
+						},
+					},
+				],
+			});
+
+			await strategy.apply(execution, makeContext());
+
+			const item = execution.data.resultData.runData.NodeA[0].data!.main[0]![0];
+			expect(item.json).toEqual({});
+			expect(item.binary).toBeUndefined();
+			expect(item.redaction).toEqual({ redacted: true, reason: 'workflow_redaction_policy' });
+		});
+
+		it('redacts all items across multiple nodes', async () => {
+			const execution = makeExecution({
+				NodeA: [
+					{
+						startTime: 0,
+						executionTime: 0,
+						executionStatus: 'success',
+						source: [],
+						data: { main: [[{ json: { a: 1 } }, { json: { b: 2 } }]] },
+					},
+				],
+				NodeB: [
+					{
+						startTime: 0,
+						executionTime: 0,
+						executionStatus: 'success',
+						source: [],
+						data: { main: [[{ json: { c: 3 } }]] },
+					},
+				],
+			});
+
+			await strategy.apply(execution, makeContext());
+
+			for (const items of execution.data.resultData.runData.NodeA[0].data!.main) {
+				for (const item of items!) {
+					expect(item.json).toEqual({});
+				}
+			}
+			expect(execution.data.resultData.runData.NodeB[0].data!.main[0]![0].json).toEqual({});
+		});
+
+		it('also redacts inputOverride', async () => {
+			const execution = makeExecution({
+				NodeA: [
+					{
+						startTime: 0,
+						executionTime: 0,
+						executionStatus: 'success',
+						source: [],
+						data: { main: [[{ json: {} }]] },
+						inputOverride: { main: [[{ json: { override: 'secret' } }]] },
+					},
+				],
+			});
+
+			await strategy.apply(execution, makeContext());
+
+			const overrideItem = execution.data.resultData.runData.NodeA[0].inputOverride!.main[0]![0];
+			expect(overrideItem.json).toEqual({});
+			expect(overrideItem.redaction).toEqual({
+				redacted: true,
+				reason: 'workflow_redaction_policy',
+			});
+		});
+
+		it('handles nodes with no items (null output slots)', async () => {
+			const execution = makeExecution({
+				NodeA: [
+					{
+						startTime: 0,
+						executionTime: 0,
+						executionStatus: 'success',
+						source: [],
+						data: { main: [null] },
+					},
+				],
+			});
+
+			await expect(strategy.apply(execution, makeContext())).resolves.toBeUndefined();
+		});
+
+		it('does nothing when runData is empty', async () => {
+			const execution = makeExecution({});
+			await expect(strategy.apply(execution, makeContext())).resolves.toBeUndefined();
+		});
+	});
+
+	describe('reason', () => {
+		it('sets reason "user_requested" when redactExecutionData === true', async () => {
+			const execution = makeExecution({
+				NodeA: [
+					{
+						startTime: 0,
+						executionTime: 0,
+						executionStatus: 'success',
+						source: [],
+						data: { main: [[{ json: { x: 1 } }]] },
+					},
+				],
+			});
+
+			await strategy.apply(execution, makeContext({ redactExecutionData: true }));
+
+			const item = execution.data.resultData.runData.NodeA[0].data!.main[0]![0];
+			expect(item.redaction?.reason).toBe('user_requested');
+			expect(execution.data.redactionInfo?.reason).toBe('user_requested');
+		});
+
+		it('sets reason "workflow_redaction_policy" in all other cases', async () => {
+			const execution = makeExecution({
+				NodeA: [
+					{
+						startTime: 0,
+						executionTime: 0,
+						executionStatus: 'success',
+						source: [],
+						data: { main: [[{ json: { x: 1 } }]] },
+					},
+				],
+			});
+
+			await strategy.apply(execution, makeContext({ redactExecutionData: undefined }));
+
+			expect(execution.data.redactionInfo?.reason).toBe('workflow_redaction_policy');
+		});
+	});
+
+	describe('redactionInfo', () => {
+		it('sets isRedacted: true with canReveal from context', async () => {
+			const execution = makeExecution({
+				NodeA: [
+					{
+						startTime: 0,
+						executionTime: 0,
+						executionStatus: 'success',
+						source: [],
+						data: { main: [[{ json: { x: 1 } }]] },
+					},
+				],
+			});
+
+			await strategy.apply(execution, makeContext({ userCanReveal: true }));
+
+			expect(execution.data.redactionInfo).toMatchObject({
+				isRedacted: true,
+				canReveal: true,
+			});
+		});
+
+		it('merges into existing redactionInfo rather than overwriting', async () => {
+			const execution = makeExecution({
+				NodeA: [
+					{
+						startTime: 0,
+						executionTime: 0,
+						executionStatus: 'success',
+						source: [],
+						data: { main: [[{ json: { x: 1 } }]] },
+					},
+				],
+			});
+			(execution.data as unknown as Record<string, unknown>).redactionInfo = {
+				isRedacted: false,
+				reason: 'prior_strategy',
+				canReveal: true,
+				extraField: 'preserved',
+			};
+
+			await strategy.apply(execution, makeContext());
+
+			expect(execution.data.redactionInfo).toMatchObject({
+				isRedacted: true,
+				reason: 'workflow_redaction_policy',
+				canReveal: false,
+				extraField: 'preserved',
+			});
+		});
+	});
+});

--- a/packages/cli/src/modules/redaction/executions/strategies/__tests__/full-item-redaction.strategy.test.ts
+++ b/packages/cli/src/modules/redaction/executions/strategies/__tests__/full-item-redaction.strategy.test.ts
@@ -1,4 +1,9 @@
-import type { IRunExecutionData } from 'n8n-workflow';
+import type {
+	IRunExecutionData,
+	NodeApiError,
+	NodeOperationError,
+	ExecutionError,
+} from 'n8n-workflow';
 
 import type { RedactableExecution } from '@/executions/execution-redaction';
 import type { RedactionContext } from '../../execution-redaction.interfaces';
@@ -46,6 +51,7 @@ describe('FullItemRedactionStrategy', () => {
 				NodeA: [
 					{
 						startTime: 0,
+						executionIndex: 0,
 						executionTime: 0,
 						executionStatus: 'success',
 						source: [],
@@ -76,6 +82,7 @@ describe('FullItemRedactionStrategy', () => {
 				NodeA: [
 					{
 						startTime: 0,
+						executionIndex: 0,
 						executionTime: 0,
 						executionStatus: 'success',
 						source: [],
@@ -85,6 +92,7 @@ describe('FullItemRedactionStrategy', () => {
 				NodeB: [
 					{
 						startTime: 0,
+						executionIndex: 0,
 						executionTime: 0,
 						executionStatus: 'success',
 						source: [],
@@ -108,6 +116,7 @@ describe('FullItemRedactionStrategy', () => {
 				NodeA: [
 					{
 						startTime: 0,
+						executionIndex: 0,
 						executionTime: 0,
 						executionStatus: 'success',
 						source: [],
@@ -132,6 +141,7 @@ describe('FullItemRedactionStrategy', () => {
 				NodeA: [
 					{
 						startTime: 0,
+						executionIndex: 0,
 						executionTime: 0,
 						executionStatus: 'success',
 						source: [],
@@ -155,6 +165,7 @@ describe('FullItemRedactionStrategy', () => {
 				NodeA: [
 					{
 						startTime: 0,
+						executionIndex: 0,
 						executionTime: 0,
 						executionStatus: 'success',
 						source: [],
@@ -175,6 +186,7 @@ describe('FullItemRedactionStrategy', () => {
 				NodeA: [
 					{
 						startTime: 0,
+						executionIndex: 0,
 						executionTime: 0,
 						executionStatus: 'success',
 						source: [],
@@ -189,12 +201,124 @@ describe('FullItemRedactionStrategy', () => {
 		});
 	});
 
+	describe('error redaction', () => {
+		const makeNodeApiError = (httpCode: string | null = '404') =>
+			({ name: 'NodeApiError', message: 'API error', httpCode }) as unknown as NodeApiError;
+
+		const makeNodeOperationError = () =>
+			({ name: 'NodeOperationError', message: 'Op error' }) as unknown as NodeOperationError;
+
+		const makeExecutionError = (name: string) =>
+			({ name, message: 'error' }) as unknown as ExecutionError;
+
+		it('redacts item-level NodeApiError and stores type + httpCode in item.redaction.error', async () => {
+			const execution = makeExecution({
+				NodeA: [
+					{
+						startTime: 0,
+						executionIndex: 0,
+						executionTime: 0,
+						executionStatus: 'error',
+						source: [],
+						data: { main: [[{ json: {}, error: makeNodeApiError('404') }]] },
+					},
+				],
+			});
+
+			await strategy.apply(execution, makeContext());
+
+			const item = execution.data.resultData.runData.NodeA[0].data!.main[0]![0];
+			expect(item.error).toBeUndefined();
+			expect(item.redaction?.error).toEqual({ type: 'NodeApiError', httpCode: '404' });
+		});
+
+		it('redacts item-level NodeOperationError without httpCode', async () => {
+			const execution = makeExecution({
+				NodeA: [
+					{
+						startTime: 0,
+						executionIndex: 0,
+						executionTime: 0,
+						executionStatus: 'error',
+						source: [],
+						data: { main: [[{ json: {}, error: makeNodeOperationError() }]] },
+					},
+				],
+			});
+
+			await strategy.apply(execution, makeContext());
+
+			const item = execution.data.resultData.runData.NodeA[0].data!.main[0]![0];
+			expect(item.error).toBeUndefined();
+			expect(item.redaction?.error).toEqual({ type: 'NodeOperationError' });
+			expect(item.redaction?.error).not.toHaveProperty('httpCode');
+		});
+
+		it('redacts task-level error into taskData.redactedError', async () => {
+			const error = makeExecutionError('NodeApiError');
+			(error as unknown as { httpCode: string | null }).httpCode = null;
+
+			const execution = makeExecution({
+				NodeA: [
+					{
+						startTime: 0,
+						executionIndex: 0,
+						executionTime: 0,
+						executionStatus: 'error',
+						source: [],
+						error,
+					},
+				],
+			});
+
+			await strategy.apply(execution, makeContext());
+
+			const taskData = execution.data.resultData.runData.NodeA[0];
+			expect(taskData.error).toBeUndefined();
+			expect(taskData.redactedError).toEqual({ type: 'NodeApiError', httpCode: null });
+		});
+
+		it('redacts workflow-level error into resultData.redactedError', async () => {
+			const execution = makeExecution({});
+			(execution.data.resultData as unknown as Record<string, unknown>).error =
+				makeExecutionError('NodeOperationError');
+
+			await strategy.apply(execution, makeContext());
+
+			expect(execution.data.resultData.error).toBeUndefined();
+			expect(execution.data.resultData.redactedError).toEqual({ type: 'NodeOperationError' });
+			expect(execution.data.resultData.redactedError).not.toHaveProperty('httpCode');
+		});
+
+		it('does not set redactedError when there is no error', async () => {
+			const execution = makeExecution({
+				NodeA: [
+					{
+						startTime: 0,
+						executionIndex: 0,
+						executionTime: 0,
+						executionStatus: 'success',
+						source: [],
+						data: { main: [[{ json: { x: 1 } }]] },
+					},
+				],
+			});
+
+			await strategy.apply(execution, makeContext());
+
+			const taskData = execution.data.resultData.runData.NodeA[0];
+			expect(taskData.redactedError).toBeUndefined();
+			expect(execution.data.resultData.redactedError).toBeUndefined();
+		});
+	});
+
 	describe('redactionInfo', () => {
 		it('sets isRedacted: true with canReveal from context', async () => {
 			const execution = makeExecution({
 				NodeA: [
 					{
 						startTime: 0,
+						executionIndex: 0,
 						executionTime: 0,
 						executionStatus: 'success',
 						source: [],
@@ -216,6 +340,7 @@ describe('FullItemRedactionStrategy', () => {
 				NodeA: [
 					{
 						startTime: 0,
+						executionIndex: 0,
 						executionTime: 0,
 						executionStatus: 'success',
 						source: [],

--- a/packages/cli/src/modules/redaction/executions/strategies/__tests__/full-item-redaction.strategy.test.ts
+++ b/packages/cli/src/modules/redaction/executions/strategies/__tests__/full-item-redaction.strategy.test.ts
@@ -1,4 +1,4 @@
-import type { IRunExecutionData, ExecutionError } from 'n8n-workflow';
+import type { IRunExecutionData } from 'n8n-workflow';
 import { NodeApiError, NodeOperationError } from 'n8n-workflow';
 
 import type { RedactableExecution } from '@/executions/execution-redaction';
@@ -211,10 +211,10 @@ describe('FullItemRedactionStrategy', () => {
 		// Errors loaded from the database are plain objects, not class instances,
 		// because flatted deserialization does not reconstruct class prototypes.
 		const makePlainNodeApiError = (httpCode: string | null = '404') =>
-			({ name: 'NodeApiError', message: 'API error', httpCode }) as unknown as ExecutionError;
+			({ name: 'NodeApiError', message: 'API error', httpCode }) as unknown as NodeApiError;
 
 		const makePlainNodeOperationError = () =>
-			({ name: 'NodeOperationError', message: 'Op error' }) as unknown as ExecutionError;
+			({ name: 'NodeOperationError', message: 'Op error' }) as unknown as NodeOperationError;
 
 		describe('item-level', () => {
 			it('deletes item.error and stores safe metadata in item.redaction.error for NodeApiError', async () => {

--- a/packages/cli/src/modules/redaction/executions/strategies/__tests__/full-item-redaction.strategy.test.ts
+++ b/packages/cli/src/modules/redaction/executions/strategies/__tests__/full-item-redaction.strategy.test.ts
@@ -1,9 +1,5 @@
-import type {
-	IRunExecutionData,
-	NodeApiError,
-	NodeOperationError,
-	ExecutionError,
-} from 'n8n-workflow';
+import type { IRunExecutionData, ExecutionError } from 'n8n-workflow';
+import { NodeApiError, NodeOperationError } from 'n8n-workflow';
 
 import type { RedactableExecution } from '@/executions/execution-redaction';
 import type { RedactionContext } from '../../execution-redaction.interfaces';
@@ -202,113 +198,221 @@ describe('FullItemRedactionStrategy', () => {
 	});
 
 	describe('error redaction', () => {
-		const makeNodeApiError = (httpCode: string | null = '404') =>
-			({ name: 'NodeApiError', message: 'API error', httpCode }) as unknown as NodeApiError;
+		const mockNode = {
+			id: 'node-1',
+			name: 'Test Node',
+			type: 'n8n-nodes-base.httpRequest',
+			typeVersion: 1,
+			position: [0, 0] as [number, number],
+			parameters: {},
+		};
 
-		const makeNodeOperationError = () =>
-			({ name: 'NodeOperationError', message: 'Op error' }) as unknown as NodeOperationError;
+		// Plain-object helpers representing post-DB-deserialization scenarios.
+		// Errors loaded from the database are plain objects, not class instances,
+		// because flatted deserialization does not reconstruct class prototypes.
+		const makePlainNodeApiError = (httpCode: string | null = '404') =>
+			({ name: 'NodeApiError', message: 'API error', httpCode }) as unknown as ExecutionError;
 
-		const makeExecutionError = (name: string) =>
-			({ name, message: 'error' }) as unknown as ExecutionError;
+		const makePlainNodeOperationError = () =>
+			({ name: 'NodeOperationError', message: 'Op error' }) as unknown as ExecutionError;
 
-		it('redacts item-level NodeApiError and stores type + httpCode in item.redaction.error', async () => {
-			const execution = makeExecution({
-				NodeA: [
-					{
-						startTime: 0,
-						executionIndex: 0,
-						executionTime: 0,
-						executionStatus: 'error',
-						source: [],
-						data: { main: [[{ json: {}, error: makeNodeApiError('404') }]] },
-					},
-				],
+		describe('item-level', () => {
+			it('deletes item.error and stores safe metadata in item.redaction.error for NodeApiError', async () => {
+				const error = new NodeApiError(mockNode, { message: 'Bad Gateway' }, { httpCode: '502' });
+				const execution = makeExecution({
+					NodeA: [
+						{
+							startTime: 0,
+							executionIndex: 0,
+							executionTime: 0,
+							executionStatus: 'error',
+							source: [],
+							data: { main: [[{ json: { x: 1 }, error }]] },
+						},
+					],
+				});
+
+				await strategy.apply(execution, makeContext());
+
+				const item = execution.data.resultData.runData.NodeA[0].data!.main[0]![0];
+				expect(item.error).toBeUndefined();
+				expect(item.redaction?.error).toEqual({ type: 'NodeApiError', httpCode: '502' });
 			});
 
-			await strategy.apply(execution, makeContext());
+			it('stores only type (no httpCode) for NodeOperationError', async () => {
+				const error = new NodeOperationError(mockNode, 'Something failed');
+				const execution = makeExecution({
+					NodeA: [
+						{
+							startTime: 0,
+							executionIndex: 0,
+							executionTime: 0,
+							executionStatus: 'error',
+							source: [],
+							data: { main: [[{ json: {}, error }]] },
+						},
+					],
+				});
 
-			const item = execution.data.resultData.runData.NodeA[0].data!.main[0]![0];
-			expect(item.error).toBeUndefined();
-			expect(item.redaction?.error).toEqual({ type: 'NodeApiError', httpCode: '404' });
-		});
+				await strategy.apply(execution, makeContext());
 
-		it('redacts item-level NodeOperationError without httpCode', async () => {
-			const execution = makeExecution({
-				NodeA: [
-					{
-						startTime: 0,
-						executionIndex: 0,
-						executionTime: 0,
-						executionStatus: 'error',
-						source: [],
-						data: { main: [[{ json: {}, error: makeNodeOperationError() }]] },
-					},
-				],
+				const item = execution.data.resultData.runData.NodeA[0].data!.main[0]![0];
+				expect(item.error).toBeUndefined();
+				expect(item.redaction?.error).toEqual({ type: 'NodeOperationError' });
+				expect(item.redaction?.error).not.toHaveProperty('httpCode');
 			});
 
-			await strategy.apply(execution, makeContext());
+			it('does not set item.redaction.error when item has no error', async () => {
+				const execution = makeExecution({
+					NodeA: [
+						{
+							startTime: 0,
+							executionIndex: 0,
+							executionTime: 0,
+							executionStatus: 'success',
+							source: [],
+							data: { main: [[{ json: { x: 1 } }]] },
+						},
+					],
+				});
 
-			const item = execution.data.resultData.runData.NodeA[0].data!.main[0]![0];
-			expect(item.error).toBeUndefined();
-			expect(item.redaction?.error).toEqual({ type: 'NodeOperationError' });
-			expect(item.redaction?.error).not.toHaveProperty('httpCode');
-		});
+				await strategy.apply(execution, makeContext());
 
-		it('redacts task-level error into taskData.redactedError', async () => {
-			const error = makeExecutionError('NodeApiError');
-			(error as unknown as { httpCode: string | null }).httpCode = null;
-
-			const execution = makeExecution({
-				NodeA: [
-					{
-						startTime: 0,
-						executionIndex: 0,
-						executionTime: 0,
-						executionStatus: 'error',
-						source: [],
-						error,
-					},
-				],
+				const item = execution.data.resultData.runData.NodeA[0].data!.main[0]![0];
+				expect(item.redaction).not.toHaveProperty('error');
 			});
 
-			await strategy.apply(execution, makeContext());
+			it('handles post-DB-deserialization plain-object NodeApiError (duck typing)', async () => {
+				const execution = makeExecution({
+					NodeA: [
+						{
+							startTime: 0,
+							executionIndex: 0,
+							executionTime: 0,
+							executionStatus: 'error',
+							source: [],
+							data: { main: [[{ json: {}, error: makePlainNodeApiError('404') }]] },
+						},
+					],
+				});
 
-			const taskData = execution.data.resultData.runData.NodeA[0];
-			expect(taskData.error).toBeUndefined();
-			expect(taskData.redactedError).toEqual({ type: 'NodeApiError', httpCode: null });
+				await strategy.apply(execution, makeContext());
+
+				const item = execution.data.resultData.runData.NodeA[0].data!.main[0]![0];
+				expect(item.error).toBeUndefined();
+				expect(item.redaction?.error).toEqual({ type: 'NodeApiError', httpCode: '404' });
+			});
 		});
 
-		it('redacts workflow-level error into resultData.redactedError', async () => {
-			const execution = makeExecution({});
-			(execution.data.resultData as unknown as Record<string, unknown>).error =
-				makeExecutionError('NodeOperationError');
+		describe('task-level', () => {
+			it('moves taskData.error to taskData.redactedError', async () => {
+				const error = new NodeApiError(mockNode, { message: 'Forbidden' }, { httpCode: '403' });
+				const execution = makeExecution({
+					NodeA: [
+						{
+							startTime: 0,
+							executionIndex: 0,
+							executionTime: 0,
+							executionStatus: 'error',
+							source: [],
+							data: { main: [[{ json: {} }]] },
+							error,
+						},
+					],
+				});
 
-			await strategy.apply(execution, makeContext());
+				await strategy.apply(execution, makeContext());
 
-			expect(execution.data.resultData.error).toBeUndefined();
-			expect(execution.data.resultData.redactedError).toEqual({ type: 'NodeOperationError' });
-			expect(execution.data.resultData.redactedError).not.toHaveProperty('httpCode');
-		});
-
-		it('does not set redactedError when there is no error', async () => {
-			const execution = makeExecution({
-				NodeA: [
-					{
-						startTime: 0,
-						executionIndex: 0,
-						executionTime: 0,
-						executionStatus: 'success',
-						source: [],
-						data: { main: [[{ json: { x: 1 } }]] },
-					},
-				],
+				const taskData = execution.data.resultData.runData.NodeA[0];
+				expect(taskData.error).toBeUndefined();
+				expect(taskData.redactedError).toEqual({ type: 'NodeApiError', httpCode: '403' });
 			});
 
-			await strategy.apply(execution, makeContext());
+			it('does not set redactedError when task has no error', async () => {
+				const execution = makeExecution({
+					NodeA: [
+						{
+							startTime: 0,
+							executionIndex: 0,
+							executionTime: 0,
+							executionStatus: 'success',
+							source: [],
+							data: { main: [[{ json: {} }]] },
+						},
+					],
+				});
 
-			const taskData = execution.data.resultData.runData.NodeA[0];
-			expect(taskData.redactedError).toBeUndefined();
-			expect(execution.data.resultData.redactedError).toBeUndefined();
+				await strategy.apply(execution, makeContext());
+
+				expect(execution.data.resultData.runData.NodeA[0].redactedError).toBeUndefined();
+			});
+
+			it('sets httpCode: null for post-DB plain-object NodeApiError with null httpCode', async () => {
+				// Exercises the `?? null` fallback in redactError when httpCode is null or absent.
+				const execution = makeExecution({
+					NodeA: [
+						{
+							startTime: 0,
+							executionIndex: 0,
+							executionTime: 0,
+							executionStatus: 'error',
+							source: [],
+							error: makePlainNodeApiError(null),
+						},
+					],
+				});
+
+				await strategy.apply(execution, makeContext());
+
+				const taskData = execution.data.resultData.runData.NodeA[0];
+				expect(taskData.error).toBeUndefined();
+				expect(taskData.redactedError).toEqual({ type: 'NodeApiError', httpCode: null });
+			});
+		});
+
+		describe('workflow-level', () => {
+			it('moves resultData.error to resultData.redactedError for NodeOperationError', async () => {
+				const error = new NodeOperationError(mockNode, 'Workflow operation failed');
+				const execution = makeExecution({});
+				execution.data.resultData.error = error;
+
+				await strategy.apply(execution, makeContext());
+
+				expect(execution.data.resultData.error).toBeUndefined();
+				expect(execution.data.resultData.redactedError).toEqual({ type: 'NodeOperationError' });
+				expect(execution.data.resultData.redactedError).not.toHaveProperty('httpCode');
+			});
+
+			it('handles post-DB-deserialization plain-object NodeOperationError', async () => {
+				const execution = makeExecution({});
+				(execution.data.resultData as unknown as Record<string, unknown>).error =
+					makePlainNodeOperationError();
+
+				await strategy.apply(execution, makeContext());
+
+				expect(execution.data.resultData.error).toBeUndefined();
+				expect(execution.data.resultData.redactedError).toEqual({ type: 'NodeOperationError' });
+				expect(execution.data.resultData.redactedError).not.toHaveProperty('httpCode');
+			});
+
+			it('does not set redactedError when resultData has no error', async () => {
+				const execution = makeExecution({
+					NodeA: [
+						{
+							startTime: 0,
+							executionIndex: 0,
+							executionTime: 0,
+							executionStatus: 'success',
+							source: [],
+							data: { main: [[{ json: {} }]] },
+						},
+					],
+				});
+
+				await strategy.apply(execution, makeContext());
+
+				expect(execution.data.resultData.redactedError).toBeUndefined();
+			});
 		});
 	});
 

--- a/packages/cli/src/modules/redaction/executions/strategies/__tests__/node-defined-field-redaction.strategy.test.ts
+++ b/packages/cli/src/modules/redaction/executions/strategies/__tests__/node-defined-field-redaction.strategy.test.ts
@@ -289,8 +289,8 @@ describe('NodeDefinedFieldRedactionStrategy', () => {
 		});
 	});
 
-	describe('fail-secure behavior', () => {
-		it('logs a warning and skips a node when its type cannot be resolved', async () => {
+	describe('fail-closed behavior', () => {
+		it('redacts all outputs conservatively when node type cannot be resolved', async () => {
 			nodeTypes.getByNameAndVersion.mockImplementation(() => {
 				throw new Error('Unknown node type');
 			});
@@ -304,18 +304,13 @@ describe('NodeDefinedFieldRedactionStrategy', () => {
 			expect(logger.warn).toHaveBeenCalledWith(
 				expect.stringContaining('Could not load type for node "Webhook"'),
 			);
-			// Item should be untouched
-			expect(
-				(
-					execution.data.resultData.runData.Webhook[0].data!.main[0]![0].json.headers as Record<
-						string,
-						unknown
-					>
-				).authorization,
-			).toBe('secret');
+			// Item should be fully wiped
+			const item = execution.data.resultData.runData.Webhook[0].data!.main[0]![0];
+			expect(item.json).toEqual({});
+			expect(item.redaction).toEqual({ redacted: true, reason: 'node_type_unavailable' });
 		});
 
-		it('continues redacting other nodes when one node type lookup fails', async () => {
+		it('continues redacting other nodes and clears unknown-type node outputs', async () => {
 			nodeTypes.getByNameAndVersion
 				.mockImplementationOnce(() => {
 					throw new Error('Unknown node type');
@@ -330,18 +325,18 @@ describe('NodeDefinedFieldRedactionStrategy', () => {
 					{ name: 'Webhook', type: 'n8n-nodes-base.webhook', typeVersion: 1 },
 				],
 				{
-					BadNode: [{ data: { main: [[{ json: { secret: 'untouched' } }]] } }],
+					BadNode: [{ data: { main: [[{ json: { secret: 'sensitive' } }]] } }],
 					Webhook: [{ data: { main: [[{ json: { headers: { authorization: 'secret' } } }]] } }],
 				},
 			);
 
 			await strategy.apply(execution, makeContext());
 
-			// BadNode untouched
-			expect(execution.data.resultData.runData.BadNode[0].data!.main[0]![0].json.secret).toBe(
-				'untouched',
-			);
-			// Webhook still redacted
+			// BadNode cleared conservatively
+			const badItem = execution.data.resultData.runData.BadNode[0].data!.main[0]![0];
+			expect(badItem.json).toEqual({});
+			expect(badItem.redaction).toEqual({ redacted: true, reason: 'node_type_unavailable' });
+			// Webhook still has field-level redaction
 			expect(
 				(
 					execution.data.resultData.runData.Webhook[0].data!.main[0]![0].json.headers as Record<

--- a/packages/cli/src/modules/redaction/executions/strategies/__tests__/node-defined-field-redaction.strategy.test.ts
+++ b/packages/cli/src/modules/redaction/executions/strategies/__tests__/node-defined-field-redaction.strategy.test.ts
@@ -1,0 +1,381 @@
+import { Logger } from '@n8n/backend-common';
+import { mockInstance } from '@n8n/backend-test-utils';
+import type { IRedactedFieldMarker } from 'n8n-workflow';
+
+import type { RedactableExecution } from '@/executions/execution-redaction';
+import { NodeTypes } from '@/node-types';
+
+import type { RedactionContext } from '../../execution-redaction.interfaces';
+import { NodeDefinedFieldRedactionStrategy } from '../node-defined-field-redaction.strategy';
+
+const makeContext = (overrides: Partial<RedactionContext> = {}): RedactionContext => ({
+	user: { id: 'user-1' } as RedactionContext['user'],
+	redactExecutionData: undefined,
+	userCanReveal: false,
+	...overrides,
+});
+
+const makeExecution = (
+	nodes: Array<{ name: string; type: string; typeVersion: number }>,
+	runData: Record<
+		string,
+		Array<{
+			data?: Record<string, Array<Array<{ json: Record<string, unknown> }> | null>>;
+		}>
+	>,
+): RedactableExecution =>
+	({
+		mode: 'manual',
+		workflowId: 'wf-1',
+		data: {
+			version: 1,
+			resultData: { runData },
+			executionData: {
+				contextData: {},
+				nodeExecutionStack: [],
+				metadata: {},
+				waitingExecution: {},
+				waitingExecutionSource: null,
+			},
+		},
+		workflowData: {
+			settings: {},
+			nodes: nodes.map((n) => ({
+				id: n.name,
+				name: n.name,
+				type: n.type,
+				typeVersion: n.typeVersion,
+				position: [0, 0] as [number, number],
+				parameters: {},
+			})),
+		},
+	}) as unknown as RedactableExecution;
+
+const REDACTED_MARKER: IRedactedFieldMarker = {
+	__redacted: true,
+	reason: 'node_defined_field',
+	canReveal: false,
+};
+
+describe('NodeDefinedFieldRedactionStrategy', () => {
+	const logger = mockInstance(Logger);
+	const nodeTypes = mockInstance(NodeTypes);
+	let strategy: NodeDefinedFieldRedactionStrategy;
+
+	const mockNodeDescription = (sensitiveOutputFields: string[]) => ({
+		name: 'n8n-nodes-base.webhook',
+		sensitiveOutputFields,
+	});
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		strategy = new NodeDefinedFieldRedactionStrategy(logger, nodeTypes);
+	});
+
+	it('has name "node-defined-field-redaction"', () => {
+		expect(strategy.name).toBe('node-defined-field-redaction');
+	});
+
+	describe('field redaction', () => {
+		it('redacts a field at a dot-notation path', async () => {
+			nodeTypes.getByNameAndVersion.mockReturnValue({
+				description: mockNodeDescription(['headers.authorization']),
+			} as ReturnType<typeof nodeTypes.getByNameAndVersion>);
+
+			const execution = makeExecution(
+				[{ name: 'Webhook', type: 'n8n-nodes-base.webhook', typeVersion: 1 }],
+				{
+					Webhook: [
+						{
+							data: {
+								main: [
+									[
+										{
+											json: {
+												headers: {
+													authorization: 'Bearer secret',
+													'content-type': 'application/json',
+												},
+											},
+										},
+									],
+								],
+							},
+						},
+					],
+				},
+			);
+
+			await strategy.apply(execution, makeContext());
+
+			const item = execution.data.resultData.runData.Webhook[0].data!.main[0]![0];
+			expect(item.json.headers).toEqual({
+				authorization: REDACTED_MARKER,
+				'content-type': 'application/json',
+			});
+		});
+
+		it('redacts multiple declared fields on a single node independently', async () => {
+			nodeTypes.getByNameAndVersion.mockReturnValue({
+				description: mockNodeDescription(['headers.authorization', 'headers.cookie']),
+			} as ReturnType<typeof nodeTypes.getByNameAndVersion>);
+
+			const execution = makeExecution(
+				[{ name: 'Webhook', type: 'n8n-nodes-base.webhook', typeVersion: 1 }],
+				{
+					Webhook: [
+						{
+							data: {
+								main: [
+									[
+										{
+											json: {
+												headers: {
+													authorization: 'Bearer secret',
+													cookie: 'session=abc',
+												},
+											},
+										},
+									],
+								],
+							},
+						},
+					],
+				},
+			);
+
+			await strategy.apply(execution, makeContext());
+
+			const item = execution.data.resultData.runData.Webhook[0].data!.main[0]![0];
+			expect(item.json.headers).toEqual({
+				authorization: REDACTED_MARKER,
+				cookie: REDACTED_MARKER,
+			});
+		});
+
+		it('handles multiple nodes each with different sensitiveOutputFields', async () => {
+			nodeTypes.getByNameAndVersion
+				.mockReturnValueOnce({
+					description: mockNodeDescription(['headers.authorization']),
+				} as ReturnType<typeof nodeTypes.getByNameAndVersion>)
+				.mockReturnValueOnce({
+					description: mockNodeDescription(['body.password']),
+				} as ReturnType<typeof nodeTypes.getByNameAndVersion>);
+
+			const execution = makeExecution(
+				[
+					{ name: 'NodeA', type: 'n8n-nodes-base.webhook', typeVersion: 1 },
+					{ name: 'NodeB', type: 'n8n-nodes-base.httpRequest', typeVersion: 1 },
+				],
+				{
+					NodeA: [{ data: { main: [[{ json: { headers: { authorization: 'secret' } } }]] } }],
+					NodeB: [{ data: { main: [[{ json: { body: { password: 'hunter2' } } }]] } }],
+				},
+			);
+
+			await strategy.apply(execution, makeContext());
+
+			expect(
+				(
+					execution.data.resultData.runData.NodeA[0].data!.main[0]![0].json.headers as Record<
+						string,
+						unknown
+					>
+				).authorization,
+			).toEqual(REDACTED_MARKER);
+			expect(
+				(
+					execution.data.resultData.runData.NodeB[0].data!.main[0]![0].json.body as Record<
+						string,
+						unknown
+					>
+				).password,
+			).toEqual(REDACTED_MARKER);
+		});
+
+		it('leaves items unchanged for a node with no sensitiveOutputFields', async () => {
+			nodeTypes.getByNameAndVersion.mockReturnValue({
+				description: { name: 'n8n-nodes-base.set', sensitiveOutputFields: [] },
+			} as ReturnType<typeof nodeTypes.getByNameAndVersion>);
+
+			const original = { name: 'Alice' };
+			const execution = makeExecution(
+				[{ name: 'Set', type: 'n8n-nodes-base.set', typeVersion: 1 }],
+				{ Set: [{ data: { main: [[{ json: { name: 'Alice' } }]] } }] },
+			);
+
+			await strategy.apply(execution, makeContext());
+
+			expect(execution.data.resultData.runData.Set[0].data!.main[0]![0].json).toEqual(original);
+		});
+	});
+
+	describe('fail-fast path traversal', () => {
+		it('silently skips when an intermediate path segment is missing', async () => {
+			nodeTypes.getByNameAndVersion.mockReturnValue({
+				description: mockNodeDescription(['headers.authorization']),
+			} as ReturnType<typeof nodeTypes.getByNameAndVersion>);
+
+			const execution = makeExecution(
+				[{ name: 'Webhook', type: 'n8n-nodes-base.webhook', typeVersion: 1 }],
+				{
+					Webhook: [
+						{
+							// no 'headers' key at all
+							data: { main: [[{ json: { body: 'payload' } }]] },
+						},
+					],
+				},
+			);
+
+			await expect(strategy.apply(execution, makeContext())).resolves.toBeUndefined();
+			expect(execution.data.resultData.runData.Webhook[0].data!.main[0]![0].json).toEqual({
+				body: 'payload',
+			});
+		});
+
+		it('does not traverse sibling keys when one segment is missing', async () => {
+			nodeTypes.getByNameAndVersion.mockReturnValue({
+				description: mockNodeDescription(['deep.nested.field']),
+			} as ReturnType<typeof nodeTypes.getByNameAndVersion>);
+
+			const execution = makeExecution(
+				[{ name: 'Webhook', type: 'n8n-nodes-base.webhook', typeVersion: 1 }],
+				{
+					Webhook: [
+						{
+							data: {
+								main: [
+									[
+										{
+											// 'deep' exists but 'nested' is not an object
+											json: { deep: 'scalar-value', sibling: 'untouched' },
+										},
+									],
+								],
+							},
+						},
+					],
+				},
+			);
+
+			await strategy.apply(execution, makeContext());
+
+			const item = execution.data.resultData.runData.Webhook[0].data!.main[0]![0];
+			expect(item.json.deep).toBe('scalar-value');
+			expect(item.json.sibling).toBe('untouched');
+		});
+
+		it('silently skips when the final field is not present', async () => {
+			nodeTypes.getByNameAndVersion.mockReturnValue({
+				description: mockNodeDescription(['headers.x-api-key']),
+			} as ReturnType<typeof nodeTypes.getByNameAndVersion>);
+
+			const execution = makeExecution(
+				[{ name: 'Webhook', type: 'n8n-nodes-base.webhook', typeVersion: 1 }],
+				{
+					Webhook: [
+						{
+							data: { main: [[{ json: { headers: { 'content-type': 'application/json' } } }]] },
+						},
+					],
+				},
+			);
+
+			await strategy.apply(execution, makeContext());
+
+			const item = execution.data.resultData.runData.Webhook[0].data!.main[0]![0];
+			expect(item.json.headers).toEqual({ 'content-type': 'application/json' });
+		});
+	});
+
+	describe('fail-secure behavior', () => {
+		it('logs a warning and skips a node when its type cannot be resolved', async () => {
+			nodeTypes.getByNameAndVersion.mockImplementation(() => {
+				throw new Error('Unknown node type');
+			});
+
+			const execution = makeExecution(
+				[{ name: 'Webhook', type: 'n8n-nodes-base.webhook', typeVersion: 1 }],
+				{ Webhook: [{ data: { main: [[{ json: { headers: { authorization: 'secret' } } }]] } }] },
+			);
+
+			await expect(strategy.apply(execution, makeContext())).resolves.toBeUndefined();
+			expect(logger.warn).toHaveBeenCalledWith(
+				expect.stringContaining('Could not load type for node "Webhook"'),
+			);
+			// Item should be untouched
+			expect(
+				(
+					execution.data.resultData.runData.Webhook[0].data!.main[0]![0].json.headers as Record<
+						string,
+						unknown
+					>
+				).authorization,
+			).toBe('secret');
+		});
+
+		it('continues redacting other nodes when one node type lookup fails', async () => {
+			nodeTypes.getByNameAndVersion
+				.mockImplementationOnce(() => {
+					throw new Error('Unknown node type');
+				})
+				.mockReturnValueOnce({
+					description: mockNodeDescription(['headers.authorization']),
+				} as ReturnType<typeof nodeTypes.getByNameAndVersion>);
+
+			const execution = makeExecution(
+				[
+					{ name: 'BadNode', type: 'n8n-nodes-base.unknown', typeVersion: 1 },
+					{ name: 'Webhook', type: 'n8n-nodes-base.webhook', typeVersion: 1 },
+				],
+				{
+					BadNode: [{ data: { main: [[{ json: { secret: 'untouched' } }]] } }],
+					Webhook: [{ data: { main: [[{ json: { headers: { authorization: 'secret' } } }]] } }],
+				},
+			);
+
+			await strategy.apply(execution, makeContext());
+
+			// BadNode untouched
+			expect(execution.data.resultData.runData.BadNode[0].data!.main[0]![0].json.secret).toBe(
+				'untouched',
+			);
+			// Webhook still redacted
+			expect(
+				(
+					execution.data.resultData.runData.Webhook[0].data!.main[0]![0].json.headers as Record<
+						string,
+						unknown
+					>
+				).authorization,
+			).toEqual(REDACTED_MARKER);
+		});
+	});
+
+	describe('IRedactedFieldMarker', () => {
+		it('produced marker always has canReveal: false', async () => {
+			nodeTypes.getByNameAndVersion.mockReturnValue({
+				description: mockNodeDescription(['headers.authorization']),
+			} as ReturnType<typeof nodeTypes.getByNameAndVersion>);
+
+			const execution = makeExecution(
+				[{ name: 'Webhook', type: 'n8n-nodes-base.webhook', typeVersion: 1 }],
+				{ Webhook: [{ data: { main: [[{ json: { headers: { authorization: 'secret' } } }]] } }] },
+			);
+
+			await strategy.apply(execution, makeContext({ userCanReveal: true }));
+
+			const marker = (
+				execution.data.resultData.runData.Webhook[0].data!.main[0]![0].json.headers as Record<
+					string,
+					unknown
+				>
+			).authorization as IRedactedFieldMarker;
+
+			expect(marker.__redacted).toBe(true);
+			expect(marker.reason).toBe('node_defined_field');
+			expect(marker.canReveal).toBe(false);
+		});
+	});
+});

--- a/packages/cli/src/modules/redaction/executions/strategies/__tests__/node-defined-field-redaction.strategy.test.ts
+++ b/packages/cli/src/modules/redaction/executions/strategies/__tests__/node-defined-field-redaction.strategy.test.ts
@@ -195,7 +195,7 @@ describe('NodeDefinedFieldRedactionStrategy', () => {
 
 		it('leaves items unchanged for a node with no sensitiveOutputFields', async () => {
 			nodeTypes.getByNameAndVersion.mockReturnValue({
-				description: { name: 'n8n-nodes-base.set', sensitiveOutputFields: [] },
+				description: { name: 'n8n-nodes-base.set', sensitiveOutputFields: [] as string[] },
 			} as ReturnType<typeof nodeTypes.getByNameAndVersion>);
 
 			const original = { name: 'Alice' };

--- a/packages/cli/src/modules/redaction/executions/strategies/full-item-redaction.strategy.ts
+++ b/packages/cli/src/modules/redaction/executions/strategies/full-item-redaction.strategy.ts
@@ -1,0 +1,57 @@
+import type { INodeExecutionData, ITaskDataConnections } from 'n8n-workflow';
+
+import type { RedactableExecution } from '@/executions/execution-redaction';
+
+import type {
+	IExecutionRedactionStrategy,
+	RedactionContext,
+} from '../execution-redaction.interfaces';
+
+export class FullItemRedactionStrategy implements IExecutionRedactionStrategy {
+	readonly name = 'full-item-redaction';
+
+	async apply(execution: RedactableExecution, context: RedactionContext): Promise<void> {
+		const runData = execution.data.resultData.runData;
+		if (!runData) return;
+
+		const reason =
+			context.redactExecutionData === true ? 'user_requested' : 'workflow_redaction_policy';
+
+		for (const nodeName of Object.keys(runData)) {
+			for (const taskData of runData[nodeName]) {
+				if (taskData.data) {
+					this.redactConnections(taskData.data, reason);
+				}
+				if (taskData.inputOverride) {
+					this.redactConnections(taskData.inputOverride, reason);
+				}
+			}
+		}
+
+		execution.data.redactionInfo = {
+			...execution.data.redactionInfo,
+			isRedacted: true,
+			reason,
+			canReveal: context.userCanReveal,
+		};
+	}
+
+	private redactConnections(connections: ITaskDataConnections, reason: string): void {
+		for (const connectionType of Object.keys(connections)) {
+			const outputs = connections[connectionType];
+			for (const items of outputs) {
+				if (items) {
+					for (const item of items) {
+						this.redactItem(item, reason);
+					}
+				}
+			}
+		}
+	}
+
+	private redactItem(item: INodeExecutionData, reason: string): void {
+		item.json = {};
+		delete item.binary;
+		item.redaction = { redacted: true, reason };
+	}
+}

--- a/packages/cli/src/modules/redaction/executions/strategies/full-item-redaction.strategy.ts
+++ b/packages/cli/src/modules/redaction/executions/strategies/full-item-redaction.strategy.ts
@@ -1,4 +1,10 @@
-import type { INodeExecutionData, ITaskDataConnections } from 'n8n-workflow';
+import { Service } from '@n8n/di';
+import type {
+	ExecutionError,
+	INodeExecutionData,
+	IRedactedErrorInfo,
+	ITaskDataConnections,
+} from 'n8n-workflow';
 
 import type { RedactableExecution } from '@/executions/execution-redaction';
 
@@ -7,6 +13,7 @@ import type {
 	RedactionContext,
 } from '../execution-redaction.interfaces';
 
+@Service()
 export class FullItemRedactionStrategy implements IExecutionRedactionStrategy {
 	readonly name = 'full-item-redaction';
 
@@ -25,7 +32,17 @@ export class FullItemRedactionStrategy implements IExecutionRedactionStrategy {
 				if (taskData.inputOverride) {
 					this.redactConnections(taskData.inputOverride, reason);
 				}
+				if (taskData.error) {
+					taskData.redactedError = this.redactError(taskData.error);
+					delete taskData.error;
+				}
 			}
+		}
+
+		const resultData = execution.data.resultData;
+		if (resultData.error) {
+			resultData.redactedError = this.redactError(resultData.error);
+			delete resultData.error;
 		}
 
 		execution.data.redactionInfo = {
@@ -50,8 +67,23 @@ export class FullItemRedactionStrategy implements IExecutionRedactionStrategy {
 	}
 
 	private redactItem(item: INodeExecutionData, reason: string): void {
+		const redactedError = item.error ? this.redactError(item.error) : undefined;
+		delete item.error;
 		item.json = {};
 		delete item.binary;
-		item.redaction = { redacted: true, reason };
+		item.redaction = {
+			redacted: true,
+			reason,
+			...(redactedError && { error: redactedError }),
+		};
+	}
+
+	private redactError(error: ExecutionError): IRedactedErrorInfo {
+		const result: IRedactedErrorInfo = { type: error.name };
+		if (error.name === 'NodeApiError') {
+			result.httpCode =
+				('httpCode' in error ? (error as { httpCode: string | null }).httpCode : null) ?? null;
+		}
+		return result;
 	}
 }

--- a/packages/cli/src/modules/redaction/executions/strategies/full-item-redaction.strategy.ts
+++ b/packages/cli/src/modules/redaction/executions/strategies/full-item-redaction.strategy.ts
@@ -71,13 +71,19 @@ export class FullItemRedactionStrategy implements IExecutionRedactionStrategy {
 		delete item.error;
 		item.json = {};
 		delete item.binary;
+
 		item.redaction = {
 			redacted: true,
 			reason,
-			...(redactedError && { error: redactedError }),
+			...(redactedError !== undefined && { error: redactedError }),
 		};
 	}
 
+	/**
+	 * Extracts safe, non-PII technical metadata from any execution error.
+	 * Preserves: error name (type classification), HTTP status code from NodeApiError.
+	 * Omits: message, description, cause, context — may contain PII or credential data.
+	 */
 	private redactError(error: ExecutionError): IRedactedErrorInfo {
 		const result: IRedactedErrorInfo = { type: error.name };
 		if (error.name === 'NodeApiError') {

--- a/packages/cli/src/modules/redaction/executions/strategies/node-defined-field-redaction.strategy.ts
+++ b/packages/cli/src/modules/redaction/executions/strategies/node-defined-field-redaction.strategy.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
-import type { INodeExecutionData, IRedactedFieldMarker } from 'n8n-workflow';
+import type { INodeExecutionData, IRedactedFieldMarker, ITaskDataConnections } from 'n8n-workflow';
 
 import type { RedactableExecution } from '@/executions/execution-redaction';
 import { NodeTypes } from '@/node-types';
@@ -20,14 +20,23 @@ export class NodeDefinedFieldRedactionStrategy implements IExecutionRedactionStr
 	) {}
 
 	async apply(execution: RedactableExecution, _context: RedactionContext): Promise<void> {
-		const sensitiveFieldsMap = this.buildSensitiveFieldsMap(execution);
-		if (sensitiveFieldsMap.size === 0) return;
+		const { sensitiveFields, unknownNodes } = this.buildSensitiveFieldsMap(execution);
+		if (sensitiveFields.size === 0 && unknownNodes.size === 0) return;
 
 		const runData = execution.data.resultData.runData;
 		if (!runData) return;
 
 		for (const nodeName of Object.keys(runData)) {
-			const fieldPaths = sensitiveFieldsMap.get(nodeName);
+			if (unknownNodes.has(nodeName)) {
+				for (const taskData of runData[nodeName]) {
+					if (taskData.data) {
+						this.redactAllOutputs(taskData.data);
+					}
+				}
+				continue;
+			}
+
+			const fieldPaths = sensitiveFields.get(nodeName);
 			if (!fieldPaths?.length) continue;
 
 			for (const taskData of runData[nodeName]) {
@@ -49,9 +58,18 @@ export class NodeDefinedFieldRedactionStrategy implements IExecutionRedactionStr
 	/**
 	 * Builds a map from workflow node name → sensitive field paths declared on
 	 * that node's type description.  Resolved once per execution call.
+	 *
+	 * When a node type cannot be resolved (e.g. community node uninstalled), the
+	 * node is added to `unknownNodes` so its entire output is wiped conservatively
+	 * (fail-closed), honouring the contract that `sensitiveOutputFields` are
+	 * always redacted and never revealable.
 	 */
-	private buildSensitiveFieldsMap(execution: RedactableExecution): Map<string, string[]> {
-		const map = new Map<string, string[]>();
+	private buildSensitiveFieldsMap(execution: RedactableExecution): {
+		sensitiveFields: Map<string, string[]>;
+		unknownNodes: Set<string>;
+	} {
+		const sensitiveFields = new Map<string, string[]>();
+		const unknownNodes = new Set<string>();
 
 		for (const node of execution.workflowData.nodes) {
 			let description;
@@ -59,17 +77,37 @@ export class NodeDefinedFieldRedactionStrategy implements IExecutionRedactionStr
 				description = this.nodeTypes.getByNameAndVersion(node.type, node.typeVersion).description;
 			} catch {
 				this.logger.warn(
-					`[NodeDefinedFieldRedactionStrategy] Could not load type for node "${node.name}" (${node.type} v${node.typeVersion}) — skipping`,
+					`[NodeDefinedFieldRedactionStrategy] Could not load type for node "${node.name}" (${node.type} v${node.typeVersion}) — redacting all outputs conservatively`,
 				);
+				unknownNodes.add(node.name);
 				continue;
 			}
 
 			if (description.sensitiveOutputFields?.length) {
-				map.set(node.name, description.sensitiveOutputFields);
+				sensitiveFields.set(node.name, description.sensitiveOutputFields);
 			}
 		}
 
-		return map;
+		return { sensitiveFields, unknownNodes };
+	}
+
+	/**
+	 * Clears all items across every connection output for a node whose type
+	 * could not be resolved.  Fail-closed: wipes `json` and `binary`, sets a
+	 * redaction marker so callers know the data was removed.
+	 */
+	private redactAllOutputs(connections: ITaskDataConnections): void {
+		for (const outputs of Object.values(connections)) {
+			for (const items of outputs) {
+				if (items) {
+					for (const item of items) {
+						item.json = {};
+						delete item.binary;
+						item.redaction = { redacted: true, reason: 'node_type_unavailable' };
+					}
+				}
+			}
+		}
 	}
 
 	/**

--- a/packages/cli/src/modules/redaction/executions/strategies/node-defined-field-redaction.strategy.ts
+++ b/packages/cli/src/modules/redaction/executions/strategies/node-defined-field-redaction.strategy.ts
@@ -121,6 +121,10 @@ export class NodeDefinedFieldRedactionStrategy implements IExecutionRedactionStr
 		}
 	}
 
+	private isRecord(value: unknown): value is Record<string, unknown> {
+		return typeof value === 'object' && value !== null;
+	}
+
 	private redactPath(obj: Record<string, unknown>, path: string): void {
 		const segments = path.split('.');
 		let current: Record<string, unknown> = obj;
@@ -128,11 +132,11 @@ export class NodeDefinedFieldRedactionStrategy implements IExecutionRedactionStr
 		for (let i = 0; i < segments.length - 1; i++) {
 			const segment = segments[i];
 			const next = current[segment];
-			if (next === null || next === undefined || typeof next !== 'object') {
+			if (!this.isRecord(next)) {
 				// Fail fast — path does not exist, nothing to redact
 				return;
 			}
-			current = next as Record<string, unknown>;
+			current = next;
 		}
 
 		const lastSegment = segments[segments.length - 1];

--- a/packages/cli/src/modules/redaction/executions/strategies/node-defined-field-redaction.strategy.ts
+++ b/packages/cli/src/modules/redaction/executions/strategies/node-defined-field-redaction.strategy.ts
@@ -1,0 +1,110 @@
+import { Logger } from '@n8n/backend-common';
+import { Service } from '@n8n/di';
+import type { INodeExecutionData, IRedactedFieldMarker } from 'n8n-workflow';
+
+import type { RedactableExecution } from '@/executions/execution-redaction';
+import { NodeTypes } from '@/node-types';
+
+import type {
+	IExecutionRedactionStrategy,
+	RedactionContext,
+} from '../execution-redaction.interfaces';
+
+@Service()
+export class NodeDefinedFieldRedactionStrategy implements IExecutionRedactionStrategy {
+	readonly name = 'node-defined-field-redaction';
+
+	constructor(
+		private readonly logger: Logger,
+		private readonly nodeTypes: NodeTypes,
+	) {}
+
+	async apply(execution: RedactableExecution, _context: RedactionContext): Promise<void> {
+		const sensitiveFieldsMap = this.buildSensitiveFieldsMap(execution);
+		if (sensitiveFieldsMap.size === 0) return;
+
+		const runData = execution.data.resultData.runData;
+		if (!runData) return;
+
+		for (const nodeName of Object.keys(runData)) {
+			const fieldPaths = sensitiveFieldsMap.get(nodeName);
+			if (!fieldPaths?.length) continue;
+
+			for (const taskData of runData[nodeName]) {
+				if (taskData.data) {
+					for (const outputs of Object.values(taskData.data)) {
+						for (const items of outputs) {
+							if (items) {
+								for (const item of items) {
+									this.redactFields(item, fieldPaths);
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Builds a map from workflow node name → sensitive field paths declared on
+	 * that node's type description.  Resolved once per execution call.
+	 */
+	private buildSensitiveFieldsMap(execution: RedactableExecution): Map<string, string[]> {
+		const map = new Map<string, string[]>();
+
+		for (const node of execution.workflowData.nodes) {
+			let description;
+			try {
+				description = this.nodeTypes.getByNameAndVersion(node.type, node.typeVersion).description;
+			} catch {
+				this.logger.warn(
+					`[NodeDefinedFieldRedactionStrategy] Could not load type for node "${node.name}" (${node.type} v${node.typeVersion}) — skipping`,
+				);
+				continue;
+			}
+
+			if (description.sensitiveOutputFields?.length) {
+				map.set(node.name, description.sensitiveOutputFields);
+			}
+		}
+
+		return map;
+	}
+
+	/**
+	 * Replaces declared sensitive field values in `item.json` with an
+	 * `IRedactedFieldMarker`.  Uses fail-fast path traversal: stops at the
+	 * first missing segment (no error, no sibling traversal).
+	 */
+	private redactFields(item: INodeExecutionData, fieldPaths: string[]): void {
+		for (const path of fieldPaths) {
+			this.redactPath(item.json, path);
+		}
+	}
+
+	private redactPath(obj: Record<string, unknown>, path: string): void {
+		const segments = path.split('.');
+		let current: Record<string, unknown> = obj;
+
+		for (let i = 0; i < segments.length - 1; i++) {
+			const segment = segments[i];
+			const next = current[segment];
+			if (next === null || next === undefined || typeof next !== 'object') {
+				// Fail fast — path does not exist, nothing to redact
+				return;
+			}
+			current = next as Record<string, unknown>;
+		}
+
+		const lastSegment = segments[segments.length - 1];
+		if (!(lastSegment in current)) return;
+
+		const marker: IRedactedFieldMarker = {
+			__redacted: true,
+			reason: 'node_defined_field',
+			canReveal: false,
+		};
+		current[lastSegment] = marker;
+	}
+}

--- a/packages/cli/src/modules/redaction/executions/strategies/node-defined-field-redaction.strategy.ts
+++ b/packages/cli/src/modules/redaction/executions/strategies/node-defined-field-redaction.strategy.ts
@@ -40,16 +40,21 @@ export class NodeDefinedFieldRedactionStrategy implements IExecutionRedactionStr
 			if (!fieldPaths?.length) continue;
 
 			for (const taskData of runData[nodeName]) {
-				if (taskData.data) {
-					for (const outputs of Object.values(taskData.data)) {
-						for (const items of outputs) {
-							if (items) {
-								for (const item of items) {
-									this.redactFields(item, fieldPaths);
-								}
-							}
-						}
-					}
+				if (!taskData.data) continue;
+				this.redactTaskDataOutputs(taskData.data, fieldPaths);
+			}
+		}
+	}
+
+	/**
+	 * Redacts sensitive fields across all outputs in a task's data connections.
+	 */
+	private redactTaskDataOutputs(connections: ITaskDataConnections, fieldPaths: string[]): void {
+		for (const outputs of Object.values(connections)) {
+			for (const items of outputs) {
+				if (!items) continue;
+				for (const item of items) {
+					this.redactFields(item, fieldPaths);
 				}
 			}
 		}

--- a/packages/nodes-base/nodes/Webhook/Webhook.node.ts
+++ b/packages/nodes-base/nodes/Webhook/Webhook.node.ts
@@ -71,6 +71,7 @@ export class Webhook extends Node {
 		outputs: `={{(${configuredOutputs})($parameter)}}`,
 		credentials: credentialsProperty(this.authPropertyName),
 		webhooks: [defaultWebhookDescription],
+		sensitiveOutputFields: ['headers.authorization', 'headers.cookie'],
 		properties: [
 			{
 				displayName: 'Allow Multiple HTTP Methods',

--- a/packages/nodes-base/nodes/Webhook/test/Webhook.test.ts
+++ b/packages/nodes-base/nodes/Webhook/test/Webhook.test.ts
@@ -134,4 +134,17 @@ describe('Test Webhook Node', () => {
 			});
 		});
 	});
+
+	describe('sensitiveOutputFields', () => {
+		it('declares authorization and cookie headers as sensitive', () => {
+			const node = new Webhook();
+			expect(node.description.sensitiveOutputFields).toContain('headers.authorization');
+			expect(node.description.sensitiveOutputFields).toContain('headers.cookie');
+		});
+
+		it('does not mark other headers as sensitive', () => {
+			const node = new Webhook();
+			expect(node.description.sensitiveOutputFields).not.toContain('headers.content-type');
+		});
+	});
 });

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1391,6 +1391,21 @@ export interface INodeExecutionRedactionInfo {
 	error?: IRedactedErrorInfo;
 }
 
+/**
+ * Marker placed on an `item.json` field when it has been redacted by a
+ * node-declared field redaction strategy.  A typed object (not `null` or a
+ * string) so consumers can distinguish intentional redaction from absent data.
+ *
+ * `canReveal` controls whether the UI should offer an option to unmask the
+ * value.  For credential-equivalent fields (e.g. auth headers) this is always
+ * `false`; future strategies may produce `true` for less-sensitive fields.
+ */
+export interface IRedactedFieldMarker {
+	__redacted: true;
+	reason: 'node_defined_field';
+	canReveal: boolean;
+}
+
 export interface INodeExecutionData {
 	[key: string]:
 		| IDataObject
@@ -2416,6 +2431,13 @@ export interface INodeTypeDescription extends INodeTypeBaseDescription {
 	features?: NodeFeaturesDefinition;
 	/** Hints for workflow-sdk type generation, including explicit AI input requirements */
 	builderHint?: IBuilderHint;
+	/**
+	 * Dot-notation paths relative to `item.json` that contain
+	 * credential-equivalent sensitive data (e.g. `'headers.authorization'`).
+	 * These fields are always redacted regardless of workflow policy or user
+	 * permissions and are never revealable.
+	 */
+	sensitiveOutputFields?: string[];
 }
 
 export type TriggerPanelDefinition = {


### PR DESCRIPTION
## Summary

Refactors `ExecutionRedactionService` into a composable strategy pipeline and adds a mechanism for node authors to declare output fields that must always be redacted — regardless of workflow policy, user permissions, or execution mode.

### Problem

Webhook nodes pass raw HTTP request data (including `Authorization` and `Cookie` headers) directly into workflow execution data. Any user with `execution:read` scope could read these values. There was no way to prevent this without redacting the entire execution.

### Solution

**New type system** (`packages/workflow`):
- `IRedactedFieldMarker` — a sentinel value that replaces redacted fields in `item.json`, carrying `{ __redacted: true, reason, canReveal }` so the frontend can render appropriate UI
- `sensitiveOutputFields?: string[]` on `INodeTypeDescription` — dot-notation paths (e.g. `headers.authorization`) that a node declares as always-sensitive

**Strategy pipeline** (`packages/cli`):
- `IExecutionRedactionStrategy` interface — each strategy receives the execution and a `RedactionContext` and owns its own mutations
- `FullItemRedactionStrategy` — extracts the existing item-clearing logic; included by the orchestrator when policy or an explicit request requires it
- `NodeDefinedFieldRedactionStrategy` — walks `sensitiveOutputFields` paths in `item.json` for every node that declares them; runs in all cases including on the "reveal" path, since these fields are **never revealable**
- `ExecutionRedactionService` now acts as an orchestrator: resolves `userCanReveal` once, builds the pipeline, and delegates all mutations to strategies

**Fail-closed behaviour**: if a node's type cannot be resolved at redaction time (e.g. a community node was uninstalled), `NodeDefinedFieldRedactionStrategy` wipes the entire node output conservatively rather than skipping it.

**Reference implementation** (`packages/nodes-base`):
- Webhook node declares `sensitiveOutputFields: ['headers.authorization', 'headers.cookie']`

### How it works end-to-end

1. A webhook fires with an `Authorization: Bearer <token>` header
2. The execution is stored with the raw header value
3. When the execution is retrieved, `NodeDefinedFieldRedactionStrategy` replaces `item.json.headers.authorization` with `{ __redacted: true, reason: 'node_defined_field', canReveal: false }`
4. Even if the requesting user is a global owner with `execution:reveal`, this field is not restored — `canReveal: false` is unconditional for node-declared fields

### Example screenshot

<img width="1428" height="680" alt="image" src="https://github.com/user-attachments/assets/d24ce3dd-e0d8-41b2-955b-eba3fa6cdcfa" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-278

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)