### PR TITLE
fix(core): Return resolver_missing status when dynamic credentials lack resolver

### DIFF
--- a/packages/@n8n/api-types/src/schemas/workflow-execution-status.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/workflow-execution-status.schema.ts
@@ -8,7 +8,7 @@ export const WorkflowExecutionStatusSchema = z.object({
 				credentialId: z.string(),
 				credentialName: z.string(),
 				credentialType: z.string(),
-				credentialStatus: z.enum(['missing', 'configured']),
+				credentialStatus: z.enum(['missing', 'configured', 'resolver_missing']),
 				authorizationUrl: z.string().optional(),
 				revokeUrl: z.string().optional(),
 			}),

--- a/packages/cli/src/modules/dynamic-credentials.ee/__tests__/workflow-status.controller.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/__tests__/workflow-status.controller.test.ts
@@ -252,6 +252,32 @@ describe('WorkflowStatusController', () => {
 			});
 		});
 
+		it('should return readyToExecute false when credential has resolver_missing status', async () => {
+			const req = mock<Request>({
+				params: { workflowId: 'workflow-1' },
+				headers: { authorization: 'Bearer token-123' },
+			});
+			const res = mock<Response>();
+
+			mockService.getWorkflowStatus.mockResolvedValue([
+				{
+					credentialId: 'cred-1',
+					credentialName: 'My OAuth2 Credential',
+					status: 'resolver_missing',
+					credentialType: 'oauth2Api',
+				},
+			]);
+
+			const result = await controller.checkWorkflowForExecution(req, res);
+
+			expect(result.readyToExecute).toBe(false);
+			expect(result.workflowId).toBe('workflow-1');
+			expect(result.credentials).toHaveLength(1);
+			expect(result.credentials?.[0].credentialStatus).toBe('resolver_missing');
+			expect(result.credentials?.[0].authorizationUrl).toBeUndefined();
+			expect(result.credentials?.[0].revokeUrl).toBeUndefined();
+		});
+
 		it('should return readyToExecute true for empty credentials array', async () => {
 			const req = mock<Request>({
 				params: { workflowId: 'workflow-1' },

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-resolver-workflow.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-resolver-workflow.service.test.ts
@@ -336,7 +336,7 @@ describe('CredentialResolverWorkflowService', () => {
 			);
 		});
 
-		it('should skip credentials without resolver ID', async () => {
+		it('should return resolver_missing status for credentials without resolver ID', async () => {
 			const mockWorkflow = createMockWorkflow({
 				nodes: [
 					createMockNode({
@@ -351,6 +351,7 @@ describe('CredentialResolverWorkflowService', () => {
 			const mockCredential = createMockCredential({
 				id: 'cred-1',
 				type: 'oauth2Api',
+				name: 'OAuth2 API',
 				isResolvable: true,
 				resolverId: null,
 			});
@@ -364,7 +365,13 @@ describe('CredentialResolverWorkflowService', () => {
 				metadata: {},
 			});
 
-			expect(result).toEqual([]);
+			expect(result).toHaveLength(1);
+			expect(result[0]).toEqual({
+				credentialId: 'cred-1',
+				credentialName: 'OAuth2 API',
+				status: 'resolver_missing',
+				credentialType: 'oauth2Api',
+			});
 			expect(mockResolverImplementation.getSecret).not.toHaveBeenCalled();
 		});
 

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/credential-resolver-workflow.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/credential-resolver-workflow.service.ts
@@ -1,17 +1,18 @@
 import { CredentialsEntity, CredentialsRepository, In, WorkflowRepository } from '@n8n/db';
-import { DynamicCredentialResolverRegistry } from './credential-resolver-registry.service';
-import { DynamicCredentialResolverRepository } from '../database/repositories/credential-resolver.repository';
-import { Cipher } from 'n8n-core';
-import { ICredentialContext, jsonParse } from 'n8n-workflow';
 import { ICredentialResolver } from '@n8n/decorators';
 import { Service } from '@n8n/di';
+import { Cipher } from 'n8n-core';
+import { ICredentialContext, jsonParse } from 'n8n-workflow';
+
+import { DynamicCredentialResolverRegistry } from './credential-resolver-registry.service';
+import { DynamicCredentialResolverRepository } from '../database/repositories/credential-resolver.repository';
 
 type CredentialStatus = {
 	credentialId: string;
 	credentialName: string;
-	resolverId: string;
+	resolverId?: string;
 	credentialType: string;
-	status: 'missing' | 'configured';
+	status: 'missing' | 'configured' | 'resolver_missing';
 };
 
 function isCredentialStatus(obj: unknown): obj is CredentialStatus {
@@ -21,12 +22,10 @@ function isCredentialStatus(obj: unknown): obj is CredentialStatus {
 	return (
 		'credentialId' in obj &&
 		typeof obj.credentialId === 'string' &&
-		'resolverId' in obj &&
-		typeof obj.resolverId === 'string' &&
 		'credentialType' in obj &&
 		typeof obj.credentialType === 'string' &&
 		'status' in obj &&
-		(obj.status === 'missing' || obj.status === 'configured')
+		(obj.status === 'missing' || obj.status === 'configured' || obj.status === 'resolver_missing')
 	);
 }
 
@@ -146,7 +145,12 @@ export class CredentialResolverWorkflowService {
 		let resolverConfig: Record<string, unknown> | null = options.workflowResolverConfig;
 		const credentialResolverId = credential.resolverId ?? options.resolverId;
 		if (!credentialResolverId) {
-			return null;
+			return {
+				credentialId: credential.id,
+				credentialName: credential.name,
+				status: 'resolver_missing' as const,
+				credentialType: credential.type,
+			};
 		}
 		if (credentialResolverId !== options.resolverId) {
 			const {

--- a/packages/cli/src/modules/dynamic-credentials.ee/workflow-status.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/workflow-status.controller.ts
@@ -70,8 +70,12 @@ export class WorkflowStatusController {
 				credentialName: s.credentialName,
 				credentialStatus: s.status,
 				credentialType: s.credentialType,
-				authorizationUrl: `${basePath}/${restPath}/credentials/${s.credentialId}/authorize?resolverId=${encodeURIComponent(s.resolverId)}`,
-				revokeUrl: `${basePath}/${restPath}/credentials/${s.credentialId}/revoke?resolverId=${encodeURIComponent(s.resolverId)}`,
+				...(s.resolverId
+					? {
+							authorizationUrl: `${basePath}/${restPath}/credentials/${s.credentialId}/authorize?resolverId=${encodeURIComponent(s.resolverId)}`,
+							revokeUrl: `${basePath}/${restPath}/credentials/${s.credentialId}/revoke?resolverId=${encodeURIComponent(s.resolverId)}`,
+						}
+					: {}),
 			})),
 		};
 		return executionStatus;

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useDynamicCredentialsStatus.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/composables/useDynamicCredentialsStatus.ts
@@ -11,7 +11,7 @@ export interface DynamicCredentialItem {
 	credentialId: string;
 	credentialName: string;
 	credentialType: string;
-	credentialStatus: 'missing' | 'configured';
+	credentialStatus: 'missing' | 'configured' | 'resolver_missing';
 	resolverId: string;
 	isConnecting: boolean;
 	error: string | null;


### PR DESCRIPTION
## Summary

When a workflow uses resolvable credentials but has no credential resolver configured, the execution-status endpoint now returns `readyToExecute: false` with credential status `resolver_missing`. This prevents workflows from failing at execution time and helps users debug configuration issues earlier.

Changes include:
- Added `resolver_missing` credential status to the schema
- Updated `CredentialResolverWorkflowService` to detect missing resolvers
- Omit `authorizationUrl` and `revokeUrl` when no resolver is available
- Added comprehensive test coverage for the new behavior

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-169/execution-status-endpoint-should-return-non-ready-if-flow-contains

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)