### PR TITLE
fix(HTTP Request Node): Improve invalid JSON field error messages

### DIFF
--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -3,6 +3,7 @@ import type {
 	IBinaryKeyData,
 	IDataObject,
 	IExecuteFunctions,
+	INode,
 	INodeExecutionData,
 	INodeType,
 	INodeTypeBaseDescription,
@@ -23,6 +24,7 @@ import {
 	removeCircularRefs,
 	sleep,
 	isDomainAllowed,
+	ensureError,
 } from 'n8n-workflow';
 import type { Readable } from 'stream';
 
@@ -44,6 +46,7 @@ import {
 import { setFilename } from './utils/binaryData';
 import { mimeTypeFromResponse } from './utils/parse';
 import { configureResponseOptimizer } from '../shared/optimizeResponse';
+
 import { binaryToStringWithEncodingDetection } from './utils/buffer-decoding';
 
 function toText<T>(data: T) {
@@ -441,19 +444,12 @@ export class HttpRequestV3 implements INodeType {
 					} else if (specifyBody === 'json') {
 						// body is specified using JSON
 						if (typeof jsonBodyParameter !== 'object' && jsonBodyParameter !== null) {
-							try {
-								JSON.parse(jsonBodyParameter);
-							} catch {
-								throw new NodeOperationError(
-									this.getNode(),
-									'JSON parameter needs to be valid JSON',
-									{
-										itemIndex,
-									},
-								);
-							}
-
-							requestOptions.body = jsonParse(jsonBodyParameter);
+							requestOptions.body = parseJsonParameter(
+								this.getNode(),
+								jsonBodyParameter,
+								'JSON Body',
+								itemIndex,
+							);
 						} else {
 							requestOptions.body = jsonBodyParameter;
 						}
@@ -507,19 +503,12 @@ export class HttpRequestV3 implements INodeType {
 						requestOptions.qs = await reduceAsync(queryParameters, parametersToKeyValue);
 					} else if (specifyQuery === 'json') {
 						// query is specified using JSON
-						try {
-							JSON.parse(jsonQueryParameter);
-						} catch {
-							throw new NodeOperationError(
-								this.getNode(),
-								'JSON parameter needs to be valid JSON',
-								{
-									itemIndex,
-								},
-							);
-						}
-
-						requestOptions.qs = jsonParse(jsonQueryParameter);
+						requestOptions.qs = parseJsonParameter(
+							this.getNode(),
+							jsonQueryParameter,
+							'JSON Query Parameters',
+							itemIndex,
+						);
 					}
 				}
 
@@ -532,20 +521,12 @@ export class HttpRequestV3 implements INodeType {
 							parametersToKeyValue,
 						);
 					} else if (specifyHeaders === 'json') {
-						// body is specified using JSON
-						try {
-							JSON.parse(jsonHeadersParameter);
-						} catch {
-							throw new NodeOperationError(
-								this.getNode(),
-								'JSON parameter needs to be valid JSON',
-								{
-									itemIndex,
-								},
-							);
-						}
-
-						additionalHeaders = jsonParse(jsonHeadersParameter);
+						additionalHeaders = parseJsonParameter(
+							this.getNode(),
+							jsonHeadersParameter,
+							'JSON Headers',
+							itemIndex,
+						);
 					}
 					requestOptions.headers = {
 						...requestOptions.headers,
@@ -1147,5 +1128,29 @@ export class HttpRequestV3 implements INodeType {
 		}
 
 		return [returnItems];
+	}
+}
+
+/**
+ * Parses a JSON string and returns the result.
+ *
+ * @throws {NodeOperationError} if the string is not valid JSON.
+ */
+function parseJsonParameter(
+	node: INode,
+	jsonString: string,
+	fieldName: string,
+	itemIndex: number,
+): IDataObject {
+	try {
+		JSON.parse(jsonString);
+
+		return jsonParse(jsonString);
+	} catch (e) {
+		const error = ensureError(e);
+		throw new NodeOperationError(node, `The value in the "${fieldName}" field is not valid JSON`, {
+			itemIndex,
+			description: error.message,
+		});
 	}
 }

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -1143,9 +1143,7 @@ function parseJsonParameter(
 	itemIndex: number,
 ): IDataObject {
 	try {
-		JSON.parse(jsonString);
-
-		return jsonParse(jsonString);
+		return JSON.parse(jsonString) as IDataObject;
 	} catch (e) {
 		const error = ensureError(e);
 		throw new NodeOperationError(node, `The value in the "${fieldName}" field is not valid JSON`, {

--- a/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequestV3.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequestV3.test.ts
@@ -300,6 +300,124 @@ describe('HttpRequestV3', () => {
 		});
 	});
 
+	describe('JSON Parameter Validation', () => {
+		it.each([
+			{
+				field: 'body',
+				params: {
+					sendBody: true,
+					specifyBody: 'json',
+					jsonBody: '{"valid": true}',
+					'bodyParameters.parameters': [],
+				},
+			},
+			{
+				field: 'query',
+				params: {
+					sendQuery: true,
+					specifyQuery: 'json',
+					jsonQuery: '{"key": "value"}',
+					'queryParameters.parameters': [],
+				},
+			},
+			{
+				field: 'headers',
+				params: {
+					sendHeaders: true,
+					specifyHeaders: 'json',
+					jsonHeaders: '{"X-Custom": "header"}',
+					'headerParameters.parameters': [],
+				},
+			},
+		])('should accept valid JSON in $field parameter', async ({ params }) => {
+			(executeFunctions.getInputData as jest.Mock).mockReturnValue([{ json: {} }]);
+			(executeFunctions.getNodeParameter as jest.Mock).mockImplementation((paramName: string) => {
+				switch (paramName) {
+					case 'method':
+						return 'POST';
+					case 'url':
+						return baseUrl;
+					case 'authentication':
+						return 'none';
+					case 'options':
+						return options;
+					default:
+						return params[paramName as keyof typeof params] ?? undefined;
+				}
+			});
+			const response = {
+				headers: { 'content-type': 'application/json' },
+				body: Buffer.from(JSON.stringify({ success: true })),
+			};
+			(executeFunctions.helpers.request as jest.Mock).mockResolvedValue(response);
+
+			const result = await node.execute.call(executeFunctions);
+
+			expect(result).toBeDefined();
+		});
+
+		it.each([
+			{
+				field: 'body',
+				fieldName: 'JSON Body',
+				params: {
+					sendBody: true,
+					specifyBody: 'json',
+					jsonBody: '{"invalid: json}',
+					'bodyParameters.parameters': [],
+				},
+			},
+			{
+				field: 'query',
+				fieldName: 'JSON Query Parameters',
+				params: {
+					sendQuery: true,
+					specifyQuery: 'json',
+					jsonQuery: '{not valid}',
+					'queryParameters.parameters': [],
+				},
+			},
+			{
+				field: 'headers',
+				fieldName: 'JSON Headers',
+				params: {
+					sendHeaders: true,
+					specifyHeaders: 'json',
+					jsonHeaders: 'not json at all',
+					'headerParameters.parameters': [],
+				},
+			},
+		])(
+			'should throw descriptive error for invalid JSON in $field parameter',
+			async ({ fieldName, params }) => {
+				(executeFunctions.getInputData as jest.Mock).mockReturnValue([{ json: {} }]);
+				(executeFunctions.getNodeParameter as jest.Mock).mockImplementation((paramName: string) => {
+					switch (paramName) {
+						case 'method':
+							return 'POST';
+						case 'url':
+							return baseUrl;
+						case 'authentication':
+							return 'none';
+						case 'options':
+							return options;
+						default:
+							return params[paramName as keyof typeof params] ?? undefined;
+					}
+				});
+				const response = {
+					headers: { 'content-type': 'application/json' },
+					body: Buffer.from(JSON.stringify({ success: true })),
+				};
+				(executeFunctions.helpers.request as jest.Mock).mockResolvedValue(response);
+
+				await expect(node.execute.call(executeFunctions)).rejects.toThrow(
+					`The value in the "${fieldName}" field is not valid JSON`,
+				);
+			},
+		);
+	});
+
 	describe('Cross-Origin Redirects', () => {
 		it('should pass sendCredentialsOnCrossOriginRedirect = true to the request by default for node versions < 4.4', async () => {
 			(executeFunctions.getNode as jest.Mock).mockReturnValue({

--- a/packages/nodes-base/nodes/HttpRequest/test/node/workflow.use_error_output.json
+++ b/packages/nodes-base/nodes/HttpRequest/test/node/workflow.use_error_output.json
@@ -82,7 +82,7 @@
 		"Request body error": [
 			{
 				"json": {
-					"error": "JSON parameter needs to be valid JSON"
+					"error": "The value in the \"JSON Body\" field is not valid JSON"
 				}
 			}
 		],


### PR DESCRIPTION
## Summary

Improve HTTP Request V3 JSON validation errors by returning field-specific messages for body, query, and headers JSON inputs.
Refactor duplicated JSON parsing/validation code into a shared helper.
Add/extend tests to cover valid and invalid JSON parameter handling and update the workflow test fixture for the new error text.

Before
<img width="1077" height="303" alt="image" src="https://github.com/user-attachments/assets/d8423a72-7dbb-4e6a-a2ab-747aa3cd50d5" />


After
<img width="1047" height="272" alt="image" src="https://github.com/user-attachments/assets/c0fbb67f-4278-4418-b036-0bd07c15424e" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2576/better-error-message-if-param-is-not-valid-json-in-http-request-node

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
