### PR TITLE
feat: Add support for publishing community nodes through GitHub Actions

### DIFF
--- a/packages/@n8n/node-cli/src/commands/release.test.ts
+++ b/packages/@n8n/node-cli/src/commands/release.test.ts
@@ -27,6 +27,7 @@ describe('release command', () => {
 		vi.clearAllMocks();
 		process.env = { ...originalEnv };
 		delete process.env.npm_config_user_agent;
+		delete process.env.GITHUB_ACTIONS;
 	});
 
 	afterEach(() => {
@@ -77,6 +78,52 @@ describe('release command', () => {
 			exitCode: 1,
 			stderr: 'Release failed: Git working directory is not clean',
 		});
+
+		await expect(CommandTester.run('release')).rejects.toThrow('EEXIT: 1');
+	});
+
+	tmpdirTest('CI mode - runs lint, build, then npm publish with provenance', async ({ tmpdir }) => {
+		process.env.GITHUB_ACTIONS = 'true';
+
+		await fs.writeFile(
+			`${tmpdir}/package.json`,
+			JSON.stringify({
+				name: 'test-node',
+				version: '1.0.0',
+				n8n: {
+					nodes: ['dist/nodes/TestNode.node.js'],
+				},
+			}),
+		);
+		await fs.writeFile(`${tmpdir}/pnpm-lock.yaml`, '# pnpm lock file');
+
+		mockSpawn([
+			{ command: 'pnpm', args: ['run', 'lint'], options: { exitCode: 0 } },
+			{ command: 'pnpm', args: ['run', 'build'], options: { exitCode: 0 } },
+			{ command: 'npm', args: ['publish'], options: { exitCode: 0 } },
+		]);
+
+		const result = await CommandTester.run('release');
+
+		expect(result).toBeDefined();
+	});
+
+	tmpdirTest('CI mode - exits with error code on lint failure', async ({ tmpdir }) => {
+		process.env.GITHUB_ACTIONS = 'true';
+
+		await fs.writeFile(
+			`${tmpdir}/package.json`,
+			JSON.stringify({
+				name: 'test-node',
+				version: '1.0.0',
+				n8n: {
+					nodes: ['dist/nodes/TestNode.node.js'],
+				},
+			}),
+		);
+		await fs.writeFile(`${tmpdir}/pnpm-lock.yaml`, '# pnpm lock file');
+
+		mockSpawn([{ command: 'pnpm', args: ['run', 'lint'], options: { exitCode: 1 } }]);
 
 		await expect(CommandTester.run('release')).rejects.toThrow('EEXIT: 1');
 	});

