### PR TITLE
refactor(editor): Migrate app components to workflowDocumentStore (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/ChatEmbedModal.vue
+++ b/packages/frontend/editor-ui/src/app/components/ChatEmbedModal.vue
@@ -6,6 +6,10 @@ import Modal from './Modal.vue';
 import { CHAT_EMBED_MODAL_KEY, CHAT_TRIGGER_NODE_TYPE, WEBHOOK_NODE_TYPE } from '../constants';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import HtmlEditor from '@/features/shared/editors/components/HtmlEditor/HtmlEditor.vue';
 import JsEditor from '@/features/shared/editors/components/JsEditor/JsEditor.vue';
 import { useI18n } from '@n8n/i18n';
@@ -24,6 +28,11 @@ const props = withDefaults(
 const i18n = useI18n();
 const rootStore = useRootStore();
 const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = computed(() =>
+	workflowsStore.workflowId
+		? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+		: undefined,
+);
 
 type ChatEmbedModalTabValue = 'cdn' | 'vue' | 'react' | 'other';
 type ChatEmbedModalTab = {
@@ -52,7 +61,7 @@ const currentTab = ref<ChatEmbedModalTabValue>('cdn');
 
 const webhookNode = computed(() => {
 	for (const type of [CHAT_TRIGGER_NODE_TYPE, WEBHOOK_NODE_TYPE]) {
-		const node = workflowsStore.workflow.nodes.find((node) => node.type === type);
+		const node = (workflowDocumentStore.value?.allNodes ?? []).find((node) => node.type === type);
 		if (node) {
 			// This has to be kept up-to-date with the mode in the Chat-Trigger node
 			if (type === CHAT_TRIGGER_NODE_TYPE && !node.parameters.public) {

--- a/packages/frontend/editor-ui/src/app/components/FocusPanel.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/FocusPanel.test.ts
@@ -6,11 +6,16 @@ import { SET_NODE_TYPE } from '@/app/constants';
 import { useFocusPanelStore } from '@/app/stores/focusPanel.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	injectWorkflowDocumentStore,
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { createTestingPinia } from '@pinia/testing';
 import { useVueFlow } from '@vue-flow/core';
 import type { INodeProperties } from 'n8n-workflow';
 import { setActivePinia } from 'pinia';
-import { reactive, computed } from 'vue';
+import { reactive, computed, shallowRef } from 'vue';
 import { WorkflowIdKey } from '@/app/constants/injectionKeys';
 import { useExperimentalNdvStore } from '@/features/workflows/canvas/experimental/experimentalNdv.store';
 import FocusPanel from './FocusPanel.vue';
@@ -19,6 +24,11 @@ vi.mock('vue-router', () => ({
 	useRouter: () => ({}),
 	useRoute: () => reactive({}),
 	RouterLink: vi.fn(),
+}));
+
+vi.mock('@/app/stores/workflowDocument.store', async (importOriginal) => ({
+	...(await importOriginal()),
+	injectWorkflowDocumentStore: vi.fn(),
 }));
 
 describe('FocusPanel', () => {
@@ -54,6 +64,11 @@ describe('FocusPanel', () => {
 	let focusPanelStore: ReturnType<typeof useFocusPanelStore>;
 	let nodeTypesStore: ReturnType<typeof useNodeTypesStore>;
 	let workflowsStore: ReturnType<typeof useWorkflowsStore>;
+	let workflowDocumentStore: ReturnType<typeof useWorkflowDocumentStore>;
+
+	const testNodes = [
+		createTestNode({ id: 'n0', name: 'N0', parameters: { p0: 'v0' }, type: SET_NODE_TYPE }),
+	];
 
 	beforeEach(() => {
 		const pinia = setActivePinia(createTestingPinia({ stubActions: false }));
@@ -69,9 +84,11 @@ describe('FocusPanel', () => {
 		]);
 		workflowsStore = useWorkflowsStore(pinia);
 		workflowsStore.setWorkflow(createTestWorkflow({ id: 'w0' }));
-		workflowsStore.setNodes([
-			createTestNode({ id: 'n0', name: 'N0', parameters: { p0: 'v0' }, type: SET_NODE_TYPE }),
-		]);
+
+		workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId('w0'));
+		workflowDocumentStore.setNodes(testNodes);
+		vi.mocked(injectWorkflowDocumentStore).mockReturnValue(shallowRef(workflowDocumentStore));
+
 		focusPanelStore = useFocusPanelStore(pinia);
 		focusPanelStore.toggleFocusPanel();
 	});

--- a/packages/frontend/editor-ui/src/app/components/FocusPanel.vue
+++ b/packages/frontend/editor-ui/src/app/components/FocusPanel.vue
@@ -39,6 +39,7 @@ import { useTelemetry } from '@/app/composables/useTelemetry';
 import { computedAsync } from '@vueuse/core';
 import { useExecutionData } from '@/features/execution/executions/composables/useExecutionData';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import ExperimentalNodeDetailsDrawer from '@/features/workflows/canvas/experimental/components/ExperimentalNodeDetailsDrawer.vue';
 import { useExperimentalNdvStore } from '@/features/workflows/canvas/experimental/experimentalNdv.store';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
@@ -72,6 +73,7 @@ const nodeHelpers = useNodeHelpers();
 const focusPanelStore = useFocusPanelStore();
 const workflowId = useInjectWorkflowId();
 const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const workflowState = injectWorkflowState();
 const nodeTypesStore = useNodeTypesStore();
 const telemetry = useTelemetry();
@@ -130,7 +132,7 @@ const node = computed<INodeUi | undefined>(() => {
 	const selected: CanvasNode | undefined = vueFlow.getSelectedNodes.value[0];
 
 	return selected?.data?.render.type === CanvasNodeRenderType.Default
-		? workflowsStore.allNodes.find((n) => n.id === selected.id)
+		? (workflowDocumentStore?.value?.allNodes ?? []).find((n) => n.id === selected.id)
 		: undefined;
 });
 const multipleNodesSelected = computed(() => vueFlow.getSelectedNodes.value.length > 1);

--- a/packages/frontend/editor-ui/src/app/components/FocusSidebar.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/FocusSidebar.test.ts
@@ -6,11 +6,16 @@ import { SET_NODE_TYPE } from '@/app/constants';
 import { useFocusPanelStore } from '@/app/stores/focusPanel.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	injectWorkflowDocumentStore,
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { createTestingPinia } from '@pinia/testing';
 import { useVueFlow } from '@vue-flow/core';
 import type { INodeProperties } from 'n8n-workflow';
 import { setActivePinia } from 'pinia';
-import { reactive, computed } from 'vue';
+import { reactive, computed, shallowRef } from 'vue';
 import { WorkflowIdKey } from '@/app/constants/injectionKeys';
 import { useExperimentalNdvStore } from '@/features/workflows/canvas/experimental/experimentalNdv.store';
 import { useSetupPanelStore } from '@/features/setupPanel/setupPanel.store';
@@ -20,6 +25,11 @@ vi.mock('vue-router', () => ({
 	useRouter: () => ({}),
 	useRoute: () => reactive({}),
 	RouterLink: vi.fn(),
+}));
+
+vi.mock('@/app/stores/workflowDocument.store', async (importOriginal) => ({
+	...(await importOriginal()),
+	injectWorkflowDocumentStore: vi.fn(),
 }));
 
 describe('FocusSidebar', () => {
@@ -55,7 +65,12 @@ describe('FocusSidebar', () => {
 	let focusPanelStore: ReturnType<typeof useFocusPanelStore>;
 	let nodeTypesStore: ReturnType<typeof useNodeTypesStore>;
 	let workflowsStore: ReturnType<typeof useWorkflowsStore>;
+	let workflowDocumentStore: ReturnType<typeof useWorkflowDocumentStore>;
 	let setupPanelStore: ReturnType<typeof mockedStore<typeof useSetupPanelStore>>;
+
+	const testNodes = [
+		createTestNode({ id: 'n0', name: 'N0', parameters: { p0: 'v0' }, type: SET_NODE_TYPE }),
+	];
 
 	beforeEach(() => {
 		const pinia = setActivePinia(createTestingPinia({ stubActions: false }));
@@ -71,9 +86,11 @@ describe('FocusSidebar', () => {
 		]);
 		workflowsStore = useWorkflowsStore(pinia);
 		workflowsStore.setWorkflow(createTestWorkflow({ id: 'w0' }));
-		workflowsStore.setNodes([
-			createTestNode({ id: 'n0', name: 'N0', parameters: { p0: 'v0' }, type: SET_NODE_TYPE }),
-		]);
+
+		workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId('w0'));
+		workflowDocumentStore.setNodes(testNodes);
+		vi.mocked(injectWorkflowDocumentStore).mockReturnValue(shallowRef(workflowDocumentStore));
+
 		focusPanelStore = useFocusPanelStore(pinia);
 		focusPanelStore.toggleFocusPanel();
 

--- a/packages/frontend/editor-ui/src/app/components/FocusSidebar.vue
+++ b/packages/frontend/editor-ui/src/app/components/FocusSidebar.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { useFocusPanelStore } from '@/app/stores/focusPanel.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useExperimentalNdvStore } from '@/features/workflows/canvas/experimental/experimentalNdv.store';
 import { useSetupPanelStore } from '@/features/setupPanel/setupPanel.store';
@@ -34,7 +33,6 @@ const wrapperRef = useTemplateRef('wrapper');
 
 const workflowId = useInjectWorkflowId();
 const focusPanelStore = useFocusPanelStore();
-const workflowsStore = useWorkflowsStore();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 const experimentalNdvStore = useExperimentalNdvStore();
 const setupPanelStore = useSetupPanelStore();

--- a/packages/frontend/editor-ui/src/app/components/FocusSidebar.vue
+++ b/packages/frontend/editor-ui/src/app/components/FocusSidebar.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useFocusPanelStore } from '@/app/stores/focusPanel.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useExperimentalNdvStore } from '@/features/workflows/canvas/experimental/experimentalNdv.store';
 import { useSetupPanelStore } from '@/features/setupPanel/setupPanel.store';
 import { useInjectWorkflowId } from '@/app/composables/useInjectWorkflowId';
@@ -34,6 +35,7 @@ const wrapperRef = useTemplateRef('wrapper');
 const workflowId = useInjectWorkflowId();
 const focusPanelStore = useFocusPanelStore();
 const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const experimentalNdvStore = useExperimentalNdvStore();
 const setupPanelStore = useSetupPanelStore();
 const telemetry = useTelemetry();
@@ -62,7 +64,7 @@ const node = computed<INodeUi | undefined>(() => {
 	const selected: CanvasNode | undefined = vueFlow.getSelectedNodes.value[0];
 
 	return selected?.data?.render.type === CanvasNodeRenderType.Default
-		? workflowsStore.allNodes.find((n) => n.id === selected.id)
+		? (workflowDocumentStore?.value?.allNodes ?? []).find((n) => n.id === selected.id)
 		: undefined;
 });
 

--- a/packages/frontend/editor-ui/src/app/components/FromAiParametersModal.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/FromAiParametersModal.test.ts
@@ -4,7 +4,6 @@ import FromAiParametersModal from '@/app/components/FromAiParametersModal.vue';
 import { FROM_AI_PARAMETERS_MODAL_KEY, AI_MCP_TOOL_NODE_TYPE } from '@/app/constants';
 import { STORES } from '@n8n/stores';
 import userEvent from '@testing-library/user-event';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useAgentRequestStore } from '@n8n/stores/useAgentRequestStore';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { useRouter } from 'vue-router';
@@ -15,6 +14,17 @@ import { nextTick } from 'vue';
 import { mock } from 'vitest-mock-extended';
 import { createTestWorkflow } from '@/__tests__/mocks';
 import { type MockedStore, mockedStore } from '@/__tests__/utils';
+
+const { mockWorkflowDocumentStore } = vi.hoisted(() => ({
+	mockWorkflowDocumentStore: {
+		getNodeByName: vi.fn(),
+	},
+}));
+
+vi.mock('@/app/stores/workflowDocument.store', () => ({
+	useWorkflowDocumentStore: vi.fn().mockReturnValue(mockWorkflowDocumentStore),
+	createWorkflowDocumentId: vi.fn().mockReturnValue('test-id'),
+}));
 
 const ModalStub = {
 	template: `
@@ -98,7 +108,6 @@ const mockTools = [
 
 const renderModal = createComponentRenderer(FromAiParametersModal);
 let pinia: ReturnType<typeof createTestingPinia>;
-let workflowsStore: ReturnType<typeof useWorkflowsStore>;
 let agentRequestStore: ReturnType<typeof useAgentRequestStore>;
 let nodeTypesStore: ReturnType<typeof useNodeTypesStore>;
 let projectsStore: MockedStore<typeof useProjectsStore>;
@@ -125,8 +134,7 @@ describe('FromAiParametersModal', () => {
 				},
 			},
 		});
-		workflowsStore = useWorkflowsStore();
-		workflowsStore.getNodeByName = vi.fn().mockImplementation((name: string) => {
+		mockWorkflowDocumentStore.getNodeByName.mockImplementation((name: string) => {
 			switch (name) {
 				case 'Test Node':
 					return mockNode;

--- a/packages/frontend/editor-ui/src/app/components/FromAiParametersModal.vue
+++ b/packages/frontend/editor-ui/src/app/components/FromAiParametersModal.vue
@@ -4,6 +4,10 @@ import { useRunWorkflow } from '@/app/composables/useRunWorkflow';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { FROM_AI_PARAMETERS_MODAL_KEY } from '@/app/constants';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import type { FormFieldValueUpdate } from '@n8n/design-system';
 import { N8nButton, N8nCallout, N8nFormInputs, N8nText } from '@n8n/design-system';
@@ -37,19 +41,24 @@ const telemetry = useTelemetry();
 const ndvStore = useNDVStore();
 const modalBus = createEventBus();
 const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = computed(() =>
+	workflowsStore.workflowId
+		? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+		: undefined,
+);
 const router = useRouter();
 const { runWorkflow } = useRunWorkflow({ router });
 const agentRequestStore = useAgentRequestStore();
 
 const node = computed(() =>
-	props.data.nodeName ? workflowsStore.getNodeByName(props.data.nodeName) : undefined,
+	props.data.nodeName ? workflowDocumentStore.value?.getNodeByName(props.data.nodeName) : undefined,
 );
 
 const parentNode = computed(() => {
 	if (!node.value) return undefined;
 	const parentNodes = workflowsStore.workflowObject.getChildNodes(node.value.name, 'ALL', 1);
 	if (parentNodes.length === 0) return undefined;
-	return workflowsStore.getNodeByName(parentNodes[0])?.name;
+	return workflowDocumentStore.value?.getNodeByName(parentNodes[0])?.name;
 });
 
 const { getToolName, parameters, error, updateSelectedTool } = useToolParameters({ node });

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowPublishModal.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowPublishModal.vue
@@ -150,7 +150,10 @@ const shouldShowFreeAiCreditsWarning = computed((): boolean => {
 	const managedOpenAiCredentialId = findManagedOpenAiCredentialId(usedCredentials);
 	if (!managedOpenAiCredentialId) return false;
 
-	return hasActiveNodeUsingCredential(workflowsStore.allNodes, managedOpenAiCredentialId);
+	return hasActiveNodeUsingCredential(
+		workflowDocumentStore.value?.allNodes ?? [],
+		managedOpenAiCredentialId,
+	);
 });
 
 async function displayActivationError() {

--- a/packages/frontend/editor-ui/src/app/components/NodeExecuteButton.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/NodeExecuteButton.test.ts
@@ -1,4 +1,4 @@
-import { reactive } from 'vue';
+import { reactive, shallowRef } from 'vue';
 import { createTestingPinia } from '@pinia/testing';
 import { useRouter } from 'vue-router';
 import userEvent from '@testing-library/user-event';
@@ -20,6 +20,11 @@ import {
 } from '@/app/constants';
 import NodeExecuteButton from './NodeExecuteButton.vue';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	injectWorkflowDocumentStore,
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useRunWorkflow } from '@/app/composables/useRunWorkflow';
@@ -99,8 +104,14 @@ vi.mock('@/app/composables/useWorkflowState', async () => {
 	};
 });
 
+vi.mock('@/app/stores/workflowDocument.store', async (importOriginal) => ({
+	...(await importOriginal()),
+	injectWorkflowDocumentStore: vi.fn(),
+}));
+
 let renderComponent: ReturnType<typeof createComponentRenderer>;
 let workflowsStore: MockedStore<typeof useWorkflowsStore>;
+let workflowDocumentStore: ReturnType<typeof useWorkflowDocumentStore>;
 let nodeTypesStore: MockedStore<typeof useNodeTypesStore>;
 let ndvStore: MockedStore<typeof useNDVStore>;
 
@@ -126,6 +137,9 @@ describe('NodeExecuteButton', () => {
 		});
 
 		workflowsStore = mockedStore(useWorkflowsStore);
+		workflowsStore.workflowId = 'abc123';
+		workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId('abc123'));
+		vi.mocked(injectWorkflowDocumentStore).mockReturnValue(shallowRef(workflowDocumentStore));
 		workflowState = useWorkflowState();
 		vi.mocked(injectWorkflowState).mockReturnValue(workflowState);
 
@@ -136,8 +150,6 @@ describe('NodeExecuteButton', () => {
 		externalHooks = useExternalHooks();
 		message = useMessage();
 		toast = useToast();
-
-		workflowsStore.workflowId = 'abc123';
 	});
 
 	it('renders without error', () => {
@@ -151,7 +163,7 @@ describe('NodeExecuteButton', () => {
 
 	it('displays correct button label for webhook node', () => {
 		const node = mockNode({ name: 'test-node', type: WEBHOOK_NODE_TYPE });
-		workflowsStore.getNodeByName.mockReturnValue(node);
+		vi.spyOn(workflowDocumentStore, 'getNodeByName').mockReturnValue(node);
 		nodeTypesStore.getNodeType = () => ({
 			...mockNodeTypeDescription(),
 			name: WEBHOOK_NODE_TYPE,
@@ -163,7 +175,7 @@ describe('NodeExecuteButton', () => {
 
 	it('displays correct button label for form trigger node', () => {
 		const node = mockNode({ name: 'test-node', type: FORM_TRIGGER_NODE_TYPE });
-		workflowsStore.getNodeByName.mockReturnValue(node);
+		vi.spyOn(workflowDocumentStore, 'getNodeByName').mockReturnValue(node);
 		nodeTypesStore.getNodeType = () => ({
 			...mockNodeTypeDescription(),
 			name: FORM_TRIGGER_NODE_TYPE,
@@ -175,7 +187,7 @@ describe('NodeExecuteButton', () => {
 
 	it('displays correct button label for chat node', () => {
 		const node = mockNode({ name: 'test-node', type: CHAT_TRIGGER_NODE_TYPE });
-		workflowsStore.getNodeByName.mockReturnValue(node);
+		vi.spyOn(workflowDocumentStore, 'getNodeByName').mockReturnValue(node);
 		nodeTypesStore.getNodeType = () => ({
 			...mockNodeTypeDescription(),
 			name: CHAT_TRIGGER_NODE_TYPE,
@@ -187,7 +199,7 @@ describe('NodeExecuteButton', () => {
 
 	it('displays correct button label for polling node', () => {
 		const node = mockNode({ name: 'test-node', type: SET_NODE_TYPE });
-		workflowsStore.getNodeByName.mockReturnValue(node);
+		vi.spyOn(workflowDocumentStore, 'getNodeByName').mockReturnValue(node);
 		nodeTypesStore.getNodeType = () => ({
 			...mockNodeTypeDescription(),
 			polling: true,
@@ -199,7 +211,7 @@ describe('NodeExecuteButton', () => {
 
 	it('displays "Stop Listening" when node is listening for events', () => {
 		const node = mockNode({ name: 'test-node', type: SET_NODE_TYPE });
-		workflowsStore.getNodeByName.mockReturnValue(node);
+		vi.spyOn(workflowDocumentStore, 'getNodeByName').mockReturnValue(node);
 		workflowsStore.executionWaitingForWebhook = true;
 		nodeTypesStore.isTriggerNode = () => true;
 
@@ -209,7 +221,7 @@ describe('NodeExecuteButton', () => {
 
 	it('displays "Stop Listening" when node is running and is a trigger node', () => {
 		const node = mockNode({ name: 'test-node', type: SET_NODE_TYPE });
-		workflowsStore.getNodeByName.mockReturnValue(node);
+		vi.spyOn(workflowDocumentStore, 'getNodeByName').mockReturnValue(node);
 		workflowState.executingNode.isNodeExecuting = vi.fn().mockReturnValue(true);
 		nodeTypesStore.isTriggerNode = () => true;
 		workflowsStore.isWorkflowRunning = true;
@@ -220,7 +232,7 @@ describe('NodeExecuteButton', () => {
 
 	it('sets button to loading state when node is executing', () => {
 		const node = mockNode({ name: 'test-node', type: SET_NODE_TYPE });
-		workflowsStore.getNodeByName.mockReturnValue(node);
+		vi.spyOn(workflowDocumentStore, 'getNodeByName').mockReturnValue(node);
 		workflowState.executingNode.isNodeExecuting = vi.fn().mockReturnValue(true);
 		workflowsStore.isWorkflowRunning = true;
 
@@ -229,7 +241,7 @@ describe('NodeExecuteButton', () => {
 	});
 
 	it('should be disabled if the node is disabled and show tooltip', async () => {
-		workflowsStore.getNodeByName.mockReturnValue(
+		vi.spyOn(workflowDocumentStore, 'getNodeByName').mockReturnValue(
 			mockNode({ name: 'test', type: SET_NODE_TYPE, disabled: true }),
 		);
 
@@ -249,7 +261,7 @@ describe('NodeExecuteButton', () => {
 	it('should be disabled when workflow is running but node is not executing', async () => {
 		workflowsStore.isWorkflowRunning = true;
 		workflowState.executingNode.isNodeExecuting = vi.fn().mockReturnValue(false);
-		workflowsStore.getNodeByName.mockReturnValue(
+		vi.spyOn(workflowDocumentStore, 'getNodeByName').mockReturnValue(
 			mockNode({ name: 'test-node', type: SET_NODE_TYPE }),
 		);
 
@@ -268,7 +280,7 @@ describe('NodeExecuteButton', () => {
 
 	it('disables button when trigger node has issues', async () => {
 		nodeTypesStore.isTriggerNode = () => true;
-		workflowsStore.getNodeByName.mockReturnValue(
+		vi.spyOn(workflowDocumentStore, 'getNodeByName').mockReturnValue(
 			mockNode({
 				name: 'test',
 				type: SET_NODE_TYPE,
@@ -286,7 +298,7 @@ describe('NodeExecuteButton', () => {
 	it('stops webhook when clicking button while listening for events', async () => {
 		workflowsStore.executionWaitingForWebhook = true;
 		nodeTypesStore.isTriggerNode = () => true;
-		workflowsStore.getNodeByName.mockReturnValue(
+		vi.spyOn(workflowDocumentStore, 'getNodeByName').mockReturnValue(
 			mockNode({ name: 'test-node', type: SET_NODE_TYPE }),
 		);
 
@@ -302,7 +314,7 @@ describe('NodeExecuteButton', () => {
 		nodeTypesStore.isTriggerNode = () => true;
 		useWorkflowState().setActiveExecutionId('test-execution-id');
 		workflowState.executingNode.isNodeExecuting = vi.fn().mockReturnValue(true);
-		workflowsStore.getNodeByName.mockReturnValue(
+		vi.spyOn(workflowDocumentStore, 'getNodeByName').mockReturnValue(
 			mockNode({ name: 'test-node', type: SET_NODE_TYPE }),
 		);
 
@@ -316,7 +328,7 @@ describe('NodeExecuteButton', () => {
 
 	it('runs workflow when clicking button normally', async () => {
 		const node = mockNode({ name: 'test-node', type: SET_NODE_TYPE });
-		workflowsStore.getNodeByName.mockReturnValue(node);
+		vi.spyOn(workflowDocumentStore, 'getNodeByName').mockReturnValue(node);
 		nodeTypesStore.getNodeType = () => mockNodeTypeDescription();
 
 		const { getByRole, emitted } = renderComponent();
@@ -336,7 +348,7 @@ describe('NodeExecuteButton', () => {
 
 	it('opens chat when clicking button for chat node', async () => {
 		const node = mockNode({ name: 'test-node', type: SET_NODE_TYPE });
-		workflowsStore.getNodeByName.mockReturnValue(node);
+		vi.spyOn(workflowDocumentStore, 'getNodeByName').mockReturnValue(node);
 		nodeTypesStore.getNodeType = () => mockNodeTypeDescription({ name: CHAT_TRIGGER_NODE_TYPE });
 
 		const { getByRole } = renderComponent();
@@ -350,7 +362,7 @@ describe('NodeExecuteButton', () => {
 
 	it('opens chat when clicking button for chat child node', async () => {
 		const node = mockNode({ name: 'test-node', type: SET_NODE_TYPE });
-		workflowsStore.getNodeByName.mockReturnValue(node);
+		vi.spyOn(workflowDocumentStore, 'getNodeByName').mockReturnValue(node);
 		workflowsStore.checkIfNodeHasChatParent.mockReturnValue(true);
 
 		const { getByRole } = renderComponent();
@@ -364,7 +376,7 @@ describe('NodeExecuteButton', () => {
 
 	it('prompts for confirmation when pinned data exists', async () => {
 		const node = mockNode({ name: 'test-node', type: SET_NODE_TYPE });
-		workflowsStore.getNodeByName.mockReturnValue(node);
+		vi.spyOn(workflowDocumentStore, 'getNodeByName').mockReturnValue(node);
 		pinnedData = usePinnedData(node);
 		Object.defineProperty(pinnedData.hasData, 'value', { value: true });
 
@@ -393,7 +405,7 @@ describe('NodeExecuteButton', () => {
 				[AI_TRANSFORM_CODE_GENERATED_FOR_PROMPT]: 'Test prompt',
 			},
 		});
-		workflowsStore.getNodeByName.mockReturnValue(node);
+		vi.spyOn(workflowDocumentStore, 'getNodeByName').mockReturnValue(node);
 
 		const { getByRole } = renderComponent();
 

--- a/packages/frontend/editor-ui/src/app/components/NodeExecuteButton.vue
+++ b/packages/frontend/editor-ui/src/app/components/NodeExecuteButton.vue
@@ -5,7 +5,7 @@ import type { ButtonSize, IUpdateInformation } from '@/Interface';
 import type { ButtonVariant } from '@n8n/design-system';
 import { type IconName } from '@n8n/design-system/components/N8nIcon/icons';
 import { N8nButton, N8nTooltip } from '@n8n/design-system';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeExecution } from '@/app/composables/useNodeExecution';
 
@@ -53,10 +53,10 @@ defineOptions({
 });
 
 const i18n = useI18n();
-const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const ndvStore = useNDVStore();
 
-const node = computed(() => workflowsStore.getNodeByName(props.nodeName));
+const node = computed(() => workflowDocumentStore?.value?.getNodeByName(props.nodeName) ?? null);
 
 const {
 	isExecuting,


### PR DESCRIPTION
## Summary

This pull request refactors several frontend components and tests to use the new `workflowDocumentStore` for node access, replacing direct use of `workflowsStore.allNodes` and related methods. This change improves consistency and prepares the codebase for enhanced workflow document management. The updates also include adjustments to test setups and mocks to accommodate the new store.

**Migration to `workflowDocumentStore` for Node Access:**

* Updated `FocusPanel.vue`, `FocusSidebar.vue`, `ChatEmbedModal.vue`, `FromAiParametersModal.vue`, and `WorkflowPublishModal.vue` to use `workflowDocumentStore` for accessing nodes instead of `workflowsStore.allNodes` or `workflowsStore.getNodeByName`. [[1]](diffhunk://#diff-d23bc17fe0a4a2d3a9a5c3a56e04dd7bb448aff5c5a88c3ddfe6579e535dc2a5R42) [[2]](diffhunk://#diff-d23bc17fe0a4a2d3a9a5c3a56e04dd7bb448aff5c5a88c3ddfe6579e535dc2a5R74) [[3]](diffhunk://#diff-d23bc17fe0a4a2d3a9a5c3a56e04dd7bb448aff5c5a88c3ddfe6579e535dc2a5L131-R133) [[4]](diffhunk://#diff-d658194fa1ff502734be97712c04c9e18540ae0437e4218dd2c902f6eb610cc2R4) [[5]](diffhunk://#diff-d658194fa1ff502734be97712c04c9e18540ae0437e4218dd2c902f6eb610cc2R36) [[6]](diffhunk://#diff-d658194fa1ff502734be97712c04c9e18540ae0437e4218dd2c902f6eb610cc2L63-R65) [[7]](diffhunk://#diff-564b4146fc7656f8094b00262a9a693c3c7fc284372cdbe3d72d5d3f92433637R9-R12) [[8]](diffhunk://#diff-564b4146fc7656f8094b00262a9a693c3c7fc284372cdbe3d72d5d3f92433637R31-R35) [[9]](diffhunk://#diff-564b4146fc7656f8094b00262a9a693c3c7fc284372cdbe3d72d5d3f92433637L55-R64) [[10]](diffhunk://#diff-95f5e3ecf42f85b679a11f6aaf858615f52a1cff27dd82b4c69128084342aebeR7-R10) [[11]](diffhunk://#diff-95f5e3ecf42f85b679a11f6aaf858615f52a1cff27dd82b4c69128084342aebeR44-R61) [[12]](diffhunk://#diff-e301cbea98047d9c975154189e14c59087aa0a289d42f2375a5e12e7d1119a74L153-R156)

**Test Refactoring and Mocking:**

* Refactored tests for `FocusPanel`, `FocusSidebar`, `NodeExecuteButton`, and `FromAiParametersModal` to setup and mock `workflowDocumentStore`, replacing direct node access via `workflowsStore`. This includes mocking store injection and updating test node setup. [[1]](diffhunk://#diff-ac5199407b874a54568bdec6c7051fd3550a9b0e816eec609c9ffaa19193d951R9-R18) [[2]](diffhunk://#diff-ac5199407b874a54568bdec6c7051fd3550a9b0e816eec609c9ffaa19193d951R28-R32) [[3]](diffhunk://#diff-ac5199407b874a54568bdec6c7051fd3550a9b0e816eec609c9ffaa19193d951R61-R65) [[4]](diffhunk://#diff-ac5199407b874a54568bdec6c7051fd3550a9b0e816eec609c9ffaa19193d951L66-R85) [[5]](diffhunk://#diff-af5ebb7bad61c9ae00650e896ac9e8672d75717bc25af813f6c5348047b89359R9-R18) [[6]](diffhunk://#diff-af5ebb7bad61c9ae00650e896ac9e8672d75717bc25af813f6c5348047b89359R29-R33) [[7]](diffhunk://#diff-af5ebb7bad61c9ae00650e896ac9e8672d75717bc25af813f6c5348047b89359R62-R68) [[8]](diffhunk://#diff-af5ebb7bad61c9ae00650e896ac9e8672d75717bc25af813f6c5348047b89359L68-R87) [[9]](diffhunk://#diff-9b21b3631096e9e37ad95c2553b10e4b25c488dbff6ab6f962ebb9cba8d9aad9L1-R1) [[10]](diffhunk://#diff-9b21b3631096e9e37ad95c2553b10e4b25c488dbff6ab6f962ebb9cba8d9aad9R23-R27) [[11]](diffhunk://#diff-9b21b3631096e9e37ad95c2553b10e4b25c488dbff6ab6f962ebb9cba8d9aad9R107-R114) [[12]](diffhunk://#diff-9b21b3631096e9e37ad95c2553b10e4b25c488dbff6ab6f962ebb9cba8d9aad9R140-R142) [[13]](diffhunk://#diff-8731a619ee18ff0b67e49b963d0f8f25d890866110aa8a718a96d82c8280b58eL7) [[14]](diffhunk://#diff-8731a619ee18ff0b67e49b963d0f8f25d890866110aa8a718a96d82c8280b58eR18-R28) [[15]](diffhunk://#diff-8731a619ee18ff0b67e49b963d0f8f25d890866110aa8a718a96d82c8280b58eL101) [[16]](diffhunk://#diff-8731a619ee18ff0b67e49b963d0f8f25d890866110aa8a718a96d82c8280b58eL128-R137)

**Code Consistency and Preparation for Future Enhancements:**

* Ensured all components and tests consistently use the new workflow document abstraction, laying groundwork for future improvements in workflow state and node management. [[1]](diffhunk://#diff-d23bc17fe0a4a2d3a9a5c3a56e04dd7bb448aff5c5a88c3ddfe6579e535dc2a5R42) [[2]](diffhunk://#diff-564b4146fc7656f8094b00262a9a693c3c7fc284372cdbe3d72d5d3f92433637R9-R12) [[3]](diffhunk://#diff-95f5e3ecf42f85b679a11f6aaf858615f52a1cff27dd82b4c69128084342aebeR7-R10)

These changes collectively enhance maintainability and scalability of workflow-related features in the frontend codebase.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2521/migrate-app-components-to-workflowdocumentstore

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
