### PR TITLE
ci: Add version release notification workflow

### DIFF
--- a/.github/scripts/send-version-release-notification.mjs
+++ b/.github/scripts/send-version-release-notification.mjs
@@ -1,0 +1,32 @@
+import { ensureEnvVar } from './github-helpers.mjs';
+
+async function sendVersionReleaseNotification() {
+	const payload = ensureEnvVar('PAYLOAD');
+	const webhookData = ensureEnvVar('N8N_VERSION_RELEASE_NOTIFICATION_DATA');
+
+	const { user, secret, url } = JSON.parse(webhookData);
+
+	console.log('Payload: ', JSON.parse(payload));
+
+	const response = await fetch(url, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: 'Basic ' + Buffer.from(`${user}:${secret}`).toString('base64'),
+		},
+		body: payload,
+	});
+
+	const status = response.status;
+	console.log('Webhook call returned status ' + status);
+
+	if (status !== 200) {
+		const body = await response.text();
+		throw new Error(`Webhook call failed:\n\n ${body}`);
+	}
+}
+
+// only run when executed directly, not when imported by tests
+if (import.meta.url === `file://${process.argv[1]}`) {
+	sendVersionReleaseNotification();
+}

--- a/.github/workflows/release-publish-post-release.yml
+++ b/.github/workflows/release-publish-post-release.yml
@@ -64,3 +64,11 @@ jobs:
       version: ${{ inputs.version }}
       experimental: ${{ inputs.release_type == 'rc' }}
     secrets: inherit
+
+  send-version-release-notification:
+    name: 'Send version release notifications'
+    uses: ./.github/workflows/release-version-release-notification.yml
+    with:
+      previous-version: ${{ inputs.previous_version }}
+      version: ${{ inputs.version }}
+    secrets: inherit

--- a/.github/workflows/release-version-release-notification.yml
+++ b/.github/workflows/release-version-release-notification.yml
@@ -1,0 +1,50 @@
+name: 'Release: Send version release notification'
+run-name: 'Send version release notification for n8n@${{ inputs.version }}'
+
+on:
+  workflow_dispatch:
+    inputs:
+      previous-version:
+        description: 'The previous release version (e.g. 2.10.2)'
+        required: true
+        type: string
+      version:
+        description: 'The release version (e.g. 2.11.0)'
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      previous-version:
+        description: 'The previous release version (e.g. 2.10.2)'
+        required: true
+        type: string
+      version:
+        description: 'The release version (e.g. 2.11.0)'
+        required: true
+        type: string
+
+jobs:
+  release-notification:
+    runs-on: ubuntu-slim
+    environment: release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-nodejs
+        with:
+          build-command: ''
+          install-command: npm install --prefix=.github/scripts --no-package-lock
+
+      - name: Send release notification
+        env:
+          N8N_VERSION_RELEASE_NOTIFICATION_DATA: ${{ secrets.N8N_VERSION_RELEASE_NOTIFICATION_DATA }}
+          PAYLOAD: |
+            {
+              "previous_version": "${{ inputs.previous-version }}",
+              "new_version": "${{ inputs.version }}"
+            }
+        run: node ./.github/scripts/send-version-release-notification.mjs


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow and supporting script to send a webhook notification when a new n8n version is released.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2425

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)