### PR TITLE
fix(core): Support project-scoped externalSecret:list in credential validation (no-changelog)

### DIFF
--- a/packages/cli/src/credentials/__tests__/credentials.controller.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.controller.test.ts
@@ -20,6 +20,7 @@ import type { CredentialsFinderService } from '../credentials-finder.service';
 import { CredentialsController } from '../credentials.controller';
 import { CredentialsService } from '../credentials.service';
 import * as validation from '../validation';
+import * as checkAccess from '@/permissions.ee/check-access';
 import { createNewCredentialsPayload, createdCredentialsWithScopes } from './credentials.test-data';
 
 describe('CredentialsController', () => {
@@ -461,6 +462,7 @@ describe('CredentialsController', () => {
 		});
 
 		it('should throw error when editing external secret expression without permission', async () => {
+			jest.spyOn(checkAccess, 'userHasScopes').mockResolvedValue(false);
 			const memberReq = {
 				user: { id: 'member-id', role: GLOBAL_MEMBER_ROLE },
 				params: { credentialId },
@@ -494,6 +496,7 @@ describe('CredentialsController', () => {
 		});
 
 		it('should throw error when adding new external secret expression without permission', async () => {
+			jest.spyOn(checkAccess, 'userHasScopes').mockResolvedValue(false);
 			const memberReq = {
 				user: { id: 'member-id', role: GLOBAL_MEMBER_ROLE },
 				params: { credentialId },

--- a/packages/cli/src/credentials/__tests__/credentials.controller.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.controller.test.ts
@@ -484,13 +484,12 @@ describe('CredentialsController', () => {
 			await expect(credentialsController.updateCredentials(memberReq)).rejects.toThrow(
 				'Lacking permissions to reference external secrets in credentials',
 			);
-			expect(validateExternalSecretsPermissionsSpy).toHaveBeenCalledWith(
-				memberReq.user,
-				memberReq.body.data,
-				{
-					apiKey: '$secrets.oldKey',
-				},
-			);
+			expect(validateExternalSecretsPermissionsSpy).toHaveBeenCalledWith({
+				user: memberReq.user,
+				projectId: existingCredential.shared[0].projectId,
+				dataToSave: memberReq.body.data,
+				decryptedExistingData: { apiKey: '$secrets.oldKey' },
+			});
 			expect(credentialsService.update).not.toHaveBeenCalled();
 		});
 
@@ -514,13 +513,12 @@ describe('CredentialsController', () => {
 			await expect(credentialsController.updateCredentials(memberReq)).rejects.toThrow(
 				'Lacking permissions to reference external secrets in credentials',
 			);
-			expect(validateExternalSecretsPermissionsSpy).toHaveBeenCalledWith(
-				memberReq.user,
-				memberReq.body.data,
-				{
-					apiKey: 'regular-key',
-				},
-			);
+			expect(validateExternalSecretsPermissionsSpy).toHaveBeenCalledWith({
+				user: memberReq.user,
+				projectId: existingCredential.shared[0].projectId,
+				dataToSave: memberReq.body.data,
+				decryptedExistingData: { apiKey: 'regular-key' },
+			});
 			expect(credentialsService.update).not.toHaveBeenCalled();
 		});
 	});

--- a/packages/cli/src/credentials/__tests__/credentials.service.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.service.test.ts
@@ -10,7 +10,11 @@ import type {
 import { GLOBAL_OWNER_ROLE, GLOBAL_MEMBER_ROLE } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 import { CREDENTIAL_ERRORS, CredentialDataError, Credentials, type ErrorReporter } from 'n8n-core';
-import { CREDENTIAL_EMPTY_VALUE, type ICredentialType } from 'n8n-workflow';
+import {
+	CREDENTIAL_EMPTY_VALUE,
+	type ICredentialDataDecryptedObject,
+	type ICredentialType,
+} from 'n8n-workflow';
 
 import { CREDENTIAL_BLANKING_VALUE } from '@/constants';
 import type { CredentialTypes } from '@/credential-types';
@@ -21,6 +25,7 @@ import type { CredentialsHelper } from '@/credentials-helper';
 import type { ExternalHooks } from '@/external-hooks';
 import type { ExternalSecretsConfig } from '@/modules/external-secrets.ee/external-secrets.config';
 import type { SecretsProviderAccessCheckService } from '@/modules/external-secrets.ee/secret-provider-access-check.service.ee';
+import * as checkAccess from '@/permissions.ee/check-access';
 import type { CredentialsTester } from '@/services/credentials-tester.service';
 import type { OwnershipService } from '@/services/ownership.service';
 import type { ProjectService } from '@/services/project.service.ee';
@@ -1671,6 +1676,7 @@ describe('CredentialsService', () => {
 
 		describe('external secrets', () => {
 			it('should prevent use of external secret expression when required permission is missing', async () => {
+				jest.spyOn(checkAccess, 'userHasScopes').mockResolvedValue(false);
 				credentialsHelper.getCredentialsProperties.mockReturnValue([]);
 				const payload = {
 					name: 'Test Credential',
@@ -2060,9 +2066,8 @@ describe('CredentialsService', () => {
 				},
 			]);
 
-			const data = { apiKey: undefined };
+			const data = { apiKey: undefined } as unknown as ICredentialDataDecryptedObject;
 
-			// @ts-expect-error - Testing edge case with undefined value
 			await expect(
 				service.checkCredentialData('apiCredential', data, ownerUser, testProjectId),
 			).rejects.toThrow('The field "apiKey" is mandatory for credentials of type "apiCredential"');

--- a/packages/cli/src/credentials/__tests__/credentials.service.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.service.test.ts
@@ -1938,12 +1938,14 @@ describe('CredentialsService', () => {
 
 	describe('checkCredentialData', () => {
 		const ownerUser = mock<User>({ id: 'owner-id', role: GLOBAL_OWNER_ROLE });
+		const testProjectId = 'test-project-id';
 
 		beforeEach(() => {
 			jest.clearAllMocks();
+			jest.spyOn(validation, 'validateExternalSecretsPermissions').mockResolvedValue();
 		});
 
-		it('should pass when all required fields are provided', () => {
+		it('should pass when all required fields are provided', async () => {
 			credentialsHelper.getCredentialsProperties.mockReturnValue([
 				{
 					displayName: 'API Key',
@@ -1968,10 +1970,12 @@ describe('CredentialsService', () => {
 				domain: 'example.com',
 			};
 
-			expect(() => service.checkCredentialData('apiCredential', data, ownerUser)).not.toThrow();
+			await expect(
+				service.checkCredentialData('apiCredential', data, ownerUser, testProjectId),
+			).resolves.not.toThrow();
 		});
 
-		it('should pass when required field with valid default is not provided', () => {
+		it('should pass when required field with valid default is not provided', async () => {
 			credentialsHelper.getCredentialsProperties.mockReturnValue([
 				{
 					displayName: 'Host',
@@ -1985,10 +1989,12 @@ describe('CredentialsService', () => {
 
 			const data = {};
 
-			expect(() => service.checkCredentialData('apiCredential', data, ownerUser)).not.toThrow();
+			await expect(
+				service.checkCredentialData('apiCredential', data, ownerUser, testProjectId),
+			).resolves.not.toThrow();
 		});
 
-		it('should pass when credential has no required fields', () => {
+		it('should pass when credential has no required fields', async () => {
 			credentialsHelper.getCredentialsProperties.mockReturnValue([
 				{
 					displayName: 'Optional Field',
@@ -2001,21 +2007,29 @@ describe('CredentialsService', () => {
 
 			const data = {};
 
-			expect(() => service.checkCredentialData('apiCredential', data, ownerUser)).not.toThrow();
+			await expect(
+				service.checkCredentialData('apiCredential', data, ownerUser, testProjectId),
+			).resolves.not.toThrow();
 		});
 
-		it('should call validateExternalSecretsPermissions', () => {
+		it('should call validateExternalSecretsPermissions', async () => {
 			credentialsHelper.getCredentialsProperties.mockReturnValue([]);
-			const validateSpy = jest.spyOn(validation, 'validateExternalSecretsPermissions');
+			const validateSpy = jest
+				.spyOn(validation, 'validateExternalSecretsPermissions')
+				.mockResolvedValue();
 
 			const data = { apiKey: 'test-key' };
 
-			service.checkCredentialData('apiCredential', data, ownerUser);
+			await service.checkCredentialData('apiCredential', data, ownerUser, testProjectId);
 
-			expect(validateSpy).toHaveBeenCalledWith(ownerUser, data);
+			expect(validateSpy).toHaveBeenCalledWith({
+				user: ownerUser,
+				projectId: testProjectId,
+				dataToSave: data,
+			});
 		});
 
-		it('should throw BadRequestError when required field is missing and has no default', () => {
+		it('should throw BadRequestError when required field is missing and has no default', async () => {
 			credentialsHelper.getCredentialsProperties.mockReturnValue([
 				{
 					displayName: 'API Key',
@@ -2029,12 +2043,12 @@ describe('CredentialsService', () => {
 
 			const data = {}; // apiKey is missing
 
-			expect(() => service.checkCredentialData('apiCredential', data, ownerUser)).toThrow(
-				'The field "apiKey" is mandatory for credentials of type "apiCredential"',
-			);
+			await expect(
+				service.checkCredentialData('apiCredential', data, ownerUser, testProjectId),
+			).rejects.toThrow('The field "apiKey" is mandatory for credentials of type "apiCredential"');
 		});
 
-		it('should throw when required field value is undefined', () => {
+		it('should throw when required field value is undefined', async () => {
 			credentialsHelper.getCredentialsProperties.mockReturnValue([
 				{
 					displayName: 'API Key',
@@ -2049,12 +2063,12 @@ describe('CredentialsService', () => {
 			const data = { apiKey: undefined };
 
 			// @ts-expect-error - Testing edge case with undefined value
-			expect(() => service.checkCredentialData('apiCredential', data, ownerUser)).toThrow(
-				'The field "apiKey" is mandatory for credentials of type "apiCredential"',
-			);
+			await expect(
+				service.checkCredentialData('apiCredential', data, ownerUser, testProjectId),
+			).rejects.toThrow('The field "apiKey" is mandatory for credentials of type "apiCredential"');
 		});
 
-		it('should throw when required field value is empty string', () => {
+		it('should throw when required field value is empty string', async () => {
 			credentialsHelper.getCredentialsProperties.mockReturnValue([
 				{
 					displayName: 'API Key',
@@ -2068,12 +2082,12 @@ describe('CredentialsService', () => {
 
 			const data = { apiKey: '' };
 
-			expect(() => service.checkCredentialData('apiCredential', data, ownerUser)).toThrow(
-				'The field "apiKey" is mandatory for credentials of type "apiCredential"',
-			);
+			await expect(
+				service.checkCredentialData('apiCredential', data, ownerUser, testProjectId),
+			).rejects.toThrow('The field "apiKey" is mandatory for credentials of type "apiCredential"');
 		});
 
-		it('should skip validation when required field has displayOptions undefined', () => {
+		it('should skip validation when required field has displayOptions undefined', async () => {
 			credentialsHelper.getCredentialsProperties.mockReturnValue([
 				{
 					displayName: 'API Key',
@@ -2088,10 +2102,12 @@ describe('CredentialsService', () => {
 			const data = {}; // apiKey is missing
 
 			// Should not throw because displayOptions is undefined, so validation is skipped
-			expect(() => service.checkCredentialData('apiCredential', data, ownerUser)).not.toThrow();
+			await expect(
+				service.checkCredentialData('apiCredential', data, ownerUser, testProjectId),
+			).resolves.not.toThrow();
 		});
 
-		it('should skip validation when required field is hidden by displayOptions', () => {
+		it('should skip validation when required field is hidden by displayOptions', async () => {
 			credentialsHelper.getCredentialsProperties.mockReturnValue([
 				{
 					displayName: 'API Key',
@@ -2110,10 +2126,12 @@ describe('CredentialsService', () => {
 			const data = { authType: 'apiKey' }; // apiKey is missing and field is hidden
 
 			// Should not throw because displayParameter will return false (field is hidden)
-			expect(() => service.checkCredentialData('apiCredential', data, ownerUser)).not.toThrow();
+			await expect(
+				service.checkCredentialData('apiCredential', data, ownerUser, testProjectId),
+			).resolves.not.toThrow();
 		});
 
-		it('should validate when required field is shown by displayOptions', () => {
+		it('should validate when required field is shown by displayOptions', async () => {
 			credentialsHelper.getCredentialsProperties.mockReturnValue([
 				{
 					displayName: 'API Key',
@@ -2132,12 +2150,12 @@ describe('CredentialsService', () => {
 			const data = { authType: 'oauth2' }; // Field is shown but apiKey is missing
 
 			// Should throw because field is shown but value is missing
-			expect(() => service.checkCredentialData('apiCredential', data, ownerUser)).toThrow(
-				'The field "apiKey" is mandatory for credentials of type "apiCredential"',
-			);
+			await expect(
+				service.checkCredentialData('apiCredential', data, ownerUser, testProjectId),
+			).rejects.toThrow('The field "apiKey" is mandatory for credentials of type "apiCredential"');
 		});
 
-		it('should validate when displayOptions is explicitly null (edge case)', () => {
+		it('should validate when displayOptions is explicitly null (edge case)', async () => {
 			credentialsHelper.getCredentialsProperties.mockReturnValue([
 				{
 					displayName: 'API Key',
@@ -2154,9 +2172,9 @@ describe('CredentialsService', () => {
 
 			// null !== undefined, so the check passes and displayParameter is called
 			// displayParameter treats null as falsy and returns true, so validation proceeds
-			expect(() => service.checkCredentialData('apiCredential', data, ownerUser)).toThrow(
-				'The field "apiKey" is mandatory for credentials of type "apiCredential"',
-			);
+			await expect(
+				service.checkCredentialData('apiCredential', data, ownerUser, testProjectId),
+			).rejects.toThrow('The field "apiKey" is mandatory for credentials of type "apiCredential"');
 		});
 	});
 });

--- a/packages/cli/src/credentials/__tests__/validation.test.ts
+++ b/packages/cli/src/credentials/__tests__/validation.test.ts
@@ -3,6 +3,7 @@ import type { User } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 
 import type { SecretsProviderAccessCheckService } from '@/modules/external-secrets.ee/secret-provider-access-check.service.ee';
+import * as checkAccess from '@/permissions.ee/check-access';
 
 import {
 	validateExternalSecretsPermissions,
@@ -14,6 +15,7 @@ import {
 describe('Credentials Validation', () => {
 	const ownerUser = mock<User>({ id: 'owner-id', role: GLOBAL_OWNER_ROLE });
 	const memberUser = mock<User>({ id: 'member-id', role: GLOBAL_MEMBER_ROLE });
+	const projectId = 'project-id';
 	const errorMessage = 'Lacking permissions to reference external secrets in credentials';
 
 	describe('extractProviderKeys', () => {
@@ -65,34 +67,47 @@ describe('Credentials Validation', () => {
 	});
 
 	describe('validateExternalSecretsPermissions', () => {
-		it('should pass when credential data contains no external secrets', () => {
+		beforeEach(() => {
+			jest.restoreAllMocks();
+		});
+
+		it('should pass when credential data contains no external secrets', async () => {
 			const data = {
 				apiKey: 'regular-key',
 				domain: 'example.com',
 			};
 
-			expect(() => validateExternalSecretsPermissions(memberUser, data)).not.toThrow();
+			await expect(
+				validateExternalSecretsPermissions({ user: memberUser, projectId, dataToSave: data }),
+			).resolves.not.toThrow();
 		});
 
-		it('should pass when credential data contains external secrets and user has permission', () => {
+		it('should pass when credential data contains external secrets and user has permission', async () => {
+			jest.spyOn(checkAccess, 'userHasScopes').mockResolvedValue(true);
 			const data = {
 				apiKey: '={{ $secrets.myApiKey }}',
 				domain: 'example.com',
 			};
 
-			expect(() => validateExternalSecretsPermissions(ownerUser, data)).not.toThrow();
+			await expect(
+				validateExternalSecretsPermissions({ user: ownerUser, projectId, dataToSave: data }),
+			).resolves.not.toThrow();
 		});
 
-		it('should throw BadRequestError when user lacks externalSecret:list permission', () => {
+		it('should throw BadRequestError when user lacks externalSecret:list permission', async () => {
+			jest.spyOn(checkAccess, 'userHasScopes').mockResolvedValue(false);
 			const data = {
 				apiKey: '={{ $secrets.myApiKey }}',
 				domain: 'example.com',
 			};
 
-			expect(() => validateExternalSecretsPermissions(memberUser, data)).toThrow(errorMessage);
+			await expect(
+				validateExternalSecretsPermissions({ user: memberUser, projectId, dataToSave: data }),
+			).rejects.toThrow(errorMessage);
 		});
 
-		it('should throw when user lacks permission and uses nested external secrets', () => {
+		it('should throw when user lacks permission and uses nested external secrets', async () => {
+			jest.spyOn(checkAccess, 'userHasScopes').mockResolvedValue(false);
 			const data = {
 				apiKey: 'regular-key',
 				advanced: {
@@ -100,10 +115,13 @@ describe('Credentials Validation', () => {
 				},
 			};
 
-			expect(() => validateExternalSecretsPermissions(memberUser, data)).toThrow(errorMessage);
+			await expect(
+				validateExternalSecretsPermissions({ user: memberUser, projectId, dataToSave: data }),
+			).rejects.toThrow(errorMessage);
 		});
 
-		it('should pass when user has permission and uses nested external secrets', () => {
+		it('should pass when user has permission and uses nested external secrets', async () => {
+			jest.spyOn(checkAccess, 'userHasScopes').mockResolvedValue(true);
 			const data = {
 				apiKey: 'regular-key',
 				advanced: {
@@ -111,10 +129,13 @@ describe('Credentials Validation', () => {
 				},
 			};
 
-			expect(() => validateExternalSecretsPermissions(ownerUser, data)).not.toThrow();
+			await expect(
+				validateExternalSecretsPermissions({ user: ownerUser, projectId, dataToSave: data }),
+			).resolves.not.toThrow();
 		});
 
-		it('should throw when updating nested credential with external secret without permission', () => {
+		it('should throw when updating nested credential with external secret without permission', async () => {
+			jest.spyOn(checkAccess, 'userHasScopes').mockResolvedValue(false);
 			const existingData = {
 				apiKey: 'key',
 				config: { token: 'old-token' },
@@ -124,34 +145,48 @@ describe('Credentials Validation', () => {
 				config: { token: '={{ $secrets.newToken }}' },
 			};
 
-			expect(() => validateExternalSecretsPermissions(memberUser, newData, existingData)).toThrow(
-				errorMessage,
-			);
+			await expect(
+				validateExternalSecretsPermissions({
+					user: memberUser,
+					projectId,
+					dataToSave: newData,
+					decryptedExistingData: existingData,
+				}),
+			).rejects.toThrow(errorMessage);
 		});
 
 		describe('bracket notation', () => {
-			it('should throw when user lacks permission and uses bracket notation', () => {
+			it('should throw when user lacks permission and uses bracket notation', async () => {
+				jest.spyOn(checkAccess, 'userHasScopes').mockResolvedValue(false);
 				const data = {
 					apiKey: "={{ $secrets['vault']['key'] }}",
 				};
 
-				expect(() => validateExternalSecretsPermissions(memberUser, data)).toThrow(errorMessage);
+				await expect(
+					validateExternalSecretsPermissions({ user: memberUser, projectId, dataToSave: data }),
+				).rejects.toThrow(errorMessage);
 			});
 
-			it('should pass when user has permission and uses bracket notation', () => {
+			it('should pass when user has permission and uses bracket notation', async () => {
+				jest.spyOn(checkAccess, 'userHasScopes').mockResolvedValue(true);
 				const data = {
 					apiKey: "={{ $secrets['vault']['key'] }}",
 				};
 
-				expect(() => validateExternalSecretsPermissions(ownerUser, data)).not.toThrow();
+				await expect(
+					validateExternalSecretsPermissions({ user: ownerUser, projectId, dataToSave: data }),
+				).resolves.not.toThrow();
 			});
 
-			it('should throw when user lacks permission and uses mixed notation', () => {
+			it('should throw when user lacks permission and uses mixed notation', async () => {
+				jest.spyOn(checkAccess, 'userHasScopes').mockResolvedValue(false);
 				const data = {
 					apiKey: "={{ $secrets.vault['nested'] }}",
 				};
 
-				expect(() => validateExternalSecretsPermissions(memberUser, data)).toThrow(errorMessage);
+				await expect(
+					validateExternalSecretsPermissions({ user: memberUser, projectId, dataToSave: data }),
+				).rejects.toThrow(errorMessage);
 			});
 		});
 	});

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -561,12 +561,18 @@ export class CredentialsService {
 		existingCredential: CredentialsEntity,
 	): Promise<CredentialsEntity> {
 		const decryptedData = this.decrypt(existingCredential, true);
-		validateExternalSecretsPermissions(user, data.data, decryptedData);
 
 		// eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain -- credential will always have an owner
 		const projectOwningCredential = existingCredential.shared?.find(
 			(shared) => shared.role === 'credential:owner',
 		)!;
+
+		await validateExternalSecretsPermissions({
+			user,
+			projectId: projectOwningCredential.projectId,
+			dataToSave: data.data,
+			decryptedExistingData: decryptedData,
+		});
 
 		if (this.externalSecretsConfig.externalSecretsForProjects && data.data) {
 			await validateAccessToReferencedSecretProviders(
@@ -1003,7 +1009,12 @@ export class CredentialsService {
 	 * TODO: consider refactoring enable using this for both creating and updating, right now only used for creation
 	 * (likely only affects the validateExternalSecretsPermissions call)
 	 */
-	checkCredentialData(type: string, data: ICredentialDataDecryptedObject, user: User) {
+	async checkCredentialData(
+		type: string,
+		data: ICredentialDataDecryptedObject,
+		user: User,
+		projectId: string,
+	): Promise<void> {
 		// check mandatory fields are present
 		const credentialProperties = this.credentialsHelper.getCredentialsProperties(type);
 		for (const property of credentialProperties) {
@@ -1028,7 +1039,7 @@ export class CredentialsService {
 				}
 			}
 		}
-		validateExternalSecretsPermissions(user, data);
+		await validateExternalSecretsPermissions({ user, projectId, dataToSave: data });
 		this.validateOAuthCredentialUrls(type, data);
 	}
 
@@ -1069,7 +1080,12 @@ export class CredentialsService {
 	}
 
 	private async createCredential(opts: CreateCredentialOptions, user: User) {
-		this.checkCredentialData(opts.type, opts.data as ICredentialDataDecryptedObject, user);
+		await this.checkCredentialData(
+			opts.type,
+			opts.data as ICredentialDataDecryptedObject,
+			user,
+			opts.projectId ?? '',
+		);
 		if (this.externalSecretsConfig.externalSecretsForProjects && opts.projectId) {
 			await validateAccessToReferencedSecretProviders(
 				opts.projectId,

--- a/packages/cli/src/credentials/validation.ts
+++ b/packages/cli/src/credentials/validation.ts
@@ -1,10 +1,10 @@
 import type { User } from '@n8n/db';
-import { hasGlobalScope } from '@n8n/permissions';
 import get from 'lodash/get';
 import { type ICredentialDataDecryptedObject } from 'n8n-workflow';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import type { SecretsProviderAccessCheckService } from '@/modules/external-secrets.ee/secret-provider-access-check.service.ee';
+import { userHasScopes } from '@/permissions.ee/check-access';
 import { getAllKeyPaths } from '@/utils';
 
 // #region External Secrets
@@ -101,17 +101,24 @@ export function isChangingExternalSecretExpression(
 }
 
 /**
- * Validates if a user has permission to use external secrets in credentials
+ * Validates if a user has permission to use external secrets in credentials.
+ * Accepts either global scope or project-level scope for `externalSecret:list`.
  *
  * @param dataToSave - only optional in case it's not provided in the payload of the request
  * @param decryptedExistingData - Optional existing credential data (optional as it can only be provided when updating an existing credential)
  * @throws {BadRequestError} If user lacks permission when attempting to use external secrets
  */
-export function validateExternalSecretsPermissions(
-	user: User,
-	dataToSave?: ICredentialDataDecryptedObject,
-	decryptedExistingData?: ICredentialDataDecryptedObject,
-): void {
+export async function validateExternalSecretsPermissions({
+	user,
+	projectId,
+	dataToSave,
+	decryptedExistingData,
+}: {
+	user: User;
+	projectId: string;
+	dataToSave?: ICredentialDataDecryptedObject;
+	decryptedExistingData?: ICredentialDataDecryptedObject;
+}): Promise<void> {
 	if (!dataToSave) {
 		return;
 	}
@@ -120,7 +127,8 @@ export function validateExternalSecretsPermissions(
 		? isChangingExternalSecretExpression(dataToSave, decryptedExistingData)
 		: containsExternalSecrets(dataToSave);
 	if (needsCheck) {
-		if (!hasGlobalScope(user, 'externalSecret:list')) {
+		const hasAccess = await userHasScopes(user, ['externalSecret:list'], false, { projectId });
+		if (!hasAccess) {
 			throw new BadRequestError('Lacking permissions to reference external secrets in credentials');
 		}
 	}

--- a/packages/cli/src/public-api/v1/handlers/credentials/__tests__/credentials.service.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/credentials/__tests__/credentials.service.test.ts
@@ -9,6 +9,7 @@ import type { GenericValue, IDataObject, INodeProperties } from 'n8n-workflow';
 import { CredentialsService } from '@/credentials/credentials.service';
 import { ExternalSecretsConfig } from '@/modules/external-secrets.ee/external-secrets.config';
 import { SecretsProviderAccessCheckService } from '@/modules/external-secrets.ee/secret-provider-access-check.service.ee';
+import * as checkAccess from '@/permissions.ee/check-access';
 import type { IDependency } from '@/public-api/types';
 
 import { buildSharedForCredential, toJsonSchema, updateCredential } from '../credentials.service';
@@ -475,6 +476,7 @@ describe('CredentialsService', () => {
 				project: owningProjectData as Project,
 			} as SharedCredentials;
 			it('should throw error when user without permission tries to add external secret expression', async () => {
+				jest.spyOn(checkAccess, 'userHasScopes').mockResolvedValue(false);
 				const existingCredential = mock<CredentialsEntity>({
 					id: 'cred-id',
 					name: 'Test Credential',
@@ -496,6 +498,7 @@ describe('CredentialsService', () => {
 			});
 
 			it('should throw error when user without permission tries to modify existing external secret expression', async () => {
+				jest.spyOn(checkAccess, 'userHasScopes').mockResolvedValue(false);
 				const existingCredential = mock<CredentialsEntity>({
 					id: 'cred-id',
 					name: 'Test Credential',

--- a/packages/cli/src/public-api/v1/handlers/credentials/__tests__/credentials.service.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/credentials/__tests__/credentials.service.test.ts
@@ -523,6 +523,7 @@ describe('CredentialsService', () => {
 			});
 
 			it('should throw error when external secret store referenced in expression is not shared with current project', async () => {
+				jest.spyOn(checkAccess, 'userHasScopes').mockResolvedValue(true);
 				const existingCredential = mock<CredentialsEntity>({
 					id: 'UdGtZBYb2TLDgSHy',
 					name: 'Test Credential',
@@ -597,6 +598,7 @@ describe('CredentialsService', () => {
 			});
 
 			it('should allow user with permission to add external secret expression', async () => {
+				jest.spyOn(checkAccess, 'userHasScopes').mockResolvedValue(true);
 				const existingCredential = mock<CredentialsEntity>({
 					id: 'cred-id',
 					name: 'Test Credential',

--- a/packages/cli/src/public-api/v1/handlers/credentials/credentials.service.ts
+++ b/packages/cli/src/public-api/v1/handlers/credentials/credentials.service.ts
@@ -106,12 +106,18 @@ export async function saveCredential(
 ): Promise<CredentialsEntity> {
 	const credential = await createCredential(payload);
 
-	validateExternalSecretsPermissions(user, payload.data);
+	const projectRepository = Container.get(ProjectRepository);
+	const personalProject = await projectRepository.getPersonalProjectForUserOrFail(user.id);
+
+	await validateExternalSecretsPermissions({
+		user,
+		projectId: personalProject.id,
+		dataToSave: payload.data,
+	});
 
 	const encryptedData = await encryptCredential(credential);
 	Object.assign(credential, encryptedData);
 
-	const projectRepository = Container.get(ProjectRepository);
 	const { manager: dbManager } = projectRepository;
 	const result = await dbManager.transaction(async (transactionManager) => {
 		const savedCredential = await transactionManager.save<CredentialsEntity>(credential);
@@ -119,11 +125,6 @@ export async function saveCredential(
 		savedCredential.data = credential.data;
 
 		const newSharedCredential = new SharedCredentials();
-
-		const personalProject = await projectRepository.getPersonalProjectForUserOrFail(
-			user.id,
-			transactionManager,
-		);
 
 		Object.assign(newSharedCredential, {
 			role: 'credential:owner',
@@ -194,14 +195,19 @@ export async function updateCredential(
 		// Decrypt existing data to access oauthTokenData
 		const decryptedData = credentialsService.decrypt(existingCredential as CredentialsEntity, true);
 
-		validateExternalSecretsPermissions(user, updateData.data, decryptedData);
+		// eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain -- credential will always have an owner
+		const projectOwningCredential = existingCredential.shared?.find(
+			(shared) => shared.role === 'credential:owner',
+		)!;
+
+		await validateExternalSecretsPermissions({
+			user,
+			projectId: projectOwningCredential.project.id,
+			dataToSave: updateData.data,
+			decryptedExistingData: decryptedData,
+		});
 
 		if (isProjectScopedExternalSecretsEnabled() && decryptedData) {
-			// eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain -- credential will always have an owner
-			const projectOwningCredential = existingCredential.shared?.find(
-				(shared) => shared.role === 'credential:owner',
-			)!;
-
 			await validateAccessToReferencedSecretProviders(
 				projectOwningCredential.project.id,
 				updateData.data,


### PR DESCRIPTION
## Summary

Updates `validateExternalSecretsPermissions` to accept project-scoped `externalSecret:list` access in addition to global scope. Previously the check was global-only, blocking project users with custom roles that grant `externalSecret:list` at the project level.

- `validateExternalSecretsPermissions` is now async and takes an object param `{ user, projectId, dataToSave?, decryptedExistingData? }`, using `userHasScopes` instead of `hasGlobalScope`
- `checkCredentialData` becomes async and accepts `projectId`
- Public API `saveCredential` resolves personal project before the permission check (also eliminates a redundant inner DB fetch)
- All affected unit tests updated

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-313

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)