### PR TITLE
fix(editor): Fix parameter label hover glitch with Fixed/Expression toggle

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nInputLabel/InputLabel.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInputLabel/InputLabel.vue
@@ -175,7 +175,7 @@ const addTargetBlank = (html: string) =>
 		transition: opacity 100ms ease-in; // transition on hover in
 	}
 }
-.withOptions:hover {
+.withOptions {
 	.title > span {
 		text-overflow: ellipsis;
 		overflow: hidden;


### PR DESCRIPTION
## Summary

Long parameter labels in the NVD would briefly overlap with the Fixed/Expression toggle on hover. This happened because `text-overflow: ellipsis` was only applied during the `:hover` state in the `InputLabel` component.

Changed the CSS selector from `.withOptions:hover` to `.withOptions` so label text is always truncated when the options slot (Fixed/Expression toggle) exists, preventing the visual overlap glitch.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4919

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)