### PR TITLE
fix(MistralAI): handle undefined pages in processResponseData

### DIFF
--- a/packages/nodes-base/nodes/MistralAI/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/MistralAI/GenericFunctions.ts
@@ -53,10 +53,10 @@ export async function encodeBinaryData(
 }
 
 export function processResponseData(response: IDataObject): IDataObject {
-	const pages = response.pages as Page[];
+	const pages = response.pages as Page[] | undefined;
 	return {
 		...response,
-		extractedText: pages.map((page) => page.markdown).join('\n\n'),
-		pageCount: pages.length,
+		extractedText: pages?.map((page) => page.markdown).join('\n\n') || '',
+		pageCount: pages?.length || 0,
 	};
 }


### PR DESCRIPTION
## Description

Add null check for response.pages to prevent runtime errors when pages is undefined.

## Changes

- Add null check for response.pages
- Return empty string for extractedText when pages is undefined
- Return 0 for pageCount when pages is undefined