### PR TITLE
ci: Retry SafeChain install download in setup action

### DIFF
--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -50,8 +50,8 @@ runs:
       run: |
         VERSION="1.4.1"
         EXPECTED_SHA256="628235987175072a4255aa3f5f0128f31795b63970f1970ae8a04d07bf8527b0"
-        curl -fsSL -o install-safe-chain.sh \
-          "https://github.com/AikidoSec/safe-chain/releases/download/${VERSION}/install-safe-chain.sh"
+        node .github/scripts/retry.mjs --attempts 3 --delay 10 \
+          "curl -fsSL -o install-safe-chain.sh https://github.com/AikidoSec/safe-chain/releases/download/${VERSION}/install-safe-chain.sh"
         echo "${EXPECTED_SHA256}  install-safe-chain.sh" | sha256sum -c -
         sh install-safe-chain.sh --ci
         rm install-safe-chain.sh


### PR DESCRIPTION
## Summary

Wrap the SafeChain installer `curl` command in `.github/scripts/retry.mjs` with 3 attempts and a 10-second delay.
This reduces transient network flakes in CI while keeping checksum verification and installation behavior unchanged.
To test, run a workflow that uses `./.github/actions/setup-nodejs` and verify the SafeChain install step succeeds.

## Related Linear tickets, Github issues, and Community forum posts

None.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
