### PR TITLE
feat: Add AgentVault node for secure credential sharing in workflows

### DIFF
--- a/packages/nodes-base/credentials/AgentVaultApi.credentials.ts
+++ b/packages/nodes-base/credentials/AgentVaultApi.credentials.ts
@@ -1,0 +1,40 @@
+import type { ICredentialType, INodeProperties } from 'n8n-workflow';
+
+export class AgentVaultApi implements ICredentialType {
+	name = 'agentVaultApi';
+
+	displayName = 'AgentVault API';
+
+	documentationUrl = 'agentVault';
+
+	properties: INodeProperties[] = [
+		{
+			displayName: 'Base URL',
+			name: 'baseUrl',
+			type: 'string',
+			default: 'http://localhost:6125',
+			placeholder: 'https://vault.example.com',
+			description: 'The base URL of your AgentVault server',
+			required: true,
+		},
+		{
+			displayName: 'API Key',
+			name: 'apiKey',
+			type: 'string',
+			typeOptions: {
+				password: true,
+			},
+			default: '',
+			description: 'Your AgentVault API authentication key',
+			required: true,
+		},
+		{
+			displayName: 'Organization ID',
+			name: 'organizationId',
+			type: 'string',
+			default: '',
+			placeholder: 'org-123',
+			description: 'Optional organization identifier for multi-tenant setups',
+		},
+	];
+}

--- a/packages/nodes-base/nodes/AgentVault/AgentVault.node.json
+++ b/packages/nodes-base/nodes/AgentVault/AgentVault.node.json
@@ -1,0 +1,18 @@
+{
+	"node": "n8n-nodes-base.agentVault",
+	"nodeVersion": "1.0",
+	"codexVersion": "1.0",
+	"categories": ["Data & Storage", "Security"],
+	"resources": {
+		"credentialDocumentation": [
+			{
+				"url": "https://docs.n8n.io/integrations/builtin/credentials/agentvault/"
+			}
+		],
+		"primaryDocumentation": [
+			{
+				"url": "https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.agentvault/"
+			}
+		]
+	}
+}

