### PR TITLE
ci: Clarify messaging around backporting

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -59,7 +59,7 @@ jobs:
             # Description
             Backport of #${pull_number} to `${target_branch}`.
 
-            Checklist for the author (@${pull_author}) to go through.
+            ## Checklist for the author (@${pull_author}) to go through.
 
             - [ ] Review the backport changes
             - [ ] Fix possible conflicts

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -59,18 +59,24 @@ jobs:
             # Description
             Backport of #${pull_number} to `${target_branch}`.
 
-            - [ ] Review the changes
+            Checklist for the author (@${pull_author}) to go through.
+
+            - [ ] Review the backport changes
             - [ ] Fix possible conflicts
             - [ ] Merge to target branch
+
+            After this PR has been merged, it will be picked up in the next patch release for release track.
 
             # Original description
 
             ${pull_description}
           pull_title: ${pull_title} (backport to ${target_branch})
           add_author_as_assignee: true
+          add_author_as_reviewer: true
           copy_assignees: true
-          copy_requested_reviewers: true
+          copy_requested_reviewers: false
           copy_labels_pattern: '^(?!Backport to\b).+' # Copy everything except backport labels
+          add_labels: 'automation:backport'
           experimental: >
             {
               "conflict_resolution": "draft_commit_conflicts"


### PR DESCRIPTION

## Summary

- Add Author as reviewer of backport PR
- Clarify steps and messaging around them
- Add label 'automation:backport'

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
