### PR TITLE
ci: Workflow to create Patch release for track

### DIFF
--- a/.github/scripts/determine-release-candidate-branch-for-track.mjs
+++ b/.github/scripts/determine-release-candidate-branch-for-track.mjs
@@ -1,0 +1,33 @@
+import {
+	countCommitsBetweenRefs,
+	ensureEnvVar,
+	listCommitsBetweenRefs,
+	resolveRcBranchForTrack,
+	resolveReleaseTagForTrack,
+	writeGithubOutput,
+} from './github-helpers.mjs';
+
+function main() {
+	const track = /** @type { import('./github-helpers.mjs').ReleaseTrack } */ (
+		ensureEnvVar('TRACK')
+	);
+
+	const currentTag = resolveReleaseTagForTrack(track);
+
+	const releaseCandidateBranch = resolveRcBranchForTrack(track);
+
+	console.log(`Commits between ${releaseCandidateBranch} and ${currentTag.tag}:`);
+	console.log(listCommitsBetweenRefs(releaseCandidateBranch, currentTag.tag));
+
+	const commitCount = countCommitsBetweenRefs(releaseCandidateBranch, currentTag.tag);
+
+	writeGithubOutput({
+		release_candidate_branch: releaseCandidateBranch,
+		should_update: commitCount > 0 ? 'true' : 'false',
+	});
+}
+
+// only run when executed directly, not when imported by tests
+if (import.meta.url === `file://${process.argv[1]}`) {
+	main();
+}

--- a/.github/scripts/determine-release-candidate-branch-for-track.mjs
+++ b/.github/scripts/determine-release-candidate-branch-for-track.mjs
@@ -16,6 +16,12 @@ function main() {
 
 	const releaseCandidateBranch = resolveRcBranchForTrack(track);
 
+	if (!currentTag.tag || !releaseCandidateBranch) {
+		throw new Error(
+			`Couldn't resolve needed parameters. currentTag.tag=${currentTag.tag}, releaseCandidateBranch=${releaseCandidateBranch}`,
+		);
+	}
+
 	console.log(`Commits between ${releaseCandidateBranch} and ${currentTag.tag}:`);
 	console.log(listCommitsBetweenRefs(releaseCandidateBranch, currentTag.tag));
 

--- a/.github/scripts/determine-release-candidate-branch-for-track.mjs
+++ b/.github/scripts/determine-release-candidate-branch-for-track.mjs
@@ -16,7 +16,7 @@ function main() {
 
 	const releaseCandidateBranch = resolveRcBranchForTrack(track);
 
-	if (!currentTag.tag || !releaseCandidateBranch) {
+	if (!currentTag?.tag || !releaseCandidateBranch) {
 		throw new Error(
 			`Couldn't resolve needed parameters. currentTag.tag=${currentTag.tag}, releaseCandidateBranch=${releaseCandidateBranch}`,
 		);

--- a/.github/scripts/determine-release-candidate-branch-for-track.mjs
+++ b/.github/scripts/determine-release-candidate-branch-for-track.mjs
@@ -18,7 +18,7 @@ function main() {
 
 	if (!currentTag?.tag || !releaseCandidateBranch) {
 		throw new Error(
-			`Couldn't resolve needed parameters. currentTag.tag=${currentTag.tag}, releaseCandidateBranch=${releaseCandidateBranch}`,
+			`Couldn't resolve needed parameters. currentTag.tag=${currentTag?.tag}, releaseCandidateBranch=${releaseCandidateBranch}`,
 		);
 	}
 

--- a/.github/scripts/github-helpers.mjs
+++ b/.github/scripts/github-helpers.mjs
@@ -91,9 +91,13 @@ export function resolveReleaseTagForTrack(track) {
  *
  * Returns null if the track tag or release tag is missing.
  *
- * @param { typeof RELEASE_TRACKS[number] } track
+ * @param { ReleaseTrack } track
  * */
 export function resolveRcBranchForTrack(track) {
+	if (track === 'v1') {
+		return '1.x';
+	}
+
 	const commit = getCommitForRef(track);
 	if (!commit) return null;
 
@@ -239,6 +243,25 @@ export function listTagsPointingAt(commit) {
 		.split('\n')
 		.map((s) => s.trim())
 		.filter(Boolean);
+}
+
+/**
+ * @param {string} from
+ * @param {string} to
+ */
+export function listCommitsBetweenRefs(from, to) {
+	return sh('git', ['--no-pager', 'log', '--format="- %s (%h)', `${to}..origin/${from}`]);
+}
+
+/**
+ * @param {string} from
+ * @param {string} to
+ */
+export function countCommitsBetweenRefs(from, to) {
+	const output = sh('git', ['rev-list', '--count', `${to}..origin/${from}`]);
+	const count = parseInt(output);
+
+	return isNaN(count) ? 0 : count;
 }
 
 /**

--- a/.github/scripts/github-helpers.mjs
+++ b/.github/scripts/github-helpers.mjs
@@ -68,7 +68,7 @@ export function ensureReleaseTrack(track) {
  *
  * @param { typeof RELEASE_TRACKS[number] } track
  *
- * @returns { TagVersionInfo }
+ * @returns { TagVersionInfo | null }
  * */
 export function resolveReleaseTagForTrack(track) {
 	const commit = getCommitForRef(track);

--- a/.github/workflows/release-create-patch-pr.yml
+++ b/.github/workflows/release-create-patch-pr.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Determine release candidate branch from track
         id: determine-branch
+        env:
+          TRACK: ${{ inputs.track }}
         run: node .github/scripts/determine-release-candidate-branch-for-track.mjs
 
   skip-release-pr:

--- a/.github/workflows/release-create-patch-pr.yml
+++ b/.github/workflows/release-create-patch-pr.yml
@@ -1,0 +1,52 @@
+name: 'Release: Create Patch Release PR'
+
+on:
+  workflow_dispatch:
+    inputs:
+      track:
+        description: 'Release Track'
+        required: true
+        type: choice
+        options: [stable, beta, v1]
+
+jobs:
+  determine-version-info:
+    name: Determine publishing track
+    runs-on: ubuntu-latest
+    outputs:
+      release_candidate_branch: ${{ steps.determine-branch.outputs.release_candidate_branch }}
+      should_update: ${{ steps.determine-branch.outputs.should_update }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-nodejs
+        with:
+          build-command: ''
+          install-command: npm install --prefix=.github/scripts --no-package-lock
+
+      - name: Determine release candidate branch from track
+        id: determine-branch
+        run: node .github/scripts/determine-release-candidate-branch-for-track.mjs
+
+  skip-release-pr:
+    name: Skip release PR (no new commits)
+    needs: [determine-version-info]
+    if: needs.determine-version-info.outputs.should_update != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log skip reason
+        run: echo "No new commits found between the release candidate branch and the current release tag. Skipping PR creation."
+
+  create-release-pr:
+    name: Create release PR
+    needs: [determine-version-info]
+    if: needs.determine-version-info.outputs.should_update == 'true'
+    uses: ./.github/workflows/release-create-pr.yml
+    secrets: inherit
+    with:
+      base-branch: ${{ needs.determine-version-info.outputs.release_candidate_branch }}
+      release-type: patch


### PR DESCRIPTION
## Summary

Allow creating automated patch releases via a single Workflow dispatch call. Might set on schedule later on.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2579

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
