### PR TITLE
refactor(editor): Migrate AI assistant composables to `workflowDocumentStore` (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.test.ts
@@ -372,7 +372,7 @@ describe('AI Assistant store', () => {
 			},
 		};
 		const assistantStore = useAssistantStore();
-		await assistantStore.initErrorHelper(context);
+		await assistantStore.initErrorHelper('test-workflow', context);
 		expect(apiSpy).toHaveBeenCalled();
 	});
 
@@ -402,7 +402,7 @@ describe('AI Assistant store', () => {
 			});
 		});
 
-		await assistantStore.initErrorHelper(context);
+		await assistantStore.initErrorHelper('test-workflow', context);
 		expect(apiSpy).toHaveBeenCalled();
 		expect(assistantStore.currentSessionId).toEqual(mockSessionId);
 
@@ -529,7 +529,7 @@ describe('AI Assistant store', () => {
 		const assistantStore = useAssistantStore();
 		setAssistantEnabled(true);
 
-		await assistantStore.initSupportChat('hello');
+		await assistantStore.initSupportChat('test-workflow', 'hello');
 
 		expect(apiSpy).toHaveBeenCalledWith(
 			expect.anything(),
@@ -559,7 +559,7 @@ describe('AI Assistant store', () => {
 		};
 
 		const assistantStore = useAssistantStore();
-		await assistantStore.initErrorHelper(context);
+		await assistantStore.initErrorHelper('test-workflow', context);
 
 		expect(apiSpy).toHaveBeenCalledWith(
 			expect.anything(),
@@ -583,7 +583,7 @@ describe('AI Assistant store', () => {
 			// Don't call onDone to simulate ongoing streaming
 		});
 
-		await assistantStore.initSupportChat('hello');
+		await assistantStore.initSupportChat('test-workflow', 'hello');
 		expect(assistantStore.streaming).toBe(true);
 
 		assistantStore.abortStreaming();
@@ -616,13 +616,13 @@ describe('AI Assistant store', () => {
 			onDone();
 		});
 
-		await assistantStore.initSupportChat('hello');
+		await assistantStore.initSupportChat('test-workflow', 'hello');
 
 		expect(assistantStore.chatMessages.length).toBe(2);
 		expect(assistantStore.chatMessages[0].type).toBe('text');
 		expect(assistantStore.chatMessages[1].type).toBe('text');
 
-		await assistantStore.sendMessage({ text: 'test' });
+		await assistantStore.sendMessage('test-workflow', { text: 'test' });
 
 		expect(assistantStore.chatMessages.length).toBe(4);
 		expect(assistantStore.chatMessages[0].type).toBe('text');

--- a/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.test.ts
@@ -278,7 +278,7 @@ describe('AI Assistant store', () => {
 		assistantStore.addAssistantMessages([message], '1');
 		expect(assistantStore.chatMessages.length).toBe(1);
 
-		assistantStore.resetAssistantChat();
+		assistantStore.resetAssistantChat('test-workflow-id');
 		expect(assistantStore.chatMessages).toEqual([]);
 		expect(assistantStore.currentSessionId).toBeUndefined();
 	});

--- a/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.ts
@@ -110,7 +110,7 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 		() => settings.settings.ai.allowSendingParameterValues,
 	);
 
-	function resetAssistantChat() {
+	function resetAssistantChat(workflowId?: string) {
 		clearMessages();
 		currentSessionId.value = undefined;
 		chatSessionError.value = undefined;
@@ -120,7 +120,7 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 		nodeExecutionStatus.value = 'not_executed';
 		chatSessionCredType.value = undefined;
 		chatSessionTask.value = undefined;
-		currentSessionWorkflowId.value = workflowsStore.workflowId;
+		currentSessionWorkflowId.value = workflowId ?? workflowsStore.workflowId;
 	}
 
 	function addAssistantMessages(newMessages: ChatRequest.MessageResponse[], id: string) {
@@ -298,13 +298,13 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 		}, 4000);
 	}
 
-	async function initCredHelp(credType: ICredentialType) {
+	async function initCredHelp(workflowId: string, credType: ICredentialType) {
 		const hasExistingSession = !!currentSessionId.value;
 		const question = locale.baseText('aiAssistant.builder.credentialHelpMessage', {
 			interpolate: { credentialName: credType.displayName },
 		});
 
-		await initSupportChat(question, credType);
+		await initSupportChat(workflowId, question, credType);
 
 		trackUserOpenedAssistant({
 			source: 'credential',
@@ -394,17 +394,17 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 		};
 	}
 
-	async function initSupportChat(userMessage: string, credentialType?: ICredentialType) {
-		resetAssistantChat();
+	async function initSupportChat(
+		workflowId: string,
+		userMessage: string,
+		credentialType?: ICredentialType,
+	) {
+		resetAssistantChat(workflowId);
 		chatSessionTask.value = credentialType ? 'credentials' : 'support';
 		const activeNode = workflowsStore.activeNode() as INode;
-		const nodeInfo = assistantHelpers.getNodeInfoForAssistant(
-			workflowsStore.workflowId,
-			activeNode,
-			{
-				excludeParameterValues: !allowSendingParameterValues.value,
-			},
-		);
+		const nodeInfo = assistantHelpers.getNodeInfoForAssistant(workflowId, activeNode, {
+			excludeParameterValues: !allowSendingParameterValues.value,
+		});
 		// For the initial message, only provide visual context if the task is support
 		const visualContext =
 			chatSessionTask.value === 'support'
@@ -458,12 +458,16 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 			(msg) => onEachStreamingMessage(msg, id),
 			() => onDoneStreaming(id),
 			(e) =>
-				handleServiceError(e, id, async () => await initSupportChat(userMessage, credentialType)),
+				handleServiceError(
+					e,
+					id,
+					async () => await initSupportChat(workflowId, userMessage, credentialType),
+				),
 			streamingAbortController.value.signal,
 		);
 	}
 
-	async function initErrorHelper(context: ChatRequest.ErrorContext) {
+	async function initErrorHelper(workflowId: string, context: ChatRequest.ErrorContext) {
 		const id = getRandomId();
 		if (chatSessionError.value) {
 			if (isNodeErrorActive(context)) {
@@ -472,17 +476,17 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 			}
 		}
 
-		resetAssistantChat();
+		resetAssistantChat(workflowId);
 		chatSessionTask.value = 'error';
 		chatSessionError.value = context;
-		currentSessionWorkflowId.value = workflowsStore.workflowId;
+		currentSessionWorkflowId.value = workflowId;
 
 		if (workflowsStore.activeExecutionId) {
 			currentSessionActiveExecutionId.value = workflowsStore.activeExecutionId;
 		}
 
 		const { authType, nodeInputData, schemas } = assistantHelpers.getNodeInfoForAssistant(
-			workflowsStore.workflowId,
+			workflowId,
 			context.node,
 			{ excludeParameterValues: !allowSendingParameterValues.value },
 		);
@@ -524,7 +528,7 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 			},
 			(msg) => onEachStreamingMessage(msg, id),
 			() => onDoneStreaming(id),
-			(e) => handleServiceError(e, id, async () => await initErrorHelper(context)),
+			(e) => handleServiceError(e, id, async () => await initErrorHelper(workflowId, context)),
 			streamingAbortController.value.signal,
 		);
 	}
@@ -597,6 +601,7 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 	}
 
 	async function sendMessage(
+		workflowId: string,
 		chatMessage: Pick<ChatRequest.UserChatMessage, 'text' | 'quickReplyType'>,
 	) {
 		if (isSessionEnded.value || streaming.value) {
@@ -607,7 +612,7 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 
 		const retry = async () => {
 			chatMessages.value = chatMessages.value.filter((msg) => msg.id !== id);
-			await sendMessage(chatMessage);
+			await sendMessage(workflowId, chatMessage);
 		};
 
 		try {
@@ -623,13 +628,9 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 				nodeExecutionStatus.value = 'not_executed';
 			}
 			const activeNode = workflowsStore.activeNode() as INode;
-			const nodeInfo = assistantHelpers.getNodeInfoForAssistant(
-				workflowsStore.workflowId,
-				activeNode,
-				{
-					excludeParameterValues: !allowSendingParameterValues.value,
-				},
-			);
+			const nodeInfo = assistantHelpers.getNodeInfoForAssistant(workflowId, activeNode, {
+				excludeParameterValues: !allowSendingParameterValues.value,
+			});
 			const userContext = await getVisualContext(nodeInfo);
 
 			if (streamingAbortController.value) {

--- a/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.ts
@@ -398,9 +398,13 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 		resetAssistantChat();
 		chatSessionTask.value = credentialType ? 'credentials' : 'support';
 		const activeNode = workflowsStore.activeNode() as INode;
-		const nodeInfo = assistantHelpers.getNodeInfoForAssistant(activeNode, {
-			excludeParameterValues: !allowSendingParameterValues.value,
-		});
+		const nodeInfo = assistantHelpers.getNodeInfoForAssistant(
+			workflowsStore.workflowId,
+			activeNode,
+			{
+				excludeParameterValues: !allowSendingParameterValues.value,
+			},
+		);
 		// For the initial message, only provide visual context if the task is support
 		const visualContext =
 			chatSessionTask.value === 'support'
@@ -478,6 +482,7 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 		}
 
 		const { authType, nodeInputData, schemas } = assistantHelpers.getNodeInfoForAssistant(
+			workflowsStore.workflowId,
 			context.node,
 			{ excludeParameterValues: !allowSendingParameterValues.value },
 		);
@@ -618,9 +623,13 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 				nodeExecutionStatus.value = 'not_executed';
 			}
 			const activeNode = workflowsStore.activeNode() as INode;
-			const nodeInfo = assistantHelpers.getNodeInfoForAssistant(activeNode, {
-				excludeParameterValues: !allowSendingParameterValues.value,
-			});
+			const nodeInfo = assistantHelpers.getNodeInfoForAssistant(
+				workflowsStore.workflowId,
+				activeNode,
+				{
+					excludeParameterValues: !allowSendingParameterValues.value,
+				},
+			);
 			const userContext = await getVisualContext(nodeInfo);
 
 			if (streamingAbortController.value) {

--- a/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.ts
@@ -110,7 +110,7 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 		() => settings.settings.ai.allowSendingParameterValues,
 	);
 
-	function resetAssistantChat(workflowId?: string) {
+	function resetAssistantChat(workflowId: string) {
 		clearMessages();
 		currentSessionId.value = undefined;
 		chatSessionError.value = undefined;
@@ -120,7 +120,7 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 		nodeExecutionStatus.value = 'not_executed';
 		chatSessionCredType.value = undefined;
 		chatSessionTask.value = undefined;
-		currentSessionWorkflowId.value = workflowId ?? workflowsStore.workflowId;
+		currentSessionWorkflowId.value = workflowId;
 	}
 
 	function addAssistantMessages(newMessages: ChatRequest.MessageResponse[], id: string) {
@@ -722,7 +722,7 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 		) {
 			return;
 		}
-		resetAssistantChat();
+		resetAssistantChat(activeWorkflowId);
 	});
 
 	watch(

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
@@ -178,12 +178,6 @@ describe('AI Builder store', () => {
 		workflowsStore.workflow.name = DEFAULT_NEW_WORKFLOW_NAME;
 		workflowsStore.workflow.nodes = [];
 		workflowsStore.workflow.connections = {};
-		// mockedStore converts allNodes from a computed to a writable ref,
-		// breaking the link to workflow.nodes. Re-establish it as a getter.
-		Object.defineProperty(workflowsStore, 'allNodes', {
-			get: () => workflowsStore.workflow.nodes,
-			configurable: true,
-		});
 		workflowsStore.nodesByName = {};
 		workflowsStore.workflowExecutionData = null;
 

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
@@ -1549,6 +1549,7 @@ describe('AI Builder store', () => {
 					},
 				},
 			];
+			workflowsStore.allNodes = workflowsStore.workflow.nodes;
 
 			const builderStore = useBuilderStore();
 			expect(builderStore.workflowTodos).toContainEqual(
@@ -1572,6 +1573,7 @@ describe('AI Builder store', () => {
 					},
 				},
 			];
+			workflowsStore.allNodes = workflowsStore.workflow.nodes;
 
 			const builderStore = useBuilderStore();
 			expect(builderStore.workflowTodos.length).toBeGreaterThanOrEqual(2);
@@ -1597,6 +1599,7 @@ describe('AI Builder store', () => {
 					parameters: {},
 				},
 			];
+			workflowsStore.allNodes = workflowsStore.workflow.nodes;
 
 			const builderStore = useBuilderStore();
 			expect(builderStore.workflowTodos).toEqual([]);
@@ -1613,6 +1616,7 @@ describe('AI Builder store', () => {
 					position: [0, 0],
 				} as Parameters<typeof workflowsStore.workflow.nodes.push>[0],
 			];
+			workflowsStore.allNodes = workflowsStore.workflow.nodes;
 
 			const builderStore = useBuilderStore();
 			expect(builderStore.workflowTodos).toEqual([]);
@@ -1636,6 +1640,7 @@ describe('AI Builder store', () => {
 					},
 				},
 			];
+			workflowsStore.allNodes = workflowsStore.workflow.nodes;
 
 			const builderStore = useBuilderStore();
 			const placeholderIssues = builderStore.workflowTodos.filter((t) => t.type === 'parameters');
@@ -1663,6 +1668,7 @@ describe('AI Builder store', () => {
 					},
 				},
 			];
+			workflowsStore.allNodes = workflowsStore.workflow.nodes;
 
 			const builderStore = useBuilderStore();
 			const placeholderIssues = builderStore.workflowTodos.filter((t) => t.type === 'parameters');
@@ -1688,6 +1694,7 @@ describe('AI Builder store', () => {
 					},
 				},
 			];
+			workflowsStore.allNodes = workflowsStore.workflow.nodes;
 
 			const builderStore = useBuilderStore();
 			const placeholderIssues = builderStore.workflowTodos.filter((t) => t.type === 'parameters');
@@ -1718,6 +1725,7 @@ describe('AI Builder store', () => {
 					},
 				},
 			];
+			workflowsStore.allNodes = workflowsStore.workflow.nodes;
 
 			const builderStore = useBuilderStore();
 			const placeholderIssues = builderStore.workflowTodos.filter((t) => t.type === 'parameters');
@@ -1742,6 +1750,7 @@ describe('AI Builder store', () => {
 					},
 				},
 			];
