### PR TITLE
fix: prevent crash on undefined resourceIds in FlowTrigger and invalid regex in filter

### DIFF
--- a/packages/nodes-base/nodes/Flow/FlowTrigger.node.ts
+++ b/packages/nodes-base/nodes/Flow/FlowTrigger.node.ts
@@ -110,8 +110,7 @@ export class FlowTrigger implements INodeType {
 				webhooks = await flowApiRequest.call(this, 'GET', endpoint, {}, qs);
 				webhooks = webhooks.integration_webhooks;
 				for (const webhook of webhooks) {
-					// @ts-ignore
-					if (webhookData.webhookIds.includes(webhook.id)) {
+					if ((webhookData.webhookIds as number[]).includes(webhook.id)) {
 						continue;
 					} else {
 						return false;
@@ -122,18 +121,19 @@ export class FlowTrigger implements INodeType {
 			async create(this: IHookFunctions): Promise<boolean> {
 				const credentials = await this.getCredentials('flowApi');
 
-				let resourceIds, body, responseData;
+				let resourceIds: string[];
+				let body, responseData;
 				const webhookUrl = this.getNodeWebhookUrl('default');
 				const webhookData = this.getWorkflowStaticData('node');
 				const resource = this.getNodeParameter('resource') as string;
 				const endpoint = '/integration_webhooks';
 				if (resource === 'list') {
 					resourceIds = (this.getNodeParameter('listIds') as string).split(',');
-				}
-				if (resource === 'task') {
+				} else if (resource === 'task') {
 					resourceIds = (this.getNodeParameter('taskIds') as string).split(',');
+				} else {
+					throw new Error(`Unsupported resource type: "${resource}"`);
 				}
-				// @ts-ignore
 				for (const resourceId of resourceIds) {
 					body = {
 						organization_id: credentials.organizationId as number,
@@ -156,8 +156,7 @@ export class FlowTrigger implements INodeType {
 						// Required data is missing so was not successful
 						return false;
 					}
-					// @ts-ignore
-					webhookData.webhookIds.push(responseData.integration_webhook.id);
+					(webhookData.webhookIds as number[]).push(responseData.integration_webhook.id);
 				}
 				return true;
 			},
@@ -167,10 +166,8 @@ export class FlowTrigger implements INodeType {
 				const qs: IDataObject = {};
 				const webhookData = this.getWorkflowStaticData('node');
 				qs.organization_id = credentials.organizationId as number;
-				// @ts-ignore
-				if (webhookData.webhookIds.length > 0) {
-					// @ts-ignore
-					for (const webhookId of webhookData.webhookIds) {
+				if ((webhookData.webhookIds as number[]).length > 0) {
+					for (const webhookId of webhookData.webhookIds as number[]) {
 						const endpoint = `/integration_webhooks/${webhookId}`;
 						try {
 							await flowApiRequest.call(this, 'DELETE', endpoint, {}, qs);

--- a/packages/workflow/src/node-parameters/filter-parameter.ts
+++ b/packages/workflow/src/node-parameters/filter-parameter.ts
@@ -195,15 +195,18 @@ function parseFilterConditionValues(
 
 function parseRegexPattern(pattern: string): RegExp {
 	const regexMatch = (pattern || '').match(new RegExp('^/(.*?)/([gimusy]*)$'));
-	let regex: RegExp;
 
-	if (!regexMatch) {
-		regex = new RegExp((pattern || '').toString());
-	} else {
-		regex = new RegExp(regexMatch[1], regexMatch[2]);
+	try {
+		if (!regexMatch) {
+			return new RegExp((pattern || '').toString());
+		}
+		return new RegExp(regexMatch[1], regexMatch[2]);
+	} catch (error) {
+		throw new FilterError(
+			`Invalid regular expression: "${pattern}"`,
+			(error as Error).message,
+		);
 	}
-
-	return regex;
 }
 
 export function arrayContainsValue(array: unknown[], value: unknown, ignoreCase: boolean): boolean {


### PR DESCRIPTION
## Summary
- **FlowTrigger node**: Fix potential `TypeError: undefined is not iterable` crash when `resourceIds` is left uninitialized. The variable was declared with `let` but only assigned inside two separate `if` blocks — if the resource type matched neither `'list'` nor `'task'`, `resourceIds` remained `undefined` and the `for...of` loop on line 137 would crash. Changed to a proper `if/else if/else` chain that throws a descriptive error for unknown resource types. Also removed all `@ts-ignore` comments and replaced with proper type assertions.
- **filter-parameter**: Wrap `new RegExp(pattern)` in `parseRegexPattern()` with try/catch so that invalid regex patterns (e.g. unclosed groups, bad escapes) throw a user-friendly `FilterError` instead of an unhandled exception.

## Test plan
- [x] Verify FlowTrigger handles unknown resource types gracefully (throws descriptive error instead of crash)
- [x] Verify existing list/task paths are unchanged
- [x] Verify invalid regex in filter conditions produces a FilterError with the original pattern and native error message
- [x] Verify valid regex patterns still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)