### PR TITLE
fix(weaviate): fix Tenant Name option not appearing in UI due to undefined default

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/VectorStoreWeaviate.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/VectorStoreWeaviate.node.ts
@@ -105,7 +105,7 @@ const shared_options: Array<INodePropertyOptions | INodeProperties | INodeProper
 		displayName: 'Tenant Name',
 		name: 'tenant',
 		type: 'string',
-		default: undefined,
+		default: '',
 		validateType: 'string',
 		description: 'Tenant Name. Collection must have been created with tenant support enabled.',
 	},


### PR DESCRIPTION
The `Tenant Name` option in the Weaviate Vector Store node had `default: undefined` instead 
of `default: ''`. In n8n's node UI, options collection fields require a valid default value 
to render correctly — `undefined` caused the field to not appear/work in the dropdown UI.

<img width="454" height="605" alt="Screenshot 2026-03-06 at 4 42 26 PM" src="https://github.com/user-attachments/assets/a6e8bf29-cd74-4cd2-ade6-2504c49ea9d7" />

**Fix:** Changed `default: undefined` to `default: ''` for the `tenant` field in `shared_options`.

**To test:**
1. Add a Weaviate Vector Store node in n8n
2. Open the Options panel
3. Confirm "Tenant Name" field appears and is interactable

#26579