### PR TITLE
fix(editor): Hide AI context menu option when AI builder is not licensed

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.test.ts
@@ -69,6 +69,7 @@ describe('AI Assistant store', () => {
 		settingsStore.setSettings(
 			merge({}, defaultSettings, {
 				posthog: DEFAULT_POSTHOG_SETTINGS,
+				aiAssistant: { enabled: true, setup: true },
 			}),
 		);
 		window.posthog = {

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
@@ -159,6 +159,7 @@ describe('AI Builder store', () => {
 		settingsStore.setSettings(
 			merge({}, defaultSettings, {
 				posthog: DEFAULT_POSTHOG_SETTINGS,
+				aiAssistant: { enabled: true, setup: true },
 			}),
 		);
 		window.posthog = {

--- a/packages/frontend/editor-ui/src/features/ai/assistant/chatPanel.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/chatPanel.store.test.ts
@@ -15,9 +15,12 @@ import { ASSISTANT_ENABLED_VIEWS, BUILDER_ENABLED_VIEWS } from './constants';
 import { VIEWS } from '@/app/constants';
 import { reactive, nextTick } from 'vue';
 import { mockedStore } from '@/__tests__/utils';
+import { useSettingsStore } from '@/app/stores/settings.store';
+import { defaultSettings } from '@/__tests__/defaults';
 import type { ICredentialType } from 'n8n-workflow';
 import type { ChatRequest } from '@/features/ai/assistant/assistant.types';
 import type { ChatUI } from '@n8n/design-system/types/assistant';
+import merge from 'lodash-es/merge';
 
 // Mock vue-router
 const mockRoute = reactive({ name: VIEWS.WORKFLOW });
@@ -48,6 +51,13 @@ describe('chatPanel.store', () => {
 			createTestingPinia({
 				createSpy: vi.fn,
 				stubActions: false, // Don't stub actions so actual store logic runs
+			}),
+		);
+
+		const settingsStore = useSettingsStore();
+		settingsStore.setSettings(
+			merge({}, defaultSettings, {
+				aiAssistant: { enabled: true, setup: true },
 			}),
 		);
 

--- a/packages/frontend/editor-ui/src/features/ai/assistant/chatPanel.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/chatPanel.store.ts
@@ -63,6 +63,8 @@ export const useChatPanelStore = defineStore(STORES.CHAT_PANEL, () => {
 
 	// Actions
 	async function open(options?: { mode?: ChatPanelMode; showCoachmark?: boolean }) {
+		if (!settingsStore.isAiAssistantOrBuilderEnabled) return;
+
 		const mode = options?.mode ? resolveMode(options.mode) : undefined;
 		const showCoachmark = options?.showCoachmark ?? true;
 

--- a/packages/frontend/editor-ui/src/features/shared/contextMenu/composables/useContextMenuItems.ts
+++ b/packages/frontend/editor-ui/src/features/shared/contextMenu/composables/useContextMenuItems.ts
@@ -6,6 +6,7 @@ import {
 } from '@/app/constants';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
+import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import {
@@ -49,6 +50,7 @@ type Item = ActionDropdownItem<ContextMenuAction>;
 
 export function useContextMenuItems(targetNodeIds: ComputedRef<string[]>): ComputedRef<Item[]> {
 	const uiStore = useUIStore();
+	const settingsStore = useSettingsStore();
 	const nodeTypesStore = useNodeTypesStore();
 	const workflowsStore = useWorkflowsStore();
 	const workflowDocumentStore = injectWorkflowDocumentStore();
@@ -164,6 +166,7 @@ export function useContextMenuItems(targetNodeIds: ComputedRef<string[]>): Compu
 
 		const aiActions: Item[] = [
 			!onlyStickies &&
+				settingsStore.isAiAssistantOrBuilderEnabled &&
 				focusedNodesStore.isFeatureEnabled && {
 					id: 'focus_ai_on_selected',
 					divided: true,


### PR DESCRIPTION
## Summary
The "Focus AI on selected" context menu item was visible on self-hosted instances without an AI license, opening a broken chat panel. Added a license gate (isAiAssistantOrBuilderEnabled) to the context menu condition and a defense-in-depth guard in chatPanel.store open().

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2161/unlicensed-ai-option-in-node-menu-opens-broken-chat

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
