### PR TITLE
test: Remove dead code NodeDetailsViewPage.getParameterInputContainer (no-changelog)

### DIFF
--- a/packages/testing/playwright/pages/NodeDetailsViewPage.ts
+++ b/packages/testing/playwright/pages/NodeDetailsViewPage.ts
@@ -417,14 +417,6 @@ export class NodeDetailsViewPage extends BasePage {
 		return this.getParameterInput(parameterName).locator('input[type="text"]');
 	}
 
-	/**
-	 * Get the N8nInput container element for a parameter.
-	 * Use this for checking border styles since N8nInput has border on container, not input.
-	 */
-	getParameterInputContainer(parameterName: string) {
-		return this.getParameterInput(parameterName).locator('input[type="text"]').locator('..');
-	}
-
 	getInlineExpressionEditorContent() {
 		return this.getInlineExpressionEditorInput().locator('.cm-content');
 	}


### PR DESCRIPTION
## Summary

Remove unused `getParameterInputContainer()` method from `NodeDetailsViewPage` page object, identified by the Playwright janitor's dead-code rule.

No tests reference this method — confirmed via static analysis (janitor) and typecheck.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)