+			workflowsStore.allNodes = workflowsStore.workflow.nodes;
 
 			const builderStore = useBuilderStore();
 			const placeholderIssues = builderStore.workflowTodos.filter((t) => t.type === 'parameters');
@@ -1771,6 +1780,7 @@ describe('AI Builder store', () => {
 					},
 				},
 			];
+			workflowsStore.allNodes = workflowsStore.workflow.nodes;
 			workflowsStore.workflowValidationIssues = [];
 
 			const builderStore = useBuilderStore();
@@ -1797,6 +1807,7 @@ describe('AI Builder store', () => {
 					},
 				},
 			];
+			workflowsStore.allNodes = workflowsStore.workflow.nodes;
 			workflowsStore.workflowValidationIssues = [];
 
 			const builderStore = useBuilderStore();
@@ -1821,6 +1832,7 @@ describe('AI Builder store', () => {
 					},
 				},
 			];
+			workflowsStore.allNodes = workflowsStore.workflow.nodes;
 
 			const builderStore = useBuilderStore();
 			expect(builderStore.workflowTodos).toEqual([]);
@@ -1843,6 +1855,7 @@ describe('AI Builder store', () => {
 					},
 				},
 			];
+			workflowsStore.allNodes = workflowsStore.workflow.nodes;
 
 			const builderStore = useBuilderStore();
 			expect(builderStore.workflowTodos).toEqual([]);
