### PR TITLE
ci: Add release environment to post release jobs

### DIFF
--- a/.github/workflows/release-push-to-channel.yml
+++ b/.github/workflows/release-push-to-channel.yml
@@ -131,6 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: validate-inputs
     timeout-minutes: 5
+    environment: release
     permissions:
       packages: write
     steps:

--- a/.github/workflows/release-push-to-channel.yml
+++ b/.github/workflows/release-push-to-channel.yml
@@ -69,6 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: validate-inputs
     timeout-minutes: 5
+    environment: release
     permissions:
       id-token: write
     steps:
@@ -96,6 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: validate-inputs
     timeout-minutes: 5
+    environment: release
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -129,6 +131,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: validate-inputs
     timeout-minutes: 5
+    permissions:
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -156,6 +160,7 @@ jobs:
     name: Update latest and next in the docs
     runs-on: ubuntu-latest
     needs: [validate-inputs, release-to-npm, release-to-docker-hub]
+    environment: release
     steps:
       - continue-on-error: true
         run: curl -u docsWorkflows:${{ secrets.N8N_WEBHOOK_DOCS_PASSWORD }} --request GET 'https://internal.users.n8n.cloud/webhook/update-latest-next'


### PR DESCRIPTION
## Summary

Post-release publish automation seems to require the environment explicitly declared to access secrets within.

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/actions/runs/22841185427/job/66250573396

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
