### PR TITLE
refactor(editor): Migrate AI assistant components to useWorkflowDocumentStore (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/AskAssistantBuild.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/AskAssistantBuild.vue
@@ -11,6 +11,10 @@ import { useInjectWorkflowId } from '@/app/composables/useInjectWorkflowId';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useI18n } from '@n8n/i18n';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { useRoute, useRouter } from 'vue-router';
 import type { RatingFeedback, WorkflowSuggestion } from '@n8n/design-system/types/assistant';
 import { isTaskAbortedMessage, isWorkflowUpdatedMessage } from '@n8n/design-system/types/assistant';
@@ -66,6 +70,11 @@ const workflowId = useInjectWorkflowId();
 const telemetry = useTelemetry();
 const slots = useSlots();
 const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = computed(() =>
+	workflowsStore.workflowId
+		? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+		: undefined,
+);
 const assistantStore = useAssistantStore();
 const settingsStore = useSettingsStore();
 const chatPanelStateStore = useChatPanelStateStore();
@@ -160,7 +169,7 @@ const showExecuteMessage = computed(() => {
 
 	return (
 		!builderStore.streaming &&
-		workflowsStore.workflow.nodes.length > 0 &&
+		(workflowDocumentStore.value?.allNodes ?? []).length > 0 &&
 		builderUpdatedWorkflowMessageIndex > -1 &&
 		!hasErrorAfterUpdate &&
 		!hasTaskAbortedAfterUpdate &&
@@ -179,7 +188,7 @@ const thinkingCompletionMessage = computed(() =>
 );
 
 const workflowSuggestions = computed<WorkflowSuggestion[] | undefined>(() => {
-	if (builderStore.hasMessages || workflowsStore.workflow.nodes.length > 0) {
+	if (builderStore.hasMessages || (workflowDocumentStore.value?.allNodes ?? []).length > 0) {
 		return undefined;
 	}
 	return shuffle(WORKFLOW_SUGGESTIONS);
@@ -295,7 +304,7 @@ async function onUserMessage(content: string) {
 	accumulatedNodeIdsToTidyUp.value = [];
 
 	// If the workflow is empty, set the initial generation flag
-	const isInitialGeneration = workflowsStore.workflow.nodes.length === 0;
+	const isInitialGeneration = (workflowDocumentStore.value?.allNodes ?? []).length === 0;
 
 	await builderStore.sendChatMessage({
 		text: content,
@@ -340,7 +349,7 @@ async function onWorkflowExecuted() {
 	const executionStatus = executionData?.status ?? 'unknown';
 	const errorNodeName = executionData?.data?.resultData.lastNodeExecuted;
 	const errorNodeType = errorNodeName
-		? workflowsStore.workflow.nodes.find((node) => node.name === errorNodeName)?.type
+		? workflowDocumentStore.value?.getNodeByName(errorNodeName)?.type
 		: undefined;
 
 	if (!executionData) {
@@ -457,7 +466,10 @@ watch(
 			return;
 		}
 
-		if (builderStore.initialGeneration && workflowsStore.workflow.nodes.length > 0) {
+		if (
+			builderStore.initialGeneration &&
+			(workflowDocumentStore.value?.allNodes ?? []).length > 0
+		) {
 			builderStore.initialGeneration = false;
 		}
 

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/AskAssistantBuild.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/AskAssistantBuild.vue
@@ -71,8 +71,8 @@ const telemetry = useTelemetry();
 const slots = useSlots();
 const workflowsStore = useWorkflowsStore();
 const workflowDocumentStore = computed(() =>
-	workflowsStore.workflowId
-		? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+	workflowId.value
+		? useWorkflowDocumentStore(createWorkflowDocumentId(workflowId.value))
 		: undefined,
 );
 const assistantStore = useAssistantStore();

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/ExecuteMessage.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/ExecuteMessage.test.ts
@@ -115,6 +115,7 @@ describe('ExecuteMessage', () => {
 		setActivePinia(pinia);
 
 		workflowsStore = mockedStore(useWorkflowsStore);
+		workflowsStore.workflow.id = 'test-workflow';
 		nodeTypesStore = mockedStore(useNodeTypesStore);
 		logsStore = mockedStore(useLogsStore);
 		uiStore = mockedStore(useUIStore);
@@ -143,9 +144,6 @@ describe('ExecuteMessage', () => {
 		workflowsStore.setSelectedTriggerNodeName = vi.fn((name: string | undefined) => {
 			selectedTriggerNodeNameRef.value = name;
 		});
-		workflowsStore.getNodeByName = vi.fn(
-			(name: string) => workflowNodes.find((node) => node.name === name) ?? null,
-		);
 		logsStore.toggleOpen = vi.fn();
 		nodeTypesStore.isTriggerNode = vi
 			.fn()

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/ExecuteMessage.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/ExecuteMessage.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { reactive, ref, nextTick } from 'vue';
+import { computed, reactive, ref, nextTick } from 'vue';
 import { fireEvent } from '@testing-library/vue';
 import { flushPromises } from '@vue/test-utils';
 import { createTestingPinia } from '@pinia/testing';
@@ -11,6 +11,7 @@ import type { INodeUi } from '@/Interface';
 import ExecuteMessage from './ExecuteMessage.vue';
 import { CHAT_TRIGGER_NODE_TYPE } from '@/app/constants';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { WorkflowIdKey } from '@/app/constants/injectionKeys';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useLogsStore } from '@/app/stores/logs.store';
 import { useUIStore } from '@/app/stores/ui.store';
@@ -67,7 +68,13 @@ vi.mock('@/app/composables/useToast', () => ({
 	}),
 }));
 
-const renderComponent = createComponentRenderer(ExecuteMessage);
+const renderComponent = createComponentRenderer(ExecuteMessage, {
+	global: {
+		provide: {
+			[WorkflowIdKey as unknown as string]: computed(() => 'test-workflow'),
+		},
+	},
+});
 
 vi.mock('./NodeIssueItem.vue', () => ({
 	default: {

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/ExecuteMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/ExecuteMessage.vue
@@ -1,6 +1,10 @@
 <!-- eslint-disable import-x/extensions -->
 <script setup lang="ts">
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useUIStore } from '@/app/stores/ui.store';
 
@@ -31,6 +35,11 @@ const emit = defineEmits<Emits>();
 // Initialize composables and stores
 const router = useRouter();
 const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = computed(() =>
+	workflowsStore.workflowId
+		? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+		: undefined,
+);
 const nodeTypesStore = useNodeTypesStore();
 const uiStore = useUIStore();
 const i18n = useI18n();
@@ -78,7 +87,9 @@ const ensureExecutionWatcher = () => {
 
 const hasValidationIssues = computed(() => builderStore.workflowTodos.length > 0);
 const triggerNodes = computed(() =>
-	workflowsStore.workflow.nodes.filter((node) => nodeTypesStore.isTriggerNode(node.type)),
+	(workflowDocumentStore.value?.allNodes ?? []).filter((node) =>
+		nodeTypesStore.isTriggerNode(node.type),
+	),
 );
 
 const issuesByType = computed(() => {
@@ -132,7 +143,7 @@ function formatIssueMessage(issue: string | string[]): string {
 
 // Helper to get node type
 function getNodeTypeByName(nodeName: string) {
-	const node = workflowsStore.workflow.nodes.find((n) => n.name === nodeName);
+	const node = workflowDocumentStore.value?.getNodeByName(nodeName);
 
 	if (!node) return null;
 	return nodeTypesStore.getNodeType(node.type);
@@ -174,7 +185,7 @@ async function onExecute() {
 	const selectedTriggerNode =
 		workflowsStore.selectedTriggerNodeName ?? availableTriggerNodes.value[0]?.name;
 	const selectedTriggerNodeType = selectedTriggerNode
-		? workflowsStore.getNodeByName(selectedTriggerNode)
+		? workflowDocumentStore.value?.getNodeByName(selectedTriggerNode)
 		: null;
 
 	// If the selected trigger is a chat node, open logs panel instead of executing
@@ -207,7 +218,7 @@ function scrollIntoView() {
 
 function trackBuilderPlaceholders(issue: WorkflowValidationIssue) {
 	builderStore.trackWorkflowBuilderJourney('user_clicked_todo', {
-		node_type: workflowsStore.getNodeByName(issue.node)?.type,
+		node_type: workflowDocumentStore.value?.getNodeByName(issue.node)?.type,
 		type: issue.type,
 	});
 }

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/ExecuteMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/ExecuteMessage.vue
@@ -8,6 +8,7 @@ import {
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useUIStore } from '@/app/stores/ui.store';
 
+import { useInjectWorkflowId } from '@/app/composables/useInjectWorkflowId';
 import { useRunWorkflow } from '@/app/composables/useRunWorkflow';
 import { useI18n, type BaseTextKey } from '@n8n/i18n';
 import { computed, onBeforeUnmount, onMounted, ref, watch, type WatchStopHandle } from 'vue';
@@ -35,9 +36,10 @@ const emit = defineEmits<Emits>();
 // Initialize composables and stores
 const router = useRouter();
 const workflowsStore = useWorkflowsStore();
+const workflowId = useInjectWorkflowId();
 const workflowDocumentStore = computed(() =>
-	workflowsStore.workflowId
-		? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+	workflowId.value
+		? useWorkflowDocumentStore(createWorkflowDocumentId(workflowId.value))
 		: undefined,
 );
 const nodeTypesStore = useNodeTypesStore();

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/FocusedNodes/MessageFocusedNodesChips.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/FocusedNodes/MessageFocusedNodesChips.vue
@@ -5,6 +5,10 @@ import { useI18n } from '@n8n/i18n';
 import NodeIcon from '@/app/components/NodeIcon.vue';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { CHIP_BUNDLE_THRESHOLD } from '../../composables/useFocusedNodesChipUI';
 
 interface Props {
@@ -15,20 +19,24 @@ const props = defineProps<Props>();
 const i18n = useI18n();
 const nodeTypesStore = useNodeTypesStore();
 const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = computed(() =>
+	workflowsStore.workflowId
+		? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+		: undefined,
+);
 
 const nodeCount = computed(() => props.focusedNodeNames?.length ?? 0);
 const shouldBundle = computed(() => nodeCount.value >= CHIP_BUNDLE_THRESHOLD);
-const allNodesSelected = computed(
-	() =>
-		nodeCount.value > 0 &&
-		workflowsStore.allNodes.length > 0 &&
-		nodeCount.value >= workflowsStore.allNodes.length,
-);
+const allNodesSelected = computed(() => {
+	const allNodes = workflowDocumentStore.value?.allNodes ?? [];
+	return nodeCount.value > 0 && allNodes.length > 0 && nodeCount.value >= allNodes.length;
+});
 
 const resolvedNodes = computed(() => {
 	if (!props.focusedNodeNames?.length) return [];
+	const allNodes = workflowDocumentStore.value?.allNodes ?? [];
 	return props.focusedNodeNames.map((name) => {
-		const workflowNode = workflowsStore.allNodes.find((n) => n.name === name);
+		const workflowNode = allNodes.find((n) => n.name === name);
 		const nodeType = workflowNode ? nodeTypesStore.getNodeType(workflowNode.type) : null;
 		return { name, nodeType };
 	});

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/FocusedNodes/MessageFocusedNodesChips.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/FocusedNodes/MessageFocusedNodesChips.vue
@@ -4,7 +4,7 @@ import { N8nIcon } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
 import NodeIcon from '@/app/components/NodeIcon.vue';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useInjectWorkflowId } from '@/app/composables/useInjectWorkflowId';
 import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
@@ -18,10 +18,10 @@ interface Props {
 const props = defineProps<Props>();
 const i18n = useI18n();
 const nodeTypesStore = useNodeTypesStore();
-const workflowsStore = useWorkflowsStore();
+const workflowId = useInjectWorkflowId();
 const workflowDocumentStore = computed(() =>
-	workflowsStore.workflowId
-		? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+	workflowId.value
+		? useWorkflowDocumentStore(createWorkflowDocumentId(workflowId.value))
 		: undefined,
 );
 


### PR DESCRIPTION
## Summary

This pull request refactors several frontend components in the AI assistant feature to use the new `workflowDocumentStore` abstraction instead of directly accessing workflow data from `workflowsStore`. This improves consistency and reliability when handling workflow nodes and related operations across the UI. The changes are primarily focused on updating node access patterns, improving computed properties, and ensuring that workflow-related logic leverages the new store.

**Migration to `workflowDocumentStore`:**

* In `AskAssistantBuild.vue`, replaced all direct accesses to workflow nodes (e.g., `workflowsStore.workflow.nodes`) with computed properties that use `workflowDocumentStore` and its `allNodes` and `getNodeByName` methods. This affects logic for showing execute messages, workflow suggestions, initial generation checks, error node type resolution, and watcher logic. [[1]](diffhunk://#diff-0ef93f53ef202b842748eccc3c0d1906804067d58c8bbf8febcfa780ce4b1ed7R14-R17) [[2]](diffhunk://#diff-0ef93f53ef202b842748eccc3c0d1906804067d58c8bbf8febcfa780ce4b1ed7R73-R77) [[3]](diffhunk://#diff-0ef93f53ef202b842748eccc3c0d1906804067d58c8bbf8febcfa780ce4b1ed7L163-R172) [[4]](diffhunk://#diff-0ef93f53ef202b842748eccc3c0d1906804067d58c8bbf8febcfa780ce4b1ed7L182-R191) [[5]](diffhunk://#diff-0ef93f53ef202b842748eccc3c0d1906804067d58c8bbf8febcfa780ce4b1ed7L298-R307) [[6]](diffhunk://#diff-0ef93f53ef202b842748eccc3c0d1906804067d58c8bbf8febcfa780ce4b1ed7L343-R352) [[7]](diffhunk://#diff-0ef93f53ef202b842748eccc3c0d1906804067d58c8bbf8febcfa780ce4b1ed7L460-R472)

* In `ExecuteMessage.vue`, updated all node access and trigger node logic to use `workflowDocumentStore` instead of `workflowsStore`. This includes filtering trigger nodes, resolving node types, execution logic, and tracking builder placeholders. [[1]](diffhunk://#diff-1828295a7fb045bbda6aba2a02af304b8b538aa6b81e4cbc59722c0f922fe203R4-R7) [[2]](diffhunk://#diff-1828295a7fb045bbda6aba2a02af304b8b538aa6b81e4cbc59722c0f922fe203R38-R42) [[3]](diffhunk://#diff-1828295a7fb045bbda6aba2a02af304b8b538aa6b81e4cbc59722c0f922fe203L81-R92) [[4]](diffhunk://#diff-1828295a7fb045bbda6aba2a02af304b8b538aa6b81e4cbc59722c0f922fe203L135-R146) [[5]](diffhunk://#diff-1828295a7fb045bbda6aba2a02af304b8b538aa6b81e4cbc59722c0f922fe203L177-R188) [[6]](diffhunk://#diff-1828295a7fb045bbda6aba2a02af304b8b538aa6b81e4cbc59722c0f922fe203L210-R221)

* In `MessageFocusedNodesChips.vue`, refactored node selection and resolution logic to use `workflowDocumentStore` for determining if all nodes are selected and for resolving node types, ensuring consistency with the new abstraction. [[1]](diffhunk://#diff-c14e8eb61040c0425faee032752b3571f74b84ad39764481a6aa55196897eec9R8-R11) [[2]](diffhunk://#diff-c14e8eb61040c0425faee032752b3571f74b84ad39764481a6aa55196897eec9R22-R39)

**Test updates:**

* In `ExecuteMessage.test.ts`, removed the mock implementation of `workflowsStore.getNodeByName` and set the workflow ID to support the new store structure. [[1]](diffhunk://#diff-9685d7d6c0b717a5e62d64f12f88cf93c187ea553529b1f8e7643657c609d235R118) [[2]](diffhunk://#diff-9685d7d6c0b717a5e62d64f12f88cf93c187ea553529b1f8e7643657c609d235L146-L148)

These changes collectively transition workflow node handling to a more robust and centralized store, reducing direct coupling to the workflow store and preparing the codebase for future enhancements.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
