### PR TITLE
fix:  Bug with odd error message on project limit cloud

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -4345,7 +4345,7 @@
 	"projects.create.limitReached.cloud": "You have reached the {planName} plan limit of {limit}. Upgrade your plan to unlock more projects.",
 	"projects.create.limitReached.self": "Upgrade to unlock projects for more granular control over sharing, access and organisation of workflows",
 	"projects.create.limitReached.link": "View plans",
-	"projects.create.permissionDenied": "Your current role does not allow you to create projects",
+	"projects.create.permissionDenied": "Your current role does not allow you to create projects. Contact your administrator to request access.",
 	"projects.move.resource.modal.title": "Choose a project or user to move this {resourceTypeLabel} to",
 	"projects.move.resource.modal.message": "\"{resourceName}\" is currently {inPersonalProject}{inTeamProject}",
 	"projects.move.resource.modal.message.team": "in the \"{resourceHomeProjectName}\" project.",

--- a/packages/frontend/editor-ui/src/app/composables/useGlobalEntityCreation.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useGlobalEntityCreation.ts
@@ -219,6 +219,10 @@ export const useGlobalEntityCreation = () => {
 	};
 
 	const projectsLimitReachedMessage = computed(() => {
+		if (!projectsStore.hasPermissionToCreateProjects) {
+			return i18n.baseText('projects.create.permissionDenied');
+		}
+
 		if (settingsStore.isCloudDeployment) {
 			return i18n.baseText('projects.create.limitReached.cloud', {
 				interpolate: {
@@ -230,10 +234,6 @@ export const useGlobalEntityCreation = () => {
 
 		if (!projectsStore.isTeamProjectFeatureEnabled) {
 			return i18n.baseText('projects.create.limitReached.self');
-		}
-
-		if (!projectsStore.hasPermissionToCreateProjects) {
-			return i18n.baseText('projects.create.permissionDenied');
 		}
 
 		return i18n.baseText('projects.create.limitReached', {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This PR fixes a bug where the incorrect error message is shown on cloud when you have no valid permissions to create a project, and the project limit is reached causing the disabled state.

This now checks permissions and shows that message first for all cases.

## Related Linear tickets, Github issues, and Community forum posts

IAM-300

<img width="1512" height="826" alt="image" src="https://github.com/user-attachments/assets/e85264e0-a803-416a-80a8-11aa35547060" />

Tested by configuring my local instance for cloud and viewing the error message appears correctly.

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
