### PR TITLE
fix(Gitlab Node): prevent duplicate webhooks on workflow publish

### DIFF
--- a/.github/scripts/compute-backport-targets.mjs
+++ b/.github/scripts/compute-backport-targets.mjs
@@ -1,6 +1,11 @@
 // Creates backport PR's according to labels on merged PR
 
-import { readPrLabels, resolveRcBranchForTrack, writeGithubOutput } from './github-helpers.mjs';
+import {
+	getPullRequestById,
+	readPrLabels,
+	resolveRcBranchForTrack,
+	writeGithubOutput,
+} from './github-helpers.mjs';
 
 /** @type { Record<string, import('./github-helpers.mjs').ReleaseTrack> } */
 const BACKPORT_BY_TAG_MAP = {
@@ -50,8 +55,38 @@ export function labelsToReleaseCandidateBranches(labels) {
 	return targets;
 }
 
+/**
+ * This script is called in 2 cases:
+ *
+ * 1. When a PR is merged, in which case functions like `readPrLabels` reads PR info from GITHUB_EVENT_PATH
+ * 2. Manually via Workflow Dispatch, where a Pull Request ID is passed as an env parameter
+ *
+ * @returns { Promise<undefined | any> } Pull request object, if ID was provided in env params
+ */
+async function fetchPossiblePullRequestFromEnv() {
+	const pullRequestEnv = process.env.PULL_REQUEST_ID;
+	if (!pullRequestEnv) {
+		// No ID provided, will proceed to read data from GITHUB_EVENT_PATH
+		return undefined;
+	}
+
+	const pullRequestNumber = parseInt(pullRequestEnv);
+	if (isNaN(pullRequestNumber)) {
+		throw new Error(
+			"PULL_REQUEST_ID must be a number. It shouldn't contain any other symbols (#, PR, etc.)",
+		);
+	}
+
+	return await getPullRequestById(pullRequestNumber);
+}
+
+export async function getLabels() {
+	const pullRequest = await fetchPossiblePullRequestFromEnv();
+	return new Set(readPrLabels(pullRequest));
+}
+
 async function main() {
-	const labels = new Set(readPrLabels());
+	const labels = await getLabels();
 	if (!labels || labels.size === 0) {
 		console.log('No labels on PR. Exiting...');
 		return;

--- a/.github/scripts/compute-backport-targets.test.mjs
+++ b/.github/scripts/compute-backport-targets.test.mjs
@@ -1,5 +1,6 @@
 import { describe, it, mock, before } from 'node:test';
 import assert from 'node:assert/strict';
+import { readPrLabels } from './github-helpers.mjs';
 
 /**
  * Run these tests by running
@@ -12,9 +13,14 @@ import assert from 'node:assert/strict';
 mock.module('./github-helpers.mjs', {
 	namedExports: {
 		ensureEnvVar: () => {}, // no-op
-		readPrLabels: () => {}, // no-op
+		readPrLabels: readPrLabels,
 		resolveRcBranchForTrack: mockResolveRcBranchForTrack,
 		writeGithubOutput: () => {}, //no-op
+		getPullRequestById: () => {
+			return {
+				labels: ['n8n team', 'Backport to Beta'],
+			};
+		},
 	},
 });
 
@@ -28,9 +34,11 @@ function mockResolveRcBranchForTrack(track) {
 	return undefined;
 }
 
-let labelsToReleaseCandidateBranches;
+let labelsToReleaseCandidateBranches, getLabels;
 before(async () => {
-	({ labelsToReleaseCandidateBranches } = await import('./compute-backport-targets.mjs'));
+	({ labelsToReleaseCandidateBranches, getLabels } = await import(
+		'./compute-backport-targets.mjs'
+	));
 });
 
 describe('Compute backport targets', () => {
@@ -58,5 +66,39 @@ describe('Compute backport targets', () => {
 		const result = labelsToReleaseCandidateBranches(labels);
 
 		assert.equal(result.size, 0);
+	});
+
+	it('Should parse labels properly in Pull request context', async () => {
+		process.env.GITHUB_EVENT_PATH = './fixtures/mock-github-event.json';
+		/** @type { Set<string> } */
+		const labels = await getLabels();
+
+		assert.equal(labels.size, 2);
+		assert.ok(labels.has('release'));
+		assert.ok(labels.has('Backport to Stable'));
+	});
+	it('Should parse labels properly in manual workflow context', async () => {
+		process.env.PULL_REQUEST_ID = '123';
+		/** @type { Set<string> } */
+		const labels = await getLabels();
+
+		assert.equal(labels.size, 2);
+		assert.ok(labels.has('n8n team'));
+		assert.ok(labels.has('Backport to Beta'));
+	});
+
+	it('Should throw when passed pull request id with #', async () => {
+		process.env.PULL_REQUEST_ID = '#123';
+		await assert.rejects(getLabels);
+	});
+
+	it('Should not throw when passed pull request id with just a number', async () => {
+		process.env.PULL_REQUEST_ID = '123';
+		await assert.doesNotReject(getLabels);
+	});
+
+	it('Should throw when passed pull request id with other than numbers included', async () => {
+		process.env.PULL_REQUEST_ID = 'abc-123';
+		await assert.rejects(getLabels);
 	});
 });

--- a/.github/scripts/fixtures/mock-github-event.json
+++ b/.github/scripts/fixtures/mock-github-event.json
@@ -1,0 +1,5 @@
+{
+	"pull_request": {
+		"labels": ["release", "Backport to Stable"]
+	}
+}

