### PR TITLE
refactor(editor): Migrate credentials and setup panel to `workflowDocumentStore` (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/setupPanel/composables/useWorkflowSetupState.test.ts
+++ b/packages/frontend/editor-ui/src/features/setupPanel/composables/useWorkflowSetupState.test.ts
@@ -1,4 +1,4 @@
-import { ref, nextTick } from 'vue';
+import { ref, shallowRef, nextTick } from 'vue';
 import { createTestingPinia } from '@pinia/testing';
 
 import { createTestNode } from '@/__tests__/mocks';
@@ -28,11 +28,20 @@ const mockUpdateNodeProperties = vi.fn();
 const mockUpdateNodeCredentialIssuesByName = vi.fn();
 const mockUpdateNodesCredentialsIssues = vi.fn();
 
-vi.mock('@/app/composables/useWorkflowState', () => ({
-	injectWorkflowState: vi.fn(() => ({
-		updateNodeProperties: mockUpdateNodeProperties,
-	})),
-}));
+const mockWorkflowDocumentStore = {
+	allNodes: [] as INodeUi[],
+	getNodeByName: vi.fn() as ReturnType<typeof vi.fn>,
+	getNodes: vi.fn() as ReturnType<typeof vi.fn>,
+	updateNodeProperties: mockUpdateNodeProperties,
+};
+
+vi.mock('@/app/stores/workflowDocument.store', async () => {
+	const actual = await vi.importActual('@/app/stores/workflowDocument.store');
+	return {
+		...actual,
+		injectWorkflowDocumentStore: vi.fn(() => shallowRef(mockWorkflowDocumentStore)),
+	};
+});
 
 vi.mock('@/app/composables/useNodeHelpers', () => ({
 	useNodeHelpers: vi.fn(() => ({
@@ -88,6 +97,9 @@ describe('useWorkflowSetupState', () => {
 		workflowsStore.getWorkflowResultDataByNodeName = vi.fn().mockReturnValue(null);
 
 		mockGetNodeTypeDisplayableCredentials.mockReturnValue([]);
+		mockWorkflowDocumentStore.allNodes = [];
+		mockWorkflowDocumentStore.getNodeByName = vi.fn();
+		mockWorkflowDocumentStore.getNodes = vi.fn();
 		mockUpdateNodeProperties.mockReset();
 		mockUpdateNodeCredentialIssuesByName.mockReset();
 		mockUpdateNodesCredentialsIssues.mockReset();
@@ -96,7 +108,7 @@ describe('useWorkflowSetupState', () => {
 
 	describe('setupCards', () => {
 		it('should return empty array when no nodes', () => {
-			workflowsStore.allNodes = [];
+			mockWorkflowDocumentStore.allNodes = [];
 
 			const { setupCards } = useWorkflowSetupState();
 
@@ -108,7 +120,7 @@ describe('useWorkflowSetupState', () => {
 				name: 'WebhookTrigger',
 				type: 'n8n-nodes-base.webhook',
 			});
-			workflowsStore.allNodes = [triggerNode];
+			mockWorkflowDocumentStore.allNodes = [triggerNode];
 			nodeTypesStore.isTriggerNode = vi.fn().mockReturnValue(true);
 
 			const { setupCards } = useWorkflowSetupState();
@@ -122,12 +134,12 @@ describe('useWorkflowSetupState', () => {
 
 		it('should return credential cards for nodes with credentials', () => {
 			const node = createNode({ name: 'OpenAI' });
-			workflowsStore.allNodes = [node];
+			mockWorkflowDocumentStore.allNodes = [node];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'openAiApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'OpenAI API',
 			});
-			workflowsStore.getNodeByName = vi.fn().mockReturnValue(node);
+			mockWorkflowDocumentStore.getNodeByName = vi.fn().mockReturnValue(node);
 
 			const { setupCards } = useWorkflowSetupState();
 
@@ -142,12 +154,12 @@ describe('useWorkflowSetupState', () => {
 		it('should group multiple nodes needing same credential into one credential card', () => {
 			const node1 = createNode({ name: 'OpenAI1', position: [0, 0] });
 			const node2 = createNode({ name: 'OpenAI2', position: [100, 0] });
-			workflowsStore.allNodes = [node1, node2];
+			mockWorkflowDocumentStore.allNodes = [node1, node2];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'openAiApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'OpenAI API',
 			});
-			workflowsStore.getNodeByName = vi.fn((name: string) => {
+			mockWorkflowDocumentStore.getNodeByName = vi.fn((name: string) => {
 				if (name === 'OpenAI1') return node1;
 				if (name === 'OpenAI2') return node2;
 				return null;
@@ -167,7 +179,7 @@ describe('useWorkflowSetupState', () => {
 		it('should create separate credential cards for different credential types', () => {
 			const node1 = createNode({ name: 'Node1', position: [0, 0] });
 			const node2 = createNode({ name: 'Node2', position: [100, 0] });
-			workflowsStore.allNodes = [node1, node2];
+			mockWorkflowDocumentStore.allNodes = [node1, node2];
 			mockGetNodeTypeDisplayableCredentials.mockImplementation((_store, node) => {
 				if ((node as INodeUi).name === 'Node1') return [{ name: 'slackApi' }];
 				if ((node as INodeUi).name === 'Node2') return [{ name: 'openAiApi' }];
@@ -176,7 +188,7 @@ describe('useWorkflowSetupState', () => {
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'Test',
 			});
-			workflowsStore.getNodeByName = vi.fn((name: string) => {
+			mockWorkflowDocumentStore.getNodeByName = vi.fn((name: string) => {
 				if (name === 'Node1') return node1;
 				if (name === 'Node2') return node2;
 				return null;
@@ -193,13 +205,13 @@ describe('useWorkflowSetupState', () => {
 				name: 'SlackTrigger',
 				type: 'n8n-nodes-base.slackTrigger',
 			});
-			workflowsStore.allNodes = [triggerNode];
+			mockWorkflowDocumentStore.allNodes = [triggerNode];
 			nodeTypesStore.isTriggerNode = vi.fn().mockReturnValue(true);
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'slackApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'Slack API',
 			});
-			workflowsStore.getNodeByName = vi.fn().mockReturnValue(triggerNode);
+			mockWorkflowDocumentStore.getNodeByName = vi.fn().mockReturnValue(triggerNode);
 
 			const { setupCards } = useWorkflowSetupState();
 
@@ -227,13 +239,13 @@ describe('useWorkflowSetupState', () => {
 				type: 'n8n-nodes-base.slackTrigger',
 				position: [100, 0],
 			});
-			workflowsStore.allNodes = [trigger1, trigger2];
+			mockWorkflowDocumentStore.allNodes = [trigger1, trigger2];
 			nodeTypesStore.isTriggerNode = vi.fn().mockReturnValue(true);
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'slackApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'Slack API',
 			});
-			workflowsStore.getNodeByName = vi.fn((name: string) => {
+			mockWorkflowDocumentStore.getNodeByName = vi.fn((name: string) => {
 				if (name === 'SlackTrigger1') return trigger1;
 				if (name === 'SlackTrigger2') return trigger2;
 				return null;
@@ -264,7 +276,7 @@ describe('useWorkflowSetupState', () => {
 				name: 'ManualTrigger',
 				type: 'n8n-nodes-base.manualTrigger',
 			});
-			workflowsStore.allNodes = [triggerNode];
+			mockWorkflowDocumentStore.allNodes = [triggerNode];
 			nodeTypesStore.isTriggerNode = vi.fn().mockReturnValue(true);
 
 			const { setupCards } = useWorkflowSetupState();
@@ -285,7 +297,7 @@ describe('useWorkflowSetupState', () => {
 				type: 'n8n-nodes-base.regular',
 				position: [100, 0],
 			});
-			workflowsStore.allNodes = [triggerNode, regularNode];
+			mockWorkflowDocumentStore.allNodes = [triggerNode, regularNode];
 			nodeTypesStore.isTriggerNode = vi.fn(
 				(type: string) => type === 'n8n-nodes-base.manualTrigger',
 			);
@@ -296,7 +308,7 @@ describe('useWorkflowSetupState', () => {
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'Test',
 			});
-			workflowsStore.getNodeByName = vi.fn((name: string) => {
+			mockWorkflowDocumentStore.getNodeByName = vi.fn((name: string) => {
 				if (name === 'Regular') return regularNode;
 				if (name === 'ManualTrigger') return triggerNode;
 				return null;
@@ -313,7 +325,7 @@ describe('useWorkflowSetupState', () => {
 
 		it('should exclude disabled nodes', () => {
 			const node = createNode({ name: 'DisabledNode', disabled: true });
-			workflowsStore.allNodes = [node];
+			mockWorkflowDocumentStore.allNodes = [node];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'testApi' }]);
 
 			const { setupCards } = useWorkflowSetupState();
@@ -323,7 +335,7 @@ describe('useWorkflowSetupState', () => {
 
 		it('should exclude nodes without credentials (non-trigger)', () => {
 			const node = createNode({ name: 'NoCredNode' });
-			workflowsStore.allNodes = [node];
+			mockWorkflowDocumentStore.allNodes = [node];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([]);
 
 			const { setupCards } = useWorkflowSetupState();
@@ -336,12 +348,12 @@ describe('useWorkflowSetupState', () => {
 		it('should group by credential type', () => {
 			const node1 = createNode({ name: 'Node1', position: [0, 0] });
 			const node2 = createNode({ name: 'Node2', position: [100, 0] });
-			workflowsStore.allNodes = [node1, node2];
+			mockWorkflowDocumentStore.allNodes = [node1, node2];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'openAiApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'OpenAI API',
 			});
-			workflowsStore.getNodeByName = vi.fn((name: string) => {
+			mockWorkflowDocumentStore.getNodeByName = vi.fn((name: string) => {
 				if (name === 'Node1') return node1;
 				if (name === 'Node2') return node2;
 				return null;
@@ -356,12 +368,12 @@ describe('useWorkflowSetupState', () => {
 		it('should include all nodes sharing the credential type', () => {
 			const node1 = createNode({ name: 'Node1', position: [0, 0] });
 			const node2 = createNode({ name: 'Node2', position: [100, 0] });
-			workflowsStore.allNodes = [node1, node2];
+			mockWorkflowDocumentStore.allNodes = [node1, node2];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'openAiApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'OpenAI API',
 			});
-			workflowsStore.getNodeByName = vi.fn((name: string) => {
+			mockWorkflowDocumentStore.getNodeByName = vi.fn((name: string) => {
 				if (name === 'Node1') return node1;
 				if (name === 'Node2') return node2;
 				return null;
@@ -380,12 +392,12 @@ describe('useWorkflowSetupState', () => {
 					slackApi: { id: 'cred-1', name: 'My Slack' },
 				},
 			});
-			workflowsStore.allNodes = [node];
+			mockWorkflowDocumentStore.allNodes = [node];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'slackApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'Slack API',
 			});
-			workflowsStore.getNodeByName = vi.fn().mockReturnValue(node);
+			mockWorkflowDocumentStore.getNodeByName = vi.fn().mockReturnValue(node);
 
 			const { credentialTypeStates } = useWorkflowSetupState();
 
@@ -398,13 +410,13 @@ describe('useWorkflowSetupState', () => {
 				type: 'n8n-nodes-base.slackTrigger',
 				credentials: { slackApi: { id: 'cred-1', name: 'My Slack' } },
 			});
-			workflowsStore.allNodes = [triggerNode];
+			mockWorkflowDocumentStore.allNodes = [triggerNode];
 			nodeTypesStore.isTriggerNode = vi.fn().mockReturnValue(true);
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'slackApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'Slack API',
 			});
-			workflowsStore.getNodeByName = vi.fn().mockReturnValue(triggerNode);
+			mockWorkflowDocumentStore.getNodeByName = vi.fn().mockReturnValue(triggerNode);
 			workflowsStore.getWorkflowResultDataByNodeName = vi.fn().mockReturnValue(null);
 
 			const { credentialTypeStates } = useWorkflowSetupState();
@@ -422,13 +434,13 @@ describe('useWorkflowSetupState', () => {
 				type: 'n8n-nodes-base.slackTrigger',
 				credentials: { slackApi: { id: 'cred-1', name: 'My Slack' } },
 			});
-			workflowsStore.allNodes = [triggerNode];
+			mockWorkflowDocumentStore.allNodes = [triggerNode];
 			nodeTypesStore.isTriggerNode = vi.fn().mockReturnValue(true);
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'slackApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'Slack API',
 			});
-			workflowsStore.getNodeByName = vi.fn().mockReturnValue(triggerNode);
+			mockWorkflowDocumentStore.getNodeByName = vi.fn().mockReturnValue(triggerNode);
 			workflowsStore.getWorkflowResultDataByNodeName = vi.fn().mockReturnValue([{ data: {} }]);
 
 			const { credentialTypeStates } = useWorkflowSetupState();
@@ -442,9 +454,9 @@ describe('useWorkflowSetupState', () => {
 
 		it('should mark isComplete false when credential is missing', () => {
 			const node = createNode({ name: 'Slack' });
-			workflowsStore.allNodes = [node];
+			mockWorkflowDocumentStore.allNodes = [node];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'slackApi' }]);
-			workflowsStore.getNodeByName = vi.fn().mockReturnValue(node);
+			mockWorkflowDocumentStore.getNodeByName = vi.fn().mockReturnValue(node);
 
 			const { credentialTypeStates } = useWorkflowSetupState();
 
@@ -463,12 +475,12 @@ describe('useWorkflowSetupState', () => {
 					},
 				},
 			});
-			workflowsStore.allNodes = [node];
+			mockWorkflowDocumentStore.allNodes = [node];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'slackApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'Slack API',
 			});
-			workflowsStore.getNodeByName = vi.fn().mockReturnValue(node);
+			mockWorkflowDocumentStore.getNodeByName = vi.fn().mockReturnValue(node);
 
 			const { credentialTypeStates } = useWorkflowSetupState();
 
@@ -479,7 +491,7 @@ describe('useWorkflowSetupState', () => {
 			const nodeA = createNode({ name: 'NodeA', position: [300, 0] });
 			const nodeB = createNode({ name: 'NodeB', position: [100, 0] });
 			// sortNodesByExecutionOrder is mocked as pass-through, so order matches allNodes
-			workflowsStore.allNodes = [nodeA, nodeB];
+			mockWorkflowDocumentStore.allNodes = [nodeA, nodeB];
 			mockGetNodeTypeDisplayableCredentials.mockImplementation((_store, node) => {
 				if ((node as INodeUi).name === 'NodeA') return [{ name: 'apiA' }];
 				if ((node as INodeUi).name === 'NodeB') return [{ name: 'apiB' }];
@@ -488,7 +500,7 @@ describe('useWorkflowSetupState', () => {
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'Test',
 			});
-			workflowsStore.getNodeByName = vi.fn((name: string) => {
+			mockWorkflowDocumentStore.getNodeByName = vi.fn((name: string) => {
 				if (name === 'NodeA') return nodeA;
 				if (name === 'NodeB') return nodeB;
 				return null;
@@ -507,7 +519,7 @@ describe('useWorkflowSetupState', () => {
 				name: 'ManualTrigger',
 				type: 'n8n-nodes-base.manualTrigger',
 			});
-			workflowsStore.allNodes = [triggerNode];
+			mockWorkflowDocumentStore.allNodes = [triggerNode];
 			nodeTypesStore.isTriggerNode = vi.fn().mockReturnValue(true);
 			workflowsStore.getWorkflowResultDataByNodeName = vi.fn().mockReturnValue([{ data: {} }]);
 
@@ -522,13 +534,13 @@ describe('useWorkflowSetupState', () => {
 				name: 'SlackTrigger',
 				type: 'n8n-nodes-base.slackTrigger',
 			});
-			workflowsStore.allNodes = [triggerNode];
+			mockWorkflowDocumentStore.allNodes = [triggerNode];
 			nodeTypesStore.isTriggerNode = vi.fn().mockReturnValue(true);
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'slackApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'Slack API',
 			});
-			workflowsStore.getNodeByName = vi.fn().mockReturnValue(triggerNode);
+			mockWorkflowDocumentStore.getNodeByName = vi.fn().mockReturnValue(triggerNode);
 			workflowsStore.getWorkflowResultDataByNodeName = vi.fn().mockReturnValue(null);
 
 			const { triggerStates } = useWorkflowSetupState();
@@ -541,7 +553,7 @@ describe('useWorkflowSetupState', () => {
 				name: 'ManualTrigger',
 				type: 'n8n-nodes-base.manualTrigger',
 			});
-			workflowsStore.allNodes = [triggerNode];
+			mockWorkflowDocumentStore.allNodes = [triggerNode];
 			nodeTypesStore.isTriggerNode = vi.fn().mockReturnValue(true);
 			workflowsStore.getWorkflowResultDataByNodeName = vi.fn().mockReturnValue(null);
 
@@ -555,12 +567,12 @@ describe('useWorkflowSetupState', () => {
 		it('should update all nodes that need the credential type', () => {
 			const node1 = createNode({ name: 'OpenAI1', position: [0, 0] });
 			const node2 = createNode({ name: 'OpenAI2', position: [100, 0] });
-			workflowsStore.allNodes = [node1, node2];
+			mockWorkflowDocumentStore.allNodes = [node1, node2];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'openAiApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'OpenAI API',
 			});
-			workflowsStore.getNodeByName = vi.fn((name: string) => {
+			mockWorkflowDocumentStore.getNodeByName = vi.fn((name: string) => {
 				if (name === 'OpenAI1') return node1;
 				if (name === 'OpenAI2') return node2;
 				return null;
@@ -594,12 +606,12 @@ describe('useWorkflowSetupState', () => {
 		it('should call updateNodesCredentialsIssues once', () => {
 			const node1 = createNode({ name: 'OpenAI1', position: [0, 0] });
 			const node2 = createNode({ name: 'OpenAI2', position: [100, 0] });
-			workflowsStore.allNodes = [node1, node2];
+			mockWorkflowDocumentStore.allNodes = [node1, node2];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'openAiApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'OpenAI API',
 			});
-			workflowsStore.getNodeByName = vi.fn((name: string) => {
+			mockWorkflowDocumentStore.getNodeByName = vi.fn((name: string) => {
 				if (name === 'OpenAI1') return node1;
 				if (name === 'OpenAI2') return node2;
 				return null;
@@ -617,12 +629,12 @@ describe('useWorkflowSetupState', () => {
 
 		it('should not call updateNodeCredentialIssuesByName', () => {
 			const node = createNode({ name: 'OpenAI' });
-			workflowsStore.allNodes = [node];
+			mockWorkflowDocumentStore.allNodes = [node];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'openAiApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'OpenAI API',
 			});
-			workflowsStore.getNodeByName = vi.fn().mockReturnValue(node);
+			mockWorkflowDocumentStore.getNodeByName = vi.fn().mockReturnValue(node);
 			credentialsStore.getCredentialById = vi.fn().mockReturnValue({
 				id: 'cred-1',
 				name: 'My OpenAI Key',
@@ -637,12 +649,12 @@ describe('useWorkflowSetupState', () => {
 		it('should not show toast (no auto-assign toast)', () => {
 			const node1 = createNode({ name: 'OpenAI1', position: [0, 0] });
 			const node2 = createNode({ name: 'OpenAI2', position: [100, 0] });
-			workflowsStore.allNodes = [node1, node2];
+			mockWorkflowDocumentStore.allNodes = [node1, node2];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'openAiApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'OpenAI API',
 			});
-			workflowsStore.getNodeByName = vi.fn((name: string) => {
+			mockWorkflowDocumentStore.getNodeByName = vi.fn((name: string) => {
 				if (name === 'OpenAI1') return node1;
 				if (name === 'OpenAI2') return node2;
 				return null;
@@ -661,7 +673,7 @@ describe('useWorkflowSetupState', () => {
 
 		it('should return early when credential not found', () => {
 			const node = createNode({ name: 'OpenAI' });
-			workflowsStore.allNodes = [node];
+			mockWorkflowDocumentStore.allNodes = [node];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'openAiApi' }]);
 			credentialsStore.getCredentialById = vi.fn().mockReturnValue(undefined);
 
@@ -678,7 +690,7 @@ describe('useWorkflowSetupState', () => {
 					existingApi: { id: 'existing-1', name: 'Existing' },
 				},
 			});
-			workflowsStore.allNodes = [node];
+			mockWorkflowDocumentStore.allNodes = [node];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([
 				{ name: 'existingApi' },
 				{ name: 'newApi' },
@@ -686,7 +698,7 @@ describe('useWorkflowSetupState', () => {
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'Test',
 			});
-			workflowsStore.getNodeByName = vi.fn().mockReturnValue(node);
+			mockWorkflowDocumentStore.getNodeByName = vi.fn().mockReturnValue(node);
 			credentialsStore.getCredentialById = vi.fn().mockReturnValue({
 				id: 'cred-2',
 				name: 'New Cred',
@@ -721,12 +733,12 @@ describe('useWorkflowSetupState', () => {
 				position: [100, 0],
 				parameters: { url: 'https://api.example.com/data' },
 			});
-			workflowsStore.allNodes = [httpNode1, httpNode2];
+			mockWorkflowDocumentStore.allNodes = [httpNode1, httpNode2];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'httpHeaderAuth' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'Header Auth',
 			});
-			workflowsStore.getNodeByName = vi.fn((name: string) => {
+			mockWorkflowDocumentStore.getNodeByName = vi.fn((name: string) => {
 				if (name === 'HTTP Request') return httpNode1;
 				if (name === 'HTTP Request1') return httpNode2;
 				return null;
@@ -767,12 +779,12 @@ describe('useWorkflowSetupState', () => {
 				position: [100, 0],
 				parameters: { url: 'https://api.other.com/data' },
 			});
-			workflowsStore.allNodes = [httpNode1, httpNode2];
+			mockWorkflowDocumentStore.allNodes = [httpNode1, httpNode2];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'httpHeaderAuth' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'Header Auth',
 			});
-			workflowsStore.getNodeByName = vi.fn((name: string) => {
+			mockWorkflowDocumentStore.getNodeByName = vi.fn((name: string) => {
 				if (name === 'HTTP Request') return httpNode1;
 				if (name === 'HTTP Request1') return httpNode2;
 				return null;
@@ -806,12 +818,12 @@ describe('useWorkflowSetupState', () => {
 				name: 'Slack',
 				position: [100, 0],
 			});
-			workflowsStore.allNodes = [httpNode, regularNode];
+			mockWorkflowDocumentStore.allNodes = [httpNode, regularNode];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'httpHeaderAuth' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'Header Auth',
 			});
-			workflowsStore.getNodeByName = vi.fn((name: string) => {
+			mockWorkflowDocumentStore.getNodeByName = vi.fn((name: string) => {
 				if (name === 'HTTP Request') return httpNode;
 				if (name === 'Slack') return regularNode;
 				return null;
@@ -843,12 +855,12 @@ describe('useWorkflowSetupState', () => {
 					openAiApi: { id: 'cred-1', name: 'My OpenAI' },
 				},
 			});
-			workflowsStore.allNodes = [node1, node2];
+			mockWorkflowDocumentStore.allNodes = [node1, node2];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'openAiApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'OpenAI API',
 			});
-			workflowsStore.getNodeByName = vi.fn((name: string) => {
+			mockWorkflowDocumentStore.getNodeByName = vi.fn((name: string) => {
 				if (name === 'OpenAI1') return node1;
 				if (name === 'OpenAI2') return node2;
 				return null;
@@ -880,12 +892,12 @@ describe('useWorkflowSetupState', () => {
 					slackApi: { id: 'cred-1', name: 'My Slack' },
 				},
 			});
-			workflowsStore.allNodes = [node];
+			mockWorkflowDocumentStore.allNodes = [node];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'slackApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'Slack API',
 			});
-			workflowsStore.getNodeByName = vi.fn().mockReturnValue(node);
+			mockWorkflowDocumentStore.getNodeByName = vi.fn().mockReturnValue(node);
 
 			const { unsetCredential } = useWorkflowSetupState();
 			unsetCredential('slackApi');
@@ -896,7 +908,7 @@ describe('useWorkflowSetupState', () => {
 
 	describe('isAllComplete', () => {
 		it('should return false when empty', () => {
-			workflowsStore.allNodes = [];
+			mockWorkflowDocumentStore.allNodes = [];
 
 			const { isAllComplete } = useWorkflowSetupState();
 
@@ -910,12 +922,12 @@ describe('useWorkflowSetupState', () => {
 					slackApi: { id: 'cred-1', name: 'My Slack' },
 				},
 			});
-			workflowsStore.allNodes = [node];
+			mockWorkflowDocumentStore.allNodes = [node];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'slackApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'Slack API',
 			});
-			workflowsStore.getNodeByName = vi.fn().mockReturnValue(node);
+			mockWorkflowDocumentStore.getNodeByName = vi.fn().mockReturnValue(node);
 
 			const { isAllComplete } = useWorkflowSetupState();
 
@@ -934,7 +946,7 @@ describe('useWorkflowSetupState', () => {
 				name: 'Incomplete',
 				position: [100, 0],
 			});
-			workflowsStore.allNodes = [node1, node2];
+			mockWorkflowDocumentStore.allNodes = [node1, node2];
 			mockGetNodeTypeDisplayableCredentials.mockImplementation((_store, node) => {
 				if ((node as INodeUi).name === 'Complete') return [{ name: 'slackApi' }];
 				if ((node as INodeUi).name === 'Incomplete') return [{ name: 'openAiApi' }];
@@ -943,7 +955,7 @@ describe('useWorkflowSetupState', () => {
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'Test',
 			});
-			workflowsStore.getNodeByName = vi.fn((name: string) => {
+			mockWorkflowDocumentStore.getNodeByName = vi.fn((name: string) => {
 				if (name === 'Complete') return node1;
 				if (name === 'Incomplete') return node2;
 				return null;
@@ -959,7 +971,7 @@ describe('useWorkflowSetupState', () => {
 				name: 'Trigger',
 				type: 'n8n-nodes-base.trigger',
 			});
-			workflowsStore.allNodes = [triggerNode];
+			mockWorkflowDocumentStore.allNodes = [triggerNode];
 			nodeTypesStore.isTriggerNode = vi.fn().mockReturnValue(true);
 			workflowsStore.getWorkflowResultDataByNodeName = vi.fn().mockReturnValue(null);
 
@@ -971,7 +983,7 @@ describe('useWorkflowSetupState', () => {
 
 	describe('totalCredentialsMissing', () => {
 		it('should return 0 when no credential cards exist', () => {
-			workflowsStore.allNodes = [];
+			mockWorkflowDocumentStore.allNodes = [];
 
 			const { totalCredentialsMissing } = useWorkflowSetupState();
 
@@ -980,9 +992,9 @@ describe('useWorkflowSetupState', () => {
 
 		it('should count incomplete credential type cards', () => {
 			const node = createNode({ name: 'TestNode' });
-			workflowsStore.allNodes = [node];
+			mockWorkflowDocumentStore.allNodes = [node];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'credA' }, { name: 'credB' }]);
-			workflowsStore.getNodeByName = vi.fn().mockReturnValue(node);
+			mockWorkflowDocumentStore.getNodeByName = vi.fn().mockReturnValue(node);
 
 			const { totalCredentialsMissing } = useWorkflowSetupState();
 
@@ -996,12 +1008,12 @@ describe('useWorkflowSetupState', () => {
 					testApi: { id: 'cred-1', name: 'Test' },
 				},
 			});
-			workflowsStore.allNodes = [node];
+			mockWorkflowDocumentStore.allNodes = [node];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'testApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'Test',
 			});
-			workflowsStore.getNodeByName = vi.fn().mockReturnValue(node);
+			mockWorkflowDocumentStore.getNodeByName = vi.fn().mockReturnValue(node);
 
 			const { totalCredentialsMissing } = useWorkflowSetupState();
 
@@ -1020,12 +1032,12 @@ describe('useWorkflowSetupState', () => {
 					},
 				},
 			});
-			workflowsStore.allNodes = [node];
+			mockWorkflowDocumentStore.allNodes = [node];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'testApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'Test',
 			});
-			workflowsStore.getNodeByName = vi.fn().mockReturnValue(node);
+			mockWorkflowDocumentStore.getNodeByName = vi.fn().mockReturnValue(node);
 
 			const { totalCredentialsMissing } = useWorkflowSetupState();
 
@@ -1035,12 +1047,12 @@ describe('useWorkflowSetupState', () => {
 		it('should count shared credential type only once even when multiple nodes need it', () => {
 			const node1 = createNode({ name: 'Node1', position: [0, 0] });
 			const node2 = createNode({ name: 'Node2', position: [100, 0] });
-			workflowsStore.allNodes = [node1, node2];
+			mockWorkflowDocumentStore.allNodes = [node1, node2];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'openAiApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'OpenAI API',
 			});
-			workflowsStore.getNodeByName = vi.fn((name: string) => {
+			mockWorkflowDocumentStore.getNodeByName = vi.fn((name: string) => {
 				if (name === 'Node1') return node1;
 				if (name === 'Node2') return node2;
 				return null;
@@ -1055,7 +1067,7 @@ describe('useWorkflowSetupState', () => {
 
 	describe('totalCardsRequiringSetup', () => {
 		it('should return 0 when no cards exist', () => {
-			workflowsStore.allNodes = [];
+			mockWorkflowDocumentStore.allNodes = [];
 
 			const { totalCardsRequiringSetup } = useWorkflowSetupState();
 
@@ -1073,7 +1085,7 @@ describe('useWorkflowSetupState', () => {
 				type: 'n8n-nodes-base.regular',
 				position: [100, 0],
 			});
-			workflowsStore.allNodes = [triggerNode, regularNode];
+			mockWorkflowDocumentStore.allNodes = [triggerNode, regularNode];
 			nodeTypesStore.isTriggerNode = vi.fn(
 				(type: string) => type === 'n8n-nodes-base.manualTrigger',
 			);
@@ -1084,7 +1096,7 @@ describe('useWorkflowSetupState', () => {
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'Test',
 			});
-			workflowsStore.getNodeByName = vi.fn((name: string) => {
+			mockWorkflowDocumentStore.getNodeByName = vi.fn((name: string) => {
 				if (name === 'ManualTrigger') return triggerNode;
 				if (name === 'Regular') return regularNode;
 				return null;
@@ -1101,13 +1113,13 @@ describe('useWorkflowSetupState', () => {
 				name: 'SlackTrigger',
 				type: 'n8n-nodes-base.slackTrigger',
 			});
-			workflowsStore.allNodes = [triggerNode];
+			mockWorkflowDocumentStore.allNodes = [triggerNode];
 			nodeTypesStore.isTriggerNode = vi.fn().mockReturnValue(true);
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'slackApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'Slack API',
 			});
-			workflowsStore.getNodeByName = vi.fn().mockReturnValue(triggerNode);
+			mockWorkflowDocumentStore.getNodeByName = vi.fn().mockReturnValue(triggerNode);
 
 			const { totalCardsRequiringSetup } = useWorkflowSetupState();
 
@@ -1126,13 +1138,13 @@ describe('useWorkflowSetupState', () => {
 				type: 'n8n-nodes-base.slackTrigger',
 				position: [100, 0],
 			});
-			workflowsStore.allNodes = [trigger1, trigger2];
+			mockWorkflowDocumentStore.allNodes = [trigger1, trigger2];
 			nodeTypesStore.isTriggerNode = vi.fn().mockReturnValue(true);
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'slackApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'Slack API',
 			});
-			workflowsStore.getNodeByName = vi.fn((name: string) => {
+			mockWorkflowDocumentStore.getNodeByName = vi.fn((name: string) => {
 				if (name === 'SlackTrigger1') return trigger1;
 				if (name === 'SlackTrigger2') return trigger2;
 				return null;
@@ -1149,13 +1161,13 @@ describe('useWorkflowSetupState', () => {
 		it('should use provided nodes ref instead of store nodes', () => {
 			const customNode = createNode({ name: 'CustomNode' });
 			const storeNode = createNode({ name: 'StoreNode' });
-			workflowsStore.allNodes = [storeNode];
+			mockWorkflowDocumentStore.allNodes = [storeNode];
 
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'testApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'Test',
 			});
-			workflowsStore.getNodeByName = vi.fn().mockReturnValue(customNode);
+			mockWorkflowDocumentStore.getNodeByName = vi.fn().mockReturnValue(customNode);
 
 			const nodesRef = ref<INodeUi[]>([customNode]);
 			const { setupCards } = useWorkflowSetupState(nodesRef);
@@ -1177,7 +1189,7 @@ describe('useWorkflowSetupState', () => {
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'Test',
 			});
-			workflowsStore.getNodeByName = vi.fn((name: string) => {
+			mockWorkflowDocumentStore.getNodeByName = vi.fn((name: string) => {
 				if (name === 'Node1') return node1;
 				if (name === 'Node2') return node2;
 				return null;
@@ -1213,12 +1225,12 @@ describe('useWorkflowSetupState', () => {
 					openAiApi: { id: 'cred-1', name: 'My OpenAI' },
 				},
 			});
-			workflowsStore.allNodes = [node1, node2];
+			mockWorkflowDocumentStore.allNodes = [node1, node2];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'openAiApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'OpenAI API',
 			});
-			workflowsStore.getNodeByName = vi.fn((name: string) => {
+			mockWorkflowDocumentStore.getNodeByName = vi.fn((name: string) => {
 				if (name === 'OpenAI1') return node1;
 				if (name === 'OpenAI2') return node2;
 				return null;
@@ -1246,12 +1258,12 @@ describe('useWorkflowSetupState', () => {
 					openAiApi: { id: 'cred-1', name: 'My OpenAI' },
 				},
 			});
-			workflowsStore.allNodes = [node];
+			mockWorkflowDocumentStore.allNodes = [node];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'openAiApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'OpenAI API',
 			});
-			workflowsStore.getNodeByName = vi.fn().mockReturnValue(node);
+			mockWorkflowDocumentStore.getNodeByName = vi.fn().mockReturnValue(node);
 
 			useWorkflowSetupState();
 
@@ -1268,7 +1280,7 @@ describe('useWorkflowSetupState', () => {
 					slackApi: { id: 'cred-2', name: 'My Slack' },
 				},
 			});
-			workflowsStore.allNodes = [node];
+			mockWorkflowDocumentStore.allNodes = [node];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([
 				{ name: 'openAiApi' },
 				{ name: 'slackApi' },
@@ -1276,7 +1288,7 @@ describe('useWorkflowSetupState', () => {
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'Test',
 			});
-			workflowsStore.getNodeByName = vi.fn().mockReturnValue(node);
+			mockWorkflowDocumentStore.getNodeByName = vi.fn().mockReturnValue(node);
 
 			useWorkflowSetupState();
 
@@ -1296,13 +1308,13 @@ describe('useWorkflowSetupState', () => {
 	describe('testCredentialInBackground', () => {
 		it('should trigger background test when setCredential is called', async () => {
 			const node = createNode({ name: 'OpenAI' });
-			workflowsStore.allNodes = [node];
+			mockWorkflowDocumentStore.allNodes = [node];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'openAiApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'OpenAI API',
 				test: { request: {} },
 			});
-			workflowsStore.getNodeByName = vi.fn().mockReturnValue(node);
+			mockWorkflowDocumentStore.getNodeByName = vi.fn().mockReturnValue(node);
 			credentialsStore.getCredentialById = vi.fn().mockReturnValue({
 				id: 'cred-1',
 				name: 'My OpenAI Key',
@@ -1329,13 +1341,13 @@ describe('useWorkflowSetupState', () => {
 
 		it('should skip test when credential is already tested OK', async () => {
 			const node = createNode({ name: 'OpenAI' });
-			workflowsStore.allNodes = [node];
+			mockWorkflowDocumentStore.allNodes = [node];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'openAiApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'OpenAI API',
 				test: { request: {} },
 			});
-			workflowsStore.getNodeByName = vi.fn().mockReturnValue(node);
+			mockWorkflowDocumentStore.getNodeByName = vi.fn().mockReturnValue(node);
 			credentialsStore.getCredentialById = vi.fn().mockReturnValue({
 				id: 'cred-1',
 				name: 'My OpenAI Key',
@@ -1352,13 +1364,13 @@ describe('useWorkflowSetupState', () => {
 
 		it('should skip test when a test is already pending', async () => {
 			const node = createNode({ name: 'OpenAI' });
-			workflowsStore.allNodes = [node];
+			mockWorkflowDocumentStore.allNodes = [node];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'openAiApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'OpenAI API',
 				test: { request: {} },
 			});
-			workflowsStore.getNodeByName = vi.fn().mockReturnValue(node);
+			mockWorkflowDocumentStore.getNodeByName = vi.fn().mockReturnValue(node);
 			credentialsStore.getCredentialById = vi.fn().mockReturnValue({
 				id: 'cred-1',
 				name: 'My OpenAI Key',
@@ -1376,13 +1388,13 @@ describe('useWorkflowSetupState', () => {
 
 		it('should mark OAuth credentials as success without calling testCredential', async () => {
 			const node = createNode({ name: 'Google' });
-			workflowsStore.allNodes = [node];
+			mockWorkflowDocumentStore.allNodes = [node];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'googleApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'Google API',
 				test: { request: {} },
 			});
-			workflowsStore.getNodeByName = vi.fn().mockReturnValue(node);
+			mockWorkflowDocumentStore.getNodeByName = vi.fn().mockReturnValue(node);
 			credentialsStore.getCredentialById = vi.fn().mockReturnValue({
 				id: 'cred-1',
 				name: 'My Google',
@@ -1405,13 +1417,13 @@ describe('useWorkflowSetupState', () => {
 
 		it('should skip test for non-testable credential types', async () => {
 			const node = createNode({ name: 'HttpRequest' });
-			workflowsStore.allNodes = [node];
+			mockWorkflowDocumentStore.allNodes = [node];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'httpHeaderAuth' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'Header Auth',
 			});
 			credentialsStore.getNodesWithAccess = vi.fn().mockReturnValue([]);
-			workflowsStore.getNodeByName = vi.fn().mockReturnValue(node);
+			mockWorkflowDocumentStore.getNodeByName = vi.fn().mockReturnValue(node);
 			credentialsStore.getCredentialById = vi.fn().mockReturnValue({
 				id: 'cred-1',
 				name: 'My Header Auth',
@@ -1446,13 +1458,13 @@ describe('useWorkflowSetupState', () => {
 					openAiApi: { id: 'cred-1', name: 'My OpenAI Key' },
 				},
 			});
-			workflowsStore.allNodes = [node];
+			mockWorkflowDocumentStore.allNodes = [node];
 			mockGetNodeTypeDisplayableCredentials.mockReturnValue([{ name: 'openAiApi' }]);
 			credentialsStore.getCredentialTypeByName = vi.fn().mockReturnValue({
 				displayName: 'OpenAI API',
 				test: { request: {} },
 			});
-			workflowsStore.getNodeByName = vi.fn().mockReturnValue(node);
+			mockWorkflowDocumentStore.getNodeByName = vi.fn().mockReturnValue(node);
 
 			useWorkflowSetupState();
 

--- a/packages/frontend/editor-ui/src/features/setupPanel/composables/useWorkflowSetupState.ts
+++ b/packages/frontend/editor-ui/src/features/setupPanel/composables/useWorkflowSetupState.ts
@@ -12,7 +12,7 @@ import {
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useEnvironmentsStore } from '@/features/settings/environments.ee/environments.store';
-import { injectWorkflowState } from '@/app/composables/useWorkflowState';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 
 import {
 	getNodeCredentialTypes,
@@ -36,9 +36,9 @@ export const useWorkflowSetupState = (nodes?: Ref<INodeUi[]>) => {
 	const nodeTypesStore = useNodeTypesStore();
 	const environmentsStore = useEnvironmentsStore();
 	const nodeHelpers = useNodeHelpers();
-	const workflowState = injectWorkflowState();
+	const workflowDocumentStore = injectWorkflowDocumentStore();
 
-	const sourceNodes = computed(() => nodes?.value ?? workflowsStore.allNodes);
+	const sourceNodes = computed(() => nodes?.value ?? workflowDocumentStore?.value?.allNodes ?? []);
 
 	const getCredentialDisplayName = (credentialType: string): string => {
 		const credentialTypeInfo = credentialsStore.getCredentialTypeByName(credentialType);
@@ -372,9 +372,9 @@ export const useWorkflowSetupState = (nodes?: Ref<INodeUi[]>) => {
 		void testCredentialInBackground(credentialId, credential.name, credentialType);
 
 		const assignCredentialToNode = (nodeName: string) => {
-			const node = workflowsStore.getNodeByName(nodeName);
+			const node = workflowDocumentStore?.value?.getNodeByName(nodeName);
 			if (!node) return;
-			workflowState.updateNodeProperties({
+			workflowDocumentStore?.value?.updateNodeProperties({
 				name: nodeName,
 				properties: {
 					credentials: {
@@ -407,13 +407,13 @@ export const useWorkflowSetupState = (nodes?: Ref<INodeUi[]>) => {
 		if (!credState) return;
 
 		for (const stateNode of credState.nodes) {
-			const node = workflowsStore.getNodeByName(stateNode.name);
+			const node = workflowDocumentStore?.value?.getNodeByName(stateNode.name);
 			if (!node) continue;
 
 			const updatedCredentials = { ...node.credentials };
 			delete updatedCredentials[credentialType];
 
-			workflowState.updateNodeProperties({
+			workflowDocumentStore?.value?.updateNodeProperties({
 				name: stateNode.name,
 				properties: {
 					credentials: updatedCredentials,

--- a/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.test.ts
@@ -89,11 +89,18 @@ const EMPTY_WORKFLOW = {
 	meta: { templateId: '2722', templateCredsSetupCompleted: true },
 };
 
-function setDocumentStoreMeta(meta: Record<string, unknown>) {
-	const docStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId));
-	// Note: createTestingPinia() stubs actions by default, so setMeta() won't work
-	Object.defineProperty(docStore, 'meta', { value: meta, configurable: true });
-	workflowDocumentStoreRef.value = docStore;
+function setWorkflowDocumentStoreState(meta: Record<string, unknown>, nodes: unknown[] = []) {
+	const workflowDocumentStore = useWorkflowDocumentStore(
+		createWorkflowDocumentId(workflowsStore.workflowId),
+	);
+	// Note: createTestingPinia() stubs actions by default, so setMeta()/getNodes() won't work
+	Object.defineProperty(workflowDocumentStore, 'meta', { value: meta, configurable: true });
+	Object.defineProperty(workflowDocumentStore, 'getNodes', {
+		value: () => nodes.map((n) => ({ ...(n as Record<string, unknown>) })),
+		configurable: true,
+	});
+	Object.defineProperty(workflowDocumentStore, 'allNodes', { value: nodes, configurable: true });
+	workflowDocumentStoreRef.value = workflowDocumentStore;
 }
 
 describe('SetupWorkflowCredentialsButton', () => {
@@ -109,15 +116,13 @@ describe('SetupWorkflowCredentialsButton', () => {
 
 	it('renders', () => {
 		workflowsStore.workflow = EMPTY_WORKFLOW;
-		setDocumentStoreMeta(EMPTY_WORKFLOW.meta);
-		workflowsStore.getNodes.mockReturnValue([]);
+		setWorkflowDocumentStoreState(EMPTY_WORKFLOW.meta, []);
 		expect(() => renderComponent()).not.toThrow();
 	});
 
 	it('does not render the button if there are no nodes', () => {
 		workflowsStore.workflow = EMPTY_WORKFLOW;
-		setDocumentStoreMeta(EMPTY_WORKFLOW.meta);
-		workflowsStore.getNodes.mockReturnValue([]);
+		setWorkflowDocumentStoreState(EMPTY_WORKFLOW.meta, []);
 		const { queryByTestId } = renderComponent();
 		expect(queryByTestId('setup-credentials-button')).toBeNull();
 	});
@@ -137,8 +142,7 @@ describe('SetupWorkflowCredentialsButton', () => {
 			],
 		};
 		workflowsStore.workflow = workflowWithNodes;
-		setDocumentStoreMeta(workflowWithNodes.meta);
-		workflowsStore.getNodes.mockReturnValue(workflowWithNodes.nodes as never);
+		setWorkflowDocumentStoreState(workflowWithNodes.meta, workflowWithNodes.nodes);
 		setupPanelStore.isFeatureEnabled = true;
 		focusPanelStore.focusPanelActive = true;
 		focusPanelStore.selectedTab = 'setup';
@@ -162,8 +166,7 @@ describe('SetupWorkflowCredentialsButton', () => {
 			],
 		};
 		workflowsStore.workflow = workflowWithNodes;
-		setDocumentStoreMeta(workflowWithNodes.meta);
-		workflowsStore.getNodes.mockReturnValue(workflowWithNodes.nodes as never);
+		setWorkflowDocumentStoreState(workflowWithNodes.meta, workflowWithNodes.nodes);
 		setupPanelStore.isFeatureEnabled = true;
 		focusPanelStore.focusPanelActive = false;
 
@@ -187,8 +190,7 @@ describe('SetupWorkflowCredentialsButton', () => {
 			],
 		};
 		workflowsStore.workflow = workflowWithNodes;
-		setDocumentStoreMeta(workflowWithNodes.meta);
-		workflowsStore.getNodes.mockReturnValue(workflowWithNodes.nodes as never);
+		setWorkflowDocumentStoreState(workflowWithNodes.meta, workflowWithNodes.nodes);
 		mockDoesNodeHaveAllCredentialsFilled.mockReturnValue(false);
 		setupPanelStore.isFeatureEnabled = false;
 		focusPanelStore.focusPanelActive = true;
@@ -214,8 +216,7 @@ describe('SetupWorkflowCredentialsButton', () => {
 			],
 		};
 		workflowsStore.workflow = readyToRunWorkflow;
-		setDocumentStoreMeta(readyToRunWorkflow.meta);
-		workflowsStore.getNodes.mockReturnValue(readyToRunWorkflow.nodes as never);
+		setWorkflowDocumentStoreState(readyToRunWorkflow.meta, readyToRunWorkflow.nodes);
 
 		mockGetVariant.mockReturnValue(TEMPLATE_SETUP_EXPERIENCE.variant);
 
@@ -234,8 +235,7 @@ describe('SetupWorkflowCredentialsButton', () => {
 			nodes: [],
 		};
 		workflowsStore.workflow = templateWorkflow;
-		setDocumentStoreMeta(templateWorkflow.meta);
-		workflowsStore.getNodes.mockReturnValue([]);
+		setWorkflowDocumentStoreState(templateWorkflow.meta, []);
 
 		mockGetVariant.mockReturnValue(TEMPLATE_SETUP_EXPERIENCE.variant);
 		mockRouteQuery.mockReturnValue({ templateId: 'ready-to-run-ai-workflow-v5' });
@@ -266,8 +266,10 @@ describe('SetupWorkflowCredentialsButton', () => {
 
 		it('opens modal when all conditions are met and setup panel is disabled', async () => {
 			workflowsStore.workflow = workflowWithUnfilledCredentials;
-			setDocumentStoreMeta(workflowWithUnfilledCredentials.meta);
-			workflowsStore.getNodes.mockReturnValue(workflowWithUnfilledCredentials.nodes as never);
+			setWorkflowDocumentStoreState(
+				workflowWithUnfilledCredentials.meta,
+				workflowWithUnfilledCredentials.nodes,
+			);
 			mockDoesNodeHaveAllCredentialsFilled.mockReturnValue(false);
 			mockGetVariant.mockReturnValue(TEMPLATE_SETUP_EXPERIENCE.variant);
 			readyToRunStore.isReadyToRunTemplateId.mockReturnValue(false);
@@ -282,8 +284,10 @@ describe('SetupWorkflowCredentialsButton', () => {
 
 		it('opens setup panel when all conditions are met and setup panel is enabled', async () => {
 			workflowsStore.workflow = workflowWithUnfilledCredentials;
-			setDocumentStoreMeta(workflowWithUnfilledCredentials.meta);
-			workflowsStore.getNodes.mockReturnValue(workflowWithUnfilledCredentials.nodes as never);
+			setWorkflowDocumentStoreState(
+				workflowWithUnfilledCredentials.meta,
+				workflowWithUnfilledCredentials.nodes,
+			);
 			mockDoesNodeHaveAllCredentialsFilled.mockReturnValue(false);
 			mockGetVariant.mockReturnValue(TEMPLATE_SETUP_EXPERIENCE.variant);
 			readyToRunStore.isReadyToRunTemplateId.mockReturnValue(false);
@@ -300,8 +304,10 @@ describe('SetupWorkflowCredentialsButton', () => {
 
 		it('does not open modal when not on template import route (no templateId in query)', () => {
 			workflowsStore.workflow = workflowWithUnfilledCredentials;
-			setDocumentStoreMeta(workflowWithUnfilledCredentials.meta);
-			workflowsStore.getNodes.mockReturnValue(workflowWithUnfilledCredentials.nodes as never);
+			setWorkflowDocumentStoreState(
+				workflowWithUnfilledCredentials.meta,
+				workflowWithUnfilledCredentials.nodes,
+			);
 			mockDoesNodeHaveAllCredentialsFilled.mockReturnValue(false);
 			mockGetVariant.mockReturnValue(TEMPLATE_SETUP_EXPERIENCE.variant);
 			readyToRunStore.isReadyToRunTemplateId.mockReturnValue(false);
@@ -314,8 +320,10 @@ describe('SetupWorkflowCredentialsButton', () => {
 
 		it('does not open modal when feature flag is disabled', () => {
 			workflowsStore.workflow = workflowWithUnfilledCredentials;
-			setDocumentStoreMeta(workflowWithUnfilledCredentials.meta);
-			workflowsStore.getNodes.mockReturnValue(workflowWithUnfilledCredentials.nodes as never);
+			setWorkflowDocumentStoreState(
+				workflowWithUnfilledCredentials.meta,
+				workflowWithUnfilledCredentials.nodes,
+			);
 			mockDoesNodeHaveAllCredentialsFilled.mockReturnValue(false);
 			mockGetVariant.mockReturnValue('control');
 			readyToRunStore.isReadyToRunTemplateId.mockReturnValue(false);
@@ -332,8 +340,7 @@ describe('SetupWorkflowCredentialsButton', () => {
 				meta: { templateId: '123', templateCredsSetupCompleted: true },
 			};
 			workflowsStore.workflow = completedWorkflow;
-			setDocumentStoreMeta(completedWorkflow.meta);
-			workflowsStore.getNodes.mockReturnValue(completedWorkflow.nodes as never);
+			setWorkflowDocumentStoreState(completedWorkflow.meta, completedWorkflow.nodes);
 			mockDoesNodeHaveAllCredentialsFilled.mockReturnValue(false);
 			mockGetVariant.mockReturnValue(TEMPLATE_SETUP_EXPERIENCE.variant);
 			readyToRunStore.isReadyToRunTemplateId.mockReturnValue(false);
@@ -350,8 +357,7 @@ describe('SetupWorkflowCredentialsButton', () => {
 				meta: {},
 			};
 			workflowsStore.workflow = nonTemplateWorkflow;
-			setDocumentStoreMeta(nonTemplateWorkflow.meta);
-			workflowsStore.getNodes.mockReturnValue(nonTemplateWorkflow.nodes as never);
+			setWorkflowDocumentStoreState(nonTemplateWorkflow.meta, nonTemplateWorkflow.nodes);
 			mockDoesNodeHaveAllCredentialsFilled.mockReturnValue(false);
 			mockGetVariant.mockReturnValue(TEMPLATE_SETUP_EXPERIENCE.variant);
 			readyToRunStore.isReadyToRunTemplateId.mockReturnValue(false);
@@ -364,8 +370,10 @@ describe('SetupWorkflowCredentialsButton', () => {
 
 		it('does not open modal when all credentials are already filled', () => {
 			workflowsStore.workflow = workflowWithUnfilledCredentials;
-			setDocumentStoreMeta(workflowWithUnfilledCredentials.meta);
-			workflowsStore.getNodes.mockReturnValue(workflowWithUnfilledCredentials.nodes as never);
+			setWorkflowDocumentStoreState(
+				workflowWithUnfilledCredentials.meta,
+				workflowWithUnfilledCredentials.nodes,
+			);
 			mockDoesNodeHaveAllCredentialsFilled.mockReturnValue(true);
 			mockGetVariant.mockReturnValue(TEMPLATE_SETUP_EXPERIENCE.variant);
 			readyToRunStore.isReadyToRunTemplateId.mockReturnValue(false);
@@ -378,8 +386,10 @@ describe('SetupWorkflowCredentialsButton', () => {
 
 		it('does not open modal for ready-to-run workflows', () => {
 			workflowsStore.workflow = workflowWithUnfilledCredentials;
-			setDocumentStoreMeta(workflowWithUnfilledCredentials.meta);
-			workflowsStore.getNodes.mockReturnValue(workflowWithUnfilledCredentials.nodes as never);
+			setWorkflowDocumentStoreState(
+				workflowWithUnfilledCredentials.meta,
+				workflowWithUnfilledCredentials.nodes,
+			);
 			mockDoesNodeHaveAllCredentialsFilled.mockReturnValue(false);
 			mockGetVariant.mockReturnValue(TEMPLATE_SETUP_EXPERIENCE.variant);
 			readyToRunStore.isReadyToRunTemplateId.mockReturnValue(true);

--- a/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.vue
@@ -5,7 +5,6 @@ import { SETUP_CREDENTIALS_MODAL_KEY, TEMPLATE_SETUP_EXPERIENCE } from '@/app/co
 import { useUIStore } from '@/app/stores/ui.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useFocusPanelStore } from '@/app/stores/focusPanel.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { doesNodeHaveAllCredentialsFilled } from '@/app/utils/nodes/nodeTransforms';
 
 import { N8nButton } from '@n8n/design-system';
@@ -16,7 +15,6 @@ import { useRoute } from 'vue-router';
 import { useSetupPanelStore } from '@/features/setupPanel/setupPanel.store';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 
-const workflowsStore = useWorkflowsStore();
 const readyToRunStore = useReadyToRunStore();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 const nodeTypesStore = useNodeTypesStore();
@@ -40,7 +38,7 @@ const allCredentialsFilled = computed(() => {
 		return true;
 	}
 
-	const nodes = workflowsStore.getNodes();
+	const nodes = workflowDocumentStore?.value?.getNodes() ?? [];
 	if (!nodes.length) {
 		return true;
 	}
@@ -65,7 +63,7 @@ const showButton = computed(() => {
 	}
 
 	if (isSetupPanelFeatureEnabled.value) {
-		return workflowsStore.getNodes().length > 0;
+		return (workflowDocumentStore?.value?.getNodes() ?? []).length > 0;
 	}
 
 	if (isTemplateSetupCompleted.value) {

--- a/packages/frontend/editor-ui/src/features/workflows/templates/composables/useSetupWorkflowCredentialsModalState.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/composables/useSetupWorkflowCredentialsModalState.ts
@@ -2,19 +2,17 @@ import { computed } from 'vue';
 import type { INodeCredentialsDetails } from 'n8n-workflow';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import type { TemplateCredentialKey } from '../utils/templateTransforms';
 import { useCredentialSetupState } from './useCredentialSetupState';
-import { injectWorkflowState } from '@/app/composables/useWorkflowState';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 
 export const useSetupWorkflowCredentialsModalState = () => {
-	const workflowsStore = useWorkflowsStore();
-	const workflowState = injectWorkflowState();
+	const workflowDocumentStore = injectWorkflowDocumentStore();
 	const credentialsStore = useCredentialsStore();
 	const nodeHelpers = useNodeHelpers();
 
 	const workflowNodes = computed(() => {
-		return workflowsStore.allNodes;
+		return workflowDocumentStore?.value?.allNodes ?? [];
 	});
 
 	const {
@@ -65,7 +63,7 @@ export const useSetupWorkflowCredentialsModalState = () => {
 		};
 
 		usages.usedBy.forEach((node) => {
-			workflowState.updateNodeProperties({
+			workflowDocumentStore?.value?.updateNodeProperties({
 				name: node.name,
 				properties: {
 					credentials: {
@@ -99,7 +97,7 @@ export const useSetupWorkflowCredentialsModalState = () => {
 			const credentials = { ...node.credentials };
 			delete credentials[usages.credentialType];
 
-			workflowState.updateNodeProperties({
+			workflowDocumentStore?.value?.updateNodeProperties({
 				name: node.name,
 				properties: {
 					credentials,

--- a/packages/frontend/editor-ui/src/features/workflows/templates/composables/useSetupWorkflowCredentialsModalState.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/composables/useSetupWorkflowCredentialsModalState.ts
@@ -2,17 +2,30 @@ import { computed } from 'vue';
 import type { INodeCredentialsDetails } from 'n8n-workflow';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import type { TemplateCredentialKey } from '../utils/templateTransforms';
 import { useCredentialSetupState } from './useCredentialSetupState';
-import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 
 export const useSetupWorkflowCredentialsModalState = () => {
-	const workflowDocumentStore = injectWorkflowDocumentStore();
+	const workflowsStore = useWorkflowsStore();
 	const credentialsStore = useCredentialsStore();
 	const nodeHelpers = useNodeHelpers();
 
+	// This composable is used inside a modal that renders outside the WorkflowLayout
+	// provider tree, so we can't use injectWorkflowDocumentStore(). Instead, we
+	// access the Pinia store directly using the current workflow ID.
+	const workflowDocumentStore = computed(() => {
+		const workflowId = workflowsStore.workflowId;
+		if (!workflowId) return undefined;
+		return useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
+	});
+
 	const workflowNodes = computed(() => {
-		return workflowDocumentStore?.value?.allNodes ?? [];
+		return workflowDocumentStore.value?.allNodes ?? [];
 	});
 
 	const {
@@ -63,7 +76,7 @@ export const useSetupWorkflowCredentialsModalState = () => {
 		};
 
 		usages.usedBy.forEach((node) => {
-			workflowDocumentStore?.value?.updateNodeProperties({
+			workflowDocumentStore.value?.updateNodeProperties({
 				name: node.name,
 				properties: {
 					credentials: {
@@ -97,7 +110,7 @@ export const useSetupWorkflowCredentialsModalState = () => {
 			const credentials = { ...node.credentials };
 			delete credentials[usages.credentialType];
 
-			workflowDocumentStore?.value?.updateNodeProperties({
+			workflowDocumentStore.value?.updateNodeProperties({
 				name: node.name,
 				properties: {
 					credentials,


### PR DESCRIPTION
## Summary

Update useWorkflowSetupState, SetupWorkflowCredentialsButton, and useSetupWorkflowCredentialsModalState to use injectWorkflowDocumentStore instead of useWorkflowsStore and injectWorkflowState for accessing workflow nodes and updating node properties.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2522/migrate-credentials-and-setup-panel-to-workflowdocumentstore

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
