### PR TITLE
feat(core): Add workflow execution duration histogram metric

### DIFF
--- a/packages/@n8n/config/src/configs/endpoints.config.ts
+++ b/packages/@n8n/config/src/configs/endpoints.config.ts
@@ -68,6 +68,10 @@ class PrometheusMetricsConfig {
 	@Env('N8N_METRICS_INCLUDE_WORKFLOW_NAME_LABEL')
 	includeWorkflowNameLabel: boolean = false;
 
+	/** Whether to include a histogram metric for workflow execution duration. */
+	@Env('N8N_METRICS_INCLUDE_WORKFLOW_EXECUTION_DURATION')
+	includeWorkflowExecutionDuration: boolean = true;
+
 	/** Whether to include workflow execution statistics as metrics. */
 	@Env('N8N_METRICS_INCLUDE_WORKFLOW_STATISTICS')
 	includeWorkflowStatistics: boolean = false;

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -213,6 +213,7 @@ describe('GlobalConfig', () => {
 				includeCredentialTypeLabel: false,
 				includeApiStatusCodeLabel: false,
 				includeQueueMetrics: false,
+				includeWorkflowExecutionDuration: true,
 				queueMetricsInterval: 20,
 				activeWorkflowCountInterval: 60,
 				includeWorkflowStatistics: false,

--- a/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
+++ b/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
@@ -631,7 +631,7 @@ describe('PrometheusMetricsService', () => {
 				runData: {
 					startedAt: new Date('2026-01-01T00:00:00Z'),
 					stoppedAt: new Date('2026-01-01T00:00:05Z'),
-					finished: true,
+					status: 'success',
 					mode: 'trigger',
 				},
 				workflow: { id: 'wf_123', name: 'Test Workflow' },
@@ -653,7 +653,7 @@ describe('PrometheusMetricsService', () => {
 				runData: {
 					startedAt: new Date('2026-01-01T00:00:00Z'),
 					stoppedAt: new Date('2026-01-01T00:00:02.5Z'),
-					finished: false,
+					status: 'error',
 					mode: 'webhook',
 				},
 				workflow: { id: 'wf_456', name: 'Failed Workflow' },
@@ -662,6 +662,28 @@ describe('PrometheusMetricsService', () => {
 			expect(promClient.Histogram.prototype.observe).toHaveBeenCalledWith(
 				{ status: 'failed', mode: 'webhook' },
 				2.5,
+			);
+		});
+
+		it('should map crashed status to failed', async () => {
+			prometheusMetricsService.enableMetric('workflowExecutionDuration');
+			promClient.Histogram.prototype.observe = jest.fn();
+			await prometheusMetricsService.init(app);
+
+			const handler = getEventHandler();
+			handler({
+				runData: {
+					startedAt: new Date('2026-01-01T00:00:00Z'),
+					stoppedAt: new Date('2026-01-01T00:00:03Z'),
+					status: 'crashed',
+					mode: 'trigger',
+				},
+				workflow: { id: 'wf_789', name: 'Crashed Workflow' },
+			});
+
+			expect(promClient.Histogram.prototype.observe).toHaveBeenCalledWith(
+				{ status: 'failed', mode: 'trigger' },
+				3,
 			);
 		});
 
@@ -676,7 +698,7 @@ describe('PrometheusMetricsService', () => {
 				runData: {
 					startedAt: new Date('2026-01-01T00:00:00Z'),
 					stoppedAt: new Date('2026-01-01T00:00:01Z'),
-					finished: true,
+					status: 'success',
 					mode: 'manual',
 				},
 				workflow: { id: 'wf_789', name: 'My Workflow' },
@@ -698,7 +720,7 @@ describe('PrometheusMetricsService', () => {
 				runData: {
 					startedAt: new Date('2026-01-01T00:00:00Z'),
 					stoppedAt: undefined,
-					finished: true,
+					status: 'success',
 					mode: 'manual',
 				},
 				workflow: { id: 'wf_123', name: 'Test' },

--- a/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
+++ b/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
@@ -53,6 +53,7 @@ describe('PrometheusMetricsService', () => {
 					includeApiMethodLabel: false,
 					includeApiStatusCodeLabel: false,
 					includeQueueMetrics: false,
+					includeWorkflowExecutionDuration: false,
 					includeWorkflowNameLabel: false,
 					includeWorkflowStatistics: false,
 					activeWorkflowCountInterval: 30,
@@ -577,6 +578,147 @@ describe('PrometheusMetricsService', () => {
 				(call) => call[0]?.name === 'n8n_instance_role_leader',
 			);
 			expect(hasInstanceRoleMetric).toBe(false);
+		});
+	});
+
+	describe('workflow execution duration metric', () => {
+		const getEventHandler = () => {
+			const call = (eventService.on as jest.Mock).mock.calls.find(
+				(c) => c[0] === 'workflow-post-execute',
+			);
+			return call ? call[1] : undefined;
+		};
+
+		it('should register histogram when enabled', async () => {
+			prometheusMetricsService.enableMetric('workflowExecutionDuration');
+			await prometheusMetricsService.init(app);
+
+			expect(promClient.Histogram).toHaveBeenCalledWith({
+				name: 'n8n_workflow_execution_duration_seconds',
+				help: 'Workflow execution duration in seconds.',
+				labelNames: ['status', 'mode'],
+				buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600],
+			});
+
+			expect(eventService.on).toHaveBeenCalledWith('workflow-post-execute', expect.any(Function));
+		});
+
+		it('should not register histogram when disabled', async () => {
+			await prometheusMetricsService.init(app);
+
+			expect(promClient.Histogram).not.toHaveBeenCalled();
+		});
+
+		it('should include workflow_id label when enabled', async () => {
+			prometheusMetricsService.enableMetric('workflowExecutionDuration');
+			prometheusMetricsService.enableLabels(['workflowId']);
+			await prometheusMetricsService.init(app);
+
+			expect(promClient.Histogram).toHaveBeenCalledWith(
+				expect.objectContaining({
+					labelNames: ['status', 'mode', 'workflow_id'],
+				}),
+			);
+		});
+
+		it('should observe duration on successful workflow execution', async () => {
+			prometheusMetricsService.enableMetric('workflowExecutionDuration');
+			promClient.Histogram.prototype.observe = jest.fn();
+			await prometheusMetricsService.init(app);
+
+			const handler = getEventHandler();
+			handler({
+				runData: {
+					startedAt: new Date('2026-01-01T00:00:00Z'),
+					stoppedAt: new Date('2026-01-01T00:00:05Z'),
+					finished: true,
+					mode: 'trigger',
+				},
+				workflow: { id: 'wf_123', name: 'Test Workflow' },
+			});
+
+			expect(promClient.Histogram.prototype.observe).toHaveBeenCalledWith(
+				{ status: 'success', mode: 'trigger' },
+				5,
+			);
+		});
+
+		it('should observe duration on failed workflow execution', async () => {
+			prometheusMetricsService.enableMetric('workflowExecutionDuration');
+			promClient.Histogram.prototype.observe = jest.fn();
+			await prometheusMetricsService.init(app);
+
+			const handler = getEventHandler();
+			handler({
+				runData: {
+					startedAt: new Date('2026-01-01T00:00:00Z'),
+					stoppedAt: new Date('2026-01-01T00:00:02.5Z'),
+					finished: false,
+					mode: 'webhook',
+				},
+				workflow: { id: 'wf_456', name: 'Failed Workflow' },
+			});
+
+			expect(promClient.Histogram.prototype.observe).toHaveBeenCalledWith(
+				{ status: 'failed', mode: 'webhook' },
+				2.5,
+			);
+		});
+
+		it('should include workflow_id in observation labels when enabled', async () => {
+			prometheusMetricsService.enableMetric('workflowExecutionDuration');
+			prometheusMetricsService.enableLabels(['workflowId']);
+			promClient.Histogram.prototype.observe = jest.fn();
+			await prometheusMetricsService.init(app);
+
+			const handler = getEventHandler();
+			handler({
+				runData: {
+					startedAt: new Date('2026-01-01T00:00:00Z'),
+					stoppedAt: new Date('2026-01-01T00:00:01Z'),
+					finished: true,
+					mode: 'manual',
+				},
+				workflow: { id: 'wf_789', name: 'My Workflow' },
+			});
+
+			expect(promClient.Histogram.prototype.observe).toHaveBeenCalledWith(
+				{ status: 'success', mode: 'manual', workflow_id: 'wf_789' },
+				1,
+			);
+		});
+
+		it('should skip observation when stoppedAt is missing', async () => {
+			prometheusMetricsService.enableMetric('workflowExecutionDuration');
+			promClient.Histogram.prototype.observe = jest.fn();
+			await prometheusMetricsService.init(app);
+
+			const handler = getEventHandler();
+			handler({
+				runData: {
+					startedAt: new Date('2026-01-01T00:00:00Z'),
+					stoppedAt: undefined,
+					finished: true,
+					mode: 'manual',
+				},
+				workflow: { id: 'wf_123', name: 'Test' },
+			});
+
+			expect(promClient.Histogram.prototype.observe).not.toHaveBeenCalled();
+		});
+
+		it('should skip observation when runData is missing', async () => {
+			prometheusMetricsService.enableMetric('workflowExecutionDuration');
+			promClient.Histogram.prototype.observe = jest.fn();
+			await prometheusMetricsService.init(app);
+
+			const handler = getEventHandler();
+			handler({
+				runData: undefined,
+				workflow: { id: 'wf_123', name: 'Test' },
+			});
+
+			expect(promClient.Histogram.prototype.observe).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/cli/src/metrics/prometheus-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus-metrics.service.ts
@@ -10,7 +10,7 @@ import promBundle from 'express-prom-bundle';
 import { DateTime } from 'luxon';
 import { InstanceSettings } from 'n8n-core';
 import { EventMessageTypeNames, jsonParse } from 'n8n-workflow';
-import promClient, { type Counter, type Gauge } from 'prom-client';
+import promClient, { type Counter, type Gauge, type Histogram } from 'prom-client';
 import semverParse from 'semver/functions/parse';
 
 import { N8N_VERSION } from '@/constants';
@@ -37,6 +37,8 @@ export class PrometheusMetricsService {
 
 	private readonly gauges: Record<string, Gauge<string>> = {};
 
+	private readonly histograms: Record<string, Histogram<string>> = {};
+
 	private readonly prefix = this.globalConfig.endpoints.metrics.prefix;
 
 	private readonly includes: Includes = {
@@ -46,6 +48,8 @@ export class PrometheusMetricsService {
 			cache: this.globalConfig.endpoints.metrics.includeCacheMetrics,
 			logs: this.globalConfig.endpoints.metrics.includeMessageEventBusMetrics,
 			queue: this.globalConfig.endpoints.metrics.includeQueueMetrics,
+			workflowExecutionDuration:
+				this.globalConfig.endpoints.metrics.includeWorkflowExecutionDuration,
 			workflowStatistics: this.globalConfig.endpoints.metrics.includeWorkflowStatistics,
 		},
 		labels: {
@@ -69,6 +73,7 @@ export class PrometheusMetricsService {
 		this.initEventBusMetrics();
 		this.initRouteMetrics(app);
 		this.initQueueMetrics();
+		this.initWorkflowExecutionDurationMetric();
 		this.initActiveWorkflowCountMetric();
 		this.initWorkflowStatisticsMetrics();
 		this.mountMetricsEndpoint(app);
@@ -339,6 +344,43 @@ export class PrometheusMetricsService {
 			this.gauges.active.set(jobCounts.active);
 			this.counters.completed?.inc(jobCounts.completed);
 			this.counters.failed?.inc(jobCounts.failed);
+		});
+	}
+
+	/**
+	 * Set up histogram for workflow execution duration: `n8n_workflow_execution_duration_seconds`
+	 *
+	 * Observes duration from `startedAt` to `stoppedAt` on each completed workflow execution.
+	 * Labels: `status` (success/failed), `mode` (manual/trigger/webhook/etc.),
+	 * and optionally `workflow_id` (gated by existing config flag).
+	 */
+	private initWorkflowExecutionDurationMetric() {
+		if (!this.includes.metrics.workflowExecutionDuration) return;
+
+		const labelNames = ['status', 'mode'];
+		if (this.includes.labels.workflowId) labelNames.push('workflow_id');
+
+		this.histograms.workflowExecutionDuration = new promClient.Histogram({
+			name: this.prefix + 'workflow_execution_duration_seconds',
+			help: 'Workflow execution duration in seconds.',
+			labelNames,
+			buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600],
+		});
+
+		this.eventService.on('workflow-post-execute', ({ runData, workflow }) => {
+			if (!runData?.startedAt || !runData?.stoppedAt) return;
+
+			const durationSeconds = (runData.stoppedAt.getTime() - runData.startedAt.getTime()) / 1000;
+			const labels: Record<string, string> = {
+				status: runData.finished ? 'success' : 'failed',
+				mode: runData.mode ?? 'unknown',
+			};
+
+			if (this.includes.labels.workflowId) {
+				labels.workflow_id = String(workflow.id ?? 'unknown');
+			}
+
+			this.histograms.workflowExecutionDuration?.observe(labels, durationSeconds);
 		});
 	}
 

--- a/packages/cli/src/metrics/prometheus-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus-metrics.service.ts
@@ -368,12 +368,12 @@ export class PrometheusMetricsService {
 		});
 
 		this.eventService.on('workflow-post-execute', ({ runData, workflow }) => {
-			if (!runData?.startedAt || !runData?.stoppedAt) return;
+			if (!runData?.stoppedAt) return;
 
 			const durationSeconds = (runData.stoppedAt.getTime() - runData.startedAt.getTime()) / 1000;
 			const labels: Record<string, string> = {
-				status: runData.finished ? 'success' : 'failed',
-				mode: runData.mode ?? 'unknown',
+				status: runData.status === 'success' ? 'success' : 'failed',
+				mode: runData.mode,
 			};
 
 			if (this.includes.labels.workflowId) {

--- a/packages/cli/src/metrics/types.ts
+++ b/packages/cli/src/metrics/types.ts
@@ -4,6 +4,7 @@ export type MetricCategory =
 	| 'cache'
 	| 'logs'
 	| 'queue'
+	| 'workflowExecutionDuration'
 	| 'workflowStatistics';
 
 export type MetricLabel =

--- a/packages/cli/test/integration/prometheus-metrics.test.ts
+++ b/packages/cli/test/integration/prometheus-metrics.test.ts
@@ -35,6 +35,7 @@ globalConfig.endpoints.metrics = {
 	includeApiMethodLabel: true,
 	includeApiStatusCodeLabel: true,
 	includeQueueMetrics: true,
+	includeWorkflowExecutionDuration: true,
 	queueMetricsInterval: 20,
 	activeWorkflowCountInterval: 60,
 	includeWorkflowStatistics: false,

--- a/packages/cli/test/integration/prometheus-metrics.test.ts
+++ b/packages/cli/test/integration/prometheus-metrics.test.ts
@@ -6,6 +6,8 @@ import { DateTime } from 'luxon';
 import { parse as semverParse } from 'semver';
 import request, { type Response } from 'supertest';
 
+import type { IRun, IWorkflowBase } from 'n8n-workflow';
+
 import { N8N_VERSION } from '@/constants';
 import { EventService } from '@/events/event.service';
 import { PrometheusMetricsService } from '@/metrics/prometheus-metrics.service';
@@ -348,6 +350,48 @@ describe('PrometheusMetricsService', () => {
 		expect(lines).toContain('n8n_test_scaling_mode_queue_jobs_active 2');
 		expect(lines).toContain('n8n_test_scaling_mode_queue_jobs_completed 0');
 		expect(lines).toContain('n8n_test_scaling_mode_queue_jobs_failed 0');
+	});
+
+	it('should return workflow execution duration histogram after event', async () => {
+		/**
+		 * Arrange
+		 */
+		prometheusService.enableMetric('workflowExecutionDuration');
+		await prometheusService.init(server.app);
+
+		/**
+		 * Act
+		 */
+		eventService.emit('workflow-post-execute', {
+			executionId: 'exec_123',
+			workflow: { id: 'wf_1', name: 'Test' } as IWorkflowBase,
+			runData: {
+				startedAt: new Date('2026-01-01T00:00:00Z'),
+				stoppedAt: new Date('2026-01-01T00:00:02Z'),
+				status: 'success',
+				mode: 'trigger',
+			} as IRun,
+		});
+
+		/**
+		 * Assert
+		 */
+		const response = await agent.get('/metrics');
+
+		expect(response.status).toEqual(200);
+		expect(response.type).toEqual('text/plain');
+
+		const lines = toLines(response);
+
+		expect(lines).toContainEqual(
+			expect.stringContaining('n8n_test_workflow_execution_duration_seconds_bucket'),
+		);
+		expect(lines).toContainEqual(
+			expect.stringContaining('n8n_test_workflow_execution_duration_seconds_sum'),
+		);
+		expect(lines).toContainEqual(
+			expect.stringContaining('n8n_test_workflow_execution_duration_seconds_count'),
+		);
 	});
 
 	it('should return active workflow count', async () => {


### PR DESCRIPTION
## Summary
- Adds `n8n_workflow_execution_duration_seconds` Prometheus histogram metric
- Enables PromQL-based latency percentiles (p50/p95/p99) decoupled from execution persistence
- Labels: `status` (success/failed), `mode` (manual/trigger/webhook/etc.), optional `workflow_id`
- 16 histogram buckets covering 5ms to 600s (fast webhooks to slow batch jobs)
- Gated by `N8N_METRICS_INCLUDE_WORKFLOW_EXECUTION_DURATION` (default: `true` when metrics enabled)

## PromQL examples
```promql
# p95 execution duration
histogram_quantile(0.95, rate(n8n_workflow_execution_duration_seconds_bucket[5m]))

# Average execution duration
rate(n8n_workflow_execution_duration_seconds_sum[5m]) / rate(n8n_workflow_execution_duration_seconds_count[5m])

# Per-workflow p95 (when workflow_id label enabled)
histogram_quantile(0.95, rate(n8n_workflow_execution_duration_seconds_bucket{workflow_id="123"}[5m]))
```

## Test plan
- [x] Unit tests: histogram registration, observation with correct labels, disabled behavior, missing data handling (8 tests)
- [x] Typecheck passes on `@n8n/config` and `cli` packages
- [ ] Integration: verify histogram appears in `/metrics` scrape output
- [ ] Verify no double-counting in queue mode (histogram observed on main only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)