### PR TITLE
feat(core): Add configurable HTTP status code for OAuth2 token refresh

### DIFF
--- a/packages/@n8n/client-oauth2/src/types.ts
+++ b/packages/@n8n/client-oauth2/src/types.ts
@@ -15,6 +15,7 @@ export interface OAuth2CredentialData {
 	additionalBodyProperties?: string;
 	grantType: OAuth2GrantType;
 	ignoreSSLIssues?: boolean;
+	tokenExpiredStatusCode?: number;
 	oauthTokenData?: {
 		access_token: string;
 		refresh_token?: string;

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/request-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/request-helper-functions.test.ts
@@ -28,6 +28,7 @@ import {
 	proxyRequestToAxios,
 	refreshOAuth2Token,
 	removeEmptyBody,
+	requestOAuth2,
 } from '../request-helper-functions';
 
 describe('Request Helper Functions', () => {
@@ -1264,6 +1265,155 @@ describe('Request Helper Functions', () => {
 			expect(
 				mockAdditionalData.credentialsHelper.updateCredentialsOauthTokenData,
 			).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('requestOAuth2 - tokenExpiredStatusCode', () => {
+		const baseUrl = 'https://api.example.com';
+		const tokenUrl = 'https://auth.example.com';
+		const mockThis = mockDeep<IAllExecuteFunctions>();
+		const mockNode = mockDeep<INode>();
+		const mockAdditionalData = mockDeep<IWorkflowExecuteAdditionalData>();
+
+		const makeCredentialData = (overrides?: Record<string, unknown>) => ({
+			clientId: 'test-client-id',
+			clientSecret: 'test-client-secret',
+			grantType: 'clientCredentials',
+			accessTokenUrl: `${tokenUrl}/token`,
+			authentication: 'body',
+			scope: 'read',
+			oauthTokenData: {
+				access_token: 'expired-token',
+				token_type: 'bearer',
+			},
+			...overrides,
+		});
+
+		beforeEach(() => {
+			nock.cleanAll();
+			jest.resetAllMocks();
+			mockNode.name = 'test-node';
+			mockNode.credentials = {
+				testOAuth2: {
+					id: 'cred-id',
+					name: 'cred-name',
+				},
+			};
+		});
+
+		test('should retry on 401 by default (isN8nRequest path)', async () => {
+			mockThis.getCredentials.mockResolvedValue(makeCredentialData());
+
+			// First call returns 401
+			nock(baseUrl).get('/data').reply(401, 'Unauthorized');
+			// Token re-fetch
+			nock(tokenUrl).post('/token').reply(200, {
+				access_token: 'new-token',
+				token_type: 'bearer',
+			});
+			// Retry succeeds
+			nock(baseUrl).get('/data').reply(200, { success: true });
+
+			mockThis.helpers.httpRequest.mockRejectedValueOnce(
+				Object.assign(new Error('401'), { response: { status: 401 } }),
+			);
+			mockThis.helpers.httpRequest.mockResolvedValueOnce({ success: true });
+
+			const result = await requestOAuth2.call(
+				mockThis,
+				'testOAuth2',
+				{ method: 'GET', url: `${baseUrl}/data` },
+				mockNode,
+				mockAdditionalData,
+				undefined,
+				true, // isN8nRequest
+			);
+
+			expect(result).toEqual({ success: true });
+			expect(mockThis.helpers.httpRequest).toHaveBeenCalledTimes(2);
+		});
+
+		test('should retry on custom tokenExpiredStatusCode from credentials (isN8nRequest path)', async () => {
+			mockThis.getCredentials.mockResolvedValue(
+				makeCredentialData({ tokenExpiredStatusCode: 403 }),
+			);
+
+			// Token re-fetch
+			nock(tokenUrl).post('/token').reply(200, {
+				access_token: 'new-token',
+				token_type: 'bearer',
+			});
+
+			mockThis.helpers.httpRequest.mockRejectedValueOnce(
+				Object.assign(new Error('403'), { response: { status: 403 } }),
+			);
+			mockThis.helpers.httpRequest.mockResolvedValueOnce({ success: true });
+
+			const result = await requestOAuth2.call(
+				mockThis,
+				'testOAuth2',
+				{ method: 'GET', url: `${baseUrl}/data` },
+				mockNode,
+				mockAdditionalData,
+				undefined,
+				true,
+			);
+
+			expect(result).toEqual({ success: true });
+			expect(mockThis.helpers.httpRequest).toHaveBeenCalledTimes(2);
+		});
+
+		test('should NOT retry on 401 when credential sets tokenExpiredStatusCode to 403 (isN8nRequest path)', async () => {
+			mockThis.getCredentials.mockResolvedValue(
+				makeCredentialData({ tokenExpiredStatusCode: 403 }),
+			);
+
+			const error401 = Object.assign(new Error('401'), { response: { status: 401 } });
+			mockThis.helpers.httpRequest.mockRejectedValueOnce(error401);
+
+			await expect(
+				requestOAuth2.call(
+					mockThis,
+					'testOAuth2',
+					{ method: 'GET', url: `${baseUrl}/data` },
+					mockNode,
+					mockAdditionalData,
+					undefined,
+					true,
+				),
+			).rejects.toThrow('401');
+
+			expect(mockThis.helpers.httpRequest).toHaveBeenCalledTimes(1);
+		});
+
+		test('credential-level tokenExpiredStatusCode should take priority over oAuth2Options', async () => {
+			mockThis.getCredentials.mockResolvedValue(
+				makeCredentialData({ tokenExpiredStatusCode: 403 }),
+			);
+
+			// Token re-fetch
+			nock(tokenUrl).post('/token').reply(200, {
+				access_token: 'new-token',
+				token_type: 'bearer',
+			});
+
+			// credential says 403, oAuth2Options says 429 — 403 should win
+			const error403 = Object.assign(new Error('403'), { response: { status: 403 } });
+			mockThis.helpers.httpRequest.mockRejectedValueOnce(error403);
+			mockThis.helpers.httpRequest.mockResolvedValueOnce({ success: true });
+
+			const result = await requestOAuth2.call(
+				mockThis,
+				'testOAuth2',
+				{ method: 'GET', url: `${baseUrl}/data` },
+				mockNode,
+				mockAdditionalData,
+				{ tokenExpiredStatusCode: 429 },
+				true,
+			);
+
+			expect(result).toEqual({ success: true });
+			expect(mockThis.helpers.httpRequest).toHaveBeenCalledTimes(2);
 		});
 	});
 });

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helper-functions.ts
@@ -10,6 +10,7 @@ import { Logger } from '@n8n/backend-common';
 import type {
 	ClientOAuth2Options,
 	ClientOAuth2RequestObject,
+	ClientOAuth2Token,
 	ClientOAuth2TokenData,
 	OAuth2CredentialData,
 } from '@n8n/client-oauth2';
@@ -55,6 +56,7 @@ import type {
 	IRunExecutionData,
 	IWorkflowDataProxyAdditionalKeys,
 	IWorkflowExecuteAdditionalData,
+	Logger as WorkflowLogger,
 	NodeParameterValueType,
 	PaginationOptions,
 	RequestHelperFunctions,
@@ -941,6 +943,70 @@ function createOAuth2Client(credentials: OAuth2CredentialData): ClientOAuth2 {
 	});
 }
 
+interface RefreshOAuth2TokenContext {
+	credentials: OAuth2CredentialData;
+	token: ClientOAuth2Token;
+	credentialsType: string;
+	node: INode;
+	additionalData: IWorkflowExecuteAdditionalData;
+	oAuth2Options?: IOAuth2Options;
+	logger: WorkflowLogger;
+}
+
+async function refreshOrFetchToken(ctx: RefreshOAuth2TokenContext): Promise<ClientOAuth2Token> {
+	const { credentials, token, credentialsType, node, additionalData, oAuth2Options, logger } = ctx;
+	const tokenRefreshOptions: IDataObject = {};
+	if (oAuth2Options?.includeCredentialsOnRefreshOnBody) {
+		const body: IDataObject = {
+			client_id: credentials.clientId,
+			...(credentials.grantType === 'authorizationCode' && {
+				client_secret: credentials.clientSecret as string,
+			}),
+		};
+		tokenRefreshOptions.body = body;
+		tokenRefreshOptions.headers = { Authorization: '' };
+	}
+
+	logger.debug(
+		`OAuth2 token for "${credentialsType}" used by node "${node.name}" expired. Revalidating.`,
+	);
+
+	let newToken;
+	if (credentials.grantType === 'clientCredentials') {
+		newToken = await token.client.credentials.getToken();
+	} else {
+		newToken = await token.refresh(tokenRefreshOptions as unknown as ClientOAuth2Options);
+	}
+
+	logger.debug(
+		`OAuth2 token for "${credentialsType}" used by node "${node.name}" has been renewed.`,
+	);
+
+	credentials.oauthTokenData = newToken.data;
+	if (!node.credentials?.[credentialsType]) {
+		throw new ApplicationError('Node does not have credential type', {
+			extra: { nodeName: node.name, credentialType: credentialsType },
+		});
+	}
+
+	const nodeCredentials = node.credentials[credentialsType];
+	await additionalData.credentialsHelper.updateCredentialsOauthTokenData(
+		nodeCredentials,
+		credentialsType,
+		credentials as unknown as ICredentialDataDecryptedObject,
+		additionalData,
+	);
+
+	return newToken;
+}
+
+function resolveTokenExpiredStatusCode(
+	oAuth2Options?: IOAuth2Options,
+	credentials?: OAuth2CredentialData,
+): number {
+	return credentials?.tokenExpiredStatusCode ?? oAuth2Options?.tokenExpiredStatusCode ?? 401;
+}
+
 /** @deprecated make these requests using httpRequestWithAuthentication */
 export async function requestOAuth2(
 	this: IAllExecuteFunctions,
@@ -1022,74 +1088,40 @@ export async function requestOAuth2(
 			[oAuth2Options.keyToIncludeInAccessTokenHeader]: token.accessToken,
 		});
 	}
+	const tokenExpiredStatusCode = resolveTokenExpiredStatusCode(oAuth2Options, credentials);
+
+	const refreshCtx: RefreshOAuth2TokenContext = {
+		credentials,
+		token,
+		credentialsType,
+		node,
+		additionalData,
+		oAuth2Options,
+		logger: this.logger,
+	};
+
+	const retryWithNewToken = async (
+		makeRequest: (opts: ClientOAuth2RequestObject) => Promise<any>,
+	) => {
+		const newToken = await refreshOrFetchToken(refreshCtx);
+		const refreshedRequestOptions = newToken.sign(requestOptions as ClientOAuth2RequestObject);
+		refreshedRequestOptions.headers = refreshedRequestOptions.headers ?? {};
+		if (oAuth2Options?.keyToIncludeInAccessTokenHeader) {
+			Object.assign(refreshedRequestOptions.headers, {
+				[oAuth2Options.keyToIncludeInAccessTokenHeader]: newToken.accessToken,
+			});
+		}
+		return await makeRequest(refreshedRequestOptions);
+	};
+
 	if (isN8nRequest) {
 		return await this.helpers.httpRequest(newRequestOptions).catch(async (error: AxiosError) => {
-			if (error.response?.status === 401) {
-				this.logger.debug(
-					`OAuth2 token for "${credentialsType}" used by node "${node.name}" expired. Should revalidate.`,
-				);
-				const tokenRefreshOptions: IDataObject = {};
-				if (oAuth2Options?.includeCredentialsOnRefreshOnBody) {
-					const body: IDataObject = {
-						client_id: credentials.clientId,
-						...(credentials.grantType === 'authorizationCode' && {
-							client_secret: credentials.clientSecret as string,
-						}),
-					};
-					tokenRefreshOptions.body = body;
-					tokenRefreshOptions.headers = {
-						Authorization: '',
-					};
-				}
-
-				let newToken;
-
-				this.logger.debug(
-					`OAuth2 token for "${credentialsType}" used by node "${node.name}" has been renewed.`,
-				);
-				// if it's OAuth2 with client credentials grant type, get a new token
-				// instead of refreshing it.
-				if (credentials.grantType === 'clientCredentials') {
-					newToken = await token.client.credentials.getToken();
-				} else {
-					newToken = await token.refresh(tokenRefreshOptions as unknown as ClientOAuth2Options);
-				}
-
-				this.logger.debug(
-					`OAuth2 token for "${credentialsType}" used by node "${node.name}" has been renewed.`,
-				);
-
-				credentials.oauthTokenData = newToken.data;
-				// Find the credentials
-				if (!node.credentials?.[credentialsType]) {
-					throw new ApplicationError('Node does not have credential type', {
-						extra: { nodeName: node.name, credentialType: credentialsType },
-					});
-				}
-				const nodeCredentials = node.credentials[credentialsType];
-				await additionalData.credentialsHelper.updateCredentialsOauthTokenData(
-					nodeCredentials,
-					credentialsType,
-					credentials as unknown as ICredentialDataDecryptedObject,
-					additionalData,
-				);
-				const refreshedRequestOption = newToken.sign(requestOptions as ClientOAuth2RequestObject);
-
-				if (oAuth2Options?.keyToIncludeInAccessTokenHeader) {
-					Object.assign(newRequestHeaders, {
-						[oAuth2Options.keyToIncludeInAccessTokenHeader]: token.accessToken,
-					});
-				}
-
-				return await this.helpers.httpRequest(refreshedRequestOption);
+			if (error.response?.status === tokenExpiredStatusCode) {
+				return await retryWithNewToken(async (opts) => await this.helpers.httpRequest(opts));
 			}
 			throw error;
 		});
 	}
-	const tokenExpiredStatusCode =
-		oAuth2Options?.tokenExpiredStatusCode === undefined
-			? 401
-			: oAuth2Options?.tokenExpiredStatusCode;
 
 	return await this.helpers
 		.request(newRequestOptions as IRequestOptions)
@@ -1106,73 +1138,10 @@ export async function requestOAuth2(
 		})
 		.catch(async (error: IResponseError) => {
 			if (error.statusCode === tokenExpiredStatusCode) {
-				// Token is probably not valid anymore. So try refresh it.
-				const tokenRefreshOptions: IDataObject = {};
-				if (oAuth2Options?.includeCredentialsOnRefreshOnBody) {
-					const body: IDataObject = {
-						client_id: credentials.clientId,
-						client_secret: credentials.clientSecret,
-					};
-					tokenRefreshOptions.body = body;
-					// Override authorization property so the credentials are not included in it
-					tokenRefreshOptions.headers = {
-						Authorization: '',
-					};
-				}
-				this.logger.debug(
-					`OAuth2 token for "${credentialsType}" used by node "${node.name}" expired. Should revalidate.`,
+				return await retryWithNewToken(
+					async (opts) => await this.helpers.request(opts as IRequestOptions),
 				);
-
-				let newToken;
-
-				// if it's OAuth2 with client credentials grant type, get a new token
-				// instead of refreshing it.
-				if (credentials.grantType === 'clientCredentials') {
-					newToken = await token.client.credentials.getToken();
-				} else {
-					newToken = await token.refresh(tokenRefreshOptions as unknown as ClientOAuth2Options);
-				}
-				this.logger.debug(
-					`OAuth2 token for "${credentialsType}" used by node "${node.name}" has been renewed.`,
-				);
-
-				credentials.oauthTokenData = newToken.data;
-
-				// Find the credentials
-				if (!node.credentials?.[credentialsType]) {
-					throw new ApplicationError('Node does not have credential type', {
-						tags: { credentialType: credentialsType },
-						extra: { nodeName: node.name },
-					});
-				}
-				const nodeCredentials = node.credentials[credentialsType];
-
-				// Save the refreshed token
-				await additionalData.credentialsHelper.updateCredentialsOauthTokenData(
-					nodeCredentials,
-					credentialsType,
-					credentials as unknown as ICredentialDataDecryptedObject,
-					additionalData,
-				);
-
-				this.logger.debug(
-					`OAuth2 token for "${credentialsType}" used by node "${node.name}" has been saved to database successfully.`,
-				);
-
-				// Make the request again with the new token
-				const newRequestOptions = newToken.sign(requestOptions as ClientOAuth2RequestObject);
-				newRequestOptions.headers = newRequestOptions.headers ?? {};
-
-				if (oAuth2Options?.keyToIncludeInAccessTokenHeader) {
-					Object.assign(newRequestOptions.headers, {
-						[oAuth2Options.keyToIncludeInAccessTokenHeader]: token.accessToken,
-					});
-				}
-
-				return await this.helpers.request(newRequestOptions as IRequestOptions);
 			}
-
-			// Unknown error so simply throw it
 			throw error;
 		});
 }
@@ -1277,54 +1246,16 @@ export async function refreshOAuth2Token(
 		},
 		oAuth2Options?.tokenType || oauthTokenData.tokenType,
 	);
-	const tokenRefreshOptions: IDataObject = {};
-	if (oAuth2Options?.includeCredentialsOnRefreshOnBody) {
-		const body: IDataObject = {
-			client_id: credentials.clientId,
-			...(credentials.grantType === 'authorizationCode' && {
-				client_secret: credentials.clientSecret as string,
-			}),
-		};
-		tokenRefreshOptions.body = body;
-		tokenRefreshOptions.headers = {
-			Authorization: '',
-		};
-	}
 
-	this.logger.debug(
-		`Refreshing the OAuth2 token for "${credentialsType}" used by node "${node.name}".`,
-	);
-
-	let newToken;
-	// If it's OAuth2 with client credentials grant type, get a new token instead of refreshing it.
-	if (credentials.grantType === 'clientCredentials') {
-		newToken = await token.client.credentials.getToken();
-	} else {
-		newToken = await token.refresh(tokenRefreshOptions as unknown as ClientOAuth2Options);
-	}
-
-	this.logger.debug(
-		`OAuth2 token for "${credentialsType}" used by node "${node.name}" has been renewed.`,
-	);
-
-	credentials.oauthTokenData = newToken.data;
-	if (!node.credentials?.[credentialsType]) {
-		throw new ApplicationError('Node does not have credential type', {
-			extra: { nodeName: node.name, credentialType: credentialsType },
-		});
-	}
-
-	const nodeCredentials = node.credentials[credentialsType];
-	await additionalData.credentialsHelper.updateCredentialsOauthTokenData(
-		nodeCredentials,
+	const newToken = await refreshOrFetchToken({
+		credentials,
+		token,
 		credentialsType,
-		credentials as unknown as ICredentialDataDecryptedObject,
+		node,
 		additionalData,
-	);
-
-	this.logger.debug(
-		`OAuth2 token for "${credentialsType}" used by node "${node.name}" has been saved to database successfully.`,
-	);
+		oAuth2Options,
+		logger: this.logger,
+	});
 
 	return newToken.data;
 }

