### PR TITLE
feat(core): Allow manual configuration of HashiCorp Vault KV mount path and version

### DIFF
--- a/packages/cli/src/modules/external-secrets.ee/providers/__tests__/vault.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/__tests__/vault.test.ts
@@ -24,6 +24,41 @@ const vaultSettings = {
 	},
 };
 
+function vaultSettingsWithKvPath(kvMountPath: string, kvVersion: string) {
+	return {
+		...vaultSettings,
+		settings: {
+			...vaultSettings.settings,
+			kvMountPath,
+			kvVersion,
+		},
+	};
+}
+
+function tokenLookupResponse() {
+	return {
+		data: {
+			accessor: 'test',
+			creation_time: 0,
+			creation_ttl: 0,
+			display_name: 'test',
+			entity_id: '',
+			expire_time: null,
+			explicit_max_ttl: 0,
+			id: 'test-token',
+			issue_time: '',
+			meta: {},
+			num_uses: 0,
+			orphan: false,
+			path: 'auth/token/create',
+			policies: ['default'],
+			ttl: 0,
+			renewable: false,
+			type: 'service',
+		},
+	};
+}
+
 function mountsResponse(mounts: Record<string, object>) {
 	return { data: mounts };
 }
@@ -167,6 +202,111 @@ describe('VaultProvider', () => {
 
 			expect(provider.hasSecret('forbidden')).toBe(false);
 			expect(provider.getSecretNames()).toHaveLength(0);
+			scope.done();
+		});
+	});
+
+	describe('update with manual KV path', () => {
+		it('should load secrets from a manually configured KV v2 path', async () => {
+			const provider = new VaultProvider(logger);
+			await provider.init(vaultSettingsWithKvPath('secret/', '2'));
+
+			const scope = nock(VAULT_BASE_URL)
+				.get('/v1/secret/metadata/?list=true')
+				.reply(200, { data: { keys: ['myapp'] } })
+				.get('/v1/secret/data/myapp')
+				.reply(200, kvV2SecretResponse({ password: 'hunter2' }));
+
+			await provider.update();
+
+			expect(provider.getSecret('secret')).toEqual({ myapp: { password: 'hunter2' } });
+			expect(provider.hasSecret('secret')).toBe(true);
+			expect(provider.getSecretNames()).toContain('secret.myapp.password');
+			scope.done();
+		});
+
+		it('should load secrets from a manually configured KV v1 path', async () => {
+			const provider = new VaultProvider(logger);
+			await provider.init(vaultSettingsWithKvPath('kv/', '1'));
+
+			const scope = nock(VAULT_BASE_URL)
+				.get('/v1/kv/?list=true')
+				.reply(200, { data: { keys: ['myapp'] } })
+				.get('/v1/kv/myapp')
+				.reply(200, { data: { password: 'hunter2' } });
+
+			await provider.update();
+
+			expect(provider.getSecret('kv')).toEqual({ myapp: { password: 'hunter2' } });
+			expect(provider.hasSecret('kv')).toBe(true);
+			expect(provider.getSecretNames()).toContain('kv.myapp.password');
+			scope.done();
+		});
+
+		it('should normalise a mount path without a trailing slash', async () => {
+			const provider = new VaultProvider(logger);
+			await provider.init(vaultSettingsWithKvPath('secret', '2'));
+
+			const scope = nock(VAULT_BASE_URL)
+				.get('/v1/secret/metadata/?list=true')
+				.reply(200, { data: { keys: ['myapp'] } })
+				.get('/v1/secret/data/myapp')
+				.reply(200, kvV2SecretResponse({ password: 'hunter2' }));
+
+			await provider.update();
+
+			expect(provider.getSecret('secret')).toEqual({ myapp: { password: 'hunter2' } });
+			scope.done();
+		});
+	});
+
+	describe('test with manual KV path', () => {
+		it('should validate access to the configured KV path instead of sys/mounts', async () => {
+			const provider = new VaultProvider(logger);
+			await provider.init(vaultSettingsWithKvPath('secret/', '2'));
+
+			const scope = nock(VAULT_BASE_URL)
+				.get('/v1/auth/token/lookup-self')
+				.reply(200, tokenLookupResponse())
+				.get('/v1/secret/metadata/?list=true')
+				.reply(200, { data: { keys: [] } });
+
+			const [success] = await provider.test();
+
+			expect(success).toBe(true);
+			scope.done();
+		});
+
+		it('should return error when token lacks access to the configured KV path', async () => {
+			const provider = new VaultProvider(logger);
+			await provider.init(vaultSettingsWithKvPath('secret/', '2'));
+
+			const scope = nock(VAULT_BASE_URL)
+				.get('/v1/auth/token/lookup-self')
+				.reply(200, tokenLookupResponse())
+				.get('/v1/secret/metadata/?list=true')
+				.reply(403, { errors: ['permission denied'] });
+
+			const [success, message] = await provider.test();
+
+			expect(success).toBe(false);
+			expect(message).toContain('Permission denied');
+			scope.done();
+		});
+
+		it('should validate KV v1 path without metadata segment', async () => {
+			const provider = new VaultProvider(logger);
+			await provider.init(vaultSettingsWithKvPath('kv/', '1'));
+
+			const scope = nock(VAULT_BASE_URL)
+				.get('/v1/auth/token/lookup-self')
+				.reply(200, tokenLookupResponse())
+				.get('/v1/kv/?list=true')
+				.reply(200, { data: { keys: [] } });
+
+			const [success] = await provider.test();
+
+			expect(success).toBe(true);
 			scope.done();
 		});
 	});