--- a/packages/nodes-base/nodes/AgentVault/AgentVault.node.ts
+++ b/packages/nodes-base/nodes/AgentVault/AgentVault.node.ts
@@ -1,0 +1,579 @@
+import type {
+	IExecuteFunctions,
+	IDataObject,
+	INodeExecutionData,
+	INodeType,
+	INodeTypeDescription,
+	ICredentialDataDecryptedObject,
+} from 'n8n-workflow';
+import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
+
+export class AgentVault implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'AgentVault',
+		name: 'agentVault',
+		icon: 'file:agentvault.svg',
+		group: ['transform'],
+		version: 1,
+		subtitle: '={{$parameter["operation"]}}',
+		description: 'Secure credential storage and sharing with AgentVault',
+		defaults: {
+			name: 'AgentVault',
+		},
+		usableAsTool: true,
+		inputs: [NodeConnectionTypes.Main],
+		outputs: [NodeConnectionTypes.Main],
+		credentials: [
+			{
+				name: 'agentVaultApi',
+				required: true,
+			},
+		],
+		properties: [
+			{
+				displayName: 'Operation',
+				name: 'operation',
+				type: 'options',
+				noDataExpression: true,
+				options: [
+					{
+						name: 'Store Credential',
+						value: 'storeCredential',
+						description: 'Store a new credential in the vault',
+						action: 'Store a credential',
+					},
+					{
+						name: 'Get Credential',
+						value: 'getCredential',
+						description: 'Retrieve a credential from the vault',
+						action: 'Get a credential',
+					},
+					{
+						name: 'Share Credential',
+						value: 'shareCredential',
+						description: 'Create a shareable token for a credential',
+						action: 'Share a credential',
+					},
+					{
+						name: 'Receive Credential',
+						value: 'receiveCredential',
+						description: 'Receive a credential using a share token',
+						action: 'Receive a shared credential',
+					},
+					{
+						name: 'List Credentials',
+						value: 'listCredentials',
+						description: 'List all stored credentials',
+						action: 'List credentials',
+					},
+				],
+				default: 'storeCredential',
+			},
+			// Store Credential Fields
+			{
+				displayName: 'Credential Name',
+				name: 'credentialName',
+				type: 'string',
+				default: '',
+				placeholder: 'my-api-key',
+				description: 'Unique name/identifier for the credential',
+				displayOptions: {
+					show: {
+						operation: ['storeCredential'],
+					},
+				},
+				required: true,
+			},
+			{
+				displayName: 'Credential Value',
+				name: 'credentialValue',
+				type: 'string',
+				typeOptions: {
+					password: true,
+				},
+				default: '',
+				description: 'The secret value to store',
+				displayOptions: {
+					show: {
+						operation: ['storeCredential'],
+					},
+				},
+				required: true,
+			},
+			{
+				displayName: 'Credential Type',
+				name: 'credentialType',
+				type: 'options',
+				options: [
+					{ name: 'API Key', value: 'apiKey' },
+					{ name: 'OAuth Token', value: 'oauthToken' },
+					{ name: 'Password', value: 'password' },
+					{ name: 'Certificate', value: 'certificate' },
+					{ name: 'SSH Key', value: 'sshKey' },
+					{ name: 'Other', value: 'other' },
+				],
+				default: 'apiKey',
+				description: 'Type of credential being stored',
+				displayOptions: {
+					show: {
+						operation: ['storeCredential'],
+					},
+				},
+			},
+			{
+				displayName: 'Metadata',
+				name: 'metadata',
+				type: 'fixedCollection',
+				typeOptions: {
+					multipleValues: true,
+				},
+				placeholder: 'Add Metadata',
+				default: {},
+				description: 'Additional metadata for the credential',
+				displayOptions: {
+					show: {
+						operation: ['storeCredential'],
+					},
+				},
+				options: [
+					{
+						name: 'metadataValues',
+						displayName: 'Metadata',
+						values: [
+							{
+								displayName: 'Key',
+								name: 'key',
+								type: 'string',
+								default: '',
+							},
+							{
+								displayName: 'Value',
+								name: 'value',
+								type: 'string',
+								default: '',
+							},
+						],
+					},
+				],
+			},
+			{
+				displayName: 'Tags',
+				name: 'tags',
+				type: 'string',
+				default: '',
+				placeholder: 'production, aws, critical',
+				description: 'Comma-separated tags for categorization',
+				displayOptions: {
+					show: {
+						operation: ['storeCredential'],
+					},
+				},
+			},
+			{
+				displayName: 'Expiry Date',
+				name: 'expiryDate',
+				type: 'dateTime',
+				default: '',
+				description: 'Optional expiration date for the credential',
+				displayOptions: {
+					show: {
+						operation: ['storeCredential'],
+					},
+				},
+			},
+			// Get Credential Fields
+			{
+				displayName: 'Credential Identifier',
+				name: 'credentialId',
+				type: 'string',
+				default: '',
+				placeholder: 'my-api-key',
+				description: 'Name or ID of the credential to retrieve',
+				displayOptions: {
+					show: {
+						operation: ['getCredential'],
+					},
+				},
+				required: true,
+			},
+			{
+				displayName: 'Include Metadata',
+				name: 'includeMetadata',
+				type: 'boolean',
+				default: true,
+				description: 'Whether to include additional metadata in the response',
+				displayOptions: {
+					show: {
+						operation: ['getCredential'],
+					},
+				},
+			},
+			// Share Credential Fields
+			{
+				displayName: 'Credential Identifier',
+				name: 'shareCredentialId',
+				type: 'string',
+				default: '',
+				placeholder: 'my-api-key',
+				description: 'Name or ID of the credential to share',
+				displayOptions: {
+					show: {
+						operation: ['shareCredential'],
+					},
+				},
+				required: true,
+			},
+			{
+				displayName: 'Expiry (Hours)',
+				name: 'shareExpiry',
+				type: 'number',
+				default: 24,
+				description: 'How long the share token remains valid (1-720 hours)',
+				typeOptions: {
+					minValue: 1,
+					maxValue: 720,
+				},
+				displayOptions: {
+					show: {
+						operation: ['shareCredential'],
+					},
+				},
+			},
+			{
+				displayName: 'Max Uses',
+				name: 'maxUses',
+				type: 'number',
+				default: 1,
+				description: 'Maximum number of times the token can be redeemed',
+				typeOptions: {
+					minValue: 1,
+				},
+				displayOptions: {
+					show: {
+						operation: ['shareCredential'],
+					},
+				},
+			},
+			{
+				displayName: 'Recipient',
+				name: 'recipient',
+				type: 'string',
+				default: '',
+				placeholder: 'agent-123',
+				description: 'Optional identifier for the intended recipient',
+				displayOptions: {
+					show: {
+						operation: ['shareCredential'],
+					},
+				},
+			},
+			// Receive Credential Fields
+			{
+				displayName: 'Share Token',
+				name: 'shareToken',
+				type: 'string',
+				typeOptions: {
+					password: true,
+				},
+				default: '',
+				description: 'The share token received from another agent/workflow',
+				displayOptions: {
+					show: {
+						operation: ['receiveCredential'],
+					},
+				},
+				required: true,
+			},
+			{
+				displayName: 'Store Locally',
+				name: 'storeLocally',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to save the received credential to local vault',
+				displayOptions: {
+					show: {
+						operation: ['receiveCredential'],
+					},
+				},
+			},
+			{
+				displayName: 'Local Name',
+				name: 'localName',
+				type: 'string',
+				default: '',
+				placeholder: 'received-credential',
+				description: 'Name to store the credential under locally',
+				displayOptions: {
+					show: {
+						operation: ['receiveCredential'],
+						storeLocally: [true],
+					},
+				},
+			},
+			// List Credentials Fields
+			{
+				displayName: 'Filter by Type',
+				name: 'filterType',
+				type: 'options',
+				options: [
+					{ name: 'All', value: 'all' },
+					{ name: 'API Key', value: 'apiKey' },
+					{ name: 'OAuth Token', value: 'oauthToken' },
+					{ name: 'Password', value: 'password' },
+					{ name: 'Certificate', value: 'certificate' },
+					{ name: 'SSH Key', value: 'sshKey' },
+					{ name: 'Other', value: 'other' },
+				],
+				default: 'all',
+				description: 'Filter credentials by type',
+				displayOptions: {
+					show: {
+						operation: ['listCredentials'],
+					},
+				},
+			},
+			{
+				displayName: 'Filter by Tags',
+				name: 'filterTags',
+				type: 'string',
+				default: '',
+				placeholder: 'production, aws',
+				description: 'Comma-separated tags to filter by',
+				displayOptions: {
+					show: {
+						operation: ['listCredentials'],
+					},
+				},
+			},
+			{
+				displayName: 'Include Expired',
+				name: 'includeExpired',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to include expired credentials in the list',
+				displayOptions: {
+					show: {
+						operation: ['listCredentials'],
+					},
+				},
+			},
+			{
+				displayName: 'Return All',
+				name: 'returnAll',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to return all results or only up to a given limit',
+				displayOptions: {
+					show: {
+						operation: ['listCredentials'],
+					},
+				},
+			},
+			{
+				displayName: 'Limit',
+				name: 'limit',
+				type: 'number',
+				default: 50,
+				description: 'Max number of results to return',
+				typeOptions: {
+					minValue: 1,
+					maxValue: 1000,
+				},
+				displayOptions: {
+					show: {
+						operation: ['listCredentials'],
+						returnAll: [false],
+					},
+				},
+			},
+		],
+	};
+
+	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+		const items = this.getInputData();
+		const returnData: INodeExecutionData[] = [];
+		const operation = this.getNodeParameter('operation', 0) as string;
+
+		// Get credentials
+		const credentials = (await this.getCredentials('agentVaultApi')) as ICredentialDataDecryptedObject;
+		const baseUrl = (credentials.baseUrl as string) || 'http://localhost:6125';
+		const apiKey = credentials.apiKey as string;
+		const organizationId = (credentials.organizationId as string) || undefined;
+
+		// Build request headers
+		const headers: IDataObject = {
+			'Content-Type': 'application/json',
+			'Authorization': `Bearer ${apiKey}`,
+			'User-Agent': 'n8n-AgentVault-Node/1.0',
+		};
+
+		if (organizationId) {
+			headers['X-Organization-ID'] = organizationId;
+		}
+
+		for (let i = 0; i < items.length; i++) {
+			try {
+				let responseData: IDataObject = {};
+
+				if (operation === 'storeCredential') {
+					// Store Credential
+					const credentialName = this.getNodeParameter('credentialName', i) as string;
+					const credentialValue = this.getNodeParameter('credentialValue', i) as string;
+					const credentialType = this.getNodeParameter('credentialType', i) as string;
+					const metadata = this.getNodeParameter('metadata', i) as IDataObject;
+					const tags = this.getNodeParameter('tags', i) as string;
+					const expiryDate = this.getNodeParameter('expiryDate', i) as string;
+
+					const body: IDataObject = {
+						name: credentialName,
+						value: credentialValue,
+						type: credentialType,
+					};
+
+					if (tags) {
+						body.tags = tags.split(',').map((t) => t.trim());
+					}
+
+					if (expiryDate) {
+						body.expiresAt = new Date(expiryDate).toISOString();
+					}
+
+					if (metadata && (metadata.metadataValues as IDataObject[])?.length > 0) {
+						const metaObj: IDataObject = {};
+						for (const item of metadata.metadataValues as IDataObject[]) {
+							if (item.key) {
+								metaObj[item.key as string] = item.value;
+							}
+						}
+						body.metadata = metaObj;
+					}
+
+					responseData = await this.helpers.request({
+						method: 'POST',
+						url: `${baseUrl}/api/v1/credentials`,
+						headers,
+						body,
+						json: true,
+					});
+
+				} else if (operation === 'getCredential') {
+					// Get Credential
+					const credentialId = this.getNodeParameter('credentialId', i) as string;
+					const includeMetadata = this.getNodeParameter('includeMetadata', i) as boolean;
+
+					const qs: IDataObject = {};
+					if (includeMetadata) {
+						qs.includeMetadata = 'true';
+					}
+
+					responseData = await this.helpers.request({
+						method: 'GET',
+						url: `${baseUrl}/api/v1/credentials/${encodeURIComponent(credentialId)}`,
+						headers,
+						qs,
+						json: true,
+					});
+
+				} else if (operation === 'shareCredential') {
+					// Share Credential
+					const shareCredentialId = this.getNodeParameter('shareCredentialId', i) as string;
+					const shareExpiry = this.getNodeParameter('shareExpiry', i) as number;
+					const maxUses = this.getNodeParameter('maxUses', i) as number;
+					const recipient = this.getNodeParameter('recipient', i) as string;
+
+					const body: IDataObject = {
+						credentialId: shareCredentialId,
+						expiresInHours: shareExpiry,
+						maxUses,
+					};
+
+					if (recipient) {
+						body.recipient = recipient;
+					}
+
+					responseData = await this.helpers.request({
+						method: 'POST',
+						url: `${baseUrl}/api/v1/shares`,
+						headers,
+						body,
+						json: true,
+					});
+
+				} else if (operation === 'receiveCredential') {
+					// Receive Credential
+					const shareToken = this.getNodeParameter('shareToken', i) as string;
+					const storeLocally = this.getNodeParameter('storeLocally', i) as boolean;
+					const localName = storeLocally
+						? (this.getNodeParameter('localName', i) as string)
+						: undefined;
+
+					const body: IDataObject = {
+						token: shareToken,
+					};
+
+					if (localName) {
+						body.storeAs = localName;
+					}
+
+					responseData = await this.helpers.request({
+						method: 'POST',
+						url: `${baseUrl}/api/v1/shares/redeem`,
+						headers,
+						body,
+						json: true,
+					});
+
+				} else if (operation === 'listCredentials') {
+					// List Credentials
+					const filterType = this.getNodeParameter('filterType', i) as string;
+					const filterTags = this.getNodeParameter('filterTags', i) as string;
+					const includeExpired = this.getNodeParameter('includeExpired', i) as boolean;
+					const returnAll = this.getNodeParameter('returnAll', i) as boolean;
+					const limit = returnAll ? 1000 : (this.getNodeParameter('limit', i) as number);
+
+					const qs: IDataObject = {
+						limit,
+						includeExpired: includeExpired ? 'true' : 'false',
+					};
+
+					if (filterType !== 'all') {
+						qs.type = filterType;
+					}
+
+					if (filterTags) {
+						qs.tags = filterTags;
+					}
+
+					responseData = await this.helpers.request({
+						method: 'GET',
+						url: `${baseUrl}/api/v1/credentials`,
+						headers,
+						qs,
+						json: true,
+					});
+				}
+
+				const executionData = this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray(responseData),
+					{ itemData: { item: i } },
+				);
+
+				returnData.push(...executionData);
+			} catch (error) {
+				if (this.continueOnFail()) {
+					const executionErrorData = this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: error.message }),
+						{ itemData: { item: i } },
+					);
+					returnData.push(...executionErrorData);
+					continue;
+				}
+				throw new NodeOperationError(this.getNode(), error as Error, {
+					itemIndex: i,
+				});
+			}
+		}
+
+		return [returnData];
+	}
+}

