### PR TITLE
fix: MCP - Resolve webhook id during workflow creation and update

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/utils/node-creation.utils.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/utils/node-creation.utils.ts
@@ -1,5 +1,6 @@
 import {
 	assert,
+	resolveNodeWebhook,
 	type INode,
 	type INodeTypeDescription,
 	type NodeParameterValueType,
@@ -55,23 +56,6 @@ export function generateNodeId(): string {
 }
 
 /**
- * Generate a webhook ID for nodes that require it
- * @returns A unique webhook identifier
- */
-export function generateWebhookId(): string {
-	return crypto.randomUUID();
-}
-
-/**
- * Check if a node type requires a webhook
- * @param nodeType - The node type description
- * @returns True if the node requires a webhook
- */
-export function requiresWebhook(nodeType: INodeTypeDescription): boolean {
-	return !!(nodeType.webhooks && nodeType.webhooks.length > 0);
-}
-
-/**
  * Create a new node instance with all required properties
  * @param nodeType - The node type description
  * @param typeVersion - The node type version - nodeType can have multiple versions
@@ -108,9 +92,7 @@ export function createNodeInstance(
 	};
 
 	// Add webhook ID if required
-	if (requiresWebhook(nodeType)) {
-		node.webhookId = generateWebhookId();
-	}
+	resolveNodeWebhook(node, nodeType);
 
 	return node;
 }

--- a/packages/@n8n/ai-workflow-builder.ee/src/tools/utils/node-creation.utils.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/tools/utils/node-creation.utils.ts
@@ -1,6 +1,6 @@
 import {
 	assert,
-	resolveNodeWebhook,
+	resolveNodeWebhookId,
 	type INode,
 	type INodeTypeDescription,
 	type NodeParameterValueType,
@@ -92,7 +92,7 @@ export function createNodeInstance(
 	};
 
 	// Add webhook ID if required
-	resolveNodeWebhook(node, nodeType);
+	resolveNodeWebhookId(node, nodeType);
 
 	return node;
 }

--- a/packages/cli/src/modules/mcp/__tests__/create-workflow-from-code.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/create-workflow-from-code.tool.test.ts
@@ -69,6 +69,7 @@ describe('create-workflow-from-code MCP tool', () => {
 	let createWorkflowMock: jest.Mock;
 	let urlService: UrlService;
 	let telemetry: Telemetry;
+	let nodeTypes: ReturnType<typeof mockInstance<NodeTypes>>;
 
 	beforeEach(() => {
 		jest.clearAllMocks();
@@ -87,12 +88,12 @@ describe('create-workflow-from-code MCP tool', () => {
 		telemetry = mockInstance(Telemetry, {
 			track: jest.fn(),
 		});
+		nodeTypes = mockInstance(NodeTypes);
 
 		mockParseAndValidate.mockResolvedValue({ workflow: mockWorkflowJson });
 		mockStripImportStatements.mockImplementation((code: string) => code);
 	});
 
-	const nodeTypes = mockInstance(NodeTypes);
 	const credentialsService = mockInstance(CredentialsService, {
 		getCredentialsAUserCanUseInAWorkflow: jest.fn().mockResolvedValue([]),
 	});

--- a/packages/cli/src/modules/mcp/__tests__/create-workflow-from-code.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/create-workflow-from-code.tool.test.ts
@@ -276,6 +276,27 @@ describe('create-workflow-from-code MCP tool', () => {
 			);
 		});
 
+		test('assigns webhookId to webhook nodes before saving', async () => {
+			nodeTypes.getByNameAndVersion.mockImplementation(((type: string) => {
+				if (type === 'n8n-nodes-base.webhook') {
+					return { description: { webhooks: [{ httpMethod: 'GET', path: '' }] } };
+				}
+				return { description: {} };
+			}) as typeof nodeTypes.getByNameAndVersion);
+
+			await callHandler({ code: 'const wf = ...' });
+
+			const savedWorkflow = createWorkflowMock.mock.calls[0][1] as WorkflowEntity;
+			const webhookNode = savedWorkflow.nodes.find(
+				(n: INode) => n.type === 'n8n-nodes-base.webhook',
+			);
+			const setNode = savedWorkflow.nodes.find((n: INode) => n.type === 'n8n-nodes-base.set');
+
+			expect(webhookNode!.webhookId).toBeDefined();
+			expect(typeof webhookNode!.webhookId).toBe('string');
+			expect(setNode!.webhookId).toBeUndefined();
+		});
+
 		test('tracks telemetry on failure', async () => {
 			mockParseAndValidate.mockRejectedValue(new Error('Parse failed'));
 

--- a/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
@@ -75,6 +75,8 @@ const mockWorkflowJson = {
 const parseResult = (result: { content: Array<{ type: string; text?: string }> }) =>
 	JSON.parse((result.content[0] as { type: 'text'; text: string }).text) as Record<string, unknown>;
 
+const nodeTypes = mockInstance(NodeTypes);
+
 describe('update-workflow MCP tool', () => {
 	const user = Object.assign(new User(), { id: 'user-1' });
 	let workflowFinderService: WorkflowFinderService;
@@ -83,7 +85,6 @@ describe('update-workflow MCP tool', () => {
 	let updateMock: jest.Mock;
 	let urlService: UrlService;
 	let telemetry: Telemetry;
-	let nodeTypes: NodeTypes;
 	let credentialsService: CredentialsService;
 	let sharedWorkflowRepository: SharedWorkflowRepository;
 
@@ -114,7 +115,6 @@ describe('update-workflow MCP tool', () => {
 		telemetry = mockInstance(Telemetry, {
 			track: jest.fn(),
 		});
-		nodeTypes = mockInstance(NodeTypes);
 		credentialsService = mockInstance(CredentialsService);
 		sharedWorkflowRepository = mockInstance(SharedWorkflowRepository, {
 			findOneOrFail: jest.fn().mockResolvedValue({ projectId: 'project-1' }),
@@ -285,6 +285,27 @@ describe('update-workflow MCP tool', () => {
 					}),
 				}),
 			);
+		});
+
+		test('assigns webhookId to webhook nodes before saving', async () => {
+			nodeTypes.getByNameAndVersion.mockImplementation(((type: string) => {
+				if (type === 'n8n-nodes-base.webhook') {
+					return { description: { webhooks: [{ httpMethod: 'GET', path: '' }] } };
+				}
+				return { description: {} };
+			}) as typeof nodeTypes.getByNameAndVersion);
+
+			await callHandler({ workflowId: 'wf-1', code: 'const wf = ...' });
+
+			const savedWorkflow = updateMock.mock.calls[0][1] as WorkflowEntity;
+			const webhookNode = savedWorkflow.nodes.find(
+				(n: INode) => n.type === 'n8n-nodes-base.webhook',
+			);
+			const setNode = savedWorkflow.nodes.find((n: INode) => n.type === 'n8n-nodes-base.set');
+
+			expect(webhookNode!.webhookId).toBeDefined();
+			expect(typeof webhookNode!.webhookId).toBe('string');
+			expect(setNode!.webhookId).toBeUndefined();
 		});
 
 		test('tracks telemetry on failure', async () => {

--- a/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
@@ -75,8 +75,6 @@ const mockWorkflowJson = {
 const parseResult = (result: { content: Array<{ type: string; text?: string }> }) =>
 	JSON.parse((result.content[0] as { type: 'text'; text: string }).text) as Record<string, unknown>;
 
-const nodeTypes = mockInstance(NodeTypes);
-
 describe('update-workflow MCP tool', () => {
 	const user = Object.assign(new User(), { id: 'user-1' });
 	let workflowFinderService: WorkflowFinderService;
@@ -87,6 +85,7 @@ describe('update-workflow MCP tool', () => {
 	let telemetry: Telemetry;
 	let credentialsService: CredentialsService;
 	let sharedWorkflowRepository: SharedWorkflowRepository;
+	let nodeTypes: ReturnType<typeof mockInstance<NodeTypes>>;
 
 	const mockExistingWorkflow = Object.assign(new WorkflowEntity(), {
 		id: 'wf-1',
@@ -119,6 +118,7 @@ describe('update-workflow MCP tool', () => {
 		sharedWorkflowRepository = mockInstance(SharedWorkflowRepository, {
 			findOneOrFail: jest.fn().mockResolvedValue({ projectId: 'project-1' }),
 		});
+		nodeTypes = mockInstance(NodeTypes);
 
 		mockParseAndValidate.mockResolvedValue({ workflow: mockWorkflowJson });
 		mockStripImportStatements.mockImplementation((code: string) => code);

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
@@ -1,5 +1,5 @@
 import { type User, type ProjectRepository, WorkflowEntity } from '@n8n/db';
-import { resolveNodeWebhook } from 'n8n-workflow';
+import { resolveNodeWebhookId } from 'n8n-workflow';
 import z from 'zod';
 
 import { MCP_CREATE_WORKFLOW_FROM_CODE_TOOL, CODE_BUILDER_VALIDATE_TOOL } from './constants';
@@ -127,7 +127,7 @@ export const createCreateWorkflowFromCodeTool = (
 			for (const node of newWorkflow.nodes) {
 				try {
 					const desc = nodeTypes.getByNameAndVersion(node.type, node.typeVersion);
-					resolveNodeWebhook(node, desc.description);
+					resolveNodeWebhookId(node, desc.description);
 				} catch {
 					// Node type not found, skip
 				}

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
@@ -1,4 +1,5 @@
 import { type User, type ProjectRepository, WorkflowEntity } from '@n8n/db';
+import { resolveNodeWebhook } from 'n8n-workflow';
 import z from 'zod';
 
 import { MCP_CREATE_WORKFLOW_FROM_CODE_TOOL, CODE_BUILDER_VALIDATE_TOOL } from './constants';
@@ -122,6 +123,15 @@ export const createCreateWorkflowFromCodeTool = (
 				pinData: workflowJson.pinData,
 				meta: { ...workflowJson.meta, aiBuilderAssisted: true },
 			});
+
+			for (const node of newWorkflow.nodes) {
+				try {
+					const desc = nodeTypes.getByNameAndVersion(node.type, node.typeVersion);
+					resolveNodeWebhook(node, desc.description);
+				} catch {
+					// Node type not found, skip
+				}
+			}
 
 			// Resolve the effective project ID — default to the user's personal project
 			let effectiveProjectId = projectId;

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
@@ -1,4 +1,5 @@
 import { type User, type SharedWorkflowRepository, WorkflowEntity } from '@n8n/db';
+import { resolveNodeWebhook } from 'n8n-workflow';
 import z from 'zod';
 
 import { USER_CALLED_MCP_TOOL_EVENT } from '../../mcp.constants';
@@ -124,6 +125,15 @@ export const createUpdateWorkflowTool = (
 				pinData: workflowJson.pinData,
 				meta: { ...workflowJson.meta, aiBuilderAssisted: true },
 			});
+
+			for (const node of workflowUpdateData.nodes) {
+				try {
+					const desc = nodeTypes.getByNameAndVersion(node.type, node.typeVersion);
+					resolveNodeWebhook(node, desc.description);
+				} catch {
+					// Node type not found, skip
+				}
+			}
 
 			// Resolve the project ID from the workflow's owner relationship
 			const sharedWorkflow = await sharedWorkflowRepository.findOneOrFail({

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
@@ -1,5 +1,5 @@
 import { type User, type SharedWorkflowRepository, WorkflowEntity } from '@n8n/db';
-import { resolveNodeWebhook } from 'n8n-workflow';
+import { resolveNodeWebhookId } from 'n8n-workflow';
 import z from 'zod';
 
 import { USER_CALLED_MCP_TOOL_EVENT } from '../../mcp.constants';
@@ -129,7 +129,7 @@ export const createUpdateWorkflowTool = (
 			for (const node of workflowUpdateData.nodes) {
 				try {
 					const desc = nodeTypes.getByNameAndVersion(node.type, node.typeVersion);
-					resolveNodeWebhook(node, desc.description);
+					resolveNodeWebhookId(node, desc.description);
 				} catch {
 					// Node type not found, skip
 				}

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -112,7 +112,7 @@ import {
 	TelemetryHelpers,
 	isCommunityPackageName,
 	isHitlToolType,
-	resolveNodeWebhook as resolveNodeWebhookId,
+	resolveNodeWebhookId,
 } from 'n8n-workflow';
 import { computed, nextTick, ref, type DeepReadonly } from 'vue';
 import { useUniqueNodeName } from '@/app/composables/useUniqueNodeName';

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -112,6 +112,7 @@ import {
 	TelemetryHelpers,
 	isCommunityPackageName,
 	isHitlToolType,
+	resolveNodeWebhook as resolveNodeWebhookId,
 } from 'n8n-workflow';
 import { computed, nextTick, ref, type DeepReadonly } from 'vue';
 import { useUniqueNodeName } from '@/app/composables/useUniqueNodeName';
@@ -1472,9 +1473,7 @@ export function useCanvasOperations() {
 	}
 
 	function resolveNodeWebhook(node: INodeUi, nodeTypeDescription: INodeTypeDescription) {
-		if (nodeTypeDescription.webhooks?.length && !node.webhookId) {
-			nodeHelpers.assignWebhookId(node);
-		}
+		resolveNodeWebhookId(node, nodeTypeDescription);
 
 		// if it's a webhook and the path is empty set the UUID as the default path
 		if (

--- a/packages/workflow/src/node-helpers.ts
+++ b/packages/workflow/src/node-helpers.ts
@@ -5,6 +5,7 @@
 import { ApplicationError } from '@n8n/errors';
 import get from 'lodash/get';
 import isEqual from 'lodash/isEqual';
+import { v4 as uuid } from 'uuid';
 
 import { EXECUTE_WORKFLOW_NODE_TYPE, WORKFLOW_TOOL_LANGCHAIN_NODE_TYPE } from './constants';
 import { isExpression } from './expressions/expression-helpers';
@@ -1099,6 +1100,19 @@ export function getNodeWebhookUrl(
 		path = path.slice(1);
 	}
 	return `${baseUrl}/${getNodeWebhookPath(workflowId, node, path, isFullPath)}`;
+}
+
+/**
+ * Assigns a webhookId to a node if its type has webhook definitions
+ * and the node doesn't already have one.
+ */
+export function resolveNodeWebhook(
+	node: Pick<INode, 'webhookId'>,
+	nodeTypeDescription: Pick<INodeTypeDescription, 'webhooks'>,
+): void {
+	if (nodeTypeDescription.webhooks?.length && !node.webhookId) {
+		node.webhookId = uuid();
+	}
 }
 
 export function getConnectionTypes(

--- a/packages/workflow/src/node-helpers.ts
+++ b/packages/workflow/src/node-helpers.ts
@@ -1106,7 +1106,7 @@ export function getNodeWebhookUrl(
  * Assigns a webhookId to a node if its type has webhook definitions
  * and the node doesn't already have one.
  */
-export function resolveNodeWebhook(
+export function resolveNodeWebhookId(
 	node: Pick<INode, 'webhookId'>,
 	nodeTypeDescription: Pick<INodeTypeDescription, 'webhooks'>,
 ): void {

--- a/packages/workflow/test/resolve-node-webhook-id.test.ts
+++ b/packages/workflow/test/resolve-node-webhook-id.test.ts
@@ -1,7 +1,7 @@
 import type { INode, INodeTypeDescription } from '../src/interfaces';
-import { resolveNodeWebhook } from '../src/node-helpers';
+import { resolveNodeWebhookId } from '../src/node-helpers';
 
-describe('resolveNodeWebhook', () => {
+describe('resolveNodeWebhookId', () => {
 	const makeNode = (webhookId?: string): Pick<INode, 'webhookId'> => ({ webhookId });
 
 	const withWebhooks: Pick<INodeTypeDescription, 'webhooks'> = {
@@ -15,7 +15,7 @@ describe('resolveNodeWebhook', () => {
 	test('assigns webhookId when webhooks is non-empty and node has no webhookId', () => {
 		const node = makeNode();
 
-		resolveNodeWebhook(node, withWebhooks);
+		resolveNodeWebhookId(node, withWebhooks);
 
 		expect(node.webhookId).toBeDefined();
 		expect(typeof node.webhookId).toBe('string');
@@ -24,7 +24,7 @@ describe('resolveNodeWebhook', () => {
 	test('does not assign webhookId when webhooks is undefined', () => {
 		const node = makeNode();
 
-		resolveNodeWebhook(node, withoutWebhooks);
+		resolveNodeWebhookId(node, withoutWebhooks);
 
 		expect(node.webhookId).toBeUndefined();
 	});
@@ -32,7 +32,7 @@ describe('resolveNodeWebhook', () => {
 	test('does not assign webhookId when webhooks is empty', () => {
 		const node = makeNode();
 
-		resolveNodeWebhook(node, { webhooks: [] });
+		resolveNodeWebhookId(node, { webhooks: [] });
 
 		expect(node.webhookId).toBeUndefined();
 	});
@@ -40,7 +40,7 @@ describe('resolveNodeWebhook', () => {
 	test('preserves existing webhookId', () => {
 		const node = makeNode('existing-id');
 
-		resolveNodeWebhook(node, withWebhooks);
+		resolveNodeWebhookId(node, withWebhooks);
 
 		expect(node.webhookId).toBe('existing-id');
 	});

--- a/packages/workflow/test/resolve-node-webhook.test.ts
+++ b/packages/workflow/test/resolve-node-webhook.test.ts
@@ -1,0 +1,47 @@
+import type { INode, INodeTypeDescription } from '../src/interfaces';
+import { resolveNodeWebhook } from '../src/node-helpers';
+
+describe('resolveNodeWebhook', () => {
+	const makeNode = (webhookId?: string): Pick<INode, 'webhookId'> => ({ webhookId });
+
+	const withWebhooks: Pick<INodeTypeDescription, 'webhooks'> = {
+		webhooks: [{ httpMethod: 'GET', path: '', name: 'default', isFullPath: false }],
+	};
+
+	const withoutWebhooks: Pick<INodeTypeDescription, 'webhooks'> = {
+		webhooks: undefined,
+	};
+
+	test('assigns webhookId when webhooks is non-empty and node has no webhookId', () => {
+		const node = makeNode();
+
+		resolveNodeWebhook(node, withWebhooks);
+
+		expect(node.webhookId).toBeDefined();
+		expect(typeof node.webhookId).toBe('string');
+	});
+
+	test('does not assign webhookId when webhooks is undefined', () => {
+		const node = makeNode();
+
+		resolveNodeWebhook(node, withoutWebhooks);
+
+		expect(node.webhookId).toBeUndefined();
+	});
+
+	test('does not assign webhookId when webhooks is empty', () => {
+		const node = makeNode();
+
+		resolveNodeWebhook(node, { webhooks: [] });
+
+		expect(node.webhookId).toBeUndefined();
+	});
+
+	test('preserves existing webhookId', () => {
+		const node = makeNode('existing-id');
+
+		resolveNodeWebhook(node, withWebhooks);
+
+		expect(node.webhookId).toBe('existing-id');
+	});
+});


### PR DESCRIPTION
## Summary

When workflows are created or updated via MCP tools, webhook nodes are missing `webhookId`. Without it, webhook registration falls back to a path built from `{workflowId}/{nodeName}/{path}`. Moreover, this fallback is unreachable for the default webhook trigger node name because `encodeURIComponent` produces `%20` for spaces in node names, but Express decodes the URL to a literal space, so they never match. As a result, webhooks created or edited through MCP were permanently 404.

This PR introduces a shared `resolveNodeWebhookId` utility and uses it in both MCP tools. It also refactors the frontend and AI workflow builder, which previously implemented similar logic, to use this utility and eliminate code duplication.

### How to test

Ask MCP client to create a workflow with a GET webhook trigger and to publish it. Check that production URL is not returning 404 anymore.

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-4932](https://linear.app/n8n/issue/ADO-4932/bug-mcp-workflow-create-and-update-webhook-id-is-not-set)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
