### PR TITLE
feat(core): Add (un)publish workflow tools to MCP

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/publish-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/publish-workflow.tool.test.ts
@@ -1,0 +1,233 @@
+import { mockInstance } from '@n8n/backend-test-utils';
+import { User } from '@n8n/db';
+import { v4 as uuid } from 'uuid';
+
+import { createWorkflow } from './mock.utils';
+import { createPublishWorkflowTool } from '../tools/publish-workflow.tool';
+
+import { Telemetry } from '@/telemetry';
+import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
+import { WorkflowService } from '@/workflows/workflow.service';
+
+describe('publish-workflow MCP tool', () => {
+	const user = Object.assign(new User(), { id: 'user-1' });
+	let workflowFinderService: WorkflowFinderService;
+	let workflowService: WorkflowService;
+	let telemetry: Telemetry;
+
+	beforeEach(() => {
+		workflowFinderService = mockInstance(WorkflowFinderService);
+		workflowService = mockInstance(WorkflowService);
+		telemetry = mockInstance(Telemetry, {
+			track: jest.fn(),
+		});
+	});
+
+	describe('smoke tests', () => {
+		test('creates tool correctly', () => {
+			const tool = createPublishWorkflowTool(
+				user,
+				workflowFinderService,
+				workflowService,
+				telemetry,
+			);
+
+			expect(tool.name).toBe('publish_workflow');
+			expect(tool.config).toBeDefined();
+			expect(typeof tool.config.description).toBe('string');
+			expect(tool.config.description).toContain('Publish');
+			expect(tool.config.inputSchema).toBeDefined();
+			expect(tool.config.outputSchema).toBeDefined();
+			expect(typeof tool.handler).toBe('function');
+		});
+	});
+
+	describe('handler tests', () => {
+		describe('workflow validation', () => {
+			test('returns error response when workflow validation fails', async () => {
+				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(null);
+
+				const tool = createPublishWorkflowTool(
+					user,
+					workflowFinderService,
+					workflowService,
+					telemetry,
+				);
+
+				const result = await tool.handler(
+					{ workflowId: 'any-workflow', versionId: undefined },
+					{} as Parameters<typeof tool.handler>[1],
+				);
+
+				expect(result.structuredContent).toMatchObject({
+					success: false,
+					workflowId: 'any-workflow',
+					activeVersionId: null,
+					error: expect.any(String),
+				});
+			});
+		});
+
+		describe('successful publish', () => {
+			test('publishes workflow successfully', async () => {
+				const workflow = createWorkflow({ settings: { availableInMCP: true } });
+				const activeVersionId = uuid();
+				const activatedWorkflow = { ...workflow, activeVersionId };
+
+				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
+				(workflowService.activateWorkflow as jest.Mock).mockResolvedValue(activatedWorkflow);
+
+				const tool = createPublishWorkflowTool(
+					user,
+					workflowFinderService,
+					workflowService,
+					telemetry,
+				);
+
+				const result = await tool.handler(
+					{ workflowId: 'wf-1', versionId: undefined },
+					{} as Parameters<typeof tool.handler>[1],
+				);
+
+				expect(result.structuredContent).toMatchObject({
+					success: true,
+					workflowId: 'wf-1',
+					activeVersionId,
+				});
+
+				expect(workflowService.activateWorkflow).toHaveBeenCalledWith(user, 'wf-1', {
+					versionId: undefined,
+				});
+			});
+
+			test('publishes specific version when versionId provided', async () => {
+				const workflow = createWorkflow({ settings: { availableInMCP: true } });
+				const versionId = uuid();
+				const activatedWorkflow = { ...workflow, activeVersionId: versionId };
+
+				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
+				(workflowService.activateWorkflow as jest.Mock).mockResolvedValue(activatedWorkflow);
+
+				const tool = createPublishWorkflowTool(
+					user,
+					workflowFinderService,
+					workflowService,
+					telemetry,
+				);
+
+				const result = await tool.handler(
+					{ workflowId: 'wf-1', versionId },
+					{} as Parameters<typeof tool.handler>[1],
+				);
+
+				expect(result.structuredContent).toMatchObject({
+					success: true,
+					workflowId: 'wf-1',
+					activeVersionId: versionId,
+				});
+
+				expect(workflowService.activateWorkflow).toHaveBeenCalledWith(user, 'wf-1', {
+					versionId,
+				});
+			});
+		});
+
+		describe('telemetry tracking', () => {
+			test('tracks successful publish', async () => {
+				const workflow = createWorkflow({ settings: { availableInMCP: true } });
+				const activeVersionId = uuid();
+				const activatedWorkflow = { ...workflow, activeVersionId };
+
+				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
+				(workflowService.activateWorkflow as jest.Mock).mockResolvedValue(activatedWorkflow);
+
+				const tool = createPublishWorkflowTool(
+					user,
+					workflowFinderService,
+					workflowService,
+					telemetry,
+				);
+
+				await tool.handler(
+					{ workflowId: 'wf-1', versionId: undefined },
+					{} as Parameters<typeof tool.handler>[1],
+				);
+
+				expect(telemetry.track).toHaveBeenCalledWith(
+					'User called mcp tool',
+					expect.objectContaining({
+						user_id: 'user-1',
+						tool_name: 'publish_workflow',
+						parameters: { workflowId: 'wf-1', versionId: undefined },
+						results: {
+							success: true,
+							data: {
+								workflow_id: 'wf-1',
+								active_version_id: activeVersionId,
+							},
+						},
+					}),
+				);
+			});
+
+			test('tracks failed publish with error reason', async () => {
+				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(null);
+
+				const tool = createPublishWorkflowTool(
+					user,
+					workflowFinderService,
+					workflowService,
+					telemetry,
+				);
+
+				await tool.handler(
+					{ workflowId: 'missing-workflow', versionId: undefined },
+					{} as Parameters<typeof tool.handler>[1],
+				);
+
+				expect(telemetry.track).toHaveBeenCalledWith(
+					'User called mcp tool',
+					expect.objectContaining({
+						user_id: 'user-1',
+						tool_name: 'publish_workflow',
+						parameters: { workflowId: 'missing-workflow', versionId: undefined },
+						results: {
+							success: false,
+							error: "Workflow not found or you don't have permission to access it.",
+							error_reason: 'no_permission',
+						},
+					}),
+				);
+			});
+		});
+
+		describe('error handling', () => {
+			test('handles WorkflowService errors gracefully', async () => {
+				const workflow = createWorkflow({ settings: { availableInMCP: true } });
+				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
+				(workflowService.activateWorkflow as jest.Mock).mockRejectedValue(
+					new Error('Version not found'),
+				);
+
+				const tool = createPublishWorkflowTool(
+					user,
+					workflowFinderService,
+					workflowService,
+					telemetry,
+				);
+
+				const result = await tool.handler(
+					{ workflowId: 'wf-1', versionId: undefined },
+					{} as Parameters<typeof tool.handler>[1],
+				);
+
+				expect(result.structuredContent).toMatchObject({
+					success: false,
+					workflowId: 'wf-1',
+					activeVersionId: null,
+					error: 'Version not found',
+				});
+			});
+		});
+	});
+});

