### PR TITLE
ci: Extract merge-tag-to-branch into reusable workflow and support patch release merges to RC branch

### DIFF
--- a/.github/scripts/determine-version-info.mjs
+++ b/.github/scripts/determine-version-info.mjs
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { RELEASE_TRACKS, resolveReleaseTagForTrack, writeGithubOutput } from './github-helpers.mjs';
+import { tagVersionInfoToReleaseCandidateBranchName } from './ensure-release-candidate-branches.mjs';
 import semver from 'semver';
 
 /**
@@ -50,17 +51,23 @@ export function determineTrack(packageVersion) {
 		throw new Error('Could not determine track for release. Exiting...');
 	}
 
+	const rc_branch = tagVersionInfoToReleaseCandidateBranchName({
+		version: packageVersion,
+		tag: /** @type {import('./github-helpers.mjs').ReleaseVersion} */ (`n8n@${packageVersion}`),
+	});
+
 	const output = {
 		version: packageVersion,
 		track,
 		bump,
 		new_stable_version: newStable,
 		release_type: releaseType,
+		rc_branch,
 	};
 
 	writeGithubOutput(output);
 	console.log(
-		`Determined track info: track=${track}, version=${packageVersion}, new_stable_version=${newStable}, release_type=${releaseType}`,
+		`Determined track info: track=${track}, version=${packageVersion}, new_stable_version=${newStable}, release_type=${releaseType}, rc_branch=${rc_branch}`,
 	);
 
 	return output;

--- a/.github/scripts/determine-version-info.test.mjs
+++ b/.github/scripts/determine-version-info.test.mjs
@@ -19,6 +19,10 @@ mock.module('./github-helpers.mjs', {
 			return { version: '1.123.33', tag: 'n8n@1.123.33' };
 		},
 		writeGithubOutput: () => {}, // no-op in tests
+		getCommitForRef: () => {}, // no-op
+		localRefExists: () => {}, // no-op
+		remoteBranchExists: () => {}, // no-op
+		sh: () => {}, // no-op
 	},
 });
 
@@ -36,6 +40,7 @@ describe('determine-tracks', () => {
 		assert.equal(output.bump, 'patch');
 		assert.equal(output.new_stable_version, null);
 		assert.equal(output.release_type, 'stable');
+		assert.equal(output.rc_branch, 'release-candidate/2.9.x');
 	});
 
 	it('Allow patch releases on beta', () => {
@@ -46,6 +51,7 @@ describe('determine-tracks', () => {
 		assert.equal(output.bump, 'patch');
 		assert.equal(output.new_stable_version, null);
 		assert.equal(output.release_type, 'stable');
+		assert.equal(output.rc_branch, 'release-candidate/2.10.x');
 	});
 
 	// This use case might happen if a patch release fails and we proceed with rolling over to next release
@@ -57,6 +63,7 @@ describe('determine-tracks', () => {
 		assert.equal(output.bump, 'patch');
 		assert.equal(output.new_stable_version, null);
 		assert.equal(output.release_type, 'stable');
+		assert.equal(output.rc_branch, 'release-candidate/2.9.x');
 	});
 
 	it('Disallow skipping versions in minors', () => {
@@ -77,6 +84,7 @@ describe('determine-tracks', () => {
 		assert.equal(output.bump, 'minor');
 		assert.equal(output.new_stable_version, '2.10.1');
 		assert.equal(output.release_type, 'stable');
+		assert.equal(output.rc_branch, 'release-candidate/2.11.x');
 	});
 
 	it('Set release_type accordingly on rc releases', () => {
@@ -87,5 +95,6 @@ describe('determine-tracks', () => {
 		assert.equal(output.bump, 'patch');
 		assert.equal(output.new_stable_version, null);
 		assert.equal(output.release_type, 'rc');
+		assert.equal(output.rc_branch, 'release-candidate/2.10.x');
 	});
 });

--- a/.github/workflows/release-merge-tag-to-branch.yml
+++ b/.github/workflows/release-merge-tag-to-branch.yml
@@ -1,0 +1,66 @@
+name: 'Release: Merge tag to branch'
+run-name: 'Merge n8n@${{ inputs.version }} to ${{ inputs.target-branch }}'
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'The release version (e.g. 2.10.2)'
+        required: true
+        type: string
+      target-branch:
+        description: 'The branch to merge the release tag into (e.g. master or release-candidate/2.10.x)'
+        required: true
+        type: string
+
+jobs:
+  merge-tag-to-branch:
+    name: Merge release tag to ${{ inputs.target-branch }}
+    runs-on: ubuntu-latest
+    environment: minor-release-tag-merge
+    env:
+      VERSION: ${{ inputs.version }}
+      TARGET_BRANCH: ${{ inputs.target-branch }}
+    steps:
+      - name: Generate GitHub App Token
+        id: generate_token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.RELEASE_TAG_MERGE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_TAG_MERGE_PRIVATE_KEY }}
+          skip-token-revoke: false
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.target-branch }}
+          fetch-depth: 500
+          token: ${{ steps.generate_token.outputs.token }}
+
+      - name: Verify release tag exists
+        run: |
+          if ! git ls-remote --tags origin "refs/tags/n8n@${VERSION}" | grep -q .; then
+            echo "::error::Tag n8n@${VERSION} not found on remote"
+            exit 1
+          fi
+
+      - name: Fetch release tag
+        run: git fetch origin "refs/tags/n8n@${VERSION}:refs/tags/n8n@${VERSION}"
+
+      - name: Merge release tag to branch
+        run: |
+          git config user.name "n8n-release-tag-merge[bot]"
+          git config user.email "256767729+n8n-release-tag-merge[bot]@users.noreply.github.com"
+          git merge --ff "n8n@${VERSION}"
+
+      - name: Push to ${{ inputs.target-branch }}
+        run: git push origin "HEAD:${TARGET_BRANCH}"
+
+      - name: Notify Slack on failure
+        if: failure()
+        uses: act10ns/slack@44541246747a30eb3102d87f7a4cc5471b0ffb7d # v2.1.0
+        with:
+          status: ${{ job.status }}
+          channel: '#updates-and-product-releases'
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          message: |
+            <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}| Release tag merge to ${{ inputs.target-branch }} failed for n8n@${{ inputs.version }} >

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -18,6 +18,7 @@ jobs:
       bump: ${{ steps.determine-info.outputs.bump }}
       new_stable_version: ${{ steps.determine-info.outputs.new_stable_version }}
       release_type: ${{ steps.determine-info.outputs.release_type }}
