### PR TITLE
ci: Add label on node popularity automation

### DIFF
--- a/.github/workflows/util-update-node-popularity.yml
+++ b/.github/workflows/util-update-node-popularity.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           token: ${{ steps.generate-token.outputs.token }}
           commit-message: 'chore: Update node popularity data'
+          labels: 'automation:scheduled-update'
           title: 'chore: Update node popularity data'
           body: |
             This automated PR updates the node popularity data used for sorting nodes in the node creator panel.


### PR DESCRIPTION
## Summary

As a part of enabling automation around repo PR's, let's start labeling them.

## Related Linear tickets, Github issues, and Community forum posts

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
