### PR TITLE
test: Fix deduplication violations and update janitor baseline (no-changelog)

### DIFF
--- a/packages/testing/playwright/.janitor-baseline.json
+++ b/packages/testing/playwright/.janitor-baseline.json
@@ -1,7 +1,7 @@
 {
 	"version": 1,
-	"generated": "2026-03-05T10:03:55.711Z",
-	"totalViolations": 550,
+	"generated": "2026-03-10T15:03:43.108Z",
+	"totalViolations": 539,
 	"violations": {
 		"pages/AIAssistantPage.ts": [
 			{
@@ -41,18 +41,6 @@
 				"line": 6,
 				"message": "ChatHubPersonalAgentsPage: Ambiguous page - add a container (for scoped components) or a navigation method (for top-level pages)",
 				"hash": "f8ca4379facf"
-			},
-			{
-				"rule": "deduplication",
-				"line": 22,
-				"message": "Duplicate locator: this.page.getByTestId(\"chat-agent-card\") in pages scope",
-				"hash": "93472d766ead"
-			},
-			{
-				"rule": "deduplication",
-				"line": 26,
-				"message": "Duplicate locator: this.page.getByTestId(\"chat-agent-card\") in pages scope",
-				"hash": "93472d766ead"
 			}
 		],
 		"pages/ChatHubSettingsPage.ts": [
@@ -678,109 +666,109 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 726,
+				"line": 751,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 730,
+				"line": 755,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 730,
+				"line": 755,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 734,
+				"line": 759,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 740,
+				"line": 765,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 768,
+				"line": 793,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 772,
+				"line": 797,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 776,
+				"line": 801,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 780,
+				"line": 805,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 785,
+				"line": 810,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 791,
+				"line": 816,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 795,
+				"line": 820,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 795,
+				"line": 820,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 803,
+				"line": 828,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 807,
+				"line": 832,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 811,
+				"line": 836,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 843,
+				"line": 872,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 847,
+				"line": 876,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			}
@@ -960,12 +948,6 @@
 			},
 			{
 				"rule": "deduplication",
-				"line": 24,
-				"message": "Duplicate locator: this.page.getByTestId(\"resources-list-search\") in pages scope",
-				"hash": "3b38dddeafed"
-			},
-			{
-				"rule": "deduplication",
 				"line": 32,
 				"message": "Duplicate locator: this.page.getByTestId(\"resources-list-search\") in pages scope",
 				"hash": "3b38dddeafed"
@@ -1141,14 +1123,6 @@
 				"hash": "c324de315cb4"
 			}
 		],
-		"tests/e2e/ai/assistant-basic.spec.ts": [
-			{
-				"rule": "selector-purity",
-				"line": 166,
-				"message": "Chained locator call in test: n8n.aiAssistant .getNewAssistantSessionModal() .getByRole...",
-				"hash": "8a89adbe00d9"
-			}
-		],
 		"tests/e2e/ai/assistant-credential-help.spec.ts": [
 			{
 				"rule": "selector-purity",
@@ -1184,31 +1158,31 @@
 			},
 			{
 				"rule": "selector-purity",
-				"line": 87,
+				"line": 88,
 				"message": "Direct page locator call: n8n.page.getByTestId('add-connection-button')",
 				"hash": "e87a57e25440"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 116,
+				"line": 117,
 				"message": "Chained locator call in test: n8n.ndv.getParameterInput('description').locator('textarea')",
 				"hash": "00a4addafb63"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 142,
+				"line": 143,
 				"message": "Direct page locator call: n8n.page.getByTestId('canvas-chat').getByText('Approve')",
 				"hash": "158ef58d883a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 142,
+				"line": 143,
 				"message": "Chained locator call in test: n8n.page.getByTestId('canvas-chat').getByText('Approve')",
 				"hash": "9717a7a385c3"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 142,
+				"line": 143,
 				"message": "Direct page locator call: n8n.page.getByTestId('canvas-chat')",
 				"hash": "0810223b0675"
 			}
@@ -1272,13 +1246,13 @@
 		"tests/e2e/ai/langchain-vectorstores.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 87,
+				"line": 88,
 				"message": "Chained locator call in test: n8n.canvas.getManualChatModal().getByTestId('canvas-chat-...",
 				"hash": "0651461e8fda"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 93,
+				"line": 94,
 				"message": "Chained locator call in test: n8n.canvas.getManualChatModal().getByTestId('canvas-chat-...",
 				"hash": "0651461e8fda"
 			}
@@ -1300,13 +1274,13 @@
 		"tests/e2e/app-config/security-notifications.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 184,
+				"line": 189,
 				"message": "Chained locator call in test: versionCard.locator('.el-tag--danger').getByText('Securit...",
 				"hash": "41e0381dfdf0"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 184,
+				"line": 189,
 				"message": "Chained locator call in test: versionCard.locator('.el-tag--danger')",
 				"hash": "60a61866e32a"
 			}
@@ -1314,30 +1288,24 @@
 		"tests/e2e/building-blocks/node-details-configuration.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 60,
+				"line": 63,
 				"message": "Chained locator call in test: n8n.ndv.getAssignmentName('assignments', 0).getByRole('te...",
 				"hash": "fa1cc41275f1"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 74,
+				"line": 77,
 				"message": "Chained locator call in test: n8n.ndv.getAssignmentCollectionContainer('assignments').g...",
 				"hash": "f36b5d7ebe58"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 89,
+				"line": 92,
 				"message": "Chained locator call in test: n8n.ndv.getAssignmentCollectionContainer('assignments').g...",
 				"hash": "f36b5d7ebe58"
 			}
 		],
 		"tests/e2e/chat-hub/chat-hub-attachment.spec.ts": [
-			{
-				"rule": "selector-purity",
-				"line": 61,
-				"message": "Chained locator call in test: newPage.locator('img')",
-				"hash": "787461cb35dd"
-			},
 			{
 				"rule": "selector-purity",
 				"line": 62,
@@ -1351,20 +1319,26 @@
 				"hash": "787461cb35dd"
 			},
 			{
+				"rule": "selector-purity",
+				"line": 64,
+				"message": "Chained locator call in test: newPage.locator('img')",
+				"hash": "787461cb35dd"
+			},
+			{
 				"rule": "no-direct-page-instantiation",
-				"line": 42,
+				"line": 43,
 				"message": "Direct page instantiation: new ChatHubChatPage(n8n.page)",
 				"hash": "4c6c3053ee95"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 68,
+				"line": 69,
 				"message": "Direct page instantiation: new ChatHubChatPage(n8n.page)",
 				"hash": "4c6c3053ee95"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 84,
+				"line": 85,
 				"message": "Direct page instantiation: new ChatHubChatPage(n8n.page)",
 				"hash": "4c6c3053ee95"
 			}
@@ -1372,25 +1346,25 @@
 		"tests/e2e/chat-hub/chat-hub-basic.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 34,
+				"line": 35,
 				"message": "Direct page locator call: n8n.page.getByTestId('editCredential-modal')",
 				"hash": "2786a49972b3"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 13,
+				"line": 14,
 				"message": "Direct page instantiation: new ChatHubChatPage(n8n.page)",
 				"hash": "4c6c3053ee95"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 33,
+				"line": 34,
 				"message": "Direct page instantiation: new ChatHubChatPage(n8n.page)",
 				"hash": "4c6c3053ee95"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 60,
+				"line": 61,
 				"message": "Direct page instantiation: new ChatHubChatPage(n8n.page)",
 				"hash": "4c6c3053ee95"
 			}
