### PR TITLE
feat(Linear Node): Add v2 with Issue and Comment resources

### DIFF
--- a/packages/nodes-base/nodes/Linear/Linear.node.ts
+++ b/packages/nodes-base/nodes/Linear/Linear.node.ts
@@ -2,6 +2,7 @@ import type { INodeTypeBaseDescription, IVersionedNodeType } from 'n8n-workflow'
 import { VersionedNodeType } from 'n8n-workflow';
 
 import { LinearV1 } from './v1/LinearV1.node';
+import { LinearV2 } from './v2/LinearV2.node';
 
 export class Linear extends VersionedNodeType {
 	constructor() {
@@ -11,12 +12,13 @@ export class Linear extends VersionedNodeType {
 			icon: 'file:linear.svg',
 			group: ['output'],
 			description: 'Consume Linear API',
-			defaultVersion: 1.1,
+			defaultVersion: 2,
 		};
 
 		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
 			1: new LinearV1(baseDescription),
 			1.1: new LinearV1(baseDescription),
+			2: new LinearV2(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/packages/nodes-base/nodes/Linear/LinearTrigger.node.ts
+++ b/packages/nodes-base/nodes/Linear/LinearTrigger.node.ts
@@ -2,6 +2,7 @@ import type { INodeTypeBaseDescription, IVersionedNodeType } from 'n8n-workflow'
 import { VersionedNodeType } from 'n8n-workflow';
 
 import { LinearTriggerV1 } from './v1/LinearTriggerV1.node';
+import { LinearTriggerV2 } from './v2/LinearTriggerV2.node';
 
 export class LinearTrigger extends VersionedNodeType {
 	constructor() {
@@ -11,11 +12,12 @@ export class LinearTrigger extends VersionedNodeType {
 			icon: 'file:linear.svg',
 			group: ['trigger'],
 			description: 'Starts the workflow when Linear events occur',
-			defaultVersion: 1,
+			defaultVersion: 2,
 		};
 
 		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
 			1: new LinearTriggerV1(baseDescription),
+			2: new LinearTriggerV2(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/packages/nodes-base/nodes/Linear/test/node/v2/LinearV2.issue.test.ts
+++ b/packages/nodes-base/nodes/Linear/test/node/v2/LinearV2.issue.test.ts
@@ -1,0 +1,139 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+import * as GenericFunctions from '../../../shared/GenericFunctions';
+import * as commentCreate from '../../../v2/actions/comment/create.operation';
+import * as issueCreate from '../../../v2/actions/issue/create.operation';
+import * as issueGet from '../../../v2/actions/issue/get.operation';
+import * as issueGetAll from '../../../v2/actions/issue/getAll.operation';
+
+describe('Linear v2 → Issue & Comment', () => {
+	let mockThis: IExecuteFunctions;
+	let apiRequestSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		mockThis = {
+			getInputData: jest.fn().mockReturnValue([{ json: {} }]),
+			getNodeParameter: jest.fn(),
+			continueOnFail: jest.fn().mockReturnValue(false),
+			helpers: {
+				returnJsonArray: jest.fn().mockImplementation((d) => [{ json: d }]),
+				constructExecutionMetaData: jest.fn().mockImplementation((d) => d),
+			},
+		} as unknown as IExecuteFunctions;
+	});
+
+	afterEach(() => jest.restoreAllMocks());
+
+	describe('issue.create', () => {
+		it('sends issueCreate mutation with required fields', async () => {
+			apiRequestSpy = jest
+				.spyOn(GenericFunctions, 'linearApiRequest')
+				.mockResolvedValue({ data: { issueCreate: { issue: { id: 'issue-1', title: 'Bug' } } } });
+
+			(mockThis.getNodeParameter as jest.Mock).mockImplementation((param: string) => {
+				if (param === 'teamId') return 'team-abc';
+				if (param === 'title') return 'Bug report';
+				if (param === 'additionalFields') return {};
+				return undefined;
+			});
+
+			await issueCreate.execute.call(mockThis, [{ json: {} }]);
+
+			expect(apiRequestSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					query: expect.stringContaining('issueCreate'),
+					variables: expect.objectContaining({ teamId: 'team-abc', title: 'Bug report' }),
+				}),
+			);
+		});
+	});
+
+	describe('issue.getAll', () => {
+		it('calls issues query and respects limit', async () => {
+			const allItemsSpy = jest
+				.spyOn(GenericFunctions, 'linearApiRequestAllItems')
+				.mockResolvedValue([{ id: 'issue-1' }, { id: 'issue-2' }]);
+
+			(mockThis.getNodeParameter as jest.Mock).mockImplementation((param: string) => {
+				if (param === 'returnAll') return false;
+				if (param === 'limit') return 10;
+				if (param === 'filters') return {};
+				return undefined;
+			});
+
+			await issueGetAll.execute.call(mockThis, [{ json: {} }]);
+
+			expect(allItemsSpy).toHaveBeenCalledWith(
+				'data.issues',
+				expect.objectContaining({ query: expect.stringContaining('issues') }),
+				10,
+			);
+		});
+
+		it('passes undefined limit when returnAll is true', async () => {
+			const allItemsSpy = jest
+				.spyOn(GenericFunctions, 'linearApiRequestAllItems')
+				.mockResolvedValue([]);
+
+			(mockThis.getNodeParameter as jest.Mock).mockImplementation((param: string) => {
+				if (param === 'returnAll') return true;
+				if (param === 'filters') return {};
+				return undefined;
+			});
+
+			await issueGetAll.execute.call(mockThis, [{ json: {} }]);
+
+			expect(allItemsSpy).toHaveBeenCalledWith(
+				'data.issues',
+				expect.objectContaining({ query: expect.stringContaining('issues') }),
+				undefined,
+			);
+		});
+	});
+
+	describe('issue.get', () => {
+		it('sends issue query with correct ID', async () => {
+			apiRequestSpy = jest
+				.spyOn(GenericFunctions, 'linearApiRequest')
+				.mockResolvedValue({ data: { issue: { id: 'issue-42', title: 'Test' } } });
+
+			(mockThis.getNodeParameter as jest.Mock).mockImplementation((param: string) => {
+				if (param === 'issueId') return 'issue-42';
+				return undefined;
+			});
+
+			await issueGet.execute.call(mockThis, [{ json: {} }]);
+
+			expect(apiRequestSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					query: expect.stringContaining('issue'),
+					variables: expect.objectContaining({ issueId: 'issue-42' }),
+				}),
+			);
+		});
+	});
+
+	describe('comment.create', () => {
+		it('sends commentCreate mutation with issueId and body', async () => {
+			apiRequestSpy = jest.spyOn(GenericFunctions, 'linearApiRequest').mockResolvedValue({
+				data: { commentCreate: { id: 'comment-1', body: 'Hello' } },
+			});
+
+			(mockThis.getNodeParameter as jest.Mock).mockImplementation((param: string) => {
+				if (param === 'issueId') return 'issue-abc';
+				if (param === 'body') return 'This is a comment';
+				if (param === 'additionalFields') return {};
+				return undefined;
+			});
+
+			await commentCreate.execute.call(mockThis, [{ json: {} }]);
+
+			expect(apiRequestSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					query: expect.stringContaining('commentCreate'),
+					variables: expect.objectContaining({ issueId: 'issue-abc', body: 'This is a comment' }),
+				}),
+			);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Linear/v2/LinearTriggerV2.node.ts
+++ b/packages/nodes-base/nodes/Linear/v2/LinearTriggerV2.node.ts
@@ -1,0 +1,311 @@
+import {
+	type IHookFunctions,
+	type IWebhookFunctions,
+	type ILoadOptionsFunctions,
+	type INodePropertyOptions,
+	type INodeType,
+	type INodeTypeBaseDescription,
+	type INodeTypeDescription,
+	type IWebhookResponseData,
+	type IDataObject,
+	NodeConnectionTypes,
+} from 'n8n-workflow';
+
+import { capitalizeFirstLetter, linearApiRequest } from '../shared/GenericFunctions';
+
+export class LinearTriggerV2 implements INodeType {
+	description: INodeTypeDescription;
+
+	constructor(baseDescription: INodeTypeBaseDescription) {
+		this.description = {
+			...baseDescription,
+			displayName: 'Linear Trigger',
+			name: 'linearTrigger',
+			icon: 'file:linear.svg',
+			group: ['trigger'],
+			version: 2,
+			subtitle: '={{$parameter["triggerOn"]}}',
+			description: 'Starts the workflow when Linear events occur',
+			defaults: {
+				name: 'Linear Trigger',
+			},
+			inputs: [],
+			outputs: [NodeConnectionTypes.Main],
+			credentials: [
+				{
+					name: 'linearApi',
+					required: true,
+					testedBy: 'linearApiTest',
+					displayOptions: {
+						show: {
+							authentication: ['apiToken'],
+						},
+					},
+				},
+				{
+					name: 'linearOAuth2Api',
+					required: true,
+					displayOptions: {
+						show: {
+							authentication: ['oAuth2'],
+						},
+					},
+				},
+			],
+			webhooks: [
+				{
+					name: 'default',
+					httpMethod: 'POST',
+					responseMode: 'onReceived',
+					path: 'webhook',
+				},
+			],
+			properties: [
+				{
+					displayName: 'Authentication',
+					name: 'authentication',
+					type: 'options',
+					options: [
+						{
+							name: 'API Token',
+							value: 'apiToken',
+						},
+						{
+							name: 'OAuth2',
+							value: 'oAuth2',
+						},
+					],
+					default: 'apiToken',
+				},
+				{
+					displayName: 'Make sure your credential has the "Admin" scope to create webhooks.',
+					name: 'notice',
+					type: 'notice',
+					default: '',
+				},
+				{
+					displayName: 'Team Name or ID',
+					name: 'teamId',
+					type: 'options',
+					description:
+						'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					typeOptions: {
+						loadOptionsMethod: 'getTeams',
+					},
+					default: '',
+				},
+				{
+					displayName: 'Listen to Resources',
+					name: 'resources',
+					type: 'multiOptions',
+					options: [
+						{
+							name: 'Attachment',
+							value: 'attachment',
+						},
+						{
+							name: 'Comment Reaction',
+							value: 'reaction',
+						},
+						{
+							name: 'Cycle',
+							value: 'cycle',
+						},
+						{
+							name: 'Document',
+							value: 'document',
+						},
+						{
+							name: 'Issue',
+							value: 'issue',
+						},
+						{
+							name: 'Issue Comment',
+							value: 'comment',
+						},
+						{
+							name: 'Issue Label',
+							value: 'issueLabel',
+						},
+						{
+							name: 'Project',
+							value: 'project',
+						},
+						{
+							name: 'Roadmap',
+							value: 'roadmap',
+						},
+						{
+							name: 'Team Membership',
+							value: 'teamMembership',
+						},
+					],
+					default: [],
+					required: true,
+				},
+			],
+		};
+	}
+
+	methods = {
+		loadOptions: {
+			async getTeams(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+				const returnData: INodePropertyOptions[] = [];
+				const body = {
+					query: `query Teams {
+						 teams {
+							nodes {
+								id
+								name
+							}
+						}
+					}`,
+				};
+				const {
+					data: {
+						teams: { nodes },
+					},
+				} = (await linearApiRequest.call(this, body)) as {
+					data: { teams: { nodes: Array<{ id: string; name: string }> } };
+				};
+
+				for (const node of nodes) {
+					returnData.push({
+						name: node.name,
+						value: node.id,
+					});
+				}
+				return returnData;
+			},
+		},
+	};
+
+	webhookMethods = {
+		default: {
+			async checkExists(this: IHookFunctions): Promise<boolean> {
+				const webhookUrl = this.getNodeWebhookUrl('default');
+				const webhookData = this.getWorkflowStaticData('node');
+				const teamId = this.getNodeParameter('teamId') as string;
+				const body = {
+					query: `query {
+						 webhooks {
+								nodes {
+									id
+									url
+									enabled
+									team {
+										id
+										name
+									}
+								}
+						}
+					}`,
+				};
+				const {
+					data: {
+						webhooks: { nodes },
+					},
+				} = (await linearApiRequest.call(this, body)) as {
+					data: {
+						webhooks: {
+							nodes: Array<{ id: string; url: string; enabled: boolean; team: { id: string } }>;
+						};
+					};
+				};
+
+				for (const node of nodes) {
+					if (node.url === webhookUrl && node.team.id === teamId && node.enabled === true) {
+						webhookData.webhookId = node.id as string;
+						return true;
+					}
+				}
+				return false;
+			},
+			async create(this: IHookFunctions): Promise<boolean> {
+				const webhookData = this.getWorkflowStaticData('node');
+				const webhookUrl = this.getNodeWebhookUrl('default');
+				const teamId = this.getNodeParameter('teamId') as string;
+				const resources = this.getNodeParameter('resources') as string[];
+				const body = {
+					query: `
+						mutation webhookCreate($url: String!, $teamId: String!, $resources: [String!]!) {
+							webhookCreate(
+								input: {
+									url: $url
+									teamId: $teamId
+									resourceTypes: $resources
+								}
+							) {
+								success
+								webhook {
+									id
+									enabled
+								}
+							}
+						}`,
+					variables: {
+						url: webhookUrl,
+						teamId,
+						resources: resources.map(capitalizeFirstLetter),
+					},
+				};
+
+				const {
+					data: {
+						webhookCreate: {
+							success,
+							webhook: { id },
+						},
+					},
+				} = (await linearApiRequest.call(this, body)) as {
+					data: {
+						webhookCreate: {
+							success: boolean;
+							webhook: { id: string; enabled: boolean };
+						};
+					};
+				};
+
+				if (!success) {
+					return false;
+				}
+				webhookData.webhookId = id as string;
+
+				return true;
+			},
+			async delete(this: IHookFunctions): Promise<boolean> {
+				const webhookData = this.getWorkflowStaticData('node');
+				if (webhookData.webhookId !== undefined) {
+					const body = {
+						query: `
+							mutation webhookDelete($id: String!){
+								webhookDelete(
+									id: $id
+								) {
+									success
+								}
+							}`,
+						variables: {
+							id: webhookData.webhookId,
+						},
+					};
+
+					try {
+						await linearApiRequest.call(this, body as IDataObject);
+					} catch (error) {
+						return false;
+					}
+					delete webhookData.webhookId;
+				}
+				return true;
+			},
+		},
+	};
+
+	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
+		const bodyData = this.getBodyData();
+		return {
+			workflowData: [this.helpers.returnJsonArray(bodyData)],
+		};
+	}
+}

--- a/packages/nodes-base/nodes/Linear/v2/LinearV2.node.ts
+++ b/packages/nodes-base/nodes/Linear/v2/LinearV2.node.ts
@@ -1,0 +1,79 @@
+import type {
+	ICredentialDataDecryptedObject,
+	ICredentialsDecrypted,
+	ICredentialTestFunctions,
+	IExecuteFunctions,
+	INodeCredentialTestResult,
+	INodeExecutionData,
+	INodeType,
+	INodeTypeBaseDescription,
+	INodeTypeDescription,
+	JsonObject,
+	IDataObject,
+} from 'n8n-workflow';
+
+import { router } from './actions/router';
+import { versionDescription } from './actions/versionDescription';
+import {
+	getTeams,
+	getUsers,
+	getStates,
+	getLabels,
+	getProjects,
+	getCycles,
+} from '../shared/methods/loadOptions';
+import { validateCredentials } from '../shared/GenericFunctions';
+
+export class LinearV2 implements INodeType {
+	description: INodeTypeDescription;
+
+	constructor(baseDescription: INodeTypeBaseDescription) {
+		this.description = {
+			...baseDescription,
+			...versionDescription,
+			usableAsTool: true,
+		};
+	}
+
+	methods = {
+		credentialTest: {
+			async linearApiTest(
+				this: ICredentialTestFunctions,
+				credential: ICredentialsDecrypted,
+			): Promise<INodeCredentialTestResult> {
+				try {
+					await validateCredentials.call(this, credential.data as ICredentialDataDecryptedObject);
+				} catch (error) {
+					const { error: err } = error as JsonObject;
+					const errors = (err as IDataObject).errors as [{ extensions: { code: string } }];
+					const authenticationError = Boolean(
+						errors?.filter((e) => e.extensions.code === 'AUTHENTICATION_ERROR').length,
+					);
+					if (authenticationError) {
+						return {
+							status: 'Error',
+							message: 'The security token included in the request is invalid',
+						};
+					}
+				}
+
+				return {
+					status: 'OK',
+					message: 'Connection successful!',
+				};
+			},
+		},
+		loadOptions: {
+			getTeams,
+			getUsers,
+			getStates,
+			getLabels,
+			getProjects,
+			getCycles,
+		},
+	};
+
+	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+		return await router.call(this);
+	}
+}

--- a/packages/nodes-base/nodes/Linear/v2/LinearV2.node.ts
+++ b/packages/nodes-base/nodes/Linear/v2/LinearV2.node.ts
@@ -55,6 +55,7 @@ export class LinearV2 implements INodeType {
 							message: 'The security token included in the request is invalid',
 						};
 					}