--- a/packages/cli/src/modules/mcp/__tests__/unpublish-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/unpublish-workflow.tool.test.ts
@@ -1,0 +1,190 @@
+import { mockInstance } from '@n8n/backend-test-utils';
+import { User } from '@n8n/db';
+
+import { Telemetry } from '@/telemetry';
+import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
+import { WorkflowService } from '@/workflows/workflow.service';
+
+import { createWorkflow } from './mock.utils';
+import { createUnpublishWorkflowTool } from '../tools/unpublish-workflow.tool';
+
+describe('unpublish-workflow MCP tool', () => {
+	const user = Object.assign(new User(), { id: 'user-1' });
+	let workflowFinderService: WorkflowFinderService;
+	let workflowService: WorkflowService;
+	let telemetry: Telemetry;
+
+	beforeEach(() => {
+		workflowFinderService = mockInstance(WorkflowFinderService);
+		workflowService = mockInstance(WorkflowService);
+		telemetry = mockInstance(Telemetry, {
+			track: jest.fn(),
+		});
+	});
+
+	describe('smoke tests', () => {
+		test('creates tool correctly', () => {
+			const tool = createUnpublishWorkflowTool(
+				user,
+				workflowFinderService,
+				workflowService,
+				telemetry,
+			);
+
+			expect(tool.name).toBe('unpublish_workflow');
+			expect(tool.config).toBeDefined();
+			expect(typeof tool.config.description).toBe('string');
+			expect(tool.config.description).toContain('Unpublish');
+			expect(tool.config.inputSchema).toBeDefined();
+			expect(tool.config.outputSchema).toBeDefined();
+			expect(typeof tool.handler).toBe('function');
+		});
+	});
+
+	describe('handler tests', () => {
+		describe('workflow validation', () => {
+			test('returns error response when workflow validation fails', async () => {
+				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(null);
+
+				const tool = createUnpublishWorkflowTool(
+					user,
+					workflowFinderService,
+					workflowService,
+					telemetry,
+				);
+
+				const result = await tool.handler(
+					{ workflowId: 'any-workflow' },
+					{} as Parameters<typeof tool.handler>[1],
+				);
+
+				expect(result.structuredContent).toMatchObject({
+					success: false,
+					workflowId: 'any-workflow',
+					error: expect.any(String),
+				});
+			});
+		});
+
+		describe('successful unpublish', () => {
+			test('unpublishes workflow successfully', async () => {
+				const workflow = createWorkflow({ settings: { availableInMCP: true } });
+				const deactivatedWorkflow = { ...workflow, activeVersionId: null, active: false };
+
+				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
+				(workflowService.deactivateWorkflow as jest.Mock).mockResolvedValue(deactivatedWorkflow);
+
+				const tool = createUnpublishWorkflowTool(
+					user,
+					workflowFinderService,
+					workflowService,
+					telemetry,
+				);
+
+				const result = await tool.handler(
+					{ workflowId: 'wf-1' },
+					{} as Parameters<typeof tool.handler>[1],
+				);
+
+				expect(result.structuredContent).toMatchObject({
+					success: true,
+					workflowId: 'wf-1',
+				});
+
+				expect(workflowService.deactivateWorkflow).toHaveBeenCalledWith(user, 'wf-1');
+			});
+		});
+
+		describe('telemetry tracking', () => {
+			test('tracks successful unpublish', async () => {
+				const workflow = createWorkflow({ settings: { availableInMCP: true } });
+				const deactivatedWorkflow = { ...workflow, activeVersionId: null, active: false };
+
+				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
+				(workflowService.deactivateWorkflow as jest.Mock).mockResolvedValue(deactivatedWorkflow);
+
+				const tool = createUnpublishWorkflowTool(
+					user,
+					workflowFinderService,
+					workflowService,
+					telemetry,
+				);
+
+				await tool.handler({ workflowId: 'wf-1' }, {} as Parameters<typeof tool.handler>[1]);
+
+				expect(telemetry.track).toHaveBeenCalledWith(
+					'User called mcp tool',
+					expect.objectContaining({
+						user_id: 'user-1',
+						tool_name: 'unpublish_workflow',
+						parameters: { workflowId: 'wf-1' },
+						results: {
+							success: true,
+							data: {
+								workflow_id: 'wf-1',
+							},
+						},
+					}),
+				);
+			});
+
+			test('tracks failed unpublish with error reason', async () => {
+				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(null);
+
+				const tool = createUnpublishWorkflowTool(
+					user,
+					workflowFinderService,
+					workflowService,
+					telemetry,
+				);
+
+				await tool.handler(
+					{ workflowId: 'missing-workflow' },
+					{} as Parameters<typeof tool.handler>[1],
+				);
+
+				expect(telemetry.track).toHaveBeenCalledWith(
+					'User called mcp tool',
+					expect.objectContaining({
+						user_id: 'user-1',
+						tool_name: 'unpublish_workflow',
+						parameters: { workflowId: 'missing-workflow' },
+						results: {
+							success: false,
+							error: "Workflow not found or you don't have permission to access it.",
+							error_reason: 'no_permission',
+						},
+					}),
+				);
+			});
+		});
+
+		describe('error handling', () => {
+			test('handles WorkflowService errors gracefully', async () => {
+				const workflow = createWorkflow({ settings: { availableInMCP: true } });
+				(workflowFinderService.findWorkflowForUser as jest.Mock).mockResolvedValue(workflow);
+				(workflowService.deactivateWorkflow as jest.Mock).mockRejectedValue(
+					new Error('Deactivation failed'),
+				);
+
+				const tool = createUnpublishWorkflowTool(
+					user,
+					workflowFinderService,
+					workflowService,
+					telemetry,
+				);
+
+				const result = await tool.handler(
+					{ workflowId: 'wf-1' },
+					{} as Parameters<typeof tool.handler>[1],
+				);
+
+				expect(result.structuredContent).toMatchObject({
+					success: false,
+					workflowId: 'wf-1',
+					error: 'Deactivation failed',
+				});
+			});
+		});
+	});
+});

