### PR TITLE
fix(editor): I18n for sign out label in bottom menu

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/BottomMenu.vue
+++ b/packages/frontend/editor-ui/src/app/components/BottomMenu.vue
@@ -156,7 +156,11 @@ function onLogout() {
 							<span :class="$style.divider" />
 							<N8nMenuItem
 								:data-test-id="'main-sidebar-log-out'"
-								:item="{ id: 'sign-out', label: 'Sign out', icon: 'door-open' }"
+								:item="{
+									id: 'sign-out',
+									label: i18n.baseText('auth.signout'),
+									icon: 'door-open',
+								}"
 								@click="onLogout"
 							/>
 						</div>


### PR DESCRIPTION
## Summary

Replaces hard-coded `Sign out` string with `auth.signout` usage.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
