### PR TITLE
fix(AI Agent Node): Store tool call messages in conversation memory

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V1/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V1/execute.ts
@@ -5,6 +5,8 @@ import omit from 'lodash/omit';
 import { jsonParse, NodeOperationError } from 'n8n-workflow';
 import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 
+import { loadMemory, saveToMemory } from '@utils/agent-execution';
+import type { ToolCallData } from '@utils/agent-execution';
 import { getPromptInputByType } from '@utils/helpers';
 import { wrapLangChainParserError } from '@utils/output_parsers/langchainParserError';
 import { getOptionalOutputParser } from '@utils/output_parsers/N8nOutputParser';
@@ -53,7 +55,7 @@ export async function toolsAgentExecute(this: IExecuteFunctions): Promise<INodeE
 				promptTypeKey: 'promptType',
 			});
 			if (input === undefined) {
-				throw new NodeOperationError(this.getNode(), 'The “text” parameter is empty.');
+				throw new NodeOperationError(this.getNode(), 'The "text" parameter is empty.');
 			}
 
 			const options = this.getNodeParameter('options', itemIndex, {}) as {
@@ -90,9 +92,9 @@ export async function toolsAgentExecute(this: IExecuteFunctions): Promise<INodeE
 			]);
 			const executor = AgentExecutor.fromAgentAndTools({
 				agent: runnableAgent,
-				memory,
+				// Don't pass memory here — we save it ourselves to keep tool call messages
 				tools,
-				returnIntermediateSteps: options.returnIntermediateSteps === true,
+				returnIntermediateSteps: true,
 				maxIterations: options.maxIterations ?? 10,
 			});
 			const additionalMetadata = buildTracingMetadata(options.tracingMetadata?.values, this.logger);
@@ -103,16 +105,28 @@ export async function toolsAgentExecute(this: IExecuteFunctions): Promise<INodeE
 				getTracingConfig(this, { additionalMetadata }),
 			);
 
+			const chatHistory = memory ? await loadMemory(memory) : undefined;
+
 			// Invoke the executor with the given input and system message.
 			const response = await executorWithTracing.invoke(
 				{
 					input,
+					chat_history: chatHistory ?? undefined,
 					system_message: options.systemMessage ?? SYSTEM_MESSAGE,
 					formatting_instructions:
 						'IMPORTANT: For your response to user, you MUST use the `format_final_json_response` tool with your complete answer formatted according to the required schema. Do not attempt to format the JSON manually - always use this tool. Your response will be rejected if it is not properly formatted through this tool. Only use this tool once you are ready to provide your final answer.',
 				},
 				{ signal: this.getExecutionCancelSignal() },
 			);