--- a/packages/cli/src/modules/mcp/mcp.service.ts
+++ b/packages/cli/src/modules/mcp/mcp.service.ts
@@ -15,6 +15,7 @@ import { createExecuteWorkflowTool } from './tools/execute-workflow.tool';
 import { createWorkflowDetailsTool } from './tools/get-workflow-details.tool';
 import { createPublishWorkflowTool } from './tools/publish-workflow.tool';
 import { createSearchWorkflowsTool } from './tools/search-workflows.tool';
+import { createUnpublishWorkflowTool } from './tools/unpublish-workflow.tool';
 import { createCreateWorkflowFromCodeTool } from './tools/workflow-builder/create-workflow-from-code.tool';
 import { createArchiveWorkflowTool } from './tools/workflow-builder/delete-workflow.tool';
 import { createUpdateWorkflowTool } from './tools/workflow-builder/update-workflow.tool';
@@ -145,6 +146,18 @@ export class McpService {
 			publishWorkflowTool.name,
 			publishWorkflowTool.config,
 			publishWorkflowTool.handler,
+		);
+
+		const unpublishWorkflowTool = createUnpublishWorkflowTool(
+			user,
+			this.workflowFinderService,
+			this.workflowService,
+			this.telemetry,
+		);
+		server.registerTool(
+			unpublishWorkflowTool.name,
+			unpublishWorkflowTool.config,
+			unpublishWorkflowTool.handler,
 		);
 
 		// Workflow builder tools (enabled via N8N_MCP_BUILDER_ENABLED)

