### PR TITLE
feat(Linear Node): Add Document, Roadmap, and TeamMembership resources to v2

### DIFF
--- a/packages/nodes-base/nodes/Linear/test/node/v2/LinearV2.document.test.ts
+++ b/packages/nodes-base/nodes/Linear/test/node/v2/LinearV2.document.test.ts
@@ -1,0 +1,115 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+import * as GenericFunctions from '../../../shared/GenericFunctions';
+import * as documentCreate from '../../../v2/actions/document/create.operation';
+import * as roadmapGetAll from '../../../v2/actions/roadmap/getAll.operation';
+import * as teamMembershipCreate from '../../../v2/actions/teamMembership/create.operation';
+
+describe('Linear v2 → Document, Roadmap & TeamMembership', () => {
+	let mockThis: IExecuteFunctions;
+	let apiRequestSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		mockThis = {
+			getInputData: jest.fn().mockReturnValue([{ json: {} }]),
+			getNodeParameter: jest.fn(),
+			continueOnFail: jest.fn().mockReturnValue(false),
+			helpers: {
+				returnJsonArray: jest.fn().mockImplementation((d) => [{ json: d }]),
+				constructExecutionMetaData: jest.fn().mockImplementation((d) => d),
+			},
+		} as unknown as IExecuteFunctions;
+	});
+
+	afterEach(() => jest.restoreAllMocks());
+
+	describe('document.create', () => {
+		it('sends documentCreate mutation with title', async () => {
+			apiRequestSpy = jest.spyOn(GenericFunctions, 'linearApiRequest').mockResolvedValue({
+				data: { documentCreate: { document: { id: 'doc-1', title: 'Spec' } } },
+			});
+
+			(mockThis.getNodeParameter as jest.Mock).mockImplementation((param: string) => {
+				if (param === 'title') return 'Spec';
+				if (param === 'additionalFields') return {};
+				return undefined;
+			});
+
+			await documentCreate.execute.call(mockThis, [{ json: {} }]);
+
+			expect(apiRequestSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					query: expect.stringContaining('documentCreate'),
+					variables: expect.objectContaining({ title: 'Spec' }),
+				}),
+			);
+		});
+
+		it('includes projectId when provided in additionalFields', async () => {
+			apiRequestSpy = jest.spyOn(GenericFunctions, 'linearApiRequest').mockResolvedValue({
+				data: { documentCreate: { document: { id: 'doc-2', title: 'Roadmap doc' } } },
+			});
+
+			(mockThis.getNodeParameter as jest.Mock).mockImplementation((param: string) => {
+				if (param === 'title') return 'Roadmap doc';
+				if (param === 'additionalFields') return { projectId: 'proj-abc' };
+				return undefined;
+			});
+
+			await documentCreate.execute.call(mockThis, [{ json: {} }]);
+
+			expect(apiRequestSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					variables: expect.objectContaining({ title: 'Roadmap doc', projectId: 'proj-abc' }),
+				}),
+			);
+		});
+	});
+
+	describe('roadmap.getAll', () => {
+		it('calls roadmaps query', async () => {
+			const allItemsSpy = jest
+				.spyOn(GenericFunctions, 'linearApiRequestAllItems')
+				.mockResolvedValue([{ id: 'road-1', name: 'Q1 Roadmap' }]);
+
+			(mockThis.getNodeParameter as jest.Mock).mockImplementation((param: string) => {
+				if (param === 'returnAll') return false;
+				if (param === 'limit') return 50;
+				return undefined;
+			});
+
+			await roadmapGetAll.execute.call(mockThis, [{ json: {} }]);
+
+			expect(allItemsSpy).toHaveBeenCalledWith(
+				'data.roadmaps',
+				expect.objectContaining({ query: expect.stringContaining('roadmaps') }),
+				50,
+			);
+		});
+	});
+
+	describe('teamMembership.create', () => {
+		it('sends teamMembershipCreate mutation with userId and teamId', async () => {
+			apiRequestSpy = jest.spyOn(GenericFunctions, 'linearApiRequest').mockResolvedValue({
+				data: {
+					teamMembershipCreate: { teamMembership: { id: 'mem-1', team: { id: 'team-1' } } },
+				},
+			});
+
+			(mockThis.getNodeParameter as jest.Mock).mockImplementation((param: string) => {
+				if (param === 'teamId') return 'team-xyz';
+				if (param === 'userId') return 'user-abc';
+				return undefined;
+			});
+
+			await teamMembershipCreate.execute.call(mockThis, [{ json: {} }]);
+
+			expect(apiRequestSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					query: expect.stringContaining('teamMembershipCreate'),
+					variables: expect.objectContaining({ teamId: 'team-xyz', userId: 'user-abc' }),
+				}),
+			);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Linear/v2/actions/document/create.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/document/create.operation.ts
@@ -1,0 +1,113 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Title',
+		name: 'title',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		options: [
+			{
+				displayName: 'Content',
+				name: 'content',
+				type: 'string',
+				typeOptions: { rows: 4 },
+				default: '',
+				description: 'The document content in markdown format',
+			},
+			{
+				displayName: 'Project Name or ID',
+				name: 'projectId',
+				type: 'options',
+				description:
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: { loadOptionsMethod: 'getProjects' },
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['document'],
+		operation: ['create'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const title = this.getNodeParameter('title', i) as string;
+			const additionalFields = this.getNodeParameter('additionalFields', i) as Record<
+				string,
+				unknown
+			>;
+
+			const body = {
+				query: `mutation DocumentCreate($title: String!, $content: String, $projectId: String) {
+					documentCreate(input: {
+						title: $title
+						content: $content
+						projectId: $projectId
+					}) {
+						success
+						document {
+							id
+							title
+							content
+							createdAt
+							updatedAt
+						}
+					}
+				}`,
+				variables: { title, ...additionalFields },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const document = (responseData as { data: { documentCreate: { document: IDataObject } } })
+				.data.documentCreate?.document;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(document), {
+					itemData: { item: i },
+				}),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/document/delete.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/document/delete.operation.ts
@@ -1,0 +1,72 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Document ID',
+		name: 'documentId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['document'],
+		operation: ['delete'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const documentId = this.getNodeParameter('documentId', i) as string;
+
+			const body = {
+				query: `mutation DocumentDelete($documentId: String!) {
+					documentDelete(id: $documentId) {
+						success
+					}
+				}`,
+				variables: { documentId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const result = (responseData as { data: { documentDelete: IDataObject } }).data
+				.documentDelete;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(result), {
+					itemData: { item: i },
+				}),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/document/get.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/document/get.operation.ts
@@ -1,0 +1,79 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Document ID',
+		name: 'documentId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['document'],
+		operation: ['get'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const documentId = this.getNodeParameter('documentId', i) as string;
+
+			const body = {
+				query: `query Document($documentId: String!) {
+					document(id: $documentId) {
+						id
+						title
+						content
+						createdAt
+						updatedAt
+						project {
+							id
+							name
+						}
+					}
+				}`,
+				variables: { documentId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const document = (responseData as { data: { document: IDataObject } }).data.document;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(document), {
+					itemData: { item: i },
+				}),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/document/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/document/getAll.operation.ts
@@ -1,0 +1,82 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+
+import { linearApiRequestAllItems } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: { minValue: 1 },
+		displayOptions: { show: { returnAll: [false] } },
+		description: 'Max number of results to return',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['document'],
+		operation: ['getAll'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	_items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+	const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
+	const limit = returnAll ? undefined : (this.getNodeParameter('limit', 0) as number);
+
+	const body = {
+		query: `query Documents($first: Int, $after: String) {
+			documents(first: $first, after: $after) {
+				nodes {
+					id
+					title
+					content
+					createdAt
+					updatedAt
+					project {
+						id
+						name
+					}
+				}
+				pageInfo { hasNextPage endCursor }
+			}
+		}`,
+		variables: { first: 50 },
+	};
+
+	try {
+		const documents = await linearApiRequestAllItems.call(this, 'data.documents', body, limit);
+		returnData.push(
+			...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(documents), {
+				itemData: { item: 0 },
+			}),
+		);
+	} catch (error) {
+		if (this.continueOnFail()) {
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ error: (error as Error).message }),
+					{ itemData: { item: 0 } },
+				),
+			);
+		} else {
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/document/index.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/document/index.ts
@@ -1,0 +1,61 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as create from './create.operation';
+import * as deleteDocument from './delete.operation';
+import * as get from './get.operation';
+import * as getAll from './getAll.operation';
+import * as update from './update.operation';
+
+export { create, deleteDocument as delete, get, getAll, update };
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['document'],
+			},
+		},
+		options: [
+			{
+				name: 'Create',
+				value: 'create',
+				description: 'Create a document',
+				action: 'Create a document',
+			},
+			{
+				name: 'Delete',
+				value: 'delete',
+				description: 'Delete a document',
+				action: 'Delete a document',
+			},
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a document',
+				action: 'Get a document',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get many documents',
+				action: 'Get many documents',
+			},
+			{
+				name: 'Update',
+				value: 'update',
+				description: 'Update a document',
+				action: 'Update a document',
+			},
+		],
+		default: 'getAll',
+	},
+	...create.description,
+	...deleteDocument.description,
+	...get.description,
+	...getAll.description,
+	...update.description,
+];

--- a/packages/nodes-base/nodes/Linear/v2/actions/document/update.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/document/update.operation.ts
@@ -1,0 +1,104 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Document ID',
+		name: 'documentId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'Update Fields',
+		name: 'updateFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		options: [
+			{
+				displayName: 'Content',
+				name: 'content',
+				type: 'string',
+				typeOptions: { rows: 4 },
+				default: '',
+			},
+			{
+				displayName: 'Title',
+				name: 'title',
+				type: 'string',
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['document'],
+		operation: ['update'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const documentId = this.getNodeParameter('documentId', i) as string;
+			const updateFields = this.getNodeParameter('updateFields', i) as IDataObject;
+
+			const body = {
+				query: `mutation DocumentUpdate($documentId: String!, $title: String, $content: String) {
+					documentUpdate(id: $documentId, input: {
+						title: $title
+						content: $content
+					}) {
+						success
+						document {
+							id
+							title
+							content
+							updatedAt
+						}
+					}
+				}`,
+				variables: { documentId, ...updateFields },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const document = (responseData as { data: { documentUpdate: { document: IDataObject } } })
+				.data.documentUpdate?.document;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(document), {
+					itemData: { item: i },
+				}),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/node.type.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/node.type.ts
@@ -10,6 +10,9 @@ type NodeMap = {
 	cycle: 'create' | 'get' | 'getAll' | 'update' | 'delete' | 'archive';
 	attachment: 'create' | 'get' | 'getAll' | 'delete';
 	workflowState: 'get' | 'getAll';
+	document: 'create' | 'get' | 'getAll' | 'update' | 'delete';
+	roadmap: 'create' | 'get' | 'getAll' | 'update' | 'delete';
+	teamMembership: 'create' | 'getAll' | 'delete';
 };
 
 export type Linear = AllEntities<NodeMap>;

--- a/packages/nodes-base/nodes/Linear/v2/actions/roadmap/create.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/roadmap/create.operation.ts
@@ -1,0 +1,105 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Name',
+		name: 'name',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		options: [
+			{
+				displayName: 'Description',
+				name: 'description',
+				type: 'string',
+				typeOptions: { rows: 4 },
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['roadmap'],
+		operation: ['create'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const name = this.getNodeParameter('name', i) as string;
+			const additionalFields = this.getNodeParameter('additionalFields', i) as Record<
+				string,
+				unknown
+			>;
+
+			const body = {
+				query: `mutation RoadmapCreate($name: String!, $description: String) {
+					roadmapCreate(input: {
+						name: $name
+						description: $description
+					}) {
+						success
+						roadmap {
+							id
+							name
+							description
+							createdAt
+							updatedAt
+						}
+					}
+				}`,
+				variables: { name, ...additionalFields },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const roadmap = (responseData as { data: { roadmapCreate: { roadmap: IDataObject } } }).data
+				.roadmapCreate?.roadmap;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray(roadmap as IDataObject),
+					{
+						itemData: { item: i },
+					},
+				),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/roadmap/delete.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/roadmap/delete.operation.ts
@@ -1,0 +1,74 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Roadmap ID',
+		name: 'roadmapId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['roadmap'],
+		operation: ['delete'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const roadmapId = this.getNodeParameter('roadmapId', i) as string;
+
+			const body = {
+				query: `mutation RoadmapDelete($roadmapId: String!) {
+					roadmapDelete(id: $roadmapId) {
+						success
+					}
+				}`,
+				variables: { roadmapId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const result = (responseData as { data: { roadmapDelete: IDataObject } }).data.roadmapDelete;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray(result as IDataObject),
+					{
+						itemData: { item: i },
+					},
+				),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/roadmap/get.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/roadmap/get.operation.ts
@@ -1,0 +1,78 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Roadmap ID',
+		name: 'roadmapId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['roadmap'],
+		operation: ['get'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const roadmapId = this.getNodeParameter('roadmapId', i) as string;
+
+			const body = {
+				query: `query Roadmap($roadmapId: String!) {
+					roadmap(id: $roadmapId) {
+						id
+						name
+						description
+						createdAt
+						updatedAt
+					}
+				}`,
+				variables: { roadmapId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const roadmap = (responseData as { data: { roadmap: IDataObject } }).data.roadmap;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray(roadmap as IDataObject),
+					{
+						itemData: { item: i },
+					},
+				),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/roadmap/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/roadmap/getAll.operation.ts
@@ -1,0 +1,78 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+
+import { linearApiRequestAllItems } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: { minValue: 1 },
+		displayOptions: { show: { returnAll: [false] } },
+		description: 'Max number of results to return',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['roadmap'],
+		operation: ['getAll'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	_items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+	const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
+	const limit = returnAll ? undefined : (this.getNodeParameter('limit', 0) as number);
+
+	const body = {
+		query: `query Roadmaps($first: Int, $after: String) {
+			roadmaps(first: $first, after: $after) {
+				nodes {
+					id
+					name
+					description
+					createdAt
+					updatedAt
+				}
+				pageInfo { hasNextPage endCursor }
+			}
+		}`,
+		variables: { first: 50 },
+	};
+
+	try {
+		const roadmaps = await linearApiRequestAllItems.call(this, 'data.roadmaps', body, limit);
+		returnData.push(
+			...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(roadmaps), {
+				itemData: { item: 0 },
+			}),
+		);
+	} catch (error) {
+		if (this.continueOnFail()) {
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ error: (error as Error).message }),
+					{ itemData: { item: 0 } },
+				),
+			);
+		} else {
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/roadmap/index.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/roadmap/index.ts
@@ -1,0 +1,61 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as create from './create.operation';
+import * as deleteRoadmap from './delete.operation';
+import * as get from './get.operation';
+import * as getAll from './getAll.operation';
+import * as update from './update.operation';
+
+export { create, deleteRoadmap as delete, get, getAll, update };
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['roadmap'],
+			},
+		},
+		options: [
+			{
+				name: 'Create',
+				value: 'create',
+				description: 'Create a roadmap',
+				action: 'Create a roadmap',
+			},
+			{
+				name: 'Delete',
+				value: 'delete',
+				description: 'Delete a roadmap',
+				action: 'Delete a roadmap',
+			},
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a roadmap',
+				action: 'Get a roadmap',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get many roadmaps',
+				action: 'Get many roadmaps',
+			},
+			{
+				name: 'Update',
+				value: 'update',
+				description: 'Update a roadmap',
+				action: 'Update a roadmap',
+			},
+		],
+		default: 'getAll',
+	},
+	...create.description,
+	...deleteRoadmap.description,
+	...get.description,
+	...getAll.description,
+	...update.description,
+];

--- a/packages/nodes-base/nodes/Linear/v2/actions/roadmap/update.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/roadmap/update.operation.ts
@@ -1,0 +1,107 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Roadmap ID',
+		name: 'roadmapId',
+		type: 'string',
+		required: true,
+		default: '',
+	},
+	{
+		displayName: 'Update Fields',
+		name: 'updateFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		options: [
+			{
+				displayName: 'Description',
+				name: 'description',
+				type: 'string',
+				typeOptions: { rows: 4 },
+				default: '',
+			},
+			{
+				displayName: 'Name',
+				name: 'name',
+				type: 'string',
+				default: '',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['roadmap'],
+		operation: ['update'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const roadmapId = this.getNodeParameter('roadmapId', i) as string;
+			const updateFields = this.getNodeParameter('updateFields', i) as IDataObject;
+
+			const body = {
+				query: `mutation RoadmapUpdate($roadmapId: String!, $name: String, $description: String) {
+					roadmapUpdate(id: $roadmapId, input: {
+						name: $name
+						description: $description
+					}) {
+						success
+						roadmap {
+							id
+							name
+							description
+							updatedAt
+						}
+					}
+				}`,
+				variables: { roadmapId, ...updateFields },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const roadmap = (responseData as { data: { roadmapUpdate: { roadmap: IDataObject } } }).data
+				.roadmapUpdate?.roadmap;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray(roadmap as IDataObject),
+					{
+						itemData: { item: i },
+					},
+				),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/router.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/router.ts
@@ -4,11 +4,14 @@ import { NodeOperationError } from 'n8n-workflow';
 import * as attachment from './attachment';
 import * as comment from './comment';
 import * as cycle from './cycle';
+import * as document from './document';
 import * as issue from './issue';
 import * as label from './label';
 import type { Linear } from './node.type';
 import * as project from './project';
+import * as roadmap from './roadmap';
 import * as team from './team';
+import * as teamMembership from './teamMembership';
 import * as user from './user';
 import * as workflowState from './workflowState';
 
@@ -48,6 +51,15 @@ export async function router(this: IExecuteFunctions): Promise<INodeExecutionDat
 			break;
 		case 'workflowState':
 			returnData = await workflowState[linear.operation].execute.call(this, items);
+			break;
+		case 'document':
+			returnData = await document[linear.operation].execute.call(this, items);
+			break;
+		case 'roadmap':
+			returnData = await roadmap[linear.operation].execute.call(this, items);
+			break;
+		case 'teamMembership':
+			returnData = await teamMembership[linear.operation].execute.call(this, items);
 			break;
 		default:
 			throw new NodeOperationError(this.getNode(), `The resource "${resource}" is not known`);

--- a/packages/nodes-base/nodes/Linear/v2/actions/teamMembership/create.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/teamMembership/create.operation.ts
@@ -1,0 +1,108 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Team Name or ID',
+		name: 'teamId',
+		type: 'options',
+		required: true,
+		description:
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+		typeOptions: { loadOptionsMethod: 'getTeams' },
+		default: '',
+	},
+	{
+		displayName: 'User Name or ID',
+		name: 'userId',
+		type: 'options',
+		required: true,
+		description:
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+		typeOptions: { loadOptionsMethod: 'getUsers' },
+		default: '',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['teamMembership'],
+		operation: ['create'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const teamId = this.getNodeParameter('teamId', i) as string;
+			const userId = this.getNodeParameter('userId', i) as string;
+
+			const body = {
+				query: `mutation TeamMembershipCreate($teamId: String!, $userId: String!) {
+					teamMembershipCreate(input: {
+						teamId: $teamId
+						userId: $userId
+					}) {
+						success
+						teamMembership {
+							id
+							createdAt
+							team {
+								id
+								name
+							}
+							user {
+								id
+								displayName
+								email
+							}
+						}
+					}
+				}`,
+				variables: { teamId, userId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const membership = (
+				responseData as {
+					data: { teamMembershipCreate: { teamMembership: IDataObject } };
+				}
+			).data.teamMembershipCreate?.teamMembership;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray(membership as IDataObject),
+					{
+						itemData: { item: i },
+					},
+				),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/teamMembership/delete.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/teamMembership/delete.operation.ts
@@ -1,0 +1,76 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { linearApiRequest } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Team Membership ID',
+		name: 'teamMembershipId',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'The ID of the team membership to delete',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['teamMembership'],
+		operation: ['delete'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const teamMembershipId = this.getNodeParameter('teamMembershipId', i) as string;
+
+			const body = {
+				query: `mutation TeamMembershipDelete($teamMembershipId: String!) {
+					teamMembershipDelete(id: $teamMembershipId) {
+						success
+					}
+				}`,
+				variables: { teamMembershipId },
+			};
+
+			const responseData = await linearApiRequest.call(this, body);
+			const result = (responseData as { data: { teamMembershipDelete: IDataObject } }).data
+				.teamMembershipDelete;
+
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray(result as IDataObject),
+					{
+						itemData: { item: i },
+					},
+				),
+			);
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push(
+					...this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: (error as Error).message }),
+						{ itemData: { item: i } },
+					),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/teamMembership/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/teamMembership/getAll.operation.ts
@@ -1,0 +1,92 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+
+import { linearApiRequestAllItems } from '../../../shared/GenericFunctions';
+import { updateDisplayOptions } from '../../../../../utils/utilities';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Team Name or ID',
+		name: 'teamId',
+		type: 'options',
+		required: true,
+		description:
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+		typeOptions: { loadOptionsMethod: 'getTeams' },
+		default: '',
+	},
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: { minValue: 1 },
+		displayOptions: { show: { returnAll: [false] } },
+		description: 'Max number of results to return',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['teamMembership'],
+		operation: ['getAll'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	_items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+	const teamId = this.getNodeParameter('teamId', 0) as string;
+	const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
+	const limit = returnAll ? undefined : (this.getNodeParameter('limit', 0) as number);
+
+	const body = {
+		query: `query TeamMemberships($teamId: String!, $first: Int, $after: String) {
+			team(id: $teamId) {
+				members(first: $first, after: $after) {
+					nodes {
+						id
+						name
+						displayName
+						email
+						avatarUrl
+						active
+					}
+					pageInfo { hasNextPage endCursor }
+				}
+			}
+		}`,
+		variables: { teamId, first: 50 },
+	};
+
+	try {
+		const members = await linearApiRequestAllItems.call(this, 'data.team.members', body, limit);
+		returnData.push(
+			...this.helpers.constructExecutionMetaData(this.helpers.returnJsonArray(members), {
+				itemData: { item: 0 },
+			}),
+		);
+	} catch (error) {
+		if (this.continueOnFail()) {
+			returnData.push(
+				...this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ error: (error as Error).message }),
+					{ itemData: { item: 0 } },
+				),
+			);
+		} else {
+			throw error;
+		}
+	}
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Linear/v2/actions/teamMembership/index.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/teamMembership/index.ts
@@ -1,0 +1,45 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as create from './create.operation';
+import * as deleteTeamMembership from './delete.operation';
+import * as getAll from './getAll.operation';
+
+export { create, deleteTeamMembership as delete, getAll };
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['teamMembership'],
+			},
+		},
+		options: [
+			{
+				name: 'Add Member',
+				value: 'create',
+				description: 'Add a member to a team',
+				action: 'Add a member to a team',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get team memberships',
+				action: 'Get many team memberships',
+			},
+			{
+				name: 'Remove Member',
+				value: 'delete',
+				description: 'Remove a member from a team',
+				action: 'Remove a member from a team',
+			},
+		],
+		default: 'getAll',
+	},
+	...create.description,
+	...deleteTeamMembership.description,
+	...getAll.description,
+];