@@ -1398,119 +1372,99 @@
 		"tests/e2e/chat-hub/chat-hub-personal-agent.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 92,
+				"line": 93,
 				"message": "Direct page locator call: n8n.page.getByRole('dialog').getByText('Delete', { exact:...",
 				"hash": "5fd52ad894c3"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 92,
+				"line": 93,
 				"message": "Direct page locator call: n8n.page.getByRole('dialog').getByText('Delete', { exact:...",
 				"hash": "5fd52ad894c3"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 92,
+				"line": 93,
 				"message": "Chained locator call in test: n8n.page.getByRole('dialog').getByText('Delete', { exact:...",
 				"hash": "41d47e05bb02"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 92,
+				"line": 93,
 				"message": "Direct page locator call: n8n.page.getByRole('dialog')",
 				"hash": "68deb7ade2bb"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 16,
+				"line": 17,
 				"message": "Direct page instantiation: new ChatHubChatPage(n8n.page)",
 				"hash": "4c6c3053ee95"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 47,
+				"line": 48,
 				"message": "Direct page instantiation: new ChatHubPersonalAgentsPage(n8n.page)",
 				"hash": "e85eb6a08ae6"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 48,
+				"line": 49,
 				"message": "Direct page instantiation: new ChatHubChatPage(n8n.page)",
 				"hash": "4c6c3053ee95"
-			}
-		],
-		"tests/e2e/credentials/crud.spec.ts": [
-			{
-				"rule": "selector-purity",
-				"line": 346,
-				"message": "Direct page locator call: n8n.page.locator('.el-overlay').first()",
-				"hash": "6e0141ec89e6"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 346,
-				"message": "Direct page locator call: n8n.page.locator('.el-overlay')",
-				"hash": "4668d190d0af"
-			},
-			{
-				"rule": "api-purity",
-				"line": 299,
-				"message": "Raw API call detected: fetch(",
-				"hash": "b52df352569e"
 			}
 		],
 		"tests/e2e/credentials/global.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 39,
+				"line": 40,
 				"message": "Chained locator call in test: n8n.credentials.credentialModal.getVisibleDropdown().getB...",
 				"hash": "5ffd78437b38"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 48,
+				"line": 49,
 				"message": "Chained locator call in test: n8n.credentials.cards .getCredential('Global HTTP Header ...",
 				"hash": "05e7dd651e5e"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 65,
+				"line": 66,
 				"message": "Chained locator call in test: n8n.credentials.cards .getCredential('Global HTTP Header ...",
 				"hash": "05e7dd651e5e"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 95,
+				"line": 96,
 				"message": "Chained locator call in test: dropdown.getByText('Global HTTP Header Cred')",
 				"hash": "4a7662ea3718"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 98,
+				"line": 99,
 				"message": "Chained locator call in test: dropdown.getByText('Global HTTP Header Cred')",
 				"hash": "4a7662ea3718"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 125,
+				"line": 126,
 				"message": "Chained locator call in test: n8n.credentials.credentialModal .getModal() .getByTestId(...",
 				"hash": "ea4ed603d27a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 132,
+				"line": 133,
 				"message": "Chained locator call in test: n8n.credentials.credentialModal .getModal() .getByTestId(...",
 				"hash": "ea4ed603d27a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 132,
+				"line": 133,
 				"message": "Chained locator call in test: n8n.credentials.credentialModal .getModal() .getByTestId(...",
 				"hash": "ea4ed603d27a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 145,
+				"line": 146,
 				"message": "Chained locator call in test: n8n.credentials.cards .getCredential('Global HTTP Header ...",
 				"hash": "05e7dd651e5e"
 			}
@@ -1518,7 +1472,7 @@
 		"tests/e2e/node-creator/categories.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 23,
+				"line": 25,
 				"message": "Chained locator call in test: n8n.canvas.nodeCreator.getCategoryItem('Triggers').locato...",
 				"hash": "7bf32888198a"
 			},
@@ -1548,7 +1502,7 @@
 			},
 			{
 				"rule": "selector-purity",
-				"line": 60,
+				"line": 61,
 				"message": "Chained locator call in test: n8n.canvas.nodeCreator.getCategoryItem('Triggers').locato...",
 				"hash": "7bf32888198a"
 			},
@@ -1562,73 +1516,73 @@
 		"tests/e2e/nodes/community-nodes.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 83,
+				"line": 84,
 				"message": "Direct page locator call: n8n.page.getByTestId('credentials-label').click()",
 				"hash": "b487b1272454"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 83,
+				"line": 84,
 				"message": "Direct page locator call: n8n.page.getByTestId('credentials-label')",
 				"hash": "c57d3abbea50"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 84,
+				"line": 85,
 				"message": "Direct page locator call: n8n.page.getByTestId('node-credentials-select-item-new')....",
 				"hash": "b9824deca284"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 84,
+				"line": 85,
 				"message": "Direct page locator call: n8n.page.getByTestId('node-credentials-select-item-new')",
 				"hash": "ba4a66294bfb"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 86,
+				"line": 87,
 				"message": "Direct page locator call: n8n.page.getByTestId('editCredential-modal')",
 				"hash": "2786a49972b3"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 98,
+				"line": 99,
 				"message": "Direct page locator call: n8n.page.getByTestId('credentials-label').click()",
 				"hash": "b487b1272454"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 98,
+				"line": 99,
 				"message": "Direct page locator call: n8n.page.getByTestId('credentials-label')",
 				"hash": "c57d3abbea50"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 99,
+				"line": 100,
 				"message": "Direct page locator call: n8n.page.getByTestId('node-credentials-select-item-new')....",
 				"hash": "b9824deca284"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 99,
+				"line": 100,
 				"message": "Direct page locator call: n8n.page.getByTestId('node-credentials-select-item-new')",
 				"hash": "ba4a66294bfb"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 101,
+				"line": 102,
 				"message": "Direct page locator call: n8n.page.getByTestId('editCredential-modal')",
 				"hash": "2786a49972b3"
 			},
 			{
 				"rule": "api-purity",
-				"line": 19,
+				"line": 20,
 				"message": "Raw API call detected: fetch(",
 				"hash": "b52df352569e"
 			},
 			{
 				"rule": "api-purity",
-				"line": 34,
+				"line": 35,
 				"message": "Raw API call detected: fetch(",
 				"hash": "b52df352569e"
 			}
