### PR TITLE
ci: Ignore bundle commits on sync action

### DIFF
--- a/.github/workflows/sec-sync-public-to-private.yml
+++ b/.github/workflows/sec-sync-public-to-private.yml
@@ -43,8 +43,8 @@ jobs:
         run: |
           git fetch https://github.com/n8n-io/n8n.git master:public-master
 
-          # Check if private is ahead of public
-          AHEAD_COUNT=$(git rev-list public-master..HEAD --count)
+          # Check if private is ahead of public, ignore Bundle commits
+          AHEAD_COUNT=$(git rev-list public-master..HEAD --pretty=oneline --grep="chore: Bundle" --invert-grep --count)
 
           if [ "$AHEAD_COUNT" -gt 0 ]; then
             if [ "${{ github.event_name }}" = "schedule" ]; then


### PR DESCRIPTION
## Summary

Updated sync job to ignore commits matching `chore: Bundle` grep.

Previously this required a manual step from the action level to overwrite these commits.

## Related Linear tickets, Github issues, and Community forum posts

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
