### PR TITLE
ci: Add nightly schedule to Docker build smoke test (no-changelog)

### DIFF
--- a/.github/workflows/docker-build-smoke.yml
+++ b/.github/workflows/docker-build-smoke.yml
@@ -9,6 +9,8 @@ name: 'Docker Build Smoke Test'
 #             build n8n + runners images (no Docker cache)
 
 on:
+  schedule:
+    - cron: '0 3 * * *' # 3:00 AM UTC, after the nightly Docker build at midnight
   pull_request:
     paths:
       - 'docker/images/n8n/**'
@@ -46,3 +48,17 @@ jobs:
           sleep 5
           docker logs n8n-smoke-test 2>&1 | tail -20
           docker stop n8n-smoke-test
+
+  notify-on-failure:
+    name: Notify on nightly smoke test failure
+    runs-on: ubuntu-slim
+    needs: [docker-smoke-test]
+    if: needs.docker-smoke-test.result == 'failure' && github.event_name == 'schedule'
+    steps:
+      - uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.QBOT_SLACK_TOKEN }}
+          payload: |
+            channel: C0A9RLY8Y20
+            text: "🚨 Nightly Docker smoke test failed (no-cache build) - ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/cubic.yaml
+++ b/cubic.yaml
@@ -40,6 +40,14 @@ reviews:
     - Version files
 
     Approve if reasonably tested. Let humans handle edge cases.
+
+    ## Step 4: Design System Tokens
+
+    For any hard-coded visual values in CSS (colors, shadows, spacing), check
+    `@n8n/design-system/src/css/_primitives.scss` and
+    `@n8n/design-system/src/css/_tokens.scss` for an appropriate alternative.
+    If one exists, suggest using it. If none exist, ask why the hard-coded
+    value is required.
   custom_rules:
     - name: Tests
       description: |-
@@ -187,9 +195,57 @@ reviews:
         - Higher scrutiny for: expression engine, credential handling, code execution nodes, license enforcement, SSO integrations
         - Consider n8n's security audit categories: credentials, database, nodes, instance, filesystem risks
         - Community/custom nodes have higher risk profile than official nodes
+    - name: Design System Tokens
+      description: |-
+        For any hard-coded visual values in CSS (colors, shadows, spacing),
+        check `@n8n/design-system/src/css/_primitives.scss` and
+        `@n8n/design-system/src/css/_tokens.scss` for an appropriate alternative.
+        If one exists, suggest using it. If none exist, ask why the hard-coded
+        value is required.
+    - name: Use workflowDocumentStore for Migrated Workflow Fields
+      description: |-
+        We are actively migrating workflow state from `workflowsStore` (Pinia store defined in
+        `packages/frontend/editor-ui/src/app/stores/workflows.store.ts`) to `workflowDocumentStore`
+        (defined in `packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts`).
+
+        The `workflowDocumentStore` is the single source of truth for migrated fields.
+        When new frontend code reads or writes any of the fields listed below, it **must** use
+        `workflowDocumentStore` instead of `workflowsStore.workflow.*` or equivalent accessors.
+
+        **Already-migrated fields (do NOT access via workflowsStore):**
+        - `active`
+        - `activeVersion`
+        - `activeVersionId`
+        - `checksum`
+        - `createdAt`
+        - `homeProject`
+        - `meta`
+        - `pinData`
+        - `settings`
+        - `tags`
+        - `updatedAt`
+
+        **Detection criteria — flag when NEW code in `packages/frontend/` does any of:**
+        1. Reads a migrated field from `workflowsStore.workflow.<field>` (e.g. `workflowsStore.workflow.tags`)
+        2. Reads a migrated field from a destructured `workflow` ref originating from `workflowsStore`
+        3. Writes to a migrated field through `workflowsStore` (e.g. `workflowsStore.workflow.active = true`)
+        4. Calls a `workflowsStore` setter/action that only mutates a migrated field when
+           `workflowDocumentStore` already exposes an equivalent method
+
+        **Do NOT flag:**
+        - Existing unchanged code (only review new or modified lines)
+        - Access to non-migrated fields (e.g. `workflowsStore.workflow.nodes`, `workflowsStore.workflow.connections`)
+        - Backend code — this rule applies only to `packages/frontend/`
+        - Code inside `workflowDocument.store.ts` or its sub-modules (those *are* the source of truth)
+        - Code inside `workflows.store.ts` itself (the migration is still in progress there)
+
+        **Recommendation:**
+        Use `useWorkflowDocumentStore(createWorkflowDocumentId(workflowId))` from
+        `@/app/stores/workflowDocument.store.ts` to access migrated fields.
+
+        This is an active migration. The list of migrated fields will grow over time.
 pr_descriptions:
   generate: false
   instructions: Each PR is supposed to have a limited scope. In your review, focus on changes made in the PR and avoid pointing out problems you found in the code that already existed.
 issues:
   fix_with_cubic_buttons: true