--- a/packages/cli/src/modules/external-secrets.ee/providers/__tests__/vault.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/__tests__/vault.test.ts
@@ -348,6 +348,22 @@ describe('VaultProvider', () => {
 			scope.done();
 		});
 
+		it('should treat 404 as success for an empty KV mount', async () => {
+			const provider = new VaultProvider(logger);
+			await provider.init(vaultSettingsWithKvPath('secret/', '2'));
+
+			const scope = nock(VAULT_BASE_URL)
+				.get('/v1/auth/token/lookup-self')
+				.reply(200, tokenLookupResponse())
+				.get('/v1/secret/metadata/?list=true')
+				.reply(404, { errors: [] });
+
+			const [success] = await provider.test();
+
+			expect(success).toBe(true);
+			scope.done();
+		});
+
 		it('should return error when token lacks access to the configured KV path', async () => {
 			const provider = new VaultProvider(logger);
 			await provider.init(vaultSettingsWithKvPath('secret/', '2'));

--- a/packages/cli/src/modules/external-secrets.ee/providers/__tests__/vault.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/__tests__/vault.test.ts
@@ -243,7 +243,7 @@ describe('VaultProvider', () => {
 			scope.done();
 		});
 
-		it('should normalise a mount path without a trailing slash', async () => {
+		it('should append trailing slash to mount path when missing', async () => {
 			const provider = new VaultProvider(logger);
 			await provider.init(vaultSettingsWithKvPath('secret', '2'));
 
@@ -256,6 +256,77 @@ describe('VaultProvider', () => {
 			await provider.update();
 
 			expect(provider.getSecret('secret')).toEqual({ myapp: { password: 'hunter2' } });
+			scope.done();
+		});
+
+		it('should return no secrets when the configured KV path returns 403', async () => {
+			const provider = new VaultProvider(logger);
+			await provider.init(vaultSettingsWithKvPath('secret/', '2'));
+
+			const scope = nock(VAULT_BASE_URL)
+				.get('/v1/secret/metadata/?list=true')
+				.reply(403, { errors: ['permission denied'] });
+
+			await provider.update();
+
+			expect(provider.hasSecret('secret')).toBe(false);
+			expect(provider.getSecretNames()).toHaveLength(0);
+			scope.done();
+		});
+	});
+
+	describe('test with auto-discovery', () => {
+		it('should validate access to sys/mounts when no manual KV path is configured', async () => {
+			const provider = new VaultProvider(logger);
+			await provider.init(vaultSettings);
+
+			const scope = nock(VAULT_BASE_URL)
+				.get('/v1/auth/token/lookup-self')
+				.reply(200, tokenLookupResponse())
+				.get('/v1/sys/mounts')
+				.reply(200, mountsResponse({ 'secret/': { type: 'kv', options: { version: '2' } } }));
+
+			const [success] = await provider.test();
+
+			expect(success).toBe(true);
+			scope.done();
+		});
+
+		it('should return error when token lacks access to sys/mounts', async () => {
+			const provider = new VaultProvider(logger);
+			await provider.init(vaultSettings);
+
+			const scope = nock(VAULT_BASE_URL)
+				.get('/v1/auth/token/lookup-self')
+				.reply(200, tokenLookupResponse())
+				.get('/v1/sys/mounts')
+				.reply(403, { errors: ['permission denied'] });
+
+			const [success, message] = await provider.test();
+
+			expect(success).toBe(false);
+			expect(message).toBe(
+				"Couldn't list mounts. Please give these credentials 'read' access to sys/mounts.",
+			);
+			scope.done();
+		});
+
+		it('should return error when sys/mounts returns an unexpected status', async () => {
+			const provider = new VaultProvider(logger);
+			await provider.init(vaultSettings);
+
+			const scope = nock(VAULT_BASE_URL)
+				.get('/v1/auth/token/lookup-self')
+				.reply(200, tokenLookupResponse())
+				.get('/v1/sys/mounts')
+				.reply(500, { errors: ['internal error'] });
+
+			const [success, message] = await provider.test();
+
+			expect(success).toBe(false);
+			expect(message).toBe(
+				"Couldn't list mounts but it wasn't a permissions issue. Please consult your Vault admin.",
+			);
 			scope.done();
 		});
 	});
@@ -290,7 +361,24 @@ describe('VaultProvider', () => {
 			const [success, message] = await provider.test();
 
 			expect(success).toBe(false);
-			expect(message).toContain('Permission denied');
+			expect(message).toBe('Permission denied accessing secret/. Check your token policies.');
+			scope.done();
+		});
+
+		it('should return error when configured KV path returns an unexpected status', async () => {
+			const provider = new VaultProvider(logger);
+			await provider.init(vaultSettingsWithKvPath('secret/', '2'));
+
+			const scope = nock(VAULT_BASE_URL)
+				.get('/v1/auth/token/lookup-self')
+				.reply(200, tokenLookupResponse())
+				.get('/v1/secret/metadata/?list=true')
+				.reply(500, { errors: ['internal error'] });
+
+			const [success, message] = await provider.test();
+
+			expect(success).toBe(false);
+			expect(message).toBe('Could not access KV mount at secret/ (status 500).');
 			scope.done();
 		});
 

--- a/packages/cli/src/modules/external-secrets.ee/providers/vault.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/vault.ts
@@ -27,6 +27,10 @@ interface VaultSettings {
 	// AppRole
 	roleId: string;
 	secretId: string;
+
+	// Manual KV configuration (bypasses sys/mounts auto-discovery)
+	kvMountPath?: string;
+	kvVersion?: string;
 }
 
 interface VaultResponse<T> {
@@ -211,6 +215,31 @@ export class VaultProvider extends SecretsProvider {
 					authMethod: ['appRole'],
 				},
 			},
+		},
+
+		// Manual KV configuration
+		{
+			displayName: 'KV Mount Path (optional)',
+			name: 'kvMountPath',
+			type: 'string',
+			default: '',
+			required: false,
+			noDataExpression: true,
+			placeholder: 'e.g. secret/',
+			hint: 'Specify the KV engine mount path to skip sys/mounts auto-discovery. Leave blank to auto-detect.',
+		},
+		{
+			displayName: 'KV Version',
+			name: 'kvVersion',
+			type: 'options',
+			default: '2',
+			required: false,
+			noDataExpression: true,
+			options: [
+				{ name: 'v1', value: '1' },
+				{ name: 'v2', value: '2' },
+			],
+			hint: 'Only used when KV Mount Path is specified.',
 		},
 	];
 
@@ -449,28 +478,81 @@ export class VaultProvider extends SecretsProvider {
 		return [name, data];
 	}
 
-	async update(): Promise<void> {
-		const mounts = await this.#http.get<VaultResponse<VaultMountsResp>>('sys/mounts');
+	#normalizeKvPath(mountPath: string): string {
+		return mountPath.endsWith('/') ? mountPath : `${mountPath}/`;
+	}
 
-		const kvs = Object.entries(mounts.data.data).filter(([, v]) => v.type === 'kv');
+	async #discoverKvMounts(): Promise<Array<{ path: string; version: string }>> {
+		const { kvMountPath, kvVersion } = this.settings;
+
+		if (kvMountPath) {
+			return [{ path: this.#normalizeKvPath(kvMountPath), version: kvVersion ?? '2' }];
+		}
+
+		const mounts = await this.#http.get<VaultResponse<VaultMountsResp>>('sys/mounts');
+		const kvMounts = Object.entries(mounts.data.data).filter(([, mount]) => mount.type === 'kv');
+
+		return kvMounts
+			.map(([basePath, mount]) => {
+				const version = mount.options?.version;
+				if (typeof version !== 'string') {
+					this.logger.debug(`Skipping KV mount "${basePath}" — no version in mount options`);
+					return null;
+				}
+				return { path: basePath, version };
+			})
+			.filter((entry): entry is { path: string; version: string } => entry !== null);
+	}
+
+	async #testSecretAccess(): Promise<[boolean] | [boolean, string]> {
+		const { kvMountPath, kvVersion } = this.settings;
+
+		let listUrl: string;
+		let forbiddenMessage: string;
+		let failureMessage: (status: number) => string;
+
+		if (kvMountPath) {
+			const normalizedPath = this.#normalizeKvPath(kvMountPath);
+			const version = kvVersion ?? '2';
+			listUrl =
+				version === '2' ? `${normalizedPath}metadata/?list=true` : `${normalizedPath}?list=true`;
+			forbiddenMessage = `Permission denied accessing ${kvMountPath}. Check your token policies.`;
+			failureMessage = (status) =>
+				`Could not access KV mount at ${kvMountPath} (status ${status}).`;
+		} else {
+			listUrl = 'sys/mounts';
+			forbiddenMessage =
+				"Couldn't list mounts. Please give these credentials 'read' access to sys/mounts.";
+			failureMessage = () =>
+				"Couldn't list mounts but it wasn't a permissions issue. Please consult your Vault admin.";
+		}
+
+		const resp = await this.#http.get(listUrl, { validateStatus: () => true });
+
+		if (resp.status === 403) {
+			return [false, forbiddenMessage];
+		}
+		if (resp.status !== 200) {
+			return [false, failureMessage(resp.status)];
+		}
+		return [true];
+	}
+
+	async update(): Promise<void> {
+		const kvMounts = await this.#discoverKvMounts();
 
 		const secrets = Object.fromEntries(
 			(
 				await Promise.all(
-					kvs.map(async ([basePath, data]): Promise<[string, IDataObject] | null> => {
-						const version = data.options?.version;
-						if (typeof version !== 'string') {
-							this.logger.debug(`Skipping KV mount "${basePath}" — no version in mount options`);
-							return null;
-						}
-						const value = await this.getKVSecrets(basePath, version, '');
+					kvMounts.map(async ({ path, version }): Promise<[string, IDataObject] | null> => {
+						const value = await this.getKVSecrets(path, version, '');
 						if (value === null) {
 							return null;
 						}
-						return [basePath.substring(0, basePath.length - 1), value[1]];
+						return [path.substring(0, path.length - 1), value[1]];
 					}),
 				)
-			).filter((v): v is [string, IDataObject] => v !== null),
+			).filter((entry): entry is [string, IDataObject] => entry !== null),
 		);
 		this.cachedSecrets = secrets;
 		this.logger.debug('Vault provider secrets updated');
@@ -487,29 +569,10 @@ export class VaultProvider extends SecretsProvider {
 				return [false, 'Invalid credentials'];
 			}
 
-			const resp = await this.#http.request<VaultResponse<VaultTokenInfo>>({
-				method: 'GET',
-				url: 'sys/mounts',
-				responseType: 'json',
-				validateStatus: () => true,
-			});
-
-			if (resp.status === 403) {
-				return [
-					false,
-					"Couldn't list mounts. Please give these credentials 'read' access to sys/mounts.",
-				];
-			} else if (resp.status !== 200) {
-				return [
-					false,
-					"Couldn't list mounts but wasn't a permissions issue. Please consult your Vault admin.",
-				];
-			}
-
-			return [true];
-		} catch (e) {
-			if (axios.isAxiosError(e)) {
-				if (e.code === 'ECONNREFUSED') {
+			return await this.#testSecretAccess();
+		} catch (error) {
+			if (axios.isAxiosError(error)) {
+				if (error.code === 'ECONNREFUSED') {
 					return [
 						false,
 						'Connection refused. Please check the host and port of the server are correct.',

--- a/packages/cli/src/modules/external-secrets.ee/providers/vault.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/vault.ts
@@ -532,10 +532,11 @@ export class VaultProvider extends SecretsProvider {
 		if (resp.status === 403) {
 			return [false, forbiddenMessage];
 		}
-		if (resp.status !== 200) {
-			return [false, failureMessage(resp.status)];
+		// Vault returns 404 when listing an empty KV mount — this is valid, not an error
+		if (resp.status === 200 || (kvMountPath && resp.status === 404)) {
+			return [true];
 		}
-		return [true];
+		return [false, failureMessage(resp.status)];
 	}
 
 	async update(): Promise<void> {

--- a/packages/cli/src/modules/external-secrets.ee/providers/vault.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/vault.ts
@@ -478,15 +478,15 @@ export class VaultProvider extends SecretsProvider {
 		return [name, data];
 	}
 
-	#normalizeKvPath(mountPath: string): string {
+	private normalizeKvPath(mountPath: string): string {
 		return mountPath.endsWith('/') ? mountPath : `${mountPath}/`;
 	}
 
-	async #discoverKvMounts(): Promise<Array<{ path: string; version: string }>> {
+	private async discoverKvMounts(): Promise<Array<{ path: string; version: string }>> {
 		const { kvMountPath, kvVersion } = this.settings;
 
 		if (kvMountPath) {
-			return [{ path: this.#normalizeKvPath(kvMountPath), version: kvVersion ?? '2' }];
+			return [{ path: this.normalizeKvPath(kvMountPath), version: kvVersion ?? '2' }];
 		}
 
 		const mounts = await this.#http.get<VaultResponse<VaultMountsResp>>('sys/mounts');
@@ -504,7 +504,7 @@ export class VaultProvider extends SecretsProvider {
 			.filter((entry): entry is { path: string; version: string } => entry !== null);
 	}
 
-	async #testSecretAccess(): Promise<[boolean] | [boolean, string]> {
+	private async testSecretAccess(): Promise<[boolean] | [boolean, string]> {
 		const { kvMountPath, kvVersion } = this.settings;
 
 		let listUrl: string;
@@ -512,7 +512,7 @@ export class VaultProvider extends SecretsProvider {
 		let failureMessage: (status: number) => string;
 
 		if (kvMountPath) {
-			const normalizedPath = this.#normalizeKvPath(kvMountPath);
+			const normalizedPath = this.normalizeKvPath(kvMountPath);
 			const version = kvVersion ?? '2';
 			listUrl =
 				version === '2' ? `${normalizedPath}metadata/?list=true` : `${normalizedPath}?list=true`;
@@ -539,7 +539,7 @@ export class VaultProvider extends SecretsProvider {
 	}
 
 	async update(): Promise<void> {
-		const kvMounts = await this.#discoverKvMounts();
+		const kvMounts = await this.discoverKvMounts();
 
 		const secrets = Object.fromEntries(
 			(
@@ -569,7 +569,7 @@ export class VaultProvider extends SecretsProvider {
 				return [false, 'Invalid credentials'];
 			}
 
-			return await this.#testSecretAccess();
+			return await this.testSecretAccess();
 		} catch (error) {
 			if (axios.isAxiosError(error)) {
 				if (error.code === 'ECONNREFUSED') {


### PR DESCRIPTION
## Summary

Enterprise customers whose Vault tokens lack `sys/mounts` read access cannot use n8n's external secrets integration because auto-discovery fails. This PR adds optional `kvMountPath` and `kvVersion` settings to the HashiCorp Vault external secrets provider, allowing users to bypass `sys/mounts` auto-discovery entirely.

**Changes:**
- Added `kvMountPath` (string) and `kvVersion` (v1/v2 dropdown) fields to the Vault provider UI
- Extracted `discoverKvMounts()` to unify mount discovery — returns manual config or auto-discovered mounts with zero branching in `update()`
- Extracted `testSecretAccess()` to unify connection testing — validates the configured KV path directly instead of `sys/mounts` when manual path is set
- Added `normalizeKvPath()` helper to ensure trailing slash consistency
- Comprehensive test coverage: 16 tests covering auto-discovery, manual KV v1/v2 paths, path normalisation, 403/500 error handling

**How to test:**
1. Set up a Vault instance with a KV v2 store (e.g. `secret/`)
2. Create a token **without** `sys/mounts` access but with read/list on `secret/data/*` and `secret/metadata/*`
3. Configure Vault external secrets in n8n with the restricted token, setting KV Mount Path to `secret/` and KV Version to `v2`
4. Verify connection test succeeds and secrets are loaded
5. Verify that leaving KV Mount Path blank still uses auto-discovery as before

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-90

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)