### PR TITLE
fix(core): Handle null KV mount options in Vault provider

### DIFF
--- a/packages/cli/src/modules/external-secrets.ee/providers/__tests__/vault.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/__tests__/vault.test.ts
@@ -1,0 +1,173 @@
+import { mockInstance } from '@n8n/backend-test-utils';
+import { Logger } from '@n8n/backend-common';
+import nock from 'nock';
+
+import { ExternalSecretsConfig } from '../../external-secrets.config';
+import { VaultProvider } from '../vault';
+
+const VAULT_BASE_URL = 'https://vault.test.com';
+const VAULT_URL = `${VAULT_BASE_URL}/v1/`;
+
+const vaultSettings = {
+	connected: true,
+	connectedAt: new Date(),
+	settings: {
+		url: VAULT_URL,
+		authMethod: 'token',
+		token: 'test-token',
+		renewToken: false,
+		namespace: '',
+		username: '',
+		password: '',
+		roleId: '',
+		secretId: '',
+	},
+};
+
+function mountsResponse(mounts: Record<string, object>) {
+	return { data: mounts };
+}
+
+function kvV2SecretResponse(data: Record<string, unknown>) {
+	return { data: { data } };
+}
+
+describe('VaultProvider', () => {
+	const logger = mockInstance(Logger);
+	logger.scoped.mockReturnValue(logger);
+
+	// Use preferGet so nock can intercept GET requests instead of custom LIST method
+	mockInstance(ExternalSecretsConfig, { preferGet: true });
+
+	beforeAll(() => {
+		nock.disableNetConnect();
+	});
+
+	beforeEach(() => {
+		nock.cleanAll();
+	});
+
+	afterAll(() => {
+		nock.cleanAll();
+		nock.enableNetConnect();
+	});
+
+	describe('update', () => {
+		it('should cache secrets from a valid KV v2 mount', async () => {
+			const provider = new VaultProvider(logger);
+			await provider.init(vaultSettings);
+
+			const scope = nock(VAULT_BASE_URL)
+				.get('/v1/sys/mounts')
+				.reply(200, mountsResponse({ 'secret/': { type: 'kv', options: { version: '2' } } }))
+				.get('/v1/secret/metadata/?list=true')
+				.reply(200, { data: { keys: ['myapp'] } })
+				.get('/v1/secret/data/myapp')
+				.reply(200, kvV2SecretResponse({ password: 'hunter2' }));
+
+			await provider.update();
+
+			expect(provider.getSecret('secret')).toEqual({ myapp: { password: 'hunter2' } });
+			expect(provider.hasSecret('secret')).toBe(true);
+			expect(provider.getSecretNames()).toContain('secret.myapp.password');
+			scope.done();
+		});
+
+		it('should skip inaccessible mounts that return null metadata', async () => {
+			const provider = new VaultProvider(logger);
+			await provider.init(vaultSettings);
+
+			const scope = nock(VAULT_BASE_URL)
+				.get('/v1/sys/mounts')
+				.reply(
+					200,
+					mountsResponse({
+						'inaccessible/': { type: 'kv', options: null },
+						'secret/': { type: 'kv', options: { version: '2' } },
+					}),
+				)
+				.get('/v1/secret/metadata/?list=true')
+				.reply(200, { data: { keys: ['myapp'] } })
+				.get('/v1/secret/data/myapp')
+				.reply(200, kvV2SecretResponse({ password: 'hunter2' }));
+
+			await provider.update();
+
+			expect(provider.hasSecret('inaccessible')).toBe(false);
+			expect(provider.getSecret('secret')).toEqual({ myapp: { password: 'hunter2' } });
+			scope.done();
+		});
+
+		it('should skip mounts created without an explicit KV version', async () => {
+			const provider = new VaultProvider(logger);
+			await provider.init(vaultSettings);
+
+			const scope = nock(VAULT_BASE_URL)
+				.get('/v1/sys/mounts')
+				.reply(
+					200,
+					mountsResponse({
+						'bad-mount/': { type: 'kv', options: { version: null } },
+						'secret/': { type: 'kv', options: { version: '2' } },
+					}),
+				)
+				.get('/v1/secret/metadata/?list=true')
+				.reply(200, { data: { keys: ['myapp'] } })
+				.get('/v1/secret/data/myapp')
+				.reply(200, kvV2SecretResponse({ password: 'hunter2' }));
+
+			await provider.update();
+
+			expect(provider.hasSecret('bad-mount')).toBe(false);
+			expect(provider.getSecret('secret')).toEqual({ myapp: { password: 'hunter2' } });
+			scope.done();
+		});
+
+		it('should skip mounts with incomplete configuration', async () => {
+			const provider = new VaultProvider(logger);
+			await provider.init(vaultSettings);
+
+			const scope = nock(VAULT_BASE_URL)
+				.get('/v1/sys/mounts')
+				.reply(
+					200,
+					mountsResponse({
+						'no-version/': { type: 'kv', options: {} },
+						'secret/': { type: 'kv', options: { version: '2' } },
+					}),
+				)
+				.get('/v1/secret/metadata/?list=true')
+				.reply(200, { data: { keys: ['myapp'] } })
+				.get('/v1/secret/data/myapp')
+				.reply(200, kvV2SecretResponse({ password: 'hunter2' }));
+
+			await provider.update();
+
+			expect(provider.hasSecret('no-version')).toBe(false);
+			expect(provider.getSecret('secret')).toEqual({ myapp: { password: 'hunter2' } });
+			scope.done();
+		});
+
+		it('should skip mounts the token lacks permission to read', async () => {
+			const provider = new VaultProvider(logger);
+			await provider.init(vaultSettings);
+
+			const scope = nock(VAULT_BASE_URL)
+				.get('/v1/sys/mounts')
+				.reply(
+					200,
+					mountsResponse({
+						'forbidden/': { type: 'kv', options: { version: '2' } },
+					}),
+				)
+				.get('/v1/forbidden/metadata/?list=true')
+				.reply(403, { errors: ['permission denied'] });
+
+			await provider.update();
+
+			expect(provider.hasSecret('forbidden')).toBe(false);
+			expect(provider.getSecretNames()).toHaveLength(0);
+			scope.done();
+		});
+	});
+});

