### PR TITLE
refactor: Remove `KeepAlive` for `NodeView` (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.test.ts
+++ b/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.test.ts
@@ -63,6 +63,15 @@ vi.mock('@/app/composables/usePostMessageHandler', () => ({
 	})),
 }));
 
+const mockPushConnect = vi.fn();
+const mockPushDisconnect = vi.fn();
+vi.mock('@/app/stores/pushConnection.store', () => ({
+	usePushConnectionStore: vi.fn(() => ({
+		pushConnect: mockPushConnect,
+		pushDisconnect: mockPushDisconnect,
+	})),
+}));
+
 const defaultStubs = {
 	AppHeader: {
 		template: '<div data-test-id="app-header">App Header</div>',
@@ -182,5 +191,16 @@ describe('WorkflowLayout', () => {
 		expect(getByTestId('app-header')).toBeInTheDocument();
 		expect(getByTestId('app-sidebar')).toBeInTheDocument();
 		expect(getByText('Workflow Content')).toBeInTheDocument();
+	});
+
+	it('should call pushConnect on mount', () => {
+		renderComponent();
+		expect(mockPushConnect).toHaveBeenCalledOnce();
+	});
+
+	it('should call pushDisconnect on unmount', () => {
+		const { unmount } = renderComponent();
+		unmount();
+		expect(mockPushDisconnect).toHaveBeenCalledOnce();
 	});
 });

--- a/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
@@ -5,6 +5,7 @@ import { useLayoutProps } from '@/app/composables/useLayoutProps';
 import { useWorkflowState } from '@/app/composables/useWorkflowState';
 import { useWorkflowInitialization } from '@/app/composables/useWorkflowInitialization';
 import { usePostMessageHandler } from '@/app/composables/usePostMessageHandler';
+import { usePushConnectionStore } from '@/app/stores/pushConnection.store';
 import AskAssistantFloatingButton from '@/features/ai/assistant/components/Chat/AskAssistantFloatingButton.vue';
 import { useAssistantStore } from '@/features/ai/assistant/assistant.store';
 import AppHeader from '@/app/components/app/AppHeader.vue';
