### PR TITLE
test(core): Wrap bare assertion in test block in expression-extension.test.ts (no-changelog)

### DIFF
--- a/packages/workflow/test/ExpressionExtensions/expression-extension.test.ts
+++ b/packages/workflow/test/ExpressionExtensions/expression-extension.test.ts
@@ -164,7 +164,9 @@ describe('Expression Parser', () => {
 );`);
 		});
 
-		expect(evaluate('={{ [1, 2, 3, 4]?.sum((undefined)?.test) }}')).toBe(10);
+		test('Optional chaining with undefined argument', () => {
+			expect(evaluate('={{ [1, 2, 3, 4]?.sum((undefined)?.test) }}')).toBe(10);
+		});
 	});
 
 	describe('Non dot extensions', () => {


### PR DESCRIPTION
## Summary

- Wrap a bare `expect(evaluate(...))` call that was outside any `test()` block into a proper test, fixing VM evaluator initialization failure under `N8N_EXPRESSION_ENGINE=vm`
- The bare assertion ran during file collection (before `beforeAll`), so the VM evaluator was never initialized when it tried to evaluate

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2537

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.


🤖 Generated with [Claude Code](https://claude.com/claude-code)