--- a/packages/nodes-base/credentials/OAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/OAuth2Api.credentials.ts
@@ -188,6 +188,15 @@ export class OAuth2Api implements ICredentialType {
 			default: '',
 		},
 		{
+			displayName: 'Token Expired Status Code',
+			name: 'tokenExpiredStatusCode',
+			type: 'number',
+			default: 401,
+			description:
+				'HTTP status code that indicates the token has expired. Some APIs return 403 instead of 401.',
+			doNotInherit: true,
+		},
+		{
 			displayName: 'Ignore SSL Issues (Insecure)',
 			name: 'ignoreSSLIssues',
 			type: 'boolean',

--- a/packages/nodes-base/credentials/OAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/OAuth2Api.credentials.ts
@@ -188,19 +188,19 @@ export class OAuth2Api implements ICredentialType {
 			default: '',
 		},
 		{
+			displayName: 'Ignore SSL Issues (Insecure)',
+			name: 'ignoreSSLIssues',
+			type: 'boolean',
+			default: false,
+			doNotInherit: true,
+		},
+		{
 			displayName: 'Token Expired Status Code',
 			name: 'tokenExpiredStatusCode',
 			type: 'number',
 			default: 401,
 			description:
 				'HTTP status code that indicates the token has expired. Some APIs return 403 instead of 401.',
-			doNotInherit: true,
-		},
-		{
-			displayName: 'Ignore SSL Issues (Insecure)',
-			name: 'ignoreSSLIssues',
-			type: 'boolean',
-			default: false,
 			doNotInherit: true,
 		},
 	];


### PR DESCRIPTION
## Summary

- Added support for configurable HTTP status codes to trigger OAuth2 token refresh. 
  - Previously, only 401 was checked. 
  - This PR allows users to specify custom status codes (e.g., 403) that indicate token expiration for APIs that return non-standard codes. 
- Extracted duplicate token refresh logic into a shared helper and added comprehensive unit tests covering the new behavior.

<img width="2224" height="1222" alt="image" src="https://github.com/user-attachments/assets/b8415286-a07b-4031-b329-ed3953562543" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-36

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] Tests included (4 new unit tests for token refresh behavior)
- [ ] Docs updated or follow-up ticket created
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)