### PR TITLE
fix(Airtable Node): Revert flattening output from search and get operations

### DIFF
--- a/packages/nodes-base/nodes/Airtable/Airtable.node.ts
+++ b/packages/nodes-base/nodes/Airtable/Airtable.node.ts
@@ -12,13 +12,14 @@ export class Airtable extends VersionedNodeType {
 			icon: 'file:airtable.svg',
 			group: ['input'],
 			description: 'Read, update, write and delete data from Airtable',
-			defaultVersion: 2.1,
+			defaultVersion: 2.2,
 		};
 
 		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
 			1: new AirtableV1(baseDescription),
 			2: new AirtableV2(baseDescription),
 			2.1: new AirtableV2(baseDescription),
+			2.2: new AirtableV2(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/helpers.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/helpers.ts
@@ -5,7 +5,7 @@ import type { IDataObject, IExecuteFunctions, IGetNodeParameterOptions, INode } 
 export const node: INode = {
 	id: '11',
 	name: 'Airtable node',
-	typeVersion: 2,
+	typeVersion: 2.2,
 	type: 'n8n-nodes-base.airtable',
 	position: [42, 42],
 	parameters: {
@@ -13,7 +13,11 @@ export const node: INode = {
 	},
 };
 
-export const createMockExecuteFunction = (nodeParameters: IDataObject) => {
+export const createMockExecuteFunction = (
+	nodeParameters: IDataObject,
+	typeVersion = node.typeVersion,
+) => {
+	const mockNode = typeVersion === node.typeVersion ? node : { ...node, typeVersion };
 	const fakeExecuteFunction = {
 		getInputData: jest.fn(() => {
 			return [{ json: {} }];
@@ -30,7 +34,7 @@ export const createMockExecuteFunction = (nodeParameters: IDataObject) => {
 			},
 		),
 		getNode: jest.fn(() => {
-			return node;
+			return mockNode;
 		}),
 		helpers: { constructExecutionMetaData: jest.fn(constructExecutionMetaData) },
 		continueOnFail: jest.fn(() => false),

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/record/get.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/record/get.test.ts
@@ -17,6 +17,21 @@ jest.mock('../../../../v2/transport', () => {
 				};
 			}
 		}),
+		downloadRecordAttachments: jest.fn(async function () {
+			return [
+				{
+					json: {
+						id: 'recXXX',
+						fields: {
+							foo: 'foo 1',
+							bar: 'bar 1',
+							attachment: [{ url: 'http://example.com/file.png' }],
+						},
+					},
+					binary: { attachment_0: { data: 'binary-data' } },
+				},
+			];
+		}),
 	};
 });
 
@@ -56,6 +71,70 @@ describe('Test AirtableV2, get operation', () => {
 				pairedItem: {
 					item: 0,
 				},
+			},
+		]);
+	});
+
+	afterEach(() => jest.clearAllMocks());
+
+	it('should get a record with attachments and nested fields structure for v2.2', async () => {
+		const nodeParameters = {
+			operation: 'get',
+			id: 'recXXX',
+			options: { downloadFields: ['attachment'] },
+		};
+
+		const items = [{ json: {} }];
+
+		const result = await get.execute.call(
+			createMockExecuteFunction(nodeParameters),
+			items,
+			'appYoLbase',
+			'tblltable',
+		);
+
+		expect(transport.downloadRecordAttachments).toHaveBeenCalledTimes(1);
+		expect(result).toEqual([
+			{
+				json: {
+					id: 'recXXX',
+					fields: {
+						foo: 'foo 1',
+						bar: 'bar 1',
+						attachment: [{ url: 'http://example.com/file.png' }],
+					},
+				},
+				binary: { attachment_0: { data: 'binary-data' } },
+			},
+		]);
+	});
+
+	it('should get a record with attachments and flatten output for v2', async () => {
+		const nodeParameters = {
+			operation: 'get',
+			id: 'recXXX',
+			options: { downloadFields: ['attachment'] },
+		};
+
+		const items = [{ json: {} }];
+
+		const result = await get.execute.call(
+			createMockExecuteFunction(nodeParameters, 2),
+			items,
+			'appYoLbase',
+			'tblltable',
+		);
+
+		expect(transport.downloadRecordAttachments).toHaveBeenCalledTimes(1);
+		expect(result).toEqual([
+			{
+				json: {
+					id: 'recXXX',
+					foo: 'foo 1',
+					bar: 'bar 1',
+					attachment: [{ url: 'http://example.com/file.png' }],
+				},
+				binary: { attachment_0: { data: 'binary-data' } },
 			},
 		]);
 	});

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/record/get.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/record/get.test.ts
@@ -20,8 +20,8 @@ jest.mock('../../../../v2/transport', () => {
 	};
 });
 
