### PR TITLE
feat(editor): Show folder tree view in source control push/pull modals

### DIFF
--- a/packages/@n8n/api-types/src/schemas/source-controlled-file.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/source-controlled-file.schema.ts
@@ -52,6 +52,8 @@ export const SourceControlledFileSchema = z.object({
 	pushed: z.boolean().optional(),
 	isLocalPublished: z.boolean().optional(),
 	isRemoteArchived: z.boolean().optional(),
+	parentFolderId: z.string().nullable().optional(),
+	folderPath: z.array(z.string()).optional(),
 	owner: ResourceOwnerSchema.optional(), // Resource owner can be a personal email or team information
 	publishingError: z.string().optional(),
 });

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-status.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-status.service.test.ts
@@ -886,6 +886,109 @@ describe('getStatus', () => {
 			});
 		});
 
+		describe('folder paths', () => {
+			it('includes folderPath for remote-only workflow', async () => {
+				const remote = createWorkflow({
+					id: 'wf-remote-foldered',
+					filename: 'workflows/wf-remote-foldered.json',
+					parentFolderId: 'child-folder',
+				});
+
+				sourceControlImportService.getRemoteVersionIdsFromFiles.mockResolvedValue([remote]);
+				sourceControlImportService.getLocalVersionIdsFromDb.mockResolvedValue([]);
+				sourceControlImportService.getRemoteFoldersAndMappingsFromFile.mockResolvedValue({
+					folders: [
+						{
+							id: 'root-folder',
+							name: 'Root',
+							parentFolderId: null,
+							homeProjectId: 'project1',
+							createdAt: '2023-01-01T00:00:00.000Z',
+							updatedAt: '2023-01-01T00:00:00.000Z',
+						},
+						{
+							id: 'child-folder',
+							name: 'Child',
+							parentFolderId: 'root-folder',
+							homeProjectId: 'project1',
+							createdAt: '2023-01-01T00:00:00.000Z',
+							updatedAt: '2023-01-01T00:00:00.000Z',
+						},
+					],
+				});
+
+				const result = await sourceControlStatusService.getStatus(user, {
+					direction: 'pull',
+					verbose: false,
+					preferLocalVersion: false,
+				});
+
+				const workflow = result.find((f) => f.id === 'wf-remote-foldered');
+				expect(workflow).toBeDefined();
+				expect(workflow?.parentFolderId).toBe('child-folder');
+				expect(workflow?.folderPath).toEqual(['Root', 'Child']);
+			});
+
+			it('uses local folder path for modified workflow when preferLocalVersion is true', async () => {
+				const local = createWorkflow({
+					id: 'wf-modified-foldered',
+					versionId: 'local-v1',
+					parentFolderId: 'local-child',
+				});
+				const remote = createWorkflow({
+					id: 'wf-modified-foldered',
+					versionId: 'remote-v2',
+					parentFolderId: 'remote-child',
+				});
+
+				sourceControlImportService.getLocalVersionIdsFromDb.mockResolvedValue([local]);
+				sourceControlImportService.getRemoteVersionIdsFromFiles.mockResolvedValue([remote]);
+				sourceControlImportService.getLocalFoldersAndMappingsFromDb.mockResolvedValue({
+					folders: [],
+				});
+				sourceControlImportService.getRemoteFoldersAndMappingsFromFile.mockResolvedValue({
+					folders: [
+						{
+							id: 'remote-child',
+							name: 'Remote Child',
+							parentFolderId: null,
+							homeProjectId: 'project1',
+							createdAt: '2023-01-01T00:00:00.000Z',
+							updatedAt: '2023-01-01T00:00:00.000Z',
+						},
+					],
+				});
+
+				folderRepository.find
+					.mockResolvedValueOnce([
+						{
+							id: 'local-child',
+							name: 'Local Child',
+							parentFolder: { id: 'local-parent' },
+						} as any,
+					])
+					.mockResolvedValueOnce([
+						{
+							id: 'local-parent',
+							name: 'Local Parent',
+							parentFolder: null,
+						} as any,
+					]);
+
+				const result = await sourceControlStatusService.getStatus(user, {
+					direction: 'push',
+					verbose: false,
+					preferLocalVersion: true,
+				});
+
+				const workflow = result.find((f) => f.id === 'wf-modified-foldered');
+				expect(workflow).toBeDefined();
+				expect(workflow?.status).toBe('modified');
+				expect(workflow?.parentFolderId).toBe('local-child');
+				expect(workflow?.folderPath).toEqual(['Local Parent', 'Local Child']);
+			});
+		});
+
 		describe('owner changes', () => {
 			describe('team project ownership changes (detected)', () => {
 				it('should detect when team project changes', async () => {

--- a/packages/cli/src/modules/source-control.ee/source-control-status.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-status.service.ee.ts
@@ -3,13 +3,11 @@ import { Logger } from '@n8n/backend-common';
 import { FolderRepository, TagRepository, type User, WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { hasGlobalScope } from '@n8n/permissions';
+import pick from 'lodash/pick';
 import { UserError } from 'n8n-workflow';
 
-import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
-import { EventService } from '@/events/event.service';
-
-import { SourceControlGitService } from './source-control-git.service.ee';
 import { SOURCE_CONTROL_DATATABLES_EXPORT_FOLDER } from './constants';
+import { SourceControlGitService } from './source-control-git.service.ee';
 import {
 	hasOwnerChanged,
 	getDataTableExportPath,
@@ -30,7 +28,7 @@ import type {
 	ExportableDataTable,
 	StatusExportableDataTable,
 } from './types/exportable-data-table';
-import type { ExportableFolder } from './types/exportable-folders';
+import type { ExportableFolder, FolderPathNode } from './types/exportable-folders';
 import type { ExportableProjectWithFileName } from './types/exportable-project';
 import { ExportableVariable } from './types/exportable-variable';
 import type { StatusResourceOwner } from './types/resource-owner';
@@ -40,6 +38,9 @@ import type {
 	SourceControlGetStatusVerboseResult,
 } from './types/source-control-get-status';
 import type { SourceControlWorkflowVersionId } from './types/source-control-workflow-version-id';
+
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { EventService } from '@/events/event.service';
 import { ExportableTagEntity } from '@/modules/source-control.ee/types/exportable-tags';
 
 @Service()
@@ -91,6 +92,32 @@ export class SourceControlStatusService {
 		}
 
 		return;
+	}
+
+	private buildFolderPath(
+		parentFolderId: string | null | undefined,
+		foldersById: Map<string, FolderPathNode>,
+	): string[] {
+		if (!parentFolderId) {
+			return [];
+		}
+
+		const pathSegments: string[] = [];
+		const visited = new Set<string>();
+		let currentFolderId: string | null | undefined = parentFolderId;
+
+		while (currentFolderId && !visited.has(currentFolderId)) {
+			visited.add(currentFolderId);
+			const folder = foldersById.get(currentFolderId);
+			if (!folder) {
+				break;
+			}
+
+			pathSegments.unshift(folder.name);
+			currentFolderId = folder.parentFolderId;
+		}
+
+		return pathSegments;
 	}
 
 	/**
@@ -237,6 +264,42 @@ export class SourceControlStatusService {
 			await this.sourceControlImportService.getRemoteVersionIdsFromFiles(context);
 		const wfLocalVersionIds =
 			await this.sourceControlImportService.getLocalVersionIdsFromDb(context);
+		const foldersMappingsRemote =
+			await this.sourceControlImportService.getRemoteFoldersAndMappingsFromFile(context);
+		const foldersMappingsLocal =
+			await this.sourceControlImportService.getLocalFoldersAndMappingsFromDb(context);
+		const remoteFoldersById = new Map<string, FolderPathNode>(
+			foldersMappingsRemote.folders.map((folder) => [
+				folder.id,
+				pick(folder, ['name', 'parentFolderId']),
+			]),
+		);
+		const localFoldersById = new Map<string, FolderPathNode>(
+			foldersMappingsLocal.folders.map((folder) => [
+				folder.id,
+				pick(folder, ['name', 'parentFolderId']),
+			]),
+		);
+		const allLocalFolders = await this.folderRepository.find({
+			relations: ['parentFolder'],
+			select: {
+				id: true,
+				name: true,
+				parentFolder: {
+					id: true,
+				},
+				createdAt: true,
+				updatedAt: true,
+			},
+		});
+		allLocalFolders.forEach((folder) => {
+			if (!localFoldersById.has(folder.id)) {
+				localFoldersById.set(folder.id, {
+					name: folder.name,
+					parentFolderId: folder.parentFolder?.id ?? null,
+				});
+			}
+		});
 
 		const wfRemoteById = new Map(wfRemoteVersionIds.map((w) => [w.id, w]));
 		const wfRemoteIds = new Set(wfRemoteVersionIds.map((w) => w.id));
@@ -290,6 +353,8 @@ export class SourceControlStatusService {
 					updatedAt: remoteWorkflow.updatedAt ?? new Date().toISOString(),
 					isLocalPublished: false, // New workflow, not published locally
 					isRemoteArchived: archivedWorkflowIds.get(remoteWorkflow.id) ?? false,
+					parentFolderId: remoteWorkflow.parentFolderId,
+					folderPath: this.buildFolderPath(remoteWorkflow.parentFolderId, remoteFoldersById),
 					owner: remoteWorkflow.owner,
 				});
 			}
@@ -313,6 +378,8 @@ export class SourceControlStatusService {
 					updatedAt: localWorkflow.updatedAt ?? new Date().toISOString(),
 					isLocalPublished: publishedWorkflowIds.has(localWorkflow.id),
 					isRemoteArchived: false, // Workflow deleted from remote, no archived status
+					parentFolderId: localWorkflow.parentFolderId,
+					folderPath: this.buildFolderPath(localWorkflow.parentFolderId, localFoldersById),
 					owner: localWorkflow.owner,
 				});
 				continue;
@@ -336,9 +403,18 @@ export class SourceControlStatusService {
 					: (name = `${remoteWorkflowWithSameId.name} (Local: ${localWorkflow.name})`);
 			}
 
+			const preferredParentFolderId = options.preferLocalVersion
+				? localWorkflow.parentFolderId
+				: remoteWorkflowWithSameId.parentFolderId;
+			const preferredFolderPath = this.buildFolderPath(
+				preferredParentFolderId,
+				options.preferLocalVersion ? localFoldersById : remoteFoldersById,
+			);
+
 			const wfModified: SourceControlWorkflowVersionId = {
 				...localWorkflow,
 				name,
+				parentFolderId: preferredParentFolderId,
 				versionId: options.preferLocalVersion
 					? localWorkflow.versionId
 					: remoteWorkflowWithSameId.versionId,
@@ -361,6 +437,8 @@ export class SourceControlStatusService {
 				updatedAt: wfModified.updatedAt ?? new Date().toISOString(),
 				isLocalPublished: publishedWorkflowIds.has(wfModified.id),
 				isRemoteArchived: archivedWorkflowIds.get(wfModified.id) ?? false,
+				parentFolderId: preferredParentFolderId,
+				folderPath: preferredFolderPath,
 				owner: wfModified.owner,
 			});
 		}

--- a/packages/cli/src/modules/source-control.ee/source-control-status.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-status.service.ee.ts
@@ -3,6 +3,7 @@ import { Logger } from '@n8n/backend-common';
 import { FolderRepository, TagRepository, type User, WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { hasGlobalScope } from '@n8n/permissions';
+import { In } from '@n8n/typeorm';
 import pick from 'lodash/pick';
 import { UserError } from 'n8n-workflow';
 
@@ -253,6 +254,61 @@ export class SourceControlStatusService {
 		}
 	}
 
+	/**
+	 * Populates the provided localFoldersById map with all missing parent folder path nodes required by the given workflows.
+	 * For each workflow, traverses up the parent chain and injects any folders missing from localFoldersById.
+	 *
+	 * @param localFoldersById - Map to inject missing folder nodes into.
+	 * @param localWorkflows - List of workflows, each referencing a parent folder.
+	 * @returns Promise<void>
+	 */
+	private async populateMissingLocalFolderPathNodes(
+		localFoldersById: Map<string, FolderPathNode>,
+		localWorkflows: SourceControlWorkflowVersionId[],
+	): Promise<void> {
+		const getMissingFolderIds = (folderIds: Array<string | null>): Set<string> => {
+			const missingFolderIds = folderIds.filter(
+				(id): id is string => id !== null && localFoldersById.has(id) === false,
+			);
+
+			return new Set<string>(missingFolderIds);
+		};
+
+		const initialParentFolderIds = localWorkflows.map((workflow) => workflow.parentFolderId);
+		const folderIdsToProcessQueue = getMissingFolderIds(initialParentFolderIds);
+
+		while (folderIdsToProcessQueue.size > 0) {
+			const currentBatchFolderIds = Array.from(folderIdsToProcessQueue);
+			folderIdsToProcessQueue.clear();
+
+			const loadedFolders = await this.folderRepository.find({
+				where: { id: In(currentBatchFolderIds) },
+				relations: ['parentFolder'],
+				select: {
+					id: true,
+					name: true,
+					parentFolder: {
+						id: true,
+					},
+				},
+			});
+
+			loadedFolders.forEach((folder) => {
+				localFoldersById.set(folder.id, {
+					name: folder.name,
+					parentFolderId: folder.parentFolder?.id ?? null,
+				});
+			});
+
+			const parentFolderIds = loadedFolders.map((folder) => folder.parentFolder?.id ?? null);
+			const missingParentFolderIds = getMissingFolderIds(parentFolderIds);
+
+			missingParentFolderIds.forEach((folderId) => {
+				folderIdsToProcessQueue.add(folderId);
+			});
+		}
+	}
+
 	private async getStatusWorkflows(
 		options: SourceControlGetStatus,
 		context: SourceControlContext,
@@ -260,14 +316,13 @@ export class SourceControlStatusService {
 		collectVerbose: boolean,
 	) {
 		// TODO: We need to check the case where it exists in the DB (out of scope) but is in GIT
-		const wfRemoteVersionIds =
-			await this.sourceControlImportService.getRemoteVersionIdsFromFiles(context);
-		const wfLocalVersionIds =
-			await this.sourceControlImportService.getLocalVersionIdsFromDb(context);
-		const foldersMappingsRemote =
-			await this.sourceControlImportService.getRemoteFoldersAndMappingsFromFile(context);
-		const foldersMappingsLocal =
-			await this.sourceControlImportService.getLocalFoldersAndMappingsFromDb(context);
+		const [wfRemoteVersionIds, wfLocalVersionIds, foldersMappingsRemote, foldersMappingsLocal] =
+			await Promise.all([
+				this.sourceControlImportService.getRemoteVersionIdsFromFiles(context),
+				this.sourceControlImportService.getLocalVersionIdsFromDb(context),
+				this.sourceControlImportService.getRemoteFoldersAndMappingsFromFile(context),
+				this.sourceControlImportService.getLocalFoldersAndMappingsFromDb(context),
+			]);
 		const remoteFoldersById = new Map<string, FolderPathNode>(
 			foldersMappingsRemote.folders.map((folder) => [
 				folder.id,
@@ -280,26 +335,7 @@ export class SourceControlStatusService {
 				pick(folder, ['name', 'parentFolderId']),
 			]),
 		);
-		const allLocalFolders = await this.folderRepository.find({
-			relations: ['parentFolder'],
-			select: {
-				id: true,
-				name: true,
-				parentFolder: {
-					id: true,
-				},
-				createdAt: true,
-				updatedAt: true,
-			},
-		});
-		allLocalFolders.forEach((folder) => {
-			if (!localFoldersById.has(folder.id)) {
-				localFoldersById.set(folder.id, {
-					name: folder.name,
-					parentFolderId: folder.parentFolder?.id ?? null,
-				});
-			}
-		});
+		await this.populateMissingLocalFolderPathNodes(localFoldersById, wfLocalVersionIds);
 
 		const wfRemoteById = new Map(wfRemoteVersionIds.map((w) => [w.id, w]));
 		const wfRemoteIds = new Set(wfRemoteVersionIds.map((w) => w.id));

--- a/packages/cli/src/modules/source-control.ee/source-control-status.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-status.service.ee.ts
@@ -268,7 +268,7 @@ export class SourceControlStatusService {
 	): Promise<void> {
 		const getMissingFolderIds = (folderIds: Array<string | null>): Set<string> => {
 			const missingFolderIds = folderIds.filter(
-				(id): id is string => id !== null && localFoldersById.has(id) === false,
+				(id): id is string => id !== null && !localFoldersById.has(id),
 			);
 
 			return new Set<string>(missingFolderIds);

--- a/packages/cli/src/modules/source-control.ee/types/exportable-folders.ts
+++ b/packages/cli/src/modules/source-control.ee/types/exportable-folders.ts
@@ -10,3 +10,5 @@ export type ExportableFolder = {
 export type ExportedFolders = {
 	folders: ExportableFolder[];
 };
+
+export type FolderPathNode = Pick<ExportableFolder, 'name' | 'parentFolderId'>;

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -3199,6 +3199,7 @@
 	"settings.sourceControl.modals.push.success.title": "Pushed successfully",
 	"settings.sourceControl.modals.push.success.description": "was committed and pushed to your remote repository | were committed and pushed to your remote repository",
 	"settings.sourceControl.modals.push.projectAdmin.callout": "If you want to push workflows from your personal space, move them to a project first.",
+	"settings.sourceControl.modals.push.currentWorkflow": "Current workflow",
 	"settings.sourceControl.status.modified": "Modified",
 	"settings.sourceControl.status.deleted": "Deleted",
 	"settings.sourceControl.status.created": "New",

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPullModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPullModal.test.ts
@@ -380,6 +380,69 @@ describe('SourceControlPullModal', () => {
 		expect(getByText(/Projects \(2\)/)).toBeInTheDocument();
 	});
 
+	it('should collapse and expand nested workflow folders', async () => {
+		const status: SourceControlledFile[] = [
+			{
+				id: 'wf-root',
+				name: 'Root workflow',
+				type: 'workflow',
+				status: 'created',
+				location: 'remote',
+				conflict: false,
+				file: '/workflows/wf-root.json',
+				updatedAt: '2025-01-19T10:00:00.000Z',
+			},
+			{
+				id: 'wf-child-1',
+				name: 'Child workflow 1',
+				type: 'workflow',
+				status: 'created',
+				location: 'remote',
+				conflict: false,
+				file: '/workflows/wf-child-1.json',
+				updatedAt: '2025-01-19T10:00:00.000Z',
+				folderPath: ['Prod'],
+			},
+			{
+				id: 'wf-child-2',
+				name: 'Child workflow 2',
+				type: 'workflow',
+				status: 'created',
+				location: 'remote',
+				conflict: false,
+				file: '/workflows/wf-child-2.json',
+				updatedAt: '2025-01-19T10:00:00.000Z',
+				folderPath: ['Prod'],
+			},
+		];
+
+		const { getAllByTestId, getByTestId } = renderModal({
+			pinia,
+			props: {
+				data: {
+					eventBus,
+					status,
+				},
+			},
+		});
+
+		await waitFor(() => {
+			expect(getAllByTestId('pull-modal-item')).toHaveLength(3);
+		});
+
+		await userEvent.click(getByTestId('source-control-pull-modal-folder-toggle'));
+
+		await waitFor(() => {
+			expect(getAllByTestId('pull-modal-item')).toHaveLength(1);
+		});
+
+		await userEvent.click(getByTestId('source-control-pull-modal-folder-toggle'));
+
+		await waitFor(() => {
+			expect(getAllByTestId('pull-modal-item')).toHaveLength(3);
+		});
+	});
+
 	describe('Data Tables tab', () => {
 		it('should display data tables tab with correct count', () => {
 			const status: SourceControlledFile[] = [

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPullModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPullModal.vue
@@ -13,11 +13,13 @@ import { useSettingsStore } from '@/app/stores/settings.store';
 import { useSourceControlStore } from '../sourceControl.store';
 import type { ProjectListItem } from '@/features/collaboration/projects/projects.types';
 import {
+	buildWorkflowTreeRows,
 	getPullPriorityByStatus,
 	getStatusText,
 	getStatusTheme,
 	notifyUserAboutPullWorkFolderOutcome,
 } from '../sourceControl.utils';
+import type { SourceControlTreeRow } from '../sourceControl.types';
 import { useUIStore } from '@/app/stores/ui.store';
 import { type SourceControlledFile, SOURCE_CONTROL_FILE_TYPE } from '@n8n/api-types';
 import { shouldAutoPublishWorkflow, type AutoPublishMode } from 'n8n-workflow';
@@ -50,7 +52,6 @@ type SourceControlledFileWithProject = SourceControlledFile & {
 	project?: ProjectListItem;
 	willBeAutoPublished?: boolean;
 };
-
 const props = defineProps<{
 	data: { eventBus: EventBus; status?: SourceControlledFile[] };
 }>();
@@ -184,8 +185,12 @@ const filteredWorkflows = computed(() => {
 const sortedWorkflows = computed(() => {
 	const sorted = orderBy(
 		filteredWorkflows.value,
-		[({ status }) => getPullPriorityByStatus(status), 'updatedAt'],
-		['asc', 'desc'],
+		[
+			({ folderPath }) => folderPath?.join('/') ?? '',
+			({ status }) => getPullPriorityByStatus(status),
+			'updatedAt',
+		],
+		['asc', 'asc', 'desc'],
 	);
 
 	// Add willBeAutoPublished property to each workflow
@@ -202,6 +207,10 @@ const sortedWorkflows = computed(() => {
 			}),
 	}));
 });
+
+const workflowTreeRows = computed<SourceControlTreeRow<SourceControlledFileWithProject>[]>(() =>
+	buildWorkflowTreeRows(sortedWorkflows.value),
+);
 
 // Filtered credentials
 const filteredCredentials = computed(() => {
@@ -262,6 +271,19 @@ const activeDataSourceFiltered = computed(() => {
 		return sortedDataTables.value;
 	}
 	return [];
+});
+
+const activeRows = computed<SourceControlTreeRow[]>(() => {
+	if (activeTab.value === SOURCE_CONTROL_FILE_TYPE.workflow) {
+		return workflowTreeRows.value;
+	}
+
+	return activeDataSourceFiltered.value.map((file) => ({
+		id: `file:${file.id}`,
+		type: 'file' as const,
+		file,
+		depth: 0,
+	}));
 });
 
 const filtersNoResultText = computed(() => {
@@ -518,46 +540,67 @@ onMounted(() => {
 									{{ filtersNoResultText }}
 								</N8nInfoTip>
 								<DynamicScroller
-									v-if="activeDataSourceFiltered.length"
+									v-if="activeRows.length"
 									:class="[$style.scroller]"
-									:items="activeDataSourceFiltered"
+									:items="activeRows"
 									:min-item-size="57"
 									item-class="scrollerItem"
 								>
-									<template #default="{ item: file, active, index }">
+									<template #default="{ item: row, active, index }">
 										<DynamicScrollerItem
-											:item="file"
+											:item="row"
 											:active="active"
-											:size-dependencies="[file.name, file.id]"
+											:size-dependencies="[
+												row.type,
+												row.type === 'file' ? row.file.name : row.name,
+												row.id,
+												row.depth,
+											]"
 											:data-index="index"
 										>
-											<div :class="[$style.listItem]" data-test-id="pull-modal-item">
-												<div :class="[$style.itemContent]">
+											<div
+												v-if="row.type === 'folder'"
+												:class="[$style.folderRow]"
+												:style="{ paddingLeft: `${16 + row.depth * 16}px` }"
+												data-test-id="source-control-pull-modal-folder-row"
+											>
+												<N8nText tag="span" color="text-light">
+													{{ row.name }}
+												</N8nText>
+											</div>
+											<div v-else :class="[$style.listItem]" data-test-id="pull-modal-item">
+												<div
+													:class="[$style.itemContent]"
+													:style="{ paddingLeft: `${row.depth * 16}px` }"
+												>
 													<N8nText tag="div" bold color="text-dark" :class="[$style.listItemName]">
 														<RouterLink
-															v-if="file.type === SOURCE_CONTROL_FILE_TYPE.credential"
+															v-if="row.file.type === SOURCE_CONTROL_FILE_TYPE.credential"
 															target="_blank"
 															rel="noopener noreferrer"
-															:to="{ name: VIEWS.CREDENTIALS, params: { credentialId: file.id } }"
+															:to="{
+																name: VIEWS.CREDENTIALS,
+																params: { credentialId: row.file.id },
+															}"
 														>
-															{{ file.name }}
+															{{ row.file.name }}
 														</RouterLink>
 														<RouterLink
-															v-else-if="file.type === SOURCE_CONTROL_FILE_TYPE.workflow"
+															v-else-if="row.file.type === SOURCE_CONTROL_FILE_TYPE.workflow"
 															target="_blank"
 															rel="noopener noreferrer"
-															:to="{ name: VIEWS.WORKFLOW, params: { name: file.id } }"
+															:to="{ name: VIEWS.WORKFLOW, params: { name: row.file.id } }"
 														>
-															{{ file.name }}
+															{{ row.file.name }}
 														</RouterLink>
-														<span v-else>{{ file.name }}</span>
+														<span v-else>{{ row.file.name }}</span>
 													</N8nText>
 													<div :class="$style.statusLine">
-														<N8nText v-if="file.updatedAt" color="text-light" size="small">
-															{{ renderUpdatedAt(file) }}
+														<N8nText v-if="row.file.updatedAt" color="text-light" size="small">
+															{{ renderUpdatedAt(row.file) }}
 														</N8nText>
 														<N8nText
-															v-if="file.willBeAutoPublished"
+															v-if="row.file.willBeAutoPublished"
 															color="success"
 															size="small"
 															bold
@@ -566,7 +609,12 @@ onMounted(() => {
 																i18n.baseText('settings.sourceControl.modals.pull.autoPublishing')
 															}}
 														</N8nText>
-														<N8nText v-if="file.isRemoteArchived" color="warning" size="small" bold>
+														<N8nText
+															v-if="row.file.isRemoteArchived"
+															color="warning"
+															size="small"
+															bold
+														>
 															{{
 																i18n.baseText('settings.sourceControl.modals.pull.willBeArchived')
 															}}
@@ -574,14 +622,14 @@ onMounted(() => {
 													</div>
 												</div>
 												<span :class="[$style.badges]">
-													<N8nBadge :theme="getStatusTheme(file.status)" style="height: 25px">
-														{{ getStatusText(file.status) }}
+													<N8nBadge :theme="getStatusTheme(row.file.status)" style="height: 25px">
+														{{ getStatusText(row.file.status) }}
 													</N8nBadge>
 													<template v-if="isWorkflowDiffsEnabled">
 														<N8nTooltip
 															v-if="
-																file.type === SOURCE_CONTROL_FILE_TYPE.workflow &&
-																file.status === 'modified'
+																row.file.type === SOURCE_CONTROL_FILE_TYPE.workflow &&
+																row.file.status === 'modified'
 															"
 															:content="i18n.baseText('workflowDiff.compare')"
 															placement="top"
@@ -589,7 +637,7 @@ onMounted(() => {
 															<N8nIconButton
 																variant="subtle"
 																icon="file-diff"
-																@click="openDiffModal(file.id)"
+																@click="openDiffModal(row.file.id)"
 															/>
 														</N8nTooltip>
 													</template>
@@ -696,6 +744,13 @@ onMounted(() => {
 	margin: 0;
 	border-bottom: var(--border);
 	gap: 30px;
+}
+
+.folderRow {
+	display: flex;
+	align-items: center;
+	padding: var(--spacing--2xs) var(--spacing--sm);
+	border-bottom: var(--border);
 }
 
 .itemContent {

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPullModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPullModal.vue
@@ -12,8 +12,10 @@ import { useProjectsStore } from '@/features/collaboration/projects/projects.sto
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useSourceControlStore } from '../sourceControl.store';
 import type { ProjectListItem } from '@/features/collaboration/projects/projects.types';
+import { useSourceControlFileList } from '../composables/useSourceControlFileList';
 import { useWorkflowTreeRows } from '../composables/useWorkflowTreeRows';
 import {
+	formatSourceControlUpdatedAt,
 	getPullPriorityByStatus,
 	getStatusText,
 	getStatusTheme,
@@ -25,8 +27,6 @@ import { type SourceControlledFile, SOURCE_CONTROL_FILE_TYPE } from '@n8n/api-ty
 import { shouldAutoPublishWorkflow, type AutoPublishMode } from 'n8n-workflow';
 import { useI18n } from '@n8n/i18n';
 import type { EventBus } from '@n8n/utils/event-bus';
-import dateformat from 'dateformat';
-import orderBy from 'lodash/orderBy';
 import { computed, onBeforeMount, onMounted, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { DynamicScroller, DynamicScrollerItem } from 'vue-virtual-scroller';
@@ -177,25 +177,18 @@ const groupedFilesByType = computed(() => {
 	return grouped;
 });
 
-// Filtered workflows
-const filteredWorkflows = computed(() => {
-	const workflows = groupedFilesByType.value[SOURCE_CONTROL_FILE_TYPE.workflow] || [];
-	return workflows;
+const baseSortedWorkflows = useSourceControlFileList({
+	files: computed(() => groupedFilesByType.value[SOURCE_CONTROL_FILE_TYPE.workflow] || []),
+	sortBy: [
+		({ folderPath }) => folderPath?.join('/') ?? '',
+		({ status }) => getPullPriorityByStatus(status),
+		'updatedAt',
+	],
+	sortOrder: ['asc', 'asc', 'desc'],
 });
 
-const sortedWorkflows = computed(() => {
-	const sorted = orderBy(
-		filteredWorkflows.value,
-		[
-			({ folderPath }) => folderPath?.join('/') ?? '',
-			({ status }) => getPullPriorityByStatus(status),
-			'updatedAt',
-		],
-		['asc', 'asc', 'desc'],
-	);
-
-	// Add willBeAutoPublished property to each workflow
-	return sorted.map((file) => ({
+const sortedWorkflows = computed(() =>
+	baseSortedWorkflows.value.map((file) => ({
 		...file,
 		willBeAutoPublished:
 			file.type === SOURCE_CONTROL_FILE_TYPE.workflow &&
@@ -206,43 +199,27 @@ const sortedWorkflows = computed(() => {
 				isRemoteArchived: file.isRemoteArchived ?? false,
 				autoPublish: autoPublish.value,
 			}),
-	}));
-});
+	})),
+);
 
 const { visibleWorkflowRows, isFolderCollapsed, toggleFolderCollapse } =
 	useWorkflowTreeRows(sortedWorkflows);
 
-// Filtered credentials
-const filteredCredentials = computed(() => {
-	const credentials = groupedFilesByType.value[SOURCE_CONTROL_FILE_TYPE.credential] || [];
-	return credentials;
+const sortedCredentials = useSourceControlFileList({
+	files: computed(() => groupedFilesByType.value[SOURCE_CONTROL_FILE_TYPE.credential] || []),
+	sortBy: [({ status }) => getPullPriorityByStatus(status), 'updatedAt'],
+	sortOrder: ['asc', 'desc'],
 });
 
-const sortedCredentials = computed(() =>
-	orderBy(
-		filteredCredentials.value,
-		[({ status }) => getPullPriorityByStatus(status), 'updatedAt'],
-		['asc', 'desc'],
-	),
-);
-
-// Filtered data tables
-const filteredDataTables = computed(() => {
-	const dataTables = groupedFilesByType.value[SOURCE_CONTROL_FILE_TYPE.datatable] || [];
-	return dataTables;
+const sortedDataTables = useSourceControlFileList({
+	files: computed(() => groupedFilesByType.value[SOURCE_CONTROL_FILE_TYPE.datatable] || []),
+	sortBy: [({ status }) => getPullPriorityByStatus(status), 'updatedAt'],
+	sortOrder: ['asc', 'desc'],
 });
-
-const sortedDataTables = computed(() =>
-	orderBy(
-		filteredDataTables.value,
-		[({ status }) => getPullPriorityByStatus(status), 'updatedAt'],
-		['asc', 'desc'],
-	),
-);
 
 // Data tables with schema conflicts (columns will be lost)
 const conflictedDataTables = computed(() => {
-	return filteredDataTables.value.filter((dt) => {
+	return sortedDataTables.value.filter((dt) => {
 		// For pull operations, show warning for modified data tables with conflicts
 		// (schema changes) not for deleted data tables (entire table removed)
 		return dt.conflict === true && dt.status === 'modified';
@@ -415,17 +392,7 @@ async function pullWorkfolder() {
 }
 
 function renderUpdatedAt(file: SourceControlledFile) {
-	const currentYear = new Date().getFullYear().toString();
-
-	return i18n.baseText('settings.sourceControl.lastUpdated', {
-		interpolate: {
-			date: dateformat(
-				file.updatedAt,
-				`d mmm${file.updatedAt?.startsWith(currentYear) ? '' : ', yyyy'}`,
-			),
-			time: dateformat(file.updatedAt, 'HH:MM'),
-		},
-	});
+	return formatSourceControlUpdatedAt(file.updatedAt);
 }
 
 function openDiffModal(id: string) {

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPullModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPullModal.vue
@@ -209,15 +209,15 @@ const sortedWorkflows = computed(() => {
 	}));
 });
 
-const workflowTreeRows = computed<SourceControlTreeRow<SourceControlledFileWithProject>[]>(() =>
-	buildWorkflowTreeRows(sortedWorkflows.value),
+const workflowTreeRows = computed<Array<SourceControlTreeRow<SourceControlledFileWithProject>>>(
+	() => buildWorkflowTreeRows(sortedWorkflows.value),
 );
 
 const collapsedFolderIds = ref<Set<string>>(new Set());
 
-const visibleWorkflowRows = computed<SourceControlTreeRow<SourceControlledFileWithProject>[]>(
+const visibleWorkflowRows = computed<Array<SourceControlTreeRow<SourceControlledFileWithProject>>>(
 	() => {
-		const visibleRows: SourceControlTreeRow<SourceControlledFileWithProject>[] = [];
+		const visibleRows: Array<SourceControlTreeRow<SourceControlledFileWithProject>> = [];
 		const collapsedDepths: number[] = [];
 
 		for (const row of workflowTreeRows.value) {
@@ -314,7 +314,7 @@ const activeDataSourceFiltered = computed(() => {
 	return [];
 });
 
-const activeRows = computed<SourceControlTreeRow<SourceControlledFileWithProject>[]>(() => {
+const activeRows = computed<Array<SourceControlTreeRow<SourceControlledFileWithProject>>>(() => {
 	if (activeTab.value === SOURCE_CONTROL_FILE_TYPE.workflow) {
 		return visibleWorkflowRows.value;
 	}

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPullModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPullModal.vue
@@ -38,6 +38,7 @@ import {
 	N8nButton,
 	N8nCallout,
 	N8nHeading,
+	N8nIcon,
 	N8nIconButton,
 	N8nInfoTip,
 	N8nLink,
@@ -212,6 +213,46 @@ const workflowTreeRows = computed<SourceControlTreeRow<SourceControlledFileWithP
 	buildWorkflowTreeRows(sortedWorkflows.value),
 );
 
+const collapsedFolderIds = ref<Set<string>>(new Set());
+
+const visibleWorkflowRows = computed<SourceControlTreeRow<SourceControlledFileWithProject>[]>(
+	() => {
+		const visibleRows: SourceControlTreeRow<SourceControlledFileWithProject>[] = [];
+		const collapsedDepths: number[] = [];
+
+		for (const row of workflowTreeRows.value) {
+			while (collapsedDepths.length && row.depth <= collapsedDepths[collapsedDepths.length - 1]) {
+				collapsedDepths.pop();
+			}
+
+			if (collapsedDepths.length) {
+				continue;
+			}
+
+			visibleRows.push(row);
+
+			if (row.type === 'folder' && collapsedFolderIds.value.has(row.id)) {
+				collapsedDepths.push(row.depth);
+			}
+		}
+
+		return visibleRows;
+	},
+);
+
+function isFolderCollapsed(folderId: string) {
+	return collapsedFolderIds.value.has(folderId);
+}
+
+function toggleFolderCollapse(folderId: string) {
+	if (collapsedFolderIds.value.has(folderId)) {
+		collapsedFolderIds.value.delete(folderId);
+		return;
+	}
+
+	collapsedFolderIds.value.add(folderId);
+}
+
 // Filtered credentials
 const filteredCredentials = computed(() => {
 	const credentials = groupedFilesByType.value[SOURCE_CONTROL_FILE_TYPE.credential] || [];
@@ -273,9 +314,9 @@ const activeDataSourceFiltered = computed(() => {
 	return [];
 });
 
-const activeRows = computed<SourceControlTreeRow[]>(() => {
+const activeRows = computed<SourceControlTreeRow<SourceControlledFileWithProject>[]>(() => {
 	if (activeTab.value === SOURCE_CONTROL_FILE_TYPE.workflow) {
-		return workflowTreeRows.value;
+		return visibleWorkflowRows.value;
 	}
 
 	return activeDataSourceFiltered.value.map((file) => ({
@@ -560,15 +601,39 @@ onMounted(() => {
 										>
 											<div
 												v-if="row.type === 'folder'"
-												:class="[$style.folderRow]"
+												:class="[
+													$style.folderRow,
+													{ [$style.rowNoBorder]: index === activeRows.length - 1 },
+												]"
 												:style="{ paddingLeft: `${16 + row.depth * 16}px` }"
 												data-test-id="source-control-pull-modal-folder-row"
 											>
 												<N8nText tag="span" color="text-light">
 													{{ row.name }}
 												</N8nText>
+												<button
+													type="button"
+													:class="$style.folderToggle"
+													data-test-id="source-control-pull-modal-folder-toggle"
+													@click.stop="toggleFolderCollapse(row.id)"
+													@mousedown.stop
+													@pointerdown.stop
+												>
+													<N8nIcon
+														:icon="isFolderCollapsed(row.id) ? 'chevron-right' : 'chevron-down'"
+														color="text-light"
+														size="small"
+													/>
+												</button>
 											</div>
-											<div v-else :class="[$style.listItem]" data-test-id="pull-modal-item">
+											<div
+												v-else
+												:class="[
+													$style.listItem,
+													{ [$style.rowNoBorder]: index === activeRows.length - 1 },
+												]"
+												data-test-id="pull-modal-item"
+											>
 												<div
 													:class="[$style.itemContent]"
 													:style="{ paddingLeft: `${row.depth * 16}px` }"
@@ -726,14 +791,6 @@ onMounted(() => {
 	max-height: 100%;
 	scrollbar-color: var(--color--foreground) transparent;
 	outline: var(--border);
-
-	:global(.scrollerItem) {
-		border-bottom: var(--border);
-
-		&:last-child {
-			border-bottom: 0;
-		}
-	}
 }
 
 .listItem {
@@ -742,7 +799,7 @@ onMounted(() => {
 	justify-content: space-between;
 	padding: 10px 16px;
 	margin: 0;
-	border-bottom: 0;
+	border-bottom: var(--border);
 	gap: 30px;
 }
 
@@ -750,7 +807,20 @@ onMounted(() => {
 	display: flex;
 	align-items: center;
 	padding: var(--spacing--2xs) var(--spacing--sm);
-	border-bottom: 0;
+	border-bottom: var(--border);
+}
+
+.folderToggle {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 24px;
+	height: 24px;
+	border: 0;
+	background: transparent;
+	padding: 0;
+	margin-left: var(--spacing--4xs);
+	cursor: pointer;
 }
 
 .itemContent {
@@ -884,5 +954,9 @@ onMounted(() => {
 	margin: var(--spacing--3xs) 0;
 	white-space: normal;
 	padding-right: var(--spacing--md);
+}
+
+.rowNoBorder {
+	border-bottom: 0;
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPullModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPullModal.vue
@@ -12,8 +12,8 @@ import { useProjectsStore } from '@/features/collaboration/projects/projects.sto
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useSourceControlStore } from '../sourceControl.store';
 import type { ProjectListItem } from '@/features/collaboration/projects/projects.types';
+import { useWorkflowTreeRows } from '../composables/useWorkflowTreeRows';
 import {
-	buildWorkflowTreeRows,
 	getPullPriorityByStatus,
 	getStatusText,
 	getStatusTheme,
@@ -209,49 +209,8 @@ const sortedWorkflows = computed(() => {
 	}));
 });
 
-const workflowTreeRows = computed<Array<SourceControlTreeRow<SourceControlledFileWithProject>>>(
-	() => buildWorkflowTreeRows(sortedWorkflows.value),
-);
-
-const collapsedFolderIds = ref<Set<string>>(new Set());
-
-const visibleWorkflowRows = computed<Array<SourceControlTreeRow<SourceControlledFileWithProject>>>(
-	() => {
-		const visibleRows: Array<SourceControlTreeRow<SourceControlledFileWithProject>> = [];
-		const collapsedDepths: number[] = [];
-
-		for (const row of workflowTreeRows.value) {
-			while (collapsedDepths.length && row.depth <= collapsedDepths[collapsedDepths.length - 1]) {
-				collapsedDepths.pop();
-			}
-
-			if (collapsedDepths.length) {
-				continue;
-			}
-
-			visibleRows.push(row);
-
-			if (row.type === 'folder' && collapsedFolderIds.value.has(row.id)) {
-				collapsedDepths.push(row.depth);
-			}
-		}
-
-		return visibleRows;
-	},
-);
-
-function isFolderCollapsed(folderId: string) {
-	return collapsedFolderIds.value.has(folderId);
-}
-
-function toggleFolderCollapse(folderId: string) {
-	if (collapsedFolderIds.value.has(folderId)) {
-		collapsedFolderIds.value.delete(folderId);
-		return;
-	}
-
-	collapsedFolderIds.value.add(folderId);
-}
+const { visibleWorkflowRows, isFolderCollapsed, toggleFolderCollapse } =
+	useWorkflowTreeRows(sortedWorkflows);
 
 // Filtered credentials
 const filteredCredentials = computed(() => {

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPullModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPullModal.vue
@@ -728,10 +728,10 @@ onMounted(() => {
 	outline: var(--border);
 
 	:global(.scrollerItem) {
+		border-bottom: var(--border);
+
 		&:last-child {
-			.listItem {
-				border-bottom: 0;
-			}
+			border-bottom: 0;
 		}
 	}
 }
@@ -742,7 +742,7 @@ onMounted(() => {
 	justify-content: space-between;
 	padding: 10px 16px;
 	margin: 0;
-	border-bottom: var(--border);
+	border-bottom: 0;
 	gap: 30px;
 }
 
@@ -750,7 +750,7 @@ onMounted(() => {
 	display: flex;
 	align-items: center;
 	padding: var(--spacing--2xs) var(--spacing--sm);
-	border-bottom: var(--border);
+	border-bottom: 0;
 }
 
 .itemContent {

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.test.ts
@@ -271,6 +271,83 @@ describe('SourceControlPushModal', () => {
 		expect(files[1]).not.toBeChecked();
 	});
 
+	it('should toggle folder checkbox and select nested workflows', async () => {
+		const status: SourceControlledFile[] = [
+			{
+				id: 'wf-root',
+				name: 'Root workflow',
+				type: 'workflow',
+				status: 'created',
+				location: 'local',
+				conflict: false,
+				file: '/home/user/.n8n/git/workflows/wf-root.json',
+				updatedAt: '2024-09-20T10:31:40.000Z',
+			},
+			{
+				id: 'wf-child-1',
+				name: 'Child workflow 1',
+				type: 'workflow',
+				status: 'created',
+				location: 'local',
+				conflict: false,
+				file: '/home/user/.n8n/git/workflows/wf-child-1.json',
+				updatedAt: '2024-09-20T10:32:40.000Z',
+				folderPath: ['Prod'],
+			},
+			{
+				id: 'wf-child-2',
+				name: 'Child workflow 2',
+				type: 'workflow',
+				status: 'created',
+				location: 'local',
+				conflict: false,
+				file: '/home/user/.n8n/git/workflows/wf-child-2.json',
+				updatedAt: '2024-09-20T10:33:40.000Z',
+				folderPath: ['Prod'],
+			},
+		];
+
+		sourceControlStore.getAggregatedStatus.mockResolvedValue(status);
+
+		const { getAllByTestId, getByText } = renderModal({
+			pinia,
+			props: {
+				data: {
+					eventBus,
+					status,
+				},
+			},
+		});
+
+		await waitFor(() => {
+			expect(getByText('Commit and push changes')).toBeInTheDocument();
+		});
+
+		await waitFor(() => {
+			expect(getAllByTestId('source-control-push-modal-file-checkbox')).toHaveLength(3);
+			expect(getAllByTestId('source-control-push-modal-folder-checkbox')).toHaveLength(1);
+		});
+
+		const fileCheckboxes = getAllByTestId('source-control-push-modal-file-checkbox');
+		const folderCheckbox = getAllByTestId('source-control-push-modal-folder-checkbox')[0];
+
+		expect(fileCheckboxes[0]).not.toBeChecked();
+		expect(fileCheckboxes[1]).not.toBeChecked();
+		expect(fileCheckboxes[2]).not.toBeChecked();
+
+		await userEvent.click(folderCheckbox);
+
+		expect(fileCheckboxes[0]).not.toBeChecked();
+		expect(fileCheckboxes[1]).toBeChecked();
+		expect(fileCheckboxes[2]).toBeChecked();
+
+		await userEvent.click(folderCheckbox);
+
+		expect(fileCheckboxes[0]).not.toBeChecked();
+		expect(fileCheckboxes[1]).not.toBeChecked();
+		expect(fileCheckboxes[2]).not.toBeChecked();
+	});
+
 	it('should push all entities besides workflows and credentials', async () => {
 		const status: SourceControlledFile[] = [
 			{

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.test.ts
@@ -311,7 +311,7 @@ describe('SourceControlPushModal', () => {
 
 		sourceControlStore.getAggregatedStatus.mockResolvedValue(status);
 
-		const { getAllByTestId, getByText } = renderModal({
+		const { getAllByTestId, getByText, getByRole } = renderModal({
 			pinia,
 			props: {
 				data: {
@@ -330,24 +330,23 @@ describe('SourceControlPushModal', () => {
 			expect(getAllByTestId('source-control-push-modal-folder-checkbox')).toHaveLength(1);
 		});
 
-		const fileCheckboxes = getAllByTestId('source-control-push-modal-file-checkbox');
 		const folderCheckbox = getAllByTestId('source-control-push-modal-folder-checkbox')[0];
 
-		expect(fileCheckboxes[0]).not.toBeChecked();
-		expect(fileCheckboxes[1]).not.toBeChecked();
-		expect(fileCheckboxes[2]).not.toBeChecked();
+		expect(getByRole('checkbox', { name: /Root workflow/i })).not.toBeChecked();
+		expect(getByRole('checkbox', { name: /Child workflow 1/i })).not.toBeChecked();
+		expect(getByRole('checkbox', { name: /Child workflow 2/i })).not.toBeChecked();
 
 		await userEvent.click(folderCheckbox);
 
-		expect(fileCheckboxes[0]).not.toBeChecked();
-		expect(fileCheckboxes[1]).toBeChecked();
-		expect(fileCheckboxes[2]).toBeChecked();
+		expect(getByRole('checkbox', { name: /Root workflow/i })).not.toBeChecked();
+		expect(getByRole('checkbox', { name: /Child workflow 1/i })).toBeChecked();
+		expect(getByRole('checkbox', { name: /Child workflow 2/i })).toBeChecked();
 
 		await userEvent.click(folderCheckbox);
 
-		expect(fileCheckboxes[0]).not.toBeChecked();
-		expect(fileCheckboxes[1]).not.toBeChecked();
-		expect(fileCheckboxes[2]).not.toBeChecked();
+		expect(getByRole('checkbox', { name: /Root workflow/i })).not.toBeChecked();
+		expect(getByRole('checkbox', { name: /Child workflow 1/i })).not.toBeChecked();
+		expect(getByRole('checkbox', { name: /Child workflow 2/i })).not.toBeChecked();
 	});
 
 	it('should collapse and expand nested folder workflows', async () => {

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.test.ts
@@ -1404,6 +1404,96 @@ describe('SourceControlPushModal', () => {
 			});
 		});
 
+		it('should build folder filter options in hierarchical sorted order', async () => {
+			const status: SourceControlledFile[] = [
+				{
+					id: 'wf-alpha',
+					name: 'Alpha workflow',
+					type: 'workflow',
+					status: 'created',
+					location: 'local',
+					conflict: false,
+					file: '/home/user/.n8n/git/workflows/wf-alpha.json',
+					updatedAt: '2024-09-20T10:31:40.000Z',
+					folderPath: ['Alpha'],
+				},
+				{
+					id: 'wf-prod-root',
+					name: 'Prod root workflow',
+					type: 'workflow',
+					status: 'created',
+					location: 'local',
+					conflict: false,
+					file: '/home/user/.n8n/git/workflows/wf-prod-root.json',
+					updatedAt: '2024-09-20T10:32:40.000Z',
+					folderPath: ['Prod'],
+				},
+				{
+					id: 'wf-prod-billing',
+					name: 'Prod billing workflow',
+					type: 'workflow',
+					status: 'created',
+					location: 'local',
+					conflict: false,
+					file: '/home/user/.n8n/git/workflows/wf-prod-billing.json',
+					updatedAt: '2024-09-20T10:33:40.000Z',
+					folderPath: ['Prod', 'Billing'],
+				},
+				{
+					id: 'wf-prod-analytics',
+					name: 'Prod analytics workflow',
+					type: 'workflow',
+					status: 'created',
+					location: 'local',
+					conflict: false,
+					file: '/home/user/.n8n/git/workflows/wf-prod-analytics.json',
+					updatedAt: '2024-09-20T10:34:40.000Z',
+					folderPath: ['Prod', 'Analytics'],
+				},
+			];
+
+			sourceControlStore.getAggregatedStatus.mockResolvedValue(status);
+
+			const { getByTestId, getByText } = renderModal({
+				pinia,
+				props: {
+					data: {
+						eventBus,
+						status,
+					},
+				},
+			});
+
+			await waitFor(() => {
+				expect(getByText('Commit and push changes')).toBeInTheDocument();
+			});
+
+			await waitFor(() => {
+				expect(getByTestId('source-control-filter-dropdown')).toBeInTheDocument();
+			});
+
+			await userEvent.click(getByTestId('source-control-filter-dropdown'));
+			const folderSelect = getByTestId('source-control-folder-filter');
+			const folderCombobox = within(folderSelect).getByRole('combobox');
+			await userEvent.click(folderCombobox);
+
+			const dropdownId = folderCombobox.getAttribute('aria-controls');
+			expect(dropdownId).toBeTruthy();
+
+			await waitFor(() => {
+				const dropdown = document.getElementById(dropdownId as string);
+				expect(dropdown).toBeInTheDocument();
+				expect(within(dropdown as HTMLElement).getByText('Alpha')).toBeInTheDocument();
+			});
+
+			const dropdown = document.getElementById(dropdownId as string) as HTMLElement;
+			const optionLabels = Array.from(dropdown.querySelectorAll('[role="option"]'))
+				.map((option) => option.textContent?.trim() ?? '')
+				.filter(Boolean);
+
+			expect(optionLabels).toEqual(['Alpha', 'Prod', 'Prod / Analytics', 'Prod / Billing']);
+		});
+
 		test.each([
 			['credential', 'Credentials'],
 			['workflow', 'Workflows'],

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.test.ts
@@ -348,6 +348,78 @@ describe('SourceControlPushModal', () => {
 		expect(fileCheckboxes[2]).not.toBeChecked();
 	});
 
+	it('should collapse and expand nested folder workflows', async () => {
+		const status: SourceControlledFile[] = [
+			{
+				id: 'wf-root',
+				name: 'Root workflow',
+				type: 'workflow',
+				status: 'created',
+				location: 'local',
+				conflict: false,
+				file: '/home/user/.n8n/git/workflows/wf-root.json',
+				updatedAt: '2024-09-20T10:31:40.000Z',
+			},
+			{
+				id: 'wf-child-1',
+				name: 'Child workflow 1',
+				type: 'workflow',
+				status: 'created',
+				location: 'local',
+				conflict: false,
+				file: '/home/user/.n8n/git/workflows/wf-child-1.json',
+				updatedAt: '2024-09-20T10:32:40.000Z',
+				folderPath: ['Prod'],
+			},
+			{
+				id: 'wf-child-2',
+				name: 'Child workflow 2',
+				type: 'workflow',
+				status: 'created',
+				location: 'local',
+				conflict: false,
+				file: '/home/user/.n8n/git/workflows/wf-child-2.json',
+				updatedAt: '2024-09-20T10:33:40.000Z',
+				folderPath: ['Prod'],
+			},
+		];
+
+		sourceControlStore.getAggregatedStatus.mockResolvedValue(status);
+
+		const { getByText, getByTestId, getAllByTestId } = renderModal({
+			pinia,
+			props: {
+				data: {
+					eventBus,
+					status,
+				},
+			},
+		});
+
+		let folderToggle: HTMLElement;
+
+		await waitFor(() => {
+			expect(getByText('Commit and push changes')).toBeInTheDocument();
+			expect(getAllByTestId('source-control-push-modal-file-checkbox')).toHaveLength(3);
+			folderToggle = getByTestId('source-control-push-modal-folder-toggle');
+			expect(folderToggle).toBeInTheDocument();
+			expect(getAllByTestId('source-control-push-modal-folder-checkbox')[0]).not.toBeChecked();
+		});
+
+		await userEvent.click(folderToggle!);
+
+		await waitFor(() => {
+			expect(getAllByTestId('source-control-push-modal-file-checkbox')).toHaveLength(1);
+			expect(getAllByTestId('source-control-push-modal-folder-checkbox')[0]).not.toBeChecked();
+		});
+
+		await userEvent.click(folderToggle!);
+
+		await waitFor(() => {
+			expect(getAllByTestId('source-control-push-modal-file-checkbox')).toHaveLength(3);
+		});
+	});
+
 	it('should push all entities besides workflows and credentials', async () => {
 		const status: SourceControlledFile[] = [
 			{

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.test.ts
@@ -72,6 +72,7 @@ vi.mock('@/app/composables/useToast', () => ({
 }));
 
 let telemetry: ReturnType<typeof useTelemetry>;
+const scrollToItemMock = vi.fn();
 
 const DynamicScrollerStub = {
 	props: {
@@ -83,7 +84,7 @@ const DynamicScrollerStub = {
 	template:
 		'<div><template v-for="(item, index) in items" :key="index"><slot v-bind="{ item, index, active: false }"></slot></template></div>',
 	methods: {
-		scrollToItem: vi.fn(),
+		scrollToItem: scrollToItemMock,
 	},
 };
 
@@ -140,6 +141,7 @@ describe('SourceControlPushModal', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		scrollToItemMock.mockClear();
 		telemetry = useTelemetry();
 
 		// Reset route mock to default values
@@ -587,6 +589,9 @@ describe('SourceControlPushModal', () => {
 		await waitFor(() => {
 			expect(getByRole('checkbox', { name: /My workflow 1/i })).toBeChecked();
 			expect(getByRole('checkbox', { name: /My workflow 2/i })).not.toBeChecked();
+		});
+		await waitFor(() => {
+			expect(scrollToItemMock).toHaveBeenCalled();
 		});
 
 		await userEvent.type(getByTestId('source-control-push-modal-commit'), 'message');

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.test.ts
@@ -563,7 +563,7 @@ describe('SourceControlPushModal', () => {
 		mockRoute.name = VIEWS.WORKFLOW;
 		mockRoute.params = { name: 'gTbbBkkYTnNyX1jD' };
 
-		const { getByTestId, getAllByTestId, getByText } = renderModal({
+		const { getByTestId, getAllByTestId, getByText, getByRole } = renderModal({
 			pinia,
 			props: {
 				data: {
@@ -583,11 +583,11 @@ describe('SourceControlPushModal', () => {
 			expect(files).toHaveLength(2);
 		});
 
-		const files = getAllByTestId('source-control-push-modal-file-checkbox');
-
-		// The current workflow should be auto-selected now that we fixed the regression
-		expect(files[0]).toBeChecked();
-		expect(files[1]).not.toBeChecked();
+		// The current workflow should be auto-selected regardless of rendered order
+		await waitFor(() => {
+			expect(getByRole('checkbox', { name: /My workflow 1/i })).toBeChecked();
+			expect(getByRole('checkbox', { name: /My workflow 2/i })).not.toBeChecked();
+		});
 
 		await userEvent.type(getByTestId('source-control-push-modal-commit'), 'message');
 		const submitButton = getByTestId('source-control-push-modal-submit');

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.test.ts
@@ -512,10 +512,10 @@ describe('SourceControlPushModal', () => {
 		expect(getByRole('alert').textContent).toContain(
 			[
 				'Changes to variables, tags, folders and projects',
-				'Variables : at least one new or modified.',
-				'Tags : at least one new or modified.',
-				'Folders : at least one new or modified.',
-				'Projects : at least one new or modified.',
+				'Variables: at least one new or modified.',
+				'Tags: at least one new or modified.',
+				'Folders: at least one new or modified.',
+				'Projects: at least one new or modified.',
 			].join(' '),
 		);
 

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
@@ -15,7 +15,13 @@ import type {
 	ProjectSharingData,
 } from '@/features/collaboration/projects/projects.types';
 import { ResourceType } from '@/features/collaboration/projects/projects.utils';
-import { getPushPriorityByStatus, getStatusText, getStatusTheme } from '../sourceControl.utils';
+import {
+	buildWorkflowTreeRows,
+	getPushPriorityByStatus,
+	getStatusText,
+	getStatusTheme,
+} from '../sourceControl.utils';
+import type { SourceControlTreeRow } from '../sourceControl.types';
 import type { SourceControlledFile, SourceControlledFileStatus } from '@n8n/api-types';
 import {
 	ROLE,
@@ -137,8 +143,9 @@ const projectsForFilters = computed(() => {
 const concatenateWithAnd = (messages: string[]) =>
 	new Intl.ListFormat(i18n.locale, { style: 'long', type: 'conjunction' }).format(messages);
 
-type SourceControlledFileWithProject = SourceControlledFile & { project?: ProjectListItem };
-
+type SourceControlledFileWithProject = SourceControlledFile & {
+	project?: ProjectListItem;
+};
 type Changes = {
 	tags: SourceControlledFileWithProject[];
 	variables: SourceControlledFileWithProject[];
@@ -271,14 +278,19 @@ const selectedWorkflows = reactive<Set<string>>(new Set());
 const maybeSelectCurrentWorkflow = (workflow?: SourceControlledFileWithProject) =>
 	workflow && selectedWorkflows.add(workflow.id);
 
-const filters = ref<{ status?: SourceControlledFileStatus; project: ProjectSharingData | null }>({
+const filters = ref<{
+	status?: SourceControlledFileStatus;
+	project: ProjectSharingData | null;
+	folder?: string;
+}>({
 	project: null,
+	folder: '',
 });
 const filtersApplied = computed(
 	() => Boolean(search.value) || Boolean(Object.values(filters.value).filter(Boolean).length),
 );
 const resetFilters = () => {
-	filters.value = { project: null };
+	filters.value = { project: null, folder: '' };
 	search.value = '';
 };
 
@@ -304,18 +316,60 @@ const filterCount = computed(() =>
 	Object.values(filters.value).reduce((acc, item) => (item ? acc + 1 : acc), 0),
 );
 
+const folderFilterOptions = computed(() => {
+	const folderPathSet = new Set<string>();
+
+	for (const workflow of changes.value.workflow) {
+		const pathSegments = workflow.folderPath ?? [];
+		let path = '';
+
+		for (const segment of pathSegments) {
+			path = path ? `${path}/${segment}` : segment;
+			folderPathSet.add(path);
+		}
+	}
+
+	return Array.from(folderPathSet)
+		.sort((a, b) => {
+			const depthDiff = a.split('/').length - b.split('/').length;
+			if (depthDiff !== 0) {
+				return depthDiff;
+			}
+			return a.localeCompare(b);
+		})
+		.map((path) => ({
+			label: path.replaceAll('/', ' / '),
+			value: path,
+		}));
+});
+
 const filteredWorkflows = computed(() => {
 	const searchQuery = debouncedSearch.value.toLocaleLowerCase();
 
 	return changes.value.workflow.filter((workflow) => {
-		if (!workflow.name.toLocaleLowerCase().includes(searchQuery)) {
+		const nameMatches = workflow.name.toLocaleLowerCase().includes(searchQuery);
+		const folderPathMatches = (workflow.folderPath ?? []).some((segment) =>
+			segment.toLocaleLowerCase().includes(searchQuery),
+		);
+
+		if (searchQuery && !nameMatches && !folderPathMatches) {
 			return false;
 		}
 
 		// Project filter logic: if a project filter is set, only show items from that project
-		if (filters.value.project) {
-			// Item must have a project and it must match the filter
-			return workflow.project?.id === filters.value.project.id;
+		if (filters.value.project && workflow.project?.id !== filters.value.project.id) {
+			return false;
+		}
+
+		const folderFilter = filters.value.folder?.trim();
+		if (folderFilter) {
+			const workflowPath = (workflow.folderPath ?? []).join('/');
+			const matchesFolderFilter =
+				workflowPath === folderFilter || workflowPath.startsWith(`${folderFilter}/`);
+
+			if (!matchesFolderFilter) {
+				return false;
+			}
 		}
 
 		// Status filter (only applied when no project filter is active)
@@ -333,12 +387,45 @@ const sortedWorkflows = computed(() =>
 		[
 			// keep the current workflow at the top of the list
 			({ id }) => id === changes.value.currentWorkflow?.id,
+			({ folderPath }) => folderPath?.join('/') ?? '',
 			({ status }) => getPushPriorityByStatus(status),
 			'updatedAt',
 		],
-		['desc', 'asc', 'desc'],
+		['desc', 'asc', 'asc', 'desc'],
 	),
 );
+
+const workflowTreeRows = computed<SourceControlTreeRow<SourceControlledFileWithProject>[]>(() =>
+	buildWorkflowTreeRows(sortedWorkflows.value),
+);
+
+const folderChildrenMap = computed(() => {
+	const childrenByFolderId = new Map<string, string[]>();
+	const rows = workflowTreeRows.value;
+
+	for (const [index, row] of rows.entries()) {
+		if (row.type !== 'folder') {
+			continue;
+		}
+
+		const childWorkflowIds: string[] = [];
+		for (let next = index + 1; next < rows.length; next++) {
+			const candidate = rows[next];
+
+			if (candidate.depth <= row.depth) {
+				break;
+			}
+
+			if (candidate.type === 'file') {
+				childWorkflowIds.push(candidate.file.id);
+			}
+		}
+
+		childrenByFolderId.set(row.id, childWorkflowIds);
+	}
+
+	return childrenByFolderId;
+});
 
 const selectedCredentials = reactive<Set<string>>(new Set());
 
@@ -641,6 +728,42 @@ function toggleSelected(id: string) {
 	}
 }
 
+function isFolderSelected(folderId: string) {
+	const folderChildren = folderChildrenMap.value.get(folderId) ?? [];
+	if (!folderChildren.length) {
+		return false;
+	}
+
+	return folderChildren.every((childId) => selectedWorkflows.has(childId));
+}
+
+function isFolderSelectionIndeterminate(folderId: string) {
+	const folderChildren = folderChildrenMap.value.get(folderId) ?? [];
+	if (!folderChildren.length) {
+		return false;
+	}
+
+	const selectedChildrenCount = folderChildren.filter((childId) =>
+		selectedWorkflows.has(childId),
+	).length;
+
+	return selectedChildrenCount > 0 && selectedChildrenCount < folderChildren.length;
+}
+
+function toggleFolderSelection(folderId: string) {
+	const folderChildren = folderChildrenMap.value.get(folderId) ?? [];
+	if (!folderChildren.length) {
+		return;
+	}
+
+	if (isFolderSelected(folderId)) {
+		folderChildren.forEach((childId) => selectedWorkflows.delete(childId));
+		return;
+	}
+
+	folderChildren.forEach((childId) => selectedWorkflows.add(childId));
+}
+
 const activeDataSource = computed(() => {
 	if (activeTab.value === SOURCE_CONTROL_FILE_TYPE.workflow) {
 		return changes.value.workflow;
@@ -665,6 +788,19 @@ const activeDataSourceFiltered = computed(() => {
 		return sortedDataTables.value;
 	}
 	return [];
+});
+
+const activeRows = computed<SourceControlTreeRow[]>(() => {
+	if (activeTab.value === SOURCE_CONTROL_FILE_TYPE.workflow) {
+		return workflowTreeRows.value;
+	}
+
+	return activeDataSourceFiltered.value.map((file) => ({
+		id: `file:${file.id}`,
+		type: 'file' as const,
+		file,
+		depth: 0,
+	}));
 });
 
 const activeEntityLocale = computed(() => {
@@ -868,6 +1004,26 @@ onMounted(async () => {
 								:placeholder="i18n.baseText('forms.resourceFiltersDropdown.owner.placeholder')"
 								:empty-options-text="i18n.baseText('projects.sharing.noMatchingProjects')"
 							/>
+							<N8nInputLabel
+								:label="i18n.baseText('generic.folder')"
+								:bold="false"
+								size="small"
+								color="text-base"
+								class="mb-3xs mt-3xs"
+							/>
+							<N8nSelect
+								v-model="filters.folder"
+								data-test-id="source-control-folder-filter"
+								clearable
+								:placeholder="i18n.baseText('generic.folder')"
+							>
+								<N8nOption
+									v-for="option in folderFilterOptions"
+									:key="option.value"
+									:label="option.label"
+									:value="option.value"
+								/>
+							</N8nSelect>
 							<div v-if="filterCount" class="mt-s">
 								<N8nLink @click="resetFilters">
 									{{ i18n.baseText('forms.resourceFiltersDropdown.reset') }}
@@ -958,96 +1114,135 @@ onMounted(async () => {
 								{{ filtersNoResultText }}
 							</N8nInfoTip>
 							<DynamicScroller
-								v-if="activeDataSourceFiltered.length"
+								v-if="activeRows.length"
 								:class="[$style.scroller]"
-								:items="activeDataSourceFiltered"
+								:items="activeRows"
 								:min-item-size="57"
 								item-class="scrollerItem"
 							>
-								<template #default="{ item: file, active, index }">
+								<template #default="{ item: row, active, index }">
 									<DynamicScrollerItem
-										:item="file"
+										:item="row"
 										:active="active"
-										:size-dependencies="[file.name, file.id]"
+										:size-dependencies="[
+											row.type,
+											row.type === 'file' ? row.file.name : row.name,
+											row.id,
+											row.depth,
+										]"
 										:data-index="index"
-										data-test-id="push-modal-item"
 									>
-										<N8nCheckbox
-											:class="[$style.listItem]"
-											data-test-id="source-control-push-modal-file-checkbox"
-											:model-value="activeSelection.has(file.id)"
-											@update:model-value="toggleSelected(file.id)"
+										<div
+											v-if="row.type === 'folder'"
+											:class="[$style.folderRow]"
+											:style="{ paddingLeft: `${16 + row.depth * 16}px` }"
 										>
-											<template #label>
-												<div :class="$style.listItemContent">
-													<span>
-														<N8nText
-															tag="div"
-															bold
-															color="text-dark"
-															:class="[$style.listItemName]"
-														>
-															{{ file.name || file.id }}
+											<N8nCheckbox
+												:class="$style.folderCheckbox"
+												data-test-id="source-control-push-modal-folder-checkbox"
+												:model-value="isFolderSelected(row.id)"
+												:indeterminate="isFolderSelectionIndeterminate(row.id)"
+												@update:model-value="toggleFolderSelection(row.id)"
+											>
+												<template #label>
+													<div :class="$style.folderLabel">
+														<N8nIcon icon="folder" color="text-light" size="small" />
+														<N8nText tag="span" color="text-light">
+															{{ row.name }}
 														</N8nText>
-														<N8nText
-															v-if="file.updatedAt"
-															tag="p"
-															class="mt-0"
-															color="text-light"
-															size="small"
-														>
-															{{ renderUpdatedAt(file) }}
-														</N8nText>
-													</span>
-													<span :class="[$style.badges]">
-														<N8nBadge
-															v-if="
-																changes.currentWorkflow && file.id === changes.currentWorkflow.id
-															"
-															class="mr-2xs"
-														>
-															Current workflow
-														</N8nBadge>
-														<template
-															v-if="
-																file.type === SOURCE_CONTROL_FILE_TYPE.workflow ||
-																file.type === SOURCE_CONTROL_FILE_TYPE.credential ||
-																file.type === SOURCE_CONTROL_FILE_TYPE.datatable
-															"
-														>
-															<ProjectCardBadge
-																v-if="file.project"
-																data-test-id="source-control-push-modal-project-badge"
-																:resource="castProject(file.project)"
-																:resource-type="castType(file.type)"
-																:resource-type-label="
-																	i18n.baseText(`generic.${file.type}`).toLowerCase()
-																"
-																:personal-project="projectsStore.personalProject"
-																:show-badge-border="false"
-															/>
-														</template>
-														<N8nBadge :theme="getStatusTheme(file.status)" style="height: 25px">
-															{{ getStatusText(file.status) }}
-														</N8nBadge>
-														<template v-if="isWorkflowDiffsEnabled">
-															<N8nTooltip
-																v-if="file.type === SOURCE_CONTROL_FILE_TYPE.workflow"
-																:content="i18n.baseText('workflowDiff.compare')"
-																placement="top"
+													</div>
+												</template>
+											</N8nCheckbox>
+										</div>
+										<div
+											v-else
+											:class="$style.fileRow"
+											:style="{
+												marginLeft: `${row.depth * 16}px`,
+												width: `calc(100% - ${row.depth * 16}px)`,
+											}"
+										>
+											<N8nCheckbox
+												:class="[$style.listItem]"
+												data-test-id="source-control-push-modal-file-checkbox"
+												:model-value="activeSelection.has(row.file.id)"
+												@update:model-value="toggleSelected(row.file.id)"
+											>
+												<template #label>
+													<div :class="$style.listItemContent">
+														<span>
+															<N8nText
+																tag="div"
+																bold
+																color="text-dark"
+																:class="[$style.listItemName]"
 															>
-																<N8nIconButton
-																	variant="subtle"
-																	data-test-id="source-control-workflow-diff-button"
-																	icon="file-diff"
-																	@click="openDiffModal(file.id, file.status)"
+																{{ row.file.name || row.file.id }}
+															</N8nText>
+															<N8nText
+																v-if="row.file.updatedAt"
+																tag="p"
+																class="mt-0"
+																color="text-light"
+																size="small"
+															>
+																{{ renderUpdatedAt(row.file) }}
+															</N8nText>
+														</span>
+														<span :class="[$style.badges]">
+															<N8nBadge
+																v-if="
+																	changes.currentWorkflow &&
+																	row.file.id === changes.currentWorkflow.id
+																"
+																class="mr-2xs"
+															>
+																Current workflow
+															</N8nBadge>
+															<template
+																v-if="
+																	row.file.type === SOURCE_CONTROL_FILE_TYPE.workflow ||
+																	row.file.type === SOURCE_CONTROL_FILE_TYPE.credential ||
+																	row.file.type === SOURCE_CONTROL_FILE_TYPE.datatable
+																"
+															>
+																<ProjectCardBadge
+																	v-if="row.file.project"
+																	data-test-id="source-control-push-modal-project-badge"
+																	:resource="castProject(row.file.project)"
+																	:resource-type="castType(row.file.type)"
+																	:resource-type-label="
+																		i18n.baseText(`generic.${row.file.type}`).toLowerCase()
+																	"
+																	:personal-project="projectsStore.personalProject"
+																	:show-badge-border="false"
 																/>
-															</N8nTooltip>
-														</template>
-													</span>
-												</div>
-											</template>
-										</N8nCheckbox>
+															</template>
+															<N8nBadge
+																:theme="getStatusTheme(row.file.status)"
+																style="height: 25px"
+															>
+																{{ getStatusText(row.file.status) }}
+															</N8nBadge>
+															<template v-if="isWorkflowDiffsEnabled">
+																<N8nTooltip
+																	v-if="row.file.type === SOURCE_CONTROL_FILE_TYPE.workflow"
+																	:content="i18n.baseText('workflowDiff.compare')"
+																	placement="top"
+																>
+																	<N8nIconButton
+																		variant="subtle"
+																		data-test-id="source-control-workflow-diff-button"
+																		icon="file-diff"
+																		@click="openDiffModal(row.file.id, row.file.status)"
+																	/>
+																</N8nTooltip>
+															</template>
+														</span>
+													</div>
+												</template>
+											</N8nCheckbox>
+										</div>
 									</DynamicScrollerItem>
 								</template>
 							</DynamicScroller>
@@ -1060,9 +1255,9 @@ onMounted(async () => {
 		<template #footer>
 			<N8nNotice
 				v-if="userNotices.length || hasModifiedCredentialsSelected"
+				id="source-control-push-modal-notice"
 				:compact="false"
 				class="mt-0"
-				id="source-control-push-modal-notice"
 			>
 				<template v-if="userNotices.length">
 					<N8nText bold size="medium">Changes to variables, tags, folders and projects </N8nText>
@@ -1143,10 +1338,10 @@ onMounted(async () => {
 	outline: var(--border);
 
 	:global(.scrollerItem) {
+		border-bottom: var(--border);
+
 		&:last-child {
-			.listItem {
-				border-bottom: 0;
-			}
+			border-bottom: 0;
 		}
 	}
 }
@@ -1155,7 +1350,7 @@ onMounted(async () => {
 	align-items: center;
 	padding: 10px 16px;
 	margin: 0;
-	border-bottom: var(--border);
+	border-bottom: 0;
 	width: 100%;
 
 	.listItemContent {
@@ -1174,6 +1369,30 @@ onMounted(async () => {
 		-webkit-box-orient: vertical;
 		word-wrap: break-word; /* Important for long words! */
 	}
+}
+
+.folderRow {
+	display: flex;
+	align-items: center;
+	padding: var(--spacing--2xs) var(--spacing--sm);
+	border-bottom: 0;
+}
+
+.folderCheckbox {
+	display: flex;
+	align-items: center;
+	width: 100%;
+	margin-bottom: 0;
+}
+
+.folderLabel {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing--4xs);
+}
+
+.fileRow {
+	box-sizing: border-box;
 }
 
 .badges {

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
@@ -15,6 +15,7 @@ import type {
 	ProjectSharingData,
 } from '@/features/collaboration/projects/projects.types';
 import { ResourceType } from '@/features/collaboration/projects/projects.utils';
+import { useRevealWorkflowInScroller } from '../composables/useRevealWorkflowInScroller';
 import { useSourceControlFileList } from '../composables/useSourceControlFileList';
 import { useWorkflowTreeRows } from '../composables/useWorkflowTreeRows';
 import {
@@ -384,9 +385,13 @@ const sortedWorkflows = useSourceControlFileList({
 	},
 });
 
+const activeTab = ref<
+	| typeof SOURCE_CONTROL_FILE_TYPE.workflow
+	| typeof SOURCE_CONTROL_FILE_TYPE.credential
+	| typeof SOURCE_CONTROL_FILE_TYPE.datatable
+>(SOURCE_CONTROL_FILE_TYPE.workflow);
+
 const workflowScroller = ref<{ scrollToItem: (index: number) => void; $el?: Element } | null>(null);
-const hasScrolledCurrentWorkflow = ref(false);
-const isRevealInProgress = ref(false);
 
 const {
 	workflowTreeRows,
@@ -397,68 +402,17 @@ const {
 	getAncestorFolderIdsForWorkflow,
 } = useWorkflowTreeRows(sortedWorkflows);
 
-async function animationFrame() {
-	await new Promise<void>((resolve) => {
-		if (typeof requestAnimationFrame === 'function') {
-			requestAnimationFrame(() => resolve());
-			return;
-		}
-
-		setTimeout(resolve, 0);
-	});
-}
-
-function getCurrentWorkflowRowElement(workflowId: string): HTMLElement | null {
-	const scrollerRoot = workflowScroller.value?.$el;
-	if (!(scrollerRoot instanceof Element)) {
-		return null;
-	}
-
-	return scrollerRoot.querySelector<HTMLElement>(`[data-workflow-id="${workflowId}"]`);
-}
-
-async function revealAndScrollToCurrentWorkflow() {
-	const isWorkflowTab = activeTab.value === SOURCE_CONTROL_FILE_TYPE.workflow;
-
-	if (
-		isRevealInProgress.value ||
-		hasScrolledCurrentWorkflow.value ||
-		!isWorkflowTab ||
-		!changes.value.currentWorkflow ||
-		isLoading.value
-	) {
-		return;
-	}
-
-	isRevealInProgress.value = true;
-	try {
-		const currentWorkflowId = changes.value.currentWorkflow.id;
-		expandFolders(getAncestorFolderIdsForWorkflow(currentWorkflowId));
-
-		for (let attempt = 0; attempt < 6; attempt++) {
-			const visibleIndex = visibleWorkflowRows.value.findIndex(
-				(row) => row.type === 'file' && row.file.id === currentWorkflowId,
-			);
-			const scroller = workflowScroller.value;
-
-			if (visibleIndex >= 0 && scroller) {
-				scroller.scrollToItem(visibleIndex);
-				await animationFrame();
-
-				const workflowRowElement = getCurrentWorkflowRowElement(currentWorkflowId);
-				if (!workflowRowElement) {
-					continue;
-				}
-
-				workflowRowElement.scrollIntoView({ block: 'center', inline: 'nearest' });
-				hasScrolledCurrentWorkflow.value = true;
-				return;
-			}
-		}
-	} finally {
-		isRevealInProgress.value = false;
-	}
-}
+const { revealAndScrollToCurrentWorkflow } = useRevealWorkflowInScroller({
+	visibleWorkflowRows,
+	workflowScroller,
+	activeTab,
+	workflowTabValue: SOURCE_CONTROL_FILE_TYPE.workflow,
+	currentWorkflowId: computed(() => changes.value.currentWorkflow?.id),
+	isLoading,
+	expandAncestorFolders: (workflowId) => {
+		expandFolders(getAncestorFolderIdsForWorkflow(workflowId));
+	},
+});
 
 const folderChildrenMap = computed(() => {
 	const childrenByFolderId = new Map<string, string[]>();
@@ -707,12 +661,6 @@ watch(
 watch(refDebounced(search, 500), (term) => {
 	telemetry.track('User searched workflows in commit modal', { search: term });
 });
-
-const activeTab = ref<
-	| typeof SOURCE_CONTROL_FILE_TYPE.workflow
-	| typeof SOURCE_CONTROL_FILE_TYPE.credential
-	| typeof SOURCE_CONTROL_FILE_TYPE.datatable
->(SOURCE_CONTROL_FILE_TYPE.workflow);
 
 const allVisibleItemsSelected = computed(() => {
 	if (!activeSelection.value.size) {

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
@@ -397,8 +397,8 @@ const sortedWorkflows = computed(() =>
 	),
 );
 
-const workflowTreeRows = computed<SourceControlTreeRow<SourceControlledFileWithProject>[]>(() =>
-	buildWorkflowTreeRows(sortedWorkflows.value),
+const workflowTreeRows = computed<Array<SourceControlTreeRow<SourceControlledFileWithProject>>>(
+	() => buildWorkflowTreeRows(sortedWorkflows.value),
 );
 
 const collapsedFolderIds = ref<Set<string>>(new Set());
@@ -406,9 +406,9 @@ const workflowScroller = ref<{ scrollToItem: (index: number) => void; $el?: Elem
 const hasScrolledCurrentWorkflow = ref(false);
 const isRevealInProgress = ref(false);
 
-const visibleWorkflowRows = computed<SourceControlTreeRow<SourceControlledFileWithProject>[]>(
+const visibleWorkflowRows = computed<Array<SourceControlTreeRow<SourceControlledFileWithProject>>>(
 	() => {
-		const visibleRows: SourceControlTreeRow<SourceControlledFileWithProject>[] = [];
+		const visibleRows: Array<SourceControlTreeRow<SourceControlledFileWithProject>> = [];
 		const collapsedDepths: number[] = [];
 
 		for (const row of workflowTreeRows.value) {
@@ -921,7 +921,7 @@ const activeDataSourceFiltered = computed(() => {
 	return [];
 });
 
-const activeRows = computed<SourceControlTreeRow<SourceControlledFileWithProject>[]>(() => {
+const activeRows = computed<Array<SourceControlTreeRow<SourceControlledFileWithProject>>>(() => {
 	if (activeTab.value === SOURCE_CONTROL_FILE_TYPE.workflow) {
 		return visibleWorkflowRows.value;
 	}

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
@@ -399,6 +399,46 @@ const workflowTreeRows = computed<SourceControlTreeRow<SourceControlledFileWithP
 	buildWorkflowTreeRows(sortedWorkflows.value),
 );
 
+const collapsedFolderIds = ref<Set<string>>(new Set());
+
+const visibleWorkflowRows = computed<SourceControlTreeRow<SourceControlledFileWithProject>[]>(
+	() => {
+		const visibleRows: SourceControlTreeRow<SourceControlledFileWithProject>[] = [];
+		const collapsedDepths: number[] = [];
+
+		for (const row of workflowTreeRows.value) {
+			while (collapsedDepths.length && row.depth <= collapsedDepths[collapsedDepths.length - 1]) {
+				collapsedDepths.pop();
+			}
+
+			if (collapsedDepths.length) {
+				continue;
+			}
+
+			visibleRows.push(row);
+
+			if (row.type === 'folder' && collapsedFolderIds.value.has(row.id)) {
+				collapsedDepths.push(row.depth);
+			}
+		}
+
+		return visibleRows;
+	},
+);
+
+function isFolderCollapsed(folderId: string) {
+	return collapsedFolderIds.value.has(folderId);
+}
+
+function toggleFolderCollapse(folderId: string) {
+	if (collapsedFolderIds.value.has(folderId)) {
+		collapsedFolderIds.value.delete(folderId);
+		return;
+	}
+
+	collapsedFolderIds.value.add(folderId);
+}
+
 const folderChildrenMap = computed(() => {
 	const childrenByFolderId = new Map<string, string[]>();
 	const rows = workflowTreeRows.value;
@@ -790,9 +830,9 @@ const activeDataSourceFiltered = computed(() => {
 	return [];
 });
 
-const activeRows = computed<SourceControlTreeRow[]>(() => {
+const activeRows = computed<SourceControlTreeRow<SourceControlledFileWithProject>[]>(() => {
 	if (activeTab.value === SOURCE_CONTROL_FILE_TYPE.workflow) {
-		return workflowTreeRows.value;
+		return visibleWorkflowRows.value;
 	}
 
 	return activeDataSourceFiltered.value.map((file) => ({
@@ -1135,7 +1175,10 @@ onMounted(async () => {
 									>
 										<div
 											v-if="row.type === 'folder'"
-											:class="[$style.folderRow]"
+											:class="[
+												$style.folderRow,
+												{ [$style.rowNoBorder]: index === activeRows.length - 1 },
+											]"
 											:style="{ paddingLeft: `${16 + row.depth * 16}px` }"
 										>
 											<N8nCheckbox
@@ -1151,13 +1194,31 @@ onMounted(async () => {
 														<N8nText tag="span" color="text-light">
 															{{ row.name }}
 														</N8nText>
+														<button
+															type="button"
+															:class="$style.folderToggle"
+															data-test-id="source-control-push-modal-folder-toggle"
+															@click.stop.prevent="toggleFolderCollapse(row.id)"
+															@mousedown.stop.prevent
+															@mouseup.stop.prevent
+															@pointerdown.stop.prevent
+														>
+															<N8nIcon
+																:icon="isFolderCollapsed(row.id) ? 'chevron-right' : 'chevron-down'"
+																color="text-light"
+																size="small"
+															/>
+														</button>
 													</div>
 												</template>
 											</N8nCheckbox>
 										</div>
 										<div
 											v-else
-											:class="$style.fileRow"
+											:class="[
+												$style.fileRow,
+												{ [$style.rowNoBorder]: index === activeRows.length - 1 },
+											]"
 											:style="{ paddingLeft: `${row.depth * 16}px` }"
 										>
 											<N8nCheckbox
@@ -1338,14 +1399,6 @@ onMounted(async () => {
 	max-height: 100%;
 	scrollbar-color: var(--color--foreground) transparent;
 	outline: var(--border);
-
-	:global(.scrollerItem) {
-		border-bottom: var(--border);
-
-		&:last-child {
-			border-bottom: 0;
-		}
-	}
 }
 
 .listItem {
@@ -1377,7 +1430,7 @@ onMounted(async () => {
 	display: flex;
 	align-items: center;
 	padding: var(--spacing--2xs) var(--spacing--sm);
-	border-bottom: 0;
+	border-bottom: var(--border);
 }
 
 .folderCheckbox {
@@ -1385,6 +1438,19 @@ onMounted(async () => {
 	align-items: center;
 	width: 100%;
 	margin-bottom: 0;
+}
+
+.folderToggle {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 24px;
+	height: 24px;
+	border: 0;
+	background: transparent;
+	padding: 0;
+	margin-left: var(--spacing--4xs);
+	cursor: pointer;
 }
 
 .folderLabel {
@@ -1396,6 +1462,11 @@ onMounted(async () => {
 .fileRow {
 	box-sizing: border-box;
 	width: 100%;
+	border-bottom: var(--border);
+}
+
+.rowNoBorder {
+	border-bottom: 0;
 }
 
 .badges {

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
@@ -385,13 +385,11 @@ const sortedWorkflows = computed(() =>
 	orderBy(
 		filteredWorkflows.value,
 		[
-			// Keep the current workflow at the top of the list.
-			({ id }) => id === changes.value.currentWorkflow?.id,
 			({ folderPath }) => folderPath?.join('/') ?? '',
 			({ status }) => getPushPriorityByStatus(status),
 			'updatedAt',
 		],
-		['desc', 'asc', 'asc', 'desc'],
+		['asc', 'asc', 'desc'],
 	),
 );
 
@@ -400,6 +398,9 @@ const workflowTreeRows = computed<SourceControlTreeRow<SourceControlledFileWithP
 );
 
 const collapsedFolderIds = ref<Set<string>>(new Set());
+const workflowScroller = ref<{ scrollToItem: (index: number) => void; $el?: Element } | null>(null);
+const hasScrolledCurrentWorkflow = ref(false);
+const isRevealInProgress = ref(false);
 
 const visibleWorkflowRows = computed<SourceControlTreeRow<SourceControlledFileWithProject>[]>(
 	() => {
@@ -437,6 +438,92 @@ function toggleFolderCollapse(folderId: string) {
 	}
 
 	collapsedFolderIds.value.add(folderId);
+}
+
+function getAncestorFolderIdsForWorkflow(workflowId: string): string[] {
+	const ancestorStack: Array<{ id: string; depth: number }> = [];
+
+	for (const row of workflowTreeRows.value) {
+		while (ancestorStack.length && row.depth <= ancestorStack[ancestorStack.length - 1].depth) {
+			ancestorStack.pop();
+		}
+
+		if (row.type === 'folder') {
+			ancestorStack.push({ id: row.id, depth: row.depth });
+			continue;
+		}
+
+		if (row.file.id === workflowId) {
+			return ancestorStack.map(({ id }) => id);
+		}
+	}
+
+	return [];
+}
+
+async function animationFrame() {
+	await new Promise<void>((resolve) => {
+		if (typeof requestAnimationFrame === 'function') {
+			requestAnimationFrame(() => resolve());
+			return;
+		}
+
+		setTimeout(resolve, 0);
+	});
+}
+
+function getCurrentWorkflowRowElement(workflowId: string): HTMLElement | null {
+	const scrollerRoot = workflowScroller.value?.$el;
+	if (!(scrollerRoot instanceof Element)) {
+		return null;
+	}
+
+	return scrollerRoot.querySelector<HTMLElement>(`[data-workflow-id="${workflowId}"]`);
+}
+
+async function revealAndScrollToCurrentWorkflow() {
+	const isWorkflowTab = activeTab.value === SOURCE_CONTROL_FILE_TYPE.workflow;
+
+	if (
+		isRevealInProgress.value ||
+		hasScrolledCurrentWorkflow.value ||
+		!isWorkflowTab ||
+		!changes.value.currentWorkflow ||
+		isLoading.value
+	) {
+		return;
+	}
+
+	isRevealInProgress.value = true;
+	try {
+		const currentWorkflowId = changes.value.currentWorkflow.id;
+		for (const folderId of getAncestorFolderIdsForWorkflow(currentWorkflowId)) {
+			collapsedFolderIds.value.delete(folderId);
+		}
+
+		for (let attempt = 0; attempt < 6; attempt++) {
+			const visibleIndex = visibleWorkflowRows.value.findIndex(
+				(row) => row.type === 'file' && row.file.id === currentWorkflowId,
+			);
+			const scroller = workflowScroller.value;
+
+			if (visibleIndex >= 0 && scroller) {
+				scroller.scrollToItem(visibleIndex);
+				await animationFrame();
+
+				const workflowRowElement = getCurrentWorkflowRowElement(currentWorkflowId);
+				if (!workflowRowElement) {
+					continue;
+				}
+
+				workflowRowElement.scrollIntoView({ block: 'center', inline: 'nearest' });
+				hasScrolledCurrentWorkflow.value = true;
+				return;
+			}
+		}
+	} finally {
+		isRevealInProgress.value = false;
+	}
 }
 
 const folderChildrenMap = computed(() => {
@@ -952,6 +1039,20 @@ watchEffect(() => {
 	}
 });
 
+watch(
+	[
+		() => changes.value.currentWorkflow?.id,
+		() => activeTab.value,
+		() => visibleWorkflowRows.value.length,
+		() => workflowScroller.value,
+		() => isLoading.value,
+	],
+	() => {
+		void revealAndScrollToCurrentWorkflow();
+	},
+	{ immediate: true, flush: 'post' },
+);
+
 // Load data when modal opens
 onMounted(async () => {
 	// Always load fresh data to ensure workflow names are populated
@@ -1156,6 +1257,7 @@ onMounted(async () => {
 							</N8nInfoTip>
 							<DynamicScroller
 								v-if="activeRows.length"
+								ref="workflowScroller"
 								:class="[$style.scroller]"
 								:items="activeRows"
 								:min-item-size="57"
@@ -1220,6 +1322,11 @@ onMounted(async () => {
 												{ [$style.rowNoBorder]: index === activeRows.length - 1 },
 											]"
 											:style="{ paddingLeft: `${row.depth * 16}px` }"
+											:data-workflow-id="
+												row.file.type === SOURCE_CONTROL_FILE_TYPE.workflow
+													? row.file.id
+													: undefined
+											"
 										>
 											<N8nCheckbox
 												:class="[$style.listItem]"
@@ -1327,7 +1434,7 @@ onMounted(async () => {
 					<br />
 					<template v-for="{ title, content } in userNotices" :key="title">
 						<N8nText bold size="small"> {{ title }}</N8nText>
-						<N8nText size="small"> : {{ content }}. </N8nText>
+						<N8nText size="small">: {{ content }}. </N8nText>
 					</template>
 					<br v-if="hasModifiedCredentialsSelected" />
 				</template>

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
@@ -15,12 +15,8 @@ import type {
 	ProjectSharingData,
 } from '@/features/collaboration/projects/projects.types';
 import { ResourceType } from '@/features/collaboration/projects/projects.utils';
-import {
-	buildWorkflowTreeRows,
-	getPushPriorityByStatus,
-	getStatusText,
-	getStatusTheme,
-} from '../sourceControl.utils';
+import { useWorkflowTreeRows } from '../composables/useWorkflowTreeRows';
+import { getPushPriorityByStatus, getStatusText, getStatusTheme } from '../sourceControl.utils';
 import type { SourceControlTreeRow } from '../sourceControl.types';
 import type { SourceControlledFile, SourceControlledFileStatus } from '@n8n/api-types';
 import {
@@ -397,73 +393,18 @@ const sortedWorkflows = computed(() =>
 	),
 );
 
-const workflowTreeRows = computed<Array<SourceControlTreeRow<SourceControlledFileWithProject>>>(
-	() => buildWorkflowTreeRows(sortedWorkflows.value),
-);
-
-const collapsedFolderIds = ref<Set<string>>(new Set());
 const workflowScroller = ref<{ scrollToItem: (index: number) => void; $el?: Element } | null>(null);
 const hasScrolledCurrentWorkflow = ref(false);
 const isRevealInProgress = ref(false);
 
-const visibleWorkflowRows = computed<Array<SourceControlTreeRow<SourceControlledFileWithProject>>>(
-	() => {
-		const visibleRows: Array<SourceControlTreeRow<SourceControlledFileWithProject>> = [];
-		const collapsedDepths: number[] = [];
-
-		for (const row of workflowTreeRows.value) {
-			while (collapsedDepths.length && row.depth <= collapsedDepths[collapsedDepths.length - 1]) {
-				collapsedDepths.pop();
-			}
-
-			if (collapsedDepths.length) {
-				continue;
-			}
-
-			visibleRows.push(row);
-
-			if (row.type === 'folder' && collapsedFolderIds.value.has(row.id)) {
-				collapsedDepths.push(row.depth);
-			}
-		}
-
-		return visibleRows;
-	},
-);
-
-function isFolderCollapsed(folderId: string) {
-	return collapsedFolderIds.value.has(folderId);
-}
-
-function toggleFolderCollapse(folderId: string) {
-	if (collapsedFolderIds.value.has(folderId)) {
-		collapsedFolderIds.value.delete(folderId);
-		return;
-	}
-
-	collapsedFolderIds.value.add(folderId);
-}
-
-function getAncestorFolderIdsForWorkflow(workflowId: string): string[] {
-	const ancestorStack: Array<{ id: string; depth: number }> = [];
-
-	for (const row of workflowTreeRows.value) {
-		while (ancestorStack.length && row.depth <= ancestorStack[ancestorStack.length - 1].depth) {
-			ancestorStack.pop();
-		}
-
-		if (row.type === 'folder') {
-			ancestorStack.push({ id: row.id, depth: row.depth });
-			continue;
-		}
-
-		if (row.file.id === workflowId) {
-			return ancestorStack.map(({ id }) => id);
-		}
-	}
-
-	return [];
-}
+const {
+	workflowTreeRows,
+	visibleWorkflowRows,
+	isFolderCollapsed,
+	toggleFolderCollapse,
+	expandFolders,
+	getAncestorFolderIdsForWorkflow,
+} = useWorkflowTreeRows(sortedWorkflows);
 
 async function animationFrame() {
 	await new Promise<void>((resolve) => {
@@ -501,9 +442,7 @@ async function revealAndScrollToCurrentWorkflow() {
 	isRevealInProgress.value = true;
 	try {
 		const currentWorkflowId = changes.value.currentWorkflow.id;
-		for (const folderId of getAncestorFolderIdsForWorkflow(currentWorkflowId)) {
-			collapsedFolderIds.value.delete(folderId);
-		}
+		expandFolders(getAncestorFolderIdsForWorkflow(currentWorkflowId));
 
 		for (let attempt = 0; attempt < 6; attempt++) {
 			const visibleIndex = visibleWorkflowRows.value.findIndex(

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
@@ -19,6 +19,7 @@ import { useRevealWorkflowInScroller } from '../composables/useRevealWorkflowInS
 import { useSourceControlFileList } from '../composables/useSourceControlFileList';
 import { useWorkflowTreeRows } from '../composables/useWorkflowTreeRows';
 import {
+	buildFolderFilterOptions,
 	formatSourceControlUpdatedAt,
 	getPushPriorityByStatus,
 	getStatusText,
@@ -321,32 +322,7 @@ const filterCount = computed(() =>
 	Object.values(filters.value).reduce((acc, item) => (item ? acc + 1 : acc), 0),
 );
 
-const folderFilterOptions = computed(() => {
-	const folderPathSet = new Set<string>();
-
-	for (const workflow of changes.value.workflow) {
-		const pathSegments = workflow.folderPath ?? [];
-		let path = '';
-
-		for (const segment of pathSegments) {
-			path = path ? `${path}/${segment}` : segment;
-			folderPathSet.add(path);
-		}
-	}
-
-	return Array.from(folderPathSet)
-		.sort((a, b) => {
-			const depthDiff = a.split('/').length - b.split('/').length;
-			if (depthDiff !== 0) {
-				return depthDiff;
-			}
-			return a.localeCompare(b);
-		})
-		.map((path) => ({
-			label: path.replaceAll('/', ' / '),
-			value: path,
-		}));
-});
+const folderFilterOptions = computed(() => buildFolderFilterOptions(changes.value.workflow));
 
 const sortedWorkflows = useSourceControlFileList({
 	files: computed(() => changes.value.workflow),

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
@@ -378,7 +378,7 @@ const {
 	getAncestorFolderIdsForWorkflow,
 } = useWorkflowTreeRows(sortedWorkflows);
 
-const { revealAndScrollToCurrentWorkflow, resetRevealState } = useRevealWorkflowInScroller({
+const { revealAndScrollToCurrentWorkflow } = useRevealWorkflowInScroller({
 	visibleWorkflowRows,
 	workflowScroller,
 	activeTab,
@@ -637,15 +637,6 @@ watch(
 watch(refDebounced(search, 500), (term) => {
 	telemetry.track('User searched workflows in commit modal', { search: term });
 });
-
-watch(
-	() => activeTab.value,
-	(tab) => {
-		if (tab !== SOURCE_CONTROL_FILE_TYPE.workflow) {
-			resetRevealState();
-		}
-	},
-);
 
 const allVisibleItemsSelected = computed(() => {
 	if (!activeSelection.value.size) {

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
@@ -402,7 +402,7 @@ const {
 	getAncestorFolderIdsForWorkflow,
 } = useWorkflowTreeRows(sortedWorkflows);
 
-const { revealAndScrollToCurrentWorkflow } = useRevealWorkflowInScroller({
+const { revealAndScrollToCurrentWorkflow, resetRevealState } = useRevealWorkflowInScroller({
 	visibleWorkflowRows,
 	workflowScroller,
 	activeTab,
@@ -661,6 +661,15 @@ watch(
 watch(refDebounced(search, 500), (term) => {
 	telemetry.track('User searched workflows in commit modal', { search: term });
 });
+
+watch(
+	() => activeTab.value,
+	(tab) => {
+		if (tab !== SOURCE_CONTROL_FILE_TYPE.workflow) {
+			resetRevealState();
+		}
+	},
+);
 
 const allVisibleItemsSelected = computed(() => {
 	if (!activeSelection.value.size) {

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
@@ -294,6 +294,10 @@ const resetFilters = () => {
 	search.value = '';
 };
 
+function clearProjectFilter() {
+	filters.value.project = null;
+}
+
 const statusFilterOptions: Array<{ label: string; value: SourceControlledFileStatus }> = [
 	{
 		label: 'New',
@@ -1141,9 +1145,11 @@ onMounted(async () => {
 							<ProjectSharing
 								v-model="filters.project"
 								data-test-id="source-control-push-modal-project-search"
+								clearable
 								:projects="projectsForFilters"
 								:placeholder="i18n.baseText('forms.resourceFiltersDropdown.owner.placeholder')"
 								:empty-options-text="i18n.baseText('projects.sharing.noMatchingProjects')"
+								@clear="clearProjectFilter"
 							/>
 							<N8nInputLabel
 								:label="i18n.baseText('generic.folder')"

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
@@ -15,8 +15,14 @@ import type {
 	ProjectSharingData,
 } from '@/features/collaboration/projects/projects.types';
 import { ResourceType } from '@/features/collaboration/projects/projects.utils';
+import { useSourceControlFileList } from '../composables/useSourceControlFileList';
 import { useWorkflowTreeRows } from '../composables/useWorkflowTreeRows';
-import { getPushPriorityByStatus, getStatusText, getStatusTheme } from '../sourceControl.utils';
+import {
+	formatSourceControlUpdatedAt,
+	getPushPriorityByStatus,
+	getStatusText,
+	getStatusTheme,
+} from '../sourceControl.utils';
 import type { SourceControlTreeRow } from '../sourceControl.types';
 import type { SourceControlledFile, SourceControlledFileStatus } from '@n8n/api-types';
 import {
@@ -28,8 +34,6 @@ import {
 import { useI18n } from '@n8n/i18n';
 import type { EventBus } from '@n8n/utils/event-bus';
 import { refDebounced, useStorage } from '@vueuse/core';
-import dateformat from 'dateformat';
-import orderBy from 'lodash/orderBy';
 import { computed, onBeforeMount, onMounted, reactive, ref, toRaw, watch, watchEffect } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { DynamicScroller, DynamicScrollerItem } from 'vue-virtual-scroller';
@@ -343,10 +347,16 @@ const folderFilterOptions = computed(() => {
 		}));
 });
 
-const filteredWorkflows = computed(() => {
-	const searchQuery = debouncedSearch.value.toLocaleLowerCase();
-
-	return changes.value.workflow.filter((workflow) => {
+const sortedWorkflows = useSourceControlFileList({
+	files: computed(() => changes.value.workflow),
+	sortBy: [
+		({ folderPath }) => folderPath?.join('/') ?? '',
+		({ status }) => getPushPriorityByStatus(status),
+		'updatedAt',
+	],
+	sortOrder: ['asc', 'asc', 'desc'],
+	filter: (workflow) => {
+		const searchQuery = debouncedSearch.value.toLocaleLowerCase().trim();
 		const nameMatches = workflow.name.toLocaleLowerCase().includes(searchQuery);
 		const folderPathMatches = (workflow.folderPath ?? []).some((segment) =>
 			segment.toLocaleLowerCase().includes(searchQuery),
@@ -356,42 +366,23 @@ const filteredWorkflows = computed(() => {
 			return false;
 		}
 
-		// Project filter logic: if a project filter is set, only show items from that project
 		if (filters.value.project && workflow.project?.id !== filters.value.project.id) {
 			return false;
 		}
 
-		const folderFilter = filters.value.folder?.trim();
-		if (folderFilter) {
-			const workflowPath = (workflow.folderPath ?? []).join('/');
-			const matchesFolderFilter =
-				workflowPath === folderFilter || workflowPath.startsWith(`${folderFilter}/`);
-
-			if (!matchesFolderFilter) {
-				return false;
-			}
-		}
-
-		// Status filter (only applied when no project filter is active)
 		if (filters.value.status && filters.value.status !== workflow.status) {
 			return false;
 		}
 
-		return true;
-	});
-});
+		const folderFilter = filters.value.folder?.trim();
+		if (!folderFilter) {
+			return true;
+		}
 
-const sortedWorkflows = computed(() =>
-	orderBy(
-		filteredWorkflows.value,
-		[
-			({ folderPath }) => folderPath?.join('/') ?? '',
-			({ status }) => getPushPriorityByStatus(status),
-			'updatedAt',
-		],
-		['asc', 'asc', 'desc'],
-	),
-);
+		const workflowPath = (workflow.folderPath ?? []).join('/');
+		return workflowPath === folderFilter || workflowPath.startsWith(`${folderFilter}/`);
+	},
+});
 
 const workflowScroller = ref<{ scrollToItem: (index: number) => void; $el?: Element } | null>(null);
 const hasScrolledCurrentWorkflow = ref(false);
@@ -501,67 +492,49 @@ const selectedCredentials = reactive<Set<string>>(new Set());
 
 const selectedDataTables = reactive<Set<string>>(new Set());
 
-const filteredCredentials = computed(() => {
-	const searchQuery = debouncedSearch.value.toLocaleLowerCase();
-
-	return changes.value.credential.filter((credential) => {
-		if (!credential.name.toLocaleLowerCase().includes(searchQuery)) {
+const sortedCredentials = useSourceControlFileList({
+	files: computed(() => changes.value.credential),
+	sortBy: [({ status }) => getPushPriorityByStatus(status), 'updatedAt'],
+	sortOrder: ['asc', 'desc'],
+	filter: (credential) => {
+		const searchQuery = debouncedSearch.value.toLocaleLowerCase().trim();
+		if (searchQuery && !credential.name.toLocaleLowerCase().includes(searchQuery)) {
 			return false;
 		}
 
-		// Project filter logic: if a project filter is set, only show items from that project
-		if (filters.value.project) {
-			// Item must have a project and it must match the filter
-			return credential.project?.id === filters.value.project.id;
+		if (filters.value.project && credential.project?.id !== filters.value.project.id) {
+			return false;
 		}
 
-		// Status filter (only applied when no project filter is active)
 		if (filters.value.status && filters.value.status !== credential.status) {
 			return false;
 		}
 
 		return true;
-	});
+	},
 });
 
-const sortedCredentials = computed(() =>
-	orderBy(
-		filteredCredentials.value,
-		[({ status }) => getPushPriorityByStatus(status), 'updatedAt'],
-		['asc', 'desc'],
-	),
-);
-
-const filteredDataTables = computed(() => {
-	const searchQuery = debouncedSearch.value.toLocaleLowerCase();
-
-	return changes.value.datatable.filter((dataTable) => {
-		if (!dataTable.name.toLocaleLowerCase().includes(searchQuery)) {
+const sortedDataTables = useSourceControlFileList({
+	files: computed(() => changes.value.datatable),
+	sortBy: [({ status }) => getPushPriorityByStatus(status), 'updatedAt'],
+	sortOrder: ['asc', 'desc'],
+	filter: (dataTable) => {
+		const searchQuery = debouncedSearch.value.toLocaleLowerCase().trim();
+		if (searchQuery && !dataTable.name.toLocaleLowerCase().includes(searchQuery)) {
 			return false;
 		}
 
-		// Project filter logic: if a project filter is set, only show items from that project
-		if (filters.value.project) {
-			// Item must have a project and it must match the filter
-			return dataTable.project?.id === filters.value.project.id;
+		if (filters.value.project && dataTable.project?.id !== filters.value.project.id) {
+			return false;
 		}
 
-		// Status filter (only applied when no project filter is active)
 		if (filters.value.status && filters.value.status !== dataTable.status) {
 			return false;
 		}
 
 		return true;
-	});
+	},
 });
-
-const sortedDataTables = computed(() =>
-	orderBy(
-		filteredDataTables.value,
-		[({ status }) => getPushPriorityByStatus(status), 'updatedAt'],
-		['asc', 'desc'],
-	),
-);
 
 const commitMessage = ref('');
 const isSubmitDisabled = computed(() => {
@@ -621,17 +594,7 @@ function close() {
 }
 
 function renderUpdatedAt(file: SourceControlledFile) {
-	const currentYear = new Date().getFullYear().toString();
-
-	return i18n.baseText('settings.sourceControl.lastUpdated', {
-		interpolate: {
-			date: dateformat(
-				file.updatedAt,
-				`d mmm${file.updatedAt?.startsWith(currentYear) ? '' : ', yyyy'}`,
-			),
-			time: dateformat(file.updatedAt, 'HH:MM'),
-		},
-	});
+	return formatSourceControlUpdatedAt(file.updatedAt);
 }
 
 async function onCommitKeyDownEnter() {

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
@@ -385,7 +385,7 @@ const sortedWorkflows = computed(() =>
 	orderBy(
 		filteredWorkflows.value,
 		[
-			// keep the current workflow at the top of the list
+			// Keep the current workflow at the top of the list.
 			({ id }) => id === changes.value.currentWorkflow?.id,
 			({ folderPath }) => folderPath?.join('/') ?? '',
 			({ status }) => getPushPriorityByStatus(status),
@@ -1015,6 +1015,7 @@ onMounted(async () => {
 								v-model="filters.folder"
 								data-test-id="source-control-folder-filter"
 								clearable
+								filterable
 								:placeholder="i18n.baseText('generic.folder')"
 							>
 								<N8nOption
@@ -1157,10 +1158,7 @@ onMounted(async () => {
 										<div
 											v-else
 											:class="$style.fileRow"
-											:style="{
-												marginLeft: `${row.depth * 16}px`,
-												width: `calc(100% - ${row.depth * 16}px)`,
-											}"
+											:style="{ paddingLeft: `${row.depth * 16}px` }"
 										>
 											<N8nCheckbox
 												:class="[$style.listItem]"
@@ -1197,7 +1195,11 @@ onMounted(async () => {
 																"
 																class="mr-2xs"
 															>
-																Current workflow
+																{{
+																	i18n.baseText(
+																		'settings.sourceControl.modals.push.currentWorkflow',
+																	)
+																}}
 															</N8nBadge>
 															<template
 																v-if="
@@ -1393,6 +1395,7 @@ onMounted(async () => {
 
 .fileRow {
 	box-sizing: border-box;
+	width: 100%;
 }
 
 .badges {

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/composables/useRevealWorkflowInScroller.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/composables/useRevealWorkflowInScroller.test.ts
@@ -1,0 +1,115 @@
+import { ref } from 'vue';
+import type { SourceControlledFile } from '@n8n/api-types';
+import { useRevealWorkflowInScroller } from './useRevealWorkflowInScroller';
+
+const createWorkflow = (overrides: Partial<SourceControlledFile> = {}): SourceControlledFile => ({
+	id: 'wf-1',
+	name: 'Workflow 1',
+	type: 'workflow',
+	status: 'created',
+	location: 'local',
+	conflict: false,
+	file: '/wf-1.json',
+	updatedAt: '2025-01-01T00:00:00.000Z',
+	...overrides,
+});
+
+describe('useRevealWorkflowInScroller', () => {
+	it('reveals current workflow and scrolls only once until reset', async () => {
+		const workflowId = 'wf-target';
+		const element = document.createElement('div');
+		element.dataset.workflowId = workflowId;
+		element.scrollIntoView = vi.fn();
+
+		const scrollerRoot = document.createElement('div');
+		scrollerRoot.appendChild(element);
+		const scrollToItem = vi.fn();
+
+		const composable = useRevealWorkflowInScroller({
+			visibleWorkflowRows: ref([
+				{
+					id: `file:${workflowId}`,
+					type: 'file',
+					depth: 0,
+					file: createWorkflow({ id: workflowId }),
+				},
+			]),
+			workflowScroller: ref({ scrollToItem, $el: scrollerRoot }),
+			activeTab: ref('workflow'),
+			workflowTabValue: 'workflow',
+			currentWorkflowId: ref(workflowId),
+			isLoading: ref(false),
+			expandAncestorFolders: vi.fn(),
+		});
+
+		await composable.revealAndScrollToCurrentWorkflow();
+		await composable.revealAndScrollToCurrentWorkflow();
+
+		expect(scrollToItem).toHaveBeenCalledTimes(1);
+		expect(element.scrollIntoView).toHaveBeenCalledTimes(1);
+
+		composable.resetRevealState();
+		await composable.revealAndScrollToCurrentWorkflow();
+
+		expect(scrollToItem).toHaveBeenCalledTimes(2);
+		expect(element.scrollIntoView).toHaveBeenCalledTimes(2);
+	});
+
+	it('does not reveal when tab is not workflow tab', async () => {
+		const scrollToItem = vi.fn();
+		const expandAncestorFolders = vi.fn();
+		const composable = useRevealWorkflowInScroller({
+			visibleWorkflowRows: ref([
+				{
+					id: 'file:wf-target',
+					type: 'file',
+					depth: 0,
+					file: createWorkflow({ id: 'wf-target' }),
+				},
+			]),
+			workflowScroller: ref({ scrollToItem, $el: document.createElement('div') }),
+			activeTab: ref('credential'),
+			workflowTabValue: 'workflow',
+			currentWorkflowId: ref('wf-target'),
+			isLoading: ref(false),
+			expandAncestorFolders,
+		});
+
+		await composable.revealAndScrollToCurrentWorkflow();
+
+		expect(scrollToItem).not.toHaveBeenCalled();
+		expect(expandAncestorFolders).not.toHaveBeenCalled();
+	});
+
+	it('expands ancestor folders before scrolling', async () => {
+		const workflowId = 'wf-target';
+		const element = document.createElement('div');
+		element.dataset.workflowId = workflowId;
+		element.scrollIntoView = vi.fn();
+
+		const scrollerRoot = document.createElement('div');
+		scrollerRoot.appendChild(element);
+
+		const expandAncestorFolders = vi.fn();
+		const composable = useRevealWorkflowInScroller({
+			visibleWorkflowRows: ref([
+				{
+					id: `file:${workflowId}`,
+					type: 'file',
+					depth: 2,
+					file: createWorkflow({ id: workflowId, folderPath: ['A', 'B'] }),
+				},
+			]),
+			workflowScroller: ref({ scrollToItem: vi.fn(), $el: scrollerRoot }),
+			activeTab: ref('workflow'),
+			workflowTabValue: 'workflow',
+			currentWorkflowId: ref(workflowId),
+			isLoading: ref(false),
+			expandAncestorFolders,
+		});
+
+		await composable.revealAndScrollToCurrentWorkflow();
+
+		expect(expandAncestorFolders).toHaveBeenCalledWith(workflowId);
+	});
+});

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/composables/useRevealWorkflowInScroller.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/composables/useRevealWorkflowInScroller.test.ts
@@ -15,7 +15,7 @@ const createWorkflow = (overrides: Partial<SourceControlledFile> = {}): SourceCo
 });
 
 describe('useRevealWorkflowInScroller', () => {
-	it('reveals current workflow and scrolls only once until reset', async () => {
+	it('reveals current workflow and scrolls only once', async () => {
 		const workflowId = 'wf-target';
 		const element = document.createElement('div');
 		element.dataset.workflowId = workflowId;
@@ -47,12 +47,6 @@ describe('useRevealWorkflowInScroller', () => {
 
 		expect(scrollToItem).toHaveBeenCalledTimes(1);
 		expect(element.scrollIntoView).toHaveBeenCalledTimes(1);
-
-		composable.resetRevealState();
-		await composable.revealAndScrollToCurrentWorkflow();
-
-		expect(scrollToItem).toHaveBeenCalledTimes(2);
-		expect(element.scrollIntoView).toHaveBeenCalledTimes(2);
 	});
 
 	it('does not reveal when tab is not workflow tab', async () => {
@@ -97,7 +91,7 @@ describe('useRevealWorkflowInScroller', () => {
 					id: `file:${workflowId}`,
 					type: 'file',
 					depth: 2,
-					file: createWorkflow({ id: workflowId, folderPath: ['A', 'B'] }),
+					file: createWorkflow({ id: workflowId }),
 				},
 			]),
 			workflowScroller: ref({ scrollToItem: vi.fn(), $el: scrollerRoot }),

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/composables/useRevealWorkflowInScroller.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/composables/useRevealWorkflowInScroller.ts
@@ -1,0 +1,84 @@
+import type { SourceControlledFile } from '@n8n/api-types';
+import type { SourceControlTreeRow } from '../sourceControl.types';
+import { nextTick, ref, type Ref } from 'vue';
+
+type WorkflowScroller = { scrollToItem: (index: number) => void; $el?: Element };
+
+export function useRevealWorkflowInScroller<T extends SourceControlledFile>({
+	visibleWorkflowRows,
+	workflowScroller,
+	activeTab,
+	workflowTabValue,
+	currentWorkflowId,
+	isLoading,
+	expandAncestorFolders,
+}: {
+	visibleWorkflowRows: Readonly<Ref<Array<SourceControlTreeRow<T>>>>;
+	workflowScroller: Readonly<Ref<WorkflowScroller | null>>;
+	activeTab: Readonly<Ref<string>>;
+	workflowTabValue: string;
+	currentWorkflowId: Readonly<Ref<string | undefined>>;
+	isLoading: Readonly<Ref<boolean>>;
+	expandAncestorFolders: (workflowId: string) => void;
+}) {
+	const hasScrolledCurrentWorkflow = ref(false);
+	const isRevealInProgress = ref(false);
+
+	function getCurrentWorkflowRowElement(workflowId: string): HTMLElement | null {
+		const scrollerRoot = workflowScroller.value?.$el;
+		if (!(scrollerRoot instanceof Element)) {
+			return null;
+		}
+
+		return scrollerRoot.querySelector<HTMLElement>(`[data-workflow-id="${workflowId}"]`);
+	}
+
+	async function revealAndScrollToCurrentWorkflow() {
+		const isWorkflowTab = activeTab.value === workflowTabValue;
+		if (
+			isRevealInProgress.value ||
+			hasScrolledCurrentWorkflow.value ||
+			!isWorkflowTab ||
+			!currentWorkflowId.value ||
+			isLoading.value
+		) {
+			return;
+		}
+
+		isRevealInProgress.value = true;
+		try {
+			expandAncestorFolders(currentWorkflowId.value);
+
+			for (let attempt = 0; attempt < 6; attempt++) {
+				if (attempt > 0) {
+					// Wait for DOM updates after folder expansion before retrying lookup.
+					await nextTick();
+				}
+
+				const visibleIndex = visibleWorkflowRows.value.findIndex(
+					(row) => row.type === 'file' && row.file.id === currentWorkflowId.value,
+				);
+				const scroller = workflowScroller.value;
+
+				if (visibleIndex >= 0 && scroller) {
+					scroller.scrollToItem(visibleIndex);
+
+					const workflowRowElement = getCurrentWorkflowRowElement(currentWorkflowId.value);
+					if (!workflowRowElement) {
+						continue;
+					}
+
+					workflowRowElement.scrollIntoView({ block: 'center', inline: 'nearest' });
+					hasScrolledCurrentWorkflow.value = true;
+					return;
+				}
+			}
+		} finally {
+			isRevealInProgress.value = false;
+		}
+	}
+
+	return {
+		revealAndScrollToCurrentWorkflow,
+	};
+}

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/composables/useRevealWorkflowInScroller.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/composables/useRevealWorkflowInScroller.ts
@@ -78,12 +78,5 @@ export function useRevealWorkflowInScroller<T extends SourceControlledFile>({
 		}
 	}
 
-	function resetRevealState() {
-		hasScrolledCurrentWorkflow.value = false;
-	}
-
-	return {
-		revealAndScrollToCurrentWorkflow,
-		resetRevealState,
-	};
+	return { revealAndScrollToCurrentWorkflow };
 }

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/composables/useRevealWorkflowInScroller.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/composables/useRevealWorkflowInScroller.ts
@@ -78,7 +78,12 @@ export function useRevealWorkflowInScroller<T extends SourceControlledFile>({
 		}
 	}
 
+	function resetRevealState() {
+		hasScrolledCurrentWorkflow.value = false;
+	}
+
 	return {
 		revealAndScrollToCurrentWorkflow,
+		resetRevealState,
 	};
 }

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/composables/useSourceControlFileList.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/composables/useSourceControlFileList.test.ts
@@ -1,0 +1,46 @@
+import { ref } from 'vue';
+import { useSourceControlFileList } from './useSourceControlFileList';
+import type { SourceControlledFile } from '@n8n/api-types';
+
+const createFile = (overrides: Partial<SourceControlledFile> = {}): SourceControlledFile => ({
+	id: 'wf-1',
+	name: 'Workflow 1',
+	type: 'workflow',
+	status: 'created',
+	location: 'local',
+	conflict: false,
+	file: '/wf-1.json',
+	updatedAt: '2025-01-01T00:00:00.000Z',
+	...overrides,
+});
+
+describe('useSourceControlFileList', () => {
+	it('sorts files with provided sort configuration', () => {
+		const files = ref([createFile({ id: '2', name: 'B' }), createFile({ id: '1', name: 'A' })]);
+
+		const list = useSourceControlFileList({
+			files,
+			sortBy: ['name'],
+			sortOrder: ['asc'],
+		});
+
+		expect(list.value.map((item) => item.id)).toEqual(['1', '2']);
+	});
+
+	it('applies filter before sorting', () => {
+		const files = ref([
+			createFile({ id: 'created', status: 'created', updatedAt: '2025-01-01T00:00:00.000Z' }),
+			createFile({ id: 'modified', status: 'modified', updatedAt: '2025-02-01T00:00:00.000Z' }),
+			createFile({ id: 'deleted', status: 'deleted', updatedAt: '2025-03-01T00:00:00.000Z' }),
+		]);
+
+		const list = useSourceControlFileList({
+			files,
+			sortBy: ['updatedAt'],
+			sortOrder: ['desc'],
+			filter: (file) => file.status !== 'deleted',
+		});
+
+		expect(list.value.map((item) => item.id)).toEqual(['modified', 'created']);
+	});
+});

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/composables/useSourceControlFileList.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/composables/useSourceControlFileList.ts
@@ -1,0 +1,33 @@
+import type { SourceControlledFile } from '@n8n/api-types';
+import orderBy from 'lodash/orderBy';
+import { computed, type Ref } from 'vue';
+
+type SourceControlledFileWithOptionalProject = SourceControlledFile & {
+	project?: { id: string };
+};
+
+type SortByEntry<T extends SourceControlledFileWithOptionalProject> =
+	| keyof T
+	| ((file: T) => unknown);
+
+type UseSourceControlFileListOptions<T extends SourceControlledFileWithOptionalProject> = {
+	files: Readonly<Ref<T[]>>;
+	sortBy: Array<SortByEntry<T>>;
+	sortOrder: Array<'asc' | 'desc'>;
+	filter?: (file: T) => boolean;
+};
+
+export function useSourceControlFileList<T extends SourceControlledFileWithOptionalProject>({
+	files,
+	sortBy,
+	sortOrder,
+	filter,
+}: UseSourceControlFileListOptions<T>) {
+	const list = computed(() => {
+		const filtered = filter ? files.value.filter(filter) : files.value;
+		const ordered = orderBy(filtered, sortBy, sortOrder);
+		return ordered;
+	});
+
+	return list;
+}

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/composables/useWorkflowTreeRows.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/composables/useWorkflowTreeRows.test.ts
@@ -1,0 +1,54 @@
+import { ref } from 'vue';
+import type { SourceControlledFile } from '@n8n/api-types';
+import { useWorkflowTreeRows } from './useWorkflowTreeRows';
+
+const createWorkflow = (overrides: Partial<SourceControlledFile> = {}): SourceControlledFile => ({
+	id: 'wf-1',
+	name: 'Workflow 1',
+	type: 'workflow',
+	status: 'created',
+	location: 'local',
+	conflict: false,
+	file: '/wf-1.json',
+	updatedAt: '2025-01-01T00:00:00.000Z',
+	...overrides,
+});
+
+describe('useWorkflowTreeRows', () => {
+	it('hides descendants when a folder is collapsed and reveals them when expanded', () => {
+		const workflows = ref<SourceControlledFile[]>([
+			createWorkflow({ id: 'wf-a', folderPath: ['Prod', 'Billing'] }),
+			createWorkflow({ id: 'wf-b', folderPath: ['Prod', 'Support'] }),
+		]);
+
+		const tree = useWorkflowTreeRows(workflows);
+
+		expect(tree.visibleWorkflowRows.value.some((row) => row.type === 'file')).toBe(true);
+
+		tree.toggleFolderCollapse('folder:Prod');
+		expect(tree.isFolderCollapsed('folder:Prod')).toBe(true);
+		expect(tree.visibleWorkflowRows.value.map((row) => row.id)).toEqual(['folder:Prod']);
+
+		tree.toggleFolderCollapse('folder:Prod');
+		expect(tree.isFolderCollapsed('folder:Prod')).toBe(false);
+		expect(tree.visibleWorkflowRows.value.some((row) => row.type === 'file')).toBe(true);
+	});
+
+	it('returns ancestor folders for workflow and supports expandFolders', () => {
+		const workflows = ref<SourceControlledFile[]>([
+			createWorkflow({ id: 'wf-target', folderPath: ['Prod', 'Billing'] }),
+		]);
+
+		const tree = useWorkflowTreeRows(workflows);
+		const ancestors = tree.getAncestorFolderIdsForWorkflow('wf-target');
+
+		expect(ancestors).toEqual(['folder:Prod', 'folder:Prod/Billing']);
+
+		tree.toggleFolderCollapse('folder:Prod');
+		tree.toggleFolderCollapse('folder:Prod/Billing');
+		tree.expandFolders(ancestors);
+
+		expect(tree.isFolderCollapsed('folder:Prod')).toBe(false);
+		expect(tree.isFolderCollapsed('folder:Prod/Billing')).toBe(false);
+	});
+});

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/composables/useWorkflowTreeRows.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/composables/useWorkflowTreeRows.ts
@@ -1,0 +1,85 @@
+import type { SourceControlledFile } from '@n8n/api-types';
+import type { SourceControlTreeRow } from '../sourceControl.types';
+import { buildWorkflowTreeRows } from '../sourceControl.utils';
+import { computed, ref, type Ref } from 'vue';
+
+export function useWorkflowTreeRows<T extends SourceControlledFile>(workflows: Readonly<Ref<T[]>>) {
+	const collapsedFolderIds = ref<Set<string>>(new Set());
+
+	const workflowTreeRows = computed<Array<SourceControlTreeRow<T>>>(() =>
+		buildWorkflowTreeRows(workflows.value),
+	);
+
+	const visibleWorkflowRows = computed<Array<SourceControlTreeRow<T>>>(() => {
+		const visibleRows: Array<SourceControlTreeRow<T>> = [];
+		const collapsedDepths: number[] = [];
+
+		for (const row of workflowTreeRows.value) {
+			while (collapsedDepths.length && row.depth <= collapsedDepths[collapsedDepths.length - 1]) {
+				collapsedDepths.pop();
+			}
+
+			if (collapsedDepths.length) {
+				continue;
+			}
+
+			visibleRows.push(row);
+
+			if (row.type === 'folder' && collapsedFolderIds.value.has(row.id)) {
+				collapsedDepths.push(row.depth);
+			}
+		}
+
+		return visibleRows;
+	});
+
+	function isFolderCollapsed(folderId: string) {
+		return collapsedFolderIds.value.has(folderId);
+	}
+
+	function toggleFolderCollapse(folderId: string) {
+		if (collapsedFolderIds.value.has(folderId)) {
+			collapsedFolderIds.value.delete(folderId);
+			return;
+		}
+
+		collapsedFolderIds.value.add(folderId);
+	}
+
+	function expandFolders(folderIds: string[]) {
+		for (const folderId of folderIds) {
+			collapsedFolderIds.value.delete(folderId);
+		}
+	}
+
+	function getAncestorFolderIdsForWorkflow(workflowId: string): string[] {
+		const ancestorStack: Array<{ id: string; depth: number }> = [];
+
+		for (const row of workflowTreeRows.value) {
+			while (ancestorStack.length && row.depth <= ancestorStack[ancestorStack.length - 1].depth) {
+				ancestorStack.pop();
+			}
+
+			if (row.type === 'folder') {
+				ancestorStack.push({ id: row.id, depth: row.depth });
+				continue;
+			}
+
+			if (row.file.id === workflowId) {
+				return ancestorStack.map(({ id }) => id);
+			}
+		}
+
+		return [];
+	}
+
+	return {
+		collapsedFolderIds,
+		workflowTreeRows,
+		visibleWorkflowRows,
+		isFolderCollapsed,
+		toggleFolderCollapse,
+		expandFolders,
+		getAncestorFolderIdsForWorkflow,
+	};
+}

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/sourceControl.types.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/sourceControl.types.ts
@@ -1,3 +1,4 @@
+import type { SourceControlledFile } from '@n8n/api-types';
 import type { TupleToUnion } from '@/app/utils/typeHelpers';
 
 export type SshKeyTypes = ['ed25519', 'rsa'];
@@ -14,6 +15,10 @@ export type SourceControlPreferences = {
 	currentBranch?: string;
 	connectionType?: 'ssh' | 'https';
 };
+
+export type SourceControlTreeRow<T extends SourceControlledFile = SourceControlledFile> =
+	| { id: string; type: 'folder'; name: string; depth: number }
+	| { id: string; type: 'file'; depth: number; file: T };
 
 export interface SourceControlStatus {
 	ahead: number;

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/sourceControl.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/sourceControl.utils.test.ts
@@ -1,4 +1,5 @@
 import {
+	buildWorkflowTreeRows,
 	getStatusText,
 	getStatusTheme,
 	getPullPriorityByStatus,
@@ -34,6 +35,78 @@ describe('source control utils', () => {
 	describe('getPushPriorityByStatus()', () => {
 		it('defaults to 0', () => {
 			expect(getPushPriorityByStatus(SOURCE_CONTROL_FILE_STATUS.new)).toBe(0);
+		});
+	});
+
+	describe('buildWorkflowTreeRows()', () => {
+		it('builds folder and file rows with nested depth', () => {
+			const rows = buildWorkflowTreeRows([
+				{
+					id: 'wf-root',
+					name: 'Root',
+					type: 'workflow',
+					status: 'created',
+					location: 'local',
+					conflict: false,
+					file: '/wf-root.json',
+					updatedAt: '2025-01-01T00:00:00.000Z',
+				},
+				{
+					id: 'wf-nested',
+					name: 'Nested',
+					type: 'workflow',
+					status: 'created',
+					location: 'local',
+					conflict: false,
+					file: '/wf-nested.json',
+					updatedAt: '2025-01-01T00:00:00.000Z',
+					folderPath: ['Prod', 'Billing'],
+				},
+			]);
+
+			expect(rows).toEqual([
+				expect.objectContaining({ id: 'file:wf-root', type: 'file', depth: 0 }),
+				expect.objectContaining({ id: 'folder:Prod', type: 'folder', depth: 0, name: 'Prod' }),
+				expect.objectContaining({
+					id: 'folder:Prod/Billing',
+					type: 'folder',
+					depth: 1,
+					name: 'Billing',
+				}),
+				expect.objectContaining({ id: 'file:wf-nested', type: 'file', depth: 2 }),
+			]);
+		});
+
+		it('does not duplicate folders shared by multiple workflows', () => {
+			const rows = buildWorkflowTreeRows([
+				{
+					id: 'wf-1',
+					name: 'One',
+					type: 'workflow',
+					status: 'created',
+					location: 'local',
+					conflict: false,
+					file: '/wf-1.json',
+					updatedAt: '2025-01-01T00:00:00.000Z',
+					folderPath: ['Prod'],
+				},
+				{
+					id: 'wf-2',
+					name: 'Two',
+					type: 'workflow',
+					status: 'created',
+					location: 'local',
+					conflict: false,
+					file: '/wf-2.json',
+					updatedAt: '2025-01-01T00:00:00.000Z',
+					folderPath: ['Prod'],
+				},
+			]);
+
+			expect(rows.filter((row) => row.type === 'folder' && row.id === 'folder:Prod')).toHaveLength(
+				1,
+			);
+			expect(rows.filter((row) => row.type === 'file')).toHaveLength(2);
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/sourceControl.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/sourceControl.utils.test.ts
@@ -1,5 +1,6 @@
 import {
 	buildWorkflowTreeRows,
+	formatSourceControlUpdatedAt,
 	getStatusText,
 	getStatusTheme,
 	getPullPriorityByStatus,
@@ -107,6 +108,17 @@ describe('source control utils', () => {
 				1,
 			);
 			expect(rows.filter((row) => row.type === 'file')).toHaveLength(2);
+		});
+	});
+
+	describe('formatSourceControlUpdatedAt()', () => {
+		it('includes year for dates from previous years', () => {
+			const lastYear = new Date().getFullYear() - 1;
+			const value = formatSourceControlUpdatedAt(`${lastYear}-01-02T03:04:00.000Z`);
+
+			expect(value).toContain('2 Jan');
+			expect(value).toContain(String(lastYear));
+			expect(value).toContain('03:04');
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/sourceControl.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/sourceControl.utils.test.ts
@@ -1,4 +1,5 @@
 import {
+	buildFolderFilterOptions,
 	buildWorkflowTreeRows,
 	formatSourceControlUpdatedAt,
 	getStatusText,
@@ -108,6 +109,81 @@ describe('source control utils', () => {
 				1,
 			);
 			expect(rows.filter((row) => row.type === 'file')).toHaveLength(2);
+		});
+	});
+
+	describe('buildFolderFilterOptions()', () => {
+		it('builds deduplicated hierarchical options sorted by depth then name', () => {
+			const options = buildFolderFilterOptions([
+				{
+					id: 'wf-alpha',
+					name: 'Alpha',
+					type: 'workflow',
+					status: 'created',
+					location: 'local',
+					conflict: false,
+					file: '/wf-alpha.json',
+					updatedAt: '2025-01-01T00:00:00.000Z',
+					folderPath: ['Alpha'],
+				},
+				{
+					id: 'wf-prod-billing',
+					name: 'Prod Billing',
+					type: 'workflow',
+					status: 'created',
+					location: 'local',
+					conflict: false,
+					file: '/wf-prod-billing.json',
+					updatedAt: '2025-01-01T00:00:00.000Z',
+					folderPath: ['Prod', 'Billing'],
+				},
+				{
+					id: 'wf-prod-analytics',
+					name: 'Prod Analytics',
+					type: 'workflow',
+					status: 'created',
+					location: 'local',
+					conflict: false,
+					file: '/wf-prod-analytics.json',
+					updatedAt: '2025-01-01T00:00:00.000Z',
+					folderPath: ['Prod', 'Analytics'],
+				},
+				{
+					id: 'wf-prod-root',
+					name: 'Prod Root',
+					type: 'workflow',
+					status: 'created',
+					location: 'local',
+					conflict: false,
+					file: '/wf-prod-root.json',
+					updatedAt: '2025-01-01T00:00:00.000Z',
+					folderPath: ['Prod'],
+				},
+			]);
+
+			expect(options).toEqual([
+				{ label: 'Alpha', value: 'Alpha' },
+				{ label: 'Prod', value: 'Prod' },
+				{ label: 'Prod / Analytics', value: 'Prod/Analytics' },
+				{ label: 'Prod / Billing', value: 'Prod/Billing' },
+			]);
+		});
+
+		it('returns empty array when workflows have no folder paths', () => {
+			const options = buildFolderFilterOptions([
+				{
+					id: 'wf-root',
+					name: 'Root',
+					type: 'workflow',
+					status: 'created',
+					location: 'local',
+					conflict: false,
+					file: '/wf-root.json',
+					updatedAt: '2025-01-01T00:00:00.000Z',
+				},
+			]);
+
+			expect(options).toEqual([]);
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/sourceControl.utils.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/sourceControl.utils.ts
@@ -7,6 +7,7 @@ import { VIEWS } from '@/app/constants';
 import groupBy from 'lodash/groupBy';
 import type { useToast } from '@/app/composables/useToast';
 import { telemetry } from '@/app/plugins/telemetry';
+import type { SourceControlTreeRow } from './sourceControl.types';
 
 type SourceControlledFileStatus = SourceControlledFile['status'];
 
@@ -172,6 +173,42 @@ const pullMessage = ({
 		}),
 	].join(' ');
 };
+
+export function buildWorkflowTreeRows<T extends SourceControlledFile>(
+	workflows: T[],
+): Array<SourceControlTreeRow<T>> {
+	const rows: Array<SourceControlTreeRow<T>> = [];
+	const seenFolders = new Set<string>();
+
+	for (const workflow of workflows) {
+		const path = workflow.folderPath ?? [];
+		let pathKey = '';
+
+		for (const [index, segment] of path.entries()) {
+			pathKey = pathKey ? `${pathKey}/${segment}` : segment;
+			if (seenFolders.has(pathKey)) {
+				continue;
+			}
+
+			rows.push({
+				id: `folder:${pathKey}`,
+				type: 'folder',
+				name: segment,
+				depth: index,
+			});
+			seenFolders.add(pathKey);
+		}
+
+		rows.push({
+			id: `file:${workflow.id}`,
+			type: 'file',
+			file: workflow,
+			depth: path.length,
+		});
+	}
+
+	return rows;
+}
 
 export const notifyUserAboutPullWorkFolderOutcome = async (
 	files: SourceControlledFile[],

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/sourceControl.utils.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/sourceControl.utils.ts
@@ -211,6 +211,33 @@ export function buildWorkflowTreeRows<T extends SourceControlledFile>(
 	return rows;
 }
 
+export const buildFolderFilterOptions = (workflows: SourceControlledFile[]) => {
+	const folderPathSet = new Set<string>();
+
+	for (const workflow of workflows) {
+		const pathSegments = workflow.folderPath ?? [];
+		let path = '';
+
+		for (const segment of pathSegments) {
+			path = path ? `${path}/${segment}` : segment;
+			folderPathSet.add(path);
+		}
+	}
+
+	return Array.from(folderPathSet)
+		.sort((a, b) => {
+			const depthDiff = a.split('/').length - b.split('/').length;
+			if (depthDiff !== 0) {
+				return depthDiff;
+			}
+			return a.localeCompare(b);
+		})
+		.map((path) => ({
+			label: path.replaceAll('/', ' / '),
+			value: path,
+		}));
+};
+
 export const formatSourceControlUpdatedAt = (updatedAt: string | undefined) => {
 	const currentYear = new Date().getFullYear().toString();
 

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/sourceControl.utils.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/sourceControl.utils.ts
@@ -5,6 +5,7 @@ import { type SourceControlledFile, SOURCE_CONTROL_FILE_STATUS } from '@n8n/api-
 import type { BaseTextKey } from '@n8n/i18n';
 import { VIEWS } from '@/app/constants';
 import groupBy from 'lodash/groupBy';
+import dateformat from 'dateformat';
 import type { useToast } from '@/app/composables/useToast';
 import { telemetry } from '@/app/plugins/telemetry';
 import type { SourceControlTreeRow } from './sourceControl.types';
@@ -209,6 +210,17 @@ export function buildWorkflowTreeRows<T extends SourceControlledFile>(
 
 	return rows;
 }
+
+export const formatSourceControlUpdatedAt = (updatedAt: string | undefined) => {
+	const currentYear = new Date().getFullYear().toString();
+
+	return i18n.baseText('settings.sourceControl.lastUpdated', {
+		interpolate: {
+			date: dateformat(updatedAt, `d mmm${updatedAt?.startsWith(currentYear) ? '' : ', yyyy'}`),
+			time: dateformat(updatedAt, 'HH:MM'),
+		},
+	});
+};
 
 export const notifyUserAboutPullWorkFolderOutcome = async (
 	files: SourceControlledFile[],


### PR DESCRIPTION
## Summary

https://www.loom.com/share/dbc0c0524a944badba2a409e432619ea

- Adds folder/path data (`parentFolderId`, `folderPath`) to source control status responses in the backend
- Displays workflows in a hierarchical folder tree view in the **Push** and **Pull** source control modals
- Push modal: adds folder rows with checkboxes that select/deselect all child workflows (with indeterminate state support)
- Push modal: adds a folder filter to the filters panel so users can scope the list to a specific folder path
- Adds `buildWorkflowTreeRows` utility and `SourceControlTreeRow` type shared between both modals

> **Note:** This is a proof-of-concept branch to validate the UX approach before full implementation.

## How to test

1. Set up source control on an n8n instance with workflows organised in folders
2. Open the **Push** modal — workflows should appear grouped under their folder path with folder checkboxes
3. Clicking a folder checkbox should check/uncheck all workflows within that folder
4. The **Folder** filter in the filters panel should narrow the list to workflows under the selected path
5. Open the **Pull** modal — workflows should appear in the same folder-grouped order

## Related Linear tickets, Github issues, and Community forum posts

<!-- Link to Linear ticket: https://linear.app/n8n/issue/[TICKET-ID] -->
https://linear.app/n8n/issue/LIGO-316

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)