### PR TITLE
fix(core): Make ChatHub work with LM Studio's OpenAI compatible endpoint

### DIFF
--- a/packages/cli/src/modules/chat-hub/chat-hub-workflow.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-workflow.service.ts
@@ -741,7 +741,13 @@ ${this.getSystemMessageMetadata(timeZone) + artifactContext}`;
 					...common,
 					parameters: {
 						model: { __rl: true, mode: 'id', value: model },
-						options: {},
+						options: {
+							textFormat: {
+								textOptions: {
+									type: 'text',
+								},
+							},
+						},
 					},
 				};
 			case 'anthropic':


### PR DESCRIPTION
## Summary

This PR makes ChatHub work with LM Studio's OpenAI compatible endpoint by explicitly passing the format options as node parameter.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-134/community-issue-n8n-chat-feature-bug

Fixes #25113


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
