### PR TITLE
feat(core): Read from workflow_published_version for webhooks/triggers/pollers

### DIFF
--- a/packages/@n8n/db/src/entities/index.ts
+++ b/packages/@n8n/db/src/entities/index.ts
@@ -34,6 +34,7 @@ import { WorkflowDependency } from './workflow-dependency-entity';
 import { WorkflowEntity } from './workflow-entity';
 import { WorkflowHistory } from './workflow-history';
 import { WorkflowPublishHistory } from './workflow-publish-history';
+import { WorkflowPublishedVersion } from './workflow-published-version';
 import { WorkflowStatistics } from './workflow-statistics';
 import { WorkflowTagMapping } from './workflow-tag-mapping';
 
@@ -66,6 +67,7 @@ export {
 	FolderTagMapping,
 	AuthProviderSyncHistory,
 	WorkflowHistory,
+	WorkflowPublishedVersion,
 	WorkflowPublishHistory,
 	ExecutionData,
 	ExecutionMetadata,
@@ -105,6 +107,7 @@ export const entities = {
 	FolderTagMapping,
 	AuthProviderSyncHistory,
 	WorkflowHistory,
+	WorkflowPublishedVersion,
 	WorkflowPublishHistory,
 	ExecutionData,
 	ExecutionMetadata,

--- a/packages/@n8n/db/src/entities/workflow-published-version.ts
+++ b/packages/@n8n/db/src/entities/workflow-published-version.ts
@@ -1,0 +1,26 @@
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn, Relation } from '@n8n/typeorm';
+
+import { WithTimestamps } from './abstract-entity';
+import type { WorkflowEntity } from './workflow-entity';
+import type { WorkflowHistory } from './workflow-history';
+
+@Entity({ name: 'workflow_published_version' })
+export class WorkflowPublishedVersion extends WithTimestamps {
+	@PrimaryColumn({ type: 'varchar', length: 36 })
+	workflowId: string;
+
+	@Column({ type: 'varchar', length: 36 })
+	publishedVersionId: string;
+
+	@ManyToOne('WorkflowEntity', {
+		onDelete: 'CASCADE',
+	})
+	@JoinColumn({ name: 'workflowId' })
+	workflow: Relation<WorkflowEntity>;
+
+	@ManyToOne('WorkflowHistory', {
+		onDelete: 'CASCADE',
+	})
+	@JoinColumn({ name: 'publishedVersionId', referencedColumnName: 'versionId' })
+	publishedVersion: Relation<WorkflowHistory>;
+}

--- a/packages/@n8n/db/src/repositories/index.ts
+++ b/packages/@n8n/db/src/repositories/index.ts
@@ -33,6 +33,7 @@ export { WorkflowTagMappingRepository } from './workflow-tag-mapping.repository'
 export { SharedWorkflowRepository } from './shared-workflow.repository';
 export { SharedCredentialsRepository } from './shared-credentials.repository';
 export { WorkflowRepository } from './workflow.repository';
+export { WorkflowPublishedVersionRepository } from './workflow-published-version.repository';
 export { WorkflowPublishHistoryRepository } from './workflow-publish-history.repository';
 export {
 	WorkflowDependencyRepository,

--- a/packages/@n8n/db/src/repositories/workflow-published-version.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-published-version.repository.ts
@@ -1,0 +1,24 @@
+import { Service } from '@n8n/di';
+import { DataSource, Repository } from '@n8n/typeorm';
+
+import { WorkflowPublishedVersion } from '../entities';
+
+@Service()
+export class WorkflowPublishedVersionRepository extends Repository<WorkflowPublishedVersion> {
+	constructor(dataSource: DataSource) {
+		super(WorkflowPublishedVersion, dataSource.manager);
+	}
+
+	async setPublishedVersion(workflowId: string, publishedVersionId: string): Promise<void> {
+		await this.upsert({ workflowId, publishedVersionId }, ['workflowId']);
+	}
+
+	async removePublishedVersion(workflowId: string): Promise<void> {
+		await this.delete({ workflowId });
+	}
+
+	async getPublishedVersionId(workflowId: string): Promise<string | null> {
+		const record = await this.findOne({ where: { workflowId } });
+		return record?.publishedVersionId ?? null;
+	}
+}

--- a/packages/cli/src/__tests__/active-workflow-manager.test.ts
+++ b/packages/cli/src/__tests__/active-workflow-manager.test.ts
@@ -49,6 +49,8 @@ describe('ActiveWorkflowManager', () => {
 			mock(),
 			mock(),
 			mock(),
+			mock(), // globalConfig
+			mock(), // workflowPublishedVersionService
 		);
 	});
 
@@ -240,6 +242,8 @@ describe('ActiveWorkflowManager', () => {
 				mock(),
 				eventService,
 				mock(),
+				mock(), // globalConfig
+				mock(), // workflowPublishedVersionService
 			);
 		});
 

