### PR TITLE
fix: Fix segfault in arm64 image due to missing native addon

### DIFF
--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -15,7 +15,7 @@ COPY ./compiled /usr/local/lib/node_modules/n8n
 COPY docker/images/n8n/docker-entrypoint.sh /
 
 RUN cd /usr/local/lib/node_modules/n8n && \
-    npm rebuild sqlite3 && \
+    npm rebuild sqlite3 isolated-vm && \
     ln -s /usr/local/lib/node_modules/n8n/bin/n8n /usr/local/bin/n8n && \
     mkdir -p /home/node/.n8n && \
     chown -R node:node /home/node && \

--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -30,9 +30,11 @@ RUN node -e "const pkg = require('./package.json'); \
 RUN rm -f node_modules/.modules.yaml && \
     pnpm add moment@2.30.1 --prod --no-lockfile
 
-# Rebuild isolated-vm for the container platform (prebuilt binaries exist for
-# linuxmusl-arm64 and linuxmusl-x64, so no compilation toolchain is needed).
-RUN npm rebuild isolated-vm
+# Rebuild isolated-vm for the container platform. Install build tools as
+# fallback in case prebuild-install cannot find a prebuilt binary.
+RUN apk add --no-cache --virtual .build-deps python3 make g++ && \
+    npm rebuild isolated-vm && \
+    apk del .build-deps
 
 # ==============================================================================
 # STAGE 2: Python runner build (@n8n/task-runner-python) with uv

--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -31,7 +31,7 @@ RUN rm -f node_modules/.modules.yaml && \
     pnpm add moment@2.30.1 --prod --no-lockfile
 
 # Rebuild native modules for the container platform (e.g. linux-arm64-musl)
-RUN npm rebuild isolated-vm 2>/dev/null || true
+RUN npm rebuild isolated-vm
 
 # ==============================================================================
 # STAGE 2: Python runner build (@n8n/task-runner-python) with uv

--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -30,13 +30,9 @@ RUN node -e "const pkg = require('./package.json'); \
 RUN rm -f node_modules/.modules.yaml && \
     pnpm add moment@2.30.1 --prod --no-lockfile
 
-# Rebuild isolated-vm native addon against the current Node.js version.
-# The pre-built binary from CI may have been compiled against a different
-# Node.js version (e.g., v22), causing ERR_DLOPEN_FAILED at runtime when
-# the V8 ABI has changed (e.g., missing ArrayBuffer::Allocator::Reallocate).
-RUN apk add --no-cache --virtual .build-deps python3 make g++ && \
-    npm rebuild isolated-vm && \
-    apk del .build-deps
+# Rebuild isolated-vm for the container platform (prebuilt binaries exist for
+# linuxmusl-arm64 and linuxmusl-x64, so no compilation toolchain is needed).
+RUN npm rebuild isolated-vm
 
 # ==============================================================================
 # STAGE 2: Python runner build (@n8n/task-runner-python) with uv

--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -30,6 +30,9 @@ RUN node -e "const pkg = require('./package.json'); \
 RUN rm -f node_modules/.modules.yaml && \
     pnpm add moment@2.30.1 --prod --no-lockfile
 
+# Rebuild native modules for the container platform (e.g. linux-arm64-musl)
+RUN npm rebuild isolated-vm 2>/dev/null || true
+
 # ==============================================================================
 # STAGE 2: Python runner build (@n8n/task-runner-python) with uv
 # Produces a relocatable venv tied to the python version used

--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -30,8 +30,13 @@ RUN node -e "const pkg = require('./package.json'); \
 RUN rm -f node_modules/.modules.yaml && \
     pnpm add moment@2.30.1 --prod --no-lockfile
 
-# Rebuild native modules for the container platform (e.g. linux-arm64-musl)
-RUN npm rebuild isolated-vm
+# Rebuild isolated-vm native addon against the current Node.js version.
+# The pre-built binary from CI may have been compiled against a different
+# Node.js version (e.g., v22), causing ERR_DLOPEN_FAILED at runtime when
+# the V8 ABI has changed (e.g., missing ArrayBuffer::Allocator::Reallocate).
+RUN apk add --no-cache --virtual .build-deps python3 make g++ && \
+    npm rebuild isolated-vm && \
+    apk del .build-deps
 
 # ==============================================================================
 # STAGE 2: Python runner build (@n8n/task-runner-python) with uv