-

--- a/cubic.yaml
+++ b/cubic.yaml
@@ -195,6 +195,34 @@ reviews:
         - Higher scrutiny for: expression engine, credential handling, code execution nodes, license enforcement, SSO integrations
         - Consider n8n's security audit categories: credentials, database, nodes, instance, filesystem risks
         - Community/custom nodes have higher risk profile than official nodes
+    - name: Native C++ Addon Check
+      description: |-
+        Flag PRs that add native C++ addons to any package.json or pnpm-lock.yaml.
+
+        **Detection criteria — flag when a PR adds:**
+        - A known native module (isolated-vm, better-sqlite3, sharp, canvas, sqlite3,
+          node-sass, bcrypt, cpu-features, re2, libxmljs, etc.)
+        - A dependency with node-gyp, prebuild-install, or node-pre-gyp in its build scripts
+        - A new `binding.gyp` file or C++/C addon source files
+
+        **When detected, comment with:**
+        1. Native C++ addons compiled on Ubuntu/glibc CI runners produce binaries
+           incompatible with Alpine/musl Docker containers
+        2. The Dockerfile(s) in `docker/images/` may need an explicit `npm rebuild`
+           for the new module
+        3. Run `pnpm build:docker:clean` locally or trigger the Docker Build Smoke
+           Test workflow to verify the image builds and starts correctly
+        4. A nightly smoke test catches this automatically, but same-day verification
+           prevents up to 24h of broken containers
+
+        **Context:** In Feb 2026, `isolated-vm` was added without a Dockerfile change.
+        The glibc binary was silently copied into the Alpine runner container, breaking
+        Code node execution for 16 days until discovered.
+
+        **Do NOT flag:**
+        - Version bumps of existing native dependencies (already handled in Dockerfiles)
+        - Pure JavaScript/WASM alternatives (e.g., better-sqlite3-wasm)
+        - Existing unchanged code
     - name: Design System Tokens
       description: |-
         For any hard-coded visual values in CSS (colors, shadows, spacing),

--- a/cubic.yaml
+++ b/cubic.yaml
@@ -40,14 +40,6 @@ reviews:
     - Version files
 
     Approve if reasonably tested. Let humans handle edge cases.
-
-    ## Step 4: Design System Tokens
-
-    For any hard-coded visual values in CSS (colors, shadows, spacing), check
-    `@n8n/design-system/src/css/_primitives.scss` and
-    `@n8n/design-system/src/css/_tokens.scss` for an appropriate alternative.
-    If one exists, suggest using it. If none exist, ask why the hard-coded
-    value is required.
   custom_rules:
     - name: Tests
       description: |-
@@ -195,85 +187,9 @@ reviews:
         - Higher scrutiny for: expression engine, credential handling, code execution nodes, license enforcement, SSO integrations
         - Consider n8n's security audit categories: credentials, database, nodes, instance, filesystem risks
         - Community/custom nodes have higher risk profile than official nodes
