### PR TITLE
feat(editor): migrate node composables to workflowDocumentStore (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/MIGRATION_RECIPE.md
+++ b/packages/frontend/editor-ui/MIGRATION_RECIPE.md
@@ -41,7 +41,7 @@ Migrate files from direct `workflowsStore` / `workflowState` node access to `wor
 | `workflowState.resetAllNodesIssues()` | `.resetAllNodesIssues()` |
 | `workflowState.setLastNodeParameters(...)` | `.setLastNodeParameters(...)` |
 | `workflowState.resetParametersLastUpdatedAt(...)` | `.resetParametersLastUpdatedAt(...)` |
-| `workflowState.updateNodeAtIndex(idx, data)` | No 1:1 mapping — review each call site and use the appropriate facade method (`updateNodeById`, `updateNodeProperties`, `setNodeIssue`, etc.) |
+| `workflowState.updateNodeAtIndex(idx, data)` | `.updateNodeById(id, data)` — same semantics, pass node ID instead of index. `updateNodeAtIndex` exists in the facade as an internal helper but is not exposed publicly. |
 
 ## Migration guidelines
 

--- a/packages/frontend/editor-ui/MIGRATION_RECIPE.md
+++ b/packages/frontend/editor-ui/MIGRATION_RECIPE.md
@@ -45,8 +45,12 @@ Migrate files from direct `workflowsStore` / `workflowState` node access to `wor
 
 ## Migration guidelines
 
+- **Always name the variable `workflowDocumentStore`.** Never abbreviate to `docStore`, `wds`, `documentStore`, or any other shorthand. The canonical name is `workflowDocumentStore` — in production code, tests, and local variables alike. This keeps the codebase grep-friendly and avoids confusion with other stores.
 - **Migrate all guarded APIs per file together.** When migrating a file, replace ALL `workflowsStore` reads AND `workflowState` mutations in one pass. Don't leave some calls on the old API — partial migrations make the code harder to follow and the ESLint warnings will remain.
 - **Each ticket lists both surfaces.** The "Facade methods used" section covers `workflowsStore` reads; the "`workflowState` migration" section covers per-node mutations. Both need to move to `workflowDocumentStore`.
+- **Consolidate existing inline `useWorkflowDocumentStore()` calls.** Some files may already have partial migrations (e.g. for `usedCredentials` or `pinData`). When you add the computed accessor, consolidate all inline calls into the single computed. Pinia deduplicates store instances by ID, so this is always safe.
+- **Remove dead `workflowState` parameters after migration.** If a composable accepts `workflowState` only for node mutations (e.g. `setNodeIssue`, `updateNodeProperties`), migrating those to `workflowDocumentStore` makes the parameter dead. Remove it from the signature and update all callers. Keep `workflowState` only if the composable still uses non-node-document properties like `executingNode`.
+- **Update callers when signatures change.** Removing a parameter or changing a composable's signature is a cascading change — grep for all call sites and update them. Check both production code and tests.
 
 ## Access Patterns
 
@@ -83,6 +87,34 @@ workflowDocumentStore.value?.allNodes ?? []
 workflowDocumentStore.value?.getNodeById(id)
 workflowDocumentStore.value?.getNodeByName(name)
 ```
+
+### 3. Standalone exported functions (no reactive context)
+
+Some files export plain functions (not composables or components) that are called imperatively — e.g. push connection handlers. These have no Vue reactive setup context, so `computed()` won't work. Construct the store inline at call time:
+
+```ts
+import { useWorkflowDocumentStore, createWorkflowDocumentId } from '@/app/stores/workflowDocument.store';
+
+function handleSomeEvent() {
+  const workflowsStore = useWorkflowsStore();
+  const workflowDocumentStore = workflowsStore.workflowId
+    ? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+    : undefined;
+
+  const node = workflowDocumentStore?.getNodeByName(name) ?? null;
+}
+```
+
+### Fallback values
+
+Since `workflowDocumentStore` can be `undefined` (no workflow loaded), always provide a fallback:
+
+| Return type | Fallback |
+|---|---|
+| Array (`.allNodes`, `.getNodes()`, `.getNodesByIds()`) | `?? []` |
+| Single node (`.getNodeById()`, `.getNodeByName()`, `.findNodeByPartialId()`) | `?? null` |
+| Map/Record (`.nodesByName`, `.canvasNames`) | `?? {}` |
+| Void mutations (`.setNodeIssue()`, `.updateNodeProperties()`, etc.) | Optional chaining only (`?.`) — no fallback needed |
 
 ## Test Patterns
 

--- a/packages/frontend/editor-ui/MIGRATION_RECIPE.md
+++ b/packages/frontend/editor-ui/MIGRATION_RECIPE.md
@@ -1,0 +1,144 @@
+# Node Migration Recipe
+
+Migrate files from direct `workflowsStore` / `workflowState` node access to `workflowDocumentStore`.
+
+## API Mapping
+
+### Read accessors
+
+| Before | After (`workflowDocumentStore`) |
+|---|---|
+| `workflowsStore.allNodes` | `.allNodes` |
+| `workflowsStore.nodesByName` | `.nodesByName` |
+| `workflowsStore.getNodeById(id)` | `.getNodeById(id)` |
+| `workflowsStore.getNodeByName(name)` | `.getNodeByName(name)` |
+| `workflowsStore.getNodes()` | `.getNodes()` |
+| `workflowsStore.getNodesByIds(ids)` | `.getNodesByIds(ids)` |
+| `workflowsStore.workflow.nodes` (direct — includes `.find()`, `.findIndex()`, `.length`, `.map()`, `= [...]` assignment) | `.allNodes` (for reads), `.setNodes()` (for assignment) |
+| `workflowsStore.canvasNames` | `.canvasNames` |
+| `workflowsStore.findNodeByPartialId(id)` | `.findNodeByPartialId(id)` |
+
+### Collection mutations
+
+| Before | After (`workflowDocumentStore`) |
+|---|---|
+| `workflowsStore.setNodes(nodes)` | `.setNodes(nodes)` |
+| `workflowsStore.addNode(node)` | `.addNode(node)` |
+| `workflowsStore.removeNode(node)` | `.removeNode(node)` |
+| `workflowsStore.removeNodeById(id)` | `.removeNodeById(id)` |
+| `workflowState.removeAllNodes(opts)` | `.removeAllNodes(opts)` |
+
+### Per-node mutations
+
+| Before | After (`workflowDocumentStore`) |
+|---|---|
+| `workflowState.setNodeParameters(...)` | `.setNodeParameters(...)` |
+| `workflowState.setNodeValue(...)` | `.setNodeValue(...)` |
+| `workflowState.setNodePositionById(...)` | `.setNodePositionById(...)` |
+| `workflowState.updateNodeProperties(...)` | `.updateNodeProperties(...)` |
+| `workflowState.updateNodeById(...)` | `.updateNodeById(...)` |
+| `workflowState.setNodeIssue(...)` | `.setNodeIssue(...)` |
+| `workflowState.resetAllNodesIssues()` | `.resetAllNodesIssues()` |
+| `workflowState.setLastNodeParameters(...)` | `.setLastNodeParameters(...)` |
+| `workflowState.resetParametersLastUpdatedAt(...)` | `.resetParametersLastUpdatedAt(...)` |
+| `workflowState.updateNodeAtIndex(idx, data)` | No 1:1 mapping — review each call site and use the appropriate facade method (`updateNodeById`, `updateNodeProperties`, `setNodeIssue`, etc.) |
+
+## Migration guidelines
+
+- **Migrate all guarded APIs per file together.** When migrating a file, replace ALL `workflowsStore` reads AND `workflowState` mutations in one pass. Don't leave some calls on the old API — partial migrations make the code harder to follow and the ESLint warnings will remain.
+- **Each ticket lists both surfaces.** The "Facade methods used" section covers `workflowsStore` reads; the "`workflowState` migration" section covers per-node mutations. Both need to move to `workflowDocumentStore`.
+
+## Access Patterns
+
+### 1. Vue components inside WorkflowLayout
+
+Components rendered inside the `WorkflowLayout` tree (canvas, NDV, node settings, etc.) use the injected store:
+
+```ts
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+
+const workflowDocumentStore = injectWorkflowDocumentStore();
+
+// Usage — inject returns ShallowRef<Store | null>, so ?.value?. chain
+workflowDocumentStore?.value?.allNodes ?? []
+workflowDocumentStore?.value?.getNodeById(id)
+workflowDocumentStore?.value?.getNodeByName(name)
+```
+
+### 2. Pinia stores and composables outside WorkflowLayout
+
+Code outside the WorkflowLayout tree (stores, standalone composables, utils) uses a computed accessor:
+
+```ts
+import { useWorkflowDocumentStore, createWorkflowDocumentId } from '@/app/stores/workflowDocument.store';
+
+const workflowDocumentStore = computed(() =>
+  workflowsStore.workflowId
+    ? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+    : undefined,
+);
+
+// Usage — computed wraps the store, so .value?. chain
+workflowDocumentStore.value?.allNodes ?? []
+workflowDocumentStore.value?.getNodeById(id)
+workflowDocumentStore.value?.getNodeByName(name)
+```
+
+## Test Patterns
+
+### Component / composable tests (inside WorkflowLayout)
+
+Mock `injectWorkflowDocumentStore` and return a real store:
+
+```ts
+import { injectWorkflowDocumentStore, useWorkflowDocumentStore, createWorkflowDocumentId } from '@/app/stores/workflowDocument.store';
+
+vi.mock('@/app/stores/workflowDocument.store', async () => {
+  const actual = await vi.importActual('@/app/stores/workflowDocument.store');
+  return { ...actual, injectWorkflowDocumentStore: vi.fn() };
+});
+
+beforeEach(() => {
+  workflowsStore.workflow.id = 'test-workflow';
+  vi.mocked(injectWorkflowDocumentStore).mockReturnValue(
+    shallowRef(useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))),
+  );
+});
+```
+
+### Store tests (computed pattern)
+
+Mock the store factory:
+
+```ts
+const { mockDocumentStore } = vi.hoisted(() => ({
+  mockDocumentStore: {
+    allNodes: [],
+    getNodeById: vi.fn(),
+    getNodeByName: vi.fn(),
+    // ... only the methods your test needs
+  },
+}));
+
+vi.mock('@/app/stores/workflowDocument.store', () => ({
+  useWorkflowDocumentStore: vi.fn().mockReturnValue(mockDocumentStore),
+  createWorkflowDocumentId: vi.fn().mockReturnValue('test-id'),
+}));
+```
+
+### Fixing `mockedStore` + `allNodes` detachment
+
+If tests use `mockedStore(useWorkflowsStore)`, the `allNodes` computed gets detached from `workflow.nodes`. Fix by wiring it back:
+
+```ts
+Object.defineProperty(workflowsStore, 'allNodes', {
+  get: () => workflowsStore.workflow.nodes,
+  configurable: true,
+});
+```
+
+## What NOT to migrate
+
+- **`workflowsStore.workflowObject`** (39 files) — provides indirect node access via `Workflow` class methods (`.getNode()`, `.nodes`, `.getParentNodes()`, etc.). This is intentionally NOT migrated until both nodes **and** connections move to `workflowDocumentStore`. No ESLint guard for this — it's accepted tech debt.
+- **Execution-related methods** (e.g., `renameNodeSelectedAndExecution`, `removeNodeExecutionDataById`) — these are not node document state
+- **`workflowState.executingNode`** and other execution-state properties — these are not node document state

--- a/packages/frontend/editor-ui/MIGRATION_RECIPE.md
+++ b/packages/frontend/editor-ui/MIGRATION_RECIPE.md
@@ -51,6 +51,7 @@ Migrate files from direct `workflowsStore` / `workflowState` node access to `wor
 - **Consolidate existing inline `useWorkflowDocumentStore()` calls.** Some files may already have partial migrations (e.g. for `usedCredentials` or `pinData`). When you add the computed accessor, consolidate all inline calls into the single computed. Pinia deduplicates store instances by ID, so this is always safe.
 - **Remove dead `workflowState` parameters after migration.** If a composable accepts `workflowState` only for node mutations (e.g. `setNodeIssue`, `updateNodeProperties`), migrating those to `workflowDocumentStore` makes the parameter dead. Remove it from the signature and update all callers. Keep `workflowState` only if the composable still uses non-node-document properties like `executingNode`.
 - **Update callers when signatures change.** Removing a parameter or changing a composable's signature is a cascading change — grep for all call sites and update them. Check both production code and tests.
+- **Fix downstream test spies.** Tests for *consumers* of a migrated composable may spy on `workflowState.updateNodeProperties` (or similar) to assert behavior. After migration, the composable calls `workflowDocumentStore` instead, so those spies see zero calls. Grep for the method name across all test files — not just the ones for the file you migrated.
 
 ## Access Patterns
 