@@ -1636,131 +1590,111 @@
 		"tests/e2e/nodes/form-trigger-node.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 63,
+				"line": 64,
 				"message": "Direct page locator call: n8n.page.getByRole('button', { name: 'Add Field Option' }...",
 				"hash": "c3629563dd24"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 63,
+				"line": 64,
 				"message": "Direct page locator call: n8n.page.getByRole('button', { name: 'Add Field Option' })",
 				"hash": "69e3d4b550e1"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 106,
+				"line": 107,
 				"message": "Direct page locator call: n8n.page.locator('text=/form-test\\\\/[a-f0-9-]+/')",
 				"hash": "ccdce08746cc"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 115,
+				"line": 116,
 				"message": "Chained locator call in test: formPage.getByLabel('What is your first name?')",
 				"hash": "1223d29492d9"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 116,
+				"line": 117,
 				"message": "Chained locator call in test: formPage.getByRole('button', { name: 'Submit' })",
 				"hash": "e4d7841ebb40"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 120,
+				"line": 121,
 				"message": "Chained locator call in test: formPage.getByLabel('What is your last name?')",
 				"hash": "cfc3f214f389"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 121,
+				"line": 122,
 				"message": "Chained locator call in test: formPage.getByRole('button', { name: 'Submit' })",
 				"hash": "e4d7841ebb40"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 124,
+				"line": 125,
 				"message": "Chained locator call in test: formPage.getByText('Your response has been recorded')",
 				"hash": "0e9a9b561cfa"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 197,
+				"line": 198,
 				"message": "Direct page locator call: n8n.page.locator('text=/form-test\\\\/[a-f0-9-]+/')",
 				"hash": "ccdce08746cc"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 206,
+				"line": 207,
 				"message": "Chained locator call in test: formPage.getByRole('button', { name: 'Submit' })",
 				"hash": "e4d7841ebb40"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 207,
+				"line": 208,
 				"message": "Chained locator call in test: formPage.getByText('This worked')",
 				"hash": "a0552602d3c9"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 311,
+				"line": 312,
 				"message": "Direct page locator call: n8n.page.locator('text=/form-test\\\\/[a-f0-9-]+/')",
 				"hash": "ccdce08746cc"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 320,
+				"line": 321,
 				"message": "Chained locator call in test: formPage.getByRole('button', { name: 'Submit' })",
 				"hash": "e4d7841ebb40"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 321,
+				"line": 322,
 				"message": "Chained locator call in test: formPage.getByText('Step 2')",
 				"hash": "94ffa2350779"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 324,
+				"line": 325,
 				"message": "Chained locator call in test: formPage.getByRole('button', { name: 'Submit' })",
 				"hash": "e4d7841ebb40"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 325,
+				"line": 326,
 				"message": "Chained locator call in test: formPage.getByText('This worked')",
 				"hash": "a0552602d3c9"
-			}
-		],
-		"tests/e2e/nodes/if-node.spec.ts": [
-			{
-				"rule": "selector-purity",
-				"line": 25,
-				"message": "Chained locator call in test: n8n.ndv.getFilterConditionLeft(FILTER_PARAM_NAME, 0).loca...",
-				"hash": "c3fc875effa7"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 26,
-				"message": "Chained locator call in test: n8n.ndv.getFilterConditionLeft(FILTER_PARAM_NAME, 1).loca...",
-				"hash": "5f2f690a0a6a"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 33,
-				"message": "Chained locator call in test: n8n.ndv.getFilterConditionLeft(FILTER_PARAM_NAME, 0).loca...",
-				"hash": "c3fc875effa7"
 			}
 		],
 		"tests/e2e/nodes/webhook.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 70,
+				"line": 71,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Response Code' }).c...",
 				"hash": "4ec8fd179f0d"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 70,
+				"line": 71,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Response Code' })",
 				"hash": "3f5a68018809"
 			}
@@ -1768,31 +1702,31 @@
 		"tests/e2e/projects/folders-basic.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 155,
+				"line": 156,
 				"message": "Chained locator call in test: n8n.modal.container.getByText(errorMessage, { exact: fals...",
 				"hash": "493ced26c9ed"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 159,
+				"line": 160,
 				"message": "Chained locator call in test: n8n.modal.container.getByText(emptyErrorMessage)",
 				"hash": "1a0616eac3d8"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 162,
+				"line": 163,
 				"message": "Chained locator call in test: n8n.modal.container.getByText(tooLongErrorMessage)",
 				"hash": "d7e82d2a75eb"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 165,
+				"line": 166,
 				"message": "Chained locator call in test: n8n.modal.container.getByText(dotsErrorMessage)",
 				"hash": "bbb98f3cbb44"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 181,
+				"line": 182,
 				"message": "Chained locator call in test: n8n.notifications .getNotificationByTitleOrContent(FOLDER...",
 				"hash": "ef7efad8acb2"
 			}
@@ -1800,73 +1734,73 @@
 		"tests/e2e/projects/project-settings.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 64,
+				"line": 67,
 				"message": "Direct page locator call: n8n.page.getByText('Project Updated Project Name saved su...",
 				"hash": "5c8bb96d8da1"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 84,
+				"line": 87,
 				"message": "Chained locator call in test: table.getByText('User')",
 				"hash": "35eb3e7e10a1"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 85,
+				"line": 88,
 				"message": "Chained locator call in test: table.getByText('Role')",
 				"hash": "598e22980502"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 88,
+				"line": 91,
 				"message": "Chained locator call in test: table.locator('tbody tr')",
 				"hash": "fdc278cf27e4"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 93,
+				"line": 96,
 				"message": "Chained locator call in test: ownerRow.getByTestId('project-member-role-dropdown')",
 				"hash": "c69f7e1bd77a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 109,
+				"line": 112,
 				"message": "Direct page locator call: n8n.page.locator('tbody tr').first()",
 				"hash": "c57a14994e07"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 109,
+				"line": 112,
 				"message": "Direct page locator call: n8n.page.locator('tbody tr')",
 				"hash": "48de3852588f"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 110,
+				"line": 113,
 				"message": "Chained locator call in test: currentUserRow.getByTestId('project-member-role-dropdown')",
 				"hash": "f1e1476c1fc9"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 113,
+				"line": 116,
 				"message": "Chained locator call in test: currentUserRow.getByText('Admin')",
 				"hash": "1927ce34d19a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 180,
+				"line": 183,
 				"message": "Direct page locator call: n8n.page.getByText('Danger zone')",
 				"hash": "58fee023d77a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 182,
+				"line": 185,
 				"message": "Direct page locator call: n8n.page.getByText( 'When deleting a project, you can als...",
 				"hash": "f2d055ed66a9"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 208,
+				"line": 211,
 				"message": "Direct page locator call: n8n.page.getByText('Project Persisted Project Name saved ...",
 				"hash": "0f573d3d200b"
 			}
@@ -1874,37 +1808,37 @@
 		"tests/e2e/projects/projects-move-resources.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 106,
