### PR TITLE
fix(editor): Show version name instead of current changes label for named versions

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryListItem.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryListItem.test.ts
@@ -115,8 +115,8 @@ describe('WorkflowHistoryListItem', () => {
 		expect(queryByTestId('workflow-history-compare-item-button')).not.toBeInTheDocument();
 	});
 
-	it('should render current changes for first item', () => {
-		const item = workflowHistoryDataFactory();
+	it('should render current changes for first unnamed item', () => {
+		const item = { ...workflowHistoryDataFactory(), name: null };
 		const { getByText } = renderComponent({
 			pinia,
 			props: {
@@ -130,7 +130,22 @@ describe('WorkflowHistoryListItem', () => {
 		expect(getByText('Current changes')).toBeInTheDocument();
 	});
 
-	it('should render generated version label when name is missing', () => {
+	it('should render version name for first named item', () => {
+		const item = { ...workflowHistoryDataFactory(), name: 'Named Version' };
+		const { getByText } = renderComponent({
+			pinia,
+			props: {
+				item,
+				index: 0,
+				actions,
+				isSelected: true,
+			},
+		});
+
+		expect(getByText('Named Version')).toBeInTheDocument();
+	});
+
+	it('should render a generated version label when the item has no name and it is not the first item', () => {
 		const item = { ...workflowHistoryDataFactory(), name: null };
 		const { getByText } = renderComponent({
 			pinia,

--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/utils.test.ts
@@ -224,7 +224,7 @@ describe('generateVersionLabelFromId', () => {
 describe('getVersionLabel', () => {
 	it('returns current changes label for current version', () => {
 		const result = getVersionLabel({
-			workflowHistory: { versionId: 'v1', name: 'Named Version' },
+			workflowHistory: { versionId: 'v1', name: 'Named Version', workflowPublishHistory: [] },
 			currentVersionId: 'v1',
 		});
 
@@ -233,10 +233,32 @@ describe('getVersionLabel', () => {
 
 	it('returns generated label when version has no name', () => {
 		const result = getVersionLabel({
-			workflowHistory: { versionId: '12345678abcdef', name: null },
+			workflowHistory: { versionId: '12345678abcdef', name: null, workflowPublishHistory: [] },
 			currentVersionId: 'other',
 		});
 
 		expect(result).toBe('Version 12345678');
+	});
+
+	it('does not return current changes label when current version is published', () => {
+		const result = getVersionLabel({
+			workflowHistory: {
+				versionId: 'v1',
+				name: 'Named Version',
+				workflowPublishHistory: [
+					{
+						createdAt: '2026-03-08T10:00:00.000Z',
+						id: 1,
+						event: 'activated',
+						userId: 'user-1',
+						versionId: 'v1',
+						workflowId: 'wf-1',
+					},
+				],
+			},
+			currentVersionId: 'v1',
+		});
+
+		expect(result).toBe('Named Version');
 	});
 });

--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/utils.test.ts
@@ -222,43 +222,38 @@ describe('generateVersionLabelFromId', () => {
 });
 
 describe('getVersionLabel', () => {
-	it('returns current changes label for current version', () => {
+	it('returns the version name when current version is named', () => {
 		const result = getVersionLabel({
-			workflowHistory: { versionId: 'v1', name: 'Named Version', workflowPublishHistory: [] },
+			workflowHistory: { versionId: 'v1', name: 'Named Version' },
 			currentVersionId: 'v1',
 		});
 
-		expect(result).toBe('workflowHistory.item.currentChanges');
+		expect(result).toBe('Named Version');
 	});
 
 	it('returns generated label when version has no name', () => {
 		const result = getVersionLabel({
-			workflowHistory: { versionId: '12345678abcdef', name: null, workflowPublishHistory: [] },
+			workflowHistory: { versionId: '12345678abcdef', name: null },
 			currentVersionId: 'other',
 		});
 
 		expect(result).toBe('Version 12345678');
 	});
 
-	it('does not return current changes label when current version is published', () => {
+	it('returns generated label when no current version is provided', () => {
 		const result = getVersionLabel({
-			workflowHistory: {
-				versionId: 'v1',
-				name: 'Named Version',
-				workflowPublishHistory: [
-					{
-						createdAt: '2026-03-08T10:00:00.000Z',
-						id: 1,
-						event: 'activated',
-						userId: 'user-1',
-						versionId: 'v1',
-						workflowId: 'wf-1',
-					},
-				],
-			},
+			workflowHistory: { versionId: '87654321abcdef', name: null },
+		});
+
+		expect(result).toBe('Version 87654321');
+	});
+
+	it('returns current changes label for unnamed current version', () => {
+		const result = getVersionLabel({
+			workflowHistory: { versionId: 'v1', name: null },
 			currentVersionId: 'v1',
 		});
 
-		expect(result).toBe('Named Version');
+		expect(result).toBe('workflowHistory.item.currentChanges');
 	});
 });

--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/utils.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/utils.ts
@@ -24,11 +24,15 @@ export const getVersionLabel = ({
 	currentVersionId?: string;
 }) => {
 	const i18n = useI18n();
-	if (workflowHistory.versionId === currentVersionId) {
-		return i18n.baseText('workflowHistory.item.currentChanges');
+	const isNamedVersion = Boolean(workflowHistory.name);
+	if (isNamedVersion) {
+		return workflowHistory.name;
 	}
 
-	return workflowHistory.name ?? generateVersionLabelFromId(workflowHistory.versionId);
+	const isCurrentVersion = workflowHistory.versionId === currentVersionId;
+	return isCurrentVersion
+		? i18n.baseText('workflowHistory.item.currentChanges')
+		: generateVersionLabelFromId(workflowHistory.versionId);
 };
 
 export const formatTimestamp = (value: string) => {

--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/utils.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/utils.ts
@@ -24,8 +24,7 @@ export const getVersionLabel = ({
 	currentVersionId?: string;
 }) => {
 	const i18n = useI18n();
-	const isNamedVersion = Boolean(workflowHistory.name);
-	if (isNamedVersion) {
+	if (workflowHistory.name) {
 		return workflowHistory.name;
 	}
 


### PR DESCRIPTION
## Summary

https://www.loom.com/share/4be06b87afd74f4587677f6b75916ff3

When a workflow history version has a name (e.g. it was published/saved with a label), the version list was still showing \"Current Changes\" for the active version instead of its name. This fix prioritizes displaying the version name when available, falling back to \"Current Changes\" only for unnamed current versions.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Link to Linear ticket: https://linear.app/n8n/issue/LIGO-350 -->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)