### PR TITLE
ci: Automatically approve and auto-merge node popularity

### DIFF
--- a/.github/workflows/util-approve-and-set-automerge.yml
+++ b/.github/workflows/util-approve-and-set-automerge.yml
@@ -1,0 +1,44 @@
+name: 'Util: Approve and set Automerge'
+
+run-name: Approve and automerge PR ${{ inputs.pull-request-number }}
+
+on:
+  workflow_call:
+    inputs:
+      pull-request-number:
+        type: string
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  approve-and-automerge:
+    if: |
+      inputs.pull-request-number != ''
+    runs-on: ubuntu-slim
+    environment: release
+    steps:
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        with:
+          app-id: ${{ secrets.N8N_RELEASE_HELPER_APP_ID }}
+          private-key: ${{ secrets.N8N_RELEASE_HELPER_PRIVATE_KEY }}
+
+      - name: Approve PR (as the App)
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          gh pr review "${{ inputs.pull-request-number }}" \
+            --approve \
+            --repo "${{ github.repository }}"
+
+      - name: Enable auto-merge (merge when checks pass)
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          gh pr merge "${{ inputs.pull-request-number }}" \
+            --auto \
+            --repo "${{ github.repository }}"

--- a/.github/workflows/util-update-node-popularity.yml
+++ b/.github/workflows/util-update-node-popularity.yml
@@ -99,5 +99,4 @@ jobs:
         run: |
           gh pr merge "${{ needs.update-popularity.outputs.pull-request-number }}" \
             --auto \
-            --squash \
             --repo "${{ github.repository }}"

--- a/.github/workflows/util-update-node-popularity.yml
+++ b/.github/workflows/util-update-node-popularity.yml
@@ -16,6 +16,8 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'schedule' && github.repository == 'n8n-io/n8n')
     runs-on: ubuntu-latest
+    outputs:
+      pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -48,6 +50,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check-changes.outputs.has_changes == 'true'
+        id: create-pr
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           branch-token: ${{ secrets.GITHUB_TOKEN }}
@@ -65,3 +68,37 @@ jobs:
           reviewers: Matsuuu
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+
+  approve-and-automerge:
+    if: |
+      needs.update-popularity.outputs.pull-request-number != '' &&
+      (github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'schedule' && github.repository == 'n8n-io/n8n'))
+    runs-on: ubuntu-slim
+    environment: release
+    needs: [update-popularity]
+    steps:
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        with:
+          app-id: ${{ secrets.N8N_RELEASE_HELPER_APP_ID }}
+          private-key: ${{ secrets.N8N_RELEASE_HELPER_PRIVATE_KEY }}
+
+      - name: Approve PR (as the App)
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          gh pr review "${{ needs.update-popularity.outputs.pull-request-number }}" \
+            --approve \
+            --repo "${{ github.repository }}"
+
+      - name: Enable auto-merge (merge when checks pass)
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          gh pr merge "${{ needs.update-popularity.outputs.pull-request-number }}" \
+            --auto \
+            --squash \
+            --delete-branch \
+            --repo "${{ github.repository }}"

--- a/.github/workflows/util-update-node-popularity.yml
+++ b/.github/workflows/util-update-node-popularity.yml
@@ -19,8 +19,17 @@ jobs:
     outputs:
       pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
     steps:
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        with:
+          app-id: ${{ secrets.N8N_ASSISTANT_APP_ID }}
+          private-key: ${{ secrets.N8N_ASSISTANT_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Setup Node.js and Dependencies
         uses: ./.github/actions/setup-nodejs
@@ -53,7 +62,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
-          branch-token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           commit-message: 'chore: Update node popularity data'
           title: 'chore: Update node popularity data'
           body: |

--- a/.github/workflows/util-update-node-popularity.yml
+++ b/.github/workflows/util-update-node-popularity.yml
@@ -100,5 +100,4 @@ jobs:
           gh pr merge "${{ needs.update-popularity.outputs.pull-request-number }}" \
             --auto \
             --squash \
-            --delete-branch \
             --repo "${{ github.repository }}"

--- a/.github/workflows/util-update-node-popularity.yml
+++ b/.github/workflows/util-update-node-popularity.yml
@@ -65,7 +65,6 @@ jobs:
           branch: update-node-popularity
           base: master
           delete-branch: true
-          reviewers: Matsuuu
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
 

--- a/.github/workflows/util-update-node-popularity.yml
+++ b/.github/workflows/util-update-node-popularity.yml
@@ -69,33 +69,12 @@ jobs:
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
 
   approve-and-automerge:
+    needs: [update-popularity]
     if: |
       needs.update-popularity.outputs.pull-request-number != '' &&
       (github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'schedule' && github.repository == 'n8n-io/n8n'))
-    runs-on: ubuntu-slim
-    environment: release
-    needs: [update-popularity]
-    steps:
-      - name: Generate GitHub App Token
-        id: generate-token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
-        with:
-          app-id: ${{ secrets.N8N_RELEASE_HELPER_APP_ID }}
-          private-key: ${{ secrets.N8N_RELEASE_HELPER_PRIVATE_KEY }}
-
-      - name: Approve PR (as the App)
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
-          gh pr review "${{ needs.update-popularity.outputs.pull-request-number }}" \
-            --approve \
-            --repo "${{ github.repository }}"
-
-      - name: Enable auto-merge (merge when checks pass)
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
-          gh pr merge "${{ needs.update-popularity.outputs.pull-request-number }}" \
-            --auto \
-            --repo "${{ github.repository }}"
+    uses: ./.github/workflows/util-approve-and-set-automerge.yml
+    secrets: inherit
+    with:
+      pull-request-number: ${{ needs.update-popularity.outputs.pull-request-number }}


### PR DESCRIPTION
## Summary

Introduces the new Release Helper App to approve automated process PR's and put them into merge queue.

See it in action here https://github.com/n8n-io/n8n/pull/26612

Note: Requires allowlisting branches this action can be run from in the `release` environment 

## Related Linear tickets, Github issues, and Community forum posts

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
