### PR TITLE
feat(Linear Node): Add v2 with 12 resources and 52 operations

### DIFF
--- a/packages/nodes-base/nodes/Linear/v2/LinearTriggerV2.node.ts
+++ b/packages/nodes-base/nodes/Linear/v2/LinearTriggerV2.node.ts
@@ -1,0 +1,311 @@
+import {
+	type IHookFunctions,
+	type IWebhookFunctions,
+	type ILoadOptionsFunctions,
+	type INodePropertyOptions,
+	type INodeType,
+	type INodeTypeBaseDescription,
+	type INodeTypeDescription,
+	type IWebhookResponseData,
+	type IDataObject,
+	NodeConnectionTypes,
+} from 'n8n-workflow';
+
+import { capitalizeFirstLetter, linearApiRequest } from '../shared/GenericFunctions';
+
+export class LinearTriggerV2 implements INodeType {
+	description: INodeTypeDescription;
+
+	constructor(baseDescription: INodeTypeBaseDescription) {
+		this.description = {
+			...baseDescription,
+			displayName: 'Linear Trigger',
+			name: 'linearTrigger',
+			icon: 'file:linear.svg',
+			group: ['trigger'],
+			version: 2,
+			subtitle: '={{$parameter["triggerOn"]}}',
+			description: 'Starts the workflow when Linear events occur',
+			defaults: {
+				name: 'Linear Trigger',
+			},
+			inputs: [],
+			outputs: [NodeConnectionTypes.Main],
+			credentials: [
+				{
+					name: 'linearApi',
+					required: true,
+					testedBy: 'linearApiTest',
+					displayOptions: {
+						show: {
+							authentication: ['apiToken'],
+						},
+					},
+				},
+				{
+					name: 'linearOAuth2Api',
+					required: true,
+					displayOptions: {
+						show: {
+							authentication: ['oAuth2'],
+						},
+					},
+				},
+			],
+			webhooks: [
+				{
+					name: 'default',
+					httpMethod: 'POST',
+					responseMode: 'onReceived',
+					path: 'webhook',
+				},
+			],
+			properties: [
+				{
+					displayName: 'Authentication',
+					name: 'authentication',
+					type: 'options',
+					options: [
+						{
+							name: 'API Token',
+							value: 'apiToken',
+						},
+						{
+							name: 'OAuth2',
+							value: 'oAuth2',
+						},
+					],
+					default: 'apiToken',
+				},
+				{
+					displayName: 'Make sure your credential has the "Admin" scope to create webhooks.',
+					name: 'notice',
+					type: 'notice',
+					default: '',
+				},
+				{
+					displayName: 'Team Name or ID',
+					name: 'teamId',
+					type: 'options',
+					description:
+						'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					typeOptions: {
+						loadOptionsMethod: 'getTeams',
+					},
+					default: '',
+				},
+				{
+					displayName: 'Listen to Resources',
+					name: 'resources',
+					type: 'multiOptions',
+					options: [
+						{
+							name: 'Attachment',
+							value: 'attachment',
+						},
+						{
+							name: 'Comment Reaction',
+							value: 'reaction',
+						},
+						{
+							name: 'Cycle',
+							value: 'cycle',
+						},
+						{
+							name: 'Document',
+							value: 'document',
+						},
+						{
+							name: 'Issue',
+							value: 'issue',
+						},
+						{
+							name: 'Issue Comment',
+							value: 'comment',
+						},
+						{
+							name: 'Issue Label',
+							value: 'issueLabel',
+						},
+						{
+							name: 'Project',
+							value: 'project',
+						},
+						{
+							name: 'Roadmap',
+							value: 'roadmap',
+						},
+						{
+							name: 'Team Membership',
+							value: 'teamMembership',
+						},
+					],
+					default: [],
+					required: true,
+				},
+			],
+		};
+	}
+
+	methods = {
+		loadOptions: {
+			async getTeams(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+				const returnData: INodePropertyOptions[] = [];
+				const body = {
+					query: `query Teams {
+						 teams {
+							nodes {
+								id
+								name
+							}
+						}
+					}`,
+				};
+				const {
+					data: {
+						teams: { nodes },
+					},
+				} = (await linearApiRequest.call(this, body)) as {
+					data: { teams: { nodes: Array<{ id: string; name: string }> } };
+				};
+
+				for (const node of nodes) {
+					returnData.push({
+						name: node.name,
+						value: node.id,
+					});
+				}
+				return returnData;
+			},
+		},
+	};
+
+	webhookMethods = {
+		default: {
+			async checkExists(this: IHookFunctions): Promise<boolean> {
+				const webhookUrl = this.getNodeWebhookUrl('default');
+				const webhookData = this.getWorkflowStaticData('node');
+				const teamId = this.getNodeParameter('teamId') as string;
+				const body = {
+					query: `query {
+						 webhooks {
+								nodes {
+									id
+									url
+									enabled
+									team {
+										id
+										name
+									}
+								}
+						}
+					}`,
+				};
+				const {
+					data: {
+						webhooks: { nodes },
+					},
+				} = (await linearApiRequest.call(this, body)) as {
+					data: {
+						webhooks: {
+							nodes: Array<{ id: string; url: string; enabled: boolean; team: { id: string } }>;
+						};
+					};
+				};
+
+				for (const node of nodes) {
+					if (node.url === webhookUrl && node.team.id === teamId && node.enabled === true) {
+						webhookData.webhookId = node.id as string;
+						return true;
+					}
+				}
+				return false;
+			},
+			async create(this: IHookFunctions): Promise<boolean> {
+				const webhookData = this.getWorkflowStaticData('node');
+				const webhookUrl = this.getNodeWebhookUrl('default');
+				const teamId = this.getNodeParameter('teamId') as string;
+				const resources = this.getNodeParameter('resources') as string[];
+				const body = {
+					query: `
+						mutation webhookCreate($url: String!, $teamId: String!, $resources: [String!]!) {
+							webhookCreate(
+								input: {
+									url: $url
+									teamId: $teamId
+									resourceTypes: $resources
+								}
+							) {
+								success
+								webhook {
+									id
+									enabled
+								}
+							}
+						}`,
+					variables: {
+						url: webhookUrl,
+						teamId,
+						resources: resources.map(capitalizeFirstLetter),
+					},
+				};
+
+				const {
+					data: {
+						webhookCreate: {
+							success,
+							webhook: { id },
+						},
+					},
+				} = (await linearApiRequest.call(this, body)) as {
+					data: {
+						webhookCreate: {
+							success: boolean;
+							webhook: { id: string; enabled: boolean };
+						};
+					};
+				};
+
+				if (!success) {
+					return false;
+				}
+				webhookData.webhookId = id as string;
+
+				return true;
+			},
+			async delete(this: IHookFunctions): Promise<boolean> {
+				const webhookData = this.getWorkflowStaticData('node');
+				if (webhookData.webhookId !== undefined) {
+					const body = {
+						query: `
+							mutation webhookDelete($id: String!){
+								webhookDelete(
+									id: $id
+								) {
+									success
+								}
+							}`,
+						variables: {
+							id: webhookData.webhookId,
+						},
+					};
+
+					try {
+						await linearApiRequest.call(this, body as IDataObject);
+					} catch (error) {
+						return false;
+					}
+					delete webhookData.webhookId;
+				}
+				return true;
+			},
+		},
+	};
+
+	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
+		const bodyData = this.getBodyData();
+		return {
+			workflowData: [this.helpers.returnJsonArray(bodyData)],
+		};
+	}
+}

--- a/packages/nodes-base/nodes/Linear/v2/LinearV2.node.ts
+++ b/packages/nodes-base/nodes/Linear/v2/LinearV2.node.ts
@@ -1,0 +1,79 @@
+import type {
+	ICredentialDataDecryptedObject,
+	ICredentialsDecrypted,
+	ICredentialTestFunctions,
+	IExecuteFunctions,
+	INodeCredentialTestResult,
+	INodeExecutionData,
+	INodeType,
+	INodeTypeBaseDescription,
+	INodeTypeDescription,
+	JsonObject,
+	IDataObject,
+} from 'n8n-workflow';
+
+import { router } from './actions/router';
+import { versionDescription } from './actions/versionDescription';
+import {
+	getTeams,
+	getUsers,
+	getStates,
+	getLabels,
+	getProjects,
+	getCycles,
+} from '../shared/methods/loadOptions';
+import { validateCredentials } from '../shared/GenericFunctions';
+
+export class LinearV2 implements INodeType {
+	description: INodeTypeDescription;
+
+	constructor(baseDescription: INodeTypeBaseDescription) {
+		this.description = {
+			...baseDescription,
+			...versionDescription,
+			usableAsTool: true,
+		};
+	}
+
+	methods = {
+		credentialTest: {
+			async linearApiTest(
+				this: ICredentialTestFunctions,
+				credential: ICredentialsDecrypted,
+			): Promise<INodeCredentialTestResult> {
+				try {
+					await validateCredentials.call(this, credential.data as ICredentialDataDecryptedObject);
+				} catch (error) {
+					const { error: err } = error as JsonObject;
+					const errors = (err as IDataObject).errors as [{ extensions: { code: string } }];
+					const authenticationError = Boolean(
+						errors?.filter((e) => e.extensions.code === 'AUTHENTICATION_ERROR').length,
+					);
+					if (authenticationError) {
+						return {
+							status: 'Error',
+							message: 'The security token included in the request is invalid',
+						};
+					}
+				}
+
+				return {
+					status: 'OK',
+					message: 'Connection successful!',
+				};
+			},
+		},
+		loadOptions: {
+			getTeams,
+			getUsers,
+			getStates,
+			getLabels,
+			getProjects,
+			getCycles,
+		},
+	};
+
+	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+		return await router.call(this);
+	}
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/attachment/create.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/attachment/create.operation.ts
@@ -1,0 +1,125 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Issue ID',
+		name: 'issueId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'URL',
+		name: 'url',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'The URL to attach to the issue',
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		options: [
+			{
+				displayName: 'Title',
+				name: 'title',
+				type: 'string',
+				default: '',
+				description: 'The attachment title',
+			},
+			{
+				displayName: 'Subtitle',
+				name: 'subtitle',
+				type: 'string',
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['attachment'],
+		operation: ['create'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const issueId = this.getNodeParameter('issueId', i) as string;
+			const url = this.getNodeParameter('url', i) as string;
+			const additionalFields = this.getNodeParameter('additionalFields', i) as Record<
+				string,
+				unknown
+			>;
+
+			const body = {
+				query: `mutation AttachmentCreate($issueId: String!, $url: String!, $title: String, $subtitle: String) {
+					attachmentCreate(input: {
+						issueId: $issueId
+						url: $url
+						title: $title
+						subtitle: $subtitle
+					}) {
+						success
+						attachment {
+							id
+							url
+							title
+							subtitle
+							createdAt
+							updatedAt
+						}
+					}
+				}`,
+				variables: {
+					issueId,
+					url,
+					...additionalFields,
+				},
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const attachment = (
+				responseData as { data: { attachmentCreate: { attachment: IDataObject } } }
+			).data.attachmentCreate?.attachment;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(attachment), {
+					itemData: { item: i },
+				}),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/attachment/delete.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/attachment/delete.operation.ts
@@ -1,0 +1,72 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Attachment ID',
+		name: 'attachmentId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['attachment'],
+		operation: ['delete'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const attachmentId = this.getNodeParameter('attachmentId', i) as string;
+
+			const body = {
+				query: `mutation AttachmentDelete($attachmentId: String!) {
+					attachmentDelete(id: $attachmentId) {
+						success
+					}
+				}`,
+				variables: { attachmentId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const result = (responseData as { data: { attachmentDelete: IDataObject } }).data
+				.attachmentDelete;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(result), {
+					itemData: { item: i },
+				}),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/attachment/get.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/attachment/get.operation.ts
@@ -1,0 +1,81 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Attachment ID',
+		name: 'attachmentId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['attachment'],
+		operation: ['get'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const attachmentId = this.getNodeParameter('attachmentId', i) as string;
+
+			const body = {
+				query: `query Attachment($attachmentId: String!) {
+					attachment(id: $attachmentId) {
+						id
+						url
+						title
+						subtitle
+						createdAt
+						updatedAt
+						issue {
+							id
+							identifier
+							title
+						}
+					}
+				}`,
+				variables: { attachmentId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const attachment = (responseData as { data: { attachment: IDataObject } }).data.attachment;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(attachment), {
+					itemData: { item: i },
+				}),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/attachment/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/attachment/getAll.operation.ts
@@ -1,0 +1,95 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+
+import { linearApiRequestAllItems } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Issue ID',
+		name: 'issueId',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'The ID of the issue to get attachments for',
+	},
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: { minValue: 1 },
+		displayOptions: { show: { returnAll: [false] } },
+		description: 'Max number of results to return',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['attachment'],
+		operation: ['getAll'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	_items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+	const issueId = this.getNodeParameter('issueId', 0) as string;
+	const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
+	const limit = returnAll ? undefined : (this.getNodeParameter('limit', 0) as number);
+
+	const body = {
+		query: `query IssueAttachments($issueId: String!, $first: Int, $after: String) {
+			issue(id: $issueId) {
+				attachments(first: $first, after: $after) {
+					nodes {
+						id
+						url
+						title
+						subtitle
+						createdAt
+						updatedAt
+					}
+					pageInfo { hasNextPage endCursor }
+				}
+			}
+		}`,
+		variables: { issueId, first: 50 },
+	};
+
+	try {
+		const attachments = await linearApiRequestAllItems.call(
+			this,
+			'data.issue.attachments',
+			body,
+			limit,
+		);
+		returnData.push(
+			...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(attachments), {
+				itemData: { item: 0 },
+			}),
+		);
+	} catch (error) {
+		if (this.continueOnFail()) {
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ error: (error as Error).message }),
+					{ itemData: { item: 0 } },
+				),
+			);
+		} else {
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/attachment/index.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/attachment/index.ts
@@ -1,0 +1,53 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as create from './create.operation';
+import * as deleteAttachment from './delete.operation';
+import * as get from './get.operation';
+import * as getAll from './getAll.operation';
+
+export { create, deleteAttachment as delete, get, getAll };
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['attachment'],
+			},
+		},
+		options: [
+			{
+				name: 'Create',
+				value: 'create',
+				description: 'Create an attachment',
+				action: 'Create an attachment',
+			},
+			{
+				name: 'Delete',
+				value: 'delete',
+				description: 'Delete an attachment',
+				action: 'Delete an attachment',
+			},
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get an attachment',
+				action: 'Get an attachment',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get attachments for an issue',
+				action: 'Get many attachments',
+			},
+		],
+		default: 'getAll',
+	},
+	...create.description,
+	...deleteAttachment.description,
+	...get.description,
+	...getAll.description,
+];