+				"line": 107,
 				"message": "Chained locator call in test: n8n.resourceMoveModal.getProjectSelectCredential().locato...",
 				"hash": "e8eff63d49af"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 107,
+				"line": 108,
 				"message": "Direct page locator call: n8n.page.getByRole('option')",
 				"hash": "c58b0877f9a1"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 123,
-				"message": "Chained locator call in test: n8n.resourceMoveModal.getProjectSelectCredential().locato...",
-				"hash": "e8eff63d49af"
 			},
 			{
 				"rule": "selector-purity",
 				"line": 124,
-				"message": "Direct page locator call: n8n.page.getByRole('option')",
-				"hash": "c58b0877f9a1"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 140,
 				"message": "Chained locator call in test: n8n.resourceMoveModal.getProjectSelectCredential().locato...",
 				"hash": "e8eff63d49af"
 			},
 			{
 				"rule": "selector-purity",
+				"line": 125,
+				"message": "Direct page locator call: n8n.page.getByRole('option')",
+				"hash": "c58b0877f9a1"
+			},
+			{
+				"rule": "selector-purity",
 				"line": 141,
+				"message": "Chained locator call in test: n8n.resourceMoveModal.getProjectSelectCredential().locato...",
+				"hash": "e8eff63d49af"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 142,
 				"message": "Direct page locator call: n8n.page.getByRole('option')",
 				"hash": "c58b0877f9a1"
 			}
@@ -1912,49 +1846,49 @@
 		"tests/e2e/projects/projects.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 89,
+				"line": 90,
 				"message": "Chained locator call in test: n8n.workflows.cards.getWorkflow('My workflow').getByText(...",
 				"hash": "c5bffdc35ac3"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 165,
+				"line": 166,
 				"message": "Direct page locator call: subn8n.page.getByRole('heading', { name: 'My Sub-Workflow...",
 				"hash": "788ef93cfb62"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 165,
+				"line": 166,
 				"message": "Chained locator call in test: subn8n.page.getByRole('heading', { name: 'My Sub-Workflow...",
 				"hash": "9e664e14b0a8"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 170,
+				"line": 171,
 				"message": "Direct page locator call: subn8n.page.getByRole('heading', { name: 'Notion account' })",
 				"hash": "43671aca120d"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 170,
+				"line": 171,
 				"message": "Chained locator call in test: subn8n.page.getByRole('heading', { name: 'Notion account' })",
 				"hash": "c98e5c7b276b"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 210,
+				"line": 211,
 				"message": "Chained locator call in test: n8n.projectSettings.getIconPickerButton().locator('svg')",
 				"hash": "4342f0cc13b8"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 247,
+				"line": 248,
 				"message": "Direct page locator call: n8n.page.locator('body').click()",
 				"hash": "4484dbdcd879"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 247,
+				"line": 248,
 				"message": "Direct page locator call: n8n.page.locator('body')",
 				"hash": "6667df4502c4"
 			}
@@ -1962,25 +1896,25 @@
 		"tests/e2e/regression/ADO-2372-prevent-clipping-params.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 66,
-				"message": "Chained locator call in test: editor.locator('.cm-line')",
-				"hash": "1ac80885fc71"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 67,
-				"message": "Chained locator call in test: editor.locator('.cm-line')",
-				"hash": "1ac80885fc71"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 68,
-				"message": "Chained locator call in test: editor.locator('.cm-line')",
-				"hash": "1ac80885fc71"
-			},
-			{
-				"rule": "selector-purity",
 				"line": 69,
+				"message": "Chained locator call in test: editor.locator('.cm-line')",
+				"hash": "1ac80885fc71"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 70,
+				"message": "Chained locator call in test: editor.locator('.cm-line')",
+				"hash": "1ac80885fc71"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 71,
+				"message": "Chained locator call in test: editor.locator('.cm-line')",
+				"hash": "1ac80885fc71"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 72,
 				"message": "Chained locator call in test: editor.locator('.cm-line')",
 				"hash": "1ac80885fc71"
 			}
@@ -1988,25 +1922,25 @@
 		"tests/e2e/regression/AI-1401-sub-nodes-input-panel.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 23,
+				"line": 24,
 				"message": "Chained locator call in test: n8n.ndv.inputPanel.get().locator('[data-test-id*=\"input-s...",
 				"hash": "396dc4f1d5af"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 26,
+				"line": 27,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Edit Fields' })",
 				"hash": "c6c4cc5bf6c4"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 27,
+				"line": 28,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Manual Trigger' })",
 				"hash": "503597d4ef3e"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 28,
+				"line": 30,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'No Operation, do no...",
 				"hash": "7a16d85129d2"
 			}
@@ -2014,13 +1948,13 @@
 		"tests/e2e/regression/SUG-121-fields-reset-after-closing-ndv.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 25,
+				"line": 26,
 				"message": "Chained locator call in test: n8n.ndv.getParameterByLabel('JavaScript').getByRole('text...",
 				"hash": "f8105d6d3a8d"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 28,
+				"line": 29,
 				"message": "Chained locator call in test: n8n.ndv.getParameterByLabel('JavaScript').getByRole('text...",
 				"hash": "f8105d6d3a8d"
 			}
@@ -2084,25 +2018,25 @@
 		"tests/e2e/sharing/access-control.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 79,
+				"line": 83,
 				"message": "Chained locator call in test: adminN8n.credentials.credentialModal.getVisibleDropdown()...",
 				"hash": "466547047099"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 140,
+				"line": 144,
 				"message": "Chained locator call in test: credentialDropdown.getByText(testCredName)",
 				"hash": "88f241af5012"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 141,
+				"line": 145,
 				"message": "Chained locator call in test: credentialDropdown.getByText(devCredName)",
 				"hash": "7c1126e1a52a"
 			},
 			{
 				"rule": "api-purity",
-				"line": 105,
+				"line": 109,
 				"message": "Raw API call detected: request.get(",
 				"hash": "5128d500e46f"
 			}
@@ -2110,65 +2044,57 @@
 		"tests/e2e/sharing/credential-visibility.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 52,
+				"line": 53,
 				"message": "Chained locator call in test: credentialDropdown.getByText(testCredName)",
 				"hash": "88f241af5012"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 53,
+				"line": 54,
 				"message": "Chained locator call in test: credentialDropdown.getByText(personalCredName)",
 				"hash": "8a03b8f32fa8"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 54,
+				"line": 55,
 				"message": "Chained locator call in test: credentialDropdown.getByText(devCredName)",
 				"hash": "7c1126e1a52a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 96,
