### PR TITLE
test(Discord Node): Fix flaky roleRemove test with proper nock setup (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Discord/test/v2/node/member/roleRemove.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/member/roleRemove.test.ts
@@ -2,10 +2,16 @@ import { NodeTestHarness } from '@nodes-testing/node-test-harness';
 import nock from 'nock';
 
 describe('Test DiscordV2, member => roleRemove', () => {
-	nock('https://discord.com/api/v10')
-		.persist()
-		.delete(/\/guilds\/1168516062791340136\/members\/470936827994570762\/roles\/\d+/)
-		.reply(200, { success: true });
+	beforeEach(() => {
+		nock('https://discord.com/api/v10')
+			.persist()
+			.delete(/\/guilds\/1168516062791340136\/members\/470936827994570762\/roles\/\d+/)
+			.reply(200, { success: true });
+	});
+
+	afterEach(() => {
+		nock.cleanAll();
+	});
 
 	new NodeTestHarness().setupTests({
 		workflowFiles: ['roleRemove.workflow.json'],


### PR DESCRIPTION
## Summary

Fixed intermittent test failure in the Discord roleRemove test by moving nock mock setup from the describe block into beforeEach/afterEach hooks. This prevents test isolation issues when tests run in parallel across Jest workers.

**Changes:**
- Moved nock mock registration to `beforeEach` to ensure fresh mocks for each test
- Added `afterEach(() => nock.cleanAll())` to properly clean up nock state
- Test verified with 20 consecutive passes

## How to test

Run the test multiple times:
```bash
cd packages/nodes-base
pnpm test nodes/Discord/test/v2/node/member/roleRemove.test.ts
```

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] Tests included (test fix itself)
- [x] No documentation changes needed