### PR TITLE
fix(core): Apply empty-hash placeholder fix to getHash cache method

### DIFF
--- a/packages/cli/src/services/cache/__tests__/cache.service.test.ts
+++ b/packages/cli/src/services/cache/__tests__/cache.service.test.ts
@@ -235,6 +235,32 @@ for (const backend of ['memory', 'redis'] as const) {
 			});
 		});
 
+		describe('getHash', () => {
+			const createHashRefreshFn = () =>
+				jest.fn(async (_key: string) => await Promise.resolve({ field: 'refreshValue' }));
+
+			test('should treat hash as cache hit when key is present', async () => {
+				const refreshFn = createHashRefreshFn();
+				await cacheService.setHash('testHash', { field: 'value' });
+
+				const value = await cacheService.getHash('testHash', { refreshFn });
+				expect(value).toEqual({ field: 'value' });
+				expect(refreshFn).not.toHaveBeenCalled();
+			});
+
+			if (backend === 'redis') {
+				describe('when backend is redis', () => {
+					test('should treat empty hash placeholder as cache miss when key is missing', async () => {
+						const refreshFn = createHashRefreshFn();
+						await expect(cacheService.getHash('testHash', { refreshFn })).resolves.toEqual({
+							field: 'refreshValue',
+						});
+						expect(refreshFn).toHaveBeenCalledTimes(1);
+					});
+				});
+			}
+		});
+
 		describe('delete', () => {
 			test('should handle non-ASCII key', async () => {
 				const nonAsciiKey = 'ԱԲԳ';

--- a/packages/cli/src/services/cache/cache.service.ts
+++ b/packages/cli/src/services/cache/cache.service.ts
@@ -13,6 +13,7 @@ import type {
 	Hash,
 } from '@/services/cache/cache.types';
 import { TypedEmitter } from '@/typed-emitter';
+import { isObject } from '@/utils';
 
 type CacheEvents = {
 	'metrics.cache.hit': never;
@@ -188,9 +189,7 @@ export class CacheService extends TypedEmitter<CacheEvents> {
 		if (key?.length === 0) return;
 
 		const value = await this.cache.store.get<T>(key);
-
-		const hasValue = value !== undefined;
-		const cacheHit = hasValue && !(await this.isValueAMissingKeyPlaceholder(key, value));
+		const cacheHit = await this.isAValidCacheHit(key, value);
 		if (cacheHit) {
 			this.emit('metrics.cache.hit');
 
@@ -228,7 +227,8 @@ export class CacheService extends TypedEmitter<CacheEvents> {
 		const hash: MaybeHash<T> =
 			this.cache.kind === 'redis' ? await this.cache.store.hgetall(key) : await this.get(key);
 
-		if (hash !== undefined) {
+		const cacheHit = await this.isAValidCacheHit(key, hash);
+		if (cacheHit) {
 			this.emit('metrics.cache.hit');
 
 			return hash;
@@ -336,20 +336,28 @@ export class CacheService extends TypedEmitter<CacheEvents> {
 		await this.cache.store.set(cacheKey, hashObject);
 	}
 
-	/**
-	 * Check if a value is a Redis missing key placeholder.
-	 * After a cache loss (e.g. Redis restart), some adapters may return [] for a missing key.
-	 * @param key - The key to check.
-	 * @param value - The value to check.
-	 * @returns True if the value is a Redis missing key placeholder, false otherwise.
-	 */
-	private async isValueAMissingKeyPlaceholder(key: string, value: unknown): Promise<boolean> {
-		// Memory cache uses `undefined` for misses and [] can be a valid cached value, so this check is only needed for Redis cache.
-		if (this.isRedis() && Array.isArray(value) && value.length === 0) {
-			const ttl = await this.cache.store.ttl(key);
-			return ttl === REDIS_TTL_KEY_MISSING;
+	private async isAValidCacheHit(key: string, value: unknown): Promise<boolean> {
+		if (value === undefined) {
+			return false;
 		}
 
-		return false;
+		const isEmptyArray = Array.isArray(value) && value.length === 0;
+		const isEmptyObject = isObject(value) && Object.keys(value).length === 0;
+		if (isEmptyArray || isEmptyObject) {
+			// Redis adapters may return [] or {} for missing string or hash keys after restart.
+			const keyExists = await this.doesRedisKeyExist(key);
+			return keyExists;
+		}
+
+		return true;
+	}
+
+	private async doesRedisKeyExist(key: string): Promise<boolean> {
+		if (this.isRedis()) {
+			const ttl = await this.cache.store.ttl(key);
+			return ttl !== REDIS_TTL_KEY_MISSING;
+		}
+
+		return true;
 	}
 }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -143,3 +143,7 @@ export function setMicrosoftObservabilityDefaults(): void {
 export function containsExpression(testString: string): boolean {
 	return /^=.*\{\{.+\}\}/.test(testString);
 }
+
+export function isObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## Summary

After a Redis restart, the cache adapter may return `{}` (empty object) for a missing hash key — similar to how it returns `[]` for a missing string key. The existing `isValueAMissingKeyPlaceholder` check only handled `[]`, so `getHash` was treating empty-object responses as cache hits.

This PR:
- Refactors the placeholder detection into a unified `isAValidCacheHit` method covering both `[]` and `{}` cases
- Applies the fix to `getHash` (in addition to `get`, which was already fixed)
- Adds a regression test for `getHash` cache hit/miss behavior

## Related Linear tickets, Github issues, and Community forum posts

<!-- Link to Linear ticket: https://linear.app/n8n/issue/LIGO-300 -->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)