### PR TITLE
feat: Add connection tests to ChatHub vector store nodes (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/credentials/ChatHubVectorStoreQdrantApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/ChatHubVectorStoreQdrantApi.credentials.ts
@@ -16,7 +16,7 @@ export class ChatHubVectorStoreQdrantApi implements ICredentialType {
 			type: 'string',
 			default: 'n8n_vectors',
 			description:
-				'The Qdrant collection to use. All users share this collection; access is scoped per user via a userId metadata field.',
+				'The Qdrant collection to use. All users share this collection; access is scoped per user via a userId metadata field. The collection is created automatically if it does not exist.',
 		},
 	];
 }

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/ChatHubVectorStorePinecone/ChatHubVectorStorePinecone.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/ChatHubVectorStorePinecone/ChatHubVectorStorePinecone.node.ts
@@ -2,8 +2,11 @@ import type { PineconeStoreParams } from '@langchain/pinecone';
 import { PineconeStore } from '@langchain/pinecone';
 import { Pinecone } from '@pinecone-database/pinecone';
 import type {
+	ICredentialsDecrypted,
+	ICredentialTestFunctions,
 	IDataObject,
 	ILoadOptionsFunctions,
+	INodeCredentialTestResult,
 	INodeProperties,
 	NodeParameterValueType,
 } from 'n8n-workflow';
@@ -38,6 +41,35 @@ const insertFields: INodeProperties[] = [
 		options: [],
 	},
 ];
+
+async function chatHubVectorStorePineconeApiConnectionTest(
+	this: ICredentialTestFunctions,
+	credential: ICredentialsDecrypted,
+): Promise<INodeCredentialTestResult> {
+	const credentials = credential.data as ChatHubVectorStorePineconeApiCredentials;
+
+	try {
+		const client = new Pinecone({ apiKey: credentials.apiKey });
+		const indexes = ((await client.listIndexes()).indexes ?? []).map((i) => i.name);
+
+		if (!indexes.includes(credentials.pineconeIndex)) {
+			return {
+				status: 'Error',
+				message: `Index "${credentials.pineconeIndex}" not found. Please create the index first or check the index name.`,
+			};
+		}
+	} catch (error) {
+		return {
+			status: 'Error',
+			message: error.message as string,
+		};
+	}
+
+	return {
+		status: 'OK',
+		message: 'Connection successful',
+	};
+}
 
 async function deleteDocuments(
 	this: ILoadOptionsFunctions,
@@ -78,12 +110,16 @@ export class ChatHubVectorStorePinecone extends createVectorStoreNode<PineconeSt
 			{
 				name: 'chatHubVectorStorePineconeApi',
 				required: true,
+				testedBy: 'chatHubVectorStorePineconeApiConnectionTest',
 			},
 		],
 		operationModes: ['load', 'insert', 'retrieve', 'retrieve-as-tool'],
 	},
 	hidden: true,
-	methods: { actionHandler: { deleteDocuments } },
+	methods: {
+		credentialTest: { chatHubVectorStorePineconeApiConnectionTest },
+		actionHandler: { deleteDocuments },
+	},
 	sharedFields: [],
 	retrieveFields,
 	loadFields: retrieveFields,

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/ChatHubVectorStoreQdrant/ChatHubVectorStoreQdrant.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/ChatHubVectorStoreQdrant/ChatHubVectorStoreQdrant.node.ts
@@ -2,8 +2,11 @@ import type { QdrantLibArgs } from '@langchain/qdrant';
 import { QdrantVectorStore } from '@langchain/qdrant';
 import {
 	jsonParse,
+	type ICredentialsDecrypted,
+	type ICredentialTestFunctions,
 	type IDataObject,
 	type ILoadOptionsFunctions,
+	type INodeCredentialTestResult,
 	type NodeParameterValueType,
 } from 'n8n-workflow';
 
@@ -34,6 +37,28 @@ async function ensurePayloadIndexes(
 			field_schema: 'keyword',
 		});
 	}
+}
+
+async function chatHubVectorStoreQdrantApiConnectionTest(
+	this: ICredentialTestFunctions,
+	credential: ICredentialsDecrypted,
+): Promise<INodeCredentialTestResult> {
+	const credentials = credential.data as ChatHubVectorStoreQdrantApiCredentials;
+
+	try {
+		const client = createQdrantClient(credentials);
+		await client.getCollections();
+	} catch (error) {
+		return {
+			status: 'Error',
+			message: error.message as string,
+		};
+	}
+
+	return {
+		status: 'OK',
+		message: 'Connection successful',
+	};
 }
 
 async function deleteDocuments(
@@ -80,12 +105,16 @@ export class ChatHubVectorStoreQdrant extends createVectorStoreNode<QdrantVector
 			{
 				name: 'chatHubVectorStoreQdrantApi',
 				required: true,
+				testedBy: 'chatHubVectorStoreQdrantApiConnectionTest',
 			},
 		],
 		operationModes: ['load', 'insert', 'retrieve', 'retrieve-as-tool'],
 	},
 	hidden: true,
-	methods: { actionHandler: { deleteDocuments } },
+	methods: {
+		credentialTest: { chatHubVectorStoreQdrantApiConnectionTest },
+		actionHandler: { deleteDocuments },
+	},
 	sharedFields: [],
 	insertFields: [],
 	loadFields: [],


### PR DESCRIPTION
## Summary

This PR adds connection tests to vector store nodes used in ChatHub semantic search.
- `ChatHubVectorStorePinecone` checks connectivity and the existence of specified index
- `ChatHubVectorStoreQdrant` checks connectivity only. The collection and necessary indexes can be dynamically created through SDK

For `ChatHubVectorStorePGVector` the check is already implemented.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-159/feature-add-missing-connection-test-for-chathub-qdrant-and-pinecone


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
