### PR TITLE
fix(Microsoft Teams Node): Use $top query parameter for server-side pagination instead of client-side splice

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channel/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channel/getAll.test.ts
@@ -6,6 +6,7 @@ import { credentials } from '../../../credentials';
 describe('Test MicrosoftTeamsV2, channel => getAll', () => {
 	nock('https://graph.microsoft.com')
 		.get('/v1.0/teams/1111-2222-3333/channels')
+		.query({ $top: 100 })
 		.reply(200, {
 			value: [
 				{

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMessage/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMessage/getAll.test.ts
@@ -6,6 +6,7 @@ import { credentials } from '../../../credentials';
 describe('Test MicrosoftTeamsV2, chatMessage => getAll', () => {
 	nock('https://graph.microsoft.com')
 		.get('/v1.0/chats/19:ebed9ad42c904d6c83adf0db360053ec@thread.v2/messages')
+		.query({ $top: 2 })
 		.reply(200, {
 			value: [
 				{

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channel/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channel/getAll.operation.ts
@@ -37,7 +37,10 @@ export async function execute(this: IExecuteFunctions, i: number) {
 			'GET',
 			`/v1.0/teams/${teamId}/channels`,
 			{},
+			{
+				$top: limit,
+			},
 		);
-		return responseData.splice(0, limit);
+		return responseData;
 	}
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channelMessage/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channelMessage/getAll.operation.ts
@@ -39,7 +39,10 @@ export async function execute(this: IExecuteFunctions, i: number) {
 			'GET',
 			`/beta/teams/${teamId}/channels/${channelId}/messages`,
 			{},
+			{
+				$top: limit,
+			},
 		);
-		return responseData.splice(0, limit);
+		return responseData;
 	}
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/getAll.operation.ts
@@ -38,7 +38,10 @@ export async function execute(this: IExecuteFunctions, i: number) {
 			'GET',
 			`/v1.0/chats/${chatId}/messages`,
 			{},
+			{
+				$top: limit,
+			},
 		);
-		return responseData.splice(0, limit);
+		return responseData;
 	}
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/getAll.operation.ts
@@ -71,8 +71,11 @@ export async function execute(this: IExecuteFunctions, i: number) {
 				'GET',
 				`/v1.0/users/${memberId}/planner/tasks`,
 				{},
+				{
+					$top: limit,
+				},
 			);
-			return responseData.splice(0, limit);
+			return responseData;
 		}
 	} else {
 		//https://docs.microsoft.com/en-us/graph/api/plannerplan-list-tasks?view=graph-rest-1.0&tabs=http

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
@@ -75,7 +75,10 @@ export async function microsoftApiRequestAllItems(
 		responseData = await microsoftApiRequest.call(this, method, endpoint, body, query, uri);
 		uri = responseData['@odata.nextLink'];
 		returnData.push.apply(returnData, responseData[propertyName] as IDataObject[]);
-		const limit = query.limit as number | undefined;
+		const limit =
+			typeof (query.$top || query.limit) === 'number'
+				? ((query.$top || query.limit) as number)
+				: undefined;
 		if (limit && limit <= returnData.length) {
 			return returnData;
 		}


### PR DESCRIPTION
## Summary

The Microsoft Teams node's getAll operations (channels, channel messages, chat messages, and tasks) previously fetched all results from the Microsoft Graph API and then truncated them client-side using [Array.splice()](vscode-file://vscode-app/c:/Users/rgr/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html). This is inefficient, especially for large datasets, as it transfers far more data than needed over the network.

This PR passes the user-configured [limit] as the [$top] query parameter directly to the API, enabling proper server-side pagination. The API itself now returns only the requested number of items.

Changes
channel/getAll operation – Pass [$top: limit] instead of splicing the response
channelMessage/getAll operation – Pass [$top: limit] instead of splicing the response
chatMessage/getAll operation – Pass [$top: limit] instead of splicing the response
task/getAll operation – Pass [$top: limit] for the "member" tasks path instead of splicing the response
microsoftApiRequestAllItems transport – Update pagination logic to check both [query.$top] and [query.limit] when determining whether the requested limit has been reached
Tests – Update nock mocks for channel/getAll, channelMessage/getAll, and chatMessage/getAll to expect the correct [$top] query parameters

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