@@ -1863,6 +1876,7 @@ describe('AI Builder store', () => {
 					},
 				},
 			];
+			workflowsStore.allNodes = workflowsStore.workflow.nodes;
 
 			const builderStore = useBuilderStore();
 			expect(builderStore.workflowTodos).toEqual([]);

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
@@ -178,7 +178,12 @@ describe('AI Builder store', () => {
 		workflowsStore.workflow.name = DEFAULT_NEW_WORKFLOW_NAME;
 		workflowsStore.workflow.nodes = [];
 		workflowsStore.workflow.connections = {};
-		workflowsStore.allNodes = [];
+		// mockedStore converts allNodes from a computed to a writable ref,
+		// breaking the link to workflow.nodes. Re-establish it as a getter.
+		Object.defineProperty(workflowsStore, 'allNodes', {
+			get: () => workflowsStore.workflow.nodes,
+			configurable: true,
+		});
 		workflowsStore.nodesByName = {};
 		workflowsStore.workflowExecutionData = null;
 
@@ -1549,7 +1554,6 @@ describe('AI Builder store', () => {
 					},
 				},
 			];
-			workflowsStore.allNodes = workflowsStore.workflow.nodes;
 
 			const builderStore = useBuilderStore();
 			expect(builderStore.workflowTodos).toContainEqual(
@@ -1573,7 +1577,6 @@ describe('AI Builder store', () => {
 					},
 				},
 			];
-			workflowsStore.allNodes = workflowsStore.workflow.nodes;
 
 			const builderStore = useBuilderStore();
 			expect(builderStore.workflowTodos.length).toBeGreaterThanOrEqual(2);
@@ -1599,7 +1602,6 @@ describe('AI Builder store', () => {
 					parameters: {},
 				},
 			];
-			workflowsStore.allNodes = workflowsStore.workflow.nodes;
 
 			const builderStore = useBuilderStore();
 			expect(builderStore.workflowTodos).toEqual([]);
@@ -1616,7 +1618,6 @@ describe('AI Builder store', () => {
 					position: [0, 0],
 				} as Parameters<typeof workflowsStore.workflow.nodes.push>[0],
 			];
-			workflowsStore.allNodes = workflowsStore.workflow.nodes;
 
 			const builderStore = useBuilderStore();
 			expect(builderStore.workflowTodos).toEqual([]);
@@ -1640,7 +1641,6 @@ describe('AI Builder store', () => {
 					},
 				},
 			];
-			workflowsStore.allNodes = workflowsStore.workflow.nodes;
 
 			const builderStore = useBuilderStore();
 			const placeholderIssues = builderStore.workflowTodos.filter((t) => t.type === 'parameters');
@@ -1668,7 +1668,6 @@ describe('AI Builder store', () => {
 					},
 				},
 			];
-			workflowsStore.allNodes = workflowsStore.workflow.nodes;
 
 			const builderStore = useBuilderStore();
 			const placeholderIssues = builderStore.workflowTodos.filter((t) => t.type === 'parameters');
@@ -1694,7 +1693,6 @@ describe('AI Builder store', () => {
 					},
 				},
 			];
-			workflowsStore.allNodes = workflowsStore.workflow.nodes;
 
 			const builderStore = useBuilderStore();
 			const placeholderIssues = builderStore.workflowTodos.filter((t) => t.type === 'parameters');
@@ -1725,7 +1723,6 @@ describe('AI Builder store', () => {
 					},
 				},
 			];
-			workflowsStore.allNodes = workflowsStore.workflow.nodes;
 
 			const builderStore = useBuilderStore();
 			const placeholderIssues = builderStore.workflowTodos.filter((t) => t.type === 'parameters');
@@ -1750,7 +1747,6 @@ describe('AI Builder store', () => {
 					},
 				},
 			];
-			workflowsStore.allNodes = workflowsStore.workflow.nodes;
 
 			const builderStore = useBuilderStore();
 			const placeholderIssues = builderStore.workflowTodos.filter((t) => t.type === 'parameters');
@@ -1780,7 +1776,7 @@ describe('AI Builder store', () => {
 					},
 				},
 			];
-			workflowsStore.allNodes = workflowsStore.workflow.nodes;
+
 			workflowsStore.workflowValidationIssues = [];
 
 			const builderStore = useBuilderStore();
@@ -1807,7 +1803,7 @@ describe('AI Builder store', () => {
 					},
 				},
 			];
-			workflowsStore.allNodes = workflowsStore.workflow.nodes;
+
 			workflowsStore.workflowValidationIssues = [];
 
 			const builderStore = useBuilderStore();
@@ -1832,7 +1828,6 @@ describe('AI Builder store', () => {
 					},
 				},
 			];
-			workflowsStore.allNodes = workflowsStore.workflow.nodes;
 
 			const builderStore = useBuilderStore();
 			expect(builderStore.workflowTodos).toEqual([]);
@@ -1855,7 +1850,6 @@ describe('AI Builder store', () => {
 					},
 				},
 			];
-			workflowsStore.allNodes = workflowsStore.workflow.nodes;
 
 			const builderStore = useBuilderStore();
 			expect(builderStore.workflowTodos).toEqual([]);
@@ -1876,7 +1870,6 @@ describe('AI Builder store', () => {
 					},
 				},
 			];
-			workflowsStore.allNodes = workflowsStore.workflow.nodes;
 
 			const builderStore = useBuilderStore();
 			expect(builderStore.workflowTodos).toEqual([]);
