### PR TITLE
chore: Rename migration `transaction` flag

### DIFF
--- a/packages/@n8n/db/src/migrations/migration-helpers.ts
+++ b/packages/@n8n/db/src/migrations/migration-helpers.ts
@@ -207,6 +207,16 @@ export const wrapMigration = (migration: Migration) => {
 	}
 	prototype.__n8n_wrapped = true;
 	const { up, down } = migration.prototype;
+	// When withFKsDisabled is set as an instance property (class field), it
+	// won't be on the prototype at wrap-time. A getter defers the check to
+	// when TypeORM reads `transaction` on the already-constructed instance.
+	Object.defineProperty(migration.prototype, 'transaction', {
+		get(this: BaseMigration) {
+			return this.withFKsDisabled ? false : undefined;
+		},
+		configurable: true,
+	});
+
 	if (up) {
 		Object.assign(migration.prototype, {
 			async up(this: BaseMigration, queryRunner: QueryRunner) {

--- a/packages/@n8n/db/src/migrations/migration-helpers.ts
+++ b/packages/@n8n/db/src/migrations/migration-helpers.ts
@@ -212,7 +212,7 @@ export const wrapMigration = (migration: Migration) => {
 			async up(this: BaseMigration, queryRunner: QueryRunner) {
 				logMigrationStart(migration.name);
 				const context = createContext(queryRunner, migration);
-				if (this.transaction === false) {
+				if (this.withFKsDisabled === true) {
 					await runDisablingForeignKeys(this, context, up);
 				} else {
 					await up.call(this, context);
@@ -227,7 +227,7 @@ export const wrapMigration = (migration: Migration) => {
 		Object.assign(migration.prototype, {
 			async down(this: BaseMigration, queryRunner: QueryRunner) {
 				const context = createContext(queryRunner, migration);
-				if (this.transaction === false) {
+				if (this.withFKsDisabled === true) {
 					await runDisablingForeignKeys(this, context, down);
 				} else {
 					await down.call(this, context);

--- a/packages/@n8n/db/src/migrations/migration-types.ts
+++ b/packages/@n8n/db/src/migrations/migration-types.ts
@@ -44,7 +44,12 @@ export interface BaseMigration {
 	up: MigrationFn;
 	// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
 	down?: MigrationFn | never;
-	transaction?: false;
+	/**
+	 * Run the migration on SQLite with foreign keys disabled. This should be
+	 * used for migrations that need to recreate tables that have FKs from
+	 * other tables. Otherwise it can cause data loss due CASCADE behaviour.
+	 */
+	withFKsDisabled?: true;
 }
 
 export interface ReversibleMigration extends BaseMigration {

--- a/packages/@n8n/db/src/migrations/sqlite/1652367743993-AddUserSettings.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1652367743993-AddUserSettings.ts
@@ -1,7 +1,7 @@
 import type { MigrationContext, ReversibleMigration } from '../migration-types';
 
 export class AddUserSettings1652367743993 implements ReversibleMigration {
-	transaction = false as const;
+	withFKsDisabled = true as const;
 
 	async up({ queryRunner, tablePrefix }: MigrationContext) {
 		await queryRunner.query(

--- a/packages/@n8n/db/src/migrations/sqlite/1652905585850-AddAPIKeyColumn.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1652905585850-AddAPIKeyColumn.ts
@@ -1,7 +1,7 @@
 import type { MigrationContext, ReversibleMigration } from '../migration-types';
 
 export class AddAPIKeyColumn1652905585850 implements ReversibleMigration {
-	transaction = false as const;
+	withFKsDisabled = true as const;
 
 	async up({ queryRunner, tablePrefix }: MigrationContext) {
 		await queryRunner.query(

--- a/packages/@n8n/db/src/migrations/sqlite/1673268682475-DeleteExecutionsWithWorkflows.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1673268682475-DeleteExecutionsWithWorkflows.ts
@@ -1,7 +1,7 @@
 import type { MigrationContext, ReversibleMigration } from '../migration-types';
 
 export class DeleteExecutionsWithWorkflows1673268682475 implements ReversibleMigration {
-	transaction = false as const;
+	withFKsDisabled = true as const;
 
 	async up({ queryRunner, tablePrefix }: MigrationContext) {
 		const workflowIds = (await queryRunner.query(`

--- a/packages/@n8n/db/src/migrations/sqlite/1690000000002-MigrateIntegerKeysToString.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1690000000002-MigrateIntegerKeysToString.ts
@@ -7,7 +7,7 @@ import path from 'path';
 import type { MigrationContext, IrreversibleMigration } from '../migration-types';
 
 export class MigrateIntegerKeysToString1690000000002 implements IrreversibleMigration {
-	transaction = false as const;
+	withFKsDisabled = true as const;
 
 	async up(context: MigrationContext) {
 		await pruneExecutionsData(context);

--- a/packages/@n8n/db/src/migrations/sqlite/1690000000030-RemoveResetPasswordColumns.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1690000000030-RemoveResetPasswordColumns.ts
@@ -1,5 +1,5 @@
 import { RemoveResetPasswordColumns1690000000030 as BaseMigration } from '../common/1690000000030-RemoveResetPasswordColumns';
 
 export class RemoveResetPasswordColumns1690000000030 extends BaseMigration {
-	transaction = false as const;
+	withFKsDisabled = true as const;
 }

--- a/packages/@n8n/db/src/migrations/sqlite/1690000000040-AddMfaColumns.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1690000000040-AddMfaColumns.ts
@@ -1,5 +1,5 @@
 import { AddMfaColumns1690000000030 as BaseMigration } from '../common/1690000000040-AddMfaColumns';
 
 export class AddMfaColumns1690000000030 extends BaseMigration {
-	transaction = false as const;
+	withFKsDisabled = true as const;
 }

--- a/packages/@n8n/db/src/migrations/sqlite/1693491613982-ExecutionSoftDelete.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1693491613982-ExecutionSoftDelete.ts
@@ -1,5 +1,5 @@
 import { ExecutionSoftDelete1693491613982 as BaseMigration } from '../common/1693491613982-ExecutionSoftDelete';
 
 export class ExecutionSoftDelete1693491613982 extends BaseMigration {
-	transaction = false as const;
+	withFKsDisabled = true as const;
 }

--- a/packages/@n8n/db/src/migrations/sqlite/1695128658538-AddWorkflowMetadata.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1695128658538-AddWorkflowMetadata.ts
@@ -1,5 +1,5 @@
 import { AddWorkflowMetadata1695128658538 as BaseMigration } from '../common/1695128658538-AddWorkflowMetadata';
 
 export class AddWorkflowMetadata1695128658538 extends BaseMigration {
-	transaction = false as const;
+	withFKsDisabled = true as const;
 }

--- a/packages/@n8n/db/src/migrations/sqlite/1705429061930-DropRoleMapping.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1705429061930-DropRoleMapping.ts
@@ -1,5 +1,5 @@
 import { DropRoleMapping1705429061930 as BaseMigration } from '../common/1705429061930-DropRoleMapping';
 
 export class DropRoleMapping1705429061930 extends BaseMigration {
-	transaction = false as const;
+	withFKsDisabled = true as const;
 }

--- a/packages/@n8n/db/src/migrations/sqlite/1717498465931-AddActivatedAtUserSetting.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1717498465931-AddActivatedAtUserSetting.ts
@@ -1,7 +1,7 @@
 import type { MigrationContext, ReversibleMigration } from '../migration-types';
 
 export class AddActivatedAtUserSetting1717498465931 implements ReversibleMigration {
-	transaction = false as const;
+	withFKsDisabled = true as const;
 
 	async up({ queryRunner, escape }: MigrationContext) {
 		const now = Date.now();

--- a/packages/@n8n/db/src/migrations/sqlite/1724951148974-AddApiKeysTable.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1724951148974-AddApiKeysTable.ts
@@ -4,7 +4,7 @@ import type { ApiKey } from '../../entities';
 import type { MigrationContext, ReversibleMigration } from '../migration-types';
 
 export class AddApiKeysTable1724951148974 implements ReversibleMigration {
-	transaction = false as const;
+	withFKsDisabled = true as const;
 
 	async up({ queryRunner, tablePrefix, runQuery }: MigrationContext) {
 		const tableName = `${tablePrefix}user_api_keys`;

--- a/packages/@n8n/db/src/migrations/sqlite/1729607673469-AddProjectIcons.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1729607673469-AddProjectIcons.ts
@@ -1,5 +1,5 @@
 import { AddProjectIcons1729607673469 as BaseMigration } from '../common/1729607673469-AddProjectIcons';
 
 export class AddProjectIcons1729607673469 extends BaseMigration {
-	transaction = false as const;
+	withFKsDisabled = true as const;
 }

--- a/packages/@n8n/db/src/migrations/sqlite/1731404028106-AddDescriptionToTestDefinition.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1731404028106-AddDescriptionToTestDefinition.ts
@@ -1,5 +1,5 @@
 import { AddDescriptionToTestDefinition1731404028106 as BaseMigration } from '../common/1731404028106-AddDescriptionToTestDefinition';
 
 export class AddDescriptionToTestDefinition1731404028106 extends BaseMigration {
-	transaction = false as const;
+	withFKsDisabled = true as const;
 }

--- a/packages/@n8n/db/src/migrations/sqlite/1731582748663-MigrateTestDefinitionKeyToString.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1731582748663-MigrateTestDefinitionKeyToString.ts
@@ -1,7 +1,7 @@
 import type { MigrationContext, IrreversibleMigration } from '../migration-types';
 
 export class MigrateTestDefinitionKeyToString1731582748663 implements IrreversibleMigration {
-	transaction = false as const;
+	withFKsDisabled = true as const;
 
 	async up(context: MigrationContext) {
 		const { queryRunner, tablePrefix } = context;

--- a/packages/@n8n/db/src/migrations/sqlite/1738709609940-CreateFolderTable.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1738709609940-CreateFolderTable.ts
@@ -1,5 +1,5 @@
 import { CreateFolderTable1738709609940 as BaseMigration } from '../common/1738709609940-CreateFolderTable';
 
 export class CreateFolderTable1738709609940 extends BaseMigration {
-	transaction = false as const;
+	withFKsDisabled = true as const;
 }

--- a/packages/@n8n/db/src/migrations/sqlite/1742918400000-AddScopesColumnToApiKeys.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1742918400000-AddScopesColumnToApiKeys.ts
@@ -1,5 +1,5 @@
 import { AddScopesColumnToApiKeys1742918400000 as BaseMigration } from '../common/1742918400000-AddScopesColumnToApiKeys';
 
 export class AddScopesColumnToApiKeys1742918400000 extends BaseMigration {
-	transaction = false as const;
+	withFKsDisabled = true as const;
 }

--- a/packages/@n8n/db/src/migrations/sqlite/1764276827837-AddCreatorIdToProjectTable.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1764276827837-AddCreatorIdToProjectTable.ts
@@ -8,7 +8,7 @@ const table = {
 const FOREIGN_KEY_NAME = 'projects_creatorId_foreign';
 
 export class AddCreatorIdToProjectTable1764276827837 implements ReversibleMigration {
-	transaction = false as const;
+	withFKsDisabled = true as const;
 
 	async up({
 		escape,

--- a/packages/@n8n/db/src/migrations/sqlite/1764689448000-AddResolvableFieldsToCredentials.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1764689448000-AddResolvableFieldsToCredentials.ts
@@ -5,7 +5,7 @@ const resolverTableName = 'dynamic_credential_resolver';
 const FOREIGN_KEY_NAME = 'credentials_entity_resolverId_foreign';
 
 export class AddResolvableFieldsToCredentials1764689448000 implements ReversibleMigration {
-	transaction = false as const;
+	withFKsDisabled = true as const;
 
 	async up({ schemaBuilder: { addColumns, addForeignKey, column } }: MigrationContext) {
 		await addColumns(credentialsTableName, [

--- a/packages/@n8n/db/src/migrations/sqlite/1765886667897-AddAgentIdForeignKeys.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1765886667897-AddAgentIdForeignKeys.ts
@@ -1,5 +1,5 @@
 import { AddAgentIdForeignKeys1765886667897 as BaseMigration } from '../common/1765886667897-AddAgentIdForeignKeys';
 
 export class AddAgentIdForeignKeys1765886667897 extends BaseMigration {
-	transaction = false as const;
+	withFKsDisabled = true as const;
 }

--- a/packages/@n8n/db/src/migrations/sqlite/1766068346315-AddChatMessageIndices.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1766068346315-AddChatMessageIndices.ts
@@ -1,5 +1,5 @@
 import { AddChatMessageIndices1766068346315 as BaseMigration } from '../common/1766068346315-AddChatMessageIndices';
 
 export class AddChatMessageIndices1766068346315 extends BaseMigration {
-	transaction = false as const;
+	withFKsDisabled = true as const;
 }

--- a/packages/@n8n/db/src/migrations/sqlite/1767018516000-ChangeWorkflowStatisticsFKToNoAction.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1767018516000-ChangeWorkflowStatisticsFKToNoAction.ts
@@ -9,7 +9,7 @@ import type { MigrationContext, ReversibleMigration } from '../migration-types';
  * - Add unique index on (workflowId, name)
  */
 export class ChangeWorkflowStatisticsFKToNoAction1767018516000 implements ReversibleMigration {
-	transaction = false as const; // Disable FK checks for table recreation
+	withFKsDisabled = true as const;
 
 	async up({ queryRunner, tablePrefix }: MigrationContext) {
 		// Create new table with id primary key, non nullable workflowId, workflowName column, and no foreign key constraint


### PR DESCRIPTION
## Summary

Rename the `transaction` flag on migrations to `withFKsDisabled` to better indicate the behaviour. This has been a recurring source of confusion for people writing migrations.


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
