### PR TITLE
fix(editor): Command bar wasn't finding any workflows

### DIFF
--- a/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useWorkflowNavigationCommands.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useWorkflowNavigationCommands.test.ts
@@ -95,19 +95,6 @@ describe('useWorkflowNavigationCommands', () => {
 		}),
 	];
 
-	const getSearchWorkflowCalls = () =>
-		vi
-			.mocked(mockWorkflowsListStore.searchWorkflows)
-			.mock.calls.map(([params]) => params as { select?: string[] });
-
-	const expectSearchCallsToIncludeVersionId = (expectedCalls: number) => {
-		const calls = getSearchWorkflowCalls();
-		expect(calls).toHaveLength(expectedCalls);
-		calls.forEach((params) => {
-			expect(params.select).toEqual(expect.arrayContaining(['versionId']));
-		});
-	};
-
 	beforeEach(() => {
 		vi.clearAllMocks();
 		setActivePinia(createTestingPinia());
@@ -162,12 +149,7 @@ describe('useWorkflowNavigationCommands', () => {
 			configurable: true,
 		});
 		vi.spyOn(mockWorkflowsListStore, 'searchWorkflows').mockImplementation(
-			async (params: {
-				query?: string;
-				nodeTypes?: string[];
-				tags?: string[];
-				select?: string[];
-			}) => {
+			async (params: { query?: string; nodeTypes?: string[]; tags?: string[] }) => {
 				if (params.nodeTypes && params.nodeTypes.length > 0) {
 					return [
 						{ ...allWorkflows[0], nodes: [{ type: 'n8n-nodes-base.httpRequest' }] } as IWorkflowDb,
@@ -311,22 +293,6 @@ describe('useWorkflowNavigationCommands', () => {
 		expect(resolveMock).toHaveBeenCalled();
 	});
 
-	it('includes versionId in workflow search select when opening workflow search', async () => {
-		const api = useWorkflowNavigationCommands({
-			lastQuery: ref(''),
-			activeNodeId: ref(null),
-			currentProjectName: ref('My Project'),
-		});
-
-		api.handlers?.onCommandBarNavigateTo?.('open-workflow');
-
-		await waitFor(() => {
-			expect(mockWorkflowsListStore.searchWorkflows).toHaveBeenCalled();
-		});
-
-		expectSearchCallsToIncludeVersionId(1);
-	});
-
 	it('create workflow navigates to NEW_WORKFLOW route with project and folder', async () => {
 		const api = useWorkflowNavigationCommands({
 			lastQuery: ref(''),
@@ -365,38 +331,6 @@ describe('useWorkflowNavigationCommands', () => {
 		expect(item.keywords).toEqual(expect.arrayContaining(['Alpha', 'Marketing']));
 		// Icon present when matched by node type
 		expect(item.icon).toBeDefined();
-	});
-
-	it('includes versionId in workflow search select when matching node types', async () => {
-		const api = useWorkflowNavigationCommands({
-			lastQuery: ref('http request'),
-			activeNodeId: ref('open-workflow'),
-			currentProjectName: ref('My Project'),
-		});
-
-		(api.handlers?.onCommandBarChange as (q: string) => void)('http request');
-
-		await waitFor(() => {
-			expect(mockWorkflowsListStore.searchWorkflows).toHaveBeenCalledTimes(2);
-		});
-
-		expectSearchCallsToIncludeVersionId(2);
-	});
-
-	it('includes versionId in workflow search select when matching tags', async () => {
-		const api = useWorkflowNavigationCommands({
-			lastQuery: ref('Marketing'),
-			activeNodeId: ref('open-workflow'),
-			currentProjectName: ref('My Project'),
-		});
-
-		(api.handlers?.onCommandBarChange as (q: string) => void)('Marketing');
-
-		await waitFor(() => {
-			expect(mockWorkflowsListStore.searchWorkflows).toHaveBeenCalledTimes(2);
-		});
-
-		expectSearchCallsToIncludeVersionId(2);
 	});
 
 	it('root workflow items have correct title and section', async () => {

--- a/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useWorkflowNavigationCommands.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useWorkflowNavigationCommands.test.ts
@@ -95,6 +95,19 @@ describe('useWorkflowNavigationCommands', () => {
 		}),
 	];
 
+	const getSearchWorkflowCalls = () =>
+		vi
+			.mocked(mockWorkflowsListStore.searchWorkflows)
+			.mock.calls.map(([params]) => params as { select?: string[] });
+
+	const expectSearchCallsToIncludeVersionId = (expectedCalls: number) => {
+		const calls = getSearchWorkflowCalls();
+		expect(calls).toHaveLength(expectedCalls);
+		calls.forEach((params) => {
+			expect(params.select).toEqual(expect.arrayContaining(['versionId']));
+		});
+	};
+
 	beforeEach(() => {
 		vi.clearAllMocks();
 		setActivePinia(createTestingPinia());
@@ -149,7 +162,12 @@ describe('useWorkflowNavigationCommands', () => {
 			configurable: true,
 		});
 		vi.spyOn(mockWorkflowsListStore, 'searchWorkflows').mockImplementation(
-			async (params: { query?: string; nodeTypes?: string[]; tags?: string[] }) => {
+			async (params: {
+				query?: string;
+				nodeTypes?: string[];
+				tags?: string[];
+				select?: string[];
+			}) => {
 				if (params.nodeTypes && params.nodeTypes.length > 0) {
 					return [
 						{ ...allWorkflows[0], nodes: [{ type: 'n8n-nodes-base.httpRequest' }] } as IWorkflowDb,
@@ -293,6 +311,22 @@ describe('useWorkflowNavigationCommands', () => {
 		expect(resolveMock).toHaveBeenCalled();
 	});
 
+	it('includes versionId in workflow search select when opening workflow search', async () => {
+		const api = useWorkflowNavigationCommands({
+			lastQuery: ref(''),
+			activeNodeId: ref(null),
+			currentProjectName: ref('My Project'),
+		});
+
+		api.handlers?.onCommandBarNavigateTo?.('open-workflow');
+
+		await waitFor(() => {
+			expect(mockWorkflowsListStore.searchWorkflows).toHaveBeenCalled();
+		});
+
+		expectSearchCallsToIncludeVersionId(1);
+	});
+
 	it('create workflow navigates to NEW_WORKFLOW route with project and folder', async () => {
 		const api = useWorkflowNavigationCommands({
 			lastQuery: ref(''),
@@ -331,6 +365,38 @@ describe('useWorkflowNavigationCommands', () => {
 		expect(item.keywords).toEqual(expect.arrayContaining(['Alpha', 'Marketing']));
 		// Icon present when matched by node type
 		expect(item.icon).toBeDefined();
+	});
+
+	it('includes versionId in workflow search select when matching node types', async () => {
+		const api = useWorkflowNavigationCommands({
+			lastQuery: ref('http request'),
+			activeNodeId: ref('open-workflow'),
+			currentProjectName: ref('My Project'),
+		});
+
+		(api.handlers?.onCommandBarChange as (q: string) => void)('http request');
+
+		await waitFor(() => {
+			expect(mockWorkflowsListStore.searchWorkflows).toHaveBeenCalledTimes(2);
+		});
+
+		expectSearchCallsToIncludeVersionId(2);
+	});
+
+	it('includes versionId in workflow search select when matching tags', async () => {
+		const api = useWorkflowNavigationCommands({
+			lastQuery: ref('Marketing'),
+			activeNodeId: ref('open-workflow'),
+			currentProjectName: ref('My Project'),
+		});
+
+		(api.handlers?.onCommandBarChange as (q: string) => void)('Marketing');
+
+		await waitFor(() => {
+			expect(mockWorkflowsListStore.searchWorkflows).toHaveBeenCalledTimes(2);
+		});
+
+		expectSearchCallsToIncludeVersionId(2);
 	});
 
 	it('root workflow items have correct title and section', async () => {

--- a/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useWorkflowNavigationCommands.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useWorkflowNavigationCommands.ts
@@ -82,16 +82,7 @@ export function useWorkflowNavigationCommands(options: {
 			// Search workflows by name with minimal fields
 			const nameSearchPromise = workflowsListStore.searchWorkflows({
 				query: trimmed,
-				select: [
-					'id',
-					'name',
-					'active',
-					'versionId',
-					'ownedBy',
-					'parentFolder',
-					'isArchived',
-					'description',
-				],
+				select: ['id', 'name', 'versionId', 'ownedBy', 'parentFolder', 'isArchived', 'description'],
 			});
 
 			const nodeTypeSearchPromise =
@@ -101,7 +92,6 @@ export function useWorkflowNavigationCommands(options: {
 							select: [
 								'id',
 								'name',
-								'active',
 								'versionId',
 								'nodes',
 								'ownedBy',
@@ -118,7 +108,6 @@ export function useWorkflowNavigationCommands(options: {
 						select: [
 							'id',
 							'name',
-							'active',
 							'versionId',
 							'ownedBy',
 							'tags',

--- a/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useWorkflowNavigationCommands.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useWorkflowNavigationCommands.ts
@@ -82,7 +82,16 @@ export function useWorkflowNavigationCommands(options: {
 			// Search workflows by name with minimal fields
 			const nameSearchPromise = workflowsListStore.searchWorkflows({
 				query: trimmed,
-				select: ['id', 'name', 'active', 'ownedBy', 'parentFolder', 'isArchived', 'description'],
+				select: [
+					'id',
+					'name',
+					'active',
+					'versionId',
+					'ownedBy',
+					'parentFolder',
+					'isArchived',
+					'description',
+				],
 			});
 
 			const nodeTypeSearchPromise =
@@ -93,6 +102,7 @@ export function useWorkflowNavigationCommands(options: {
 								'id',
 								'name',
 								'active',
+								'versionId',
 								'nodes',
 								'ownedBy',
 								'parentFolder',
@@ -109,6 +119,7 @@ export function useWorkflowNavigationCommands(options: {
 							'id',
 							'name',
 							'active',
+							'versionId',
 							'ownedBy',
 							'tags',
 							'parentFolder',

--- a/packages/testing/playwright/pages/components/CommandBar.ts
+++ b/packages/testing/playwright/pages/components/CommandBar.ts
@@ -1,0 +1,45 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+export class CommandBar {
+	constructor(private page: Page) {}
+
+	getContainer(): Locator {
+		return this.page.getByTestId('command-bar');
+	}
+
+	getInput(): Locator {
+		return this.getContainer().getByRole('textbox');
+	}
+
+	getItemsList(): Locator {
+		return this.page.getByTestId('command-bar-items-list');
+	}
+
+	getItem(name: string): Locator {
+		return this.getItemsList().getByText(name);
+	}
+
+	getSpinner(): Locator {
+		return this.page.getByTestId('command-bar-input-spinner');
+	}
+
+	async open(): Promise<void> {
+		await this.page.getByRole('button', { name: 'Open command palette' }).click();
+		await expect(this.getContainer()).toBeVisible();
+	}
+
+	async search(query: string): Promise<void> {
+		await this.open();
+		await this.getInput().fill(query);
+	}
+
+	async waitForLoadingToFinish(): Promise<void> {
+		await expect(this.getSpinner()).toBeHidden();
+	}
+
+	async selectItem(name: string): Promise<void> {
+		const item = this.getItem(name);
+		await expect(item).toBeVisible();
+		await item.click();
+	}
+}

--- a/packages/testing/playwright/pages/n8nPage.ts
+++ b/packages/testing/playwright/pages/n8nPage.ts
@@ -6,6 +6,7 @@ import { CanvasPage } from './CanvasPage';
 import { CommunityNodesPage } from './CommunityNodesPage';
 import { BaseModal } from './components/BaseModal';
 import { Breadcrumbs } from './components/Breadcrumbs';
+import { CommandBar } from './components/CommandBar';
 import { DeleteSecretsProviderModal } from './components/DeleteSecretsProviderModal';
 import { ProjectTabsComponent } from './components/ProjectTabsComponent';
 import { ResourceMoveModal } from './components/ResourceMoveModal';
@@ -97,6 +98,7 @@ export class n8nPage {
 
 	// Components
 	readonly projectTabs: ProjectTabsComponent;
+	readonly commandBar: CommandBar;
 
 	readonly settingsEnvironment: SettingsEnvironmentPage;
 	readonly secretsProviderSettings: SecretsProviderSettingsPage;
@@ -173,6 +175,7 @@ export class n8nPage {
 
 		// Components
 		this.projectTabs = new ProjectTabsComponent(page);
+		this.commandBar = new CommandBar(page);
 
 		// Modals
 		this.workflowActivationModal = new WorkflowActivationModal(page);

--- a/packages/testing/playwright/tests/e2e/workflows/list/workflows.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/list/workflows.spec.ts
@@ -67,6 +67,33 @@ test.describe(
 			await expect(n8n.workflows.getNoWorkflowsFoundMessage()).toBeVisible();
 		});
 
+		test('should search workflows in command bar', async ({ n8n }) => {
+			const uniqueId = nanoid(8);
+			const firstWorkflowName = `Command Bar Alpha ${uniqueId}`;
+			const secondWorkflowName = `Command Bar Beta ${uniqueId}`;
+
+			const firstWorkflow = await n8n.api.workflows.createWorkflow({
+				name: firstWorkflowName,
+				nodes: [],
+				connections: {},
+			});
+			await n8n.api.workflows.createWorkflow({
+				name: secondWorkflowName,
+				nodes: [],
+				connections: {},
+			});
+
+			await n8n.goHome();
+			await n8n.commandBar.search(firstWorkflowName);
+			await n8n.commandBar.waitForLoadingToFinish();
+
+			await expect(n8n.commandBar.getItem(firstWorkflowName)).toBeVisible();
+			await expect(n8n.commandBar.getItem(secondWorkflowName)).toBeHidden();
+
+			await n8n.commandBar.selectItem(firstWorkflowName);
+			await expect(n8n.page).toHaveURL(new RegExp(`/workflow/${firstWorkflow.id}(\\?.*)?$`));
+		});
+
 		test('should archive and unarchive a workflow', async ({ n8n }) => {
 			const uniqueIdForArchive = nanoid(8);
 			const workflowName = `Archive Test ${uniqueIdForArchive}`;


### PR DESCRIPTION
## Summary

There was a condition added on the backend related to scopes that was determining if the entity being fetched is workflow or not based on the fields being selected.

Background: https://github.com/n8n-io/n8n/pull/26248 changed this behavior.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4929/command-bar-doesnt-see-workflows


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
