### PR TITLE
fix: Rebuild isolated-vm in Dockerfile

### DIFF
--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -15,7 +15,7 @@ COPY ./compiled /usr/local/lib/node_modules/n8n
 COPY docker/images/n8n/docker-entrypoint.sh /
 
 RUN cd /usr/local/lib/node_modules/n8n && \
-    npm rebuild sqlite3 && \
+    npm rebuild sqlite3 isolated-vm && \
     ln -s /usr/local/lib/node_modules/n8n/bin/n8n /usr/local/bin/n8n && \
     mkdir -p /home/node/.n8n && \
     chown -R node:node /home/node && \


### PR DESCRIPTION
## Summary

This PR fixes the runtime error below in running n8n Docker image built locally on Mac, caused by CPU architecture mismatch.

> Error loading shared library /usr/local/lib/node_modules/n8n/node_modules/.pnpm/isolated-vm@6.0.2/node_modules/isolated-vm/out/isolated_vm.node: Exec format error

## Related Linear tickets, Github issues, and Community forum posts

N/A


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
