### PR TITLE
fix(editor): Fix ChatHub chat UI layout (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/ChatView.vue
@@ -850,7 +850,6 @@ function onFilesDropped(files: File[]) {
 
 							<ChatPrompt
 								ref="inputRef"
-								:class="$style.prompt"
 								:selected-model="selectedModel"
 								:checked-tool-ids="canSelectTools ? checkedToolIds : []"
 								:session-id="isNewSession ? undefined : sessionId"
@@ -1005,19 +1004,18 @@ function onFilesDropped(files: File[]) {
 }
 
 .promptContainer {
-	position: absolute;
-	bottom: 0;
 	display: flex;
 	justify-content: center;
 	padding-block: var(--spacing--md);
 	background: var(--color--background--light-2);
-	left: 50%;
-	transform: translateX(-50%);
+	align-self: center;
 
 	.isMobileDevice &,
 	.isExistingSession & {
 		position: absolute;
 		bottom: 0;
+		left: 50%;
+		transform: translateX(-50%);
 	}
 }
 

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatPrompt.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatPrompt.vue
@@ -493,6 +493,7 @@ defineExpose({
 .header,
 .footer {
 	position: absolute;
+	left: 1px;
 	width: calc(100% - 2px);
 	z-index: 10;
 	background: var(--color--background--light-2);


### PR DESCRIPTION
## Summary

Follows up #26759

- "Start chat" message not centered vertically
- Chat prompt border cut by footer's background
<img width="1229" height="819" alt="Screenshot 2026-03-11 at 10 47 45" src="https://github.com/user-attachments/assets/f3e920a7-f48f-44ab-b6c2-4fd50ccbac73" />

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
