### PR TITLE
ci: Add GITHUB_TOKEN to backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -33,6 +33,7 @@ jobs:
         id: targets
         env:
           PULL_REQUEST_ID: ${{ inputs.pull-request-id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node .github/scripts/compute-backport-targets.mjs
 
       - name: Backport


### PR DESCRIPTION
## Summary

The new codepath introduced by https://github.com/n8n-io/n8n/pull/26576 requires the GITHUB_TOKEN. Pass that into the env vars.

## Related Linear tickets, Github issues, and Community forum posts

Fixes what https://github.com/n8n-io/n8n/pull/26576 introduced.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
