### PR TITLE
feat(Linear Node): Add Cycle, Attachment, and WorkflowState resources to v2

### DIFF
--- a/packages/nodes-base/nodes/Linear/test/node/v2/LinearV2.cycle.test.ts
+++ b/packages/nodes-base/nodes/Linear/test/node/v2/LinearV2.cycle.test.ts
@@ -1,0 +1,99 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+import * as GenericFunctions from '../../../shared/GenericFunctions';
+import * as attachmentGet from '../../../v2/actions/attachment/get.operation';
+import * as cycleCreate from '../../../v2/actions/cycle/create.operation';
+import * as workflowStateGetAll from '../../../v2/actions/workflowState/getAll.operation';
+
+describe('Linear v2 → Cycle, Attachment & WorkflowState', () => {
+	let mockThis: IExecuteFunctions;
+	let apiRequestSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		mockThis = {
+			getInputData: jest.fn().mockReturnValue([{ json: {} }]),
+			getNodeParameter: jest.fn(),
+			continueOnFail: jest.fn().mockReturnValue(false),
+			helpers: {
+				returnJsonArray: jest.fn().mockImplementation((d) => [{ json: d }]),
+				constructExecutionMetaData: jest.fn().mockImplementation((d) => d),
+			},
+		} as unknown as IExecuteFunctions;
+	});
+
+	afterEach(() => jest.restoreAllMocks());
+
+	describe('cycle.create', () => {
+		it('sends cycleCreate mutation with teamId, startsAt, and endsAt', async () => {
+			apiRequestSpy = jest.spyOn(GenericFunctions, 'linearApiRequest').mockResolvedValue({
+				data: { cycleCreate: { cycle: { id: 'cycle-1', number: 1 } } },
+			});
+
+			(mockThis.getNodeParameter as jest.Mock).mockImplementation((param: string) => {
+				if (param === 'teamId') return 'team-abc';
+				if (param === 'startsAt') return '2024-01-01T00:00:00.000Z';
+				if (param === 'endsAt') return '2024-01-14T00:00:00.000Z';
+				if (param === 'additionalFields') return {};
+				return undefined;
+			});
+
+			await cycleCreate.execute.call(mockThis, [{ json: {} }]);
+
+			expect(apiRequestSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					query: expect.stringContaining('cycleCreate'),
+					variables: expect.objectContaining({
+						teamId: 'team-abc',
+						startsAt: '2024-01-01T00:00:00.000Z',
+						endsAt: '2024-01-14T00:00:00.000Z',
+					}),
+				}),
+			);
+		});
+	});
+
+	describe('attachment.get', () => {
+		it('sends attachment query with correct ID', async () => {
+			apiRequestSpy = jest.spyOn(GenericFunctions, 'linearApiRequest').mockResolvedValue({
+				data: { attachment: { id: 'att-1', url: 'https://example.com/file.pdf' } },
+			});
+
+			(mockThis.getNodeParameter as jest.Mock).mockImplementation((param: string) => {
+				if (param === 'attachmentId') return 'att-1';
+				return undefined;
+			});
+
+			await attachmentGet.execute.call(mockThis, [{ json: {} }]);
+
+			expect(apiRequestSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					query: expect.stringContaining('attachment'),
+					variables: expect.objectContaining({ attachmentId: 'att-1' }),
+				}),
+			);
+		});
+	});
+
+	describe('workflowState.getAll', () => {
+		it('calls workflowStates query', async () => {
+			const allItemsSpy = jest
+				.spyOn(GenericFunctions, 'linearApiRequestAllItems')
+				.mockResolvedValue([{ id: 'state-1', name: 'In Progress' }]);
+
+			(mockThis.getNodeParameter as jest.Mock).mockImplementation((param: string) => {
+				if (param === 'returnAll') return false;
+				if (param === 'limit') return 50;
+				if (param === 'filters') return {};
+				return undefined;
+			});
+
+			await workflowStateGetAll.execute.call(mockThis, [{ json: {} }]);
+
+			expect(allItemsSpy).toHaveBeenCalledWith(
+				'data.workflowStates',
+				expect.objectContaining({ query: expect.stringContaining('workflowStates') }),
+				50,
+			);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Linear/v2/actions/attachment/create.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/attachment/create.operation.ts
@@ -1,0 +1,125 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Issue ID',
+		name: 'issueId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'URL',
+		name: 'url',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'The URL to attach to the issue',
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		options: [
+			{
+				displayName: 'Title',
+				name: 'title',
+				type: 'string',
+				default: '',
+				description: 'The attachment title',
+			},
+			{
+				displayName: 'Subtitle',
+				name: 'subtitle',
+				type: 'string',
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['attachment'],
+		operation: ['create'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const issueId = this.getNodeParameter('issueId', i) as string;
+			const url = this.getNodeParameter('url', i) as string;
+			const additionalFields = this.getNodeParameter('additionalFields', i) as Record<
+				string,
+				unknown
+			>;
+
+			const body = {
+				query: `mutation AttachmentCreate($issueId: String!, $url: String!, $title: String, $subtitle: String) {
+					attachmentCreate(input: {
+						issueId: $issueId
+						url: $url
+						title: $title
+						subtitle: $subtitle
+					}) {
+						success
+						attachment {
+							id
+							url
+							title
+							subtitle
+							createdAt
+							updatedAt
+						}
+					}
+				}`,
+				variables: {
+					issueId,
+					url,
+					...additionalFields,
+				},
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const attachment = (
+				responseData as { data: { attachmentCreate: { attachment: IDataObject } } }
+			).data.attachmentCreate?.attachment;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(attachment), {
+					itemData: { item: i },
+				}),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/attachment/delete.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/attachment/delete.operation.ts
@@ -1,0 +1,72 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Attachment ID',
+		name: 'attachmentId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['attachment'],
+		operation: ['delete'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const attachmentId = this.getNodeParameter('attachmentId', i) as string;
+
+			const body = {
+				query: `mutation AttachmentDelete($attachmentId: String!) {
+					attachmentDelete(id: $attachmentId) {
+						success
+					}
+				}`,
+				variables: { attachmentId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const result = (responseData as { data: { attachmentDelete: IDataObject } }).data
+				.attachmentDelete;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(result), {
+					itemData: { item: i },
+				}),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/attachment/get.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/attachment/get.operation.ts
@@ -1,0 +1,81 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Attachment ID',
+		name: 'attachmentId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['attachment'],
+		operation: ['get'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const attachmentId = this.getNodeParameter('attachmentId', i) as string;
+
+			const body = {
+				query: `query Attachment($attachmentId: String!) {
+					attachment(id: $attachmentId) {
+						id
+						url
+						title
+						subtitle
+						createdAt
+						updatedAt
+						issue {
+							id
+							identifier
+							title
+						}
+					}
+				}`,
+				variables: { attachmentId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const attachment = (responseData as { data: { attachment: IDataObject } }).data.attachment;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(attachment), {
+					itemData: { item: i },
+				}),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/attachment/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/attachment/getAll.operation.ts
@@ -1,0 +1,95 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+
+import { linearApiRequestAllItems } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Issue ID',
+		name: 'issueId',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'The ID of the issue to get attachments for',
+	},
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: { minValue: 1 },
+		displayOptions: { show: { returnAll: [false] } },
+		description: 'Max number of results to return',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['attachment'],
+		operation: ['getAll'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	_items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+	const issueId = this.getNodeParameter('issueId', 0) as string;
+	const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
+	const limit = returnAll ? undefined : (this.getNodeParameter('limit', 0) as number);
+
+	const body = {
+		query: `query IssueAttachments($issueId: String!, $first: Int, $after: String) {
+			issue(id: $issueId) {
+				attachments(first: $first, after: $after) {
+					nodes {
+						id
+						url
+						title
+						subtitle
+						createdAt
+						updatedAt
+					}
+					pageInfo { hasNextPage endCursor }
+				}
+			}
+		}`,
+		variables: { issueId, first: 50 },
+	};
+
+	try {
+		const attachments = await linearApiRequestAllItems.call(
+			this,
+			'data.issue.attachments',
+			body,
+			limit,
+		);
+		returnData.push(
+			...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(attachments), {
+				itemData: { item: 0 },
+			}),
+		);
+	} catch (error) {
+		if (this.continueOnFail()) {
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ error: (error as Error).message }),
+					{ itemData: { item: 0 } },
+				),
+			);
+		} else {
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/attachment/index.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/attachment/index.ts
@@ -1,0 +1,53 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as create from './create.operation';
+import * as deleteAttachment from './delete.operation';
+import * as get from './get.operation';
+import * as getAll from './getAll.operation';
+
+export { create, deleteAttachment as delete, get, getAll };
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['attachment'],
+			},
+		},
+		options: [
+			{
+				name: 'Create',
+				value: 'create',
+				description: 'Create an attachment',
+				action: 'Create an attachment',
+			},
+			{
+				name: 'Delete',
+				value: 'delete',
+				description: 'Delete an attachment',
+				action: 'Delete an attachment',
+			},
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get an attachment',
+				action: 'Get an attachment',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get attachments for an issue',
+				action: 'Get many attachments',
+			},
+		],
+		default: 'getAll',
+	},
+	...create.description,
+	...deleteAttachment.description,
+	...get.description,
+	...getAll.description,
+];

--- a/packages/nodes-base/nodes/Linear/v2/actions/cycle/archive.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/cycle/archive.operation.ts
@@ -1,0 +1,71 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Cycle ID',
+		name: 'cycleId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['cycle'],
+		operation: ['archive'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const cycleId = this.getNodeParameter('cycleId', i) as string;
+
+			const body = {
+				query: `mutation CycleArchive($cycleId: String!) {
+					cycleArchive(id: $cycleId) {
+						success
+					}
+				}`,
+				variables: { cycleId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const result = (responseData as { data: { cycleArchive: IDataObject } }).data.cycleArchive;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(result), {
+					itemData: { item: i },
+				}),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/cycle/create.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/cycle/create.operation.ts
@@ -1,0 +1,130 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Team Name or ID',
+		name: 'teamId',
+		type: 'options',
+		required: true,
+		description:
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+		typeOptions: { loadOptionsMethod: 'getTeams' },
+		default: '',
+	},
+	{
+		displayName: 'Start Date',
+		name: 'startsAt',
+		type: 'dateTime',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'End Date',
+		name: 'endsAt',
+		type: 'dateTime',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		options: [
+			{
+				displayName: 'Name',
+				name: 'name',
+				type: 'string',
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['cycle'],
+		operation: ['create'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const teamId = this.getNodeParameter('teamId', i) as string;
+			const startsAt = this.getNodeParameter('startsAt', i) as string;
+			const endsAt = this.getNodeParameter('endsAt', i) as string;
+			const additionalFields = this.getNodeParameter('additionalFields', i) as Record<
+				string,
+				unknown
+			>;
+
+			const body = {
+				query: `mutation CycleCreate($teamId: String!, $startsAt: DateTime!, $endsAt: DateTime!, $name: String) {
+					cycleCreate(input: {
+						teamId: $teamId
+						startsAt: $startsAt
+						endsAt: $endsAt
+						name: $name
+					}) {
+						success
+						cycle {
+							id
+							name
+							number
+							startsAt
+							endsAt
+							createdAt
+							updatedAt
+						}
+					}
+				}`,
+				variables: {
+					teamId,
+					startsAt,
+					endsAt,
+					...additionalFields,
+				},
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const cycle = (responseData as { data: { cycleCreate: { cycle: IDataObject } } }).data
+				.cycleCreate?.cycle;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(cycle),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/cycle/delete.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/cycle/delete.operation.ts
@@ -39,7 +39,7 @@ export async function execute(
 
 			const body = {
 				query: `mutation CycleDelete($cycleId: String!) {
-					cycleArchive(id: $cycleId) {
+					cycleDelete(id: $cycleId) {
 						success
 					}
 				}`,
@@ -47,7 +47,7 @@ export async function execute(
 			};
 
 			const responseData = await linearApiRequest.call(this, body);
-			const result = (responseData as { data: { cycleArchive: IDataObject } }).data.cycleArchive;
+			const result = (responseData as { data: { cycleDelete: IDataObject } }).data.cycleDelete;
 
 			returnData.push(
 				...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(result), {

--- a/packages/nodes-base/nodes/Linear/v2/actions/cycle/delete.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/cycle/delete.operation.ts
@@ -1,0 +1,71 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Cycle ID',
+		name: 'cycleId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['cycle'],
+		operation: ['delete'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const cycleId = this.getNodeParameter('cycleId', i) as string;
+
+			const body = {
+				query: `mutation CycleDelete($cycleId: String!) {
+					cycleArchive(id: $cycleId) {
+						success
+					}
+				}`,
+				variables: { cycleId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const result = (responseData as { data: { cycleArchive: IDataObject } }).data.cycleArchive;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(result), {
+					itemData: { item: i },
+				}),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/cycle/get.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/cycle/get.operation.ts
@@ -1,0 +1,83 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Cycle ID',
+		name: 'cycleId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['cycle'],
+		operation: ['get'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const cycleId = this.getNodeParameter('cycleId', i) as string;
+
+			const body = {
+				query: `query Cycle($cycleId: String!) {
+					cycle(id: $cycleId) {
+						id
+						name
+						number
+						startsAt
+						endsAt
+						archivedAt
+						createdAt
+						updatedAt
+						team {
+							id
+							name
+						}
+					}
+				}`,
+				variables: { cycleId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const cycle = (responseData as { data: { cycle: IDataObject } }).data.cycle;
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(cycle),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/cycle/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/cycle/getAll.operation.ts
@@ -1,0 +1,85 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+
+import { linearApiRequestAllItems } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: { minValue: 1 },
+		displayOptions: { show: { returnAll: [false] } },
+		description: 'Max number of results to return',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['cycle'],
+		operation: ['getAll'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	_items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+	const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
+	const limit = returnAll ? undefined : (this.getNodeParameter('limit', 0) as number);
+
+	const body = {
+		query: `query Cycles($first: Int, $after: String) {
+			cycles(first: $first, after: $after) {
+				nodes {
+					id
+					name
+					number
+					startsAt
+					endsAt
+					archivedAt
+					createdAt
+					updatedAt
+					team {
+						id
+						name
+					}
+				}
+				pageInfo { hasNextPage endCursor }
+			}
+		}`,
+		variables: { first: 50 },
+	};
+
+	try {
+		const cycles = await linearApiRequestAllItems.call(this, 'data.cycles', body, limit);
+		returnData.push(
+			...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(cycles), {
+				itemData: { item: 0 },
+			}),
+		);
+	} catch (error) {
+		if (this.continueOnFail()) {
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ error: (error as Error).message }),
+					{ itemData: { item: 0 } },
+				),
+			);
+		} else {
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/cycle/index.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/cycle/index.ts
@@ -1,0 +1,69 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as archive from './archive.operation';
+import * as create from './create.operation';
+import * as deleteCycle from './delete.operation';
+import * as get from './get.operation';
+import * as getAll from './getAll.operation';
+import * as update from './update.operation';
+
+export { archive, create, deleteCycle as delete, get, getAll, update };
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['cycle'],
+			},
+		},
+		options: [
+			{
+				name: 'Archive',
+				value: 'archive',
+				description: 'Archive a cycle',
+				action: 'Archive a cycle',
+			},
+			{
+				name: 'Create',
+				value: 'create',
+				description: 'Create a cycle',
+				action: 'Create a cycle',
+			},
+			{
+				name: 'Delete',
+				value: 'delete',
+				description: 'Delete a cycle',
+				action: 'Delete a cycle',
+			},
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a cycle',
+				action: 'Get a cycle',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get many cycles',
+				action: 'Get many cycles',
+			},
+			{
+				name: 'Update',
+				value: 'update',
+				description: 'Update a cycle',
+				action: 'Update a cycle',
+			},
+		],
+		default: 'getAll',
+	},
+	...archive.description,
+	...create.description,
+	...deleteCycle.description,
+	...get.description,
+	...getAll.description,
+	...update.description,
+];

--- a/packages/nodes-base/nodes/Linear/v2/actions/cycle/update.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/cycle/update.operation.ts
@@ -87,11 +87,13 @@ export async function execute(
 			};
 
 			const responseData = await linearApiRequest.call(this, body);
-			const cycle = (responseData as { data: { cycleUpdate: { cycle: IDataObject } } }).data
-				.cycleUpdate?.cycle;
+			const cycleUpdate = (
+				responseData as { data: { cycleUpdate: { success: boolean; cycle: IDataObject } } }
+			).data.cycleUpdate;
+			const result = cycleUpdate?.cycle ?? (cycleUpdate as unknown as IDataObject);
 
 			returnData.push(
-				...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(cycle), {
+				...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(result), {
 					itemData: { item: i },
 				}),
 			);

--- a/packages/nodes-base/nodes/Linear/v2/actions/cycle/update.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/cycle/update.operation.ts
@@ -1,0 +1,112 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Cycle ID',
+		name: 'cycleId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'Update Fields',
+		name: 'updateFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		options: [
+			{
+				displayName: 'End Date',
+				name: 'endsAt',
+				type: 'dateTime',
+				default: '',
+			},
+			{
+				displayName: 'Name',
+				name: 'name',
+				type: 'string',
+				default: '',
+			},
+			{
+				displayName: 'Start Date',
+				name: 'startsAt',
+				type: 'dateTime',
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['cycle'],
+		operation: ['update'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const cycleId = this.getNodeParameter('cycleId', i) as string;
+			const updateFields = this.getNodeParameter('updateFields', i) as IDataObject;
+
+			const body = {
+				query: `mutation CycleUpdate($cycleId: String!, $name: String, $startsAt: DateTime, $endsAt: DateTime) {
+					cycleUpdate(id: $cycleId, input: {
+						name: $name
+						startsAt: $startsAt
+						endsAt: $endsAt
+					}) {
+						success
+						cycle {
+							id
+							name
+							number
+							startsAt
+							endsAt
+							updatedAt
+						}
+					}
+				}`,
+				variables: { cycleId, ...updateFields },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const cycle = (responseData as { data: { cycleUpdate: { cycle: IDataObject } } }).data
+				.cycleUpdate?.cycle;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(cycle), {
+					itemData: { item: i },
+				}),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/node.type.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/node.type.ts
@@ -7,6 +7,9 @@ type NodeMap = {
 	user: 'get' | 'getAll' | 'getCurrent';
 	team: 'get' | 'getAll';
 	label: 'create' | 'get' | 'getAll' | 'update' | 'delete';
+	cycle: 'create' | 'get' | 'getAll' | 'update' | 'delete' | 'archive';
+	attachment: 'create' | 'get' | 'getAll' | 'delete';
+	workflowState: 'get' | 'getAll';
 };
 
 export type Linear = AllEntities<NodeMap>;

--- a/packages/nodes-base/nodes/Linear/v2/actions/router.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/router.ts
@@ -1,13 +1,16 @@
 import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 
+import * as attachment from './attachment';
 import * as comment from './comment';
+import * as cycle from './cycle';
 import * as issue from './issue';
-import type { Linear } from './node.type';
 import * as label from './label';
+import type { Linear } from './node.type';
 import * as project from './project';
 import * as team from './team';
 import * as user from './user';
+import * as workflowState from './workflowState';
 
 export async function router(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 	const items = this.getInputData();
@@ -36,6 +39,15 @@ export async function router(this: IExecuteFunctions): Promise<INodeExecutionDat
 			break;
 		case 'label':
 			returnData = await label[linear.operation].execute.call(this, items);
+			break;
+		case 'cycle':
+			returnData = await cycle[linear.operation].execute.call(this, items);
+			break;
+		case 'attachment':
+			returnData = await attachment[linear.operation].execute.call(this, items);
+			break;
+		case 'workflowState':
+			returnData = await workflowState[linear.operation].execute.call(this, items);
 			break;
 		default:
 			throw new NodeOperationError(this.getNode(), `The resource "${resource}" is not known`);

--- a/packages/nodes-base/nodes/Linear/v2/actions/versionDescription.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/versionDescription.ts
@@ -1,11 +1,14 @@
 import { NodeConnectionTypes, type INodeTypeDescription } from 'n8n-workflow';
 
+import * as attachment from './attachment';
 import * as comment from './comment';
+import * as cycle from './cycle';
 import * as issue from './issue';
 import * as label from './label';
 import * as project from './project';
 import * as team from './team';
 import * as user from './user';
+import * as workflowState from './workflowState';
 
 export const versionDescription: INodeTypeDescription = {
 	displayName: 'Linear',
@@ -65,8 +68,16 @@ export const versionDescription: INodeTypeDescription = {
 			noDataExpression: true,
 			options: [
 				{
+					name: 'Attachment',
+					value: 'attachment',
+				},
+				{
 					name: 'Comment',
 					value: 'comment',
+				},
+				{
+					name: 'Cycle',
+					value: 'cycle',
 				},
 				{
 					name: 'Issue',
@@ -88,14 +99,21 @@ export const versionDescription: INodeTypeDescription = {
 					name: 'User',
 					value: 'user',
 				},
+				{
+					name: 'Workflow State',
+					value: 'workflowState',
+				},
 			],
 			default: 'issue',
 		},
+		...attachment.description,
 		...comment.description,
+		...cycle.description,
 		...issue.description,
 		...label.description,
 		...project.description,
 		...team.description,
 		...user.description,
+		...workflowState.description,
 	],
 };

--- a/packages/nodes-base/nodes/Linear/v2/actions/workflowState/get.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/workflowState/get.operation.ts
@@ -1,0 +1,85 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Workflow State ID',
+		name: 'workflowStateId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['workflowState'],
+		operation: ['get'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const workflowStateId = this.getNodeParameter('workflowStateId', i) as string;
+
+			const body = {
+				query: `query WorkflowState($workflowStateId: String!) {
+					workflowState(id: $workflowStateId) {
+						id
+						name
+						type
+						color
+						description
+						position
+						createdAt
+						updatedAt
+						team {
+							id
+							name
+						}
+					}
+				}`,
+				variables: { workflowStateId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const state = (responseData as { data: { workflowState: IDataObject } }).data.workflowState;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray(state as IDataObject),
+					{
+						itemData: { item: i },
+					},
+				),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/workflowState/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/workflowState/getAll.operation.ts
@@ -1,0 +1,115 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequestAllItems } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: { minValue: 1 },
+		displayOptions: { show: { returnAll: [false] } },
+		description: 'Max number of results to return',
+	},
+	{
+		displayName: 'Filters',
+		name: 'filters',
+		type: 'collection',
+		placeholder: 'Add Filter',
+		default: {},
+		options: [
+			{
+				displayName: 'Team Name or ID',
+				name: 'teamId',
+				type: 'options',
+				description:
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: { loadOptionsMethod: 'getTeams' },
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['workflowState'],
+		operation: ['getAll'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	_items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+	const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
+	const limit = returnAll ? undefined : (this.getNodeParameter('limit', 0) as number);
+	const filters = this.getNodeParameter('filters', 0) as IDataObject;
+
+	const filter: IDataObject = {};
+	if (filters.teamId) filter.team = { id: { eq: filters.teamId } };
+
+	const body = {
+		query: `query WorkflowStates($first: Int, $after: String, $filter: WorkflowStateFilter) {
+			workflowStates(first: $first, after: $after, filter: $filter) {
+				nodes {
+					id
+					name
+					type
+					color
+					description
+					position
+					createdAt
+					updatedAt
+					team {
+						id
+						name
+					}
+				}
+				pageInfo { hasNextPage endCursor }
+			}
+		}`,
+		variables: {
+			first: 50,
+			...(Object.keys(filter).length > 0 ? { filter } : {}),
+		},
+	};
+
+	try {
+		const states = await linearApiRequestAllItems.call(this, 'data.workflowStates', body, limit);
+		returnData.push(
+			...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(states), {
+				itemData: { item: 0 },
+			}),
+		);
+	} catch (error) {
+		if (this.continueOnFail()) {
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ error: (error as Error).message }),
+					{ itemData: { item: 0 } },
+				),
+			);
+		} else {
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/workflowState/index.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/workflowState/index.ts
@@ -1,0 +1,37 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as get from './get.operation';
+import * as getAll from './getAll.operation';
+
+export { get, getAll };
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['workflowState'],
+			},
+		},
+		options: [
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a workflow state',
+				action: 'Get a workflow state',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get many workflow states',
+				action: 'Get many workflow states',
+			},
+		],
+		default: 'getAll',
+	},
+	...get.description,
+	...getAll.description,
+];


### PR DESCRIPTION
## Summary

- **Cycle** resource (6 operations): create, get, getAll, update, delete, archive
- **Attachment** resource (4 operations): create, get, getAll, delete
- **WorkflowState** resource (2 operations): get, getAll
- Expands `router.ts` and `versionDescription.ts` with 3 new resources
- Jest tests covering: `cycle.create`, `attachment.get`, `workflowState.getAll`

## Stacked on

PR #26703 (Project + User + Team + Label)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4288