-    - name: Native C++ Addon Check
-      description: |-
-        Flag PRs that add native C++ addons to any package.json or pnpm-lock.yaml.
-
-        **Detection criteria — flag when a PR adds:**
-        - A known native module (isolated-vm, better-sqlite3, sharp, canvas, sqlite3,
-          node-sass, bcrypt, cpu-features, re2, libxmljs, etc.)
-        - A dependency with node-gyp, prebuild-install, or node-pre-gyp in its build scripts
-        - A new `binding.gyp` file or C++/C addon source files
-
-        **When detected, comment with:**
-        1. Native C++ addons compiled on Ubuntu/glibc CI runners produce binaries
-           incompatible with Alpine/musl Docker containers
-        2. The Dockerfile(s) in `docker/images/` may need an explicit `npm rebuild`
-           for the new module
-        3. Run `pnpm build:docker:clean` locally or trigger the Docker Build Smoke
-           Test workflow to verify the image builds and starts correctly
-        4. A nightly smoke test catches this automatically, but same-day verification
-           prevents up to 24h of broken containers
-
-        **Context:** In Feb 2026, `isolated-vm` was added without a Dockerfile change.
-        The glibc binary was silently copied into the Alpine runner container, breaking
-        Code node execution for 16 days until discovered.
-
-        **Do NOT flag:**
-        - Version bumps of existing native dependencies (already handled in Dockerfiles)
-        - Pure JavaScript/WASM alternatives (e.g., better-sqlite3-wasm)
-        - Existing unchanged code
-    - name: Design System Tokens
-      description: |-
-        For any hard-coded visual values in CSS (colors, shadows, spacing),
-        check `@n8n/design-system/src/css/_primitives.scss` and
-        `@n8n/design-system/src/css/_tokens.scss` for an appropriate alternative.
-        If one exists, suggest using it. If none exist, ask why the hard-coded
-        value is required.
-    - name: Use workflowDocumentStore for Migrated Workflow Fields
-      description: |-
-        We are actively migrating workflow state from `workflowsStore` (Pinia store defined in
-        `packages/frontend/editor-ui/src/app/stores/workflows.store.ts`) to `workflowDocumentStore`
-        (defined in `packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts`).
-
-        The `workflowDocumentStore` is the single source of truth for migrated fields.
-        When new frontend code reads or writes any of the fields listed below, it **must** use
-        `workflowDocumentStore` instead of `workflowsStore.workflow.*` or equivalent accessors.
-
-        **Already-migrated fields (do NOT access via workflowsStore):**
-        - `active`
-        - `activeVersion`
-        - `activeVersionId`
-        - `checksum`
-        - `createdAt`
-        - `homeProject`
-        - `meta`
-        - `pinData`
-        - `settings`
-        - `tags`
-        - `updatedAt`
-
-        **Detection criteria — flag when NEW code in `packages/frontend/` does any of:**
-        1. Reads a migrated field from `workflowsStore.workflow.<field>` (e.g. `workflowsStore.workflow.tags`)
-        2. Reads a migrated field from a destructured `workflow` ref originating from `workflowsStore`
-        3. Writes to a migrated field through `workflowsStore` (e.g. `workflowsStore.workflow.active = true`)
-        4. Calls a `workflowsStore` setter/action that only mutates a migrated field when
-           `workflowDocumentStore` already exposes an equivalent method
-
-        **Do NOT flag:**
-        - Existing unchanged code (only review new or modified lines)
-        - Access to non-migrated fields (e.g. `workflowsStore.workflow.nodes`, `workflowsStore.workflow.connections`)
-        - Backend code — this rule applies only to `packages/frontend/`
-        - Code inside `workflowDocument.store.ts` or its sub-modules (those *are* the source of truth)
-        - Code inside `workflows.store.ts` itself (the migration is still in progress there)
-
-        **Recommendation:**
-        Use `useWorkflowDocumentStore(createWorkflowDocumentId(workflowId))` from
-        `@/app/stores/workflowDocument.store.ts` to access migrated fields.
-
-        This is an active migration. The list of migrated fields will grow over time.
 pr_descriptions:
   generate: false
   instructions: Each PR is supposed to have a limited scope. In your review, focus on changes made in the PR and avoid pointing out problems you found in the code that already existed.
 issues:
   fix_with_cubic_buttons: true
+


### PR DESCRIPTION
## Summary

- Adds a nightly `schedule` trigger (3 AM UTC) to `docker-build-smoke.yml` so the no-cache Docker build runs daily, catching native C++ addon drift regardless of which files changed
- Adds Slack notification to `#updates-quality` on nightly failure (using same `QBOT_SLACK_TOKEN` bot as Trivy)


## Related Linear tickets, Github issues, and Community forum posts

<!-- Post-incident improvement from isolated-vm incident -->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)