### PR TITLE
test: Add end-to-end SSRF integration coverage

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/request-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/request-helper-functions.test.ts
@@ -13,7 +13,6 @@ import type {
 	PaginationOptions,
 	Workflow,
 } from 'n8n-workflow';
-import { UserError } from 'n8n-workflow';
 import nock from 'nock';
 import type { SecureContextOptions } from 'tls';
 
@@ -1437,7 +1436,7 @@ describe('Request Helper Functions', () => {
 		});
 	});
 
-	describe('SSRF protection integration', () => {
+	describe('SSRF protection wiring', () => {
 		const baseUrl = 'https://example.com';
 		const workflow = mock<Workflow>();
 		const hooks = mock<ExecutionLifecycleHooks>();
@@ -1454,63 +1453,6 @@ describe('Request Helper Functions', () => {
 		beforeEach(() => {
 			nock.cleanAll();
 			hooks.runHook.mockClear();
-		});
-
-		describe('httpRequest (modern path)', () => {
-			test('should work normally when ssrfBridge is absent', async () => {
-				nock(baseUrl).get('/test').reply(200, { ok: true });
-
-				const response = await httpRequest({
-					method: 'GET',
-					url: `${baseUrl}/test`,
-				});
-
-				expect(response).toEqual({ ok: true });
-			});
-
-			test('should throw when validateUrl blocks a direct IP request', async () => {
-				const blockedError = new UserError('IP address is blocked');
-				const ssrfBridge = createSsrfBridge({
-					validateUrl: jest.fn().mockResolvedValue({ ok: false, error: blockedError }),
-				});
-				const additionalData = mock<IWorkflowExecuteAdditionalData>({
-					hooks,
-					ssrfBridge,
-				});
-
-				const { getRequestHelperFunctions } = await import('../request-helper-functions');
-				const helpers = getRequestHelperFunctions(workflow, node, additionalData, null, []);
-
-				await expect(
-					helpers.httpRequest({
-						method: 'GET',
-						url: 'http://127.0.0.1/secret',
-					}),
-				).rejects.toThrow('IP address is blocked');
-
-				expect(ssrfBridge.validateUrl).toHaveBeenCalledWith(new URL('http://127.0.0.1/secret'));
-			});
-
-			test('should validate hostname URLs with validateUrl', async () => {
-				const ssrfBridge = createSsrfBridge();
-				const additionalData = mock<IWorkflowExecuteAdditionalData>({
-					hooks,
-					ssrfBridge,
-				});
-
-				nock(baseUrl).get('/test').reply(200, { ok: true });
-
-				const { getRequestHelperFunctions } = await import('../request-helper-functions');
-				const helpers = getRequestHelperFunctions(workflow, node, additionalData, null, []);
-
-				const response = await helpers.httpRequest({
-					method: 'GET',
-					url: `${baseUrl}/test`,
-				});
-
-				expect(response).toEqual({ ok: true });
-				expect(ssrfBridge.validateUrl).toHaveBeenCalledWith(new URL(`${baseUrl}/test`));
-			});
 		});
 
 		describe('convertN8nRequestToAxios with ssrfBridge', () => {
@@ -1557,122 +1499,22 @@ describe('Request Helper Functions', () => {
 			});
 		});
 
-		describe('proxyRequestToAxios (legacy path)', () => {
-			test('should throw when validateUrl blocks a direct IP request', async () => {
-				const blockedError = new UserError('IP address is blocked');
-				const ssrfBridge = createSsrfBridge({
-					validateUrl: jest.fn().mockResolvedValue({ ok: false, error: blockedError }),
-				});
-				const additionalData = mock<IWorkflowExecuteAdditionalData>({
-					hooks,
-					ssrfBridge,
-				});
-
-				await expect(
-					proxyRequestToAxios(workflow, additionalData, node, 'http://10.0.0.1/internal'),
-				).rejects.toThrow('IP address is blocked');
-
-				expect(ssrfBridge.validateUrl).toHaveBeenCalledWith(new URL('http://10.0.0.1/internal'));
+		test('proxyRequestToAxios should resolve baseURL + relative url for validateUrl', async () => {
+			const ssrfBridge = createSsrfBridge();
+			const additionalData = mock<IWorkflowExecuteAdditionalData>({
+				hooks,
+				ssrfBridge,
 			});
 
-			test('should validate hostname URLs with validateUrl', async () => {
-				const ssrfBridge = createSsrfBridge();
-				const additionalData = mock<IWorkflowExecuteAdditionalData>({
-					hooks,
-					ssrfBridge,
-				});
+			nock(baseUrl).get('/test').reply(200, 'ok');
 
-				nock(baseUrl).get('/test').reply(200, 'ok');
-
-				const response = await proxyRequestToAxios(
-					workflow,
-					additionalData,
-					node,
-					`${baseUrl}/test`,
-				);
-
-				expect(response).toEqual('ok');
-				expect(ssrfBridge.validateUrl).toHaveBeenCalledWith(new URL(`${baseUrl}/test`));
+			const response = await proxyRequestToAxios(workflow, additionalData, node, {
+				baseURL: baseUrl,
+				url: '/test',
 			});
 
-			test('should validate hostname URLs with baseURL via validateUrl', async () => {
-				const ssrfBridge = createSsrfBridge();
-				const additionalData = mock<IWorkflowExecuteAdditionalData>({
-					hooks,
-					ssrfBridge,
-				});
-
-				nock(baseUrl).get('/test').reply(200, 'ok');
-
-				const response = await proxyRequestToAxios(workflow, additionalData, node, {
-					baseURL: baseUrl,
-					url: '/test',
-				});
-
-				expect(response).toEqual('ok');
-				expect(ssrfBridge.validateUrl).toHaveBeenCalledWith(new URL(`${baseUrl}/test`));
-			});
-
-			test('should work normally when ssrfBridge is absent', async () => {
-				const additionalData = mock<IWorkflowExecuteAdditionalData>({
-					hooks,
-					ssrfBridge: undefined,
-				});
-
-				nock(baseUrl).get('/test').reply(200, 'ok');
-
-				const response = await proxyRequestToAxios(
-					workflow,
-					additionalData,
-					node,
-					`${baseUrl}/test`,
-				);
-
-				expect(response).toEqual('ok');
-			});
-		});
-
-		describe('redirect validation', () => {
-			test('should call validateRedirectSync on redirect', async () => {
-				const ssrfBridge = createSsrfBridge();
-				const additionalData = mock<IWorkflowExecuteAdditionalData>({
-					hooks,
-					ssrfBridge,
-				});
-
-				nock(baseUrl)
-					.get('/redirect')
-					.reply(301, '', { Location: `${baseUrl}/target` });
-				nock(baseUrl).get('/target').reply(200, 'redirected');
-
-				const response = await proxyRequestToAxios(
-					workflow,
-					additionalData,
-					node,
-					`${baseUrl}/redirect`,
-				);
-
-				expect(response).toEqual('redirected');
-				expect(ssrfBridge.validateRedirectSync).toHaveBeenCalledWith(`${baseUrl}/target`);
-			});
-
-			test('should block redirect when validateRedirectSync throws', async () => {
-				const ssrfBridge = createSsrfBridge({
-					validateRedirectSync: jest.fn().mockImplementation(() => {
-						throw new UserError('SSRF: blocked redirect to internal IP');
-					}),
-				});
-				const additionalData = mock<IWorkflowExecuteAdditionalData>({
-					hooks,
-					ssrfBridge,
-				});
-
-				nock(baseUrl).get('/redirect').reply(301, '', { Location: 'http://127.0.0.1/evil' });
-
-				await expect(
-					proxyRequestToAxios(workflow, additionalData, node, `${baseUrl}/redirect`),
-				).rejects.toThrow('SSRF: blocked redirect to internal IP');
-			});
+			expect(response).toEqual('ok');
+			expect(ssrfBridge.validateUrl).toHaveBeenCalledWith(new URL(`${baseUrl}/test`));
 		});
 	});
 });

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/ssrf-integration.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/ssrf-integration.test.ts
@@ -1,0 +1,166 @@
+import type { Logger } from '@n8n/backend-common';
+import { SsrfProtectionConfig } from '@n8n/config';
+import { mock } from 'jest-mock-extended';
+import type {
+	INode,
+	IWorkflowExecuteAdditionalData,
+	IHttpRequestOptions,
+	Workflow,
+} from 'n8n-workflow';
+import { UserError } from 'n8n-workflow';
+import nock from 'nock';
+import type { LookupAddress, LookupOptions } from 'node:dns';
+
+import type { SsrfBridge } from '@/execution-engine';
+import type { ExecutionLifecycleHooks } from '@/execution-engine/execution-lifecycle-hooks';
+
+import { getRequestHelperFunctions, httpRequest } from '../request-helper-functions';
+
+type DnsResolverLike = {
+	lookup(hostname: string, options?: LookupOptions): Promise<LookupAddress[]>;
+};
+
+type SsrfProtectionServiceCtor = new (
+	config: SsrfProtectionConfig,
+	dnsResolver: DnsResolverLike,
+	logger: Logger,
+) => SsrfBridge;
+
+const { SsrfProtectionService } =
+	require('../../../../../../cli/src/services/ssrf/ssrf-protection.service') as {
+		SsrfProtectionService: SsrfProtectionServiceCtor;
+	};
+
+function createConfig(overrides: Partial<SsrfProtectionConfig> = {}): SsrfProtectionConfig {
+	const config = new SsrfProtectionConfig();
+	Object.assign(config, overrides);
+	return config;
+}
+
+function createMockDnsResolver(
+	entries: Record<string, LookupAddress[]> = {},
+): jest.Mocked<DnsResolverLike> {
+	return {
+		lookup: jest.fn(async (hostname) => entries[hostname] ?? []),
+	};
+}
+
+function createSsrfBridge(
+	configOverrides: Partial<SsrfProtectionConfig> = {},
+	dnsResolver = createMockDnsResolver(),
+): { ssrfBridge: SsrfBridge; dnsResolver: jest.Mocked<DnsResolverLike> } {
+	const scopedLogger = mock<Logger>();
+	const logger = mock<Logger>({ scoped: jest.fn().mockReturnValue(scopedLogger) });
+	const config = createConfig(configOverrides);
+
+	const ssrfBridge = new SsrfProtectionService(config, dnsResolver, logger);
+
+	return { ssrfBridge, dnsResolver };
+}
+
+function createRequestHelpers(ssrfBridge?: SsrfBridge) {
+	const workflow = mock<Workflow>();
+	const node = mock<INode>();
+	const hooks = mock<ExecutionLifecycleHooks>();
+	const additionalData = mock<IWorkflowExecuteAdditionalData>({
+		hooks,
+		ssrfBridge,
+	});
+
+	return getRequestHelperFunctions(workflow, node, additionalData, null, []);
+}
+
+describe('SSRF end-to-end integration', () => {
+	afterEach(() => {
+		nock.cleanAll();
+		jest.clearAllMocks();
+	});
+
+	test('blocks request to a private IP', async () => {
+		const { ssrfBridge } = createSsrfBridge();
+		const helpers = createRequestHelpers(ssrfBridge);
+
+		await expect(
+			helpers.httpRequest({ method: 'GET', url: 'http://10.0.0.1/secret' }),
+		).rejects.toThrow(UserError);
+	});
+
+	test('allows request to a public hostname', async () => {
+		const dnsResolver = createMockDnsResolver({
+			'example.com': [{ address: '93.184.216.34', family: 4 }],
+		});
+		const { ssrfBridge } = createSsrfBridge({}, dnsResolver);
+		const helpers = createRequestHelpers(ssrfBridge);
+
+		nock('https://example.com').get('/api').reply(200, { ok: true });
+
+		await expect(
+			helpers.httpRequest({ method: 'GET', url: 'https://example.com/api' }),
+		).resolves.toEqual({ ok: true });
+		expect(dnsResolver.lookup).toHaveBeenCalledWith('example.com', { all: true });
+	});
+
+	test('blocks redirects from public URLs to private IPs', async () => {
+		const dnsResolver = createMockDnsResolver({
+			'public.example': [{ address: '93.184.216.34', family: 4 }],
+		});
+		const { ssrfBridge } = createSsrfBridge({}, dnsResolver);
+		const helpers = createRequestHelpers(ssrfBridge);
+
+		nock('http://public.example')
+			.get('/redirect')
+			.reply(301, '', { Location: 'http://192.168.1.1/internal' });
+
+		await expect(
+			helpers.httpRequest({ method: 'GET', url: 'http://public.example/redirect' }),
+		).rejects.toThrow('IP address is blocked');
+	});
+
+	test('allows allowlisted hostname even when it resolves to private IP', async () => {
+		const dnsResolver = createMockDnsResolver({
+			'internal.corp': [{ address: '10.0.0.5', family: 4 }],
+		});
+		const { ssrfBridge } = createSsrfBridge({ allowedHostnames: ['internal.corp'] }, dnsResolver);
+		const helpers = createRequestHelpers(ssrfBridge);
+
+		nock('http://internal.corp').get('/health').reply(200, { ok: true });
+
+		await expect(
+			helpers.httpRequest({ method: 'GET', url: 'http://internal.corp/health' }),
+		).resolves.toEqual({ ok: true });
+	});
+
+	test('allows private IP within configured allowlisted range', async () => {
+		const { ssrfBridge } = createSsrfBridge({ allowedIpRanges: ['10.0.0.0/24'] });
+		const helpers = createRequestHelpers(ssrfBridge);
+
+		nock('http://10.0.0.5').get('/internal').reply(200, { ok: true });
+
+		await expect(
+			helpers.httpRequest({ method: 'GET', url: 'http://10.0.0.5/internal' }),
+		).resolves.toEqual({ ok: true });
+	});
+
+	test('passes requests through when ssrfBridge is not provided', async () => {
+		const helpers = createRequestHelpers(undefined);
+
+		nock('http://10.0.0.8').get('/open').reply(200, { ok: true });
+
+		await expect(
+			helpers.httpRequest({ method: 'GET', url: 'http://10.0.0.8/open' }),
+		).resolves.toEqual({
+			ok: true,
+		});
+	});
+
+	test('keeps module-level request helper unguarded for system-level calls', async () => {
+		nock('http://10.0.0.9').get('/system').reply(200, { ok: true });
+
+		const requestOptions: IHttpRequestOptions = {
+			method: 'GET',
+			url: 'http://10.0.0.9/system',
+		};
+
+		await expect(httpRequest(requestOptions)).resolves.toEqual({ ok: true });
+	});
+});


### PR DESCRIPTION
## Summary

Adds a dedicated SSRF end-to-end integration test suite in `packages/core/src/execution-engine/node-execution-context/utils/__tests__/ssrf-integration.test.ts` covering private IP blocking, public hostname allow, redirect blocking, hostname/IP allowlists, and unguarded system-level requests.
Refactors `packages/core/src/execution-engine/node-execution-context/utils/__tests__/request-helper-functions.test.ts` to keep SSRF wiring assertions there while removing duplicated integration-style coverage.
Tested with `pushd packages/core && pnpm test src/execution-engine/node-execution-context/utils/__tests__/request-helper-functions.test.ts --runInBand && pnpm test src/execution-engine/node-execution-context/utils/__tests__/ssrf-integration.test.ts --runInBand && popd`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2389

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
