### PR TITLE
fix: Improve SSRF blocked IP error message

### DIFF
--- a/packages/cli/src/services/ssrf/__tests__/ssrf-protection.service.test.ts
+++ b/packages/cli/src/services/ssrf/__tests__/ssrf-protection.service.test.ts
@@ -278,7 +278,7 @@ describe('SsrfProtectionService', () => {
 			const { service } = createService();
 
 			expect(() => service.validateRedirectSync('http://127.0.0.1/admin')).toThrow(
-				'IP address is blocked',
+				'The request was blocked because it resolves to a restricted IP address',
 			);
 		});
 
@@ -294,7 +294,7 @@ describe('SsrfProtectionService', () => {
 
 			// Redirect target is private (blocked)
 			expect(() => service.validateRedirectSync('http://192.168.1.1/admin')).toThrow(
-				'IP address is blocked',
+				'The request was blocked because it resolves to a restricted IP address',
 			);
 		});
 
@@ -330,7 +330,9 @@ describe('SsrfProtectionService', () => {
 
 			lookup('evil.com', { all: false }, (lookupError) => {
 				expect(lookupError).toBeTruthy();
-				expect(lookupError?.message).toContain('IP address is blocked');
+				expect(lookupError?.message).toContain(
+					'The request was blocked because it resolves to a restricted IP address',
+				);
 				done();
 			});
 		});
@@ -504,7 +506,9 @@ describe('SsrfProtectionService', () => {
 
 				lookup('rebinding.evil.com', { all: false }, (lookupError) => {
 					expect(lookupError).toBeTruthy();
-					expect(lookupError?.message).toContain('IP address is blocked');
+					expect(lookupError?.message).toContain(
+						'The request was blocked because it resolves to a restricted IP address',
+					);
 					done();
 				});
 			});
@@ -515,7 +519,7 @@ describe('SsrfProtectionService', () => {
 				const { service } = createService();
 
 				expect(() => service.validateRedirectSync('http://10.0.0.1/internal')).toThrow(
-					'IP address is blocked',
+					'The request was blocked because it resolves to a restricted IP address',
 				);
 			});
 
@@ -523,7 +527,7 @@ describe('SsrfProtectionService', () => {
 				const { service } = createService();
 
 				expect(() => service.validateRedirectSync('http://[::1]/admin')).toThrow(
-					'IP address is blocked',
+					'The request was blocked because it resolves to a restricted IP address',
 				);
 			});
 		});

--- a/packages/cli/src/services/ssrf/ssrf-blocked-ip.error.ts
+++ b/packages/cli/src/services/ssrf/ssrf-blocked-ip.error.ts
@@ -8,7 +8,13 @@ export class SsrfBlockedIpError extends UserError {
 	readonly hostname?: string;
 
 	constructor(ip: string, hostname?: string) {
-		super('IP address is blocked', {
+		const target = hostname ? `'${hostname}' (${ip})` : ip;
+		super('The request was blocked because it resolves to a restricted IP address', {
+			description:
+				`The target ${target} is not allowed. ` +
+				'This is a security measure to prevent Server-Side Request Forgery (SSRF). ' +
+				'If you need to access internal resources, ask your n8n administrator to allowlist ' +
+				'the hostname or IP range in the environment configuration.',
 			extra: { ip, hostname },
 		});
 

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/ssrf-integration.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/ssrf-integration.test.ts
@@ -113,7 +113,7 @@ describe('SSRF end-to-end integration', () => {
 
 		await expect(
 			helpers.httpRequest({ method: 'GET', url: 'http://public.example/redirect' }),
-		).rejects.toThrow('IP address is blocked');
+		).rejects.toThrow('The request was blocked because it resolves to a restricted IP address');
 	});
 
 	test('allows allowlisted hostname even when it resolves to private IP', async () => {


### PR DESCRIPTION
## Summary

Improve the SSRF blocked-IP error text to be clearer for users and add a descriptive explanation with remediation guidance.
Update SSRF unit and integration tests to assert the new message.

Before:
<img width="592" height="306" alt="image" src="https://github.com/user-attachments/assets/b2e04c17-477a-4c58-bc74-630b688d10a9" />

After:
<img width="1045" height="286" alt="image" src="https://github.com/user-attachments/assets/3636f177-09c4-4a81-bdf4-845c5c062337" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2573

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)