-				"message": "Chained locator call in test: credentialDropdown.getByText(ownerCredName)",
-				"hash": "7b09c1090b15"
-			},
-			{
-				"rule": "selector-purity",
 				"line": 97,
-				"message": "Chained locator call in test: credentialDropdown.getByText(memberCredName)",
-				"hash": "241866f0d4df"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 154,
-				"message": "Chained locator call in test: credentialDropdown.getByText(memberCredName)",
-				"hash": "241866f0d4df"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 155,
 				"message": "Chained locator call in test: credentialDropdown.getByText(ownerCredName)",
 				"hash": "7b09c1090b15"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 209,
+				"line": 98,
+				"message": "Chained locator call in test: credentialDropdown.getByText(memberCredName)",
+				"hash": "241866f0d4df"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 158,
+				"message": "Chained locator call in test: credentialDropdown.getByText(memberCredName)",
+				"hash": "241866f0d4df"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 159,
+				"message": "Chained locator call in test: credentialDropdown.getByText(ownerCredName)",
+				"hash": "7b09c1090b15"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 213,
 				"message": "Chained locator call in test: n8n.ndv.getVisiblePopper().locator('li')",
 				"hash": "eb4832404c9b"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 239,
+				"line": 243,
 				"message": "Chained locator call in test: n8n.ndv.getVisiblePopper().locator('li')",
 				"hash": "eb4832404c9b"
-			}
-		],
-		"tests/e2e/source-control/pull.spec.ts": [
-			{
-				"rule": "selector-purity",
-				"line": 95,
-				"message": "Chained locator call in test: n8n.canvas.tagsManagerModal.getTable().getByText('pull-te...",
-				"hash": "9cd079655a6b"
 			}
 		],
 		"tests/e2e/workflows/checklist/production-checklist.spec.ts": [
@@ -2230,133 +2156,133 @@
 		"tests/e2e/workflows/demo-diff.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 120,
+				"line": 121,
 				"message": "Direct page locator call: n8n.page.getByText('Waiting for workflow data...')",
 				"hash": "b6b8ed64d974"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 127,
+				"line": 128,
 				"message": "Direct page locator call: n8n.page.getByText('Waiting for workflow data...')",
 				"hash": "b6b8ed64d974"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 145,
+				"line": 146,
 				"message": "Direct page locator call: n8n.page.getByText('Waiting for workflow data...')",
 				"hash": "b6b8ed64d974"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 149,
+				"line": 150,
 				"message": "Direct page locator call: n8n.page.getByRole('heading', { name: /Test Workflow/, ex...",
 				"hash": "27a3f117a93a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 153,
+				"line": 154,
 				"message": "Direct page locator call: n8n.page.getByRole('button', { name: /Changes/ })",
 				"hash": "1daa8f688214"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 160,
+				"line": 161,
 				"message": "Direct page locator call: n8n.page.getByText('Waiting for workflow data...')",
 				"hash": "b6b8ed64d974"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 177,
+				"line": 178,
 				"message": "Direct page locator call: n8n.page.getByText('Waiting for workflow data...')",
 				"hash": "b6b8ed64d974"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 180,
+				"line": 181,
 				"message": "Direct page locator call: n8n.page.getByRole('heading', { name: 'Test Workflow - Af...",
 				"hash": "284153f6d798"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 187,
+				"line": 188,
 				"message": "Direct page locator call: n8n.page.getByText('Waiting for workflow data...')",
 				"hash": "b6b8ed64d974"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 204,
+				"line": 205,
 				"message": "Direct page locator call: n8n.page.getByText('Waiting for workflow data...')",
 				"hash": "b6b8ed64d974"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 207,
+				"line": 208,
 				"message": "Direct page locator call: n8n.page.getByRole('heading', { name: 'Test Workflow - Be...",
 				"hash": "dd7b576b2982"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 214,
+				"line": 215,
 				"message": "Direct page locator call: n8n.page.getByText('Waiting for workflow data...')",
 				"hash": "b6b8ed64d974"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 233,
+				"line": 234,
 				"message": "Direct page locator call: n8n.page.getByText('Waiting for workflow data...')",
 				"hash": "b6b8ed64d974"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 237,
+				"line": 238,
 				"message": "Direct page locator call: n8n.page.getByRole('heading', { name: /Test Workflow/, ex...",
 				"hash": "27a3f117a93a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 241,
+				"line": 242,
 				"message": "Direct page locator call: n8n.page.getByRole('button', { name: /Changes/ })",
 				"hash": "1daa8f688214"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 248,
+				"line": 249,
 				"message": "Direct page locator call: n8n.page.getByText('Waiting for workflow data...')",
 				"hash": "b6b8ed64d974"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 256,
+				"line": 257,
 				"message": "Direct page locator call: n8n.page.getByText('Waiting for workflow data...')",
 				"hash": "b6b8ed64d974"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 263,
+				"line": 264,
 				"message": "Direct page locator call: n8n.page.getByText('Waiting for workflow data...')",
 				"hash": "b6b8ed64d974"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 277,
+				"line": 278,
 				"message": "Direct page locator call: n8n.page.getByText('Waiting for workflow data...')",
 				"hash": "b6b8ed64d974"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 282,
+				"line": 283,
 				"message": "Direct page locator call: n8n.page.locator('body')",
 				"hash": "6667df4502c4"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 287,
+				"line": 288,
 				"message": "Direct page locator call: n8n.page.locator('body')",
 				"hash": "6667df4502c4"
 			},
 			{
 				"rule": "duplicate-logic",
-				"line": 117,
+				"line": 118,
 				"message": "Duplicate test logic: \"shows waiting state initially\" has identical structure to tests/e2e/ai/workflow-builder.spec.ts:\"should show Build with AI button on empty canvas\"",
 				"hash": "6cf55be1ebdb"
 			}
@@ -2364,13 +2290,13 @@
 		"tests/e2e/workflows/editor/canvas/canvas-nodes.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 28,
+				"line": 29,
 				"message": "Direct page locator call: n8n.page.getByText('Add Routing Rule').click()",
 				"hash": "bb9ccdaa6e0f"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 28,
+				"line": 29,
 				"message": "Direct page locator call: n8n.page.getByText('Add Routing Rule')",
 				"hash": "f13800d70ddd"
 			}
@@ -2398,37 +2324,37 @@
 		"tests/e2e/workflows/editor/code/code-node.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 28,
+				"line": 29,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Run Once for Each I...",
 				"hash": "354ddeafe76a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 28,
+				"line": 29,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Run Once for Each I...",
 				"hash": "354ddeafe76a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 35,
+				"line": 36,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Run Once for All It...",
 				"hash": "03087d1206ad"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 35,
+				"line": 36,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Run Once for All It...",
 				"hash": "03087d1206ad"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 50,
+				"line": 51,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Run Once for Each I...",
 				"hash": "354ddeafe76a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 50,
+				"line": 51,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Run Once for Each I...",
 				"hash": "354ddeafe76a"
 			}
@@ -2456,7 +2382,7 @@
 		"tests/e2e/workflows/editor/execution/inject-previous.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 59,
+				"line": 60,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.get().locator('[contenteditable=\"true...",
 				"hash": "cae3335d44be"
 			}
@@ -2518,19 +2444,19 @@
 		"tests/e2e/workflows/editor/expressions/transformation.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 19,
+				"line": 20,
 				"message": "Chained locator call in test: assignmentValue.locator('text=Expression')",
 				"hash": "398682465503"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 114,