+      rc_branch: ${{ steps.determine-info.outputs.rc_branch }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -147,59 +148,31 @@ jobs:
     secrets: inherit
 
   merge-release-tag-to-master:
-    name: Merge release tag to master
+    name: Merge release tag to master on minor release
     needs: [determine-version-info, publish-to-npm, create-github-release]
     if: |
       github.event.pull_request.merged == true &&
       needs.determine-version-info.outputs.bump == 'minor' &&
       needs.determine-version-info.outputs.release_type != 'rc'
-    runs-on: ubuntu-latest
-    environment: minor-release-tag-merge
-    env:
-      VERSION: ${{ needs.determine-version-info.outputs.version }}
-    steps:
-      - name: Generate GitHub App Token
-        id: generate_token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        with:
-          app-id: ${{ secrets.RELEASE_TAG_MERGE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_TAG_MERGE_PRIVATE_KEY }}
-          skip-token-revoke: false
+    uses: ./.github/workflows/release-merge-tag-to-branch.yml
+    with:
+      version: ${{ needs.determine-version-info.outputs.version }}
+      target-branch: master
+    secrets: inherit
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: master
-          fetch-depth: 500
-          token: ${{ steps.generate_token.outputs.token }}
+  merge-release-tag-to-rc-branch:
+    name: Merge release tag to RC branch on patch release
+    needs: [determine-version-info, publish-to-npm, create-github-release]
+    if: |
+      github.event.pull_request.merged == true &&
+      needs.determine-version-info.outputs.bump == 'patch' &&
+      needs.determine-version-info.outputs.release_type != 'rc'
+    uses: ./.github/workflows/release-merge-tag-to-branch.yml
+    with:
+      version: ${{ needs.determine-version-info.outputs.version }}
+      target-branch: ${{ needs.determine-version-info.outputs.rc_branch }}
+    secrets: inherit
 
-      - name: Verify release tag exists
-        run: |
-          if ! git ls-remote --tags origin "refs/tags/n8n@${VERSION}" | grep -q .; then
-            echo "::error::Tag n8n@${VERSION} not found on remote"
-            exit 1
-          fi
-
-      - name: Fetch release tag
-        run: git fetch origin "refs/tags/n8n@${VERSION}:refs/tags/n8n@${VERSION}"
-
-      - name: Merge release tag to master
-        run: |
-          git config user.name "n8n-release-tag-merge[bot]"
-          git config user.email "256767729+n8n-release-tag-merge[bot]@users.noreply.github.com"
-          git merge --ff "n8n@${VERSION}"
-
-      - name: Push to master
-        run: git push origin HEAD:master
-
-      - name: Notify Slack on failure
-        if: failure()
-        uses: act10ns/slack@44541246747a30eb3102d87f7a4cc5471b0ffb7d # v2.1.0
-        with:
-          status: ${{ job.status }}
-          channel: '#updates-and-product-releases'
-          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          message: |
-            <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}| Release tag merge to master failed for n8n@${{ needs.determine-version-info.outputs.version }} >
   post-release:
     name: Run Post-release actions
     needs: [determine-version-info, publish-to-npm, create-github-release]


### PR DESCRIPTION
## Summary

Refactors the inline `merge-release-tag-to-master` job in `release-publish.yml` into a reusable workflow, and extends it to handle patch releases correctly.

**Changes:**
- Extracts the merge logic into a new reusable workflow `release-merge-tag-to-branch.yml`, parameterised by `version` and `target-branch`
- For **minor releases**: merges the release tag to `master` (existing behaviour, unchanged)
- For **patch releases**: merges the release tag to the originating `release-candidate/{major}.{minor}.x` branch instead
- Adds `rc_branch` output to `determine-version-info.mjs` (and its job outputs) by reusing `tagVersionInfoToReleaseCandidateBranchName` from `ensure-release-candidate-branches.mjs`
- Updates tests to assert the new `rc_branch` output

## Related Linear tickets, Github issues, and Community forum posts



## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with \`release/backport\` (if the PR is an urgent fix that needs to be backported)