### PR TITLE
chore(editor): ChatHub file knowledge telemetry events

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/chatHub/ChatSemanticSearchSettings.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/ChatSemanticSearchSettings.vue
@@ -19,6 +19,7 @@ import { storeToRefs } from 'pinia';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { updateSemanticSearchSettingsApi } from './chat.api';
 import { useToast } from '@/app/composables/useToast';
+import { useTelemetry } from '@/app/composables/useTelemetry';
 import { providerDisplayNames, vectorStoreProviderDisplayNames } from './constants';
 import { DEFAULT_SEMANTIC_SEARCH_SETTINGS, EMBEDDINGS_NODE_TYPE_MAP } from '@n8n/chat-hub';
 import { deepCopy } from 'n8n-workflow';
@@ -28,11 +29,28 @@ const message = useMessage();
 const rootStore = useRootStore();
 const chatStore = useChatStore();
 const toast = useToast();
+const telemetry = useTelemetry();
 const settingsStore = useSettingsStore();
 
 const { semanticSearchReadiness } = storeToRefs(chatStore);
 
 const settings = ref<ChatHubSemanticSearchSettings>(deepCopy(DEFAULT_SEMANTIC_SEARCH_SETTINGS));
+
+function trackSettingsUpdate(newSettings: ChatHubSemanticSearchSettings) {
+	const vsCredEntered = !!newSettings.vectorStore.credentialId;
+	const emCredEntered = !!newSettings.embeddingModel.credentialId;
+
+	telemetry.track('User updated semantic search settings', {
+		vector_store_provider: newSettings.vectorStore.provider,
+		embedding_provider: newSettings.embeddingModel.provider,
+		vector_store_credential_entered: vsCredEntered,
+		embedding_credential_entered: emCredEntered,
+		vector_store_credential_shared:
+			vsCredEntered && semanticSearchReadiness.value.vectorStoreIssue !== 'notShared',
+		embedding_credential_shared:
+			emCredEntered && semanticSearchReadiness.value.embeddingIssue !== 'notShared',
+	});
+}
 
 const vectorStoreCredentialType = computed(() => {
 	const provider = settings.value.vectorStore.provider;
@@ -85,12 +103,14 @@ async function onVectorStoreProviderChange(provider: ChatHubVectorStoreProvider)
 		}
 	}
 
