### PR TITLE
feat(core): Add type field to chat hub sessions

### DIFF
--- a/packages/@n8n/api-types/src/chat-hub.ts
+++ b/packages/@n8n/api-types/src/chat-hub.ts
@@ -67,6 +67,9 @@ export const chatHubProviderSchema = z.enum([
 ] as const);
 export type ChatHubProvider = z.infer<typeof chatHubProviderSchema>;
 
+export const chatHubSessionTypeSchema = z.enum(['production', 'manual']);
+export type ChatHubSessionType = z.infer<typeof chatHubSessionTypeSchema>;
+
 /**
  * Map of providers to their credential types
  * Only LLM providers (openai, anthropic, google) have credentials
@@ -347,6 +350,22 @@ export class ChatHubSendMessageRequest extends Z.class({
 	timeZone: TimeZoneSchema,
 }) {}
 
+/**
+ * Request schema for sending a message via the manual (draft) execution path.
+ * The workflowId comes from the URL param; model and credentials are not needed
+ * because the draft workflow provides its own configuration.
+ * Requires workflow:execute permission (not available to chat-only users).
+ */
+export class ChatHubManualSendMessageRequest extends Z.class({
+	messageId: z.string().uuid(),
+	sessionId: z.string().uuid(),
+	message: z.string(),
+	previousMessageId: z.string().uuid().nullable(),
+	attachments: z.array(chatAttachmentSchema),
+	agentName: z.string().optional(),
+	timeZone: TimeZoneSchema,
+}) {}
+
 export class ChatHubRegenerateMessageRequest extends Z.class({
 	model: chatHubConversationModelSchema,
 	credentials: z.record(
@@ -355,6 +374,13 @@ export class ChatHubRegenerateMessageRequest extends Z.class({
 			name: z.string(),
 		}),
 	),
+	timeZone: TimeZoneSchema,
+}) {}
+
+/**
+ * Manual (draft) regenerate — workflowId comes from the URL param.
+ */
+export class ChatHubManualRegenerateMessageRequest extends Z.class({
 	timeZone: TimeZoneSchema,
 }) {}
 
@@ -368,6 +394,17 @@ export class ChatHubEditMessageRequest extends Z.class({
 			name: z.string(),
 		}),
 	),