--- a/docker/images/runners/Dockerfile.distroless
+++ b/docker/images/runners/Dockerfile.distroless
@@ -45,9 +45,12 @@ RUN node -e "const pkg = require('./package.json'); \
 RUN rm -f node_modules/.modules.yaml && \
     pnpm add moment@2.30.1 --prod --no-lockfile
 
-# Rebuild isolated-vm for the container platform (prebuilt binaries exist for
-# linux-arm64 and linux-x64, so no compilation toolchain is needed).
-RUN npm rebuild isolated-vm
+# Rebuild isolated-vm for the container platform. Install build tools as
+# fallback in case prebuild-install cannot find a prebuilt binary.
+RUN apt-get update && apt-get install -y --no-install-recommends python3 make g++ && \
+    npm rebuild isolated-vm && \
+    apt-get purge -y python3 make g++ && apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # ==============================================================================
 # STAGE 2: Python runner build (@n8n/task-runner-python) with uv

--- a/docker/images/runners/Dockerfile.distroless
+++ b/docker/images/runners/Dockerfile.distroless
@@ -45,13 +45,9 @@ RUN node -e "const pkg = require('./package.json'); \
 RUN rm -f node_modules/.modules.yaml && \
     pnpm add moment@2.30.1 --prod --no-lockfile
 
-# Rebuild isolated-vm native addon against the current Node.js version.
-# The pre-built binary from CI may have been compiled against a different
-# Node.js version (e.g., v22), causing ERR_DLOPEN_FAILED at runtime when
-# the V8 ABI has changed (e.g., missing ArrayBuffer::Allocator::Reallocate).
-RUN apk add --no-cache --virtual .build-deps python3 make g++ && \
-    npm rebuild isolated-vm && \
-    apk del .build-deps
+# Rebuild isolated-vm for the container platform (prebuilt binaries exist for
+# linux-arm64 and linux-x64, so no compilation toolchain is needed).
+RUN npm rebuild isolated-vm
 
 # ==============================================================================
 # STAGE 2: Python runner build (@n8n/task-runner-python) with uv

--- a/docker/images/runners/Dockerfile.distroless
+++ b/docker/images/runners/Dockerfile.distroless
@@ -45,6 +45,14 @@ RUN node -e "const pkg = require('./package.json'); \
 RUN rm -f node_modules/.modules.yaml && \
     pnpm add moment@2.30.1 --prod --no-lockfile
 
+# Rebuild isolated-vm native addon against the current Node.js version.
+# The pre-built binary from CI may have been compiled against a different
+# Node.js version (e.g., v22), causing ERR_DLOPEN_FAILED at runtime when
+# the V8 ABI has changed (e.g., missing ArrayBuffer::Allocator::Reallocate).
+RUN apk add --no-cache --virtual .build-deps python3 make g++ && \
+    npm rebuild isolated-vm && \
+    apk del .build-deps
+
 # ==============================================================================
 # STAGE 2: Python runner build (@n8n/task-runner-python) with uv
 # Produces a relocatable venv tied to the python version used


### PR DESCRIPTION
## Summary

Fixes segmentation fault on ARM64 Alpine (musl libc) when activating workflows that use the Merge node's SQL mode. The `isolated-vm` native module was compiled on the host machine (e.g., darwin-arm64 or linux-x64-glibc) and copied into the Docker image without rebuilding for the target platform. When n8n starts and loads the Merge node, it tries to import the incompatible binary, causing a crash on ARM64 musl.

Added `npm rebuild isolated-vm` alongside the existing `sqlite3` rebuild in both the main n8n and runners Dockerfiles to ensure the native module is compiled for the container's platform (linux-arm64-musl).

**Testing:** Verified the fix by building Docker images and testing that isolated-vm loads without error on linux-arm64 Alpine, whereas the unfixed image fails with "invalid ELF header" error.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2561

Closes https://github.com/n8n-io/n8n/issues/26728

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included (Docker image verification).
- [x] No docs changes needed (Docker build process change).
- [ ] PR Labeled with `release/backport` (if urgent fix) - **To be labeled by reviewers**