### PR TITLE
fix(core): handle URIError when decoding Content-Disposition filename with literal '%'

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/parse-incoming-message.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/parse-incoming-message.test.ts
@@ -142,6 +142,12 @@ describe('parseContentDisposition', () => {
 			description: 'should handle encoded filenames',
 		},
 		{
+			input: 'attachment; filename="my_scan_144dpi_75%.pdf"',
+			expected: { type: 'attachment', filename: 'my_scan_144dpi_75%.pdf' },
+			description:
+				'should handle filenames with literal "%" not part of a valid percent-encoding sequence',
+		},
+		{
 			input: 'attachment; size=123; filename="test.txt"; creation-date="Thu, 1 Jan 2020"',
 			expected: { type: 'attachment', filename: 'test.txt' },
 			description: 'should handle multiple parameters',

--- a/packages/core/src/execution-engine/node-execution-context/utils/parse-incoming-message.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/parse-incoming-message.ts
@@ -4,7 +4,12 @@ function parseHeaderParameters(parameters: string[]): Record<string, string> {
 	return parameters.reduce(
 		(acc, param) => {
 			const [key, value] = param.split('=');
-			let decodedValue = decodeURIComponent(value).trim();
+			let decodedValue: string;
+			try {
+				decodedValue = decodeURIComponent(value).trim();
+			} catch {
+				decodedValue = value.trim();
+			}
 			if (decodedValue.startsWith('"') && decodedValue.endsWith('"')) {
 				decodedValue = decodedValue.slice(1, -1);
 			}


### PR DESCRIPTION
## What

Fix HTTP node crashing with `URI Malformed` error when downloading files whose `Content-Disposition` filename contains a literal `%` not followed by a valid percent-encoding sequence (e.g. `my_scan_144dpi_75%.pdf`).

## Why

`decodeURIComponent()` throws a `URIError` when the input contains `%` followed by anything that isn't two valid hex digits. Filenames like `scan_75%.pdf` or `report_100%.txt` are perfectly valid but trip this error in `parseHeaderParameters`.

Fixes #26031

## How

Wrap `decodeURIComponent(value)` in a try/catch in `parse-incoming-message.ts`. On `URIError`, fall back to the raw (untrimmed) value. This preserves correct URL-decoding for headers that do contain valid percent-encoded sequences (e.g. `%20` → space) while gracefully handling filenames that happen to contain a bare `%`.

```diff
-  let decodedValue = decodeURIComponent(value).trim();
+  let decodedValue: string;
+  try {
+    decodedValue = decodeURIComponent(value).trim();
+  } catch {
+    decodedValue = value.trim();
+  }
```

## Testing

```bash
cd packages/core
node --experimental-vm-modules ../../node_modules/jest-cli/bin/jest.js parse-incoming-message.test --no-coverage
```

Added a regression test case:
- `attachment; filename="my_scan_144dpi_75%.pdf"` → `{ type: 'attachment', filename: 'my_scan_144dpi_75%.pdf' }`

All 27 tests pass.

## Breaking Changes

None. Files with valid percent-encoded filenames (e.g. `screenshot%20(1).png`) continue to be decoded correctly.