### PR TITLE
feat(core): Implements telemetry group identify calls

### DIFF
--- a/packages/cli/src/__tests__/license.test.ts
+++ b/packages/cli/src/__tests__/license.test.ts
@@ -451,4 +451,221 @@ describe('License', () => {
 			);
 		});
 	});
+
+	describe('getExpiringInDays', () => {
+		let license: License;
+		const instanceSettings = mock<InstanceSettings>({
+			instanceId: MOCK_INSTANCE_ID,
+			instanceType: 'main',
+			isLeader: true,
+		});
+
+		beforeEach(async () => {
+			jest.restoreAllMocks();
+			const globalConfig = mock<GlobalConfig>({
+				license: licenseConfig,
+				multiMainSetup: { enabled: false },
+			});
+			license = new License(mockLogger(), instanceSettings, mock(), mock(), globalConfig);
+			await license.init();
+		});
+
+		it('should return number of days until expiry for future date', () => {
+			License.prototype.getExpiryDate = jest.fn().mockReturnValue(makeDateWithHourOffset(72)); // 3 days
+
+			const result = license.getExpiringInDays();
+
+			expect(result).toBe(3);
+		});
+
+		it('should return 0 for already expired licenses', () => {
+			License.prototype.getExpiryDate = jest.fn().mockReturnValue(makeDateWithHourOffset(-24)); // 1 day ago
+
+			const result = license.getExpiringInDays();
+
+			expect(result).toBe(0);
+		});
+
+		it('should return undefined when no expiry date exists', () => {
+			License.prototype.getExpiryDate = jest.fn().mockReturnValue(null);
+
+			const result = license.getExpiringInDays();
+
+			expect(result).toBeUndefined();
+		});
+
+		it('should handle exactly 0 hours remaining', () => {
+			const now = new Date();
+			License.prototype.getExpiryDate = jest.fn().mockReturnValue(now);
+
+			const result = license.getExpiringInDays();
+
+			expect(result).toBe(0);
+		});
+
+		it('should handle dates far in the future', () => {
+			License.prototype.getExpiryDate = jest.fn().mockReturnValue(makeDateWithHourOffset(365 * 24)); // 1 year
+
+			const result = license.getExpiringInDays();
+
+			expect(result).toBe(365);
+		});
+
+		it('should handle fractional days by ceiling', () => {
+			License.prototype.getExpiryDate = jest.fn().mockReturnValue(makeDateWithHourOffset(37)); // 1.5+ days
+
+			const result = license.getExpiringInDays();
+
+			expect(result).toBe(2); // ceiling of 1.5 is 2
+		});
+
+		it('should handle invalid date (NaN)', () => {
+			const invalidDate = new Date('invalid');
+			License.prototype.getExpiryDate = jest.fn().mockReturnValue(invalidDate);
+
+			const result = license.getExpiringInDays();
+
+			expect(result).toBeUndefined();
+		});
+
+		it('should return maximum 0 for negative day differences', () => {
+			License.prototype.getExpiryDate = jest.fn().mockReturnValue(makeDateWithHourOffset(-100)); // 4+ days ago
+
+			const result = license.getExpiringInDays();
+
+			expect(result).toBe(0);
+		});
+	});
+
+	describe('getTerminatingInDays', () => {
+		let license: License;
+		const instanceSettings = mock<InstanceSettings>({
+			instanceId: MOCK_INSTANCE_ID,
+			instanceType: 'main',
+			isLeader: true,
+		});
+
+		beforeEach(async () => {
+			jest.restoreAllMocks();
+			const globalConfig = mock<GlobalConfig>({
+				license: licenseConfig,
+				multiMainSetup: { enabled: false },
+			});
+			license = new License(mockLogger(), instanceSettings, mock(), mock(), globalConfig);
+			await license.init();
+		});
+
+		it('should return number of days until termination for future date', () => {
+			License.prototype.getTerminationDate = jest.fn().mockReturnValue(makeDateWithHourOffset(48)); // 2 days
+
+			const result = license.getTerminatingInDays();
+
+			expect(result).toBe(2);
+		});
+
+		it('should return 0 for already terminated licenses', () => {
+			License.prototype.getTerminationDate = jest.fn().mockReturnValue(makeDateWithHourOffset(-48)); // 2 days ago
+
+			const result = license.getTerminatingInDays();
+
+			expect(result).toBe(0);
+		});
+
+		it('should return undefined when no termination date exists', () => {
+			License.prototype.getTerminationDate = jest.fn().mockReturnValue(null);
+
+			const result = license.getTerminatingInDays();
+
+			expect(result).toBeUndefined();
+		});
+
+		it('should handle exactly 0 hours until termination', () => {
+			const now = new Date();
+			License.prototype.getTerminationDate = jest.fn().mockReturnValue(now);
+
+			const result = license.getTerminatingInDays();
+
+			expect(result).toBe(0);
+		});
+
+		it('should handle termination dates far in the future', () => {
+			License.prototype.getTerminationDate = jest
+				.fn()
+				.mockReturnValue(makeDateWithHourOffset(720 * 24)); // 2 years
+
+			const result = license.getTerminatingInDays();
+
+			expect(result).toBe(720);
+		});
+
+		it('should handle fractional days by ceiling', () => {
+			License.prototype.getTerminationDate = jest.fn().mockReturnValue(makeDateWithHourOffset(13)); // 0.5+ days
+
+			const result = license.getTerminatingInDays();
+
+			expect(result).toBe(1); // ceiling of 0.5 is 1
+		});
+
+		it('should handle invalid date (NaN)', () => {
+			const invalidDate = new Date('invalid');
+			License.prototype.getTerminationDate = jest.fn().mockReturnValue(invalidDate);
+
+			const result = license.getTerminatingInDays();
+
+			expect(result).toBeUndefined();
+		});
+
+		it('should return maximum 0 for negative day differences', () => {
+			License.prototype.getTerminationDate = jest
+				.fn()
+				.mockReturnValue(makeDateWithHourOffset(-200)); // 8+ days ago
+
+			const result = license.getTerminatingInDays();
+
+			expect(result).toBe(0);
+		});
+	});
+
+	describe('getExpiringInDays vs getTerminatingInDays', () => {
+		let license: License;
+		const instanceSettings = mock<InstanceSettings>({
+			instanceId: MOCK_INSTANCE_ID,
+			instanceType: 'main',
+			isLeader: true,
+		});
+
+		beforeEach(async () => {
+			jest.restoreAllMocks();
+			const globalConfig = mock<GlobalConfig>({
+				license: licenseConfig,
+				multiMainSetup: { enabled: false },
+			});
+			license = new License(mockLogger(), instanceSettings, mock(), mock(), globalConfig);
+			await license.init();
+		});
+
+		it('should handle both dates being set independently', () => {
+			License.prototype.getExpiryDate = jest.fn().mockReturnValue(makeDateWithHourOffset(72)); // 3 days
+			License.prototype.getTerminationDate = jest.fn().mockReturnValue(makeDateWithHourOffset(168)); // 7 days
+
+			const expiringDays = license.getExpiringInDays();
+			const terminatingDays = license.getTerminatingInDays();
+
+			expect(expiringDays).toBe(3);
+			expect(terminatingDays).toBe(7);
+		});
+
+		it('should handle different precisions for dates', () => {
+			// Expiry in 2.3 days
+			License.prototype.getExpiryDate = jest.fn().mockReturnValue(makeDateWithHourOffset(55));
+			// Termination in 5.7 days
+			License.prototype.getTerminationDate = jest.fn().mockReturnValue(makeDateWithHourOffset(137));
+
+			const expiringDays = license.getExpiringInDays();
+			const terminatingDays = license.getTerminatingInDays();
+
+			expect(expiringDays).toBe(3); // ceiling of 2.3
+			expect(terminatingDays).toBe(6); // ceiling of 5.7
+		});
+	});
 });

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -1,5 +1,6 @@
 import type { NodeTypes } from '@/node-types';
 import { mockInstance } from '@n8n/backend-test-utils';