+	const newSettings: ChatHubSemanticSearchSettings = {
+		...settings.value,
+		vectorStore: { provider, credentialId: null },
+	};
 	try {
-		await updateSemanticSearchSettingsApi(rootStore.restApiContext, {
-			...settings.value,
-			vectorStore: { provider, credentialId: null },
-		});
+		await updateSemanticSearchSettingsApi(rootStore.restApiContext, newSettings);
 		await settingsStore.getModuleSettings();
+		trackSettingsUpdate(newSettings);
 		toast.showMessage({
 			type: 'success',
 			title: i18n.baseText('settings.chatHub.semanticSearch.save.success'),
@@ -105,12 +125,14 @@ async function onVectorStoreCredentialSelected(credentialId: string | null) {
 		return;
 	}
 
+	const newSettings: ChatHubSemanticSearchSettings = {
+		...settings.value,
+		vectorStore: { ...settings.value.vectorStore, credentialId },
+	};
 	try {
-		await updateSemanticSearchSettingsApi(rootStore.restApiContext, {
-			...settings.value,
-			vectorStore: { ...settings.value.vectorStore, credentialId },
-		});
+		await updateSemanticSearchSettingsApi(rootStore.restApiContext, newSettings);
 		await settingsStore.getModuleSettings();
+		trackSettingsUpdate(newSettings);
 		toast.showMessage({
 			type: 'success',
 			title: i18n.baseText('settings.chatHub.semanticSearch.save.success'),
@@ -143,12 +165,14 @@ async function onEmbeddingModelProviderChange(provider: ChatHubLLMProvider) {
 		}
 	}
 
+	const newSettings: ChatHubSemanticSearchSettings = {
+		...settings.value,
+		embeddingModel: { provider, credentialId: null },
+	};
 	try {
-		await updateSemanticSearchSettingsApi(rootStore.restApiContext, {
-			...settings.value,
-			embeddingModel: { provider, credentialId: null },
-		});
+		await updateSemanticSearchSettingsApi(rootStore.restApiContext, newSettings);
 		await settingsStore.getModuleSettings();
+		trackSettingsUpdate(newSettings);
 		toast.showMessage({
 			type: 'success',
 			title: i18n.baseText('settings.chatHub.semanticSearch.save.success'),
@@ -163,12 +187,14 @@ async function onEmbeddingCredentialSelected(credentialId: string | null) {
 		return;
 	}
 
+	const newSettings: ChatHubSemanticSearchSettings = {
+		...settings.value,
+		embeddingModel: { ...settings.value.embeddingModel, credentialId },
+	};
 	try {
-		await updateSemanticSearchSettingsApi(rootStore.restApiContext, {
-			...settings.value,
-			embeddingModel: { ...settings.value.embeddingModel, credentialId },
-		});
+		await updateSemanticSearchSettingsApi(rootStore.restApiContext, newSettings);
 		await settingsStore.getModuleSettings();
+		trackSettingsUpdate(newSettings);
 		toast.showMessage({
 			type: 'success',
 			title: i18n.baseText('settings.chatHub.semanticSearch.save.success'),

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/AgentEditorModal.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/AgentEditorModal.vue
@@ -46,6 +46,7 @@ import { useCustomAgent } from '@/features/ai/chatHub/composables/useCustomAgent
 import { useFileDrop } from '@/features/ai/chatHub/composables/useFileDrop';
 import { usePostHog } from '@/app/stores/posthog.store';
 import { CHAT_HUB_SEMANTIC_SEARCH_EXPERIMENT } from '@/app/constants';
+import { useTelemetry } from '@/app/composables/useTelemetry';
 
 const props = defineProps<{
 	modalName: string;
@@ -259,24 +260,39 @@ async function onSave() {
 			suggestedPrompts: filteredPrompts.length > 0 ? filteredPrompts : undefined,
 		};
 
+		// Capture before async calls — the customAgent watcher resets newFiles mid-await
+		const addedFiles = [...newFiles.value];
+
 		if (isEditMode.value && props.data.agentId) {
 			await chatStore.updateCustomAgent(
 				props.data.agentId,
 				payload,
-				newFiles.value,
+				addedFiles,
 				removedFileKnowledgeIds.value,
 				props.data.credentials,
 			);
+			if (addedFiles.length > 0) {
+				const totalSizeMb = addedFiles.reduce((sum, f) => sum + f.size, 0) / (1024 * 1024);
+				telemetry.track('User added files to personal agent', {
+					count: addedFiles.length,
+					total_size_mb: totalSizeMb,
+					agent_id: props.data.agentId,
+				});
+			}
 			toast.showMessage({
 				title: i18n.baseText('chatHub.agent.editor.success.update'),
 				type: 'success',
 			});
 		} else {
-			const agent = await chatStore.createCustomAgent(
-				payload,
-				newFiles.value,
-				props.data.credentials,
-			);
+			const agent = await chatStore.createCustomAgent(payload, addedFiles, props.data.credentials);
+			if (addedFiles.length > 0) {
+				const totalSizeMb = addedFiles.reduce((sum, f) => sum + f.size, 0) / (1024 * 1024);
+				telemetry.track('User added files to personal agent', {
+					count: addedFiles.length,
+					total_size_mb: totalSizeMb,
+					agent_id: agent.model.provider === 'custom-agent' ? agent.model.agentId : undefined,
+				});
+			}
 			props.data.onCreateCustomAgent?.(agent);
 
 			toast.showMessage({
@@ -384,6 +400,7 @@ function removeFile(row: FileRow) {
 }
 
 const posthogStore = usePostHog();
+const telemetry = useTelemetry();
 const isSemanticSearchEnabled = computed(() =>
 	posthogStore.isVariantEnabled(
 		CHAT_HUB_SEMANTIC_SEARCH_EXPERIMENT.name,

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatPrompt.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatPrompt.vue
@@ -443,11 +443,6 @@ defineExpose({
 </template>
 
 <style lang="scss" module>
-.prompt {
-	display: grid;
-	place-items: center;
-}
-
 .callout {
 	margin: -1px;
 	padding: var(--spacing--sm);


### PR DESCRIPTION
## Summary

This PR implements telemetry events to track the usage of ChatHub personal agent's file knowledge feature

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-160/file-knowledge-telemetry


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
