### PR TITLE
fix(core): Skip task runner startup on main in offload mode

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -194,6 +194,10 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 			const scopedLogger = this.logger.scoped('scaling');
 			scopedLogger.debug('Starting main instance in scaling mode');
 			scopedLogger.debug(`Host ID: ${this.instanceSettings.hostId}`);
+
+			if (process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS === 'true') {
+				this.needsTaskRunner = false;
+			}
 		}
 
 		await super.init();

--- a/packages/testing/containers/services/n8n.ts
+++ b/packages/testing/containers/services/n8n.ts
@@ -153,7 +153,7 @@ async function createContainer(
 	}
 
 	const waitStrategy = isWorker ? WORKER_WAIT_STRATEGY : MAIN_WAIT_STRATEGY;
-	const ports = hostPort ? [{ container: 5678, host: hostPort }, 5679] : [5678, 5679];
+	const ports = hostPort ? [{ container: 5678, host: hostPort }, 5679] : [5678];
 
 	container = container.withExposedPorts(...ports).withWaitStrategy(waitStrategy);
 

--- a/packages/testing/containers/services/n8n.ts
+++ b/packages/testing/containers/services/n8n.ts
@@ -1,4 +1,4 @@
-import type { StartedNetwork, StartedTestContainer } from 'testcontainers';
+import type { PortWithOptionalBinding, StartedNetwork, StartedTestContainer } from 'testcontainers';
 import { GenericContainer, Wait } from 'testcontainers';
 
 import { DockerImageNotFoundError } from '../docker-image-not-found-error';
@@ -153,7 +153,12 @@ async function createContainer(
 	}
 
 	const waitStrategy = isWorker ? WORKER_WAIT_STRATEGY : MAIN_WAIT_STRATEGY;
-	const ports = hostPort ? [{ container: 5678, host: hostPort }, 5679] : [5678];
+	const ports: PortWithOptionalBinding[] = hostPort
+		? [{ container: 5678, host: hostPort }]
+		: [5678];
+	if (isWorker) {
+		ports.push(5679);
+	}
 
 	container = container.withExposedPorts(...ports).withWaitStrategy(waitStrategy);
 


### PR DESCRIPTION
## Summary

When running in queue mode with `OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS=true`, this change disables task runner startup in the `start` command.
Task runners used to be always enforced on main instances, due to MCP trigger node not supporting running the executions on workers. That was fixed in #25147 so we shouldn't need this anymore.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2596

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)