### PR TITLE
fix(core): Ignore parameter name when renaming binary file

### DIFF
--- a/packages/cli/src/execution-lifecycle/__tests__/restore-binary-data-id.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/restore-binary-data-id.test.ts
@@ -25,7 +25,7 @@ function toIRun(item?: object) {
 
 function getDataId(run: IRun, kind: 'binary' | 'json') {
 	// @ts-expect-error The type doesn't have the correct structure
-	return run.data.resultData.runData.myNode[0].data.main[0][0][kind].data.id;
+	return Object.values(run.data.resultData.runData.myNode[0].data.main[0][0][kind])[0].id;
 }
 
 const binaryDataService = mockInstance(BinaryDataService);
@@ -50,6 +50,28 @@ for (const mode of ['filesystem', 's3'] as const) {
 			const run = toIRun({
 				binary: {
 					data: { id: `s3:${incorrectFileId}` },
+				},
+			});
+
+			await restoreBinaryDataId(run, executionId, 'webhook');
+
+			const correctFileId = incorrectFileId.replace('temp', executionId);
+			const correctBinaryDataId = `s3:${correctFileId}`;
+
+			expect(binaryDataService.rename).toHaveBeenCalledWith(incorrectFileId, correctFileId);
+			expect(getDataId(run, 'binary')).toBe(correctBinaryDataId);
+		});
+
+		it('should restore if binary data ID in a given form-data name is missing execution ID', async () => {
+			const workflowId = '6HYhhKmJch2cYxGj';
+			const executionId = '999';
+			const binaryDataFileUuid = 'a5c3f1ed-9d59-4155-bc68-9a370b3c51f6';
+
+			const incorrectFileId = `workflows/${workflowId}/executions/temp/binary_data/${binaryDataFileUuid}`;
+
+			const run = toIRun({
+				binary: {
+					formDataName: { id: `s3:${incorrectFileId}` },
 				},
 			});
 

--- a/packages/cli/src/execution-lifecycle/__tests__/restore-binary-data-id.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/restore-binary-data-id.test.ts
@@ -42,7 +42,7 @@ for (const mode of ['filesystem', 's3'] as const) {
 
 		it('should restore if binary data ID is missing execution ID', async () => {
 			const workflowId = '6HYhhKmJch2cYxGj';
-			const executionId = 'temp';
+			const executionId = '999';
 			const binaryDataFileUuid = 'a5c3f1ed-9d59-4155-bc68-9a370b3c51f6';
 
 			const incorrectFileId = `workflows/${workflowId}/executions/temp/binary_data/${binaryDataFileUuid}`;
@@ -167,7 +167,7 @@ for (const mode of ['filesystem', 's3'] as const) {
 
 		it('should ignore error thrown on renaming', async () => {
 			const workflowId = '6HYhhKmJch2cYxGj';
-			const executionId = 'temp';
+			const executionId = '999';
 			const binaryDataFileUuid = 'a5c3f1ed-9d59-4155-bc68-9a370b3c51f6';
 
 			const incorrectFileId = `workflows/${workflowId}/executions/temp/binary_data/${binaryDataFileUuid}`;

--- a/packages/cli/src/execution-lifecycle/restore-binary-data-id.ts
+++ b/packages/cli/src/execution-lifecycle/restore-binary-data-id.ts
@@ -33,8 +33,13 @@ export async function restoreBinaryDataId(
 		const { runData } = run.data.resultData;
 
 		const promises = Object.keys(runData).map(async (nodeName) => {
-			const binaryDataId = runData[nodeName]?.[0]?.data?.main?.[0]?.[0]?.binary?.data?.id;
+			const binaryObj = runData[nodeName]?.[0]?.data?.main?.[0]?.[0]?.binary;
+			if (!binaryObj) return;
 
+			const binaryData = Object.values(binaryObj)[0];
+			if (!binaryData) return;
+
+			const binaryDataId = binaryData.id;
 			if (!binaryDataId) return;
 
 			const [mode, fileId] = binaryDataId.split(':') as [BinaryData.StoredMode, string];
@@ -49,8 +54,7 @@ export async function restoreBinaryDataId(
 
 			const correctBinaryDataId = `${mode}:${correctFileId}`;
 
-			// @ts-expect-error Validated at the top
-			run.data.resultData.runData[nodeName][0].data.main[0][0].binary.data.id = correctBinaryDataId;
+			binaryData.id = correctBinaryDataId;
 		});
 
 		await Promise.all(promises);


### PR DESCRIPTION
## Summary

Fixes a problem where the process to `restoreBinaryDataId` cannot find the binary file, when the request had a defined form data parameter name. Then the `restoreBinaryDataId` method cannot move the binary file from the 'temp' execution folder to the execution ID folder. Therefore the binary file stays in the 'temp' execution folder.

In the fix, the binary file is read from any form data name supplied by the request, rather than being hard-coded to `data`.

## Problem

After submitting a Webhook request with a defined form-data parameter name, the binary file remains in the `temp` execution directory after `restoreBinaryDataId` completes, whereas it should have been moved into a folder named by its `executionId` (eg. `999`).

## Fix

This fix finds the first (only) binary file in the run data structure, irrespective of the data field's name, and then applies the rename based on that file.

## Tests

* Added a test verifying that `rename` occurs and the binary data ID is updated when the data structure provided includes a given form data parameter name
* Updated `getDataId()` method in the tests file to not be hard-coded to `data` as the form data parameter name

## Related Linear tickets, Github issues, and Community forum posts

GitHub issue: #25064, Linear reference apparently: GHC-6584

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
