### PR TITLE
fix(editor): Fix expression autocomplete for optional chaining

### DIFF
--- a/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/completions/completions.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/completions/completions.test.ts
@@ -563,6 +563,48 @@ describe('Resolution-based completions', () => {
 		});
 	});
 
+	describe('optional chaining', () => {
+		const { $input } = mockProxy;
+
+		test('should return completions for: {{ $json?.| }}', async () => {
+			vi.spyOn(workflowHelpers, 'resolveParameter').mockResolvedValue($input.item?.json);
+
+			const found = await completions('{{ $json?.| }}');
+
+			if (!found) throw new Error('Expected to find completions');
+
+			expect(found).toHaveLength(
+				Object.keys($input.item?.json ?? {}).length + extensions({ typeName: 'object' }).length,
+			);
+		});
+
+		test('should return completions for: {{ $json?.str?.| }}', async () => {
+			vi.spyOn(workflowHelpers, 'resolveParameter').mockResolvedValue($input.item?.json.str);
+
+			const found = await completions('{{ $json?.str?.| }}');
+
+			if (!found) throw new Error('Expected to find completions');
+
+			expect(found).toHaveLength(
+				extensions({ typeName: 'string' }).length +
+					natives({ typeName: 'string' }).length +
+					STRING_RECOMMENDED_OPTIONS.length,
+			);
+		});
+
+		test('should return completions for: {{ $input.first()?.json?.| }}', async () => {
+			vi.spyOn(workflowHelpers, 'resolveParameter').mockResolvedValue($input.item?.json);
+
+			const found = await completions('{{ $input.first()?.json?.| }}');
+
+			if (!found) throw new Error('Expected to find completions');
+
+			expect(found).toHaveLength(
+				Object.keys($input.item?.json ?? {}).length + extensions({ typeName: 'object' }).length,
+			);
+		});
+	});
+
 	describe('bracket access', () => {
 		const { $input } = mockProxy;
 

--- a/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/completions/datatype.completions.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/completions/datatype.completions.ts
@@ -1514,8 +1514,8 @@ export const objectGlobalOptions = () => {
 };
 
 const regexes = {
-	generalRef: /\$[^$'"]+\.(.*)/, // $input. or $json. or similar ones
-	selectorRef: /\$\(['"][\S\s]+['"]\)\.(.*)/, // $('nodeName').
+	generalRef: /\$[^$'"]+\.(.*)/, // $input. or $json. or $json?. or similar ones
+	selectorRef: /\$\(['"][\S\s]+['"]\)\??\.(.*)/, // $('nodeName'). or $('nodeName')?.
 
 	numberLiteral: /\((\d+)\.?(\d*)\)\.(.*)/, // (123). or (123.4).
 	singleQuoteStringLiteral: /('.*')\.([^'{\s])*/, // 'abc'.
@@ -1523,7 +1523,7 @@ const regexes = {
 	doubleQuoteStringLiteral: /(".*")\.([^"{\s])*/, // "abc".
 	dateLiteral: /\(?new Date\(\(?.*?\)\)?\.(.*)/, // new Date(). or (new Date()).
 	arrayLiteral: /\(?(\[.*\])\)?\.(.*)/, // [1, 2, 3].
-	indexedAccess: /([^"{\s]+\[.+\])\.(.*)/, // 'abc'[0]. or 'abc'.split('')[0] or similar ones
+	indexedAccess: /([^"{\s]+\[.+\])\??\.(.*)/, // 'abc'[0]. or 'abc'[0]?. or similar ones
 	objectLiteral: /\(\{.*\}\)\.(.*)/, // ({}).
 
 	mathGlobal: /Math\.(.*)/, // Math.

--- a/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/completions/utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/completions/utils.test.ts
@@ -9,6 +9,7 @@ import type { MockInstance } from 'vitest';
 import {
 	autocompletableNodeNames,
 	expressionWithFirstItem,
+	splitBaseTail,
 	stripExcessParens,
 	isAllowedInDotNotation,
 } from './utils';
@@ -186,6 +187,45 @@ describe('completion utils', () => {
 			}
 
 			expect(view.state.doc.toString()).toEqual(expected);
+		});
+	});
+
+	describe('splitBaseTail', () => {
+		const parse = (input: string) => javascriptLanguage.parser.parse(input);
+
+		describe('standard dot access', () => {
+			it('should return base and empty tail for: $json.', () => {
+				expect(splitBaseTail(parse('$json.'), '$json.')).toEqual(['$json', '']);
+			});
+
+			it('should return base and partial tail for: $json.fo', () => {
+				expect(splitBaseTail(parse('$json.fo'), '$json.fo')).toEqual(['$json', 'fo']);
+			});
+		});
+
+		describe('optional chaining access', () => {
+			it('should return base and empty tail for: $json?.', () => {
+				expect(splitBaseTail(parse('$json?.'), '$json?.')).toEqual(['$json', '']);
+			});
+
+			it('should return base and partial tail for: $json?.fo', () => {
+				expect(splitBaseTail(parse('$json?.fo'), '$json?.fo')).toEqual(['$json', 'fo']);
+			});
+
+			it('should handle chained optional access: $json?.foo.', () => {
+				expect(splitBaseTail(parse('$json?.foo.'), '$json?.foo.')).toEqual(['$json?.foo', '']);
+			});
+
+			it('should handle chained optional access with partial tail: $json?.foo.ba', () => {
+				expect(splitBaseTail(parse('$json?.foo.ba'), '$json?.foo.ba')).toEqual([
+					'$json?.foo',
+					'ba',
+				]);
+			});
+
+			it('should handle double optional chaining: $json?.foo?.', () => {
+				expect(splitBaseTail(parse('$json?.foo?.'), '$json?.foo?.')).toEqual(['$json?.foo', '']);
+			});
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/completions/utils.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/completions/utils.ts
@@ -27,11 +27,16 @@ export function splitBaseTail(syntaxTree: Tree, userInput: string): [string, str
 	switch (lastNode.type.name) {
 		case '.':
 			return [read(lastNode.parent, userInput).slice(0, -1), ''];
+		case '?.':
+			return [read(lastNode.parent, userInput).slice(0, -2), ''];
 		case 'MemberExpression':
 			return [read(lastNode.parent, userInput), read(lastNode, userInput)];
-		case 'PropertyName':
+		case 'PropertyName': {
 			const tail = read(lastNode, userInput);
-			return [read(lastNode.parent, userInput).slice(0, -(tail.length + 1)), tail];
+			const parentText = read(lastNode.parent, userInput);
+			const accessorLen = parentText.endsWith('?.' + tail) ? 2 : 1;
+			return [parentText.slice(0, -(tail.length + accessorLen)), tail];
+		}
 		default:
 			return ['', ''];
 	}
@@ -376,7 +381,8 @@ export const applyBracketAccessCompletion = (
 	to: number,
 ): void => {
 	const label = applyBracketAccess(completion.label);
-	const completionAtDot = view.state.sliceDoc(from - 1, from) === '.';
+	const completionAtOptionalDot = view.state.sliceDoc(from - 2, from) === '?.';
+	const completionAtDot = !completionAtOptionalDot && view.state.sliceDoc(from - 1, from) === '.';
 
 	view.dispatch({
 		...insertCompletionText(view.state, label, completionAtDot ? from - 1 : from, to),


### PR DESCRIPTION
## Summary

Handle optional chaining (?.) syntax in expression completions:
- Update splitBaseTail to recognize ?. node type and correctly extract base/tail
- Detect optional chaining in PropertyName accessor to get correct accessor length
- Fix applyBracketAccessCompletion to check ?. before . to prevent partial stripping
- Update datatype completion regexes to match expressions with optional chaining
- Add comprehensive unit and integration tests for optional chaining patterns

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2467/nit-expression-autocomplete-fails-for-optional-chaining-operator


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