+				"line": 115,
 				"message": "Chained locator call in test: n8n.ndv.getOutputDataContainer().locator('[class*=value_]')",
 				"hash": "78a1c969575d"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 134,
+				"line": 135,
 				"message": "Chained locator call in test: n8n.ndv.getOutputDataContainer().locator('[class*=value_]')",
 				"hash": "78a1c969575d"
 			}
@@ -2538,109 +2464,109 @@
 		"tests/e2e/workflows/editor/ndv/io-filter.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 32,
-				"message": "Chained locator call in test: pagination.locator('li')",
-				"hash": "5a7163c291f8"
-			},
-			{
-				"rule": "selector-purity",
 				"line": 33,
-				"message": "Chained locator call in test: n8n.ndv.outputPanel.getDataContainer().locator('mark')",
-				"hash": "fc731709a0e9"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 42,
-				"message": "Chained locator call in test: n8n.ndv.outputPanel.getDataContainer().locator('mark')",
-				"hash": "fc731709a0e9"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 46,
 				"message": "Chained locator call in test: pagination.locator('li')",
 				"hash": "5a7163c291f8"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 66,
+				"line": 34,
+				"message": "Chained locator call in test: n8n.ndv.outputPanel.getDataContainer().locator('mark')",
+				"hash": "fc731709a0e9"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 43,
+				"message": "Chained locator call in test: n8n.ndv.outputPanel.getDataContainer().locator('mark')",
+				"hash": "fc731709a0e9"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 47,
+				"message": "Chained locator call in test: pagination.locator('li')",
+				"hash": "5a7163c291f8"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 67,
 				"message": "Chained locator call in test: n8n.ndv.inputPanel.get().getByTestId('ndv-data-pagination')",
 				"hash": "1a869dd91e67"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 68,
+				"line": 70,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.get().getByTestId('ndv-data-pagination')",
 				"hash": "58e725977612"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 72,
-				"message": "Chained locator call in test: getInputPagination().locator('li')",
-				"hash": "5aa75994ab8d"
-			},
-			{
-				"rule": "selector-purity",
 				"line": 74,
-				"message": "Chained locator call in test: getOutputPagination().locator('li')",
-				"hash": "d452a5950767"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 81,
-				"message": "Chained locator call in test: getOutputPagination().locator('li')",
-				"hash": "d452a5950767"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 88,
-				"message": "Chained locator call in test: getOutputPagination().locator('li')",
-				"hash": "d452a5950767"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 92,
 				"message": "Chained locator call in test: getInputPagination().locator('li')",
 				"hash": "5aa75994ab8d"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 76,
+				"message": "Chained locator call in test: getOutputPagination().locator('li')",
+				"hash": "d452a5950767"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 83,
+				"message": "Chained locator call in test: getOutputPagination().locator('li')",
+				"hash": "d452a5950767"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 90,
+				"message": "Chained locator call in test: getOutputPagination().locator('li')",
+				"hash": "d452a5950767"
 			},
 			{
 				"rule": "selector-purity",
 				"line": 94,
-				"message": "Chained locator call in test: getOutputPagination().locator('li')",
-				"hash": "d452a5950767"
+				"message": "Chained locator call in test: getInputPagination().locator('li')",
+				"hash": "5aa75994ab8d"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 104,
-				"message": "Chained locator call in test: getInputPagination().locator('li')",
-				"hash": "5aa75994ab8d"
+				"line": 96,
+				"message": "Chained locator call in test: getOutputPagination().locator('li')",
+				"hash": "d452a5950767"
 			},
 			{
 				"rule": "selector-purity",
 				"line": 106,
+				"message": "Chained locator call in test: getInputPagination().locator('li')",
+				"hash": "5aa75994ab8d"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 108,
 				"message": "Chained locator call in test: getOutputPagination().locator('li')",
 				"hash": "d452a5950767"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 111,
+				"line": 113,
 				"message": "Chained locator call in test: getInputPagination().locator('li')",
 				"hash": "5aa75994ab8d"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 118,
-				"message": "Chained locator call in test: getInputPagination().locator('li')",
-				"hash": "5aa75994ab8d"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 124,
+				"line": 120,
 				"message": "Chained locator call in test: getInputPagination().locator('li')",
 				"hash": "5aa75994ab8d"
 			},
 			{
 				"rule": "selector-purity",
 				"line": 126,
+				"message": "Chained locator call in test: getInputPagination().locator('li')",
+				"hash": "5aa75994ab8d"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 128,
 				"message": "Chained locator call in test: getOutputPagination().locator('li')",
 				"hash": "d452a5950767"
 			}
@@ -2648,25 +2574,25 @@
 		"tests/e2e/workflows/editor/ndv/ndv-core.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 120,
+				"line": 121,
 				"message": "Chained locator call in test: n8n.ndv.getContainer().getByText('Webhook URLs').locator(...",
 				"hash": "15c9e3d9aeba"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 120,
+				"line": 121,
 				"message": "Chained locator call in test: n8n.ndv.getContainer().getByText('Webhook URLs')",
 				"hash": "9026e28e4f47"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 175,
+				"line": 178,
 				"message": "Chained locator call in test: n8n.ndv.getParameterInput('jsCode').locator('.cm-content')",
 				"hash": "b09a3f3d56fc"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 206,
+				"line": 209,
 				"message": "Chained locator call in test: n8n.ndv.getParameterInput('jsCode').locator('.cm-content')",
 				"hash": "b09a3f3d56fc"
 			}
@@ -2674,49 +2600,49 @@
 		"tests/e2e/workflows/editor/ndv/ndv-data-display.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 63,
+				"line": 64,
 				"message": "Chained locator call in test: objectValueItem.locator('.toggle')",
 				"hash": "45d8699925c6"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 82,
+				"line": 83,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.get().getByText('5 items')",
 				"hash": "beef6d951ce8"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 98,
+				"line": 99,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.get().getByText('26 items')",
 				"hash": "f1b1cc3c04b4"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 120,
+				"line": 121,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.getTableRow(1).locator('mark')",
 				"hash": "6212a0d5e5bc"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 135,
+				"line": 136,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.get().locator('[class*=\"active\"]')",
 				"hash": "ddd992a3778f"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 147,
+				"line": 148,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.getTableRow(1).locator('mark')",
 				"hash": "6212a0d5e5bc"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 151,
+				"line": 152,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.getDataContainer().locator('.json-data')",
 				"hash": "8c80e9607f84"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 254,
+				"line": 255,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel .get() .getByText('To search field va...",
 				"hash": "6bd1281071a1"
 			}
@@ -2724,13 +2650,13 @@
 		"tests/e2e/workflows/editor/ndv/ndv-parameters.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 119,
+				"line": 123,
 				"message": "Chained locator call in test: n8n.ndv.getResourceLocatorInput('documentId').locator('in...",
 				"hash": "a10387b2b4a5"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 177,
