### PR TITLE
refactor(editor): Migrate AI assistant stores to workflowDocumentStore (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.test.ts
@@ -25,14 +25,14 @@ import type { Telemetry } from '@/app/plugins/telemetry';
 import type { ChatUI } from '@n8n/design-system/types/assistant';
 import type { INodeUi } from '@/Interface';
 
-const { mockDocumentStore } = vi.hoisted(() => ({
-	mockDocumentStore: {
+const { mockWorkflowDocumentStore } = vi.hoisted(() => ({
+	mockWorkflowDocumentStore: {
 		allNodes: [] as INodeUi[],
 	},
 }));
 
 vi.mock('@/app/stores/workflowDocument.store', () => ({
-	useWorkflowDocumentStore: vi.fn().mockReturnValue(mockDocumentStore),
+	useWorkflowDocumentStore: vi.fn().mockReturnValue(mockWorkflowDocumentStore),
 	createWorkflowDocumentId: vi.fn().mockReturnValue('test-id'),
 }));
 
@@ -76,7 +76,7 @@ describe('AI Assistant store', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		currentRouteParams = {};
-		mockDocumentStore.allNodes = [];
+		mockWorkflowDocumentStore.allNodes = [];
 		setActivePinia(createPinia());
 		settingsStore = useSettingsStore();
 		settingsStore.setSettings(
@@ -482,7 +482,7 @@ describe('AI Assistant store', () => {
 		workflowsStore.workflow.id = 'test-wf';
 
 		// Add a node to the workflow
-		mockDocumentStore.allNodes = [
+		mockWorkflowDocumentStore.allNodes = [
 			{
 				id: '1',
 				type: 'n8n-nodes-base.start',

--- a/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.test.ts
@@ -23,6 +23,18 @@ import * as chatAPI from '@/features/ai/assistant/assistant.api';
 import * as telemetryModule from '@/app/composables/useTelemetry';
 import type { Telemetry } from '@/app/plugins/telemetry';
 import type { ChatUI } from '@n8n/design-system/types/assistant';
+import type { INodeUi } from '@/Interface';
+
+const { mockDocumentStore } = vi.hoisted(() => ({
+	mockDocumentStore: {
+		allNodes: [] as INodeUi[],
+	},
+}));
+
+vi.mock('@/app/stores/workflowDocument.store', () => ({
+	useWorkflowDocumentStore: vi.fn().mockReturnValue(mockDocumentStore),
+	createWorkflowDocumentId: vi.fn().mockReturnValue('test-id'),
+}));
 
 let settingsStore: ReturnType<typeof useSettingsStore>;
 let posthogStore: ReturnType<typeof usePostHog>;
@@ -64,6 +76,7 @@ describe('AI Assistant store', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		currentRouteParams = {};
+		mockDocumentStore.allNodes = [];
 		setActivePinia(createPinia());
 		settingsStore = useSettingsStore();
 		settingsStore.setSettings(
@@ -465,8 +478,11 @@ describe('AI Assistant store', () => {
 		const assistantStore = useAssistantStore();
 		const workflowsStore = useWorkflowsStore();
 
+		// Set workflow id so workflowDocumentStore is created
+		workflowsStore.workflow.id = 'test-wf';
+
 		// Add a node to the workflow
-		workflowsStore.workflow.nodes = [
+		mockDocumentStore.allNodes = [
 			{
 				id: '1',
 				type: 'n8n-nodes-base.start',
@@ -475,7 +491,7 @@ describe('AI Assistant store', () => {
 				position: [250, 250],
 				parameters: {},
 			},
-		];
+		] as INodeUi[];
 
 		assistantStore.trackUserOpenedAssistant({
 			task: 'placeholder',
@@ -488,7 +504,7 @@ describe('AI Assistant store', () => {
 			task: 'placeholder',
 			has_existing_session: false,
 			instance_id: '',
-			workflow_id: '',
+			workflow_id: 'test-wf',
 			canvas_status: 'existing_workflow',
 			node_type: undefined,
 			error: undefined,

--- a/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.ts
@@ -8,6 +8,10 @@ import type { ChatUI } from '@n8n/design-system/types/assistant';
 import { defineStore } from 'pinia';
 import type { PushPayload } from '@n8n/api-types';
 import { computed, ref, watch } from 'vue';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import { useRoute } from 'vue-router';
@@ -36,6 +40,11 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 	const usersStore = useUsersStore();
 	const uiStore = useUIStore();
 	const workflowsStore = useWorkflowsStore();
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
 	const route = useRoute();
 	const streaming = ref<boolean>();
 	const streamingAbortController = ref<AbortController | null>(null);
@@ -699,7 +708,8 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 				task: 'credentials';
 		  }
 	)) {
-		const canvasStatus = workflowsStore.allNodes.length === 0 ? 'empty' : 'existing_workflow';
+		const canvasStatus =
+			(workflowDocumentStore.value?.allNodes ?? []).length === 0 ? 'empty' : 'existing_workflow';
 		telemetry.track('User opened assistant', {
 			source,
 			task,

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
@@ -17,6 +17,7 @@ const ENABLED_VIEWS = BUILDER_ENABLED_VIEWS;
 import { usePostHog } from '@/app/stores/posthog.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { defaultSettings } from '@/__tests__/defaults';
+import { createTestNode } from '@/__tests__/mocks';
 import merge from 'lodash/merge';
 import { DEFAULT_POSTHOG_SETTINGS } from '@/app/stores/posthog.store.test';
 import { DEFAULT_NEW_WORKFLOW_NAME } from '@/app/constants';
@@ -2258,7 +2259,7 @@ describe('AI Builder store', () => {
 				const builderStore = useBuilderStore();
 
 				// Start with nodes, then clear them (simulates workflow load sequence)
-				workflowsStore.allNodes = [{ name: 'Node1' }] as never;
+				workflowsStore.allNodes = [createTestNode({ name: 'Node1' })];
 				await nextTick();
 				expect(builderStore.builderMode).toBe('build');
 
@@ -2270,7 +2271,7 @@ describe('AI Builder store', () => {
 			it('should switch to build mode when nodes are added', async () => {
 				enablePlanModeExperiment();
 				// Start with nodes so the watcher can observe changes
-				workflowsStore.allNodes = [{ name: 'Node1' }] as never;
+				workflowsStore.allNodes = [createTestNode({ name: 'Node1' })];
 
 				const builderStore = useBuilderStore();
 				await nextTick();
@@ -2281,7 +2282,7 @@ describe('AI Builder store', () => {
 				expect(builderStore.builderMode).toBe('plan');
 
 				// Add nodes back to trigger build mode
-				workflowsStore.allNodes = [{ name: 'Node1' }] as never;
+				workflowsStore.allNodes = [createTestNode({ name: 'Node1' })];
 				await nextTick();
 				expect(builderStore.builderMode).toBe('build');
 			});
@@ -2301,7 +2302,7 @@ describe('AI Builder store', () => {
 				const builderStore = useBuilderStore();
 
 				// Add nodes first so we can trigger a change later
-				workflowsStore.allNodes = [{ name: 'Node1' }] as never;
+				workflowsStore.allNodes = [createTestNode({ name: 'Node1' })];
 				await nextTick();
 
 				// Simulate an active conversation
@@ -2336,7 +2337,7 @@ describe('AI Builder store', () => {
 					{ role: 'user', type: 'text', text: 'Build me something' } as never,
 					{ role: 'assistant', type: 'text', text: 'Done' } as never,
 				];
-				workflowsStore.allNodes = [{ name: 'Node1' }] as never;
+				workflowsStore.allNodes = [createTestNode({ name: 'Node1' })];
 				await nextTick();
 				expect(builderStore.builderMode).toBe('build');
 

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
@@ -2258,11 +2258,11 @@ describe('AI Builder store', () => {
 				const builderStore = useBuilderStore();
 
 				// Start with nodes, then clear them (simulates workflow load sequence)
-				workflowsStore.workflow.nodes = [{ name: 'Node1' }] as never;
+				workflowsStore.allNodes = [{ name: 'Node1' }] as never;
 				await nextTick();
 				expect(builderStore.builderMode).toBe('build');
 
-				workflowsStore.workflow.nodes = [];
+				workflowsStore.allNodes = [];
 				await nextTick();
 				expect(builderStore.builderMode).toBe('plan');
 			});
@@ -2270,18 +2270,18 @@ describe('AI Builder store', () => {
 			it('should switch to build mode when nodes are added', async () => {
 				enablePlanModeExperiment();
 				// Start with nodes so the watcher can observe changes
-				workflowsStore.workflow.nodes = [{ name: 'Node1' }] as never;
+				workflowsStore.allNodes = [{ name: 'Node1' }] as never;
 
 				const builderStore = useBuilderStore();
 				await nextTick();
 
 				// Clear nodes to trigger plan mode
-				workflowsStore.workflow.nodes = [];
+				workflowsStore.allNodes = [];
 				await nextTick();
 				expect(builderStore.builderMode).toBe('plan');
 
 				// Add nodes back to trigger build mode
-				workflowsStore.workflow.nodes = [{ name: 'Node1' }] as never;
+				workflowsStore.allNodes = [{ name: 'Node1' }] as never;
 				await nextTick();
 				expect(builderStore.builderMode).toBe('build');
 			});
@@ -2301,14 +2301,14 @@ describe('AI Builder store', () => {
 				const builderStore = useBuilderStore();
 
 				// Add nodes first so we can trigger a change later
-				workflowsStore.workflow.nodes = [{ name: 'Node1' }] as never;
+				workflowsStore.allNodes = [{ name: 'Node1' }] as never;
 				await nextTick();
 
 				// Simulate an active conversation
 				builderStore.chatMessages = [{ role: 'user', type: 'text', text: 'hello' } as never];
 
 				// Remove nodes — would normally switch to plan, but chat has messages
-				workflowsStore.workflow.nodes = [];
+				workflowsStore.allNodes = [];
 				await nextTick();
 
 				// Should stay at build because chat has messages
@@ -2321,7 +2321,7 @@ describe('AI Builder store', () => {
 
 				// Simulate navigating to a new empty workflow
 				workflowsStore.workflowId = 'new-empty-workflow';
-				workflowsStore.workflow.nodes = [];
+				workflowsStore.allNodes = [];
 				await nextTick();
 
 				expect(builderStore.builderMode).toBe('plan');
@@ -2336,14 +2336,14 @@ describe('AI Builder store', () => {
 					{ role: 'user', type: 'text', text: 'Build me something' } as never,
 					{ role: 'assistant', type: 'text', text: 'Done' } as never,
 				];
-				workflowsStore.workflow.nodes = [{ name: 'Node1' }] as never;
+				workflowsStore.allNodes = [{ name: 'Node1' }] as never;
 				await nextTick();
 				expect(builderStore.builderMode).toBe('build');
 
 				// Simulate what happens during restore: chat messages are truncated to []
 				// and nodes are cleared. The watcher would normally switch to plan mode.
 				builderStore.chatMessages = [];
-				workflowsStore.workflow.nodes = [];
+				workflowsStore.allNodes = [];
 				await nextTick();
 
 				// The watcher fires and sets plan mode

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
@@ -185,6 +185,11 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 	const settings = useSettingsStore();
 	const rootStore = useRootStore();
 	const workflowsStore = useWorkflowsStore();
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
 	const workflowState = injectWorkflowState();
 	const ndvStore = useNDVStore();
 	const route = useRoute();
@@ -731,10 +736,8 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 
 		// Use workflow updatedAt as version timestamp
 		// might not be the same as "version.createdAt" but close enough
-		const workflowDocumentStore = useWorkflowDocumentStore(
-			createWorkflowDocumentId(workflowsStore.workflowId),
-		);
-		const updatedAt = workflowDocumentStore.updatedAt;
+		const updatedAt = workflowDocumentStore.value?.updatedAt;
+		if (!updatedAt) return undefined;
 		return {
 			id: versionId,
 			createdAt: typeof updatedAt === 'number' ? new Date(updatedAt).toISOString() : updatedAt,
@@ -856,7 +859,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 			quickReplyType,
 			workflow: workflowsStore.workflow,
 			executionData: executionResult,
-			nodesForSchema: Object.keys(workflowsStore.nodesByName),
+			nodesForSchema: Object.keys(workflowDocumentStore.value?.nodesByName ?? {}),
 			mode: modeForPayload,
 			isPlanModeEnabled: isPlanModeAvailable.value,
 			allowSendingParameterValues: settings.settings.ai.allowSendingParameterValues,
@@ -1061,13 +1064,11 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 	}
 
 	function unpinAllNodes() {
-		const workflowDocumentStore = workflowsStore.workflowId
-			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
-			: undefined;
-		const pinData = workflowDocumentStore?.pinData;
+		const store = workflowDocumentStore.value;
+		const pinData = store?.pinData;
 		if (!pinData) return;
 		for (const nodeName of Object.keys(pinData)) {
-			workflowDocumentStore?.unpinNodeData(nodeName);
+			store.unpinNodeData(nodeName);
 			if (workflowsStore.nodeMetadata[nodeName]) {
 				workflowsStore.nodeMetadata[nodeName].pinnedDataLastRemovedAt = Date.now();
 			}
@@ -1077,7 +1078,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 
 	function clearExistingWorkflow() {
 		workflowState.removeAllConnections({ setStateDirty: false });
-		workflowState.removeAllNodes({ setStateDirty: false, removePinData: true });
+		workflowDocumentStore.value?.removeAllNodes();
 	}
 
 	function getWorkflowSnapshot() {
@@ -1161,7 +1162,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 	// Only applies when the chat is fresh (no messages) so it doesn't interfere
 	// with an active conversation.
 	watch(
-		[() => workflowsStore.workflowId, () => workflowsStore.workflow.nodes?.length ?? 0],
+		[() => workflowsStore.workflowId, () => (workflowDocumentStore.value?.allNodes ?? []).length],
 		([, nodesCount]) => {
 			if (chatMessages.value.length > 0) return;
 			if (!isPlanModeAvailable.value) return;
@@ -1247,8 +1248,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 		// version id is important to update, because otherwise the next time user saves,
 		// "overwrite" prevention modal shows, because the version id on the FE would be out of sync with latest on the backend
 		workflowState.setWorkflowProperty('versionId', updatedWorkflow.versionId);
-		const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
-		workflowDocumentStore.setUpdatedAt(updatedWorkflow.updatedAt);
+		workflowDocumentStore.value?.setUpdatedAt(updatedWorkflow.updatedAt);
 
 		// 2. Truncate messages in backend session (removes message with messageId and all after)
 		await truncateBuilderMessages(

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
@@ -737,7 +737,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 		// Use workflow updatedAt as version timestamp
 		// might not be the same as "version.createdAt" but close enough
 		const updatedAt = workflowDocumentStore.value?.updatedAt;
-		if (!updatedAt) throw new Error('Workflow updatedAt is missing');
+		if (!updatedAt) return undefined;
 		return {
 			id: versionId,
 			createdAt: typeof updatedAt === 'number' ? new Date(updatedAt).toISOString() : updatedAt,

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
@@ -737,7 +737,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 		// Use workflow updatedAt as version timestamp
 		// might not be the same as "version.createdAt" but close enough
 		const updatedAt = workflowDocumentStore.value?.updatedAt;
-		if (!updatedAt) return undefined;
+		if (!updatedAt) throw new Error('Workflow updatedAt is missing');
 		return {
 			id: versionId,
 			createdAt: typeof updatedAt === 'number' ? new Date(updatedAt).toISOString() : updatedAt,
@@ -1064,11 +1064,10 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 	}
 
 	function unpinAllNodes() {
-		const store = workflowDocumentStore.value;
-		const pinData = store?.pinData;
+		const pinData = workflowDocumentStore.value?.pinData;
 		if (!pinData) return;
 		for (const nodeName of Object.keys(pinData)) {
-			store.unpinNodeData(nodeName);
+			workflowDocumentStore.value?.unpinNodeData(nodeName);
 			if (workflowsStore.nodeMetadata[nodeName]) {
 				workflowsStore.nodeMetadata[nodeName].pinnedDataLastRemovedAt = Date.now();
 			}

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useNodeMention.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useNodeMention.test.ts
@@ -21,14 +21,14 @@ vi.mock('@/features/ndv/shared/ndv.store', () => ({
 	useNDVStore: () => ({ activeNode: null }),
 }));
 
-const { mockDocumentStore } = vi.hoisted(() => ({
-	mockDocumentStore: {
+const { mockWorkflowDocumentStore } = vi.hoisted(() => ({
+	mockWorkflowDocumentStore: {
 		allNodes: [] as INodeUi[],
 	},
 }));
 
 vi.mock('@/app/stores/workflowDocument.store', () => ({
-	useWorkflowDocumentStore: vi.fn().mockReturnValue(mockDocumentStore),
+	useWorkflowDocumentStore: vi.fn().mockReturnValue(mockWorkflowDocumentStore),
 	createWorkflowDocumentId: vi.fn().mockReturnValue('test-id'),
 }));
 
@@ -88,7 +88,7 @@ describe('useNodeMention', () => {
 		workflowsStore.workflowId = 'test-wf';
 		// @ts-expect-error -- mock readonly property for focusedNodesStore which still reads workflowsStore.allNodes
 		workflowsStore.allNodes = mockNodes;
-		mockDocumentStore.allNodes = mockNodes;
+		mockWorkflowDocumentStore.allNodes = mockNodes;
 	});
 
 	describe('handleInput - @ trigger conditions', () => {

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useNodeMention.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useNodeMention.test.ts
@@ -84,7 +84,8 @@ describe('useNodeMention', () => {
 		workflowsStore = useWorkflowsStore();
 		focusedNodesStore = useFocusedNodesStore();
 
-		workflowsStore.workflow.id = 'test-workflow';
+		// @ts-expect-error -- mock readonly getter
+		workflowsStore.workflowId = 'test-wf';
 		// @ts-expect-error -- mock readonly property for focusedNodesStore which still reads workflowsStore.allNodes
 		workflowsStore.allNodes = mockNodes;
 		mockDocumentStore.allNodes = mockNodes;

--- a/packages/frontend/editor-ui/src/features/ai/assistant/focusedNodes.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/focusedNodes.store.ts
@@ -2,6 +2,10 @@ import { computed, ref, watch } from 'vue';
 import { defineStore } from 'pinia';
 import { STORES } from '@n8n/stores';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { usePostHog } from '@/app/stores/posthog.store';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useDebounceFn } from '@vueuse/core';
@@ -20,6 +24,11 @@ const MAX_UNCONFIRMED_DISPLAY = 50;
 
 export const useFocusedNodesStore = defineStore(STORES.FOCUSED_NODES, () => {
 	const workflowsStore = useWorkflowsStore();
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
 	const posthogStore = usePostHog();
 	const telemetry = useTelemetry();
 	const chatPanelStateStore = useChatPanelStateStore();
@@ -44,7 +53,7 @@ export const useFocusedNodesStore = defineStore(STORES.FOCUSED_NODES, () => {
 	);
 
 	const filteredUnconfirmedNodes = computed(() => {
-		const totalWorkflowNodes = workflowsStore.allNodes.length;
+		const totalWorkflowNodes = (workflowDocumentStore.value?.allNodes ?? []).length;
 		const availableNodes = totalWorkflowNodes - confirmedNodes.value.length;
 		if (
 			confirmedNodes.value.length > 0 &&
@@ -76,7 +85,7 @@ export const useFocusedNodesStore = defineStore(STORES.FOCUSED_NODES, () => {
 	}
 
 	function getNodeInfo(nodeId: string): { name: string; type: string } | null {
-		const node = workflowsStore.allNodes.find((n) => n.id === nodeId);
+		const node = (workflowDocumentStore.value?.allNodes ?? []).find((n) => n.id === nodeId);
 		if (!node) return null;
 		return { name: node.name, type: node.type };
 	}
@@ -273,7 +282,7 @@ export const useFocusedNodesStore = defineStore(STORES.FOCUSED_NODES, () => {
 	);
 
 	watch(
-		() => workflowsStore.allNodes,
+		() => workflowDocumentStore.value?.allNodes ?? [],
 		(newNodes) => {
 			const currentNodeIds = new Set(newNodes.map((n) => n.id));
 			const focusedIds = Object.keys(focusedNodesMap.value);
@@ -302,7 +311,7 @@ export const useFocusedNodesStore = defineStore(STORES.FOCUSED_NODES, () => {
 	);
 
 	watch(
-		() => workflowsStore.allNodes.map((n) => ({ id: n.id, name: n.name })),
+		() => (workflowDocumentStore.value?.allNodes ?? []).map((n) => ({ id: n.id, name: n.name })),
 		(newNodeNames) => {
 			for (const { id, name } of newNodeNames) {
 				const focusedNode = focusedNodesMap.value[id];
@@ -331,7 +340,7 @@ export const useFocusedNodesStore = defineStore(STORES.FOCUSED_NODES, () => {
 
 		return buildFocusedNodesPayload(
 			confirmedNodes.value,
-			workflowsStore.allNodes,
+			workflowDocumentStore.value?.allNodes ?? [],
 			workflowsStore.connectionsByDestinationNode,
 			workflowsStore.connectionsBySourceNode,
 		);


### PR DESCRIPTION
## Summary

Migrates three AI assistant Pinia stores from direct `workflowsStore`/`workflowState` node access to the `workflowDocumentStore` facade, following the established migration recipe (computed accessor pattern).

**Stores migrated:**
- `assistant.store.ts` — 1 `allNodes` read
- `builder.store.ts` — `nodesByName`, `allNodes`, `removeAllNodes`, plus consolidation of 3 inline `useWorkflowDocumentStore()` calls into a single computed accessor
- `focusedNodes.store.ts` — 5 `allNodes` usages (computeds, watchers, helper function)

**Not migrated (accepted tech debt per recipe):**
- `workflowsStore.workflow` references passed to `createBuilderPayload` and `simplifyWorkflowForAssistant` — these use `Workflow` class methods and are intentionally deferred until connections also move to `workflowDocumentStore`
- `workflowState.removeAllConnections()` and `workflowState.setWorkflowProperty()` — not node document state

## Related Linear ticket

https://linear.app/n8n/issue/CAT-2513

## Review / Merge checklist

- [x] Tests pass (assistant 38/38, builder 137/137, focusedNodes 56/56)
- [x] Typecheck passes
- [x] Follows migration recipe patterns (computed accessor, fallback values, canonical naming)

## Test plan

- [x] Verify all existing AI assistant store tests pass without regressions
- [x] Verify typecheck passes
- [ ] Manual: Open AI assistant chat on empty canvas → verify plan mode activates
- [ ] Manual: Open AI assistant chat on populated canvas → verify build mode activates
- [ ] Manual: AI builder "clear and rebuild" action → verify nodes are removed correctly