--- a/.github/scripts/github-helpers.mjs
+++ b/.github/scripts/github-helpers.mjs
@@ -1,5 +1,7 @@
+import { getOctokit } from '@actions/github';
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
+import path from 'node:path';
 import semver from 'semver';
 
 export const RELEASE_TRACKS = /** @type { const } */ ([
@@ -117,6 +119,14 @@ export function stripReleasePrefixes(tag) {
 	);
 }
 
+export function getEventFromGithubEventPath() {
+	let eventPath = ensureEnvVar('GITHUB_EVENT_PATH');
+	if (!path.isAbsolute(eventPath)) {
+		eventPath = import.meta.dirname + '/' + eventPath;
+	}
+	return JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+}
+
 /**
  * @param {any} [pullRequest] Optional pull request object. If not provided, reads from GITHUB_EVENT_PATH
  *
@@ -124,8 +134,7 @@ export function stripReleasePrefixes(tag) {
  */
 export function readPrLabels(pullRequest) {
 	if (!pullRequest) {
-		const eventPath = ensureEnvVar('GITHUB_EVENT_PATH');
-		const event = JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+		const event = getEventFromGithubEventPath();
 		pullRequest = event.pull_request;
 	}
 	/** @type { string[] | { name: string }[] } */
@@ -246,4 +255,39 @@ export function remoteBranchExists(branch) {
 export function localRefExists(ref) {
 	const res = trySh('git', ['show-ref', '--verify', '--quiet', ref]);
 	return res.ok;
+}
+
+/**
+ * Initializes octokit with GITHUB_TOKEN from env vars.
+ *
+ * Also ensures the existence of useful environment variables.
+ * */
+export function initGithub() {
+	const token = ensureEnvVar('GITHUB_TOKEN');
+	const repoFullName = ensureEnvVar('GITHUB_REPOSITORY');
+
+	const [owner, repo] = repoFullName.split('/');
+
+	const octokit = getOctokit(token);
+
+	return {
+		octokit,
+		owner,
+		repo,
+	};
+}
+
+/**
+ * @param {number} pullRequestId
+ */
+export async function getPullRequestById(pullRequestId) {
+	const { octokit, owner, repo } = initGithub();
+
+	const pullRequest = await octokit.rest.pulls.get({
+		owner,
+		repo,
+		pull_number: pullRequestId,
+	});
+
+	return pullRequest.data;
 }

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,6 +1,12 @@
 on:
   pull_request:
     types: [closed]
+  workflow_dispatch:
+    inputs:
+      pull-request-id:
+        description: 'The ID number of the pull request (e.g. 3342). No #, no extra letters.'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -8,7 +14,9 @@ permissions:
 
 jobs:
   backport:
-    if: github.event.pull_request.merged == true
+    if: |
+      github.event.pull_request.merged == true ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -23,6 +31,8 @@ jobs:
 
       - name: Compute backport targets
         id: targets
+        env:
+          PULL_REQUEST_ID: ${{ inputs.pull-request-id }}
         run: node .github/scripts/compute-backport-targets.mjs
 
       - name: Backport
@@ -30,7 +40,7 @@ jobs:
         uses: korthout/backport-action@c656f5d5851037b2b38fb5db2691a03fa229e3b2 # v4.0.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          source_pr_number: ${{ github.event.pull_request.number }}
+          source_pr_number: ${{ github.event.pull_request.number || inputs.pull-request-id }}
           target_branches: ${{ steps.targets.outputs.target_branches }}
           pull_description: |-
             # Description

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,3 +1,5 @@
+name: 'Util: Backport pull request changes'
+
 on:
   pull_request:
     types: [closed]

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -35,6 +35,7 @@ jobs:
         id: targets
         env:
           PULL_REQUEST_ID: ${{ inputs.pull-request-id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node .github/scripts/compute-backport-targets.mjs
 
       - name: Backport

--- a/packages/@n8n/config/src/configs/__tests__/ssrf-protection.config.test.ts
+++ b/packages/@n8n/config/src/configs/__tests__/ssrf-protection.config.test.ts
@@ -1,0 +1,175 @@
+import { Container } from '@n8n/di';
+
+import { SsrfProtectionConfig, SSRF_DEFAULT_BLOCKED_IP_RANGES } from '../ssrf-protection.config';
+
+describe('SsrfProtectionConfig', () => {
+	beforeEach(() => {
+		Container.reset();
+		jest.clearAllMocks();
+	});
+
+	const originalEnv = process.env;
+	afterEach(() => {
+		process.env = originalEnv;
+	});
+
+	describe('defaults', () => {
+		test('enabled is false', () => {
+			process.env = {};
+			expect(Container.get(SsrfProtectionConfig).enabled).toBe(false);
+		});
+
+		test('blockedIpRanges defaults to default ranges', () => {
+			process.env = {};
+			const config = Container.get(SsrfProtectionConfig);
+			expect(config.blockedIpRanges).toEqual(SSRF_DEFAULT_BLOCKED_IP_RANGES);
+		});
+
+		test('allowedIpRanges is empty array', () => {
+			process.env = {};
+			expect(Container.get(SsrfProtectionConfig).allowedIpRanges).toEqual([]);
+		});
+
+		test('allowedHostnames is empty array', () => {
+			process.env = {};
+			expect(Container.get(SsrfProtectionConfig).allowedHostnames).toEqual([]);
+		});
+
+		test('dnsCacheMaxTtlSeconds is 300', () => {
+			process.env = {};
+			expect(Container.get(SsrfProtectionConfig).dnsCacheMaxTtlSeconds).toBe(300);
+		});
+
+		test('dnsCacheMaxSize is 1048576', () => {
+			process.env = {};
+			expect(Container.get(SsrfProtectionConfig).dnsCacheMaxSize).toBe(1048576);
+		});
+	});
+
+	describe('N8N_SSRF_PROTECTION_ENABLED', () => {
+		test('sets enabled to true', () => {
+			process.env = { N8N_SSRF_PROTECTION_ENABLED: 'true' };
+			expect(Container.get(SsrfProtectionConfig).enabled).toBe(true);
+		});
+
+		test('sets enabled to false', () => {
+			process.env = { N8N_SSRF_PROTECTION_ENABLED: 'false' };
+			expect(Container.get(SsrfProtectionConfig).enabled).toBe(false);
+		});
+	});
+
+	describe('N8N_SSRF_BLOCKED_IP_RANGES', () => {
+		test('expands "default" to default ranges', () => {
+			process.env = { N8N_SSRF_BLOCKED_IP_RANGES: 'default' };
+			const config = Container.get(SsrfProtectionConfig);
+			expect(config.blockedIpRanges).toEqual(SSRF_DEFAULT_BLOCKED_IP_RANGES);
+		});
+
+		test('expands "default" and appends custom ranges', () => {
+			process.env = { N8N_SSRF_BLOCKED_IP_RANGES: 'default,100.0.0.0/8' };
+			const config = Container.get(SsrfProtectionConfig);
+			expect(config.blockedIpRanges).toEqual([...SSRF_DEFAULT_BLOCKED_IP_RANGES, '100.0.0.0/8']);
+		});
+
+		test('matches "default" case-insensitively', () => {
+			process.env = { N8N_SSRF_BLOCKED_IP_RANGES: 'DEFAULT,100.0.0.0/8' };
+			const config = Container.get(SsrfProtectionConfig);
+			expect(config.blockedIpRanges).toEqual([...SSRF_DEFAULT_BLOCKED_IP_RANGES, '100.0.0.0/8']);
+		});
+
+		test('parses custom comma-separated CIDRs', () => {
+			process.env = { N8N_SSRF_BLOCKED_IP_RANGES: '10.0.0.0/8,192.168.0.0/16' };
+			const config = Container.get(SsrfProtectionConfig);
+			expect(config.blockedIpRanges).toEqual(['10.0.0.0/8', '192.168.0.0/16']);
+		});
+
+		test('trims whitespace in custom CIDRs', () => {
+			process.env = { N8N_SSRF_BLOCKED_IP_RANGES: ' 10.0.0.0/8 , 192.168.0.0/16 ' };
+			const config = Container.get(SsrfProtectionConfig);
+			expect(config.blockedIpRanges).toEqual(['10.0.0.0/8', '192.168.0.0/16']);
+		});
+
+		test('filters empty entries', () => {
+			process.env = { N8N_SSRF_BLOCKED_IP_RANGES: '10.0.0.0/8,,192.168.0.0/16' };
+			const config = Container.get(SsrfProtectionConfig);
+			expect(config.blockedIpRanges).toEqual(['10.0.0.0/8', '192.168.0.0/16']);
+		});
+
+		test('handles a single CIDR', () => {
+			process.env = { N8N_SSRF_BLOCKED_IP_RANGES: '10.0.0.0/8' };
+			expect(Container.get(SsrfProtectionConfig).blockedIpRanges).toEqual(['10.0.0.0/8']);
+		});
+	});
+
+	describe('N8N_SSRF_ALLOWED_IP_RANGES', () => {
+		test('parses comma-separated CIDRs', () => {
+			process.env = { N8N_SSRF_ALLOWED_IP_RANGES: '10.5.0.0/24,10.6.0.0/24' };
+			expect(Container.get(SsrfProtectionConfig).allowedIpRanges).toEqual([
+				'10.5.0.0/24',
+				'10.6.0.0/24',
+			]);
+		});
+
+		test('is empty when env var is empty string', () => {
+			process.env = { N8N_SSRF_ALLOWED_IP_RANGES: '' };
+			expect(Container.get(SsrfProtectionConfig).allowedIpRanges).toEqual([]);
+		});
+	});
+
+	describe('N8N_SSRF_ALLOWED_HOSTNAMES', () => {
+		test('parses comma-separated patterns', () => {
+			process.env = { N8N_SSRF_ALLOWED_HOSTNAMES: '*.n8n.internal,api.example.com' };
+			expect(Container.get(SsrfProtectionConfig).allowedHostnames).toEqual([
+				'*.n8n.internal',
+				'api.example.com',
+			]);
+		});
+
+		test('is empty when env var is empty string', () => {
+			process.env = { N8N_SSRF_ALLOWED_HOSTNAMES: '' };
+			expect(Container.get(SsrfProtectionConfig).allowedHostnames).toEqual([]);
+		});
+	});
+
+	describe('numeric fields', () => {
+		test('overrides dnsCacheMaxTtlSeconds from env', () => {
+			process.env = { N8N_SSRF_DNS_CACHE_MAX_TTL_SECONDS: '600' };
+			expect(Container.get(SsrfProtectionConfig).dnsCacheMaxTtlSeconds).toBe(600);
+		});
+
+		test('overrides dnsCacheMaxSize from env', () => {
+			process.env = { N8N_SSRF_DNS_CACHE_MAX_SIZE: '2097152' };
+			expect(Container.get(SsrfProtectionConfig).dnsCacheMaxSize).toBe(2097152);
+		});
+
+		test('falls back to default for invalid dnsCacheMaxTtlSeconds', () => {
+			const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+			process.env = { N8N_SSRF_DNS_CACHE_MAX_TTL_SECONDS: 'notanumber' };
+			expect(Container.get(SsrfProtectionConfig).dnsCacheMaxTtlSeconds).toBe(300);
+			expect(consoleWarnSpy).toHaveBeenCalled();
+
+			consoleWarnSpy.mockRestore();
+		});
+
+		test('falls back to default for non-positive dnsCacheMaxTtlSeconds', () => {
+			const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+			process.env = { N8N_SSRF_DNS_CACHE_MAX_TTL_SECONDS: '0' };
+			expect(Container.get(SsrfProtectionConfig).dnsCacheMaxTtlSeconds).toBe(300);
+			expect(consoleWarnSpy).toHaveBeenCalled();
+
+			consoleWarnSpy.mockRestore();
+		});
+
+		test('falls back to default for invalid dnsCacheMaxSize', () => {
+			const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+			process.env = { N8N_SSRF_DNS_CACHE_MAX_SIZE: 'invalid' };
+			expect(Container.get(SsrfProtectionConfig).dnsCacheMaxSize).toBe(1048576);
+			expect(consoleWarnSpy).toHaveBeenCalled();
+
+			consoleWarnSpy.mockRestore();
+		});
+	});
+});

--- a/packages/@n8n/config/src/configs/ssrf-protection.config.ts
+++ b/packages/@n8n/config/src/configs/ssrf-protection.config.ts
@@ -1,0 +1,87 @@
+import { z } from 'zod';
+
+import { CommaSeparatedStringArray } from '../custom-types';
+import { Config, Env } from '../decorators';
+
+/**
+ * Default blocked IP ranges applied when N8N_SSRF_BLOCKED_IP_RANGES is 'default'.
+ * Covers RFC 1918, loopback, link-local, IPv6 unique local, and reserved/special ranges.
+ */
+export const SSRF_DEFAULT_BLOCKED_IP_RANGES: readonly string[] = Object.freeze([
+	// RFC 1918 private ranges
+	'10.0.0.0/8',
+	'172.16.0.0/12',
+	'192.168.0.0/16',
+	// Loopback
+	'127.0.0.0/8',
+	'::1',
+	// Link-local
+	'169.254.0.0/16',
+	'fe80::/10',
+	// IPv6 unique local
+	'fc00::/7',
+	'fd00::/8',
+	// Reserved/special purpose
+	'0.0.0.0/8',
+	'192.0.0.0/24',
+	'192.0.2.0/24',
+	'198.18.0.0/15',
+	'198.51.100.0/24',
+	'203.0.113.0/24',
+]);
+
+/**
+ * Parses comma-separated blocked ranges, expands `default` (case-insensitive)
+ * to the built-in blocked ranges, and removes duplicates while preserving order.
+ *
+ * @example
+ * parseBlockedIpRanges('default,100.0.0.0/8')
+ * // returns [...SSRF_DEFAULT_BLOCKED_IP_RANGES, '100.0.0.0/8']
+ */
+const parseBlockedIpRanges = (input: string): string[] => {
+	const values = input
+		.split(',')
+		.map((value) => value.trim())
+		.filter((value) => value.length > 0);
+
+	const expanded = values.flatMap((value) =>
+		value.toLowerCase() === 'default' ? SSRF_DEFAULT_BLOCKED_IP_RANGES : value,
+	);
+
+	return [...new Set(expanded)];
+};
+
+const blockedIpRangesSchema = z.string().transform(parseBlockedIpRanges);
+
+const positiveNumberSchema = z.coerce.number().gt(0);
+
+@Config
+export class SsrfProtectionConfig {
+	/** Whether SSRF protection is enabled for nodes making HTTP requests to user-controllable targets. */
+	@Env('N8N_SSRF_PROTECTION_ENABLED')
+	enabled: boolean = false;
+
+	/**
+	 * Comma-separated CIDR ranges to block.
+	 * Use `default` to include the standard set, optionally with custom ranges
+	 * (for example: `default,100.0.0.0/8`).
+	 */
+	@Env('N8N_SSRF_BLOCKED_IP_RANGES', blockedIpRangesSchema)
+	blockedIpRanges: string[] = [...SSRF_DEFAULT_BLOCKED_IP_RANGES];
+
+	/** Comma-separated CIDR ranges to allow (takes precedence over the block list). */
+	@Env('N8N_SSRF_ALLOWED_IP_RANGES')
+	allowedIpRanges: CommaSeparatedStringArray<string> = [];
+
+	/** Comma-separated hostname patterns to allow. Supports wildcards: *.n8n.internal */
+	@Env('N8N_SSRF_ALLOWED_HOSTNAMES')
+	allowedHostnames: CommaSeparatedStringArray<string> = [];
+
+	/** Maximum DNS cache TTL in seconds. Default: 300. */
+	@Env('N8N_SSRF_DNS_CACHE_MAX_TTL_SECONDS', positiveNumberSchema)
+	dnsCacheMaxTtlSeconds: number = 300;
+
+	/** Maximum DNS cache size in bytes (LRU eviction). Default: 1 MB. */
+	@Env('N8N_SSRF_DNS_CACHE_MAX_SIZE')
+	dnsCacheMaxSize: number = 1024 * 1024;
+}

--- a/packages/@n8n/config/src/index.ts
+++ b/packages/@n8n/config/src/index.ts
@@ -31,6 +31,7 @@ import { ScalingModeConfig } from './configs/scaling-mode.config';
 import { SecurityConfig } from './configs/security.config';
 import { SentryConfig } from './configs/sentry.config';
 import { SsoConfig } from './configs/sso.config';
+import { SsrfProtectionConfig } from './configs/ssrf-protection.config';
 import { TagsConfig } from './configs/tags.config';
 import { TemplatesConfig } from './configs/templates.config';
 import { UserManagementConfig } from './configs/user-management.config';
@@ -48,6 +49,10 @@ export { sampleRateSchema } from './configs/sentry.config';
 export type { TaskRunnerMode } from './configs/runners.config';
 export { TaskRunnersConfig } from './configs/runners.config';
 export { SecurityConfig } from './configs/security.config';
+export {
+	SsrfProtectionConfig,
+	SSRF_DEFAULT_BLOCKED_IP_RANGES,
+} from './configs/ssrf-protection.config';
 export { ExecutionsConfig } from './configs/executions.config';
 export { LOG_SCOPES } from './configs/logging.config';
 export type { LogScope } from './configs/logging.config';
@@ -186,6 +191,9 @@ export class GlobalConfig {
 
 	@Nested
 	sso: SsoConfig;
+
+	@Nested
+	ssrfProtection: SsrfProtectionConfig;
 
 	/** Default locale for the UI. */
 	@Env('N8N_DEFAULT_LOCALE')

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -4,15 +4,29 @@ import { mock } from 'jest-mock-extended';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-import type { UserManagementConfig } from '../src/configs/user-management.config';
 import type { DatabaseConfig } from '../src/index';
-import { GlobalConfig } from '../src/index';
+import { GlobalConfig, SSRF_DEFAULT_BLOCKED_IP_RANGES } from '../src/index';
 
 jest.mock('fs');
 const mockFs = mock<typeof fs>();
 fs.readFileSync = mockFs.readFileSync;
 
 const consoleWarnMock = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+// Ignore the sanitize function from the GlobalConfig nested types
+type ConfigShape<T> = T extends ReadonlyArray<infer U>
+	? Array<ConfigShape<U>>
+	: T extends object
+		? {
+				[K in keyof T as K extends 'sanitize'
+					? never
+					: T[K] extends (...args: unknown[]) => unknown
+						? never
+						: K]: ConfigShape<T[K]>;
+			}
+		: T;
+
+type GlobalConfigShape = ConfigShape<GlobalConfig>;
 
 describe('GlobalConfig', () => {
 	beforeEach(() => {
@@ -25,7 +39,7 @@ describe('GlobalConfig', () => {
 		process.env = originalEnv;
 	});
 
-	const defaultConfig: GlobalConfig = {
+	const defaultConfig = {
 		path: '/',
 		host: 'localhost',
 		port: 5678,
@@ -135,7 +149,7 @@ describe('GlobalConfig', () => {
 					'project-shared': '',
 				},
 			},
-		} as UserManagementConfig,
+		},
 		eventBus: {
 			checkUnsentInterval: 0,
 			crashRecoveryMode: 'extensive',
@@ -410,6 +424,14 @@ describe('GlobalConfig', () => {
 				scopesProjectsRolesClaimName: 'n8n_projects',
 			},
 		},
+		ssrfProtection: {
+			enabled: false,
+			blockedIpRanges: [...SSRF_DEFAULT_BLOCKED_IP_RANGES],
+			allowedIpRanges: [],
+			allowedHostnames: [],
+			dnsCacheMaxTtlSeconds: 300,
+			dnsCacheMaxSize: 1024 * 1024,
+		},
 		redis: {
 			prefix: 'n8n',
 		},
@@ -430,7 +452,7 @@ describe('GlobalConfig', () => {
 			trimmingTimeWindowDays: 2,
 			trimOnStartUp: false,
 		},
-	};
+	} satisfies GlobalConfigShape;
 
 	it('should use all default values when no env variables are defined', () => {
 		process.env = {};

--- a/packages/@n8n/task-runner/src/start.ts
+++ b/packages/@n8n/task-runner/src/start.ts
@@ -6,6 +6,16 @@ import type { HealthCheckServer } from './health-check-server';
 import { JsTaskRunner } from './js-task-runner/js-task-runner';
 import { TaskRunnerSentry } from './task-runner-sentry';
 
+// Initialize module paths from NODE_PATH environment variable.
+// This is necessary because Node.js doesn't automatically pick up NODE_PATH
+// after the process starts. Without this, external npm packages installed
+// in custom locations won't be found by the require() calls.
+if (process.env.NODE_PATH) {
+	// @ts-expect-error - _initPaths is an internal Node.js API
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+	module.constructor._initPaths();
+}
+
 let healthCheckServer: HealthCheckServer | undefined;
 let runner: JsTaskRunner | undefined;
 let isShuttingDown = false;

--- a/packages/cli/src/__tests__/credentials-helper.test.ts
+++ b/packages/cli/src/__tests__/credentials-helper.test.ts
@@ -738,7 +738,7 @@ describe('CredentialsHelper', () => {
 			expect(result).not.toEqual({ apiKey: 'static-key' });
 		});
 
-		test('should skip resolution when executionContext is missing', async () => {
+		test('should skip resolution when executionContext is missing (manual mode)', async () => {
 			dynamicCredentialProxy.setResolverProvider(mockCredentialResolutionProvider);
 			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue({
 				data: { apiKey: 'resolved' },
@@ -785,7 +785,7 @@ describe('CredentialsHelper', () => {
 			expect(result).toEqual(dynamicData);
 		});
 
-		test('should skip resolution when credentials context is missing', async () => {
+		test('should skip resolution when credentials context is missing (manual mode)', async () => {
 			dynamicCredentialProxy.setResolverProvider(mockCredentialResolutionProvider);
 			mockCredentialResolutionProvider.resolveIfNeeded.mockResolvedValue({
 				data: { apiKey: 'resolved' },
@@ -811,7 +811,7 @@ describe('CredentialsHelper', () => {
 				true,
 			);
 
-			// Resolution should not happen when credentials context is missing
+			// Resolution should not happen when credentials context is missing in manual mode
 			expect(mockCredentialResolutionProvider.resolveIfNeeded).not.toHaveBeenCalled();
 			// Should return static decrypted data
 			expect(result).toEqual({ apiKey: 'static-key' });
@@ -842,6 +842,85 @@ describe('CredentialsHelper', () => {
 
 			expect(mockCredentialResolutionProvider.resolveIfNeeded).not.toHaveBeenCalled();
 			expect(result).toEqual({ apiKey: 'static-key' });
+		});
+
+		test('should throw when dynamic credential cannot be resolved in non-manual mode (no execution context)', async () => {
+			dynamicCredentialProxy.setResolverProvider(mockCredentialResolutionProvider);
+
+			const { CredentialResolutionError } = await import(
+				'@/modules/dynamic-credentials.ee/errors/credential-resolution.error'
+			);
+
+			const resolvableCredentialEntity = {
+				...mockCredentialEntity,
+				isResolvable: true,
+				resolverId: 'resolver-123',
+			} as CredentialsEntity;
+
+			credentialsRepository.findOneByOrFail.mockResolvedValue(resolvableCredentialEntity);
+			mockCredentialResolutionProvider.resolveIfNeeded.mockRejectedValue(
+				new CredentialResolutionError(
+					'Cannot resolve dynamic credentials without execution context for "Test Credentials"',
+				),
+			);
+
+			await expect(
+				credentialsHelper.getDecrypted(
+					{ ...mockAdditionalData, executionContext: undefined },
+					nodeCredentials,
+					credentialType,
+					'webhook',
+					undefined,
+					true,
+				),
+			).rejects.toThrow(CredentialResolutionError);
+
+			expect(mockCredentialResolutionProvider.resolveIfNeeded).toHaveBeenCalledTimes(1);
+		});
+
+		test('should throw when dynamic credential cannot be resolved in non-manual mode (no credentials in context)', async () => {
+			dynamicCredentialProxy.setResolverProvider(mockCredentialResolutionProvider);
+
+			const { CredentialResolutionError } = await import(
+				'@/modules/dynamic-credentials.ee/errors/credential-resolution.error'
+			);
+
+			const resolvableCredentialEntity = {
+				...mockCredentialEntity,
+				isResolvable: true,
+				resolverId: 'resolver-123',
+			} as CredentialsEntity;
+
+			credentialsRepository.findOneByOrFail.mockResolvedValue(resolvableCredentialEntity);
+			mockCredentialResolutionProvider.resolveIfNeeded.mockRejectedValue(
+				new CredentialResolutionError(
+					'Cannot resolve dynamic credentials without execution context for "Test Credentials"',
+				),
+			);
+
+			const additionalDataWithEmptyContext = {
+				...mockAdditionalData,
+				executionContext: {
+					version: 1 as const,
+					establishedAt: Date.now(),
+					source: 'webhook' as const,
+					// credentials is undefined
+				},
+			};
+
+			await expect(
+				credentialsHelper.getDecrypted(
+					additionalDataWithEmptyContext,
+					nodeCredentials,
+					credentialType,
+					'webhook',
+					undefined,
+					true,
+				),
+			).rejects.toThrow(CredentialResolutionError);
+
+			// Verify static credentials were NOT used as a fallback
+			expect(mockCredentialResolutionProvider.resolveIfNeeded).toHaveBeenCalledTimes(1);
 		});
 
 		test('should handle missing workflowSettings gracefully', async () => {

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/identifier-interface.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/identifier-interface.ts
@@ -1,9 +1,17 @@
 import type { ICredentialContext } from 'n8n-workflow';
 
+import { CredentialResolutionError } from '../../errors/credential-resolution.error';
+
 /**
- * Error thrown when token identifier validation or resolution fails
+ * Error thrown when token identifier validation or resolution fails.
+ * Extends CredentialResolutionError so it propagates correctly through the resolution pipeline.
  */
-export class IdentifierValidationError extends Error {}
+export class IdentifierValidationError extends CredentialResolutionError {
+	constructor(message: string, options?: ErrorOptions) {
+		super(message, options);
+		this.name = 'IdentifierValidationError';
+	}
+}
 
 /**
  * Interface for resolving unique identifiers from credential contexts

--- a/packages/cli/src/modules/dynamic-credentials.ee/errors/credential-resolver-not-configured.error.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/errors/credential-resolver-not-configured.error.ts
@@ -1,0 +1,12 @@
+import { CredentialResolutionError } from './credential-resolution.error';
+
+/**
+ * Thrown when a credential is marked as resolvable but has no resolver configured
+ * (neither on the credential itself nor on the workflow settings).
+ */
+export class CredentialResolverNotConfiguredError extends CredentialResolutionError {
+	constructor(credentialName: string) {
+		super(`No resolver configured for dynamic credential "${credentialName}"`);
+		this.name = 'CredentialResolverNotConfiguredError';
+	}
+}

--- a/packages/cli/src/modules/dynamic-credentials.ee/errors/credential-resolver-not-found.error.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/errors/credential-resolver-not-found.error.ts
@@ -1,7 +1,21 @@
 import { UserError } from 'n8n-workflow';
 
+import { CredentialResolutionError } from './credential-resolution.error';
+
+/** Thrown by the resolver CRUD API when a resolver with the given ID does not exist. */
 export class DynamicCredentialResolverNotFoundError extends UserError {
 	constructor(resolverId: string) {
 		super(`Credential resolver with ID "${resolverId}" does not exist.`);
+	}
+}
+
+/**
+ * Thrown during execution when the resolver referenced by a credential or workflow setting
+ * cannot be found (entity deleted from DB or resolver type no longer registered).
+ */
+export class CredentialResolverNotFoundError extends CredentialResolutionError {
+	constructor(credentialName: string, resolverId: string) {
+		super(`Resolver "${resolverId}" not found for credential "${credentialName}"`);
+		this.name = 'CredentialResolverNotFoundError';
 	}
 }

--- a/packages/cli/src/modules/dynamic-credentials.ee/errors/missing-execution-context.error.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/errors/missing-execution-context.error.ts
@@ -1,0 +1,12 @@
+import { CredentialResolutionError } from './credential-resolution.error';
+
+/**
+ * Thrown when dynamic credential resolution is attempted but no execution context
+ * (or no credentials field within it) is available.
+ */
+export class MissingExecutionContextError extends CredentialResolutionError {
+	constructor(credentialName: string) {
+		super(`Cannot resolve dynamic credentials without execution context for "${credentialName}"`);
+		this.name = 'MissingExecutionContextError';
+	}
+}

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential.service.test.ts
@@ -1,4 +1,5 @@
 import type { Logger } from '@n8n/backend-common';
+import type { AuthenticatedRequest } from '@n8n/db';
 import { CredentialResolverDataNotFoundError, type ICredentialResolver } from '@n8n/decorators';
 import type { Response } from 'express';
 import type { Cipher } from 'n8n-core';
@@ -19,10 +20,13 @@ import type { DynamicCredentialResolver } from '../../database/entities/credenti
 import type { DynamicCredentialResolverRepository } from '../../database/repositories/credential-resolver.repository';
 import type { DynamicCredentialsConfig } from '../../dynamic-credentials.config';
 import { CredentialResolutionError } from '../../errors/credential-resolution.error';
+import { CredentialResolverNotConfiguredError } from '../../errors/credential-resolver-not-configured.error';
+import { CredentialResolverNotFoundError } from '../../errors/credential-resolver-not-found.error';
+import { MissingExecutionContextError } from '../../errors/missing-execution-context.error';
+import { IdentifierValidationError } from '../../credential-resolvers/identifiers/identifier-interface';
 import type { DynamicCredentialResolverRegistry } from '../credential-resolver-registry.service';
 import { DynamicCredentialService } from '../dynamic-credential.service';
 import type { ResolverConfigExpressionService } from '../resolver-config-expression.service';
-import type { AuthenticatedRequest } from '@n8n/db';
 
 describe('DynamicCredentialService', () => {
 	let service: DynamicCredentialService;
@@ -243,7 +247,7 @@ describe('DynamicCredentialService', () => {
 
 				await expect(
 					service.resolveIfNeeded(credentialsEntity, staticData, undefined),
-				).rejects.toThrow(CredentialResolutionError);
+				).rejects.toThrow(CredentialResolverNotFoundError);
 
 				await expect(
 					service.resolveIfNeeded(credentialsEntity, staticData, undefined),
@@ -267,7 +271,7 @@ describe('DynamicCredentialService', () => {
 						additionalData.executionContext,
 						undefined,
 					),
-				).rejects.toThrow(CredentialResolutionError);
+				).rejects.toThrow(CredentialResolverNotConfiguredError);
 			});
 
 			it('credential has no resolver ID', async () => {
@@ -278,7 +282,7 @@ describe('DynamicCredentialService', () => {
 
 				await expect(
 					service.resolveIfNeeded(credentialsEntity, staticData, undefined),
-				).rejects.toThrow(CredentialResolutionError);
+				).rejects.toThrow(CredentialResolverNotConfiguredError);
 			});
 
 			it('resolver instance is not found in registry', async () => {
@@ -290,7 +294,7 @@ describe('DynamicCredentialService', () => {
 
 				await expect(
 					service.resolveIfNeeded(credentialsEntity, staticData, undefined),
-				).rejects.toThrow(CredentialResolutionError);
+				).rejects.toThrow(CredentialResolverNotFoundError);
 			});
 
 			it('execution context is missing', async () => {
@@ -303,7 +307,7 @@ describe('DynamicCredentialService', () => {
 
 				await expect(
 					service.resolveIfNeeded(credentialsEntity, staticData, undefined),
-				).rejects.toThrow(CredentialResolutionError);
+				).rejects.toThrow(MissingExecutionContextError);
 
 				await expect(
 					service.resolveIfNeeded(credentialsEntity, staticData, undefined),
@@ -344,12 +348,14 @@ describe('DynamicCredentialService', () => {
 						additionalData.executionContext,
 						undefined,
 					),
+					// Internal error message must NOT be exposed to the user
 				).rejects.toThrow('Failed to resolve dynamic credentials for "Test Credential"');
 
 				expect(mockLogger.debug).toHaveBeenCalledWith(
 					'Dynamic credential resolution failed',
 					expect.objectContaining({
 						credentialId: 'cred-123',
+						error: 'Resolution failed',
 					}),
 				);
 			});
@@ -385,7 +391,7 @@ describe('DynamicCredentialService', () => {
 			it('resolver throws CredentialResolverDataNotFoundError', async () => {
 				const credentialsEntity = createMockCredentialsMetadata();
 				const resolverEntity = createMockResolverEntity();
-				const mockResolver = createMockResolver(false, true); // Throws DataNotFoundError
+				const mockResolver = createMockResolver(false, true); // Throws CredentialResolverDataNotFoundError
 				const executionContext = createMockExecutionContext('encrypted-credentials');
 				const credentialContext = createMockCredentialContext();
 				const additionalData = createMockAdditionalData('exec-123', {}, executionContext);
@@ -403,7 +409,42 @@ describe('DynamicCredentialService', () => {
 						additionalData.executionContext,
 						undefined,
 					),
-				).rejects.toThrow(CredentialResolutionError);
+				).rejects.toThrow(
+					'Failed to resolve dynamic credentials for "Test Credential": No data found available for the requested credential and context combination.',
+				);
+			});
+
+			it('resolver throws IdentifierValidationError', async () => {
+				const credentialsEntity = createMockCredentialsMetadata();
+				const resolverEntity = createMockResolverEntity();
+				const executionContext = createMockExecutionContext('encrypted-credentials');
+				const credentialContext = createMockCredentialContext();
+				const additionalData = createMockAdditionalData('exec-123', {}, executionContext);
+				const mockResolver: jest.Mocked<ICredentialResolver> = {
+					metadata: { name: 'test-resolver-1.0', description: 'Test resolver' },
+					getSecret: jest
+						.fn()
+						.mockRejectedValue(new IdentifierValidationError('Token is not active')),
+					setSecret: jest.fn(),
+					validateOptions: jest.fn(),
+				};
+
+				mockResolverRepository.findOneBy.mockResolvedValue(resolverEntity);
+				mockResolverRegistry.getResolverByTypename.mockReturnValue(mockResolver);
+				mockCipher.decrypt
+					.mockReturnValueOnce(JSON.stringify(credentialContext))
+					.mockReturnValueOnce(JSON.stringify({ prefix: 'test' }));
+
+				await expect(
+					service.resolveIfNeeded(
+						credentialsEntity,
+						staticData,
+						additionalData.executionContext,
+						undefined,
+					),
+				).rejects.toThrow(
+					'Failed to resolve dynamic credentials for "Test Credential": Token is not active',
+				);
 			});
 		});
 

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential.service.ts
@@ -1,4 +1,6 @@
 import { Logger } from '@n8n/backend-common';
+import { AuthenticatedRequest } from '@n8n/db';
+import { CredentialResolverError } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import { NextFunction, Response } from 'express';
 import { Cipher } from 'n8n-core';
@@ -23,7 +25,9 @@ import type {
 import { DynamicCredentialResolverRepository } from '../database/repositories/credential-resolver.repository';
 import { DynamicCredentialsConfig } from '../dynamic-credentials.config';
 import { CredentialResolutionError } from '../errors/credential-resolution.error';
-import { AuthenticatedRequest } from '@n8n/db';
+import { CredentialResolverNotConfiguredError } from '../errors/credential-resolver-not-configured.error';
+import { CredentialResolverNotFoundError } from '../errors/credential-resolver-not-found.error';
+import { MissingExecutionContextError } from '../errors/missing-execution-context.error';
 
 /**
  * Service for resolving credentials dynamically via configured resolvers.
@@ -69,7 +73,7 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 		}
 
 		if (!resolverId) {
-			return this.handleMissingResolver(credentialsResolveMetadata, resolverId);
+			return this.handleResolverNotConfigured(credentialsResolveMetadata);
 		}
 
 		// Load resolver configuration
@@ -78,14 +82,14 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 		});
 
 		if (!resolverEntity) {
-			return this.handleMissingResolver(credentialsResolveMetadata, resolverId);
+			return this.handleResolverNotFound(credentialsResolveMetadata, resolverId);
 		}
 
 		// Get resolver instance from registry
 		const resolver = this.resolverRegistry.getResolverByTypename(resolverEntity.type);
 
 		if (!resolver) {
-			return this.handleMissingResolver(credentialsResolveMetadata, resolverId);
+			return this.handleResolverNotFound(credentialsResolveMetadata, resolverId);
 		}
 
 		// Build credential context from execution context
@@ -165,8 +169,11 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 	}
 
 	/**
-	 * Handles resolution errors by always throwing.
-	 * Dynamic credentials must resolve successfully — no silent fallback to static data.
+	 * Throws when resolution fails inside getSecret().
+	 * - CredentialResolutionError subtypes (e.g. IdentifierValidationError)
+	 *   → rethrown with credential name prepended to the message
+	 * - CredentialResolverDataNotFoundError → rethrown with credential name prepended to the message
+	 * - Anything else → generic CredentialResolutionError (no internal detail surfaced)
 	 */
 	private handleResolutionError(
 		credentialsResolveMetadata: CredentialResolveMetadata,
@@ -181,6 +188,16 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 			error: error instanceof Error ? error.message : String(error),
 		});
 
+		// Known errors from both the CLI and resolver SDK layers.
+		// User-facing, safe to propagate details.
+		if (error instanceof CredentialResolutionError || error instanceof CredentialResolverError) {
+			throw new CredentialResolutionError(
+				`Failed to resolve dynamic credentials for "${credentialsResolveMetadata.name}": ${error.message}`,
+				{ cause: error },
+			);
+		}
+
+		// Internal errors (network, crypto, DB, config validation) must not leak details to the user.
 		throw new CredentialResolutionError(
 			`Failed to resolve dynamic credentials for "${credentialsResolveMetadata.name}"`,
 			{ cause: error },
@@ -188,12 +205,27 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 	}
 
 	/**
-	 * Handles missing resolver by always throwing.
-	 * Dynamic credentials must have a valid resolver — no silent fallback to static data.
+	 * Throws when the credential is resolvable but no resolver ID is configured
+	 * on the credential or the workflow settings.
 	 */
-	private handleMissingResolver(
+	private handleResolverNotConfigured(
 		credentialsResolveMetadata: CredentialResolveMetadata,
-		resolverId?: string,
+	): never {
+		this.logger.debug('No resolver configured for dynamic credential', {
+			credentialId: credentialsResolveMetadata.id,
+			credentialName: credentialsResolveMetadata.name,
+		});
+
+		throw new CredentialResolverNotConfiguredError(credentialsResolveMetadata.name);
+	}
+
+	/**
+	 * Throws when a resolver ID is set but the entity no longer exists in the DB
+	 * or the resolver type is not registered.
+	 */
+	private handleResolverNotFound(
+		credentialsResolveMetadata: CredentialResolveMetadata,
+		resolverId: string,
 	): never {
 		this.logger.debug('Resolver not found for dynamic credential', {
 			credentialId: credentialsResolveMetadata.id,
@@ -202,14 +234,11 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 			resolverSource: credentialsResolveMetadata.resolverId ? 'credential' : 'workflow',
 		});
 
-		throw new CredentialResolutionError(
-			`Resolver "${resolverId ?? 'unknown'}" not found for credential "${credentialsResolveMetadata.name}"`,
-		);
+		throw new CredentialResolverNotFoundError(credentialsResolveMetadata.name, resolverId);
 	}
 
 	/**
-	 * Handles missing execution context by always throwing.
-	 * Dynamic credentials require an execution context — no silent fallback to static data.
+	 * Throws when no execution context (or credentials field within it) is available.
 	 */
 	private handleMissingContext(credentialsResolveMetadata: CredentialResolveMetadata): never {
 		this.logger.debug('No execution context available for dynamic credential', {
@@ -217,9 +246,7 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 			credentialName: credentialsResolveMetadata.name,
 		});
 
-		throw new CredentialResolutionError(
-			`Cannot resolve dynamic credentials without execution context for "${credentialsResolveMetadata.name}"`,
-		);
+		throw new MissingExecutionContextError(credentialsResolveMetadata.name);
 	}
 
 	/**

--- a/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
+++ b/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
@@ -1,7 +1,14 @@
 import { Logger } from '@n8n/backend-common';
 import { mockInstance } from '@n8n/backend-test-utils';
 import type { IExecutionDb, User } from '@n8n/db';
-import type { ExecutionStatus, IRunExecutionData, WorkflowExecuteMode } from 'n8n-workflow';
+import type {
+	ExecutionError,
+	ExecutionStatus,
+	INode,
+	IRunExecutionData,
+	WorkflowExecuteMode,
+} from 'n8n-workflow';
+import { ExpressionError, NodeApiError, NodeOperationError } from 'n8n-workflow';
 
 import type { ExecutionRedactionOptions } from '@/executions/execution-redaction';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
@@ -499,6 +506,294 @@ describe('ExecutionRedactionService', () => {
 				isRedacted: true,
 				reason: 'workflow_redaction_policy',
 				canReveal: false,
+			});
+		});
+	});
+
+	describe('error redaction', () => {
+		const mockNode = {
+			id: 'node-1',
+			name: 'TestNode',
+			type: 'n8n-nodes-base.httpRequest',
+			typeVersion: 1,
+			position: [0, 0] as [number, number],
+			parameters: {},
+		} as INode;
+
+		describe('item-level error (INodeExecutionData.error)', () => {
+			it('should redact NodeApiError with httpCode and preserve type and httpCode', async () => {
+				const error = new NodeApiError(mockNode, { message: 'Not Found' }, { httpCode: '404' });
+				const execution = createMockExecution({
+					policy: 'all',
+					mode: 'trigger',
+					withRunData: true,
+				});
+				execution.data.resultData.runData.TestNode[0].data!.main[0]![0].error = error;
+				const options: ExecutionRedactionOptions = { user: mockUser };
+
+				const result = await service.processExecution(execution, options);
+
+				const item = result.data.resultData.runData.TestNode[0].data!.main[0]![0];
+				expect(item.error).toBeUndefined();
+				expect(item.redaction?.error).toEqual({ type: 'NodeApiError', httpCode: '404' });
+			});
+
+			it('should preserve httpCode: null when NodeApiError has no http code', async () => {
+				const error = new NodeApiError(mockNode, { message: 'Unknown Error' });
+				const execution = createMockExecution({
+					policy: 'all',
+					mode: 'trigger',
+					withRunData: true,
+				});
+				execution.data.resultData.runData.TestNode[0].data!.main[0]![0].error = error;
+				const options: ExecutionRedactionOptions = { user: mockUser };
+
+				const result = await service.processExecution(execution, options);
+
+				const item = result.data.resultData.runData.TestNode[0].data!.main[0]![0];
+				expect(item.error).toBeUndefined();
+				expect(item.redaction?.error).toEqual({ type: 'NodeApiError', httpCode: null });
+			});
+
+			it('should redact NodeOperationError without httpCode', async () => {
+				const error = new NodeOperationError(mockNode, 'Operation failed');
+				const execution = createMockExecution({
+					policy: 'all',
+					mode: 'trigger',
+					withRunData: true,
+				});
+				execution.data.resultData.runData.TestNode[0].data!.main[0]![0].error = error;
+				const options: ExecutionRedactionOptions = { user: mockUser };
+
+				const result = await service.processExecution(execution, options);
+
+				const item = result.data.resultData.runData.TestNode[0].data!.main[0]![0];
+				expect(item.error).toBeUndefined();
+				expect(item.redaction?.error).toEqual({ type: 'NodeOperationError' });
+				expect(item.redaction?.error).not.toHaveProperty('httpCode');
+			});
+
+			it('should not add error key to redaction when item has no error', async () => {
+				const execution = createMockExecution({
+					policy: 'all',
+					mode: 'trigger',
+					withRunData: true,
+				});
+				// item has no error field
+				const options: ExecutionRedactionOptions = { user: mockUser };
+
+				const result = await service.processExecution(execution, options);
+
+				const item = result.data.resultData.runData.TestNode[0].data!.main[0]![0];
+				expect(item.error).toBeUndefined();
+				expect(item.redaction).toEqual({ redacted: true, reason: 'workflow_redaction_policy' });
+				expect(item.redaction).not.toHaveProperty('error');
+			});
+		});
+
+		describe('task-level error (ITaskData.error)', () => {
+			it('should redact NodeApiError on task and preserve type and httpCode', async () => {
+				const error = new NodeApiError(mockNode, { message: 'Server Error' }, { httpCode: '500' });
+				const execution = createMockExecution({
+					policy: 'all',
+					mode: 'trigger',
+					withRunData: true,
+				});
+				execution.data.resultData.runData.TestNode[0].error = error;
+				const options: ExecutionRedactionOptions = { user: mockUser };
+
+				const result = await service.processExecution(execution, options);
+
+				const taskData = result.data.resultData.runData.TestNode[0];
+				expect(taskData.error).toBeUndefined();
+				expect(taskData.redactedError).toEqual({ type: 'NodeApiError', httpCode: '500' });
+			});
+
+			it('should redact ExpressionError on task without httpCode', async () => {
+				const error = new ExpressionError('Expression evaluation failed');
+				const execution = createMockExecution({
+					policy: 'all',
+					mode: 'trigger',
+					withRunData: true,
+				});
+				execution.data.resultData.runData.TestNode[0].error = error;
+				const options: ExecutionRedactionOptions = { user: mockUser };
+
+				const result = await service.processExecution(execution, options);
+
+				const taskData = result.data.resultData.runData.TestNode[0];
+				expect(taskData.error).toBeUndefined();
+				expect(taskData.redactedError).toEqual({ type: 'ExpressionError' });
+				expect(taskData.redactedError).not.toHaveProperty('httpCode');
+			});
+
+			it('should not set redactedError on task when task has no error', async () => {
+				const execution = createMockExecution({
+					policy: 'all',
+					mode: 'trigger',
+					withRunData: true,
+				});
+				const options: ExecutionRedactionOptions = { user: mockUser };
+
+				const result = await service.processExecution(execution, options);
+
+				const taskData = result.data.resultData.runData.TestNode[0];
+				expect(taskData.error).toBeUndefined();
+				expect(taskData.redactedError).toBeUndefined();
+			});
+		});
+
+		describe('workflow-level error (resultData.error)', () => {
+			it('should redact resultData.error and preserve type', async () => {
+				const error = new NodeOperationError(mockNode, 'Workflow operation failed');
+				const execution = createMockExecution({
+					policy: 'all',
+					mode: 'trigger',
+					withRunData: false,
+				});
+				execution.data.resultData.error = error;
+				const options: ExecutionRedactionOptions = { user: mockUser };
+
+				const result = await service.processExecution(execution, options);
+
+				expect(result.data.resultData.error).toBeUndefined();
+				expect(result.data.resultData.redactedError).toEqual({ type: 'NodeOperationError' });
+			});
+
+			it('should redact NodeApiError in resultData and preserve httpCode', async () => {
+				const error = new NodeApiError(mockNode, { message: 'Forbidden' }, { httpCode: '403' });
+				const execution = createMockExecution({
+					policy: 'all',
+					mode: 'trigger',
+					withRunData: false,
+				});
+				execution.data.resultData.error = error;
+				const options: ExecutionRedactionOptions = { user: mockUser };
+
+				const result = await service.processExecution(execution, options);
+
+				expect(result.data.resultData.error).toBeUndefined();
+				expect(result.data.resultData.redactedError).toEqual({
+					type: 'NodeApiError',
+					httpCode: '403',
+				});
+			});
+
+			it('should not set redactedError in resultData when no error is present', async () => {
+				const execution = createMockExecution({
+					policy: 'all',
+					mode: 'trigger',
+					withRunData: false,
+				});
+				const options: ExecutionRedactionOptions = { user: mockUser };
+
+				const result = await service.processExecution(execution, options);
+
+				expect(result.data.resultData.error).toBeUndefined();
+				expect(result.data.resultData.redactedError).toBeUndefined();
+			});
+		});
+
+		describe('deserialized plain objects (after DB round-trip)', () => {
+			it('should use error.name for type when error is a deserialized NodeApiError', async () => {
+				const error = {
+					name: 'NodeApiError',
+					message: 'Not Found',
+					timestamp: Date.now(),
+					lineNumber: undefined,
+					description: null,
+					context: {},
+					cause: undefined,
+				} as unknown as ExecutionError;
+
+				const execution = createMockExecution({
+					policy: 'all',
+					mode: 'trigger',
+					withRunData: false,
+				});
+				execution.data.resultData.error = error;
+				const options: ExecutionRedactionOptions = { user: mockUser };
+
+				const result = await service.processExecution(execution, options);
+
+				expect(result.data.resultData.error).toBeUndefined();
+				expect(result.data.resultData.redactedError).toEqual({
+					type: 'NodeApiError',
+					httpCode: null,
+				});
+			});
+
+			it('should use error.name for deserialized NodeOperationError without httpCode', async () => {
+				const error = {
+					name: 'NodeOperationError',
+					message: 'Operation failed',
+					timestamp: Date.now(),
+					lineNumber: undefined,
+					description: null,
+					context: {},
+					cause: undefined,
+				} as unknown as ExecutionError;
+
+				const execution = createMockExecution({
+					policy: 'all',
+					mode: 'trigger',
+					withRunData: false,
+				});
+				execution.data.resultData.error = error;
+				const options: ExecutionRedactionOptions = { user: mockUser };
+
+				const result = await service.processExecution(execution, options);
+
+				expect(result.data.resultData.error).toBeUndefined();
+				expect(result.data.resultData.redactedError).toEqual({ type: 'NodeOperationError' });
+				expect(result.data.resultData.redactedError).not.toHaveProperty('httpCode');
+			});
+
+			it('should use error.name for deserialized ExpressionError without httpCode', async () => {
+				const error = {
+					name: 'ExpressionError',
+					message: 'Expression evaluation failed',
+					timestamp: Date.now(),
+					lineNumber: undefined,
+					description: null,
+					context: {},
+					cause: undefined,
+				} as unknown as ExecutionError;
+
+				const execution = createMockExecution({
+					policy: 'all',
+					mode: 'trigger',
+					withRunData: false,
+				});
+				execution.data.resultData.error = error;
+				const options: ExecutionRedactionOptions = { user: mockUser };
+
+				const result = await service.processExecution(execution, options);
+
+				expect(result.data.resultData.error).toBeUndefined();
+				expect(result.data.resultData.redactedError).toEqual({ type: 'ExpressionError' });
+				expect(result.data.resultData.redactedError).not.toHaveProperty('httpCode');
+			});
+
+			it('should preserve httpCode from spread plain object (pre-DB serialization)', async () => {
+				const liveError = new NodeApiError(mockNode, { message: 'Not Found' }, { httpCode: '404' });
+				const spreadError = { ...liveError } as unknown as ExecutionError;
+
+				const execution = createMockExecution({
+					policy: 'all',
+					mode: 'trigger',
+					withRunData: false,
+				});
+				execution.data.resultData.error = spreadError;
+				const options: ExecutionRedactionOptions = { user: mockUser };
+
+				const result = await service.processExecution(execution, options);
+
+				expect(result.data.resultData.error).toBeUndefined();
+				expect(result.data.resultData.redactedError).toEqual({
+					type: 'NodeApiError',
+					httpCode: '404',
+				});
 			});
 		});
 	});

--- a/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
+++ b/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
@@ -7,9 +7,11 @@ import type {
 	ExecutionRedactionOptions,
 } from '@/executions/execution-redaction';
 import {
-	INodeExecutionData,
-	ITaskDataConnections,
-	WorkflowExecuteMode,
+	type ExecutionError,
+	type INodeExecutionData,
+	type IRedactedErrorInfo,
+	type ITaskDataConnections,
+	type WorkflowExecuteMode,
 	WorkflowSettings,
 } from 'n8n-workflow';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
@@ -135,17 +137,27 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 	 */
 	private applyRedaction(execution: IExecutionDb, reason: string, canReveal: boolean): void {
 		const runData = execution.data.resultData.runData;
-		if (!runData) return;
-
-		for (const nodeName of Object.keys(runData)) {
-			for (const taskData of runData[nodeName]) {
-				if (taskData.data) {
-					this.redactConnections(taskData.data, reason);
-				}
-				if (taskData.inputOverride) {
-					this.redactConnections(taskData.inputOverride, reason);
+		if (runData) {
+			for (const nodeName of Object.keys(runData)) {
+				for (const taskData of runData[nodeName]) {
+					if (taskData.data) {
+						this.redactConnections(taskData.data, reason);
+					}
+					if (taskData.inputOverride) {
+						this.redactConnections(taskData.inputOverride, reason);
+					}
+					if (taskData.error) {
+						taskData.redactedError = this.redactError(taskData.error);
+						delete taskData.error;
+					}
 				}
 			}
+		}
+
+		const resultData = execution.data.resultData;
+		if (resultData.error) {
+			resultData.redactedError = this.redactError(resultData.error);
+			delete resultData.error;
 		}
 
 		execution.data.redactionInfo = { isRedacted: true, reason, canReveal };
@@ -173,9 +185,37 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 	private redactItem(item: INodeExecutionData, reason: string): void {
 		item.json = {};
 		delete item.binary;
+
+		const redactedError = item.error ? this.redactError(item.error) : undefined;
+		delete item.error;
+
 		item.redaction = {
 			redacted: true,
 			reason,
+			...(redactedError !== undefined && { error: redactedError }),
 		};
+	}
+
+	/**
+	 * Extracts safe, non-PII technical metadata from any execution error for
+	 * inclusion in the redaction marker. Handles both live class instances and
+	 * deserialized plain objects (after DB round-trip via flatted.stringify/parse).
+	 *
+	 * Uses error.name (survives serialization) instead of error.constructor.name
+	 * (returns 'Object' for plain objects) and name-based checks instead of
+	 * instanceof (fails for plain objects).
+	 *
+	 * Preserves: error name (type classification), HTTP status code
+	 * from NodeApiError (numeric code only, null if absent or unknown).
+	 * Omits: message, description, messages[], cause, context, errorResponse
+	 * — all of which may contain PII or sensitive credential data.
+	 */
+	private redactError(error: ExecutionError): IRedactedErrorInfo {
+		const result: IRedactedErrorInfo = { type: error.name };
+		if (error.name === 'NodeApiError') {
+			result.httpCode =
+				('httpCode' in error ? (error as { httpCode: string | null }).httpCode : null) ?? null;
+		}
+		return result;
 	}
 }

--- a/packages/cli/test/integration/execution-redaction.test.ts
+++ b/packages/cli/test/integration/execution-redaction.test.ts
@@ -7,8 +7,8 @@ import {
 } from '@n8n/backend-test-utils';
 import type { User } from '@n8n/db';
 import { stringify } from 'flatted';
-import type { IRunExecutionData, IWorkflowBase, WorkflowExecuteMode } from 'n8n-workflow';
-import { createRunExecutionData } from 'n8n-workflow';
+import type { INode, IRunExecutionData, IWorkflowBase, WorkflowExecuteMode } from 'n8n-workflow';
+import { createRunExecutionData, NodeApiError, NodeOperationError } from 'n8n-workflow';
 
 import { ConcurrencyControlService } from '@/concurrency/concurrency-control.service';
 import { WaitTracker } from '@/wait-tracker';
@@ -404,6 +404,61 @@ describe('GET /executions/:id — Execution Redaction', () => {
 				.expect(200);
 
 			assertRedacted(parseResponseData(response.body));
+		});
+	});
+
+	describe('error redaction through DB round-trip', () => {
+		const mockNode: INode = {
+			id: 'node-1',
+			name: 'Test Node',
+			type: 'n8n-nodes-base.httpRequest',
+			typeVersion: 1,
+			position: [0, 0],
+			parameters: {},
+		};
+
+		test('task-level NodeApiError is redacted after DB round-trip', async () => {
+			const workflow = await createWorkflow({}, owner);
+			const error = new NodeApiError(mockNode, { message: 'Bad Gateway' }, { httpCode: '502' });
+			const runData = buildRunExecutionData({ policy: 'all', mode: 'trigger' });
+			runData.resultData.runData['Test Node'][0].error = error;
+
+			const execution = await createExecution(
+				{ data: stringify(runData), mode: 'trigger' },
+				workflow,
+			);
+
+			const response = await testServer
+				.authAgentFor(owner)
+				.get(`/executions/${execution.id}`)
+				.expect(200);
+
+			const data = parseResponseData(response.body);
+			const taskData = data.resultData.runData['Test Node'][0];
+			expect(taskData.error).toBeUndefined();
+			expect(taskData.redactedError).toEqual({ type: 'NodeApiError', httpCode: null });
+		});
+
+		test('workflow-level NodeOperationError is redacted after DB round-trip', async () => {
+			const workflow = await createWorkflow({}, owner);
+			const error = new NodeOperationError(mockNode, 'Workflow operation failed');
+			const runData = buildRunExecutionData({ policy: 'all', mode: 'trigger' });
+			runData.resultData.error = error;
+
+			const execution = await createExecution(
+				{ data: stringify(runData), mode: 'trigger' },
+				workflow,
+			);
+
+			const response = await testServer
+				.authAgentFor(owner)
+				.get(`/executions/${execution.id}`)
+				.expect(200);
+
+			const data = parseResponseData(response.body);
+			expect(data.resultData.error).toBeUndefined();
+			expect(data.resultData.redactedError).toEqual({ type: 'NodeOperationError' });
+			expect(data.resultData.redactedError).not.toHaveProperty('httpCode');
 		});
 	});
 });

--- a/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
+++ b/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
@@ -9,7 +9,7 @@ import type {
 } from 'n8n-workflow';
 import { NodeConnectionTypes, NodeApiError } from 'n8n-workflow';
 
-import { gitlabApiRequest } from './GenericFunctions';
+import { gitlabApiRequest, gitlabApiRequestAllItems } from './GenericFunctions';
 
 const GITLAB_EVENTS = [
 	{
@@ -199,7 +199,7 @@ export class GitlabTrigger implements INodeType {
 							return true;
 						}
 					} catch (error) {
-						if (error.cause?.httpCode === '404' || error.description?.includes('404')) {
+						if (error.httpCode === '404' || error.httpCode === 404) {
 							// Webhook does not exist, clear the stored ID
 							delete webhookData.webhookId;
 							delete webhookData.webhookEvents;
@@ -215,35 +215,38 @@ export class GitlabTrigger implements INodeType {
 				const hooksEndpoint = `/projects/${path}/hooks`;
 
 				try {
-					const webhooks = await gitlabApiRequest.call(this, 'GET', hooksEndpoint, {});
+					const webhooks = await gitlabApiRequestAllItems.call(this, 'GET', hooksEndpoint, {});
 
 					// Look for a webhook with matching URL
 					for (const webhook of webhooks as IDataObject[]) {
-						if (webhook.url === webhookUrl) {
-							// Found a webhook with our URL
-							// Check if events match
-							const webhookEvents = new Set<string>();
-							for (const [key, value] of Object.entries(webhook)) {
-								if (key.endsWith('_events') && value === true) {
-									const eventName = key.replace('_events', '');
-									webhookEvents.add(eventName);
-								}
-							}
-
-							const expectedEvents = new Set(eventsArray);
-
-							// Check if the webhook has the same events configured
-							const eventsMatch =
-								webhookEvents.size === expectedEvents.size &&
-								[...expectedEvents].every((event) => webhookEvents.has(event));
-
-							if (eventsMatch) {
-								// Webhook exists with same URL and events, store the ID
-								webhookData.webhookId = webhook.id as string;
-								webhookData.webhookEvents = eventsArray;
-								return true;
+						if (webhook.url !== webhookUrl) {
+							continue;
+						}
+						// Found a webhook with our URL
+						// Check if events match
+						const webhookEvents = new Set<string>();
+						for (const [key, value] of Object.entries(webhook)) {
+							if (key.endsWith('_events') && value === true) {
+								const eventName = key.replace('_events', '');
+								webhookEvents.add(eventName);
 							}
 						}
+
+						const expectedEvents = new Set(eventsArray);
+
+						// Check if the webhook has the same events configured
+						const eventsMatch =
+							webhookEvents.size === expectedEvents.size &&
+							[...expectedEvents].every((event) => webhookEvents.has(event));
+
+						if (!eventsMatch) {
+							continue;
+						}
+
+						// Webhook exists with same URL and events, store the ID
+						webhookData.webhookId = webhook.id as string;
+						webhookData.webhookEvents = eventsArray;
+						return true;
 					}
 				} catch (error) {
 					// If we can't list webhooks, throw the error

--- a/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
+++ b/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
@@ -178,37 +178,80 @@ export class GitlabTrigger implements INodeType {
 		default: {
 			async checkExists(this: IHookFunctions): Promise<boolean> {
 				const webhookData = this.getWorkflowStaticData('node');
-
-				if (webhookData.webhookId === undefined) {
-					// No webhook id is set so no webhook can exist
-					return false;
-				}
-
-				// Webhook got created before so check if it still exists
+				const webhookUrl = this.getNodeWebhookUrl('default');
 				const owner = this.getNodeParameter('owner') as string;
 				const repository = this.getNodeParameter('repository') as string;
-
 				const path = `${owner}/${repository}`.replace(/\//g, '%2F');
 
-				const endpoint = `/projects/${path}/hooks/${webhookData.webhookId}`;
+				let eventsArray = this.getNodeParameter('events', []) as string[];
+				if (eventsArray.includes('*')) {
+					eventsArray = GITLAB_EVENTS.map((e) => e.value);
+				}
+
+				// If we have a stored webhook ID, check if it still exists
+				if (webhookData.webhookId !== undefined) {
+					const endpoint = `/projects/${path}/hooks/${webhookData.webhookId}`;
+
+					try {
+						const webhook = await gitlabApiRequest.call(this, 'GET', endpoint, {});
+						// Webhook exists, verify it matches our configuration
+						if (webhook.url === webhookUrl) {
+							return true;
+						}
+					} catch (error) {
+						if (error.cause?.httpCode === '404' || error.description?.includes('404')) {
+							// Webhook does not exist, clear the stored ID
+							delete webhookData.webhookId;
+							delete webhookData.webhookEvents;
+						} else {
+							// Some other error occurred
+							throw error;
+						}
+					}
+				}
+
+				// No stored webhook ID or the webhook was deleted
+				// Check if a webhook with our URL already exists in GitLab
+				const hooksEndpoint = `/projects/${path}/hooks`;
 
 				try {
-					await gitlabApiRequest.call(this, 'GET', endpoint, {});
-				} catch (error) {
-					if (error.cause.httpCode === '404' || error.description.includes('404')) {
-						// Webhook does not exist
-						delete webhookData.webhookId;
-						delete webhookData.webhookEvents;
+					const webhooks = await gitlabApiRequest.call(this, 'GET', hooksEndpoint, {});
 
-						return false;
+					// Look for a webhook with matching URL
+					for (const webhook of webhooks as IDataObject[]) {
+						if (webhook.url === webhookUrl) {
+							// Found a webhook with our URL
+							// Check if events match
+							const webhookEvents = new Set<string>();
+							for (const [key, value] of Object.entries(webhook)) {
+								if (key.endsWith('_events') && value === true) {
+									const eventName = key.replace('_events', '');
+									webhookEvents.add(eventName);
+								}
+							}
+
+							const expectedEvents = new Set(eventsArray);
+
+							// Check if the webhook has the same events configured
+							const eventsMatch =
+								webhookEvents.size === expectedEvents.size &&
+								[...expectedEvents].every((event) => webhookEvents.has(event));
+
+							if (eventsMatch) {
+								// Webhook exists with same URL and events, store the ID
+								webhookData.webhookId = webhook.id as string;
+								webhookData.webhookEvents = eventsArray;
+								return true;
+							}
+						}
 					}
-
-					// Some error occured
+				} catch (error) {
+					// If we can't list webhooks, throw the error
 					throw error;
 				}
 
-				// If it did not error then the webhook exists
-				return true;
+				// No matching webhook found
+				return false;
 			},
 			/**
 			 * Gitlab API - Add project hook:

--- a/packages/testing/janitor/src/cli.ts
+++ b/packages/testing/janitor/src/cli.ts
@@ -27,7 +27,6 @@ import {
 	showOrchestrateHelp,
 } from './cli/index.js';
 import { setConfig, getConfig, defineConfig, type JanitorConfig } from './config.js';
-import { diffFileMethods } from './core/ast-diff-analyzer.js';
 import {
 	generateBaseline,
 	saveBaseline,
@@ -177,17 +176,10 @@ async function runImpact(options: CliOptions): Promise<void> {
 		return;
 	}
 
-	// Compute AST diffs for additive-only narrowing
-	const diffs = changedFiles
-		.filter((f) => f.endsWith('.ts') && !f.endsWith('.spec.ts'))
-		.map((f) => {
-			const abs = path.isAbsolute(f) ? f : path.resolve(config.rootDir, f);
-			return diffFileMethods(abs);
-		});
-
-	// Analyze impact
+	// No diffs passed — all files use conservative property-level resolution.
+	// Method-level precision requires pre-computed AST diffs (used by TCR flow).
 	const analyzer = new ImpactAnalyzer(project);
-	const result = analyzer.analyze(changedFiles, diffs);
+	const result = analyzer.analyze(changedFiles);
 
 	// Output
 	if (options.json) {
@@ -456,15 +448,8 @@ async function runOrchestrate(options: CliOptions): Promise<void> {
 			console.error('Impact: No changed files detected. Returning empty orchestration.');
 			specs = [];
 		} else {
-			const diffs = changedFiles
-				.filter((f) => f.endsWith('.ts') && !f.endsWith('.spec.ts'))
-				.map((f) => {
-					const abs = path.isAbsolute(f) ? f : path.resolve(config.rootDir, f);
-					return diffFileMethods(abs);
-				});
-
 			const impactAnalyzer = new ImpactAnalyzer(project);
-			const impactResult = impactAnalyzer.analyze(changedFiles, diffs);
+			const impactResult = impactAnalyzer.analyze(changedFiles);
 			const affectedSet = new Set(impactResult.affectedTests);
 			const totalBefore = specs.length;
 			specs = specs.filter((s) => affectedSet.has(s.path));

--- a/packages/testing/janitor/src/core/impact-analyzer.test.ts
+++ b/packages/testing/janitor/src/core/impact-analyzer.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import type { FileDiffResult } from './ast-diff-analyzer.js';
 import { ImpactAnalyzer } from './impact-analyzer.js';
+import type { MethodUsageIndex } from './method-usage-analyzer.js';
 import { setConfig, resetConfig, defineConfig } from '../config.js';
 
 /**
@@ -856,30 +857,13 @@ test('uses api', () => {});
 			];
 
 			const analyzer = new ImpactAnalyzer(project);
-			const result = analyzer.analyze(['services/api-helper.ts'], diffs);
+			const result = analyzer.analyze(['services/api-helper.ts'], { diffs });
 
 			// No transitive tests affected — the change is purely additive
 			expect(result.affectedTests).toEqual([]);
 		});
 
-		it('traces normally when a method is modified', () => {
-			project.createSourceFile(
-				'/test-root/services/api-helper.ts',
-				`
-export class ApiHelper {
-  async getWorkflows() {}
-}
-`,
-			);
-
-			project.createSourceFile(
-				'/test-root/tests/api.spec.ts',
-				`
-import { ApiHelper } from '../services/api-helper';
-test('uses api', () => {});
-`,
-			);
-
+		it('finds affected tests via method-level when a method is modified', () => {
 			const diffs: FileDiffResult[] = [
 				{
 					filePath: '/test-root/services/api-helper.ts',
@@ -892,31 +876,30 @@ test('uses api', () => {});
 				},
 			];
 
+			const methodUsageIndex: MethodUsageIndex = {
+				methods: {
+					'ApiHelper.getWorkflows': [
+						{
+							testFile: 'tests/api.spec.ts',
+							line: 1,
+							column: 1,
+							fullCall: 'ApiHelper.getWorkflows()',
+						},
+					],
+				},
+				fixtureMapping: {},
+				timestamp: new Date().toISOString(),
+				testFilesAnalyzed: 1,
+			};
+
 			const analyzer = new ImpactAnalyzer(project);
-			const result = analyzer.analyze(['services/api-helper.ts'], diffs);
+			const result = analyzer.analyze(['services/api-helper.ts'], { diffs, methodUsageIndex });
 
 			expect(result.affectedTests).toContain('tests/api.spec.ts');
+			expect(result.strategies['services/api-helper.ts']).toBe('method-level');
 		});
 
-		it('traces normally when changes are mixed (added + modified)', () => {
-			project.createSourceFile(
-				'/test-root/services/api-helper.ts',
-				`
-export class ApiHelper {
-  async getWorkflows() {}
-  async newMethod() {}
-}
-`,
-			);
-
-			project.createSourceFile(
-				'/test-root/tests/api.spec.ts',
-				`
-import { ApiHelper } from '../services/api-helper';
-test('uses api', () => {});
-`,
-			);
-
+		it('finds affected tests via method-level when changes are mixed (added + modified)', () => {
 			const diffs: FileDiffResult[] = [
 				{
 					filePath: '/test-root/services/api-helper.ts',
@@ -930,10 +913,27 @@ test('uses api', () => {});
 				},
 			];
 
+			const methodUsageIndex: MethodUsageIndex = {
+				methods: {
+					'ApiHelper.getWorkflows': [
+						{
+							testFile: 'tests/api.spec.ts',
+							line: 1,
+							column: 1,
+							fullCall: 'ApiHelper.getWorkflows()',
+						},
+					],
+				},
+				fixtureMapping: {},
+				timestamp: new Date().toISOString(),
+				testFilesAnalyzed: 1,
+			};
+
 			const analyzer = new ImpactAnalyzer(project);
-			const result = analyzer.analyze(['services/api-helper.ts'], diffs);
+			const result = analyzer.analyze(['services/api-helper.ts'], { diffs, methodUsageIndex });
 
 			expect(result.affectedTests).toContain('tests/api.spec.ts');
+			expect(result.strategies['services/api-helper.ts']).toBe('method-level');
 		});
 
 		it('traces normally when no diffs are provided (backwards-compatible)', () => {
@@ -992,10 +992,335 @@ test('uses api', () => {});
 			];
 
 			const analyzer = new ImpactAnalyzer(project);
-			const result = analyzer.analyze(['services/api-helper.ts'], diffs);
+			const result = analyzer.analyze(['services/api-helper.ts'], { diffs });
 
 			// Empty changedMethods = conservative, still traces
 			expect(result.affectedTests).toContain('tests/api.spec.ts');
+		});
+	});
+
+	describe('Method-Level Resolution', () => {
+		function createMethodUsageIndex(
+			methods: Record<string, Array<{ testFile: string }>>,
+		): MethodUsageIndex {
+			const index: MethodUsageIndex = {
+				methods: {},
+				fixtureMapping: {},
+				timestamp: new Date().toISOString(),
+				testFilesAnalyzed: 0,
+			};
+
+			for (const [key, usages] of Object.entries(methods)) {
+				index.methods[key] = usages.map((u) => ({
+					testFile: u.testFile,
+					line: 1,
+					column: 1,
+					fullCall: `${key}()`,
+				}));
+			}
+
+			return index;
+		}
+
+		it('returns 0 affected tests for removed unused method', () => {
+			const diffs: FileDiffResult[] = [
+				{
+					filePath: '/test-root/pages/SomePage.ts',
+					changedMethods: [
+						{ className: 'SomePage', methodName: 'unusedMethod', changeType: 'removed' },
+					],
+					isNewFile: false,
+					isDeletedFile: false,
+					parseTimeMs: 0,
+				},
+			];
+
+			const methodIndex = createMethodUsageIndex({});
+
+			const analyzer = new ImpactAnalyzer(project);
+			const result = analyzer.analyze(['pages/SomePage.ts'], {
+				diffs,
+				methodUsageIndex: methodIndex,
+			});
+
+			expect(result.affectedTests).toEqual([]);
+			expect(result.strategies['pages/SomePage.ts']).toBe('method-level');
+		});
+
+		it('returns exactly the tests using a modified method', () => {
+			const diffs: FileDiffResult[] = [
+				{
+					filePath: '/test-root/pages/CanvasPage.ts',
+					changedMethods: [
+						{ className: 'CanvasPage', methodName: 'addNode', changeType: 'modified' },
+					],
+					isNewFile: false,
+					isDeletedFile: false,
+					parseTimeMs: 0,
+				},
+			];
+
+			const methodIndex = createMethodUsageIndex({
+				'CanvasPage.addNode': [
+					{ testFile: 'tests/canvas-crud.spec.ts' },
+					{ testFile: 'tests/canvas-drag.spec.ts' },
+				],
+				'CanvasPage.deleteNode': [{ testFile: 'tests/canvas-delete.spec.ts' }],
+			});
+
+			const analyzer = new ImpactAnalyzer(project);
+			const result = analyzer.analyze(['pages/CanvasPage.ts'], {
+				diffs,
+				methodUsageIndex: methodIndex,
+			});
+
+			expect(result.affectedTests).toEqual([
+				'tests/canvas-crud.spec.ts',
+				'tests/canvas-drag.spec.ts',
+			]);
+			expect(result.affectedFiles).toContain('tests/canvas-crud.spec.ts');
+			expect(result.affectedFiles).toContain('tests/canvas-drag.spec.ts');
+			expect(result.strategies['pages/CanvasPage.ts']).toBe('method-level');
+		});
+
+		it('only returns tests using modified methods when changes are mixed', () => {
+			const diffs: FileDiffResult[] = [
+				{
+					filePath: '/test-root/pages/CanvasPage.ts',
+					changedMethods: [
+						{ className: 'CanvasPage', methodName: 'newMethod', changeType: 'added' },
+						{ className: 'CanvasPage', methodName: 'addNode', changeType: 'modified' },
+					],
+					isNewFile: false,
+					isDeletedFile: false,
+					parseTimeMs: 0,
+				},
+			];
+
+			const methodIndex = createMethodUsageIndex({
+				'CanvasPage.addNode': [{ testFile: 'tests/canvas.spec.ts' }],
+				'CanvasPage.deleteNode': [{ testFile: 'tests/canvas-delete.spec.ts' }],
+			});
+
+			const analyzer = new ImpactAnalyzer(project);
+			const result = analyzer.analyze(['pages/CanvasPage.ts'], {
+				diffs,
+				methodUsageIndex: methodIndex,
+			});
+
+			expect(result.affectedTests).toEqual(['tests/canvas.spec.ts']);
+			expect(result.strategies['pages/CanvasPage.ts']).toBe('method-level');
+		});
+
+		it('includes changed test file alongside method-level results', () => {
+			const diffs: FileDiffResult[] = [
+				{
+					filePath: '/test-root/pages/CanvasPage.ts',
+					changedMethods: [
+						{ className: 'CanvasPage', methodName: 'addNode', changeType: 'modified' },
+					],
+					isNewFile: false,
+					isDeletedFile: false,
+					parseTimeMs: 0,
+				},
+			];
+
+			const methodIndex = createMethodUsageIndex({
+				'CanvasPage.addNode': [{ testFile: 'tests/canvas.spec.ts' }],
+			});
+
+			const analyzer = new ImpactAnalyzer(project);
+			const result = analyzer.analyze(['pages/CanvasPage.ts', 'tests/other.spec.ts'], {
+				diffs,
+				methodUsageIndex: methodIndex,
+			});
+
+			expect(result.affectedTests).toContain('tests/canvas.spec.ts');
+			expect(result.affectedTests).toContain('tests/other.spec.ts');
+		});
+
+		it('skips new files (cannot break existing tests)', () => {
+			const diffs: FileDiffResult[] = [
+				{
+					filePath: '/test-root/pages/BrandNewPage.ts',
+					changedMethods: [
+						{ className: 'BrandNewPage', methodName: 'doThing', changeType: 'added' },
+					],
+					isNewFile: true,
+					isDeletedFile: false,
+					parseTimeMs: 0,
+				},
+			];
+
+			const methodIndex = createMethodUsageIndex({});
+
+			const analyzer = new ImpactAnalyzer(project);
+			const result = analyzer.analyze(['pages/BrandNewPage.ts'], {
+				diffs,
+				methodUsageIndex: methodIndex,
+			});
+
+			expect(result.affectedTests).toEqual([]);
+			expect(result.strategies['pages/BrandNewPage.ts']).toBe('skipped');
+		});
+
+		it('unions affected tests from multiple files with different strategies', () => {
+			const diffs: FileDiffResult[] = [
+				{
+					filePath: '/test-root/pages/CanvasPage.ts',
+					changedMethods: [
+						{ className: 'CanvasPage', methodName: 'addNode', changeType: 'modified' },
+					],
+					isNewFile: false,
+					isDeletedFile: false,
+					parseTimeMs: 0,
+				},
+				{
+					filePath: '/test-root/pages/NewPage.ts',
+					changedMethods: [{ className: 'NewPage', methodName: 'newMethod', changeType: 'added' }],
+					isNewFile: false,
+					isDeletedFile: false,
+					parseTimeMs: 0,
+				},
+			];
+
+			const methodIndex = createMethodUsageIndex({
+				'CanvasPage.addNode': [{ testFile: 'tests/canvas.spec.ts' }],
+			});
+
+			const analyzer = new ImpactAnalyzer(project);
+			const result = analyzer.analyze(
+				['pages/CanvasPage.ts', 'pages/NewPage.ts', 'tests/direct.spec.ts'],
+				{ diffs, methodUsageIndex: methodIndex },
+			);
+
+			expect(result.affectedTests).toContain('tests/canvas.spec.ts');
+			expect(result.affectedTests).toContain('tests/direct.spec.ts');
+			expect(result.strategies['pages/CanvasPage.ts']).toBe('method-level');
+			expect(result.strategies['pages/NewPage.ts']).toBe('skipped');
+		});
+
+		it('falls back to property-level for deleted files', () => {
+			const diffs: FileDiffResult[] = [
+				{
+					filePath: '/test-root/pages/DeletedPage.ts',
+					changedMethods: [],
+					isNewFile: false,
+					isDeletedFile: true,
+					parseTimeMs: 0,
+				},
+			];
+
+			const methodIndex = createMethodUsageIndex({});
+
+			const analyzer = new ImpactAnalyzer(project);
+			const result = analyzer.analyze(['pages/DeletedPage.ts'], {
+				diffs,
+				methodUsageIndex: methodIndex,
+			});
+
+			expect(result.strategies['pages/DeletedPage.ts']).toBe('property-level');
+		});
+
+		it('includes changed test file that references a newly added method', () => {
+			project.createSourceFile(
+				'/test-root/tests/new-feature.spec.ts',
+				`
+test('uses new method', async ({ app }) => {
+  await app.canvas.brandNewMethod();
+});
+`,
+			);
+
+			const diffs: FileDiffResult[] = [
+				{
+					filePath: '/test-root/pages/CanvasPage.ts',
+					changedMethods: [
+						{ className: 'CanvasPage', methodName: 'brandNewMethod', changeType: 'added' },
+					],
+					isNewFile: false,
+					isDeletedFile: false,
+					parseTimeMs: 0,
+				},
+			];
+
+			const methodIndex = createMethodUsageIndex({});
+
+			const analyzer = new ImpactAnalyzer(project);
+			const result = analyzer.analyze(['pages/CanvasPage.ts', 'tests/new-feature.spec.ts'], {
+				diffs,
+				methodUsageIndex: methodIndex,
+			});
+
+			expect(result.affectedTests).toContain('tests/new-feature.spec.ts');
+		});
+	});
+
+	describe('Regex Escaping', () => {
+		function emptyMethodIndex(): MethodUsageIndex {
+			return {
+				methods: {},
+				fixtureMapping: {},
+				timestamp: new Date().toISOString(),
+				testFilesAnalyzed: 0,
+			};
+		}
+
+		it('does not throw on method names with regex metacharacters', () => {
+			const diffs: FileDiffResult[] = [
+				{
+					filePath: '/test-root/pages/StorePage.ts',
+					changedMethods: [
+						{ className: 'StorePage', methodName: '$reset', changeType: 'added' },
+						{ className: 'StorePage', methodName: '$patch', changeType: 'added' },
+					],
+					isNewFile: true,
+					isDeletedFile: false,
+					parseTimeMs: 0,
+				},
+			];
+
+			const analyzer = new ImpactAnalyzer(project);
+
+			expect(() =>
+				analyzer.analyze(['pages/StorePage.ts'], {
+					diffs,
+					methodUsageIndex: emptyMethodIndex(),
+				}),
+			).not.toThrow();
+		});
+
+		it('matches method names containing $ when properly escaped', () => {
+			project.createSourceFile(
+				'/test-root/tests/pinia.spec.ts',
+				`
+test('uses pinia store', async ({ app }) => {
+  await app.store.$reset();
+});
+`,
+			);
+
+			const diffs: FileDiffResult[] = [
+				{
+					filePath: '/test-root/pages/StorePage.ts',
+					changedMethods: [{ className: 'StorePage', methodName: '$reset', changeType: 'added' }],
+					isNewFile: false,
+					isDeletedFile: false,
+					parseTimeMs: 0,
+				},
+			];
+
+			const analyzer = new ImpactAnalyzer(project);
+
+			// tests/pinia.spec.ts is both a changed test file AND references .$reset()
+			// Without escaping, $ would be treated as end-of-line anchor and fail to match
+			const result = analyzer.analyze(['pages/StorePage.ts', 'tests/pinia.spec.ts'], {
+				diffs,
+				methodUsageIndex: emptyMethodIndex(),
+			});
+
+			expect(result.affectedTests).toContain('tests/pinia.spec.ts');
+			expect(result.strategies['pages/StorePage.ts']).toBe('skipped');
 		});
 	});
 

--- a/packages/testing/janitor/src/core/impact-analyzer.ts
+++ b/packages/testing/janitor/src/core/impact-analyzer.ts
@@ -1,32 +1,45 @@
 /**
  * Impact Analyzer
  *
- * Analyzes the impact of file changes - which tests need to run?
- * Uses import graph tracing with facade-aware property-based search.
+ * Analyzes the impact of file changes — which tests need to run?
+ *
+ * Decision flow per changed file:
+ *   - New file / all methods added → SKIP (can't break existing tests)
+ *   - Has modified/removed methods → METHOD-LEVEL (MethodUsageAnalyzer lookup)
+ *   - No method changes detected (imports, types, comments) → PROPERTY-LEVEL fallback
+ *
+ * Method-level uses MethodUsageAnalyzer (fixture-pattern text search).
+ * Property-level uses import graph tracing with facade-aware search.
  */
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { type Project, type SourceFile } from 'ts-morph';
 
-import { type FileDiffResult } from './ast-diff-analyzer.js';
+import { type FileDiffResult, type MethodChange } from './ast-diff-analyzer.js';
 import { FacadeResolver } from './facade-resolver.js';
+import { MethodUsageAnalyzer, type MethodUsageIndex } from './method-usage-analyzer.js';
 import { getRootDir, findFilesRecursive, getRelativePath, isTestFile } from '../utils/paths.js';
 
-function isAdditiveOnly(diff: FileDiffResult): boolean {
-	if (diff.changedMethods.length === 0) return false;
-	return diff.changedMethods.every((m) => m.changeType === 'added');
+export type ResolutionStrategy = 'method-level' | 'property-level' | 'skipped';
+
+export interface AnalyzeOptions {
+	diffs?: FileDiffResult[];
+	methodUsageIndex?: MethodUsageIndex;
 }
 
 export interface ImpactResult {
 	changedFiles: string[];
 	affectedFiles: string[];
 	affectedTests: string[];
-	graph: Record<string, string[]>; // file -> files that depend on it
+	graph: Record<string, string[]>;
+	strategies: Record<string, ResolutionStrategy>;
 }
 
 /**
- * Analyze the impact of file changes - what tests need to run?
+ * Analyze the impact of file changes — what tests need to run?
+ *
+ * Single entry point used by both TCR and CI orchestration.
  */
 export class ImpactAnalyzer {
 	private root: string;
@@ -39,90 +52,195 @@ export class ImpactAnalyzer {
 
 	/**
 	 * Given a list of changed files, determine which test files are affected.
-	 * When diffs are provided, files with only additive changes (new methods)
-	 * skip dependency tracing — new exports can't break existing consumers.
+	 *
+	 * Uses method-level precision when AST diffs show modified/removed methods,
+	 * falls back to property-level import graph tracing otherwise.
 	 */
-	analyze(changedFiles: string[], diffs?: FileDiffResult[]): ImpactResult {
-		const absolutePaths = changedFiles.map((f) =>
-			path.isAbsolute(f) ? f : path.join(this.root, f),
-		);
+	analyze(changedFiles: string[], options: AnalyzeOptions = {}): ImpactResult {
+		const { diffs: precomputedDiffs, methodUsageIndex: precomputedIndex } = options;
 
-		const diffMap = new Map<string, FileDiffResult>();
-		if (diffs) {
-			for (const diff of diffs) {
-				diffMap.set(diff.filePath, diff);
-			}
-		}
-
-		const affectedSet = new Set<string>();
+		const affectedTests = new Set<string>();
+		const affectedFilesSet = new Set<string>();
+		const strategies: Record<string, ResolutionStrategy> = {};
 		const graph: Record<string, string[]> = {};
 
-		// For each changed file, find all files that depend on it
-		for (const filePath of absolutePaths) {
-			const sourceFile = this.project.getSourceFile(filePath);
-			if (!sourceFile) {
-				console.warn(`Warning: File not found in project: ${filePath}`);
-				continue;
-			}
+		// Separate test files from source files
+		const sourceFiles: string[] = [];
+		const testFiles: string[] = [];
 
-			const relativePath = getRelativePath(filePath);
-
-			// If the changed file is itself a test, it's affected
-			if (isTestFile(relativePath)) {
-				affectedSet.add(filePath);
-			}
-
-			// If we have diff info and all changes are additive, skip dependency tracing.
-			// New exports can't break existing consumers.
-			const diff = diffMap.get(filePath);
-			if (diff && isAdditiveOnly(diff)) {
-				continue;
-			}
-
-			// Find property names this file exposes (for property-based search)
-			const propertyNames = this.extractPropertyNames(sourceFile);
-
-			const dependents = this.findAllDependents(sourceFile, new Set(), propertyNames);
-
-			graph[relativePath] = dependents.map((f) => getRelativePath(f));
-
-			for (const dep of dependents) {
-				affectedSet.add(dep);
+		for (const file of changedFiles) {
+			const relative = this.toRelative(file);
+			if (isTestFile(relative)) {
+				testFiles.push(relative);
+			} else if (file.endsWith('.ts')) {
+				sourceFiles.push(file);
 			}
 		}
 
-		// Convert to relative paths and filter
-		const allAffected = Array.from(affectedSet).map((f) => getRelativePath(f));
-		const affectedTests = allAffected
-			.filter((f) => isTestFile(f))
-			.sort((a, b) => a.localeCompare(b));
+		// Include directly changed test files
+		for (const testFile of testFiles) {
+			affectedTests.add(testFile);
+		}
+
+		// Build diff map from pre-computed diffs (no diffs = property-level for all files)
+		const diffMap = this.buildDiffMap(precomputedDiffs);
+
+		// Lazy method usage index — only built if a file needs method-level resolution
+		let methodIndex: MethodUsageIndex | undefined = precomputedIndex;
+		const getMethodIndex = (): MethodUsageIndex => {
+			methodIndex ??= new MethodUsageAnalyzer(this.project).buildIndex();
+			return methodIndex;
+		};
+
+		for (const file of sourceFiles) {
+			const abs = this.toAbsolute(file);
+			const relative = this.toRelative(file);
+			const diff = diffMap.get(abs);
+
+			if (!diff) {
+				// No diff available — conservative property-level fallback
+				strategies[relative] = 'property-level';
+				this.resolvePropertyLevel(file, affectedTests, affectedFilesSet, graph);
+				continue;
+			}
+
+			// New file or all methods added → skip (can't break existing tests)
+			if (diff.isNewFile || this.isAllAdditive(diff)) {
+				strategies[relative] = 'skipped';
+				this.addTestsUsingNewMethods(
+					diff.changedMethods.filter((m) => m.changeType === 'added'),
+					testFiles,
+					affectedTests,
+				);
+				continue;
+			}
+
+			// Has modified/removed methods → method-level resolution
+			const modifiedOrRemoved = diff.changedMethods.filter((m) => m.changeType !== 'added');
+			if (modifiedOrRemoved.length > 0) {
+				strategies[relative] = 'method-level';
+				const methodTests: string[] = [];
+				for (const change of modifiedOrRemoved) {
+					const key = `${change.className}.${change.methodName}`;
+					const usages = getMethodIndex().methods[key] ?? [];
+					for (const usage of usages) {
+						affectedTests.add(usage.testFile);
+						affectedFilesSet.add(usage.testFile);
+						methodTests.push(usage.testFile);
+					}
+				}
+				if (methodTests.length > 0) {
+					graph[relative] = [...new Set(methodTests)].sort((a, b) => a.localeCompare(b));
+				}
+				// Also check for new methods referenced by changed test files
+				const addedMethods = diff.changedMethods.filter((m) => m.changeType === 'added');
+				this.addTestsUsingNewMethods(addedMethods, testFiles, affectedTests);
+				continue;
+			}
+
+			// No method changes detected (imports, types, comments) → property-level fallback
+			strategies[relative] = 'property-level';
+			this.resolvePropertyLevel(file, affectedTests, affectedFilesSet, graph);
+		}
 
 		return {
-			changedFiles: absolutePaths.map((f) => getRelativePath(f)),
-			affectedFiles: allAffected.sort((a, b) => a.localeCompare(b)),
-			affectedTests,
+			changedFiles: changedFiles.map((f) => this.toRelative(f)),
+			affectedFiles: Array.from(affectedFilesSet).sort((a, b) => a.localeCompare(b)),
+			affectedTests: Array.from(affectedTests).sort((a, b) => a.localeCompare(b)),
 			graph,
+			strategies,
 		};
 	}
 
+	// --- Strategy Helpers ---
+
+	private resolvePropertyLevel(
+		file: string,
+		affectedTests: Set<string>,
+		affectedFilesSet: Set<string>,
+		graph: Record<string, string[]>,
+	): void {
+		const abs = this.toAbsolute(file);
+		const relative = this.toRelative(file);
+		const sourceFile = this.project.getSourceFile(abs);
+		if (!sourceFile) return;
+
+		const propertyNames = this.extractPropertyNames(sourceFile);
+		const dependents = this.findAllDependents(sourceFile, new Set(), propertyNames);
+
+		const depRelative = dependents.map((f) => getRelativePath(f));
+		graph[relative] = depRelative;
+
+		for (const dep of depRelative) {
+			affectedFilesSet.add(dep);
+			if (isTestFile(dep)) {
+				affectedTests.add(dep);
+			}
+		}
+	}
+
+	private buildDiffMap(precomputedDiffs?: FileDiffResult[]): Map<string, FileDiffResult> {
+		const map = new Map<string, FileDiffResult>();
+
+		if (precomputedDiffs) {
+			for (const diff of precomputedDiffs) {
+				map.set(diff.filePath, diff);
+			}
+		}
+
+		return map;
+	}
+
+	private static escapeRegex(value: string): string {
+		return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	}
+
+	private isAllAdditive(diff: FileDiffResult): boolean {
+		if (diff.changedMethods.length === 0) return false;
+		return diff.changedMethods.every((m) => m.changeType === 'added');
+	}
+
+	private addTestsUsingNewMethods(
+		addedMethods: MethodChange[],
+		changedTestFiles: string[],
+		affectedTests: Set<string>,
+	): void {
+		if (addedMethods.length === 0 || changedTestFiles.length === 0) return;
+
+		for (const testFile of changedTestFiles) {
+			const fullPath = path.join(this.root, testFile);
+			const sourceFile = this.project.getSourceFile(fullPath);
+			if (!sourceFile) continue;
+
+			const content = sourceFile.getFullText();
+			for (const method of addedMethods) {
+				const methodPattern = new RegExp(
+					`\\.${ImpactAnalyzer.escapeRegex(method.methodName)}\\s*\\(`,
+				);
+				if (methodPattern.test(content)) {
+					affectedTests.add(testFile);
+					break;
+				}
+			}
+		}
+	}
+
+	// --- Import Graph Tracing (property-level internals) ---
+
 	/**
 	 * Extract property names that a file's exports are exposed as in the facade
-	 * Uses the pre-built facade property map for accurate lookup
 	 */
 	private extractPropertyNames(file: SourceFile): string[] {
 		const names: string[] = [];
 
-		// Get exported class names and look up their property names in facade
 		for (const classDecl of file.getClasses()) {
 			if (classDecl.isExported()) {
 				const className = classDecl.getName();
 				if (className) {
-					// Look up actual property name(s) from facade
 					const facadeProps = this.facade.getPropertiesForClass(className);
 					if (facadeProps.length > 0) {
 						names.push(...facadeProps);
 					} else {
-						// Fallback to camelCase conversion if not in facade
 						const propertyName = className.charAt(0).toLowerCase() + className.slice(1);
 						names.push(propertyName);
 					}
@@ -134,8 +252,8 @@ export class ImpactAnalyzer {
 	}
 
 	/**
-	 * Find all files that depend on a source file
-	 * Stops at facades and switches to property-based search
+	 * Find all files that depend on a source file.
+	 * Stops at facades and switches to property-based search.
 	 */
 	private findAllDependents(
 		file: SourceFile,
@@ -149,25 +267,19 @@ export class ImpactAnalyzer {
 		visited.add(filePath);
 
 		const dependents: string[] = [];
-
-		// Get direct dependents (files that import this file)
 		const directDependents = file.getReferencingSourceFiles();
 
 		for (const dep of directDependents) {
 			const depPath = dep.getFilePath();
 
-			// If we hit a facade, stop import tracing and switch to property search
 			if (this.facade.isFacade(depPath)) {
-				// Resolve through multi-hop chains (page → facade → composable → test)
 				const testsUsingProperty = this.resolvePropertyToTests(propertyNames, visited);
 				dependents.push(...testsUsingProperty);
 				continue;
 			}
 
-			// Not a facade - continue normal import tracing
 			dependents.push(depPath);
 
-			// For the next level, track what property this file is exposed as
 			const nextPropertyNames = this.extractPropertyNames(dep);
 			const combinedProperties = [...propertyNames, ...nextPropertyNames];
 
@@ -178,11 +290,6 @@ export class ImpactAnalyzer {
 		return dependents;
 	}
 
-	/**
-	 * Find all .ts files that use the given property names via text search.
-	 * Searches the entire project root (not just tests/) to catch composables,
-	 * helpers, and other intermediaries between the facade and tests.
-	 */
 	private findConsumersUsingProperties(propertyNames: string[]): string[] {
 		if (propertyNames.length === 0) {
 			return [];
@@ -190,15 +297,12 @@ export class ImpactAnalyzer {
 
 		const matchingFiles = new Set<string>();
 		const facadePath = this.facade.getFacadePath();
-
-		// Word-boundary regex: matches .name followed by any non-identifier char
-		const patterns = propertyNames.map((name) => new RegExp(`\\.${name}(?![a-zA-Z0-9_])`));
-
-		// Search all .ts files in the project root
+		const patterns = propertyNames.map(
+			(name) => new RegExp(`\\.${ImpactAnalyzer.escapeRegex(name)}(?![a-zA-Z0-9_])`),
+		);
 		const allFiles = findFilesRecursive(this.root, '.ts');
 
 		for (const file of allFiles) {
-			// Skip the facade itself — it declares properties, doesn't consume them
 			if (file === facadePath) continue;
 
 			try {
@@ -217,17 +321,6 @@ export class ImpactAnalyzer {
 		return Array.from(matchingFiles);
 	}
 
-	/**
-	 * Resolve property names to affected test files, following multi-hop chains.
-	 *
-	 * When a page changes and we hit the facade, the consumers might be:
-	 * 1. Test files → add directly to results
-	 * 2. Composables/helpers on the facade → extract THEIR property names, recurse
-	 * 3. Non-facade files → import-trace via findAllDependents
-	 *
-	 * Example chain: MfaLoginPage → facade(mfaLogin) → MfaComposer(mfaLogin.*) →
-	 *   facade(mfaComposer) → test(n8n.mfaComposer.*)
-	 */
 	private resolvePropertyToTests(
 		propertyNames: string[],
 		visited: Set<string>,
@@ -237,7 +330,6 @@ export class ImpactAnalyzer {
 		const tests: string[] = [];
 
 		for (const consumer of consumers) {
-			// Guard against cyclic property chains (A→B→A)
 			if (resolvedConsumers.has(consumer)) continue;
 			resolvedConsumers.add(consumer);
 
@@ -248,14 +340,11 @@ export class ImpactAnalyzer {
 				continue;
 			}
 
-			// Non-test consumer (composable, helper, etc.)
 			const sourceFile = this.project.getSourceFile(consumer);
 			if (!sourceFile) continue;
 
-			// Check if this file is exposed on the facade
 			const consumerPropertyNames = this.extractPropertyNames(sourceFile);
 			if (consumerPropertyNames.length > 0) {
-				// File is on the facade — recurse with its property names
 				const transitiveTests = this.resolvePropertyToTests(
 					consumerPropertyNames,
 					visited,
@@ -263,13 +352,28 @@ export class ImpactAnalyzer {
 				);
 				tests.push(...transitiveTests);
 			} else {
-				// Not on the facade — fall back to import tracing
 				const dependents = this.findAllDependents(sourceFile, visited, []);
 				tests.push(...dependents);
 			}
 		}
 
 		return tests;
+	}
+
+	// --- Path Helpers ---
+
+	private toRelative(filePath: string): string {
+		if (path.isAbsolute(filePath)) {
+			return getRelativePath(filePath);
+		}
+		return filePath;
+	}
+
+	private toAbsolute(filePath: string): string {
+		if (path.isAbsolute(filePath)) {
+			return filePath;
+		}
+		return path.join(this.root, filePath);
 	}
 }
 

--- a/packages/testing/janitor/src/core/tcr-executor.ts
+++ b/packages/testing/janitor/src/core/tcr-executor.ts
@@ -6,8 +6,9 @@ import { execFileSync } from 'node:child_process';
 import * as path from 'node:path';
 import { Project } from 'ts-morph';
 
-import { diffFileMethods, type MethodChange } from './ast-diff-analyzer.js';
+import { diffFileMethods, type FileDiffResult, type MethodChange } from './ast-diff-analyzer.js';
 import { loadBaseline, filterNewViolations } from './baseline.js';
+import { ImpactAnalyzer } from './impact-analyzer.js';
 import { MethodUsageAnalyzer, type MethodUsageIndex } from './method-usage-analyzer.js';
 import { createProject } from './project-loader.js';
 import { RuleRunner } from './rule-runner.js';
@@ -122,7 +123,8 @@ export class TcrExecutor {
 		this.logger.debugList(changedFiles);
 
 		// Analyze changed methods early (useful for understanding the change even if later checks fail)
-		const changedMethods = this.extractChangedMethods(changedFiles, baseRef);
+		const diffs = this.extractDiffs(changedFiles, baseRef);
+		const changedMethods = diffs.flatMap((d) => d.changedMethods);
 		this.logChangedMethods(changedMethods);
 
 		// Validation: rules
@@ -165,7 +167,7 @@ export class TcrExecutor {
 		this.logger.debug('\u2713 Typecheck passed');
 
 		// Find affected tests
-		const affectedTests = this.findAffectedTests(changedFiles, changedMethods);
+		const affectedTests = this.findAffectedTests(changedFiles, diffs);
 		this.logger.debug(`\nAffected tests: ${affectedTests.length}`);
 		this.logger.debugList(affectedTests);
 
@@ -351,15 +353,14 @@ export class TcrExecutor {
 
 	// --- Method Analysis ---
 
-	private extractChangedMethods(changedFiles: string[], baseRef: string): MethodChange[] {
-		const changedMethods: MethodChange[] = [];
+	private extractDiffs(changedFiles: string[], baseRef: string): FileDiffResult[] {
+		const diffs: FileDiffResult[] = [];
 		for (const file of changedFiles) {
 			if (file.endsWith('.ts') && !file.endsWith('.spec.ts')) {
-				const diff = diffFileMethods(file, baseRef);
-				changedMethods.push(...diff.changedMethods);
+				diffs.push(diffFileMethods(file, baseRef));
 			}
 		}
-		return changedMethods;
+		return diffs;
 	}
 
 	private logChangedMethods(changedMethods: MethodChange[]): void {
@@ -461,38 +462,13 @@ export class TcrExecutor {
 		return gitGetChangedFiles({ targetBranch, scopeDir: this.root, extensions: ['.ts'] });
 	}
 
-	private findAffectedTests(changedFiles: string[], changedMethods: MethodChange[]): string[] {
-		const affectedTests = new Set<string>();
-
-		const changedTestFiles = this.getChangedTestFiles(changedFiles);
-		const methodIndex = this.getMethodUsageIndex();
-
-		// Find tests using modified/removed methods
-		this.addTestsUsingMethods(
-			changedMethods.filter((m) => m.changeType !== 'added'),
-			methodIndex,
-			affectedTests,
-		);
-
-		// Find tests using newly added methods
-		this.addTestsUsingNewMethods(
-			changedMethods.filter((m) => m.changeType === 'added'),
-			changedTestFiles,
-			affectedTests,
-		);
-
-		// Include directly changed test files
-		for (const testFile of changedTestFiles) {
-			affectedTests.add(testFile);
-		}
-
-		return Array.from(affectedTests).sort((a, b) => a.localeCompare(b));
-	}
-
-	private getChangedTestFiles(changedFiles: string[]): string[] {
-		return changedFiles
-			.filter((f) => f.endsWith('.spec.ts'))
-			.map((f) => path.relative(this.root, f));
+	private findAffectedTests(changedFiles: string[], diffs: FileDiffResult[]): string[] {
+		const analyzer = new ImpactAnalyzer(this.project);
+		const result = analyzer.analyze(changedFiles, {
+			diffs,
+			methodUsageIndex: this.getMethodUsageIndex(),
+		});
+		return result.affectedTests;
 	}
 
 	private getMethodUsageIndex(): MethodUsageIndex {
@@ -501,43 +477,6 @@ export class TcrExecutor {
 			this.methodUsageIndex = analyzer.buildIndex();
 		}
 		return this.methodUsageIndex;
-	}
-
-	private addTestsUsingMethods(
-		methods: MethodChange[],
-		methodIndex: MethodUsageIndex,
-		affectedTests: Set<string>,
-	): void {
-		for (const change of methods) {
-			const key = `${change.className}.${change.methodName}`;
-			const usages = methodIndex.methods[key] ?? [];
-			for (const usage of usages) {
-				affectedTests.add(usage.testFile);
-			}
-		}
-	}
-
-	private addTestsUsingNewMethods(
-		addedMethods: MethodChange[],
-		changedTestFiles: string[],
-		affectedTests: Set<string>,
-	): void {
-		if (addedMethods.length === 0 || changedTestFiles.length === 0) return;
-
-		for (const testFile of changedTestFiles) {
-			const fullPath = path.join(this.root, testFile);
-			const sourceFile = this.project.getSourceFile(fullPath);
-			if (!sourceFile) continue;
-
-			const content = sourceFile.getFullText();
-			for (const method of addedMethods) {
-				const methodPattern = new RegExp(`\\.${method.methodName}\\s*\\(`);
-				if (methodPattern.test(content)) {
-					affectedTests.add(testFile);
-					break;
-				}
-			}
-		}
 	}
 
 	private runTests(testFiles: string[], testCommand?: string): boolean {

--- a/packages/testing/janitor/src/index.ts
+++ b/packages/testing/janitor/src/index.ts
@@ -163,6 +163,8 @@ export {
 	formatImpactJSON,
 	formatTestList,
 	type ImpactResult,
+	type AnalyzeOptions,
+	type ResolutionStrategy,
 } from './core/impact-analyzer.js';
 
 export {

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1368,9 +1368,27 @@ export type ChatNodeMessageWithButtons = {
 
 export type ChatNodeMessage = ChatNodeMessageWithButtons | string;
 
+/**
+ * Technical metadata preserved when an error is redacted.
+ * Contains only non-PII debugging information.
+ * Deliberately excludes: message, description, messages[], cause,
+ * context, and errorResponse — all of which may contain PII.
+ */
+export interface IRedactedErrorInfo {
+	/** Constructor name of the original error class, e.g. 'NodeApiError' */
+	type: string;
+	/** HTTP status code from NodeApiError, e.g. '404', '500', null */
+	httpCode?: string | null;
+}
+
 export interface INodeExecutionRedactionInfo {
 	redacted: true;
 	reason: string;
+	/**
+	 * When present, indicates the item's `error` field was redacted.
+	 * Contains only non-PII technical metadata. Placeholder for future smart filtering.
+	 */
+	error?: IRedactedErrorInfo;
 }
 
 export interface INodeExecutionData {
@@ -2700,6 +2718,11 @@ export interface ITaskData extends ITaskStartedData {
 	data?: ITaskDataConnections;
 	inputOverride?: ITaskDataConnections;
 	error?: ExecutionError;
+	/**
+	 * When present, indicates `error` was redacted.
+	 * Contains only non-PII technical metadata from the original error.
+	 */
+	redactedError?: IRedactedErrorInfo;
 	metadata?: ITaskMetadata;
 	/** True when at least one credential used by this node was resolved dynamically */
 	usedDynamicCredentials?: boolean;

--- a/packages/workflow/src/run-execution-data/run-execution-data.v1.ts
+++ b/packages/workflow/src/run-execution-data/run-execution-data.v1.ts
@@ -5,6 +5,7 @@ import type {
 	IExecuteData,
 	IExecutionContext,
 	IPinData,
+	IRedactedErrorInfo,
 	IRunData,
 	ITaskMetadata,
 	IWaitingForExecution,
@@ -32,6 +33,11 @@ export interface IRunExecutionDataV1 {
 	};
 	resultData: {
 		error?: ExecutionError;
+		/**
+		 * When present, indicates `error` was redacted.
+		 * Contains only non-PII technical metadata from the original error.
+		 */
+		redactedError?: IRedactedErrorInfo;
 		runData: IRunData;
 		pinData?: IPinData;
 		lastNodeExecuted?: string;


### PR DESCRIPTION
## Summary

This PR fixes a bug where publishing a workflow with a GitLab trigger multiple times accidentally creates duplicate webhooks in GitLab instead of reusing the existing one.

**Root Cause:**
The `checkExists()` method in `GitlabTrigger.node.ts` was returning `false` immediately if the internal `webhookData.webhookId` was undefined, without actually checking GitLab's side. Because of this, if static data gets cleared or a workflow is duplicated, n8n blindly spins up a brand new webhook.

**Solution:**
Updated `checkExists()` so that if the internal ID is missing, it falls back to querying the GitLab API (`GET /projects/{path}/hooks`). It checks the remote webhooks for a matching URL and matching events. If a match is found, it saves that webhook ID and returns `true`, successfully preventing duplicates.

**Testing performed:**
Tested locally via Codespaces with a public tunnel:
- Initial workflow activation successfully creates the webhook in GitLab.
- Deactivating and reactivating the workflow reuses the existing webhook (no duplicates created).
- TypeScript compliance maintained (no `@ts-ignore` or `any` used).

**Workflow Test JSON:** https://gist.github.com/EricDev10/2abfe565d599877c2141f7b2eb5d6eff

## Related Linear tickets, Github issues, and Community forum posts

Fixes https://github.com/n8n-io/n8n/issues/25381

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)