+import type { LicenseState } from '@n8n/backend-common';
 import type { GlobalConfig } from '@n8n/config';
 import {
 	type CredentialsEntity,
@@ -35,6 +36,7 @@ const flushPromises = async () => await new Promise((resolve) => setImmediate(re
 describe('TelemetryEventRelay', () => {
 	const telemetry = mock<Telemetry>();
 	const license = mock<License>();
+	const licenseState = mock<LicenseState>();
 	const globalConfig = mock<GlobalConfig>({
 		deployment: {
 			type: 'default',
@@ -87,6 +89,7 @@ describe('TelemetryEventRelay', () => {
 			eventService,
 			telemetry,
 			license,
+			licenseState,
 			globalConfig,
 			instanceSettings,
 			binaryDataConfig,
@@ -112,6 +115,7 @@ describe('TelemetryEventRelay', () => {
 				eventService,
 				telemetry,
 				license,
+				licenseState,
 				globalConfig,
 				instanceSettings,
 				binaryDataConfig,
@@ -136,6 +140,7 @@ describe('TelemetryEventRelay', () => {
 				eventService,
 				telemetry,
 				license,
+				licenseState,
 				globalConfig,
 				instanceSettings,
 				binaryDataConfig,

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -34,7 +34,9 @@ import type { Telemetry } from '@/telemetry';
 const flushPromises = async () => await new Promise((resolve) => setImmediate(resolve));
 
 describe('TelemetryEventRelay', () => {
-	const telemetry = mock<Telemetry>();
+	const telemetry = mock<Telemetry>({
+		sanitizeTelemetryProperties: jest.fn((data) => data),
+	});
 	const license = mock<License>();
 	const licenseState = mock<LicenseState>();
 	const globalConfig = mock<GlobalConfig>({
@@ -68,6 +70,35 @@ describe('TelemetryEventRelay', () => {
 			batchSize: 234,
 			optimizingTimeWindowHours: 400,
 			trimmingTimeWindowDays: 600,
+		},
+		host: 'localhost',
+		generic: {
+			timezone: 'UTC',
+			releaseChannel: 'stable',
+		},
+		defaultLocale: 'en',
+		personalization: {
+			enabled: true,
+		},
+		multiMainSetup: {
+			enabled: false,
+		},
+		taskRunners: {
+			mode: 'external',
+		},
+		templates: {
+			enabled: true,
+		},
+		ai: {
+			enabled: false,
+		},
+		license: {
+			tenantId: 1,
+			autoRenewalEnabled: false,
+			activationKey: '',
+		},
+		database: {
+			type: 'sqlite',
 		},
 	});
 	const binaryDataConfig = mock<BinaryDataConfig>({
@@ -1271,6 +1302,13 @@ describe('TelemetryEventRelay', () => {
 
 			eventService.emit('user-updated', event);
 
+			expect(telemetry.identify).toHaveBeenCalledWith(
+				{
+					user_role: GLOBAL_OWNER_ROLE.slug,
+					user_email: 'user@example.com',
+				},
+				'user123',
+			);
 			expect(telemetry.track).toHaveBeenCalledWith('User changed personal settings', {
 				user_id: 'user123',
 				fields_changed: ['firstName', 'lastName'],
@@ -1303,6 +1341,12 @@ describe('TelemetryEventRelay', () => {
 				target_user_id: 'user456',
 				migration_user_id: 'user789',
 			});
+			expect(telemetry.identify).toHaveBeenCalledWith(
+				{
+					deleted: true,
+				},
+				'user456',
+			);
 		});
 
 		it('should track on `user-invited` event', () => {
@@ -1346,6 +1390,17 @@ describe('TelemetryEventRelay', () => {
 
 			eventService.emit('user-signed-up', event);
 
+			expect(telemetry.identify).toHaveBeenCalledWith(
+				{
+					user_id: 'user123',
+					user_type: 'email',
+					was_disabled_ldap_user: false,
+				},
+				'user123',
+			);
+			expect(telemetry.groupIdentify).toHaveBeenCalledWith({
+				userId: 'user123',
+			});
 			expect(telemetry.track).toHaveBeenCalledWith('User signed up', {
 				user_id: 'user123',
 				user_type: 'email',
@@ -1385,6 +1440,12 @@ describe('TelemetryEventRelay', () => {
 
 			eventService.emit('user-changed-role', event);
 
+			expect(telemetry.identify).toHaveBeenCalledWith(
+				{
+					user_role: 'global:member',
+				},
+				'user456',
+			);
 			expect(telemetry.track).toHaveBeenCalledWith('User changed role', {
 				user_id: 'user123',
 				target_user_id: 'user456',
@@ -1431,6 +1492,15 @@ describe('TelemetryEventRelay', () => {
 
 			await flushPromises();
 
+			expect(telemetry.groupIdentify).toHaveBeenCalledWith(
+				expect.objectContaining({
+					traits: expect.objectContaining({
+						n8n_host: expect.any(String),
+						version_cli: N8N_VERSION,
+						n8n_deployment_type: 'default',
+					}),
+				}),
+			);
 			expect(telemetry.identify).toHaveBeenCalledWith(
 				expect.objectContaining({
 					version_cli: N8N_VERSION,
@@ -1502,6 +1572,9 @@ describe('TelemetryEventRelay', () => {
 
 			eventService.emit('instance-owner-setup', event);
 
+			expect(telemetry.groupIdentify).toHaveBeenCalledWith({
+				userId: 'user123',
+			});
 			expect(telemetry.track).toHaveBeenCalledWith('Owner finished instance setup', {
 				user_id: 'user123',
 			});

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -27,7 +27,7 @@ import {
 import { N8N_VERSION } from '@/constants';
 import { EventService } from '@/events/event.service';
 import type { RelayEventMap } from '@/events/maps/relay.event-map';
-import { TelemetryEventRelay } from '@/events/relays/telemetry.event-relay';
+import { TelemetryEventRelay, getSemanticVersioning } from '@/events/relays/telemetry.event-relay';
 import type { License } from '@/license';
 import type { Telemetry } from '@/telemetry';
 
@@ -2305,6 +2305,78 @@ describe('TelemetryEventRelay', () => {
 				user_id: 'user456',
 				'2fa_enforcement': false,
 			});
+		});
+	});
+
+	describe('getSemanticVersioning', () => {
+		it('should parse standard semantic version', () => {
+			const result = getSemanticVersioning('2.11.0');
+			expect(result).toEqual({ major: 2, minor: 11, patch: 0 });
+		});
+
+		it('should parse version with pre-release', () => {
+			const result = getSemanticVersioning('2.11.0-beta.1');
+			expect(result).toEqual({ major: 2, minor: 11, patch: 0 });
+		});
+
+		it('should parse version with pre-release rc', () => {
+			const result = getSemanticVersioning('2.11.0-rc.5');
+			expect(result).toEqual({ major: 2, minor: 11, patch: 0 });
+		});
+
+		it('should parse version with build metadata', () => {
+			const result = getSemanticVersioning('2.11.0+build.123');
+			expect(result).toEqual({ major: 2, minor: 11, patch: 0 });
+		});
+
+		it('should parse version with pre-release and build metadata', () => {
+			const result = getSemanticVersioning('2.11.0-alpha.1+build.456');
+			expect(result).toEqual({ major: 2, minor: 11, patch: 0 });
+		});
+
+		it('should handle single digit versions', () => {
+			const result = getSemanticVersioning('1.0.0');
+			expect(result).toEqual({ major: 1, minor: 0, patch: 0 });
+		});
+
+		it('should handle large version numbers', () => {
+			const result = getSemanticVersioning('100.200.300');
+			expect(result).toEqual({ major: 100, minor: 200, patch: 300 });
+		});
+
+		it('should return null for invalid version', () => {
+			const result = getSemanticVersioning('invalid');
+			expect(result).toEqual({ major: null, minor: null, patch: null });
+		});
+
+		it('should return null for empty string', () => {
+			const result = getSemanticVersioning('');
+			expect(result).toEqual({ major: null, minor: null, patch: null });
+		});
+
+		it('should return null for malformed version', () => {
+			const result = getSemanticVersioning('a.b.c');
+			expect(result).toEqual({ major: null, minor: null, patch: null });
+		});
+
+		it('should return null for version with only major.minor', () => {
+			const result = getSemanticVersioning('2.11');
+			expect(result).toEqual({ major: null, minor: null, patch: null });
+		});
+
+		it('should handle errors gracefully', () => {
+			const result = getSemanticVersioning('very.weird.version.string');
+			expect(result).toEqual({ major: null, minor: null, patch: null });
+		});
+
+		it('should parse the current N8N_VERSION', () => {
+			const result = getSemanticVersioning(N8N_VERSION);
+			expect(result.major).not.toBeNull();
+			expect(result.minor).not.toBeNull();
+			expect(result.patch).not.toBeNull();
+			expect(typeof result.major).toBe('number');
+			expect(typeof result.minor).toBe('number');
+			expect(typeof result.patch).toBe('number');
 		});
 	});
 });

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -1,3 +1,4 @@
+import { LicenseState } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import {
 	CredentialsRepository,
@@ -52,6 +53,7 @@ export class TelemetryEventRelay extends EventRelay {
 		readonly eventService: EventService,
 		private readonly telemetry: Telemetry,
 		private readonly license: License,
+		private readonly licenseState: LicenseState,
 		private readonly globalConfig: GlobalConfig,
 		private readonly instanceSettings: InstanceSettings,
 		private readonly binaryDataConfig: BinaryDataConfig,
@@ -1050,10 +1052,60 @@ export class TelemetryEventRelay extends EventRelay {
 			},
 		};
 
+		const versionParts = getSemanticVersioning(N8N_VERSION);
+
+		// Instance information available at group level on PostHog & Rudderstack
+		const telemetryInstanceInfo = {
+			// Main instance settings
+			n8n_host: this.globalConfig.host,
+			version_cli: N8N_VERSION,
+			version_cli_major: versionParts.major,
+			version_cli_minor: versionParts.minor,
+			version_cli_patch: versionParts.patch,
+			release_channel: this.globalConfig.generic.releaseChannel,
+			executions_mode: this.globalConfig.executions.mode,
+			n8n_deployment_type: this.globalConfig.deployment.type,
+			db_type: this.globalConfig.database.type,
+
+			// Location settings
+			timezone: this.globalConfig.generic.timezone,
+			default_locale: this.globalConfig.defaultLocale,
+
+			// Feature settings
+			personalization_enabled: this.globalConfig.personalization.enabled,
+			multi_main_setup_enabled: this.globalConfig.multiMainSetup.enabled,
+			task_runners_mode: this.globalConfig.taskRunners.mode,
+			templates_enabled: this.globalConfig.templates.enabled,
+			ai_enabled: this.globalConfig.ai.enabled,
+
+			// Licensing
+			license: {
+				plan_name: this.license.getPlanName(),
+				tenant_id: this.globalConfig.license.tenantId,
+				auto_renewal_enabled: this.globalConfig.license.autoRenewalEnabled,
+				has_activation_key: !!this.globalConfig.license.activationKey,
+				expiry_date: this.license.getExpiryDate()?.toISOString(),
+				termination_date: this.license.getTerminationDate()?.toISOString(),
+				expiring_in_days: this.license.getExpiringInDays(),
+				terminating_in_days: this.license.getTerminatingInDays(),
+				features: this.getLicenseFeatures(),
+			},
+
+			// Misc instance settings
+			smtp_set_up: this.globalConfig.userManagement.emails.mode === 'smtp',
+			ldap_allowed: authenticationMethod === 'ldap',
+			saml_enabled: authenticationMethod === 'saml',
+		};
+
 		const firstWorkflow = await this.workflowRepository.findOne({
 			select: ['createdAt'],
 			order: { createdAt: 'ASC' },
 			where: {},
+		});
+
+		// Inject instance info on telemetry instance group
+		this.telemetry.groupIdentify({
+			traits: this.telemetry.sanitizeTelemetryProperties(telemetryInstanceInfo),
 		});
 
 		this.telemetry.identify(info);
@@ -1061,6 +1113,57 @@ export class TelemetryEventRelay extends EventRelay {
 			...info,
 			earliest_workflow_created: firstWorkflow?.createdAt,
 		});
+	}
+
+	private getLicenseFeatures() {
+		return {
+			// Features
+			customRoles: this.licenseState.isCustomRolesLicensed(),
+			dynamicCredentials: this.licenseState.isDynamicCredentialsLicensed(),
+			personalSpacePolicy: this.licenseState.isPersonalSpacePolicyLicensed(),
+			sharing: this.licenseState.isSharingLicensed(),
+			logStreaming: this.licenseState.isLogStreamingLicensed(),
+			ldap: this.licenseState.isLdapLicensed(),
+			saml: this.licenseState.isSamlLicensed(),
+			oidc: this.licenseState.isOidcLicensed(),
+			mfaEnforcement: this.licenseState.isMFAEnforcementLicensed(),
+			apiKeyScopes: this.licenseState.isApiKeyScopesLicensed(),
+			aiAssistant: this.licenseState.isAiAssistantLicensed(),
+			askAi: this.licenseState.isAskAiLicensed(),
+			aiCredits: this.licenseState.isAiCreditsLicensed(),
+			advancedExecutionFilters: this.licenseState.isAdvancedExecutionFiltersLicensed(),
+			advancedPermissions: this.licenseState.isAdvancedPermissionsLicensed(),
+			debugInEditor: this.licenseState.isDebugInEditorLicensed(),
+			binaryDataS3: this.licenseState.isBinaryDataS3Licensed(),
+			multiMain: this.licenseState.isMultiMainLicensed(),
+			variables: this.licenseState.isVariablesLicensed(),
+			sourceControl: this.licenseState.isSourceControlLicensed(),
+			externalSecrets: this.licenseState.isExternalSecretsLicensed(),
+			apiDisabled: this.licenseState.isAPIDisabled(),
+			workerView: this.licenseState.isWorkerViewLicensed(),
+			projectRoleAdmin: this.licenseState.isProjectRoleAdminLicensed(),
+			projectRoleEditor: this.licenseState.isProjectRoleEditorLicensed(),
+			projectRoleViewer: this.licenseState.isProjectRoleViewerLicensed(),
+			customNpmRegistry: this.licenseState.isCustomNpmRegistryLicensed(),
+			folders: this.licenseState.isFoldersLicensed(),
+			insightsSummary: this.licenseState.isInsightsSummaryLicensed(),
+			insightsDashboard: this.licenseState.isInsightsDashboardLicensed(),
+			insightsHourlyData: this.licenseState.isInsightsHourlyDataLicensed(),
+			workflowDiffs: this.licenseState.isWorkflowDiffsLicensed(),
+			provisioning: this.licenseState.isProvisioningLicensed(),
+
+			// Quotas
+			maxUsers: this.licenseState.getMaxUsers(),
+			maxActiveWorkflows: this.licenseState.getMaxActiveWorkflows(),
+			maxVariables: this.licenseState.getMaxVariables(),
+			maxAiCredits: this.licenseState.getMaxAiCredits(),
+			workflowHistoryPruneQuota: this.licenseState.getWorkflowHistoryPruneQuota(),
+			insightsMaxHistory: this.licenseState.getInsightsMaxHistory(),
+			insightsRetentionMaxAge: this.licenseState.getInsightsRetentionMaxAge(),
+			insightsRetentionPruneInterval: this.licenseState.getInsightsRetentionPruneInterval(),
+			maxTeamProjects: this.licenseState.getMaxTeamProjects(),
+			maxWorkflowsWithEvaluations: this.licenseState.getMaxWorkflowsWithEvaluations(),
+		};
 	}
 
 	private sessionStarted({ pushRef }: RelayEventMap['session-started']) {
@@ -1072,6 +1175,11 @@ export class TelemetryEventRelay extends EventRelay {
 	}
 
 	private async instanceOwnerSetup({ userId }: RelayEventMap['instance-owner-setup']) {
+		// Attach owner to instance group on telemetry
+		this.telemetry.groupIdentify({
+			userId,
+		});
+
 		this.telemetry.track('Owner finished instance setup', { user_id: userId });
 	}
 
@@ -1127,6 +1235,13 @@ export class TelemetryEventRelay extends EventRelay {
 		targetUserNewRole,
 		publicApi,
 	}: RelayEventMap['user-changed-role']) {
+		this.telemetry.identify(
+			{
+				user_role: targetUserNewRole,
+			},
+			userId,
+		);
+
 		this.telemetry.track('User changed role', {
 			user_id: userId,
 			target_user_id: targetUserId,
@@ -1194,6 +1309,14 @@ export class TelemetryEventRelay extends EventRelay {
 	}
 
 	private userUpdated({ user, fieldsChanged }: RelayEventMap['user-updated']) {
+		this.telemetry.identify(
+			{
+				user_role: user?.role?.slug,
+				user_email: user.email,
+			},
+			user.id,
+		);
+
 		this.telemetry.track('User changed personal settings', {
 			user_id: user.id,
 			fields_changed: fieldsChanged,
@@ -1216,6 +1339,13 @@ export class TelemetryEventRelay extends EventRelay {
 			target_user_id: targetUserId,
 			migration_user_id: migrationUserId,
 		});
+
+		this.telemetry.identify(
+			{
+				deleted: true,
+			},
+			targetUserId,
+		);
 	}
 
 	private userInvited({
@@ -1241,9 +1371,16 @@ export class TelemetryEventRelay extends EventRelay {
 			was_disabled_ldap_user: wasDisabledLdapUser,
 			...(this.globalConfig.deployment.type === 'cloud' && {
 				user_email: user.email,
-				user_role: user.role,
+				user_role: user?.role?.slug,
 			}),
 		};
+
+		this.telemetry.identify(payload, user.id);
+
+		// Attach new instance user to instance group on telemetry
+		this.telemetry.groupIdentify({
+			userId: user.id,
+		});
 
 		this.telemetry.track('User signed up', payload);
 	}
@@ -1443,4 +1580,34 @@ export class TelemetryEventRelay extends EventRelay {
 	}
 
 	// #endregion
+}
+
+function getSemanticVersioning(versionCli: string): {
+	major: number;
+	minor: number;
+	patch: number;
+} {
+	try {
+		if (!versionCli || typeof versionCli !== 'string') {
+			return { major: 0, minor: 0, patch: 0 };
+		}
+
+		// Remove any pre-release or build metadata (e.g "2.11.0-beta.1" -> "2.11.0")
+		const cleanVersion = versionCli.split('-')[0] ?? '';
+		const parts = cleanVersion.split('.');
+
+		const parseVersion = (part: string | undefined): number => {
+			if (!part) return 0;
+			const parsed = parseInt(part, 10);
+			return Number.isNaN(parsed) ? 0 : parsed;
+		};
+
+		return {
+			major: parseVersion(parts[0]),
+			minor: parseVersion(parts[1]),
+			patch: parseVersion(parts[2]),
+		};
+	} catch (e) {
+		return { major: 0, minor: 0, patch: 0 };
+	}
 }

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -25,9 +25,7 @@ import {
 	toExecutionContextEstablishmentHookParameter,
 } from 'n8n-workflow';
 import os from 'node:os';
-
-import { Telemetry } from '../../telemetry';
-import { EventRelay } from './event-relay';
+import semver from 'semver';
 
 import config from '@/config';
 import { N8N_VERSION } from '@/constants';
@@ -37,6 +35,9 @@ import { determineFinalExecutionStatus } from '@/execution-lifecycle/shared/shar
 import type { IExecutionTrackProperties } from '@/interfaces';
 import { License } from '@/license';
 import { NodeTypes } from '@/node-types';
+
+import { EventRelay } from './event-relay';
+import { Telemetry } from '../../telemetry';
 
 // Max size for node_graph_string to avoid exceeding telemetry payload limits (32 KB), leaving room for other fields
 const MAX_NODE_GRAPH_STRING_SIZE = 24 * 1024;
@@ -1582,32 +1583,22 @@ export class TelemetryEventRelay extends EventRelay {
 	// #endregion
 }
 
-function getSemanticVersioning(versionCli: string): {
-	major: number;
-	minor: number;
-	patch: number;
+export function getSemanticVersioning(versionCli: string): {
+	major: number | null;
+	minor: number | null;
+	patch: number | null;
 } {
 	try {
-		if (!versionCli || typeof versionCli !== 'string') {
-			return { major: 0, minor: 0, patch: 0 };
+		const parsed = semver.parse(versionCli);
+		if (!parsed) {
+			return { major: null, minor: null, patch: null };
 		}
-
-		// Remove any pre-release or build metadata (e.g "2.11.0-beta.1" -> "2.11.0")
-		const cleanVersion = versionCli.split('-')[0] ?? '';
-		const parts = cleanVersion.split('.');
-
-		const parseVersion = (part: string | undefined): number => {
-			if (!part) return 0;
-			const parsed = parseInt(part, 10);
-			return Number.isNaN(parsed) ? 0 : parsed;
-		};
-
 		return {
-			major: parseVersion(parts[0]),
-			minor: parseVersion(parts[1]),
-			patch: parseVersion(parts[2]),
+			major: parsed.major,
+			minor: parsed.minor,
+			patch: parsed.patch,
 		};
 	} catch (e) {
-		return { major: 0, minor: 0, patch: 0 };
+		return { major: null, minor: null, patch: null };
 	}
 }

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -1239,7 +1239,7 @@ export class TelemetryEventRelay extends EventRelay {
 			{
 				user_role: targetUserNewRole,
 			},
-			userId,
+			targetUserId,
 		);
 
 		this.telemetry.track('User changed role', {

--- a/packages/cli/src/license.ts
+++ b/packages/cli/src/license.ts
@@ -453,6 +453,52 @@ export class License implements LicenseProvider {
 		return this.getValue('planName') ?? 'Community';
 	}
 
+	getExpiryDate(): Date | null {
+		try {
+			return this.manager?.getExpiryDate() ?? null;
+		} catch {
+			return null;
+		}
+	}
+
+	getTerminationDate(): Date | null {
+		try {
+			return this.manager?.getTerminationDate() ?? null;
+		} catch {
+			return null;
+		}
+	}
+
+	getExpiringInDays(): number | undefined {
+		const expiryDate = this.getExpiryDate();
+		if (!expiryDate) return undefined;
+
+		const expiryTime = expiryDate.getTime();
+		if (Number.isNaN(expiryTime)) return undefined;
+
+		const now = new Date();
+		const diffMs = expiryTime - now.getTime();
+		const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+
+		// Return 0 for already expired licenses instead of negative values
+		return Math.max(0, diffDays);
+	}
+
+	getTerminatingInDays(): number | undefined {
+		const terminationDate = this.getTerminationDate();
+		if (!terminationDate) return undefined;
+
+		const terminationTime = terminationDate.getTime();
+		if (Number.isNaN(terminationTime)) return undefined;
+
+		const now = new Date();
+		const diffMs = terminationTime - now.getTime();
+		const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+
+		// Return 0 for already terminated licenses instead of negative values
+		return Math.max(0, diffDays);
+	}
+
 	getInfo(): string {
 		if (!this.manager) {
 			return 'n/a';

--- a/packages/cli/src/posthog/index.ts
+++ b/packages/cli/src/posthog/index.ts
@@ -5,6 +5,12 @@ import { InstanceSettings } from 'n8n-core';
 import type { FeatureFlags, ITelemetryTrackProperties } from 'n8n-workflow';
 import type { PostHog } from 'posthog-node';
 
+/**
+ * PostHog group type for instance-level properties.
+ * Note: Aliased as "instance" on PostHog dashboard
+ */
+const POSTHOG_GROUP_TYPE_INSTANCE = 'company';
+
 @Service()
 export class PostHogClient {
 	private postHog?: PostHog;
@@ -52,7 +58,7 @@ export class PostHogClient {
 		if (!instanceId) return;
 
 		this.postHog?.groupIdentify({
-			groupType: 'company', // NOTE : Aliased as "instance" on PostHog dashboard
+			groupType: POSTHOG_GROUP_TYPE_INSTANCE,
 			groupKey: instanceId,
 			properties,
 			...(distinctId && { distinctId }),
@@ -62,7 +68,7 @@ export class PostHogClient {
 	identify({
 		distinctId,
 		properties,
-	}: { distinctId: string; properties: Record<string | number, any> | undefined }): void {
+	}: { distinctId: string; properties: Record<string | number, unknown> | undefined }): void {
 		if (!distinctId) return;
 
 		this.postHog?.identify({

--- a/packages/cli/src/posthog/index.ts
+++ b/packages/cli/src/posthog/index.ts
@@ -40,6 +40,37 @@ export class PostHogClient {
 		});
 	}
 
+	groupIdentify({
+		instanceId,
+		distinctId,
+		properties,
+	}: {
+		instanceId: string;
+		distinctId?: string;
+		properties: Record<string, string | number> | undefined;
+	}): void {
+		if (!instanceId) return;
+
+		this.postHog?.groupIdentify({
+			groupType: 'company', // NOTE : Aliased as "instance" on PostHog dashboard
+			groupKey: instanceId,
+			properties,
+			...(distinctId && { distinctId }),
+		});
+	}
+
+	identify({
+		distinctId,
+		properties,
+	}: { distinctId: string; properties: Record<string | number, any> | undefined }): void {
+		if (!distinctId) return;
+
+		this.postHog?.identify({
+			distinctId,
+			properties: properties ?? undefined,
+		});
+	}
+
 	async getFeatureFlags(user: Pick<PublicUser, 'id' | 'createdAt'>): Promise<FeatureFlags> {
 		if (!this.postHog) return {};
 

--- a/packages/cli/src/telemetry/index.ts
+++ b/packages/cli/src/telemetry/index.ts
@@ -252,11 +252,6 @@ export class Telemetry {
 		const { instanceId } = this.instanceSettings;
 		if (!instanceId) return;
 
-		console.log('-- groupIdentify called --');
-		console.log('instanceId:', instanceId);
-		console.log('userId:', userId);
-		console.log('traits:', traits);
-
 		if (this.postHog) {
 			this.postHog.groupIdentify({
 				...(userId && { distinctId: `${userId}#${instanceId}` }),
@@ -283,11 +278,6 @@ export class Telemetry {
 	): void {
 		const { instanceId } = this.instanceSettings;
 		if (!instanceId) return;
-
-		console.log('-- identify called --');
-		console.log('instanceId:', instanceId);
-		console.log('userId:', userId);
-		console.log('traits:', traits);
 
 		if (this.rudderStack) {
 			this.rudderStack.identify({

--- a/packages/cli/src/telemetry/index.ts
+++ b/packages/cli/src/telemetry/index.ts
@@ -63,33 +63,40 @@ export class Telemetry {
 		private readonly errorReporter: ErrorReporter,
 	) {}
 
-	// PostHog groupIdentify only accept flat objects with string or number values, function sanitizes objects to match that format.
+	// PostHog groupIdentify only accepts flat objects with string or number values, function sanitizes objects to match that format.
 	sanitizeTelemetryProperties(
 		obj: Record<string, any>,
-		prefix = '',
+		depth = 0,
+		maxDepth = 10,
 	): Record<string, string | number> {
 		try {
 			const result: Record<string, string | number> = {};
 
 			for (const [key, value] of Object.entries(obj)) {
-				const newKey = prefix ? `${prefix}.${key}` : key;
-
 				if (value === null || value === undefined) {
 					continue;
 				} else if (typeof value === 'boolean') {
-					result[newKey] = value ? 'true' : 'false';
+					result[key] = value ? 'true' : 'false';
 				} else if (typeof value === 'number') {
-					result[newKey] = value;
+					result[key] = value;
 				} else if (typeof value === 'string') {
-					result[newKey] = value;
+					result[key] = value;
 				} else if (Array.isArray(value)) {
-					result[newKey] = JSON.stringify(value);
+					result[key] = JSON.stringify(value);
 				} else if (typeof value === 'object' && value.constructor === Object) {
-					// Recursively flatten nested objects
-					Object.assign(
-						result,
-						this.sanitizeTelemetryProperties(value as Record<string, unknown>, newKey),
-					);
+					if (depth >= maxDepth) {
+						result[key] = JSON.stringify(value);
+					} else {
+						// Recursively flatten nested objects
+						Object.assign(
+							result,
+							this.sanitizeTelemetryProperties(
+								value as Record<string, unknown>,
+								depth + 1,
+								maxDepth,
+							),
+						);
+					}
 				} else {
 					continue;
 				}

--- a/packages/cli/src/telemetry/index.ts
+++ b/packages/cli/src/telemetry/index.ts
@@ -63,6 +63,45 @@ export class Telemetry {
 		private readonly errorReporter: ErrorReporter,
 	) {}
 
+	// PostHog groupIdentify only accept flat objects with string or number values, function sanitizes objects to match that format.
+	sanitizeTelemetryProperties(
+		obj: Record<string, any>,
+		prefix = '',
+	): Record<string, string | number> {
+		try {
+			const result: Record<string, string | number> = {};
+
+			for (const [key, value] of Object.entries(obj)) {
+				const newKey = prefix ? `${prefix}.${key}` : key;
+
+				if (value === null || value === undefined) {
+					continue;
+				} else if (typeof value === 'boolean') {
+					result[newKey] = value ? 'true' : 'false';
+				} else if (typeof value === 'number') {
+					result[newKey] = value;
+				} else if (typeof value === 'string') {
+					result[newKey] = value;
+				} else if (Array.isArray(value)) {
+					result[newKey] = JSON.stringify(value);
+				} else if (typeof value === 'object' && value.constructor === Object) {
+					// Recursively flatten nested objects
+					Object.assign(
+						result,
+						this.sanitizeTelemetryProperties(value as Record<string, unknown>, newKey),
+					);
+				} else {
+					continue;
+				}
+			}
+
+			return result;
+		} catch (e) {
+			this.logger.error('Error sanitizing telemetry properties', { error: e, object: obj });
+			return {};
+		}
+	}
+
 	async init() {
 		const { enabled, backendConfig } = this.globalConfig.diagnostics;
 		if (enabled) {
@@ -202,21 +241,71 @@ export class Telemetry {
 		await Promise.all([this.postHog.stop(), this.rudderStack?.flush()]);
 	}
 
-	identify(traits?: { [key: string]: string | number | boolean | object | undefined | null }) {
-		if (!this.rudderStack) {
-			return;
+	// Used for either adding properties to group (no userId provided), or attaching user to instance group (userId provided)
+	groupIdentify({
+		userId,
+		traits,
+	}: {
+		userId?: string;
+		traits?: Record<string, string | number>;
+	}): void {
+		const { instanceId } = this.instanceSettings;
+		if (!instanceId) return;
+
+		console.log('-- groupIdentify called --');
+		console.log('instanceId:', instanceId);
+		console.log('userId:', userId);
+		console.log('traits:', traits);
+
+		if (this.postHog) {
+			this.postHog.groupIdentify({
+				...(userId && { distinctId: `${userId}#${instanceId}` }),
+				instanceId,
+				properties: traits,
+			});
 		}
 
-		const { instanceId } = this.instanceSettings;
+		if (this.rudderStack) {
+			this.rudderStack.group({
+				groupId: instanceId,
+				userId: userId ? `${userId}#${instanceId}` : instanceId, // Rudderstack requires a userId for group calls, using instanceId as fallback
+				traits,
+				context: {
+					ip: '0.0.0.0',
+				},
+			});
+		}
+	}
 
-		this.rudderStack.identify({
-			userId: instanceId,
-			traits: { ...traits, instanceId },
-			context: {
-				// provide a fake IP address to instruct RudderStack to not use the user's IP address
-				ip: '0.0.0.0',
-			},
-		});
+	identify(
+		traits?: { [key: string]: string | number | boolean | object | undefined | null },
+		userId?: string,
+	): void {
+		const { instanceId } = this.instanceSettings;
+		if (!instanceId) return;
+
+		console.log('-- identify called --');
+		console.log('instanceId:', instanceId);
+		console.log('userId:', userId);
+		console.log('traits:', traits);
+
+		if (this.rudderStack) {
+			this.rudderStack.identify({
+				userId: userId ? `${userId}#${instanceId}` : instanceId, // If no userId provided, falling back to instanceId for cross-compatibility
+				traits: { ...traits, instanceId },
+				context: {
+					// provide a fake IP address to instruct RudderStack to not use the user's IP address
+					ip: '0.0.0.0',
+				},
+			});
+		}
+
+		if (this.postHog && userId) {
+			this.postHog.identify({
+				distinctId: `${userId}#${instanceId}`,
+				properties: traits,
+			});
+		}
 	}
 
 	track(eventName: string, properties: ITelemetryTrackProperties = {}) {

--- a/packages/cli/src/telemetry/index.ts
+++ b/packages/cli/src/telemetry/index.ts
@@ -261,7 +261,7 @@ export class Telemetry {
 
 		if (this.postHog) {
 			this.postHog.groupIdentify({
-				...(userId && { distinctId: `${userId}#${instanceId}` }),
+				...(userId && { distinctId: `${instanceId}#${userId}` }),
 				instanceId,
 				properties: traits,
 			});
@@ -270,7 +270,7 @@ export class Telemetry {
 		if (this.rudderStack) {
 			this.rudderStack.group({
 				groupId: instanceId,
-				userId: userId ? `${userId}#${instanceId}` : instanceId, // Rudderstack requires a userId for group calls, using instanceId as fallback
+				userId: userId ? `${instanceId}#${userId}` : instanceId, // Rudderstack requires a userId for group calls, using instanceId as fallback
 				traits,
 				context: {
 					ip: '0.0.0.0',
@@ -288,7 +288,7 @@ export class Telemetry {
 
 		if (this.rudderStack) {
 			this.rudderStack.identify({
-				userId: userId ? `${userId}#${instanceId}` : instanceId, // If no userId provided, falling back to instanceId for cross-compatibility
+				userId: userId ? `${instanceId}#${userId}` : instanceId, // If no userId provided, falling back to instanceId for cross-compatibility
 				traits: { ...traits, instanceId },
 				context: {
 					// provide a fake IP address to instruct RudderStack to not use the user's IP address
@@ -299,7 +299,7 @@ export class Telemetry {
 
 		if (this.postHog && userId) {
 			this.postHog.identify({
-				distinctId: `${userId}#${instanceId}`,
+				distinctId: `${instanceId}#${userId}`,
 				properties: traits,
 			});
 		}


### PR DESCRIPTION
## Summary
Implements telemetry (Rudderstack & PostHog) group calls to group instance users under common instance group for feature flag targeting & analytics segmentation. Includes general instance settings & licensing information.

Maintains legacy telemetry (Rudderstack identify call under `instanceId` on server startup) for cross-compatibility.
