### PR TITLE
fix(core): Disable dynamic banners when diagnostics are disabled

### DIFF
--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -228,7 +228,7 @@ export class FrontendService {
 			},
 			dynamicBanners: {
 				endpoint: this.globalConfig.dynamicBanners.endpoint,
-				enabled: this.globalConfig.dynamicBanners.enabled,
+				enabled: this.globalConfig.dynamicBanners.enabled && this.globalConfig.diagnostics.enabled,
 			},
 			instanceId: this.instanceSettings.instanceId,
 			telemetry: telemetrySettings,


### PR DESCRIPTION
## Summary

  Fixes #26474

  When users disable diagnostics via N8N_DIAGNOSTICS_ENABLED=false, the frontend still calls api.n8n.io/api/banners because the dynamic banners enabled flag is independent of the diagnostics setting.

  This adds a check for diagnostics.enabled when building the frontend settings, following the same pattern already used for personalizationSurveyEnabled in the same file.