### PR TITLE
fix(@n8n/chat): Change chat widget title from h1 to span

### DIFF
--- a/packages/frontend/@n8n/chat/src/components/Chat.vue
+++ b/packages/frontend/@n8n/chat/src/components/Chat.vue
@@ -130,9 +130,9 @@ onUnmounted(() => {
 	<Layout class="chat-wrapper">
 		<template #header>
 			<div class="chat-heading">
-				<h1>
+				<span>
 					{{ t('title') }}
-				</h1>
+				</span>
 				<button
 					v-if="showCloseButton"
 					class="chat-close-button"


### PR DESCRIPTION
## Summary

  Fixes #26553

  The chat widget renders its title in an `<h1>` tag, which triggers SEO tool warnings for users embedding the widget on their sites. This changes it to a `<span>` to avoid any heading-level SEO impact while
  preserving the visual styling.