### PR TITLE
feat(Linear Node): Add Project, User, Team, and Label resources to v2

### DIFF
--- a/packages/nodes-base/nodes/Linear/test/node/v2/LinearV2.project.test.ts
+++ b/packages/nodes-base/nodes/Linear/test/node/v2/LinearV2.project.test.ts
@@ -1,0 +1,112 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+import * as GenericFunctions from '../../../shared/GenericFunctions';
+import * as labelCreate from '../../../v2/actions/label/create.operation';
+import * as projectCreate from '../../../v2/actions/project/create.operation';
+import * as teamGetAll from '../../../v2/actions/team/getAll.operation';
+import * as userGetCurrent from '../../../v2/actions/user/getCurrent.operation';
+
+describe('Linear v2 → Project, User, Team & Label', () => {
+	let mockThis: IExecuteFunctions;
+	let apiRequestSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		mockThis = {
+			getInputData: jest.fn().mockReturnValue([{ json: {} }]),
+			getNodeParameter: jest.fn(),
+			continueOnFail: jest.fn().mockReturnValue(false),
+			helpers: {
+				returnJsonArray: jest.fn().mockImplementation((d) => [{ json: d }]),
+				constructExecutionMetaData: jest.fn().mockImplementation((d) => d),
+			},
+		} as unknown as IExecuteFunctions;
+	});
+
+	afterEach(() => jest.restoreAllMocks());
+
+	describe('project.create', () => {
+		it('sends projectCreate mutation with name and teamIds', async () => {
+			apiRequestSpy = jest.spyOn(GenericFunctions, 'linearApiRequest').mockResolvedValue({
+				data: { projectCreate: { project: { id: 'proj-1', name: 'My Project' } } },
+			});
+
+			(mockThis.getNodeParameter as jest.Mock).mockImplementation((param: string) => {
+				if (param === 'name') return 'My Project';
+				if (param === 'teamIds') return ['team-abc'];
+				if (param === 'additionalFields') return {};
+				return undefined;
+			});
+
+			await projectCreate.execute.call(mockThis, [{ json: {} }]);
+
+			expect(apiRequestSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					query: expect.stringContaining('projectCreate'),
+					variables: expect.objectContaining({ name: 'My Project', teamIds: ['team-abc'] }),
+				}),
+			);
+		});
+	});
+
+	describe('user.getCurrent', () => {
+		it('sends viewer query with no variables', async () => {
+			apiRequestSpy = jest.spyOn(GenericFunctions, 'linearApiRequest').mockResolvedValue({
+				data: { viewer: { id: 'user-1', displayName: 'Alice' } },
+			});
+
+			await userGetCurrent.execute.call(mockThis, [{ json: {} }]);
+
+			expect(apiRequestSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					query: expect.stringContaining('viewer'),
+				}),
+			);
+		});
+	});
+
+	describe('team.getAll', () => {
+		it('calls teams query', async () => {
+			const allItemsSpy = jest
+				.spyOn(GenericFunctions, 'linearApiRequestAllItems')
+				.mockResolvedValue([{ id: 'team-1', name: 'Engineering' }]);
+
+			(mockThis.getNodeParameter as jest.Mock).mockImplementation((param: string) => {
+				if (param === 'returnAll') return false;
+				if (param === 'limit') return 50;
+				return undefined;
+			});
+
+			await teamGetAll.execute.call(mockThis, [{ json: {} }]);
+
+			expect(allItemsSpy).toHaveBeenCalledWith(
+				'data.teams',
+				expect.objectContaining({ query: expect.stringContaining('teams') }),
+				50,
+			);
+		});
+	});
+
+	describe('label.create', () => {
+		it('sends issueLabelCreate mutation with name and teamId', async () => {
+			apiRequestSpy = jest.spyOn(GenericFunctions, 'linearApiRequest').mockResolvedValue({
+				data: { issueLabelCreate: { issueLabel: { id: 'label-1', name: 'Bug' } } },
+			});
+
+			(mockThis.getNodeParameter as jest.Mock).mockImplementation((param: string) => {
+				if (param === 'name') return 'Bug';
+				if (param === 'teamId') return 'team-xyz';
+				if (param === 'additionalFields') return {};
+				return undefined;
+			});
+
+			await labelCreate.execute.call(mockThis, [{ json: {} }]);
+
+			expect(apiRequestSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					query: expect.stringContaining('issueLabelCreate'),
+					variables: expect.objectContaining({ name: 'Bug', teamId: 'team-xyz' }),
+				}),
+			);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Linear/v2/actions/label/create.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/label/create.operation.ts
@@ -1,0 +1,126 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Name',
+		name: 'name',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'Team Name or ID',
+		name: 'teamId',
+		type: 'options',
+		required: true,
+		description:
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+		typeOptions: { loadOptionsMethod: 'getTeams' },
+		default: '',
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		options: [
+			{
+				displayName: 'Color',
+				name: 'color',
+				type: 'color',
+				default: '#000000',
+				description: 'The label color as a hex code',
+			},
+			{
+				displayName: 'Description',
+				name: 'description',
+				type: 'string',
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['label'],
+		operation: ['create'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const name = this.getNodeParameter('name', i) as string;
+			const teamId = this.getNodeParameter('teamId', i) as string;
+			const additionalFields = this.getNodeParameter('additionalFields', i) as Record<
+				string,
+				unknown
+			>;
+
+			const body = {
+				query: `mutation IssueLabelCreate($name: String!, $teamId: String!, $color: String, $description: String) {
+					issueLabelCreate(input: {
+						name: $name
+						teamId: $teamId
+						color: $color
+						description: $description
+					}) {
+						success
+						issueLabel {
+							id
+							name
+							color
+							description
+							createdAt
+						}
+					}
+				}`,
+				variables: {
+					name,
+					teamId,
+					...additionalFields,
+				},
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const label = (responseData as { data: { issueLabelCreate: { issueLabel: IDataObject } } })
+				.data.issueLabelCreate?.issueLabel;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(label),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/label/delete.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/label/delete.operation.ts
@@ -1,0 +1,73 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Label ID',
+		name: 'labelId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['label'],
+		operation: ['delete'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const labelId = this.getNodeParameter('labelId', i) as string;
+
+			const body = {
+				query: `mutation IssueLabelDelete($labelId: String!) {
+					issueLabelDelete(id: $labelId) {
+						success
+					}
+				}`,
+				variables: { labelId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const result = (responseData as { data: { issueLabelDelete: IDataObject } }).data
+				.issueLabelDelete;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(result),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/label/get.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/label/get.operation.ts
@@ -1,0 +1,77 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Label ID',
+		name: 'labelId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['label'],
+		operation: ['get'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const labelId = this.getNodeParameter('labelId', i) as string;
+
+			const body = {
+				query: `query IssueLabel($labelId: String!) {
+					issueLabel(id: $labelId) {
+						id
+						name
+						color
+						description
+						createdAt
+						updatedAt
+					}
+				}`,
+				variables: { labelId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const label = (responseData as { data: { issueLabel: IDataObject } }).data.issueLabel;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(label),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/label/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/label/getAll.operation.ts
@@ -1,0 +1,87 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+
+import { linearApiRequestAllItems } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: { minValue: 1 },
+		displayOptions: {
+			show: { returnAll: [false] },
+		},
+		description: 'Max number of results to return',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['label'],
+		operation: ['getAll'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	_items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
+	const limit = returnAll ? undefined : (this.getNodeParameter('limit', 0) as number);
+
+	const body = {
+		query: `query IssueLabels($first: Int, $after: String) {
+			issueLabels(first: $first, after: $after) {
+				nodes {
+					id
+					name
+					color
+					description
+					createdAt
+					updatedAt
+				}
+				pageInfo {
+					hasNextPage
+					endCursor
+				}
+			}
+		}`,
+		variables: { first: 50 },
+	};
+
+	try {
+		const labels = await linearApiRequestAllItems.call(this, 'data.issueLabels', body, limit);
+
+		const executionData = this.helpers.constructExecutionMetaData(
+			this.helpers.returnJsonArray(labels),
+			{ itemData: { item: 0 } },
+		);
+		returnData.push(...executionData);
+	} catch (error) {
+		if (this.continueOnFail()) {
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ error: (error as Error).message }),
+					{ itemData: { item: 0 } },
+				),
+			);
+		} else {
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/label/index.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/label/index.ts
@@ -1,0 +1,61 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as create from './create.operation';
+import * as deleteLabel from './delete.operation';
+import * as get from './get.operation';
+import * as getAll from './getAll.operation';
+import * as update from './update.operation';
+
+export { create, deleteLabel as delete, get, getAll, update };
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['label'],
+			},
+		},
+		options: [
+			{
+				name: 'Create',
+				value: 'create',
+				description: 'Create a label',
+				action: 'Create a label',
+			},
+			{
+				name: 'Delete',
+				value: 'delete',
+				description: 'Delete a label',
+				action: 'Delete a label',
+			},
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a label',
+				action: 'Get a label',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get many labels',
+				action: 'Get many labels',
+			},
+			{
+				name: 'Update',
+				value: 'update',
+				description: 'Update a label',
+				action: 'Update a label',
+			},
+		],
+		default: 'getAll',
+	},
+	...create.description,
+	...deleteLabel.description,
+	...get.description,
+	...getAll.description,
+	...update.description,
+];

--- a/packages/nodes-base/nodes/Linear/v2/actions/label/update.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/label/update.operation.ts
@@ -1,0 +1,115 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Label ID',
+		name: 'labelId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'Update Fields',
+		name: 'updateFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		options: [
+			{
+				displayName: 'Color',
+				name: 'color',
+				type: 'color',
+				default: '#000000',
+			},
+			{
+				displayName: 'Description',
+				name: 'description',
+				type: 'string',
+				default: '',
+			},
+			{
+				displayName: 'Name',
+				name: 'name',
+				type: 'string',
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['label'],
+		operation: ['update'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const labelId = this.getNodeParameter('labelId', i) as string;
+			const updateFields = this.getNodeParameter('updateFields', i) as IDataObject;
+
+			const body = {
+				query: `mutation IssueLabelUpdate($labelId: String!, $name: String, $color: String, $description: String) {
+					issueLabelUpdate(id: $labelId, input: {
+						name: $name
+						color: $color
+						description: $description
+					}) {
+						success
+						issueLabel {
+							id
+							name
+							color
+							description
+							updatedAt
+						}
+					}
+				}`,
+				variables: {
+					labelId,
+					...updateFields,
+				},
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const label = (responseData as { data: { issueLabelUpdate: { issueLabel: IDataObject } } })
+				.data.issueLabelUpdate?.issueLabel;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(label),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/node.type.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/node.type.ts
@@ -3,6 +3,10 @@ import type { AllEntities } from 'n8n-workflow';
 type NodeMap = {
 	issue: 'create' | 'get' | 'getAll' | 'update' | 'delete' | 'archive' | 'unarchive' | 'search';
 	comment: 'create' | 'get' | 'getAll' | 'update' | 'delete';
+	project: 'create' | 'get' | 'getAll' | 'update' | 'delete' | 'archive';
+	user: 'get' | 'getAll' | 'getCurrent';
+	team: 'get' | 'getAll';
+	label: 'create' | 'get' | 'getAll' | 'update' | 'delete';
 };
 
 export type Linear = AllEntities<NodeMap>;

--- a/packages/nodes-base/nodes/Linear/v2/actions/project/archive.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/project/archive.operation.ts
@@ -1,0 +1,73 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Project ID',
+		name: 'projectId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['project'],
+		operation: ['archive'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const projectId = this.getNodeParameter('projectId', i) as string;
+
+			const body = {
+				query: `mutation ProjectArchive($projectId: String!) {
+					projectArchive(id: $projectId) {
+						success
+					}
+				}`,
+				variables: { projectId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const result = (responseData as { data: { projectArchive: IDataObject } }).data
+				.projectArchive;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(result),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/project/create.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/project/create.operation.ts
@@ -1,0 +1,164 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Name',
+		name: 'name',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'Team Names or IDs',
+		name: 'teamIds',
+		type: 'multiOptions',
+		required: true,
+		description:
+			'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+		typeOptions: { loadOptionsMethod: 'getTeams' },
+		default: [],
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		options: [
+			{
+				displayName: 'Description',
+				name: 'description',
+				type: 'string',
+				typeOptions: { rows: 4 },
+				default: '',
+			},
+			{
+				displayName: 'Lead Name or ID',
+				name: 'leadId',
+				type: 'options',
+				description:
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: { loadOptionsMethod: 'getUsers' },
+				default: '',
+			},
+			{
+				displayName: 'Status',
+				name: 'state',
+				type: 'options',
+				options: [
+					{ name: 'Backlog', value: 'backlog' },
+					{ name: 'Planned', value: 'planned' },
+					{ name: 'In Progress', value: 'inProgress' },
+					{ name: 'Paused', value: 'paused' },
+					{ name: 'Completed', value: 'completed' },
+					{ name: 'Cancelled', value: 'cancelled' },
+				],
+				default: 'planned',
+			},
+			{
+				displayName: 'Target Date',
+				name: 'targetDate',
+				type: 'dateTime',
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['project'],
+		operation: ['create'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const name = this.getNodeParameter('name', i) as string;
+			const teamIds = this.getNodeParameter('teamIds', i) as string[];
+			const additionalFields = this.getNodeParameter('additionalFields', i) as Record<
+				string,
+				unknown
+			>;
+
+			const body = {
+				query: `mutation ProjectCreate(
+					$name: String!,
+					$teamIds: [String!]!,
+					$description: String,
+					$leadId: String,
+					$state: String,
+					$targetDate: TimelessDate
+				) {
+					projectCreate(input: {
+						name: $name
+						teamIds: $teamIds
+						description: $description
+						leadId: $leadId
+						state: $state
+						targetDate: $targetDate
+					}) {
+						success
+						project {
+							id
+							name
+							description
+							state
+							createdAt
+							updatedAt
+							targetDate
+							lead {
+								id
+								displayName
+							}
+						}
+					}
+				}`,
+				variables: {
+					name,
+					teamIds,
+					...additionalFields,
+				},
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const project = (responseData as { data: { projectCreate: { project: IDataObject } } }).data
+				.projectCreate?.project;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(project),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/project/delete.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/project/delete.operation.ts
@@ -1,0 +1,72 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Project ID',
+		name: 'projectId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['project'],
+		operation: ['delete'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const projectId = this.getNodeParameter('projectId', i) as string;
+
+			const body = {
+				query: `mutation ProjectDelete($projectId: String!) {
+					projectDelete(id: $projectId) {
+						success
+					}
+				}`,
+				variables: { projectId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const result = (responseData as { data: { projectDelete: IDataObject } }).data.projectDelete;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(result as IDataObject),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/project/get.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/project/get.operation.ts
@@ -1,0 +1,84 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Project ID',
+		name: 'projectId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['project'],
+		operation: ['get'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const projectId = this.getNodeParameter('projectId', i) as string;
+
+			const body = {
+				query: `query Project($projectId: String!) {
+					project(id: $projectId) {
+						id
+						name
+						description
+						state
+						createdAt
+						updatedAt
+						targetDate
+						url
+						lead {
+							id
+							displayName
+							email
+						}
+					}
+				}`,
+				variables: { projectId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const project = (responseData as { data: { project: IDataObject } }).data.project;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(project as IDataObject),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/project/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/project/getAll.operation.ts
@@ -1,0 +1,93 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+
+import { linearApiRequestAllItems } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: { minValue: 1 },
+		displayOptions: {
+			show: { returnAll: [false] },
+		},
+		description: 'Max number of results to return',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['project'],
+		operation: ['getAll'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	_items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
+	const limit = returnAll ? undefined : (this.getNodeParameter('limit', 0) as number);
+
+	const body = {
+		query: `query Projects($first: Int, $after: String) {
+			projects(first: $first, after: $after) {
+				nodes {
+					id
+					name
+					description
+					state
+					createdAt
+					updatedAt
+					targetDate
+					url
+					lead {
+						id
+						displayName
+					}
+				}
+				pageInfo {
+					hasNextPage
+					endCursor
+				}
+			}
+		}`,
+		variables: { first: 50 },
+	};
+
+	try {
+		const projects = await linearApiRequestAllItems.call(this, 'data.projects', body, limit);
+
+		const executionData = this.helpers.constructExecutionMetaData(
+			this.helpers.returnJsonArray(projects),
+			{ itemData: { item: 0 } },
+		);
+		returnData.push(...executionData);
+	} catch (error) {
+		if (this.continueOnFail()) {
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ error: (error as Error).message }),
+					{ itemData: { item: 0 } },
+				),
+			);
+		} else {
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/project/index.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/project/index.ts
@@ -1,0 +1,69 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as archive from './archive.operation';
+import * as create from './create.operation';
+import * as deleteProject from './delete.operation';
+import * as get from './get.operation';
+import * as getAll from './getAll.operation';
+import * as update from './update.operation';
+
+export { archive, create, deleteProject as delete, get, getAll, update };
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['project'],
+			},
+		},
+		options: [
+			{
+				name: 'Archive',
+				value: 'archive',
+				description: 'Archive a project',
+				action: 'Archive a project',
+			},
+			{
+				name: 'Create',
+				value: 'create',
+				description: 'Create a project',
+				action: 'Create a project',
+			},
+			{
+				name: 'Delete',
+				value: 'delete',
+				description: 'Delete a project',
+				action: 'Delete a project',
+			},
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a project',
+				action: 'Get a project',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get many projects',
+				action: 'Get many projects',
+			},
+			{
+				name: 'Update',
+				value: 'update',
+				description: 'Update a project',
+				action: 'Update a project',
+			},
+		],
+		default: 'create',
+	},
+	...archive.description,
+	...create.description,
+	...deleteProject.description,
+	...get.description,
+	...getAll.description,
+	...update.description,
+];

--- a/packages/nodes-base/nodes/Linear/v2/actions/project/update.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/project/update.operation.ts
@@ -1,0 +1,150 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Project ID',
+		name: 'projectId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'Update Fields',
+		name: 'updateFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		options: [
+			{
+				displayName: 'Description',
+				name: 'description',
+				type: 'string',
+				typeOptions: { rows: 4 },
+				default: '',
+			},
+			{
+				displayName: 'Lead Name or ID',
+				name: 'leadId',
+				type: 'options',
+				description:
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: { loadOptionsMethod: 'getUsers' },
+				default: '',
+			},
+			{
+				displayName: 'Name',
+				name: 'name',
+				type: 'string',
+				default: '',
+			},
+			{
+				displayName: 'Status',
+				name: 'state',
+				type: 'options',
+				options: [
+					{ name: 'Backlog', value: 'backlog' },
+					{ name: 'Planned', value: 'planned' },
+					{ name: 'In Progress', value: 'inProgress' },
+					{ name: 'Paused', value: 'paused' },
+					{ name: 'Completed', value: 'completed' },
+					{ name: 'Cancelled', value: 'cancelled' },
+				],
+				default: 'planned',
+			},
+			{
+				displayName: 'Target Date',
+				name: 'targetDate',
+				type: 'dateTime',
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['project'],
+		operation: ['update'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const projectId = this.getNodeParameter('projectId', i) as string;
+			const updateFields = this.getNodeParameter('updateFields', i) as IDataObject;
+
+			const body = {
+				query: `mutation ProjectUpdate(
+					$projectId: String!,
+					$name: String,
+					$description: String,
+					$leadId: String,
+					$state: String,
+					$targetDate: TimelessDate
+				) {
+					projectUpdate(id: $projectId, input: {
+						name: $name
+						description: $description
+						leadId: $leadId
+						state: $state
+						targetDate: $targetDate
+					}) {
+						success
+						project {
+							id
+							name
+							description
+							state
+							createdAt
+							updatedAt
+							targetDate
+						}
+					}
+				}`,
+				variables: {
+					projectId,
+					...updateFields,
+				},
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const project = (responseData as { data: { projectUpdate: { project: IDataObject } } }).data
+				.projectUpdate?.project;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(project as IDataObject),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/router.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/router.ts
@@ -4,6 +4,10 @@ import { NodeOperationError } from 'n8n-workflow';
 import * as comment from './comment';
 import * as issue from './issue';
 import type { Linear } from './node.type';
+import * as label from './label';
+import * as project from './project';
+import * as team from './team';
+import * as user from './user';
 
 export async function router(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 	const items = this.getInputData();
@@ -20,6 +24,18 @@ export async function router(this: IExecuteFunctions): Promise<INodeExecutionDat
 			break;
 		case 'comment':
 			returnData = await comment[linear.operation].execute.call(this, items);
+			break;
+		case 'project':
+			returnData = await project[linear.operation].execute.call(this, items);
+			break;
+		case 'user':
+			returnData = await user[linear.operation].execute.call(this, items);
+			break;
+		case 'team':
+			returnData = await team[linear.operation].execute.call(this, items);
+			break;
+		case 'label':
+			returnData = await label[linear.operation].execute.call(this, items);
 			break;
 		default:
 			throw new NodeOperationError(this.getNode(), `The resource "${resource}" is not known`);

--- a/packages/nodes-base/nodes/Linear/v2/actions/team/get.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/team/get.operation.ts
@@ -1,0 +1,79 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Team ID',
+		name: 'teamId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['team'],
+		operation: ['get'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const teamId = this.getNodeParameter('teamId', i) as string;
+
+			const body = {
+				query: `query Team($teamId: String!) {
+					team(id: $teamId) {
+						id
+						name
+						description
+						key
+						color
+						createdAt
+						updatedAt
+						timezone
+					}
+				}`,
+				variables: { teamId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const team = (responseData as { data: { team: IDataObject } }).data.team;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(team as IDataObject),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/team/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/team/getAll.operation.ts
@@ -1,0 +1,89 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+
+import { linearApiRequestAllItems } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: { minValue: 1 },
+		displayOptions: {
+			show: { returnAll: [false] },
+		},
+		description: 'Max number of results to return',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['team'],
+		operation: ['getAll'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	_items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
+	const limit = returnAll ? undefined : (this.getNodeParameter('limit', 0) as number);
+
+	const body = {
+		query: `query Teams($first: Int, $after: String) {
+			teams(first: $first, after: $after) {
+				nodes {
+					id
+					name
+					description
+					key
+					color
+					createdAt
+					updatedAt
+					timezone
+				}
+				pageInfo {
+					hasNextPage
+					endCursor
+				}
+			}
+		}`,
+		variables: { first: 50 },
+	};
+
+	try {
+		const teams = await linearApiRequestAllItems.call(this, 'data.teams', body, limit);
+
+		const executionData = this.helpers.constructExecutionMetaData(
+			this.helpers.returnJsonArray(teams),
+			{ itemData: { item: 0 } },
+		);
+		returnData.push(...executionData);
+	} catch (error) {
+		if (this.continueOnFail()) {
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ error: (error as Error).message }),
+					{ itemData: { item: 0 } },
+				),
+			);
+		} else {
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/team/index.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/team/index.ts
@@ -1,0 +1,37 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as get from './get.operation';
+import * as getAll from './getAll.operation';
+
+export { get, getAll };
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['team'],
+			},
+		},
+		options: [
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a team',
+				action: 'Get a team',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get many teams',
+				action: 'Get many teams',
+			},
+		],
+		default: 'getAll',
+	},
+	...get.description,
+	...getAll.description,
+];

--- a/packages/nodes-base/nodes/Linear/v2/actions/user/get.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/user/get.operation.ts
@@ -1,0 +1,80 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'User ID',
+		name: 'userId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['user'],
+		operation: ['get'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const userId = this.getNodeParameter('userId', i) as string;
+
+			const body = {
+				query: `query User($userId: String!) {
+					user(id: $userId) {
+						id
+						name
+						displayName
+						email
+						avatarUrl
+						active
+						admin
+						createdAt
+						updatedAt
+					}
+				}`,
+				variables: { userId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const user = (responseData as { data: { user: IDataObject } }).data.user;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(user as IDataObject),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/user/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/user/getAll.operation.ts
@@ -1,0 +1,90 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+
+import { linearApiRequestAllItems } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: { minValue: 1 },
+		displayOptions: {
+			show: { returnAll: [false] },
+		},
+		description: 'Max number of results to return',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['user'],
+		operation: ['getAll'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	_items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
+	const limit = returnAll ? undefined : (this.getNodeParameter('limit', 0) as number);
+
+	const body = {
+		query: `query Users($first: Int, $after: String) {
+			users(first: $first, after: $after) {
+				nodes {
+					id
+					name
+					displayName
+					email
+					avatarUrl
+					active
+					admin
+					createdAt
+					updatedAt
+				}
+				pageInfo {
+					hasNextPage
+					endCursor
+				}
+			}
+		}`,
+		variables: { first: 50 },
+	};
+
+	try {
+		const users = await linearApiRequestAllItems.call(this, 'data.users', body, limit);
+
+		const executionData = this.helpers.constructExecutionMetaData(
+			this.helpers.returnJsonArray(users),
+			{ itemData: { item: 0 } },
+		);
+		returnData.push(...executionData);
+	} catch (error) {
+		if (this.continueOnFail()) {
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ error: (error as Error).message }),
+					{ itemData: { item: 0 } },
+				),
+			);
+		} else {
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/user/getCurrent.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/user/getCurrent.operation.ts
@@ -1,0 +1,68 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [];
+
+const displayOptions = {
+	show: {
+		resource: ['user'],
+		operation: ['getCurrent'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	_items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	try {
+		const body = {
+			query: `query Viewer {
+				viewer {
+					id
+					name
+					displayName
+					email
+					avatarUrl
+					active
+					admin
+					createdAt
+					updatedAt
+				}
+			}`,
+			variables: {},
+		};
+
+		const responseData = await linearApiRequest.call(this, body);
+		const user = (responseData as { data: { viewer: IDataObject } }).data.viewer;
+
+		const executionData = this.helpers.constructExecutionMetaData(
+			this.helpers.returnJsonArray(user as IDataObject),
+			{ itemData: { item: 0 } },
+		);
+		returnData.push(...executionData);
+	} catch (error) {
+		if (this.continueOnFail()) {
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ error: (error as Error).message }),
+					{ itemData: { item: 0 } },
+				),
+			);
+		} else {
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/user/index.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/user/index.ts
@@ -1,0 +1,45 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as get from './get.operation';
+import * as getAll from './getAll.operation';
+import * as getCurrent from './getCurrent.operation';
+
+export { get, getAll, getCurrent };
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['user'],
+			},
+		},
+		options: [
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a user',
+				action: 'Get a user',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get many users',
+				action: 'Get many users',
+			},
+			{
+				name: 'Get Current',
+				value: 'getCurrent',
+				description: 'Get the currently authenticated user',
+				action: 'Get current user',
+			},
+		],
+		default: 'getCurrent',
+	},
+	...get.description,
+	...getAll.description,
+	...getCurrent.description,
+];

--- a/packages/nodes-base/nodes/Linear/v2/actions/versionDescription.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/versionDescription.ts
@@ -2,6 +2,10 @@ import { NodeConnectionTypes, type INodeTypeDescription } from 'n8n-workflow';
 
 import * as comment from './comment';
 import * as issue from './issue';
+import * as label from './label';
+import * as project from './project';
+import * as team from './team';
+import * as user from './user';
 
 export const versionDescription: INodeTypeDescription = {
 	displayName: 'Linear',
@@ -68,10 +72,30 @@ export const versionDescription: INodeTypeDescription = {
 					name: 'Issue',
 					value: 'issue',
 				},
+				{
+					name: 'Label',
+					value: 'label',
+				},
+				{
+					name: 'Project',
+					value: 'project',
+				},
+				{
+					name: 'Team',
+					value: 'team',
+				},
+				{
+					name: 'User',
+					value: 'user',
+				},
 			],
 			default: 'issue',
 		},
 		...comment.description,
 		...issue.description,
+		...label.description,
+		...project.description,
+		...team.description,
+		...user.description,
 	],
 };


### PR DESCRIPTION
## Summary

- **Project** resource (6 operations): create, get, getAll, update, delete, archive
- **User** resource (3 operations): get, getAll, getCurrent
- **Team** resource (2 operations): get, getAll
- **Label** resource (5 operations): create, get, getAll, update, delete
- Expands `router.ts` and `versionDescription.ts` with 4 new resources
- Jest tests covering: `project.create`, `user.getCurrent`, `team.getAll`, `label.create`

## Stacked on

PR #26702 (v2 core + Issue + Comment)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4288