### PR TITLE
fix(core): Fix entity import failing in Kubernetes due to ZIP self-inclusion and local header size placeholders

### DIFF
--- a/packages/cli/src/utils/compression.util.ts
+++ b/packages/cli/src/utils/compression.util.ts
@@ -1,8 +1,12 @@
-import * as fflate from 'fflate';
-import { readFile, readdir, writeFile, mkdir } from 'fs/promises';
+import { createWriteStream, mkdirSync } from 'fs';
+import type { FileHandle } from 'fs/promises';
+import { open, readFile, readdir, mkdir } from 'fs/promises';
 import * as path from 'path';
-import { createWriteStream, createReadStream } from 'fs';
+import { Readable } from 'stream';
+import { pipeline } from 'stream/promises';
+import { createInflateRaw } from 'zlib';
 import { safeJoinPath } from '@n8n/backend-common';
+import * as fflate from 'fflate';
 
 // Reuse the same compression levels as the Compression node
 const ALREADY_COMPRESSED = [
@@ -115,80 +119,53 @@ export async function compressFolder(
 }
 
 /**
- * Decompress a ZIP archive to a folder using streaming
- * Reuses the same patterns as the Compression node but with streaming approach
+ * Decompress a ZIP archive to a folder.
+ *
+ * Uses the central directory (at the end of the ZIP) for correct file sizes and
+ * offsets — including ZIP64 — rather than local file headers, which may contain
+ * zero-size placeholders when the archive was created with a streaming compressor.
+ * Each file is streamed through Node's built-in zlib one at a time, keeping memory
+ * usage constant regardless of archive size.
  */
 export async function decompressFolder(sourcePath: string, outputDir: string): Promise<void> {
-	// Ensure output directory exists
 	await mkdir(outputDir, { recursive: true });
 
-	return await new Promise<void>(async (resolve, reject) => {
-		let filesToProcess = 0;
+	// Resolve once so we can skip the source ZIP if it was included in the archive.
+	// This happens when the archive is created inside the same directory it compresses,
+	// causing a 0-byte self-referential entry that would otherwise truncate the source.
+	const absoluteSourcePath = path.resolve(sourcePath);
 
-		const unzip = new fflate.Unzip((stream) => {
-			if (!stream.name.endsWith('/')) {
-				filesToProcess++;
+	const fh = await open(sourcePath, 'r');
+	try {
+		const { size: fileSize } = await fh.stat();
+		const { cdOffset, cdSize } = await readEOCD(fh, fileSize);
+		const entries = await readCentralDirectory(fh, cdOffset, cdSize);
 
-				const chunks: Uint8Array[] = [];
-				let totalLength = 0;
+		for (const entry of entries) {
+			if (entry.name.endsWith('/')) continue;
 
-				// Sanitize path to prevent zip slip attacks
-				const filePath = sanitizePath(stream.name, outputDir);
-				const dirPath = path.dirname(filePath);
+			const filePath = sanitizePath(entry.name, outputDir);
+			if (filePath === absoluteSourcePath) continue;
 
-				// Create directory if it doesn't exist
-				mkdir(dirPath, { recursive: true }).catch((error) => {
-					if (error.code !== 'EEXIST') {
-						reject(error);
-					}
-				});
+			mkdirSync(path.dirname(filePath), { recursive: true });
 
-				stream.ondata = async (error, chunk, final) => {
-					if (error) {
-						reject(error);
-						return;
-					}
+			const dataOffset = await getDataOffset(fh, entry.localHeaderOffset);
+			const readStream = Readable.from(
+				readFileChunks(fh, Number(dataOffset), Number(entry.compressedSize)),
+			);
+			const writeStream = createWriteStream(filePath);
 
-					chunks.push(chunk);
-					totalLength += chunk.length;
-
-					if (final) {
-						const finalBuffer = new Uint8Array(totalLength);
-						let offset = 0;
-						for (const chunk of chunks) {
-							finalBuffer.set(chunk, offset);
-							offset += chunk.length;
-						}
-						await writeFile(filePath, Buffer.from(finalBuffer));
-
-						filesToProcess--;
-
-						if (filesToProcess === 0) {
-							resolve();
-						}
-					}
-				};
-
-				stream.start();
+			if (entry.compressionMethod === COMPRESSION_DEFLATE) {
+				await pipeline(readStream, createInflateRaw(), writeStream);
+			} else if (entry.compressionMethod === COMPRESSION_STORED) {
+				await pipeline(readStream, writeStream);
+			} else {
+				throw new Error(`Unsupported ZIP compression method: ${entry.compressionMethod}`);
 			}
-		});
-
-		unzip.register(fflate.AsyncUnzipInflate);
-
-		// Create readable stream
-		const zipStream = createReadStream(sourcePath);
-
-		for await (const chunk of zipStream) {
-			unzip.push(chunk as Uint8Array);
 		}
-
-		zipStream.on('error', reject);
-
-		// If no files were processed (e.g., only directories), resolve immediately
-		if (filesToProcess === 0) {
-			resolve();
-		}
-	});
+	} finally {
+		await fh.close();
+	}
 }
 
 /**
@@ -244,5 +221,170 @@ async function addDirectoryToZipStreaming(
 			const fileContent = await readFile(fullPath);
 			zipStream.push(new Uint8Array(fileContent), true);
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ZIP parsing helpers for decompressFolder
+// ---------------------------------------------------------------------------
+
+const EOCD_SIG = 0x06054b50;
+const EOCD64_LOCATOR_SIG = 0x07064b50;
+const EOCD64_SIG = 0x06064b50;
+const CD_ENTRY_SIG = 0x02014b50;
+const LOCAL_HEADER_SIG = 0x04034b50;
+const ZIP64_EXTRA_ID = 0x0001;
+
+const COMPRESSION_STORED = 0;
+const COMPRESSION_DEFLATE = 8;
+
+interface ZipEntry {
+	name: string;
+	compressionMethod: number;
+	compressedSize: bigint;
+	localHeaderOffset: bigint;
+}
+
+/**
+ * Locate the end-of-central-directory record and return the central directory
+ * offset and size. Handles ZIP64 archives transparently.
+ */
+async function readEOCD(
+	fh: FileHandle,
+	fileSize: number,
+): Promise<{ cdOffset: bigint; cdSize: bigint }> {
+	// EOCD is at most 65557 bytes from the end (22 fixed + 65535 max comment)
+	const searchSize = Math.min(65557, fileSize);
+	const buf = Buffer.allocUnsafe(searchSize);
+	await fh.read(buf, 0, searchSize, fileSize - searchSize);
+
+	for (let i = searchSize - 22; i >= 0; i--) {
+		if (buf.readUInt32LE(i) !== EOCD_SIG) continue;
+
+		const cdSize32 = buf.readUInt32LE(i + 12);
+		const cdOffset32 = buf.readUInt32LE(i + 16);
+
+		if (cdSize32 === 0xffffffff || cdOffset32 === 0xffffffff) {
+			const locatorPos = fileSize - searchSize + i - 20;
+			if (locatorPos >= 0) {
+				const locBuf = Buffer.allocUnsafe(20);
+				await fh.read(locBuf, 0, 20, locatorPos);
+				if (locBuf.readUInt32LE(0) === EOCD64_LOCATOR_SIG) {
+					const eocd64Offset = Number(locBuf.readBigUInt64LE(8));
+					const eocd64Buf = Buffer.allocUnsafe(56);
+					await fh.read(eocd64Buf, 0, 56, eocd64Offset);
+					if (eocd64Buf.readUInt32LE(0) === EOCD64_SIG) {
+						return {
+							cdSize: eocd64Buf.readBigUInt64LE(40),
+							cdOffset: eocd64Buf.readBigUInt64LE(48),
+						};
+					}
+				}
+			}
+		}
+
+		return { cdSize: BigInt(cdSize32), cdOffset: BigInt(cdOffset32) };
+	}
+
+	throw new Error('Could not find End of Central Directory record in ZIP file');
+}
+
+/**
+ * Parse the central directory and return all file entries.
+ * The central directory always has correct sizes and offsets, including ZIP64
+ * extended fields, unlike local file headers which may hold placeholder values.
+ */
+async function readCentralDirectory(
+	fh: FileHandle,
+	cdOffset: bigint,
+	cdSize: bigint,
+): Promise<ZipEntry[]> {
+	const buf = Buffer.allocUnsafe(Number(cdSize));
+	await fh.read(buf, 0, Number(cdSize), Number(cdOffset));
+
+	const entries: ZipEntry[] = [];
+	let pos = 0;
+
+	while (pos + 46 <= buf.length) {
+		if (buf.readUInt32LE(pos) !== CD_ENTRY_SIG) break;
+
+		const compressionMethod = buf.readUInt16LE(pos + 10);
+		let compressedSize = BigInt(buf.readUInt32LE(pos + 20));
+		let uncompressedSize = BigInt(buf.readUInt32LE(pos + 24));
+		const nameLength = buf.readUInt16LE(pos + 28);
+		const extraLength = buf.readUInt16LE(pos + 30);
+		const commentLength = buf.readUInt16LE(pos + 32);
+		let localHeaderOffset = BigInt(buf.readUInt32LE(pos + 42));
+
+		const name = buf.toString('utf8', pos + 46, pos + 46 + nameLength);
+
+		// Read ZIP64 extended fields when 32-bit values have overflowed
+		let ePos = pos + 46 + nameLength;
+		const eEnd = ePos + extraLength;
+		while (ePos + 4 <= eEnd) {
+			const headerId = buf.readUInt16LE(ePos);
+			const dataSize = buf.readUInt16LE(ePos + 2);
+			if (headerId === ZIP64_EXTRA_ID) {
+				let z = ePos + 4;
+				if (uncompressedSize === BigInt(0xffffffff) && z + 8 <= eEnd) {
+					uncompressedSize = buf.readBigUInt64LE(z);
+					z += 8;
+				}
+				if (compressedSize === BigInt(0xffffffff) && z + 8 <= eEnd) {
+					compressedSize = buf.readBigUInt64LE(z);
+					z += 8;
+				}
+				if (localHeaderOffset === BigInt(0xffffffff) && z + 8 <= eEnd) {
+					localHeaderOffset = buf.readBigUInt64LE(z);
+				}
+				break;
+			}
+			ePos += 4 + dataSize;
+		}
+
+		entries.push({ name, compressionMethod, compressedSize, localHeaderOffset });
+		pos += 46 + nameLength + extraLength + commentLength;
+	}
+
+	return entries;
+}
+
+/**
+ * Read the local file header to find where compressed data actually starts.
+ * The local header's extra field may differ in length from the central directory.
+ */
+async function getDataOffset(fh: FileHandle, localHeaderOffset: bigint): Promise<bigint> {
+	const buf = Buffer.allocUnsafe(30);
+	await fh.read(buf, 0, 30, Number(localHeaderOffset));
+
+	if (buf.readUInt32LE(0) !== LOCAL_HEADER_SIG) {
+		throw new Error(`Invalid local file header at offset ${localHeaderOffset}`);
+	}
+
+	const nameLength = buf.readUInt16LE(26);
+	const extraLength = buf.readUInt16LE(28);
+	return localHeaderOffset + BigInt(30 + nameLength + extraLength);
+}
+
+/**
+ * Yield file data in chunks using positioned reads (pread), without advancing
+ * the FileHandle's cursor or accumulating listeners. Safe on NFS/EFS.
+ */
+async function* readFileChunks(
+	fh: FileHandle,
+	offset: number,
+	size: number,
+	chunkSize = 64 * 1024,
+): AsyncGenerator<Buffer> {
+	let pos = offset;
+	let remaining = size;
+	while (remaining > 0) {
+		const toRead = Math.min(remaining, chunkSize);
+		const buf = Buffer.allocUnsafe(toRead);
+		const { bytesRead } = await fh.read(buf, 0, toRead, pos);
+		if (bytesRead === 0) break;
+		yield bytesRead === toRead ? buf : buf.subarray(0, bytesRead);
+		pos += bytesRead;
+		remaining -= bytesRead;
 	}
 }

--- a/packages/cli/src/utils/compression.util.ts
+++ b/packages/cli/src/utils/compression.util.ts
@@ -246,6 +246,31 @@ interface ZipEntry {
 }
 
 /**
+ * Try to read a ZIP64 end-of-central-directory record using the ZIP64 locator
+ * immediately preceding the standard EOCD. Returns null if not found.
+ */
+async function tryReadZip64(
+	fh: FileHandle,
+	locatorPos: number,
+): Promise<{ cdOffset: bigint; cdSize: bigint } | null> {
+	if (locatorPos < 0) return null;
+
+	const locBuf = Buffer.allocUnsafe(20);
+	await fh.read(locBuf, 0, 20, locatorPos);
+	if (locBuf.readUInt32LE(0) !== EOCD64_LOCATOR_SIG) return null;
+
+	const eocd64Offset = Number(locBuf.readBigUInt64LE(8));
+	const eocd64Buf = Buffer.allocUnsafe(56);
+	await fh.read(eocd64Buf, 0, 56, eocd64Offset);
+	if (eocd64Buf.readUInt32LE(0) !== EOCD64_SIG) return null;
+
+	return {
+		cdSize: eocd64Buf.readBigUInt64LE(40),
+		cdOffset: eocd64Buf.readBigUInt64LE(48),
+	};
+}
+
+/**
  * Locate the end-of-central-directory record and return the central directory
  * offset and size. Handles ZIP64 archives transparently.
  */
@@ -265,22 +290,8 @@ async function readEOCD(
 		const cdOffset32 = buf.readUInt32LE(i + 16);
 
 		if (cdSize32 === 0xffffffff || cdOffset32 === 0xffffffff) {
-			const locatorPos = fileSize - searchSize + i - 20;
-			if (locatorPos >= 0) {
-				const locBuf = Buffer.allocUnsafe(20);
-				await fh.read(locBuf, 0, 20, locatorPos);
-				if (locBuf.readUInt32LE(0) === EOCD64_LOCATOR_SIG) {
-					const eocd64Offset = Number(locBuf.readBigUInt64LE(8));
-					const eocd64Buf = Buffer.allocUnsafe(56);
-					await fh.read(eocd64Buf, 0, 56, eocd64Offset);
-					if (eocd64Buf.readUInt32LE(0) === EOCD64_SIG) {
-						return {
-							cdSize: eocd64Buf.readBigUInt64LE(40),
-							cdOffset: eocd64Buf.readBigUInt64LE(48),
-						};
-					}
-				}
-			}
+			const zip64 = await tryReadZip64(fh, fileSize - searchSize + i - 20);
+			if (zip64) return zip64;
 		}
 
 		return { cdSize: BigInt(cdSize32), cdOffset: BigInt(cdOffset32) };

--- a/packages/cli/src/utils/compression.util.ts
+++ b/packages/cli/src/utils/compression.util.ts
@@ -135,11 +135,11 @@ export async function decompressFolder(sourcePath: string, outputDir: string): P
 	// causing a 0-byte self-referential entry that would otherwise truncate the source.
 	const absoluteSourcePath = path.resolve(sourcePath);
 
-	const fh = await open(sourcePath, 'r');
+	const fileHandle = await open(sourcePath, 'r');
 	try {
-		const { size: fileSize } = await fh.stat();
-		const { cdOffset, cdSize } = await readEOCD(fh, fileSize);
-		const entries = await readCentralDirectory(fh, cdOffset, cdSize);
+		const { size: fileSize } = await fileHandle.stat();
+		const { cdOffset, cdSize } = await readEOCD(fileHandle, fileSize);
+		const entries = await readCentralDirectory(fileHandle, cdOffset, cdSize);
 
 		for (const entry of entries) {
 			if (entry.name.endsWith('/')) continue;
@@ -149,9 +149,9 @@ export async function decompressFolder(sourcePath: string, outputDir: string): P
 
 			mkdirSync(path.dirname(filePath), { recursive: true });
 
-			const dataOffset = await getDataOffset(fh, entry.localHeaderOffset);
+			const dataOffset = await getDataOffset(fileHandle, entry.localHeaderOffset);
 			const readStream = Readable.from(
-				readFileChunks(fh, Number(dataOffset), Number(entry.compressedSize)),
+				readFileChunks(fileHandle, Number(dataOffset), Number(entry.compressedSize)),
 			);
 			const writeStream = createWriteStream(filePath);
 
@@ -164,7 +164,7 @@ export async function decompressFolder(sourcePath: string, outputDir: string): P
 			}
 		}
 	} finally {
-		await fh.close();
+		await fileHandle.close();
 	}
 }
 
@@ -250,18 +250,18 @@ interface ZipEntry {
  * immediately preceding the standard EOCD. Returns null if not found.
  */
 async function tryReadZip64(
-	fh: FileHandle,
+	fileHandle: FileHandle,
 	locatorPos: number,
 ): Promise<{ cdOffset: bigint; cdSize: bigint } | null> {
 	if (locatorPos < 0) return null;
 
 	const locBuf = Buffer.allocUnsafe(20);
-	await fh.read(locBuf, 0, 20, locatorPos);
+	await fileHandle.read(locBuf, 0, 20, locatorPos);
 	if (locBuf.readUInt32LE(0) !== EOCD64_LOCATOR_SIG) return null;
 
 	const eocd64Offset = Number(locBuf.readBigUInt64LE(8));
 	const eocd64Buf = Buffer.allocUnsafe(56);
-	await fh.read(eocd64Buf, 0, 56, eocd64Offset);
+	await fileHandle.read(eocd64Buf, 0, 56, eocd64Offset);
 	if (eocd64Buf.readUInt32LE(0) !== EOCD64_SIG) return null;
 
 	return {
@@ -275,13 +275,13 @@ async function tryReadZip64(
  * offset and size. Handles ZIP64 archives transparently.
  */
 async function readEOCD(
-	fh: FileHandle,
+	fileHandle: FileHandle,
 	fileSize: number,
 ): Promise<{ cdOffset: bigint; cdSize: bigint }> {
 	// EOCD is at most 65557 bytes from the end (22 fixed + 65535 max comment)
 	const searchSize = Math.min(65557, fileSize);
 	const buf = Buffer.allocUnsafe(searchSize);
-	await fh.read(buf, 0, searchSize, fileSize - searchSize);
+	await fileHandle.read(buf, 0, searchSize, fileSize - searchSize);
 
 	for (let i = searchSize - 22; i >= 0; i--) {
 		if (buf.readUInt32LE(i) !== EOCD_SIG) continue;
@@ -290,7 +290,7 @@ async function readEOCD(
 		const cdOffset32 = buf.readUInt32LE(i + 16);
 
 		if (cdSize32 === 0xffffffff || cdOffset32 === 0xffffffff) {
-			const zip64 = await tryReadZip64(fh, fileSize - searchSize + i - 20);
+			const zip64 = await tryReadZip64(fileHandle, fileSize - searchSize + i - 20);
 			if (zip64) return zip64;
 		}
 
@@ -306,12 +306,12 @@ async function readEOCD(
  * extended fields, unlike local file headers which may hold placeholder values.
  */
 async function readCentralDirectory(
-	fh: FileHandle,
+	fileHandle: FileHandle,
 	cdOffset: bigint,
 	cdSize: bigint,
 ): Promise<ZipEntry[]> {
 	const buf = Buffer.allocUnsafe(Number(cdSize));
-	await fh.read(buf, 0, Number(cdSize), Number(cdOffset));
+	await fileHandle.read(buf, 0, Number(cdSize), Number(cdOffset));
 
 	const entries: ZipEntry[] = [];
 	let pos = 0;
@@ -364,9 +364,9 @@ async function readCentralDirectory(
  * Read the local file header to find where compressed data actually starts.
  * The local header's extra field may differ in length from the central directory.
  */
-async function getDataOffset(fh: FileHandle, localHeaderOffset: bigint): Promise<bigint> {
+async function getDataOffset(fileHandle: FileHandle, localHeaderOffset: bigint): Promise<bigint> {
 	const buf = Buffer.allocUnsafe(30);
-	await fh.read(buf, 0, 30, Number(localHeaderOffset));
+	await fileHandle.read(buf, 0, 30, Number(localHeaderOffset));
 
 	if (buf.readUInt32LE(0) !== LOCAL_HEADER_SIG) {
 		throw new Error(`Invalid local file header at offset ${localHeaderOffset}`);
@@ -382,7 +382,7 @@ async function getDataOffset(fh: FileHandle, localHeaderOffset: bigint): Promise
  * the FileHandle's cursor or accumulating listeners. Safe on NFS/EFS.
  */
 async function* readFileChunks(
-	fh: FileHandle,
+	fileHandle: FileHandle,
 	offset: number,
 	size: number,
 	chunkSize = 64 * 1024,
@@ -392,7 +392,7 @@ async function* readFileChunks(
 	while (remaining > 0) {
 		const toRead = Math.min(remaining, chunkSize);
 		const buf = Buffer.allocUnsafe(toRead);
-		const { bytesRead } = await fh.read(buf, 0, toRead, pos);
+		const { bytesRead } = await fileHandle.read(buf, 0, toRead, pos);
 		if (bytesRead === 0) break;
 		yield bytesRead === toRead ? buf : buf.subarray(0, bytesRead);
 		pos += bytesRead;


### PR DESCRIPTION
## Summary

Problem: import:entities failed with "unexpected EOF" on large ZIP archives in Kubernetes.

Root causes:
1. entities.zip was included in its own archive during export. When import extracted the 0-byte self-referential entry, it truncated the source file mid-read.
2. fflate.Zip (streaming writer) writes 0-size placeholders in local file headers. fflate.Unzip (streaming reader) relies on those headers for file boundaries, causing DEFLATE misalignment on any archive created this way.

Fix: Replace fflate.Unzip in decompressFolder with a custom parser that reads the ZIP central directory — located at the end of the archive, it always contains the correct sizes and offsets regardless of how the archive was created.

Each file is then streamed through Node's built-in zlib using positioned reads, keeping memory usage constant. The source archive path is skipped if it appears as an entry.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CP-2510/n8n-import-cli-failing-on-k8s

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
