### PR TITLE
fix(Filter node): misleading description

### DIFF
--- a/packages/nodes-base/nodes/Filter/Filter.node.ts
+++ b/packages/nodes-base/nodes/Filter/Filter.node.ts
@@ -12,7 +12,7 @@ export class Filter extends VersionedNodeType {
 			icon: 'fa:filter',
 			iconColor: 'light-blue',
 			group: ['transform'],
-			description: 'Remove items matching a condition',
+			description: 'Keep items matching a condition',
 			defaultVersion: 2.3,
 		};
 

--- a/packages/nodes-base/nodes/Filter/Filter.node.ts
+++ b/packages/nodes-base/nodes/Filter/Filter.node.ts
@@ -12,7 +12,7 @@ export class Filter extends VersionedNodeType {
 			icon: 'fa:filter',
 			iconColor: 'light-blue',
 			group: ['transform'],
-			description: 'Keep items matching a condition',
+			description: 'Keep only items matching a condition',
 			defaultVersion: 2.3,
 		};
 


### PR DESCRIPTION
Fixes #26564. Updates the Filter node description from 'Remove items matching a condition' to 'Keep items matching a condition' to accurately reflect the node's behavior.