### PR TITLE
ci: Bump korthout/backport-action to enable add_author_as_reviewer

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Backport
         if: steps.targets.outputs.target_branches != ''
-        uses: korthout/backport-action@c656f5d5851037b2b38fb5db2691a03fa229e3b2 # v4.0.1
+        uses: korthout/backport-action@4aaf0e03a94ff0a619c9a511b61aeb42adea5b02 # v4.2.0
         with:
           github_token: ${{ steps.generate-token.outputs.token }}
           source_pr_number: ${{ github.event.pull_request.number || inputs.pull-request-id }}


### PR DESCRIPTION
## Summary

Update [korthout/backport-action](https://github.com/korthout/backport-action) so that we can use `add_author_as_reviewer`. 

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/actions/runs/22901162124/job/66447743275#step:6:1

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