--- a/packages/@n8n/node-cli/src/commands/release.ts
+++ b/packages/@n8n/node-cli/src/commands/release.ts
@@ -16,32 +16,45 @@ export default class Release extends Command {
 		intro(await getCommandHeader('n8n-node release'));
 
 		const pm = (await detectPackageManager()) ?? 'npm';
+		const isCI = Boolean(process.env.GITHUB_ACTIONS);
 
 		try {
-			await runCommand(
-				'release-it',
-				[
-					'-n',
-					'--git.requireBranch main',
-					'--git.requireCleanWorkingDir',
-					'--git.requireUpstream',
-					'--git.requireCommits',
-					'--git.commit',
-					'--git.tag',
-					'--git.push',
-					'--git.changelog="npx auto-changelog --stdout --unreleased --commit-limit false -u --hide-credit"',
-					'--github.release',
-					`--hooks.before:init="${pm} run lint && ${pm} run build"`,
-					'--hooks.after:bump="npx auto-changelog -p"',
-				],
-				{
+			if (isCI) {
+				await runCommand(pm, ['run', 'lint'], { stdio: 'inherit' });
+				await runCommand(pm, ['run', 'build'], { stdio: 'inherit' });
+				await runCommand('npm', ['publish'], {
 					stdio: 'inherit',
-					context: 'local',
 					env: {
 						RELEASE_MODE: 'true',
+						NPM_CONFIG_PROVENANCE: 'true',
 					},
-				},
-			);
+				});
+			} else {
+				await runCommand(
+					'release-it',
+					[
+						'-n',
+						'--git.requireBranch main',
+						'--git.requireCleanWorkingDir',
+						'--git.requireUpstream',
+						'--git.requireCommits',
+						'--git.commit',
+						'--git.tag',
+						'--git.push',
+						'--git.changelog="npx auto-changelog --stdout --unreleased --commit-limit false -u --hide-credit"',
+						'--github.release',
+						`--hooks.before:init="${pm} run lint && ${pm} run build"`,
+						'--hooks.after:bump="npx auto-changelog -p"',
+					],
+					{
+						stdio: 'inherit',
+						context: 'local',
+						env: {
+							RELEASE_MODE: 'true',
+						},
+					},
+				);
+			}
 		} catch (error) {
 			if (error instanceof ChildProcessError) {
 				if (error.signal) {

--- a/packages/@n8n/node-cli/src/commands/release.ts
+++ b/packages/@n8n/node-cli/src/commands/release.ts
@@ -29,32 +29,33 @@ export default class Release extends Command {
 						NPM_CONFIG_PROVENANCE: 'true',
 					},
 				});
-			} else {
-				await runCommand(
-					'release-it',
-					[
-						'-n',
-						'--git.requireBranch main',
-						'--git.requireCleanWorkingDir',
-						'--git.requireUpstream',
-						'--git.requireCommits',
-						'--git.commit',
-						'--git.tag',
-						'--git.push',
-						'--git.changelog="npx auto-changelog --stdout --unreleased --commit-limit false -u --hide-credit"',
-						'--github.release',
-						`--hooks.before:init="${pm} run lint && ${pm} run build"`,
-						'--hooks.after:bump="npx auto-changelog -p"',
-					],
-					{
-						stdio: 'inherit',
-						context: 'local',
-						env: {
-							RELEASE_MODE: 'true',
-						},
-					},
-				);
+				return;
 			}
+
+			await runCommand(
+				'release-it',
+				[
+					'-n',
+					'--git.requireBranch main',
+					'--git.requireCleanWorkingDir',
+					'--git.requireUpstream',
+					'--git.requireCommits',
+					'--git.commit',
+					'--git.tag',
+					'--git.push',
+					'--git.changelog="npx auto-changelog --stdout --unreleased --commit-limit false -u --hide-credit"',
+					'--github.release',
+					`--hooks.before:init="${pm} run lint && ${pm} run build"`,
+					'--hooks.after:bump="npx auto-changelog -p"',
+				],
+				{
+					stdio: 'inherit',
+					context: 'local',
+					env: {
+						RELEASE_MODE: 'true',
+					},
+				},
+			);
 		} catch (error) {
 			if (error instanceof ChildProcessError) {
 				if (error.signal) {

--- a/packages/@n8n/node-cli/src/commands/release.ts
+++ b/packages/@n8n/node-cli/src/commands/release.ts
@@ -6,7 +6,27 @@ import { detectPackageManager } from '../utils/package-manager';
 import { getCommandHeader } from '../utils/prompts';
 
 export default class Release extends Command {
-	static override description = 'Publish your community node package to npm';
+	static override description = `Publish your community node package to npm.
+
+Starting May 1 2026, n8n requires all community nodes to be published via GitHub Actions with npm provenance. Provenance lets anyone cryptographically verify that a package was built from a specific repository and commit.
+
+When this command is running locally: Runs release-it to bump the version interactively, generate a changelog, commit, tag, push, create a GitHub release, and publish to npm.
+
+When it's running inside a GitHub Action: Detected automatically via the GITHUB_ACTIONS environment variable. Runs lint and build, then publishes with provenance enabled (NPM_CONFIG_PROVENANCE=true).
+
+To set up GitHub Actions publishing:
+  1. Add a publish.yml workflow that triggers on version tags (e.g. v*.*.*).
+  2. Grant the publish job: permissions: { id-token: write, contents: read }
+  3. Use actions/setup-node with registry-url: 'https://registry.npmjs.org/'
+  4. Run \`npm run release\` as the publish step.
+
+For npm Trusted Publishing (no long-lived secrets):
+  On npmjs.com → package settings → Trusted Publishers → add your repo and workflow name.
+  Leave NPM_TOKEN unset; GitHub's OIDC token is used automatically.
+
+For token-based auth (fallback):
+  Add NPM_TOKEN to your repository secrets and pass it as NODE_AUTH_TOKEN.`;
+
 	static override examples = ['<%= config.bin %> <%= command.id %>'];
 	static override flags = {};
 

--- a/packages/@n8n/node-cli/src/commands/release.ts
+++ b/packages/@n8n/node-cli/src/commands/release.ts
@@ -1,4 +1,4 @@
-import { intro } from '@clack/prompts';
+import { intro, log } from '@clack/prompts';
 import { Command } from '@oclif/core';
 
 import { ChildProcessError, runCommand } from '../utils/child-process';
@@ -51,6 +51,10 @@ For token-based auth (fallback):
 				});
 				return;
 			}
+
+			log.warning(
+				'Starting May 1 2026, n8n requires community nodes to be published via GitHub Actions with npm provenance.\nRun `n8n-node release --help` to learn how to set this up.',
+			);
 
 			await runCommand(
 				'release-it',


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

`n8n-node publish` now includes a gate that checks if we're running in a GitHub Action (this will be enforced starting May 1st). If this is the case, we do an `npm release` with trusted publishing (also enforced soon).

In case we're running locally, the behavior of the command remains unchanged.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/CE-576/update-n8n-node-release-cli-to-handle-publishing-with-provenance


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or [follow-up ticket](https://linear.app/n8n/issue/CE-579/add-gh-action-example-to-documentation) created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
