### PR TITLE
fix: Rebuild isolated-vm in runners Dockerfile for Node.js v24

### DIFF
--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -30,6 +30,15 @@ RUN node -e "const pkg = require('./package.json'); \
 RUN rm -f node_modules/.modules.yaml && \
     pnpm add moment@2.30.1 --prod --no-lockfile
 
+# Rebuild isolated-vm native addon against the current Node.js version.
+# The pre-built binary from CI may have been compiled against a different
+# Node.js version (e.g., v22), causing ERR_DLOPEN_FAILED at runtime when
+# the V8 ABI has changed (e.g., missing ArrayBuffer::Allocator::Reallocate).
+# This mirrors the fix applied to docker/images/n8n/Dockerfile in #26672.
+RUN apk add --no-cache --virtual .build-deps python3 make g++ && \
+    npm rebuild isolated-vm && \
+    apk del .build-deps
+
 # ==============================================================================
 # STAGE 2: Python runner build (@n8n/task-runner-python) with uv
 # Produces a relocatable venv tied to the python version used


### PR DESCRIPTION
## Summary

The task runner image (`docker/images/runners/Dockerfile`) crash-loops with `ERR_DLOPEN_FAILED` after the Node.js v24 upgrade (#25707). The pre-built `isolated-vm` native addon was compiled against Node.js v22's V8 engine, and the `ArrayBuffer::Allocator::Reallocate` symbol does not exist in Node.js v24's V8 ABI.

This is the companion fix to #26672, which applied the same `npm rebuild isolated-vm` fix to `docker/images/n8n/Dockerfile` but did not update the runners image.

## Timeline

| Date | Event |
|------|-------|
| **Feb 13** | #25707 upgraded `NODE_VERSION` from `22.22.0` to `24.13.1` in the runners Dockerfile |
| **Feb 13+** | External task runners using `n8nio/runners:latest` began crash-looping (runner process exits with code 1 on every startup attempt) |
| **Mar 6** | #26672 fixed the main n8n image (`docker/images/n8n/Dockerfile`) by adding `npm rebuild isolated-vm`, but the runners image was not updated |
| **Mar 7** | This PR applies the same fix to `docker/images/runners/Dockerfile` |

## Affected Versions

All n8n releases that include the Node.js v24 upgrade (#25707) are affected when using external task runners (`n8nio/runners:latest`). This includes **n8n >= 2.8.0**.

## Error Logs (sanitized)

```
ERROR [runner:js] node:internal/modules/cjs/loader:1963
ERROR [runner:js]   return process.dlopen(module, path.toNamespacedPath(filename));
ERROR [runner:js]                  ^
ERROR [runner:js] Error: Error relocating /opt/runners/task-runner-javascript/node_modules/.pnpm/isolated-vm@6.0.2/node_modules/isolated-vm/out/isolated_vm.node: _ZN2v811ArrayBuffer9Allocator10ReallocateEPvmm: symbol not found
ERROR [runner:js]     at Object..node (node:internal/modules/cjs/loader:1963:18)
ERROR [runner:js]   code: 'ERR_DLOPEN_FAILED'
ERROR [runner:js] Node.js v24.13.1
ERROR [launcher:js] Runner process exited with error: exit status 1
```

The runner process crash-loops continuously, making all Code node executions fail with task timeouts.

## Changes

Added `npm rebuild isolated-vm` to Stage 1 (`javascript-runner-builder`) of the runners Dockerfile, matching the fix in #26672. Build dependencies (`python3`, `make`, `g++`) are installed temporarily via `--virtual .build-deps` and removed after the rebuild to keep the builder stage clean.

## Related

- #25707 — `feat: Update default Node.js version to v24` (introduced the breaking change)
- #26672 — `fix: Rebuild isolated-vm in Dockerfile` (fixed the main n8n image, but not the runners image)

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] Tests are not required (Dockerfile-only change, same pattern as #26672)