--- a/packages/cli/src/modules/external-secrets.ee/providers/vault.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/vault.ts
@@ -59,7 +59,7 @@ interface VaultMount {
 	description: string;
 	external_entropy_access: boolean;
 	local: boolean;
-	options: Record<string, string | number | boolean | null>;
+	options: Record<string, string | number | boolean | null> | null;
 	plugin_version: string;
 	running_plugin_version: string;
 	running_sha256: string;
@@ -458,7 +458,12 @@ export class VaultProvider extends SecretsProvider {
 			(
 				await Promise.all(
 					kvs.map(async ([basePath, data]): Promise<[string, IDataObject] | null> => {
-						const value = await this.getKVSecrets(basePath, data.options.version as string, '');
+						const version = data.options?.version;
+						if (typeof version !== 'string') {
+							this.logger.debug(`Skipping KV mount "${basePath}" — no version in mount options`);
+							return null;
+						}
+						const value = await this.getKVSecrets(basePath, version, '');
 						if (value === null) {
 							return null;
 						}


### PR DESCRIPTION
## Summary

When a Vault token is scoped to one KV mount but `sys/mounts` returns other mounts the token can't access, the provider would crash on null mount options. Now skips mounts without a valid KV version string gracefully instead of crashing.

Reproduces the bug scenario from LIGO-345 and covers null metadata, missing version configurations, and permission errors with comprehensive tests.

## Manual Testing

### Setup

```bash
# Start Vault
docker run --cap-add=IPC_LOCK -d --name vault -p 8200:8200 -e 'VAULT_DEV_ROOT_TOKEN_ID=root' hashicorp/vault

VAULT_ADDR=http://127.0.0.1:8200
TOKEN=root

# Create extra mounts
curl -s -X POST "$VAULT_ADDR/v1/sys/mounts/restricted" -H "X-Vault-Token: $TOKEN" -d '{"type":"kv","options":{"version":"2"}}'

# Add test data
curl -s -X POST "$VAULT_ADDR/v1/secret/data/myapp" -H "X-Vault-Token: $TOKEN" -d '{"data":{"password":"hunter2"}}'
curl -s -X POST "$VAULT_ADDR/v1/restricted/data/internal" -H "X-Vault-Token: $TOKEN" -d '{"data":{"db_password":"supersecret"}}'

# Create scoped policy + token
curl -s -X PUT "$VAULT_ADDR/v1/sys/policies/acl/limited" -H "X-Vault-Token: $TOKEN" \
  -d '{"policy":"path \"sys/mounts\" { capabilities = [\"read\"] }\npath \"secret/*\" { capabilities = [\"read\", \"list\"] }"}'

# Create the scoped token
curl -s -X POST "$VAULT_ADDR/v1/auth/token/create" -H "X-Vault-Token: $TOKEN" \
  -d '{"policies":["limited"],"ttl":"1h"}' | jq -r .auth.client_token
```

### Test in n8n
* Go to Settings > External Secrets > HashiCorp Vault
* Set URL to http://127.0.0.1:8200/v1/, auth method to Token, paste the scoped token
* Click Connect

**Expected:** Provider connects. Only secret/myapp secrets are synced. Inaccessible mounts are skipped without error.

### Cleanup

```
docker stop vault && docker rm vault
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-345

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. (No docs needed - internal fix)
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)