### PR TITLE
test: Fix selector-purity violations and enable method-level impact analysis (no-changelog)

### DIFF
--- a/packages/testing/janitor/src/cli.ts
+++ b/packages/testing/janitor/src/cli.ts
@@ -35,6 +35,7 @@ import {
 	formatBaselineInfo,
 	getBaselinePath,
 } from './core/baseline.js';
+import { extractDiffs } from './core/extract-diffs.js';
 import {
 	ImpactAnalyzer,
 	formatImpactConsole,
@@ -179,10 +180,10 @@ async function runImpact(options: CliOptions): Promise<void> {
 		return;
 	}
 
-	// No diffs passed — all files use conservative property-level resolution.
-	// Method-level precision requires pre-computed AST diffs (used by TCR flow).
+	const baseRef = options.baseRef ?? 'HEAD';
+	const diffs = extractDiffs(changedFiles, baseRef);
 	const analyzer = new ImpactAnalyzer(project);
-	const result = analyzer.analyze(changedFiles);
+	const result = analyzer.analyze(changedFiles, { diffs });
 
 	// Output
 	if (options.json) {
@@ -453,8 +454,10 @@ async function runOrchestrate(options: CliOptions): Promise<void> {
 			console.error('Impact: No changed files detected. Returning empty orchestration.');
 			specs = [];
 		} else {
+			const baseRef = options.baseRef ?? 'HEAD';
+			const diffs = extractDiffs(changedFiles, baseRef);
 			const impactAnalyzer = new ImpactAnalyzer(project);
-			const impactResult = impactAnalyzer.analyze(changedFiles);
+			const impactResult = impactAnalyzer.analyze(changedFiles, { diffs });
 			const affectedSet = new Set(impactResult.affectedTests);
 			const totalBefore = specs.length;
 			specs = specs.filter((s) => affectedSet.has(s.path));

--- a/packages/testing/janitor/src/cli/help.ts
+++ b/packages/testing/janitor/src/cli/help.ts
@@ -92,7 +92,7 @@ Files with modified/removed methods use method-level resolution for precision.
 Options:
   --file=<path>        Analyze a specific file
   --files=<p1,p2>      Analyze multiple files (comma-separated)
-  --base=<ref>         Git ref to diff against (default: HEAD)
+  --base=<ref>         Git ref to diff against (default: HEAD — compares working tree to HEAD)
   --json               Output as JSON (includes resolution strategies)
   --test-list          Output affected test paths only (for piping to playwright)
   --verbose, -v        Show dependency graph and resolution strategies

--- a/packages/testing/janitor/src/cli/help.ts
+++ b/packages/testing/janitor/src/cli/help.ts
@@ -85,8 +85,22 @@ export function showImpactHelp(): void {
 	console.log(`
 Impact - Find affected tests for changed files
 
-Options: --file=<path>, --files=<p1,p2>, --json, --test-list, --verbose
-Example: playwright-janitor impact --test-list | xargs npx playwright test
+Uses AST diffing to detect which methods were added, modified, or removed.
+Files with only added methods are skipped (can't break existing tests).
+Files with modified/removed methods use method-level resolution for precision.
+
+Options:
+  --file=<path>        Analyze a specific file
+  --files=<p1,p2>      Analyze multiple files (comma-separated)
+  --base=<ref>         Git ref to diff against (default: HEAD)
+  --json               Output as JSON (includes resolution strategies)
+  --test-list          Output affected test paths only (for piping to playwright)
+  --verbose, -v        Show dependency graph and resolution strategies
+
+Examples:
+  playwright-janitor impact                                    # Auto-detect from git status
+  playwright-janitor impact --files=pages/X.ts --base=main     # Diff against main branch
+  playwright-janitor impact --test-list | xargs npx playwright test
 `);
 }
 

--- a/packages/testing/janitor/src/core/extract-diffs.ts
+++ b/packages/testing/janitor/src/core/extract-diffs.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared utility for extracting AST diffs from changed files.
+ *
+ * Used by both the standalone `impact` CLI command and the TCR executor
+ * to enable method-level impact resolution.
+ */
+
+import { diffFileMethods, type FileDiffResult } from './ast-diff-analyzer.js';
+
+/**
+ * Extract AST diffs for source files (non-test .ts files).
+ * Test files are skipped — they're already included as directly changed.
+ */
+export function extractDiffs(changedFiles: string[], baseRef: string): FileDiffResult[] {
+	const diffs: FileDiffResult[] = [];
+	for (const file of changedFiles) {
+		if (file.endsWith('.ts') && !file.endsWith('.spec.ts')) {
+			diffs.push(diffFileMethods(file, baseRef));
+		}
+	}
+	return diffs;
+}

--- a/packages/testing/janitor/src/core/impact-analyzer.ts
+++ b/packages/testing/janitor/src/core/impact-analyzer.ts
@@ -376,7 +376,11 @@ export function formatImpactConsole(result: ImpactResult, verbose = false): void
 	console.log('====================================\n');
 
 	console.log(`Changed files: ${result.changedFiles.length}`);
-	result.changedFiles.forEach((f) => console.log(`  - ${f}`));
+	result.changedFiles.forEach((f) => {
+		const strategy = result.strategies[f];
+		const label = strategy ? ` [${strategy}]` : '';
+		console.log(`  - ${f}${label}`);
+	});
 
 	console.log(`\nAffected test files: ${result.affectedTests.length}`);
 	if (result.affectedTests.length === 0) {

--- a/packages/testing/janitor/src/core/impact-analyzer.ts
+++ b/packages/testing/janitor/src/core/impact-analyzer.ts
@@ -370,17 +370,22 @@ export class ImpactAnalyzer {
 /**
  * Format impact result for console output
  */
+function formatChangedFileEntry(
+	file: string,
+	strategies: Record<string, ResolutionStrategy>,
+): string {
+	const strategy = strategies[file];
+	const label = strategy ? ` [${strategy}]` : '';
+	return `  - ${file}${label}`;
+}
+
 export function formatImpactConsole(result: ImpactResult, verbose = false): void {
 	console.log('\n====================================');
 	console.log('       IMPACT ANALYSIS REPORT');
 	console.log('====================================\n');
 
 	console.log(`Changed files: ${result.changedFiles.length}`);
-	result.changedFiles.forEach((f) => {
-		const strategy = result.strategies[f];
-		const label = strategy ? ` [${strategy}]` : '';
-		console.log(`  - ${f}${label}`);
-	});
+	result.changedFiles.forEach((f) => console.log(formatChangedFileEntry(f, result.strategies)));
 
 	console.log(`\nAffected test files: ${result.affectedTests.length}`);
 	if (result.affectedTests.length === 0) {

--- a/packages/testing/janitor/src/core/tcr-executor.ts
+++ b/packages/testing/janitor/src/core/tcr-executor.ts
@@ -124,7 +124,7 @@ export class TcrExecutor {
 		this.logger.debugList(changedFiles);
 
 		// Analyze changed methods early (useful for understanding the change even if later checks fail)
-		const diffs = this.extractDiffs(changedFiles, baseRef);
+		const diffs = extractDiffs(changedFiles, baseRef);
 		const changedMethods = diffs.flatMap((d) => d.changedMethods);
 		this.logChangedMethods(changedMethods);
 
@@ -353,10 +353,6 @@ export class TcrExecutor {
 	}
 
 	// --- Method Analysis ---
-
-	private extractDiffs(changedFiles: string[], baseRef: string): FileDiffResult[] {
-		return extractDiffs(changedFiles, baseRef);
-	}
 
 	private logChangedMethods(changedMethods: MethodChange[]): void {
 		if (changedMethods.length === 0) return;

--- a/packages/testing/janitor/src/core/tcr-executor.ts
+++ b/packages/testing/janitor/src/core/tcr-executor.ts
@@ -6,7 +6,8 @@ import { execFileSync } from 'node:child_process';
 import * as path from 'node:path';
 import { Project } from 'ts-morph';
 
-import { diffFileMethods, type FileDiffResult, type MethodChange } from './ast-diff-analyzer.js';
+import { type FileDiffResult, type MethodChange } from './ast-diff-analyzer.js';
+import { extractDiffs } from './extract-diffs.js';
 import { loadBaseline, filterNewViolations } from './baseline.js';
 import { ImpactAnalyzer } from './impact-analyzer.js';
 import { MethodUsageAnalyzer, type MethodUsageIndex } from './method-usage-analyzer.js';
@@ -354,13 +355,7 @@ export class TcrExecutor {
 	// --- Method Analysis ---
 
 	private extractDiffs(changedFiles: string[], baseRef: string): FileDiffResult[] {
-		const diffs: FileDiffResult[] = [];
-		for (const file of changedFiles) {
-			if (file.endsWith('.ts') && !file.endsWith('.spec.ts')) {
-				diffs.push(diffFileMethods(file, baseRef));
-			}
-		}
-		return diffs;
+		return extractDiffs(changedFiles, baseRef);
 	}
 
 	private logChangedMethods(changedMethods: MethodChange[]): void {

--- a/packages/testing/janitor/src/core/tcr-executor.ts
+++ b/packages/testing/janitor/src/core/tcr-executor.ts
@@ -7,8 +7,8 @@ import * as path from 'node:path';
 import { Project } from 'ts-morph';
 
 import { type FileDiffResult, type MethodChange } from './ast-diff-analyzer.js';
-import { extractDiffs } from './extract-diffs.js';
 import { loadBaseline, filterNewViolations } from './baseline.js';
+import { extractDiffs } from './extract-diffs.js';
 import { ImpactAnalyzer } from './impact-analyzer.js';
 import { MethodUsageAnalyzer, type MethodUsageIndex } from './method-usage-analyzer.js';
 import { createProject } from './project-loader.js';

--- a/packages/testing/playwright/pages/NodeDetailsViewPage.ts
+++ b/packages/testing/playwright/pages/NodeDetailsViewPage.ts
@@ -844,6 +844,10 @@ export class NodeDetailsViewPage extends BasePage {
 		return this.getFilterComponent(paramName).getByTestId('filter-condition-left').nth(index);
 	}
 
+	getFilterConditionLeftInput(paramName: string, index: number = 0) {
+		return this.getFilterConditionLeft(paramName, index).locator('input');
+	}
+
 	getFilterConditionOperator(paramName: string, index: number = 0) {
 		return this.getFilterComponent(paramName).getByTestId('filter-operator-select').nth(index);
 	}

--- a/packages/testing/playwright/tests/e2e/nodes/if-node.spec.ts
+++ b/packages/testing/playwright/tests/e2e/nodes/if-node.spec.ts
@@ -23,23 +23,17 @@ test.describe(
 
 			// Add
 			await n8n.ndv.addFilterCondition(FILTER_PARAM_NAME);
-			await n8n.ndv
-				.getFilterConditionLeft(FILTER_PARAM_NAME, 0)
-				.locator('input')
-				.fill('first left');
-			await n8n.ndv
-				.getFilterConditionLeft(FILTER_PARAM_NAME, 1)
-				.locator('input')
-				.fill('second left');
+			await n8n.ndv.getFilterConditionLeftInput(FILTER_PARAM_NAME, 0).fill('first left');
+			await n8n.ndv.getFilterConditionLeftInput(FILTER_PARAM_NAME, 1).fill('second left');
 			await n8n.ndv.addFilterCondition(FILTER_PARAM_NAME);
 			await expect(n8n.ndv.getFilterConditions(FILTER_PARAM_NAME)).toHaveCount(3);
 
 			// Delete
 			await n8n.ndv.removeFilterCondition(FILTER_PARAM_NAME, 0);
 			await expect(n8n.ndv.getFilterConditions(FILTER_PARAM_NAME)).toHaveCount(2);
-			await expect(
-				n8n.ndv.getFilterConditionLeft(FILTER_PARAM_NAME, 0).locator('input'),
-			).toHaveValue('second left');
+			await expect(n8n.ndv.getFilterConditionLeftInput(FILTER_PARAM_NAME, 0)).toHaveValue(
+				'second left',
+			);
 			await n8n.ndv.removeFilterCondition(FILTER_PARAM_NAME, 1);
 			await expect(n8n.ndv.getFilterConditions(FILTER_PARAM_NAME)).toHaveCount(1);
 		});


### PR DESCRIPTION
## Summary
- Moved chained `.locator('input')` calls from `if-node.spec.ts` into a new `getFilterConditionLeftInput()` method on `NodeDetailsViewPage`, fixing 2 janitor `selector-purity` violations
- Wired AST diff computation (`diffFileMethods`) into the standalone `impact` and `orchestrate --impact` CLI commands, enabling method-level resolution that was previously only available in the TCR flow
- Extracted shared `extractDiffs()` utility used by both CLI and TCR
- Updated impact help text to document the `--base=<ref>` option

## Impact precision improvement
**Before:** `impact --files=pages/NodeDetailsViewPage.ts` → 71 affected tests (property-level fallback)
**After:** `impact --files=pages/NodeDetailsViewPage.ts --base=HEAD~1` → 1 affected test (method-level, detects additive-only change)

Resolution strategies shown in output:
- `[skipped]` — all methods added, can't break existing tests
- `[method-level]` — modified/removed methods traced to specific tests
- `[property-level]` — fallback when AST diff unavailable

## Test plan
- [x] Janitor passes on `if-node.spec.ts` (0 violations)
- [x] 332/332 janitor unit tests pass
- [x] Lint and typecheck clean
- [ ] CI confirms `if-node.spec.ts` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)