### PR TITLE
feat(core): Propagate workflow timezone into V8 isolate

### DIFF
--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -208,6 +208,14 @@ describe('Integration: ExpressionEvaluator + IsolatedVmBridge', () => {
 		// Midnight UTC = 9am in Tokyo (JST = UTC+9)
 		expect(result).toBe('09:00 +09:00');
 	});
+
+	it('should throw on invalid timezone', async () => {
+		const data = { $json: { x: 1 } };
+
+		expect(() => evaluator.evaluate('{{ $json.x }}', data, { timezone: 'Not/A/Timezone' })).toThrow(
+			'Invalid timezone: "Not/A/Timezone"',
+		);
+	});
 });
 
 describe('Integration: IsolatedVmBridge error handling', () => {

--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -178,6 +178,36 @@ describe('Integration: ExpressionEvaluator + IsolatedVmBridge', () => {
 
 		expect(result).toBe(150);
 	});
+
+	it('should use provided timezone for DateTime operations', async () => {
+		const data = {
+			$json: { ts: 1704067200000 }, // 2024-01-01T00:00:00Z
+		};
+
+		const result = evaluator.evaluate(
+			'{{ DateTime.fromMillis($json.ts).toFormat("HH:mm ZZ") }}',
+			data,
+			{ timezone: 'America/New_York' },
+		);
+
+		// Midnight UTC = 7pm previous day in New York (EST = UTC-5)
+		expect(result).toBe('19:00 -05:00');
+	});
+
+	it('should use different timezone when specified', async () => {
+		const data = {
+			$json: { ts: 1704067200000 }, // 2024-01-01T00:00:00Z
+		};
+
+		const result = evaluator.evaluate(
+			'{{ DateTime.fromMillis($json.ts).toFormat("HH:mm ZZ") }}',
+			data,
+			{ timezone: 'Asia/Tokyo' },
+		);
+
+		// Midnight UTC = 9am in Tokyo (JST = UTC+9)
+		expect(result).toBe('09:00 +09:00');
+	});
 });
 
 describe('Integration: IsolatedVmBridge error handling', () => {

--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -216,6 +216,28 @@ describe('Integration: ExpressionEvaluator + IsolatedVmBridge', () => {
 			'Invalid timezone: "Not/A/Timezone"',
 		);
 	});
+
+	it('should reset to system timezone when no timezone is provided after one was set', async () => {
+		const data = {
+			$json: { ts: 1704067200000 }, // 2024-01-01T00:00:00Z
+		};
+
+		// Capture the system default offset before any timezone is set
+		const systemOffset = evaluator.evaluate(
+			'{{ DateTime.fromMillis($json.ts).toFormat("ZZ") }}',
+			data,
+		);
+
+		// Evaluate with explicit timezone (changes Settings.defaultZone)
+		evaluator.evaluate('{{ DateTime.fromMillis($json.ts).toFormat("HH:mm ZZ") }}', data, {
+			timezone: 'Asia/Tokyo',
+		});
+
+		// Evaluate WITHOUT timezone — should reset to system default, not keep Tokyo
+		const result = evaluator.evaluate('{{ DateTime.fromMillis($json.ts).toFormat("ZZ") }}', data);
+
+		expect(result).toBe(systemOffset);
+	});
 });
 
 describe('Integration: IsolatedVmBridge error handling', () => {

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -1,7 +1,7 @@
 import ivm from 'isolated-vm';
 import { readFile } from 'node:fs/promises';
 import * as path from 'node:path';
-import type { RuntimeBridge, BridgeConfig } from '../types';
+import type { RuntimeBridge, BridgeConfig, ExecuteOptions } from '../types';
 import { DEFAULT_BRIDGE_CONFIG, TimeoutError, MemoryLimitError } from '../types';
 
 const BUNDLE_RELATIVE_PATH = path.join('dist', 'bundle', 'runtime.iife.js');
@@ -249,7 +249,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 	 * @private
 	 * @throws {Error} If context not initialized or reset fails
 	 */
-	private resetDataProxies(): void {
+	private resetDataProxies(timezone?: string): void {
 		if (!this.context) {
 			throw new Error('Context not initialized');
 		}
@@ -257,7 +257,11 @@ export class IsolatedVmBridge implements RuntimeBridge {
 		try {
 			// Call the resetDataProxies function in the isolate
 			// This function is loaded as part of the runtime bundle
-			this.context.evalSync('resetDataProxies()');
+			if (timezone) {
+				this.context.evalSync(`resetDataProxies(${JSON.stringify(timezone)})`);
+			} else {
+				this.context.evalSync('resetDataProxies()');
+			}
 
 			if (this.config.debug) {
 				console.log('[IsolatedVmBridge] Data proxies reset successfully');
@@ -427,7 +431,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 	 * @returns Result of the expression
 	 * @throws {Error} If bridge not initialized or execution fails
 	 */
-	execute(code: string, data: Record<string, unknown>): unknown {
+	execute(code: string, data: Record<string, unknown>, options?: ExecuteOptions): unknown {
 		if (!this.initialized || !this.context) {
 			throw new Error('Bridge not initialized. Call initialize() first.');
 		}
@@ -438,7 +442,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 
 			// Step 2: Reset proxies for this evaluation
 			// This initializes $json, $binary, etc. as lazy proxies
-			this.resetDataProxies();
+			this.resetDataProxies(options?.timezone);
 
 			// Step 3: Wrap transformed code so 'this' === __data in the isolate.
 			// Tournament generates: this.$json.email, this.$items(), etc.

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -55,6 +55,11 @@ export class IsolatedVmBridge implements RuntimeBridge {
 	private arrayElementRef?: ivm.Reference;
 	private callFunctionRef?: ivm.Reference;
 
+	// Pre-resolved reference to resetDataProxies() inside the isolate.
+	// Using applySync on a stored reference avoids the per-call
+	// ScriptCompiler::Compile() cost that evalSync incurs.
+	private resetDataProxiesRef?: ivm.Reference;
+
 	constructor(config: BridgeConfig = {}) {
 		this.config = {
 			...DEFAULT_BRIDGE_CONFIG,
@@ -101,6 +106,11 @@ export class IsolatedVmBridge implements RuntimeBridge {
 
 		// Inject E() error handler needed by tournament-generated try-catch code
 		await this.injectErrorHandler();
+
+		// Store a reference to resetDataProxies for efficient per-call invocation
+		this.resetDataProxiesRef = await this.context.global.get('resetDataProxies', {
+			reference: true,
+		});
 
 		this.initialized = true;
 
@@ -250,18 +260,14 @@ export class IsolatedVmBridge implements RuntimeBridge {
 	 * @throws {Error} If context not initialized or reset fails
 	 */
 	private resetDataProxies(timezone?: string): void {
-		if (!this.context) {
+		if (!this.resetDataProxiesRef) {
 			throw new Error('Context not initialized');
 		}
 
 		try {
-			// Call the resetDataProxies function in the isolate
-			// This function is loaded as part of the runtime bundle
-			if (timezone) {
-				this.context.evalSync(`resetDataProxies(${JSON.stringify(timezone)})`);
-			} else {
-				this.context.evalSync('resetDataProxies()');
-			}
+			this.resetDataProxiesRef.applySync(null, [timezone ?? null], {
+				arguments: { copy: true },
+			});
 
 			if (this.config.debug) {
 				console.log('[IsolatedVmBridge] Data proxies reset successfully');

--- a/packages/@n8n/expression-runtime/src/evaluator/expression-evaluator.ts
+++ b/packages/@n8n/expression-runtime/src/evaluator/expression-evaluator.ts
@@ -26,14 +26,16 @@ export class ExpressionEvaluator implements IExpressionEvaluator {
 		await this.config.bridge.initialize();
 	}
 
-	evaluate(expression: string, data: WorkflowData, _options?: EvaluateOptions): unknown {
+	evaluate(expression: string, data: WorkflowData, options?: EvaluateOptions): unknown {
 		if (this.disposed) throw new Error('Evaluator disposed');
 
 		// Transform template expression → sanitized JavaScript (cached)
 		const transformedCode = this.getTransformedCode(expression);
 
 		try {
-			const result = this.config.bridge.execute(transformedCode, data);
+			const result = this.config.bridge.execute(transformedCode, data, {
+				timezone: options?.timezone,
+			});
 
 			if (this.config.observability) {
 				this.config.observability.metrics.counter('expression.evaluation.success', 1);

--- a/packages/@n8n/expression-runtime/src/index.ts
+++ b/packages/@n8n/expression-runtime/src/index.ts
@@ -10,6 +10,7 @@ export type {
 	EvaluatorConfig,
 	WorkflowData,
 	EvaluateOptions,
+	ExecuteOptions,
 	RuntimeBridge,
 	BridgeConfig,
 	ObservabilityProvider,

--- a/packages/@n8n/expression-runtime/src/runtime/reset.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/reset.ts
@@ -1,3 +1,5 @@
+import { Settings } from 'luxon';
+
 import { extend, extendOptional } from '../extensions/extend';
 
 import { __sanitize } from './safe-globals';
@@ -21,7 +23,11 @@ import { createDeepLazyProxy } from './lazy-proxy';
  *
  * Called from bridge: context.evalSync('resetDataProxies()')
  */
-export function resetDataProxies(): void {
+export function resetDataProxies(timezone?: string): void {
+	if (timezone) {
+		Settings.defaultZone = timezone;
+	}
+
 	// Clear existing __data object
 	globalThis.__data = {};
 

--- a/packages/@n8n/expression-runtime/src/runtime/reset.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/reset.ts
@@ -1,4 +1,4 @@
-import { Settings } from 'luxon';
+import { IANAZone, Settings } from 'luxon';
 
 import { extend, extendOptional } from '../extensions/extend';
 
@@ -25,6 +25,9 @@ import { createDeepLazyProxy } from './lazy-proxy';
  */
 export function resetDataProxies(timezone?: string): void {
 	if (timezone) {
+		if (!IANAZone.isValidZone(timezone)) {
+			throw new Error(`Invalid timezone: "${timezone}"`);
+		}
 		Settings.defaultZone = timezone;
 	}
 

--- a/packages/@n8n/expression-runtime/src/runtime/reset.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/reset.ts
@@ -24,12 +24,10 @@ import { createDeepLazyProxy } from './lazy-proxy';
  * Called from bridge: context.evalSync('resetDataProxies()')
  */
 export function resetDataProxies(timezone?: string): void {
-	if (timezone) {
-		if (!IANAZone.isValidZone(timezone)) {
-			throw new Error(`Invalid timezone: "${timezone}"`);
-		}
-		Settings.defaultZone = timezone;
+	if (timezone && !IANAZone.isValidZone(timezone)) {
+		throw new Error(`Invalid timezone: "${timezone}"`);
 	}
+	Settings.defaultZone = timezone ?? 'system';
 
 	// Clear existing __data object
 	globalThis.__data = {};

--- a/packages/@n8n/expression-runtime/src/types/bridge.ts
+++ b/packages/@n8n/expression-runtime/src/types/bridge.ts
@@ -32,7 +32,7 @@ export interface RuntimeBridge {
 	 * Note: Synchronous for Node.js vm module (Slice 1).
 	 *       Will be async for isolated-vm (Slice 2).
 	 */
-	execute(code: string, data: Record<string, unknown>): unknown;
+	execute(code: string, data: Record<string, unknown>, options?: ExecuteOptions): unknown;
 
 	/**
 	 * Dispose of the isolated context and free resources.
@@ -78,3 +78,12 @@ export const DEFAULT_BRIDGE_CONFIG: Required<BridgeConfig> = {
 	timeout: 5000,
 	debug: false,
 };
+
+/** Options for a single execute() call. */
+export interface ExecuteOptions {
+	/**
+	 * IANA timezone for this evaluation (e.g., 'America/New_York').
+	 * Sets luxon Settings.defaultZone inside the isolate before execution.
+	 */
+	timezone?: string;
+}

--- a/packages/@n8n/expression-runtime/src/types/evaluator.ts
+++ b/packages/@n8n/expression-runtime/src/types/evaluator.ts
@@ -78,9 +78,6 @@ export type WorkflowData = Record<string, unknown>;
 
 /**
  * Options for evaluate().
- */
-/**
- * Options for evaluate().
  *
  * Note: Slice 1 is minimal. Tournament options will be added later.
  */
@@ -90,6 +87,12 @@ export interface EvaluateOptions {
 	 * Overrides the bridge's default timeout.
 	 */
 	timeout?: number;
+
+	/**
+	 * IANA timezone for this evaluation (e.g., 'America/New_York').
+	 * Sets luxon Settings.defaultZone inside the isolate before execution.
+	 */
+	timezone?: string;
 }
 
 // ============================================================================

--- a/packages/@n8n/expression-runtime/src/types/index.ts
+++ b/packages/@n8n/expression-runtime/src/types/index.ts
@@ -5,7 +5,7 @@
  */
 
 // Bridge types
-export type { RuntimeBridge, BridgeConfig } from './bridge';
+export type { RuntimeBridge, BridgeConfig, ExecuteOptions } from './bridge';
 export { DEFAULT_BRIDGE_CONFIG } from './bridge';
 
 // Runtime types

--- a/packages/frontend/editor-ui/vite/expression-runtime-stub.ts
+++ b/packages/frontend/editor-ui/vite/expression-runtime-stub.ts
@@ -50,3 +50,4 @@ export type MetricsAPI = never;
 export type TracesAPI = never;
 export type Span = never;
 export type LogsAPI = never;
+export type ExecuteOptions = never;

--- a/packages/workflow/src/expression.ts
+++ b/packages/workflow/src/expression.ts
@@ -531,7 +531,9 @@ export class Expression {
 			}
 
 			try {
-				const result = Expression.vmEvaluator.evaluate(expression, data);
+				const result = Expression.vmEvaluator.evaluate(expression, data, {
+					timezone: this.timezone,
+				});
 				return result as string | null | (() => unknown);
 			} catch (error) {
 				if (isExpressionError(error)) throw error;


### PR DESCRIPTION
## Summary

- Thread workflow timezone through `EvaluateOptions` → `ExecuteOptions` → `resetDataProxies()` so Luxon inside the V8 isolate uses the correct timezone instead of the system default
- Add `ExecuteOptions` interface to `RuntimeBridge.execute()` with `timezone?: string`
- Set `luxon.Settings.defaultZone` inside the isolate before each expression evaluation
- Fix 11 VM engine test failures in `date-extensions.test.ts` and `number-extensions.test.ts`

## Related tickets

https://linear.app/n8n/issue/CAT-2540

## Review / Merge checklist

- [x] All timezone-related VM test failures fixed (11 tests)
- [x] Integration tests for timezone propagation added
- [x] Existing tests unaffected (all changes are additive — timezone is optional everywhere)
- [x] Typecheck passes in both `@n8n/expression-runtime` and `n8n-workflow`
- [ ] 6 remaining `.inBetween`/`instanceof` failures tracked separately (different root causes)

## Test plan

- Run `pushd packages/@n8n/expression-runtime && pnpm test && popd` — all integration tests pass including 2 new timezone tests
- Run `pushd packages/workflow && pnpm test && popd` — all ~2025 tests pass (default engine)
- Run `pushd packages/workflow && N8N_EXPRESSION_ENGINE=vm pnpm test && popd` — 49 failures (down from 60)

🤖 Generated with [Claude Code](https://claude.com/claude-code)