--- a/packages/cli/src/active-workflow-manager.ts
+++ b/packages/cli/src/active-workflow-manager.ts
@@ -6,7 +6,7 @@ import {
 	WORKFLOW_REACTIVATE_MAX_TIMEOUT,
 } from '@/constants';
 import { Logger } from '@n8n/backend-common';
-import { WorkflowsConfig } from '@n8n/config';
+import { GlobalConfig, WorkflowsConfig } from '@n8n/config';
 import type { WorkflowEntity, IWorkflowDb } from '@n8n/db';
 import { WorkflowRepository } from '@n8n/db';
 import { OnLeaderStepdown, OnLeaderTakeover, OnPubSubEvent, OnShutdown } from '@n8n/decorators';
@@ -62,6 +62,7 @@ import * as WebhookHelpers from '@/webhooks/webhook-helpers';
 import { WebhookService } from '@/webhooks/webhook.service';
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
 import { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
+import { WorkflowPublishedVersionService } from '@/workflows/workflow-published-version.service';
 import { WorkflowStaticDataService } from '@/workflows/workflow-static-data.service';
 import { formatWorkflow } from '@/workflows/workflow.formatter';
 
@@ -96,6 +97,8 @@ export class ActiveWorkflowManager {
 		private readonly push: Push,
 		private readonly eventService: EventService,
 		private readonly storageConfig: StorageConfig,
+		private readonly globalConfig: GlobalConfig,
+		private readonly workflowPublishedVersionService: WorkflowPublishedVersionService,
 	) {
 		this.logger = this.logger.scoped(['workflow-activation']);
 	}
@@ -247,13 +250,25 @@ export class ActiveWorkflowManager {
 			throw new UnexpectedError('Could not find workflow', { extra: { workflowId } });
 		}
 
-		if (!workflowData.activeVersion) {
-			throw new UnexpectedError('Active version not found for workflow', {
-				extra: { workflowId },
-			});
-		}
+		let nodes: INode[];
+		let connections: IWorkflowBase['connections'];
 
-		const { nodes, connections } = workflowData.activeVersion;
+		if (this.globalConfig.workflows.useWorkflowPublicationService) {
+			const published = await this.workflowPublishedVersionService.getPublishedVersion(workflowId);
+			if (!published) {
+				throw new UnexpectedError('Published version not found for workflow', {
+					extra: { workflowId },
+				});
+			}
+			({ nodes, connections } = published);
+		} else {
+			if (!workflowData.activeVersion) {
+				throw new UnexpectedError('Active version not found for workflow', {
+					extra: { workflowId },
+				});
+			}
+			({ nodes, connections } = workflowData.activeVersion);
+		}
 
 		const workflow = new Workflow({
 			id: workflowId,
@@ -622,23 +637,43 @@ export class ActiveWorkflowManager {
 		const shouldAddTriggersAndPollers = this.shouldAddTriggersAndPollers();
 
 		try {
-			if (['init', 'leadershipChange'].includes(activationMode) && !dbWorkflow.activeVersion) {
-				this.logger.debug(
-					`Skipping workflow ${formatWorkflow(dbWorkflow)} as it is no longer active`,
-					{ workflowId: dbWorkflow.id },
+			let nodes: INode[];
+			let connections: IWorkflowBase['connections'];
+
+			if (this.globalConfig.workflows.useWorkflowPublicationService) {
+				const published = await this.workflowPublishedVersionService.getPublishedVersion(
+					dbWorkflow.id,
 				);
+				if (!published) {
+					if (['init', 'leadershipChange'].includes(activationMode)) {
+						this.logger.debug(
+							`Skipping workflow ${formatWorkflow(dbWorkflow)} as it has no published version`,
+							{ workflowId: dbWorkflow.id },
+						);
+						return added;
+					}
+					throw new UnexpectedError('Published version not found for workflow', {
+						extra: { workflowId: dbWorkflow.id },
+					});
+				}
+				({ nodes, connections } = published);
+			} else {
+				if (['init', 'leadershipChange'].includes(activationMode) && !dbWorkflow.activeVersion) {
+					this.logger.debug(
+						`Skipping workflow ${formatWorkflow(dbWorkflow)} as it is no longer active`,
+						{ workflowId: dbWorkflow.id },
+					);
+					return added;
+				}
 
-				return added;
+				if (!dbWorkflow.activeVersion) {
+					throw new UnexpectedError('Active version not found for workflow', {
+						extra: { workflowId: dbWorkflow.id },
+					});
+				}
+				({ nodes, connections } = dbWorkflow.activeVersion);
 			}
 
-			// Get workflow data from the active version
-			if (!dbWorkflow.activeVersion) {
-				throw new UnexpectedError('Active version not found for workflow', {
-					extra: { workflowId: dbWorkflow.id },
-				});
-			}
-
-			const { nodes, connections } = dbWorkflow.activeVersion;
 			dbWorkflow.nodes = nodes;
 			dbWorkflow.connections = connections;
 

--- a/packages/cli/src/webhooks/__tests__/live-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/live-webhooks.test.ts
@@ -36,9 +36,11 @@ describe('LiveWebhooks', () => {
 		jest.clearAllMocks();
 		liveWebhooks = new LiveWebhooks(
 			mockLogger(),
+			mock(), // globalConfig
 			nodeTypes,
 			webhookService,
 			workflowRepository,
+			mock(), // workflowPublishedVersionService
 			workflowStaticDataService,
 		);
 

--- a/packages/cli/src/webhooks/live-webhooks.ts
+++ b/packages/cli/src/webhooks/live-webhooks.ts
@@ -1,4 +1,5 @@
 import { Logger } from '@n8n/backend-common';
+import { GlobalConfig } from '@n8n/config';
 import { WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 import type { Response } from 'express';
@@ -20,6 +21,7 @@ import { NodeTypes } from '@/node-types';
 import * as WebhookHelpers from '@/webhooks/webhook-helpers';
 import { WebhookService } from '@/webhooks/webhook.service';
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
+import { WorkflowPublishedVersionService } from '@/workflows/workflow-published-version.service';
 import { WorkflowStaticDataService } from '@/workflows/workflow-static-data.service';
 
 /**
@@ -31,9 +33,11 @@ import { WorkflowStaticDataService } from '@/workflows/workflow-static-data.serv
 export class LiveWebhooks implements IWebhookManager {
 	constructor(
 		private readonly logger: Logger,
+		private readonly globalConfig: GlobalConfig,
 		private readonly nodeTypes: NodeTypes,
 		private readonly webhookService: WebhookService,
 		private readonly workflowRepository: WorkflowRepository,
+		private readonly workflowPublishedVersionService: WorkflowPublishedVersionService,
 		private readonly workflowStaticDataService: WorkflowStaticDataService,
 	) {}
 
@@ -106,15 +110,29 @@ export class LiveWebhooks implements IWebhookManager {
 			throw new NotFoundError(`Could not find workflow with id "${webhook.workflowId}"`);
 		}
 
-		if (!workflowData.activeVersion) {
-			throw new NotFoundError(
-				`Active version not found for workflow with id "${webhook.workflowId}"`,
+		let nodes: INode[];
+		let connections: IWorkflowBase['connections'];
+
+		if (this.globalConfig.workflows.useWorkflowPublicationService) {
+			const published = await this.workflowPublishedVersionService.getPublishedVersion(
+				webhook.workflowId,
 			);
+			if (!published) {
+				throw new NotFoundError(
+					`Published version not found for workflow with id "${webhook.workflowId}"`,
+				);
+			}
+			({ nodes, connections } = published);
+		} else {
+			if (!workflowData.activeVersion) {
+				throw new NotFoundError(
+					`Active version not found for workflow with id "${webhook.workflowId}"`,
+				);
+			}
+			({ nodes, connections } = workflowData.activeVersion);
 		}
 
-		const { nodes, connections } = workflowData.activeVersion;
-
-		// Create a clean workflowData object with only activeVersion nodes/connections
+		// Create a clean workflowData object with only published nodes/connections
 		// This prevents any downstream code from accidentally using the draft nodes
 		const activeWorkflowData: IWorkflowBase = {
 			...workflowData,

--- a/packages/cli/src/workflows/__tests__/workflow-published-version.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-published-version.service.test.ts
@@ -1,0 +1,88 @@
+import { mockLogger } from '@n8n/backend-test-utils';
+import type {
+	WorkflowPublishedVersionRepository,
+	WorkflowHistoryRepository,
+	WorkflowPublishedVersion,
+	WorkflowHistory,
+} from '@n8n/db';
+import { mock } from 'jest-mock-extended';
+import type { INode, IConnections } from 'n8n-workflow';
+
+import { WorkflowPublishedVersionService } from '@/workflows/workflow-published-version.service';
+
+describe('WorkflowPublishedVersionService', () => {
+	const workflowPublishedVersionRepository = mock<WorkflowPublishedVersionRepository>();
+	const workflowHistoryRepository = mock<WorkflowHistoryRepository>();
+
+	const service = new WorkflowPublishedVersionService(
+		mockLogger(),
+		workflowPublishedVersionRepository,
+		workflowHistoryRepository,
+	);
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('getPublishedVersion', () => {
+		const workflowId = 'workflow-1';
+		const publishedVersionId = 'version-1';
+
+		const nodes: INode[] = [
+			{
+				id: 'node-1',
+				name: 'Trigger',
+				type: 'n8n-nodes-base.manualTrigger',
+				typeVersion: 1,
+				position: [0, 0],
+				parameters: {},
+			},
+		];
+
+		const connections: IConnections = {};
+
+		it('should return published version data when it exists', async () => {
+			workflowPublishedVersionRepository.getPublishedVersionId.mockResolvedValue(
+				publishedVersionId,
+			);
+			workflowHistoryRepository.findOne.mockResolvedValue(
+				mock<WorkflowHistory>({
+					versionId: publishedVersionId,
+					nodes,
+					connections,
+				}),
+			);
+
+			const result = await service.getPublishedVersion(workflowId);
+
+			expect(result).toEqual({ versionId: publishedVersionId, nodes, connections });
+			expect(workflowPublishedVersionRepository.getPublishedVersionId).toHaveBeenCalledWith(
+				workflowId,
+			);
+			expect(workflowHistoryRepository.findOne).toHaveBeenCalledWith({
+				where: { versionId: publishedVersionId, workflowId },
+				select: ['versionId', 'nodes', 'connections'],
+			});
+		});
+
+		it('should return null when no published version record exists', async () => {
+			workflowPublishedVersionRepository.getPublishedVersionId.mockResolvedValue(null);
+
+			const result = await service.getPublishedVersion(workflowId);
+
+			expect(result).toBeNull();
+			expect(workflowHistoryRepository.findOne).not.toHaveBeenCalled();
+		});
+
+		it('should return null when history entry is missing', async () => {
+			workflowPublishedVersionRepository.getPublishedVersionId.mockResolvedValue(
+				publishedVersionId,
+			);
+			workflowHistoryRepository.findOne.mockResolvedValue(null);
+
+			const result = await service.getPublishedVersion(workflowId);
+
+			expect(result).toBeNull();
+		});
+	});
+});

--- a/packages/cli/src/workflows/__tests__/workflow.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow.service.test.ts
@@ -53,6 +53,7 @@ describe('WorkflowService', () => {
 				mock(), // globalConfig
 				mock(), // folderRepository
 				mock(), // workflowFinderService
+				mock(), // workflowPublishedVersionRepository
 				mock(), // workflowPublishHistoryRepository
 				mock(), // workflowValidationService
 				mock(), // nodeTypes
@@ -190,6 +191,7 @@ describe('WorkflowService', () => {
 				mock(), // globalConfig
 				mock(), // folderRepository
 				workflowFinderServiceMock, // workflowFinderService
+				mock(), // workflowPublishedVersionRepository
 				mock(), // workflowPublishHistoryRepository
 				mock(), // workflowValidationService
 				mock(), // nodeTypes

--- a/packages/cli/src/workflows/workflow-published-version.service.ts
+++ b/packages/cli/src/workflows/workflow-published-version.service.ts
@@ -1,0 +1,47 @@
+import { Logger } from '@n8n/backend-common';
+import { WorkflowPublishedVersionRepository, WorkflowHistoryRepository } from '@n8n/db';
+import { Service } from '@n8n/di';
+import type { INode, IConnections } from 'n8n-workflow';
+
+export interface PublishedWorkflowVersion {
+	versionId: string;
+	nodes: INode[];
+	connections: IConnections;
+}
+
+@Service()
+export class WorkflowPublishedVersionService {
+	constructor(
+		private readonly logger: Logger,
+		private readonly workflowPublishedVersionRepository: WorkflowPublishedVersionRepository,
+		private readonly workflowHistoryRepository: WorkflowHistoryRepository,
+	) {}
+
+	async getPublishedVersion(workflowId: string): Promise<PublishedWorkflowVersion | null> {
+		const publishedVersionId =
+			await this.workflowPublishedVersionRepository.getPublishedVersionId(workflowId);
+
+		if (!publishedVersionId) {
+			return null;
+		}
+
+		const history = await this.workflowHistoryRepository.findOne({
+			where: { versionId: publishedVersionId, workflowId },
+			select: ['versionId', 'nodes', 'connections'],
+		});
+
+		if (!history) {
+			this.logger.warn('Published version record points to missing workflow history entry', {
+				workflowId,
+				publishedVersionId,
+			});
+			return null;
+		}
+
+		return {
+			versionId: history.versionId,
+			nodes: history.nodes,
+			connections: history.connections,
+		};
+	}
+}

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -545,6 +545,9 @@ export class WorkflowService {
 			if (didPublish) {
 				assert(workflow.activeVersionId !== null);
 
+				// Temporary: In the future, the workflow publication service will
+				// manage this mapping. We set it here for now to support incremental
+				// development and testing.
 				if (this.globalConfig.workflows.useWorkflowPublicationService) {
 					await this.workflowPublishedVersionRepository.setPublishedVersion(
 						workflowId,
@@ -792,6 +795,7 @@ export class WorkflowService {
 
 		const deactivatedVersionId = workflow.activeVersionId;
 
+		// Temporary: will be removed when the workflow publication service manages this.
 		if (this.globalConfig.workflows.useWorkflowPublicationService) {
 			await this.workflowPublishedVersionRepository.removePublishedVersion(workflowId);
 		}
@@ -892,6 +896,7 @@ export class WorkflowService {
 		if (workflow.activeVersionId !== null) {
 			await this.activeWorkflowManager.remove(workflowId);
 
+			// Temporary: will be removed when the workflow publication service manages this.
 			if (this.globalConfig.workflows.useWorkflowPublicationService) {
 				await this.workflowPublishedVersionRepository.removePublishedVersion(workflowId);
 			}

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -15,6 +15,7 @@ import {
 	WorkflowTagMappingRepository,
 	SharedWorkflowRepository,
 	WorkflowRepository,
+	WorkflowPublishedVersionRepository,
 	WorkflowPublishHistoryRepository,
 	ProjectRepository,
 } from '@n8n/db';
@@ -87,6 +88,7 @@ export class WorkflowService {
 		private readonly globalConfig: GlobalConfig,
 		private readonly folderRepository: FolderRepository,
 		private readonly workflowFinderService: WorkflowFinderService,
+		private readonly workflowPublishedVersionRepository: WorkflowPublishedVersionRepository,
 		private readonly workflowPublishHistoryRepository: WorkflowPublishHistoryRepository,
 		private readonly workflowValidationService: WorkflowValidationService,
 		private readonly nodeTypes: NodeTypes,
@@ -542,6 +544,14 @@ export class WorkflowService {
 		} finally {
 			if (didPublish) {
 				assert(workflow.activeVersionId !== null);
+
+				if (this.globalConfig.workflows.useWorkflowPublicationService) {
+					await this.workflowPublishedVersionRepository.setPublishedVersion(
+						workflowId,
+						workflow.activeVersionId,
+					);
+				}
+
 				await this.workflowPublishHistoryRepository.addRecord({
 					workflowId,
 					versionId: workflow.activeVersionId,
@@ -782,6 +792,10 @@ export class WorkflowService {
 
 		const deactivatedVersionId = workflow.activeVersionId;
 
+		if (this.globalConfig.workflows.useWorkflowPublicationService) {
+			await this.workflowPublishedVersionRepository.removePublishedVersion(workflowId);
+		}
+
 		await this.workflowPublishHistoryRepository.addRecord({
 			workflowId,
 			versionId: deactivatedVersionId,
@@ -877,6 +891,11 @@ export class WorkflowService {
 
 		if (workflow.activeVersionId !== null) {
 			await this.activeWorkflowManager.remove(workflowId);
+
+			if (this.globalConfig.workflows.useWorkflowPublicationService) {
+				await this.workflowPublishedVersionRepository.removePublishedVersion(workflowId);
+			}
+
 			await this.workflowPublishHistoryRepository.addRecord({
 				workflowId,
 				versionId: workflow.activeVersionId,

--- a/packages/cli/test/integration/workflows/workflow.service.test.ts
+++ b/packages/cli/test/integration/workflows/workflow.service.test.ts
@@ -507,7 +507,6 @@ describe('workflow_published_version table population', () => {
 			const publishedVersion = await workflowPublishedVersionRepository.findOne({
 				where: { workflowId: workflow.id },
 			});
-			expect(publishedVersion).not.toBeNull();
 			expect(publishedVersion?.publishedVersionId).toBe(workflow.versionId);
 		});
 

--- a/packages/cli/test/integration/workflows/workflow.service.test.ts
+++ b/packages/cli/test/integration/workflows/workflow.service.test.ts
@@ -11,6 +11,7 @@ import { GlobalConfig } from '@n8n/config';
 import {
 	SharedWorkflowRepository,
 	type WorkflowEntity,
+	WorkflowPublishedVersionRepository,
 	WorkflowPublishHistoryRepository,
 	WorkflowRepository,
 	ProjectRepository,
@@ -40,6 +41,7 @@ import { WebhookService } from '@/webhooks/webhook.service';
 let globalConfig: GlobalConfig;
 let workflowRepository: WorkflowRepository;
 let workflowService: WorkflowService;
+let workflowPublishedVersionRepository: WorkflowPublishedVersionRepository;
 let workflowPublishHistoryRepository: WorkflowPublishHistoryRepository;
 let workflowHistoryService: WorkflowHistoryService;
 const activeWorkflowManager = mockInstance(ActiveWorkflowManager);
@@ -54,6 +56,7 @@ beforeAll(async () => {
 
 	globalConfig = Container.get(GlobalConfig);
 	workflowRepository = Container.get(WorkflowRepository);
+	workflowPublishedVersionRepository = Container.get(WorkflowPublishedVersionRepository);
 	workflowPublishHistoryRepository = Container.get(WorkflowPublishHistoryRepository);
 	workflowHistoryService = Container.get(WorkflowHistoryService);
 	workflowService = new WorkflowService(
@@ -74,6 +77,7 @@ beforeAll(async () => {
 		globalConfig,
 		mock(),
 		Container.get(WorkflowFinderService),
+		workflowPublishedVersionRepository,
 		workflowPublishHistoryRepository,
 		workflowValidationService,
 		nodeTypes,
@@ -94,6 +98,7 @@ afterEach(async () => {
 	await testDb.truncate([
 		'SharedWorkflow',
 		'ProjectRelation',
+		'WorkflowPublishedVersion',
 		'WorkflowEntity',
 		'WorkflowHistory',
 		'WorkflowPublishHistory',
@@ -480,6 +485,108 @@ describe('deactivateWorkflow()', () => {
 		const workflowAfter = await workflowRepository.findOne({ where: { id: workflow.id } });
 		expect(workflowAfter?.active).toBe(true);
 		expect(workflowAfter?.activeVersionId).toBe(workflow.activeVersionId);
+	});
+});
+
+describe('workflow_published_version table population', () => {
+	describe('when feature flag is enabled', () => {
+		beforeEach(() => {
+			globalConfig.workflows.useWorkflowPublicationService = true;
+		});
+
+		afterEach(() => {
+			globalConfig.workflows.useWorkflowPublicationService = false;
+		});
+
+		test('should write to workflow_published_version on activation', async () => {
+			const owner = await createOwner();
+			const workflow = await createWorkflowWithHistory({}, owner);
+
+			await workflowService.activateWorkflow(owner, workflow.id);
+
+			const publishedVersion = await workflowPublishedVersionRepository.findOne({
+				where: { workflowId: workflow.id },
+			});
+			expect(publishedVersion).not.toBeNull();
+			expect(publishedVersion?.publishedVersionId).toBe(workflow.versionId);
+		});
+
+		test('should update workflow_published_version when activating a new version', async () => {
+			const owner = await createOwner();
+			const workflow = await createWorkflowWithHistory({}, owner);
+
+			await workflowService.activateWorkflow(owner, workflow.id);
+
+			const newVersionId = uuid();
+			await createWorkflowHistoryItem(workflow.id, { versionId: newVersionId });
+
+			await workflowService.activateWorkflow(owner, workflow.id, {
+				versionId: newVersionId,
+			});
+
+			const publishedVersion = await workflowPublishedVersionRepository.findOne({
+				where: { workflowId: workflow.id },
+			});
+			expect(publishedVersion?.publishedVersionId).toBe(newVersionId);
+		});
+
+		test('should remove workflow_published_version on deactivation', async () => {
+			const owner = await createOwner();
+			const workflow = await createWorkflowWithHistory({}, owner);
+
+			await workflowService.activateWorkflow(owner, workflow.id);
+
+			await workflowService.deactivateWorkflow(owner, workflow.id);
+
+			const publishedVersion = await workflowPublishedVersionRepository.findOne({
+				where: { workflowId: workflow.id },
+			});
+			expect(publishedVersion).toBeNull();
+		});
+
+		test('should remove workflow_published_version on archive', async () => {
+			const owner = await createOwner();
+			const workflow = await createWorkflowWithHistory({}, owner);
+
+			await workflowService.activateWorkflow(owner, workflow.id);
+
+			const publishedVersionBefore = await workflowPublishedVersionRepository.findOne({
+				where: { workflowId: workflow.id },
+			});
+			expect(publishedVersionBefore).not.toBeNull();
+
+			await workflowService.archive(owner, workflow.id);
+
+			const publishedVersionAfter = await workflowPublishedVersionRepository.findOne({
+				where: { workflowId: workflow.id },
+			});
+			expect(publishedVersionAfter).toBeNull();
+		});
+	});
+
+	describe('when feature flag is disabled', () => {
+		test('should not write to workflow_published_version on activation', async () => {
+			const owner = await createOwner();
+			const workflow = await createWorkflowWithHistory({}, owner);
+
+			await workflowService.activateWorkflow(owner, workflow.id);
+
+			const publishedVersion = await workflowPublishedVersionRepository.findOne({
+				where: { workflowId: workflow.id },
+			});
+			expect(publishedVersion).toBeNull();
+		});
+
+		test('should not write to workflow_published_version on deactivation', async () => {
+			const owner = await createOwner();
+			const workflow = await createWorkflowWithHistory({}, owner);
+
+			await workflowService.activateWorkflow(owner, workflow.id);
+			await workflowService.deactivateWorkflow(owner, workflow.id);
+
+			const count = await workflowPublishedVersionRepository.count();
+			expect(count).toBe(0);
+		});
 	});
 });
 


### PR DESCRIPTION
## Summary
- Introduces `WorkflowPublishedVersionService` with a clean key-value lookup interface (`getPublishedVersion(workflowId) → {versionId, nodes, connections}`) designed to support caching in a future PR
- Behind the `N8N_USE_WORKFLOW_PUBLICATION_SERVICE` feature flag, webhooks (`LiveWebhooks`), triggers, and pollers (`ActiveWorkflowManager`) read version data from the `workflow_published_version` table instead of the `activeVersion` relation
- No-op when the flag is off — existing behavior is unchanged

## Related Linear ticket(s)
https://linear.app/n8n/issue/CAT-2191

## Review / Merge checklist
- [x] Unit tests for `WorkflowPublishedVersionService` (3 tests)
- [x] Existing tests updated and passing
- [x] Typecheck and lint pass
- [x] All changes gated behind feature flag

> **Note:** This PR targets the CAT-2192 branch so the diff only shows changes from this ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)