@@ -3017,7 +3010,7 @@ describe('AI Builder store', () => {
 			// Add focused nodes
 			const { useFocusedNodesStore } = await import('./focusedNodes.store');
 			const focusedNodesStore = useFocusedNodesStore();
-			workflowsStore.allNodes = [
+			workflowsStore.workflow.nodes = [
 				{
 					id: 'test-node-1',
 					name: 'HTTP Request',
@@ -3026,7 +3019,7 @@ describe('AI Builder store', () => {
 					position: [0, 0],
 					parameters: {},
 				},
-			] as unknown as typeof workflowsStore.allNodes;
+			];
 			focusedNodesStore.confirmNodes(['test-node-1'], 'context_menu');
 			track.mockReset();
 
@@ -3050,7 +3043,7 @@ describe('AI Builder store', () => {
 
 			const { useFocusedNodesStore } = await import('./focusedNodes.store');
 			const focusedNodesStore = useFocusedNodesStore();
-			workflowsStore.allNodes = [
+			workflowsStore.workflow.nodes = [
 				{
 					id: 'test-node-1',
 					name: 'HTTP Request',
@@ -3059,7 +3052,7 @@ describe('AI Builder store', () => {
 					position: [0, 0],
 					parameters: {},
 				},
-			] as unknown as typeof workflowsStore.allNodes;
+			];
 			focusedNodesStore.confirmNodes(['test-node-1'], 'context_menu');
 			track.mockReset();
 
@@ -3095,7 +3088,7 @@ describe('AI Builder store', () => {
 
 			const { useFocusedNodesStore } = await import('./focusedNodes.store');
 			const focusedNodesStore = useFocusedNodesStore();
-			workflowsStore.allNodes = [
+			workflowsStore.workflow.nodes = [
 				{
 					id: 'test-node-1',
 					name: 'HTTP Request',
@@ -3104,7 +3097,7 @@ describe('AI Builder store', () => {
 					position: [0, 0],
 					parameters: {},
 				},
-			] as unknown as typeof workflowsStore.allNodes;
+			];
 			focusedNodesStore.confirmNodes(['test-node-1'], 'context_menu');
 			track.mockReset();
 
@@ -3127,7 +3120,7 @@ describe('AI Builder store', () => {
 
 			const { useFocusedNodesStore } = await import('./focusedNodes.store');
 			const focusedNodesStore = useFocusedNodesStore();
-			workflowsStore.allNodes = [
+			workflowsStore.workflow.nodes = [
 				{
 					id: 'test-node-1',
 					name: 'HTTP Request',
@@ -3136,7 +3129,7 @@ describe('AI Builder store', () => {
 					position: [0, 0],
 					parameters: {},
 				},
-			] as unknown as typeof workflowsStore.allNodes;
+			];
 			focusedNodesStore.confirmNodes(['test-node-1'], 'context_menu');
 
 			apiSpy.mockImplementationOnce((_ctx, _payload, _onMessage, onDone) => {

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
@@ -828,6 +828,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 				? mode
 				: (mode ?? (builderMode.value === 'plan' ? 'plan' : undefined));
 		const payload = await createBuilderPayload(text, userMessageId, {
+			workflowId: workflowsStore.workflowId,
 			quickReplyType,
 			workflow: workflowsStore.workflow,
 			executionData: executionResult,

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.utils.test.ts
@@ -373,6 +373,7 @@ describe('builder.utils', () => {
 
 		it('should include executionData and expressionValues when allowSendingParameterValues is true', async () => {
 			const result = await createBuilderPayload('test message', 'msg-1', {
+				workflowId: 'workflow-1',
 				workflow: mockWorkflow,
 				executionData: mockExecutionData,
 				nodesForSchema: ['Node 1'],
@@ -395,6 +396,7 @@ describe('builder.utils', () => {
 
 		it('should include executionData and expressionValues when allowSendingParameterValues is undefined (default)', async () => {
 			const result = await createBuilderPayload('test message', 'msg-1', {
+				workflowId: 'workflow-1',
 				workflow: mockWorkflow,
 				executionData: mockExecutionData,
 				nodesForSchema: ['Node 1'],
@@ -416,6 +418,7 @@ describe('builder.utils', () => {
 
 		it('should include executionData but NOT expressionValues when allowSendingParameterValues is false', async () => {
 			const result = await createBuilderPayload('test message', 'msg-1', {
+				workflowId: 'workflow-1',
 				workflow: mockWorkflow,
 				executionData: mockExecutionData,
 				nodesForSchema: ['Node 1'],
@@ -438,18 +441,20 @@ describe('builder.utils', () => {
 
 		it('should always include executionSchema regardless of privacy setting', async () => {
 			const result = await createBuilderPayload('test message', 'msg-1', {
+				workflowId: 'workflow-1',
 				workflow: mockWorkflow,
 				executionData: mockExecutionData,
 				nodesForSchema: ['Node 1'],
 				allowSendingParameterValues: false,
 			});
 
-			expect(mockGetNodesSchemas).toHaveBeenCalledWith(['Node 1'], true);
+			expect(mockGetNodesSchemas).toHaveBeenCalledWith('workflow-1', ['Node 1'], true);
 			expect(result.workflowContext?.executionSchema).toBeDefined();
 		});
 
 		it('should include workflow in payload when privacy is OFF but with trimmed parameter values', async () => {
 			const result = await createBuilderPayload('test message', 'msg-1', {
+				workflowId: 'workflow-1',
 				workflow: mockWorkflow,
 				allowSendingParameterValues: false,
 			});

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.utils.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.utils.ts
@@ -28,6 +28,7 @@ export async function createBuilderPayload(
 	text: string,
 	id: string,
 	options: {
+		workflowId: string;
 		quickReplyType?: string;
 		executionData?: IRunExecutionData['resultData'];
 		workflow?: IWorkflowDb;
@@ -35,7 +36,7 @@ export async function createBuilderPayload(
 		mode?: 'build' | 'plan';
 		isPlanModeEnabled?: boolean;
 		allowSendingParameterValues?: boolean;
-	} = {},
+	},
 ): Promise<ChatRequest.UserChatMessage> {
 	const assistantHelpers = useAIAssistantHelpers();
 	const posthogStore = usePostHog();
@@ -94,6 +95,7 @@ export async function createBuilderPayload(
 
 	if (options.nodesForSchema?.length) {
 		const { schemas, pinnedNodeNames } = assistantHelpers.getNodesSchemas(
+			options.workflowId,
 			options.nodesForSchema,
 			shouldExcludeParameterValues,
 		);

--- a/packages/frontend/editor-ui/src/features/ai/assistant/chatPanel.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/chatPanel.store.test.ts
@@ -327,7 +327,7 @@ describe('chatPanel.store', () => {
 
 			await chatPanelStore.openWithCredHelp(credType);
 
-			expect(assistantStore.initCredHelp).toHaveBeenCalledWith(credType);
+			expect(assistantStore.initCredHelp).toHaveBeenCalledWith('', credType);
 			expect(chatPanelStateStore.isOpen).toBe(true);
 			expect(chatPanelStateStore.activeMode).toBe('assistant');
 		});
@@ -353,7 +353,7 @@ describe('chatPanel.store', () => {
 
 			await chatPanelStore.openWithErrorHelper(errorContext);
 
-			expect(assistantStore.initErrorHelper).toHaveBeenCalledWith(errorContext);
+			expect(assistantStore.initErrorHelper).toHaveBeenCalledWith('', errorContext);
 			expect(chatPanelStateStore.isOpen).toBe(true);
 			expect(chatPanelStateStore.activeMode).toBe('assistant');
 		});

--- a/packages/frontend/editor-ui/src/features/ai/assistant/chatPanel.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/chatPanel.store.ts
@@ -123,7 +123,8 @@ export const useChatPanelStore = defineStore(STORES.CHAT_PANEL, () => {
 
 			// Reset assistant only if session has ended
 			if (assistantStore.isSessionEnded) {
-				assistantStore.resetAssistantChat();
+				const workflowsStore = useWorkflowsStore();
+				assistantStore.resetAssistantChat(workflowsStore.workflowId);
 			}
 		}, ASK_AI_SLIDE_OUT_DURATION_MS + 50);
 	}

--- a/packages/frontend/editor-ui/src/features/ai/assistant/chatPanel.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/chatPanel.store.ts
@@ -37,6 +37,7 @@ export const useChatPanelStore = defineStore(STORES.CHAT_PANEL, () => {
 	const route = useRoute();
 	const chatPanelStateStore = useChatPanelStateStore();
 	const settingsStore = useSettingsStore();
+	const workflowsStore = useWorkflowsStore();
 	const posthogStore = usePostHog();
 	const locale = useI18n();
 
@@ -123,7 +124,6 @@ export const useChatPanelStore = defineStore(STORES.CHAT_PANEL, () => {
 
 			// Reset assistant only if session has ended
 			if (assistantStore.isSessionEnded) {
-				const workflowsStore = useWorkflowsStore();
 				assistantStore.resetAssistantChat(workflowsStore.workflowId);
 			}
 		}, ASK_AI_SLIDE_OUT_DURATION_MS + 50);
@@ -180,7 +180,6 @@ export const useChatPanelStore = defineStore(STORES.CHAT_PANEL, () => {
 			return;
 		}
 		const assistantStore = useAssistantStore();
-		const workflowsStore = useWorkflowsStore();
 		await assistantStore.initCredHelp(workflowsStore.workflowId, credentialType);
 		await open({ mode: 'assistant' });
 	}
@@ -199,7 +198,6 @@ export const useChatPanelStore = defineStore(STORES.CHAT_PANEL, () => {
 			return;
 		}
 		const assistantStore = useAssistantStore();
-		const workflowsStore = useWorkflowsStore();
 		await assistantStore.initErrorHelper(workflowsStore.workflowId, context);
 		await open({ mode: 'assistant' });
 	}

--- a/packages/frontend/editor-ui/src/features/ai/assistant/chatPanel.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/chatPanel.store.ts
@@ -10,6 +10,7 @@ import { useChatPanelStateStore, type ChatPanelMode } from './chatPanelState.sto
 import { useAssistantStore } from './assistant.store';
 import { useBuilderStore } from './builder.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { usePostHog } from '@/app/stores/posthog.store';
 import { MERGE_ASK_BUILD_EXPERIMENT } from '@/app/constants/experiments';
 import type { ICredentialType } from 'n8n-workflow';
@@ -178,7 +179,8 @@ export const useChatPanelStore = defineStore(STORES.CHAT_PANEL, () => {
 			return;
 		}
 		const assistantStore = useAssistantStore();
-		await assistantStore.initCredHelp(credentialType);
+		const workflowsStore = useWorkflowsStore();
+		await assistantStore.initCredHelp(workflowsStore.workflowId, credentialType);
 		await open({ mode: 'assistant' });
 	}
 
@@ -196,7 +198,8 @@ export const useChatPanelStore = defineStore(STORES.CHAT_PANEL, () => {
 			return;
 		}
 		const assistantStore = useAssistantStore();
-		await assistantStore.initErrorHelper(context);
+		const workflowsStore = useWorkflowsStore();
+		await assistantStore.initErrorHelper(workflowsStore.workflowId, context);
 		await open({ mode: 'assistant' });
 	}
 

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/AskAssistantBuild.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/AskAssistantBuild.vue
@@ -207,11 +207,11 @@ function onSelectChangedNode(nodeId: string) {
 }
 
 async function onCodeReplace(index: number) {
-	await builderStore.applyCodeDiff(workflowId, index);
+	await builderStore.applyCodeDiff(workflowId.value, index);
 }
 
 async function onCodeUndo(index: number) {
-	await builderStore.undoCodeDiff(workflowId, index);
+	await builderStore.undoCodeDiff(workflowId.value, index);
 }
 
 const disabledTooltip = computed(() => {

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/AskAssistantBuild.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/AskAssistantBuild.vue
@@ -35,7 +35,6 @@ import { useAssistantStore } from '@/features/ai/assistant/assistant.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useChatPanelStateStore } from '@/features/ai/assistant/chatPanelState.store';
 import { useReviewChanges } from '@/features/ai/assistant/composables/useReviewChanges';
-import { injectWorkflowState } from '@/app/composables/useWorkflowState';
 
 import { N8nAskAssistantChat, N8nInfoTip } from '@n8n/design-system';
 import BuildModeEmptyState from './BuildModeEmptyState.vue';
@@ -207,14 +206,12 @@ function onSelectChangedNode(nodeId: string) {
 	canvasEventBus.emit('nodes:select', { ids: [nodeId], panIntoView: true });
 }
 
-const codeDiffWorkflowState = injectWorkflowState();
-
 async function onCodeReplace(index: number) {
-	await builderStore.applyCodeDiff(codeDiffWorkflowState, index);
+	await builderStore.applyCodeDiff(workflowId, index);
 }
 
 async function onCodeUndo(index: number) {
-	await builderStore.undoCodeDiff(codeDiffWorkflowState, index);
+	await builderStore.undoCodeDiff(workflowId, index);
 }
 
 const disabledTooltip = computed(() => {

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Chat/AskAssistantChat.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Chat/AskAssistantChat.vue
@@ -6,7 +6,7 @@ import { N8nAskAssistantChat, N8nInfoTip } from '@n8n/design-system';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useI18n } from '@n8n/i18n';
 import { useSettingsStore } from '@/app/stores/settings.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useInjectWorkflowId } from '@/app/composables/useInjectWorkflowId';
 import AskModeEmptyState from './AskModeEmptyState.vue';
 
 const emit = defineEmits<{
@@ -14,7 +14,7 @@ const emit = defineEmits<{
 }>();
 
 const assistantStore = useAssistantStore();
-const workflowsStore = useWorkflowsStore();
+const workflowId = useInjectWorkflowId();
 const settingsStore = useSettingsStore();
 const usersStore = useUsersStore();
 const telemetry = useTelemetry();
@@ -59,14 +59,14 @@ async function onUserMessage(content: string, quickReplyType?: string, isFeedbac
 }
 
 async function onCodeReplace(index: number) {
-	await assistantStore.applyCodeDiff(workflowsStore.workflowId, index);
+	await assistantStore.applyCodeDiff(workflowId.value, index);
 	telemetry.track('User clicked solution card action', {
 		action: 'replace_code',
 	});
 }
 
 async function undoCodeDiff(index: number) {
-	await assistantStore.undoCodeDiff(workflowsStore.workflowId, index);
+	await assistantStore.undoCodeDiff(workflowId.value, index);
 	telemetry.track('User clicked solution card action', {
 		action: 'undo_code_replace',
 	});

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Chat/AskAssistantChat.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Chat/AskAssistantChat.vue
@@ -38,9 +38,9 @@ const showUsabilityNotice = computed(
 async function onUserMessage(content: string, quickReplyType?: string, isFeedback = false) {
 	// If there is no current session running, initialize the support chat session
 	if (!assistantStore.currentSessionId) {
-		await assistantStore.initSupportChat(content);
+		await assistantStore.initSupportChat(workflowId.value, content);
 	} else {
-		await assistantStore.sendMessage({ text: content, quickReplyType });
+		await assistantStore.sendMessage(workflowId.value, { text: content, quickReplyType });
 	}
 	const task = assistantStore.chatSessionTask;
 	const solutionCount = assistantStore.chatMessages.filter(

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Chat/AskAssistantChat.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Chat/AskAssistantChat.vue
@@ -4,9 +4,9 @@ import { useUsersStore } from '@/features/settings/users/users.store';
 import { computed, ref, useSlots } from 'vue';
 import { N8nAskAssistantChat, N8nInfoTip } from '@n8n/design-system';
 import { useTelemetry } from '@/app/composables/useTelemetry';
-import { injectWorkflowState } from '@/app/composables/useWorkflowState';
 import { useI18n } from '@n8n/i18n';
 import { useSettingsStore } from '@/app/stores/settings.store';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import AskModeEmptyState from './AskModeEmptyState.vue';
 
 const emit = defineEmits<{
@@ -14,8 +14,8 @@ const emit = defineEmits<{
 }>();
 
 const assistantStore = useAssistantStore();
+const workflowsStore = useWorkflowsStore();
 const settingsStore = useSettingsStore();
-const workflowState = injectWorkflowState();
 const usersStore = useUsersStore();
 const telemetry = useTelemetry();
 const slots = useSlots();
@@ -59,14 +59,14 @@ async function onUserMessage(content: string, quickReplyType?: string, isFeedbac
 }
 
 async function onCodeReplace(index: number) {
-	await assistantStore.applyCodeDiff(workflowState, index);
+	await assistantStore.applyCodeDiff(workflowsStore.workflowId, index);
 	telemetry.track('User clicked solution card action', {
 		action: 'replace_code',
 	});
 }
 
 async function undoCodeDiff(index: number) {
-	await assistantStore.undoCodeDiff(workflowState, index);
+	await assistantStore.undoCodeDiff(workflowsStore.workflowId, index);
 	telemetry.track('User clicked solution card action', {
 		action: 'undo_code_replace',
 	});

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useAIAssistantHelpers.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useAIAssistantHelpers.ts
@@ -304,15 +304,15 @@ export const useAIAssistantHelpers = () => {
 	 * @returns schemas and list of node names whose schema was derived from pin data
 	 */
 	function getNodesSchemas(workflowId: string, nodeNames: string[], excludeValues?: boolean) {
-		const docStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
+		const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
 		const schemas: ChatRequest.NodeExecutionSchema[] = [];
 		const pinnedNodeNames: string[] = [];
 		for (const name of nodeNames) {
-			const node = docStore.getNodeByName(name);
+			const node = workflowDocumentStore.getNodeByName(name);
 			if (!node) {
 				continue;
 			}
-			if (docStore.pinData?.[node.name]) {
+			if (workflowDocumentStore.pinData?.[node.name]) {
 				pinnedNodeNames.push(node.name);
 			}
 			const { getSchemaForExecutionData, getInputDataWithPinned } = useDataSchema();

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useAIAssistantHelpers.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useAIAssistantHelpers.ts
@@ -25,8 +25,6 @@ import {
 	getNodeAuthOptions,
 } from '@/app/utils/nodeTypesUtils';
 import type { AssistantProcessOptions, ChatRequest } from '../assistant.types';
-import { computed } from 'vue';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
@@ -45,13 +43,6 @@ const CREDENTIALS_LIST_VIEWS = [VIEWS.CREDENTIALS, VIEWS.PROJECTS_CREDENTIALS];
 export const useAIAssistantHelpers = () => {
 	const ndvStore = useNDVStore();
 	const nodeTypesStore = useNodeTypesStore();
-	const workflowsStore = useWorkflowsStore();
-
-	const workflowDocumentStore = computed(() =>
-		workflowsStore.workflowId
-			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
-			: undefined,
-	);
 
 	const workflowHelpers = useWorkflowHelpers();
 	const locale = useI18n();
@@ -231,6 +222,7 @@ export const useAIAssistantHelpers = () => {
 	}
 
 	function getNodeInfoForAssistant(
+		workflowId: string,
 		node: INode,
 		options?: AssistantProcessOptions,
 	): ChatRequest.NodeInfo {
@@ -239,7 +231,11 @@ export const useAIAssistantHelpers = () => {
 		}
 		// Get all referenced nodes and their schemas
 		const referencedNodeNames = getReferencedNodes(node);
-		const { schemas } = getNodesSchemas(referencedNodeNames, options?.excludeParameterValues);
+		const { schemas } = getNodesSchemas(
+			workflowId,
+			referencedNodeNames,
+			options?.excludeParameterValues,
+		);
 
 		const nodeType = nodeTypesStore.getNodeType(node.type);
 
@@ -307,15 +303,16 @@ export const useAIAssistantHelpers = () => {
 	 * @param nodeNames The names of the nodes to get the schema for
 	 * @returns schemas and list of node names whose schema was derived from pin data
 	 */
-	function getNodesSchemas(nodeNames: string[], excludeValues?: boolean) {
+	function getNodesSchemas(workflowId: string, nodeNames: string[], excludeValues?: boolean) {
+		const docStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
 		const schemas: ChatRequest.NodeExecutionSchema[] = [];
 		const pinnedNodeNames: string[] = [];
 		for (const name of nodeNames) {
-			const node = workflowDocumentStore.value?.getNodeByName(name);
+			const node = docStore.getNodeByName(name);
 			if (!node) {
 				continue;
 			}
-			if (workflowDocumentStore.value?.pinData?.[node.name]) {
+			if (docStore.pinData?.[node.name]) {
 				pinnedNodeNames.push(node.name);
 			}
 			const { getSchemaForExecutionData, getInputDataWithPinned } = useDataSchema();

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useAIAssistantHelpers.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useAIAssistantHelpers.ts
@@ -25,6 +25,7 @@ import {
 	getNodeAuthOptions,
 } from '@/app/utils/nodeTypesUtils';
 import type { AssistantProcessOptions, ChatRequest } from '../assistant.types';
+import { computed } from 'vue';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import {
 	useWorkflowDocumentStore,
@@ -45,6 +46,12 @@ export const useAIAssistantHelpers = () => {
 	const ndvStore = useNDVStore();
 	const nodeTypesStore = useNodeTypesStore();
 	const workflowsStore = useWorkflowsStore();
+
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
 
 	const workflowHelpers = useWorkflowHelpers();
 	const locale = useI18n();
@@ -301,17 +308,14 @@ export const useAIAssistantHelpers = () => {
 	 * @returns schemas and list of node names whose schema was derived from pin data
 	 */
 	function getNodesSchemas(nodeNames: string[], excludeValues?: boolean) {
-		const workflowDocumentStore = workflowsStore.workflowId
-			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
-			: undefined;
 		const schemas: ChatRequest.NodeExecutionSchema[] = [];
 		const pinnedNodeNames: string[] = [];
 		for (const name of nodeNames) {
-			const node = workflowsStore.getNodeByName(name);
+			const node = workflowDocumentStore.value?.getNodeByName(name);
 			if (!node) {
 				continue;
 			}
-			if (workflowDocumentStore?.pinData?.[node.name]) {
+			if (workflowDocumentStore.value?.pinData?.[node.name]) {
 				pinnedNodeNames.push(node.name);
 			}
 			const { getSchemaForExecutionData, getInputDataWithPinned } = useDataSchema();

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useBuilderTodos.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useBuilderTodos.ts
@@ -147,7 +147,7 @@ export function useBuilderTodos() {
 		}
 		visited.add(nodeName);
 
-		const node = workflowsStore.getNodeByName(nodeName);
+		const node = workflowDocumentStore.value?.getNodeByName(nodeName) ?? null;
 
 		// Check if node itself is disabled
 		if (node?.disabled === true) {
@@ -227,7 +227,7 @@ export function useBuilderTodos() {
 		// Vue's computed may not track dependencies accessed in recursive helper functions,
 		// so we access pinData and nodes here to register them as dependencies.
 		const _pinData = workflowDocumentStore.value?.pinData;
-		const _nodes = workflowsStore.workflow.nodes;
+		const _nodes = workflowDocumentStore.value?.allNodes;
 		void _pinData;
 		void _nodes;
 
@@ -253,7 +253,7 @@ export function useBuilderTodos() {
 		const issues: WorkflowValidationIssue[] = [];
 		const seen = new Set<string>();
 
-		for (const node of workflowsStore.workflow.nodes) {
+		for (const node of workflowDocumentStore.value?.allNodes ?? []) {
 			if (!node?.parameters) continue;
 
 			// Skip nodes with pinned data - their output is already defined
@@ -324,7 +324,7 @@ export function useBuilderTodos() {
 		if (wouldHaveBaseIssues) return true;
 
 		// Check placeholder issues that would show if not for pinned data
-		for (const node of workflowsStore.workflow.nodes) {
+		for (const node of workflowDocumentStore.value?.allNodes ?? []) {
 			if (!node?.parameters) continue;
 			if (!nodeHasPinnedData(node.name)) continue;
 			if (nodeIsDisabled(node.name)) continue;
@@ -349,7 +349,7 @@ export function useBuilderTodos() {
 			placeholders_todo_count,
 			todos: workflowTodos.value.map((todo) => ({
 				type: todo.type,
-				node_type: workflowsStore.getNodeByName(todo.node)?.type,
+				node_type: workflowDocumentStore.value?.getNodeByName(todo.node)?.type,
 				label: todo.value,
 			})),
 		};

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useBuilderTodos.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useBuilderTodos.ts
@@ -147,7 +147,7 @@ export function useBuilderTodos() {
 		}
 		visited.add(nodeName);
 
-		const node = workflowDocumentStore.value?.getNodeByName(nodeName) ?? null;
+		const node = workflowDocumentStore.value?.getNodeByName(nodeName);
 
 		// Check if node itself is disabled
 		if (node?.disabled === true) {

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useCodeDiff.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useCodeDiff.ts
@@ -36,11 +36,7 @@ export function useCodeDiff(options: UseCodeDiffOptions) {
 		};
 	}>({});
 
-	function updateParameters(
-		nodeName: string,
-		parameters: INodeParameters,
-		docStore: ReturnType<typeof useWorkflowDocumentStore> | undefined,
-	) {
+	function updateParameters(workflowId: string, nodeName: string, parameters: INodeParameters) {
 		if (ndvStore.activeNodeName === nodeName) {
 			Object.keys(parameters).forEach((key) => {
 				const update: IUpdateInformation = {
@@ -52,7 +48,8 @@ export function useCodeDiff(options: UseCodeDiffOptions) {
 				ndvEventBus.emit('updateParameterValue', update);
 			});
 		} else {
-			docStore?.setNodeParameters(
+			const docStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
+			docStore.setNodeParameters(
 				{
 					name: nodeName,
 					value: parameters,
@@ -107,7 +104,7 @@ export function useCodeDiff(options: UseCodeDiffOptions) {
 
 			const cached = suggestions.value[suggestionId];
 			if (cached) {
-				updateParameters(activeNode.name, cached.suggested, docStore);
+				updateParameters(workflowId, activeNode.name, cached.suggested);
 			} else {
 				const { parameters: suggested } = await replaceCode(rootStore.restApiContext, {
 					suggestionId: codeDiff.suggestionId,
@@ -118,7 +115,7 @@ export function useCodeDiff(options: UseCodeDiffOptions) {
 					previous: getRelevantParameters(activeNode.parameters, Object.keys(suggested)),
 					suggested,
 				};
-				updateParameters(activeNode.name, suggested, docStore);
+				updateParameters(workflowId, activeNode.name, suggested);
 			}
 
 			codeDiff.replaced = true;
@@ -154,7 +151,7 @@ export function useCodeDiff(options: UseCodeDiffOptions) {
 			assert(activeNode);
 
 			const suggested = suggestion.previous;
-			updateParameters(activeNode.name, suggested, docStore);
+			updateParameters(workflowId, activeNode.name, suggested);
 
 			codeDiff.replaced = false;
 			codeNodeEditorEventBus.emit('codeDiffApplied');

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useCodeDiff.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useCodeDiff.ts
@@ -6,14 +6,16 @@ import { deepCopy } from 'n8n-workflow';
 import { assert } from '@n8n/utils/assert';
 import { replaceCode } from '@/features/ai/assistant/assistant.api';
 import { useRootStore } from '@n8n/stores/useRootStore';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useI18n } from '@n8n/i18n';
 import { useToast } from '@/app/composables/useToast';
 import { codeNodeEditorEventBus } from '@/app/event-bus';
 import { ndvEventBus } from '@/features/ndv/shared/ndv.eventBus';
 import type { IUpdateInformation } from '@/Interface';
-import type { WorkflowState } from '@/app/composables/useWorkflowState';
 import AiUpdatedCodeMessage from '@/app/components/AiUpdatedCodeMessage.vue';
 
 export interface UseCodeDiffOptions {
@@ -24,7 +26,6 @@ export interface UseCodeDiffOptions {
 
 export function useCodeDiff(options: UseCodeDiffOptions) {
 	const rootStore = useRootStore();
-	const workflowsStore = useWorkflowsStore();
 	const ndvStore = useNDVStore();
 	const locale = useI18n();
 
@@ -36,9 +37,9 @@ export function useCodeDiff(options: UseCodeDiffOptions) {
 	}>({});
 
 	function updateParameters(
-		workflowState: WorkflowState,
 		nodeName: string,
 		parameters: INodeParameters,
+		docStore: ReturnType<typeof useWorkflowDocumentStore> | undefined,
 	) {
 		if (ndvStore.activeNodeName === nodeName) {
 			Object.keys(parameters).forEach((key) => {
@@ -51,7 +52,7 @@ export function useCodeDiff(options: UseCodeDiffOptions) {
 				ndvEventBus.emit('updateParameterValue', update);
 			});
 		} else {
-			workflowState.setNodeParameters(
+			docStore?.setNodeParameters(
 				{
 					name: nodeName,
 					value: parameters,
@@ -84,7 +85,7 @@ export function useCodeDiff(options: UseCodeDiffOptions) {
 		}
 	}
 
-	async function applyCodeDiff(workflowState: WorkflowState, index: number) {
+	async function applyCodeDiff(workflowId: string, index: number) {
 		const codeDiffMessage = options.chatMessages.value[index];
 		if (!codeDiffMessage || codeDiffMessage.type !== 'code-diff') {
 			throw new Error('No code diff to apply');
@@ -100,13 +101,13 @@ export function useCodeDiff(options: UseCodeDiffOptions) {
 			codeDiff.replacing = true;
 			const suggestionId = codeDiff.suggestionId;
 
-			const workflowObject = workflowsStore.workflowObject;
-			const activeNode = workflowObject.getNode(nodeName);
+			const docStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
+			const activeNode = docStore.getNodeByName(nodeName);
 			assert(activeNode);
 
 			const cached = suggestions.value[suggestionId];
 			if (cached) {
-				updateParameters(workflowState, activeNode.name, cached.suggested);
+				updateParameters(activeNode.name, cached.suggested, docStore);
 			} else {
 				const { parameters: suggested } = await replaceCode(rootStore.restApiContext, {
 					suggestionId: codeDiff.suggestionId,
@@ -117,7 +118,7 @@ export function useCodeDiff(options: UseCodeDiffOptions) {
 					previous: getRelevantParameters(activeNode.parameters, Object.keys(suggested)),
 					suggested,
 				};
-				updateParameters(workflowState, activeNode.name, suggested);
+				updateParameters(activeNode.name, suggested, docStore);
 			}
 
 			codeDiff.replaced = true;
@@ -130,7 +131,7 @@ export function useCodeDiff(options: UseCodeDiffOptions) {
 		codeDiff.replacing = false;
 	}
 
-	async function undoCodeDiff(workflowState: WorkflowState, index: number) {
+	async function undoCodeDiff(workflowId: string, index: number) {
 		const codeDiffMessage = options.chatMessages.value[index];
 		if (!codeDiffMessage || codeDiffMessage.type !== 'code-diff') {
 			throw new Error('No code diff to apply');
@@ -148,12 +149,12 @@ export function useCodeDiff(options: UseCodeDiffOptions) {
 			const suggestion = suggestions.value[suggestionId];
 			assert(suggestion);
 
-			const workflowObject = workflowsStore.workflowObject;
-			const activeNode = workflowObject.getNode(nodeName);
+			const docStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
+			const activeNode = docStore.getNodeByName(nodeName);
 			assert(activeNode);
 
 			const suggested = suggestion.previous;
-			updateParameters(workflowState, activeNode.name, suggested);
+			updateParameters(activeNode.name, suggested, docStore);
 
 			codeDiff.replaced = false;
 			codeNodeEditorEventBus.emit('codeDiffApplied');

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useCodeDiff.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useCodeDiff.ts
@@ -48,8 +48,8 @@ export function useCodeDiff(options: UseCodeDiffOptions) {
 				ndvEventBus.emit('updateParameterValue', update);
 			});
 		} else {
-			const docStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
-			docStore.setNodeParameters(
+			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
+			workflowDocumentStore.setNodeParameters(
 				{
 					name: nodeName,
 					value: parameters,
@@ -98,8 +98,8 @@ export function useCodeDiff(options: UseCodeDiffOptions) {
 			codeDiff.replacing = true;
 			const suggestionId = codeDiff.suggestionId;
 
-			const docStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
-			const activeNode = docStore.getNodeByName(nodeName);
+			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
+			const activeNode = workflowDocumentStore.getNodeByName(nodeName);
 			assert(activeNode);
 
 			const cached = suggestions.value[suggestionId];
@@ -146,8 +146,8 @@ export function useCodeDiff(options: UseCodeDiffOptions) {
 			const suggestion = suggestions.value[suggestionId];
 			assert(suggestion);
 
-			const docStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
-			const activeNode = docStore.getNodeByName(nodeName);
+			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
+			const activeNode = workflowDocumentStore.getNodeByName(nodeName);
 			assert(activeNode);
 
 			const suggested = suggestion.previous;

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useFocusedNodesChipUI.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useFocusedNodesChipUI.ts
@@ -2,6 +2,10 @@ import { computed } from 'vue';
 import { useFocusedNodesStore } from '../focusedNodes.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { canvasEventBus } from '@/features/workflows/canvas/canvas.eventBus';
 
 /** Threshold at which individual chips are bundled into a single count chip */
@@ -15,6 +19,11 @@ export function useFocusedNodesChipUI() {
 	const focusedNodesStore = useFocusedNodesStore();
 	const nodeTypesStore = useNodeTypesStore();
 	const workflowsStore = useWorkflowsStore();
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
 
 	const confirmedNodes = computed(() => focusedNodesStore.confirmedNodes);
 	const unconfirmedNodes = computed(() => focusedNodesStore.filteredUnconfirmedNodes);
@@ -24,16 +33,16 @@ export function useFocusedNodesChipUI() {
 	const allNodesConfirmed = computed(
 		() =>
 			confirmedCount.value > 0 &&
-			workflowsStore.allNodes.length > 0 &&
-			confirmedCount.value >= workflowsStore.allNodes.length,
+			(workflowDocumentStore.value?.allNodes ?? []).length > 0 &&
+			confirmedCount.value >= (workflowDocumentStore.value?.allNodes ?? []).length,
 	);
 
 	const allNodesUnconfirmed = computed(
 		() =>
 			confirmedCount.value === 0 &&
 			unconfirmedCount.value > 0 &&
-			workflowsStore.allNodes.length > 0 &&
-			unconfirmedCount.value >= workflowsStore.allNodes.length,
+			(workflowDocumentStore.value?.allNodes ?? []).length > 0 &&
+			unconfirmedCount.value >= (workflowDocumentStore.value?.allNodes ?? []).length,
 	);
 
 	const shouldBundleConfirmed = computed(() => confirmedCount.value >= CHIP_BUNDLE_THRESHOLD);

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useNodeMention.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useNodeMention.test.ts
@@ -21,6 +21,17 @@ vi.mock('@/features/ndv/shared/ndv.store', () => ({
 	useNDVStore: () => ({ activeNode: null }),
 }));
 
+const { mockDocumentStore } = vi.hoisted(() => ({
+	mockDocumentStore: {
+		allNodes: [] as INodeUi[],
+	},
+}));
+
+vi.mock('@/app/stores/workflowDocument.store', () => ({
+	useWorkflowDocumentStore: vi.fn().mockReturnValue(mockDocumentStore),
+	createWorkflowDocumentId: vi.fn().mockReturnValue('test-id'),
+}));
+
 function createMockInput(value = '', selectionStart: number | null = null): HTMLInputElement {
 	const input = document.createElement('input');
 	input.value = value;
@@ -73,8 +84,10 @@ describe('useNodeMention', () => {
 		workflowsStore = useWorkflowsStore();
 		focusedNodesStore = useFocusedNodesStore();
 
-		// @ts-expect-error -- mock readonly property
+		workflowsStore.workflow.id = 'test-workflow';
+		// @ts-expect-error -- mock readonly property for focusedNodesStore which still reads workflowsStore.allNodes
 		workflowsStore.allNodes = mockNodes;
+		mockDocumentStore.allNodes = mockNodes;
 	});
 
 	describe('handleInput - @ trigger conditions', () => {

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useNodeMention.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useNodeMention.ts
@@ -2,6 +2,10 @@ import { ref, computed, watch, type Ref } from 'vue';
 import type { INodeUi } from '@/Interface';
 import { useFocusedNodesStore } from '../focusedNodes.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 
 export interface UseNodeMentionOptions {
 	maxResults?: number;
@@ -34,6 +38,11 @@ export function useNodeMention(options: UseNodeMentionOptions = {}): UseNodeMent
 
 	const focusedNodesStore = useFocusedNodesStore();
 	const workflowsStore = useWorkflowsStore();
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
 
 	const showDropdown = ref(false);
 	const searchQuery = ref('');
@@ -45,7 +54,7 @@ export function useNodeMention(options: UseNodeMentionOptions = {}): UseNodeMent
 
 	const filteredNodes = computed(() => {
 		const query = searchQuery.value.toLowerCase();
-		const allNodes = workflowsStore.allNodes;
+		const allNodes = workflowDocumentStore.value?.allNodes ?? [];
 		const confirmedIds = new Set(focusedNodesStore.confirmedNodeIds);
 
 		let result = allNodes.filter((node) => !confirmedIds.has(node.id));
@@ -59,7 +68,7 @@ export function useNodeMention(options: UseNodeMentionOptions = {}): UseNodeMent
 
 	// Close dropdown when workflow nodes change (e.g. paste, import) to ensure fresh data
 	watch(
-		() => workflowsStore.allNodes.length,
+		() => (workflowDocumentStore.value?.allNodes ?? []).length,
 		() => {
 			if (showDropdown.value) {
 				closeDropdown();

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useReviewChanges.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useReviewChanges.test.ts
@@ -78,12 +78,23 @@ const mockChatPanelStateStore = reactive({
 	isOpen: true,
 });
 
+const mockDocumentStore = reactive({
+	get allNodes() {
+		return mockWorkflowsStore.workflow.nodes;
+	},
+});
+
 vi.mock('@/features/ai/assistant/builder.store', () => ({
 	useBuilderStore: () => mockBuilderStore,
 }));
 
 vi.mock('@/app/stores/workflows.store', () => ({
 	useWorkflowsStore: () => mockWorkflowsStore,
+}));
+
+vi.mock('@/app/stores/workflowDocument.store', () => ({
+	useWorkflowDocumentStore: () => mockDocumentStore,
+	createWorkflowDocumentId: () => 'test-id',
 }));
 
 vi.mock('@/features/workflows/workflowHistory/workflowHistory.store', () => ({

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useReviewChanges.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useReviewChanges.test.ts
@@ -78,7 +78,7 @@ const mockChatPanelStateStore = reactive({
 	isOpen: true,
 });
 
-const mockDocumentStore = reactive({
+const mockWorkflowDocumentStore = reactive({
 	get allNodes() {
 		return mockWorkflowsStore.workflow.nodes;
 	},
@@ -93,7 +93,7 @@ vi.mock('@/app/stores/workflows.store', () => ({
 }));
 
 vi.mock('@/app/stores/workflowDocument.store', () => ({
-	useWorkflowDocumentStore: () => mockDocumentStore,
+	useWorkflowDocumentStore: () => mockWorkflowDocumentStore,
 	createWorkflowDocumentId: () => 'test-id',
 }));
 

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useReviewChanges.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useReviewChanges.ts
@@ -10,6 +10,10 @@ import { createEventBus } from '@n8n/utils/event-bus';
 import { useI18n } from '@n8n/i18n';
 import { useBuilderStore } from '@/features/ai/assistant/builder.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { useWorkflowHistoryStore } from '@/features/workflows/workflowHistory/workflowHistory.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useUIStore } from '@/app/stores/ui.store';
@@ -39,6 +43,12 @@ export function useReviewChanges() {
 	const chatPanelStateStore = useChatPanelStateStore();
 	const posthogStore = usePostHog();
 	const i18n = useI18n();
+
+	const workflowDocumentStore = computed(() =>
+		workflowsStore.workflowId
+			? useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: undefined,
+	);
 	const isLoadingDiff = ref(false);
 	const cachedVersionNodes = ref<INode[]>([]);
 	const cachedVersionConnections = ref<IConnections>({});
@@ -96,7 +106,7 @@ export function useReviewChanges() {
 	const nodeChanges = computed<NodeChangeEntry[]>(() => {
 		if (!cachedVersionLoaded.value || builderStore.streaming) return [];
 		const normalized = resolveNodeDefaults(cachedVersionNodes.value);
-		const currentNodes: INode[] = workflowsStore.workflow.nodes;
+		const currentNodes: INode[] = workflowDocumentStore.value?.allNodes ?? [];
 		const diff = compareWorkflowsNodes(normalized, currentNodes);
 		const currentNodesById = new Map(currentNodes.map((n) => [n.id, n]));
 		return [...diff.values()]


### PR DESCRIPTION
## Summary

Replace direct workflowsStore references with WorkflowDocumentStore in AI assistant composables. This includes updates to useAIAssistantHelpers, useBuilderTodos, useCodeDiff, useFocusedNodesChipUI, useNodeMention, and useReviewChanges to use the document store pattern for better modularity and consistency.


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2514

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