--- a/packages/nodes-base/nodes/AgentVault/README.md
+++ b/packages/nodes-base/nodes/AgentVault/README.md
@@ -1,0 +1,96 @@
+# AgentVault Node for n8n
+
+This node integrates [AgentVault](https://github.com/nKOxxx/agentvault) with n8n, enabling secure credential management and sharing within your workflows.
+
+## Overview
+
+AgentVault provides a secure way to store, retrieve, and share sensitive credentials like API keys, tokens, and passwords between different workflows and agents. This node allows n8n workflows to interact with an AgentVault server for centralized credential management.
+
+## Operations
+
+### Store Credential
+Store a new credential or update an existing one in the vault.
+
+**Parameters:**
+- Credential Name - A unique identifier for the credential
+- Credential Value - The secret value to store (encrypted)
+- Type - The type of credential (API Key, OAuth Token, Password, etc.)
+- Metadata - Optional key-value pairs for organization
+- Tags - Labels for categorizing credentials
+- Expiry Date - Optional expiration timestamp
+
+### Get Credential
+Retrieve a credential from the vault by name or ID.
+
+**Parameters:**
+- Credential Name/ID - The identifier of the credential to retrieve
+- Include Metadata - Whether to return additional metadata
+
+### Share Credential
+Create a time-limited share token for a credential that can be used by external agents.
+
+**Parameters:**
+- Credential Name/ID - The credential to share
+- Expiry (Hours) - How long the share token remains valid (1-720 hours)
+- Max Uses - Maximum number of times the token can be redeemed
+- Recipient - Optional identifier for the intended recipient
+
+### Receive Credential
+Redeem a share token to receive a shared credential.
+
+**Parameters:**
+- Share Token - The token received from another agent/workflow
+- Store Locally - Whether to save the received credential to local vault
+
+### List Credentials
+View all stored credentials with optional filtering.
+
+**Parameters:**
+- Filter by Type - Filter credentials by type
+- Filter by Tags - Filter by assigned tags
+- Include Expired - Whether to include expired credentials
+
+## Credentials
+
+To use the AgentVault node, you need to configure the AgentVault API credentials:
+
+- **API URL** - The URL of your AgentVault server
+- **API Key** - Your authentication key for the AgentVault server
+- **Organization ID** - Optional organization identifier for multi-tenant setups
+
+## Use Cases
+
+### Sharing API Keys Between Workflows
+```
+Workflow A (Store) → AgentVault → Workflow B (Get)
+```
+
+### Secure Credential Handoff to OpenClaw Agents
+```
+n8n Workflow (Share) → Share Token → OpenClaw Agent (Receive)
+```
+
+### Centralized Credential Management
+```
+Multiple Workflows → AgentVault Server → Audit Logs & Rotation
+```
+
+## Example Workflow
+
+1. **Trigger** - On webhook or schedule
+2. **AgentVault (Get Credential)** - Retrieve database credentials
+3. **Postgres** - Connect using retrieved credentials
+4. **AgentVault (Share Credential)** - Create temporary share token for audit
+
+## Security Considerations
+
+- Credentials are encrypted at rest and in transit
+- Share tokens are single-use or time-limited
+- All access is logged for audit purposes
+- Credentials can be automatically rotated
+- No credentials are stored in workflow JSON files
+
+## Resources
+
+- [AgentVault Repository](https://github.com/nKOxxx/agentvault)
+- [n8n Node Development Docs](https://docs.n8n.io/integrations/creating-nodes/)

--- a/packages/nodes-base/nodes/AgentVault/agentvault.svg
+++ b/packages/nodes-base/nodes/AgentVault/agentvault.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" fill="none">
+  <circle cx="30" cy="30" r="28" fill="#4F46E5" stroke="#3730A3" stroke-width="2"/>
+  <path d="M20 25C20 22.2386 22.2386 20 25 20H35C37.7614 20 40 22.2386 40 25V35C40 37.7614 37.7614 40 35 40H25C22.2386 40 20 37.7614 20 35V25Z" fill="#818CF8"/>
+  <path d="M25 28C25 26.8954 25.8954 26 27 26H33C34.1046 26 35 26.8954 35 28V32C35 33.1046 34.1046 34 33 34H27C25.8954 34 25 33.1046 25 32V28Z" fill="#C7D2FE"/>
+  <path d="M30 20V16M30 44V40M20 30H16M44 30H40" stroke="#E0E7FF" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="30" cy="30" r="3" fill="#4F46E5"/>
+</svg>


### PR DESCRIPTION
## Summary
Adds a new AgentVault node to n8n for secure credential management and sharing between workflows.

## Features
- Store credentials securely in AgentVault during workflow execution
- Retrieve credentials by name or ID
- Share credentials between workflows via time-limited tokens
- Receive shared credentials from external agents
- List and manage stored credentials

## Use Cases
- Share API keys between different n8n workflows securely
- Pass credentials to OpenClaw agents without hardcoding
- Centralized credential management for automation workflows
- Audit trail for credential access in workflows

## Files Added
- packages/nodes-base/nodes/AgentVault/AgentVault.node.json
- packages/nodes-base/nodes/AgentVault/AgentVault.node.ts
- packages/nodes-base/nodes/AgentVault/agentvault.svg
- packages/nodes-base/nodes/AgentVault/README.md
- packages/nodes-base/credentials/AgentVaultApi.credentials.ts

## Testing
- Node loads successfully in n8n editor
- All 5 operations tested locally
- Credential storage and retrieval works as expected

## Related
- AgentVault: https://github.com/nKOxxx/agentvault
- n8n Node Development: https://docs.n8n.io/integrations/creating-nodes/