### PR TITLE
fix(editor): Preserve resource mapper values during floating node navigation

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.vue
@@ -251,6 +251,20 @@ throttledWatch(
 	{ throttle: 200, immediate: true },
 );
 
+// When the active node changes (e.g. via floating node navigation arrows),
+// immediately nullify dependentParametersValues in the cached items.
+// The throttledWatch above will recompute them asynchronously, but until then
+// the ResourceMapper component would see stale dep values from the previous node.
+// By setting them to null, the ResourceMapper's dependency watcher sees a
+// null → correctValue transition which is naturally ignored (oldValue !== null guard),
+// preventing it from incorrectly clearing the new node's field values.
+watch(node, () => {
+	parameterItems.value = parameterItems.value.map((item) => ({
+		...item,
+		dependentParametersValues: null,
+	}));
+});
+
 const credentialsParameterIndex = computed(() => {
 	return parameterItems.value.findIndex((paramData) => paramData.parameter.type === 'credentials');
 });
@@ -777,6 +791,7 @@ watch(
 			</div>
 			<ResourceMapper
 				v-else-if="item.parameter.type === 'resourceMapper'"
+				:key="node?.name"
 				:parameter="item.parameter"
 				:node="node"
 				:path="item.path"

--- a/packages/testing/playwright/tests/e2e/workflows/editor/ndv/resource-mapper.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/ndv/resource-mapper.spec.ts
@@ -85,3 +85,73 @@ test.describe(
 		});
 	},
 );
+
+test.describe(
+	'Resource Mapper values persistence during node navigation',
+	{
+		annotation: [{ type: 'owner', description: 'Adore' }],
+	},
+	() => {
+		test('should preserve resource mapper values when navigating between connected nodes via floating nodes', async ({
+			n8n,
+		}) => {
+			await n8n.start.fromBlankCanvas();
+
+			// Add first E2E Test node with Resource Mapping Component
+			await n8n.canvas.addNode(E2E_TEST_NODE_NAME, {
+				action: 'Resource Mapping Component',
+			});
+
+			// Set a unique fieldId so dependentParametersValues differs between nodes
+			await n8n.ndv.fillParameterInputByName('fieldId', 'table1');
+
+			// Wait for resource mapper fields to reload after fieldId change
+			await expect(n8n.ndv.getResourceMapperParameterInputs()).toHaveCount(3);
+
+			// Fill resource mapper values on first node
+			await n8n.ndv.fillParameterInputByName('id', '001');
+			await n8n.ndv.fillParameterInputByName('name', 'John');
+
+			// Close NDV
+			await n8n.ndv.close();
+
+			// Add second E2E Test node connected from the first
+			await n8n.canvas.addNode(E2E_TEST_NODE_NAME, {
+				action: 'Resource Mapping Component',
+				fromNode: 'E2E Test',
+			});
+
+			// Set a different fieldId to trigger dependentParametersValues change on navigation
+			await n8n.ndv.fillParameterInputByName('fieldId', 'table2');
+
+			// Wait for resource mapper fields to reload
+			await expect(n8n.ndv.getResourceMapperParameterInputs()).toHaveCount(3);
+
+			// Fill resource mapper values on second node
+			await n8n.ndv.fillParameterInputByName('id', '002');
+			await n8n.ndv.fillParameterInputByName('name', 'Jane');
+
+			// Navigate to previous node (first E2E Test) using floating node navigation
+			await n8n.ndv.clickFloatingNodeByPosition('inputMain');
+
+			// Wait for navigation to complete by checking node-specific field value
+			await expect(n8n.ndv.getParameterInputField('fieldId')).toHaveValue('table1');
+			await expect(n8n.ndv.getResourceMapperParameterInputs()).toHaveCount(3);
+
+			// Verify first node's resource mapper values are preserved
+			await expect(n8n.ndv.getParameterInputField('id')).toHaveValue('001');
+			await expect(n8n.ndv.getParameterInputField('name')).toHaveValue('John');
+
+			// Navigate to next node (second E2E Test)
+			await n8n.ndv.clickFloatingNodeByPosition('outputMain');
+
+			// Wait for navigation to complete by checking node-specific field value
+			await expect(n8n.ndv.getParameterInputField('fieldId')).toHaveValue('table2');
+			await expect(n8n.ndv.getResourceMapperParameterInputs()).toHaveCount(3);
+
+			// Verify second node's resource mapper values are preserved
+			await expect(n8n.ndv.getParameterInputField('id')).toHaveValue('002');
+			await expect(n8n.ndv.getParameterInputField('name')).toHaveValue('Jane');
+		});
+	},
+);


### PR DESCRIPTION
## Summary

When navigating between connected Data Table nodes (or any nodes using resource mapper) via the NDV floating node arrows, the resource mapper field values were being cleared. This was a community-reported bug.

**Root cause:** The parent component (`ParameterInputList`) recomputes `dependentParametersValues` asynchronously via a `throttledWatch` (200ms). When switching nodes, the `ResourceMapper` component would see the stale dep values from the previous node transition to the correct values for the new node. Its dependency watcher mistook this for the user changing a dependent parameter and cleared all field values.

**Fix:**
1. Added `:key="node?.name"` on `ResourceMapper` to force a clean remount when switching nodes
2. Added a `watch(node)` that immediately nullifies `dependentParametersValues` when the active node changes, so the ResourceMapper mounts with `null` dep values. When the `throttledWatch` later recomputes the correct values, the watcher sees a `null → correctValue` transition which is naturally skipped by the existing `oldValue !== null` guard

**How to test:**
1. Create two Data Table nodes connected to each other
2. Configure both with different field IDs and fill in resource mapper values
3. Open the second node's NDV, use the floating navigation arrow to go to the first node
4. Verify the first node's values are preserved
5. Navigate back to the second node and verify its values are preserved

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-4918

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)