### PR TITLE
feat(API): Allow filtering executions by `new` status

### DIFF
--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -638,6 +638,8 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 			condition.status = 'canceled';
 		} else if (status === 'running') {
 			condition.status = 'running';
+		} else if (status === 'new') {
+			condition.status = 'new';
 		}
 
 		return condition;

--- a/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.yml
+++ b/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.yml
@@ -13,7 +13,7 @@ get:
       required: false
       schema:
         type: string
-        enum: ['canceled', 'error', 'running', 'success', 'waiting']
+        enum: ['canceled', 'error', 'new', 'running', 'success', 'waiting']
     - name: workflowId
       in: query
       description: Workflow to filter the executions by.

--- a/packages/cli/test/integration/public-api/executions.test.ts
+++ b/packages/cli/test/integration/public-api/executions.test.ts
@@ -406,12 +406,14 @@ describe('GET /executions', () => {
 	});
 
 	describe('with query status', () => {
-		type AllowedQueryStatus = 'canceled' | 'error' | 'running' | 'success' | 'waiting';
+		type AllowedQueryStatus = 'canceled' | 'error' | 'new' | 'running' | 'success' | 'waiting';
+
 		test.each`
 			queryStatus   | entityStatus
 			${'canceled'} | ${'canceled'}
 			${'error'}    | ${'error'}
 			${'error'}    | ${'crashed'}
+			${'new'}      | ${'new'}
 			${'running'}  | ${'running'}
 			${'success'}  | ${'success'}
 			${'waiting'}  | ${'waiting'}


### PR DESCRIPTION
## Summary

Adds `new` to the enum of permissible `status` to fetch executions by.

Note: this PR only partially closes the gap between what is [currently exposed in the API](https://docs.n8n.io/api/api-reference/#tag/execution/GET/executions.query.status) and the [full list of statuses](https://github.com/n8n-io/n8n/blob/master/packages/workflow/src/execution-status.ts#L1):

```ts
export const ExecutionStatusList = [
	'canceled',
	'crashed',
	'error',
	'new',
	'running',
	'success',
	'unknown',
	'waiting',
] as const;
``` 


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
