### PR TITLE
ci: Wait for git tag updates before ensuring RC branches

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -175,7 +175,14 @@ jobs:
 
   post-release:
     name: Run Post-release actions
-    needs: [determine-version-info, publish-to-npm, create-github-release]
+    needs:
+      [
+        determine-version-info,
+        publish-to-npm,
+        create-github-release,
+        move-track-tag,
+        promote-stable-tag,
+      ]
     uses: ./.github/workflows/release-publish-post-release.yml
     with:
       track: ${{ needs.determine-version-info.outputs.track }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -183,6 +183,12 @@ jobs:
         move-track-tag,
         promote-stable-tag,
       ]
+    if: |
+      always() &&
+      needs.publish-to-npm.result == 'success' &&
+      needs.create-github-release.result == 'success' &&
+      (needs.move-track-tag.result == 'success' || needs.move-track-tag.result == 'skipped') &&
+      (needs.promote-stable-tag.result == 'success' || needs.promote-stable-tag.result == 'skipped')
     uses: ./.github/workflows/release-publish-post-release.yml
     with:
       track: ${{ needs.determine-version-info.outputs.track }}


### PR DESCRIPTION
## Summary

Misconfigured `needs` field caused a race condition in release, causing RC branches not being ensured with up-to-date info.

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/actions/runs/22861728871

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
