### PR TITLE
test: Fix selector-purity violations in Playwright tests (no-changelog)

### DIFF
--- a/packages/testing/playwright/.janitor-baseline.json
+++ b/packages/testing/playwright/.janitor-baseline.json
@@ -1,7 +1,7 @@
 {
 	"version": 1,
-	"generated": "2026-03-10T15:03:43.108Z",
-	"totalViolations": 539,
+	"generated": "2026-03-10T16:33:25.292Z",
+	"totalViolations": 523,
 	"violations": {
 		"pages/AIAssistantPage.ts": [
 			{
@@ -234,19 +234,7 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 157,
-				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "5244a408a8df"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 180,
-				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "5244a408a8df"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 184,
+				"line": 161,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
@@ -264,61 +252,49 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 200,
+				"line": 196,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 221,
+				"line": 204,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 239,
+				"line": 212,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 243,
+				"line": 233,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 253,
+				"line": 255,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 262,
+				"line": 259,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 270,
-				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "5244a408a8df"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 274,
+				"line": 269,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
 				"line": 278,
-				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "5244a408a8df"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 282,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
@@ -360,6 +336,18 @@
 			},
 			{
 				"rule": "scope-lockdown",
+				"line": 310,
+				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "5244a408a8df"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 314,
+				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "5244a408a8df"
+			},
+			{
+				"rule": "scope-lockdown",
 				"line": 318,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
@@ -372,55 +360,49 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 326,
-				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "5244a408a8df"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 330,
-				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "5244a408a8df"
-			},
-			{
-				"rule": "scope-lockdown",
 				"line": 334,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 340,
+				"line": 338,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 360,
+				"line": 342,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 366,
+				"line": 346,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 377,
+				"line": 350,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 385,
+				"line": 356,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 389,
+				"line": 376,
+				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "5244a408a8df"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 382,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
@@ -432,91 +414,91 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 397,
+				"line": 401,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 425,
+				"line": 405,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 429,
+				"line": 409,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 429,
+				"line": 413,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 433,
+				"line": 441,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 437,
+				"line": 445,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 455,
+				"line": 445,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 459,
+				"line": 449,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 459,
+				"line": 453,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 470,
+				"line": 471,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 479,
+				"line": 475,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 510,
+				"line": 475,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 520,
+				"line": 486,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 521,
+				"line": 495,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 526,
+				"line": 501,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
@@ -528,7 +510,13 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 542,
+				"line": 540,
+				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "5244a408a8df"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 541,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
@@ -540,25 +528,25 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 565,
+				"line": 550,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 571,
+				"line": 562,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 583,
+				"line": 566,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 587,
+				"line": 585,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
@@ -570,19 +558,7 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 595,
-				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "5244a408a8df"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 595,
-				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "5244a408a8df"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 599,
+				"line": 603,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
@@ -606,13 +582,19 @@
 			},
 			{
 				"rule": "scope-lockdown",
+				"line": 615,
+				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "5244a408a8df"
+			},
+			{
+				"rule": "scope-lockdown",
 				"line": 619,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 623,
+				"line": 627,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
@@ -630,127 +612,121 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 661,
+				"line": 639,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 697,
+				"line": 643,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 701,
+				"line": 651,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 706,
+				"line": 655,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 711,
+				"line": 681,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 715,
+				"line": 717,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 751,
+				"line": 721,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 755,
+				"line": 726,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 755,
+				"line": 731,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 759,
+				"line": 735,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 765,
+				"line": 771,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 793,
+				"line": 775,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 797,
+				"line": 775,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 801,
+				"line": 779,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 805,
+				"line": 785,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 810,
+				"line": 813,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 816,
+				"line": 817,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 820,
+				"line": 821,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 820,
+				"line": 825,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 828,
-				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "5244a408a8df"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 832,
+				"line": 830,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
@@ -762,13 +738,43 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 872,
+				"line": 840,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 876,
+				"line": 840,
+				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "5244a408a8df"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 848,
+				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "5244a408a8df"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 852,
+				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "5244a408a8df"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 856,
+				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "5244a408a8df"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 892,
+				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "5244a408a8df"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 896,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "5244a408a8df"
 			}
@@ -2301,26 +2307,6 @@
 				"hash": "f13800d70ddd"
 			}
 		],
-		"tests/e2e/workflows/editor/canvas/canvas-zoom.spec.ts": [
-			{
-				"rule": "selector-purity",
-				"line": 241,
-				"message": "Chained locator call in test: n8n.canvas.nodeByName('n8n').getByTestId('overflow-node-b...",
-				"hash": "3d500494797e"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 242,
-				"message": "Direct page locator call: n8n.page.getByTestId('context-menu-item-open').click()",
-				"hash": "803edc6e2d15"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 242,
-				"message": "Direct page locator call: n8n.page.getByTestId('context-menu-item-open')",
-				"hash": "049003f6550b"
-			}
-		],
 		"tests/e2e/workflows/editor/code/code-node.spec.ts": [
 			{
 				"rule": "selector-purity",
@@ -2357,56 +2343,6 @@
 				"line": 51,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Run Once for Each I...",
 				"hash": "354ddeafe76a"
-			}
-		],
-		"tests/e2e/workflows/editor/execution/execution.spec.ts": [
-			{
-				"rule": "selector-purity",
-				"line": 150,
-				"message": "Direct page locator call: n8n.page.getByTestId('copy-input').click()",
-				"hash": "20e9bf63ae83"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 150,
-				"message": "Direct page locator call: n8n.page.getByTestId('copy-input')",
-				"hash": "dd5c167f4482"
-			},
-			{
-				"rule": "api-purity",
-				"line": 154,
-				"message": "Raw API call detected: request.get(",
-				"hash": "5128d500e46f"
-			}
-		],
-		"tests/e2e/workflows/editor/execution/inject-previous.spec.ts": [
-			{
-				"rule": "selector-purity",
-				"line": 60,
-				"message": "Chained locator call in test: n8n.ndv.outputPanel.get().locator('[contenteditable=\"true...",
-				"hash": "cae3335d44be"
-			}
-		],
-		"tests/e2e/workflows/editor/execution/logs.spec.ts": [
-			{
-				"rule": "selector-purity",
-				"line": 268,
-				"message": "Chained locator call in test: n8n.ndv.outputPanel .getDataContainer() .locator('a')",
-				"hash": "6a673016ebff"
-			},
-			{
-				"rule": "api-purity",
-				"line": 278,
-				"message": "Raw API call detected: request.get(",
-				"hash": "5128d500e46f"
-			}
-		],
-		"tests/e2e/workflows/editor/expressions/inline.spec.ts": [
-			{
-				"rule": "selector-purity",
-				"line": 54,
-				"message": "Chained locator call in test: n8n.ndv.getParameterInput('value').getByRole('textbox')",
-				"hash": "e6c73a21e494"
 			}
 		],
 		"tests/e2e/workflows/editor/expressions/mapping.spec.ts": [
@@ -2747,26 +2683,6 @@
 				"hash": "6e9d8666bad6"
 			}
 		],
