### PR TITLE
feat(Anthropic Chat Model Node): Add User-Agent header for API calls

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
@@ -19,6 +19,11 @@ import {
 
 import { searchModels } from './methods/searchModels';
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { version: N8N_VERSION } = require('@n8n/n8n-nodes-langchain/package.json') as {
+	version: string;
+};
+
 const modelField: INodeProperties = {
 	displayName: 'Model',
 	name: 'model',
@@ -339,6 +344,9 @@ export class LmChatAnthropic implements INodeType {
 			fetchOptions: {
 				dispatcher: getProxyAgent(baseURL),
 			},
+			defaultHeaders: {
+				'User-Agent': `n8n/${N8N_VERSION}`,
+			},
 		};
 
 		if (
@@ -348,6 +356,7 @@ export class LmChatAnthropic implements INodeType {
 			typeof credentials.headerValue === 'string'
 		) {
 			clientOptions.defaultHeaders = {
+				...clientOptions.defaultHeaders,
 				[credentials.headerName]: credentials.headerValue,
 			};
 		}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
@@ -130,6 +130,9 @@ describe('LmChatAnthropic', () => {
 						fetchOptions: {
 							dispatcher: {},
 						},
+						defaultHeaders: {
+							'User-Agent': expect.stringMatching(/^n8n\//),
+						},
 					},
 				}),
 			);
@@ -568,6 +571,52 @@ describe('LmChatAnthropic', () => {
 				value: 'claude-sonnet-4-5-20250929',
 				cachedResultName: 'Claude Sonnet 4.5',
 			});
+		});
+	});
+
+	describe('defaultHeaders', () => {
+		it('should include User-Agent header with n8n version', async () => {
+			const mockContext = setupMockContext();
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-20250514';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			const callArgs = MockedChatAnthropic.mock.calls[0][0];
+			const headers = callArgs?.clientOptions?.defaultHeaders as Record<string, string> | undefined;
+			expect(headers).toBeDefined();
+			expect(headers?.['User-Agent']).toMatch(/^n8n\/\d+\.\d+\.\d+/);
+		});
+
+		it('should preserve User-Agent when credential headers are also set', async () => {
+			const mockContext = setupMockContext();
+
+			mockContext.getCredentials = jest.fn().mockResolvedValue({
+				apiKey: 'test-api-key',
+				header: true,
+				headerName: 'X-Custom-Header',
+				headerValue: 'custom-value',
+			});
+
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-20250514';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			const callArgs = MockedChatAnthropic.mock.calls[0][0];
+			expect(callArgs?.clientOptions?.defaultHeaders).toEqual(
+				expect.objectContaining({
+					'User-Agent': expect.stringMatching(/^n8n\//),
+					'X-Custom-Header': 'custom-value',
+				}),
+			);
 		});
 	});
 

--- a/packages/@n8n/nodes-langchain/nodes/llms/test/LmChatAnthropic.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/test/LmChatAnthropic.test.ts
@@ -111,6 +111,9 @@ describe('LmChatAnthropic', () => {
 						fetchOptions: {
 							dispatcher: {},
 						},
+						defaultHeaders: {
+							'User-Agent': expect.stringMatching(/^n8n\//),
+						},
 					},
 				}),
 			);
@@ -145,6 +148,9 @@ describe('LmChatAnthropic', () => {
 						fetchOptions: {
 							dispatcher: {},
 						},
+						defaultHeaders: {
+							'User-Agent': expect.stringMatching(/^n8n\//),
+						},
 					},
 				}),
 			);
@@ -178,6 +184,9 @@ describe('LmChatAnthropic', () => {
 					clientOptions: {
 						fetchOptions: {
 							dispatcher: {},
+						},
+						defaultHeaders: {
+							'User-Agent': expect.stringMatching(/^n8n\//),
 						},
 					},
 				}),
@@ -215,6 +224,7 @@ describe('LmChatAnthropic', () => {
 							dispatcher: {},
 						},
 						defaultHeaders: {
+							'User-Agent': expect.stringMatching(/^n8n\//),
 							'X-Custom-Header': 'custom-value',
 						},
 					},
@@ -254,6 +264,9 @@ describe('LmChatAnthropic', () => {
 					clientOptions: {
 						fetchOptions: {
 							dispatcher: {},
+						},
+						defaultHeaders: {
+							'User-Agent': expect.stringMatching(/^n8n\//),
 						},
 					},
 				}),
@@ -298,6 +311,9 @@ describe('LmChatAnthropic', () => {
 						fetchOptions: {
 							dispatcher: {},
 						},
+						defaultHeaders: {
+							'User-Agent': expect.stringMatching(/^n8n\//),
+						},
 					},
 				}),
 			);
@@ -333,7 +349,7 @@ describe('LmChatAnthropic', () => {
 			expect(mockedMakeN8nLlmFailedAttemptHandler).toHaveBeenCalledWith(mockContext, undefined);
 		});
 
-		it('should not add custom headers when header toggle is disabled', async () => {
+		it('should not add custom credential headers when header toggle is disabled', async () => {
 			const mockContext = setupMockContext();
 
 			mockContext.getCredentials.mockResolvedValue({
@@ -351,19 +367,12 @@ describe('LmChatAnthropic', () => {
 
 			await lmChatAnthropic.supplyData.call(mockContext, 0);
 
-			expect(MockedChatAnthropic).toHaveBeenCalledWith(
-				expect.objectContaining({
-					clientOptions: {
-						fetchOptions: {
-							dispatcher: {},
-						},
-					},
-				}),
-			);
-
-			// Verify that defaultHeaders is not set
 			const callArgs = MockedChatAnthropic.mock.calls[0]?.[0];
-			expect(callArgs?.clientOptions?.defaultHeaders).toBeUndefined();
+			const headers = callArgs?.clientOptions?.defaultHeaders as Record<string, string> | undefined;
+			// User-Agent should still be present
+			expect(headers?.['User-Agent']).toMatch(/^n8n\//);
+			// Custom credential header should not be present
+			expect(headers?.['X-Custom-Header']).toBeUndefined();
 		});
 
 		it('should handle custom headers and custom URL together', async () => {
@@ -399,6 +408,7 @@ describe('LmChatAnthropic', () => {
 							dispatcher: {},
 						},
 						defaultHeaders: {
+							'User-Agent': expect.stringMatching(/^n8n\//),
 							'X-Custom-Header': 'custom-value',
 						},
 					},


### PR DESCRIPTION
## Summary

Passes User-Agent: n8n/{version} to the Anthropic SDK so Anthropic can identify traffic from n8n workflows.

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [X] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included.
- [X] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
