### PR TITLE
feat(core): Make workflow index batch size configurable via env var

### DIFF
--- a/packages/@n8n/config/src/configs/workflows.config.ts
+++ b/packages/@n8n/config/src/configs/workflows.config.ts
@@ -23,6 +23,10 @@ export class WorkflowsConfig {
 	@Env('N8N_WORKFLOWS_INDEXING_ENABLED')
 	indexingEnabled: boolean = true;
 
+	/** Number of workflows to process per batch during dependency indexing on startup. */
+	@Env('N8N_WORKFLOW_INDEX_BATCH_SIZE')
+	indexingBatchSize: number = 100;
+
 	/** Whether to use the workflow publication service. Still under development. */
 	@Env('N8N_USE_WORKFLOW_PUBLICATION_SERVICE')
 	useWorkflowPublicationService: boolean = false;

--- a/packages/@n8n/config/src/configs/workflows.config.ts
+++ b/packages/@n8n/config/src/configs/workflows.config.ts
@@ -23,9 +23,9 @@ export class WorkflowsConfig {
 	@Env('N8N_WORKFLOWS_INDEXING_ENABLED')
 	indexingEnabled: boolean = true;
 
-	/** Number of workflows to process per batch during dependency indexing on startup. */
+	/** Number of workflows to process per batch during dependency indexing on startup. Defaults to 10. */
 	@Env('N8N_WORKFLOW_INDEX_BATCH_SIZE')
-	indexingBatchSize: number = 100;
+	indexingBatchSize: number = 10;
 
 	/** Whether to use the workflow publication service. Still under development. */
 	@Env('N8N_USE_WORKFLOW_PUBLICATION_SERVICE')

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -195,7 +195,7 @@ describe('GlobalConfig', () => {
 			callerPolicyDefaultOption: 'workflowsFromSameOwner',
 			activationBatchSize: 1,
 			indexingEnabled: true,
-			indexingBatchSize: 100,
+			indexingBatchSize: 10,
 			useWorkflowPublicationService: false,
 		},
 		endpoints: {

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -195,6 +195,7 @@ describe('GlobalConfig', () => {
 			callerPolicyDefaultOption: 'workflowsFromSameOwner',
 			activationBatchSize: 1,
 			indexingEnabled: true,
+			indexingBatchSize: 100,
 			useWorkflowPublicationService: false,
 		},
 		endpoints: {

--- a/packages/cli/src/modules/workflow-index/__tests__/workflow-index.service.test.ts
+++ b/packages/cli/src/modules/workflow-index/__tests__/workflow-index.service.test.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { Logger } from '@n8n/backend-common';
 import { mockInstance } from '@n8n/backend-test-utils';
+import type { WorkflowsConfig } from '@n8n/config';
 import { WorkflowDependencyRepository, WorkflowEntity, WorkflowRepository } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 import type { Span } from 'n8n-core';
@@ -21,6 +22,9 @@ describe('WorkflowIndexService', () => {
 	const mockEventService = mockInstance(EventService);
 	const mockTracing = mockInstance(Tracing);
 
+	const createWorkflowsConfig = (overrides: Partial<WorkflowsConfig> = {}) =>
+		mock<WorkflowsConfig>({ indexingBatchSize: 100, ...overrides });
+
 	beforeEach(() => {
 		jest.resetAllMocks();
 
@@ -33,6 +37,7 @@ describe('WorkflowIndexService', () => {
 			mockLogger,
 			mockErrorReporter,
 			mockTracing,
+			createWorkflowsConfig(),
 		);
 	});
 
@@ -612,7 +617,7 @@ describe('WorkflowIndexService', () => {
 				mockLogger,
 				mockErrorReporter,
 				mockTracing,
-				batchSize,
+				createWorkflowsConfig({ indexingBatchSize: batchSize }),
 			);
 
 			// Create 5 workflows to test multiple batches

--- a/packages/cli/src/modules/workflow-index/__tests__/workflow-index.service.test.ts
+++ b/packages/cli/src/modules/workflow-index/__tests__/workflow-index.service.test.ts
@@ -23,7 +23,7 @@ describe('WorkflowIndexService', () => {
 	const mockTracing = mockInstance(Tracing);
 
 	const createWorkflowsConfig = (overrides: Partial<WorkflowsConfig> = {}) =>
-		mock<WorkflowsConfig>({ indexingBatchSize: 100, ...overrides });
+		mock<WorkflowsConfig>({ indexingBatchSize: 10, ...overrides });
 
 	beforeEach(() => {
 		jest.resetAllMocks();

--- a/packages/cli/src/modules/workflow-index/__tests__/workflow-index.service.test.ts
+++ b/packages/cli/src/modules/workflow-index/__tests__/workflow-index.service.test.ts
@@ -591,7 +591,7 @@ describe('WorkflowIndexService', () => {
 			await service.buildIndex();
 
 			// Verify findWorkflowsNeedingIndexing was called with correct pagination
-			expect(mockWorkflowRepository.findWorkflowsNeedingIndexing).toHaveBeenCalledWith(100); // default batch size
+			expect(mockWorkflowRepository.findWorkflowsNeedingIndexing).toHaveBeenCalledWith(10); // default batch size
 
 			// Verify updateDependenciesForWorkflow was called for each workflow
 			expect(mockWorkflowDependencyRepository.updateDependenciesForWorkflow).toHaveBeenCalledTimes(

--- a/packages/cli/src/modules/workflow-index/workflow-index.service.ts
+++ b/packages/cli/src/modules/workflow-index/workflow-index.service.ts
@@ -1,4 +1,5 @@
 import { Logger } from '@n8n/backend-common';
+import { WorkflowsConfig } from '@n8n/config';
 import type { IWorkflowDb } from '@n8n/db';
 import { WorkflowDependencies, WorkflowDependencyRepository, WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
@@ -21,6 +22,8 @@ const WORKFLOW_INDEXED_PLACEHOLDER_KEY = '__INDEXED__';
  */
 @Service()
 export class WorkflowIndexService {
+	private readonly batchSize: number;
+
 	constructor(
 		private readonly dependencyRepository: WorkflowDependencyRepository,
 		private readonly workflowRepository: WorkflowRepository,
@@ -28,8 +31,10 @@ export class WorkflowIndexService {
 		private readonly logger: Logger,
 		private readonly errorReporter: ErrorReporter,
 		private readonly tracing: Tracing,
-		private readonly batchSize = 100,
-	) {}
+		workflowsConfig: WorkflowsConfig,
+	) {
+		this.batchSize = workflowsConfig.indexingBatchSize;
+	}
 
 	init() {
 		this.eventService.on('server-started', async (): Promise<void> => {

--- a/packages/cli/test/integration/workflows/workflow-index.test.ts
+++ b/packages/cli/test/integration/workflows/workflow-index.test.ts
@@ -5,6 +5,7 @@ import {
 	createWorkflowHistory,
 	setActiveVersion,
 } from '@n8n/backend-test-utils';
+import { WorkflowsConfig } from '@n8n/config';
 import type { IWorkflowDb } from '@n8n/db';
 import { WorkflowDependencyRepository, WorkflowRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
@@ -38,6 +39,7 @@ beforeAll(async () => {
 		Container.get(Logger),
 		Container.get(ErrorReporter),
 		Container.get(Tracing),
+		Container.get(WorkflowsConfig),
 	);
 
 	// Initialize the service to register event listeners


### PR DESCRIPTION
## Summary

Expose the workflow indexing batch size as an environment variable.

The queries support a configurable batch size but it wasn't previously exposed. This can be a way to manage memory usage.

## Related Linear ticket
https://linear.app/n8n/issue/CAT-2599

## Review / Merge checklist
- [x] Tests pass
- [x] Follows n8n config conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)