### PR TITLE
feat(api): Expose queued executions and enable stopping them via public API

### DIFF
--- a/packages/cli/src/executions/__tests__/execution.service.test.ts
+++ b/packages/cli/src/executions/__tests__/execution.service.test.ts
@@ -511,6 +511,68 @@ describe('ExecutionService', () => {
 					expect(executionRepository.stopDuringRun).toHaveBeenCalled();
 				});
 			});
+
+			it('should stop a queued `new` execution in scaling mode by removing the Bull job', async () => {
+				/**
+				 * Arrange
+				 */
+				globalConfig.executions.mode = 'queue';
+				const execution = mock<IExecutionResponse>({
+					id: '123',
+					status: 'new',
+					mode: 'trigger',
+				});
+				executionRepository.findWithUnflattenedData.mockResolvedValue(execution);
+
+				const job = mock<Job>({ data: { executionId: execution.id } });
+				scalingService.findJobsByStatus.mockResolvedValue([job]);
+				executionRepository.stopBeforeRun.mockResolvedValue(mock<IExecutionResponse>());
+
+				/**
+				 * Act
+				 */
+				await executionService.stop(execution.id, [execution.id]);
+
+				/**
+				 * Assert
+				 */
+				expect(scalingService.findJobsByStatus).toHaveBeenCalledWith(['waiting']);
+				expect(scalingService.stopJob).toHaveBeenCalledWith(job);
+				expect(executionRepository.stopBeforeRun).toHaveBeenCalledWith(execution);
+				expect(executionRepository.stopDuringRun).not.toHaveBeenCalled();
+				expect(activeExecutions.stopExecution).not.toHaveBeenCalled();
+				expect(waitTracker.stopExecution).not.toHaveBeenCalled();
+			});
+
+			it('should stop a queued `new` execution even when no matching Bull job is found', async () => {
+				/**
+				 * Arrange
+				 */
+				globalConfig.executions.mode = 'queue';
+				const execution = mock<IExecutionResponse>({
+					id: '123',
+					status: 'new',
+					mode: 'trigger',
+				});
+				executionRepository.findWithUnflattenedData.mockResolvedValue(execution);
+
+				// No matching job in the queue
+				const otherJob = mock<Job>({ data: { executionId: 'other-id' } });
+				scalingService.findJobsByStatus.mockResolvedValue([otherJob]);
+				executionRepository.stopBeforeRun.mockResolvedValue(mock<IExecutionResponse>());
+
+				/**
+				 * Act
+				 */
+				await executionService.stop(execution.id, [execution.id]);
+
+				/**
+				 * Assert
+				 */
+				expect(scalingService.findJobsByStatus).toHaveBeenCalledWith(['waiting']);
+				expect(scalingService.stopJob).not.toHaveBeenCalled();
+				expect(executionRepository.stopBeforeRun).toHaveBeenCalledWith(execution);
+			});
 		});
 	});
 	describe('stopMany', () => {
@@ -543,6 +605,61 @@ describe('ExecutionService', () => {
 			expect(stopFn).toBeCalledWith('2', shared);
 			expect(stopFn).toBeCalledWith('3', shared);
 			expect(executionRepository.findByStopExecutionsFilter).toBeCalledWith(filters);
+		});
+
+		it('should return the count of successfully stopped executions', async () => {
+			/**
+			 * Arrange
+			 */
+			executionRepository.findByStopExecutionsFilter.mockResolvedValue(
+				['1', '2', '3'].map((id) => ({ id })),
+			);
+			const stopFn = jest.fn();
+			executionService.stop = stopFn;
+
+			const filters = {
+				workflowId: '1',
+				status: ['running'],
+			} satisfies ExecutionRequest.StopMany['body']['filter'];
+
+			/**
+			 * Act
+			 */
+			const result = await executionService.stopMany(filters, ['A']);
+
+			/**
+			 * Assert
+			 */
+			expect(result).toBe(3);
+		});
+
+		it('should not count executions that throw MissingExecutionStopError', async () => {
+			/**
+			 * Arrange
+			 */
+			executionRepository.findByStopExecutionsFilter.mockResolvedValue(
+				['1', '2', '3'].map((id) => ({ id })),
+			);
+			const stopFn = jest.fn().mockImplementation((id: string) => {
+				if (id === '2') throw new MissingExecutionStopError(id);
+			});
+			executionService.stop = stopFn;
+
+			const filters = {
+				workflowId: '1',
+				status: ['running'],
+			} satisfies ExecutionRequest.StopMany['body']['filter'];
+
+			/**
+			 * Act
+			 */
+			const result = await executionService.stopMany(filters, ['A']);
+
+			/**
+			 * Assert
+			 */
+			expect(result).toBe(2);
+			expect(stopFn).toBeCalledTimes(3);
 		});
 	});
 });

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -14,7 +14,7 @@ import {
 	ExecutionRepository,
 	WorkflowRepository,
 } from '@n8n/db';
