### PR TITLE
fix(core): Prefix external secrets retry logs

### DIFF
--- a/packages/cli/src/modules/external-secrets.ee/retry-manager.service.ts
+++ b/packages/cli/src/modules/external-secrets.ee/retry-manager.service.ts
@@ -1,9 +1,11 @@
 import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
+import type { LogMetadata } from 'n8n-workflow';
 
 import { EXTERNAL_SECRETS_INITIAL_BACKOFF, EXTERNAL_SECRETS_MAX_BACKOFF } from './constants';
 
 type RetryOperation = () => Promise<{ success: boolean; error?: Error }>;
+type LogMethod = (message: string, metadata?: LogMetadata) => void;
 
 interface RetryInfo {
 	timeout: NodeJS.Timeout;
@@ -20,8 +22,21 @@ interface RetryInfo {
 export class ExternalSecretsRetryManager {
 	private retries = new Map<string, RetryInfo>();
 
-	constructor(private readonly logger: Logger) {
-		this.logger = this.logger.scoped('external-secrets');
+	private readonly logger: Record<'debug' | 'error' | 'warn' | 'info', LogMethod>;
+
+	constructor(logger: Logger) {
+		const scopedLogger = logger.scoped('external-secrets');
+		const withPrefix =
+			(level: 'debug' | 'error' | 'warn' | 'info'): LogMethod =>
+			(message, metadata?) =>
+				scopedLogger[level](`External secrets: ${message}`, metadata);
+
+		this.logger = {
+			debug: withPrefix('debug'),
+			error: withPrefix('error'),
+			warn: withPrefix('warn'),
+			info: withPrefix('info'),
+		};
 	}
 
 	async runWithRetry(


### PR DESCRIPTION
## Summary

Wraps the scoped logger in `ExternalSecretsRetryManager` with an "External secrets:" prefix so that retry log messages (e.g. "Operation failed for X", "Retrying operation for X") are immediately identifiable by operators debugging live instances via SSH.

Uses a closure-based wrapper to automatically prefix all log messages without modifying individual log call sites.

**Before:**
```
Operation failed for infisical
Retrying operation for infisical (attempt 1)
```

**After:**
```
External secrets: Operation failed for infisical
External secrets: Retrying operation for infisical (attempt 1)
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-302

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)