--- a/packages/cli/src/modules/mcp/mcp.service.ts
+++ b/packages/cli/src/modules/mcp/mcp.service.ts
@@ -13,6 +13,7 @@ import {
 
 import { createExecuteWorkflowTool } from './tools/execute-workflow.tool';
 import { createWorkflowDetailsTool } from './tools/get-workflow-details.tool';
+import { createPublishWorkflowTool } from './tools/publish-workflow.tool';
 import { createSearchWorkflowsTool } from './tools/search-workflows.tool';
 import { createCreateWorkflowFromCodeTool } from './tools/workflow-builder/create-workflow-from-code.tool';
 import { createArchiveWorkflowTool } from './tools/workflow-builder/delete-workflow.tool';
@@ -132,6 +133,18 @@ export class McpService {
 			workflowDetailsTool.name,
 			workflowDetailsTool.config,
 			workflowDetailsTool.handler,
+		);
+
+		const publishWorkflowTool = createPublishWorkflowTool(
+			user,
+			this.workflowFinderService,
+			this.workflowService,
+			this.telemetry,
+		);
+		server.registerTool(
+			publishWorkflowTool.name,
+			publishWorkflowTool.config,
+			publishWorkflowTool.handler,
 		);
 
 		// Workflow builder tools (enabled via N8N_MCP_BUILDER_ENABLED)

--- a/packages/cli/src/modules/mcp/tools/publish-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/publish-workflow.tool.ts
@@ -1,0 +1,115 @@
+import type { User } from '@n8n/db';
+import { jsonStringify, ensureError } from 'n8n-workflow';
+import z from 'zod';
+
+import { USER_CALLED_MCP_TOOL_EVENT } from '../mcp.constants';
+import { WorkflowAccessError } from '../mcp.errors';
+import type { ToolDefinition, UserCalledMCPToolEventPayload } from '../mcp.types';
+import { getMcpWorkflow } from './workflow-validation.utils';
+
+import type { Telemetry } from '@/telemetry';
+import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
+import type { WorkflowService } from '@/workflows/workflow.service';
+
+const inputSchema = z.object({
+	workflowId: z.string().describe('The ID of the workflow to publish'),
+	versionId: z
+		.string()
+		.optional()
+		.describe(
+			'Optional version ID to publish. If not provided, publishes the current draft version.',
+		),
+});
+
+type PublishWorkflowOutput = {
+	success: boolean;
+	workflowId: string;
+	activeVersionId: string | null;
+	error?: string;
+};
+
+const outputSchema = {
+	success: z.boolean(),
+	workflowId: z.string(),
+	activeVersionId: z.string().nullable(),
+	error: z.string().optional(),
+} satisfies z.ZodRawShape;
+
+export const createPublishWorkflowTool = (
+	user: User,
+	workflowFinderService: WorkflowFinderService,
+	workflowService: WorkflowService,
+	telemetry: Telemetry,
+): ToolDefinition<typeof inputSchema.shape> => ({
+	name: 'publish_workflow',
+	config: {
+		description:
+			'Publish (activate) a workflow to make it available for production execution. This creates an active version from the current draft.',
+		inputSchema: inputSchema.shape,
+		outputSchema,
+		annotations: {
+			title: 'Publish Workflow',
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: false,
+		},
+	},
+	handler: async ({ workflowId, versionId }: z.infer<typeof inputSchema>) => {
+		const telemetryPayload: UserCalledMCPToolEventPayload = {
+			user_id: user.id,
+			tool_name: 'publish_workflow',
+			parameters: { workflowId, versionId },
+		};
+
+		try {
+			await getMcpWorkflow(workflowId, user, ['workflow:publish'], workflowFinderService);
+
+			const activatedWorkflow = await workflowService.activateWorkflow(user, workflowId, {
+				versionId,
+			});
+
+			const output: PublishWorkflowOutput = {
+				success: true,
+				workflowId: activatedWorkflow.id,
+				activeVersionId: activatedWorkflow.activeVersionId,
+			};
+
+			telemetryPayload.results = {
+				success: true,
+				data: {
+					workflow_id: workflowId,
+					active_version_id: activatedWorkflow.activeVersionId,
+				},
+			};
+			telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
+
+			return {
+				content: [{ type: 'text', text: jsonStringify(output) }],
+				structuredContent: output,
+			};
+		} catch (er) {
+			const error = ensureError(er);
+			const isAccessError = error instanceof WorkflowAccessError;
+
+			const output: PublishWorkflowOutput = {
+				success: false,
+				workflowId,
+				activeVersionId: null,
+				error: error.message,
+			};
+
+			telemetryPayload.results = {
+				success: false,
+				error: error.message,
+				error_reason: isAccessError ? error.reason : undefined,
+			};
+			telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
+
+			return {
+				content: [{ type: 'text', text: jsonStringify(output) }],
+				structuredContent: output,
+			};
+		}
+	},
+});

--- a/packages/cli/src/modules/mcp/tools/unpublish-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/unpublish-workflow.tool.ts
@@ -1,0 +1,102 @@
+import type { User } from '@n8n/db';
+import { jsonStringify, ensureError } from 'n8n-workflow';
+import z from 'zod';
+
+import { USER_CALLED_MCP_TOOL_EVENT } from '../mcp.constants';
+import { WorkflowAccessError } from '../mcp.errors';
+import type { ToolDefinition, UserCalledMCPToolEventPayload } from '../mcp.types';
+import { getMcpWorkflow } from './workflow-validation.utils';
+
+import type { Telemetry } from '@/telemetry';
+import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
+import type { WorkflowService } from '@/workflows/workflow.service';
+
+const inputSchema = z.object({
+	workflowId: z.string().describe('The ID of the workflow to unpublish'),
+});
+
+type UnpublishWorkflowOutput = {
+	success: boolean;
+	workflowId: string;
+	error?: string;
+};
+
+const outputSchema = {
+	success: z.boolean(),
+	workflowId: z.string(),
+	error: z.string().optional(),
+} satisfies z.ZodRawShape;
+
+export const createUnpublishWorkflowTool = (
+	user: User,
+	workflowFinderService: WorkflowFinderService,
+	workflowService: WorkflowService,
+	telemetry: Telemetry,
+): ToolDefinition<typeof inputSchema.shape> => ({
+	name: 'unpublish_workflow',
+	config: {
+		description:
+			'Unpublish (deactivate) a workflow to stop it from being available for production execution.',
+		inputSchema: inputSchema.shape,
+		outputSchema,
+		annotations: {
+			title: 'Unpublish Workflow',
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: false,
+		},
+	},
+	handler: async ({ workflowId }: z.infer<typeof inputSchema>) => {
+		const telemetryPayload: UserCalledMCPToolEventPayload = {
+			user_id: user.id,
+			tool_name: 'unpublish_workflow',
+			parameters: { workflowId },
+		};
+
+		try {
+			await getMcpWorkflow(workflowId, user, ['workflow:unpublish'], workflowFinderService);
+
+			await workflowService.deactivateWorkflow(user, workflowId);
+
+			const output: UnpublishWorkflowOutput = {
+				success: true,
+				workflowId,
+			};
+
+			telemetryPayload.results = {
+				success: true,
+				data: {
+					workflow_id: workflowId,
+				},
+			};
+			telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
+
+			return {
+				content: [{ type: 'text', text: jsonStringify(output) }],
+				structuredContent: output,
+			};
+		} catch (er) {
+			const error = ensureError(er);
+			const isAccessError = error instanceof WorkflowAccessError;
+
+			const output: UnpublishWorkflowOutput = {
+				success: false,
+				workflowId,
+				error: error.message,
+			};
+
+			telemetryPayload.results = {
+				success: false,
+				error: error.message,
+				error_reason: isAccessError ? error.reason : undefined,
+			};
+			telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
+
+			return {
+				content: [{ type: 'text', text: jsonStringify(output) }],
+				structuredContent: output,
+			};
+		}
+	},
+});

--- a/packages/testing/playwright/services/mcp-api-helper.ts
+++ b/packages/testing/playwright/services/mcp-api-helper.ts
@@ -124,6 +124,21 @@ export interface ExecuteWorkflowResult {
 	error?: unknown;
 }
 
+/** Response from publish_workflow tool */
+export interface PublishWorkflowResult {
+	success: boolean;
+	workflowId: string;
+	activeVersionId: string | null;
+	error?: string;
+}
+
+/** Response from unpublish_workflow tool */
+export interface UnpublishWorkflowResult {
+	success: boolean;
+	workflowId: string;
+	error?: string;
+}
+
 /**
  * Helper class for interacting with MCP Server endpoints.
  * Supports both SSE and Streamable HTTP transports.
@@ -972,6 +987,101 @@ export class McpApiHelper {
 		}
 		throw new Error(
 			`Unexpected response format from execute_workflow: ${JSON.stringify(result ?? body)}`,
+		);
+	}
+
+	/**
+	 * Calls publish_workflow tool on the internal MCP service.
+	 */
+	async internalMcpPublishWorkflow(
+		apiKey: string,
+		workflowId: string,
+		versionId?: string,
+	): Promise<PublishWorkflowResult> {
+		const args: Record<string, unknown> = { workflowId };
+		if (versionId) {
+			args.versionId = versionId;
+		}
+		const message = this.createMessage('tools/call', {
+			name: 'publish_workflow',
+			arguments: args,
+		});
+		const response = await this.internalMcpSendMessage(apiKey, message);
+		const contentType = response.headers()['content-type'] ?? '';
+		const body = await response.text();
+
+		let result: McpToolCallResponse;
+		if (contentType.includes('text/event-stream')) {
+			result = this.parseSSEToolResponse(body);
+		} else {
+			const parsed = JSON.parse(body) as { result?: McpToolCallResponse; error?: unknown };
+			if (parsed.error) {
+				throw new Error(`MCP Error: ${JSON.stringify(parsed.error)}`);
+			}
+			result = parsed.result as McpToolCallResponse;
+		}
+
+		if (result?.content?.[0]?.text) {
+			const text = result.content[0].text;
+			try {
+				return JSON.parse(text) as PublishWorkflowResult;
+			} catch {
+				if (result.isError) {
+					return { success: false, workflowId, activeVersionId: null, error: text };
+				}
+				throw new Error(`Invalid JSON response from publish_workflow: ${text}`);
+			}
+		}
+		if (result?.isError) {
+			return { success: false, workflowId, activeVersionId: null, error: JSON.stringify(result) };
+		}
+		throw new Error(
+			`Unexpected response format from publish_workflow: ${JSON.stringify(result ?? body)}`,
+		);
+	}
+
+	/**
+	 * Calls unpublish_workflow tool on the internal MCP service.
+	 */
+	async internalMcpUnpublishWorkflow(
+		apiKey: string,
+		workflowId: string,
+	): Promise<UnpublishWorkflowResult> {
+		const message = this.createMessage('tools/call', {
+			name: 'unpublish_workflow',
+			arguments: { workflowId },
+		});
+		const response = await this.internalMcpSendMessage(apiKey, message);
+		const contentType = response.headers()['content-type'] ?? '';
+		const body = await response.text();
+
+		let result: McpToolCallResponse;
+		if (contentType.includes('text/event-stream')) {
+			result = this.parseSSEToolResponse(body);
+		} else {
+			const parsed = JSON.parse(body) as { result?: McpToolCallResponse; error?: unknown };
+			if (parsed.error) {
+				throw new Error(`MCP Error: ${JSON.stringify(parsed.error)}`);
+			}
+			result = parsed.result as McpToolCallResponse;
+		}
+
+		if (result?.content?.[0]?.text) {
+			const text = result.content[0].text;
+			try {
+				return JSON.parse(text) as UnpublishWorkflowResult;
+			} catch {
+				if (result.isError) {
+					return { success: false, workflowId, error: text };
+				}
+				throw new Error(`Invalid JSON response from unpublish_workflow: ${text}`);
+			}
+		}
+		if (result?.isError) {
+			return { success: false, workflowId, error: JSON.stringify(result) };
+		}
+		throw new Error(
+			`Unexpected response format from unpublish_workflow: ${JSON.stringify(result ?? body)}`,
 		);
 	}
 }

