### PR TITLE
refactor(editor): Use `workflowDocumentStore` for node access in context menus and completions (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/shared/contextMenu/composables/useContextMenuItems.ts
+++ b/packages/frontend/editor-ui/src/features/shared/contextMenu/composables/useContextMenuItems.ts
@@ -9,10 +9,6 @@ import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
-import {
-	useWorkflowDocumentStore,
-	createWorkflowDocumentId,
-} from '@/app/stores/workflowDocument.store';
 import { useCollaborationStore } from '@/features/collaboration/collaboration/collaboration.store';
 import { useFocusedNodesStore } from '@/features/ai/assistant/focusedNodes.store';
 import { useI18n } from '@n8n/i18n';
@@ -85,11 +81,15 @@ export function useContextMenuItems(targetNodeIds: ComputedRef<string[]>): Compu
 	});
 
 	const targetNodes = computed(() =>
-		targetNodeIds.value.map((nodeId) => workflowsStore.getNodeById(nodeId)).filter(isPresent),
+		targetNodeIds.value
+			.map((nodeId) => workflowDocumentStore?.value?.getNodeById(nodeId) ?? null)
+			.filter(isPresent),
 	);
 
 	const canAddNodeOfType = (nodeType: INodeTypeDescription) => {
-		const sameTypeNodes = workflowsStore.allNodes.filter((n) => n.type === nodeType.name);
+		const sameTypeNodes = (workflowDocumentStore?.value?.allNodes ?? []).filter(
+			(n) => n.type === nodeType.name,
+		);
 		return nodeType.maxNodes === undefined || sameTypeNodes.length < nodeType.maxNodes;
 	};
 
