### PR TITLE
fix(editor): Fix toogle share action based on scopes

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/MainHeader/ActionsDropdownMenu.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/ActionsDropdownMenu.vue
@@ -121,7 +121,7 @@ const workflowMenuItems = computed<Array<ActionDropdownItem<WORKFLOW_MENU_ACTION
 		},
 	];
 
-	if (isSharingEnabled.value) {
+	if (isSharingEnabled.value && props.workflowPermissions.share) {
 		actions.push({
 			id: WORKFLOW_MENU_ACTIONS.SHARE,
 			label: locale.baseText('workflowDetails.share'),

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.test.ts
@@ -235,6 +235,7 @@ describe('WorkflowDetails', () => {
 	it('opens share modal on share button click', async () => {
 		const openModalSpy = vi.spyOn(uiStore, 'openModalWithData');
 
+		workflowDocumentStoreRef.value?.setScopes(['workflow:share']);
 		const { getByTestId } = renderComponent({
 			props: {
 				...defaultProps,
@@ -297,7 +298,7 @@ describe('WorkflowDetails', () => {
 		});
 
 		it('should have workflow duplicate and import options if permission update is true', async () => {
-			workflowDocumentStoreRef.value?.setScopes(['workflow:update']);
+			workflowDocumentStoreRef.value?.setScopes(['workflow:update', 'workflow:share']);
 			const { getByTestId, queryByTestId } = renderComponent({
 				props: {
 					...defaultProps,

--- a/packages/frontend/editor-ui/src/app/components/WorkflowCard.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowCard.vue
@@ -182,11 +182,14 @@ const actions = computed(() => {
 			label: locale.baseText('workflows.item.open'),
 			value: WORKFLOW_LIST_ITEM_ACTIONS.OPEN,
 		},
-		{
+	];
+
+	if (workflowPermissions.value.share) {
+		items.push({
 			label: locale.baseText('workflows.item.share'),
 			value: WORKFLOW_LIST_ITEM_ACTIONS.SHARE,
-		},
-	];
+		});
+	}
 
 	if (
 		workflowPermissions.value.read &&


### PR DESCRIPTION
## Summary

The problem was a disconnect between backend enforcement and frontend visibility.

When an admin toggles off "Personal Space Sharing" in Security Settings, the backend correctly removes the workflow:share scope from the personalOwner role. But the frontend never checked that scope when deciding whether to show the Share option:

In the workflow editor dropdown menu ([ActionsDropdownMenu.vue:124](https://github.com/n8n-io/n8n/blob/master/packages/frontend/editor-ui/src/app/components/MainHeader/ActionsDropdownMenu.vue#L124)), it only checked the license flag (enterprise.sharing), which is always true as long as sharing is licensed, regardless of the admin toggle.
In the workflow list cards ([WorkflowCard.vue:185](https://github.com/n8n-io/n8n/blob/master/packages/frontend/editor-ui/src/app/components/WorkflowCard.vue#L185)), the Share action was added unconditionally with no check at all.
So the button stayed visible even though the user no longer had permission to share. Clicking it would open the share modal in a restricted/read-only state, confusing but not functional. The fix adds a workflowPermissions.share check to both places so the option is hidden when the scope is absent.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-382/ui-freezes-when-typing-username-in-workflow-sharing-dialog

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