+	newAttachments: z.array(chatAttachmentSchema),
+	keepAttachmentIndices: z.array(z.number()),
+	timeZone: TimeZoneSchema,
+}) {}
+
+/**
+ * Manual (draft) edit — workflowId comes from the URL param.
+ */
+export class ChatHubManualEditMessageRequest extends Z.class({
+	message: z.string(),
+	messageId: z.string().uuid(),
 	newAttachments: z.array(chatAttachmentSchema),
 	keepAttachmentIndices: z.array(z.number()),
 	timeZone: TimeZoneSchema,
@@ -403,6 +440,7 @@ export interface ChatHubSessionDto {
 	agentId: string | null;
 	agentName: string;
 	agentIcon: AgentIconOrEmoji | null;
+	type: ChatHubSessionType;
 	createdAt: string;
 	updatedAt: string;
 	toolIds: string[];
@@ -455,6 +493,7 @@ export interface ChatHubMessageDto {
 export class ChatHubConversationsRequest extends Z.class({
 	limit: z.coerce.number().int().min(1).max(100),
 	cursor: z.string().uuid().optional(),
+	type: chatHubSessionTypeSchema.optional(),
 }) {}
 
 export interface ChatHubConversationsResponse {

--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -76,6 +76,8 @@ export {
 	chatHubVectorStoreProviderSchema,
 	type ChatHubVectorStoreProvider,
 	VECTOR_STORE_PROVIDER_CREDENTIAL_TYPE_MAP,
+	chatHubSessionTypeSchema,
+	type ChatHubSessionType,
 } from './chat-hub';
 
 export type {

--- a/packages/@n8n/db/src/migrations/common/1772700000000-AddTypeToChatHubSessions.ts
+++ b/packages/@n8n/db/src/migrations/common/1772700000000-AddTypeToChatHubSessions.ts
@@ -1,0 +1,13 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+export class AddTypeToChatHubSessions1772700000000 implements ReversibleMigration {
+	async up({ schemaBuilder: { addColumns, column } }: MigrationContext) {
+		await addColumns('chat_hub_sessions', [
+			column('type').varchar(16).notNull.default("'production'"),
+		]);
+	}
+
+	async down({ schemaBuilder: { dropColumns } }: MigrationContext) {
+		await dropColumns('chat_hub_sessions', ['type']);
+	}
+}

--- a/packages/@n8n/db/src/migrations/common/1772700000000-AddTypeToChatHubSessions.ts
+++ b/packages/@n8n/db/src/migrations/common/1772700000000-AddTypeToChatHubSessions.ts
@@ -3,7 +3,10 @@ import type { MigrationContext, ReversibleMigration } from '../migration-types';
 export class AddTypeToChatHubSessions1772700000000 implements ReversibleMigration {
 	async up({ schemaBuilder: { addColumns, column } }: MigrationContext) {
 		await addColumns('chat_hub_sessions', [
-			column('type').varchar(16).notNull.default("'production'"),
+			column('type')
+				.varchar(16)
+				.notNull.default("'production'")
+				.withEnumCheck(['production', 'manual']),
 		]);
 	}
 

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -151,6 +151,7 @@ import { AddFilesColumnToChatHubAgents1771500000002 } from '../common/1771500000
 import { AddSuggestedPromptsToAgentTable1772000000000 } from '../common/1772000000000-AddSuggestedPromptsToAgentTable';
 import { AddRoleColumnToProjectSecretsProviderAccess1772619247761 } from '../common/1772619247761-AddRoleColumnToProjectSecretsProviderAccess';
 import { ChangeWorkflowPublishedVersionFKsToRestrict1772619247762 } from '../common/1772619247762-ChangeWorkflowPublishedVersionFKsToRestrict';
+import { AddTypeToChatHubSessions1772700000000 } from '../common/1772700000000-AddTypeToChatHubSessions';
 import type { Migration } from '../migration-types';
 
 export const postgresMigrations: Migration[] = [
@@ -307,4 +308,5 @@ export const postgresMigrations: Migration[] = [
 	AddSuggestedPromptsToAgentTable1772000000000,
 	AddRoleColumnToProjectSecretsProviderAccess1772619247761,
 	ChangeWorkflowPublishedVersionFKsToRestrict1772619247762,
+	AddTypeToChatHubSessions1772700000000,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -145,6 +145,7 @@ import { AddFilesColumnToChatHubAgents1771500000002 } from '../common/1771500000
 import { AddSuggestedPromptsToAgentTable1772000000000 } from '../common/1772000000000-AddSuggestedPromptsToAgentTable';
 import { AddRoleColumnToProjectSecretsProviderAccess1772619247761 } from '../common/1772619247761-AddRoleColumnToProjectSecretsProviderAccess';
 import { ChangeWorkflowPublishedVersionFKsToRestrict1772619247762 } from '../common/1772619247762-ChangeWorkflowPublishedVersionFKsToRestrict';
+import { AddTypeToChatHubSessions1772700000000 } from '../common/1772700000000-AddTypeToChatHubSessions';
 import type { Migration } from '../migration-types';
 
 const sqliteMigrations: Migration[] = [
@@ -295,6 +296,7 @@ const sqliteMigrations: Migration[] = [
 	AddSuggestedPromptsToAgentTable1772000000000,
 	AddRoleColumnToProjectSecretsProviderAccess1772619247761,
 	ChangeWorkflowPublishedVersionFKsToRestrict1772619247762,
+	AddTypeToChatHubSessions1772700000000,
 ];
 
 export { sqliteMigrations };

--- a/packages/cli/src/modules/chat-hub/chat-hub-session.entity.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub-session.entity.ts
@@ -1,4 +1,4 @@
-import { ChatHubProvider } from '@n8n/api-types';
+import { ChatHubProvider, type ChatHubSessionType } from '@n8n/api-types';
 import { WithTimestamps, DateTimeColumn, User, CredentialsEntity, WorkflowEntity } from '@n8n/db';
 import {
 	Column,
@@ -29,6 +29,7 @@ export interface IChatHubSession {
 	workflowId: string | null;
 	agentId: string | null;
 	agentName: string | null;
+	type: ChatHubSessionType;
 }
 
 @Entity({ name: 'chat_hub_sessions' })
@@ -121,6 +122,13 @@ export class ChatHubSession extends WithTimestamps {
 	 */
 	@Column({ type: 'varchar', length: 128, nullable: true })
 	agentName: string | null;
+
+	/**
+	 * Whether this session was created from the Chat Hub ('production')
+	 * or from a manual canvas executions ('manual').
+	 */
+	@Column({ type: 'varchar', length: 16, default: 'production' })
+	type: ChatHubSessionType;
 
 	/**
 	 * All messages that belong to this chat session.

--- a/packages/cli/src/modules/chat-hub/chat-hub.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.service.ts
@@ -866,6 +866,7 @@ export class ChatHubService {
 			agentId: session.agentId,
 			agentName: agent?.name ?? session.agentName ?? session.model ?? '',
 			agentIcon: agent?.icon ?? null,
+			type: session.type,
 			createdAt: session.createdAt.toISOString(),
 			updatedAt: session.updatedAt.toISOString(),
 			toolIds,

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/__test__/data.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/__test__/data.ts
@@ -75,6 +75,7 @@ export function createMockSession(overrides: Partial<ChatHubSessionDto> = {}): C
 		agentIcon: null,
 		createdAt: '2024-01-15T12:00:00Z',
 		updatedAt: '2024-01-15T12:00:00Z',
+		type: 'production',
 		toolIds: [],
 		...overrides,
 	};

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chat.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chat.store.test.ts
@@ -56,6 +56,7 @@ function createMockSession(overrides: Partial<ChatHubSessionDto> = {}): ChatHubS
 		agentId: null,
 		agentName: 'GPT-4',
 		agentIcon: null,
+		type: 'production',
 		toolIds: [],
 		...overrides,
 	};

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chat.utils.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chat.utils.ts
@@ -392,6 +392,7 @@ export function createSessionFromStreamingState(
 		agentIcon: streaming.agent.icon,
 		createdAt: new Date().toISOString(),
 		updatedAt: new Date().toISOString(),
+		type: 'production',
 		toolIds,
 		...flattenModel(streaming.agent.model),
 	};


### PR DESCRIPTION
## Summary

Add migration and entity changes to support a `type` field on chat hub sessions, distinguishing between 'evaluation' and 'manual' session types.

Manual chat hub executions are to be something added in https://github.com/n8n-io/n8n/pull/26137, where users can do manual executions in chat hub mode directly on the canvas. We want to differentiate sessions related to them on the DB to not display them on Chat hub.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CHA-147

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