@@ -174,3 +175,7 @@ Object.defineProperty(workflowsStore, 'allNodes', {
 - **`workflowsStore.workflowObject`** (39 files) — provides indirect node access via `Workflow` class methods (`.getNode()`, `.nodes`, `.getParentNodes()`, etc.). This is intentionally NOT migrated until both nodes **and** connections move to `workflowDocumentStore`. No ESLint guard for this — it's accepted tech debt.
 - **Execution-related methods** (e.g., `renameNodeSelectedAndExecution`, `removeNodeExecutionDataById`) — these are not node document state
 - **`workflowState.executingNode`** and other execution-state properties — these are not node document state
+
+## Maintaining this recipe
+
+Update this file when a migration reveals a new pattern, edge case, or pitfall that would save the next person time. Don't add noise — only document something if you had to figure it out and it wasn't already covered above.

--- a/packages/frontend/editor-ui/eslint.config.mjs
+++ b/packages/frontend/editor-ui/eslint.config.mjs
@@ -67,6 +67,121 @@ export default defineConfig(
 					message:
 						'Use workflowDocumentStore node accessors instead of workflowsStore.workflow.nodes',
 				},
+				{
+					selector:
+						"CallExpression[callee.property.name='setNodeParameters'][callee.object.name='workflowsStore']",
+					message:
+						'Use workflowDocumentStore.setNodeParameters() instead of workflowsStore.setNodeParameters()',
+				},
+				{
+					selector:
+						"CallExpression[callee.property.name='setNodeValue'][callee.object.name='workflowsStore']",
+					message:
+						'Use workflowDocumentStore.setNodeValue() instead of workflowsStore.setNodeValue()',
+				},
+				{
+					selector:
+						"CallExpression[callee.property.name='setNodePositionById'][callee.object.name='workflowsStore']",
+					message:
+						'Use workflowDocumentStore.setNodePositionById() instead of workflowsStore.setNodePositionById()',
+				},
+				{
+					selector:
+						"CallExpression[callee.property.name='updateNodeById'][callee.object.name='workflowsStore']",
+					message:
+						'Use workflowDocumentStore.updateNodeById() instead of workflowsStore.updateNodeById()',
+				},
+				{
+					selector:
+						"CallExpression[callee.property.name='updateNodeProperties'][callee.object.name='workflowsStore']",
+					message:
+						'Use workflowDocumentStore.updateNodeProperties() instead of workflowsStore.updateNodeProperties()',
+				},
+				{
+					selector:
+						"CallExpression[callee.property.name='setNodeIssue'][callee.object.name='workflowsStore']",
+					message:
+						'Use workflowDocumentStore.setNodeIssue() instead of workflowsStore.setNodeIssue()',
+				},
+				{
+					selector:
+						"CallExpression[callee.property.name='resetAllNodesIssues'][callee.object.name='workflowsStore']",
+					message:
+						'Use workflowDocumentStore.resetAllNodesIssues() instead of workflowsStore.resetAllNodesIssues()',
+				},
+				{
+					selector:
+						"CallExpression[callee.property.name='setLastNodeParameters'][callee.object.name='workflowsStore']",
+					message:
+						'Use workflowDocumentStore.setLastNodeParameters() instead of workflowsStore.setLastNodeParameters()',
+				},
+				// Guard: prevent per-node mutations via deprecated workflowState composable.
+				{
+					selector:
+						"CallExpression[callee.property.name='setNodeParameters'][callee.object.name='workflowState']",
+					message:
+						'Use workflowDocumentStore.setNodeParameters() instead of workflowState.setNodeParameters()',
+				},
+				{
+					selector:
+						"CallExpression[callee.property.name='setNodeValue'][callee.object.name='workflowState']",
+					message:
+						'Use workflowDocumentStore.setNodeValue() instead of workflowState.setNodeValue()',
+				},
+				{
+					selector:
+						"CallExpression[callee.property.name='setNodePositionById'][callee.object.name='workflowState']",
+					message:
+						'Use workflowDocumentStore.setNodePositionById() instead of workflowState.setNodePositionById()',
+				},
+				{
+					selector:
+						"CallExpression[callee.property.name='updateNodeById'][callee.object.name='workflowState']",
+					message:
+						'Use workflowDocumentStore.updateNodeById() instead of workflowState.updateNodeById()',
+				},
+				{
+					selector:
+						"CallExpression[callee.property.name='updateNodeProperties'][callee.object.name='workflowState']",
+					message:
+						'Use workflowDocumentStore.updateNodeProperties() instead of workflowState.updateNodeProperties()',
+				},
+				{
+					selector:
+						"CallExpression[callee.property.name='setNodeIssue'][callee.object.name='workflowState']",
+					message:
+						'Use workflowDocumentStore.setNodeIssue() instead of workflowState.setNodeIssue()',
+				},
+				{
+					selector:
+						"CallExpression[callee.property.name='resetAllNodesIssues'][callee.object.name='workflowState']",
+					message:
+						'Use workflowDocumentStore.resetAllNodesIssues() instead of workflowState.resetAllNodesIssues()',
+				},
+				{
+					selector:
+						"CallExpression[callee.property.name='setLastNodeParameters'][callee.object.name='workflowState']",
+					message:
+						'Use workflowDocumentStore.setLastNodeParameters() instead of workflowState.setLastNodeParameters()',
+				},
+				{
+					selector:
+						"CallExpression[callee.property.name='resetParametersLastUpdatedAt'][callee.object.name='workflowState']",
+					message:
+						'Use workflowDocumentStore.resetParametersLastUpdatedAt() instead of workflowState.resetParametersLastUpdatedAt()',
+				},
+				{
+					selector:
+						"CallExpression[callee.property.name='removeAllNodes'][callee.object.name='workflowState']",
+					message:
+						'Use workflowDocumentStore.removeAllNodes() instead of workflowState.removeAllNodes()',
+				},
+				{
+					selector:
+						"CallExpression[callee.property.name='updateNodeAtIndex'][callee.object.name='workflowState']",
+					message:
+						'Use per-node mutation methods on workflowDocumentStore instead of workflowState.updateNodeAtIndex()',
+				},
 			],
 			// TODO: Remove these
 			'n8n-local-rules/no-internal-package-import': 'warn',

--- a/packages/frontend/editor-ui/eslint.config.mjs
+++ b/packages/frontend/editor-ui/eslint.config.mjs
@@ -1,59 +1,134 @@
 import { defineConfig } from 'eslint/config';
 import { frontendConfig } from '@n8n/eslint-config/frontend';
 
-export default defineConfig(frontendConfig, {
-	rules: {
-		// TODO: Remove these
-		'n8n-local-rules/no-internal-package-import': 'warn',
-		'@typescript-eslint/ban-ts-comment': ['warn', { 'ts-ignore': true }],
-		'id-denylist': 'warn',
-		'no-case-declarations': 'warn',
-		'no-useless-escape': 'warn',
-		'no-prototype-builtins': 'warn',
-		'no-empty': 'warn',
-		'no-fallthrough': 'warn',
-		'no-extra-boolean-cast': 'warn',
-		'no-sparse-arrays': 'warn',
-		'no-control-regex': 'warn',
-		'import-x/extensions': 'warn',
-		'import-x/no-default-export': 'warn',
-		'import-x/order': 'off',
-		'import-x/no-cycle': 'warn',
-		'import-x/no-duplicates': 'warn',
-		'no-unsafe-optional-chaining': 'warn',
-		'@typescript-eslint/no-restricted-types': 'warn',
-		'@typescript-eslint/dot-notation': 'warn',
-		'@stylistic/lines-between-class-members': 'warn',
-		'@stylistic/member-delimiter-style': 'warn',
-		'@typescript-eslint/naming-convention': 'off',
-		'@typescript-eslint/no-empty-interface': 'warn',
-		'@typescript-eslint/no-for-in-array': 'warn',
-		'@typescript-eslint/no-loop-func': 'warn',
-		'@typescript-eslint/no-non-null-assertion': 'warn',
-		'@typescript-eslint/no-shadow': 'warn',
-		'@typescript-eslint/no-this-alias': 'warn',
-		'@typescript-eslint/no-unnecessary-boolean-literal-compare': 'warn',
-		'@typescript-eslint/no-unnecessary-type-assertion': 'warn',
-		'@typescript-eslint/no-unused-expressions': 'warn',
-		'@typescript-eslint/no-unused-vars': 'warn',
-		'@typescript-eslint/no-var-requires': 'warn',
-		'@typescript-eslint/prefer-nullish-coalescing': 'warn',
-		'@typescript-eslint/prefer-optional-chain': 'warn',
-		'@typescript-eslint/restrict-plus-operands': 'warn',
-		'@typescript-eslint/no-redundant-type-constituents': 'warn',
-		'@typescript-eslint/no-unsafe-enum-comparison': 'warn',
-		'@typescript-eslint/require-await': 'warn',
-		'@typescript-eslint/prefer-promise-reject-errors': 'warn',
-		'@typescript-eslint/no-base-to-string': 'warn',
-		'@typescript-eslint/no-empty-object-type': 'warn',
-		'@typescript-eslint/no-unsafe-function-type': 'warn',
-		'vue/attribute-hyphenation': 'warn',
-		'@typescript-eslint/no-unsafe-assignment': 'warn',
-		'@typescript-eslint/unbound-method': 'warn',
-		'@typescript-eslint/restrict-template-expressions': 'warn',
-		'@typescript-eslint/no-unsafe-call': 'warn',
-		'@typescript-eslint/no-unsafe-argument': 'warn',
-		'@typescript-eslint/no-unsafe-member-access': 'warn',
-		'@typescript-eslint/no-unsafe-return': 'warn',
+export default defineConfig(
+	frontendConfig,
+	{
+		rules: {
+			// Guard: prevent direct node access on workflowsStore — use workflowDocumentStore instead.
+			// Level: 'warn' during migration. Flip to 'error' when migration is complete.
+			'no-restricted-syntax': [
+				'warn',
+				{
+					selector: "MemberExpression[property.name='allNodes'][object.name='workflowsStore']",
+					message: 'Use workflowDocumentStore.allNodes instead of workflowsStore.allNodes',
+				},
+				{
+					selector:
+						"CallExpression[callee.property.name='getNodeById'][callee.object.name='workflowsStore']",
+					message:
+						'Use workflowDocumentStore.getNodeById() instead of workflowsStore.getNodeById()',
+				},
+				{
+					selector:
+						"CallExpression[callee.property.name='getNodeByName'][callee.object.name='workflowsStore']",
+					message:
+						'Use workflowDocumentStore.getNodeByName() instead of workflowsStore.getNodeByName()',
+				},
+				{
+					selector:
+						"CallExpression[callee.property.name='getNodes'][callee.object.name='workflowsStore']",
+					message: 'Use workflowDocumentStore.getNodes() instead of workflowsStore.getNodes()',
+				},
+				{
+					selector:
+						"CallExpression[callee.property.name='getNodesByIds'][callee.object.name='workflowsStore']",
+					message:
+						'Use workflowDocumentStore.getNodesByIds() instead of workflowsStore.getNodesByIds()',
+				},
+				{
+					selector: "MemberExpression[property.name='nodesByName'][object.name='workflowsStore']",
+					message: 'Use workflowDocumentStore.nodesByName instead of workflowsStore.nodesByName',
+				},
+				{
+					selector:
+						"CallExpression[callee.property.name='addNode'][callee.object.name='workflowsStore']",
+					message: 'Use workflowDocumentStore.addNode() instead of workflowsStore.addNode()',
+				},
+				{
+					selector:
+						"CallExpression[callee.property.name='removeNode'][callee.object.name='workflowsStore']",
+					message: 'Use workflowDocumentStore.removeNode() instead of workflowsStore.removeNode()',
+				},
+				{
+					selector:
+						"CallExpression[callee.property.name='removeNodeById'][callee.object.name='workflowsStore']",
+					message:
+						'Use workflowDocumentStore.removeNodeById() instead of workflowsStore.removeNodeById()',
+				},
+				{
+					selector:
+						"CallExpression[callee.property.name='setNodes'][callee.object.name='workflowsStore']",
+					message: 'Use workflowDocumentStore.setNodes() instead of workflowsStore.setNodes()',
+				},
+				{
+					selector:
+						"MemberExpression[property.name='nodes'][object.property.name='workflow'][object.object.name='workflowsStore']",
+					message:
+						'Use workflowDocumentStore node accessors instead of workflowsStore.workflow.nodes',
+				},
+			],
+			// TODO: Remove these
+			'n8n-local-rules/no-internal-package-import': 'warn',
+			'@typescript-eslint/ban-ts-comment': ['warn', { 'ts-ignore': true }],
+			'id-denylist': 'warn',
+			'no-case-declarations': 'warn',
+			'no-useless-escape': 'warn',
+			'no-prototype-builtins': 'warn',
+			'no-empty': 'warn',
+			'no-fallthrough': 'warn',
+			'no-extra-boolean-cast': 'warn',
+			'no-sparse-arrays': 'warn',
+			'no-control-regex': 'warn',
+			'import-x/extensions': 'warn',
+			'import-x/no-default-export': 'warn',
+			'import-x/order': 'off',
+			'import-x/no-cycle': 'warn',
+			'import-x/no-duplicates': 'warn',
+			'no-unsafe-optional-chaining': 'warn',
+			'@typescript-eslint/no-restricted-types': 'warn',
+			'@typescript-eslint/dot-notation': 'warn',
+			'@stylistic/lines-between-class-members': 'warn',
+			'@stylistic/member-delimiter-style': 'warn',
+			'@typescript-eslint/naming-convention': 'off',
+			'@typescript-eslint/no-empty-interface': 'warn',
+			'@typescript-eslint/no-for-in-array': 'warn',
+			'@typescript-eslint/no-loop-func': 'warn',
+			'@typescript-eslint/no-non-null-assertion': 'warn',
+			'@typescript-eslint/no-shadow': 'warn',
+			'@typescript-eslint/no-this-alias': 'warn',
+			'@typescript-eslint/no-unnecessary-boolean-literal-compare': 'warn',
+			'@typescript-eslint/no-unnecessary-type-assertion': 'warn',
+			'@typescript-eslint/no-unused-expressions': 'warn',
+			'@typescript-eslint/no-unused-vars': 'warn',
+			'@typescript-eslint/no-var-requires': 'warn',
+			'@typescript-eslint/prefer-nullish-coalescing': 'warn',
+			'@typescript-eslint/prefer-optional-chain': 'warn',
+			'@typescript-eslint/restrict-plus-operands': 'warn',
+			'@typescript-eslint/no-redundant-type-constituents': 'warn',
+			'@typescript-eslint/no-unsafe-enum-comparison': 'warn',
+			'@typescript-eslint/require-await': 'warn',
+			'@typescript-eslint/prefer-promise-reject-errors': 'warn',
+			'@typescript-eslint/no-base-to-string': 'warn',
+			'@typescript-eslint/no-empty-object-type': 'warn',
+			'@typescript-eslint/no-unsafe-function-type': 'warn',
+			'vue/attribute-hyphenation': 'warn',
+			'@typescript-eslint/no-unsafe-assignment': 'warn',
+			'@typescript-eslint/unbound-method': 'warn',
+			'@typescript-eslint/restrict-template-expressions': 'warn',
+			'@typescript-eslint/no-unsafe-call': 'warn',
+			'@typescript-eslint/no-unsafe-argument': 'warn',
+			'@typescript-eslint/no-unsafe-member-access': 'warn',
+			'@typescript-eslint/no-unsafe-return': 'warn',
+		},
 	},
-});
+	{
+		// The workflowDocument facades and workflows.store are the canonical delegation layer —
+		// they are allowed to access workflowsStore node methods directly.
+		files: ['src/app/stores/workflowDocument/**', 'src/app/stores/workflows.store.ts'],
+		ignores: ['src/app/stores/workflowDocument/*.test.ts'],
+		rules: {
+			'no-restricted-syntax': 'off',
+		},
+	},
+);

--- a/packages/frontend/editor-ui/src/app/components/NodeExecuteButton.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/NodeExecuteButton.test.ts
@@ -33,6 +33,10 @@ import {
 	useWorkflowState,
 	type WorkflowState,
 } from '@/app/composables/useWorkflowState';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 
 vi.mock('vue-router', () => ({
 	useRouter: () => ({}),
@@ -384,7 +388,10 @@ describe('NodeExecuteButton', () => {
 				name: 'test',
 				value: 'Test',
 			}));
-		const updateNodePropertiesSpy = vi.spyOn(workflowState, 'updateNodeProperties');
+		const workflowDocumentStore = useWorkflowDocumentStore(
+			createWorkflowDocumentId(workflowsStore.workflowId),
+		);
+		const updateNodePropertiesSpy = vi.spyOn(workflowDocumentStore, 'updateNodeProperties');
 		const node = mockNode({
 			name: 'test-node',
 			type: AI_TRANSFORM_NODE_TYPE,

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -1804,7 +1804,10 @@ describe('useCanvasOperations', () => {
 				createTestNode({ id: '2', name: 'B' }),
 			];
 			workflowsStore.getNodesByIds.mockReturnValue(nodes);
-			const updateNodePropertiesSpy = vi.spyOn(workflowState, 'updateNodeProperties');
+			const workflowDocumentStore = useWorkflowDocumentStore(
+				createWorkflowDocumentId(workflowsStore.workflowId),
+			);
+			const updateNodePropertiesSpy = vi.spyOn(workflowDocumentStore, 'updateNodeProperties');
 
 			const { toggleNodesDisabled } = useCanvasOperations();
 			toggleNodesDisabled([nodes[0].id, nodes[1].id], {
@@ -1827,7 +1830,10 @@ describe('useCanvasOperations', () => {
 			const nodeName = 'testNode';
 			const node = createTestNode({ name: nodeName });
 			workflowsStore.getNodeByName.mockReturnValue(node);
-			const updateNodePropertiesSpy = vi.spyOn(workflowState, 'updateNodeProperties');
+			const workflowDocumentStore = useWorkflowDocumentStore(
+				createWorkflowDocumentId(workflowsStore.workflowId),
+			);
+			const updateNodePropertiesSpy = vi.spyOn(workflowDocumentStore, 'updateNodeProperties');
 
 			const { revertToggleNodeDisabled } = useCanvasOperations();
 			revertToggleNodeDisabled(nodeName);

--- a/packages/frontend/editor-ui/src/app/composables/useFloatingUiOffsets.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useFloatingUiOffsets.test.ts
@@ -3,6 +3,10 @@ import { useLogsStore } from '@/app/stores/logs.store';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { setActivePinia } from 'pinia';
 import { useFloatingUiOffsets } from './useFloatingUiOffsets';
 import { reactive } from 'vue';
@@ -28,7 +32,12 @@ describe(useFloatingUiOffsets, () => {
 	beforeEach(() => {
 		setActivePinia(createTestingPinia({ stubActions: false }));
 		currentRouteName = '';
-		useWorkflowsStore().setNodes([createTestNode({ name: 'n0' })]);
+		const workflowsStore = useWorkflowsStore();
+		workflowsStore.workflow.id = 'test-workflow';
+		const workflowDocumentStore = useWorkflowDocumentStore(
+			createWorkflowDocumentId('test-workflow'),
+		);
+		workflowDocumentStore.setNodes([createTestNode({ name: 'n0' })]);
 	});
 
 	describe('toastBottomOffset', () => {

--- a/packages/frontend/editor-ui/src/app/composables/useNodeDirtiness.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeDirtiness.ts
@@ -10,6 +10,10 @@ import {
 import { useHistoryStore } from '@/app/stores/history.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
+import {
 	CanvasNodeDirtiness,
 	type CanvasNodeDirtinessType,
 } from '@/features/workflows/canvas/canvas.types';
@@ -121,6 +125,12 @@ export function useNodeDirtiness() {
 	const historyStore = useHistoryStore();
 	const workflowsStore = useWorkflowsStore();
 
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
+
 	function getParentSubNodes(nodeName: string) {
 		return Object.entries(workflowsStore.incomingConnectionsByNodeName(nodeName))
 			.filter(([type]) => (type as NodeConnectionType) !== NodeConnectionTypes.Main)
@@ -211,7 +221,7 @@ export function useNodeDirtiness() {
 			}
 		}
 
-		for (const startNode of workflowsStore.allNodes) {
+		for (const startNode of workflowDocumentStore.value?.allNodes ?? []) {
 			const hasIncomingNode =
 				Object.keys(workflowsStore.incomingConnectionsByNodeName(startNode.name)).length > 0;
 

--- a/packages/frontend/editor-ui/src/app/composables/useNodeExecution.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeExecution.test.ts
@@ -31,6 +31,7 @@ import {
 
 const {
 	mockWorkflowsStore,
+	mockDocumentStore,
 	mockNodeTypesStore,
 	mockNdvStore,
 	mockRunWorkflow,
@@ -46,6 +47,9 @@ const {
 		checkIfNodeHasChatParent: vi.fn(),
 		getNodeByName: vi.fn(),
 		removeTestWebhook: vi.fn(),
+	},
+	mockDocumentStore: {
+		updateNodeProperties: vi.fn(),
 	},
 	mockNodeTypesStore: {
 		getNodeType: vi.fn(),
@@ -81,6 +85,11 @@ vi.mock('vue-router', async (importOriginal) => {
 
 vi.mock('@/app/stores/workflows.store', () => ({
 	useWorkflowsStore: vi.fn().mockReturnValue(mockWorkflowsStore),
+}));
+
+vi.mock('@/app/stores/workflowDocument.store', () => ({
+	useWorkflowDocumentStore: vi.fn().mockReturnValue(mockDocumentStore),
+	createWorkflowDocumentId: vi.fn().mockReturnValue('test-id'),
 }));
 
 vi.mock('@/app/stores/nodeTypes.store', () => ({
@@ -189,6 +198,7 @@ describe('useNodeExecution', () => {
 		mockWorkflowsStore.checkIfNodeHasChatParent.mockReturnValue(false);
 		mockWorkflowsStore.removeTestWebhook.mockReset();
 		mockWorkflowsStore.getNodeByName.mockReset();
+		mockDocumentStore.updateNodeProperties.mockReset();
 
 		mockNodeTypesStore.getNodeType.mockReturnValue(null);
 		mockNodeTypesStore.isTriggerNode.mockReturnValue(false);
@@ -755,7 +765,6 @@ describe('useNodeExecution', () => {
 				name: `parameters.${AI_TRANSFORM_JS_CODE}`,
 				value: 'return items;',
 			});
-			vi.spyOn(workflowState, 'updateNodeProperties').mockImplementation(() => {});
 			const node = ref(
 				createTestNode({
 					name: 'AI Transform',
@@ -768,7 +777,7 @@ describe('useNodeExecution', () => {
 			const result = await execute();
 
 			expect(generateCodeForAiTransform).toHaveBeenCalled();
-			expect(workflowState.updateNodeProperties).toHaveBeenCalled();
+			expect(mockDocumentStore.updateNodeProperties).toHaveBeenCalled();
 			expect(result).toBe('executed');
 		});
 
@@ -777,7 +786,6 @@ describe('useNodeExecution', () => {
 				name: `parameters.${AI_TRANSFORM_JS_CODE}`,
 				value: 'return items;',
 			});
-			vi.spyOn(workflowState, 'updateNodeProperties').mockImplementation(() => {});
 			const onCodeGenerated = vi.fn();
 			const node = ref(
 				createTestNode({

--- a/packages/frontend/editor-ui/src/app/composables/useNodeExecution.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeExecution.ts
@@ -15,6 +15,10 @@ import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useUIStore } from '@/app/stores/ui.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 
 import { useRunWorkflow } from '@/app/composables/useRunWorkflow';
 import { usePinnedData } from '@/app/composables/usePinnedData';
@@ -99,6 +103,12 @@ export function useNodeExecution(
 	const ndvStore = useNDVStore();
 	const uiStore = useUIStore();
 	const workflowState = injectWorkflowState();
+
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
 
 	const { runWorkflow, stopCurrentExecution } = useRunWorkflow({ router });
 
@@ -289,7 +299,7 @@ export function useNodeExecution(
 			}
 
 			// Update node with generated code
-			workflowState.updateNodeProperties({
+			workflowDocumentStore.value?.updateNodeProperties({
 				name: nodeRef.value.name,
 				properties: {
 					parameters: {

--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.test.ts
@@ -19,9 +19,10 @@ import { faker } from '@faker-js/faker';
 import type { INodeUi } from '@/Interface';
 import type { IUsedCredential } from '@/features/credentials/credentials.types';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
-import { injectWorkflowState, useWorkflowState } from './useWorkflowState';
 
 const mockDocumentStoreUsedCredentials: Record<string, IUsedCredential> = {};
+const mockDocumentStoreSetNodeIssue = vi.fn();
+const mockDocumentStoreUpdateNodeProperties = vi.fn();
 
 vi.mock('@/app/stores/workflowDocument.store', async () => {
 	const actual = await vi.importActual('@/app/stores/workflowDocument.store');
@@ -29,15 +30,11 @@ vi.mock('@/app/stores/workflowDocument.store', async () => {
 		...actual,
 		useWorkflowDocumentStore: vi.fn(() => ({
 			usedCredentials: mockDocumentStoreUsedCredentials,
+			allNodes: [],
+			getNodeByName: vi.fn(),
+			setNodeIssue: mockDocumentStoreSetNodeIssue,
+			updateNodeProperties: mockDocumentStoreUpdateNodeProperties,
 		})),
-	};
-});
-
-vi.mock('@/app/composables/useWorkflowState', async () => {
-	const actual = await vi.importActual('@/app/composables/useWorkflowState');
-	return {
-		...actual,
-		injectWorkflowState: vi.fn(),
 	};
 });
 
@@ -52,23 +49,6 @@ describe('useNodeHelpers()', () => {
 		for (const key of Object.keys(mockDocumentStoreUsedCredentials)) {
 			delete mockDocumentStoreUsedCredentials[key];
 		}
-	});
-
-	describe('initialization', () => {
-		it('should use provided workflowState and not inject', () => {
-			const workflowState = useWorkflowState();
-			vi.clearAllMocks();
-
-			useNodeHelpers({ workflowState });
-
-			expect(injectWorkflowState).not.toBeCalled();
-		});
-
-		it('should create workflowState if not provided', () => {
-			useNodeHelpers();
-
-			expect(injectWorkflowState).toBeCalled();
-		});
 	});
 
 	describe('isNodeExecutable()', () => {
@@ -763,8 +743,7 @@ describe('useNodeHelpers()', () => {
 			mockedStore(useNodeTypesStore).getNodeType = vi.fn().mockReturnValue(nodeTypeWithFeatures);
 			const getNodeParametersIssuesSpy = vi.spyOn(NodeHelpers, 'getNodeParametersIssues');
 
-			const workflowState = useWorkflowState();
-			const { updateNodeParameterIssues } = useNodeHelpers({ workflowState });
+			const { updateNodeParameterIssues } = useNodeHelpers();
 
 			updateNodeParameterIssues(node);
 

--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
@@ -47,7 +47,6 @@ import { useTelemetry } from './useTelemetry';
 import { hasPermission } from '@/app/utils/rbac/permissions';
 import { useCanvasStore } from '@/app/stores/canvas.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
-import { injectWorkflowState, type WorkflowState } from './useWorkflowState';
 import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
@@ -63,15 +62,20 @@ declare namespace HttpRequestNode {
 	}
 }
 
-export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
+export function useNodeHelpers() {
 	const credentialsStore = useCredentialsStore();
 	const historyStore = useHistoryStore();
 	const nodeTypesStore = useNodeTypesStore();
 	const workflowsStore = useWorkflowsStore();
-	const workflowState = opts.workflowState ?? injectWorkflowState();
 	const settingsStore = useSettingsStore();
 	const i18n = useI18n();
 	const canvasStore = useCanvasStore();
+
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
 
 	const isInsertingNodes = ref(false);
 	const credentialsUpdated = ref(false);
@@ -156,10 +160,7 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 			return [];
 		}
 
-		const workflowDocumentStore = workflowsStore.workflowId
-			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
-			: undefined;
-		const usedCredentials = workflowDocumentStore?.usedCredentials ?? {};
+		const usedCredentials = workflowDocumentStore.value?.usedCredentials ?? {};
 
 		return Object.values(credentials)
 			.map(({ id }) => id)
@@ -194,10 +195,7 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 		workflow: Workflow,
 		ignoreIssues?: string[],
 	): INodeIssues | null {
-		const workflowDocumentStore = workflowsStore.workflowId
-			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
-			: undefined;
-		const pinDataNodeNames = Object.keys(workflowDocumentStore?.pinData ?? {});
+		const pinDataNodeNames = Object.keys(workflowDocumentStore.value?.pinData ?? {});
 
 		let nodeIssues: INodeIssues | null = null;
 		ignoreIssues = ignoreIssues ?? [];
@@ -290,7 +288,7 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 
 		const nodeInputIssues = getNodeInputIssues(workflowObject.value, node, nodeType);
 
-		workflowState.setNodeIssue({
+		workflowDocumentStore.value?.setNodeIssue({
 			node: node.name,
 			type: 'input',
 			value: nodeInputIssues?.input ? nodeInputIssues.input : null,
@@ -298,7 +296,7 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 	}
 
 	function updateNodesInputIssues() {
-		const nodes = workflowsStore.allNodes;
+		const nodes = workflowDocumentStore.value?.allNodes ?? [];
 
 		for (const node of nodes) {
 			updateNodeInputIssues(node);
@@ -306,10 +304,10 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 	}
 
 	function updateNodesExecutionIssues() {
-		const nodes = workflowsStore.allNodes;
+		const nodes = workflowDocumentStore.value?.allNodes ?? [];
 
 		for (const node of nodes) {
-			workflowState.setNodeIssue({
+			workflowDocumentStore.value?.setNodeIssue({
 				node: node.name,
 				type: 'execution',
 				value: hasNodeExecutionIssues(node) ? true : null,
@@ -318,7 +316,7 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 	}
 
 	function updateNodesParameterIssues() {
-		const nodes = workflowsStore.allNodes;
+		const nodes = workflowDocumentStore.value?.allNodes ?? [];
 
 		for (const node of nodes) {
 			updateNodeParameterIssues(node);
@@ -326,7 +324,7 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 	}
 
 	function updateNodeCredentialIssuesByName(name: string): void {
-		const node = workflowsStore.getNodeByName(name);
+		const node = workflowDocumentStore.value?.getNodeByName(name) ?? null;
 
 		if (node) {
 			updateNodeCredentialIssues(node);
@@ -341,7 +339,7 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 			newIssues = fullNodeIssues.credentials!;
 		}
 
-		workflowState.setNodeIssue({
+		workflowDocumentStore.value?.setNodeIssue({
 			node: node.name,
 			type: 'credentials',
 			value: newIssues,
@@ -349,7 +347,7 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 	}
 
 	function updateNodeParameterIssuesByName(name: string): void {
-		const node = workflowsStore.getNodeByName(name);
+		const node = workflowDocumentStore.value?.getNodeByName(name) ?? null;
 
 		if (node) {
 			updateNodeParameterIssues(node);
@@ -376,7 +374,7 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 			newIssues = fullNodeIssues.parameters!;
 		}
 
-		workflowState.setNodeIssue({
+		workflowDocumentStore.value?.setNodeIssue({
 			node: node.name,
 			type: 'parameters',
 			value: newIssues,
@@ -426,9 +424,6 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 		nodeType?: INodeTypeDescription,
 	): INodeIssues | null {
 		const localNodeType = nodeType ?? nodeTypesStore.getNodeType(node.type, node.typeVersion);
-		const workflowDocumentStore = workflowsStore.workflowId
-			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
-			: undefined;
 		if (node.disabled) {
 			// Node is disabled
 			return null;
@@ -467,7 +462,7 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 			// Prevents HTTP Request node from being unusable if a sharee does not have direct
 			// access to a credential
 			const isCredentialUsedInWorkflow =
-				workflowDocumentStore?.usedCredentials?.[
+				workflowDocumentStore.value?.usedCredentials?.[
 					node.credentials?.[nodeCredentialType]?.id as string
 				];
 
@@ -553,7 +548,7 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 
 				if (nameMatches.length === 0) {
 					const isCredentialUsedInWorkflow =
-						workflowDocumentStore?.usedCredentials?.[selectedCredentials.id as string];
+						workflowDocumentStore.value?.usedCredentials?.[selectedCredentials.id as string];
 
 					if (
 						!isCredentialUsedInWorkflow &&
@@ -606,13 +601,13 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 	}
 
 	function updateNodesCredentialsIssues() {
-		const nodes = workflowsStore.allNodes;
+		const nodes = workflowDocumentStore.value?.allNodes ?? [];
 		let issues: INodeIssues | null;
 
 		for (const node of nodes) {
 			issues = getNodeCredentialIssues(node);
 
-			workflowState.setNodeIssue({
+			workflowDocumentStore.value?.setNodeIssue({
 				node: node.name,
 				type: 'credentials',
 				value: issues?.credentials ?? null,
@@ -744,7 +739,7 @@ export function useNodeHelpers(opts: { workflowState?: WorkflowState } = {}) {
 				workflow_id: workflowsStore.workflowId,
 			});
 
-			workflowState.updateNodeProperties(updateInformation);
+			workflowDocumentStore.value?.updateNodeProperties(updateInformation);
 			workflowsStore.clearNodeExecutionData(node.name);
 			updateNodeParameterIssues(node);
 			updateNodeCredentialIssues(node);

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
@@ -415,12 +415,15 @@ export function handleExecutionFinishedWithSuccessOrOther(
 	const nodeTypesStore = useNodeTypesStore();
 	const workflowObject = workflowsStore.workflowObject;
 	const workflowName = workflowObject.name ?? '';
+	const workflowDocumentStore = workflowsStore.workflowId
+		? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+		: undefined;
 
 	useDocumentTitle().setDocumentTitle(workflowName, 'IDLE');
 
 	const workflowExecution = workflowsStore.getWorkflowExecution;
 	if (workflowExecution?.executedNode) {
-		const node = workflowsStore.getNodeByName(workflowExecution.executedNode);
+		const node = workflowDocumentStore?.getNodeByName(workflowExecution.executedNode) ?? null;
 		const nodeType = node && nodeTypesStore.getNodeType(node.type, node.typeVersion);
 		const nodeOutput =
 			workflowExecution.data?.resultData?.runData?.[workflowExecution.executedNode];
@@ -467,7 +470,7 @@ export function setRunExecutionData(
 	workflowState: WorkflowState,
 ) {
 	const workflowsStore = useWorkflowsStore();
-	const nodeHelpers = useNodeHelpers({ workflowState });
+	const nodeHelpers = useNodeHelpers();
 	const runDataExecutedErrorMessage = getRunDataExecutedErrorMessage(execution);
 	const workflowExecution = workflowsStore.getWorkflowExecution;
 

--- a/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.ts
@@ -38,6 +38,10 @@ import {
 
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { displayForm } from '@/features/execution/executions/executions.utils';
 import { useExternalHooks } from '@/app/composables/useExternalHooks';
 import { useWorkflowHelpers } from '@/app/composables/useWorkflowHelpers';
@@ -75,7 +79,13 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 	const pushConnectionStore = usePushConnectionStore();
 	const workflowsStore = useWorkflowsStore();
 	const workflowState = useRunWorkflowOpts.workflowState ?? injectWorkflowState();
-	const nodeHelpers = useNodeHelpers({ workflowState });
+	const nodeHelpers = useNodeHelpers();
+
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
 	const workflowSaving = useWorkflowSaving({
 		router: useRunWorkflowOpts.router,
 		workflowState,
@@ -88,8 +98,8 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 
 	function sortNodesByYPosition(nodes: string[]) {
 		return [...nodes].sort((a, b) => {
-			const nodeA = workflowsStore.getNodeByName(a)?.position ?? [0, 0];
-			const nodeB = workflowsStore.getNodeByName(b)?.position ?? [0, 0];
+			const nodeA = workflowDocumentStore.value?.getNodeByName(a)?.position ?? [0, 0];
+			const nodeB = workflowDocumentStore.value?.getNodeByName(b)?.position ?? [0, 0];
 
 			const nodeAYPosition = nodeA[1];
 			const nodeBYPosition = nodeB[1];
@@ -186,7 +196,7 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 
 			const { startNodeNames } = consolidatedData;
 			const destinationNodeType = options.destinationNode
-				? workflowsStore.getNodeByName(options.destinationNode.nodeName)?.type
+				? (workflowDocumentStore.value?.getNodeByName(options.destinationNode.nodeName)?.type ?? '')
 				: '';
 
 			let executedNode: string | undefined;
@@ -332,7 +342,9 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 
 			if ('destinationNode' in options) {
 				startRunData.destinationNode = options.destinationNode;
-				const nodeId = workflowsStore.getNodeByName(options.destinationNode?.nodeName ?? '')?.id;
+				const nodeId = workflowDocumentStore.value?.getNodeByName(
+					options.destinationNode?.nodeName ?? '',
+				)?.id;
 				if (workflowObject.value.id && nodeId) {
 					const agentRequest = agentRequestStore.getAgentRequest(workflowObject.value.id, nodeId);
 

--- a/packages/frontend/editor-ui/src/app/composables/useToolParameters.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useToolParameters.test.ts
@@ -14,6 +14,17 @@ import type { INode, INodeTypeDescription, Workflow } from 'n8n-workflow';
 import { AI_MCP_TOOL_NODE_TYPE } from '../constants';
 import { mock } from 'vitest-mock-extended';
 
+const { mockDocumentStore } = vi.hoisted(() => ({
+	mockDocumentStore: {
+		getNodeByName: vi.fn(),
+	},
+}));
+
+vi.mock('@/app/stores/workflowDocument.store', () => ({
+	useWorkflowDocumentStore: vi.fn().mockReturnValue(mockDocumentStore),
+	createWorkflowDocumentId: vi.fn().mockReturnValue('test-id'),
+}));
+
 describe('useToolParameters', () => {
 	let workflowsStore: MockedStore<typeof useWorkflowsStore>;
 	let projectsStore: MockedStore<typeof useProjectsStore>;
@@ -377,7 +388,7 @@ describe('useToolParameters', () => {
 			});
 
 			workflowsStore.workflowObject = mockWorkflow;
-			workflowsStore.getNodeByName = vi.fn().mockImplementation((name: string) => {
+			mockDocumentStore.getNodeByName.mockImplementation((name: string) => {
 				if (name === 'Connected Tool') return connectedTool;
 				return null;
 			});
@@ -430,7 +441,7 @@ describe('useToolParameters', () => {
 			});
 
 			workflowsStore.workflowObject = mockWorkflow;
-			workflowsStore.getNodeByName = vi.fn().mockImplementation((name: string) => {
+			mockDocumentStore.getNodeByName.mockImplementation((name: string) => {
 				if (name === 'Connected Tool') return connectedTool;
 				return null;
 			});

--- a/packages/frontend/editor-ui/src/app/composables/useToolParameters.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useToolParameters.ts
@@ -8,6 +8,10 @@ import {
 } from 'n8n-workflow';
 import { computed, reactive, ref, watch, type Ref } from 'vue';
 import { useWorkflowsStore } from '../stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { useNodeTypesStore } from '../stores/nodeTypes.store';
 import { useAgentRequestStore } from '@n8n/stores/useAgentRequestStore';
@@ -30,6 +34,12 @@ export function useToolParameters({ node }: GetToolParametersProps) {
 	const projectsStore = useProjectsStore();
 	const nodeTypesStore = useNodeTypesStore();
 	const agentRequestStore = useAgentRequestStore();
+
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
 
 	const selectedToolMap = reactive<Record<string, string | undefined>>({});
 	const error = ref<Error | undefined>(undefined);
@@ -197,7 +207,7 @@ export function useToolParameters({ node }: GetToolParametersProps) {
 			1,
 		);
 		const connectedTools = connectedToolNodeNames
-			.map((nodeName) => workflowsStore.getNodeByName(nodeName))
+			.map((nodeName) => workflowDocumentStore.value?.getNodeByName(nodeName))
 			.filter((tool): tool is INode => !!tool);
 
 		const ignoredFields = ['tool', 'toolParameters'];

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowState.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowState.ts
@@ -81,6 +81,7 @@ export function useWorkflowState() {
 		ws.workflowObject.setConnections({});
 	}
 
+	/** @deprecated Use `workflowDocumentStore.removeAllNodes()` instead. */
 	function removeAllNodes(data: { setStateDirty: boolean; removePinData: boolean }): void {
 		if (data.setStateDirty) {
 			uiStore.markStateDirty();
@@ -112,6 +113,7 @@ export function useWorkflowState() {
 		ws.workflowExecutionStartedData = undefined;
 	}
 
+	/** @deprecated Use `workflowDocumentStore.resetAllNodesIssues()` instead. */
 	function resetAllNodesIssues(): boolean {
 		ws.workflow.nodes.forEach((node) => {
 			node.issues = undefined;
@@ -222,6 +224,7 @@ export function useWorkflowState() {
 	////
 
 	/**
+	 * @deprecated Use per-node mutation methods on `workflowDocumentStore` instead.
 	 * @returns `true` if the object was changed
 	 */
 	function updateNodeAtIndex(nodeIndex: number, nodeData: Partial<INodeUi>): boolean {
@@ -241,6 +244,7 @@ export function useWorkflowState() {
 		return false;
 	}
 
+	/** @deprecated Use `workflowDocumentStore.setNodeParameters()` instead. */
 	function setNodeParameters(updateInformation: IUpdateInformation, append?: boolean): void {
 		// Find the node that should be updated
 		const nodeIndex = ws.workflow.nodes.findIndex((node) => {
@@ -270,6 +274,7 @@ export function useWorkflowState() {
 		}
 	}
 
+	/** @deprecated Use `workflowDocumentStore.setLastNodeParameters()` instead. */
 	function setLastNodeParameters(updateInformation: IUpdateInformation): void {
 		const latestNode = findLast(
 			ws.workflow.nodes,
@@ -292,6 +297,7 @@ export function useWorkflowState() {
 		}
 	}
 
+	/** @deprecated Use `workflowDocumentStore.setNodeValue()` instead. */
 	function setNodeValue(updateInformation: IUpdateInformation): void {
 		// Find the node that should be updated
 		const nodeIndex = ws.workflow.nodes.findIndex((node) => {
@@ -319,6 +325,7 @@ export function useWorkflowState() {
 		}
 	}
 
+	/** @deprecated Use `workflowDocumentStore.setNodePositionById()` instead. */
 	function setNodePositionById(id: string, position: INodeUi['position']): void {
 		const node = ws.workflow.nodes.find((n) => n.id === id);
 		if (!node) return;
@@ -328,6 +335,7 @@ export function useWorkflowState() {
 
 	/**
 	 * Update node by ID. Finds the node by ID and updates it with the provided data.
+	 * @deprecated Use `workflowDocumentStore.updateNodeById()` instead.
 	 * @returns `true` if the node was found and updated
 	 */
 	function updateNodeById(nodeId: string, nodeData: Partial<INodeUi>): boolean {
@@ -339,6 +347,7 @@ export function useWorkflowState() {
 	/**
 	 * Reset parametersLastUpdatedAt to current timestamp for a node.
 	 * Used to mark a node as "dirty" when its parameters change.
+	 * @deprecated Use `workflowDocumentStore.resetParametersLastUpdatedAt()` instead.
 	 */
 	function resetParametersLastUpdatedAt(nodeName: string): void {
 		if (!ws.nodeMetadata[nodeName]) {
@@ -347,6 +356,7 @@ export function useWorkflowState() {
 		ws.nodeMetadata[nodeName].parametersLastUpdatedAt = Date.now();
 	}
 
+	/** @deprecated Use `workflowDocumentStore.updateNodeProperties()` instead. */
 	function updateNodeProperties(
 		this: WorkflowState,
 		updateInformation: INodeUpdatePropertiesInformation,
@@ -372,6 +382,7 @@ export function useWorkflowState() {
 		workflowStateEventBus.emit('updateNodeProperties', [this, updateInformation]);
 	}
 
+	/** @deprecated Use `workflowDocumentStore.setNodeIssue()` instead. */
 	function setNodeIssue(nodeIssueData: INodeIssueData): void {
 		const nodeIndex = ws.workflow.nodes.findIndex((node) => {
 			return node.name === nodeIssueData.node;

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Integration tests for workflowDocument.store cross-cut wiring.
+ *
+ * These tests verify the orchestration logic in workflowDocument.store.ts —
+ * the glue that connects composables to each other and to external stores.
+ * Individual composable behavior is tested in their own test files.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
+import { useUIStore } from '@/app/stores/ui.store';
+import { createTestNode } from '@/__tests__/mocks';
+import type { INodeUi } from '@/Interface';
+
+vi.mock('@/app/stores/nodeTypes.store', () => ({
+	useNodeTypesStore: vi.fn(() => ({
+		getNodeType: vi.fn().mockReturnValue(null),
+	})),
+}));
+
+function createNode(overrides: Partial<INodeUi> = {}): INodeUi {
+	return createTestNode({ name: 'Test Node', ...overrides }) as INodeUi;
+}
+
+describe('workflowDocument.store orchestration', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia());
+	});
+
+	it('removeAllNodes clears both nodes and pin data', () => {
+		const store = useWorkflowDocumentStore(createWorkflowDocumentId('test-wf'));
+
+		// Set up nodes and pin data
+		store.setNodes([createNode({ name: 'A' }), createNode({ name: 'B' })]);
+		store.setPinData({ A: [{ json: { value: 1 } }] });
+
+		// Verify both are populated
+		expect(store.allNodes).toHaveLength(2);
+		expect(store.pinData).toHaveProperty('A');
+
+		// removeAllNodes should clear both
+		store.removeAllNodes();
+
+		expect(store.allNodes).toHaveLength(0);
+		expect(store.pinData).toEqual({});
+	});
+
+	it('node mutation triggers markStateDirty on UI store', () => {
+		const store = useWorkflowDocumentStore(createWorkflowDocumentId('test-wf'));
+		const uiStore = useUIStore();
+
+		// Start clean
+		uiStore.markStateClean();
+		expect(uiStore.stateIsDirty).toBe(false);
+
+		// addNode fires onStateDirty, which the store wires to markStateDirty
+		store.addNode(createNode({ name: 'A' }));
+
+		expect(uiStore.stateIsDirty).toBe(true);
+	});
+});

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
@@ -75,8 +75,20 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 			getNodeType: (typeName, version) => nodeTypesStore.getNodeType(typeName, version),
 		});
 
-		// Cross-cut: wire the nodes facade's dirty signal to UI store
+		// --- Cross-cut orchestration ---
+		// Each composable is self-contained and unaware of its siblings. This
+		// store is where cross-concern side effects are wired. When adding new
+		// composables (e.g. connections), check workflowsStore for hidden
+		// cross-cuts that need to surface here. Known future ones:
+		//   - removeNode → unpinNodeData (currently in workflowsStore.removeNode)
+		//   - removeAllNodes → removeAllConnections (when connections composable exists)
+
 		onStateDirty(() => useUIStore().markStateDirty());
+
+		function removeAllNodes() {
+			workflowDocumentNodes.removeAllNodes();
+			workflowDocumentPinData.setPinData({});
+		}
 
 		return {
 			workflowId,
@@ -94,6 +106,7 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 			...workflowDocumentParentFolder,
 			...workflowDocumentUsedCredentials,
 			...workflowDocumentNodes,
+			removeAllNodes,
 		};
 	})();
 }

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
@@ -14,6 +14,8 @@ import { useWorkflowDocumentIsArchived } from './workflowDocument/useWorkflowDoc
 import { useWorkflowDocumentTimestamps } from './workflowDocument/useWorkflowDocumentTimestamps';
 import { useWorkflowDocumentParentFolder } from './workflowDocument/useWorkflowDocumentParentFolder';
 import { useWorkflowDocumentUsedCredentials } from './workflowDocument/useWorkflowDocumentUsedCredentials';
+import { useWorkflowDocumentNodes } from './workflowDocument/useWorkflowDocumentNodes';
+import { useUIStore } from '@/app/stores/ui.store';
 
 export {
 	getPinDataSize,
@@ -67,6 +69,10 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 		const workflowDocumentSettings = useWorkflowDocumentSettings();
 		const workflowDocumentParentFolder = useWorkflowDocumentParentFolder();
 		const workflowDocumentUsedCredentials = useWorkflowDocumentUsedCredentials();
+		const { onStateDirty, ...workflowDocumentNodes } = useWorkflowDocumentNodes();
+
+		// Cross-cut: wire the nodes facade's dirty signal to UI store
+		onStateDirty(() => useUIStore().markStateDirty());
 
 		return {
 			workflowId,
@@ -83,6 +89,7 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 			...workflowDocumentTimestamps,
 			...workflowDocumentParentFolder,
 			...workflowDocumentUsedCredentials,
+			...workflowDocumentNodes,
 		};
 	})();
 }

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
@@ -16,6 +16,7 @@ import { useWorkflowDocumentParentFolder } from './workflowDocument/useWorkflowD
 import { useWorkflowDocumentUsedCredentials } from './workflowDocument/useWorkflowDocumentUsedCredentials';
 import { useWorkflowDocumentNodes } from './workflowDocument/useWorkflowDocumentNodes';
 import { useUIStore } from '@/app/stores/ui.store';
+import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 
 export {
 	getPinDataSize,
@@ -69,7 +70,10 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 		const workflowDocumentSettings = useWorkflowDocumentSettings();
 		const workflowDocumentParentFolder = useWorkflowDocumentParentFolder();
 		const workflowDocumentUsedCredentials = useWorkflowDocumentUsedCredentials();
-		const { onStateDirty, ...workflowDocumentNodes } = useWorkflowDocumentNodes();
+		const nodeTypesStore = useNodeTypesStore();
+		const { onStateDirty, ...workflowDocumentNodes } = useWorkflowDocumentNodes({
+			getNodeType: (typeName, version) => nodeTypesStore.getNodeType(typeName, version),
+		});
 
 		// Cross-cut: wire the nodes facade's dirty signal to UI store
 		onStateDirty(() => useUIStore().markStateDirty());

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.test.ts
@@ -1,17 +1,17 @@
 /**
- * Integration tests for the useWorkflowDocumentNodes facade.
+ * Integration tests for useWorkflowDocumentNodes.
  *
  * These tests use a real Pinia store (createPinia, not createTestingPinia) so
  * that every write goes through the actual workflowsStore and every read comes
- * back through the facade's public API. This "round-trip" pattern (write → read
- * back → assert) is intentional:
+ * back through the public API. This "round-trip" pattern (write → read back →
+ * assert) is intentional:
  *
  *  - It catches regressions when consumers migrate from workflowsStore to
  *    workflowDocumentStore — the round-trip proves both paths produce the same
  *    result.
- *  - It survives internal refactors. When the facade's internals change (e.g.
- *    owning its own refs instead of delegating), these tests stay unchanged
- *    because they only exercise the public contract.
+ *  - It survives internal refactors. When the internals change (e.g. owning
+ *    its own refs instead of delegating), these tests stay unchanged because
+ *    they only exercise the public contract.
  *  - Delegation-style tests (expect(store.method).toHaveBeenCalled()) would
  *    need to be rewritten every time internals change; round-trips do not.
  */
@@ -51,66 +51,66 @@ describe('useWorkflowDocumentNodes', () => {
 			const nodeA = createNode({ name: 'A' });
 			const nodeB = createNode({ name: 'B' });
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([nodeA, nodeB]);
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([nodeA, nodeB]);
 
-			expect(facade.allNodes.value).toHaveLength(2);
-			expect(facade.allNodes.value.map((n) => n.name)).toEqual(['A', 'B']);
+			expect(workflowDocumentNodes.allNodes.value).toHaveLength(2);
+			expect(workflowDocumentNodes.allNodes.value.map((n) => n.name)).toEqual(['A', 'B']);
 		});
 
 		it('nodes set via setNodes are readable via getNodeById', () => {
 			const node = createNode({ name: 'A' });
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([node]);
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([node]);
 
-			expect(facade.getNodeById(node.id)).toBeDefined();
-			expect(facade.getNodeById(node.id)?.name).toBe('A');
+			expect(workflowDocumentNodes.getNodeById(node.id)).toBeDefined();
+			expect(workflowDocumentNodes.getNodeById(node.id)?.name).toBe('A');
 		});
 
 		it('nodes set via setNodes are readable via getNodeByName', () => {
 			const node = createNode({ name: 'MyNode' });
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([node]);
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([node]);
 
-			expect(facade.getNodeByName('MyNode')).toBeDefined();
-			expect(facade.getNodeByName('MyNode')?.id).toBe(node.id);
+			expect(workflowDocumentNodes.getNodeByName('MyNode')).toBeDefined();
+			expect(workflowDocumentNodes.getNodeByName('MyNode')?.id).toBe(node.id);
 		});
 
 		it('nodes set via setNodes are readable via getNodes', () => {
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([createNode({ name: 'A' }), createNode({ name: 'B' })]);
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([createNode({ name: 'A' }), createNode({ name: 'B' })]);
 
-			const nodes = facade.getNodes();
+			const nodes = workflowDocumentNodes.getNodes();
 			expect(nodes).toHaveLength(2);
 		});
 
 		it('nodes set via setNodes are readable via nodesByName', () => {
 			const node = createNode({ name: 'Alpha' });
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([node]);
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([node]);
 
-			expect(facade.nodesByName.value).toHaveProperty('Alpha');
-			expect(facade.nodesByName.value.Alpha.id).toBe(node.id);
+			expect(workflowDocumentNodes.nodesByName.value).toHaveProperty('Alpha');
+			expect(workflowDocumentNodes.nodesByName.value.Alpha.id).toBe(node.id);
 		});
 
 		it('canvasNames reflects set nodes', () => {
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([createNode({ name: 'X' }), createNode({ name: 'Y' })]);
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([createNode({ name: 'X' }), createNode({ name: 'Y' })]);
 
-			expect(facade.canvasNames.value).toEqual(new Set(['X', 'Y']));
+			expect(workflowDocumentNodes.canvasNames.value).toEqual(new Set(['X', 'Y']));
 		});
 
 		it('getNodesByIds returns matching nodes', () => {
 			const nodeA = createNode({ name: 'A' });
 			const nodeB = createNode({ name: 'B' });
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([nodeA, nodeB]);
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([nodeA, nodeB]);
 
-			const result = facade.getNodesByIds([nodeA.id]);
+			const result = workflowDocumentNodes.getNodesByIds([nodeA.id]);
 			expect(result).toHaveLength(1);
 			expect(result[0].name).toBe('A');
 		});
@@ -118,12 +118,12 @@ describe('useWorkflowDocumentNodes', () => {
 		it('findNodeByPartialId matches partial id', () => {
 			const node = createNode({ name: 'FindMe' });
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([node]);
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([node]);
 
 			// Use first 8 chars of UUID as partial
 			const partial = node.id.slice(0, 8);
-			const found = facade.findNodeByPartialId(partial);
+			const found = workflowDocumentNodes.findNodeByPartialId(partial);
 			expect(found?.name).toBe('FindMe');
 		});
 	});
@@ -132,20 +132,20 @@ describe('useWorkflowDocumentNodes', () => {
 		it('node added via addNode is readable via allNodes', () => {
 			const node = createNode({ name: 'Added' });
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.addNode(node);
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.addNode(node);
 
-			expect(facade.allNodes.value).toHaveLength(1);
-			expect(facade.allNodes.value[0].name).toBe('Added');
+			expect(workflowDocumentNodes.allNodes.value).toHaveLength(1);
+			expect(workflowDocumentNodes.allNodes.value[0].name).toBe('Added');
 		});
 
 		it('node added via addNode is readable via getNodeById', () => {
 			const node = createNode({ name: 'Added' });
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.addNode(node);
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.addNode(node);
 
-			expect(facade.getNodeById(node.id)?.name).toBe('Added');
+			expect(workflowDocumentNodes.getNodeById(node.id)?.name).toBe('Added');
 		});
 	});
 
@@ -154,31 +154,31 @@ describe('useWorkflowDocumentNodes', () => {
 			const nodeA = createNode({ name: 'A' });
 			const nodeB = createNode({ name: 'B' });
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([nodeA, nodeB]);
-			facade.removeNode(nodeA);
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([nodeA, nodeB]);
+			workflowDocumentNodes.removeNode(nodeA);
 
-			expect(facade.allNodes.value).toHaveLength(1);
-			expect(facade.allNodes.value[0].name).toBe('B');
+			expect(workflowDocumentNodes.allNodes.value).toHaveLength(1);
+			expect(workflowDocumentNodes.allNodes.value[0].name).toBe('B');
 		});
 
 		it('removeNodeById removes node from allNodes', () => {
 			const node = createNode({ name: 'ToRemove' });
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([node]);
-			facade.removeNodeById(node.id);
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([node]);
+			workflowDocumentNodes.removeNodeById(node.id);
 
-			expect(facade.allNodes.value).toHaveLength(0);
+			expect(workflowDocumentNodes.allNodes.value).toHaveLength(0);
 		});
 
 		it('removeAllNodes empties all nodes', () => {
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([createNode({ name: 'A' }), createNode({ name: 'B' })]);
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([createNode({ name: 'A' }), createNode({ name: 'B' })]);
 
-			facade.removeAllNodes({ setStateDirty: false, removePinData: false });
+			workflowDocumentNodes.removeAllNodes({ setStateDirty: false, removePinData: false });
 
-			expect(facade.allNodes.value).toHaveLength(0);
+			expect(workflowDocumentNodes.allNodes.value).toHaveLength(0);
 		});
 	});
 
@@ -186,93 +186,96 @@ describe('useWorkflowDocumentNodes', () => {
 		it('setNodeParameters updates parameters readable via getNodeByName', () => {
 			const node = createNode({ name: 'Target', parameters: { old: 'value' } });
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([node]);
-			facade.setNodeParameters({ name: 'Target', value: { new: 'value' } });
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([node]);
+			workflowDocumentNodes.setNodeParameters({ name: 'Target', value: { new: 'value' } });
 
-			expect(facade.getNodeByName('Target')?.parameters).toEqual({ new: 'value' });
+			expect(workflowDocumentNodes.getNodeByName('Target')?.parameters).toEqual({ new: 'value' });
 		});
 
 		it('setNodeParameters with append merges parameters', () => {
 			const node = createNode({ name: 'Target', parameters: { existing: 'keep' } });
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([node]);
-			facade.setNodeParameters({ name: 'Target', value: { added: 'new' } }, true);
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([node]);
+			workflowDocumentNodes.setNodeParameters({ name: 'Target', value: { added: 'new' } }, true);
 
-			expect(facade.getNodeByName('Target')?.parameters).toEqual({
+			expect(workflowDocumentNodes.getNodeByName('Target')?.parameters).toEqual({
 				existing: 'keep',
 				added: 'new',
 			});
 		});
 
 		it('setNodeParameters throws when node not found', () => {
-			const facade = useWorkflowDocumentNodes(deps);
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
 
-			expect(() => facade.setNodeParameters({ name: 'NonExistent', value: {} })).toThrow(
-				'could not be found',
-			);
+			expect(() =>
+				workflowDocumentNodes.setNodeParameters({ name: 'NonExistent', value: {} }),
+			).toThrow('could not be found');
 		});
 
 		it('setNodeValue updates a property readable via getNodeByName', () => {
 			const node = createNode({ name: 'Target' });
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([node]);
-			facade.setNodeValue({ name: 'Target', key: 'disabled', value: true });
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([node]);
+			workflowDocumentNodes.setNodeValue({ name: 'Target', key: 'disabled', value: true });
 
-			expect(facade.getNodeByName('Target')?.disabled).toBe(true);
+			expect(workflowDocumentNodes.getNodeByName('Target')?.disabled).toBe(true);
 		});
 
 		it('setNodePositionById updates position readable via getNodeById', () => {
 			const node = createNode({ name: 'Mover' });
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([node]);
-			facade.setNodePositionById(node.id, [300, 400]);
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([node]);
+			workflowDocumentNodes.setNodePositionById(node.id, [300, 400]);
 
-			expect(facade.getNodeById(node.id)?.position).toEqual([300, 400]);
+			expect(workflowDocumentNodes.getNodeById(node.id)?.position).toEqual([300, 400]);
 		});
 
 		it('updateNodeById updates node readable via getNodeById', () => {
 			const node = createNode({ name: 'Target' });
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([node]);
-			const result = facade.updateNodeById(node.id, { disabled: true });
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([node]);
+			const result = workflowDocumentNodes.updateNodeById(node.id, { disabled: true });
 
 			expect(result).toBe(true);
-			expect(facade.getNodeById(node.id)?.disabled).toBe(true);
+			expect(workflowDocumentNodes.getNodeById(node.id)?.disabled).toBe(true);
 		});
 
 		it('updateNodeById returns false when node not found', () => {
-			const facade = useWorkflowDocumentNodes(deps);
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
 
-			expect(facade.updateNodeById('nonexistent', { disabled: true })).toBe(false);
+			expect(workflowDocumentNodes.updateNodeById('nonexistent', { disabled: true })).toBe(false);
 		});
 
 		it('updateNodeProperties updates properties readable via getNodeByName', () => {
 			const node = createNode({ name: 'Target' });
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([node]);
-			facade.updateNodeProperties({ name: 'Target', properties: { disabled: true } });
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([node]);
+			workflowDocumentNodes.updateNodeProperties({
+				name: 'Target',
+				properties: { disabled: true },
+			});
 
-			expect(facade.getNodeByName('Target')?.disabled).toBe(true);
+			expect(workflowDocumentNodes.getNodeByName('Target')?.disabled).toBe(true);
 		});
 
 		it('setNodeIssue adds issue readable via getNodeByName', () => {
 			const node = createNode({ name: 'Target' });
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([node]);
-			facade.setNodeIssue({
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([node]);
+			workflowDocumentNodes.setNodeIssue({
 				node: 'Target',
 				type: 'parameters',
 				value: { param: ['Missing required parameter'] },
 			});
 
-			expect(facade.getNodeByName('Target')?.issues).toEqual({
+			expect(workflowDocumentNodes.getNodeByName('Target')?.issues).toEqual({
 				parameters: { param: ['Missing required parameter'] },
 			});
 		});
@@ -284,11 +287,11 @@ describe('useWorkflowDocumentNodes', () => {
 				credentials: { cred: ['Invalid'] },
 			};
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([node]);
-			facade.setNodeIssue({ node: 'Target', type: 'parameters', value: null });
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([node]);
+			workflowDocumentNodes.setNodeIssue({ node: 'Target', type: 'parameters', value: null });
 
-			const issues = facade.getNodeByName('Target')?.issues;
+			const issues = workflowDocumentNodes.getNodeByName('Target')?.issues;
 			expect(issues).toEqual({ credentials: { cred: ['Invalid'] } });
 			expect(issues).not.toHaveProperty('parameters');
 		});
@@ -297,13 +300,13 @@ describe('useWorkflowDocumentNodes', () => {
 			const nodeA = createNode({ name: 'A', issues: { parameters: { x: ['err'] } } });
 			const nodeB = createNode({ name: 'B', issues: { credentials: { y: ['err'] } } });
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([nodeA, nodeB]);
-			const result = facade.resetAllNodesIssues();
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([nodeA, nodeB]);
+			const result = workflowDocumentNodes.resetAllNodesIssues();
 
 			expect(result).toBe(true);
-			expect(facade.getNodeByName('A')?.issues).toBeUndefined();
-			expect(facade.getNodeByName('B')?.issues).toBeUndefined();
+			expect(workflowDocumentNodes.getNodeByName('A')?.issues).toBeUndefined();
+			expect(workflowDocumentNodes.getNodeByName('B')?.issues).toBeUndefined();
 		});
 
 		it('setLastNodeParameters does nothing when node type is not found', () => {
@@ -313,16 +316,16 @@ describe('useWorkflowDocumentNodes', () => {
 				parameters: { old: 'value' },
 			});
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([node]);
-			facade.setLastNodeParameters({
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([node]);
+			workflowDocumentNodes.setLastNodeParameters({
 				key: 'n8n-nodes-base.set',
 				name: '',
 				value: { new: 'value' },
 			});
 
 			// getNodeType returns null (default mock), so parameters should not change
-			expect(facade.getNodeByName('Target')?.parameters).toEqual({ old: 'value' });
+			expect(workflowDocumentNodes.getNodeByName('Target')?.parameters).toEqual({ old: 'value' });
 		});
 
 		it('setLastNodeParameters finds latest node by type and sets parameters', () => {
@@ -340,9 +343,9 @@ describe('useWorkflowDocumentNodes', () => {
 				getNodeType: vi.fn().mockReturnValue(mockNodeType),
 			});
 
-			const facade = useWorkflowDocumentNodes(customDeps);
-			facade.setNodes([node]);
-			facade.setLastNodeParameters({
+			const workflowDocumentNodes = useWorkflowDocumentNodes(customDeps);
+			workflowDocumentNodes.setNodes([node]);
+			workflowDocumentNodes.setLastNodeParameters({
 				key: 'n8n-nodes-base.set',
 				name: '',
 				value: { value: 'hello' },
@@ -356,11 +359,11 @@ describe('useWorkflowDocumentNodes', () => {
 		it('setNodeValue does not update parametersLastUpdatedAt for position changes', () => {
 			const node = createNode({ name: 'Target' });
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([node]);
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([node]);
 
 			const tsBefore = workflowsStore.nodeMetadata.Target.parametersLastUpdatedAt;
-			facade.setNodeValue({ name: 'Target', key: 'position', value: [300, 400] });
+			workflowDocumentNodes.setNodeValue({ name: 'Target', key: 'position', value: [300, 400] });
 
 			expect(workflowsStore.nodeMetadata.Target.parametersLastUpdatedAt).toBe(tsBefore);
 		});
@@ -368,10 +371,10 @@ describe('useWorkflowDocumentNodes', () => {
 		it('setNodeValue updates parametersLastUpdatedAt for non-position changes', () => {
 			const node = createNode({ name: 'Target' });
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([node]);
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([node]);
 
-			facade.setNodeValue({ name: 'Target', key: 'disabled', value: true });
+			workflowDocumentNodes.setNodeValue({ name: 'Target', key: 'disabled', value: true });
 
 			expect(workflowsStore.nodeMetadata.Target.parametersLastUpdatedAt).toBeGreaterThan(0);
 		});
@@ -379,18 +382,18 @@ describe('useWorkflowDocumentNodes', () => {
 		it('resetParametersLastUpdatedAt updates timestamp', () => {
 			const node = createNode({ name: 'Target' });
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([node]);
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([node]);
 
-			facade.resetParametersLastUpdatedAt('Target');
+			workflowDocumentNodes.resetParametersLastUpdatedAt('Target');
 
 			expect(workflowsStore.nodeMetadata.Target.parametersLastUpdatedAt).toBeGreaterThan(0);
 		});
 
 		it('resetParametersLastUpdatedAt creates metadata entry if missing', () => {
-			const facade = useWorkflowDocumentNodes(deps);
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
 
-			facade.resetParametersLastUpdatedAt('NewNode');
+			workflowDocumentNodes.resetParametersLastUpdatedAt('NewNode');
 
 			expect(workflowsStore.nodeMetadata.NewNode).toBeDefined();
 			expect(workflowsStore.nodeMetadata.NewNode.parametersLastUpdatedAt).toBeGreaterThan(0);
@@ -401,9 +404,9 @@ describe('useWorkflowDocumentNodes', () => {
 		it('setNodes does not fire onNodesChange (initialization path)', () => {
 			const hookSpy = vi.fn();
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.onNodesChange(hookSpy);
-			facade.setNodes([createNode()]);
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.onNodesChange(hookSpy);
+			workflowDocumentNodes.setNodes([createNode()]);
 
 			expect(hookSpy).not.toHaveBeenCalled();
 		});
@@ -412,9 +415,9 @@ describe('useWorkflowDocumentNodes', () => {
 			const hookSpy = vi.fn();
 			const node = createNode();
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.onNodesChange(hookSpy);
-			facade.addNode(node);
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.onNodesChange(hookSpy);
+			workflowDocumentNodes.addNode(node);
 
 			expect(hookSpy).toHaveBeenCalledWith({
 				action: 'add',
@@ -426,10 +429,10 @@ describe('useWorkflowDocumentNodes', () => {
 			const hookSpy = vi.fn();
 			const node = createNode({ name: 'Target' });
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([node]);
-			facade.onNodesChange(hookSpy);
-			facade.removeNode(node);
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([node]);
+			workflowDocumentNodes.onNodesChange(hookSpy);
+			workflowDocumentNodes.removeNode(node);
 
 			expect(hookSpy).toHaveBeenCalledWith({
 				action: 'delete',
@@ -441,10 +444,10 @@ describe('useWorkflowDocumentNodes', () => {
 			const hookSpy = vi.fn();
 			const node = createNode({ name: 'Target' });
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([node]);
-			facade.onNodesChange(hookSpy);
-			facade.removeNodeById(node.id);
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([node]);
+			workflowDocumentNodes.onNodesChange(hookSpy);
+			workflowDocumentNodes.removeNodeById(node.id);
 
 			expect(hookSpy).toHaveBeenCalledWith({
 				action: 'delete',
@@ -455,9 +458,9 @@ describe('useWorkflowDocumentNodes', () => {
 		it('addNode fires onStateDirty', () => {
 			const dirtySpy = vi.fn();
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.onStateDirty(dirtySpy);
-			facade.addNode(createNode());
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.onStateDirty(dirtySpy);
+			workflowDocumentNodes.addNode(createNode());
 
 			expect(dirtySpy).toHaveBeenCalledOnce();
 		});
@@ -466,10 +469,10 @@ describe('useWorkflowDocumentNodes', () => {
 			const dirtySpy = vi.fn();
 			const node = createNode();
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([node]);
-			facade.onStateDirty(dirtySpy);
-			facade.removeNode(node);
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([node]);
+			workflowDocumentNodes.onStateDirty(dirtySpy);
+			workflowDocumentNodes.removeNode(node);
 
 			expect(dirtySpy).toHaveBeenCalledOnce();
 		});
@@ -478,10 +481,10 @@ describe('useWorkflowDocumentNodes', () => {
 			const dirtySpy = vi.fn();
 			const node = createNode();
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([node]);
-			facade.onStateDirty(dirtySpy);
-			facade.removeNodeById(node.id);
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([node]);
+			workflowDocumentNodes.onStateDirty(dirtySpy);
+			workflowDocumentNodes.removeNodeById(node.id);
 
 			expect(dirtySpy).toHaveBeenCalledOnce();
 		});
@@ -489,9 +492,9 @@ describe('useWorkflowDocumentNodes', () => {
 		it('setNodes does not fire onStateDirty (initialization path)', () => {
 			const dirtySpy = vi.fn();
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.onStateDirty(dirtySpy);
-			facade.setNodes([createNode()]);
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.onStateDirty(dirtySpy);
+			workflowDocumentNodes.setNodes([createNode()]);
 
 			expect(dirtySpy).not.toHaveBeenCalled();
 		});
@@ -500,10 +503,10 @@ describe('useWorkflowDocumentNodes', () => {
 			const dirtySpy = vi.fn();
 			const node = createNode({ name: 'Target', parameters: { old: 'value' } });
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([node]);
-			facade.onStateDirty(dirtySpy);
-			facade.setNodeParameters({ name: 'Target', value: { new: 'value' } });
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([node]);
+			workflowDocumentNodes.onStateDirty(dirtySpy);
+			workflowDocumentNodes.setNodeParameters({ name: 'Target', value: { new: 'value' } });
 
 			expect(dirtySpy).toHaveBeenCalledOnce();
 		});
@@ -512,10 +515,10 @@ describe('useWorkflowDocumentNodes', () => {
 			const dirtySpy = vi.fn();
 			const node = createNode({ name: 'Target' });
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([node]);
-			facade.onStateDirty(dirtySpy);
-			facade.setNodeValue({ name: 'Target', key: 'disabled', value: true });
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([node]);
+			workflowDocumentNodes.onStateDirty(dirtySpy);
+			workflowDocumentNodes.setNodeValue({ name: 'Target', key: 'disabled', value: true });
 
 			expect(dirtySpy).toHaveBeenCalledOnce();
 		});
@@ -523,10 +526,10 @@ describe('useWorkflowDocumentNodes', () => {
 		it('removeAllNodes fires onStateDirty when setStateDirty is true', () => {
 			const dirtySpy = vi.fn();
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([createNode()]);
-			facade.onStateDirty(dirtySpy);
-			facade.removeAllNodes({ setStateDirty: true, removePinData: false });
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([createNode()]);
+			workflowDocumentNodes.onStateDirty(dirtySpy);
+			workflowDocumentNodes.removeAllNodes({ setStateDirty: true, removePinData: false });
 
 			expect(dirtySpy).toHaveBeenCalledOnce();
 		});
@@ -534,10 +537,10 @@ describe('useWorkflowDocumentNodes', () => {
 		it('removeAllNodes does not fire onStateDirty when setStateDirty is false', () => {
 			const dirtySpy = vi.fn();
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.setNodes([createNode()]);
-			facade.onStateDirty(dirtySpy);
-			facade.removeAllNodes({ setStateDirty: false, removePinData: false });
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([createNode()]);
+			workflowDocumentNodes.onStateDirty(dirtySpy);
+			workflowDocumentNodes.removeAllNodes({ setStateDirty: false, removePinData: false });
 
 			expect(dirtySpy).not.toHaveBeenCalled();
 		});
@@ -545,9 +548,9 @@ describe('useWorkflowDocumentNodes', () => {
 		it('removeNodeById uses empty name when node not found', () => {
 			const hookSpy = vi.fn();
 
-			const facade = useWorkflowDocumentNodes(deps);
-			facade.onNodesChange(hookSpy);
-			facade.removeNodeById('nonexistent');
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.onNodesChange(hookSpy);
+			workflowDocumentNodes.removeNodeById('nonexistent');
 
 			expect(hookSpy).toHaveBeenCalledWith({
 				action: 'delete',

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.test.ts
@@ -1,8 +1,23 @@
+/**
+ * Integration tests for the useWorkflowDocumentNodes facade.
+ *
+ * These tests use a real Pinia store (createPinia, not createTestingPinia) so
+ * that every write goes through the actual workflowsStore and every read comes
+ * back through the facade's public API. This "round-trip" pattern (write → read
+ * back → assert) is intentional:
+ *
+ *  - It catches regressions when consumers migrate from workflowsStore to
+ *    workflowDocumentStore — the round-trip proves both paths produce the same
+ *    result.
+ *  - It survives internal refactors. When the facade's internals change (e.g.
+ *    owning its own refs instead of delegating), these tests stay unchanged
+ *    because they only exercise the public contract.
+ *  - Delegation-style tests (expect(store.method).toHaveBeenCalled()) would
+ *    need to be rewritten every time internals change; round-trips do not.
+ */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { setActivePinia } from 'pinia';
-import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia, createPinia } from 'pinia';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
-import { mockedStore } from '@/__tests__/utils';
 import { createTestNode } from '@/__tests__/mocks';
 import type { INodeUi } from '@/Interface';
 import {
@@ -22,342 +37,312 @@ function createDeps(overrides: Partial<WorkflowDocumentNodesDeps> = {}): Workflo
 }
 
 describe('useWorkflowDocumentNodes', () => {
-	let workflowsStore: ReturnType<typeof mockedStore<typeof useWorkflowsStore>>;
+	let workflowsStore: ReturnType<typeof useWorkflowsStore>;
 	let deps: WorkflowDocumentNodesDeps;
 
 	beforeEach(() => {
-		setActivePinia(createTestingPinia());
-		workflowsStore = mockedStore(useWorkflowsStore);
+		setActivePinia(createPinia());
+		workflowsStore = useWorkflowsStore();
 		deps = createDeps();
-
-		// Provide workflowObject.setNodes for updateNodeAtIndex
-		workflowsStore.workflowObject = { setNodes: vi.fn() } as unknown as ReturnType<
-			typeof useWorkflowsStore
-		>['workflowObject'];
 	});
 
-	describe('read API delegation', () => {
-		it('getNodeById delegates to workflowsStore.getNodeById', () => {
-			const node = createNode();
-			workflowsStore.getNodeById.mockReturnValue(node);
-
-			const { getNodeById } = useWorkflowDocumentNodes(deps);
-			const result = getNodeById('node-1');
-
-			expect(result).toBe(node);
-			expect(workflowsStore.getNodeById).toHaveBeenCalledWith('node-1');
-		});
-
-		it('getNodeByName delegates to workflowsStore.getNodeByName', () => {
-			const node = createNode();
-			workflowsStore.getNodeByName.mockReturnValue(node);
-
-			const { getNodeByName } = useWorkflowDocumentNodes(deps);
-			const result = getNodeByName('Test Node');
-
-			expect(result).toBe(node);
-			expect(workflowsStore.getNodeByName).toHaveBeenCalledWith('Test Node');
-		});
-
-		it('getNodes delegates to workflowsStore.getNodes', () => {
-			const nodes = [createNode()];
-			workflowsStore.getNodes.mockReturnValue(nodes);
-
-			const { getNodes } = useWorkflowDocumentNodes(deps);
-			const result = getNodes();
-
-			expect(result).toBe(nodes);
-			expect(workflowsStore.getNodes).toHaveBeenCalled();
-		});
-
-		it('findNodeByPartialId delegates to workflowsStore.findNodeByPartialId', () => {
-			const node = createNode();
-			workflowsStore.findNodeByPartialId.mockReturnValue(node);
-
-			const { findNodeByPartialId } = useWorkflowDocumentNodes(deps);
-			const result = findNodeByPartialId('node');
-
-			expect(result).toBe(node);
-			expect(workflowsStore.findNodeByPartialId).toHaveBeenCalledWith('node');
-		});
-
-		it('getNodesByIds delegates to workflowsStore.getNodesByIds', () => {
-			const nodes = [createNode()];
-			workflowsStore.getNodesByIds.mockReturnValue(nodes);
-
-			const { getNodesByIds } = useWorkflowDocumentNodes(deps);
-			const result = getNodesByIds(['node-1']);
-
-			expect(result).toBe(nodes);
-			expect(workflowsStore.getNodesByIds).toHaveBeenCalledWith(['node-1']);
-		});
-	});
-
-	describe('computed properties', () => {
-		it('allNodes reflects workflowsStore.allNodes', () => {
-			const nodes = [createNode({ name: 'A' }), createNode({ name: 'B' })];
-			workflowsStore.allNodes = nodes;
-
-			const { allNodes } = useWorkflowDocumentNodes(deps);
-
-			expect(allNodes.value).toEqual(nodes);
-		});
-
-		it('nodesByName reflects workflowsStore.nodesByName', () => {
+	describe('round-trip: setNodes → read', () => {
+		it('nodes set via setNodes are readable via allNodes', () => {
 			const nodeA = createNode({ name: 'A' });
-			workflowsStore.nodesByName = { A: nodeA };
+			const nodeB = createNode({ name: 'B' });
 
-			const { nodesByName } = useWorkflowDocumentNodes(deps);
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([nodeA, nodeB]);
 
-			expect(nodesByName.value).toEqual({ A: nodeA });
+			expect(facade.allNodes.value).toHaveLength(2);
+			expect(facade.allNodes.value.map((n) => n.name)).toEqual(['A', 'B']);
 		});
 
-		it('canvasNames returns a Set of all node names', () => {
-			const nodes = [createNode({ name: 'A' }), createNode({ name: 'B' })];
-			workflowsStore.allNodes = nodes;
+		it('nodes set via setNodes are readable via getNodeById', () => {
+			const node = createNode({ name: 'A' });
 
-			const { canvasNames } = useWorkflowDocumentNodes(deps);
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([node]);
 
-			expect(canvasNames.value).toEqual(new Set(['A', 'B']));
+			expect(facade.getNodeById(node.id)).toBeDefined();
+			expect(facade.getNodeById(node.id)?.name).toBe('A');
+		});
+
+		it('nodes set via setNodes are readable via getNodeByName', () => {
+			const node = createNode({ name: 'MyNode' });
+
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([node]);
+
+			expect(facade.getNodeByName('MyNode')).toBeDefined();
+			expect(facade.getNodeByName('MyNode')?.id).toBe(node.id);
+		});
+
+		it('nodes set via setNodes are readable via getNodes', () => {
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([createNode({ name: 'A' }), createNode({ name: 'B' })]);
+
+			const nodes = facade.getNodes();
+			expect(nodes).toHaveLength(2);
+		});
+
+		it('nodes set via setNodes are readable via nodesByName', () => {
+			const node = createNode({ name: 'Alpha' });
+
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([node]);
+
+			expect(facade.nodesByName.value).toHaveProperty('Alpha');
+			expect(facade.nodesByName.value.Alpha.id).toBe(node.id);
+		});
+
+		it('canvasNames reflects set nodes', () => {
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([createNode({ name: 'X' }), createNode({ name: 'Y' })]);
+
+			expect(facade.canvasNames.value).toEqual(new Set(['X', 'Y']));
+		});
+
+		it('getNodesByIds returns matching nodes', () => {
+			const nodeA = createNode({ name: 'A' });
+			const nodeB = createNode({ name: 'B' });
+
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([nodeA, nodeB]);
+
+			const result = facade.getNodesByIds([nodeA.id]);
+			expect(result).toHaveLength(1);
+			expect(result[0].name).toBe('A');
+		});
+
+		it('findNodeByPartialId matches partial id', () => {
+			const node = createNode({ name: 'FindMe' });
+
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([node]);
+
+			// Use first 8 chars of UUID as partial
+			const partial = node.id.slice(0, 8);
+			const found = facade.findNodeByPartialId(partial);
+			expect(found?.name).toBe('FindMe');
 		});
 	});
 
-	describe('write API delegation', () => {
-		it('setNodes delegates to workflowsStore.setNodes', () => {
-			const nodes = [createNode()];
+	describe('round-trip: addNode → read', () => {
+		it('node added via addNode is readable via allNodes', () => {
+			const node = createNode({ name: 'Added' });
 
-			const { setNodes } = useWorkflowDocumentNodes(deps);
-			setNodes(nodes);
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.addNode(node);
 
-			expect(workflowsStore.setNodes).toHaveBeenCalledWith(nodes);
+			expect(facade.allNodes.value).toHaveLength(1);
+			expect(facade.allNodes.value[0].name).toBe('Added');
 		});
 
-		it('addNode delegates to workflowsStore.addNode', () => {
-			const node = createNode();
+		it('node added via addNode is readable via getNodeById', () => {
+			const node = createNode({ name: 'Added' });
 
-			const { addNode } = useWorkflowDocumentNodes(deps);
-			addNode(node);
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.addNode(node);
 
-			expect(workflowsStore.addNode).toHaveBeenCalledWith(node);
-		});
-
-		it('removeNode delegates to workflowsStore.removeNode', () => {
-			const node = createNode();
-
-			const { removeNode } = useWorkflowDocumentNodes(deps);
-			removeNode(node);
-
-			expect(workflowsStore.removeNode).toHaveBeenCalledWith(node);
-		});
-
-		it('removeNodeById delegates to workflowsStore.removeNodeById', () => {
-			const { removeNodeById } = useWorkflowDocumentNodes(deps);
-			removeNodeById('node-1');
-
-			expect(workflowsStore.removeNodeById).toHaveBeenCalledWith('node-1');
+			expect(facade.getNodeById(node.id)?.name).toBe('Added');
 		});
 	});
 
-	describe('node mutation', () => {
-		it('setNodeParameters updates node parameters', () => {
-			const node = createNode({ parameters: { old: 'value' } });
-			workflowsStore.workflow.nodes = [node];
-			workflowsStore.nodeMetadata = {
-				'Test Node': { pristine: true, parametersLastUpdatedAt: 0 },
-			};
+	describe('round-trip: removeNode → read', () => {
+		it('removeNode removes node from allNodes', () => {
+			const nodeA = createNode({ name: 'A' });
+			const nodeB = createNode({ name: 'B' });
 
-			const { setNodeParameters } = useWorkflowDocumentNodes(deps);
-			setNodeParameters({ name: 'Test Node', value: { new: 'value' } });
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([nodeA, nodeB]);
+			facade.removeNode(nodeA);
 
-			expect(node.parameters).toEqual({ new: 'value' });
+			expect(facade.allNodes.value).toHaveLength(1);
+			expect(facade.allNodes.value[0].name).toBe('B');
+		});
+
+		it('removeNodeById removes node from allNodes', () => {
+			const node = createNode({ name: 'ToRemove' });
+
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([node]);
+			facade.removeNodeById(node.id);
+
+			expect(facade.allNodes.value).toHaveLength(0);
+		});
+
+		it('removeAllNodes empties all nodes', () => {
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([createNode({ name: 'A' }), createNode({ name: 'B' })]);
+
+			facade.removeAllNodes({ setStateDirty: false, removePinData: false });
+
+			expect(facade.allNodes.value).toHaveLength(0);
+		});
+	});
+
+	describe('round-trip: mutations → read', () => {
+		it('setNodeParameters updates parameters readable via getNodeByName', () => {
+			const node = createNode({ name: 'Target', parameters: { old: 'value' } });
+
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([node]);
+			facade.setNodeParameters({ name: 'Target', value: { new: 'value' } });
+
+			expect(facade.getNodeByName('Target')?.parameters).toEqual({ new: 'value' });
 		});
 
 		it('setNodeParameters with append merges parameters', () => {
-			const node = createNode({ parameters: { existing: 'keep' } });
-			workflowsStore.workflow.nodes = [node];
-			workflowsStore.nodeMetadata = {
-				'Test Node': { pristine: true, parametersLastUpdatedAt: 0 },
-			};
+			const node = createNode({ name: 'Target', parameters: { existing: 'keep' } });
 
-			const { setNodeParameters } = useWorkflowDocumentNodes(deps);
-			setNodeParameters({ name: 'Test Node', value: { added: 'new' } }, true);
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([node]);
+			facade.setNodeParameters({ name: 'Target', value: { added: 'new' } }, true);
 
-			expect(node.parameters).toEqual({ existing: 'keep', added: 'new' });
+			expect(facade.getNodeByName('Target')?.parameters).toEqual({
+				existing: 'keep',
+				added: 'new',
+			});
 		});
 
 		it('setNodeParameters throws when node not found', () => {
-			workflowsStore.workflow.nodes = [];
+			const facade = useWorkflowDocumentNodes(deps);
 
-			const { setNodeParameters } = useWorkflowDocumentNodes(deps);
-
-			expect(() => setNodeParameters({ name: 'NonExistent', value: {} })).toThrow(
+			expect(() => facade.setNodeParameters({ name: 'NonExistent', value: {} })).toThrow(
 				'could not be found',
 			);
 		});
 
-		it('setNodeValue updates a node property', () => {
-			const node = createNode();
-			workflowsStore.workflow.nodes = [node];
-			workflowsStore.nodeMetadata = {
-				'Test Node': { pristine: true, parametersLastUpdatedAt: 0 },
-			};
+		it('setNodeValue updates a property readable via getNodeByName', () => {
+			const node = createNode({ name: 'Target' });
 
-			const { setNodeValue } = useWorkflowDocumentNodes(deps);
-			setNodeValue({ name: 'Test Node', key: 'disabled', value: true });
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([node]);
+			facade.setNodeValue({ name: 'Target', key: 'disabled', value: true });
 
-			expect(node.disabled).toBe(true);
+			expect(facade.getNodeByName('Target')?.disabled).toBe(true);
 		});
 
-		it('setNodeValue does not update parametersLastUpdatedAt for position changes', () => {
-			const node = createNode();
-			workflowsStore.workflow.nodes = [node];
-			workflowsStore.nodeMetadata = {
-				'Test Node': { pristine: true, parametersLastUpdatedAt: 42 },
-			};
+		it('setNodePositionById updates position readable via getNodeById', () => {
+			const node = createNode({ name: 'Mover' });
 
-			const { setNodeValue } = useWorkflowDocumentNodes(deps);
-			setNodeValue({ name: 'Test Node', key: 'position', value: [300, 400] });
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([node]);
+			facade.setNodePositionById(node.id, [300, 400]);
 
-			expect(workflowsStore.nodeMetadata['Test Node'].parametersLastUpdatedAt).toBe(42);
+			expect(facade.getNodeById(node.id)?.position).toEqual([300, 400]);
 		});
 
-		it('setNodePositionById finds node by id and sets position', () => {
-			const node = createNode({ id: 'abc-123' });
-			workflowsStore.workflow.nodes = [node];
-			workflowsStore.nodeMetadata = {
-				'Test Node': { pristine: true, parametersLastUpdatedAt: 0 },
-			};
+		it('updateNodeById updates node readable via getNodeById', () => {
+			const node = createNode({ name: 'Target' });
 
-			const { setNodePositionById } = useWorkflowDocumentNodes(deps);
-			setNodePositionById('abc-123', [300, 400]);
-
-			expect(node.position).toEqual([300, 400]);
-		});
-
-		it('updateNodeById updates a node by its id', () => {
-			const node = createNode({ id: 'abc-123' });
-			workflowsStore.workflow.nodes = [node];
-
-			const { updateNodeById } = useWorkflowDocumentNodes(deps);
-			const result = updateNodeById('abc-123', { disabled: true });
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([node]);
+			const result = facade.updateNodeById(node.id, { disabled: true });
 
 			expect(result).toBe(true);
-			expect(node.disabled).toBe(true);
+			expect(facade.getNodeById(node.id)?.disabled).toBe(true);
 		});
 
 		it('updateNodeById returns false when node not found', () => {
-			workflowsStore.workflow.nodes = [];
+			const facade = useWorkflowDocumentNodes(deps);
 
-			const { updateNodeById } = useWorkflowDocumentNodes(deps);
-			const result = updateNodeById('nonexistent', { disabled: true });
-
-			expect(result).toBe(false);
+			expect(facade.updateNodeById('nonexistent', { disabled: true })).toBe(false);
 		});
 
-		it('updateNodeProperties updates multiple properties', () => {
-			const node = createNode();
-			workflowsStore.workflow.nodes = [node];
+		it('updateNodeProperties updates properties readable via getNodeByName', () => {
+			const node = createNode({ name: 'Target' });
 
-			const { updateNodeProperties } = useWorkflowDocumentNodes(deps);
-			updateNodeProperties({
-				name: 'Test Node',
-				properties: { disabled: true },
-			});
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([node]);
+			facade.updateNodeProperties({ name: 'Target', properties: { disabled: true } });
 
-			expect(node.disabled).toBe(true);
+			expect(facade.getNodeByName('Target')?.disabled).toBe(true);
 		});
 
-		it('setNodeIssue adds an issue to a node', () => {
-			const node = createNode();
-			workflowsStore.workflow.nodes = [node];
+		it('setNodeIssue adds issue readable via getNodeByName', () => {
+			const node = createNode({ name: 'Target' });
 
-			const { setNodeIssue } = useWorkflowDocumentNodes(deps);
-			setNodeIssue({
-				node: 'Test Node',
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([node]);
+			facade.setNodeIssue({
+				node: 'Target',
 				type: 'parameters',
 				value: { param: ['Missing required parameter'] },
 			});
 
-			expect(node.issues).toEqual({
+			expect(facade.getNodeByName('Target')?.issues).toEqual({
 				parameters: { param: ['Missing required parameter'] },
 			});
 		});
 
-		it('setNodeIssue removes an issue from a node', () => {
-			const node = createNode();
+		it('setNodeIssue removes issue readable via getNodeByName', () => {
+			const node = createNode({ name: 'Target' });
 			node.issues = {
 				parameters: { param: ['Missing'] },
 				credentials: { cred: ['Invalid'] },
 			};
-			workflowsStore.workflow.nodes = [node];
 
-			const { setNodeIssue } = useWorkflowDocumentNodes(deps);
-			setNodeIssue({
-				node: 'Test Node',
-				type: 'parameters',
-				value: null,
-			});
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([node]);
+			facade.setNodeIssue({ node: 'Target', type: 'parameters', value: null });
 
-			expect(node.issues).toEqual({ credentials: { cred: ['Invalid'] } });
-			expect(node.issues).not.toHaveProperty('parameters');
-		});
-
-		it('removeAllNodes clears all nodes and metadata', () => {
-			workflowsStore.workflow.nodes = [createNode(), createNode({ id: 'node-2', name: 'B' })];
-			workflowsStore.nodeMetadata = { 'Test Node': { pristine: true }, B: { pristine: true } };
-
-			const { removeAllNodes } = useWorkflowDocumentNodes(deps);
-			removeAllNodes({ setStateDirty: true, removePinData: false });
-
-			expect(workflowsStore.workflow.nodes).toHaveLength(0);
-			expect(workflowsStore.nodeMetadata).toEqual({});
-			expect(workflowsStore.workflowObject.setNodes).toHaveBeenCalledWith([]);
+			const issues = facade.getNodeByName('Target')?.issues;
+			expect(issues).toEqual({ credentials: { cred: ['Invalid'] } });
+			expect(issues).not.toHaveProperty('parameters');
 		});
 
 		it('resetAllNodesIssues clears issues on all nodes', () => {
-			const nodeA = createNode({ issues: { parameters: { x: ['err'] } } });
-			const nodeB = createNode({
-				id: 'node-2',
-				name: 'B',
-				issues: { credentials: { y: ['err'] } },
-			});
-			workflowsStore.workflow.nodes = [nodeA, nodeB];
+			const nodeA = createNode({ name: 'A', issues: { parameters: { x: ['err'] } } });
+			const nodeB = createNode({ name: 'B', issues: { credentials: { y: ['err'] } } });
 
-			const { resetAllNodesIssues } = useWorkflowDocumentNodes(deps);
-			const result = resetAllNodesIssues();
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([nodeA, nodeB]);
+			const result = facade.resetAllNodesIssues();
 
 			expect(result).toBe(true);
-			expect(nodeA.issues).toBeUndefined();
-			expect(nodeB.issues).toBeUndefined();
+			expect(facade.getNodeByName('A')?.issues).toBeUndefined();
+			expect(facade.getNodeByName('B')?.issues).toBeUndefined();
+		});
+
+		it('setLastNodeParameters does nothing when node type is not found', () => {
+			const node = createNode({
+				name: 'Target',
+				type: 'n8n-nodes-base.set',
+				parameters: { old: 'value' },
+			});
+
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([node]);
+			facade.setLastNodeParameters({
+				key: 'n8n-nodes-base.set',
+				name: '',
+				value: { new: 'value' },
+			});
+
+			// getNodeType returns null (default mock), so parameters should not change
+			expect(facade.getNodeByName('Target')?.parameters).toEqual({ old: 'value' });
 		});
 
 		it('setLastNodeParameters finds latest node by type and sets parameters', () => {
 			const node = createNode({
+				name: 'Target',
 				type: 'n8n-nodes-base.set',
 				parameters: { existing: 'keep' },
 			});
-			workflowsStore.workflow.nodes = [node];
-			workflowsStore.nodeMetadata = {
-				'Test Node': { pristine: true, parametersLastUpdatedAt: 0 },
-			};
 
 			const mockNodeType = {
-				properties: [
-					{
-						displayName: 'Value',
-						name: 'value',
-						type: 'string' as const,
-						default: '',
-					},
-				],
+				properties: [{ displayName: 'Value', name: 'value', type: 'string' as const, default: '' }],
 			};
 
 			const customDeps = createDeps({
 				getNodeType: vi.fn().mockReturnValue(mockNodeType),
 			});
 
-			const { setLastNodeParameters } = useWorkflowDocumentNodes(customDeps);
-			setLastNodeParameters({
+			const facade = useWorkflowDocumentNodes(customDeps);
+			facade.setNodes([node]);
+			facade.setLastNodeParameters({
 				key: 'n8n-nodes-base.set',
 				name: '',
 				value: { value: 'hello' },
@@ -365,41 +350,47 @@ describe('useWorkflowDocumentNodes', () => {
 
 			expect(customDeps.getNodeType).toHaveBeenCalledWith('n8n-nodes-base.set');
 		});
+	});
 
-		it('setLastNodeParameters does nothing when node type is not found', () => {
-			const node = createNode({ type: 'n8n-nodes-base.set', parameters: { old: 'value' } });
-			workflowsStore.workflow.nodes = [node];
-			workflowsStore.nodeMetadata = {
-				'Test Node': { pristine: true, parametersLastUpdatedAt: 0 },
-			};
+	describe('dirty tracking', () => {
+		it('setNodeValue does not update parametersLastUpdatedAt for position changes', () => {
+			const node = createNode({ name: 'Target' });
 
-			const { setLastNodeParameters } = useWorkflowDocumentNodes(deps);
-			setLastNodeParameters({
-				key: 'n8n-nodes-base.set',
-				name: '',
-				value: { new: 'value' },
-			});
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([node]);
 
-			// getNodeType returns null (default mock), so parameters should not change
-			expect(node.parameters).toEqual({ old: 'value' });
+			const tsBefore = workflowsStore.nodeMetadata.Target.parametersLastUpdatedAt;
+			facade.setNodeValue({ name: 'Target', key: 'position', value: [300, 400] });
+
+			expect(workflowsStore.nodeMetadata.Target.parametersLastUpdatedAt).toBe(tsBefore);
+		});
+
+		it('setNodeValue updates parametersLastUpdatedAt for non-position changes', () => {
+			const node = createNode({ name: 'Target' });
+
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([node]);
+
+			facade.setNodeValue({ name: 'Target', key: 'disabled', value: true });
+
+			expect(workflowsStore.nodeMetadata.Target.parametersLastUpdatedAt).toBeGreaterThan(0);
 		});
 
 		it('resetParametersLastUpdatedAt updates timestamp', () => {
-			workflowsStore.nodeMetadata = {
-				'Test Node': { pristine: true, parametersLastUpdatedAt: 0 },
-			};
+			const node = createNode({ name: 'Target' });
 
-			const { resetParametersLastUpdatedAt } = useWorkflowDocumentNodes(deps);
-			resetParametersLastUpdatedAt('Test Node');
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([node]);
 
-			expect(workflowsStore.nodeMetadata['Test Node'].parametersLastUpdatedAt).toBeGreaterThan(0);
+			facade.resetParametersLastUpdatedAt('Target');
+
+			expect(workflowsStore.nodeMetadata.Target.parametersLastUpdatedAt).toBeGreaterThan(0);
 		});
 
 		it('resetParametersLastUpdatedAt creates metadata entry if missing', () => {
-			workflowsStore.nodeMetadata = {};
+			const facade = useWorkflowDocumentNodes(deps);
 
-			const { resetParametersLastUpdatedAt } = useWorkflowDocumentNodes(deps);
-			resetParametersLastUpdatedAt('NewNode');
+			facade.resetParametersLastUpdatedAt('NewNode');
 
 			expect(workflowsStore.nodeMetadata.NewNode).toBeDefined();
 			expect(workflowsStore.nodeMetadata.NewNode.parametersLastUpdatedAt).toBeGreaterThan(0);
@@ -409,11 +400,10 @@ describe('useWorkflowDocumentNodes', () => {
 	describe('events', () => {
 		it('setNodes does not fire onNodesChange (initialization path)', () => {
 			const hookSpy = vi.fn();
-			const nodes = [createNode()];
 
-			const { setNodes, onNodesChange } = useWorkflowDocumentNodes(deps);
-			onNodesChange(hookSpy);
-			setNodes(nodes);
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.onNodesChange(hookSpy);
+			facade.setNodes([createNode()]);
 
 			expect(hookSpy).not.toHaveBeenCalled();
 		});
@@ -422,9 +412,9 @@ describe('useWorkflowDocumentNodes', () => {
 			const hookSpy = vi.fn();
 			const node = createNode();
 
-			const { addNode, onNodesChange } = useWorkflowDocumentNodes(deps);
-			onNodesChange(hookSpy);
-			addNode(node);
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.onNodesChange(hookSpy);
+			facade.addNode(node);
 
 			expect(hookSpy).toHaveBeenCalledWith({
 				action: 'add',
@@ -434,40 +424,40 @@ describe('useWorkflowDocumentNodes', () => {
 
 		it('removeNode fires onNodesChange with delete action', () => {
 			const hookSpy = vi.fn();
-			const node = createNode({ id: 'abc-123', name: 'Test Node' });
+			const node = createNode({ name: 'Target' });
 
-			const { removeNode, onNodesChange } = useWorkflowDocumentNodes(deps);
-			onNodesChange(hookSpy);
-			removeNode(node);
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([node]);
+			facade.onNodesChange(hookSpy);
+			facade.removeNode(node);
 
 			expect(hookSpy).toHaveBeenCalledWith({
 				action: 'delete',
-				payload: { name: 'Test Node', id: 'abc-123' },
+				payload: { name: 'Target', id: node.id },
 			});
 		});
 
 		it('removeNodeById fires onNodesChange with delete action', () => {
 			const hookSpy = vi.fn();
-			const node = createNode({ id: 'abc-123', name: 'Test Node' });
-			workflowsStore.getNodeById.mockReturnValue(node);
+			const node = createNode({ name: 'Target' });
 
-			const { removeNodeById, onNodesChange } = useWorkflowDocumentNodes(deps);
-			onNodesChange(hookSpy);
-			removeNodeById('abc-123');
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([node]);
+			facade.onNodesChange(hookSpy);
+			facade.removeNodeById(node.id);
 
 			expect(hookSpy).toHaveBeenCalledWith({
 				action: 'delete',
-				payload: { name: 'Test Node', id: 'abc-123' },
+				payload: { name: 'Target', id: node.id },
 			});
 		});
 
 		it('addNode fires onStateDirty', () => {
 			const dirtySpy = vi.fn();
-			const node = createNode();
 
-			const { addNode, onStateDirty } = useWorkflowDocumentNodes(deps);
-			onStateDirty(dirtySpy);
-			addNode(node);
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.onStateDirty(dirtySpy);
+			facade.addNode(createNode());
 
 			expect(dirtySpy).toHaveBeenCalledOnce();
 		});
@@ -476,20 +466,22 @@ describe('useWorkflowDocumentNodes', () => {
 			const dirtySpy = vi.fn();
 			const node = createNode();
 
-			const { removeNode, onStateDirty } = useWorkflowDocumentNodes(deps);
-			onStateDirty(dirtySpy);
-			removeNode(node);
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([node]);
+			facade.onStateDirty(dirtySpy);
+			facade.removeNode(node);
 
 			expect(dirtySpy).toHaveBeenCalledOnce();
 		});
 
 		it('removeNodeById fires onStateDirty', () => {
 			const dirtySpy = vi.fn();
-			workflowsStore.getNodeById.mockReturnValue(createNode({ id: 'abc-123' }));
+			const node = createNode();
 
-			const { removeNodeById, onStateDirty } = useWorkflowDocumentNodes(deps);
-			onStateDirty(dirtySpy);
-			removeNodeById('abc-123');
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([node]);
+			facade.onStateDirty(dirtySpy);
+			facade.removeNodeById(node.id);
 
 			expect(dirtySpy).toHaveBeenCalledOnce();
 		});
@@ -497,74 +489,65 @@ describe('useWorkflowDocumentNodes', () => {
 		it('setNodes does not fire onStateDirty (initialization path)', () => {
 			const dirtySpy = vi.fn();
 
-			const { setNodes, onStateDirty } = useWorkflowDocumentNodes(deps);
-			onStateDirty(dirtySpy);
-			setNodes([createNode()]);
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.onStateDirty(dirtySpy);
+			facade.setNodes([createNode()]);
 
 			expect(dirtySpy).not.toHaveBeenCalled();
 		});
 
 		it('setNodeParameters fires onStateDirty when parameters change', () => {
 			const dirtySpy = vi.fn();
-			const node = createNode({ parameters: { old: 'value' } });
-			workflowsStore.workflow.nodes = [node];
-			workflowsStore.nodeMetadata = {
-				'Test Node': { pristine: true, parametersLastUpdatedAt: 0 },
-			};
+			const node = createNode({ name: 'Target', parameters: { old: 'value' } });
 
-			const { setNodeParameters, onStateDirty } = useWorkflowDocumentNodes(deps);
-			onStateDirty(dirtySpy);
-			setNodeParameters({ name: 'Test Node', value: { new: 'value' } });
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([node]);
+			facade.onStateDirty(dirtySpy);
+			facade.setNodeParameters({ name: 'Target', value: { new: 'value' } });
 
 			expect(dirtySpy).toHaveBeenCalledOnce();
 		});
 
 		it('setNodeValue fires onStateDirty when value changes', () => {
 			const dirtySpy = vi.fn();
-			const node = createNode();
-			workflowsStore.workflow.nodes = [node];
-			workflowsStore.nodeMetadata = {
-				'Test Node': { pristine: true, parametersLastUpdatedAt: 0 },
-			};
+			const node = createNode({ name: 'Target' });
 
-			const { setNodeValue, onStateDirty } = useWorkflowDocumentNodes(deps);
-			onStateDirty(dirtySpy);
-			setNodeValue({ name: 'Test Node', key: 'disabled', value: true });
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([node]);
+			facade.onStateDirty(dirtySpy);
+			facade.setNodeValue({ name: 'Target', key: 'disabled', value: true });
 
 			expect(dirtySpy).toHaveBeenCalledOnce();
 		});
 
 		it('removeAllNodes fires onStateDirty when setStateDirty is true', () => {
 			const dirtySpy = vi.fn();
-			workflowsStore.workflow.nodes = [createNode()];
-			workflowsStore.nodeMetadata = { 'Test Node': { pristine: true } };
 
-			const { removeAllNodes, onStateDirty } = useWorkflowDocumentNodes(deps);
-			onStateDirty(dirtySpy);
-			removeAllNodes({ setStateDirty: true, removePinData: false });
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([createNode()]);
+			facade.onStateDirty(dirtySpy);
+			facade.removeAllNodes({ setStateDirty: true, removePinData: false });
 
 			expect(dirtySpy).toHaveBeenCalledOnce();
 		});
 
 		it('removeAllNodes does not fire onStateDirty when setStateDirty is false', () => {
 			const dirtySpy = vi.fn();
-			workflowsStore.workflow.nodes = [createNode()];
-			workflowsStore.nodeMetadata = { 'Test Node': { pristine: true } };
 
-			const { removeAllNodes, onStateDirty } = useWorkflowDocumentNodes(deps);
-			onStateDirty(dirtySpy);
-			removeAllNodes({ setStateDirty: false, removePinData: false });
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.setNodes([createNode()]);
+			facade.onStateDirty(dirtySpy);
+			facade.removeAllNodes({ setStateDirty: false, removePinData: false });
 
 			expect(dirtySpy).not.toHaveBeenCalled();
 		});
 
 		it('removeNodeById uses empty name when node not found', () => {
 			const hookSpy = vi.fn();
-			workflowsStore.getNodeById.mockReturnValue(undefined);
 
-			const { removeNodeById, onNodesChange } = useWorkflowDocumentNodes(deps);
-			onNodesChange(hookSpy);
-			removeNodeById('nonexistent');
+			const facade = useWorkflowDocumentNodes(deps);
+			facade.onNodesChange(hookSpy);
+			facade.removeNodeById('nonexistent');
 
 			expect(hookSpy).toHaveBeenCalledWith({
 				action: 'delete',

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setActivePinia } from 'pinia';
+import { createTestingPinia } from '@pinia/testing';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { mockedStore } from '@/__tests__/utils';
+import { createTestNode } from '@/__tests__/mocks';
+import type { INodeUi } from '@/Interface';
+import { useWorkflowDocumentNodes } from './useWorkflowDocumentNodes';
+
+function createNode(overrides: Partial<INodeUi> = {}): INodeUi {
+	return createTestNode({ name: 'Test Node', ...overrides }) as INodeUi;
+}
+
+describe('useWorkflowDocumentNodes', () => {
+	let workflowsStore: ReturnType<typeof mockedStore<typeof useWorkflowsStore>>;
+
+	beforeEach(() => {
+		setActivePinia(createTestingPinia());
+		workflowsStore = mockedStore(useWorkflowsStore);
+	});
+
+	describe('read API delegation', () => {
+		it('getNodeById delegates to workflowsStore.getNodeById', () => {
+			const node = createNode();
+			workflowsStore.getNodeById.mockReturnValue(node);
+
+			const { getNodeById } = useWorkflowDocumentNodes();
+			const result = getNodeById('node-1');
+
+			expect(result).toBe(node);
+			expect(workflowsStore.getNodeById).toHaveBeenCalledWith('node-1');
+		});
+
+		it('getNodeByName delegates to workflowsStore.getNodeByName', () => {
+			const node = createNode();
+			workflowsStore.getNodeByName.mockReturnValue(node);
+
+			const { getNodeByName } = useWorkflowDocumentNodes();
+			const result = getNodeByName('Test Node');
+
+			expect(result).toBe(node);
+			expect(workflowsStore.getNodeByName).toHaveBeenCalledWith('Test Node');
+		});
+
+		it('getNodes delegates to workflowsStore.getNodes', () => {
+			const nodes = [createNode()];
+			workflowsStore.getNodes.mockReturnValue(nodes);
+
+			const { getNodes } = useWorkflowDocumentNodes();
+			const result = getNodes();
+
+			expect(result).toBe(nodes);
+			expect(workflowsStore.getNodes).toHaveBeenCalled();
+		});
+
+		it('getNodesByIds delegates to workflowsStore.getNodesByIds', () => {
+			const nodes = [createNode()];
+			workflowsStore.getNodesByIds.mockReturnValue(nodes);
+
+			const { getNodesByIds } = useWorkflowDocumentNodes();
+			const result = getNodesByIds(['node-1']);
+
+			expect(result).toBe(nodes);
+			expect(workflowsStore.getNodesByIds).toHaveBeenCalledWith(['node-1']);
+		});
+	});
+
+	describe('computed properties', () => {
+		it('allNodes reflects workflowsStore.allNodes', () => {
+			const nodes = [createNode({ name: 'A' }), createNode({ name: 'B' })];
+			workflowsStore.allNodes = nodes;
+
+			const { allNodes } = useWorkflowDocumentNodes();
+
+			expect(allNodes.value).toEqual(nodes);
+		});
+
+		it('nodesByName reflects workflowsStore.nodesByName', () => {
+			const nodeA = createNode({ name: 'A' });
+			workflowsStore.nodesByName = { A: nodeA };
+
+			const { nodesByName } = useWorkflowDocumentNodes();
+
+			expect(nodesByName.value).toEqual({ A: nodeA });
+		});
+	});
+
+	describe('write API delegation', () => {
+		it('setNodes delegates to workflowsStore.setNodes', () => {
+			const nodes = [createNode()];
+
+			const { setNodes } = useWorkflowDocumentNodes();
+			setNodes(nodes);
+
+			expect(workflowsStore.setNodes).toHaveBeenCalledWith(nodes);
+		});
+
+		it('addNode delegates to workflowsStore.addNode', () => {
+			const node = createNode();
+
+			const { addNode } = useWorkflowDocumentNodes();
+			addNode(node);
+
+			expect(workflowsStore.addNode).toHaveBeenCalledWith(node);
+		});
+
+		it('removeNode delegates to workflowsStore.removeNode', () => {
+			const node = createNode();
+
+			const { removeNode } = useWorkflowDocumentNodes();
+			removeNode(node);
+
+			expect(workflowsStore.removeNode).toHaveBeenCalledWith(node);
+		});
+
+		it('removeNodeById delegates to workflowsStore.removeNodeById', () => {
+			const { removeNodeById } = useWorkflowDocumentNodes();
+			removeNodeById('node-1');
+
+			expect(workflowsStore.removeNodeById).toHaveBeenCalledWith('node-1');
+		});
+	});
+
+	describe('events', () => {
+		it('setNodes does not fire onNodesChange (initialization path)', () => {
+			const hookSpy = vi.fn();
+			const nodes = [createNode()];
+
+			const { setNodes, onNodesChange } = useWorkflowDocumentNodes();
+			onNodesChange(hookSpy);
+			setNodes(nodes);
+
+			expect(hookSpy).not.toHaveBeenCalled();
+		});
+
+		it('addNode fires onNodesChange with add action', () => {
+			const hookSpy = vi.fn();
+			const node = createNode();
+
+			const { addNode, onNodesChange } = useWorkflowDocumentNodes();
+			onNodesChange(hookSpy);
+			addNode(node);
+
+			expect(hookSpy).toHaveBeenCalledWith({
+				action: 'add',
+				payload: { node },
+			});
+		});
+
+		it('removeNode fires onNodesChange with delete action', () => {
+			const hookSpy = vi.fn();
+			const node = createNode({ id: 'abc-123', name: 'Test Node' });
+
+			const { removeNode, onNodesChange } = useWorkflowDocumentNodes();
+			onNodesChange(hookSpy);
+			removeNode(node);
+
+			expect(hookSpy).toHaveBeenCalledWith({
+				action: 'delete',
+				payload: { name: 'Test Node', id: 'abc-123' },
+			});
+		});
+
+		it('removeNodeById fires onNodesChange with delete action', () => {
+			const hookSpy = vi.fn();
+			const node = createNode({ id: 'abc-123', name: 'Test Node' });
+			workflowsStore.getNodeById.mockReturnValue(node);
+
+			const { removeNodeById, onNodesChange } = useWorkflowDocumentNodes();
+			onNodesChange(hookSpy);
+			removeNodeById('abc-123');
+
+			expect(hookSpy).toHaveBeenCalledWith({
+				action: 'delete',
+				payload: { name: 'Test Node', id: 'abc-123' },
+			});
+		});
+
+		it('addNode fires onStateDirty', () => {
+			const dirtySpy = vi.fn();
+			const node = createNode();
+
+			const { addNode, onStateDirty } = useWorkflowDocumentNodes();
+			onStateDirty(dirtySpy);
+			addNode(node);
+
+			expect(dirtySpy).toHaveBeenCalledOnce();
+		});
+
+		it('removeNode fires onStateDirty', () => {
+			const dirtySpy = vi.fn();
+			const node = createNode();
+
+			const { removeNode, onStateDirty } = useWorkflowDocumentNodes();
+			onStateDirty(dirtySpy);
+			removeNode(node);
+
+			expect(dirtySpy).toHaveBeenCalledOnce();
+		});
+
+		it('removeNodeById fires onStateDirty', () => {
+			const dirtySpy = vi.fn();
+			workflowsStore.getNodeById.mockReturnValue(createNode({ id: 'abc-123' }));
+
+			const { removeNodeById, onStateDirty } = useWorkflowDocumentNodes();
+			onStateDirty(dirtySpy);
+			removeNodeById('abc-123');
+
+			expect(dirtySpy).toHaveBeenCalledOnce();
+		});
+
+		it('setNodes does not fire onStateDirty (initialization path)', () => {
+			const dirtySpy = vi.fn();
+
+			const { setNodes, onStateDirty } = useWorkflowDocumentNodes();
+			onStateDirty(dirtySpy);
+			setNodes([createNode()]);
+
+			expect(dirtySpy).not.toHaveBeenCalled();
+		});
+
+		it('removeNodeById uses empty name when node not found', () => {
+			const hookSpy = vi.fn();
+			workflowsStore.getNodeById.mockReturnValue(undefined);
+
+			const { removeNodeById, onNodesChange } = useWorkflowDocumentNodes();
+			onNodesChange(hookSpy);
+			removeNodeById('nonexistent');
+
+			expect(hookSpy).toHaveBeenCalledWith({
+				action: 'delete',
+				payload: { name: '', id: 'nonexistent' },
+			});
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.test.ts
@@ -5,18 +5,35 @@ import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { mockedStore } from '@/__tests__/utils';
 import { createTestNode } from '@/__tests__/mocks';
 import type { INodeUi } from '@/Interface';
-import { useWorkflowDocumentNodes } from './useWorkflowDocumentNodes';
+import {
+	useWorkflowDocumentNodes,
+	type WorkflowDocumentNodesDeps,
+} from './useWorkflowDocumentNodes';
 
 function createNode(overrides: Partial<INodeUi> = {}): INodeUi {
 	return createTestNode({ name: 'Test Node', ...overrides }) as INodeUi;
 }
 
+function createDeps(overrides: Partial<WorkflowDocumentNodesDeps> = {}): WorkflowDocumentNodesDeps {
+	return {
+		getNodeType: vi.fn().mockReturnValue(null),
+		...overrides,
+	};
+}
+
 describe('useWorkflowDocumentNodes', () => {
 	let workflowsStore: ReturnType<typeof mockedStore<typeof useWorkflowsStore>>;
+	let deps: WorkflowDocumentNodesDeps;
 
 	beforeEach(() => {
 		setActivePinia(createTestingPinia());
 		workflowsStore = mockedStore(useWorkflowsStore);
+		deps = createDeps();
+
+		// Provide workflowObject.setNodes for updateNodeAtIndex
+		workflowsStore.workflowObject = { setNodes: vi.fn() } as unknown as ReturnType<
+			typeof useWorkflowsStore
+		>['workflowObject'];
 	});
 
 	describe('read API delegation', () => {
@@ -24,7 +41,7 @@ describe('useWorkflowDocumentNodes', () => {
 			const node = createNode();
 			workflowsStore.getNodeById.mockReturnValue(node);
 
-			const { getNodeById } = useWorkflowDocumentNodes();
+			const { getNodeById } = useWorkflowDocumentNodes(deps);
 			const result = getNodeById('node-1');
 
 			expect(result).toBe(node);
@@ -35,7 +52,7 @@ describe('useWorkflowDocumentNodes', () => {
 			const node = createNode();
 			workflowsStore.getNodeByName.mockReturnValue(node);
 
-			const { getNodeByName } = useWorkflowDocumentNodes();
+			const { getNodeByName } = useWorkflowDocumentNodes(deps);
 			const result = getNodeByName('Test Node');
 
 			expect(result).toBe(node);
@@ -46,18 +63,29 @@ describe('useWorkflowDocumentNodes', () => {
 			const nodes = [createNode()];
 			workflowsStore.getNodes.mockReturnValue(nodes);
 
-			const { getNodes } = useWorkflowDocumentNodes();
+			const { getNodes } = useWorkflowDocumentNodes(deps);
 			const result = getNodes();
 
 			expect(result).toBe(nodes);
 			expect(workflowsStore.getNodes).toHaveBeenCalled();
 		});
 
+		it('findNodeByPartialId delegates to workflowsStore.findNodeByPartialId', () => {
+			const node = createNode();
+			workflowsStore.findNodeByPartialId.mockReturnValue(node);
+
+			const { findNodeByPartialId } = useWorkflowDocumentNodes(deps);
+			const result = findNodeByPartialId('node');
+
+			expect(result).toBe(node);
+			expect(workflowsStore.findNodeByPartialId).toHaveBeenCalledWith('node');
+		});
+
 		it('getNodesByIds delegates to workflowsStore.getNodesByIds', () => {
 			const nodes = [createNode()];
 			workflowsStore.getNodesByIds.mockReturnValue(nodes);
 
-			const { getNodesByIds } = useWorkflowDocumentNodes();
+			const { getNodesByIds } = useWorkflowDocumentNodes(deps);
 			const result = getNodesByIds(['node-1']);
 
 			expect(result).toBe(nodes);
@@ -70,7 +98,7 @@ describe('useWorkflowDocumentNodes', () => {
 			const nodes = [createNode({ name: 'A' }), createNode({ name: 'B' })];
 			workflowsStore.allNodes = nodes;
 
-			const { allNodes } = useWorkflowDocumentNodes();
+			const { allNodes } = useWorkflowDocumentNodes(deps);
 
 			expect(allNodes.value).toEqual(nodes);
 		});
@@ -79,9 +107,18 @@ describe('useWorkflowDocumentNodes', () => {
 			const nodeA = createNode({ name: 'A' });
 			workflowsStore.nodesByName = { A: nodeA };
 
-			const { nodesByName } = useWorkflowDocumentNodes();
+			const { nodesByName } = useWorkflowDocumentNodes(deps);
 
 			expect(nodesByName.value).toEqual({ A: nodeA });
+		});
+
+		it('canvasNames returns a Set of all node names', () => {
+			const nodes = [createNode({ name: 'A' }), createNode({ name: 'B' })];
+			workflowsStore.allNodes = nodes;
+
+			const { canvasNames } = useWorkflowDocumentNodes(deps);
+
+			expect(canvasNames.value).toEqual(new Set(['A', 'B']));
 		});
 	});
 
@@ -89,7 +126,7 @@ describe('useWorkflowDocumentNodes', () => {
 		it('setNodes delegates to workflowsStore.setNodes', () => {
 			const nodes = [createNode()];
 
-			const { setNodes } = useWorkflowDocumentNodes();
+			const { setNodes } = useWorkflowDocumentNodes(deps);
 			setNodes(nodes);
 
 			expect(workflowsStore.setNodes).toHaveBeenCalledWith(nodes);
@@ -98,7 +135,7 @@ describe('useWorkflowDocumentNodes', () => {
 		it('addNode delegates to workflowsStore.addNode', () => {
 			const node = createNode();
 
-			const { addNode } = useWorkflowDocumentNodes();
+			const { addNode } = useWorkflowDocumentNodes(deps);
 			addNode(node);
 
 			expect(workflowsStore.addNode).toHaveBeenCalledWith(node);
@@ -107,17 +144,265 @@ describe('useWorkflowDocumentNodes', () => {
 		it('removeNode delegates to workflowsStore.removeNode', () => {
 			const node = createNode();
 
-			const { removeNode } = useWorkflowDocumentNodes();
+			const { removeNode } = useWorkflowDocumentNodes(deps);
 			removeNode(node);
 
 			expect(workflowsStore.removeNode).toHaveBeenCalledWith(node);
 		});
 
 		it('removeNodeById delegates to workflowsStore.removeNodeById', () => {
-			const { removeNodeById } = useWorkflowDocumentNodes();
+			const { removeNodeById } = useWorkflowDocumentNodes(deps);
 			removeNodeById('node-1');
 
 			expect(workflowsStore.removeNodeById).toHaveBeenCalledWith('node-1');
+		});
+	});
+
+	describe('node mutation', () => {
+		it('setNodeParameters updates node parameters', () => {
+			const node = createNode({ parameters: { old: 'value' } });
+			workflowsStore.workflow.nodes = [node];
+			workflowsStore.nodeMetadata = {
+				'Test Node': { pristine: true, parametersLastUpdatedAt: 0 },
+			};
+
+			const { setNodeParameters } = useWorkflowDocumentNodes(deps);
+			setNodeParameters({ name: 'Test Node', value: { new: 'value' } });
+
+			expect(node.parameters).toEqual({ new: 'value' });
+		});
+
+		it('setNodeParameters with append merges parameters', () => {
+			const node = createNode({ parameters: { existing: 'keep' } });
+			workflowsStore.workflow.nodes = [node];
+			workflowsStore.nodeMetadata = {
+				'Test Node': { pristine: true, parametersLastUpdatedAt: 0 },
+			};
+
+			const { setNodeParameters } = useWorkflowDocumentNodes(deps);
+			setNodeParameters({ name: 'Test Node', value: { added: 'new' } }, true);
+
+			expect(node.parameters).toEqual({ existing: 'keep', added: 'new' });
+		});
+
+		it('setNodeParameters throws when node not found', () => {
+			workflowsStore.workflow.nodes = [];
+
+			const { setNodeParameters } = useWorkflowDocumentNodes(deps);
+
+			expect(() => setNodeParameters({ name: 'NonExistent', value: {} })).toThrow(
+				'could not be found',
+			);
+		});
+
+		it('setNodeValue updates a node property', () => {
+			const node = createNode();
+			workflowsStore.workflow.nodes = [node];
+			workflowsStore.nodeMetadata = {
+				'Test Node': { pristine: true, parametersLastUpdatedAt: 0 },
+			};
+
+			const { setNodeValue } = useWorkflowDocumentNodes(deps);
+			setNodeValue({ name: 'Test Node', key: 'disabled', value: true });
+
+			expect(node.disabled).toBe(true);
+		});
+
+		it('setNodeValue does not update parametersLastUpdatedAt for position changes', () => {
+			const node = createNode();
+			workflowsStore.workflow.nodes = [node];
+			workflowsStore.nodeMetadata = {
+				'Test Node': { pristine: true, parametersLastUpdatedAt: 42 },
+			};
+
+			const { setNodeValue } = useWorkflowDocumentNodes(deps);
+			setNodeValue({ name: 'Test Node', key: 'position', value: [300, 400] });
+
+			expect(workflowsStore.nodeMetadata['Test Node'].parametersLastUpdatedAt).toBe(42);
+		});
+
+		it('setNodePositionById finds node by id and sets position', () => {
+			const node = createNode({ id: 'abc-123' });
+			workflowsStore.workflow.nodes = [node];
+			workflowsStore.nodeMetadata = {
+				'Test Node': { pristine: true, parametersLastUpdatedAt: 0 },
+			};
+
+			const { setNodePositionById } = useWorkflowDocumentNodes(deps);
+			setNodePositionById('abc-123', [300, 400]);
+
+			expect(node.position).toEqual([300, 400]);
+		});
+
+		it('updateNodeById updates a node by its id', () => {
+			const node = createNode({ id: 'abc-123' });
+			workflowsStore.workflow.nodes = [node];
+
+			const { updateNodeById } = useWorkflowDocumentNodes(deps);
+			const result = updateNodeById('abc-123', { disabled: true });
+
+			expect(result).toBe(true);
+			expect(node.disabled).toBe(true);
+		});
+
+		it('updateNodeById returns false when node not found', () => {
+			workflowsStore.workflow.nodes = [];
+
+			const { updateNodeById } = useWorkflowDocumentNodes(deps);
+			const result = updateNodeById('nonexistent', { disabled: true });
+
+			expect(result).toBe(false);
+		});
+
+		it('updateNodeProperties updates multiple properties', () => {
+			const node = createNode();
+			workflowsStore.workflow.nodes = [node];
+
+			const { updateNodeProperties } = useWorkflowDocumentNodes(deps);
+			updateNodeProperties({
+				name: 'Test Node',
+				properties: { disabled: true },
+			});
+
+			expect(node.disabled).toBe(true);
+		});
+
+		it('setNodeIssue adds an issue to a node', () => {
+			const node = createNode();
+			workflowsStore.workflow.nodes = [node];
+
+			const { setNodeIssue } = useWorkflowDocumentNodes(deps);
+			setNodeIssue({
+				node: 'Test Node',
+				type: 'parameters',
+				value: { param: ['Missing required parameter'] },
+			});
+
+			expect(node.issues).toEqual({
+				parameters: { param: ['Missing required parameter'] },
+			});
+		});
+
+		it('setNodeIssue removes an issue from a node', () => {
+			const node = createNode();
+			node.issues = {
+				parameters: { param: ['Missing'] },
+				credentials: { cred: ['Invalid'] },
+			};
+			workflowsStore.workflow.nodes = [node];
+
+			const { setNodeIssue } = useWorkflowDocumentNodes(deps);
+			setNodeIssue({
+				node: 'Test Node',
+				type: 'parameters',
+				value: null,
+			});
+
+			expect(node.issues).toEqual({ credentials: { cred: ['Invalid'] } });
+			expect(node.issues).not.toHaveProperty('parameters');
+		});
+
+		it('removeAllNodes clears all nodes and metadata', () => {
+			workflowsStore.workflow.nodes = [createNode(), createNode({ id: 'node-2', name: 'B' })];
+			workflowsStore.nodeMetadata = { 'Test Node': { pristine: true }, B: { pristine: true } };
+
+			const { removeAllNodes } = useWorkflowDocumentNodes(deps);
+			removeAllNodes({ setStateDirty: true, removePinData: false });
+
+			expect(workflowsStore.workflow.nodes).toHaveLength(0);
+			expect(workflowsStore.nodeMetadata).toEqual({});
+			expect(workflowsStore.workflowObject.setNodes).toHaveBeenCalledWith([]);
+		});
+
+		it('resetAllNodesIssues clears issues on all nodes', () => {
+			const nodeA = createNode({ issues: { parameters: { x: ['err'] } } });
+			const nodeB = createNode({
+				id: 'node-2',
+				name: 'B',
+				issues: { credentials: { y: ['err'] } },
+			});
+			workflowsStore.workflow.nodes = [nodeA, nodeB];
+
+			const { resetAllNodesIssues } = useWorkflowDocumentNodes(deps);
+			const result = resetAllNodesIssues();
+
+			expect(result).toBe(true);
+			expect(nodeA.issues).toBeUndefined();
+			expect(nodeB.issues).toBeUndefined();
+		});
+
+		it('setLastNodeParameters finds latest node by type and sets parameters', () => {
+			const node = createNode({
+				type: 'n8n-nodes-base.set',
+				parameters: { existing: 'keep' },
+			});
+			workflowsStore.workflow.nodes = [node];
+			workflowsStore.nodeMetadata = {
+				'Test Node': { pristine: true, parametersLastUpdatedAt: 0 },
+			};
+
+			const mockNodeType = {
+				properties: [
+					{
+						displayName: 'Value',
+						name: 'value',
+						type: 'string' as const,
+						default: '',
+					},
+				],
+			};
+
+			const customDeps = createDeps({
+				getNodeType: vi.fn().mockReturnValue(mockNodeType),
+			});
+
+			const { setLastNodeParameters } = useWorkflowDocumentNodes(customDeps);
+			setLastNodeParameters({
+				key: 'n8n-nodes-base.set',
+				name: '',
+				value: { value: 'hello' },
+			});
+
+			expect(customDeps.getNodeType).toHaveBeenCalledWith('n8n-nodes-base.set');
+		});
+
+		it('setLastNodeParameters does nothing when node type is not found', () => {
+			const node = createNode({ type: 'n8n-nodes-base.set', parameters: { old: 'value' } });
+			workflowsStore.workflow.nodes = [node];
+			workflowsStore.nodeMetadata = {
+				'Test Node': { pristine: true, parametersLastUpdatedAt: 0 },
+			};
+
+			const { setLastNodeParameters } = useWorkflowDocumentNodes(deps);
+			setLastNodeParameters({
+				key: 'n8n-nodes-base.set',
+				name: '',
+				value: { new: 'value' },
+			});
+
+			// getNodeType returns null (default mock), so parameters should not change
+			expect(node.parameters).toEqual({ old: 'value' });
+		});
+
+		it('resetParametersLastUpdatedAt updates timestamp', () => {
+			workflowsStore.nodeMetadata = {
+				'Test Node': { pristine: true, parametersLastUpdatedAt: 0 },
+			};
+
+			const { resetParametersLastUpdatedAt } = useWorkflowDocumentNodes(deps);
+			resetParametersLastUpdatedAt('Test Node');
+
+			expect(workflowsStore.nodeMetadata['Test Node'].parametersLastUpdatedAt).toBeGreaterThan(0);
+		});
+
+		it('resetParametersLastUpdatedAt creates metadata entry if missing', () => {
+			workflowsStore.nodeMetadata = {};
+
+			const { resetParametersLastUpdatedAt } = useWorkflowDocumentNodes(deps);
+			resetParametersLastUpdatedAt('NewNode');
+
+			expect(workflowsStore.nodeMetadata.NewNode).toBeDefined();
+			expect(workflowsStore.nodeMetadata.NewNode.parametersLastUpdatedAt).toBeGreaterThan(0);
 		});
 	});
 
@@ -126,7 +411,7 @@ describe('useWorkflowDocumentNodes', () => {
 			const hookSpy = vi.fn();
 			const nodes = [createNode()];
 
-			const { setNodes, onNodesChange } = useWorkflowDocumentNodes();
+			const { setNodes, onNodesChange } = useWorkflowDocumentNodes(deps);
 			onNodesChange(hookSpy);
 			setNodes(nodes);
 
@@ -137,7 +422,7 @@ describe('useWorkflowDocumentNodes', () => {
 			const hookSpy = vi.fn();
 			const node = createNode();
 
-			const { addNode, onNodesChange } = useWorkflowDocumentNodes();
+			const { addNode, onNodesChange } = useWorkflowDocumentNodes(deps);
 			onNodesChange(hookSpy);
 			addNode(node);
 
@@ -151,7 +436,7 @@ describe('useWorkflowDocumentNodes', () => {
 			const hookSpy = vi.fn();
 			const node = createNode({ id: 'abc-123', name: 'Test Node' });
 
-			const { removeNode, onNodesChange } = useWorkflowDocumentNodes();
+			const { removeNode, onNodesChange } = useWorkflowDocumentNodes(deps);
 			onNodesChange(hookSpy);
 			removeNode(node);
 
@@ -166,7 +451,7 @@ describe('useWorkflowDocumentNodes', () => {
 			const node = createNode({ id: 'abc-123', name: 'Test Node' });
 			workflowsStore.getNodeById.mockReturnValue(node);
 
-			const { removeNodeById, onNodesChange } = useWorkflowDocumentNodes();
+			const { removeNodeById, onNodesChange } = useWorkflowDocumentNodes(deps);
 			onNodesChange(hookSpy);
 			removeNodeById('abc-123');
 
@@ -180,7 +465,7 @@ describe('useWorkflowDocumentNodes', () => {
 			const dirtySpy = vi.fn();
 			const node = createNode();
 
-			const { addNode, onStateDirty } = useWorkflowDocumentNodes();
+			const { addNode, onStateDirty } = useWorkflowDocumentNodes(deps);
 			onStateDirty(dirtySpy);
 			addNode(node);
 
@@ -191,7 +476,7 @@ describe('useWorkflowDocumentNodes', () => {
 			const dirtySpy = vi.fn();
 			const node = createNode();
 
-			const { removeNode, onStateDirty } = useWorkflowDocumentNodes();
+			const { removeNode, onStateDirty } = useWorkflowDocumentNodes(deps);
 			onStateDirty(dirtySpy);
 			removeNode(node);
 
@@ -202,7 +487,7 @@ describe('useWorkflowDocumentNodes', () => {
 			const dirtySpy = vi.fn();
 			workflowsStore.getNodeById.mockReturnValue(createNode({ id: 'abc-123' }));
 
-			const { removeNodeById, onStateDirty } = useWorkflowDocumentNodes();
+			const { removeNodeById, onStateDirty } = useWorkflowDocumentNodes(deps);
 			onStateDirty(dirtySpy);
 			removeNodeById('abc-123');
 
@@ -212,9 +497,63 @@ describe('useWorkflowDocumentNodes', () => {
 		it('setNodes does not fire onStateDirty (initialization path)', () => {
 			const dirtySpy = vi.fn();
 
-			const { setNodes, onStateDirty } = useWorkflowDocumentNodes();
+			const { setNodes, onStateDirty } = useWorkflowDocumentNodes(deps);
 			onStateDirty(dirtySpy);
 			setNodes([createNode()]);
+
+			expect(dirtySpy).not.toHaveBeenCalled();
+		});
+
+		it('setNodeParameters fires onStateDirty when parameters change', () => {
+			const dirtySpy = vi.fn();
+			const node = createNode({ parameters: { old: 'value' } });
+			workflowsStore.workflow.nodes = [node];
+			workflowsStore.nodeMetadata = {
+				'Test Node': { pristine: true, parametersLastUpdatedAt: 0 },
+			};
+
+			const { setNodeParameters, onStateDirty } = useWorkflowDocumentNodes(deps);
+			onStateDirty(dirtySpy);
+			setNodeParameters({ name: 'Test Node', value: { new: 'value' } });
+
+			expect(dirtySpy).toHaveBeenCalledOnce();
+		});
+
+		it('setNodeValue fires onStateDirty when value changes', () => {
+			const dirtySpy = vi.fn();
+			const node = createNode();
+			workflowsStore.workflow.nodes = [node];
+			workflowsStore.nodeMetadata = {
+				'Test Node': { pristine: true, parametersLastUpdatedAt: 0 },
+			};
+
+			const { setNodeValue, onStateDirty } = useWorkflowDocumentNodes(deps);
+			onStateDirty(dirtySpy);
+			setNodeValue({ name: 'Test Node', key: 'disabled', value: true });
+
+			expect(dirtySpy).toHaveBeenCalledOnce();
+		});
+
+		it('removeAllNodes fires onStateDirty when setStateDirty is true', () => {
+			const dirtySpy = vi.fn();
+			workflowsStore.workflow.nodes = [createNode()];
+			workflowsStore.nodeMetadata = { 'Test Node': { pristine: true } };
+
+			const { removeAllNodes, onStateDirty } = useWorkflowDocumentNodes(deps);
+			onStateDirty(dirtySpy);
+			removeAllNodes({ setStateDirty: true, removePinData: false });
+
+			expect(dirtySpy).toHaveBeenCalledOnce();
+		});
+
+		it('removeAllNodes does not fire onStateDirty when setStateDirty is false', () => {
+			const dirtySpy = vi.fn();
+			workflowsStore.workflow.nodes = [createNode()];
+			workflowsStore.nodeMetadata = { 'Test Node': { pristine: true } };
+
+			const { removeAllNodes, onStateDirty } = useWorkflowDocumentNodes(deps);
+			onStateDirty(dirtySpy);
+			removeAllNodes({ setStateDirty: false, removePinData: false });
 
 			expect(dirtySpy).not.toHaveBeenCalled();
 		});
@@ -223,7 +562,7 @@ describe('useWorkflowDocumentNodes', () => {
 			const hookSpy = vi.fn();
 			workflowsStore.getNodeById.mockReturnValue(undefined);
 
-			const { removeNodeById, onNodesChange } = useWorkflowDocumentNodes();
+			const { removeNodeById, onNodesChange } = useWorkflowDocumentNodes(deps);
 			onNodesChange(hookSpy);
 			removeNodeById('nonexistent');
 

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.test.ts
@@ -176,9 +176,20 @@ describe('useWorkflowDocumentNodes', () => {
 			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
 			workflowDocumentNodes.setNodes([createNode({ name: 'A' }), createNode({ name: 'B' })]);
 
-			workflowDocumentNodes.removeAllNodes({ setStateDirty: false, removePinData: false });
+			workflowDocumentNodes.removeAllNodes();
 
 			expect(workflowDocumentNodes.allNodes.value).toHaveLength(0);
+		});
+
+		it('removeAllNodes clears nodeMetadata', () => {
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([createNode({ name: 'A' })]);
+
+			expect(workflowsStore.nodeMetadata).toHaveProperty('A');
+
+			workflowDocumentNodes.removeAllNodes();
+
+			expect(workflowsStore.nodeMetadata).toEqual({});
 		});
 	});
 
@@ -222,6 +233,14 @@ describe('useWorkflowDocumentNodes', () => {
 			workflowDocumentNodes.setNodeValue({ name: 'Target', key: 'disabled', value: true });
 
 			expect(workflowDocumentNodes.getNodeByName('Target')?.disabled).toBe(true);
+		});
+
+		it('setNodeValue throws when node not found', () => {
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+
+			expect(() =>
+				workflowDocumentNodes.setNodeValue({ name: 'NonExistent', key: 'disabled', value: true }),
+			).toThrow('could not be found');
 		});
 
 		it('setNodePositionById updates position readable via getNodeById', () => {
@@ -523,24 +542,13 @@ describe('useWorkflowDocumentNodes', () => {
 			expect(dirtySpy).toHaveBeenCalledOnce();
 		});
 
-		it('removeAllNodes fires onStateDirty when setStateDirty is true', () => {
+		it('removeAllNodes does not fire onStateDirty (initialization path)', () => {
 			const dirtySpy = vi.fn();
 
 			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
 			workflowDocumentNodes.setNodes([createNode()]);
 			workflowDocumentNodes.onStateDirty(dirtySpy);
-			workflowDocumentNodes.removeAllNodes({ setStateDirty: true, removePinData: false });
-
-			expect(dirtySpy).toHaveBeenCalledOnce();
-		});
-
-		it('removeAllNodes does not fire onStateDirty when setStateDirty is false', () => {
-			const dirtySpy = vi.fn();
-
-			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
-			workflowDocumentNodes.setNodes([createNode()]);
-			workflowDocumentNodes.onStateDirty(dirtySpy);
-			workflowDocumentNodes.removeAllNodes({ setStateDirty: false, removePinData: false });
+			workflowDocumentNodes.removeAllNodes();
 
 			expect(dirtySpy).not.toHaveBeenCalled();
 		});

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.ts
@@ -1,0 +1,125 @@
+import { computed } from 'vue';
+import { createEventHook } from '@vueuse/core';
+import type { INodeUi } from '@/Interface';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { CHANGE_ACTION } from './types';
+import type { ChangeEvent } from './types';
+
+// --- Event types ---
+
+export type NodeAddedPayload = { node: INodeUi };
+export type NodeRemovedPayload = { name: string; id: string };
+
+export type NodesChangeEvent = ChangeEvent<NodeAddedPayload> | ChangeEvent<NodeRemovedPayload>;
+
+// --- Composable ---
+
+// TODO: Inject workflowsStore as a dep once the facade owns its own refs (Phase C).
+// Direct import is an intentional deviation during the delegation/migration phase.
+export function useWorkflowDocumentNodes() {
+	const workflowsStore = useWorkflowsStore();
+
+	const onNodesChange = createEventHook<NodesChangeEvent>();
+	// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+	const onStateDirty = createEventHook<void>();
+
+	// -----------------------------------------------------------------------
+	// Apply methods — CRDT entry point in Phase C. Today they just delegate.
+	// -----------------------------------------------------------------------
+
+	function applySetNodes(nodes: INodeUi[]) {
+		workflowsStore.setNodes(nodes);
+	}
+
+	function applyAddNode(node: INodeUi) {
+		workflowsStore.addNode(node);
+		void onNodesChange.trigger({
+			action: CHANGE_ACTION.ADD,
+			payload: { node },
+		});
+		void onStateDirty.trigger();
+	}
+
+	function applyRemoveNode(node: INodeUi) {
+		workflowsStore.removeNode(node);
+		void onNodesChange.trigger({
+			action: CHANGE_ACTION.DELETE,
+			payload: { name: node.name, id: node.id },
+		});
+		void onStateDirty.trigger();
+	}
+
+	function applyRemoveNodeById(id: string) {
+		const node = workflowsStore.getNodeById(id);
+		workflowsStore.removeNodeById(id);
+		void onNodesChange.trigger({
+			action: CHANGE_ACTION.DELETE,
+			payload: { name: node?.name ?? '', id },
+		});
+		void onStateDirty.trigger();
+	}
+
+	// -----------------------------------------------------------------------
+	// Read API
+	// -----------------------------------------------------------------------
+
+	const allNodes = computed<INodeUi[]>(() => workflowsStore.allNodes);
+
+	const nodesByName = computed<Record<string, INodeUi>>(() => workflowsStore.nodesByName);
+
+	function getNodeById(id: string): INodeUi | undefined {
+		return workflowsStore.getNodeById(id);
+	}
+
+	function getNodeByName(name: string): INodeUi | null {
+		return workflowsStore.getNodeByName(name);
+	}
+
+	function getNodes(): INodeUi[] {
+		return workflowsStore.getNodes();
+	}
+
+	function getNodesByIds(ids: string[]): INodeUi[] {
+		return workflowsStore.getNodesByIds(ids);
+	}
+
+	// -----------------------------------------------------------------------
+	// Write API
+	// -----------------------------------------------------------------------
+
+	function setNodes(nodes: INodeUi[]): void {
+		applySetNodes(nodes);
+	}
+
+	function addNode(node: INodeUi): void {
+		applyAddNode(node);
+	}
+
+	function removeNode(node: INodeUi): void {
+		applyRemoveNode(node);
+	}
+
+	function removeNodeById(id: string): void {
+		applyRemoveNodeById(id);
+	}
+
+	return {
+		// Read
+		allNodes,
+		nodesByName,
+		getNodeById,
+		getNodeByName,
+		getNodes,
+		getNodesByIds,
+
+		// Write
+		setNodes,
+		addNode,
+		removeNode,
+		removeNodeById,
+
+		// Events
+		onNodesChange: onNodesChange.on,
+		onStateDirty: onStateDirty.on,
+	};
+}

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.ts
@@ -36,8 +36,11 @@ export interface WorkflowDocumentNodesDeps {
 
 // --- Composable ---
 
-// TODO: Inject workflowsStore as a dep once the facade owns its own refs (Phase C).
-// Direct import is an intentional deviation during the delegation/migration phase.
+// TODO: This composable currently delegates to workflowsStore for reads and writes.
+// The long-term goal is to remove workflowsStore entirely — workflow and
+// workflowObject will become private state owned by workflowDocumentStore.
+// Once that happens, the direct import (and the import-cycle warning it causes)
+// will go away.
 export function useWorkflowDocumentNodes(deps: WorkflowDocumentNodesDeps) {
 	const workflowsStore = useWorkflowsStore();
 
@@ -71,7 +74,7 @@ export function useWorkflowDocumentNodes(deps: WorkflowDocumentNodesDeps) {
 	}
 
 	// -----------------------------------------------------------------------
-	// Apply methods — CRDT entry point in Phase C. Today they just delegate.
+	// Apply methods — will become the CRDT entry point. Today they delegate.
 	// -----------------------------------------------------------------------
 
 	function applySetNodes(nodes: INodeUi[]) {
@@ -298,13 +301,7 @@ export function useWorkflowDocumentNodes(deps: WorkflowDocumentNodesDeps) {
 		}
 	}
 
-	function removeAllNodes(data: { setStateDirty: boolean; removePinData: boolean }): void {
-		if (data.setStateDirty) {
-			void onStateDirty.trigger();
-		}
-
-		// TODO: handle data.removePinData — needs store-level orchestration to call setPinData({})
-
+	function removeAllNodes(): void {
 		workflowsStore.workflow.nodes.splice(0, workflowsStore.workflow.nodes.length);
 		workflowsStore.workflowObject.setNodes(workflowsStore.workflow.nodes);
 		workflowsStore.nodeMetadata = {};

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.ts
@@ -57,20 +57,19 @@ export function useWorkflowDocumentNodes(deps: WorkflowDocumentNodesDeps) {
 	 * @returns `true` if the object was changed
 	 */
 	function updateNodeAtIndex(nodeIndex: number, nodeData: Partial<INodeUi>): boolean {
-		if (nodeIndex !== -1) {
-			const node = workflowsStore.workflow.nodes[nodeIndex];
-			const existingData = pick<Partial<INodeUi>>(node, Object.keys(nodeData));
-			const changed = !isEqual(existingData, nodeData);
+		if (nodeIndex === -1) return false;
 
-			if (changed) {
-				Object.assign(node, nodeData);
-				workflowsStore.workflow.nodes[nodeIndex] = node;
-				workflowsStore.workflowObject.setNodes(workflowsStore.workflow.nodes);
-			}
+		const node = workflowsStore.workflow.nodes[nodeIndex];
+		const existingData = pick<Partial<INodeUi>>(node, Object.keys(nodeData));
+		const changed = !isEqual(existingData, nodeData);
 
-			return changed;
+		if (changed) {
+			Object.assign(node, nodeData);
+			workflowsStore.workflow.nodes[nodeIndex] = node;
+			workflowsStore.workflowObject.setNodes(workflowsStore.workflow.nodes);
 		}
-		return false;
+
+		return changed;
 	}
 
 	// -----------------------------------------------------------------------

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.ts
@@ -1,7 +1,23 @@
 import { computed } from 'vue';
 import { createEventHook } from '@vueuse/core';
-import type { INodeUi } from '@/Interface';
+import type {
+	INodeIssueData,
+	INodeIssueObjectProperty,
+	INodeParameters,
+	INodeTypeDescription,
+} from 'n8n-workflow';
+import { NodeHelpers } from 'n8n-workflow';
+import type {
+	INodeUi,
+	INodeUpdatePropertiesInformation,
+	IUpdateInformation,
+	XYPosition,
+} from '@/Interface';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { isObject } from '@/app/utils/objectUtils';
+import pick from 'lodash/pick';
+import isEqual from 'lodash/isEqual';
+import findLast from 'lodash/findLast';
 import { CHANGE_ACTION } from './types';
 import type { ChangeEvent } from './types';
 
@@ -12,16 +28,47 @@ export type NodeRemovedPayload = { name: string; id: string };
 
 export type NodesChangeEvent = ChangeEvent<NodeAddedPayload> | ChangeEvent<NodeRemovedPayload>;
 
+// --- Deps ---
+
+export interface WorkflowDocumentNodesDeps {
+	getNodeType: (typeName: string, version?: number) => INodeTypeDescription | null;
+}
+
 // --- Composable ---
 
 // TODO: Inject workflowsStore as a dep once the facade owns its own refs (Phase C).
 // Direct import is an intentional deviation during the delegation/migration phase.
-export function useWorkflowDocumentNodes() {
+export function useWorkflowDocumentNodes(deps: WorkflowDocumentNodesDeps) {
 	const workflowsStore = useWorkflowsStore();
 
 	const onNodesChange = createEventHook<NodesChangeEvent>();
 	// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 	const onStateDirty = createEventHook<void>();
+
+	// -----------------------------------------------------------------------
+	// Internal helpers
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Low-level node update by array index.
+	 * @returns `true` if the object was changed
+	 */
+	function updateNodeAtIndex(nodeIndex: number, nodeData: Partial<INodeUi>): boolean {
+		if (nodeIndex !== -1) {
+			const node = workflowsStore.workflow.nodes[nodeIndex];
+			const existingData = pick<Partial<INodeUi>>(node, Object.keys(nodeData));
+			const changed = !isEqual(existingData, nodeData);
+
+			if (changed) {
+				Object.assign(node, nodeData);
+				workflowsStore.workflow.nodes[nodeIndex] = node;
+				workflowsStore.workflowObject.setNodes(workflowsStore.workflow.nodes);
+			}
+
+			return changed;
+		}
+		return false;
+	}
 
 	// -----------------------------------------------------------------------
 	// Apply methods — CRDT entry point in Phase C. Today they just delegate.
@@ -67,6 +114,10 @@ export function useWorkflowDocumentNodes() {
 
 	const nodesByName = computed<Record<string, INodeUi>>(() => workflowsStore.nodesByName);
 
+	const canvasNames = computed<Set<string>>(
+		() => new Set(workflowsStore.allNodes.map((n) => n.name)),
+	);
+
 	function getNodeById(id: string): INodeUi | undefined {
 		return workflowsStore.getNodeById(id);
 	}
@@ -77,6 +128,10 @@ export function useWorkflowDocumentNodes() {
 
 	function getNodes(): INodeUi[] {
 		return workflowsStore.getNodes();
+	}
+
+	function findNodeByPartialId(partialId: string): INodeUi | undefined {
+		return workflowsStore.findNodeByPartialId(partialId);
 	}
 
 	function getNodesByIds(ids: string[]): INodeUi[] {
@@ -103,13 +158,181 @@ export function useWorkflowDocumentNodes() {
 		applyRemoveNodeById(id);
 	}
 
+	function setNodeParameters(updateInformation: IUpdateInformation, append?: boolean): void {
+		const nodeIndex = workflowsStore.workflow.nodes.findIndex(
+			(node) => node.name === updateInformation.name,
+		);
+
+		if (nodeIndex === -1) {
+			throw new Error(
+				`Node with the name "${updateInformation.name}" could not be found to set parameter.`,
+			);
+		}
+
+		const { name, parameters } = workflowsStore.workflow.nodes[nodeIndex];
+
+		const newParameters =
+			!!append && isObject(updateInformation.value)
+				? { ...parameters, ...updateInformation.value }
+				: updateInformation.value;
+
+		const changed = updateNodeAtIndex(nodeIndex, {
+			parameters: newParameters as INodeParameters,
+		});
+
+		if (changed) {
+			void onStateDirty.trigger();
+			workflowsStore.nodeMetadata[name].parametersLastUpdatedAt = Date.now();
+		}
+	}
+
+	function setLastNodeParameters(updateInformation: IUpdateInformation): void {
+		const latestNode = findLast(
+			workflowsStore.workflow.nodes,
+			(node) => node.type === updateInformation.key,
+		) as INodeUi;
+		const nodeType = deps.getNodeType(latestNode.type);
+		if (!nodeType) return;
+
+		const nodeParams = NodeHelpers.getNodeParameters(
+			nodeType.properties,
+			updateInformation.value as INodeParameters,
+			true,
+			false,
+			latestNode,
+			nodeType,
+		);
+
+		if (latestNode) {
+			setNodeParameters({ value: nodeParams, name: latestNode.name }, true);
+		}
+	}
+
+	function setNodeValue(updateInformation: IUpdateInformation): void {
+		const nodeIndex = workflowsStore.workflow.nodes.findIndex(
+			(node) => node.name === updateInformation.name,
+		);
+
+		if (nodeIndex === -1 || !updateInformation.key) {
+			throw new Error(
+				`Node with the name "${updateInformation.name}" could not be found to set parameter.`,
+			);
+		}
+
+		const changed = updateNodeAtIndex(nodeIndex, {
+			[updateInformation.key]: updateInformation.value,
+		});
+
+		if (changed) {
+			void onStateDirty.trigger();
+		}
+
+		const excludeKeys = ['position', 'notes', 'notesInFlow'];
+
+		if (changed && !excludeKeys.includes(updateInformation.key)) {
+			workflowsStore.nodeMetadata[
+				workflowsStore.workflow.nodes[nodeIndex].name
+			].parametersLastUpdatedAt = Date.now();
+		}
+	}
+
+	function setNodePositionById(id: string, position: XYPosition): void {
+		const node = workflowsStore.workflow.nodes.find((n) => n.id === id);
+		if (!node) return;
+
+		setNodeValue({ name: node.name, key: 'position', value: position });
+	}
+
+	function updateNodeById(nodeId: string, nodeData: Partial<INodeUi>): boolean {
+		const nodeIndex = workflowsStore.workflow.nodes.findIndex((node) => node.id === nodeId);
+		if (nodeIndex === -1) return false;
+		return updateNodeAtIndex(nodeIndex, nodeData);
+	}
+
+	function updateNodeProperties(updateInformation: INodeUpdatePropertiesInformation): void {
+		const nodeIndex = workflowsStore.workflow.nodes.findIndex(
+			(node) => node.name === updateInformation.name,
+		);
+
+		if (nodeIndex !== -1) {
+			for (const key of Object.keys(updateInformation.properties)) {
+				const typedKey = key as keyof INodeUpdatePropertiesInformation['properties'];
+				const property = updateInformation.properties[typedKey];
+
+				const changed = updateNodeAtIndex(nodeIndex, { [key]: property });
+
+				if (changed) {
+					void onStateDirty.trigger();
+				}
+			}
+		}
+	}
+
+	function setNodeIssue(nodeIssueData: INodeIssueData): void {
+		const nodeIndex = workflowsStore.workflow.nodes.findIndex(
+			(node) => node.name === nodeIssueData.node,
+		);
+		if (nodeIndex === -1) {
+			return;
+		}
+
+		const node = workflowsStore.workflow.nodes[nodeIndex];
+
+		if (nodeIssueData.value === null) {
+			if (node.issues?.[nodeIssueData.type] === undefined) {
+				return;
+			}
+
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			const { [nodeIssueData.type]: _removedNodeIssue, ...remainingNodeIssues } = node.issues;
+			updateNodeAtIndex(nodeIndex, {
+				issues: remainingNodeIssues,
+			});
+		} else {
+			updateNodeAtIndex(nodeIndex, {
+				issues: {
+					...node.issues,
+					[nodeIssueData.type]: nodeIssueData.value as INodeIssueObjectProperty,
+				},
+			});
+		}
+	}
+
+	function removeAllNodes(data: { setStateDirty: boolean; removePinData: boolean }): void {
+		if (data.setStateDirty) {
+			void onStateDirty.trigger();
+		}
+
+		// TODO: handle data.removePinData — needs store-level orchestration to call setPinData({})
+
+		workflowsStore.workflow.nodes.splice(0, workflowsStore.workflow.nodes.length);
+		workflowsStore.workflowObject.setNodes(workflowsStore.workflow.nodes);
+		workflowsStore.nodeMetadata = {};
+	}
+
+	function resetAllNodesIssues(): boolean {
+		workflowsStore.workflow.nodes.forEach((node) => {
+			node.issues = undefined;
+		});
+		return true;
+	}
+
+	function resetParametersLastUpdatedAt(nodeName: string): void {
+		if (!workflowsStore.nodeMetadata[nodeName]) {
+			workflowsStore.nodeMetadata[nodeName] = { pristine: true };
+		}
+		workflowsStore.nodeMetadata[nodeName].parametersLastUpdatedAt = Date.now();
+	}
+
 	return {
 		// Read
 		allNodes,
 		nodesByName,
+		canvasNames,
 		getNodeById,
 		getNodeByName,
 		getNodes,
+		findNodeByPartialId,
 		getNodesByIds,
 
 		// Write
@@ -117,6 +340,16 @@ export function useWorkflowDocumentNodes() {
 		addNode,
 		removeNode,
 		removeNodeById,
+		setNodeParameters,
+		setNodeValue,
+		setNodePositionById,
+		updateNodeProperties,
+		updateNodeById,
+		setNodeIssue,
+		removeAllNodes,
+		resetAllNodesIssues,
+		setLastNodeParameters,
+		resetParametersLastUpdatedAt,
 
 		// Events
 		onNodesChange: onNodesChange.on,

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.ts
@@ -193,7 +193,9 @@ export function useWorkflowDocumentNodes(deps: WorkflowDocumentNodesDeps) {
 		const latestNode = findLast(
 			workflowsStore.workflow.nodes,
 			(node) => node.type === updateInformation.key,
-		) as INodeUi;
+		);
+		if (!latestNode) return;
+
 		const nodeType = deps.getNodeType(latestNode.type);
 		if (!nodeType) return;
 
@@ -206,9 +208,7 @@ export function useWorkflowDocumentNodes(deps: WorkflowDocumentNodesDeps) {
 			nodeType,
 		);
 
-		if (latestNode) {
-			setNodeParameters({ value: nodeParams, name: latestNode.name }, true);
-		}
+		setNodeParameters({ value: nodeParams, name: latestNode.name }, true);
 	}
 
 	function setNodeValue(updateInformation: IUpdateInformation): void {

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -197,6 +197,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 
 	const allConnections = computed(() => workflow.value.connections);
 
+	/** @deprecated Use `workflowDocumentStore.allNodes` instead. */
 	const allNodes = computed<INodeUi[]>(() => workflow.value.nodes);
 
 	const willNodeWait = (node: INodeUi): boolean => {
@@ -242,9 +243,10 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		return false;
 	});
 
-	// Names of all nodes currently on canvas.
+	/** @deprecated Use `workflowDocumentStore.canvasNames` instead. */
 	const canvasNames = computed(() => new Set(allNodes.value.map((n) => n.name)));
 
+	/** @deprecated Use `workflowDocumentStore.nodesByName` instead. */
 	const nodesByName = computed(() => {
 		return workflow.value.nodes.reduce<Record<string, INodeUi>>((acc, node) => {
 			acc[node.name] = node;
@@ -430,10 +432,12 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		);
 	}
 
+	/** @deprecated Use `workflowDocumentStore.getNodeByName()` instead. */
 	function getNodeByName(nodeName: string): INodeUi | null {
 		return workflowUtils.getNodeByName(nodesByName.value, nodeName);
 	}
 
+	/** @deprecated Use `workflowDocumentStore.getNodeById()` instead. */
 	function getNodeById(nodeId: string): INodeUi | undefined {
 		return workflow.value.nodes.find((node) => node.id === nodeId);
 	}
@@ -453,7 +457,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		return null;
 	}
 
-	// Finds the full id for a given partial id for a node, relying on order for uniqueness in edge cases
+	/** @deprecated Use `workflowDocumentStore.findNodeByPartialId()` instead. */
 	function findNodeByPartialId(partialId: string): INodeUi | undefined {
 		return workflow.value.nodes.find((node) => node.id.startsWith(partialId));
 	}
@@ -469,6 +473,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		return fullId;
 	}
 
+	/** @deprecated Use `workflowDocumentStore.getNodesByIds()` instead. */
 	function getNodesByIds(nodeIds: string[]): INodeUi[] {
 		return nodeIds.map(getNodeById).filter(isPresent);
 	}
@@ -523,10 +528,13 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		return nodeTypes;
 	}
 
-	// Returns a shallow copy of the nodes which means that all the data on the lower
-	// levels still only gets referenced but the top level object is a different one.
-	// This has the advantage that it is very fast and does not cause problems with vuex
-	// when the workflow replaces the node-parameters.
+	/**
+	 * Returns a shallow copy of the nodes which means that all the data on the lower
+	 * levels still only gets referenced but the top level object is a different one.
+	 * This has the advantage that it is very fast and does not cause problems with vuex
+	 * when the workflow replaces the node-parameters.
+	 * @deprecated Use `workflowDocumentStore.getNodes()` instead.
+	 */
 	function getNodes(): INodeUi[] {
 		return workflow.value.nodes.map((node) => ({ ...node }));
 	}
@@ -1048,6 +1056,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			});
 	}
 
+	/** @deprecated Use `workflowDocumentStore.setNodes()` instead. */
 	function setNodes(nodes: INodeUi[]): void {
 		nodes.forEach((node) => {
 			if (!node.id) {
@@ -1076,6 +1085,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		workflowObject.value.setConnections(value);
 	}
 
+	/** @deprecated Use `workflowDocumentStore.addNode()` instead. */
 	function addNode(nodeData: INodeUi): void {
 		// @TODO(ckolb): Reminder to refactor useActions:setAddedNodeActionParameters
 		// which listens to this function being called, when this is moved to workflowState soon
@@ -1095,6 +1105,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		}
 	}
 
+	/** @deprecated Use `workflowDocumentStore.removeNode()` instead. */
 	function removeNode(node: INodeUi): void {
 		const { [node.name]: removedNodeMetadata, ...remainingNodeMetadata } = nodeMetadata.value;
 		nodeMetadata.value = remainingNodeMetadata;
@@ -1584,6 +1595,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 	// Start Canvas V2 Functions
 	//
 
+	/** @deprecated Use `workflowDocumentStore.removeNodeById()` instead. */
 	function removeNodeById(nodeId: string): void {
 		const node = getNodeById(nodeId);
 		if (!node) {

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsPanel.test.ts
@@ -67,14 +67,11 @@ vi.mock('@/stores/pushConnection.store', () => ({
 }));
 
 // Use a mutable reference so the mock always returns the current workflowState
-const workflowStateRef: { current: WorkflowState | undefined } = { current: undefined };
-
 vi.mock('@/app/composables/useNodeHelpers', async (importOriginal) => {
 	const actual = await importOriginal<typeof useNodeHelpersModule>();
 	return {
 		...actual,
-		useNodeHelpers: (opts = {}) =>
-			actual.useNodeHelpers({ ...opts, workflowState: workflowStateRef.current }),
+		useNodeHelpers: () => actual.useNodeHelpers(),
 	};
 });
 
@@ -123,7 +120,6 @@ describe('LogsPanel', () => {
 
 		workflowsStore = mockedStore(useWorkflowsStore);
 		workflowState = useWorkflowState();
-		workflowStateRef.current = workflowState;
 		workflowState.setWorkflowExecutionData(null);
 
 		logsStore = mockedStore(useLogsStore);

--- a/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.test.ts
@@ -90,10 +90,12 @@ const EMPTY_WORKFLOW = {
 };
 
 function setDocumentStoreMeta(meta: Record<string, unknown>) {
-	const docStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId));
+	const workflowDocumentStore = useWorkflowDocumentStore(
+		createWorkflowDocumentId(workflowsStore.workflowId),
+	);
 	// Note: createTestingPinia() stubs actions by default, so setMeta() won't work
-	Object.defineProperty(docStore, 'meta', { value: meta, configurable: true });
-	workflowDocumentStoreRef.value = docStore;
+	Object.defineProperty(workflowDocumentStore, 'meta', { value: meta, configurable: true });
+	workflowDocumentStoreRef.value = workflowDocumentStore;
 }
 
 describe('SetupWorkflowCredentialsButton', () => {


### PR DESCRIPTION
## Summary

Experiment to validate the workflowDocumentStore migration approach against CI/E2E.

Migrates 6 node composables from direct `workflowsStore`/`workflowState` node access to the `workflowDocumentStore` facade:

- `useNodeHelpers` — allNodes, getNodeByName, setNodeIssue, updateNodeProperties
- `useNodeExecution` — updateNodeProperties
- `useRunWorkflow` — getNodeByName
- `useToolParameters` — getNodeByName
- `useNodeDirtiness` — allNodes
- `executionFinished` handler — getNodeByName

Also:
- Removed dead `workflowState` parameter from `useNodeHelpers()` and updated all callers
- Consolidated inline `useWorkflowDocumentStore()` calls
- Updated `MIGRATION_RECIPE.md` with naming conventions, fallback values, standalone function pattern, and cascading caller update guidance
- Fixed `docStore` → `workflowDocumentStore` naming in test files

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)