### PR TITLE
fix(editor): Adjust chat input styling after design system update (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
@@ -1005,23 +1005,24 @@ function onFilesDropped(files: File[]) {
 }
 
 .promptContainer {
+	position: absolute;
+	bottom: 0;
 	display: flex;
 	justify-content: center;
 	padding-block: var(--spacing--md);
+	background: var(--color--background--light-2);
+	left: 50%;
+	transform: translateX(-50%);
 
 	.isMobileDevice &,
 	.isExistingSession & {
 		position: absolute;
 		bottom: 0;
-		left: 0;
-		width: 100%;
-		padding-block: var(--spacing--md);
-		background: var(--color--background--light-2);
 	}
 }
 
 .messageList,
-.prompt {
+.promptContainer {
 	width: 100%;
 	max-width: 88ch;
 	padding-inline: 64px;
@@ -1033,7 +1034,7 @@ function onFilesDropped(files: File[]) {
 
 .scrollToBottomButton {
 	position: absolute;
-	bottom: 100%;
+	bottom: calc(100% + var(--spacing--md));
 	left: auto;
 	box-shadow: 0 4px 12px 0 rgba(0, 0, 0, 0.15);
 	border-radius: 50%;

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatConversationHeader.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatConversationHeader.vue
@@ -8,7 +8,7 @@ import type {
 	ChatModelDto,
 	ChatSessionId,
 } from '@n8n/api-types';
-import { N8nButton } from '@n8n/design-system';
+import { N8nButton, N8nIconButton } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
 import { computed, useTemplateRef, watch, ref } from 'vue';
 import { useChatStore } from '../chat.store';
@@ -94,37 +94,38 @@ defineExpose({
 				"
 			/>
 		</div>
-		<N8nButton
-			v-if="showArtifactIcon"
-			variant="subtle"
-			size="medium"
-			icon="notebook-pen"
-			@click="emit('reopenArtifact')"
-		/>
-		<N8nButton
-			variant="subtle"
-			v-if="selectedModel?.model.provider === 'custom-agent'"
-			:class="$style.editAgent"
-			size="small"
-			icon="settings"
-			:label="i18n.baseText('chatHub.chat.header.button.editAgent')"
-			@click="emit('editCustomAgent', selectedModel.model.agentId)"
-		/>
-		<N8nButton
-			variant="subtle"
-			v-if="showOpenWorkflow"
-			:class="$style.editAgent"
-			size="small"
-			icon="settings"
-			:label="i18n.baseText('chatHub.chat.header.button.openWorkflow')"
-			@click="onOpenWorkflow"
-		/>
+		<div :class="$style.buttons">
+			<N8nButton
+				variant="subtle"
+				v-if="selectedModel?.model.provider === 'custom-agent'"
+				size="small"
+				icon="settings"
+				:label="i18n.baseText('chatHub.chat.header.button.editAgent')"
+				@click="emit('editCustomAgent', selectedModel.model.agentId)"
+			/>
+			<N8nIconButton
+				v-if="showArtifactIcon"
+				variant="subtle"
+				size="small"
+				icon="panel-right"
+				@click="emit('reopenArtifact')"
+			/>
+			<N8nButton
+				v-if="showOpenWorkflow"
+				variant="subtle"
+				size="small"
+				icon="settings"
+				:label="i18n.baseText('chatHub.chat.header.button.openWorkflow')"
+				@click="onOpenWorkflow"
+			/>
+		</div>
 	</div>
 </template>
 
 <style lang="scss" module>
 .component {
-	padding-inline: var(--spacing--4xs);
+	padding-left: var(--spacing--4xs);
+	padding-right: var(--spacing--xs);
 	height: 56px;
 	flex-grow: 0;
 	flex-shrink: 0;
@@ -149,7 +150,9 @@ defineExpose({
 	margin-inline: var(--spacing--md);
 }
 
-.editAgent {
-	margin-right: var(--spacing--3xs);
+.buttons {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing--2xs);
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
@@ -571,7 +571,7 @@ onBeforeMount(() => {
 	padding: var(--spacing--sm);
 	padding-top: calc(var(--spacing--sm) + var(--attachments--height));
 	padding-bottom: 64px;
-	color: var(----color--text--shade-1);
+	color: var(--color--text--shade-1);
 }
 
 .fileInput {

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatMessage.vue
@@ -8,7 +8,7 @@ import type {
 	ChatModelDto,
 } from '@n8n/api-types';
 import { N8nButton, N8nIcon, N8nIconButton, N8nInput } from '@n8n/design-system';
-import { useSpeechSynthesis } from '@vueuse/core';
+import { useElementSize, useSpeechSynthesis } from '@vueuse/core';
 import {
 	computed,
 	onBeforeMount,
@@ -84,6 +84,8 @@ const newFiles = ref<File[]>([]);
 const removedExistingIndices = ref<Set<number>>(new Set());
 const fileInputRef = useTemplateRef<HTMLInputElement>('fileInputRef');
 const textareaRef = useTemplateRef<InstanceType<typeof N8nInput>>('textarea');
+const attachmentsRef = useTemplateRef('attachmentsRef');
+const attachmentsElSize = useElementSize(attachmentsRef, undefined, { box: 'border-box' });
 const markdownChunkRefs = useTemplateRef<
 	Array<ComponentPublicInstance<{
 		hoveredCodeBlockActions: HTMLElement | null;
@@ -340,9 +342,14 @@ onBeforeMount(() => {
 				multiple
 				@change="handleFileSelect"
 			/>
-			<div v-if="isEditing" :class="$style.editContainer">
+			<div
+				v-if="isEditing"
+				:class="$style.editContainer"
+				:style="{ '--attachments--height': `${attachmentsElSize.height.value}px` }"
+			>
 				<div
 					v-if="message.type === 'human' && mergedAttachments.length > 0"
+					ref="attachmentsRef"
 					:class="$style.attachments"
 				>
 					<ChatFile
@@ -491,6 +498,13 @@ onBeforeMount(() => {
 	.chatMessage & {
 		margin-top: var(--spacing--xs);
 	}
+
+	.editContainer & {
+		position: absolute;
+		top: 0;
+		padding: var(--spacing--sm);
+		padding-bottom: 0;
+	}
 }
 
 .chatMessage {
@@ -544,19 +558,7 @@ onBeforeMount(() => {
 
 .editContainer {
 	width: 100%;
-	border-radius: var(--radius--lg);
-	padding: var(--spacing--xs);
-	background-color: var(--color--background--light-3);
-	border: var(--border);
-	display: flex;
-	flex-direction: column;
-	gap: var(--spacing--sm);
-	transition: border-color 0.2s cubic-bezier(0.645, 0.045, 0.355, 1);
-
-	&:focus-within,
-	&:hover {
-		border-color: var(--color--secondary);
-	}
+	position: relative;
 }
 
 .textarea {
@@ -566,10 +568,10 @@ onBeforeMount(() => {
 .textarea textarea {
 	font-family: inherit;
 	line-height: 1.5em;
-	resize: none;
-	background-color: transparent !important;
-	border: none !important;
-	padding: 0 !important;
+	padding: var(--spacing--sm);
+	padding-top: calc(var(--spacing--sm) + var(--attachments--height));
+	padding-bottom: 64px;
+	color: var(----color--text--shade-1);
 }
 
 .fileInput {
@@ -577,9 +579,18 @@ onBeforeMount(() => {
 }
 
 .editFooter {
+	position: absolute;
+	bottom: 0;
+	width: 100%;
+	padding: var(--spacing--xs);
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
+	pointer-events: none;
+
+	& > * {
+		pointer-events: auto;
+	}
 }
 
 .editActions {

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatPrompt.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatPrompt.vue
@@ -475,7 +475,7 @@ defineExpose({
 		padding: var(--spacing--sm);
 		padding-top: calc(var(--spacing--sm) + var(--attachments-el--height));
 		padding-bottom: 64px;
-		color: var(----color--text--shade-1);
+		color: var(--color--text--shade-1);
 		box-shadow: 0 10px 24px 0 #00000010;
 		border-radius: 16px;
 

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatPrompt.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatPrompt.vue
@@ -12,7 +12,7 @@ import {
 	N8nTooltip,
 	N8nCallout,
 } from '@n8n/design-system';
-import { useSpeechRecognition } from '@vueuse/core';
+import { useElementSize, useSpeechRecognition } from '@vueuse/core';
 import { computed, ref, useTemplateRef, watch } from 'vue';
 import ToolsSelector from './ToolsSelector.vue';
 import {
@@ -54,6 +54,8 @@ const fileInputRef = useTemplateRef<HTMLInputElement>('fileInputRef');
 const message = ref('');
 const committedSpokenMessage = ref('');
 const attachments = ref<File[]>([]);
+const attachmentsEl = useTemplateRef('attachmentsEl');
+const attachmentsElSize = useElementSize(attachmentsEl, undefined, { box: 'border-box' });
 
 const toast = useToast();
 const i18n = useI18n();
@@ -83,18 +85,10 @@ const acceptedMimeTypes = computed(() =>
 
 const canUploadFiles = computed(() => props.selectedModel?.metadata.allowFileUploads ?? false);
 
-const showMisisngAgentCallout = computed(() => props.messagingState === 'missingAgent');
+const showMissingAgentCallout = computed(() => props.messagingState === 'missingAgent');
 const showMissingCredentialsCallout = computed(
 	() => props.messagingState === 'missingCredentials' && !!llmProvider.value,
 );
-const calloutVisible = computed(() => {
-	return (
-		showMisisngAgentCallout.value ||
-		showMissingCredentialsCallout.value ||
-		props.showDynamicCredentialsMissingCallout ||
-		props.showCreditsClaimedCallout
-	);
-});
 
 function onMic() {
 	committedSpokenMessage.value = message.value;
@@ -158,10 +152,6 @@ function handleKeydownTextarea(e: KeyboardEvent) {
 		speechInput.stop();
 		emit('submit', trimmed, attachments.value);
 	}
-}
-
-function handleClickInputWrapper() {
-	inputRef.value?.focus();
 }
 
 watch(speechInput.result, (spoken) => {
@@ -233,10 +223,23 @@ defineExpose({
 </script>
 
 <template>
-	<form :class="$style.prompt" @submit.prevent="handleSubmitForm">
-		<div :class="$style.inputWrap">
+	<form
+		:class="$style.prompt"
+		:style="{ '--attachments-el--height': `${attachmentsElSize.height.value}px` }"
+		@submit.prevent="handleSubmitForm"
+	>
+		<input
+			ref="fileInputRef"
+			type="file"
+			:class="$style.fileInput"
+			:accept="acceptedMimeTypes"
+			multiple
+			@change="handleFileSelect"
+		/>
+
+		<div :class="$style.header">
 			<N8nCallout
-				v-if="showMisisngAgentCallout"
+				v-if="showMissingAgentCallout"
 				icon="info"
 				theme="secondary"
 				:class="$style.callout"
@@ -343,111 +346,97 @@ defineExpose({
 				</template>
 			</N8nCallout>
 
-			<input
-				ref="fileInputRef"
-				type="file"
-				:class="$style.fileInput"
-				:accept="acceptedMimeTypes"
-				multiple
-				@change="handleFileSelect"
-			/>
-
-			<div
-				:class="[{ [$style.calloutVisible]: calloutVisible }, $style.inputWrapper]"
-				@click="handleClickInputWrapper"
-			>
-				<div v-if="attachments.length > 0" :class="$style.attachments">
-					<ChatFile
-						v-for="(file, index) in attachments"
-						:key="index"
-						:file="file"
-						:is-previewable="true"
-						:is-removable="messagingState === 'idle'"
-						@remove="removeAttachment"
-					/>
-				</div>
-
-				<N8nInput
-					ref="inputRef"
-					v-model="message"
-					type="textarea"
-					:placeholder="placeholder"
-					autocomplete="off"
-					:autosize="{ minRows: 1, maxRows: 6 }"
-					autofocus
-					:disabled="messagingState !== 'idle'"
-					@keydown="handleKeydownTextarea"
+			<div v-if="attachments.length > 0" ref="attachmentsEl" :class="$style.attachments">
+				<ChatFile
+					v-for="(file, index) in attachments"
+					:key="index"
+					:file="file"
+					:is-previewable="true"
+					:is-removable="messagingState === 'idle'"
+					@remove="removeAttachment"
 				/>
+			</div>
+		</div>
 
-				<div :class="$style.footer">
-					<div :class="$style.tools">
-						<ToolsSelector
-							:class="$style.toolsButton"
-							:checked-tool-ids="checkedToolIds"
-							:custom-agent-id="customAgentId"
-							:disabled="messagingState !== 'idle' || !isToolsSelectable"
-							:disabled-tooltip="
-								isToolsSelectable
-									? undefined
-									: selectedModel
-										? i18n.baseText('chatHub.tools.selector.disabled.tooltip')
-										: i18n.baseText('chatHub.tools.selector.disabled.noModel.tooltip')
-							"
-							@toggle="handleToolToggle"
-						/>
-					</div>
-					<div :class="$style.actions">
-						<N8nTooltip
-							:content="
-								!canUploadFiles
-									? i18n.baseText('chatHub.chat.prompt.button.attach.disabled')
-									: i18n.baseText('chatHub.chat.prompt.button.attach')
-							"
-							:disabled="canUploadFiles && messagingState === 'idle'"
-							placement="top"
-						>
-							<N8nIconButton
-								variant="ghost"
-								:disabled="messagingState !== 'idle' || !canUploadFiles"
-								icon="paperclip"
-								icon-size="large"
-								@click.stop="onAttach"
-							/>
-						</N8nTooltip>
-						<N8nIconButton
-							v-if="speechInput.isSupported"
-							variant="outline"
-							:title="
-								speechInput.isListening.value
-									? i18n.baseText('chatHub.chat.prompt.button.stopRecording')
-									: i18n.baseText('chatHub.chat.prompt.button.voiceInput')
-							"
-							:disabled="messagingState !== 'idle'"
-							:icon="speechInput.isListening.value ? 'square' : 'mic'"
-							:class="{ [$style.recording]: speechInput.isListening.value }"
-							icon-size="large"
-							@click.stop="onMic"
-						/>
-						<N8nIconButton
-							v-if="messagingState !== 'receiving'"
-							type="submit"
-							:disabled="messagingState !== 'idle' || !message.trim()"
-							:title="i18n.baseText('chatHub.chat.prompt.button.send')"
-							:loading="messagingState === 'waitingFirstChunk'"
-							icon="arrow-up"
-							icon-size="large"
-							@click.stop
-						/>
-						<N8nIconButton
-							v-else
-							native-type="button"
-							:title="i18n.baseText('chatHub.chat.prompt.button.stopGenerating')"
-							icon="square"
-							icon-size="large"
-							@click.stop="onStop"
-						/>
-					</div>
-				</div>
+		<N8nInput
+			ref="inputRef"
+			v-model="message"
+			type="textarea"
+			:placeholder="placeholder"
+			autocomplete="off"
+			:autosize="{ minRows: 1, maxRows: 6 }"
+			autofocus
+			:disabled="messagingState !== 'idle'"
+			@keydown="handleKeydownTextarea"
+		/>
+
+		<div :class="$style.footer">
+			<div :class="$style.tools">
+				<ToolsSelector
+					:class="$style.toolsButton"
+					:checked-tool-ids="checkedToolIds"
+					:custom-agent-id="customAgentId"
+					:disabled="messagingState !== 'idle' || !isToolsSelectable"
+					:disabled-tooltip="
+						isToolsSelectable
+							? undefined
+							: selectedModel
+								? i18n.baseText('chatHub.tools.selector.disabled.tooltip')
+								: i18n.baseText('chatHub.tools.selector.disabled.noModel.tooltip')
+					"
+					@toggle="handleToolToggle"
+				/>
+			</div>
+			<div :class="$style.actions">
+				<N8nTooltip
+					:content="
+						!canUploadFiles
+							? i18n.baseText('chatHub.chat.prompt.button.attach.disabled')
+							: i18n.baseText('chatHub.chat.prompt.button.attach')
+					"
+					:disabled="canUploadFiles && messagingState === 'idle'"
+					placement="top"
+				>
+					<N8nIconButton
+						variant="ghost"
+						:disabled="messagingState !== 'idle' || !canUploadFiles"
+						icon="paperclip"
+						icon-size="large"
+						@click.stop="onAttach"
+					/>
+				</N8nTooltip>
+				<N8nIconButton
+					v-if="speechInput.isSupported"
+					variant="outline"
+					:title="
+						speechInput.isListening.value
+							? i18n.baseText('chatHub.chat.prompt.button.stopRecording')
+							: i18n.baseText('chatHub.chat.prompt.button.voiceInput')
+					"
+					:disabled="messagingState !== 'idle'"
+					:icon="speechInput.isListening.value ? 'square' : 'mic'"
+					:class="{ [$style.recording]: speechInput.isListening.value }"
+					icon-size="large"
+					@click.stop="onMic"
+				/>
+				<N8nIconButton
+					v-if="messagingState !== 'receiving'"
+					type="submit"
+					:disabled="messagingState !== 'idle' || !message.trim()"
+					:title="i18n.baseText('chatHub.chat.prompt.button.send')"
+					:loading="messagingState === 'waitingFirstChunk'"
+					icon="arrow-up"
+					icon-size="large"
+					@click.stop
+				/>
+				<N8nIconButton
+					v-else
+					native-type="button"
+					:title="i18n.baseText('chatHub.chat.prompt.button.stopGenerating')"
+					icon="square"
+					icon-size="large"
+					@click.stop="onStop"
+				/>
 			</div>
 		</div>
 	</form>
@@ -459,19 +448,10 @@ defineExpose({
 	place-items: center;
 }
 
-.inputWrap {
-	position: relative;
-	display: flex;
-	align-items: center;
-	flex-direction: column;
-	width: 100%;
-}
-
 .callout {
-	width: 100%;
+	margin: -1px;
 	padding: var(--spacing--sm);
 	border-radius: 16px 16px 0 0;
-	box-shadow: 0 10px 24px 0 #00000010;
 }
 
 .closeButton {
@@ -482,71 +462,64 @@ defineExpose({
 	display: none;
 }
 
-.inputWrapper {
+.prompt {
 	width: 100%;
-	border-radius: 16px;
-	padding: 16px;
-	box-shadow: 0 10px 24px 0 #00000010;
-	background-color: var(--color--background--light-3);
-	border: var(--border);
+	position: relative;
 	display: flex;
 	flex-direction: column;
 	gap: var(--spacing--md);
-	transition: border-color 0.2s cubic-bezier(0.645, 0.045, 0.355, 1);
-
-	&:focus-within,
-	&:hover:has(textarea:not(:disabled)) {
-		border-color: var(--color--secondary);
-	}
 
 	& textarea {
 		font-size: var(--font-size--md);
 		line-height: 1.5em;
-		resize: none;
-		padding: 0 !important;
-		box-shadow: none;
+		padding: var(--spacing--sm);
+		padding-top: calc(var(--spacing--sm) + var(--attachments-el--height));
+		padding-bottom: 64px;
+		color: var(----color--text--shade-1);
+		box-shadow: 0 10px 24px 0 #00000010;
+		border-radius: 16px;
 
-		&:focus {
-			outline-width: 0;
+		&::placeholder {
+			color: var(--color--text--tint-1);
 		}
 	}
 
-	/** NOTE (@heymynameisrob): Resets default Input styles for focus and border **/
 	:global(.n8n-input__wrapper) {
-		--input--shadow: 0 0 0 0 transparent;
-		--input--shadow--hover: 0 0 0 0 transparent;
-		--input--shadow--focus: 0 0 0 0 transparent;
-		--input--border-color: transparent;
-		--input--border-color--hover: transparent;
-		--input--border-color--focus: transparent;
-		--input--border--shadow: 0 0 0 0 transparent;
-		--input--border--shadow--hover: 0 0 0 0 transparent;
-		--input--border--shadow--focus: 0 0 0 0 transparent;
-
-		&:focus-within {
-			outline: none;
-		}
+		--input--radius: 16px;
 	}
 
-	:global(.n8n-input) > div {
-		padding: 0;
+	&:has(.callout) textarea {
+		padding-top: calc(
+			var(--spacing--sm) + var(--attachments-el--height) + 52px /* callout height */
+		);
 	}
+}
 
-	&.calloutVisible {
-		border-radius: 0 0 16px 16px;
-		border-top: 0;
+.header,
+.footer {
+	position: absolute;
+	width: calc(100% - 2px);
+	z-index: 10;
+	background: var(--color--background--light-2);
+	border-radius: 16px;
+	pointer-events: none; /* click to focus textarea */
+
+	& > * {
+		pointer-events: auto;
 	}
+}
+
+.header {
+	top: 1px;
 }
 
 .footer {
+	bottom: 1px;
+	padding: var(--spacing--sm);
 	display: flex;
 	align-items: flex-end;
-	justify-content: flex-end;
+	justify-content: space-between;
 	gap: var(--spacing--sm);
-}
-
-.tools {
-	flex-grow: 1;
 }
 
 .toolsButton {
@@ -591,6 +564,8 @@ defineExpose({
 	display: flex;
 	flex-wrap: wrap;
 	gap: var(--spacing--2xs);
+	padding: var(--spacing--sm);
+	padding-bottom: 0;
 }
 
 .recording {


### PR DESCRIPTION
## Summary

This PR updates styles of chat-hub prompt inputs to fix doubled outline in the edit input and reduces deviation from the new standard n8n input styles for a better visual consistency and maintainability.

| \ | Before | After |
|--------|--------|--------|
| ChatPrompt (light) | <img width="810" height="200" alt="Screenshot 2026-03-09 at 09 57 39" src="https://github.com/user-attachments/assets/dc23bf23-ddc8-48f5-873b-158e569a4bd2" /><img width="795" height="216" alt="Screenshot 2026-03-09 at 09 57 04" src="https://github.com/user-attachments/assets/04a302ae-510b-4e73-96a6-e26d32a0d518" /> | <img width="805" height="199" alt="Screenshot 2026-03-09 at 09 45 47" src="https://github.com/user-attachments/assets/7fa27380-5be1-49ae-bb77-c791d2b9f71e" /><img width="824" height="268" alt="Screenshot 2026-03-09 at 09 44 22" src="https://github.com/user-attachments/assets/86ab4328-9a94-4831-94f2-bc1909101d09" /> |
| ChatPrompt (dark) | <img width="801" height="202" alt="Screenshot 2026-03-09 at 09 57 57" src="https://github.com/user-attachments/assets/4bcb4225-ebec-47bf-9606-599de8ebeba8" /><img width="805" height="215" alt="Screenshot 2026-03-09 at 09 57 13" src="https://github.com/user-attachments/assets/20e33af1-96f2-42ce-935e-8f17e0a1ef88" /> | <img width="802" height="206" alt="Screenshot 2026-03-09 at 09 45 26" src="https://github.com/user-attachments/assets/54225637-c026-492a-bf9a-7684fecb615a" /><img width="839" height="232" alt="Screenshot 2026-03-09 at 09 45 09" src="https://github.com/user-attachments/assets/2b19136c-349f-40e9-a900-14c2773b9809" /> |
| Edit state of ChatMessage (light) | <img width="820" height="189" alt="Screenshot 2026-03-09 at 10 00 31" src="https://github.com/user-attachments/assets/db00e155-a1ba-4346-8ba2-c8ab1f268d29" /> | <img width="839" height="201" alt="Screenshot 2026-03-09 at 09 55 16" src="https://github.com/user-attachments/assets/4727678c-83a2-45a7-a9ac-9a3f1c3d6704" /> |
| Edit state of ChatMessage (dark) | <img width="833" height="179" alt="Screenshot 2026-03-09 at 10 00 20" src="https://github.com/user-attachments/assets/d0e62e21-2e87-454f-995f-db2fd2ca249c" /> | <img width="849" height="191" alt="Screenshot 2026-03-09 at 09 55 07" src="https://github.com/user-attachments/assets/17f9f3e6-e1c4-4907-8d39-018e19c6969d" /> | 


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-161/bug-adjust-prompt-input-styling-after-design-system-update


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
