### PR TITLE
fix(core): Don't fail 2.x migration for workflows without history record

### DIFF
--- a/packages/@n8n/db/src/migrations/common/1763048000000-ActivateExecuteWorkflowTriggerWorkflows.ts
+++ b/packages/@n8n/db/src/migrations/common/1763048000000-ActivateExecuteWorkflowTriggerWorkflows.ts
@@ -189,6 +189,21 @@ export class ActivateExecuteWorkflowTriggerWorkflows1763048000000 implements Irr
 						},
 					);
 				} else {
+					// Ensure a workflow_history record exists for this versionId.
+					// Imported workflows may have a versionId that was never recorded in this instance's history.
+					await runQuery(
+						`INSERT INTO ${historyTableName} (${versionIdColumn}, ${workflowIdColumn}, ${authorsColumn}, ${nodesColumn}, ${connectionsColumn}, ${createdAtColumn}, ${updatedAtColumn}) SELECT :versionId, :workflowId, :authors, :nodes, :connections, :createdAt, :updatedAt WHERE NOT EXISTS (SELECT 1 FROM ${historyTableName} WHERE ${versionIdColumn} = :versionId)`,
+						{
+							versionId: workflow.versionId,
+							workflowId: workflow.id,
+							authors: 'system migration',
+							nodes: JSON.stringify(nodes),
+							connections: workflow.connections,
+							createdAt: new Date(),
+							updatedAt: new Date(),
+						},
+					);
+
 					// No nodes modified, just activate with existing versionId
 					await runQuery(
 						`UPDATE ${tableName} SET ${activeColumn} = :active, ${activeVersionIdColumn} = :versionId WHERE ${idColumn} = :id`,

--- a/packages/cli/test/migration/1763048000000-activate-execute-workflow-trigger-workflows.test.ts
+++ b/packages/cli/test/migration/1763048000000-activate-execute-workflow-trigger-workflows.test.ts
@@ -148,6 +148,7 @@ describe('ActivateExecuteWorkflowTriggerWorkflows Migration', () => {
 			disabledExecuteWorkflowTrigger: randomUUID(),
 			disabledErrorTrigger: randomUUID(),
 			invalidJson: randomUUID(),
+			errorTriggerMissingHistory: randomUUID(),
 		};
 
 		beforeAll(async () => {
@@ -431,6 +432,44 @@ describe('ActivateExecuteWorkflowTriggerWorkflows Migration', () => {
 				updatedAt: new Date(),
 			});
 
+			// Insert a workflow whose versionId has no matching workflow_history record,
+			// simulating the case where saveVersion() failed silently during a workflow save.
+			// Only the workflow_entity row is inserted — no history record.
+			{
+				const tableName = context.escape.tableName('workflow_entity');
+				const idColumn = context.escape.columnName('id');
+				const nameColumn = context.escape.columnName('name');
+				const nodesColumn = context.escape.columnName('nodes');
+				const connectionsColumn = context.escape.columnName('connections');
+				const activeColumn = context.escape.columnName('active');
+				const versionIdColumn = context.escape.columnName('versionId');
+				const createdAtColumn = context.escape.columnName('createdAt');
+				const updatedAtColumn = context.escape.columnName('updatedAt');
+
+				await context.runQuery(
+					`INSERT INTO ${tableName} (${idColumn}, ${nameColumn}, ${nodesColumn}, ${connectionsColumn}, ${activeColumn}, ${versionIdColumn}, ${createdAtColumn}, ${updatedAtColumn}) VALUES (:id, :name, :nodes, :connections, :active, :versionId, :createdAt, :updatedAt)`,
+					{
+						id: workflowIds.errorTriggerMissingHistory,
+						name: 'Test Error Trigger Missing History',
+						nodes: JSON.stringify([
+							{
+								id: randomUUID(),
+								name: 'Error Trigger',
+								type: 'n8n-nodes-base.errorTrigger',
+								parameters: {},
+								typeVersion: 1,
+								position: [0, 0],
+							},
+						]),
+						connections: '{}',
+						active: false,
+						versionId: randomUUID(),
+						createdAt: new Date(),
+						updatedAt: new Date(),
+					},
+				);
+			}
+
 			// Insert workflow with invalid JSON containing unescaped control characters
 			// Note: PostgreSQL enforces strict JSON validation and won't allow invalid JSON,
 			// so we skip this test data for PostgreSQL
@@ -591,6 +630,16 @@ describe('ActivateExecuteWorkflowTriggerWorkflows Migration', () => {
 
 			expect(workflow?.active).toBeFalsy();
 			expect(workflow?.activeVersionId).toBeNull();
+
+			await context.queryRunner.release();
+		});
+
+		it('should activate Error Trigger workflow even when its versionId is missing from workflow_history', async () => {
+			const context = createTestMigrationContext(dataSource);
+			const workflow = await getWorkflowById(context, workflowIds.errorTriggerMissingHistory);
+
+			expect(workflow?.active).toBeTruthy();
+			expect(workflow?.activeVersionId).toBeTruthy();
 
 			await context.queryRunner.release();
 		});


### PR DESCRIPTION
## Summary

Disclaimer: this fix is fully AI generated.

### Root Cause
workflow_entity.versionId and workflow_history can become out of sync due to silent error handling in the saveVersion() method (packages/cli/src/workflows/workflow-history/workflow-history.service.ts):

```ts
try {
    await repository.insert({...});
} catch (e) {
    const error = ensureError(e);
    this.logger.error(`Failed to save workflow history version...`, { error });
    // No rethrow — silently continues
}
```
When a workflow is saved with node/connection changes, n8n:

Generates a new versionId
Calls saveVersion() — which inserts into workflow_history
Updates workflow_entity.versionId
If step 2 fails (e.g. due to a transient DB error, a constraint violation, disk pressure, etc.), the error is swallowed. Step 3 still executes. The result: workflow_entity.versionId points to a UUID that has no matching record in workflow_history.

This is a known recurring issue — the codebase already contains two separate backfill migrations (1762763704614-BackfillMissingWorkflowHistoryRecords and 1765448186933-BackfillMissingWorkflowHistoryRecords) specifically to repair this out-of-sync state.

When ActivateExecuteWorkflowTriggerWorkflows1763048000000 later runs and tries to set activeVersionId = workflow.versionId, it hits the FK constraint because that versionId was never persisted to workflow_history.

### Fix Description
The else branch (no nodes modified) in ActivateExecuteWorkflowTriggerWorkflows blindly sets activeVersionId = workflow.versionId without verifying the versionId exists in workflow_history. Before performing that update, a workflow_history record must be conditionally inserted for the workflow's current versionId — only if one does not already exist. This is the same defensive pattern used in the two existing backfill migrations. The fix uses INSERT ... SELECT ... WHERE NOT EXISTS which is compatible with both PostgreSQL and SQLite.

The if (nodesModified) branch is not affected — it always generates a fresh versionId and creates the history record itself before touching workflow_entity.


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-9775/


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
