### PR TITLE
ci: Set auto-merge to squash

### DIFF
--- a/.github/workflows/util-approve-and-set-automerge.yml
+++ b/.github/workflows/util-approve-and-set-automerge.yml
@@ -41,4 +41,5 @@ jobs:
         run: |
           gh pr merge "${{ inputs.pull-request-number }}" \
             --auto \
+            --squash \
             --repo "${{ github.repository }}"


### PR DESCRIPTION
## Summary

When we target the master branch, this flag isn't needed but I'm assuming due to our rulesets, targeting release branches the `--squash` is required. This should set the PR into auto-merge successfully.

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/actions/runs/22942447425/job/66587015157

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
