### PR TITLE
fix: add explicit radix to parseInt() calls

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/Guardrails/actions/checks/urls.ts
+++ b/packages/@n8n/nodes-langchain/nodes/Guardrails/actions/checks/urls.ts
@@ -232,7 +232,7 @@ function isUrlAllowed(parsedUrl: URL, allowList: string[], allowSubdomains: bool
 				// Proper CIDR validation
 				if (entry.includes('/') && urlHost.match(/^\d+\.\d+\.\d+\.\d+$/)) {
 					const [network, prefixStr] = entry.split('/');
-					const prefix = parseInt(prefixStr);
+					const prefix = parseInt(prefixStr, 10);
 
 					if (prefix >= 0 && prefix <= 32) {
 						// Convert IPs to 32-bit integers for bitwise comparison

--- a/packages/cli/src/services/import.service.ts
+++ b/packages/cli/src/services/import.service.ts
@@ -626,8 +626,8 @@ export class ImportService {
 
 		// Find the latest migration in import data
 		const latestImportMigration = importMigrations.reduce((latest, current) => {
-			const currentTimestamp = parseInt(String(current.timestamp || current.id || '0'));
-			const latestTimestamp = parseInt(String(latest.timestamp || latest.id || '0'));
+			const currentTimestamp = parseInt(String(current.timestamp || current.id || '0'), 10);
+			const latestTimestamp = parseInt(String(latest.timestamp || latest.id || '0'), 10);
 			return currentTimestamp > latestTimestamp ? current : latest;
 		});
 
@@ -657,8 +657,9 @@ export class ImportService {
 		// Compare timestamps, names, and IDs for comprehensive validation
 		const importTimestamp = parseInt(
 			String(latestImportMigration.timestamp || latestImportMigration.id || '0'),
+			10,
 		);
-		const dbTimestamp = parseInt(String(latestDbMigration.timestamp || '0'));
+		const dbTimestamp = parseInt(String(latestDbMigration.timestamp || '0'), 10);
 		const importName = latestImportMigration.name;
 		const dbName = latestDbMigration.name;
 

--- a/packages/nodes-base/nodes/Elastic/Elasticsearch/Elasticsearch.node.ts
+++ b/packages/nodes-base/nodes/Elastic/Elasticsearch/Elasticsearch.node.ts
@@ -393,7 +393,7 @@ export class Elasticsearch implements INodeType {
 						const errorData = itemData.error as IDataObject;
 						const message = errorData.type as string;
 						const description = errorData.reason as string;
-						const itemIndex = parseInt(Object.keys(bulkBody)[j]);
+						const itemIndex = parseInt(Object.keys(bulkBody)[j], 10);
 						if (this.continueOnFail()) {
 							returnData.push(
 								...this.helpers.constructExecutionMetaData(
@@ -412,7 +412,7 @@ export class Elasticsearch implements INodeType {
 					}
 					const executionData = this.helpers.constructExecutionMetaData(
 						this.helpers.returnJsonArray(itemData),
-						{ itemData: { item: parseInt(Object.keys(bulkBody)[j]) } },
+						{ itemData: { item: parseInt(Object.keys(bulkBody)[j], 10) } },
 					);
 					returnData.push(...executionData);
 				}
@@ -427,7 +427,7 @@ export class Elasticsearch implements INodeType {
 					const errorData = itemData.error as IDataObject;
 					const message = errorData.type as string;
 					const description = errorData.reason as string;
-					const itemIndex = parseInt(Object.keys(bulkBody)[j]);
+					const itemIndex = parseInt(Object.keys(bulkBody)[j], 10);
 					if (this.continueOnFail()) {
 						returnData.push(
 							...this.helpers.constructExecutionMetaData(
@@ -446,7 +446,7 @@ export class Elasticsearch implements INodeType {
 				}
 				const executionData = this.helpers.constructExecutionMetaData(
 					this.helpers.returnJsonArray(itemData),
-					{ itemData: { item: parseInt(Object.keys(bulkBody)[j]) } },
+					{ itemData: { item: parseInt(Object.keys(bulkBody)[j], 10) } },
 				);
 				returnData.push(...executionData);
 			}

--- a/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheets.utils.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheets.utils.ts
@@ -49,7 +49,7 @@ export function getSpreadsheetId(
 
 export function getSheetId(value: string): number {
 	if (value === 'gid=0') return 0;
-	return parseInt(value);
+	return parseInt(value, 10);
 }
 
 // Convert number to Sheets / Excel column name


### PR DESCRIPTION
## Summary
- Add explicit radix parameter (10) to `parseInt()` calls across multiple packages
- Without radix, `parseInt()` can produce unexpected results with `0x` or `0o` prefixed strings
- Follows ESLint `radix` rule best practice

## Test plan
- [x] All parseInt calls now explicitly specify base 10
- [x] No functional change for decimal inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)