### PR TITLE
fix(editor): Fix canvas loading state indicator position and style (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/views/LoadingView.vue
+++ b/packages/frontend/editor-ui/src/app/views/LoadingView.vue
@@ -12,17 +12,19 @@ import { N8nSpinner } from '@n8n/design-system';
 
 <style lang="scss" module>
 .wrapper {
+	top: 0;
+	left: 0;
 	width: 100%;
 	height: 100%;
 	position: absolute;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	background-color: var(--color--background--light-2);
 }
 
 .spinner {
-	margin-bottom: var(--spacing--lg);
-	position: absolute;
-	left: 50%;
-	top: 30%;
+	margin: 0 auto;
 
 	* {
 		color: var(--color--primary);

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -1668,7 +1668,6 @@ onBeforeMount(() => {
 });
 
 onMounted(async () => {
-	canvasStore.startLoading();
 	documentTitle.reset();
 
 	// Register callback for collaboration store to refresh canvas when workflow updates arrive
@@ -1689,7 +1688,6 @@ onMounted(async () => {
 		}
 	} finally {
 		isLoading.value = false;
-		canvasStore.stopLoading();
 
 		void externalHooks.run('nodeView.mount').catch(() => {});
 


### PR DESCRIPTION
## Summary

This pull request makes a minor adjustment to the workflow loading logic in the `NodeView.vue` component. The change removes calls to `canvasStore.startLoading()` and `canvasStore.stopLoading()`, streamlining the loading state management.

<img width="1303" height="1210" alt="Screenshot 2026-03-05 at 12 59 26" src="https://github.com/user-attachments/assets/777174fd-9f71-49db-884b-86ed953b943a" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2548/fix-workflowlayout-loading-spinner-design-and-position

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