-import { Service } from '@n8n/di';
+import { Container, Service } from '@n8n/di';
 import { stringify } from 'flatted';
 import { validate as jsonSchemaValidate } from 'jsonschema';
 import type {
@@ -624,6 +624,24 @@ export class ExecutionService {
 	}
 
 	private async stopInScalingMode(execution: IExecutionResponse) {
+		// Handle queued executions (status 'new') that are waiting in the Bull
+		// queue but haven't been picked up by a worker yet. These executions are
+		// not tracked in activeExecutions or waitTracker -- they only exist in
+		// the Bull/Redis queue. We need to find the corresponding Bull job and
+		// remove it directly via the scaling service.
+		if (execution.status === 'new') {
+			const { ScalingService } = await import('@/scaling/scaling.service');
+			const scalingService = Container.get(ScalingService);
+			const waitingJobs = await scalingService.findJobsByStatus(['waiting']);
+			const job = waitingJobs.find((j) => j.data.executionId === execution.id);
+
+			if (job) {
+				await scalingService.stopJob(job);
+			}
+
+			return await this.executionRepository.stopBeforeRun(execution);
+		}
+
 		if (this.activeExecutions.has(execution.id)) {
 			this.activeExecutions.stopExecution(
 				execution.id,

--- a/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/executions/executions.handler.ts
@@ -149,8 +149,9 @@ export = {
 					workflowIds: workflowId ? [workflowId] : sharedWorkflowsIds,
 
 					// for backward compatibility `running` executions are always excluded
-					// unless the user explicitly filters by `running` status
-					excludedExecutionsIds: status !== 'running' ? runningExecutionsIds : undefined,
+					// unless the user explicitly filters by `running` or `new` status
+					excludedExecutionsIds:
+						status !== 'running' && status !== 'new' ? runningExecutionsIds : undefined,
 				};
 
 			const executions =

--- a/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.yml
+++ b/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.yml
@@ -13,7 +13,7 @@ get:
       required: false
       schema:
         type: string
-        enum: ['canceled', 'error', 'running', 'success', 'waiting']
+        enum: ['canceled', 'error', 'new', 'running', 'success', 'waiting']
     - name: workflowId
       in: query
       description: Workflow to filter the executions by.


### PR DESCRIPTION
## Summary

In queue mode, executions are enqueued to Bull/Redis with status `new` in Postgres before a worker picks them up. Currently, these queued executions are **invisible to the public API** and **cannot be stopped/canceled**, making it impossible to perform loadshedding on backlogged queues through safe, supported mechanisms.

## Problem

When running n8n in queue mode with external task runners (Kubernetes, Cloud Run worker pools, Docker Compose sidecars), queues can back up significantly during traffic spikes or when workers are temporarily unavailable. With 100 workers at max capacity and 1,000+ jobs waiting in Bull/Redis, operators currently have **no API-level way to drain the backlog**.

The only option today is directly manipulating the Bull/Redis queue -- which removes jobs from Redis but leaves the corresponding Postgres execution records stuck as `running` indefinitely (zombie executions). These zombies clutter the UI, corrupt execution count metrics, and confuse monitoring systems.

### Specific gaps:

1. **GET /executions** does not accept `new` as a status filter, so queued executions cannot be listed
2. **stopInScalingMode()** does not handle `new` status executions -- it only looks at `activeExecutions` and `waitTracker`, which don't track jobs that haven't been picked up by a worker yet
3. The existing `ScalingService.stopJob()` method correctly handles both active and waiting Bull jobs, but it's never called from the stop path for queued executions

### Real-world impact:

We operate 100 Cloud Run worker pool instances processing critical security evaluations. During a recent incident, the queue backed up to **2,700+ jobs** with all workers at capacity. With no API to cancel queued jobs, the backlog took **18+ hours** to drain naturally. The loadshedder (direct Redis manipulation) was the only alternative, but it creates zombie executions.

## Changes

**3 files changed, 23 insertions, 4 deletions:**

1. **OpenAPI spec** (`executions.yml`): Added `new` to the GET /executions status enum so queued executions can be listed

2. **List handler** (`executions.handler.ts`): Updated the exclusion filter to include `new` alongside `running` -- queued executions are no longer excluded from API results when explicitly filtered

3. **Stop logic** (`execution.service.ts`): Added Bull queue job removal to `stopInScalingMode()` for `new` status executions:
   - Finds the corresponding Bull job via `ScalingService.findJobsByStatus(['waiting'])`
   - Removes it via the existing `ScalingService.stopJob()` (which correctly handles both active and waiting jobs)
   - Updates Postgres via `stopBeforeRun()` (same path used by regular mode's concurrency control)

### What already worked (no changes needed):

- `assertStoppable()` already includes `new` in `STOPPABLE_STATUSES`
- `stopMany` spec already accepts `queued` (mapped to `new` internally on line 312)
- `ScalingService.stopJob()` already handles both active jobs (`discard + moveToFailed`) and waiting jobs (`remove`)
- `executionRepository.stopBeforeRun()` already handles the Postgres status update

## Usage

List queued executions:
```
GET /api/v1/executions?status=new
```

Stop all queued executions for a workflow:
```
POST /api/v1/executions/stop
{
  "status": ["queued"],
  "workflowId": "abc123",
  "startedBefore": "2026-03-07T18:00:00Z"
}
```

This properly removes Bull jobs AND updates Postgres to `canceled` -- no zombie executions.

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] Tests included
- [x] Changes are minimal and focused (3 files, 23 lines added)