--- a/packages/nodes-base/nodes/Linear/v2/actions/versionDescription.ts
+++ b/packages/nodes-base/nodes/Linear/v2/actions/versionDescription.ts
@@ -3,10 +3,13 @@ import { NodeConnectionTypes, type INodeTypeDescription } from 'n8n-workflow';
 import * as attachment from './attachment';
 import * as comment from './comment';
 import * as cycle from './cycle';
+import * as document from './document';
 import * as issue from './issue';
 import * as label from './label';
 import * as project from './project';
+import * as roadmap from './roadmap';
 import * as team from './team';
+import * as teamMembership from './teamMembership';
 import * as user from './user';
 import * as workflowState from './workflowState';
 
@@ -80,6 +83,10 @@ export const versionDescription: INodeTypeDescription = {
 					value: 'cycle',
 				},
 				{
+					name: 'Document',
+					value: 'document',
+				},
+				{
 					name: 'Issue',
 					value: 'issue',
 				},
@@ -92,8 +99,16 @@ export const versionDescription: INodeTypeDescription = {
 					value: 'project',
 				},
 				{
+					name: 'Roadmap',
+					value: 'roadmap',
+				},
+				{
 					name: 'Team',
 					value: 'team',
+				},
+				{
+					name: 'Team Membership',
+					value: 'teamMembership',
 				},
 				{
 					name: 'User',
@@ -109,10 +124,13 @@ export const versionDescription: INodeTypeDescription = {
 		...attachment.description,
 		...comment.description,
 		...cycle.description,
+		...document.description,
 		...issue.description,
 		...label.description,
 		...project.description,
+		...roadmap.description,
 		...team.description,
+		...teamMembership.description,
 		...user.description,
 		...workflowState.description,
 	],


### PR DESCRIPTION
## Summary

Completes the 12-resource Linear v2 implementation.

- **Document** resource (5 operations): create, get, getAll, update, delete
- **Roadmap** resource (5 operations): create, get, getAll, update, delete
- **TeamMembership** resource (3 operations): create, getAll, delete
- Finalizes `router.ts` and `versionDescription.ts` with all 12 resources
- Jest tests covering: `document.create` (with and without `projectId`), `roadmap.getAll`, `teamMembership.create`

## Full v2 resource summary (across all 4 PRs)

| Resource | Operations |
|---|---|
| Issue | create, get, getAll, update, delete, archive, unarchive, search |
| Comment | create, get, getAll, update, delete |
| Project | create, get, getAll, update, delete, archive |
| User | get, getAll, getCurrent |
| Team | get, getAll |
| Label | create, get, getAll, update, delete |
| Cycle | create, get, getAll, update, delete, archive |
| Attachment | create, get, getAll, delete |
| WorkflowState | get, getAll |
| Document | create, get, getAll, update, delete |
| Roadmap | create, get, getAll, update, delete |
| TeamMembership | create, getAll, delete |

## Stacked on

PR #26704 (Cycle + Attachment + WorkflowState)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4288