@@ -19,6 +20,7 @@ import {
 
 const { layoutProps } = useLayoutProps();
 const assistantStore = useAssistantStore();
+const pushConnectionStore = usePushConnectionStore();
 
 const workflowState = useWorkflowState();
 provide(WorkflowStateKey, workflowState);
@@ -43,6 +45,7 @@ const { setup: setupPostMessages, cleanup: cleanupPostMessages } = usePostMessag
 });
 
 onMounted(async () => {
+	pushConnectionStore.pushConnect();
 	setupPostMessages();
 	await initializeData();
 	await initializeWorkflow();
@@ -72,6 +75,7 @@ watch(
 );
 
 onBeforeUnmount(() => {
+	pushConnectionStore.pushDisconnect();
 	cleanupPostMessages();
 	cleanup();
 });
@@ -86,11 +90,7 @@ onBeforeUnmount(() => {
 			<AppSidebar />
 		</template>
 		<LoadingView v-if="isLoading" />
-		<RouterView v-else v-slot="{ Component }">
-			<KeepAlive include="NodeView" :max="1">
-				<component :is="Component" />
-			</KeepAlive>
-		</RouterView>
+		<RouterView v-else />
 		<template v-if="layoutProps.logs" #footer>
 			<LogsPanel />
 		</template>

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
@@ -14,6 +14,7 @@ import { useWorkflowDocumentIsArchived } from './workflowDocument/useWorkflowDoc
 import { useWorkflowDocumentTimestamps } from './workflowDocument/useWorkflowDocumentTimestamps';
 import { useWorkflowDocumentParentFolder } from './workflowDocument/useWorkflowDocumentParentFolder';
 import { useWorkflowDocumentUsedCredentials } from './workflowDocument/useWorkflowDocumentUsedCredentials';
+import { useWorkflowDocumentViewport } from './workflowDocument/useWorkflowDocumentViewport';
 
 export {
 	getPinDataSize,
@@ -67,6 +68,7 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 		const workflowDocumentSettings = useWorkflowDocumentSettings();
 		const workflowDocumentParentFolder = useWorkflowDocumentParentFolder();
 		const workflowDocumentUsedCredentials = useWorkflowDocumentUsedCredentials();
+		const workflowDocumentViewport = useWorkflowDocumentViewport();
 
 		return {
 			workflowId,
@@ -83,6 +85,7 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 			...workflowDocumentTimestamps,
 			...workflowDocumentParentFolder,
 			...workflowDocumentUsedCredentials,
+			...workflowDocumentViewport,
 		};
 	})();
 }

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentViewport.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentViewport.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import { useWorkflowDocumentViewport } from './useWorkflowDocumentViewport';
+
+function createViewport() {
+	return useWorkflowDocumentViewport();
+}
+
+describe('useWorkflowDocumentViewport', () => {
+	describe('initial state', () => {
+		it('should start with null', () => {
+			const { viewport } = createViewport();
+			expect(viewport.value).toBeNull();
+		});
+	});
+
+	describe('setViewport', () => {
+		it('should store the viewport transform', () => {
+			const { viewport, setViewport } = createViewport();
+
+			setViewport({ x: 100, y: 200, zoom: 1.5 });
+
+			expect(viewport.value).toEqual({ x: 100, y: 200, zoom: 1.5 });
+		});
+
+		it('should clear the viewport when set to null', () => {
+			const { viewport, setViewport } = createViewport();
+			setViewport({ x: 100, y: 200, zoom: 1.5 });
+
+			setViewport(null);
+
+			expect(viewport.value).toBeNull();
+		});
+
+		it('should replace existing viewport', () => {
+			const { viewport, setViewport } = createViewport();
+			setViewport({ x: 100, y: 200, zoom: 1.5 });
+
+			setViewport({ x: 300, y: 400, zoom: 0.5 });
+
+			expect(viewport.value).toEqual({ x: 300, y: 400, zoom: 0.5 });
+		});
+	});
+
+	describe('onViewportChange', () => {
+		it('should fire when viewport is set', async () => {
+			const { setViewport, onViewportChange } = createViewport();
+			const handler = vi.fn();
+			onViewportChange(handler);
+
+			setViewport({ x: 100, y: 200, zoom: 1.5 });
+
+			await vi.waitFor(() => {
+				expect(handler).toHaveBeenCalledWith({
+					action: 'update',
+					payload: { viewport: { x: 100, y: 200, zoom: 1.5 } },
+				});
+			});
+		});
+
+		it('should fire when viewport is cleared', async () => {
+			const { setViewport, onViewportChange } = createViewport();
+			setViewport({ x: 100, y: 200, zoom: 1.5 });
+
+			const handler = vi.fn();
+			onViewportChange(handler);
+
+			setViewport(null);
+
+			await vi.waitFor(() => {
+				expect(handler).toHaveBeenCalledWith({
+					action: 'update',
+					payload: { viewport: null },
+				});
+			});
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentViewport.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentViewport.ts
@@ -1,0 +1,35 @@
+import { ref, readonly } from 'vue';
+import { createEventHook } from '@vueuse/core';
+import type { ViewportTransform } from '@vue-flow/core';
+import { CHANGE_ACTION } from './types';
+import type { ChangeAction, ChangeEvent } from './types';
+
+export type ViewportPayload = {
+	viewport: ViewportTransform | null;
+};
+
+export type ViewportChangeEvent = ChangeEvent<ViewportPayload>;
+
+export function useWorkflowDocumentViewport() {
+	const viewport = ref<ViewportTransform | null>(null);
+
+	const onViewportChange = createEventHook<ViewportChangeEvent>();
+
+	function applyViewport(
+		newViewport: ViewportTransform | null,
+		action: ChangeAction = CHANGE_ACTION.UPDATE,
+	) {
+		viewport.value = newViewport;
+		void onViewportChange.trigger({ action, payload: { viewport: newViewport } });
+	}
+
+	function setViewport(newViewport: ViewportTransform | null) {
+		applyViewport(newViewport);
+	}
+
+	return {
+		viewport: readonly(viewport),
+		setViewport,
+		onViewportChange: onViewportChange.on,
+	};
+}

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -3,9 +3,6 @@ import {
 	computed,
 	defineAsyncComponent,
 	nextTick,
-	onActivated,
-	onBeforeMount,
-	onDeactivated,
 	onMounted,
 	ref,
 	useCssModule,
@@ -101,7 +98,7 @@ import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import { sourceControlEventBus } from '@/features/integrations/sourceControl.ee/sourceControl.eventBus';
 import { useTagsStore } from '@/features/shared/tags/tags.store';
-import { usePushConnectionStore } from '@/app/stores/pushConnection.store';
+
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { getBounds, getNodeViewTab } from '@/app/utils/nodeViewUtils';
 import CanvasStopCurrentExecutionButton from '@/features/workflows/canvas/components/elements/buttons/CanvasStopCurrentExecutionButton.vue';
@@ -192,7 +189,7 @@ const npsSurveyStore = useNpsSurveyStore();
 const projectsStore = useProjectsStore();
 const usersStore = useUsersStore();
 const tagsStore = useTagsStore();
-const pushConnectionStore = usePushConnectionStore();
+
 const ndvStore = useNDVStore();
 const focusPanelStore = useFocusPanelStore();
 const builderStore = useBuilderStore();
@@ -1661,12 +1658,6 @@ onBeforeRouteLeave(async (to, from, next) => {
  * Lifecycle
  */
 
-onBeforeMount(() => {
-	if (!isDemoRoute.value) {
-		pushConnectionStore.pushConnect();
-	}
-});
-
 onMounted(async () => {
 	documentTitle.reset();
 
@@ -1712,20 +1703,15 @@ onMounted(async () => {
 	addExecutionOpenedEventBindings();
 	addCommandBarEventBindings();
 	registerCustomActions();
-});
-
-onActivated(() => {
 	addUndoRedoEventBindings();
 	showAddFirstStepIfEnabled();
 });
 
-onDeactivated(() => {
-	uiStore.closeModal(WORKFLOW_SETTINGS_MODAL_KEY);
-	removeUndoRedoEventBindings();
-	toast.clearAllStickyNotifications();
-});
-
 onBeforeUnmount(() => {
+	uiStore.closeModal(WORKFLOW_SETTINGS_MODAL_KEY);
+	toast.clearAllStickyNotifications();
+	workflowDocumentStore?.value?.setViewport(viewportTransform.value);
+
 	removeSourceControlEventBindings();
 	removeWorkflowSavedEventBindings();
 	removeBeforeUnloadEventBindings();
@@ -1733,10 +1719,8 @@ onBeforeUnmount(() => {
 	removeExecutionOpenedEventBindings();
 	removeCommandBarEventBindings();
 	unregisterCustomActions();
+	removeUndoRedoEventBindings();
 	canvasEventBus.off('saved:workflow', onSaveFromWithinExecutionDebug);
-	if (!isDemoRoute.value) {
-		pushConnectionStore.pushDisconnect();
-	}
 });
 </script>
 
@@ -1756,6 +1740,7 @@ onBeforeUnmount(() => {
 			:key-bindings="keyBindingsEnabled"
 			:suppress-interaction="experimentalNdvStore.isMapperOpen"
 			:hide-controls="hideCanvasControls"
+			:initial-viewport="workflowDocumentStore?.viewport"
 			@update:nodes:position="onUpdateNodesPosition"
 			@update:node:position="onUpdateNodePosition"
 			@update:node:activated="onSetNodeActivated"

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
@@ -145,6 +145,7 @@ const props = withDefaults(
 		loading?: boolean;
 		suppressInteraction?: boolean;
 		hideControls?: boolean;
+		initialViewport?: ViewportTransform | null;
 	}>(),
 	{
 		id: 'canvas',
@@ -959,7 +960,11 @@ onUnmounted(() => {
 });
 
 onPaneReady(async () => {
-	await onFitView();
+	if (props.initialViewport) {
+		await setViewport(props.initialViewport);
+	} else {
+		await onFitView();
+	}
 	isPaneReady.value = true;
 });
 

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/WorkflowCanvas.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/WorkflowCanvas.vue
@@ -3,6 +3,7 @@ import type { ContextMenuAction } from '@/features/shared/contextMenu/composable
 import type { IWorkflowDb } from '@/Interface';
 import type { EventBus } from '@n8n/utils/event-bus';
 import { createEventBus } from '@n8n/utils/event-bus';
+import type { ViewportTransform } from '@vue-flow/core';
 import { getRectOfNodes, useVueFlow } from '@vue-flow/core';
 import { throttledRef } from '@vueuse/core';
 import type { Workflow } from 'n8n-workflow';
@@ -26,6 +27,7 @@ const props = withDefaults(
 		readOnly?: boolean;
 		executing?: boolean;
 		suppressInteraction?: boolean;
+		initialViewport?: ViewportTransform | null;
 	}>(),
 	{
 		id: 'canvas',
@@ -60,7 +62,9 @@ const { nodes: mappedNodes, connections: mappedConnections } = useCanvasMapping(
 const initialFitViewDone = ref(false); // Workaround for https://github.com/bcakmakoglu/vue-flow/issues/1636
 const { off } = onNodesInitialized(() => {
 	if (!initialFitViewDone.value) {
-		props.eventBus.emit('fitView');
+		if (!props.initialViewport) {
+			props.eventBus.emit('fitView');
+		}
 		initialFitViewDone.value = true;
 		off();
 	}
@@ -152,6 +156,7 @@ defineExpose({
 				:read-only="readOnly"
 				:executing="executing"
 				:suppress-interaction="suppressInteraction"
+				:initial-viewport="initialViewport"
 				v-bind="$attrs"
 			/>
 		</div>


### PR DESCRIPTION
## Summary

Pre-requisite for removing the need to keep workflow document store in a watched composable, re-initializing NodeView every time the route loads.

Replace Vue KeepAlive wrapper with explicit lifecycle management. Push connection is now owned by WorkflowLayout (which persists across navigations), and canvas viewport position is explicitly saved to/restored from the workflow document store via a new composable.

The new useWorkflowDocumentViewport composable follows the workflowDocument store pattern with apply/public method split, createEventHook event notifications, and ChangeEvent typed payloads.


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2546/remove-keepalive-for-nodeview

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