+					throw error;
 				}
 
 				return {

--- a/packages/nodes-base/nodes/Linear/v2/LinearV2.node.ts
+++ b/packages/nodes-base/nodes/Linear/v2/LinearV2.node.ts
@@ -8,7 +8,6 @@ import type {
 	INodeType,
 	INodeTypeBaseDescription,
 	INodeTypeDescription,
-	IDataObject,
 } from 'n8n-workflow';
 
 import { router } from './actions/router';

--- a/packages/nodes-base/nodes/Linear/v2/LinearV2.node.ts
+++ b/packages/nodes-base/nodes/Linear/v2/LinearV2.node.ts
@@ -8,7 +8,6 @@ import type {
 	INodeType,
 	INodeTypeBaseDescription,
 	INodeTypeDescription,
-	JsonObject,
 	IDataObject,
 } from 'n8n-workflow';
 
@@ -44,12 +43,12 @@ export class LinearV2 implements INodeType {
 				try {
 					await validateCredentials.call(this, credential.data as ICredentialDataDecryptedObject);
 				} catch (error) {
-					const { error: err } = error as JsonObject;
-					const errors = (err as IDataObject).errors as [{ extensions: { code: string } }];
-					const authenticationError = Boolean(
-						errors?.filter((e) => e.extensions.code === 'AUTHENTICATION_ERROR').length,
-					);
-					if (authenticationError) {
+					const apiErrors = (
+						error as { error?: { errors?: Array<{ extensions?: { code?: string } }> } }
+					)?.error?.errors;
+					const isAuthError =
+						apiErrors?.some((e) => e?.extensions?.code === 'AUTHENTICATION_ERROR') ?? false;
+					if (isAuthError) {
 						return {
 							status: 'Error',
 							message: 'The security token included in the request is invalid',

--- a/packages/nodes-base/nodes/Linear/v2/actions/comment/create.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/comment/create.operation.ts
@@ -1,0 +1,117 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Issue ID',
+		name: 'issueId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'Body',
+		name: 'body',
+		type: 'string',
+		required: true,
+		typeOptions: { rows: 4 },
+		default: '',
+		description: 'The comment body in markdown format',
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		options: [
+			{
+				displayName: 'Parent Comment ID',
+				name: 'parentId',
+				type: 'string',
+				description: 'ID of the parent comment if this is a reply',
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['comment'],
+		operation: ['create'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const issueId = this.getNodeParameter('issueId', i) as string;
+			const body = this.getNodeParameter('body', i) as string;
+			const additionalFields = this.getNodeParameter('additionalFields', i) as Record<
+				string,
+				unknown
+			>;
+
+			const variables: IDataObject = { issueId, body };
+			if (additionalFields.parentId && (additionalFields.parentId as string).trim() !== '') {
+				variables.parentId = additionalFields.parentId;
+			}
+
+			const requestBody = {
+				query: `mutation CommentCreate($issueId: String!, $body: String!, $parentId: String) {
+					commentCreate(input: { issueId: $issueId, body: $body, parentId: $parentId }) {
+						success
+						comment {
+							id
+							body
+							createdAt
+							updatedAt
+							user {
+								id
+								displayName
+							}
+						}
+					}
+				}`,
+				variables,
+			};
+
+			const responseData = await linearApiRequest.call(this, requestBody);
+			const result = (responseData as { data: { commentCreate: IDataObject } }).data.commentCreate;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(result),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/comment/delete.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/comment/delete.operation.ts
@@ -1,0 +1,72 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Comment ID',
+		name: 'commentId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['comment'],
+		operation: ['delete'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const commentId = this.getNodeParameter('commentId', i) as string;
+
+			const body = {
+				query: `mutation CommentDelete($commentId: String!) {
+					commentDelete(id: $commentId) {
+						success
+					}
+				}`,
+				variables: { commentId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const result = (responseData as { data: { commentDelete: IDataObject } }).data.commentDelete;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(result),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/comment/get.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/comment/get.operation.ts
@@ -1,0 +1,85 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Comment ID',
+		name: 'commentId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['comment'],
+		operation: ['get'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const commentId = this.getNodeParameter('commentId', i) as string;
+
+			const body = {
+				query: `query Comment($commentId: String!) {
+					comment(id: $commentId) {
+						id
+						body
+						createdAt
+						updatedAt
+						user {
+							id
+							displayName
+							email
+						}
+						issue {
+							id
+							identifier
+							title
+						}
+					}
+				}`,
+				variables: { commentId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const comment = (responseData as { data: { comment: IDataObject } }).data.comment;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(comment),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/comment/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/comment/getAll.operation.ts
@@ -1,0 +1,104 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+
+import { linearApiRequestAllItems } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Issue ID',
+		name: 'issueId',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'The ID of the issue to get comments for',
+	},
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: { minValue: 1 },
+		displayOptions: {
+			show: { returnAll: [false] },
+		},
+		description: 'Max number of results to return',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['comment'],
+		operation: ['getAll'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	_items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	const issueId = this.getNodeParameter('issueId', 0) as string;
+	const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
+	const limit = returnAll ? undefined : (this.getNodeParameter('limit', 0) as number);
+
+	const body = {
+		query: `query IssueComments($issueId: String!, $first: Int, $after: String) {
+			issue(id: $issueId) {
+				comments(first: $first, after: $after) {
+					nodes {
+						id
+						body
+						createdAt
+						updatedAt
+						user {
+							id
+							displayName
+							email
+						}
+					}
+					pageInfo {
+						hasNextPage
+						endCursor
+					}
+				}
+			}
+		}`,
+		variables: {
+			issueId,
+			first: 50,
+		},
+	};
+
+	try {
+		const comments = await linearApiRequestAllItems.call(this, 'data.issue.comments', body, limit);
+
+		const executionData = this.helpers.constructExecutionMetaData(
+			this.helpers.returnJsonArray(comments),
+			{ itemData: { item: 0 } },
+		);
+		returnData.push(...executionData);
+	} catch (error) {
+		if (this.continueOnFail()) {
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ error: (error as Error).message }),
+					{ itemData: { item: 0 } },
+				),
+			);
+		} else {
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/comment/index.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/comment/index.ts
@@ -1,0 +1,61 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as create from './create.operation';
+import * as deleteComment from './delete.operation';
+import * as get from './get.operation';
+import * as getAll from './getAll.operation';
+import * as update from './update.operation';
+
+export { create, deleteComment as delete, get, getAll, update };
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['comment'],
+			},
+		},
+		options: [
+			{
+				name: 'Create',
+				value: 'create',
+				description: 'Create a comment',
+				action: 'Create a comment',
+			},
+			{
+				name: 'Delete',
+				value: 'delete',
+				description: 'Delete a comment',
+				action: 'Delete a comment',
+			},
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a comment',
+				action: 'Get a comment',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get comments for an issue',
+				action: 'Get many comments',
+			},
+			{
+				name: 'Update',
+				value: 'update',
+				description: 'Update a comment',
+				action: 'Update a comment',
+			},
+		],
+		default: 'create',
+	},
+	...create.description,
+	...deleteComment.description,
+	...get.description,
+	...getAll.description,
+	...update.description,
+];

--- a/packages/nodes-base/nodes/Linear/v2/actions/comment/update.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/comment/update.operation.ts
@@ -43,10 +43,10 @@ export async function execute(
 	const returnData: INodeExecutionData[] = [];
 
 	for (let i = 0; i < items.length; i++) {
-		try {
-			const commentId = this.getNodeParameter('commentId', i) as string;
-			const body = this.getNodeParameter('body', i) as string;
+		const commentId = this.getNodeParameter('commentId', i) as string;
+		const body = this.getNodeParameter('body', i) as string;
 
+		try {
 			const requestBody = {
 				query: `mutation CommentUpdate($commentId: String!, $body: String!) {
 					commentUpdate(id: $commentId, input: { body: $body }) {

--- a/packages/nodes-base/nodes/Linear/v2/actions/comment/update.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/comment/update.operation.ts
@@ -1,0 +1,92 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Comment ID',
+		name: 'commentId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'Body',
+		name: 'body',
+		type: 'string',
+		required: true,
+		typeOptions: { rows: 4 },
+		default: '',
+		description: 'The new comment body in markdown format',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['comment'],
+		operation: ['update'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const commentId = this.getNodeParameter('commentId', i) as string;
+			const body = this.getNodeParameter('body', i) as string;
+
+			const requestBody = {
+				query: `mutation CommentUpdate($commentId: String!, $body: String!) {
+					commentUpdate(id: $commentId, input: { body: $body }) {
+						success
+						comment {
+							id
+							body
+							createdAt
+							updatedAt
+							user {
+								id
+								displayName
+							}
+						}
+					}
+				}`,
+				variables: { commentId, body },
+			};
+
+			const responseData = await linearApiRequest.call(this, requestBody);
+			const result = (responseData as { data: { commentUpdate: IDataObject } }).data.commentUpdate;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(result),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/issue/archive.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/issue/archive.operation.ts
@@ -1,0 +1,72 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Issue ID',
+		name: 'issueId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['issue'],
+		operation: ['archive'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const issueId = this.getNodeParameter('issueId', i) as string;
+
+			const body = {
+				query: `mutation IssueArchive($issueId: String!) {
+					issueArchive(id: $issueId) {
+						success
+					}
+				}`,
+				variables: { issueId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const result = (responseData as { data: { issueArchive: IDataObject } }).data.issueArchive;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(result),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/issue/create.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/issue/create.operation.ts
@@ -1,0 +1,183 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { ISSUE_FIELDS, PRIORITY_OPTIONS } from '../../../shared/constants';
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Team Name or ID',
+		name: 'teamId',
+		type: 'options',
+		description:
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+		required: true,
+		typeOptions: {
+			loadOptionsMethod: 'getTeams',
+		},
+		default: '',
+	},
+	{
+		displayName: 'Title',
+		name: 'title',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		options: [
+			{
+				displayName: 'Assignee Name or ID',
+				name: 'assigneeId',
+				type: 'options',
+				description:
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: {
+					loadOptionsMethod: 'getUsers',
+				},
+				default: '',
+			},
+			{
+				displayName: 'Description',
+				name: 'description',
+				type: 'string',
+				typeOptions: {
+					rows: 4,
+				},
+				default: '',
+			},
+			{
+				displayName: 'Due Date',
+				name: 'dueDate',
+				type: 'dateTime',
+				default: '',
+			},
+			{
+				displayName: 'Label Names or IDs',
+				name: 'labelIds',
+				type: 'multiOptions',
+				description:
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: {
+					loadOptionsMethod: 'getLabels',
+				},
+				default: [],
+			},
+			{
+				displayName: 'Priority',
+				name: 'priority',
+				type: 'options',
+				options: PRIORITY_OPTIONS,
+				default: 0,
+			},
+			{
+				displayName: 'State Name or ID',
+				name: 'stateId',
+				type: 'options',
+				description:
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: {
+					loadOptionsMethod: 'getStates',
+				},
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['issue'],
+		operation: ['create'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const teamId = this.getNodeParameter('teamId', i) as string;
+			const title = this.getNodeParameter('title', i) as string;
+			const additionalFields = this.getNodeParameter('additionalFields', i) as Record<
+				string,
+				unknown
+			>;
+
+			const body = {
+				query: `mutation IssueCreate(
+					$title: String!,
+					$teamId: String!,
+					$description: String,
+					$assigneeId: String,
+					$priority: Int,
+					$stateId: String,
+					$dueDate: TimelessDate,
+					$labelIds: [String!]
+				) {
+					issueCreate(input: {
+						title: $title
+						teamId: $teamId
+						description: $description
+						assigneeId: $assigneeId
+						priority: $priority
+						stateId: $stateId
+						dueDate: $dueDate
+						labelIds: $labelIds
+					}) {
+						success
+						issue {
+							${ISSUE_FIELDS}
+						}
+					}
+				}`,
+				variables: {
+					teamId,
+					title,
+					...additionalFields,
+				},
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const issue = (
+				responseData as {
+					data: { issueCreate: { issue: IDataObject } };
+				}
+			).data.issueCreate?.issue;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(issue),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/issue/delete.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/issue/delete.operation.ts
@@ -1,0 +1,72 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Issue ID',
+		name: 'issueId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['issue'],
+		operation: ['delete'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const issueId = this.getNodeParameter('issueId', i) as string;
+
+			const body = {
+				query: `mutation IssueDelete($issueId: String!) {
+					issueDelete(id: $issueId) {
+						success
+					}
+				}`,
+				variables: { issueId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const result = (responseData as { data: { issueDelete: IDataObject } }).data.issueDelete;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(result),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/issue/get.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/issue/get.operation.ts
@@ -36,9 +36,9 @@ export async function execute(
 	const returnData: INodeExecutionData[] = [];
 
 	for (let i = 0; i < items.length; i++) {
-		try {
-			const issueId = this.getNodeParameter('issueId', i) as string;
+		const issueId = this.getNodeParameter('issueId', i) as string;
 
+		try {
 			const body = {
 				query: `query Issue($issueId: String!) {
 					issue(id: $issueId) {

--- a/packages/nodes-base/nodes/Linear/v2/actions/issue/get.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/issue/get.operation.ts
@@ -1,0 +1,74 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { ISSUE_FIELDS } from '../../../shared/constants';
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Issue ID',
+		name: 'issueId',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'The ID of the issue to retrieve',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['issue'],
+		operation: ['get'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const issueId = this.getNodeParameter('issueId', i) as string;
+
+			const body = {
+				query: `query Issue($issueId: String!) {
+					issue(id: $issueId) {
+						${ISSUE_FIELDS}
+					}
+				}`,
+				variables: { issueId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const issue = (responseData as { data: { issue: IDataObject } }).data.issue;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(issue),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/issue/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/issue/getAll.operation.ts
@@ -1,0 +1,144 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { ISSUE_FIELDS, PRIORITY_OPTIONS } from '../../../shared/constants';
+import { linearApiRequestAllItems } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: { minValue: 1 },
+		displayOptions: {
+			show: { returnAll: [false] },
+		},
+		description: 'Max number of results to return',
+	},
+	{
+		displayName: 'Filters',
+		name: 'filters',
+		type: 'collection',
+		placeholder: 'Add Filter',
+		default: {},
+		options: [
+			{
+				displayName: 'Assignee Name or ID',
+				name: 'assigneeId',
+				type: 'options',
+				description:
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: { loadOptionsMethod: 'getUsers' },
+				default: '',
+			},
+			{
+				displayName: 'Priority',
+				name: 'priority',
+				type: 'options',
+				options: PRIORITY_OPTIONS,
+				default: 0,
+			},
+			{
+				displayName: 'State Name or ID',
+				name: 'stateId',
+				type: 'options',
+				description:
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: { loadOptionsMethod: 'getStates' },
+				default: '',
+			},
+			{
+				displayName: 'Team Name or ID',
+				name: 'teamId',
+				type: 'options',
+				description:
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: { loadOptionsMethod: 'getTeams' },
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['issue'],
+		operation: ['getAll'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	_items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
+	const filters = this.getNodeParameter('filters', 0) as IDataObject;
+	const limit = returnAll ? undefined : (this.getNodeParameter('limit', 0) as number);
+
+	// Build filter object for the query
+	const filter: IDataObject = {};
+	if (filters.assigneeId) filter.assignee = { id: { eq: filters.assigneeId } };
+	if (filters.priority !== undefined && filters.priority !== '') {
+		filter.priority = { eq: filters.priority };
+	}
+	if (filters.stateId) filter.state = { id: { eq: filters.stateId } };
+	if (filters.teamId) filter.team = { id: { eq: filters.teamId } };
+
+	const body = {
+		query: `query Issues($first: Int, $after: String, $filter: IssueFilter) {
+			issues(first: $first, after: $after, filter: $filter) {
+				nodes {
+					${ISSUE_FIELDS}
+				}
+				pageInfo {
+					hasNextPage
+					endCursor
+				}
+			}
+		}`,
+		variables: {
+			first: 50,
+			...(Object.keys(filter).length > 0 ? { filter } : {}),
+		},
+	};
+
+	try {
+		const issues = await linearApiRequestAllItems.call(this, 'data.issues', body, limit);
+
+		const executionData = this.helpers.constructExecutionMetaData(
+			this.helpers.returnJsonArray(issues),
+			{ itemData: { item: 0 } },
+		);
+		returnData.push(...executionData);
+	} catch (error) {
+		if (this.continueOnFail()) {
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ error: (error as Error).message }),
+					{ itemData: { item: 0 } },
+				),
+			);
+		} else {
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/issue/index.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/issue/index.ts
@@ -1,0 +1,85 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as archive from './archive.operation';
+import * as create from './create.operation';
+import * as deleteIssue from './delete.operation';
+import * as get from './get.operation';
+import * as getAll from './getAll.operation';
+import * as search from './search.operation';
+import * as unarchive from './unarchive.operation';
+import * as update from './update.operation';
+
+export { archive, create, deleteIssue as delete, get, getAll, search, unarchive, update };
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['issue'],
+			},
+		},
+		options: [
+			{
+				name: 'Archive',
+				value: 'archive',
+				description: 'Archive an issue',
+				action: 'Archive an issue',
+			},
+			{
+				name: 'Create',
+				value: 'create',
+				description: 'Create an issue',
+				action: 'Create an issue',
+			},
+			{
+				name: 'Delete',
+				value: 'delete',
+				description: 'Delete an issue',
+				action: 'Delete an issue',
+			},
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get an issue',
+				action: 'Get an issue',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get many issues',
+				action: 'Get many issues',
+			},
+			{
+				name: 'Search',
+				value: 'search',
+				description: 'Search issues by text',
+				action: 'Search issues',
+			},
+			{
+				name: 'Unarchive',
+				value: 'unarchive',
+				description: 'Unarchive an issue',
+				action: 'Unarchive an issue',
+			},
+			{
+				name: 'Update',
+				value: 'update',
+				description: 'Update an issue',
+				action: 'Update an issue',
+			},
+		],
+		default: 'create',
+	},
+	...archive.description,
+	...create.description,
+	...deleteIssue.description,
+	...get.description,
+	...getAll.description,
+	...search.description,
+	...unarchive.description,
+	...update.description,
+];

--- a/packages/nodes-base/nodes/Linear/v2/actions/issue/search.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/issue/search.operation.ts
@@ -1,0 +1,100 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+
+import { ISSUE_FIELDS } from '../../../shared/constants';
+import { linearApiRequestAllItems } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Query',
+		name: 'query',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'Text to search for in issue titles and descriptions',
+	},
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: { minValue: 1 },
+		displayOptions: {
+			show: { returnAll: [false] },
+		},
+		description: 'Max number of results to return',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['issue'],
+		operation: ['search'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	_items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	const searchQuery = this.getNodeParameter('query', 0) as string;
+	const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
+	const limit = returnAll ? undefined : (this.getNodeParameter('limit', 0) as number);
+
+	const body = {
+		query: `query IssueSearch($first: Int, $after: String, $filter: IssueFilter) {
+			issues(first: $first, after: $after, filter: $filter) {
+				nodes {
+					${ISSUE_FIELDS}
+				}
+				pageInfo {
+					hasNextPage
+					endCursor
+				}
+			}
+		}`,
+		variables: {
+			first: 50,
+			filter: {
+				or: [
+					{ title: { containsIgnoreCase: searchQuery } },
+					{ description: { containsIgnoreCase: searchQuery } },
+				],
+			},
+		},
+	};
+
+	try {
+		const issues = await linearApiRequestAllItems.call(this, 'data.issues', body, limit);
+
+		const executionData = this.helpers.constructExecutionMetaData(
+			this.helpers.returnJsonArray(issues),
+			{ itemData: { item: 0 } },
+		);
+		returnData.push(...executionData);
+	} catch (error) {
+		if (this.continueOnFail()) {
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ error: (error as Error).message }),
+					{ itemData: { item: 0 } },
+				),
+			);
+		} else {
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/issue/unarchive.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/issue/unarchive.operation.ts
@@ -34,9 +34,9 @@ export async function execute(
 	const returnData: INodeExecutionData[] = [];
 
 	for (let i = 0; i < items.length; i++) {
-		try {
-			const issueId = this.getNodeParameter('issueId', i) as string;
+		const issueId = this.getNodeParameter('issueId', i) as string;
 
+		try {
 			const body = {
 				query: `mutation IssueUnarchive($issueId: String!) {
 					issueUnarchive(id: $issueId) {

--- a/packages/nodes-base/nodes/Linear/v2/actions/issue/unarchive.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/issue/unarchive.operation.ts
@@ -1,0 +1,73 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Issue ID',
+		name: 'issueId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['issue'],
+		operation: ['unarchive'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const issueId = this.getNodeParameter('issueId', i) as string;
+
+			const body = {
+				query: `mutation IssueUnarchive($issueId: String!) {
+					issueUnarchive(id: $issueId) {
+						success
+					}
+				}`,
+				variables: { issueId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const result = (responseData as { data: { issueUnarchive: IDataObject } }).data
+				.issueUnarchive;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(result),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/issue/update.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/issue/update.operation.ts
@@ -106,10 +106,10 @@ export async function execute(
 	const returnData: INodeExecutionData[] = [];
 
 	for (let i = 0; i < items.length; i++) {
-		try {
-			const issueId = this.getNodeParameter('issueId', i) as string;
-			const updateFields = this.getNodeParameter('updateFields', i) as IDataObject;
+		const issueId = this.getNodeParameter('issueId', i) as string;
+		const updateFields = this.getNodeParameter('updateFields', i) as IDataObject;
 
+		try {
 			const body = {
 				query: `mutation IssueUpdate(
 					$issueId: String!,

--- a/packages/nodes-base/nodes/Linear/v2/actions/issue/update.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/issue/update.operation.ts
@@ -1,0 +1,171 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { ISSUE_FIELDS, PRIORITY_OPTIONS } from '../../../shared/constants';
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Issue ID',
+		name: 'issueId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'Update Fields',
+		name: 'updateFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		options: [
+			{
+				displayName: 'Assignee Name or ID',
+				name: 'assigneeId',
+				type: 'options',
+				description:
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: { loadOptionsMethod: 'getUsers' },
+				default: '',
+			},
+			{
+				displayName: 'Description',
+				name: 'description',
+				type: 'string',
+				typeOptions: { rows: 4 },
+				default: '',
+			},
+			{
+				displayName: 'Due Date',
+				name: 'dueDate',
+				type: 'dateTime',
+				default: '',
+			},
+			{
+				displayName: 'Label Names or IDs',
+				name: 'labelIds',
+				type: 'multiOptions',
+				description:
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: { loadOptionsMethod: 'getLabels' },
+				default: [],
+			},
+			{
+				displayName: 'Priority',
+				name: 'priority',
+				type: 'options',
+				options: PRIORITY_OPTIONS,
+				default: 0,
+			},
+			{
+				displayName: 'State Name or ID',
+				name: 'stateId',
+				type: 'options',
+				description:
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: { loadOptionsMethod: 'getStates' },
+				default: '',
+			},
+			{
+				displayName: 'Team Name or ID',
+				name: 'teamId',
+				type: 'options',
+				description:
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: { loadOptionsMethod: 'getTeams' },
+				default: '',
+			},
+			{
+				displayName: 'Title',
+				name: 'title',
+				type: 'string',
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['issue'],
+		operation: ['update'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const issueId = this.getNodeParameter('issueId', i) as string;
+			const updateFields = this.getNodeParameter('updateFields', i) as IDataObject;
+
+			const body = {
+				query: `mutation IssueUpdate(
+					$issueId: String!,
+					$title: String,
+					$teamId: String,
+					$description: String,
+					$assigneeId: String,
+					$priority: Int,
+					$stateId: String,
+					$dueDate: TimelessDate,
+					$labelIds: [String!]
+				) {
+					issueUpdate(id: $issueId, input: {
+						title: $title
+						teamId: $teamId
+						description: $description
+						assigneeId: $assigneeId
+						priority: $priority
+						stateId: $stateId
+						dueDate: $dueDate
+						labelIds: $labelIds
+					}) {
+						success
+						issue {
+							${ISSUE_FIELDS}
+						}
+					}
+				}`,
+				variables: {
+					issueId,
+					...updateFields,
+				},
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const issue = (responseData as { data: { issueUpdate: { issue: IDataObject } } }).data
+				.issueUpdate?.issue;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(issue),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/node.type.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/node.type.ts
@@ -1,0 +1,8 @@
+import type { AllEntities } from 'n8n-workflow';
+
+type NodeMap = {
+	issue: 'create' | 'get' | 'getAll' | 'update' | 'delete' | 'archive' | 'unarchive' | 'search';
+	comment: 'create' | 'get' | 'getAll' | 'update' | 'delete';
+};
+
+export type Linear = AllEntities<NodeMap>;

--- a/packages/nodes-base/nodes/Linear/v2/actions/router.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/router.ts
@@ -1,0 +1,29 @@
+import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+
+import * as comment from './comment';
+import * as issue from './issue';
+import type { Linear } from './node.type';
+
+export async function router(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+	const items = this.getInputData();
+	const resource = this.getNodeParameter('resource', 0) as string;
+	const operation = this.getNodeParameter('operation', 0) as string;
+
+	const linear = { resource, operation } as Linear;
+
+	let returnData: INodeExecutionData[] = [];
+
+	switch (linear.resource) {
+		case 'issue':
+			returnData = await issue[linear.operation].execute.call(this, items);
+			break;
+		case 'comment':
+			returnData = await comment[linear.operation].execute.call(this, items);
+			break;
+		default:
+			throw new NodeOperationError(this.getNode(), `The resource "${resource}" is not known`);
+	}
+
+	return [returnData];
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/versionDescription.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/versionDescription.ts
@@ -1,0 +1,77 @@
+import { NodeConnectionTypes, type INodeTypeDescription } from 'n8n-workflow';
+
+import * as comment from './comment';
+import * as issue from './issue';
+
+export const versionDescription: INodeTypeDescription = {
+	displayName: 'Linear',
+	name: 'linear',
+	icon: 'file:linear.svg',
+	group: ['output'],
+	version: 2,
+	subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
+	description: 'Consume Linear API',
+	defaults: {
+		name: 'Linear',
+	},
+	inputs: [NodeConnectionTypes.Main],
+	outputs: [NodeConnectionTypes.Main],
+	credentials: [
+		{
+			name: 'linearApi',
+			required: true,
+			testedBy: 'linearApiTest',
+			displayOptions: {
+				show: {
+					authentication: ['apiToken'],
+				},
+			},
+		},
+		{
+			name: 'linearOAuth2Api',
+			required: true,
+			displayOptions: {
+				show: {
+					authentication: ['oAuth2'],
+				},
+			},
+		},
+	],
+	properties: [
+		{
+			displayName: 'Authentication',
+			name: 'authentication',
+			type: 'options',
+			options: [
+				{
+					name: 'API Token',
+					value: 'apiToken',
+				},
+				{
+					name: 'OAuth2',
+					value: 'oAuth2',
+				},
+			],
+			default: 'apiToken',
+		},
+		{
+			displayName: 'Resource',
+			name: 'resource',
+			type: 'options',
+			noDataExpression: true,
+			options: [
+				{
+					name: 'Comment',
+					value: 'comment',
+				},
+				{
+					name: 'Issue',
+					value: 'issue',
+				},
+			],
+			default: 'issue',
+		},
+		...comment.description,
+		...issue.description,
+	],
+};


### PR DESCRIPTION
## Summary

- Introduces v2 node infrastructure: `LinearV2.node.ts`, `LinearTriggerV2.node.ts`, `router.ts`, `versionDescription.ts`, `node.type.ts`
- Sets `defaultVersion: 2` for both Linear and LinearTrigger nodes
- **Issue** resource (8 operations): create, get, getAll, update, delete, archive, unarchive, search
- **Comment** resource (5 operations): create, get, getAll, update, delete
- Jest tests covering: `issue.create`, `issue.get`, `issue.getAll` (with/without returnAll), `comment.create`

## Stacked on

PR #26699 (refactor — VersionedNodeType architecture)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4288

## Review checklist

- [ ] `updateDisplayOptions()` used in all operation files
- [ ] "Name or ID" pattern on all dynamic options fields
- [ ] `returnAll` + `limit` pattern in all getAll operations
- [ ] Optional params in "Additional Fields" / "Filters" collections