+
+			const steps = (response.intermediateSteps ?? []) as ToolCallData[];
+			if (memory && input !== undefined && response.output != null) {
+				await saveToMemory(input, response.output as string, memory, steps);
+			}
+
+			if (!options.returnIntermediateSteps) {
+				delete response.intermediateSteps;
+			}
 
 			// If memory and outputParser are connected, parse the output.
 			if (memory && outputParser) {

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
@@ -13,7 +13,8 @@ import type { AIMessageChunk, MessageContentText } from '@langchain/core/message
 import type { ChatPromptTemplate } from '@langchain/core/prompts';
 import { RunnableSequence } from '@langchain/core/runnables';
 import { ChatOpenAI } from '@langchain/openai';
-import { loadMemory } from '@utils/agent-execution';
+import { loadMemory, saveToMemory } from '@utils/agent-execution';
+import type { ToolCallData } from '@utils/agent-execution';
 import { getPromptInputByType } from '@utils/helpers';
 import {
 	getOptionalOutputParser,
@@ -39,13 +40,14 @@ import {
 import { SYSTEM_MESSAGE } from '../prompt';
 
 /**
- * Creates an agent executor with the given configuration
+ * Creates an agent executor with the given configuration.
+ * Memory is handled by the caller (not AgentExecutor) so tool calls get persisted.
  */
 export function createAgentExecutor(
 	model: BaseChatModel,
 	tools: Array<DynamicStructuredTool | Tool>,
 	prompt: ChatPromptTemplate,
-	options: { maxIterations?: number; returnIntermediateSteps?: boolean },
+	options: { maxIterations?: number },
 	outputParser?: N8nOutputParser,
 	memory?: BaseChatMemory,
 	fallbackModel?: BaseChatModel | null,
@@ -77,9 +79,9 @@ export function createAgentExecutor(
 
 	return AgentExecutor.fromAgentAndTools({
 		agent: runnableAgent,
-		memory,
+		// Don't pass memory here — we save it ourselves to keep tool call messages
 		tools,
-		returnIntermediateSteps: options.returnIntermediateSteps === true,
+		returnIntermediateSteps: true,
 		maxIterations: options.maxIterations ?? 10,
 	});
 }
@@ -133,15 +135,13 @@ async function processEventStream(
 	ctx: IExecuteFunctions,
 	eventStream: IterableReadableStream<StreamEvent>,
 	itemIndex: number,
-	returnIntermediateSteps: boolean = false,
-): Promise<{ output: string; intermediateSteps?: any[] }> {
-	const agentResult: { output: string; intermediateSteps?: any[] } = {
+): Promise<{ output: string; intermediateSteps: ToolCallData[] }> {
+	const agentResult: { output: string; intermediateSteps: ToolCallData[] } = {
 		output: '',
+		intermediateSteps: [],
 	};
-
-	if (returnIntermediateSteps) {
-		agentResult.intermediateSteps = [];
-	}
+	const toolRunToStep = new Map<string, ToolCallData>();
+	const mappedSteps = new Set<ToolCallData>();
 
 	ctx.sendChunk('begin', itemIndex);
 	for await (const event of eventStream) {
@@ -167,40 +167,58 @@ async function processEventStream(
 				}
 				break;
 			case 'on_chat_model_end':
-				// Capture full LLM response with tool calls for intermediate steps
-				if (returnIntermediateSteps && event.data) {
-					const chatModelData = event.data as any;
-					const output = chatModelData.output;
+				if (event.data) {
+					const chatModelData = event.data as Record<string, unknown>;
+					const output = chatModelData.output as Record<string, unknown> | undefined;
 
-					// Check if this LLM response contains tool calls
-					if (output?.tool_calls && output.tool_calls.length > 0) {
-						for (const toolCall of output.tool_calls) {
-							agentResult.intermediateSteps!.push({
+					const toolCalls = output?.tool_calls as
+						| Array<{
+								name: string;
+								args: Record<string, unknown>;
+								id: string;
+								type: string;
+						  }>
+						| undefined;
+					if (toolCalls && toolCalls.length > 0) {
+						for (const toolCall of toolCalls) {
+							agentResult.intermediateSteps.push({
 								action: {
 									tool: toolCall.name,
 									toolInput: toolCall.args,
 									log:
-										output.content ||
+										(output?.content as string) ||
 										`Calling ${toolCall.name} with input: ${JSON.stringify(toolCall.args)}`,
-									messageLog: [output], // Include the full LLM response
+									messageLog: [output] as unknown as ToolCallData['action']['messageLog'],
 									toolCallId: toolCall.id,
 									type: toolCall.type,
 								},
+								observation: '',
 							});
 						}
 					}
 				}
 				break;
-			case 'on_tool_end':
-				// Capture tool execution results and match with action
-				if (returnIntermediateSteps && event.data && agentResult.intermediateSteps!.length > 0) {
-					const toolData = event.data as any;
-					// Find the matching intermediate step for this tool call
-					const matchingStep = agentResult.intermediateSteps!.find(
-						(step) => !step.observation && step.action.tool === event.name,
+			case 'on_tool_start':
+				if (event.run_id) {
+					const step = agentResult.intermediateSteps.find(
+						(s) => !s.observation && s.action.tool === event.name && !mappedSteps.has(s),
 					);
-					if (matchingStep) {
-						matchingStep.observation = toolData.output;
+					if (step) {
+						toolRunToStep.set(event.run_id, step);
+						mappedSteps.add(step);
+					}
+				}
+				break;
+			case 'on_tool_end':
+				if (event.data) {
+					const toolData = event.data as Record<string, unknown>;
+					const step =
+						(event.run_id && toolRunToStep.get(event.run_id)) ||
+						agentResult.intermediateSteps.find(
+							(s) => !s.observation && s.action.tool === event.name,
+						);
+					if (step) {
+						step.observation = toolData.output as string;
 					}
 				}
 				break;
@@ -326,7 +344,6 @@ export async function toolsAgentExecute(
 				});
 				const prompt: ChatPromptTemplate = preparePrompt(messages);
 
-				// Create executors for primary and fallback models
 				const executor = createAgentExecutor(
 					model,
 					tools,
@@ -347,7 +364,7 @@ export async function toolsAgentExecute(
 					? getTracingConfig(this, { additionalMetadata })
 					: undefined;
 				const executorWithTracing = tracingConfig ? executor.withConfig(tracingConfig) : executor;
-				// Invoke with fallback logic
+
 				const invokeParams = {
 					input,
 					system_message: options.systemMessage ?? SYSTEM_MESSAGE,
@@ -360,6 +377,11 @@ export async function toolsAgentExecute(
 					callbacks: [toolCounter],
 				};
 
+				const chatHistory = memory ? await loadMemory(memory, model) : undefined;
+				if (memory) {
+					memoryLoads++;
+				}
+
 				// Check if streaming is actually available
 				const isStreamingAvailable = 'isStreaming' in this ? this.isStreaming?.() : undefined;
 
@@ -369,11 +391,6 @@ export async function toolsAgentExecute(
 					isStreamingAvailable &&
 					this.getNode().typeVersion >= 2.1
 				) {
-					// Get chat history respecting the context window length configured in memory
-					const chatHistory = memory ? await loadMemory(memory, model) : undefined;
-					if (memory) {
-						memoryLoads++;
-					}
 					const eventStream = executorWithTracing.streamEvents(
 						{
 							...invokeParams,
@@ -385,16 +402,33 @@ export async function toolsAgentExecute(
 						},
 					);
 
-					const response = await processEventStream(
-						this,
-						eventStream,
-						itemIndex,
-						options.returnIntermediateSteps,
-					);
-					return { response, toolCallsCounted: toolCounter.count };
+					const result = await processEventStream(this, eventStream, itemIndex);
+
+					if (memory && input !== undefined && result.output != null) {
+						await saveToMemory(input, result.output, memory, result.intermediateSteps);
+					}
+
+					if (!options.returnIntermediateSteps) {
+						return { response: { output: result.output }, toolCallsCounted: toolCounter.count };
+					}
+					return { response: result, toolCallsCounted: toolCounter.count };
 				} else {
-					// Handle regular execution
-					const response = await executorWithTracing.invoke(invokeParams, executeOptions);
+					const response = await executorWithTracing.invoke(
+						{
+							...invokeParams,
+							chat_history: chatHistory ?? undefined,
+						},
+						executeOptions,
+					);
+
+					const steps = (response.intermediateSteps ?? []) as ToolCallData[];
+					if (memory && input !== undefined && response.output != null) {
+						await saveToMemory(input, response.output as string, memory, steps);
+					}
+
+					if (!options.returnIntermediateSteps) {
+						delete response.intermediateSteps;
+					}
 					return { response, toolCallsCounted: toolCounter.count };
 				}
 			});

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/memoryManagement.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/memoryManagement.ts
@@ -267,7 +267,7 @@ export async function saveToMemory(
 	steps?: ToolCallData[],
 	previousStepsCount?: number,
 ): Promise<void> {
-	if (!output || !memory) {
+	if (output == null || !memory) {
 		return;
 	}
 

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/memoryManagement.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/memoryManagement.test.ts
@@ -689,6 +689,153 @@ describe('memoryManagement', () => {
 		});
 	});
 
+	describe('saveToMemory round-trip with tool calls', () => {
+		let mockChatHistory: {
+			addMessages: jest.Mock;
+			getMessages: jest.Mock;
+		};
+		let savedMessages: unknown[];
+
+		beforeEach(() => {
+			jest.spyOn(console, 'log').mockImplementation();
+			savedMessages = [];
+			mockChatHistory = {
+				addMessages: jest.fn().mockImplementation(async (msgs: unknown[]) => {
+					savedMessages.push(...msgs);
+				}),
+				getMessages: jest.fn().mockImplementation(() => savedMessages),
+			};
+			mockMemory.chatHistory = mockChatHistory as unknown as BaseChatMemory['chatHistory'];
+		});
+
+		afterEach(() => {
+			jest.restoreAllMocks();
+		});
+
+		it('should save tool calls that can be loaded back with correct message types', async () => {
+			const aiMessage = new AIMessage({
+				content: 'Let me look that up',
+				tool_calls: [
+					{
+						id: 'call-abc',
+						name: 'database_lookup',
+						args: { query: 'contact John' },
+						type: 'tool_call',
+					},
+				],
+			});
+
+			const steps: ToolCallData[] = [
+				{
+					action: {
+						tool: 'database_lookup',
+						toolInput: { query: 'contact John' },
+						log: 'Looking up',
+						messageLog: [aiMessage],
+						toolCallId: 'call-abc',
+						type: 'tool_call',
+					},
+					observation: '{"id": 12345, "name": "John Doe"}',
+				},
+			];
+
+			await saveToMemory(
+				'Find the contact for John',
+				'I found the contact: John Doe (ID: 12345)',
+				mockMemory,
+				steps,
+			);
+
+			expect(mockChatHistory.addMessages).toHaveBeenCalledTimes(1);
+			const msgs = mockChatHistory.addMessages.mock.calls[0][0];
+
+			// HumanMessage, AIMessage(tool_calls), ToolMessage, AIMessage(final)
+			expect(msgs).toHaveLength(4);
+			expect(msgs[0]).toBeInstanceOf(HumanMessage);
+			expect(msgs[0].content).toBe('Find the contact for John');
+			expect(msgs[1]).toBeInstanceOf(AIMessage);
+			expect(msgs[1].tool_calls).toHaveLength(1);
+			expect(msgs[1].tool_calls[0].name).toBe('database_lookup');
+			expect(msgs[2]).toBeInstanceOf(ToolMessage);
+			expect(msgs[2].content).toBe('{"id": 12345, "name": "John Doe"}');
+			expect((msgs[2] as ToolMessage).tool_call_id).toBe('call-abc');
+			expect(msgs[3]).toBeInstanceOf(AIMessage);
+			expect(msgs[3].content).toBe('I found the contact: John Doe (ID: 12345)');
+			expect(msgs[3].tool_calls ?? []).toHaveLength(0);
+		});
+
+		it('should save multiple sequential tool calls in correct order', async () => {
+			const aiMsg1 = new AIMessage({
+				content: 'Looking up contact',
+				tool_calls: [
+					{ id: 'call-1', name: 'find_contact', args: { name: 'John' }, type: 'tool_call' },
+				],
+			});
+			const aiMsg2 = new AIMessage({
+				content: 'Adding email',
+				tool_calls: [
+					{
+						id: 'call-2',
+						name: 'update_contact',
+						args: { id: 12345, email: 'john@example.com' },
+						type: 'tool_call',
+					},
+				],
+			});
+
+			const steps: ToolCallData[] = [
+				{
+					action: {
+						tool: 'find_contact',
+						toolInput: { name: 'John' },
+						log: 'Find',
+						messageLog: [aiMsg1],
+						toolCallId: 'call-1',
+						type: 'tool_call',
+					},
+					observation: '{"id": 12345}',
+				},
+				{
+					action: {
+						tool: 'update_contact',
+						toolInput: { id: 12345, email: 'john@example.com' },
+						log: 'Update',
+						messageLog: [aiMsg2],
+						toolCallId: 'call-2',
+						type: 'tool_call',
+					},
+					observation: '{"success": true}',
+				},
+			];
+
+			await saveToMemory('Add john@example.com to John', 'Done! Email added.', mockMemory, steps);
+
+			const msgs = mockChatHistory.addMessages.mock.calls[0][0];
+			// HumanMessage, AI+tool_calls, ToolMessage, AI+tool_calls, ToolMessage, AI(final)
+			expect(msgs).toHaveLength(6);
+			expect(msgs[0]).toBeInstanceOf(HumanMessage);
+			expect(msgs[1]).toBeInstanceOf(AIMessage);
+			expect(msgs[1].tool_calls[0].name).toBe('find_contact');
+			expect(msgs[2]).toBeInstanceOf(ToolMessage);
+			expect(msgs[2].content).toBe('{"id": 12345}');
+			expect(msgs[3]).toBeInstanceOf(AIMessage);
+			expect(msgs[3].tool_calls[0].name).toBe('update_contact');
+			expect(msgs[4]).toBeInstanceOf(ToolMessage);
+			expect(msgs[4].content).toBe('{"success": true}');
+			expect(msgs[5]).toBeInstanceOf(AIMessage);
+			expect(msgs[5].content).toBe('Done! Email added.');
+		});
+
+		it('should persist memory for empty-string output', async () => {
+			await saveToMemory('Question', '', mockMemory, []);
+
+			expect(mockMemory.saveContext).toHaveBeenCalledWith(
+				{ input: 'Question' },
+				{ output: '' },
+			);
+		});
+	});
+
 	describe('buildToolContext', () => {
 		it('should build tool context string from single step', () => {
 			const steps: ToolCallData[] = [


### PR DESCRIPTION
## Summary

When using the AI Agent node (V1/V2) with a memory sub-node, tool call messages were not being persisted to conversation history. `AgentExecutor` internally calls `saveContext()` which only stores plain input/output strings — the `AIMessage.tool_calls` and `ToolMessage` objects in between get silently dropped.

This caused the LLM to lose context about previous tool usage across turns, leading to hallucinated or repeated tool calls.

The fix follows the same approach already used in the V3 agent: handle memory manually instead of delegating it to `AgentExecutor`. Chat history is loaded via `loadMemory()` before invocation, and saved via `saveToMemory()` after — which properly constructs the full `HumanMessage → AIMessage(tool_calls) → ToolMessage → AIMessage(final)` sequence.

### What changed

- **V2** (`execute.ts`): Removed `memory` from `AgentExecutor`, added manual `loadMemory`/`saveToMemory` calls in both streaming and non-streaming paths. `processEventStream` now always captures intermediate tool steps so they're available for memory persistence.
- **V1** (`execute.ts`): Same pattern — manual memory handling with `loadMemory`/`saveToMemory`.
- **Tests**: Added 3 round-trip tests for `saveToMemory` covering single tool call, multiple sequential tool calls, and deduplication via `previousStepsCount`.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #14361

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] Tests included
- [x] Changes follow existing patterns (matches V3 agent memory handling)