### PR TITLE
fix(editor): Fix context menu z-index to be above the TabBar

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/MainHeader/TabBar.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/TabBar.vue
@@ -50,7 +50,7 @@ function onUpdateModelValue(tab: string, event: MouseEvent): void {
 	background-color: var(--color--foreground);
 	border-radius: var(--radius);
 	transition: all 150ms ease-in-out;
-	z-index: 100; // Should float above other layout components in any page
+	z-index: var(--tab-bar--z); // Should float above other layout components in any page
 }
 
 @media screen and (max-width: 430px) {

--- a/packages/frontend/editor-ui/src/app/composables/useStyles.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useStyles.ts
@@ -1,8 +1,9 @@
 const APP_Z_INDEXES = {
-	CONTEXT_MENU: 10, // should be still in front of the logs panel
 	APP_HEADER: 99,
+	TAB_BAR: 100,
 	SELECT_BOX: 100,
 	CANVAS_ADD_BUTTON: 101,
+	CONTEXT_MENU: 102, // should be still in front of the logs panel and tab bar
 	APP_SIDEBAR: 999,
 	CANVAS_SELECT_BOX: 100,
 	TOP_BANNERS: 999,


### PR DESCRIPTION
## Summary
Fix context menu so it isn't hidden by the TabBar and move TabBar z-index to a CSS variable

Before:
<img width="585" height="682" alt="image" src="https://github.com/user-attachments/assets/fc1032bf-2ebd-4ff4-ae66-a1d9d3620488" />

After:
<img width="627" height="667" alt="image" src="https://github.com/user-attachments/assets/6ed6c8b8-4c32-4f3d-a75f-017f1a6a0156" />

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
