### PR TITLE
feat(editor): Add telemetry events for workflow diff in version history

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/WorkflowDiffModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/WorkflowDiffModal.test.ts
@@ -10,6 +10,11 @@ import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { mockedStore, type MockedStore } from '@/__tests__/utils';
 import { reactive, ref } from 'vue';
 import { createTestWorkflow } from '@/__tests__/mocks';
+import { telemetry } from '@/app/plugins/telemetry';
+
+vi.mock('@/app/plugins/telemetry', () => ({
+	telemetry: { track: vi.fn() },
+}));
 
 const eventBus = createEventBus();
 
@@ -160,6 +165,13 @@ describe('WorkflowDiffModal', () => {
 		// Component should render with the basic structure
 		expect(container.querySelector('.header')).toBeInTheDocument();
 		expect(container.querySelector('h4')).toBeInTheDocument();
+		await waitFor(() => {
+			expect(telemetry.track).toHaveBeenCalledWith('user_clicks_compare_workflows', {
+				instance_id: '',
+				workflow_id: 'test-workflow-id',
+				source: 'push_pull_modal',
+			});
+		});
 	});
 
 	it('should initialize with correct props', () => {

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/WorkflowDiffModal.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/WorkflowDiffModal.vue
@@ -13,6 +13,8 @@ import type { EventBus } from '@n8n/utils/event-bus';
 import { useAsyncState } from '@vueuse/core';
 import { computed, onMounted, onUnmounted, ref, useCssModule } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
+import { telemetry } from '@/app/plugins/telemetry';
+import { useRootStore } from '@n8n/stores/useRootStore';
 
 import { N8nIcon, N8nText } from '@n8n/design-system';
 
@@ -127,6 +129,11 @@ onMounted(async () => {
 	await nodeTypesStore.loadNodeTypesIfNotLoaded();
 	void remote.execute();
 	void local.execute();
+	telemetry.track('user_clicks_compare_workflows', {
+		instance_id: useRootStore().instanceId,
+		workflow_id: props.data.workflowId,
+		source: 'push_pull_modal',
+	});
 });
 
 onUnmounted(() => {
@@ -154,6 +161,7 @@ onUnmounted(() => {
 				:source-label="sourceLabel"
 				:target-label="targetLabel"
 				:show-back-button="true"
+				source="push_pull_modal"
 				@back="handleBeforeClose"
 			>
 				<template #sourceLabel>

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/WorkflowDiffView.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/WorkflowDiffView.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { defineComponent, h, ref, computed } from 'vue';
 import { createTestingPinia } from '@pinia/testing';
-import { render } from '@testing-library/vue';
+import { render, waitFor } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
 import type * as I18nModule from '@n8n/i18n';
+import { NodeDiffStatus } from 'n8n-workflow';
+import type { INodeUi } from '@/Interface';
+import { createComponentRenderer } from '@/__tests__/render';
 
 // Capture applyLayout prop from SyncedWorkflowCanvas
 let capturedApplyLayoutProps: { top: boolean | undefined; bottom: boolean | undefined } = {
@@ -37,13 +41,58 @@ vi.mock('@/features/workflows/workflowDiff/useViewportSync', () => ({
 
 // Mock useWorkflowDiff
 vi.mock('@/features/workflows/workflowDiff/useWorkflowDiff', () => ({
-	useWorkflowDiff: () => ({
-		source: { nodes: [], connections: [] },
-		target: { nodes: [], connections: [] },
-		nodesDiff: ref(new Map()),
-		connectionsDiff: ref(new Map()),
-	}),
+	useWorkflowDiff: vi.fn(),
 }));
+
+vi.mock('@/app/plugins/telemetry', () => ({
+	telemetry: { track: vi.fn() },
+}));
+
+vi.mock('@n8n/stores/useRootStore', () => ({
+	useRootStore: () => ({ instanceId: 'test-instance' }),
+}));
+
+// Mock element-plus dropdown components to make @visible-change testable in jsdom
+vi.mock('element-plus', async (importOriginal) => {
+	const actual = await importOriginal<Record<string, unknown>>();
+	return {
+		...actual,
+		ElDropdown: defineComponent({
+			props: ['trigger', 'popperOptions', 'popperClass'],
+			emits: ['visible-change'],
+			setup(_, { slots, emit }) {
+				return () =>
+					h('div', [
+						h(
+							'button',
+							{
+								'data-test-id': 'el-dropdown-trigger',
+								onClick: () => emit('visible-change', true),
+							},
+							slots.default?.(),
+						),
+						h('div', { 'data-test-id': 'el-dropdown-content' }, slots.dropdown?.()),
+					]);
+			},
+		}),
+		ElDropdownMenu: defineComponent({
+			setup(_, { slots }) {
+				return () => h('div', slots.default?.());
+			},
+		}),
+		ElDropdownItem: defineComponent({
+			emits: ['click'],
+			setup(_, { slots, emit }) {
+				return () =>
+					h(
+						'li',
+						{ class: 'workflow-diff-node-item', onClick: (e: Event) => emit('click', e) },
+						slots.default?.(),
+					);
+			},
+		}),
+	};
+});
 
 // Mock stores
 vi.mock('@/app/stores/nodeTypes.store', () => ({
@@ -95,12 +144,23 @@ vi.mock('@/features/workflows/canvas/composables/useCanvasMapping', () => ({
 
 // Import after mocks
 import WorkflowDiffView from './WorkflowDiffView.vue';
+import { useWorkflowDiff } from '@/features/workflows/workflowDiff/useWorkflowDiff';
+import { telemetry } from '@/app/plugins/telemetry';
+
+const defaultWorkflowDiffMock = () =>
+	({
+		source: { nodes: [], connections: [] },
+		target: { nodes: [], connections: [] },
+		nodesDiff: ref(new Map()),
+		connectionsDiff: ref(new Map()),
+	}) as unknown as ReturnType<typeof useWorkflowDiff>;
 
 describe('WorkflowDiffView', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		capturedApplyLayoutProps = { top: undefined, bottom: undefined };
 		createTestingPinia();
+		vi.mocked(useWorkflowDiff).mockReturnValue(defaultWorkflowDiffMock());
 	});
 
 	describe('tidyUp prop', () => {
@@ -165,6 +225,102 @@ describe('WorkflowDiffView', () => {
 			// When tidyUp is undefined, applyLayout will be falsy (false)
 			expect(capturedApplyLayoutProps.top).toBeFalsy();
 			expect(capturedApplyLayoutProps.bottom).toBeFalsy();
+		});
+	});
+
+	describe('changes dropdown', () => {
+		const createMockWorkflow = (id: string, name: string) => ({
+			id,
+			name,
+			nodes: [],
+			connections: {},
+			active: false,
+			isArchived: false,
+			createdAt: '2024-01-01T00:00:00.000Z',
+			updatedAt: '2024-01-01T00:00:00.000Z',
+			versionId: '1',
+			activeVersionId: null,
+			homeProject: {
+				id: 'project-1',
+				name: 'Project',
+				type: 'personal' as const,
+				icon: null,
+				createdAt: '2024-01-01T00:00:00.000Z',
+				updatedAt: '2024-01-01T00:00:00.000Z',
+			},
+		});
+
+		const sourceWorkflow = createMockWorkflow('source-workflow-id', 'Source Workflow');
+		const targetWorkflow = createMockWorkflow('target-workflow-id', 'Target Workflow');
+
+		const renderView = createComponentRenderer(WorkflowDiffView, {
+			global: {
+				stubs: {
+					SyncedWorkflowCanvas: { template: '<div />' },
+					WorkflowDiffAside: { template: '<div />' },
+					HighlightedEdge: { template: '<div />' },
+				},
+			},
+		});
+
+		it('should open the changes dropdown and track the event', async () => {
+			const { getByTestId } = renderView({
+				props: {
+					sourceWorkflow,
+					targetWorkflow,
+					source: 'version_history',
+				},
+			});
+
+			await userEvent.click(getByTestId('el-dropdown-trigger'));
+
+			await waitFor(() => {
+				expect(telemetry.track).toHaveBeenCalledWith('user_opens_diff_changes_list', {
+					instance_id: 'test-instance',
+					workflow_id: sourceWorkflow.id,
+					source: 'version_history',
+				});
+			});
+		});
+
+		it('should select a node from the changes list and track the event', async () => {
+			const mockNode: INodeUi = {
+				id: 'node-1',
+				name: 'Test Node',
+				type: 'n8n-nodes-base.manualTrigger',
+				typeVersion: 1,
+				position: [0, 0] as [number, number],
+				parameters: {},
+			};
+
+			vi.mocked(useWorkflowDiff).mockReturnValue({
+				...defaultWorkflowDiffMock(),
+				nodesDiff: ref(new Map([['node-1', { status: NodeDiffStatus.Added, node: mockNode }]])),
+			} as unknown as ReturnType<typeof useWorkflowDiff>);
+
+			const { getByTestId, getByText } = renderView({
+				props: {
+					sourceWorkflow,
+					targetWorkflow,
+					source: 'push_pull_modal',
+				},
+			});
+
+			await userEvent.click(getByTestId('el-dropdown-trigger'));
+
+			await waitFor(() => expect(getByText('Test Node')).toBeInTheDocument());
+			await userEvent.click(getByText('Test Node'));
+
+			await waitFor(() => {
+				expect(telemetry.track).toHaveBeenCalledWith('user_clicks_node_in_diff_changes_list', {
+					instance_id: 'test-instance',
+					workflow_id: sourceWorkflow.id,
+					node_id: 'node-1',
+					node_name: 'Test Node',
+					node_status: NodeDiffStatus.Added,
+					source: 'push_pull_modal',
+				});
+			});
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/WorkflowDiffView.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/WorkflowDiffView.vue
@@ -8,13 +8,15 @@ import WorkflowDiffNodeItem from '@/features/workflows/workflowDiff/WorkflowDiff
 import { useProvideViewportSync } from '@/features/workflows/workflowDiff/useViewportSync';
 import { useWorkflowDiff } from '@/features/workflows/workflowDiff/useWorkflowDiff';
 import { useWorkflowDiffUI } from '@/features/workflows/workflowDiff/useWorkflowDiffUI';
-import type { IWorkflowDb } from '@/Interface';
+import type { IWorkflowDb, INodeUi } from '@/Interface';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { removeWorkflowExecutionData } from '@/app/utils/workflowUtils';
 import type { BaseTextKey } from '@n8n/i18n';
 import { useI18n } from '@n8n/i18n';
 import { NodeDiffStatus } from 'n8n-workflow';
 import { computed, useCssModule, onMounted } from 'vue';
+import { telemetry } from '@/app/plugins/telemetry';
+import { useRootStore } from '@n8n/stores/useRootStore';
 
 import { ElDropdown, ElDropdownMenu } from 'element-plus';
 import {
@@ -34,6 +36,7 @@ const props = withDefaults(
 		targetLabel?: string;
 		tidyUp?: boolean;
 		showBackButton?: boolean;
+		source?: 'version_history' | 'push_pull_modal' | 'unknown';
 	}>(),
 	{
 		sourceWorkflow: undefined,
@@ -41,6 +44,7 @@ const props = withDefaults(
 		sourceLabel: 'Before',
 		targetLabel: 'After',
 		showBackButton: false,
+		source: 'unknown',
 	},
 );
 const emit = defineEmits<{
@@ -51,6 +55,7 @@ const { selectedDetailId, onNodeClick, syncIsEnabled } = useProvideViewportSync(
 
 const $style = useCssModule();
 const nodeTypesStore = useNodeTypesStore();
+const rootStore = useRootStore();
 const i18n = useI18n();
 const toast = useToast();
 
@@ -100,6 +105,29 @@ onMounted(async () => {
 		toast.showError(error, i18n.baseText('workflowDiff.error.loadNodeTypes'));
 	}
 });
+
+const onChangesDropdownVisibleChange = (visible: boolean) => {
+	setActiveTab(visible);
+	if (visible) {
+		telemetry.track('user_opens_diff_changes_list', {
+			instance_id: rootStore.instanceId,
+			workflow_id: props.sourceWorkflow?.id ?? props.targetWorkflow?.id,
+			source: props.source,
+		});
+	}
+};
+
+const onNodeChangeSelect = (change: { node: INodeUi; status: NodeDiffStatus }) => {
+	setSelectedDetailId(change.node.id);
+	telemetry.track('user_clicks_node_in_diff_changes_list', {
+		instance_id: rootStore.instanceId,
+		workflow_id: props.sourceWorkflow?.id ?? props.targetWorkflow?.id,
+		node_id: change.node.id,
+		node_name: change.node.name,
+		node_status: change.status,
+		source: props.source,
+	});
+};
 </script>
 
 <template>
@@ -134,7 +162,7 @@ onMounted(async () => {
 						modifiers,
 					}"
 					:popper-class="$style.popper"
-					@visible-change="setActiveTab"
+					@visible-change="onChangesDropdownVisibleChange"
 				>
 					<N8nButton variant="subtle" style="--button--radius: 4px 0 0 4px">
 						<div v-if="changesCount" :class="$style.circleBadge">
@@ -166,7 +194,7 @@ onMounted(async () => {
 												:node-type="change.type"
 												:node-name="change.node.name"
 												:is-active="selectedDetailId === change.node.id"
-												@select="setSelectedDetailId(change.node.id)"
+												@select="onNodeChangeSelect(change)"
 											/>
 										</template>
 										<WorkflowDiffEmptyState

--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/views/WorkflowHistory.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/views/WorkflowHistory.test.ts
@@ -266,6 +266,11 @@ describe('WorkflowHistory', () => {
 				diffWith: versionId,
 			},
 		});
+		expect(telemetry.track).toHaveBeenCalledWith('user_clicks_compare_workflows', {
+			instance_id: '',
+			workflow_id: workflowId,
+			source: 'version_history',
+		});
 	});
 
 	it('should not open compare view when workflow diffs are not licensed', async () => {

--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/views/WorkflowHistory.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/views/WorkflowHistory.vue
@@ -147,10 +147,11 @@ const createCompareRoute = (compareVersionId: string) => {
 	};
 };
 
-const sendTelemetry = (event: string) => {
+const sendTelemetry = (event: string, extras?: Record<string, unknown>) => {
 	telemetry.track(event, {
 		instance_id: useRootStore().instanceId,
 		workflow_id: workflowId.value,
+		...extras,
 	});
 };
 
@@ -492,6 +493,7 @@ const openCompareView = async (compareVersionId: WorkflowVersionId) => {
 	}
 
 	await router.push(createCompareRoute(compareVersionId));
+	sendTelemetry('user_clicks_compare_workflows', { source: 'version_history' });
 };
 
 const closeCompareView = async () => {

--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/views/WorkflowHistoryDiff.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/views/WorkflowHistoryDiff.test.ts
@@ -8,6 +8,11 @@ import type { WorkflowHistory, WorkflowVersion } from '@n8n/rest-api-client/api/
 import { useWorkflowHistoryStore } from '../workflowHistory.store';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import WorkflowHistoryDiff from './WorkflowHistoryDiff.vue';
+import { telemetry } from '@/app/plugins/telemetry';
+
+vi.mock('@/app/plugins/telemetry', () => ({
+	telemetry: { track: vi.fn() },
+}));
 
 const workflowId = 'wf-1';
 const sourceVersionId = 'v-source';
@@ -129,6 +134,13 @@ describe('WorkflowHistoryDiff', () => {
 			expect(rendered.getByTestId('workflow-history-diff-target-version-value')).toHaveTextContent(
 				sourceVersionId,
 			);
+			expect(telemetry.track).toHaveBeenCalledWith('user_selects_version_in_diff', {
+				instance_id: '',
+				workflow_id: workflowId,
+				version_id: targetVersionId,
+				side: 'source',
+				source: 'version_history',
+			});
 		});
 	});
 
@@ -171,6 +183,13 @@ describe('WorkflowHistoryDiff', () => {
 			expect(rendered.getByTestId('workflow-history-diff-target-version-value')).toHaveTextContent(
 				sourceVersionId,
 			);
+			expect(telemetry.track).toHaveBeenCalledWith('user_selects_version_in_diff', {
+				instance_id: '',
+				workflow_id: workflowId,
+				version_id: sourceVersionId,
+				side: 'target',
+				source: 'version_history',
+			});
 		});
 	});
 
@@ -211,6 +230,13 @@ describe('WorkflowHistoryDiff', () => {
 			expect(rendered.getByTestId('workflow-history-diff-target-version-value')).toHaveTextContent(
 				targetVersionId,
 			);
+			expect(telemetry.track).toHaveBeenCalledWith('user_selects_version_in_diff', {
+				instance_id: '',
+				workflow_id: workflowId,
+				version_id: otherVersionId,
+				side: 'source',
+				source: 'version_history',
+			});
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/views/WorkflowHistoryDiff.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/views/WorkflowHistoryDiff.vue
@@ -12,6 +12,8 @@ import type { WorkflowHistory } from '@n8n/rest-api-client/api/workflowHistory';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import WorkflowHistoryVersionSelect from '../components/WorkflowHistoryVersionSelect.vue';
 import { useWorkflowHistoryVersionOptions } from '../useWorkflowHistoryVersionOptions';
+import { telemetry } from '@/app/plugins/telemetry';
+import { useRootStore } from '@n8n/stores/useRootStore';
 
 const props = defineProps<{
 	workflowId: string;
@@ -26,6 +28,7 @@ const emit = defineEmits<{
 const i18n = useI18n();
 const toast = useToast();
 const workflowHistoryStore = useWorkflowHistoryStore();
+const rootStore = useRootStore();
 const workflowsListStore = useWorkflowsListStore();
 const usersStore = useUsersStore();
 
@@ -119,7 +122,18 @@ const swapSelectedVersions = () => {
 	selectedTargetVersionId.value = previousSourceVersionId;
 };
 
+const trackVersionSelectionInDiff = (side: 'source' | 'target', versionId: string) => {
+	telemetry.track('user_selects_version_in_diff', {
+		instance_id: rootStore.instanceId,
+		workflow_id: props.workflowId,
+		version_id: versionId,
+		side,
+		source: 'version_history',
+	});
+};
+
 const onSourceVersionChange = (nextSourceVersionId: string) => {
+	trackVersionSelectionInDiff('source', nextSourceVersionId);
 	if (nextSourceVersionId === selectedTargetVersionId.value) {
 		swapSelectedVersions();
 		return;
@@ -129,6 +143,7 @@ const onSourceVersionChange = (nextSourceVersionId: string) => {
 };
 
 const onTargetVersionChange = (nextTargetVersionId: string) => {
+	trackVersionSelectionInDiff('target', nextTargetVersionId);
 	if (nextTargetVersionId === selectedSourceVersionId.value) {
 		swapSelectedVersions();
 		return;
@@ -166,6 +181,7 @@ watch(
 			:source-label="sourceLabel"
 			:target-label="targetLabel"
 			:show-back-button="true"
+			source="version_history"
 			@back="emit('close')"
 		>
 			<template #sourceLabel>


### PR DESCRIPTION
## Summary

  Adds telemetry tracking for user interactions with the workflow diff feature in version history.

This existing event has been updated:
  1. **`user_clicks_compare_workflows`** — fired when a user opens the diff view, now with a `source` field indicating
   whether it was triggered from `version_history` or `push_pull_modal`

  Three new telemetry events are tracked:

  2. **`user_selects_version_in_diff`** — fired when a user changes either the source or target version in the
  diff view's version selectors (version history only)
  3. **`user_opens_diff_changes_list`** — fired when a user opens the "Changes" dropdown, with `source` context
  4. **`user_clicks_node_in_diff_changes_list`** — fired when a user clicks a node from the changes list, with
  `source` context and node info

  **Implementation:**
  - Added `source` prop to `WorkflowDiffView` so it can pass context to events
  - `WorkflowHistory.vue`: fires event  with `source: 'version_history'`
  - `WorkflowDiffModal.vue` (push/pull): fires event 1 with `source: 'push_pull_modal'`
  - `WorkflowHistoryDiff.vue`: fires event 2 on source/target version change
  - `WorkflowDiffView.vue`: fires events 3 & 4 from the changes dropdown


## Related Linear tickets, Github issues, and Community forum posts

Closes [LIGO-286](https://linear.app/n8n/issue/LIGO-286/add-telemetry-events-for-workflow-diff-in-version-history)


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