-		"tests/e2e/workflows/editor/ndv/pinning.spec.ts": [
-			{
-				"rule": "selector-purity",
-				"line": 82,
-				"message": "Chained locator call in test: runDataHeader.getByRole('button', { name: 'Edit Output' })",
-				"hash": "aa1904651d9c"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 178,
-				"message": "Chained locator call in test: n8n.ndv.getAssignmentValue('assignments').getByText('Expr...",
-				"hash": "25491e82dd43"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 187,
-				"message": "Chained locator call in test: n8n.ndv.getParameterInputHint().getByText(expectedOutput)",
-				"hash": "393fc24d0bf4"
-			}
-		],
 		"tests/e2e/workflows/editor/ndv/resource-locator.spec.ts": [
 			{
 				"rule": "selector-purity",
@@ -2829,34 +2745,6 @@
 				"hash": "160fc14cc93a"
 			}
 		],
-		"tests/e2e/workflows/editor/ndv/schema-preview.spec.ts": [
-			{
-				"rule": "selector-purity",
-				"line": 16,
-				"message": "Chained locator call in test: n8n.ndv.inputPanel.get().getByText('No input data')",
-				"hash": "89dc9850c2d6"
-			}
-		],
-		"tests/e2e/workflows/editor/subworkflows/debugging.spec.ts": [
-			{
-				"rule": "selector-purity",
-				"line": 43,
-				"message": "Chained locator call in test: n8n.ndv.outputPanel.getTbodyCell(0, 0).locator('a')",
-				"hash": "11bb70e5e4f9"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 90,
-				"message": "Chained locator call in test: n8n.ndv.outputPanel.getTbodyCell(0, 0).locator('a')",
-				"hash": "11bb70e5e4f9"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 104,
-				"message": "Chained locator call in test: n8n.ndv.outputPanel.getTbodyCell(0, 0).locator('a')",
-				"hash": "11bb70e5e4f9"
-			}
-		],
 		"tests/e2e/workflows/editor/subworkflows/workflow-selector.spec.ts": [
 			{
 				"rule": "selector-purity",
@@ -2901,14 +2789,6 @@
 				"line": 215,
 				"message": "Chained locator call in test: n8n.canvas.getVisibleDropdown().locator('li')",
 				"hash": "4febc57392da"
-			}
-		],
-		"tests/e2e/workflows/editor/workflow-actions/archive.spec.ts": [
-			{
-				"rule": "selector-purity",
-				"line": 41,
-				"message": "Chained locator call in test: n8n.workflowSettingsModal.getArchiveMenuItem().locator('..')",
-				"hash": "ec8d53703e0b"
 			}
 		],
 		"tests/e2e/workflows/editor/workflow-actions/settings.spec.ts": [
@@ -3155,14 +3035,6 @@
 				"hash": "36b71f3e9617"
 			}
 		],
