### PR TITLE
fix: Cache node initialization in test harness (no-changelog)

### DIFF
--- a/packages/core/nodes-testing/node-test-harness.ts
+++ b/packages/core/nodes-testing/node-test-harness.ts
@@ -47,11 +47,14 @@ export class NodeTestHarness {
 
 	private readonly packagePaths: string[];
 
+	private nodesLoadedPromise: Promise<void> | undefined;
+
 	constructor({ additionalPackagePaths }: TestHarnessOptions = {}) {
 		this.testDir = path.dirname(callsites()[1].getFileName()!);
 		this.packagePaths = additionalPackagePaths ?? [];
 		this.packagePaths.unshift(this.packageDir);
 
+		beforeAll(() => this.ensureNodesLoaded(), 30_000);
 		beforeEach(() => nock.disableNetConnect());
 	}
 
@@ -184,10 +187,19 @@ export class NodeTestHarness {
 		);
 	}
 
+	private async ensureNodesLoaded() {
+		if (!this.nodesLoadedPromise) {
+			this.nodesLoadedPromise = (async () => {
+				const loadNodesAndCredentials = new LoadNodesAndCredentials(this.packagePaths);
+				Container.set(LoadNodesAndCredentials, loadNodesAndCredentials);
+				await loadNodesAndCredentials.init();
+			})();
+		}
+		return this.nodesLoadedPromise;
+	}
+
 	private async executeWorkflow(testData: WorkflowTestData) {
-		const loadNodesAndCredentials = new LoadNodesAndCredentials(this.packagePaths);
-		Container.set(LoadNodesAndCredentials, loadNodesAndCredentials);
-		await loadNodesAndCredentials.init();
+		await this.ensureNodesLoaded();
 		const nodeTypes = Container.get(NodeTypes);
 		const credentialsHelper = Container.get(CredentialsHelper);
 		credentialsHelper.setCredentials(testData.credentials ?? {});


### PR DESCRIPTION
## Summary

Agent V3 integration tests were failing with Jest timeout errors (10s) because node loading was happening per-test. The expensive `LoadNodesAndCredentials.init()` call scans and loads all node packages, which takes >10 seconds on CI during cold-start.

This fix caches the initialization in a promise and moves it to `beforeAll` so it runs once per test file instead of per test, and doesn't count against individual test timeouts. Tests now complete in ~8s with all passing.

## Testing

- `agent-v3.workflow.test.ts`: 10 tests pass in 7.3s (was failing with timeout)
- `agent-tool-v3.workflow.test.ts`: 1 test passes in 6.7s (was timing out)