### PR TITLE
fix(cli): prevent self-inclusion of output ZIP during export

### DIFF
--- a/packages/cli/src/utils/compression.util.ts
+++ b/packages/cli/src/utils/compression.util.ts
@@ -83,6 +83,17 @@ export async function compressFolder(
 	const outputDir = path.dirname(outputPath);
 	await mkdir(outputDir, { recursive: true });
 
+	// If the output ZIP is inside the source directory, exclude it so the archive
+	// does not contain a self-referential entry that would truncate the source on import.
+	const resolvedSourceDir = path.resolve(sourceDir);
+	const resolvedOutputPath = path.resolve(outputPath);
+	const outputIsInSource =
+		resolvedOutputPath.startsWith(resolvedSourceDir + path.sep) ||
+		resolvedOutputPath === resolvedSourceDir;
+	const effectiveExclude = outputIsInSource
+		? [...exclude, path.basename(resolvedOutputPath)]
+		: exclude;
+
 	// Create write stream for the output ZIP file
 	const outputStream = createWriteStream(outputPath);
 
@@ -102,7 +113,11 @@ export async function compressFolder(
 	};
 
 	// Add directory contents to ZIP using streaming
-	await addDirectoryToZipStreaming(sourceDir, '', zip, { exclude, includeHidden, level });
+	await addDirectoryToZipStreaming(sourceDir, '', zip, {
+		exclude: effectiveExclude,
+		includeHidden,
+		level,
+	});
 
 	// Finalize the ZIP
 	zip.end();


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