-		"tests/e2e/workflows/templates/templates.spec.ts": [
-			{
-				"rule": "selector-purity",
-				"line": 247,
-				"message": "Chained locator call in test: n8n.templates.getDescription().locator('img')",
-				"hash": "5f06d991a2b6"
-			}
-		],
 		"composables/CanvasComposer.ts": [
 			{
 				"rule": "no-page-in-flow",
@@ -3303,6 +3175,22 @@
 			{
 				"rule": "api-purity",
 				"line": 123,
+				"message": "Raw API call detected: request.get(",
+				"hash": "5128d500e46f"
+			}
+		],
+		"tests/e2e/workflows/editor/execution/execution.spec.ts": [
+			{
+				"rule": "api-purity",
+				"line": 154,
+				"message": "Raw API call detected: request.get(",
+				"hash": "5128d500e46f"
+			}
+		],
+		"tests/e2e/workflows/editor/execution/logs.spec.ts": [
+			{
+				"rule": "api-purity",
+				"line": 275,
 				"message": "Raw API call detected: request.get(",
 				"hash": "5128d500e46f"
 			}

--- a/packages/testing/playwright/pages/CanvasPage.ts
+++ b/packages/testing/playwright/pages/CanvasPage.ts
@@ -43,6 +43,10 @@ export class CanvasPage extends BasePage {
 		return this.page.locator(`[data-test-id="canvas-node"][data-node-name="${nodeName}"]`);
 	}
 
+	nodeOverflowButton(nodeName: string): Locator {
+		return this.nodeByName(nodeName).getByTestId('overflow-node-button');
+	}
+
 	nodeIssuesBadge(nodeName: string) {
 		return this.nodeByName(nodeName).getByTestId('node-issues');
 	}

--- a/packages/testing/playwright/pages/NodeDetailsViewPage.ts
+++ b/packages/testing/playwright/pages/NodeDetailsViewPage.ts
@@ -221,6 +221,10 @@ export class NodeDetailsViewPage extends BasePage {
 		return locatorByIndex(this.page.getByTestId(`parameter-input-${parameterName}`), index);
 	}
 
+	getParameterInputTextbox(parameterName: string, index?: number) {
+		return this.getParameterInput(parameterName, index).getByRole('textbox');
+	}
+
 	getParameterInputField(parameterName: string, index?: number) {
 		return this.getParameterInput(parameterName, index).locator('input');
 	}

--- a/packages/testing/playwright/pages/NodeDetailsViewPage.ts
+++ b/packages/testing/playwright/pages/NodeDetailsViewPage.ts
@@ -485,6 +485,10 @@ export class NodeDetailsViewPage extends BasePage {
 		await this.page.waitForTimeout(2500);
 	}
 
+	getCopyInputButton() {
+		return this.page.getByTestId('copy-input');
+	}
+
 	getOutputPagination() {
 		return this.outputPanel.get().getByTestId('ndv-data-pagination');
 	}

--- a/packages/testing/playwright/pages/NodeDetailsViewPage.ts
+++ b/packages/testing/playwright/pages/NodeDetailsViewPage.ts
@@ -127,6 +127,10 @@ export class NodeDetailsViewPage extends BasePage {
 		return this.page.getByTestId('run-data-pane-header');
 	}
 
+	getEditOutputButton() {
+		return this.getRunDataPaneHeader().getByRole('button', { name: 'Edit Output' });
+	}
+
 	getOutputDataContainer() {
 		return this.getOutputPanel().getByTestId('ndv-data-container');
 	}
@@ -167,6 +171,10 @@ export class NodeDetailsViewPage extends BasePage {
 			.getByTestId('assignment-value');
 	}
 
+	async clickAssignmentExpressionToggle(paramName: string) {
+		await this.getAssignmentValue(paramName).getByText('Expression').click();
+	}
+
 	/**
 	 * Get the inline expression editor input
 	 * @param parameterName - The name of the parameter to get the inline expression editor input for. If not set, gets the first inline expression editor input on page
@@ -186,6 +194,10 @@ export class NodeDetailsViewPage extends BasePage {
 
 	getParameterInputHint() {
 		return this.page.getByTestId('parameter-input-hint');
+	}
+
+	getParameterInputHintWithText(text: string) {
+		return this.getParameterInputHint().getByText(text);
 	}
 
 	getInputLabel() {

--- a/packages/testing/playwright/pages/TemplatesPage.ts
+++ b/packages/testing/playwright/pages/TemplatesPage.ts
@@ -27,6 +27,10 @@ export class TemplatesPage extends BasePage {
 		return this.page.getByTestId('template-description');
 	}
 
+	getDescriptionImages(): Locator {
+		return this.getDescription().locator('img');
+	}
+
 	getSearchInput(): Locator {
 		return this.page.getByTestId('template-search-input');
 	}

--- a/packages/testing/playwright/pages/WorkflowSettingsModal.ts
+++ b/packages/testing/playwright/pages/WorkflowSettingsModal.ts
@@ -59,6 +59,10 @@ export class WorkflowSettingsModal extends BasePage {
 		return this.page.getByTestId('workflow-menu-item-archive');
 	}
 
+	getArchiveMenuItemWrapper(): Locator {
+		return this.getArchiveMenuItem().locator('..');
+	}
+
 	getUnarchiveMenuItem(): Locator {
 		return this.page.getByTestId('workflow-menu-item-unarchive');
 	}

--- a/packages/testing/playwright/pages/components/RunDataPanel.ts
+++ b/packages/testing/playwright/pages/components/RunDataPanel.ts
@@ -139,6 +139,10 @@ export class RunDataPanel {
 		return this.root.locator('[contenteditable="true"]');
 	}
 
+	getFirstLink() {
+		return this.root.locator('a').first();
+	}
+
 	async switchDisplayMode(mode: 'table' | 'ai' | 'json' | 'schema' | 'binary'): Promise<void> {
 		await this.root.getByTestId(`radio-button-${mode}`).click();
 	}

--- a/packages/testing/playwright/pages/components/RunDataPanel.ts
+++ b/packages/testing/playwright/pages/components/RunDataPanel.ts
@@ -131,6 +131,14 @@ export class RunDataPanel {
 		await this.root.getByTestId('link-run').click();
 	}
 
+	getNoInputDataMessage() {
+		return this.root.getByText('No input data');
+	}
+
+	getContentEditableEditor() {
+		return this.root.locator('[contenteditable="true"]');
+	}
+
 	async switchDisplayMode(mode: 'table' | 'ai' | 'json' | 'schema' | 'binary'): Promise<void> {
 		await this.root.getByTestId(`radio-button-${mode}`).click();
 	}

--- a/packages/testing/playwright/pages/components/RunDataPanel.ts
+++ b/packages/testing/playwright/pages/components/RunDataPanel.ts
@@ -71,6 +71,10 @@ export class RunDataPanel {
 		return this.root.locator('table tbody tr').nth(row).locator('td').nth(col);
 	}
 
+	getTbodyCellLink(row: number, col: number) {
+		return this.getTbodyCell(row, col).locator('a');
+	}
+
 	getTableCellSpan(row: number, col: number, dataName: string) {
 		return this.getTbodyCell(row, col).locator(`span[data-name="${dataName}"]`).first();
 	}

--- a/packages/testing/playwright/tests/e2e/workflows/editor/canvas/canvas-zoom.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/canvas/canvas-zoom.spec.ts
@@ -238,8 +238,8 @@ test.describe(
 			await expect(n8n.canvas.getCanvasNodes()).toHaveCount(2);
 
 			await n8n.canvas.nodeByName('n8n').hover();
-			await n8n.canvas.nodeByName('n8n').getByTestId('overflow-node-button').click();
-			await n8n.page.getByTestId('context-menu-item-open').click();
+			await n8n.canvas.nodeOverflowButton('n8n').click();
+			await n8n.canvas.getContextMenuItem('open').click();
 
 			await expect(n8n.ndv.getNodesWithIssues()).toHaveCount(1);
 		});

--- a/packages/testing/playwright/tests/e2e/workflows/editor/execution/execution.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/execution/execution.spec.ts
@@ -147,7 +147,7 @@ test.describe(
 			await n8n.canvas.openNode('Webhook');
 
 			await n8n.clipboard.grant();
-			await n8n.page.getByTestId('copy-input').click();
+			await n8n.ndv.getCopyInputButton().click();
 			await n8n.ndv.clickBackToCanvasButton();
 
 			const webhookUrl = await n8n.clipboard.readText();

--- a/packages/testing/playwright/tests/e2e/workflows/editor/execution/inject-previous.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/execution/inject-previous.spec.ts
@@ -57,7 +57,7 @@ test.describe(
 			await n8n.canvas.openNode('DebugHelper');
 
 			await n8n.ndv.getEditPinnedDataButton().click();
-			const editor = n8n.ndv.outputPanel.get().locator('[contenteditable="true"]');
+			const editor = n8n.ndv.outputPanel.getContentEditableEditor();
 			await expect(editor).toContainText('"password":');
 			await expect(editor).toContainText('"uid":');
 		});

--- a/packages/testing/playwright/tests/e2e/workflows/editor/execution/logs.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/execution/logs.spec.ts
@@ -265,10 +265,7 @@ test.describe(
 			await expect(n8n.canvas.logsPanel.getLogEntries().nth(1)).toContainText('Waiting');
 
 			await n8n.canvas.openNode(NODES.WAIT_NODE);
-			const webhookUrl = await n8n.ndv.outputPanel
-				.getDataContainer()
-				.locator('a')
-				.getAttribute('href');
+			const webhookUrl = await n8n.ndv.outputPanel.getFirstLink().getAttribute('href');
 			await n8n.ndv.clickBackToCanvasButton();
 
 			// [CAT-1454] Assert that no duplicate logs added at this point

--- a/packages/testing/playwright/tests/e2e/workflows/editor/expressions/inline.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/expressions/inline.spec.ts
@@ -51,7 +51,7 @@ test.describe(
 				// Should switch back to fixed with backspace on empty expression
 				await n8n.ndv.clearExpressionEditor('value');
 				await expect(n8n.ndv.getParameterInputHint()).toContainText('empty');
-				const parameterInput = n8n.ndv.getParameterInput('value').getByRole('textbox');
+				const parameterInput = n8n.ndv.getParameterInputTextbox('value');
 				await parameterInput.click();
 				await parameterInput.focus();
 				await parameterInput.press('Backspace');

--- a/packages/testing/playwright/tests/e2e/workflows/editor/ndv/pinning.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/ndv/pinning.spec.ts
@@ -78,9 +78,7 @@ test.describe(
 			test('should display pin data edit button for Webhook node', async ({ n8n }) => {
 				await n8n.canvas.addNode(NODES.WEBHOOK);
 
-				const runDataHeader = n8n.ndv.getRunDataPaneHeader();
-				const editButton = runDataHeader.getByRole('button', { name: 'Edit Output' });
-				await expect(editButton).toBeVisible();
+				await expect(n8n.ndv.getEditOutputButton()).toBeVisible();
 			});
 
 			test('should duplicate pinned data when duplicating node', async ({ n8n }) => {
@@ -175,7 +173,7 @@ test.describe(
 
 				await expect(n8n.ndv.getAssignmentCollectionAdd('assignments')).toBeVisible();
 				await n8n.ndv.getAssignmentCollectionAdd('assignments').click();
-				await n8n.ndv.getAssignmentValue('assignments').getByText('Expression').click();
+				await n8n.ndv.clickAssignmentExpressionToggle('assignments');
 
 				const expressionInput = n8n.ndv.getInlineExpressionEditorInput();
 				await expressionInput.click();
@@ -184,7 +182,7 @@ test.describe(
 				await n8n.page.keyboard.press('Escape');
 
 				const expectedOutput = '[Object: {"json": {"http": 123}, "pairedItem": {"item": 0}}]';
-				await expect(n8n.ndv.getParameterInputHint().getByText(expectedOutput)).toBeVisible();
+				await expect(n8n.ndv.getParameterInputHintWithText(expectedOutput)).toBeVisible();
 			});
 
 			test('should use pin data in manual webhook executions', async ({

--- a/packages/testing/playwright/tests/e2e/workflows/editor/ndv/schema-preview.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/ndv/schema-preview.spec.ts
@@ -13,7 +13,7 @@ test.describe(
 			await n8n.ndv.close();
 
 			await n8n.canvas.addNode('Edit Fields (Set)');
-			await n8n.ndv.inputPanel.get().getByText('No input data').waitFor();
+			await n8n.ndv.inputPanel.getNoInputDataMessage().waitFor();
 			await n8n.ndv.close();
 
 			await n8n.canvas.addNode('Hacker News', { action: 'Get an article' });

--- a/packages/testing/playwright/tests/e2e/workflows/editor/subworkflows/debugging.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/subworkflows/debugging.spec.ts
@@ -40,10 +40,7 @@ test.describe(
 				await expect(n8n.ndv.outputPanel.getRelatedExecutionLink()).not.toBeAttached();
 
 				await expect(n8n.ndv.outputPanel.getTableHeaders()).toHaveCount(3);
-				await expect(n8n.ndv.outputPanel.getTbodyCell(0, 0).locator('a')).toHaveAttribute(
-					'href',
-					/.+/,
-				);
+				await expect(n8n.ndv.outputPanel.getTbodyCellLink(0, 0)).toHaveAttribute('href', /.+/);
 				await expect(n8n.ndv.outputPanel.getTbodyCell(0, 1)).toHaveText('world Natalie Moore');
 			});
 
@@ -87,10 +84,7 @@ test.describe(
 				await expect(n8n.ndv.outputPanel.getTableHeaders()).toHaveCount(7);
 				await expect(n8n.ndv.outputPanel.getTableHeader(1)).toHaveText('uid');
 				await expect(n8n.ndv.outputPanel.getTableRows()).toHaveCount(4);
-				await expect(n8n.ndv.outputPanel.getTbodyCell(0, 0).locator('a')).toHaveAttribute(
-					'href',
-					/.+/,
-				);
+				await expect(n8n.ndv.outputPanel.getTbodyCellLink(0, 0)).toHaveAttribute('href', /.+/);
 				await expect(n8n.ndv.outputPanel.getTbodyCell(0, 2)).toContainText('Jon_Ebert@yahoo.com');
 
 				await n8n.ndv.changeOutputRunSelector('1 of 2 (2 items, 2 sub-executions)');
@@ -101,10 +95,7 @@ test.describe(
 				await expect(n8n.ndv.outputPanel.getTableHeader(1)).toHaveText('uid');
 				await expect(n8n.ndv.outputPanel.getTableRows()).toHaveCount(3);
 
-				await expect(n8n.ndv.outputPanel.getTbodyCell(0, 0).locator('a')).toHaveAttribute(
-					'href',
-					/.+/,
-				);
+				await expect(n8n.ndv.outputPanel.getTbodyCellLink(0, 0)).toHaveAttribute('href', /.+/);
 				await expect(n8n.ndv.outputPanel.getTbodyCell(0, 2)).toContainText(
 					'Terry.Dach@hotmail.com',
 				);

--- a/packages/testing/playwright/tests/e2e/workflows/editor/workflow-actions/archive.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/workflow-actions/archive.spec.ts
@@ -38,7 +38,7 @@ test.describe(
 			await n8n.workflowSettingsModal.getWorkflowMenu().click();
 
 			await expect(n8n.workflowSettingsModal.getDeleteMenuItem()).toBeHidden();
-			await expect(n8n.workflowSettingsModal.getArchiveMenuItem().locator('..')).toHaveClass(
+			await expect(n8n.workflowSettingsModal.getArchiveMenuItemWrapper()).toHaveClass(
 				/is-disabled/,
 			);
 		});

--- a/packages/testing/playwright/tests/e2e/workflows/templates/templates.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/templates/templates.spec.ts
@@ -244,7 +244,7 @@ test.describe(
 			test('can open template with images and hides workflow screenshots', async ({ n8n }) => {
 				await n8n.navigate.toTemplate(TEMPLATE_ID);
 				await expect(n8n.templates.getDescription()).toBeVisible();
-				await expect(n8n.templates.getDescription().locator('img')).toHaveCount(1);
+				await expect(n8n.templates.getDescriptionImages()).toHaveCount(1);
 			});
 
 			test('renders search elements correctly', async ({ n8n }) => {


### PR DESCRIPTION
## Summary

Fix 16 selector-purity violations across 10 Playwright test files by extracting raw locator chains into proper page object methods.

**Approach:** Used the janitor TCR (Test && Commit || Revert) loop for safe, incremental fixes — each change was automatically tested and committed only if tests passed.

### Changes

**New page object methods added:**
- `RunDataPanel`: `getNoInputDataMessage()`, `getContentEditableEditor()`, `getFirstLink()`, `getTbodyCellLink()`
- `NodeDetailsViewPage`: `getParameterInputTextbox()`, `getCopyInputButton()`, `getEditOutputButton()`, `clickAssignmentExpressionToggle()`, `getParameterInputHintWithText()`
- `CanvasPage`: `nodeOverflowButton()`
- `TemplatesPage`: `getDescriptionImages()`
- `WorkflowSettingsModal`: `getArchiveMenuItemWrapper()`

**Test files updated:**
- `schema-preview.spec.ts`, `inject-previous.spec.ts`, `templates.spec.ts`, `archive.spec.ts`
- `inline.spec.ts`, `canvas-zoom.spec.ts`, `execution.spec.ts`, `logs.spec.ts`
- `debugging.spec.ts`, `pinning.spec.ts`

**Baseline:** Updated `.janitor-baseline.json` (539 → 523 violations)

## Test plan

- [x] All changes validated via janitor TCR loop (tests pass before commit)
- [x] Janitor impact analysis confirms minimal blast radius (1 affected test file)
- [ ] CI passes


🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>