### PR TITLE
feat: Add optional `--publish` flag to n8n-node release command

### DIFF
--- a/packages/@n8n/node-cli/src/commands/release.test.ts
+++ b/packages/@n8n/node-cli/src/commands/release.test.ts
@@ -21,6 +21,8 @@ describe('release command', () => {
 		'--git.push',
 		'--git.changelog="npx auto-changelog --stdout --unreleased --commit-limit false -u --hide-credit"',
 		'--github.release',
+		'--hooks.before:init="pnpm run lint && pnpm run build"',
+		'--hooks.after:bump="npx auto-changelog -p"',
 	];
 
 	beforeEach(() => {
@@ -47,17 +49,29 @@ describe('release command', () => {
 		);
 		await fs.writeFile(`${tmpdir}/pnpm-lock.yaml`, '# pnpm lock file');
 
-		mockSpawn(
-			'pnpm',
-			[
-				...releaseItArgs,
-				'--hooks.before:init="pnpm run lint && pnpm run build"',
-				'--hooks.after:bump="npx auto-changelog -p"',
-			],
-			{ exitCode: 0 },
-		);
+		mockSpawn('pnpm', [...releaseItArgs, '--npm.publish=false'], { exitCode: 0 });
 
 		const result = await CommandTester.run('release');
+
+		expect(result).toBeDefined();
+	});
+
+	tmpdirTest('--publish flag - runs release-it with npm publish', async ({ tmpdir }) => {
+		await fs.writeFile(
+			`${tmpdir}/package.json`,
+			JSON.stringify({
+				name: 'test-node',
+				version: '1.0.0',
+				n8n: {
+					nodes: ['dist/nodes/TestNode.node.js'],
+				},
+			}),
+		);
+		await fs.writeFile(`${tmpdir}/pnpm-lock.yaml`, '# pnpm lock file');
+
+		mockSpawn('pnpm', releaseItArgs, { exitCode: 0 });
+
+		const result = await CommandTester.run('release --publish');
 
 		expect(result).toBeDefined();
 	});

--- a/packages/@n8n/node-cli/src/commands/release.ts
+++ b/packages/@n8n/node-cli/src/commands/release.ts
@@ -1,18 +1,18 @@
 import { intro, log } from '@clack/prompts';
-import { Command } from '@oclif/core';
+import { Command, Flags } from '@oclif/core';
 
 import { ChildProcessError, runCommand } from '../utils/child-process';
 import { detectPackageManager } from '../utils/package-manager';
 import { getCommandHeader } from '../utils/prompts';
 
 export default class Release extends Command {
-	static override description = `Publish your community node package to npm.
+	static override description = `Release your community node package.
+
+When running locally (default): Runs release-it to bump the version interactively, generate a changelog, commit, tag, push, and create a GitHub release. Does NOT publish to npm — use GitHub Actions for that.
+
+When running inside a GitHub Action: Detected automatically via the GITHUB_ACTIONS environment variable. Runs lint and build, then publishes with provenance enabled (NPM_CONFIG_PROVENANCE=true).
 
 Starting May 1 2026, n8n requires all community nodes to be published via GitHub Actions with npm provenance. Provenance lets anyone cryptographically verify that a package was built from a specific repository and commit.
-
-When this command is running locally: Runs release-it to bump the version interactively, generate a changelog, commit, tag, push, create a GitHub release, and publish to npm.
-
-When it's running inside a GitHub Action: Detected automatically via the GITHUB_ACTIONS environment variable. Runs lint and build, then publishes with provenance enabled (NPM_CONFIG_PROVENANCE=true).
 
 To set up GitHub Actions publishing:
   1. Add a publish.yml workflow that triggers on version tags (e.g. v*.*.*).
@@ -25,13 +25,22 @@ For npm Trusted Publishing (no long-lived secrets):
   Leave NPM_TOKEN unset; GitHub's OIDC token is used automatically.
 
 For token-based auth (fallback):
-  Add NPM_TOKEN to your repository secrets and pass it as NODE_AUTH_TOKEN.`;
+  Add NPM_TOKEN to your repository secrets and pass it as NODE_AUTH_TOKEN.
+
+Full documentation: https://docs.n8n.io/integrations/creating-nodes/deploy/submit-community-nodes/`;
 
 	static override examples = ['<%= config.bin %> <%= command.id %>'];
-	static override flags = {};
+
+	static override flags = {
+		publish: Flags.boolean({
+			description:
+				'Publish to npm from your local machine (not recommended). Packages published this way will not include npm provenance and cannot become verified community nodes.',
+			default: false,
+		}),
+	};
 
 	async run(): Promise<void> {
-		await this.parse(Release);
+		const { flags } = await this.parse(Release);
 
 		intro(await getCommandHeader('n8n-node release'));
 
@@ -52,9 +61,11 @@ For token-based auth (fallback):
 				return;
 			}
 
-			log.warning(
-				'Starting May 1 2026, n8n requires community nodes to be published via GitHub Actions with npm provenance.\nRun `n8n-node release --help` to learn how to set this up.',
-			);
+			if (flags.publish) {
+				log.warning(
+					'Publishing directly from your machine will not include npm provenance, which is required for n8n Cloud starting May 1 2026.\nConsider switching to GitHub Actions publishing. See: https://docs.n8n.io/integrations/creating-nodes/deploy/submit-community-nodes/',
+				);
+			}
 
 			await runCommand(
 				'release-it',
@@ -71,6 +82,7 @@ For token-based auth (fallback):
 					'--github.release',
 					`--hooks.before:init="${pm} run lint && ${pm} run build"`,
 					'--hooks.after:bump="npx auto-changelog -p"',
+					...(flags.publish ? [] : ['--npm.publish=false']),
 				],
 				{
 					stdio: 'inherit',
@@ -80,6 +92,12 @@ For token-based auth (fallback):
 					},
 				},
 			);
+
+			if (!flags.publish) {
+				log.info(
+					'The node was not published to NPM. Starting May 1 2026, n8n requires verified community nodes to be published via GitHub Actions with npm provenance. Learn more in our documentation: https://docs.n8n.io/integrations/creating-nodes/deploy/submit-community-nodes/',
+				);
+			}
 		} catch (error) {
 			if (error instanceof ChildProcessError) {
 				if (error.signal) {


### PR DESCRIPTION
## Summary

Changes `n8n-node release` to not publish to npm by default. Instead, it bumps the version, generates a changelog, commits, tags, and pushes to GitHub — leaving the actual npm publish to a GitHub Actions workflow (which can attach npm provenance).

**New behavior:**
- `n8n-node release` — runs release-it as before, but skips `npm publish` (`--npm.publish=false`). After a successful release, logs a notice explaining that verified community nodes must be published via GitHub Actions with provenance, and links to the docs.
- `n8n-node release --publish` — restores the old behavior (publishes to npm directly), with a warning that provenance won't be included.
- CI mode (`GITHUB_ACTIONS=true`) — unchanged: runs lint → build → `npm publish` with `NPM_CONFIG_PROVENANCE=true`.

**Why:** Starting May 1 2026, n8n requires verified community nodes to be published with npm provenance, which can only be attached when publishing from GitHub Actions via OIDC. This change nudges node authors toward that setup while keeping the local release workflow familiar.

**How to test:**
1. In a community node repo, run `n8n-node release` — confirm release-it runs interactively but does not publish to npm, and the post-release info message appears.
2. Run `n8n-node release --publish` — confirm the provenance warning appears and npm publish runs.
3. Run with `GITHUB_ACTIONS=true n8n-node release` — confirm CI behavior is unchanged.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CE-588/make-n8n-node-release-optionally-publish-to-npm-via-publish-flag

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
