### PR TITLE
fix(config): handle Windows absolute paths in EXTERNAL_HOOK_FILES

### DIFF
--- a/packages/@n8n/config/src/custom-types.ts
+++ b/packages/@n8n/config/src/custom-types.ts
@@ -15,5 +15,32 @@ export class CommaSeparatedStringArray<T extends string> extends StringArray<T> 
 export class ColonSeparatedStringArray<T extends string = string> extends StringArray<T> {
 	constructor(str: string) {
 		super(str, ':');
+		return ColonSeparatedStringArray.rejoinWindowsPaths(this);
+	}
+
+	/**
+	 * After splitting by ':', rejoin segments that were split on a Windows
+	 * drive-letter colon (e.g. 'C:\path' was split into ['C', '\path']).
+	 * A drive letter is a single ASCII letter whose next segment starts with
+	 * a backslash or forward slash.
+	 */
+	private static rejoinWindowsPaths<T extends string>(parts: T[]): T[] {
+		const result: T[] = [];
+		for (let i = 0; i < parts.length; i++) {
+			const part = parts[i];
+			if (
+				part.length === 1 &&
+				/^[a-zA-Z]$/.test(part) &&
+				i + 1 < parts.length &&
+				/^[\\\/]/.test(parts[i + 1])
+			) {
+				// Rejoin the drive letter with the rest of the path
+				result.push((part + ':' + parts[i + 1]) as T);
+				i++; // Skip the next segment since we merged it
+			} else {
+				result.push(part);
+			}
+		}
+		return result;
 	}
 }

--- a/packages/@n8n/config/test/custom-types.test.ts
+++ b/packages/@n8n/config/test/custom-types.test.ts
@@ -22,4 +22,40 @@ describe('ColonSeparatedStringArray', () => {
 		const result = new ColonSeparatedStringArray('a::b:::');
 		expect(result).toEqual(['a', 'b']);
 	});
+
+	it('should handle a single Windows absolute path', () => {
+		const result = new ColonSeparatedStringArray('C:\\n8n\\hooks\\my-hook.js');
+		expect(result).toEqual(['C:\\n8n\\hooks\\my-hook.js']);
+	});
+
+	it('should handle multiple Windows absolute paths separated by colons', () => {
+		const result = new ColonSeparatedStringArray(
+			'C:\\hooks\\hook1.js:D:\\hooks\\hook2.js',
+		);
+		expect(result).toEqual(['C:\\hooks\\hook1.js', 'D:\\hooks\\hook2.js']);
+	});
+
+	it('should handle a mix of Windows paths and Unix-style paths', () => {
+		const result = new ColonSeparatedStringArray(
+			'C:\\hooks\\hook1.js:/usr/local/hooks/hook2.js',
+		);
+		expect(result).toEqual(['C:\\hooks\\hook1.js', '/usr/local/hooks/hook2.js']);
+	});
+
+	it('should handle Windows paths with forward slashes', () => {
+		const result = new ColonSeparatedStringArray('C:/hooks/hook1.js');
+		expect(result).toEqual(['C:/hooks/hook1.js']);
+	});
+
+	it('should not rejoin segments that are not drive letters', () => {
+		const result = new ColonSeparatedStringArray('ab:\\path');
+		expect(result).toEqual(['ab', '\\path']);
+	});
+
+	it('should handle Unix paths without modification', () => {
+		const result = new ColonSeparatedStringArray(
+			'/usr/local/hook1.js:/opt/hooks/hook2.js',
+		);
+		expect(result).toEqual(['/usr/local/hook1.js', '/opt/hooks/hook2.js']);
+	});
 });


### PR DESCRIPTION
## Summary

Fixes #26557

The `EXTERNAL_HOOK_FILES` environment variable uses `ColonSeparatedStringArray` which splits by colon (`:`). This breaks Windows absolute paths like `C:
8nhooksmy-hook.js` because the colon after the drive letter is treated as a delimiter, splitting it into `["C", "
8nhooksmy-hook.js"]` instead of keeping `["C:
8nhooksmy-hook.js"]`.

## Changes

- Added `rejoinWindowsPaths()` static method to `ColonSeparatedStringArray` that detects Windows drive-letter patterns (a single ASCII letter followed by a segment starting with `` or `/`) and rejoins them after splitting
- Added comprehensive tests for Windows paths: single path, multiple paths, mixed Windows/Unix paths, forward-slash Windows paths, and non-drive-letter segments
- Existing Unix behavior is fully preserved (the method is a no-op when no drive-letter pattern is found)

## How it works

After the standard colon-split, the method scans the resulting array. When it finds a single ASCII letter followed by a segment starting with `` or `/`, it rejoins them with `:` (e.g. `["C", "hooksile.js"]` becomes `["C:hooksile.js"]`). All other segments pass through unchanged.

## Test plan

- [x] Added unit tests covering:
  - Single Windows absolute path (`C:
8nhooksmy-hook.js`)
  - Multiple Windows paths separated by colons
  - Mixed Windows and Unix paths
  - Windows paths with forward slashes (`C:/hooks/hook.js`)
  - Non-drive-letter segments are not rejoined (`ab:path` stays split)
  - Unix paths remain unchanged

---

> **Transparency note:** This PR was authored by an AI (Claude Opus 4.6) as part of an open-source contribution effort. I am not a human pretending to be an AI -- I am an AI transparently contributing to open source.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.