### PR TITLE
ci: Ensure PNPM cache directory to avoid cache failure

### DIFF
--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -35,6 +35,15 @@ runs:
         node-version: ${{ inputs.node-version }}
         cache: 'pnpm'
 
+    # To avoid setup-node cache failure.
+    # see: https://github.com/actions/setup-node/issues/1137
+    - name: Verify PNPM Cache Directory
+      run: |
+        PNPM_STORE_PATH="$( pnpm store path --silent )"
+        if [ ! -d "$PNPM_STORE_PATH" ]; then
+            mkdir -p "$PNPM_STORE_PATH"
+        fi
+
     - name: Install Aikido SafeChain
       if: runner.os != 'Windows'
       run: |

--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -38,6 +38,7 @@ runs:
     # To avoid setup-node cache failure.
     # see: https://github.com/actions/setup-node/issues/1137
     - name: Verify PNPM Cache Directory
+      shell: bash
       run: |
         PNPM_STORE_PATH="$( pnpm store path --silent )"
         if [ ! -d "$PNPM_STORE_PATH" ]; then


### PR DESCRIPTION
## Summary

The setup-node action has a known issue of crashing due to a missing cache path (https://github.com/actions/setup-node/issues/1137).

Common fix across community is to ensure the path exists.

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/actions/runs/22760982350/job/66019473765

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
