### PR TITLE
fix(AWS ELB Node): Correct typo in Remove Listener Certificate response

### DIFF
--- a/packages/nodes-base/nodes/Aws/ELB/AwsElb.node.ts
+++ b/packages/nodes-base/nodes/Aws/ELB/AwsElb.node.ts
@@ -294,7 +294,7 @@ export class AwsElb implements INodeType {
 							'/?Action=RemoveListenerCertificates&' + params.join('&'),
 						);
 
-						responseData = { sucess: true };
+						responseData = { success: true };
 					}
 				}
 

--- a/packages/nodes-base/nodes/Aws/ELB/test/README.md
+++ b/packages/nodes-base/nodes/Aws/ELB/test/README.md
@@ -4,13 +4,12 @@ This document explains intentional test data adjustments made to match the curre
 
 ## Known Implementation Issues
 
-### 1. Typo in Remove Listener Certificate Operation
+### 1. Typo in Remove Listener Certificate Operation (FIXED)
 
 **File**: `remove-listener-certificate.workflow.json`
 **Issue**: The response contains `"sucess": true` instead of `"success": true`
 **Root Cause**: Spelling error in the node implementation
-**Test Adjustment**: The pinData uses the misspelled version to match actual output
-**TODO**: Fix the typo in the AWS ELB node implementation and update test accordingly
+**Status**: Fixed - both the node implementation and test data have been corrected
 
 ### 2. Boolean Values Returned as Strings
 

--- a/packages/nodes-base/nodes/Aws/ELB/test/remove-listener-certificate.workflow.json
+++ b/packages/nodes-base/nodes/Aws/ELB/test/remove-listener-certificate.workflow.json
@@ -34,7 +34,7 @@
 		"Remove Listener Certificate": [
 			{
 				"json": {
-					"sucess": true
+					"success": true
 				}
 			}
 		]


### PR DESCRIPTION
## Summary

This PR fixes a typo in the AWS ELB node's Remove Listener Certificate operation where the response contained `sucess: true` instead of the correct `success: true`.

## Changes

- Fixed typo in `AwsElb.node.ts` - changed response key from `sucess` to `success`
- Updated corresponding test workflow pinData in `remove-listener-certificate.workflow.json`
- Updated test README to reflect the fix

## Related

This addresses a known issue documented in the test README where the misspelled response key was being used to match actual (incorrect) node output.