--- a/packages/testing/playwright/tests/e2e/mcp/mcp-service.spec.ts
+++ b/packages/testing/playwright/tests/e2e/mcp/mcp-service.spec.ts
@@ -6,10 +6,12 @@ import { test, expect } from '../../../fixtures/base';
  * E2E tests for the Internal MCP Service (/mcp-server/http).
  *
  * This tests the built-in MCP server that exposes n8n workflows to external
- * MCP clients (like Claude AI). It provides 3 tools:
+ * MCP clients (like Claude AI). It provides 5 tools:
  * - search_workflows: Search for workflows available in MCP
  * - get_workflow_details: Get detailed information about a workflow
  * - execute_workflow: Execute a workflow and get results
+ * - publish_workflow: Publish (activate) a workflow
+ * - unpublish_workflow: Unpublish (deactivate) a workflow
  *
  * Authentication is via Bearer token (MCP API key).
  *
@@ -95,14 +97,20 @@ test.describe(
 		});
 
 		test.describe('tools/list', () => {
-			test('should return all 3 built-in tools', async ({ api }) => {
+			test('should return all 5 built-in tools', async ({ api }) => {
 				const { apiKey } = await api.rotateMcpApiKey();
 				const tools = await api.mcp.internalMcpListTools(apiKey);
 
-				expect(tools).toHaveLength(3);
+				expect(tools).toHaveLength(5);
 
 				const toolNames = tools.map((t) => t.name).sort();
-				expect(toolNames).toEqual(['execute_workflow', 'get_workflow_details', 'search_workflows']);
+				expect(toolNames).toEqual([
+					'execute_workflow',
+					'get_workflow_details',
+					'publish_workflow',
+					'search_workflows',
+					'unpublish_workflow',
+				]);
 			});
 
 			test('should include proper tool descriptions and schemas', async ({ api }) => {

--- a/packages/testing/playwright/tests/e2e/mcp/mcp-service.spec.ts
+++ b/packages/testing/playwright/tests/e2e/mcp/mcp-service.spec.ts
@@ -330,6 +330,36 @@ test.describe(
 			});
 		});
 
+		test.describe('publish_workflow', () => {
+			test('should publish a workflow successfully', async ({ api }) => {
+				const { workflowId } = await api.workflows.importWorkflowFromFile(
+					'mcp-service/mcp-available-basic.json',
+				);
+
+				const { apiKey } = await api.rotateMcpApiKey();
+				const result = await api.mcp.internalMcpPublishWorkflow(apiKey, workflowId);
+
+				expect(result.success).toBe(true);
+				expect(result.workflowId).toBe(workflowId);
+				expect(result.activeVersionId).toBeTruthy();
+			});
+		});
+
+		test.describe('unpublish_workflow', () => {
+			test('should unpublish a workflow successfully', async ({ api }) => {
+				const { workflowId, createdWorkflow } = await api.workflows.importWorkflowFromFile(
+					'mcp-service/mcp-available-basic.json',
+				);
+				await api.workflows.activate(workflowId, createdWorkflow.versionId!);
+
+				const { apiKey } = await api.rotateMcpApiKey();
+				const result = await api.mcp.internalMcpUnpublishWorkflow(apiKey, workflowId);
+
+				expect(result.success).toBe(true);
+				expect(result.workflowId).toBe(workflowId);
+			});
+		});
+
 		test.describe('Error Handling', () => {
 			test('should handle malformed JSON-RPC messages', async ({ api }) => {
 				const { apiKey } = await api.rotateMcpApiKey();


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-4914](https://linear.app/n8n/issue/ADO-4914/feature-add-unpublish-workflow-tool-to-mcp)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
