### PR TITLE
fix: Replace `setTimeout` with deterministic waits in `MessagePort` transport tests (no-changelog)

### DIFF
--- a/packages/@n8n/crdt/src/transports/message-port.test.ts
+++ b/packages/@n8n/crdt/src/transports/message-port.test.ts
@@ -1,5 +1,21 @@
 import { MessagePortTransport } from './message-port';
 
+function waitForMessage(transport: MessagePortTransport): {
+	promise: Promise<Uint8Array>;
+	received: Uint8Array[];
+} {
+	const received: Uint8Array[] = [];
+	let resolve: (data: Uint8Array) => void;
+	const promise = new Promise<Uint8Array>((r) => {
+		resolve = r;
+	});
+	transport.onReceive((data) => {
+		received.push(data);
+		resolve(data);
+	});
+	return { promise, received };
+}
+
 describe('MessagePortTransport', () => {
 	let channel: MessageChannel;
 	let transport1: MessagePortTransport;
@@ -63,43 +79,37 @@ describe('MessagePortTransport', () => {
 		});
 
 		it('should send data from port1 to port2', async () => {
-			const received: Uint8Array[] = [];
-			transport2.onReceive((data) => received.push(data));
+			const { promise, received } = waitForMessage(transport2);
 
 			const testData = new Uint8Array([1, 2, 3, 4, 5]);
 			transport1.send(testData);
 
-			// MessagePort is async, need to wait
-			await new Promise((resolve) => setTimeout(resolve, 10));
+			await promise;
 
 			expect(received).toHaveLength(1);
 			expect(Array.from(received[0])).toEqual([1, 2, 3, 4, 5]);
 		});
 
 		it('should send data from port2 to port1', async () => {
-			const received: Uint8Array[] = [];
-			transport1.onReceive((data) => received.push(data));
+			const { promise, received } = waitForMessage(transport1);
 
 			const testData = new Uint8Array([5, 4, 3, 2, 1]);
 			transport2.send(testData);
 
-			await new Promise((resolve) => setTimeout(resolve, 10));
+			await promise;
 
 			expect(received).toHaveLength(1);
 			expect(Array.from(received[0])).toEqual([5, 4, 3, 2, 1]);
 		});
 
 		it('should support bidirectional communication', async () => {
-			const received1: Uint8Array[] = [];
-			const received2: Uint8Array[] = [];
-
-			transport1.onReceive((data) => received1.push(data));
-			transport2.onReceive((data) => received2.push(data));
+			const { promise: promise1, received: received1 } = waitForMessage(transport1);
+			const { promise: promise2, received: received2 } = waitForMessage(transport2);
 
 			transport1.send(new Uint8Array([1, 2, 3]));
 			transport2.send(new Uint8Array([4, 5, 6]));
 
-			await new Promise((resolve) => setTimeout(resolve, 10));
+			await Promise.all([promise1, promise2]);
 
 			expect(received1).toHaveLength(1);
 			expect(received2).toHaveLength(1);
@@ -108,15 +118,13 @@ describe('MessagePortTransport', () => {
 		});
 
 		it('should deliver to multiple handlers', async () => {
-			const received1: Uint8Array[] = [];
+			const { promise, received: received1 } = waitForMessage(transport2);
 			const received2: Uint8Array[] = [];
-
-			transport2.onReceive((data) => received1.push(data));
 			transport2.onReceive((data) => received2.push(data));
 
 			transport1.send(new Uint8Array([1, 2, 3]));
 
-			await new Promise((resolve) => setTimeout(resolve, 10));
+			await promise;
 
 			expect(received1).toHaveLength(1);
 			expect(received2).toHaveLength(1);
@@ -139,30 +147,45 @@ describe('MessagePortTransport', () => {
 
 		it('should stop receiving after unsubscribe', async () => {
 			const received: Uint8Array[] = [];
-			const unsubscribe = transport2.onReceive((data) => received.push(data));
+			let resolveFirst: () => void;
+			const firstMessage = new Promise<void>((r) => {
+				resolveFirst = r;
+			});
+			const unsubscribe = transport2.onReceive((data) => {
+				received.push(data);
+				resolveFirst();
+			});
 
 			transport1.send(new Uint8Array([1, 2, 3]));
-			await new Promise((resolve) => setTimeout(resolve, 10));
+			await firstMessage;
 			expect(received).toHaveLength(1);
 
 			unsubscribe();
 
 			transport1.send(new Uint8Array([4, 5, 6]));
-			await new Promise((resolve) => setTimeout(resolve, 10));
+			// No event to wait for since handler is removed; use a tick to confirm no delivery
+			await new Promise((resolve) => setTimeout(resolve, 50));
 			expect(received).toHaveLength(1); // No new data
 		});
 
 		it('should only unsubscribe the specific handler', async () => {
 			const received1: Uint8Array[] = [];
 			const received2: Uint8Array[] = [];
+			let resolveMessage: () => void;
+			const messageReceived = new Promise<void>((r) => {
+				resolveMessage = r;
+			});
 
 			const unsubscribe1 = transport2.onReceive((data) => received1.push(data));
-			transport2.onReceive((data) => received2.push(data));
+			transport2.onReceive((data) => {
+				received2.push(data);
+				resolveMessage();
+			});
 
 			unsubscribe1();
 
 			transport1.send(new Uint8Array([1, 2, 3]));
-			await new Promise((resolve) => setTimeout(resolve, 10));
+			await messageReceived;
 
 			expect(received1).toHaveLength(0);
 			expect(received2).toHaveLength(1);
@@ -176,8 +199,7 @@ describe('MessagePortTransport', () => {
 		});
 
 		it('should handle large payloads', async () => {
-			const received: Uint8Array[] = [];
-			transport2.onReceive((data) => received.push(data));
+			const { promise, received } = waitForMessage(transport2);
 
 			// 1MB payload
 			const largeData = new Uint8Array(1024 * 1024);
@@ -187,7 +209,7 @@ describe('MessagePortTransport', () => {
 
 			transport1.send(largeData);
 
-			await new Promise((resolve) => setTimeout(resolve, 50));
+			await promise;
 
 			expect(received).toHaveLength(1);
 			expect(received[0].length).toBe(1024 * 1024);


### PR DESCRIPTION
## Summary

Replace arbitrary setTimeout delays with a deterministic waitForMessage() helper that resolves when onReceive handlers actually fire. This eliminates race conditions that cause flaky tests under CI load, where 10ms timeouts aren't reliable for async MessagePort delivery.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2571/replace-settimeout-with-deterministic-waits-in-messageport-transport

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