-describe('Test AirtableV2, create operation', () => {
-	it('should create a record, autoMapInputData', async () => {
+describe('Test AirtableV2, get operation', () => {
+	it('should get a record and with nested fields structure for v2.2', async () => {
 		const nodeParameters = {
 			operation: 'get',
 			id: 'recXXX',
@@ -45,6 +45,38 @@ describe('Test AirtableV2, create operation', () => {
 		expect(transport.apiRequest).toHaveBeenCalledWith('GET', 'appYoLbase/tblltable/recXXX');
 
 		expect(responce).toEqual([
+			{
+				json: {
+					id: 'recXXX',
+					fields: {
+						foo: 'foo 1',
+						bar: 'bar 1',
+					},
+				},
+				pairedItem: {
+					item: 0,
+				},
+			},
+		]);
+	});
+
+	it('should get a record and flatten output for v2', async () => {
+		const nodeParameters = {
+			operation: 'get',
+			id: 'recXXX',
+			options: {},
+		};
+
+		const items = [{ json: {} }];
+
+		const result = await get.execute.call(
+			createMockExecuteFunction(nodeParameters, 2),
+			items,
+			'appYoLbase',
+			'tblltable',
+		);
+
+		expect(result).toEqual([
 			{
 				json: {
 					id: 'recXXX',

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/record/search.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/record/search.test.ts
@@ -43,6 +43,22 @@ jest.mock('../../../../v2/transport', () => {
 				};
 			}
 		}),
+		downloadRecordAttachments: jest.fn(async function () {
+			return [
+				{
+					json: {
+						id: 'recYYY',
+						fields: {
+							foo: 'foo 2',
+							bar: 'bar 2',
+							attachment: [{ url: 'http://example.com/file.png' }],
+						},
+					},
+					binary: { attachment_0: { data: 'binary-data' } },
+					pairedItem: [{ item: 0 }],
+				},
+			];
+		}),
 	};
 });
 
@@ -148,6 +164,84 @@ describe('Test AirtableV2, search operation', () => {
 				},
 			],
 		});
+	});
+
+	afterEach(() => jest.clearAllMocks());
+
+	it('should search records with attachments and nested fields structure for v2.2', async () => {
+		const nodeParameters = {
+			operation: 'search',
+			filterByFormula: 'foo',
+			returnAll: false,
+			limit: 1,
+			options: {
+				fields: ['foo', 'bar'],
+				downloadFields: ['attachment'],
+			},
+			sort: {},
+		};
+
+		const items = [{ json: {} }];
+
+		const result = await search.execute.call(
+			createMockExecuteFunction(nodeParameters),
+			items,
+			'appYoLbase',
+			'tblltable',
+		);
+
+		expect(transport.downloadRecordAttachments).toHaveBeenCalledTimes(1);
+		expect(result).toEqual([
+			{
+				json: {
+					id: 'recYYY',
+					fields: {
+						foo: 'foo 2',
+						bar: 'bar 2',
+						attachment: [{ url: 'http://example.com/file.png' }],
+					},
+				},
+				binary: { attachment_0: { data: 'binary-data' } },
+				pairedItem: [{ item: 0 }],
+			},
+		]);
+	});
+
+	it('should search records with attachments and flatten output for v2', async () => {
+		const nodeParameters = {
+			operation: 'search',
+			filterByFormula: 'foo',
+			returnAll: false,
+			limit: 1,
+			options: {
+				fields: ['foo', 'bar'],
+				downloadFields: ['attachment'],
+			},
+			sort: {},
+		};
+
+		const items = [{ json: {} }];
+
+		const result = await search.execute.call(
+			createMockExecuteFunction(nodeParameters, 2),
+			items,
+			'appYoLbase',
+			'tblltable',
+		);
+
+		expect(transport.downloadRecordAttachments).toHaveBeenCalledTimes(1);
+		expect(result).toEqual([
+			{
+				json: {
+					id: 'recYYY',
+					foo: 'foo 2',
+					bar: 'bar 2',
+					attachment: [{ url: 'http://example.com/file.png' }],
+				},
+				binary: { attachment_0: { data: 'binary-data' } },
+				pairedItem: [{ item: 0 }],
+			},
+		]);
 	});
 
 	it('should flatten output for v2', async () => {

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/record/search.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/record/search.test.ts
@@ -47,7 +47,7 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('Test AirtableV2, search operation', () => {
-	it('should return all records', async () => {
+	it('should return all records using nested fields structure for v2.2', async () => {
 		const nodeParameters = {
 			operation: 'search',
 			filterByFormula: 'foo',
@@ -97,7 +97,7 @@ describe('Test AirtableV2, search operation', () => {
 
 		expect(result).toHaveLength(2);
 		expect(result[0]).toEqual({
-			json: { id: 'recYYY', foo: 'foo 2', bar: 'bar 2' },
+			json: { id: 'recYYY', fields: { foo: 'foo 2', bar: 'bar 2' } },
 			pairedItem: [
 				{
 					item: 0,
@@ -106,7 +106,7 @@ describe('Test AirtableV2, search operation', () => {
 		});
 	});
 
-	it('should return all records', async () => {
+	it('should return limited records using nested fields structure for v2.2', async () => {
 		const nodeParameters = {
 			operation: 'search',
 			filterByFormula: 'foo',
@@ -137,6 +137,38 @@ describe('Test AirtableV2, search operation', () => {
 			'appYoLbase/tblltable',
 			{},
 			{ fields: ['foo', 'bar'], filterByFormula: 'foo', maxRecords: 1 },
+		);
+
+		expect(result).toHaveLength(1);
+		expect(result[0]).toEqual({
+			json: { id: 'recYYY', fields: { foo: 'foo 2', bar: 'bar 2' } },
+			pairedItem: [
+				{
+					item: 0,
+				},
+			],
+		});
+	});
+
+	it('should flatten output for v2', async () => {
+		const nodeParameters = {
+			operation: 'search',
+			filterByFormula: 'foo',
+			returnAll: false,
+			limit: 1,
+			options: {
+				fields: ['foo', 'bar'],
+			},
+			sort: {},
+		};
+
+		const items = [{ json: {} }];
+
+		const result = await search.execute.call(
+			createMockExecuteFunction(nodeParameters, 2),
+			items,
+			'appYoLbase',
+			'tblltable',
 		);
 
 		expect(result).toHaveLength(1);

--- a/packages/nodes-base/nodes/Airtable/v2/actions/record/get.operation.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/record/get.operation.ts
@@ -85,8 +85,7 @@ export async function execute(
 					[responseData] as IRecord[],
 					options.downloadFields as string[],
 				);
-				legacyFlattenRecordOutputs(itemWithAttachments, nodeVersion);
-				returnData.push(...itemWithAttachments);
+				returnData.push(...legacyFlattenRecordOutputs(itemWithAttachments, nodeVersion));
 				continue;
 			}
 

--- a/packages/nodes-base/nodes/Airtable/v2/actions/record/get.operation.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/record/get.operation.ts
@@ -8,11 +8,7 @@ import type {
 
 import { updateDisplayOptions, wrapData } from '../../../../../utils/utilities';
 import type { IRecord } from '../../helpers/interfaces';
-import {
-	flattenOutput,
-	legacyFlattenRecordOutputs,
-	processAirtableError,
-} from '../../helpers/utils';
+import { legacyFlattenOutput, processAirtableError } from '../../helpers/utils';
 import { apiRequest, downloadRecordAttachments } from '../../transport';
 
 const properties: INodeProperties[] = [
@@ -85,14 +81,16 @@ export async function execute(
 					[responseData] as IRecord[],
 					options.downloadFields as string[],
 				);
-				returnData.push(...legacyFlattenRecordOutputs(itemWithAttachments, nodeVersion));
+				returnData.push(
+					...itemWithAttachments.map((item) => ({
+						...item,
+						json: legacyFlattenOutput(item.json, nodeVersion),
+					})),
+				);
 				continue;
 			}
 
-			const output =
-				nodeVersion < 2.2
-					? flattenOutput(responseData as IDataObject)
-					: (responseData as IDataObject);
+			const output = legacyFlattenOutput(responseData as IDataObject, nodeVersion);
 
 			const executionData = this.helpers.constructExecutionMetaData(wrapData(output), {
 				itemData: { item: i },

--- a/packages/nodes-base/nodes/Airtable/v2/actions/record/get.operation.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/record/get.operation.ts
@@ -64,6 +64,7 @@ export async function execute(
 	table: string,
 ): Promise<INodeExecutionData[]> {
 	const returnData: INodeExecutionData[] = [];
+	const nodeVersion = this.getNode().typeVersion;
 
 	for (let i = 0; i < items.length; i++) {
 		let id;
@@ -80,14 +81,23 @@ export async function execute(
 					[responseData] as IRecord[],
 					options.downloadFields as string[],
 				);
+				if (nodeVersion < 2.2) {
+					for (const item of itemWithAttachments) {
+						item.json = flattenOutput(item.json);
+					}
+				}
 				returnData.push(...itemWithAttachments);
 				continue;
 			}
 
-			const executionData = this.helpers.constructExecutionMetaData(
-				wrapData(flattenOutput(responseData as IDataObject)),
-				{ itemData: { item: i } },
-			);
+			const output =
+				nodeVersion < 2.2
+					? flattenOutput(responseData as IDataObject)
+					: (responseData as IDataObject);
+
+			const executionData = this.helpers.constructExecutionMetaData(wrapData(output), {
+				itemData: { item: i },
+			});
 
 			returnData.push(...executionData);
 		} catch (error) {

--- a/packages/nodes-base/nodes/Airtable/v2/actions/record/get.operation.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/record/get.operation.ts
@@ -8,7 +8,11 @@ import type {
 
 import { updateDisplayOptions, wrapData } from '../../../../../utils/utilities';
 import type { IRecord } from '../../helpers/interfaces';
-import { flattenOutput, processAirtableError } from '../../helpers/utils';
+import {
+	flattenOutput,
+	legacyFlattenRecordOutputs,
+	processAirtableError,
+} from '../../helpers/utils';
 import { apiRequest, downloadRecordAttachments } from '../../transport';
 
 const properties: INodeProperties[] = [
@@ -81,11 +85,7 @@ export async function execute(
 					[responseData] as IRecord[],
 					options.downloadFields as string[],
 				);
-				if (nodeVersion < 2.2) {
-					for (const item of itemWithAttachments) {
-						item.json = flattenOutput(item.json);
-					}
-				}
+				legacyFlattenRecordOutputs(itemWithAttachments, nodeVersion);
 				returnData.push(...itemWithAttachments);
 				continue;
 			}

--- a/packages/nodes-base/nodes/Airtable/v2/actions/record/search.operation.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/record/search.operation.ts
@@ -210,8 +210,7 @@ export async function execute(
 					options.downloadFields as string[],
 					fallbackPairedItems || [{ item: i }],
 				);
-				legacyFlattenRecordOutputs(itemWithAttachments, nodeVersion);
-				returnData.push(...itemWithAttachments);
+				returnData.push(...legacyFlattenRecordOutputs(itemWithAttachments, nodeVersion));
 				continue;
 			}
 

--- a/packages/nodes-base/nodes/Airtable/v2/actions/record/search.operation.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/record/search.operation.ts
@@ -210,6 +210,11 @@ export async function execute(
 					options.downloadFields as string[],
 					fallbackPairedItems || [{ item: i }],
 				);
+				if (nodeVersion < 2.2) {
+					for (const item of itemWithAttachments) {
+						item.json = flattenOutput(item.json);
+					}
+				}
 				returnData.push(...itemWithAttachments);
 				continue;
 			}
@@ -217,7 +222,7 @@ export async function execute(
 			let records = responseData.records;
 
 			records = (records as IDataObject[]).map((record) => ({
-				json: flattenOutput(record),
+				json: nodeVersion < 2.2 ? flattenOutput(record) : record,
 			})) as INodeExecutionData[];
 
 			const itemData = fallbackPairedItems || [{ item: i }];

--- a/packages/nodes-base/nodes/Airtable/v2/actions/record/search.operation.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/record/search.operation.ts
@@ -7,7 +7,7 @@ import type {
 
 import { generatePairedItemData, updateDisplayOptions } from '../../../../../utils/utilities';
 import type { IRecord } from '../../helpers/interfaces';
-import { flattenOutput, legacyFlattenRecordOutputs } from '../../helpers/utils';
+import { legacyFlattenOutput } from '../../helpers/utils';
 import { apiRequest, apiRequestAllItems, downloadRecordAttachments } from '../../transport';
 import { viewRLC } from '../common.descriptions';
 
@@ -210,14 +210,19 @@ export async function execute(
 					options.downloadFields as string[],
 					fallbackPairedItems || [{ item: i }],
 				);
-				returnData.push(...legacyFlattenRecordOutputs(itemWithAttachments, nodeVersion));
+				returnData.push(
+					...itemWithAttachments.map((item) => ({
+						...item,
+						json: legacyFlattenOutput(item.json, nodeVersion),
+					})),
+				);
 				continue;
 			}
 
 			let records = responseData.records;
 
 			records = (records as IDataObject[]).map((record) => ({
-				json: nodeVersion < 2.2 ? flattenOutput(record) : record,
+				json: legacyFlattenOutput(record, nodeVersion),
 			})) as INodeExecutionData[];
 
 			const itemData = fallbackPairedItems || [{ item: i }];

--- a/packages/nodes-base/nodes/Airtable/v2/actions/record/search.operation.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/record/search.operation.ts
@@ -7,7 +7,7 @@ import type {
 
 import { generatePairedItemData, updateDisplayOptions } from '../../../../../utils/utilities';
 import type { IRecord } from '../../helpers/interfaces';
-import { flattenOutput } from '../../helpers/utils';
+import { flattenOutput, legacyFlattenRecordOutputs } from '../../helpers/utils';
 import { apiRequest, apiRequestAllItems, downloadRecordAttachments } from '../../transport';
 import { viewRLC } from '../common.descriptions';
 
@@ -210,11 +210,7 @@ export async function execute(
 					options.downloadFields as string[],
 					fallbackPairedItems || [{ item: i }],
 				);
-				if (nodeVersion < 2.2) {
-					for (const item of itemWithAttachments) {
-						item.json = flattenOutput(item.json);
-					}
-				}
+				legacyFlattenRecordOutputs(itemWithAttachments, nodeVersion);
 				returnData.push(...itemWithAttachments);
 				continue;
 			}

--- a/packages/nodes-base/nodes/Airtable/v2/actions/versionDescription.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/versionDescription.ts
@@ -9,7 +9,7 @@ export const versionDescription: INodeTypeDescription = {
 	name: 'airtable',
 	icon: 'file:airtable.svg',
 	group: ['input'],
-	version: [2, 2.1],
+	version: [2, 2.1, 2.2],
 	subtitle: '={{ $parameter["operation"] + ": " + $parameter["resource"] }}',
 	description: 'Read, update, write and delete data from Airtable',
 	defaults: {

--- a/packages/nodes-base/nodes/Airtable/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/helpers/utils.ts
@@ -96,10 +96,10 @@ export const flattenOutput = (record: IDataObject) => {
 	};
 };
 
-export function legacyFlattenRecordOutputs(items: INodeExecutionData[], nodeVersion: number) {
-	if (nodeVersion < 2.2) {
-		for (const item of items) {
-			item.json = flattenOutput(item.json);
-		}
-	}
+export function legacyFlattenRecordOutputs(
+	items: INodeExecutionData[],
+	nodeVersion: number,
+): INodeExecutionData[] {
+	if (nodeVersion >= 2.2) return items;
+	return items.map((item) => ({ ...item, json: flattenOutput(item.json) }));
 }

--- a/packages/nodes-base/nodes/Airtable/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/helpers/utils.ts
@@ -1,10 +1,5 @@
 import set from 'lodash/set';
-import {
-	ApplicationError,
-	type IDataObject,
-	type INodeExecutionData,
-	type NodeApiError,
-} from 'n8n-workflow';
+import { ApplicationError, type IDataObject, type NodeApiError } from 'n8n-workflow';
 
 import type { UpdateRecord } from './interfaces';
 
@@ -88,18 +83,11 @@ export function processAirtableError(error: NodeApiError, id?: string, itemIndex
 	return error;
 }
 
-export const flattenOutput = (record: IDataObject) => {
+export function legacyFlattenOutput(record: IDataObject, nodeVersion: number): IDataObject {
+	if (nodeVersion >= 2.2) return record;
 	const { fields, ...rest } = record;
 	return {
 		...rest,
 		...(fields as IDataObject),
 	};
-};
-
-export function legacyFlattenRecordOutputs(
-	items: INodeExecutionData[],
-	nodeVersion: number,
-): INodeExecutionData[] {
-	if (nodeVersion >= 2.2) return items;
-	return items.map((item) => ({ ...item, json: flattenOutput(item.json) }));
 }

--- a/packages/nodes-base/nodes/Airtable/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/helpers/utils.ts
@@ -1,5 +1,10 @@
 import set from 'lodash/set';
-import { ApplicationError, type IDataObject, type NodeApiError } from 'n8n-workflow';
+import {
+	ApplicationError,
+	type IDataObject,
+	type INodeExecutionData,
+	type NodeApiError,
+} from 'n8n-workflow';
 
 import type { UpdateRecord } from './interfaces';
 
@@ -90,3 +95,11 @@ export const flattenOutput = (record: IDataObject) => {
 		...(fields as IDataObject),
 	};
 };
+
+export function legacyFlattenRecordOutputs(items: INodeExecutionData[], nodeVersion: number) {
+	if (nodeVersion < 2.2) {
+		for (const item of items) {
+			item.json = flattenOutput(item.json);
+		}
+	}
+}

--- a/packages/nodes-base/nodes/Airtable/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/transport/index.ts
@@ -12,7 +12,6 @@ import type {
 import { ApplicationError } from '@n8n/errors';
 
 import type { IAttachment, IRecord } from '../helpers/interfaces';
-import { flattenOutput } from '../helpers/utils';
 
 /**
  * Make an API request to Airtable
@@ -105,7 +104,7 @@ export async function downloadRecordAttachments(
 		if (pairedItem) {
 			element.pairedItem = pairedItem;
 		}
-		element.json = flattenOutput(record as unknown as IDataObject);
+		element.json = record as unknown as IDataObject;
 		for (const fieldName of fieldNames) {
 			if (record.fields[fieldName] !== undefined) {
 				for (const [index, attachment] of (record.fields[fieldName] as IAttachment[]).entries()) {


### PR DESCRIPTION
## Summary

In v2 of the Airtable node, we started flattening the output form the Search and Get operations. If the table contains an `id` column it will overwrite the built-in `id` of the airtable element which users might need for deletion operations. This PR brings back the old behavior which nests all table fields under `fields`,  while the built-in `id` remains outside.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-4030/bug-airtable-node-search-operation-not-returning-element-id-rec

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