+				"line": 184,
 				"message": "Chained locator call in test: n8n.ndv.getAssignmentValue('assignments').getByText('Expr...",
 				"hash": "25491e82dd43"
 			}
@@ -2738,91 +2664,85 @@
 		"tests/e2e/workflows/editor/ndv/paired-item.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 95,
+				"line": 96,
 				"message": "Direct page locator call: n8n.page.locator('[data-test-id=\"hovering-item\"]')",
 				"hash": "170e68f7b7b7"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 101,
+				"line": 102,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Set1' }).click()",
 				"hash": "7363e0425bfb"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 101,
+				"line": 102,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Set1' })",
 				"hash": "7e6cc145ca37"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 105,
+				"line": 106,
 				"message": "Chained locator call in test: n8n.ndv.inputPanel.getTable().locator('text=1000')",
 				"hash": "d54ea49f3e0f"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 106,
+				"line": 108,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.get().locator('[data-test-id=\"hoverin...",
 				"hash": "6e9d8666bad6"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 113,
+				"line": 114,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Sort' }).click()",
 				"hash": "dab3a0c3f01f"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 113,
+				"line": 114,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Sort' })",
 				"hash": "57ea397df648"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 117,
+				"line": 118,
 				"message": "Chained locator call in test: n8n.ndv.inputPanel.getTable().locator('text=1111')",
 				"hash": "20de742a14d7"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 118,
+				"line": 120,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.get().locator('[data-test-id=\"hoverin...",
 				"hash": "6e9d8666bad6"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 197,
+				"line": 198,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.get().getByText('False Branch (2 item...",
 				"hash": "4ed4184926d5"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 221,
+				"line": 222,
 				"message": "Chained locator call in test: n8n.ndv.inputPanel.get().getByText('True Branch')",
 				"hash": "cc551456a986"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 228,
+				"line": 229,
 				"message": "Chained locator call in test: n8n.ndv.inputPanel.get().locator('[data-test-id=\"hovering...",
 				"hash": "8d39d87925b5"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 233,
-				"message": "Chained locator call in test: n8n.ndv.outputPanel.get().locator('[data-test-id=\"hoverin...",
-				"hash": "6e9d8666bad6"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 237,
+				"line": 238,
 				"message": "Chained locator call in test: n8n.ndv.inputPanel.get().getByText('False Branch')",
 				"hash": "dee1bac10eac"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 248,
+				"line": 250,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.get().locator('[data-test-id=\"hoverin...",
 				"hash": "6e9d8666bad6"
 			}
@@ -2912,7 +2832,7 @@
 		"tests/e2e/workflows/editor/ndv/schema-preview.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 15,
+				"line": 16,
 				"message": "Chained locator call in test: n8n.ndv.inputPanel.get().getByText('No input data')",
 				"hash": "89dc9850c2d6"
 			}
@@ -2920,19 +2840,19 @@
 		"tests/e2e/workflows/editor/subworkflows/debugging.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 42,
+				"line": 43,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.getTbodyCell(0, 0).locator('a')",
 				"hash": "11bb70e5e4f9"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 85,
+				"line": 90,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.getTbodyCell(0, 0).locator('a')",
 				"hash": "11bb70e5e4f9"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 99,
+				"line": 104,
 				"message": "Chained locator call in test: n8n.ndv.outputPanel.getTbodyCell(0, 0).locator('a')",
 				"hash": "11bb70e5e4f9"
 			}
@@ -2940,25 +2860,25 @@
 		"tests/e2e/workflows/editor/subworkflows/workflow-selector.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 62,
+				"line": 63,
 				"message": "Chained locator call in test: n8n.ndv.getResourceLocatorInput('workflowId').locator('in...",
 				"hash": "d4ee6d0058ed"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 68,
+				"line": 69,
 				"message": "Chained locator call in test: n8n.ndv.getResourceLocatorInput('workflowId').locator('a')",
 				"hash": "1cadf974d1a1"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 77,
+				"line": 78,
 				"message": "Chained locator call in test: n8n.ndv.getResourceLocatorModeSelector('workflowId').loca...",
 				"hash": "b893416c36ed"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 91,
+				"line": 92,
 				"message": "Chained locator call in test: addResourceItem.getByText(/Create a/)",
 				"hash": "f7f77ebf40c7"
 			}
@@ -2966,19 +2886,19 @@
 		"tests/e2e/workflows/editor/tags.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 63,
+				"line": 64,
 				"message": "Chained locator call in test: n8n.canvas.tagsManagerModal.getTable().getByText(tag1)",
 				"hash": "f31292c4e171"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 68,
+				"line": 69,
 				"message": "Chained locator call in test: n8n.canvas.tagsManagerModal.getTable().getByText(tag2)",
 				"hash": "20fbe08893cc"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 213,
+				"line": 215,
 				"message": "Chained locator call in test: n8n.canvas.getVisibleDropdown().locator('li')",
 				"hash": "4febc57392da"
 			}
@@ -3238,7 +3158,7 @@
 		"tests/e2e/workflows/templates/templates.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 246,
+				"line": 247,
 				"message": "Chained locator call in test: n8n.templates.getDescription().locator('img')",
 				"hash": "5f06d991a2b6"
 			}