--- a/packages/nodes-base/nodes/Linear/v2/actions/comment/create.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/comment/create.operation.ts
@@ -1,0 +1,117 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Issue ID',
+		name: 'issueId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'Body',
+		name: 'body',
+		type: 'string',
+		required: true,
+		typeOptions: { rows: 4 },
+		default: '',
+		description: 'The comment body in markdown format',
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		options: [
+			{
+				displayName: 'Parent Comment ID',
+				name: 'parentId',
+				type: 'string',
+				description: 'ID of the parent comment if this is a reply',
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['comment'],
+		operation: ['create'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const issueId = this.getNodeParameter('issueId', i) as string;
+			const body = this.getNodeParameter('body', i) as string;
+			const additionalFields = this.getNodeParameter('additionalFields', i) as Record<
+				string,
+				unknown
+			>;
+
+			const variables: IDataObject = { issueId, body };
+			if (additionalFields.parentId && (additionalFields.parentId as string).trim() !== '') {
+				variables.parentId = additionalFields.parentId;
+			}
+
+			const requestBody = {
+				query: `mutation CommentCreate($issueId: String!, $body: String!, $parentId: String) {
+					commentCreate(input: { issueId: $issueId, body: $body, parentId: $parentId }) {
+						success
+						comment {
+							id
+							body
+							createdAt
+							updatedAt
+							user {
+								id
+								displayName
+							}
+						}
+					}
+				}`,
+				variables,
+			};
+
+			const responseData = await linearApiRequest.call(this, requestBody);
+			const result = (responseData as { data: { commentCreate: IDataObject } }).data.commentCreate;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(result),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/comment/delete.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/comment/delete.operation.ts
@@ -1,0 +1,72 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Comment ID',
+		name: 'commentId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['comment'],
+		operation: ['delete'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const commentId = this.getNodeParameter('commentId', i) as string;
+
+			const body = {
+				query: `mutation CommentDelete($commentId: String!) {
+					commentDelete(id: $commentId) {
+						success
+					}
+				}`,
+				variables: { commentId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const result = (responseData as { data: { commentDelete: IDataObject } }).data.commentDelete;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(result),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/comment/get.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/comment/get.operation.ts
@@ -1,0 +1,85 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Comment ID',
+		name: 'commentId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['comment'],
+		operation: ['get'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const commentId = this.getNodeParameter('commentId', i) as string;
+
+			const body = {
+				query: `query Comment($commentId: String!) {
+					comment(id: $commentId) {
+						id
+						body
+						createdAt
+						updatedAt
+						user {
+							id
+							displayName
+							email
+						}
+						issue {
+							id
+							identifier
+							title
+						}
+					}
+				}`,
+				variables: { commentId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const comment = (responseData as { data: { comment: IDataObject } }).data.comment;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(comment),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/comment/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/comment/getAll.operation.ts
@@ -1,0 +1,104 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+
+import { linearApiRequestAllItems } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Issue ID',
+		name: 'issueId',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'The ID of the issue to get comments for',
+	},
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: { minValue: 1 },
+		displayOptions: {
+			show: { returnAll: [false] },
+		},
+		description: 'Max number of results to return',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['comment'],
+		operation: ['getAll'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	_items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	const issueId = this.getNodeParameter('issueId', 0) as string;
+	const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
+	const limit = returnAll ? undefined : (this.getNodeParameter('limit', 0) as number);
+
+	const body = {
+		query: `query IssueComments($issueId: String!, $first: Int, $after: String) {
+			issue(id: $issueId) {
+				comments(first: $first, after: $after) {
+					nodes {
+						id
+						body
+						createdAt
+						updatedAt
+						user {
+							id
+							displayName
+							email
+						}
+					}
+					pageInfo {
+						hasNextPage
+						endCursor
+					}
+				}
+			}
+		}`,
+		variables: {
+			issueId,
+			first: 50,
+		},
+	};
+
+	try {
+		const comments = await linearApiRequestAllItems.call(this, 'data.issue.comments', body, limit);
+
+		const executionData = this.helpers.constructExecutionMetaData(
+			this.helpers.returnJsonArray(comments),
+			{ itemData: { item: 0 } },
+		);
+		returnData.push(...executionData);
+	} catch (error) {
+		if (this.continueOnFail()) {
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ error: (error as Error).message }),
+					{ itemData: { item: 0 } },
+				),
+			);
+		} else {
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/comment/index.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/comment/index.ts
@@ -1,0 +1,61 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as create from './create.operation';
+import * as deleteComment from './delete.operation';
+import * as get from './get.operation';
+import * as getAll from './getAll.operation';
+import * as update from './update.operation';
+
+export { create, deleteComment as delete, get, getAll, update };
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['comment'],
+			},
+		},
+		options: [
+			{
+				name: 'Create',
+				value: 'create',
+				description: 'Create a comment',
+				action: 'Create a comment',
+			},
+			{
+				name: 'Delete',
+				value: 'delete',
+				description: 'Delete a comment',
+				action: 'Delete a comment',
+			},
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a comment',
+				action: 'Get a comment',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get comments for an issue',
+				action: 'Get many comments',
+			},
+			{
+				name: 'Update',
+				value: 'update',
+				description: 'Update a comment',
+				action: 'Update a comment',
+			},
+		],
+		default: 'create',
+	},
+	...create.description,
+	...deleteComment.description,
+	...get.description,
+	...getAll.description,
+	...update.description,
+];

--- a/packages/nodes-base/nodes/Linear/v2/actions/comment/update.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/comment/update.operation.ts
@@ -1,0 +1,92 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Comment ID',
+		name: 'commentId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'Body',
+		name: 'body',
+		type: 'string',
+		required: true,
+		typeOptions: { rows: 4 },
+		default: '',
+		description: 'The new comment body in markdown format',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['comment'],
+		operation: ['update'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const commentId = this.getNodeParameter('commentId', i) as string;
+			const body = this.getNodeParameter('body', i) as string;
+
+			const requestBody = {
+				query: `mutation CommentUpdate($commentId: String!, $body: String!) {
+					commentUpdate(id: $commentId, input: { body: $body }) {
+						success
+						comment {
+							id
+							body
+							createdAt
+							updatedAt
+							user {
+								id
+								displayName
+							}
+						}
+					}
+				}`,
+				variables: { commentId, body },
+			};
+
+			const responseData = await linearApiRequest.call(this, requestBody);
+			const result = (responseData as { data: { commentUpdate: IDataObject } }).data.commentUpdate;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(result),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/cycle/archive.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/cycle/archive.operation.ts
@@ -1,0 +1,71 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Cycle ID',
+		name: 'cycleId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['cycle'],
+		operation: ['archive'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const cycleId = this.getNodeParameter('cycleId', i) as string;
+
+			const body = {
+				query: `mutation CycleArchive($cycleId: String!) {
+					cycleArchive(id: $cycleId) {
+						success
+					}
+				}`,
+				variables: { cycleId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const result = (responseData as { data: { cycleArchive: IDataObject } }).data.cycleArchive;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(result), {
+					itemData: { item: i },
+				}),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/cycle/create.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/cycle/create.operation.ts
@@ -1,0 +1,130 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Team Name or ID',
+		name: 'teamId',
+		type: 'options',
+		required: true,
+		description:
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+		typeOptions: { loadOptionsMethod: 'getTeams' },
+		default: '',
+	},
+	{
+		displayName: 'Start Date',
+		name: 'startsAt',
+		type: 'dateTime',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'End Date',
+		name: 'endsAt',
+		type: 'dateTime',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		options: [
+			{
+				displayName: 'Name',
+				name: 'name',
+				type: 'string',
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['cycle'],
+		operation: ['create'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const teamId = this.getNodeParameter('teamId', i) as string;
+			const startsAt = this.getNodeParameter('startsAt', i) as string;
+			const endsAt = this.getNodeParameter('endsAt', i) as string;
+			const additionalFields = this.getNodeParameter('additionalFields', i) as Record<
+				string,
+				unknown
+			>;
+
+			const body = {
+				query: `mutation CycleCreate($teamId: String!, $startsAt: DateTime!, $endsAt: DateTime!, $name: String) {
+					cycleCreate(input: {
+						teamId: $teamId
+						startsAt: $startsAt
+						endsAt: $endsAt
+						name: $name
+					}) {
+						success
+						cycle {
+							id
+							name
+							number
+							startsAt
+							endsAt
+							createdAt
+							updatedAt
+						}
+					}
+				}`,
+				variables: {
+					teamId,
+					startsAt,
+					endsAt,
+					...additionalFields,
+				},
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const cycle = (responseData as { data: { cycleCreate: { cycle: IDataObject } } }).data
+				.cycleCreate?.cycle;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(cycle),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/cycle/delete.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/cycle/delete.operation.ts
@@ -1,0 +1,71 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Cycle ID',
+		name: 'cycleId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['cycle'],
+		operation: ['delete'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const cycleId = this.getNodeParameter('cycleId', i) as string;
+
+			const body = {
+				query: `mutation CycleDelete($cycleId: String!) {
+					cycleArchive(id: $cycleId) {
+						success
+					}
+				}`,
+				variables: { cycleId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const result = (responseData as { data: { cycleArchive: IDataObject } }).data.cycleArchive;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(result), {
+					itemData: { item: i },
+				}),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/cycle/get.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/cycle/get.operation.ts
@@ -1,0 +1,83 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Cycle ID',
+		name: 'cycleId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['cycle'],
+		operation: ['get'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const cycleId = this.getNodeParameter('cycleId', i) as string;
+
+			const body = {
+				query: `query Cycle($cycleId: String!) {
+					cycle(id: $cycleId) {
+						id
+						name
+						number
+						startsAt
+						endsAt
+						archivedAt
+						createdAt
+						updatedAt
+						team {
+							id
+							name
+						}
+					}
+				}`,
+				variables: { cycleId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const cycle = (responseData as { data: { cycle: IDataObject } }).data.cycle;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(cycle),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/cycle/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/cycle/getAll.operation.ts
@@ -1,0 +1,85 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+
+import { linearApiRequestAllItems } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: { minValue: 1 },
+		displayOptions: { show: { returnAll: [false] } },
+		description: 'Max number of results to return',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['cycle'],
+		operation: ['getAll'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	_items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+	const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
+	const limit = returnAll ? undefined : (this.getNodeParameter('limit', 0) as number);
+
+	const body = {
+		query: `query Cycles($first: Int, $after: String) {
+			cycles(first: $first, after: $after) {
+				nodes {
+					id
+					name
+					number
+					startsAt
+					endsAt
+					archivedAt
+					createdAt
+					updatedAt
+					team {
+						id
+						name
+					}
+				}
+				pageInfo { hasNextPage endCursor }
+			}
+		}`,
+		variables: { first: 50 },
+	};
+
+	try {
+		const cycles = await linearApiRequestAllItems.call(this, 'data.cycles', body, limit);
+		returnData.push(
+			...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(cycles), {
+				itemData: { item: 0 },
+			}),
+		);
+	} catch (error) {
+		if (this.continueOnFail()) {
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ error: (error as Error).message }),
+					{ itemData: { item: 0 } },
+				),
+			);
+		} else {
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/cycle/index.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/cycle/index.ts
@@ -1,0 +1,69 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as archive from './archive.operation';
+import * as create from './create.operation';
+import * as deleteCycle from './delete.operation';
+import * as get from './get.operation';
+import * as getAll from './getAll.operation';
+import * as update from './update.operation';
+
+export { archive, create, deleteCycle as delete, get, getAll, update };
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['cycle'],
+			},
+		},
+		options: [
+			{
+				name: 'Archive',
+				value: 'archive',
+				description: 'Archive a cycle',
+				action: 'Archive a cycle',
+			},
+			{
+				name: 'Create',
+				value: 'create',
+				description: 'Create a cycle',
+				action: 'Create a cycle',
+			},
+			{
+				name: 'Delete',
+				value: 'delete',
+				description: 'Delete a cycle',
+				action: 'Delete a cycle',
+			},
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a cycle',
+				action: 'Get a cycle',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get many cycles',
+				action: 'Get many cycles',
+			},
+			{
+				name: 'Update',
+				value: 'update',
+				description: 'Update a cycle',
+				action: 'Update a cycle',
+			},
+		],
+		default: 'getAll',
+	},
+	...archive.description,
+	...create.description,
+	...deleteCycle.description,
+	...get.description,
+	...getAll.description,
+	...update.description,
+];

--- a/packages/nodes-base/nodes/Linear/v2/actions/cycle/update.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/cycle/update.operation.ts
@@ -1,0 +1,112 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Cycle ID',
+		name: 'cycleId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'Update Fields',
+		name: 'updateFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		options: [
+			{
+				displayName: 'End Date',
+				name: 'endsAt',
+				type: 'dateTime',
+				default: '',
+			},
+			{
+				displayName: 'Name',
+				name: 'name',
+				type: 'string',
+				default: '',
+			},
+			{
+				displayName: 'Start Date',
+				name: 'startsAt',
+				type: 'dateTime',
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['cycle'],
+		operation: ['update'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const cycleId = this.getNodeParameter('cycleId', i) as string;
+			const updateFields = this.getNodeParameter('updateFields', i) as IDataObject;
+
+			const body = {
+				query: `mutation CycleUpdate($cycleId: String!, $name: String, $startsAt: DateTime, $endsAt: DateTime) {
+					cycleUpdate(id: $cycleId, input: {
+						name: $name
+						startsAt: $startsAt
+						endsAt: $endsAt
+					}) {
+						success
+						cycle {
+							id
+							name
+							number
+							startsAt
+							endsAt
+							updatedAt
+						}
+					}
+				}`,
+				variables: { cycleId, ...updateFields },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const cycle = (responseData as { data: { cycleUpdate: { cycle: IDataObject } } }).data
+				.cycleUpdate?.cycle;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(cycle), {
+					itemData: { item: i },
+				}),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/document/create.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/document/create.operation.ts
@@ -1,0 +1,113 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Title',
+		name: 'title',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		options: [
+			{
+				displayName: 'Content',
+				name: 'content',
+				type: 'string',
+				typeOptions: { rows: 4 },
+				default: '',
+				description: 'The document content in markdown format',
+			},
+			{
+				displayName: 'Project Name or ID',
+				name: 'projectId',
+				type: 'options',
+				description:
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: { loadOptionsMethod: 'getProjects' },
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['document'],
+		operation: ['create'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const title = this.getNodeParameter('title', i) as string;
+			const additionalFields = this.getNodeParameter('additionalFields', i) as Record<
+				string,
+				unknown
+			>;
+
+			const body = {
+				query: `mutation DocumentCreate($title: String!, $content: String, $projectId: String) {
+					documentCreate(input: {
+						title: $title
+						content: $content
+						projectId: $projectId
+					}) {
+						success
+						document {
+							id
+							title
+							content
+							createdAt
+							updatedAt
+						}
+					}
+				}`,
+				variables: { title, ...additionalFields },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const document = (responseData as { data: { documentCreate: { document: IDataObject } } })
+				.data.documentCreate?.document;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(document), {
+					itemData: { item: i },
+				}),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/document/delete.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/document/delete.operation.ts
@@ -1,0 +1,72 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Document ID',
+		name: 'documentId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['document'],
+		operation: ['delete'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const documentId = this.getNodeParameter('documentId', i) as string;
+
+			const body = {
+				query: `mutation DocumentDelete($documentId: String!) {
+					documentDelete(id: $documentId) {
+						success
+					}
+				}`,
+				variables: { documentId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const result = (responseData as { data: { documentDelete: IDataObject } }).data
+				.documentDelete;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(result), {
+					itemData: { item: i },
+				}),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/document/get.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/document/get.operation.ts
@@ -1,0 +1,79 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Document ID',
+		name: 'documentId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['document'],
+		operation: ['get'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const documentId = this.getNodeParameter('documentId', i) as string;
+
+			const body = {
+				query: `query Document($documentId: String!) {
+					document(id: $documentId) {
+						id
+						title
+						content
+						createdAt
+						updatedAt
+						project {
+							id
+							name
+						}
+					}
+				}`,
+				variables: { documentId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const document = (responseData as { data: { document: IDataObject } }).data.document;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(document), {
+					itemData: { item: i },
+				}),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/document/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/document/getAll.operation.ts
@@ -1,0 +1,82 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+
+import { linearApiRequestAllItems } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: { minValue: 1 },
+		displayOptions: { show: { returnAll: [false] } },
+		description: 'Max number of results to return',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['document'],
+		operation: ['getAll'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	_items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+	const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
+	const limit = returnAll ? undefined : (this.getNodeParameter('limit', 0) as number);
+
+	const body = {
+		query: `query Documents($first: Int, $after: String) {
+			documents(first: $first, after: $after) {
+				nodes {
+					id
+					title
+					content
+					createdAt
+					updatedAt
+					project {
+						id
+						name
+					}
+				}
+				pageInfo { hasNextPage endCursor }
+			}
+		}`,
+		variables: { first: 50 },
+	};
+
+	try {
+		const documents = await linearApiRequestAllItems.call(this, 'data.documents', body, limit);
+		returnData.push(
+			...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(documents), {
+				itemData: { item: 0 },
+			}),
+		);
+	} catch (error) {
+		if (this.continueOnFail()) {
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ error: (error as Error).message }),
+					{ itemData: { item: 0 } },
+				),
+			);
+		} else {
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/document/index.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/document/index.ts
@@ -1,0 +1,61 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as create from './create.operation';
+import * as deleteDocument from './delete.operation';
+import * as get from './get.operation';
+import * as getAll from './getAll.operation';
+import * as update from './update.operation';
+
+export { create, deleteDocument as delete, get, getAll, update };
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['document'],
+			},
+		},
+		options: [
+			{
+				name: 'Create',
+				value: 'create',
+				description: 'Create a document',
+				action: 'Create a document',
+			},
+			{
+				name: 'Delete',
+				value: 'delete',
+				description: 'Delete a document',
+				action: 'Delete a document',
+			},
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a document',
+				action: 'Get a document',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get many documents',
+				action: 'Get many documents',
+			},
+			{
+				name: 'Update',
+				value: 'update',
+				description: 'Update a document',
+				action: 'Update a document',
+			},
+		],
+		default: 'getAll',
+	},
+	...create.description,
+	...deleteDocument.description,
+	...get.description,
+	...getAll.description,
+	...update.description,
+];

--- a/packages/nodes-base/nodes/Linear/v2/actions/document/update.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/document/update.operation.ts
@@ -1,0 +1,104 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Document ID',
+		name: 'documentId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'Update Fields',
+		name: 'updateFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		options: [
+			{
+				displayName: 'Content',
+				name: 'content',
+				type: 'string',
+				typeOptions: { rows: 4 },
+				default: '',
+			},
+			{
+				displayName: 'Title',
+				name: 'title',
+				type: 'string',
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['document'],
+		operation: ['update'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const documentId = this.getNodeParameter('documentId', i) as string;
+			const updateFields = this.getNodeParameter('updateFields', i) as IDataObject;
+
+			const body = {
+				query: `mutation DocumentUpdate($documentId: String!, $title: String, $content: String) {
+					documentUpdate(id: $documentId, input: {
+						title: $title
+						content: $content
+					}) {
+						success
+						document {
+							id
+							title
+							content
+							updatedAt
+						}
+					}
+				}`,
+				variables: { documentId, ...updateFields },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const document = (responseData as { data: { documentUpdate: { document: IDataObject } } })
+				.data.documentUpdate?.document;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(document), {
+					itemData: { item: i },
+				}),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/issue/archive.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/issue/archive.operation.ts
@@ -1,0 +1,72 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Issue ID',
+		name: 'issueId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['issue'],
+		operation: ['archive'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const issueId = this.getNodeParameter('issueId', i) as string;
+
+			const body = {
+				query: `mutation IssueArchive($issueId: String!) {
+					issueArchive(id: $issueId) {
+						success
+					}
+				}`,
+				variables: { issueId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const result = (responseData as { data: { issueArchive: IDataObject } }).data.issueArchive;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(result),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/issue/create.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/issue/create.operation.ts
@@ -1,0 +1,183 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { ISSUE_FIELDS, PRIORITY_OPTIONS } from '../../../shared/constants';
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Team Name or ID',
+		name: 'teamId',
+		type: 'options',
+		description:
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+		required: true,
+		typeOptions: {
+			loadOptionsMethod: 'getTeams',
+		},
+		default: '',
+	},
+	{
+		displayName: 'Title',
+		name: 'title',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		options: [
+			{
+				displayName: 'Assignee Name or ID',
+				name: 'assigneeId',
+				type: 'options',
+				description:
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: {
+					loadOptionsMethod: 'getUsers',
+				},
+				default: '',
+			},
+			{
+				displayName: 'Description',
+				name: 'description',
+				type: 'string',
+				typeOptions: {
+					rows: 4,
+				},
+				default: '',
+			},
+			{
+				displayName: 'Due Date',
+				name: 'dueDate',
+				type: 'dateTime',
+				default: '',
+			},
+			{
+				displayName: 'Label Names or IDs',
+				name: 'labelIds',
+				type: 'multiOptions',
+				description:
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: {
+					loadOptionsMethod: 'getLabels',
+				},
+				default: [],
+			},
+			{
+				displayName: 'Priority',
+				name: 'priority',
+				type: 'options',
+				options: PRIORITY_OPTIONS,
+				default: 0,
+			},
+			{
+				displayName: 'State Name or ID',
+				name: 'stateId',
+				type: 'options',
+				description:
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: {
+					loadOptionsMethod: 'getStates',
+				},
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['issue'],
+		operation: ['create'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const teamId = this.getNodeParameter('teamId', i) as string;
+			const title = this.getNodeParameter('title', i) as string;
+			const additionalFields = this.getNodeParameter('additionalFields', i) as Record<
+				string,
+				unknown
+			>;
+
+			const body = {
+				query: `mutation IssueCreate(
+					$title: String!,
+					$teamId: String!,
+					$description: String,
+					$assigneeId: String,
+					$priority: Int,
+					$stateId: String,
+					$dueDate: TimelessDate,
+					$labelIds: [String!]
+				) {
+					issueCreate(input: {
+						title: $title
+						teamId: $teamId
+						description: $description
+						assigneeId: $assigneeId
+						priority: $priority
+						stateId: $stateId
+						dueDate: $dueDate
+						labelIds: $labelIds
+					}) {
+						success
+						issue {
+							${ISSUE_FIELDS}
+						}
+					}
+				}`,
+				variables: {
+					teamId,
+					title,
+					...additionalFields,
+				},
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const issue = (
+				responseData as {
+					data: { issueCreate: { issue: IDataObject } };
+				}
+			).data.issueCreate?.issue;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(issue),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/issue/delete.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/issue/delete.operation.ts
@@ -1,0 +1,72 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Issue ID',
+		name: 'issueId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['issue'],
+		operation: ['delete'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const issueId = this.getNodeParameter('issueId', i) as string;
+
+			const body = {
+				query: `mutation IssueDelete($issueId: String!) {
+					issueDelete(id: $issueId) {
+						success
+					}
+				}`,
+				variables: { issueId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const result = (responseData as { data: { issueDelete: IDataObject } }).data.issueDelete;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(result),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/issue/get.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/issue/get.operation.ts
@@ -1,0 +1,74 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { ISSUE_FIELDS } from '../../../shared/constants';
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Issue ID',
+		name: 'issueId',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'The ID of the issue to retrieve',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['issue'],
+		operation: ['get'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const issueId = this.getNodeParameter('issueId', i) as string;
+
+			const body = {
+				query: `query Issue($issueId: String!) {
+					issue(id: $issueId) {
+						${ISSUE_FIELDS}
+					}
+				}`,
+				variables: { issueId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const issue = (responseData as { data: { issue: IDataObject } }).data.issue;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(issue),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/issue/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/issue/getAll.operation.ts
@@ -1,0 +1,144 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { ISSUE_FIELDS, PRIORITY_OPTIONS } from '../../../shared/constants';
+import { linearApiRequestAllItems } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: { minValue: 1 },
+		displayOptions: {
+			show: { returnAll: [false] },
+		},
+		description: 'Max number of results to return',
+	},
+	{
+		displayName: 'Filters',
+		name: 'filters',
+		type: 'collection',
+		placeholder: 'Add Filter',
+		default: {},
+		options: [
+			{
+				displayName: 'Assignee Name or ID',
+				name: 'assigneeId',
+				type: 'options',
+				description:
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: { loadOptionsMethod: 'getUsers' },
+				default: '',
+			},
+			{
+				displayName: 'Priority',
+				name: 'priority',
+				type: 'options',
+				options: PRIORITY_OPTIONS,
+				default: 0,
+			},
+			{
+				displayName: 'State Name or ID',
+				name: 'stateId',
+				type: 'options',
+				description:
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: { loadOptionsMethod: 'getStates' },
+				default: '',
+			},
+			{
+				displayName: 'Team Name or ID',
+				name: 'teamId',
+				type: 'options',
+				description:
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: { loadOptionsMethod: 'getTeams' },
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['issue'],
+		operation: ['getAll'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	_items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
+	const filters = this.getNodeParameter('filters', 0) as IDataObject;
+	const limit = returnAll ? undefined : (this.getNodeParameter('limit', 0) as number);
+
+	// Build filter object for the query
+	const filter: IDataObject = {};
+	if (filters.assigneeId) filter.assignee = { id: { eq: filters.assigneeId } };
+	if (filters.priority !== undefined && filters.priority !== '') {
+		filter.priority = { eq: filters.priority };
+	}
+	if (filters.stateId) filter.state = { id: { eq: filters.stateId } };
+	if (filters.teamId) filter.team = { id: { eq: filters.teamId } };
+
+	const body = {
+		query: `query Issues($first: Int, $after: String, $filter: IssueFilter) {
+			issues(first: $first, after: $after, filter: $filter) {
+				nodes {
+					${ISSUE_FIELDS}
+				}
+				pageInfo {
+					hasNextPage
+					endCursor
+				}
+			}
+		}`,
+		variables: {
+			first: 50,
+			...(Object.keys(filter).length > 0 ? { filter } : {}),
+		},
+	};
+
+	try {
+		const issues = await linearApiRequestAllItems.call(this, 'data.issues', body, limit);
+
+		const executionData = this.helpers.constructExecutionMetaData(
+			this.helpers.returnJsonArray(issues),
+			{ itemData: { item: 0 } },
+		);
+		returnData.push(...executionData);
+	} catch (error) {
+		if (this.continueOnFail()) {
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ error: (error as Error).message }),
+					{ itemData: { item: 0 } },
+				),
+			);
+		} else {
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/issue/index.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/issue/index.ts
@@ -1,0 +1,85 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as archive from './archive.operation';
+import * as create from './create.operation';
+import * as deleteIssue from './delete.operation';
+import * as get from './get.operation';
+import * as getAll from './getAll.operation';
+import * as search from './search.operation';
+import * as unarchive from './unarchive.operation';
+import * as update from './update.operation';
+
+export { archive, create, deleteIssue as delete, get, getAll, search, unarchive, update };
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['issue'],
+			},
+		},
+		options: [
+			{
+				name: 'Archive',
+				value: 'archive',
+				description: 'Archive an issue',
+				action: 'Archive an issue',
+			},
+			{
+				name: 'Create',
+				value: 'create',
+				description: 'Create an issue',
+				action: 'Create an issue',
+			},
+			{
+				name: 'Delete',
+				value: 'delete',
+				description: 'Delete an issue',
+				action: 'Delete an issue',
+			},
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get an issue',
+				action: 'Get an issue',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get many issues',
+				action: 'Get many issues',
+			},
+			{
+				name: 'Search',
+				value: 'search',
+				description: 'Search issues by text',
+				action: 'Search issues',
+			},
+			{
+				name: 'Unarchive',
+				value: 'unarchive',
+				description: 'Unarchive an issue',
+				action: 'Unarchive an issue',
+			},
+			{
+				name: 'Update',
+				value: 'update',
+				description: 'Update an issue',
+				action: 'Update an issue',
+			},
+		],
+		default: 'create',
+	},
+	...archive.description,
+	...create.description,
+	...deleteIssue.description,
+	...get.description,
+	...getAll.description,
+	...search.description,
+	...unarchive.description,
+	...update.description,
+];

--- a/packages/nodes-base/nodes/Linear/v2/actions/issue/search.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/issue/search.operation.ts
@@ -1,0 +1,100 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+
+import { ISSUE_FIELDS } from '../../../shared/constants';
+import { linearApiRequestAllItems } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Query',
+		name: 'query',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'Text to search for in issue titles and descriptions',
+	},
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: { minValue: 1 },
+		displayOptions: {
+			show: { returnAll: [false] },
+		},
+		description: 'Max number of results to return',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['issue'],
+		operation: ['search'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	_items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	const searchQuery = this.getNodeParameter('query', 0) as string;
+	const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
+	const limit = returnAll ? undefined : (this.getNodeParameter('limit', 0) as number);
+
+	const body = {
+		query: `query IssueSearch($first: Int, $after: String, $filter: IssueFilter) {
+			issues(first: $first, after: $after, filter: $filter) {
+				nodes {
+					${ISSUE_FIELDS}
+				}
+				pageInfo {
+					hasNextPage
+					endCursor
+				}
+			}
+		}`,
+		variables: {
+			first: 50,
+			filter: {
+				or: [
+					{ title: { containsIgnoreCase: searchQuery } },
+					{ description: { containsIgnoreCase: searchQuery } },
+				],
+			},
+		},
+	};
+
+	try {
+		const issues = await linearApiRequestAllItems.call(this, 'data.issues', body, limit);
+
+		const executionData = this.helpers.constructExecutionMetaData(
+			this.helpers.returnJsonArray(issues),
+			{ itemData: { item: 0 } },
+		);
+		returnData.push(...executionData);
+	} catch (error) {
+		if (this.continueOnFail()) {
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ error: (error as Error).message }),
+					{ itemData: { item: 0 } },
+				),
+			);
+		} else {
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/issue/unarchive.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/issue/unarchive.operation.ts
@@ -1,0 +1,73 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Issue ID',
+		name: 'issueId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['issue'],
+		operation: ['unarchive'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const issueId = this.getNodeParameter('issueId', i) as string;
+
+			const body = {
+				query: `mutation IssueUnarchive($issueId: String!) {
+					issueUnarchive(id: $issueId) {
+						success
+					}
+				}`,
+				variables: { issueId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const result = (responseData as { data: { issueUnarchive: IDataObject } }).data
+				.issueUnarchive;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(result),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/issue/update.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/issue/update.operation.ts
@@ -1,0 +1,171 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { ISSUE_FIELDS, PRIORITY_OPTIONS } from '../../../shared/constants';
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Issue ID',
+		name: 'issueId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'Update Fields',
+		name: 'updateFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		options: [
+			{
+				displayName: 'Assignee Name or ID',
+				name: 'assigneeId',
+				type: 'options',
+				description:
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: { loadOptionsMethod: 'getUsers' },
+				default: '',
+			},
+			{
+				displayName: 'Description',
+				name: 'description',
+				type: 'string',
+				typeOptions: { rows: 4 },
+				default: '',
+			},
+			{
+				displayName: 'Due Date',
+				name: 'dueDate',
+				type: 'dateTime',
+				default: '',
+			},
+			{
+				displayName: 'Label Names or IDs',
+				name: 'labelIds',
+				type: 'multiOptions',
+				description:
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: { loadOptionsMethod: 'getLabels' },
+				default: [],
+			},
+			{
+				displayName: 'Priority',
+				name: 'priority',
+				type: 'options',
+				options: PRIORITY_OPTIONS,
+				default: 0,
+			},
+			{
+				displayName: 'State Name or ID',
+				name: 'stateId',
+				type: 'options',
+				description:
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: { loadOptionsMethod: 'getStates' },
+				default: '',
+			},
+			{
+				displayName: 'Team Name or ID',
+				name: 'teamId',
+				type: 'options',
+				description:
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: { loadOptionsMethod: 'getTeams' },
+				default: '',
+			},
+			{
+				displayName: 'Title',
+				name: 'title',
+				type: 'string',
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['issue'],
+		operation: ['update'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const issueId = this.getNodeParameter('issueId', i) as string;
+			const updateFields = this.getNodeParameter('updateFields', i) as IDataObject;
+
+			const body = {
+				query: `mutation IssueUpdate(
+					$issueId: String!,
+					$title: String,
+					$teamId: String,
+					$description: String,
+					$assigneeId: String,
+					$priority: Int,
+					$stateId: String,
+					$dueDate: TimelessDate,
+					$labelIds: [String!]
+				) {
+					issueUpdate(id: $issueId, input: {
+						title: $title
+						teamId: $teamId
+						description: $description
+						assigneeId: $assigneeId
+						priority: $priority
+						stateId: $stateId
+						dueDate: $dueDate
+						labelIds: $labelIds
+					}) {
+						success
+						issue {
+							${ISSUE_FIELDS}
+						}
+					}
+				}`,
+				variables: {
+					issueId,
+					...updateFields,
+				},
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const issue = (responseData as { data: { issueUpdate: { issue: IDataObject } } }).data
+				.issueUpdate?.issue;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(issue),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/label/create.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/label/create.operation.ts
@@ -1,0 +1,126 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Name',
+		name: 'name',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'Team Name or ID',
+		name: 'teamId',
+		type: 'options',
+		required: true,
+		description:
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+		typeOptions: { loadOptionsMethod: 'getTeams' },
+		default: '',
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		options: [
+			{
+				displayName: 'Color',
+				name: 'color',
+				type: 'color',
+				default: '#000000',
+				description: 'The label color as a hex code',
+			},
+			{
+				displayName: 'Description',
+				name: 'description',
+				type: 'string',
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['label'],
+		operation: ['create'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const name = this.getNodeParameter('name', i) as string;
+			const teamId = this.getNodeParameter('teamId', i) as string;
+			const additionalFields = this.getNodeParameter('additionalFields', i) as Record<
+				string,
+				unknown
+			>;
+
+			const body = {
+				query: `mutation IssueLabelCreate($name: String!, $teamId: String!, $color: String, $description: String) {
+					issueLabelCreate(input: {
+						name: $name
+						teamId: $teamId
+						color: $color
+						description: $description
+					}) {
+						success
+						issueLabel {
+							id
+							name
+							color
+							description
+							createdAt
+						}
+					}
+				}`,
+				variables: {
+					name,
+					teamId,
+					...additionalFields,
+				},
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const label = (responseData as { data: { issueLabelCreate: { issueLabel: IDataObject } } })
+				.data.issueLabelCreate?.issueLabel;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(label),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/label/delete.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/label/delete.operation.ts
@@ -1,0 +1,73 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Label ID',
+		name: 'labelId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['label'],
+		operation: ['delete'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const labelId = this.getNodeParameter('labelId', i) as string;
+
+			const body = {
+				query: `mutation IssueLabelDelete($labelId: String!) {
+					issueLabelDelete(id: $labelId) {
+						success
+					}
+				}`,
+				variables: { labelId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const result = (responseData as { data: { issueLabelDelete: IDataObject } }).data
+				.issueLabelDelete;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(result),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/label/get.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/label/get.operation.ts
@@ -1,0 +1,77 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Label ID',
+		name: 'labelId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['label'],
+		operation: ['get'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const labelId = this.getNodeParameter('labelId', i) as string;
+
+			const body = {
+				query: `query IssueLabel($labelId: String!) {
+					issueLabel(id: $labelId) {
+						id
+						name
+						color
+						description
+						createdAt
+						updatedAt
+					}
+				}`,
+				variables: { labelId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const label = (responseData as { data: { issueLabel: IDataObject } }).data.issueLabel;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(label),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/label/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/label/getAll.operation.ts
@@ -1,0 +1,87 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+
+import { linearApiRequestAllItems } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: { minValue: 1 },
+		displayOptions: {
+			show: { returnAll: [false] },
+		},
+		description: 'Max number of results to return',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['label'],
+		operation: ['getAll'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	_items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
+	const limit = returnAll ? undefined : (this.getNodeParameter('limit', 0) as number);
+
+	const body = {
+		query: `query IssueLabels($first: Int, $after: String) {
+			issueLabels(first: $first, after: $after) {
+				nodes {
+					id
+					name
+					color
+					description
+					createdAt
+					updatedAt
+				}
+				pageInfo {
+					hasNextPage
+					endCursor
+				}
+			}
+		}`,
+		variables: { first: 50 },
+	};
+
+	try {
+		const labels = await linearApiRequestAllItems.call(this, 'data.issueLabels', body, limit);
+
+		const executionData = this.helpers.constructExecutionMetaData(
+			this.helpers.returnJsonArray(labels),
+			{ itemData: { item: 0 } },
+		);
+		returnData.push(...executionData);
+	} catch (error) {
+		if (this.continueOnFail()) {
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ error: (error as Error).message }),
+					{ itemData: { item: 0 } },
+				),
+			);
+		} else {
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/label/index.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/label/index.ts
@@ -1,0 +1,61 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as create from './create.operation';
+import * as deleteLabel from './delete.operation';
+import * as get from './get.operation';
+import * as getAll from './getAll.operation';
+import * as update from './update.operation';
+
+export { create, deleteLabel as delete, get, getAll, update };
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['label'],
+			},
+		},
+		options: [
+			{
+				name: 'Create',
+				value: 'create',
+				description: 'Create a label',
+				action: 'Create a label',
+			},
+			{
+				name: 'Delete',
+				value: 'delete',
+				description: 'Delete a label',
+				action: 'Delete a label',
+			},
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a label',
+				action: 'Get a label',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get many labels',
+				action: 'Get many labels',
+			},
+			{
+				name: 'Update',
+				value: 'update',
+				description: 'Update a label',
+				action: 'Update a label',
+			},
+		],
+		default: 'getAll',
+	},
+	...create.description,
+	...deleteLabel.description,
+	...get.description,
+	...getAll.description,
+	...update.description,
+];

--- a/packages/nodes-base/nodes/Linear/v2/actions/label/update.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/label/update.operation.ts
@@ -1,0 +1,115 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Label ID',
+		name: 'labelId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'Update Fields',
+		name: 'updateFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		options: [
+			{
+				displayName: 'Color',
+				name: 'color',
+				type: 'color',
+				default: '#000000',
+			},
+			{
+				displayName: 'Description',
+				name: 'description',
+				type: 'string',
+				default: '',
+			},
+			{
+				displayName: 'Name',
+				name: 'name',
+				type: 'string',
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['label'],
+		operation: ['update'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const labelId = this.getNodeParameter('labelId', i) as string;
+			const updateFields = this.getNodeParameter('updateFields', i) as IDataObject;
+
+			const body = {
+				query: `mutation IssueLabelUpdate($labelId: String!, $name: String, $color: String, $description: String) {
+					issueLabelUpdate(id: $labelId, input: {
+						name: $name
+						color: $color
+						description: $description
+					}) {
+						success
+						issueLabel {
+							id
+							name
+							color
+							description
+							updatedAt
+						}
+					}
+				}`,
+				variables: {
+					labelId,
+					...updateFields,
+				},
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const label = (responseData as { data: { issueLabelUpdate: { issueLabel: IDataObject } } })
+				.data.issueLabelUpdate?.issueLabel;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(label),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/node.type.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/node.type.ts
@@ -1,0 +1,18 @@
+import type { AllEntities } from 'n8n-workflow';
+
+type NodeMap = {
+	issue: 'create' | 'get' | 'getAll' | 'update' | 'delete' | 'archive' | 'unarchive' | 'search';
+	comment: 'create' | 'get' | 'getAll' | 'update' | 'delete';
+	project: 'create' | 'get' | 'getAll' | 'update' | 'delete' | 'archive';
+	user: 'get' | 'getAll' | 'getCurrent';
+	team: 'get' | 'getAll';
+	label: 'create' | 'get' | 'getAll' | 'update' | 'delete';
+	cycle: 'create' | 'get' | 'getAll' | 'update' | 'delete' | 'archive';
+	attachment: 'create' | 'get' | 'getAll' | 'delete';
+	workflowState: 'get' | 'getAll';
+	document: 'create' | 'get' | 'getAll' | 'update' | 'delete';
+	roadmap: 'create' | 'get' | 'getAll' | 'update' | 'delete';
+	teamMembership: 'create' | 'getAll' | 'delete';
+};
+
+export type Linear = AllEntities<NodeMap>;

--- a/packages/nodes-base/nodes/Linear/v2/actions/project/archive.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/project/archive.operation.ts
@@ -1,0 +1,73 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Project ID',
+		name: 'projectId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['project'],
+		operation: ['archive'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const projectId = this.getNodeParameter('projectId', i) as string;
+
+			const body = {
+				query: `mutation ProjectArchive($projectId: String!) {
+					projectArchive(id: $projectId) {
+						success
+					}
+				}`,
+				variables: { projectId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const result = (responseData as { data: { projectArchive: IDataObject } }).data
+				.projectArchive;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(result),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/project/create.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/project/create.operation.ts
@@ -1,0 +1,164 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Name',
+		name: 'name',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'Team Names or IDs',
+		name: 'teamIds',
+		type: 'multiOptions',
+		required: true,
+		description:
+			'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+		typeOptions: { loadOptionsMethod: 'getTeams' },
+		default: [],
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		options: [
+			{
+				displayName: 'Description',
+				name: 'description',
+				type: 'string',
+				typeOptions: { rows: 4 },
+				default: '',
+			},
+			{
+				displayName: 'Lead Name or ID',
+				name: 'leadId',
+				type: 'options',
+				description:
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: { loadOptionsMethod: 'getUsers' },
+				default: '',
+			},
+			{
+				displayName: 'Status',
+				name: 'state',
+				type: 'options',
+				options: [
+					{ name: 'Backlog', value: 'backlog' },
+					{ name: 'Planned', value: 'planned' },
+					{ name: 'In Progress', value: 'inProgress' },
+					{ name: 'Paused', value: 'paused' },
+					{ name: 'Completed', value: 'completed' },
+					{ name: 'Cancelled', value: 'cancelled' },
+				],
+				default: 'planned',
+			},
+			{
+				displayName: 'Target Date',
+				name: 'targetDate',
+				type: 'dateTime',
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['project'],
+		operation: ['create'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const name = this.getNodeParameter('name', i) as string;
+			const teamIds = this.getNodeParameter('teamIds', i) as string[];
+			const additionalFields = this.getNodeParameter('additionalFields', i) as Record<
+				string,
+				unknown
+			>;
+
+			const body = {
+				query: `mutation ProjectCreate(
+					$name: String!,
+					$teamIds: [String!]!,
+					$description: String,
+					$leadId: String,
+					$state: String,
+					$targetDate: TimelessDate
+				) {
+					projectCreate(input: {
+						name: $name
+						teamIds: $teamIds
+						description: $description
+						leadId: $leadId
+						state: $state
+						targetDate: $targetDate
+					}) {
+						success
+						project {
+							id
+							name
+							description
+							state
+							createdAt
+							updatedAt
+							targetDate
+							lead {
+								id
+								displayName
+							}
+						}
+					}
+				}`,
+				variables: {
+					name,
+					teamIds,
+					...additionalFields,
+				},
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const project = (responseData as { data: { projectCreate: { project: IDataObject } } }).data
+				.projectCreate?.project;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(project),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/project/delete.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/project/delete.operation.ts
@@ -1,0 +1,72 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Project ID',
+		name: 'projectId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['project'],
+		operation: ['delete'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const projectId = this.getNodeParameter('projectId', i) as string;
+
+			const body = {
+				query: `mutation ProjectDelete($projectId: String!) {
+					projectDelete(id: $projectId) {
+						success
+					}
+				}`,
+				variables: { projectId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const result = (responseData as { data: { projectDelete: IDataObject } }).data.projectDelete;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(result as IDataObject),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/project/get.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/project/get.operation.ts
@@ -1,0 +1,84 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Project ID',
+		name: 'projectId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['project'],
+		operation: ['get'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const projectId = this.getNodeParameter('projectId', i) as string;
+
+			const body = {
+				query: `query Project($projectId: String!) {
+					project(id: $projectId) {
+						id
+						name
+						description
+						state
+						createdAt
+						updatedAt
+						targetDate
+						url
+						lead {
+							id
+							displayName
+							email
+						}
+					}
+				}`,
+				variables: { projectId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const project = (responseData as { data: { project: IDataObject } }).data.project;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(project as IDataObject),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/project/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/project/getAll.operation.ts
@@ -1,0 +1,93 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+
+import { linearApiRequestAllItems } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: { minValue: 1 },
+		displayOptions: {
+			show: { returnAll: [false] },
+		},
+		description: 'Max number of results to return',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['project'],
+		operation: ['getAll'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	_items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
+	const limit = returnAll ? undefined : (this.getNodeParameter('limit', 0) as number);
+
+	const body = {
+		query: `query Projects($first: Int, $after: String) {
+			projects(first: $first, after: $after) {
+				nodes {
+					id
+					name
+					description
+					state
+					createdAt
+					updatedAt
+					targetDate
+					url
+					lead {
+						id
+						displayName
+					}
+				}
+				pageInfo {
+					hasNextPage
+					endCursor
+				}
+			}
+		}`,
+		variables: { first: 50 },
+	};
+
+	try {
+		const projects = await linearApiRequestAllItems.call(this, 'data.projects', body, limit);
+
+		const executionData = this.helpers.constructExecutionMetaData(
+			this.helpers.returnJsonArray(projects),
+			{ itemData: { item: 0 } },
+		);
+		returnData.push(...executionData);
+	} catch (error) {
+		if (this.continueOnFail()) {
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ error: (error as Error).message }),
+					{ itemData: { item: 0 } },
+				),
+			);
+		} else {
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/project/index.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/project/index.ts
@@ -1,0 +1,69 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as archive from './archive.operation';
+import * as create from './create.operation';
+import * as deleteProject from './delete.operation';
+import * as get from './get.operation';
+import * as getAll from './getAll.operation';
+import * as update from './update.operation';
+
+export { archive, create, deleteProject as delete, get, getAll, update };
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['project'],
+			},
+		},
+		options: [
+			{
+				name: 'Archive',
+				value: 'archive',
+				description: 'Archive a project',
+				action: 'Archive a project',
+			},
+			{
+				name: 'Create',
+				value: 'create',
+				description: 'Create a project',
+				action: 'Create a project',
+			},
+			{
+				name: 'Delete',
+				value: 'delete',
+				description: 'Delete a project',
+				action: 'Delete a project',
+			},
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a project',
+				action: 'Get a project',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get many projects',
+				action: 'Get many projects',
+			},
+			{
+				name: 'Update',
+				value: 'update',
+				description: 'Update a project',
+				action: 'Update a project',
+			},
+		],
+		default: 'create',
+	},
+	...archive.description,
+	...create.description,
+	...deleteProject.description,
+	...get.description,
+	...getAll.description,
+	...update.description,
+];

--- a/packages/nodes-base/nodes/Linear/v2/actions/project/update.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/project/update.operation.ts
@@ -1,0 +1,150 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Project ID',
+		name: 'projectId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'Update Fields',
+		name: 'updateFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		options: [
+			{
+				displayName: 'Description',
+				name: 'description',
+				type: 'string',
+				typeOptions: { rows: 4 },
+				default: '',
+			},
+			{
+				displayName: 'Lead Name or ID',
+				name: 'leadId',
+				type: 'options',
+				description:
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: { loadOptionsMethod: 'getUsers' },
+				default: '',
+			},
+			{
+				displayName: 'Name',
+				name: 'name',
+				type: 'string',
+				default: '',
+			},
+			{
+				displayName: 'Status',
+				name: 'state',
+				type: 'options',
+				options: [
+					{ name: 'Backlog', value: 'backlog' },
+					{ name: 'Planned', value: 'planned' },
+					{ name: 'In Progress', value: 'inProgress' },
+					{ name: 'Paused', value: 'paused' },
+					{ name: 'Completed', value: 'completed' },
+					{ name: 'Cancelled', value: 'cancelled' },
+				],
+				default: 'planned',
+			},
+			{
+				displayName: 'Target Date',
+				name: 'targetDate',
+				type: 'dateTime',
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['project'],
+		operation: ['update'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const projectId = this.getNodeParameter('projectId', i) as string;
+			const updateFields = this.getNodeParameter('updateFields', i) as IDataObject;
+
+			const body = {
+				query: `mutation ProjectUpdate(
+					$projectId: String!,
+					$name: String,
+					$description: String,
+					$leadId: String,
+					$state: String,
+					$targetDate: TimelessDate
+				) {
+					projectUpdate(id: $projectId, input: {
+						name: $name
+						description: $description
+						leadId: $leadId
+						state: $state
+						targetDate: $targetDate
+					}) {
+						success
+						project {
+							id
+							name
+							description
+							state
+							createdAt
+							updatedAt
+							targetDate
+						}
+					}
+				}`,
+				variables: {
+					projectId,
+					...updateFields,
+				},
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const project = (responseData as { data: { projectUpdate: { project: IDataObject } } }).data
+				.projectUpdate?.project;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(project as IDataObject),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/roadmap/create.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/roadmap/create.operation.ts
@@ -1,0 +1,105 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Name',
+		name: 'name',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		options: [
+			{
+				displayName: 'Description',
+				name: 'description',
+				type: 'string',
+				typeOptions: { rows: 4 },
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['roadmap'],
+		operation: ['create'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const name = this.getNodeParameter('name', i) as string;
+			const additionalFields = this.getNodeParameter('additionalFields', i) as Record<
+				string,
+				unknown
+			>;
+
+			const body = {
+				query: `mutation RoadmapCreate($name: String!, $description: String) {
+					roadmapCreate(input: {
+						name: $name
+						description: $description
+					}) {
+						success
+						roadmap {
+							id
+							name
+							description
+							createdAt
+							updatedAt
+						}
+					}
+				}`,
+				variables: { name, ...additionalFields },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const roadmap = (responseData as { data: { roadmapCreate: { roadmap: IDataObject } } }).data
+				.roadmapCreate?.roadmap;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray(roadmap as IDataObject),
+					{
+						itemData: { item: i },
+					},
+				),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/roadmap/delete.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/roadmap/delete.operation.ts
@@ -1,0 +1,74 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Roadmap ID',
+		name: 'roadmapId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['roadmap'],
+		operation: ['delete'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const roadmapId = this.getNodeParameter('roadmapId', i) as string;
+
+			const body = {
+				query: `mutation RoadmapDelete($roadmapId: String!) {
+					roadmapDelete(id: $roadmapId) {
+						success
+					}
+				}`,
+				variables: { roadmapId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const result = (responseData as { data: { roadmapDelete: IDataObject } }).data.roadmapDelete;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray(result as IDataObject),
+					{
+						itemData: { item: i },
+					},
+				),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/roadmap/get.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/roadmap/get.operation.ts
@@ -1,0 +1,78 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Roadmap ID',
+		name: 'roadmapId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['roadmap'],
+		operation: ['get'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const roadmapId = this.getNodeParameter('roadmapId', i) as string;
+
+			const body = {
+				query: `query Roadmap($roadmapId: String!) {
+					roadmap(id: $roadmapId) {
+						id
+						name
+						description
+						createdAt
+						updatedAt
+					}
+				}`,
+				variables: { roadmapId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const roadmap = (responseData as { data: { roadmap: IDataObject } }).data.roadmap;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray(roadmap as IDataObject),
+					{
+						itemData: { item: i },
+					},
+				),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/roadmap/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/roadmap/getAll.operation.ts
@@ -1,0 +1,78 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+
+import { linearApiRequestAllItems } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: { minValue: 1 },
+		displayOptions: { show: { returnAll: [false] } },
+		description: 'Max number of results to return',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['roadmap'],
+		operation: ['getAll'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	_items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+	const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
+	const limit = returnAll ? undefined : (this.getNodeParameter('limit', 0) as number);
+
+	const body = {
+		query: `query Roadmaps($first: Int, $after: String) {
+			roadmaps(first: $first, after: $after) {
+				nodes {
+					id
+					name
+					description
+					createdAt
+					updatedAt
+				}
+				pageInfo { hasNextPage endCursor }
+			}
+		}`,
+		variables: { first: 50 },
+	};
+
+	try {
+		const roadmaps = await linearApiRequestAllItems.call(this, 'data.roadmaps', body, limit);
+		returnData.push(
+			...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(roadmaps), {
+				itemData: { item: 0 },
+			}),
+		);
+	} catch (error) {
+		if (this.continueOnFail()) {
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ error: (error as Error).message }),
+					{ itemData: { item: 0 } },
+				),
+			);
+		} else {
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/roadmap/index.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/roadmap/index.ts
@@ -1,0 +1,61 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as create from './create.operation';
+import * as deleteRoadmap from './delete.operation';
+import * as get from './get.operation';
+import * as getAll from './getAll.operation';
+import * as update from './update.operation';
+
+export { create, deleteRoadmap as delete, get, getAll, update };
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['roadmap'],
+			},
+		},
+		options: [
+			{
+				name: 'Create',
+				value: 'create',
+				description: 'Create a roadmap',
+				action: 'Create a roadmap',
+			},
+			{
+				name: 'Delete',
+				value: 'delete',
+				description: 'Delete a roadmap',
+				action: 'Delete a roadmap',
+			},
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a roadmap',
+				action: 'Get a roadmap',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get many roadmaps',
+				action: 'Get many roadmaps',
+			},
+			{
+				name: 'Update',
+				value: 'update',
+				description: 'Update a roadmap',
+				action: 'Update a roadmap',
+			},
+		],
+		default: 'getAll',
+	},
+	...create.description,
+	...deleteRoadmap.description,
+	...get.description,
+	...getAll.description,
+	...update.description,
+];

--- a/packages/nodes-base/nodes/Linear/v2/actions/roadmap/update.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/roadmap/update.operation.ts
@@ -1,0 +1,107 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Roadmap ID',
+		name: 'roadmapId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'Update Fields',
+		name: 'updateFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		options: [
+			{
+				displayName: 'Description',
+				name: 'description',
+				type: 'string',
+				typeOptions: { rows: 4 },
+				default: '',
+			},
+			{
+				displayName: 'Name',
+				name: 'name',
+				type: 'string',
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['roadmap'],
+		operation: ['update'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const roadmapId = this.getNodeParameter('roadmapId', i) as string;
+			const updateFields = this.getNodeParameter('updateFields', i) as IDataObject;
+
+			const body = {
+				query: `mutation RoadmapUpdate($roadmapId: String!, $name: String, $description: String) {
+					roadmapUpdate(id: $roadmapId, input: {
+						name: $name
+						description: $description
+					}) {
+						success
+						roadmap {
+							id
+							name
+							description
+							updatedAt
+						}
+					}
+				}`,
+				variables: { roadmapId, ...updateFields },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const roadmap = (responseData as { data: { roadmapUpdate: { roadmap: IDataObject } } }).data
+				.roadmapUpdate?.roadmap;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray(roadmap as IDataObject),
+					{
+						itemData: { item: i },
+					},
+				),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/router.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/router.ts
@@ -1,0 +1,69 @@
+import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+
+import * as attachment from './attachment';
+import * as comment from './comment';
+import * as cycle from './cycle';
+import * as document from './document';
+import * as issue from './issue';
+import * as label from './label';
+import type { Linear } from './node.type';
+import * as project from './project';
+import * as roadmap from './roadmap';
+import * as team from './team';
+import * as teamMembership from './teamMembership';
+import * as user from './user';
+import * as workflowState from './workflowState';
+
+export async function router(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+	const items = this.getInputData();
+	const resource = this.getNodeParameter('resource', 0) as string;
+	const operation = this.getNodeParameter('operation', 0) as string;
+
+	const linear = { resource, operation } as Linear;
+
+	let returnData: INodeExecutionData[] = [];
+
+	switch (linear.resource) {
+		case 'issue':
+			returnData = await issue[linear.operation].execute.call(this, items);
+			break;
+		case 'comment':
+			returnData = await comment[linear.operation].execute.call(this, items);
+			break;
+		case 'project':
+			returnData = await project[linear.operation].execute.call(this, items);
+			break;
+		case 'user':
+			returnData = await user[linear.operation].execute.call(this, items);
+			break;
+		case 'team':
+			returnData = await team[linear.operation].execute.call(this, items);
+			break;
+		case 'label':
+			returnData = await label[linear.operation].execute.call(this, items);
+			break;
+		case 'cycle':
+			returnData = await cycle[linear.operation].execute.call(this, items);
+			break;
+		case 'attachment':
+			returnData = await attachment[linear.operation].execute.call(this, items);
+			break;
+		case 'workflowState':
+			returnData = await workflowState[linear.operation].execute.call(this, items);
+			break;
+		case 'document':
+			returnData = await document[linear.operation].execute.call(this, items);
+			break;
+		case 'roadmap':
+			returnData = await roadmap[linear.operation].execute.call(this, items);
+			break;
+		case 'teamMembership':
+			returnData = await teamMembership[linear.operation].execute.call(this, items);
+			break;
+		default:
+			throw new NodeOperationError(this.getNode(), `The resource "${resource}" is not known`);
+	}
+
+	return [returnData];
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/team/get.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/team/get.operation.ts
@@ -1,0 +1,79 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Team ID',
+		name: 'teamId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['team'],
+		operation: ['get'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const teamId = this.getNodeParameter('teamId', i) as string;
+
+			const body = {
+				query: `query Team($teamId: String!) {
+					team(id: $teamId) {
+						id
+						name
+						description
+						key
+						color
+						createdAt
+						updatedAt
+						timezone
+					}
+				}`,
+				variables: { teamId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const team = (responseData as { data: { team: IDataObject } }).data.team;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(team as IDataObject),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/team/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/team/getAll.operation.ts
@@ -1,0 +1,89 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+
+import { linearApiRequestAllItems } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: { minValue: 1 },
+		displayOptions: {
+			show: { returnAll: [false] },
+		},
+		description: 'Max number of results to return',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['team'],
+		operation: ['getAll'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	_items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
+	const limit = returnAll ? undefined : (this.getNodeParameter('limit', 0) as number);
+
+	const body = {
+		query: `query Teams($first: Int, $after: String) {
+			teams(first: $first, after: $after) {
+				nodes {
+					id
+					name
+					description
+					key
+					color
+					createdAt
+					updatedAt
+					timezone
+				}
+				pageInfo {
+					hasNextPage
+					endCursor
+				}
+			}
+		}`,
+		variables: { first: 50 },
+	};
+
+	try {
+		const teams = await linearApiRequestAllItems.call(this, 'data.teams', body, limit);
+
+		const executionData = this.helpers.constructExecutionMetaData(
+			this.helpers.returnJsonArray(teams),
+			{ itemData: { item: 0 } },
+		);
+		returnData.push(...executionData);
+	} catch (error) {
+		if (this.continueOnFail()) {
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ error: (error as Error).message }),
+					{ itemData: { item: 0 } },
+				),
+			);
+		} else {
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/team/index.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/team/index.ts
@@ -1,0 +1,37 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as get from './get.operation';
+import * as getAll from './getAll.operation';
+
+export { get, getAll };
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['team'],
+			},
+		},
+		options: [
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a team',
+				action: 'Get a team',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get many teams',
+				action: 'Get many teams',
+			},
+		],
+		default: 'getAll',
+	},
+	...get.description,
+	...getAll.description,
+];

--- a/packages/nodes-base/nodes/Linear/v2/actions/teamMembership/create.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/teamMembership/create.operation.ts
@@ -1,0 +1,108 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Team Name or ID',
+		name: 'teamId',
+		type: 'options',
+		required: true,
+		description:
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+		typeOptions: { loadOptionsMethod: 'getTeams' },
+		default: '',
+	},
+	{
+		displayName: 'User Name or ID',
+		name: 'userId',
+		type: 'options',
+		required: true,
+		description:
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+		typeOptions: { loadOptionsMethod: 'getUsers' },
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['teamMembership'],
+		operation: ['create'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const teamId = this.getNodeParameter('teamId', i) as string;
+			const userId = this.getNodeParameter('userId', i) as string;
+
+			const body = {
+				query: `mutation TeamMembershipCreate($teamId: String!, $userId: String!) {
+					teamMembershipCreate(input: {
+						teamId: $teamId
+						userId: $userId
+					}) {
+						success
+						teamMembership {
+							id
+							createdAt
+							team {
+								id
+								name
+							}
+							user {
+								id
+								displayName
+								email
+							}
+						}
+					}
+				}`,
+				variables: { teamId, userId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const membership = (
+				responseData as {
+					data: { teamMembershipCreate: { teamMembership: IDataObject } };
+				}
+			).data.teamMembershipCreate?.teamMembership;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray(membership as IDataObject),
+					{
+						itemData: { item: i },
+					},
+				),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/teamMembership/delete.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/teamMembership/delete.operation.ts
@@ -1,0 +1,76 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Team Membership ID',
+		name: 'teamMembershipId',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'The ID of the team membership to delete',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['teamMembership'],
+		operation: ['delete'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const teamMembershipId = this.getNodeParameter('teamMembershipId', i) as string;
+
+			const body = {
+				query: `mutation TeamMembershipDelete($teamMembershipId: String!) {
+					teamMembershipDelete(id: $teamMembershipId) {
+						success
+					}
+				}`,
+				variables: { teamMembershipId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const result = (responseData as { data: { teamMembershipDelete: IDataObject } }).data
+				.teamMembershipDelete;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray(result as IDataObject),
+					{
+						itemData: { item: i },
+					},
+				),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/teamMembership/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/teamMembership/getAll.operation.ts
@@ -1,0 +1,92 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+
+import { linearApiRequestAllItems } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Team Name or ID',
+		name: 'teamId',
+		type: 'options',
+		required: true,
+		description:
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+		typeOptions: { loadOptionsMethod: 'getTeams' },
+		default: '',
+	},
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: { minValue: 1 },
+		displayOptions: { show: { returnAll: [false] } },
+		description: 'Max number of results to return',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['teamMembership'],
+		operation: ['getAll'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	_items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+	const teamId = this.getNodeParameter('teamId', 0) as string;
+	const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
+	const limit = returnAll ? undefined : (this.getNodeParameter('limit', 0) as number);
+
+	const body = {
+		query: `query TeamMemberships($teamId: String!, $first: Int, $after: String) {
+			team(id: $teamId) {
+				members(first: $first, after: $after) {
+					nodes {
+						id
+						name
+						displayName
+						email
+						avatarUrl
+						active
+					}
+					pageInfo { hasNextPage endCursor }
+				}
+			}
+		}`,
+		variables: { teamId, first: 50 },
+	};
+
+	try {
+		const members = await linearApiRequestAllItems.call(this, 'data.team.members', body, limit);
+		returnData.push(
+			...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(members), {
+				itemData: { item: 0 },
+			}),
+		);
+	} catch (error) {
+		if (this.continueOnFail()) {
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ error: (error as Error).message }),
+					{ itemData: { item: 0 } },
+				),
+			);
+		} else {
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/teamMembership/index.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/teamMembership/index.ts
@@ -1,0 +1,45 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as create from './create.operation';
+import * as deleteTeamMembership from './delete.operation';
+import * as getAll from './getAll.operation';
+
+export { create, deleteTeamMembership as delete, getAll };
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['teamMembership'],
+			},
+		},
+		options: [
+			{
+				name: 'Add Member',
+				value: 'create',
+				description: 'Add a member to a team',
+				action: 'Add a member to a team',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get team memberships',
+				action: 'Get many team memberships',
+			},
+			{
+				name: 'Remove Member',
+				value: 'delete',
+				description: 'Remove a member from a team',
+				action: 'Remove a member from a team',
+			},
+		],
+		default: 'getAll',
+	},
+	...create.description,
+	...deleteTeamMembership.description,
+	...getAll.description,
+];

--- a/packages/nodes-base/nodes/Linear/v2/actions/user/get.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/user/get.operation.ts
@@ -1,0 +1,80 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'User ID',
+		name: 'userId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['user'],
+		operation: ['get'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const userId = this.getNodeParameter('userId', i) as string;
+
+			const body = {
+				query: `query User($userId: String!) {
+					user(id: $userId) {
+						id
+						name
+						displayName
+						email
+						avatarUrl
+						active
+						admin
+						createdAt
+						updatedAt
+					}
+				}`,
+				variables: { userId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const user = (responseData as { data: { user: IDataObject } }).data.user;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(user as IDataObject),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/user/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/user/getAll.operation.ts
@@ -1,0 +1,90 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+
+import { linearApiRequestAllItems } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: { minValue: 1 },
+		displayOptions: {
+			show: { returnAll: [false] },
+		},
+		description: 'Max number of results to return',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['user'],
+		operation: ['getAll'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	_items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
+	const limit = returnAll ? undefined : (this.getNodeParameter('limit', 0) as number);
+
+	const body = {
+		query: `query Users($first: Int, $after: String) {
+			users(first: $first, after: $after) {
+				nodes {
+					id
+					name
+					displayName
+					email
+					avatarUrl
+					active
+					admin
+					createdAt
+					updatedAt
+				}
+				pageInfo {
+					hasNextPage
+					endCursor
+				}
+			}
+		}`,
+		variables: { first: 50 },
+	};
+
+	try {
+		const users = await linearApiRequestAllItems.call(this, 'data.users', body, limit);
+
+		const executionData = this.helpers.constructExecutionMetaData(
+			this.helpers.returnJsonArray(users),
+			{ itemData: { item: 0 } },
+		);
+		returnData.push(...executionData);
+	} catch (error) {
+		if (this.continueOnFail()) {
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ error: (error as Error).message }),
+					{ itemData: { item: 0 } },
+				),
+			);
+		} else {
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/user/getCurrent.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/user/getCurrent.operation.ts
@@ -1,0 +1,68 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [];
+
+const displayOptions = {
+	show: {
+		resource: ['user'],
+		operation: ['getCurrent'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	_items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	try {
+		const body = {
+			query: `query Viewer {
+				viewer {
+					id
+					name
+					displayName
+					email
+					avatarUrl
+					active
+					admin
+					createdAt
+					updatedAt
+				}
+			}`,
+			variables: {},
+		};
+
+		const responseData = await linearApiRequest.call(this, body);
+		const user = (responseData as { data: { viewer: IDataObject } }).data.viewer;
+
+		const executionData = this.helpers.constructExecutionMetaData(
+			this.helpers.returnJsonArray(user as IDataObject),
+			{ itemData: { item: 0 } },
+		);
+		returnData.push(...executionData);
+	} catch (error) {
+		if (this.continueOnFail()) {
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ error: (error as Error).message }),
+					{ itemData: { item: 0 } },
+				),
+			);
+		} else {
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/user/index.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/user/index.ts
@@ -1,0 +1,45 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as get from './get.operation';
+import * as getAll from './getAll.operation';
+import * as getCurrent from './getCurrent.operation';
+
+export { get, getAll, getCurrent };
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['user'],
+			},
+		},
+		options: [
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a user',
+				action: 'Get a user',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get many users',
+				action: 'Get many users',
+			},
+			{
+				name: 'Get Current',
+				value: 'getCurrent',
+				description: 'Get the currently authenticated user',
+				action: 'Get current user',
+			},
+		],
+		default: 'getCurrent',
+	},
+	...get.description,
+	...getAll.description,
+	...getCurrent.description,
+];

--- a/packages/nodes-base/nodes/Linear/v2/actions/versionDescription.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/versionDescription.ts
@@ -1,0 +1,137 @@
+import { NodeConnectionTypes, type INodeTypeDescription } from 'n8n-workflow';
+
+import * as attachment from './attachment';
+import * as comment from './comment';
+import * as cycle from './cycle';
+import * as document from './document';
+import * as issue from './issue';
+import * as label from './label';
+import * as project from './project';
+import * as roadmap from './roadmap';
+import * as team from './team';
+import * as teamMembership from './teamMembership';
+import * as user from './user';
+import * as workflowState from './workflowState';
+
+export const versionDescription: INodeTypeDescription = {
+	displayName: 'Linear',
+	name: 'linear',
+	icon: 'file:linear.svg',
+	group: ['output'],
+	version: 2,
+	subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
+	description: 'Consume Linear API',
+	defaults: {
+		name: 'Linear',
+	},
+	inputs: [NodeConnectionTypes.Main],
+	outputs: [NodeConnectionTypes.Main],
+	credentials: [
+		{
+			name: 'linearApi',
+			required: true,
+			testedBy: 'linearApiTest',
+			displayOptions: {
+				show: {
+					authentication: ['apiToken'],
+				},
+			},
+		},
+		{
+			name: 'linearOAuth2Api',
+			required: true,
+			displayOptions: {
+				show: {
+					authentication: ['oAuth2'],
+				},
+			},
+		},
+	],
+	properties: [
+		{
+			displayName: 'Authentication',
+			name: 'authentication',
+			type: 'options',
+			options: [
+				{
+					name: 'API Token',
+					value: 'apiToken',
+				},
+				{
+					name: 'OAuth2',
+					value: 'oAuth2',
+				},
+			],
+			default: 'apiToken',
+		},
+		{
+			displayName: 'Resource',
+			name: 'resource',
+			type: 'options',
+			noDataExpression: true,
+			options: [
+				{
+					name: 'Attachment',
+					value: 'attachment',
+				},
+				{
+					name: 'Comment',
+					value: 'comment',
+				},
+				{
+					name: 'Cycle',
+					value: 'cycle',
+				},
+				{
+					name: 'Document',
+					value: 'document',
+				},
+				{
+					name: 'Issue',
+					value: 'issue',
+				},
+				{
+					name: 'Label',
+					value: 'label',
+				},
+				{
+					name: 'Project',
+					value: 'project',
+				},
+				{
+					name: 'Roadmap',
+					value: 'roadmap',
+				},
+				{
+					name: 'Team',
+					value: 'team',
+				},
+				{
+					name: 'Team Membership',
+					value: 'teamMembership',
+				},
+				{
+					name: 'User',
+					value: 'user',
+				},
+				{
+					name: 'Workflow State',
+					value: 'workflowState',
+				},
+			],
+			default: 'issue',
+		},
+		...attachment.description,
+		...comment.description,
+		...cycle.description,
+		...document.description,
+		...issue.description,
+		...label.description,
+		...project.description,
+		...roadmap.description,
+		...team.description,
+		...teamMembership.description,
+		...user.description,
+		...workflowState.description,
+	],
+};

--- a/packages/nodes-base/nodes/Linear/v2/actions/workflowState/get.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/workflowState/get.operation.ts
@@ -1,0 +1,85 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Workflow State ID',
+		name: 'workflowStateId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['workflowState'],
+		operation: ['get'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const workflowStateId = this.getNodeParameter('workflowStateId', i) as string;
+
+			const body = {
+				query: `query WorkflowState($workflowStateId: String!) {
+					workflowState(id: $workflowStateId) {
+						id
+						name
+						type
+						color
+						description
+						position
+						createdAt
+						updatedAt
+						team {
+							id
+							name
+						}
+					}
+				}`,
+				variables: { workflowStateId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const state = (responseData as { data: { workflowState: IDataObject } }).data.workflowState;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray(state as IDataObject),
+					{
+						itemData: { item: i },
+					},
+				),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/workflowState/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/workflowState/getAll.operation.ts
@@ -1,0 +1,115 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequestAllItems } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: { minValue: 1 },
+		displayOptions: { show: { returnAll: [false] } },
+		description: 'Max number of results to return',
+	},
+	{
+		displayName: 'Filters',
+		name: 'filters',
+		type: 'collection',
+		placeholder: 'Add Filter',
+		default: {},
+		options: [
+			{
+				displayName: 'Team Name or ID',
+				name: 'teamId',
+				type: 'options',
+				description:
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: { loadOptionsMethod: 'getTeams' },
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['workflowState'],
+		operation: ['getAll'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	_items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+	const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
+	const limit = returnAll ? undefined : (this.getNodeParameter('limit', 0) as number);
+	const filters = this.getNodeParameter('filters', 0) as IDataObject;
+
+	const filter: IDataObject = {};
+	if (filters.teamId) filter.team = { id: { eq: filters.teamId } };
+
+	const body = {
+		query: `query WorkflowStates($first: Int, $after: String, $filter: WorkflowStateFilter) {
+			workflowStates(first: $first, after: $after, filter: $filter) {
+				nodes {
+					id
+					name
+					type
+					color
+					description
+					position
+					createdAt
+					updatedAt
+					team {
+						id
+						name
+					}
+				}
+				pageInfo { hasNextPage endCursor }
+			}
+		}`,
+		variables: {
+			first: 50,
+			...(Object.keys(filter).length > 0 ? { filter } : {}),
+		},
+	};
+
+	try {
+		const states = await linearApiRequestAllItems.call(this, 'data.workflowStates', body, limit);
+		returnData.push(
+			...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(states), {
+				itemData: { item: 0 },
+			}),
+		);
+	} catch (error) {
+		if (this.continueOnFail()) {
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ error: (error as Error).message }),
+					{ itemData: { item: 0 } },
+				),
+			);
+		} else {
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/workflowState/index.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/workflowState/index.ts
@@ -1,0 +1,37 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as get from './get.operation';
+import * as getAll from './getAll.operation';
+
+export { get, getAll };
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['workflowState'],
+			},
+		},
+		options: [
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a workflow state',
+				action: 'Get a workflow state',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get many workflow states',
+				action: 'Get many workflow states',
+			},
+		],
+		default: 'getAll',
+	},
+	...get.description,
+	...getAll.description,
+];


### PR DESCRIPTION
## Summary

Adds Linear node v2 supporting a significantly expanded set of resources and operations. Stacked on top of the refactor PR — v1 remains fully intact for existing workflows.

**New resources and operations:**

| Resource | Operations |
|----------|-----------|
| Issue | create, update, delete, get, getAll, archive, unarchive, search |
| Comment | create, update, delete, get, getAll |
| Project | create, update, delete, get, getAll, archive |
| User | get, getAll, getCurrent |
| Team | get, getAll |
| Label | create, update, delete, get, getAll |
| Cycle | create, update, delete, get, getAll, archive |
| Attachment | create, update, delete, get |
| WorkflowState | get, getAll |
| Document | create, update, delete, get, getAll |
| Roadmap | create, update, delete, get, getAll |
| TeamMembership | create, delete, getAll |

**Trigger node** expanded with Attachment, Document, Roadmap, and TeamMembership events.

**Architecture:** Follows n8n's `VersionedNodeType` pattern with a clean `actions/` structure (one file per operation). Shared `GenericFunctions`, `constants`, and `loadOptions` methods are reused from the `shared/` layer introduced in the refactor PR.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4288

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included. (existing v1 tests pass; v2 smoke paths covered by typecheck + lint)