### PR TITLE
test: Move raw locators from spec files into page objects (no-changelog)

### DIFF
--- a/packages/testing/playwright/pages/AIAssistantPage.ts
+++ b/packages/testing/playwright/pages/AIAssistantPage.ts
@@ -75,6 +75,10 @@ export class AIAssistantPage extends BasePage {
 		return this.page.getByTestId('new-assistant-session-modal');
 	}
 
+	getStartNewSessionButton() {
+		return this.getNewAssistantSessionModal().getByRole('button', { name: 'Start new session' });
+	}
+
 	getCodeDiffs() {
 		return this.page.getByTestId('code-diff-suggestion');
 	}

--- a/packages/testing/playwright/pages/NotificationsPage.ts
+++ b/packages/testing/playwright/pages/NotificationsPage.ts
@@ -137,6 +137,10 @@ export class NotificationsPage {
 		}
 	}
 
+	getModalOverlay(): Locator {
+		return this.page.locator('.el-overlay').first();
+	}
+
 	getErrorNotifications(): Locator {
 		return this.page.locator('.el-notification:has(.el-notification--error)');
 	}

--- a/packages/testing/playwright/pages/components/TagsManagerModal.ts
+++ b/packages/testing/playwright/pages/components/TagsManagerModal.ts
@@ -33,6 +33,10 @@ export class TagsManagerModal extends BasePage {
 		return this.getTable().locator('tbody tr').first();
 	}
 
+	getTagByName(name: string): Locator {
+		return this.getTable().getByText(name);
+	}
+
 	getDeleteTagButton(): Locator {
 		return this.root.getByTestId('delete-tag-button');
 	}

--- a/packages/testing/playwright/tests/e2e/ai/assistant-basic.spec.ts
+++ b/packages/testing/playwright/tests/e2e/ai/assistant-basic.spec.ts
@@ -165,10 +165,7 @@ test.describe('AI Assistant::enabled', () => {
 
 		await expect(n8n.aiAssistant.getNewAssistantSessionModal()).toBeVisible();
 
-		await n8n.aiAssistant
-			.getNewAssistantSessionModal()
-			.getByRole('button', { name: 'Start new session' })
-			.click();
+		await n8n.aiAssistant.getStartNewSessionButton().click();
 
 		await expect(n8n.aiAssistant.getChatMessagesAll()).toHaveCount(1);
 	});

--- a/packages/testing/playwright/tests/e2e/credentials/crud.spec.ts
+++ b/packages/testing/playwright/tests/e2e/credentials/crud.spec.ts
@@ -343,9 +343,8 @@ test.describe(
 			await expect(errorNotification).toBeVisible();
 			await expect(n8n.canvas.credentialModal.getModal()).toBeVisible();
 
-			const modalOverlay = n8n.page.locator('.el-overlay').first();
 			await expect(errorNotification).toHaveCSS('z-index', '2100');
-			await expect(modalOverlay).toHaveCSS('z-index', '2001');
+			await expect(n8n.notifications.getModalOverlay()).toHaveCSS('z-index', '2001');
 		});
 	},
 );

--- a/packages/testing/playwright/tests/e2e/source-control/pull.spec.ts
+++ b/packages/testing/playwright/tests/e2e/source-control/pull.spec.ts
@@ -92,7 +92,7 @@ test.describe(
 			await n8n.canvas.openTagManagerModal();
 			await expect(n8n.canvas.tagsManagerModal.getModal()).toBeVisible();
 			await expect(n8n.canvas.tagsManagerModal.getTable()).toBeVisible();
-			await expect(n8n.canvas.tagsManagerModal.getTable().getByText('pull-test-tag')).toBeVisible();
+			await expect(n8n.canvas.tagsManagerModal.getTagByName('pull-test-tag')).toBeVisible();
 		});
 
 		test('should pull modified and deleted resources from remote', async ({ n8n }) => {


### PR DESCRIPTION
## Summary

Extract selector-purity violations from 3 spec files into their respective page objects:

- **`assistant-basic.spec.ts`** — Chained `.getByRole()` on modal → new `getStartNewSessionButton()` on `AIAssistantPage`
- **`crud.spec.ts`** — Direct `n8n.page.locator('.el-overlay')` → new `getModalOverlay()` on `NotificationsPage`
- **`pull.spec.ts`** — Chained `.getByText()` on table → new `getTagByName()` on `TagsManagerModal`

Identified via `pnpm janitor --rule=selector-purity`. Impact analysis confirms only the 3 spec files are affected.

## Related Linear tickets, Github issues, and Community forum posts

N/A — incremental test architecture cleanup

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)