@@ -3328,7 +3248,7 @@
 		"tests/e2e/auth/password-reset.spec.ts": [
 			{
 				"rule": "api-purity",
-				"line": 11,
+				"line": 12,
 				"message": "Raw API call detected: request.post(",
 				"hash": "fc24119a27f0"
 			}
@@ -3336,7 +3256,7 @@
 		"tests/e2e/building-blocks/workflow-entry-points.spec.ts": [
 			{
 				"rule": "api-purity",
-				"line": 39,
+				"line": 42,
 				"message": "Raw API call detected: request.post(",
 				"hash": "fc24119a27f0"
 			}
@@ -3344,13 +3264,21 @@
 		"tests/e2e/capabilities/proxy-server.spec.ts": [
 			{
 				"rule": "api-purity",
-				"line": 27,
+				"line": 28,
 				"message": "Raw API call detected: fetch(",
 				"hash": "b52df352569e"
 			},
 			{
 				"rule": "api-purity",
-				"line": 64,
+				"line": 65,
+				"message": "Raw API call detected: fetch(",
+				"hash": "b52df352569e"
+			}
+		],
+		"tests/e2e/credentials/crud.spec.ts": [
+			{
+				"rule": "api-purity",
+				"line": 299,
 				"message": "Raw API call detected: fetch(",
 				"hash": "b52df352569e"
 			}
@@ -3374,7 +3302,7 @@
 		"tests/e2e/sharing/workflow-sharing.spec.ts": [
 			{
 				"rule": "api-purity",
-				"line": 122,
+				"line": 123,
 				"message": "Raw API call detected: request.get(",
 				"hash": "5128d500e46f"
 			}
@@ -3382,25 +3310,25 @@
 		"tests/e2e/workflows/editor/subworkflows/subworkflow-version-resolution.spec.ts": [
 			{
 				"rule": "api-purity",
-				"line": 64,
+				"line": 65,
 				"message": "Raw API call detected: request.patch(",
 				"hash": "8b1d786219ad"
 			},
 			{
 				"rule": "api-purity",
-				"line": 116,
+				"line": 117,
 				"message": "Raw API call detected: request.post(",
 				"hash": "fc24119a27f0"
 			},
 			{
 				"rule": "api-purity",
-				"line": 145,
+				"line": 146,
 				"message": "Raw API call detected: request.patch(",
 				"hash": "8b1d786219ad"
 			},
 			{
 				"rule": "api-purity",
-				"line": 298,
+				"line": 299,
 				"message": "Raw API call detected: request.patch(",
 				"hash": "8b1d786219ad"
 			}
@@ -3424,7 +3352,7 @@
 		"tests/e2e/workflows/editor/canvas/actions.spec.ts": [
 			{
 				"rule": "duplicate-logic",
-				"line": 66,
+				"line": 69,
 				"message": "Duplicate test logic: \"should add disconnected node if nothing is selected\" has identical structure to tests/e2e/building-blocks/canvas-actions.spec.ts:\"should add disconnected node when nothing selected\"",
 				"hash": "5cda70c65afc"
 			}
@@ -3432,7 +3360,7 @@
 		"tests/e2e/chat-hub/chat-hub-chat-user.spec.ts": [
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 28,
+				"line": 29,
 				"message": "Direct page instantiation: new ChatHubChatPage(n8n.page)",
 				"hash": "4c6c3053ee95"
 			}
@@ -3440,25 +3368,25 @@
 		"tests/e2e/chat-hub/chat-hub-settings.spec.ts": [
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 14,
+				"line": 15,
 				"message": "Direct page instantiation: new ChatHubSettingsPage(n8n.page)",
 				"hash": "03642a3feb2b"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 39,
+				"line": 40,
 				"message": "Direct page instantiation: new ChatHubChatPage(memberN8n.page)",
 				"hash": "397d824f0d69"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 61,
+				"line": 62,
 				"message": "Direct page instantiation: new ChatHubSettingsPage(n8n.page)",
 				"hash": "03642a3feb2b"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 98,
+				"line": 99,
 				"message": "Direct page instantiation: new ChatHubChatPage(memberN8n.page)",
 				"hash": "397d824f0d69"
 			}
@@ -3466,7 +3394,7 @@
 		"tests/e2e/chat-hub/chat-hub-tools.spec.ts": [
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 16,
+				"line": 17,
 				"message": "Direct page instantiation: new ChatHubChatPage(n8n.page)",
 				"hash": "4c6c3053ee95"
 			}
@@ -3474,55 +3402,55 @@
 		"tests/e2e/chat-hub/chat-hub-workflow-agent.spec.ts": [
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 16,
+				"line": 17,
 				"message": "Direct page instantiation: new ChatHubWorkflowAgentsPage(n8n.page)",
 				"hash": "c9be1b5d1bc9"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 17,
+				"line": 18,
 				"message": "Direct page instantiation: new ChatHubChatPage(n8n.page)",
 				"hash": "4c6c3053ee95"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 35,
+				"line": 36,
 				"message": "Direct page instantiation: new CanvasPage(tab1)",
 				"hash": "57ca97b38297"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 36,
+				"line": 37,
 				"message": "Direct page instantiation: new NodeDetailsViewPage(tab1)",
 				"hash": "b2f3d965950b"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 58,
+				"line": 59,
 				"message": "Direct page instantiation: new CanvasPage(tab2)",
 				"hash": "0bd465646efa"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 59,
+				"line": 60,
 				"message": "Direct page instantiation: new NodeDetailsViewPage(tab2)",
 				"hash": "e3b9a2a545fd"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 84,
+				"line": 85,
 				"message": "Direct page instantiation: new ChatHubWorkflowAgentsPage(n8n.page)",
 				"hash": "c9be1b5d1bc9"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 89,
+				"line": 90,
 				"message": "Direct page instantiation: new ChatHubWorkflowAgentsPage(memberN8n.page)",
 				"hash": "13e61175005b"
 			},
 			{
 				"rule": "no-direct-page-instantiation",
-				"line": 107,
+				"line": 108,
 				"message": "Direct page instantiation: new ChatHubChatPage(memberN8n.page)",
 				"hash": "397d824f0d69"
 			}

--- a/packages/testing/playwright/pages/ChatHubPersonalAgentsPage.ts
+++ b/packages/testing/playwright/pages/ChatHubPersonalAgentsPage.ts
@@ -19,10 +19,10 @@ export class ChatHubPersonalAgentsPage extends BasePage {
 	}
 
 	getEditButtonAt(index: number): Locator {
-		return this.page.getByTestId('chat-agent-card').nth(index).getByTitle('Edit');
+		return this.getAgentCards().nth(index).getByTitle('Edit');
 	}
 
 	getMenuAt(index: number): Locator {
-		return this.page.getByTestId('chat-agent-card').nth(index).getByTitle('More options');
+		return this.getAgentCards().nth(index).getByTitle('More options');
 	}
 }

--- a/packages/testing/playwright/pages/TemplateCredentialSetupPage.ts
+++ b/packages/testing/playwright/pages/TemplateCredentialSetupPage.ts
@@ -43,9 +43,7 @@ export class TemplateCredentialSetupPage extends BasePage {
 	}
 
 	getSetupCredentialModalSteps(): Locator {
-		return this.page
-			.getByTestId('setup-workflow-credentials-modal')
-			.getByTestId('setup-credentials-form-step');
+		return this.getCanvasCredentialModal().getByTestId('setup-credentials-form-step');
 	}
 
 	getCreateCredentialButton(appName: string): Locator {

--- a/packages/testing/playwright/pages/WorkflowsPage.ts
+++ b/packages/testing/playwright/pages/WorkflowsPage.ts
@@ -20,8 +20,8 @@ export class WorkflowsPage extends BasePage {
 	}
 
 	async clearSearch() {
-		await this.clickByTestId('resources-list-search');
-		await this.page.getByTestId('resources-list-search').clear();
+		await this.getSearchBar().click();
+		await this.getSearchBar().clear();
 	}
 
 	getProjectName() {


### PR DESCRIPTION
## Summary
- Fix 11 deduplication violations across 3 page objects by reusing existing methods instead of repeating raw locators
- Regenerate janitor baseline (550 → 539 known violations)

### Changes
- **ChatHubPersonalAgentsPage**: `getEditButtonAt()` and `getMenuAt()` reuse `getAgentCards()`
- **TemplateCredentialSetupPage**: `getSetupCredentialModalSteps()` reuses `getCanvasCredentialModal()`
- **WorkflowsPage**: `clearSearch()` reuses `getSearchBar()`

## Test plan
- [x] `pnpm janitor` passes with no new violations
- [x] Pre-commit hooks pass (biome)

🤖 Generated with [Claude Code](https://claude.com/claude-code)