@@ -102,10 +102,7 @@ export function useContextMenuItems(targetNodeIds: ComputedRef<string[]>): Compu
 	};
 
 	const hasPinData = (node: INode): boolean => {
-		const workflowDocumentStore = workflowsStore.workflowId
-			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
-			: undefined;
-		return !!workflowDocumentStore?.pinData?.[node.name];
+		return !!workflowDocumentStore?.value?.pinData?.[node.name];
 	};
 
 	const isExecutable = (node: INodeUi) => {
@@ -145,7 +142,7 @@ export function useContextMenuItems(targetNodeIds: ComputedRef<string[]>): Compu
 				divided: true,
 				label: i18n.baseText('contextMenu.selectAll'),
 				shortcut: { metaKey: true, keys: ['A'] },
-				disabled: nodes.length === workflowsStore.allNodes.length,
+				disabled: nodes.length === (workflowDocumentStore?.value?.allNodes ?? []).length,
 			},
 			{
 				id: 'deselect_all',

--- a/packages/frontend/editor-ui/src/features/shared/editors/components/CodeNodeEditor/completions/base.completions.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/components/CodeNodeEditor/completions/base.completions.ts
@@ -4,8 +4,13 @@ import { addVarType } from '@/features/settings/environments.ee/completions/vari
 import type { Completion, CompletionContext, CompletionResult } from '@codemirror/autocomplete';
 import type { INodeUi } from '@/Interface';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { escapeMappingString } from '@/app/utils/mappingUtils';
 import { useI18n } from '@n8n/i18n';
+import { computed } from 'vue';
 
 function getAutoCompletableNodeNames(nodes: INodeUi[]) {
 	return nodes
@@ -19,6 +24,11 @@ export function useBaseCompletions(
 ) {
 	const i18n = useI18n();
 	const workflowsStore = useWorkflowsStore();
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
 
 	const itemCompletions = (context: CompletionContext): CompletionResult | null => {
 		const preCursor = context.matchBefore(/i\w*/);
@@ -103,15 +113,17 @@ export function useBaseCompletions(
 		const options: Completion[] = TOP_LEVEL_COMPLETIONS_IN_BOTH_MODES.map(addVarType);
 
 		options.push(
-			...getAutoCompletableNodeNames(workflowsStore.allNodes).map((nodeName) => {
-				return {
-					label: `${prefix}('${escapeMappingString(nodeName)}')`,
-					type: 'variable',
-					info: i18n.baseText('codeNodeEditor.completer.$()', {
-						interpolate: { nodeName },
-					}),
-				};
-			}),
+			...getAutoCompletableNodeNames(workflowDocumentStore.value?.allNodes ?? []).map(
+				(nodeName) => {
+					return {
+						label: `${prefix}('${escapeMappingString(nodeName)}')`,
+						type: 'variable',
+						info: i18n.baseText('codeNodeEditor.completer.$()', {
+							interpolate: { nodeName },
+						}),
+					};
+				},
+			),
 		);
 
 		if (mode === 'runOnceForEachItem') {
@@ -142,17 +154,17 @@ export function useBaseCompletions(
 
 		if (!preCursor || (preCursor.from === preCursor.to && !context.explicit)) return null;
 
-		const options: Completion[] = getAutoCompletableNodeNames(workflowsStore.allNodes).map(
-			(nodeName) => {
-				return {
-					label: `${prefix}('${escapeMappingString(nodeName)}')`,
-					type: 'variable',
-					info: i18n.baseText('codeNodeEditor.completer.$()', {
-						interpolate: { nodeName },
-					}),
-				};
-			},
-		);
+		const options: Completion[] = getAutoCompletableNodeNames(
+			workflowDocumentStore.value?.allNodes ?? [],
+		).map((nodeName) => {
+			return {
+				label: `${prefix}('${escapeMappingString(nodeName)}')`,
+				type: 'variable',
+				info: i18n.baseText('codeNodeEditor.completer.$()', {
+					interpolate: { nodeName },
+				}),
+			};
+		});
 
 		return {
 			from: preCursor.from,

--- a/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/typescript/client/useTypescript.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/typescript/client/useTypescript.ts
@@ -62,7 +62,7 @@ export function useTypescript(
 				binaryMode: workflowDocumentStore?.value?.settings?.binaryMode,
 			},
 			Comlink.proxy(async (nodeName) => {
-				const node = workflowsStore.getNodeByName(nodeName);
+				const node = workflowDocumentStore?.value?.getNodeByName(nodeName);
 
 				if (node) {
 					const inputData: INodeExecutionData[] = getInputDataWithPinned(node);

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/components/ExperimentalNodeDetailsDrawer.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/components/ExperimentalNodeDetailsDrawer.test.ts
@@ -4,9 +4,14 @@ import { SET_NODE_TYPE } from '@/app/constants';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	injectWorkflowDocumentStore,
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { createTestingPinia } from '@pinia/testing';
 import ExperimentalNodeDetailsDrawer from './ExperimentalNodeDetailsDrawer.vue';
-import { nextTick } from 'vue';
+import { nextTick, shallowRef } from 'vue';
 import { fireEvent } from '@testing-library/vue';
 import {
 	injectWorkflowState,
@@ -19,6 +24,14 @@ vi.mock('@/app/composables/useWorkflowState', async () => {
 	return {
 		...actual,
 		injectWorkflowState: vi.fn(),
+	};
+});
+
+vi.mock('@/app/stores/workflowDocument.store', async () => {
+	const actual = await vi.importActual('@/app/stores/workflowDocument.store');
+	return {
+		...actual,
+		injectWorkflowDocumentStore: vi.fn(),
 	};
 });
 
@@ -48,7 +61,14 @@ describe('ExperimentalNodeDetailsDrawer', () => {
 		});
 
 		workflowsStore = useWorkflowsStore(pinia);
+		workflowsStore.workflow.id = 'test-workflow';
 		workflowsStore.setNodes(mockNodes);
+
+		const workflowDocumentStore = useWorkflowDocumentStore(
+			createWorkflowDocumentId(workflowsStore.workflowId),
+		);
+		workflowDocumentStore.setNodes(mockNodes);
+		vi.mocked(injectWorkflowDocumentStore).mockReturnValue(shallowRef(workflowDocumentStore));
 		nodeTypesStore = useNodeTypesStore(pinia);
 		nodeTypesStore.setNodeTypes([
 			{


### PR DESCRIPTION
## Summary

Migrate node-related store access from workflowsStore to workflowDocumentStore across three frontend files for better state isolation. This change removes redundant store initialization and leverages the existing injected store instance.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2523/migrate-shared-editors-and-context-menu-to-workflowdocumentstore

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
