### PR TITLE
refactor: Move `getMcpWorkflow` to a separate method

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/execute-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/execute-workflow.tool.test.ts
@@ -1,5 +1,5 @@
 import { mockInstance } from '@n8n/backend-test-utils';
-import { User, WorkflowRepository } from '@n8n/db';
+import { User } from '@n8n/db';
 import {
 	CHAT_TRIGGER_NODE_TYPE,
 	FORM_TRIGGER_NODE_TYPE,
@@ -9,6 +9,7 @@ import {
 	type IWorkflowExecutionDataProcess,
 	UnexpectedError,
 } from 'n8n-workflow';
+import { v4 as uuid } from 'uuid';
 
 import { createWorkflow } from './mock.utils';
 import { WorkflowAccessError } from '../mcp.errors';
@@ -19,12 +20,10 @@ import { McpService } from '@/modules/mcp/mcp.service';
 import { Telemetry } from '@/telemetry';
 import { WorkflowRunner } from '@/workflow-runner';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
-import { v4 as uuid } from 'uuid';
 
 describe('execute-workflow MCP tool', () => {
 	const user = Object.assign(new User(), { id: 'user-1' });
 	let workflowFinderService: WorkflowFinderService;
-	let workflowRepository: WorkflowRepository;
 	let activeExecutions: ActiveExecutions;
 	let workflowRunner: WorkflowRunner;
 	let telemetry: Telemetry;
@@ -32,7 +31,6 @@ describe('execute-workflow MCP tool', () => {
 
 	beforeEach(() => {
 		workflowFinderService = mockInstance(WorkflowFinderService);
-		workflowRepository = mockInstance(WorkflowRepository);
 		activeExecutions = mockInstance(ActiveExecutions);
 		workflowRunner = mockInstance(WorkflowRunner);
 		telemetry = mockInstance(Telemetry, {
@@ -48,7 +46,6 @@ describe('execute-workflow MCP tool', () => {
 			const tool = createExecuteWorkflowTool(
 				user,
 				workflowFinderService,
-				workflowRepository,
 				activeExecutions,
 				workflowRunner,
 				telemetry,
@@ -69,205 +66,20 @@ describe('execute-workflow MCP tool', () => {
 
 	describe('handler tests', () => {
 		describe('workflow validation', () => {
-			test('throws error when workflow does not exist', async () => {
-				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(null);
-				(workflowRepository.findById as jest.Mock).mockResolvedValue(null);
-
-				await expect(
-					executeWorkflow(
-						user,
-						workflowFinderService,
-						workflowRepository,
-						activeExecutions,
-						workflowRunner,
-						mcpService,
-						'missing-workflow',
-						undefined,
-					),
-				).rejects.toThrow(WorkflowAccessError);
-
-				await expect(
-					executeWorkflow(
-						user,
-						workflowFinderService,
-						workflowRepository,
-						activeExecutions,
-						workflowRunner,
-						mcpService,
-						'missing-workflow',
-						undefined,
-					),
-				).rejects.toThrow("Workflow with ID 'missing-workflow' does not exist");
-			});
-
-			test('throws error with correct reason when workflow does not exist', async () => {
-				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(null);
-				(workflowRepository.findById as jest.Mock).mockResolvedValue(null);
-
-				await expect(
-					executeWorkflow(
-						user,
-						workflowFinderService,
-						workflowRepository,
-						activeExecutions,
-						workflowRunner,
-						mcpService,
-						'missing-workflow',
-						undefined,
-					),
-				).rejects.toMatchObject({
-					reason: 'workflow_does_not_exist',
-				});
-			});
-
-			test('throws error when user has no permission to access workflow', async () => {
-				(workflowRepository.existsBy as jest.Mock).mockResolvedValue(true);
+			test('propagates errors from getMcpWorkflow', async () => {
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(null);
 
 				await expect(
 					executeWorkflow(
 						user,
 						workflowFinderService,
-						workflowRepository,
 						activeExecutions,
 						workflowRunner,
 						mcpService,
-						'no-permission-workflow',
+						'any-workflow',
 						undefined,
 					),
 				).rejects.toThrow(WorkflowAccessError);
-
-				await expect(
-					executeWorkflow(
-						user,
-						workflowFinderService,
-						workflowRepository,
-						activeExecutions,
-						workflowRunner,
-						mcpService,
-						'no-permission-workflow',
-						undefined,
-					),
-				).rejects.toThrow("You don't have permission to execute workflow 'no-permission-workflow'");
-			});
-
-			test('throws error with correct reason when user has no permission', async () => {
-				(workflowRepository.existsBy as jest.Mock).mockResolvedValue(true);
-				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(null);
-
-				await expect(
-					executeWorkflow(
-						user,
-						workflowFinderService,
-						workflowRepository,
-						activeExecutions,
-						workflowRunner,
-						mcpService,
-						'no-permission-workflow',
-						undefined,
-					),
-				).rejects.toMatchObject({
-					reason: 'no_permission',
-				});
-			});
-
-			test('throws error when workflow is archived', async () => {
-				const workflow = createWorkflow({ activeVersionId: uuid(), isArchived: true });
-				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
-				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
-
-				await expect(
-					executeWorkflow(
-						user,
-						workflowFinderService,
-						workflowRepository,
-						activeExecutions,
-						workflowRunner,
-						mcpService,
-						'archived-workflow',
-						undefined,
-					),
-				).rejects.toThrow(WorkflowAccessError);
-
-				await expect(
-					executeWorkflow(
-						user,
-						workflowFinderService,
-						workflowRepository,
-						activeExecutions,
-						workflowRunner,
-						mcpService,
-						'archived-workflow',
-						undefined,
-					),
-				).rejects.toThrow("Workflow 'archived-workflow' is archived and cannot be executed");
-			});
-
-			test('throws error with correct reason when workflow is archived', async () => {
-				const workflow = createWorkflow({ activeVersionId: uuid(), isArchived: true });
-				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
-				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
-
-				await expect(
-					executeWorkflow(
-						user,
-						workflowFinderService,
-						workflowRepository,
-						activeExecutions,
-						workflowRunner,
-						mcpService,
-						'archived-workflow',
-						undefined,
-					),
-				).rejects.toMatchObject({
-					reason: 'workflow_archived',
-				});
-			});
-
-			test('throws error when workflow is not available in MCP', async () => {
-				const workflow = createWorkflow({
-					activeVersionId: uuid(),
-					settings: { availableInMCP: false },
-				});
-				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
-				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
-
-				await expect(
-					executeWorkflow(
-						user,
-						workflowFinderService,
-						workflowRepository,
-						activeExecutions,
-						workflowRunner,
-						mcpService,
-						'unavailable-workflow',
-						undefined,
-					),
-				).rejects.toThrow(WorkflowAccessError);
-			});
-
-			test('throws error with correct reason when workflow is not available in MCP', async () => {
-				const workflow = createWorkflow({
-					activeVersionId: uuid(),
-					settings: { availableInMCP: false },
-				});
-				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
-				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
-
-				await expect(
-					executeWorkflow(
-						user,
-						workflowFinderService,
-						workflowRepository,
-						activeExecutions,
-						workflowRunner,
-						mcpService,
-						'unavailable-workflow',
-						undefined,
-					),
-				).rejects.toMatchObject({
-					reason: 'not_available_in_mcp',
-				});
 			});
 
 			test('throws when production mode is requested for unpublished workflow', async () => {
@@ -281,7 +93,6 @@ describe('execute-workflow MCP tool', () => {
 					executeWorkflow(
 						user,
 						workflowFinderService,
-						workflowRepository,
 						activeExecutions,
 						workflowRunner,
 						mcpService,
@@ -309,7 +120,6 @@ describe('execute-workflow MCP tool', () => {
 				const result = await executeWorkflow(
 					user,
 					workflowFinderService,
-					workflowRepository,
 					activeExecutions,
 					workflowRunner,
 					mcpService,
@@ -348,7 +158,6 @@ describe('execute-workflow MCP tool', () => {
 				const result = await executeWorkflow(
 					user,
 					workflowFinderService,
-					workflowRepository,
 					activeExecutions,
 					workflowRunner,
 					mcpService,
@@ -382,14 +191,12 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
-				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 
 				await expect(
 					executeWorkflow(
 						user,
 						workflowFinderService,
-						workflowRepository,
 						activeExecutions,
 						workflowRunner,
 						mcpService,
@@ -402,7 +209,6 @@ describe('execute-workflow MCP tool', () => {
 					executeWorkflow(
 						user,
 						workflowFinderService,
-						workflowRepository,
 						activeExecutions,
 						workflowRunner,
 						mcpService,
@@ -427,14 +233,12 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
-				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 
 				await expect(
 					executeWorkflow(
 						user,
 						workflowFinderService,
-						workflowRepository,
 						activeExecutions,
 						workflowRunner,
 						mcpService,
@@ -461,14 +265,12 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
-				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 
 				await expect(
 					executeWorkflow(
 						user,
 						workflowFinderService,
-						workflowRepository,
 						activeExecutions,
 						workflowRunner,
 						mcpService,
@@ -495,7 +297,6 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
-				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-123');
 				(activeExecutions.getPostExecutePromise as jest.Mock).mockResolvedValue({
@@ -512,7 +313,6 @@ describe('execute-workflow MCP tool', () => {
 				const result = await executeWorkflow(
 					user,
 					workflowFinderService,
-					workflowRepository,
 					activeExecutions,
 					workflowRunner,
 					mcpService,
@@ -568,7 +368,6 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
-				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-456');
 				(activeExecutions.getPostExecutePromise as jest.Mock).mockResolvedValue({
@@ -579,7 +378,6 @@ describe('execute-workflow MCP tool', () => {
 				await executeWorkflow(
 					user,
 					workflowFinderService,
-					workflowRepository,
 					activeExecutions,
 					workflowRunner,
 					mcpService,
@@ -625,7 +423,6 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
-				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-789');
 				(activeExecutions.getPostExecutePromise as jest.Mock).mockResolvedValue({
@@ -636,7 +433,6 @@ describe('execute-workflow MCP tool', () => {
 				const result = await executeWorkflow(
 					user,
 					workflowFinderService,
-					workflowRepository,
 					activeExecutions,
 					workflowRunner,
 					mcpService,
@@ -685,7 +481,6 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
-				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-101');
 				(activeExecutions.getPostExecutePromise as jest.Mock).mockResolvedValue({
@@ -696,7 +491,6 @@ describe('execute-workflow MCP tool', () => {
 				const result = await executeWorkflow(
 					user,
 					workflowFinderService,
-					workflowRepository,
 					activeExecutions,
 					workflowRunner,
 					mcpService,
@@ -751,7 +545,6 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
-				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-success');
 				(activeExecutions.getPostExecutePromise as jest.Mock).mockResolvedValue({
@@ -768,7 +561,6 @@ describe('execute-workflow MCP tool', () => {
 				const result = await executeWorkflow(
 					user,
 					workflowFinderService,
-					workflowRepository,
 					activeExecutions,
 					workflowRunner,
 					mcpService,
@@ -800,7 +592,6 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
-				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-error');
 				(activeExecutions.getPostExecutePromise as jest.Mock).mockResolvedValue({
@@ -818,7 +609,6 @@ describe('execute-workflow MCP tool', () => {
 				const result = await executeWorkflow(
 					user,
 					workflowFinderService,
-					workflowRepository,
 					activeExecutions,
 					workflowRunner,
 					mcpService,
@@ -851,7 +641,6 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
-				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-data-error');
 				(activeExecutions.getPostExecutePromise as jest.Mock).mockResolvedValue({
@@ -869,7 +658,6 @@ describe('execute-workflow MCP tool', () => {
 				const result = await executeWorkflow(
 					user,
 					workflowFinderService,
-					workflowRepository,
 					activeExecutions,
 					workflowRunner,
 					mcpService,
@@ -902,7 +690,6 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
-				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-no-data');
 				(activeExecutions.getPostExecutePromise as jest.Mock).mockResolvedValue(undefined);
@@ -911,7 +698,6 @@ describe('execute-workflow MCP tool', () => {
 					executeWorkflow(
 						user,
 						workflowFinderService,
-						workflowRepository,
 						activeExecutions,
 						workflowRunner,
 						mcpService,
@@ -924,7 +710,6 @@ describe('execute-workflow MCP tool', () => {
 					executeWorkflow(
 						user,
 						workflowFinderService,
-						workflowRepository,
 						activeExecutions,
 						workflowRunner,
 						mcpService,
@@ -951,7 +736,6 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
-				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-no-inputs');
 				(activeExecutions.getPostExecutePromise as jest.Mock).mockResolvedValue({
@@ -962,7 +746,6 @@ describe('execute-workflow MCP tool', () => {
 				await executeWorkflow(
 					user,
 					workflowFinderService,
-					workflowRepository,
 					activeExecutions,
 					workflowRunner,
 					mcpService,
@@ -1002,7 +785,6 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
-				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-telemetry');
 				(activeExecutions.getPostExecutePromise as jest.Mock).mockResolvedValue({
@@ -1013,7 +795,6 @@ describe('execute-workflow MCP tool', () => {
 				const tool = createExecuteWorkflowTool(
 					user,
 					workflowFinderService,
-					workflowRepository,
 					activeExecutions,
 					workflowRunner,
 					telemetry,
@@ -1050,23 +831,20 @@ describe('execute-workflow MCP tool', () => {
 				);
 			});
 
-			test('tracks failed execution with tool handler and error reason', async () => {
+			test('tracks failed execution when workflow not found', async () => {
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(null);
-				(workflowRepository.findById as jest.Mock).mockResolvedValue(null);
 
 				const tool = createExecuteWorkflowTool(
 					user,
 					workflowFinderService,
-					workflowRepository,
 					activeExecutions,
 					workflowRunner,
 					telemetry,
 					mcpService,
 				);
 
-				// Call through the tool handler to test telemetry
 				await tool.handler(
-					{ workflowId: 'error-tracking', executionMode: 'production', inputs: undefined },
+					{ workflowId: 'non-existent', executionMode: 'production', inputs: undefined },
 					{} as any,
 				);
 
@@ -1076,38 +854,35 @@ describe('execute-workflow MCP tool', () => {
 						user_id: 'user-1',
 						tool_name: 'execute_workflow',
 						parameters: {
-							workflowId: 'error-tracking',
+							workflowId: 'non-existent',
 							executionMode: 'production',
 							inputs: undefined,
 						},
 						results: {
 							success: false,
 							error: expect.objectContaining({
-								message: "Workflow with ID 'error-tracking' does not exist",
+								message: "Workflow not found or you don't have permission to access it.",
 							}),
-							error_reason: 'workflow_does_not_exist',
+							error_reason: 'no_permission',
 						},
 					}),
 				);
 			});
 
-			test('tracks failed execution for no permission with error reason', async () => {
-				(workflowRepository.existsBy as jest.Mock).mockResolvedValue(true);
+			test('tracks failed execution when user lacks permission (same error as not found)', async () => {
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(null);
 
 				const tool = createExecuteWorkflowTool(
 					user,
 					workflowFinderService,
-					workflowRepository,
 					activeExecutions,
 					workflowRunner,
 					telemetry,
 					mcpService,
 				);
 
-				// Call through the tool handler to test telemetry
 				await tool.handler(
-					{ workflowId: 'no-perm-workflow', executionMode: 'production', inputs: undefined },
+					{ workflowId: 'no-permission-workflow', executionMode: 'production', inputs: undefined },
 					{} as any,
 				);
 
@@ -1117,14 +892,14 @@ describe('execute-workflow MCP tool', () => {
 						user_id: 'user-1',
 						tool_name: 'execute_workflow',
 						parameters: {
-							workflowId: 'no-perm-workflow',
+							workflowId: 'no-permission-workflow',
 							executionMode: 'production',
 							inputs: undefined,
 						},
 						results: {
 							success: false,
 							error: expect.objectContaining({
-								message: "You don't have permission to execute workflow 'no-perm-workflow'",
+								message: "Workflow not found or you don't have permission to access it.",
 							}),
 							error_reason: 'no_permission',
 						},
@@ -1167,7 +942,6 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
-				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-multi');
 				(activeExecutions.getPostExecutePromise as jest.Mock).mockResolvedValue({
@@ -1178,7 +952,6 @@ describe('execute-workflow MCP tool', () => {
 				await executeWorkflow(
 					user,
 					workflowFinderService,
-					workflowRepository,
 					activeExecutions,
 					workflowRunner,
 					mcpService,
@@ -1227,14 +1000,12 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
-				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-queue');
 
 				const result = await executeWorkflow(
 					user,
 					workflowFinderService,
-					workflowRepository,
 					activeExecutions,
 					workflowRunner,
 					queueModeMcpService,
@@ -1265,14 +1036,12 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
-				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-mcp-meta');
 
 				await executeWorkflow(
 					user,
 					workflowFinderService,
-					workflowRepository,
 					activeExecutions,
 					workflowRunner,
 					queueModeMcpService,
@@ -1303,7 +1072,6 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
-				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-regular');
 				(activeExecutions.getPostExecutePromise as jest.Mock).mockResolvedValue({
@@ -1314,7 +1082,6 @@ describe('execute-workflow MCP tool', () => {
 				await executeWorkflow(
 					user,
 					workflowFinderService,
-					workflowRepository,
 					activeExecutions,
 					workflowRunner,
 					mcpService,
@@ -1344,7 +1111,6 @@ describe('execute-workflow MCP tool', () => {
 						} as INode,
 					],
 				});
-				(workflowRepository.findById as jest.Mock).mockResolvedValue(workflow);
 				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
 				(workflowRunner.run as jest.Mock).mockResolvedValue('exec-regular-2');
 				(activeExecutions.getPostExecutePromise as jest.Mock).mockResolvedValue({
@@ -1355,7 +1121,6 @@ describe('execute-workflow MCP tool', () => {
 				await executeWorkflow(
 					user,
 					workflowFinderService,
-					workflowRepository,
 					activeExecutions,
 					workflowRunner,
 					mcpService,

--- a/packages/cli/src/modules/mcp/__tests__/get-workflow-details.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/get-workflow-details.tool.test.ts
@@ -97,63 +97,26 @@ describe('get-workflow-details MCP tool', () => {
 			expect(payload.workflow.canExecute).toBe(true);
 		});
 
-		test('throws for not found/archived/unavailable workflow', async () => {
-			const archived = createWorkflow({ activeVersionId: uuid(), isArchived: true });
-			const unavailable = createWorkflow({
-				activeVersionId: uuid(),
-				settings: { availableInMCP: false },
-			});
-
+		test('propagates errors from workflow validation', async () => {
 			const credentialsService = mockInstance(CredentialsService, {});
 			const endpoints = { webhook: 'webhook', webhookTest: 'webhook-test' };
 
-			const wfFinder1 = mockInstance(WorkflowFinderService, {
+			const wfFinder = mockInstance(WorkflowFinderService, {
 				findWorkflowForUser: jest.fn().mockResolvedValue(null),
 			});
-			await expect(
-				getWorkflowDetails(
-					user,
-					baseWebhookUrl,
-					wfFinder1,
-					credentialsService,
-					endpoints,
-					roleService,
-					projectService,
-					{ workflowId: 'missing' },
-				),
-			).rejects.toThrow('Workflow not found');
 
-			const wfFinder2 = mockInstance(WorkflowFinderService, {
-				findWorkflowForUser: jest.fn().mockResolvedValue(archived),
-			});
 			await expect(
 				getWorkflowDetails(
 					user,
 					baseWebhookUrl,
-					wfFinder2,
+					wfFinder,
 					credentialsService,
 					endpoints,
 					roleService,
 					projectService,
-					{ workflowId: 'archived' },
+					{ workflowId: 'any-id' },
 				),
-			).rejects.toThrow('Workflow not found');
-
-			const wfFinder3 = mockInstance(WorkflowFinderService, {
-				findWorkflowForUser: jest.fn().mockResolvedValue(unavailable),
-			});
-			await expect(
-				getWorkflowDetails(
-					user,
-					baseWebhookUrl,
-					wfFinder3,
-					credentialsService,
-					endpoints,
-					roleService,
-					projectService,
-					{ workflowId: 'unavailable' },
-				),
-			).rejects.toThrow('Workflow not found');
+			).rejects.toThrow();
 		});
 
 		test('returns null activeVersion for unpublished workflows', async () => {

--- a/packages/cli/src/modules/mcp/__tests__/mcp.service.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.service.test.ts
@@ -1,7 +1,7 @@
 import type { Logger } from '@n8n/backend-common';
 import { mockInstance, mockLogger } from '@n8n/backend-test-utils';
 import { ExecutionsConfig, GlobalConfig } from '@n8n/config';
-import { User, WorkflowRepository } from '@n8n/db';
+import { User } from '@n8n/db';
 import { InstanceSettings } from 'n8n-core';
 import type { IRun } from 'n8n-workflow';
 import { createEmptyRunExecutionData, ManualExecutionCancelledError } from 'n8n-workflow';
@@ -42,7 +42,6 @@ describe('McpService', () => {
 			executionsConfig,
 			instanceSettings,
 			mockInstance(WorkflowFinderService),
-			mockInstance(WorkflowRepository),
 			mockInstance(WorkflowService),
 			mockInstance(UrlService),
 			mockInstance(CredentialsService),
@@ -75,7 +74,6 @@ describe('McpService', () => {
 				queueExecutionsConfig,
 				instanceSettings,
 				mockInstance(WorkflowFinderService),
-				mockInstance(WorkflowRepository),
 				mockInstance(WorkflowService),
 				mockInstance(UrlService),
 				mockInstance(CredentialsService),
@@ -269,7 +267,6 @@ describe('McpService', () => {
 				executionsConfig,
 				instanceSettings,
 				mockInstance(WorkflowFinderService),
-				mockInstance(WorkflowRepository),
 				mockInstance(WorkflowService),
 				mockInstance(UrlService),
 				mockInstance(CredentialsService),
@@ -304,7 +301,6 @@ describe('McpService', () => {
 				executionsConfig,
 				instanceSettings,
 				mockInstance(WorkflowFinderService),
-				mockInstance(WorkflowRepository),
 				mockInstance(WorkflowService),
 				mockInstance(UrlService),
 				mockInstance(CredentialsService),

--- a/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
@@ -220,46 +220,14 @@ describe('update-workflow MCP tool', () => {
 			);
 		});
 
-		test('returns error when workflow not found', async () => {
+		test('propagates errors from getMcpWorkflow', async () => {
 			findWorkflowMock.mockResolvedValue(null);
 
 			const result = await callHandler({ workflowId: 'wf-missing', code: 'const wf = ...' });
 
 			const response = parseResult(result);
 			expect(result.isError).toBe(true);
-			expect(response.error).toContain('not found');
-		});
-
-		test('returns error when workflow is not available in MCP', async () => {
-			findWorkflowMock.mockResolvedValue(
-				Object.assign(new WorkflowEntity(), {
-					id: 'wf-1',
-					name: 'Non-MCP Workflow',
-					settings: { availableInMCP: false },
-				}),
-			);
-
-			const result = await callHandler({ workflowId: 'wf-1', code: 'const wf = ...' });
-
-			const response = parseResult(result);
-			expect(result.isError).toBe(true);
-			expect(response.error).toContain('not available in MCP');
-		});
-
-		test('returns error when workflow has no settings', async () => {
-			findWorkflowMock.mockResolvedValue(
-				Object.assign(new WorkflowEntity(), {
-					id: 'wf-1',
-					name: 'No Settings Workflow',
-					settings: null,
-				}),
-			);
-
-			const result = await callHandler({ workflowId: 'wf-1', code: 'const wf = ...' });
-
-			const response = parseResult(result);
-			expect(result.isError).toBe(true);
-			expect(response.error).toContain('not available in MCP');
+			expect(response.error).toBe("Workflow not found or you don't have permission to access it.");
 		});
 
 		test('returns error when parse fails', async () => {

--- a/packages/cli/src/modules/mcp/__tests__/workflow-validation.utils.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/workflow-validation.utils.test.ts
@@ -1,0 +1,247 @@
+import { mockInstance } from '@n8n/backend-test-utils';
+import { User } from '@n8n/db';
+
+import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
+
+import { createWorkflow } from './mock.utils';
+import { WorkflowAccessError } from '../mcp.errors';
+import { getMcpWorkflow } from '../tools/workflow-validation.utils';
+
+describe('getMcpWorkflow', () => {
+	const user = Object.assign(new User(), { id: 'user-1' });
+
+	describe('permission checks', () => {
+		test('throws generic error when workflow not found (does not reveal if workflow exists)', async () => {
+			const workflowFinderService = mockInstance(WorkflowFinderService, {
+				findWorkflowForUser: jest.fn().mockResolvedValue(null),
+			});
+
+			await expect(
+				getMcpWorkflow('non-existent-id', user, ['workflow:read'], workflowFinderService),
+			).rejects.toThrow(WorkflowAccessError);
+
+			await expect(
+				getMcpWorkflow('non-existent-id', user, ['workflow:read'], workflowFinderService),
+			).rejects.toThrow("Workflow not found or you don't have permission to access it.");
+		});
+
+		test('throws generic error when user lacks permission (does not reveal workflow exists)', async () => {
+			const workflowFinderService = mockInstance(WorkflowFinderService, {
+				findWorkflowForUser: jest.fn().mockResolvedValue(null),
+			});
+
+			await expect(
+				getMcpWorkflow('existing-but-no-access', user, ['workflow:execute'], workflowFinderService),
+			).rejects.toThrow("Workflow not found or you don't have permission to access it.");
+		});
+
+		test('returns no_permission reason for both not-found and no-permission cases', async () => {
+			const workflowFinderService = mockInstance(WorkflowFinderService, {
+				findWorkflowForUser: jest.fn().mockResolvedValue(null),
+			});
+
+			await expect(
+				getMcpWorkflow('any-id', user, ['workflow:read'], workflowFinderService),
+			).rejects.toMatchObject({
+				reason: 'no_permission',
+			});
+		});
+
+		test('passes correct scope to workflowFinderService', async () => {
+			const workflow = createWorkflow({ settings: { availableInMCP: true } });
+			const findWorkflowForUser = jest.fn().mockResolvedValue(workflow);
+			const workflowFinderService = mockInstance(WorkflowFinderService, {
+				findWorkflowForUser,
+			});
+
+			await getMcpWorkflow('wf-1', user, ['workflow:execute'], workflowFinderService);
+
+			expect(findWorkflowForUser).toHaveBeenCalledWith('wf-1', user, ['workflow:execute'], {
+				includeActiveVersion: undefined,
+			});
+		});
+
+		test('passes includeActiveVersion option to workflowFinderService', async () => {
+			const workflow = createWorkflow({ settings: { availableInMCP: true } });
+			const findWorkflowForUser = jest.fn().mockResolvedValue(workflow);
+			const workflowFinderService = mockInstance(WorkflowFinderService, {
+				findWorkflowForUser,
+			});
+
+			await getMcpWorkflow('wf-1', user, ['workflow:publish'], workflowFinderService, {
+				includeActiveVersion: true,
+			});
+
+			expect(findWorkflowForUser).toHaveBeenCalledWith('wf-1', user, ['workflow:publish'], {
+				includeActiveVersion: true,
+			});
+		});
+	});
+
+	describe('archived workflow checks', () => {
+		test('throws specific error for archived workflows', async () => {
+			const workflow = createWorkflow({ isArchived: true });
+			const workflowFinderService = mockInstance(WorkflowFinderService, {
+				findWorkflowForUser: jest.fn().mockResolvedValue(workflow),
+			});
+
+			await expect(
+				getMcpWorkflow('wf-1', user, ['workflow:read'], workflowFinderService),
+			).rejects.toThrow(WorkflowAccessError);
+
+			await expect(
+				getMcpWorkflow('wf-1', user, ['workflow:read'], workflowFinderService),
+			).rejects.toThrow("Workflow 'wf-1' is archived and cannot be accessed.");
+		});
+
+		test('returns workflow_archived reason for archived workflows', async () => {
+			const workflow = createWorkflow({ isArchived: true });
+			const workflowFinderService = mockInstance(WorkflowFinderService, {
+				findWorkflowForUser: jest.fn().mockResolvedValue(workflow),
+			});
+
+			await expect(
+				getMcpWorkflow('wf-1', user, ['workflow:read'], workflowFinderService),
+			).rejects.toMatchObject({
+				reason: 'workflow_archived',
+			});
+		});
+	});
+
+	describe('MCP availability checks', () => {
+		test('throws error when workflow is not available in MCP', async () => {
+			const workflow = createWorkflow({ settings: { availableInMCP: false } });
+			const workflowFinderService = mockInstance(WorkflowFinderService, {
+				findWorkflowForUser: jest.fn().mockResolvedValue(workflow),
+			});
+
+			await expect(
+				getMcpWorkflow('wf-1', user, ['workflow:read'], workflowFinderService),
+			).rejects.toThrow(WorkflowAccessError);
+
+			await expect(
+				getMcpWorkflow('wf-1', user, ['workflow:read'], workflowFinderService),
+			).rejects.toThrow('Workflow is not available in MCP.');
+		});
+
+		test('throws error when workflow settings is undefined', async () => {
+			const workflow = createWorkflow({ settings: undefined });
+			const workflowFinderService = mockInstance(WorkflowFinderService, {
+				findWorkflowForUser: jest.fn().mockResolvedValue(workflow),
+			});
+
+			await expect(
+				getMcpWorkflow('wf-1', user, ['workflow:read'], workflowFinderService),
+			).rejects.toThrow('not available in MCP');
+		});
+
+		test('throws error when availableInMCP is not set', async () => {
+			const workflow = createWorkflow({ settings: {} });
+			const workflowFinderService = mockInstance(WorkflowFinderService, {
+				findWorkflowForUser: jest.fn().mockResolvedValue(workflow),
+			});
+
+			await expect(
+				getMcpWorkflow('wf-1', user, ['workflow:read'], workflowFinderService),
+			).rejects.toThrow('not available in MCP');
+		});
+
+		test('returns not_available_in_mcp reason', async () => {
+			const workflow = createWorkflow({ settings: { availableInMCP: false } });
+			const workflowFinderService = mockInstance(WorkflowFinderService, {
+				findWorkflowForUser: jest.fn().mockResolvedValue(workflow),
+			});
+
+			await expect(
+				getMcpWorkflow('wf-1', user, ['workflow:read'], workflowFinderService),
+			).rejects.toMatchObject({
+				reason: 'not_available_in_mcp',
+			});
+		});
+	});
+
+	describe('successful retrieval', () => {
+		test('returns workflow when all checks pass', async () => {
+			const workflow = createWorkflow({
+				id: 'wf-123',
+				name: 'Test Workflow',
+				settings: { availableInMCP: true },
+				isArchived: false,
+			});
+			const workflowFinderService = mockInstance(WorkflowFinderService, {
+				findWorkflowForUser: jest.fn().mockResolvedValue(workflow),
+			});
+
+			const result = await getMcpWorkflow('wf-123', user, ['workflow:read'], workflowFinderService);
+
+			expect(result).toBe(workflow);
+			expect(result.id).toBe('wf-123');
+			expect(result.name).toBe('Test Workflow');
+		});
+
+		test('works with different scopes', async () => {
+			const workflow = createWorkflow({ settings: { availableInMCP: true } });
+			const findWorkflowForUser = jest.fn().mockResolvedValue(workflow);
+			const workflowFinderService = mockInstance(WorkflowFinderService, {
+				findWorkflowForUser,
+			});
+
+			// Test with workflow:read
+			await getMcpWorkflow('wf-1', user, ['workflow:read'], workflowFinderService);
+			expect(findWorkflowForUser).toHaveBeenLastCalledWith(
+				'wf-1',
+				user,
+				['workflow:read'],
+				expect.any(Object),
+			);
+
+			// Test with workflow:execute
+			await getMcpWorkflow('wf-1', user, ['workflow:execute'], workflowFinderService);
+			expect(findWorkflowForUser).toHaveBeenLastCalledWith(
+				'wf-1',
+				user,
+				['workflow:execute'],
+				expect.any(Object),
+			);
+
+			// Test with workflow:publish
+			await getMcpWorkflow('wf-1', user, ['workflow:publish'], workflowFinderService);
+			expect(findWorkflowForUser).toHaveBeenLastCalledWith(
+				'wf-1',
+				user,
+				['workflow:publish'],
+				expect.any(Object),
+			);
+		});
+	});
+
+	describe('validation order', () => {
+		test('checks permission before archive status', async () => {
+			const workflowFinderService = mockInstance(WorkflowFinderService, {
+				findWorkflowForUser: jest.fn().mockResolvedValue(null),
+			});
+
+			await expect(
+				getMcpWorkflow('archived-workflow', user, ['workflow:read'], workflowFinderService),
+			).rejects.toMatchObject({
+				reason: 'no_permission',
+			});
+		});
+
+		test('checks archive status before MCP availability', async () => {
+			const workflow = createWorkflow({
+				isArchived: true,
+				settings: { availableInMCP: false },
+			});
+			const workflowFinderService = mockInstance(WorkflowFinderService, {
+				findWorkflowForUser: jest.fn().mockResolvedValue(workflow),
+			});
+
+			await expect(
+				getMcpWorkflow('wf-1', user, ['workflow:read'], workflowFinderService),
+			).rejects.toMatchObject({
+				reason: 'workflow_archived',
+			});
+		});
+	});
+});

--- a/packages/cli/src/modules/mcp/mcp.service.ts
+++ b/packages/cli/src/modules/mcp/mcp.service.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { Logger } from '@n8n/backend-common';
 import { ExecutionsConfig, GlobalConfig } from '@n8n/config';
-import { User, WorkflowRepository } from '@n8n/db';
+import { User } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { InstanceSettings } from 'n8n-core';
 import {
@@ -59,7 +59,6 @@ export class McpService {
 		private readonly executionsConfig: ExecutionsConfig,
 		_instanceSettings: InstanceSettings,
 		private readonly workflowFinderService: WorkflowFinderService,
-		private readonly workflowRepository: WorkflowRepository,
 		private readonly workflowService: WorkflowService,
 		private readonly urlService: UrlService,
 		private readonly credentialsService: CredentialsService,
@@ -101,7 +100,6 @@ export class McpService {
 		const executeWorkflowTool = createExecuteWorkflowTool(
 			user,
 			this.workflowFinderService,
-			this.workflowRepository,
 			this.activeExecutions,
 			this.workflowRunner,
 			this.telemetry,

--- a/packages/cli/src/modules/mcp/tools/execute-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/execute-workflow.tool.ts
@@ -1,5 +1,5 @@
 import { Time } from '@n8n/constants';
-import type { User, WorkflowRepository } from '@n8n/db';
+import type { User } from '@n8n/db';
 import {
 	CHAT_TRIGGER_NODE_TYPE,
 	FORM_TRIGGER_NODE_TYPE,
@@ -32,6 +32,7 @@ import type {
 	UserCalledMCPToolEventPayload,
 } from '../mcp.types';
 import { findMcpSupportedTrigger } from '../mcp.utils';
+import { getMcpWorkflow, type FoundWorkflow } from './workflow-validation.utils';
 
 import type { ActiveExecutions } from '@/active-executions';
 import type { McpService } from '@/modules/mcp/mcp.service';
@@ -41,6 +42,8 @@ import type { WorkflowFinderService } from '@/workflows/workflow-finder.service'
 
 const WORKFLOW_EXECUTION_TIMEOUT_MS = 5 * Time.minutes.toMilliseconds; // 5 minutes
 const ERROR_KEYS_TO_IGNORE = ['stack', 'node'];
+
+export { type FoundWorkflow };
 
 const inputSchema = z.object({
 	workflowId: z.string().describe('The ID of the workflow to execute'),
@@ -94,8 +97,6 @@ type ExecuteWorkflowOutput = {
 	error?: unknown;
 };
 
-type FoundWorkflow = NonNullable<Awaited<ReturnType<WorkflowFinderService['findWorkflowForUser']>>>;
-
 const outputSchema = {
 	success: z.boolean(),
 	executionId: z.string().nullable().optional(),
@@ -106,7 +107,6 @@ const outputSchema = {
 export const createExecuteWorkflowTool = (
 	user: User,
 	workflowFinderService: WorkflowFinderService,
-	workflowRepository: WorkflowRepository,
 	activeExecutions: ActiveExecutions,
 	workflowRunner: WorkflowRunner,
 	telemetry: Telemetry,
@@ -136,7 +136,6 @@ export const createExecuteWorkflowTool = (
 			const output = await executeWorkflow(
 				user,
 				workflowFinderService,
-				workflowRepository,
 				activeExecutions,
 				workflowRunner,
 				mcpService,
@@ -213,7 +212,6 @@ export const createExecuteWorkflowTool = (
 export const executeWorkflow = async (
 	user: User,
 	workflowFinderService: WorkflowFinderService,
-	workflowRepository: WorkflowRepository,
 	activeExecutions: ActiveExecutions,
 	workflowRunner: WorkflowRunner,
 	mcpService: McpService,
@@ -221,11 +219,12 @@ export const executeWorkflow = async (
 	inputs?: z.infer<typeof inputSchema>['inputs'],
 	executionMode: z.infer<typeof inputSchema>['executionMode'] = 'production',
 ): Promise<ExecuteWorkflowOutput> => {
-	const workflow = await getExecutableWorkflow(
-		workflowFinderService,
-		workflowRepository,
-		user,
+	const workflow = await getMcpWorkflow(
 		workflowId,
+		user,
+		['workflow:execute'],
+		workflowFinderService,
+		{ includeActiveVersion: true },
 	);
 	const runData = await buildRunData(
 		workflow,
@@ -246,53 +245,6 @@ export const executeWorkflow = async (
 		result: data.data.resultData,
 		error: data.data.resultData?.error,
 	};
-};
-
-const getExecutableWorkflow = async (
-	workflowFinderService: WorkflowFinderService,
-	workflowRepository: WorkflowRepository,
-	user: User,
-	workflowId: string,
-): Promise<FoundWorkflow> => {
-	// Check if user has permission to access the workflow
-	const workflow = await workflowFinderService.findWorkflowForUser(
-		workflowId,
-		user,
-		['workflow:execute'],
-		{ includeActiveVersion: true },
-	);
-
-	if (!workflow) {
-		const workflowExists = await workflowRepository.existsBy({ id: workflowId });
-		if (!workflowExists) {
-			throw new WorkflowAccessError(
-				`Workflow with ID '${workflowId}' does not exist`,
-				'workflow_does_not_exist',
-			);
-		}
-
-		// Workflow exists but user doesn't have permission
-		throw new WorkflowAccessError(
-			`You don't have permission to execute workflow '${workflowId}'`,
-			'no_permission',
-		);
-	}
-
-	if (workflow.isArchived) {
-		throw new WorkflowAccessError(
-			`Workflow '${workflowId}' is archived and cannot be executed`,
-			'workflow_archived',
-		);
-	}
-
-	if (!workflow.settings?.availableInMCP) {
-		throw new WorkflowAccessError(
-			'Workflow is not available for execution via MCP. Enable access in the workflow settings to make it available.',
-			'not_available_in_mcp',
-		);
-	}
-
-	return workflow;
 };
 
 const getVersionDataForExecution = (

--- a/packages/cli/src/modules/mcp/tools/get-workflow-details.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/get-workflow-details.tool.ts
@@ -1,5 +1,4 @@
 import type { User } from '@n8n/db';
-import { UserError } from 'n8n-workflow';
 import z from 'zod';
 
 import { SUPPORTED_MCP_TRIGGERS, USER_CALLED_MCP_TOOL_EVENT } from '../mcp.constants';
@@ -10,6 +9,7 @@ import type {
 } from '../mcp.types';
 import { workflowDetailsOutputSchema } from './schemas';
 import { getTriggerDetails, type WebhookEndpoints } from './webhook-utils';
+import { getMcpWorkflow } from './workflow-validation.utils';
 
 import type { CredentialsService } from '@/credentials/credentials.service';
 import type { ProjectService } from '@/services/project.service.ee';
@@ -111,15 +111,13 @@ export async function getWorkflowDetails(
 	projectService: ProjectService,
 	{ workflowId }: { workflowId: string },
 ): Promise<WorkflowDetailsResult> {
-	const workflow = await workflowFinderService.findWorkflowForUser(
+	const workflow = await getMcpWorkflow(
 		workflowId,
 		user,
 		['workflow:read'],
+		workflowFinderService,
 		{ includeActiveVersion: true },
 	);
-	if (!workflow || workflow.isArchived || !workflow.settings?.availableInMCP) {
-		throw new UserError('Workflow not found');
-	}
 
 	// Compute user scopes for this workflow
 	const projectRelations = await projectService.getProjectRelationsForUser(user);

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
@@ -10,6 +10,8 @@ import type { Telemetry } from '@/telemetry';
 import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import type { WorkflowService } from '@/workflows/workflow.service';
 
+import { getMcpWorkflow } from '../workflow-validation.utils';
+
 const inputSchema = {
 	workflowId: z.string().describe('The ID of the workflow to update'),
 	code: z
@@ -74,19 +76,7 @@ export const createUpdateWorkflowTool = (
 
 		try {
 			// Fetch the workflow to check if it's available in MCP
-			const existingWorkflow = await workflowFinderService.findWorkflowForUser(workflowId, user, [
-				'workflow:update',
-			]);
-
-			if (!existingWorkflow) {
-				throw new Error("Workflow not found or you don't have permission to update it.");
-			}
-
-			if (!existingWorkflow.settings?.availableInMCP) {
-				throw new Error(
-					'This workflow is not available in MCP. Only workflows created via MCP can be updated.',
-				);
-			}
+			await getMcpWorkflow(workflowId, user, ['workflow:update'], workflowFinderService);
 
 			const { ParseValidateHandler, stripImportStatements } = await import(
 				'@n8n/ai-workflow-builder'

--- a/packages/cli/src/modules/mcp/tools/workflow-validation.utils.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-validation.utils.ts
@@ -1,0 +1,55 @@
+import type { User } from '@n8n/db';
+import type { Scope } from '@n8n/permissions';
+
+import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
+
+import { WorkflowAccessError } from '../mcp.errors';
+
+export type FoundWorkflow = NonNullable<
+	Awaited<ReturnType<WorkflowFinderService['findWorkflowForUser']>>
+>;
+
+export type GetMcpWorkflowOptions = {
+	includeActiveVersion?: boolean;
+};
+
+/**
+ * Validates and retrieves a workflow for MCP operations.
+ * Performs permission, archive, and MCP availability checks.
+ *
+ * @throws WorkflowAccessError with appropriate reason if validation fails
+ */
+export async function getMcpWorkflow(
+	workflowId: string,
+	user: User,
+	scopes: Scope[],
+	workflowFinderService: WorkflowFinderService,
+	options?: GetMcpWorkflowOptions,
+): Promise<FoundWorkflow> {
+	const workflow = await workflowFinderService.findWorkflowForUser(workflowId, user, scopes, {
+		includeActiveVersion: options?.includeActiveVersion,
+	});
+
+	if (!workflow) {
+		throw new WorkflowAccessError(
+			"Workflow not found or you don't have permission to access it.",
+			'no_permission',
+		);
+	}
+
+	if (workflow.isArchived) {
+		throw new WorkflowAccessError(
+			`Workflow '${workflowId}' is archived and cannot be accessed.`,
+			'workflow_archived',
+		);
+	}
+
+	if (!workflow.settings?.availableInMCP) {
+		throw new WorkflowAccessError(
+			'Workflow is not available in MCP. Enable MCP access in workflow settings.',
+			'not_available_in_mcp',
+		);
+	}
+
+	return workflow;
+}


### PR DESCRIPTION
## Summary

- Move MCP workflow validation to a separate method and use it for all the tools where applicable
- Move all the validation tests to a separate workflow validation test

One main change: we no longer disclose whether the workflow doesn’t exist or the user lacks the required scope, aligning this behavior with how our internal services handle it.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
